### PR TITLE
feat(sessions): carry state in the row's words rather than a chip

### DIFF
--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -75,6 +75,20 @@ const CONDUCTOR_SESSION_STATUS = {
   ERROR: "error",
 } as const;
 
+/**
+ * Which chat gets to speak for its workspace, most urgent first. A failure
+ * outranks a question — both want a person, but only one of them is stuck —
+ * a question outranks work still running, and anything known outranks a chat
+ * whose status could not be read.
+ */
+const STATUS_URGENCY: readonly SessionStatus[] = [
+  SESSION_STATUS.ERROR,
+  SESSION_STATUS.WAITING,
+  SESSION_STATUS.WORKING,
+  SESSION_STATUS.COMPLETE,
+  SESSION_STATUS.UNKNOWN,
+];
+
 type ConductorSessionStatus =
   (typeof CONDUCTOR_SESSION_STATUS)[keyof typeof CONDUCTOR_SESSION_STATUS];
 
@@ -144,6 +158,9 @@ interface ConductorSession {
  * Observes Conductor cloud sessions through the documented public API. It reads
  * only workspaces the authenticated user created, issues no request that can
  * change provider state, and reports nothing at all without a credential.
+ * Each workspace is reported as one session — the workspace is the unit
+ * Conductor's own surface shows, and the one its name names — in the state of
+ * whichever chat inside it most needs a person.
  */
 export class ConductorSessionAdapter extends CloudSessionAdapter {
   readonly #maximumObservedWorkspaces: number;
@@ -215,10 +232,28 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
       .flat()
       .slice(0, this.#maximumObservedSessions);
 
-    const observations = await Promise.all(
-      sessions.map((session) => this.#observationFor(request, session, now)),
+    const observed = await Promise.all(
+      sessions.map((session) =>
+        this.#observationFor(request, session, now).then(
+          (observation) => observation && { workspaceId: session.workspace.id, observation },
+        ),
+      ),
     );
-    return observations.filter(isDefined);
+
+    // One row per workspace. The workspace is the session the user knows —
+    // it is what titles the row — so two chats inside it would draw as
+    // identical lines that open different places. Every chat's status is
+    // still read, because the workspace is in whatever state its neediest
+    // chat is in; that chat is the one the row reports and the one a press
+    // opens.
+    const byWorkspace = new Map<string, ProviderSessionObservation>();
+    for (const { workspaceId, observation } of observed.filter(isDefined)) {
+      const held = byWorkspace.get(workspaceId);
+      if (!held || urgencyOrder(observation, held) < 0) {
+        byWorkspace.set(workspaceId, observation);
+      }
+    }
+    return [...byWorkspace.values()];
   }
 
   async #identity(request: CloudRequest): Promise<string | undefined> {
@@ -425,6 +460,17 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
       ...(errorMessage ? { errorMessage } : {}),
     };
   }
+}
+
+/** Most urgent first, and between two equally urgent chats, the one that moved last. */
+function urgencyOrder(
+  first: ProviderSessionObservation,
+  second: ProviderSessionObservation,
+): number {
+  return (
+    STATUS_URGENCY.indexOf(first.status) - STATUS_URGENCY.indexOf(second.status) ||
+    second.observedAt - first.observedAt
+  );
 }
 
 /** Conductor reports the model it resolved as well as the one that was asked for. */

