### PR TITLE
feat(settings): ask before deleting a stored API key

### DIFF
--- a/apps/desktop/src/renderer/credential-entry.ts
+++ b/apps/desktop/src/renderer/credential-entry.ts
@@ -91,39 +91,50 @@ export function removalEndsEntry(
 }
 
 /** Long enough for any stage to arrive, and short enough to be a backstop. */
-const CARET_FRAME_LIMIT = 60;
+const FOCUS_FRAME_LIMIT = 60;
 
 /**
- * Puts the caret in a field as soon as the field can hold it, for as long as
- * holding it is what the field is for.
+ * Hands focus to an element as soon as it can take it, and answers with the way
+ * to stop waiting.
  *
- * Both places an entry is drawn sit in a staged surface that is `visibility:
- * hidden` until its arrival delay has passed, and a hidden element refuses
- * focus outright — so asking on the frame the shape changes silently does
- * nothing. This waits for the stage rather than guessing at its delay, which
- * keeps the timing in the stylesheet where the rest of the motion lives.
+ * Everything the panel draws around a credential sits in a staged surface that
+ * is `visibility: hidden` until its arrival delay has passed, and a hidden
+ * element refuses focus outright — so asking on the frame the shape changes
+ * silently does nothing. This waits for the stage rather than guessing at its
+ * delay, which keeps the timing in the stylesheet where the rest of the motion
+ * lives.
+ */
+export function focusWhenVisible(element: HTMLElement | null): () => void {
+  let frame = 0;
+  let frames = 0;
+  const takeFocus = () => {
+    if (!element) return;
+    if (getComputedStyle(element).visibility !== "visible") {
+      if (frames++ > FOCUS_FRAME_LIMIT) return;
+      frame = requestAnimationFrame(takeFocus);
+      return;
+    }
+    element.focus({ preventScroll: true });
+  };
+  takeFocus();
+  return () => cancelAnimationFrame(frame);
+}
+
+/**
+ * Keeps focus on an element for as long as holding it is what that element is
+ * for.
  *
- * A field that goes disabled hands the caret out and does not take it back, so
+ * A control that goes disabled hands focus out and does not take it back, so
  * `active` falls while a credential is being written and rises again with the
  * refusal that re-opens the field — which is what puts someone straight back to
  * correcting the credential rather than clicking to get there.
  */
-export function useFieldCaret(field: RefObject<HTMLInputElement | null>, active: boolean): void {
+export function useStagedFocus<Element extends HTMLElement>(
+  target: RefObject<Element | null>,
+  active: boolean,
+): void {
   useEffect(() => {
     if (!active) return;
-    let frame = 0;
-    let frames = 0;
-    const takeCaret = () => {
-      const element = field.current;
-      if (!element) return;
-      if (getComputedStyle(element).visibility !== "visible") {
-        if (frames++ > CARET_FRAME_LIMIT) return;
-        frame = requestAnimationFrame(takeCaret);
-        return;
-      }
-      element.focus({ preventScroll: true });
-    };
-    takeCaret();
-    return () => cancelAnimationFrame(frame);
-  }, [active, field]);
+    return focusWhenVisible(target.current);
+  }, [active, target]);
 }

--- a/apps/desktop/src/renderer/credential-removal.ts
+++ b/apps/desktop/src/renderer/credential-removal.ts
@@ -1,0 +1,66 @@
+/**
+ * What a provider line's delete is currently asking.
+ *
+ * Deleting a stored key is the one act in this panel that cannot be undone from
+ * inside it. Luke never sends a key back — the main process reports where a
+ * credential resolved from and nothing more — so a trash pressed by mistake
+ * costs a trip to the provider's own site to put right. That is what the
+ * confirm is for, and it is why the trash asks rather than acts.
+ */
+export const REMOVAL_STAGE = {
+  /** Nothing asked: the line is showing what can be done to the key. */
+  RESTING: "resting",
+  /** Asked, and waiting to be answered. */
+  ASKING: "asking",
+  /** Answered, and the key is being cleared. */
+  CLEARING: "clearing",
+} as const;
+
+export type RemovalStage = (typeof REMOVAL_STAGE)[keyof typeof REMOVAL_STAGE];
+
+/** What is true around the question, which is what decides whether it survives. */
+export interface RemovalSurroundings {
+  /** True while Luke still keeps a key of its own for this provider. */
+  stored: boolean;
+  /** True while the panel is the shape on screen. */
+  panelOpen: boolean;
+}
+
+/**
+ * What the line draws, given the question it is holding and what has become
+ * true around it.
+ *
+ * A question outlives neither its subject nor the surface it was asked on. The
+ * key going takes it: there is nothing left to confirm, and a confirm left
+ * standing where a key used to be would be pointed at whatever is stored there
+ * next. The panel closing takes it too — a confirm is a question put to
+ * somebody standing in front of it, and one still waiting behind a closed panel
+ * would be the first thing under the pointer the next time it opened, with
+ * nobody having asked for it. Standing down to the slot closes the panel by
+ * this measure, which is what keeps a trip to fetch a key from bringing an
+ * armed delete back with it.
+ *
+ * Both are the opposite of a key half-entered, which is the one thing here that
+ * does survive a close: that is work someone is in the middle of, and this is a
+ * question they walked away from.
+ *
+ * A delete already sent is the exception to both. It is no longer a question,
+ * so it finishes wherever it is and the line reports what came back.
+ */
+export function removalStage(
+  held: RemovalStage,
+  { stored, panelOpen }: RemovalSurroundings,
+): RemovalStage {
+  if (held === REMOVAL_STAGE.CLEARING) return held;
+  if (!stored || !panelOpen) return REMOVAL_STAGE.RESTING;
+  return held;
+}
+
+/**
+ * Whether the confirm is what the line is showing, rather than its controls.
+ * A delete in flight still draws it, so the answer that was given stays on
+ * screen saying what it is doing.
+ */
+export function removalAsked(stage: RemovalStage): boolean {
+  return stage !== REMOVAL_STAGE.RESTING;
+}

