### PR TITLE
ci: report required checks on merge groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   push:
     branches: [main]
 


### PR DESCRIPTION
## Summary

- Add the `merge_group` trigger to the CI workflow so `TypeScript checks` and `macOS app and evidence` — the two required status checks on `main` — report against a merge group.

A merge queue validates a pull request by building a temporary `gh-readonly-queue/main/...` ref and dispatching a `merge_group` event. Required status checks are evaluated against that ref rather than the pull request, so a workflow that does not list `merge_group` as a trigger never reports at all: the queue waits out its status-check timeout and then evicts the batch. Both required checks live in this workflow, so this has to land on `main` before a merge queue is enabled.

Two adjacent behaviors were checked and need no change:

- The concurrency group already keys on `github.ref`, which is unique per merge group, so `cancel-in-progress` cannot cancel one queue entry on behalf of another.
- The evidence-linking step already guards on a `pull_request` event, so it and its `pull-requests: write` permission stay inert on a merge group.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — pass (exit 0, 0 test failures)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — workflow-trigger change only, no macOS, Electron-window, native-adapter, or UI surface touched

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31752953004/artifacts/9201642391) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31752953004)

- Commit: `c53f41bc8c5a098cbdb93ab7c495446d178aab0a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` — no UI change
- Physical-notch check: `not performed` — no UI change
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: This change is inert until a merge queue is actually enabled on `main`; it only adds an event trigger. The ruleset changes that enable the queue follow separately, after this merges.