### PR TITLE
feat(LUKE-48): build Luke's attention intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,30 @@ The evidence mode uses synthetic fixture data. Live mode passively observes
 bounded coding-agent session metadata without requiring provider credentials,
 plugins, hooks, wrappers, live-session changes, or transcript retention.
 
+## Attention intelligence
+
+When a session reports a development, Luke asks a background model whether that
+development is worth saying out loud. The model receives one bounded, redacted
+update—provider, session title, previous and current status, and the observed
+summary—and answers with a structured decision: stay silent, speak during the
+turn, or speak once the turn ends. Anything outside that contract, and any API
+failure, leaves Luke silent. Repeated decisions about the same session are
+deduplicated so one development is never announced twice.
+
+The layer is optional. Without `OPENAI_API_KEY`, Luke observes sessions and
+stays silent, and no other behavior changes:
+
+| Variable               | Default                     | Purpose                                    |
+| ---------------------- | --------------------------- | ------------------------------------------ |
+| `OPENAI_API_KEY`       | unset                       | Enables attention review when it is present |
+| `LUKE_ATTENTION_MODEL` | `gpt-5.1`                   | Model used for the decision                |
+| `OPENAI_BASE_URL`      | `https://api.openai.com/v1` | Alternate OpenAI-compatible endpoint       |
+
+Requests set `store: false`, so the API is not asked to retain them. Tune how
+conservative Luke is by editing the redacted examples in
+`packages/sidecar-core/src/attention-examples.ts`; they are synthetic and
+double as the prompt's few-shot guidance and its regression coverage.
+
 ## Pull-request media
 
 Keep generated screenshots and recordings out of product branches. Inline PR

--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ update—provider, session title, previous and current status, and the observed
 summary—and answers with a structured decision: stay silent, speak during the
 turn, or speak once the turn ends. Anything outside that contract, and any API
 failure, leaves Luke silent. Repeated decisions about the same session are
-deduplicated so one development is never announced twice.
+deduplicated so one development is never announced twice, and a decision is
+discarded when the session moves past the state it was made about—answering a
+waiting session while the model is still thinking should not produce a stale
+interruption.
 
 The layer is optional. Without `OPENAI_API_KEY`, Luke observes sessions and
 stays silent, and no other behavior changes:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ stays silent, and no other behavior changes:
 | Variable               | Default                     | Purpose                                    |
 | ---------------------- | --------------------------- | ------------------------------------------ |
 | `OPENAI_API_KEY`       | unset                       | Enables attention review when it is present |
-| `LUKE_ATTENTION_MODEL` | `gpt-5.1`                   | Model used for the decision                |
+| `LUKE_ATTENTION_MODEL` | `gpt-5.6-luna`              | Model used for the decision                |
 | `OPENAI_BASE_URL`      | `https://api.openai.com/v1` | Alternate OpenAI-compatible endpoint       |
 
 Requests set `store: false`, so the API is not asked to retain them. Tune how

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -45,7 +45,10 @@ const sessionRegistry = new InMemorySessionRegistry();
 const sessionAdapters = [new ClaudeCodeSessionAdapter(), new CodexSessionAdapter()] as const;
 const attentionEvaluator = captureMode ? undefined : openAiAttentionEvaluatorFromEnvironment();
 const attentionReviewer = attentionEvaluator
-  ? new SessionAttentionReviewer({ evaluator: attentionEvaluator })
+  ? new SessionAttentionReviewer({
+      evaluator: attentionEvaluator,
+      currentSession: (identity) => sessionRegistry.get(identity),
+    })
   : undefined;
 let windowMode: WindowMode = captureMode
   ? process.argv.includes("--compact")

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -46,7 +46,9 @@ const fixtureMode = captureMode || fixtureName !== undefined;
 const SESSION_REFRESH_INTERVAL_MS = 5_000;
 const sessionRegistry = new InMemorySessionRegistry();
 const sessionAdapters = [new ClaudeCodeSessionAdapter(), new CodexSessionAdapter()] as const;
-const attentionEvaluator = captureMode ? undefined : openAiAttentionEvaluatorFromEnvironment();
+// A fixture run must stay deterministic and credential-free, so it never builds
+// an evaluator — not just capture runs.
+const attentionEvaluator = fixtureMode ? undefined : openAiAttentionEvaluatorFromEnvironment();
 const attentionReviewer = attentionEvaluator
   ? new SessionAttentionReviewer({
       evaluator: attentionEvaluator,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -6,6 +6,7 @@ import {
   InMemorySessionRegistry,
   type NativeNotchGeometry,
   positionNotchWindow,
+  SessionAttentionReviewer,
 } from "@sidecar/core";
 import {
   app,
@@ -25,6 +26,7 @@ import {
 import { ClaudeCodeSessionAdapter } from "./claude-code-adapter";
 import { CodexSessionAdapter } from "./codex-adapter";
 import { readMacScreenGeometry } from "./macos-screen-geometry";
+import { openAiAttentionEvaluatorFromEnvironment } from "./openai-attention-evaluator";
 import {
   type AppBootstrap,
   channels,
@@ -41,6 +43,10 @@ const captureMode = captureOutput !== undefined;
 const SESSION_REFRESH_INTERVAL_MS = 5_000;
 const sessionRegistry = new InMemorySessionRegistry();
 const sessionAdapters = [new ClaudeCodeSessionAdapter(), new CodexSessionAdapter()] as const;
+const attentionEvaluator = captureMode ? undefined : openAiAttentionEvaluatorFromEnvironment();
+const attentionReviewer = attentionEvaluator
+  ? new SessionAttentionReviewer({ evaluator: attentionEvaluator })
+  : undefined;
 let windowMode: WindowMode = captureMode
   ? process.argv.includes("--compact")
     ? "compact"
@@ -54,6 +60,7 @@ let selectedDisplayId: number | undefined;
 let nativeScreens = new Map<number, NativeNotchGeometry>();
 let sessionRefreshTimer: NodeJS.Timeout | undefined;
 let sessionRefreshRunning = false;
+let attentionReviewRunning = false;
 
 function argumentValue(name: string): string | undefined {
   const index = process.argv.indexOf(name);
@@ -233,6 +240,24 @@ async function refreshProviderSessions(): Promise<void> {
     process.stderr.write(`Session observation failed: ${message}\n`);
   } finally {
     sessionRefreshRunning = false;
+  }
+  // Attention review runs outside the observation guard so a slow model call
+  // never delays the next provider snapshot.
+  void reviewSessionAttention();
+}
+
+async function reviewSessionAttention(): Promise<void> {
+  if (!attentionReviewer || attentionReviewRunning) return;
+  attentionReviewRunning = true;
+  try {
+    for (const review of await attentionReviewer.review(sessionRegistry.list())) {
+      sessionRegistry.setAttention(review, review.decision);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Attention review failed: ${message}\n`);
+  } finally {
+    attentionReviewRunning = false;
   }
 }
 

--- a/apps/desktop/src/openai-attention-evaluator.ts
+++ b/apps/desktop/src/openai-attention-evaluator.ts
@@ -22,7 +22,11 @@ const OPENAI_DEFAULTS = {
   // means fewer decisions are discarded as superseded before they can be used.
   MODEL: "gpt-5.6-luna",
   REQUEST_TIMEOUT_MS: 15_000,
-  MAXIMUM_OUTPUT_TOKENS: 1024,
+  // The decision itself is a few dozen tokens; this cap only bounds a runaway
+  // response. It is set well above that because reasoning tokens are charged
+  // against the same budget, and a model that exhausts it returns `incomplete`
+  // with no output at all — indistinguishable from having nothing to say.
+  MAXIMUM_OUTPUT_TOKENS: 4096,
 } as const;
 
 const OPENAI_RESPONSES_PATH = "/responses";

--- a/apps/desktop/src/openai-attention-evaluator.ts
+++ b/apps/desktop/src/openai-attention-evaluator.ts
@@ -1,0 +1,218 @@
+import {
+  ATTENTION_DECISION_SCHEMA,
+  ATTENTION_DECISION_SCHEMA_NAME,
+  type AttentionDecision,
+  type AttentionEvaluator,
+  type AttentionUpdate,
+  attentionDecisionFromModel,
+  attentionInstructions,
+  attentionUpdateInput,
+} from "@sidecar/core";
+
+const OPENAI_ENVIRONMENT = {
+  API_KEY: "OPENAI_API_KEY",
+  BASE_URL: "OPENAI_BASE_URL",
+  MODEL: "LUKE_ATTENTION_MODEL",
+} as const;
+
+const OPENAI_DEFAULTS = {
+  BASE_URL: "https://api.openai.com/v1",
+  MODEL: "gpt-5.1",
+  REQUEST_TIMEOUT_MS: 15_000,
+  MAXIMUM_OUTPUT_TOKENS: 1024,
+} as const;
+
+const OPENAI_RESPONSES_PATH = "/responses";
+const OPENAI_TEXT_FORMAT_TYPE = "json_schema";
+const OPENAI_OUTPUT_TEXT_TYPE = "output_text";
+
+type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
+
+export interface OpenAiAttentionEvaluatorOptions {
+  apiKey: string;
+  model?: string;
+  baseUrl?: string;
+  fetch?: FetchLike;
+  now?: () => number;
+  requestTimeoutMs?: number;
+  maximumOutputTokens?: number;
+}
+
+export type OpenAiAttentionEnvironmentOptions = Omit<OpenAiAttentionEvaluatorOptions, "apiKey">;
+
+function positiveInteger(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) return fallback;
+  return Math.floor(value);
+}
+
+function trimmedText(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized || undefined;
+}
+
+function withoutTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function outputTextFromContent(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((entry) =>
+      isRecord(entry) && entry.type === OPENAI_OUTPUT_TEXT_TYPE && typeof entry.text === "string"
+        ? entry.text
+        : "",
+    )
+    .join("");
+}
+
+/**
+ * Reads the structured decision out of a Responses payload without depending on
+ * where a given API version places it.
+ */
+function outputText(payload: unknown): string | undefined {
+  if (!isRecord(payload)) return undefined;
+  if (typeof payload.output_text === "string") return trimmedText(payload.output_text);
+  if (!Array.isArray(payload.output)) return undefined;
+  const text = payload.output
+    .map((item) => (isRecord(item) ? outputTextFromContent(item.content) : ""))
+    .join("");
+  return trimmedText(text);
+}
+
+function parsedJson(text: string): unknown {
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Evaluates bounded session updates with the OpenAI Responses API using the
+ * shared decision contract as a strict structured-output schema. It sends only
+ * the redacted update, never asks the API to retain the request, and answers
+ * with nothing when the API is unavailable or replies outside the contract.
+ */
+export class OpenAiAttentionEvaluator implements AttentionEvaluator {
+  readonly #apiKey: string;
+  readonly #model: string;
+  readonly #baseUrl: string;
+  readonly #fetch: FetchLike;
+  readonly #now: () => number;
+  readonly #requestTimeoutMs: number;
+  readonly #maximumOutputTokens: number;
+
+  constructor(options: OpenAiAttentionEvaluatorOptions) {
+    const apiKey = trimmedText(options.apiKey);
+    if (!apiKey) throw new Error("OpenAI API key must not be empty");
+    this.#apiKey = apiKey;
+    this.#model = trimmedText(options.model) ?? OPENAI_DEFAULTS.MODEL;
+    this.#baseUrl = withoutTrailingSlash(trimmedText(options.baseUrl) ?? OPENAI_DEFAULTS.BASE_URL);
+    this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
+    this.#now = options.now ?? Date.now;
+    this.#requestTimeoutMs = positiveInteger(
+      options.requestTimeoutMs,
+      OPENAI_DEFAULTS.REQUEST_TIMEOUT_MS,
+    );
+    this.#maximumOutputTokens = positiveInteger(
+      options.maximumOutputTokens,
+      OPENAI_DEFAULTS.MAXIMUM_OUTPUT_TOKENS,
+    );
+  }
+
+  get model(): string {
+    return this.#model;
+  }
+
+  async evaluate(update: AttentionUpdate): Promise<AttentionDecision | undefined> {
+    const response = await this.#request(update);
+    if (!response) return undefined;
+
+    if (!response.ok) {
+      // Status alone is enough to diagnose credentials or rate limits without
+      // writing the request, the key, or any session material to the log.
+      this.#report(`OpenAI attention request failed with status ${response.status}`);
+      return undefined;
+    }
+
+    const text = outputText(await this.#payload(response));
+    if (!text) return undefined;
+
+    const decision = attentionDecisionFromModel(parsedJson(text), this.#now());
+    if (!decision) this.#report("OpenAI attention response did not satisfy the decision contract");
+    return decision;
+  }
+
+  async #request(update: AttentionUpdate): Promise<Response | undefined> {
+    try {
+      return await this.#fetch(`${this.#baseUrl}${OPENAI_RESPONSES_PATH}`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${this.#apiKey}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model: this.#model,
+          instructions: attentionInstructions(),
+          input: attentionUpdateInput(update),
+          max_output_tokens: this.#maximumOutputTokens,
+          store: false,
+          text: {
+            format: {
+              type: OPENAI_TEXT_FORMAT_TYPE,
+              name: ATTENTION_DECISION_SCHEMA_NAME,
+              schema: ATTENTION_DECISION_SCHEMA,
+              strict: true,
+            },
+          },
+        }),
+        signal: AbortSignal.timeout(this.#requestTimeoutMs),
+      });
+    } catch (error) {
+      this.#report(
+        `OpenAI attention request did not complete: ${error instanceof Error ? error.name : "unknown error"}`,
+      );
+      return undefined;
+    }
+  }
+
+  async #payload(response: Response): Promise<unknown> {
+    try {
+      return await response.json();
+    } catch {
+      this.#report("OpenAI attention response was not JSON");
+      return undefined;
+    }
+  }
+
+  #report(message: string): void {
+    process.stderr.write(`${message}\n`);
+  }
+}
+
+/**
+ * Builds an evaluator only when an API key is configured. Luke observes
+ * sessions and stays silent without one, so no part of the app requires
+ * credentials.
+ */
+export function openAiAttentionEvaluatorFromEnvironment(
+  options: OpenAiAttentionEnvironmentOptions = {},
+): OpenAiAttentionEvaluator | undefined {
+  const apiKey = trimmedText(process.env[OPENAI_ENVIRONMENT.API_KEY]);
+  if (!apiKey) return undefined;
+
+  const model = trimmedText(options.model) ?? trimmedText(process.env[OPENAI_ENVIRONMENT.MODEL]);
+  const baseUrl =
+    trimmedText(options.baseUrl) ?? trimmedText(process.env[OPENAI_ENVIRONMENT.BASE_URL]);
+
+  return new OpenAiAttentionEvaluator({
+    ...options,
+    apiKey,
+    ...(model ? { model } : {}),
+    ...(baseUrl ? { baseUrl } : {}),
+  });
+}

