### PR TITLE
feat(LUKE-61): integrate GitHub Copilot coding agent tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Download published builds from [GitHub Releases](https://github.com/ReviewStage/
 - Claude Code — reads local session state; no provider credential required
 - Codex — reads local session state; no provider credential required
 - Conductor — reads cloud session metadata after you supply a Conductor API key
+- Copilot — reads GitHub Copilot coding-agent task metadata after you supply a
+  GitHub fine-grained personal access token
 - Cursor — reads local session state for the agents running on this machine,
   and cloud agent metadata after you supply a Cursor API key
 - Devin — reads cloud session metadata after you supply a Devin personal access
@@ -23,10 +25,14 @@ Download published builds from [GitHub Releases](https://github.com/ReviewStage/
 
 Cursor is the one provider Luke watches in two places, and both halves arrive as
 Cursor sessions: the ones on this machine need no credential, and its cloud
-agents need a key. Conductor, Cursor's cloud half, Devin, and Jules remain silent
-until their own credential is saved in Luke's Settings or supplied through
-`CONDUCTOR_API_KEY`, `CONDUCTOR_API_TOKEN`, `CURSOR_API_KEY`, `DEVIN_API_KEY`, or
-`JULES_API_KEY`.
+agents need a key. Conductor, Copilot, Cursor's cloud half, Devin, and Jules
+remain silent until their own credential is saved in Luke's Settings or supplied
+through `CONDUCTOR_API_KEY`, `CONDUCTOR_API_TOKEN`, `COPILOT_API_KEY`,
+`CURSOR_API_KEY`, `DEVIN_API_KEY`, or `JULES_API_KEY`.
+Copilot's agent-tasks API answers only user tokens: a fine-grained personal
+access token with **Agent tasks** read access or a GitHub App user token.
+Classic PATs and GitHub App installation tokens are not supported, and the API
+is in public preview, so Luke pins the dated API version it was written against.
 Devin is the one that asks for a particular credential: Luke reads its v3 API, so
 it takes a personal access token (`cog_…`, created under **Devin API · PATs**)
 and refuses the deprecated `apk_` keys of v1 and v2. A token that belongs to a

--- a/apps/desktop/src/cloud-session-adapter.ts
+++ b/apps/desktop/src/cloud-session-adapter.ts
@@ -41,6 +41,10 @@ const AUTHORIZATION_HEADERS: Readonly<
   [CLOUD_AUTH_SCHEME.GOOGLE_API_KEY_HEADER]: (apiKey) => ({ [GOOGLE_API_KEY_HEADER]: apiKey }),
 };
 
+const DEFAULT_REQUEST_HEADERS: Readonly<Record<string, string>> = {
+  Accept: "application/json",
+};
+
 export const CLOUD_FAILURE = {
   UNAUTHORIZED: "unauthorized",
   TRANSIENT: "transient",
@@ -287,6 +291,16 @@ export abstract class CloudSessionAdapter implements SessionProviderAdapter {
       : SESSION_STATUS.UNKNOWN;
   }
 
+  /**
+   * The headers every request carries besides the credential. A subclass
+   * overrides this only when its provider asks for its own media type or a
+   * version pin; the authorization header is layered on after these, so no
+   * override can replace the credential.
+   */
+  protected requestHeaders(): Readonly<Record<string, string>> {
+    return DEFAULT_REQUEST_HEADERS;
+  }
+
   /** Keeps one failed resource from discarding an otherwise complete pass. */
   protected async tolerateItemFailure<Result>(
     operation: () => Promise<Result>,
@@ -351,8 +365,8 @@ export abstract class CloudSessionAdapter implements SessionProviderAdapter {
       response = await this.#fetch(this.#url(segments, query), {
         method: HTTP_METHOD.GET,
         headers: {
+          ...this.requestHeaders(),
           ...this.#authorizationHeaders(apiKey),
-          Accept: "application/json",
         },
         signal: AbortSignal.timeout(CLOUD_ADAPTER_DEFAULTS.REQUEST_TIMEOUT_MS),
       });

--- a/apps/desktop/src/copilot-adapter.ts
+++ b/apps/desktop/src/copilot-adapter.ts
@@ -1,0 +1,296 @@
+import {
+  type ProviderSessionObservation,
+  SESSION_STATUS,
+  type SessionProvider,
+  type SessionStatus,
+} from "@sidecar/core";
+import {
+  CLOUD_ADAPTER_DEFAULTS,
+  type CloudAdapterOptions,
+  type CloudRequest,
+  CloudSessionAdapter,
+  isDefined,
+  isRecord,
+  knownValue,
+  positiveInteger,
+  recordsFromPage,
+  repositoryLabel,
+  textFromRecord,
+  timestampFromRecord,
+} from "./cloud-session-adapter";
+import { CREDENTIAL_PROVIDER_ID, CREDENTIAL_PROVIDERS } from "./shared/credential-providers";
+
+// Shared with the credential registry so the key the user saves and the
+// provider Luke observes with it can never name different things.
+const COPILOT_PROVIDER_ID = CREDENTIAL_PROVIDER_ID.COPILOT;
+const COPILOT_PROVIDER_NAME = CREDENTIAL_PROVIDERS[CREDENTIAL_PROVIDER_ID.COPILOT].displayName;
+
+const COPILOT_ENVIRONMENT = {
+  API_URL: "COPILOT_API_URL",
+} as const;
+
+const COPILOT_DEFAULT_API_URL = "https://api.github.com";
+
+const COPILOT_ROUTE_SEGMENT = {
+  AGENTS: "agents",
+  TASKS: "tasks",
+} as const;
+
+/** The one read-only route Luke calls. Every other agent-tasks route writes. */
+const COPILOT_ROUTE = {
+  TASKS: [COPILOT_ROUTE_SEGMENT.AGENTS, COPILOT_ROUTE_SEGMENT.TASKS],
+} as const;
+
+const COPILOT_QUERY = {
+  PER_PAGE: "per_page",
+  SINCE: "since",
+} as const;
+
+const COPILOT_FIELD = {
+  ARCHIVED_AT: "archived_at",
+  ARTIFACTS: "artifacts",
+  BASE_REF: "base_ref",
+  CREATED_AT: "created_at",
+  DATA: "data",
+  HTML_URL: "html_url",
+  ID: "id",
+  STATE: "state",
+  TASKS: "tasks",
+  TYPE: "type",
+  UPDATED_AT: "updated_at",
+  URL: "url",
+} as const;
+
+/** The structural segment in front of `{owner}/{repo}` in a task's API URL. */
+const COPILOT_URL_SEGMENT = {
+  REPOS: "repos",
+} as const;
+
+const GITHUB_REQUEST_HEADER = {
+  ACCEPT: "Accept",
+  API_VERSION: "X-GitHub-Api-Version",
+} as const;
+
+const GITHUB_MEDIA_TYPE = "application/vnd.github+json";
+
+/**
+ * The dated API version this adapter was written against. The agent-tasks
+ * endpoint is in public preview and subject to change, so every request pins
+ * the version rather than taking whatever shape GitHub answers with today.
+ */
+const GITHUB_API_VERSION = "2026-03-10";
+
+const COPILOT_REQUEST_HEADERS: Readonly<Record<string, string>> = {
+  [GITHUB_REQUEST_HEADER.ACCEPT]: GITHUB_MEDIA_TYPE,
+  [GITHUB_REQUEST_HEADER.API_VERSION]: GITHUB_API_VERSION,
+};
+
+const COPILOT_ARTIFACT_TYPE = {
+  BRANCH: "branch",
+  PULL: "pull",
+} as const;
+
+const COPILOT_TASK_STATE = {
+  QUEUED: "queued",
+  IN_PROGRESS: "in_progress",
+  COMPLETED: "completed",
+  FAILED: "failed",
+  IDLE: "idle",
+  WAITING_FOR_USER: "waiting_for_user",
+  TIMED_OUT: "timed_out",
+  CANCELLED: "cancelled",
+} as const;
+
+type CopilotTaskState = (typeof COPILOT_TASK_STATE)[keyof typeof COPILOT_TASK_STATE];
+
+/**
+ * A task is a container for sessions, and GitHub derives its state from the
+ * most recent one. Queued and in-progress are work the user cannot act on yet;
+ * `waiting_for_user` is the task holding for the user. Completed and cancelled
+ * are both settled — cancelling is the user closing the task, not the task
+ * stopping on something. A failed or timed-out task reports no reason on the
+ * list projection and can be sent back to work from its task page with a new
+ * session, so like a suspended Devin session it is neither settled nor asking;
+ * Luke leaves it unknown rather than promoting it to an error it cannot
+ * describe. Idle says only that no session is running at all.
+ */
+const SESSION_STATUS_BY_COPILOT_STATE: Readonly<Record<CopilotTaskState, SessionStatus>> = {
+  [COPILOT_TASK_STATE.QUEUED]: SESSION_STATUS.WORKING,
+  [COPILOT_TASK_STATE.IN_PROGRESS]: SESSION_STATUS.WORKING,
+  [COPILOT_TASK_STATE.WAITING_FOR_USER]: SESSION_STATUS.WAITING,
+  [COPILOT_TASK_STATE.COMPLETED]: SESSION_STATUS.COMPLETE,
+  [COPILOT_TASK_STATE.CANCELLED]: SESSION_STATUS.COMPLETE,
+  [COPILOT_TASK_STATE.FAILED]: SESSION_STATUS.UNKNOWN,
+  [COPILOT_TASK_STATE.TIMED_OUT]: SESSION_STATUS.UNKNOWN,
+  [COPILOT_TASK_STATE.IDLE]: SESSION_STATUS.UNKNOWN,
+};
+
+const COPILOT_ADAPTER_DEFAULTS = {
+  /** The documented maximum, so one call covers as much of a day as it can. */
+  TASK_PAGE_SIZE: 100,
+  MAXIMUM_OBSERVED_TASKS: 12,
+  MAXIMUM_BRANCH_LABEL_LENGTH: 60,
+} as const;
+
+export const COPILOT_PROVIDER: SessionProvider = {
+  id: COPILOT_PROVIDER_ID,
+  displayName: COPILOT_PROVIDER_NAME,
+};
+
+export interface CopilotAdapterOptions extends CloudAdapterOptions {
+  maximumObservedTasks?: number;
+}
+
+interface CopilotTask {
+  id: string;
+  repositoryLabel: string;
+  state: CopilotTaskState | undefined;
+  archived: boolean;
+  observedAt: number;
+  branch?: string;
+  link?: string;
+}
+
+/**
+ * The list projection names a task's repository only by a numeric id, but the
+ * task's own API address is `/agents/repos/{owner}/{repo}/tasks/{id}`, so the
+ * repository is the segment two past `repos`.
+ */
+function repositoryFromTaskUrl(url: string | undefined): string | undefined {
+  const segments = url?.split("/").filter(Boolean) ?? [];
+  const repos = segments.indexOf(COPILOT_URL_SEGMENT.REPOS);
+  return repos > 0 ? segments[repos + 2] : undefined;
+}
+
+/**
+ * The branch a task was pointed at, from its branch artifact. The artifact's
+ * `head_ref` is named by Copilot from the task prompt, so like the task's
+ * `name` it stays off the row; `base_ref` is chosen by whoever opened the
+ * task, the same thing Jules' starting branch reports.
+ */
+function baseBranchFromArtifacts(record: Record<string, unknown>): string | undefined {
+  const artifacts = record[COPILOT_FIELD.ARTIFACTS];
+  if (!Array.isArray(artifacts)) return undefined;
+  const branch = artifacts
+    .filter(isRecord)
+    .find(
+      (artifact) => textFromRecord(artifact, COPILOT_FIELD.TYPE) === COPILOT_ARTIFACT_TYPE.BRANCH,
+    );
+  const data = branch?.[COPILOT_FIELD.DATA];
+  return isRecord(data) ? textFromRecord(data, COPILOT_FIELD.BASE_REF) : undefined;
+}
+
+function taskFromRecord(record: Record<string, unknown>): CopilotTask | undefined {
+  const id = textFromRecord(record, COPILOT_FIELD.ID);
+  const observedAt =
+    timestampFromRecord(record, COPILOT_FIELD.UPDATED_AT) ??
+    timestampFromRecord(record, COPILOT_FIELD.CREATED_AT);
+  if (!id || observedAt === undefined) return undefined;
+
+  const branch = baseBranchFromArtifacts(record)?.slice(
+    0,
+    COPILOT_ADAPTER_DEFAULTS.MAXIMUM_BRANCH_LABEL_LENGTH,
+  );
+  const link = textFromRecord(record, COPILOT_FIELD.HTML_URL);
+
+  return {
+    id,
+    observedAt,
+    // GitHub documents a task's `name` as derived from the task prompt, so it
+    // is transcript content and there is deliberately no fallback to it.
+    repositoryLabel: repositoryLabel(
+      repositoryFromTaskUrl(textFromRecord(record, COPILOT_FIELD.URL)),
+      undefined,
+    ),
+    state: knownValue(COPILOT_TASK_STATE, textFromRecord(record, COPILOT_FIELD.STATE)),
+    archived: textFromRecord(record, COPILOT_FIELD.ARCHIVED_AT) !== undefined,
+    ...(branch ? { branch } : {}),
+    ...(link ? { link } : {}),
+  };
+}
+
+/**
+ * Observes GitHub Copilot coding-agent tasks through the documented
+ * agent-tasks API. It reads only the tasks the supplied token can see, issues
+ * no request that can change provider state, and reports nothing at all
+ * without a credential.
+ */
+export class CopilotSessionAdapter extends CloudSessionAdapter {
+  readonly #maximumObservedTasks: number;
+
+  constructor(options: CopilotAdapterOptions) {
+    super(
+      {
+        provider: COPILOT_PROVIDER,
+        defaultBaseUrl: COPILOT_DEFAULT_API_URL,
+        baseUrlEnvironmentVariable: COPILOT_ENVIRONMENT.API_URL,
+      },
+      options,
+    );
+    this.#maximumObservedTasks = positiveInteger(
+      options.maximumObservedTasks,
+      COPILOT_ADAPTER_DEFAULTS.MAXIMUM_OBSERVED_TASKS,
+    );
+  }
+
+  /** GitHub asks for its own media type, and the preview endpoint is pinned. */
+  protected override requestHeaders(): Readonly<Record<string, string>> {
+    return COPILOT_REQUEST_HEADERS;
+  }
+
+  protected async collect(
+    request: CloudRequest,
+    now: number,
+  ): Promise<readonly ProviderSessionObservation[]> {
+    // One call per pass. The list projection already carries the state, the
+    // timestamps, and the task's own addresses, so there is nothing a
+    // per-task read would add. `since` asks GitHub for the observation window,
+    // and the filter below holds it against whatever comes back.
+    const body = await request(COPILOT_ROUTE.TASKS, {
+      [COPILOT_QUERY.PER_PAGE]: String(COPILOT_ADAPTER_DEFAULTS.TASK_PAGE_SIZE),
+      [COPILOT_QUERY.SINCE]: new Date(
+        now - CLOUD_ADAPTER_DEFAULTS.MAXIMUM_SESSION_AGE_MS,
+      ).toISOString(),
+    });
+
+    return recordsFromPage(body, COPILOT_FIELD.TASKS)
+      .map(taskFromRecord)
+      .filter(isDefined)
+      .filter((task) => now - task.observedAt <= CLOUD_ADAPTER_DEFAULTS.MAXIMUM_SESSION_AGE_MS)
+      .sort((first, second) => second.observedAt - first.observedAt)
+      .slice(0, this.#maximumObservedTasks)
+      .map((task) => this.#observationFor(task, now));
+  }
+
+  #observationFor(task: CopilotTask, now: number): ProviderSessionObservation {
+    return {
+      providerSessionId: task.id,
+      // The provider is already on the row as its mark and in the context line,
+      // so the title carries only what tells one Copilot task from another.
+      title: task.repositoryLabel,
+      status: this.#statusFor(task, now),
+      observedAt: task.observedAt,
+      detail: {
+        repository: task.repositoryLabel,
+        ...(task.branch ? { branch: task.branch } : {}),
+        ...(task.link ? { link: task.link } : {}),
+      },
+    };
+  }
+
+  #statusFor(task: CopilotTask, now: number): SessionStatus {
+    // A task the user filed away is settled whatever its last session did.
+    if (task.archived) return SESSION_STATUS.COMPLETE;
+    // A state this build does not know is not guessed at.
+    if (!task.state) return SESSION_STATUS.UNKNOWN;
+    const status = SESSION_STATUS_BY_COPILOT_STATE[task.state];
+    // `updated_at` marks when the task last changed rather than a heartbeat,
+    // so a long turn is still working and a completed task stays complete
+    // however long ago it finished. Only waiting decays: once it is stale Luke
+    // cannot tell a task that just asked for the user from one the user walked
+    // away from hours ago.
+    return status === SESSION_STATUS.WAITING
+      ? this.statusWhileRecent(status, task.observedAt, now)
+      : status;
+  }
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -31,6 +31,7 @@ import {
 import { ClaudeCodeSessionAdapter } from "./claude-code-adapter";
 import { CodexSessionAdapter } from "./codex-adapter";
 import { ConductorSessionAdapter } from "./conductor-adapter";
+import { CopilotSessionAdapter } from "./copilot-adapter";
 import { CURSOR_PROVIDER, CursorSessionAdapter } from "./cursor-adapter";
 import { CursorLocalSessionAdapter } from "./cursor-local-adapter";
 import { DevinSessionAdapter } from "./devin-adapter";
@@ -81,6 +82,9 @@ const settingsStore = new SettingsStore({
 const conductorAdapter = new ConductorSessionAdapter({
   readApiKey: () => settingsStore.readApiKey(CREDENTIAL_PROVIDER_ID.CONDUCTOR),
 });
+const copilotAdapter = new CopilotSessionAdapter({
+  readApiKey: () => settingsStore.readApiKey(CREDENTIAL_PROVIDER_ID.COPILOT),
+});
 // Cursor runs sessions in two places: on this machine, which needs no
 // credential and is observed from the transcripts Cursor writes for itself, and
 // in its cloud, which needs a key. They are one provider wherever they ran, so
@@ -106,6 +110,7 @@ const julesAdapter = new JulesSessionAdapter({
 const adapterByCredentialProvider: ReadonlyMap<CredentialProviderId, SessionProviderAdapter> =
   new Map<CredentialProviderId, SessionProviderAdapter>([
     [CREDENTIAL_PROVIDER_ID.CONDUCTOR, conductorAdapter],
+    [CREDENTIAL_PROVIDER_ID.COPILOT, copilotAdapter],
     [CREDENTIAL_PROVIDER_ID.CURSOR, cursorAdapter],
     [CREDENTIAL_PROVIDER_ID.DEVIN, devinAdapter],
     [CREDENTIAL_PROVIDER_ID.JULES, julesAdapter],
@@ -114,6 +119,7 @@ const sessionAdapters = [
   new ClaudeCodeSessionAdapter(),
   new CodexSessionAdapter(),
   conductorAdapter,
+  copilotAdapter,
   cursorAdapter,
   devinAdapter,
   julesAdapter,

--- a/apps/desktop/src/renderer/provider-marks.tsx
+++ b/apps/desktop/src/renderer/provider-marks.tsx
@@ -10,17 +10,18 @@ import { useId } from "react";
  * Each is the provider's own mark, reproduced rather than redrawn — Claude Code
  * via Simple Icons (CC0-1.0, sourced from code.claude.com), Codex via
  * @lobehub/icons (MIT), Conductor's letter mark verbatim from the published
- * brand kit at https://www.conductor.build/brandkit, Cursor via Simple Icons
- * (CC0-1.0, sourced from https://cursor.com/brand), Devin's verbatim from
- * the mark https://devin.ai serves as its own favicon and site header, and
- * Jules via Simple Icons (CC0-1.0, sourced from https://jules.google). Each
- * keeps its own brand colour (see the `--mark-*` custom properties), so a mark
- * says which provider a session belongs to while the chips and row tints say
- * what state it is in. Cursor and Devin each publish one silhouette rather than
- * a colour, so both are drawn in the light form their brand uses on a dark
- * surface. They are trademarks of their respective owners. Do not restyle the
- * geometry or recolour them; swap the path if a provider publishes an updated
- * mark.
+ * brand kit at https://www.conductor.build/brandkit, Copilot via Simple Icons
+ * (MIT, sourced from https://primer.style/foundations/icons/copilot-24),
+ * Cursor via Simple Icons (CC0-1.0, sourced from https://cursor.com/brand),
+ * Devin's verbatim from the mark https://devin.ai serves as its own favicon
+ * and site header, and Jules via Simple Icons (CC0-1.0, sourced from
+ * https://jules.google). Each keeps its own brand colour (see the `--mark-*`
+ * custom properties), so a mark says which provider a session belongs to while
+ * the chips and row tints say what state it is in. Copilot, Cursor, and Devin
+ * each publish one silhouette rather than a colour, so all three are drawn in
+ * the light form their brand uses on a dark surface. They are trademarks of
+ * their respective owners. Do not restyle the geometry or recolour them; swap
+ * the path if a provider publishes an updated mark.
  */
 interface MarkProps {
   className?: string;
@@ -31,6 +32,9 @@ const CLAUDE_CODE_PATH =
 
 const CODEX_PATH =
   "M8.086.457a6.105 6.105 0 013.046-.415c1.333.153 2.521.72 3.564 1.7a.117.117 0 00.107.029c1.408-.346 2.762-.224 4.061.366l.063.03.154.076c1.357.703 2.33 1.77 2.918 3.198.278.679.418 1.388.421 2.126a5.655 5.655 0 01-.18 1.631.167.167 0 00.04.155 5.982 5.982 0 011.578 2.891c.385 1.901-.01 3.615-1.183 5.14l-.182.22a6.063 6.063 0 01-2.934 1.851.162.162 0 00-.108.102c-.255.736-.511 1.364-.987 1.992-1.199 1.582-2.962 2.462-4.948 2.451-1.583-.008-2.986-.587-4.21-1.736a.145.145 0 00-.14-.032c-.518.167-1.04.191-1.604.185a5.924 5.924 0 01-2.595-.622 6.058 6.058 0 01-2.146-1.781c-.203-.269-.404-.522-.551-.821a7.74 7.74 0 01-.495-1.283 6.11 6.11 0 01-.017-3.064.166.166 0 00.008-.074.115.115 0 00-.037-.064 5.958 5.958 0 01-1.38-2.202 5.196 5.196 0 01-.333-1.589 6.915 6.915 0 01.188-2.132c.45-1.484 1.309-2.648 2.577-3.493.282-.188.55-.334.802-.438.286-.12.573-.22.861-.304a.129.129 0 00.087-.087A6.016 6.016 0 015.635 2.31C6.315 1.464 7.132.846 8.086.457zm-.804 7.85a.848.848 0 00-1.473.842l1.694 2.965-1.688 2.848a.849.849 0 001.46.864l1.94-3.272a.849.849 0 00.007-.854l-1.94-3.393zm5.446 6.24a.849.849 0 000 1.695h4.848a.849.849 0 000-1.696h-4.848z";
+
+const COPILOT_PATH =
+  "M23.922 16.997C23.061 18.492 18.063 22.02 12 22.02 5.937 22.02.939 18.492.078 16.997A.641.641 0 0 1 0 16.741v-2.869a.883.883 0 0 1 .053-.22c.372-.935 1.347-2.292 2.605-2.656.167-.429.414-1.055.644-1.517a10.098 10.098 0 0 1-.052-1.086c0-1.331.282-2.499 1.132-3.368.397-.406.89-.717 1.474-.952C7.255 2.937 9.248 1.98 11.978 1.98c2.731 0 4.767.957 6.166 2.093.584.235 1.077.546 1.474.952.85.869 1.132 2.037 1.132 3.368 0 .368-.014.733-.052 1.086.23.462.477 1.088.644 1.517 1.258.364 2.233 1.721 2.605 2.656a.841.841 0 0 1 .053.22v2.869a.641.641 0 0 1-.078.256Zm-11.75-5.992h-.344a4.359 4.359 0 0 1-.355.508c-.77.947-1.918 1.492-3.508 1.492-1.725 0-2.989-.359-3.782-1.259a2.137 2.137 0 0 1-.085-.104L4 11.746v6.585c1.435.779 4.514 2.179 8 2.179 3.486 0 6.565-1.4 8-2.179v-6.585l-.098-.104s-.033.045-.085.104c-.793.9-2.057 1.259-3.782 1.259-1.59 0-2.738-.545-3.508-1.492a4.359 4.359 0 0 1-.355-.508Zm2.328 3.25c.549 0 1 .451 1 1v2c0 .549-.451 1-1 1-.549 0-1-.451-1-1v-2c0-.549.451-1 1-1Zm-5 0c.549 0 1 .451 1 1v2c0 .549-.451 1-1 1-.549 0-1-.451-1-1v-2c0-.549.451-1 1-1Zm3.313-6.185c.136 1.057.403 1.913.878 2.497.442.544 1.134.938 2.344.938 1.573 0 2.292-.337 2.657-.751.384-.435.558-1.15.558-2.361 0-1.14-.243-1.847-.705-2.319-.477-.488-1.319-.862-2.824-1.025-1.487-.161-2.192.138-2.533.529-.269.307-.437.808-.438 1.578v.021c0 .265.021.562.063.893Zm-1.626 0c.042-.331.063-.628.063-.894v-.02c-.001-.77-.169-1.271-.438-1.578-.341-.391-1.046-.69-2.533-.529-1.505.163-2.347.537-2.824 1.025-.462.472-.705 1.179-.705 2.319 0 1.211.175 1.926.558 2.361.365.414 1.084.751 2.657.751 1.21 0 1.902-.394 2.344-.938.475-.584.742-1.44.878-2.497Z";
 
 const CURSOR_PATH =
   "M11.503.131 1.891 5.678a.84.84 0 0 0-.42.726v11.188c0 .3.162.575.42.724l9.609 5.55a1 1 0 0 0 .998 0l9.61-5.55a.84.84 0 0 0 .42-.724V6.404a.84.84 0 0 0-.42-.726L12.497.131a1.01 1.01 0 0 0-.996 0M2.657 6.338h18.55c.263 0 .43.287.297.515L12.23 22.918c-.062.107-.229.064-.229-.06V12.335a.59.59 0 0 0-.295-.51l-9.11-5.257c-.109-.063-.064-.23.061-.23";
@@ -128,6 +132,20 @@ function ConductorMark({ className }: MarkProps): React.JSX.Element {
   );
 }
 
+function CopilotMark({ className }: MarkProps): React.JSX.Element {
+  return (
+    <svg
+      className={className}
+      data-mark={PROVIDER_ID.COPILOT}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path fill="currentColor" d={COPILOT_PATH} />
+    </svg>
+  );
+}
+
 function CursorMark({ className }: MarkProps): React.JSX.Element {
   return (
     <svg
@@ -184,6 +202,7 @@ const PROVIDER_MARKS = new Map<string, (props: MarkProps) => React.JSX.Element>(
   [PROVIDER_ID.CLAUDE_CODE, ClaudeCodeMark],
   [PROVIDER_ID.CODEX, CodexMark],
   [PROVIDER_ID.CONDUCTOR, ConductorMark],
+  [PROVIDER_ID.COPILOT, CopilotMark],
   [PROVIDER_ID.CURSOR, CursorMark],
   [PROVIDER_ID.DEVIN, DevinMark],
   [PROVIDER_ID.JULES, JulesMark],

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -22,6 +22,7 @@
   --mark-codex-middle: #7a9dff;
   --mark-codex-bottom: #3941ff;
   --mark-conductor: #eae8e6;
+  --mark-copilot: #ffffff;
   --mark-cursor: #ffffff;
   --mark-devin: #ffffff;
   --mark-jules: #715cd7;
@@ -595,6 +596,13 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 .provider-mark[data-mark="conductor"] {
   color: var(--mark-conductor);
   transform: scale(0.93);
+}
+
+/* Copilot fills its box edge to edge the way the Codex and Cursor marks do, so
+   it takes the same scale they do. */
+.provider-mark[data-mark="copilot"] {
+  color: var(--mark-copilot);
+  transform: scale(0.94);
 }
 
 .provider-mark[data-mark="cursor"] {

--- a/apps/desktop/src/shared/credential-providers.ts
+++ b/apps/desktop/src/shared/credential-providers.ts
@@ -9,6 +9,7 @@ import { PROVIDER_ID } from "@sidecar/core";
  */
 export const CREDENTIAL_PROVIDER_ID = {
   CONDUCTOR: PROVIDER_ID.CONDUCTOR,
+  COPILOT: PROVIDER_ID.COPILOT,
   CURSOR: PROVIDER_ID.CURSOR,
   DEVIN: PROVIDER_ID.DEVIN,
   JULES: PROVIDER_ID.JULES,
@@ -24,6 +25,10 @@ export type CredentialProviderId =
 const CONDUCTOR_ENVIRONMENT = {
   API_KEY: "CONDUCTOR_API_KEY",
   API_TOKEN: "CONDUCTOR_API_TOKEN",
+} as const;
+
+const COPILOT_ENVIRONMENT = {
+  API_KEY: "COPILOT_API_KEY",
 } as const;
 
 const CURSOR_ENVIRONMENT = {
@@ -81,6 +86,20 @@ export const CREDENTIAL_PROVIDERS: Readonly<Record<CredentialProviderId, Credent
     hint: "Create a key in Conductor under Settings · API keys.",
     apiKeysUrl: "https://app.conductor.build/users/api-keys",
     environmentVariables: [CONDUCTOR_ENVIRONMENT.API_KEY, CONDUCTOR_ENVIRONMENT.API_TOKEN],
+  },
+  [CREDENTIAL_PROVIDER_ID.COPILOT]: {
+    id: CREDENTIAL_PROVIDER_ID.COPILOT,
+    displayName: "Copilot",
+    // GitHub's agent-tasks endpoints answer only user tokens. The copy names
+    // the kind to create because the wrong kinds also come from GitHub: a
+    // classic PAT cannot carry the Agent tasks permission, and an installation
+    // token is refused by the endpoint itself.
+    hint: "Create a GitHub fine-grained personal access token with Agent tasks read access. Classic and installation tokens will not work.",
+    apiKeysUrl: "https://github.com/settings/personal-access-tokens/new",
+    environmentVariables: [COPILOT_ENVIRONMENT.API_KEY],
+    // No key format: Luke accepts two kinds GitHub issues — fine-grained
+    // personal access tokens (`github_pat_…`) and GitHub App user tokens
+    // (`ghu_…`) — so a single prefix would refuse a working credential.
   },
   [CREDENTIAL_PROVIDER_ID.CURSOR]: {
     id: CREDENTIAL_PROVIDER_ID.CURSOR,

--- a/apps/desktop/tests/cloud-session-adapter.test.ts
+++ b/apps/desktop/tests/cloud-session-adapter.test.ts
@@ -139,6 +139,47 @@ test("authenticates a bounded read and encodes the route a subclass asked for", 
   ]);
 });
 
+/** Stands in for a provider that asks for its own media type and version pin. */
+class PinnedHeaderAdapter extends StubCloudAdapter {
+  protected override requestHeaders(): Readonly<Record<string, string>> {
+    return { Accept: "application/vnd.stub+json", "X-Stub-Api-Version": "2026-03-10" };
+  }
+}
+
+test("lets a subclass pin its own request headers without touching the credential", async () => {
+  const requests: {
+    accept: string | undefined;
+    version: string | undefined;
+    auth: string | undefined;
+  }[] = [];
+  const fetch: CloudFetch = async (_url, init) => {
+    const headers = new Headers(init.headers);
+    requests.push({
+      accept: headers.get("accept") ?? undefined,
+      version: headers.get("x-stub-api-version") ?? undefined,
+      auth: headers.get("authorization") ?? undefined,
+    });
+    return new Response(JSON.stringify({}), { status: HTTP_STATUS.OK });
+  };
+  const adapter = new PinnedHeaderAdapter({
+    readApiKey: async () => TEST_API_KEY,
+    baseUrl: TEST_BASE_URL,
+    fetch,
+    now: () => TEST_TIME,
+    minimumRefreshIntervalMs: 0,
+  });
+
+  await adapter.observe();
+
+  assert.deepEqual(requests, [
+    {
+      accept: "application/vnd.stub+json",
+      version: "2026-03-10",
+      auth: `Bearer ${TEST_API_KEY}`,
+    },
+  ]);
+});
+
 test("reports every session it serves as running in the cloud", async () => {
   const stub = stubFetch();
   const adapter = adapterFor(stub.fetch);

--- a/apps/desktop/tests/copilot-adapter.test.ts
+++ b/apps/desktop/tests/copilot-adapter.test.ts
@@ -1,0 +1,478 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { SESSION_STATUS } from "@sidecar/core";
+import type { CloudFetch } from "../src/cloud-session-adapter";
+import { COPILOT_PROVIDER, CopilotSessionAdapter } from "../src/copilot-adapter";
+
+const TEST_TIME = Date.parse("2026-08-13T02:45:00.000Z");
+const TEST_BASE_URL = "https://github.test";
+const TEST_API_KEY = "github_pat_test-token";
+const TEST_OWNER = "reviewstage";
+const TEST_REPOSITORY = "luke";
+const SECRET_PROMPT_TEXT = "SECRET_PROMPT_TEXT";
+
+/** The documented `state` enum for the public-preview agent-tasks API. */
+const TEST_STATE = {
+  QUEUED: "queued",
+  IN_PROGRESS: "in_progress",
+  COMPLETED: "completed",
+  FAILED: "failed",
+  IDLE: "idle",
+  WAITING_FOR_USER: "waiting_for_user",
+  TIMED_OUT: "timed_out",
+  CANCELLED: "cancelled",
+} as const;
+
+const HTTP_STATUS = {
+  OK: 200,
+  UNAUTHORIZED: 401,
+  SERVER_ERROR: 500,
+} as const;
+
+interface TestTask {
+  id: string;
+  state?: string;
+  repository?: string;
+  omitUrl?: boolean;
+  omitArtifacts?: boolean;
+  baseRef?: string;
+  archivedAt?: number;
+  createdAt: number;
+  updatedAt?: number;
+}
+
+interface RecordedRequest {
+  method: string;
+  pathname: string;
+  search: string;
+  authorization: string | undefined;
+  accept: string | undefined;
+  apiVersion: string | undefined;
+}
+
+interface FakeAgentTasksApi {
+  fetch: CloudFetch;
+  requests: RecordedRequest[];
+}
+
+function isoTimestamp(timestampMs: number): string {
+  return new Date(timestampMs).toISOString();
+}
+
+function jsonResponse(body: unknown, status = HTTP_STATUS.OK): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function lastActivityAt(task: TestTask): number {
+  return task.updatedAt ?? task.createdAt;
+}
+
+function taskPayload(task: TestTask): Record<string, unknown> {
+  const repository = task.repository ?? TEST_REPOSITORY;
+  return {
+    id: task.id,
+    ...(task.omitUrl
+      ? {}
+      : {
+          url: `https://api.github.com/agents/repos/${TEST_OWNER}/${repository}/tasks/${task.id}`,
+        }),
+    html_url: `https://github.com/${TEST_OWNER}/${repository}/copilot/tasks/${task.id}`,
+    // GitHub documents `name` as derived from the task prompt, and the branch
+    // Copilot opens is named from the same text, so neither may reach a row.
+    name: `${SECRET_PROMPT_TEXT} title`,
+    creator: { id: 1 },
+    creator_type: "user",
+    owner: { id: 1 },
+    repository: { id: 1296269 },
+    state: task.state ?? TEST_STATE.IN_PROGRESS,
+    session_count: 1,
+    ...(task.omitArtifacts
+      ? { artifacts: [] }
+      : {
+          artifacts: [
+            { provider: "github", type: "pull", data: { id: 42, global_id: "PR_global" } },
+            {
+              provider: "github",
+              type: "branch",
+              data: {
+                head_ref: `copilot/${SECRET_PROMPT_TEXT}`,
+                base_ref: task.baseRef ?? "main",
+              },
+            },
+          ],
+        }),
+    archived_at: task.archivedAt === undefined ? null : isoTimestamp(task.archivedAt),
+    created_at: isoTimestamp(task.createdAt),
+    updated_at: isoTimestamp(lastActivityAt(task)),
+  };
+}
+
+/** Serves the read-only subset of the agent-tasks API the adapter may use. */
+function fakeAgentTasksApi(tasks: readonly TestTask[]): FakeAgentTasksApi {
+  const requests: RecordedRequest[] = [];
+  const fetch: CloudFetch = async (url, init) => {
+    const { pathname, searchParams, search } = new URL(url);
+    const headers = new Headers(init.headers);
+    requests.push({
+      method: init.method ?? "",
+      pathname,
+      search,
+      authorization: headers.get("authorization") ?? undefined,
+      accept: headers.get("accept") ?? undefined,
+      apiVersion: headers.get("x-github-api-version") ?? undefined,
+    });
+
+    const segments = pathname.split("/").filter((segment) => segment.length > 0);
+    if (segments.length !== 2 || segments[0] !== "agents" || segments[1] !== "tasks") {
+      return jsonResponse({}, HTTP_STATUS.SERVER_ERROR);
+    }
+
+    // GitHub sorts by `updated_at` descending by default, but the fake answers
+    // in the order it was given: the adapter must order the pass itself.
+    const pageSize = Number(searchParams.get("per_page") ?? "30");
+    const page = tasks.slice(0, pageSize);
+    return jsonResponse({
+      tasks: page.map(taskPayload),
+      total_active_count: tasks.length,
+      total_archived_count: 0,
+    });
+  };
+  return { fetch, requests };
+}
+
+function adapterFor(
+  fetch: CloudFetch,
+  overrides: {
+    apiKey?: string | undefined;
+    readApiKey?: () => Promise<string | undefined>;
+    now?: () => number;
+    minimumRefreshIntervalMs?: number;
+    maximumObservedTasks?: number;
+  } = {},
+): CopilotSessionAdapter {
+  const apiKey = "apiKey" in overrides ? overrides.apiKey : TEST_API_KEY;
+  return new CopilotSessionAdapter({
+    readApiKey: overrides.readApiKey ?? (async () => apiKey),
+    baseUrl: TEST_BASE_URL,
+    fetch,
+    now: overrides.now ?? (() => TEST_TIME),
+    minimumRefreshIntervalMs: overrides.minimumRefreshIntervalMs ?? 0,
+    ...(overrides.maximumObservedTasks === undefined
+      ? {}
+      : { maximumObservedTasks: overrides.maximumObservedTasks }),
+  });
+}
+
+function workingTask(id: string, updatedAt: number): TestTask {
+  return { id, state: TEST_STATE.IN_PROGRESS, createdAt: updatedAt, updatedAt };
+}
+
+test("observes a task in progress without exposing prompt-derived text", async () => {
+  const api = fakeAgentTasksApi([
+    {
+      id: "task-in-progress",
+      state: TEST_STATE.IN_PROGRESS,
+      createdAt: TEST_TIME - 60_000,
+      updatedAt: TEST_TIME - 30_000,
+    },
+  ]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.deepEqual(COPILOT_PROVIDER, { id: "copilot", displayName: "Copilot" });
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "task-in-progress");
+  assert.equal(observations[0]?.title, "luke");
+  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
+  assert.equal(observations[0]?.observedAt, TEST_TIME - 30_000);
+  assert.equal(observations[0]?.controls, undefined);
+  // The row is worded by the surface from these fields, never by the adapter.
+  assert.equal(observations[0]?.summary, undefined);
+  assert.deepEqual(observations[0]?.detail, {
+    repository: "luke",
+    branch: "main",
+    link: `https://github.com/${TEST_OWNER}/luke/copilot/tasks/task-in-progress`,
+  });
+  // Neither the task's name nor the branch Copilot named from the prompt.
+  assert.equal(JSON.stringify(observations).includes(SECRET_PROMPT_TEXT), false);
+});
+
+test("reads the whole pass with one pinned, GitHub-typed list call", async () => {
+  const api = fakeAgentTasksApi([
+    workingTask("task-one", TEST_TIME - 1_000),
+    workingTask("task-two", TEST_TIME - 2_000),
+  ]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations.length, 2);
+  assert.deepEqual(
+    api.requests.map((request) => request.pathname),
+    ["/agents/tasks"],
+  );
+  const since = isoTimestamp(TEST_TIME - 24 * 60 * 60 * 1000);
+  assert.equal(api.requests[0]?.search, `?per_page=100&since=${encodeURIComponent(since)}`);
+  assert.equal(api.requests[0]?.method, "GET");
+  assert.equal(api.requests[0]?.authorization, `Bearer ${TEST_API_KEY}`);
+  // GitHub's own media type rather than plain JSON, and the endpoint is in
+  // public preview, so the dated API version must ride every request.
+  assert.equal(api.requests[0]?.accept, "application/vnd.github+json");
+  assert.equal(api.requests[0]?.apiVersion, "2026-03-10");
+});
+
+test("maps every state GitHub reports onto a state Luke can show", async () => {
+  const api = fakeAgentTasksApi(
+    (
+      [
+        [TEST_STATE.QUEUED, "queued"],
+        [TEST_STATE.IN_PROGRESS, "in-progress"],
+        [TEST_STATE.WAITING_FOR_USER, "waiting"],
+        [TEST_STATE.COMPLETED, "completed"],
+        [TEST_STATE.CANCELLED, "cancelled"],
+        [TEST_STATE.FAILED, "failed"],
+        [TEST_STATE.TIMED_OUT, "timed-out"],
+        [TEST_STATE.IDLE, "idle"],
+        ["SOME_LATER_STATE", "later-state"],
+      ] as const
+    ).map(([state, name], index) => ({
+      id: `task-${name}`,
+      state,
+      createdAt: TEST_TIME - (index + 1) * 1_000,
+      updatedAt: TEST_TIME - (index + 1) * 1_000,
+    })),
+  );
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => [observation.providerSessionId, observation.status]),
+    [
+      ["task-queued", SESSION_STATUS.WORKING],
+      ["task-in-progress", SESSION_STATUS.WORKING],
+      ["task-waiting", SESSION_STATUS.WAITING],
+      ["task-completed", SESSION_STATUS.COMPLETE],
+      ["task-cancelled", SESSION_STATUS.COMPLETE],
+      // A failed or timed-out task can be sent back to work with a new
+      // session, so neither is promoted to an error Luke cannot describe.
+      ["task-failed", SESSION_STATUS.UNKNOWN],
+      ["task-timed-out", SESSION_STATUS.UNKNOWN],
+      ["task-idle", SESSION_STATUS.UNKNOWN],
+      ["task-later-state", SESSION_STATUS.UNKNOWN],
+    ],
+  );
+});
+
+test("keeps reporting a long turn as working", async () => {
+  // `updated_at` marks when the task last changed rather than a heartbeat, so
+  // a turn that started an hour ago and is still going must not read as stale.
+  const startedAt = TEST_TIME - 60 * 60 * 1000;
+  const api = fakeAgentTasksApi([workingTask("task-long-turn", startedAt)]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
+  assert.equal(observations[0]?.observedAt, startedAt);
+});
+
+test("stops calling a task that asked for the user waiting once it goes stale", async () => {
+  const askedAt = TEST_TIME - 2 * 60 * 60 * 1000;
+  const api = fakeAgentTasksApi([
+    {
+      id: "task-abandoned",
+      state: TEST_STATE.WAITING_FOR_USER,
+      createdAt: askedAt,
+      updatedAt: askedAt,
+    },
+  ]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
+});
+
+test("keeps a completed task complete however long ago it finished", async () => {
+  const finishedAt = TEST_TIME - 8 * 60 * 60 * 1000;
+  const api = fakeAgentTasksApi([
+    {
+      id: "task-finished",
+      state: TEST_STATE.COMPLETED,
+      createdAt: finishedAt,
+      updatedAt: finishedAt,
+    },
+  ]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations[0]?.status, SESSION_STATUS.COMPLETE);
+});
+
+test("reports a task the user filed away as settled whatever it was doing", async () => {
+  const api = fakeAgentTasksApi([
+    {
+      id: "task-archived",
+      state: TEST_STATE.WAITING_FOR_USER,
+      archivedAt: TEST_TIME - 1_000,
+      createdAt: TEST_TIME - 2_000,
+      updatedAt: TEST_TIME - 1_000,
+    },
+  ]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations[0]?.status, SESSION_STATUS.COMPLETE);
+});
+
+test("ignores tasks untouched for longer than the maximum session age", async () => {
+  const api = fakeAgentTasksApi([workingTask("task-last-week", TEST_TIME - 48 * 60 * 60 * 1000)]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.deepEqual(observations, []);
+});
+
+test("orders the pass itself rather than trusting the order GitHub answers in", async () => {
+  const api = fakeAgentTasksApi([
+    workingTask("task-oldest", TEST_TIME - 3_000),
+    workingTask("task-newest", TEST_TIME - 1_000),
+    workingTask("task-middle", TEST_TIME - 2_000),
+  ]);
+
+  const observations = await adapterFor(api.fetch, { maximumObservedTasks: 2 }).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.providerSessionId),
+    ["task-newest", "task-middle"],
+  );
+});
+
+test("labels a task by its repository, and by neither its name nor nothing", async () => {
+  const api = fakeAgentTasksApi([
+    { id: "task-repository", repository: "sidecar", createdAt: TEST_TIME - 1_000 },
+    { id: "task-addressless", omitUrl: true, omitArtifacts: true, createdAt: TEST_TIME - 2_000 },
+  ]);
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  // The repository is read from the task's own API address — the list
+  // projection names the repository only by a numeric id.
+  assert.equal(observations[0]?.title, "sidecar");
+  assert.equal(observations[0]?.detail?.repository, "sidecar");
+  assert.equal(observations[1]?.title, "workspace");
+  assert.equal(observations[1]?.detail?.branch, undefined);
+  assert.equal(JSON.stringify(observations).includes(SECRET_PROMPT_TEXT), false);
+});
+
+test("drops a task it cannot place in time without losing the rest of the pass", async () => {
+  const fetch: CloudFetch = async () =>
+    jsonResponse({
+      tasks: [
+        { state: TEST_STATE.IN_PROGRESS },
+        { id: "task-undated", state: TEST_STATE.IN_PROGRESS },
+        taskPayload({ id: "task-complete", createdAt: TEST_TIME - 1_000 }),
+      ],
+    });
+
+  const observations = await adapterFor(fetch).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.providerSessionId),
+    ["task-complete"],
+  );
+});
+
+test("reports nothing and issues no request without an API key", async () => {
+  const api = fakeAgentTasksApi([workingTask("task-in-progress", TEST_TIME - 1_000)]);
+
+  const observations = await adapterFor(api.fetch, { apiKey: undefined }).observe();
+
+  assert.deepEqual(observations, []);
+  assert.deepEqual(api.requests, []);
+});
+
+test("reports nothing when the credential cannot be read", async () => {
+  const api = fakeAgentTasksApi([workingTask("task-in-progress", TEST_TIME - 1_000)]);
+  const adapter = adapterFor(api.fetch, {
+    readApiKey: async () => {
+      throw new Error("settings are unreadable");
+    },
+  });
+
+  assert.deepEqual(await adapter.observe(), []);
+  assert.deepEqual(api.requests, []);
+});
+
+test("reuses the previous snapshot inside the minimum refresh interval", async () => {
+  const api = fakeAgentTasksApi([workingTask("task-in-progress", TEST_TIME - 1_000)]);
+  let now = TEST_TIME;
+  const adapter = adapterFor(api.fetch, { now: () => now, minimumRefreshIntervalMs: 15_000 });
+
+  const first = await adapter.observe();
+  now = TEST_TIME + 5_000;
+  const throttled = await adapter.observe();
+  const requestsAfterThrottledPass = api.requests.length;
+  now = TEST_TIME + 20_000;
+  const refreshed = await adapter.observe();
+
+  assert.equal(first.length, 1);
+  assert.deepEqual(throttled, first);
+  assert.equal(requestsAfterThrottledPass, 1, "throttled pass issued a request");
+  assert.equal(api.requests.length, 2, "refreshed pass issued no request");
+  assert.equal(refreshed.length, 1);
+});
+
+test("observes again immediately after the API key changes", async () => {
+  const api = fakeAgentTasksApi([workingTask("task-in-progress", TEST_TIME - 1_000)]);
+  let apiKey = TEST_API_KEY;
+  const adapter = adapterFor(api.fetch, {
+    readApiKey: async () => apiKey,
+    minimumRefreshIntervalMs: 60_000,
+  });
+
+  await adapter.observe();
+  const requestsAfterFirstPass = api.requests.length;
+  apiKey = "github_pat_replacement-token";
+  const observations = await adapter.observe();
+
+  assert.ok(api.requests.length > requestsAfterFirstPass);
+  assert.equal(observations.length, 1);
+  assert.equal(
+    api.requests.at(-1)?.authorization,
+    "Bearer github_pat_replacement-token",
+    "the replacement key was not used",
+  );
+});
+
+test("clears observations when GitHub rejects the token", async () => {
+  const api = fakeAgentTasksApi([workingTask("task-in-progress", TEST_TIME - 1_000)]);
+  let rejectRequests = false;
+  const gatedFetch: CloudFetch = async (url, init) =>
+    rejectRequests ? jsonResponse({}, HTTP_STATUS.UNAUTHORIZED) : api.fetch(url, init);
+  const adapter = adapterFor(gatedFetch);
+
+  const authorized = await adapter.observe();
+  rejectRequests = true;
+  const rejected = await adapter.observe();
+
+  assert.equal(authorized.length, 1);
+  assert.deepEqual(rejected, []);
+});
+
+test("keeps the previous snapshot when the list request fails transiently", async () => {
+  const api = fakeAgentTasksApi([workingTask("task-in-progress", TEST_TIME - 1_000)]);
+  let failRequests = false;
+  const gatedFetch: CloudFetch = async (url, init) => {
+    if (failRequests) throw new Error("network unreachable");
+    return api.fetch(url, init);
+  };
+  const adapter = adapterFor(gatedFetch);
+
+  const observed = await adapter.observe();
+  failRequests = true;
+  const duringOutage = await adapter.observe();
+
+  assert.equal(observed.length, 1);
+  assert.deepEqual(duringOutage, observed);
+});

--- a/apps/desktop/tests/credential-providers.test.ts
+++ b/apps/desktop/tests/credential-providers.test.ts
@@ -37,6 +37,22 @@ test("describes every provider it lists", () => {
   }
 });
 
+test("sends the user to the one GitHub token kind the agent-tasks API answers", () => {
+  const copilot = CREDENTIAL_PROVIDERS[CREDENTIAL_PROVIDER_ID.COPILOT];
+
+  assert.equal(copilot.displayName, "Copilot");
+  assert.deepEqual(copilot.environmentVariables, ["COPILOT_API_KEY"]);
+  // The endpoint takes only user tokens, and GitHub also issues the kinds it
+  // refuses, so the copy has to name what to create and what will not work.
+  assert.match(copilot.hint, /fine-grained personal access token/i);
+  assert.match(copilot.hint, /Agent tasks/);
+  assert.match(copilot.hint, /installation/i);
+  assert.match(copilot.apiKeysUrl, /personal-access-tokens\/new$/);
+  // No key format: fine-grained PATs and GitHub App user tokens carry
+  // different prefixes, and a single one would refuse a working credential.
+  assert.equal(copilot.keyFormat, undefined);
+});
+
 test("takes only the Devin credentials its API version issues", () => {
   const devin = CREDENTIAL_PROVIDERS[CREDENTIAL_PROVIDER_ID.DEVIN];
 

--- a/packages/sidecar-core/src/providers.ts
+++ b/packages/sidecar-core/src/providers.ts
@@ -9,6 +9,7 @@ export const PROVIDER_ID = {
   CLAUDE_CODE: "claude-code",
   CODEX: "codex",
   CONDUCTOR: "conductor",
+  COPILOT: "copilot",
   CURSOR: "cursor",
   DEVIN: "devin",
   JULES: "jules",


### PR DESCRIPTION
## Summary

Adds a `CopilotSessionAdapter` on `CloudSessionAdapter` that observes GitHub Copilot coding-agent tasks through the public-preview agent-tasks API ([LUKE-61](https://linear.app/stage-review/issue/LUKE-61/integrate-github-copilot-coding-agent-tasks)).

- One read-only `GET /agents/tasks` call per pass, bounded by `per_page=100` and a `since` of the 24-hour observation window.
- `CloudSessionAdapter` gains an overridable `requestHeaders()`; Copilot overrides it with `Accept: application/vnd.github+json` and the `X-GitHub-Api-Version: 2026-03-10` pin (verified against `GET /versions`). The authorization header is layered on after the hook, so no override can replace the credential.
- State mapping per the ticket: `waiting_for_user` → waiting; `queued`/`in_progress` → working; `completed`/`cancelled` → complete; `failed`/`timed_out`/`idle` → unknown. An unrecognized state is left unknown via the shared `knownValue` guard rather than throwing. A non-null `archived_at` reads as complete, and only waiting decays when stale.
- GitHub's OpenAPI description documents a task's `name` as *derived from the task prompt*, so it never reaches a row. Rows are titled by the repository parsed from the task's own API address (`/agents/repos/{owner}/{repo}/tasks/{id}`); the list projection names the repository only by numeric id. From the branch artifact only the user-chosen `base_ref` is surfaced — `head_ref` is Copilot-named from the prompt and stays off the row.
- Settings copy makes the supported token type explicit: a fine-grained PAT with **Agent tasks: read** (or a GitHub App user token); classic PATs and installation tokens are called out as unsupported. No `keyFormat` prefix is enforced because two valid prefixes exist (`github_pat_…`, `ghu_…`).
- Copilot mark via Simple Icons (MIT, sourced from Primer), drawn light like Cursor and Devin.

## Testing

- `./scripts/check.sh` passes (231 desktop tests, 0 failures), including a full adapter matrix in `copilot-adapter.test.ts`, a base-class test for the header hook, and a registry test pinning the settings copy.
- Live-validated the request shape against api.github.com with a real fine-grained PAT: `HTTP 200` with the exact headers and query the adapter sends.
- `./scripts/verify.sh` was not run (implemented in a Linux sandbox) and no physical-notch check was performed. The UI delta is the Copilot settings row and the provider mark, which only renders beside a live Copilot session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/9706bcf7-c035-4e64-a118-e78907b20415)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31748460231/artifacts/9199975624) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31748460231)

- Commit: `46dab8526ad7ab2da484b924170f2b48a60db4fc`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
