### PR TITLE
feat(LUKE-65): observe Cursor sessions running on this machine

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -9,6 +9,12 @@ the current implementation; it is not a promise about third-party services.
   read-only, and inspects them in memory.
 - For Codex, Luke opens the local SQLite state database in read-only mode and
   reads the recent rollout logs named by its thread records.
+- For the Cursor agents running on this machine, Luke finds recent transcripts,
+  opens bounded tails read-only, and reads only the markers around a turn — its
+  end and how it ended. It does not read message content, and reports the fact
+  of a failed turn rather than the reason Cursor recorded for it. A session is
+  labelled by the folder it runs in, which Luke reads from Cursor's own record
+  of that folder, not from the chat's generated name.
 
 Luke processes bounded fields needed to identify and display a session:
 provider and session identifiers, provider-generated titles, the workspace
@@ -23,9 +29,11 @@ memory for the local display. Luke does not control provider sessions.
 
 ## Optional cloud-provider reads
 
-Conductor and Cursor have no local session state for Luke to observe. Without a
-key for one of those providers, Luke sends that provider no request and reports
-none of its sessions.
+Conductor has no local session state for Luke to observe, and neither do
+Cursor's cloud agents. Without a key for one of those providers, Luke sends that
+provider no request and reports none of its sessions; the Cursor sessions
+running on this machine are read from disk and are unaffected by whether a
+Cursor key exists.
 
 When a key is supplied, Luke sends it as a bearer credential to that provider
 and issues authenticated `GET` requests only:

