### PR TITLE
fix(notch): flare the shape into the top edge the way the housing does

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,13 @@ it.
 The surface is opaque black in every state and shaped like the housing it sits
 beside: the convex bottom corners and the concave flare where its sides meet
 the top edge are both derived from the reported notch inset, at the ratios
-measured off the hardware (0.348 and 0.094 of its height). The panel keeps that
-flare, so all three states meet the top edge the same way. Depth comes from a
-shadow and a hairline edge rather than from letting anything show through. A
-display with no housing to blend into gets a free-floating pill instead.
+measured off photographs of the hardware (0.348 and 0.170 of its height). The
+panel's corners are its own rather than the housing's, so its flare keeps the
+proportion between the two rather than the size — 0.489 of whatever corner it
+turns — and all three states still meet the top edge the same way. Depth comes
+from a shadow and a hairline edge rather than from letting anything show
+through. A display with no housing to blend into gets a free-floating pill
+instead.
 
 The panel's shadow arrives once the shape has settled, so a blurred shadow is
 never repainted mid-spring; the peek's is small enough to ride along with it. A

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -153,12 +153,24 @@
   --capsule-width: calc(var(--notch-housing-width) + 72px);
   --capsule-height: max(var(--notch-top-inset), 32px);
   --peek-width: calc(var(--notch-housing-width) + 248px);
-  /* Measured off the hardware rather than guessed: the housing's own corners are
-     a convex 0.348 of its height, and where its sides meet the top edge it
-     flares outward on a concave 0.094. Deriving both from the reported inset
-     keeps the capsule matching whatever notch it is sitting beside. */
+  /* Measured off photographs of the hardware rather than guessed: the housing's
+     own corners are a convex 0.348 of its height, and where its sides meet the
+     top edge it flares outward on a concave 0.170 — about half the bottom
+     corner, not the sixth of it this was drawn at, which was small enough to
+     read as a straight edge with a chamfer. Deriving both from the reported
+     inset keeps the capsule matching whatever notch it is sitting beside. */
   --notch-convex-radius: calc(var(--capsule-height) * 0.348);
