### PR TITLE
feat(LUKE-58): observe Cursor cloud agent sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,14 +164,15 @@ no configuration. A cloud provider has no local state to read, so it stays
 silent until you press the capsule to open the panel, choose the **Settings**
 tab, and connect it with a key. Each provider holds its own credential and also
 reads its own `<PROVIDER>_API_KEY` from the environment; Conductor accepts
-`CONDUCTOR_API_KEY` or `CONDUCTOR_API_TOKEN`, and issues keys at
-<https://app.conductor.build/users/api-keys>. A provider you
-give no key to reports nothing and issues no request. A key you enter is
-encrypted with `safeStorage`, whose key comes from the login Keychain, and it is
-never returned to the renderer. Luke reads only cloud workspaces you created,
-issues only read requests, and labels each session by its repository rather than
-by a provider workspace or session name, because those names are generated from
-the opening prompt.
+`CONDUCTOR_API_KEY` or `CONDUCTOR_API_TOKEN` and issues keys at
+<https://app.conductor.build/users/api-keys>, and Cursor accepts
+`CURSOR_API_KEY` and issues keys at <https://cursor.com/dashboard/api>. A
+provider you give no key to reports nothing and issues no request. A key you
+enter is encrypted with `safeStorage`, whose key comes from the login Keychain,
+and it is never returned to the renderer. Luke reads only cloud workspaces and
+agents you created, issues only read requests, and labels each session by its
+repository rather than by a provider workspace, agent, or session name, because
+those names are generated from the opening prompt.
 
 ## Attention intelligence
 

--- a/apps/desktop/src/cloud-session-adapter.ts
+++ b/apps/desktop/src/cloud-session-adapter.ts
@@ -108,6 +108,17 @@ export function timestampFromRecord(
   return Number.isFinite(timestampMs) ? timestampMs : undefined;
 }
 
