### PR TITLE
feat(sessions): open a session where its provider keeps it

### DIFF
--- a/apps/desktop/src/claude-code-adapter.ts
+++ b/apps/desktop/src/claude-code-adapter.ts
@@ -386,6 +386,15 @@ function titleFromTail(parsed: ParsedClaudeSessionTail): string {
   return parsed.aiTitle ?? workspaceLabel(parsed.cwd);
 }
 
+/**
+ * No address is reported, because Claude Code publishes none that opens *this*
+ * session. Its own `claude-cli://open` handler takes a directory and a prompt
+ * and starts a new terminal session; the one route that names a session at all,
+ * the VS Code extension's `session` parameter, resolves against whichever
+ * workspace that editor happens to have open and starts a fresh conversation
+ * when it does not match. A row that opened a new chat instead of the one it
+ * named would be worse than a row that opens nothing.
+ */
 function detailFromTail(parsed: ParsedClaudeSessionTail): SessionDetail {
   return {
     ...(parsed.activity ? { activity: parsed.activity } : {}),

--- a/apps/desktop/src/codex-adapter.ts
+++ b/apps/desktop/src/codex-adapter.ts
@@ -34,6 +34,14 @@ const CODEX_CONFIG_KEY = {
   SQLITE_DIRECTORY: "sqlite_home",
 } as const;
 
+/**
+ * The Codex app's own address for a local thread. Codex registers the `codex`
+ * scheme for its windows and documents `threads/<thread-id>` as the route to an
+ * existing local chat, keyed by the same `threads.id` this adapter reads — so
+ * the row and the address it opens name one thread rather than two.
+ */
+const CODEX_THREAD_LINK_PREFIX = "codex://threads/";
+
 const CODEX_THREAD_COLUMN = {
   ID: "id",
   CWD: "cwd",
@@ -498,11 +506,13 @@ function detailFromRow(
   const activity = rollout?.activity;
   const branch = textFromRow(row, CODEX_THREAD_COLUMN.GIT_BRANCH);
   const model = modelFromRow(row);
+  const threadId = textFromRow(row, CODEX_THREAD_COLUMN.ID);
   return {
     ...(activity ? { activity } : {}),
     repository: workspaceLabel(textFromRow(row, CODEX_THREAD_COLUMN.CWD)),
     ...(branch ? { branch } : {}),
     ...(model ? { model } : {}),
+    ...(threadId ? { link: `${CODEX_THREAD_LINK_PREFIX}${encodeURIComponent(threadId)}` } : {}),
   };
 }
 

--- a/apps/desktop/src/cursor-local-adapter.ts
+++ b/apps/desktop/src/cursor-local-adapter.ts
@@ -270,6 +270,12 @@ function statusFromTurn(turn: { failed: boolean } | undefined, isFresh: boolean)
  * that a turn failed. Cursor records why it failed, but that reason is written
  * from the turn itself, so the fact of the failure is reported and its wording
  * is not — the same fixed line the cloud half reports for a failed run.
+ *
+ * No address, unlike the cloud half, which reports the agent's own page. Cursor
+ * registers `cursor://` for its windows but publishes no route to a chat: its
+ * handler answers a prompt, a command, a rule, and a background agent, and none
+ * of them is a chat that already exists. The folder the chat was held in is not
+ * the chat, so it is not offered as one.
  */
 function detailFor(label: string, status: SessionStatus): SessionDetail {
   return {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -8,6 +8,7 @@ import {
   type NativeNotchGeometry,
   positionNotchWindow,
   SessionAttentionReviewer,
+  type SessionIdentity,
   type SessionProviderAdapter,
 } from "@sidecar/core";
 import {
@@ -302,6 +303,23 @@ function trustedSender(event: IpcMainEvent | IpcMainInvokeEvent): boolean {
   return url === rendererUrl();
 }
 
+/**
+ * Whether a renderer message names a session. Both halves are required to be
+ * present here because the registry rejects an empty one by throwing, and a
+ * malformed message is a broken request rather than something a user can act
+ * on.
+ */
+function isSessionIdentity(value: unknown): value is SessionIdentity {
+  if (value === null || typeof value !== "object") return false;
+  const { providerId, providerSessionId } = value as Partial<SessionIdentity>;
+  return (
+    typeof providerId === "string" &&
+    providerId.trim().length > 0 &&
+    typeof providerSessionId === "string" &&
+    providerSessionId.trim().length > 0
+  );
+}
+
 function registerIpc(): void {
   ipcMain.handle(channels.bootstrap, async (event): Promise<AppBootstrap> => {
     if (!trustedSender(event)) throw new Error("Untrusted renderer");
@@ -382,6 +400,23 @@ function registerIpc(): void {
   ipcMain.on(channels.openProviderApiKeys, (event, providerId: unknown) => {
     if (!trustedSender(event) || !isCredentialProviderId(providerId)) return;
     void shell.openExternal(CREDENTIAL_PROVIDERS[providerId].apiKeysUrl);
+  });
+
+  // Pressing a session hands its provider's own address to the system. Luke
+  // does not draw the chat, navigate it, or write to it — the provider opens
+  // its own window and Luke has already stood down — so this stays inside what
+  // a read-only sidecar may do.
+  //
+  // The renderer names a session rather than an address, so the set of places
+  // Luke can send you is the set of sessions currently observed. The address is
+  // read back out of the registry, which holds only normalized sessions: an
+  // address a provider reported in a scheme outside `SESSION_LINK_SCHEME` never
+  // reached one. A fixture run has an empty registry and so opens nothing,
+  // which is what a deterministic capture needs.
+  ipcMain.on(channels.openSession, (event, identity: unknown) => {
+    if (!trustedSender(event) || !isSessionIdentity(identity)) return;
+    const link = sessionRegistry.get(identity)?.detail.link;
+    if (link) void shell.openExternal(link);
   });
 
   // The panel is normally shown without stealing focus. A text field cannot be

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -1,4 +1,4 @@
-import type { NormalizedSession } from "@sidecar/core";
+import type { NormalizedSession, SessionIdentity } from "@sidecar/core";
 import { contextBridge, ipcRenderer } from "electron";
 import type {
   AppBootstrap,
@@ -28,6 +28,9 @@ const bridge: AppBridge = {
     ) as Promise<SettingsUpdateResult>,
   openProviderApiKeys: (providerId: CredentialProviderId) => {
     ipcRenderer.send(channels.openProviderApiKeys, providerId);
+  },
+  openSession: (identity: SessionIdentity) => {
+    ipcRenderer.send(channels.openSession, identity);
   },
   focusPanel: () => ipcRenderer.send(channels.focusPanel),
   notifyReady: () => ipcRenderer.send(channels.rendererReady),

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -28,6 +28,7 @@ import { PANEL_TAB, type PanelTab } from "./panel-tabs";
 import {
   arrangeSessions,
   DEFAULT_SESSION_VIEW,
+  type DisplaySession,
   displaySessions,
   type SessionView,
   sessionTally,
@@ -515,6 +516,26 @@ export function App(): React.JSX.Element {
     remove: removeProviderApiKey,
   };
 
+  /**
+   * Sends a session to its provider and gets out of the way. Luke floats above
+   * every window, so a panel left open would be sitting on top of the very chat
+   * it was just asked to bring forward — the same reason fetching a key stands
+   * the panel down. The pointer is on the row that was pressed and cannot leave
+   * a shape that is no longer drawn, so the close is asked for here rather than
+   * waited for.
+   */
+  const openSession = useCallback(
+    (session: DisplaySession) => {
+      window.sidecar.openSession({
+        providerId: session.providerId,
+        providerSessionId: session.id,
+      });
+      cancelHoverTransition();
+      void changeMode(false);
+    },
+    [cancelHoverTransition, changeMode],
+  );
+
   /** The capsule is a button: pressing it opens the panel, or closes it again. */
   const handleCapsulePress = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -711,6 +732,7 @@ export function App(): React.JSX.Element {
             list={list}
             view={sessionView}
             onViewChange={changeSessionView}
+            onOpenSession={openSession}
             offerOptions={offerOptions}
             optionsOpen={optionsOpen}
             onOptionsToggle={() => setOptionsOpen((open) => !open)}

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -1,7 +1,7 @@
 import { SESSION_LOCATION } from "@sidecar/core";
 import { PANEL_TAB, type PanelTab, TabBar } from "./panel-tabs";
 import { CloudBadge, ProviderMark } from "./provider-marks";
-import type { ArrangedSessions, SessionView } from "./session-model";
+import type { ArrangedSessions, DisplaySession, SessionView } from "./session-model";
 import {
   EmptyState,
   SessionOptions,
@@ -11,10 +11,66 @@ import {
 } from "./session-parts";
 import { SettingsPanel, type SettingsPanelProps } from "./settings-panel";
 
+/**
+ * One session, drawn the same way whether or not it can be opened. A row whose
+ * provider gave an address is a button and nothing else changes: the panel is
+ * five rows of dense text, and a second permanent mark on some of them would be
+ * read as a state before it was read as an affordance. The pointer is what
+ * separates them — a row that can be opened lifts and takes the hand cursor,
+ * one that cannot stays flat under it, which is the honest answer to whether
+ * pressing would do anything.
+ */
+function SessionRow({
+  session,
+  index,
+  onOpen,
+}: {
+  session: DisplaySession;
+  index: number;
+  onOpen: (session: DisplaySession) => void;
+}): React.JSX.Element {
+  const shared = {
+    className: "session-row",
+    "data-state": session.state,
+    style: { "--row-index": index + 1 } as React.CSSProperties,
+  };
+  const content = (
+    <>
+      <span className="row-avatar">
+        <ProviderMark providerId={session.providerId} />
+        {session.location === SESSION_LOCATION.CLOUD ? <CloudBadge /> : null}
+      </span>
+      <span className="row-copy">
+        <strong>{session.title}</strong>
+        {session.detail ? <small>{session.detail}</small> : null}
+        <small className="row-context">{session.context}</small>
+      </span>
+      <StateChip state={session.state} label={session.label} />
+    </>
+  );
+
+  if (!session.openable) return <article {...shared}>{content}</article>;
+  return (
+    <button
+      {...shared}
+      type="button"
+      // The row's own lines are its accessible name, which already reads as
+      // the session; the title says what pressing it does, and names the agent
+      // because that is the window you are about to be in.
+      title={`Open in ${session.provider}`}
+      onClick={() => onOpen(session)}
+    >
+      {content}
+    </button>
+  );
+}
+
 export interface PanelBodyProps {
   list: ArrangedSessions;
   view: SessionView;
   onViewChange: (view: SessionView) => void;
+  /** Sends the pressed session to its provider, wherever the provider keeps it. */
+  onOpenSession: (session: DisplaySession) => void;
   /**
    * Whether there is anything for the sheet to decide. Decided by the panel
    * rather than here, because whoever offers the button also has to be the one
@@ -33,6 +89,7 @@ export function PanelBody({
   list,
   view,
   onViewChange,
+  onOpenSession,
   offerOptions,
   optionsOpen,
   onOptionsToggle,
@@ -63,23 +120,12 @@ export function PanelBody({
               <EmptyState />
             ) : (
               list.sessions.map((session, index) => (
-                <article
-                  className="session-row"
+                <SessionRow
                   key={session.id}
-                  data-state={session.state}
-                  style={{ "--row-index": index + 1 } as React.CSSProperties}
-                >
-                  <span className="row-avatar">
-                    <ProviderMark providerId={session.providerId} />
-                    {session.location === SESSION_LOCATION.CLOUD ? <CloudBadge /> : null}
-                  </span>
-                  <span className="row-copy">
-                    <strong>{session.title}</strong>
-                    {session.detail ? <small>{session.detail}</small> : null}
-                    <small className="row-context">{session.context}</small>
-                  </span>
-                  <StateChip state={session.state} label={session.label} />
-                </article>
+                  session={session}
+                  index={index}
+                  onOpen={onOpenSession}
+                />
               ))
             )}
           </div>

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -93,6 +93,12 @@ export interface DisplaySession {
   label: string;
   location: SessionLocation;
   observedAt: number;
+  /**
+   * Whether the provider gave an address that opens this session, which is what
+   * decides if the row is a control at all. The address itself stays in the
+   * main process: the row only has to know that pressing it would do something.
+   */
+  openable: boolean;
 }
 
 /** One filter someone can choose, and how many sessions it would leave. */
@@ -200,6 +206,11 @@ export function displaySessions(
     ? bootstrap.fixture.sessions.map((session) => ({
         ...session,
         label: STATE_LABEL[session.state],
+        // A fixture stands for sessions that are not on the machine drawing
+        // them, so there is nothing for a press to open. Nothing is lost from
+        // the visual evidence by that: a row that can be opened and one that
+        // cannot are drawn alike until a pointer is over one.
+        openable: false,
       }))
     : sessions.map((session) => ({
         id: session.providerSessionId,
@@ -212,6 +223,7 @@ export function displaySessions(
         label: STATE_LABEL[sessionState(session)],
         location: session.location,
         observedAt: session.observedAt,
+        openable: session.detail.link !== undefined,
       }));
 
   return [...visible].sort(byUrgency);

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1031,6 +1031,18 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
     transform var(--duration-shape) var(--spring);
 }
 
+/* The row is the one member of that group that is also a control, so its
+   transition carries the pointer's answer as well as its arrival. A transition
+   list replaces rather than extends, so the whole of it is restated here rather
+   than in the session stylesheet, where the two would drift apart unseen. */
+.session-row {
+  transition:
+    opacity var(--duration-exit) var(--motion-exit),
+    transform var(--duration-shape) var(--spring),
+    border-color var(--duration-hover) ease,
+    background-color var(--duration-hover) ease;
+}
+
 .app-stage[data-presentation="panel"] .session-row,
 .app-stage[data-presentation="panel"] .settings-section,
 .app-stage[data-presentation="panel"] .quit-button,

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1016,29 +1016,45 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 /* Content arrives behind the surface, never in front of it, and it arrives on
    the same spring the surface is riding. Each row starts further up than the
    one above it, so the stack is compressed and the gaps spring open — the
-   space between sessions is the thing that moves. */
+   space between sessions is the thing that moves.
+ *
+ * The stagger is written into the shorthand beside the property it delays,
+ * rather than as a `transition-delay` list beside the rule that sets the state.
+ * Some of this stack also answers the pointer, and a single `transition-delay`
+ * applies to every property in the list: the row's turn to appear would become
+ * the wait before its hover, for as long as the panel stayed open. A list
+ * positioned against the property list can express that, but only by matching
+ * two rules by index — so inserting a property silently delays the wrong one.
+ * Here each delay travels with the property it belongs to, and an element that
+ * declares its own transition carries the arrival pair unchanged.
+ *
+ * `--row-delay` is what makes it directional: zero here, so leaving is
+ * immediate, and the stagger below, so arriving fans out. A transition reads
+ * its timing from the state being entered, which is what keeps the two apart. */
 .session-row,
 .settings-section,
 .quit-button,
 .empty-state,
 .panel-header {
+  --row-delay: 0s;
+
   opacity: 0;
   transform: translateY(
     calc((min(var(--row-index, 0), var(--row-fan-limit)) + 1) * var(--row-fan) * -1)
   );
   transition:
-    opacity var(--duration-exit) var(--motion-exit),
-    transform var(--duration-shape) var(--spring);
+    opacity var(--duration-exit) var(--motion-exit) var(--row-delay),
+    transform var(--duration-shape) var(--spring) var(--row-delay);
 }
 
-/* The row is the one member of that group that is also a control, so its
-   transition carries the pointer's answer as well as its arrival. A transition
-   list replaces rather than extends, so the whole of it is restated here rather
-   than in the session stylesheet, where the two would drift apart unseen. */
+/* The row is one of the two members of that stack that is also a control, so
+   its transition carries the pointer's answer as well as its arrival. The
+   answer takes no delay, which is the whole reason the stagger is declared per
+   property above. */
 .session-row {
   transition:
-    opacity var(--duration-exit) var(--motion-exit),
-    transform var(--duration-shape) var(--spring),
+    opacity var(--duration-exit) var(--motion-exit) var(--row-delay),
+    transform var(--duration-shape) var(--spring) var(--row-delay),
     border-color var(--duration-hover) ease,
     background-color var(--duration-hover) ease;
 }
@@ -1056,14 +1072,6 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 
   opacity: 1;
   transform: none;
-  transition-delay: var(--row-delay);
-}
-
-/* The one element in the stack that also answers the pointer. A delay list
-   matched to its property list keeps the stagger on the arrival, where it
-   belongs, instead of making the hover wait for the row's turn to appear. */
-.app-stage[data-presentation="panel"] .quit-button {
-  transition-delay: var(--row-delay), var(--row-delay), 0s, 0s;
 }
 
 /* Settings --------------------------------------------------------------- */
@@ -1126,11 +1134,11 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   color: var(--text-secondary);
   font-size: 11.5px;
   font-weight: 620;
-  /* Arrival first, then feedback: this order is what the panel's delay list
-     above is matched against, so the two are edited together. */
+  /* Arrival on the stack's stagger, feedback with none. The order no longer
+     matters to anything outside this declaration. */
   transition:
-    opacity var(--duration-exit) var(--motion-exit),
-    transform var(--duration-shape) var(--spring),
+    opacity var(--duration-exit) var(--motion-exit) var(--row-delay),
+    transform var(--duration-shape) var(--spring) var(--row-delay),
     background-color var(--duration-hover) ease,
     color var(--duration-hover) ease;
 }

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -284,8 +284,14 @@
   }
 }
 
+/* Both kinds of row: the ones a provider gave an address for are buttons and
+   the rest are articles, drawn identically at rest. `width` and `text-align`
+   are all a button needs to sit in the column the way an article does; the rest
+   of the button reset, and the row's transition, are in base.css beside the
+   arrival that transition also carries. */
 .session-row {
   display: flex;
+  width: 100%;
   min-height: 66px;
   flex: 0 0 auto;
   align-items: center;
@@ -294,11 +300,39 @@
   border: 1px solid var(--hairline);
   border-radius: 17px;
   background: rgba(255, 255, 255, 0.028);
+  text-align: left;
 }
 
 .session-row[data-state="attention"] {
   border-color: color-mix(in srgb, var(--accent) 30%, transparent);
   background: color-mix(in srgb, var(--accent) 9%, transparent);
+}
+
+/* Whether pressing a row would do anything is answered by the pointer and
+   nowhere else: a row that can be opened lifts under it, one that cannot stays
+   exactly as it was drawn. That is also why nothing is added at rest — every
+   mark and every chip on this row already means something, and one more on some
+   rows would be read as another state before it was read as an affordance.
+   Colour alone: the row's `transform` is spoken for by its arrival, and its box
+   is what the surface behind it is measured from, so neither may move. */
+button.session-row:hover {
+  border-color: rgba(255, 255, 255, 0.16);
+  background: var(--raised);
+}
+
+button.session-row[data-state="attention"]:hover {
+  border-color: color-mix(in srgb, var(--accent) 46%, transparent);
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+}
+
+/* Inset, like every other ring in the panel: an outline outside this box would
+   be drawn on the desktop past the edge of the shape. It belongs to the
+   keyboard alone — the flag on the root is set only once the keyboard has
+   actually moved focus, because the panel takes focus programmatically when it
+   opens and the engine reads that as keyboard modality. */
+html[data-keyboard="true"] button.session-row:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -3px;
 }
 
 /* Neutral tile: the mark inside carries the provider's own colour, so tinting

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -3,6 +3,7 @@ import type {
   NormalizedSession,
   Rectangle,
   ResolvedNotchGeometry,
+  SessionIdentity,
   WindowMode,
 } from "@sidecar/core";
 import type { CredentialProviderId } from "./credential-providers";
@@ -83,6 +84,13 @@ export interface AppBridge {
    * fixed by this build.
    */
   openProviderApiKeys(providerId: CredentialProviderId): void;
+  /**
+   * Opens an observed session where its provider keeps it. The renderer names
+   * the session rather than its address, for the same reason it names a
+   * provider above: the places Luke can send you are the sessions it is already
+   * watching, and no URL crosses this boundary.
+   */
+  openSession(identity: SessionIdentity): void;
   /** Brings the expanded panel forward so it can accept typed input. */
   focusPanel(): void;
   notifyReady(): void;
@@ -99,6 +107,7 @@ export const channels = {
   requestMicrophone: "app:request-microphone",
   setProviderApiKey: "app:set-provider-api-key",
   openProviderApiKeys: "app:open-provider-api-keys",
+  openSession: "app:open-session",
   focusPanel: "app:focus-panel",
   rendererReady: "app:renderer-ready",
   lifecycle: "app:lifecycle",

--- a/apps/desktop/tests/codex-adapter.test.ts
+++ b/apps/desktop/tests/codex-adapter.test.ts
@@ -178,7 +178,31 @@ test("observes a Codex thread under the name Codex gave it", async (t) => {
     repository: "luke",
     branch: "codex/bump-version",
     model: "gpt-5.6-luna · medium",
+    link: "codex://threads/codex-active",
   });
+});
+
+test("addresses a Codex thread by the id Codex files it under", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeCodexState(codexHome, [
+    {
+      // A real thread id is a UUID, but the id is Codex's to choose and it is
+      // carried into an address, so one needing escaping proves it is escaped
+      // rather than pasted in.
+      id: "codex thread/one?two",
+      cwd: "/Users/test/luke",
+      observedAt: TEST_TIME - 1_000,
+    },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations[0]?.detail?.link, "codex://threads/codex%20thread%2Fone%3Ftwo");
 });
 
 test("reports a finished Codex turn as waiting for its developer", async (t) => {

--- a/apps/desktop/tests/session-model.test.ts
+++ b/apps/desktop/tests/session-model.test.ts
@@ -95,6 +95,29 @@ test("a row carries where its session runs, from either data source", () => {
   assert.equal(live[1]?.location, SESSION_LOCATION.LOCAL);
 });
 
+test("a row is a control only where its provider gave an address", () => {
+  const live = displaySessions(bootstrap(false), [
+    normalizeSession(CODEX_PROVIDER, {
+      providerSessionId: "codex-addressed",
+      title: "Session codex-addressed",
+      status: SESSION_STATUS.WORKING,
+      observedAt: 1_000,
+      detail: { link: "codex://threads/codex-addressed" },
+    }),
+    liveSession(CLAUDE_PROVIDER, "claude-unaddressed", SESSION_STATUS.WORKING),
+  ]);
+
+  assert.equal(live.find((session) => session.id === "codex-addressed")?.openable, true);
+  assert.equal(live.find((session) => session.id === "claude-unaddressed")?.openable, false);
+
+  // A fixture stands for sessions that are not on the machine drawing them, so
+  // no fixture row is ever a control however the panel is being run.
+  assert.equal(
+    FIXTURE_SESSIONS.every((session) => session.openable === false),
+    true,
+  );
+});
+
 test("a speaking disposition needs a person even while the session works", () => {
   const speaking = normalizeSession(
     CLAUDE_PROVIDER,

--- a/packages/sidecar-core/src/session.ts
+++ b/packages/sidecar-core/src/session.ts
@@ -66,6 +66,36 @@ export interface SessionIdentity {
 }
 
 /**
+ * The schemes Luke will hand a session's address to the operating system with:
+ * `https` for a provider that keeps the session in its own cloud, and an app
+ * scheme for one that registered a handler for its own windows on this machine.
+ *
+ * A link is the one observed field the surface does not merely draw — it acts on
+ * it — and it arrives from provider-owned data like every other field. So the
+ * set is fixed by this build and applied where every other bound is applied:
+ * an address outside it never reaches a session at all, rather than being
+ * checked again wherever something is about to open one.
+ */
+export const SESSION_LINK_SCHEME = {
+  HTTPS: "https:",
+  CODEX: "codex:",
+  CONDUCTOR: "conductor:",
+} as const;
+
+export type SessionLinkScheme = (typeof SESSION_LINK_SCHEME)[keyof typeof SESSION_LINK_SCHEME];
+
+const SESSION_LINK_SCHEMES: ReadonlySet<string> = new Set(Object.values(SESSION_LINK_SCHEME));
+
+/** Whether an address is one Luke may ask the system to open. */
+export function isOpenableSessionLink(link: string): boolean {
+  try {
+    return SESSION_LINK_SCHEMES.has(new URL(link).protocol);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * The context that makes one session tellable from another. Every field is
  * optional because no provider reports all of them, and every field is bounded
  * so a row stays a row. Adapters fill in whatever their provider actually
@@ -80,7 +110,13 @@ export interface SessionDetail {
   model?: string;
   /** Why the session stopped, when it stopped on something it cannot pass. */
   error?: string;
-  /** A provider-owned address that opens this session where it lives. */
+  /**
+   * A provider-owned address that opens this session where it lives. Only a
+   * provider that can address the session itself reports one: an address that
+   * lands near a session rather than on it — its folder, or a fresh chat in the
+   * same place — is worse than no address at all, because pressing a row would
+   * then do something other than what it said.
+   */
   link?: string;
   /** The work the session has published, such as a pull request. */
   change?: string;
@@ -138,6 +174,17 @@ function boundedText(value: string | undefined, maximumLength: number): string |
   return normalized.slice(0, maximumLength);
 }
 
+/**
+ * A session's address, or nothing. Unlike every other bounded field this one is
+ * dropped rather than cut when it runs long: a truncated address is a different
+ * address, and this is the field something is opened from.
+ */
+function sessionLink(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  if (!normalized || normalized.length > maximumSessionLinkLength) return undefined;
+  return isOpenableSessionLink(normalized) ? normalized : undefined;
+}
+
 function timestamp(value: number, field: string): number {
   if (!Number.isFinite(value) || value < 0) {
     throw new Error(`${field} must be a non-negative finite timestamp`);
@@ -189,7 +236,7 @@ export function normalizeSessionDetail(detail: SessionDetail | undefined): Sessi
   const branch = boundedText(detail.branch, maximumSessionDetailLength);
   const model = boundedText(detail.model, maximumSessionDetailLength);
   const error = boundedText(detail.error, maximumSessionDetailLength);
-  const link = boundedText(detail.link, maximumSessionLinkLength);
+  const link = sessionLink(detail.link);
   const change = boundedText(detail.change, maximumSessionLinkLength);
 
   return {

--- a/packages/sidecar-core/tests/session-registry.test.ts
+++ b/packages/sidecar-core/tests/session-registry.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   ATTENTION_DISPOSITION,
   InMemorySessionRegistry,
+  maximumSessionLinkLength,
   maximumSessionSummaryLength,
   type ProviderSessionObservation,
   SESSION_LOCATION,
@@ -19,6 +20,7 @@ const TEST_CONTROL = {
   INTERRUPT: "interrupt",
 } as const;
 const TEST_CONTROL_WITH_WHITESPACE = " open ";
+const TEST_DEVIN_LINK = "https://app.devin.ai/sessions/devin-1";
 
 function observation(
   providerSessionId: string,
@@ -60,6 +62,38 @@ test("normalizes provider observations without conflating provider-local identit
   assert.equal(supportsSessionControl(session, TEST_CONTROL.OPEN), true);
   assert.equal(supportsSessionControl(session, TEST_CONTROL.INTERRUPT), false);
   assert.equal(registry.list().length, 2);
+});
+
+test("keeps only the addresses Luke would open, and never a shortened one", () => {
+  const registry = new InMemorySessionRegistry();
+  const linkFor = (link: string) =>
+    registry.upsert(codex, observation("run:link", 100, { detail: { link } })).detail.link;
+
+  for (const link of [
+    "https://cursor.com/agents?id=bc_1",
+    "codex://threads/019ff315-8735-7382-9fbe-16b0ea8ad990",
+    "conductor://workspace?session=session-working",
+  ]) {
+    assert.equal(linkFor(link), link, `${link} is a session's own address`);
+  }
+  assert.equal(linkFor("  https://app.devin.ai/sessions/devin-1  "), TEST_DEVIN_LINK);
+
+  // A scheme outside the set never becomes a session's address, so nothing
+  // downstream has to ask a second time whether an address is safe to open.
+  for (const link of [
+    "http://cursor.com/agents?id=bc_1",
+    "file:///Users/dean/.claude/projects/luke/session.jsonl",
+    "javascript:void 0",
+    "/Users/dean/luke",
+    "not a url",
+    "",
+  ]) {
+    assert.equal(linkFor(link), undefined, `${link} is not an address Luke may open`);
+  }
+
+  // A link past the bound is dropped rather than cut: every other field is
+  // shortened to fit a row, but a shortened address is a different address.
+  assert.equal(linkFor(`https://example.com/${"a".repeat(maximumSessionLinkLength)}`), undefined);
 });
 
 test("a session runs on this machine unless its provider observed it elsewhere", () => {


### PR DESCRIPTION
## Summary

- Pressing a session row opens the chat behind it, where its provider keeps it.
- Four providers already reported an address that nothing ever read — Conductor's deep link, Cursor's agent page, Devin's and Jules' session URLs. This wires them up.
- **Codex** is the new address: it registers the `codex` scheme for its own windows and documents `threads/<thread-id>` as the route to an existing local chat, keyed by the same `threads.id` the adapter already reads. Verified against a real thread on a physical Mac — it opens that thread, not a new one.
- **Claude Code and Cursor's local sessions report no address**, because neither provider publishes one that opens the session itself. `claude-cli://open` takes a directory and a prompt and starts a *new* terminal session; the one route that names a session — the VS Code extension's `session` parameter — resolves against whichever workspace that editor happens to have open and quietly starts a fresh conversation when it does not match (confirmed in the extension's own `/open` handler, which reads `session` and `prompt` and nothing else). Cursor's deeplink extension ships five routes — `prompt`, `command`, `rule`, `automations`, `background-agent` — and none of them is a chat that already exists. A row that opened something *near* a session rather than the session would be worse than a row that opens nothing, so those rows are not controls.

A row with an address is a `<button>` and one without stays an `<article>`; the two are drawn identically at rest. The pointer is what separates them — a row that can be opened lifts and takes the hand cursor, one that cannot stays flat under it. Nothing is added at rest because every mark and chip on that row already means something, and one more on some rows would be read as another state before it was read as an affordance. Pressing stands the panel down, for the same reason fetching an API key does: Luke floats above every window, including the one it was just asked to bring forward.

The renderer names a session rather than an address, exactly as it names a provider for a key page, so the places Luke can send you are the sessions it is already watching. `SESSION_LINK_SCHEME` bounds what may be opened where every other observed field is bounded, so an address in another scheme never becomes part of a session at all — and one past the length bound is dropped rather than cut, because a shortened address is a different address.

## Evidence

- Platform-independent checks: `passed` — `./scripts/check.sh`, 198 desktop and 41 core tests
- macOS Electron verification (`./scripts/verify.sh`): `passed` on a physical Mac (macOS, Apple silicon), re-run after the hover fix

All five evidence captures are **byte-identical** to a baseline rebuilt from `HEAD`, which is the intended result: fixture sessions carry no address, because a fixture stands for sessions that are not on the machine drawing them. A row that can be opened and one that cannot are drawn alike until a pointer is over one, so the rest capture is unchanged by design.

Adapters were also probed against real local session stores: `codex: 1 observed, 1 addressed`, `claude-code: 2 observed, 0 addressed`, `cursor: 1 observed, 0 addressed`.

### Follow-up: hover lag on openable rows

Bugbot caught — and manual testing confirmed — that a row answering the pointer waited for its own arrival stagger before lighting up, for as long as the panel stayed open. `transition-delay` is a list positioned against `transition-property`, and the panel rule set a single value, so the stagger covered the two colour properties too.

Fixed by moving the stagger into the `transition` shorthand beside the property it delays, so it cannot leak to the others. `--row-delay` is `0s` in the resting state and the stagger in the panel state, which keeps arrival fanned out and leaving immediate. This also let `.quit-button`'s positional delay list (`var(--row-delay), var(--row-delay), 0s, 0s`) be deleted, so the index-matching between two rules is gone rather than duplicated.

Measured from the built stylesheet in a headless browser, `--row-index: 4`:

| | before | after |
|---|---|---|
| row, panel open | `delays=[0.328s]` | `delays=[0.328s, 0.328s, 0s, 0s]` |
| quit button, panel open | `[0.328s, 0.328s, 0s, 0s]` via the delay list | `[0.328s, 0.328s, 0s, 0s]` with no delay list |
| row, panel closed | `[0s, 0s, 0s, 0s]` | `[0s, 0s, 0s, 0s]` |

Captures are byte-identical before and after this fix, which is expected: a capture run zeroes `--row-stagger` and `--expand-delay` so the shape settles deterministically.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31731587016/artifacts/9193453682) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31731587016)

- Commit: `5155cd07993586c0a2e9b3f36fba1b2690611bc4`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded` — verification ran against the fixture geometry

## Notes

- Blockers or follow-up verification: none. One deliberate omission is described above: if the workspace-dependent VS Code route is judged acceptable for Claude Code, adding it is a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/9138063b-4cc0-4949-bed8-1b6cb06cd3c3)

