### PR TITLE
feat(face): bounce when a session starts asking rather than while it waits

### DIFF
--- a/apps/desktop/src/renderer/luke-face-mood.ts
+++ b/apps/desktop/src/renderer/luke-face-mood.ts
@@ -226,12 +226,15 @@ export function useFaceMotion(context: FaceContext, still: boolean): FaceMotion 
     return () => window.clearTimeout(timer);
   }, [gesture, restful, still]);
 
-  // A gesture the rest has taken the face back from is over, not paused: left
-  // set, it would resume partway through its cycle whenever the rest turned
-  // restful again, which reads as a glitch rather than a gesture.
+  // A gesture the rest will not spare the face for is over, not paused: left
+  // set, it would surface partway through its own timer whenever the rest
+  // turned restful again, which reads as a glitch rather than a gesture. Every
+  // such gesture, not only the ones a change of rest interrupted — a session
+  // that starts asking into an open microphone is a moment the face missed
+  // rather than one it owes you the instant the microphone closes.
   useEffect(() => {
-    if (!restful) setGesture(undefined);
-  }, [restful]);
+    if (!restful && gesture !== undefined) setGesture(undefined);
+  }, [restful, gesture]);
 
   // Held still, the face keeps one pose rather than a quieter set of them: the
   // stylesheet stops the loops, and this stops the poses changing underneath.

--- a/apps/desktop/src/renderer/luke-face-mood.ts
+++ b/apps/desktop/src/renderer/luke-face-mood.ts
@@ -6,11 +6,15 @@ import { FACE_MOTION, FACE_MOTION_CYCLE_MS, type FaceMotion } from "./luke-face-
  * badge reports — sessions, and whether the microphone is open — because the
  * face is the one thing the capsule always has room for, and a face that knew
  * something the panel did not would be a second, quieter source of truth.
