### PR TITLE
feat(release): add local macOS DMG pipeline

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -81,3 +81,10 @@ spctl -a -t exec -vv Luke.app
 ```
 
 A successful assessment identifies the source as `Notarized Developer ID`.
+
+## Local DMG release
+
+The GitHub Actions flow above produces a zip and uses App Store Connect API-key
+secrets. The separate local `pnpm release:macos` flow produces a DMG under
+`artifacts/release/` and uses the `luke-notary` keychain profile. It does not
+upload or publish the DMG; distribution remains a separate deliberate step.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Canonical commands:
 - `./scripts/check.sh` — run portable repository, type, test, and build checks
 - `./scripts/test-macos.sh` — package and validate the macOS app
 - `./scripts/verify.sh` — complete macOS validation plus visual evidence
+- `pnpm release:macos` — create a local signed, notarized, and verified DMG
 - `./scripts/run.sh` — launch the app against live sessions, replacing any
   running instance (`--fixture smoke` for fixture data, `--keep-running` to keep
   the running instance)

--- a/README.md
+++ b/README.md
@@ -101,6 +101,35 @@ pnpm --filter @luke/web dev
 Use `./scripts/run.sh --profile speaking` to preview a deterministic fixture
 waveform without requesting microphone access.
 
+### Release a signed DMG
+
+The local release path requires Xcode Command Line Tools, a Developer ID
+Application identity in the login keychain, and a `luke-notary` keychain
+profile. Configure the profile once without placing credentials in the
+repository:
+
+```sh
+xcrun notarytool store-credentials luke-notary
+```
+
+Build, sign, notarize, staple, and verify the DMG with:
+
+```sh
+LUKE_CODESIGN_IDENTITY='Developer ID Application: Charles Pan (FZ47TN3469)' pnpm release:macos
+```
+
+The command writes `artifacts/release/Luke-<version>-arm64.dmg`. This path is
+gitignored, remains local, and is never uploaded. Publishing it to the website
+is a separate deliberate step.
+
+For a local rehearsal that creates a signed DMG without submitting it to Apple,
+run `pnpm release:macos --skip-notarization` with the same identity variable.
+
+Before distribution, copy the notarized DMG to a fresh Apple Silicon Mac or
+account, open it, drag Luke to Applications, and confirm the first launch passes
+Gatekeeper without an override. You can also assess the installed app with
+`spctl --assess --type execute -vv /Applications/Luke.app`.
+
 ## Optional attention review
 
 Session monitoring does not require `OPENAI_API_KEY`: Claude Code and Codex use

--- a/apps/desktop/scripts/release-config.mjs
+++ b/apps/desktop/scripts/release-config.mjs
@@ -34,6 +34,10 @@ export function releaseSignatureMatchesIdentity({ identity, authority, certifica
   return authority === identity;
 }
 
+export function codesignDisplayArguments(certificatePrefix, appPath) {
+  return ["--display", "--verbose=2", `--extract-certificates=${certificatePrefix}`, appPath];
+}
+
 export function hdiutilCreateArguments({ stagingDirectory, dmgPath }) {
   return [
     "create",

--- a/apps/desktop/scripts/release-config.mjs
+++ b/apps/desktop/scripts/release-config.mjs
@@ -1,0 +1,88 @@
+import path from "node:path";
+import { PACKAGED_ARCHITECTURE, resolveSigningMode, SIGNING_MODE } from "./package-config.mjs";
+
+export const NOTARY_KEYCHAIN_PROFILE = "luke-notary";
+export const RELEASE_VOLUME_NAME = "Luke";
+export const DMG_STAGING_ENTRIES = [
+  { name: "Luke.app", kind: "application" },
+  { name: "Applications", kind: "symlink", target: "/Applications" },
+];
+
+export function releaseDmgFileName(version) {
+  return `Luke-${version}-${PACKAGED_ARCHITECTURE}.dmg`;
+}
+
+export function releaseArtifactDirectory(repoRoot) {
+  return path.join(repoRoot, "artifacts", "release");
+}
+
+export function resolveReleaseSigning(env) {
+  const signing = resolveSigningMode(env);
+  if (signing.mode !== SIGNING_MODE.DEVELOPER_ID) {
+    throw new Error("LUKE_CODESIGN_IDENTITY must name a Developer ID Application identity");
+  }
+  return { identity: signing.identity };
+}
+
+export function hdiutilCreateArguments({ stagingDirectory, dmgPath }) {
+  return [
+    "create",
+    "-volname",
+    RELEASE_VOLUME_NAME,
+    "-srcfolder",
+    stagingDirectory,
+    "-fs",
+    "APFS",
+    "-format",
+    "UDZO",
+    "-ov",
+    dmgPath,
+  ];
+}
+
+export function dmgCodesignArguments(identity, dmgPath) {
+  return ["--sign", identity, "--timestamp", dmgPath];
+}
+
+export function notarySubmitArguments(dmgPath) {
+  return [
+    "notarytool",
+    "submit",
+    dmgPath,
+    "--keychain-profile",
+    NOTARY_KEYCHAIN_PROFILE,
+    "--wait",
+    "--timeout",
+    "20m",
+    "--output-format",
+    "json",
+  ];
+}
+
+export function notaryLogArguments(submissionId) {
+  return ["notarytool", "log", submissionId, "--keychain-profile", NOTARY_KEYCHAIN_PROFILE];
+}
+
+export function stapleArguments(dmgPath) {
+  return ["stapler", "staple", dmgPath];
+}
+
+export function dmgVerificationCommands(dmgPath) {
+  return [
+    { command: "codesign", arguments: ["--verify", "--strict", dmgPath] },
+    {
+      command: "spctl",
+      arguments: [
+        "--assess",
+        "--type",
+        "open",
+        "--context",
+        "context:primary-signature",
+        "-vv",
+        dmgPath,
+      ],
+    },
+    { command: "xcrun", arguments: ["stapler", "validate", dmgPath] },
+    { command: "hdiutil", arguments: ["verify", dmgPath] },
+  ];
+}

--- a/apps/desktop/scripts/release-config.mjs
+++ b/apps/desktop/scripts/release-config.mjs
@@ -24,6 +24,16 @@ export function resolveReleaseSigning(env) {
   return { identity: signing.identity };
 }
 
+export function releaseSignatureMatchesIdentity({ identity, authority, certificateSha1 }) {
+  if (/^[a-f\d]{40}$/i.test(identity)) {
+    return (
+      typeof certificateSha1 === "string" &&
+      certificateSha1.toLowerCase() === identity.toLowerCase()
+    );
+  }
+  return authority === identity;
+}
+
 export function hdiutilCreateArguments({ stagingDirectory, dmgPath }) {
   return [
     "create",

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { packagedAppExecutable } from "./package-layout.mjs";
 import {
+  codesignDisplayArguments,
   DMG_STAGING_ENTRIES,
   dmgCodesignArguments,
   dmgVerificationCommands,
@@ -53,13 +54,9 @@ try {
   const certificatePrefix = path.join(signatureCaptureDirectory, "certificate");
   const signatureOutputDescriptor = fs.openSync(signatureOutputPath, "w");
   try {
-    execFileSync(
-      "codesign",
-      ["--display", "--verbose=2", "--extract-certificates", certificatePrefix, appPath],
-      {
-        stdio: ["ignore", "inherit", signatureOutputDescriptor],
-      },
-    );
+    execFileSync("codesign", codesignDisplayArguments(certificatePrefix, appPath), {
+      stdio: ["ignore", "inherit", signatureOutputDescriptor],
+    });
   } finally {
     fs.closeSync(signatureOutputDescriptor);
   }

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -13,6 +14,7 @@ import {
   notarySubmitArguments,
   releaseArtifactDirectory,
   releaseDmgFileName,
+  releaseSignatureMatchesIdentity,
   resolveReleaseSigning,
   stapleArguments,
 } from "./release-config.mjs";
@@ -45,22 +47,38 @@ execFileSync("codesign", ["--verify", "--deep", "--strict", appPath], { stdio: "
 
 const signatureCaptureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "luke-signature-"));
 let signatureOutput;
+let certificateSha1;
 try {
   const signatureOutputPath = path.join(signatureCaptureDirectory, "codesign.txt");
+  const certificatePrefix = path.join(signatureCaptureDirectory, "certificate");
   const signatureOutputDescriptor = fs.openSync(signatureOutputPath, "w");
   try {
-    execFileSync("codesign", ["--display", "--verbose=2", appPath], {
-      stdio: ["ignore", "inherit", signatureOutputDescriptor],
-    });
+    execFileSync(
+      "codesign",
+      ["--display", "--verbose=2", "--extract-certificates", certificatePrefix, appPath],
+      {
+        stdio: ["ignore", "inherit", signatureOutputDescriptor],
+      },
+    );
   } finally {
     fs.closeSync(signatureOutputDescriptor);
   }
   signatureOutput = fs.readFileSync(signatureOutputPath, "utf8");
+  certificateSha1 = createHash("sha1")
+    .update(fs.readFileSync(`${certificatePrefix}0`))
+    .digest("hex");
 } finally {
   fs.rmSync(signatureCaptureDirectory, { recursive: true, force: true });
 }
 process.stdout.write(signatureOutput);
-if (!signatureOutput.includes(`Authority=${signing.identity}`)) {
+const authority = signatureOutput.match(/^Authority=(.+)$/m)?.[1];
+if (
+  !releaseSignatureMatchesIdentity({
+    identity: signing.identity,
+    authority,
+    certificateSha1,
+  })
+) {
   throw new Error(`Packaged app is not signed by ${signing.identity}. Run pnpm package first.`);
 }
 

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -1,0 +1,138 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { packagedAppExecutable } from "./package-layout.mjs";
+import {
+  DMG_STAGING_ENTRIES,
+  dmgCodesignArguments,
+  dmgVerificationCommands,
+  hdiutilCreateArguments,
+  notaryLogArguments,
+  notarySubmitArguments,
+  releaseArtifactDirectory,
+  releaseDmgFileName,
+  resolveReleaseSigning,
+  stapleArguments,
+} from "./release-config.mjs";
+
+if (process.platform !== "darwin") {
+  throw new Error("Releasing Luke requires macOS");
+}
+
+const unknownArguments = process.argv
+  .slice(2)
+  .filter((argument) => argument !== "--skip-notarization");
+if (unknownArguments.length > 0) {
+  throw new Error(`Unknown release argument: ${unknownArguments[0]}`);
+}
+
+const skipNotarization = process.argv.includes("--skip-notarization");
+const signing = resolveReleaseSigning(process.env);
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const appRoot = path.resolve(scriptDirectory, "..");
+const repoRoot = path.resolve(appRoot, "../..");
+const desktopPackage = JSON.parse(fs.readFileSync(path.join(appRoot, "package.json"), "utf8"));
+const appExecutable = packagedAppExecutable(repoRoot);
+const appPath = path.dirname(path.dirname(path.dirname(appExecutable)));
+
+if (!fs.existsSync(appExecutable)) {
+  throw new Error(`Packaged app was not found: ${appPath}. Run pnpm package first.`);
+}
+
+execFileSync("codesign", ["--verify", "--deep", "--strict", appPath], { stdio: "inherit" });
+
+const signatureCaptureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "luke-signature-"));
+let signatureOutput;
+try {
+  const signatureOutputPath = path.join(signatureCaptureDirectory, "codesign.txt");
+  const signatureOutputDescriptor = fs.openSync(signatureOutputPath, "w");
+  try {
+    execFileSync("codesign", ["--display", "--verbose=2", appPath], {
+      stdio: ["ignore", "inherit", signatureOutputDescriptor],
+    });
+  } finally {
+    fs.closeSync(signatureOutputDescriptor);
+  }
+  signatureOutput = fs.readFileSync(signatureOutputPath, "utf8");
+} finally {
+  fs.rmSync(signatureCaptureDirectory, { recursive: true, force: true });
+}
+process.stdout.write(signatureOutput);
+if (!signatureOutput.includes(`Authority=${signing.identity}`)) {
+  throw new Error(`Packaged app is not signed by ${signing.identity}. Run pnpm package first.`);
+}
+
+const artifactDirectory = releaseArtifactDirectory(repoRoot);
+const dmgPath = path.join(artifactDirectory, releaseDmgFileName(desktopPackage.version));
+const stagingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "luke-dmg-"));
+
+function runVerificationCommands(commands) {
+  for (const { command, arguments: commandArguments } of commands) {
+    execFileSync(command, commandArguments, { stdio: "inherit" });
+  }
+}
+
+try {
+  for (const entry of DMG_STAGING_ENTRIES) {
+    const destination = path.join(stagingDirectory, entry.name);
+    if (entry.kind === "application") {
+      execFileSync("ditto", [appPath, destination], { stdio: "inherit" });
+    } else {
+      fs.symlinkSync(entry.target, destination);
+    }
+  }
+
+  fs.mkdirSync(artifactDirectory, { recursive: true });
+  fs.rmSync(dmgPath, { force: true });
+  execFileSync("hdiutil", hdiutilCreateArguments({ stagingDirectory, dmgPath }), {
+    stdio: "inherit",
+  });
+  execFileSync("codesign", dmgCodesignArguments(signing.identity, dmgPath), { stdio: "inherit" });
+
+  const verificationCommands = dmgVerificationCommands(dmgPath);
+  if (skipNotarization) {
+    runVerificationCommands([verificationCommands[0], verificationCommands[3]]);
+    process.stdout.write(
+      "Notarization SKIPPED: this DMG is signed but not ready for distribution.\n",
+    );
+  } else {
+    let notaryOutput;
+    try {
+      notaryOutput = execFileSync("xcrun", notarySubmitArguments(dmgPath), {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "inherit"],
+      });
+    } catch (error) {
+      notaryOutput = error.stdout?.toString() ?? "";
+      if (!notaryOutput) throw error;
+    }
+
+    let submission;
+    try {
+      submission = JSON.parse(notaryOutput);
+    } catch {
+      process.stderr.write(notaryOutput);
+      throw new Error(
+        "Could not parse the notarization response. Configure credentials with: xcrun notarytool store-credentials luke-notary",
+      );
+    }
+
+    if (submission.status !== "Accepted") {
+      process.stderr.write(`Notarization failed with status: ${submission.status ?? "unknown"}\n`);
+      if (submission.id) {
+        execFileSync("xcrun", notaryLogArguments(submission.id), { stdio: "inherit" });
+      }
+      throw new Error("Apple did not accept the DMG for notarization");
+    }
+
+    execFileSync("xcrun", stapleArguments(dmgPath), { stdio: "inherit" });
+    runVerificationCommands(verificationCommands);
+  }
+
+  const sizeInMegabytes = (fs.statSync(dmgPath).size / 1_000_000).toFixed(1);
+  process.stdout.write(`Released macOS DMG: ${dmgPath} (${sizeInMegabytes} MB)\n`);
+} finally {
+  fs.rmSync(stagingDirectory, { recursive: true, force: true });
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint:fix": "biome check --write .",
     "package": "pnpm --filter @luke/desktop package",
     "prepare": "husky",
+    "release:macos": "./scripts/release-macos.sh",
     "start": "pnpm --filter @luke/desktop start",
     "test": "pnpm test:harness && pnpm --recursive --if-present run test",
     "test:harness": "node --test scripts/*.test.mjs",

--- a/scripts/release-macos.sh
+++ b/scripts/release-macos.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIRECTORY=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=scripts/lib/workspace.sh
+source "$SCRIPT_DIRECTORY/lib/workspace.sh"
+
+sidecar_require_macos
+if [[ -z "${LUKE_CODESIGN_IDENTITY:-}" ]]; then
+    printf 'error: LUKE_CODESIGN_IDENTITY must name a Developer ID Application identity\n' >&2
+    exit 1
+fi
+
+"$SCRIPT_DIRECTORY/check.sh"
+
+cd "$SIDECAR_REPO_ROOT"
+pnpm package
+node "$SIDECAR_DESKTOP_APP_ROOT/scripts/release.mjs" "$@"

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -5,6 +5,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { PACKAGED_ARCHITECTURE } from "../apps/desktop/scripts/package-layout.mjs";
 import {
+  codesignDisplayArguments,
   DMG_STAGING_ENTRIES,
   dmgCodesignArguments,
   dmgVerificationCommands,
@@ -78,6 +79,15 @@ test("release signing accepts readable identities and SHA-1 certificate hashes",
     }),
     false,
   );
+});
+
+test("release certificate extraction attaches the output prefix to the codesign flag", () => {
+  assert.deepEqual(codesignDisplayArguments("/tmp/certificate", "/tmp/Luke.app"), [
+    "--display",
+    "--verbose=2",
+    "--extract-certificates=/tmp/certificate",
+    "/tmp/Luke.app",
+  ]);
 });
 
 test("release DMG layout and hdiutil arguments are deterministic", () => {

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { PACKAGED_ARCHITECTURE } from "../apps/desktop/scripts/package-layout.mjs";
+import {
+  DMG_STAGING_ENTRIES,
+  dmgCodesignArguments,
+  dmgVerificationCommands,
+  hdiutilCreateArguments,
+  notaryLogArguments,
+  notarySubmitArguments,
+  releaseArtifactDirectory,
+  releaseDmgFileName,
+  resolveReleaseSigning,
+  stapleArguments,
+} from "../apps/desktop/scripts/release-config.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+test("release DMG names include the desktop version and packaged architecture", () => {
+  const desktopPackage = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, "apps", "desktop", "package.json"), "utf8"),
+  );
+
+  assert.equal(releaseDmgFileName("0.1.0"), "Luke-0.1.0-arm64.dmg");
+  assert.equal(
+    releaseDmgFileName(desktopPackage.version),
+    `Luke-${desktopPackage.version}-${PACKAGED_ARCHITECTURE}.dmg`,
+  );
+});
+
+test("release signing requires a Developer ID identity", () => {
+  assert.throws(() => resolveReleaseSigning({}), /LUKE_CODESIGN_IDENTITY/);
+  assert.throws(
+    () => resolveReleaseSigning({ LUKE_CODESIGN_IDENTITY: "  " }),
+    /LUKE_CODESIGN_IDENTITY/,
+  );
+  assert.deepEqual(
+    resolveReleaseSigning({ LUKE_CODESIGN_IDENTITY: "Developer ID Application: Example" }),
+    {
+      identity: "Developer ID Application: Example",
+    },
+  );
+});
+
+test("release DMG layout and hdiutil arguments are deterministic", () => {
+  assert.deepEqual(DMG_STAGING_ENTRIES, [
+    { name: "Luke.app", kind: "application" },
+    { name: "Applications", kind: "symlink", target: "/Applications" },
+  ]);
+  assert.deepEqual(
+    hdiutilCreateArguments({
+      stagingDirectory: "/tmp/staging",
+      dmgPath: "/repo/artifacts/Luke.dmg",
+    }),
+    [
+      "create",
+      "-volname",
+      "Luke",
+      "-srcfolder",
+      "/tmp/staging",
+      "-fs",
+      "APFS",
+      "-format",
+      "UDZO",
+      "-ov",
+      "/repo/artifacts/Luke.dmg",
+    ],
+  );
+});
+
+test("release notarization commands use the local keychain profile", () => {
+  assert.deepEqual(notarySubmitArguments("/tmp/Luke.dmg"), [
+    "notarytool",
+    "submit",
+    "/tmp/Luke.dmg",
+    "--keychain-profile",
+    "luke-notary",
+    "--wait",
+    "--timeout",
+    "20m",
+    "--output-format",
+    "json",
+  ]);
+  assert.deepEqual(notaryLogArguments("submission-id"), [
+    "notarytool",
+    "log",
+    "submission-id",
+    "--keychain-profile",
+    "luke-notary",
+  ]);
+  assert.deepEqual(stapleArguments("/tmp/Luke.dmg"), ["stapler", "staple", "/tmp/Luke.dmg"]);
+  assert.deepEqual(dmgCodesignArguments("Developer ID Application: Example", "/tmp/Luke.dmg"), [
+    "--sign",
+    "Developer ID Application: Example",
+    "--timestamp",
+    "/tmp/Luke.dmg",
+  ]);
+});
+
+test("release artifacts stay under the repository artifacts directory", () => {
+  assert.equal(releaseArtifactDirectory("/repo"), path.join("/repo", "artifacts", "release"));
+});
+
+test("release verification covers signing, Gatekeeper, stapling, and disk image integrity", () => {
+  assert.deepEqual(dmgVerificationCommands("/tmp/Luke.dmg"), [
+    { command: "codesign", arguments: ["--verify", "--strict", "/tmp/Luke.dmg"] },
+    {
+      command: "spctl",
+      arguments: [
+        "--assess",
+        "--type",
+        "open",
+        "--context",
+        "context:primary-signature",
+        "-vv",
+        "/tmp/Luke.dmg",
+      ],
+    },
+    { command: "xcrun", arguments: ["stapler", "validate", "/tmp/Luke.dmg"] },
+    { command: "hdiutil", arguments: ["verify", "/tmp/Luke.dmg"] },
+  ]);
+});

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -13,6 +13,7 @@ import {
   notarySubmitArguments,
   releaseArtifactDirectory,
   releaseDmgFileName,
+  releaseSignatureMatchesIdentity,
   resolveReleaseSigning,
   stapleArguments,
 } from "../apps/desktop/scripts/release-config.mjs";
@@ -42,6 +43,40 @@ test("release signing requires a Developer ID identity", () => {
     {
       identity: "Developer ID Application: Example",
     },
+  );
+});
+
+test("release signing accepts readable identities and SHA-1 certificate hashes", () => {
+  assert.equal(
+    releaseSignatureMatchesIdentity({
+      identity: "Developer ID Application: Example (TEAMID)",
+      authority: "Developer ID Application: Example (TEAMID)",
+      certificateSha1: "unused",
+    }),
+    true,
+  );
+  assert.equal(
+    releaseSignatureMatchesIdentity({
+      identity: "3E4A41C54E100FFC57BC2C6AA19409467994D4B5",
+      authority: "Developer ID Application: Example (TEAMID)",
+      certificateSha1: "3e4a41c54e100ffc57bc2c6aa19409467994d4b5",
+    }),
+    true,
+  );
+  assert.equal(
+    releaseSignatureMatchesIdentity({
+      identity: "3E4A41C54E100FFC57BC2C6AA19409467994D4B5",
+      authority: "Developer ID Application: Example (TEAMID)",
+      certificateSha1: "0000000000000000000000000000000000000000",
+    }),
+    false,
+  );
+  assert.equal(
+    releaseSignatureMatchesIdentity({
+      identity: "3E4A41C54E100FFC57BC2C6AA19409467994D4B5",
+      authority: "Developer ID Application: Example (TEAMID)",
+    }),
+    false,
   );
 });
 

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -19,8 +19,10 @@ required_files=(
     tsconfig.base.json
     apps/desktop/package.json
     apps/desktop/scripts/package.mjs
+    apps/desktop/scripts/release.mjs
     apps/desktop/native/macos/ScreenGeometry.swift
     packages/sidecar-core/package.json
+    scripts/release-macos.sh
     scripts/verify.sh
     .conductor/settings.toml
     .github/pull_request_template.md


### PR DESCRIPTION
## Summary

- Add a local `pnpm release:macos` pipeline that packages, Developer-ID signs, notarizes, staples, and verifies an arm64 DMG without uploading it.
- Keep release decisions portable and covered by regression tests, while documenting local credentials, rehearsal, clean-Mac verification, and the separate CI zip flow.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (18 harness, 41 core, and 198 desktop tests; lint, typecheck, and builds passed)
- macOS Electron verification (`./scripts/verify.sh`): `passed` — packaging and all five deterministic fixture captures completed

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31743425326/artifacts/9198012008) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31743425326)

- Commit: `c2e553c69be5f75482abe1b23c4dacfce75a3303`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- The signed `--skip-notarization` rehearsal reached Developer ID signing, but local keychain private-key access failed with `errSecInternalComponent`; an isolated signing probe reproduced the same failure.
- No DMG was produced and nothing was submitted to Apple.
