### PR TITLE
chore(desktop): prepare v0.1.0 macOS packaging

### DIFF
--- a/apps/desktop/native/macos/entitlements.plist
+++ b/apps/desktop/native/macos/entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+</dict>
+</plist>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luke/desktop",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "description": "Luke desktop application",
   "main": "dist/main.js",

--- a/apps/desktop/scripts/build-native.mjs
+++ b/apps/desktop/scripts/build-native.mjs
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { swiftCompilerArguments } from "./package-config.mjs";
 
 if (process.platform !== "darwin") {
   process.stdout.write("Skipping the macOS screen-geometry helper on this platform.\n");
@@ -15,11 +16,7 @@ const outputDirectory = path.join(appRoot, ".build", "native");
 const output = path.join(outputDirectory, "mac-screen-geometry");
 
 fs.mkdirSync(outputDirectory, { recursive: true });
-const result = spawnSync(
-  "xcrun",
-  ["swiftc", "-parse-as-library", "-framework", "AppKit", source, "-o", output],
-  { stdio: "inherit" },
-);
+const result = spawnSync("xcrun", swiftCompilerArguments(source, output), { stdio: "inherit" });
 
 if (result.error) throw result.error;
 if (result.status !== 0) {

--- a/apps/desktop/scripts/package-config.mjs
+++ b/apps/desktop/scripts/package-config.mjs
@@ -1,0 +1,82 @@
+import { PACKAGED_ARCHITECTURE, packageIgnorePatterns } from "./package-layout.mjs";
+
+export { PACKAGED_ARCHITECTURE };
+
+export const MACOS_DEPLOYMENT_TARGET = "14.0";
+export const SWIFT_TARGET_TRIPLE = `${PACKAGED_ARCHITECTURE}-apple-macos${MACOS_DEPLOYMENT_TARGET}`;
+export const LICENSE_RESOURCE_NAME = "LUKE-LICENSE.txt";
+export const MICROPHONE_USAGE_DESCRIPTION =
+  "Luke uses microphone input to display live audio activity. Audio is processed locally and is not recorded or uploaded.";
+export const SIGNING_MODE = {
+  AD_HOC: "ad-hoc",
+  DEVELOPER_ID: "developer-id",
+};
+
+export function swiftCompilerArguments(source, output) {
+  return [
+    "swiftc",
+    "-parse-as-library",
+    "-target",
+    SWIFT_TARGET_TRIPLE,
+    "-framework",
+    "AppKit",
+    source,
+    "-o",
+    output,
+  ];
+}
+
+export function resolveSigningMode(env) {
+  const identity =
+    typeof env.LUKE_CODESIGN_IDENTITY === "string" ? env.LUKE_CODESIGN_IDENTITY.trim() : "";
+  return identity ? { mode: SIGNING_MODE.DEVELOPER_ID, identity } : { mode: SIGNING_MODE.AD_HOC };
+}
+
+export function createPackagerOptions({
+  appRoot,
+  outputRoot,
+  helperPath,
+  licensePath,
+  entitlementsPath,
+  signing,
+  version,
+}) {
+  const options = {
+    dir: appRoot,
+    out: outputRoot,
+    name: "Luke",
+    executableName: "Luke",
+    appBundleId: "dev.reviewstage.luke",
+    appCategoryType: "public.app-category.developer-tools",
+    platform: "darwin",
+    arch: PACKAGED_ARCHITECTURE,
+    appVersion: version,
+    asar: true,
+    overwrite: true,
+    prune: false,
+    extraResource: [helperPath, licensePath],
+    extendInfo: {
+      CFBundleDisplayName: "Luke",
+      LSMinimumSystemVersion: MACOS_DEPLOYMENT_TARGET,
+      LSUIElement: true,
+      NSMicrophoneUsageDescription: MICROPHONE_USAGE_DESCRIPTION,
+      NSPrefersDisplaySafeAreaCompatibilityMode: false,
+    },
+    ignore: packageIgnorePatterns,
+  };
+
+  if (signing.mode === SIGNING_MODE.DEVELOPER_ID) {
+    return {
+      ...options,
+      osxSign: {
+        identity: signing.identity,
+        optionsForFile: () => ({
+          hardenedRuntime: true,
+          entitlements: entitlementsPath,
+        }),
+      },
+    };
+  }
+
+  return options;
+}

--- a/apps/desktop/scripts/package-layout.mjs
+++ b/apps/desktop/scripts/package-layout.mjs
@@ -1,5 +1,6 @@
 import path from "node:path";
-import process from "node:process";
+
+export const PACKAGED_ARCHITECTURE = "arm64";
 
 export const packageIgnorePatterns = [
   /^\/(?:\.build|native|node_modules|out|scripts|src|tests)(?:$|\/)/,
@@ -7,7 +8,7 @@ export const packageIgnorePatterns = [
   /\.map$/,
 ];
 
-export function packagedAppExecutable(repoRoot, architecture = process.arch) {
+export function packagedAppExecutable(repoRoot, architecture = PACKAGED_ARCHITECTURE) {
   return path.join(
     repoRoot,
     "apps",

--- a/apps/desktop/scripts/package.mjs
+++ b/apps/desktop/scripts/package.mjs
@@ -3,7 +3,12 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { packager } from "@electron/packager";
-import { packageIgnorePatterns } from "./package-layout.mjs";
+import {
+  createPackagerOptions,
+  LICENSE_RESOURCE_NAME,
+  resolveSigningMode,
+  SIGNING_MODE,
+} from "./package-config.mjs";
 
 if (process.platform !== "darwin") {
   throw new Error("Packaging Luke requires macOS");
@@ -11,45 +16,47 @@ if (process.platform !== "darwin") {
 
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const appRoot = path.resolve(scriptDirectory, "..");
+const repoRoot = path.resolve(appRoot, "../..");
 const outputRoot = path.join(appRoot, "out");
 const helperPath = path.join(appRoot, ".build", "native", "mac-screen-geometry");
+const licensePath = path.join(appRoot, ".build", LICENSE_RESOURCE_NAME);
+const entitlementsPath = path.join(appRoot, "native", "macos", "entitlements.plist");
+const desktopPackage = JSON.parse(fs.readFileSync(path.join(appRoot, "package.json"), "utf8"));
+const signing = resolveSigningMode(process.env);
 
 if (!fs.existsSync(helperPath)) {
   throw new Error(`macOS screen-geometry helper is missing: ${helperPath}`);
 }
 
+fs.mkdirSync(path.dirname(licensePath), { recursive: true });
+fs.copyFileSync(path.join(repoRoot, "LICENSE"), licensePath);
 fs.rmSync(outputRoot, { recursive: true, force: true });
-const appPaths = await packager({
-  dir: appRoot,
-  out: outputRoot,
-  name: "Luke",
-  executableName: "Luke",
-  appBundleId: "dev.reviewstage.luke",
-  appCategoryType: "public.app-category.developer-tools",
-  platform: "darwin",
-  arch: process.arch,
-  asar: true,
-  overwrite: true,
-  prune: false,
-  extraResource: [helperPath],
-  extendInfo: {
-    CFBundleDisplayName: "Luke",
-    LSUIElement: true,
-    NSMicrophoneUsageDescription:
-      "Luke uses microphone input when you press to talk. Audio processing stays in the active voice session.",
-    NSPrefersDisplaySafeAreaCompatibilityMode: false,
-  },
-  ignore: packageIgnorePatterns,
-});
+const appPaths = await packager(
+  createPackagerOptions({
+    appRoot,
+    outputRoot,
+    helperPath,
+    licensePath,
+    entitlementsPath,
+    signing,
+    version: desktopPackage.version,
+  }),
+);
 
 const packageRoot = appPaths[0];
 if (!packageRoot) throw new Error("Electron Packager did not return an output path");
 const appPath = path.join(packageRoot, "Luke.app");
 if (!fs.existsSync(appPath)) throw new Error(`Packaged app was not found: ${appPath}`);
+const packagedLicensePath = path.join(appPath, "Contents", "Resources", LICENSE_RESOURCE_NAME);
+if (!fs.existsSync(packagedLicensePath)) {
+  throw new Error(`Packaged app is missing the Luke license: ${packagedLicensePath}`);
+}
 
-execFileSync("codesign", ["--force", "--deep", "--sign", "-", appPath], {
-  stdio: "inherit",
-});
+if (signing.mode === SIGNING_MODE.AD_HOC) {
+  execFileSync("codesign", ["--force", "--deep", "--sign", "-", appPath], {
+    stdio: "inherit",
+  });
+}
 execFileSync("codesign", ["--verify", "--deep", "--strict", appPath], {
   stdio: "inherit",
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luke/web",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "description": "Luke landing page",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luke",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "description": "A notch-attached desktop sidecar for coding-agent sessions",
   "packageManager": "pnpm@9.15.0",

--- a/packages/sidecar-core/package.json
+++ b/packages/sidecar-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/core",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": "./src/index.ts",

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  createPackagerOptions,
+  LICENSE_RESOURCE_NAME,
+  MACOS_DEPLOYMENT_TARGET,
+  MICROPHONE_USAGE_DESCRIPTION,
+  PACKAGED_ARCHITECTURE,
+  resolveSigningMode,
+  SIGNING_MODE,
+  SWIFT_TARGET_TRIPLE,
+  swiftCompilerArguments,
+} from "../apps/desktop/scripts/package-config.mjs";
+import { packagedAppExecutable } from "../apps/desktop/scripts/package-layout.mjs";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDirectory, "..");
+const entitlementsPath = path.join(
+  repoRoot,
+  "apps",
+  "desktop",
+  "native",
+  "macos",
+  "entitlements.plist",
+);
+
+function packagerOptions(signing = resolveSigningMode({})) {
+  return createPackagerOptions({
+    appRoot: "/repo/apps/desktop",
+    outputRoot: "/repo/apps/desktop/out",
+    helperPath: "/repo/apps/desktop/.build/native/mac-screen-geometry",
+    licensePath: `/repo/apps/desktop/.build/${LICENSE_RESOURCE_NAME}`,
+    entitlementsPath,
+    signing,
+    version: "0.1.0",
+  });
+}
+
+test("workspace package versions agree on v0.1.0", () => {
+  const packagePaths = [
+    "package.json",
+    "apps/desktop/package.json",
+    "apps/web/package.json",
+    "packages/sidecar-core/package.json",
+  ];
+  const versions = packagePaths.map((packagePath) =>
+    JSON.parse(fs.readFileSync(path.join(repoRoot, packagePath), "utf8")),
+  );
+
+  assert.deepEqual(
+    versions.map(({ version }) => version),
+    packagePaths.map(() => "0.1.0"),
+  );
+});
+
+test("packaging is pinned to Apple Silicon", () => {
+  const options = packagerOptions();
+
+  assert.equal(options.platform, "darwin");
+  assert.equal(options.arch, PACKAGED_ARCHITECTURE);
+  assert.equal(PACKAGED_ARCHITECTURE, "arm64");
+  assert.equal(
+    packagedAppExecutable("/repo"),
+    path.join(
+      "/repo",
+      "apps",
+      "desktop",
+      "out",
+      "Luke-darwin-arm64",
+      "Luke.app",
+      "Contents",
+      "MacOS",
+      "Luke",
+    ),
+  );
+});
+
+test("packaging declares the macOS deployment target", () => {
+  const options = packagerOptions();
+  const compilerArguments = swiftCompilerArguments("source.swift", "helper");
+
+  assert.equal(MACOS_DEPLOYMENT_TARGET, "14.0");
+  assert.equal(SWIFT_TARGET_TRIPLE, "arm64-apple-macos14.0");
+  assert.equal(options.extendInfo.LSMinimumSystemVersion, MACOS_DEPLOYMENT_TARGET);
+  assert.deepEqual(compilerArguments.slice(0, 4), [
+    "swiftc",
+    "-parse-as-library",
+    "-target",
+    SWIFT_TARGET_TRIPLE,
+  ]);
+});
+
+test("packaging includes the Luke license and approved microphone description", () => {
+  const options = packagerOptions();
+
+  assert.equal(LICENSE_RESOURCE_NAME, "LUKE-LICENSE.txt");
+  assert.equal(
+    options.extraResource.some((resourcePath) => resourcePath.endsWith(LICENSE_RESOURCE_NAME)),
+    true,
+  );
+  assert.equal(
+    options.extendInfo.NSMicrophoneUsageDescription,
+    "Luke uses microphone input to display live audio activity. Audio is processed locally and is not recorded or uploaded.",
+  );
+  assert.equal(options.extendInfo.NSMicrophoneUsageDescription, MICROPHONE_USAGE_DESCRIPTION);
+});
+
+test("signing configuration separates ad-hoc and Developer ID modes", () => {
+  const adHocSigning = resolveSigningMode({});
+  assert.deepEqual(adHocSigning, { mode: SIGNING_MODE.AD_HOC });
+  assert.equal("osxSign" in packagerOptions(adHocSigning), false);
+
+  const identity = "Developer ID Application: X (TEAM)";
+  const developerIdSigning = resolveSigningMode({ LUKE_CODESIGN_IDENTITY: identity });
+  const developerIdOptions = packagerOptions(developerIdSigning);
+  assert.deepEqual(developerIdSigning, { mode: SIGNING_MODE.DEVELOPER_ID, identity });
+  assert.equal(developerIdOptions.osxSign.identity, identity);
+  assert.deepEqual(developerIdOptions.osxSign.optionsForFile(), {
+    hardenedRuntime: true,
+    entitlements: entitlementsPath,
+  });
+});
+
+test("release entitlements allow microphone input", () => {
+  const entitlements = fs.readFileSync(entitlementsPath, "utf8");
+  assert.match(entitlements, /<key>com\.apple\.security\.device\.audio-input<\/key>/);
+});


### PR DESCRIPTION
## Summary

- Prepare Luke v0.1.0 as an Apple Silicon macOS app with a macOS 14 deployment target, deterministic packaging architecture, updated microphone disclosure, and bundled license.
- Add Developer ID hardened-runtime signing configuration and portable regression tests for versions, architecture, minimum OS, resources, and signing boundaries.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed
- macOS Electron verification (`./scripts/verify.sh`): passed

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31662258657/artifacts/9166603100) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31662258657)

- Commit: `fb3c06eb78a2cd46a307ad8e4a5eb35396901379`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: Developer ID signing is unit-tested but was not exercised with a real signing identity.
