### PR TITLE
ci(pr-assets): disable Vercel preview deployments for the media branch

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "pr-assets": false
+    }
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "deploymentEnabled": false
+    "deploymentEnabled": {
+      "pr-assets": false
+    }
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "deploymentEnabled": {
-      "pr-assets": false
-    }
+    "deploymentEnabled": false
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `pr-assets` is the durable, media-only branch described in `WORKFLOW.md` (step 7): it stores inline PR images/GIFs/MP4s under per-PR paths and carries no web app. Since Vercel previews were added, every push to `pr-assets` triggers a preview build that has nothing to build and fails.
- This adds a `vercel.json` on the branch that disables Vercel Git deployments for `pr-assets` using the documented named-branch form of `git.deploymentEnabled`. Vercel reads this file from the branch being pushed, so once it lands on `pr-assets`, future pushes no longer create (failing) preview deployments. `main` and product branches are unaffected because they don't carry this file.

```json
{
  "$schema": "https://openapi.vercel.sh/vercel.json",
  "git": {
    "deploymentEnabled": {
      "pr-assets": false
    }
  }
}
```

## Evidence

- Platform-independent checks: `n/a` — config-only change on the media branch; the repo's `check.sh`/`verify.sh` toolchain does not run against `pr-assets` (it has no `package.json`, `biome.json`, or CI workflows).
- macOS Electron verification (`./scripts/verify.sh`): `n/a` — no macOS/UI change.
- JSON validated with `node -e "require('./vercel.json')"` and matches the repo's authoritative Biome JSON style (2-space indent).

<!-- automated-visual-evidence:start -->
### Automated visual evidence

`n/a` — no UI change.
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` — non-UI change.
- Physical-notch check: `not performed` — non-UI change.
- Device/display configuration: `not recorded`

## Notes

- The config uses the named-branch key so it's self-documenting about which branch it targets. Because Vercel builds a preview for every branch in this repo and this update branch isn't named `pr-assets`, this PR's own Vercel check is expected to show as failed; that's cosmetic. Once merged into `pr-assets`, pushes to that branch will skip Vercel previews instead of failing.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffbe0-bad3-7674-86d3-2414e7379c20?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffbe0-bad3-7674-86d3-2414e7379c20&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

