### PR TITLE
feat(LUKE-46): integrate existing Claude Code sessions

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,6 +9,7 @@
     "build:native": "node scripts/build-native.mjs",
     "package": "pnpm build:native && pnpm build && node scripts/package.mjs",
     "start": "pnpm build:native && pnpm build && electron .",
+    "test": "tsx --test tests/**/*.test.ts",
     "typecheck": "tsc --project tsconfig.json"
   },
   "devDependencies": {
@@ -21,6 +22,7 @@
     "esbuild": "0.28.2",
     "react": "19.2.8",
     "react-dom": "19.2.8",
+    "tsx": "4.23.12",
     "typescript": "7.0.2"
   }
 }

--- a/apps/desktop/src/claude-code-adapter.ts
+++ b/apps/desktop/src/claude-code-adapter.ts
@@ -27,6 +27,10 @@ const CLAUDE_EVENT_TYPE = {
 
 type ClaudeEventType = (typeof CLAUDE_EVENT_TYPE)[keyof typeof CLAUDE_EVENT_TYPE];
 
+const CLAUDE_CONTENT_TYPE = {
+  TOOL_USE: "tool_use",
+} as const;
+
 const CLAUDE_ADAPTER_DEFAULTS = {
   MAXIMUM_PROJECT_DIRECTORIES: 200,
   MAXIMUM_SESSION_FILES: 40,
@@ -57,6 +61,7 @@ interface SessionFileCandidate {
 }
 
 interface ParsedClaudeSessionTail {
+  assistantUsedTool?: boolean;
   cwd?: string;
   eventType?: ClaudeEventType;
   timestampMs?: number;
@@ -205,6 +210,22 @@ function eventTypeFromRecord(record: Record<string, unknown>): ClaudeEventType |
     : undefined;
 }
 
+function containsToolUseMarker(value: unknown, depth = 0): boolean {
+  if (depth > 4 || value === null || typeof value !== "object") return false;
+  if (
+    !Array.isArray(value) &&
+    "type" in value &&
+    (value as Record<string, unknown>).type === CLAUDE_CONTENT_TYPE.TOOL_USE
+  ) {
+    return true;
+  }
+  return Object.values(value).some((nestedValue) => containsToolUseMarker(nestedValue, depth + 1));
+}
+
+function assistantUsedTool(record: Record<string, unknown>): boolean {
+  return containsToolUseMarker(record.message) || containsToolUseMarker(record.content);
+}
+
 function timestampFromRecord(record: Record<string, unknown>): number | undefined {
   const timestamp = record.timestamp;
   if (typeof timestamp !== "string") return undefined;
@@ -224,7 +245,11 @@ function parseClaudeSessionTail(tail: string): ParsedClaudeSessionTail {
     if (!record) continue;
     parsed.cwd = cwdFromRecord(record) ?? parsed.cwd;
     parsed.timestampMs = timestampFromRecord(record) ?? parsed.timestampMs;
-    parsed.eventType = eventTypeFromRecord(record) ?? parsed.eventType;
+    const eventType = eventTypeFromRecord(record);
+    if (!eventType) continue;
+    parsed.eventType = eventType;
+    parsed.assistantUsedTool =
+      eventType === CLAUDE_EVENT_TYPE.ASSISTANT ? assistantUsedTool(record) : false;
   }
   return parsed;
 }
@@ -238,12 +263,13 @@ function statusFromTail(
   const isFresh = now - observedAt <= activeSessionFreshnessMs;
   if (parsed.eventType === CLAUDE_EVENT_TYPE.RESULT) return SESSION_STATUS.COMPLETE;
   if (parsed.eventType === CLAUDE_EVENT_TYPE.ASSISTANT) {
+    if (parsed.assistantUsedTool) return isFresh ? SESSION_STATUS.WORKING : SESSION_STATUS.UNKNOWN;
     return isFresh ? SESSION_STATUS.WAITING : SESSION_STATUS.UNKNOWN;
   }
   if (parsed.eventType === CLAUDE_EVENT_TYPE.USER) {
     return isFresh ? SESSION_STATUS.WORKING : SESSION_STATUS.UNKNOWN;
   }
-  return SESSION_STATUS.UNKNOWN;
+  return isFresh ? SESSION_STATUS.WORKING : SESSION_STATUS.UNKNOWN;
 }
 
 function workspaceLabel(cwd: string | undefined): string {

--- a/apps/desktop/src/claude-code-adapter.ts
+++ b/apps/desktop/src/claude-code-adapter.ts
@@ -1,0 +1,347 @@
+import type { Dirent, Stats } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  type ProviderSessionObservation,
+  SESSION_STATUS,
+  type SessionProvider,
+  type SessionProviderAdapter,
+} from "@sidecar/core";
+
+const CLAUDE_CODE_PROVIDER_ID = "claude-code";
+const CLAUDE_CODE_PROVIDER_NAME = "Claude Code";
+const CLAUDE_PROJECTS_DIRECTORY = "projects";
+const CLAUDE_SESSION_FILE_EXTENSION = ".jsonl";
+const UNKNOWN_WORKSPACE_LABEL = "workspace";
+
+const CLAUDE_ENVIRONMENT = {
+  CONFIG_DIRECTORY: "CLAUDE_CONFIG_DIR",
+} as const;
+
+const CLAUDE_EVENT_TYPE = {
+  ASSISTANT: "assistant",
+  RESULT: "result",
+  SUMMARY: "summary",
+  SYSTEM: "system",
+  USER: "user",
+} as const;
+
+type ClaudeEventType = (typeof CLAUDE_EVENT_TYPE)[keyof typeof CLAUDE_EVENT_TYPE];
+
+const CLAUDE_ADAPTER_DEFAULTS = {
+  MAXIMUM_PROJECT_DIRECTORIES: 200,
+  MAXIMUM_SESSION_FILES: 40,
+  MAXIMUM_SESSION_AGE_MS: 24 * 60 * 60 * 1000,
+  ACTIVE_SESSION_FRESHNESS_MS: 15 * 60 * 1000,
+  READ_TAIL_BYTES: 64 * 1024,
+} as const;
+
+export const CLAUDE_CODE_PROVIDER: SessionProvider = {
+  id: CLAUDE_CODE_PROVIDER_ID,
+  displayName: CLAUDE_CODE_PROVIDER_NAME,
+};
+
+export interface ClaudeCodeAdapterOptions {
+  claudeHome?: string;
+  now?: () => number;
+  maximumProjectDirectories?: number;
+  maximumSessionFiles?: number;
+  maximumSessionAgeMs?: number;
+  activeSessionFreshnessMs?: number;
+  readTailBytes?: number;
+}
+
+interface SessionFileCandidate {
+  filePath: string;
+  providerSessionId: string;
+  mtimeMs: number;
+}
+
+interface ParsedClaudeSessionTail {
+  cwd?: string;
+  eventType?: ClaudeEventType;
+  timestampMs?: number;
+}
+
+interface DirectoryEntry {
+  directoryPath: string;
+  name: string;
+  stats: Stats;
+}
+
+function positiveInteger(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) return fallback;
+  return Math.floor(value);
+}
+
+function nonNegativeNumber(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value < 0) return fallback;
+  return value;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
+
+function canIgnoreFilesystemError(error: unknown): boolean {
+  return (
+    isNodeError(error) &&
+    (error.code === "ENOENT" ||
+      error.code === "ENOTDIR" ||
+      error.code === "EACCES" ||
+      error.code === "EPERM")
+  );
+}
+
+async function readDirectory(directoryPath: string): Promise<Dirent[]> {
+  try {
+    return await fs.readdir(directoryPath, { withFileTypes: true });
+  } catch (error) {
+    if (canIgnoreFilesystemError(error)) return [];
+    throw error;
+  }
+}
+
+async function statDirectoryEntry(
+  directoryPath: string,
+  entry: Dirent,
+): Promise<DirectoryEntry | undefined> {
+  const entryPath = path.join(directoryPath, entry.name);
+  try {
+    const stats = await fs.lstat(entryPath);
+    return { directoryPath: entryPath, name: entry.name, stats };
+  } catch (error) {
+    if (canIgnoreFilesystemError(error)) return undefined;
+    throw error;
+  }
+}
+
+function sessionIdFromFileName(fileName: string): string | undefined {
+  if (!fileName.endsWith(CLAUDE_SESSION_FILE_EXTENSION)) return undefined;
+  const providerSessionId = fileName.slice(0, -CLAUDE_SESSION_FILE_EXTENSION.length).trim();
+  return providerSessionId || undefined;
+}
+
+async function sessionFilesInProject(
+  projectDirectory: DirectoryEntry,
+): Promise<SessionFileCandidate[]> {
+  const entries = await readDirectory(projectDirectory.directoryPath);
+  const candidates = await Promise.all(
+    entries.map(async (entry) => {
+      const providerSessionId = sessionIdFromFileName(entry.name);
+      if (!providerSessionId) return undefined;
+      const candidate = await statDirectoryEntry(projectDirectory.directoryPath, entry);
+      if (!candidate?.stats.isFile()) return undefined;
+      return {
+        filePath: candidate.directoryPath,
+        providerSessionId,
+        mtimeMs: candidate.stats.mtimeMs,
+      };
+    }),
+  );
+  return candidates.filter(
+    (candidate): candidate is SessionFileCandidate => candidate !== undefined,
+  );
+}
+
+async function discoverSessionFiles(
+  projectsDirectory: string,
+  maximumProjectDirectories: number,
+  maximumSessionFiles: number,
+): Promise<SessionFileCandidate[]> {
+  const entries = await readDirectory(projectsDirectory);
+  const projectDirectories = (
+    await Promise.all(entries.map((entry) => statDirectoryEntry(projectsDirectory, entry)))
+  )
+    .filter((entry): entry is DirectoryEntry => entry?.stats.isDirectory() === true)
+    .sort((first, second) => second.stats.mtimeMs - first.stats.mtimeMs)
+    .slice(0, maximumProjectDirectories);
+
+  const files = (await Promise.all(projectDirectories.map(sessionFilesInProject))).flat();
+  return files
+    .sort((first, second) => second.mtimeMs - first.mtimeMs)
+    .slice(0, maximumSessionFiles);
+}
+
+async function readTail(filePath: string, maximumBytes: number): Promise<string> {
+  let handle: fs.FileHandle | undefined;
+  try {
+    handle = await fs.open(filePath, "r");
+    const stats = await handle.stat();
+    if (!stats.isFile() || stats.size <= 0) return "";
+    const length = Math.min(stats.size, maximumBytes);
+    const buffer = Buffer.alloc(length);
+    await handle.read(buffer, 0, length, stats.size - length);
+    return buffer.toString("utf8");
+  } catch (error) {
+    if (canIgnoreFilesystemError(error)) return "";
+    throw error;
+  } finally {
+    await handle?.close();
+  }
+}
+
+function tailLines(tail: string): string[] {
+  const lines = tail.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  if (!tail.startsWith("{")) lines.shift();
+  return lines;
+}
+
+function recordFromJsonLine(line: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function eventTypeFromRecord(record: Record<string, unknown>): ClaudeEventType | undefined {
+  const eventType = record.type;
+  return typeof eventType === "string" &&
+    Object.values(CLAUDE_EVENT_TYPE).includes(eventType as ClaudeEventType)
+    ? (eventType as ClaudeEventType)
+    : undefined;
+}
+
+function timestampFromRecord(record: Record<string, unknown>): number | undefined {
+  const timestamp = record.timestamp;
+  if (typeof timestamp !== "string") return undefined;
+  const timestampMs = Date.parse(timestamp);
+  return Number.isFinite(timestampMs) ? timestampMs : undefined;
+}
+
+function cwdFromRecord(record: Record<string, unknown>): string | undefined {
+  const cwd = record.cwd;
+  return typeof cwd === "string" && cwd.trim().length > 0 ? cwd : undefined;
+}
+
+function parseClaudeSessionTail(tail: string): ParsedClaudeSessionTail {
+  const parsed: ParsedClaudeSessionTail = {};
+  for (const line of tailLines(tail)) {
+    const record = recordFromJsonLine(line);
+    if (!record) continue;
+    parsed.cwd = cwdFromRecord(record) ?? parsed.cwd;
+    parsed.timestampMs = timestampFromRecord(record) ?? parsed.timestampMs;
+    parsed.eventType = eventTypeFromRecord(record) ?? parsed.eventType;
+  }
+  return parsed;
+}
+
+function statusFromTail(
+  parsed: ParsedClaudeSessionTail,
+  observedAt: number,
+  now: number,
+  activeSessionFreshnessMs: number,
+): ProviderSessionObservation["status"] {
+  if (parsed.eventType === CLAUDE_EVENT_TYPE.RESULT) return SESSION_STATUS.COMPLETE;
+  if (parsed.eventType === CLAUDE_EVENT_TYPE.ASSISTANT) return SESSION_STATUS.WAITING;
+  if (parsed.eventType === CLAUDE_EVENT_TYPE.USER) {
+    return now - observedAt <= activeSessionFreshnessMs
+      ? SESSION_STATUS.WORKING
+      : SESSION_STATUS.UNKNOWN;
+  }
+  return SESSION_STATUS.UNKNOWN;
+}
+
+function workspaceLabel(cwd: string | undefined): string {
+  if (!cwd) return UNKNOWN_WORKSPACE_LABEL;
+  const label = path.basename(cwd.trim());
+  return label || UNKNOWN_WORKSPACE_LABEL;
+}
+
+function titleFromTail(parsed: ParsedClaudeSessionTail): string {
+  return `${CLAUDE_CODE_PROVIDER_NAME}: ${workspaceLabel(parsed.cwd)}`;
+}
+
+function summaryFromStatus(status: ProviderSessionObservation["status"]): string {
+  return `${CLAUDE_CODE_PROVIDER_NAME} ${status}; transcript content is not retained.`;
+}
+
+function observationFromSessionFile(
+  candidate: SessionFileCandidate,
+  parsed: ParsedClaudeSessionTail,
+  now: number,
+  activeSessionFreshnessMs: number,
+): ProviderSessionObservation {
+  const observedAt = Math.max(candidate.mtimeMs, parsed.timestampMs ?? 0);
+  const status = statusFromTail(parsed, observedAt, now, activeSessionFreshnessMs);
+  return {
+    providerSessionId: candidate.providerSessionId,
+    title: titleFromTail(parsed),
+    status,
+    observedAt,
+    summary: summaryFromStatus(status),
+  };
+}
+
+function defaultClaudeHome(): string {
+  const configuredHome = process.env[CLAUDE_ENVIRONMENT.CONFIG_DIRECTORY]?.trim();
+  return configuredHome || path.join(os.homedir(), ".claude");
+}
+
+export class ClaudeCodeSessionAdapter implements SessionProviderAdapter {
+  readonly provider = CLAUDE_CODE_PROVIDER;
+
+  readonly #claudeHome: string;
+  readonly #now: () => number;
+  readonly #maximumProjectDirectories: number;
+  readonly #maximumSessionFiles: number;
+  readonly #maximumSessionAgeMs: number;
+  readonly #activeSessionFreshnessMs: number;
+  readonly #readTailBytes: number;
+
+  constructor(options: ClaudeCodeAdapterOptions = {}) {
+    this.#claudeHome = options.claudeHome ?? defaultClaudeHome();
+    this.#now = options.now ?? Date.now;
+    this.#maximumProjectDirectories = positiveInteger(
+      options.maximumProjectDirectories,
+      CLAUDE_ADAPTER_DEFAULTS.MAXIMUM_PROJECT_DIRECTORIES,
+    );
+    this.#maximumSessionFiles = positiveInteger(
+      options.maximumSessionFiles,
+      CLAUDE_ADAPTER_DEFAULTS.MAXIMUM_SESSION_FILES,
+    );
+    this.#maximumSessionAgeMs = nonNegativeNumber(
+      options.maximumSessionAgeMs,
+      CLAUDE_ADAPTER_DEFAULTS.MAXIMUM_SESSION_AGE_MS,
+    );
+    this.#activeSessionFreshnessMs = nonNegativeNumber(
+      options.activeSessionFreshnessMs,
+      CLAUDE_ADAPTER_DEFAULTS.ACTIVE_SESSION_FRESHNESS_MS,
+    );
+    this.#readTailBytes = positiveInteger(
+      options.readTailBytes,
+      CLAUDE_ADAPTER_DEFAULTS.READ_TAIL_BYTES,
+    );
+  }
+
+  async observe(): Promise<readonly ProviderSessionObservation[]> {
+    const now = this.#now();
+    const candidates = await discoverSessionFiles(
+      path.join(this.#claudeHome, CLAUDE_PROJECTS_DIRECTORY),
+      this.#maximumProjectDirectories,
+      this.#maximumSessionFiles,
+    );
+    const observations = new Map<string, ProviderSessionObservation>();
+
+    for (const candidate of candidates) {
+      if (now - candidate.mtimeMs > this.#maximumSessionAgeMs) continue;
+      const tail = await readTail(candidate.filePath, this.#readTailBytes);
+      const observation = observationFromSessionFile(
+        candidate,
+        parseClaudeSessionTail(tail),
+        now,
+        this.#activeSessionFreshnessMs,
+      );
+      if (!observations.has(observation.providerSessionId)) {
+        observations.set(observation.providerSessionId, observation);
+      }
+    }
+
+    return [...observations.values()];
+  }
+}

--- a/apps/desktop/src/claude-code-adapter.ts
+++ b/apps/desktop/src/claude-code-adapter.ts
@@ -22,8 +22,6 @@ const CLAUDE_ENVIRONMENT = {
 const CLAUDE_EVENT_TYPE = {
   ASSISTANT: "assistant",
   RESULT: "result",
-  SUMMARY: "summary",
-  SYSTEM: "system",
   USER: "user",
 } as const;
 

--- a/apps/desktop/src/claude-code-adapter.ts
+++ b/apps/desktop/src/claude-code-adapter.ts
@@ -237,12 +237,13 @@ function statusFromTail(
   now: number,
   activeSessionFreshnessMs: number,
 ): ProviderSessionObservation["status"] {
+  const isFresh = now - observedAt <= activeSessionFreshnessMs;
   if (parsed.eventType === CLAUDE_EVENT_TYPE.RESULT) return SESSION_STATUS.COMPLETE;
-  if (parsed.eventType === CLAUDE_EVENT_TYPE.ASSISTANT) return SESSION_STATUS.WAITING;
+  if (parsed.eventType === CLAUDE_EVENT_TYPE.ASSISTANT) {
+    return isFresh ? SESSION_STATUS.WAITING : SESSION_STATUS.UNKNOWN;
+  }
   if (parsed.eventType === CLAUDE_EVENT_TYPE.USER) {
-    return now - observedAt <= activeSessionFreshnessMs
-      ? SESSION_STATUS.WORKING
-      : SESSION_STATUS.UNKNOWN;
+    return isFresh ? SESSION_STATUS.WORKING : SESSION_STATUS.UNKNOWN;
   }
   return SESSION_STATUS.UNKNOWN;
 }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,7 +1,12 @@
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { fixtureSnapshot, type NativeNotchGeometry, positionNotchWindow } from "@sidecar/core";
+import {
+  fixtureSnapshot,
+  InMemorySessionRegistry,
+  type NativeNotchGeometry,
+  positionNotchWindow,
+} from "@sidecar/core";
 import {
   app,
   BrowserWindow,
@@ -17,6 +22,7 @@ import {
   systemPreferences,
   Tray,
 } from "electron";
+import { ClaudeCodeSessionAdapter } from "./claude-code-adapter";
 import { readMacScreenGeometry } from "./macos-screen-geometry";
 import {
   type AppBootstrap,
@@ -31,6 +37,9 @@ const profile = argumentValue("--profile") ?? "idle";
 const fixtureName = argumentValue("--fixture") ?? "smoke";
 const fixture = fixtureSnapshot(fixtureName);
 const captureMode = captureOutput !== undefined;
+const SESSION_REFRESH_INTERVAL_MS = 5_000;
+const sessionRegistry = new InMemorySessionRegistry();
+const sessionAdapters = [new ClaudeCodeSessionAdapter()] as const;
 let windowMode: WindowMode = captureMode
   ? process.argv.includes("--compact")
     ? "compact"
@@ -42,6 +51,8 @@ let panelWindow: BrowserWindow | undefined;
 let tray: Tray | undefined;
 let selectedDisplayId: number | undefined;
 let nativeScreens = new Map<number, NativeNotchGeometry>();
+let sessionRefreshTimer: NodeJS.Timeout | undefined;
+let sessionRefreshRunning = false;
 
 function argumentValue(name: string): string | undefined {
   const index = process.argv.indexOf(name);
@@ -159,6 +170,7 @@ function registerIpc(): void {
       mode: windowMode,
       profile,
       fixture,
+      captureMode,
       packaged: app.isPackaged,
       platform: process.platform,
       electronVersion: process.versions.electron,
@@ -166,6 +178,7 @@ function registerIpc(): void {
       nodeVersion: process.versions.node,
       microphoneStatus: microphoneStatus(),
       display: displayDiagnostic(),
+      sessions: captureMode ? [] : sessionRegistry.snapshot().sessions,
     };
   });
 
@@ -205,6 +218,33 @@ function registerIpc(): void {
     process.stdout.write(`Electron evidence: ${destination}\n`);
     app.quit();
   });
+}
+
+async function refreshProviderSessions(): Promise<void> {
+  if (captureMode || sessionRefreshRunning) return;
+  sessionRefreshRunning = true;
+  try {
+    for (const adapter of sessionAdapters) {
+      await sessionRegistry.refresh(adapter);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Session observation failed: ${message}\n`);
+  } finally {
+    sessionRefreshRunning = false;
+  }
+}
+
+function startSessionObservation(): void {
+  if (captureMode) return;
+  sessionRegistry.subscribe((snapshot) => {
+    panelWindow?.webContents.send(channels.sessionsChanged, snapshot.sessions);
+  });
+  void refreshProviderSessions();
+  sessionRefreshTimer = setInterval(() => {
+    void refreshProviderSessions();
+  }, SESSION_REFRESH_INTERVAL_MS);
+  sessionRefreshTimer.unref();
 }
 
 function configurePermissions(): void {
@@ -349,6 +389,7 @@ if (!app.requestSingleInstanceLock()) {
     createPanel();
     configurePermissions();
     createTray();
+    startSessionObservation();
 
     screen.on("display-added", handleDisplayChange);
     screen.on("display-removed", handleDisplayChange);
@@ -368,5 +409,9 @@ if (!app.requestSingleInstanceLock()) {
     }
   });
 }
+
+app.on("before-quit", () => {
+  if (sessionRefreshTimer) clearInterval(sessionRefreshTimer);
+});
 
 app.on("window-all-closed", () => app.quit());

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -1,3 +1,4 @@
+import type { NormalizedSession } from "@sidecar/core";
 import { contextBridge, ipcRenderer } from "electron";
 import type {
   AppBootstrap,
@@ -34,6 +35,12 @@ const bridge: AppBridge = {
       callback(display);
     ipcRenderer.on(channels.displayChanged, listener);
     return () => ipcRenderer.removeListener(channels.displayChanged, listener);
+  },
+  onSessionsChanged: (callback: (sessions: readonly NormalizedSession[]) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, sessions: readonly NormalizedSession[]) =>
+      callback(sessions);
+    ipcRenderer.on(channels.sessionsChanged, listener);
+    return () => ipcRenderer.removeListener(channels.sessionsChanged, listener);
   },
 };
 

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -18,6 +18,7 @@ const stateLabels: Record<SessionState, string> = {
   [SESSION_STATE.WORKING]: "Working",
   [SESSION_STATE.ATTENTION]: "Needs attention",
   [SESSION_STATE.COMPLETE]: "Complete",
+  [SESSION_STATE.UNKNOWN]: "Observed",
 };
 
 const statusLabels: Record<NormalizedSession["status"], string> = {
@@ -154,6 +155,7 @@ function sessionNeedsAttention(session: NormalizedSession): boolean {
 function sessionState(session: NormalizedSession): SessionState {
   if (sessionNeedsAttention(session)) return SESSION_STATE.ATTENTION;
   if (session.status === SESSION_STATUS.COMPLETE) return SESSION_STATE.COMPLETE;
+  if (session.status === SESSION_STATUS.UNKNOWN) return SESSION_STATE.UNKNOWN;
   return SESSION_STATE.WORKING;
 }
 
@@ -354,12 +356,24 @@ function App(): React.JSX.Element {
   const attention = visibleSessions.filter(
     (session) => session.state === SESSION_STATE.ATTENTION,
   ).length;
+  const active = visibleSessions.filter(
+    (session) => session.state === SESSION_STATE.WORKING,
+  ).length;
   const fixtureSpeaking = bootstrap.profile === "speaking";
   const hasAudioSignal = fixtureSpeaking || analyser !== undefined;
-  const indicatorState = attention > 0 ? "attention" : "working";
+  const indicatorState =
+    attention > 0
+      ? SESSION_STATE.ATTENTION
+      : active > 0
+        ? SESSION_STATE.WORKING
+        : SESSION_STATE.UNKNOWN;
   const hasLiveSessions = !bootstrap.captureMode && sessions.length > 0;
   const sessionSummary =
-    visibleSessions.length > 0 ? "All sessions are moving" : "No sessions observed";
+    visibleSessions.length === 0
+      ? "No sessions observed"
+      : active > 0
+        ? "Active sessions observed"
+        : "No active sessions observed";
   const style = notchStyle(display);
 
   return (

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -1,6 +1,7 @@
 import {
   ATTENTION_DISPOSITION,
   type NormalizedSession,
+  SESSION_STATE,
   SESSION_STATUS,
   type SessionState,
 } from "@sidecar/core";
@@ -14,9 +15,9 @@ import type {
 } from "../shared/contracts";
 
 const stateLabels: Record<SessionState, string> = {
-  working: "Working",
-  attention: "Needs attention",
-  complete: "Complete",
+  [SESSION_STATE.WORKING]: "Working",
+  [SESSION_STATE.ATTENTION]: "Needs attention",
+  [SESSION_STATE.COMPLETE]: "Complete",
 };
 
 const statusLabels: Record<NormalizedSession["status"], string> = {
@@ -151,9 +152,9 @@ function sessionNeedsAttention(session: NormalizedSession): boolean {
 }
 
 function sessionState(session: NormalizedSession): SessionState {
-  if (sessionNeedsAttention(session)) return "attention";
-  if (session.status === SESSION_STATUS.COMPLETE) return "complete";
-  return "working";
+  if (sessionNeedsAttention(session)) return SESSION_STATE.ATTENTION;
+  if (session.status === SESSION_STATUS.COMPLETE) return SESSION_STATE.COMPLETE;
+  return SESSION_STATE.WORKING;
 }
 
 function displaySessions(bootstrap: AppBootstrap, sessions: readonly NormalizedSession[]) {
@@ -350,7 +351,9 @@ function App(): React.JSX.Element {
   if (!bootstrap || !display) return <div />;
 
   const visibleSessions = displaySessions(bootstrap, sessions);
-  const attention = visibleSessions.filter((session) => session.state === "attention").length;
+  const attention = visibleSessions.filter(
+    (session) => session.state === SESSION_STATE.ATTENTION,
+  ).length;
   const fixtureSpeaking = bootstrap.profile === "speaking";
   const hasAudioSignal = fixtureSpeaking || analyser !== undefined;
   const indicatorState = attention > 0 ? "attention" : "working";

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -1,4 +1,9 @@
-import type { SessionState } from "@sidecar/core";
+import {
+  ATTENTION_DISPOSITION,
+  type NormalizedSession,
+  SESSION_STATUS,
+  type SessionState,
+} from "@sidecar/core";
 import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import type {
@@ -13,6 +18,22 @@ const stateLabels: Record<SessionState, string> = {
   attention: "Needs attention",
   complete: "Complete",
 };
+
+const statusLabels: Record<NormalizedSession["status"], string> = {
+  [SESSION_STATUS.WORKING]: "Working",
+  [SESSION_STATUS.WAITING]: "Waiting",
+  [SESSION_STATUS.COMPLETE]: "Complete",
+  [SESSION_STATUS.UNKNOWN]: "Observed",
+};
+
+interface DisplaySession {
+  id: string;
+  title: string;
+  provider: string;
+  detail: string;
+  state: SessionState;
+  label: string;
+}
 
 function usePointerPassthrough(onHitRegionEnter: () => void, onHitRegionLeave: () => void): void {
   const lastValue = useRef<boolean | undefined>(undefined);
@@ -122,8 +143,44 @@ function notchStyle(display: DisplayDiagnostic): CSSProperties {
   } as CSSProperties;
 }
 
+function sessionNeedsAttention(session: NormalizedSession): boolean {
+  return (
+    session.status === SESSION_STATUS.WAITING ||
+    session.attention.disposition !== ATTENTION_DISPOSITION.SILENT
+  );
+}
+
+function sessionState(session: NormalizedSession): SessionState {
+  if (sessionNeedsAttention(session)) return "attention";
+  if (session.status === SESSION_STATUS.COMPLETE) return "complete";
+  return "working";
+}
+
+function displaySessions(bootstrap: AppBootstrap, sessions: readonly NormalizedSession[]) {
+  if (bootstrap.captureMode) {
+    return bootstrap.fixture.sessions.map(
+      (session): DisplaySession => ({
+        ...session,
+        label: stateLabels[session.state],
+      }),
+    );
+  }
+
+  return sessions.map(
+    (session): DisplaySession => ({
+      id: session.providerSessionId,
+      title: session.title,
+      provider: session.provider.displayName,
+      detail: session.summary ?? statusLabels[session.status],
+      state: sessionState(session),
+      label: statusLabels[session.status],
+    }),
+  );
+}
+
 function App(): React.JSX.Element {
   const [bootstrap, setBootstrap] = useState<AppBootstrap>();
+  const [sessions, setSessions] = useState<readonly NormalizedSession[]>([]);
   const [display, setDisplay] = useState<DisplayDiagnostic>();
   const [mode, setMode] = useState<WindowMode>("compact");
   const [microphoneStatus, setMicrophoneStatus] = useState<MicrophoneStatus>("not-determined");
@@ -254,6 +311,7 @@ function App(): React.JSX.Element {
     const bootstrapGeneration = modeGeneration.current;
     void window.sidecar.getBootstrap().then((value) => {
       setBootstrap(value);
+      setSessions(value.sessions);
       setDisplay(value.display);
       if (modeGeneration.current === bootstrapGeneration) applyAuthoritativeMode(value.mode);
       setMicrophoneStatus(value.microphoneStatus);
@@ -270,11 +328,13 @@ function App(): React.JSX.Element {
       void startMicrophone();
     });
     const removeDisplay = window.sidecar.onDisplayChanged(setDisplay);
+    const removeSessions = window.sidecar.onSessionsChanged(setSessions);
     return () => {
       cancelHoverTransition();
       removeLifecycle();
       removeMicrophone();
       removeDisplay();
+      removeSessions();
       void stopMicrophone();
     };
   }, [applyAuthoritativeMode, cancelHoverTransition, startMicrophone, stopMicrophone]);
@@ -289,12 +349,14 @@ function App(): React.JSX.Element {
 
   if (!bootstrap || !display) return <div />;
 
-  const attention = bootstrap.fixture.sessions.filter(
-    (session) => session.state === "attention",
-  ).length;
+  const visibleSessions = displaySessions(bootstrap, sessions);
+  const attention = visibleSessions.filter((session) => session.state === "attention").length;
   const fixtureSpeaking = bootstrap.profile === "speaking";
   const hasAudioSignal = fixtureSpeaking || analyser !== undefined;
   const indicatorState = attention > 0 ? "attention" : "working";
+  const hasLiveSessions = !bootstrap.captureMode && sessions.length > 0;
+  const sessionSummary =
+    visibleSessions.length > 0 ? "All sessions are moving" : "No sessions observed";
   const style = notchStyle(display);
 
   return (
@@ -316,7 +378,7 @@ function App(): React.JSX.Element {
           aria-label={
             attention > 0
               ? `${attention} session${attention === 1 ? "" : "s"} needs attention`
-              : "Sessions are active"
+              : sessionSummary
           }
           onPointerEnter={() => scheduleMode(true)}
           onPointerLeave={cancelHoverTransition}
@@ -349,7 +411,7 @@ function App(): React.JSX.Element {
                 <small>
                   {attention > 0
                     ? `${attention} session${attention === 1 ? "" : "s"} needs attention`
-                    : "All sessions are moving"}
+                    : sessionSummary}
                 </small>
               </span>
             </div>
@@ -359,13 +421,19 @@ function App(): React.JSX.Element {
             <div>
               <p className="eyebrow">Notch sidecar</p>
               <h1>Agent activity</h1>
-              <p className="subtle">Synthetic sessions · no credentials or live transcripts</p>
+              <p className="subtle">
+                {bootstrap.captureMode
+                  ? "Synthetic sessions · no credentials or live transcripts"
+                  : "Live sessions · no credentials or transcripts retained"}
+              </p>
             </div>
-            <span className="fixture-badge">FIXTURE · SMOKE</span>
+            <span className="fixture-badge">
+              {hasLiveSessions ? "LIVE" : bootstrap.captureMode ? "FIXTURE · SMOKE" : "IDLE"}
+            </span>
           </div>
 
           <div className="session-list">
-            {bootstrap.fixture.sessions.map((item) => (
+            {visibleSessions.map((item) => (
               <article className="session-row" key={item.id}>
                 <span className={`status-mark ${item.state}`} />
                 <span className="session-copy">
@@ -374,7 +442,7 @@ function App(): React.JSX.Element {
                     {item.provider} · {item.detail}
                   </small>
                 </span>
-                <span className={`session-status ${item.state}`}>{stateLabels[item.state]}</span>
+                <span className={`session-status ${item.state}`}>{item.label}</span>
               </article>
             ))}
           </div>

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -106,6 +106,11 @@ button {
   background: #ff963f;
 }
 
+.compact-indicator.unknown,
+.header-indicator.unknown {
+  background: rgba(255, 255, 255, 0.42);
+}
+
 .waveform {
   display: flex;
   width: 28px;
@@ -305,6 +310,10 @@ h1 {
   background: #68d39a;
   box-shadow: 0 0 0 10px rgba(104, 211, 154, 0.07);
 }
+.status-mark.unknown {
+  background: rgba(255, 255, 255, 0.42);
+  box-shadow: 0 0 0 10px rgba(255, 255, 255, 0.045);
+}
 
 .session-copy {
   display: flex;
@@ -343,6 +352,9 @@ h1 {
 }
 .session-status.complete {
   color: #68d39a;
+}
+.session-status.unknown {
+  color: rgba(255, 255, 255, 0.52);
 }
 
 .panel-footer {

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -1,4 +1,10 @@
-import type { FixtureSnapshot, Rectangle, ResolvedNotchGeometry, WindowMode } from "@sidecar/core";
+import type {
+  FixtureSnapshot,
+  NormalizedSession,
+  Rectangle,
+  ResolvedNotchGeometry,
+  WindowMode,
+} from "@sidecar/core";
 
 export type { WindowMode } from "@sidecar/core";
 
@@ -17,6 +23,7 @@ export interface AppBootstrap {
   mode: WindowMode;
   profile: string;
   fixture: FixtureSnapshot;
+  captureMode: boolean;
   packaged: boolean;
   platform: string;
   electronVersion: string;
@@ -24,6 +31,7 @@ export interface AppBootstrap {
   nodeVersion: string;
   microphoneStatus: MicrophoneStatus;
   display: DisplayDiagnostic;
+  sessions: readonly NormalizedSession[];
 }
 
 export interface AppBridge {
@@ -36,6 +44,7 @@ export interface AppBridge {
   onLifecycle(callback: (eventName: string) => void): () => void;
   onStartMicrophone(callback: () => void): () => void;
   onDisplayChanged(callback: (display: DisplayDiagnostic) => void): () => void;
+  onSessionsChanged(callback: (sessions: readonly NormalizedSession[]) => void): () => void;
 }
 
 export const channels = {
@@ -47,5 +56,6 @@ export const channels = {
   lifecycle: "app:lifecycle",
   startMicrophone: "app:start-microphone",
   displayChanged: "app:display-changed",
+  sessionsChanged: "app:sessions-changed",
   quit: "app:quit",
 } as const;

--- a/apps/desktop/tests/claude-code-adapter.test.ts
+++ b/apps/desktop/tests/claude-code-adapter.test.ts
@@ -104,6 +104,34 @@ test("keeps stale user-tail sessions unknown instead of inventing activity", asy
   assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
 });
 
+test("keeps stale assistant-tail sessions from staying in attention", async (t) => {
+  const claudeHome = await temporaryClaudeHome(t);
+  await writeSessionFile(
+    claudeHome,
+    "-Users-test-review",
+    "stale-assistant-tail",
+    [
+      {
+        type: TEST_CLAUDE_EVENT_TYPE.ASSISTANT,
+        cwd: "/Users/test/review",
+        timestamp: "2026-08-11T23:25:00.000Z",
+      },
+    ],
+    TEST_TIME - 20 * 60 * 1000,
+  );
+
+  const adapter = new ClaudeCodeSessionAdapter({
+    activeSessionFreshnessMs: 15 * 60 * 1000,
+    claudeHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60 * 60 * 1000,
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
+});
+
 test("filters old sessions and preserves the newest duplicate provider id", async (t) => {
   const claudeHome = await temporaryClaudeHome(t);
   await writeSessionFile(

--- a/apps/desktop/tests/claude-code-adapter.test.ts
+++ b/apps/desktop/tests/claude-code-adapter.test.ts
@@ -12,6 +12,7 @@ const CLAUDE_PROJECTS_DIRECTORY = "projects";
 const TEST_CLAUDE_EVENT_TYPE = {
   ASSISTANT: "assistant",
   RESULT: "result",
+  SYSTEM: "system",
   USER: "user",
 } as const;
 
@@ -130,6 +131,39 @@ test("keeps stale assistant-tail sessions from staying in attention", async (t) 
 
   assert.equal(observations.length, 1);
   assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
+});
+
+test("ignores trailing system records when finding Claude session status", async (t) => {
+  const claudeHome = await temporaryClaudeHome(t);
+  await writeSessionFile(
+    claudeHome,
+    "-Users-test-system",
+    "system-tail",
+    [
+      {
+        type: TEST_CLAUDE_EVENT_TYPE.ASSISTANT,
+        cwd: "/Users/test/system",
+        timestamp: "2026-08-11T23:44:55.000Z",
+      },
+      {
+        type: TEST_CLAUDE_EVENT_TYPE.SYSTEM,
+        cwd: "/Users/test/system",
+        timestamp: "2026-08-11T23:44:58.000Z",
+        turn_duration_ms: 3000,
+      },
+    ],
+    TEST_TIME - 1_000,
+  );
+
+  const adapter = new ClaudeCodeSessionAdapter({
+    claudeHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
 });
 
 test("filters old sessions and preserves the newest duplicate provider id", async (t) => {

--- a/apps/desktop/tests/claude-code-adapter.test.ts
+++ b/apps/desktop/tests/claude-code-adapter.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test, { type TestContext } from "node:test";
+import { SESSION_STATUS } from "@sidecar/core";
+import { CLAUDE_CODE_PROVIDER, ClaudeCodeSessionAdapter } from "../src/claude-code-adapter";
+
+const TEST_TIME = Date.parse("2026-08-11T23:45:00.000Z");
+const SECRET_TRANSCRIPT_TEXT = "SECRET_TRANSCRIPT_TEXT";
+const CLAUDE_PROJECTS_DIRECTORY = "projects";
+const TEST_CLAUDE_EVENT_TYPE = {
+  ASSISTANT: "assistant",
+  RESULT: "result",
+  USER: "user",
+} as const;
+
+async function temporaryClaudeHome(t: TestContext): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-claude-code-"));
+  t.after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  return directory;
+}
+
+async function writeSessionFile(
+  claudeHome: string,
+  projectDirectoryName: string,
+  sessionFileName: string,
+  records: readonly Record<string, unknown>[],
+  mtimeMs: number,
+): Promise<void> {
+  const projectDirectory = path.join(claudeHome, CLAUDE_PROJECTS_DIRECTORY, projectDirectoryName);
+  await fs.mkdir(projectDirectory, { recursive: true });
+  const filePath = path.join(projectDirectory, `${sessionFileName}.jsonl`);
+  await fs.writeFile(filePath, `${records.map((record) => JSON.stringify(record)).join("\n")}\n`);
+  await fs.utimes(filePath, mtimeMs / 1000, mtimeMs / 1000);
+}
+
+test("observes Claude Code session files without exposing transcript text", async (t) => {
+  const claudeHome = await temporaryClaudeHome(t);
+  await writeSessionFile(
+    claudeHome,
+    "-Users-test-luke",
+    "session-waiting",
+    [
+      {
+        type: TEST_CLAUDE_EVENT_TYPE.USER,
+        cwd: "/Users/test/luke",
+        timestamp: "2026-08-11T23:44:50.000Z",
+        message: { content: SECRET_TRANSCRIPT_TEXT },
+      },
+      {
+        type: TEST_CLAUDE_EVENT_TYPE.ASSISTANT,
+        cwd: "/Users/test/luke",
+        timestamp: "2026-08-11T23:44:55.000Z",
+        message: { content: SECRET_TRANSCRIPT_TEXT },
+      },
+    ],
+    TEST_TIME - 1_000,
+  );
+
+  const adapter = new ClaudeCodeSessionAdapter({
+    claudeHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.deepEqual(adapter.provider, CLAUDE_CODE_PROVIDER);
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "session-waiting");
+  assert.equal(observations[0]?.title, "Claude Code: luke");
+  assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
+  assert.equal(observations[0]?.controls, undefined);
+  assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);
+});
+
+test("keeps stale user-tail sessions unknown instead of inventing activity", async (t) => {
+  const claudeHome = await temporaryClaudeHome(t);
+  await writeSessionFile(
+    claudeHome,
+    "-Users-test-other",
+    "stale-user-tail",
+    [
+      {
+        type: TEST_CLAUDE_EVENT_TYPE.USER,
+        cwd: "/Users/test/other",
+        timestamp: "2026-08-11T23:25:00.000Z",
+      },
+    ],
+    TEST_TIME - 20 * 60 * 1000,
+  );
+
+  const adapter = new ClaudeCodeSessionAdapter({
+    activeSessionFreshnessMs: 15 * 60 * 1000,
+    claudeHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60 * 60 * 1000,
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
+});
+
+test("filters old sessions and preserves the newest duplicate provider id", async (t) => {
+  const claudeHome = await temporaryClaudeHome(t);
+  await writeSessionFile(
+    claudeHome,
+    "-Users-test-old",
+    "old-session",
+    [{ type: TEST_CLAUDE_EVENT_TYPE.ASSISTANT, cwd: "/Users/test/old" }],
+    TEST_TIME - 90_000,
+  );
+  await writeSessionFile(
+    claudeHome,
+    "-Users-test-duplicate-old",
+    "duplicate-session",
+    [{ type: TEST_CLAUDE_EVENT_TYPE.ASSISTANT, cwd: "/Users/test/duplicate-old" }],
+    TEST_TIME - 30_000,
+  );
+  await writeSessionFile(
+    claudeHome,
+    "-Users-test-duplicate-new",
+    "duplicate-session",
+    [{ type: TEST_CLAUDE_EVENT_TYPE.RESULT, cwd: "/Users/test/duplicate-new" }],
+    TEST_TIME - 10_000,
+  );
+
+  const adapter = new ClaudeCodeSessionAdapter({
+    claudeHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.deepEqual(
+    observations.map((observation) => ({
+      providerSessionId: observation.providerSessionId,
+      status: observation.status,
+      title: observation.title,
+    })),
+    [
+      {
+        providerSessionId: "duplicate-session",
+        status: SESSION_STATUS.COMPLETE,
+        title: "Claude Code: duplicate-new",
+      },
+    ],
+  );
+});
+
+test("returns an empty snapshot when Claude Code has no local project directory", async (t) => {
+  const claudeHome = await temporaryClaudeHome(t);
+  const adapter = new ClaudeCodeSessionAdapter({
+    claudeHome,
+    now: () => TEST_TIME,
+  });
+
+  assert.deepEqual(await adapter.observe(), []);
+});

--- a/apps/desktop/tests/claude-code-adapter.test.ts
+++ b/apps/desktop/tests/claude-code-adapter.test.ts
@@ -15,6 +15,10 @@ const TEST_CLAUDE_EVENT_TYPE = {
   SYSTEM: "system",
   USER: "user",
 } as const;
+const TEST_CLAUDE_CONTENT_TYPE = {
+  TOOL_RESULT: "tool_result",
+  TOOL_USE: "tool_use",
+} as const;
 
 async function temporaryClaudeHome(t: TestContext): Promise<string> {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-claude-code-"));
@@ -164,6 +168,86 @@ test("ignores trailing system records when finding Claude session status", async
 
   assert.equal(observations.length, 1);
   assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
+});
+
+test("treats fresh assistant tool use as active work", async (t) => {
+  const claudeHome = await temporaryClaudeHome(t);
+  await writeSessionFile(
+    claudeHome,
+    "-Users-test-tool",
+    "tool-use",
+    [
+      {
+        type: TEST_CLAUDE_EVENT_TYPE.ASSISTANT,
+        cwd: "/Users/test/tool",
+        timestamp: "2026-08-11T23:44:55.000Z",
+        message: {
+          content: [
+            {
+              type: TEST_CLAUDE_CONTENT_TYPE.TOOL_USE,
+              name: "Read",
+            },
+          ],
+        },
+      },
+    ],
+    TEST_TIME - 1_000,
+  );
+
+  const adapter = new ClaudeCodeSessionAdapter({
+    claudeHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
+});
+
+test("keeps fresh sessions active when a large tail has no complete status event", async (t) => {
+  const claudeHome = await temporaryClaudeHome(t);
+  await writeSessionFile(
+    claudeHome,
+    "-Users-test-large-tail",
+    "large-tail",
+    [
+      {
+        type: TEST_CLAUDE_EVENT_TYPE.ASSISTANT,
+        cwd: "/Users/test/large-tail",
+        timestamp: "2026-08-11T23:44:55.000Z",
+        message: {
+          content: [
+            {
+              type: TEST_CLAUDE_CONTENT_TYPE.TOOL_USE,
+              name: "Read",
+            },
+          ],
+        },
+      },
+      {
+        type: TEST_CLAUDE_EVENT_TYPE.USER,
+        cwd: "/Users/test/large-tail",
+        timestamp: "2026-08-11T23:44:58.000Z",
+        toolUseResult: {
+          type: TEST_CLAUDE_CONTENT_TYPE.TOOL_RESULT,
+          content: "x".repeat(512),
+        },
+      },
+    ],
+    TEST_TIME - 1_000,
+  );
+
+  const adapter = new ClaudeCodeSessionAdapter({
+    claudeHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+    readTailBytes: 128,
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
 });
 
 test("filters old sessions and preserves the newest duplicate provider id", async (t) => {

--- a/packages/sidecar-core/src/fixtures.ts
+++ b/packages/sidecar-core/src/fixtures.ts
@@ -2,6 +2,7 @@ export const SESSION_STATE = {
   WORKING: "working",
   ATTENTION: "attention",
   COMPLETE: "complete",
+  UNKNOWN: "unknown",
 } as const;
 
 export type SessionState = (typeof SESSION_STATE)[keyof typeof SESSION_STATE];

--- a/packages/sidecar-core/src/fixtures.ts
+++ b/packages/sidecar-core/src/fixtures.ts
@@ -1,4 +1,10 @@
-export type SessionState = "working" | "attention" | "complete";
+export const SESSION_STATE = {
+  WORKING: "working",
+  ATTENTION: "attention",
+  COMPLETE: "complete",
+} as const;
+
+export type SessionState = (typeof SESSION_STATE)[keyof typeof SESSION_STATE];
 
 export interface SessionSnapshot {
   id: string;
@@ -21,21 +27,21 @@ const smokeFixture: FixtureSnapshot = {
       title: "Bootstrap the desktop shell",
       provider: "Codex",
       detail: "Testing Electron window semantics",
-      state: "working",
+      state: SESSION_STATE.WORKING,
     },
     {
       id: "claude-review",
       title: "Review trust constraints",
       provider: "Claude Code",
       detail: "One architecture decision is ready",
-      state: "attention",
+      state: SESSION_STATE.ATTENTION,
     },
     {
       id: "codex-evidence",
       title: "Capture deterministic evidence",
       provider: "Codex",
       detail: "Fixture requires no live sessions",
-      state: "complete",
+      state: SESSION_STATE.COMPLETE,
     },
   ],
 };
@@ -48,5 +54,5 @@ export function fixtureSnapshot(name: string): FixtureSnapshot {
 }
 
 export function attentionCount(snapshot: FixtureSnapshot): number {
-  return snapshot.sessions.filter((session) => session.state === "attention").length;
+  return snapshot.sessions.filter((session) => session.state === SESSION_STATE.ATTENTION).length;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       react-dom:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
+      tsx:
+        specifier: 4.23.12
+        version: 4.23.12
       typescript:
         specifier: 7.0.2
         version: 7.0.2


### PR DESCRIPTION
## Summary

- Add a passive Claude Code main-process adapter that discovers local Claude session files without hooks, wrappers, MCP, controls, or provider-owned writes.
- Feed bounded, redacted observations into the shared session registry and expose normalized session state through narrow IPC.
- Show live sessions in the notch panel, with smoke fixtures limited to capture/evidence mode.
- Add synthetic adapter tests for transcript non-leakage, stale states, duplicate ids, and missing Claude data.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed
- macOS Electron verification (`./scripts/verify.sh`): embedded portable checks passed, then stopped with `error: this command requires macOS` in this Linux environment

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31550579789/artifacts/9124101240) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31550579789)

- Commit: `bfdf16c8b662e5f8b6b877e21985946043e24c1d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Local macOS smoke testing was reported working by the requester before this PR was opened.
- Blockers or follow-up verification: macOS visual evidence must come from CI or a physical Mac.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/4b6e5029-fb0d-404c-a6d2-33bacf391a09)
