### PR TITLE
fix(sessions): stop the options sheet hiding the list it narrows

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -33,6 +33,7 @@ import {
   sessionTally,
   tallySummary,
 } from "./session-model";
+import { SESSION_OPTIONS_BUTTON_ID, SESSION_OPTIONS_ID } from "./session-parts";
 
 function usePointerPassthrough(
   onHitRegionEnter: () => void,
@@ -185,10 +186,27 @@ export function App(): React.JSX.Element {
     setOptionsOpen(false);
   }, []);
 
+  // A choice made in the sheet puts the sheet away. It is drawn over the list
+  // and is taller than a row, so a list narrowed to one or two sessions ends up
+  // entirely behind it — the control would hide the very rows it was asked for,
+  // which reads as a filter that shows nothing at all. The fallback the render
+  // performs when a filter empties writes the view directly instead: that is the
+  // list correcting itself, not somebody choosing.
+  const changeSessionView = useCallback((next: SessionView) => {
+    setSessionView(next);
+    setOptionsOpen(false);
+  }, []);
+
   const applyPresentation = useCallback(
     (next: PanelPresentation) => {
       presentationRef.current = next;
       setPresentation(next);
+      // The sheet is only ever drawn inside the panel, so any other shape puts
+      // it away. Left set behind a shape that cannot draw it, it would be over
+      // the list again the next time the panel came forward with nothing having
+      // been pressed — and a key half-entered is the one thing that survives a
+      // close, which the sheet is not.
+      if (next !== PANEL_PRESENTATION.PANEL) setOptionsOpen(false);
       // A panel that has closed reopens on the session list, showing every
       // session with whatever needs a person first: settings are somewhere you
       // go, not a state the capsule remembers, and a filter left in place would
@@ -619,6 +637,28 @@ export function App(): React.JSX.Element {
     return () => window.removeEventListener("keydown", handleKey);
   }, [cancelEntry, changeMode, changeTab, optionsOpen, presentation, tab]);
 
+  // A press anywhere else is the same dismissal Escape is, and the one a sheet
+  // over a list has to answer: what is behind it can only be reached by asking
+  // it to move, so pressing there has to be what asks. The press is taken on the
+  // way down, before whatever it lands on can act on it, and the button that
+  // opened the sheet is left to its own toggle. Nothing outside the drawn shape
+  // reaches this renderer at all — those presses belong to whatever is behind
+  // Luke — so leaving the shape is what closes the panel, and closing the panel
+  // is what puts the sheet away.
+  useEffect(() => {
+    if (!optionsOpen) return;
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target instanceof Node ? event.target : undefined;
+      if (!target) return;
+      const sheet = document.getElementById(SESSION_OPTIONS_ID);
+      const button = document.getElementById(SESSION_OPTIONS_BUTTON_ID);
+      if (sheet?.contains(target) || button?.contains(target)) return;
+      setOptionsOpen(false);
+    };
+    window.addEventListener("pointerdown", handlePointerDown, { capture: true });
+    return () => window.removeEventListener("pointerdown", handlePointerDown, { capture: true });
+  }, [optionsOpen]);
+
   if (!bootstrap || !display) return <div />;
 
   const visibleSessions = displaySessions(bootstrap, sessions);
