### PR TITLE
fix: keep the notch capsule inside the compact window

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Canonical commands:
 - `./scripts/check.sh` — run portable repository, type, test, and build checks
 - `./scripts/test-macos.sh` — package and validate the macOS app
 - `./scripts/verify.sh` — complete macOS validation plus visual evidence
-- `./scripts/run.sh` — launch the deterministic fixture app
+- `./scripts/run.sh` — launch the app against live sessions (`--fixture smoke` for fixture data)
 - `./scripts/evidence.sh` — write the fixture PNG under `artifacts/`
 - `pnpm evidence:record` — record the fixture transition on a physical Mac
 - `pnpm lint:fix` — apply repository formatting and safe lint fixes

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ From a fresh checkout:
 ./scripts/check.sh
 ```
 
-On macOS, launch the fixture app or run complete validation:
+On macOS, launch the app or run complete validation:
 
 ```sh
 ./scripts/run.sh

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -35,9 +35,12 @@ import {
 
 const captureOutput = argumentValue("--capture-evidence");
 const profile = argumentValue("--profile") ?? "idle";
-const fixtureName = argumentValue("--fixture") ?? "smoke";
-const fixture = fixtureSnapshot(fixtureName);
+const fixtureName = argumentValue("--fixture");
+const fixture = fixtureSnapshot(fixtureName ?? "smoke");
 const captureMode = captureOutput !== undefined;
+// `--fixture` is enough on its own to make a run deterministic: the panel renders
+// the fixture snapshot and no provider is observed. Capture runs always imply it.
+const fixtureMode = captureMode || fixtureName !== undefined;
 const SESSION_REFRESH_INTERVAL_MS = 5_000;
 const sessionRegistry = new InMemorySessionRegistry();
 const sessionAdapters = [new ClaudeCodeSessionAdapter(), new CodexSessionAdapter()] as const;
@@ -172,6 +175,7 @@ function registerIpc(): void {
       profile,
       fixture,
       captureMode,
+      fixtureMode,
       packaged: app.isPackaged,
       platform: process.platform,
       electronVersion: process.versions.electron,
@@ -179,7 +183,7 @@ function registerIpc(): void {
       nodeVersion: process.versions.node,
       microphoneStatus: microphoneStatus(),
       display: displayDiagnostic(),
-      sessions: captureMode ? [] : sessionRegistry.snapshot().sessions,
+      sessions: fixtureMode ? [] : sessionRegistry.snapshot().sessions,
     };
   });
 
