### PR TITLE
feat(LUKE-45): add shared session core

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,3 +41,12 @@ untracked.
 Biome is the executable style policy for TypeScript, JavaScript, JSON,
 Markdown, and CSS. Husky runs the same checks against staged files as a local
 convenience; `./scripts/check.sh` and CI remain authoritative.
+
+## TypeScript value sets and keys
+
+- Do not use stringly typed fixed value sets. Define `as const`
+  SCREAMING_SNAKE_CASE objects, derive unions with
+  `typeof VALUE_SET[keyof typeof VALUE_SET]`, and use the constants at call
+  sites. Raw strings are only for freeform, user-facing text.
+- Do not construct keys by concatenating or interpolating identifiers. Use
+  nested objects or nested `Map` instances keyed by the original identifiers.

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -1,2 +1,5 @@
 export * from "./fixtures";
 export * from "./geometry";
+export * from "./providers";
+export * from "./session";
+export * from "./session-registry";

--- a/packages/sidecar-core/src/providers.ts
+++ b/packages/sidecar-core/src/providers.ts
@@ -1,0 +1,31 @@
+import type { ProviderSessionObservation, SessionControl, SessionProvider } from "./session";
+
+/** A provider adapter has no dependency on Electron, a renderer, or live UI state. */
+export interface SessionProviderAdapter {
+  readonly provider: SessionProvider;
+  observe(): Promise<readonly ProviderSessionObservation[]>;
+}
+
+/** A provider-local request for a control that was previously exposed by observation. */
+export interface ProviderControlRequest {
+  providerSessionId: string;
+  control: SessionControl;
+}
+
+/**
+ * Providers must report unsupported or rejected controls explicitly; the core
+ * deliberately provides no fallback path such as terminal input injection.
+ */
+export type ProviderControlResult =
+  | { status: "accepted" }
+  | { status: "rejected"; reason: string }
+  | { status: "unsupported" };
+
+/**
+ * Optional extension for adapters with a reliable provider-owned control path.
+ * Adapters must reject any request whose control was not advertised for the
+ * observed session.
+ */
+export interface ControllableSessionProviderAdapter extends SessionProviderAdapter {
+  executeControl(request: ProviderControlRequest): Promise<ProviderControlResult>;
+}

--- a/packages/sidecar-core/src/providers.ts
+++ b/packages/sidecar-core/src/providers.ts
@@ -1,5 +1,14 @@
 import type { ProviderSessionObservation, SessionControl, SessionProvider } from "./session";
 