--- a/README.md
+++ b/README.md
@@ -15,20 +15,23 @@ Download published builds from [GitHub Releases](https://github.com/ReviewStage/
 - Claude Code — reads local session state; no provider credential required
 - Codex — reads local session state; no provider credential required
 - Conductor — reads cloud session metadata after you supply a Conductor API key
-- Cursor — reads cloud agent metadata after you supply a Cursor API key
+- Cursor — reads local session state for the agents running on this machine,
+  and cloud agent metadata after you supply a Cursor API key
 - Devin — reads cloud session metadata after you supply a Devin personal access
   token
 
-Conductor, Cursor, and Devin remain silent until their own credential is saved
-in Luke's Settings or supplied through `CONDUCTOR_API_KEY`,
-`CONDUCTOR_API_TOKEN`, `CURSOR_API_KEY`, or `DEVIN_API_KEY`. Devin is the one
-that asks for a particular credential: Luke reads its v3 API, so it takes a
-personal access token (`cog_…`, created under **Devin API · PATs**) and refuses
-the deprecated `apk_` keys of v1 and v2. A token that belongs to a service user
-rather than to a person is refused too — Devin lists an organization's sessions,
-and Luke reports only the sessions belonging to whoever the token authenticates
-as. Every provider integration is read-only. None requires hooks,
-plugins, wrappers, or changes to how a session is launched.
+Cursor is the one provider Luke watches in two places, and both halves arrive as
+Cursor sessions: the ones on this machine need no credential, and its cloud
+agents need a key. Conductor, Cursor's cloud half, and Devin remain silent until
+their own credential is saved in Luke's Settings or supplied through
+`CONDUCTOR_API_KEY`, `CONDUCTOR_API_TOKEN`, `CURSOR_API_KEY`, or `DEVIN_API_KEY`.
+Devin is the one that asks for a particular credential: Luke reads its v3 API, so
+it takes a personal access token (`cog_…`, created under **Devin API · PATs**)
+and refuses the deprecated `apk_` keys of v1 and v2. A token that belongs to a
+service user rather than to a person is refused too — Devin lists an
+organization's sessions, and Luke reports only the sessions belonging to whoever
+the token authenticates as. Every provider integration is read-only. None
+requires hooks, plugins, wrappers, or changes to how a session is launched.
 
 ## What works in v0.1
 

--- a/apps/desktop/src/claude-code-adapter.ts
+++ b/apps/desktop/src/claude-code-adapter.ts
@@ -1,5 +1,3 @@
-import type { Dirent, Stats } from "node:fs";
-import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -12,12 +10,25 @@ import {
   type SessionProvider,
   type SessionProviderAdapter,
 } from "@sidecar/core";
+import {
+  discoverSessionFiles,
+  LOCAL_ADAPTER_DEFAULTS,
+  nonNegativeNumber,
+  positiveInteger,
+  readDirectory,
+  readHead,
+  readTail,
+  recordFromJsonLine,
+  type SessionFileCandidate,
+  statDirectoryEntry,
+  tailRecords,
+  workspaceLabel,
+} from "./local-session-adapter";
 
 const CLAUDE_CODE_PROVIDER_ID = PROVIDER_ID.CLAUDE_CODE;
 const CLAUDE_CODE_PROVIDER_NAME = "Claude Code";
 const CLAUDE_PROJECTS_DIRECTORY = "projects";
 const CLAUDE_SESSION_FILE_EXTENSION = ".jsonl";
-const UNKNOWN_WORKSPACE_LABEL = "workspace";
 
 const CLAUDE_ENVIRONMENT = {
   CONFIG_DIRECTORY: "CLAUDE_CONFIG_DIR",
@@ -71,9 +82,6 @@ const CLAUDE_TOOL_INPUT_KEY = ["description", "file_path", "pattern", "command",
 const CLAUDE_ADAPTER_DEFAULTS = {
   MAXIMUM_PROJECT_DIRECTORIES: 200,
   MAXIMUM_SESSION_FILES: 40,
-  MAXIMUM_SESSION_AGE_MS: 24 * 60 * 60 * 1000,
-  ACTIVE_SESSION_FRESHNESS_MS: 15 * 60 * 1000,
-  READ_TAIL_BYTES: 64 * 1024,
   /**
    * Claude Code writes its generated title early and then only when the subject
    * changes, so a long session's title sits far behind the tail. Only a file
@@ -99,12 +107,6 @@ export interface ClaudeCodeAdapterOptions {
   readHeadBytes?: number;
 }
 
-interface SessionFileCandidate {
-  filePath: string;
-  providerSessionId: string;
-  mtimeMs: number;
-}
-
 interface ParsedClaudeSessionTail {
   activity?: string;
   aiTitle?: string;
@@ -120,74 +122,20 @@ interface ParsedClaudeSessionTail {
   usedTool?: boolean;
 }
 
-interface DirectoryEntry {
-  directoryPath: string;
-  name: string;
-  stats: Stats;
-}
-
-function positiveInteger(value: number | undefined, fallback: number): number {
-  if (value === undefined || !Number.isFinite(value) || value <= 0) return fallback;
-  return Math.floor(value);
-}
-
-function nonNegativeNumber(value: number | undefined, fallback: number): number {
-  if (value === undefined || !Number.isFinite(value) || value < 0) return fallback;
-  return value;
-}
-
-function isNodeError(error: unknown): error is NodeJS.ErrnoException {
-  return error instanceof Error && "code" in error;
-}
-
-function canIgnoreFilesystemError(error: unknown): boolean {
-  return (
-    isNodeError(error) &&
-    (error.code === "ENOENT" ||
-      error.code === "ENOTDIR" ||
-      error.code === "EACCES" ||
-      error.code === "EPERM")
-  );
-}
-
-async function readDirectory(directoryPath: string): Promise<Dirent[]> {
-  try {
-    return await fs.readdir(directoryPath, { withFileTypes: true });
-  } catch (error) {
-    if (canIgnoreFilesystemError(error)) return [];
-    throw error;
-  }
-}
-
-async function statDirectoryEntry(
-  directoryPath: string,
-  entry: Dirent,
-): Promise<DirectoryEntry | undefined> {
-  const entryPath = path.join(directoryPath, entry.name);
-  try {
-    const stats = await fs.lstat(entryPath);
-    return { directoryPath: entryPath, name: entry.name, stats };
-  } catch (error) {
-    if (canIgnoreFilesystemError(error)) return undefined;
-    throw error;
-  }
-}
-
 function sessionIdFromFileName(fileName: string): string | undefined {
   if (!fileName.endsWith(CLAUDE_SESSION_FILE_EXTENSION)) return undefined;
   const providerSessionId = fileName.slice(0, -CLAUDE_SESSION_FILE_EXTENSION.length).trim();
   return providerSessionId || undefined;
 }
 
-async function sessionFilesInProject(
-  projectDirectory: DirectoryEntry,
-): Promise<SessionFileCandidate[]> {
-  const entries = await readDirectory(projectDirectory.directoryPath);
+/** Claude Code keeps a session's transcript directly in its project directory. */
+async function sessionFilesIn(projectDirectory: string): Promise<SessionFileCandidate[]> {
+  const entries = await readDirectory(projectDirectory);
   const candidates = await Promise.all(
     entries.map(async (entry) => {
       const providerSessionId = sessionIdFromFileName(entry.name);
       if (!providerSessionId) return undefined;
-      const candidate = await statDirectoryEntry(projectDirectory.directoryPath, entry);
+      const candidate = await statDirectoryEntry(projectDirectory, entry.name);
       if (!candidate?.stats.isFile()) return undefined;
       return {
         filePath: candidate.directoryPath,
@@ -199,78 +147,6 @@ async function sessionFilesInProject(
   return candidates.filter(
     (candidate): candidate is SessionFileCandidate => candidate !== undefined,
   );
-}
-
-async function discoverSessionFiles(
-  projectsDirectory: string,
-  maximumProjectDirectories: number,
-  maximumSessionFiles: number,
-): Promise<SessionFileCandidate[]> {
-  const entries = await readDirectory(projectsDirectory);
-  const projectDirectories = (
-    await Promise.all(entries.map((entry) => statDirectoryEntry(projectsDirectory, entry)))
-  )
-    .filter((entry): entry is DirectoryEntry => entry?.stats.isDirectory() === true)
-    .sort((first, second) => second.stats.mtimeMs - first.stats.mtimeMs)
-    .slice(0, maximumProjectDirectories);
-
-  const files = (await Promise.all(projectDirectories.map(sessionFilesInProject))).flat();
-  return files
-    .sort((first, second) => second.mtimeMs - first.mtimeMs)
-    .slice(0, maximumSessionFiles);
-}
-
-async function readTail(filePath: string, maximumBytes: number): Promise<string> {
-  let handle: fs.FileHandle | undefined;
-  try {
-    handle = await fs.open(filePath, "r");
-    const stats = await handle.stat();
-    if (!stats.isFile() || stats.size <= 0) return "";
-    const length = Math.min(stats.size, maximumBytes);
-    const buffer = Buffer.alloc(length);
-    await handle.read(buffer, 0, length, stats.size - length);
-    return buffer.toString("utf8");
-  } catch (error) {
-    if (canIgnoreFilesystemError(error)) return "";
-    throw error;
-  } finally {
-    await handle?.close();
-  }
-}
-
-async function readHead(filePath: string, maximumBytes: number): Promise<string> {
-  let handle: fs.FileHandle | undefined;
-  try {
-    handle = await fs.open(filePath, "r");
-    const stats = await handle.stat();
-    if (!stats.isFile() || stats.size <= 0) return "";
-    const length = Math.min(stats.size, maximumBytes);
-    const buffer = Buffer.alloc(length);
-    await handle.read(buffer, 0, length, 0);
-    return buffer.toString("utf8");
-  } catch (error) {
-    if (canIgnoreFilesystemError(error)) return "";
-    throw error;
-  } finally {
-    await handle?.close();
-  }
-}
-
-function tailLines(tail: string): string[] {
-  const lines = tail.split(/\r?\n/).filter((line) => line.trim().length > 0);
-  if (!tail.startsWith("{")) lines.shift();
-  return lines;
-}
-
-function recordFromJsonLine(line: string): Record<string, unknown> | undefined {
-  try {
-    const parsed = JSON.parse(line) as unknown;
-    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : undefined;
-  } catch {
-    return undefined;
-  }
 }
 
 function eventTypeFromRecord(record: Record<string, unknown>): ClaudeEventType | undefined {
@@ -459,10 +335,7 @@ function readClaudeRecord(record: Record<string, unknown>, parsed: ParsedClaudeS
 
 function parseClaudeSessionTail(tail: string): ParsedClaudeSessionTail {
   const parsed: ParsedClaudeSessionTail = {};
-  for (const line of tailLines(tail)) {
-    const record = recordFromJsonLine(line);
-    if (record) readClaudeRecord(record, parsed);
-  }
+  for (const record of tailRecords(tail)) readClaudeRecord(record, parsed);
   return parsed;
 }
 
@@ -502,12 +375,6 @@ function statusFromTail(
     return turnEnded(parsed) ? SESSION_STATUS.WAITING : SESSION_STATUS.WORKING;
   }
   return SESSION_STATUS.WORKING;
-}
-
-function workspaceLabel(cwd: string | undefined): string {
-  if (!cwd) return UNKNOWN_WORKSPACE_LABEL;
-  const label = path.basename(cwd.trim());
-  return label || UNKNOWN_WORKSPACE_LABEL;
 }
 
 /**
@@ -578,15 +445,15 @@ export class ClaudeCodeSessionAdapter implements SessionProviderAdapter {
     );
     this.#maximumSessionAgeMs = nonNegativeNumber(
       options.maximumSessionAgeMs,
-      CLAUDE_ADAPTER_DEFAULTS.MAXIMUM_SESSION_AGE_MS,
+      LOCAL_ADAPTER_DEFAULTS.MAXIMUM_SESSION_AGE_MS,
     );
     this.#activeSessionFreshnessMs = nonNegativeNumber(
       options.activeSessionFreshnessMs,
-      CLAUDE_ADAPTER_DEFAULTS.ACTIVE_SESSION_FRESHNESS_MS,
+      LOCAL_ADAPTER_DEFAULTS.ACTIVE_SESSION_FRESHNESS_MS,
     );
     this.#readTailBytes = positiveInteger(
       options.readTailBytes,
-      CLAUDE_ADAPTER_DEFAULTS.READ_TAIL_BYTES,
+      LOCAL_ADAPTER_DEFAULTS.READ_TAIL_BYTES,
     );
     this.#readHeadBytes = positiveInteger(
       options.readHeadBytes,
@@ -596,11 +463,12 @@ export class ClaudeCodeSessionAdapter implements SessionProviderAdapter {
 
   async observe(): Promise<readonly ProviderSessionObservation[]> {
     const now = this.#now();
-    const candidates = await discoverSessionFiles(
-      path.join(this.#claudeHome, CLAUDE_PROJECTS_DIRECTORY),
-      this.#maximumProjectDirectories,
-      this.#maximumSessionFiles,
-    );
+    const candidates = await discoverSessionFiles({
+      projectsDirectory: path.join(this.#claudeHome, CLAUDE_PROJECTS_DIRECTORY),
+      maximumProjectDirectories: this.#maximumProjectDirectories,
+      maximumSessionFiles: this.#maximumSessionFiles,
+      sessionFilesIn,
+    });
     const observations = new Map<string, ProviderSessionObservation>();
 
     for (const candidate of candidates) {

--- a/apps/desktop/src/cursor-local-adapter.ts
+++ b/apps/desktop/src/cursor-local-adapter.ts
@@ -1,0 +1,367 @@
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  type ProviderSessionObservation,
+  SESSION_STATUS,
+  type SessionDetail,
+  type SessionProviderAdapter,
+  type SessionStatus,
+} from "@sidecar/core";
+import { CURSOR_PROVIDER } from "./cursor-adapter";
+import {
+  type DirectoryEntry,
+  discoverSessionFiles,
+  fileStats,
+  LOCAL_ADAPTER_DEFAULTS,
+  nonNegativeNumber,
+  positiveInteger,
+  readDirectory,
+  readTail,
+  readTextFile,
+  type SessionFileCandidate,
+  tailRecords,
+  UNKNOWN_WORKSPACE_LABEL,
+  workspaceLabel,
+} from "./local-session-adapter";
+
+/** A turn Cursor failed records its own reason, which is transcript content. */
+const CURSOR_TURN_FAILED_MESSAGE = "The turn failed";
+
+const CURSOR_DIRECTORY = {
+  /** One directory per folder Cursor has been opened on, named after that folder. */
+  PROJECTS: "projects",
+  /** One directory per session inside a project, named after the session. */
+  TRANSCRIPTS: "agent-transcripts",
+} as const;
+
+/** Where the app keeps a record of each folder it has opened, one directory each. */
+const CURSOR_WORKSPACE_STORAGE_SEGMENTS = [
+  "Library",
+  "Application Support",
+  "Cursor",
+  "User",
+  "workspaceStorage",
+] as const;
+
+const CURSOR_TRANSCRIPT_FILE_EXTENSION = ".jsonl";
+const CURSOR_WORKSPACE_FILE = "workspace.json";
+
+const CURSOR_WORKSPACE_FIELD = {
+  /** A window opened on a single folder. Cursor omits it for every other window. */
+  FOLDER: "folder",
+} as const;
+
+const CURSOR_RECORD_FIELD = {
+  ROLE: "role",
+  STATUS: "status",
+  TYPE: "type",
+} as const;
+
+/** The one record type Luke reads: Cursor marking the end of a turn. */
+const CURSOR_RECORD_TYPE = {
+  TURN_ENDED: "turn_ended",
+} as const;
+
+/**
+ * How a turn ended. Only failure is named: every other outcome is a turn that
+ * finished and is holding for the user, including one this build cannot name.
+ */
+const CURSOR_TURN_STATUS = {
+  ERROR: "error",
+} as const;
+
+/** Who a message record belongs to. Its content is never read. */
+const CURSOR_ROLE = {
+  ASSISTANT: "assistant",
+  USER: "user",
+} as const;
+
+const CURSOR_LOCAL_ADAPTER_DEFAULTS = {
+  MAXIMUM_PROJECT_DIRECTORIES: 200,
+  MAXIMUM_SESSION_FILES: 40,
+} as const;
+
+export interface CursorLocalAdapterOptions {
+  cursorHome?: string;
+  workspaceStorageDirectory?: string;
+  now?: () => number;
+  maximumProjectDirectories?: number;
+  maximumSessionFiles?: number;
+  maximumSessionAgeMs?: number;
+  activeSessionFreshnessMs?: number;
+  readTailBytes?: number;
+}
+
+interface CursorTranscriptCandidate extends SessionFileCandidate {
+  projectDirectoryName: string;
+}
+
+/**
+ * Cursor names a project directory after the folder it belongs to, with every
+ * run of characters that cannot appear in a directory name replaced by a
+ * hyphen. This reproduces that name rather than inventing one, because it is
+ * the only key the two halves of Cursor's local state share.
+ */
+function projectDirectoryNameFor(folderPath: string): string {
+  return folderPath.replace(/[^A-Za-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+function folderPathFromWorkspaceRecord(source: string): string | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source) as unknown;
+  } catch {
+    return undefined;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+  const folder = (parsed as Record<string, unknown>)[CURSOR_WORKSPACE_FIELD.FOLDER];
+  if (typeof folder !== "string") return undefined;
+  try {
+    return fileURLToPath(folder);
+  } catch {
+    // A window opened on something that is not a folder on this machine.
+    return undefined;
+  }
+}
+
+/**
+ * Names the folder a session ran in. A transcript records neither its folder
+ * nor its own path — only the project directory Cursor filed it under, whose
+ * name has already lost the separators of the path it was made from. Cursor
+ * keeps the folder itself in its workspace records, so the label is recovered
+ * by naming those the same way and matching, and never by guessing at where
+ * the hyphens in a directory name used to be.
+ */
+class CursorWorkspaceLabels {
+  readonly #directory: string;
+  readonly #labelsByProjectDirectoryName = new Map<string, string | undefined>();
+  readonly #readWorkspaceRecords = new Set<string>();
+
+  constructor(directory: string) {
+    this.#directory = directory;
+  }
+
+  /**
+   * Reads Cursor's workspace records for any project this pass cannot already
+   * name. A record is read once; a project that stays unnamed is looked for
+   * again, because the folder it belongs to may be opened later.
+   */
+  async resolve(projectDirectoryNames: readonly string[]): Promise<void> {
+    if (projectDirectoryNames.every((name) => this.#labelsByProjectDirectoryName.has(name))) return;
+    for (const entry of await readDirectory(this.#directory)) {
+      if (this.#readWorkspaceRecords.has(entry.name)) continue;
+      this.#readWorkspaceRecords.add(entry.name);
+      const record = await readTextFile(
+        path.join(this.#directory, entry.name, CURSOR_WORKSPACE_FILE),
+      );
+      const folderPath = record ? folderPathFromWorkspaceRecord(record) : undefined;
+      if (folderPath) this.#record(folderPath);
+    }
+  }
+
+  label(projectDirectoryName: string): string {
+    return this.#labelsByProjectDirectoryName.get(projectDirectoryName) ?? UNKNOWN_WORKSPACE_LABEL;
+  }
+
+  #record(folderPath: string): void {
+    const projectDirectoryName = projectDirectoryNameFor(folderPath);
+    const label = workspaceLabel(folderPath);
+    if (!this.#labelsByProjectDirectoryName.has(projectDirectoryName)) {
+      this.#labelsByProjectDirectoryName.set(projectDirectoryName, label);
+      return;
+    }
+    // Two folders can carry one project directory name. When they disagree
+    // about what to call it, Luke names neither.
+    if (this.#labelsByProjectDirectoryName.get(projectDirectoryName) !== label) {
+      this.#labelsByProjectDirectoryName.set(projectDirectoryName, undefined);
+    }
+  }
+}
+
+async function transcriptsIn(
+  transcriptsDirectory: string,
+  projectDirectory: DirectoryEntry,
+): Promise<CursorTranscriptCandidate[]> {
+  const entries = await readDirectory(transcriptsDirectory);
+  const candidates = await Promise.all(
+    entries.map(async (entry) => {
+      const providerSessionId = entry.name.trim();
+      if (!providerSessionId) return undefined;
+      // Cursor names a session's own transcript after the session, so this
+      // reads that file rather than everything in the directory: the subagents
+      // a session spawns file their transcripts beside it, and they are part of
+      // the session rather than sessions of their own.
+      const filePath = path.join(
+        transcriptsDirectory,
+        entry.name,
+        `${entry.name}${CURSOR_TRANSCRIPT_FILE_EXTENSION}`,
+      );
+      const stats = await fileStats(filePath);
+      if (!stats?.isFile()) return undefined;
+      return {
+        filePath,
+        providerSessionId,
+        mtimeMs: stats.mtimeMs,
+        projectDirectoryName: projectDirectory.name,
+      };
+    }),
+  );
+  return candidates.filter(
+    (candidate): candidate is CursorTranscriptCandidate => candidate !== undefined,
+  );
+}
+
+function isMessageRecord(record: Record<string, unknown>): boolean {
+  const role = record[CURSOR_RECORD_FIELD.ROLE];
+  return Object.values(CURSOR_ROLE).some((knownRole) => knownRole === role);
+}
+
+/**
+ * How the newest turn ended, or nothing while one is still open. Cursor marks
+ * the end of a turn explicitly, so an open turn is read from the absence of
+ * that mark rather than inferred from what the assistant last said — which is
+ * transcript content, and is not read here at all. A record this build does not
+ * know is passed over rather than taken for either.
+ */
+function closedTurn(tail: string): { failed: boolean } | undefined {
+  for (const record of tailRecords(tail).toReversed()) {
+    if (record[CURSOR_RECORD_FIELD.TYPE] === CURSOR_RECORD_TYPE.TURN_ENDED) {
+      return { failed: record[CURSOR_RECORD_FIELD.STATUS] === CURSOR_TURN_STATUS.ERROR };
+    }
+    if (isMessageRecord(record)) return undefined;
+  }
+  return undefined;
+}
+
+/**
+ * A turn Cursor has closed is holding for the user; one it failed is stuck
+ * until someone comes back to it, which asks something different and is
+ * reported as such. Anything else is a turn still in progress. A transcript
+ * that has gone quiet reports neither: after a quarter of an hour its last
+ * record cannot tell a turn that just ended from a chat left open yesterday.
+ * A failure does not decay that way, because it does not heal by going stale —
+ * which is how every other adapter treats one too.
+ */
+function statusFromTurn(turn: { failed: boolean } | undefined, isFresh: boolean): SessionStatus {
+  if (turn?.failed) return SESSION_STATUS.ERROR;
+  if (!isFresh) return SESSION_STATUS.UNKNOWN;
+  return turn ? SESSION_STATUS.WAITING : SESSION_STATUS.WORKING;
+}
+
+/**
+ * What Cursor knows about a local session beyond its state: the folder, and
+ * that a turn failed. Cursor records why it failed, but that reason is written
+ * from the turn itself, so the fact of the failure is reported and its wording
+ * is not — the same fixed line the cloud half reports for a failed run.
+ */
+function detailFor(label: string, status: SessionStatus): SessionDetail {
+  return {
+    repository: label,
+    ...(status === SESSION_STATUS.ERROR ? { error: CURSOR_TURN_FAILED_MESSAGE } : {}),
+  };
+}
+
+function defaultCursorHome(): string {
+  return path.join(os.homedir(), ".cursor");
+}
+
+function defaultWorkspaceStorageDirectory(): string {
+  return path.join(os.homedir(), ...CURSOR_WORKSPACE_STORAGE_SEGMENTS);
+}
+
+/**
+ * Observes the Cursor sessions that run on this machine, from the transcripts
+ * Cursor already writes for itself. It reads no message content, needs no
+ * credential, and reports nothing that Cursor has not written down.
+ */
+export class CursorLocalSessionAdapter implements SessionProviderAdapter {
+  readonly provider = CURSOR_PROVIDER;
+
+  readonly #cursorHome: string;
+  readonly #workspaceLabels: CursorWorkspaceLabels;
+  readonly #now: () => number;
+  readonly #maximumProjectDirectories: number;
+  readonly #maximumSessionFiles: number;
+  readonly #maximumSessionAgeMs: number;
+  readonly #activeSessionFreshnessMs: number;
+  readonly #readTailBytes: number;
+
+  constructor(options: CursorLocalAdapterOptions = {}) {
+    this.#cursorHome = options.cursorHome ?? defaultCursorHome();
+    this.#workspaceLabels = new CursorWorkspaceLabels(
+      options.workspaceStorageDirectory ?? defaultWorkspaceStorageDirectory(),
+    );
+    this.#now = options.now ?? Date.now;
+    this.#maximumProjectDirectories = positiveInteger(
+      options.maximumProjectDirectories,
+      CURSOR_LOCAL_ADAPTER_DEFAULTS.MAXIMUM_PROJECT_DIRECTORIES,
+    );
+    this.#maximumSessionFiles = positiveInteger(
+      options.maximumSessionFiles,
+      CURSOR_LOCAL_ADAPTER_DEFAULTS.MAXIMUM_SESSION_FILES,
+    );
+    this.#maximumSessionAgeMs = nonNegativeNumber(
+      options.maximumSessionAgeMs,
+      LOCAL_ADAPTER_DEFAULTS.MAXIMUM_SESSION_AGE_MS,
+    );
+    this.#activeSessionFreshnessMs = nonNegativeNumber(
+      options.activeSessionFreshnessMs,
+      LOCAL_ADAPTER_DEFAULTS.ACTIVE_SESSION_FRESHNESS_MS,
+    );
+    this.#readTailBytes = positiveInteger(
+      options.readTailBytes,
+      LOCAL_ADAPTER_DEFAULTS.READ_TAIL_BYTES,
+    );
+  }
+
+  async observe(): Promise<readonly ProviderSessionObservation[]> {
+    const now = this.#now();
+    const candidates = (
+      await discoverSessionFiles({
+        projectsDirectory: path.join(this.#cursorHome, CURSOR_DIRECTORY.PROJECTS),
+        sessionsDirectoryName: CURSOR_DIRECTORY.TRANSCRIPTS,
+        maximumProjectDirectories: this.#maximumProjectDirectories,
+        maximumSessionFiles: this.#maximumSessionFiles,
+        sessionFilesIn: transcriptsIn,
+      })
+    ).filter((candidate) => now - candidate.mtimeMs <= this.#maximumSessionAgeMs);
+    // Only the sessions this pass reports are worth naming a folder for.
+    await this.#workspaceLabels.resolve(
+      candidates.map((candidate) => candidate.projectDirectoryName),
+    );
+
+    const observations = new Map<string, ProviderSessionObservation>();
+    for (const candidate of candidates) {
+      if (observations.has(candidate.providerSessionId)) continue;
+      observations.set(candidate.providerSessionId, await this.#observationFor(candidate, now));
+    }
+    return [...observations.values()];
+  }
+
+  /**
+   * A session is named by the folder it ran in and by nothing else. Cursor
+   * names a chat from its opening prompt, so that name is the prompt and never
+   * reaches an observation — and the location is left unsaid, which is how an
+   * adapter reading this machine reports one that runs on it.
+   */
+  async #observationFor(
+    candidate: CursorTranscriptCandidate,
+    now: number,
+  ): Promise<ProviderSessionObservation> {
+    const label = this.#workspaceLabels.label(candidate.projectDirectoryName);
+    const tail = await readTail(candidate.filePath, this.#readTailBytes);
+    const isFresh = now - candidate.mtimeMs <= this.#activeSessionFreshnessMs;
+    const status = statusFromTurn(closedTurn(tail), isFresh);
+    return {
+      providerSessionId: candidate.providerSessionId,
+      title: label,
+      status,
+      // A transcript carries no timestamps of its own, so when it was last
+      // written is the only account Cursor keeps of when this session last did
+      // anything.
+      observedAt: candidate.mtimeMs,
+      detail: detailFor(label, status),
+    };
+  }
+}

--- a/apps/desktop/src/cursor-local-adapter.ts
+++ b/apps/desktop/src/cursor-local-adapter.ts
@@ -98,13 +98,20 @@ interface CursorTranscriptCandidate extends SessionFileCandidate {
 }
 
 /**
- * Cursor names a project directory after the folder it belongs to, with every
- * run of characters that cannot appear in a directory name replaced by a
- * hyphen. This reproduces that name rather than inventing one, because it is
- * the only key the two halves of Cursor's local state share.
+ * Reduces a name to what both halves of Cursor's local state can still agree
+ * on. Cursor files a project under a directory named after its folder, with the
+ * characters it will not put in one rewritten — but exactly which characters a
+ * given build rewrites is Cursor's business, not Luke's. Rather than reproduce
+ * that rule and be wrong whenever it differs, the directory Cursor wrote and
+ * the folder Luke is matching it to are reduced the same way, so any character
+ * either side may have rewritten stops being the difference between them.
+ *
+ * This deliberately loses information: two folders can reduce alike, and the
+ * caller names neither rather than guessing. That is the safe direction — the
+ * cost is a session labelled `workspace`, which is what it would have been.
  */
-function projectDirectoryNameFor(folderPath: string): string {
-  return folderPath.replace(/[^A-Za-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+function canonicalProjectName(value: string): string {
+  return value.replace(/[^A-Za-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
 }
 
 function folderPathFromWorkspaceRecord(source: string): string | undefined {
@@ -130,12 +137,12 @@ function folderPathFromWorkspaceRecord(source: string): string | undefined {
  * nor its own path — only the project directory Cursor filed it under, whose
  * name has already lost the separators of the path it was made from. Cursor
  * keeps the folder itself in its workspace records, so the label is recovered
- * by naming those the same way and matching, and never by guessing at where
- * the hyphens in a directory name used to be.
+ * by reducing both to the name they still share, and never by guessing at
+ * where the hyphens in a directory name used to be.
  */
 class CursorWorkspaceLabels {
   readonly #directory: string;
-  readonly #labelsByProjectDirectoryName = new Map<string, string | undefined>();
+  readonly #labelsByProjectName = new Map<string, string | undefined>();
   readonly #readWorkspaceRecords = new Set<string>();
 
   constructor(directory: string) {
@@ -148,7 +155,13 @@ class CursorWorkspaceLabels {
    * again, because the folder it belongs to may be opened later.
    */
   async resolve(projectDirectoryNames: readonly string[]): Promise<void> {
-    if (projectDirectoryNames.every((name) => this.#labelsByProjectDirectoryName.has(name))) return;
+    if (
+      projectDirectoryNames.every((name) =>
+        this.#labelsByProjectName.has(canonicalProjectName(name)),
+      )
+    ) {
+      return;
+    }
     for (const entry of await readDirectory(this.#directory)) {
       if (this.#readWorkspaceRecords.has(entry.name)) continue;
       this.#readWorkspaceRecords.add(entry.name);
@@ -161,20 +174,23 @@ class CursorWorkspaceLabels {
   }
 
   label(projectDirectoryName: string): string {
-    return this.#labelsByProjectDirectoryName.get(projectDirectoryName) ?? UNKNOWN_WORKSPACE_LABEL;
+    return (
+      this.#labelsByProjectName.get(canonicalProjectName(projectDirectoryName)) ??
+      UNKNOWN_WORKSPACE_LABEL
+    );
   }
 
   #record(folderPath: string): void {
-    const projectDirectoryName = projectDirectoryNameFor(folderPath);
+    const projectName = canonicalProjectName(folderPath);
     const label = workspaceLabel(folderPath);
-    if (!this.#labelsByProjectDirectoryName.has(projectDirectoryName)) {
-      this.#labelsByProjectDirectoryName.set(projectDirectoryName, label);
+    if (!this.#labelsByProjectName.has(projectName)) {
+      this.#labelsByProjectName.set(projectName, label);
       return;
     }
-    // Two folders can carry one project directory name. When they disagree
-    // about what to call it, Luke names neither.
-    if (this.#labelsByProjectDirectoryName.get(projectDirectoryName) !== label) {
-      this.#labelsByProjectDirectoryName.set(projectDirectoryName, undefined);
+    // Two folders can reduce to one project name. When they disagree about
+    // what to call it, Luke names neither.
+    if (this.#labelsByProjectName.get(projectName) !== label) {
+      this.#labelsByProjectName.set(projectName, undefined);
     }
   }
 }

--- a/apps/desktop/src/local-session-adapter.ts
+++ b/apps/desktop/src/local-session-adapter.ts
@@ -1,0 +1,258 @@
+import type { Dirent, Stats } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * The shared half of every adapter that observes sessions on this machine:
+ * bounded, failure-tolerant reads of the files a provider already writes for
+ * itself. Nothing here opens a file for writing, and no caller may.
+ */
+
+/** The label a session takes when Luke cannot name the folder it belongs to. */
+export const UNKNOWN_WORKSPACE_LABEL = "workspace";
+
+/**
+ * Shared bounds for every local provider. They match the cloud adapters, so a
+ * session reads the same whether Luke observed it on disk or over the network.
+ */
+export const LOCAL_ADAPTER_DEFAULTS = {
+  MAXIMUM_SESSION_AGE_MS: 24 * 60 * 60 * 1000,
+  ACTIVE_SESSION_FRESHNESS_MS: 15 * 60 * 1000,
+  READ_TAIL_BYTES: 64 * 1024,
+} as const;
+
+export interface DirectoryEntry {
+  directoryPath: string;
+  name: string;
+  stats: Stats;
+}
+
+/** The least an adapter has to know about a session file to place it in time. */
+export interface SessionFileCandidate {
+  filePath: string;
+  providerSessionId: string;
+  mtimeMs: number;
+}
+
+/** How one provider's directory layout turns into session files. */
+export interface SessionFileDiscovery<Candidate extends SessionFileCandidate> {
+  projectsDirectory: string;
+  /**
+   * The directory inside a project that its sessions land in, for a provider
+   * that keeps them somewhere other than the project directory itself.
+   */
+  sessionsDirectoryName?: string;
+  maximumProjectDirectories: number;
+  maximumSessionFiles: number;
+  sessionFilesIn: (sessionsDirectory: string, project: DirectoryEntry) => Promise<Candidate[]>;
+}
+
+/** Where one project keeps its sessions, and when it last started one. */
+interface ProjectSessionsDirectory {
+  project: DirectoryEntry;
+  sessionsDirectory: string;
+  mtimeMs: number;
+}
+
+export function positiveInteger(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) return fallback;
+  return Math.floor(value);
+}
+
+export function nonNegativeNumber(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value < 0) return fallback;
+  return value;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
+
+/**
+ * A provider directory that is absent, or that this user cannot read, means
+ * Luke observes nothing there — never that the observation pass failed.
+ */
+export function canIgnoreFilesystemError(error: unknown): boolean {
+  return (
+    isNodeError(error) &&
+    (error.code === "ENOENT" ||
+      error.code === "ENOTDIR" ||
+      error.code === "EACCES" ||
+      error.code === "EPERM")
+  );
+}
+
+export async function readDirectory(directoryPath: string): Promise<Dirent[]> {
+  try {
+    return await fs.readdir(directoryPath, { withFileTypes: true });
+  } catch (error) {
+    if (canIgnoreFilesystemError(error)) return [];
+    throw error;
+  }
+}
+
+export async function fileStats(filePath: string): Promise<Stats | undefined> {
+  try {
+    return await fs.stat(filePath);
+  } catch (error) {
+    if (canIgnoreFilesystemError(error)) return undefined;
+    throw error;
+  }
+}
+
+/** `lstat`, so a link out of a provider directory is never followed. */
+export async function statDirectoryEntry(
+  directoryPath: string,
+  name: string,
+): Promise<DirectoryEntry | undefined> {
+  const entryPath = path.join(directoryPath, name);
+  try {
+    const stats = await fs.lstat(entryPath);
+    return { directoryPath: entryPath, name, stats };
+  } catch (error) {
+    if (canIgnoreFilesystemError(error)) return undefined;
+    throw error;
+  }
+}
+
+export async function readTextFile(filePath: string): Promise<string | undefined> {
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch (error) {
+    if (canIgnoreFilesystemError(error)) return undefined;
+    throw error;
+  }
+}
+
+/**
+ * Reads a bounded region of a session file. A transcript grows without bound,
+ * so no adapter may read one whole, and the file is opened for reading alone.
+ */
+async function readRegion(
+  filePath: string,
+  maximumBytes: number,
+  offset: (size: number, length: number) => number,
+): Promise<string> {
+  let handle: fs.FileHandle | undefined;
+  try {
+    handle = await fs.open(filePath, "r");
+    const stats = await handle.stat();
+    if (!stats.isFile() || stats.size <= 0) return "";
+    const length = Math.min(stats.size, maximumBytes);
+    const buffer = Buffer.alloc(length);
+    await handle.read(buffer, 0, length, offset(stats.size, length));
+    return buffer.toString("utf8");
+  } catch (error) {
+    if (canIgnoreFilesystemError(error)) return "";
+    throw error;
+  } finally {
+    await handle?.close();
+  }
+}
+
+/** The end of a session file, where its newest records say what it is doing. */
+export function readTail(filePath: string, maximumBytes: number): Promise<string> {
+  return readRegion(filePath, maximumBytes, (size, length) => size - length);
+}
+
+/** The start of a session file, for the records a provider writes only once. */
+export function readHead(filePath: string, maximumBytes: number): Promise<string> {
+  return readRegion(filePath, maximumBytes, () => 0);
+}
+
+export function recordFromJsonLine(line: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function tailLines(tail: string): string[] {
+  const lines = tail.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  // A bounded read lands mid-record, and a provider appending right now can
+  // leave the last one unfinished; neither half-record is a record.
+  if (!tail.startsWith("{")) lines.shift();
+  return lines;
+}
+
+/** The whole records a tail holds, oldest first. */
+export function tailRecords(tail: string): Record<string, unknown>[] {
+  return tailLines(tail)
+    .map(recordFromJsonLine)
+    .filter((record): record is Record<string, unknown> => record !== undefined);
+}
+
+/** Sessions are labelled by the folder they run in, never by a provider's own name for them. */
+export function workspaceLabel(directoryPath: string | undefined): string {
+  if (!directoryPath) return UNKNOWN_WORKSPACE_LABEL;
+  const label = path.basename(directoryPath.trim());
+  return label || UNKNOWN_WORKSPACE_LABEL;
+}
+
+/**
+ * Places a project in time by the directory its sessions land in, which is the
+ * one a new session moves. A project directory's own mtime stops moving the
+ * moment a provider nests its transcripts inside it — nothing done to a session
+ * afterwards reaches it — so ranking by it would rank a folder used every day
+ * by the day the provider first wrote there. A project with no sessions
+ * directory has no sessions, and takes none of the bound below.
+ */
+async function projectSessionsDirectory(
+  project: DirectoryEntry,
+  sessionsDirectoryName: string | undefined,
+): Promise<ProjectSessionsDirectory | undefined> {
+  if (sessionsDirectoryName === undefined) {
+    return {
+      project,
+      sessionsDirectory: project.directoryPath,
+      mtimeMs: project.stats.mtimeMs,
+    };
+  }
+  const sessionsDirectory = path.join(project.directoryPath, sessionsDirectoryName);
+  const stats = await fileStats(sessionsDirectory);
+  if (!stats?.isDirectory()) return undefined;
+  return { project, sessionsDirectory, mtimeMs: stats.mtimeMs };
+}
+
+/**
+ * Finds the newest session files across a provider's project directories. Both
+ * levels are bounded and ordered by recency, so a machine with years of
+ * projects costs the same pass as a machine with one. A directory's mtime does
+ * not move when a file inside it is appended to, so the project bound keeps the
+ * projects that most recently *started* a session; the session bound that
+ * follows it is ordered by each transcript's own last write.
+ */
+export async function discoverSessionFiles<Candidate extends SessionFileCandidate>(
+  discovery: SessionFileDiscovery<Candidate>,
+): Promise<Candidate[]> {
+  const entries = await readDirectory(discovery.projectsDirectory);
+  const projects = (
+    await Promise.all(
+      entries.map((entry) => statDirectoryEntry(discovery.projectsDirectory, entry.name)),
+    )
+  ).filter((entry): entry is DirectoryEntry => entry?.stats.isDirectory() === true);
+
+  const sessionsDirectories = (
+    await Promise.all(
+      projects.map((project) => projectSessionsDirectory(project, discovery.sessionsDirectoryName)),
+    )
+  )
+    .filter((entry): entry is ProjectSessionsDirectory => entry !== undefined)
+    .sort((first, second) => second.mtimeMs - first.mtimeMs)
+    .slice(0, discovery.maximumProjectDirectories);
+
+  const files = (
+    await Promise.all(
+      sessionsDirectories.map((entry) =>
+        discovery.sessionFilesIn(entry.sessionsDirectory, entry.project),
+      ),
+    )
+  ).flat();
+  return files
+    .sort((first, second) => second.mtimeMs - first.mtimeMs)
+    .slice(0, discovery.maximumSessionFiles);
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import {
+  CompositeSessionProviderAdapter,
   fixtureSnapshot,
   InMemorySessionRegistry,
   type NativeNotchGeometry,
@@ -29,7 +30,8 @@ import {
 import { ClaudeCodeSessionAdapter } from "./claude-code-adapter";
 import { CodexSessionAdapter } from "./codex-adapter";
 import { ConductorSessionAdapter } from "./conductor-adapter";
-import { CursorSessionAdapter } from "./cursor-adapter";
+import { CURSOR_PROVIDER, CursorSessionAdapter } from "./cursor-adapter";
+import { CursorLocalSessionAdapter } from "./cursor-local-adapter";
 import { DevinSessionAdapter } from "./devin-adapter";
 import { readMacScreenGeometry } from "./macos-screen-geometry";
 import { openAiAttentionEvaluatorFromEnvironment } from "./openai-attention-evaluator";
@@ -75,8 +77,19 @@ const settingsStore = new SettingsStore({
 const conductorAdapter = new ConductorSessionAdapter({
   readApiKey: () => settingsStore.readApiKey(CREDENTIAL_PROVIDER_ID.CONDUCTOR),
 });
-const cursorAdapter = new CursorSessionAdapter({
-  readApiKey: () => settingsStore.readApiKey(CREDENTIAL_PROVIDER_ID.CURSOR),
+// Cursor runs sessions in two places: on this machine, which needs no
+// credential and is observed from the transcripts Cursor writes for itself, and
+// in its cloud, which needs a key. They are one provider wherever they ran, so
+// they are observed as one adapter — a provider's sessions are replaced in a
+// single commit, and two adapters sharing an id would retire each other's.
+const cursorAdapter = new CompositeSessionProviderAdapter({
+  provider: CURSOR_PROVIDER,
+  adapters: [
+    new CursorLocalSessionAdapter(),
+    new CursorSessionAdapter({
+      readApiKey: () => settingsStore.readApiKey(CREDENTIAL_PROVIDER_ID.CURSOR),
+    }),
+  ],
 });
 const devinAdapter = new DevinSessionAdapter({
   readApiKey: () => settingsStore.readApiKey(CREDENTIAL_PROVIDER_ID.DEVIN),

--- a/apps/desktop/tests/cursor-local-adapter.test.ts
+++ b/apps/desktop/tests/cursor-local-adapter.test.ts
@@ -355,6 +355,36 @@ test("names a folder its project directory can no longer spell", async (t) => {
   );
 });
 
+test("names a folder whose project directory kept a character Luke would rewrite", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeWorkspaceRecord(state, "4d5e", "/Users/test/my_project");
+  await writeWorkspaceRecord(state, "8f9a", "/Users/test/Notes (2026)");
+  // Cursor decides for itself which characters it will not put in a directory
+  // name, so these keep an underscore and a bracket that Luke's own reduction
+  // would have rewritten. Matching must not depend on agreeing with it.
+  await writeTranscript(
+    state,
+    "Users-test-my_project",
+    "session-underscored",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 1_000,
+  );
+  await writeTranscript(
+    state,
+    "Users-test-Notes (2026)",
+    "session-bracketed",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 2_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.title),
+    ["my_project", "Notes (2026)"],
+  );
+});
+
 test("labels a session neutrally rather than guessing at a folder", async (t) => {
   const state = await temporaryCursorState(t);
   // A window with no folder, and two folders that share one project directory

--- a/apps/desktop/tests/cursor-local-adapter.test.ts
+++ b/apps/desktop/tests/cursor-local-adapter.test.ts
@@ -1,0 +1,502 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test, { type TestContext } from "node:test";
+import { pathToFileURL } from "node:url";
+import { SESSION_STATUS } from "@sidecar/core";
+import { CURSOR_PROVIDER } from "../src/cursor-adapter";
+import { CursorLocalSessionAdapter } from "../src/cursor-local-adapter";
+
+const TEST_TIME = Date.parse("2026-08-13T02:45:00.000Z");
+const YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+const SECRET_TRANSCRIPT_TEXT = "SECRET_TRANSCRIPT_TEXT";
+const CURSOR_PROJECTS_DIRECTORY = "projects";
+const CURSOR_TRANSCRIPTS_DIRECTORY = "agent-transcripts";
+const CURSOR_WORKSPACE_FILE = "workspace.json";
+
+const TEST_ROLE = {
+  ASSISTANT: "assistant",
+  USER: "user",
+} as const;
+
+const TEST_RECORD_TYPE = {
+  TURN_ENDED: "turn_ended",
+} as const;
+
+const TEST_TURN_STATUS = {
+  ERROR: "error",
+  SUCCESS: "success",
+} as const;
+
+const TEST_CONTENT_TYPE = {
+  TEXT: "text",
+  TOOL_USE: "tool_use",
+} as const;
+
+interface CursorState {
+  cursorHome: string;
+  workspaceStorageDirectory: string;
+}
+
+function messageRecord(role: string, contentType: string): Record<string, unknown> {
+  return {
+    role,
+    message: { content: [{ type: contentType, text: SECRET_TRANSCRIPT_TEXT }] },
+  };
+}
+
+function turnEndedRecord(status: string): Record<string, unknown> {
+  return {
+    type: TEST_RECORD_TYPE.TURN_ENDED,
+    status,
+    ...(status === TEST_TURN_STATUS.ERROR ? { error: { message: SECRET_TRANSCRIPT_TEXT } } : {}),
+  };
+}
+
+async function temporaryCursorState(t: TestContext): Promise<CursorState> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-cursor-local-"));
+  t.after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  return {
+    cursorHome: path.join(directory, "cursor-home"),
+    workspaceStorageDirectory: path.join(directory, "workspace-storage"),
+  };
+}
+
+async function writeTranscript(
+  state: CursorState,
+  projectDirectoryName: string,
+  sessionId: string,
+  records: readonly Record<string, unknown>[],
+  mtimeMs: number,
+): Promise<void> {
+  const sessionDirectory = path.join(
+    state.cursorHome,
+    CURSOR_PROJECTS_DIRECTORY,
+    projectDirectoryName,
+    CURSOR_TRANSCRIPTS_DIRECTORY,
+    sessionId,
+  );
+  await fs.mkdir(sessionDirectory, { recursive: true });
+  const filePath = path.join(sessionDirectory, `${sessionId}.jsonl`);
+  await fs.writeFile(filePath, `${records.map((record) => JSON.stringify(record)).join("\n")}\n`);
+  await fs.utimes(filePath, mtimeMs / 1000, mtimeMs / 1000);
+}
+
+/** A session's subagents file their transcripts beside its own. */
+async function writeSubagentTranscript(
+  state: CursorState,
+  projectDirectoryName: string,
+  sessionId: string,
+  subagentId: string,
+  mtimeMs: number,
+): Promise<void> {
+  const subagentsDirectory = path.join(
+    state.cursorHome,
+    CURSOR_PROJECTS_DIRECTORY,
+    projectDirectoryName,
+    CURSOR_TRANSCRIPTS_DIRECTORY,
+    sessionId,
+    "subagents",
+  );
+  await fs.mkdir(subagentsDirectory, { recursive: true });
+  const filePath = path.join(subagentsDirectory, `${subagentId}.jsonl`);
+  await fs.writeFile(
+    filePath,
+    `${JSON.stringify(messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TEXT))}\n`,
+  );
+  await fs.utimes(filePath, mtimeMs / 1000, mtimeMs / 1000);
+}
+
+function projectDirectory(state: CursorState, projectDirectoryName: string): string {
+  return path.join(state.cursorHome, CURSOR_PROJECTS_DIRECTORY, projectDirectoryName);
+}
+
+/**
+ * Backdates a directory the way the filesystem would have. A directory's mtime
+ * moves when it gains or loses an entry and at no other time, so a project's
+ * and its transcripts directory's can be years apart.
+ */
+async function setDirectoryMtime(directory: string, mtimeMs: number): Promise<void> {
+  await fs.mkdir(directory, { recursive: true });
+  await fs.utimes(directory, mtimeMs / 1000, mtimeMs / 1000);
+}
+
+/** Cursor's own record of a window it opened on a folder. */
+async function writeWorkspaceRecord(
+  state: CursorState,
+  entryName: string,
+  folderPath: string | undefined,
+): Promise<void> {
+  const entryDirectory = path.join(state.workspaceStorageDirectory, entryName);
+  await fs.mkdir(entryDirectory, { recursive: true });
+  await fs.writeFile(
+    path.join(entryDirectory, CURSOR_WORKSPACE_FILE),
+    JSON.stringify(folderPath ? { folder: pathToFileURL(folderPath).href } : {}),
+  );
+}
+
+function adapterFor(
+  state: CursorState,
+  overrides: {
+    now?: () => number;
+    maximumSessionAgeMs?: number;
+    activeSessionFreshnessMs?: number;
+    maximumProjectDirectories?: number;
+    maximumSessionFiles?: number;
+    readTailBytes?: number;
+  } = {},
+): CursorLocalSessionAdapter {
+  return new CursorLocalSessionAdapter({
+    ...state,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60 * 60 * 1000,
+    ...overrides,
+  });
+}
+
+test("observes an open turn as work, labelled by its folder and free of transcript text", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "0b1f4b0e-2c5a-4d1e-9a3c-6d5f7e8a9b0c",
+    [
+      messageRecord(TEST_ROLE.USER, TEST_CONTENT_TYPE.TEXT),
+      messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TOOL_USE),
+    ],
+    TEST_TIME - 5_000,
+  );
+
+  const adapter = adapterFor(state);
+  const observations = await adapter.observe();
+
+  assert.deepEqual(adapter.provider, CURSOR_PROVIDER);
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "0b1f4b0e-2c5a-4d1e-9a3c-6d5f7e8a9b0c");
+  assert.equal(observations[0]?.title, "luke");
+  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
+  assert.equal(observations[0]?.observedAt, TEST_TIME - 5_000);
+  assert.equal(observations[0]?.controls, undefined);
+  assert.equal(observations[0]?.summary, undefined);
+  assert.deepEqual(observations[0]?.detail, { repository: "luke" });
+  // Nothing says this session runs anywhere but here, which is what leaves it
+  // local once the registry normalizes it.
+  assert.equal(observations[0]?.location, undefined);
+  assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);
+});
+
+test("tells a turn that finished from one that failed", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "session-finished",
+    [
+      messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TEXT),
+      turnEndedRecord(TEST_TURN_STATUS.SUCCESS),
+    ],
+    TEST_TIME - 5_000,
+  );
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "session-failed",
+    [
+      messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TOOL_USE),
+      turnEndedRecord(TEST_TURN_STATUS.ERROR),
+    ],
+    TEST_TIME - 10_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => [observation.providerSessionId, observation.status]),
+    [
+      ["session-finished", SESSION_STATUS.WAITING],
+      ["session-failed", SESSION_STATUS.ERROR],
+    ],
+  );
+  // The failure is reported; the reason Cursor recorded for it is not.
+  assert.deepEqual(observations[1]?.detail, {
+    repository: "luke",
+    error: "The turn failed",
+  });
+  assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);
+});
+
+test("passes over trailing records this build does not know", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "session-annotated",
+    [
+      messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TEXT),
+      turnEndedRecord(TEST_TURN_STATUS.SUCCESS),
+      { type: "some_later_record", detail: SECRET_TRANSCRIPT_TEXT },
+    ],
+    TEST_TIME - 5_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
+});
+
+test("leaves a transcript that has gone quiet unknown instead of inventing activity", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "session-quiet",
+    [messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TOOL_USE)],
+    TEST_TIME - 20 * 60 * 1000,
+  );
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "session-abandoned",
+    [
+      messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TEXT),
+      turnEndedRecord(TEST_TURN_STATUS.SUCCESS),
+    ],
+    TEST_TIME - 21 * 60 * 1000,
+  );
+
+  const observations = await adapterFor(state, {
+    activeSessionFreshnessMs: 15 * 60 * 1000,
+  }).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.status),
+    [SESSION_STATUS.UNKNOWN, SESSION_STATUS.UNKNOWN],
+  );
+});
+
+test("keeps reporting a failure that has gone quiet, because it has not healed", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "session-stuck",
+    [
+      messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TOOL_USE),
+      turnEndedRecord(TEST_TURN_STATUS.ERROR),
+    ],
+    TEST_TIME - 40 * 60 * 1000,
+  );
+
+  const observations = await adapterFor(state, {
+    activeSessionFreshnessMs: 15 * 60 * 1000,
+  }).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.status),
+    [SESSION_STATUS.ERROR],
+  );
+});
+
+test("ignores sessions older than the maximum session age", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "session-yesterday",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 25 * 60 * 60 * 1000,
+  );
+
+  const observations = await adapterFor(state, {
+    maximumSessionAgeMs: 24 * 60 * 60 * 1000,
+  }).observe();
+
+  assert.deepEqual(observations, []);
+});
+
+test("names a folder its project directory can no longer spell", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeWorkspaceRecord(state, "6a20", "/Users/test/luke.github.io");
+  await writeWorkspaceRecord(state, "77b8", "/Users/test/Documents/[00] Notes:Archive");
+  await writeWorkspaceRecord(state, "c4d1", "/Users/test/workspaces/luke/sidecar-v2");
+  await writeTranscript(
+    state,
+    "Users-test-luke-github-io",
+    "session-site",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 1_000,
+  );
+  await writeTranscript(
+    state,
+    "Users-test-Documents-00-Notes-Archive",
+    "session-notes",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 2_000,
+  );
+  await writeTranscript(
+    state,
+    "Users-test-workspaces-luke-sidecar-v2",
+    "session-workspace",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 3_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.title),
+    ["luke.github.io", "[00] Notes:Archive", "sidecar-v2"],
+  );
+});
+
+test("labels a session neutrally rather than guessing at a folder", async (t) => {
+  const state = await temporaryCursorState(t);
+  // A window with no folder, and two folders that share one project directory
+  // name while disagreeing about what it should be called.
+  await writeWorkspaceRecord(state, "1a2b", undefined);
+  await writeWorkspaceRecord(state, "3c4d", "/Users/test/luke-v2");
+  await writeWorkspaceRecord(state, "5e6f", "/Users/test/luke/v2");
+  await writeTranscript(
+    state,
+    "empty-window",
+    "session-windowed",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 1_000,
+  );
+  await writeTranscript(
+    state,
+    "Users-test-luke-v2",
+    "session-ambiguous",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 2_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.title),
+    ["workspace", "workspace"],
+  );
+});
+
+test("observes a session and not the subagents it ran", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "session-with-subagents",
+    [messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TOOL_USE)],
+    TEST_TIME - 5_000,
+  );
+  await writeSubagentTranscript(
+    state,
+    "Users-test-luke",
+    "session-with-subagents",
+    "subagent-explore",
+    TEST_TIME - 1_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.providerSessionId),
+    ["session-with-subagents"],
+  );
+});
+
+test("finds the newest records when only the end of a long transcript is read", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "session-long",
+    [
+      { role: TEST_ROLE.ASSISTANT, message: { content: [{ text: "x".repeat(512) }] } },
+      turnEndedRecord(TEST_TURN_STATUS.SUCCESS),
+    ],
+    TEST_TIME - 1_000,
+  );
+
+  const observations = await adapterFor(state, { readTailBytes: 128 }).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
+});
+
+test("bounds how many sessions one pass reports, keeping the newest", async (t) => {
+  const state = await temporaryCursorState(t);
+  for (const [index, sessionId] of [
+    "session-newest",
+    "session-older",
+    "session-oldest",
+  ].entries()) {
+    await writeTranscript(
+      state,
+      "Users-test-luke",
+      sessionId,
+      [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+      TEST_TIME - (index + 1) * 1_000,
+    );
+  }
+
+  const observations = await adapterFor(state, { maximumSessionFiles: 2 }).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.providerSessionId),
+    ["session-newest", "session-older"],
+  );
+});
+
+test("keeps the projects that most recently started a session", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeWorkspaceRecord(state, "9f1c", "/Users/test/daily");
+  await writeWorkspaceRecord(state, "7b2e", "/Users/test/dormant");
+  await writeTranscript(
+    state,
+    "Users-test-daily",
+    "session-today",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 1_000,
+  );
+  await writeTranscript(
+    state,
+    "Users-test-dormant",
+    "session-long-ago",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 2_000,
+  );
+  // The project Cursor wrote to first holds the newer session, and a folder
+  // opened moments ago has never run an agent at all. A project directory's own
+  // mtime tells all three apart backwards.
+  await setDirectoryMtime(projectDirectory(state, "Users-test-daily"), TEST_TIME - YEAR_MS);
+  await setDirectoryMtime(projectDirectory(state, "Users-test-dormant"), TEST_TIME - 60_000);
+  await setDirectoryMtime(projectDirectory(state, "Users-test-opened-today"), TEST_TIME);
+  await setDirectoryMtime(
+    path.join(projectDirectory(state, "Users-test-daily"), CURSOR_TRANSCRIPTS_DIRECTORY),
+    TEST_TIME - 1_000,
+  );
+  await setDirectoryMtime(
+    path.join(projectDirectory(state, "Users-test-dormant"), CURSOR_TRANSCRIPTS_DIRECTORY),
+    TEST_TIME - YEAR_MS,
+  );
+
+  const observations = await adapterFor(state, { maximumProjectDirectories: 1 }).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.providerSessionId),
+    ["session-today"],
+  );
+});
+
+test("returns an empty snapshot when Cursor has no local sessions", async (t) => {
+  const state = await temporaryCursorState(t);
+
+  assert.deepEqual(await adapterFor(state).observe(), []);
+});