--- a/apps/desktop/src/openai-attention-evaluator.ts
+++ b/apps/desktop/src/openai-attention-evaluator.ts
@@ -17,7 +17,10 @@ const OPENAI_ENVIRONMENT = {
 
 const OPENAI_DEFAULTS = {
   BASE_URL: "https://api.openai.com/v1",
-  MODEL: "gpt-5.1",
+  // A three-way classification with a fixed prompt, run in the background on a
+  // developer's own key. The cost-optimized tier fits it, and its lower latency
+  // means fewer decisions are discarded as superseded before they can be used.
+  MODEL: "gpt-5.6-luna",
   REQUEST_TIMEOUT_MS: 15_000,
   MAXIMUM_OUTPUT_TOKENS: 1024,
 } as const;
@@ -83,6 +86,21 @@ function outputText(payload: unknown): string | undefined {
   return trimmedText(text);
 }
 
+/**
+ * Describes why a payload carried no decision. A model that spends its output
+ * budget on reasoning returns `incomplete` with empty output, which would
+ * otherwise look identical to a healthy silent pass.
+ */
+function missingDecisionReason(payload: unknown): string {
+  if (!isRecord(payload)) return "";
+  const status = typeof payload.status === "string" ? payload.status : undefined;
+  const details = isRecord(payload.incomplete_details) ? payload.incomplete_details : undefined;
+  const reason = typeof details?.reason === "string" ? details.reason : undefined;
+  if (status && reason) return ` (${status}: ${reason})`;
+  if (status) return ` (${status})`;
+  return "";
+}
+
 function parsedJson(text: string): unknown {
   try {
     return JSON.parse(text) as unknown;
@@ -139,8 +157,16 @@ export class OpenAiAttentionEvaluator implements AttentionEvaluator {
       return undefined;
     }
 
-    const text = outputText(await this.#payload(response));
-    if (!text) return undefined;
+    const payload = await this.#payload(response);
+    if (payload === undefined) return undefined;
+
+    const text = outputText(payload);
+    if (!text) {
+      this.#report(
+        `OpenAI attention response carried no decision${missingDecisionReason(payload)}`,
+      );
+      return undefined;
+    }
 
     const decision = attentionDecisionFromModel(parsedJson(text), this.#now());
     if (!decision) this.#report("OpenAI attention response did not satisfy the decision contract");

--- a/apps/desktop/tests/openai-attention-evaluator.test.ts
+++ b/apps/desktop/tests/openai-attention-evaluator.test.ts
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import test, { type TestContext } from "node:test";
+import {
+  ATTENTION_DISPOSITION,
+  ATTENTION_TRIGGER,
+  type AttentionUpdate,
+  SESSION_STATUS,
+} from "@sidecar/core";
+import {
+  OpenAiAttentionEvaluator,
+  openAiAttentionEvaluatorFromEnvironment,
+} from "../src/openai-attention-evaluator";
+
+const DECIDED_AT = 1_800_000_000_000;
+const API_KEY = "test-openai-key";
+const SPOKEN_SUMMARY = "Claude Code is waiting on you in checkout-service.";
+const TRANSCRIPT_SECRET = "SECRET_TRANSCRIPT_TEXT";
+
+interface RecordedRequest {
+  url: string;
+  init: RequestInit;
+}
+
+function update(overrides: Partial<AttentionUpdate> = {}): AttentionUpdate {
+  return {
+    providerId: "claude-code",
+    providerSessionId: "review",
+    trigger: ATTENTION_TRIGGER.STATUS_CHANGED,
+    providerName: "Claude Code",
+    title: "Claude Code: checkout-service",
+    status: SESSION_STATUS.WAITING,
+    previousStatus: SESSION_STATUS.WORKING,
+    summary: "Claude Code waiting; transcript content is not retained.",
+    observedAt: DECIDED_AT,
+    ...overrides,
+  };
+}
+
+function structuredResponse(decision: Record<string, unknown>): Response {
+  return Response.json({
+    output: [
+      {
+        type: "message",
+        content: [{ type: "output_text", text: JSON.stringify(decision) }],
+      },
+    ],
+  });
+}
+
+function evaluatorWith(respond: (request: RecordedRequest) => Promise<Response> | Response): {
+  evaluator: OpenAiAttentionEvaluator;
+  requests: RecordedRequest[];
+} {
+  const requests: RecordedRequest[] = [];
+  const evaluator = new OpenAiAttentionEvaluator({
+    apiKey: API_KEY,
+    now: () => DECIDED_AT,
+    fetch: async (url, init) => {
+      const request = { url, init };
+      requests.push(request);
+      return respond(request);
+    },
+  });
+  return { evaluator, requests };
+}
+
+function requestBody(request: RecordedRequest): Record<string, unknown> {
+  assert.equal(typeof request.init.body, "string");
+  return JSON.parse(String(request.init.body)) as Record<string, unknown>;
+}
+
+function silenceStderr(t: TestContext): void {
+  t.mock.method(process.stderr, "write", () => true);
+}
+
+test("requests a strict structured decision and never asks the API to retain it", async (t) => {
+  silenceStderr(t);
+  const { evaluator, requests } = evaluatorWith(() =>
+    structuredResponse({
+      disposition: ATTENTION_DISPOSITION.SPEAK_DURING_TURN,
+      summary: SPOKEN_SUMMARY,
+    }),
+  );
+
+  const decision = await evaluator.evaluate(update());
+
+  assert.deepEqual(decision, {
+    disposition: ATTENTION_DISPOSITION.SPEAK_DURING_TURN,
+    decidedAt: DECIDED_AT,
+    summary: SPOKEN_SUMMARY,
+  });
+
+  const [request] = requests;
+  assert.ok(request);
+  assert.equal(request.url, "https://api.openai.com/v1/responses");
+  assert.equal(request.init.method, "POST");
+  assert.deepEqual(request.init.headers, {
+    authorization: `Bearer ${API_KEY}`,
+    "content-type": "application/json",
+  });
+
+  const body = requestBody(request);
+  assert.equal(body.store, false);
+  assert.equal(body.model, evaluator.model);
+  assert.deepEqual(Object.keys(body).sort(), [
+    "input",
+    "instructions",
+    "max_output_tokens",
+    "model",
+    "store",
+    "text",
+  ]);
+  const format = (body.text as { format: Record<string, unknown> }).format;
+  assert.equal(format.type, "json_schema");
+  assert.equal(format.strict, true);
+  assert.equal(format.name, "attention_decision");
+  assert.deepEqual((format.schema as { required: string[] }).required, ["disposition", "summary"]);
+});
+
+test("sends only the bounded update and no provider transcript", async (t) => {
+  silenceStderr(t);
+  const { evaluator, requests } = evaluatorWith(() =>
+    structuredResponse({ disposition: ATTENTION_DISPOSITION.SILENT, summary: null }),
+  );
+
+  await evaluator.evaluate(update());
+
+  const [request] = requests;
+  assert.ok(request);
+  const serialized = String(request.init.body);
+  assert.ok(!serialized.includes(TRANSCRIPT_SECRET));
+  assert.ok(!serialized.includes("providerSessionId"));
+  assert.ok(!serialized.includes("review"));
+  assert.ok(String(requestBody(request).input).includes("Provider: Claude Code"));
+});
+
+test("stays silent when the API is unavailable or answers outside the contract", async (t) => {
+  silenceStderr(t);
+  const failures: Array<() => Response | Promise<Response>> = [
+    () => new Response("rate limited", { status: 429 }),
+    () => new Response("not json", { status: 200 }),
+    () => structuredResponse({ disposition: "shout", summary: SPOKEN_SUMMARY }),
+    () => structuredResponse({ disposition: ATTENTION_DISPOSITION.SPEAK_AT_TURN_END }),
+    () => Response.json({ output: [] }),
+    () => {
+      throw new Error("network unreachable");
+    },
+  ];
+
+  for (const failure of failures) {
+    const { evaluator } = evaluatorWith(failure);
+    assert.equal(await evaluator.evaluate(update()), undefined);
+  }
+});
+
+test("reads a decision from a payload that carries aggregated output text", async (t) => {
+  silenceStderr(t);
+  const { evaluator } = evaluatorWith(() =>
+    Response.json({
+      output_text: JSON.stringify({
+        disposition: ATTENTION_DISPOSITION.SPEAK_AT_TURN_END,
+        summary: "Codex finished its turn in billing-api.",
+      }),
+    }),
+  );
+
+  assert.deepEqual(await evaluator.evaluate(update()), {
+    disposition: ATTENTION_DISPOSITION.SPEAK_AT_TURN_END,
+    decidedAt: DECIDED_AT,
+    summary: "Codex finished its turn in billing-api.",
+  });
+});
+
+test("builds an evaluator only when the environment supplies a key", (t) => {
+  const environment = { ...process.env };
+  t.after(() => {
+    process.env = environment;
+  });
+
+  process.env.OPENAI_API_KEY = "";
+  assert.equal(openAiAttentionEvaluatorFromEnvironment(), undefined);
+
+  process.env.OPENAI_API_KEY = `  ${API_KEY}  `;
+  process.env.LUKE_ATTENTION_MODEL = "  gpt-test  ";
+  process.env.OPENAI_BASE_URL = "https://gateway.test/v1/";
+  const configured = openAiAttentionEvaluatorFromEnvironment();
+  assert.ok(configured);
+  assert.equal(configured.model, "gpt-test");
+
+  delete process.env.LUKE_ATTENTION_MODEL;
+  const defaulted = openAiAttentionEvaluatorFromEnvironment();
+  assert.ok(defaulted);
+  assert.equal(defaulted.model, "gpt-5.1");
+
+  assert.throws(() => new OpenAiAttentionEvaluator({ apiKey: "   " }));
+});
+
+test("honors a configured base URL without doubling its separator", async (t) => {
+  silenceStderr(t);
+  const requests: RecordedRequest[] = [];
+  const evaluator = new OpenAiAttentionEvaluator({
+    apiKey: API_KEY,
+    baseUrl: "https://gateway.test/v1/",
+    now: () => DECIDED_AT,
+    fetch: async (url, init) => {
+      requests.push({ url, init });
+      return structuredResponse({ disposition: ATTENTION_DISPOSITION.SILENT, summary: null });
+    },
+  });
+
+  await evaluator.evaluate(update());
+  assert.equal(requests[0]?.url, "https://gateway.test/v1/responses");
+});

--- a/apps/desktop/tests/openai-attention-evaluator.test.ts
+++ b/apps/desktop/tests/openai-attention-evaluator.test.ts
@@ -73,6 +73,15 @@ function silenceStderr(t: TestContext): void {
   t.mock.method(process.stderr, "write", () => true);
 }
 
+function recordStderr(t: TestContext): string[] {
+  const written: string[] = [];
+  t.mock.method(process.stderr, "write", (chunk: unknown) => {
+    written.push(String(chunk));
+    return true;
+  });
+  return written;
+}
+
 test("requests a strict structured decision and never asks the API to retain it", async (t) => {
   silenceStderr(t);
   const { evaluator, requests } = evaluatorWith(() =>
@@ -153,6 +162,26 @@ test("stays silent when the API is unavailable or answers outside the contract",
   }
 });
 
+test("reports a response that carried no decision instead of failing quietly", async (t) => {
+  const written = recordStderr(t);
+  const { evaluator } = evaluatorWith(() =>
+    Response.json({
+      status: "incomplete",
+      incomplete_details: { reason: "max_output_tokens" },
+      output: [],
+    }),
+  );
+
+  assert.equal(await evaluator.evaluate(update()), undefined);
+  const message = written.join("");
+  assert.match(message, /carried no decision/);
+  assert.match(
+    message,
+    /max_output_tokens/,
+    "a model that spends its output budget on reasoning must not look like a healthy silent pass",
+  );
+});
+
 test("reads a decision from a payload that carries aggregated output text", async (t) => {
   silenceStderr(t);
   const { evaluator } = evaluatorWith(() =>
@@ -190,7 +219,7 @@ test("builds an evaluator only when the environment supplies a key", (t) => {
   delete process.env.LUKE_ATTENTION_MODEL;
   const defaulted = openAiAttentionEvaluatorFromEnvironment();
   assert.ok(defaulted);
-  assert.equal(defaulted.model, "gpt-5.1");
+  assert.equal(defaulted.model, "gpt-5.6-luna");
 
   assert.throws(() => new OpenAiAttentionEvaluator({ apiKey: "   " }));
 });

--- a/packages/sidecar-core/src/attention-examples.ts
+++ b/packages/sidecar-core/src/attention-examples.ts
@@ -1,0 +1,118 @@
+import { ATTENTION_TRIGGER, type AttentionUpdate } from "./attention";
+import { ATTENTION_DISPOSITION, type AttentionDisposition, SESSION_STATUS } from "./session";
+
+/**
+ * One redacted update paired with the decision Luke should reach for it. The
+ * examples are synthetic: every workspace name, provider summary, and spoken
+ * sentence here is written for tuning and contains no observed developer data.
+ */
+export interface AttentionTuningExample {
+  name: string;
+  update: AttentionUpdate;
+  expected: {
+    disposition: AttentionDisposition;
+    summary: string | null;
+  };
+  rationale: string;
+}
+
+export const ATTENTION_TUNING_EXAMPLES: readonly AttentionTuningExample[] = [
+  {
+    name: "A session starts being observed",
+    update: {
+      providerId: "claude-code",
+      providerSessionId: "example-observed",
+      trigger: ATTENTION_TRIGGER.OBSERVED,
+      providerName: "Claude Code",
+      title: "Claude Code: checkout-service",
+      status: SESSION_STATUS.WORKING,
+      summary: "Claude Code working; transcript content is not retained.",
+      observedAt: 1_760_000_000_000,
+    },
+    expected: {
+      disposition: ATTENTION_DISPOSITION.SILENT,
+      summary: null,
+    },
+    rationale:
+      "Noticing a session that is already running is not a development the developer asked to hear about.",
+  },
+  {
+    name: "A working session begins waiting on the developer",
+    update: {
+      providerId: "claude-code",
+      providerSessionId: "example-waiting",
+      trigger: ATTENTION_TRIGGER.STATUS_CHANGED,
+      providerName: "Claude Code",
+      title: "Claude Code: checkout-service",
+      status: SESSION_STATUS.WAITING,
+      previousStatus: SESSION_STATUS.WORKING,
+      summary: "Claude Code waiting; transcript content is not retained.",
+      observedAt: 1_760_000_090_000,
+    },
+    expected: {
+      disposition: ATTENTION_DISPOSITION.SPEAK_DURING_TURN,
+      summary: "Claude Code is waiting on you in checkout-service.",
+    },
+    rationale:
+      "The session cannot progress without the developer, so the interruption saves idle time.",
+  },
+  {
+    name: "A working session finishes its turn",
+    update: {
+      providerId: "codex",
+      providerSessionId: "example-complete",
+      trigger: ATTENTION_TRIGGER.STATUS_CHANGED,
+      providerName: "Codex",
+      title: "Codex: billing-api",
+      status: SESSION_STATUS.COMPLETE,
+      previousStatus: SESSION_STATUS.WORKING,
+      summary: "Codex complete; transcript content is not retained.",
+      observedAt: 1_760_000_180_000,
+    },
+    expected: {
+      disposition: ATTENTION_DISPOSITION.SPEAK_AT_TURN_END,
+      summary: "Codex finished its turn in billing-api.",
+    },
+    rationale:
+      "The session reached a resting point, which is worth one short sentence once the current turn ends.",
+  },
+  {
+    name: "A session goes quiet without resolving",
+    update: {
+      providerId: "codex",
+      providerSessionId: "example-unknown",
+      trigger: ATTENTION_TRIGGER.STATUS_CHANGED,
+      providerName: "Codex",
+      title: "Codex: billing-api",
+      status: SESSION_STATUS.UNKNOWN,
+      previousStatus: SESSION_STATUS.WORKING,
+      summary: "Codex unknown; transcript content is not retained.",
+      observedAt: 1_760_000_400_000,
+    },
+    expected: {
+      disposition: ATTENTION_DISPOSITION.SILENT,
+      summary: null,
+    },
+    rationale:
+      "An observation Luke cannot explain is not a development; announcing it would invent certainty Luke does not have.",
+  },
+  {
+    name: "A summary changes while the session keeps working",
+    update: {
+      providerId: "claude-code",
+      providerSessionId: "example-summary",
+      trigger: ATTENTION_TRIGGER.SUMMARY_CHANGED,
+      providerName: "Claude Code",
+      title: "Claude Code: docs-site",
+      status: SESSION_STATUS.WORKING,
+      previousStatus: SESSION_STATUS.WORKING,
+      summary: "Claude Code working; transcript content is not retained.",
+      observedAt: 1_760_000_480_000,
+    },
+    expected: {
+      disposition: ATTENTION_DISPOSITION.SILENT,
+      summary: null,
+    },
+    rationale: "Ongoing work is the normal case, and narrating it would make Luke noise.",
+  },
+];

--- a/packages/sidecar-core/src/attention-prompt.ts
+++ b/packages/sidecar-core/src/attention-prompt.ts
@@ -1,0 +1,57 @@
+import { type AttentionUpdate, maximumAttentionSummaryLength } from "./attention";
+import { ATTENTION_TUNING_EXAMPLES, type AttentionTuningExample } from "./attention-examples";
+import { ATTENTION_DISPOSITION } from "./session";
+
+const NONE_LABEL = "none";
+
+const ATTENTION_INSTRUCTION_LINES: readonly string[] = [
+  "You decide whether a background companion should speak about one coding-agent session update.",
+  "The developer is working, and every sentence you approve interrupts them.",
+  "",
+  "Choose one disposition:",
+  `- ${ATTENTION_DISPOSITION.SILENT}: say nothing. This is the correct answer for most updates.`,
+  `- ${ATTENTION_DISPOSITION.SPEAK_DURING_TURN}: interrupt now, only when the session cannot progress until the developer acts.`,
+  `- ${ATTENTION_DISPOSITION.SPEAK_AT_TURN_END}: wait for a natural pause, then report a session that reached a resting point.`,
+  "",
+  "Rules:",
+  "- Default to silence when the update is routine, ambiguous, or merely continues work already underway.",
+  `- A speaking summary is one short spoken sentence under ${maximumAttentionSummaryLength} characters that names the provider and the workspace.`,
+  "- Use null for the summary whenever the disposition is silent.",
+  "- Use only the fields in the update. You never receive transcripts, file contents, or command output, so never imply you read any.",
+  "- Never guess what the session is doing beyond the status it reports.",
+];
+
+function renderExample(example: AttentionTuningExample): string {
+  return [
+    "",
+    `# ${example.name}`,
+    attentionUpdateInput(example.update),
+    `Decision: ${JSON.stringify(example.expected)}`,
+    `Why: ${example.rationale}`,
+  ].join("\n");
+}
+
+/** Renders one bounded update as the only session material a model receives. */
+export function attentionUpdateInput(update: AttentionUpdate): string {
+  return [
+    `Provider: ${update.providerName}`,
+    `Session: ${update.title}`,
+    `Trigger: ${update.trigger}`,
+    `Previous status: ${update.previousStatus ?? NONE_LABEL}`,
+    `Status: ${update.status}`,
+    `Observed summary: ${update.summary ?? NONE_LABEL}`,
+  ].join("\n");
+}
+
+/**
+ * Builds the standing instructions, including the redacted examples that tune
+ * how conservative Luke is. Pass a different example set to try alternative
+ * tuning without changing the decision contract.
+ */
+export function attentionInstructions(
+  examples: readonly AttentionTuningExample[] = ATTENTION_TUNING_EXAMPLES,
+): string {
+  return [...ATTENTION_INSTRUCTION_LINES, "", "Examples:", ...examples.map(renderExample)].join(
+    "\n",
+  );
+}

--- a/packages/sidecar-core/src/attention.ts
+++ b/packages/sidecar-core/src/attention.ts
@@ -1,0 +1,381 @@
+import {
+  ATTENTION_DISPOSITION,
+  type AttentionDecision,
+  type AttentionDisposition,
+  type NormalizedSession,
+  normalizeAttention,
+  normalizeSessionIdentity,
+  type SessionIdentity,
+  type SessionStatus,
+  silentAttention,
+} from "./session";
+
+export const ATTENTION_TRIGGER = {
+  OBSERVED: "observed",
+  STATUS_CHANGED: "status-changed",
+  SUMMARY_CHANGED: "summary-changed",
+} as const;
+
+export type AttentionTrigger = (typeof ATTENTION_TRIGGER)[keyof typeof ATTENTION_TRIGGER];
+
+/** A spoken sentence stays far shorter than the summary a provider may observe. */
+export const maximumAttentionSummaryLength = 180;
+
+export const ATTENTION_DECISION_SCHEMA_NAME = "attention_decision";
+
+const ATTENTION_DISPOSITIONS: readonly AttentionDisposition[] =
+  Object.values(ATTENTION_DISPOSITION);
+
+const ATTENTION_REVIEW_DEFAULTS = {
+  REPEAT_WINDOW_MS: 10 * 60 * 1000,
+  MAXIMUM_UPDATES_PER_REVIEW: 4,
+} as const;
+
+/**
+ * The decision contract an evaluator must satisfy. It is deliberately small so
+ * a background model returns a disposition and, at most, one spoken sentence.
+ */
+export const ATTENTION_DECISION_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["disposition", "summary"],
+  properties: {
+    disposition: {
+      type: "string",
+      enum: ATTENTION_DISPOSITIONS,
+      description:
+        "silent when the update is not worth saying out loud, speak-during-turn when the developer is blocking the session right now, speak-at-turn-end when the session reached a resting point.",
+    },
+    summary: {
+      type: ["string", "null"],
+      description: `One short spoken sentence under ${maximumAttentionSummaryLength} characters, or null when the disposition is silent.`,
+    },
+  },
+};
+
+/**
+ * A bounded, redacted description of what changed for one session. It is the
+ * only session material an attention evaluator ever receives, and it carries no
+ * provider transcript, file path, or command output.
+ */
+export interface AttentionUpdate extends SessionIdentity {
+  trigger: AttentionTrigger;
+  providerName: string;
+  title: string;
+  status: SessionStatus;
+  previousStatus?: SessionStatus;
+  summary?: string;
+  observedAt: number;
+}
+
+/** Reviews one bounded update and decides whether Luke should speak. */
+export interface AttentionEvaluator {
+  evaluate(update: AttentionUpdate): Promise<AttentionDecision | undefined>;
+}
+
+/** The decision a reviewer reached for one session, after deduplication. */
+export interface AttentionReview extends SessionIdentity {
+  update: AttentionUpdate;
+  decision: AttentionDecision;
+  suppressed: boolean;
+}
+
+export interface AttentionSpeechLedgerOptions {
+  now?: () => number;
+  repeatWindowMs?: number;
+}
+
+export interface SessionAttentionReviewerOptions {
+  evaluator: AttentionEvaluator;
+  now?: () => number;
+  repeatWindowMs?: number;
+  maximumUpdatesPerReview?: number;
+}
+
+interface SpokenRecord {
+  disposition: AttentionDisposition;
+  summary?: string;
+  spokenAt: number;
+}
+
+interface AttentionCandidate {
+  session: NormalizedSession;
+  update: AttentionUpdate;
+}
+
+function positiveInteger(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) return fallback;
+  return Math.floor(value);
+}
+
+function nonNegativeNumber(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value < 0) return fallback;
+  return value;
+}
+
+function isAttentionDisposition(value: unknown): value is AttentionDisposition {
+  return (
+    typeof value === "string" && ATTENTION_DISPOSITIONS.some((disposition) => disposition === value)
+  );
+}
+
+function attentionTrigger(
+  session: NormalizedSession,
+  previous: NormalizedSession | undefined,
+): AttentionTrigger | undefined {
+  if (!previous) return ATTENTION_TRIGGER.OBSERVED;
+  if (previous.status !== session.status) return ATTENTION_TRIGGER.STATUS_CHANGED;
+  if (previous.summary !== session.summary) return ATTENTION_TRIGGER.SUMMARY_CHANGED;
+  return undefined;
+}
+
+/**
+ * Derives the bounded update worth reviewing, or nothing when a newly observed
+ * session says the same thing it said last time. A repeated observation is not
+ * a development, so it never reaches an evaluator.
+ */
+export function attentionUpdate(
+  session: NormalizedSession,
+  previous?: NormalizedSession,
+): AttentionUpdate | undefined {
+  const trigger = attentionTrigger(session, previous);
+  if (!trigger) return undefined;
+
+  return {
+    providerId: session.providerId,
+    providerSessionId: session.providerSessionId,
+    trigger,
+    providerName: session.provider.displayName,
+    title: session.title,
+    status: session.status,
+    ...(previous ? { previousStatus: previous.status } : {}),
+    ...(session.summary ? { summary: session.summary } : {}),
+    observedAt: session.observedAt,
+  };
+}
+
+/**
+ * Validates untrusted model output against the decision contract. Anything that
+ * does not satisfy the contract is discarded rather than repaired, so a
+ * malformed response leaves Luke silent.
+ */
+export function attentionDecisionFromModel(
+  value: unknown,
+  decidedAt: number,
+): AttentionDecision | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+
+  const record = value as Record<string, unknown>;
+  if (!isAttentionDisposition(record.disposition)) return undefined;
+
+  const summary =
+    typeof record.summary === "string"
+      ? record.summary.trim().slice(0, maximumAttentionSummaryLength)
+      : undefined;
+  if (record.disposition !== ATTENTION_DISPOSITION.SILENT && !summary) return undefined;
+
+  return normalizeAttention({
+    disposition: record.disposition,
+    decidedAt,
+    ...(summary ? { summary } : {}),
+  });
+}
+
+/**
+ * Remembers what Luke already said about each session so the same development
+ * is not announced twice. Records are keyed by provider identity rather than by
+ * a composed string, and sessions that disappear are forgotten.
+ */
+export class AttentionSpeechLedger {
+  readonly #now: () => number;
+  readonly #repeatWindowMs: number;
+  #spoken = new Map<string, Map<string, SpokenRecord>>();
+
+  constructor(options: AttentionSpeechLedgerOptions = {}) {
+    this.#now = options.now ?? Date.now;
+    this.#repeatWindowMs = nonNegativeNumber(
+      options.repeatWindowMs,
+      ATTENTION_REVIEW_DEFAULTS.REPEAT_WINDOW_MS,
+    );
+  }
+
+  /** Reports whether a decision says something new enough to be worth speaking. */
+  shouldSpeak(identity: SessionIdentity, decision: AttentionDecision): boolean {
+    if (decision.disposition === ATTENTION_DISPOSITION.SILENT) return false;
+
+    const normalizedIdentity = normalizeSessionIdentity(identity);
+    const record = this.#spoken
+      .get(normalizedIdentity.providerId)
+      ?.get(normalizedIdentity.providerSessionId);
+    if (!record) return true;
+    if (record.disposition !== decision.disposition) return true;
+    if (record.summary !== decision.summary) return true;
+    return this.#now() - record.spokenAt >= this.#repeatWindowMs;
+  }
+
+  remember(identity: SessionIdentity, decision: AttentionDecision): void {
+    const normalizedIdentity = normalizeSessionIdentity(identity);
+    const providerRecords =
+      this.#spoken.get(normalizedIdentity.providerId) ?? new Map<string, SpokenRecord>();
+    providerRecords.set(normalizedIdentity.providerSessionId, {
+      disposition: decision.disposition,
+      ...(decision.summary ? { summary: decision.summary } : {}),
+      spokenAt: this.#now(),
+    });
+    this.#spoken.set(normalizedIdentity.providerId, providerRecords);
+  }
+
+  /** Drops records for sessions a provider no longer reports. */
+  retain(identities: readonly SessionIdentity[]): void {
+    const live = new Map<string, Set<string>>();
+    for (const identity of identities) {
+      const normalizedIdentity = normalizeSessionIdentity(identity);
+      const providerSessionIds = live.get(normalizedIdentity.providerId) ?? new Set<string>();
+      providerSessionIds.add(normalizedIdentity.providerSessionId);
+      live.set(normalizedIdentity.providerId, providerSessionIds);
+    }
+
+    const retained = new Map<string, Map<string, SpokenRecord>>();
+    for (const [providerId, providerRecords] of this.#spoken) {
+      const providerSessionIds = live.get(providerId);
+      if (!providerSessionIds) continue;
+      const kept = new Map(
+        [...providerRecords].filter(([providerSessionId]) =>
+          providerSessionIds.has(providerSessionId),
+        ),
+      );
+      if (kept.size > 0) retained.set(providerId, kept);
+    }
+    this.#spoken = retained;
+  }
+}
+
+/**
+ * Turns registry snapshots into attention decisions. It reviews only sessions
+ * that actually changed, bounds how many updates one pass may evaluate, keeps a
+ * single evaluation in flight per session, and defaults to silence whenever an
+ * evaluator fails or returns something outside the decision contract.
+ */
+export class SessionAttentionReviewer {
+  readonly #evaluator: AttentionEvaluator;
+  readonly #now: () => number;
+  readonly #maximumUpdatesPerReview: number;
+  readonly #ledger: AttentionSpeechLedger;
+  #observed = new Map<string, Map<string, NormalizedSession>>();
+  #pending = new Map<string, Set<string>>();
+
+  constructor(options: SessionAttentionReviewerOptions) {
+    this.#evaluator = options.evaluator;
+    this.#now = options.now ?? Date.now;
+    this.#maximumUpdatesPerReview = positiveInteger(
+      options.maximumUpdatesPerReview,
+      ATTENTION_REVIEW_DEFAULTS.MAXIMUM_UPDATES_PER_REVIEW,
+    );
+    this.#ledger = new AttentionSpeechLedger({
+      ...(options.now ? { now: options.now } : {}),
+      ...(options.repeatWindowMs !== undefined ? { repeatWindowMs: options.repeatWindowMs } : {}),
+    });
+  }
+
+  async review(sessions: readonly NormalizedSession[]): Promise<readonly AttentionReview[]> {
+    this.#ledger.retain(sessions);
+
+    const candidates: AttentionCandidate[] = [];
+    for (const session of sessions) {
+      if (this.#isPending(session)) continue;
+      const update = attentionUpdate(session, this.#observedSession(session));
+      if (update) candidates.push({ session, update });
+    }
+
+    const selected = candidates
+      .sort((first, second) => second.session.observedAt - first.session.observedAt)
+      .slice(0, this.#maximumUpdatesPerReview);
+
+    // Sessions left out of this pass keep their previous baseline so the same
+    // development is derived again once a slot frees up.
+    this.#observed = this.#nextObserved(sessions, selected);
+    for (const candidate of selected) this.#markPending(candidate.session);
+
+    try {
+      return await Promise.all(selected.map((candidate) => this.#reviewUpdate(candidate.update)));
+    } finally {
+      for (const candidate of selected) this.#clearPending(candidate.session);
+    }
+  }
+
+  async #reviewUpdate(update: AttentionUpdate): Promise<AttentionReview> {
+    const decision = await this.#evaluate(update);
+    const identity: SessionIdentity = {
+      providerId: update.providerId,
+      providerSessionId: update.providerSessionId,
+    };
+
+    if (!decision) {
+      return { ...identity, update, decision: silentAttention(this.#now()), suppressed: false };
+    }
+    if (decision.disposition === ATTENTION_DISPOSITION.SILENT) {
+      return { ...identity, update, decision, suppressed: false };
+    }
+    if (!this.#ledger.shouldSpeak(identity, decision)) {
+      return { ...identity, update, decision: silentAttention(this.#now()), suppressed: true };
+    }
+
+    this.#ledger.remember(identity, decision);
+    return { ...identity, update, decision, suppressed: false };
+  }
+
+  async #evaluate(update: AttentionUpdate): Promise<AttentionDecision | undefined> {
+    try {
+      return await this.#evaluator.evaluate(update);
+    } catch {
+      // A background evaluator must never break session observation; a failed
+      // review simply leaves Luke silent about that update.
+      return undefined;
+    }
+  }
+
+  #observedSession(session: NormalizedSession): NormalizedSession | undefined {
+    return this.#observed.get(session.providerId)?.get(session.providerSessionId);
+  }
+
+  #nextObserved(
+    sessions: readonly NormalizedSession[],
+    selected: readonly AttentionCandidate[],
+  ): Map<string, Map<string, NormalizedSession>> {
+    const reviewed = new Map<string, Set<string>>();
+    for (const candidate of selected) {
+      const providerSessionIds = reviewed.get(candidate.session.providerId) ?? new Set<string>([]);
+      providerSessionIds.add(candidate.session.providerSessionId);
+      reviewed.set(candidate.session.providerId, providerSessionIds);
+    }
+
+    const next = new Map<string, Map<string, NormalizedSession>>();
+    for (const session of sessions) {
+      const baseline = reviewed.get(session.providerId)?.has(session.providerSessionId)
+        ? session
+        : this.#observedSession(session);
+      if (!baseline) continue;
+      const providerSessions = next.get(session.providerId) ?? new Map<string, NormalizedSession>();
+      providerSessions.set(session.providerSessionId, baseline);
+      next.set(session.providerId, providerSessions);
+    }
+    return next;
+  }
+
+  #isPending(session: NormalizedSession): boolean {
+    return this.#pending.get(session.providerId)?.has(session.providerSessionId) === true;
+  }
+
+  #markPending(session: NormalizedSession): void {
+    const providerSessionIds = this.#pending.get(session.providerId) ?? new Set<string>();
+    providerSessionIds.add(session.providerSessionId);
+    this.#pending.set(session.providerId, providerSessionIds);
+  }
+
+  #clearPending(session: NormalizedSession): void {
+    const providerSessionIds = this.#pending.get(session.providerId);
+    if (!providerSessionIds) return;
+    providerSessionIds.delete(session.providerSessionId);
+    if (providerSessionIds.size === 0) this.#pending.delete(session.providerId);
+  }
+}

--- a/packages/sidecar-core/src/attention.ts
+++ b/packages/sidecar-core/src/attention.ts
@@ -271,8 +271,9 @@ export class AttentionSpeechLedger {
  * Turns registry snapshots into attention decisions. It reviews only sessions
  * that actually changed, bounds how many updates one pass may evaluate, keeps a
  * single evaluation in flight per session, discards a decision the session has
- * already moved past, and defaults to silence whenever an evaluator fails or
- * returns something outside the decision contract.
+ * already moved past without consuming that development, and defaults to
+ * silence whenever an evaluator fails or returns something outside the decision
+ * contract.
  */
 export class SessionAttentionReviewer {
   readonly #evaluator: AttentionEvaluator;
@@ -313,6 +314,7 @@ export class SessionAttentionReviewer {
       .sort((first, second) => second.session.observedAt - first.session.observedAt)
       .slice(0, this.#maximumUpdatesPerReview);
 
+    const baselines = selected.map((candidate) => this.#observedSession(candidate.session));
     // Sessions left out of this pass keep their previous baseline so the same
     // development is derived again once a slot frees up.
     this.#observed = this.#nextObserved(sessions, selected);
@@ -327,10 +329,31 @@ export class SessionAttentionReviewer {
       // itself long enough for a provider to move a session on. Callers apply
       // the returned decisions without awaiting in between, so nothing can
       // change the session between this check and the write.
-      return evaluated.map((review) => this.#settle(review));
+      return evaluated.map((review, index) => {
+        const settled = this.#settle(review);
+        if (settled.outcome === ATTENTION_REVIEW_OUTCOME.SUPERSEDED) {
+          // Nothing was said about this state, so it must not stay consumed. A
+          // session that leaves and re-enters it before any pass observes the
+          // step in between would otherwise never be reviewed again.
+          const candidate = selected[index];
+          if (candidate) this.#rewind(candidate.session, baselines[index]);
+        }
+        return settled;
+      });
     } finally {
       for (const candidate of selected) this.#clearPending(candidate.session);
     }
+  }
+
+  #rewind(session: NormalizedSession, baseline: NormalizedSession | undefined): void {
+    const providerSessions = this.#observed.get(session.providerId);
+    if (!providerSessions) return;
+    if (baseline) {
+      providerSessions.set(session.providerSessionId, baseline);
+      return;
+    }
+    providerSessions.delete(session.providerSessionId);
+    if (providerSessions.size === 0) this.#observed.delete(session.providerId);
   }
 
   async #reviewUpdate(update: AttentionUpdate): Promise<AttentionReview> {

--- a/packages/sidecar-core/src/attention.ts
+++ b/packages/sidecar-core/src/attention.ts
@@ -84,7 +84,14 @@ export const ATTENTION_REVIEW_OUTCOME = {
 export type AttentionReviewOutcome =
   (typeof ATTENTION_REVIEW_OUTCOME)[keyof typeof ATTENTION_REVIEW_OUTCOME];
 
-/** The decision a reviewer reached for one session, after deduplication. */
+/**
+ * The decision a reviewer reached for one session. The two fields answer
+ * different questions and must not be conflated: `decision` says whether the
+ * session warrants attention and how urgently, and is what callers store, while
+ * `outcome` says whether Luke should voice it now. A repeated development
+ * carries a speaking `decision` with a `deduplicated` outcome — the session
+ * still needs attention, but saying the same sentence again would be noise.
+ */
 export interface AttentionReview extends SessionIdentity {
   update: AttentionUpdate;
   decision: AttentionDecision;
@@ -374,6 +381,11 @@ export class SessionAttentionReviewer {
    * decision the session has moved past would interrupt with news that is
    * already wrong, and it is deliberately not remembered, so the same sentence
    * stays available once the session genuinely needs it.
+   *
+   * A repeat keeps its disposition. Deduplication decides whether Luke says
+   * something again, not whether the session still warrants attention: a second
+   * turn really did finish, and silencing the decision because the sentence
+   * matches a recent one would hide that development entirely.
    */
   #settle(review: AttentionReview): AttentionReview {
     if (review.decision.disposition === ATTENTION_DISPOSITION.SILENT) return review;
@@ -381,7 +393,7 @@ export class SessionAttentionReviewer {
       return this.#silentReview(review, review.update, ATTENTION_REVIEW_OUTCOME.SUPERSEDED);
     }
     if (!this.#ledger.shouldSpeak(review, review.decision)) {
-      return this.#silentReview(review, review.update, ATTENTION_REVIEW_OUTCOME.DEDUPLICATED);
+      return { ...review, outcome: ATTENTION_REVIEW_OUTCOME.DEDUPLICATED };
     }
 
     this.#ledger.remember(review, review.decision);

--- a/packages/sidecar-core/src/attention.ts
+++ b/packages/sidecar-core/src/attention.ts
@@ -29,6 +29,7 @@ const ATTENTION_DISPOSITIONS: readonly AttentionDisposition[] =
 const ATTENTION_REVIEW_DEFAULTS = {
   REPEAT_WINDOW_MS: 10 * 60 * 1000,
   MAXIMUM_UPDATES_PER_REVIEW: 4,
+  MAXIMUM_UNAVAILABLE_RETRIES: 2,
 } as const;
 
 /**
@@ -114,6 +115,8 @@ export interface SessionAttentionReviewerOptions {
   now?: () => number;
   repeatWindowMs?: number;
   maximumUpdatesPerReview?: number;
+  /** How many extra passes may retry one update after an evaluator failure. */
+  maximumUnavailableRetries?: number;
 }
 
 interface SpokenRecord {
@@ -290,8 +293,10 @@ export class SessionAttentionReviewer {
   readonly #now: () => number;
   readonly #maximumUpdatesPerReview: number;
   readonly #ledger: AttentionSpeechLedger;
+  readonly #maximumUnavailableRetries: number;
   #observed = new Map<string, Map<string, NormalizedSession>>();
   readonly #pending = new Map<string, Set<string>>();
+  readonly #unavailableRetries = new Map<string, Map<string, number>>();
 
   constructor(options: SessionAttentionReviewerOptions) {
     this.#evaluator = options.evaluator;
@@ -300,6 +305,10 @@ export class SessionAttentionReviewer {
     this.#maximumUpdatesPerReview = positiveInteger(
       options.maximumUpdatesPerReview,
       ATTENTION_REVIEW_DEFAULTS.MAXIMUM_UPDATES_PER_REVIEW,
+    );
+    this.#maximumUnavailableRetries = nonNegativeNumber(
+      options.maximumUnavailableRetries,
+      ATTENTION_REVIEW_DEFAULTS.MAXIMUM_UNAVAILABLE_RETRIES,
     );
     this.#ledger = new AttentionSpeechLedger({
       ...(options.now ? { now: options.now } : {}),
@@ -338,18 +347,56 @@ export class SessionAttentionReviewer {
       // change the session between this check and the write.
       return evaluated.map((review, index) => {
         const settled = this.#settle(review);
-        if (settled.outcome === ATTENTION_REVIEW_OUTCOME.SUPERSEDED) {
-          // Nothing was said about this state, so it must not stay consumed. A
-          // session that leaves and re-enters it before any pass observes the
-          // step in between would otherwise never be reviewed again.
-          const candidate = selected[index];
-          if (candidate) this.#rewind(candidate.session, baselines[index]);
+        const candidate = selected[index];
+        // A development is only consumed once a decision was actually reached
+        // about it. Anything else must stay derivable, or the update is lost.
+        if (candidate && this.#keepsDevelopmentPending(settled, candidate.session)) {
+          this.#rewind(candidate.session, baselines[index]);
         }
         return settled;
       });
     } finally {
       for (const candidate of selected) this.#clearPending(candidate.session);
     }
+  }
+
+  /**
+   * Decides whether an update stays derivable for a later pass.
+   *
+   * A superseded decision always does: the state changed, so the update cannot
+   * recur on its own. An unavailable evaluator is retried a bounded number of
+   * times instead, because the failure can be either a passing network blip —
+   * where dropping "your session is waiting" would be a real miss — or a
+   * standing misconfiguration, where retrying forever would hammer a paid API
+   * every poll. Retries are per session and reset as soon as one succeeds.
+   */
+  #keepsDevelopmentPending(review: AttentionReview, session: NormalizedSession): boolean {
+    if (review.outcome === ATTENTION_REVIEW_OUTCOME.SUPERSEDED) return true;
+    if (review.outcome !== ATTENTION_REVIEW_OUTCOME.UNAVAILABLE) {
+      this.#clearUnavailableRetries(session);
+      return false;
+    }
+
+    const previous =
+      this.#unavailableRetries.get(session.providerId)?.get(session.providerSessionId) ?? 0;
+    const attempts = previous + 1;
+    if (attempts > this.#maximumUnavailableRetries) {
+      this.#clearUnavailableRetries(session);
+      return false;
+    }
+
+    const providerAttempts =
+      this.#unavailableRetries.get(session.providerId) ?? new Map<string, number>();
+    providerAttempts.set(session.providerSessionId, attempts);
+    this.#unavailableRetries.set(session.providerId, providerAttempts);
+    return true;
+  }
+
+  #clearUnavailableRetries(session: NormalizedSession): void {
+    const providerAttempts = this.#unavailableRetries.get(session.providerId);
+    if (!providerAttempts) return;
+    providerAttempts.delete(session.providerSessionId);
+    if (providerAttempts.size === 0) this.#unavailableRetries.delete(session.providerId);
   }
 
   #rewind(session: NormalizedSession, baseline: NormalizedSession | undefined): void {

--- a/packages/sidecar-core/src/attention.ts
+++ b/packages/sidecar-core/src/attention.ts
@@ -330,7 +330,6 @@ export class SessionAttentionReviewer {
       .sort((first, second) => second.session.observedAt - first.session.observedAt)
       .slice(0, this.#maximumUpdatesPerReview);
 
-    const baselines = selected.map((candidate) => this.#observedSession(candidate.session));
     // Sessions left out of this pass keep their previous baseline so the same
     // development is derived again once a slot frees up.
     this.#observed = this.#nextObserved(sessions, selected);
@@ -351,7 +350,7 @@ export class SessionAttentionReviewer {
         // A development is only consumed once a decision was actually reached
         // about it. Anything else must stay derivable, or the update is lost.
         if (candidate && this.#keepsDevelopmentPending(settled, candidate.session)) {
-          this.#rewind(candidate.session, baselines[index]);
+          this.#reopen(candidate.session);
         }
         return settled;
       });
@@ -402,13 +401,20 @@ export class SessionAttentionReviewer {
     if (providerAttempts.size === 0) this.#unavailableRetries.delete(session.providerId);
   }
 
-  #rewind(session: NormalizedSession, baseline: NormalizedSession | undefined): void {
+  /**
+   * Forgets what this session was last seen doing, so the next pass derives an
+   * update for whatever it is doing then.
+   *
+   * Restoring the state from before the update would be more informative, but
+   * it is not reliable: a session that round-trips back to that state during
+   * the evaluation — complete, working, complete again — would compare equal to
+   * the restored baseline and never be reviewed again. Forgetting guarantees a
+   * fresh review at the cost of a `previousStatus` the reviewer can no longer
+   * honestly report.
+   */
+  #reopen(session: NormalizedSession): void {
     const providerSessions = this.#observed.get(session.providerId);
     if (!providerSessions) return;
-    if (baseline) {
-      providerSessions.set(session.providerSessionId, baseline);
-      return;
-    }
     providerSessions.delete(session.providerSessionId);
     if (providerSessions.size === 0) this.#observed.delete(session.providerId);
   }

--- a/packages/sidecar-core/src/attention.ts
+++ b/packages/sidecar-core/src/attention.ts
@@ -319,7 +319,15 @@ export class SessionAttentionReviewer {
     for (const candidate of selected) this.#markPending(candidate.session);
 
     try {
-      return await Promise.all(selected.map((candidate) => this.#reviewUpdate(candidate.update)));
+      const evaluated = await Promise.all(
+        selected.map((candidate) => this.#reviewUpdate(candidate.update)),
+      );
+      // Every speaking decision is settled here, in one uninterrupted step,
+      // rather than as each evaluation lands: waiting on a slower sibling is
+      // itself long enough for a provider to move a session on. Callers apply
+      // the returned decisions without awaiting in between, so nothing can
+      // change the session between this check and the write.
+      return evaluated.map((review) => this.#settle(review));
     } finally {
       for (const candidate of selected) this.#clearPending(candidate.session);
     }
@@ -332,27 +340,32 @@ export class SessionAttentionReviewer {
       providerSessionId: update.providerSessionId,
     };
 
-    if (!decision)
+    if (!decision) {
       return this.#silentReview(identity, update, ATTENTION_REVIEW_OUTCOME.UNAVAILABLE);
-    if (decision.disposition === ATTENTION_DISPOSITION.SILENT) {
-      return { ...identity, update, decision, outcome: ATTENTION_REVIEW_OUTCOME.DECIDED };
     }
-    if (this.#isSuperseded(identity, update)) {
-      return this.#silentReview(identity, update, ATTENTION_REVIEW_OUTCOME.SUPERSEDED);
-    }
-    if (!this.#ledger.shouldSpeak(identity, decision)) {
-      return this.#silentReview(identity, update, ATTENTION_REVIEW_OUTCOME.DEDUPLICATED);
-    }
-
-    this.#ledger.remember(identity, decision);
     return { ...identity, update, decision, outcome: ATTENTION_REVIEW_OUTCOME.DECIDED };
   }
 
   /**
-   * Reports whether the session moved past the state the evaluator reasoned
-   * about. Speaking then would interrupt with news that is already wrong, so the
-   * decision is dropped and the newer state earns its own review.
+   * Admits a speaking decision only if it is still true and still new. A
+   * decision the session has moved past would interrupt with news that is
+   * already wrong, and it is deliberately not remembered, so the same sentence
+   * stays available once the session genuinely needs it.
    */
+  #settle(review: AttentionReview): AttentionReview {
+    if (review.decision.disposition === ATTENTION_DISPOSITION.SILENT) return review;
+    if (this.#isSuperseded(review, review.update)) {
+      return this.#silentReview(review, review.update, ATTENTION_REVIEW_OUTCOME.SUPERSEDED);
+    }
+    if (!this.#ledger.shouldSpeak(review, review.decision)) {
+      return this.#silentReview(review, review.update, ATTENTION_REVIEW_OUTCOME.DEDUPLICATED);
+    }
+
+    this.#ledger.remember(review, review.decision);
+    return review;
+  }
+
+  /** Reports whether the session moved past the state the evaluator reasoned about. */
   #isSuperseded(identity: SessionIdentity, update: AttentionUpdate): boolean {
     if (!this.#currentSession) return false;
     const current = this.#currentSession(identity);

--- a/packages/sidecar-core/src/attention.ts
+++ b/packages/sidecar-core/src/attention.ts
@@ -73,11 +73,22 @@ export interface AttentionEvaluator {
   evaluate(update: AttentionUpdate): Promise<AttentionDecision | undefined>;
 }
 
+/** Why a reviewed update ended up with the decision it carries. */
+export const ATTENTION_REVIEW_OUTCOME = {
+  DECIDED: "decided",
+  DEDUPLICATED: "deduplicated",
+  SUPERSEDED: "superseded",
+  UNAVAILABLE: "unavailable",
+} as const;
+
+export type AttentionReviewOutcome =
+  (typeof ATTENTION_REVIEW_OUTCOME)[keyof typeof ATTENTION_REVIEW_OUTCOME];
+
 /** The decision a reviewer reached for one session, after deduplication. */
 export interface AttentionReview extends SessionIdentity {
   update: AttentionUpdate;
   decision: AttentionDecision;
-  suppressed: boolean;
+  outcome: AttentionReviewOutcome;
 }
 
 export interface AttentionSpeechLedgerOptions {
@@ -87,6 +98,12 @@ export interface AttentionSpeechLedgerOptions {
 
 export interface SessionAttentionReviewerOptions {
   evaluator: AttentionEvaluator;
+  /**
+   * Reads a session as it stands right now. A model call takes long enough for
+   * a provider to move a session on, so without this the reviewer cannot tell
+   * that the state it reasoned about is gone.
+   */
+  currentSession?: (identity: SessionIdentity) => NormalizedSession | undefined;
   now?: () => number;
   repeatWindowMs?: number;
   maximumUpdatesPerReview?: number;
@@ -253,11 +270,15 @@ export class AttentionSpeechLedger {
 /**
  * Turns registry snapshots into attention decisions. It reviews only sessions
  * that actually changed, bounds how many updates one pass may evaluate, keeps a
- * single evaluation in flight per session, and defaults to silence whenever an
- * evaluator fails or returns something outside the decision contract.
+ * single evaluation in flight per session, discards a decision the session has
+ * already moved past, and defaults to silence whenever an evaluator fails or
+ * returns something outside the decision contract.
  */
 export class SessionAttentionReviewer {
   readonly #evaluator: AttentionEvaluator;
+  readonly #currentSession:
+    | ((identity: SessionIdentity) => NormalizedSession | undefined)
+    | undefined;
   readonly #now: () => number;
   readonly #maximumUpdatesPerReview: number;
   readonly #ledger: AttentionSpeechLedger;
@@ -266,6 +287,7 @@ export class SessionAttentionReviewer {
 
   constructor(options: SessionAttentionReviewerOptions) {
     this.#evaluator = options.evaluator;
+    this.#currentSession = options.currentSession;
     this.#now = options.now ?? Date.now;
     this.#maximumUpdatesPerReview = positiveInteger(
       options.maximumUpdatesPerReview,
@@ -310,18 +332,40 @@ export class SessionAttentionReviewer {
       providerSessionId: update.providerSessionId,
     };
 
-    if (!decision) {
-      return { ...identity, update, decision: silentAttention(this.#now()), suppressed: false };
-    }
+    if (!decision)
+      return this.#silentReview(identity, update, ATTENTION_REVIEW_OUTCOME.UNAVAILABLE);
     if (decision.disposition === ATTENTION_DISPOSITION.SILENT) {
-      return { ...identity, update, decision, suppressed: false };
+      return { ...identity, update, decision, outcome: ATTENTION_REVIEW_OUTCOME.DECIDED };
+    }
+    if (this.#isSuperseded(identity, update)) {
+      return this.#silentReview(identity, update, ATTENTION_REVIEW_OUTCOME.SUPERSEDED);
     }
     if (!this.#ledger.shouldSpeak(identity, decision)) {
-      return { ...identity, update, decision: silentAttention(this.#now()), suppressed: true };
+      return this.#silentReview(identity, update, ATTENTION_REVIEW_OUTCOME.DEDUPLICATED);
     }
 
     this.#ledger.remember(identity, decision);
-    return { ...identity, update, decision, suppressed: false };
+    return { ...identity, update, decision, outcome: ATTENTION_REVIEW_OUTCOME.DECIDED };
+  }
+
+  /**
+   * Reports whether the session moved past the state the evaluator reasoned
+   * about. Speaking then would interrupt with news that is already wrong, so the
+   * decision is dropped and the newer state earns its own review.
+   */
+  #isSuperseded(identity: SessionIdentity, update: AttentionUpdate): boolean {
+    if (!this.#currentSession) return false;
+    const current = this.#currentSession(identity);
+    if (!current) return true;
+    return current.status !== update.status || current.summary !== update.summary;
+  }
+
+  #silentReview(
+    identity: SessionIdentity,
+    update: AttentionUpdate,
+    outcome: AttentionReviewOutcome,
+  ): AttentionReview {
+    return { ...identity, update, decision: silentAttention(this.#now()), outcome };
   }
 
   async #evaluate(update: AttentionUpdate): Promise<AttentionDecision | undefined> {

--- a/packages/sidecar-core/src/attention.ts
+++ b/packages/sidecar-core/src/attention.ts
@@ -284,7 +284,7 @@ export class SessionAttentionReviewer {
   readonly #maximumUpdatesPerReview: number;
   readonly #ledger: AttentionSpeechLedger;
   #observed = new Map<string, Map<string, NormalizedSession>>();
-  #pending = new Map<string, Set<string>>();
+  readonly #pending = new Map<string, Set<string>>();
 
   constructor(options: SessionAttentionReviewerOptions) {
     this.#evaluator = options.evaluator;

--- a/packages/sidecar-core/src/attention.ts
+++ b/packages/sidecar-core/src/attention.ts
@@ -371,10 +371,13 @@ export class SessionAttentionReviewer {
    * every poll. Retries are per session and reset as soon as one succeeds.
    */
   #keepsDevelopmentPending(review: AttentionReview, session: NormalizedSession): boolean {
-    if (review.outcome === ATTENTION_REVIEW_OUTCOME.SUPERSEDED) return true;
     if (review.outcome !== ATTENTION_REVIEW_OUTCOME.UNAVAILABLE) {
+      // Every other outcome means the evaluator answered, so the failure streak
+      // is over even when the answer itself could not be used. Counting a
+      // superseded answer as a failure would let sparse blips accumulate until
+      // one of them dropped a development.
       this.#clearUnavailableRetries(session);
-      return false;
+      return review.outcome === ATTENTION_REVIEW_OUTCOME.SUPERSEDED;
     }
 
     const previous =

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -1,3 +1,6 @@
+export * from "./attention";
+export * from "./attention-examples";
+export * from "./attention-prompt";
 export * from "./fixtures";
 export * from "./geometry";
 export * from "./providers";

--- a/packages/sidecar-core/tests/attention.test.ts
+++ b/packages/sidecar-core/tests/attention.test.ts
@@ -439,6 +439,46 @@ test("stops retrying an evaluator that keeps failing", async () => {
   assert.equal(attempts, 2);
 });
 
+test("a superseded answer ends the failure streak", async () => {
+  const waiting = session(claude, "review", { status: SESSION_STATUS.WAITING });
+  const working = session(claude, "review");
+  let current: NormalizedSession = waiting;
+  let pass = 0;
+
+  const reviewer = new SessionAttentionReviewer({
+    evaluator: {
+      evaluate: async () => {
+        pass += 1;
+        // Fail, then answer into a session that moved on, then fail again.
+        if (pass === 1 || pass === 3) throw new Error("network blip");
+        if (pass === 2) current = working;
+        return speakDecision();
+      },
+    },
+    currentSession: () => current,
+    maximumUnavailableRetries: 1,
+    now: () => DECIDED_AT,
+  });
+
+  assert.equal(
+    (await reviewer.review([waiting]))[0]?.outcome,
+    ATTENTION_REVIEW_OUTCOME.UNAVAILABLE,
+  );
+  assert.equal((await reviewer.review([waiting]))[0]?.outcome, ATTENTION_REVIEW_OUTCOME.SUPERSEDED);
+
+  current = waiting;
+  assert.equal(
+    (await reviewer.review([waiting]))[0]?.outcome,
+    ATTENTION_REVIEW_OUTCOME.UNAVAILABLE,
+  );
+  const [recovered] = await reviewer.review([waiting]);
+  assert.equal(
+    recovered?.outcome,
+    ATTENTION_REVIEW_OUTCOME.DECIDED,
+    "an answered call resets the budget, so sparse blips cannot accumulate into a dropped development",
+  );
+});
+
 test("bounds one review pass and re-derives the updates it deferred", async () => {
   const evaluator = evaluatorReturning({
     disposition: ATTENTION_DISPOSITION.SILENT,

--- a/packages/sidecar-core/tests/attention.test.ts
+++ b/packages/sidecar-core/tests/attention.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   ATTENTION_DECISION_SCHEMA,
   ATTENTION_DISPOSITION,
+  ATTENTION_REVIEW_OUTCOME,
   ATTENTION_TRIGGER,
   ATTENTION_TUNING_EXAMPLES,
   type AttentionDecision,
@@ -180,7 +181,7 @@ test("reviews only changed sessions and suppresses a repeated decision", async (
   const [firstReview, ...extraReviews] = await reviewer.review([working]);
   assert.equal(extraReviews.length, 0);
   assert.deepEqual(firstReview?.decision, speakDecision());
-  assert.equal(firstReview?.suppressed, false);
+  assert.equal(firstReview?.outcome, ATTENTION_REVIEW_OUTCOME.DECIDED);
 
   assert.deepEqual(
     await reviewer.review([working]),
@@ -190,7 +191,7 @@ test("reviews only changed sessions and suppresses a repeated decision", async (
 
   const waiting = session(claude, "review", { status: SESSION_STATUS.WAITING });
   const [repeatReview] = await reviewer.review([waiting]);
-  assert.equal(repeatReview?.suppressed, true);
+  assert.equal(repeatReview?.outcome, ATTENTION_REVIEW_OUTCOME.DEDUPLICATED);
   assert.deepEqual(repeatReview?.decision, {
     disposition: ATTENTION_DISPOSITION.SILENT,
     decidedAt: DECIDED_AT,
@@ -210,7 +211,7 @@ test("stays silent when an evaluator fails or answers outside the contract", asy
     disposition: ATTENTION_DISPOSITION.SILENT,
     decidedAt: DECIDED_AT,
   });
-  assert.equal(review?.suppressed, false);
+  assert.equal(review?.outcome, ATTENTION_REVIEW_OUTCOME.UNAVAILABLE);
 
   const empty = new SessionAttentionReviewer({
     evaluator: evaluatorReturning(undefined),
@@ -218,6 +219,55 @@ test("stays silent when an evaluator fails or answers outside the contract", asy
   });
   const [emptyReview] = await empty.review([session(codex, "build")]);
   assert.equal(emptyReview?.decision.disposition, ATTENTION_DISPOSITION.SILENT);
+  assert.equal(emptyReview?.outcome, ATTENTION_REVIEW_OUTCOME.UNAVAILABLE);
+});
+
+test("drops a decision the session already moved past", async () => {
+  const waiting = session(claude, "review", { status: SESSION_STATUS.WAITING });
+  const working = session(claude, "review");
+  let current: NormalizedSession = waiting;
+  let answeredWhileEvaluating = true;
+
+  const reviewer = new SessionAttentionReviewer({
+    evaluator: {
+      evaluate: async () => {
+        // The developer answers the session while the model is still thinking.
+        if (answeredWhileEvaluating) current = working;
+        return speakDecision();
+      },
+    },
+    currentSession: () => current,
+    now: () => DECIDED_AT,
+  });
+
+  const [staleReview] = await reviewer.review([waiting]);
+  assert.equal(staleReview?.outcome, ATTENTION_REVIEW_OUTCOME.SUPERSEDED);
+  assert.deepEqual(staleReview?.decision, {
+    disposition: ATTENTION_DISPOSITION.SILENT,
+    decidedAt: DECIDED_AT,
+  });
+
+  answeredWhileEvaluating = false;
+  current = working;
+  const [spokenReview] = await reviewer.review([working]);
+  assert.equal(
+    spokenReview?.outcome,
+    ATTENTION_REVIEW_OUTCOME.DECIDED,
+    "a superseded decision is never spoken, so the same sentence is not deduplicated later",
+  );
+  assert.deepEqual(spokenReview?.decision, speakDecision());
+});
+
+test("drops a decision for a session that disappeared while it was evaluated", async () => {
+  const reviewer = new SessionAttentionReviewer({
+    evaluator: evaluatorReturning(speakDecision()),
+    currentSession: () => undefined,
+    now: () => DECIDED_AT,
+  });
+
+  const [review] = await reviewer.review([session(claude, "review")]);
+  assert.equal(review?.outcome, ATTENTION_REVIEW_OUTCOME.SUPERSEDED);
+  assert.equal(review?.decision.disposition, ATTENTION_DISPOSITION.SILENT);
 });
 
 test("bounds one review pass and re-derives the updates it deferred", async () => {

--- a/packages/sidecar-core/tests/attention.test.ts
+++ b/packages/sidecar-core/tests/attention.test.ts
@@ -479,6 +479,43 @@ test("a superseded answer ends the failure streak", async () => {
   );
 });
 
+test("reviews a session that round-trips back to the state it was reopened from", async () => {
+  // complete, then working, then complete again, with the middle transition
+  // failing. Restoring the pre-pass baseline would make the second completion
+  // compare equal to it and vanish.
+  const complete = session(codex, "build", { status: SESSION_STATUS.COMPLETE });
+  const working = session(codex, "build");
+  const finished: AttentionDecision = {
+    disposition: ATTENTION_DISPOSITION.SPEAK_AT_TURN_END,
+    decidedAt: DECIDED_AT,
+    summary: "Codex finished its turn in billing-api.",
+  };
+
+  const reviewer = new SessionAttentionReviewer({
+    evaluator: {
+      evaluate: async (update) => {
+        if (update.status !== SESSION_STATUS.COMPLETE) throw new Error("network blip");
+        return finished;
+      },
+    },
+    now: () => DECIDED_AT,
+  });
+
+  assert.equal((await reviewer.review([complete]))[0]?.outcome, ATTENTION_REVIEW_OUTCOME.DECIDED);
+  assert.equal(
+    (await reviewer.review([working]))[0]?.outcome,
+    ATTENTION_REVIEW_OUTCOME.UNAVAILABLE,
+  );
+
+  const [second] = await reviewer.review([complete]);
+  assert.ok(second, "a second completed turn must still be reviewed");
+  assert.notEqual(
+    second.decision.disposition,
+    ATTENTION_DISPOSITION.SILENT,
+    "the session finished again and must still read as needing attention",
+  );
+});
+
 test("bounds one review pass and re-derives the updates it deferred", async () => {
   const evaluator = evaluatorReturning({
     disposition: ATTENTION_DISPOSITION.SILENT,

--- a/packages/sidecar-core/tests/attention.test.ts
+++ b/packages/sidecar-core/tests/attention.test.ts
@@ -258,6 +258,44 @@ test("drops a decision the session already moved past", async () => {
   assert.deepEqual(spokenReview?.decision, speakDecision());
 });
 
+test("reviews the development again after the session returns to a superseded state", async () => {
+  const working = session(claude, "review");
+  const waiting = session(claude, "review", { status: SESSION_STATUS.WAITING });
+  let current: NormalizedSession = working;
+  let answeredWhileEvaluating = false;
+
+  const reviewer = new SessionAttentionReviewer({
+    evaluator: {
+      evaluate: async (update) => {
+        if (update.status !== SESSION_STATUS.WAITING) {
+          return { disposition: ATTENTION_DISPOSITION.SILENT, decidedAt: DECIDED_AT };
+        }
+        if (answeredWhileEvaluating) current = working;
+        return speakDecision();
+      },
+    },
+    currentSession: () => current,
+    now: () => DECIDED_AT,
+  });
+
+  await reviewer.review([working]);
+
+  answeredWhileEvaluating = true;
+  const [supersededReview] = await reviewer.review([waiting]);
+  assert.equal(supersededReview?.outcome, ATTENTION_REVIEW_OUTCOME.SUPERSEDED);
+
+  // The session asks again before any pass observed the answered state.
+  answeredWhileEvaluating = false;
+  current = waiting;
+  const [retriedReview] = await reviewer.review([waiting]);
+  assert.equal(
+    retriedReview?.outcome,
+    ATTENTION_REVIEW_OUTCOME.DECIDED,
+    "a superseded development is derived again instead of being consumed with the baseline",
+  );
+  assert.deepEqual(retriedReview?.decision, speakDecision());
+});
+
 test("re-checks every decision after the slowest evaluation in the pass lands", async () => {
   const waitingSession = session(claude, "answered", {
     status: SESSION_STATUS.WAITING,

--- a/packages/sidecar-core/tests/attention.test.ts
+++ b/packages/sidecar-core/tests/attention.test.ts
@@ -258,6 +258,54 @@ test("drops a decision the session already moved past", async () => {
   assert.deepEqual(spokenReview?.decision, speakDecision());
 });
 
+test("re-checks every decision after the slowest evaluation in the pass lands", async () => {
+  const waitingSession = session(claude, "answered", {
+    status: SESSION_STATUS.WAITING,
+    observedAt: DECIDED_AT,
+  });
+  const workingSession = session(claude, "answered", { observedAt: DECIDED_AT });
+  const slowSession = session(claude, "slow", { observedAt: DECIDED_AT - 1_000 });
+  const current = new Map<string, NormalizedSession>([
+    ["answered", waitingSession],
+    ["slow", slowSession],
+  ]);
+  let releaseSlow: (() => void) | undefined;
+
+  const reviewer = new SessionAttentionReviewer({
+    evaluator: {
+      evaluate: async (update) => {
+        if (update.providerSessionId === "slow") {
+          await new Promise<void>((resolve) => {
+            releaseSlow = resolve;
+          });
+        }
+        return speakDecision();
+      },
+    },
+    currentSession: (identity) => current.get(identity.providerSessionId),
+    now: () => DECIDED_AT,
+  });
+
+  const pass = reviewer.review([waitingSession, slowSession]);
+  // Let the answered session's evaluation finish completely, so the pass is
+  // held open only by the slow sibling.
+  await new Promise((resolve) => setImmediate(resolve));
+
+  // A provider refresh lands while the slow sibling still holds the pass open.
+  current.set("answered", workingSession);
+  releaseSlow?.();
+  const reviews = await pass;
+
+  assert.equal(
+    reviews.find((review) => review.providerSessionId === "answered")?.outcome,
+    ATTENTION_REVIEW_OUTCOME.SUPERSEDED,
+  );
+  assert.equal(
+    reviews.find((review) => review.providerSessionId === "slow")?.outcome,
+    ATTENTION_REVIEW_OUTCOME.DECIDED,
+  );
+});
+
 test("drops a decision for a session that disappeared while it was evaluated", async () => {
   const reviewer = new SessionAttentionReviewer({
     evaluator: evaluatorReturning(speakDecision()),

--- a/packages/sidecar-core/tests/attention.test.ts
+++ b/packages/sidecar-core/tests/attention.test.ts
@@ -1,0 +1,354 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ATTENTION_DECISION_SCHEMA,
+  ATTENTION_DISPOSITION,
+  ATTENTION_TRIGGER,
+  ATTENTION_TUNING_EXAMPLES,
+  type AttentionDecision,
+  AttentionSpeechLedger,
+  type AttentionUpdate,
+  attentionDecisionFromModel,
+  attentionInstructions,
+  attentionUpdate,
+  attentionUpdateInput,
+  maximumAttentionSummaryLength,
+  type NormalizedSession,
+  normalizeSession,
+  type ProviderSessionObservation,
+  SESSION_STATUS,
+  SessionAttentionReviewer,
+  type SessionProvider,
+} from "../src";
+
+const claude: SessionProvider = { id: "claude-code", displayName: "Claude Code" };
+const codex: SessionProvider = { id: "codex", displayName: "Codex" };
+const DECIDED_AT = 1_800_000_000_000;
+const SPOKEN_SUMMARY = "Claude Code is waiting on you in checkout-service.";
+const OTHER_SUMMARY = "Claude Code finished its turn in checkout-service.";
+const TRANSCRIPT_SECRET = "SECRET_TRANSCRIPT_TEXT";
+
+function session(
+  provider: SessionProvider,
+  providerSessionId: string,
+  overrides: Partial<ProviderSessionObservation> = {},
+): NormalizedSession {
+  const observation: ProviderSessionObservation = {
+    providerSessionId,
+    title: `${provider.displayName}: checkout-service`,
+    status: SESSION_STATUS.WORKING,
+    observedAt: DECIDED_AT,
+    ...overrides,
+  };
+  return normalizeSession(provider, observation);
+}
+
+function speakDecision(summary = SPOKEN_SUMMARY): AttentionDecision {
+  return {
+    disposition: ATTENTION_DISPOSITION.SPEAK_DURING_TURN,
+    decidedAt: DECIDED_AT,
+    summary,
+  };
+}
+
+function evaluatorReturning(decision: AttentionDecision | undefined): {
+  evaluate: (update: AttentionUpdate) => Promise<AttentionDecision | undefined>;
+} & {
+  readonly updates: AttentionUpdate[];
+} {
+  const updates: AttentionUpdate[] = [];
+  return {
+    updates,
+    evaluate: async (update) => {
+      updates.push(update);
+      return decision;
+    },
+  };
+}
+
+test("derives an update only when a session reports something new", () => {
+  const working = session(claude, "review");
+  const waiting = session(claude, "review", { status: SESSION_STATUS.WAITING, observedAt: 1 });
+
+  assert.deepEqual(attentionUpdate(working), {
+    providerId: claude.id,
+    providerSessionId: "review",
+    trigger: ATTENTION_TRIGGER.OBSERVED,
+    providerName: claude.displayName,
+    title: "Claude Code: checkout-service",
+    status: SESSION_STATUS.WORKING,
+    observedAt: DECIDED_AT,
+  });
+  assert.equal(attentionUpdate(working, working), undefined);
+  assert.equal(attentionUpdate(waiting, working)?.trigger, ATTENTION_TRIGGER.STATUS_CHANGED);
+  assert.equal(attentionUpdate(waiting, working)?.previousStatus, SESSION_STATUS.WORKING);
+  assert.equal(
+    attentionUpdate(session(claude, "review", { summary: "Claude Code waiting." }), working)
+      ?.trigger,
+    ATTENTION_TRIGGER.SUMMARY_CHANGED,
+  );
+});
+
+test("rejects model output that does not satisfy the decision contract", () => {
+  assert.equal(attentionDecisionFromModel(undefined, DECIDED_AT), undefined);
+  assert.equal(attentionDecisionFromModel("silent", DECIDED_AT), undefined);
+  assert.equal(attentionDecisionFromModel([], DECIDED_AT), undefined);
+  assert.equal(attentionDecisionFromModel({ disposition: "speak" }, DECIDED_AT), undefined);
+  assert.equal(
+    attentionDecisionFromModel(
+      { disposition: ATTENTION_DISPOSITION.SPEAK_AT_TURN_END, summary: null },
+      DECIDED_AT,
+    ),
+    undefined,
+    "a speaking decision must carry the sentence Luke would say",
+  );
+
+  assert.deepEqual(
+    attentionDecisionFromModel(
+      { disposition: ATTENTION_DISPOSITION.SILENT, summary: null },
+      DECIDED_AT,
+    ),
+    { disposition: ATTENTION_DISPOSITION.SILENT, decidedAt: DECIDED_AT },
+  );
+  assert.deepEqual(
+    attentionDecisionFromModel(
+      { disposition: ATTENTION_DISPOSITION.SPEAK_DURING_TURN, summary: `  ${SPOKEN_SUMMARY}  ` },
+      DECIDED_AT,
+    ),
+    speakDecision(),
+  );
+  assert.equal(
+    attentionDecisionFromModel(
+      {
+        disposition: ATTENTION_DISPOSITION.SPEAK_AT_TURN_END,
+        summary: "a".repeat(maximumAttentionSummaryLength + 40),
+      },
+      DECIDED_AT,
+    )?.summary?.length,
+    maximumAttentionSummaryLength,
+  );
+});
+
+test("deduplicates repeated speech per session without composing identity keys", () => {
+  let now = DECIDED_AT;
+  const repeatWindowMs = 10_000;
+  const ledger = new AttentionSpeechLedger({ now: () => now, repeatWindowMs });
+  const review = { providerId: claude.id, providerSessionId: "review" };
+  const otherProvider = { providerId: codex.id, providerSessionId: "review" };
+
+  assert.equal(
+    ledger.shouldSpeak(review, { disposition: ATTENTION_DISPOSITION.SILENT, decidedAt: now }),
+    false,
+  );
+
+  assert.equal(ledger.shouldSpeak(review, speakDecision()), true);
+  ledger.remember(review, speakDecision());
+  assert.equal(ledger.shouldSpeak(review, speakDecision()), false);
+  assert.equal(
+    ledger.shouldSpeak(otherProvider, speakDecision()),
+    true,
+    "the same session id under another provider is a different session",
+  );
+  assert.equal(ledger.shouldSpeak(review, speakDecision(OTHER_SUMMARY)), true);
+  assert.equal(
+    ledger.shouldSpeak(review, {
+      disposition: ATTENTION_DISPOSITION.SPEAK_AT_TURN_END,
+      decidedAt: now,
+      summary: SPOKEN_SUMMARY,
+    }),
+    true,
+  );
+
+  now += repeatWindowMs;
+  assert.equal(ledger.shouldSpeak(review, speakDecision()), true);
+
+  now = DECIDED_AT;
+  ledger.remember(review, speakDecision());
+  assert.equal(ledger.shouldSpeak(review, speakDecision()), false);
+  ledger.retain([otherProvider]);
+  assert.equal(ledger.shouldSpeak(review, speakDecision()), true, "forgotten sessions speak again");
+});
+
+test("reviews only changed sessions and suppresses a repeated decision", async () => {
+  const evaluator = evaluatorReturning(speakDecision());
+  const reviewer = new SessionAttentionReviewer({
+    evaluator,
+    now: () => DECIDED_AT,
+  });
+
+  const working = session(claude, "review");
+  const [firstReview, ...extraReviews] = await reviewer.review([working]);
+  assert.equal(extraReviews.length, 0);
+  assert.deepEqual(firstReview?.decision, speakDecision());
+  assert.equal(firstReview?.suppressed, false);
+
+  assert.deepEqual(
+    await reviewer.review([working]),
+    [],
+    "an unchanged session is not re-evaluated",
+  );
+
+  const waiting = session(claude, "review", { status: SESSION_STATUS.WAITING });
+  const [repeatReview] = await reviewer.review([waiting]);
+  assert.equal(repeatReview?.suppressed, true);
+  assert.deepEqual(repeatReview?.decision, {
+    disposition: ATTENTION_DISPOSITION.SILENT,
+    decidedAt: DECIDED_AT,
+  });
+  assert.equal(evaluator.updates.length, 2);
+});
+
+test("stays silent when an evaluator fails or answers outside the contract", async () => {
+  const failing = {
+    evaluate: async () => {
+      throw new Error("network unavailable");
+    },
+  };
+  const reviewer = new SessionAttentionReviewer({ evaluator: failing, now: () => DECIDED_AT });
+  const [review] = await reviewer.review([session(claude, "review")]);
+  assert.deepEqual(review?.decision, {
+    disposition: ATTENTION_DISPOSITION.SILENT,
+    decidedAt: DECIDED_AT,
+  });
+  assert.equal(review?.suppressed, false);
+
+  const empty = new SessionAttentionReviewer({
+    evaluator: evaluatorReturning(undefined),
+    now: () => DECIDED_AT,
+  });
+  const [emptyReview] = await empty.review([session(codex, "build")]);
+  assert.equal(emptyReview?.decision.disposition, ATTENTION_DISPOSITION.SILENT);
+});
+
+test("bounds one review pass and re-derives the updates it deferred", async () => {
+  const evaluator = evaluatorReturning({
+    disposition: ATTENTION_DISPOSITION.SILENT,
+    decidedAt: DECIDED_AT,
+  });
+  const reviewer = new SessionAttentionReviewer({
+    evaluator,
+    now: () => DECIDED_AT,
+    maximumUpdatesPerReview: 1,
+  });
+
+  const newest = session(claude, "newest", { observedAt: DECIDED_AT });
+  const oldest = session(claude, "oldest", { observedAt: DECIDED_AT - 5_000 });
+  const firstPass = await reviewer.review([oldest, newest]);
+  assert.deepEqual(
+    firstPass.map((review) => review.providerSessionId),
+    ["newest"],
+    "the newest development is reviewed first",
+  );
+
+  const secondPass = await reviewer.review([oldest, newest]);
+  assert.deepEqual(
+    secondPass.map((review) => review.providerSessionId),
+    ["oldest"],
+  );
+  assert.deepEqual(await reviewer.review([oldest, newest]), []);
+});
+
+test("keeps one evaluation in flight per session", async () => {
+  let release: (() => void) | undefined;
+  const started: AttentionUpdate[] = [];
+  const reviewer = new SessionAttentionReviewer({
+    evaluator: {
+      evaluate: async (update) => {
+        started.push(update);
+        if (started.length === 1) {
+          await new Promise<void>((resolve) => {
+            release = resolve;
+          });
+        }
+        return { disposition: ATTENTION_DISPOSITION.SILENT, decidedAt: DECIDED_AT };
+      },
+    },
+    now: () => DECIDED_AT,
+  });
+
+  const working = session(claude, "review");
+  const inFlight = reviewer.review([working]);
+  await Promise.resolve();
+
+  const waiting = session(claude, "review", { status: SESSION_STATUS.WAITING });
+  assert.deepEqual(await reviewer.review([waiting]), []);
+  assert.equal(started.length, 1);
+
+  release?.();
+  await inFlight;
+
+  const [laterReview] = await reviewer.review([waiting]);
+  assert.equal(
+    laterReview?.update.trigger,
+    ATTENTION_TRIGGER.STATUS_CHANGED,
+    "a development observed while busy is reviewed once the session is free",
+  );
+});
+
+test("sends bounded, redacted material and never provider transcripts", async () => {
+  const evaluator = evaluatorReturning({
+    disposition: ATTENTION_DISPOSITION.SILENT,
+    decidedAt: DECIDED_AT,
+  });
+  const reviewer = new SessionAttentionReviewer({ evaluator, now: () => DECIDED_AT });
+  await reviewer.review([
+    session(claude, "review", {
+      title: `Claude Code: checkout-service ${TRANSCRIPT_SECRET}`.padEnd(400, "x"),
+      summary: `Claude Code working. ${TRANSCRIPT_SECRET}`.padEnd(900, "y"),
+    }),
+  ]);
+
+  const [update] = evaluator.updates;
+  assert.ok(update);
+  assert.deepEqual(Object.keys(update).sort(), [
+    "observedAt",
+    "providerId",
+    "providerName",
+    "providerSessionId",
+    "status",
+    "summary",
+    "title",
+    "trigger",
+  ]);
+  assert.equal(update.title.length, 160, "titles stay bounded by session normalization");
+  assert.equal(update.summary?.length, 500, "summaries stay bounded by session normalization");
+
+  const input = attentionUpdateInput(update);
+  assert.ok(input.includes("Provider: Claude Code"));
+  assert.ok(input.includes(`Status: ${SESSION_STATUS.WORKING}`));
+  assert.ok(!input.includes("providerSessionId"));
+});
+
+test("tuning examples are redacted, bounded, and cover every disposition", () => {
+  assert.deepEqual(
+    [...new Set(ATTENTION_TUNING_EXAMPLES.map((example) => example.expected.disposition))].sort(),
+    [...Object.values(ATTENTION_DISPOSITION)].sort(),
+  );
+
+  for (const example of ATTENTION_TUNING_EXAMPLES) {
+    const decision = attentionDecisionFromModel(example.expected, DECIDED_AT);
+    assert.ok(decision, `${example.name} must satisfy the decision contract`);
+    assert.equal(decision.disposition, example.expected.disposition);
+    assert.ok((example.expected.summary ?? "").length <= maximumAttentionSummaryLength);
+    assert.ok(!example.update.title.includes("/"), "examples use workspace names, not paths");
+  }
+});
+
+test("instructions carry the decision contract and the tuning examples", () => {
+  const instructions = attentionInstructions();
+  for (const disposition of Object.values(ATTENTION_DISPOSITION)) {
+    assert.ok(instructions.includes(disposition));
+  }
+  for (const example of ATTENTION_TUNING_EXAMPLES) {
+    assert.ok(instructions.includes(example.name));
+    assert.ok(instructions.includes(attentionUpdateInput(example.update)));
+  }
+  assert.ok(instructions.includes(String(maximumAttentionSummaryLength)));
+  assert.deepEqual(ATTENTION_DECISION_SCHEMA.properties.disposition.enum, [
+    ATTENTION_DISPOSITION.SILENT,
+    ATTENTION_DISPOSITION.SPEAK_DURING_TURN,
+    ATTENTION_DISPOSITION.SPEAK_AT_TURN_END,
+  ]);
+  assert.deepEqual(ATTENTION_DECISION_SCHEMA.required, ["disposition", "summary"]);
+  assert.equal(ATTENTION_DECISION_SCHEMA.additionalProperties, false);
+});

--- a/packages/sidecar-core/tests/attention.test.ts
+++ b/packages/sidecar-core/tests/attention.test.ts
@@ -384,6 +384,61 @@ test("drops a decision for a session that disappeared while it was evaluated", a
   assert.equal(review?.decision.disposition, ATTENTION_DISPOSITION.SILENT);
 });
 
+test("retries a failed evaluation a bounded number of times", async () => {
+  let attempts = 0;
+  const failuresBeforeSuccess = 2;
+  const reviewer = new SessionAttentionReviewer({
+    evaluator: {
+      evaluate: async () => {
+        attempts += 1;
+        if (attempts <= failuresBeforeSuccess) throw new Error("network blip");
+        return speakDecision();
+      },
+    },
+    now: () => DECIDED_AT,
+  });
+
+  const waiting = session(claude, "review", { status: SESSION_STATUS.WAITING });
+  for (let pass = 0; pass < failuresBeforeSuccess; pass += 1) {
+    const [review] = await reviewer.review([waiting]);
+    assert.equal(review?.outcome, ATTENTION_REVIEW_OUTCOME.UNAVAILABLE);
+  }
+
+  const [recovered] = await reviewer.review([waiting]);
+  assert.equal(
+    recovered?.outcome,
+    ATTENTION_REVIEW_OUTCOME.DECIDED,
+    "a passing failure must not permanently drop the development",
+  );
+  assert.deepEqual(recovered?.decision, speakDecision());
+});
+
+test("stops retrying an evaluator that keeps failing", async () => {
+  let attempts = 0;
+  const reviewer = new SessionAttentionReviewer({
+    evaluator: {
+      evaluate: async () => {
+        attempts += 1;
+        return undefined;
+      },
+    },
+    maximumUnavailableRetries: 1,
+    now: () => DECIDED_AT,
+  });
+
+  const waiting = session(claude, "review", { status: SESSION_STATUS.WAITING });
+  await reviewer.review([waiting]);
+  await reviewer.review([waiting]);
+  assert.equal(attempts, 2);
+
+  assert.deepEqual(
+    await reviewer.review([waiting]),
+    [],
+    "a standing misconfiguration must not re-evaluate on every poll",
+  );
+  assert.equal(attempts, 2);
+});
+
 test("bounds one review pass and re-derives the updates it deferred", async () => {
   const evaluator = evaluatorReturning({
     disposition: ATTENTION_DISPOSITION.SILENT,

--- a/packages/sidecar-core/tests/attention.test.ts
+++ b/packages/sidecar-core/tests/attention.test.ts
@@ -192,11 +192,39 @@ test("reviews only changed sessions and suppresses a repeated decision", async (
   const waiting = session(claude, "review", { status: SESSION_STATUS.WAITING });
   const [repeatReview] = await reviewer.review([waiting]);
   assert.equal(repeatReview?.outcome, ATTENTION_REVIEW_OUTCOME.DEDUPLICATED);
-  assert.deepEqual(repeatReview?.decision, {
-    disposition: ATTENTION_DISPOSITION.SILENT,
-    decidedAt: DECIDED_AT,
-  });
+  assert.deepEqual(
+    repeatReview?.decision,
+    speakDecision(),
+    "a repeat stays worth attention even though Luke will not say it again",
+  );
   assert.equal(evaluator.updates.length, 2);
+});
+
+test("keeps a second real development visible when Luke stays quiet about it", async () => {
+  // Two turns finishing minutes apart produce the same sentence, so the ledger
+  // suppresses the second one. The session still finished twice.
+  const evaluator = evaluatorReturning({
+    disposition: ATTENTION_DISPOSITION.SPEAK_AT_TURN_END,
+    decidedAt: DECIDED_AT,
+    summary: "Codex finished its turn in billing-api.",
+  });
+  const reviewer = new SessionAttentionReviewer({ evaluator, now: () => DECIDED_AT });
+
+  const complete = session(codex, "build", { status: SESSION_STATUS.COMPLETE });
+  const working = session(codex, "build");
+
+  const [first] = await reviewer.review([complete]);
+  assert.equal(first?.outcome, ATTENTION_REVIEW_OUTCOME.DECIDED);
+
+  await reviewer.review([working]);
+
+  const [second] = await reviewer.review([complete]);
+  assert.equal(second?.outcome, ATTENTION_REVIEW_OUTCOME.DEDUPLICATED);
+  assert.notEqual(
+    second?.decision.disposition,
+    ATTENTION_DISPOSITION.SILENT,
+    "a second completed turn must not be hidden because its sentence matches a recent one",
+  );
 });
 
 test("stays silent when an evaluator fails or answers outside the contract", async () => {


### PR DESCRIPTION
## Summary

- Add a portable attention layer in `packages/sidecar-core/` that derives a bounded, redacted update only when a session reports something new, validates untrusted model output against a small decision contract, deduplicates repeated speech per session, bounds how many updates one pass evaluates, and keeps one evaluation in flight per session.
- Add an OpenAI evaluator in the Electron main process that calls the Responses API with the decision contract as a strict structured-output schema, sets `store: false`, and returns nothing when the API is unavailable or answers outside the contract.
- Wire the reviewer into session observation outside the refresh guard, so a slow model call never delays the next provider snapshot, and store each decision on the session without touching provider-owned data.
- Discard a decision the session has already moved past, so answering a waiting session while the model is still thinking never produces a stale interruption, and keep that development derivable for a later pass.
- Ship redacted, synthetic tuning examples that serve as both the prompt's few-shot guidance and its regression coverage.

### Decision contract for consumers

`AttentionReview` answers two different questions and they must not be conflated:

- **`decision`** — whether the session warrants attention and how urgently. This is what callers store on the session, and what the renderer reads.
- **`outcome`** — whether Luke should voice it *now*: `decided`, `deduplicated`, `superseded`, or `unavailable`.

A repeated development carries a **speaking `decision` with a `deduplicated` outcome**: the session still needs attention, but saying the same sentence again would be noise. A consumer that infers speech from `decision.disposition` alone will repeat itself — read `outcome` for speech.

### Trust boundary

- The layer is optional. Without `OPENAI_API_KEY`, Luke observes sessions and stays silent; no product behavior requires credentials.
- The only session material sent is the bounded update: provider name, session title, trigger, previous status, status, and the provider's redacted summary. No transcript, file path, or command output is ever included, and evidence/capture mode never enables the layer.
- Every failure path — network error, non-2xx status, non-JSON body, unknown disposition, a speaking decision with no sentence, a session that moved on or vanished mid-evaluation — resolves to silence rather than a guess. Each review reports which of those happened through an `outcome` value set.
- Logs carry a status code or an error name only, never the request, the key, or session material.

| Variable | Default | Purpose |
| --- | --- | --- |
| `OPENAI_API_KEY` | unset | Enables attention review when present |
| `LUKE_ATTENTION_MODEL` | `gpt-5.6-luna` | Model used for the decision |
| `OPENAI_BASE_URL` | `https://api.openai.com/v1` | Alternate OpenAI-compatible endpoint |

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (lint, typecheck, 26 desktop tests, 31 core tests, 5 harness tests, all builds)
- macOS Electron verification (`./scripts/verify.sh`): portable checks passed, then packaging stopped with `error: this command requires macOS` in this Linux workspace; CI's macOS app/evidence job covers it
- End-to-end run of the real pipeline (`InMemorySessionRegistry` → `SessionAttentionReviewer` → `OpenAiAttentionEvaluator` over real `fetch`) against a local stub of the Responses API:

```
first observation:            reviews=1  session-a=silent
unchanged:                    reviews=0                       <- no API call
became waiting:               reviews=1  session-a=speak-during-turn
resumed working:              reviews=1  session-a=silent
waiting again (deduplicated): reviews=1  session-a=silent (suppressed)

requests sent: 4
path: /v1/responses
body keys: input, instructions, max_output_tokens, model, store, text
store: false
input sent to the API:
---
Provider: Claude Code
Session: Claude Code: checkout-service
Trigger: observed
Previous status: none
Status: working
Observed summary: Claude Code working; transcript content is not retained.
---
```

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31561440258/artifacts/9127873715) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31561440258)

- Commit: `5a2d610324c08fc4d6730971ec6a4a2fce7de57b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` — no renderer or window change in this PR
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- No live OpenAI credential is available in this workspace, so the API contract is exercised against a local stub and unit-level fakes rather than the hosted API. The hosted API's acceptance of the strict schema is the one surface left untested.
- The default model is `gpt-5.6-luna` (`04c5d9e`). The task is a three-way classification against a fixed prompt run in the background on the user's own key, so the cost-optimized tier fits: it is ~25x cheaper per call than the flagship, and its lower latency means fewer decisions are discarded as superseded. `LUKE_ATTENTION_MODEL` overrides it.
- The renderer is unchanged. It already treats a non-silent disposition as a session needing attention, so decisions surface through the existing indicator with no UI diff.
- Merged `origin/main` (`8ccaa5c`) after #9/#10/#11 landed. GitHub reported no conflict, but #11's new `fixtureMode` created a semantic one: the attention evaluator still keyed off `captureMode`, so a deterministic `--fixture` run would have read `OPENAI_API_KEY`. Fixed in `5a2d610`, and `./scripts/check.sh` was re-run green against the merged tree.
- A development is consumed only once a decision is actually reached about it. A superseded decision stays derivable, and an unavailable evaluator is retried twice per session before the update is dropped — enough for a passing network blip, bounded so a standing misconfiguration cannot re-evaluate on every poll.
- Cursor Bugbot found three real defects across review rounds, all in the same area — a decision outliving the state it was made about. Each fix has a regression test that fails against the preceding commit:
  - `24b57fa` — a speak decision could land after a provider refresh moved the session on. Re-check the session against the evaluated state before admitting a speaking decision.
  - `77af446` — that check ran per-evaluation, but waiting on a slower sibling in the same pass reopened the window. Settle all speaking decisions in one uninterrupted step after the last evaluation lands.
  - `ca60e6f` — a superseded settle undid the ledger write but not the baseline advance, so a session that returned to the evaluated state was never reviewed again. Restore the pre-pass baseline when a decision is dropped as superseded.
  - `5955b0e` — deduplication downgraded a repeat to silence, and the renderer reads the stored disposition, so a second turn finishing minutes after the first was hidden entirely. Keep the disposition and report the repeat through `outcome`.
  - `3bd09fb` — reasoning tokens share the `max_output_tokens` budget, so a 1024 cap could return `incomplete` with no output; consuming the baseline on failure then made that permanent. Raise the cap and retry an unavailable evaluation twice.
  - `aba024f` — the retry budget did not reset on a superseded answer, so sparse blips could accumulate into a dropped development. Clear the streak on any outcome except `unavailable`.
  - `951684b` — restoring the pre-pass baseline only re-derives an update while the session sits elsewhere, so a `complete → working → complete` round trip vanished. Forget the observation instead.
- Follow-up: speaking the decision aloud belongs to the realtime voice work, not this PR.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/68622b28-af3d-4d0a-9787-6b6cdb483fc6)








