### PR TITLE
fix(web): clean up the landing page

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
+    "@sidecar/core": "workspace:*",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
+    "@fontsource-variable/bricolage-grotesque": "5.3.0",
     "@sidecar/core": "workspace:*",
     "react": "19.2.8",
     "react-dom": "19.2.8"

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -85,9 +85,6 @@ export function App(): React.JSX.Element {
           <span>Apache-2.0</span>
           <span>macOS 14+</span>
         </div>
-        <p className="footnote">
-          Product names belong to their owners. Luke is independent and unaffiliated.
-        </p>
       </footer>
     </>
   );

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -82,9 +82,6 @@ export function App(): React.JSX.Element {
 
       <footer className="site-footer shell">
         <div className="footer-meta">
-          <span>
-            <a href={REPOSITORY_URL}>GitHub</a>
-          </span>
           <span>Apache-2.0</span>
           <span>macOS 14+</span>
         </div>

--- a/apps/web/src/NotchMock.tsx
+++ b/apps/web/src/NotchMock.tsx
@@ -1,29 +1,11 @@
+import { fixtureSnapshot, SESSION_LOCATION, SESSION_STATE, type SessionState } from "@sidecar/core";
 import { useEffect, useState } from "react";
 
 /**
  * The hero visual: a CSS recreation of Luke's compact capsule expanding into
- * its session panel. There are no product screenshots in this repository, and
- * the landing page must build without the desktop workspace, so this mirrors
- * `@sidecar/core`'s value set locally instead of depending on it. Any drift is
- * cosmetic; the source of truth is `SESSION_STATE` in
- * `packages/sidecar-core/src/fixtures.ts`.
+ * its session panel. It renders the product's smoke fixture directly so the
+ * sessions cannot drift from the app it represents.
  */
-const MOCK_SESSION_STATE = {
-  WORKING: "working",
-  ATTENTION: "attention",
-  COMPLETE: "complete",
-  UNKNOWN: "unknown",
-} as const;
-
-type MockSessionState = (typeof MOCK_SESSION_STATE)[keyof typeof MOCK_SESSION_STATE];
-
-const MOCK_LOCATION = {
-  LOCAL: "local",
-  CLOUD: "cloud",
-} as const;
-
-type MockLocation = (typeof MOCK_LOCATION)[keyof typeof MOCK_LOCATION];
-
 const MOCK_MODE = {
   COMPACT: "compact",
   EXPANDED: "expanded",
@@ -31,78 +13,35 @@ const MOCK_MODE = {
 
 type MockMode = (typeof MOCK_MODE)[keyof typeof MOCK_MODE];
 
-interface MockSession {
-  id: string;
-  title: string;
-  provider: string;
-  detail: string;
-  state: MockSessionState;
-  location: MockLocation;
-  label: string;
-}
+const STATE_LABEL: Record<SessionState, string> = {
+  [SESSION_STATE.WORKING]: "Working",
+  [SESSION_STATE.ATTENTION]: "Needs you",
+  [SESSION_STATE.COMPLETE]: "Complete",
+  [SESSION_STATE.UNKNOWN]: "Idle",
+};
 
-/**
- * The repository's smoke fixture, rendered with text-only provider names.
- * Conductor's brand mark is licensed for the product's provider rows only.
- */
-const MOCK_SESSIONS: readonly MockSession[] = [
-  {
-    id: "codex-bootstrap",
-    title: "Bootstrap the desktop shell",
-    provider: "Codex",
-    detail: "Testing Electron window semantics",
-    state: MOCK_SESSION_STATE.WORKING,
-    location: MOCK_LOCATION.LOCAL,
-    label: "Working",
-  },
-  {
-    id: "claude-review",
-    title: "Review trust constraints",
-    provider: "Claude Code",
-    detail: "One architecture decision is ready",
-    state: MOCK_SESSION_STATE.ATTENTION,
-    location: MOCK_LOCATION.LOCAL,
-    label: "Needs attention",
-  },
-  {
-    id: "conductor-workspace",
-    title: "Observe a cloud workspace",
-    provider: "Conductor",
-    detail: "Cloud session metadata only · no live credentials",
-    state: MOCK_SESSION_STATE.COMPLETE,
-    location: MOCK_LOCATION.CLOUD,
-    label: "Complete",
-  },
-  {
-    id: "cursor-agent",
-    title: "Follow a cloud agent",
-    provider: "Cursor",
-    detail: "Opened a pull request against sidecar",
-    state: MOCK_SESSION_STATE.WORKING,
-    location: MOCK_LOCATION.CLOUD,
-    label: "Working",
-  },
-  {
-    id: "devin-session",
-    title: "Watch a cloud session",
-    provider: "Devin",
-    detail: "Suspended before it opened a pull request",
-    state: MOCK_SESSION_STATE.UNKNOWN,
-    location: MOCK_LOCATION.CLOUD,
-    label: "Unknown",
-  },
+const STATE_PRIORITY: readonly SessionState[] = [
+  SESSION_STATE.ATTENTION,
+  SESSION_STATE.WORKING,
+  SESSION_STATE.COMPLETE,
+  SESSION_STATE.UNKNOWN,
 ];
 
+const MOCK_SESSIONS = fixtureSnapshot("smoke").sessions.toSorted(
+  (left, right) => STATE_PRIORITY.indexOf(left.state) - STATE_PRIORITY.indexOf(right.state),
+);
+
 const ATTENTION_COUNT = MOCK_SESSIONS.filter(
-  (session) => session.state === MOCK_SESSION_STATE.ATTENTION,
+  (session) => session.state === SESSION_STATE.ATTENTION,
 ).length;
 
 /** The compact dot takes the most urgent state, exactly as the renderer does. */
-const COMPACT_INDICATOR_STATE: MockSessionState =
-  ATTENTION_COUNT > 0 ? MOCK_SESSION_STATE.ATTENTION : MOCK_SESSION_STATE.WORKING;
+const COMPACT_INDICATOR_STATE: SessionState =
+  ATTENTION_COUNT > 0 ? SESSION_STATE.ATTENTION : SESSION_STATE.WORKING;
 
 const MOCK_LABEL = `Luke's notch capsule expanding into its session panel, listing ${MOCK_SESSIONS.map(
-  (session) => `${session.title} on ${session.provider}, ${session.label.toLowerCase()}`,
+  (session) =>
+    `${session.title} on ${session.provider}, ${STATE_LABEL[session.state].toLowerCase()}`,
 ).join("; ")}.`;
 
 /* ── How busy the idle hero feels ─────────────────────────────────────────────
@@ -212,7 +151,6 @@ export function NotchMock(): React.JSX.Element {
         }}
       >
         <span className="mock-frame" />
-        <span className="mock-glow" />
 
         {/* Both stages keep their full layout box behind `opacity: 0`, so the
             hidden one is marked inert for the same reason the app marks its
@@ -227,58 +165,38 @@ export function NotchMock(): React.JSX.Element {
 
         <div className="mock-expanded" inert={displayMode !== MOCK_MODE.EXPANDED}>
           <section className="mock-panel">
-            <header className="mock-header">
-              <div className="mock-header-status">
-                <span className="mock-header-indicator" />
-                <span className="mock-header-copy">
-                  <strong>Monitoring</strong>
-                  <small>
-                    {ATTENTION_COUNT} session{ATTENTION_COUNT === 1 ? "" : "s"} needs attention
-                  </small>
-                </span>
-              </div>
-            </header>
-
             <div className="mock-body">
-              <div className="mock-summary">
-                <div>
-                  <p className="mock-eyebrow">Notch sidecar</p>
-                  <p className="mock-title">Agent activity</p>
-                  <p className="mock-subtle">Live sessions · no transcripts retained</p>
-                </div>
-                <span className="mock-badge">LIVE</span>
+              <div className="mock-tab-bar">
+                <span className="mock-tab-thumb" />
+                <span className="mock-tab" data-active="true">
+                  Sessions
+                </span>
+                <span className="mock-tab" data-active="false">
+                  Settings
+                </span>
               </div>
 
               <div className="mock-session-list">
                 {MOCK_SESSIONS.map((session) => (
                   <article className="mock-session-row" key={session.id}>
+                    {/* The app leads with licensed provider marks. The public
+                        mock uses a state dot so it does not republish them. */}
                     <span className={`mock-status-mark ${session.state}`} />
                     <span className="mock-session-copy">
                       <strong>{session.title}</strong>
                       <small>
                         {session.provider}
-                        {session.location === MOCK_LOCATION.CLOUD ? " · Cloud" : ""} ·{" "}
-                        {session.detail}
+                        {session.location === SESSION_LOCATION.CLOUD ? " · Cloud" : ""}
+                        {session.detail ? ` · ${session.detail}` : ""}
                       </small>
                     </span>
-                    <span className={`mock-session-status ${session.state}`}>{session.label}</span>
+                    <span className={`mock-session-status ${session.state}`}>
+                      {STATE_LABEL[session.state]}
+                    </span>
                   </article>
                 ))}
               </div>
             </div>
