### PR TITLE
fix(settings): offer the editor, not Connect, for a key from the environment

### DIFF
--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -45,11 +45,20 @@ const CREDENTIAL_STATUS: Partial<Record<CredentialSource, string>> = {
   [CREDENTIAL_SOURCE.ENVIRONMENT]: "From environment",
 };
 
+/* One field, three jobs: what it is for depends on what is answering for the
+   provider now, and a key typed here always wins over one read elsewhere. */
+const CREDENTIAL_PLACEHOLDER: Record<CredentialSource, string> = {
+  [CREDENTIAL_SOURCE.NONE]: "Paste an API key",
+  [CREDENTIAL_SOURCE.ENVIRONMENT]: "Paste a key to use instead of the one from the environment",
+  [CREDENTIAL_SOURCE.ENCRYPTED_FILE]: "Replace the stored key",
+};
+
 /**
- * One provider, one line: its mark, its name, whether it is connected, and the
- * two things you can do about that. The field only exists while a key is being
- * entered, because a settings tab that is mostly empty input boxes reads as
- * work to do rather than as a state to check.
+ * One provider, one line: its mark, its name, whether it is connected, and what
+ * can be done about that — connect, supersede, or delete, whichever the state
+ * actually allows. The field only exists while a key is being entered, because
+ * a settings tab that is mostly empty input boxes reads as work to do rather
+ * than as a state to check.
  *
  * The credential is write-only from here: this can replace or clear the stored
  * key, and the main process never sends one back — only where it was resolved
@@ -77,11 +86,20 @@ function ProviderCredential({
   const field = useRef<HTMLInputElement | null>(null);
   const fieldId = `${provider.id}-api-key`;
   const editing = draft !== undefined;
-  // Stored here is what can be edited or deleted; connected includes a key Luke
-  // only reads from the environment, which it has no business changing.
+  // Deleting is only ever for a key kept here; one read from the environment is
+  // not Luke's to remove. Either can be superseded by a key typed in, so both
+  // connected states offer the same editor and only the unconnected one is
+  // asked to connect.
   const stored = source === CREDENTIAL_SOURCE.ENCRYPTED_FILE;
   const connected = source !== CREDENTIAL_SOURCE.NONE;
   const status = CREDENTIAL_STATUS[source];
+  // The pencil opens the same editor from either connected state, but it does
+  // not mean the same thing: one replaces the key Luke keeps, the other stands
+  // in front of one it only reads.
+  const editTitle = stored ? "Replace" : "Use a key stored here";
+  const editLabel = stored
+    ? `Replace the ${provider.displayName} API key`
+    : `Store a ${provider.displayName} API key instead of the one from the environment`;
 
   // Opening the tab is not a request to type, so the editor opens only on a
   // press — and then it takes the caret, because opening it is a request to
@@ -94,6 +112,13 @@ function ProviderCredential({
     onEditingChange(provider.id, editing);
   }, [editing, onEditingChange, provider.id]);
   useEffect(() => () => onEditingChange(provider.id, false), [onEditingChange, provider.id]);
+
+  // Every control that offers to write a key opens the one editor, and clears
+  // whatever the last attempt was rejected for on the way in.
+  const openEditor = () => {
+    setRejection(undefined);
+    setDraft("");
+  };
 
   const submit = async (apiKey: string | undefined) => {
     setBusy(true);
@@ -113,9 +138,9 @@ function ProviderCredential({
           <span className="credential-name">{provider.displayName}</span>
           {connected ? <CheckIcon /> : null}
         </span>
-        {/* The check says connected and Connect says the opposite, so the words
-            are kept for the one thing neither can say: connected from the
-            environment rather than from a key kept here. */}
+        {/* The check says connected and the controls say what can be done about
+            it, so the words are kept for the one thing neither can say:
+            connected from the environment rather than from a key kept here. */}
         {status ? <span className="credential-status">{status}</span> : null}
         <span className="settings-actions">
           {stored ? (
@@ -130,29 +155,26 @@ function ProviderCredential({
               <TrashIcon />
             </button>
           ) : null}
-          {stored ? (
+          {connected ? (
             <button
               type="button"
               className="icon-button"
-              disabled={busy || editing}
-              aria-label={`Replace the ${provider.displayName} API key`}
-              title="Edit"
-              onClick={() => {
-                setRejection(undefined);
-                setDraft("");
-              }}
+              disabled={busy || storageUnavailable || editing}
+              aria-label={editLabel}
+              title={editTitle}
+              onClick={openEditor}
             >
               <PencilIcon />
             </button>
           ) : (
+            /* Named for its provider like the icon buttons beside it: a list of
+               controls read on its own is otherwise two identical Connects. */
             <button
               type="button"
               className="quiet-button"
               disabled={busy || storageUnavailable || editing}
-              onClick={() => {
-                setRejection(undefined);
-                setDraft("");
-              }}
+              aria-label={`Connect ${provider.displayName}`}
+              onClick={openEditor}
             >
               Connect
             </button>
@@ -161,7 +183,10 @@ function ProviderCredential({
       </div>
 
       {editing ? (
-        <div className="credential-editor">
+        /* Named as a group, because Cancel, Save key, and the link to the
+           provider's own page are the same three words on every row and two
+           editors can be open at once. */
+        <fieldset className="credential-editor" aria-label={`${provider.displayName} API key`}>
           <label className="settings-field" htmlFor={fieldId}>
             {/* The provider is named on the line above, so the visible label
                 does not repeat it — but a reader hearing the field alone still
@@ -175,7 +200,7 @@ function ProviderCredential({
               type="password"
               autoComplete="off"
               spellCheck={false}
-              placeholder={stored ? "Replace the stored key" : "Paste an API key"}
+              placeholder={CREDENTIAL_PLACEHOLDER[source]}
               value={draft}
               disabled={busy}
               onChange={(event) => setDraft(event.target.value)}
@@ -228,7 +253,7 @@ function ProviderCredential({
               </button>
             </span>
           </div>
-        </div>
+        </fieldset>
       ) : null}
       {rejection ? <p className="error-message">{rejection}</p> : null}
     </div>

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1092,10 +1092,18 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   color: var(--text-secondary);
 }
 
-/* The field exists only while a key is being entered. */
+/* The field exists only while a key is being entered. It is a fieldset because
+   the group is what names the provider for the controls inside it — every row's
+   editor otherwise offers the same Cancel, Save key, and link. None of the
+   user-agent frame is wanted, including the `min-inline-size` that would stop
+   it shrinking with the panel. */
 .credential-editor {
   display: flex;
+  min-inline-size: 0;
   flex-direction: column;
+  padding: 0;
+  border: 0;
+  margin: 0;
   gap: 8px;
 }
 


### PR DESCRIPTION
## Summary

- A provider whose key Luke reads from an environment variable is already
  connected, so a `Connect` button beside `From environment` invited someone to do
  the thing they had already done. That row now offers the same pencil a stored
  key does. Either connected state can be superseded by a key typed in; only an
  unconnected one is asked to connect.
- Deleting stays where it belongs. The trash still appears only for a key kept
  here, because a key in the environment is not Luke's to remove — the row offers
  to stand in front of it, never to unset it.
- The field says which of the three things it is about to do, so a key that will
  supersede the environment's says so instead of reading as a first entry.
- Every control on the row now names its provider to a screen reader. `Connect`
  was the odd one out beside `Delete the Conductor API key` and `Replace the
  Conductor API key`, so two providers meant two buttons announced only as
  "Connect". The editor becomes a `fieldset` named for its provider for the same
  reason: `Cancel`, `Save key`, and the link to the provider's own page are the
  same three words on every row, and two editors can be open at once.
- The two identical `onClick` handlers that opened the editor collapse into one
  `openEditor`, and the pencil now carries the same `secretStorageAvailable`
  guard `Connect` always had — a system with no encrypted storage should not open
  an editor whose Save the store will refuse. That guard is inert for a stored
  key, which cannot be reported as stored unless decryption worked.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — **pass** (repository contract
  checks, Biome across 119 files with no fixes, typecheck, 94 desktop tests,
  33 sidecar-core tests, 5 harness tests, and both builds)
- macOS Electron verification (`./scripts/verify.sh`): `not run` locally — this
  workspace is a Linux cloud sandbox with no macOS host. The macOS CI job runs it
  on this PR and links its evidence below.

Appearance and announcement only, so the evidence is a rendering and a reading of
the accessibility tree. Both come from the renderer mounted against the fixture a
capture run uses — a 38pt inset, a 210pt housing, and the `smoke` sessions — so
the only difference between before and after is this commit.

### The row

Both frames carry both providers, covering all three credential sources: no key,
a key stored here, and a key read from the environment.

**Before** — the environment row offers `Connect`, which it has already done:

![Credential rows before: the Cursor row reads "From environment" beside a Connect button](https://raw.githubusercontent.com/ReviewStage/luke/pr-assets/pr-36/rows-before.png)

**After** — it offers the pencil, and the unconnected and stored rows are
untouched:

![Credential rows after: the Cursor row reads "From environment" beside a pencil, and the stored Conductor row keeps its trash and pencil](https://raw.githubusercontent.com/ReviewStage/luke/pr-assets/pr-36/rows-after.png)

### The editor it opens

**Before** — reached by pressing `Connect`, and the field reads as a first entry:

![Key editor before: the field placeholder reads "Paste an API key"](https://raw.githubusercontent.com/ReviewStage/luke/pr-assets/pr-36/editor-before.png)

**After** — reached by pressing the pencil, and the field says what the key will
displace:

![Key editor after: the field placeholder reads "Paste a key to use instead of the one from the environment"](https://raw.githubusercontent.com/ReviewStage/luke/pr-assets/pr-36/editor-after.png)

### What a screen reader hears

No screenshot can show this, so it is read out of Chromium's accessibility tree
for the same three states, in tree order. Only the credential section is listed;
the panel's tabs, capsule, microphone, and Quit are unchanged.

| state | before | after |
| --- | --- | --- |
| no key supplied | `Connect`, `Connect` | `Connect Conductor`, `Connect Cursor` |
| key stored here | `Delete the Conductor API key`, `Replace the Conductor API key` | unchanged |
| key from the environment | `Connect` | `Store a Cursor API key instead of the one from the environment` |
| editor open | `Cancel`, `Save key`, `Cursor API key` (field), `Get an API key` | the same four, inside a group named `Cursor API key` |

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31663099547/artifacts/9166920830) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31663099547)

- Commit: `9f9ebebb56ef18e9d2a9cfb0de0a0cdd9b7217b9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` — the change is confined to the
  settings tab, which the deterministic evidence above renders at every state
- Physical-notch check: `not performed` — nothing here touches the drawn shape
- Device/display configuration: `not recorded`

## Notes

- Follow-up to #28, which removed the `Not connected` caption from the same row.
- The `.credential-editor` rule gains the resets a `fieldset` needs — no
  user-agent border, margin, or padding, and `min-inline-size: 0` so it still
  shrinks with the panel. The rendering is unchanged; the editor frames above are
  the check on that.
- The automated macOS evidence photographs the sessions tab, so it will not show
  this change; the frames above are the coverage for it.
- Blockers or follow-up verification: None