+/**
+ * Reads a value a provider reported only when this build knows it, so a state
+ * added after this build shipped is left undefined rather than guessed at.
+ */
+export function knownValue<Value extends string>(
+  values: Readonly<Record<string, Value>>,
+  reported: string | undefined,
+): Value | undefined {
+  return Object.values(values).find((candidate) => candidate === reported);
+}
+
 /** Reads a list page without assuming which key a given provider wraps it in. */
 export function recordsFromPage(
   body: Record<string, unknown>,

--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -10,6 +10,7 @@ import {
   type CloudRequest,
   CloudSessionAdapter,
   isDefined,
+  knownValue,
   positiveInteger,
   recordsFromPage,
   repositoryLabel,
@@ -121,13 +122,6 @@ interface ConductorSession {
   archived: boolean;
   archivedAt?: number;
   model?: string;
-}
-
-function conductorSessionStatus(value: string | undefined): ConductorSessionStatus | undefined {
-  return value !== undefined &&
-    Object.values(CONDUCTOR_SESSION_STATUS).includes(value as ConductorSessionStatus)
-    ? (value as ConductorSessionStatus)
-    : undefined;
 }
 
 /**
@@ -375,7 +369,7 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
       CONDUCTOR_ROUTE_SEGMENT.STATUS,
     ]);
     return {
-      status: conductorSessionStatus(textFromRecord(body, CONDUCTOR_FIELD.STATUS)),
+      status: knownValue(CONDUCTOR_SESSION_STATUS, textFromRecord(body, CONDUCTOR_FIELD.STATUS)),
       updatedAt: timestampFromRecord(body, CONDUCTOR_FIELD.UPDATED_AT),
     };
   }

--- a/apps/desktop/src/cursor-adapter.ts
+++ b/apps/desktop/src/cursor-adapter.ts
@@ -1,0 +1,285 @@
+import {
+  type ProviderSessionObservation,
+  SESSION_STATUS,
+  type SessionProvider,
+  type SessionStatus,
+} from "@sidecar/core";
+import {
+  CLOUD_ADAPTER_DEFAULTS,
+  type CloudAdapterOptions,
+  type CloudRequest,
+  CloudSessionAdapter,
+  isDefined,
+  isRecord,
+  knownValue,
+  positiveInteger,
+  recordsFromPage,
+  repositoryLabel,
+  textFromRecord,
+  timestampFromRecord,
+} from "./cloud-session-adapter";
+import { CREDENTIAL_PROVIDER_ID, CREDENTIAL_PROVIDERS } from "./shared/credential-providers";
+
+// Shared with the credential registry so the key the user saves and the
+// provider Luke observes with it can never name different things.
+const CURSOR_PROVIDER_ID = CREDENTIAL_PROVIDER_ID.CURSOR;
+const CURSOR_PROVIDER_NAME = CREDENTIAL_PROVIDERS[CREDENTIAL_PROVIDER_ID.CURSOR].displayName;
+
+const CURSOR_ENVIRONMENT = {
+  API_URL: "CURSOR_API_URL",
+} as const;
+
+const CURSOR_DEFAULT_API_URL = "https://api.cursor.com";
+
+const CURSOR_ROUTE_SEGMENT = {
+  AGENTS: "agents",
+  RUNS: "runs",
+  V1: "v1",
+} as const;
+
+/** Read-only routes from the documented public API. Luke never calls a writer. */
+const CURSOR_ROUTE = {
+  AGENTS: [CURSOR_ROUTE_SEGMENT.V1, CURSOR_ROUTE_SEGMENT.AGENTS],
+} as const;
+
+const CURSOR_QUERY = {
+  LIMIT: "limit",
+} as const;
+
+const CURSOR_FIELD = {
+  CREATED_AT: "createdAt",
+  ID: "id",
+  ITEMS: "items",
+  LATEST_RUN_ID: "latestRunId",
+  REPOS: "repos",
+  STARTING_REF: "startingRef",
+  STATUS: "status",
+  UPDATED_AT: "updatedAt",
+  URL: "url",
+} as const;
+
+/**
+ * An agent is the standing definition of a task, so its own status says only
+ * whether the user has filed it away. What the agent is doing right now belongs
+ * to its latest run.
+ */
+const CURSOR_AGENT_STATUS = {
+  ACTIVE: "ACTIVE",
+  ARCHIVED: "ARCHIVED",
+} as const;
+
+const CURSOR_RUN_STATUS = {
+  CREATING: "CREATING",
+  RUNNING: "RUNNING",
+  FINISHED: "FINISHED",
+  CANCELLED: "CANCELLED",
+  EXPIRED: "EXPIRED",
+  ERROR: "ERROR",
+} as const;
+
+type CursorRunStatus = (typeof CURSOR_RUN_STATUS)[keyof typeof CURSOR_RUN_STATUS];
+
+/**
+ * A finished run has stopped and is holding for the user, which is what Luke
+ * reports as waiting. A run that was cancelled or expired stopped for good. One
+ * that is still being created, or that failed, is left unknown rather than
+ * promoted to a state Luke cannot verify.
+ */
+const SESSION_STATUS_BY_CURSOR_RUN_STATUS: Readonly<Record<CursorRunStatus, SessionStatus>> = {
+  [CURSOR_RUN_STATUS.RUNNING]: SESSION_STATUS.WORKING,
+  [CURSOR_RUN_STATUS.FINISHED]: SESSION_STATUS.WAITING,
+  [CURSOR_RUN_STATUS.CANCELLED]: SESSION_STATUS.COMPLETE,
+  [CURSOR_RUN_STATUS.EXPIRED]: SESSION_STATUS.COMPLETE,
+  [CURSOR_RUN_STATUS.CREATING]: SESSION_STATUS.UNKNOWN,
+  [CURSOR_RUN_STATUS.ERROR]: SESSION_STATUS.UNKNOWN,
+};
+
+const CURSOR_ADAPTER_DEFAULTS = {
+  /** The documented maximum, so one call covers as much of a day as it can. */
+  AGENT_PAGE_SIZE: 100,
+  MAXIMUM_OBSERVED_SESSIONS: 12,
+  MAXIMUM_REFERENCE_LABEL_LENGTH: 60,
+} as const;
+
+export const CURSOR_PROVIDER: SessionProvider = {
+  id: CURSOR_PROVIDER_ID,
+  displayName: CURSOR_PROVIDER_NAME,
+};
+
+export interface CursorAdapterOptions extends CloudAdapterOptions {
+  maximumObservedSessions?: number;
+}
+
+interface CursorAgent {
+  id: string;
+  repositoryLabel: string;
+  archived: boolean;
+  lastActivityAt: number;
+  latestRunId?: string;
+  ref?: string;
+}
+
+interface CursorRun {
+  status: CursorRunStatus | undefined;
+  updatedAt: number | undefined;
+}
+
+/** An agent can be attached to several repositories; the first is its subject. */
+function firstRepository(record: Record<string, unknown>): Record<string, unknown> {
+  const repositories = record[CURSOR_FIELD.REPOS];
+  const first = Array.isArray(repositories) ? repositories[0] : undefined;
+  return isRecord(first) ? first : {};
+}
+
+function agentFromRecord(record: Record<string, unknown>): CursorAgent | undefined {
+  const id = textFromRecord(record, CURSOR_FIELD.ID);
+  // An agent is a standing definition that can be run again months later, so
+  // the time it was last touched is what places it in the observation window.
+  const lastActivityAt =
+    timestampFromRecord(record, CURSOR_FIELD.UPDATED_AT) ??
+    timestampFromRecord(record, CURSOR_FIELD.CREATED_AT);
+  if (!id || lastActivityAt === undefined) return undefined;
+
+  const repository = firstRepository(record);
+  const ref = textFromRecord(repository, CURSOR_FIELD.STARTING_REF)?.slice(
+    0,
+    CURSOR_ADAPTER_DEFAULTS.MAXIMUM_REFERENCE_LABEL_LENGTH,
+  );
+  const latestRunId = textFromRecord(record, CURSOR_FIELD.LATEST_RUN_ID);
+  return {
+    id,
+    lastActivityAt,
+    // An agent's name and summary are written from its opening prompt, so the
+    // repository is the only label available and there is deliberately no
+    // fallback to the name Cursor reports.
+    repositoryLabel: repositoryLabel(textFromRecord(repository, CURSOR_FIELD.URL), undefined),
+    archived: textFromRecord(record, CURSOR_FIELD.STATUS) === CURSOR_AGENT_STATUS.ARCHIVED,
+    ...(latestRunId ? { latestRunId } : {}),
+    ...(ref ? { ref } : {}),
+  };
+}
+
+/**
+ * Observes Cursor cloud agents through the documented public API. It reads only
+ * the agents the supplied key owns, issues no request that can change provider
+ * state, and reports nothing at all without a credential.
+ */
+export class CursorSessionAdapter extends CloudSessionAdapter {
+  readonly #maximumObservedSessions: number;
+
+  constructor(options: CursorAdapterOptions) {
+    super(
+      {
+        provider: CURSOR_PROVIDER,
+        defaultBaseUrl: CURSOR_DEFAULT_API_URL,
+        baseUrlEnvironmentVariable: CURSOR_ENVIRONMENT.API_URL,
+      },
+      options,
+    );
+    this.#maximumObservedSessions = positiveInteger(
+      options.maximumObservedSessions,
+      CURSOR_ADAPTER_DEFAULTS.MAXIMUM_OBSERVED_SESSIONS,
+    );
+  }
+
+  protected async collect(
+    request: CloudRequest,
+    now: number,
+  ): Promise<readonly ProviderSessionObservation[]> {
+    const body = await request(CURSOR_ROUTE.AGENTS, {
+      [CURSOR_QUERY.LIMIT]: String(CURSOR_ADAPTER_DEFAULTS.AGENT_PAGE_SIZE),
+    });
+
+    // Cursor lists agents newest-first, so a full first page already reaches
+    // past the observation window and the `cursor` page after it could only
+    // hold agents Luke has already aged out.
+    const agents = recordsFromPage(body, CURSOR_FIELD.ITEMS)
+      .map(agentFromRecord)
+      .filter(isDefined)
+      .filter(
+        (agent) => now - agent.lastActivityAt <= CLOUD_ADAPTER_DEFAULTS.MAXIMUM_SESSION_AGE_MS,
+      )
+      // When a day holds more agents than Luke observes, the ones that can
+      // still change take the budget: an agent the user filed away has nothing
+      // left to say, however recently it was touched.
+      .sort(
+        (first, second) =>
+          Number(first.archived) - Number(second.archived) ||
+          second.lastActivityAt - first.lastActivityAt,
+      )
+      .slice(0, this.#maximumObservedSessions);
+
+    // The only fan-out in a pass, already bounded by the cap above: an agent
+    // record reports whether it was filed away, never what it is doing, so the
+    // status Luke shows exists only on the run.
+    const observations = await Promise.all(
+      agents.map((agent) => this.#observationFor(request, agent, now)),
+    );
+    return observations.filter(isDefined);
+  }
+
+  async #observationFor(
+    request: CloudRequest,
+    agent: CursorAgent,
+    now: number,
+  ): Promise<ProviderSessionObservation | undefined> {
+    // An archived agent is already settled, and one that has never run has no
+    // run to ask about, so neither spends a request.
+    const latestRunId = agent.archived ? undefined : agent.latestRunId;
+    const run = latestRunId
+      ? await this.tolerateItemFailure(() => this.#latestRun(request, agent.id, latestRunId))
+      : undefined;
+    // The run's timestamp is the moment its state was entered; the agent's is
+    // only the last resort, because it also moves for edits that are not work.
+    const observedAt = run?.updatedAt ?? agent.lastActivityAt;
+    if (now - observedAt > CLOUD_ADAPTER_DEFAULTS.MAXIMUM_SESSION_AGE_MS) return undefined;
+
+    const status = this.#statusFor(agent, run, observedAt, now);
+    return {
+      providerSessionId: agent.id,
+      title: `${CURSOR_PROVIDER_NAME}: ${agent.repositoryLabel}`,
+      status,
+      observedAt,
+      summary: summaryFromStatus(status, agent.ref),
+    };
+  }
+
+  #statusFor(
+    agent: CursorAgent,
+    run: CursorRun | undefined,
+    observedAt: number,
+    now: number,
+  ): SessionStatus {
+    if (agent.archived) return SESSION_STATUS.COMPLETE;
+    // A run state this build does not know is not guessed at.
+    if (!run?.status) return SESSION_STATUS.UNKNOWN;
+    const status = SESSION_STATUS_BY_CURSOR_RUN_STATUS[run.status];
+    // Cursor reports live state, and the run's timestamp marks when that state
+    // was entered rather than a heartbeat, so a long turn is still working and
+    // a run that stopped for good stays complete however long ago it stopped.
+    // Only a finished run decays: once it is stale Luke cannot tell a turn that
+    // just ended from one the user walked away from hours ago.
+    return status === SESSION_STATUS.WAITING
+      ? this.statusWhileRecent(status, observedAt, now)
+      : status;
+  }
+
+  async #latestRun(request: CloudRequest, agentId: string, runId: string): Promise<CursorRun> {
+    // The agent names its own latest run, so this reads that run rather than
+    // assuming how the run list happens to be ordered.
+    const body = await request([...CURSOR_ROUTE.AGENTS, agentId, CURSOR_ROUTE_SEGMENT.RUNS, runId]);
+    return {
+      status: knownValue(CURSOR_RUN_STATUS, textFromRecord(body, CURSOR_FIELD.STATUS)),
+      updatedAt:
+        timestampFromRecord(body, CURSOR_FIELD.UPDATED_AT) ??
+        timestampFromRecord(body, CURSOR_FIELD.CREATED_AT),
+    };
+  }
+}
+
+function summaryFromStatus(status: SessionStatus, ref: string | undefined): string {
+  // The starting ref is chosen by whoever launched the agent, unlike the branch
+  // Cursor generates for the work, which is named from the prompt.
+  const refDetail = ref ? ` from ${ref}` : "";
+  return `${CURSOR_PROVIDER_NAME} ${status}${refDetail}; cloud session metadata is observed read-only and transcript content is not retained.`;
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -29,6 +29,7 @@ import {
 import { ClaudeCodeSessionAdapter } from "./claude-code-adapter";
 import { CodexSessionAdapter } from "./codex-adapter";
 import { ConductorSessionAdapter } from "./conductor-adapter";
+import { CursorSessionAdapter } from "./cursor-adapter";
 import { readMacScreenGeometry } from "./macos-screen-geometry";
 import { openAiAttentionEvaluatorFromEnvironment } from "./openai-attention-evaluator";
 import { SettingsStore } from "./settings-store";
@@ -73,14 +74,21 @@ const settingsStore = new SettingsStore({
 const conductorAdapter = new ConductorSessionAdapter({
   readApiKey: () => settingsStore.readApiKey(CREDENTIAL_PROVIDER_ID.CONDUCTOR),
 });
+const cursorAdapter = new CursorSessionAdapter({
+  readApiKey: () => settingsStore.readApiKey(CREDENTIAL_PROVIDER_ID.CURSOR),
+});
 // Saving a key affects only the provider it belongs to, so this maps each
 // credential to the one observer that reads it.
 const adapterByCredentialProvider: ReadonlyMap<CredentialProviderId, SessionProviderAdapter> =
-  new Map([[CREDENTIAL_PROVIDER_ID.CONDUCTOR, conductorAdapter]]);
+  new Map<CredentialProviderId, SessionProviderAdapter>([
+    [CREDENTIAL_PROVIDER_ID.CONDUCTOR, conductorAdapter],
+    [CREDENTIAL_PROVIDER_ID.CURSOR, cursorAdapter],
+  ]);
 const sessionAdapters = [
   new ClaudeCodeSessionAdapter(),
   new CodexSessionAdapter(),
   conductorAdapter,
+  cursorAdapter,
 ] as const;
 // A fixture run must stay deterministic and credential-free, so it never builds
 // an evaluator — not just capture runs.

--- a/apps/desktop/src/renderer/provider-marks.tsx
+++ b/apps/desktop/src/renderer/provider-marks.tsx
@@ -7,10 +7,13 @@ import { useId } from "react";
  *
  * Each is the provider's own mark, reproduced rather than redrawn — Claude Code
  * via Simple Icons (CC0-1.0, sourced from code.claude.com), Codex via
- * @lobehub/icons (MIT), and Conductor's letter mark verbatim from the published
- * brand kit at https://www.conductor.build/brandkit. Each keeps its own brand
- * colour (see the `--mark-*` custom properties), so a mark says which provider
- * a session belongs to while the chips and row tints say what state it is in.
+ * @lobehub/icons (MIT), Conductor's letter mark verbatim from the published
+ * brand kit at https://www.conductor.build/brandkit, and Cursor via Simple
+ * Icons (CC0-1.0, sourced from https://cursor.com/brand). Each keeps its own
+ * brand colour (see the `--mark-*` custom properties), so a mark says which
+ * provider a session belongs to while the chips and row tints say what state it
+ * is in. Cursor publishes its mark as a single silhouette rather than in a
+ * colour, so it is drawn in the light form the brand uses on a dark surface.
  * They are trademarks of their respective owners. Do not restyle the geometry
  * or recolour them; swap the path if a provider publishes an updated mark.
  */
@@ -23,6 +26,9 @@ const CLAUDE_CODE_PATH =
 
 const CODEX_PATH =
   "M8.086.457a6.105 6.105 0 013.046-.415c1.333.153 2.521.72 3.564 1.7a.117.117 0 00.107.029c1.408-.346 2.762-.224 4.061.366l.063.03.154.076c1.357.703 2.33 1.77 2.918 3.198.278.679.418 1.388.421 2.126a5.655 5.655 0 01-.18 1.631.167.167 0 00.04.155 5.982 5.982 0 011.578 2.891c.385 1.901-.01 3.615-1.183 5.14l-.182.22a6.063 6.063 0 01-2.934 1.851.162.162 0 00-.108.102c-.255.736-.511 1.364-.987 1.992-1.199 1.582-2.962 2.462-4.948 2.451-1.583-.008-2.986-.587-4.21-1.736a.145.145 0 00-.14-.032c-.518.167-1.04.191-1.604.185a5.924 5.924 0 01-2.595-.622 6.058 6.058 0 01-2.146-1.781c-.203-.269-.404-.522-.551-.821a7.74 7.74 0 01-.495-1.283 6.11 6.11 0 01-.017-3.064.166.166 0 00.008-.074.115.115 0 00-.037-.064 5.958 5.958 0 01-1.38-2.202 5.196 5.196 0 01-.333-1.589 6.915 6.915 0 01.188-2.132c.45-1.484 1.309-2.648 2.577-3.493.282-.188.55-.334.802-.438.286-.12.573-.22.861-.304a.129.129 0 00.087-.087A6.016 6.016 0 015.635 2.31C6.315 1.464 7.132.846 8.086.457zm-.804 7.85a.848.848 0 00-1.473.842l1.694 2.965-1.688 2.848a.849.849 0 001.46.864l1.94-3.272a.849.849 0 00.007-.854l-1.94-3.393zm5.446 6.24a.849.849 0 000 1.695h4.848a.849.849 0 000-1.696h-4.848z";
+
+const CURSOR_PATH =
+  "M11.503.131 1.891 5.678a.84.84 0 0 0-.42.726v11.188c0 .3.162.575.42.724l9.609 5.55a1 1 0 0 0 .998 0l9.61-5.55a.84.84 0 0 0 .42-.724V6.404a.84.84 0 0 0-.42-.726L12.497.131a1.01 1.01 0 0 0-.996 0M2.657 6.338h18.55c.263 0 .43.287.297.515L12.23 22.918c-.062.107-.229.064-.229-.06V12.335a.59.59 0 0 0-.295-.51l-9.11-5.257c-.109-.063-.064-.23.061-.23";
 
 /* Conductor publishes a letter mark rather than a glyph, so it is taller than
    it is wide; the box below fits it by height like any other mark. */
@@ -111,6 +117,20 @@ function ConductorMark({ className }: MarkProps): React.JSX.Element {
   );
 }
 
+function CursorMark({ className }: MarkProps): React.JSX.Element {
+  return (
+    <svg
+      className={className}
+      data-mark={PROVIDER_ID.CURSOR}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path fill="currentColor" d={CURSOR_PATH} />
+    </svg>
+  );
+}
+
 /** Drawn here, not a brand: a provider Luke has no mark for still needs a slot. */
 function UnknownProviderMark({ className }: MarkProps): React.JSX.Element {
   return (
@@ -125,6 +145,7 @@ const PROVIDER_MARKS = new Map<string, (props: MarkProps) => React.JSX.Element>(
   [PROVIDER_ID.CLAUDE_CODE, ClaudeCodeMark],
   [PROVIDER_ID.CODEX, CodexMark],
   [PROVIDER_ID.CONDUCTOR, ConductorMark],
+  [PROVIDER_ID.CURSOR, CursorMark],
 ]);
 
 export function ProviderMark({

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -10,16 +10,19 @@
   --state-idle: rgba(255, 255, 255, 0.44);
 
   /* Provider brand colours, used only by the marks: Claude Code's published
-     coral, the vertical gradient Codex draws its mark with, and the light half
-     of Conductor's two-colour palette — its dark half is the surface the mark
-     already sits on, so the pairing is the published one. Session state is
-     carried by the chips, row tints, and count badge instead, so the two colour
-     systems never compete for the same pixel. */
+     coral, the vertical gradient Codex draws its mark with, the light half of
+     Conductor's two-colour palette — its dark half is the surface the mark
+     already sits on, so the pairing is the published one — and Cursor's mark,
+     which is published as one silhouette and so is drawn in the light form the
+     brand uses on a dark surface. Session state is carried by the chips, row
+     tints, and count badge instead, so the two colour systems never compete for
+     the same pixel. */
   --mark-claude-code: #d97757;
   --mark-codex-top: #b1a7ff;
   --mark-codex-middle: #7a9dff;
   --mark-codex-bottom: #3941ff;
   --mark-conductor: #eae8e6;
+  --mark-cursor: #ffffff;
 
   --text-primary: rgba(255, 255, 255, 0.95);
   --text-secondary: rgba(255, 255, 255, 0.56);
@@ -470,9 +473,9 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 }
 
 /* The marks fill their box very differently — the Claude Code glyph is wide and
-   short, the Codex mark is full-bleed, and Conductor's letter mark is taller
-   than it is wide — so each gets a uniform scale to sit at the same optical
-   weight. Proportions are untouched. */
+   short, the Codex and Cursor marks are full-bleed, and Conductor's letter mark
+   is taller than it is wide — so each gets a uniform scale to sit at the same
+   optical weight. Proportions are untouched. */
 .provider-mark[data-mark="claude-code"] {
   color: var(--mark-claude-code);
   transform: scale(1.12);
@@ -485,6 +488,11 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 .provider-mark[data-mark="conductor"] {
   color: var(--mark-conductor);
   transform: scale(0.93);
+}
+
+.provider-mark[data-mark="cursor"] {
+  color: var(--mark-cursor);
+  transform: scale(0.94);
 }
 
 /* Nothing to blend into on a display without a housing, so the shape stops

--- a/apps/desktop/src/shared/credential-providers.ts
+++ b/apps/desktop/src/shared/credential-providers.ts
@@ -9,6 +9,7 @@ import { PROVIDER_ID } from "@sidecar/core";
  */
 export const CREDENTIAL_PROVIDER_ID = {
   CONDUCTOR: PROVIDER_ID.CONDUCTOR,
+  CURSOR: PROVIDER_ID.CURSOR,
 } as const;
 
 export type CredentialProviderId =
@@ -21,6 +22,10 @@ export type CredentialProviderId =
 const CONDUCTOR_ENVIRONMENT = {
   API_KEY: "CONDUCTOR_API_KEY",
   API_TOKEN: "CONDUCTOR_API_TOKEN",
+} as const;
+
+const CURSOR_ENVIRONMENT = {
+  API_KEY: "CURSOR_API_KEY",
 } as const;
 
 export interface CredentialProvider {
@@ -46,6 +51,13 @@ export const CREDENTIAL_PROVIDERS: Readonly<Record<CredentialProviderId, Credent
     hint: "Create a key in Conductor under Settings · API keys.",
     apiKeysUrl: "https://app.conductor.build/users/api-keys",
     environmentVariables: [CONDUCTOR_ENVIRONMENT.API_KEY, CONDUCTOR_ENVIRONMENT.API_TOKEN],
+  },
+  [CREDENTIAL_PROVIDER_ID.CURSOR]: {
+    id: CREDENTIAL_PROVIDER_ID.CURSOR,
+    displayName: "Cursor",
+    hint: "Create a key in the Cursor dashboard under Integrations · API keys.",
+    apiKeysUrl: "https://cursor.com/dashboard/api",
+    environmentVariables: [CURSOR_ENVIRONMENT.API_KEY],
   },
 };
 

--- a/apps/desktop/tests/cloud-session-adapter.test.ts
+++ b/apps/desktop/tests/cloud-session-adapter.test.ts
@@ -7,6 +7,7 @@ import {
   type CloudRequest,
   CloudSessionAdapter,
   isDefined,
+  knownValue,
 } from "../src/cloud-session-adapter";
 
 const TEST_TIME = Date.parse("2026-08-12T02:45:00.000Z");
@@ -107,6 +108,17 @@ function adapterFor(
     minimumRefreshIntervalMs: 0,
   });
 }
+
+test("accepts only a state this build knows", () => {
+  const REPORTED_STATE = { IDLE: "idle", WORKING: "working" } as const;
+
+  assert.equal(knownValue(REPORTED_STATE, "working"), REPORTED_STATE.WORKING);
+  // A state a provider adds later is left undefined rather than guessed at, and
+  // an inherited property name is not a state at all.
+  assert.equal(knownValue(REPORTED_STATE, "reviewing"), undefined);
+  assert.equal(knownValue(REPORTED_STATE, "toString"), undefined);
+  assert.equal(knownValue(REPORTED_STATE, undefined), undefined);
+});
 
 test("authenticates a bounded read and encodes the route a subclass asked for", async () => {
   const stub = stubFetch();

--- a/apps/desktop/tests/credential-providers.test.ts
+++ b/apps/desktop/tests/credential-providers.test.ts
@@ -9,6 +9,7 @@ import {
 
 test("accepts only a provider the build ships", () => {
   assert.equal(isCredentialProviderId(CREDENTIAL_PROVIDER_ID.CONDUCTOR), true);
+  assert.equal(isCredentialProviderId(CREDENTIAL_PROVIDER_ID.CURSOR), true);
   assert.equal(isCredentialProviderId("unknown-cloud"), false);
   // An inherited property name is not a provider, and neither is a value that
   // is not a string at all.

--- a/apps/desktop/tests/cursor-adapter.test.ts
+++ b/apps/desktop/tests/cursor-adapter.test.ts
@@ -1,0 +1,581 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { SESSION_STATUS } from "@sidecar/core";
+import type { CloudFetch } from "../src/cloud-session-adapter";
+import { CURSOR_PROVIDER, CursorSessionAdapter } from "../src/cursor-adapter";
+
+const TEST_TIME = Date.parse("2026-08-12T02:45:00.000Z");
+const TEST_BASE_URL = "https://api.cursor.test";
+const TEST_API_KEY = "cursor-test-key";
+const TEST_REPOSITORY = "https://github.com/reviewstage/luke";
+const SECRET_PROMPT_TEXT = "SECRET_PROMPT_TEXT";
+
+/** An agent reports only whether the user filed it away. */
+const TEST_AGENT_STATUS = {
+  ACTIVE: "ACTIVE",
+  ARCHIVED: "ARCHIVED",
+} as const;
+
+/** Its latest run reports what it is actually doing. */
+const TEST_RUN_STATUS = {
+  CREATING: "CREATING",
+  RUNNING: "RUNNING",
+  FINISHED: "FINISHED",
+  CANCELLED: "CANCELLED",
+  EXPIRED: "EXPIRED",
+  ERROR: "ERROR",
+} as const;
+
+const HTTP_STATUS = {
+  OK: 200,
+  UNAUTHORIZED: 401,
+  SERVER_ERROR: 500,
+} as const;
+
+interface TestRun {
+  id: string;
+  status?: string;
+  updatedAt?: number;
+  httpStatus?: number;
+}
+
+interface TestAgent {
+  id: string;
+  /** Written from the opening prompt, like `summary` and the run's branch. */
+  name: string;
+  archived?: boolean;
+  repository?: string;
+  startingRef?: string;
+  omitRepos?: boolean;
+  createdAt: number;
+  updatedAt?: number;
+  run?: TestRun;
+}
+
+interface RecordedRequest {
+  method: string;
+  pathname: string;
+  search: string;
+  authorization: string | undefined;
+}
+
+interface FakeCursorApi {
+  fetch: CloudFetch;
+  requests: RecordedRequest[];
+}
+
+function isoTimestamp(timestampMs: number): string {
+  return new Date(timestampMs).toISOString();
+}
+
+function jsonResponse(body: unknown, status = HTTP_STATUS.OK): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function lastActivityAt(agent: TestAgent): number {
+  return agent.updatedAt ?? agent.createdAt;
+}
+
+function agentPayload(agent: TestAgent): Record<string, unknown> {
+  return {
+    id: agent.id,
+    name: agent.name,
+    summary: `${SECRET_PROMPT_TEXT} was requested`,
+    status: agent.archived ? TEST_AGENT_STATUS.ARCHIVED : TEST_AGENT_STATUS.ACTIVE,
+    env: { type: "cloud" },
+    ...(agent.omitRepos
+      ? {}
+      : {
+          repos: [
+            {
+              url: agent.repository ?? TEST_REPOSITORY,
+              ...(agent.startingRef ? { startingRef: agent.startingRef } : {}),
+            },
+          ],
+        }),
+    url: `https://cursor.com/agents/${agent.id}`,
+    createdAt: isoTimestamp(agent.createdAt),
+    updatedAt: isoTimestamp(lastActivityAt(agent)),
+    ...(agent.run ? { latestRunId: agent.run.id } : {}),
+  };
+}
+
+function runPayload(agent: TestAgent, run: TestRun): Record<string, unknown> {
+  return {
+    id: run.id,
+    agentId: agent.id,
+    status: run.status ?? TEST_RUN_STATUS.FINISHED,
+    createdAt: isoTimestamp(agent.createdAt),
+    updatedAt: isoTimestamp(run.updatedAt ?? lastActivityAt(agent)),
+    durationMs: 12_357,
+    // Cursor writes the result and names the branch it opens from the prompt,
+    // so both are transcript content that no observation may carry.
+    result: `${SECRET_PROMPT_TEXT} was completed`,
+    git: {
+      branches: [
+        {
+          repoUrl: agent.repository ?? TEST_REPOSITORY,
+          branch: `cursor/${SECRET_PROMPT_TEXT}-a1b2`,
+        },
+      ],
+    },
+  };
+}
+
+/** Serves the read-only subset of the public API the adapter is allowed to use. */
+function fakeCursorApi(agents: readonly TestAgent[]): FakeCursorApi {
+  const requests: RecordedRequest[] = [];
+  const fetch: CloudFetch = async (url, init) => {
+    const { pathname, searchParams, search } = new URL(url);
+    const headers = new Headers(init.headers);
+    requests.push({
+      method: init.method ?? "",
+      pathname,
+      search,
+      authorization: headers.get("authorization") ?? undefined,
+    });
+
+    const segments = pathname.split("/").filter((segment) => segment.length > 0);
+    if (segments[0] !== "v1" || segments[1] !== "agents") {
+      return jsonResponse({}, HTTP_STATUS.SERVER_ERROR);
+    }
+
+    if (segments.length === 2) {
+      const limit = Number(searchParams.get("limit") ?? "20");
+      // Cursor answers newest-first and pages the rest behind `nextCursor`.
+      const page = [...agents]
+        .sort((first, second) => lastActivityAt(second) - lastActivityAt(first))
+        .slice(0, limit);
+      return jsonResponse({
+        items: page.map(agentPayload),
+        ...(page.length < agents.length ? { nextCursor: "next-page" } : {}),
+      });
+    }
+
+    if (segments[3] === "runs" && segments.length === 5) {
+      const agent = agents.find((candidate) => candidate.id === segments[2]);
+      const run = agent?.run?.id === segments[4] ? agent.run : undefined;
+      if (!agent || !run) return jsonResponse({}, HTTP_STATUS.SERVER_ERROR);
+      if (run.httpStatus) return jsonResponse({}, run.httpStatus);
+      return jsonResponse(runPayload(agent, run));
+    }
+    return jsonResponse({}, HTTP_STATUS.SERVER_ERROR);
+  };
+  return { fetch, requests };
+}
+
+function adapterFor(
+  fetch: CloudFetch,
+  overrides: {
+    apiKey?: string | undefined;
+    readApiKey?: () => Promise<string | undefined>;
+    now?: () => number;
+    minimumRefreshIntervalMs?: number;
+    maximumObservedSessions?: number;
+  } = {},
+): CursorSessionAdapter {
+  const apiKey = "apiKey" in overrides ? overrides.apiKey : TEST_API_KEY;
+  return new CursorSessionAdapter({
+    readApiKey: overrides.readApiKey ?? (async () => apiKey),
+    baseUrl: TEST_BASE_URL,
+    fetch,
+    now: overrides.now ?? (() => TEST_TIME),
+    minimumRefreshIntervalMs: overrides.minimumRefreshIntervalMs ?? 0,
+    ...(overrides.maximumObservedSessions === undefined
+      ? {}
+      : { maximumObservedSessions: overrides.maximumObservedSessions }),
+  });
+}
+
+function runningAgent(id: string, updatedAt: number): TestAgent {
+  return {
+    id,
+    name: SECRET_PROMPT_TEXT,
+    createdAt: updatedAt,
+    updatedAt,
+    run: { id: `run-${id}`, status: TEST_RUN_STATUS.RUNNING, updatedAt },
+  };
+}
+
+test("observes a running agent without exposing prompt-derived names", async () => {
+  const api = fakeCursorApi([
+    {
+      id: "agent-running",
+      name: SECRET_PROMPT_TEXT,
+      startingRef: "main",
+      createdAt: TEST_TIME - 60_000,
+      updatedAt: TEST_TIME - 30_000,
+      run: { id: "run-running", status: TEST_RUN_STATUS.RUNNING, updatedAt: TEST_TIME - 30_000 },
+    },
+  ]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.deepEqual(CURSOR_PROVIDER, { id: "cursor", displayName: "Cursor" });
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "agent-running");
+  assert.equal(observations[0]?.title, "Cursor: luke");
+  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
+  assert.equal(observations[0]?.observedAt, TEST_TIME - 30_000);
+  assert.equal(observations[0]?.controls, undefined);
+  assert.match(observations[0]?.summary ?? "", /from main/);
+  assert.equal(JSON.stringify(observations).includes(SECRET_PROMPT_TEXT), false);
+  // One list call, then one read of the run that list named. Nothing else.
+  assert.deepEqual(
+    api.requests.map((request) => request.pathname),
+    ["/v1/agents", "/v1/agents/agent-running/runs/run-running"],
+  );
+  assert.equal(api.requests[0]?.search, "?limit=100");
+  assert.equal(
+    api.requests.every(
+      (request) => request.method === "GET" && request.authorization === `Bearer ${TEST_API_KEY}`,
+    ),
+    true,
+  );
+});
+
+test("maps every run state Cursor reports onto a state Luke can show", async () => {
+  const api = fakeCursorApi(
+    (
+      [
+        [TEST_RUN_STATUS.RUNNING, "running"],
+        [TEST_RUN_STATUS.FINISHED, "finished"],
+        [TEST_RUN_STATUS.CANCELLED, "cancelled"],
+        [TEST_RUN_STATUS.EXPIRED, "expired"],
+        [TEST_RUN_STATUS.CREATING, "creating"],
+        [TEST_RUN_STATUS.ERROR, "errored"],
+      ] as const
+    ).map(([status, name], index) => ({
+      id: `agent-${name}`,
+      name: SECRET_PROMPT_TEXT,
+      createdAt: TEST_TIME - (index + 1) * 1_000,
+      updatedAt: TEST_TIME - (index + 1) * 1_000,
+      run: { id: `run-${name}`, status, updatedAt: TEST_TIME - (index + 1) * 1_000 },
+    })),
+  );
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => [observation.providerSessionId, observation.status]),
+    [
+      ["agent-running", SESSION_STATUS.WORKING],
+      ["agent-finished", SESSION_STATUS.WAITING],
+      ["agent-cancelled", SESSION_STATUS.COMPLETE],
+      ["agent-expired", SESSION_STATUS.COMPLETE],
+      ["agent-creating", SESSION_STATUS.UNKNOWN],
+      ["agent-errored", SESSION_STATUS.UNKNOWN],
+    ],
+  );
+});
+
+test("reports a turn that just ended as waiting however long the run took", async () => {
+  // The agent was started hours ago and the run took most of that time. Dating
+  // the turn from the agent instead of its run would call this stale and leave
+  // Luke silent at the one moment the user is being waited on.
+  const api = fakeCursorApi([
+    {
+      id: "agent-long-turn",
+      name: SECRET_PROMPT_TEXT,
+      createdAt: TEST_TIME - 4 * 60 * 60 * 1000,
+      updatedAt: TEST_TIME - 3 * 60 * 60 * 1000,
+      run: { id: "run-long-turn", status: TEST_RUN_STATUS.FINISHED, updatedAt: TEST_TIME - 60_000 },
+    },
+  ]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
+  assert.equal(observations[0]?.observedAt, TEST_TIME - 60_000);
+});
+
+test("stops calling a finished run waiting once it goes stale", async () => {
+  const api = fakeCursorApi([
+    {
+      id: "agent-abandoned",
+      name: SECRET_PROMPT_TEXT,
+      createdAt: TEST_TIME - 3 * 60 * 60 * 1000,
+      updatedAt: TEST_TIME - 2 * 60 * 60 * 1000,
+      run: {
+        id: "run-abandoned",
+        status: TEST_RUN_STATUS.FINISHED,
+        updatedAt: TEST_TIME - 2 * 60 * 60 * 1000,
+      },
+    },
+  ]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
+});
+
+test("keeps reporting a long run as working", async () => {
+  // A run state is stamped with the moment it was entered rather than with a
+  // heartbeat, so a turn that started an hour ago and is still going must not
+  // read as stale.
+  const startedAt = TEST_TIME - 60 * 60 * 1000;
+  const api = fakeCursorApi([runningAgent("agent-long-run", startedAt)]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
+  assert.equal(observations[0]?.observedAt, startedAt);
+});
+
+test("reports an archived agent as complete without reading its run", async () => {
+  const api = fakeCursorApi([
+    {
+      id: "agent-archived",
+      name: SECRET_PROMPT_TEXT,
+      archived: true,
+      createdAt: TEST_TIME - 30_000,
+      updatedAt: TEST_TIME - 20_000,
+      run: { id: "run-archived", status: TEST_RUN_STATUS.RUNNING },
+    },
+  ]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.status, SESSION_STATUS.COMPLETE);
+  assert.equal(observations[0]?.observedAt, TEST_TIME - 20_000);
+  assert.deepEqual(
+    api.requests.map((request) => request.pathname),
+    ["/v1/agents"],
+  );
+});
+
+test("leaves an agent that has never run unknown without reading a run", async () => {
+  const api = fakeCursorApi([
+    { id: "agent-unrun", name: SECRET_PROMPT_TEXT, createdAt: TEST_TIME - 5_000 },
+  ]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
+  assert.deepEqual(
+    api.requests.map((request) => request.pathname),
+    ["/v1/agents"],
+  );
+});
+
+test("leaves a run state this build does not know unknown", async () => {
+  const api = fakeCursorApi([
+    {
+      id: "agent-unrecognized",
+      name: SECRET_PROMPT_TEXT,
+      createdAt: TEST_TIME - 1_000,
+      run: { id: "run-unrecognized", status: "SOME_LATER_STATE", updatedAt: TEST_TIME - 1_000 },
+    },
+  ]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
+});
+
+test("keeps observing when one agent's run cannot be read", async () => {
+  const api = fakeCursorApi([
+    {
+      id: "agent-unreadable",
+      name: SECRET_PROMPT_TEXT,
+      createdAt: TEST_TIME - 1_000,
+      updatedAt: TEST_TIME - 1_000,
+      run: { id: "run-unreadable", httpStatus: HTTP_STATUS.SERVER_ERROR },
+    },
+    runningAgent("agent-readable", TEST_TIME - 2_000),
+  ]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations.length, 2);
+  assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(observations[1]?.status, SESSION_STATUS.WORKING);
+});
+
+test("ignores agents untouched for longer than the maximum session age", async () => {
+  const api = fakeCursorApi([runningAgent("agent-last-week", TEST_TIME - 48 * 60 * 60 * 1000)]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.deepEqual(observations, []);
+  assert.deepEqual(
+    api.requests.map((request) => request.pathname),
+    ["/v1/agents"],
+  );
+});
+
+test("labels an agent by its repository, and by neither its name nor nothing", async () => {
+  const api = fakeCursorApi([
+    {
+      id: "agent-repository",
+      name: SECRET_PROMPT_TEXT,
+      repository: "git@github.com:reviewstage/sidecar.git",
+      createdAt: TEST_TIME - 1_000,
+    },
+    {
+      id: "agent-repositoryless",
+      name: SECRET_PROMPT_TEXT,
+      omitRepos: true,
+      createdAt: TEST_TIME - 2_000,
+    },
+  ]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations[0]?.title, "Cursor: sidecar");
+  assert.equal(observations[1]?.title, "Cursor: workspace");
+  assert.equal(JSON.stringify(observations).includes(SECRET_PROMPT_TEXT), false);
+});
+
+test("bounds the agents a single pass observes, keeping the ones that can still change", async () => {
+  const api = fakeCursorApi([
+    {
+      id: "agent-archived-moments-ago",
+      name: SECRET_PROMPT_TEXT,
+      archived: true,
+      createdAt: TEST_TIME - 1_000,
+      updatedAt: TEST_TIME - 1_000,
+    },
+    runningAgent("agent-running-newer", TEST_TIME - 2_000),
+    runningAgent("agent-running-older", TEST_TIME - 3_000),
+  ]);
+
+  const observations = await adapterFor(api.fetch, { maximumObservedSessions: 2 }).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.providerSessionId),
+    ["agent-running-newer", "agent-running-older"],
+  );
+});
+
+test("drops an agent it cannot place in time without losing the rest of the pass", async () => {
+  const fetch: CloudFetch = async () =>
+    jsonResponse({
+      items: [
+        { name: SECRET_PROMPT_TEXT, status: TEST_AGENT_STATUS.ACTIVE },
+        { id: "agent-undated", name: SECRET_PROMPT_TEXT, status: TEST_AGENT_STATUS.ACTIVE },
+        {
+          id: "agent-complete",
+          name: SECRET_PROMPT_TEXT,
+          status: TEST_AGENT_STATUS.ACTIVE,
+          repos: [{ url: TEST_REPOSITORY }],
+          createdAt: isoTimestamp(TEST_TIME - 1_000),
+          updatedAt: isoTimestamp(TEST_TIME - 1_000),
+        },
+      ],
+    });
+
+  const observations = await adapterFor(fetch).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.providerSessionId),
+    ["agent-complete"],
+  );
+});
+
+test("reports nothing and issues no request without an API key", async () => {
+  const api = fakeCursorApi([runningAgent("agent-running", TEST_TIME - 1_000)]);
+
+  const observations = await adapterFor(api.fetch, { apiKey: undefined }).observe();
+
+  assert.deepEqual(observations, []);
+  assert.deepEqual(api.requests, []);
+});
+
+test("reports nothing when the credential cannot be read", async () => {
+  const api = fakeCursorApi([runningAgent("agent-running", TEST_TIME - 1_000)]);
+  const adapter = adapterFor(api.fetch, {
+    readApiKey: async () => {
+      throw new Error("settings are unreadable");
+    },
+  });
+
+  assert.deepEqual(await adapter.observe(), []);
+  assert.deepEqual(api.requests, []);
+});
+
+test("reuses the previous snapshot inside the minimum refresh interval", async () => {
+  const api = fakeCursorApi([runningAgent("agent-running", TEST_TIME - 1_000)]);
+  let now = TEST_TIME;
+  const adapter = adapterFor(api.fetch, { now: () => now, minimumRefreshIntervalMs: 15_000 });
+
+  const first = await adapter.observe();
+  const requestsAfterFirstPass = api.requests.length;
+  now = TEST_TIME + 5_000;
+  const throttled = await adapter.observe();
+  const requestsAfterThrottledPass = api.requests.length;
+  now = TEST_TIME + 20_000;
+  const refreshed = await adapter.observe();
+
+  assert.equal(first.length, 1);
+  assert.deepEqual(throttled, first);
+  assert.equal(
+    requestsAfterThrottledPass,
+    requestsAfterFirstPass,
+    "throttled pass issued requests",
+  );
+  assert.ok(api.requests.length > requestsAfterThrottledPass, "refreshed pass issued no request");
+  assert.equal(refreshed.length, 1);
+});
+
+test("observes again immediately after the API key changes", async () => {
+  const api = fakeCursorApi([runningAgent("agent-running", TEST_TIME - 1_000)]);
+  let apiKey = TEST_API_KEY;
+  const adapter = adapterFor(api.fetch, {
+    readApiKey: async () => apiKey,
+    minimumRefreshIntervalMs: 60_000,
+  });
+
+  await adapter.observe();
+  const requestsAfterFirstPass = api.requests.length;
+  apiKey = "cursor-replacement-key";
+  const observations = await adapter.observe();
+
+  assert.ok(api.requests.length > requestsAfterFirstPass);
+  assert.equal(observations.length, 1);
+  assert.equal(
+    api.requests.at(-1)?.authorization,
+    "Bearer cursor-replacement-key",
+    "the replacement key was not used",
+  );
+});
+
+test("clears observations when Cursor rejects the API key", async () => {
+  const api = fakeCursorApi([runningAgent("agent-running", TEST_TIME - 1_000)]);
+  let rejectRequests = false;
+  const gatedFetch: CloudFetch = async (url, init) =>
+    rejectRequests ? jsonResponse({}, HTTP_STATUS.UNAUTHORIZED) : api.fetch(url, init);
+  const adapter = adapterFor(gatedFetch);
+
+  const authorized = await adapter.observe();
+  rejectRequests = true;
+  const rejected = await adapter.observe();
+
+  assert.equal(authorized.length, 1);
+  assert.deepEqual(rejected, []);
+});
+
+test("keeps the previous snapshot when the list request fails transiently", async () => {
+  const api = fakeCursorApi([runningAgent("agent-running", TEST_TIME - 1_000)]);
+  let failRequests = false;
+  const gatedFetch: CloudFetch = async (url, init) => {
+    if (failRequests) throw new Error("network unreachable");
+    return api.fetch(url, init);
+  };
+  const adapter = adapterFor(gatedFetch);
+
+  const observed = await adapter.observe();
+  failRequests = true;
+  const duringOutage = await adapter.observe();
+
+  assert.equal(observed.length, 1);
+  assert.deepEqual(duringOutage, observed);
+});

--- a/apps/desktop/tests/session-model.test.ts
+++ b/apps/desktop/tests/session-model.test.ts
@@ -44,6 +44,7 @@ test("the most urgent sessions are listed first in either data source", () => {
   assert.deepEqual(fixtureStates, [
     SESSION_STATE.ATTENTION,
     SESSION_STATE.WORKING,
+    SESSION_STATE.WORKING,
     SESSION_STATE.COMPLETE,
     SESSION_STATE.UNKNOWN,
   ]);
@@ -83,18 +84,21 @@ test("the tally counts per state and per provider", () => {
   assert.deepEqual(
     { ...tally, providers: undefined },
     {
-      total: 4,
+      total: 5,
       attention: 1,
-      working: 1,
+      working: 2,
       complete: 1,
       idle: 1,
       state: SESSION_STATE.ATTENTION,
       providers: undefined,
     },
   );
+  // Providers follow the order their most urgent session takes, so Cursor's
+  // working agent is listed ahead of Conductor's completed session.
   assert.deepEqual(tally.providers, [
     { providerId: PROVIDER_ID.CLAUDE_CODE, provider: "Claude Code", total: 2, attention: 1 },
     { providerId: PROVIDER_ID.CODEX, provider: "Codex", total: 1, attention: 0 },
+    { providerId: PROVIDER_ID.CURSOR, provider: "Cursor", total: 1, attention: 0 },
     { providerId: PROVIDER_ID.CONDUCTOR, provider: "Conductor", total: 1, attention: 0 },
   ]);
 });
@@ -117,7 +121,7 @@ test("the caption names its own number so the count is never misread", () => {
   const tally = sessionTally(displaySessions(bootstrap(true), []));
 
   assert.equal(tallyCaption(tally), "1 needs you");
-  assert.equal(tallySummary(tally), "4 sessions tracked, 1 needing you");
+  assert.equal(tallySummary(tally), "5 sessions tracked, 1 needing you");
   assert.equal(tallyCaption({ ...tally, attention: 2 }), "2 need you");
   assert.equal(tallyCaption({ ...tally, attention: 0, working: 3 }), "3 working");
   assert.equal(tallyCaption({ ...tally, attention: 0, working: 0 }), "1 complete");

--- a/packages/sidecar-core/src/fixtures.ts
+++ b/packages/sidecar-core/src/fixtures.ts
@@ -51,7 +51,15 @@ const smokeFixture: FixtureSnapshot = {
       detail: "Cloud session metadata only · no live credentials",
       state: SESSION_STATE.COMPLETE,
     },
-    // A fourth session keeps every state and every provider mark visible in the
+    {
+      id: "cursor-agent",
+      title: "Follow a cloud agent",
+      providerId: PROVIDER_ID.CURSOR,
+      provider: "Cursor",
+      detail: "Cloud session metadata only · no live credentials",
+      state: SESSION_STATE.WORKING,
+    },
+    // A fifth session keeps every state and every provider mark visible in the
     // one screenshot the visual evidence is reviewed from.
     {
       id: "claude-observe",

--- a/packages/sidecar-core/src/providers.ts
+++ b/packages/sidecar-core/src/providers.ts
@@ -9,6 +9,7 @@ export const PROVIDER_ID = {
   CLAUDE_CODE: "claude-code",
   CODEX: "codex",
   CONDUCTOR: "conductor",
+  CURSOR: "cursor",
 } as const;
 
 export type ProviderId = (typeof PROVIDER_ID)[keyof typeof PROVIDER_ID];


### PR DESCRIPTION
## Summary

- Add a `CursorSessionAdapter` on `CloudSessionAdapter` ([LUKE-58](https://linear.app/stage-review/issue/LUKE-58/integrate-cursor-cloud-agent-sessions)), so a Cursor API key saved in Settings — or read from `CURSOR_API_KEY` — lets Luke observe cloud agents the way it already observes Conductor sessions. Without a key it reports nothing and issues no request, and every other provider keeps working without one. The id is core's `PROVIDER_ID.CURSOR`, so the credential row, the session row, and the mark all name the same provider.
- A pass is one bounded `GET /v1/agents` call plus one read of the run each observed agent names as its latest. A Cursor agent is a standing definition whose own status reports only whether the user filed it away, so the state Luke shows exists only on the run; that is the fan-out the issue allows "unless a status needs it". An archived agent and one that has never run are already settled and cost no second request.
- Map run states as the issue specifies: `RUNNING` to working without freshness decay, since a run state is stamped with the moment it was entered rather than with a heartbeat; `FINISHED` to waiting through `statusWhileRecent`; `CANCELLED` and `EXPIRED` to complete; `CREATING`, `ERROR`, or a state this build does not know to unknown rather than a state Luke cannot verify.
- Stamp each observation with the run's `updatedAt`, so a turn that just ended reads as waiting however long the run took. The agent's own timestamps would date a 40-minute run from when it started and call the finished turn stale at the one moment the user is being waited on.
- Label each session by `repos[].url` through `repositoryLabel()`. An agent's `name`, `summary`, the run's `result`, and the branch Cursor opens are all written from the opening prompt, so the label has no fallback to any of them; a test plants `SECRET_PROMPT_TEXT` in all four and asserts none of it reaches an observation.
- Show Cursor's brand mark on Cursor sessions, reproduced from Simple Icons (CC0-1.0, sourced from cursor.com/brand) as inline path data like the other marks. Cursor publishes one silhouette rather than a colour pair, so it is drawn in the light form the brand uses on a dark surface. The smoke fixture gains a Cursor session so the mark appears in generated evidence, as every other provider's does.
- Move the guard for reading a state a provider reported into the shared cloud adapter as `knownValue`, now that a second provider needs it. Both adapters had written it out with their own pair of casts; matching against the known values needs none.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — passed (repository contract checks, Biome, typecheck, 94 desktop tests including 19 new Cursor tests, 33 sidecar-core tests, 5 harness tests, and both builds)
- macOS Electron verification (`./scripts/verify.sh`): `not run` locally — this workspace is a Linux cloud sandbox; the macOS CI job runs it on this PR, and its evidence now carries a Cursor row
- Live account verification: the adapter itself was run against a real Cursor account on macOS, decrypting the stored key in process. One pass issued exactly two requests — `GET /v1/agents?limit=100` and `GET /v1/agents/{id}/runs/{latestRunId}` — and produced one row, `waiting · Cursor: luke`, stamped `2026-08-12T22:33:45Z`, the moment that run finished. Agents last touched outside the 24-hour window were dropped, and no prompt-derived text appeared in the observation.
- Re-run after the shared-guard cleanup: the same two requests, the same row and timestamp, by then reported as `unknown` because the run had finished twenty minutes earlier — `statusWhileRecent` holding the waiting state only while it is recent.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31656654135/artifacts/9164637188) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31656654135)

- Commit: `4648b68c579e3445bea2f99eb533113a91c4735c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` — the deterministic CI evidence covers the new mark in the panel
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Rebased onto main for the panel revamp (#18) and the provider marks (#17). The three earlier commits collapsed into two: the adapter, and the mark, matching how Conductor's mark landed separately.
- The issue describes the `/v0/agents` payload, which is still served and returns `source.repository`, `source.ref`, and a run-level `status` in one call. This PR uses `/v1/agents` instead because v0 carries no per-run timestamp: its only date is when the agent was created, so a finished turn would decay to unknown minutes after a long run ended. The status mapping the issue specifies is unchanged; it moved to the object that actually reports it.
- Blockers or follow-up verification: None