### PR TITLE
feat(LUKE-59): observe Devin cloud sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,18 @@ Download published builds from [GitHub Releases](https://github.com/ReviewStage/
 - Codex — reads local session state; no provider credential required
 - Conductor — reads cloud session metadata after you supply a Conductor API key
 - Cursor — reads cloud agent metadata after you supply a Cursor API key
+- Devin — reads cloud session metadata after you supply a Devin personal access
+  token
 
-Conductor and Cursor remain silent until their own key is saved in Luke's
-Settings or supplied through `CONDUCTOR_API_KEY`, `CONDUCTOR_API_TOKEN`, or
-`CURSOR_API_KEY`. Every provider integration is read-only. None requires hooks,
+Conductor, Cursor, and Devin remain silent until their own credential is saved
+in Luke's Settings or supplied through `CONDUCTOR_API_KEY`,
+`CONDUCTOR_API_TOKEN`, `CURSOR_API_KEY`, or `DEVIN_API_KEY`. Devin is the one
+that asks for a particular credential: Luke reads its v3 API, so it takes a
+personal access token (`cog_…`, created under **Devin API · PATs**) and refuses
+the deprecated `apk_` keys of v1 and v2. A token that belongs to a service user
+rather than to a person is refused too — Devin lists an organization's sessions,
+and Luke reports only the sessions belonging to whoever the token authenticates
+as. Every provider integration is read-only. None requires hooks,
 plugins, wrappers, or changes to how a session is launched.
 
 ## What works in v0.1
@@ -83,8 +91,8 @@ waveform without requesting microphone access.
 ## Optional attention review
 
 Session monitoring does not require `OPENAI_API_KEY`: Claude Code and Codex use
-local state, while Conductor and Cursor use their separately configured provider
-keys. If `OPENAI_API_KEY` is set, Luke can also send a bounded status update to
+local state, while Conductor, Cursor, and Devin use their separately configured
+provider credentials. If `OPENAI_API_KEY` is set, Luke can also send a bounded status update to
 the configured Responses endpoint for attention classification. That update can
 include the session title, recap, repository, branch, current tool activity, and
 reported error; see [PRIVACY.md](PRIVACY.md) for the exact boundary. This does

--- a/apps/desktop/src/devin-adapter.ts
+++ b/apps/desktop/src/devin-adapter.ts
@@ -1,0 +1,400 @@
+import {
+  type ProviderSessionObservation,
+  SESSION_STATUS,
+  type SessionProvider,
+  type SessionStatus,
+} from "@sidecar/core";
+import {
+  CLOUD_ADAPTER_DEFAULTS,
+  type CloudAdapterOptions,
+  type CloudRequest,
+  CloudSessionAdapter,
+  isDefined,
+  isRecord,
+  knownValue,
+  positiveInteger,
+  recordsFromPage,
+  textFromRecord,
+} from "./cloud-session-adapter";
+import { CREDENTIAL_PROVIDER_ID, CREDENTIAL_PROVIDERS } from "./shared/credential-providers";
+
+// Shared with the credential registry so the key the user saves and the
+// provider Luke observes with it can never name different things.
+const DEVIN_PROVIDER_ID = CREDENTIAL_PROVIDER_ID.DEVIN;
+const DEVIN_PROVIDER_NAME = CREDENTIAL_PROVIDERS[CREDENTIAL_PROVIDER_ID.DEVIN].displayName;
+
+const DEVIN_ENVIRONMENT = {
+  API_URL: "DEVIN_API_URL",
+} as const;
+
+const DEVIN_DEFAULT_API_URL = "https://api.devin.ai";
+
+/** Used only for a session Devin has not named yet and that opened nothing. */
+const UNKNOWN_SESSION_LABEL = "Cloud session";
+const DEVIN_SESSION_FAILED_MESSAGE = "The session stopped on an error";
+
+/**
+ * Read-only routes from the documented public API. Luke never calls a writer,
+ * and it reads v3 rather than the deprecated v1 the older `apk_` keys are for:
+ * v3 is the only version that says who a credential belongs to and that can
+ * narrow a list to one person.
+ */
+const DEVIN_ROUTE_SEGMENT = {
+  SELF: "self",
+  V3: "v3",
+  ORGANIZATIONS: "organizations",
+  SESSIONS: "sessions",
+} as const;
+
+const DEVIN_QUERY = {
+  FIRST: "first",
+  UPDATED_AFTER: "updated_after",
+  USER_IDS: "user_ids",
+} as const;
+
+const DEVIN_FIELD = {
+  IS_ARCHIVED: "is_archived",
+  TITLE: "title",
+  URL: "url",
+  ITEMS: "items",
+  ORG_ID: "org_id",
+  PRINCIPAL_TYPE: "principal_type",
+  PR_URL: "pr_url",
+  PULL_REQUESTS: "pull_requests",
+  SESSION_ID: "session_id",
+  STATUS: "status",
+  STATUS_DETAIL: "status_detail",
+  UPDATED_AT: "updated_at",
+  USER_ID: "user_id",
+} as const;
+
+/**
+ * Who a credential authenticates as. A service user is a non-human automation
+ * account: it belongs to an organization rather than to a person, and the
+ * sessions it can reach are attributed to it rather than to anyone using this
+ * Mac. Only a personal access token names the human Luke is sitting beside.
+ */
+const DEVIN_PRINCIPAL = {
+  PAT_USER: "pat_user",
+} as const;
+
+/** The session lifecycle, which is what a status means on its own. */
+const DEVIN_SESSION_STATUS = {
+  NEW: "new",
+  CLAIMED: "claimed",
+  RUNNING: "running",
+  EXIT: "exit",
+  ERROR: "error",
+  SUSPENDED: "suspended",
+  RESUMING: "resuming",
+} as const;
+
+type DevinSessionStatus = (typeof DEVIN_SESSION_STATUS)[keyof typeof DEVIN_SESSION_STATUS];
+
+/**
+ * What a running session is doing. Devin also reports a detail for a suspended
+ * session, but those are reasons for the suspension rather than states, so this
+ * map deliberately holds none of them and a suspended session falls through to
+ * its status.
+ */
+const DEVIN_RUNNING_DETAIL = {
+  WORKING: "working",
+  WAITING_FOR_USER: "waiting_for_user",
+  WAITING_FOR_APPROVAL: "waiting_for_approval",
+  FINISHED: "finished",
+} as const;
+
+type DevinRunningDetail = (typeof DEVIN_RUNNING_DETAIL)[keyof typeof DEVIN_RUNNING_DETAIL];
+
+/**
+ * A session that exited is over for good, and one Devin reports as errored
+ * stopped on something it cannot pass. The rest are either on their way
+ * somewhere — being created, claimed by a machine, or resuming — or dormant:
+ * unlike a Cursor run that expired, a suspended Devin session can be resumed,
+ * so it is neither settled nor holding for anyone. Luke leaves those unknown
+ * rather than promoting them to a state it cannot verify.
+ */
+const SESSION_STATUS_BY_DEVIN_STATUS: Readonly<Record<DevinSessionStatus, SessionStatus>> = {
+  [DEVIN_SESSION_STATUS.RUNNING]: SESSION_STATUS.WORKING,
+  [DEVIN_SESSION_STATUS.EXIT]: SESSION_STATUS.COMPLETE,
+  [DEVIN_SESSION_STATUS.NEW]: SESSION_STATUS.UNKNOWN,
+  [DEVIN_SESSION_STATUS.CLAIMED]: SESSION_STATUS.UNKNOWN,
+  [DEVIN_SESSION_STATUS.SUSPENDED]: SESSION_STATUS.UNKNOWN,
+  [DEVIN_SESSION_STATUS.RESUMING]: SESSION_STATUS.UNKNOWN,
+  // Not left unknown: a session that stopped on an error is asking to be
+  // rescued rather than answered, and Luke has a state that says so.
+  [DEVIN_SESSION_STATUS.ERROR]: SESSION_STATUS.ERROR,
+};
+
+/**
+ * A running session that is waiting on the user, waiting on an approval, or has
+ * finished its task has stopped and is holding for the user, which is what Luke
+ * reports as waiting. This is the one thing v1 could not say: it reported only
+ * that a session was blocked, never that the machine was still up and the turn
+ * had simply ended.
+ */
+const SESSION_STATUS_BY_RUNNING_DETAIL: Readonly<Record<DevinRunningDetail, SessionStatus>> = {
+  [DEVIN_RUNNING_DETAIL.WORKING]: SESSION_STATUS.WORKING,
+  [DEVIN_RUNNING_DETAIL.WAITING_FOR_USER]: SESSION_STATUS.WAITING,
+  [DEVIN_RUNNING_DETAIL.WAITING_FOR_APPROVAL]: SESSION_STATUS.WAITING,
+  [DEVIN_RUNNING_DETAIL.FINISHED]: SESSION_STATUS.WAITING,
+};
+
+/**
+ * Where a forge's path stops naming the repository and starts naming the
+ * request it holds: GitHub's `/pull/1`, Bitbucket's `/pull-requests/1`, and the
+ * `/-/` GitLab puts before `merge_requests/1`.
+ */
+const PULL_REQUEST_PATH_SEGMENT = {
+  GITHUB: "pull",
+  GITLAB: "-",
+  BITBUCKET: "pull-requests",
+} as const;
+
+const PULL_REQUEST_PATH_SEGMENTS: ReadonlySet<string> = new Set(
+  Object.values(PULL_REQUEST_PATH_SEGMENT),
+);
+
+const DEVIN_ADAPTER_DEFAULTS = {
+  /** The documented maximum, so one call covers as much of a day as it can. */
+  SESSION_PAGE_SIZE: 200,
+  MAXIMUM_OBSERVED_SESSIONS: 12,
+} as const;
+
+/**
+ * Below this a reported timestamp cannot be milliseconds — it would be 1973 —
+ * so it is seconds. Devin types both `created_at` and `updated_at` as integers
+ * without naming the unit, and reading one as the other would place every
+ * session either far in the past or far in the future.
+ */
+const EARLIEST_MILLISECOND_TIMESTAMP = 1e11;
+
+export const DEVIN_PROVIDER: SessionProvider = {
+  id: DEVIN_PROVIDER_ID,
+  displayName: DEVIN_PROVIDER_NAME,
+};
+
+export interface DevinAdapterOptions extends CloudAdapterOptions {
+  maximumObservedSessions?: number;
+}
+
+/** The person a credential belongs to, and the organization to read as them. */
+interface DevinIdentity {
+  userId: string;
+  orgId: string;
+}
+
+interface DevinSession {
+  id: string;
+  /** What Devin named the session, which is what the row is labelled by. */
+  name?: string;
+  repository?: string;
+  link?: string;
+  pullRequest?: string;
+  status: DevinSessionStatus | undefined;
+  detail: DevinRunningDetail | undefined;
+  archived: boolean;
+  observedAt: number;
+}
+
+function millisecondsFromRecord(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key];
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return undefined;
+  return value < EARLIEST_MILLISECOND_TIMESTAMP ? value * 1000 : value;
+}
+
+/**
+ * Devin reports the pull request a session opened rather than the repository it
+ * opened it in, so the repository is the path segment in front of the request.
+ */
+function pullRequestUrl(record: Record<string, unknown>): string | undefined {
+  const pullRequests = record[DEVIN_FIELD.PULL_REQUESTS];
+  const first = Array.isArray(pullRequests) ? pullRequests[0] : undefined;
+  return isRecord(first) ? textFromRecord(first, DEVIN_FIELD.PR_URL) : undefined;
+}
+
+function repositoryFromPullRequest(url: string | undefined): string | undefined {
+  const segments = url?.split("/").filter(Boolean) ?? [];
+  const request = segments.findIndex((segment) => PULL_REQUEST_PATH_SEGMENTS.has(segment));
+  return request > 0 ? segments[request - 1] : undefined;
+}
+
+function sessionFromRecord(
+  record: Record<string, unknown>,
+  identity: DevinIdentity,
+): DevinSession | undefined {
+  const id = textFromRecord(record, DEVIN_FIELD.SESSION_ID);
+  const observedAt = millisecondsFromRecord(record, DEVIN_FIELD.UPDATED_AT);
+  if (!id || observedAt === undefined) return undefined;
+
+  // The request already asked for this person's sessions, but a filter Luke
+  // cannot see is not one it can answer for, and what it would be answering for
+  // is a teammate's work in a personal sidecar.
+  if (textFromRecord(record, DEVIN_FIELD.USER_ID) !== identity.userId) return undefined;
+
+  const pullRequest = pullRequestUrl(record);
+  const repository = repositoryFromPullRequest(pullRequest);
+  const name = textFromRecord(record, DEVIN_FIELD.TITLE);
+  const link = textFromRecord(record, DEVIN_FIELD.URL);
+  return {
+    id,
+    observedAt,
+    status: knownValue(DEVIN_SESSION_STATUS, textFromRecord(record, DEVIN_FIELD.STATUS)),
+    detail: knownValue(DEVIN_RUNNING_DETAIL, textFromRecord(record, DEVIN_FIELD.STATUS_DETAIL)),
+    archived: record[DEVIN_FIELD.IS_ARCHIVED] === true,
+    ...(name ? { name } : {}),
+    ...(repository ? { repository } : {}),
+    ...(link ? { link } : {}),
+    ...(pullRequest ? { pullRequest } : {}),
+  };
+}
+
+/**
+ * Observes Devin cloud sessions through the documented public v3 API. Devin
+ * lists an organization's sessions rather than a credential owner's, so this
+ * first asks Devin who the credential belongs to and then reads only that
+ * person's sessions. It issues no request that can change provider state,
+ * reports nothing at all without a credential, and reports nothing for a
+ * service-user credential, which names an organization rather than a person.
+ */
+export class DevinSessionAdapter extends CloudSessionAdapter {
+  readonly #maximumObservedSessions: number;
+
+  /** The identity, or `null` once Devin has named one Luke cannot observe as. */
+  #principal: DevinIdentity | null | undefined;
+
+  constructor(options: DevinAdapterOptions) {
+    super(
+      {
+        provider: DEVIN_PROVIDER,
+        defaultBaseUrl: DEVIN_DEFAULT_API_URL,
+        baseUrlEnvironmentVariable: DEVIN_ENVIRONMENT.API_URL,
+      },
+      options,
+    );
+    this.#maximumObservedSessions = positiveInteger(
+      options.maximumObservedSessions,
+      DEVIN_ADAPTER_DEFAULTS.MAXIMUM_OBSERVED_SESSIONS,
+    );
+  }
+
+  protected override forgetCachedIdentity(): void {
+    this.#principal = undefined;
+  }
+
+  protected async collect(
+    request: CloudRequest,
+    now: number,
+  ): Promise<readonly ProviderSessionObservation[]> {
+    const identity = await this.#identity(request);
+    // A credential Luke cannot attribute to a person reads an organization's
+    // work. It reports nothing rather than a teammate's.
+    if (!identity) return [];
+
+    return (await this.#listSessions(request, identity, now))
+      .sort((first, second) => second.observedAt - first.observedAt)
+      .slice(0, this.#maximumObservedSessions)
+      .map((session) => this.#observationFor(session, now));
+  }
+
+  /**
+   * Devin names the principal behind a credential, so unlike the email a v1
+   * adapter would have had to be told, this is read from the credential itself
+   * and cannot disagree with it.
+   *
+   * The answer is cached either way, so a credential Luke cannot observe as
+   * costs one request rather than one every refresh for as long as it is
+   * stored. The base clears the cache the moment the credential changes.
+   */
+  async #identity(request: CloudRequest): Promise<DevinIdentity | undefined> {
+    if (this.#principal !== undefined) return this.#principal ?? undefined;
+    const body = await request([DEVIN_ROUTE_SEGMENT.V3, DEVIN_ROUTE_SEGMENT.SELF]);
+    const userId = textFromRecord(body, DEVIN_FIELD.USER_ID);
+    // Devin leaves `org_id` off a token it places in no organization, and every
+    // v3 session list is org-scoped — the only route that could name an
+    // organization for a token is enterprise-admin. So a token like that has
+    // nothing Luke can read, and asking again would not change that.
+    const orgId = textFromRecord(body, DEVIN_FIELD.ORG_ID);
+    const principal = textFromRecord(body, DEVIN_FIELD.PRINCIPAL_TYPE);
+    this.#principal =
+      principal === DEVIN_PRINCIPAL.PAT_USER && userId && orgId ? { userId, orgId } : null;
+    return this.#principal ?? undefined;
+  }
+
+  /**
+   * The whole pass after identity, in one request: a session record carries its
+   * own state and timestamp, so unlike the other cloud providers Luke needs no
+   * second request per session, and asking for one person's sessions inside the
+   * observation window leaves a full page far past anything it would report.
+   */
+  async #listSessions(
+    request: CloudRequest,
+    identity: DevinIdentity,
+    now: number,
+  ): Promise<DevinSession[]> {
+    const openedAt = now - CLOUD_ADAPTER_DEFAULTS.MAXIMUM_SESSION_AGE_MS;
+    const body = await request(
+      [
+        DEVIN_ROUTE_SEGMENT.V3,
+        DEVIN_ROUTE_SEGMENT.ORGANIZATIONS,
+        identity.orgId,
+        DEVIN_ROUTE_SEGMENT.SESSIONS,
+      ],
+      {
+        [DEVIN_QUERY.FIRST]: String(DEVIN_ADAPTER_DEFAULTS.SESSION_PAGE_SIZE),
+        [DEVIN_QUERY.USER_IDS]: identity.userId,
+        // Seconds rather than milliseconds, and deliberately so: Devin types
+        // this as an integer without naming the unit, and of the two ways to be
+        // wrong, a value read as milliseconds only asks for more than the window
+        // — which the filter below discards anyway — while one read as seconds
+        // would sit in the far future and match nothing at all.
+        [DEVIN_QUERY.UPDATED_AFTER]: String(Math.floor(openedAt / 1000)),
+      },
+    );
+
+    return recordsFromPage(body, DEVIN_FIELD.ITEMS)
+      .map((record) => sessionFromRecord(record, identity))
+      .filter(isDefined)
+      .filter((session) => session.observedAt >= openedAt);
+  }
+
+  #observationFor(session: DevinSession, now: number): ProviderSessionObservation {
+    const status = this.#statusFor(session, now);
+    return {
+      providerSessionId: session.id,
+      // What Devin named it, then where the work landed. The adapter reports
+      // the fields and leaves the wording to the surface that draws them.
+      title: session.name ?? session.repository ?? UNKNOWN_SESSION_LABEL,
+      status,
+      observedAt: session.observedAt,
+      detail: {
+        ...(session.repository ? { repository: session.repository } : {}),
+        ...(status === SESSION_STATUS.ERROR ? { error: DEVIN_SESSION_FAILED_MESSAGE } : {}),
+        ...(session.link ? { link: session.link } : {}),
+        ...(session.pullRequest ? { change: session.pullRequest } : {}),
+      },
+    };
+  }
+
+  #statusFor(session: DevinSession, now: number): SessionStatus {
+    // A session the user filed away is settled whatever it was doing.
+    if (session.archived) return SESSION_STATUS.COMPLETE;
+    // A state this build does not know is not guessed at.
+    if (!session.status) return SESSION_STATUS.UNKNOWN;
+    // The detail is what a live session is actually doing, and it is only
+    // meaningful while one is running: for a suspended session Devin puts the
+    // reason for the suspension there instead, which this build knows none of.
+    const status =
+      (session.status === DEVIN_SESSION_STATUS.RUNNING && session.detail
+        ? SESSION_STATUS_BY_RUNNING_DETAIL[session.detail]
+        : undefined) ?? SESSION_STATUS_BY_DEVIN_STATUS[session.status];
+    // Devin reports live state, and its timestamp marks when that state was
+    // entered rather than a heartbeat, so a long turn is still working and a
+    // session that ended stays ended however long ago it did. Only a session
+    // holding for the user decays: once it is stale Luke cannot tell a question
+    // just asked from one the user walked away from hours ago.
+    return status === SESSION_STATUS.WAITING
+      ? this.statusWhileRecent(status, session.observedAt, now)
+      : status;
+  }
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -30,6 +30,7 @@ import { ClaudeCodeSessionAdapter } from "./claude-code-adapter";
 import { CodexSessionAdapter } from "./codex-adapter";
 import { ConductorSessionAdapter } from "./conductor-adapter";
 import { CursorSessionAdapter } from "./cursor-adapter";
