### PR TITLE
feat(sessions): badge a session's mark when its work runs in the cloud

### DIFF
--- a/apps/desktop/src/cloud-session-adapter.ts
+++ b/apps/desktop/src/cloud-session-adapter.ts
@@ -1,5 +1,6 @@
 import {
   type ProviderSessionObservation,
+  SESSION_LOCATION,
   SESSION_STATUS,
   type SessionProvider,
   type SessionProviderAdapter,
@@ -214,7 +215,7 @@ export abstract class CloudSessionAdapter implements SessionProviderAdapter {
     const pass = ++this.#collectPass;
     try {
       const collected = await this.collect(this.#requestForPass(pass, apiKey), now);
-      if (pass === this.#collectPass) this.#observations = uniqueObservations(collected);
+      if (pass === this.#collectPass) this.#observations = cloudObservations(collected);
     } catch (error) {
       // A rejected credential clears observed state; a transient network or
       // server failure keeps the previous snapshot until the next attempt. A
@@ -364,13 +365,21 @@ export abstract class CloudSessionAdapter implements SessionProviderAdapter {
   }
 }
 
-function uniqueObservations(
+/**
+ * Drops a session a subclass reported twice, and stamps the location the base
+ * already knows: nothing reaches this point except over the network, so a
+ * subclass cannot forget to say its sessions run somewhere else.
+ */
+function cloudObservations(
   observations: readonly ProviderSessionObservation[],
 ): readonly ProviderSessionObservation[] {
   const unique = new Map<string, ProviderSessionObservation>();
   for (const observation of observations) {
     if (!unique.has(observation.providerSessionId)) {
-      unique.set(observation.providerSessionId, observation);
+      unique.set(observation.providerSessionId, {
+        ...observation,
+        location: SESSION_LOCATION.CLOUD,
+      });
     }
   }
   return [...unique.values()];

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -1,8 +1,8 @@
 import { SESSION_LOCATION } from "@sidecar/core";
 import { PANEL_TAB, type PanelTab, TabBar } from "./panel-tabs";
-import { ProviderMark } from "./provider-marks";
+import { CloudBadge, ProviderMark } from "./provider-marks";
 import type { DisplaySession } from "./session-model";
-import { CloudBadge, EmptyState, SessionsPanel, StateChip } from "./session-parts";
+import { EmptyState, SessionsPanel, StateChip } from "./session-parts";
 import { SettingsPanel, type SettingsPanelProps } from "./settings-panel";
 
 export interface PanelBodyProps {

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -1,7 +1,8 @@
+import { SESSION_LOCATION } from "@sidecar/core";
 import { PANEL_TAB, type PanelTab, TabBar } from "./panel-tabs";
 import { ProviderMark } from "./provider-marks";
 import type { DisplaySession } from "./session-model";
-import { EmptyState, SessionsPanel, StateChip } from "./session-parts";
+import { CloudBadge, EmptyState, SessionsPanel, StateChip } from "./session-parts";
 import { SettingsPanel, type SettingsPanelProps } from "./settings-panel";
 
 export interface PanelBodyProps {
@@ -37,6 +38,7 @@ export function PanelBody({
               >
                 <span className="row-avatar">
                   <ProviderMark providerId={session.providerId} />
+                  {session.location === SESSION_LOCATION.CLOUD ? <CloudBadge /> : null}
                 </span>
                 <span className="row-copy">
                   <strong>{session.title}</strong>

--- a/apps/desktop/src/renderer/provider-marks.tsx
+++ b/apps/desktop/src/renderer/provider-marks.tsx
@@ -2,6 +2,8 @@ import { PROVIDER_ID } from "@sidecar/core";
 import { useId } from "react";
 
 /**
+ * The provider marks, and the one badge that rides them.
+ *
  * Provider marks are inlined as path data rather than bundled image files, so
  * the renderer stays asset-free and the marks scale with the surface.
  *
@@ -154,4 +156,32 @@ export function ProviderMark({
 }: MarkProps & { providerId: string }): React.JSX.Element {
   const Mark = PROVIDER_MARKS.get(providerId) ?? UnknownProviderMark;
   return <Mark className={className ? `provider-mark ${className}` : "provider-mark"} />;
+}
+
+/**
+ * Two small puffs and one large one over a flat base, traced as a single
+ * outline: drawn as overlapping shapes instead, a fill this translucent doubles
+ * where they cross and every seam inside the cloud shows.
+ */
+const CLOUD_PATH = "M4.5 14a4.5 4.5 0 0 1-1.259-8.82 7 7 0 0 1 13.518 0A4.5 4.5 0 0 1 15.5 14z";
+
+/**
+ * Rides the bottom-right corner of a provider mark to say the work is not
+ * happening on this machine. It is ours rather than a brand mark, so it is
+ * drawn filled in the text palette: at this size a stroked outline closes up,
+ * and a second brand colour beside the provider's own would read as part of the
+ * mark. It takes the mark's corner in every place a mark is shown, and each of
+ * those places sizes it against the mark it annotates.
+ */
+export function CloudBadge(): React.JSX.Element {
+  return (
+    <span className="cloud-badge" role="img" aria-label="Runs in the cloud">
+      {/* The box is the cloud's own proportions rather than the square the
+          other glyphs use, so at this size the shape spends every pixel it has
+          on itself rather than on margin. */}
+      <svg viewBox="0 0 20 14" fill="currentColor" aria-hidden="true" focusable="false">
+        <path d={CLOUD_PATH} />
+      </svg>
+    </span>
+  );
 }

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -3,6 +3,7 @@ import {
   type NormalizedSession,
   SESSION_STATE,
   SESSION_STATUS,
+  type SessionLocation,
   type SessionState,
 } from "@sidecar/core";
 import type { AppBootstrap } from "../shared/contracts";
@@ -37,6 +38,7 @@ export interface DisplaySession {
   detail: string;
   state: SessionState;
   label: string;
+  location: SessionLocation;
 }
 
 export interface ProviderTally {
@@ -88,6 +90,7 @@ export function displaySessions(
         detail: session.summary ?? STATUS_LABEL[session.status],
         state: sessionState(session),
         label: STATE_LABEL[sessionState(session)],
+        location: session.location,
       }));
 
   return [...visible].sort(

--- a/apps/desktop/src/renderer/session-parts.tsx
+++ b/apps/desktop/src/renderer/session-parts.tsx
@@ -16,6 +16,34 @@ export function StateChip({
   );
 }
 
+/**
+ * Two small puffs and one large one over a flat base, traced as a single
+ * outline: drawn as overlapping shapes instead, a fill this translucent doubles
+ * where they cross and every seam inside the cloud shows.
+ */
+const CLOUD_PATH = "M4.5 14a4.5 4.5 0 0 1-1.259-8.82 7 7 0 0 1 13.518 0A4.5 4.5 0 0 1 15.5 14z";
+
+/**
+ * Sits in the bottom-right corner of a provider mark to say the session is not
+ * running on this machine. It is ours rather than a brand mark, so it is drawn
+ * filled in the text palette: at this size a stroked outline closes up, and a
+ * second brand colour beside the provider's own would read as part of the mark.
+ * The corner it takes is the mark's, not the row's, because what runs remotely
+ * is the session — not the provider the whole row belongs to.
+ */
+export function CloudBadge(): React.JSX.Element {
+  return (
+    <span className="row-cloud" role="img" aria-label="Runs in the cloud">
+      {/* The box is the cloud's own proportions rather than the square the
+          other glyphs use, so at this size the shape spends every pixel it has
+          on itself rather than on margin. */}
+      <svg viewBox="0 0 20 14" fill="currentColor" aria-hidden="true" focusable="false">
+        <path d={CLOUD_PATH} />
+      </svg>
+    </span>
+  );
+}
+
 export function EmptyState(): React.JSX.Element {
   return (
     <div className="empty-state">

--- a/apps/desktop/src/renderer/session-parts.tsx
+++ b/apps/desktop/src/renderer/session-parts.tsx
@@ -16,34 +16,6 @@ export function StateChip({
   );
 }
 
-/**
- * Two small puffs and one large one over a flat base, traced as a single
- * outline: drawn as overlapping shapes instead, a fill this translucent doubles
- * where they cross and every seam inside the cloud shows.
- */
-const CLOUD_PATH = "M4.5 14a4.5 4.5 0 0 1-1.259-8.82 7 7 0 0 1 13.518 0A4.5 4.5 0 0 1 15.5 14z";
-
-/**
- * Sits in the bottom-right corner of a provider mark to say the session is not
- * running on this machine. It is ours rather than a brand mark, so it is drawn
- * filled in the text palette: at this size a stroked outline closes up, and a
- * second brand colour beside the provider's own would read as part of the mark.
- * The corner it takes is the mark's, not the row's, because what runs remotely
- * is the session — not the provider the whole row belongs to.
- */
-export function CloudBadge(): React.JSX.Element {
-  return (
-    <span className="row-cloud" role="img" aria-label="Runs in the cloud">
-      {/* The box is the cloud's own proportions rather than the square the
-          other glyphs use, so at this size the shape spends every pixel it has
-          on itself rather than on margin. */}
-      <svg viewBox="0 0 20 14" fill="currentColor" aria-hidden="true" focusable="false">
-        <path d={CLOUD_PATH} />
-      </svg>
-    </span>
-  );
-}
-
 export function EmptyState(): React.JSX.Element {
   return (
     <div className="empty-state">

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -4,7 +4,7 @@ import { CREDENTIAL_SOURCE } from "../shared/contracts";
 import type { CredentialProvider, CredentialProviderId } from "../shared/credential-providers";
 import { CREDENTIAL_PROVIDER_LIST } from "../shared/credential-providers";
 import { PANEL_TAB, panelPanelId, panelTabId } from "./panel-tabs";
-import { ProviderMark } from "./provider-marks";
+import { CloudBadge, ProviderMark } from "./provider-marks";
 import {
   CheckIcon,
   ExternalIcon,
@@ -133,8 +133,15 @@ function ProviderCredential({
       <div className="credential-row">
         <span className="credential-identity">
           {/* The provider's own mark, so a list is read by brand rather than by
-              a word every line would have to repeat. */}
-          <ProviderMark providerId={provider.id} className="credential-mark" />
+              a word every line would have to repeat. Every provider that can
+              hold a key is one whose sessions live in a cloud service — that is
+              what makes the key necessary — so each mark carries the same badge
+              its session rows do, rather than one line's mark differing from
+              the same mark elsewhere. */}
+          <span className="credential-mark">
+            <ProviderMark providerId={provider.id} />
+            <CloudBadge />
+          </span>
           <span className="credential-name">{provider.displayName}</span>
           {connected ? <CheckIcon /> : null}
         </span>

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1223,17 +1223,23 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 }
 
 /* Beside the provider's name, sized to it: the mark reads as part of the word,
-   not as an icon in a column of its own. */
-/* A bare mark at text height rather than the session list's tile, so the badge
-   comes down with it: any larger and the annotation would outweigh the mark it
-   annotates, and this is the smallest the cloud still reads at. It clears the
-   name beside it because the line's gap is wider than the overhang. */
+   not as an icon in a column of its own. A bare mark at text height rather than
+   the session list's tile, so the badge comes down with it — any larger and the
+   annotation would outweigh the mark it annotates, and this is the smallest the
+   cloud still reads at.
+
+   The identity line clips what leaves it, so the badge cannot simply hang off a
+   13px mark: it would be sliced flat along the bottom. The box is instead large
+   enough to hold both, which is also what makes the line tall enough to show
+   them, and the negative side margins pull that extra width back so the mark
+   and the name sit exactly where a bare 13px mark would put them. */
 .credential-mark {
   position: relative;
   display: grid;
-  width: 13px;
-  height: 13px;
+  width: 20px;
+  height: 20px;
   flex: 0 0 auto;
+  margin: 0 -3.5px;
   place-items: center;
 }
 
@@ -1242,9 +1248,11 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   height: 13px;
 }
 
+/* Held half a pixel off the corner rather than flush with it, so no edge of the
+   disc lands on the line's clip boundary. */
 .credential-mark .cloud-badge {
-  right: -3px;
-  bottom: -3px;
+  right: 0.5px;
+  bottom: 0.5px;
   width: 10px;
   height: 10px;
 }

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -543,6 +543,30 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   transform: scale(0.94);
 }
 
+/* The work is happening somewhere the user cannot see. The badge overhangs the
+   mark's box rather than sitting inside it, so it reads as attached to the mark
+   instead of crowding it, and it is out of flow so the mark stays where it was
+   whether or not a badge is drawn. It fills against the surface rather than
+   against whatever it is laid on: a session row tinted for attention would
+   otherwise recolour the badge, and where the work runs is not a state. Each
+   place that shows a mark sets the size, because a 32px session tile and a
+   text-height settings line cannot carry the same one. */
+.cloud-badge {
+  position: absolute;
+  display: grid;
+  border-radius: 50%;
+  background: var(--surface-fill);
+  box-shadow: inset 0 0 0 1px var(--hairline);
+  color: var(--text-secondary);
+  place-items: center;
+}
+
+/* The viewBox already carries the cloud's proportions, so a place that shows a
+   badge sets a width and the height follows from the shape. */
+.cloud-badge svg {
+  height: auto;
+}
+
 /* Luke's face ------------------------------------------------------------ */
 
 /* The place nearest the housing is the one the capsule keeps, and Luke holds it
@@ -1200,10 +1224,33 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 
 /* Beside the provider's name, sized to it: the mark reads as part of the word,
    not as an icon in a column of its own. */
+/* A bare mark at text height rather than the session list's tile, so the badge
+   comes down with it: any larger and the annotation would outweigh the mark it
+   annotates, and this is the smallest the cloud still reads at. It clears the
+   name beside it because the line's gap is wider than the overhang. */
 .credential-mark {
+  position: relative;
+  display: grid;
   width: 13px;
   height: 13px;
   flex: 0 0 auto;
+  place-items: center;
+}
+
+.credential-mark .provider-mark {
+  width: 13px;
+  height: 13px;
+}
+
+.credential-mark .cloud-badge {
+  right: -3px;
+  bottom: -3px;
+  width: 10px;
+  height: 10px;
+}
+
+.credential-mark .cloud-badge svg {
+  width: 6.5px;
 }
 
 /* The hint sits opposite the editor's buttons and yields to them. */

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -56,6 +56,7 @@
 /* Neutral tile: the mark inside carries the provider's own colour, so tinting
    the tile by state would put two colour systems on top of each other. */
 .row-avatar {
+  position: relative;
   display: grid;
   width: 32px;
   height: 32px;
@@ -69,6 +70,31 @@
 .row-avatar .provider-mark {
   width: 17px;
   height: 17px;
+}
+
+/* The session runs somewhere the user cannot see. The badge overhangs the tile
+   rather than sitting inside it, so it reads as attached to the mark instead of
+   crowding it, and it is taken out of flow so the mark stays centred in the
+   tile whether or not a session carries one. It fills against the surface, not
+   the row: the attention row is tinted, and a badge that changed colour with
+   the row would read as state rather than as where the work runs. */
+.row-cloud {
+  position: absolute;
+  right: -4px;
+  bottom: -4px;
+  display: grid;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--surface-fill);
+  box-shadow: inset 0 0 0 1px var(--hairline);
+  color: var(--text-secondary);
+  place-items: center;
+}
+
+.row-cloud svg {
+  width: 9px;
+  height: 6.3px;
 }
 
 .row-copy {

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -72,29 +72,17 @@
   height: 17px;
 }
 
-/* The session runs somewhere the user cannot see. The badge overhangs the tile
-   rather than sitting inside it, so it reads as attached to the mark instead of
-   crowding it, and it is taken out of flow so the mark stays centred in the
-   tile whether or not a session carries one. It fills against the surface, not
-   the row: the attention row is tinted, and a badge that changed colour with
-   the row would read as state rather than as where the work runs. */
-.row-cloud {
-  position: absolute;
+/* Against a 32px tile the badge can be read at a glance, so it is sized to be
+   read rather than to be minimal. */
+.row-avatar .cloud-badge {
   right: -4px;
   bottom: -4px;
-  display: grid;
   width: 14px;
   height: 14px;
-  border-radius: 50%;
-  background: var(--surface-fill);
-  box-shadow: inset 0 0 0 1px var(--hairline);
-  color: var(--text-secondary);
-  place-items: center;
 }
 
-.row-cloud svg {
+.row-avatar .cloud-badge svg {
   width: 9px;
-  height: 6.3px;
 }
 
 .row-copy {

--- a/apps/desktop/tests/cloud-session-adapter.test.ts
+++ b/apps/desktop/tests/cloud-session-adapter.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { type ProviderSessionObservation, SESSION_STATUS } from "@sidecar/core";
+import { type ProviderSessionObservation, SESSION_LOCATION, SESSION_STATUS } from "@sidecar/core";
 import {
   type CloudAdapterOptions,
   type CloudFetch,
@@ -137,6 +137,21 @@ test("authenticates a bounded read and encodes the route a subclass asked for", 
       accept: "application/json",
     },
   ]);
+});
+
+test("reports every session it serves as running in the cloud", async () => {
+  const stub = stubFetch();
+  const adapter = adapterFor(stub.fetch);
+  // Neither observation says where it runs: the base knows, because nothing
+  // reaches it except over the network.
+  adapter.collected = [observation("session-one"), observation("session-two")];
+
+  const observations = await adapter.observe();
+
+  assert.deepEqual(
+    observations.map((candidate) => candidate.location),
+    [SESSION_LOCATION.CLOUD, SESSION_LOCATION.CLOUD],
+  );
 });
 
 test("drops a session a subclass reported twice in one pass", async () => {

--- a/apps/desktop/tests/session-model.test.ts
+++ b/apps/desktop/tests/session-model.test.ts
@@ -5,6 +5,7 @@ import {
   fixtureSnapshot,
   normalizeSession,
   PROVIDER_ID,
+  SESSION_LOCATION,
   SESSION_STATE,
   SESSION_STATUS,
 } from "@sidecar/core";
@@ -60,6 +61,30 @@ test("the most urgent sessions are listed first in either data source", () => {
   );
   assert.equal(live[0]?.state, SESSION_STATE.ATTENTION);
   assert.equal(live[0]?.providerId, PROVIDER_ID.CODEX);
+});
+
+test("a row carries where its session runs, from either data source", () => {
+  const fixture = new Map(
+    displaySessions(bootstrap(true), []).map((session) => [session.id, session.location]),
+  );
+
+  assert.equal(fixture.get("cursor-agent"), SESSION_LOCATION.CLOUD);
+  assert.equal(fixture.get("conductor-workspace"), SESSION_LOCATION.CLOUD);
+  assert.equal(fixture.get("codex-bootstrap"), SESSION_LOCATION.LOCAL);
+
+  const live = displaySessions(bootstrap(false), [
+    normalizeSession(CODEX_PROVIDER, {
+      providerSessionId: "codex-cloud",
+      title: "Session codex-cloud",
+      status: SESSION_STATUS.WORKING,
+      observedAt: 1_000,
+      location: SESSION_LOCATION.CLOUD,
+    }),
+    liveSession(CLAUDE_PROVIDER, "claude-here", SESSION_STATUS.WORKING),
+  ]);
+
+  assert.equal(live[0]?.location, SESSION_LOCATION.CLOUD);
+  assert.equal(live[1]?.location, SESSION_LOCATION.LOCAL);
 });
 
 test("a speaking disposition needs a person even while the session works", () => {

--- a/packages/sidecar-core/src/fixtures.ts
+++ b/packages/sidecar-core/src/fixtures.ts
@@ -1,4 +1,5 @@
 import { PROVIDER_ID, type ProviderId } from "./providers";
+import { SESSION_LOCATION, type SessionLocation } from "./session";
 
 export const SESSION_STATE = {
   WORKING: "working",
@@ -17,6 +18,7 @@ export interface SessionSnapshot {
   provider: string;
   detail: string;
   state: SessionState;
+  location: SessionLocation;
 }
 
 export interface FixtureSnapshot {
@@ -34,6 +36,7 @@ const smokeFixture: FixtureSnapshot = {
       provider: "Codex",
       detail: "Testing Electron window semantics",
       state: SESSION_STATE.WORKING,
+      location: SESSION_LOCATION.LOCAL,
     },
     {
       id: "claude-review",
@@ -42,6 +45,7 @@ const smokeFixture: FixtureSnapshot = {
       provider: "Claude Code",
       detail: "One architecture decision is ready",
       state: SESSION_STATE.ATTENTION,
+      location: SESSION_LOCATION.LOCAL,
     },
     {
       id: "conductor-workspace",
@@ -50,6 +54,7 @@ const smokeFixture: FixtureSnapshot = {
       provider: "Conductor",
       detail: "Cloud session metadata only · no live credentials",
       state: SESSION_STATE.COMPLETE,
+      location: SESSION_LOCATION.CLOUD,
     },
     {
       id: "cursor-agent",
@@ -58,6 +63,7 @@ const smokeFixture: FixtureSnapshot = {
       provider: "Cursor",
       detail: "Cloud session metadata only · no live credentials",
       state: SESSION_STATE.WORKING,
+      location: SESSION_LOCATION.CLOUD,
     },
     // A fifth session keeps every state and every provider mark visible in the
     // one screenshot the visual evidence is reviewed from.
@@ -68,6 +74,7 @@ const smokeFixture: FixtureSnapshot = {
       provider: "Claude Code",
       detail: "Idle since the last display change",
       state: SESSION_STATE.UNKNOWN,
+      location: SESSION_LOCATION.LOCAL,
     },
   ],
 };

--- a/packages/sidecar-core/src/session-registry.ts
+++ b/packages/sidecar-core/src/session-registry.ts
@@ -51,6 +51,7 @@ function sameSession(first: NormalizedSession, second: NormalizedSession): boole
     first.title === second.title &&
     first.status === second.status &&
     first.observedAt === second.observedAt &&
+    first.location === second.location &&
     first.summary === second.summary &&
     first.attention.disposition === second.attention.disposition &&
     first.attention.decidedAt === second.attention.decidedAt &&

--- a/packages/sidecar-core/src/session.ts
+++ b/packages/sidecar-core/src/session.ts
@@ -7,6 +7,19 @@ export const SESSION_STATUS = {
 
 export type SessionStatus = (typeof SESSION_STATUS)[keyof typeof SESSION_STATUS];
 
+/**
+ * Where a session's work is actually running. It is not the provider: the same
+ * provider can hold a session on this machine and one in a datacentre, and only
+ * the session knows which it is. Local is the default, so a session is only
+ * reported as remote by an adapter that observed it over the network.
+ */
+export const SESSION_LOCATION = {
+  LOCAL: "local",
+  CLOUD: "cloud",
+} as const;
+
+export type SessionLocation = (typeof SESSION_LOCATION)[keyof typeof SESSION_LOCATION];
+
 export const ATTENTION_DISPOSITION = {
   SILENT: "silent",
   SPEAK_DURING_TURN: "speak-during-turn",
@@ -54,6 +67,8 @@ export interface ProviderSessionObservation {
   title: string;
   status: SessionStatus;
   observedAt: number;
+  /** Omitted by an adapter that reads sessions off this machine. */
+  location?: SessionLocation;
   summary?: string;
   controls?: readonly SessionControl[];
 }
@@ -67,6 +82,7 @@ export interface NormalizedSession extends SessionIdentity {
   title: string;
   status: SessionStatus;
   observedAt: number;
+  location: SessionLocation;
   summary?: string;
   controls: readonly SessionControl[];
   attention: AttentionDecision;
@@ -99,6 +115,14 @@ function normalizeStatus(status: SessionStatus): SessionStatus {
     throw new Error(`Unknown session status: ${status}`);
   }
   return status;
+}
+
+function normalizeLocation(location: SessionLocation | undefined): SessionLocation {
+  if (location === undefined) return SESSION_LOCATION.LOCAL;
+  if (!Object.values(SESSION_LOCATION).includes(location)) {
+    throw new Error(`Unknown session location: ${location}`);
+  }
+  return location;
 }
 
 function normalizeControls(
@@ -174,6 +198,7 @@ export function normalizeSession(
     title: boundedText(observation.title, maximumSessionTitleLength) ?? "Untitled session",
     status: normalizeStatus(observation.status),
     observedAt,
+    location: normalizeLocation(observation.location),
     ...(summary ? { summary } : {}),
     controls: normalizeControls(observation.controls),
     attention: normalizeAttention(attention),

--- a/packages/sidecar-core/tests/session-registry.test.ts
+++ b/packages/sidecar-core/tests/session-registry.test.ts
@@ -5,7 +5,9 @@ import {
   InMemorySessionRegistry,
   maximumSessionSummaryLength,
   type ProviderSessionObservation,
+  SESSION_LOCATION,
   SESSION_STATUS,
+  type SessionLocation,
   type SessionProvider,
   supportsSessionControl,
 } from "../src";
@@ -58,6 +60,32 @@ test("normalizes provider observations without conflating provider-local identit
   assert.equal(supportsSessionControl(session, TEST_CONTROL.OPEN), true);
   assert.equal(supportsSessionControl(session, TEST_CONTROL.INTERRUPT), false);
   assert.equal(registry.list().length, 2);
+});
+
+test("a session runs on this machine unless its provider observed it elsewhere", () => {
+  const registry = new InMemorySessionRegistry();
+  const local = registry.upsert(codex, observation("local", 100));
+  const remote = registry.upsert(
+    codex,
+    observation("remote", 100, { location: SESSION_LOCATION.CLOUD }),
+  );
+
+  assert.equal(local.location, SESSION_LOCATION.LOCAL);
+  assert.equal(remote.location, SESSION_LOCATION.CLOUD);
+  // Where a session runs is the only thing that changed here, so a registry
+  // that did not compare it would leave the panel showing the old row.
+  const revision = registry.revision;
+  registry.upsert(codex, observation("local", 100, { location: SESSION_LOCATION.CLOUD }));
+  assert.equal(registry.revision, revision + 1);
+  // A location a later build adds is rejected rather than shown as local.
+  assert.throws(
+    () =>
+      registry.upsert(
+        codex,
+        observation("elsewhere", 100, { location: "orbit" as SessionLocation }),
+      ),
+    /Unknown session location: orbit/,
+  );
 });
 
 test("refresh atomically replaces one adapter's sessions and preserves attention decisions", async () => {


### PR DESCRIPTION
## Summary

- A row said which provider a session belongs to, but not where it runs — and those are different questions. The same provider can hold a session on this machine and one in a datacentre, and only the session knows which it is.
- `NormalizedSession` now carries a `location`, defaulting to `local`. `CloudSessionAdapter` stamps `cloud` on every observation it serves, in the same place it already de-duplicates them: nothing reaches that point except over the network, so no subclass can forget to say so. Conductor and Cursor sessions are badged today without either adapter changing.
- The panel draws a small cloud in the bottom-right corner of the provider mark for the sessions that carry it. It is ours rather than a brand mark, so it takes the text palette instead of putting a second brand colour beside the provider's own, and it fills against the surface rather than the row so a tinted attention row cannot make it read as state.
- Settings' API key section carries the same badge on its provider marks. Every provider that can hold a key is one whose sessions live in a cloud service — that is what makes the key necessary — so all of those marks are badged, rather than the same mark reading differently in the two places it appears. A credential line shows a bare mark at text height rather than the session list's 32px tile, so the badge is sized down to match it.
- The notch wing marks are left alone: they are a per-provider summary, and one mark there can stand for both a local and a cloud session.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — pass (repository contract checks, Biome over 119 files, typecheck across all three projects, 5 harness + 34 core + 96 desktop tests, full build)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — this workspace is a Linux cloud sandbox with no macOS host, so `evidence.sh` cannot package or launch the app. The CI macOS job runs it and links the screenshots below; I reviewed the panel locally by rendering the built renderer bundle against the smoke fixture in headless Chrome, and re-checked it after CI.

Regression coverage sits at the cheapest layer for each behavior:

- `session-registry.test.ts` — a session is local unless a provider says otherwise, a location change alone is published as a change, and an unknown location is rejected rather than shown as local.
- `cloud-session-adapter.test.ts` — the base reports every session it serves as cloud, from a subclass that never mentions a location.
- `session-model.test.ts` — a row carries where its session runs, from both the fixture and live data.

The settings badge is markup with no branch in it, so it rests on the visual evidence rather than on a test.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31664438729/artifacts/9167397503) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31664438729)

- Commit: `0416f02910f43a75aff12a231c65648669764830`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Settings tab

CI's deterministic evidence covers the sessions list, the capsule, the peek, and the speaking state — it does not capture the settings tab, so this is a render of the same renderer bundle in headless Chrome on Linux rather than a screenshot of the packaged macOS app. Both credential marks carry the badge:

![Cloud API keys section with a cloud badge on the Conductor and Cursor marks](https://raw.githubusercontent.com/ReviewStage/luke/pr-assets/pr-34/settings-cloud-badge.png)

Worth a follow-up: `scripts/evidence.sh` could capture the settings tab too, so a change there is covered by macOS evidence like every other surface.

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: the badge is appearance-only and sits inside the panel body, well away from the notch, so nothing here depends on a physical notch. A physical-device check of the panel remains outstanding as usual.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a4f81ce0-1a90-4693-84d0-f17a070eb58a)


