### PR TITLE
feat(evidence): compare visual evidence against main and gate on it

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,10 +10,16 @@
 <!-- automated-visual-evidence:start -->
 ### Automated visual evidence
 
-CI will replace this block with a link to the deterministic macOS screenshots.
+CI will replace this block with the deterministic macOS screenshots.
 <!-- automated-visual-evidence:end -->
 
-### Physical-device evidence
+### Authored evidence
+
+<!--
+A web-interface change needs a screenshot here; CI does not capture one.
+Publish it with `node scripts/publish-pr-media.mjs <pr> <file>` and embed the
+URL it prints. The same applies to physical-device screenshots and recordings.
+-->
 
 - Screenshot or screen recording: `not attached`
 - Physical-notch check: `not performed`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,13 @@
 name: CI
 
 on:
+  # Code events only. A description or label event must never start a run of
+  # this workflow: its build jobs would be skipped, GitHub counts a skipped job
+  # as successful, and the latest run for a commit is the one that decides
+  # mergeability — so editing a description would erase a failed build. The
+  # evidence recheck lives in its own workflow for exactly that reason.
   pull_request:
+    types: [opened, synchronize, reopened]
   push:
     branches: [main]
 
@@ -31,8 +37,14 @@ jobs:
   macos:
     name: macOS app and evidence
     runs-on: macos-15
+    outputs:
+      # The gate's verdict travels as a job output, which no pull-request author
+      # can write, rather than being read back out of the description.
+      scenarios-shown: ${{ steps.embed-evidence.outputs.scenarios-shown }}
     permissions:
-      contents: read
+      # `contents: write` publishes screenshots to the durable `pr-assets`
+      # branch so they render inline in the pull-request description.
+      contents: write
       pull-requests: write
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -57,7 +69,8 @@ jobs:
           path: artifacts/evidence/
           if-no-files-found: error
           retention-days: 90
-      - name: Link evidence from the pull request description
+      - name: Embed visual evidence in the pull request description
+        id: embed-evidence
         if: >-
           always() &&
           !cancelled() &&
@@ -66,9 +79,47 @@ jobs:
           steps.visual-evidence.outputs.artifact-url != ''
         env:
           ARTIFACT_URL: ${{ steps.visual-evidence.outputs.artifact-url }}
