### PR TITLE
chore(desktop): answer to Luke in the Keychain and in Application Support

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@luke/desktop",
+  "productName": "Luke",
   "version": "0.1.0",
   "private": true,
   "description": "Luke desktop application",

--- a/scripts/lib/workspace.sh
+++ b/scripts/lib/workspace.sh
@@ -54,9 +54,14 @@ sidecar_wait_for_exit() {
 # the holder `<hostname>-<pid>`, so the process that blocks a launch identifies
 # itself. That is the process to replace even when it belongs to another
 # worktree: the lock is keyed on the app name, which every checkout shares.
+#
+# That name has to be derived the way Electron derives it, since Electron is what
+# chose the directory: `productName` when the manifest sets one, and the package
+# name only when it does not.
 sidecar_app_lock_holder_pid() {
     local app_name
-    if ! app_name=$(cd "$SIDECAR_DESKTOP_APP_ROOT" && node -p 'require("./package.json").name'); then
+    if ! app_name=$(cd "$SIDECAR_DESKTOP_APP_ROOT" &&
+        node -p 'const manifest = require("./package.json"); manifest.productName ?? manifest.name'); then
         printf 'error: could not read the desktop app name\n' >&2
         return 1
     fi

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -56,6 +56,26 @@ test("workspace package versions agree on v0.1.0", () => {
   );
 });
 
+/**
+ * The bundle carries the name macOS shows, and the manifest carries the name
+ * Electron works from: `productName` is what it derives the user-data directory
+ * and the Keychain entry from, falling back to the package name — which is
+ * scoped, and would put Luke's own state two directories down inside `@luke`.
+ * Nothing warns when the two disagree; the app just answers to one name in the
+ * Finder and another in the Keychain, so they are held together here.
+ */
+test("the app answers to one name in the bundle and in Electron", () => {
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, "apps", "desktop", "package.json"), "utf8"),
+  );
+  const options = packagerOptions();
+
+  assert.equal(manifest.productName, "Luke");
+  assert.equal(options.name, manifest.productName);
+  assert.equal(options.executableName, manifest.productName);
+  assert.equal(options.extendInfo.CFBundleDisplayName, manifest.productName);
+});
+
 test("packaging is pinned to Apple Silicon", () => {
   const options = packagerOptions();
 


### PR DESCRIPTION
Electron works from `productName`, falling back to the package name when a manifest sets none. Luke set none, so the scoped package name became the app name — and that name is what Electron derives the user-data directory and the macOS Keychain entry from:

| | before | after |
|---|---|---|
| user data | `~/Library/Application Support/@luke/desktop/` | `~/Library/Application Support/Luke/` |
| Keychain entry | `@luke/desktop Safe Storage`, account `@luke/desktop Key` | `Luke Safe Storage`, account `Luke Key` |

The slash in the scope is a path separator, so Luke's settings and Chromium's caches sat two directories down inside a folder called `@luke`. The bundle itself has always said Luke — `name`, `executableName`, and `CFBundleDisplayName` are all Luke, and the bundle id is `dev.reviewstage.luke`. Only the two places Electron names itself did not, and the Keychain entry is the one macOS quotes back to the user in a permission dialog.

## What comes with it

- `scripts/lib/workspace.sh` derives the app name the way Electron does — `productName ?? name` — instead of reading the package name. Without this, `./scripts/run.sh` would look for the single-instance lock in the old directory, find nothing to stop, and quit with "Luke is already running…" instead of replacing the instance it just rebuilt.
- A packaging test holds the manifest's `productName` and the bundle's three names together. Nothing warns when they drift; the app would simply answer to one name in the Finder and another in the Keychain.

## What it costs, once

A key stored before this change cannot be carried across. The ciphertext is bound to the old Keychain entry, and the app cannot read one entry while identifying itself as the other, so copying the settings file over would only move something undecryptable. Anyone with stored keys enters them again once; `SettingsStore` already ignores ciphertext it cannot read, so nothing fails, the affected providers simply read as unconnected.

The old directory and the old Keychain entry are left where they are rather than deleted — Luke does not write outside its own state — and can be removed by hand:

    rm -rf ~/Library/Application\ Support/@luke
    security delete-generic-password -s '@luke/desktop Safe Storage'

This is why the change lands now: there are no tags and no releases, so the population that pays the one-time cost is whoever runs from source. After a release it would apply to every install, with no migration available.

## Testing

`./scripts/check.sh` passes. `./scripts/verify.sh` was not run — this branch was built on Linux, where it cannot run — so the macOS evidence job on this PR covers the packaged app, and no physical-notch check has been performed. Nothing here touches a drawn surface.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/df89230a-3e10-4e46-89da-2573a6b2beab)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31743049178/artifacts/9197877293) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31743049178)

- Commit: `2939cb2560e678ab390f6d9e1742141333a3e63a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
