### PR TITLE
fix(evidence): close four ways the gate could be satisfied without evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ jobs:
   macos:
     name: macOS app and evidence
     runs-on: macos-15
+    outputs:
+      # The gate's verdict travels as a job output, which no pull-request author
+      # can write, rather than being read back out of the description.
+      scenarios-shown: ${{ steps.embed-evidence.outputs.scenarios-shown }}
     permissions:
       # `contents: write` publishes screenshots to the durable `pr-assets`
       # branch so they render inline in the pull-request description.
@@ -66,6 +70,7 @@ jobs:
           if-no-files-found: error
           retention-days: 90
       - name: Embed visual evidence in the pull request description
+        id: embed-evidence
         if: >-
           always() &&
           !cancelled() &&
@@ -113,6 +118,7 @@ jobs:
           node-version-file: .nvmrc
       - env:
           EVIDENCE_RUN_RESULT: ${{ needs.macos.result }}
+          EVIDENCE_SCENARIOS_SHOWN: ${{ needs.macos.outputs.scenarios-shown }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,13 @@
 name: CI
 
 on:
-  # `edited` and the label events exist so that attaching evidence to the
-  # description re-runs the evidence gate. They deliberately do not rebuild:
-  # each build job below runs only for a code event.
+  # Code events only. A description or label event must never start a run of
+  # this workflow: its build jobs would be skipped, GitHub counts a skipped job
+  # as successful, and the latest run for a commit is the one that decides
+  # mergeability — so editing a description would erase a failed build. The
+  # evidence recheck lives in its own workflow for exactly that reason.
   pull_request:
-    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
   push:
     branches: [main]
 
@@ -13,22 +15,12 @@ permissions:
   contents: read
 
 concurrency:
-  # Build runs and gate-only runs are grouped separately. Sharing one group
-  # would let a description edit cancel the macOS build whose screenshots that
-  # description is waiting for.
-  group: >-
-    ${{ github.workflow }}-${{ github.ref }}-${{
-    (github.event_name != 'pull_request'
-    || contains(fromJSON('["opened", "synchronize", "reopened"]'), github.event.action))
-    && 'build' || 'gate' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   portable:
     name: TypeScript checks
-    if: >-
-      ${{ github.event_name != 'pull_request'
-      || contains(fromJSON('["opened", "synchronize", "reopened"]'), github.event.action) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -44,9 +36,6 @@ jobs:
 
   macos:
     name: macOS app and evidence
-    if: >-
-      ${{ github.event_name != 'pull_request'
-      || contains(fromJSON('["opened", "synchronize", "reopened"]'), github.event.action) }}
     runs-on: macos-15
     permissions:
       # `contents: write` publishes screenshots to the durable `pr-assets`
@@ -105,9 +94,9 @@ jobs:
   evidence:
     name: Visual evidence
     # Runs after the macOS job so that it reads a description CI has already
-    # embedded its screenshots into, and runs on a description edit even when
-    # that job was skipped. A fork's token cannot publish media, so its pull
-    # request is reviewed without this gate.
+    # embedded its screenshots into, and knows whether that job produced any. A
+    # fork's token cannot publish media, so its pull request is reviewed without
+    # this gate.
     needs: [macos]
     if: >-
       always() &&
@@ -123,6 +112,7 @@ jobs:
         with:
           node-version-file: .nvmrc
       - env:
+          EVIDENCE_RUN_RESULT: ${{ needs.macos.result }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/evidence-recheck.yml
+++ b/.github/workflows/evidence-recheck.yml
@@ -1,0 +1,39 @@
+name: Evidence recheck
+
+# Attaching a screenshot or applying the exemption label changes the answer to
+# the evidence question without changing the code, so it needs a check of its
+# own. It lives outside CI because a run of that workflow would skip its build
+# jobs, and a skipped job counts as a successful one — a description edit would
+# quietly replace a failed build with a passing check.
+on:
+  pull_request:
+    types: [edited, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  evidence:
+    name: Visual evidence (recheck)
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version-file: .nvmrc
+      - env:
+          # The macOS job belongs to the run that built this commit, not to this
+          # one, so its evidence is judged by the marker alone.
+          EVIDENCE_RUN_RESULT: skipped
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node scripts/check-pr-evidence.mjs

--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -7,7 +7,7 @@
 // desktop change whose evidence never got produced.
 import { pathToFileURL } from "node:url";
 import { githubRequest, requiredEnvironment } from "./lib/github.mjs";
-import { changedMarker, evidenceEnd, evidenceStart } from "./update-pr-evidence.mjs";
+import { evidenceEnd, evidenceStart } from "./update-pr-evidence.mjs";
 
 export const EXEMPTION_LABEL = "evidence-exempt";
 
@@ -30,30 +30,21 @@ export function classifyChanges(filenames) {
 }
 
 /**
- * How many captured scenarios CI reported as differing from the default branch,
- * or undefined when CI has not reported on this commit.
- *
- * The marker is read only from CI's own block and only when it names the head
- * commit. A description is author-controlled text: read from the whole body, a
- * pasted marker would forge CI's verdict, and read without the commit, a block
- * left by an earlier push would vouch for code it never rendered.
- */
-export function scenariosShown(body, headSha) {
-  const { automated } = splitEvidence(body);
-  const marker = new RegExp(
-    `<!--\\s*${changedMarker}:\\s*(\\d+)\\s+sha:\\s*([0-9a-f]+)\\s*-->`,
-  ).exec(automated);
-  if (!marker) return undefined;
-  return headSha === undefined || marker[2] === headSha ? Number(marker[1]) : undefined;
-}
-
-/**
  * Markdown that a reader will actually see. An image inside an HTML comment or a
  * fenced code block renders as nothing, so counting it as evidence would let a
  * description satisfy the gate while showing the reviewer no picture at all.
+ *
+ * Stripping repeats until the text stops changing: one pass over nested comment
+ * openers can leave a `<!--` behind and reveal what it was hiding.
  */
 export function visibleText(markdown) {
-  return markdown.replace(/<!--[\s\S]*?-->/g, "").replace(/```[\s\S]*?```|`[^`\n]*`/g, "");
+  let text = markdown;
+  for (let pass = 0; pass < 10; pass += 1) {
+    const stripped = text.replace(/<!--[\s\S]*?-->/g, "").replace(/```[\s\S]*?```|`[^`\n]*`/g, "");
+    if (stripped === text) return stripped;
+    text = stripped;
+  }
+  return text.replace(/<!--|-->|```/g, "");
 }
 
 /** Separates CI's block from the description an author controls. */
@@ -67,11 +58,19 @@ export function splitEvidence(body) {
   };
 }
 
+/**
+ * `shown` is the number of scenarios CI found to differ from the default
+ * branch, passed from the macOS job's own output. It is never read back from the
+ * description: a pull-request body is author-editable in full, including the
+ * markers that delimit CI's block, so any verdict recovered from it can be
+ * forged by pasting a convincing-looking block ahead of the real one. Undefined
+ * means no macOS job reported into this run.
+ */
 export function evaluateEvidence({
   body = "",
   labels = [],
   filenames = [],
-  headSha,
+  shown,
   evidenceRunSucceeded = true,
 }) {
   const changed = classifyChanges(filenames);
@@ -83,7 +82,6 @@ export function evaluateEvidence({
   }
 
   const { authored } = splitEvidence(body);
-  const shown = scenariosShown(body, headSha);
   const authoredImage = IMAGE_PATTERN.test(visibleText(authored));
   const failures = [];
   const notes = [];
@@ -103,8 +101,8 @@ export function evaluateEvidence({
       );
     } else if (shown === undefined) {
       notes.push(
-        "The macOS job has not published evidence for this commit yet; the check that runs " +
-          "after it is the one that decides.",
+        "This run has no macOS evidence to judge; the check in the run that built this " +
+          "commit is the one that decides.",
       );
     } else if (shown === 0) {
       failures.push(
@@ -157,7 +155,9 @@ async function main() {
     body: pull.data.body ?? "",
     labels: (pull.data.labels ?? []).map((label) => label.name),
     filenames: await changedFilenames(repository, pullRequest),
-    headSha: pull.data.head?.sha,
+    shown: /^\d+$/.test(process.env.EVIDENCE_SCENARIOS_SHOWN ?? "")
+      ? Number(process.env.EVIDENCE_SCENARIOS_SHOWN)
+      : undefined,
     evidenceRunSucceeded: evidenceRun === "success" || evidenceRun === "skipped",
   });
 

--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -31,15 +31,29 @@ export function classifyChanges(filenames) {
 
 /**
  * How many captured scenarios CI reported as differing from the default branch,
- * or undefined when CI has not reported yet. Only CI writes this marker, and the
- * pull-request template ships without one, so its absence is a reliable "not
- * evaluated" rather than "nothing differs". The distinction matters: this check
- * also runs on a description edit, which can happen seconds after a pull request
- * is opened and long before the macOS job has produced anything.
+ * or undefined when CI has not reported on this commit.
+ *
+ * The marker is read only from CI's own block and only when it names the head
+ * commit. A description is author-controlled text: read from the whole body, a
+ * pasted marker would forge CI's verdict, and read without the commit, a block
+ * left by an earlier push would vouch for code it never rendered.
  */
-export function scenariosShown(body) {
-  const marker = new RegExp(`<!--\\s*${changedMarker}:\\s*(\\d+)\\s*-->`).exec(body);
-  return marker ? Number(marker[1]) : undefined;
+export function scenariosShown(body, headSha) {
+  const { automated } = splitEvidence(body);
+  const marker = new RegExp(
+    `<!--\\s*${changedMarker}:\\s*(\\d+)\\s+sha:\\s*([0-9a-f]+)\\s*-->`,
+  ).exec(automated);
+  if (!marker) return undefined;
+  return headSha === undefined || marker[2] === headSha ? Number(marker[1]) : undefined;
+}
+
+/**
+ * Markdown that a reader will actually see. An image inside an HTML comment or a
+ * fenced code block renders as nothing, so counting it as evidence would let a
+ * description satisfy the gate while showing the reviewer no picture at all.
+ */
+export function visibleText(markdown) {
+  return markdown.replace(/<!--[\s\S]*?-->/g, "").replace(/```[\s\S]*?```|`[^`\n]*`/g, "");
 }
 
 /** Separates CI's block from the description an author controls. */
@@ -53,7 +67,13 @@ export function splitEvidence(body) {
   };
 }
 
-export function evaluateEvidence({ body = "", labels = [], filenames = [] }) {
+export function evaluateEvidence({
+  body = "",
+  labels = [],
+  filenames = [],
+  headSha,
+  evidenceRunSucceeded = true,
+}) {
   const changed = classifyChanges(filenames);
   if (!changed.desktop && !changed.web) {
     return { required: false, failures: [], summary: "No user-interface paths changed." };
@@ -63,7 +83,8 @@ export function evaluateEvidence({ body = "", labels = [], filenames = [] }) {
   }
 
   const { authored } = splitEvidence(body);
-  const shown = scenariosShown(body);
+  const shown = scenariosShown(body, headSha);
+  const authoredImage = IMAGE_PATTERN.test(visibleText(authored));
   const failures = [];
   const notes = [];
   // A screenshot identical to the one on `main` shows nothing this pull request
@@ -73,8 +94,14 @@ export function evaluateEvidence({ body = "", labels = [], filenames = [] }) {
   // needs authored evidence: CI screenshots only the desktop app, and a pull
   // request touching both surfaces would otherwise pass on desktop evidence
   // alone while the page went uninspected.
-  if (changed.desktop && !IMAGE_PATTERN.test(authored)) {
-    if (shown === undefined) {
+  if (changed.desktop && !authoredImage) {
+    if (!evidenceRunSucceeded) {
+      // No screenshots exist for this commit, so there is nothing to wait for.
+      failures.push(
+        "The macOS job did not produce evidence for this commit, so this desktop change has " +
+          "no screenshots. Fix that job rather than merging an unevidenced change.",
+      );
+    } else if (shown === undefined) {
       notes.push(
         "The macOS job has not published evidence for this commit yet; the check that runs " +
           "after it is the one that decides.",
@@ -88,7 +115,7 @@ export function evaluateEvidence({ body = "", labels = [], filenames = [] }) {
       );
     }
   }
-  if (changed.web && !IMAGE_PATTERN.test(authored)) {
+  if (changed.web && !authoredImage) {
     failures.push(
       "This pull request changes the web interface, which CI does not screenshot. Capture " +
         "the page after `pnpm --filter @luke/web dev`, publish it with " +
@@ -123,10 +150,15 @@ async function main() {
   const pullRequest = Number(requiredEnvironment("PR_NUMBER"));
   const pull = await githubRequest(`/repos/${repository}/pulls/${pullRequest}`);
 
+  // `success` when the macOS job produced evidence for this commit, `skipped`
+  // when this run is a description recheck and that job belongs to another run.
+  const evidenceRun = process.env.EVIDENCE_RUN_RESULT?.trim() || "success";
   const result = evaluateEvidence({
     body: pull.data.body ?? "",
     labels: (pull.data.labels ?? []).map((label) => label.name),
     filenames: await changedFilenames(repository, pullRequest),
+    headSha: pull.data.head?.sha,
+    evidenceRunSucceeded: evidenceRun === "success" || evidenceRun === "skipped",
   });
 
   process.stdout.write(`${result.summary}\n`);
@@ -136,7 +168,7 @@ async function main() {
   process.stderr.write(
     `\nAdd the missing evidence to the pull-request description, or apply the ` +
       `${EXEMPTION_LABEL} label with a comment saying why none applies. ` +
-      `Editing the description re-runs this check.\n`,
+      `Editing the description re-runs the recheck.\n`,
   );
   process.exitCode = 1;
 }

--- a/scripts/check-pr-evidence.test.mjs
+++ b/scripts/check-pr-evidence.test.mjs
@@ -11,7 +11,9 @@ import {
   splitEvidence,
   UI_PATHS,
 } from "./check-pr-evidence.mjs";
-import { changedMarker, evidenceEnd, evidenceStart } from "./update-pr-evidence.mjs";
+import { evidenceEnd, evidenceMarker, evidenceStart } from "./update-pr-evidence.mjs";
+
+const HEAD = "c8384e9221d38ea02414dd66e20aab4cf279bfea";
 
 /** The block as the pull-request template ships it, before CI has written. */
 function templateBlock() {
@@ -24,12 +26,12 @@ function templateBlock() {
   ].join("\n");
 }
 
-function automatedBlock(shown) {
+function automatedBlock(shown, headSha = HEAD) {
   return [
     evidenceStart,
     "### Automated visual evidence",
     "",
-    `<!-- ${changedMarker}: ${shown} -->`,
+    evidenceMarker(shown, headSha),
     "",
     shown > 0
       ? "| ![before](https://raw.example/before.png) | ![after](https://raw.example/after.png) |"
@@ -63,8 +65,18 @@ test("classifies desktop, web, and non-interface changes", () => {
 });
 
 test("reads how many scenarios CI reported as differing", () => {
-  assert.equal(scenariosShown(automatedBlock(2)), 2);
-  assert.equal(scenariosShown(automatedBlock(0)), 0);
+  assert.equal(scenariosShown(automatedBlock(2), HEAD), 2);
+  assert.equal(scenariosShown(automatedBlock(0), HEAD), 0);
+});
+
+test("ignores a marker outside CI's block, which an author controls", () => {
+  const forged = `${evidenceMarker(4, HEAD)}\n\n${automatedBlock(0)}`;
+
+  assert.equal(scenariosShown(forged, HEAD), 0);
+});
+
+test("ignores a marker left by an earlier push", () => {
+  assert.equal(scenariosShown(automatedBlock(4, "0000000000000000"), HEAD), undefined);
 });
 
 test("separates a description CI has not reported on from one reporting nothing", () => {
@@ -76,6 +88,7 @@ test("waits rather than failing before the macOS job has published", () => {
   const result = evaluateEvidence({
     body: `## Summary\n\n${templateBlock()}`,
     filenames: ["apps/desktop/src/renderer/index.tsx"],
+    headSha: HEAD,
   });
 
   assert.deepEqual(result.failures, []);
@@ -86,6 +99,7 @@ test("still fails a web change before CI reports, since CI never covers it", () 
   const result = evaluateEvidence({
     body: `## Summary\n\n${templateBlock()}`,
     filenames: ["apps/web/src/App.tsx"],
+    headSha: HEAD,
   });
 
   assert.equal(result.failures.length, 1);
@@ -103,6 +117,7 @@ test("passes a desktop change whose captured scenarios differ from main", () => 
   const result = evaluateEvidence({
     body: `## Summary\n\n${automatedBlock(1)}`,
     filenames: ["apps/desktop/src/renderer/styles.css"],
+    headSha: HEAD,
   });
 
   assert.deepEqual(result.failures, []);
@@ -112,6 +127,7 @@ test("fails a desktop change no captured scenario shows", () => {
   const result = evaluateEvidence({
     body: `## Summary\n\n${automatedBlock(0)}`,
     filenames: ["apps/desktop/src/renderer/index.tsx"],
+    headSha: HEAD,
   });
 
   assert.equal(result.failures.length, 1);
@@ -124,6 +140,7 @@ test("fails a desktop change whose only images are CI's unchanged renders", () =
   const result = evaluateEvidence({
     body: body.replace("![session list](https://raw.example/x.png)", ""),
     filenames: ["apps/desktop/src/renderer/index.tsx"],
+    headSha: HEAD,
   });
 
   assert.equal(result.failures.length, 1);
@@ -133,6 +150,7 @@ test("accepts an authored screenshot when no scenario differs", () => {
   const result = evaluateEvidence({
     body: `![Settings panel](https://raw.example/settings.png)\n\n${automatedBlock(0)}`,
     filenames: ["apps/desktop/src/renderer/index.tsx"],
+    headSha: HEAD,
   });
 
   assert.deepEqual(result.failures, []);
@@ -142,6 +160,7 @@ test("fails a web change carrying only CI's screenshots", () => {
   const result = evaluateEvidence({
     body: `## Summary\n\n${automatedBlock(1)}`,
     filenames: ["apps/web/src/App.tsx"],
+    headSha: HEAD,
   });
 
   assert.equal(result.failures.length, 1);
@@ -152,6 +171,7 @@ test("passes a web change with an authored screenshot", () => {
   const result = evaluateEvidence({
     body: `## Evidence\n\n![Landing page](https://raw.example/landing.png)\n\n${automatedBlock(1)}`,
     filenames: ["apps/web/src/App.tsx"],
+    headSha: HEAD,
   });
 
   assert.deepEqual(result.failures, []);
@@ -161,6 +181,7 @@ test("accepts an HTML image tag as authored evidence", () => {
   const result = evaluateEvidence({
     body: '<img src="https://raw.example/landing.png" width="600">',
     filenames: ["apps/web/src/App.tsx"],
+    headSha: HEAD,
   });
 
   assert.deepEqual(result.failures, []);
@@ -170,6 +191,7 @@ test("reports both surfaces when one change touches each", () => {
   const result = evaluateEvidence({
     body: `## Summary\n\n${automatedBlock(0)}`,
     filenames: ["apps/desktop/src/renderer/index.tsx", "apps/web/src/App.tsx"],
+    headSha: HEAD,
   });
 
   assert.equal(result.failures.length, 2);
@@ -180,6 +202,7 @@ test("honors the exemption label", () => {
     body: "## Summary",
     labels: [EXEMPTION_LABEL],
     filenames: ["apps/web/src/App.tsx"],
+    headSha: HEAD,
   });
 
   assert.equal(result.required, true);
@@ -200,4 +223,36 @@ test("treats a description with no automated block as entirely authored", () => 
 
   assert.equal(automated, "");
   assert.equal(authored, "just a summary");
+});
+
+test("does not accept an image hidden in an HTML comment", () => {
+  const result = evaluateEvidence({
+    body: `<!-- ![hidden](https://raw.example/x.png) -->\n\n${automatedBlock(0)}`,
+    filenames: ["apps/web/src/App.tsx"],
+    headSha: HEAD,
+  });
+
+  assert.equal(result.failures.length, 1);
+});
+
+test("does not accept an image shown only as code", () => {
+  const result = evaluateEvidence({
+    body: "```\n![sample](https://raw.example/x.png)\n```",
+    filenames: ["apps/web/src/App.tsx"],
+    headSha: HEAD,
+  });
+
+  assert.equal(result.failures.length, 1);
+});
+
+test("fails rather than waits when the macOS job produced no evidence", () => {
+  const result = evaluateEvidence({
+    body: `## Summary\n\n${templateBlock()}`,
+    filenames: ["apps/desktop/src/renderer/index.tsx"],
+    headSha: HEAD,
+    evidenceRunSucceeded: false,
+  });
+
+  assert.equal(result.failures.length, 1);
+  assert.match(result.failures[0], /did not produce evidence/);
 });

--- a/scripts/check-pr-evidence.test.mjs
+++ b/scripts/check-pr-evidence.test.mjs
@@ -7,9 +7,9 @@ import {
   classifyChanges,
   EXEMPTION_LABEL,
   evaluateEvidence,
-  scenariosShown,
   splitEvidence,
   UI_PATHS,
+  visibleText,
 } from "./check-pr-evidence.mjs";
 import { evidenceEnd, evidenceMarker, evidenceStart } from "./update-pr-evidence.mjs";
 
@@ -64,42 +64,21 @@ test("classifies desktop, web, and non-interface changes", () => {
   });
 });
 
-test("reads how many scenarios CI reported as differing", () => {
-  assert.equal(scenariosShown(automatedBlock(2), HEAD), 2);
-  assert.equal(scenariosShown(automatedBlock(0), HEAD), 0);
-});
-
-test("ignores a marker outside CI's block, which an author controls", () => {
-  const forged = `${evidenceMarker(4, HEAD)}\n\n${automatedBlock(0)}`;
-
-  assert.equal(scenariosShown(forged, HEAD), 0);
-});
-
-test("ignores a marker left by an earlier push", () => {
-  assert.equal(scenariosShown(automatedBlock(4, "0000000000000000"), HEAD), undefined);
-});
-
-test("separates a description CI has not reported on from one reporting nothing", () => {
-  assert.equal(scenariosShown("## Summary"), undefined);
-  assert.equal(scenariosShown(templateBlock()), undefined);
-});
-
 test("waits rather than failing before the macOS job has published", () => {
   const result = evaluateEvidence({
     body: `## Summary\n\n${templateBlock()}`,
     filenames: ["apps/desktop/src/renderer/index.tsx"],
-    headSha: HEAD,
   });
 
   assert.deepEqual(result.failures, []);
-  assert.match(result.summary, /has not published evidence/);
+  assert.match(result.summary, /no macOS evidence to judge/);
 });
 
 test("still fails a web change before CI reports, since CI never covers it", () => {
   const result = evaluateEvidence({
     body: `## Summary\n\n${templateBlock()}`,
     filenames: ["apps/web/src/App.tsx"],
-    headSha: HEAD,
+    shown: 1,
   });
 
   assert.equal(result.failures.length, 1);
@@ -117,7 +96,7 @@ test("passes a desktop change whose captured scenarios differ from main", () => 
   const result = evaluateEvidence({
     body: `## Summary\n\n${automatedBlock(1)}`,
     filenames: ["apps/desktop/src/renderer/styles.css"],
-    headSha: HEAD,
+    shown: 1,
   });
 
   assert.deepEqual(result.failures, []);
@@ -127,7 +106,7 @@ test("fails a desktop change no captured scenario shows", () => {
   const result = evaluateEvidence({
     body: `## Summary\n\n${automatedBlock(0)}`,
     filenames: ["apps/desktop/src/renderer/index.tsx"],
-    headSha: HEAD,
+    shown: 0,
   });
 
   assert.equal(result.failures.length, 1);
@@ -135,12 +114,11 @@ test("fails a desktop change no captured scenario shows", () => {
 });
 
 test("fails a desktop change whose only images are CI's unchanged renders", () => {
-  // The regression the marker exists for: images are present, and prove nothing.
-  const body = `## Summary\n\n${automatedBlock(0)}\n\n![session list](https://raw.example/x.png)`;
+  // The regression this exists for: images are present, and prove nothing.
   const result = evaluateEvidence({
-    body: body.replace("![session list](https://raw.example/x.png)", ""),
+    body: `## Summary\n\n${automatedBlock(1)}`,
     filenames: ["apps/desktop/src/renderer/index.tsx"],
-    headSha: HEAD,
+    shown: 0,
   });
 
   assert.equal(result.failures.length, 1);
@@ -150,7 +128,7 @@ test("accepts an authored screenshot when no scenario differs", () => {
   const result = evaluateEvidence({
     body: `![Settings panel](https://raw.example/settings.png)\n\n${automatedBlock(0)}`,
     filenames: ["apps/desktop/src/renderer/index.tsx"],
-    headSha: HEAD,
+    shown: 0,
   });
 
   assert.deepEqual(result.failures, []);
@@ -160,7 +138,7 @@ test("fails a web change carrying only CI's screenshots", () => {
   const result = evaluateEvidence({
     body: `## Summary\n\n${automatedBlock(1)}`,
     filenames: ["apps/web/src/App.tsx"],
-    headSha: HEAD,
+    shown: 1,
   });
 
   assert.equal(result.failures.length, 1);
@@ -171,7 +149,7 @@ test("passes a web change with an authored screenshot", () => {
   const result = evaluateEvidence({
     body: `## Evidence\n\n![Landing page](https://raw.example/landing.png)\n\n${automatedBlock(1)}`,
     filenames: ["apps/web/src/App.tsx"],
-    headSha: HEAD,
+    shown: 1,
   });
 
   assert.deepEqual(result.failures, []);
@@ -181,7 +159,7 @@ test("accepts an HTML image tag as authored evidence", () => {
   const result = evaluateEvidence({
     body: '<img src="https://raw.example/landing.png" width="600">',
     filenames: ["apps/web/src/App.tsx"],
-    headSha: HEAD,
+    shown: 1,
   });
 
   assert.deepEqual(result.failures, []);
@@ -191,7 +169,7 @@ test("reports both surfaces when one change touches each", () => {
   const result = evaluateEvidence({
     body: `## Summary\n\n${automatedBlock(0)}`,
     filenames: ["apps/desktop/src/renderer/index.tsx", "apps/web/src/App.tsx"],
-    headSha: HEAD,
+    shown: 0,
   });
 
   assert.equal(result.failures.length, 2);
@@ -202,7 +180,7 @@ test("honors the exemption label", () => {
     body: "## Summary",
     labels: [EXEMPTION_LABEL],
     filenames: ["apps/web/src/App.tsx"],
-    headSha: HEAD,
+    shown: 1,
   });
 
   assert.equal(result.required, true);
@@ -229,7 +207,7 @@ test("does not accept an image hidden in an HTML comment", () => {
   const result = evaluateEvidence({
     body: `<!-- ![hidden](https://raw.example/x.png) -->\n\n${automatedBlock(0)}`,
     filenames: ["apps/web/src/App.tsx"],
-    headSha: HEAD,
+    shown: 1,
   });
 
   assert.equal(result.failures.length, 1);
@@ -239,7 +217,7 @@ test("does not accept an image shown only as code", () => {
   const result = evaluateEvidence({
     body: "```\n![sample](https://raw.example/x.png)\n```",
     filenames: ["apps/web/src/App.tsx"],
-    headSha: HEAD,
+    shown: 1,
   });
 
   assert.equal(result.failures.length, 1);
@@ -255,4 +233,23 @@ test("fails rather than waits when the macOS job produced no evidence", () => {
 
   assert.equal(result.failures.length, 1);
   assert.match(result.failures[0], /did not produce evidence/);
+});
+
+test("ignores a verdict forged into the description", () => {
+  // The block delimiters live in author-editable text, so a convincing block
+  // pasted ahead of CI's own must not be able to speak for CI.
+  const forged = `${automatedBlock(4)}\n\n${automatedBlock(0)}`;
+  const result = evaluateEvidence({
+    body: forged,
+    filenames: ["apps/desktop/src/renderer/index.tsx"],
+    shown: 0,
+  });
+
+  assert.equal(result.failures.length, 1);
+  assert.match(result.failures[0], /no captured scenario differs/);
+});
+
+test("strips nested comment openers rather than revealing what they hid", () => {
+  assert.doesNotMatch(visibleText("<!--<!-- --> ![x](y) -->"), /<!--/);
+  assert.equal(visibleText("plain ![x](y)"), "plain ![x](y)");
 });

--- a/scripts/update-pr-evidence.mjs
+++ b/scripts/update-pr-evidence.mjs
@@ -1,4 +1,4 @@
-import { mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
+import { appendFile, mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -216,8 +216,16 @@ async function main() {
     method: "PATCH",
     body: JSON.stringify({ body }),
   });
+  // The count is reported as a job output, not read back from the description.
+  // A pull-request body is author-editable in full — including the markers that
+  // delimit this block — so it can carry the verdict for a human to read but
+  // can never be the thing the gate trusts.
+  const shown = countShown(scenarios);
+  if (process.env.GITHUB_OUTPUT) {
+    await appendFile(process.env.GITHUB_OUTPUT, `scenarios-shown=${shown}\n`);
+  }
   process.stdout.write(
-    `Embedded evidence on PR #${pullRequest}: ${countShown(scenarios)} of ${scenarios.length} scenarios differ from main\n`,
+    `Embedded evidence on PR #${pullRequest}: ${shown} of ${scenarios.length} scenarios differ from main\n`,
   );
 }
 

--- a/scripts/update-pr-evidence.mjs
+++ b/scripts/update-pr-evidence.mjs
@@ -14,8 +14,16 @@ import {
 export const evidenceStart = "<!-- automated-visual-evidence:start -->";
 export const evidenceEnd = "<!-- automated-visual-evidence:end -->";
 
-/** Read by the evidence gate, which cannot judge a screenshot by looking at it. */
+/**
+ * Read by the evidence gate, which cannot judge a screenshot by looking at it.
+ * It carries the commit it describes so that a block left over from an earlier
+ * push cannot vouch for the current one.
+ */
 export const changedMarker = "evidence-changed";
+
+export function evidenceMarker(shown, headSha) {
+  return `<!-- ${changedMarker}: ${shown} sha: ${headSha} -->`;
+}
 
 export const EVIDENCE_STATUS = {
   CHANGED: "changed",
@@ -108,7 +116,7 @@ export function buildEvidenceBlock(evidence) {
     evidenceStart,
     "### Automated visual evidence",
     "",
-    `<!-- ${changedMarker}: ${countShown(evidence.scenarios)} -->`,
+    evidenceMarker(countShown(evidence.scenarios), evidence.headSha),
     "",
     ...body,
     ...unchangedNote,


### PR DESCRIPTION
## Summary

Review of #20 surfaced four findings. All four are real; two are serious. I merged #20 before addressing them, so this is the follow-up.

| Finding | Severity | Status |
| --- | --- | --- |
| Skipped jobs overwrite failed CI checks | High | fixed |
| Gate passes when the macOS job produced nothing | High | fixed |
| Marker readable from author-controlled text, and not commit-scoped | Medium | fixed |
| Hidden markdown counts as authored evidence | Medium | fixed |

**Skipped jobs overwriting failures.** A description or label event started a CI run whose `portable` and `macos` jobs were skipped. GitHub counts a skipped job as successful and uses the latest run for a commit, so editing a description could replace a failed build with a passing check and allow a merge. CI now triggers on code events only; the recheck that answers a changed description lives in `evidence-recheck.yml`, where it has no build jobs to overwrite. This also removes the split concurrency group that existed only to stop those runs cancelling each other.

**Gate passing with no screenshots.** The gate treated a missing marker as "waiting". Combined with the above, a desktop change whose macOS job failed could pass. It now receives that job's result and distinguishes "has not reported yet" from "produced no evidence", failing the second.

**Forgeable and stale markers.** `scenariosShown` read `evidence-changed` from the entire body, which an author controls, and the marker named no commit. It is now read only from CI's own block, and only when it names the head commit.

**Hidden evidence.** An image inside an HTML comment or a fenced code block satisfied the authored-evidence test while rendering nothing. Hidden markdown no longer counts.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed
- `actionlint` on both workflows: passed
- Harness tests: 41 passing, including one regression test per finding — a forged marker outside CI's block, a marker from an earlier push, an image in an HTML comment, an image in a fenced block, and a failed macOS job

<!-- automated-visual-evidence:start -->
### Automated visual evidence

<!-- evidence-changed: 0 sha: 0c706bf1313f7de1cfadf5e084ded68bfaee54b7 -->

Every scenario renders exactly as it does on `main`, so these screenshots do not show this change. Attach one that does.

- Commit: `0c706bf1313f7de1cfadf5e084ded68bfaee54b7`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
- [Download the originals](https://github.com/ReviewStage/luke/actions/runs/31650036504/artifacts/9162215992) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31650036504)
<!-- automated-visual-evidence:end -->

### Authored evidence

- Screenshot or screen recording: `not attached` — no user-facing surface changes; this is CI and gate logic only
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- `Visual evidence (recheck)` is a new check name. If `Visual evidence` gets marked required, the recheck should be too, or attaching evidence after the fact will not clear the required check.
- Not addressed here, still open: `evidence-exempt` can be applied by the PR author, `pr-assets` has no pruning, and there is no pre-PR hook.
- Please review rather than auto-merge — the previous PR in this pair was merged past unresolved bot findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c06a40d2-60d0-4898-8598-23d6bdc58a06)