-
-            <footer className="mock-footer">
-              <div className="mock-diagnostics">
-                <span>Electron 43.3.0</span>
-                <span>Packaged</span>
-                <span>Hardware notch</span>
-                <span>appkit</span>
-              </div>
-              <div className="mock-footer-actions">
-                <span className="mock-quiet-button">Settings</span>
-                <span className="mock-quiet-button">Quit</span>
-              </div>
-            </footer>
           </section>
         </div>
       </div>

--- a/apps/web/src/NotchMock.tsx
+++ b/apps/web/src/NotchMock.tsx
@@ -1,5 +1,5 @@
 import { fixtureSnapshot, SESSION_LOCATION, SESSION_STATE, type SessionState } from "@sidecar/core";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 /**
  * The hero visual: a CSS recreation of Luke's compact capsule expanding into
@@ -44,110 +44,25 @@ const MOCK_LABEL = `Luke's notch capsule expanding into its session panel, listi
     `${session.title} on ${session.provider}, ${STATE_LABEL[session.state].toLowerCase()}`,
 ).join("; ")}.`;
 
-/* ── How busy the idle hero feels ─────────────────────────────────────────────
- *
- * The mock drives itself until a pointer enters it. Two knobs decide whether
- * that reads as "alive" or as "a GIF that will not sit still":
- *
- *   PHASE_MS      how long each state holds before the next one.
- *   SETTLE_AFTER  how many times the panel opens before the mock stops cycling
- *                 and simply stays open. `null` cycles forever.
- *
- * Settling after a single open won: cycling forever keeps demonstrating the
- * product's one gesture to a reader who arrives late, but it also moves in the
- * corner of the eye for as long as anyone is reading the copy below it. One
- * open shows the gesture, then leaves the most informative state — the full
- * session list — on screen and gets out of the way.
- *
- * `SETTLE_AFTER` is typed rather than `as const` so that `null` stays a
- * reachable option; the AGENTS.md `as const` convention covers fixed value
- * sets, not tuning constants.
- */
-const AUTO_CYCLE: { readonly PHASE_MS: number; readonly SETTLE_AFTER: number | null } = {
-  PHASE_MS: 3000,
-  SETTLE_AFTER: 1,
-};
-
-/** The next state the idle mock should move to, or `undefined` to settle. */
-function nextAutoCycleMode(current: MockMode, opensSoFar: number): MockMode | undefined {
-  if (current === MOCK_MODE.COMPACT) return MOCK_MODE.EXPANDED;
-  if (AUTO_CYCLE.SETTLE_AFTER !== null && opensSoFar >= AUTO_CYCLE.SETTLE_AFTER) return undefined;
-  return MOCK_MODE.COMPACT;
-}
-
-function useReducedMotion(): boolean {
-  const [reduced, setReduced] = useState(
-    () => window.matchMedia("(prefers-reduced-motion: reduce)").matches,
-  );
-
-  useEffect(() => {
-    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
-    // Re-read on mount: the preference can change between the lazy initializer
-    // and this effect, and it can change again while the page is open.
-    setReduced(query.matches);
-    const handleChange = (event: MediaQueryListEvent) => {
-      setReduced(event.matches);
-    };
-    query.addEventListener("change", handleChange);
-    return () => {
-      query.removeEventListener("change", handleChange);
-    };
-  }, []);
-
-  return reduced;
-}
-
 export function NotchMock(): React.JSX.Element {
-  const reducedMotion = useReducedMotion();
   const [mode, setMode] = useState<MockMode>(MOCK_MODE.COMPACT);
-  const [opens, setOpens] = useState(0);
-  const [hovering, setHovering] = useState(false);
-
-  useEffect(() => {
-    if (reducedMotion || hovering) return;
-    const next = nextAutoCycleMode(mode, opens);
-    if (!next) return;
-
-    // A re-arming timeout rather than an interval: the cycle has to be able to
-    // stop itself, and not arming is simpler than clearing from inside a tick.
-    // It is also symmetric under StrictMode's double invoke — the first timer
-    // is cleared before the second is armed, so only one ever runs.
-    const timer = window.setTimeout(() => {
-      setMode(next);
-      if (next === MOCK_MODE.EXPANDED) setOpens((count) => count + 1);
-    }, AUTO_CYCLE.PHASE_MS);
-
-    return () => {
-      window.clearTimeout(timer);
-    };
-  }, [hovering, mode, opens, reducedMotion]);
-
-  // Someone who asked for less motion gets the panel that carries the most
-  // information, held still. No timer is ever armed in that case.
-  const displayMode = reducedMotion ? MOCK_MODE.EXPANDED : mode;
 
   return (
     <div className="mock-wrapper">
       {/* Pointer handlers with no keyboard equivalent are deliberate: hovering
-          only reaches a state the auto-cycle already shows on its own, so it
-          adds emphasis rather than information. The whole mock is one labelled
-          image to assistive technology. */}
+          changes only the presentation of this labelled image. Touch pointers
+          cannot hover, so they leave the illustration compact. */}
       <div
         className="mock"
-        data-mode={displayMode}
+        data-mode={mode}
         role="img"
         aria-label={MOCK_LABEL}
-        onPointerEnter={() => {
-          setHovering(true);
-          // A hover opens the panel deliberately, so it counts toward settling
-          // exactly as an auto-open does. Without this, hovering inside the
-          // first phase leaves `opens` at zero and the mock collapses once more
-          // after the pointer leaves — the opposite of what SETTLE_AFTER is for.
-          if (mode !== MOCK_MODE.EXPANDED) setOpens((count) => count + 1);
+        onPointerEnter={(event) => {
+          if (event.pointerType === "touch") return;
           setMode(MOCK_MODE.EXPANDED);
         }}
         onPointerLeave={() => {
-          setHovering(false);
+          setMode(MOCK_MODE.COMPACT);
         }}
       >
         <span className="mock-frame" />
@@ -156,14 +71,14 @@ export function NotchMock(): React.JSX.Element {
             hidden one is marked inert for the same reason the app marks its
             own: without it, find-in-page matches invisible session titles and
             a drag selects text nobody can see. */}
-        <div className="mock-compact" inert={displayMode !== MOCK_MODE.COMPACT}>
+        <div className="mock-compact" inert={mode !== MOCK_MODE.COMPACT}>
           <span className="mock-housing" />
           <span className="mock-indicator-target">
             <span className={`mock-indicator ${COMPACT_INDICATOR_STATE}`} />
           </span>
         </div>
 
-        <div className="mock-expanded" inert={displayMode !== MOCK_MODE.EXPANDED}>
+        <div className="mock-expanded" inert={mode !== MOCK_MODE.EXPANDED}>
           <section className="mock-panel">
             <div className="mock-body">
               <div className="mock-tab-bar">

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,3 +1,4 @@
+import "@fontsource-variable/bricolage-grotesque/wght.css";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -68,7 +68,8 @@
      page and the product feel like the same software. */
   --swift: cubic-bezier(0.2, 0.8, 0.2, 1);
 
-  --font-sans: -apple-system, blinkmacsystemfont, "SF Pro Display", "Segoe UI", sans-serif;
+  --font-brand: "Bricolage Grotesque Variable", "Arial Narrow", sans-serif;
+  --font-product: -apple-system, blinkmacsystemfont, "SF Pro Display", "Segoe UI", sans-serif;
   /* The mock renders at true product geometry and scales as a unit. Stepped
      rather than fluid so the interior never lands on a half pixel. The height
      is the 520px expanded panel plus room for the display edge below it, and
@@ -79,7 +80,8 @@
   --mock-scale: 1;
   --mock-height: 540px;
 
-  font-family: var(--font-sans);
+  font-family: var(--font-brand);
+  font-optical-sizing: auto;
   font-synthesis: none;
 }
 
@@ -268,6 +270,7 @@ button {
   flex: none;
   transform: scale(var(--mock-scale));
   transform-origin: top center;
+  font-family: var(--font-product);
   /* An illustration, not page copy: dragging across a recreated interface
      should not fill someone's clipboard with invented session titles. */
   user-select: none;
@@ -589,8 +592,8 @@ button {
 }
 
 /* Reduced motion
-   The mock is pinned open in JavaScript; this removes the transitions that
-   would otherwise still animate the initial paint.
+   Hover still changes the illustration's state, but it does so without an
+   animated transition.
    ------------------------------------------------------------------------- */
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -536,7 +536,6 @@ button {
   border-top: 1px solid var(--hairline-strong);
   color: var(--text-secondary);
   font-size: var(--text-xs);
-  gap: var(--space-3);
   text-align: center;
 }
 
@@ -550,11 +549,6 @@ button {
 .footer-meta span + span::before {
   margin-right: var(--space-2);
   content: "·";
-}
-
-.footnote {
-  margin: 0;
-  color: var(--text-secondary);
 }
 
 /* Responsive

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -51,7 +51,7 @@
   --text-sm: 0.875rem;
   --text-base: 1rem;
   --text-lg: 1.125rem;
-  --text-hero: clamp(2.25rem, 5.5vw, 3.5rem);
+  --text-hero: clamp(1.5rem, 5.5vw, 3.5rem);
 
   /* Space scale, 4px grid. */
   --space-1: 4px;
@@ -190,13 +190,12 @@ button {
 }
 
 .hero h1 {
-  max-width: 18ch;
   margin: 0 auto var(--space-5);
   font-size: var(--text-hero);
   font-weight: 650;
   letter-spacing: -0.02em;
   line-height: 1.05;
-  text-wrap: balance;
+  white-space: nowrap;
 }
 
 .hero-subhead {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -51,7 +51,7 @@
   --text-sm: 0.875rem;
   --text-base: 1rem;
   --text-lg: 1.125rem;
-  --text-hero: clamp(1.5rem, 5.5vw, 3.5rem);
+  --text-hero: clamp(1rem, 5.5vw, 3.5rem);
 
   /* Space scale, 4px grid. */
   --space-1: 4px;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2,8 +2,9 @@
  *
  * The product has no screenshots in this repository, so the hero is a CSS
  * recreation of the real surface rather than an image. Every value under
- * "Notch mock" is ported from `apps/desktop/src/renderer/styles.css`; keep them
- * in step when the product's look changes.
+ * "Notch mock" is ported from `apps/desktop/src/renderer/styles/base.css` and
+ * `apps/desktop/src/renderer/styles/sessions.css`; keep them in step when the
+ * product's look changes.
  *
  * Deliberately not ported from the renderer: `overflow: clip` on the root,
  * `user-select: none`, and the transparent body. Those exist so an Electron
@@ -21,11 +22,10 @@
   --frame-top: #14171c;
   --frame-bottom: #0a0b0e;
 
-  --accent: #59d6ff;
-  --accent-eyebrow: #58cefa;
+  --accent: #5cd5ff;
   --accent-strong: #72dcff;
-  --attention: #ff963f;
-  --complete: #68d39a;
+  --attention: #ffa049;
+  --complete: #6fdca4;
   /* `unknown` is the product's idle accent: a session Luke can still see but
      has no current activity for. Matches `--state-idle` in the renderer. */
   --idle: rgba(255, 255, 255, 0.44);
@@ -35,30 +35,49 @@
   --text-muted: rgba(255, 255, 255, 0.4);
   --text-faint: rgba(255, 255, 255, 0.32);
 
-  --hairline: rgba(255, 255, 255, 0.045);
+  --hairline: rgba(255, 255, 255, 0.08);
   --hairline-strong: rgba(255, 255, 255, 0.09);
+  --raised: rgba(255, 255, 255, 0.05);
+  --raised-strong: rgba(255, 255, 255, 0.09);
 
-  --radius-card: 16px;
+  --radius-card: 17px;
   --radius-control: 10px;
-  --radius-panel: 28px;
+  --radius-panel: 30px;
   --radius-pill: 999px;
+
+  /* Type scale. The hero is the only fluid step; everything below it is fixed
+     so the rhythm does not shift with the viewport. */
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-hero: clamp(2.25rem, 5.5vw, 3.5rem);
+
+  /* Space scale, 4px grid. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+  --space-9: 96px;
 
   /* The renderer's expansion easing. Reused for every page transition so the
      page and the product feel like the same software. */
   --swift: cubic-bezier(0.2, 0.8, 0.2, 1);
 
   --font-sans: -apple-system, blinkmacsystemfont, "SF Pro Display", "Segoe UI", sans-serif;
-  --font-mono: "SF Mono", menlo, monospace;
-
   /* The mock renders at true product geometry and scales as a unit. Stepped
      rather than fluid so the interior never lands on a half pixel. The height
-     is the 610px expanded panel plus room for the display edge below it, and
+     is the 520px expanded panel plus room for the display edge below it, and
      both the mock and its wrapper derive from this one value so the painted
      art and the space reserved for it cannot drift apart. The panel is sized
      to the five-session smoke fixture at the product's own row height; the
      list does not shrink, so anything shorter clips the last row. */
   --mock-scale: 1;
-  --mock-height: 630px;
+  --mock-height: 540px;
 
   font-family: var(--font-sans);
   font-synthesis: none;
@@ -72,7 +91,7 @@ body {
   margin: 0;
   background: var(--page);
   color: var(--text);
-  font-size: 16px;
+  font-size: var(--text-base);
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
 }
@@ -89,7 +108,6 @@ button {
 }
 
 :focus-visible {
-  border-radius: 4px;
   outline: 2px solid var(--accent);
   outline-offset: 3px;
 }
@@ -101,7 +119,7 @@ button {
   width: 100%;
   max-width: 960px;
   margin: 0 auto;
-  padding: 0 24px;
+  padding: 0 var(--space-5);
 }
 
 /* Navigation
@@ -109,7 +127,7 @@ button {
 
 .site-nav {
   display: flex;
-  height: 68px;
+  height: var(--space-8);
   align-items: center;
   justify-content: space-between;
 }
@@ -117,9 +135,9 @@ button {
 .wordmark {
   display: inline-flex;
   align-items: center;
-  font-size: 15px;
+  font-size: var(--text-base);
   font-weight: 700;
-  gap: 7px;
+  gap: var(--space-2);
   letter-spacing: -0.01em;
 }
 
@@ -163,23 +181,28 @@ button {
    ------------------------------------------------------------------------- */
 
 .hero {
-  padding: 56px 0 72px;
+  /* A notch belongs at the horizontal center of a display, so the art and the
+     copy that introduces it intentionally share the same centered axis. */
+  padding: var(--space-7) 0 var(--space-8);
   text-align: center;
 }
 
 .hero h1 {
-  margin: 0 0 20px;
-  font-size: clamp(2.4rem, 6vw, 3.9rem);
+  max-width: 18ch;
+  margin: 0 auto var(--space-5);
+  font-size: var(--text-hero);
   font-weight: 650;
   letter-spacing: -0.02em;
   line-height: 1.05;
+  text-wrap: balance;
 }
 
 .hero-subhead {
   max-width: 620px;
   margin: 0 auto;
   color: var(--text-secondary);
-  font-size: 1rem;
+  font-size: var(--text-lg);
+  text-wrap: pretty;
 }
 
 .cta-row {
@@ -187,20 +210,20 @@ button {
   flex-wrap: wrap;
   align-items: center;
   justify-content: center;
-  margin-top: 32px;
-  gap: 12px;
+  margin-top: var(--space-6);
+  gap: var(--space-3);
 }
 
 .cta-primary {
   display: inline-flex;
   align-items: center;
-  padding: 12px 20px;
+  padding: var(--space-3) var(--space-5);
   border-radius: var(--radius-control);
   background: var(--accent);
   color: #04121a;
-  font-size: 14px;
+  font-size: var(--text-sm);
   font-weight: 650;
-  gap: 8px;
+  gap: var(--space-2);
   text-decoration: none;
   transition:
     background 140ms ease,
@@ -216,8 +239,9 @@ button {
 }
 
 /* Notch mock
-   Ported from apps/desktop/src/renderer/styles.css. The interior keeps true
-   product pixels; only the outer frame and the panel border are page-only.
+   Ported from apps/desktop/src/renderer/styles/base.css and styles/sessions.css.
+   The interior keeps true product pixels; only the outer frame and the panel
+   border are page-only.
    ------------------------------------------------------------------------- */
 
 .mock-wrapper {
@@ -228,7 +252,7 @@ button {
      290px-tall visual. `clip` keeps the untransformed 660px width from opening
      a horizontal scrollbar. */
   height: calc(var(--mock-height) * var(--mock-scale));
-  margin-top: 56px;
+  margin-top: var(--space-7);
   overflow: clip;
 }
 
@@ -269,22 +293,6 @@ button {
   );
   -webkit-mask-image: linear-gradient(180deg, #000 0%, #000 18%, transparent 62%);
   mask-image: linear-gradient(180deg, #000 0%, #000 18%, transparent 62%);
-}
-
-/* A black panel on a near-black page needs help separating from it. The glow
-   sits behind both stages so neither the capsule nor the panel picks it up. */
-.mock-glow {
-  position: absolute;
-  z-index: 0;
-  top: -40px;
-  left: 50%;
-  width: 560px;
-  height: 300px;
-  border-radius: 50%;
-  background: radial-gradient(closest-side, rgba(89, 214, 255, 0.12), transparent);
-  filter: blur(24px);
-  pointer-events: none;
-  transform: translateX(-50%);
 }
 
 /* The mock's root element owns its one pointer interaction, so neither stage
@@ -349,7 +357,7 @@ button {
   top: 0;
   left: 50%;
   width: 620px;
-  height: 610px;
+  height: 520px;
   padding: 0 10px 18px;
   opacity: 0;
   transform: translateX(-50%) translateY(-6px) scale(0.965);
@@ -370,7 +378,7 @@ button {
   height: 100%;
   flex-direction: column;
   padding: max(calc(var(--notch-top-inset) + 10px), 20px) 20px 18px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--hairline);
   border-radius: 0 0 var(--radius-panel) var(--radius-panel);
   background: var(--surface);
   box-shadow: 0 30px 80px rgba(0, 0, 0, 0.65);
@@ -381,43 +389,6 @@ button {
   text-align: left;
 }
 
-.mock-header {
-  display: flex;
-  flex: none;
-  align-items: center;
-}
-
-.mock-header-status {
-  display: flex;
-  height: 38px;
-  align-items: center;
-  gap: 10px;
-}
-
-.mock-header-indicator {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--attention);
-}
-
-.mock-header-copy {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.mock-header-copy strong {
-  color: var(--text);
-  font-size: 11px;
-  font-weight: 650;
-}
-
-.mock-header-copy small {
-  color: rgba(255, 255, 255, 0.38);
-  font-size: 9px;
-}
-
 .mock-body {
   display: flex;
   min-height: 0;
@@ -426,64 +397,56 @@ button {
   gap: 14px;
 }
 
-.mock-summary {
+.mock-tab-bar {
+  position: relative;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  width: 184px;
+  flex: 0 0 auto;
+  padding: 3px;
+  border-radius: 11px;
+  background: var(--raised);
 }
 
-.mock-eyebrow {
-  margin: 0 0 4px;
-  color: var(--accent-eyebrow);
-  font-size: 10px;
-  font-weight: 750;
-  letter-spacing: 1.1px;
-  text-transform: uppercase;
+.mock-tab-thumb {
+  position: absolute;
+  top: 3px;
+  bottom: 3px;
+  left: 3px;
+  width: calc((100% - 6px) / 2);
+  border-radius: 8px;
+  background: var(--raised-strong);
 }
 
-.mock-title {
-  margin: 0;
-  font-size: 23px;
+.mock-tab {
+  position: relative;
+  flex: 1;
+  padding: 6px 0;
+  color: var(--text-secondary);
+  font-size: 10.5px;
   font-weight: 650;
-  letter-spacing: -0.4px;
-  line-height: 1.2;
+  text-align: center;
 }
 
-.mock-subtle {
-  margin: 4px 0 0;
-  color: rgba(255, 255, 255, 0.43);
-  font-size: 11px;
-  line-height: 1.4;
-}
-
-.mock-badge {
-  padding: 7px 10px;
-  border: 1px solid rgba(89, 214, 255, 0.22);
-  border-radius: var(--radius-pill);
-  background: rgba(89, 214, 255, 0.07);
-  color: var(--accent);
-  font-family: var(--font-mono);
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.7px;
+.mock-tab[data-active="true"] {
+  color: var(--text);
 }
 
 .mock-session-list {
   display: flex;
   flex: none;
   flex-direction: column;
-  gap: 8px;
+  gap: 9px;
 }
 
 .mock-session-row {
   display: flex;
-  min-height: 62px;
+  min-height: 66px;
   flex: none;
   align-items: center;
   padding: 0 15px;
   border: 1px solid var(--hairline);
   border-radius: var(--radius-card);
-  background: rgba(255, 255, 255, 0.02);
+  background: rgba(255, 255, 255, 0.028);
   gap: 13px;
 }
 
@@ -496,17 +459,17 @@ button {
 
 .mock-status-mark.working {
   background: var(--accent);
-  box-shadow: 0 0 0 10px rgba(89, 214, 255, 0.07);
+  box-shadow: 0 0 0 10px rgba(92, 213, 255, 0.07);
 }
 
 .mock-status-mark.attention {
   background: var(--attention);
-  box-shadow: 0 0 0 10px rgba(255, 150, 63, 0.08);
+  box-shadow: 0 0 0 10px rgba(255, 160, 73, 0.08);
 }
 
 .mock-status-mark.complete {
   background: var(--complete);
-  box-shadow: 0 0 0 10px rgba(104, 211, 154, 0.07);
+  box-shadow: 0 0 0 10px rgba(111, 220, 164, 0.07);
 }
 
 /* No halo: an idle session is the one state that should not draw the eye. */
@@ -560,45 +523,6 @@ button {
   color: var(--idle);
 }
 
-.mock-footer {
-  display: flex;
-  min-height: 34px;
-  flex: none;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.mock-diagnostics {
-  display: flex;
-  align-items: center;
-  color: var(--text-faint);
-  font-family: var(--font-mono);
-  font-size: 8px;
-  gap: 8px;
-}
-
-.mock-diagnostics span + span::before {
-  margin-right: 8px;
-  content: "·";
-}
-
-.mock-footer-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.mock-quiet-button {
-  padding: 8px 11px;
-  border-radius: var(--radius-control);
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--text-secondary);
-  font-size: 9px;
-  font-weight: 650;
-}
-
 /* Footer
    ------------------------------------------------------------------------- */
 
@@ -606,38 +530,29 @@ button {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 40px 0 56px;
+  padding: var(--space-7) 0 var(--space-8);
   border-top: 1px solid var(--hairline-strong);
-  color: var(--text-faint);
-  font-size: 0.8125rem;
-  gap: 10px;
-  text-align: center;
-}
-
-.site-footer a {
   color: var(--text-secondary);
-  text-decoration: none;
-}
-
-.site-footer a:hover {
-  color: var(--text);
+  font-size: var(--text-xs);
+  gap: var(--space-3);
+  text-align: center;
 }
 
 .footer-meta {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .footer-meta span + span::before {
-  margin-right: 8px;
+  margin-right: var(--space-2);
   content: "·";
 }
 
 .footnote {
   margin: 0;
-  color: var(--text-faint);
+  color: var(--text-secondary);
 }
 
 /* Responsive
@@ -661,15 +576,15 @@ button {
   }
 
   .shell {
-    padding: 0 16px;
+    padding: 0 var(--space-4);
   }
 
   .hero {
-    padding: 32px 0 0;
+    padding: var(--space-6) 0 0;
   }
 
   .mock-wrapper {
-    margin-top: 40px;
+    margin-top: var(--space-7);
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@fontsource-variable/bricolage-grotesque':
+        specifier: 5.3.0
+        version: 5.3.0
       '@sidecar/core':
         specifier: workspace:*
         version: link:../../packages/sidecar-core
@@ -579,6 +582,9 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@fontsource-variable/bricolage-grotesque@5.3.0':
+    resolution: {integrity: sha512-TLi9Q4hJjS2UvoTMRSS2nHu6c4R56lAw60NR9QYtVRCHn0XtsFpiEhNffZ8Glsoxu6wEEwLKBP8lb94J52PNBA==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1642,6 +1648,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.28.2':
     optional: true
+
+  '@fontsource-variable/bricolage-grotesque@5.3.0': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@sidecar/core':
+        specifier: workspace:*
+        version: link:../../packages/sidecar-core
       react:
         specifier: 19.2.8
         version: 19.2.8


### PR DESCRIPTION
## Summary

- Add a type and spacing system, remove the decorative glow, and fix focus and footer contrast defects without changing marketing copy.
- Use a self-hosted Bricolage Grotesque variable font for the page while preserving the desktop product font inside the mock.
- Rebuild the hero mock from shared fixture data and keep it collapsed except while a non-touch pointer hovers over it.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed
- macOS Electron verification (`./scripts/verify.sh`): passed

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31747392745/artifacts/9199571119) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31747392745)

- Commit: `21ef7ad42f6071df9bca049fb41b3cf9b8512e53`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Landing page inspected at 900 px in normal and reduced-motion modes; live pointer checks confirmed idle compact, hover expanded, and pointer-leave compact states.