@@ -222,7 +226,7 @@ function registerIpc(): void {
 }
 
 async function refreshProviderSessions(): Promise<void> {
-  if (captureMode || sessionRefreshRunning) return;
+  if (fixtureMode || sessionRefreshRunning) return;
   sessionRefreshRunning = true;
   try {
     for (const adapter of sessionAdapters) {
@@ -237,7 +241,7 @@ async function refreshProviderSessions(): Promise<void> {
 }
 
 function startSessionObservation(): void {
-  if (captureMode) return;
+  if (fixtureMode) return;
   sessionRegistry.subscribe((snapshot) => {
     panelWindow?.webContents.send(channels.sessionsChanged, snapshot.sessions);
   });

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -160,7 +160,7 @@ function sessionState(session: NormalizedSession): SessionState {
 }
 
 function displaySessions(bootstrap: AppBootstrap, sessions: readonly NormalizedSession[]) {
-  if (bootstrap.captureMode) {
+  if (bootstrap.fixtureMode) {
     return bootstrap.fixture.sessions.map(
       (session): DisplaySession => ({
         ...session,
@@ -367,7 +367,7 @@ function App(): React.JSX.Element {
       : active > 0
         ? SESSION_STATE.WORKING
         : SESSION_STATE.UNKNOWN;
-  const hasLiveSessions = !bootstrap.captureMode && sessions.length > 0;
+  const hasLiveSessions = !bootstrap.fixtureMode && sessions.length > 0;
   const sessionSummary =
     visibleSessions.length === 0
       ? "No sessions observed"
@@ -443,13 +443,13 @@ function App(): React.JSX.Element {
               <p className="eyebrow">Notch sidecar</p>
               <h1>Agent activity</h1>
               <p className="subtle">
-                {bootstrap.captureMode
+                {bootstrap.fixtureMode
                   ? "Synthetic sessions · no credentials or live transcripts"
                   : "Live sessions · no credentials or transcripts retained"}
               </p>
             </div>
             <span className="fixture-badge">
-              {hasLiveSessions ? "LIVE" : bootstrap.captureMode ? "FIXTURE · SMOKE" : "IDLE"}
+              {hasLiveSessions ? "LIVE" : bootstrap.fixtureMode ? "FIXTURE · SMOKE" : "IDLE"}
             </span>
           </div>
 

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -378,7 +378,7 @@ function App(): React.JSX.Element {
 
   return (
     <div className="app-stage" data-mode={mode} style={style}>
-      <div className="compact-stage" aria-hidden={mode !== "compact"}>
+      <div className="compact-stage" aria-hidden={mode !== "compact"} inert={mode !== "compact"}>
         {display.notch.hasNotch ? <span className="notch-housing" aria-hidden="true" /> : null}
         {hasAudioSignal ? (
           <div className="compact-waveform">
@@ -405,9 +405,13 @@ function App(): React.JSX.Element {
         </div>
       </div>
 
+      {/* Inert while hidden: the panel keeps its 620x520 layout box behind
+          `opacity: 0`, so its buttons stay focusable and the browser will scroll
+          them into view, pushing the compact capsule off screen. */}
       <div
         className="expanded-stage"
         aria-hidden={mode !== "expanded"}
+        inert={mode !== "expanded"}
         data-hit-region
         onPointerEnter={cancelHoverTransition}
         onPointerLeave={() => scheduleMode(false)}

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -15,7 +15,10 @@ body,
   width: 100%;
   height: 100%;
   margin: 0;
-  overflow: hidden;
+  /* `clip` rather than `hidden`: the expanded stage is 520px tall and stays in
+     layout while the compact window is only ~32px, so `hidden` leaves a scroll
+     container that focus or scrollIntoView can drag the notch capsule out of. */
+  overflow: clip;
   background: transparent;
   user-select: none;
 }

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -24,6 +24,8 @@ export interface AppBootstrap {
   profile: string;
   fixture: FixtureSnapshot;
   captureMode: boolean;
+  /** True when `--fixture` (or a capture run) makes the panel render fixture sessions. */
+  fixtureMode: boolean;
   packaged: boolean;
   platform: string;
   electronVersion: string;

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -11,6 +11,7 @@ if [[ ! -x "$SIDECAR_ELECTRON_BIN" ]]; then
     "$SCRIPT_DIRECTORY/bootstrap.sh"
 fi
 
+# Live sessions are the default. Pass `--fixture smoke` for deterministic data;
+# the app honours it on its own, so nothing needs injecting here.
 cd "$SIDECAR_REPO_ROOT"
-exec pnpm start -- \
-    --fixture "$SIDECAR_FIXTURE_SCENARIO" "$@"
+exec pnpm start -- "$@"


### PR DESCRIPTION
## Summary

- **Fix:** the compact notch capsule rendered nothing. The expanded panel is hidden with `opacity: 0` alone, so it kept its full 620x520 layout box and focusable buttons inside a ~32px-tall window, leaving `#root` a scroll container (`scrollHeight` 496 vs `clientHeight` 32). On show, Chromium focused the first focusable element — the "Start microphone" button in the invisible panel — and scrolled it into view, pushing the compact stage to `y: -428.5`. The window was on screen and painting the whole time; only its content had been scrolled away. `overflow: clip` leaves no scroll container to move, and `inert` keeps focus out of a hidden stage.
- **Default change:** `--fixture` only took effect during capture runs, so `run.sh` injecting `--fixture smoke` did nothing and the panel always showed live sessions — the opposite of what the docs said. The flag now works on its own, `run.sh` defaults to live sessions, and `--fixture smoke` is the opt-in.

Reviewed as two commits; the fix stands alone in `ff3fc1d`.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — **passed** (repository checks, Biome, typecheck, 36 tests, build)
- macOS Electron verification (`./scripts/verify.sh`): `not run locally` — authored from a Linux workspace, so the macOS job in CI is the first full run. Behaviour was instead verified against a physical Mac over the DevTools protocol (below).

Measured on the live app, compact mode, before and after the fix:

```
before   rootScrollTop=428.5  activeElement=BUTTON.secondary-button  dotY=-416   visible=false
after    rootScrollTop=0      activeElement=BODY                     dotY=12.5   visible=true
```

Each guard was ablated independently to confirm what is load-bearing:

```
CONTROL (both guards removed)   scrollTop=428.5  dotY=-416   visible=false
overflow:clip ONLY (no inert)   scrollTop=0      dotY=12.5   visible=true
inert ONLY (overflow:hidden)    scrollTop=0      dotY=12.5   visible=true
both (shipped)                  scrollTop=0      dotY=12.5   visible=true
```

Either guard alone fixes the scroll. Both ship: `overflow: clip` is the structural
guarantee, and `inert` additionally stops a hidden button from holding keyboard
focus inside `aria-hidden="true"`.

Both launch modes after the change:

```
./scripts/run.sh                  badge "LIVE"             indicator unknown    4 live sessions
./scripts/run.sh --fixture smoke  badge "FIXTURE · SMOKE"  indicator attention  3 fixture sessions
```

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31558048580/artifacts/9126685812) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31558048580)

- Commit: `c2bc6580c10b12047cb8223482fefa100b6558b9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` — see note below
- Physical-notch check: `performed` — capsule confirmed visible beside the notch on hardware after the fix, and confirmed absent before it
- Device/display configuration: 16-inch MacBook Pro, macOS 26.3, 1728x1117 @2x, Dark Mode. AppKit reports `safeAreaTop: 32`, `notchWidth: 185`; notch spans x 771–956pt, and the indicator lands at x 974.5–981.5, 18.5pt clear of the housing.

## Notes

- **The deterministic evidence PNGs cannot demonstrate this fix.** Capture runs never call `show()`, so they never triggered the focus-driven scroll — the compact evidence screenshot looked correct throughout, before and after. Expect `app-smoke-compact.png` to be unchanged; it is not a regression signal here, and it is why the bug survived the existing visual-evidence gate. Worth considering whether a capture path that shows the window would be a useful follow-up.
- Two adjacent behaviours were deliberately left alone to keep this focused: the muted `unknown` indicator colour (`rgba(255,255,255,0.42)`), now the common state since live is the default; and a second `run.sh` while one is running still silently quits and flips the running instance to expanded, hiding the capsule.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a9d4d316-85d9-4e36-b4c6-d82a5c8b2cb7)
