### PR TITLE
feat(LUKE-60): integrate local OpenCode sessions

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -9,6 +9,12 @@ the current implementation; it is not a promise about third-party services.
   read-only, and inspects them in memory.
 - For Codex, Luke opens the local SQLite state database in read-only mode and
   reads the recent rollout logs named by its thread records.
+- For OpenCode, Luke opens the local session database in read-only mode and
+  reads session records plus the bookkeeping of a session's newest message and
+  tool records — roles, timestamps, tool names and inputs, and recorded
+  errors — not the message text, which is never opened. Installs from before
+  OpenCode moved its sessions into that database are read from its session and
+  message JSON files with the same boundary.
 - For the Cursor agents running on this machine, Luke finds recent transcripts,
   opens bounded tails read-only, and reads only the markers around a turn — its
   end and how it ended. It does not read message content, and reports the fact

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Download published builds from [GitHub Releases](https://github.com/ReviewStage/
 - Devin — reads cloud session metadata after you supply a Devin personal access
   token
 - Jules — reads cloud session metadata after you supply a Jules API key
+- OpenCode — reads local session state; no provider credential required
 
 Cursor is the one provider Luke watches in two places, and both halves arrive as
 Cursor sessions: the ones on this machine need no credential, and its cloud
@@ -138,7 +139,8 @@ Gatekeeper without an override. You can also assess the installed app with
 
 ## Optional attention review
 
-Session monitoring does not require `OPENAI_API_KEY`: Claude Code and Codex use
+Session monitoring does not require `OPENAI_API_KEY`: Claude Code, Codex, and
+OpenCode use
 local state, while Conductor, Cursor, and Devin use their separately configured
 provider credentials. If `OPENAI_API_KEY` is set, Luke can also send a bounded status update to
 the configured Responses endpoint for attention classification. That update can

--- a/apps/desktop/src/codex-adapter.ts
+++ b/apps/desktop/src/codex-adapter.ts
@@ -1,4 +1,3 @@
-import type { Stats } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -12,6 +11,12 @@ import {
   type SessionProvider,
   type SessionProviderAdapter,
 } from "@sidecar/core";
+import {
+  canIgnoreSqliteError,
+  defaultSqliteModule,
+  openReadOnlyDatabase,
+  type SqliteModuleLoader,
+} from "./local-sqlite";
 
 const CODEX_PROVIDER_ID = PROVIDER_ID.CODEX;
 const CODEX_PROVIDER_NAME = "Codex";
@@ -127,22 +132,6 @@ const CODEX_THREAD_QUERY = `
 
 type CodexThreadRow = Record<string, unknown>;
 
-interface SqliteStatement {
-  all(...anonymousParameters: readonly unknown[]): unknown[];
-}
-
-interface SqliteDatabase {
-  close(): void;
-  enableDefensive?(enabled: boolean): void;
-  prepare(source: string): SqliteStatement;
-}
-
-interface SqliteModule {
-  DatabaseSync: new (location: string, options: { readOnly: boolean }) => SqliteDatabase;
-}
-
-type SqliteModuleLoader = () => Promise<SqliteModule>;
-
 export const CODEX_PROVIDER: SessionProvider = {
   id: CODEX_PROVIDER_ID,
   displayName: CODEX_PROVIDER_NAME,
@@ -180,23 +169,6 @@ function canIgnoreFilesystemError(error: unknown): boolean {
       error.code === "EACCES" ||
       error.code === "EPERM")
   );
-}
-
-function canIgnoreSqliteError(error: unknown): boolean {
-  if (isNodeError(error) && error.code === "ERR_UNKNOWN_BUILTIN_MODULE") return true;
-  if (!(error instanceof Error)) return false;
-  return /no such table|no such column|unable to open database file|readonly database/i.test(
-    error.message,
-  );
-}
-
-async function fileStats(filePath: string): Promise<Stats | undefined> {
-  try {
-    return await fs.stat(filePath);
-  } catch (error) {
-    if (canIgnoreFilesystemError(error)) return undefined;
-    throw error;
-  }
 }
 
 async function readTextFile(filePath: string): Promise<string | undefined> {
@@ -331,28 +303,6 @@ function parseCodexRolloutTail(tail: string): ParsedCodexRollout {
     }
   }
   return parsed;
-}
-
-async function defaultSqliteModule(): Promise<SqliteModule> {
-  return (await import("node:sqlite")) as SqliteModule;
-}
-
-async function openReadOnlyDatabase(
-  sqlite: SqliteModuleLoader,
-  filePath: string,
-): Promise<SqliteDatabase | undefined> {
-  const stats = await fileStats(filePath);
-  if (!stats?.isFile()) return undefined;
-
-  try {
-    const module = await sqlite();
-    const database = new module.DatabaseSync(filePath, { readOnly: true });
-    database.enableDefensive?.(true);
-    return database;
-  } catch (error) {
-    if (canIgnoreSqliteError(error) || canIgnoreFilesystemError(error)) return undefined;
-    throw error;
-  }
 }
 
 function numberFromRow(row: CodexThreadRow, key: string): number | undefined {

--- a/apps/desktop/src/local-sqlite.ts
+++ b/apps/desktop/src/local-sqlite.ts
@@ -1,0 +1,63 @@
+import { canIgnoreFilesystemError, fileStats } from "./local-session-adapter";
+
+/**
+ * The shared half of every adapter that reads a provider's SQLite state:
+ * read-only opens of a database another process owns, and the errors that mean
+ * "observe nothing here" rather than "the observation pass failed". Nothing
+ * here opens a database for writing, and no caller may.
+ */
+
+export interface SqliteStatement {
+  all(...anonymousParameters: readonly unknown[]): unknown[];
+}
+
+export interface SqliteDatabase {
+  close(): void;
+  enableDefensive?(enabled: boolean): void;
+  prepare(source: string): SqliteStatement;
+}
+
+export interface SqliteModule {
+  DatabaseSync: new (location: string, options: { readOnly: boolean }) => SqliteDatabase;
+}
+
+export type SqliteModuleLoader = () => Promise<SqliteModule>;
+
+export async function defaultSqliteModule(): Promise<SqliteModule> {
+  return (await import("node:sqlite")) as SqliteModule;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
+
+/**
+ * A runtime without `node:sqlite`, a database another process holds, or a
+ * schema this build does not know all mean the same thing an absent provider
+ * directory means: nothing to observe, not a failed pass.
+ */
+export function canIgnoreSqliteError(error: unknown): boolean {
+  if (isNodeError(error) && error.code === "ERR_UNKNOWN_BUILTIN_MODULE") return true;
+  if (!(error instanceof Error)) return false;
+  return /no such table|no such column|unable to open database file|readonly database/i.test(
+    error.message,
+  );
+}
+
+export async function openReadOnlyDatabase(
+  sqlite: SqliteModuleLoader,
+  filePath: string,
+): Promise<SqliteDatabase | undefined> {
+  const stats = await fileStats(filePath);
+  if (!stats?.isFile()) return undefined;
+
+  try {
+    const module = await sqlite();
+    const database = new module.DatabaseSync(filePath, { readOnly: true });
+    database.enableDefensive?.(true);
+    return database;
+  } catch (error) {
+    if (canIgnoreSqliteError(error) || canIgnoreFilesystemError(error)) return undefined;
+    throw error;
+  }
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -38,6 +38,7 @@ import { DevinSessionAdapter } from "./devin-adapter";
 import { JulesSessionAdapter } from "./jules-adapter";
 import { readMacScreenGeometry } from "./macos-screen-geometry";
 import { openAiAttentionEvaluatorFromEnvironment } from "./openai-attention-evaluator";
+import { OpenCodeSessionAdapter } from "./opencode-adapter";
 import { SettingsStore } from "./settings-store";
 import {
   type AppBootstrap,
@@ -123,6 +124,7 @@ const sessionAdapters = [
   cursorAdapter,
   devinAdapter,
   julesAdapter,
+  new OpenCodeSessionAdapter(),
 ] as const;
 // A fixture run must stay deterministic and credential-free, so it never builds
 // an evaluator — not just capture runs.

--- a/apps/desktop/src/opencode-adapter.ts
+++ b/apps/desktop/src/opencode-adapter.ts
@@ -111,14 +111,18 @@ const OPENCODE_ABORT_ERROR_NAME = "MessageAbortedError";
  */
 const OPENCODE_PLACEHOLDER_TITLE_PREFIX = "New session - ";
 
-/** Tool inputs whose value names the work, in the order they read best. */
+/**
+ * Tool inputs whose value names the work, in the order they read best. The set
+ * matches what the Claude Code and Codex adapters already report — a URL is
+ * deliberately not in it, because a signed URL is a credential and no other
+ * adapter sends one anywhere; a fetch is named by its tool alone.
+ */
 const OPENCODE_TOOL_INPUT_KEY = [
   "description",
   "command",
   "filePath",
   "file_path",
   "pattern",
-  "url",
   "query",
 ] as const;
 

--- a/apps/desktop/src/opencode-adapter.ts
+++ b/apps/desktop/src/opencode-adapter.ts
@@ -1,0 +1,645 @@
+import os from "node:os";
+import path from "node:path";
+import {
+  maximumSessionTitleLength,
+  PROVIDER_ID,
+  type ProviderSessionObservation,
+  SESSION_STATUS,
+  type SessionDetail,
+  type SessionProvider,
+  type SessionProviderAdapter,
+  type SessionStatus,
+} from "@sidecar/core";
+import {
+  discoverSessionFiles,
+  LOCAL_ADAPTER_DEFAULTS,
+  nonNegativeNumber,
+  positiveInteger,
+  readDirectory,
+  readTextFile,
+  recordFromJsonLine,
+  type SessionFileCandidate,
+  statDirectoryEntry,
+  workspaceLabel,
+} from "./local-session-adapter";
+import {
+  canIgnoreSqliteError,
+  defaultSqliteModule,
+  openReadOnlyDatabase,
+  type SqliteDatabase,
+  type SqliteModuleLoader,
+} from "./local-sqlite";
+
+const OPENCODE_PROVIDER_ID = PROVIDER_ID.OPENCODE;
+const OPENCODE_PROVIDER_NAME = "OpenCode";
+
+const OPENCODE_ENVIRONMENT = {
+  DATA_HOME: "XDG_DATA_HOME",
+  DATABASE_FILE: "OPENCODE_DB",
+} as const;
+
+/** OpenCode keeps XDG data paths on every platform, macOS included. */
+const OPENCODE_DATA_HOME_SEGMENTS = [".local", "share"] as const;
+const OPENCODE_DATA_DIRECTORY_NAME = "opencode";
+
+/**
+ * The databases an install may have written. `opencode.db` is where every
+ * release channel keeps sessions today; `opencode-prod.db` is what prod-channel
+ * builds wrote for a few weeks in early 2026, and a machine that ran one still
+ * holds sessions there.
+ */
+const OPENCODE_DATABASE_FILE = {
+  CURRENT: "opencode.db",
+  PROD_CHANNEL: "opencode-prod.db",
+} as const;
+
+/** A database with no file behind it is nothing for a read-only observer. */
+const OPENCODE_MEMORY_DATABASE = ":memory:";
+
+/**
+ * Where OpenCode kept sessions as flat JSON before v1.2.0 moved them into the
+ * database. The files are left in place after the migration, so they are read
+ * only when no database is usable — a machine the migration has already visited
+ * answers from the database alone. The still older per-project trees of v0.5
+ * and earlier are not read.
+ */
+const OPENCODE_STORAGE_DIRECTORY = "storage";
+const OPENCODE_STORAGE_SEGMENT = {
+  SESSION: "session",
+  MESSAGE: "message",
+} as const;
+const OPENCODE_SESSION_FILE_EXTENSION = ".json";
+
+const OPENCODE_SESSION_COLUMN = {
+  ID: "id",
+  PARENT_ID: "parent_id",
+  DIRECTORY: "directory",
+  TITLE: "title",
+  MODEL: "model",
+  SHARE_URL: "share_url",
+  TIME_CREATED: "time_created",
+  TIME_UPDATED: "time_updated",
+  TIME_ARCHIVED: "time_archived",
+} as const;
+
+const OPENCODE_DATA_COLUMN = "data";
+
+const OPENCODE_ROLE = {
+  ASSISTANT: "assistant",
+} as const;
+
+const OPENCODE_PART_TYPE = {
+  TOOL: "tool",
+} as const;
+
+/** A tool part that has not settled is the work the session is doing now. */
+const OPENCODE_TOOL_STATUS = {
+  PENDING: "pending",
+  RUNNING: "running",
+} as const;
+
+/**
+ * The error OpenCode records when its own user stops a turn. It ends the turn
+ * rather than wedging it, so it reads as waiting and never as a failure.
+ */
+const OPENCODE_ABORT_ERROR_NAME = "MessageAbortedError";
+
+/**
+ * The title OpenCode stamps on a session before it has generated one. It is a
+ * timestamp rather than a name, so a session still carrying it has no name yet
+ * and the workspace stands in — exactly the fallback a nameless session gets.
+ */
+const OPENCODE_PLACEHOLDER_TITLE_PREFIX = "New session - ";
+
+/** Tool inputs whose value names the work, in the order they read best. */
+const OPENCODE_TOOL_INPUT_KEY = [
+  "description",
+  "command",
+  "filePath",
+  "file_path",
+  "pattern",
+  "url",
+  "query",
+] as const;
+
+const OPENCODE_ADAPTER_DEFAULTS = {
+  MAXIMUM_SESSION_ROWS: 40,
+  MAXIMUM_PROJECT_DIRECTORIES: 200,
+  /** Only the sessions that can still change are worth further reads. */
+  MAXIMUM_TURN_READS: 12,
+  /** Enough parts to reach past a finished step's bookkeeping to its tool. */
+  MAXIMUM_PART_ROWS: 8,
+  MAXIMUM_ACTIVITY_LENGTH: 80,
+} as const;
+
+// Every column is read defensively from the row, so the projection stays `*`:
+// OpenCode adds columns by migration, and naming one this build expects but an
+// older install lacks would fail the whole query rather than one field.
+const OPENCODE_SESSION_QUERY = `
+  SELECT *
+  FROM session
+  WHERE parent_id IS NULL
+    AND time_archived IS NULL
+  ORDER BY time_updated DESC, id DESC
+  LIMIT ?
+`;
+
+// The WHERE clause above is the one thing that can name a column an old schema
+// lacks, so a database it fails on is asked again with the filters moved into
+// code, where an absent column is one missing field rather than no sessions.
+const OPENCODE_SESSION_QUERY_MINIMAL = `
+  SELECT *
+  FROM session
+  ORDER BY time_updated DESC, id DESC
+  LIMIT ?
+`;
+
+const OPENCODE_LAST_MESSAGE_QUERY = `
+  SELECT *
+  FROM message
+  WHERE session_id = ?
+  ORDER BY time_created DESC, id DESC
+  LIMIT 1
+`;
+
+const OPENCODE_RECENT_PART_QUERY = `
+  SELECT *
+  FROM part
+  WHERE session_id = ?
+  ORDER BY time_created DESC, id DESC
+  LIMIT ?
+`;
+
+type OpenCodeRow = Record<string, unknown>;
+
+export const OPENCODE_PROVIDER: SessionProvider = {
+  id: OPENCODE_PROVIDER_ID,
+  displayName: OPENCODE_PROVIDER_NAME,
+};
+
+export interface OpenCodeAdapterOptions {
+  dataDirectory?: string;
+  now?: () => number;
+  maximumSessionRows?: number;
+  maximumSessionAgeMs?: number;
+  activeSessionFreshnessMs?: number;
+  sqlite?: SqliteModuleLoader;
+}
+
+/**
+ * What the last message says about the session's turn. Only the message's
+ * bookkeeping is read — role, times, and the error OpenCode recorded — never
+ * the words of the message, which live in part records and stay there.
+ */
+interface OpenCodeTurn {
+  role?: string;
+  completed?: boolean;
+  aborted?: boolean;
+  failure?: string;
+}
+
+interface OpenCodeSessionSnapshot {
+  providerSessionId: string;
+  directory?: string;
+  title?: string;
+  model?: string;
+  shareUrl?: string;
+  observedAt: number;
+  turn?: OpenCodeTurn;
+  activity?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function text(value: unknown): string | undefined {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  return normalized || undefined;
+}
+
+function wholeNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function oneLine(value: string | undefined, maximumLength: number): string | undefined {
+  const normalized = value?.replace(/\s+/gu, " ").trim();
+  if (!normalized) return undefined;
+  return normalized.length > maximumLength
+    ? `${normalized.slice(0, maximumLength - 1).trimEnd()}…`
+    : normalized;
+}
+
+function numberFromRow(row: OpenCodeRow, key: string): number | undefined {
+  return wholeNumber(row[key]);
+}
+
+function textFromRow(row: OpenCodeRow, key: string): string | undefined {
+  return text(row[key]);
+}
+
+/** OpenCode writes the session's model as JSON; older records carried an object. */
+function modelFrom(value: unknown): string | undefined {
+  const record = typeof value === "string" ? recordFromJsonLine(value) : value;
+  if (!isRecord(record)) return undefined;
+  const model = text(record.id) ?? text(record.modelID);
+  if (!model) return undefined;
+  const variant = text(record.variant);
+  return variant ? `${model} · ${variant}` : model;
+}
+
+/**
+ * OpenCode names its own sessions, and that name is what a developer is
+ * looking for. The workspace is the fallback for a session too new to have
+ * been named, which OpenCode marks with a placeholder timestamp rather than an
+ * empty title.
+ */
+function sessionTitle(title: string | undefined, directory: string | undefined): string {
+  const named = oneLine(title, maximumSessionTitleLength);
+  if (!named || named.startsWith(OPENCODE_PLACEHOLDER_TITLE_PREFIX)) {
+    return workspaceLabel(directory);
+  }
+  return named;
+}
+
+/**
+ * Reads the turn boundary out of a message's bookkeeping. OpenCode stamps
+ * `time.completed` on an assistant message when the turn ends, and records the
+ * failure that ended one early — its own user stopping the turn included,
+ * which is a turn that ended rather than one that is stuck.
+ */
+function turnFromMessage(record: Record<string, unknown>): OpenCodeTurn {
+  const turn: OpenCodeTurn = { role: text(record.role) };
+  const time = isRecord(record.time) ? record.time : undefined;
+  turn.completed = wholeNumber(time?.completed) !== undefined;
+
+  const error = isRecord(record.error) ? record.error : undefined;
+  if (!error) return turn;
+  const errorName = text(error.name);
+  if (errorName === OPENCODE_ABORT_ERROR_NAME) {
+    turn.aborted = true;
+    return turn;
+  }
+  const errorData = isRecord(error.data) ? error.data : undefined;
+  turn.failure =
+    oneLine(text(errorData?.message), OPENCODE_ADAPTER_DEFAULTS.MAXIMUM_ACTIVITY_LENGTH) ??
+    errorName;
+  return turn;
+}
+
+/**
+ * A turn that failed is stuck until someone comes back to it, and a failure
+ * does not heal by going stale — which is how every other adapter treats one.
+ * Past that, the last message's bookkeeping answers what recency alone cannot:
+ * an assistant message whose turn ended is holding for the developer, and one
+ * still open is working. Once the session is stale neither reading survives,
+ * because Luke cannot tell a turn that just ended from a session abandoned
+ * hours ago — and a killed OpenCode process leaves an open turn on disk
+ * forever, so an open turn decays the same way.
+ */
+function statusFromTurn(turn: OpenCodeTurn | undefined, isFresh: boolean): SessionStatus {
+  if (turn?.failure) return SESSION_STATUS.ERROR;
+  if (!isFresh) return SESSION_STATUS.UNKNOWN;
+  if (turn?.role === OPENCODE_ROLE.ASSISTANT) {
+    return turn.completed || turn.aborted ? SESSION_STATUS.WAITING : SESSION_STATUS.WORKING;
+  }
+  return SESSION_STATUS.WORKING;
+}
+
+/**
+ * Names the tool the session is running, from the newest tool part's own
+ * bookkeeping. Only a part still pending or running counts: the newest tool
+ * having settled means nothing is running now, so nothing older is read. The
+ * words of the conversation live in text parts, which are never opened.
+ */
+function activityFromPartRows(rows: readonly OpenCodeRow[]): string | undefined {
+  for (const row of rows) {
+    const record = recordFromJsonLine(textFromRow(row, OPENCODE_DATA_COLUMN) ?? "");
+    if (!record || record.type !== OPENCODE_PART_TYPE.TOOL) continue;
+    const state = isRecord(record.state) ? record.state : undefined;
+    const status = text(state?.status);
+    if (status !== OPENCODE_TOOL_STATUS.PENDING && status !== OPENCODE_TOOL_STATUS.RUNNING) {
+      return undefined;
+    }
+    const name = text(record.tool);
+    if (!name) return undefined;
+    const input = isRecord(state?.input) ? state.input : {};
+    for (const key of OPENCODE_TOOL_INPUT_KEY) {
+      const detail = oneLine(text(input[key]), OPENCODE_ADAPTER_DEFAULTS.MAXIMUM_ACTIVITY_LENGTH);
+      if (detail) return `${name}: ${detail}`;
+    }
+    return name;
+  }
+  return undefined;
+}
+
+/**
+ * The share page is the one address OpenCode publishes that names this exact
+ * session, and only a session its own user chose to share carries one.
+ */
+function detailFromSnapshot(snapshot: OpenCodeSessionSnapshot): SessionDetail {
+  return {
+    ...(snapshot.activity ? { activity: snapshot.activity } : {}),
+    repository: workspaceLabel(snapshot.directory),
+    ...(snapshot.model ? { model: snapshot.model } : {}),
+    ...(snapshot.turn?.failure ? { error: snapshot.turn.failure } : {}),
+    ...(snapshot.shareUrl ? { link: snapshot.shareUrl } : {}),
+  };
+}
+
+function observationFromSnapshot(
+  snapshot: OpenCodeSessionSnapshot,
+  now: number,
+  activeSessionFreshnessMs: number,
+): ProviderSessionObservation {
+  const isFresh = now - snapshot.observedAt <= activeSessionFreshnessMs;
+  return {
+    providerSessionId: snapshot.providerSessionId,
+    title: sessionTitle(snapshot.title, snapshot.directory),
+    status: statusFromTurn(snapshot.turn, isFresh),
+    observedAt: snapshot.observedAt,
+    detail: detailFromSnapshot(snapshot),
+  };
+}
+
+function snapshotFromSessionRow(row: OpenCodeRow): OpenCodeSessionSnapshot | undefined {
+  const providerSessionId = textFromRow(row, OPENCODE_SESSION_COLUMN.ID);
+  if (!providerSessionId) return undefined;
+  return {
+    providerSessionId,
+    directory: textFromRow(row, OPENCODE_SESSION_COLUMN.DIRECTORY),
+    title: textFromRow(row, OPENCODE_SESSION_COLUMN.TITLE),
+    model: modelFrom(row[OPENCODE_SESSION_COLUMN.MODEL]),
+    shareUrl: textFromRow(row, OPENCODE_SESSION_COLUMN.SHARE_URL),
+    observedAt: Math.max(
+      numberFromRow(row, OPENCODE_SESSION_COLUMN.TIME_UPDATED) ?? 0,
+      numberFromRow(row, OPENCODE_SESSION_COLUMN.TIME_CREATED) ?? 0,
+    ),
+  };
+}
+
+/**
+ * A subagent's session is part of the session that spawned it, and an archived
+ * session has been put away; neither is a row of its own. Both are also named
+ * in the primary query's WHERE clause — this is the same reading applied to
+ * rows the minimal query let through.
+ */
+function isObservableSessionRow(row: OpenCodeRow): boolean {
+  return (
+    textFromRow(row, OPENCODE_SESSION_COLUMN.PARENT_ID) === undefined &&
+    numberFromRow(row, OPENCODE_SESSION_COLUMN.TIME_ARCHIVED) === undefined
+  );
+}
+
+function sessionIdFromFileName(fileName: string): string | undefined {
+  if (!fileName.endsWith(OPENCODE_SESSION_FILE_EXTENSION)) return undefined;
+  const providerSessionId = fileName.slice(0, -OPENCODE_SESSION_FILE_EXTENSION.length).trim();
+  return providerSessionId || undefined;
+}
+
+/** Legacy storage keeps one JSON file per session inside its project directory. */
+async function legacySessionFilesIn(projectDirectory: string): Promise<SessionFileCandidate[]> {
+  const entries = await readDirectory(projectDirectory);
+  const candidates = await Promise.all(
+    entries.map(async (entry) => {
+      const providerSessionId = sessionIdFromFileName(entry.name);
+      if (!providerSessionId) return undefined;
+      const candidate = await statDirectoryEntry(projectDirectory, entry.name);
+      if (!candidate?.stats.isFile()) return undefined;
+      return {
+        filePath: candidate.directoryPath,
+        providerSessionId,
+        mtimeMs: candidate.stats.mtimeMs,
+      };
+    }),
+  );
+  return candidates.filter(
+    (candidate): candidate is SessionFileCandidate => candidate !== undefined,
+  );
+}
+
+function defaultDataDirectory(): string {
+  const dataHome = process.env[OPENCODE_ENVIRONMENT.DATA_HOME]?.trim();
+  if (dataHome) return path.join(dataHome, OPENCODE_DATA_DIRECTORY_NAME);
+  return path.join(os.homedir(), ...OPENCODE_DATA_HOME_SEGMENTS, OPENCODE_DATA_DIRECTORY_NAME);
+}
+
+function uniquePaths(paths: readonly string[]): string[] {
+  return [...new Set(paths)];
+}
+
+/**
+ * Observes the OpenCode sessions on this machine from the state OpenCode
+ * already writes for itself: the SQLite database every install since v1.2.0
+ * keeps, or the flat JSON files of the versions before it. It runs no server,
+ * needs no credential, and opens everything read-only.
+ */
+export class OpenCodeSessionAdapter implements SessionProviderAdapter {
+  readonly provider = OPENCODE_PROVIDER;
+
+  readonly #dataDirectory: string;
+  readonly #now: () => number;
+  readonly #maximumSessionRows: number;
+  readonly #maximumSessionAgeMs: number;
+  readonly #activeSessionFreshnessMs: number;
+  readonly #sqlite: SqliteModuleLoader;
+
+  constructor(options: OpenCodeAdapterOptions = {}) {
+    this.#dataDirectory = options.dataDirectory ?? defaultDataDirectory();
+    this.#now = options.now ?? Date.now;
+    this.#maximumSessionRows = positiveInteger(
+      options.maximumSessionRows,
+      OPENCODE_ADAPTER_DEFAULTS.MAXIMUM_SESSION_ROWS,
+    );
+    this.#maximumSessionAgeMs = nonNegativeNumber(
+      options.maximumSessionAgeMs,
+      LOCAL_ADAPTER_DEFAULTS.MAXIMUM_SESSION_AGE_MS,
+    );
+    this.#activeSessionFreshnessMs = nonNegativeNumber(
+      options.activeSessionFreshnessMs,
+      LOCAL_ADAPTER_DEFAULTS.ACTIVE_SESSION_FRESHNESS_MS,
+    );
+    this.#sqlite = options.sqlite ?? defaultSqliteModule;
+  }
+
+  async observe(): Promise<readonly ProviderSessionObservation[]> {
+    for (const databasePath of this.#databasePaths()) {
+      const database = await openReadOnlyDatabase(this.#sqlite, databasePath);
+      if (!database) continue;
+      let snapshots: OpenCodeSessionSnapshot[] | undefined;
+      let now = 0;
+      try {
+        now = this.#now();
+        snapshots = this.#databaseSnapshots(database, now);
+      } finally {
+        database.close();
+      }
+      // A database whose schema was unusable answers nothing; the next
+      // candidate, or the legacy files, may still answer.
+      if (snapshots === undefined) continue;
+      return snapshots.map((snapshot) =>
+        observationFromSnapshot(snapshot, now, this.#activeSessionFreshnessMs),
+      );
+    }
+    return this.#legacyObservations();
+  }
+
+  /**
+   * Where the database may be, most authoritative first: wherever
+   * `OPENCODE_DB` points, then the file every release channel writes, then the
+   * one prod-channel builds briefly wrote.
+   */
+  #databasePaths(): string[] {
+    const configured = process.env[OPENCODE_ENVIRONMENT.DATABASE_FILE]?.trim();
+    const configuredPath =
+      configured && configured !== OPENCODE_MEMORY_DATABASE
+        ? path.isAbsolute(configured)
+          ? configured
+          : path.join(this.#dataDirectory, configured)
+        : undefined;
+    return uniquePaths(
+      [
+        configuredPath,
+        path.join(this.#dataDirectory, OPENCODE_DATABASE_FILE.CURRENT),
+        path.join(this.#dataDirectory, OPENCODE_DATABASE_FILE.PROD_CHANNEL),
+      ].filter((candidate): candidate is string => candidate !== undefined),
+    );
+  }
+
+  /** The session rows, or nothing when neither query fits this database. */
+  #sessionRows(database: SqliteDatabase): OpenCodeRow[] | undefined {
+    for (const query of [OPENCODE_SESSION_QUERY, OPENCODE_SESSION_QUERY_MINIMAL]) {
+      try {
+        return database
+          .prepare(query)
+          .all(this.#maximumSessionRows)
+          .filter((row): row is OpenCodeRow => isRecord(row));
+      } catch (error) {
+        if (!canIgnoreSqliteError(error)) throw error;
+      }
+    }
+    return undefined;
+  }
+
+  #databaseSnapshots(database: SqliteDatabase, now: number): OpenCodeSessionSnapshot[] | undefined {
+    const rows = this.#sessionRows(database);
+    if (rows === undefined) return undefined;
+
+    const snapshots = rows
+      .filter(isObservableSessionRow)
+      .map(snapshotFromSessionRow)
+      .filter((snapshot): snapshot is OpenCodeSessionSnapshot => snapshot !== undefined)
+      .filter((snapshot) => now - snapshot.observedAt <= this.#maximumSessionAgeMs);
+
+    for (const snapshot of snapshots.slice(0, OPENCODE_ADAPTER_DEFAULTS.MAXIMUM_TURN_READS)) {
+      snapshot.turn = this.#turnFor(database, snapshot.providerSessionId);
+      const isFresh = now - snapshot.observedAt <= this.#activeSessionFreshnessMs;
+      if (statusFromTurn(snapshot.turn, isFresh) === SESSION_STATUS.WORKING) {
+        snapshot.activity = this.#activityFor(database, snapshot.providerSessionId);
+      }
+    }
+    return snapshots;
+  }
+
+  /** The last message's bookkeeping, or nothing this build can read. */
+  #turnFor(database: SqliteDatabase, providerSessionId: string): OpenCodeTurn | undefined {
+    const row = this.#rowsFor(database, OPENCODE_LAST_MESSAGE_QUERY, [providerSessionId])[0];
+    const record = row
+      ? recordFromJsonLine(textFromRow(row, OPENCODE_DATA_COLUMN) ?? "")
+      : undefined;
+    return record ? turnFromMessage(record) : undefined;
+  }
+
+  #activityFor(database: SqliteDatabase, providerSessionId: string): string | undefined {
+    return activityFromPartRows(
+      this.#rowsFor(database, OPENCODE_RECENT_PART_QUERY, [
+        providerSessionId,
+        OPENCODE_ADAPTER_DEFAULTS.MAXIMUM_PART_ROWS,
+      ]),
+    );
+  }
+
+  /** A message or part table this build cannot read costs a field, not the pass. */
+  #rowsFor(database: SqliteDatabase, query: string, parameters: readonly unknown[]): OpenCodeRow[] {
+    try {
+      return database
+        .prepare(query)
+        .all(...parameters)
+        .filter((row): row is OpenCodeRow => isRecord(row));
+    } catch (error) {
+      if (canIgnoreSqliteError(error)) return [];
+      throw error;
+    }
+  }
+
+  async #legacyObservations(): Promise<readonly ProviderSessionObservation[]> {
+    const now = this.#now();
+    const storageDirectory = path.join(this.#dataDirectory, OPENCODE_STORAGE_DIRECTORY);
+    const candidates = (
+      await discoverSessionFiles({
+        projectsDirectory: path.join(storageDirectory, OPENCODE_STORAGE_SEGMENT.SESSION),
+        maximumProjectDirectories: OPENCODE_ADAPTER_DEFAULTS.MAXIMUM_PROJECT_DIRECTORIES,
+        maximumSessionFiles: this.#maximumSessionRows,
+        sessionFilesIn: legacySessionFilesIn,
+      })
+    ).filter((candidate) => now - candidate.mtimeMs <= this.#maximumSessionAgeMs);
+
+    const observations = new Map<string, ProviderSessionObservation>();
+    let turnReads = 0;
+    for (const candidate of candidates) {
+      if (observations.has(candidate.providerSessionId)) continue;
+      const info = recordFromJsonLine((await readTextFile(candidate.filePath)) ?? "");
+      if (!info) continue;
+      if (text(info.parentID)) continue;
+
+      const time = isRecord(info.time) ? info.time : undefined;
+      const snapshot: OpenCodeSessionSnapshot = {
+        providerSessionId: candidate.providerSessionId,
+        directory: text(info.directory),
+        title: text(info.title),
+        model: modelFrom(info.model),
+        shareUrl: isRecord(info.share) ? text(info.share.url) : undefined,
+        observedAt: Math.max(
+          candidate.mtimeMs,
+          wholeNumber(time?.updated) ?? 0,
+          wholeNumber(time?.created) ?? 0,
+        ),
+      };
+      if (turnReads < OPENCODE_ADAPTER_DEFAULTS.MAXIMUM_TURN_READS) {
+        turnReads += 1;
+        snapshot.turn = await this.#legacyTurn(storageDirectory, candidate.providerSessionId);
+      }
+      observations.set(
+        candidate.providerSessionId,
+        observationFromSnapshot(snapshot, now, this.#activeSessionFreshnessMs),
+      );
+    }
+    return [...observations.values()];
+  }
+
+  /**
+   * The newest message file's bookkeeping. OpenCode's message identifiers sort
+   * in creation order, so the greatest file name is the newest message and no
+   * second directory pass is needed to find it.
+   */
+  async #legacyTurn(
+    storageDirectory: string,
+    providerSessionId: string,
+  ): Promise<OpenCodeTurn | undefined> {
+    const messagesDirectory = path.join(
+      storageDirectory,
+      OPENCODE_STORAGE_SEGMENT.MESSAGE,
+      providerSessionId,
+    );
+    const newest = (await readDirectory(messagesDirectory))
+      .map((entry) => entry.name)
+      .filter((name) => name.endsWith(OPENCODE_SESSION_FILE_EXTENSION))
+      .sort()
+      .at(-1);
+    if (!newest) return undefined;
+    const record = recordFromJsonLine(
+      (await readTextFile(path.join(messagesDirectory, newest))) ?? "",
+    );
+    return record ? turnFromMessage(record) : undefined;
+  }
+}

--- a/apps/desktop/src/opencode-adapter.ts
+++ b/apps/desktop/src/opencode-adapter.ts
@@ -129,8 +129,6 @@ const OPENCODE_TOOL_INPUT_KEY = [
 const OPENCODE_ADAPTER_DEFAULTS = {
   MAXIMUM_SESSION_ROWS: 40,
   MAXIMUM_PROJECT_DIRECTORIES: 200,
-  /** Only the sessions that can still change are worth further reads. */
-  MAXIMUM_TURN_READS: 12,
   /** Enough parts to reach past a finished step's bookkeeping to its tool. */
   MAXIMUM_PART_ROWS: 8,
   MAXIMUM_ACTIVITY_LENGTH: 80,
@@ -539,7 +537,12 @@ export class OpenCodeSessionAdapter implements SessionProviderAdapter {
       .filter((snapshot): snapshot is OpenCodeSessionSnapshot => snapshot !== undefined)
       .filter((snapshot) => now - snapshot.observedAt <= this.#maximumSessionAgeMs);
 
-    for (const snapshot of snapshots.slice(0, OPENCODE_ADAPTER_DEFAULTS.MAXIMUM_TURN_READS)) {
+    // Every reported session gets its turn read, because a session without one
+    // would default to working on freshness alone — inventing live work for a
+    // row whose turn actually ended. The pass stays bounded the way the Claude
+    // Code adapter's is: each read is an indexed point query against the row
+    // cap above, not a scan.
+    for (const snapshot of snapshots) {
       snapshot.turn = this.#turnFor(database, snapshot.providerSessionId);
       const isFresh = now - snapshot.observedAt <= this.#activeSessionFreshnessMs;
       if (statusFromTurn(snapshot.turn, isFresh) === SESSION_STATUS.WORKING) {
@@ -593,7 +596,6 @@ export class OpenCodeSessionAdapter implements SessionProviderAdapter {
     ).filter((candidate) => now - candidate.mtimeMs <= this.#maximumSessionAgeMs);
 
     const observations = new Map<string, ProviderSessionObservation>();
-    let turnReads = 0;
     for (const candidate of candidates) {
       if (observations.has(candidate.providerSessionId)) continue;
       const info = recordFromJsonLine((await readTextFile(candidate.filePath)) ?? "");
@@ -613,10 +615,11 @@ export class OpenCodeSessionAdapter implements SessionProviderAdapter {
           wholeNumber(time?.created) ?? 0,
         ),
       };
-      if (turnReads < OPENCODE_ADAPTER_DEFAULTS.MAXIMUM_TURN_READS) {
-        turnReads += 1;
-        snapshot.turn = await this.#legacyTurn(storageDirectory, candidate.providerSessionId);
-      }
+      // Read for every reported session, not a capped few: a session without
+      // its turn would default to working on freshness alone. Each read is one
+      // directory listing and one small file, against the same session cap the
+      // Claude Code adapter pays a bounded tail read for.
+      snapshot.turn = await this.#legacyTurn(storageDirectory, candidate.providerSessionId);
       observations.set(
         candidate.providerSessionId,
         observationFromSnapshot(snapshot, now, this.#activeSessionFreshnessMs),

--- a/apps/desktop/src/opencode-adapter.ts
+++ b/apps/desktop/src/opencode-adapter.ts
@@ -307,10 +307,14 @@ function statusFromTurn(turn: OpenCodeTurn | undefined, isFresh: boolean): Sessi
 }
 
 /**
- * Names the tool the session is running, from the newest tool part's own
- * bookkeeping. Only a part still pending or running counts: the newest tool
- * having settled means nothing is running now, so nothing older is read. The
- * words of the conversation live in text parts, which are never opened.
+ * Names the tool the session is running, from the newest live tool part's own
+ * bookkeeping. Only a part still pending or running counts, and a settled one
+ * is passed over rather than ending the search: OpenCode runs tools
+ * concurrently, so the newest tool having finished says nothing about an older
+ * one still working. A stale part left running by a killed process cannot
+ * reach here, because activity is only read for a session already fresh enough
+ * to be working. The words of the conversation live in text parts, which are
+ * never opened.
  */
 function activityFromPartRows(rows: readonly OpenCodeRow[]): string | undefined {
   for (const row of rows) {
@@ -319,10 +323,10 @@ function activityFromPartRows(rows: readonly OpenCodeRow[]): string | undefined 
     const state = isRecord(record.state) ? record.state : undefined;
     const status = text(state?.status);
     if (status !== OPENCODE_TOOL_STATUS.PENDING && status !== OPENCODE_TOOL_STATUS.RUNNING) {
-      return undefined;
+      continue;
     }
     const name = text(record.tool);
-    if (!name) return undefined;
+    if (!name) continue;
     const input = isRecord(state?.input) ? state.input : {};
     for (const key of OPENCODE_TOOL_INPUT_KEY) {
       const detail = oneLine(text(input[key]), OPENCODE_ADAPTER_DEFAULTS.MAXIMUM_ACTIVITY_LENGTH);

--- a/apps/desktop/src/renderer/provider-marks.tsx
+++ b/apps/desktop/src/renderer/provider-marks.tsx
@@ -14,14 +14,16 @@ import { useId } from "react";
  * (MIT, sourced from https://primer.style/foundations/icons/copilot-24),
  * Cursor via Simple Icons (CC0-1.0, sourced from https://cursor.com/brand),
  * Devin's verbatim from the mark https://devin.ai serves as its own favicon
- * and site header, and Jules via Simple Icons (CC0-1.0, sourced from
- * https://jules.google). Each keeps its own brand colour (see the `--mark-*`
- * custom properties), so a mark says which provider a session belongs to while
- * the chips and row tints say what state it is in. Copilot, Cursor, and Devin
- * each publish one silhouette rather than a colour, so all three are drawn in
- * the light form their brand uses on a dark surface. They are trademarks of
- * their respective owners. Do not restyle the geometry or recolour them; swap
- * the path if a provider publishes an updated mark.
+ * and site header, Jules via Simple Icons (CC0-1.0, sourced from
+ * https://jules.google), and OpenCode via @lobehub/icons (MIT), matching the
+ * terminal-block logomark at https://opencode.ai. Each keeps its own brand
+ * colour (see the `--mark-*` custom properties), so a mark says which provider
+ * a session belongs to while the chips and row tints say what state it is in.
+ * Copilot, Cursor, Devin, and OpenCode each publish one silhouette rather than
+ * a colour, so all four are drawn in the light form their brand uses on a dark
+ * surface. They are trademarks of their respective owners. Do not restyle the
+ * geometry or recolour them; swap the path if a provider publishes an updated
+ * mark.
  */
 interface MarkProps {
   className?: string;
@@ -41,6 +43,8 @@ const CURSOR_PATH =
 
 const DEVIN_PATH =
   "M70 159.333V91.3471C70 88.3592 71.594 85.5983 74.1816 84.1044L133.043 50.1205C135.631 48.6265 138.819 48.6265 141.407 50.1205L200.269 84.1044C202.856 85.5983 204.45 88.3592 204.45 91.3471V126.068C204.708 137.606 210.806 148.734 221.531 154.926C232.256 161.117 244.942 160.834 255.063 155.289L285.132 137.929C287.719 136.435 290.907 136.435 293.495 137.929L352.357 171.913C354.944 173.406 356.538 176.167 356.538 179.155V247.123C356.538 250.111 354.944 252.872 352.357 254.366L293.495 288.35C290.907 289.844 287.719 289.844 285.132 288.35L255.306 271.13C245.146 265.456 232.344 265.117 221.534 271.358C210.809 277.55 204.711 288.678 204.453 300.215V334.926C204.453 337.914 202.859 340.675 200.271 342.169L141.41 376.153C138.822 377.647 135.634 377.647 133.046 376.153L74.1845 342.169C71.5969 340.675 70.0028 337.914 70.0028 334.926V266.959C70.0029 263.971 71.5969 261.21 74.1845 259.716L133.046 225.732C135.634 224.238 138.822 224.238 141.41 225.732L171.547 243.132C181.656 248.638 194.306 248.906 205.005 242.729C215.815 236.488 221.922 225.231 222.088 213.595C221.83 202.057 215.732 189.737 205.008 183.545C194.283 177.353 181.597 177.636 171.476 183.181L141.269 200.72C138.67 202.229 135.461 202.228 132.864 200.716L74.1576 166.562C71.5835 165.065 70 162.311 70 159.333Z";
+
+const OPENCODE_PATH = "M16 6H8v12h8V6zm4 16H4V2h16v20z";
 
 const JULES_PATH =
   "M4.2 24q-1.26 0-2.13-.87T1.2 21v-.6q0-.51.345-.855T2.4 19.2t.855.345.345.855v.6q0 .24.18.42t.42.18.42-.18.18-.42V7.2q0-3 2.1-5.1T12 0t5.1 2.1 2.1 5.1V21q0 .24.18.42t.42.18.42-.18.18-.42v-.6q0-.51.345-.855t.855-.345.855.345.345.855v.6q0 1.26-.87 2.13T19.8 24t-2.13-.87T16.8 21v-5.4h-1.62v4.8q0 .51-.345.855t-.855.345-.855-.345-.345-.855v-4.8h-1.59v4.8q0 .51-.345.855t-.855.345-.855-.345-.345-.855v-4.8H7.2V21q0 1.26-.87 2.13T4.2 24m4.2-11.4q.54 0 .87-.45t.33-1.05-.33-1.05-.87-.45-.87.45-.33 1.05.33 1.05.87.45m7.2 0q.54 0 .87-.45t.33-1.05-.33-1.05-.87-.45-.87.45-.33 1.05.33 1.05.87.45";
@@ -188,6 +192,20 @@ function JulesMark({ className }: MarkProps): React.JSX.Element {
   );
 }
 
+function OpenCodeMark({ className }: MarkProps): React.JSX.Element {
+  return (
+    <svg
+      className={className}
+      data-mark={PROVIDER_ID.OPENCODE}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path fill="currentColor" fillRule="evenodd" clipRule="evenodd" d={OPENCODE_PATH} />
+    </svg>
+  );
+}
+
 /** Drawn here, not a brand: a provider Luke has no mark for still needs a slot. */
 function UnknownProviderMark({ className }: MarkProps): React.JSX.Element {
   return (
@@ -206,6 +224,7 @@ const PROVIDER_MARKS = new Map<string, (props: MarkProps) => React.JSX.Element>(
   [PROVIDER_ID.CURSOR, CursorMark],
   [PROVIDER_ID.DEVIN, DevinMark],
   [PROVIDER_ID.JULES, JulesMark],
+  [PROVIDER_ID.OPENCODE, OpenCodeMark],
 ]);
 
 export function ProviderMark({

--- a/apps/desktop/src/renderer/provider-marks.tsx
+++ b/apps/desktop/src/renderer/provider-marks.tsx
@@ -15,12 +15,12 @@ import { useId } from "react";
  * Cursor via Simple Icons (CC0-1.0, sourced from https://cursor.com/brand),
  * Devin's verbatim from the mark https://devin.ai serves as its own favicon
  * and site header, Jules via Simple Icons (CC0-1.0, sourced from
- * https://jules.google), and OpenCode via @lobehub/icons (MIT), matching the
- * terminal-block logomark at https://opencode.ai. Each keeps its own brand
- * colour (see the `--mark-*` custom properties), so a mark says which provider
- * a session belongs to while the chips and row tints say what state it is in.
- * Copilot, Cursor, Devin, and OpenCode each publish one silhouette rather than
- * a colour, so all four are drawn in the light form their brand uses on a dark
+ * https://jules.google), and OpenCode's two-tone terminal mark verbatim from
+ * the favicon https://opencode.ai serves. Each keeps its own brand colour
+ * (see the `--mark-*` custom properties), so a mark says which provider a
+ * session belongs to while the chips and row tints say what state it is in.
+ * Copilot, Cursor, and Devin each publish one silhouette rather than a
+ * colour, so all three are drawn in the light form their brand uses on a dark
  * surface. They are trademarks of their respective owners. Do not restyle the
  * geometry or recolour them; swap the path if a provider publishes an updated
  * mark.
@@ -44,7 +44,12 @@ const CURSOR_PATH =
 const DEVIN_PATH =
   "M70 159.333V91.3471C70 88.3592 71.594 85.5983 74.1816 84.1044L133.043 50.1205C135.631 48.6265 138.819 48.6265 141.407 50.1205L200.269 84.1044C202.856 85.5983 204.45 88.3592 204.45 91.3471V126.068C204.708 137.606 210.806 148.734 221.531 154.926C232.256 161.117 244.942 160.834 255.063 155.289L285.132 137.929C287.719 136.435 290.907 136.435 293.495 137.929L352.357 171.913C354.944 173.406 356.538 176.167 356.538 179.155V247.123C356.538 250.111 354.944 252.872 352.357 254.366L293.495 288.35C290.907 289.844 287.719 289.844 285.132 288.35L255.306 271.13C245.146 265.456 232.344 265.117 221.534 271.358C210.809 277.55 204.711 288.678 204.453 300.215V334.926C204.453 337.914 202.859 340.675 200.271 342.169L141.41 376.153C138.822 377.647 135.634 377.647 133.046 376.153L74.1845 342.169C71.5969 340.675 70.0028 337.914 70.0028 334.926V266.959C70.0029 263.971 71.5969 261.21 74.1845 259.716L133.046 225.732C135.634 224.238 138.822 224.238 141.41 225.732L171.547 243.132C181.656 248.638 194.306 248.906 205.005 242.729C215.815 236.488 221.922 225.231 222.088 213.595C221.83 202.057 215.732 189.737 205.008 183.545C194.283 177.353 181.597 177.636 171.476 183.181L141.269 200.72C138.67 202.229 135.461 202.228 132.864 200.716L74.1576 166.562C71.5835 165.065 70 162.311 70 159.333Z";
 
-const OPENCODE_PATH = "M16 6H8v12h8V6zm4 16H4V2h16v20z";
+/* Verbatim from the favicon https://opencode.ai serves: a frame open at the
+   top, and the block that sits inside the opening. The block is part of the
+   published two-tone mark — OpenCode draws it in its own gray on every
+   surface — so it keeps its brand colour rather than taking the frame's. */
+const OPENCODE_FRAME_PATH = "M384 416H128V96H384V416ZM320 160H192V352H320V160Z";
+const OPENCODE_BLOCK_PATH = "M320 224V352H192V224H320Z";
 
 const JULES_PATH =
   "M4.2 24q-1.26 0-2.13-.87T1.2 21v-.6q0-.51.345-.855T2.4 19.2t.855.345.345.855v.6q0 .24.18.42t.42.18.42-.18.18-.42V7.2q0-3 2.1-5.1T12 0t5.1 2.1 2.1 5.1V21q0 .24.18.42t.42.18.42-.18.18-.42v-.6q0-.51.345-.855t.855-.345.855.345.345.855v.6q0 1.26-.87 2.13T19.8 24t-2.13-.87T16.8 21v-5.4h-1.62v4.8q0 .51-.345.855t-.855.345-.855-.345-.345-.855v-4.8h-1.59v4.8q0 .51-.345.855t-.855.345-.855-.345-.345-.855v-4.8H7.2V21q0 1.26-.87 2.13T4.2 24m4.2-11.4q.54 0 .87-.45t.33-1.05-.33-1.05-.87-.45-.87.45-.33 1.05.33 1.05.87.45m7.2 0q.54 0 .87-.45t.33-1.05-.33-1.05-.87-.45-.87.45-.33 1.05.33 1.05.87.45";
@@ -193,15 +198,18 @@ function JulesMark({ className }: MarkProps): React.JSX.Element {
 }
 
 function OpenCodeMark({ className }: MarkProps): React.JSX.Element {
+  // The box crops the favicon's 512 canvas to a square the glyph fills top to
+  // bottom, centred as published; the paths themselves are untouched.
   return (
     <svg
       className={className}
       data-mark={PROVIDER_ID.OPENCODE}
-      viewBox="0 0 24 24"
+      viewBox="96 96 320 320"
       aria-hidden="true"
       focusable="false"
     >
-      <path fill="currentColor" fillRule="evenodd" clipRule="evenodd" d={OPENCODE_PATH} />
+      <path fill="var(--mark-opencode-block, #5a5858)" d={OPENCODE_BLOCK_PATH} />
+      <path fill="currentColor" fillRule="evenodd" clipRule="evenodd" d={OPENCODE_FRAME_PATH} />
     </svg>
   );
 }

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -12,9 +12,11 @@
   /* Provider brand colours, used only by the marks: Claude Code's published
      coral, the vertical gradient Codex draws its mark with, the light half of
      Conductor's two-colour palette — its dark half is the surface the mark
-     already sits on, so the pairing is the published one — and Cursor's mark,
-     and Devin's and OpenCode's marks, each published as one silhouette and so drawn in the
-     light form its brand uses on a dark surface. Session state is carried by the chips, row
+     already sits on, so the pairing is the published one — Cursor's and
+     Devin's marks, each published as one silhouette and so drawn in the light
+     form its brand uses on a dark surface, and the two tones of OpenCode's
+     terminal mark: the frame, and the gray block its favicon keeps inside the
+     frame's opening on every surface. Session state is carried by the chips, row
      tints, and count badge instead, so the two colour systems never compete for
      the same pixel. */
   --mark-claude-code: #d97757;
@@ -27,6 +29,7 @@
   --mark-devin: #ffffff;
   --mark-jules: #715cd7;
   --mark-opencode: #ffffff;
+  --mark-opencode-block: #5a5858;
 
   /* The one destructive colour, in the two weights a control that destroys
      something needs: a ground it can sit on and a text colour that reads on
@@ -663,11 +666,11 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   transform: scale(0.94);
 }
 
-/* OpenCode's block leaves a twelfth of its box empty above and below, so it is
-   scaled up to the height the full-bleed marks reach. */
+/* OpenCode's frame fills its box top to bottom the way the Codex and Cursor
+   marks do, so it takes the same scale they do. */
 .provider-mark[data-mark="opencode"] {
   color: var(--mark-opencode);
-  transform: scale(1.08);
+  transform: scale(0.94);
 }
 
 /* The work is happening somewhere the user cannot see. The badge overhangs the

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -13,7 +13,7 @@
      coral, the vertical gradient Codex draws its mark with, the light half of
      Conductor's two-colour palette — its dark half is the surface the mark
      already sits on, so the pairing is the published one — and Cursor's mark,
-     and Devin's marks, each published as one silhouette and so drawn in the
+     and Devin's and OpenCode's marks, each published as one silhouette and so drawn in the
      light form its brand uses on a dark surface. Session state is carried by the chips, row
      tints, and count badge instead, so the two colour systems never compete for
      the same pixel. */
@@ -26,6 +26,7 @@
   --mark-cursor: #ffffff;
   --mark-devin: #ffffff;
   --mark-jules: #715cd7;
+  --mark-opencode: #ffffff;
 
   /* The one destructive colour, in the two weights a control that destroys
      something needs: a ground it can sit on and a text colour that reads on
@@ -660,6 +661,13 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 .provider-mark[data-mark="jules"] {
   color: var(--mark-jules);
   transform: scale(0.94);
+}
+
+/* OpenCode's block leaves a twelfth of its box empty above and below, so it is
+   scaled up to the height the full-bleed marks reach. */
+.provider-mark[data-mark="opencode"] {
+  color: var(--mark-opencode);
+  transform: scale(1.08);
 }
 
 /* The work is happening somewhere the user cannot see. The badge overhangs the

--- a/apps/desktop/tests/opencode-adapter.test.ts
+++ b/apps/desktop/tests/opencode-adapter.test.ts
@@ -556,6 +556,41 @@ test("skips OpenCode subagent and archived sessions", async (t) => {
   );
 });
 
+test("reads every session's turn rather than a capped few", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  // More sessions than any per-pass read cap could hide behind: every one of
+  // them has finished its turn, so a session left unread would show as
+  // working on freshness alone.
+  const sessions = Array.from({ length: 15 }, (_, index) => ({
+    id: `ses_many_${String(index).padStart(2, "0")}`,
+    directory: `/Users/test/project-${index}`,
+    observedAt: TEST_TIME - 1_000 - index,
+  }));
+  await writeOpenCodeState(dataDirectory, sessions, {
+    messages: sessions.map((session, index) => ({
+      id: `msg_${String(index).padStart(2, "0")}`,
+      sessionId: session.id,
+      time: session.observedAt,
+      data: {
+        role: "assistant",
+        time: { created: session.observedAt - 1_000, completed: session.observedAt },
+      },
+    })),
+  });
+
+  const adapter = new OpenCodeSessionAdapter({
+    dataDirectory,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations.length, 15);
+  for (const observation of observations) {
+    assert.equal(observation.status, SESSION_STATUS.WAITING, observation.providerSessionId);
+  }
+});
+
 test("filters old OpenCode sessions while preserving the newest", async (t) => {
   const dataDirectory = await temporaryDataDirectory(t);
   await writeOpenCodeState(dataDirectory, [

--- a/apps/desktop/tests/opencode-adapter.test.ts
+++ b/apps/desktop/tests/opencode-adapter.test.ts
@@ -466,6 +466,60 @@ test("names the tool an OpenCode session is running", async (t) => {
   assert.equal(observation?.detail?.activity, "bash: pnpm test");
 });
 
+test("names the tool still running behind one that already settled", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  await writeOpenCodeState(
+    dataDirectory,
+    [{ id: "ses_parallel", directory: "/Users/test/luke", observedAt: TEST_TIME - 1_000 }],
+    {
+      messages: [
+        {
+          id: "msg_01",
+          sessionId: "ses_parallel",
+          time: TEST_TIME - 1_000,
+          data: { role: "assistant", time: { created: TEST_TIME - 3_000 } },
+        },
+      ],
+      parts: [
+        {
+          id: "prt_01",
+          messageId: "msg_01",
+          sessionId: "ses_parallel",
+          time: TEST_TIME - 3_000,
+          data: {
+            type: "tool",
+            tool: "bash",
+            state: { status: "running", input: { command: "pnpm test" } },
+          },
+        },
+        // OpenCode runs tools concurrently, so a newer call can settle while
+        // an older one is still the work the session is doing.
+        {
+          id: "prt_02",
+          messageId: "msg_01",
+          sessionId: "ses_parallel",
+          time: TEST_TIME - 1_000,
+          data: {
+            type: "tool",
+            tool: "read",
+            state: { status: "completed", input: { filePath: "README.md" } },
+          },
+        },
+      ],
+    },
+  );
+
+  const adapter = new OpenCodeSessionAdapter({
+    dataDirectory,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WORKING);
+  assert.equal(observation?.detail?.activity, "bash: pnpm test");
+});
+
 test("skips OpenCode subagent and archived sessions", async (t) => {
   const dataDirectory = await temporaryDataDirectory(t);
   await writeOpenCodeState(dataDirectory, [

--- a/apps/desktop/tests/opencode-adapter.test.ts
+++ b/apps/desktop/tests/opencode-adapter.test.ts
@@ -1,0 +1,730 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import test, { type TestContext } from "node:test";
+import { SESSION_STATUS } from "@sidecar/core";
+import { OPENCODE_PROVIDER, OpenCodeSessionAdapter } from "../src/opencode-adapter";
+
+const TEST_TIME = Date.parse("2026-08-13T21:30:00.000Z");
+const OPENCODE_DATABASE = "opencode.db";
+const OPENCODE_PROD_DATABASE = "opencode-prod.db";
+const TEST_SQLITE_ERROR = {
+  UNKNOWN_BUILTIN_MODULE: "ERR_UNKNOWN_BUILTIN_MODULE",
+} as const;
+const TEST_OPENCODE_ENVIRONMENT = {
+  DATABASE_FILE: "OPENCODE_DB",
+} as const;
+
+interface TestSession {
+  id: string;
+  directory: string;
+  observedAt: number;
+  title?: string;
+  parentId?: string;
+  archivedAt?: number;
+  model?: string;
+  shareUrl?: string;
+}
+
+interface TestMessage {
+  id: string;
+  sessionId: string;
+  time: number;
+  data: Record<string, unknown>;
+}
+
+interface TestPart {
+  id: string;
+  messageId: string;
+  sessionId: string;
+  time: number;
+  data: Record<string, unknown>;
+}
+
+async function temporaryDataDirectory(t: TestContext): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-opencode-"));
+  t.after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  return directory;
+}
+
+function writeSession(database: DatabaseSync, session: TestSession): void {
+  database
+    .prepare(`
+      INSERT INTO session (
+        id,
+        project_id,
+        parent_id,
+        slug,
+        directory,
+        title,
+        version,
+        share_url,
+        model,
+        cost,
+        time_created,
+        time_updated,
+        time_archived
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `)
+    .run(
+      session.id,
+      "63bb8c77541efac08dcca1c5bbb14be27bc48476",
+      session.parentId ?? null,
+      "clever-panda",
+      session.directory,
+      session.title ?? "New session - 2026-08-13T21:16:44.104Z",
+      "1.18.18",
+      session.shareUrl ?? null,
+      session.model ?? null,
+      0,
+      session.observedAt,
+      session.observedAt,
+      session.archivedAt ?? null,
+    );
+}
+
+function writeMessage(database: DatabaseSync, message: TestMessage): void {
+  database
+    .prepare(`
+      INSERT INTO message (id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?)
+    `)
+    .run(message.id, message.sessionId, message.time, message.time, JSON.stringify(message.data));
+}
+
+function writePart(database: DatabaseSync, part: TestPart): void {
+  database
+    .prepare(`
+      INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `)
+    .run(part.id, part.messageId, part.sessionId, part.time, part.time, JSON.stringify(part.data));
+}
+
+async function writeOpenCodeState(
+  dataDirectory: string,
+  sessions: readonly TestSession[],
+  options: {
+    databaseFile?: string;
+    messages?: readonly TestMessage[];
+    parts?: readonly TestPart[];
+  } = {},
+): Promise<void> {
+  await fs.mkdir(dataDirectory, { recursive: true });
+  const database = new DatabaseSync(
+    path.join(dataDirectory, options.databaseFile ?? OPENCODE_DATABASE),
+    {},
+  );
+  try {
+    database.exec(`
+      CREATE TABLE session (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        parent_id TEXT,
+        slug TEXT NOT NULL,
+        directory TEXT NOT NULL,
+        title TEXT NOT NULL,
+        version TEXT NOT NULL,
+        share_url TEXT,
+        model TEXT,
+        cost REAL DEFAULT 0 NOT NULL,
+        time_created INTEGER NOT NULL,
+        time_updated INTEGER NOT NULL,
+        time_archived INTEGER
+      );
+      CREATE TABLE message (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        time_created INTEGER NOT NULL,
+        time_updated INTEGER NOT NULL,
+        data TEXT NOT NULL
+      );
+      CREATE TABLE part (
+        id TEXT PRIMARY KEY,
+        message_id TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        time_created INTEGER NOT NULL,
+        time_updated INTEGER NOT NULL,
+        data TEXT NOT NULL
+      );
+    `);
+    for (const session of sessions) writeSession(database, session);
+    for (const message of options.messages ?? []) writeMessage(database, message);
+    for (const part of options.parts ?? []) writePart(database, part);
+  } finally {
+    database.close();
+  }
+}
+
+async function writeMalformedOpenCodeState(
+  dataDirectory: string,
+  databaseFile: string,
+): Promise<void> {
+  await fs.mkdir(dataDirectory, { recursive: true });
+  const database = new DatabaseSync(path.join(dataDirectory, databaseFile), {});
+  try {
+    database.exec("CREATE TABLE unrelated (id TEXT PRIMARY KEY)");
+  } finally {
+    database.close();
+  }
+}
+
+/** A database from before the subagent and archive columns existed. */
+async function writeEarlyOpenCodeState(
+  dataDirectory: string,
+  sessions: readonly { id: string; directory: string; observedAt: number; title: string }[],
+): Promise<void> {
+  await fs.mkdir(dataDirectory, { recursive: true });
+  const database = new DatabaseSync(path.join(dataDirectory, OPENCODE_DATABASE), {});
+  try {
+    database.exec(`
+      CREATE TABLE session (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        directory TEXT NOT NULL,
+        title TEXT NOT NULL,
+        time_created INTEGER NOT NULL,
+        time_updated INTEGER NOT NULL
+      )
+    `);
+    for (const session of sessions) {
+      database
+        .prepare("INSERT INTO session VALUES (?, ?, ?, ?, ?, ?)")
+        .run(
+          session.id,
+          "project-early",
+          session.directory,
+          session.title,
+          session.observedAt,
+          session.observedAt,
+        );
+    }
+  } finally {
+    database.close();
+  }
+}
+
+async function writeLegacySession(
+  dataDirectory: string,
+  projectId: string,
+  info: Record<string, unknown> & { id: string },
+): Promise<void> {
+  const sessionDirectory = path.join(dataDirectory, "storage", "session", projectId);
+  await fs.mkdir(sessionDirectory, { recursive: true });
+  await fs.writeFile(path.join(sessionDirectory, `${info.id}.json`), JSON.stringify(info));
+}
+
+async function writeLegacyMessage(
+  dataDirectory: string,
+  sessionId: string,
+  messageId: string,
+  record: Record<string, unknown>,
+): Promise<void> {
+  const messageDirectory = path.join(dataDirectory, "storage", "message", sessionId);
+  await fs.mkdir(messageDirectory, { recursive: true });
+  await fs.writeFile(path.join(messageDirectory, `${messageId}.json`), JSON.stringify(record));
+}
+
+test("observes an OpenCode session under the name OpenCode gave it", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  await writeOpenCodeState(
+    dataDirectory,
+    [
+      {
+        id: "ses_active",
+        directory: "/Users/test/luke",
+        observedAt: TEST_TIME - 1_000,
+        title: "Wire the notch geometry to the housing",
+        model: JSON.stringify({ providerID: "anthropic", id: "claude-sonnet-5", variant: "high" }),
+        shareUrl: "https://opencode.ai/s/AbCdEf",
+      },
+    ],
+    {
+      messages: [
+        {
+          id: "msg_01",
+          sessionId: "ses_active",
+          time: TEST_TIME - 1_000,
+          data: { role: "assistant", time: { created: TEST_TIME - 1_000 } },
+        },
+      ],
+    },
+  );
+
+  const adapter = new OpenCodeSessionAdapter({
+    dataDirectory,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.deepEqual(adapter.provider, OPENCODE_PROVIDER);
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "ses_active");
+  assert.equal(observations[0]?.title, "Wire the notch geometry to the housing");
+  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
+  assert.equal(observations[0]?.controls, undefined);
+  assert.deepEqual(observations[0]?.detail, {
+    repository: "luke",
+    model: "claude-sonnet-5 · high",
+    link: "https://opencode.ai/s/AbCdEf",
+  });
+});
+
+test("falls back to the workspace while OpenCode has not named the session", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  await writeOpenCodeState(dataDirectory, [
+    {
+      id: "ses_unnamed",
+      directory: "/Users/test/luke",
+      observedAt: TEST_TIME - 1_000,
+      title: "New session - 2026-08-13T21:16:44.104Z",
+    },
+  ]);
+
+  const adapter = new OpenCodeSessionAdapter({
+    dataDirectory,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.title, "luke");
+  // A session with no messages yet has just been started.
+  assert.equal(observation?.status, SESSION_STATUS.WORKING);
+});
+
+test("reports a finished OpenCode turn as waiting for its developer", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  await writeOpenCodeState(
+    dataDirectory,
+    [{ id: "ses_done", directory: "/Users/test/luke", observedAt: TEST_TIME - 1_000 }],
+    {
+      messages: [
+        {
+          id: "msg_01",
+          sessionId: "ses_done",
+          time: TEST_TIME - 1_000,
+          data: {
+            role: "assistant",
+            time: { created: TEST_TIME - 2_000, completed: TEST_TIME - 1_000 },
+          },
+        },
+      ],
+      parts: [
+        {
+          id: "prt_01",
+          messageId: "msg_01",
+          sessionId: "ses_done",
+          time: TEST_TIME - 1_500,
+          data: {
+            type: "tool",
+            tool: "bash",
+            state: { status: "completed", input: { command: "pnpm test" } },
+          },
+        },
+      ],
+    },
+  );
+
+  const adapter = new OpenCodeSessionAdapter({
+    dataDirectory,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WAITING);
+  assert.equal(observation?.detail?.activity, undefined);
+});
+
+test("reports a stopped OpenCode turn as waiting when its user aborted it", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  await writeOpenCodeState(
+    dataDirectory,
+    [{ id: "ses_aborted", directory: "/Users/test/luke", observedAt: TEST_TIME - 1_000 }],
+    {
+      messages: [
+        {
+          id: "msg_01",
+          sessionId: "ses_aborted",
+          time: TEST_TIME - 1_000,
+          data: {
+            role: "assistant",
+            time: { created: TEST_TIME - 2_000 },
+            error: { name: "MessageAbortedError", data: {} },
+          },
+        },
+      ],
+    },
+  );
+
+  const adapter = new OpenCodeSessionAdapter({
+    dataDirectory,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WAITING);
+  assert.equal(observation?.detail?.error, undefined);
+});
+
+test("reports a failed OpenCode turn with the failure it recorded", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  await writeOpenCodeState(
+    dataDirectory,
+    [
+      {
+        id: "ses_failed",
+        directory: "/Users/test/luke",
+        // A failure outlives freshness: it does not heal by going stale.
+        observedAt: TEST_TIME - 20 * 60 * 1000,
+      },
+    ],
+    {
+      messages: [
+        {
+          id: "msg_01",
+          sessionId: "ses_failed",
+          time: TEST_TIME - 20 * 60 * 1000,
+          data: {
+            role: "assistant",
+            time: { created: TEST_TIME - 20 * 60 * 1000 },
+            error: { name: "ProviderAuthError", data: { message: "API key is invalid" } },
+          },
+        },
+      ],
+    },
+  );
+
+  const adapter = new OpenCodeSessionAdapter({
+    dataDirectory,
+    now: () => TEST_TIME,
+    activeSessionFreshnessMs: 15 * 60 * 1000,
+    maximumSessionAgeMs: 60 * 60 * 1000,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.ERROR);
+  assert.equal(observation?.detail?.error, "API key is invalid");
+});
+
+test("names the tool an OpenCode session is running", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  await writeOpenCodeState(
+    dataDirectory,
+    [{ id: "ses_running", directory: "/Users/test/luke", observedAt: TEST_TIME - 1_000 }],
+    {
+      messages: [
+        {
+          id: "msg_01",
+          sessionId: "ses_running",
+          time: TEST_TIME - 1_000,
+          data: { role: "assistant", time: { created: TEST_TIME - 1_000 } },
+        },
+      ],
+      parts: [
+        {
+          id: "prt_01",
+          messageId: "msg_01",
+          sessionId: "ses_running",
+          time: TEST_TIME - 2_000,
+          data: { type: "step-start" },
+        },
+        {
+          id: "prt_02",
+          messageId: "msg_01",
+          sessionId: "ses_running",
+          time: TEST_TIME - 1_000,
+          data: {
+            type: "tool",
+            tool: "bash",
+            state: {
+              status: "running",
+              input: { command: "pnpm test" },
+              time: { start: TEST_TIME },
+            },
+          },
+        },
+      ],
+    },
+  );
+
+  const adapter = new OpenCodeSessionAdapter({
+    dataDirectory,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WORKING);
+  assert.equal(observation?.detail?.activity, "bash: pnpm test");
+});
+
+test("skips OpenCode subagent and archived sessions", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  await writeOpenCodeState(dataDirectory, [
+    {
+      id: "ses_parent",
+      directory: "/Users/test/luke",
+      observedAt: TEST_TIME - 1_000,
+      title: "Ship the release notes",
+    },
+    {
+      id: "ses_child",
+      directory: "/Users/test/luke",
+      observedAt: TEST_TIME - 500,
+      parentId: "ses_parent",
+    },
+    {
+      id: "ses_archived",
+      directory: "/Users/test/archived",
+      observedAt: TEST_TIME - 1_000,
+      archivedAt: TEST_TIME - 800,
+    },
+  ]);
+
+  const adapter = new OpenCodeSessionAdapter({
+    dataDirectory,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.providerSessionId),
+    ["ses_parent"],
+  );
+});
+
+test("filters old OpenCode sessions while preserving the newest", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  await writeOpenCodeState(dataDirectory, [
+    { id: "ses_old", directory: "/Users/test/old", observedAt: TEST_TIME - 90_000 },
+    { id: "ses_new", directory: "/Users/test/new", observedAt: TEST_TIME - 10_000 },
+  ]);
+
+  const adapter = new OpenCodeSessionAdapter({
+    dataDirectory,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.deepEqual(
+    observations.map((observation) => ({
+      providerSessionId: observation.providerSessionId,
+      title: observation.title,
+    })),
+    [{ providerSessionId: "ses_new", title: "new" }],
+  );
+});
+
+test("keeps stale open OpenCode turns unknown instead of inventing activity", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  await writeOpenCodeState(
+    dataDirectory,
+    [{ id: "ses_stale", directory: "/Users/test/stale", observedAt: TEST_TIME - 20 * 60 * 1000 }],
+    {
+      messages: [
+        {
+          id: "msg_01",
+          sessionId: "ses_stale",
+          time: TEST_TIME - 20 * 60 * 1000,
+          // An open turn: a killed OpenCode process leaves one on disk forever.
+          data: { role: "assistant", time: { created: TEST_TIME - 20 * 60 * 1000 } },
+        },
+      ],
+    },
+  );
+
+  const adapter = new OpenCodeSessionAdapter({
+    dataDirectory,
+    now: () => TEST_TIME,
+    activeSessionFreshnessMs: 15 * 60 * 1000,
+    maximumSessionAgeMs: 60 * 60 * 1000,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(observation?.detail?.activity, undefined);
+});
+
+test("observes the database OPENCODE_DB names", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  const previousDatabaseFile = process.env[TEST_OPENCODE_ENVIRONMENT.DATABASE_FILE];
+  process.env[TEST_OPENCODE_ENVIRONMENT.DATABASE_FILE] = "configured.db";
+  t.after(() => {
+    if (previousDatabaseFile === undefined) {
+      delete process.env[TEST_OPENCODE_ENVIRONMENT.DATABASE_FILE];
+    } else {
+      process.env[TEST_OPENCODE_ENVIRONMENT.DATABASE_FILE] = previousDatabaseFile;
+    }
+  });
+  await writeOpenCodeState(
+    dataDirectory,
+    [{ id: "ses_configured", directory: "/Users/test/configured", observedAt: TEST_TIME - 1_000 }],
+    { databaseFile: "configured.db" },
+  );
+
+  const adapter = new OpenCodeSessionAdapter({
+    dataDirectory,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "ses_configured");
+});
+
+test("falls back to the prod-channel database when the current one is unusable", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  await writeMalformedOpenCodeState(dataDirectory, OPENCODE_DATABASE);
+  await writeOpenCodeState(
+    dataDirectory,
+    [{ id: "ses_prod", directory: "/Users/test/prod", observedAt: TEST_TIME - 1_000 }],
+    { databaseFile: OPENCODE_PROD_DATABASE },
+  );
+
+  const adapter = new OpenCodeSessionAdapter({
+    dataDirectory,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "ses_prod");
+  assert.equal(observations[0]?.title, "prod");
+});
+
+test("observes sessions from a database predating the archive column", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  await writeEarlyOpenCodeState(dataDirectory, [
+    {
+      id: "ses_early",
+      directory: "/Users/test/early",
+      observedAt: TEST_TIME - 1_000,
+      title: "Rename the settings key",
+    },
+  ]);
+
+  const adapter = new OpenCodeSessionAdapter({
+    dataDirectory,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "ses_early");
+  assert.equal(observations[0]?.title, "Rename the settings key");
+});
+
+test("observes legacy JSON sessions when no database exists", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  await writeLegacySession(dataDirectory, "project-one", {
+    id: "ses_legacy",
+    title: "Migrate the settings store",
+    directory: "/Users/test/luke",
+    version: "1.1.0",
+    time: { created: TEST_TIME - 5_000, updated: TEST_TIME - 1_000 },
+  });
+  await writeLegacySession(dataDirectory, "project-one", {
+    id: "ses_legacy_child",
+    title: "Subagent",
+    directory: "/Users/test/luke",
+    parentID: "ses_legacy",
+    time: { created: TEST_TIME - 5_000, updated: TEST_TIME - 1_000 },
+  });
+  await writeLegacyMessage(dataDirectory, "ses_legacy", "msg_01", {
+    id: "msg_01",
+    sessionID: "ses_legacy",
+    role: "assistant",
+    time: { created: TEST_TIME - 2_000, completed: TEST_TIME - 1_000 },
+  });
+
+  const adapter = new OpenCodeSessionAdapter({
+    dataDirectory,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "ses_legacy");
+  assert.equal(observations[0]?.title, "Migrate the settings store");
+  assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
+  assert.deepEqual(observations[0]?.detail, { repository: "luke" });
+});
+
+test("reads the newest legacy message by its ordered identifier", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  await writeLegacySession(dataDirectory, "project-one", {
+    id: "ses_legacy_open",
+    title: "Long refactor",
+    directory: "/Users/test/luke",
+    time: { created: TEST_TIME - 5_000, updated: TEST_TIME - 1_000 },
+  });
+  await writeLegacyMessage(dataDirectory, "ses_legacy_open", "msg_01", {
+    role: "assistant",
+    time: { created: TEST_TIME - 4_000, completed: TEST_TIME - 3_000 },
+  });
+  await writeLegacyMessage(dataDirectory, "ses_legacy_open", "msg_02", {
+    role: "assistant",
+    time: { created: TEST_TIME - 2_000 },
+  });
+
+  const adapter = new OpenCodeSessionAdapter({
+    dataDirectory,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WORKING);
+});
+
+test("observes legacy JSON sessions when node sqlite is unavailable", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  await writeOpenCodeState(dataDirectory, [
+    { id: "ses_unreachable", directory: "/Users/test/luke", observedAt: TEST_TIME - 1_000 },
+  ]);
+  await writeLegacySession(dataDirectory, "project-one", {
+    id: "ses_legacy",
+    title: "Still observable",
+    directory: "/Users/test/luke",
+    time: { created: TEST_TIME - 5_000, updated: TEST_TIME - 1_000 },
+  });
+  const error = new Error("No such built-in module: node:sqlite") as NodeJS.ErrnoException;
+  error.code = TEST_SQLITE_ERROR.UNKNOWN_BUILTIN_MODULE;
+
+  const adapter = new OpenCodeSessionAdapter({
+    dataDirectory,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+    sqlite: async () => {
+      throw error;
+    },
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "ses_legacy");
+});
+
+test("returns an empty snapshot when OpenCode has no local state", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  const adapter = new OpenCodeSessionAdapter({
+    dataDirectory,
+    now: () => TEST_TIME,
+  });
+
+  assert.deepEqual(await adapter.observe(), []);
+});

--- a/packages/sidecar-core/src/providers.ts
+++ b/packages/sidecar-core/src/providers.ts
@@ -13,6 +13,7 @@ export const PROVIDER_ID = {
   CURSOR: "cursor",
   DEVIN: "devin",
   JULES: "jules",
+  OPENCODE: "opencode",
 } as const;
 
 export type ProviderId = (typeof PROVIDER_ID)[keyof typeof PROVIDER_ID];


### PR DESCRIPTION
## Summary

- Add an `OpenCodeSessionAdapter` beside the Claude Code and Codex adapters, observing OpenCode's own local state — the SQLite database every install since v1.2.0 keeps, with the short-lived prod-channel `opencode-prod.db` and the `OPENCODE_DB` override as fallback candidates, and the flat JSON files of v0.6–v1.1 when no database is usable. Filesystem-based, read-only, no credential, no `opencode serve`.
- Infer working vs waiting from the last message's bookkeeping (`time.completed`, recorded errors, the user-abort that ends a turn rather than wedging it), age-gated by the shared 24h/15min bounds; message text lives in part records and is never read. Sessions are labelled by OpenCode's own title, falling back to the workspace while the title is still the `New session - <timestamp>` placeholder. Subagent (`parent_id`) and archived sessions are not rows.
- Verified upstream before building, as the ticket asked: upstream is now `anomalyco/opencode` (v1.18.18; `sst/opencode` redirects), the data directory is XDG even on macOS, and the legacy layout's subdirectory is a project ID (today a SHA-1 of the git remote), not a path hash.
- Extract the SQLite plumbing the Codex adapter already used into a shared `local-sqlite` module; add the OpenCode provider mark via @lobehub/icons (MIT), README and PRIVACY.md entries.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (18 harness, 41 core, and 230 desktop tests; lint, typecheck, and builds passed), including 16 new OpenCode adapter tests covering both storage formats, schema drift, `OPENCODE_DB`, database fallback, and the no-`node:sqlite` path
- macOS Electron verification (`./scripts/verify.sh`): passed — packaging and all five deterministic fixture captures completed (compact/peek/speaking 1076×156, expanded/slot 1400×1120). The smoke fixture contains no OpenCode session, so captures are visually unchanged from main.

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Live-session check: verified manually against a real local OpenCode install by @dastratakos
- Device/display configuration: `not recorded`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c1e163dd-daac-4b2a-b2f2-36e0505fe4c4)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31752394801/artifacts/9201428877) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31752394801)

- Commit: `41749493ba86feee434e4a7ff6d2a2df90e8ca2f`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