+import { DevinSessionAdapter } from "./devin-adapter";
 import { readMacScreenGeometry } from "./macos-screen-geometry";
 import { openAiAttentionEvaluatorFromEnvironment } from "./openai-attention-evaluator";
 import { SettingsStore } from "./settings-store";
@@ -77,18 +78,23 @@ const conductorAdapter = new ConductorSessionAdapter({
 const cursorAdapter = new CursorSessionAdapter({
   readApiKey: () => settingsStore.readApiKey(CREDENTIAL_PROVIDER_ID.CURSOR),
 });
+const devinAdapter = new DevinSessionAdapter({
+  readApiKey: () => settingsStore.readApiKey(CREDENTIAL_PROVIDER_ID.DEVIN),
+});
 // Saving a key affects only the provider it belongs to, so this maps each
 // credential to the one observer that reads it.
 const adapterByCredentialProvider: ReadonlyMap<CredentialProviderId, SessionProviderAdapter> =
   new Map<CredentialProviderId, SessionProviderAdapter>([
     [CREDENTIAL_PROVIDER_ID.CONDUCTOR, conductorAdapter],
     [CREDENTIAL_PROVIDER_ID.CURSOR, cursorAdapter],
+    [CREDENTIAL_PROVIDER_ID.DEVIN, devinAdapter],
   ]);
 const sessionAdapters = [
   new ClaudeCodeSessionAdapter(),
   new CodexSessionAdapter(),
   conductorAdapter,
   cursorAdapter,
+  devinAdapter,
 ] as const;
 // A fixture run must stay deterministic and credential-free, so it never builds
 // an evaluator — not just capture runs.

--- a/apps/desktop/src/renderer/provider-marks.tsx
+++ b/apps/desktop/src/renderer/provider-marks.tsx
@@ -10,14 +10,16 @@ import { useId } from "react";
  * Each is the provider's own mark, reproduced rather than redrawn — Claude Code
  * via Simple Icons (CC0-1.0, sourced from code.claude.com), Codex via
  * @lobehub/icons (MIT), Conductor's letter mark verbatim from the published
- * brand kit at https://www.conductor.build/brandkit, and Cursor via Simple
- * Icons (CC0-1.0, sourced from https://cursor.com/brand). Each keeps its own
- * brand colour (see the `--mark-*` custom properties), so a mark says which
- * provider a session belongs to while the chips and row tints say what state it
- * is in. Cursor publishes its mark as a single silhouette rather than in a
- * colour, so it is drawn in the light form the brand uses on a dark surface.
- * They are trademarks of their respective owners. Do not restyle the geometry
- * or recolour them; swap the path if a provider publishes an updated mark.
+ * brand kit at https://www.conductor.build/brandkit, Cursor via Simple Icons
+ * (CC0-1.0, sourced from https://cursor.com/brand), and Devin's verbatim from
+ * the mark https://devin.ai serves as its own favicon and site header. Each
+ * keeps its own brand colour (see the `--mark-*` custom properties), so a mark
+ * says which provider a session belongs to while the chips and row tints say
+ * what state it is in. Cursor and Devin each publish one silhouette rather than
+ * a colour, so both are drawn in the light form their brand uses on a dark
+ * surface. They are trademarks of their respective owners. Do not restyle the
+ * geometry or recolour them; swap the path if a provider publishes an updated
+ * mark.
  */
 interface MarkProps {
   className?: string;
@@ -31,6 +33,9 @@ const CODEX_PATH =
 
 const CURSOR_PATH =
   "M11.503.131 1.891 5.678a.84.84 0 0 0-.42.726v11.188c0 .3.162.575.42.724l9.609 5.55a1 1 0 0 0 .998 0l9.61-5.55a.84.84 0 0 0 .42-.724V6.404a.84.84 0 0 0-.42-.726L12.497.131a1.01 1.01 0 0 0-.996 0M2.657 6.338h18.55c.263 0 .43.287.297.515L12.23 22.918c-.062.107-.229.064-.229-.06V12.335a.59.59 0 0 0-.295-.51l-9.11-5.257c-.109-.063-.064-.23.061-.23";
+
+const DEVIN_PATH =
+  "M70 159.333V91.3471C70 88.3592 71.594 85.5983 74.1816 84.1044L133.043 50.1205C135.631 48.6265 138.819 48.6265 141.407 50.1205L200.269 84.1044C202.856 85.5983 204.45 88.3592 204.45 91.3471V126.068C204.708 137.606 210.806 148.734 221.531 154.926C232.256 161.117 244.942 160.834 255.063 155.289L285.132 137.929C287.719 136.435 290.907 136.435 293.495 137.929L352.357 171.913C354.944 173.406 356.538 176.167 356.538 179.155V247.123C356.538 250.111 354.944 252.872 352.357 254.366L293.495 288.35C290.907 289.844 287.719 289.844 285.132 288.35L255.306 271.13C245.146 265.456 232.344 265.117 221.534 271.358C210.809 277.55 204.711 288.678 204.453 300.215V334.926C204.453 337.914 202.859 340.675 200.271 342.169L141.41 376.153C138.822 377.647 135.634 377.647 133.046 376.153L74.1845 342.169C71.5969 340.675 70.0028 337.914 70.0028 334.926V266.959C70.0029 263.971 71.5969 261.21 74.1845 259.716L133.046 225.732C135.634 224.238 138.822 224.238 141.41 225.732L171.547 243.132C181.656 248.638 194.306 248.906 205.005 242.729C215.815 236.488 221.922 225.231 222.088 213.595C221.83 202.057 215.732 189.737 205.008 183.545C194.283 177.353 181.597 177.636 171.476 183.181L141.269 200.72C138.67 202.229 135.461 202.228 132.864 200.716L74.1576 166.562C71.5835 165.065 70 162.311 70 159.333Z";
 
 /* Conductor publishes a letter mark rather than a glyph, so it is taller than
    it is wide; the box below fits it by height like any other mark. */
@@ -133,6 +138,20 @@ function CursorMark({ className }: MarkProps): React.JSX.Element {
   );
 }
 
+function DevinMark({ className }: MarkProps): React.JSX.Element {
+  return (
+    <svg
+      className={className}
+      data-mark={PROVIDER_ID.DEVIN}
+      viewBox="0 0 425 425"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path fill="currentColor" d={DEVIN_PATH} />
+    </svg>
+  );
+}
+
 /** Drawn here, not a brand: a provider Luke has no mark for still needs a slot. */
 function UnknownProviderMark({ className }: MarkProps): React.JSX.Element {
   return (
@@ -148,6 +167,7 @@ const PROVIDER_MARKS = new Map<string, (props: MarkProps) => React.JSX.Element>(
   [PROVIDER_ID.CODEX, CodexMark],
   [PROVIDER_ID.CONDUCTOR, ConductorMark],
   [PROVIDER_ID.CURSOR, CursorMark],
+  [PROVIDER_ID.DEVIN, DevinMark],
 ]);
 
 export function ProviderMark({

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -46,11 +46,13 @@ const CREDENTIAL_STATUS: Partial<Record<CredentialSource, string>> = {
 };
 
 /* One field, three jobs: what it is for depends on what is answering for the
-   provider now, and a key typed here always wins over one read elsewhere. */
+   provider now, and a credential typed here always wins over one read
+   elsewhere. The label above names what to paste, so these do not repeat it —
+   and cannot, since not every provider calls it the same thing. */
 const CREDENTIAL_PLACEHOLDER: Record<CredentialSource, string> = {
-  [CREDENTIAL_SOURCE.NONE]: "Paste an API key",
-  [CREDENTIAL_SOURCE.ENVIRONMENT]: "Paste a key to use instead of the one from the environment",
-  [CREDENTIAL_SOURCE.ENCRYPTED_FILE]: "Replace the stored key",
+  [CREDENTIAL_SOURCE.NONE]: "Paste it here",
+  [CREDENTIAL_SOURCE.ENVIRONMENT]: "Paste one to use instead of the one from the environment",
+  [CREDENTIAL_SOURCE.ENCRYPTED_FILE]: "Replace what is stored",
 };
 
 /**
@@ -96,10 +98,14 @@ function ProviderCredential({
   // The pencil opens the same editor from either connected state, but it does
   // not mean the same thing: one replaces the key Luke keeps, the other stands
   // in front of one it only reads.
-  const editTitle = stored ? "Replace" : "Use a key stored here";
+  const editTitle = stored ? "Replace" : "Use a credential stored here";
+  // Most providers issue an API key. One issues something it calls by another
+  // name, and a field asking for the wrong thing sends the user to the page
+  // that hands out the credential Luke refuses.
+  const credential = provider.keyFormat?.label ?? "API key";
   const editLabel = stored
-    ? `Replace the ${provider.displayName} API key`
-    : `Store a ${provider.displayName} API key instead of the one from the environment`;
+    ? `Replace the ${provider.displayName} ${credential}`
+    : `Store a ${provider.displayName} ${credential} instead of the one from the environment`;
 
   // Opening the tab is not a request to type, so the editor opens only on a
   // press — and then it takes the caret, because opening it is a request to
@@ -155,7 +161,7 @@ function ProviderCredential({
               type="button"
               className="icon-button credential-remove"
               disabled={busy}
-              aria-label={`Delete the ${provider.displayName} API key`}
+              aria-label={`Delete the ${provider.displayName} ${credential}`}
               title="Delete"
               onClick={() => void submit(undefined)}
             >
@@ -190,19 +196,22 @@ function ProviderCredential({
       </div>
 
       {editing ? (
-        /* Named as a group, because Cancel, Save key, and the link to the
+        /* Named as a group, because Cancel, Save, and the link to the
            provider's own page are the same three words on every row and two
            editors can be open at once. */
-        <fieldset className="credential-editor" aria-label={`${provider.displayName} API key`}>
+        <fieldset
+          className="credential-editor"
+          aria-label={`${provider.displayName} ${credential}`}
+        >
           <label className="settings-field" htmlFor={fieldId}>
             {/* The provider is named on the line above, so the visible label
                 does not repeat it — but a reader hearing the field alone still
                 needs to know whose key it is. */}
-            <span className="settings-label">API key</span>
+            <span className="settings-label">{credential}</span>
             <input
               id={fieldId}
               ref={field}
-              aria-label={`${provider.displayName} API key`}
+              aria-label={`${provider.displayName} ${credential}`}
               className="settings-input"
               type="password"
               autoComplete="off"
@@ -237,7 +246,7 @@ function ProviderCredential({
                 className="link-button"
                 onClick={() => window.sidecar.openProviderApiKeys(provider.id)}
               >
-                Get an API key
+                Where to get one
                 <ExternalIcon />
               </button>
             </small>
@@ -256,7 +265,7 @@ function ProviderCredential({
                 disabled={busy || draft.trim().length === 0}
                 onClick={() => void submit(draft)}
               >
-                {busy ? "Saving…" : "Save key"}
+                {busy ? "Saving…" : "Save"}
               </button>
             </span>
           </div>

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -13,8 +13,8 @@
      coral, the vertical gradient Codex draws its mark with, the light half of
      Conductor's two-colour palette — its dark half is the surface the mark
      already sits on, so the pairing is the published one — and Cursor's mark,
-     which is published as one silhouette and so is drawn in the light form the
-     brand uses on a dark surface. Session state is carried by the chips, row
+     and Devin's marks, each published as one silhouette and so drawn in the
+     light form its brand uses on a dark surface. Session state is carried by the chips, row
      tints, and count badge instead, so the two colour systems never compete for
      the same pixel. */
   --mark-claude-code: #d97757;
@@ -23,6 +23,7 @@
   --mark-codex-bottom: #3941ff;
   --mark-conductor: #eae8e6;
   --mark-cursor: #ffffff;
+  --mark-devin: #ffffff;
 
   --text-primary: rgba(255, 255, 255, 0.95);
   --text-secondary: rgba(255, 255, 255, 0.56);
@@ -541,6 +542,13 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 .provider-mark[data-mark="cursor"] {
   color: var(--mark-cursor);
   transform: scale(0.94);
+}
+
+/* Devin's published mark leaves roughly a fifth of its box empty on every side,
+   so it is scaled up to the height the full-bleed marks reach. */
+.provider-mark[data-mark="devin"] {
+  color: var(--mark-devin);
+  transform: scale(1.22);
 }
 
 /* The work is happening somewhere the user cannot see. The badge overhangs the

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -9,6 +9,7 @@ import {
 import {
   CREDENTIAL_PROVIDER_ID,
   CREDENTIAL_PROVIDER_LIST,
+  type CredentialFormat,
   type CredentialProvider,
   type CredentialProviderId,
 } from "./shared/credential-providers";
@@ -80,13 +81,17 @@ function canIgnoreFilesystemError(error: unknown): boolean {
 
 /**
  * A rejected key never reaches disk, and the reason never echoes the submitted
- * value. No provider Luke reads publishes a key format, so this only rules out
- * values that cannot be sent as an HTTP authorization header.
+ * value. Most of what this rules out is a value that cannot be sent as an HTTP
+ * authorization header at all. A provider that publishes more than one kind of
+ * key also has the kind Luke cannot use ruled out here, so a credential that
+ * would only ever be refused is refused at the door rather than stored and
+ * quietly unused.
  */
-export function apiKeyRejection(apiKey: string): string | undefined {
+export function apiKeyRejection(apiKey: string, format?: CredentialFormat): string | undefined {
   if (apiKey.length < API_KEY_LENGTH.MINIMUM) return "That API key is too short.";
   if (apiKey.length > API_KEY_LENGTH.MAXIMUM) return "That API key is too long.";
   if (!PRINTABLE_ASCII.test(apiKey)) return "That API key contains unsupported characters.";
+  if (format && !apiKey.startsWith(format.prefix)) return format.rejection;
   return undefined;
 }
 
@@ -96,7 +101,7 @@ function environmentApiKey(
 ): string | undefined {
   for (const variable of provider.environmentVariables) {
     const value = environment[variable]?.trim();
-    if (value && !apiKeyRejection(value)) return value;
+    if (value && !apiKeyRejection(value, provider.keyFormat)) return value;
   }
   return undefined;
 }
@@ -187,11 +192,12 @@ export class SettingsStore {
     providerId: CredentialProviderId,
     apiKey: string | undefined,
   ): Promise<SettingsUpdateResult> {
+    const keyFormat = this.#providers.find((candidate) => candidate.id === providerId)?.keyFormat;
     const normalized = apiKey?.trim();
     const rejection = normalized
       ? !this.#secretStorageAvailable()
         ? "Encrypted credential storage is unavailable on this system."
-        : apiKeyRejection(normalized)
+        : apiKeyRejection(normalized, keyFormat)
       : undefined;
     if (rejection) return { settings: await this.snapshot(), reason: rejection };
 
@@ -263,7 +269,9 @@ export class SettingsStore {
     if (!ciphertext) return undefined;
     try {
       const apiKey = this.#cipher.decrypt(Buffer.from(ciphertext, "base64")).trim();
-      return apiKey && !apiKeyRejection(apiKey) ? apiKey : undefined;
+      // A key stored before this build learned which kind the provider issues
+      // is held to the same rule, so a rule added later takes effect at once.
+      return apiKey && !apiKeyRejection(apiKey, provider.keyFormat) ? apiKey : undefined;
     } catch {
       // A key encrypted under a different account, or against a rotated
       // Keychain entry, cannot be recovered; the user re-enters it instead.

--- a/apps/desktop/src/shared/credential-providers.ts
+++ b/apps/desktop/src/shared/credential-providers.ts
@@ -10,6 +10,7 @@ import { PROVIDER_ID } from "@sidecar/core";
 export const CREDENTIAL_PROVIDER_ID = {
   CONDUCTOR: PROVIDER_ID.CONDUCTOR,
   CURSOR: PROVIDER_ID.CURSOR,
+  DEVIN: PROVIDER_ID.DEVIN,
 } as const;
 
 export type CredentialProviderId =
@@ -28,6 +29,28 @@ const CURSOR_ENVIRONMENT = {
   API_KEY: "CURSOR_API_KEY",
 } as const;
 
+const DEVIN_ENVIRONMENT = {
+  API_KEY: "DEVIN_API_KEY",
+} as const;
+
+/**
+ * The only kind of credential Luke will hold for a provider that issues more
+ * than one. Only a provider that publishes a format declares this; the rest
+ * accept any key the provider might issue, because guessing at a format Luke
+ * cannot check would reject a working key.
+ */
+export interface CredentialFormat {
+  /**
+   * What the provider itself calls this credential, used wherever the panel
+   * would otherwise say "API key". Asking for the wrong noun sends the user to
+   * the wrong page, which for Devin is the one issuing the keys Luke refuses.
+   */
+  label: string;
+  prefix: string;
+  /** Said to the user when a key does not carry it, never echoing the key. */
+  rejection: string;
+}
+
 export interface CredentialProvider {
   id: CredentialProviderId;
   displayName: string;
@@ -41,6 +64,8 @@ export interface CredentialProvider {
   apiKeysUrl: string;
   /** Read in order when nothing is stored for this provider. */
   environmentVariables: readonly string[];
+  /** Present only for a provider that publishes more than one kind of key. */
+  keyFormat?: CredentialFormat;
 }
 
 /** Keyed by provider id so no caller has to build a key from an identifier. */
@@ -58,6 +83,29 @@ export const CREDENTIAL_PROVIDERS: Readonly<Record<CredentialProviderId, Credent
     hint: "Create a key in the Cursor dashboard under Integrations · API keys.",
     apiKeysUrl: "https://cursor.com/dashboard/api",
     environmentVariables: [CURSOR_ENVIRONMENT.API_KEY],
+  },
+  [CREDENTIAL_PROVIDER_ID.DEVIN]: {
+    id: CREDENTIAL_PROVIDER_ID.DEVIN,
+    displayName: "Devin",
+    hint: "Create one on the Devin API settings page, under PATs.",
+    // Not the Settings · API keys page, which issues the deprecated `apk_`
+    // keys Luke refuses. Personal access tokens live on their own tab.
+    apiKeysUrl: "https://app.devin.ai/settings/devin-api?tab=pats",
+    environmentVariables: [DEVIN_ENVIRONMENT.API_KEY],
+    // Devin observes through its v3 API, which every current credential is
+    // issued for and which every legacy one — the deprecated `apk_` and
+    // `apk_user_` keys of v1 and v2 — is not. A legacy key would be refused by
+    // Devin on the first request, and a credential Luke cannot use is worth
+    // saying so about rather than storing and going quiet. Which *kind* of
+    // `cog_` credential it is, a person's or an organization's, is not
+    // something a prefix can tell: Devin answers that itself, and the adapter
+    // asks it on every pass.
+    keyFormat: {
+      label: "Personal access token",
+      prefix: "cog_",
+      rejection:
+        "Devin's personal access tokens start with cog_. The older apk_ keys are for an API version Luke does not read.",
+    },
   },
 };
 

--- a/apps/desktop/tests/credential-providers.test.ts
+++ b/apps/desktop/tests/credential-providers.test.ts
@@ -10,6 +10,7 @@ import {
 test("accepts only a provider the build ships", () => {
   assert.equal(isCredentialProviderId(CREDENTIAL_PROVIDER_ID.CONDUCTOR), true);
   assert.equal(isCredentialProviderId(CREDENTIAL_PROVIDER_ID.CURSOR), true);
+  assert.equal(isCredentialProviderId(CREDENTIAL_PROVIDER_ID.DEVIN), true);
   assert.equal(isCredentialProviderId("unknown-cloud"), false);
   // An inherited property name is not a provider, and neither is a value that
   // is not a string at all.
@@ -27,5 +28,34 @@ test("describes every provider it lists", () => {
     assert.ok(provider.hint.length > 0);
     // The environment fallback every provider offers is `<PROVIDER>_API_KEY`.
     assert.ok(provider.environmentVariables[0]?.endsWith("_API_KEY"), provider.id);
+    // A declared format has to say what it wants as well as refuse, because
+    // the reason is the only thing the user has to act on.
+    if (!provider.keyFormat) continue;
+    assert.ok(provider.keyFormat.prefix.length > 0, provider.id);
+    assert.ok(provider.keyFormat.label.length > 0, provider.id);
+    assert.ok(provider.keyFormat.rejection.includes(provider.keyFormat.prefix), provider.id);
+  }
+});
+
+test("takes only the Devin credentials its API version issues", () => {
+  const devin = CREDENTIAL_PROVIDERS[CREDENTIAL_PROVIDER_ID.DEVIN];
+
+  assert.equal(devin.displayName, "Devin");
+  assert.deepEqual(devin.environmentVariables, ["DEVIN_API_KEY"]);
+  // Luke reads Devin's v3 API, whose credentials all carry one prefix. The
+  // deprecated v1 and v2 keys carry another and would only ever be refused.
+  assert.equal(devin.keyFormat?.prefix, "cog_");
+  // Devin calls this a personal access token, and the settings field has to
+  // call it that too: its Settings · API keys page issues the `apk_` keys Luke
+  // refuses, so asking for an "API key" would send the user to the wrong one.
+  assert.equal(devin.keyFormat?.label, "Personal access token");
+  assert.match(devin.apiKeysUrl, /devin-api\?tab=pats$/);
+  for (const legacy of ["apk_service-key", "apk_user_personal-key"]) {
+    assert.equal(legacy.startsWith(devin.keyFormat?.prefix ?? ""), false, legacy);
+  }
+  // Conductor and Cursor each publish one kind of key, so neither has a format
+  // worth holding a credential to.
+  for (const providerId of [CREDENTIAL_PROVIDER_ID.CONDUCTOR, CREDENTIAL_PROVIDER_ID.CURSOR]) {
+    assert.equal(CREDENTIAL_PROVIDERS[providerId].keyFormat, undefined, providerId);
   }
 });

--- a/apps/desktop/tests/devin-adapter.test.ts
+++ b/apps/desktop/tests/devin-adapter.test.ts
@@ -1,0 +1,620 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { SESSION_STATUS } from "@sidecar/core";
+import type { CloudFetch } from "../src/cloud-session-adapter";
+import { DEVIN_PROVIDER, DevinSessionAdapter } from "../src/devin-adapter";
+
+const TEST_TIME = Date.parse("2026-08-13T02:45:00.000Z");
+const TEST_BASE_URL = "https://api.devin.test";
+const TEST_API_KEY = "cog_devin-test-token";
+const TEST_ORG_ID = "org-reviewstage";
+const TEST_USER_ID = "user-observer";
+const TEST_TEAMMATE_ID = "user-someone-else";
+const TEST_PULL_REQUEST = "https://github.com/reviewstage/luke/pull/42";
+const TEST_SESSION_TITLE = "Wire the notch geometry adapter";
+
+/** The principals Devin can report behind a `cog_` credential. */
+const TEST_PRINCIPAL = {
+  PAT_USER: "pat_user",
+  SERVICE_USER: "service_user",
+} as const;
+
+/** The session lifecycle, verbatim from the documented v3 `status`. */
+const TEST_STATUS = {
+  NEW: "new",
+  CLAIMED: "claimed",
+  RUNNING: "running",
+  EXIT: "exit",
+  ERROR: "error",
+  SUSPENDED: "suspended",
+  RESUMING: "resuming",
+} as const;
+
+/** What a session is doing, verbatim from the documented `status_detail`. */
+const TEST_DETAIL = {
+  WORKING: "working",
+  WAITING_FOR_USER: "waiting_for_user",
+  WAITING_FOR_APPROVAL: "waiting_for_approval",
+  FINISHED: "finished",
+  INACTIVITY: "inactivity",
+  OUT_OF_CREDITS: "out_of_credits",
+} as const;
+
+const HTTP_STATUS = {
+  OK: 200,
+  UNAUTHORIZED: 401,
+  SERVER_ERROR: 500,
+} as const;
+
+interface TestSession {
+  id: string;
+  status?: string;
+  detail?: string;
+  archived?: boolean;
+  title?: string;
+  omitTitle?: boolean;
+  userId?: string;
+  omitUser?: boolean;
+  pullRequest?: string;
+  omitPullRequest?: boolean;
+  /** Devin reports seconds; the adapter must not read them as milliseconds. */
+  updatedAt: number;
+}
+
+interface RecordedRequest {
+  method: string;
+  pathname: string;
+  search: string;
+  authorization: string | undefined;
+}
+
+interface FakeDevinApi {
+  fetch: CloudFetch;
+  requests: RecordedRequest[];
+}
+
+function seconds(timestampMs: number): number {
+  return Math.floor(timestampMs / 1000);
+}
+
+function jsonResponse(body: unknown, status = HTTP_STATUS.OK): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function sessionPayload(session: TestSession): Record<string, unknown> {
+  return {
+    session_id: session.id,
+    org_id: TEST_ORG_ID,
+    ...(session.omitTitle ? {} : { title: session.title ?? TEST_SESSION_TITLE }),
+    status: session.status ?? TEST_STATUS.RUNNING,
+    ...(session.detail ? { status_detail: session.detail } : {}),
+    created_at: seconds(session.updatedAt),
+    updated_at: seconds(session.updatedAt),
+    is_archived: session.archived === true,
+    origin: "webapp",
+    acus_consumed: 3.5,
+    tags: [],
+    url: `https://app.devin.ai/sessions/${session.id}`,
+    // The session's own output, which is shaped by whoever prompted it: not a
+    // recap a provider wrote, so no observation carries it.
+    structured_output: { summary: "SECRET_STRUCTURED_OUTPUT" },
+    ...(session.omitUser ? {} : { user_id: session.userId ?? TEST_USER_ID }),
+    ...(session.omitPullRequest
+      ? { pull_requests: [] }
+      : {
+          pull_requests: [{ pr_url: session.pullRequest ?? TEST_PULL_REQUEST, pr_state: "open" }],
+        }),
+  };
+}
+
+/** Serves the read-only subset of the public v3 API the adapter may use. */
+function fakeDevinApi(
+  sessions: readonly TestSession[],
+  options: { principal?: string; orgId?: string | undefined; userId?: string } = {},
+): FakeDevinApi {
+  const requests: RecordedRequest[] = [];
+  const fetch: CloudFetch = async (url, init) => {
+    const { pathname, searchParams, search } = new URL(url);
+    const headers = new Headers(init.headers);
+    requests.push({
+      method: init.method ?? "",
+      pathname,
+      search,
+      authorization: headers.get("authorization") ?? undefined,
+    });
+
+    if (pathname === "/v3/self") {
+      const principal = options.principal ?? TEST_PRINCIPAL.PAT_USER;
+      const orgId = "orgId" in options ? options.orgId : TEST_ORG_ID;
+      return jsonResponse({
+        principal_type: principal,
+        api_key_id: "key-1",
+        api_key_name: "Luke",
+        ...(principal === TEST_PRINCIPAL.SERVICE_USER
+          ? { service_user_id: "service-1", service_user_name: "CI" }
+          : { user_id: options.userId ?? TEST_USER_ID }),
+        ...(orgId ? { org_id: orgId } : {}),
+      });
+    }
+
+    if (pathname !== `/v3/organizations/${TEST_ORG_ID}/sessions`) {
+      return jsonResponse({}, HTTP_STATUS.SERVER_ERROR);
+    }
+
+    // Devin lists the organization and narrows it only when asked.
+    const requestedUser = searchParams.get("user_ids");
+    const updatedAfter = Number(searchParams.get("updated_after") ?? "0");
+    const first = Number(searchParams.get("first") ?? "100");
+    const after = Number(searchParams.get("after") ?? "0");
+    const visible = sessions
+      .filter((session) => !requestedUser || (session.userId ?? TEST_USER_ID) === requestedUser)
+      .filter((session) => seconds(session.updatedAt) >= updatedAfter);
+    const page = visible.slice(after, after + first);
+    return jsonResponse({
+      items: page.map(sessionPayload),
+      total: visible.length,
+      has_next_page: after + first < visible.length,
+      end_cursor: after + first < visible.length ? String(after + first) : null,
+    });
+  };
+  return { fetch, requests };
+}
+
+function adapterFor(
+  fetch: CloudFetch,
+  overrides: {
+    apiKey?: string | undefined;
+    readApiKey?: () => Promise<string | undefined>;
+    now?: () => number;
+    minimumRefreshIntervalMs?: number;
+    maximumObservedSessions?: number;
+  } = {},
+): DevinSessionAdapter {
+  const apiKey = "apiKey" in overrides ? overrides.apiKey : TEST_API_KEY;
+  return new DevinSessionAdapter({
+    readApiKey: overrides.readApiKey ?? (async () => apiKey),
+    baseUrl: TEST_BASE_URL,
+    fetch,
+    now: overrides.now ?? (() => TEST_TIME),
+    minimumRefreshIntervalMs: overrides.minimumRefreshIntervalMs ?? 0,
+    ...(overrides.maximumObservedSessions === undefined
+      ? {}
+      : { maximumObservedSessions: overrides.maximumObservedSessions }),
+  });
+}
+
+function workingSession(id: string, updatedAt: number): TestSession {
+  return { id, status: TEST_STATUS.RUNNING, detail: TEST_DETAIL.WORKING, updatedAt };
+}
+
+test("observes a working session and labels it the way Devin named it", async () => {
+  const api = fakeDevinApi([workingSession("devin-working", TEST_TIME - 30_000)]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.deepEqual(DEVIN_PROVIDER, { id: "devin", displayName: "Devin" });
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "devin-working");
+  assert.equal(observations[0]?.title, TEST_SESSION_TITLE);
+  assert.equal(observations[0]?.detail?.repository, "luke");
+  assert.equal(observations[0]?.detail?.change, TEST_PULL_REQUEST);
+  assert.equal(observations[0]?.detail?.link, "https://app.devin.ai/sessions/devin-working");
+  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
+  assert.equal(observations[0]?.observedAt, TEST_TIME - 30_000);
+  assert.equal(observations[0]?.controls, undefined);
+  // The session's structured output is shaped by its prompt, so it stays out.
+  assert.equal(JSON.stringify(observations).includes("SECRET_STRUCTURED_OUTPUT"), false);
+  // Devin is asked who the credential belongs to, then for that person's
+  // sessions since the observation window opened. Nothing else.
+  assert.deepEqual(
+    api.requests.map((request) => request.pathname),
+    ["/v3/self", `/v3/organizations/${TEST_ORG_ID}/sessions`],
+  );
+  assert.equal(
+    api.requests[1]?.search,
+    `?first=200&user_ids=${TEST_USER_ID}&updated_after=${seconds(TEST_TIME - 24 * 60 * 60 * 1000)}`,
+  );
+  assert.equal(
+    api.requests.every(
+      (request) => request.method === "GET" && request.authorization === `Bearer ${TEST_API_KEY}`,
+    ),
+    true,
+  );
+});
+
+test("asks Devin who the credential belongs to once and reuses the answer", async () => {
+  const api = fakeDevinApi([workingSession("devin-working", TEST_TIME - 1_000)]);
+  const adapter = adapterFor(api.fetch);
+
+  await adapter.observe();
+  await adapter.observe();
+
+  assert.deepEqual(
+    api.requests.map((request) => request.pathname),
+    [
+      "/v3/self",
+      `/v3/organizations/${TEST_ORG_ID}/sessions`,
+      `/v3/organizations/${TEST_ORG_ID}/sessions`,
+    ],
+  );
+});
+
+test("reports nothing for a service-user credential, which names no person", async () => {
+  // A service user is an organization's automation account. Every session it
+  // can reach belongs to somebody else, so there is nothing here to report.
+  const api = fakeDevinApi([workingSession("devin-working", TEST_TIME - 1_000)], {
+    principal: TEST_PRINCIPAL.SERVICE_USER,
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.deepEqual(observations, []);
+  assert.deepEqual(
+    api.requests.map((request) => request.pathname),
+    ["/v3/self"],
+  );
+});
+
+test("reports nothing for a token Devin places in no organization", async () => {
+  // Every v3 session list is org-scoped and the only route that could name an
+  // organization for a token is enterprise-admin, so there is nothing to read.
+  const api = fakeDevinApi([workingSession("devin-working", TEST_TIME - 1_000)], {
+    orgId: undefined,
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.deepEqual(observations, []);
+  assert.deepEqual(
+    api.requests.map((request) => request.pathname),
+    ["/v3/self"],
+  );
+});
+
+test("asks once about a credential it cannot observe as, not once a refresh", async () => {
+  // Asking again cannot change the answer while the credential stands, and a
+  // stored token Luke has no use for must not poll Devin forever.
+  for (const options of [{ principal: TEST_PRINCIPAL.SERVICE_USER }, { orgId: undefined }]) {
+    const api = fakeDevinApi([workingSession("devin-working", TEST_TIME - 1_000)], options);
+    const adapter = adapterFor(api.fetch);
+
+    await adapter.observe();
+    await adapter.observe();
+    await adapter.observe();
+
+    assert.deepEqual(
+      api.requests.map((request) => request.pathname),
+      ["/v3/self"],
+      JSON.stringify(options),
+    );
+  }
+});
+
+test("maps the states Devin reports onto states Luke can show", async () => {
+  const api = fakeDevinApi(
+    (
+      [
+        ["devin-working", TEST_STATUS.RUNNING, TEST_DETAIL.WORKING],
+        ["devin-waiting-user", TEST_STATUS.RUNNING, TEST_DETAIL.WAITING_FOR_USER],
+        ["devin-waiting-approval", TEST_STATUS.RUNNING, TEST_DETAIL.WAITING_FOR_APPROVAL],
+        ["devin-turn-over", TEST_STATUS.RUNNING, TEST_DETAIL.FINISHED],
+        ["devin-running-undetailed", TEST_STATUS.RUNNING, undefined],
+        ["devin-exited", TEST_STATUS.EXIT, TEST_DETAIL.FINISHED],
+        ["devin-idle-out", TEST_STATUS.SUSPENDED, TEST_DETAIL.INACTIVITY],
+        ["devin-out-of-credits", TEST_STATUS.SUSPENDED, TEST_DETAIL.OUT_OF_CREDITS],
+        ["devin-new", TEST_STATUS.NEW, undefined],
+        ["devin-claimed", TEST_STATUS.CLAIMED, undefined],
+        ["devin-resuming", TEST_STATUS.RESUMING, undefined],
+        ["devin-errored", TEST_STATUS.ERROR, undefined],
+        ["devin-later-state", "some_later_state", undefined],
+      ] as const
+    ).map(([id, status, detail], index) => ({
+      id,
+      status,
+      ...(detail ? { detail } : {}),
+      updatedAt: TEST_TIME - (index + 1) * 1_000,
+    })),
+  );
+
+  const observations = await adapterFor(api.fetch, { maximumObservedSessions: 20 }).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => [observation.providerSessionId, observation.status]),
+    [
+      ["devin-working", SESSION_STATUS.WORKING],
+      ["devin-waiting-user", SESSION_STATUS.WAITING],
+      ["devin-waiting-approval", SESSION_STATUS.WAITING],
+      // The turn ended but the machine is still up: the session is holding for
+      // whoever started it, which v1 could not distinguish at all.
+      ["devin-turn-over", SESSION_STATUS.WAITING],
+      ["devin-running-undetailed", SESSION_STATUS.WORKING],
+      ["devin-exited", SESSION_STATUS.COMPLETE],
+      // A suspended session can be resumed, so it is neither settled nor
+      // holding for anyone, whatever the reason it was suspended for.
+      ["devin-idle-out", SESSION_STATUS.UNKNOWN],
+      ["devin-out-of-credits", SESSION_STATUS.UNKNOWN],
+      ["devin-new", SESSION_STATUS.UNKNOWN],
+      ["devin-claimed", SESSION_STATUS.UNKNOWN],
+      ["devin-resuming", SESSION_STATUS.UNKNOWN],
+      ["devin-errored", SESSION_STATUS.ERROR],
+      ["devin-later-state", SESSION_STATUS.UNKNOWN],
+    ],
+  );
+});
+
+test("reports an archived session as complete whatever it was doing", async () => {
+  const api = fakeDevinApi([
+    { ...workingSession("devin-archived", TEST_TIME - 1_000), archived: true },
+  ]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations[0]?.status, SESSION_STATUS.COMPLETE);
+});
+
+test("keeps reporting a long turn as working, and a session that ended as complete", async () => {
+  // A state is stamped with the moment it was entered rather than with a
+  // heartbeat, so neither a turn that started an hour ago nor a session that
+  // ended an hour ago may be reported as anything else.
+  const startedAt = TEST_TIME - 60 * 60 * 1000;
+  const api = fakeDevinApi([
+    workingSession("devin-long-turn", startedAt),
+    { id: "devin-long-done", status: TEST_STATUS.EXIT, updatedAt: startedAt },
+  ]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.status),
+    [SESSION_STATUS.WORKING, SESSION_STATUS.COMPLETE],
+  );
+  assert.equal(observations[0]?.observedAt, startedAt);
+});
+
+test("stops calling a session that is holding for the user waiting once it goes stale", async () => {
+  const api = fakeDevinApi([
+    {
+      id: "devin-abandoned",
+      status: TEST_STATUS.RUNNING,
+      detail: TEST_DETAIL.WAITING_FOR_USER,
+      updatedAt: TEST_TIME - 2 * 60 * 60 * 1000,
+    },
+  ]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
+});
+
+test("reads a timestamp Devin reports in seconds as the moment it means", async () => {
+  // Devin types its timestamps as bare integers without naming the unit, so a
+  // session updated a minute ago must not read as one from 1970.
+  const api = fakeDevinApi([workingSession("devin-recent", TEST_TIME - 60_000)]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations[0]?.observedAt, TEST_TIME - 60_000);
+  // The window is asked for in the same unit, so a page cannot come back empty
+  // because Luke asked for sessions updated after the year 5138.
+  const requested = Number(
+    new URL(api.requests[1]?.search ?? "", TEST_BASE_URL).searchParams.get("updated_after"),
+  );
+  assert.ok(requested > 0 && requested < seconds(TEST_TIME));
+});
+
+test("ignores sessions untouched for longer than the maximum session age", async () => {
+  // The request already excludes them, so this covers a provider that answers
+  // more broadly than it was asked to.
+  const api = fakeDevinApi([workingSession("devin-last-week", TEST_TIME - 48 * 60 * 60 * 1000)]);
+  const unfiltered: CloudFetch = async (url, init) => {
+    const address = new URL(url);
+    address.searchParams.delete("updated_after");
+    return api.fetch(address.href, init);
+  };
+
+  assert.deepEqual(await adapterFor(unfiltered).observe(), []);
+});
+
+test("falls back to the repository its pull request is in when Devin named nothing", async () => {
+  const api = fakeDevinApi([
+    {
+      ...workingSession("devin-github", TEST_TIME - 1_000),
+      pullRequest: "https://github.com/reviewstage/sidecar/pull/7",
+    },
+    {
+      ...workingSession("devin-gitlab", TEST_TIME - 2_000),
+      pullRequest: "https://gitlab.com/reviewstage/group/sidecar-web/-/merge_requests/3",
+    },
+    {
+      ...workingSession("devin-bitbucket", TEST_TIME - 3_000),
+      pullRequest: "https://bitbucket.org/reviewstage/sidecar-native/pull-requests/9",
+      omitTitle: true,
+    },
+    {
+      ...workingSession("devin-unopened", TEST_TIME - 4_000),
+      omitPullRequest: true,
+      omitTitle: true,
+    },
+  ]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.detail?.repository),
+    ["sidecar", "sidecar-web", "sidecar-native", undefined],
+  );
+  // What Devin named it, then where the work landed, then neither.
+  assert.deepEqual(
+    observations.map((observation) => observation.title),
+    [TEST_SESSION_TITLE, TEST_SESSION_TITLE, "sidecar-native", "Cloud session"],
+  );
+});
+
+test("surfaces only the credential owner's work, however Devin answers the filter", async () => {
+  // The fake honours `user_ids`, so a teammate's session reaches the adapter
+  // only when the server-side filter is disregarded. It must survive neither
+  // route, and neither must a session attributed to nobody.
+  const api = fakeDevinApi([
+    workingSession("devin-mine", TEST_TIME - 1_000),
+    { ...workingSession("devin-theirs", TEST_TIME - 2_000), userId: TEST_TEAMMATE_ID },
+    { ...workingSession("devin-unattributed", TEST_TIME - 3_000), omitUser: true },
+  ]);
+  const unfiltered: CloudFetch = async (url, init) => {
+    const address = new URL(url);
+    address.searchParams.delete("user_ids");
+    return api.fetch(address.href, init);
+  };
+
+  const filtered = await adapterFor(api.fetch).observe();
+  const ignored = await adapterFor(unfiltered).observe();
+
+  assert.deepEqual(
+    filtered.map((observation) => observation.providerSessionId),
+    ["devin-mine"],
+  );
+  assert.deepEqual(
+    ignored.map((observation) => observation.providerSessionId),
+    ["devin-mine"],
+  );
+});
+
+test("bounds the sessions a single pass observes, keeping the freshest", async () => {
+  const api = fakeDevinApi([
+    workingSession("devin-oldest", TEST_TIME - 3_000),
+    workingSession("devin-newest", TEST_TIME - 1_000),
+    workingSession("devin-middle", TEST_TIME - 2_000),
+  ]);
+
+  const observations = await adapterFor(api.fetch, { maximumObservedSessions: 2 }).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.providerSessionId),
+    ["devin-newest", "devin-middle"],
+  );
+});
+
+test("drops a session it cannot place in time without losing the rest of the pass", async () => {
+  const fetch: CloudFetch = async (url) =>
+    new URL(url).pathname === "/v3/self"
+      ? jsonResponse({ principal_type: "pat_user", user_id: TEST_USER_ID, org_id: TEST_ORG_ID })
+      : jsonResponse({
+          items: [
+            { status: "running", user_id: TEST_USER_ID },
+            { session_id: "devin-undated", status: "running", user_id: TEST_USER_ID },
+            {
+              session_id: "devin-not-a-number",
+              status: "running",
+              user_id: TEST_USER_ID,
+              updated_at: "2026-08-13T02:44:00.000Z",
+            },
+            {
+              session_id: "devin-complete",
+              status: "running",
+              user_id: TEST_USER_ID,
+              updated_at: seconds(TEST_TIME - 1_000),
+            },
+          ],
+        });
+
+  const observations = await adapterFor(fetch).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.providerSessionId),
+    ["devin-complete"],
+  );
+});
+
+test("reports nothing and issues no request without an API key", async () => {
+  const api = fakeDevinApi([workingSession("devin-working", TEST_TIME - 1_000)]);
+
+  const observations = await adapterFor(api.fetch, { apiKey: undefined }).observe();
+
+  assert.deepEqual(observations, []);
+  assert.deepEqual(api.requests, []);
+});
+
+test("reuses the previous snapshot inside the minimum refresh interval", async () => {
+  const api = fakeDevinApi([workingSession("devin-working", TEST_TIME - 1_000)]);
+  let now = TEST_TIME;
+  const adapter = adapterFor(api.fetch, { now: () => now, minimumRefreshIntervalMs: 15_000 });
+
+  const first = await adapter.observe();
+  const requestsAfterFirstPass = api.requests.length;
+  now = TEST_TIME + 5_000;
+  const throttled = await adapter.observe();
+  const requestsAfterThrottledPass = api.requests.length;
+  now = TEST_TIME + 20_000;
+  const refreshed = await adapter.observe();
+
+  assert.equal(first.length, 1);
+  assert.deepEqual(throttled, first);
+  assert.equal(
+    requestsAfterThrottledPass,
+    requestsAfterFirstPass,
+    "throttled pass issued requests",
+  );
+  assert.ok(api.requests.length > requestsAfterThrottledPass, "refreshed pass issued no request");
+  assert.equal(refreshed.length, 1);
+});
+
+test("forgets who a replaced credential belonged to before reading as the new one", async () => {
+  const api = fakeDevinApi([workingSession("devin-working", TEST_TIME - 1_000)]);
+  let apiKey = TEST_API_KEY;
+  const adapter = adapterFor(api.fetch, {
+    readApiKey: async () => apiKey,
+    minimumRefreshIntervalMs: 60_000,
+  });
+
+  await adapter.observe();
+  apiKey = "cog_replacement-token";
+  const observations = await adapter.observe();
+
+  assert.equal(observations.length, 1);
+  // The identity is read again rather than carried over from the key it was
+  // read with, so no session can be reported as the wrong person's.
+  assert.deepEqual(
+    api.requests.map((request) => request.pathname),
+    [
+      "/v3/self",
+      `/v3/organizations/${TEST_ORG_ID}/sessions`,
+      "/v3/self",
+      `/v3/organizations/${TEST_ORG_ID}/sessions`,
+    ],
+  );
+  assert.equal(api.requests.at(-1)?.authorization, "Bearer cog_replacement-token");
+});
+
+test("clears observations when Devin rejects the credential", async () => {
+  const api = fakeDevinApi([workingSession("devin-working", TEST_TIME - 1_000)]);
+  let rejectRequests = false;
+  const gatedFetch: CloudFetch = async (url, init) =>
+    rejectRequests ? jsonResponse({}, HTTP_STATUS.UNAUTHORIZED) : api.fetch(url, init);
+  const adapter = adapterFor(gatedFetch);
+
+  const authorized = await adapter.observe();
+  rejectRequests = true;
+  const rejected = await adapter.observe();
+
+  assert.equal(authorized.length, 1);
+  assert.deepEqual(rejected, []);
+});
+
+test("keeps the previous snapshot when the list request fails transiently", async () => {
+  const api = fakeDevinApi([workingSession("devin-working", TEST_TIME - 1_000)]);
+  let failRequests = false;
+  const gatedFetch: CloudFetch = async (url, init) => {
+    if (failRequests) throw new Error("network unreachable");
+    return api.fetch(url, init);
+  };
+  const adapter = adapterFor(gatedFetch);
+
+  const observed = await adapter.observe();
+  failRequests = true;
+  const duringOutage = await adapter.observe();
+
+  assert.equal(observed.length, 1);
+  assert.deepEqual(duringOutage, observed);
+});

--- a/apps/desktop/tests/session-model.test.ts
+++ b/apps/desktop/tests/session-model.test.ts
@@ -119,12 +119,15 @@ test("the tally counts per state and per provider", () => {
     },
   );
   // Providers follow the order their most urgent session takes, so Cursor's
-  // working agent is listed ahead of Conductor's completed session.
+  // working agent is listed ahead of Conductor's completed session and Devin's
+  // suspended one. Five is one more than the wings hold, so the fixture also
+  // proves the remainder is counted rather than dropped.
   assert.deepEqual(tally.providers, [
-    { providerId: PROVIDER_ID.CLAUDE_CODE, provider: "Claude Code", total: 2, attention: 1 },
+    { providerId: PROVIDER_ID.CLAUDE_CODE, provider: "Claude Code", total: 1, attention: 1 },
     { providerId: PROVIDER_ID.CODEX, provider: "Codex", total: 1, attention: 0 },
     { providerId: PROVIDER_ID.CURSOR, provider: "Cursor", total: 1, attention: 0 },
     { providerId: PROVIDER_ID.CONDUCTOR, provider: "Conductor", total: 1, attention: 0 },
+    { providerId: PROVIDER_ID.DEVIN, provider: "Devin", total: 1, attention: 0 },
   ]);
 });
 

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -21,6 +21,7 @@ const TEST_ENVIRONMENT_VARIABLE = {
   API_TOKEN: "CONDUCTOR_API_TOKEN",
   FIRST_CLOUD_API_KEY: "FIRST_CLOUD_API_KEY",
   SECOND_CLOUD_API_KEY: "SECOND_CLOUD_API_KEY",
+  THIRD_CLOUD_API_KEY: "THIRD_CLOUD_API_KEY",
 } as const;
 
 /**
@@ -41,9 +42,22 @@ const SECOND_CLOUD_PROVIDER: CredentialProvider = {
   environmentVariables: [TEST_ENVIRONMENT_VARIABLE.SECOND_CLOUD_API_KEY],
 };
 
-const TEST_PROVIDERS = [FIRST_CLOUD_PROVIDER, SECOND_CLOUD_PROVIDER];
+/** Publishes a key format, which only some providers do. */
+const THIRD_CLOUD_PROVIDER: CredentialProvider = {
+  id: "third-cloud" as CredentialProviderId,
+  displayName: "Third Cloud",
+  hint: "Create a key in Third Cloud.",
+  environmentVariables: [TEST_ENVIRONMENT_VARIABLE.THIRD_CLOUD_API_KEY],
+  keyFormat: {
+    prefix: "current_",
+    rejection: "Third Cloud's current keys start with current_.",
+  },
+};
+
+const TEST_PROVIDERS = [FIRST_CLOUD_PROVIDER, SECOND_CLOUD_PROVIDER, THIRD_CLOUD_PROVIDER];
 const FIRST_CLOUD = FIRST_CLOUD_PROVIDER.id;
 const SECOND_CLOUD = SECOND_CLOUD_PROVIDER.id;
+const THIRD_CLOUD = THIRD_CLOUD_PROVIDER.id;
 
 /** Stands in for Electron's Keychain-backed `safeStorage`. */
 function testCipher(available = true): SecretCipher {
@@ -253,6 +267,50 @@ test("rejects a key that cannot be sent as an authorization header", async (t) =
   assert.match((await store.setApiKey(CONDUCTOR, "k".repeat(513))).reason ?? "", /too long/);
   assert.equal(await store.readApiKey(CONDUCTOR), undefined);
   await assert.rejects(() => readSettingsFile(directory), /ENOENT/);
+});
+
+test("holds a key only in the form its provider says it issues", async (t) => {
+  // A credential in a form the provider no longer accepts would be refused on
+  // the first request, and a key Luke cannot use is worth saying so about
+  // rather than storing and then going quiet.
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory, {
+    providers: TEST_PROVIDERS,
+    environment: { [TEST_ENVIRONMENT_VARIABLE.THIRD_CLOUD_API_KEY]: "legacy-third-cloud-key" },
+  });
+
+  const refused = await store.setApiKey(THIRD_CLOUD, "legacy-third-cloud-key");
+
+  assert.match(refused.reason ?? "", /start with current_/);
+  assert.equal(await store.readApiKey(THIRD_CLOUD), undefined);
+  // The same rule holds a key read from the environment, so a shell profile is
+  // not a way around it.
+  assert.equal(refused.settings.credentialSources[THIRD_CLOUD], CREDENTIAL_SOURCE.NONE);
+
+  const accepted = await store.setApiKey(THIRD_CLOUD, "current_third-cloud-key");
+  assert.equal(accepted.reason, undefined);
+  assert.equal(await store.readApiKey(THIRD_CLOUD), "current_third-cloud-key");
+  // A provider that publishes no format still takes whatever it issues.
+  assert.equal((await store.setApiKey(FIRST_CLOUD, "legacy-third-cloud-key")).reason, undefined);
+});
+
+test("stops honouring a stored key the moment its provider names a form it is not", async (t) => {
+  // The rule arrived after the key did, so the key was stored under an older
+  // build that had no format to hold it to.
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({ version: 2, apiKeys: { [THIRD_CLOUD]: sealed("legacy-third-cloud-key") } }),
+  );
+
+  const store = storeIn(directory, { providers: TEST_PROVIDERS });
+
+  assert.equal(await store.readApiKey(THIRD_CLOUD), undefined);
+  assert.equal(
+    (await store.snapshot()).credentialSources[THIRD_CLOUD],
+    CREDENTIAL_SOURCE.NONE,
+    "a key the provider no longer accepts must not read as connected",
+  );
 });
 
 test("refuses to store a key when encrypted storage is unavailable", async (t) => {

--- a/packages/sidecar-core/src/fixtures.ts
+++ b/packages/sidecar-core/src/fixtures.ts
@@ -75,16 +75,19 @@ const smokeFixture: FixtureSnapshot = {
       location: SESSION_LOCATION.CLOUD,
     },
     // A fifth session keeps every state and every provider mark visible in the
-    // one screenshot the visual evidence is reviewed from.
+    // one screenshot the visual evidence is reviewed from. It is also one more
+    // provider than the wings hold now that the face has the place nearest the
+    // housing, so the same screenshot proves the remainder is counted rather
+    // than dropped.
     {
-      id: "claude-observe",
-      title: "Watch the notch geometry adapter",
-      providerId: PROVIDER_ID.CLAUDE_CODE,
-      provider: "Claude Code",
-      detail: "Idle since the last display change",
-      context: "Claude Code · luke · main · claude-sonnet-5",
+      id: "devin-session",
+      title: "Watch a cloud session",
+      providerId: PROVIDER_ID.DEVIN,
+      provider: "Devin",
+      detail: "Suspended before it opened a pull request.",
+      context: "Devin · sidecar-native",
       state: SESSION_STATE.UNKNOWN,
-      location: SESSION_LOCATION.LOCAL,
+      location: SESSION_LOCATION.CLOUD,
     },
   ],
 };

--- a/packages/sidecar-core/src/providers.ts
+++ b/packages/sidecar-core/src/providers.ts
@@ -10,6 +10,7 @@ export const PROVIDER_ID = {
   CODEX: "codex",
   CONDUCTOR: "conductor",
   CURSOR: "cursor",
+  DEVIN: "devin",
 } as const;
 
 export type ProviderId = (typeof PROVIDER_ID)[keyof typeof PROVIDER_ID];


### PR DESCRIPTION
## Summary

Add a `DevinSessionAdapter` on `CloudSessionAdapter` (LUKE-59), so a Devin token
lets Luke observe cloud sessions the way it already observes Conductor
workspaces and Cursor agents. Devin's mark joins the registry and the smoke
fixture gains a Devin session.

- **Reads Devin's v3 API, not the v1 the ticket described.** v1 and v2 are
  [deprecated](https://docs.devin.ai/api-reference/authentication), cannot say
  who a credential belongs to for an ordinary user, and report only that a
  session is `blocked` — never that its turn has ended while the machine is
  still up. v3 answers all three.
- **Nothing is configured but the token.** Each pass begins with `GET /v3/self`,
  which names the principal behind it; the adapter takes `user_id` and `org_id`
  from that, narrows the list with `user_ids` inside the observation window, and
  re-checks `user_id` on every record on the way back — a filter Luke cannot see
  is not one it can answer for. The answer is cached either way, so a credential
  Luke cannot observe as costs one request rather than one every refresh.
- **A credential that is not a person's is refused.** Every current Devin token
  starts with `cog_`, whether it is a personal access token or a service user
  key, so a prefix cannot tell them apart — but `/v3/self` can, and a service
  user belongs to an organization rather than to anyone at this Mac. The prefix
  rule that remains rules out the legacy `apk_` keys of the API Luke does not
  read, with a reason rather than silence.
- **The settings row asks for what Devin actually issues.** A provider that
  declares a credential format now also says what that credential is called, so
  Devin's field reads *Personal access token* and links the **PATs** tab of the
  **Devin API** settings page. The previous link pointed at Settings · API keys —
  the page handing out the deprecated keys this adapter refuses, and the one
  Devin's own docs give under *Legacy authentication*. Every other provider is
  unchanged: with no format declared, the field still reads "API key".
- **Richer state than v1 could give.** A v3 session carries both its lifecycle
  (`status`) and what it is doing (`status_detail`), so `running` refines into
  working, waiting-for-user, waiting-for-approval, or turn-finished — the last
  three all being Luke's *waiting*. A session that errored takes `SESSION_STATUS.ERROR`;
  one that exited or was archived is complete; anything transitional or
  suspended is left unknown, since unlike a Cursor run that expired, a suspended
  Devin session can be resumed.
- **One request per pass after identity.** A session record carries its own
  state and timestamp, so there is no second call per session, and asking for
  one person's sessions since the window opened cannot fill a 200-item page.
  Devin types its timestamps as bare integers without naming the unit, so they
  are read in whichever unit they were sent and the window is *sent* in seconds
  — of the two ways to be wrong, seconds-read-as-milliseconds only over-fetches
  (the observed-at filter discards the excess), while the reverse would match
  nothing at all.

### Rebased onto a moved main

Eight PRs landed on `main` while this was open, two of which changed what this
adapter has to be. It is now a single commit replayed onto current `main`.

`#27` inverted a rule in `AGENTS.md`. It used to be that prompt-derived names
never reached a row; it now reads *"Label a session by what its provider named
it… Do not compose a sentence in an adapter; report the fields and let the
surface word them."* This adapter did the opposite of both. It now labels rows
from Devin's own `title` (falling back to the repository, then `Cloud session`),
and reports `detail: { repository, change, link, error }` instead of a composed
summary. `#27` also added `SESSION_STATUS.ERROR`, which is what a Devin `error`
session actually means, so it no longer lands in `unknown`.

Worth flagging: none of that was forced by the compiler — `detail` and
`location` are optional, so the pre-rewrite adapter still typechecked and would
have merged green while being the one adapter ignoring the new model.

`#34` stamps cloud location in `CloudSessionAdapter` itself, so the badge comes
for free. Two comments of mine that `#35` made false are corrected: the wings
hold **four** providers now that Luke's face has the place nearest the housing,
so five fixture providers prove the remainder is *counted* rather than exactly
fitting.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — **pass** (lint, typecheck,
  188 tests, build). 20 Devin adapter tests, plus coverage for the key-format
  rule in the settings store.
- macOS Electron verification (`./scripts/verify.sh`): run by the `macOS app and
  evidence` job, linked below. On the previous head I downloaded that artifact
  and inspected all four PNGs; the Devin row and mark read correctly and the
  peek showed every provider mark. **That was before the rewrite and before
  `#34`/`#35` changed the row and wing rendering, so the linked artifact for
  this commit wants a fresh look.**
- Renderer verification on Linux: used earlier to settle the mark's scale. Devin's
  published art leaves roughly a fifth of its box empty on every side, so it is
  drawn at `scale(1.22)`, which matched the macOS evidence.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31665243952/artifacts/9167678337) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31665243952)

- Commit: `9044dde7d1066e440b00a27687d39bf70214bd1a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- The ticket described the v1 endpoint, its `status_enum` mapping, and an
  account-email filter, suggesting `/v1/me` as a source for the email. There is
  no `/v1/me`; v1's nearest identity endpoint is `GET /v2/enterprise/self`, and
  [the whole v2 API requires the Enterprise Admin role](https://docs.devin.ai/api-reference/v2/overview).
  An earlier revision of this PR added a settings field for that email, which
  moving to v3 removed the need for entirely.
- The ticket mapped `expired → unknown`. v3 has no `expired`; the equivalent is
  `suspended`, mapped to unknown for the same reason.
- A PAT with no `org_id` — which Devin types as nullable — leaves the row
  connected with no sessions. Every v3 session list is org-scoped and the only
  route that could name an organization for a token is enterprise-admin, so
  reporting nothing is forced rather than chosen. It now costs one request
  rather than an endless poll. Raised and resolved on an earlier review thread.
- Unverified: the flat query-param form (`?first=200&user_ids=…`) is inferred
  from the migration guide's pagination example, since the OpenAPI renders the
  filters as a single `qs` object. If that is wrong the filters are ignored —
  the per-record `user_id` check still keeps the output correct, which is why it
  is there — but it wants one run against a real `cog_` token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
