### PR TITLE
feat(LUKE-55): observe Conductor cloud sessions via a settings-managed API key

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,10 @@ Trust constraints:
 - Never write provider transcripts or session-state files.
 - Never inject terminal input, simulate keystrokes, or request Accessibility.
 - Product behavior must not require provider MCP, plugins, hooks, wrappers,
-  credentials, or live sessions.
+  credentials, or live sessions. A provider whose sessions exist only in a cloud
+  service may read a user-supplied API key, but it must observe nothing until
+  the user supplies one, must never write through that credential, and must
+  leave every other provider working without it.
 - Keep unsupported capabilities explicit; do not invent fallback controls.
 - Keep Electron renderers sandboxed with context isolation and narrow IPC.
 - Commit only synthetic, redacted fixtures and repository-relative paths.

--- a/README.md
+++ b/README.md
@@ -63,8 +63,18 @@ camera housing. Macs and external displays without a notch use the same
 top-center attachment with no invented hardware geometry.
 
 The evidence mode uses synthetic fixture data. Live mode passively observes
-bounded coding-agent session metadata without requiring provider credentials,
-plugins, hooks, wrappers, live-session changes, or transcript retention.
+bounded coding-agent session metadata without requiring provider plugins, hooks,
+wrappers, live-session changes, or transcript retention.
+
+Claude Code and Codex sessions are observed from local provider state and need
+no configuration. Conductor cloud sessions have no local state to read, so that
+provider stays silent until you open the expanded panel, choose **Settings**,
+and paste a Conductor API key; Luke also accepts one from `CONDUCTOR_API_KEY` or
+`CONDUCTOR_API_TOKEN`. A key you enter is encrypted with `safeStorage`, whose
+key comes from the login Keychain, and it is never returned to the renderer.
+Luke reads only cloud workspaces you created, issues only read requests, and
+labels each session by its repository rather than by a Conductor workspace or
+session name, because those names are generated from the opening prompt.
 
 ## Attention intelligence
 

--- a/apps/desktop/src/cloud-session-adapter.ts
+++ b/apps/desktop/src/cloud-session-adapter.ts
@@ -161,6 +161,7 @@ export abstract class CloudSessionAdapter implements SessionProviderAdapter {
   #credential: string | undefined;
   #observations: readonly ProviderSessionObservation[] = [];
   #lastAttemptAt = Number.NEGATIVE_INFINITY;
+  #collectPass = 0;
 
   constructor(profile: CloudAdapterProfile, options: CloudAdapterOptions) {
     this.provider = profile.provider;
@@ -195,14 +196,24 @@ export abstract class CloudSessionAdapter implements SessionProviderAdapter {
     }
     this.#lastAttemptAt = now;
 
+    // Observers can overlap: a settings save refreshes this adapter while a
+    // timer-driven pass is still in flight with the key it replaced. Only the
+    // newest pass may write, or sessions read as one credential would be
+    // served as another's until the next refresh.
+    const pass = ++this.#collectPass;
     try {
-      this.#observations = uniqueObservations(
-        await this.collect((segments, query) => this.#requestJson(apiKey, segments, query), now),
-      );
+      const collected = await this.collect(this.#requestForPass(pass, apiKey), now);
+      if (pass === this.#collectPass) this.#observations = uniqueObservations(collected);
     } catch (error) {
       // A rejected credential clears observed state; a transient network or
-      // server failure keeps the previous snapshot until the next attempt.
-      if (error instanceof CloudRequestError && error.failure === CLOUD_FAILURE.UNAUTHORIZED) {
+      // server failure keeps the previous snapshot until the next attempt. A
+      // superseded pass reports on a credential that no longer stands, so its
+      // rejection says nothing about the current one.
+      if (
+        pass === this.#collectPass &&
+        error instanceof CloudRequestError &&
+        error.failure === CLOUD_FAILURE.UNAUTHORIZED
+      ) {
         this.#forgetObservedState();
       }
     }
@@ -252,8 +263,35 @@ export abstract class CloudSessionAdapter implements SessionProviderAdapter {
   }
 
   #forgetObservedState(): void {
+    // A pass still in flight was started under a credential that no longer
+    // stands, so its result must not land.
+    this.#collectPass += 1;
     this.forgetCachedIdentity();
     this.#observations = [];
+  }
+
+  /**
+   * Binds one pass's requests to the credential it started with. A superseded
+   * pass fails instead of issuing another request with a replaced key, and
+   * whatever a request already read is discarded before a subclass can cache
+   * it over state that belongs to the new credential.
+   */
+  #requestForPass(pass: number, apiKey: string): CloudRequest {
+    return async (segments, query) => {
+      this.#assertPassCurrent(pass);
+      const body = await this.#requestJson(apiKey, segments, query);
+      this.#assertPassCurrent(pass);
+      return body;
+    };
+  }
+
+  #assertPassCurrent(pass: number): void {
+    if (pass !== this.#collectPass) {
+      throw new CloudRequestError(
+        CLOUD_FAILURE.TRANSIENT,
+        `${this.provider.displayName} pass was superseded`,
+      );
+    }
   }
 
   #url(segments: readonly string[], query: Readonly<Record<string, string>>): string {

--- a/apps/desktop/src/cloud-session-adapter.ts
+++ b/apps/desktop/src/cloud-session-adapter.ts
@@ -1,0 +1,328 @@
+import {
+  type ProviderSessionObservation,
+  SESSION_STATUS,
+  type SessionProvider,
+  type SessionProviderAdapter,
+  type SessionStatus,
+} from "@sidecar/core";
+
+const UNKNOWN_REPOSITORY_LABEL = "workspace";
+const GIT_SUFFIX = ".git";
+
+const HTTP_METHOD = {
+  GET: "GET",
+} as const;
+
+const HTTP_STATUS = {
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+} as const;
+
+export const CLOUD_FAILURE = {
+  UNAUTHORIZED: "unauthorized",
+  TRANSIENT: "transient",
+} as const;
+
+export type CloudFailure = (typeof CLOUD_FAILURE)[keyof typeof CLOUD_FAILURE];
+
+/**
+ * Shared bounds for every cloud provider. They match the local adapters so a
+ * session reads the same whether Luke observed it on disk or over the network.
+ */
+export const CLOUD_ADAPTER_DEFAULTS = {
+  MAXIMUM_SESSION_AGE_MS: 24 * 60 * 60 * 1000,
+  ACTIVE_SESSION_FRESHNESS_MS: 15 * 60 * 1000,
+  MINIMUM_REFRESH_INTERVAL_MS: 15 * 1000,
+  REQUEST_TIMEOUT_MS: 8 * 1000,
+} as const;
+
+export type CloudFetch = (url: string, init: RequestInit) => Promise<Response>;
+
+export class CloudRequestError extends Error {
+  readonly failure: CloudFailure;
+
+  constructor(failure: CloudFailure, message: string) {
+    super(message);
+    this.name = "CloudRequestError";
+    this.failure = failure;
+  }
+}
+
+export interface CloudAdapterOptions {
+  /** Resolves the credential at observation time so a settings change applies immediately. */
+  readApiKey: () => Promise<string | undefined>;
+  baseUrl?: string;
+  fetch?: CloudFetch;
+  now?: () => number;
+  minimumRefreshIntervalMs?: number;
+}
+
+/** The provider-specific identity and endpoint a subclass supplies once. */
+export interface CloudAdapterProfile {
+  provider: SessionProvider;
+  defaultBaseUrl: string;
+  baseUrlEnvironmentVariable?: string;
+}
+
+/**
+ * The only way a subclass reaches its provider. It authenticates, bounds, and
+ * parses the request, and it can express nothing but a read, so no adapter
+ * built on it can change provider state.
+ */
+export type CloudRequest = (
+  segments: readonly string[],
+  query?: Readonly<Record<string, string>>,
+) => Promise<Record<string, unknown>>;
+
+export function positiveInteger(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) return fallback;
+  return Math.floor(value);
+}
+
+export function nonNegativeNumber(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value < 0) return fallback;
+  return value;
+}
+
+export function isDefined<Value>(value: Value | undefined): value is Value {
+  return value !== undefined;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function textFromRecord(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  const normalized = typeof value === "string" ? value.trim() : "";
+  return normalized || undefined;
+}
+
+export function timestampFromRecord(
+  record: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const value = textFromRecord(record, key);
+  if (!value) return undefined;
+  const timestampMs = Date.parse(value);
+  return Number.isFinite(timestampMs) ? timestampMs : undefined;
+}
+
+/** Reads a list page without assuming which key a given provider wraps it in. */
+export function recordsFromPage(
+  body: Record<string, unknown>,
+  key: string,
+): Record<string, unknown>[] {
+  const data = body[key];
+  return Array.isArray(data) ? data.filter(isRecord) : [];
+}
+
+/**
+ * Luke labels a session by its repository, never by a workspace, agent, or
+ * session name. Cloud providers derive those names from the opening prompt, so
+ * they are transcript content that no adapter may surface.
+ */
+export function repositoryLabel(
+  gitRemote: string | undefined,
+  fallbackName: string | undefined,
+): string {
+  const remote = gitRemote?.trim().replace(/\/+$/, "");
+  const lastSegment = remote?.split(/[/:]/).pop()?.trim();
+  const repository = lastSegment?.endsWith(GIT_SUFFIX)
+    ? lastSegment.slice(0, -GIT_SUFFIX.length)
+    : lastSegment;
+  return repository || fallbackName?.trim() || UNKNOWN_REPOSITORY_LABEL;
+}
+
+const defaultFetch: CloudFetch = (url, init) => fetch(url, init);
+
+function resolveBaseUrl(profile: CloudAdapterProfile, configured: string | undefined): string {
+  const fromEnvironment = profile.baseUrlEnvironmentVariable
+    ? process.env[profile.baseUrlEnvironmentVariable]?.trim()
+    : undefined;
+  return configured?.trim() || fromEnvironment || profile.defaultBaseUrl;
+}
+
+/**
+ * The shared half of every cloud provider adapter: credential handling, its own
+ * refresh cadence, the failure rules that decide whether a snapshot survives,
+ * and bounded read-only requests. A subclass supplies only the provider's
+ * routes and how its reported state maps onto Luke's.
+ */
+export abstract class CloudSessionAdapter implements SessionProviderAdapter {
+  readonly provider: SessionProvider;
+
+  readonly #readApiKey: () => Promise<string | undefined>;
+  readonly #baseUrl: string;
+  readonly #fetch: CloudFetch;
+  readonly #now: () => number;
+  readonly #minimumRefreshIntervalMs: number;
+
+  #credential: string | undefined;
+  #observations: readonly ProviderSessionObservation[] = [];
+  #lastAttemptAt = Number.NEGATIVE_INFINITY;
+
+  constructor(profile: CloudAdapterProfile, options: CloudAdapterOptions) {
+    this.provider = profile.provider;
+    this.#readApiKey = options.readApiKey;
+    this.#baseUrl = resolveBaseUrl(profile, options.baseUrl);
+    this.#fetch = options.fetch ?? defaultFetch;
+    this.#now = options.now ?? Date.now;
+    this.#minimumRefreshIntervalMs = nonNegativeNumber(
+      options.minimumRefreshIntervalMs,
+      CLOUD_ADAPTER_DEFAULTS.MINIMUM_REFRESH_INTERVAL_MS,
+    );
+  }
+
+  async observe(): Promise<readonly ProviderSessionObservation[]> {
+    // One observer must never abort the shared refresh pass, so a settings read
+    // that fails is treated the same as having no credential at all.
+    const apiKey = await this.#readApiKey().catch(() => undefined);
+    if (!apiKey) {
+      this.#credential = undefined;
+      this.#forgetObservedState();
+      return this.#observations;
+    }
+
+    const now = this.#now();
+    if (apiKey === this.#credential) {
+      // A network provider refreshes on its own cadence instead of on every
+      // tick of the shared observation timer.
+      if (now - this.#lastAttemptAt < this.#minimumRefreshIntervalMs) return this.#observations;
+    } else {
+      this.#credential = apiKey;
+      this.#forgetObservedState();
+    }
+    this.#lastAttemptAt = now;
+
+    try {
+      this.#observations = uniqueObservations(
+        await this.collect((segments, query) => this.#requestJson(apiKey, segments, query), now),
+      );
+    } catch (error) {
+      // A rejected credential clears observed state; a transient network or
+      // server failure keeps the previous snapshot until the next attempt.
+      if (error instanceof CloudRequestError && error.failure === CLOUD_FAILURE.UNAUTHORIZED) {
+        this.#forgetObservedState();
+      }
+    }
+    return this.#observations;
+  }
+
+  /** Runs one authenticated pass. Duplicate session ids are dropped by the base. */
+  protected abstract collect(
+    request: CloudRequest,
+    now: number,
+  ): Promise<readonly ProviderSessionObservation[]>;
+
+  /**
+   * Clears anything a subclass cached across passes. It runs whenever the
+   * credential changes or is rejected, so nothing read as one user can be
+   * reported as another.
+   */
+  protected forgetCachedIdentity(): void {}
+
+  /**
+   * Holds a status only while its timestamp is recent. Luke cannot tell a turn
+   * that just finished from a chat abandoned hours ago once a session goes
+   * stale, and reporting the stale state would speak at the wrong moment.
+   */
+  protected statusWhileRecent(
+    status: SessionStatus,
+    observedAt: number,
+    now: number,
+  ): SessionStatus {
+    return now - observedAt <= CLOUD_ADAPTER_DEFAULTS.ACTIVE_SESSION_FRESHNESS_MS
+      ? status
+      : SESSION_STATUS.UNKNOWN;
+  }
+
+  /** Keeps one failed resource from discarding an otherwise complete pass. */
+  protected async tolerateItemFailure<Result>(
+    operation: () => Promise<Result>,
+  ): Promise<Result | undefined> {
+    try {
+      return await operation();
+    } catch (error) {
+      if (error instanceof CloudRequestError && error.failure === CLOUD_FAILURE.UNAUTHORIZED) {
+        throw error;
+      }
+      return undefined;
+    }
+  }
+
+  #forgetObservedState(): void {
+    this.forgetCachedIdentity();
+    this.#observations = [];
+  }
+
+  #url(segments: readonly string[], query: Readonly<Record<string, string>>): string {
+    const url = new URL(this.#baseUrl);
+    url.pathname = `/${segments.map((segment) => encodeURIComponent(segment)).join("/")}`;
+    for (const [name, value] of Object.entries(query)) url.searchParams.set(name, value);
+    return url.href;
+  }
+
+  async #requestJson(
+    apiKey: string,
+    segments: readonly string[],
+    query: Readonly<Record<string, string>> = {},
+  ): Promise<Record<string, unknown>> {
+    const name = this.provider.displayName;
+    let response: Response;
+    try {
+      response = await this.#fetch(this.#url(segments, query), {
+        method: HTTP_METHOD.GET,
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          Accept: "application/json",
+        },
+        signal: AbortSignal.timeout(CLOUD_ADAPTER_DEFAULTS.REQUEST_TIMEOUT_MS),
+      });
+    } catch {
+      throw new CloudRequestError(CLOUD_FAILURE.TRANSIENT, `${name} request failed`);
+    }
+
+    if (response.status === HTTP_STATUS.UNAUTHORIZED || response.status === HTTP_STATUS.FORBIDDEN) {
+      throw new CloudRequestError(
+        CLOUD_FAILURE.UNAUTHORIZED,
+        `${name} rejected the configured API key`,
+      );
+    }
+    if (!response.ok) {
+      throw new CloudRequestError(
+        CLOUD_FAILURE.TRANSIENT,
+        `${name} responded with status ${response.status}`,
+      );
+    }
+
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch {
+      throw new CloudRequestError(
+        CLOUD_FAILURE.TRANSIENT,
+        `${name} returned an unreadable response`,
+      );
+    }
+    if (!isRecord(body)) {
+      throw new CloudRequestError(
+        CLOUD_FAILURE.TRANSIENT,
+        `${name} returned an unexpected response`,
+      );
+    }
+    return body;
+  }
+}
+
+function uniqueObservations(
+  observations: readonly ProviderSessionObservation[],
+): readonly ProviderSessionObservation[] {
+  const unique = new Map<string, ProviderSessionObservation>();
+  for (const observation of observations) {
+    if (!unique.has(observation.providerSessionId)) {
+      unique.set(observation.providerSessionId, observation);
+    }
+  }
+  return [...unique.values()];
+}