--- a/apps/desktop/src/renderer/credential-removal.ts
+++ b/apps/desktop/src/renderer/credential-removal.ts
@@ -64,3 +64,18 @@ export function removalStage(
 export function removalAsked(stage: RemovalStage): boolean {
   return stage !== REMOVAL_STAGE.RESTING;
 }
+
+/**
+ * Whether the question can still be taken back. Only one that is still a
+ * question can be: an answer already given is nobody's to withdraw, and a line
+ * that forgot a delete it had sent would draw the trash back over a key still
+ * on its way out — and take a second ask over the top of the first.
+ *
+ * This is the same rule `removalStage` keeps against the panel closing, said
+ * for the controls: `Cancel` goes disabled while a delete is in flight, so
+ * today nothing focused inside the group can reach Escape, but the invariant
+ * must not rest on which element happens to hold the caret.
+ */
+export function removalWithdrawable(stage: RemovalStage): boolean {
+  return stage === REMOVAL_STAGE.ASKING;
+}

--- a/apps/desktop/src/renderer/key-slot.tsx
+++ b/apps/desktop/src/renderer/key-slot.tsx
@@ -5,7 +5,7 @@ import {
   CREDENTIAL_PLACEHOLDER,
   type CredentialEntryControl,
   isSubmittable,
-  useFieldCaret,
+  useStagedFocus,
 } from "./credential-entry";
 import { HIT_REGION } from "./panel-state";
 import { CloudBadge, ProviderMark } from "./provider-marks";
@@ -63,7 +63,7 @@ export function KeySlot({
   // the entry ends rather than when the shape finally goes.
   const live = drawn && control.entry !== undefined;
 
-  useFieldCaret(field, live && !control.entry?.busy);
+  useStagedFocus(field, live && !control.entry?.busy);
 
   useEffect(() => {
     if (!live) return;

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { AppSettings, CredentialSource, MicrophoneStatus } from "../shared/contracts";
 import { CREDENTIAL_SOURCE } from "../shared/contracts";
 import type { CredentialProvider } from "../shared/credential-providers";
@@ -7,9 +7,11 @@ import {
   CREDENTIAL_PLACEHOLDER,
   type CredentialEntryControl,
   entryForProvider,
+  focusWhenVisible,
   isSubmittable,
-  useFieldCaret,
+  useStagedFocus,
 } from "./credential-entry";
+import { REMOVAL_STAGE, type RemovalStage, removalAsked, removalStage } from "./credential-removal";
 import { PANEL_TAB, panelPanelId, panelTabId } from "./panel-tabs";
 import { CloudBadge, ProviderMark } from "./provider-marks";
 import {
@@ -57,6 +59,19 @@ const CREDENTIAL_STATUS: Partial<Record<CredentialSource, string>> = {
 /* Why a row that could otherwise be connected is not offering to be. */
 const HELD_TITLE = "Finish the one you are entering first";
 
+/* The safe answer arrives first and the one that cannot be taken back lands a
+   beat behind it, on the same stagger the panel's rows fan open with. Their
+   order on the line is the order they arrive in, so this is their place in it
+   rather than a delay written per button. */
+const REMOVAL_ANSWER_INDEX = {
+  KEEP: 0,
+  DELETE: 1,
+} as const;
+
+function answerOrder(index: number): React.CSSProperties {
+  return { "--answer-index": index } as React.CSSProperties;
+}
+
 /**
  * One provider, one line: its mark, its name, whether it is connected, and what
  * can be done about that — connect, supersede, or delete, whichever the state
@@ -66,6 +81,8 @@ const HELD_TITLE = "Finish the one you are entering first";
  *
  * Asking to write one takes the panel down to the slot, so the field is drawn
  * here only when the panel is brought back around an entry that is still open.
+ * Asking to delete one goes nowhere at all: the question and its answer are the
+ * same few pixels the trash was drawn in.
  *
  * The credential is write-only from here: this can replace or clear the stored
  * key, and the main process never sends one back — only where it was resolved
@@ -84,23 +101,34 @@ function ProviderCredential({
   control: CredentialEntryControl;
   panelOpen: boolean;
 }): React.JSX.Element {
-  // Deleting is the one act that begins and ends on this line. Entering a
-  // credential does not: it can leave for the slot and come back, so it is held
-  // above.
-  const [removing, setRemoving] = useState(false);
+  // Deleting is the one act that begins and ends on this line, question and
+  // answer both. Entering a credential does not: it can leave for the slot and
+  // come back, so it is held above.
+  const [heldRemoval, setHeldRemoval] = useState<RemovalStage>(REMOVAL_STAGE.RESTING);
   const [removalRejection, setRemovalRejection] = useState<string>();
   const field = useRef<HTMLInputElement | null>(null);
+  const trash = useRef<HTMLButtonElement | null>(null);
+  const keep = useRef<HTMLButtonElement | null>(null);
+  const editControl = useRef<HTMLButtonElement | null>(null);
+  const returnFocus = useRef(false);
   const fieldId = `${provider.id}-api-key`;
   const entry = entryForProvider(control, provider.id);
   const editing = entry !== undefined;
-  const busy = removing || (entry?.busy ?? false);
-  const rejection = removalRejection ?? entry?.rejection;
   // Deleting is only ever for a key kept here; one read from the environment is
   // not Luke's to remove. Either can be superseded by a key typed in, so both
   // connected states offer the same editor and only the unconnected one is
   // asked to connect.
   const stored = source === CREDENTIAL_SOURCE.ENCRYPTED_FILE;
   const connected = source !== CREDENTIAL_SOURCE.NONE;
+  const removal = removalStage(heldRemoval, { stored, panelOpen });
+  // Corrected during the render that discovers it rather than from an effect,
+  // the way an emptied filter is: a question whose subject or whose surface has
+  // gone must never be drawn once and taken back on the next frame.
+  if (removal !== heldRemoval) setHeldRemoval(removal);
+  const asking = removalAsked(removal);
+  const clearing = removal === REMOVAL_STAGE.CLEARING;
+  const busy = clearing || (entry?.busy ?? false);
+  const rejection = removalRejection ?? entry?.rejection;
   const status = CREDENTIAL_STATUS[source];
   // The pencil opens the same editor from either connected state, but it does
   // not mean the same thing: one replaces the key Luke keeps, the other stands
@@ -125,7 +153,23 @@ function ProviderCredential({
   // back to a panel mid-entry — pressing the capsule while the slot holds the
   // credential — hands focus out of an inert stage on the way, and returns
   // someone who was in the middle of typing.
-  useFieldCaret(field, editing && panelOpen && !busy);
+  useStagedFocus(field, editing && panelOpen && !busy);
+
+  // The question takes the focus to the answer that changes nothing. The
+  // control that asked it is inert by the time the confirm is drawn, so focus
+  // has nowhere else to go — and of the two places it could land, only one is
+  // safe to arrive on with a key already pressed.
+  useStagedFocus(keep, asking && !clearing);
+
+  // Answering hands it back to the line: to the trash if the key survived, and
+  // to whatever now stands where the trash was if it did not. Only an answer
+  // moves focus — a question the panel closing withdrew was never answered, and
+  // reaching into a shape that is leaving would pull it back open.
+  useEffect(() => {
+    if (asking || !returnFocus.current) return;
+    returnFocus.current = false;
+    return focusWhenVisible(trash.current ?? editControl.current);
+  }, [asking]);
 
   // Every control that offers to write one begins the one entry — which takes
   // the panel down to the slot — and clears whatever the last attempt was
@@ -135,10 +179,30 @@ function ProviderCredential({
     control.begin(provider.id);
   };
 
-  const remove = async () => {
-    setRemoving(true);
-    setRemovalRejection(await control.remove(provider.id));
-    setRemoving(false);
+  // The trash asks; only the answer acts. Nothing here can hand a key back, so
+  // a delete taken on the first press would cost a trip to the provider's own
+  // site to undo.
+  const askToRemove = () => {
+    setRemovalRejection(undefined);
+    setHeldRemoval(REMOVAL_STAGE.ASKING);
+  };
+
+  // Keeping it changes nothing, so it says nothing: the line goes back to the
+  // controls it was showing.
+  const keepKey = () => {
+    returnFocus.current = true;
+    setHeldRemoval(REMOVAL_STAGE.RESTING);
+  };
+
+  const removeKey = async () => {
+    setHeldRemoval(REMOVAL_STAGE.CLEARING);
+    const reason = await control.remove(provider.id);
+    returnFocus.current = true;
+    setRemovalRejection(reason);
+    // Answered either way. A refusal is an answer too, and asking again is a
+    // fresh decision rather than a confirm left standing over a key that turned
+    // out to still be there.
+    setHeldRemoval(REMOVAL_STAGE.RESTING);
   };
 
   return (
@@ -162,44 +226,102 @@ function ProviderCredential({
             it, so the words are kept for the one thing neither can say:
             connected from the environment rather than from a key kept here. */}
         {status ? <span className="credential-status">{status}</span> : null}
-        <span className="settings-actions">
+        {/* The line's controls and the confirm that stands in for them are the
+            same cell of one grid, so the box is as wide as the wider of the two
+            whichever is showing and the provider's name beside it never
+            re-shapes as they trade places. Neither layer is mounted by the
+            press either: one arriving from nothing would have no size to spring
+            from. */}
+        <span className="credential-actions">
+          <span
+            className="settings-actions credential-controls"
+            data-drawn={String(!asking)}
+            aria-hidden={asking}
+            inert={asking}
+          >
+            {stored ? (
+              <button
+                type="button"
+                ref={trash}
+                className="icon-button credential-remove"
+                disabled={busy}
+                aria-label={`Delete the ${provider.displayName} ${credential}`}
+                /* The ellipsis is the promise that it asks first. */
+                title="Delete…"
+                onClick={askToRemove}
+              >
+                <TrashIcon />
+              </button>
+            ) : null}
+            {connected ? (
+              <button
+                type="button"
+                ref={editControl}
+                className="icon-button"
+                disabled={beginBlocked}
+                aria-label={editLabel}
+                title={held ? HELD_TITLE : editTitle}
+                onClick={beginEntry}
+              >
+                <PencilIcon />
+              </button>
+            ) : (
+              /* Named for its provider like the icon buttons beside it: a list
+                 of controls read on its own is otherwise two identical
+                 Connects. */
+              <button
+                type="button"
+                ref={editControl}
+                className="quiet-button"
+                disabled={beginBlocked}
+                aria-label={`Connect ${provider.displayName}`}
+                title={held ? HELD_TITLE : undefined}
+                onClick={beginEntry}
+              >
+                Connect
+              </button>
+            )}
+          </span>
+          {/* Only ever drawn for a key Luke keeps, because that is the only key
+              it has any business deleting. The group carries the question, so
+              the two answers are read as answers rather than as a Cancel and a
+              Delete that could belong to anything on the line. */}
           {stored ? (
-            <button
-              type="button"
-              className="icon-button credential-remove"
-              disabled={busy}
-              aria-label={`Delete the ${provider.displayName} ${credential}`}
-              title="Delete"
-              onClick={() => void remove()}
+            <fieldset
+              className="settings-actions credential-confirm"
+              aria-label={`Delete the ${provider.displayName} ${credential}?`}
+              data-drawn={String(asking)}
+              aria-hidden={!asking}
+              inert={!asking}
+              onKeyDown={(event) => {
+                // Escape withdraws the question rather than closing the panel
+                // the question was asked on.
+                if (event.key !== "Escape") return;
+                event.stopPropagation();
+                keepKey();
+              }}
             >
-              <TrashIcon />
-            </button>
+              <button
+                type="button"
+                ref={keep}
+                className="quiet-button"
+                style={answerOrder(REMOVAL_ANSWER_INDEX.KEEP)}
+                disabled={clearing}
+                onClick={keepKey}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="danger-button"
+                style={answerOrder(REMOVAL_ANSWER_INDEX.DELETE)}
+                disabled={clearing}
+                onClick={() => void removeKey()}
+              >
+                {clearing ? "Deleting…" : "Delete"}
+              </button>
+            </fieldset>
           ) : null}
-          {connected ? (
-            <button
-              type="button"
-              className="icon-button"
-              disabled={beginBlocked}
-              aria-label={editLabel}
-              title={held ? HELD_TITLE : editTitle}
-              onClick={beginEntry}
-            >
-              <PencilIcon />
-            </button>
-          ) : (
-            /* Named for its provider like the icon buttons beside it: a list of
-               controls read on its own is otherwise two identical Connects. */
-            <button
-              type="button"
-              className="quiet-button"
-              disabled={beginBlocked}
-              aria-label={`Connect ${provider.displayName}`}
-              title={held ? HELD_TITLE : undefined}
-              onClick={beginEntry}
-            >
-              Connect
-            </button>
-          )}
         </span>
       </div>
 

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -11,7 +11,13 @@ import {
   isSubmittable,
   useStagedFocus,
 } from "./credential-entry";
-import { REMOVAL_STAGE, type RemovalStage, removalAsked, removalStage } from "./credential-removal";
+import {
+  REMOVAL_STAGE,
+  type RemovalStage,
+  removalAsked,
+  removalStage,
+  removalWithdrawable,
+} from "./credential-removal";
 import { PANEL_TAB, panelPanelId, panelTabId } from "./panel-tabs";
 import { CloudBadge, ProviderMark } from "./provider-marks";
 import {
@@ -188,8 +194,10 @@ function ProviderCredential({
   };
 
   // Keeping it changes nothing, so it says nothing: the line goes back to the
-  // controls it was showing.
+  // controls it was showing. Only a question can be kept from — an answer
+  // already sent is not this control's to take back.
   const keepKey = () => {
+    if (!removalWithdrawable(removal)) return;
     returnFocus.current = true;
     setHeldRemoval(REMOVAL_STAGE.RESTING);
   };
@@ -295,8 +303,11 @@ function ProviderCredential({
               inert={!asking}
               onKeyDown={(event) => {
                 // Escape withdraws the question rather than closing the panel
-                // the question was asked on.
-                if (event.key !== "Escape") return;
+                // the question was asked on — but only while it is still a
+                // question. Once the delete has gone there is nothing here for
+                // Escape to take back, so it is left to mean what it means
+                // everywhere else in the panel.
+                if (event.key !== "Escape" || !removalWithdrawable(removal)) return;
                 event.stopPropagation();
                 keepKey();
               }}

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -26,6 +26,15 @@
   --mark-devin: #ffffff;
   --mark-jules: #715cd7;
 
+  /* The one destructive colour, in the two weights a control that destroys
+     something needs: a ground it can sit on and a text colour that reads on
+     that ground. Quitting, the trash, and the confirm the trash opens are the
+     only three places in the app that draw it, and they have to be the same
+     red — a delete that announced itself in a colour nothing else uses would
+     read as a different kind of act. */
+  --danger: #ff7e7e;
+  --danger-text: #ff9b9b;
+
   --text-primary: rgba(255, 255, 255, 0.95);
   --text-secondary: rgba(255, 255, 255, 0.56);
   --text-tertiary: rgba(255, 255, 255, 0.34);
@@ -1144,8 +1153,8 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 }
 
 .quit-button:hover {
-  background: color-mix(in srgb, #ff7e7e 12%, transparent);
-  color: #ff9b9b;
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  color: var(--danger-text);
 }
 
 .quit-button .settings-icon {
@@ -1282,13 +1291,110 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 /* Deleting a key is the one destructive control here, so it says so on hover
    rather than by sitting in red beside the others. */
 .credential-remove:hover {
-  background: color-mix(in srgb, #ff7e7e 12%, transparent);
-  color: #ff9b9b;
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  color: var(--danger-text);
 }
 
 .credential-remove:disabled:hover {
   background: var(--raised);
   color: var(--text-secondary);
+}
+
+/* Deleting a key is the one act in this panel that cannot be undone from inside
+   it: nothing here can hand a key back, so a trash pressed by mistake costs a
+   trip to the provider's own site. The trash asks instead of acting, and the
+   answer is given in the few pixels the question was asked in.
+ *
+ * The line's controls and the confirm that replaces them are the same cell of
+ * one grid. That is what makes the swap free: the cell is as wide as the wider
+ * of the two whichever one is showing, so the name flexing beside it never
+ * re-shapes, and neither layer is mounted or unmounted by the press. Only
+ * `transform`, `opacity`, and `visibility` ever change hands. */
+.credential-actions {
+  display: grid;
+  flex: 0 0 auto;
+  justify-items: end;
+}
+
+.credential-actions > * {
+  grid-area: 1 / 1;
+}
+
+/* The layer that is leaving fades over `--duration-exit`, the way panel content
+   always leaves before the thing it belongs to moves. `visibility` waits out
+   that fade so it can be seen going, and switches immediately on the way in so
+   the arriving layer can take the focus the leaving one is about to lose. */
+.credential-actions > [data-drawn="false"] {
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    opacity var(--duration-exit) var(--motion-exit),
+    visibility 0s linear var(--duration-exit);
+}
+
+.credential-actions > [data-drawn="true"] {
+  opacity: 1;
+  visibility: visible;
+  transition:
+    opacity var(--duration-quick) var(--motion-exit),
+    visibility 0s linear;
+}
+
+/* The layer fades; what springs is what is inside it. Every control here rides
+   `--spring-fast` — the same bounce the tab thumb has, which is the profile
+   every small element in the app moves on, so a control trading places belongs
+   to the same object as everything around it. Each one collapses into, and
+   grows back out of, its own right edge: the group folds toward the corner the
+   trash sits in rather than shrinking about its middle.
+ *
+ * Matched through the layer rather than by class, because `.quiet-button` and
+ * `.danger-button` are written further down the sheet and would otherwise win
+ * this declaration back at equal specificity. Their transition declares only
+ * the hover pair, so this replaces it rather than adding to it and has to carry
+ * that pair along. */
+.credential-actions > [data-drawn] > * {
+  transform-origin: 100% 50%;
+  transition:
+    transform var(--duration-fast) var(--spring-fast) var(--answer-delay, 0s),
+    background-color var(--duration-hover) ease,
+    color var(--duration-hover) ease;
+}
+
+/* Standing down happens all at once: a group leaving in sequence reads as
+   hesitation, and the answer is already on its way in. */
+.credential-actions > [data-drawn="false"] > * {
+  transform: scale(0.82) translateX(10px);
+}
+
+/* Arriving does not. The answer that changes nothing lands first and the one
+   that cannot be taken back lands a beat later, on the same stagger the panel's
+   own rows fan open with — so the confirm unfolds rather than appearing, and
+   the eye reaches the safe answer first. */
+.credential-actions > [data-drawn="true"] > * {
+  --answer-delay: calc(var(--answer-index, 0) * var(--row-stagger));
+
+  transform: none;
+}
+
+/* The can tips as it goes. It is the only rotation in the panel, and it belongs
+   to the one control whose question has just been handed somewhere else. */
+.credential-controls[data-drawn="false"] .credential-remove .icon-button-glyph {
+  transform: rotate(-14deg);
+}
+
+.credential-remove .icon-button-glyph {
+  transition: transform var(--duration-fast) var(--spring-fast);
+}
+
+/* The group is what names the question for the two controls inside it, the same
+   way the editor's group names the provider for its own Cancel and Save. None
+   of the user-agent frame is wanted, including the `min-inline-size` that would
+   stop it shrinking with the panel. */
+.credential-confirm {
+  min-inline-size: 0;
+  padding: 0;
+  border: 0;
+  margin: 0;
 }
 
 /* The field exists only while a key is being entered. It is a fieldset because
@@ -1438,17 +1544,20 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 }
 
 .action-button:disabled,
-.quiet-button:disabled {
+.quiet-button:disabled,
+.danger-button:disabled {
   opacity: 0.4;
 }
 
 .action-button:disabled:hover,
-.quiet-button:disabled:hover {
+.quiet-button:disabled:hover,
+.danger-button:disabled:hover {
   background: var(--raised);
 }
 
 .action-button,
-.quiet-button {
+.quiet-button,
+.danger-button {
   padding: 8px 13px;
   border-radius: 10px;
   font-size: 10px;
@@ -1476,6 +1585,26 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 .quiet-button:hover {
   background: var(--raised-strong);
   color: var(--text-primary);
+}
+
+/* Shaped like the editor's Save and coloured like the trash that opened it. It
+   is the one control in the app that sits in red before anything hovers it:
+   every other destructive control admits what it is on the way past, and by the
+   time this one is drawn the question has already been asked. */
+.danger-button {
+  background: color-mix(in srgb, var(--danger) 16%, transparent);
+  color: var(--danger-text);
+}
+
+.danger-button:hover {
+  background: color-mix(in srgb, var(--danger) 26%, transparent);
+}
+
+/* Held to the width of its longest word, so saying "Deleting…" does not widen
+   the group and slide the answer beside it along — the same floor the slot's
+   confirm keeps, and by measurement the same number. */
+.credential-confirm .danger-button {
+  min-width: 76px;
 }
 
 .error-message {

--- a/apps/desktop/tests/credential-removal.test.ts
+++ b/apps/desktop/tests/credential-removal.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { REMOVAL_STAGE, removalAsked, removalStage } from "../src/renderer/credential-removal";
+
+const A_KEY_ON_AN_OPEN_PANEL = { stored: true, panelOpen: true };
+const A_KEY_THAT_IS_GONE = { stored: false, panelOpen: true };
+// The panel closes outright, and it also stands down to the slot to let someone
+// fetch a key — which is exactly when a question left standing would be
+// forgotten about.
+const A_PANEL_THAT_HAS_CLOSED = { stored: true, panelOpen: false };
+
+test("a question stands until it is answered", () => {
+  assert.equal(
+    removalStage(REMOVAL_STAGE.ASKING, A_KEY_ON_AN_OPEN_PANEL),
+    REMOVAL_STAGE.ASKING,
+    "nothing about the line changed, so neither does what it is asking",
+  );
+});
+
+test("the key going takes the question with it", () => {
+  assert.equal(
+    removalStage(REMOVAL_STAGE.ASKING, A_KEY_THAT_IS_GONE),
+    REMOVAL_STAGE.RESTING,
+    "a confirm left where a key used to be would be pointed at whatever is stored there next",
+  );
+});
+
+test("the panel closing withdraws the question", () => {
+  assert.equal(
+    removalStage(REMOVAL_STAGE.ASKING, A_PANEL_THAT_HAS_CLOSED),
+    REMOVAL_STAGE.RESTING,
+    "a confirm nobody is standing in front of must not be waiting when the panel comes back",
+  );
+});
+
+test("a delete already sent finishes wherever it is", () => {
+  // It is no longer a question, so nothing that withdraws a question reaches
+  // it: the line has to stay able to report what came back.
+  assert.equal(
+    removalStage(REMOVAL_STAGE.CLEARING, A_PANEL_THAT_HAS_CLOSED),
+    REMOVAL_STAGE.CLEARING,
+  );
+  assert.equal(
+    removalStage(REMOVAL_STAGE.CLEARING, { stored: false, panelOpen: false }),
+    REMOVAL_STAGE.CLEARING,
+  );
+});
+
+test("a line at rest is left at rest", () => {
+  assert.equal(removalStage(REMOVAL_STAGE.RESTING, A_KEY_ON_AN_OPEN_PANEL), REMOVAL_STAGE.RESTING);
+  assert.equal(removalStage(REMOVAL_STAGE.RESTING, A_KEY_THAT_IS_GONE), REMOVAL_STAGE.RESTING);
+});
+
+test("the confirm is drawn from the moment it is asked until the answer lands", () => {
+  assert.equal(removalAsked(REMOVAL_STAGE.RESTING), false);
+  assert.equal(removalAsked(REMOVAL_STAGE.ASKING), true);
+  assert.equal(
+    removalAsked(REMOVAL_STAGE.CLEARING),
+    true,
+    "the answer that was given stays on screen saying what it is doing",
+  );
+});

--- a/apps/desktop/tests/credential-removal.test.ts
+++ b/apps/desktop/tests/credential-removal.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { REMOVAL_STAGE, removalAsked, removalStage } from "../src/renderer/credential-removal";
+import {
+  REMOVAL_STAGE,
+  removalAsked,
+  removalStage,
+  removalWithdrawable,
+} from "../src/renderer/credential-removal";
 
 const A_KEY_ON_AN_OPEN_PANEL = { stored: true, panelOpen: true };
 const A_KEY_THAT_IS_GONE = { stored: false, panelOpen: true };
@@ -49,6 +54,20 @@ test("a delete already sent finishes wherever it is", () => {
 test("a line at rest is left at rest", () => {
   assert.equal(removalStage(REMOVAL_STAGE.RESTING, A_KEY_ON_AN_OPEN_PANEL), REMOVAL_STAGE.RESTING);
   assert.equal(removalStage(REMOVAL_STAGE.RESTING, A_KEY_THAT_IS_GONE), REMOVAL_STAGE.RESTING);
+});
+
+test("only a question can be taken back", () => {
+  assert.equal(removalWithdrawable(REMOVAL_STAGE.ASKING), true);
+  assert.equal(
+    removalWithdrawable(REMOVAL_STAGE.CLEARING),
+    false,
+    "Cancel and Escape must not forget a delete that is already on its way out",
+  );
+  assert.equal(
+    removalWithdrawable(REMOVAL_STAGE.RESTING),
+    false,
+    "there is no question to withdraw, so nothing withdraws one",
+  );
 });
 
 test("the confirm is drawn from the moment it is asked until the answer lands", () => {


### PR DESCRIPTION
## Summary

- Deleting a stored API key now asks before it acts. The trash on a credential
  line opens a confirm in the same few pixels it was drawn in — `Cancel` and a
  red `Delete` — and only the second one clears the key. Nothing in Luke can
  hand a key back, so a press by mistake used to cost a trip to the provider's
  own site.
- The line's controls and the confirm that replaces them are the **same cell of
  one grid**, so the cell is as wide as the wider of the two whichever is
  showing. The provider's name flexing beside it never re-shapes, the row never
  changes height, and neither layer is mounted by the press — only `transform`,
  `opacity`, and `visibility` change hands. The leaving layer folds into the
  corner the trash sits in; the two answers spring back out of it on
  `--spring-fast`, one `--row-stagger` apart, so the eye reaches the safe answer
  first. The can tips as it goes and rights itself on the way back.
- `Deleting…` is held to the width of its longest word (measured: 75.5px, so the
  76px floor the slot's confirm already keeps), because a label growing mid-flight
  would slide the answer beside it along.
- A question outlives neither its subject nor the surface it was asked on. The
  key going takes it, and so does the panel closing — including the stand-down to
  the slot, which is what keeps a trip to fetch a key from bringing an armed
  delete back with it. A delete already sent is the exception and finishes
  wherever it is. That rule is `removalStage()` in
  `apps/desktop/src/renderer/credential-removal.ts`, and it is what the new tests
  cover.
- `--danger` / `--danger-text` replace the two hard-coded reds, so the quit
  button, the trash, and the confirm the trash opens are demonstrably the same
  red rather than three that happen to match.
- `useFieldCaret` is now `useStagedFocus` (widened past `HTMLInputElement`) with
  `focusWhenVisible` split out, because the confirm needs the same wait-for-the-
  stage focus the field does. Asking moves focus to `Cancel`; answering hands it
  back to the trash, or to whatever stands where the trash was if the key is
  gone.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — **passed** (204 tests,
  including 6 new ones for `removalStage` / `removalAsked`)
- macOS Electron verification (`./scripts/verify.sh`): **passed on macos-15 in CI**
  ([job](https://github.com/ReviewStage/luke/actions/runs/31734417316/job/94562492144)) —
  this branch was written in a Linux cloud sandbox, so CI is where it ran. All five
  evidence PNGs were downloaded and inspected: the sessions panel, capsule, peek,
  key slot, and speaking states are unchanged.

### Browser-driven verification

The real `SettingsPanel` was mounted over the real stylesheet and driven through
the DevTools protocol with **trusted** input (so `:focus-visible` modality
behaves as it does under a real pointer), reading computed style rather than
judging by eye. Measured across resting → asking → clearing → cancelled →
deleted → withdrawn:

| | resting | asking | clearing | cancelled | withdrawn |
|---|---|---|---|---|---|
| actions box width | 142px | 142px | 142px | 142px | 142px |
| row height | 28px | 28px | 28px | 28px | 28px |
| provider name width | 61px | 61px | 61px | 61px | 61px |

Nothing on the line moves. The whole settings tab at rest is **byte-identical**
to the same capture taken at `817a6d3` (the commit before this one), so the grid
cell and the always-mounted confirm layer disturb nothing until the trash is
pressed.

In flight, `Cancel` runs `scale(0.961) → 1.0023 →
none` and `Delete` trails it at `0.918 → 0.9988 → 1.00175 → none`, with a
`32ms` (`--row-stagger`) delay on `Delete` alone — the spring's overshoot and
the stagger both land. The departing trash settles at `scale(0.82)
translateX(8.2px)` before its layer is gone.

Also confirmed: Escape withdraws the question and returns focus to the trash
(with the keyboard ring, correctly, since it was a keyboard action); a real
pointer press draws no ring (`:focus-visible` false); a successful delete moves
focus to the `Connect` that replaces the trash; closing the panel withdraws the
question without touching focus; two lines can ask at once without interfering.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31739677829/artifacts/9196575453) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31739677829)

- Commit: `c86afa37b002529f2d1e4d2f39fed54d170bedbd`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

**Note on coverage:** the automated capture states are `expanded`, `compact`,
`peek`, `slot`, and `speaking` — none of them draws the settings tab, and the
trash only exists for a key Luke keeps, so **the confirm is not in any capture**.
The CI evidence proves this change did not disturb the shapes; it does not show
the new control. Adding a capture state for it would mean giving a capture run
synthetic credential sources, which is a deliberate product decision about the
credential boundary rather than something to slip into this PR. Happy to do it as
a follow-up if it is wanted.

### Physical-device evidence

- Screenshot or screen recording: `not attached` — needs a Mac with a key stored
  under Settings → Cloud API keys
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: a physical-device pass on the settings tab
  is the one thing outstanding. `./scripts/run.sh`, open Settings, and press the
  trash on a line that shows a check without "From environment".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/bf0d7330-5c39-4e70-898e-c37d5be46af6)