+ *
+ * The sessions asking for a person arrive as ids rather than as a count,
+ * because what the face owes them is one nudge each as they start asking, and a
+ * count cannot tell one starting from another being answered in the same poll.
  */
 export interface FaceContext {
   speaking: boolean;
   microphoneLive: boolean;
-  attention: number;
+  attention: readonly string[];
   working: number;
   complete: number;
   total: number;
@@ -24,16 +28,20 @@ export interface FaceContext {
 export function restingMotion(context: FaceContext): FaceMotion {
   if (context.speaking) return FACE_MOTION.TALKING;
   if (context.microphoneLive) return FACE_MOTION.LISTENING;
-  // Someone is needed. The fidget is the only rest that reads as impatience,
-  // and it is the one rest nothing playful is allowed to interrupt.
-  if (context.attention > 0) return FACE_MOTION.WAITING;
+  // Nothing here asks who is waiting on you. A rest holds for as long as it
+  // stays true, and for anyone whose sessions are usually waiting on them a
+  // fidget that never stops is a face permanently mid-nag: it says what the
+  // count badge is already saying, and says it so constantly that the one
+  // moment worth catching — a session that has just started asking — arrives
+  // indistinguishable from the hour before it. That moment is a gesture
+  // instead; see `noticedMotion`.
   if (context.working > 0) return FACE_MOTION.MONITORING;
   // Nothing to watch at all, which is a different thing from nothing happening.
   if (context.total === 0) return FACE_MOTION.SLEEPING;
   return FACE_MOTION.IDLE;
 }
 
-/** The rests a gesture may interrupt: the ones where nobody is being kept waiting. */
+/** The rests a gesture may interrupt: every one the microphone does not own. */
 const RESTFUL: ReadonlySet<FaceMotion> = new Set([
   FACE_MOTION.IDLE,
   FACE_MOTION.MONITORING,
@@ -42,13 +50,12 @@ const RESTFUL: ReadonlySet<FaceMotion> = new Set([
 
 /**
  * What the face actually plays. A gesture holds it only while the rest beneath
- * can spare it: the moment something needs saying, the rest takes the face
+ * can spare it: the moment the microphone opens, the rest takes the face
  * straight back rather than waiting the gesture out.
  *
  * Scheduling a gesture only while the rest is restful is not enough, because the
- * rest can change under one that is already playing. A session that starts
- * waiting on you would be announced by a wink, and — the reason this is decided
- * here rather than in an effect that runs afterwards — a microphone opened mid
+ * rest can change under one that is already playing — and this is decided here
+ * rather than in an effect that runs afterwards because a microphone opened mid
  * gesture would not tint the face at all until the gesture ran out, leaving the
  * capsule silent about an open microphone for as long as five seconds.
  */
@@ -57,11 +64,56 @@ export function playedMotion(resting: FaceMotion, gesture: FaceMotion | undefine
 }
 
 /**
+ * What the face has already reacted to. Sessions arriving and finishing are
+ * counted, because one arrival is the same news as any other; the ones asking
+ * for a person are remembered by id, because three still asking is not the news
+ * that one of them being answered as a fourth starts asking is, and the count
+ * those two states share is the same number.
+ */
+export interface FaceObservation {
+  attention: ReadonlySet<string>;
+  complete: number;
+  total: number;
+}
+
+function observedFace(
+  context: Pick<FaceContext, "attention" | "complete" | "total">,
+): FaceObservation {
+  return {
+    attention: new Set(context.attention),
+    complete: context.complete,
+    total: context.total,
+  };
+}
+
+/**
+ * The one-shot a change has earned, if any. A session that has just started
+ * asking outranks the other two: it is the only one of them that is about to
+ * cost someone their attention, and the fidget is the face saying so — once, at
+ * the moment it becomes true, rather than for however long it stays true.
+ */
+export function noticedMotion(
+  previous: FaceObservation,
+  current: FaceObservation,
+): FaceMotion | undefined {
+  for (const session of current.attention) {
+    if (!previous.attention.has(session)) return FACE_MOTION.WAITING;
+  }
+  if (current.complete > previous.complete) return FACE_MOTION.SUCCESS;
+  if (current.total > previous.total) return FACE_MOTION.NOTIFICATION;
+  return undefined;
+}
+
+/**
  * Gestures Luke makes for no reason at all. They are what keeps a permanent
  * fixture from reading as a static one — a face that only ever blinks is a
  * screensaver — and they are all short, so the rest underneath is still what the
  * strip mostly says. Nothing here means anything; the ones that do are chosen by
- * `restingMotion` or fired at a session arriving or finishing.
+ * `restingMotion` or fired by `noticedMotion` at something that just changed.
+ *
+ * They matter more than they did when a waiting session held the face: for
+ * anyone with sessions perpetually asking for them, this list is now most of
+ * what the face does between one nudge and the next.
  */
 export const IDLE_ASIDES: readonly FaceMotion[] = [
   FACE_MOTION.WINK,
@@ -109,34 +161,57 @@ export function usePrefersReducedMotion(): boolean {
 }
 
 /**
+ * The gesture holding the face, boxed rather than held as a bare motion. The
+ * same motion can be earned twice running — a second session starting to ask
+ * while the first nudge is still playing — and setting state to the value it
+ * already holds is a change React is entitled to drop, which would leave the
+ * second nudge swallowed by the still tail of the first. A new box is a new
+ * cycle, whatever motion is in it.
+ */
+interface PlayingGesture {
+  motion: FaceMotion;
+}
+
+/**
  * The motion Luke is playing: a rest, or a gesture that has taken the face for
  * one cycle. Gestures always give it back — nothing here can leave the face
  * stuck saying something that has stopped being true.
  */
 export function useFaceMotion(context: FaceContext, still: boolean): FaceMotion {
   const resting = restingMotion(context);
-  const [gesture, setGesture] = useState<FaceMotion>();
+  const [gesture, setGesture] = useState<PlayingGesture>();
   const lastAside = useRef<FaceMotion | undefined>(undefined);
-  const observed = useRef({ total: context.total, complete: context.complete });
-  const { total, complete } = context;
+  const observed = useRef(observedFace(context));
+  const { total, complete, attention } = context;
 
-  // A session arriving or finishing is worth reacting to once, rather than for
-  // as long as it stays true. Seeded from the first render, so a panel that
-  // opens onto four running sessions does not greet all four of them.
+  // A session arriving, finishing, or turning to ask for you is worth reacting
+  // to once, rather than for as long as it stays true. Seeded from the first
+  // render, so a panel that opens onto four running sessions does not greet all
+  // four of them — nor bounce at the three that were already waiting.
+  //
+  // The list of askers is a fresh array every render, so this runs far more
+  // often than anything actually changes; what makes that free is that the
+  // comparison is against the sessions seen last time rather than against the
+  // last render.
   useEffect(() => {
     const previous = observed.current;
-    observed.current = { total, complete };
+    const current = observedFace({ attention, complete, total });
+    observed.current = current;
     if (still) return;
-    if (complete > previous.complete) setGesture(FACE_MOTION.SUCCESS);
-    else if (total > previous.total) setGesture(FACE_MOTION.NOTIFICATION);
-  }, [total, complete, still]);
+    const noticed = noticedMotion(previous, current);
+    if (noticed !== undefined) setGesture({ motion: noticed });
+  }, [attention, complete, total, still]);
 
   // Every gesture is a one-shot. The artwork loops — each one is drawn with its
   // own rest built into the tail — so the cycle length is what says when it has
-  // been seen.
+  // been seen, and a gesture played again starts its cycle again rather than
+  // finishing the one already running.
   useEffect(() => {
     if (gesture === undefined) return;
-    const timer = window.setTimeout(() => setGesture(undefined), FACE_MOTION_CYCLE_MS[gesture]);
+    const timer = window.setTimeout(
+      () => setGesture(undefined),
+      FACE_MOTION_CYCLE_MS[gesture.motion],
+    );
     return () => window.clearTimeout(timer);
   }, [gesture]);
 
@@ -146,7 +221,7 @@ export function useFaceMotion(context: FaceContext, still: boolean): FaceMotion 
     const timer = window.setTimeout(() => {
       const aside = nextAside(lastAside.current);
       lastAside.current = aside;
-      setGesture(aside);
+      setGesture({ motion: aside });
     }, asideDelay());
     return () => window.clearTimeout(timer);
   }, [gesture, restful, still]);
@@ -161,5 +236,5 @@ export function useFaceMotion(context: FaceContext, still: boolean): FaceMotion 
   // Held still, the face keeps one pose rather than a quieter set of them: the
   // stylesheet stops the loops, and this stops the poses changing underneath.
   if (still) return FACE_MOTION.IDLE;
-  return playedMotion(resting, gesture);
+  return playedMotion(resting, gesture?.motion);
 }

--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -41,7 +41,7 @@ export function NotchWings({
     {
       speaking,
       microphoneLive: hasAudioSignal,
-      attention: tally.attention,
+      attention: tally.attentionIds,
       working: tally.working,
       complete: tally.complete,
       total: tally.total,

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -127,6 +127,14 @@ export interface ProviderTally {
 export interface SessionTally {
   total: number;
   attention: number;
+  /**
+   * The same sessions the count above counts, by id, because one of them
+   * starting to ask is a different event from three of them still asking and
+   * the count cannot tell those apart: answer one while another starts in the
+   * same poll and it never moves. Luke's face reacts to the event and the badge
+   * reports the count, so the tally has to carry both.
+   */
+  attentionIds: readonly string[];
   working: number;
   complete: number;
   idle: number;
@@ -308,10 +316,13 @@ export function arrangeSessions(
 export function sessionTally(sessions: readonly DisplaySession[]): SessionTally {
   const providers = new Map<string, ProviderTally>();
   const counts = { attention: 0, working: 0, complete: 0, idle: 0 };
+  const attentionIds: string[] = [];
 
   for (const session of sessions) {
-    if (session.state === SESSION_STATE.ATTENTION) counts.attention += 1;
-    else if (session.state === SESSION_STATE.WORKING) counts.working += 1;
+    if (session.state === SESSION_STATE.ATTENTION) {
+      counts.attention += 1;
+      attentionIds.push(session.id);
+    } else if (session.state === SESSION_STATE.WORKING) counts.working += 1;
     else if (session.state === SESSION_STATE.COMPLETE) counts.complete += 1;
     else counts.idle += 1;
 
@@ -330,6 +341,7 @@ export function sessionTally(sessions: readonly DisplaySession[]): SessionTally 
 
   return {
     ...counts,
+    attentionIds,
     total: sessions.length,
     state: dominantState(counts),
     providers: [...providers.values()],

--- a/apps/desktop/tests/luke-face-mood.test.ts
+++ b/apps/desktop/tests/luke-face-mood.test.ts
@@ -7,8 +7,10 @@ import {
 } from "../src/renderer/luke-face-art";
 import {
   type FaceContext,
+  type FaceObservation,
   IDLE_ASIDES,
   nextAside,
+  noticedMotion,
   playedMotion,
   restingMotion,
 } from "../src/renderer/luke-face-mood";
@@ -17,7 +19,7 @@ function context(overrides: Partial<FaceContext> = {}): FaceContext {
   return {
     speaking: false,
     microphoneLive: false,
-    attention: 0,
+    attention: [],
     working: 0,
     complete: 0,
     total: 0,
@@ -25,8 +27,12 @@ function context(overrides: Partial<FaceContext> = {}): FaceContext {
   };
 }
 
+function observed(attention: readonly string[], counts: Partial<FaceObservation> = {}) {
+  return { attention: new Set(attention), complete: 0, total: attention.length, ...counts };
+}
+
 test("the microphone outranks the session list", () => {
-  const busy = { attention: 3, working: 2, total: 5 };
+  const busy = { attention: ["a", "b", "c"], working: 2, total: 5 };
   assert.equal(
     restingMotion(context({ ...busy, microphoneLive: true, speaking: true })),
     FACE_MOTION.TALKING,
@@ -36,9 +42,41 @@ test("the microphone outranks the session list", () => {
   assert.equal(restingMotion(context({ microphoneLive: true })), FACE_MOTION.LISTENING);
 });
 
-test("a session that needs a person outranks one that is working", () => {
-  assert.equal(restingMotion(context({ attention: 1, working: 4, total: 5 })), FACE_MOTION.WAITING);
+test("a session that needs a person does not hold the face for as long as it waits", () => {
+  // Anyone whose sessions are usually waiting on them would otherwise get a
+  // face that fidgets permanently, which is the count badge's sentence said
+  // twice and leaves nothing to notice when one more session starts asking.
+  assert.equal(
+    restingMotion(context({ attention: ["a"], working: 4, total: 5 })),
+    FACE_MOTION.MONITORING,
+  );
+  assert.equal(restingMotion(context({ attention: ["a"], total: 1 })), FACE_MOTION.IDLE);
   assert.equal(restingMotion(context({ working: 4, total: 4 })), FACE_MOTION.MONITORING);
+});
+
+test("the fidget answers a session that has just started asking", () => {
+  const asking = observed(["a"]);
+  assert.equal(noticedMotion(asking, observed(["a", "b"])), FACE_MOTION.WAITING);
+  // The same session still asking is not news, however long it goes on asking.
+  assert.equal(noticedMotion(asking, observed(["a"])), undefined);
+  // One answered as another starts leaves the count where it was, and is
+  // exactly the moment counting would have missed.
+  assert.equal(noticedMotion(asking, observed(["b"])), FACE_MOTION.WAITING);
+  // Answered and not replaced: the panel says so, and the face has no news.
+  assert.equal(noticedMotion(asking, observed([])), undefined);
+});
+
+test("a session that arrives already asking bounces rather than greeting itself", () => {
+  const empty = observed([], { total: 0 });
+  assert.equal(noticedMotion(empty, observed(["a"], { total: 1 })), FACE_MOTION.WAITING);
+});
+
+test("sessions arriving and finishing are still counted rather than named", () => {
+  const two = observed([], { total: 2 });
+  assert.equal(noticedMotion(two, observed([], { complete: 1, total: 2 })), FACE_MOTION.SUCCESS);
+  assert.equal(noticedMotion(two, observed([], { total: 3 })), FACE_MOTION.NOTIFICATION);
+  // Sessions leaving are not an event: nothing has asked for anyone.
+  assert.equal(noticedMotion(two, observed([], { total: 1 })), undefined);
 });
 
 test("nothing tracked is a different rest from nothing happening", () => {
@@ -55,9 +93,9 @@ test("an aside never repeats the one before it", () => {
   }
 });
 
-test("asides say nothing a rest is already saying", () => {
+test("asides say nothing a rest or a moment already says", () => {
   // An aside interrupts a rest, so one that carried meaning would overwrite it:
-  // Luke must not look like he is waiting on you because a timer fired.
+  // Luke must not look like a session just started asking because a timer fired.
   for (const aside of IDLE_ASIDES) {
     assert.ok(
       ![
@@ -75,13 +113,17 @@ test("asides say nothing a rest is already saying", () => {
 });
 
 test("a rest that needs the face takes it back from a gesture at once", () => {
-  // Scheduling asides only while the rest is restful is not enough: the rest can
-  // change under one that is already playing, and a gesture allowed to run out
-  // would announce a waiting session with a wink.
-  for (const gesture of [...IDLE_ASIDES, FACE_MOTION.SUCCESS, FACE_MOTION.NOTIFICATION]) {
-    assert.equal(playedMotion(FACE_MOTION.WAITING, gesture), FACE_MOTION.WAITING);
-    // The microphone is the one that matters most: the capsule reports an open
-    // microphone through the face's colour, and only these two motions carry it.
+  // Scheduling gestures only while the rest is restful is not enough: the rest
+  // can change under one that is already playing.
+  for (const gesture of [
+    ...IDLE_ASIDES,
+    FACE_MOTION.SUCCESS,
+    FACE_MOTION.NOTIFICATION,
+    FACE_MOTION.WAITING,
+  ]) {
+    // The microphone is what matters most: the capsule reports an open
+    // microphone through the face's colour, and only these two motions carry
+    // it, so not even a session asking for you may hold the face over one.
     assert.equal(playedMotion(FACE_MOTION.LISTENING, gesture), FACE_MOTION.LISTENING);
     assert.equal(playedMotion(FACE_MOTION.TALKING, gesture), FACE_MOTION.TALKING);
     // The calm rests can still spare it.

--- a/apps/desktop/tests/session-model.test.ts
+++ b/apps/desktop/tests/session-model.test.ts
@@ -119,6 +119,9 @@ test("the tally counts per state and per provider", () => {
     {
       total: 5,
       attention: 1,
+      // Named as well as counted: Luke's face reacts to a session that has just
+      // started asking, which the count alone cannot report.
+      attentionIds: ["claude-review"],
       working: 2,
       complete: 1,
       idle: 1,


### PR DESCRIPTION
## What this changes

Luke's fidget was a **rest** — `restingMotion` returned it for as long as any
session was in Needs you, so a face belonging to someone who usually has a
session waiting on them bounced permanently. That says what the count badge is
already saying, and it buries the one moment worth catching in the hour of
fidgeting either side of it.

The fidget is a **one-shot** now, fired at the change and handed back after its
cycle:

- **A session starting to ask bounces once.** It outranks the arrival and the
  completion gestures, since it is the only one of the three about to cost
  someone their attention.
- **Otherwise the face rests calm** — monitoring while anything works, idle
  while nothing does, asleep when nothing is tracked — and cycles through the
  idle asides (wink, brow waggle, float, peekaboo, …) at the same unhurried
  9–26s cadence it always used. That list is now most of what the face does
  between one nudge and the next.
- **The standing state is untouched.** The count badge still reads
  `N needs you` and the capsule still takes the attention colour; the face
  reports the event, the badge reports the count.

## Why the nudge is owed to a session rather than to a number

A count cannot tell one session starting to ask from another being answered in
the same poll — answer one as a second starts and the number never moves, which
is exactly the moment worth a bounce. So `sessionTally` now carries the ids of
the sessions asking alongside the count, and the face remembers which sessions
it has already reacted to.

The playing gesture is boxed for a related reason: a second session asking
mid-bounce would set the state to the value it already holds, and React is
entitled to drop that, leaving the second nudge swallowed by the still tail of
the first. A new box is a new cycle.

No artwork changed — `design/generate-brand-assets.mjs` and its three generated
outputs are untouched. This is only which motion is chosen, and when.

## Verification

- `./scripts/check.sh` — clean (lint, typecheck, 199 desktop tests + core, build).
- New tests cover the moment the count would have missed, an arrival that is
  already asking, and that the fidget is no longer a rest.
- macOS packaging and visual evidence come from CI; no physical-notch check was
  performed (this was written in a Linux cloud sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/9039db84-e63f-46cd-9534-dde31226cd27)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31737862799/artifacts/9195874810) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31737862799)

- Commit: `1e5bcb81e4c02a7b2337632bfebb42b5558d9f8b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