--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -116,6 +116,7 @@ interface ConductorSession {
   id: string;
   workspace: ConductorWorkspace;
   archived: boolean;
+  archivedAt?: number;
   model?: string;
 }
 
@@ -193,7 +194,7 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
     const sessions = (
       await Promise.all(
         workspaces.map((workspace) =>
-          this.tolerateItemFailure(() => this.#listSessions(request, workspace)),
+          this.tolerateItemFailure(() => this.#listSessions(request, workspace, now)),
         ),
       )
     )
@@ -264,6 +265,7 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
   async #listSessions(
     request: CloudRequest,
     workspace: ConductorWorkspace,
+    now: number,
   ): Promise<ConductorSession[]> {
     const body = await request(
       [
@@ -279,6 +281,7 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
         .map((record): ConductorSession | undefined => {
           const id = textFromRecord(record, CONDUCTOR_FIELD.ID);
           if (!id) return undefined;
+          const archivedAt = timestampFromRecord(record, CONDUCTOR_FIELD.ARCHIVED_AT);
           const model = (
             textFromRecord(record, CONDUCTOR_FIELD.RESOLVED_MODEL) ??
             textFromRecord(record, CONDUCTOR_FIELD.MODEL)
@@ -287,15 +290,27 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
             id,
             workspace,
             archived: textFromRecord(record, CONDUCTOR_FIELD.ARCHIVED_AT) !== undefined,
+            ...(archivedAt === undefined ? {} : { archivedAt }),
             ...(model ? { model } : {}),
           };
         })
         .filter(isDefined)
-        // Conductor reports no per-session timestamp until its status is read,
-        // so an open chat is preferred over a closed one and the rest of the
-        // workspace is left out. Capping here keeps one crowded workspace from
+        // A chat closed before the observation window opened is already
+        // outside it, so it must not spend budget a live session could hold.
+        .filter(
+          (session) =>
+            session.archivedAt === undefined ||
+            now - session.archivedAt <= CLOUD_ADAPTER_DEFAULTS.MAXIMUM_SESSION_AGE_MS,
+        )
+        // An open chat carries no timestamp until its status is read, so open
+        // chats are preferred over closed ones, then closed ones by how
+        // recently they closed. Capping here keeps one crowded workspace from
         // spending the whole session budget.
-        .sort((first, second) => Number(first.archived) - Number(second.archived))
+        .sort(
+          (first, second) =>
+            Number(first.archived) - Number(second.archived) ||
+            (second.archivedAt ?? 0) - (first.archivedAt ?? 0),
+        )
         .slice(0, CONDUCTOR_ADAPTER_DEFAULTS.MAXIMUM_SESSIONS_PER_WORKSPACE)
     );
   }
@@ -311,9 +326,11 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
       ? undefined
       : await this.tolerateItemFailure(() => this.#sessionStatus(request, session.id));
     // A workspace timestamp covers every chat in that workspace, so it would
-    // make chats a user left hours ago look like they just stopped. The session
-    // status carries the only per-session timestamp Conductor reports.
-    const observedAt = reported?.updatedAt ?? session.workspace.lastActivityAt;
+    // make chats a user left hours ago look like they just stopped. The status
+    // timestamp is per-session, and a closed chat's archive time is the moment
+    // it settled; the workspace timestamp is only the last resort.
+    const observedAt =
+      reported?.updatedAt ?? session.archivedAt ?? session.workspace.lastActivityAt;
     if (now - observedAt > CLOUD_ADAPTER_DEFAULTS.MAXIMUM_SESSION_AGE_MS) return undefined;
 
     const status = this.#statusFor(session, reported?.status, observedAt, now);

--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -1,0 +1,367 @@
+import {
+  type ProviderSessionObservation,
+  SESSION_STATUS,
+  type SessionProvider,
+  type SessionStatus,
+} from "@sidecar/core";
+import {
+  CLOUD_ADAPTER_DEFAULTS,
+  type CloudAdapterOptions,
+  type CloudRequest,
+  CloudSessionAdapter,
+  isDefined,
+  positiveInteger,
+  recordsFromPage,
+  repositoryLabel,
+  textFromRecord,
+  timestampFromRecord,
+} from "./cloud-session-adapter";
+
+const CONDUCTOR_PROVIDER_ID = "conductor";
+const CONDUCTOR_PROVIDER_NAME = "Conductor";
+
+const CONDUCTOR_ENVIRONMENT = {
+  API_URL: "CONDUCTOR_API_URL",
+} as const;
+
+const CONDUCTOR_DEFAULT_API_URL = "https://api.conductor.build";
+
+/** Read-only routes from the documented public API. Luke never calls a writer. */
+const CONDUCTOR_ROUTE = {
+  IDENTITY: ["me"],
+  PROJECTS: ["v0", "projects"],
+} as const;
+
+const CONDUCTOR_ROUTE_SEGMENT = {
+  SESSIONS: "sessions",
+  STATUS: "status",
+  V0: "v0",
+  WORKSPACES: "workspaces",
+} as const;
+
+const CONDUCTOR_QUERY = {
+  LIMIT: "limit",
+} as const;
+
+const CONDUCTOR_FIELD = {
+  ARCHIVED_AT: "archivedAt",
+  CREATED_AT: "createdAt",
+  CREATOR_ID: "creatorId",
+  DATA: "data",
+  GIT_REMOTE: "gitRemote",
+  ID: "id",
+  LAST_ACTIVITY_AT: "lastActivityAt",
+  MODEL: "model",
+  NAME: "name",
+  RESOLVED_MODEL: "resolvedModel",
+  STATUS: "status",
+  UPDATED_AT: "updatedAt",
+  USER_ID: "userId",
+} as const;
+
+const CONDUCTOR_SESSION_STATUS = {
+  IDLE: "idle",
+  WORKING: "working",
+  ERROR: "error",
+} as const;
+
+type ConductorSessionStatus =
+  (typeof CONDUCTOR_SESSION_STATUS)[keyof typeof CONDUCTOR_SESSION_STATUS];
+
+/**
+ * An idle Conductor session has finished its turn and is holding for the user,
+ * which is what Luke reports as waiting. A session the provider reports as
+ * errored is left unknown rather than promoted to a state Luke cannot verify.
+ */
+const SESSION_STATUS_BY_CONDUCTOR_STATUS: Readonly<Record<ConductorSessionStatus, SessionStatus>> =
+  {
+    [CONDUCTOR_SESSION_STATUS.IDLE]: SESSION_STATUS.WAITING,
+    [CONDUCTOR_SESSION_STATUS.WORKING]: SESSION_STATUS.WORKING,
+    [CONDUCTOR_SESSION_STATUS.ERROR]: SESSION_STATUS.UNKNOWN,
+  };
+
+const CONDUCTOR_ADAPTER_DEFAULTS = {
+  MAXIMUM_PROJECTS: 10,
+  WORKSPACE_PAGE_SIZE: 100,
+  MAXIMUM_OBSERVED_WORKSPACES: 8,
+  SESSION_PAGE_SIZE: 20,
+  MAXIMUM_SESSIONS_PER_WORKSPACE: 4,
+  MAXIMUM_OBSERVED_SESSIONS: 12,
+  MAXIMUM_MODEL_LABEL_LENGTH: 60,
+} as const;
+
+export const CONDUCTOR_PROVIDER: SessionProvider = {
+  id: CONDUCTOR_PROVIDER_ID,
+  displayName: CONDUCTOR_PROVIDER_NAME,
+};
+
+export interface ConductorAdapterOptions extends CloudAdapterOptions {
+  maximumObservedWorkspaces?: number;
+  maximumObservedSessions?: number;
+}
+
+interface ConductorProject {
+  id: string;
+  repositoryLabel: string;
+}
+
+interface ConductorWorkspace {
+  id: string;
+  repositoryLabel: string;
+  creatorId?: string;
+  lastActivityAt: number;
+}
+
+interface ConductorSession {
+  id: string;
+  workspace: ConductorWorkspace;
+  archived: boolean;
+  model?: string;
+}
+
+function conductorSessionStatus(value: string | undefined): ConductorSessionStatus | undefined {
+  return value !== undefined &&
+    Object.values(CONDUCTOR_SESSION_STATUS).includes(value as ConductorSessionStatus)
+    ? (value as ConductorSessionStatus)
+    : undefined;
+}
+
+/**
+ * Observes Conductor cloud sessions through the documented public API. It reads
+ * only workspaces the authenticated user created, issues no request that can
+ * change provider state, and reports nothing at all without a credential.
+ */
+export class ConductorSessionAdapter extends CloudSessionAdapter {
+  readonly #maximumObservedWorkspaces: number;
+  readonly #maximumObservedSessions: number;
+
+  #userId: string | undefined;
+
+  constructor(options: ConductorAdapterOptions) {
+    super(
+      {
+        provider: CONDUCTOR_PROVIDER,
+        defaultBaseUrl: CONDUCTOR_DEFAULT_API_URL,
+        baseUrlEnvironmentVariable: CONDUCTOR_ENVIRONMENT.API_URL,
+      },
+      options,
+    );
+    this.#maximumObservedWorkspaces = positiveInteger(
+      options.maximumObservedWorkspaces,
+      CONDUCTOR_ADAPTER_DEFAULTS.MAXIMUM_OBSERVED_WORKSPACES,
+    );
+    this.#maximumObservedSessions = positiveInteger(
+      options.maximumObservedSessions,
+      CONDUCTOR_ADAPTER_DEFAULTS.MAXIMUM_OBSERVED_SESSIONS,
+    );
+  }
+
+  protected override forgetCachedIdentity(): void {
+    this.#userId = undefined;
+  }
+
+  protected async collect(
+    request: CloudRequest,
+    now: number,
+  ): Promise<readonly ProviderSessionObservation[]> {
+    const userId = await this.#identity(request);
+    if (!userId) return [];
+
+    // Every fan-out below is already bounded by the caps in
+    // CONDUCTOR_ADAPTER_DEFAULTS, so at most a dozen requests are ever in flight.
+    const projects = await this.#listProjects(request);
+    const workspaces = (
+      await Promise.all(
+        projects.map((project) =>
+          this.tolerateItemFailure(() => this.#listWorkspaces(request, project)),
+        ),
+      )
+    )
+      .filter(isDefined)
+      .flat()
+      // Conductor does not attribute a workspace Luke can prove belongs to this
+      // user unless it reports a creator, and unattributed org workspaces stay
+      // out of a personal sidecar.
+      .filter((workspace) => workspace.creatorId === userId)
+      .filter(
+        (workspace) =>
+          now - workspace.lastActivityAt <= CLOUD_ADAPTER_DEFAULTS.MAXIMUM_SESSION_AGE_MS,
+      )
+      .sort((first, second) => second.lastActivityAt - first.lastActivityAt)
+      .slice(0, this.#maximumObservedWorkspaces);
+
+    const sessions = (
+      await Promise.all(
+        workspaces.map((workspace) =>
+          this.tolerateItemFailure(() => this.#listSessions(request, workspace)),
+        ),
+      )
+    )
+      .filter(isDefined)
+      .flat()
+      .slice(0, this.#maximumObservedSessions);
+
+    const observations = await Promise.all(
+      sessions.map((session) => this.#observationFor(request, session, now)),
+    );
+    return observations.filter(isDefined);
+  }
+
+  async #identity(request: CloudRequest): Promise<string | undefined> {
+    if (this.#userId) return this.#userId;
+    const body = await request(CONDUCTOR_ROUTE.IDENTITY);
+    this.#userId = textFromRecord(body, CONDUCTOR_FIELD.USER_ID);
+    return this.#userId;
+  }
+
+  async #listProjects(request: CloudRequest): Promise<ConductorProject[]> {
+    const body = await request(CONDUCTOR_ROUTE.PROJECTS, {
+      [CONDUCTOR_QUERY.LIMIT]: String(CONDUCTOR_ADAPTER_DEFAULTS.MAXIMUM_PROJECTS),
+    });
+    return recordsFromPage(body, CONDUCTOR_FIELD.DATA)
+      .map((record): ConductorProject | undefined => {
+        const id = textFromRecord(record, CONDUCTOR_FIELD.ID);
+        return id
+          ? {
+              id,
+              repositoryLabel: repositoryLabel(
+                textFromRecord(record, CONDUCTOR_FIELD.GIT_REMOTE),
+                textFromRecord(record, CONDUCTOR_FIELD.NAME),
+              ),
+            }
+          : undefined;
+      })
+      .filter(isDefined)
+      .slice(0, CONDUCTOR_ADAPTER_DEFAULTS.MAXIMUM_PROJECTS);
+  }
+
+  async #listWorkspaces(
+    request: CloudRequest,
+    project: ConductorProject,
+  ): Promise<ConductorWorkspace[]> {
+    const body = await request(
+      [...CONDUCTOR_ROUTE.PROJECTS, project.id, CONDUCTOR_ROUTE_SEGMENT.WORKSPACES],
+      { [CONDUCTOR_QUERY.LIMIT]: String(CONDUCTOR_ADAPTER_DEFAULTS.WORKSPACE_PAGE_SIZE) },
+    );
+    return recordsFromPage(body, CONDUCTOR_FIELD.DATA)
+      .map((record): ConductorWorkspace | undefined => {
+        const id = textFromRecord(record, CONDUCTOR_FIELD.ID);
+        const lastActivityAt =
+          timestampFromRecord(record, CONDUCTOR_FIELD.LAST_ACTIVITY_AT) ??
+          timestampFromRecord(record, CONDUCTOR_FIELD.CREATED_AT);
+        if (!id || lastActivityAt === undefined) return undefined;
+        const creatorId = textFromRecord(record, CONDUCTOR_FIELD.CREATOR_ID);
+        return {
+          id,
+          repositoryLabel: project.repositoryLabel,
+          lastActivityAt,
+          ...(creatorId ? { creatorId } : {}),
+        };
+      })
+      .filter(isDefined);
+  }
+
+  async #listSessions(
+    request: CloudRequest,
+    workspace: ConductorWorkspace,
+  ): Promise<ConductorSession[]> {
+    const body = await request(
+      [
+        CONDUCTOR_ROUTE_SEGMENT.V0,
+        CONDUCTOR_ROUTE_SEGMENT.WORKSPACES,
+        workspace.id,
+        CONDUCTOR_ROUTE_SEGMENT.SESSIONS,
+      ],
+      { [CONDUCTOR_QUERY.LIMIT]: String(CONDUCTOR_ADAPTER_DEFAULTS.SESSION_PAGE_SIZE) },
+    );
+    return (
+      recordsFromPage(body, CONDUCTOR_FIELD.DATA)
+        .map((record): ConductorSession | undefined => {
+          const id = textFromRecord(record, CONDUCTOR_FIELD.ID);
+          if (!id) return undefined;
+          const model = (
+            textFromRecord(record, CONDUCTOR_FIELD.RESOLVED_MODEL) ??
+            textFromRecord(record, CONDUCTOR_FIELD.MODEL)
+          )?.slice(0, CONDUCTOR_ADAPTER_DEFAULTS.MAXIMUM_MODEL_LABEL_LENGTH);
+          return {
+            id,
+            workspace,
+            archived: textFromRecord(record, CONDUCTOR_FIELD.ARCHIVED_AT) !== undefined,
+            ...(model ? { model } : {}),
+          };
+        })
+        .filter(isDefined)
+        // Conductor reports no per-session timestamp until its status is read,
+        // so an open chat is preferred over a closed one and the rest of the
+        // workspace is left out. Capping here keeps one crowded workspace from
+        // spending the whole session budget.
+        .sort((first, second) => Number(first.archived) - Number(second.archived))
+        .slice(0, CONDUCTOR_ADAPTER_DEFAULTS.MAXIMUM_SESSIONS_PER_WORKSPACE)
+    );
+  }
+
+  async #observationFor(
+    request: CloudRequest,
+    session: ConductorSession,
+    now: number,
+  ): Promise<ProviderSessionObservation | undefined> {
+    // An archived session is a closed chat, so its state is already settled and
+    // no status request is needed.
+    const reported = session.archived
+      ? undefined
+      : await this.tolerateItemFailure(() => this.#sessionStatus(request, session.id));
+    // A workspace timestamp covers every chat in that workspace, so it would
+    // make chats a user left hours ago look like they just stopped. The session
+    // status carries the only per-session timestamp Conductor reports.
+    const observedAt = reported?.updatedAt ?? session.workspace.lastActivityAt;
+    if (now - observedAt > CLOUD_ADAPTER_DEFAULTS.MAXIMUM_SESSION_AGE_MS) return undefined;
+
+    const status = this.#statusFor(session, reported?.status, observedAt, now);
+    return {
+      providerSessionId: session.id,
+      title: `${CONDUCTOR_PROVIDER_NAME}: ${session.workspace.repositoryLabel}`,
+      status,
+      observedAt,
+      summary: summaryFromStatus(status, session.model),
+    };
+  }
+
+  #statusFor(
+    session: ConductorSession,
+    reportedStatus: ConductorSessionStatus | undefined,
+    observedAt: number,
+    now: number,
+  ): SessionStatus {
+    if (session.archived) return SESSION_STATUS.COMPLETE;
+    if (!reportedStatus) return SESSION_STATUS.UNKNOWN;
+    // Conductor reports live state, and its timestamp marks when that state was
+    // entered rather than a heartbeat, so a long turn is still working.
+    if (reportedStatus === CONDUCTOR_SESSION_STATUS.WORKING) return SESSION_STATUS.WORKING;
+    return this.statusWhileRecent(
+      SESSION_STATUS_BY_CONDUCTOR_STATUS[reportedStatus],
+      observedAt,
+      now,
+    );
+  }
+
+  async #sessionStatus(
+    request: CloudRequest,
+    sessionId: string,
+  ): Promise<{ status: ConductorSessionStatus | undefined; updatedAt: number | undefined }> {
+    const body = await request([
+      CONDUCTOR_ROUTE_SEGMENT.V0,
+      CONDUCTOR_ROUTE_SEGMENT.SESSIONS,
+      sessionId,
+      CONDUCTOR_ROUTE_SEGMENT.STATUS,
+    ]);
+    return {
+      status: conductorSessionStatus(textFromRecord(body, CONDUCTOR_FIELD.STATUS)),
+      updatedAt: timestampFromRecord(body, CONDUCTOR_FIELD.UPDATED_AT),
+    };
+  }
+}
+
+function summaryFromStatus(status: SessionStatus, model: string | undefined): string {
+  const modelDetail = model ? ` on ${model}` : "";
+  return `${CONDUCTOR_PROVIDER_NAME} ${status}${modelDetail}; cloud session metadata is observed read-only and transcript content is not retained.`;
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -18,6 +18,7 @@ import {
   Menu,
   nativeImage,
   powerMonitor,
+  safeStorage,
   screen,
   session,
   systemPreferences,
@@ -25,13 +26,16 @@ import {
 } from "electron";
 import { ClaudeCodeSessionAdapter } from "./claude-code-adapter";
 import { CodexSessionAdapter } from "./codex-adapter";
+import { ConductorSessionAdapter } from "./conductor-adapter";
 import { readMacScreenGeometry } from "./macos-screen-geometry";
 import { openAiAttentionEvaluatorFromEnvironment } from "./openai-attention-evaluator";
+import { SettingsStore } from "./settings-store";
 import {
   type AppBootstrap,
   channels,
   type DisplayDiagnostic,
   type MicrophoneStatus,
+  type SettingsUpdateResult,
   type WindowMode,
 } from "./shared/contracts";
 
@@ -45,7 +49,24 @@ const captureMode = captureOutput !== undefined;
 const fixtureMode = captureMode || fixtureName !== undefined;
 const SESSION_REFRESH_INTERVAL_MS = 5_000;
 const sessionRegistry = new InMemorySessionRegistry();
-const sessionAdapters = [new ClaudeCodeSessionAdapter(), new CodexSessionAdapter()] as const;
+// `directory` and the cipher are read lazily so the store can be declared before
+// the Electron app is ready.
+const settingsStore = new SettingsStore({
+  directory: () => app.getPath("userData"),
+  cipher: {
+    isAvailable: () => safeStorage.isEncryptionAvailable(),
+    encrypt: (plainText) => safeStorage.encryptString(plainText),
+    decrypt: (cipherText) => safeStorage.decryptString(cipherText),
+  },
+});
+const conductorAdapter = new ConductorSessionAdapter({
+  readApiKey: () => settingsStore.readConductorApiKey(),
+});
+const sessionAdapters = [
+  new ClaudeCodeSessionAdapter(),
+  new CodexSessionAdapter(),
+  conductorAdapter,
+] as const;
 // A fixture run must stay deterministic and credential-free, so it never builds
 // an evaluator — not just capture runs.
 const attentionEvaluator = fixtureMode ? undefined : openAiAttentionEvaluatorFromEnvironment();
@@ -139,6 +160,18 @@ function configurePanelBehavior(window: BrowserWindow): void {
   }
 }
 
+/**
+ * Brings the panel forward as the key window. An accessory app has no Dock
+ * presence, so the app itself has to come forward before one of its windows can
+ * take keyboard focus.
+ */
+function focusPanelWindow(): void {
+  if (!panelWindow || panelWindow.isDestroyed() || captureMode) return;
+  if (process.platform === "darwin") app.focus({ steal: true });
+  panelWindow.show();
+  panelWindow.focus();
+}
+
 function setWindowMode(mode: WindowMode, requestFocus: boolean): WindowMode {
   windowMode = mode;
   if (!panelWindow || panelWindow.isDestroyed()) return windowMode;
@@ -149,8 +182,7 @@ function setWindowMode(mode: WindowMode, requestFocus: boolean): WindowMode {
   panelWindow.webContents.send(channels.lifecycle, `mode:${mode}`);
 
   if (expanded && requestFocus && !captureMode) {
-    panelWindow.show();
-    panelWindow.focus();
+    focusPanelWindow();
   } else {
     panelWindow.showInactive();
   }
@@ -180,7 +212,7 @@ function trustedSender(event: IpcMainEvent | IpcMainInvokeEvent): boolean {
 }
 
 function registerIpc(): void {
-  ipcMain.handle(channels.bootstrap, (event): AppBootstrap => {
+  ipcMain.handle(channels.bootstrap, async (event): Promise<AppBootstrap> => {
     if (!trustedSender(event)) throw new Error("Untrusted renderer");
     return {
       mode: windowMode,
@@ -196,6 +228,7 @@ function registerIpc(): void {
       microphoneStatus: microphoneStatus(),
       display: displayDiagnostic(),
       sessions: fixtureMode ? [] : sessionRegistry.snapshot().sessions,
+      settings: await settingsStore.snapshot(),
     };
   });
 
@@ -216,6 +249,39 @@ function registerIpc(): void {
   ipcMain.handle(channels.requestMicrophone, async (event) => {
     if (!trustedSender(event)) throw new Error("Untrusted renderer");
     return requestMicrophone();
+  });
+
+  // The renderer can replace or clear the credential but never reads it back;
+  // the reply reports only where a key now comes from.
+  ipcMain.handle(
+    channels.setConductorApiKey,
+    async (event, apiKey: unknown): Promise<SettingsUpdateResult> => {
+      if (!trustedSender(event)) throw new Error("Untrusted renderer");
+      if (apiKey !== undefined && typeof apiKey !== "string") {
+        throw new Error("Invalid API key request");
+      }
+      try {
+        const result = await settingsStore.setConductorApiKey(apiKey);
+        // Only the credentialed provider is affected, so the local observers are
+        // left alone rather than re-crawling the filesystem on every save.
+        if (!result.reason) void sessionRegistry.refresh(conductorAdapter);
+        return result;
+      } catch {
+        // A filesystem failure is not something the user can act on, so it is
+        // reported as one line rather than as a raw system error.
+        return {
+          settings: await settingsStore.snapshot(),
+          reason: "Could not save that API key on this system.",
+        };
+      }
+    },
+  );
+
+  // The panel is normally shown without stealing focus. A text field cannot be
+  // typed into that way, so the renderer asks for focus when it opens one.
+  ipcMain.on(channels.focusPanel, (event) => {
+    if (!trustedSender(event) || windowMode !== "expanded") return;
+    focusPanelWindow();
   });
 
   ipcMain.on(channels.quit, (event) => {
@@ -241,12 +307,20 @@ async function refreshProviderSessions(): Promise<void> {
   if (fixtureMode || sessionRefreshRunning) return;
   sessionRefreshRunning = true;
   try {
-    for (const adapter of sessionAdapters) {
-      await sessionRegistry.refresh(adapter);
-    }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`Session observation failed: ${message}\n`);
+    // Providers are observed concurrently and reported independently: the
+    // registry commits each provider atomically, so one that is slow or failing
+    // can neither delay nor cancel the others. A network provider would
+    // otherwise hold up the local ones for as long as its requests take.
+    await Promise.all(
+      sessionAdapters.map(async (adapter) => {
+        try {
+          await sessionRegistry.refresh(adapter);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          process.stderr.write(`Session observation failed (${adapter.provider.id}): ${message}\n`);
+        }
+      }),
+    );
   } finally {
     sessionRefreshRunning = false;
   }
@@ -438,6 +512,10 @@ if (!app.requestSingleInstanceLock()) {
     Menu.setApplicationMenu(null);
     refreshNativeGeometry();
     registerIpc();
+    // Resolving settings touches the filesystem and the OS keychain. Starting it
+    // here keeps that work off the renderer's first paint, which blocks on the
+    // bootstrap reply.
+    void settingsStore.snapshot();
     createPanel();
     configurePermissions();
     createTray();

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -5,6 +5,7 @@ import type {
   AppBridge,
   DisplayDiagnostic,
   MicrophoneStatus,
+  SettingsUpdateResult,
   WindowMode,
 } from "./shared/contracts";
 import { channels } from "./shared/contracts";
@@ -18,6 +19,9 @@ const bridge: AppBridge = {
   },
   requestMicrophone: () =>
     ipcRenderer.invoke(channels.requestMicrophone) as Promise<MicrophoneStatus>,
+  setConductorApiKey: (apiKey: string | undefined) =>
+    ipcRenderer.invoke(channels.setConductorApiKey, apiKey) as Promise<SettingsUpdateResult>,
+  focusPanel: () => ipcRenderer.send(channels.focusPanel),
   notifyReady: () => ipcRenderer.send(channels.rendererReady),
   quit: () => ipcRenderer.send(channels.quit),
   onLifecycle: (callback: (eventName: string) => void) => {

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -9,10 +9,19 @@ import { type CSSProperties, useCallback, useEffect, useRef, useState } from "re
 import { createRoot } from "react-dom/client";
 import type {
   AppBootstrap,
+  AppSettings,
+  CredentialSource,
   DisplayDiagnostic,
   MicrophoneStatus,
   WindowMode,
 } from "../shared/contracts";
+import { CREDENTIAL_SOURCE } from "../shared/contracts";
+
+const credentialLabels: Record<CredentialSource, string> = {
+  [CREDENTIAL_SOURCE.NONE]: "Not connected",
+  [CREDENTIAL_SOURCE.ENVIRONMENT]: "Connected · key read from the environment",
+  [CREDENTIAL_SOURCE.ENCRYPTED_FILE]: "Connected · key encrypted on this Mac",
+};
 
 const stateLabels: Record<SessionState, string> = {
   [SESSION_STATE.WORKING]: "Working",
@@ -138,6 +147,95 @@ function Waveform({
   );
 }
 
+/**
+ * The credential is write-only from the renderer: this form can replace or
+ * clear the stored key, and the main process never sends one back.
+ */
+function ConductorSettings({
+  settings,
+  onSubmit,
+}: {
+  settings: AppSettings;
+  onSubmit: (apiKey: string | undefined) => Promise<string | undefined>;
+}): React.JSX.Element {
+  const [draft, setDraft] = useState("");
+  const [rejection, setRejection] = useState<string>();
+  const [busy, setBusy] = useState(false);
+  const field = useRef<HTMLInputElement | null>(null);
+
+  const storageUnavailable = !settings.secretStorageAvailable;
+  const hasStoredKey = settings.conductorApiKeySource === CREDENTIAL_SOURCE.ENCRYPTED_FILE;
+
+  useEffect(() => {
+    // The panel is shown without stealing focus, so typing only works once the
+    // window itself is key. `preventScroll` keeps this from scrolling the panel
+    // body, which is the one scroll container the layout allows.
+    window.sidecar.focusPanel();
+    if (!storageUnavailable) field.current?.focus({ preventScroll: true });
+  }, [storageUnavailable]);
+
+  const submit = async (apiKey: string | undefined) => {
+    setBusy(true);
+    const failure = await onSubmit(apiKey);
+    setBusy(false);
+    setRejection(failure);
+    if (!failure) setDraft("");
+  };
+
+  return (
+    <div className="settings-view">
+      <label className="settings-field" htmlFor="conductor-api-key">
+        <span className="settings-label">Conductor cloud API key</span>
+        <input
+          id="conductor-api-key"
+          ref={field}
+          className="settings-input"
+          type="password"
+          autoComplete="off"
+          spellCheck={false}
+          placeholder={hasStoredKey ? "Replace the stored key" : "Paste an API key"}
+          value={draft}
+          disabled={busy || storageUnavailable}
+          onChange={(event) => setDraft(event.target.value)}
+        />
+      </label>
+
+      <div className="settings-row">
+        <span className={`settings-state ${settings.conductorApiKeySource}`}>
+          {credentialLabels[settings.conductorApiKeySource]}
+        </span>
+        <span className="settings-actions">
+          {hasStoredKey ? (
+            <button
+              type="button"
+              className="quiet-button"
+              disabled={busy}
+              onClick={() => void submit(undefined)}
+            >
+              Remove key
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className="secondary-button"
+            disabled={busy || storageUnavailable || draft.trim().length === 0}
+            onClick={() => void submit(draft)}
+          >
+            {busy ? "Saving…" : "Save key"}
+          </button>
+        </span>
+      </div>
+
+      <p className="settings-hint">
+        {storageUnavailable
+          ? "This system offers no encrypted credential storage, so Luke will not store a key here."
+          : "Create a key in Conductor under Settings · API keys. Luke reads only cloud workspaces you created and never sends a prompt, message, or any other change."}
+      </p>
+      {rejection ? <p className="settings-error">{rejection}</p> : null}
+    </div>
+  );
+}
+
 function notchStyle(display: DisplayDiagnostic): CSSProperties {
   return {
     "--notch-top-inset": `${display.notch.topInset}px`,
@@ -184,6 +282,8 @@ function displaySessions(bootstrap: AppBootstrap, sessions: readonly NormalizedS
 function App(): React.JSX.Element {
   const [bootstrap, setBootstrap] = useState<AppBootstrap>();
   const [sessions, setSessions] = useState<readonly NormalizedSession[]>([]);
+  const [settings, setSettings] = useState<AppSettings>();
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const [display, setDisplay] = useState<DisplayDiagnostic>();
   const [mode, setMode] = useState<WindowMode>("compact");
   const [microphoneStatus, setMicrophoneStatus] = useState<MicrophoneStatus>("not-determined");
@@ -298,23 +398,42 @@ function App(): React.JSX.Element {
     [cancelHoverTransition, changeMode],
   );
 
+  const showSettings = useCallback(
+    (open: boolean) => {
+      setSettingsOpen(open);
+      // Settings hold a text field, so pointer position must not close them.
+      if (open) cancelHoverTransition();
+    },
+    [cancelHoverTransition],
+  );
+
   const handleHitRegionEnter = useCallback(() => {
     if (modeRef.current === "compact") scheduleMode(true);
     else cancelHoverTransition();
   }, [cancelHoverTransition, scheduleMode]);
 
   const handleHitRegionLeave = useCallback(() => {
-    if (modeRef.current === "compact") cancelHoverTransition();
-    else scheduleMode(false);
-  }, [cancelHoverTransition, scheduleMode]);
+    if (modeRef.current === "compact" || settingsOpen) {
+      cancelHoverTransition();
+      return;
+    }
+    scheduleMode(false);
+  }, [cancelHoverTransition, scheduleMode, settingsOpen]);
 
   usePointerPassthrough(handleHitRegionEnter, handleHitRegionLeave);
+
+  const submitConductorApiKey = useCallback(async (apiKey: string | undefined) => {
+    const result = await window.sidecar.setConductorApiKey(apiKey);
+    setSettings(result.settings);
+    return result.reason;
+  }, []);
 
   useEffect(() => {
     const bootstrapGeneration = modeGeneration.current;
     void window.sidecar.getBootstrap().then((value) => {
       setBootstrap(value);
       setSessions(value.sessions);
+      setSettings(value.settings);
       setDisplay(value.display);
       if (modeGeneration.current === bootstrapGeneration) applyAuthoritativeMode(value.mode);
       setMicrophoneStatus(value.microphoneStatus);
@@ -344,11 +463,18 @@ function App(): React.JSX.Element {
 
   useEffect(() => {
     const handleKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape" && mode === "expanded") void changeMode(false);
+      if (event.key !== "Escape" || mode !== "expanded") return;
+      if (settingsOpen) showSettings(false);
+      else void changeMode(false);
     };
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
-  }, [changeMode, mode]);
+  }, [changeMode, mode, settingsOpen, showSettings]);
+
+  useEffect(() => {
+    // A collapsed panel always reopens on the session list.
+    if (mode === "compact") setSettingsOpen(false);
+  }, [mode]);
 
   if (!bootstrap || !display) return <div />;
 
@@ -414,7 +540,7 @@ function App(): React.JSX.Element {
         inert={mode !== "expanded"}
         data-hit-region
         onPointerEnter={cancelHoverTransition}
-        onPointerLeave={() => scheduleMode(false)}
+        onPointerLeave={handleHitRegionLeave}
       >
         <section className="expanded-panel">
           <header className="panel-header">
@@ -446,11 +572,13 @@ function App(): React.JSX.Element {
             <div className="summary-row">
               <div>
                 <p className="eyebrow">Notch sidecar</p>
-                <h1>Agent activity</h1>
+                <h1>{settingsOpen ? "Settings" : "Agent activity"}</h1>
                 <p className="subtle">
-                  {bootstrap.fixtureMode
-                    ? "Synthetic sessions · no credentials or live transcripts"
-                    : "Live sessions · no credentials or transcripts retained"}
+                  {settingsOpen
+                    ? "Cloud providers observe over the network and need a key"
+                    : bootstrap.fixtureMode
+                      ? "Synthetic sessions · no credentials or live transcripts"
+                      : "Live sessions · no transcripts retained"}
                 </p>
               </div>
               <span className="fixture-badge">
@@ -458,20 +586,24 @@ function App(): React.JSX.Element {
               </span>
             </div>
 
-            <div className="session-list">
-              {visibleSessions.map((item) => (
-                <article className="session-row" key={item.id}>
-                  <span className={`status-mark ${item.state}`} />
-                  <span className="session-copy">
-                    <strong>{item.title}</strong>
-                    <small>
-                      {item.provider} · {item.detail}
-                    </small>
-                  </span>
-                  <span className={`session-status ${item.state}`}>{item.label}</span>
-                </article>
-              ))}
-            </div>
+            {settingsOpen && settings ? (
+              <ConductorSettings settings={settings} onSubmit={submitConductorApiKey} />
+            ) : (
+              <div className="session-list">
+                {visibleSessions.map((item) => (
+                  <article className="session-row" key={item.id}>
+                    <span className={`status-mark ${item.state}`} />
+                    <span className="session-copy">
+                      <strong>{item.title}</strong>
+                      <small>
+                        {item.provider} · {item.detail}
+                      </small>
+                    </span>
+                    <span className={`session-status ${item.state}`}>{item.label}</span>
+                  </article>
+                ))}
+              </div>
+            )}
           </div>
 
           <footer className="panel-footer">
@@ -483,6 +615,14 @@ function App(): React.JSX.Element {
             </div>
             <div className="footer-actions">
               <span className={`permission ${microphoneStatus}`}>Mic: {microphoneStatus}</span>
+              <button
+                type="button"
+                className="quiet-button"
+                aria-pressed={settingsOpen}
+                onClick={() => showSettings(!settingsOpen)}
+              >
+                {settingsOpen ? "Back" : "Settings"}
+              </button>
               <button
                 type="button"
                 className="secondary-button"

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -387,6 +387,99 @@ h1 {
   color: rgba(255, 255, 255, 0.52);
 }
 
+/* Natural height inside the scrolling body, for the same reason session rows
+   take theirs: a stretched child would be shrunk below its content instead of
+   letting the body scroll. */
+.settings-view {
+  display: flex;
+  flex: none;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.045);
+  border-radius: 16px;
+  background: rgba(0, 0, 0, 0.18);
+}
+
+.settings-field {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.settings-label {
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.settings-input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(255, 255, 255, 0.92);
+  font-family: "SF Mono", Menlo, monospace;
+  font-size: 11px;
+  user-select: text;
+}
+
+.settings-input:focus-visible {
+  border-color: rgba(89, 214, 255, 0.5);
+  outline: none;
+}
+
+.settings-input:disabled {
+  color: rgba(255, 255, 255, 0.32);
+}
+
+.settings-row,
+.settings-actions {
+  display: flex;
+  align-items: center;
+}
+
+.settings-row {
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.settings-actions {
+  gap: 8px;
+}
+
+.settings-state {
+  color: rgba(255, 255, 255, 0.42);
+  font-size: 10px;
+  font-weight: 650;
+}
+
+.settings-state.encrypted-file,
+.settings-state.environment {
+  color: #68d39a;
+}
+
+.settings-hint,
+.settings-error {
+  margin: 0;
+  font-size: 9px;
+  line-height: 1.5;
+}
+
+.settings-hint {
+  color: rgba(255, 255, 255, 0.34);
+}
+
+.settings-error {
+  color: #ff8c8c;
+}
+
+.secondary-button:disabled,
+.quiet-button:disabled {
+  opacity: 0.42;
+}
+
 .panel-footer {
   gap: 12px;
   min-height: 34px;

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -1,0 +1,244 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  type AppSettings,
+  CREDENTIAL_SOURCE,
+  type CredentialSource,
+  type SettingsUpdateResult,
+} from "./shared/contracts";
+
+const SETTINGS_FILE_NAME = "settings.json";
+const SETTINGS_TEMPORARY_FILE_NAME = "settings.json.tmp";
+const SETTINGS_FILE_VERSION = 1;
+const SETTINGS_FILE_MODE = 0o600;
+
+const CONDUCTOR_ENVIRONMENT = {
+  API_KEY: "CONDUCTOR_API_KEY",
+  API_TOKEN: "CONDUCTOR_API_TOKEN",
+} as const;
+
+const API_KEY_LENGTH = {
+  MINIMUM: 8,
+  MAXIMUM: 512,
+} as const;
+
+/** Printable ASCII with no spaces — the bytes an authorization header accepts. */
+const PRINTABLE_ASCII = /^[\x21-\x7e]+$/;
+
+/**
+ * A credential is only ever written through OS-provided encryption. Electron's
+ * `safeStorage` satisfies this on macOS by deriving its key from the Keychain.
+ */
+export interface SecretCipher {
+  isAvailable(): boolean;
+  encrypt(plainText: string): Buffer;
+  decrypt(cipherText: Buffer): string;
+}
+
+export interface SettingsStoreOptions {
+  directory: () => string;
+  cipher: SecretCipher;
+  environment?: NodeJS.ProcessEnv;
+}
+
+interface PersistedSettings {
+  version: number;
+  conductorApiKey?: string;
+}
+
+interface ResolvedApiKey {
+  apiKey?: string;
+  source: CredentialSource;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
+
+function canIgnoreFilesystemError(error: unknown): boolean {
+  return (
+    isNodeError(error) &&
+    (error.code === "ENOENT" ||
+      error.code === "ENOTDIR" ||
+      error.code === "EACCES" ||
+      error.code === "EPERM")
+  );
+}
+
+/**
+ * A rejected key never reaches disk, and the reason never echoes the submitted
+ * value. Conductor does not publish a key format, so this only rules out values
+ * that cannot be sent as an HTTP authorization header.
+ */
+export function conductorApiKeyRejection(apiKey: string): string | undefined {
+  if (apiKey.length < API_KEY_LENGTH.MINIMUM) return "That API key is too short.";
+  if (apiKey.length > API_KEY_LENGTH.MAXIMUM) return "That API key is too long.";
+  if (!PRINTABLE_ASCII.test(apiKey)) return "That API key contains unsupported characters.";
+  return undefined;
+}
+
+function environmentApiKey(environment: NodeJS.ProcessEnv): string | undefined {
+  for (const variable of [CONDUCTOR_ENVIRONMENT.API_KEY, CONDUCTOR_ENVIRONMENT.API_TOKEN]) {
+    const value = environment[variable]?.trim();
+    if (value && !conductorApiKeyRejection(value)) return value;
+  }
+  return undefined;
+}
+
+function parsePersistedSettings(source: string): PersistedSettings {
+  const parsed: unknown = JSON.parse(source);
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Settings file is not an object");
+  }
+  const record = parsed as Record<string, unknown>;
+  const conductorApiKey = record.conductorApiKey;
+  return {
+    version: typeof record.version === "number" ? record.version : SETTINGS_FILE_VERSION,
+    ...(typeof conductorApiKey === "string" && conductorApiKey ? { conductorApiKey } : {}),
+  };
+}
+
+/**
+ * Reads and writes the small set of user-owned settings Luke needs. A stored
+ * credential stays in the main process: callers can learn that a key exists and
+ * can replace it, but no accessor returns it to a renderer.
+ */
+export class SettingsStore {
+  readonly #directory: () => string;
+  readonly #cipher: SecretCipher;
+  readonly #environment: NodeJS.ProcessEnv;
+  #loading: Promise<PersistedSettings> | undefined;
+  #resolved: ResolvedApiKey | undefined;
+  #pendingWrite: Promise<void> = Promise.resolve();
+
+  constructor(options: SettingsStoreOptions) {
+    this.#directory = options.directory;
+    this.#cipher = options.cipher;
+    this.#environment = options.environment ?? process.env;
+  }
+
+  async snapshot(): Promise<AppSettings> {
+    const { source } = await this.#resolveApiKey();
+    return {
+      conductorApiKeySource: source,
+      secretStorageAvailable: this.#secretStorageAvailable(),
+    };
+  }
+
+  /** Main-process only: the resolved key used to authenticate provider reads. */
+  async readConductorApiKey(): Promise<string | undefined> {
+    return (await this.#resolveApiKey()).apiKey;
+  }
+
+  /**
+   * Stores a key encrypted at rest, or clears the stored key when omitted. A key
+   * the user cannot use comes back as a `reason` rather than an exception, so
+   * only an unexpected filesystem failure throws.
+   */
+  async setConductorApiKey(apiKey: string | undefined): Promise<SettingsUpdateResult> {
+    const normalized = apiKey?.trim();
+    const rejection = normalized
+      ? !this.#secretStorageAvailable()
+        ? "Encrypted credential storage is unavailable on this system."
+        : conductorApiKeyRejection(normalized)
+      : undefined;
+    if (rejection) return { settings: await this.snapshot(), reason: rejection };
+
+    const persisted = await this.#load();
+    const ciphertext = normalized ? this.#cipher.encrypt(normalized).toString("base64") : undefined;
+    const next: PersistedSettings = {
+      version: SETTINGS_FILE_VERSION,
+      ...(ciphertext ? { conductorApiKey: ciphertext } : {}),
+    };
+    if (persisted.conductorApiKey !== next.conductorApiKey) {
+      await this.#write(next);
+      this.#loading = Promise.resolve(next);
+      this.#resolved = undefined;
+    }
+    return { settings: await this.snapshot() };
+  }
+
+  #secretStorageAvailable(): boolean {
+    try {
+      return this.#cipher.isAvailable();
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * The resolved key is cached because the observation timer asks for it every
+   * few seconds, and decrypting on each tick would hit the OS keychain
+   * thousands of times a day for a value only the user can change.
+   */
+  async #resolveApiKey(): Promise<ResolvedApiKey> {
+    if (this.#resolved) return this.#resolved;
+    const stored = await this.#storedApiKey();
+    const fromEnvironment = stored ? undefined : environmentApiKey(this.#environment);
+    this.#resolved = stored
+      ? { apiKey: stored, source: CREDENTIAL_SOURCE.ENCRYPTED_FILE }
+      : fromEnvironment
+        ? { apiKey: fromEnvironment, source: CREDENTIAL_SOURCE.ENVIRONMENT }
+        : { source: CREDENTIAL_SOURCE.NONE };
+    return this.#resolved;
+  }
+
+  async #storedApiKey(): Promise<string | undefined> {
+    const { conductorApiKey } = await this.#load();
+    if (!conductorApiKey) return undefined;
+    try {
+      const apiKey = this.#cipher.decrypt(Buffer.from(conductorApiKey, "base64")).trim();
+      return apiKey && !conductorApiKeyRejection(apiKey) ? apiKey : undefined;
+    } catch {
+      // A key encrypted under a different account, or against a rotated
+      // Keychain entry, cannot be recovered; the user re-enters it instead.
+      return undefined;
+    }
+  }
+
+  /** Memoizes the in-flight read so concurrent first callers share one open. */
+  async #load(): Promise<PersistedSettings> {
+    this.#loading ??= this.#readPersisted();
+    return this.#loading;
+  }
+
+  async #readPersisted(): Promise<PersistedSettings> {
+    const settingsPath = path.join(this.#directory(), SETTINGS_FILE_NAME);
+    let source: string | undefined;
+    try {
+      source = await fs.readFile(settingsPath, "utf8");
+    } catch (error) {
+      if (!canIgnoreFilesystemError(error)) throw error;
+    }
+
+    let persisted: PersistedSettings = { version: SETTINGS_FILE_VERSION };
+    if (source) {
+      try {
+        persisted = parsePersistedSettings(source);
+      } catch {
+        // A corrupt settings file is replaced by the next write rather than
+        // failing app start.
+      }
+    }
+    return persisted;
+  }
+
+  async #write(persisted: PersistedSettings): Promise<void> {
+    const write = this.#pendingWrite.then(async () => {
+      const directory = this.#directory();
+      const settingsPath = path.join(directory, SETTINGS_FILE_NAME);
+      const temporaryPath = path.join(directory, SETTINGS_TEMPORARY_FILE_NAME);
+      await fs.mkdir(directory, { recursive: true });
+      await fs.writeFile(temporaryPath, `${JSON.stringify(persisted, undefined, 2)}\n`, {
+        encoding: "utf8",
+        mode: SETTINGS_FILE_MODE,
+      });
+      // `mode` only applies when the file is created, so a temporary file left
+      // behind by an interrupted write keeps whatever mode it already had.
+      await fs.chmod(temporaryPath, SETTINGS_FILE_MODE);
+      await fs.rename(temporaryPath, settingsPath);
+    });
+    this.#pendingWrite = write.catch(() => undefined);
+    await write;
+  }
+}

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -10,6 +10,31 @@ export type { WindowMode } from "@sidecar/core";
 
 export type MicrophoneStatus = "not-determined" | "granted" | "denied" | "restricted" | "unknown";
 
+/** Where a credential was resolved from, without ever exposing the credential. */
+export const CREDENTIAL_SOURCE = {
+  NONE: "none",
+  ENVIRONMENT: "environment",
+  ENCRYPTED_FILE: "encrypted-file",
+} as const;
+
+export type CredentialSource = (typeof CREDENTIAL_SOURCE)[keyof typeof CREDENTIAL_SOURCE];
+
+/** Renderer-safe settings. Credentials are never sent to a renderer. */
+export interface AppSettings {
+  conductorApiKeySource: CredentialSource;
+  /**
+   * Luke stores credentials only through OS-provided encryption. When that is
+   * unavailable the app says so rather than falling back to plaintext storage.
+   */
+  secretStorageAvailable: boolean;
+}
+
+/** A rejected update reports why without echoing the submitted value. */
+export interface SettingsUpdateResult {
+  settings: AppSettings;
+  reason?: string;
+}
+
 export interface DisplayDiagnostic {
   id: number;
   label: string;
@@ -34,6 +59,7 @@ export interface AppBootstrap {
   microphoneStatus: MicrophoneStatus;
   display: DisplayDiagnostic;
   sessions: readonly NormalizedSession[];
+  settings: AppSettings;
 }
 
 export interface AppBridge {
@@ -41,6 +67,9 @@ export interface AppBridge {
   setExpanded(expanded: boolean): Promise<WindowMode>;
   setPointerInterception(interceptsPointer: boolean): void;
   requestMicrophone(): Promise<MicrophoneStatus>;
+  setConductorApiKey(apiKey: string | undefined): Promise<SettingsUpdateResult>;
+  /** Brings the expanded panel forward so it can accept typed input. */
+  focusPanel(): void;
   notifyReady(): void;
   quit(): void;
   onLifecycle(callback: (eventName: string) => void): () => void;
@@ -54,6 +83,8 @@ export const channels = {
   setExpanded: "app:set-expanded",
   setPointerInterception: "app:set-pointer-interception",
   requestMicrophone: "app:request-microphone",
+  setConductorApiKey: "app:set-conductor-api-key",
+  focusPanel: "app:focus-panel",
   rendererReady: "app:renderer-ready",
   lifecycle: "app:lifecycle",
   startMicrophone: "app:start-microphone",

--- a/apps/desktop/tests/cloud-session-adapter.test.ts
+++ b/apps/desktop/tests/cloud-session-adapter.test.ts
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { type ProviderSessionObservation, SESSION_STATUS } from "@sidecar/core";
+import {
+  type CloudAdapterOptions,
+  type CloudFetch,
+  type CloudRequest,
+  CloudSessionAdapter,
+} from "../src/cloud-session-adapter";
+
+const TEST_TIME = Date.parse("2026-08-12T02:45:00.000Z");
+const TEST_BASE_URL = "https://api.provider.test";
+const TEST_API_KEY = "provider-test-key";
+
+const HTTP_STATUS = {
+  OK: 200,
+  UNAUTHORIZED: 401,
+} as const;
+
+const STUB_PROVIDER = { id: "stub", displayName: "Stub" };
+
+interface RecordedRequest {
+  method: string;
+  url: string;
+  authorization: string | undefined;
+  accept: string | undefined;
+}
+
+interface StubFetch {
+  fetch: CloudFetch;
+  requests: RecordedRequest[];
+}
+
+function stubFetch(status: () => number = () => HTTP_STATUS.OK): StubFetch {
+  const requests: RecordedRequest[] = [];
+  const fetch: CloudFetch = async (url, init) => {
+    const headers = new Headers(init.headers);
+    requests.push({
+      method: init.method ?? "",
+      url,
+      authorization: headers.get("authorization") ?? undefined,
+      accept: headers.get("accept") ?? undefined,
+    });
+    return new Response(JSON.stringify({}), {
+      status: status(),
+      headers: { "content-type": "application/json" },
+    });
+  };
+  return { fetch, requests };
+}
+
+function observation(
+  providerSessionId: string,
+  overrides: Partial<ProviderSessionObservation> = {},
+): ProviderSessionObservation {
+  return {
+    providerSessionId,
+    title: `Stub: ${providerSessionId}`,
+    status: SESSION_STATUS.WAITING,
+    observedAt: TEST_TIME,
+    ...overrides,
+  };
+}
+
+/** Stands in for a real provider so the shared half can be tested on its own. */
+class StubCloudAdapter extends CloudSessionAdapter {
+  passes = 0;
+  forgottenIdentities = 0;
+  collected: readonly ProviderSessionObservation[] = [];
+
+  constructor(options: CloudAdapterOptions) {
+    super({ provider: STUB_PROVIDER, defaultBaseUrl: TEST_BASE_URL }, options);
+  }
+
+  protected override forgetCachedIdentity(): void {
+    this.forgottenIdentities += 1;
+  }
+
+  protected async collect(
+    request: CloudRequest,
+    now: number,
+  ): Promise<readonly ProviderSessionObservation[]> {
+    this.passes += 1;
+    await request(["v0", "sessions", "id with/slash"], { limit: "2" });
+    return this.collected.map((candidate) => ({
+      ...candidate,
+      status: this.statusWhileRecent(candidate.status, candidate.observedAt, now),
+    }));
+  }
+}
+
+function adapterFor(
+  fetch: CloudFetch,
+  overrides: {
+    apiKey?: string | undefined;
+    readApiKey?: () => Promise<string | undefined>;
+    now?: () => number;
+  } = {},
+): StubCloudAdapter {
+  const apiKey = "apiKey" in overrides ? overrides.apiKey : TEST_API_KEY;
+  return new StubCloudAdapter({
+    readApiKey: overrides.readApiKey ?? (async () => apiKey),
+    baseUrl: TEST_BASE_URL,
+    fetch,
+    now: overrides.now ?? (() => TEST_TIME),
+    minimumRefreshIntervalMs: 0,
+  });
+}
+
+test("authenticates a bounded read and encodes the route a subclass asked for", async () => {
+  const stub = stubFetch();
+  const adapter = adapterFor(stub.fetch);
+  adapter.collected = [observation("session-one")];
+
+  const observations = await adapter.observe();
+
+  assert.equal(adapter.provider.id, "stub");
+  assert.equal(observations.length, 1);
+  assert.deepEqual(stub.requests, [
+    {
+      method: "GET",
+      url: `${TEST_BASE_URL}/v0/sessions/id%20with%2Fslash?limit=2`,
+      authorization: `Bearer ${TEST_API_KEY}`,
+      accept: "application/json",
+    },
+  ]);
+});
+
+test("drops a session a subclass reported twice in one pass", async () => {
+  const stub = stubFetch();
+  const adapter = adapterFor(stub.fetch);
+  adapter.collected = [
+    observation("session-repeated", { status: SESSION_STATUS.WORKING }),
+    observation("session-repeated", { status: SESSION_STATUS.COMPLETE }),
+    observation("session-other"),
+  ];
+
+  const observations = await adapter.observe();
+
+  assert.deepEqual(
+    observations.map((candidate) => candidate.providerSessionId),
+    ["session-repeated", "session-other"],
+  );
+  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
+});
+
+test("leaves a stopped session unknown once its timestamp goes stale", async () => {
+  const stub = stubFetch();
+  const adapter = adapterFor(stub.fetch);
+  adapter.collected = [
+    observation("session-recent", { observedAt: TEST_TIME - 60_000 }),
+    observation("session-stale", { observedAt: TEST_TIME - 60 * 60 * 1000 }),
+  ];
+
+  const observations = await adapter.observe();
+
+  assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
+  assert.equal(observations[1]?.status, SESSION_STATUS.UNKNOWN);
+});
+
+test("forgets cached identity when the credential changes, and reports nothing without one", async () => {
+  const stub = stubFetch();
+  let apiKey: string | undefined = TEST_API_KEY;
+  const adapter = adapterFor(stub.fetch, { readApiKey: async () => apiKey });
+  adapter.collected = [observation("session-one")];
+
+  await adapter.observe();
+  apiKey = "replacement-key";
+  const afterRotation = await adapter.observe();
+  apiKey = undefined;
+  const afterRemoval = await adapter.observe();
+
+  assert.equal(adapter.passes, 2, "the replacement key did not trigger a pass");
+  assert.equal(afterRotation.length, 1);
+  assert.equal(stub.requests.at(-1)?.authorization, "Bearer replacement-key");
+  assert.deepEqual(afterRemoval, []);
+  // Once when the first key was accepted, once for the rotation, once when the
+  // credential was removed.
+  assert.equal(adapter.forgottenIdentities, 3);
+});
+
+test("clears observations when the provider rejects the credential", async () => {
+  let rejectRequests = false;
+  const stub = stubFetch(() => (rejectRequests ? HTTP_STATUS.UNAUTHORIZED : HTTP_STATUS.OK));
+  const adapter = adapterFor(stub.fetch);
+  adapter.collected = [observation("session-one")];
+
+  const authorized = await adapter.observe();
+  rejectRequests = true;
+  const rejected = await adapter.observe();
+
+  assert.equal(authorized.length, 1);
+  assert.deepEqual(rejected, []);
+  // Once when the key was accepted, once when the provider rejected it.
+  assert.equal(adapter.forgottenIdentities, 2);
+});
+
+test("issues no request at all when the credential cannot be read", async () => {
+  const stub = stubFetch();
+  const adapter = adapterFor(stub.fetch, {
+    readApiKey: async () => {
+      throw new Error("settings are unreadable");
+    },
+  });
+  adapter.collected = [observation("session-one")];
+
+  assert.deepEqual(await adapter.observe(), []);
+  assert.deepEqual(stub.requests, []);
+  assert.equal(adapter.passes, 0);
+});

--- a/apps/desktop/tests/cloud-session-adapter.test.ts
+++ b/apps/desktop/tests/cloud-session-adapter.test.ts
@@ -6,6 +6,7 @@ import {
   type CloudFetch,
   type CloudRequest,
   CloudSessionAdapter,
+  isDefined,
 } from "../src/cloud-session-adapter";
 
 const TEST_TIME = Date.parse("2026-08-12T02:45:00.000Z");
@@ -193,6 +194,125 @@ test("clears observations when the provider rejects the credential", async () =>
   assert.deepEqual(rejected, []);
   // Once when the key was accepted, once when the provider rejected it.
   assert.equal(adapter.forgottenIdentities, 2);
+});
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve = () => {};
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+/**
+ * Reports whatever session the authenticated account can see, across two
+ * requests, the way a real provider pass fans out. What it reports is decided
+ * by the account that answers, not by anything cached on the adapter.
+ */
+class AccountBoundAdapter extends CloudSessionAdapter {
+  constructor(options: CloudAdapterOptions) {
+    super({ provider: STUB_PROVIDER, defaultBaseUrl: TEST_BASE_URL }, options);
+  }
+
+  protected async collect(request: CloudRequest): Promise<readonly ProviderSessionObservation[]> {
+    const first = await request(["sessions", "first"]);
+    const second = await request(["sessions", "second"]);
+    return [first, second]
+      .map((body) => (typeof body.session === "string" ? observation(body.session) : undefined))
+      .filter(isDefined);
+  }
+}
+
+const OLD_ACCOUNT_SESSION = "session-from-old-account";
+const NEW_ACCOUNT_SESSION = "session-from-new-account";
+
+function accountBoundFetch(options: { oldKeyGate: Promise<void>; oldKeyStatus?: number }): {
+  fetch: CloudFetch;
+  authorizations: string[];
+} {
+  const sessionByAuthorization: Record<string, string> = {
+    "Bearer first-key": OLD_ACCOUNT_SESSION,
+    "Bearer second-key": NEW_ACCOUNT_SESSION,
+  };
+  const authorizations: string[] = [];
+  const fetch: CloudFetch = async (_url, init) => {
+    const authorization = new Headers(init.headers).get("authorization") ?? "";
+    authorizations.push(authorization);
+    let status: number = HTTP_STATUS.OK;
+    if (authorization === "Bearer first-key") {
+      await options.oldKeyGate;
+      status = options.oldKeyStatus ?? HTTP_STATUS.OK;
+    }
+    return new Response(JSON.stringify({ session: sessionByAuthorization[authorization] }), {
+      status,
+    });
+  };
+  return { fetch, authorizations };
+}
+
+function sessionIds(observations: readonly ProviderSessionObservation[]): string[] {
+  return observations.map((candidate) => candidate.providerSessionId);
+}
+
+test("a pass superseded by a key rotation neither lands nor keeps using the old key", async () => {
+  // A settings save refreshes the adapter while a timer-driven pass is still
+  // in flight with the key it replaced. The old account's sessions must not be
+  // served under the new credential, and the replaced key must not be used for
+  // the rest of the superseded pass.
+  const oldKeyRequest = deferred();
+  const { fetch, authorizations } = accountBoundFetch({ oldKeyGate: oldKeyRequest.promise });
+  let apiKey = "first-key";
+  const adapter = new AccountBoundAdapter({
+    readApiKey: async () => apiKey,
+    baseUrl: TEST_BASE_URL,
+    fetch,
+    now: () => TEST_TIME,
+    minimumRefreshIntervalMs: 0,
+  });
+
+  const stalePass = adapter.observe();
+  apiKey = "second-key";
+  const freshObservations = await adapter.observe();
+  oldKeyRequest.resolve();
+  const staleObservations = await stalePass;
+
+  assert.deepEqual(sessionIds(freshObservations), [NEW_ACCOUNT_SESSION]);
+  assert.deepEqual(sessionIds(staleObservations), [NEW_ACCOUNT_SESSION]);
+  assert.equal(
+    authorizations.filter((value) => value === "Bearer first-key").length,
+    1,
+    "a superseded pass kept requesting with the replaced key",
+  );
+});
+
+test("a replaced key rejected mid-flight does not clear the new key's observations", async () => {
+  // The old key is often rotated out precisely because it was revoked, so its
+  // rejection arrives after the new key has already observed sessions.
+  const oldKeyRequest = deferred();
+  const { fetch } = accountBoundFetch({
+    oldKeyGate: oldKeyRequest.promise,
+    oldKeyStatus: HTTP_STATUS.UNAUTHORIZED,
+  });
+  let apiKey = "first-key";
+  const adapter = new AccountBoundAdapter({
+    readApiKey: async () => apiKey,
+    baseUrl: TEST_BASE_URL,
+    fetch,
+    now: () => TEST_TIME,
+    minimumRefreshIntervalMs: 60_000,
+  });
+
+  const stalePass = adapter.observe();
+  apiKey = "second-key";
+  await adapter.observe();
+  oldKeyRequest.resolve();
+  const staleObservations = await stalePass;
+  // Inside the refresh interval this serves the cache, which is exactly where
+  // a wrongly cleared snapshot would surface as vanished rows.
+  const cachedObservations = await adapter.observe();
+
+  assert.deepEqual(sessionIds(staleObservations), [NEW_ACCOUNT_SESSION]);
+  assert.deepEqual(sessionIds(cachedObservations), [NEW_ACCOUNT_SESSION]);
 });
 
 test("issues no request at all when the credential cannot be read", async () => {

--- a/apps/desktop/tests/conductor-adapter.test.ts
+++ b/apps/desktop/tests/conductor-adapter.test.ts
@@ -1,11 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { SESSION_STATUS } from "@sidecar/core";
-import {
-  CONDUCTOR_PROVIDER,
-  type ConductorFetch,
-  ConductorSessionAdapter,
-} from "../src/conductor-adapter";
+import type { CloudFetch } from "../src/cloud-session-adapter";
+import { CONDUCTOR_PROVIDER, ConductorSessionAdapter } from "../src/conductor-adapter";
 
 const TEST_TIME = Date.parse("2026-08-12T02:45:00.000Z");
 const TEST_BASE_URL = "https://api.conductor.test";
@@ -65,7 +62,7 @@ interface RecordedRequest {
 }
 
 interface FakeConductorApi {
-  fetch: ConductorFetch;
+  fetch: CloudFetch;
   requests: RecordedRequest[];
 }
 
@@ -108,7 +105,7 @@ function sessionPayload(session: TestSession): Record<string, unknown> {
 /** Serves the read-only subset of the public API the adapter is allowed to use. */
 function fakeConductorApi(api: TestApi): FakeConductorApi {
   const requests: RecordedRequest[] = [];
-  const fetch: ConductorFetch = async (url, init) => {
+  const fetch: CloudFetch = async (url, init) => {
     const { pathname } = new URL(url);
     const headers = new Headers(init.headers);
     requests.push({
@@ -157,7 +154,7 @@ function fakeConductorApi(api: TestApi): FakeConductorApi {
 }
 
 function adapterFor(
-  fetch: ConductorFetch,
+  fetch: CloudFetch,
   overrides: {
     apiKey?: string | undefined;
     readApiKey?: () => Promise<string | undefined>;
@@ -287,9 +284,49 @@ test("reports an archived session as complete without requesting its status", as
 
   assert.equal(observations.length, 1);
   assert.equal(observations[0]?.status, SESSION_STATUS.COMPLETE);
+  // The archive time is when the chat settled; the workspace timestamp would
+  // date it by whatever a sibling chat did since.
+  assert.equal(observations[0]?.observedAt, TEST_TIME - 20_000);
   assert.equal(
     api.requests.some((request) => request.pathname.endsWith("/status")),
     false,
+  );
+});
+
+test("drops a long-closed chat instead of letting a busy workspace make it look recent", async () => {
+  // A closed chat carries no timestamp of its own except archivedAt. Falling
+  // back to the workspace timestamp would make a chat closed days ago read as
+  // freshly complete whenever a sibling chat is active — and let it spend a
+  // budget slot a live session needed.
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [
+      ownedWorkspace("workspace-busy", TEST_TIME - 5_000),
+      ownedWorkspace("workspace-quiet", TEST_TIME - 60_000),
+    ],
+    sessions: [
+      {
+        id: "session-closed-days-ago",
+        workspaceId: "workspace-busy",
+        name: SECRET_PROMPT_TEXT,
+        archivedAt: isoTimestamp(TEST_TIME - 3 * 24 * 60 * 60 * 1000),
+      },
+      {
+        id: "session-open",
+        workspaceId: "workspace-quiet",
+        name: SECRET_PROMPT_TEXT,
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 30_000,
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch, { maximumObservedSessions: 1 }).observe();
+
+  assert.deepEqual(
+    observations.map((candidate) => candidate.providerSessionId),
+    ["session-open"],
   );
 });
 
@@ -618,7 +655,7 @@ test("clears observations when Conductor rejects the API key", async () => {
     ],
   });
   let rejectRequests = false;
-  const gatedFetch: ConductorFetch = async (url, init) =>
+  const gatedFetch: CloudFetch = async (url, init) =>
     rejectRequests ? jsonResponse({}, HTTP_STATUS.UNAUTHORIZED) : api.fetch(url, init);
   const adapter = adapterFor(gatedFetch);
 
@@ -646,7 +683,7 @@ test("keeps the previous snapshot when a request fails transiently", async () =>
     ],
   });
   let failRequests = false;
-  const gatedFetch: ConductorFetch = async (url, init) => {
+  const gatedFetch: CloudFetch = async (url, init) => {
     if (failRequests) throw new Error("network unreachable");
     return api.fetch(url, init);
   };

--- a/apps/desktop/tests/conductor-adapter.test.ts
+++ b/apps/desktop/tests/conductor-adapter.test.ts
@@ -1,0 +1,690 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { SESSION_STATUS } from "@sidecar/core";
+import {
+  CONDUCTOR_PROVIDER,
+  type ConductorFetch,
+  ConductorSessionAdapter,
+} from "../src/conductor-adapter";
+
+const TEST_TIME = Date.parse("2026-08-12T02:45:00.000Z");
+const TEST_BASE_URL = "https://api.conductor.test";
+const TEST_API_KEY = "conductor-test-key";
+const TEST_USER_ID = "user-under-observation";
+const OTHER_USER_ID = "another-user";
+const SECRET_PROMPT_TEXT = "SECRET_PROMPT_TEXT";
+
+const TEST_CONDUCTOR_STATUS = {
+  IDLE: "idle",
+  WORKING: "working",
+  ERROR: "error",
+} as const;
+
+const HTTP_STATUS = {
+  OK: 200,
+  UNAUTHORIZED: 401,
+  SERVER_ERROR: 500,
+} as const;
+
+interface TestProject {
+  id: string;
+  name: string;
+  gitRemote: string;
+}
+
+interface TestWorkspace {
+  id: string;
+  projectId: string;
+  name: string;
+  creatorId?: string;
+  lastActivityAt: number;
+}
+
+interface TestSession {
+  id: string;
+  workspaceId: string;
+  name: string;
+  resolvedModel?: string;
+  archivedAt?: string;
+  status?: string;
+  statusUpdatedAt?: number;
+  statusHttpStatus?: number;
+}
+
+interface TestApi {
+  userId?: string;
+  projects: readonly TestProject[];
+  workspaces: readonly TestWorkspace[];
+  sessions: readonly TestSession[];
+}
+
+interface RecordedRequest {
+  method: string;
+  pathname: string;
+  authorization: string | undefined;
+}
+
+interface FakeConductorApi {
+  fetch: ConductorFetch;
+  requests: RecordedRequest[];
+}
+
+function isoTimestamp(timestampMs: number): string {
+  return new Date(timestampMs).toISOString();
+}
+
+function jsonResponse(body: unknown, status = HTTP_STATUS.OK): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function page(data: readonly unknown[]): unknown {
+  return { data, offset: 0, hasMore: false };
+}
+
+function workspacePayload(workspace: TestWorkspace): Record<string, unknown> {
+  return {
+    id: workspace.id,
+    name: workspace.name,
+    createdAt: isoTimestamp(workspace.lastActivityAt),
+    deepLink: `conductor://workspace?id=${workspace.id}`,
+    lastActivityAt: isoTimestamp(workspace.lastActivityAt),
+    ...(workspace.creatorId ? { creatorId: workspace.creatorId } : {}),
+  };
+}
+
+function sessionPayload(session: TestSession): Record<string, unknown> {
+  return {
+    id: session.id,
+    deepLink: `conductor://workspace?session=${session.id}`,
+    name: session.name,
+    ...(session.resolvedModel ? { resolvedModel: session.resolvedModel } : {}),
+    ...(session.archivedAt ? { archivedAt: session.archivedAt } : {}),
+  };
+}
+
+/** Serves the read-only subset of the public API the adapter is allowed to use. */
+function fakeConductorApi(api: TestApi): FakeConductorApi {
+  const requests: RecordedRequest[] = [];
+  const fetch: ConductorFetch = async (url, init) => {
+    const { pathname } = new URL(url);
+    const headers = new Headers(init.headers);
+    requests.push({
+      method: init.method ?? "",
+      pathname,
+      authorization: headers.get("authorization") ?? undefined,
+    });
+
+    const segments = pathname.split("/").filter((segment) => segment.length > 0);
+    if (segments[0] === "me") {
+      return jsonResponse(api.userId ? { userId: api.userId } : {});
+    }
+    if (segments[1] === "projects" && segments.length === 2) {
+      return jsonResponse(page(api.projects));
+    }
+    if (segments[1] === "projects" && segments[3] === "workspaces") {
+      return jsonResponse(
+        page(
+          api.workspaces
+            .filter((workspace) => workspace.projectId === segments[2])
+            .map(workspacePayload),
+        ),
+      );
+    }
+    if (segments[1] === "workspaces" && segments[3] === "sessions") {
+      return jsonResponse(
+        page(
+          api.sessions.filter((session) => session.workspaceId === segments[2]).map(sessionPayload),
+        ),
+      );
+    }
+    if (segments[1] === "sessions" && segments[3] === "status") {
+      const session = api.sessions.find((candidate) => candidate.id === segments[2]);
+      if (!session) return jsonResponse({}, HTTP_STATUS.SERVER_ERROR);
+      if (session.statusHttpStatus) return jsonResponse({}, session.statusHttpStatus);
+      return jsonResponse({
+        workspaceId: session.workspaceId,
+        sessionId: session.id,
+        status: session.status ?? TEST_CONDUCTOR_STATUS.IDLE,
+        updatedAt: isoTimestamp(session.statusUpdatedAt ?? TEST_TIME),
+      });
+    }
+    return jsonResponse({}, HTTP_STATUS.SERVER_ERROR);
+  };
+  return { fetch, requests };
+}
+
+function adapterFor(
+  fetch: ConductorFetch,
+  overrides: {
+    apiKey?: string | undefined;
+    readApiKey?: () => Promise<string | undefined>;
+    now?: () => number;
+    minimumRefreshIntervalMs?: number;
+    maximumObservedWorkspaces?: number;
+    maximumObservedSessions?: number;
+  } = {},
+): ConductorSessionAdapter {
+  const apiKey = "apiKey" in overrides ? overrides.apiKey : TEST_API_KEY;
+  return new ConductorSessionAdapter({
+    readApiKey: overrides.readApiKey ?? (async () => apiKey),
+    baseUrl: TEST_BASE_URL,
+    fetch,
+    now: overrides.now ?? (() => TEST_TIME),
+    minimumRefreshIntervalMs: overrides.minimumRefreshIntervalMs ?? 0,
+    ...(overrides.maximumObservedWorkspaces === undefined
+      ? {}
+      : { maximumObservedWorkspaces: overrides.maximumObservedWorkspaces }),
+    ...(overrides.maximumObservedSessions === undefined
+      ? {}
+      : { maximumObservedSessions: overrides.maximumObservedSessions }),
+  });
+}
+
+const LUKE_PROJECT: TestProject = {
+  id: "project-luke",
+  name: "luke",
+  gitRemote: "https://github.com/reviewstage/luke.git",
+};
+
+function ownedWorkspace(id: string, lastActivityAt: number): TestWorkspace {
+  return {
+    id,
+    projectId: LUKE_PROJECT.id,
+    name: SECRET_PROMPT_TEXT,
+    creatorId: TEST_USER_ID,
+    lastActivityAt,
+  };
+}
+
+test("observes cloud sessions the signed-in user created without exposing prompt-derived names", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-active", TEST_TIME - 30_000)],
+    sessions: [
+      {
+        id: "session-working",
+        workspaceId: "workspace-active",
+        name: SECRET_PROMPT_TEXT,
+        resolvedModel: "claude-opus-5",
+        status: TEST_CONDUCTOR_STATUS.WORKING,
+        statusUpdatedAt: TEST_TIME - 5_000,
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.deepEqual(CONDUCTOR_PROVIDER, { id: "conductor", displayName: "Conductor" });
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "session-working");
+  assert.equal(observations[0]?.title, "Conductor: luke");
+  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
+  assert.equal(observations[0]?.observedAt, TEST_TIME - 5_000);
+  assert.equal(observations[0]?.controls, undefined);
+  assert.match(observations[0]?.summary ?? "", /claude-opus-5/);
+  assert.equal(JSON.stringify(observations).includes(SECRET_PROMPT_TEXT), false);
+  assert.equal(
+    api.requests.every((request) => request.method === "GET"),
+    true,
+  );
+  assert.equal(
+    api.requests.every((request) => request.authorization === `Bearer ${TEST_API_KEY}`),
+    true,
+  );
+});
+
+test("reports an idle session as waiting and an errored session as unknown", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-active", TEST_TIME - 30_000)],
+    sessions: [
+      {
+        id: "session-idle",
+        workspaceId: "workspace-active",
+        name: SECRET_PROMPT_TEXT,
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+      {
+        id: "session-errored",
+        workspaceId: "workspace-active",
+        name: SECRET_PROMPT_TEXT,
+        status: TEST_CONDUCTOR_STATUS.ERROR,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations.length, 2);
+  assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
+  assert.equal(observations[1]?.status, SESSION_STATUS.UNKNOWN);
+});
+
+test("reports an archived session as complete without requesting its status", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-active", TEST_TIME - 30_000)],
+    sessions: [
+      {
+        id: "session-archived",
+        workspaceId: "workspace-active",
+        name: SECRET_PROMPT_TEXT,
+        archivedAt: isoTimestamp(TEST_TIME - 20_000),
+        status: TEST_CONDUCTOR_STATUS.WORKING,
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.status, SESSION_STATUS.COMPLETE);
+  assert.equal(
+    api.requests.some((request) => request.pathname.endsWith("/status")),
+    false,
+  );
+});
+
+test("keeps reporting a long turn as working", async () => {
+  // Conductor stamps a status with the moment it was entered, so a turn that
+  // started an hour ago and is still running must not read as stale.
+  const startedAt = TEST_TIME - 60 * 60 * 1000;
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-long-turn", TEST_TIME - 1_000)],
+    sessions: [
+      {
+        id: "session-long-turn",
+        workspaceId: "workspace-long-turn",
+        name: SECRET_PROMPT_TEXT,
+        status: TEST_CONDUCTOR_STATUS.WORKING,
+        statusUpdatedAt: startedAt,
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
+  assert.equal(observations[0]?.observedAt, startedAt);
+});
+
+test("does not treat a long-idle chat as waiting because its workspace is busy", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    // One workspace holds several chats, so its activity timestamp moves
+    // whenever any one of them runs.
+    workspaces: [ownedWorkspace("workspace-busy", TEST_TIME - 1_000)],
+    sessions: [
+      {
+        id: "session-abandoned",
+        workspaceId: "workspace-busy",
+        name: SECRET_PROMPT_TEXT,
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 2 * 60 * 60 * 1000,
+      },
+      {
+        id: "session-just-finished",
+        workspaceId: "workspace-busy",
+        name: SECRET_PROMPT_TEXT,
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 20_000,
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations[0]?.providerSessionId, "session-abandoned");
+  assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(observations[1]?.providerSessionId, "session-just-finished");
+  assert.equal(observations[1]?.status, SESSION_STATUS.WAITING);
+});
+
+test("ignores workspaces created by another user and workspaces without a creator", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [
+      {
+        id: "workspace-teammate",
+        projectId: LUKE_PROJECT.id,
+        name: SECRET_PROMPT_TEXT,
+        creatorId: OTHER_USER_ID,
+        lastActivityAt: TEST_TIME - 1_000,
+      },
+      {
+        id: "workspace-unattributed",
+        projectId: LUKE_PROJECT.id,
+        name: SECRET_PROMPT_TEXT,
+        lastActivityAt: TEST_TIME - 1_000,
+      },
+    ],
+    sessions: [
+      { id: "session-teammate", workspaceId: "workspace-teammate", name: SECRET_PROMPT_TEXT },
+      {
+        id: "session-unattributed",
+        workspaceId: "workspace-unattributed",
+        name: SECRET_PROMPT_TEXT,
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.deepEqual(observations, []);
+  assert.equal(
+    api.requests.some((request) => request.pathname.includes("workspace-teammate")),
+    false,
+  );
+});
+
+test("ignores workspaces older than the maximum session age", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-yesterday", TEST_TIME - 48 * 60 * 60 * 1000)],
+    sessions: [
+      { id: "session-yesterday", workspaceId: "workspace-yesterday", name: SECRET_PROMPT_TEXT },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.deepEqual(observations, []);
+});
+
+test("bounds the workspaces and sessions a single pass observes", async () => {
+  const workspaces = Array.from({ length: 6 }, (_value, index) =>
+    ownedWorkspace(`workspace-${index}`, TEST_TIME - index * 1_000),
+  );
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces,
+    sessions: workspaces.map((workspace, index) => ({
+      id: `session-${index}`,
+      workspaceId: workspace.id,
+      name: SECRET_PROMPT_TEXT,
+      status: TEST_CONDUCTOR_STATUS.WORKING,
+      statusUpdatedAt: TEST_TIME - 1_000,
+    })),
+  });
+
+  const observations = await adapterFor(api.fetch, {
+    maximumObservedWorkspaces: 3,
+    maximumObservedSessions: 2,
+  }).observe();
+
+  assert.equal(observations.length, 2);
+  assert.deepEqual(
+    observations.map((observation) => observation.providerSessionId),
+    ["session-0", "session-1"],
+  );
+});
+
+test("spreads a bounded session budget across workspaces", async () => {
+  const workspaces = [
+    ownedWorkspace("workspace-crowded", TEST_TIME - 1_000),
+    ownedWorkspace("workspace-quiet", TEST_TIME - 2_000),
+  ];
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces,
+    sessions: [
+      ...Array.from({ length: 8 }, (_value, index) => ({
+        id: `crowded-${index}`,
+        workspaceId: "workspace-crowded",
+        name: SECRET_PROMPT_TEXT,
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      })),
+      {
+        id: "quiet-session",
+        workspaceId: "workspace-quiet",
+        name: SECRET_PROMPT_TEXT,
+        status: TEST_CONDUCTOR_STATUS.WORKING,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+  const observedIds = observations.map((observation) => observation.providerSessionId);
+
+  assert.equal(observedIds.filter((id) => id.startsWith("crowded-")).length, 4);
+  assert.equal(observedIds.includes("quiet-session"), true);
+});
+
+test("prefers open chats over closed ones inside one workspace", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-mixed", TEST_TIME - 1_000)],
+    sessions: [
+      ...Array.from({ length: 4 }, (_value, index) => ({
+        id: `closed-${index}`,
+        workspaceId: "workspace-mixed",
+        name: SECRET_PROMPT_TEXT,
+        archivedAt: isoTimestamp(TEST_TIME - 10_000),
+      })),
+      {
+        id: "open-session",
+        workspaceId: "workspace-mixed",
+        name: SECRET_PROMPT_TEXT,
+        status: TEST_CONDUCTOR_STATUS.WORKING,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations[0]?.providerSessionId, "open-session");
+  assert.equal(observations.length, 4);
+});
+
+test("reports nothing and issues no request without an API key", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-active", TEST_TIME - 1_000)],
+    sessions: [{ id: "session-active", workspaceId: "workspace-active", name: SECRET_PROMPT_TEXT }],
+  });
+
+  const observations = await adapterFor(api.fetch, { apiKey: undefined }).observe();
+
+  assert.deepEqual(observations, []);
+  assert.deepEqual(api.requests, []);
+});
+
+test("reports nothing when the credential cannot be read", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-active", TEST_TIME - 1_000)],
+    sessions: [{ id: "session-active", workspaceId: "workspace-active", name: SECRET_PROMPT_TEXT }],
+  });
+  const adapter = adapterFor(api.fetch, {
+    readApiKey: async () => {
+      throw new Error("settings are unreadable");
+    },
+  });
+
+  assert.deepEqual(await adapter.observe(), []);
+  assert.deepEqual(api.requests, []);
+});
+
+test("reuses the previous snapshot inside the minimum refresh interval", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-active", TEST_TIME - 1_000)],
+    sessions: [
+      {
+        id: "session-active",
+        workspaceId: "workspace-active",
+        name: SECRET_PROMPT_TEXT,
+        status: TEST_CONDUCTOR_STATUS.WORKING,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+    ],
+  });
+  let now = TEST_TIME;
+  const adapter = adapterFor(api.fetch, {
+    now: () => now,
+    minimumRefreshIntervalMs: 15_000,
+  });
+
+  const first = await adapter.observe();
+  const requestsAfterFirstPass = api.requests.length;
+  now = TEST_TIME + 5_000;
+  const throttled = await adapter.observe();
+  const requestsAfterThrottledPass = api.requests.length;
+  now = TEST_TIME + 20_000;
+  const refreshed = await adapter.observe();
+
+  assert.equal(first.length, 1);
+  assert.deepEqual(throttled, first);
+  assert.equal(
+    requestsAfterThrottledPass,
+    requestsAfterFirstPass,
+    "throttled pass issued requests",
+  );
+  assert.ok(api.requests.length > requestsAfterThrottledPass, "refreshed pass issued no request");
+  assert.equal(refreshed.length, 1);
+});
+
+test("observes again immediately after the API key changes", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-active", TEST_TIME - 1_000)],
+    sessions: [
+      {
+        id: "session-active",
+        workspaceId: "workspace-active",
+        name: SECRET_PROMPT_TEXT,
+        status: TEST_CONDUCTOR_STATUS.WORKING,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+    ],
+  });
+  let apiKey = TEST_API_KEY;
+  const adapter = adapterFor(api.fetch, {
+    readApiKey: async () => apiKey,
+    minimumRefreshIntervalMs: 60_000,
+  });
+
+  await adapter.observe();
+  const requestsAfterFirstPass = api.requests.length;
+  apiKey = "conductor-replacement-key";
+  const observations = await adapter.observe();
+
+  assert.ok(api.requests.length > requestsAfterFirstPass);
+  assert.equal(observations.length, 1);
+  assert.equal(
+    api.requests.at(-1)?.authorization,
+    "Bearer conductor-replacement-key",
+    "the replacement key was not used",
+  );
+});
+
+test("clears observations when Conductor rejects the API key", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-active", TEST_TIME - 1_000)],
+    sessions: [
+      {
+        id: "session-active",
+        workspaceId: "workspace-active",
+        name: SECRET_PROMPT_TEXT,
+        status: TEST_CONDUCTOR_STATUS.WORKING,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+    ],
+  });
+  let rejectRequests = false;
+  const gatedFetch: ConductorFetch = async (url, init) =>
+    rejectRequests ? jsonResponse({}, HTTP_STATUS.UNAUTHORIZED) : api.fetch(url, init);
+  const adapter = adapterFor(gatedFetch);
+
+  const authorized = await adapter.observe();
+  rejectRequests = true;
+  const rejected = await adapter.observe();
+
+  assert.equal(authorized.length, 1);
+  assert.deepEqual(rejected, []);
+});
+
+test("keeps the previous snapshot when a request fails transiently", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-active", TEST_TIME - 1_000)],
+    sessions: [
+      {
+        id: "session-active",
+        workspaceId: "workspace-active",
+        name: SECRET_PROMPT_TEXT,
+        status: TEST_CONDUCTOR_STATUS.WORKING,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+    ],
+  });
+  let failRequests = false;
+  const gatedFetch: ConductorFetch = async (url, init) => {
+    if (failRequests) throw new Error("network unreachable");
+    return api.fetch(url, init);
+  };
+  const adapter = adapterFor(gatedFetch);
+
+  const observed = await adapter.observe();
+  failRequests = true;
+  const duringOutage = await adapter.observe();
+
+  assert.equal(observed.length, 1);
+  assert.deepEqual(duringOutage, observed);
+});
+
+test("keeps observing when one session's status cannot be read", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-active", TEST_TIME - 1_000)],
+    sessions: [
+      {
+        id: "session-unreadable",
+        workspaceId: "workspace-active",
+        name: SECRET_PROMPT_TEXT,
+        statusHttpStatus: HTTP_STATUS.SERVER_ERROR,
+      },
+      {
+        id: "session-readable",
+        workspaceId: "workspace-active",
+        name: SECRET_PROMPT_TEXT,
+        status: TEST_CONDUCTOR_STATUS.WORKING,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations.length, 2);
+  assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(observations[1]?.status, SESSION_STATUS.WORKING);
+});

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test, { type TestContext } from "node:test";
+import { type SecretCipher, SettingsStore } from "../src/settings-store";
+import { CREDENTIAL_SOURCE } from "../src/shared/contracts";
+
+const TEST_API_KEY = "conductor-live-key";
+const SETTINGS_FILE_NAME = "settings.json";
+const CIPHER_PREFIX = "sealed:";
+
+const TEST_ENVIRONMENT_VARIABLE = {
+  API_KEY: "CONDUCTOR_API_KEY",
+  API_TOKEN: "CONDUCTOR_API_TOKEN",
+} as const;
+
+/** Stands in for Electron's Keychain-backed `safeStorage`. */
+function testCipher(available = true): SecretCipher {
+  return {
+    isAvailable: () => available,
+    encrypt: (plainText) => Buffer.from(`${CIPHER_PREFIX}${plainText}`, "utf8"),
+    decrypt: (cipherText) => {
+      const value = cipherText.toString("utf8");
+      if (!value.startsWith(CIPHER_PREFIX)) throw new Error("Unreadable ciphertext");
+      return value.slice(CIPHER_PREFIX.length);
+    },
+  };
+}
+
+async function temporaryDirectory(t: TestContext): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-settings-"));
+  t.after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  return directory;
+}
+
+function storeIn(
+  directory: string,
+  options: { cipher?: SecretCipher; environment?: NodeJS.ProcessEnv } = {},
+): SettingsStore {
+  return new SettingsStore({
+    directory: () => directory,
+    cipher: options.cipher ?? testCipher(),
+    environment: options.environment ?? {},
+  });
+}
+
+async function readSettingsFile(directory: string): Promise<string> {
+  return fs.readFile(path.join(directory, SETTINGS_FILE_NAME), "utf8");
+}
+
+test("stores an API key encrypted, private to the owner, and never in a snapshot", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+
+  const { settings, reason } = await store.setConductorApiKey(TEST_API_KEY);
+  const contents = await readSettingsFile(directory);
+  const stats = await fs.stat(path.join(directory, SETTINGS_FILE_NAME));
+
+  assert.equal(reason, undefined);
+  assert.equal(settings.conductorApiKeySource, CREDENTIAL_SOURCE.ENCRYPTED_FILE);
+  assert.equal(settings.secretStorageAvailable, true);
+  assert.equal(contents.includes(TEST_API_KEY), false, "the key was written in plaintext");
+  assert.equal(stats.mode & 0o777, 0o600);
+  assert.equal(JSON.stringify(settings).includes(TEST_API_KEY), false);
+  assert.equal(await store.readConductorApiKey(), TEST_API_KEY);
+});
+
+test("decrypts once and re-decrypts only after the key changes", async (t) => {
+  // The observation timer reads the credential every few seconds, so decrypting
+  // on each read would reach the OS keychain thousands of times a day.
+  const directory = await temporaryDirectory(t);
+  let decryptions = 0;
+  const cipher = testCipher();
+  const store = storeIn(directory, {
+    cipher: {
+      ...cipher,
+      decrypt: (cipherText) => {
+        decryptions += 1;
+        return cipher.decrypt(cipherText);
+      },
+    },
+  });
+  await store.setConductorApiKey(TEST_API_KEY);
+
+  const afterStore = decryptions;
+  for (let read = 0; read < 5; read += 1) await store.readConductorApiKey();
+  const afterReads = decryptions;
+  await store.setConductorApiKey("conductor-replacement-key");
+  await store.readConductorApiKey();
+
+  assert.equal(afterReads, afterStore, "a repeated read decrypted again");
+  assert.ok(decryptions > afterReads, "a replaced key was not re-read");
+  assert.equal(await store.readConductorApiKey(), "conductor-replacement-key");
+});
+
+test("reads a stored key back from a new store instance", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await storeIn(directory).setConductorApiKey(TEST_API_KEY);
+
+  const reopened = storeIn(directory);
+
+  assert.equal(await reopened.readConductorApiKey(), TEST_API_KEY);
+  assert.equal((await reopened.snapshot()).conductorApiKeySource, CREDENTIAL_SOURCE.ENCRYPTED_FILE);
+});
+
+test("clears a stored key", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+  await store.setConductorApiKey(TEST_API_KEY);
+
+  const { settings } = await store.setConductorApiKey(undefined);
+
+  assert.equal(settings.conductorApiKeySource, CREDENTIAL_SOURCE.NONE);
+  assert.equal(await store.readConductorApiKey(), undefined);
+  assert.equal((await readSettingsFile(directory)).includes("conductorApiKey"), false);
+});
+
+test("falls back to an API key from the environment", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory, {
+    environment: { [TEST_ENVIRONMENT_VARIABLE.API_TOKEN]: `  ${TEST_API_KEY}  ` },
+  });
+
+  const settings = await store.snapshot();
+
+  assert.equal(settings.conductorApiKeySource, CREDENTIAL_SOURCE.ENVIRONMENT);
+  assert.equal(await store.readConductorApiKey(), TEST_API_KEY);
+});
+
+test("prefers a stored key over one from the environment", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory, {
+    environment: { [TEST_ENVIRONMENT_VARIABLE.API_KEY]: "conductor-environment-key" },
+  });
+  await store.setConductorApiKey(TEST_API_KEY);
+
+  assert.equal(await store.readConductorApiKey(), TEST_API_KEY);
+});
+
+test("rejects a key that cannot be sent as an authorization header", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+
+  assert.match((await store.setConductorApiKey("short")).reason ?? "", /too short/);
+  assert.match((await store.setConductorApiKey("key with spaces")).reason ?? "", /unsupported/);
+  assert.match((await store.setConductorApiKey("k".repeat(513))).reason ?? "", /too long/);
+  assert.equal(await store.readConductorApiKey(), undefined);
+  await assert.rejects(() => readSettingsFile(directory), /ENOENT/);
+});
+
+test("refuses to store a key when encrypted storage is unavailable", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory, { cipher: testCipher(false) });
+
+  const { settings, reason } = await store.setConductorApiKey(TEST_API_KEY);
+
+  assert.match(reason ?? "", /unavailable/);
+  assert.equal(settings.secretStorageAvailable, false);
+  assert.equal(settings.conductorApiKeySource, CREDENTIAL_SOURCE.NONE);
+  await assert.rejects(() => readSettingsFile(directory), /ENOENT/);
+});
+
+test("ignores a stored key that can no longer be decrypted", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await storeIn(directory).setConductorApiKey(TEST_API_KEY);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({ version: 1, conductorApiKey: Buffer.from("rotated").toString("base64") }),
+  );
+
+  const store = storeIn(directory);
+
+  assert.equal(await store.readConductorApiKey(), undefined);
+  assert.equal((await store.snapshot()).conductorApiKeySource, CREDENTIAL_SOURCE.NONE);
+});
+
+test("recovers from a corrupt settings file", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(path.join(directory, SETTINGS_FILE_NAME), "{ not json");
+  const store = storeIn(directory);
+
+  const { settings } = await store.setConductorApiKey(TEST_API_KEY);
+
+  assert.equal(settings.conductorApiKeySource, CREDENTIAL_SOURCE.ENCRYPTED_FILE);
+  assert.equal(await store.readConductorApiKey(), TEST_API_KEY);
+});


### PR DESCRIPTION
## Summary

- Add `ConductorSessionAdapter`, Luke's first cloud provider: it walks the public Conductor API (`/me` → projects → workspaces → sessions → session status) with **GET requests only** and feeds each session into the existing observation pipeline. Sessions are labeled by repository (`Conductor: luke`), following the Codex adapter's precedent that prompt-derived text never reaches an observation. Observation is scoped to workspaces whose `creatorId` matches the authenticated user.
- Add a **Settings view** in the expanded panel and a `SettingsStore`: the Conductor API key is user-specific, so it belongs in the app rather than the environment. It is encrypted at rest via Electron `safeStorage` (Keychain-derived) into a mode-`0600` `settings.json`, with `CONDUCTOR_API_KEY` as an env fallback. The renderer can set or clear the key but never reads it back — it only learns where a key came from.
- Session recency is judged from each session's own status `updatedAt`, not the workspace's `lastActivityAt` (which masks per-session recency behind a running sibling), and a `working` status is trusted as live server state instead of aging out to `unknown` mid-turn. Both were caught against live data.
- Provider refreshes now run concurrently with per-adapter error isolation, so a stalled network provider can't hold the refresh lock and stop Claude Code/Codex from being observed.
- Under `--fixture`, the Conductor adapter is excluded from the adapter list entirely, keeping fixture runs deterministic and credential-free.

## Evidence

- Platform-independent checks: `./scripts/check.sh` green — 59 desktop, 31 core, 5 harness tests. Adapter tests cover status mapping, both timestamp bugs above, credential rejection clearing state, transient failures preserving the last snapshot, GET-only enforcement, and that prompt text never reaches an observation. Settings-store tests cover encryption at rest, file mode, decrypt caching, and that no accessor leaks the key.
- macOS Electron verification (`./scripts/verify.sh`): `not run` in this (Linux) workspace — covered by CI's macOS job.
- Live-data probe: 25 requests (all GET), 12 observations — 1 working, 3 waiting, 8 observed.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31633724837/artifacts/9156134462) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31633724837)

- Commit: `53af8a4f00f52d8b3b52afddfa816f6b0104de12`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` (the capture pipeline has no way to open the Settings view; a `--profile settings` capture flag is a possible follow-up)
- Physical-notch check: manually verified by @dastratakos on device — Settings reachable via notch hover → footer, key entry works (panel focus steal), rows appear on save, notch capsule stays put
- Device/display configuration: `not recorded`
- On-disk check: `settings.json` confirmed mode `600`, key present only as base64 ciphertext, no plaintext match

## Notes

- Dev runs (`@luke/desktop`) and the packaged app (`Luke`) derive different `userData` directories, so a key saved via `run.sh` won't be visible to a packaged build. Pre-existing Electron behavior; `app.setName("Luke")` would unify them but relocates existing state, so it's left for a separate decision (and `run.sh`'s lock-holder lookup would need updating in the same commit).
- Follow-up worth a ticket: cache the projects/workspaces layers with a minutes-long TTL — a full re-crawl every 15s is ~25 requests to keep 12 rows current, and only the per-session status changes on that timescale.
- Follow-up worth a ticket: `positiveInteger`/`nonNegativeNumber` and the filesystem-error helpers now exist in several copies across adapters; hoisting them into `sidecar-core` touches files outside this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a6c6a8b1-3da5-498d-9b48-374c326bed46)
