### PR TITLE
fix(panel): draw the hand over the peek and collapse from the whole strip

### DIFF
--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -418,7 +418,17 @@ button:disabled {
      body carries the panel's: the press target is the shape, not its box. */
   border-radius: 0 0 var(--notch-convex-radius) var(--notch-convex-radius);
   background: none;
-  cursor: pointer;
+  /* Each state below names the hand; the capsule is the one that does not, and
+     that is what makes the hand appear at all. A window passing the pointer
+     through is not the window the pointer is over, so a hand computed for a
+     capsule the pointer has only just landed on is drawn and then immediately
+     overridden by whatever is behind Luke — and a cursor is only reported when
+     it changes, so nothing asks for it again while the pointer stays where it
+     is. That is the arrow left over a peek for as long as anyone hovers it.
+     Every state that does name the hand is one this window has already begun
+     taking the pointer for, and each is reached by a resize, so the hand is
+     asked for afresh at a moment it can hold. */
+  cursor: default;
   transform: translateX(-50%);
   /* Pressing the capsule is a gesture, not a focus change: a ring drawn around
      the notch strip by a mouse press is the one thing on screen that cannot
@@ -442,12 +452,18 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 
 .app-stage[data-presentation="peek"] .compact-hover-target {
   width: var(--peek-width);
+  cursor: pointer;
 }
 
-/* The capsule strip keeps taking clicks over an open panel: pressing it is how
-   the panel closes again, and nothing interactive sits under it. */
+/* The strip keeps taking clicks over an open panel: pressing it is how the panel
+   closes again. It spans the shape rather than the capsule it grew from, because
+   the band the housing sits in is empty for the whole width of an open panel —
+   the wings are drawn in it but take no pointer, and the body starts below it —
+   so every part of that band means the same thing and answers the same way. */
 .app-stage[data-presentation="panel"] .compact-hover-target {
+  width: var(--panel-width);
   height: max(var(--notch-top-inset), 32px);
+  cursor: pointer;
   pointer-events: auto;
 }
 
@@ -759,6 +775,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 /* Pressing the strip while the slot is drawn brings the whole panel back, with
    the entry still in it. */
 .app-stage[data-presentation="slot"] .compact-hover-target {
+  cursor: pointer;
   pointer-events: auto;
 }
 


### PR DESCRIPTION
Two things the strip beside the housing got wrong.

**The hand cursor over the peek.** The capsule named `cursor: pointer`, and it
is the one state that must not. A window passing the pointer through is not the
window the pointer is over, so the hand computed for a capsule the pointer has
only just landed on is drawn and then immediately overridden by whatever is
behind Luke. A cursor is only reported when it changes, so nothing asks for it
again while the pointer stays where it is — which is the arrow left sitting over
a peek for as long as anyone hovers it, sometimes, depending on whether the
window had stopped ignoring mouse events yet. Every state that has already begun
taking the pointer names the hand instead, and each of them is reached by a
resize, so the hand is asked for afresh at a moment it can hold.

**Collapsing from anywhere in the notch band.** The strip over an open panel was
still the capsule's width, so only the middle of that band closed the panel. It
now spans the shape. The band the housing sits in is empty for the whole width
of an open panel — the wings are drawn in it but take no pointer, and the body
starts below it — so every part of it already meant close and now answers that
way.

## Verification

`./scripts/check.sh` — passes (212 tests, lint, typecheck, build).

Hit regions and computed cursors probed against the built stylesheet, one state
at a time:

| state | strip | cursor | band answers |
| --- | --- | --- | --- |
| capsule | 282×38 | `default` | capsule in the middle, click-through past it |
| peek | 458×38 | `pointer` | capsule across the whole peek, click-through past it |
| panel | 620×38 | `pointer` | capsule edge to edge; the body answers below the band; click-through past the panel |
| slot | 282×38 | `pointer` | capsule |

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/40f4563e-8b13-4d6b-be93-e205944230ec)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31744408135/artifacts/9198385026) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31744408135)

- Commit: `e29d029e6201b2089a502912f47fded3be8738b4`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
