### PR TITLE
fix(panel): unfold as many provider marks as the panel's wing holds

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -761,6 +761,8 @@ export function App(): React.JSX.Element {
         analyser={analyser}
         fixtureSpeaking={fixtureSpeaking}
         hasAudioSignal={hasAudioSignal}
+        presentation={presentation}
+        housingWidth={display.notch.housingWidth}
       />
 
       <div className="compact-stage">

--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -1,6 +1,8 @@
-import { useState } from "react";
+import { CAPSULE_SIDE_WIDTH, PANEL_WIDTH, PEEK_SIDE_GROWTH } from "@sidecar/core";
+import { useEffect, useState } from "react";
 import { LukeFace } from "./luke-face";
 import { useFaceMotion, usePrefersReducedMotion } from "./luke-face-mood";
+import { PANEL_PRESENTATION, type PanelPresentation } from "./panel-state";
 import { ProviderMark } from "./provider-marks";
 import { type SessionTally, tallyCaption, tallySummary } from "./session-model";
 import { Waveform } from "./waveform";
@@ -16,22 +18,51 @@ interface NotchWingsProps {
   analyser?: AnalyserNode;
   fixtureSpeaking: boolean;
   hasAudioSignal: boolean;
-  providerLimit?: number;
+  presentation: PanelPresentation;
+  housingWidth: number;
 }
 
 /**
- * Four marks are what the peek holds once the face has taken the place nearest
- * the housing: the face and its gap cost 26px of the 106px between the wing's
- * insets, and each mark past the first costs 21px of the 80px that remain.
+ * What one wing costs to fill, in the stylesheet's numbers: `--wing-inset` on
+ * both sides, then the face and its gap, then a first mark and a gap-and-mark
+ * for every mark after it.
  */
-const DEFAULT_PROVIDER_LIMIT = 4;
+const WING_INSETS = 18;
+const FACE_AND_GAP = 26;
+const MARK_WIDTH = 14;
+const MARK_AND_GAP = 21;
+
+/**
+ * How many marks fit beside the face in a wing of this width. The peek's side
+ * is fixed at 124px whatever the housing measures, which is where the old
+ * limit of four came from: the face and its gap cost 26px of the 106px between
+ * the wing's insets, and each mark past the first costs 21px of the 80px that
+ * remain. The panel's side is what is left of `--panel-width` after the
+ * housing, so it holds roughly twice as many.
+ */
+export function wingMarkCapacity(sideWidth: number): number {
+  const beyondFirst = Math.floor(
+    (sideWidth - WING_INSETS - FACE_AND_GAP - MARK_WIDTH) / MARK_AND_GAP,
+  );
+  return Math.max(1, 1 + beyondFirst);
+}
+
+const PEEK_SIDE_WIDTH = CAPSULE_SIDE_WIDTH + PEEK_SIDE_GROWTH;
+
+/**
+ * `--duration-exit`: the fade the marks leave on. A capacity that shrinks —
+ * the panel closing back past the peek — must not unmount marks that are
+ * mid-fade, so the smaller set is drawn only once the fade has finished.
+ */
+const MARK_EXIT_MS = 90;
 
 export function NotchWings({
   tally,
   analyser,
   fixtureSpeaking,
   hasAudioSignal,
-  providerLimit = DEFAULT_PROVIDER_LIMIT,
+  presentation,
+  housingWidth,
 }: NotchWingsProps): React.JSX.Element {
   const [voiceActive, setVoiceActive] = useState(false);
   // Guarded rather than reset: a microphone that has been closed cannot still be
@@ -49,12 +80,30 @@ export function NotchWings({
     usePrefersReducedMotion(),
   );
 
+  // The wing is bounded by the shape its state draws, so its capacity is too:
+  // the panel's side holds more marks than the peek's, and every other state
+  // keeps the peek's capacity because that is the set the next peek unfolds.
+  const capacity =
+    presentation === PANEL_PRESENTATION.PANEL
+      ? wingMarkCapacity((PANEL_WIDTH - housingWidth) / 2)
+      : wingMarkCapacity(PEEK_SIDE_WIDTH);
+  const [drawnCapacity, setDrawnCapacity] = useState(capacity);
+  // Growing applies in the same render, so the new marks are already mounted
+  // when the presentation flips and unfold with everything else. Shrinking
+  // waits out the exit fade below.
+  if (capacity > drawnCapacity) setDrawnCapacity(capacity);
+  useEffect(() => {
+    if (capacity >= drawnCapacity) return;
+    const timer = window.setTimeout(() => setDrawnCapacity(capacity), MARK_EXIT_MS);
+    return () => window.clearTimeout(timer);
+  }, [capacity, drawnCapacity]);
+
   // The marks are a summary, and a summary that hides its own remainder reads as
   // a complete list, so whatever does not fit is counted rather than dropped.
   // The count is a slot like any other, so it takes the last one rather than
   // being added past the edge of the peek.
-  const overflowing = tally.providers.length > providerLimit;
-  const providers = tally.providers.slice(0, overflowing ? providerLimit - 1 : providerLimit);
+  const overflowing = tally.providers.length > drawnCapacity;
+  const providers = tally.providers.slice(0, overflowing ? drawnCapacity - 1 : drawnCapacity);
   const unshown = tally.providers.length - providers.length;
 
   return (

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -571,6 +571,21 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   transition-delay: var(--peek-delay);
 }
 
+/* A mark can mount into a wing that is already unfolded — the panel's wing
+   holds more marks than the peek's, and opening the panel is what mounts the
+   extra ones — and a transition only runs from a style the element has held.
+   This is the pose every mark waits in above, so a mark that arrives late
+   unfolds on the same gesture as the rest instead of appearing in place. */
+@starting-style {
+  .app-stage[data-presentation="peek"] .wing-mark,
+  .app-stage[data-presentation="peek"] .wing-more,
+  .app-stage[data-presentation="panel"] .wing-mark,
+  .app-stage[data-presentation="panel"] .wing-more {
+    opacity: 0;
+    transform: translateX(8px);
+  }
+}
+
 /* More providers than the wing can hold. Counted rather than dropped, at the
    far end of the row, where it reads as the remainder of a list. */
 .wing-more {

--- a/apps/desktop/tests/notch-wings.test.ts
+++ b/apps/desktop/tests/notch-wings.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { CAPSULE_SIDE_WIDTH, PANEL_WIDTH, PEEK_SIDE_GROWTH } from "@sidecar/core";
+import { wingMarkCapacity } from "../src/renderer/notch-wings";
+
+const peekSideWidth = CAPSULE_SIDE_WIDTH + PEEK_SIDE_GROWTH;
+const panelSideWidth = (housingWidth: number) => (PANEL_WIDTH - housingWidth) / 2;
+
+test("the peek's fixed side holds the four marks it always has", () => {
+  assert.equal(wingMarkCapacity(peekSideWidth), 4);
+});
+
+test("the panel's side holds what is left after the housing", () => {
+  // The fixture display's 210px housing: (620 - 210) / 2 = 205px a side.
+  assert.equal(wingMarkCapacity(panelSideWidth(210)), 8);
+  // No housing at all — a display without a notch — leaves the most room.
+  assert.equal(wingMarkCapacity(panelSideWidth(0)), 13);
+});
+
+test("a wider housing costs marks rather than clipping them", () => {
+  assert.ok(wingMarkCapacity(panelSideWidth(300)) < wingMarkCapacity(panelSideWidth(210)));
+});
+
+test("a wing too narrow for the arithmetic still shows one mark", () => {
+  assert.equal(wingMarkCapacity(0), 1);
+});

--- a/packages/sidecar-core/src/geometry.ts
+++ b/packages/sidecar-core/src/geometry.ts
@@ -50,8 +50,9 @@ export interface NotchWindowLayout extends Rectangle {
 export const CAPSULE_SIDE_WIDTH = 36;
 export const PEEK_SIDE_GROWTH = 88;
 export const SURFACE_MARGIN = 40;
+/** `--panel-width` in the renderer's stylesheet; the two must agree. */
+export const PANEL_WIDTH = 620;
 const peekSideWidth = CAPSULE_SIDE_WIDTH + PEEK_SIDE_GROWTH;
-const panelWidth = 620;
 const panelHeight = 520;
 
 export function resolveNotchGeometry(
@@ -84,7 +85,7 @@ export function positionNotchWindow(
   const housingWidth = notch.hasNotch ? notch.housingWidth : 0;
   const width =
     mode === "expanded"
-      ? Math.min(panelWidth + SURFACE_MARGIN * 2, display.bounds.width)
+      ? Math.min(PANEL_WIDTH + SURFACE_MARGIN * 2, display.bounds.width)
       : Math.min(housingWidth + peekSideWidth * 2 + SURFACE_MARGIN * 2, display.bounds.width);
   const height =
     mode === "expanded"


### PR DESCRIPTION
The strip beside the housing was showing three provider marks and a `+N` in
the expanded panel, exactly as it does in the peek — the wing's mark capacity
was a single constant sized to the peek's fixed 124px side, even though an
open panel bounds the wing by `--panel-width` instead.

The capacity is now derived from the width the drawn shape actually gives the
wing, with the same arithmetic the old constant's comment reasoned from
(insets, the face and its gap, a first mark, and a gap-and-mark for each one
after):

| state | wing side | marks |
| --- | --- | --- |
| peek | 124px, fixed | 4 — unchanged |
| panel | `(620 − housing) / 2` | 8 on the fixture's 210px housing; 13 with no housing |

So the smoke fixture's five providers now all draw their marks in the
expanded panel, while the peek keeps counting the remainder it cannot fit.

Two motion details ride along, per the panel-motion rules:

- A capacity that grows mounts its new marks in the same render the
  presentation flips, and a `@starting-style` pose lets a mark that mounts
  into an already-unfolded wing enter on the same spring as the rest instead
  of appearing in place.
- A capacity that shrinks waits out `--duration-exit` before the smaller set
  is drawn, so collapsing the panel never unmounts a mark mid-fade.

`PANEL_WIDTH` moves to an exported constant in `@sidecar/core` geometry so the
renderer and the window-sizing arithmetic share one number.

## Verification

- `./scripts/check.sh` — passes (24 harness, 41 core, and 216 desktop tests;
  lint, typecheck, and builds).
- New unit tests pin the capacity arithmetic: the peek still holds exactly the
  four marks it always has, the fixture's panel wing holds eight, a wider
  housing costs marks rather than clipping them, and a degenerate width still
  shows one mark.
- macOS packaging and visual evidence come from CI (this was written in a
  Linux cloud sandbox): the `macOS app and evidence` job ran `./scripts/verify.sh`
  and passed; the screenshots below are the deterministic captures from that run,
  inspected before merging.
- Physical-notch check: not performed.

## Screenshot evidence

Deterministic smoke-fixture captures from the CI evidence artifact (five
providers in the fixture). The PNGs are hosted in a
[secret gist](https://gist.github.com/dastratakos/e597ffc9cdb077d2edc25bac1157d796)
rather than committed, per the repository's evidence rules.

**Expanded panel — all five provider marks now drawn (was three + `+2`):**

<img src="https://gist.github.com/dastratakos/e597ffc9cdb077d2edc25bac1157d796/raw/app-smoke-expanded.png" width="560" alt="Expanded panel with five provider marks beside the face" />

**Peek — unchanged, still three marks and a counted `+2` remainder:**

<img src="https://gist.github.com/dastratakos/e597ffc9cdb077d2edc25bac1157d796/raw/app-smoke-peek.png" width="430" alt="Peek with three provider marks and a +2 remainder" />

<details>
<summary>Other states (unchanged): capsule, key slot, speaking peek</summary>

<img src="https://gist.github.com/dastratakos/e597ffc9cdb077d2edc25bac1157d796/raw/app-smoke-compact.png" width="430" alt="Compact capsule" />
<img src="https://gist.github.com/dastratakos/e597ffc9cdb077d2edc25bac1157d796/raw/app-smoke-slot.png" width="560" alt="Key slot" />
<img src="https://gist.github.com/dastratakos/e597ffc9cdb077d2edc25bac1157d796/raw/app-smoke-speaking.png" width="430" alt="Speaking peek with the meter" />

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a5e9f5c7-720d-4c7a-b599-e0d799ce411d)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31746597744/artifacts/9199257914) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31746597744)

- Commit: `7c3589836742cf7a81706018fcb0f90fe4d22436`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