--- a/packages/sidecar-core/src/composite-provider-adapter.ts
+++ b/packages/sidecar-core/src/composite-provider-adapter.ts
@@ -1,0 +1,53 @@
+import type { SessionProviderAdapter } from "./providers";
+import type { ProviderSessionObservation, SessionProvider } from "./session";
+
+export interface CompositeProviderAdapterOptions {
+  provider: SessionProvider;
+  /** Observed in order, which is also the order that settles a repeated session. */
+  adapters: readonly SessionProviderAdapter[];
+}
+
+/**
+ * One provider observed in more than one place — sessions on this machine and
+ * the same provider's sessions in its cloud. The registry replaces a provider's
+ * sessions in a single commit, so observers that share a provider id have to
+ * arrive as one adapter: registered separately, each pass would retire the
+ * other's sessions.
+ */
+export class CompositeSessionProviderAdapter implements SessionProviderAdapter {
+  readonly provider: SessionProvider;
+
+  readonly #adapters: readonly SessionProviderAdapter[];
+
+  constructor(options: CompositeProviderAdapterOptions) {
+    for (const adapter of options.adapters) {
+      // Observing one provider's sessions under another's identity is a wiring
+      // mistake rather than something a user can correct.
+      if (adapter.provider.id !== options.provider.id) {
+        throw new Error(
+          `Composite adapter for ${options.provider.id} cannot observe ${adapter.provider.id}`,
+        );
+      }
+    }
+    this.provider = options.provider;
+    this.#adapters = options.adapters;
+  }
+
+  /**
+   * A pass fails whole. The registry commits a provider snapshot entire, so
+   * reporting the observers that answered would retire every session belonging
+   * to the one that did not, and the panel would lose them until it recovers.
+   */
+  async observe(): Promise<readonly ProviderSessionObservation[]> {
+    const collected = await Promise.all(this.#adapters.map((adapter) => adapter.observe()));
+    const observations = new Map<string, ProviderSessionObservation>();
+    // A session two observers both reached is still one session, and the
+    // registry rejects a snapshot that names one twice.
+    for (const observation of collected.flat()) {
+      if (!observations.has(observation.providerSessionId)) {
+        observations.set(observation.providerSessionId, observation);
+      }
+    }
+    return [...observations.values()];
+  }
+}

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./attention";
 export * from "./attention-examples";
 export * from "./attention-prompt";
+export * from "./composite-provider-adapter";
 export * from "./fixtures";
 export * from "./geometry";
 export * from "./providers";

--- a/packages/sidecar-core/tests/composite-provider-adapter.test.ts
+++ b/packages/sidecar-core/tests/composite-provider-adapter.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  CompositeSessionProviderAdapter,
+  InMemorySessionRegistry,
+  type ProviderSessionObservation,
+  SESSION_LOCATION,
+  SESSION_STATUS,
+  type SessionProvider,
+  type SessionProviderAdapter,
+} from "../src";
+
+const cursor: SessionProvider = { id: "cursor", displayName: "Cursor" };
+const codex: SessionProvider = { id: "codex", displayName: "Codex" };
+
+function observation(
+  providerSessionId: string,
+  overrides: Partial<ProviderSessionObservation> = {},
+): ProviderSessionObservation {
+  return {
+    providerSessionId,
+    title: "Cursor: luke",
+    status: SESSION_STATUS.WORKING,
+    observedAt: 100,
+    ...overrides,
+  };
+}
+
+function observerOf(
+  provider: SessionProvider,
+  observations: readonly ProviderSessionObservation[],
+): SessionProviderAdapter {
+  return { provider, observe: async () => observations };
+}
+
+function failingObserver(provider: SessionProvider): SessionProviderAdapter {
+  return {
+    provider,
+    observe: async () => {
+      throw new Error("session state is unreadable");
+    },
+  };
+}
+
+test("reports every observer's sessions as one provider snapshot", async () => {
+  const adapter = new CompositeSessionProviderAdapter({
+    provider: cursor,
+    adapters: [
+      observerOf(cursor, [observation("local-session")]),
+      observerOf(cursor, [observation("cloud-agent", { status: SESSION_STATUS.WAITING })]),
+    ],
+  });
+
+  const observations = await adapter.observe();
+
+  assert.equal(adapter.provider, cursor);
+  assert.deepEqual(
+    observations.map((entry) => [entry.providerSessionId, entry.status]),
+    [
+      ["local-session", SESSION_STATUS.WORKING],
+      ["cloud-agent", SESSION_STATUS.WAITING],
+    ],
+  );
+});
+
+test("leaves each half of a provider saying where its own sessions run", async () => {
+  const adapter = new CompositeSessionProviderAdapter({
+    provider: cursor,
+    adapters: [
+      observerOf(cursor, [observation("local-session")]),
+      observerOf(cursor, [observation("cloud-agent", { location: SESSION_LOCATION.CLOUD })]),
+    ],
+  });
+
+  // One provider mark, two places. Merging under one id must not make the
+  // sessions on this machine read as though they ran in a datacentre.
+  const registry = new InMemorySessionRegistry();
+  await registry.refresh(adapter);
+  const locations = new Map(
+    registry.list().map((session) => [session.providerSessionId, session.location]),
+  );
+  assert.equal(locations.get("local-session"), SESSION_LOCATION.LOCAL);
+  assert.equal(locations.get("cloud-agent"), SESSION_LOCATION.CLOUD);
+});
+
+test("keeps a session two observers both reached from being reported twice", async () => {
+  const adapter = new CompositeSessionProviderAdapter({
+    provider: cursor,
+    adapters: [
+      observerOf(cursor, [observation("shared", { title: "Cursor: luke" })]),
+      observerOf(cursor, [observation("shared", { title: "Cursor: workspace" })]),
+    ],
+  });
+
+  const observations = await adapter.observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.title, "Cursor: luke");
+  // The registry rejects a snapshot that names one session twice, so this is
+  // what keeps a provider observed in two places from failing its own refresh.
+  const registry = new InMemorySessionRegistry();
+  assert.equal((await registry.refresh(adapter)).sessions.length, 1);
+});
+
+test("fails the pass when one observer fails, rather than retiring its sessions", async () => {
+  const registry = new InMemorySessionRegistry();
+  const healthy = observerOf(cursor, [observation("local-session")]);
+  await registry.refresh(
+    new CompositeSessionProviderAdapter({ provider: cursor, adapters: [healthy] }),
+  );
+
+  const adapter = new CompositeSessionProviderAdapter({
+    provider: cursor,
+    adapters: [healthy, failingObserver(cursor)],
+  });
+
+  await assert.rejects(() => adapter.observe(), /unreadable/);
+  await assert.rejects(() => registry.refresh(adapter), /unreadable/);
+  assert.deepEqual(
+    registry.list().map((session) => session.providerSessionId),
+    ["local-session"],
+  );
+});
+
+test("refuses to observe one provider's sessions under another's identity", () => {
+  assert.throws(
+    () =>
+      new CompositeSessionProviderAdapter({
+        provider: cursor,
+        adapters: [observerOf(codex, [])],
+      }),
+    /cursor cannot observe codex/,
+  );
+});


