### PR TITLE
fix(desktop): explicitly set app.name for safeStorage

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -48,6 +48,8 @@ import {
   isCredentialProviderId,
 } from "./shared/credential-providers";
 
+app.name = "Luke";
+
 const captureOutput = argumentValue("--capture-evidence");
 const profile = argumentValue("--profile") ?? "idle";
 const fixtureName = argumentValue("--fixture");


### PR DESCRIPTION
SafeStorage uses the application name for its keychain entries, defaulting to the package.json name if unset, which caused macOS to prompt for '@luke/desktop Safe Storage'. This sets it explicitly to 'Luke'.

---
*PR created automatically by Jules for task [16719720030619323416](https://jules.google.com/task/16719720030619323416) started by @dastratakos*

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31666168024/artifacts/9168004634) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31666168024)

- Commit: `be70753cd62f57a4f4d648648be21fb99363e378`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
