### PR TITLE
docs: add CLAUDE.md symlink to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -7,6 +7,7 @@ source "$SCRIPT_DIRECTORY/lib/workspace.sh"
 
 required_files=(
     AGENTS.md
+    CLAUDE.md
     WORKFLOW.md
     README.md
     package.json


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` as a symlink to `AGENTS.md` so Claude Code picks up the existing agent guide without duplicating content.
- Include `CLAUDE.md` in the repository contract checks.

## Test plan
- [x] `./scripts/repository-checks.sh` passes locally
- [ ] CI portable and macOS jobs pass


Made with [Cursor](https://cursor.com)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31663951124/artifacts/9167227969) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31663951124)

- Commit: `219332480ad2b6cdf558ed2d740277e0c6d1f531`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
