### PR TITLE
fix: let the session list scroll instead of cutting off the footer

### DIFF
--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -438,34 +438,40 @@ function App(): React.JSX.Element {
             </div>
           </header>
 
-          <div className="summary-row">
-            <div>
-              <p className="eyebrow">Notch sidecar</p>
-              <h1>Agent activity</h1>
-              <p className="subtle">
-                {bootstrap.fixtureMode
-                  ? "Synthetic sessions · no credentials or live transcripts"
-                  : "Live sessions · no credentials or transcripts retained"}
-              </p>
+          {/* The panel is a fixed 620x520 box, so the body is the one region
+              allowed to scroll. Keeping the header and footer outside it means
+              the microphone state and the controls that act on it can never be
+              pushed off screen by a long session list. */}
+          <div className="panel-body">
+            <div className="summary-row">
+              <div>
+                <p className="eyebrow">Notch sidecar</p>
+                <h1>Agent activity</h1>
+                <p className="subtle">
+                  {bootstrap.fixtureMode
+                    ? "Synthetic sessions · no credentials or live transcripts"
+                    : "Live sessions · no credentials or transcripts retained"}
+                </p>
+              </div>
+              <span className="fixture-badge">
+                {hasLiveSessions ? "LIVE" : bootstrap.fixtureMode ? "FIXTURE · SMOKE" : "IDLE"}
+              </span>
             </div>
-            <span className="fixture-badge">
-              {hasLiveSessions ? "LIVE" : bootstrap.fixtureMode ? "FIXTURE · SMOKE" : "IDLE"}
-            </span>
-          </div>
 
-          <div className="session-list">
-            {visibleSessions.map((item) => (
-              <article className="session-row" key={item.id}>
-                <span className={`status-mark ${item.state}`} />
-                <span className="session-copy">
-                  <strong>{item.title}</strong>
-                  <small>
-                    {item.provider} · {item.detail}
-                  </small>
-                </span>
-                <span className={`session-status ${item.state}`}>{item.label}</span>
-              </article>
-            ))}
+            <div className="session-list">
+              {visibleSessions.map((item) => (
+                <article className="session-row" key={item.id}>
+                  <span className={`status-mark ${item.state}`} />
+                  <span className="session-copy">
+                    <strong>{item.title}</strong>
+                    <small>
+                      {item.provider} · {item.detail}
+                    </small>
+                  </span>
+                  <span className={`session-status ${item.state}`}>{item.label}</span>
+                </article>
+              ))}
+            </div>
           </div>
 
           <footer className="panel-footer">

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -197,6 +197,25 @@ button {
   background: #000;
 }
 
+/* The one scroll container in the app. The root stays `overflow: clip` so a
+   focus or scrollIntoView can never drag the notch capsule out of view; this
+   keeps that guarantee while letting a long session list scroll instead of
+   being silently cut off.
+   `min-height: 0` is what actually permits it: a flex child defaults to its
+   content size and would otherwise push the footer past the panel. */
+.panel-body {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 14px;
+  overflow-x: clip;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
+  scrollbar-width: thin;
+}
+
 .panel-header,
 .summary-row,
 .panel-footer,
@@ -204,6 +223,11 @@ button {
 .diagnostics {
   display: flex;
   align-items: center;
+}
+
+.panel-header,
+.panel-footer {
+  flex: none;
 }
 
 .panel-header,
@@ -278,15 +302,18 @@ h1 {
 
 .session-list {
   display: flex;
-  flex: 1;
+  flex: none;
   flex-direction: column;
   gap: 8px;
 }
 
+/* Rows take their natural height rather than sharing the panel between them.
+   Stretching was fine when the list owned all the leftover space; inside a
+   scrolling body it would make three sessions look different from ten. */
 .session-row {
   display: flex;
   min-height: 62px;
-  flex: 1;
+  flex: none;
   align-items: center;
   gap: 13px;
   padding: 0 15px;


### PR DESCRIPTION
## Summary

- Make the panel body between the header and footer the one scroll container in the app, so a long session list scrolls instead of pushing the footer out of a fixed-size panel.
- Keep the header and footer out of that scroll region, so microphone state and the controls that act on it stay on screen at any session count.
- Give session rows their natural height instead of sharing the panel between them.

## The bug

The expanded panel is a fixed 620x520 box with `overflow: hidden`. The session list grows with however many sessions a developer is running, and past four it pushed the footer out of the panel. Nothing could scroll it back: the root is deliberately `overflow: clip`, because `hidden` would leave a scroll container that a focus or `scrollIntoView` can use to drag the notch capsule out of view while compact.

Five observed sessions was enough to put the microphone permission readout, "Start microphone", and "Quit" out of reach — well within what Luke is for.

## Why the body and not the root

`overflow: clip` on the root is load-bearing and stays. The new scroll container is scoped to the panel body and carries `overscroll-behavior: contain`, so it cannot chain a scroll up to the root and reintroduce the problem that comment is guarding against. `min-height: 0` is what actually lets it scroll — a flex child defaults to its content size and would otherwise keep pushing the footer down.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed — lint, 3 typecheck projects, 62 tests (5 harness, 31 core, 26 desktop), all builds
- macOS Electron verification (`./scripts/verify.sh`): not run — this Linux workspace cannot package the macOS app; CI's macOS app/evidence job covers it
- Layout measured against the real `styles.css` at 620x520 in headless Chrome, before and after, across session counts. `footerCutOffBy` is how far the footer sits below the panel's bottom edge in pixels; `lastRowReachable` scrolls the body to its end first and then asks whether the final row is in view.

Before:

```
sessions= 3: footerCutOffBy=0    startReachable=true
sessions= 4: footerCutOffBy=0    startReachable=true
sessions= 5: footerCutOffBy=60   startReachable=false
sessions= 6: footerCutOffBy=130  startReachable=false
sessions= 8: footerCutOffBy=270  startReachable=false
sessions=12: footerCutOffBy=550  startReachable=false
```

After:

```
sessions= 3: footerCutOffBy=0 startReachable=true scrollable=false lastRowReachable=true
sessions= 4: footerCutOffBy=0 startReachable=true scrollable=true  lastRowReachable=true
sessions= 5: footerCutOffBy=0 startReachable=true scrollable=true  lastRowReachable=true
sessions= 6: footerCutOffBy=0 startReachable=true scrollable=true  lastRowReachable=true
sessions= 8: footerCutOffBy=0 startReachable=true scrollable=true  lastRowReachable=true
sessions=12: footerCutOffBy=0 startReachable=true scrollable=true  lastRowReachable=true
```

That measurement is Chrome rendering the real stylesheet, not the packaged Electron app. It establishes the CSS math and the regression threshold; it does not replace looking at the app.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31628581278/artifacts/9154127542) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31628581278)

- Commit: `20bb11e448cb6adcabeed569349e74546c693d6a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- The fixture scenario has three sessions, so the deterministic evidence screenshots are unchanged by this fix. The CI PNGs are worth an eye anyway, since the flex changes touch how rows are sized at counts the fixture does not cover.
- This is a precursor to #12, which adds a voice panel below the session list and hits the same ceiling much sooner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b9ea26e4-2805-4d46-aa54-7e8d22c9b70d)
