### PR TITLE
feat(panel): let session rows glide to their new order

### DIFF
--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -9,6 +9,7 @@ import {
 } from "./session-model";
 import {
   SESSION_ROW_ID_ATTRIBUTE,
+  SESSION_ROW_LEAVING_ATTRIBUTE,
   useSessionReorderMotion,
   useSessionRoster,
 } from "./session-motion";
@@ -63,7 +64,7 @@ function SessionRow({
     [SESSION_ROW_ID_ATTRIBUTE]: session.id,
     // A leaving row holds its slot while it fades, but its session is already
     // gone from the model, so nothing may read, focus, or press it.
-    "data-leaving": String(leaving),
+    [SESSION_ROW_LEAVING_ATTRIBUTE]: String(leaving),
     inert: leaving,
     style: { "--row-index": index + 1 } as React.CSSProperties,
   };

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -162,7 +162,7 @@ export function PanelBody({
   settings,
 }: PanelBodyProps): React.JSX.Element {
   const sessionListRef = useSessionReorderMotion();
-  const rows = useSessionRoster(list.sessions);
+  const rows = useSessionRoster(list.sessions, sessionListRef);
   return (
     <div className="body">
       {/* The tab bar says what you are looking at; the options button says how

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -8,6 +8,11 @@ import {
   type SessionView,
 } from "./session-model";
 import {
+  SESSION_ROW_ID_ATTRIBUTE,
+  useSessionReorderMotion,
+  useSessionRoster,
+} from "./session-motion";
+import {
   BranchGlyph,
   CheckGlyph,
   EmptyState,
@@ -41,16 +46,25 @@ function SessionRow({
   session,
   index,
   now,
+  leaving,
   onOpen,
 }: {
   session: DisplaySession;
   index: number;
   now: number;
+  leaving: boolean;
   onOpen: (session: DisplaySession) => void;
 }): React.JSX.Element {
   const shared = {
     className: "session-row",
     "data-state": session.state,
+    // How the reorder measurement finds this row again after a re-sort has
+    // moved it, whichever element it is rendered as.
+    [SESSION_ROW_ID_ATTRIBUTE]: session.id,
+    // A leaving row holds its slot while it fades, but its session is already
+    // gone from the model, so nothing may read, focus, or press it.
+    "data-leaving": String(leaving),
+    inert: leaving,
     style: { "--row-index": index + 1 } as React.CSSProperties,
   };
   // The identifier that tells this row from its neighbours: the branch, or the
@@ -147,6 +161,8 @@ export function PanelBody({
   onTabChange,
   settings,
 }: PanelBodyProps): React.JSX.Element {
+  const sessionListRef = useSessionReorderMotion();
+  const rows = useSessionRoster(list.sessions);
   return (
     <div className="body">
       {/* The tab bar says what you are looking at; the options button says how
@@ -165,16 +181,17 @@ export function PanelBody({
           {offerOptions && optionsOpen ? (
             <SessionOptions list={list} view={view} onViewChange={onViewChange} />
           ) : null}
-          <div className="session-list">
-            {list.sessions.length === 0 ? (
+          <div className="session-list" ref={sessionListRef}>
+            {rows.length === 0 ? (
               <EmptyState />
             ) : (
-              list.sessions.map((session, index) => (
+              rows.map((row, index) => (
                 <SessionRow
-                  key={session.id}
-                  session={session}
+                  key={row.session.id}
+                  session={row.session}
                   index={index}
                   now={now}
+                  leaving={row.leaving}
                   onOpen={onOpenSession}
                 />
               ))

--- a/apps/desktop/src/renderer/session-motion.ts
+++ b/apps/desktop/src/renderer/session-motion.ts
@@ -40,6 +40,16 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
  */
 export const SESSION_ROW_ID_ATTRIBUTE = "data-session-id";
 
+/**
+ * How a row says it is on its way out. The fade it announces is drawn here
+ * rather than in the stylesheet, because the row's own opacity transition
+ * carries the panel-arrival stagger: a session that returned mid-fade would
+ * wait out `--expand-delay` before resuming. An animation never touches the
+ * property underneath, so cancelling it is all a return takes — the row is
+ * simply alive again, at once.
+ */
+export const SESSION_ROW_LEAVING_ATTRIBUTE = "data-leaving";
+
 const MOTION_TOKEN = {
   SPRING_FAST: "--spring-fast",
   FAST_DURATION: "--duration-fast",
@@ -130,6 +140,8 @@ function rowVisible(row: HTMLElement): boolean {
 export function useSessionReorderMotion(): RefObject<HTMLDivElement | null> {
   const listRef = useRef<HTMLDivElement | null>(null);
   const baseline = useRef<Map<string, number> | undefined>(undefined);
+  const wasLeaving = useRef<Set<string>>(new Set());
+  const exitFades = useRef<Map<string, Animation>>(new Map());
 
   // No dependency list: a reorder arrives as new props, but the measurement
   // has to follow every commit that could have moved a row, and a handful of
@@ -138,6 +150,8 @@ export function useSessionReorderMotion(): RefObject<HTMLDivElement | null> {
     const list = listRef.current;
     if (list === null) {
       baseline.current = undefined;
+      wasLeaving.current = new Set();
+      exitFades.current.clear();
       return;
     }
 
@@ -153,9 +167,33 @@ export function useSessionReorderMotion(): RefObject<HTMLDivElement | null> {
       tops.set(id, row.offsetTop);
     }
 
+    // Rows whose leaving mark changed this commit: the newly departed begin
+    // their fade, and the returned have theirs cancelled. A fade belonging to
+    // a row no longer drawn died with its node and is only forgotten here.
+    const departed: [string, HTMLElement][] = [];
+    const returned: [string, HTMLElement][] = [];
+    const leaving = new Set<string>();
+    for (const [id, row] of rows) {
+      if (row.getAttribute(SESSION_ROW_LEAVING_ATTRIBUTE) === "true") leaving.add(id);
+      const was = wasLeaving.current.has(id);
+      if (!was && leaving.has(id)) departed.push([id, row]);
+      else if (was && !leaving.has(id)) returned.push([id, row]);
+    }
+    wasLeaving.current = leaving;
+    for (const id of [...exitFades.current.keys()]) {
+      if (!rows.has(id)) exitFades.current.delete(id);
+    }
+
     const plan = planReorder(baseline.current, tops);
     baseline.current = tops;
-    if (plan.travels.size === 0 && plan.arrivals.length === 0) return;
+    if (
+      plan.travels.size === 0 &&
+      plan.arrivals.length === 0 &&
+      departed.length === 0 &&
+      returned.length === 0
+    ) {
+      return;
+    }
 
     const style = getComputedStyle(list);
     const token = (name: MotionToken) => style.getPropertyValue(name);
@@ -181,26 +219,59 @@ export function useSessionReorderMotion(): RefObject<HTMLDivElement | null> {
     // down with the layout effect; the rows arriving in place is the better
     // failure.
     try {
+      for (const [id, row] of departed) {
+        if (!rowVisible(row) || exitDuration < STILL_MS) continue;
+        exitFades.current.set(
+          id,
+          // From wherever the row's opacity is, held at nothing until the
+          // roster lets the node go: the fade must outlive its own end,
+          // because the property underneath still says the row is drawn.
+          row.animate([{ opacity: getComputedStyle(row).opacity }, { opacity: 0 }], {
+            duration: exitDuration,
+            easing: exitEasing,
+            fill: "forwards",
+          }),
+        );
+      }
+      for (const [id, row] of returned) {
+        const fade = exitFades.current.get(id);
+        if (fade === undefined) continue;
+        const held = getComputedStyle(row).opacity;
+        fade.cancel();
+        exitFades.current.delete(id);
+        if (rowVisible(row) && quickDuration >= STILL_MS) {
+          row.animate([{ opacity: held }, { opacity: 1 }], {
+            duration: quickDuration,
+            easing: exitEasing,
+          });
+        }
+      }
       for (const [id, from] of plan.travels) {
         const row = rows.get(id);
         if (row !== undefined && rowVisible(row)) travel(row, from, 0);
       }
+      // The entrance waits only when it has something to wait for. The beat
+      // exists so an arrival is never seen crossing a neighbour still leaving
+      // its slot; with nothing travelling there is no one to cross, and a
+      // first session held invisible would leave the panel blank for the
+      // length of the hold.
+      const beat = plan.travels.size > 0 ? exitDuration : 0;
       for (const id of plan.arrivals) {
         const row = rows.get(id);
         if (row === undefined || !rowVisible(row)) continue;
         // The gap is already opening — the neighbours started travelling the
         // moment this row took up space — so the row itself waits out the
-        // exit beat and then arrives the way the stack arrives: from one fan
-        // step above, on the same spring, becoming opaque as it drops.
+        // beat and then arrives the way the stack arrives: from one fan step
+        // above, on the same spring, becoming opaque as it drops.
         if (quickDuration >= STILL_MS) {
           row.animate([{ opacity: 0 }, { opacity: 1 }], {
             duration: quickDuration,
             easing: exitEasing,
-            delay: exitDuration,
+            delay: beat,
             fill: "backwards",
           });
         }
-        if (fan > 0) travel(row, -fan, exitDuration);
+        if (fan > 0) travel(row, -fan, beat);
       }
     } catch {
       // Nothing to unwind: additive travels decay to zero on their own.

--- a/apps/desktop/src/renderer/session-motion.ts
+++ b/apps/desktop/src/renderer/session-motion.ts
@@ -345,6 +345,25 @@ export function nextDepartures<T extends { id: string }>(
 }
 
 /**
+ * The departures once one of them has been let go. Each index was taken while
+ * every other departure still held its slot, so the rows below the vanished
+ * one step up a place — without that, a session still fading would be spliced
+ * one slot too far into the shorter list and jump mid-fade.
+ */
+export function withoutDeparture<T extends { id: string }>(
+  departures: readonly Departure<T>[],
+  id: string,
+): readonly Departure<T>[] {
+  const gone = departures.find((departure) => departure.session.id === id);
+  if (gone === undefined) return departures;
+  return departures
+    .filter((departure) => departure.session.id !== id)
+    .map((departure) =>
+      departure.index > gone.index ? { ...departure, index: departure.index - 1 } : departure,
+    );
+}
+
+/**
  * Holds each departed session on screen for the exit beat, so a removal is a
  * fade and then a closing gap rather than a row vanishing between frames. The
  * beat is `--duration-exit`, read at the moment of departure from the same
@@ -398,7 +417,7 @@ export function useSessionRoster<T extends { id: string }>(
           pending.delete(id);
           setState((previous) => ({
             ...previous,
-            departures: previous.departures.filter((other) => other.session.id !== id),
+            departures: withoutDeparture(previous.departures, id),
           }));
         }, beat),
       );

--- a/apps/desktop/src/renderer/session-motion.ts
+++ b/apps/desktop/src/renderer/session-motion.ts
@@ -1,0 +1,337 @@
+import type { RefObject } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+
+/**
+ * How the session list moves when its order changes under a reader.
+ *
+ * Every poll re-sorts the rows, and React answers a new order by moving DOM
+ * nodes — which repaints each row at its new position in one frame. A session
+ * finishing its turn would teleport from the top of the list to the middle,
+ * and the reader loses it. So the list is measured on every commit, and a row
+ * found somewhere new is started back where the reader last saw it and
+ * released — on `--spring-fast`, because a row hopping a slot is a small
+ * element moving, not the surface resizing.
+ *
+ * Reorders come and go on the panel's own two-beat rule: content leaves before
+ * the shape moves, and the shape moves before content arrives. A departing row
+ * fades over `--duration-exit` while it still holds its slot (the roster below
+ * keeps it rendered exactly that long), and only then do its neighbours close
+ * the gap. An arriving row opens its gap first — it is measured, so the
+ * neighbours travel at once — and only fades in after that same beat, so it is
+ * never seen crossing a row that has not yet left its slot.
+ *
+ * Each travel is additive rather than a replacement. A second reorder landing
+ * mid-flight does not cancel the first — cancelling is a dead stop and a
+ * re-acceleration, which is exactly the snap this module exists to remove — it
+ * adds its own delta on top, and the two decay together into the new resting
+ * place. That also keeps the bookkeeping honest: no animation is ever tracked,
+ * cancelled, or corrected for, because every one of them ends at zero.
+ *
+ * The distances, durations, and springs are read from the motion tokens rather
+ * than carried here, so a capture run (which zeroes them) and reduced motion
+ * (which collapses them to a millisecond) both silence this motion without
+ * knowing it exists.
+ */
+
+/**
+ * How each row names its session to the measurement pass. An attribute rather
+ * than a React ref, so the list can be read in document order in one query and
+ * the rows need no plumbing beyond carrying their own id.
+ */
+export const SESSION_ROW_ID_ATTRIBUTE = "data-session-id";
+
+const MOTION_TOKEN = {
+  SPRING_FAST: "--spring-fast",
+  FAST_DURATION: "--duration-fast",
+  EXIT_DURATION: "--duration-exit",
+  EXIT_EASING: "--motion-exit",
+  QUICK_DURATION: "--duration-quick",
+  ROW_FAN: "--row-fan",
+} as const;
+
+type MotionToken = (typeof MOTION_TOKEN)[keyof typeof MOTION_TOKEN];
+
+/** Movement smaller than a hairline is measurement noise, not a reorder. */
+const TRAVEL_EPSILON = 0.5;
+
+/**
+ * Below this, a duration is a request for stillness rather than for very fast
+ * motion: capture zeroes the tokens outright and reduced motion leaves 1ms so
+ * transitions still fire their end events. Neither wants an animation started.
+ */
+const STILL_MS = 2;
+
+/** "460ms" or "0.46s" from a computed token, taken as milliseconds. */
+export function parseMilliseconds(value: string): number {
+  const trimmed = value.trim();
+  const parsed = Number.parseFloat(trimmed);
+  if (Number.isNaN(parsed)) return 0;
+  return trimmed.endsWith("ms") ? parsed : parsed * 1000;
+}
+
+/** "7px" from a computed token, taken as pixels. */
+export function parsePixels(value: string): number {
+  const parsed = Number.parseFloat(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+export interface ReorderPlan {
+  /**
+   * Rows that persisted and moved: how far each must be offset, in pixels, to
+   * appear back where it was before springing to where it now sits.
+   */
+  travels: ReadonlyMap<string, number>;
+  /** Rows with no previous position: they arrived rather than moved. */
+  arrivals: readonly string[];
+}
+
+const EMPTY_PLAN: ReorderPlan = { travels: new Map(), arrivals: [] };
+
+/**
+ * What moved, given where each row was and where it now is. With no baseline
+ * at all — the first measurement of a freshly built list — nothing "moved" and
+ * nothing "arrived"; the list simply is, and animating it would replay an
+ * entrance the panel's own arrival already owns. A baseline of an empty list
+ * is different: a session appearing in one the reader is watching is an event.
+ * Rows that left are not planned for — their exit is the roster's beat, and by
+ * the time they leave this measurement their nodes are already gone.
+ */
+export function planReorder(
+  previous: ReadonlyMap<string, number> | undefined,
+  next: ReadonlyMap<string, number>,
+): ReorderPlan {
+  if (previous === undefined) return EMPTY_PLAN;
+
+  const travels = new Map<string, number>();
+  const arrivals: string[] = [];
+  for (const [id, top] of next) {
+    const before = previous.get(id);
+    if (before === undefined) {
+      arrivals.push(id);
+      continue;
+    }
+    const travel = before - top;
+    if (Math.abs(travel) > TRAVEL_EPSILON) travels.set(id, travel);
+  }
+  return { travels, arrivals };
+}
+
+/** Only rows a reader can see are worth moving; hidden ones just take their place. */
+function rowVisible(row: HTMLElement): boolean {
+  return row.checkVisibility({ opacityProperty: true });
+}
+
+/**
+ * Watches the session list across commits and turns every reorder into motion.
+ * Returns the ref the list container must carry; a commit that unmounts the
+ * container (the settings tab, the slot) drops the baseline, so the next list
+ * built starts still instead of animating against positions from another life.
+ */
+export function useSessionReorderMotion(): RefObject<HTMLDivElement | null> {
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const baseline = useRef<Map<string, number> | undefined>(undefined);
+
+  // No dependency list: a reorder arrives as new props, but the measurement
+  // has to follow every commit that could have moved a row, and a handful of
+  // offset reads per commit costs less than proving which commits those are.
+  useLayoutEffect(() => {
+    const list = listRef.current;
+    if (list === null) {
+      baseline.current = undefined;
+      return;
+    }
+
+    const rows = new Map<string, HTMLElement>();
+    // `offsetTop` rather than a rect: it is the row's layout position, blind
+    // to both the scroll and every animation still in flight, so the baseline
+    // never needs correcting for either.
+    const tops = new Map<string, number>();
+    for (const row of list.querySelectorAll<HTMLElement>(`[${SESSION_ROW_ID_ATTRIBUTE}]`)) {
+      const id = row.getAttribute(SESSION_ROW_ID_ATTRIBUTE);
+      if (id === null) continue;
+      rows.set(id, row);
+      tops.set(id, row.offsetTop);
+    }
+
+    const plan = planReorder(baseline.current, tops);
+    baseline.current = tops;
+    if (plan.travels.size === 0 && plan.arrivals.length === 0) return;
+
+    const style = getComputedStyle(list);
+    const token = (name: MotionToken) => style.getPropertyValue(name);
+    const fastDuration = parseMilliseconds(token(MOTION_TOKEN.FAST_DURATION));
+    if (fastDuration < STILL_MS) return;
+    const springFast = token(MOTION_TOKEN.SPRING_FAST).trim() || "ease";
+    const exitDuration = parseMilliseconds(token(MOTION_TOKEN.EXIT_DURATION));
+    const quickDuration = parseMilliseconds(token(MOTION_TOKEN.QUICK_DURATION));
+    const exitEasing = token(MOTION_TOKEN.EXIT_EASING).trim() || "ease";
+    const fan = parsePixels(token(MOTION_TOKEN.ROW_FAN));
+
+    const travel = (row: HTMLElement, from: number, delay: number) => {
+      row.animate([{ transform: `translateY(${from}px)` }, { transform: "translateY(0px)" }], {
+        duration: fastDuration,
+        easing: springFast,
+        delay,
+        fill: "backwards",
+        composite: "add",
+      });
+    };
+
+    // A malformed token would throw out of `animate` and take the whole tree
+    // down with the layout effect; the rows arriving in place is the better
+    // failure.
+    try {
+      for (const [id, from] of plan.travels) {
+        const row = rows.get(id);
+        if (row !== undefined && rowVisible(row)) travel(row, from, 0);
+      }
+      for (const id of plan.arrivals) {
+        const row = rows.get(id);
+        if (row === undefined || !rowVisible(row)) continue;
+        // The gap is already opening — the neighbours started travelling the
+        // moment this row took up space — so the row itself waits out the
+        // exit beat and then arrives the way the stack arrives: from one fan
+        // step above, on the same spring, becoming opaque as it drops.
+        if (quickDuration >= STILL_MS) {
+          row.animate([{ opacity: 0 }, { opacity: 1 }], {
+            duration: quickDuration,
+            easing: exitEasing,
+            delay: exitDuration,
+            fill: "backwards",
+          });
+        }
+        if (fan > 0) travel(row, -fan, exitDuration);
+      }
+    } catch {
+      // Nothing to unwind: additive travels decay to zero on their own.
+    }
+  });
+
+  return listRef;
+}
+
+/**
+ * One row as the list actually draws it: a session, and whether it is on its
+ * way out. A leaving row still holds its slot — the gap only closes once it
+ * has finished fading — but it is already gone from the model, so the panel
+ * renders it inert.
+ */
+export interface RosterRow<T> {
+  session: T;
+  leaving: boolean;
+}
+
+interface Departure<T> {
+  session: T;
+  /** The slot it held when it left, so it fades where the reader last saw it. */
+  index: number;
+}
+
+interface RosterState<T> {
+  /** The list this roster was derived from, so a new one is noticed in render. */
+  sessions: readonly T[];
+  departures: readonly Departure<T>[];
+}
+
+/** The rows to draw: the living list, with each departure still in its slot. */
+export function rosterRows<T extends { id: string }>(
+  sessions: readonly T[],
+  departures: readonly Departure<T>[],
+): readonly RosterRow<T>[] {
+  const rows: RosterRow<T>[] = sessions.map((session) => ({ session, leaving: false }));
+  // Ascending, so each splice lands at the slot measured against the rows
+  // already re-inserted below it.
+  for (const departure of [...departures].sort((first, second) => first.index - second.index)) {
+    rows.splice(Math.min(departure.index, rows.length), 0, {
+      session: departure.session,
+      leaving: true,
+    });
+  }
+  return rows;
+}
+
+/**
+ * The departures after a new list arrives: everything already fading that has
+ * not come back, plus every drawn row the new list no longer contains, held at
+ * the slot it was drawn in. A session that returns mid-fade is simply alive
+ * again — its departure is dropped and the row it kept is the row it resumes.
+ */
+export function nextDepartures<T extends { id: string }>(
+  drawn: readonly RosterRow<T>[],
+  sessions: readonly T[],
+  departures: readonly Departure<T>[],
+): readonly Departure<T>[] {
+  const alive = new Set(sessions.map((session) => session.id));
+  const kept = departures.filter((departure) => !alive.has(departure.session.id));
+  const leaving = new Set(kept.map((departure) => departure.session.id));
+  const next = [...kept];
+  drawn.forEach((row, index) => {
+    if (!alive.has(row.session.id) && !leaving.has(row.session.id)) {
+      next.push({ session: row.session, index });
+    }
+  });
+  return next;
+}
+
+/**
+ * Holds each departed session on screen for the exit beat, so a removal is a
+ * fade and then a closing gap rather than a row vanishing between frames. The
+ * beat is `--duration-exit`, read from the tokens at the moment of departure,
+ * so reduced motion (1ms) lets go almost at once.
+ */
+export function useSessionRoster<T extends { id: string }>(
+  sessions: readonly T[],
+): readonly RosterRow<T>[] {
+  const [state, setState] = useState<RosterState<T>>({ sessions, departures: [] });
+
+  // Derived during render rather than in an effect: an effect runs after the
+  // commit, and the commit is exactly when React would have unmounted the
+  // departing row this roster exists to keep.
+  if (state.sessions !== sessions) {
+    setState({
+      sessions,
+      departures: nextDepartures(
+        rosterRows(state.sessions, state.departures),
+        sessions,
+        state.departures,
+      ),
+    });
+  }
+
+  const timers = useRef<Map<string, number>>(new Map());
+  useEffect(() => {
+    const pending = timers.current;
+    const leaving = new Set(state.departures.map((departure) => departure.session.id));
+    for (const [id, timer] of pending) {
+      if (!leaving.has(id)) {
+        window.clearTimeout(timer);
+        pending.delete(id);
+      }
+    }
+    for (const departure of state.departures) {
+      const id = departure.session.id;
+      if (pending.has(id)) continue;
+      const beat = parseMilliseconds(
+        getComputedStyle(document.documentElement).getPropertyValue(MOTION_TOKEN.EXIT_DURATION),
+      );
+      pending.set(
+        id,
+        window.setTimeout(() => {
+          pending.delete(id);
+          setState((previous) => ({
+            ...previous,
+            departures: previous.departures.filter((other) => other.session.id !== id),
+          }));
+        }, beat),
+      );
+    }
+  }, [state.departures]);
+  useEffect(() => {
+    const pending = timers.current;
+    return () => {
+      for (const timer of pending.values()) window.clearTimeout(timer);
+    };
+  }, []);
+
+  return rosterRows(state.sessions, state.departures);
+}

--- a/apps/desktop/src/renderer/session-motion.ts
+++ b/apps/desktop/src/renderer/session-motion.ts
@@ -276,11 +276,16 @@ export function nextDepartures<T extends { id: string }>(
 /**
  * Holds each departed session on screen for the exit beat, so a removal is a
  * fade and then a closing gap rather than a row vanishing between frames. The
- * beat is `--duration-exit`, read from the tokens at the moment of departure,
- * so reduced motion (1ms) lets go almost at once.
+ * beat is `--duration-exit`, read at the moment of departure from the same
+ * element the leaving fade inherits it through — a capture run zeroes the
+ * token on the stage rather than at the root, and a roster that read the root
+ * would hold a gap open for 90ms after the fade had already finished — so the
+ * two always let go together. The root is only the fallback for a commit with
+ * no list to read, where no row is drawn and the beat times nothing visible.
  */
 export function useSessionRoster<T extends { id: string }>(
   sessions: readonly T[],
+  stage: RefObject<HTMLElement | null>,
 ): readonly RosterRow<T>[] {
   const [state, setState] = useState<RosterState<T>>({ sessions, departures: [] });
 
@@ -312,7 +317,9 @@ export function useSessionRoster<T extends { id: string }>(
       const id = departure.session.id;
       if (pending.has(id)) continue;
       const beat = parseMilliseconds(
-        getComputedStyle(document.documentElement).getPropertyValue(MOTION_TOKEN.EXIT_DURATION),
+        getComputedStyle(stage.current ?? document.documentElement).getPropertyValue(
+          MOTION_TOKEN.EXIT_DURATION,
+        ),
       );
       pending.set(
         id,
@@ -325,7 +332,7 @@ export function useSessionRoster<T extends { id: string }>(
         }, beat),
       );
     }
-  }, [state.departures]);
+  }, [state.departures, stage]);
   useEffect(() => {
     const pending = timers.current;
     return () => {

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1227,17 +1227,11 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   transform: none;
 }
 
-/* A departing session leaves the way the panel itself closes: content first,
-   shape after. The roster in session-motion keeps the row rendered for exactly
-   `--duration-exit`, so this fade is what the reader sees of it, and only once
-   it is gone do the neighbours spring in over the gap. The stagger is cleared
-   because it belongs to arrivals — a leave that waited out `--row-delay` would
-   outlive the roster's beat and be cut mid-fade. */
-.app-stage[data-presentation="panel"] .session-row[data-leaving="true"] {
-  --row-delay: 0s;
-
-  opacity: 0;
-}
+/* A departing session's fade is drawn by session-motion rather than here: the
+   row's opacity transition above carries the panel-arrival stagger, and a
+   session that returned mid-fade would wait out `--expand-delay` before
+   resuming. An animation leaves the property underneath untouched, so a
+   return only has to cancel it. */
 
 /* Settings --------------------------------------------------------------- */
 

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1227,6 +1227,18 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   transform: none;
 }
 
+/* A departing session leaves the way the panel itself closes: content first,
+   shape after. The roster in session-motion keeps the row rendered for exactly
+   `--duration-exit`, so this fade is what the reader sees of it, and only once
+   it is gone do the neighbours spring in over the gap. The stagger is cleared
+   because it belongs to arrivals — a leave that waited out `--row-delay` would
+   outlive the roster's beat and be cut mid-fade. */
+.app-stage[data-presentation="panel"] .session-row[data-leaving="true"] {
+  --row-delay: 0s;
+
+  opacity: 0;
+}
+
 /* Settings --------------------------------------------------------------- */
 
 /* Scrolls on the same terms as the session list: contained, never chaining out
@@ -1903,6 +1915,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   --duration-shape: 0s;
   --duration-exit: 0s;
   --duration-quick: 0s;
+  --duration-fast: 0s;
   --expand-delay: 0s;
   --row-stagger: 0s;
   /* Luke blinks and sways on a loop with no end to wait for, so a capture would

--- a/apps/desktop/tests/session-motion.test.ts
+++ b/apps/desktop/tests/session-motion.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  nextDepartures,
+  parseMilliseconds,
+  parsePixels,
+  planReorder,
+  rosterRows,
+} from "../src/renderer/session-motion";
+
+const tops = (entries: Record<string, number>) => new Map(Object.entries(entries));
+
+const sessions = (...ids: string[]) => ids.map((id) => ({ id }));
+
+test("a row found somewhere new travels back by exactly the distance it moved", () => {
+  const plan = planReorder(tops({ a: 0, b: 75 }), tops({ a: 75, b: 0 }));
+  // `a` moved down 75px, so it starts 75px up — where it was — and vice versa.
+  assert.equal(plan.travels.get("a"), -75);
+  assert.equal(plan.travels.get("b"), 75);
+});
+
+test("a row that kept its place is left alone", () => {
+  const plan = planReorder(tops({ a: 0, b: 75 }), tops({ a: 0, b: 75.2 }));
+  assert.equal(plan.travels.size, 0);
+  assert.equal(plan.arrivals.length, 0);
+});
+
+test("with no baseline nothing moves and nothing arrives", () => {
+  const plan = planReorder(undefined, tops({ a: 0, b: 75 }));
+  assert.equal(plan.travels.size, 0);
+  assert.equal(plan.arrivals.length, 0);
+});
+
+test("a session appearing in a watched empty list is an arrival", () => {
+  const plan = planReorder(tops({}), tops({ a: 0 }));
+  assert.deepEqual(plan.arrivals, ["a"]);
+});
+
+test("an arrival shifts its neighbours rather than replaying them", () => {
+  const plan = planReorder(tops({ a: 0, b: 75 }), tops({ c: 0, a: 75, b: 150 }));
+  assert.deepEqual(plan.arrivals, ["c"]);
+  assert.equal(plan.travels.get("a"), -75);
+  assert.equal(plan.travels.get("b"), -75);
+});
+
+test("a departed row is not planned for", () => {
+  const plan = planReorder(tops({ a: 0, b: 75 }), tops({ a: 0 }));
+  assert.equal(plan.travels.size, 0);
+  assert.equal(plan.arrivals.length, 0);
+});
+
+test("durations are read in either unit the tokens use", () => {
+  assert.equal(parseMilliseconds("460ms"), 460);
+  assert.equal(parseMilliseconds("0.46s"), 460);
+  assert.equal(parseMilliseconds(" 0s "), 0);
+  // An unset token computes to the empty string, which must read as stillness.
+  assert.equal(parseMilliseconds(""), 0);
+});
+
+test("the fan distance reads as pixels, and an unset token as none", () => {
+  assert.equal(parsePixels("7px"), 7);
+  assert.equal(parsePixels(""), 0);
+});
+
+test("a session missing from the new list becomes a departure holding its slot", () => {
+  const drawn = rosterRows(sessions("a", "b", "c"), []);
+  const departures = nextDepartures(drawn, sessions("a", "c"), []);
+  assert.deepEqual(departures, [{ session: { id: "b" }, index: 1 }]);
+});
+
+test("a departure is drawn in the slot it held, marked leaving", () => {
+  const rows = rosterRows(sessions("a", "c"), [{ session: { id: "b" }, index: 1 }]);
+  assert.deepEqual(
+    rows.map((row) => [row.session.id, row.leaving]),
+    [
+      ["a", false],
+      ["b", true],
+      ["c", false],
+    ],
+  );
+});
+
+test("a departure that held a slot past the end is drawn last", () => {
+  const rows = rosterRows(sessions("a"), [{ session: { id: "z" }, index: 4 }]);
+  assert.deepEqual(
+    rows.map((row) => row.session.id),
+    ["a", "z"],
+  );
+});
+
+test("several departures keep their order among the living rows", () => {
+  const rows = rosterRows(sessions("b", "d"), [
+    { session: { id: "c" }, index: 2 },
+    { session: { id: "a" }, index: 0 },
+  ]);
+  assert.deepEqual(
+    rows.map((row) => row.session.id),
+    ["a", "b", "c", "d"],
+  );
+});
+
+test("a session returning mid-fade is alive again rather than a departure", () => {
+  const departures = [{ session: { id: "b" }, index: 1 }];
+  const drawn = rosterRows(sessions("a", "c"), departures);
+  assert.deepEqual(nextDepartures(drawn, sessions("a", "b", "c"), departures), []);
+});
+
+test("a departure still fading is kept while another begins", () => {
+  const departures = [{ session: { id: "b" }, index: 1 }];
+  const drawn = rosterRows(sessions("a", "c"), departures);
+  const next = nextDepartures(drawn, sessions("a"), departures);
+  assert.deepEqual(next, [
+    { session: { id: "b" }, index: 1 },
+    { session: { id: "c" }, index: 2 },
+  ]);
+});

--- a/apps/desktop/tests/session-motion.test.ts
+++ b/apps/desktop/tests/session-motion.test.ts
@@ -6,6 +6,7 @@ import {
   parsePixels,
   planReorder,
   rosterRows,
+  withoutDeparture,
 } from "../src/renderer/session-motion";
 
 const tops = (entries: Record<string, number>) => new Map(Object.entries(entries));
@@ -103,6 +104,34 @@ test("a session returning mid-fade is alive again rather than a departure", () =
   const departures = [{ session: { id: "b" }, index: 1 }];
   const drawn = rosterRows(sessions("a", "c"), departures);
   assert.deepEqual(nextDepartures(drawn, sessions("a", "b", "c"), departures), []);
+});
+
+test("a departure expiring steps the ones below it up a slot", () => {
+  // From [a, b, c, d, e], b and d left: b holds slot 1 and d slot 3. When b is
+  // let go, d must still sit between c and e rather than jump past the end.
+  const departures = [
+    { session: { id: "b" }, index: 1 },
+    { session: { id: "d" }, index: 3 },
+  ];
+  const remaining = withoutDeparture(departures, "b");
+  assert.deepEqual(remaining, [{ session: { id: "d" }, index: 2 }]);
+  assert.deepEqual(
+    rosterRows(sessions("a", "c", "e"), remaining).map((row) => row.session.id),
+    ["a", "c", "d", "e"],
+  );
+});
+
+test("a departure expiring leaves the ones above it in place", () => {
+  const departures = [
+    { session: { id: "b" }, index: 1 },
+    { session: { id: "d" }, index: 3 },
+  ];
+  assert.deepEqual(withoutDeparture(departures, "d"), [{ session: { id: "b" }, index: 1 }]);
+});
+
+test("letting go of a session that is not departing changes nothing", () => {
+  const departures = [{ session: { id: "b" }, index: 1 }];
+  assert.deepEqual(withoutDeparture(departures, "x"), departures);
 });
 
 test("a departure still fading is kept while another begins", () => {


### PR DESCRIPTION
Every poll re-sorts the session list, and React answers a new order by moving
DOM nodes — so a row teleported to its new slot in one frame, and the reader
lost the session they were watching.

The list is now measured on every commit (`session-motion.ts`), and each row
found somewhere new is started back where the reader last saw it and released
on `--spring-fast` — a row hopping a slot is a small element moving, not the
surface resizing. Three details carry the feel:

- **Travels are additive rather than replacements.** A reorder landing
  mid-flight does not cancel the running spring — cancelling is a dead stop
  and a re-acceleration — it adds its own decaying delta on top
  (`composite: "add"`), and the two settle together. That is also what keeps
  the bookkeeping honest: no animation is tracked, cancelled, or corrected
  for, because every one ends at zero.
- **Rows come and go on the panel's own two-beat rule.** A departing session
  fades over `--duration-exit` while a roster holds its slot — only then does
  the gap close. An arriving one opens its gap at once (it is in layout, so
  the neighbours travel immediately) and fades in after that same beat, from
  one `--row-fan` step above, so it is never seen crossing a row that has not
  left its slot.
- **Layout is read through `offsetTop`**, which is blind to both the scroll
  and every animation still in flight, so the baseline never needs
  correcting for either.

Everything reads from the motion tokens, so a capture run and reduced motion
silence the whole module without knowing it exists; `--duration-fast` joins
the tokens the capture block zeroes, keeping the evidence PNGs deterministic.

## Verification

- `./scripts/check.sh` — passes after the rebase onto `main`'s row redesign
  (274 desktop tests; lint, typecheck, and builds).
- New unit tests pin the reorder plan (travel distances, arrivals against an
  empty-but-watched list vs. no baseline, departed rows) and the roster (a
  departure holds its slot, a session returning mid-fade is simply alive
  again, overlapping departures keep their order).
- Chromium (the renderer's engine) probed via CDP: an additive retarget
  mid-flight continues from the row's exact visual position with no snap,
  both travels decay to zero, and the rows settle at pure layout with no
  animations left behind.
- Physical-notch check: not performed — authored in a Linux sandbox; CI's
  `verify.sh` run supplies the macOS evidence below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/3ebea30f-741b-43f8-b8cc-ce30a987baf0)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31755524797/artifacts/9202587871) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31755524797)

- Commit: `9ff9c9ed106656046bccadb765dead545a11dd2d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
