### PR TITLE
fix(run): replace the running instance instead of refreshing it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,9 @@ Canonical commands:
 - `./scripts/check.sh` — run portable repository, type, test, and build checks
 - `./scripts/test-macos.sh` — package and validate the macOS app
 - `./scripts/verify.sh` — complete macOS validation plus visual evidence
-- `./scripts/run.sh` — launch the app against live sessions (`--fixture smoke` for fixture data)
+- `./scripts/run.sh` — launch the app against live sessions, replacing any
+  running instance (`--fixture smoke` for fixture data, `--keep-running` to keep
+  the running instance)
 - `./scripts/evidence.sh` — write the fixture PNG under `artifacts/`
 - `pnpm evidence:record` — record the fixture transition on a physical Mac
 - `pnpm lint:fix` — apply repository formatting and safe lint fixes

--- a/README.md
+++ b/README.md
@@ -36,7 +36,15 @@ pnpm --filter @luke/web dev
 Use `./scripts/run.sh --profile speaking` to preview the deterministic waveform
 to the left of the notch without requesting microphone access.
 
-The run command directly owns the Electron process, so Control-C stops it.
+The run command directly owns the Electron process, so Control-C stops it. It
+also replaces an instance that is already running: Electron's single-instance
+lock belongs to the older process, so without this the newer launch would quit
+on startup and leave the previous build on screen. That lock is keyed on the app
+name, which every checkout shares, so the replaced instance can be one launched
+from a different worktree; it is named on stdout before it is stopped. Pass
+`--keep-running` to leave a running instance in place, which re-asserts its
+panel instead of starting a new one.
+
 `verify.sh` packages the desktop app and writes deterministic visual evidence to
 `artifacts/evidence/app-smoke-expanded.png`,
 `artifacts/evidence/app-smoke-compact.png`, and

--- a/scripts/lib/workspace.sh
+++ b/scripts/lib/workspace.sh
@@ -30,6 +30,78 @@ sidecar_require_command() {
     fi
 }
 
