### PR TITLE
chore(release): add signed macOS release pipeline

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -1,0 +1,83 @@
+# Releasing Luke for macOS
+
+The release workflow builds, signs, notarizes, staples, and validates an arm64 macOS app. It
+then creates `Luke-X.Y.Z-macos-arm64.zip` and a matching `.sha256` file.
+
+Pushing a `vX.Y.Z` tag publishes or updates a GitHub Release. A manual
+`workflow_dispatch` run performs the same release rehearsal without publishing; its zip and
+checksum are retained as workflow artifacts for 14 days.
+
+## Required GitHub Actions secrets
+
+| Secret | Purpose | Source |
+| --- | --- | --- |
+| `MACOS_CERTIFICATE_P12_BASE64` | Base64-encoded Developer ID Application certificate and private key | A `.p12` export from Keychain Access or Xcode |
+| `MACOS_CERTIFICATE_PASSWORD` | Password protecting the `.p12` export | The password chosen during export |
+| `APPLE_API_KEY_P8_BASE64` | Base64-encoded App Store Connect API private key | The downloaded `.p8` file from App Store Connect |
+| `APPLE_API_KEY_ID` | Identifies the App Store Connect API key | App Store Connect, Users and Access, Integrations |
+| `APPLE_API_ISSUER_ID` | Identifies the App Store Connect API key issuer | App Store Connect, Users and Access, Integrations |
+
+### Export the signing certificate
+
+Install or create the **Developer ID Application** certificate through Xcode's account
+settings or the Apple Developer portal. In Keychain Access, select the certificate and its
+private key, export both as a password-protected `.p12`, and keep the export out of the
+repository.
+
+Create a team App Store Connect API key under **Users and Access → Integrations** with the
+Developer role. Download its `.p8` file immediately; Apple only offers the private key for
+download once. Record its key ID and issuer ID.
+
+From macOS, set the repository secrets with the GitHub CLI:
+
+```sh
+base64 -i DeveloperIDApplication.p12 | gh secret set MACOS_CERTIFICATE_P12_BASE64
+printf '%s' 'the-p12-password' | gh secret set MACOS_CERTIFICATE_PASSWORD
+base64 -i AuthKey_KEYID.p8 | gh secret set APPLE_API_KEY_P8_BASE64
+printf '%s' 'KEYID' | gh secret set APPLE_API_KEY_ID
+printf '%s' 'issuer-uuid' | gh secret set APPLE_API_ISSUER_ID
+```
+
+The commands use macOS `base64`, where `-i` names an input file. Entering the certificate
+password interactively instead of placing it in shell history is safer:
+
+```sh
+gh secret set MACOS_CERTIFICATE_PASSWORD
+```
+
+## Rehearse the release
+
+Run the **Release** workflow from the Actions tab with **Run workflow**. This checks the
+credentials and performs the entire signing and notarization path, but only uploads a
+workflow artifact. It does not create a GitHub Release.
+
+## Cut a release
+
+First land the version bump and packaging changes. The tag must exactly match
+`apps/desktop/package.json`; for version `0.1.0`:
+
+```sh
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+The tag push is the human release decision. The workflow does not create credentials or
+push tags. It creates a published, non-draft release with generated notes. Re-running the
+workflow is safe: an existing release is reused and its two assets are replaced with
+`gh release upload --clobber`.
+
+## Verify a download
+
+Keep the zip and checksum file in the same directory, then verify the checksum:
+
+```sh
+shasum -a 256 -c Luke-0.1.0-macos-arm64.zip.sha256
+```
+
+After unzipping, ask Gatekeeper to assess the application:
+
+```sh
+spctl -a -t exec -vv Luke.app
+```
+
+A successful assessment identifies the source as `Notarized Developer ID`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
           )
 
       - name: Publish GitHub Release
-        if: ${{ github.ref_type == 'tag' }}
+        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,171 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Sign and notarize macOS release
+    runs-on: macos-15
+    timeout-minutes: 60
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 9.15.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
+        with:
+          xcode-version: "16.2"
+
+      - name: Check release secrets
+        env:
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
+          MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+        run: |
+          for secret_name in \
+            MACOS_CERTIFICATE_P12_BASE64 \
+            MACOS_CERTIFICATE_PASSWORD \
+            APPLE_API_KEY_P8_BASE64 \
+            APPLE_API_KEY_ID \
+            APPLE_API_ISSUER_ID; do
+            if [[ -z "${!secret_name:-}" ]]; then
+              echo "error: required GitHub Actions secret is missing: $secret_name" >&2
+              exit 1
+            fi
+          done
+
+      - name: Resolve release version
+        run: |
+          VERSION=$(node -p "require('./apps/desktop/package.json').version")
+          if [[ "$GITHUB_REF_TYPE" == "tag" && "$GITHUB_REF" != "refs/tags/v$VERSION" ]]; then
+            echo "error: tag $GITHUB_REF does not match desktop version v$VERSION" >&2
+            exit 1
+          fi
+
+          DIST_DIR="$RUNNER_TEMP/luke-release-$VERSION"
+          ASSET_NAME="Luke-$VERSION-macos-arm64.zip"
+          {
+            echo "VERSION=$VERSION"
+            echo "DIST_DIR=$DIST_DIR"
+            echo "ASSET_NAME=$ASSET_NAME"
+            echo "CHECKSUM_NAME=$ASSET_NAME.sha256"
+            echo "APP_PATH=$GITHUB_WORKSPACE/apps/desktop/out/Luke-darwin-arm64/Luke.app"
+            echo "SUBMISSION_ZIP=$RUNNER_TEMP/Luke-$VERSION-notarization.zip"
+          } >> "$GITHUB_ENV"
+
+      - name: Bootstrap workspace
+        run: ./scripts/bootstrap.sh
+
+      - name: Run repository checks
+        run: ./scripts/check.sh
+
+      - name: Import Developer ID certificate
+        env:
+          MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+        run: ./scripts/release/setup-keychain.sh
+
+      - name: Package signed application
+        run: pnpm package
+
+      - name: Verify signed application
+        run: |
+          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+          codesign_details=$(codesign -dvv "$APP_PATH" 2>&1)
+          printf '%s\n' "$codesign_details"
+          grep -q "Authority=Developer ID Application" <<< "$codesign_details"
+          grep -Eq "flags=.*\(.*runtime.*\)" <<< "$codesign_details"
+
+          architectures=$(lipo -archs "$APP_PATH/Contents/MacOS/Luke")
+          if [[ "$architectures" != "arm64" ]]; then
+            echo "error: expected an arm64-only application, found: $architectures" >&2
+            exit 1
+          fi
+
+          if [[ -z $(find "$APP_PATH" -name LUKE-LICENSE.txt -print -quit) ]]; then
+            echo "error: LUKE-LICENSE.txt is missing from the application bundle" >&2
+            exit 1
+          fi
+
+      - name: Prepare notarization submission
+        run: ditto -c -k --keepParent "$APP_PATH" "$SUBMISSION_ZIP"
+
+      - name: Notarize application
+        env:
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
+        run: ./scripts/release/notarize.sh "$SUBMISSION_ZIP"
+
+      - name: Staple notarization ticket
+        run: xcrun stapler staple "$APP_PATH"
+
+      - name: Validate notarized application
+        run: |
+          codesign --verify --deep --strict "$APP_PATH"
+          assessment=$(spctl --assess --type execute -vv "$APP_PATH" 2>&1)
+          printf '%s\n' "$assessment"
+          grep -q "source=Notarized Developer ID" <<< "$assessment"
+          xcrun stapler validate "$APP_PATH"
+
+      - name: Create release archives
+        run: |
+          rm -f "$SUBMISSION_ZIP"
+          mkdir -p "$DIST_DIR"
+          ditto -c -k --keepParent "$APP_PATH" "$DIST_DIR/$ASSET_NAME"
+          (
+            cd "$DIST_DIR"
+            shasum -a 256 "$ASSET_NAME" > "$CHECKSUM_NAME"
+          )
+
+      - name: Publish GitHub Release
+        if: ${{ github.ref_type == 'tag' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="$GITHUB_REF_NAME"
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            gh release create "$TAG" \
+              --verify-tag \
+              --title "Luke $VERSION" \
+              --generate-notes
+          fi
+          gh release upload "$TAG" \
+            "$DIST_DIR/$ASSET_NAME" \
+            "$DIST_DIR/$CHECKSUM_NAME" \
+            --clobber
+
+      - name: Preserve rehearsal artifacts
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        with:
+          name: luke-${{ env.VERSION }}-macos-arm64-rehearsal
+          path: |
+            ${{ env.DIST_DIR }}/${{ env.ASSET_NAME }}
+            ${{ env.DIST_DIR }}/${{ env.CHECKSUM_NAME }}
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Remove release keychain
+        if: ${{ always() }}
+        env:
+          LUKE_RELEASE_KEYCHAIN: ${{ env.LUKE_RELEASE_KEYCHAIN }}
+        run: ./scripts/release/cleanup-keychain.sh

--- a/scripts/release/cleanup-keychain.sh
+++ b/scripts/release/cleanup-keychain.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${LUKE_RELEASE_KEYCHAIN:-}" ]]; then
+    printf 'No temporary release keychain was created.\n'
+    exit 0
+fi
+
+if [[ "$LUKE_RELEASE_KEYCHAIN" != */luke-release-*.keychain-db ]]; then
+    printf 'error: refusing to delete an unexpected keychain path: %s\n' \
+        "$LUKE_RELEASE_KEYCHAIN" >&2
+    exit 1
+fi
+
+security delete-keychain "$LUKE_RELEASE_KEYCHAIN" 2>/dev/null || true
+printf 'Removed the temporary release keychain.\n'

--- a/scripts/release/notarize.sh
+++ b/scripts/release/notarize.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 1 ]]; then
+    printf 'usage: %s <submission.zip>\n' "$0" >&2
+    exit 2
+fi
+
+for variable_name in \
+    APPLE_API_KEY_P8_BASE64 \
+    APPLE_API_KEY_ID \
+    APPLE_API_ISSUER_ID \
+    RUNNER_TEMP; do
+    if [[ -z "${!variable_name:-}" ]]; then
+        printf 'error: required environment variable is missing: %s\n' "$variable_name" >&2
+        exit 1
+    fi
+done
+
+submission_path=$1
+if [[ ! -f "$submission_path" ]]; then
+    printf 'error: notarization submission does not exist: %s\n' "$submission_path" >&2
+    exit 1
+fi
+
+key_directory=$(mktemp -d "$RUNNER_TEMP/luke-notary.XXXXXX")
+key_path="$key_directory/AuthKey_$APPLE_API_KEY_ID.p8"
+result_path="$key_directory/result.json"
+
+cleanup_key() {
+    rm -f "$key_path" "$result_path"
+    rmdir "$key_directory" 2>/dev/null || true
+}
+trap cleanup_key EXIT
+
+printf '%s' "$APPLE_API_KEY_P8_BASE64" | /usr/bin/base64 -D > "$key_path"
+chmod 600 "$key_path"
+
+submit_exit=0
+xcrun notarytool submit "$submission_path" \
+    --key "$key_path" \
+    --key-id "$APPLE_API_KEY_ID" \
+    --issuer "$APPLE_API_ISSUER_ID" \
+    --wait \
+    --timeout 20m \
+    --output-format json > "$result_path" || submit_exit=$?
+
+cat "$result_path"
+submission_id=$(jq -r '.id // empty' "$result_path")
+status=$(jq -r '.status // empty' "$result_path")
+
+if [[ "$submit_exit" -ne 0 || "$status" != "Accepted" ]]; then
+    if [[ -n "$submission_id" ]]; then
+        printf 'Notarization failed; fetching Apple log for submission %s.\n' "$submission_id" >&2
+        xcrun notarytool log "$submission_id" \
+            --key "$key_path" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" || true
+    else
+        printf 'error: notarization failed before Apple returned a submission ID\n' >&2
+    fi
+    exit 1
+fi
+
+printf 'Apple accepted notarization submission %s.\n' "$submission_id"

--- a/scripts/release/setup-keychain.sh
+++ b/scripts/release/setup-keychain.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+for variable_name in \
+    MACOS_CERTIFICATE_P12_BASE64 \
+    MACOS_CERTIFICATE_PASSWORD \
+    RUNNER_TEMP \
+    GITHUB_ENV; do
+    if [[ -z "${!variable_name:-}" ]]; then
+        printf 'error: required environment variable is missing: %s\n' "$variable_name" >&2
+        exit 1
+    fi
+done
+
+keychain_path="$RUNNER_TEMP/luke-release-${GITHUB_RUN_ID:-local}.keychain-db"
+certificate_path="$RUNNER_TEMP/luke-release-${GITHUB_RUN_ID:-local}.p12"
+keychain_password=$(openssl rand -hex 24)
+
+printf 'LUKE_RELEASE_KEYCHAIN=%s\n' "$keychain_path" >> "$GITHUB_ENV"
+
+cleanup_certificate() {
+    rm -f "$certificate_path"
+}
+trap cleanup_certificate EXIT
+
+printf '%s' "$MACOS_CERTIFICATE_P12_BASE64" | /usr/bin/base64 -D > "$certificate_path"
+chmod 600 "$certificate_path"
+
+security create-keychain -p "$keychain_password" "$keychain_path"
+security set-keychain-settings -lut 21600 "$keychain_path"
+security unlock-keychain -p "$keychain_password" "$keychain_path"
+security import "$certificate_path" \
+    -k "$keychain_path" \
+    -P "$MACOS_CERTIFICATE_PASSWORD" \
+    -T /usr/bin/codesign
+security set-key-partition-list \
+    -S apple-tool:,apple:,codesign: \
+    -s \
+    -k "$keychain_password" \
+    "$keychain_path"
+
+search_keychains=("$keychain_path")
+while IFS= read -r existing_keychain; do
+    existing_keychain=${existing_keychain#\"}
+    existing_keychain=${existing_keychain%\"}
+    if [[ -n "$existing_keychain" && "$existing_keychain" != "$keychain_path" ]]; then
+        search_keychains+=("$existing_keychain")
+    fi
+done <<< "$(security list-keychains -d user | sed 's/^[[:space:]]*//')"
+security list-keychains -d user -s "${search_keychains[@]}"
+
+identity_output=$(security find-identity -v -p codesigning "$keychain_path")
+identity_hashes=$(
+    printf '%s\n' "$identity_output" |
+        sed -n '/Developer ID Application/ s/^[[:space:]]*[0-9]*) \([0-9A-Fa-f]\{40\}\) .*/\1/p'
+)
+identity_count=$(printf '%s\n' "$identity_hashes" | awk 'NF { count++ } END { print count + 0 }')
+
+if [[ "$identity_count" -eq 0 ]]; then
+    printf 'error: imported certificate contains no Developer ID Application identity\n' >&2
+    exit 1
+fi
+if [[ "$identity_count" -ne 1 ]]; then
+    printf 'error: imported certificate contains %s Developer ID Application identities; expected one\n' \
+        "$identity_count" >&2
+    exit 1
+fi
+
+{
+    printf 'LUKE_CODESIGN_IDENTITY=%s\n' "$identity_hashes"
+} >> "$GITHUB_ENV"
+
+printf 'Imported one Developer ID Application identity into the temporary keychain.\n'


### PR DESCRIPTION
## Summary

- Add a tag-driven GitHub Actions pipeline that signs, notarizes, staples, validates, and publishes Luke's arm64 macOS archive and checksum.
- Add temporary-keychain and notarization helpers plus setup and release documentation; manual workflow runs remain rehearsal-only and never publish.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (132 tests, typecheck, lint, and builds); `actionlint` and `shellcheck` passed
- macOS Electron verification (`./scripts/verify.sh`): `not run` (no application or UI changes)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31664596953/artifacts/9167452136) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31664596953)

- Commit: `b36c73f66a2bc3fa3ee8909388ed9c5f3dd0a371`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Before the first release tag, the separate packaging workstream must add version `0.1.0`, Developer ID signing with hardened runtime, and `LUKE-LICENSE.txt`; real signing and notarization then require the five documented GitHub secrets and a successful manual rehearsal.
