### PR TITLE
feat(LUKE-47): integrate existing Codex sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ the auxiliary top areas so the black Electron surface can join the physical
 camera housing. Macs and external displays without a notch use the same
 top-center attachment with no invented hardware geometry.
 
-The app currently uses synthetic fixture data. It requires no coding-agent
-sessions, credentials, transcripts, or personal data.
+The evidence mode uses synthetic fixture data. Live mode passively observes
+bounded coding-agent session metadata without requiring provider credentials,
+plugins, hooks, wrappers, live-session changes, or transcript retention.
 
 ## Pull-request media
 

--- a/apps/desktop/src/codex-adapter.ts
+++ b/apps/desktop/src/codex-adapter.ts
@@ -1,0 +1,287 @@
+import type { Stats } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  type ProviderSessionObservation,
+  SESSION_STATUS,
+  type SessionProvider,
+  type SessionProviderAdapter,
+} from "@sidecar/core";
+
+const CODEX_PROVIDER_ID = "codex";
+const CODEX_PROVIDER_NAME = "Codex";
+const UNKNOWN_WORKSPACE_LABEL = "workspace";
+
+const CODEX_ENVIRONMENT = {
+  CONFIG_DIRECTORY: "CODEX_HOME",
+} as const;
+
+const CODEX_DATABASE_FILE = {
+  STATE: "state_5.sqlite",
+} as const;
+
+const CODEX_THREAD_COLUMN = {
+  ID: "id",
+  CWD: "cwd",
+  ARCHIVED: "archived",
+  CREATED_AT: "created_at",
+  UPDATED_AT: "updated_at",
+  CREATED_AT_MS: "created_at_ms",
+  UPDATED_AT_MS: "updated_at_ms",
+  RECENCY_AT_MS: "recency_at_ms",
+} as const;
+
+const CODEX_ADAPTER_DEFAULTS = {
+  MAXIMUM_SESSION_ROWS: 40,
+  MAXIMUM_SESSION_AGE_MS: 24 * 60 * 60 * 1000,
+  ACTIVE_SESSION_FRESHNESS_MS: 15 * 60 * 1000,
+} as const;
+
+const CODEX_THREAD_QUERY = `
+  SELECT
+    id,
+    cwd,
+    archived,
+    created_at,
+    updated_at,
+    created_at_ms,
+    updated_at_ms,
+    recency_at_ms
+  FROM threads
+  WHERE archived = 0
+    AND id <> ''
+    AND cwd <> ''
+  ORDER BY
+    CASE
+      WHEN recency_at_ms IS NOT NULL AND recency_at_ms > 0 THEN recency_at_ms
+      WHEN updated_at_ms IS NOT NULL AND updated_at_ms > 0 THEN updated_at_ms
+      WHEN created_at_ms IS NOT NULL AND created_at_ms > 0 THEN created_at_ms
+      WHEN updated_at IS NOT NULL AND updated_at > 0 THEN updated_at * 1000
+      ELSE created_at * 1000
+    END DESC,
+    id DESC
+  LIMIT ?
+`;
+
+type CodexThreadRow = Record<string, unknown>;
+
+interface SqliteStatement {
+  all(...anonymousParameters: readonly unknown[]): unknown[];
+}
+
+interface SqliteDatabase {
+  close(): void;
+  enableDefensive?(enabled: boolean): void;
+  prepare(source: string): SqliteStatement;
+}
+
+interface SqliteModule {
+  DatabaseSync: new (location: string, options: { readOnly: boolean }) => SqliteDatabase;
+}
+
+type SqliteModuleLoader = () => Promise<SqliteModule>;
+
+export const CODEX_PROVIDER: SessionProvider = {
+  id: CODEX_PROVIDER_ID,
+  displayName: CODEX_PROVIDER_NAME,
+};
+
+export interface CodexAdapterOptions {
+  codexHome?: string;
+  now?: () => number;
+  maximumSessionRows?: number;
+  maximumSessionAgeMs?: number;
+  activeSessionFreshnessMs?: number;
+  sqlite?: SqliteModuleLoader;
+}
+
+function positiveInteger(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) return fallback;
+  return Math.floor(value);
+}
+
+function nonNegativeNumber(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value < 0) return fallback;
+  return value;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
+
+function canIgnoreFilesystemError(error: unknown): boolean {
+  return (
+    isNodeError(error) &&
+    (error.code === "ENOENT" ||
+      error.code === "ENOTDIR" ||
+      error.code === "EACCES" ||
+      error.code === "EPERM")
+  );
+}
+
+function canIgnoreSqliteError(error: unknown): boolean {
+  if (isNodeError(error) && error.code === "ERR_UNKNOWN_BUILTIN_MODULE") return true;
+  if (!(error instanceof Error)) return false;
+  return /no such table|no such column|unable to open database file|readonly database/i.test(
+    error.message,
+  );
+}
+
+async function fileStats(filePath: string): Promise<Stats | undefined> {
+  try {
+    return await fs.stat(filePath);
+  } catch (error) {
+    if (canIgnoreFilesystemError(error)) return undefined;
+    throw error;
+  }
+}
+
+async function defaultSqliteModule(): Promise<SqliteModule> {
+  return (await import("node:sqlite")) as SqliteModule;
+}
+
+async function openReadOnlyDatabase(
+  sqlite: SqliteModuleLoader,
+  filePath: string,
+): Promise<SqliteDatabase | undefined> {
+  const stats = await fileStats(filePath);
+  if (!stats?.isFile()) return undefined;
+
+  try {
+    const module = await sqlite();
+    const database = new module.DatabaseSync(filePath, { readOnly: true });
+    database.enableDefensive?.(true);
+    return database;
+  } catch (error) {
+    if (canIgnoreSqliteError(error) || canIgnoreFilesystemError(error)) return undefined;
+    throw error;
+  }
+}
+
+function numberFromRow(row: CodexThreadRow, key: string): number | undefined {
+  const value = row[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function textFromRow(row: CodexThreadRow, key: string): string | undefined {
+  const value = row[key];
+  const normalized = typeof value === "string" ? value.trim() : "";
+  return normalized || undefined;
+}
+
+function timestampFromRow(row: CodexThreadRow): number {
+  return Math.max(
+    numberFromRow(row, CODEX_THREAD_COLUMN.RECENCY_AT_MS) ?? 0,
+    numberFromRow(row, CODEX_THREAD_COLUMN.UPDATED_AT_MS) ?? 0,
+    numberFromRow(row, CODEX_THREAD_COLUMN.CREATED_AT_MS) ?? 0,
+    (numberFromRow(row, CODEX_THREAD_COLUMN.UPDATED_AT) ?? 0) * 1000,
+    (numberFromRow(row, CODEX_THREAD_COLUMN.CREATED_AT) ?? 0) * 1000,
+  );
+}
+
+function workspaceLabel(cwd: string | undefined): string {
+  if (!cwd) return UNKNOWN_WORKSPACE_LABEL;
+  const label = path.basename(cwd.trim());
+  return label || UNKNOWN_WORKSPACE_LABEL;
+}
+
+function titleFromRow(row: CodexThreadRow): string {
+  return `${CODEX_PROVIDER_NAME}: ${workspaceLabel(textFromRow(row, CODEX_THREAD_COLUMN.CWD))}`;
+}
+
+function statusFromRow(
+  row: CodexThreadRow,
+  observedAt: number,
+  now: number,
+  activeSessionFreshnessMs: number,
+): ProviderSessionObservation["status"] {
+  if ((numberFromRow(row, CODEX_THREAD_COLUMN.ARCHIVED) ?? 0) !== 0) {
+    return SESSION_STATUS.COMPLETE;
+  }
+  return now - observedAt <= activeSessionFreshnessMs
+    ? SESSION_STATUS.WORKING
+    : SESSION_STATUS.UNKNOWN;
+}
+
+function summaryFromStatus(status: ProviderSessionObservation["status"]): string {
+  return `${CODEX_PROVIDER_NAME} ${status}; session metadata is observed read-only and transcript content is not retained.`;
+}
+
+function observationFromThreadRow(
+  row: CodexThreadRow,
+  now: number,
+  activeSessionFreshnessMs: number,
+): ProviderSessionObservation | undefined {
+  const providerSessionId = textFromRow(row, CODEX_THREAD_COLUMN.ID);
+  if (!providerSessionId) return undefined;
+
+  const observedAt = timestampFromRow(row);
+  const status = statusFromRow(row, observedAt, now, activeSessionFreshnessMs);
+  return {
+    providerSessionId,
+    title: titleFromRow(row),
+    status,
+    observedAt,
+    summary: summaryFromStatus(status),
+  };
+}
+
+function defaultCodexHome(): string {
+  const configuredHome = process.env[CODEX_ENVIRONMENT.CONFIG_DIRECTORY]?.trim();
+  return configuredHome || path.join(os.homedir(), ".codex");
+}
+
+export class CodexSessionAdapter implements SessionProviderAdapter {
+  readonly provider = CODEX_PROVIDER;
+
+  readonly #codexHome: string;
+  readonly #now: () => number;
+  readonly #maximumSessionRows: number;
+  readonly #maximumSessionAgeMs: number;
+  readonly #activeSessionFreshnessMs: number;
+  readonly #sqlite: SqliteModuleLoader;
+
+  constructor(options: CodexAdapterOptions = {}) {
+    this.#codexHome = options.codexHome ?? defaultCodexHome();
+    this.#now = options.now ?? Date.now;
+    this.#maximumSessionRows = positiveInteger(
+      options.maximumSessionRows,
+      CODEX_ADAPTER_DEFAULTS.MAXIMUM_SESSION_ROWS,
+    );
+    this.#maximumSessionAgeMs = nonNegativeNumber(
+      options.maximumSessionAgeMs,
+      CODEX_ADAPTER_DEFAULTS.MAXIMUM_SESSION_AGE_MS,
+    );
+    this.#activeSessionFreshnessMs = nonNegativeNumber(
+      options.activeSessionFreshnessMs,
+      CODEX_ADAPTER_DEFAULTS.ACTIVE_SESSION_FRESHNESS_MS,
+    );
+    this.#sqlite = options.sqlite ?? defaultSqliteModule;
+  }
+
+  async observe(): Promise<readonly ProviderSessionObservation[]> {
+    const database = await openReadOnlyDatabase(
+      this.#sqlite,
+      path.join(this.#codexHome, CODEX_DATABASE_FILE.STATE),
+    );
+    if (!database) return [];
+
+    try {
+      const now = this.#now();
+      const rows = database.prepare(CODEX_THREAD_QUERY).all(this.#maximumSessionRows);
+      return rows
+        .filter((row): row is CodexThreadRow => row !== null && typeof row === "object")
+        .map((row) => observationFromThreadRow(row, now, this.#activeSessionFreshnessMs))
+        .filter((observation): observation is ProviderSessionObservation => {
+          if (!observation) return false;
+          return now - observation.observedAt <= this.#maximumSessionAgeMs;
+        });
+    } catch (error) {
+      if (canIgnoreSqliteError(error)) return [];
+      throw error;
+    } finally {
+      database.close();
+    }
+  }
+}

--- a/apps/desktop/src/codex-adapter.ts
+++ b/apps/desktop/src/codex-adapter.ts
@@ -272,8 +272,8 @@ async function stateDatabasePaths(
 ): Promise<string[]> {
   const sqliteHome =
     normalizeDirectory(configuredSqliteHome, codexHome) ??
-    normalizeDirectory(process.env[CODEX_ENVIRONMENT.SQLITE_DIRECTORY], codexHome) ??
-    (await sqliteHomeFromConfig(codexHome));
+    (await sqliteHomeFromConfig(codexHome)) ??
+    normalizeDirectory(process.env[CODEX_ENVIRONMENT.SQLITE_DIRECTORY], codexHome);
   return uniquePaths(
     [
       sqliteHome && path.join(sqliteHome, CODEX_DATABASE_FILE.STATE),
@@ -360,28 +360,25 @@ export class CodexSessionAdapter implements SessionProviderAdapter {
   }
 
   async observe(): Promise<readonly ProviderSessionObservation[]> {
-    let database: SqliteDatabase | undefined;
     for (const databasePath of await stateDatabasePaths(this.#codexHome, this.#sqliteHome)) {
-      database = await openReadOnlyDatabase(this.#sqlite, databasePath);
-      if (database) break;
+      const database = await openReadOnlyDatabase(this.#sqlite, databasePath);
+      if (!database) continue;
+      try {
+        const now = this.#now();
+        const rows = database.prepare(CODEX_THREAD_QUERY).all(this.#maximumSessionRows);
+        return rows
+          .filter((row): row is CodexThreadRow => row !== null && typeof row === "object")
+          .map((row) => observationFromThreadRow(row, now, this.#activeSessionFreshnessMs))
+          .filter((observation): observation is ProviderSessionObservation => {
+            if (!observation) return false;
+            return now - observation.observedAt <= this.#maximumSessionAgeMs;
+          });
+      } catch (error) {
+        if (!canIgnoreSqliteError(error)) throw error;
+      } finally {
+        database.close();
+      }
     }
-    if (!database) return [];
-
-    try {
-      const now = this.#now();
-      const rows = database.prepare(CODEX_THREAD_QUERY).all(this.#maximumSessionRows);
-      return rows
-        .filter((row): row is CodexThreadRow => row !== null && typeof row === "object")
-        .map((row) => observationFromThreadRow(row, now, this.#activeSessionFreshnessMs))
-        .filter((observation): observation is ProviderSessionObservation => {
-          if (!observation) return false;
-          return now - observation.observedAt <= this.#maximumSessionAgeMs;
-        });
-    } catch (error) {
-      if (canIgnoreSqliteError(error)) return [];
-      throw error;
-    } finally {
-      database.close();
-    }
+    return [];
   }
 }

--- a/apps/desktop/src/codex-adapter.ts
+++ b/apps/desktop/src/codex-adapter.ts
@@ -15,10 +15,19 @@ const UNKNOWN_WORKSPACE_LABEL = "workspace";
 
 const CODEX_ENVIRONMENT = {
   CONFIG_DIRECTORY: "CODEX_HOME",
+  SQLITE_DIRECTORY: "CODEX_SQLITE_HOME",
 } as const;
 
 const CODEX_DATABASE_FILE = {
   STATE: "state_5.sqlite",
+} as const;
+
+const CODEX_CONFIG_FILE = {
+  USER: "config.toml",
+} as const;
+
+const CODEX_CONFIG_KEY = {
+  SQLITE_DIRECTORY: "sqlite_home",
 } as const;
 
 const CODEX_THREAD_COLUMN = {
@@ -89,6 +98,7 @@ export const CODEX_PROVIDER: SessionProvider = {
 
 export interface CodexAdapterOptions {
   codexHome?: string;
+  sqliteHome?: string;
   now?: () => number;
   maximumSessionRows?: number;
   maximumSessionAgeMs?: number;
@@ -131,6 +141,15 @@ function canIgnoreSqliteError(error: unknown): boolean {
 async function fileStats(filePath: string): Promise<Stats | undefined> {
   try {
     return await fs.stat(filePath);
+  } catch (error) {
+    if (canIgnoreFilesystemError(error)) return undefined;
+    throw error;
+  }
+}
+
+async function readTextFile(filePath: string): Promise<string | undefined> {
+  try {
+    return await fs.readFile(filePath, "utf8");
   } catch (error) {
     if (canIgnoreFilesystemError(error)) return undefined;
     throw error;
@@ -186,6 +205,84 @@ function workspaceLabel(cwd: string | undefined): string {
   return label || UNKNOWN_WORKSPACE_LABEL;
 }
 
+function normalizeDirectory(value: string | undefined, baseDirectory: string): string | undefined {
+  const normalized = value?.trim();
+  if (!normalized) return undefined;
+  if (normalized === "~") return os.homedir();
+  if (normalized.startsWith("~/")) return path.join(os.homedir(), normalized.slice(2));
+  if (path.isAbsolute(normalized)) return normalized;
+  return path.resolve(baseDirectory, normalized);
+}
+
+function unescapeBasicTomlString(value: string): string {
+  return value.replace(/\\(["\\bfnrt])/g, (_match, character: string) => {
+    if (character === "b") return "\b";
+    if (character === "f") return "\f";
+    if (character === "n") return "\n";
+    if (character === "r") return "\r";
+    if (character === "t") return "\t";
+    return character;
+  });
+}
+
+function tomlStringValue(value: string): string | undefined {
+  const normalized = value.trim();
+  if (!normalized) return undefined;
+  if (normalized.startsWith('"') && normalized.endsWith('"')) {
+    return unescapeBasicTomlString(normalized.slice(1, -1)).trim() || undefined;
+  }
+  if (normalized.startsWith("'") && normalized.endsWith("'")) {
+    return normalized.slice(1, -1).trim() || undefined;
+  }
+  return normalized.trim() || undefined;
+}
+
+function topLevelTomlString(source: string, key: string): string | undefined {
+  let inTopLevel = true;
+  for (const line of source.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+      inTopLevel = false;
+      continue;
+    }
+    if (!inTopLevel) continue;
+    const separatorIndex = trimmed.indexOf("=");
+    if (separatorIndex < 0) continue;
+    if (trimmed.slice(0, separatorIndex).trim() !== key) continue;
+    return tomlStringValue(trimmed.slice(separatorIndex + 1).replace(/\s+#.*$/, ""));
+  }
+  return undefined;
+}
+
+async function sqliteHomeFromConfig(codexHome: string): Promise<string | undefined> {
+  const config = await readTextFile(path.join(codexHome, CODEX_CONFIG_FILE.USER));
+  return config
+    ? normalizeDirectory(topLevelTomlString(config, CODEX_CONFIG_KEY.SQLITE_DIRECTORY), codexHome)
+    : undefined;
+}
+
+function uniquePaths(paths: readonly string[]): string[] {
+  return [...new Set(paths)];
+}
+
+async function stateDatabasePaths(
+  codexHome: string,
+  configuredSqliteHome: string | undefined,
+): Promise<string[]> {
+  const sqliteHome =
+    normalizeDirectory(configuredSqliteHome, codexHome) ??
+    normalizeDirectory(process.env[CODEX_ENVIRONMENT.SQLITE_DIRECTORY], codexHome) ??
+    (await sqliteHomeFromConfig(codexHome));
+  return uniquePaths(
+    [
+      sqliteHome && path.join(sqliteHome, CODEX_DATABASE_FILE.STATE),
+      path.join(codexHome, "sqlite", CODEX_DATABASE_FILE.STATE),
+      path.join(codexHome, CODEX_DATABASE_FILE.STATE),
+    ].filter((candidate): candidate is string => candidate !== undefined),
+  );
+}
+
 function titleFromRow(row: CodexThreadRow): string {
   return `${CODEX_PROVIDER_NAME}: ${workspaceLabel(textFromRow(row, CODEX_THREAD_COLUMN.CWD))}`;
 }
@@ -236,6 +333,7 @@ export class CodexSessionAdapter implements SessionProviderAdapter {
   readonly provider = CODEX_PROVIDER;
 
   readonly #codexHome: string;
+  readonly #sqliteHome: string | undefined;
   readonly #now: () => number;
   readonly #maximumSessionRows: number;
   readonly #maximumSessionAgeMs: number;
@@ -244,6 +342,7 @@ export class CodexSessionAdapter implements SessionProviderAdapter {
 
   constructor(options: CodexAdapterOptions = {}) {
     this.#codexHome = options.codexHome ?? defaultCodexHome();
+    this.#sqliteHome = options.sqliteHome;
     this.#now = options.now ?? Date.now;
     this.#maximumSessionRows = positiveInteger(
       options.maximumSessionRows,
@@ -261,10 +360,11 @@ export class CodexSessionAdapter implements SessionProviderAdapter {
   }
 
   async observe(): Promise<readonly ProviderSessionObservation[]> {
-    const database = await openReadOnlyDatabase(
-      this.#sqlite,
-      path.join(this.#codexHome, CODEX_DATABASE_FILE.STATE),
-    );
+    let database: SqliteDatabase | undefined;
+    for (const databasePath of await stateDatabasePaths(this.#codexHome, this.#sqliteHome)) {
+      database = await openReadOnlyDatabase(this.#sqlite, databasePath);
+      if (database) break;
+    }
     if (!database) return [];
 
     try {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -23,6 +23,7 @@ import {
   Tray,
 } from "electron";
 import { ClaudeCodeSessionAdapter } from "./claude-code-adapter";
+import { CodexSessionAdapter } from "./codex-adapter";
 import { readMacScreenGeometry } from "./macos-screen-geometry";
 import {
   type AppBootstrap,
@@ -39,7 +40,7 @@ const fixture = fixtureSnapshot(fixtureName);
 const captureMode = captureOutput !== undefined;
 const SESSION_REFRESH_INTERVAL_MS = 5_000;
 const sessionRegistry = new InMemorySessionRegistry();
-const sessionAdapters = [new ClaudeCodeSessionAdapter()] as const;
+const sessionAdapters = [new ClaudeCodeSessionAdapter(), new CodexSessionAdapter()] as const;
 let windowMode: WindowMode = captureMode
   ? process.argv.includes("--compact")
     ? "compact"

--- a/apps/desktop/tests/codex-adapter.test.ts
+++ b/apps/desktop/tests/codex-adapter.test.ts
@@ -19,6 +19,9 @@ const TEST_CODEX_MODEL_PROVIDER = {
 const TEST_SQLITE_ERROR = {
   UNKNOWN_BUILTIN_MODULE: "ERR_UNKNOWN_BUILTIN_MODULE",
 } as const;
+const TEST_CODEX_ENVIRONMENT = {
+  SQLITE_DIRECTORY: "CODEX_SQLITE_HOME",
+} as const;
 
 interface TestThread {
   id: string;
@@ -110,6 +113,11 @@ async function writeCodexState(codexHome: string, threads: readonly TestThread[]
   }
 }
 
+async function writeCodexConfig(codexHome: string, source: string): Promise<void> {
+  await fs.mkdir(codexHome, { recursive: true });
+  await fs.writeFile(path.join(codexHome, "config.toml"), source);
+}
+
 test("observes Codex sessions without exposing transcript-derived metadata", async (t) => {
   const codexHome = await temporaryCodexHome(t);
   await writeCodexState(codexHome, [
@@ -137,6 +145,112 @@ test("observes Codex sessions without exposing transcript-derived metadata", asy
   assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
   assert.equal(observations[0]?.controls, undefined);
   assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);
+});
+
+test("observes Codex sessions from an explicit SQLite home", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const sqliteHome = path.join(codexHome, "sqlite-state");
+  await writeCodexState(sqliteHome, [
+    {
+      id: "codex-sqlite-home",
+      cwd: "/Users/test/sqlite-home",
+      observedAt: TEST_TIME - 1_000,
+    },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    sqliteHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "codex-sqlite-home");
+  assert.equal(observations[0]?.title, "Codex: sqlite-home");
+});
+
+test("observes Codex sessions from configured sqlite_home", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const previousSqliteHome = process.env[TEST_CODEX_ENVIRONMENT.SQLITE_DIRECTORY];
+  delete process.env[TEST_CODEX_ENVIRONMENT.SQLITE_DIRECTORY];
+  t.after(() => {
+    if (previousSqliteHome === undefined)
+      delete process.env[TEST_CODEX_ENVIRONMENT.SQLITE_DIRECTORY];
+    else process.env[TEST_CODEX_ENVIRONMENT.SQLITE_DIRECTORY] = previousSqliteHome;
+  });
+  await writeCodexConfig(codexHome, "sqlite_home = 'configured-sqlite'\n");
+  await writeCodexState(path.join(codexHome, "configured-sqlite"), [
+    {
+      id: "codex-configured-home",
+      cwd: "/Users/test/configured-home",
+      observedAt: TEST_TIME - 1_000,
+    },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "codex-configured-home");
+  assert.equal(observations[0]?.title, "Codex: configured-home");
+});
+
+test("observes Codex sessions from CODEX_SQLITE_HOME", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const sqliteHome = path.join(codexHome, "env-sqlite");
+  const previousSqliteHome = process.env[TEST_CODEX_ENVIRONMENT.SQLITE_DIRECTORY];
+  process.env[TEST_CODEX_ENVIRONMENT.SQLITE_DIRECTORY] = sqliteHome;
+  t.after(() => {
+    if (previousSqliteHome === undefined)
+      delete process.env[TEST_CODEX_ENVIRONMENT.SQLITE_DIRECTORY];
+    else process.env[TEST_CODEX_ENVIRONMENT.SQLITE_DIRECTORY] = previousSqliteHome;
+  });
+  await writeCodexState(sqliteHome, [
+    {
+      id: "codex-env-home",
+      cwd: "/Users/test/env-home",
+      observedAt: TEST_TIME - 1_000,
+    },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "codex-env-home");
+  assert.equal(observations[0]?.title, "Codex: env-home");
+});
+
+test("observes Codex sessions from the default sqlite subdirectory", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeCodexState(path.join(codexHome, "sqlite"), [
+    {
+      id: "codex-default-sqlite",
+      cwd: "/Users/test/default-sqlite",
+      observedAt: TEST_TIME - 1_000,
+    },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "codex-default-sqlite");
+  assert.equal(observations[0]?.title, "Codex: default-sqlite");
 });
 
 test("keeps stale unarchived Codex sessions unknown instead of inventing activity", async (t) => {

--- a/apps/desktop/tests/codex-adapter.test.ts
+++ b/apps/desktop/tests/codex-adapter.test.ts
@@ -118,6 +118,16 @@ async function writeCodexConfig(codexHome: string, source: string): Promise<void
   await fs.writeFile(path.join(codexHome, "config.toml"), source);
 }
 
+async function writeMalformedCodexState(codexHome: string): Promise<void> {
+  await fs.mkdir(codexHome, { recursive: true });
+  const database = new DatabaseSync(path.join(codexHome, CODEX_STATE_DATABASE), {});
+  try {
+    database.exec("CREATE TABLE unrelated (id TEXT PRIMARY KEY)");
+  } finally {
+    database.close();
+  }
+}
+
 test("observes Codex sessions without exposing transcript-derived metadata", async (t) => {
   const codexHome = await temporaryCodexHome(t);
   await writeCodexState(codexHome, [
@@ -231,6 +241,44 @@ test("observes Codex sessions from CODEX_SQLITE_HOME", async (t) => {
   assert.equal(observations[0]?.title, "Codex: env-home");
 });
 
+test("prefers configured sqlite_home over CODEX_SQLITE_HOME", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const envSqliteHome = path.join(codexHome, "env-sqlite");
+  const previousSqliteHome = process.env[TEST_CODEX_ENVIRONMENT.SQLITE_DIRECTORY];
+  process.env[TEST_CODEX_ENVIRONMENT.SQLITE_DIRECTORY] = envSqliteHome;
+  t.after(() => {
+    if (previousSqliteHome === undefined)
+      delete process.env[TEST_CODEX_ENVIRONMENT.SQLITE_DIRECTORY];
+    else process.env[TEST_CODEX_ENVIRONMENT.SQLITE_DIRECTORY] = previousSqliteHome;
+  });
+  await writeCodexConfig(codexHome, "sqlite_home = 'configured-sqlite'\n");
+  await writeCodexState(envSqliteHome, [
+    {
+      id: "codex-env-home",
+      cwd: "/Users/test/env-home",
+      observedAt: TEST_TIME - 1_000,
+    },
+  ]);
+  await writeCodexState(path.join(codexHome, "configured-sqlite"), [
+    {
+      id: "codex-configured-home",
+      cwd: "/Users/test/configured-home",
+      observedAt: TEST_TIME - 1_000,
+    },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "codex-configured-home");
+  assert.equal(observations[0]?.title, "Codex: configured-home");
+});
+
 test("observes Codex sessions from the default sqlite subdirectory", async (t) => {
   const codexHome = await temporaryCodexHome(t);
   await writeCodexState(path.join(codexHome, "sqlite"), [
@@ -251,6 +299,29 @@ test("observes Codex sessions from the default sqlite subdirectory", async (t) =
   assert.equal(observations.length, 1);
   assert.equal(observations[0]?.providerSessionId, "codex-default-sqlite");
   assert.equal(observations[0]?.title, "Codex: default-sqlite");
+});
+
+test("falls back when a higher-priority Codex database has an unusable schema", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeMalformedCodexState(path.join(codexHome, "sqlite"));
+  await writeCodexState(codexHome, [
+    {
+      id: "codex-legacy-valid",
+      cwd: "/Users/test/legacy-valid",
+      observedAt: TEST_TIME - 1_000,
+    },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "codex-legacy-valid");
+  assert.equal(observations[0]?.title, "Codex: legacy-valid");
 });
 
 test("keeps stale unarchived Codex sessions unknown instead of inventing activity", async (t) => {

--- a/apps/desktop/tests/codex-adapter.test.ts
+++ b/apps/desktop/tests/codex-adapter.test.ts
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import test, { type TestContext } from "node:test";
+import { SESSION_STATUS } from "@sidecar/core";
+import { CODEX_PROVIDER, CodexSessionAdapter } from "../src/codex-adapter";
+
+const TEST_TIME = Date.parse("2026-08-11T23:45:00.000Z");
+const SECRET_TRANSCRIPT_TEXT = "SECRET_TRANSCRIPT_TEXT";
+const CODEX_STATE_DATABASE = "state_5.sqlite";
+const TEST_CODEX_SOURCE = {
+  CLI: "cli",
+} as const;
+const TEST_CODEX_MODEL_PROVIDER = {
+  OPENAI_SSE: "openai_sse",
+} as const;
+const TEST_SQLITE_ERROR = {
+  UNKNOWN_BUILTIN_MODULE: "ERR_UNKNOWN_BUILTIN_MODULE",
+} as const;
+
+interface TestThread {
+  id: string;
+  cwd: string;
+  observedAt: number;
+  archived?: number;
+  title?: string;
+  preview?: string;
+  firstUserMessage?: string;
+}
+
+async function temporaryCodexHome(t: TestContext): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-codex-"));
+  t.after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  return directory;
+}
+
+function writeThread(database: DatabaseSync, thread: TestThread): void {
+  database
+    .prepare(`
+      INSERT INTO threads (
+        id,
+        rollout_path,
+        created_at,
+        updated_at,
+        source,
+        model_provider,
+        cwd,
+        title,
+        sandbox_policy,
+        approval_mode,
+        archived,
+        first_user_message,
+        created_at_ms,
+        updated_at_ms,
+        preview,
+        recency_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `)
+    .run(
+      thread.id,
+      "",
+      Math.floor(thread.observedAt / 1000),
+      Math.floor(thread.observedAt / 1000),
+      TEST_CODEX_SOURCE.CLI,
+      TEST_CODEX_MODEL_PROVIDER.OPENAI_SSE,
+      thread.cwd,
+      thread.title ?? "",
+      "workspace-write",
+      "never",
+      thread.archived ?? 0,
+      thread.firstUserMessage ?? "",
+      thread.observedAt,
+      thread.observedAt,
+      thread.preview ?? "",
+      thread.observedAt,
+    );
+}
+
+async function writeCodexState(codexHome: string, threads: readonly TestThread[]): Promise<void> {
+  await fs.mkdir(codexHome, { recursive: true });
+  const database = new DatabaseSync(path.join(codexHome, CODEX_STATE_DATABASE), {});
+  try {
+    database.exec(`
+      CREATE TABLE threads (
+        id TEXT PRIMARY KEY,
+        rollout_path TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        source TEXT NOT NULL,
+        model_provider TEXT NOT NULL,
+        cwd TEXT NOT NULL,
+        title TEXT NOT NULL,
+        sandbox_policy TEXT NOT NULL,
+        approval_mode TEXT NOT NULL,
+        archived INTEGER NOT NULL DEFAULT 0,
+        first_user_message TEXT NOT NULL DEFAULT '',
+        created_at_ms INTEGER,
+        updated_at_ms INTEGER,
+        preview TEXT NOT NULL DEFAULT '',
+        recency_at_ms INTEGER NOT NULL DEFAULT 0
+      )
+    `);
+    for (const thread of threads) writeThread(database, thread);
+  } finally {
+    database.close();
+  }
+}
+
+test("observes Codex sessions without exposing transcript-derived metadata", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeCodexState(codexHome, [
+    {
+      id: "codex-active",
+      cwd: "/Users/test/luke",
+      observedAt: TEST_TIME - 1_000,
+      title: SECRET_TRANSCRIPT_TEXT,
+      preview: SECRET_TRANSCRIPT_TEXT,
+      firstUserMessage: SECRET_TRANSCRIPT_TEXT,
+    },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.deepEqual(adapter.provider, CODEX_PROVIDER);
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "codex-active");
+  assert.equal(observations[0]?.title, "Codex: luke");
+  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
+  assert.equal(observations[0]?.controls, undefined);
+  assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);
+});
+
+test("keeps stale unarchived Codex sessions unknown instead of inventing activity", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeCodexState(codexHome, [
+    {
+      id: "codex-stale",
+      cwd: "/Users/test/stale",
+      observedAt: TEST_TIME - 20 * 60 * 1000,
+    },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    activeSessionFreshnessMs: 15 * 60 * 1000,
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60 * 60 * 1000,
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
+});
+
+test("filters old and archived Codex threads while preserving newest sessions", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeCodexState(codexHome, [
+    {
+      id: "old-session",
+      cwd: "/Users/test/old",
+      observedAt: TEST_TIME - 90_000,
+    },
+    {
+      id: "archived-session",
+      cwd: "/Users/test/archived",
+      observedAt: TEST_TIME - 1_000,
+      archived: 1,
+    },
+    {
+      id: "new-session",
+      cwd: "/Users/test/new",
+      observedAt: TEST_TIME - 10_000,
+    },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.deepEqual(
+    observations.map((observation) => ({
+      providerSessionId: observation.providerSessionId,
+      status: observation.status,
+      title: observation.title,
+    })),
+    [
+      {
+        providerSessionId: "new-session",
+        status: SESSION_STATUS.WORKING,
+        title: "Codex: new",
+      },
+    ],
+  );
+});
+
+test("returns an empty snapshot when Codex has no local state database", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+  });
+
+  assert.deepEqual(await adapter.observe(), []);
+});
+
+test("returns an empty snapshot when node sqlite is unavailable", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeCodexState(codexHome, [
+    {
+      id: "codex-active",
+      cwd: "/Users/test/luke",
+      observedAt: TEST_TIME - 1_000,
+    },
+  ]);
+  const error = new Error("No such built-in module: node:sqlite") as NodeJS.ErrnoException;
+  error.code = TEST_SQLITE_ERROR.UNKNOWN_BUILTIN_MODULE;
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    sqlite: async () => {
+      throw error;
+    },
+  });
+
+  assert.deepEqual(await adapter.observe(), []);
+});


### PR DESCRIPTION
## Summary

- Add a passive Codex session adapter in the Electron main process that reads bounded session metadata from Codex state using a read-only SQLite connection.
- Register Codex beside the existing Claude Code adapter, with no provider controls exposed for independent active sessions.
- Cover metadata-only observation, stale filtering, archived-thread filtering, missing state DB behavior, unavailable SQLite support, and Codex SQLite-home resolution.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed after review fix
- macOS Electron verification (`./scripts/verify.sh`): on the initial commit, portable checks passed locally, then screenshot packaging stopped with `error: this command requires macOS` in this Linux workspace; CI macOS app/evidence passed for the PR
- Linux headless fixture screenshot: ![Expanded smoke fixture](https://raw.githubusercontent.com/ReviewStage/luke/pr-assets/pr-6/luke-47-expanded-linux.png)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31552606779/artifacts/9124809224) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31552606779)

- Commit: `7a92f19e88376579afdc3292d61af1c3ce4f8efa`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: Linux headless expanded fixture screenshot attached above
- Physical-notch check: not performed
- Device/display configuration: Linux headless Chrome fixture harness, 620x520 expanded view

## Notes

- `./scripts/verify.sh` could not complete canonical macOS screenshot evidence locally because this workspace is not macOS.
- Local smoke read against the default Codex metadata path observed the current session as `Codex: luke`, `working`, with no controls.
- Resolved Cursor Bugbot's SQLite state-home finding in `1d3953b`.