+sidecar_wait_for_exit() {
+    local deadline=$((SECONDS + $1))
+    local pid=$2
+    while ((SECONDS < deadline)); do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            return 0
+        fi
+        sleep 0.2
+    done
+    return 1
+}
+
+# Electron writes its single-instance lock into the user-data directory and names
+# the holder `<hostname>-<pid>`, so the process that blocks a launch identifies
+# itself. That is the process to replace even when it belongs to another
+# worktree: the lock is keyed on the app name, which every checkout shares.
+sidecar_app_lock_holder_pid() {
+    local app_name
+    if ! app_name=$(cd "$SIDECAR_DESKTOP_APP_ROOT" && node -p 'require("./package.json").name'); then
+        printf 'error: could not read the desktop app name\n' >&2
+        return 1
+    fi
+
+    local lock_target
+    lock_target=$(readlink "$HOME/Library/Application Support/$app_name/SingletonLock" 2>/dev/null || true)
+    # Hostnames contain hyphens, so the pid is what follows the last one.
+    local pid=${lock_target##*-}
+    if [[ ! $pid =~ ^[0-9]+$ ]] || ! kill -0 "$pid" 2>/dev/null; then
+        # No lock, or a stale one whose holder is gone: Electron reclaims it.
+        return 0
+    fi
+
+    # A stale lock can name a pid that has since been reused, so a holder that is
+    # not an Electron app is reported rather than signalled.
+    local command_line
+    command_line=$(ps -o command= -p "$pid" 2>/dev/null || true)
+    case $command_line in
+    */Electron.app/Contents/MacOS/Electron* | */Luke.app/Contents/MacOS/Luke*)
+        printf '%s\n' "$pid"
+        ;;
+    *)
+        printf 'error: pid %s holds the Luke lock but is not Luke: %s\n' "$pid" "$command_line" >&2
+        return 1
+        ;;
+    esac
+}
+
+# Stopping the holder has to wait for it to exit, because the lock is released
+# as that process goes away rather than when it is signalled.
+sidecar_stop_running_app() {
+    local pid
+    pid=$(sidecar_app_lock_holder_pid) || return 1
+    if [[ -z $pid ]]; then
+        return 0
+    fi
+
+    # The path tells you which checkout the older instance came from.
+    printf 'Stopping the running Luke instance (pid %s: %s)\n' "$pid" "$(ps -o comm= -p "$pid")"
+    kill "$pid" 2>/dev/null || true
+    if sidecar_wait_for_exit 5 "$pid"; then
+        return 0
+    fi
+
+    kill -KILL "$pid" 2>/dev/null || true
+    if sidecar_wait_for_exit 3 "$pid"; then
+        return 0
+    fi
+
+    printf 'error: the running Luke instance did not exit; quit it and retry\n' >&2
+    return 1
+}
+
 sidecar_require_macos() {
     if [[ $(uname -s) != Darwin ]]; then
         printf 'error: this command requires macOS\n' >&2

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -11,6 +11,26 @@ if [[ ! -x "$SIDECAR_ELECTRON_BIN" ]]; then
     "$SCRIPT_DIRECTORY/bootstrap.sh"
 fi
 
+# Running this script means "launch the build I just made", so an already-running
+# instance is replaced rather than left in place. `--keep-running` opts out: the
+# new launch then quits on startup and only re-asserts the running panel. Every
+# other argument is forwarded to Electron.
+replace_running_app=true
+remaining_arguments=$#
+while ((remaining_arguments-- > 0)); do
+    argument=$1
+    shift
+    if [[ $argument == --keep-running ]]; then
+        replace_running_app=false
+        continue
+    fi
+    set -- "$@" "$argument"
+done
+
+if [[ $replace_running_app == true ]]; then
+    sidecar_stop_running_app
+fi
+
 # Live sessions are the default. Pass `--fixture smoke` for deterministic data;
 # the app honours it on its own, so nothing needs injecting here.
 cd "$SIDECAR_REPO_ROOT"


### PR DESCRIPTION
## Summary

- `./scripts/run.sh` rebuilds the app and then launches Electron, but a running instance owns the single-instance lock, so the new process quits on startup and only nudges the old one — it re-reads display geometry and re-asserts the panel. The freshly built code never runs, which reads as the launcher doing nothing.
- The script now stops the instance that holds the lock and waits for it to exit, because the lock is released as that process goes away rather than when it is signalled. `--keep-running` opts out and keeps the re-assert behaviour.
- The holder is identified from Electron's own lock file (`SingletonLock`, a symlink named `<hostname>-<pid>`) rather than by matching process names. That is exact, and it covers the case a name match would miss: the lock is keyed on the app name, so a Luke launched from any worktree blocks every other checkout, and that is the process a relaunch has to replace. A stale lock can name a pid that has since been reused, so a holder that is not an Electron app is reported instead of signalled.
- No app code changes: `apps/` is untouched.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — passed (repository contract checks passed; biome checked 48 files, no fixes; 0 test failures; builds clean)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — no app-code change, and `verify.sh` packages and screenshots the app without exercising `run.sh`, so it cannot cover this change. CI runs it.

Behaviour of the new helper was exercised against stand-in processes, covering every path:

| Case | Result |
| --- | --- |
| No lock file | no-op, exit 0 |
| Lock naming a dead pid (stale) | no-op, exit 0 — Electron reclaims it |
| Lock naming a live pid that is not Luke | refuses, exit 1, process left alone |
| Lock naming a live Electron main process | stopped, exit 0 |
| Holder ignoring `SIGTERM` | escalates to `SIGKILL` after 5s, exit 0 |

Argument handling: `--keep-running` is consumed and every other argument is forwarded to Electron with order and quoting preserved.

The lookup was also dry-run (read-only) against a real Luke running on macOS: the app name resolved to `@luke/desktop`, `SingletonLock` parsed to a live pid, `ps` confirmed the Electron identity check matches, and the verdict was "would stop pid 3313". That instance belonged to a *different* Conductor workspace than the one launching — the case that motivated identifying the holder by lock file rather than by process path.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31630151480/artifacts/9154745641) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31630151480)

- Commit: `31701fae0bfa2d465b74a32a7fd49ca595d8b78d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` — no UI change
- Physical-notch check: `not performed` — no window geometry or appearance change
- Device/display configuration: `not recorded`

## Notes

- Not verified: a real launch on macOS end-to-end (stop the live instance, then start the new build). The sandbox is Linux, so the pieces were verified separately — lock resolution and the identity check against the real running instance, and stop/wait/escalate against stand-in processes.
- The old instance is stopped before `pnpm start` builds, so a failing build leaves nothing running. Building first would keep the old panel up until the new one is ready, but means duplicating the desktop `start` pipeline into `run.sh` or running `swiftc` twice, since `build:native` has no caching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/baa3e6fd-2a3f-40d3-8b7e-be94a7862181)