-  --notch-concave-radius: calc(var(--capsule-height) * 0.094);
+  --notch-concave-radius: calc(var(--capsule-height) * 0.17);
+}
+
+/* The panel's corners are `--panel-radius`, not the housing's, and a flare
+   belongs to the corner it turns into rather than to the notch: beside the
+   housing it has to disappear into one, and at the panel's size it has to turn
+   a corner more than twice as round. So it keeps the proportion the hardware
+   holds between the two — 0.170 against 0.348 — and grows with the corner
+   instead of staying the size the housing wanted. */
+.app-stage[data-presentation="panel"] {
+  --notch-concave-radius: calc(var(--panel-radius) * 0.489);
 }
 
 * {
@@ -265,25 +277,43 @@ button:disabled {
   width: var(--notch-concave-radius);
   height: var(--notch-concave-radius);
   opacity: 1;
-  transition: opacity var(--duration-quick) var(--motion-exit);
+  /* The flare turns the surface's own corner, so it travels on the surface's
+     spring and waits out `--duration-exit` with it. Three properties here, and
+     the panel rule below overrides the delays by position. */
+  transition:
+    width var(--duration-shape) var(--spring) var(--duration-exit),
+    height var(--duration-shape) var(--spring) var(--duration-exit),
+    opacity var(--duration-quick) var(--motion-exit);
 }
 
+/* Sized in percentages of the element rather than in the radius the element is
+   already sized by, so a growing flare is a box resizing under a fixed gradient
+   instead of a gradient that has to be interpolated on every frame. The last
+   half-pixel is a feather: a hard stop inside a gradient is not antialiased, and
+   at the panel's radius the stair-steps on the arc would be plain. */
 .app-stage[data-notch="true"] .panel-surface::before {
   right: 100%;
   background: radial-gradient(
-    circle at 0 100%,
-    transparent var(--notch-concave-radius),
-    var(--surface-fill) var(--notch-concave-radius)
+    ellipse 100% 100% at 0 100%,
+    transparent calc(100% - 0.5px),
+    var(--surface-fill) 100%
   );
 }
 
 .app-stage[data-notch="true"] .panel-surface::after {
   left: 100%;
   background: radial-gradient(
-    circle at 100% 100%,
-    transparent var(--notch-concave-radius),
-    var(--surface-fill) var(--notch-concave-radius)
+    ellipse 100% 100% at 100% 100%,
+    transparent calc(100% - 0.5px),
+    var(--surface-fill) 100%
   );
+}
+
+/* Growing, the flare leads with the surface rather than waiting for content to
+   leave; shrinking, the base rule's delay applies and the two close together. */
+.app-stage[data-notch="true"][data-presentation="panel"] .panel-surface::before,
+.app-stage[data-notch="true"][data-presentation="panel"] .panel-surface::after {
+  transition-delay: 0s, 0s, 0s;
 }
 
 .app-stage[data-presentation="peek"] .panel-surface,


### PR DESCRIPTION
## Summary

The concave flare where the surface meets the top edge of the screen was drawn
at **0.094** of the notch's height — about 3pt beside a 38pt housing, which
reads as a chamfer on a straight edge rather than as the shape turning into the
screen's top edge. It is now **0.170**, measured off photographs of the
hardware, and the panel gets a flare sized for its own corner instead of the
housing's.

**What changed**

- `--notch-concave-radius` is `0.094 → 0.170` of the notch's height. Collapsed
  and peek now flare the way the housing beside them does.
- The panel's corners are `--panel-radius`, not the housing's, so a flare sized
  for the housing is the wrong flare for it. It now keeps the proportion the
  hardware holds between the two — **0.489 of whatever corner it turns** —
  giving the panel's 30px corner a 15px flare, and it travels on the surface's
  spring so the corner and the flare into it move as one shape.
- The flare's gradient is sized in percentages of the element it fills rather
  than in the radius that element is already sized by, so growing it is a box
  resizing under a fixed gradient rather than a gradient interpolated on every
  frame. Its arc takes a half-pixel feather: a hard stop inside a gradient is
  not antialiased, and at fifteen pixels the stair-steps showed.
- The convex bottom corners are **unchanged**. They measured 0.320 against the
  0.348 they are already drawn at — under a pixel at any notch size — so they
  stand.

## Where 0.170 comes from

Two Creative-Commons photographs of a 16-inch MacBook Pro's cutout
([one](https://commons.wikimedia.org/wiki/File:Notch_of_Macbook_Pro_16_inti_model_-_1.jpg),
[two](https://commons.wikimedia.org/wiki/File:Notch_of_Macbook_Pro_16_inti_model_-_2.jpg)),
shot at different angles against desktops with no exposure in common. Each was
deskewed against the display's own top edge; the two straight edges every corner
joins were fitted over long runs, and the boundary probed once along the
45° diagonal from where those lines cross — a circular corner of radius `r` sits
exactly `r(√2−1)` from that crossing, so one probe gives the radius without ever
having to decide where a tangent ends.

| corner | photo 1 left | photo 1 right | photo 2 left | photo 2 right | mean |
| --- | --- | --- | --- | --- | --- |
| concave flare | 0.158 | 0.162 | 0.197 | 0.162 | **0.170** |
| convex base | 0.305 | 0.312 | 0.334 | 0.329 | **0.320** |

All four corners of both photographs agree within a fifth of a point. Fractions
are of the notch's own height, because `safeAreaInsets.top` is the only
dimension macOS reports about the cutout.

The measured arcs, drawn back onto the photograph they came from:

![Concave flare measured against the hardware](https://raw.githubusercontent.com/ReviewStage/luke/pr-assets/pr-26/hardware-flare.png)

![Convex bottom corner measured against the hardware](https://raw.githubusercontent.com/ReviewStage/luke/pr-assets/pr-26/hardware-base.png)

For a second opinion, the two most-used open-source notch apps both draw the
compact shape at a `(6, 14)` top/bottom radius against a 32pt notch —
[`boring.notch`](https://github.com/TheBoredTeam/boring.notch/blob/main/boringNotch/sizing/matters.swift)
and
[`DynamicNotchKit`](https://github.com/MrKai77/DynamicNotchKit/blob/main/Sources/DynamicNotchKit/Views/NotchView.swift) —
and both grow the flare when opened, which is what the panel now does.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — **pass**
- macOS Electron verification (`./scripts/verify.sh`): **pass**, run on a 16-inch
  MacBook Pro (macOS 26.3, 3456×2234). Repository contract checks, lint,
  typecheck, 94 desktop tests, build, package, and all four evidence captures.

### Collapsed and peek — beside the housing

Before, after, and the hardware at the same scale. One notch pixel of the
photograph is scaled to one rendered pixel, so the three shoulders are directly
comparable.

![Collapsed flare, before and after, against the hardware](https://raw.githubusercontent.com/ReviewStage/luke/pr-assets/pr-26/flare-collapsed.png)

![Peek flare, before and after, against the hardware](https://raw.githubusercontent.com/ReviewStage/luke/pr-assets/pr-26/flare-peek.png)

![Collapsed and peek shapes, before and after](https://raw.githubusercontent.com/ReviewStage/luke/pr-assets/pr-26/states-compact.png)

### Expanded — its own corner

![Expanded flare, before and after](https://raw.githubusercontent.com/ReviewStage/luke/pr-assets/pr-26/flare-expanded.png)

![Expanded panel, before and after](https://raw.githubusercontent.com/ReviewStage/luke/pr-assets/pr-26/states-expanded.png)

### Rendered geometry, measured

Probing the macOS build's own evidence PNGs for how far the black reaches past
the surface's edge at each depth. A circular flare of radius `r` reaches
`r − √(2ry − y²)` at depth `y`, which is what these are:

| state | depth 0pt | 1pt | 4pt | 10pt | 12pt | closes at |
| --- | --- | --- | --- | --- | --- | --- |
| collapsed / peek | 4.5pt | 2.5pt | 0.5pt | — | — | ~6.5pt |
| expanded | 12.0pt | 8.5pt | 4.5pt | 0.5pt | 0.0pt | ~14.7pt |

Predicted for a 38pt fixture notch: 6.46pt collapsed, 14.67pt expanded.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31660446259/artifacts/9165991358) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31660446259)

- Commit: `7bedc01622d346caf426219f8e28bf50481cd8f9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed` — the packaged fixture build was
  launched on the 16-inch MacBook Pro and ran, but `screencapture` driven from a
  shell on that machine returns the desktop and menu bar without other apps'
  windows, so the panel could not be captured over the real housing. Granting
  Screen Recording to the invoking process, or one manual `⌘⇧4`, would close
  this out.
- Device/display configuration: 16-inch MacBook Pro, macOS 26.3, built-in Liquid
  Retina XDR at 3456×2234 (notched)

## Notes

- The `before`/`after` app screenshots above were captured from the real Electron
  build under Xvfb in the cloud sandbox so the two could be produced from the
  same commit pair; the `verify.sh` run above is the macOS one, and its
  evidence PNGs are what the rendered-geometry table measures.
- Screenshots live on the `pr-assets` branch under `pr-26/`, following the
  existing convention there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

