### PR TITLE
feat(desktop): package the Luke brand icon into the macOS app

### DIFF
--- a/apps/desktop/scripts/package-config.mjs
+++ b/apps/desktop/scripts/package-config.mjs
@@ -7,6 +7,18 @@ export const SWIFT_TARGET_TRIPLE = `${PACKAGED_ARCHITECTURE}-apple-macos${MACOS_
 export const LICENSE_RESOURCE_NAME = "LUKE-LICENSE.txt";
 export const MICROPHONE_USAGE_DESCRIPTION =
   "Luke uses microphone input to display live audio activity. Audio is processed locally and is not recorded or uploaded.";
+export const ICONSET_SOURCES = Object.freeze({
+  "icon_16x16.png": "luke-icon-16.png",
+  "icon_16x16@2x.png": "luke-icon-32.png",
+  "icon_32x32.png": "luke-icon-32.png",
+  "icon_32x32@2x.png": "luke-icon-64.png",
+  "icon_128x128.png": "luke-icon-128.png",
+  "icon_128x128@2x.png": "luke-icon-256.png",
+  "icon_256x256.png": "luke-icon-256.png",
+  "icon_256x256@2x.png": "luke-icon-512.png",
+  "icon_512x512.png": "luke-icon-512.png",
+  "icon_512x512@2x.png": "luke-icon-1024.png",
+});
 export const SIGNING_MODE = {
   AD_HOC: "ad-hoc",
   DEVELOPER_ID: "developer-id",
@@ -26,6 +38,10 @@ export function swiftCompilerArguments(source, output) {
   ];
 }
 
+export function iconutilArguments(iconsetPath, icnsPath) {
+  return ["-c", "icns", iconsetPath, "-o", icnsPath];
+}
+
 export function resolveSigningMode(env) {
   const identity =
     typeof env.LUKE_CODESIGN_IDENTITY === "string" ? env.LUKE_CODESIGN_IDENTITY.trim() : "";
@@ -36,6 +52,7 @@ export function createPackagerOptions({
   appRoot,
   outputRoot,
   helperPath,
+  iconPath,
   licensePath,
   entitlementsPath,
   signing,
@@ -54,6 +71,7 @@ export function createPackagerOptions({
     asar: true,
     overwrite: true,
     prune: false,
+    icon: iconPath,
     extraResource: [helperPath, licensePath],
     extendInfo: {
       CFBundleDisplayName: "Luke",

--- a/apps/desktop/scripts/package.mjs
+++ b/apps/desktop/scripts/package.mjs
@@ -5,6 +5,8 @@ import { fileURLToPath } from "node:url";
 import { packager } from "@electron/packager";
 import {
   createPackagerOptions,
+  ICONSET_SOURCES,
+  iconutilArguments,
   LICENSE_RESOURCE_NAME,
   resolveSigningMode,
   SIGNING_MODE,
@@ -19,6 +21,8 @@ const appRoot = path.resolve(scriptDirectory, "..");
 const repoRoot = path.resolve(appRoot, "../..");
 const outputRoot = path.join(appRoot, "out");
 const helperPath = path.join(appRoot, ".build", "native", "mac-screen-geometry");
+const iconsetPath = path.join(appRoot, ".build", "luke.iconset");
+const iconPath = path.join(appRoot, ".build", "Luke.icns");
 const licensePath = path.join(appRoot, ".build", LICENSE_RESOURCE_NAME);
 const entitlementsPath = path.join(appRoot, "native", "macos", "entitlements.plist");
 const desktopPackage = JSON.parse(fs.readFileSync(path.join(appRoot, "package.json"), "utf8"));
@@ -30,12 +34,26 @@ if (!fs.existsSync(helperPath)) {
 
 fs.mkdirSync(path.dirname(licensePath), { recursive: true });
 fs.copyFileSync(path.join(repoRoot, "LICENSE"), licensePath);
+const brandIconDirectory = path.join(repoRoot, "design", "brand", "icon");
+fs.rmSync(iconsetPath, { recursive: true, force: true });
+fs.mkdirSync(iconsetPath, { recursive: true });
+for (const [iconsetName, sourceName] of Object.entries(ICONSET_SOURCES)) {
+  const sourcePath = path.join(brandIconDirectory, sourceName);
+  if (!fs.existsSync(sourcePath)) {
+    throw new Error(`Luke brand icon source is missing: ${sourcePath}`);
+  }
+  fs.copyFileSync(sourcePath, path.join(iconsetPath, iconsetName));
+}
+execFileSync("iconutil", iconutilArguments(iconsetPath, iconPath), {
+  stdio: "inherit",
+});
 fs.rmSync(outputRoot, { recursive: true, force: true });
 const appPaths = await packager(
   createPackagerOptions({
     appRoot,
     outputRoot,
     helperPath,
+    iconPath,
     licensePath,
     entitlementsPath,
     signing,
@@ -50,6 +68,19 @@ if (!fs.existsSync(appPath)) throw new Error(`Packaged app was not found: ${appP
 const packagedLicensePath = path.join(appPath, "Contents", "Resources", LICENSE_RESOURCE_NAME);
 if (!fs.existsSync(packagedLicensePath)) {
   throw new Error(`Packaged app is missing the Luke license: ${packagedLicensePath}`);
+}
+const infoPlistPath = path.join(appPath, "Contents", "Info.plist");
+const bundleIconFile = execFileSync(
+  "plutil",
+  ["-extract", "CFBundleIconFile", "raw", "-o", "-", infoPlistPath],
+  { encoding: "utf8" },
+).trim();
+const packagedIconPath = path.join(appPath, "Contents", "Resources", bundleIconFile);
+if (!fs.existsSync(packagedIconPath)) {
+  throw new Error(`Packaged app is missing its declared icon: ${packagedIconPath}`);
+}
+if (!fs.readFileSync(packagedIconPath).equals(fs.readFileSync(iconPath))) {
+  throw new Error(`Packaged app icon does not match the generated Luke icon: ${packagedIconPath}`);
 }
 
 if (signing.mode === SIGNING_MODE.AD_HOC) {

--- a/design/brand/README.md
+++ b/design/brand/README.md
@@ -71,7 +71,7 @@ keep the full 240×240 canvas — they need headroom to move.
 | `luke-wordmark-{light,dark}.svg` | Face-first caps LUKE wordmark |
 | `luke-wordmark-talking-{light,dark}.svg` | Animated hero: the face talks mid-word |
 | `icon/luke-icon.svg` + `luke-icon-{16…1024}.png` | App icon (squircle tile) |
-| `menubar/luke-menubar-template.svg` + `lukeTemplate{,@2x}.png` | macOS menu-bar template image (pure black + alpha; macOS recolors it). To build an `.icns`: put the icon PNGs in a `.iconset` folder and run `iconutil -c icns` on macOS |
+| `menubar/luke-menubar-template.svg` + `lukeTemplate{,@2x}.png` | macOS menu-bar template image (pure black + alpha; macOS recolors it). Packaging builds `Luke.icns` from the icon PNGs automatically in `apps/desktop/scripts/package.mjs`; no `.icns` is committed |
 | `motion/luke-<state>-{light,dark}.svg` | Animated state marks (below) |
 
 ## Motion states

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -5,6 +5,8 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
   createPackagerOptions,
+  ICONSET_SOURCES,
+  iconutilArguments,
   LICENSE_RESOURCE_NAME,
   MACOS_DEPLOYMENT_TARGET,
   MICROPHONE_USAGE_DESCRIPTION,
@@ -26,12 +28,14 @@ const entitlementsPath = path.join(
   "macos",
   "entitlements.plist",
 );
+const iconPath = "/repo/apps/desktop/.build/Luke.icns";
 
 function packagerOptions(signing = resolveSigningMode({})) {
   return createPackagerOptions({
     appRoot: "/repo/apps/desktop",
     outputRoot: "/repo/apps/desktop/out",
     helperPath: "/repo/apps/desktop/.build/native/mac-screen-geometry",
+    iconPath,
     licensePath: `/repo/apps/desktop/.build/${LICENSE_RESOURCE_NAME}`,
     entitlementsPath,
     signing,
@@ -126,6 +130,59 @@ test("packaging includes the Luke license and approved microphone description", 
     "Luke uses microphone input to display live audio activity. Audio is processed locally and is not recorded or uploaded.",
   );
   assert.equal(options.extendInfo.NSMicrophoneUsageDescription, MICROPHONE_USAGE_DESCRIPTION);
+});
+
+test("packaging uses the generated Luke application icon", () => {
+  assert.equal(packagerOptions().icon, iconPath);
+});
+
+test("the iconset maps every required macOS size to a consistent source PNG", () => {
+  assert.deepEqual(Object.keys(ICONSET_SOURCES), [
+    "icon_16x16.png",
+    "icon_16x16@2x.png",
+    "icon_32x32.png",
+    "icon_32x32@2x.png",
+    "icon_128x128.png",
+    "icon_128x128@2x.png",
+    "icon_256x256.png",
+    "icon_256x256@2x.png",
+    "icon_512x512.png",
+    "icon_512x512@2x.png",
+  ]);
+  assert.deepEqual(ICONSET_SOURCES, {
+    "icon_16x16.png": "luke-icon-16.png",
+    "icon_16x16@2x.png": "luke-icon-32.png",
+    "icon_32x32.png": "luke-icon-32.png",
+    "icon_32x32@2x.png": "luke-icon-64.png",
+    "icon_128x128.png": "luke-icon-128.png",
+    "icon_128x128@2x.png": "luke-icon-256.png",
+    "icon_256x256.png": "luke-icon-256.png",
+    "icon_256x256@2x.png": "luke-icon-512.png",
+    "icon_512x512.png": "luke-icon-512.png",
+    "icon_512x512@2x.png": "luke-icon-1024.png",
+  });
+});
+
+test("every iconset source PNG is committed", () => {
+  const brandIconDirectory = path.join(repoRoot, "design", "brand", "icon");
+
+  for (const sourceName of new Set(Object.values(ICONSET_SOURCES))) {
+    assert.equal(
+      fs.existsSync(path.join(brandIconDirectory, sourceName)),
+      true,
+      `${sourceName} is missing`,
+    );
+  }
+});
+
+test("iconutil receives explicit input and output paths", () => {
+  assert.deepEqual(iconutilArguments("/tmp/luke.iconset", "/tmp/Luke.icns"), [
+    "-c",
+    "icns",
+    "/tmp/luke.iconset",
+    "-o",
+    "/tmp/Luke.icns",
+  ]);
 });
 
 test("signing configuration separates ad-hoc and Developer ID modes", () => {

--- a/scripts/test-macos.sh
+++ b/scripts/test-macos.sh
@@ -20,5 +20,17 @@ if [[ ! -x "$PACKAGED_APP/Contents/Resources/mac-screen-geometry" ]]; then
     printf 'error: packaged app is missing the AppKit screen-geometry helper\n' >&2
     exit 1
 fi
+INFO_PLIST="$PACKAGED_APP/Contents/Info.plist"
+BUNDLE_ICON_FILE=$(plutil -extract CFBundleIconFile raw -o - "$INFO_PLIST")
+PACKAGED_ICON="$PACKAGED_APP/Contents/Resources/$BUNDLE_ICON_FILE"
+GENERATED_ICON="$SIDECAR_DESKTOP_APP_ROOT/.build/Luke.icns"
+if [[ ! -f "$PACKAGED_ICON" ]]; then
+    printf 'error: packaged app is missing its declared icon: %s\n' "$PACKAGED_ICON" >&2
+    exit 1
+fi
+if ! cmp -s "$PACKAGED_ICON" "$GENERATED_ICON"; then
+    printf 'error: packaged app icon does not match the generated Luke icon\n' >&2
+    exit 1
+fi
 
 printf 'Packaged macOS app: %s\n' "$PACKAGED_APP"


### PR DESCRIPTION
## Summary

- build `Luke.icns` from the committed brand PNGs during macOS packaging
- configure Electron Packager to use the generated icon and verify the packaged bundle declares and contains it
- add portable icon-source coverage plus a macOS bundle assertion

## Verification

- `./scripts/check.sh`
- `./scripts/verify.sh`
- `./scripts/test-macos.sh`
- inspected the generated `.icns` and expanded fixture evidence

The physical-notch check was not performed because this change only affects the packaged application icon.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31745795563/artifacts/9198939411) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31745795563)

- Commit: `73779ba6646b9b5fff80120abf3999f6f1a3e886`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