--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -78,15 +78,21 @@ const CONDUCTOR_SESSION_STATUS = {
 /**
  * Which chat gets to speak for its workspace, most urgent first. A failure
  * outranks a question — both want a person, but only one of them is stuck —
- * a question outranks work still running, and anything known outranks a chat
- * whose status could not be read.
+ * and a question outranks work still running.
+ *
+ * Unknown outranks complete, which reads backwards until the provider's shapes
+ * are laid over it: complete only ever comes from an archived chat, and unknown
+ * is an open one — idle long enough to decay, or with a status that could not
+ * be read. However quiet, the open chat is where the user would return, so a
+ * closed sibling must not make the workspace read as finished or take the
+ * press that would have landed there.
  */
 const STATUS_URGENCY: readonly SessionStatus[] = [
   SESSION_STATUS.ERROR,
   SESSION_STATUS.WAITING,
   SESSION_STATUS.WORKING,
-  SESSION_STATUS.COMPLETE,
   SESSION_STATUS.UNKNOWN,
+  SESSION_STATUS.COMPLETE,
 ];
 
 type ConductorSessionStatus =

--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -133,7 +133,6 @@ interface ConductorWorkspace {
 
 interface ConductorSession {
   id: string;
-  name?: string;
   workspace: ConductorWorkspace;
   archived: boolean;
   archivedAt?: number;
@@ -302,17 +301,15 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
           if (!id) return undefined;
           const archivedAt = timestampFromRecord(record, CONDUCTOR_FIELD.ARCHIVED_AT);
           const model = modelLabel(record);
-          const name = textFromRecord(record, CONDUCTOR_FIELD.NAME)?.slice(
-            0,
-            maximumSessionTitleLength,
-          );
           const deepLink = textFromRecord(record, CONDUCTOR_FIELD.DEEP_LINK);
+          // The chat's own `name` is deliberately not read: Conductor generates
+          // it, nobody chose it, and the one thing it ever did here — titling
+          // the row — belongs to the workspace's name instead.
           return {
             id,
             workspace,
             archived: textFromRecord(record, CONDUCTOR_FIELD.ARCHIVED_AT) !== undefined,
             ...(archivedAt === undefined ? {} : { archivedAt }),
-            ...(name ? { name } : {}),
             ...(model ? { model } : {}),
             ...(deepLink ? { deepLink } : {}),
           };
@@ -359,15 +356,16 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
     const status = this.#statusFor(session, reported?.status, observedAt, now);
     return {
       providerSessionId: session.id,
-      // A workspace holds several chats and a project holds several workspaces,
-      // so labelling by the project's repository gave every session in a repo
-      // the same row. The session's own name is what separates them.
-      title: session.name ?? session.workspace.name ?? session.workspace.repositoryLabel,
+      // The workspace's name is the name the user knows this work by — it is
+      // what Conductor itself shows them — where a chat's own name is generated
+      // and identifies nothing. So the workspace titles the row, and it is not
+      // reported as a branch: it never was one, and the surface now draws a
+      // branch under a glyph that says so.
+      title: session.workspace.name ?? session.workspace.repositoryLabel,
       status,
       observedAt,
       detail: {
         repository: session.workspace.repositoryLabel,
-        ...(session.workspace.name ? { branch: session.workspace.name } : {}),
         ...(session.model ? { model: session.model } : {}),
         ...(reported?.errorMessage ? { error: reported.errorMessage } : {}),
         ...(session.deepLink ? { link: session.deepLink } : {}),

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1,4 +1,4 @@
-import type { NormalizedSession } from "@sidecar/core";
+import { FIXTURE_EPOCH_MS, type NormalizedSession } from "@sidecar/core";
 import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
 import type {
   AppBootstrap,
@@ -168,6 +168,9 @@ export function App(): React.JSX.Element {
   const [microphoneError, setMicrophoneError] = useState<string>();
   const [analyser, setAnalyser] = useState<AnalyserNode>();
   const [entry, setEntry] = useState<CredentialEntry>();
+  // Counts for nothing except having changed: each tick re-renders the rows so
+  // their "how long ago" labels stay honest while they are on screen.
+  const [, setClock] = useState(0);
   const [panelElement, panelHeight] = useShapeHeight();
   const [slotElement, slotHeight] = useShapeHeight();
   const audioContext = useRef<AudioContext | undefined>(undefined);
@@ -658,6 +661,20 @@ export function App(): React.JSX.Element {
     return () => window.removeEventListener("keydown", handleKey);
   }, [cancelEntry, changeMode, changeTab, optionsOpen, presentation, tab]);
 
+  // The rows say how long ago each session was seen, and a label left alone
+  // goes stale the moment a minute passes with no session changing — the very
+  // sessions worth noticing are the ones nothing is updating. A slow tick keeps
+  // the labels honest, and only while they are on screen: the labels are
+  // minute-grained, so half a minute is as fine as the answer gets. Fixture
+  // rows are read against a fixed epoch, so for them a tick could only change
+  // nothing — and a capture run must not risk a re-render mid-shutter.
+  useEffect(() => {
+    if (presentation !== PANEL_PRESENTATION.PANEL) return;
+    if (bootstrap?.fixtureMode !== false) return;
+    const timer = window.setInterval(() => setClock((tick) => tick + 1), 30_000);
+    return () => window.clearInterval(timer);
+  }, [presentation, bootstrap?.fixtureMode]);
+
   // A press anywhere else is the same dismissal Escape is, and the one a sheet
   // over a list has to answer: what is behind it can only be reached by asking
   // it to move, so pressing there has to be what asks. The press is taken on the
@@ -702,6 +719,10 @@ export function App(): React.JSX.Element {
   // the next session to arrive would open it again with nothing pressed.
   const offerOptions = tab === PANEL_TAB.SESSIONS && list.total > 1;
   if (optionsOpen && !offerOptions) setOptionsOpen(false);
+  // Which clock the rows' ages are honest against. Fixture observations are
+  // measured back from the fixture's own epoch precisely so that no capture
+  // run reads them against the time it happened to run at.
+  const now = bootstrap.fixtureMode ? FIXTURE_EPOCH_MS : Date.now();
   const fixtureSpeaking = bootstrap.profile === "speaking";
   const hasAudioSignal = fixtureSpeaking || analyser !== undefined;
   const panelOpen = presentation === PANEL_PRESENTATION.PANEL;
@@ -732,6 +753,7 @@ export function App(): React.JSX.Element {
             list={list}
             view={sessionView}
             onViewChange={changeSessionView}
+            now={now}
             onOpenSession={openSession}
             offerOptions={offerOptions}
             optionsOpen={optionsOpen}

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -1,13 +1,19 @@
-import { SESSION_LOCATION } from "@sidecar/core";
+import { SESSION_LOCATION, SESSION_STATE } from "@sidecar/core";
 import { PANEL_TAB, type PanelTab, TabBar } from "./panel-tabs";
 import { CloudBadge, ProviderMark } from "./provider-marks";
-import type { ArrangedSessions, DisplaySession, SessionView } from "./session-model";
 import {
+  type ArrangedSessions,
+  type DisplaySession,
+  observedAgoLabel,
+  type SessionView,
+} from "./session-model";
+import {
+  BranchGlyph,
+  CheckGlyph,
   EmptyState,
   SessionOptions,
   SessionOptionsButton,
   SessionsPanel,
-  StateChip,
 } from "./session-parts";
 import { SettingsPanel, type SettingsPanelProps } from "./settings-panel";
 
@@ -19,14 +25,27 @@ import { SettingsPanel, type SettingsPanelProps } from "./settings-panel";
  * separates them — a row that can be opened lifts and takes the hand cursor,
  * one that cannot stays flat under it, which is the honest answer to whether
  * pressing would do anything.
+ *
+ * The state rides the sentence under the title rather than a control-shaped
+ * chip beside it: a spinner leads a working row, a check a finished one, and a
+ * session that needs a person says so in the attention colour — the one colour
+ * on the row, spent only where someone is needed. The label is still spoken to
+ * a screen reader ahead of a sentence that would not otherwise carry it.
+ *
+ * The provider is its mark, and only its mark: naming it again in words was the
+ * subtitle saying what the row's left edge already says. The mark's hover
+ * answers with the name — and the model, which identifies the session to nobody
+ * and so earns a hover rather than a line.
  */
 function SessionRow({
   session,
   index,
+  now,
   onOpen,
 }: {
   session: DisplaySession;
   index: number;
+  now: number;
   onOpen: (session: DisplaySession) => void;
 }): React.JSX.Element {
   const shared = {
@@ -34,18 +53,42 @@ function SessionRow({
     "data-state": session.state,
     style: { "--row-index": index + 1 } as React.CSSProperties,
   };
+  // The identifier that tells this row from its neighbours: the branch, or the
+  // repository where a provider reported no branch. The glyph belongs to the
+  // branch alone — under a repository name it would say the wrong thing.
+  const place = session.branch ?? session.repository;
   const content = (
     <>
-      <span className="row-avatar">
+      <span
+        className="row-mark"
+        title={session.model ? `${session.provider} · ${session.model}` : session.provider}
+      >
+        <span className="visually-hidden">{session.provider}</span>
         <ProviderMark providerId={session.providerId} />
         {session.location === SESSION_LOCATION.CLOUD ? <CloudBadge /> : null}
       </span>
       <span className="row-copy">
         <strong>{session.title}</strong>
-        {session.detail ? <small>{session.detail}</small> : null}
-        <small className="row-context">{session.context}</small>
+        <small className="row-doing">
+          {session.state === SESSION_STATE.WORKING ? (
+            <span className="row-spinner" aria-hidden="true" />
+          ) : null}
+          {session.state === SESSION_STATE.COMPLETE ? <CheckGlyph /> : null}
+          <span className="row-doing-text">
+            {session.detail === session.label ? null : (
+              <span className="visually-hidden">{session.label}. </span>
+            )}
+            {session.detail}
+          </span>
+        </small>
+        {place ? (
+          <small className="row-place">
+            {session.branch ? <BranchGlyph /> : null}
+            <span>{place}</span>
+          </small>
+        ) : null}
       </span>
-      <StateChip state={session.state} label={session.label} />
+      <small className="row-when">{observedAgoLabel(session.observedAt, now)}</small>
     </>
   );
 
@@ -69,6 +112,12 @@ export interface PanelBodyProps {
   list: ArrangedSessions;
   view: SessionView;
   onViewChange: (view: SessionView) => void;
+  /**
+   * The instant the rows' ages are read against. Passed down rather than read
+   * here, because only the app knows which clock is honest: the wall clock for
+   * live sessions, the fixture's own epoch for fixture rows.
+   */
+  now: number;
   /** Sends the pressed session to its provider, wherever the provider keeps it. */
   onOpenSession: (session: DisplaySession) => void;
   /**
@@ -89,6 +138,7 @@ export function PanelBody({
   list,
   view,
   onViewChange,
+  now,
   onOpenSession,
   offerOptions,
   optionsOpen,
@@ -124,6 +174,7 @@ export function PanelBody({
                   key={session.id}
                   session={session}
                   index={index}
+                  now={now}
                   onOpen={onOpenSession}
                 />
               ))

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -19,8 +19,6 @@ export const STATE_LABEL: Record<SessionState, string> = {
   [SESSION_STATE.UNKNOWN]: "Idle",
 };
 
-const CONTEXT_SEPARATOR = " · ";
-
 /** The state order the surface reads top-down and the badge collapses to. */
 const STATE_PRIORITY: readonly SessionState[] = [
   SESSION_STATE.ATTENTION,
@@ -85,10 +83,17 @@ export interface DisplaySession {
   title: string;
   providerId: string;
   provider: string;
-  /** What the session is doing, or what stopped it. */
+  /** What the session is doing, or what stopped it, worded to carry the state. */
   detail: string;
-  /** Where it is doing it: provider, repository, branch, model. */
-  context: string;
+  /**
+   * Which checkout the work is in. Two fields rather than one line, because the
+   * row draws a branch under its own glyph and a repository plain, and only the
+   * fields can say which kind of identifier this is.
+   */
+  repository?: string;
+  branch?: string;
+  /** Read on the provider mark's hover, never spent on a line of the row. */
+  model?: string;
   state: SessionState;
   label: string;
   location: SessionLocation;
@@ -163,27 +168,13 @@ function sessionNeedsAttention(session: NormalizedSession): boolean {
  * The line under the title. What stopped a session outranks what it was doing,
  * and what it was doing outranks the recap of a turn that has already ended.
  *
- * It is empty when a provider reported none of them. Falling back to the status
- * would only restate the chip at the other end of the same row.
+ * When a provider reported none of them, the line says the state in so many
+ * words. This sentence is the one place the row states it — there is no chip at
+ * the other end any more — so a session whose provider said nothing still reads
+ * as Working or Complete rather than as a row with a line missing.
  */
-function sessionDetail(session: NormalizedSession): string {
-  return session.detail.error ?? session.detail.activity ?? session.summary ?? "";
-}
-
-/**
- * The line under that. It answers "which one is this?" for the rows that would
- * otherwise read alike — two checkouts of one repository, or one repository on
- * two branches.
- */
-function sessionContext(session: NormalizedSession): string {
-  return [
-    session.provider.displayName,
-    session.detail.repository,
-    session.detail.branch,
-    session.detail.model,
-  ]
-    .filter((part): part is string => part !== undefined && part.length > 0)
-    .join(CONTEXT_SEPARATOR);
+function sessionDetail(session: NormalizedSession, state: SessionState): string {
+  return session.detail.error ?? session.detail.activity ?? session.summary ?? STATE_LABEL[state];
 }
 
 function sessionState(session: NormalizedSession): SessionState {
@@ -213,6 +204,10 @@ export function displaySessions(
   const visible: readonly DisplaySession[] = bootstrap.fixtureMode
     ? bootstrap.fixture.sessions.map((session) => ({
         ...session,
+        // The same wording rule the live path applies: a fixture row whose
+        // provider said nothing states its own state, so the evidence shows
+        // the fallback rather than a gap.
+        detail: session.detail || STATE_LABEL[session.state],
         label: STATE_LABEL[session.state],
         // A fixture stands for sessions that are not on the machine drawing
         // them, so there is nothing for a press to open. Nothing is lost from
@@ -220,19 +215,24 @@ export function displaySessions(
         // cannot are drawn alike until a pointer is over one.
         openable: false,
       }))
-    : sessions.map((session) => ({
-        id: session.providerSessionId,
-        title: session.title,
-        providerId: session.providerId,
-        provider: session.provider.displayName,
-        detail: sessionDetail(session),
-        context: sessionContext(session),
-        state: sessionState(session),
-        label: STATE_LABEL[sessionState(session)],
-        location: session.location,
-        observedAt: session.observedAt,
-        openable: session.detail.link !== undefined,
-      }));
+    : sessions.map((session) => {
+        const state = sessionState(session);
+        return {
+          id: session.providerSessionId,
+          title: session.title,
+          providerId: session.providerId,
+          provider: session.provider.displayName,
+          detail: sessionDetail(session, state),
+          repository: session.detail.repository,
+          branch: session.detail.branch,
+          model: session.detail.model,
+          state,
+          label: STATE_LABEL[state],
+          location: session.location,
+          observedAt: session.observedAt,
+          openable: session.detail.link !== undefined,
+        };
+      });
 
   return [...visible].sort(byUrgency);
 }
@@ -380,6 +380,25 @@ export function tallySummary(tally: SessionTally): string {
   }
   if (tally.working > 0) return `${tally.total} ${sessionWord} tracked, ${tally.working} working`;
   return `${tally.total} ${sessionWord} tracked`;
+}
+
+/**
+ * How long ago a session was last seen, in the coarsest unit that has begun,
+ * because the label answers "is this thing alive" rather than telling time.
+ * Anything under a minute is "Now" — and so is a timestamp ahead of the clock,
+ * which a provider's clock skew can produce and a negative age would only
+ * dramatize. `now` is an argument rather than a clock read here: fixture rows
+ * are measured against the fixture's own epoch so the evidence stays
+ * reproducible, and live rows against whatever render tick asked.
+ */
+export function observedAgoLabel(observedAt: number, now: number): string {
+  const elapsedMinutes = Math.floor((now - observedAt) / 60_000);
+  if (elapsedMinutes < 1) return "Now";
+  if (elapsedMinutes < 60) return `${elapsedMinutes} min`;
+  const elapsedHours = Math.floor(elapsedMinutes / 60);
+  if (elapsedHours < 24) return `${elapsedHours} hr`;
+  const elapsedDays = Math.floor(elapsedHours / 24);
+  return `${elapsedDays} ${elapsedDays === 1 ? "day" : "days"}`;
 }
 
 /**

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -385,20 +385,21 @@ export function tallySummary(tally: SessionTally): string {
 /**
  * How long ago a session was last seen, in the coarsest unit that has begun,
  * because the label answers "is this thing alive" rather than telling time.
- * Anything under a minute is "Now" — and so is a timestamp ahead of the clock,
- * which a provider's clock skew can produce and a negative age would only
- * dramatize. `now` is an argument rather than a clock read here: fixture rows
- * are measured against the fixture's own epoch so the evidence stays
- * reproducible, and live rows against whatever render tick asked.
+ * Single-letter units, the way Mail and Messages abbreviate: the label is
+ * consulted, not read, and "23m" against the row's edge says everything
+ * "23 min" did. Anything under a minute is "Now" — and so is a timestamp ahead
+ * of the clock, which a provider's clock skew can produce and a negative age
+ * would only dramatize. `now` is an argument rather than a clock read here:
+ * fixture rows are measured against the fixture's own epoch so the evidence
+ * stays reproducible, and live rows against whatever render tick asked.
  */
 export function observedAgoLabel(observedAt: number, now: number): string {
   const elapsedMinutes = Math.floor((now - observedAt) / 60_000);
   if (elapsedMinutes < 1) return "Now";
-  if (elapsedMinutes < 60) return `${elapsedMinutes} min`;
+  if (elapsedMinutes < 60) return `${elapsedMinutes}m`;
   const elapsedHours = Math.floor(elapsedMinutes / 60);
-  if (elapsedHours < 24) return `${elapsedHours} hr`;
-  const elapsedDays = Math.floor(elapsedHours / 24);
-  return `${elapsedDays} ${elapsedDays === 1 ? "day" : "days"}`;
+  if (elapsedHours < 24) return `${elapsedHours}h`;
+  return `${Math.floor(elapsedHours / 24)}d`;
 }
 
 /**

--- a/apps/desktop/src/renderer/session-parts.tsx
+++ b/apps/desktop/src/renderer/session-parts.tsx
@@ -1,4 +1,3 @@
-import type { SessionState } from "@sidecar/core";
 import { PANEL_TAB, panelPanelId, panelTabId } from "./panel-tabs";
 import { ProviderMark } from "./provider-marks";
 import {
@@ -12,18 +11,37 @@ import {
 } from "./session-model";
 import { CloudIcon, LaptopIcon, OptionsIcon } from "./settings-icons";
 
-export function StateChip({
-  state,
-  label,
-}: {
-  state: SessionState;
-  label: string;
-}): React.JSX.Element {
+/**
+ * Rides beside a branch name to say which kind of identifier it is: a branch
+ * name alone reads as any string of slashes. Ours rather than a brand, so it is
+ * drawn in whatever text colour the line already has.
+ */
+export function BranchGlyph(): React.JSX.Element {
   return (
-    <span className="state-chip" data-state={state}>
-      <span className="state-dot" aria-hidden="true" />
-      {label}
-    </span>
+    <svg className="row-branch-glyph" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+      <g fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round">
+        <circle cx="4.2" cy="3.4" r="1.55" />
+        <circle cx="4.2" cy="12.6" r="1.55" />
+        <circle cx="11.8" cy="5.2" r="1.55" />
+        <path d="M4.2 5v6M11.8 6.9c0 2.5-2.6 3-5.4 3.4" />
+      </g>
+    </svg>
+  );
+}
+
+/** Leads a finished session's sentence, the way a spinner leads a working one. */
+export function CheckGlyph(): React.JSX.Element {
+  return (
+    <svg className="row-check" viewBox="0 0 12 12" aria-hidden="true" focusable="false">
+      <path
+        d="M2.4 6.6l2.5 2.5 4.7-5.6"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.7"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
   );
 }
 

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -159,6 +159,12 @@
      every motion holds its first frame, which is the resting pose every one of
      them starts from — head upright, eyes open. */
   --face-motion: running;
+  /* The other loop with no end to wait for: the spinner on a working row. Its
+     own token rather than the face's, because the face's is about Luke and this
+     one is about the sessions, but it stops in the same two places for the same
+     two reasons — a capture must land on one frame, and reduced motion asked
+     for stillness. */
+  --loop-motion: running;
 
   /* Opaque in every state: the shape has to pass for part of a physical camera
      housing, and nothing behind the window should ever show through it. Depth
@@ -1034,25 +1040,18 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 
 /* Session primitives ----------------------------------------------------- */
 
-.state-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 4px 9px;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--accent) 13%, transparent);
-  color: var(--accent);
-  font-size: 9.5px;
-  font-weight: 660;
-  letter-spacing: 0.1px;
+/* Read by assistive tech and drawn nowhere: the rows carry state in colour and
+   glyphs, and this is how the words behind them stay spoken. */
+.visually-hidden {
+  position: absolute;
+  overflow: hidden;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip-path: inset(50%);
   white-space: nowrap;
-}
-
-.state-dot {
-  width: 5px;
-  height: 5px;
-  border-radius: 50%;
-  background: currentcolor;
 }
 
 .empty-state {
@@ -1810,8 +1809,10 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   --row-stagger: 0s;
   /* Luke blinks and sways on a loop with no end to wait for, so a capture would
      otherwise land wherever in it the shutter happened to fall. Held on its
-     first frame, he is the same face in every PNG. */
+     first frame, he is the same face in every PNG. The working rows' spinners
+     hold still for exactly the same reason. */
   --face-motion: paused;
+  --loop-motion: paused;
 }
 
 /* COLLAPSE_ANIMATION_MS in app.tsx drops to zero under the same query, so the
@@ -1834,8 +1835,10 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
     /* Nothing travels, so the stack has no distance to spring across. */
     --row-fan: 0px;
     /* Idle motion is the one thing here that no one asked for, so it is the
-       first thing to stop: Luke sits still, upright, with his eyes open. */
+       first thing to stop: Luke sits still, upright, with his eyes open. The
+       spinner holds too — a working row still says Working in words. */
     --face-motion: paused;
+    --loop-motion: paused;
   }
 
   .panel-surface,

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -292,13 +292,12 @@
 .session-row {
   display: flex;
   width: 100%;
-  min-height: 66px;
   flex: 0 0 auto;
   align-items: center;
-  gap: 13px;
-  padding: 0 15px;
+  gap: 12px;
+  padding: 11px 14px;
   border: 1px solid var(--hairline);
-  border-radius: 17px;
+  border-radius: 15px;
   background: rgba(255, 255, 255, 0.028);
   text-align: left;
 }
@@ -311,10 +310,10 @@
 /* Whether pressing a row would do anything is answered by the pointer and
    nowhere else: a row that can be opened lifts under it, one that cannot stays
    exactly as it was drawn. That is also why nothing is added at rest — every
-   mark and every chip on this row already means something, and one more on some
-   rows would be read as another state before it was read as an affordance.
-   Colour alone: the row's `transform` is spoken for by its arrival, and its box
-   is what the surface behind it is measured from, so neither may move. */
+   glyph on this row already means something, and one more on some rows would be
+   read as another state before it was read as an affordance. Colour alone: the
+   row's `transform` is spoken for by its arrival, and its box is what the
+   surface behind it is measured from, so neither may move. */
 button.session-row:hover {
   border-color: rgba(255, 255, 255, 0.16);
   background: var(--raised);
@@ -335,36 +334,36 @@ html[data-keyboard="true"] button.session-row:focus-visible {
   outline-offset: -3px;
 }
 
-/* Neutral tile: the mark inside carries the provider's own colour, so tinting
-   the tile by state would put two colour systems on top of each other. */
-.row-avatar {
+/* The mark stands bare. The tile it used to sit in was the one box on the row
+   that carried no information — a hairline square inside a hairline card — and
+   the mark's own colour and silhouette are the identification. The slot keeps a
+   fixed size so every title starts on the same column whatever shape the mark
+   is, and so the cloud badge has a corner to hold whichever mark it rides. */
+.row-mark {
   position: relative;
   display: grid;
-  width: 32px;
-  height: 32px;
+  width: 30px;
+  height: 30px;
   flex: 0 0 auto;
-  border-radius: 11px;
-  background: var(--raised);
-  box-shadow: inset 0 0 0 1px var(--hairline);
   place-items: center;
 }
 
-.row-avatar .provider-mark {
-  width: 17px;
-  height: 17px;
+.row-mark .provider-mark {
+  width: 20px;
+  height: 20px;
 }
 
-/* Against a 32px tile the badge can be read at a glance, so it is sized to be
-   read rather than to be minimal. */
-.row-avatar .cloud-badge {
-  right: -4px;
-  bottom: -4px;
-  width: 14px;
-  height: 14px;
+/* Tucked closer than it sat on the tile: with no box edge to overlap, the
+   badge reads as attached to the mark only while it touches it. */
+.row-mark .cloud-badge {
+  right: -2px;
+  bottom: -1px;
+  width: 13px;
+  height: 13px;
 }
 
-.row-avatar .cloud-badge svg {
-  width: 9px;
+.row-mark .cloud-badge svg {
+  width: 8.5px;
 }
 
 .row-copy {
@@ -372,7 +371,7 @@ html[data-keyboard="true"] button.session-row:focus-visible {
   min-width: 0;
   flex: 1;
   flex-direction: column;
-  gap: 4px;
+  gap: 3.5px;
 }
 
 .row-copy strong {
@@ -385,18 +384,101 @@ html[data-keyboard="true"] button.session-row:focus-visible {
   white-space: nowrap;
 }
 
-.row-copy small {
-  overflow: hidden;
+/* What the session is doing, worded to carry the state. The glyph ahead of it
+   answers at a glance — a spinner turning, a check — and the attention colour
+   is spent here and nowhere else on the line, because a person being needed is
+   the one thing worth a colour. */
+.row-doing {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
   color: var(--text-secondary);
-  font-size: 10px;
+  font-size: 10.5px;
+}
+
+/* The ellipsis needs a text box rather than a flex row to bite on, so the
+   words sit in their own span beside the glyph. */
+.row-doing-text {
+  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-/* Where the session is, under what it is doing. It is the line a reader scans
-   only when two rows say the same thing, so it sits back a step. Qualified by
-   the parent because `.row-copy small` above is an element selector and would
-   otherwise out-rank a bare class, leaving both lines the same weight. */
-.row-copy .row-context {
+.session-row[data-state="attention"] .row-doing {
+  color: var(--accent);
+  font-weight: 560;
+}
+
+/* A session nothing is known about has nothing urgent to say, so its line sits
+   back with the identifier under it. */
+.session-row[data-state="unknown"] .row-doing {
   color: var(--text-tertiary);
+}
+
+/* Turns on its own clock — it means "still happening", not "arriving" — and
+   holds still under the same token that stills Luke: a capture must land on
+   one frame, and reduced motion asked for stillness, which the row survives
+   because the sentence still says Working in words. */
+.row-spinner {
+  width: 10px;
+  height: 10px;
+  flex: 0 0 auto;
+  border: 1.5px solid rgba(255, 255, 255, 0.15);
+  border-radius: 50%;
+  border-top-color: rgba(255, 255, 255, 0.62);
+  animation: row-spin 900ms linear infinite;
+  animation-play-state: var(--loop-motion);
+}
+
+@keyframes row-spin {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+.row-check {
+  width: 11px;
+  height: 11px;
+  flex: 0 0 auto;
+  color: var(--state-complete);
+  opacity: 0.85;
+}
+
+/* Which checkout this is, for the rows that would otherwise read alike. An
+   identifier rather than prose, so it is set in the system's mono face — and
+   it is the line a reader consults rather than scans, so it sits back a step. */
+.row-place {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 4.5px;
+  color: var(--text-tertiary);
+  font-family: ui-monospace, "SF Mono", SFMono-Regular, Menlo, monospace;
+  font-size: 9.5px;
+}
+
+.row-place span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.row-branch-glyph {
+  width: 10px;
+  height: 10px;
+  flex: 0 0 auto;
+}
+
+/* When the session was last seen, where every Apple surface puts it. Top-right
+   against the title's line rather than centred on the row, so two-line and
+   three-line rows hold it at the same height. */
+.row-when {
+  flex: 0 0 auto;
+  align-self: flex-start;
+  padding-top: 2px;
+  color: var(--text-tertiary);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }

--- a/apps/desktop/tests/conductor-adapter.test.ts
+++ b/apps/desktop/tests/conductor-adapter.test.ts
@@ -400,6 +400,40 @@ test("separates sessions that share one project by their workspaces' names", asy
   );
 });
 
+// The inverse trap of the one above: an open chat idle past the staleness
+// window decays to unknown, and an archived sibling reads as complete. The
+// open chat is still the one the user would return to, so it keeps the row —
+// a closed chat must not make the workspace read as finished, or take the
+// press that would have landed in the open one.
+test("a closed chat does not speak for a workspace whose open chat went quiet", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-quieted", TEST_TIME - 1_000)],
+    sessions: [
+      {
+        id: "session-open-stale",
+        workspaceId: "workspace-quieted",
+        name: TEST_SESSION_NAME,
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 2 * 60 * 60 * 1000,
+      },
+      {
+        id: "session-archived",
+        workspaceId: "workspace-quieted",
+        name: TEST_SESSION_NAME,
+        archivedAt: isoTimestamp(TEST_TIME - 10_000),
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "session-open-stale");
+  assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
+});
+
 test("reports an archived session as complete without requesting its status", async () => {
   const api = fakeConductorApi({
     userId: TEST_USER_ID,

--- a/apps/desktop/tests/conductor-adapter.test.ts
+++ b/apps/desktop/tests/conductor-adapter.test.ts
@@ -225,13 +225,15 @@ test("observes cloud sessions the signed-in user created, under their own names"
   assert.deepEqual(CONDUCTOR_PROVIDER, { id: "conductor", displayName: "Conductor" });
   assert.equal(observations.length, 1);
   assert.equal(observations[0]?.providerSessionId, "session-working");
-  assert.equal(observations[0]?.title, TEST_SESSION_NAME);
+  // Titled by the workspace, which carries the name the user knows the work
+  // by; the chat's generated name is not read, and the workspace name is not a
+  // branch, so no branch is reported at all.
+  assert.equal(observations[0]?.title, TEST_WORKSPACE_NAME);
   assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
   assert.equal(observations[0]?.observedAt, TEST_TIME - 5_000);
   assert.equal(observations[0]?.controls, undefined);
   assert.deepEqual(observations[0]?.detail, {
     repository: "luke",
-    branch: TEST_WORKSPACE_NAME,
     model: "claude-opus-5",
     link: "conductor://workspace?session=session-working",
   });
@@ -323,15 +325,17 @@ test("keeps an errored session errored after it goes stale", async () => {
   assert.equal(observations[0]?.status, SESSION_STATUS.ERROR);
 });
 
-test("separates sessions that share one project by their own names", async () => {
+test("separates sessions that share one project by their workspaces' names", async () => {
   const api = fakeConductorApi({
     userId: TEST_USER_ID,
     projects: [LUKE_PROJECT],
     workspaces: [
-      ownedWorkspace("workspace-one", TEST_TIME - 30_000),
-      ownedWorkspace("workspace-two", TEST_TIME - 40_000),
+      { ...ownedWorkspace("workspace-one", TEST_TIME - 30_000), name: "lisbon-v2" },
+      { ...ownedWorkspace("workspace-two", TEST_TIME - 40_000), name: "porto-v1" },
     ],
     sessions: [
+      // Each chat carries a generated name, which must not become the title:
+      // the workspace's name is the one the user chose or accepted.
       {
         id: "session-one",
         workspaceId: "workspace-one",
@@ -351,7 +355,7 @@ test("separates sessions that share one project by their own names", async () =>
 
   assert.deepEqual(
     observations.map((observation) => observation.title),
-    ["Revamp the notch panel", "Observe Cursor cloud agents"],
+    ["lisbon-v2", "porto-v1"],
   );
 });
 

--- a/apps/desktop/tests/conductor-adapter.test.ts
+++ b/apps/desktop/tests/conductor-adapter.test.ts
@@ -251,18 +251,21 @@ test("reports an idle session as waiting and an errored session with its reason"
   const api = fakeConductorApi({
     userId: TEST_USER_ID,
     projects: [LUKE_PROJECT],
-    workspaces: [ownedWorkspace("workspace-active", TEST_TIME - 30_000)],
+    workspaces: [
+      ownedWorkspace("workspace-idle", TEST_TIME - 30_000),
+      ownedWorkspace("workspace-errored", TEST_TIME - 40_000),
+    ],
     sessions: [
       {
         id: "session-idle",
-        workspaceId: "workspace-active",
+        workspaceId: "workspace-idle",
         name: TEST_SESSION_NAME,
         status: TEST_CONDUCTOR_STATUS.IDLE,
         statusUpdatedAt: TEST_TIME - 1_000,
       },
       {
         id: "session-errored",
-        workspaceId: "workspace-active",
+        workspaceId: "workspace-errored",
         name: TEST_SESSION_NAME,
         status: TEST_CONDUCTOR_STATUS.ERROR,
         statusUpdatedAt: TEST_TIME - 1_000,
@@ -276,6 +279,44 @@ test("reports an idle session as waiting and an errored session with its reason"
   assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
   assert.equal(observations[1]?.status, SESSION_STATUS.ERROR);
   assert.equal(observations[1]?.detail?.error, TEST_ERROR_MESSAGE);
+});
+
+// Rows are titled by their workspace, so two chats in one workspace would draw
+// as identical lines that open different places. The workspace reports once,
+// in the state of whichever chat most needs a person — a failure over a
+// question, a question over work still running.
+test("reports one row per workspace, carried by the chat that most needs a person", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-shared", TEST_TIME - 30_000)],
+    sessions: [
+      {
+        id: "session-working",
+        workspaceId: "workspace-shared",
+        name: TEST_SESSION_NAME,
+        status: TEST_CONDUCTOR_STATUS.WORKING,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+      {
+        id: "session-errored",
+        workspaceId: "workspace-shared",
+        name: TEST_SESSION_NAME,
+        status: TEST_CONDUCTOR_STATUS.ERROR,
+        statusUpdatedAt: TEST_TIME - 5_000,
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "session-errored");
+  assert.equal(observations[0]?.status, SESSION_STATUS.ERROR);
+  assert.equal(observations[0]?.title, TEST_WORKSPACE_NAME);
+  // The row opens the chat it reports, not whichever chat happened to be
+  // listed first.
+  assert.equal(observations[0]?.detail?.link, "conductor://workspace?session=session-errored");
 });
 
 test("does not carry a past failure into a session that recovered", async () => {
@@ -455,9 +496,13 @@ test("does not treat a long-idle chat as waiting because its workspace is busy",
   const api = fakeConductorApi({
     userId: TEST_USER_ID,
     projects: [LUKE_PROJECT],
-    // One workspace holds several chats, so its activity timestamp moves
-    // whenever any one of them runs.
-    workspaces: [ownedWorkspace("workspace-busy", TEST_TIME - 1_000)],
+    // A workspace's activity timestamp moves whenever anything in it runs, so
+    // it can read as fresh while the chat inside was walked away from hours
+    // ago. Staleness has to be judged on the chat's own status timestamp.
+    workspaces: [
+      ownedWorkspace("workspace-busy", TEST_TIME - 1_000),
+      ownedWorkspace("workspace-fresh", TEST_TIME - 2_000),
+    ],
     sessions: [
       {
         id: "session-abandoned",
@@ -468,7 +513,7 @@ test("does not treat a long-idle chat as waiting because its workspace is busy",
       },
       {
         id: "session-just-finished",
-        workspaceId: "workspace-busy",
+        workspaceId: "workspace-fresh",
         name: TEST_SESSION_NAME,
         status: TEST_CONDUCTOR_STATUS.IDLE,
         statusUpdatedAt: TEST_TIME - 20_000,
@@ -596,8 +641,12 @@ test("spreads a bounded session budget across workspaces", async () => {
   const observations = await adapterFor(api.fetch).observe();
   const observedIds = observations.map((observation) => observation.providerSessionId);
 
-  assert.equal(observedIds.filter((id) => id.startsWith("crowded-")).length, 4);
+  // The crowded workspace spent four of the session budget's slots on its
+  // chats — the cap is what kept it from spending all of them — but it still
+  // reports as one row beside its quiet neighbour.
+  assert.equal(observedIds.filter((id) => id.startsWith("crowded-")).length, 1);
   assert.equal(observedIds.includes("quiet-session"), true);
+  assert.equal(observations.length, 2);
 });
 
 test("prefers open chats over closed ones inside one workspace", async () => {
@@ -624,8 +673,11 @@ test("prefers open chats over closed ones inside one workspace", async () => {
 
   const observations = await adapterFor(api.fetch).observe();
 
+  // The open chat takes the budget ahead of the closed ones, and it is the one
+  // that speaks for the workspace: work still running outranks work settled.
+  assert.equal(observations.length, 1);
   assert.equal(observations[0]?.providerSessionId, "open-session");
-  assert.equal(observations.length, 4);
+  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
 });
 
 test("reports nothing and issues no request without an API key", async () => {
@@ -816,7 +868,9 @@ test("keeps observing when one session's status cannot be read", async () => {
 
   const observations = await adapterFor(api.fetch).observe();
 
-  assert.equal(observations.length, 2);
-  assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
-  assert.equal(observations[1]?.status, SESSION_STATUS.WORKING);
+  // One chat's unreadable status does not cost the workspace its row, and the
+  // chat whose state is known is the one that speaks for it.
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "session-readable");
+  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
 });

--- a/apps/desktop/tests/session-model.test.ts
+++ b/apps/desktop/tests/session-model.test.ts
@@ -176,12 +176,12 @@ test("how long ago a session was seen is worded by the unit that has begun", () 
   assert.equal(observedAgoLabel(now, now), "Now");
   assert.equal(observedAgoLabel(now - 59_000, now), "Now");
   assert.equal(observedAgoLabel(now + minute, now), "Now");
-  assert.equal(observedAgoLabel(now - minute, now), "1 min");
-  assert.equal(observedAgoLabel(now - 59 * minute, now), "59 min");
-  assert.equal(observedAgoLabel(now - 60 * minute, now), "1 hr");
-  assert.equal(observedAgoLabel(now - 23 * 60 * minute, now), "23 hr");
-  assert.equal(observedAgoLabel(now - 24 * 60 * minute, now), "1 day");
-  assert.equal(observedAgoLabel(now - 3 * 24 * 60 * minute, now), "3 days");
+  assert.equal(observedAgoLabel(now - minute, now), "1m");
+  assert.equal(observedAgoLabel(now - 59 * minute, now), "59m");
+  assert.equal(observedAgoLabel(now - 60 * minute, now), "1h");
+  assert.equal(observedAgoLabel(now - 23 * 60 * minute, now), "23h");
+  assert.equal(observedAgoLabel(now - 24 * 60 * minute, now), "1d");
+  assert.equal(observedAgoLabel(now - 3 * 24 * 60 * minute, now), "3d");
 });
 
 test("a speaking disposition needs a person even while the session works", () => {

--- a/apps/desktop/tests/session-model.test.ts
+++ b/apps/desktop/tests/session-model.test.ts
@@ -14,6 +14,7 @@ import {
   arrangeSessions,
   DEFAULT_SESSION_VIEW,
   displaySessions,
+  observedAgoLabel,
   SESSION_FILTER,
   SESSION_SORT,
   sessionTally,
@@ -116,6 +117,71 @@ test("a row is a control only where its provider gave an address", () => {
     FIXTURE_SESSIONS.every((session) => session.openable === false),
     true,
   );
+});
+
+// The sentence under the title is the one place the row states what is
+// happening — there is no chip at the other end — so a provider that reported
+// nothing must still leave the row reading as Working or Complete.
+test("the line under the title says the state when the provider said nothing", () => {
+  const [bare] = displaySessions(bootstrap(false), [
+    liveSession(CLAUDE_PROVIDER, "claude-quiet", SESSION_STATUS.WORKING),
+  ]);
+  assert.equal(bare?.detail, "Working");
+  assert.equal(bare?.detail, bare?.label);
+
+  const [spoken] = displaySessions(bootstrap(false), [
+    normalizeSession(CODEX_PROVIDER, {
+      providerSessionId: "codex-busy",
+      title: "Session codex-busy",
+      status: SESSION_STATUS.WORKING,
+      observedAt: 1_000,
+      detail: { activity: "Running tests" },
+    }),
+  ]);
+  assert.equal(spoken?.detail, "Running tests");
+
+  // The fixture's silent row proves the same fallback in the visual evidence.
+  const conductor = FIXTURE_SESSIONS.find((session) => session.id === "conductor-workspace");
+  assert.equal(conductor?.detail, "Complete");
+});
+
+test("a row carries the identifiers that tell it from its neighbours", () => {
+  const [live] = displaySessions(bootstrap(false), [
+    normalizeSession(CODEX_PROVIDER, {
+      providerSessionId: "codex-checkout",
+      title: "Session codex-checkout",
+      status: SESSION_STATUS.WORKING,
+      observedAt: 1_000,
+      detail: { repository: "luke", branch: "dean/session-rows", model: "gpt-5.6-luna" },
+    }),
+  ]);
+  assert.equal(live?.repository, "luke");
+  assert.equal(live?.branch, "dean/session-rows");
+  assert.equal(live?.model, "gpt-5.6-luna");
+
+  // The fixture keeps one row with a repository and no branch, so the surface's
+  // fallback line stays visible in the evidence.
+  const devin = FIXTURE_SESSIONS.find((session) => session.id === "devin-session");
+  assert.equal(devin?.branch, undefined);
+  assert.equal(devin?.repository, "sidecar-native");
+});
+
+// The label answers "is this thing alive", so it reports the coarsest unit
+// that has begun rather than telling time. A timestamp ahead of the clock is
+// clock skew, not the future, and reads as Now.
+test("how long ago a session was seen is worded by the unit that has begun", () => {
+  const minute = 60_000;
+  const now = 100 * 24 * 60 * minute;
+
+  assert.equal(observedAgoLabel(now, now), "Now");
+  assert.equal(observedAgoLabel(now - 59_000, now), "Now");
+  assert.equal(observedAgoLabel(now + minute, now), "Now");
+  assert.equal(observedAgoLabel(now - minute, now), "1 min");
+  assert.equal(observedAgoLabel(now - 59 * minute, now), "59 min");
+  assert.equal(observedAgoLabel(now - 60 * minute, now), "1 hr");
+  assert.equal(observedAgoLabel(now - 23 * 60 * minute, now), "23 hr");
+  assert.equal(observedAgoLabel(now - 24 * 60 * minute, now), "1 day");
+  assert.equal(observedAgoLabel(now - 3 * 24 * 60 * minute, now), "3 days");
 });
 
 test("a speaking disposition needs a person even while the session works", () => {

--- a/packages/sidecar-core/src/fixtures.ts
+++ b/packages/sidecar-core/src/fixtures.ts
@@ -86,14 +86,16 @@ const smokeFixture: FixtureSnapshot = {
     // fixture tells the two orderings apart rather than agreeing with both.
     {
       id: "conductor-workspace",
-      title: "Observe a cloud workspace",
+      // Conductor sessions are titled by the workspace's own name — the name
+      // the user knows the work by — and carry no branch, because the
+      // workspace name never was one.
+      title: "lisbon-v2",
       providerId: PROVIDER_ID.CONDUCTOR,
       provider: "Conductor",
       // A provider that reported no activity, failure, or recap: the surface
       // words the state itself, and this row is what proves it does.
       detail: "",
       repository: "luke",
-      branch: "lisbon-v2",
       model: "claude-opus-5",
       state: SESSION_STATE.COMPLETE,
       location: SESSION_LOCATION.CLOUD,

--- a/packages/sidecar-core/src/fixtures.ts
+++ b/packages/sidecar-core/src/fixtures.ts
@@ -16,10 +16,17 @@ export interface SessionSnapshot {
   /** The observing provider's stable identity, as an adapter reports it. */
   providerId: ProviderId;
   provider: string;
-  /** What the session is doing, or what stopped it. */
+  /** What the session is doing, or what stopped it; empty when it said nothing. */
   detail: string;
-  /** Where it is doing it: provider, repository, branch, model. */
-  context: string;
+  /**
+   * Which checkout the work is in, as separate fields rather than a composed
+   * line: the surface words them, and it needs to know which kind of identifier
+   * it is drawing.
+   */
+  repository?: string;
+  branch?: string;
+  /** Named on the provider mark's hover rather than spent on a line of its own. */
+  model?: string;
   state: SessionState;
   location: SessionLocation;
   /** When the session was last seen, in the same units a live observation uses. */
@@ -35,8 +42,12 @@ export interface FixtureSnapshot {
  * A fixed instant the fixture's observation times are measured back from. A
  * clock read at load would make the ordering depend on when the fixture was
  * read, and the evidence screenshots are only reproducible while it does not.
+ * Exported because the surface draws how long ago each session was seen, and a
+ * fixture row's age has to be read against this instant rather than the wall
+ * clock — measured against the real clock, the labels would grow with every
+ * capture run and the PNGs would stop being reproducible.
  */
-const FIXTURE_EPOCH_MS = 1_735_689_600_000;
+export const FIXTURE_EPOCH_MS = 1_735_689_600_000;
 
 function minutesBeforeEpoch(minutes: number): number {
   return FIXTURE_EPOCH_MS - minutes * 60_000;
@@ -51,7 +62,9 @@ const smokeFixture: FixtureSnapshot = {
       providerId: PROVIDER_ID.CODEX,
       provider: "Codex",
       detail: "exec_command: pnpm --filter @luke/desktop build",
-      context: "Codex · luke · dean/desktop-shell · gpt-5.6-luna · medium",
+      repository: "luke",
+      branch: "dean/desktop-shell",
+      model: "gpt-5.6-luna",
       state: SESSION_STATE.WORKING,
       location: SESSION_LOCATION.LOCAL,
       observedAt: minutesBeforeEpoch(4),
@@ -62,7 +75,9 @@ const smokeFixture: FixtureSnapshot = {
       providerId: PROVIDER_ID.CLAUDE_CODE,
       provider: "Claude Code",
       detail: "Both adapters observe read-only; next, say whether to ship it.",
-      context: "Claude Code · luke · dean/trust-constraints · claude-opus-5",
+      repository: "luke",
+      branch: "dean/trust-constraints",
+      model: "claude-opus-5",
       state: SESSION_STATE.ATTENTION,
       location: SESSION_LOCATION.LOCAL,
       observedAt: minutesBeforeEpoch(9),
@@ -74,10 +89,12 @@ const smokeFixture: FixtureSnapshot = {
       title: "Observe a cloud workspace",
       providerId: PROVIDER_ID.CONDUCTOR,
       provider: "Conductor",
-      // A provider that reported no activity, failure, or recap leaves the
-      // middle line out rather than restating the chip beside it.
+      // A provider that reported no activity, failure, or recap: the surface
+      // words the state itself, and this row is what proves it does.
       detail: "",
-      context: "Conductor · luke · lisbon-v2 · claude-opus-5",
+      repository: "luke",
+      branch: "lisbon-v2",
+      model: "claude-opus-5",
       state: SESSION_STATE.COMPLETE,
       location: SESSION_LOCATION.CLOUD,
       observedAt: minutesBeforeEpoch(1),
@@ -88,7 +105,8 @@ const smokeFixture: FixtureSnapshot = {
       providerId: PROVIDER_ID.CURSOR,
       provider: "Cursor",
       detail: "Opened a pull request against sidecar.",
-      context: "Cursor · sidecar · cursor/follow-agent-a1b2",
+      repository: "sidecar",
+      branch: "cursor/follow-agent-a1b2",
       state: SESSION_STATE.WORKING,
       location: SESSION_LOCATION.CLOUD,
       observedAt: minutesBeforeEpoch(18),
@@ -97,14 +115,15 @@ const smokeFixture: FixtureSnapshot = {
     // one screenshot the visual evidence is reviewed from. It is also one more
     // provider than the wings hold now that the face has the place nearest the
     // housing, so the same screenshot proves the remainder is counted rather
-    // than dropped.
+    // than dropped. Reporting a repository and no branch, it is also the row
+    // that shows the identifier line falling back.
     {
       id: "devin-session",
       title: "Watch a cloud session",
       providerId: PROVIDER_ID.DEVIN,
       provider: "Devin",
       detail: "Suspended before it opened a pull request.",
-      context: "Devin · sidecar-native",
+      repository: "sidecar-native",
       state: SESSION_STATE.UNKNOWN,
       location: SESSION_LOCATION.CLOUD,
       observedAt: minutesBeforeEpoch(41),


### PR DESCRIPTION
## Summary

- **Session rows read like notifications instead of dashboards.** The state
  rides the sentence under the title — a quiet spinner leads a working row, a
  check a finished one, and a session that needs a person says so in the
  attention colour, the one colour on the row. The pill with the dot is gone;
  a provider that reported no activity, failure, or recap has its state said
  in words in the same place, because there is no chip left to restate it.
- **The dot-joined subtitle is gone.** The branch stands alone in the system
  mono face under a branch glyph, falling back to the repository. The provider
  name and model answer on the mark's hover (the name stays in the row's
  accessible text); the mark itself stands bare, its tile removed.
- **Rows gain a time.** How long ago a session was seen, top-right. Fixture
  rows read their age against the fixture's own epoch so the evidence stays
  reproducible; live rows tick every 30s while the panel is open.
- **Conductor sessions are titled by their workspace's name** — the name the
  user knows the work by — and no longer report that name as a branch. The
  chat's auto-generated name is not read at all, and each workspace reports as
  one row, carried by whichever chat inside it most needs a person, so
  identically titled rows cannot occur (flagged by Bugbot, fixed in-branch).
- The working spinner holds still under a new `--loop-motion` token in capture
  runs and under reduced motion, exactly as Luke's face does; state labels
  stay spoken to screen readers via a new `.visually-hidden` utility.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — clean (lint, typecheck,
  238 desktop tests + 41 core, build). New tests cover the state-label
  fallback, the branch/repository fields, the relative-time wording including
  clock skew, and the Conductor title/branch mapping.
- macOS Electron verification (`./scripts/verify.sh`): `run by CI on macos-15`
  (this change was written in a Linux cloud sandbox) — see the automated
  evidence below; all five PNGs inspected.

The expanded panel from the deterministic evidence at the current head —
attention, working, complete, and idle states, the branch line with its glyph,
the repository-only fallback (`lisbon-v2` and `sidecar-native` rows), and the
relative times:

![Session rows, expanded panel](https://raw.githubusercontent.com/reviewstage/luke/pr-assets/pr-56/session-rows-expanded.png)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31752127018/artifacts/9201330570) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31752127018)

- Commit: `e81f3f9f4588f5e6fbbbf92193bd110ff5f9a158`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: a physical-notch check remains open; the
  30s relative-time tick and row hover behaviour are worth one look against
  live sessions with `./scripts/run.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

