### PR TITLE
feat(settings): add a menu bar visibility setting

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -859,11 +859,14 @@ if (!app.requestSingleInstanceLock()) {
     // Resolving settings touches the filesystem, and the OS keychain only for a
     // provider that already has a stored key to decrypt. Starting it here keeps
     // that work off the renderer's first paint, which blocks on the bootstrap
-    // reply. The status item waits for the answer because whether to draw it at
-    // all is part of it; a settings file that cannot be read leaves the item
-    // shown, the same answer a file that has never said gives.
-    void settingsStore.snapshot().then(
-      (settings) => applyMenuBarVisibility(settings.showInMenuBar),
+    // reply.
+    void settingsStore.snapshot();
+    // The status item waits only for the settings file, never for the keychain
+    // behind the stored keys: a locked or slow Keychain must not delay the one
+    // fixed point Luke has outside the notch. A file that cannot be read
+    // leaves the item shown, the same answer a file that has never said gives.
+    void settingsStore.showInMenuBar().then(
+      (show) => applyMenuBarVisibility(show),
       () => applyMenuBarVisibility(true),
     );
     reportVoiceAvailability();

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -529,6 +529,28 @@ function registerIpc(): void {
     },
   );
 
+  // The status item follows the stored answer at once: a setting that only
+  // took effect on the next launch would read as a toggle that does nothing.
+  ipcMain.handle(
+    channels.setShowInMenuBar,
+    async (event, show: unknown): Promise<SettingsUpdateResult> => {
+      if (!trustedSender(event)) throw new Error("Untrusted renderer");
+      if (typeof show !== "boolean") throw new Error("Invalid menu bar request");
+      try {
+        const result = await settingsStore.setShowInMenuBar(show);
+        applyMenuBarVisibility(result.settings.showInMenuBar);
+        return result;
+      } catch {
+        // A filesystem failure is not something the user can act on, so it is
+        // reported as one line rather than as a raw system error.
+        return {
+          settings: await settingsStore.snapshot(),
+          reason: "Could not save that setting on this system.",
+        };
+      }
+    },
+  );
+
   // Where to get a key is a question the panel cannot answer itself, so it
   // hands the question to the browser. The renderer names a provider rather
   // than an address: the pages Luke can open are the ones in the provider
@@ -774,13 +796,31 @@ function createTray(): void {
   const image = trayImage();
   tray = new Tray(image);
   // A status item that draws nothing is a status item no one can find, and this
-  // one is the only way to reach Settings or to quit. If the artwork is ever
-  // missing from a build, the name it used to carry stands in for it.
+  // one is the quickest way to reach Settings or to quit. If the artwork is
+  // ever missing from a build, the name it used to carry stands in for it.
   if (image.isEmpty()) tray.setTitle("Luke");
   tray.setToolTip("Luke");
   // Clicking opens the menu and nothing else. The capsule is how the panel is
   // opened; a menu bar item that also toggled it made one of them a surprise.
   tray.setContextMenu(trayMenu());
+}
+
+function destroyTray(): void {
+  tray?.destroy();
+  tray = undefined;
+}
+
+/**
+ * Draws or removes the status item to match the setting. Hiding it loses no
+ * capability — Settings and Quit are both in the panel — which is what makes
+ * this the user's choice rather than Luke's.
+ */
+function applyMenuBarVisibility(show: boolean): void {
+  if (show) {
+    if (!tray) createTray();
+    return;
+  }
+  destroyTray();
 }
 
 function handleDisplayChange(): void {
@@ -819,8 +859,13 @@ if (!app.requestSingleInstanceLock()) {
     // Resolving settings touches the filesystem, and the OS keychain only for a
     // provider that already has a stored key to decrypt. Starting it here keeps
     // that work off the renderer's first paint, which blocks on the bootstrap
-    // reply.
-    void settingsStore.snapshot();
+    // reply. The status item waits for the answer because whether to draw it at
+    // all is part of it; a settings file that cannot be read leaves the item
+    // shown, the same answer a file that has never said gives.
+    void settingsStore.snapshot().then(
+      (settings) => applyMenuBarVisibility(settings.showInMenuBar),
+      () => applyMenuBarVisibility(true),
+    );
     reportVoiceAvailability();
     // The report is not made here: the helper answers over its own stdout a
     // moment later, and a line printed now would state an absence that only
@@ -828,7 +873,6 @@ if (!app.requestSingleInstanceLock()) {
     registerVoiceHotkey();
     createPanel();
     configurePermissions();
-    createTray();
     startSessionObservation();
 
     screen.on("display-added", handleDisplayChange);

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -36,6 +36,8 @@ const bridge: AppBridge = {
   openProviderApiKeys: (providerId: CredentialProviderId) => {
     ipcRenderer.send(channels.openProviderApiKeys, providerId);
   },
+  setShowInMenuBar: (show: boolean) =>
+    ipcRenderer.invoke(channels.setShowInMenuBar, show) as Promise<SettingsUpdateResult>,
   openSession: (identity: SessionIdentity) => {
     ipcRenderer.send(channels.openSession, identity);
   },

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -617,6 +617,17 @@ export function App(): React.JSX.Element {
     [applyEntry],
   );
 
+  /**
+   * Shows or hides the menu bar status item. The reply carries the whole
+   * snapshot either way, so the row reads the state the store actually holds
+   * rather than the one the press hoped for.
+   */
+  const changeShowInMenuBar = useCallback(async (show: boolean) => {
+    const result = await window.sidecar.setShowInMenuBar(show);
+    setSettings(result.settings);
+    return result.reason;
+  }, []);
+
   const credentials: CredentialEntryControl = {
     entry,
     begin: beginEntry,
@@ -967,6 +978,7 @@ export function App(): React.JSX.Element {
               panelOpen,
               ...(shownHotkey.hotkey ? { voiceHotkey: shownHotkey.hotkey } : {}),
               voiceHotkeyHeld: shownHotkey.held,
+              onShowInMenuBarChange: changeShowInMenuBar,
               onQuit: () => window.sidecar.quit(),
             }}
           />

--- a/apps/desktop/src/renderer/settings-icons.tsx
+++ b/apps/desktop/src/renderer/settings-icons.tsx
@@ -111,26 +111,26 @@ export function ExternalIcon(): React.JSX.Element {
   );
 }
 
-/**
- * A screen with the bar across its top and the status item's dot at the bar's
- * right end, which is where this group's subject lives.
- */
-export function MenuBarIcon(): React.JSX.Element {
-  return (
-    <Glyph>
-      <rect x="2.4" y="4.2" width="19.2" height="15.6" rx="2.4" />
-      <path d="M2.4 8.6h19.2" />
-      <path d="M17.8 6.4h.01" />
-    </Glyph>
-  );
-}
-
 export function PowerIcon(): React.JSX.Element {
   return (
     <Glyph>
       <path d="M12 3v8.4" />
       <path d="M17.6 6.2a7.6 7.6 0 1 1-11.2 0" />
     </Glyph>
+  );
+}
+
+/** Two sliders, drawn once for both controls that mean "choices". */
+function SliderMarks(): React.JSX.Element {
+  return (
+    <>
+      <path d="M3.6 8.4h5.2" />
+      <path d="M13.2 8.4h7.2" />
+      <circle cx="11" cy="8.4" r="2.2" />
+      <path d="M3.6 15.6h2.6" />
+      <path d="M10.6 15.6h9.8" />
+      <circle cx="8.4" cy="15.6" r="2.2" />
+    </>
   );
 }
 
@@ -141,12 +141,16 @@ export function PowerIcon(): React.JSX.Element {
 export function OptionsIcon(): React.JSX.Element {
   return (
     <Glyph className="options-glyph">
-      <path d="M3.6 8.4h5.2" />
-      <path d="M13.2 8.4h7.2" />
-      <circle cx="11" cy="8.4" r="2.2" />
-      <path d="M3.6 15.6h2.6" />
-      <path d="M10.6 15.6h9.8" />
-      <circle cx="8.4" cy="15.6" r="2.2" />
+      <SliderMarks />
+    </Glyph>
+  );
+}
+
+/** The same two sliders at a heading's size: settings the user has chosen. */
+export function PreferencesIcon(): React.JSX.Element {
+  return (
+    <Glyph>
+      <SliderMarks />
     </Glyph>
   );
 }

--- a/apps/desktop/src/renderer/settings-icons.tsx
+++ b/apps/desktop/src/renderer/settings-icons.tsx
@@ -111,6 +111,20 @@ export function ExternalIcon(): React.JSX.Element {
   );
 }
 
+/**
+ * A screen with the bar across its top and the status item's dot at the bar's
+ * right end, which is where this group's subject lives.
+ */
+export function MenuBarIcon(): React.JSX.Element {
+  return (
+    <Glyph>
+      <rect x="2.4" y="4.2" width="19.2" height="15.6" rx="2.4" />
+      <path d="M2.4 8.6h19.2" />
+      <path d="M17.8 6.4h.01" />
+    </Glyph>
+  );
+}
+
 export function PowerIcon(): React.JSX.Element {
   return (
     <Glyph>

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -26,9 +26,9 @@ import {
   ExternalIcon,
   KeyboardIcon,
   KeyIcon,
-  MenuBarIcon,
   PencilIcon,
   PowerIcon,
+  PreferencesIcon,
   ShieldIcon,
   TrashIcon,
 } from "./settings-icons";
@@ -444,7 +444,7 @@ function CredentialsSection({
   // about storage nobody has tried to use yet would be a guess.
   const storageUnavailable = settings.secretStorage === SECRET_STORAGE.UNAVAILABLE;
   return (
-    <section className="settings-section" style={{ "--row-index": 2 } as React.CSSProperties}>
+    <section className="settings-section" style={{ "--row-index": 3 } as React.CSSProperties}>
       <h2>
         <KeyIcon />
         Cloud API keys
@@ -470,18 +470,20 @@ function CredentialsSection({
 }
 
 /**
- * Whether Luke stands in the menu bar as well as at the notch. One line and one
- * control, because nothing rides on the answer: Settings and Quit live in this
- * panel, so the status item is a second door rather than the only one.
+ * The user's own choices about Luke, ahead of the sections about what Luke can
+ * reach. One so far: whether the status item stands in the menu bar as well as
+ * at the notch. A switch and nothing else, because nothing rides on the answer
+ * — Settings and Quit live in this panel, so the item is a second door rather
+ * than the only one.
  */
-function MenuBarSection({
+function PreferencesSection({
   shown,
   onChange,
 }: {
   shown: boolean;
   onChange: (show: boolean) => Promise<string | undefined>;
 }): React.JSX.Element {
-  // The change is a round trip through the settings file, so the control rests
+  // The change is a round trip through the settings file, so the switch rests
   // until the store has answered rather than claiming a state it may not get.
   const [busy, setBusy] = useState(false);
   const [rejection, setRejection] = useState<string>();
@@ -491,35 +493,26 @@ function MenuBarSection({
     setBusy(false);
   };
   return (
-    <section className="settings-section" style={{ "--row-index": 4 } as React.CSSProperties}>
+    <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
       <h2>
-        <MenuBarIcon />
-        Menu bar
+        <PreferencesIcon />
+        Preferences
       </h2>
-      {/* The check says shown, the way it says connected on a provider's line,
-          and the button offers only the state the row is not already in. */}
       <div className="settings-row">
         <span className="settings-copy">
-          <span className="settings-name">
-            <strong>Show Luke in the menu bar</strong>
-            {shown ? <CheckIcon /> : null}
-          </span>
-          <small>
-            {shown
-              ? "Luke's face at the right end of the bar, with Settings and Quit under it."
-              : "Hidden. Settings and Quit stay right here in the panel."}
-          </small>
+          <strong>Show Luke in the menu bar</strong>
         </span>
-        <span className="settings-actions">
-          <button
-            type="button"
-            className="quiet-button"
-            disabled={busy}
-            onClick={() => void toggle()}
-          >
-            {shown ? "Hide" : "Show"}
-          </button>
-        </span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={shown}
+          aria-label="Show Luke in the menu bar"
+          className="switch"
+          disabled={busy}
+          onClick={() => void toggle()}
+        >
+          <span className="switch-thumb" />
+        </button>
       </div>
       {rejection ? <p className="error-message">{rejection}</p> : null}
     </section>
@@ -548,10 +541,14 @@ export function SettingsPanel({
       id={panelPanelId(PANEL_TAB.SETTINGS)}
       aria-labelledby={panelTabId(PANEL_TAB.SETTINGS)}
     >
-      {/* First, because it is how Luke is reached rather than what he can see.
-          Shown rather than offered: the key is fixed for now, and a control
-          that cannot change anything is worse than a plain statement of it. */}
-      <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
+      {settings ? (
+        <PreferencesSection shown={settings.showInMenuBar} onChange={onShowInMenuBarChange} />
+      ) : null}
+
+      {/* How Luke is reached rather than what he can see. Shown rather than
+          offered: the key is fixed for now, and a control that cannot change
+          anything is worse than a plain statement of it. */}
+      <section className="settings-section" style={{ "--row-index": 2 } as React.CSSProperties}>
         <h2>
           <KeyboardIcon />
           Keyboard shortcuts
@@ -576,7 +573,7 @@ export function SettingsPanel({
         <CredentialsSection settings={settings} control={credentials} panelOpen={panelOpen} />
       ) : null}
 
-      <section className="settings-section" style={{ "--row-index": 3 } as React.CSSProperties}>
+      <section className="settings-section" style={{ "--row-index": 4 } as React.CSSProperties}>
         <h2>
           <ShieldIcon />
           Permissions
@@ -618,10 +615,6 @@ export function SettingsPanel({
         </div>
         {microphoneError ? <p className="error-message">{microphoneError}</p> : null}
       </section>
-
-      {settings ? (
-        <MenuBarSection shown={settings.showInMenuBar} onChange={onShowInMenuBarChange} />
-      ) : null}
 
       <button
         type="button"

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -26,6 +26,7 @@ import {
   ExternalIcon,
   KeyboardIcon,
   KeyIcon,
+  MenuBarIcon,
   PencilIcon,
   PowerIcon,
   ShieldIcon,
@@ -50,6 +51,11 @@ export interface SettingsPanelProps {
    * and an entry can outlast the panel it was started in.
    */
   panelOpen: boolean;
+  /**
+   * Shows or hides the menu bar status item. The store answers with why when it
+   * refuses, and the row is where that answer belongs.
+   */
+  onShowInMenuBarChange: (show: boolean) => Promise<string | undefined>;
   onQuit: () => void;
   /** The talk key, shown so it can be learned. It is not editable yet. */
   voiceHotkey?: string;
@@ -463,6 +469,63 @@ function CredentialsSection({
   );
 }
 
+/**
+ * Whether Luke stands in the menu bar as well as at the notch. One line and one
+ * control, because nothing rides on the answer: Settings and Quit live in this
+ * panel, so the status item is a second door rather than the only one.
+ */
+function MenuBarSection({
+  shown,
+  onChange,
+}: {
+  shown: boolean;
+  onChange: (show: boolean) => Promise<string | undefined>;
+}): React.JSX.Element {
+  // The change is a round trip through the settings file, so the control rests
+  // until the store has answered rather than claiming a state it may not get.
+  const [busy, setBusy] = useState(false);
+  const [rejection, setRejection] = useState<string>();
+  const toggle = async () => {
+    setBusy(true);
+    setRejection(await onChange(!shown));
+    setBusy(false);
+  };
+  return (
+    <section className="settings-section" style={{ "--row-index": 4 } as React.CSSProperties}>
+      <h2>
+        <MenuBarIcon />
+        Menu bar
+      </h2>
+      {/* The check says shown, the way it says connected on a provider's line,
+          and the button offers only the state the row is not already in. */}
+      <div className="settings-row">
+        <span className="settings-copy">
+          <span className="settings-name">
+            <strong>Show Luke in the menu bar</strong>
+            {shown ? <CheckIcon /> : null}
+          </span>
+          <small>
+            {shown
+              ? "Luke's face at the right end of the bar, with Settings and Quit under it."
+              : "Hidden. Settings and Quit stay right here in the panel."}
+          </small>
+        </span>
+        <span className="settings-actions">
+          <button
+            type="button"
+            className="quiet-button"
+            disabled={busy}
+            onClick={() => void toggle()}
+          >
+            {shown ? "Hide" : "Show"}
+          </button>
+        </span>
+      </div>
+      {rejection ? <p className="error-message">{rejection}</p> : null}
+    </section>
+  );
+}
+
 export function SettingsPanel({
   microphoneStatus,
   microphoneError,
@@ -472,6 +535,7 @@ export function SettingsPanel({
   settings,
   credentials,
   panelOpen,
+  onShowInMenuBarChange,
   onQuit,
   voiceHotkey,
   voiceHotkeyHeld,
@@ -555,10 +619,14 @@ export function SettingsPanel({
         {microphoneError ? <p className="error-message">{microphoneError}</p> : null}
       </section>
 
+      {settings ? (
+        <MenuBarSection shown={settings.showInMenuBar} onChange={onShowInMenuBarChange} />
+      ) : null}
+
       <button
         type="button"
         className="quit-button"
-        style={{ "--row-index": 4 } as React.CSSProperties}
+        style={{ "--row-index": 5 } as React.CSSProperties}
         onClick={onQuit}
       >
         <PowerIcon />

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1339,6 +1339,41 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   margin: 0;
 }
 
+/* The one switch in the panel. On is the palette connected and complete
+   already use, so an item that is drawn reads the same way a provider that is
+   reachable does. Only the thumb moves, only by transform, and on
+   `--spring-fast` — the bounce every small element in the app rides. */
+.switch {
+  display: inline-flex;
+  width: 34px;
+  flex: 0 0 auto;
+  align-items: center;
+  padding: 2px;
+  border-radius: 999px;
+  background: var(--raised-strong);
+  transition: background-color var(--duration-hover) ease;
+}
+
+.switch[aria-checked="true"] {
+  background: color-mix(in srgb, var(--state-complete) 62%, transparent);
+}
+
+.switch:disabled {
+  opacity: 0.4;
+}
+
+.switch-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--text-primary);
+  transition: transform var(--duration-fast) var(--spring-fast);
+}
+
+.switch[aria-checked="true"] .switch-thumb {
+  transform: translateX(14px);
+}
+
 /* One provider per line: mark, name, whether it is connected, and what you can
    do about that. Providers are separated by a rule rather than by nested cards,
    so the section stays one object however many keys it holds. */

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -25,6 +25,7 @@ const SETTINGS_FILE_MODE = 0o600;
 const SETTINGS_FIELD = {
   API_KEYS: "apiKeys",
   LEGACY_CONDUCTOR_API_KEY: "conductorApiKey",
+  SHOW_IN_MENU_BAR: "showInMenuBar",
   VERSION: "version",
 } as const;
 
@@ -65,6 +66,12 @@ interface PersistedSettings {
    * through untouched so an older build cannot discard a newer one's key.
    */
   apiKeys: Readonly<Record<string, string>>;
+  /**
+   * Whether the menu bar status item is drawn. A file that has never said —
+   * written before the choice existed, or hand-edited into nonsense — means the
+   * item is shown, because until the user hides it that is what Luke does.
+   */
+  showInMenuBar: boolean;
 }
 
 interface ResolvedApiKey {
@@ -137,9 +144,11 @@ function parsePersistedSettings(source: string): PersistedSettings {
   }
   const record = parsed as Record<string, unknown>;
   const version = record[SETTINGS_FIELD.VERSION];
+  const showInMenuBar = record[SETTINGS_FIELD.SHOW_IN_MENU_BAR];
   return {
     version: typeof version === "number" ? version : SETTINGS_FILE_VERSION,
     apiKeys: storedApiKeys(record),
+    showInMenuBar: typeof showInMenuBar === "boolean" ? showInMenuBar : true,
   };
 }
 
@@ -180,6 +189,7 @@ export class SettingsStore {
       // its own: a snapshot is taken on every launch, and most of them are for
       // a user with no key to protect.
       secretStorage: this.#secretStorage,
+      showInMenuBar: (await this.#load()).showInMenuBar,
     };
   }
 
@@ -233,6 +243,26 @@ export class SettingsStore {
       await this.#write(next);
       this.#loading = Promise.resolve(next);
       this.#resolved.delete(providerId);
+    });
+    return { settings: await this.snapshot() };
+  }
+
+  /**
+   * Remembers whether the menu bar status item is drawn. A preference is not a
+   * credential, so nothing here touches the cipher: storing this choice must
+   * never be the reason the Keychain dialog appears.
+   */
+  async setShowInMenuBar(show: boolean): Promise<SettingsUpdateResult> {
+    await this.#serialize(async () => {
+      const persisted = await this.#load();
+      if (persisted.showInMenuBar === show) return;
+      const next: PersistedSettings = {
+        ...persisted,
+        version: SETTINGS_FILE_VERSION,
+        showInMenuBar: show,
+      };
+      await this.#write(next);
+      this.#loading = Promise.resolve(next);
     });
     return { settings: await this.snapshot() };
   }
@@ -322,7 +352,11 @@ export class SettingsStore {
       if (!canIgnoreFilesystemError(error)) throw error;
     }
 
-    let persisted: PersistedSettings = { version: SETTINGS_FILE_VERSION, apiKeys: {} };
+    let persisted: PersistedSettings = {
+      version: SETTINGS_FILE_VERSION,
+      apiKeys: {},
+      showInMenuBar: true,
+    };
     if (source) {
       try {
         persisted = parsePersistedSettings(source);

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -194,6 +194,15 @@ export class SettingsStore {
   }
 
   /**
+   * Deliberately shallower than `snapshot()`: the answer comes from the
+   * settings file alone, so a caller deciding whether to draw the status item
+   * never waits on — or wakes — the OS keychain behind the stored keys.
+   */
+  async showInMenuBar(): Promise<boolean> {
+    return (await this.#load()).showInMenuBar;
+  }
+
+  /**
    * Main-process only: the resolved key used to authenticate that provider's
    * reads. A provider with no key resolves to nothing, so its adapter observes
    * nothing and issues no request.

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -49,6 +49,12 @@ export interface AppSettings {
    * plaintext storage; while it is unknown the app says nothing about it.
    */
   secretStorage: SecretStorage;
+  /**
+   * Whether Luke stands in the menu bar as well as at the notch. Hiding the
+   * status item costs nothing it alone provides — Settings and Quit are both in
+   * the panel — so the choice is the user's to make and to keep.
+   */
+  showInMenuBar: boolean;
 }
 
 /** A rejected update reports why without echoing the submitted value. */
@@ -133,6 +139,8 @@ export interface AppBridge {
    * fixed by this build.
    */
   openProviderApiKeys(providerId: CredentialProviderId): void;
+  /** Shows or hides the menu bar status item, and remembers the choice. */
+  setShowInMenuBar(show: boolean): Promise<SettingsUpdateResult>;
   /**
    * Opens an observed session where its provider keeps it. The renderer names
    * the session rather than its address, for the same reason it names a
@@ -169,6 +177,7 @@ export const channels = {
   openMicrophoneSettings: "app:open-microphone-settings",
   setProviderApiKey: "app:set-provider-api-key",
   openProviderApiKeys: "app:open-provider-api-keys",
+  setShowInMenuBar: "app:set-show-in-menu-bar",
   openSession: "app:open-session",
   focusPanel: "app:focus-panel",
   requestRealtimeCredential: "app:request-realtime-credential",

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -522,6 +522,26 @@ test("keeps stored keys when the menu bar preference changes beside them", async
   assert.equal((await store.snapshot()).showInMenuBar, false);
 });
 
+test("decides the menu bar item from the file alone, never the keychain", async (t) => {
+  // The status item is drawn at launch from this answer, so a locked or slow
+  // Keychain — which decrypting a stored key can wait on — must not be able to
+  // delay it.
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({
+      version: 2,
+      apiKeys: { [CONDUCTOR]: sealed(TEST_API_KEY) },
+      showInMenuBar: false,
+    }),
+  );
+  const cipher = countingCipher();
+  const store = storeIn(directory, { cipher });
+
+  assert.equal(await store.showInMenuBar(), false);
+  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
+});
+
 test("shows the menu bar item when the file says something a boolean is not", async (t) => {
   const directory = await temporaryDirectory(t);
   await fs.writeFile(

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -249,12 +249,13 @@ test("keeps both keys when two providers are saved at once", async (t) => {
   assert.equal(await store.readApiKey(SECOND_CLOUD), "second-cloud-key");
   assert.deepEqual(JSON.parse(await readSettingsFile(directory)), {
     version: 2,
-    // Written even when false, so the file states what it is rather than
-    // leaving it to be inferred from an absence.
     apiKeys: {
       [FIRST_CLOUD]: sealed("first-cloud-key"),
       [SECOND_CLOUD]: sealed("second-cloud-key"),
     },
+    // Written even at its default, so the file states what it is rather than
+    // leaving it to be inferred from an absence.
+    showInMenuBar: true,
   });
   const reopened = storeIn(directory, { providers: TEST_PROVIDERS });
   assert.equal(await reopened.readApiKey(FIRST_CLOUD), "first-cloud-key");
@@ -450,6 +451,7 @@ test("keeps a Conductor key stored by an earlier version working", async (t) => 
   assert.deepEqual(persisted, {
     version: 2,
     apiKeys: { [CONDUCTOR]: sealed("conductor-replacement-key") },
+    showInMenuBar: true,
   });
   assert.equal(await storeIn(directory).readApiKey(CONDUCTOR), "conductor-replacement-key");
 });
@@ -468,7 +470,66 @@ test("carries a key belonging to a provider this build does not know", async (t)
   assert.deepEqual(persisted, {
     version: 2,
     apiKeys: { "later-cloud": sealed("later-cloud-key"), [CONDUCTOR]: sealed(TEST_API_KEY) },
+    showInMenuBar: true,
   });
+});
+
+test("shows the menu bar item until asked otherwise, and remembers the answer", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+
+  assert.equal((await store.snapshot()).showInMenuBar, true);
+
+  const { settings, reason } = await store.setShowInMenuBar(false);
+
+  assert.equal(reason, undefined);
+  assert.equal(settings.showInMenuBar, false);
+  assert.deepEqual(JSON.parse(await readSettingsFile(directory)), {
+    version: 2,
+    apiKeys: {},
+    showInMenuBar: false,
+  });
+  // The choice outlives the run that heard it.
+  assert.equal((await storeIn(directory).snapshot()).showInMenuBar, false);
+});
+
+test("changes the menu bar preference without touching the cipher", async (t) => {
+  // A preference is not a credential, so storing one must never be the reason
+  // the Keychain dialog appears.
+  const directory = await temporaryDirectory(t);
+  const cipher = countingCipher();
+  const store = storeIn(directory, { cipher });
+
+  const { settings } = await store.setShowInMenuBar(false);
+
+  assert.equal(settings.showInMenuBar, false);
+  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
+  assert.equal(settings.secretStorage, SECRET_STORAGE.UNKNOWN);
+});
+
+test("keeps stored keys when the menu bar preference changes beside them", async (t) => {
+  // The preference and a key share the settings file, so a save of one racing a
+  // save of the other must drop neither.
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory, { providers: TEST_PROVIDERS });
+
+  await Promise.all([
+    store.setApiKey(FIRST_CLOUD, "first-cloud-key"),
+    store.setShowInMenuBar(false),
+  ]);
+
+  assert.equal(await store.readApiKey(FIRST_CLOUD), "first-cloud-key");
+  assert.equal((await store.snapshot()).showInMenuBar, false);
+});
+
+test("shows the menu bar item when the file says something a boolean is not", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({ version: 2, apiKeys: {}, showInMenuBar: "sometimes" }),
+  );
+
+  assert.equal((await storeIn(directory).snapshot()).showInMenuBar, true);
 });
 
 test("recovers from a corrupt settings file", async (t) => {


### PR DESCRIPTION
## What

Adds a user setting for whether Luke shows its status item in the macOS menu bar, surfaced as a **Preferences** section at the top of the settings panel — a single row with a switch (the panel's first; track and thumb use the existing palette, and the thumb moves by `transform` on `--spring-fast` per the panel-motion rules).

- `AppSettings` gains `showInMenuBar` (default `true`), persisted in `settings.json` beside the API keys through the same serialized write queue, so a preference save racing a key save drops neither.
- A new `app:set-show-in-menu-bar` IPC channel applies the change immediately — the tray is created or destroyed on the spot — and the stored answer decides whether the tray is created at launch.
- Changing the preference never touches the cipher, so it can never be the reason the Keychain dialog appears.
- Hiding the item loses no capability: Settings and Quit remain in the panel.
- A file without the field (any existing install) or with a non-boolean value reads as shown.

## Tests

- `./scripts/check.sh` passes (lint, typecheck, 345 tests, build).
- New `settings-store` cases: default + persistence across store instances, on-disk shape, no cipher calls, concurrency with a key save, and tolerance of a malformed value.
- UI change: visual evidence comes from the macOS CI job; no physical-notch check was performed (developed in a cloud sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31755679477/artifacts/9202644913) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31755679477)

- Commit: `7515d7b0bc7bbf42980fe23d27d73b4f4143f8fc`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