+          EVIDENCE_DIRECTORY: artifacts/evidence
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: node scripts/update-pr-evidence.mjs
+      - name: Republish the evidence baseline
+        # Every pull request is compared against the default branch's own
+        # render, so the baseline is refreshed whenever that branch moves.
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        env:
+          EVIDENCE_DIRECTORY: artifacts/evidence
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/publish-evidence-baseline.mjs
+
+  evidence:
+    name: Visual evidence
+    # Runs after the macOS job so that it reads a description CI has already
+    # embedded its screenshots into, and knows whether that job produced any. A
+    # fork's token cannot publish media, so its pull request is reviewed without
+    # this gate.
+    needs: [macos]
+    if: >-
+      always() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version-file: .nvmrc
+      - env:
+          EVIDENCE_RUN_RESULT: ${{ needs.macos.result }}
+          EVIDENCE_SCENARIOS_SHOWN: ${{ needs.macos.outputs.scenarios-shown }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node scripts/check-pr-evidence.mjs

--- a/.github/workflows/evidence-recheck.yml
+++ b/.github/workflows/evidence-recheck.yml
@@ -1,0 +1,39 @@
+name: Evidence recheck
+
+# Attaching a screenshot or applying the exemption label changes the answer to
+# the evidence question without changing the code, so it needs a check of its
+# own. It lives outside CI because a run of that workflow would skip its build
+# jobs, and a skipped job counts as a successful one — a description edit would
+# quietly replace a failed build with a passing check.
+on:
+  pull_request:
+    types: [edited, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  evidence:
+    name: Visual evidence (recheck)
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version-file: .nvmrc
+      - env:
+          # The macOS job belongs to the run that built this commit, not to this
+          # one, so its evidence is judged by the marker alone.
+          EVIDENCE_RUN_RESULT: skipped
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node scripts/check-pr-evidence.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,39 @@ Deployable products belong in `apps/`, and reusable packages belong in
 renderer sandboxed, and put platform-independent behavior in
 `packages/sidecar-core/`.
 
-Canonical commands:
+## Read this before opening a pull request
+
+`WORKFLOW.md` is the issue-to-pull-request contract. Read it in full before you
+open or update a pull request; the rules below are the ones that fail CI.
+
+- Every user-interface change ships with a screenshot in the pull-request
+  description. CI screenshots the desktop app for you and embeds the images.
+  For a web change, capture and attach the page yourself.
+- CI compares each screenshot with the same render on `main` and embeds a
+  before-and-after pair for every scenario that differs. A change no scenario
+  shows is not evidenced: add a scenario to `./scripts/evidence.sh` that renders
+  the affected surface, or attach a screenshot of your own.
+- Publish your own images with `node scripts/publish-pr-media.mjs <pr> <file>`
+  and embed the URLs it prints. Never commit generated evidence to a product
+  branch, and never assume you can use GitHub's web editor.
+- The `Visual evidence` check enforces this. If it fails, the fix is to attach
+  the missing image, not to explain its absence. Editing the description re-runs
+  the check.
+
+## Where your workspace can run
+
+Check `uname -s` before promising evidence.
+
+- On macOS, `./scripts/verify.sh` runs the whole contract, screenshots
+  included.
+- In a Linux cloud workspace, `./scripts/check.sh` is everything you can run.
+  Say so plainly: report that desktop verification is pending CI, and let the
+  macOS CI job produce the screenshots. Do not describe a desktop change as
+  verified when no packaged app ever ran.
+- A physical-notch check and `pnpm evidence:record` need a physical Mac. Neither
+  CI nor a cloud workspace can perform them; report them as not performed.
+
+## Canonical commands
 
 - `./scripts/bootstrap.sh` — install pinned workspace dependencies
 - `./scripts/check.sh` — run portable repository, type, test, and build checks
@@ -17,11 +49,14 @@ Canonical commands:
 - `./scripts/run.sh` — launch the app against live sessions, replacing any
   running instance (`--fixture smoke` for fixture data, `--keep-running` to keep
   the running instance)
-- `./scripts/evidence.sh` — write the fixture PNG under `artifacts/`
+- `./scripts/evidence.sh` — write the expanded, settings, compact, and speaking
+  fixture PNGs under `artifacts/evidence/`
 - `pnpm evidence:record` — record the fixture transition on a physical Mac
+- `node scripts/publish-pr-media.mjs <pr> <file>...` — publish pull-request
+  images and print their URLs
 - `pnpm lint:fix` — apply repository formatting and safe lint fixes
 
-Trust constraints:
+## Trust constraints
 
 - Never write provider transcripts or session-state files.
 - Never inject terminal input, simulate keystrokes, or request Accessibility.
@@ -33,15 +68,8 @@ Trust constraints:
 - Keep unsupported capabilities explicit; do not invent fallback controls.
 - Keep Electron renderers sandboxed with context isolation and narrow IPC.
 - Commit only synthetic, redacted fixtures and repository-relative paths.
-
-Before handoff, run `./scripts/check.sh` for portable-only changes. For any
-macOS or UI change, `./scripts/verify.sh` is the completion invariant. Report
-exact results; UI changes also require inspection of the visual evidence and a
-note stating whether a physical-notch check was performed. CI links generated
-evidence from the pull request description. Attach physical-device screenshots
-or recordings through GitHub's PR editor; do not commit generated evidence or
-one-off QA worksheets. Keep generated state and private planning files
-untracked.
+- Keep generated evidence, generated state, and private planning files
+  untracked.
 
 Biome is the executable style policy for TypeScript, JavaScript, JSON,
 Markdown, and CSS. Husky runs the same checks against staged files as a local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -47,8 +47,12 @@ panel instead of starting a new one.
 
 `verify.sh` packages the desktop app and writes deterministic visual evidence to
 `artifacts/evidence/app-smoke-expanded.png`,
+`artifacts/evidence/app-smoke-settings.png`,
 `artifacts/evidence/app-smoke-compact.png`, and
-`artifacts/evidence/app-smoke-speaking.png`.
+`artifacts/evidence/app-smoke-speaking.png`. `--view settings` is what opens the
+credential surface for its capture; renders are deterministic so that CI can
+compare each one against the same render on `main` and show a reviewer only what
+changed.
 
 For PR motion evidence, run `pnpm evidence:record` on a Mac with `ffmpeg`
 installed and Screen & System Audio Recording permission granted to Conductor.
@@ -109,9 +113,15 @@ double as the prompt's few-shot guidance and its regression coverage.
 ## Pull-request media
 
 Keep generated screenshots and recordings out of product branches. Inline PR
-media is stored on the shared `pr-assets` branch under `pr-<number>/` and linked
-with its `raw.githubusercontent.com` URL. Keep that one branch: deleting it
-breaks rendered images in open and historical PRs.
+media is stored on the shared `pr-assets` branch under `pr-<number>/<commit>/`
+and linked with its `raw.githubusercontent.com` URL. Publish it with
+`node scripts/publish-pr-media.mjs <pr> <file>...`, which prints the URLs to
+embed. CI publishes the macOS screenshots this way on every pull request, so a
+desktop change needs no manual capture.
+
+Keep that one branch: deleting it breaks rendered images in open and historical
+PRs. The per-commit path exists because GitHub caches image URLs, so a refreshed
+screenshot needs a new path to be visible.
 
 ## Repository map
 
@@ -122,4 +132,5 @@ breaks rendered images in open and historical PRs.
 - `.conductor/settings.toml` — shared Conductor command configuration
 
 See `WORKFLOW.md` for the issue-to-PR contract and `AGENTS.md` for agent-facing
-repository guidance.
+repository guidance. `CLAUDE.md` is a symlink to `AGENTS.md` so that every agent
+harness loads the same guide.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,41 +1,92 @@
 # Workflow
 
-1. Start from a scoped issue and an isolated workspace. Confirm non-goals and
-   trust constraints before editing.
-2. Bootstrap with `./scripts/bootstrap.sh`, then make the smallest change that
-   satisfies the issue. Use deterministic fixtures instead of personal data or
-   live provider state. Put regression coverage at the cheapest layer that
-   would have caught a behavior bug; use visual evidence for appearance-only
-   changes.
-3. Run `./scripts/check.sh` for portable-only work. For a macOS, Electron-window,
-   native-adapter, microphone, or desktop UI change, run `./scripts/verify.sh`;
-   it packages the desktop app and generates visual evidence. Inspect all PNGs.
-   For a web UI change, run `pnpm --filter @luke/web dev` and inspect the page in
-   a browser. For desktop motion changes, run `pnpm evidence:record`
-   on a physical Mac and inspect the generated MP4 or GIF before publishing it.
-4. Review the complete diff for secrets, machine-specific paths, generated
-   files, unsafe IPC, unsupported provider behavior, and accidental scope
-   expansion.
-5. Open a focused PR. Record commands and results in the template's Evidence
-   section. For every UI change, upload an inspected verification screenshot to
-   the PR description's Evidence section through GitHub's PR editor. For desktop
-   UI, use a PNG from `./scripts/verify.sh` in `artifacts/evidence/`; for web UI,
-   capture the page after running `pnpm --filter @luke/web dev`. CI
-   maintains the automated-evidence link there. Attach physical-device
-   screenshots or recordings through GitHub's PR editor and call out
-   physical-notch checks that remain.
-6. When pushing follow-up commits to an open PR, re-read the PR description and
-   update it if the change made it inaccurate or incomplete. Keep the summary,
-   scope, and Evidence section matching the commands and results for the current
-   head commit; refresh screenshots whose UI has changed and drop claims that no
-   longer hold. Leave the description alone when the new commits do not change
-   what it says.
-7. When an agent must add inline PR media without the GitHub editor, store it on
-   the shared `pr-assets` branch, not the product branch. Use a per-PR path such
-   as `pr-<number>/landing-page.png`, then embed the raw GitHub URL in the PR
-   description. Keep `pr-assets` as the one durable media branch: deleting it
-   breaks PR images. Delete an old per-PR asset branch only after every PR URL
-   that uses it has moved to `pr-assets`.
+The contract from a scoped issue to a merged pull request. `AGENTS.md` carries
+the repository conventions this assumes.
+
+## 1. Scope
+
+Start from a scoped issue in an isolated workspace. Confirm non-goals and trust
+constraints before editing.
+
+## 2. Change
+
+Bootstrap with `./scripts/bootstrap.sh`, then make the smallest change that
+satisfies the issue. Use deterministic fixtures instead of personal data or live
+provider state. Put regression coverage at the cheapest layer that would have
+caught a behavior bug; use visual evidence for appearance-only changes.
+
+## 3. Verify
+
+Run the checks your change and your machine allow.
+
+| Change                                       | Command                                                   |
+| -------------------------------------------- | --------------------------------------------------------- |
+| Portable code only                           | `./scripts/check.sh`                                       |
+| macOS, Electron window, native adapter, microphone, or desktop UI | `./scripts/verify.sh`                 |
+| Web UI                                       | `pnpm --filter @luke/web dev`, then inspect the page       |
+| Desktop motion                               | `pnpm evidence:record` on a physical Mac                   |
+
+`./scripts/verify.sh` packages the desktop app and writes PNGs to
+`artifacts/evidence/`. Inspect every one of them; generating a screenshot is not
+the same as looking at it.
+
+A Linux cloud workspace cannot run `verify.sh`, `evidence.sh`, or
+`evidence:record`. Run `./scripts/check.sh`, then say in the pull request that
+desktop verification is pending the macOS CI job. Do not claim verification you
+did not perform.
+
+## 4. Review your own diff
+
+Read the complete diff for secrets, machine-specific paths, generated files,
+unsafe IPC, unsupported provider behavior, and accidental scope expansion.
+
+## 5. Open the pull request
+
+Fill in the template's Evidence section with the commands you ran and their
+results. Then attach visual evidence:
+
+- **Desktop UI** — CI packages the app on macOS, screenshots every scenario in
+  `./scripts/evidence.sh`, and compares each with the same render on `main`. It
+  embeds a before-and-after pair for the scenarios that differ and names the
+  ones that did not. Inspect them once they appear and state whether a
+  physical-notch check was performed.
+
+  When no scenario differs, the screenshots cannot show your change and the
+  gate fails. That is a gap in the evidence, not a formality: add a scenario
+  that renders the surface you changed — `--view` opens a named panel view, and
+  `--profile` and `--fixture` select the state it renders — or attach a
+  screenshot of your own.
+- **Web UI** — CI cannot screenshot the web app. Capture the page yourself,
+  publish it with `node scripts/publish-pr-media.mjs <pr> <file>`, and embed the
+  URLs it prints in the Evidence section.
+- **Physical-device screenshots and recordings** — capture on a physical Mac and
+  publish them the same way.
+
+The `Visual evidence` check fails a pull request that changes a user-facing
+surface without evidence that shows the change. Editing the description re-runs
+it. When no image can apply, apply the `evidence-exempt` label and comment
+saying why.
+
+## 6. Keep the description true
+
+When you push follow-up commits, re-read the description and update it if the
+change made it inaccurate or incomplete. Keep the summary, scope, and Evidence
+section matching the commands and results for the current head commit. Refresh
+screenshots whose interface has changed and drop claims that no longer hold.
+Leave the description alone when the new commits do not change what it says.
+
+## Pull-request media
+
+`scripts/publish-pr-media.mjs` writes to the shared `pr-assets` branch under
+`pr-<number>/<commit>/` and prints raw URLs that render inline. Two properties
+matter:
+
+- Media never belongs on a product branch.
+- `pr-assets` is the one durable media branch. Deleting it breaks images in open
+  and historical pull requests. The per-commit path exists because GitHub caches
+  image URLs, so a refreshed screenshot needs a new path to be visible.
+
+## Blockers
 
 Stop and report a genuine blocker when validation requires unavailable access,
 credentials, hardware, or a product decision. Agents prepare evidence and

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -33,8 +33,13 @@ import { openAiAttentionEvaluatorFromEnvironment } from "./openai-attention-eval
 import { SettingsStore } from "./settings-store";
 import {
   type AppBootstrap,
+  type AppSettings,
+  CAPTURE_VIEW,
+  type CaptureView,
+  CREDENTIAL_SOURCE,
   channels,
   type DisplayDiagnostic,
+  isCaptureView,
   type MicrophoneStatus,
   type SettingsUpdateResult,
   type WindowMode,
@@ -47,9 +52,14 @@ import {
 
 const captureOutput = argumentValue("--capture-evidence");
 const profile = argumentValue("--profile") ?? "idle";
+const requestedView = argumentValue("--view");
 const fixtureName = argumentValue("--fixture");
 const fixture = fixtureSnapshot(fixtureName ?? "smoke");
 const captureMode = captureOutput !== undefined;
+if (requestedView !== undefined && !isCaptureView(requestedView)) {
+  throw new Error(`Unknown view: ${requestedView}`);
+}
+const view: CaptureView = requestedView ?? CAPTURE_VIEW.SESSIONS;
 // `--fixture` is enough on its own to make a run deterministic: the panel renders
 // the fixture snapshot and no provider is observed. Capture runs always imply it.
 const fixtureMode = captureMode || fixtureName !== undefined;
@@ -221,12 +231,32 @@ function trustedSender(event: IpcMainEvent | IpcMainInvokeEvent): boolean {
   return url === rendererUrl();
 }
 
+/**
+ * A capture run has to render the same pixels on every machine, so it reports a
+ * fixed settings snapshot instead of whatever this machine's Keychain and
+ * stored keys happen to say. Without this, evidence would differ between a
+ * developer's Mac and a CI runner, and comparing a screenshot against its
+ * baseline would report a change that is not in the diff. Live runs report the
+ * real state.
+ */
+async function bootstrapSettings(): Promise<AppSettings> {
+  if (!captureMode) return settingsStore.snapshot();
+  const sources = Object.values(CREDENTIAL_PROVIDER_ID).map(
+    (providerId) => [providerId, CREDENTIAL_SOURCE.NONE] as const,
+  );
+  return {
+    credentialSources: Object.fromEntries(sources) as AppSettings["credentialSources"],
+    secretStorageAvailable: true,
+  };
+}
+
 function registerIpc(): void {
   ipcMain.handle(channels.bootstrap, async (event): Promise<AppBootstrap> => {
     if (!trustedSender(event)) throw new Error("Untrusted renderer");
     return {
       mode: windowMode,
       profile,
+      view,
       fixture,
       captureMode,
       fixtureMode,
@@ -238,7 +268,7 @@ function registerIpc(): void {
       microphoneStatus: microphoneStatus(),
       display: displayDiagnostic(),
       sessions: fixtureMode ? [] : sessionRegistry.snapshot().sessions,
-      settings: await settingsStore.snapshot(),
+      settings: await bootstrapSettings(),
     };
   });
 

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -15,7 +15,7 @@ import type {
   MicrophoneStatus,
   WindowMode,
 } from "../shared/contracts";
-import { CREDENTIAL_SOURCE } from "../shared/contracts";
+import { CAPTURE_VIEW, CREDENTIAL_SOURCE } from "../shared/contracts";
 import type { CredentialProvider, CredentialProviderId } from "../shared/credential-providers";
 import { CREDENTIAL_PROVIDER_LIST } from "../shared/credential-providers";
 import { ProviderMark } from "./provider-mark";
@@ -490,6 +490,9 @@ function App(): React.JSX.Element {
       if (value.profile === "microphone") {
         window.setTimeout(() => void startMicrophone(), 500);
       }
+      // Opened before the ready signal so the capture that follows it renders
+      // the requested view rather than the session list behind it.
+      if (value.view === CAPTURE_VIEW.SETTINGS) setSettingsOpen(true);
       window.sidecar.notifyReady();
     });
     const removeLifecycle = window.sidecar.onLifecycle((eventName) => {

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -31,6 +31,22 @@ export interface AppSettings {
   secretStorageAvailable: boolean;
 }
 
+/**
+ * The panel view a capture run opens. Visual evidence is only useful for the
+ * surfaces it renders, so a screenshot run names the one it wants rather than
+ * always capturing the session list.
+ */
+export const CAPTURE_VIEW = {
+  SESSIONS: "sessions",
+  SETTINGS: "settings",
+} as const;
+
+export type CaptureView = (typeof CAPTURE_VIEW)[keyof typeof CAPTURE_VIEW];
+
+export function isCaptureView(value: unknown): value is CaptureView {
+  return Object.values(CAPTURE_VIEW).some((view) => view === value);
+}
+
 /** A rejected update reports why without echoing the submitted value. */
 export interface SettingsUpdateResult {
   settings: AppSettings;
@@ -49,6 +65,7 @@ export interface DisplayDiagnostic {
 export interface AppBootstrap {
   mode: WindowMode;
   profile: string;
+  view: CaptureView;
   fixture: FixtureSnapshot;
   captureMode: boolean;
   /** True when `--fixture` (or a capture run) makes the panel render fixture sessions. */

--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+// Fails a pull request whose user-interface change carries no visual evidence.
+//
+// The rule this enforces is in WORKFLOW.md. It runs after the macOS job has
+// embedded its screenshots, so a desktop change satisfies it automatically once
+// that job succeeds; what it catches is a surface CI cannot screenshot, or a
+// desktop change whose evidence never got produced.
+import { pathToFileURL } from "node:url";
+import { githubRequest, requiredEnvironment } from "./lib/github.mjs";
+import { evidenceEnd, evidenceStart } from "./update-pr-evidence.mjs";
+
+export const EXEMPTION_LABEL = "evidence-exempt";
+
+/**
+ * Paths whose change is visible to a user. Desktop surfaces are screenshotted
+ * by CI; web surfaces have no automated capture, so their evidence is attached
+ * by whoever opens the pull request.
+ */
+export const UI_PATHS = {
+  DESKTOP: ["apps/desktop/src/renderer/", "apps/desktop/native/macos/"],
+  WEB: ["apps/web/"],
+};
+
+const IMAGE_PATTERN = /!\[[^\]]*\]\([^)]+\)|<img\b/;
+
+export function classifyChanges(filenames) {
+  const touches = (prefixes) =>
+    filenames.some((filename) => prefixes.some((prefix) => filename.startsWith(prefix)));
+  return { desktop: touches(UI_PATHS.DESKTOP), web: touches(UI_PATHS.WEB) };
+}
+
+/**
+ * Markdown that a reader will actually see. An image inside an HTML comment or a
+ * fenced code block renders as nothing, so counting it as evidence would let a
+ * description satisfy the gate while showing the reviewer no picture at all.
+ *
+ * Stripping repeats until the text stops changing: one pass over nested comment
+ * openers can leave a `<!--` behind and reveal what it was hiding.
+ */
+export function visibleText(markdown) {
+  let text = markdown;
+  for (let pass = 0; pass < 10; pass += 1) {
+    const stripped = text.replace(/<!--[\s\S]*?-->/g, "").replace(/```[\s\S]*?```|`[^`\n]*`/g, "");
+    if (stripped === text) return stripped;
+    text = stripped;
+  }
+  return text.replace(/<!--|-->|```/g, "");
+}
+
+/** Separates CI's block from the description an author controls. */
+export function splitEvidence(body) {
+  const start = body.indexOf(evidenceStart);
+  const end = body.indexOf(evidenceEnd);
+  if (start < 0 || end < start) return { automated: "", authored: body };
+  return {
+    automated: body.slice(start, end + evidenceEnd.length),
+    authored: body.slice(0, start) + body.slice(end + evidenceEnd.length),
+  };
+}
+
+/**
+ * `shown` is the number of scenarios CI found to differ from the default
+ * branch, passed from the macOS job's own output. It is never read back from the
+ * description: a pull-request body is author-editable in full, including the
+ * markers that delimit CI's block, so any verdict recovered from it can be
+ * forged by pasting a convincing-looking block ahead of the real one. Undefined
+ * means no macOS job reported into this run.
+ */
+export function evaluateEvidence({
+  body = "",
+  labels = [],
+  filenames = [],
+  shown,
+  evidenceRunSucceeded = true,
+}) {
+  const changed = classifyChanges(filenames);
+  if (!changed.desktop && !changed.web) {
+    return { required: false, failures: [], summary: "No user-interface paths changed." };
+  }
+  if (labels.includes(EXEMPTION_LABEL)) {
+    return { required: true, failures: [], summary: `Exempted by the ${EXEMPTION_LABEL} label.` };
+  }
+
+  const { authored } = splitEvidence(body);
+  const authoredImage = IMAGE_PATTERN.test(visibleText(authored));
+  const failures = [];
+  const notes = [];
+  // A screenshot identical to the one on `main` shows nothing this pull request
+  // did, so the presence of an image is not the test. CI reports how many
+  // scenarios actually differ; a desktop change passes when at least one does,
+  // or when the author attached evidence of their own. A web change always
+  // needs authored evidence: CI screenshots only the desktop app, and a pull
+  // request touching both surfaces would otherwise pass on desktop evidence
+  // alone while the page went uninspected.
+  if (changed.desktop && !authoredImage) {
+    if (!evidenceRunSucceeded) {
+      // No screenshots exist for this commit, so there is nothing to wait for.
+      failures.push(
+        "The macOS job did not produce evidence for this commit, so this desktop change has " +
+          "no screenshots. Fix that job rather than merging an unevidenced change.",
+      );
+    } else if (shown === undefined) {
+      notes.push(
+        "This run has no macOS evidence to judge; the check in the run that built this " +
+          "commit is the one that decides.",
+      );
+    } else if (shown === 0) {
+      failures.push(
+        "This pull request changes the desktop interface, but no captured scenario differs " +
+          "from `main`, so CI's screenshots do not show the change. Add a scenario to " +
+          "`./scripts/evidence.sh` that renders the affected surface, or capture it yourself " +
+          "and publish it with `node scripts/publish-pr-media.mjs <pr> <file>`.",
+      );
+    }
+  }
+  if (changed.web && !authoredImage) {
+    failures.push(
+      "This pull request changes the web interface, which CI does not screenshot. Capture " +
+        "the page after `pnpm --filter @luke/web dev`, publish it with " +
+        "`node scripts/publish-pr-media.mjs <pr> <file>`, and embed the URL in the " +
+        "Evidence section.",
+    );
+  }
+
+  const summary =
+    failures.length > 0
+      ? "Visual evidence is missing."
+      : notes.length > 0
+        ? notes.join(" ")
+        : "Visual evidence is attached.";
+  return { required: true, failures, notes, summary };
+}
+
+async function changedFilenames(repository, pullRequest) {
+  const filenames = [];
+  for (let page = 1; page <= 10; page += 1) {
+    const response = await githubRequest(
+      `/repos/${repository}/pulls/${pullRequest}/files?per_page=100&page=${page}`,
+    );
+    filenames.push(...response.data.map((file) => file.filename));
+    if (response.data.length < 100) break;
+  }
+  return filenames;
+}
+
+async function main() {
+  const repository = requiredEnvironment("GITHUB_REPOSITORY");
+  const pullRequest = Number(requiredEnvironment("PR_NUMBER"));
+  const pull = await githubRequest(`/repos/${repository}/pulls/${pullRequest}`);
+
+  // `success` when the macOS job produced evidence for this commit, `skipped`
+  // when this run is a description recheck and that job belongs to another run.
+  const evidenceRun = process.env.EVIDENCE_RUN_RESULT?.trim() || "success";
+  const result = evaluateEvidence({
+    body: pull.data.body ?? "",
+    labels: (pull.data.labels ?? []).map((label) => label.name),
+    filenames: await changedFilenames(repository, pullRequest),
+    shown: /^\d+$/.test(process.env.EVIDENCE_SCENARIOS_SHOWN ?? "")
+      ? Number(process.env.EVIDENCE_SCENARIOS_SHOWN)
+      : undefined,
+    evidenceRunSucceeded: evidenceRun === "success" || evidenceRun === "skipped",
+  });
+
+  process.stdout.write(`${result.summary}\n`);
+  if (result.failures.length === 0) return;
+
+  for (const failure of result.failures) process.stderr.write(`error: ${failure}\n`);
+  process.stderr.write(
+    `\nAdd the missing evidence to the pull-request description, or apply the ` +
+      `${EXEMPTION_LABEL} label with a comment saying why none applies. ` +
+      `Editing the description re-runs the recheck.\n`,
+  );
+  process.exitCode = 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/scripts/check-pr-evidence.test.mjs
+++ b/scripts/check-pr-evidence.test.mjs
@@ -1,0 +1,255 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  classifyChanges,
+  EXEMPTION_LABEL,
+  evaluateEvidence,
+  splitEvidence,
+  UI_PATHS,
+  visibleText,
+} from "./check-pr-evidence.mjs";
+import { evidenceEnd, evidenceMarker, evidenceStart } from "./update-pr-evidence.mjs";
+
+const HEAD = "c8384e9221d38ea02414dd66e20aab4cf279bfea";
+
+/** The block as the pull-request template ships it, before CI has written. */
+function templateBlock() {
+  return [
+    evidenceStart,
+    "### Automated visual evidence",
+    "",
+    "CI will replace this block with the deterministic macOS screenshots.",
+    evidenceEnd,
+  ].join("\n");
+}
+
+function automatedBlock(shown, headSha = HEAD) {
+  return [
+    evidenceStart,
+    "### Automated visual evidence",
+    "",
+    evidenceMarker(shown, headSha),
+    "",
+    shown > 0
+      ? "| ![before](https://raw.example/before.png) | ![after](https://raw.example/after.png) |"
+      : "Every scenario renders exactly as it does on `main`.",
+    evidenceEnd,
+  ].join("\n");
+}
+
+test("every configured interface path still exists", () => {
+  // A renamed directory would leave the prefixes matching nothing, quietly
+  // disabling the gate for the surface it was meant to cover. Failing here
+  // makes that rename loud instead.
+  const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+  for (const prefixes of Object.values(UI_PATHS)) {
+    for (const prefix of prefixes) {
+      assert.ok(existsSync(join(repositoryRoot, prefix)), `missing interface path: ${prefix}`);
+    }
+  }
+});
+
+test("classifies desktop, web, and non-interface changes", () => {
+  assert.deepEqual(classifyChanges(["apps/desktop/src/renderer/index.tsx"]), {
+    desktop: true,
+    web: false,
+  });
+  assert.deepEqual(classifyChanges(["apps/web/src/App.tsx"]), { desktop: false, web: true });
+  assert.deepEqual(classifyChanges(["packages/sidecar-core/src/session.ts", "README.md"]), {
+    desktop: false,
+    web: false,
+  });
+});
+
+test("waits rather than failing before the macOS job has published", () => {
+  const result = evaluateEvidence({
+    body: `## Summary\n\n${templateBlock()}`,
+    filenames: ["apps/desktop/src/renderer/index.tsx"],
+  });
+
+  assert.deepEqual(result.failures, []);
+  assert.match(result.summary, /no macOS evidence to judge/);
+});
+
+test("still fails a web change before CI reports, since CI never covers it", () => {
+  const result = evaluateEvidence({
+    body: `## Summary\n\n${templateBlock()}`,
+    filenames: ["apps/web/src/App.tsx"],
+    shown: 1,
+  });
+
+  assert.equal(result.failures.length, 1);
+  assert.match(result.failures[0], /web interface/);
+});
+
+test("passes a change that touches no interface", () => {
+  const result = evaluateEvidence({ filenames: ["packages/sidecar-core/src/session.ts"] });
+
+  assert.equal(result.required, false);
+  assert.deepEqual(result.failures, []);
+});
+
+test("passes a desktop change whose captured scenarios differ from main", () => {
+  const result = evaluateEvidence({
+    body: `## Summary\n\n${automatedBlock(1)}`,
+    filenames: ["apps/desktop/src/renderer/styles.css"],
+    shown: 1,
+  });
+
+  assert.deepEqual(result.failures, []);
+});
+
+test("fails a desktop change no captured scenario shows", () => {
+  const result = evaluateEvidence({
+    body: `## Summary\n\n${automatedBlock(0)}`,
+    filenames: ["apps/desktop/src/renderer/index.tsx"],
+    shown: 0,
+  });
+
+  assert.equal(result.failures.length, 1);
+  assert.match(result.failures[0], /no captured scenario differs/);
+});
+
+test("fails a desktop change whose only images are CI's unchanged renders", () => {
+  // The regression this exists for: images are present, and prove nothing.
+  const result = evaluateEvidence({
+    body: `## Summary\n\n${automatedBlock(1)}`,
+    filenames: ["apps/desktop/src/renderer/index.tsx"],
+    shown: 0,
+  });
+
+  assert.equal(result.failures.length, 1);
+});
+
+test("accepts an authored screenshot when no scenario differs", () => {
+  const result = evaluateEvidence({
+    body: `![Settings panel](https://raw.example/settings.png)\n\n${automatedBlock(0)}`,
+    filenames: ["apps/desktop/src/renderer/index.tsx"],
+    shown: 0,
+  });
+
+  assert.deepEqual(result.failures, []);
+});
+
+test("fails a web change carrying only CI's screenshots", () => {
+  const result = evaluateEvidence({
+    body: `## Summary\n\n${automatedBlock(1)}`,
+    filenames: ["apps/web/src/App.tsx"],
+    shown: 1,
+  });
+
+  assert.equal(result.failures.length, 1);
+  assert.match(result.failures[0], /web interface/);
+});
+
+test("passes a web change with an authored screenshot", () => {
+  const result = evaluateEvidence({
+    body: `## Evidence\n\n![Landing page](https://raw.example/landing.png)\n\n${automatedBlock(1)}`,
+    filenames: ["apps/web/src/App.tsx"],
+    shown: 1,
+  });
+
+  assert.deepEqual(result.failures, []);
+});
+
+test("accepts an HTML image tag as authored evidence", () => {
+  const result = evaluateEvidence({
+    body: '<img src="https://raw.example/landing.png" width="600">',
+    filenames: ["apps/web/src/App.tsx"],
+    shown: 1,
+  });
+
+  assert.deepEqual(result.failures, []);
+});
+
+test("reports both surfaces when one change touches each", () => {
+  const result = evaluateEvidence({
+    body: `## Summary\n\n${automatedBlock(0)}`,
+    filenames: ["apps/desktop/src/renderer/index.tsx", "apps/web/src/App.tsx"],
+    shown: 0,
+  });
+
+  assert.equal(result.failures.length, 2);
+});
+
+test("honors the exemption label", () => {
+  const result = evaluateEvidence({
+    body: "## Summary",
+    labels: [EXEMPTION_LABEL],
+    filenames: ["apps/web/src/App.tsx"],
+    shown: 1,
+  });
+
+  assert.equal(result.required, true);
+  assert.deepEqual(result.failures, []);
+});
+
+test("separates CI's block from the authored description", () => {
+  const { automated, authored } = splitEvidence(`before\n${automatedBlock(1)}\nafter`);
+
+  assert.match(automated, /raw\.example/);
+  assert.doesNotMatch(authored, /raw\.example/);
+  assert.match(authored, /before/);
+  assert.match(authored, /after/);
+});
+
+test("treats a description with no automated block as entirely authored", () => {
+  const { automated, authored } = splitEvidence("just a summary");
+
+  assert.equal(automated, "");
+  assert.equal(authored, "just a summary");
+});
+
+test("does not accept an image hidden in an HTML comment", () => {
+  const result = evaluateEvidence({
+    body: `<!-- ![hidden](https://raw.example/x.png) -->\n\n${automatedBlock(0)}`,
+    filenames: ["apps/web/src/App.tsx"],
+    shown: 1,
+  });
+
+  assert.equal(result.failures.length, 1);
+});
+
+test("does not accept an image shown only as code", () => {
+  const result = evaluateEvidence({
+    body: "```\n![sample](https://raw.example/x.png)\n```",
+    filenames: ["apps/web/src/App.tsx"],
+    shown: 1,
+  });
+
+  assert.equal(result.failures.length, 1);
+});
+
+test("fails rather than waits when the macOS job produced no evidence", () => {
+  const result = evaluateEvidence({
+    body: `## Summary\n\n${templateBlock()}`,
+    filenames: ["apps/desktop/src/renderer/index.tsx"],
+    headSha: HEAD,
+    evidenceRunSucceeded: false,
+  });
+
+  assert.equal(result.failures.length, 1);
+  assert.match(result.failures[0], /did not produce evidence/);
+});
+
+test("ignores a verdict forged into the description", () => {
+  // The block delimiters live in author-editable text, so a convincing block
+  // pasted ahead of CI's own must not be able to speak for CI.
+  const forged = `${automatedBlock(4)}\n\n${automatedBlock(0)}`;
+  const result = evaluateEvidence({
+    body: forged,
+    filenames: ["apps/desktop/src/renderer/index.tsx"],
+    shown: 0,
+  });
+
+  assert.equal(result.failures.length, 1);
+  assert.match(result.failures[0], /no captured scenario differs/);
+});
+
+test("strips nested comment openers rather than revealing what they hid", () => {
+  assert.doesNotMatch(visibleText("<!--<!-- --> ![x](y) -->"), /<!--/);
+  assert.equal(visibleText("plain ![x](y)"), "plain ![x](y)");
+});

--- a/scripts/evidence.sh
+++ b/scripts/evidence.sh
@@ -25,26 +25,41 @@ mkdir -p "$(dirname -- "$SIDECAR_EXPANDED_EVIDENCE_PATH")"
 rm -f -- \
     "$SIDECAR_EXPANDED_EVIDENCE_PATH" \
     "$SIDECAR_COMPACT_EVIDENCE_PATH" \
-    "$SIDECAR_SPEAKING_EVIDENCE_PATH"
+    "$SIDECAR_SPEAKING_EVIDENCE_PATH" \
+    "$SIDECAR_SETTINGS_EVIDENCE_PATH"
 EXPANDED_PROFILE=$(mktemp -d "$SIDECAR_BUILD_ROOT/evidence-expanded.XXXXXX")
 COMPACT_PROFILE=$(mktemp -d "$SIDECAR_BUILD_ROOT/evidence-compact.XXXXXX")
 SPEAKING_PROFILE=$(mktemp -d "$SIDECAR_BUILD_ROOT/evidence-speaking.XXXXXX")
+SETTINGS_PROFILE=$(mktemp -d "$SIDECAR_BUILD_ROOT/evidence-settings.XXXXXX")
 "$APP_EXECUTABLE" \
+    --force-device-scale-factor="$SIDECAR_EVIDENCE_SCALE" \
     --user-data-dir="$EXPANDED_PROFILE" \
     --fixture "$SIDECAR_FIXTURE_SCENARIO" \
     --expanded \
     --capture-evidence "$SIDECAR_EXPANDED_EVIDENCE_PATH"
 "$APP_EXECUTABLE" \
+    --force-device-scale-factor="$SIDECAR_EVIDENCE_SCALE" \
     --user-data-dir="$COMPACT_PROFILE" \
     --fixture "$SIDECAR_FIXTURE_SCENARIO" \
     --compact \
     --capture-evidence "$SIDECAR_COMPACT_EVIDENCE_PATH"
 "$APP_EXECUTABLE" \
+    --force-device-scale-factor="$SIDECAR_EVIDENCE_SCALE" \
     --user-data-dir="$SPEAKING_PROFILE" \
     --fixture "$SIDECAR_FIXTURE_SCENARIO" \
     --profile speaking \
     --compact \
     --capture-evidence "$SIDECAR_SPEAKING_EVIDENCE_PATH"
+# The settings view holds the credential surface, which the session-list
+# screenshots never show. Without it, a change to that surface produces evidence
+# that cannot contain the change.
+"$APP_EXECUTABLE" \
+    --force-device-scale-factor="$SIDECAR_EVIDENCE_SCALE" \
+    --user-data-dir="$SETTINGS_PROFILE" \
+    --fixture "$SIDECAR_FIXTURE_SCENARIO" \
+    --view settings \
+    --expanded \
+    --capture-evidence "$SIDECAR_SETTINGS_EVIDENCE_PATH"
 
 validate_evidence() {
     local evidence_path=$1
@@ -74,9 +89,15 @@ validate_evidence() {
         exit 1
     fi
 
+    # The scale is asserted rather than merely bounded: a runner that ignored
+    # the forced scale factor would otherwise publish evidence at half the
+    # resolution a developer's Mac produces, which reads as a blurry screenshot
+    # and makes every render differ from its baseline.
     local scale_factor=$((actual_width / expected_width))
-    if (( scale_factor < 1 || scale_factor > 4 || actual_height != expected_height * scale_factor )); then
-        printf 'error: evidence PNG has unexpected dimensions: %s\n' "$evidence_path" >&2
+    if (( scale_factor != SIDECAR_EVIDENCE_SCALE || actual_height != expected_height * scale_factor )); then
+        printf 'error: evidence PNG is %sx%s, expected %sx at %sx%s: %s\n' \
+            "$actual_width" "$actual_height" "$SIDECAR_EVIDENCE_SCALE" \
+            "$expected_width" "$expected_height" "$evidence_path" >&2
         exit 1
     fi
 }
@@ -84,7 +105,9 @@ validate_evidence() {
 validate_evidence "$SIDECAR_EXPANDED_EVIDENCE_PATH" 620 520
 validate_evidence "$SIDECAR_COMPACT_EVIDENCE_PATH" 282 38
 validate_evidence "$SIDECAR_SPEAKING_EVIDENCE_PATH" 282 38
+validate_evidence "$SIDECAR_SETTINGS_EVIDENCE_PATH" 620 520
 
 printf 'Expanded visual evidence: %s\n' "$SIDECAR_EXPANDED_EVIDENCE_PATH"
 printf 'Compact visual evidence: %s\n' "$SIDECAR_COMPACT_EVIDENCE_PATH"
 printf 'Speaking visual evidence: %s\n' "$SIDECAR_SPEAKING_EVIDENCE_PATH"
+printf 'Settings visual evidence: %s\n' "$SIDECAR_SETTINGS_EVIDENCE_PATH"

--- a/scripts/lib/github.mjs
+++ b/scripts/lib/github.mjs
@@ -1,0 +1,41 @@
+const apiRoot = "https://api.github.com";
+
+export function requiredEnvironment(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+export class GitHubError extends Error {
+  constructor(status, path, body) {
+    super(`GitHub API ${status} for ${path}: ${body}`);
+    this.status = status;
+    this.path = path;
+  }
+}
+
+/**
+ * Issues an authenticated GitHub REST request. `allowStatuses` returns the
+ * response for statuses the caller handles itself, such as the 404 that means a
+ * branch does not exist yet.
+ */
+export async function githubRequest(path, { allowStatuses = [], ...init } = {}) {
+  const response = await fetch(`${apiRoot}${path}`, {
+    ...init,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${requiredEnvironment("GITHUB_TOKEN")}`,
+      "Content-Type": "application/json",
+      "User-Agent": "luke-visual-evidence",
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...init.headers,
+    },
+  });
+
+  if (!response.ok) {
+    if (allowStatuses.includes(response.status)) return { ok: false, status: response.status };
+    throw new GitHubError(response.status, path, await response.text());
+  }
+
+  return { ok: true, status: response.status, data: await response.json() };
+}

--- a/scripts/lib/workspace.sh
+++ b/scripts/lib/workspace.sh
@@ -7,9 +7,15 @@ SIDECAR_CORE_PACKAGE_ROOT="$SIDECAR_REPO_ROOT/packages/sidecar-core"
 SIDECAR_BUILD_ROOT="$SIDECAR_REPO_ROOT/.build"
 SIDECAR_ARTIFACT_ROOT="$SIDECAR_REPO_ROOT/artifacts"
 SIDECAR_FIXTURE_SCENARIO=smoke
+# Evidence is captured at a fixed device scale so a screenshot is legible
+# wherever it was taken. A CI runner has a 1x display and a developer's Mac is
+# 2x, so without this the same command produces evidence at two resolutions and
+# every render differs from its baseline for no reason anyone can see.
+SIDECAR_EVIDENCE_SCALE=2
 SIDECAR_EXPANDED_EVIDENCE_PATH="$SIDECAR_ARTIFACT_ROOT/evidence/app-smoke-expanded.png"
 SIDECAR_COMPACT_EVIDENCE_PATH="$SIDECAR_ARTIFACT_ROOT/evidence/app-smoke-compact.png"
 SIDECAR_SPEAKING_EVIDENCE_PATH="$SIDECAR_ARTIFACT_ROOT/evidence/app-smoke-speaking.png"
+SIDECAR_SETTINGS_EVIDENCE_PATH="$SIDECAR_ARTIFACT_ROOT/evidence/app-smoke-settings.png"
 SIDECAR_ELECTRON_BIN="$SIDECAR_DESKTOP_APP_ROOT/node_modules/.bin/electron"
 
 export SIDECAR_REPO_ROOT
@@ -18,9 +24,11 @@ export SIDECAR_CORE_PACKAGE_ROOT
 export SIDECAR_BUILD_ROOT
 export SIDECAR_ARTIFACT_ROOT
 export SIDECAR_FIXTURE_SCENARIO
+export SIDECAR_EVIDENCE_SCALE
 export SIDECAR_EXPANDED_EVIDENCE_PATH
 export SIDECAR_COMPACT_EVIDENCE_PATH
 export SIDECAR_SPEAKING_EVIDENCE_PATH
+export SIDECAR_SETTINGS_EVIDENCE_PATH
 export SIDECAR_ELECTRON_BIN
 
 sidecar_require_command() {

--- a/scripts/publish-evidence-baseline.mjs
+++ b/scripts/publish-evidence-baseline.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+// Republish the default branch's visual evidence as the baseline every pull
+// request is compared against.
+//
+//   EVIDENCE_DIRECTORY=artifacts/evidence node scripts/publish-evidence-baseline.mjs
+//
+// Runs on a push to the default branch, after `./scripts/verify.sh`.
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { requiredEnvironment } from "./lib/github.mjs";
+import { BASELINE_DIRECTORY, publishMedia } from "./publish-pr-media.mjs";
+
+async function main() {
+  const directory = requiredEnvironment("EVIDENCE_DIRECTORY");
+  const names = (await readdir(directory)).filter((entry) => entry.endsWith(".png")).sort();
+  if (names.length === 0) throw new Error(`No screenshots to publish in ${directory}`);
+
+  const published = await publishMedia({
+    repository: requiredEnvironment("GITHUB_REPOSITORY"),
+    directory: BASELINE_DIRECTORY,
+    files: names.map((name) => join(directory, name)),
+  });
+
+  process.stdout.write(`Published ${published.length} baseline screenshots\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/scripts/publish-pr-media.mjs
+++ b/scripts/publish-pr-media.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+// Publish pull-request media to the shared `pr-assets` branch and print the raw
+// URLs that render inline in a pull-request description.
+//
+//   node scripts/publish-pr-media.mjs <pull-request-number> <file>...
+//
+// Requires GITHUB_TOKEN with `contents: write`; locally, `gh auth token`
+// supplies one. Files are written through the contents API rather than a push
+// so that a shallow checkout, a concurrent pull request, and an in-progress
+// working tree cannot interfere with publishing.
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { pathToFileURL } from "node:url";
+import { githubRequest, requiredEnvironment } from "./lib/github.mjs";
+
+export const MEDIA_BRANCH = "pr-assets";
+
+/**
+ * The baseline every pull request's evidence is compared against. It is
+ * republished on each push to the default branch, so it always describes what
+ * the app looks like today.
+ */
+export const BASELINE_DIRECTORY = "baseline";
+
+const CONFLICT_ATTEMPTS = 5;
+
+/**
+ * Pull-request media lives under `pr-<number>/<commit>/`. The commit component
+ * is what keeps a refreshed screenshot visible: GitHub proxies and caches image
+ * URLs, so reusing one path for successive versions of a screenshot serves the
+ * stale image. A new path per commit is always fetched.
+ */
+export function pullRequestDirectory(pullRequest, commit) {
+  return `pr-${pullRequest}/${commit.slice(0, 12)}`;
+}
+
+export function mediaPath(directory, file) {
+  return `${directory}/${basename(file)}`;
+}
+
+export function rawUrl(repository, path) {
+  return `https://raw.githubusercontent.com/${repository}/${MEDIA_BRANCH}/${path}`;
+}
+
+/**
+ * The media branch carries no source history, so it starts as an empty orphan
+ * commit rather than a copy of the default branch.
+ */
+async function ensureMediaBranch(repository) {
+  const existing = await githubRequest(`/repos/${repository}/branches/${MEDIA_BRANCH}`, {
+    allowStatuses: [404],
+  });
+  if (existing.ok) return;
+
+  const tree = await githubRequest(`/repos/${repository}/git/trees`, {
+    method: "POST",
+    body: JSON.stringify({ tree: [] }),
+  });
+  const commit = await githubRequest(`/repos/${repository}/git/commits`, {
+    method: "POST",
+    body: JSON.stringify({
+      message: "chore(pr-assets): start the durable pull-request media branch",
+      tree: tree.data.sha,
+      parents: [],
+    }),
+  });
+  await githubRequest(`/repos/${repository}/git/refs`, {
+    method: "POST",
+    body: JSON.stringify({ ref: `refs/heads/${MEDIA_BRANCH}`, sha: commit.data.sha }),
+  });
+}
+
+/** Reads a published file, or nothing when it has never been published. */
+export async function readMedia(repository, path) {
+  const response = await githubRequest(
+    `/repos/${repository}/contents/${path}?ref=${MEDIA_BRANCH}`,
+    { allowStatuses: [404] },
+  );
+  if (!response.ok) return undefined;
+  return { sha: response.data.sha, contents: Buffer.from(response.data.content, "base64") };
+}
+
+async function putMediaFile(repository, path, contents) {
+  // Concurrent pull requests publish to the same branch, so a 409 is an
+  // expected outcome rather than a failure: the branch moved between reading
+  // the file's state and writing it. Retrying re-reads that state.
+  for (let attempt = 1; attempt <= CONFLICT_ATTEMPTS; attempt += 1) {
+    const existing = await readMedia(repository, path);
+    const result = await githubRequest(`/repos/${repository}/contents/${path}`, {
+      method: "PUT",
+      allowStatuses: [409, 422],
+      body: JSON.stringify({
+        branch: MEDIA_BRANCH,
+        message: `chore(pr-assets): publish ${path}`,
+        content: contents.toString("base64"),
+        ...(existing ? { sha: existing.sha } : {}),
+      }),
+    });
+    if (result.ok) return;
+  }
+
+  throw new Error(`Could not publish media after ${CONFLICT_ATTEMPTS} attempts: ${path}`);
+}
+
+/** Publishes each file into `directory` and returns its raw URL, in order. */
+export async function publishMedia({ repository, directory, files }) {
+  if (files.length === 0) return [];
+  await ensureMediaBranch(repository);
+
+  const published = [];
+  for (const file of files) {
+    const path = mediaPath(directory, file);
+    await putMediaFile(repository, path, await readFile(file));
+    published.push({ file, path, url: rawUrl(repository, path) });
+  }
+  return published;
+}
+
+async function main() {
+  const [pullRequest, ...files] = process.argv.slice(2);
+  if (!/^\d+$/.test(pullRequest ?? "") || files.length === 0) {
+    process.stderr.write("usage: publish-pr-media.mjs <pull-request-number> <file>...\n");
+    process.exit(2);
+  }
+
+  const commit = process.env.MEDIA_COMMIT?.trim() || requiredEnvironment("HEAD_SHA");
+  const published = await publishMedia({
+    repository: requiredEnvironment("GITHUB_REPOSITORY"),
+    directory: pullRequestDirectory(Number(pullRequest), commit),
+    files,
+  });
+
+  process.stdout.write(`${published.map((entry) => entry.url).join("\n")}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/scripts/publish-pr-media.test.mjs
+++ b/scripts/publish-pr-media.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  BASELINE_DIRECTORY,
+  MEDIA_BRANCH,
+  mediaPath,
+  pullRequestDirectory,
+  rawUrl,
+} from "./publish-pr-media.mjs";
+
+test("scopes pull-request media to the pull request and its commit", () => {
+  const directory = pullRequestDirectory(17, "0123456789abcdef0123");
+
+  assert.equal(directory, "pr-17/0123456789ab");
+  assert.equal(
+    mediaPath(directory, "artifacts/evidence/app-smoke-compact.png"),
+    "pr-17/0123456789ab/app-smoke-compact.png",
+  );
+});
+
+test("gives successive commits distinct paths so a refreshed image is not cached", () => {
+  assert.notEqual(
+    pullRequestDirectory(17, "aaaaaaaaaaaaaaaa"),
+    pullRequestDirectory(17, "bbbbbbbbbbbbbbbb"),
+  );
+});
+
+test("keeps the baseline at one stable path", () => {
+  assert.equal(
+    mediaPath(BASELINE_DIRECTORY, "artifacts/evidence/app-smoke-settings.png"),
+    "baseline/app-smoke-settings.png",
+  );
+});
+
+test("builds a raw URL on the durable media branch", () => {
+  assert.equal(
+    rawUrl("ReviewStage/luke", "pr-17/0123456789ab/shot.png"),
+    `https://raw.githubusercontent.com/ReviewStage/luke/${MEDIA_BRANCH}/pr-17/0123456789ab/shot.png`,
+  );
+});

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -7,6 +7,7 @@ source "$SCRIPT_DIRECTORY/lib/workspace.sh"
 
 required_files=(
     AGENTS.md
+    CLAUDE.md
     WORKFLOW.md
     README.md
     package.json
@@ -35,6 +36,13 @@ done
 
 if [[ ! -x "$SIDECAR_REPO_ROOT/.husky/pre-commit" ]]; then
     printf 'error: Husky pre-commit hook must be executable\n' >&2
+    exit 1
+fi
+
+# Agents read whichever instruction file their harness loads. One file with two
+# names keeps them from drifting into separate, disagreeing guides.
+if [[ $(readlink "$SIDECAR_REPO_ROOT/CLAUDE.md") != AGENTS.md ]]; then
+    printf 'error: CLAUDE.md must be a symlink to AGENTS.md\n' >&2
     exit 1
 fi
 

--- a/scripts/update-pr-evidence.mjs
+++ b/scripts/update-pr-evidence.mjs
@@ -1,25 +1,135 @@
+import { appendFile, mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { pathToFileURL } from "node:url";
+import { githubRequest, requiredEnvironment } from "./lib/github.mjs";
+import {
+  BASELINE_DIRECTORY,
+  mediaPath,
+  publishMedia,
+  pullRequestDirectory,
+  readMedia,
+} from "./publish-pr-media.mjs";
 
 export const evidenceStart = "<!-- automated-visual-evidence:start -->";
 export const evidenceEnd = "<!-- automated-visual-evidence:end -->";
+
+/**
+ * Read by the evidence gate, which cannot judge a screenshot by looking at it.
+ * It carries the commit it describes so that a block left over from an earlier
+ * push cannot vouch for the current one.
+ */
+export const changedMarker = "evidence-changed";
+
+export function evidenceMarker(shown, headSha) {
+  return `<!-- ${changedMarker}: ${shown} sha: ${headSha} -->`;
+}
+
+export const EVIDENCE_STATUS = {
+  CHANGED: "changed",
+  UNCHANGED: "unchanged",
+  NEW: "new",
+};
+
+/**
+ * Captions are fixed here so every pull request presents its evidence the same
+ * way, and ordered so the description reads from the whole panel down.
+ */
+export const EVIDENCE_CAPTIONS = {
+  "app-smoke-expanded.png": "Expanded panel (smoke fixture)",
+  "app-smoke-settings.png": "Settings view (smoke fixture)",
+  "app-smoke-compact.png": "Compact panel (smoke fixture)",
+  "app-smoke-speaking.png": "Compact panel with the speaking waveform (smoke fixture)",
+};
 
 export function isCurrentPullHead(pull, headSha) {
   return pull.head?.sha === headSha;
 }
 
-export function updateEvidenceBlock(body, evidence) {
-  const block = [
+export function caption(name) {
+  return EVIDENCE_CAPTIONS[name] ?? name;
+}
+
+export function orderEvidenceFiles(names) {
+  const captions = Object.keys(EVIDENCE_CAPTIONS);
+  const rank = (name) => {
+    const index = captions.indexOf(name);
+    return index === -1 ? captions.length : index;
+  };
+  return [...names].sort((left, right) => rank(left) - rank(right) || left.localeCompare(right));
+}
+
+/**
+ * Renders are deterministic, so equal bytes mean the change is not visible in
+ * that scenario. That is the useful signal: a screenshot identical to the one
+ * on the default branch is not evidence of anything this pull request did.
+ */
+export function compareEvidence(current, baseline) {
+  if (baseline === undefined) return EVIDENCE_STATUS.NEW;
+  return current.equals(baseline) ? EVIDENCE_STATUS.UNCHANGED : EVIDENCE_STATUS.CHANGED;
+}
+
+export function countShown(scenarios) {
+  return scenarios.filter((scenario) => scenario.status !== EVIDENCE_STATUS.UNCHANGED).length;
+}
+
+export function buildEvidenceBlock(evidence) {
+  const shown = evidence.scenarios.filter(
+    (scenario) => scenario.status !== EVIDENCE_STATUS.UNCHANGED,
+  );
+  const unchanged = evidence.scenarios.filter(
+    (scenario) => scenario.status === EVIDENCE_STATUS.UNCHANGED,
+  );
+
+  const sections = shown.flatMap((scenario) => {
+    const heading = `#### ${caption(scenario.name)}`;
+    if (scenario.status === EVIDENCE_STATUS.NEW) {
+      return [heading, "", `![${caption(scenario.name)}](${scenario.afterUrl})`, ""];
+    }
+    return [
+      heading,
+      "",
+      "| Before (`main`) | After |",
+      "| --- | --- |",
+      `| ![before](${scenario.beforeUrl}) | ![after](${scenario.afterUrl}) |`,
+      "",
+    ];
+  });
+
+  const body =
+    evidence.scenarios.length === 0
+      ? ["This run produced no screenshots. Check the workflow run before reviewing.", ""]
+      : shown.length === 0
+        ? [
+            "Every scenario renders exactly as it does on `main`, so these screenshots do " +
+              "not show this change. Attach one that does.",
+            "",
+          ]
+        : sections;
+
+  const unchangedNote =
+    unchanged.length > 0 && shown.length > 0
+      ? [`Unchanged since \`main\`: ${unchanged.map((s) => caption(s.name)).join(", ")}.`, ""]
+      : [];
+
+  return [
     evidenceStart,
     "### Automated visual evidence",
     "",
-    `[Download the deterministic macOS evidence](${evidence.artifactUrl}) · [workflow run](${evidence.runUrl})`,
+    evidenceMarker(countShown(evidence.scenarios), evidence.headSha),
     "",
+    ...body,
+    ...unchangedNote,
     `- Commit: \`${evidence.headSha}\``,
     "- Scenario: `smoke`",
     "- Physical-notch check: not performed by CI",
+    `- [Download the originals](${evidence.artifactUrl}) · [workflow run](${evidence.runUrl})`,
     evidenceEnd,
   ].join("\n");
+}
 
+export function updateEvidenceBlock(body, evidence) {
+  const block = buildEvidenceBlock(evidence);
   const start = body.indexOf(evidenceStart);
   const end = body.indexOf(evidenceEnd);
   if (start >= 0 && end >= start) {
@@ -29,28 +139,49 @@ export function updateEvidenceBlock(body, evidence) {
   return `${body.trimEnd()}\n\n${block}\n`;
 }
 
-function requiredEnvironment(name) {
-  const value = process.env[name]?.trim();
-  if (!value) throw new Error(`Missing required environment variable: ${name}`);
-  return value;
+/**
+ * Compares each screenshot with its baseline and publishes what a reviewer
+ * needs to see: the current screenshot, plus the baseline beside it when the
+ * two differ. An unchanged scenario needs neither.
+ */
+async function resolveScenarios({ repository, directory, names, pullRequest, headSha }) {
+  const mediaDirectory = pullRequestDirectory(pullRequest, headSha);
+  const scenarios = [];
+
+  for (const name of names) {
+    const file = join(directory, name);
+    const current = await readFile(file);
+    const baseline = await readMedia(repository, mediaPath(BASELINE_DIRECTORY, name));
+    const status = compareEvidence(current, baseline?.contents);
+    if (status === EVIDENCE_STATUS.UNCHANGED) {
+      scenarios.push({ name, status });
+      continue;
+    }
+
+    const [published] = await publishMedia({
+      repository,
+      directory: mediaDirectory,
+      files: [file],
+    });
+    // The baseline is republished under this commit's directory rather than
+    // linked at its own stable path, which GitHub's image cache would serve
+    // stale once the default branch moves on.
+    const before =
+      status === EVIDENCE_STATUS.CHANGED
+        ? await publishBaselineCopy(repository, mediaDirectory, name, baseline.contents)
+        : undefined;
+    scenarios.push({ name, status, afterUrl: published.url, beforeUrl: before });
+  }
+
+  return scenarios;
 }
 
-async function githubRequest(path, init = {}) {
-  const response = await fetch(`https://api.github.com${path}`, {
-    ...init,
-    headers: {
-      Accept: "application/vnd.github+json",
-      Authorization: `Bearer ${requiredEnvironment("GITHUB_TOKEN")}`,
-      "Content-Type": "application/json",
-      "User-Agent": "luke-visual-evidence",
-      "X-GitHub-Api-Version": "2022-11-28",
-      ...init.headers,
-    },
-  });
-  if (!response.ok) {
-    throw new Error(`GitHub API ${response.status}: ${await response.text()}`);
-  }
-  return response.json();
+async function publishBaselineCopy(repository, directory, name, contents) {
+  const scratch = await mkdtemp(join(tmpdir(), "luke-baseline-"));
+  const copy = join(scratch, `before-${name}`);
+  await writeFile(copy, contents);
+  const [published] = await publishMedia({ repository, directory, files: [copy] });
+  return published.url;
 }
 
 async function main() {
@@ -62,13 +193,20 @@ async function main() {
 
   const pull = await githubRequest(`/repos/${repository}/pulls/${pullRequest}`);
   const headSha = requiredEnvironment("HEAD_SHA");
-  if (!isCurrentPullHead(pull, headSha)) {
+  if (!isCurrentPullHead(pull.data, headSha)) {
     process.stdout.write(
-      `Skipped visual evidence for stale commit ${headSha}; PR head is ${pull.head?.sha ?? "unknown"}\n`,
+      `Skipped visual evidence for stale commit ${headSha}; PR head is ${pull.data.head?.sha ?? "unknown"}\n`,
     );
     return;
   }
-  const body = updateEvidenceBlock(pull.body ?? "", {
+
+  const directory = requiredEnvironment("EVIDENCE_DIRECTORY");
+  const entries = await readdir(directory).catch(() => []);
+  const names = orderEvidenceFiles(entries.filter((entry) => entry.endsWith(".png")));
+  const scenarios = await resolveScenarios({ repository, directory, names, pullRequest, headSha });
+
+  const body = updateEvidenceBlock(pull.data.body ?? "", {
+    scenarios,
     artifactUrl: requiredEnvironment("ARTIFACT_URL"),
     runUrl: requiredEnvironment("RUN_URL"),
     headSha,
@@ -78,7 +216,17 @@ async function main() {
     method: "PATCH",
     body: JSON.stringify({ body }),
   });
-  process.stdout.write(`Updated visual evidence on PR #${pullRequest}\n`);
+  // The count is reported as a job output, not read back from the description.
+  // A pull-request body is author-editable in full — including the markers that
+  // delimit this block — so it can carry the verdict for a human to read but
+  // can never be the thing the gate trusts.
+  const shown = countShown(scenarios);
+  if (process.env.GITHUB_OUTPUT) {
+    await appendFile(process.env.GITHUB_OUTPUT, `scenarios-shown=${shown}\n`);
+  }
+  process.stdout.write(
+    `Embedded evidence on PR #${pullRequest}: ${shown} of ${scenarios.length} scenarios differ from main\n`,
+  );
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/scripts/update-pr-evidence.test.mjs
+++ b/scripts/update-pr-evidence.test.mjs
@@ -1,23 +1,130 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  buildEvidenceBlock,
+  caption,
+  changedMarker,
+  compareEvidence,
+  countShown,
+  EVIDENCE_STATUS,
   evidenceEnd,
   evidenceStart,
   isCurrentPullHead,
+  orderEvidenceFiles,
   updateEvidenceBlock,
 } from "./update-pr-evidence.mjs";
 
-const evidence = {
+const base = {
   artifactUrl: "https://github.example/artifact/1",
   runUrl: "https://github.example/run/2",
   headSha: "0123456789abcdef",
 };
 
+const changedScenario = {
+  name: "app-smoke-settings.png",
+  status: EVIDENCE_STATUS.CHANGED,
+  beforeUrl: "https://raw.example/before-settings.png",
+  afterUrl: "https://raw.example/settings.png",
+};
+
+const unchangedScenario = {
+  name: "app-smoke-compact.png",
+  status: EVIDENCE_STATUS.UNCHANGED,
+};
+
+test("reports equal renders as unchanged and different renders as changed", () => {
+  const current = Buffer.from([1, 2, 3]);
+
+  assert.equal(compareEvidence(current, Buffer.from([1, 2, 3])), EVIDENCE_STATUS.UNCHANGED);
+  assert.equal(compareEvidence(current, Buffer.from([1, 2, 4])), EVIDENCE_STATUS.CHANGED);
+  assert.equal(compareEvidence(current, undefined), EVIDENCE_STATUS.NEW);
+});
+
+test("counts every scenario that is not unchanged as shown", () => {
+  assert.equal(countShown([changedScenario, unchangedScenario]), 1);
+  assert.equal(countShown([unchangedScenario]), 0);
+  assert.equal(countShown([{ name: "app-smoke-expanded.png", status: EVIDENCE_STATUS.NEW }]), 1);
+});
+
+test("renders a changed scenario as a before and after pair", () => {
+  const result = buildEvidenceBlock({ ...base, scenarios: [changedScenario, unchangedScenario] });
+
+  assert.match(result, /#### Settings view \(smoke fixture\)/);
+  assert.match(result, /\| Before \(`main`\) \| After \|/);
+  assert.match(result, /!\[before\]\(https:\/\/raw\.example\/before-settings\.png\)/);
+  assert.match(result, /!\[after\]\(https:\/\/raw\.example\/settings\.png\)/);
+  assert.match(result, new RegExp(`${changedMarker}: 1`));
+});
+
+test("names the scenarios that did not change without embedding them", () => {
+  const result = buildEvidenceBlock({ ...base, scenarios: [changedScenario, unchangedScenario] });
+
+  assert.match(result, /Unchanged since `main`: Compact panel \(smoke fixture\)\./);
+  assert.doesNotMatch(result, /!\[Compact panel/);
+});
+
+test("says plainly when nothing differs from the default branch", () => {
+  const result = buildEvidenceBlock({ ...base, scenarios: [unchangedScenario] });
+
+  assert.match(result, /do not show this change/);
+  assert.match(result, new RegExp(`${changedMarker}: 0`));
+  assert.doesNotMatch(result, /!\[/);
+});
+
+test("embeds a scenario with no baseline on its own", () => {
+  const result = buildEvidenceBlock({
+    ...base,
+    scenarios: [
+      {
+        name: "app-smoke-settings.png",
+        status: EVIDENCE_STATUS.NEW,
+        afterUrl: "https://raw.example/new.png",
+      },
+    ],
+  });
+
+  assert.match(result, /!\[Settings view \(smoke fixture\)\]\(https:\/\/raw\.example\/new\.png\)/);
+  assert.doesNotMatch(result, /Before \(`main`\)/);
+  assert.match(result, new RegExp(`${changedMarker}: 1`));
+});
+
+test("reports a run that produced no screenshots", () => {
+  const result = buildEvidenceBlock({ ...base, scenarios: [] });
+
+  assert.match(result, /produced no screenshots/);
+  assert.match(result, new RegExp(`${changedMarker}: 0`));
+});
+
+test("captions an unrecognized screenshot with its filename", () => {
+  assert.equal(caption("app-smoke-future.png"), "app-smoke-future.png");
+  assert.equal(caption("app-smoke-compact.png"), "Compact panel (smoke fixture)");
+});
+
+test("orders screenshots by the caption table and unknown names last", () => {
+  const ordered = orderEvidenceFiles([
+    "app-smoke-speaking.png",
+    "zzz-extra.png",
+    "app-smoke-expanded.png",
+    "app-smoke-settings.png",
+    "app-smoke-compact.png",
+  ]);
+
+  assert.deepEqual(ordered, [
+    "app-smoke-expanded.png",
+    "app-smoke-settings.png",
+    "app-smoke-compact.png",
+    "app-smoke-speaking.png",
+    "zzz-extra.png",
+  ]);
+});
+
 test("appends automated evidence without replacing author content", () => {
-  const result = updateEvidenceBlock("## Summary\n\nAuthor notes\n", evidence);
+  const result = updateEvidenceBlock("## Summary\n\nAuthor notes\n", {
+    ...base,
+    scenarios: [changedScenario],
+  });
 
   assert.match(result, /Author notes/);
-  assert.match(result, /Download the deterministic macOS evidence/);
   assert.equal(result.match(new RegExp(evidenceStart, "g"))?.length, 1);
 });
 
@@ -32,7 +139,7 @@ test("replaces only the existing automated evidence block", () => {
     "## Human notes",
     "Keep this",
   ].join("\n");
-  const result = updateEvidenceBlock(initial, evidence);
+  const result = updateEvidenceBlock(initial, { ...base, scenarios: [changedScenario] });
 
   assert.doesNotMatch(result, /stale evidence/);
   assert.match(result, /Keep this/);


### PR DESCRIPTION
## Summary

Redo of #20, which was reverted in #22. Same feature, with all six review findings fixed before it lands rather than after.

Agents routinely opened UI pull requests with no screenshot. `WORKFLOW.md` was referenced from nothing an agent loads, nothing enforced it, and the upload it asked for went through a web editor no agent can use.

- CI produces the evidence instead of asking for it. The macOS job publishes its screenshots to `pr-assets` and embeds them, comparing each with the same render on `main`, so a reviewer sees a before-and-after pair for what changed.
- A screenshot identical to `main`'s shows nothing this pull request did, so the gate counts differing scenarios, not images.
- The settings view had never been capturable, leaving the credential surface with no possible evidence. `--view settings` opens it, and a capture run reports fixed settings so the render stays deterministic.
- `CLAUDE.md` symlinks to `AGENTS.md` so every harness loads one guide.

### Review findings from the first attempt, all fixed here

| Finding | Severity | Fix |
| --- | --- | --- |
| Skipped jobs overwrite failed CI checks | High | CI runs on code events only; the recheck lives in its own workflow with no build jobs to overwrite |
| Gate passes when the macOS job produced nothing | High | The gate receives that job's result and fails rather than waits |
| Verdict recoverable from the author-editable description | Medium | The verdict travels as a job output; the description is never trusted |
| Hidden markdown counts as evidence | Medium | Comments and fenced code are stripped, repeatedly, until stable |
| Screenshots published at 1x | — | Capture forces a 2x device scale, and validation asserts it |
| Renamed interface path silently disables the gate | — | A test asserts every configured path exists |

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed
- `actionlint` on both workflows: passed
- Harness tests: 39 passing, including a regression test per finding — a forged verdict block, an image in an HTML comment, an image in a fenced block, nested comment openers, and a failed macOS job
- macOS Electron verification (`./scripts/verify.sh`): `not run` locally — authored in a Linux cloud workspace, which cannot package the app. This PR's own macOS job is the verification.
- Behaviour proven on the reverted attempt: a commit changing no rendering reported `0 of 4 scenarios differ from main` and the gate failed; a commit that did report `4 of 4` and it passed.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

<!-- evidence-changed: 4 sha: b4de26c6ce8072a14bcb4f3c5bd7aaf8913aae6d -->

#### Expanded panel (smoke fixture)

![Expanded panel (smoke fixture)](https://raw.githubusercontent.com/ReviewStage/luke/pr-assets/pr-23/b4de26c6ce80/app-smoke-expanded.png)

#### Settings view (smoke fixture)

![Settings view (smoke fixture)](https://raw.githubusercontent.com/ReviewStage/luke/pr-assets/pr-23/b4de26c6ce80/app-smoke-settings.png)

#### Compact panel (smoke fixture)

![Compact panel (smoke fixture)](https://raw.githubusercontent.com/ReviewStage/luke/pr-assets/pr-23/b4de26c6ce80/app-smoke-compact.png)

#### Compact panel with the speaking waveform (smoke fixture)

![Compact panel with the speaking waveform (smoke fixture)](https://raw.githubusercontent.com/ReviewStage/luke/pr-assets/pr-23/b4de26c6ce80/app-smoke-speaking.png)

- Commit: `b4de26c6ce8072a14bcb4f3c5bd7aaf8913aae6d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
- [Download the originals](https://github.com/ReviewStage/luke/actions/runs/31650682467/artifacts/9162490991) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31650682467)
<!-- automated-visual-evidence:end -->

### Authored evidence

- Screenshot or screen recording: supplied by CI in the block above once the macOS job runs
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- `Visual evidence` and `Visual evidence (recheck)` are the checks to mark required, if you want the gate to block rather than advise. Marking only the first means attaching evidence after the fact will not clear it without a re-run.
- `pr-assets/baseline/` still holds screenshots from the reverted attempt. The first push to `main` after this merges republishes them.
- Still open, not in this PR: `evidence-exempt` can be applied by the pull request's own author, `pr-assets` has no pruning, and there is no pre-PR hook.
- Please review before merging. The first attempt was merged past unresolved bot findings; that is what this redo exists to correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c06a40d2-60d0-4898-8598-23d6bdc58a06)
