### PR TITLE
docs: keep PR descriptions current when pushing follow-up commits

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -24,7 +24,13 @@
    maintains the automated-evidence link there. Attach physical-device
    screenshots or recordings through GitHub's PR editor and call out
    physical-notch checks that remain.
-6. When an agent must add inline PR media without the GitHub editor, store it on
+6. When pushing follow-up commits to an open PR, re-read the PR description and
+   update it if the change made it inaccurate or incomplete. Keep the summary,
+   scope, and Evidence section matching the commands and results for the current
+   head commit; refresh screenshots whose UI has changed and drop claims that no
+   longer hold. Leave the description alone when the new commits do not change
+   what it says.
+7. When an agent must add inline PR media without the GitHub editor, store it on
    the shared `pr-assets` branch, not the product branch. Use a per-PR path such
    as `pr-<number>/landing-page.png`, then embed the raw GitHub URL in the PR
    description. Keep `pr-assets` as the one durable media branch: deleting it


### PR DESCRIPTION
## Summary

- Add step 6 to `WORKFLOW.md`: when pushing follow-up commits to an open PR,
  re-read the PR description and update it if the new commits made it
  inaccurate or incomplete, keeping the summary, scope, and Evidence section
  matched to the current head commit.
- Spell out the no-op case so agents do not churn descriptions on every push.
- Renumber the existing `pr-assets` media step to 7.

`WORKFLOW.md` already owns the PR lifecycle (step 5 opens the PR, the media
step follows), so the guidance lands there rather than in `AGENTS.md`, whose
Git workflow section covers commit/PR/branch naming only.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — pass (exit 0)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — docs-only
  change with no macOS, Electron, or UI surface

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31557686492/artifacts/9126565183) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31557686492)

- Commit: `a67f1f39f287366abf054a7f11deba9c03d38b87`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` — no UI change
- Physical-notch check: `not performed` — no UI change
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: None

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/5d6251c6-aa8f-40b1-9ce9-2b9a2a45095a)