@@ -670,7 +710,7 @@ export function App(): React.JSX.Element {
           <PanelBody
             list={list}
             view={sessionView}
-            onViewChange={setSessionView}
+            onViewChange={changeSessionView}
             offerOptions={offerOptions}
             optionsOpen={optionsOpen}
             onOptionsToggle={() => setOptionsOpen((open) => !open)}

--- a/apps/desktop/src/renderer/session-parts.tsx
+++ b/apps/desktop/src/renderer/session-parts.tsx
@@ -79,6 +79,12 @@ const SORT_DESCRIPTORS: readonly SortDescriptor[] = [
 const SORT_LABEL_ID = "session-sort-label";
 const SHOW_LABEL_ID = "session-show-label";
 export const SESSION_OPTIONS_ID = "session-options";
+/**
+ * Named so the panel can tell a press on the button from a press outside the
+ * sheet. The button keeps its own toggle: dismissed on the way down and toggled
+ * on the way up, a press here would close and reopen the sheet in one gesture.
+ */
+export const SESSION_OPTIONS_BUTTON_ID = "session-options-button";
 
 /** What each coarse chip is drawn with. An agent carries its own mark instead. */
 function FilterIcon({ filter }: { filter: SessionFilter }): React.JSX.Element | null {
@@ -120,6 +126,7 @@ export function SessionOptionsButton({
   return (
     <button
       type="button"
+      id={SESSION_OPTIONS_BUTTON_ID}
       className="options-button"
       data-active={String(open)}
       data-narrowed={String(narrowed !== undefined)}
@@ -149,6 +156,12 @@ export function SessionOptionsButton({
  * and the surface only grows on the spring — which would leave a row drawn on
  * the desktop for the length of it. Floating costs the top of the list while
  * the sheet is open, and costs the shape nothing.
+ *
+ * What it costs has to be paid back the moment a choice is made. The sheet is
+ * taller than a row, and a narrowed list can be a single row: left open over
+ * one, it hides the very sessions it was asked for, and the control reads as
+ * having done nothing. So `onViewChange` is also what puts the sheet away — it
+ * is a menu over the list, not a shelf beside it.
  *
  * Both groups are pressed buttons rather than radios: a radio owes its reader
  * arrow-key navigation, and the panel is a surface someone tabs through beside

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -31,6 +31,16 @@
   --text-tertiary: rgba(255, 255, 255, 0.34);
   --raised: rgba(255, 255, 255, 0.05);
   --raised-strong: rgba(255, 255, 255, 0.09);
+  /* A third step above the hover one, and an edge to go with it. Hover and
+     chosen cannot share a ground: the difference between "the pointer is here"
+     and "this is what you are looking at" is the whole content of a filter chip,
+     and one step of four percent white is not a difference anyone can see. It is
+     a ground and an edge rather than a fill light enough to invert the text
+     against, because a chip carries the agent's own mark and the marks published
+     as a single silhouette are drawn white — on a white ground they would go out
+     entirely. */
+  --selected: rgba(255, 255, 255, 0.2);
+  --selected-edge: rgba(255, 255, 255, 0.32);
   --hairline: rgba(255, 255, 255, 0.08);
 
   /* One motion vocabulary. The black surface is the only thing that changes

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -109,16 +109,17 @@
   gap: 10px;
 }
 
-/* Named in the same voice as a settings heading, because it is doing the same
-   job: saying what the controls beside it decide. */
+/* Read as ordinary text, in the system face at the size the panel speaks in.
+   The uppercase, letter-spaced voice belongs to a settings heading, which stands
+   over a section and is read once; these two are labels inside a menu, read in
+   the same glance as the controls beside them, and shouting a word that small
+   only makes it harder to read. */
 .options-label {
-  width: 36px;
+  min-width: 38px;
   flex: 0 0 auto;
-  color: var(--text-tertiary);
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 1px;
-  text-transform: uppercase;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 500;
 }
 
 /* Both groups are `fieldset`s, so each says what it is to a reader without a
@@ -168,6 +169,7 @@
   font-weight: 620;
   transition:
     background-color var(--duration-hover) ease,
+    box-shadow var(--duration-hover) ease,
     color var(--duration-hover) ease;
   white-space: nowrap;
 }
@@ -177,8 +179,13 @@
   color: var(--text-primary);
 }
 
+/* The chosen chip is the one thing in the sheet that has to be legible from
+   across the panel, because it is the answer to what the list is showing. Ground
+   and edge together, so it still reads as chosen while the pointer is somewhere
+   else on the row and while a neighbour is lit by hover. */
 .filter-chip[data-active="true"] {
-  background: var(--raised-strong);
+  box-shadow: inset 0 0 0 1px var(--selected-edge);
+  background: var(--selected);
   color: var(--text-primary);
 }
 
@@ -202,6 +209,11 @@
   opacity: 0.62;
 }
 
+/* Quiet where the chip is a tally, plain where it is the answer. */
+.filter-chip[data-active="true"] .filter-count {
+  opacity: 0.85;
+}
+
 /* Enclosed rather than chipped: an order is one choice of two, and the box is
    what says the pair is exclusive where the chips beside it are a list. */
 .sort-group {
@@ -219,6 +231,7 @@
   font-weight: 620;
   transition:
     background-color var(--duration-hover) ease,
+    box-shadow var(--duration-hover) ease,
     color var(--duration-hover) ease;
   white-space: nowrap;
 }
@@ -227,8 +240,11 @@
   color: var(--text-primary);
 }
 
+/* Chosen on the same terms as a chip, so one glance across the sheet reads both
+   rows the same way. */
 .sort-option[data-active="true"] {
-  background: var(--raised-strong);
+  box-shadow: inset 0 0 0 1px var(--selected-edge);
+  background: var(--selected);
   color: var(--text-primary);
 }
 

--- a/apps/desktop/tests/session-model.test.ts
+++ b/apps/desktop/tests/session-model.test.ts
@@ -5,6 +5,7 @@ import {
   fixtureSnapshot,
   normalizeSession,
   PROVIDER_ID,
+  PROVIDER_ID_LIST,
   SESSION_LOCATION,
   SESSION_STATE,
   SESSION_STATUS,
@@ -188,6 +189,42 @@ test("the filters offered run from everything to one agent, counted", () => {
     { filter: PROVIDER_ID.CURSOR, label: "Cursor", count: 1, providerId: PROVIDER_ID.CURSOR },
     { filter: PROVIDER_ID.DEVIN, label: "Devin", count: 1, providerId: PROVIDER_ID.DEVIN },
   ]);
+});
+
+// The fixture above covers the agents it happens to contain. Every agent the
+// registry knows has to be reachable, including whichever one was added last:
+// an agent with a session on screen and no chip of its own is a row nobody can
+// narrow to, and one whose chip does not match its sessions is worse — a filter
+// that empties a list the capsule is still counting.
+test("every agent this build knows can be narrowed down to", () => {
+  const sessions = displaySessions(
+    bootstrap(false),
+    PROVIDER_ID_LIST.map((providerId, index) =>
+      normalizeSession(
+        { id: providerId, displayName: providerId },
+        {
+          providerSessionId: providerId,
+          title: providerId,
+          status: SESSION_STATUS.WORKING,
+          observedAt: 1_000 + index,
+        },
+      ),
+    ),
+  );
+  const offered = arrangeSessions(sessions, DEFAULT_SESSION_VIEW).options;
+
+  assert.deepEqual(
+    offered.filter((option) => option.providerId !== undefined).map((option) => option.filter),
+    [...PROVIDER_ID_LIST],
+  );
+  for (const providerId of PROVIDER_ID_LIST) {
+    const narrowed = arrangeSessions(sessions, { ...DEFAULT_SESSION_VIEW, filter: providerId });
+    assert.equal(narrowed.filter, providerId);
+    assert.deepEqual(
+      narrowed.sessions.map((session) => session.id),
+      [providerId],
+    );
+  }
 });
 
 test("a level with one answer is not offered as a choice", () => {


### PR DESCRIPTION
## Summary

- Choosing an agent in the options sheet appeared to empty the panel: filter to Jules and the list goes to one row, but the sheet is 82px tall against a row's 66px, floats over the top of the list, and is opaque — so the sessions the chips just chose end up entirely behind the sheet that chose them, while the capsule goes on counting them. The sheet is a menu over the list rather than a shelf beside it, so it now behaves like one: a choice puts it away, a press outside dismisses it, and it does not survive the panel closing.
- Chosen and hovered shared one ground four percent of white apart, which left a pressed chip looking untouched. Selection takes a third step with an edge to go with it (`--selected`, `--selected-edge`), on the sort options too so one glance reads both rows of the sheet the same way. A ground rather than a light fill, because a chip carries the agent's own mark and the marks published as a single silhouette are drawn white.
- The sheet's two labels drop the uppercase, letter-spaced voice for the system face at the size the panel speaks in. That voice belongs to a settings heading, which stands over a section and is read once; these are read in the same glance as the controls beside them.
- The filter logic itself was never wrong, so coverage goes at the model layer for the part of this that is model behaviour: every agent the registry knows is offered as a chip and narrows to its own sessions, whichever one was added last. That test passes against the unfixed model, which is what says the defect was in the surface.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — pass (Biome clean, typecheck clean, 247 tests: 11 root, 40 `packages/sidecar-core`, 196 `apps/desktop`, build clean).
- macOS Electron verification (`./scripts/verify.sh`): `pass` — run by this PR's `macos-15` job at `2ea9fac` (1m14s), not locally: this change was authored in a Linux cloud workspace with no macOS host reachable. The `app-visual-evidence-43` artifact was downloaded and all five PNGs inspected — `app-smoke-compact`, `app-smoke-peek`, `app-smoke-expanded`, `app-smoke-slot`, `app-smoke-speaking`. The panel around the sheet is unchanged, including the options button on the tab bar's line. The deterministic capture opens no sheet, so it evidences the absence of a regression rather than the change itself; the change itself is below.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31716154311/artifacts/9187366288) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31716154311)

- Commit: `2ea9facb950be8c9e8a36dd3548dc0e1fd5dfc67`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` — see the renderer captures below, which are not packaged-app captures.
- Physical-notch check: `not performed` — no physical Mac was reachable from this workspace. The change touches no window geometry, only the sheet's dismissal and its own paint, so the notch is unaffected in principle; a human check remains outstanding.
- Device/display configuration: `not recorded`

### Renderer captures

Chromium rendering the app's own compiled `styles.css` and its own mark geometry, with the panel's measured height applied the way the renderer applies it. Not the packaged app: fonts fall back off macOS, so the system face and its metrics are approximate. The `before` pair is built from the stylesheet at the parent commit.

Narrowed to Jules, one session, sheet open — the row is in the DOM and behind the sheet. Measured: sheet `top 90, bottom 172`, row `top 96, bottom 162`.

![before](https://raw.githubusercontent.com/reviewstage/luke/pr-assets/pr-43/before-panel.png)

The same state after the choice, which now puts the sheet away — the button still says the list is narrowed to Jules.

![after](https://raw.githubusercontent.com/reviewstage/luke/pr-assets/pr-43/after-panel.png)

The sheet at 2x, before and after: the chosen chip against its neighbours, and the two labels.

![sheet before](https://raw.githubusercontent.com/reviewstage/luke/pr-assets/pr-43/before-sheet.png)
![sheet after](https://raw.githubusercontent.com/reviewstage/luke/pr-assets/pr-43/after-sheet.png)

## Notes

- Any choice in the sheet closes it, sort as well as filter, so a filter and an order cannot be set in one visit. The alternative — leaving it open and reserving the space it covers — grows the panel on opening, which is the case where content outruns the shape and is drawn on the desktop. Worth a maintainer's opinion: scoping the dismissal to the filter chips alone would keep the order sticky.
- The deterministic capture has no profile that opens the sheet, so the automated evidence covers the panel around it rather than the sheet itself. A capture profile for the sheet would make this reviewable from `verify.sh` alone; out of scope here.
- Blockers or follow-up verification: physical-notch check, and a look at the sheet on a real display.

