### PR TITLE
fix(LUKE-64): ask the Keychain only for a key the user has

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -621,9 +621,10 @@ if (!app.requestSingleInstanceLock()) {
     Menu.setApplicationMenu(null);
     refreshNativeGeometry();
     registerIpc();
-    // Resolving settings touches the filesystem and the OS keychain. Starting it
-    // here keeps that work off the renderer's first paint, which blocks on the
-    // bootstrap reply.
+    // Resolving settings touches the filesystem, and the OS keychain only for a
+    // provider that already has a stored key to decrypt. Starting it here keeps
+    // that work off the renderer's first paint, which blocks on the bootstrap
+    // reply.
     void settingsStore.snapshot();
     createPanel();
     configurePermissions();

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 import type { AppSettings, CredentialSource, MicrophoneStatus } from "../shared/contracts";
-import { CREDENTIAL_SOURCE } from "../shared/contracts";
+import { CREDENTIAL_SOURCE, SECRET_STORAGE } from "../shared/contracts";
 import type { CredentialProvider } from "../shared/credential-providers";
 import { CREDENTIAL_PROVIDER_LIST } from "../shared/credential-providers";
 import {
@@ -298,6 +298,10 @@ function CredentialsSection({
   control: CredentialEntryControl;
   panelOpen: boolean;
 }): React.JSX.Element {
+  // Only a system Luke has actually asked, and been refused by, is reported as
+  // one that cannot hold a key. Until then the rows stand as usual: a warning
+  // about storage nobody has tried to use yet would be a guess.
+  const storageUnavailable = settings.secretStorage === SECRET_STORAGE.UNAVAILABLE;
   return (
     <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
       <h2>
@@ -309,16 +313,16 @@ function CredentialsSection({
           key={provider.id}
           provider={provider}
           source={settings.credentialSources[provider.id]}
-          storageUnavailable={!settings.secretStorageAvailable}
+          storageUnavailable={storageUnavailable}
           control={control}
           panelOpen={panelOpen}
         />
       ))}
       {/* True of every key here, so it is said once rather than per provider. */}
       <p className="settings-note">
-        {settings.secretStorageAvailable
-          ? "Luke reads only cloud workspaces you created, and never sends a prompt or any other change."
-          : "This system offers no encrypted credential storage, so Luke will not store a key here."}
+        {storageUnavailable
+          ? "This system offers no encrypted credential storage, so Luke will not store a key here."
+          : "Luke reads only cloud workspaces you created, and never sends a prompt or any other change."}
       </p>
     </section>
   );

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -4,6 +4,8 @@ import {
   type AppSettings,
   CREDENTIAL_SOURCE,
   type CredentialSource,
+  SECRET_STORAGE,
+  type SecretStorage,
   type SettingsUpdateResult,
 } from "./shared/contracts";
 import {
@@ -37,6 +39,11 @@ const PRINTABLE_ASCII = /^[\x21-\x7e]+$/;
 /**
  * A credential is only ever written through OS-provided encryption. Electron's
  * `safeStorage` satisfies this on macOS by deriving its key from the Keychain.
+ *
+ * Every member of this interface reaches the Keychain, `isAvailable` included:
+ * it answers by fetching the same key the other two use. So none of them may be
+ * called to fill in a display value — only to protect or recover a credential
+ * the user has.
  */
 export interface SecretCipher {
   isAvailable(): boolean;
@@ -149,6 +156,7 @@ export class SettingsStore {
   #loading: Promise<PersistedSettings> | undefined;
   #resolved = new Map<CredentialProviderId, ResolvedApiKey>();
   #mutations: Promise<void> = Promise.resolve();
+  #secretStorage: SecretStorage = SECRET_STORAGE.UNKNOWN;
 
   constructor(options: SettingsStoreOptions) {
     this.#directory = options.directory;
@@ -168,7 +176,10 @@ export class SettingsStore {
         CredentialProviderId,
         CredentialSource
       >,
-      secretStorageAvailable: this.#secretStorageAvailable(),
+      // Reports what storing a key has already established, and asks nothing on
+      // its own: a snapshot is taken on every launch, and most of them are for
+      // a user with no key to protect.
+      secretStorage: this.#secretStorage,
     };
   }
 
@@ -194,8 +205,10 @@ export class SettingsStore {
   ): Promise<SettingsUpdateResult> {
     const keyFormat = this.#providers.find((candidate) => candidate.id === providerId)?.keyFormat;
     const normalized = apiKey?.trim();
+    // Clearing a key needs no cipher, so only a key on its way in asks whether
+    // there is anywhere to put it.
     const rejection = normalized
-      ? !this.#secretStorageAvailable()
+      ? !this.#secretStorageUsable()
         ? "Encrypted credential storage is unavailable on this system."
         : apiKeyRejection(normalized, keyFormat)
       : undefined;
@@ -237,12 +250,23 @@ export class SettingsStore {
     return result;
   }
 
-  #secretStorageAvailable(): boolean {
-    try {
-      return this.#cipher.isAvailable();
-    } catch {
-      return false;
+  /**
+   * Asks the cipher whether it can protect a key, and remembers the answer. The
+   * question is asked at most once per run, and only from a path that has a
+   * credential in hand: on macOS asking is a Keychain read, which is the
+   * permission dialog this deliberately keeps out of an ordinary launch.
+   */
+  #secretStorageUsable(): boolean {
+    if (this.#secretStorage === SECRET_STORAGE.UNKNOWN) {
+      let available = false;
+      try {
+        available = this.#cipher.isAvailable();
+      } catch {
+        available = false;
+      }
+      this.#secretStorage = available ? SECRET_STORAGE.AVAILABLE : SECRET_STORAGE.UNAVAILABLE;
     }
+    return this.#secretStorage === SECRET_STORAGE.AVAILABLE;
   }
 
   /**

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -20,15 +20,32 @@ export const CREDENTIAL_SOURCE = {
 
 export type CredentialSource = (typeof CREDENTIAL_SOURCE)[keyof typeof CREDENTIAL_SOURCE];
 
+/**
+ * Whether Luke can store a credential through OS-provided encryption. Asking is
+ * not free: on macOS the answer comes from the Keychain, and reading it is what
+ * raises the permission dialog. Nobody who has never stored a key has any
+ * reason to see that dialog, so the question goes unasked until a key is
+ * actually being stored, and until then the answer is `UNKNOWN` rather than a
+ * guess in either direction.
+ */
+export const SECRET_STORAGE = {
+  UNKNOWN: "unknown",
+  AVAILABLE: "available",
+  UNAVAILABLE: "unavailable",
+} as const;
+
+export type SecretStorage = (typeof SECRET_STORAGE)[keyof typeof SECRET_STORAGE];
+
 /** Renderer-safe settings. Credentials are never sent to a renderer. */
 export interface AppSettings {
   /** Where each provider's key comes from, keyed by provider id. */
   credentialSources: Readonly<Record<CredentialProviderId, CredentialSource>>;
   /**
    * Luke stores credentials only through OS-provided encryption. When that is
-   * unavailable the app says so rather than falling back to plaintext storage.
+   * known to be unavailable the app says so rather than falling back to
+   * plaintext storage; while it is unknown the app says nothing about it.
    */
-  secretStorageAvailable: boolean;
+  secretStorage: SecretStorage;
 }
 
 /** A rejected update reports why without echoing the submitted value. */

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test, { type TestContext } from "node:test";
 import { type SecretCipher, SettingsStore } from "../src/settings-store";
-import { CREDENTIAL_SOURCE } from "../src/shared/contracts";
+import { CREDENTIAL_SOURCE, SECRET_STORAGE } from "../src/shared/contracts";
 import {
   CREDENTIAL_PROVIDER_ID,
   type CredentialProvider,
@@ -72,6 +72,37 @@ function testCipher(available = true): SecretCipher {
   };
 }
 
+interface CipherCallCount {
+  isAvailable: number;
+  encrypt: number;
+  decrypt: number;
+}
+
+/**
+ * Counts what reaches the cipher. Every call is a Keychain read on macOS, so
+ * what a run does not ask for is as much a part of the behavior as what it
+ * returns.
+ */
+function countingCipher(available = true): SecretCipher & { readonly calls: CipherCallCount } {
+  const cipher = testCipher(available);
+  const calls: CipherCallCount = { isAvailable: 0, encrypt: 0, decrypt: 0 };
+  return {
+    calls,
+    isAvailable: () => {
+      calls.isAvailable += 1;
+      return cipher.isAvailable();
+    },
+    encrypt: (plainText) => {
+      calls.encrypt += 1;
+      return cipher.encrypt(plainText);
+    },
+    decrypt: (cipherText) => {
+      calls.decrypt += 1;
+      return cipher.decrypt(cipherText);
+    },
+  };
+}
+
 function sealed(plainText: string): string {
   return Buffer.from(`${CIPHER_PREFIX}${plainText}`, "utf8").toString("base64");
 }
@@ -114,7 +145,7 @@ test("stores an API key encrypted, private to the owner, and never in a snapshot
 
   assert.equal(reason, undefined);
   assert.equal(settings.credentialSources[CONDUCTOR], CREDENTIAL_SOURCE.ENCRYPTED_FILE);
-  assert.equal(settings.secretStorageAvailable, true);
+  assert.equal(settings.secretStorage, SECRET_STORAGE.AVAILABLE);
   assert.equal(contents.includes(TEST_API_KEY), false, "the key was written in plaintext");
   assert.equal(stats.mode & 0o777, 0o600);
   assert.equal(JSON.stringify(settings).includes(TEST_API_KEY), false);
@@ -320,9 +351,62 @@ test("refuses to store a key when encrypted storage is unavailable", async (t) =
   const { settings, reason } = await store.setApiKey(CONDUCTOR, TEST_API_KEY);
 
   assert.match(reason ?? "", /unavailable/);
-  assert.equal(settings.secretStorageAvailable, false);
+  assert.equal(settings.secretStorage, SECRET_STORAGE.UNAVAILABLE);
   assert.equal(settings.credentialSources[CONDUCTOR], CREDENTIAL_SOURCE.NONE);
   await assert.rejects(() => readSettingsFile(directory), /ENOENT/);
+});
+
+test("asks the cipher nothing on a launch with no key to protect", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const cipher = countingCipher();
+  const store = storeIn(directory, { cipher });
+
+  const settings = await store.snapshot();
+
+  assert.equal(await store.readApiKey(CONDUCTOR), undefined);
+  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
+  // Nothing has asked, so nothing is claimed either way.
+  assert.equal(settings.secretStorage, SECRET_STORAGE.UNKNOWN);
+});
+
+test("asks the cipher nothing to clear a key", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const cipher = countingCipher();
+  const store = storeIn(directory, { cipher });
+
+  const { settings, reason } = await store.setApiKey(CONDUCTOR, undefined);
+
+  assert.equal(reason, undefined);
+  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
+  assert.equal(settings.secretStorage, SECRET_STORAGE.UNKNOWN);
+});
+
+test("asks once when a key is stored and reports that answer from then on", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const cipher = countingCipher();
+  const store = storeIn(directory, { cipher });
+
+  const { settings } = await store.setApiKey(CONDUCTOR, TEST_API_KEY);
+  const afterwards = await store.snapshot();
+  await store.setApiKey(CONDUCTOR, `${TEST_API_KEY}-rotated`);
+
+  assert.equal(settings.secretStorage, SECRET_STORAGE.AVAILABLE);
+  assert.equal(afterwards.secretStorage, SECRET_STORAGE.AVAILABLE);
+  // Once per run, however many keys pass through it.
+  assert.equal(cipher.calls.isAvailable, 1);
+});
+
+test("decrypts a stored key without asking whether storage is available", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await storeIn(directory).setApiKey(CONDUCTOR, TEST_API_KEY);
+  const cipher = countingCipher();
+  const store = storeIn(directory, { cipher });
+
+  assert.equal(await store.readApiKey(CONDUCTOR), TEST_API_KEY);
+  // Recovering a key the user has is the one reason to reach the Keychain on a
+  // launch, and it is reason enough on its own.
+  assert.equal(cipher.calls.decrypt, 1);
+  assert.equal(cipher.calls.isAvailable, 0);
 });
 
 test("ignores a stored key that can no longer be decrypted", async (t) => {


### PR DESCRIPTION
Luke asked macOS for its Keychain entry on launches that had nothing to protect, which is where the permission dialog in LUKE-64 comes from.

## Why it asked

`safeStorage.isEncryptionAvailable()` is not a cheap capability check. On macOS it answers by fetching the same key `encryptString` and `decryptString` use, so calling it opens the `Safe Storage` Keychain entry. `SettingsStore.snapshot()` called it to fill in `secretStorageAvailable`, and a snapshot is taken on every launch — for the bootstrap reply and again to warm the cache — so every launch opened the entry whether or not the user had ever stored a key.

`scripts/evidence.sh` is where that lands hardest: `verify.sh` runs it, it packages an ad-hoc-signed app, and it launches that app five times on fixtures. An ad-hoc signature is a `cdhash` that changes with every `pnpm package`, so the Keychain ACL never matches the new build and macOS asks again — during a run whose whole point is to be deterministic and credential-free.

## What changed

- The cipher is asked whether it can protect a key only from `setApiKey`, and only for a key on its way in; clearing one asks nothing. The answer is remembered, so a run asks at most once however many keys pass through.
- A launch still decrypts a stored key, because recovering a credential the user has is reason enough to reach the Keychain. A launch with no stored key now reaches it not at all.
- `AppSettings.secretStorageAvailable` becomes `AppSettings.secretStorage`, which is `UNKNOWN` until something asks. The panel treats unknown as ordinary and reserves "this system offers no encrypted credential storage" for a system Luke has actually been refused by, rather than guessing before it has asked.

No behavior changes for a user who has keys stored: the panel reads the same, and saving a key on a system without encrypted storage is refused with the same sentence.

## Testing

`./scripts/check.sh` passes. Four tests cover what a run does *not* ask for: a launch with no key touches the cipher zero times, clearing a key touches it zero times, storing keys asks exactly once, and a launch with a stored key decrypts without asking about availability.

`./scripts/verify.sh` was not run — this branch was built on Linux, where it cannot run. The macOS evidence job on this PR covers the packaged app; no physical-notch check has been performed.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/df89230a-3e10-4e46-89da-2573a6b2beab)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31742095933/artifacts/9197503461) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31742095933)

- Commit: `98908793e87c139c10884c1856688e52bb77ed6c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
