### PR TITLE
feat(LUKE-57): store API keys for multiple cloud providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,17 @@ bounded coding-agent session metadata without requiring provider plugins, hooks,
 wrappers, live-session changes, or transcript retention.
 
 Claude Code and Codex sessions are observed from local provider state and need
-no configuration. Conductor cloud sessions have no local state to read, so that
-provider stays silent until you open the expanded panel, choose **Settings**,
-and paste a Conductor API key; Luke also accepts one from `CONDUCTOR_API_KEY` or
-`CONDUCTOR_API_TOKEN`. A key you enter is encrypted with `safeStorage`, whose
-key comes from the login Keychain, and it is never returned to the renderer.
-Luke reads only cloud workspaces you created, issues only read requests, and
-labels each session by its repository rather than by a Conductor workspace or
-session name, because those names are generated from the opening prompt.
+no configuration. A cloud provider has no local state to read, so it stays
+silent until you open the expanded panel, choose **Settings**, and paste a key
+in that provider's row. Each provider holds its own credential and also reads
+its own `<PROVIDER>_API_KEY` from the environment; Conductor accepts
+`CONDUCTOR_API_KEY` or `CONDUCTOR_API_TOKEN`. A provider you give no key to
+reports nothing and issues no request. A key you enter is encrypted with
+`safeStorage`, whose key comes from the login Keychain, and it is never returned
+to the renderer. Luke reads only cloud workspaces you created, issues only read
+requests, and labels each session by its repository rather than by a provider
+workspace or session name, because those names are generated from the opening
+prompt.
 
 ## Attention intelligence
 

--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -16,9 +16,12 @@ import {
   textFromRecord,
   timestampFromRecord,
 } from "./cloud-session-adapter";
+import { CREDENTIAL_PROVIDER_ID, CREDENTIAL_PROVIDERS } from "./shared/credential-providers";
 