### PR DESCRIPTION
## Summary

Cursor writes a transcript for each of its own local sessions under `~/.cursor/projects/<project>/agent-transcripts/`. `apps/desktop/src/cursor-local-adapter.ts` reads those, so the Cursor agents running on this machine appear beside the cloud ones with no key and no configuration, the way Claude Code and Codex already do.

- **Status comes from turn markers, never from content.** Cursor closes a turn explicitly, so a closed turn is `waiting`, one it closed on a failure is `error` — the two ask different things of the developer — and anything else is a turn still open, so `working`. A transcript quiet for a quarter of an hour reports `unknown`; a failure does not decay that way, because it does not heal by going stale. No message body is ever parsed, so no transcript text can reach an observation: a failed turn reports *that* it failed, never the reason Cursor recorded for it.
- **Sessions are labelled by the folder they run in.** A project directory name has already lost the separators of the path it was made from, so guessing where the hyphens used to be would call `sidecar-v2` "v2". Instead Luke names Cursor's own `workspaceStorage/*/workspace.json` records the same way and matches, falling back to the neutral `workspace` label when a folder is unknown or two folders disagree. Cursor names a chat from its opening prompt, so that name is the prompt and is never read. Subagent transcripts are skipped: they belong to their parent session rather than being sessions of their own.
- **Cursor is now one provider observed in two places, and the location carries which.** The registry replaces a provider's sessions in a single commit, so two adapters sharing an id would retire each other's every pass. `packages/sidecar-core/src/composite-provider-adapter.ts` merges them under one id, de-duplicates, and fails a pass whole rather than retiring the absent half's sessions. The cloud half stamps its own sessions `cloud` and this one says nothing, so #34's badge still marks each session by where it actually ran. Local Cursor needs no key; cloud Cursor still observes nothing without one.
- **A project is ranked by the directory its sessions land in.** A directory's mtime moves when it gains or loses an entry and at no other time, so for Cursor's nested layout a project directory's mtime stops moving the moment `agent-transcripts` is created. Ranking by it would have ranked a folder used every day by the day Cursor first wrote there, and past the 200-project bound its live session could be dropped for a folder idle for a year. Claude Code files sessions in the project directory itself, so its ranking is unchanged.
- `apps/desktop/src/local-session-adapter.ts` holds what this adapter and the Claude Code one read the same way — bounded head and tail reads, filesystem-error tolerance, JSONL records, session discovery — mirroring how `cloud-session-adapter.ts` already serves the cloud providers. Codex is untouched; it reads SQLite, not transcripts.
- `PRIVACY.md` said Cursor has no local session state for Luke to observe, which this change makes untrue; it now describes what is read locally and what is deliberately not.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — exit 0. 183 tests pass (5 harness, 40 core, 138 desktop), against 165 on `main`: 13 new Cursor-local tests and 5 composite tests.
- Rebased onto `main` after eight commits landed mid-flight, including #27 (which rewrote `claude-code-adapter.ts`), #34 (`SESSION_LOCATION`), and #32 (which rewrote the README). The shared-helper extraction was re-derived against the new adapter rather than merged, and main's Claude Code suite passes unchanged — which is what covers the extraction.
- The Cursor adapter was re-derived for main's new vocabulary: a failed turn now reports `error` rather than `waiting`, titles drop the `Cursor: ` prefix to match #27's convention, the fixed status summary is gone, and the folder is reported as `detail.repository`.
- The ranking fix's regression test — `keeps the projects that most recently started a session` — was confirmed to fail without the fix (observes `[]`) and pass with it, rather than being assumed to cover it.
- Verified against the real `~/.cursor` on the author's Mac (read-only, via the local bridge), which is what covers the folder labelling — the one path tests could not vouch for, since its fixtures encode the same assumptions that produced both review findings:
  - 20 project directories; 7 hold transcripts, and **6 of those 7 resolve to their folder name**. The single project inside the 24-hour window Luke actually reports resolves.
  - The remaining 13 project directories have no `agent-transcripts` at all — so the "a project with no sessions directory takes none of the bound" change frees 65% of the slots in the 200-project bound on this machine.
  - Bugbot's underscore claim does not reproduce here: 23 folders contain `_`, but none has ever had a project directory, and Cursor demonstrably rewrites space, `.`, `:`, `[` and `]` to hyphens — every one of the 20 project names contains no punctuation but `-`. The canonicalization fix is measurably neutral on this data (15 resolved before, 15 after) and is kept because it removes the dependency on Cursor's escaping rule rather than because it moved a number.
