### PR TITLE
fix: re-assert the panel instead of expanding on relaunch

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -383,9 +383,26 @@ function handleDisplayChange(): void {
 }
 
 if (!app.requestSingleInstanceLock()) {
+  // Luke runs as an accessory app, so a second launch otherwise exits silently
+  // and looks like the launcher did nothing.
+  process.stderr.write(
+    "Luke is already running; the existing panel was refreshed instead of starting a second copy.\n",
+  );
   app.quit();
 } else {
-  app.on("second-instance", () => setWindowMode("expanded", true));
+  // A repeat launch is usually someone checking the notch capsule, so re-assert
+  // the panel where it already is. Expanding hides the compact capsule, which is
+  // the one thing the relaunch was meant to show. An explicit `--expanded` is a
+  // stated intent rather than a side effect, so it is still honoured.
+  app.on("second-instance", (_event, argv) => {
+    refreshNativeGeometry();
+    if (argv.includes("--expanded")) {
+      setWindowMode("expanded", true);
+      return;
+    }
+    positionPanel();
+    if (panelWindow && !panelWindow.isDestroyed()) panelWindow.showInactive();
+  });
   void app.whenReady().then(() => {
     if (process.platform === "darwin") app.setActivationPolicy("accessory");
     Menu.setApplicationMenu(null);


### PR DESCRIPTION
## Summary

Launching Luke while it is already running made the second process fail `requestSingleInstanceLock()` and `app.quit()` with no output, while the *running* instance ran `setWindowMode("expanded", true)`. The terminal returned immediately with exit 0, so it read as "`run.sh` opened the app in expanded mode" — and expanding hides the compact capsule, which is usually the whole reason for relaunching.

It is easy to hit because Luke is nearly invisible while running: the accessory activation policy leaves no Dock icon and no app-switcher entry, and the only on-screen trace is a 7px indicator dot beside the notch. There is no natural signal that an instance is already up.

A repeat launch now re-reads display geometry and re-asserts the panel in its current mode, and the process that loses the lock says why it exited. An explicit `--expanded` is a stated intent rather than a side effect, so it still expands.

Follow-up to #10, which is where this behaviour was first observed — it repeatedly confused the debugging of that bug.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — **passed** (repository checks, Biome, typecheck, 36 tests, build)
- macOS Electron verification (`./scripts/verify.sh`): `not run locally` — authored from a Linux workspace, so the macOS job in CI is the first full run. Behaviour was verified against a physical Mac by reading window bounds from the window server (below).

Window-server bounds for the Luke panel, before and after, on hardware:

```
                              before            after
fresh ./scripts/run.sh        257x32 compact    257x32 compact
./scripts/run.sh again        620x520 EXPANDED  257x32 compact
./scripts/run.sh --expanded   620x520 expanded  620x520 expanded
```

The second launch also now prints, instead of exiting silently:

```
Luke is already running; the existing panel was refreshed instead of starting a second copy.
```

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31558665151/artifacts/9126920362) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31558665151)

- Commit: `b1199edc5e283bcf4dced9b8339677a9303eb4f4`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` — the change is a window-mode transition rather than an appearance change, and it is captured exactly by the window bounds above
- Physical-notch check: `performed` — all three cases exercised on hardware; the capsule stays beside the notch across a repeat launch
- Device/display configuration: 16-inch MacBook Pro, macOS 26.3, 1728x1117 @2x. AppKit reports `safeAreaTop: 32`, `notchWidth: 185`

## Notes

- The deterministic evidence PNGs cannot exercise this path: capture runs quit after writing their screenshot and never take a second-instance event, so expect `artifacts/evidence/` to be unchanged.
- No test covers this. It lives in Electron `app` lifecycle wiring in `main.ts`, which has no harness in this repo — the cheapest layer that would have caught it is a macOS launch test that does not exist yet. Called out rather than left implicit.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a9d4d316-85d9-4e36-b4c6-d82a5c8b2cb7)