-const CONDUCTOR_PROVIDER_ID = "conductor";
-const CONDUCTOR_PROVIDER_NAME = "Conductor";
+// Shared with the credential registry so the key the user saves and the
+// provider Luke observes with it can never name different things.
+const CONDUCTOR_PROVIDER_ID = CREDENTIAL_PROVIDER_ID.CONDUCTOR;
+const CONDUCTOR_PROVIDER_NAME = CREDENTIAL_PROVIDERS[CREDENTIAL_PROVIDER_ID.CONDUCTOR].displayName;
 
 const CONDUCTOR_ENVIRONMENT = {
   API_URL: "CONDUCTOR_API_URL",

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -7,6 +7,7 @@ import {
   type NativeNotchGeometry,
   positionNotchWindow,
   SessionAttentionReviewer,
+  type SessionProviderAdapter,
 } from "@sidecar/core";
 import {
   app,
@@ -38,6 +39,11 @@ import {
   type SettingsUpdateResult,
   type WindowMode,
 } from "./shared/contracts";
+import {
+  CREDENTIAL_PROVIDER_ID,
+  type CredentialProviderId,
+  isCredentialProviderId,
+} from "./shared/credential-providers";
 
 const captureOutput = argumentValue("--capture-evidence");
 const profile = argumentValue("--profile") ?? "idle";
@@ -60,8 +66,12 @@ const settingsStore = new SettingsStore({
   },
 });
 const conductorAdapter = new ConductorSessionAdapter({
-  readApiKey: () => settingsStore.readConductorApiKey(),
+  readApiKey: () => settingsStore.readApiKey(CREDENTIAL_PROVIDER_ID.CONDUCTOR),
 });
+// Saving a key affects only the provider it belongs to, so this maps each
+// credential to the one observer that reads it.
+const adapterByCredentialProvider: ReadonlyMap<CredentialProviderId, SessionProviderAdapter> =
+  new Map([[CREDENTIAL_PROVIDER_ID.CONDUCTOR, conductorAdapter]]);
 const sessionAdapters = [
   new ClaudeCodeSessionAdapter(),
   new CodexSessionAdapter(),
@@ -251,20 +261,25 @@ function registerIpc(): void {
     return requestMicrophone();
   });
 
-  // The renderer can replace or clear the credential but never reads it back;
-  // the reply reports only where a key now comes from.
+  // The renderer can replace or clear a provider's credential but never reads
+  // it back; the reply reports only where each key now comes from.
   ipcMain.handle(
-    channels.setConductorApiKey,
-    async (event, apiKey: unknown): Promise<SettingsUpdateResult> => {
+    channels.setProviderApiKey,
+    async (event, providerId: unknown, apiKey: unknown): Promise<SettingsUpdateResult> => {
       if (!trustedSender(event)) throw new Error("Untrusted renderer");
+      // The provider list is fixed by this build, so an id outside it is a
+      // malformed request rather than something the user can correct.
+      if (!isCredentialProviderId(providerId)) throw new Error("Unknown credential provider");
       if (apiKey !== undefined && typeof apiKey !== "string") {
         throw new Error("Invalid API key request");
       }
       try {
-        const result = await settingsStore.setConductorApiKey(apiKey);
-        // Only the credentialed provider is affected, so the local observers are
-        // left alone rather than re-crawling the filesystem on every save.
-        if (!result.reason) void sessionRegistry.refresh(conductorAdapter);
+        const result = await settingsStore.setApiKey(providerId, apiKey);
+        // Only the provider whose key changed is affected, so the local
+        // observers are left alone rather than re-crawling the filesystem on
+        // every save.
+        const adapter = adapterByCredentialProvider.get(providerId);
+        if (!result.reason && adapter) void sessionRegistry.refresh(adapter);
         return result;
       } catch {
         // A filesystem failure is not something the user can act on, so it is

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -9,6 +9,7 @@ import type {
   WindowMode,
 } from "./shared/contracts";
 import { channels } from "./shared/contracts";
+import type { CredentialProviderId } from "./shared/credential-providers";
 
 const bridge: AppBridge = {
   getBootstrap: () => ipcRenderer.invoke(channels.bootstrap) as Promise<AppBootstrap>,
@@ -19,8 +20,12 @@ const bridge: AppBridge = {
   },
   requestMicrophone: () =>
     ipcRenderer.invoke(channels.requestMicrophone) as Promise<MicrophoneStatus>,
-  setConductorApiKey: (apiKey: string | undefined) =>
-    ipcRenderer.invoke(channels.setConductorApiKey, apiKey) as Promise<SettingsUpdateResult>,
+  setProviderApiKey: (providerId: CredentialProviderId, apiKey: string | undefined) =>
+    ipcRenderer.invoke(
+      channels.setProviderApiKey,
+      providerId,
+      apiKey,
+    ) as Promise<SettingsUpdateResult>,
   focusPanel: () => ipcRenderer.send(channels.focusPanel),
   notifyReady: () => ipcRenderer.send(channels.rendererReady),
   quit: () => ipcRenderer.send(channels.quit),

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -5,7 +5,7 @@ import {
   SESSION_STATUS,
   type SessionState,
 } from "@sidecar/core";
-import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
+import { type CSSProperties, useCallback, useEffect, useId, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import type {
   AppBootstrap,
@@ -16,6 +16,8 @@ import type {
   WindowMode,
 } from "../shared/contracts";
 import { CREDENTIAL_SOURCE } from "../shared/contracts";
+import type { CredentialProvider, CredentialProviderId } from "../shared/credential-providers";
+import { CREDENTIAL_PROVIDER_LIST } from "../shared/credential-providers";
 
 const credentialLabels: Record<CredentialSource, string> = {
   [CREDENTIAL_SOURCE.NONE]: "Not connected",
@@ -148,35 +150,43 @@ function Waveform({
 }
 
 /**
- * The credential is write-only from the renderer: this form can replace or
- * clear the stored key, and the main process never sends one back.
+ * One provider's credential. It is write-only from the renderer: the row can
+ * replace or clear that provider's key, and the main process never sends one
+ * back.
  */
-function ConductorSettings({
-  settings,
+function CredentialRow({
+  provider,
+  source,
+  storageUnavailable,
+  focusOnOpen,
   onSubmit,
 }: {
-  settings: AppSettings;
-  onSubmit: (apiKey: string | undefined) => Promise<string | undefined>;
+  provider: CredentialProvider;
+  source: CredentialSource;
+  storageUnavailable: boolean;
+  focusOnOpen: boolean;
+  onSubmit: (
+    providerId: CredentialProviderId,
+    apiKey: string | undefined,
+  ) => Promise<string | undefined>;
 }): React.JSX.Element {
   const [draft, setDraft] = useState("");
   const [rejection, setRejection] = useState<string>();
   const [busy, setBusy] = useState(false);
   const field = useRef<HTMLInputElement | null>(null);
+  const fieldId = useId();
 
-  const storageUnavailable = !settings.secretStorageAvailable;
-  const hasStoredKey = settings.conductorApiKeySource === CREDENTIAL_SOURCE.ENCRYPTED_FILE;
+  const hasStoredKey = source === CREDENTIAL_SOURCE.ENCRYPTED_FILE;
 
   useEffect(() => {
-    // The panel is shown without stealing focus, so typing only works once the
-    // window itself is key. `preventScroll` keeps this from scrolling the panel
-    // body, which is the one scroll container the layout allows.
-    window.sidecar.focusPanel();
-    if (!storageUnavailable) field.current?.focus({ preventScroll: true });
-  }, [storageUnavailable]);
+    // `preventScroll` keeps this from scrolling the panel body, which is the one
+    // scroll container the layout allows.
+    if (focusOnOpen && !storageUnavailable) field.current?.focus({ preventScroll: true });
+  }, [focusOnOpen, storageUnavailable]);
 
   const submit = async (apiKey: string | undefined) => {
     setBusy(true);
-    const failure = await onSubmit(apiKey);
+    const failure = await onSubmit(provider.id, apiKey);
     setBusy(false);
     setRejection(failure);
     if (!failure) setDraft("");
@@ -184,10 +194,10 @@ function ConductorSettings({
 
   return (
     <div className="settings-view">
-      <label className="settings-field" htmlFor="conductor-api-key">
-        <span className="settings-label">Conductor cloud API key</span>
+      <label className="settings-field" htmlFor={fieldId}>
+        <span className="settings-label">{provider.displayName} cloud API key</span>
         <input
-          id="conductor-api-key"
+          id={fieldId}
           ref={field}
           className="settings-input"
           type="password"
@@ -201,9 +211,7 @@ function ConductorSettings({
       </label>
 
       <div className="settings-row">
-        <span className={`settings-state ${settings.conductorApiKeySource}`}>
-          {credentialLabels[settings.conductorApiKeySource]}
-        </span>
+        <span className={`settings-state ${source}`}>{credentialLabels[source]}</span>
         <span className="settings-actions">
           {hasStoredKey ? (
             <button
@@ -226,12 +234,48 @@ function ConductorSettings({
         </span>
       </div>
 
+      <p className="settings-hint">{provider.hint}</p>
+      {rejection ? <p className="settings-error">{rejection}</p> : null}
+    </div>
+  );
+}
+
+/** One row per cloud provider, each with its own credential and its own state. */
+function CredentialSettings({
+  settings,
+  onSubmit,
+}: {
+  settings: AppSettings;
+  onSubmit: (
+    providerId: CredentialProviderId,
+    apiKey: string | undefined,
+  ) => Promise<string | undefined>;
+}): React.JSX.Element {
+  const storageUnavailable = !settings.secretStorageAvailable;
+
+  useEffect(() => {
+    // The panel is shown without stealing focus, so typing only works once the
+    // window itself is key.
+    window.sidecar.focusPanel();
+  }, []);
+
+  return (
+    <div className="settings-list">
+      {CREDENTIAL_PROVIDER_LIST.map((provider, index) => (
+        <CredentialRow
+          key={provider.id}
+          provider={provider}
+          source={settings.credentialSources[provider.id]}
+          storageUnavailable={storageUnavailable}
+          focusOnOpen={index === 0}
+          onSubmit={onSubmit}
+        />
+      ))}
       <p className="settings-hint">
         {storageUnavailable
           ? "This system offers no encrypted credential storage, so Luke will not store a key here."
-          : "Create a key in Conductor under Settings · API keys. Luke reads only cloud workspaces you created and never sends a prompt, message, or any other change."}
+          : "Luke reads only cloud workspaces you created and never sends a prompt, message, or any other change."}
       </p>
-      {rejection ? <p className="settings-error">{rejection}</p> : null}
     </div>
   );
 }
@@ -422,11 +466,14 @@ function App(): React.JSX.Element {
 
   usePointerPassthrough(handleHitRegionEnter, handleHitRegionLeave);
 
-  const submitConductorApiKey = useCallback(async (apiKey: string | undefined) => {
-    const result = await window.sidecar.setConductorApiKey(apiKey);
-    setSettings(result.settings);
-    return result.reason;
-  }, []);
+  const submitProviderApiKey = useCallback(
+    async (providerId: CredentialProviderId, apiKey: string | undefined) => {
+      const result = await window.sidecar.setProviderApiKey(providerId, apiKey);
+      setSettings(result.settings);
+      return result.reason;
+    },
+    [],
+  );
 
   useEffect(() => {
     const bootstrapGeneration = modeGeneration.current;
@@ -587,7 +634,7 @@ function App(): React.JSX.Element {
             </div>
 
             {settingsOpen && settings ? (
-              <ConductorSettings settings={settings} onSubmit={submitConductorApiKey} />
+              <CredentialSettings settings={settings} onSubmit={submitProviderApiKey} />
             ) : (
               <div className="session-list">
                 {visibleSessions.map((item) => (

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -390,6 +390,13 @@ h1 {
 /* Natural height inside the scrolling body, for the same reason session rows
    take theirs: a stretched child would be shrunk below its content instead of
    letting the body scroll. */
+.settings-list {
+  display: flex;
+  flex: none;
+  flex-direction: column;
+  gap: 12px;
+}
+
 .settings-view {
   display: flex;
   flex: none;

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -143,7 +143,7 @@ export class SettingsStore {
   readonly #providers: readonly CredentialProvider[];
   #loading: Promise<PersistedSettings> | undefined;
   #resolved = new Map<CredentialProviderId, ResolvedApiKey>();
-  #pendingWrite: Promise<void> = Promise.resolve();
+  #mutations: Promise<void> = Promise.resolve();
 
   constructor(options: SettingsStoreOptions) {
     this.#directory = options.directory;
@@ -195,9 +195,12 @@ export class SettingsStore {
       : undefined;
     if (rejection) return { settings: await this.snapshot(), reason: rejection };
 
-    const persisted = await this.#load();
-    const ciphertext = normalized ? this.#cipher.encrypt(normalized).toString("base64") : undefined;
-    if (persisted.apiKeys[providerId] !== ciphertext) {
+    await this.#serialize(async () => {
+      const persisted = await this.#load();
+      const ciphertext = normalized
+        ? this.#cipher.encrypt(normalized).toString("base64")
+        : undefined;
+      if (persisted.apiKeys[providerId] === ciphertext) return;
       // Every other provider's ciphertext is carried over, so saving one key
       // never disturbs another.
       const apiKeys = { ...persisted.apiKeys };
@@ -207,8 +210,25 @@ export class SettingsStore {
       await this.#write(next);
       this.#loading = Promise.resolve(next);
       this.#resolved.delete(providerId);
-    }
+    });
     return { settings: await this.snapshot() };
+  }
+
+  /**
+   * Runs one settings change at a time. Serializing only the file write is not
+   * enough: a user with more than one provider row can start a second save
+   * before the first lands, and both would read the same stored keys before
+   * either wrote, so the later write would drop the other provider's key.
+   */
+  async #serialize<Result>(operation: () => Promise<Result>): Promise<Result> {
+    const result = this.#mutations.then(operation);
+    // A failed change must not wedge the queue, so the chain forgets its
+    // outcome; the caller still receives the rejection.
+    this.#mutations = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
   }
 
   #secretStorageAvailable(): boolean {
@@ -278,22 +298,19 @@ export class SettingsStore {
     return persisted;
   }
 
+  /** Only ever called from inside `#serialize`, so writes cannot interleave. */
   async #write(persisted: PersistedSettings): Promise<void> {
-    const write = this.#pendingWrite.then(async () => {
-      const directory = this.#directory();
-      const settingsPath = path.join(directory, SETTINGS_FILE_NAME);
-      const temporaryPath = path.join(directory, SETTINGS_TEMPORARY_FILE_NAME);
-      await fs.mkdir(directory, { recursive: true });
-      await fs.writeFile(temporaryPath, `${JSON.stringify(persisted, undefined, 2)}\n`, {
-        encoding: "utf8",
-        mode: SETTINGS_FILE_MODE,
-      });
-      // `mode` only applies when the file is created, so a temporary file left
-      // behind by an interrupted write keeps whatever mode it already had.
-      await fs.chmod(temporaryPath, SETTINGS_FILE_MODE);
-      await fs.rename(temporaryPath, settingsPath);
+    const directory = this.#directory();
+    const settingsPath = path.join(directory, SETTINGS_FILE_NAME);
+    const temporaryPath = path.join(directory, SETTINGS_TEMPORARY_FILE_NAME);
+    await fs.mkdir(directory, { recursive: true });
+    await fs.writeFile(temporaryPath, `${JSON.stringify(persisted, undefined, 2)}\n`, {
+      encoding: "utf8",
+      mode: SETTINGS_FILE_MODE,
     });
-    this.#pendingWrite = write.catch(() => undefined);
-    await write;
+    // `mode` only applies when the file is created, so a temporary file left
+    // behind by an interrupted write keeps whatever mode it already had.
+    await fs.chmod(temporaryPath, SETTINGS_FILE_MODE);
+    await fs.rename(temporaryPath, settingsPath);
   }
 }

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -6,15 +6,23 @@ import {
   type CredentialSource,
   type SettingsUpdateResult,
 } from "./shared/contracts";
+import {
+  CREDENTIAL_PROVIDER_ID,
+  CREDENTIAL_PROVIDER_LIST,
+  type CredentialProvider,
+  type CredentialProviderId,
+} from "./shared/credential-providers";
 
 const SETTINGS_FILE_NAME = "settings.json";
 const SETTINGS_TEMPORARY_FILE_NAME = "settings.json.tmp";
-const SETTINGS_FILE_VERSION = 1;
+/** Version 2 keys credentials by provider id; version 1 held one Conductor key. */
+const SETTINGS_FILE_VERSION = 2;
 const SETTINGS_FILE_MODE = 0o600;
 
-const CONDUCTOR_ENVIRONMENT = {
-  API_KEY: "CONDUCTOR_API_KEY",
-  API_TOKEN: "CONDUCTOR_API_TOKEN",
+const SETTINGS_FIELD = {
+  API_KEYS: "apiKeys",
+  LEGACY_CONDUCTOR_API_KEY: "conductorApiKey",
+  VERSION: "version",
 } as const;
 
 const API_KEY_LENGTH = {
@@ -39,11 +47,16 @@ export interface SettingsStoreOptions {
   directory: () => string;
   cipher: SecretCipher;
   environment?: NodeJS.ProcessEnv;
+  providers?: readonly CredentialProvider[];
 }
 
 interface PersistedSettings {
   version: number;
-  conductorApiKey?: string;
+  /**
+   * Ciphertext by provider id. A provider this build does not know is carried
+   * through untouched so an older build cannot discard a newer one's key.
+   */
+  apiKeys: Readonly<Record<string, string>>;
 }
 
 interface ResolvedApiKey {
@@ -67,22 +80,42 @@ function canIgnoreFilesystemError(error: unknown): boolean {
 
 /**
  * A rejected key never reaches disk, and the reason never echoes the submitted
- * value. Conductor does not publish a key format, so this only rules out values
- * that cannot be sent as an HTTP authorization header.
+ * value. No provider Luke reads publishes a key format, so this only rules out
+ * values that cannot be sent as an HTTP authorization header.
  */
-export function conductorApiKeyRejection(apiKey: string): string | undefined {
+export function apiKeyRejection(apiKey: string): string | undefined {
   if (apiKey.length < API_KEY_LENGTH.MINIMUM) return "That API key is too short.";
   if (apiKey.length > API_KEY_LENGTH.MAXIMUM) return "That API key is too long.";
   if (!PRINTABLE_ASCII.test(apiKey)) return "That API key contains unsupported characters.";
   return undefined;
 }
 
-function environmentApiKey(environment: NodeJS.ProcessEnv): string | undefined {
-  for (const variable of [CONDUCTOR_ENVIRONMENT.API_KEY, CONDUCTOR_ENVIRONMENT.API_TOKEN]) {
+function environmentApiKey(
+  provider: CredentialProvider,
+  environment: NodeJS.ProcessEnv,
+): string | undefined {
+  for (const variable of provider.environmentVariables) {
     const value = environment[variable]?.trim();
-    if (value && !conductorApiKeyRejection(value)) return value;
+    if (value && !apiKeyRejection(value)) return value;
   }
   return undefined;
+}
+
+function storedApiKeys(record: Record<string, unknown>): Record<string, string> {
+  const apiKeys: Record<string, string> = {};
+  const persisted = record[SETTINGS_FIELD.API_KEYS];
+  if (persisted !== null && typeof persisted === "object" && !Array.isArray(persisted)) {
+    for (const [providerId, ciphertext] of Object.entries(persisted)) {
+      if (typeof ciphertext === "string" && ciphertext) apiKeys[providerId] = ciphertext;
+    }
+  }
+  // An installation upgraded from version 1 keeps its Conductor key: the
+  // ciphertext is unchanged, so it decrypts exactly as it did before.
+  const legacy = record[SETTINGS_FIELD.LEGACY_CONDUCTOR_API_KEY];
+  if (typeof legacy === "string" && legacy && !apiKeys[CREDENTIAL_PROVIDER_ID.CONDUCTOR]) {
+    apiKeys[CREDENTIAL_PROVIDER_ID.CONDUCTOR] = legacy;
+  }
+  return apiKeys;
 }
 
 function parsePersistedSettings(source: string): PersistedSettings {
@@ -91,69 +124,89 @@ function parsePersistedSettings(source: string): PersistedSettings {
     throw new Error("Settings file is not an object");
   }
   const record = parsed as Record<string, unknown>;
-  const conductorApiKey = record.conductorApiKey;
+  const version = record[SETTINGS_FIELD.VERSION];
   return {
-    version: typeof record.version === "number" ? record.version : SETTINGS_FILE_VERSION,
-    ...(typeof conductorApiKey === "string" && conductorApiKey ? { conductorApiKey } : {}),
+    version: typeof version === "number" ? version : SETTINGS_FILE_VERSION,
+    apiKeys: storedApiKeys(record),
   };
 }
 
 /**
  * Reads and writes the small set of user-owned settings Luke needs. A stored
- * credential stays in the main process: callers can learn that a key exists and
- * can replace it, but no accessor returns it to a renderer.
+ * credential stays in the main process: callers can learn that a provider has a
+ * key and can replace it, but no accessor returns one to a renderer.
  */
 export class SettingsStore {
   readonly #directory: () => string;
   readonly #cipher: SecretCipher;
   readonly #environment: NodeJS.ProcessEnv;
+  readonly #providers: readonly CredentialProvider[];
   #loading: Promise<PersistedSettings> | undefined;
-  #resolved: ResolvedApiKey | undefined;
+  #resolved = new Map<CredentialProviderId, ResolvedApiKey>();
   #pendingWrite: Promise<void> = Promise.resolve();
 
   constructor(options: SettingsStoreOptions) {
     this.#directory = options.directory;
     this.#cipher = options.cipher;
     this.#environment = options.environment ?? process.env;
+    this.#providers = options.providers ?? CREDENTIAL_PROVIDER_LIST;
   }
 
   async snapshot(): Promise<AppSettings> {
-    const { source } = await this.#resolveApiKey();
+    const sources = await Promise.all(
+      this.#providers.map(
+        async (provider) => [provider.id, (await this.#resolveApiKey(provider)).source] as const,
+      ),
+    );
     return {
-      conductorApiKeySource: source,
+      credentialSources: Object.fromEntries(sources) as Record<
+        CredentialProviderId,
+        CredentialSource
+      >,
       secretStorageAvailable: this.#secretStorageAvailable(),
     };
   }
 
-  /** Main-process only: the resolved key used to authenticate provider reads. */
-  async readConductorApiKey(): Promise<string | undefined> {
-    return (await this.#resolveApiKey()).apiKey;
+  /**
+   * Main-process only: the resolved key used to authenticate that provider's
+   * reads. A provider with no key resolves to nothing, so its adapter observes
+   * nothing and issues no request.
+   */
+  async readApiKey(providerId: CredentialProviderId): Promise<string | undefined> {
+    const provider = this.#providers.find((candidate) => candidate.id === providerId);
+    if (!provider) return undefined;
+    return (await this.#resolveApiKey(provider)).apiKey;
   }
 
   /**
-   * Stores a key encrypted at rest, or clears the stored key when omitted. A key
-   * the user cannot use comes back as a `reason` rather than an exception, so
-   * only an unexpected filesystem failure throws.
+   * Stores one provider's key encrypted at rest, or clears it when omitted. A
+   * key the user cannot use comes back as a `reason` rather than an exception,
+   * so only an unexpected filesystem failure throws.
    */
-  async setConductorApiKey(apiKey: string | undefined): Promise<SettingsUpdateResult> {
+  async setApiKey(
+    providerId: CredentialProviderId,
+    apiKey: string | undefined,
+  ): Promise<SettingsUpdateResult> {
     const normalized = apiKey?.trim();
     const rejection = normalized
       ? !this.#secretStorageAvailable()
         ? "Encrypted credential storage is unavailable on this system."
-        : conductorApiKeyRejection(normalized)
+        : apiKeyRejection(normalized)
       : undefined;
     if (rejection) return { settings: await this.snapshot(), reason: rejection };
 
     const persisted = await this.#load();
     const ciphertext = normalized ? this.#cipher.encrypt(normalized).toString("base64") : undefined;
-    const next: PersistedSettings = {
-      version: SETTINGS_FILE_VERSION,
-      ...(ciphertext ? { conductorApiKey: ciphertext } : {}),
-    };
-    if (persisted.conductorApiKey !== next.conductorApiKey) {
+    if (persisted.apiKeys[providerId] !== ciphertext) {
+      // Every other provider's ciphertext is carried over, so saving one key
+      // never disturbs another.
+      const apiKeys = { ...persisted.apiKeys };
+      if (ciphertext) apiKeys[providerId] = ciphertext;
+      else delete apiKeys[providerId];
+      const next: PersistedSettings = { version: SETTINGS_FILE_VERSION, apiKeys };
       await this.#write(next);
       this.#loading = Promise.resolve(next);
-      this.#resolved = undefined;
+      this.#resolved.delete(providerId);
     }
     return { settings: await this.snapshot() };
   }
@@ -171,24 +224,26 @@ export class SettingsStore {
    * few seconds, and decrypting on each tick would hit the OS keychain
    * thousands of times a day for a value only the user can change.
    */
-  async #resolveApiKey(): Promise<ResolvedApiKey> {
-    if (this.#resolved) return this.#resolved;
-    const stored = await this.#storedApiKey();
-    const fromEnvironment = stored ? undefined : environmentApiKey(this.#environment);
-    this.#resolved = stored
+  async #resolveApiKey(provider: CredentialProvider): Promise<ResolvedApiKey> {
+    const cached = this.#resolved.get(provider.id);
+    if (cached) return cached;
+    const stored = await this.#storedApiKey(provider);
+    const fromEnvironment = stored ? undefined : environmentApiKey(provider, this.#environment);
+    const resolved: ResolvedApiKey = stored
       ? { apiKey: stored, source: CREDENTIAL_SOURCE.ENCRYPTED_FILE }
       : fromEnvironment
         ? { apiKey: fromEnvironment, source: CREDENTIAL_SOURCE.ENVIRONMENT }
         : { source: CREDENTIAL_SOURCE.NONE };
-    return this.#resolved;
+    this.#resolved.set(provider.id, resolved);
+    return resolved;
   }
 
-  async #storedApiKey(): Promise<string | undefined> {
-    const { conductorApiKey } = await this.#load();
-    if (!conductorApiKey) return undefined;
+  async #storedApiKey(provider: CredentialProvider): Promise<string | undefined> {
+    const ciphertext = (await this.#load()).apiKeys[provider.id];
+    if (!ciphertext) return undefined;
     try {
-      const apiKey = this.#cipher.decrypt(Buffer.from(conductorApiKey, "base64")).trim();
-      return apiKey && !conductorApiKeyRejection(apiKey) ? apiKey : undefined;
+      const apiKey = this.#cipher.decrypt(Buffer.from(ciphertext, "base64")).trim();
+      return apiKey && !apiKeyRejection(apiKey) ? apiKey : undefined;
     } catch {
       // A key encrypted under a different account, or against a rotated
       // Keychain entry, cannot be recovered; the user re-enters it instead.
@@ -211,7 +266,7 @@ export class SettingsStore {
       if (!canIgnoreFilesystemError(error)) throw error;
     }
 
-    let persisted: PersistedSettings = { version: SETTINGS_FILE_VERSION };
+    let persisted: PersistedSettings = { version: SETTINGS_FILE_VERSION, apiKeys: {} };
     if (source) {
       try {
         persisted = parsePersistedSettings(source);

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -5,6 +5,7 @@ import type {
   ResolvedNotchGeometry,
   WindowMode,
 } from "@sidecar/core";
+import type { CredentialProviderId } from "./credential-providers";
 
 export type { WindowMode } from "@sidecar/core";
 
@@ -21,7 +22,8 @@ export type CredentialSource = (typeof CREDENTIAL_SOURCE)[keyof typeof CREDENTIA
 
 /** Renderer-safe settings. Credentials are never sent to a renderer. */
 export interface AppSettings {
-  conductorApiKeySource: CredentialSource;
+  /** Where each provider's key comes from, keyed by provider id. */
+  credentialSources: Readonly<Record<CredentialProviderId, CredentialSource>>;
   /**
    * Luke stores credentials only through OS-provided encryption. When that is
    * unavailable the app says so rather than falling back to plaintext storage.
@@ -67,7 +69,10 @@ export interface AppBridge {
   setExpanded(expanded: boolean): Promise<WindowMode>;
   setPointerInterception(interceptsPointer: boolean): void;
   requestMicrophone(): Promise<MicrophoneStatus>;
-  setConductorApiKey(apiKey: string | undefined): Promise<SettingsUpdateResult>;
+  setProviderApiKey(
+    providerId: CredentialProviderId,
+    apiKey: string | undefined,
+  ): Promise<SettingsUpdateResult>;
   /** Brings the expanded panel forward so it can accept typed input. */
   focusPanel(): void;
   notifyReady(): void;
@@ -83,7 +88,7 @@ export const channels = {
   setExpanded: "app:set-expanded",
   setPointerInterception: "app:set-pointer-interception",
   requestMicrophone: "app:request-microphone",
-  setConductorApiKey: "app:set-conductor-api-key",
+  setProviderApiKey: "app:set-provider-api-key",
   focusPanel: "app:focus-panel",
   rendererReady: "app:renderer-ready",
   lifecycle: "app:lifecycle",

--- a/apps/desktop/src/shared/credential-providers.ts
+++ b/apps/desktop/src/shared/credential-providers.ts
@@ -1,0 +1,51 @@
+/**
+ * The providers Luke can hold a credential for. A provider belongs here only
+ * when its sessions live in a cloud service with no local state to observe, and
+ * it must observe nothing at all until the user supplies a key.
+ */
+export const CREDENTIAL_PROVIDER_ID = {
+  CONDUCTOR: "conductor",
+} as const;
+
+export type CredentialProviderId =
+  (typeof CREDENTIAL_PROVIDER_ID)[keyof typeof CREDENTIAL_PROVIDER_ID];
+
+/**
+ * `<PROVIDER>_API_KEY` is the convention every provider follows. A provider may
+ * name additional variables it also honours.
+ */
+const CONDUCTOR_ENVIRONMENT = {
+  API_KEY: "CONDUCTOR_API_KEY",
+  API_TOKEN: "CONDUCTOR_API_TOKEN",
+} as const;
+
+export interface CredentialProvider {
+  id: CredentialProviderId;
+  displayName: string;
+  /** Where the user creates a key, shown beside that provider's field. */
+  hint: string;
+  /** Read in order when nothing is stored for this provider. */
+  environmentVariables: readonly string[];
+}
+
+/** Keyed by provider id so no caller has to build a key from an identifier. */
+export const CREDENTIAL_PROVIDERS: Readonly<Record<CredentialProviderId, CredentialProvider>> = {
+  [CREDENTIAL_PROVIDER_ID.CONDUCTOR]: {
+    id: CREDENTIAL_PROVIDER_ID.CONDUCTOR,
+    displayName: "Conductor",
+    hint: "Create a key in Conductor under Settings · API keys.",
+    environmentVariables: [CONDUCTOR_ENVIRONMENT.API_KEY, CONDUCTOR_ENVIRONMENT.API_TOKEN],
+  },
+};
+
+/** Settings lists providers in this order. */
+export const CREDENTIAL_PROVIDER_LIST: readonly CredentialProvider[] =
+  Object.values(CREDENTIAL_PROVIDERS);
+
+/**
+ * Guards the provider id an IPC message carries. `hasOwn` rather than `in`: an
+ * inherited name such as `toString` is not a provider.
+ */
+export function isCredentialProviderId(value: unknown): value is CredentialProviderId {
+  return typeof value === "string" && Object.hasOwn(CREDENTIAL_PROVIDERS, value);
+}

--- a/apps/desktop/tests/credential-providers.test.ts
+++ b/apps/desktop/tests/credential-providers.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  CREDENTIAL_PROVIDER_ID,
+  CREDENTIAL_PROVIDER_LIST,
+  CREDENTIAL_PROVIDERS,
+  isCredentialProviderId,
+} from "../src/shared/credential-providers";
+
+test("accepts only a provider the build ships", () => {
+  assert.equal(isCredentialProviderId(CREDENTIAL_PROVIDER_ID.CONDUCTOR), true);
+  assert.equal(isCredentialProviderId("unknown-cloud"), false);
+  // An inherited property name is not a provider, and neither is a value that
+  // is not a string at all.
+  assert.equal(isCredentialProviderId("toString"), false);
+  assert.equal(isCredentialProviderId("__proto__"), false);
+  assert.equal(isCredentialProviderId(undefined), false);
+  assert.equal(isCredentialProviderId({ id: CREDENTIAL_PROVIDER_ID.CONDUCTOR }), false);
+});
+
+test("describes every provider it lists", () => {
+  assert.deepEqual(CREDENTIAL_PROVIDER_LIST, Object.values(CREDENTIAL_PROVIDERS));
+  for (const provider of CREDENTIAL_PROVIDER_LIST) {
+    assert.equal(CREDENTIAL_PROVIDERS[provider.id], provider, "a provider is filed under its id");
+    assert.ok(provider.displayName.length > 0);
+    assert.ok(provider.hint.length > 0);
+    // The environment fallback every provider offers is `<PROVIDER>_API_KEY`.
+    assert.ok(provider.environmentVariables[0]?.endsWith("_API_KEY"), provider.id);
+  }
+});

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -189,6 +189,31 @@ test("keeps each provider's key, environment fallback, and reported source separ
   );
 });
 
+test("keeps both keys when two providers are saved at once", async (t) => {
+  // Each settings row carries its own busy flag, so a user with more than one
+  // provider can start a second save before the first has landed.
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory, { providers: TEST_PROVIDERS });
+
+  await Promise.all([
+    store.setApiKey(FIRST_CLOUD, "first-cloud-key"),
+    store.setApiKey(SECOND_CLOUD, "second-cloud-key"),
+  ]);
+
+  assert.equal(await store.readApiKey(FIRST_CLOUD), "first-cloud-key");
+  assert.equal(await store.readApiKey(SECOND_CLOUD), "second-cloud-key");
+  assert.deepEqual(JSON.parse(await readSettingsFile(directory)), {
+    version: 2,
+    apiKeys: {
+      [FIRST_CLOUD]: sealed("first-cloud-key"),
+      [SECOND_CLOUD]: sealed("second-cloud-key"),
+    },
+  });
+  const reopened = storeIn(directory, { providers: TEST_PROVIDERS });
+  assert.equal(await reopened.readApiKey(FIRST_CLOUD), "first-cloud-key");
+  assert.equal(await reopened.readApiKey(SECOND_CLOUD), "second-cloud-key");
+});
+
 test("reports nothing for a provider this store does not know", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory, { providers: [FIRST_CLOUD_PROVIDER] });

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -5,15 +5,45 @@ import path from "node:path";
 import test, { type TestContext } from "node:test";
 import { type SecretCipher, SettingsStore } from "../src/settings-store";
 import { CREDENTIAL_SOURCE } from "../src/shared/contracts";
+import {
+  CREDENTIAL_PROVIDER_ID,
+  type CredentialProvider,
+  type CredentialProviderId,
+} from "../src/shared/credential-providers";
 
 const TEST_API_KEY = "conductor-live-key";
 const SETTINGS_FILE_NAME = "settings.json";
 const CIPHER_PREFIX = "sealed:";
+const CONDUCTOR = CREDENTIAL_PROVIDER_ID.CONDUCTOR;
 
 const TEST_ENVIRONMENT_VARIABLE = {
   API_KEY: "CONDUCTOR_API_KEY",
   API_TOKEN: "CONDUCTOR_API_TOKEN",
+  FIRST_CLOUD_API_KEY: "FIRST_CLOUD_API_KEY",
+  SECOND_CLOUD_API_KEY: "SECOND_CLOUD_API_KEY",
 } as const;
+
+/**
+ * Two providers the registry does not ship, so per-provider behavior is covered
+ * without waiting for a second cloud adapter to exist.
+ */
+const FIRST_CLOUD_PROVIDER: CredentialProvider = {
+  id: "first-cloud" as CredentialProviderId,
+  displayName: "First Cloud",
+  hint: "Create a key in First Cloud.",
+  environmentVariables: [TEST_ENVIRONMENT_VARIABLE.FIRST_CLOUD_API_KEY],
+};
+
+const SECOND_CLOUD_PROVIDER: CredentialProvider = {
+  id: "second-cloud" as CredentialProviderId,
+  displayName: "Second Cloud",
+  hint: "Create a key in Second Cloud.",
+  environmentVariables: [TEST_ENVIRONMENT_VARIABLE.SECOND_CLOUD_API_KEY],
+};
+
+const TEST_PROVIDERS = [FIRST_CLOUD_PROVIDER, SECOND_CLOUD_PROVIDER];
+const FIRST_CLOUD = FIRST_CLOUD_PROVIDER.id;
+const SECOND_CLOUD = SECOND_CLOUD_PROVIDER.id;
 
 /** Stands in for Electron's Keychain-backed `safeStorage`. */
 function testCipher(available = true): SecretCipher {
@@ -28,6 +58,10 @@ function testCipher(available = true): SecretCipher {
   };
 }
 
+function sealed(plainText: string): string {
+  return Buffer.from(`${CIPHER_PREFIX}${plainText}`, "utf8").toString("base64");
+}
+
 async function temporaryDirectory(t: TestContext): Promise<string> {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-settings-"));
   t.after(async () => {
@@ -38,12 +72,17 @@ async function temporaryDirectory(t: TestContext): Promise<string> {
 
 function storeIn(
   directory: string,
-  options: { cipher?: SecretCipher; environment?: NodeJS.ProcessEnv } = {},
+  options: {
+    cipher?: SecretCipher;
+    environment?: NodeJS.ProcessEnv;
+    providers?: readonly CredentialProvider[];
+  } = {},
 ): SettingsStore {
   return new SettingsStore({
     directory: () => directory,
     cipher: options.cipher ?? testCipher(),
     environment: options.environment ?? {},
+    ...(options.providers ? { providers: options.providers } : {}),
   });
 }
 
@@ -55,17 +94,17 @@ test("stores an API key encrypted, private to the owner, and never in a snapshot
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);
 
-  const { settings, reason } = await store.setConductorApiKey(TEST_API_KEY);
+  const { settings, reason } = await store.setApiKey(CONDUCTOR, TEST_API_KEY);
   const contents = await readSettingsFile(directory);
   const stats = await fs.stat(path.join(directory, SETTINGS_FILE_NAME));
 
   assert.equal(reason, undefined);
-  assert.equal(settings.conductorApiKeySource, CREDENTIAL_SOURCE.ENCRYPTED_FILE);
+  assert.equal(settings.credentialSources[CONDUCTOR], CREDENTIAL_SOURCE.ENCRYPTED_FILE);
   assert.equal(settings.secretStorageAvailable, true);
   assert.equal(contents.includes(TEST_API_KEY), false, "the key was written in plaintext");
   assert.equal(stats.mode & 0o777, 0o600);
   assert.equal(JSON.stringify(settings).includes(TEST_API_KEY), false);
-  assert.equal(await store.readConductorApiKey(), TEST_API_KEY);
+  assert.equal(await store.readApiKey(CONDUCTOR), TEST_API_KEY);
 });
 
 test("decrypts once and re-decrypts only after the key changes", async (t) => {
@@ -83,39 +122,79 @@ test("decrypts once and re-decrypts only after the key changes", async (t) => {
       },
     },
   });
-  await store.setConductorApiKey(TEST_API_KEY);
+  await store.setApiKey(CONDUCTOR, TEST_API_KEY);
 
   const afterStore = decryptions;
-  for (let read = 0; read < 5; read += 1) await store.readConductorApiKey();
+  for (let read = 0; read < 5; read += 1) await store.readApiKey(CONDUCTOR);
   const afterReads = decryptions;
-  await store.setConductorApiKey("conductor-replacement-key");
-  await store.readConductorApiKey();
+  await store.setApiKey(CONDUCTOR, "conductor-replacement-key");
+  await store.readApiKey(CONDUCTOR);
 
   assert.equal(afterReads, afterStore, "a repeated read decrypted again");
   assert.ok(decryptions > afterReads, "a replaced key was not re-read");
-  assert.equal(await store.readConductorApiKey(), "conductor-replacement-key");
+  assert.equal(await store.readApiKey(CONDUCTOR), "conductor-replacement-key");
 });
 
 test("reads a stored key back from a new store instance", async (t) => {
   const directory = await temporaryDirectory(t);
-  await storeIn(directory).setConductorApiKey(TEST_API_KEY);
+  await storeIn(directory).setApiKey(CONDUCTOR, TEST_API_KEY);
 
   const reopened = storeIn(directory);
 
-  assert.equal(await reopened.readConductorApiKey(), TEST_API_KEY);
-  assert.equal((await reopened.snapshot()).conductorApiKeySource, CREDENTIAL_SOURCE.ENCRYPTED_FILE);
+  assert.equal(await reopened.readApiKey(CONDUCTOR), TEST_API_KEY);
+  assert.equal(
+    (await reopened.snapshot()).credentialSources[CONDUCTOR],
+    CREDENTIAL_SOURCE.ENCRYPTED_FILE,
+  );
 });
 
 test("clears a stored key", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);
-  await store.setConductorApiKey(TEST_API_KEY);
+  await store.setApiKey(CONDUCTOR, TEST_API_KEY);
 
-  const { settings } = await store.setConductorApiKey(undefined);
+  const { settings } = await store.setApiKey(CONDUCTOR, undefined);
 
-  assert.equal(settings.conductorApiKeySource, CREDENTIAL_SOURCE.NONE);
-  assert.equal(await store.readConductorApiKey(), undefined);
-  assert.equal((await readSettingsFile(directory)).includes("conductorApiKey"), false);
+  assert.equal(settings.credentialSources[CONDUCTOR], CREDENTIAL_SOURCE.NONE);
+  assert.equal(await store.readApiKey(CONDUCTOR), undefined);
+  assert.equal((await readSettingsFile(directory)).includes(CONDUCTOR), false);
+});
+
+test("keeps each provider's key, environment fallback, and reported source separate", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory, {
+    providers: TEST_PROVIDERS,
+    environment: { [TEST_ENVIRONMENT_VARIABLE.SECOND_CLOUD_API_KEY]: "second-cloud-environment" },
+  });
+
+  await store.setApiKey(FIRST_CLOUD, "first-cloud-key");
+  const settings = await store.snapshot();
+
+  assert.equal(settings.credentialSources[FIRST_CLOUD], CREDENTIAL_SOURCE.ENCRYPTED_FILE);
+  assert.equal(settings.credentialSources[SECOND_CLOUD], CREDENTIAL_SOURCE.ENVIRONMENT);
+  assert.equal(await store.readApiKey(FIRST_CLOUD), "first-cloud-key");
+  assert.equal(await store.readApiKey(SECOND_CLOUD), "second-cloud-environment");
+
+  // Storing and then clearing one provider's key leaves the other untouched.
+  await store.setApiKey(SECOND_CLOUD, "second-cloud-key");
+  assert.equal(await store.readApiKey(FIRST_CLOUD), "first-cloud-key");
+  await store.setApiKey(FIRST_CLOUD, undefined);
+
+  assert.equal(await store.readApiKey(SECOND_CLOUD), "second-cloud-key");
+  assert.equal(await store.readApiKey(FIRST_CLOUD), undefined);
+  assert.equal(
+    (await store.snapshot()).credentialSources[FIRST_CLOUD],
+    CREDENTIAL_SOURCE.NONE,
+    "a provider with no key must report nothing",
+  );
+});
+
+test("reports nothing for a provider this store does not know", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory, { providers: [FIRST_CLOUD_PROVIDER] });
+
+  assert.equal(await store.readApiKey(SECOND_CLOUD), undefined);
+  assert.equal((await store.snapshot()).credentialSources[SECOND_CLOUD], undefined);
 });
 
 test("falls back to an API key from the environment", async (t) => {
@@ -126,8 +205,8 @@ test("falls back to an API key from the environment", async (t) => {
 
   const settings = await store.snapshot();
 
-  assert.equal(settings.conductorApiKeySource, CREDENTIAL_SOURCE.ENVIRONMENT);
-  assert.equal(await store.readConductorApiKey(), TEST_API_KEY);
+  assert.equal(settings.credentialSources[CONDUCTOR], CREDENTIAL_SOURCE.ENVIRONMENT);
+  assert.equal(await store.readApiKey(CONDUCTOR), TEST_API_KEY);
 });
 
 test("prefers a stored key over one from the environment", async (t) => {
@@ -135,19 +214,19 @@ test("prefers a stored key over one from the environment", async (t) => {
   const store = storeIn(directory, {
     environment: { [TEST_ENVIRONMENT_VARIABLE.API_KEY]: "conductor-environment-key" },
   });
-  await store.setConductorApiKey(TEST_API_KEY);
+  await store.setApiKey(CONDUCTOR, TEST_API_KEY);
 
-  assert.equal(await store.readConductorApiKey(), TEST_API_KEY);
+  assert.equal(await store.readApiKey(CONDUCTOR), TEST_API_KEY);
 });
 
 test("rejects a key that cannot be sent as an authorization header", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);
 
-  assert.match((await store.setConductorApiKey("short")).reason ?? "", /too short/);
-  assert.match((await store.setConductorApiKey("key with spaces")).reason ?? "", /unsupported/);
-  assert.match((await store.setConductorApiKey("k".repeat(513))).reason ?? "", /too long/);
-  assert.equal(await store.readConductorApiKey(), undefined);
+  assert.match((await store.setApiKey(CONDUCTOR, "short")).reason ?? "", /too short/);
+  assert.match((await store.setApiKey(CONDUCTOR, "key with spaces")).reason ?? "", /unsupported/);
+  assert.match((await store.setApiKey(CONDUCTOR, "k".repeat(513))).reason ?? "", /too long/);
+  assert.equal(await store.readApiKey(CONDUCTOR), undefined);
   await assert.rejects(() => readSettingsFile(directory), /ENOENT/);
 });
 
@@ -155,26 +234,72 @@ test("refuses to store a key when encrypted storage is unavailable", async (t) =
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory, { cipher: testCipher(false) });
 
-  const { settings, reason } = await store.setConductorApiKey(TEST_API_KEY);
+  const { settings, reason } = await store.setApiKey(CONDUCTOR, TEST_API_KEY);
 
   assert.match(reason ?? "", /unavailable/);
   assert.equal(settings.secretStorageAvailable, false);
-  assert.equal(settings.conductorApiKeySource, CREDENTIAL_SOURCE.NONE);
+  assert.equal(settings.credentialSources[CONDUCTOR], CREDENTIAL_SOURCE.NONE);
   await assert.rejects(() => readSettingsFile(directory), /ENOENT/);
 });
 
 test("ignores a stored key that can no longer be decrypted", async (t) => {
   const directory = await temporaryDirectory(t);
-  await storeIn(directory).setConductorApiKey(TEST_API_KEY);
+  await storeIn(directory).setApiKey(CONDUCTOR, TEST_API_KEY);
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({ version: 1, conductorApiKey: Buffer.from("rotated").toString("base64") }),
+    JSON.stringify({
+      version: 2,
+      apiKeys: { [CONDUCTOR]: Buffer.from("rotated").toString("base64") },
+    }),
   );
 
   const store = storeIn(directory);
 
-  assert.equal(await store.readConductorApiKey(), undefined);
-  assert.equal((await store.snapshot()).conductorApiKeySource, CREDENTIAL_SOURCE.NONE);
+  assert.equal(await store.readApiKey(CONDUCTOR), undefined);
+  assert.equal((await store.snapshot()).credentialSources[CONDUCTOR], CREDENTIAL_SOURCE.NONE);
+});
+
+test("keeps a Conductor key stored by an earlier version working", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({ version: 1, conductorApiKey: sealed(TEST_API_KEY) }),
+  );
+  const store = storeIn(directory);
+
+  assert.equal(await store.readApiKey(CONDUCTOR), TEST_API_KEY);
+  assert.equal(
+    (await store.snapshot()).credentialSources[CONDUCTOR],
+    CREDENTIAL_SOURCE.ENCRYPTED_FILE,
+  );
+
+  // The migrated key moves under its provider id the next time settings are
+  // written, and the version 1 field does not survive that write.
+  await store.setApiKey(CONDUCTOR, "conductor-replacement-key");
+  const persisted: unknown = JSON.parse(await readSettingsFile(directory));
+
+  assert.deepEqual(persisted, {
+    version: 2,
+    apiKeys: { [CONDUCTOR]: sealed("conductor-replacement-key") },
+  });
+  assert.equal(await storeIn(directory).readApiKey(CONDUCTOR), "conductor-replacement-key");
+});
+
+test("carries a key belonging to a provider this build does not know", async (t) => {
+  // A file written by a newer build must not lose credentials to an older one.
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({ version: 2, apiKeys: { "later-cloud": sealed("later-cloud-key") } }),
+  );
+
+  await storeIn(directory).setApiKey(CONDUCTOR, TEST_API_KEY);
+  const persisted: unknown = JSON.parse(await readSettingsFile(directory));
+
+  assert.deepEqual(persisted, {
+    version: 2,
+    apiKeys: { "later-cloud": sealed("later-cloud-key"), [CONDUCTOR]: sealed(TEST_API_KEY) },
+  });
 });
 
 test("recovers from a corrupt settings file", async (t) => {
@@ -182,8 +307,8 @@ test("recovers from a corrupt settings file", async (t) => {
   await fs.writeFile(path.join(directory, SETTINGS_FILE_NAME), "{ not json");
   const store = storeIn(directory);
 
-  const { settings } = await store.setConductorApiKey(TEST_API_KEY);
+  const { settings } = await store.setApiKey(CONDUCTOR, TEST_API_KEY);
 
-  assert.equal(settings.conductorApiKeySource, CREDENTIAL_SOURCE.ENCRYPTED_FILE);
-  assert.equal(await store.readConductorApiKey(), TEST_API_KEY);
+  assert.equal(settings.credentialSources[CONDUCTOR], CREDENTIAL_SOURCE.ENCRYPTED_FILE);
+  assert.equal(await store.readApiKey(CONDUCTOR), TEST_API_KEY);
 });


### PR DESCRIPTION
## Summary

- Key credentials by provider id end to end. A new `apps/desktop/src/shared/credential-providers.ts` registry names every provider Luke can hold a key for, with its display name, where to create a key, and its own `<PROVIDER>_API_KEY` environment fallback (Conductor keeps `CONDUCTOR_API_KEY` and `CONDUCTOR_API_TOKEN`). `ConductorSessionAdapter` takes its id and display name from that registry, so the key a user saves and the provider it authenticates can never name different things.
- Bump `SETTINGS_FILE_VERSION` to 2: `{ version: 2, apiKeys: { <providerId>: <ciphertext> } }`. A version 1 file's `conductorApiKey` is migrated **on read** — the ciphertext is untouched, so an existing installation's key keeps working with no re-entry, and it moves under its provider id at the next write. A key belonging to a provider this build does not know is carried through rather than discarded, so an older build cannot strip a newer one's credential.
- Replace `app:set-conductor-api-key` with `app:set-provider-api-key`, carrying `(providerId, apiKey)`. The main process refuses an id outside the registry before the store is touched (`Object.hasOwn`, so `toString` and `__proto__` are not providers), and refreshes only the observer whose credential changed instead of every cloud adapter.
- Settings lists a row per provider — its own field, credential source, Save/Remove buttons, busy state, and rejection message — inside the existing scrolling panel body. The storage-unavailable and read-only notes stay once at the bottom rather than repeating per row.
- Serialize the whole credential change, not just its file write. Two saves that overlapped both read the stored keys before either wrote, so the later write started from a pre-save snapshot and dropped the other provider's key — reachable as soon as a second row exists, since each row carries its own busy flag. Reported by Bugbot on this PR, reproduced, then fixed in 989d61a.
- Nothing about the trust boundary moves: no accessor returns a credential to the renderer, each key stays encrypted at rest through `safeStorage`, and a provider with no key resolves to nothing so its adapter observes nothing and issues no request.

## Evidence

- Platform-independent checks: `./scripts/check.sh` green — 69 desktop, 31 core, 5 harness tests. New coverage: per-provider key isolation (storing or clearing one leaves the other untouched), per-provider environment fallback, a version 1 file still resolving and then migrating on write, an unknown provider's ciphertext surviving a write, the provider-id guard rejecting unknown and inherited names, and two providers saved concurrently keeping both keys (this one fails against the first commit and passes against the second).
- macOS Electron verification (`./scripts/verify.sh`): `not run` in this (Linux) workspace — covered by CI's macOS job.
- Live app probe (real Electron main + preload + IPC, driven over the DevTools protocol): bootstrap returns `{"credentialSources":{"conductor":"none"},"secretStorageAvailable":false}`; the exposed bridge is `setProviderApiKey` with no credential getter; `setProviderApiKey("not-a-provider", …)` is rejected with `Unknown credential provider`. That sandbox has no keyring, so `safeStorage` reports unavailable and the save was refused with a reason and wrote no file — the correct branch, but it leaves the real `safeStorage` round trip to macOS.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31640879290/artifacts/9158805182) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31640879290)

- Commit: `989d61a64fd7307d11216940b42f5e4a0ca59fcb`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` — the capture pipeline still has no way to open the Settings view (same gap noted in #15). The Settings panel was inspected instead by rendering the built renderer bundle in headless Chrome; screenshots are linked in a comment below.
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- The store takes an optional `providers` list so per-provider behavior is covered by tests before a second adapter exists; production always uses the registry.
- Blockers or follow-up verification: the encrypted-file round trip against a real Keychain, and one look at Settings on a physical Mac, both need a macOS run.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/58272d56-9224-4c6a-a272-40412a0b4bd2)