- macOS Electron verification (`./scripts/verify.sh`): `not run` locally — it needs macOS and this workspace is Linux. The macOS CI job runs it on this branch.
- Read against a real `~/.cursor`: 10 transcripts discovered, the subagent file correctly excluded, and every folder label resolved (`stage`, `diffity`, `doha-v3`, `resolve-thread-ga7`…) except a folderless window, which fell back to `workspace`. The bounded 64 KB tail reached the same verdict as a full read on all 10 files.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31668299809/artifacts/9168773093) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31668299809)

- Commit: `afe59cd619afe8471474295d1725a173acde9573`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` — the author confirmed on their Mac that a live local Cursor session is observed. That was before the rebase, so the row's wording has since changed (no `Cursor: ` prefix, folder shown as repository, a failed turn now reads as an error).
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: None outstanding in CI. Worth re-checking a live local Cursor row on a Mac, since the rebase changed what that row says.
- A machine whose newest local Cursor transcript is older than 24 hours shows no local Cursor rows until its next session — that is the age bound working, not a gap.
- Known residual, stated rather than hidden: no directory mtime records an append, so the project bound keeps the projects that most recently *started* a session rather than most recently wrote to one. Closing that would mean reading every project directory, which is what the bound exists to avoid. The session bound that follows it is ordered by each transcript's own last write, which is exact.
