### PR TITLE
fix(settings): drop the "Not connected" label the Connect button already gives

### DIFF
--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -38,10 +38,10 @@ const MICROPHONE_STATUS_LABEL: Record<MicrophoneStatus, string> = {
   unknown: "Unknown",
 };
 
-/* What the check beside the name cannot say on its own. A key kept here needs
-   no words at all: the check is the whole message. */
+/* What nothing else on the line can say on its own. A key kept here needs no
+   words at all — the check is the whole message — and no key at all is already
+   said by the Connect button standing where the check would be. */
 const CREDENTIAL_STATUS: Partial<Record<CredentialSource, string>> = {
-  [CREDENTIAL_SOURCE.NONE]: "Not connected",
   [CREDENTIAL_SOURCE.ENVIRONMENT]: "From environment",
 };
 
@@ -113,9 +113,9 @@ function ProviderCredential({
           <span className="credential-name">{provider.displayName}</span>
           {connected ? <CheckIcon /> : null}
         </span>
-        {/* The check already says connected, so the words are kept for what it
-            cannot say: not connected at all, or connected from the environment
-            rather than from a key kept here. */}
+        {/* The check says connected and Connect says the opposite, so the words
+            are kept for the one thing neither can say: connected from the
+            environment rather than from a key kept here. */}
         {status ? <span className="credential-status">{status}</span> : null}
         <span className="settings-actions">
           {stored ? (


### PR DESCRIPTION
## Summary

- A provider with no key stated the same fact twice on one line: a `Not connected`
  caption beside a `Connect` button. The caption goes. The button is the one that
  also says what to do about it, so the row is left with a mark, a name, and the
  control — and an unconfigured settings tab reads as two things to press rather
  than as two things to press and two labels to read.
- `From environment` stays. It is the one source nothing else on the line can
  express: the check says connected and `Connect` says the opposite, but neither
  can say connected *from a variable* rather than from a key kept here. A stored
  key still says nothing at all, because the check is the whole message.
- `CREDENTIAL_STATUS` is down to the single entry that survives, and the two
  comments that explained the removed label now explain what the line still says.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — **pass** (repository contract
  checks, Biome across 119 files with no fixes, typecheck, 94 desktop tests,
  33 sidecar-core tests, 5 harness tests, and both builds)
- macOS Electron verification (`./scripts/verify.sh`): `not run` locally — this
  workspace is a Linux cloud sandbox with no macOS host. The macOS CI job runs it
  on this PR and links its evidence below.

### Settings tab, before and after

Appearance-only change, so the evidence is visual. Both frames are the renderer
mounted against the same fixture the capture runs use — a 38pt inset, a 210pt
housing, and the `smoke` session fixture — photographed in Chromium off the same
harness, so the only difference between them is this commit. Each frame carries
both providers, covering all three credential sources: no key, a key stored here,
and a key read from the environment.

**Before** — `Not connected` repeats what `Connect` beside it already says:

![Settings tab before: each unconfigured provider carries both a "Not connected" caption and a Connect button](https://raw.githubusercontent.com/ReviewStage/luke/pr-assets/pr-28/settings-before.png)

**After** — the caption is gone; `From environment` and the stored-key row are
untouched:

![Settings tab after: the unconfigured providers carry only the Connect button, and "From environment" is unchanged](https://raw.githubusercontent.com/ReviewStage/luke/pr-assets/pr-28/settings-after.png)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31661403852/artifacts/9166315508) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31661403852)

- Commit: `b8dc1090f70a9dca0a2dc08bd3af92cf8b9add14`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` — the change is a line of copy on
  the settings tab, which the deterministic evidence above renders at both states
- Physical-notch check: `not performed` — nothing here touches the drawn shape
- Device/display configuration: `not recorded`

## Notes

- The automated macOS evidence photographs the sessions tab, so it will not show
  this change; the before/after frames above are the coverage for it.
- Blockers or follow-up verification: None