+export const PROVIDER_CONTROL_RESULT_STATUS = {
+  ACCEPTED: "accepted",
+  REJECTED: "rejected",
+  UNSUPPORTED: "unsupported",
+} as const;
+
+export type ProviderControlResultStatus =
+  (typeof PROVIDER_CONTROL_RESULT_STATUS)[keyof typeof PROVIDER_CONTROL_RESULT_STATUS];
+
 /** A provider adapter has no dependency on Electron, a renderer, or live UI state. */
 export interface SessionProviderAdapter {
   readonly provider: SessionProvider;
@@ -17,9 +26,9 @@ export interface ProviderControlRequest {
  * deliberately provides no fallback path such as terminal input injection.
  */
 export type ProviderControlResult =
-  | { status: "accepted" }
-  | { status: "rejected"; reason: string }
-  | { status: "unsupported" };
+  | { status: typeof PROVIDER_CONTROL_RESULT_STATUS.ACCEPTED }
+  | { status: typeof PROVIDER_CONTROL_RESULT_STATUS.REJECTED; reason: string }
+  | { status: typeof PROVIDER_CONTROL_RESULT_STATUS.UNSUPPORTED };
 
 /**
  * Optional extension for adapters with a reliable provider-owned control path.

--- a/packages/sidecar-core/src/session-registry.ts
+++ b/packages/sidecar-core/src/session-registry.ts
@@ -175,7 +175,6 @@ export class InMemorySessionRegistry {
     const mutationEpoch = this.#providerMutationEpochs.get(providerId) ?? 0;
     const attempt = this.#startProviderRefreshAttempt(providerId);
     const observations = await adapter.observe();
-    const next = this.#nextProviderStore(adapter.provider, providerId, observations);
     const latestAttempt = this.#latestAppliedRefreshAttempts.get(providerId) ?? 0;
     if (
       latestAttempt >= attempt ||
@@ -183,6 +182,7 @@ export class InMemorySessionRegistry {
     ) {
       return this.snapshot();
     }
+    const next = this.#nextProviderStore(adapter.provider, providerId, observations);
     this.#latestAppliedRefreshAttempts.set(providerId, attempt);
     this.#commit(next);
     return this.snapshot();

--- a/packages/sidecar-core/src/session-registry.ts
+++ b/packages/sidecar-core/src/session-registry.ts
@@ -1,0 +1,203 @@
+import type { SessionProviderAdapter } from "./providers";
+import {
+  type AttentionDecision,
+  type NormalizedSession,
+  normalizeAttention,
+  normalizeSession,
+  type ProviderSessionObservation,
+  type SessionIdentity,
+  type SessionProvider,
+  sessionKey,
+} from "./session";
+
+export interface SessionRegistrySnapshot {
+  revision: number;
+  sessions: readonly NormalizedSession[];
+}
+
+export type SessionRegistryListener = (snapshot: SessionRegistrySnapshot) => void;
+
+function copySession(session: NormalizedSession): NormalizedSession {
+  return {
+    ...session,
+    provider: { ...session.provider },
+    controls: session.controls.map((control) => ({ ...control })),
+    attention: { ...session.attention },
+  };
+}
+
+function sameControls(
+  first: readonly NormalizedSession["controls"][number][],
+  second: readonly NormalizedSession["controls"][number][],
+): boolean {
+  return (
+    first.length === second.length &&
+    first.every(
+      (control, index) =>
+        control.id === second[index]?.id && control.label === second[index]?.label,
+    )
+  );
+}
+
+function sameSession(first: NormalizedSession, second: NormalizedSession): boolean {
+  return (
+    first.id === second.id &&
+    first.providerId === second.providerId &&
+    first.providerSessionId === second.providerSessionId &&
+    first.provider.id === second.provider.id &&
+    first.provider.displayName === second.provider.displayName &&
+    first.title === second.title &&
+    first.status === second.status &&
+    first.observedAt === second.observedAt &&
+    first.summary === second.summary &&
+    first.attention.disposition === second.attention.disposition &&
+    first.attention.decidedAt === second.attention.decidedAt &&
+    first.attention.summary === second.attention.summary &&
+    sameControls(first.controls, second.controls)
+  );
+}
+
+function sameSessions(
+  first: ReadonlyMap<string, NormalizedSession>,
+  second: ReadonlyMap<string, NormalizedSession>,
+): boolean {
+  return (
+    first.size === second.size &&
+    [...first].every(([id, session]) => {
+      const candidate = second.get(id);
+      return candidate !== undefined && sameSession(session, candidate);
+    })
+  );
+}
+
+/**
+ * A portable, in-memory source of truth for normalized sessions. It never
+ * persists observations, and only replaces records after a provider snapshot
+ * has been validated in full.
+ */
+export class InMemorySessionRegistry {
+  #revision = 0;
+  #sessions = new Map<string, NormalizedSession>();
+  #listeners = new Set<SessionRegistryListener>();
+
+  get revision(): number {
+    return this.#revision;
+  }
+
+  get(identity: SessionIdentity): NormalizedSession | undefined {
+    const session = this.#sessions.get(sessionKey(identity));
+    return session && copySession(session);
+  }
+
+  list(): readonly NormalizedSession[] {
+    return [...this.#sessions.values()]
+      .sort(
+        (first, second) =>
+          second.observedAt - first.observedAt || first.id.localeCompare(second.id),
+      )
+      .map(copySession);
+  }
+
+  snapshot(): SessionRegistrySnapshot {
+    return {
+      revision: this.#revision,
+      sessions: this.list(),
+    };
+  }
+
+  subscribe(listener: SessionRegistryListener): () => void {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  }
+
+  upsert(provider: SessionProvider, observation: ProviderSessionObservation): NormalizedSession {
+    const identity = {
+      providerId: provider.id,
+      providerSessionId: observation.providerSessionId,
+    };
+    const key = sessionKey(identity);
+    const existing = this.#sessions.get(key);
+    const session = normalizeSession(provider, observation, existing?.attention);
+    const next = new Map(this.#sessions);
+    next.set(key, session);
+    this.#commit(next);
+    return copySession(session);
+  }
+
+  /**
+   * Replaces one provider's observed sessions atomically. Sessions from other
+   * providers, along with their attention decisions, remain untouched.
+   */
+  replaceProvider(
+    provider: SessionProvider,
+    observations: readonly ProviderSessionObservation[],
+  ): SessionRegistrySnapshot {
+    const providerId = provider.id.trim();
+    if (!providerId) throw new Error("provider id must not be empty");
+    const existingForProvider = new Map(
+      [...this.#sessions]
+        .filter(([, session]) => session.providerId === providerId)
+        .map(([id, session]) => [id, session]),
+    );
+    const replacement = new Map<string, NormalizedSession>();
+
+    for (const observation of observations) {
+      const key = sessionKey({ providerId, providerSessionId: observation.providerSessionId });
+      if (replacement.has(key)) {
+        throw new Error(`Duplicate session observation: ${observation.providerSessionId}`);
+      }
+      replacement.set(
+        key,
+        normalizeSession(provider, observation, existingForProvider.get(key)?.attention),
+      );
+    }
+
+    const next = new Map(
+      [...this.#sessions].filter(([, session]) => session.providerId !== providerId),
+    );
+    for (const [id, session] of replacement) next.set(id, session);
+    this.#commit(next);
+    return this.snapshot();
+  }
+
+  /** Reads a provider adapter and applies its full observation as one update. */
+  async refresh(adapter: SessionProviderAdapter): Promise<SessionRegistrySnapshot> {
+    const observations = await adapter.observe();
+    return this.replaceProvider(adapter.provider, observations);
+  }
+
+  /** Stores Luke's latest attention decision without mutating provider-owned data. */
+  setAttention(
+    identity: SessionIdentity,
+    attention: AttentionDecision,
+  ): NormalizedSession | undefined {
+    const key = sessionKey(identity);
+    const existing = this.#sessions.get(key);
+    if (!existing) return undefined;
+
+    const nextSession: NormalizedSession = {
+      ...existing,
+      attention: normalizeAttention(attention),
+    };
+    const next = new Map(this.#sessions);
+    next.set(key, nextSession);
+    this.#commit(next);
+    return copySession(nextSession);
+  }
+
+  remove(identity: SessionIdentity): boolean {
+    const key = sessionKey(identity);
+    if (!this.#sessions.has(key)) return false;
+    const next = new Map(this.#sessions);
+    next.delete(key);
+    this.#commit(next);
+    return true;
+  }
+
+  #commit(next: Map<string, NormalizedSession>): void {
+    if (sameSessions(this.#sessions, next)) return;
+    this.#sessions = next;
+    this.#revision += 1;
+    for (const listener of this.#listeners) listener(this.snapshot());
+  }
+}

--- a/packages/sidecar-core/src/session-registry.ts
+++ b/packages/sidecar-core/src/session-registry.ts
@@ -4,10 +4,10 @@ import {
   type NormalizedSession,
   normalizeAttention,
   normalizeSession,
+  normalizeSessionIdentity,
   type ProviderSessionObservation,
   type SessionIdentity,
   type SessionProvider,
-  sessionKey,
 } from "./session";
 
 export interface SessionRegistrySnapshot {
@@ -16,6 +16,9 @@ export interface SessionRegistrySnapshot {
 }
 
 export type SessionRegistryListener = (snapshot: SessionRegistrySnapshot) => void;
+
+type ProviderSessions = Map<string, NormalizedSession>;
+type SessionStore = Map<string, ProviderSessions>;
 
 function copySession(session: NormalizedSession): NormalizedSession {
   return {
@@ -41,7 +44,6 @@ function sameControls(
 
 function sameSession(first: NormalizedSession, second: NormalizedSession): boolean {
   return (
-    first.id === second.id &&
     first.providerId === second.providerId &&
     first.providerSessionId === second.providerSessionId &&
     first.provider.id === second.provider.id &&
@@ -57,17 +59,31 @@ function sameSession(first: NormalizedSession, second: NormalizedSession): boole
   );
 }
 
-function sameSessions(
+function sameProviderSessions(
   first: ReadonlyMap<string, NormalizedSession>,
-  second: ReadonlyMap<string, NormalizedSession>,
+  second: ProviderSessions,
 ): boolean {
   return (
     first.size === second.size &&
-    [...first].every(([id, session]) => {
-      const candidate = second.get(id);
+    [...first].every(([providerSessionId, session]) => {
+      const candidate = second.get(providerSessionId);
       return candidate !== undefined && sameSession(session, candidate);
     })
   );
+}
+
+function sameSessions(first: ReadonlyMap<string, ProviderSessions>, second: SessionStore): boolean {
+  return (
+    first.size === second.size &&
+    [...first].every(([providerId, sessions]) => {
+      const candidate = second.get(providerId);
+      return candidate !== undefined && sameProviderSessions(sessions, candidate);
+    })
+  );
+}
+
+function copyStore(store: ReadonlyMap<string, ProviderSessions>): SessionStore {
+  return new Map([...store].map(([providerId, sessions]) => [providerId, new Map(sessions)]));
 }
 
 /**
@@ -77,7 +93,7 @@ function sameSessions(
  */
 export class InMemorySessionRegistry {
   #revision = 0;
-  #sessions = new Map<string, NormalizedSession>();
+  #sessions: SessionStore = new Map();
   #listeners = new Set<SessionRegistryListener>();
 
   get revision(): number {
@@ -85,15 +101,21 @@ export class InMemorySessionRegistry {
   }
 
   get(identity: SessionIdentity): NormalizedSession | undefined {
-    const session = this.#sessions.get(sessionKey(identity));
+    const normalizedIdentity = normalizeSessionIdentity(identity);
+    const session = this.#sessions
+      .get(normalizedIdentity.providerId)
+      ?.get(normalizedIdentity.providerSessionId);
     return session && copySession(session);
   }
 
   list(): readonly NormalizedSession[] {
     return [...this.#sessions.values()]
+      .flatMap((sessions) => [...sessions.values()])
       .sort(
         (first, second) =>
-          second.observedAt - first.observedAt || first.id.localeCompare(second.id),
+          second.observedAt - first.observedAt ||
+          first.providerId.localeCompare(second.providerId) ||
+          first.providerSessionId.localeCompare(second.providerSessionId),
       )
       .map(copySession);
   }
@@ -111,15 +133,16 @@ export class InMemorySessionRegistry {
   }
 
   upsert(provider: SessionProvider, observation: ProviderSessionObservation): NormalizedSession {
-    const identity = {
+    const identity = normalizeSessionIdentity({
       providerId: provider.id,
       providerSessionId: observation.providerSessionId,
-    };
-    const key = sessionKey(identity);
-    const existing = this.#sessions.get(key);
+    });
+    const existing = this.#sessions.get(identity.providerId)?.get(identity.providerSessionId);
     const session = normalizeSession(provider, observation, existing?.attention);
-    const next = new Map(this.#sessions);
-    next.set(key, session);
+    const next = copyStore(this.#sessions);
+    const providerSessions = next.get(identity.providerId) ?? new Map();
+    providerSessions.set(identity.providerSessionId, session);
+    next.set(identity.providerId, providerSessions);
     this.#commit(next);
     return copySession(session);
   }
@@ -134,28 +157,30 @@ export class InMemorySessionRegistry {
   ): SessionRegistrySnapshot {
     const providerId = provider.id.trim();
     if (!providerId) throw new Error("provider id must not be empty");
-    const existingForProvider = new Map(
-      [...this.#sessions]
-        .filter(([, session]) => session.providerId === providerId)
-        .map(([id, session]) => [id, session]),
-    );
-    const replacement = new Map<string, NormalizedSession>();
+    const existingForProvider = this.#sessions.get(providerId);
+    const replacement: ProviderSessions = new Map();
 
     for (const observation of observations) {
-      const key = sessionKey({ providerId, providerSessionId: observation.providerSessionId });
-      if (replacement.has(key)) {
+      const { providerSessionId } = normalizeSessionIdentity({
+        providerId,
+        providerSessionId: observation.providerSessionId,
+      });
+      if (replacement.has(providerSessionId)) {
         throw new Error(`Duplicate session observation: ${observation.providerSessionId}`);
       }
       replacement.set(
-        key,
-        normalizeSession(provider, observation, existingForProvider.get(key)?.attention),
+        providerSessionId,
+        normalizeSession(
+          provider,
+          observation,
+          existingForProvider?.get(providerSessionId)?.attention,
+        ),
       );
     }
 
-    const next = new Map(
-      [...this.#sessions].filter(([, session]) => session.providerId !== providerId),
-    );
-    for (const [id, session] of replacement) next.set(id, session);
+    const next = copyStore(this.#sessions);
+    if (replacement.size === 0) next.delete(providerId);
+    else next.set(providerId, replacement);
     this.#commit(next);
     return this.snapshot();
   }
@@ -171,30 +196,38 @@ export class InMemorySessionRegistry {
     identity: SessionIdentity,
     attention: AttentionDecision,
   ): NormalizedSession | undefined {
-    const key = sessionKey(identity);
-    const existing = this.#sessions.get(key);
+    const normalizedIdentity = normalizeSessionIdentity(identity);
+    const existing = this.#sessions
+      .get(normalizedIdentity.providerId)
+      ?.get(normalizedIdentity.providerSessionId);
     if (!existing) return undefined;
 
     const nextSession: NormalizedSession = {
       ...existing,
       attention: normalizeAttention(attention),
     };
-    const next = new Map(this.#sessions);
-    next.set(key, nextSession);
+    const next = copyStore(this.#sessions);
+    const providerSessions = next.get(normalizedIdentity.providerId);
+    if (!providerSessions) throw new Error("Session provider disappeared during attention update");
+    providerSessions.set(normalizedIdentity.providerSessionId, nextSession);
     this.#commit(next);
     return copySession(nextSession);
   }
 
   remove(identity: SessionIdentity): boolean {
-    const key = sessionKey(identity);
-    if (!this.#sessions.has(key)) return false;
-    const next = new Map(this.#sessions);
-    next.delete(key);
+    const normalizedIdentity = normalizeSessionIdentity(identity);
+    const existingProviderSessions = this.#sessions.get(normalizedIdentity.providerId);
+    if (!existingProviderSessions?.has(normalizedIdentity.providerSessionId)) return false;
+    const next = copyStore(this.#sessions);
+    const providerSessions = next.get(normalizedIdentity.providerId);
+    if (!providerSessions) throw new Error("Session provider disappeared during removal");
+    providerSessions.delete(normalizedIdentity.providerSessionId);
+    if (providerSessions.size === 0) next.delete(normalizedIdentity.providerId);
     this.#commit(next);
     return true;
   }
 
-  #commit(next: Map<string, NormalizedSession>): void {
+  #commit(next: SessionStore): void {
     if (sameSessions(this.#sessions, next)) return;
     this.#sessions = next;
     this.#revision += 1;

--- a/packages/sidecar-core/src/session-registry.ts
+++ b/packages/sidecar-core/src/session-registry.ts
@@ -100,7 +100,9 @@ function normalizedProviderId(provider: SessionProvider): string {
 export class InMemorySessionRegistry {
   #revision = 0;
   #sessions: SessionStore = new Map();
-  #providerRefreshGenerations = new Map<string, number>();
+  #providerMutationEpochs = new Map<string, number>();
+  #nextProviderRefreshAttempts = new Map<string, number>();
+  #latestAppliedRefreshAttempts = new Map<string, number>();
   #listeners = new Set<SessionRegistryListener>();
 
   get revision(): number {
@@ -146,12 +148,11 @@ export class InMemorySessionRegistry {
     });
     const existing = this.#sessions.get(identity.providerId)?.get(identity.providerSessionId);
     const session = normalizeSession(provider, observation, existing?.attention);
-    this.#advanceProviderRefreshGeneration(identity.providerId);
     const next = copyStore(this.#sessions);
     const providerSessions = next.get(identity.providerId) ?? new Map();
     providerSessions.set(identity.providerSessionId, session);
     next.set(identity.providerId, providerSessions);
-    this.#commit(next);
+    this.#commit(next, identity.providerId);
     return copySession(session);
   }
 
@@ -164,17 +165,27 @@ export class InMemorySessionRegistry {
     observations: readonly ProviderSessionObservation[],
   ): SessionRegistrySnapshot {
     const providerId = normalizedProviderId(provider);
-    this.#advanceProviderRefreshGeneration(providerId);
-    return this.#replaceProvider(provider, providerId, observations);
+    this.#commit(this.#nextProviderStore(provider, providerId, observations), providerId);
+    return this.snapshot();
   }
 
   /** Reads a provider adapter and applies its newest full observation as one update. */
   async refresh(adapter: SessionProviderAdapter): Promise<SessionRegistrySnapshot> {
     const providerId = normalizedProviderId(adapter.provider);
-    const generation = this.#advanceProviderRefreshGeneration(providerId);
+    const mutationEpoch = this.#providerMutationEpochs.get(providerId) ?? 0;
+    const attempt = this.#startProviderRefreshAttempt(providerId);
     const observations = await adapter.observe();
-    if (this.#providerRefreshGenerations.get(providerId) !== generation) return this.snapshot();
-    return this.#replaceProvider(adapter.provider, providerId, observations);
+    const next = this.#nextProviderStore(adapter.provider, providerId, observations);
+    const latestAttempt = this.#latestAppliedRefreshAttempts.get(providerId) ?? 0;
+    if (
+      latestAttempt >= attempt ||
+      (this.#providerMutationEpochs.get(providerId) ?? 0) !== mutationEpoch
+    ) {
+      return this.snapshot();
+    }
+    this.#latestAppliedRefreshAttempts.set(providerId, attempt);
+    this.#commit(next);
+    return this.snapshot();
   }
 
   /** Stores Luke's latest attention decision without mutating provider-owned data. */
@@ -204,21 +215,20 @@ export class InMemorySessionRegistry {
     const normalizedIdentity = normalizeSessionIdentity(identity);
     const existingProviderSessions = this.#sessions.get(normalizedIdentity.providerId);
     if (!existingProviderSessions?.has(normalizedIdentity.providerSessionId)) return false;
-    this.#advanceProviderRefreshGeneration(normalizedIdentity.providerId);
     const next = copyStore(this.#sessions);
     const providerSessions = next.get(normalizedIdentity.providerId);
     if (!providerSessions) throw new Error("Session provider disappeared during removal");
     providerSessions.delete(normalizedIdentity.providerSessionId);
     if (providerSessions.size === 0) next.delete(normalizedIdentity.providerId);
-    this.#commit(next);
+    this.#commit(next, normalizedIdentity.providerId);
     return true;
   }
 
-  #replaceProvider(
+  #nextProviderStore(
     provider: SessionProvider,
     providerId: string,
     observations: readonly ProviderSessionObservation[],
-  ): SessionRegistrySnapshot {
+  ): SessionStore {
     const existingForProvider = this.#sessions.get(providerId);
     const replacement: ProviderSessions = new Map();
 
@@ -243,20 +253,24 @@ export class InMemorySessionRegistry {
     const next = copyStore(this.#sessions);
     if (replacement.size === 0) next.delete(providerId);
     else next.set(providerId, replacement);
-    this.#commit(next);
-    return this.snapshot();
+    return next;
   }
 
-  #advanceProviderRefreshGeneration(providerId: string): number {
-    const nextGeneration = (this.#providerRefreshGenerations.get(providerId) ?? 0) + 1;
-    this.#providerRefreshGenerations.set(providerId, nextGeneration);
-    return nextGeneration;
+  #startProviderRefreshAttempt(providerId: string): number {
+    const nextAttempt = (this.#nextProviderRefreshAttempts.get(providerId) ?? 0) + 1;
+    this.#nextProviderRefreshAttempts.set(providerId, nextAttempt);
+    return nextAttempt;
   }
 
-  #commit(next: SessionStore): void {
-    if (sameSessions(this.#sessions, next)) return;
+  #commit(next: SessionStore, invalidateRefreshesForProvider?: string): boolean {
+    if (sameSessions(this.#sessions, next)) return false;
+    if (invalidateRefreshesForProvider) {
+      const nextEpoch = (this.#providerMutationEpochs.get(invalidateRefreshesForProvider) ?? 0) + 1;
+      this.#providerMutationEpochs.set(invalidateRefreshesForProvider, nextEpoch);
+    }
     this.#sessions = next;
     this.#revision += 1;
     for (const listener of this.#listeners) listener(this.snapshot());
+    return true;
   }
 }

--- a/packages/sidecar-core/src/session-registry.ts
+++ b/packages/sidecar-core/src/session-registry.ts
@@ -86,6 +86,12 @@ function copyStore(store: ReadonlyMap<string, ProviderSessions>): SessionStore {
   return new Map([...store].map(([providerId, sessions]) => [providerId, new Map(sessions)]));
 }
 
+function normalizedProviderId(provider: SessionProvider): string {
+  const providerId = provider.id.trim();
+  if (!providerId) throw new Error("provider id must not be empty");
+  return providerId;
+}
+
 /**
  * A portable, in-memory source of truth for normalized sessions. It never
  * persists observations, and only replaces records after a provider snapshot
@@ -94,6 +100,7 @@ function copyStore(store: ReadonlyMap<string, ProviderSessions>): SessionStore {
 export class InMemorySessionRegistry {
   #revision = 0;
   #sessions: SessionStore = new Map();
+  #providerRefreshGenerations = new Map<string, number>();
   #listeners = new Set<SessionRegistryListener>();
 
   get revision(): number {
@@ -139,6 +146,7 @@ export class InMemorySessionRegistry {
     });
     const existing = this.#sessions.get(identity.providerId)?.get(identity.providerSessionId);
     const session = normalizeSession(provider, observation, existing?.attention);
+    this.#advanceProviderRefreshGeneration(identity.providerId);
     const next = copyStore(this.#sessions);
     const providerSessions = next.get(identity.providerId) ?? new Map();
     providerSessions.set(identity.providerSessionId, session);
@@ -155,40 +163,18 @@ export class InMemorySessionRegistry {
     provider: SessionProvider,
     observations: readonly ProviderSessionObservation[],
   ): SessionRegistrySnapshot {
-    const providerId = provider.id.trim();
-    if (!providerId) throw new Error("provider id must not be empty");
-    const existingForProvider = this.#sessions.get(providerId);
-    const replacement: ProviderSessions = new Map();
-
-    for (const observation of observations) {
-      const { providerSessionId } = normalizeSessionIdentity({
-        providerId,
-        providerSessionId: observation.providerSessionId,
-      });
-      if (replacement.has(providerSessionId)) {
-        throw new Error(`Duplicate session observation: ${observation.providerSessionId}`);
-      }
-      replacement.set(
-        providerSessionId,
-        normalizeSession(
-          provider,
-          observation,
-          existingForProvider?.get(providerSessionId)?.attention,
-        ),
-      );
-    }
-
-    const next = copyStore(this.#sessions);
-    if (replacement.size === 0) next.delete(providerId);
-    else next.set(providerId, replacement);
-    this.#commit(next);
-    return this.snapshot();
+    const providerId = normalizedProviderId(provider);
+    this.#advanceProviderRefreshGeneration(providerId);
+    return this.#replaceProvider(provider, providerId, observations);
   }
 
-  /** Reads a provider adapter and applies its full observation as one update. */
+  /** Reads a provider adapter and applies its newest full observation as one update. */
   async refresh(adapter: SessionProviderAdapter): Promise<SessionRegistrySnapshot> {
+    const providerId = normalizedProviderId(adapter.provider);
+    const generation = this.#advanceProviderRefreshGeneration(providerId);
     const observations = await adapter.observe();
-    return this.replaceProvider(adapter.provider, observations);
+    if (this.#providerRefreshGenerations.get(providerId) !== generation) return this.snapshot();
+    return this.#replaceProvider(adapter.provider, providerId, observations);
   }
 
   /** Stores Luke's latest attention decision without mutating provider-owned data. */
@@ -218,6 +204,7 @@ export class InMemorySessionRegistry {
     const normalizedIdentity = normalizeSessionIdentity(identity);
     const existingProviderSessions = this.#sessions.get(normalizedIdentity.providerId);
     if (!existingProviderSessions?.has(normalizedIdentity.providerSessionId)) return false;
+    this.#advanceProviderRefreshGeneration(normalizedIdentity.providerId);
     const next = copyStore(this.#sessions);
     const providerSessions = next.get(normalizedIdentity.providerId);
     if (!providerSessions) throw new Error("Session provider disappeared during removal");
@@ -225,6 +212,45 @@ export class InMemorySessionRegistry {
     if (providerSessions.size === 0) next.delete(normalizedIdentity.providerId);
     this.#commit(next);
     return true;
+  }
+
+  #replaceProvider(
+    provider: SessionProvider,
+    providerId: string,
+    observations: readonly ProviderSessionObservation[],
+  ): SessionRegistrySnapshot {
+    const existingForProvider = this.#sessions.get(providerId);
+    const replacement: ProviderSessions = new Map();
+
+    for (const observation of observations) {
+      const { providerSessionId } = normalizeSessionIdentity({
+        providerId,
+        providerSessionId: observation.providerSessionId,
+      });
+      if (replacement.has(providerSessionId)) {
+        throw new Error(`Duplicate session observation: ${observation.providerSessionId}`);
+      }
+      replacement.set(
+        providerSessionId,
+        normalizeSession(
+          provider,
+          observation,
+          existingForProvider?.get(providerSessionId)?.attention,
+        ),
+      );
+    }
+
+    const next = copyStore(this.#sessions);
+    if (replacement.size === 0) next.delete(providerId);
+    else next.set(providerId, replacement);
+    this.#commit(next);
+    return this.snapshot();
+  }
+
+  #advanceProviderRefreshGeneration(providerId: string): number {
+    const nextGeneration = (this.#providerRefreshGenerations.get(providerId) ?? 0) + 1;
+    this.#providerRefreshGenerations.set(providerId, nextGeneration);
+    return nextGeneration;
   }
 
   #commit(next: SessionStore): void {

--- a/packages/sidecar-core/src/session.ts
+++ b/packages/sidecar-core/src/session.ts
@@ -1,14 +1,20 @@
-/**
- * The provider-independent lifecycle state Luke can present for a coding-agent
- * session. Attention is intentionally modeled separately because it is Luke's
- * decision, not a provider-owned lifecycle state.
- */
-export type SessionStatus = "working" | "waiting" | "complete" | "unknown";
+export const SESSION_STATUS = {
+  WORKING: "working",
+  WAITING: "waiting",
+  COMPLETE: "complete",
+  UNKNOWN: "unknown",
+} as const;
 
-/**
- * The three possible outcomes of Luke's bounded attention evaluation.
- */
-export type AttentionDisposition = "silent" | "speak-during-turn" | "speak-at-turn-end";
+export type SessionStatus = (typeof SESSION_STATUS)[keyof typeof SESSION_STATUS];
+
+export const ATTENTION_DISPOSITION = {
+  SILENT: "silent",
+  SPEAK_DURING_TURN: "speak-during-turn",
+  SPEAK_AT_TURN_END: "speak-at-turn-end",
+} as const;
+
+export type AttentionDisposition =
+  (typeof ATTENTION_DISPOSITION)[keyof typeof ATTENTION_DISPOSITION];
 
 /**
  * A bounded, display-safe result from Luke's attention evaluation. The summary
@@ -57,8 +63,6 @@ export interface ProviderSessionObservation {
  * any future capability-gated controls.
  */
 export interface NormalizedSession extends SessionIdentity {
-  /** Stable across display-name changes and safe to use as a UI list key. */
-  id: string;
   provider: SessionProvider;
   title: string;
   status: SessionStatus;
@@ -70,18 +74,6 @@ export interface NormalizedSession extends SessionIdentity {
 
 export const maximumSessionTitleLength = 160;
 export const maximumSessionSummaryLength = 500;
-
-const knownSessionStatuses: readonly SessionStatus[] = [
-  "working",
-  "waiting",
-  "complete",
-  "unknown",
-];
-const knownAttentionDispositions: readonly AttentionDisposition[] = [
-  "silent",
-  "speak-during-turn",
-  "speak-at-turn-end",
-];
 
 function requiredText(value: string, field: string): string {
   const normalized = value.trim();
@@ -103,7 +95,9 @@ function timestamp(value: number, field: string): number {
 }
 
 function normalizeStatus(status: SessionStatus): SessionStatus {
-  if (!knownSessionStatuses.includes(status)) throw new Error(`Unknown session status: ${status}`);
+  if (!Object.values(SESSION_STATUS).includes(status)) {
+    throw new Error(`Unknown session status: ${status}`);
+  }
   return status;
 }
 
@@ -124,24 +118,25 @@ function normalizeControls(
   });
 }
 
-/** Converts a provider-local identity into a collision-free, stable session key. */
-export function sessionKey(identity: SessionIdentity): string {
-  const providerId = requiredText(identity.providerId, "provider id");
-  const providerSessionId = requiredText(identity.providerSessionId, "provider session id");
-  return `${encodeURIComponent(providerId)}:${encodeURIComponent(providerSessionId)}`;
+/** Normalizes the two-part identity used to locate a session in the registry. */
+export function normalizeSessionIdentity(identity: SessionIdentity): SessionIdentity {
+  return {
+    providerId: requiredText(identity.providerId, "provider id"),
+    providerSessionId: requiredText(identity.providerSessionId, "provider session id"),
+  };
 }
 
 /** Creates the silent default used until an attention evaluator returns a decision. */
 export function silentAttention(observedAt: number): AttentionDecision {
   return {
-    disposition: "silent",
+    disposition: ATTENTION_DISPOSITION.SILENT,
     decidedAt: timestamp(observedAt, "observedAt"),
   };
 }
 
 /** Ensures an attention decision is safe to share with the rest of the app. */
 export function normalizeAttention(decision: AttentionDecision): AttentionDecision {
-  if (!knownAttentionDispositions.includes(decision.disposition)) {
+  if (!Object.values(ATTENTION_DISPOSITION).includes(decision.disposition)) {
     throw new Error(`Unknown attention disposition: ${decision.disposition}`);
   }
   const summary = boundedText(decision.summary, maximumSessionSummaryLength);
@@ -162,13 +157,14 @@ export function normalizeSession(
   observation: ProviderSessionObservation,
   attention = silentAttention(observation.observedAt),
 ): NormalizedSession {
-  const providerId = requiredText(provider.id, "provider id");
-  const providerSessionId = requiredText(observation.providerSessionId, "provider session id");
+  const { providerId, providerSessionId } = normalizeSessionIdentity({
+    providerId: provider.id,
+    providerSessionId: observation.providerSessionId,
+  });
   const observedAt = timestamp(observation.observedAt, "observedAt");
   const summary = boundedText(observation.summary, maximumSessionSummaryLength);
 
   return {
-    id: sessionKey({ providerId, providerSessionId }),
     providerId,
     providerSessionId,
     provider: {

--- a/packages/sidecar-core/src/session.ts
+++ b/packages/sidecar-core/src/session.ts
@@ -1,0 +1,190 @@
+/**
+ * The provider-independent lifecycle state Luke can present for a coding-agent
+ * session. Attention is intentionally modeled separately because it is Luke's
+ * decision, not a provider-owned lifecycle state.
+ */
+export type SessionStatus = "working" | "waiting" | "complete" | "unknown";
+
+/**
+ * The three possible outcomes of Luke's bounded attention evaluation.
+ */
+export type AttentionDisposition = "silent" | "speak-during-turn" | "speak-at-turn-end";
+
+/**
+ * A bounded, display-safe result from Luke's attention evaluation. The summary
+ * must be a redacted synopsis, never a provider transcript.
+ */
+export interface AttentionDecision {
+  disposition: AttentionDisposition;
+  decidedAt: number;
+  summary?: string;
+}
+
+/** A provider-defined action that has been explicitly exposed for one session. */
+export interface SessionControl {
+  id: string;
+  label: string;
+}
+
+/** A stable provider identity and the label that can be shown in the UI. */
+export interface SessionProvider {
+  id: string;
+  displayName: string;
+}
+
+/** Identifies a session without conflating identifiers from different providers. */
+export interface SessionIdentity {
+  providerId: string;
+  providerSessionId: string;
+}
+
+/**
+ * Provider-owned data observed for a session. Provider adapters are responsible
+ * for observing without writing provider files and for supplying only bounded,
+ * redacted summaries.
+ */
+export interface ProviderSessionObservation {
+  providerSessionId: string;
+  title: string;
+  status: SessionStatus;
+  observedAt: number;
+  summary?: string;
+  controls?: readonly SessionControl[];
+}
+
+/**
+ * The normalized model shared by observers, attention evaluation, the UI, and
+ * any future capability-gated controls.
+ */
+export interface NormalizedSession extends SessionIdentity {
+  /** Stable across display-name changes and safe to use as a UI list key. */
+  id: string;
+  provider: SessionProvider;
+  title: string;
+  status: SessionStatus;
+  observedAt: number;
+  summary?: string;
+  controls: readonly SessionControl[];
+  attention: AttentionDecision;
+}
+
+export const maximumSessionTitleLength = 160;
+export const maximumSessionSummaryLength = 500;
+
+const knownSessionStatuses: readonly SessionStatus[] = [
+  "working",
+  "waiting",
+  "complete",
+  "unknown",
+];
+const knownAttentionDispositions: readonly AttentionDisposition[] = [
+  "silent",
+  "speak-during-turn",
+  "speak-at-turn-end",
+];
+
+function requiredText(value: string, field: string): string {
+  const normalized = value.trim();
+  if (!normalized) throw new Error(`${field} must not be empty`);
+  return normalized;
+}
+
+function boundedText(value: string | undefined, maximumLength: number): string | undefined {
+  const normalized = value?.trim();
+  if (!normalized) return undefined;
+  return normalized.slice(0, maximumLength);
+}
+
+function timestamp(value: number, field: string): number {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`${field} must be a non-negative finite timestamp`);
+  }
+  return value;
+}
+
+function normalizeStatus(status: SessionStatus): SessionStatus {
+  if (!knownSessionStatuses.includes(status)) throw new Error(`Unknown session status: ${status}`);
+  return status;
+}
+
+function normalizeControls(
+  controls: readonly SessionControl[] | undefined,
+): readonly SessionControl[] {
+  if (!controls) return [];
+
+  const ids = new Set<string>();
+  return controls.map((control) => {
+    const id = requiredText(control.id, "control id");
+    if (ids.has(id)) throw new Error(`Duplicate session control: ${id}`);
+    ids.add(id);
+    return {
+      id,
+      label: boundedText(control.label, maximumSessionTitleLength) ?? id,
+    };
+  });
+}
+
+/** Converts a provider-local identity into a collision-free, stable session key. */
+export function sessionKey(identity: SessionIdentity): string {
+  const providerId = requiredText(identity.providerId, "provider id");
+  const providerSessionId = requiredText(identity.providerSessionId, "provider session id");
+  return `${encodeURIComponent(providerId)}:${encodeURIComponent(providerSessionId)}`;
+}
+
+/** Creates the silent default used until an attention evaluator returns a decision. */
+export function silentAttention(observedAt: number): AttentionDecision {
+  return {
+    disposition: "silent",
+    decidedAt: timestamp(observedAt, "observedAt"),
+  };
+}
+
+/** Ensures an attention decision is safe to share with the rest of the app. */
+export function normalizeAttention(decision: AttentionDecision): AttentionDecision {
+  if (!knownAttentionDispositions.includes(decision.disposition)) {
+    throw new Error(`Unknown attention disposition: ${decision.disposition}`);
+  }
+  const summary = boundedText(decision.summary, maximumSessionSummaryLength);
+  return {
+    disposition: decision.disposition,
+    decidedAt: timestamp(decision.decidedAt, "attention decidedAt"),
+    ...(summary ? { summary } : {}),
+  };
+}
+
+/**
+ * Normalizes a provider observation without retaining provider-specific shapes.
+ * A supplied attention decision is used by the registry when an evaluator has
+ * already made one for this session.
+ */
+export function normalizeSession(
+  provider: SessionProvider,
+  observation: ProviderSessionObservation,
+  attention = silentAttention(observation.observedAt),
+): NormalizedSession {
+  const providerId = requiredText(provider.id, "provider id");
+  const providerSessionId = requiredText(observation.providerSessionId, "provider session id");
+  const observedAt = timestamp(observation.observedAt, "observedAt");
+  const summary = boundedText(observation.summary, maximumSessionSummaryLength);
+
+  return {
+    id: sessionKey({ providerId, providerSessionId }),
+    providerId,
+    providerSessionId,
+    provider: {
+      id: providerId,
+      displayName: boundedText(provider.displayName, maximumSessionTitleLength) ?? providerId,
+    },
+    title: boundedText(observation.title, maximumSessionTitleLength) ?? "Untitled session",
+    status: normalizeStatus(observation.status),
+    observedAt,
+    ...(summary ? { summary } : {}),
+    controls: normalizeControls(observation.controls),
+    attention: normalizeAttention(attention),
+  };
+}
+
+/** Returns whether a provider explicitly exposed a given control for a session. */
+export function supportsSessionControl(session: NormalizedSession, controlId: string): boolean {
+  return session.controls.some((control) => control.id === controlId);
+}

--- a/packages/sidecar-core/tests/session-registry.test.ts
+++ b/packages/sidecar-core/tests/session-registry.test.ts
@@ -1,16 +1,22 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  ATTENTION_DISPOSITION,
   InMemorySessionRegistry,
   maximumSessionSummaryLength,
   type ProviderSessionObservation,
+  SESSION_STATUS,
   type SessionProvider,
-  sessionKey,
   supportsSessionControl,
 } from "../src";
 
 const codex: SessionProvider = { id: "codex", displayName: "Codex" };
 const claude: SessionProvider = { id: "claude-code", displayName: "Claude Code" };
+const TEST_CONTROL = {
+  OPEN: "open",
+  INTERRUPT: "interrupt",
+} as const;
+const TEST_CONTROL_WITH_WHITESPACE = " open ";
 
 function observation(
   providerSessionId: string,
@@ -20,45 +26,49 @@ function observation(
   return {
     providerSessionId,
     title: "Implement the shared session core",
-    status: "working",
+    status: SESSION_STATUS.WORKING,
     observedAt,
     ...overrides,
   };
 }
 
-test("normalizes provider observations into bounded, collision-free session records", () => {
+test("normalizes provider observations without conflating provider-local identities", () => {
   const registry = new InMemorySessionRegistry();
   const session = registry.upsert(
     codex,
     observation("run:42", 100, {
       title: "  Implement the shared session core  ",
       summary: `  ${"a".repeat(maximumSessionSummaryLength + 1)}  `,
-      controls: [{ id: " open ", label: " Open workspace " }],
+      controls: [{ id: TEST_CONTROL_WITH_WHITESPACE, label: " Open workspace " }],
     }),
   );
+  registry.upsert(claude, observation("run:42", 90));
 
-  assert.equal(session.id, "codex:run%3A42");
+  assert.deepEqual(
+    { providerId: session.providerId, providerSessionId: session.providerSessionId },
+    { providerId: codex.id, providerSessionId: "run:42" },
+  );
   assert.equal(session.title, "Implement the shared session core");
   assert.equal(session.summary?.length, maximumSessionSummaryLength);
-  assert.deepEqual(session.controls, [{ id: "open", label: "Open workspace" }]);
-  assert.deepEqual(session.attention, { disposition: "silent", decidedAt: 100 });
-  assert.equal(supportsSessionControl(session, "open"), true);
-  assert.equal(supportsSessionControl(session, "interrupt"), false);
-  assert.equal(
-    sessionKey({ providerId: "codex:local", providerSessionId: "run:42" }),
-    "codex%3Alocal:run%3A42",
-  );
+  assert.deepEqual(session.controls, [{ id: TEST_CONTROL.OPEN, label: "Open workspace" }]);
+  assert.deepEqual(session.attention, {
+    disposition: ATTENTION_DISPOSITION.SILENT,
+    decidedAt: 100,
+  });
+  assert.equal(supportsSessionControl(session, TEST_CONTROL.OPEN), true);
+  assert.equal(supportsSessionControl(session, TEST_CONTROL.INTERRUPT), false);
+  assert.equal(registry.list().length, 2);
 });
 
 test("refresh atomically replaces one adapter's sessions and preserves attention decisions", async () => {
   const registry = new InMemorySessionRegistry();
   registry.upsert(codex, observation("stale", 10));
   registry.upsert(codex, observation("active", 20));
-  registry.upsert(claude, observation("review", 30, { status: "waiting" }));
+  registry.upsert(claude, observation("review", 30, { status: SESSION_STATUS.WAITING }));
   registry.setAttention(
     { providerId: "codex", providerSessionId: "active" },
     {
-      disposition: "speak-at-turn-end",
+      disposition: ATTENTION_DISPOSITION.SPEAK_AT_TURN_END,
       decidedAt: 40,
       summary: "A review decision is ready.",
     },
@@ -70,16 +80,20 @@ test("refresh atomically replaces one adapter's sessions and preserves attention
   });
 
   assert.deepEqual(
-    registry.list().map((session) => session.id),
-    ["codex:new", "codex:active", "claude-code:review"],
+    registry.list().map(({ providerId, providerSessionId }) => ({ providerId, providerSessionId })),
+    [
+      { providerId: codex.id, providerSessionId: "new" },
+      { providerId: codex.id, providerSessionId: "active" },
+      { providerId: claude.id, providerSessionId: "review" },
+    ],
   );
   assert.equal(
     registry.get({ providerId: "codex", providerSessionId: "active" })?.attention.disposition,
-    "speak-at-turn-end",
+    ATTENTION_DISPOSITION.SPEAK_AT_TURN_END,
   );
   assert.equal(
     registry.get({ providerId: "claude-code", providerSessionId: "review" })?.status,
-    "waiting",
+    SESSION_STATUS.WAITING,
   );
   assert.equal(registry.get({ providerId: "codex", providerSessionId: "stale" }), undefined);
 });
@@ -97,7 +111,7 @@ test("registry snapshots are isolated and listeners only receive effective updat
   registry.upsert(codex, observation("active", 10));
   registry.setAttention(
     { providerId: "codex", providerSessionId: "active" },
-    { disposition: "speak-during-turn", decidedAt: 11 },
+    { disposition: ATTENTION_DISPOSITION.SPEAK_DURING_TURN, decidedAt: 11 },
   );
   unsubscribe();
   registry.remove({ providerId: "codex", providerSessionId: "active" });

--- a/packages/sidecar-core/tests/session-registry.test.ts
+++ b/packages/sidecar-core/tests/session-registry.test.ts
@@ -98,6 +98,32 @@ test("refresh atomically replaces one adapter's sessions and preserves attention
   assert.equal(registry.get({ providerId: "codex", providerSessionId: "stale" }), undefined);
 });
 
+test("ignores an older overlapping refresh after a newer provider snapshot is applied", async () => {
+  const registry = new InMemorySessionRegistry();
+  let resolveOlderObservation: ((value: readonly ProviderSessionObservation[]) => void) | undefined;
+  const olderObservation = new Promise<readonly ProviderSessionObservation[]>((resolve) => {
+    resolveOlderObservation = resolve;
+  });
+
+  const olderRefresh = registry.refresh({
+    provider: codex,
+    observe: async () => olderObservation,
+  });
+  await registry.refresh({
+    provider: codex,
+    observe: async () => [observation("active", 20, { title: "Newer observation" })],
+  });
+
+  if (!resolveOlderObservation) throw new Error("Older observation did not start");
+  resolveOlderObservation([observation("active", 10, { title: "Older observation" })]);
+  await olderRefresh;
+
+  assert.equal(
+    registry.get({ providerId: codex.id, providerSessionId: "active" })?.title,
+    "Newer observation",
+  );
+});
+
 test("registry snapshots are isolated and listeners only receive effective updates", () => {
   const registry = new InMemorySessionRegistry();
   const revisions: number[] = [];

--- a/packages/sidecar-core/tests/session-registry.test.ts
+++ b/packages/sidecar-core/tests/session-registry.test.ts
@@ -124,6 +124,31 @@ test("ignores an older overlapping refresh after a newer provider snapshot is ap
   );
 });
 
+test("ignores a stale malformed refresh after a newer provider snapshot is applied", async () => {
+  const registry = new InMemorySessionRegistry();
+  let resolveOlderObservation: ((value: readonly ProviderSessionObservation[]) => void) | undefined;
+  const olderObservation = new Promise<readonly ProviderSessionObservation[]>((resolve) => {
+    resolveOlderObservation = resolve;
+  });
+  const olderRefresh = registry.refresh({
+    provider: codex,
+    observe: async () => olderObservation,
+  });
+  await registry.refresh({
+    provider: codex,
+    observe: async () => [observation("active", 20, { title: "Newer observation" })],
+  });
+
+  if (!resolveOlderObservation) throw new Error("Older observation did not start");
+  resolveOlderObservation([observation("duplicate", 10), observation("duplicate", 10)]);
+  await olderRefresh;
+
+  assert.equal(
+    registry.get({ providerId: codex.id, providerSessionId: "active" })?.title,
+    "Newer observation",
+  );
+});
+
 test("keeps a valid refresh after a rejected or unchanged direct update", async () => {
   const registry = new InMemorySessionRegistry();
   registry.upsert(codex, observation("active", 10));

--- a/packages/sidecar-core/tests/session-registry.test.ts
+++ b/packages/sidecar-core/tests/session-registry.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  InMemorySessionRegistry,
+  maximumSessionSummaryLength,
+  type ProviderSessionObservation,
+  type SessionProvider,
+  sessionKey,
+  supportsSessionControl,
+} from "../src";
+
+const codex: SessionProvider = { id: "codex", displayName: "Codex" };
+const claude: SessionProvider = { id: "claude-code", displayName: "Claude Code" };
+
+function observation(
+  providerSessionId: string,
+  observedAt: number,
+  overrides: Partial<ProviderSessionObservation> = {},
+): ProviderSessionObservation {
+  return {
+    providerSessionId,
+    title: "Implement the shared session core",
+    status: "working",
+    observedAt,
+    ...overrides,
+  };
+}
+
+test("normalizes provider observations into bounded, collision-free session records", () => {
+  const registry = new InMemorySessionRegistry();
+  const session = registry.upsert(
+    codex,
+    observation("run:42", 100, {
+      title: "  Implement the shared session core  ",
+      summary: `  ${"a".repeat(maximumSessionSummaryLength + 1)}  `,
+      controls: [{ id: " open ", label: " Open workspace " }],
+    }),
+  );
+
+  assert.equal(session.id, "codex:run%3A42");
+  assert.equal(session.title, "Implement the shared session core");
+  assert.equal(session.summary?.length, maximumSessionSummaryLength);
+  assert.deepEqual(session.controls, [{ id: "open", label: "Open workspace" }]);
+  assert.deepEqual(session.attention, { disposition: "silent", decidedAt: 100 });
+  assert.equal(supportsSessionControl(session, "open"), true);
+  assert.equal(supportsSessionControl(session, "interrupt"), false);
+  assert.equal(
+    sessionKey({ providerId: "codex:local", providerSessionId: "run:42" }),
+    "codex%3Alocal:run%3A42",
+  );
+});
+
+test("refresh atomically replaces one adapter's sessions and preserves attention decisions", async () => {
+  const registry = new InMemorySessionRegistry();
+  registry.upsert(codex, observation("stale", 10));
+  registry.upsert(codex, observation("active", 20));
+  registry.upsert(claude, observation("review", 30, { status: "waiting" }));
+  registry.setAttention(
+    { providerId: "codex", providerSessionId: "active" },
+    {
+      disposition: "speak-at-turn-end",
+      decidedAt: 40,
+      summary: "A review decision is ready.",
+    },
+  );
+
+  await registry.refresh({
+    provider: codex,
+    observe: async () => [observation("active", 50), observation("new", 60)],
+  });
+
+  assert.deepEqual(
+    registry.list().map((session) => session.id),
+    ["codex:new", "codex:active", "claude-code:review"],
+  );
+  assert.equal(
+    registry.get({ providerId: "codex", providerSessionId: "active" })?.attention.disposition,
+    "speak-at-turn-end",
+  );
+  assert.equal(
+    registry.get({ providerId: "claude-code", providerSessionId: "review" })?.status,
+    "waiting",
+  );
+  assert.equal(registry.get({ providerId: "codex", providerSessionId: "stale" }), undefined);
+});
+
+test("registry snapshots are isolated and listeners only receive effective updates", () => {
+  const registry = new InMemorySessionRegistry();
+  const revisions: number[] = [];
+  const unsubscribe = registry.subscribe((snapshot) => {
+    revisions.push(snapshot.revision);
+    const mutable = snapshot.sessions[0] as { title: string } | undefined;
+    if (mutable) mutable.title = "Changed outside the registry";
+  });
+
+  registry.upsert(codex, observation("active", 10));
+  registry.upsert(codex, observation("active", 10));
+  registry.setAttention(
+    { providerId: "codex", providerSessionId: "active" },
+    { disposition: "speak-during-turn", decidedAt: 11 },
+  );
+  unsubscribe();
+  registry.remove({ providerId: "codex", providerSessionId: "active" });
+
+  assert.deepEqual(revisions, [1, 2]);
+  assert.equal(registry.revision, 3);
+  assert.equal(registry.list().length, 0);
+});
+
+test("a malformed provider snapshot leaves the previous registry state intact", () => {
+  const registry = new InMemorySessionRegistry();
+  registry.upsert(codex, observation("active", 10));
+
+  assert.throws(
+    () =>
+      registry.replaceProvider(codex, [observation("duplicate", 20), observation("duplicate", 30)]),
+    /Duplicate session observation: duplicate/,
+  );
+  assert.equal(registry.list().length, 1);
+  assert.equal(
+    registry.get({ providerId: "codex", providerSessionId: "active" })?.title,
+    "Implement the shared session core",
+  );
+  assert.throws(
+    () =>
+      registry.replaceProvider({ id: " ", displayName: "Invalid" }, [observation("ignored", 20)]),
+    /provider id must not be empty/,
+  );
+});

--- a/packages/sidecar-core/tests/session-registry.test.ts
+++ b/packages/sidecar-core/tests/session-registry.test.ts
@@ -124,6 +124,35 @@ test("ignores an older overlapping refresh after a newer provider snapshot is ap
   );
 });
 
+test("keeps a valid refresh after a rejected or unchanged direct update", async () => {
+  const registry = new InMemorySessionRegistry();
+  registry.upsert(codex, observation("active", 10));
+  let resolveObservation: ((value: readonly ProviderSessionObservation[]) => void) | undefined;
+  const pendingObservation = new Promise<readonly ProviderSessionObservation[]>((resolve) => {
+    resolveObservation = resolve;
+  });
+  const refresh = registry.refresh({
+    provider: codex,
+    observe: async () => pendingObservation,
+  });
+
+  registry.upsert(codex, observation("active", 10));
+  assert.throws(
+    () =>
+      registry.replaceProvider(codex, [observation("duplicate", 20), observation("duplicate", 30)]),
+    /Duplicate session observation: duplicate/,
+  );
+
+  if (!resolveObservation) throw new Error("Refresh observation did not start");
+  resolveObservation([observation("active", 40, { title: "Refreshed observation" })]);
+  await refresh;
+
+  assert.equal(
+    registry.get({ providerId: codex.id, providerSessionId: "active" })?.title,
+    "Refreshed observation",
+  );
+});
+
 test("registry snapshots are isolated and listeners only receive effective updates", () => {
   const registry = new InMemorySessionRegistry();
   const revisions: number[] = [];


### PR DESCRIPTION
## Summary

- Add normalized provider-neutral session, attention, and capability models.
- Use enum-style constant objects for fixed session and control values, with derived TypeScript unions.
- Store provider-local session identities in nested maps and ignore stale overlapping refreshes, with coverage for normalization, refreshes, isolation, and malformed snapshots.

## Evidence

- Platform-independent checks: `./scripts/check.sh` (passed)
- macOS Electron verification (`./scripts/verify.sh`): not run (portable core only)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31545326275/artifacts/9122243873) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31545326275)

- Commit: `32e7ceba2c28b917d97651cb0dcb53ba8b4dd4f8`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: not attached
- Physical-notch check: not performed (no UI changes)
- Device/display configuration: not recorded

## Notes

- Blockers or follow-up verification: None