### PR TITLE
feat(settings): let the spoken voice be chosen in Preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,10 @@ Accessibility or Input Monitoring grant. Where that helper cannot run, the key
 falls back to a press-to-start, press-to-send toggle and Settings says so.
 
 Settings lists the microphone under **Permissions**, with a green check once
-access is granted and a link to System Settings beside it.
+access is granted and a link to System Settings beside it. The voice Luke
+speaks with is chosen under **Preferences**; a change reaches the next
+conversation to connect, and one already open keeps the voice it answered
+with.
 
 macOS asks once, the first time Luke needs the microphone, and keeps your
 answer. No app can raise that prompt again, and only you can withdraw the
@@ -201,7 +204,7 @@ control.
 | `LUKE_ATTENTION_MODEL` | `gpt-5.6-luna` | Selects the review model |
 | `OPENAI_BASE_URL` | `https://api.openai.com/v1` | Selects the Responses-compatible endpoint |
 | `LUKE_REALTIME_MODEL` | `gpt-realtime-2.1` | Selects the conversation model |
-| `LUKE_REALTIME_VOICE` | `cedar` | Selects the spoken voice |
+| `LUKE_REALTIME_VOICE` | `cedar` | Selects the spoken voice until one is chosen in Settings · Preferences |
 
 Changing `OPENAI_BASE_URL` sends attention-review data to that endpoint instead
 of OpenAI. It does not redirect the conversation, which always uses OpenAI's own

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -895,8 +895,9 @@ if (!app.requestSingleInstanceLock()) {
     );
     // Awaited, so the chosen voice reaches the minter before the renderer
     // exists to ask for a credential: the first conversation must already
-    // speak with it.
-    const storedVoice = await settingsStore.readVoice();
+    // speak with it. A file that cannot be read means no choice was kept — it
+    // must not keep the panel, the hotkey, or observation from starting.
+    const storedVoice = await settingsStore.readVoice().catch(() => undefined);
     if (storedVoice) realtimeCredentials?.setVoice(storedVoice);
     reportVoiceAvailability();
     // The report is not made here: the helper answers over its own stdout a

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -6,6 +6,7 @@ import {
   CompositeSessionProviderAdapter,
   fixtureSnapshot,
   InMemorySessionRegistry,
+  isRealtimeVoice,
   type NativeNotchGeometry,
   positionNotchWindow,
   realtimeMintExplanation,
@@ -551,6 +552,29 @@ function registerIpc(): void {
     },
   );
 
+  // The voice is a preference rather than a credential, but it travels the
+  // same road: the renderer names a value from a set fixed by this build and
+  // hears back the settings as they now stand.
+  ipcMain.handle(
+    channels.setVoice,
+    async (event, voice: unknown): Promise<SettingsUpdateResult> => {
+      if (!trustedSender(event)) throw new Error("Untrusted renderer");
+      if (!isRealtimeVoice(voice)) throw new Error("Unknown voice");
+      try {
+        const result = await settingsStore.setVoice(voice);
+        // The next credential is minted for the new voice; a conversation
+        // already open keeps the one it answered with.
+        if (!result.reason) realtimeCredentials?.setVoice(voice);
+        return result;
+      } catch {
+        return {
+          settings: await settingsStore.snapshot(),
+          reason: "Could not save that voice on this system.",
+        };
+      }
+    },
+  );
+
   // Where to get a key is a question the panel cannot answer itself, so it
   // hands the question to the browser. The renderer names a provider rather
   // than an address: the pages Luke can open are the ones in the provider
@@ -851,7 +875,7 @@ if (!app.requestSingleInstanceLock()) {
     positionPanel();
     if (panelWindow && !panelWindow.isDestroyed()) panelWindow.showInactive();
   });
-  void app.whenReady().then(() => {
+  void app.whenReady().then(async () => {
     if (process.platform === "darwin") app.setActivationPolicy("accessory");
     Menu.setApplicationMenu(null);
     refreshNativeGeometry();
@@ -869,6 +893,11 @@ if (!app.requestSingleInstanceLock()) {
       (show) => applyMenuBarVisibility(show),
       () => applyMenuBarVisibility(true),
     );
+    // Awaited, so the chosen voice reaches the minter before the renderer
+    // exists to ask for a credential: the first conversation must already
+    // speak with it.
+    const storedVoice = await settingsStore.readVoice();
+    if (storedVoice) realtimeCredentials?.setVoice(storedVoice);
     reportVoiceAvailability();
     // The report is not made here: the helper answers over its own stdout a
     // moment later, and a line printed now would state an absence that only

--- a/apps/desktop/src/openai-realtime-credentials.ts
+++ b/apps/desktop/src/openai-realtime-credentials.ts
@@ -11,7 +11,7 @@ import {
   realtimeCredentialIsUsable,
 } from "@sidecar/core";
 
-const OPENAI_ENVIRONMENT = {
+export const OPENAI_ENVIRONMENT = {
   API_KEY: "OPENAI_API_KEY",
   MODEL: "LUKE_REALTIME_MODEL",
   VOICE: "LUKE_REALTIME_VOICE",
@@ -74,7 +74,9 @@ function withoutTrailingSlash(value: string): string {
 export class OpenAiRealtimeCredentialMinter {
   readonly #apiKey: string;
   readonly #model: string;
-  readonly #voice: string;
+  /** The voice from construction, which a cleared setting falls back to. */
+  readonly #configuredVoice: string;
+  #voice: string;
   readonly #baseUrl: string;
   readonly #fetch: FetchLike;
   readonly #now: () => number;
@@ -90,7 +92,8 @@ export class OpenAiRealtimeCredentialMinter {
     if (!apiKey) throw new Error("OpenAI API key must not be empty");
     this.#apiKey = apiKey;
     this.#model = trimmedText(options.model) ?? REALTIME_DEFAULTS.MODEL;
-    this.#voice = trimmedText(options.voice) ?? REALTIME_DEFAULTS.VOICE;
+    this.#configuredVoice = trimmedText(options.voice) ?? REALTIME_DEFAULTS.VOICE;
+    this.#voice = this.#configuredVoice;
     this.#baseUrl = withoutTrailingSlash(trimmedText(options.baseUrl) ?? OPENAI_DEFAULTS.BASE_URL);
     this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
     this.#now = options.now ?? Date.now;
@@ -106,6 +109,19 @@ export class OpenAiRealtimeCredentialMinter {
 
   get model(): string {
     return this.#model;
+  }
+
+  /**
+   * Changes the voice new credentials are minted for. The outstanding
+   * credential was minted against the old voice, so it is discarded rather
+   * than served speaking the wrong one; a call already open keeps the voice it
+   * answered with, because a credential already handed out cannot be recalled.
+   */
+  setVoice(voice: string | undefined): void {
+    const next = trimmedText(voice) ?? this.#configuredVoice;
+    if (next === this.#voice) return;
+    this.#voice = next;
+    this.#credential = undefined;
   }
 
   /** Returns a usable credential, reusing the outstanding one until it nears expiry. */

--- a/apps/desktop/src/openai-realtime-credentials.ts
+++ b/apps/desktop/src/openai-realtime-credentials.ts
@@ -1,4 +1,5 @@
 import {
+  isRealtimeVoice,
   REALTIME_CALLS_PATH,
   REALTIME_CLIENT_SECRETS_PATH,
   REALTIME_DEFAULTS,
@@ -6,6 +7,7 @@ import {
   type RealtimeConnection,
   type RealtimeDiagnostics,
   type RealtimeMintOutcome,
+  type RealtimeVoice,
   realtimeClientSecretRequest,
   realtimeCredentialFromResponse,
   realtimeCredentialIsUsable,
@@ -60,6 +62,18 @@ function trimmedText(value: string | undefined): string | undefined {
 
 function withoutTrailingSlash(value: string): string {
   return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+/**
+ * The launch environment's voice, honoured only when it is one Luke offers.
+ * The one gate for every reader — the minter, its diagnostics, and the
+ * settings snapshot — so what the panel marks is always what would be minted.
+ */
+export function environmentRealtimeVoice(
+  environment: NodeJS.ProcessEnv = process.env,
+): RealtimeVoice | undefined {
+  const value = environment[OPENAI_ENVIRONMENT.VOICE]?.trim();
+  return isRealtimeVoice(value) ? value : undefined;
 }
 
 /**
@@ -244,7 +258,7 @@ export function unavailableRealtimeDiagnostics(fixtureMode: boolean): RealtimeDi
     apiKeyConfigured,
     fixtureMode,
     model: trimmedText(process.env[OPENAI_ENVIRONMENT.MODEL]) ?? REALTIME_DEFAULTS.MODEL,
-    voice: trimmedText(process.env[OPENAI_ENVIRONMENT.VOICE]) ?? REALTIME_DEFAULTS.VOICE,
+    voice: environmentRealtimeVoice() ?? REALTIME_DEFAULTS.VOICE,
     endpoint: `${OPENAI_DEFAULTS.BASE_URL}${REALTIME_CLIENT_SECRETS_PATH}`,
     lastOutcome: fixtureMode
       ? REALTIME_MINT_OUTCOME.DISABLED_BY_FIXTURE
@@ -259,7 +273,7 @@ export function openAiRealtimeCredentialsFromEnvironment(
   if (!apiKey) return undefined;
 
   const model = trimmedText(options.model) ?? trimmedText(process.env[OPENAI_ENVIRONMENT.MODEL]);
-  const voice = trimmedText(options.voice) ?? trimmedText(process.env[OPENAI_ENVIRONMENT.VOICE]);
+  const voice = trimmedText(options.voice) ?? environmentRealtimeVoice();
 
   return new OpenAiRealtimeCredentialMinter({
     ...options,

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -2,6 +2,7 @@ import type {
   AttentionSpeech,
   NormalizedSession,
   RealtimeConnection,
+  RealtimeVoice,
   SessionIdentity,
 } from "@sidecar/core";
 import { contextBridge, ipcRenderer } from "electron";
@@ -33,6 +34,8 @@ const bridge: AppBridge = {
       providerId,
       apiKey,
     ) as Promise<SettingsUpdateResult>,
+  setVoice: (voice: RealtimeVoice) =>
+    ipcRenderer.invoke(channels.setVoice, voice) as Promise<SettingsUpdateResult>,
   openProviderApiKeys: (providerId: CredentialProviderId) => {
     ipcRenderer.send(channels.openProviderApiKeys, providerId);
   },

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -3,6 +3,7 @@ import {
   type NormalizedSession,
   REALTIME_STATUS,
   type RealtimeStatus,
+  type RealtimeVoice,
 } from "@sidecar/core";
 import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
 import type {
@@ -638,6 +639,12 @@ export function App(): React.JSX.Element {
     remove: removeProviderApiKey,
   };
 
+  // The row marks the voice the main process reports rather than the one just
+  // pressed, so what is shown as chosen is always what was actually saved.
+  const changeVoice = useCallback((voice: RealtimeVoice) => {
+    void window.sidecar.setVoice(voice).then((result) => setSettings(result.settings));
+  }, []);
+
   /**
    * Sends a session to its provider and gets out of the way. Luke floats above
    * every window, so a panel left open would be sitting on top of the very chat
@@ -975,6 +982,7 @@ export function App(): React.JSX.Element {
               voiceAvailable: bootstrap.realtimeAvailable,
               settings,
               credentials,
+              onVoiceChange: changeVoice,
               panelOpen,
               ...(shownHotkey.hotkey ? { voiceHotkey: shownHotkey.hotkey } : {}),
               voiceHotkeyHeld: shownHotkey.held,

--- a/apps/desktop/src/renderer/settings-icons.tsx
+++ b/apps/desktop/src/renderer/settings-icons.tsx
@@ -70,6 +70,16 @@ export function TrashIcon(): React.JSX.Element {
   );
 }
 
+/** The up-and-down pair macOS badges a pop-up button with. */
+export function PopUpIcon(): React.JSX.Element {
+  return (
+    <Glyph className="voice-select-glyph">
+      <path d="M7.2 9.6 12 4.8l4.8 4.8" />
+      <path d="M7.2 14.4 12 19.2l4.8-4.8" />
+    </Glyph>
+  );
+}
+
 export function KeyboardIcon(): React.JSX.Element {
   return (
     <Glyph>

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -1,3 +1,9 @@
+import {
+  isRealtimeVoice,
+  REALTIME_DEFAULTS,
+  REALTIME_VOICE_LIST,
+  type RealtimeVoice,
+} from "@sidecar/core";
 import { useEffect, useRef, useState } from "react";
 import type { AppSettings, CredentialSource, MicrophoneStatus } from "../shared/contracts";
 import { CREDENTIAL_SOURCE, SECRET_STORAGE } from "../shared/contracts";
@@ -27,6 +33,7 @@ import {
   KeyboardIcon,
   KeyIcon,
   PencilIcon,
+  PopUpIcon,
   PowerIcon,
   PreferencesIcon,
   ShieldIcon,
@@ -45,6 +52,8 @@ export interface SettingsPanelProps {
   settings?: AppSettings;
   /** The one credential being entered anywhere, and everything that can be done to it. */
   credentials: CredentialEntryControl;
+  /** Chooses the voice Luke speaks with, from the set fixed by this build. */
+  onVoiceChange: (voice: RealtimeVoice) => void;
   /**
    * True while the panel is the shape on screen. A field can only hold the
    * caret then: everything here sits in an inert stage the rest of the time,
@@ -425,6 +434,14 @@ function ProviderCredential({
   );
 }
 
+/* The API names its voices in lowercase; on a control they read as names. The
+   default carries its status into the menu, so returning to it never needs the
+   README or a memory of what shipped. */
+function voiceOptionLabel(voice: RealtimeVoice): string {
+  const name = voice.charAt(0).toUpperCase() + voice.slice(1);
+  return voice === REALTIME_DEFAULTS.VOICE ? `${name} (default)` : name;
+}
+
 /**
  * Every provider that can hold a key, one line each. A provider is listed
  * whether or not it has one, because the list is how you learn which services
@@ -471,17 +488,25 @@ function CredentialsSection({
 
 /**
  * The user's own choices about Luke, ahead of the sections about what Luke can
- * reach. One so far: whether the status item stands in the menu bar as well as
- * at the notch. A switch and nothing else, because nothing rides on the answer
- * — Settings and Quit live in this panel, so the item is a second door rather
- * than the only one.
+ * reach. The voice he speaks with comes first — it is what Luke *is* to the
+ * ear — offered the way macOS offers one value from a small fixed set: a
+ * pop-up button whose closed face is drawn here and whose open menu is the
+ * system's, which also lets it escape a window sized to the panel rather than
+ * being clipped by it. Below it, whether the status item stands in the menu
+ * bar as well as at the notch: a switch and nothing else, because nothing
+ * rides on the answer — Settings and Quit live in this panel, so the item is a
+ * second door rather than the only one.
  */
 function PreferencesSection({
+  voice,
+  onVoiceChange,
   shown,
-  onChange,
+  onShowInMenuBarChange,
 }: {
+  voice: RealtimeVoice;
+  onVoiceChange: (voice: RealtimeVoice) => void;
   shown: boolean;
-  onChange: (show: boolean) => Promise<string | undefined>;
+  onShowInMenuBarChange: (show: boolean) => Promise<string | undefined>;
 }): React.JSX.Element {
   // The change is a round trip through the settings file, so the switch rests
   // until the store has answered rather than claiming a state it may not get.
@@ -489,7 +514,7 @@ function PreferencesSection({
   const [rejection, setRejection] = useState<string>();
   const toggle = async () => {
     setBusy(true);
-    setRejection(await onChange(!shown));
+    setRejection(await onShowInMenuBarChange(!shown));
     setBusy(false);
   };
   return (
@@ -498,6 +523,43 @@ function PreferencesSection({
         <PreferencesIcon />
         Preferences
       </h2>
+      <div className="settings-row">
+        <span className="settings-copy">
+          <strong>Voice</strong>
+          {/* When it lands, because a control that seems not to act invites a
+              second press: the change rides the next conversation, and one
+              already open keeps the voice it answered with. */}
+          <small>How Luke sounds, from the next conversation on.</small>
+        </span>
+        <span className="voice-select">
+          <select
+            aria-label="Voice"
+            value={voice}
+            onChange={(event) => {
+              // The set is fixed by this build, so anything else arriving out
+              // of a select is a broken control rather than a choice.
+              const next = event.target.value;
+              if (isRealtimeVoice(next)) onVoiceChange(next);
+            }}
+            onFocus={() => {
+              // The panel can be showing without its window being key, and a
+              // menu opened then would drop its first choice.
+              window.sidecar.focusPanel();
+            }}
+          >
+            {REALTIME_VOICE_LIST.map((candidate) => (
+              <option key={candidate} value={candidate}>
+                {voiceOptionLabel(candidate)}
+              </option>
+            ))}
+          </select>
+          {/* Drawn over the select, the way macOS badges a pop-up button; the
+              select alone answers the pointer. */}
+          <span className="voice-select-badge" aria-hidden="true">
+            <PopUpIcon />
+          </span>
+        </span>
+      </div>
       <div className="settings-row">
         <span className="settings-copy">
           <strong>Show Luke in the menu bar</strong>
@@ -527,6 +589,7 @@ export function SettingsPanel({
   voiceAvailable,
   settings,
   credentials,
+  onVoiceChange,
   panelOpen,
   onShowInMenuBarChange,
   onQuit,
@@ -542,7 +605,12 @@ export function SettingsPanel({
       aria-labelledby={panelTabId(PANEL_TAB.SETTINGS)}
     >
       {settings ? (
-        <PreferencesSection shown={settings.showInMenuBar} onChange={onShowInMenuBarChange} />
+        <PreferencesSection
+          voice={settings.voice}
+          onVoiceChange={onVoiceChange}
+          shown={settings.showInMenuBar}
+          onShowInMenuBarChange={onShowInMenuBarChange}
+        />
       ) : null}
 
       {/* How Luke is reached rather than what he can see. Shown rather than

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1380,6 +1380,63 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   transform: translateX(14px);
 }
 
+/* The voice, offered as macOS offers one value from a small fixed set: a
+   pop-up button — the current value on the face, the up-and-down badge on the
+   trailing edge. The `select` underneath is what opens the system's own menu;
+   only the closed control is drawn here, and only its colors move. */
+.voice-select {
+  position: relative;
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+}
+
+.voice-select select {
+  appearance: none;
+  padding: 6px 27px 6px 11px;
+  border: 1px solid var(--hairline);
+  border-radius: 7px;
+  background: var(--raised);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 620;
+  transition:
+    background-color var(--duration-hover) ease,
+    border-color var(--duration-hover) ease;
+}
+
+.voice-select select:hover {
+  background: var(--raised-strong);
+}
+
+/* The ring the input draws, because this is the same kind of landing place. */
+.voice-select select:focus-visible {
+  border-color: color-mix(in srgb, var(--state-working) 45%, transparent);
+  outline: none;
+}
+
+/* The badge answers no pointer — the select under it is the whole control. */
+.voice-select-badge {
+  position: absolute;
+  right: 5px;
+  display: flex;
+  width: 16px;
+  height: 16px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--state-working) 24%, transparent);
+  color: var(--state-working);
+  pointer-events: none;
+}
+
+.voice-select-glyph {
+  width: 10px;
+  height: 10px;
+}
+
 /* One provider per line: mark, name, whether it is connected, and what you can
    do about that. Providers are separated by a rule rather than by nested cards,
    so the section stays one object however many keys it holds. */

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -1,5 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isRealtimeVoice, REALTIME_DEFAULTS, type RealtimeVoice } from "@sidecar/core";
+import { OPENAI_ENVIRONMENT } from "./openai-realtime-credentials";
 import {
   type AppSettings,
   CREDENTIAL_SOURCE,
@@ -27,6 +29,7 @@ const SETTINGS_FIELD = {
   LEGACY_CONDUCTOR_API_KEY: "conductorApiKey",
   SHOW_IN_MENU_BAR: "showInMenuBar",
   VERSION: "version",
+  VOICE: "voice",
 } as const;
 
 const API_KEY_LENGTH = {
@@ -72,6 +75,11 @@ interface PersistedSettings {
    * item is shown, because until the user hides it that is what Luke does.
    */
   showInMenuBar: boolean;
+  /**
+   * The voice the user chose, absent until one has been. A preference rather
+   * than a credential, so it is stored plainly and never touches the cipher.
+   */
+  voice?: RealtimeVoice;
 }
 
 interface ResolvedApiKey {
@@ -120,6 +128,12 @@ function environmentApiKey(
   return undefined;
 }
 
+/** The launch environment's voice, honoured only when it is one Luke offers. */
+function environmentVoice(environment: NodeJS.ProcessEnv): RealtimeVoice | undefined {
+  const value = environment[OPENAI_ENVIRONMENT.VOICE]?.trim();
+  return isRealtimeVoice(value) ? value : undefined;
+}
+
 function storedApiKeys(record: Record<string, unknown>): Record<string, string> {
   const apiKeys: Record<string, string> = {};
   const persisted = record[SETTINGS_FIELD.API_KEYS];
@@ -145,10 +159,15 @@ function parsePersistedSettings(source: string): PersistedSettings {
   const record = parsed as Record<string, unknown>;
   const version = record[SETTINGS_FIELD.VERSION];
   const showInMenuBar = record[SETTINGS_FIELD.SHOW_IN_MENU_BAR];
+  const voice = record[SETTINGS_FIELD.VOICE];
   return {
     version: typeof version === "number" ? version : SETTINGS_FILE_VERSION,
     apiKeys: storedApiKeys(record),
     showInMenuBar: typeof showInMenuBar === "boolean" ? showInMenuBar : true,
+    // A voice this build does not offer is dropped rather than carried: unlike
+    // a credential it has a default to fall back to, and honouring an unknown
+    // one would mint sessions the API refuses.
+    ...(isRealtimeVoice(voice) ? { voice } : {}),
   };
 }
 
@@ -190,6 +209,12 @@ export class SettingsStore {
       // a user with no key to protect.
       secretStorage: this.#secretStorage,
       showInMenuBar: (await this.#load()).showInMenuBar,
+      // Resolved the way the minter resolves it, so the panel marks the voice
+      // that would actually be heard.
+      voice:
+        (await this.#load()).voice ??
+        environmentVoice(this.#environment) ??
+        REALTIME_DEFAULTS.VOICE,
     };
   }
 
@@ -200,6 +225,32 @@ export class SettingsStore {
    */
   async showInMenuBar(): Promise<boolean> {
     return (await this.#load()).showInMenuBar;
+  }
+
+  /**
+   * Main-process only, like the resolved keys: the voice the user chose, for
+   * the minter at startup. Nothing chosen resolves to nothing — the minter
+   * already carries the environment's voice and the default.
+   */
+  async readVoice(): Promise<RealtimeVoice | undefined> {
+    return (await this.#load()).voice;
+  }
+
+  /** Stores the chosen voice, or returns to the default when omitted. */
+  async setVoice(voice: RealtimeVoice | undefined): Promise<SettingsUpdateResult> {
+    await this.#serialize(async () => {
+      const persisted = await this.#load();
+      if (persisted.voice === voice) return;
+      const next: PersistedSettings = {
+        ...persisted,
+        version: SETTINGS_FILE_VERSION,
+      };
+      if (voice) next.voice = voice;
+      else delete next.voice;
+      await this.#write(next);
+      this.#loading = Promise.resolve(next);
+    });
+    return { settings: await this.snapshot() };
   }
 
   /**

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { isRealtimeVoice, REALTIME_DEFAULTS, type RealtimeVoice } from "@sidecar/core";
-import { OPENAI_ENVIRONMENT } from "./openai-realtime-credentials";
+import { environmentRealtimeVoice } from "./openai-realtime-credentials";
 import {
   type AppSettings,
   CREDENTIAL_SOURCE,
@@ -128,12 +128,6 @@ function environmentApiKey(
   return undefined;
 }
 
-/** The launch environment's voice, honoured only when it is one Luke offers. */
-function environmentVoice(environment: NodeJS.ProcessEnv): RealtimeVoice | undefined {
-  const value = environment[OPENAI_ENVIRONMENT.VOICE]?.trim();
-  return isRealtimeVoice(value) ? value : undefined;
-}
-
 function storedApiKeys(record: Record<string, unknown>): Record<string, string> {
   const apiKeys: Record<string, string> = {};
   const persisted = record[SETTINGS_FIELD.API_KEYS];
@@ -213,7 +207,7 @@ export class SettingsStore {
       // that would actually be heard.
       voice:
         (await this.#load()).voice ??
-        environmentVoice(this.#environment) ??
+        environmentRealtimeVoice(this.#environment) ??
         REALTIME_DEFAULTS.VOICE,
     };
   }

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -3,6 +3,7 @@ import type {
   FixtureSnapshot,
   NormalizedSession,
   RealtimeConnection,
+  RealtimeVoice,
   Rectangle,
   ResolvedNotchGeometry,
   SessionIdentity,
@@ -55,6 +56,12 @@ export interface AppSettings {
    * the panel — so the choice is the user's to make and to keep.
    */
   showInMenuBar: boolean;
+  /**
+   * The voice Luke speaks with, as the settings resolve it: the one the user
+   * chose, else the launch environment's, else the default — so the panel
+   * marks the voice that would actually be heard, not just a stored value.
+   */
+  voice: RealtimeVoice;
 }
 
 /** A rejected update reports why without echoing the submitted value. */
@@ -134,6 +141,12 @@ export interface AppBridge {
     apiKey: string | undefined,
   ): Promise<SettingsUpdateResult>;
   /**
+   * Chooses the voice Luke speaks with, from the set fixed by this build. It
+   * reaches the next conversation to connect; one already open keeps the
+   * voice it answered with.
+   */
+  setVoice(voice: RealtimeVoice): Promise<SettingsUpdateResult>;
+  /**
    * Opens a provider's own API-key page in the default browser. The renderer
    * names the provider, not the address, so the set of pages Luke can open is
    * fixed by this build.
@@ -176,6 +189,7 @@ export const channels = {
   requestMicrophone: "app:request-microphone",
   openMicrophoneSettings: "app:open-microphone-settings",
   setProviderApiKey: "app:set-provider-api-key",
+  setVoice: "app:set-voice",
   openProviderApiKeys: "app:open-provider-api-keys",
   setShowInMenuBar: "app:set-show-in-menu-bar",
   openSession: "app:open-session",

--- a/apps/desktop/tests/openai-realtime-credentials.test.ts
+++ b/apps/desktop/tests/openai-realtime-credentials.test.ts
@@ -185,13 +185,42 @@ test("the model and voice come from the environment when set", () => {
   try {
     process.env.OPENAI_API_KEY = API_KEY;
     process.env.LUKE_REALTIME_MODEL = "gpt-realtime-preview";
-    process.env.LUKE_REALTIME_VOICE = "cedar";
+    process.env.LUKE_REALTIME_VOICE = REALTIME_VOICE.MARIN;
 
     assert.equal(openAiRealtimeCredentialsFromEnvironment()?.model, "gpt-realtime-preview");
+    assert.equal(
+      openAiRealtimeCredentialsFromEnvironment()?.diagnostics().voice,
+      REALTIME_VOICE.MARIN,
+    );
   } finally {
     for (const [name, value] of [
       ["OPENAI_API_KEY", previous.key],
       ["LUKE_REALTIME_MODEL", previous.model],
+      ["LUKE_REALTIME_VOICE", previous.voice],
+    ] as const) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
+});
+
+test("a voice from the environment that Luke does not offer is not minted", () => {
+  // The settings snapshot already refuses it, so honouring it here would have
+  // the panel mark the default while every session was minted for a name the
+  // API refuses.
+  const previous = { key: process.env.OPENAI_API_KEY, voice: process.env.LUKE_REALTIME_VOICE };
+  try {
+    process.env.OPENAI_API_KEY = API_KEY;
+    process.env.LUKE_REALTIME_VOICE = "baritone";
+
+    assert.equal(
+      openAiRealtimeCredentialsFromEnvironment()?.diagnostics().voice,
+      REALTIME_DEFAULTS.VOICE,
+    );
+    assert.equal(unavailableRealtimeDiagnostics(true).voice, REALTIME_DEFAULTS.VOICE);
+  } finally {
+    for (const [name, value] of [
+      ["OPENAI_API_KEY", previous.key],
       ["LUKE_REALTIME_VOICE", previous.voice],
     ] as const) {
       if (value === undefined) delete process.env[name];

--- a/apps/desktop/tests/openai-realtime-credentials.test.ts
+++ b/apps/desktop/tests/openai-realtime-credentials.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { REALTIME_DEFAULTS, REALTIME_MINT_OUTCOME } from "@sidecar/core";
+import { REALTIME_DEFAULTS, REALTIME_MINT_OUTCOME, REALTIME_VOICE } from "@sidecar/core";
 import {
   OpenAiRealtimeCredentialMinter,
   openAiRealtimeCredentialsFromEnvironment,
@@ -97,6 +97,42 @@ test("an outstanding credential is reused until it nears expiry", async () => {
   now = EXPIRES_AT_SECONDS * 1000 - 1_000;
   await instance.mint();
   assert.equal(requests.length, 2);
+});
+
+test("changing the voice discards the outstanding credential and mints for the new one", async () => {
+  const { minter: instance, requests } = minter([mintResponse(), mintResponse()]);
+  await instance.mint();
+
+  instance.setVoice(REALTIME_VOICE.MARIN);
+  await instance.mint();
+
+  // The first credential was minted against the old voice, so serving it after
+  // the change would answer the next conversation with the wrong one.
+  assert.equal(requests.length, 2);
+  const body = JSON.parse(String(requests[1]?.init.body)) as {
+    session: { audio: { output: { voice: string } } };
+  };
+  assert.equal(body.session.audio.output.voice, REALTIME_VOICE.MARIN);
+  assert.equal(instance.diagnostics().voice, REALTIME_VOICE.MARIN);
+});
+
+test("the same voice again keeps the outstanding credential", async () => {
+  const { minter: instance, requests } = minter([mintResponse(), mintResponse()]);
+  await instance.mint();
+
+  instance.setVoice(REALTIME_DEFAULTS.VOICE);
+  await instance.mint();
+
+  assert.equal(requests.length, 1);
+});
+
+test("clearing the voice returns to the one the minter was built with", () => {
+  const { minter: instance } = minter([mintResponse()]);
+
+  instance.setVoice(REALTIME_VOICE.MARIN);
+  instance.setVoice(undefined);
+
+  assert.equal(instance.diagnostics().voice, REALTIME_DEFAULTS.VOICE);
 });
 
 test("every failure path leaves the voice experience unavailable", async () => {

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test, { type TestContext } from "node:test";
+import { REALTIME_DEFAULTS, REALTIME_VOICE } from "@sidecar/core";
 import { type SecretCipher, SettingsStore } from "../src/settings-store";
 import { CREDENTIAL_SOURCE, SECRET_STORAGE } from "../src/shared/contracts";
 import {
@@ -550,6 +551,72 @@ test("shows the menu bar item when the file says something a boolean is not", as
   );
 
   assert.equal((await storeIn(directory).snapshot()).showInMenuBar, true);
+});
+
+test("reports the default voice until one is chosen", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+
+  assert.equal((await store.snapshot()).voice, REALTIME_DEFAULTS.VOICE);
+  assert.equal(await store.readVoice(), undefined);
+});
+
+test("stores the chosen voice plainly and reads it back from a new store instance", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const cipher = countingCipher();
+  const store = storeIn(directory, { cipher });
+
+  const { settings, reason } = await store.setVoice(REALTIME_VOICE.MARIN);
+
+  assert.equal(reason, undefined);
+  assert.equal(settings.voice, REALTIME_VOICE.MARIN);
+  // A preference is not a credential, so choosing one never reaches the
+  // Keychain — and never raises its permission dialog.
+  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
+  assert.equal(await storeIn(directory).readVoice(), REALTIME_VOICE.MARIN);
+});
+
+test("prefers the chosen voice over the environment, and the environment over the default", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory, {
+    environment: { LUKE_REALTIME_VOICE: REALTIME_VOICE.SAGE },
+  });
+
+  assert.equal((await store.snapshot()).voice, REALTIME_VOICE.SAGE);
+  // The environment names the voice only until the user does, so it is
+  // reported in the snapshot but never as something the user stored.
+  assert.equal(await store.readVoice(), undefined);
+
+  await store.setVoice(REALTIME_VOICE.MARIN);
+  assert.equal((await store.snapshot()).voice, REALTIME_VOICE.MARIN);
+
+  await store.setVoice(undefined);
+  assert.equal((await store.snapshot()).voice, REALTIME_VOICE.SAGE);
+});
+
+test("ignores a stored or environment voice this build does not offer", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({ version: 2, apiKeys: {}, voice: "baritone" }),
+  );
+  const store = storeIn(directory, { environment: { LUKE_REALTIME_VOICE: "baritone" } });
+
+  assert.equal(await store.readVoice(), undefined);
+  assert.equal((await store.snapshot()).voice, REALTIME_DEFAULTS.VOICE);
+});
+
+test("the voice and a stored key survive each other's writes", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+
+  await store.setApiKey(CONDUCTOR, TEST_API_KEY);
+  await store.setVoice(REALTIME_VOICE.MARIN);
+  await store.setApiKey(CONDUCTOR, "conductor-replacement-key");
+
+  const reopened = storeIn(directory);
+  assert.equal(await reopened.readApiKey(CONDUCTOR), "conductor-replacement-key");
+  assert.equal(await reopened.readVoice(), REALTIME_VOICE.MARIN);
 });
 
 test("recovers from a corrupt settings file", async (t) => {

--- a/packages/sidecar-core/src/realtime.ts
+++ b/packages/sidecar-core/src/realtime.ts
@@ -10,9 +10,37 @@ import {
   type SessionIdentity,
 } from "./session";
 
+/**
+ * Every voice the Realtime API can speak with. The set is the API's, not
+ * Luke's: a voice outside it is refused at mint time, so offering one would be
+ * a control that cannot work.
+ */
+export const REALTIME_VOICE = {
+  ALLOY: "alloy",
+  ASH: "ash",
+  BALLAD: "ballad",
+  CEDAR: "cedar",
+  CORAL: "coral",
+  ECHO: "echo",
+  MARIN: "marin",
+  SAGE: "sage",
+  SHIMMER: "shimmer",
+  VERSE: "verse",
+} as const;
+
+export type RealtimeVoice = (typeof REALTIME_VOICE)[keyof typeof REALTIME_VOICE];
+
+/** Settings offers the voices in this order. */
+export const REALTIME_VOICE_LIST: readonly RealtimeVoice[] = Object.values(REALTIME_VOICE);
+
+/** Guards a voice arriving from storage or IPC. */
+export function isRealtimeVoice(value: unknown): value is RealtimeVoice {
+  return typeof value === "string" && REALTIME_VOICE_LIST.includes(value as RealtimeVoice);
+}
+
 export const REALTIME_DEFAULTS = {
   MODEL: "gpt-realtime-2.1",
-  VOICE: "cedar",
+  VOICE: REALTIME_VOICE.CEDAR,
 } as const;
 
 /** The Realtime session shape and the endpoints that mint and open a call. */

--- a/packages/sidecar-core/tests/realtime.test.ts
+++ b/packages/sidecar-core/tests/realtime.test.ts
@@ -8,6 +8,7 @@ import {
   attentionSpeechFromReviews,
   cancelResponseEvents,
   clearInputAudioEvents,
+  isRealtimeVoice,
   maximumVoiceContextSessions,
   normalizeSession,
   proactiveSpeechEvents,
@@ -15,6 +16,7 @@ import {
   REALTIME_CLIENT_EVENT,
   REALTIME_DEFAULTS,
   REALTIME_SESSION_TYPE,
+  REALTIME_VOICE_LIST,
   realtimeClientSecretRequest,
   realtimeCredentialFromResponse,
   realtimeCredentialIsUsable,
@@ -114,6 +116,17 @@ test("a mint response without a session model falls back to the requested model"
 test("a male voice is what the session is minted with", () => {
   assert.equal(REALTIME_DEFAULTS.VOICE, "cedar");
   assert.equal(realtimeSessionConfig().audio.output.voice, "cedar");
+});
+
+test("the default voice is one the settings can offer", () => {
+  assert.equal(isRealtimeVoice(REALTIME_DEFAULTS.VOICE), true);
+});
+
+test("every offered voice is recognized and anything else is refused", () => {
+  for (const voice of REALTIME_VOICE_LIST) assert.equal(isRealtimeVoice(voice), true);
+  for (const value of ["baritone", "", "  cedar  ", undefined, null, 3]) {
+    assert.equal(isRealtimeVoice(value), false);
+  }
 });
 
 test("nothing asks the API for a transcript it will not show", () => {


### PR DESCRIPTION
## Summary

Adds a **Voice** row to the Preferences group in the settings panel — above the menu bar switch that group already holds — offering the ten Realtime voices as an Apple-style pop-up button, with the default named in the menu ("Cedar (default)").

- The control is a native `<select>` drawn as a macOS pop-up button: current value on the face, up-and-down badge on the trailing edge. The open menu is the system's, so it renders dark (`color-scheme: dark` is global) and escapes the panel-sized window rather than being clipped by it.
- The choice is stored plainly in `settings.json` beside the API keys — a preference, not a credential, so it never touches the cipher or wakes the Keychain.
- Resolution order everywhere: chosen voice, else a valid `LUKE_REALTIME_VOICE`, else the default — and the panel marks the voice that would actually be heard.
- On save, the minter discards its outstanding credential so the next conversation connects speaking the chosen voice; a call already open keeps the voice it answered with. At startup the stored voice reaches the minter before the renderer exists to ask for a credential.
- `REALTIME_VOICE` is an `as const` value set in `@sidecar/core` with an `isRealtimeVoice` guard applied at the IPC boundary, at parse time (an unknown stored voice is dropped, not honoured), and to the environment variable.

## Testing

- `./scripts/check.sh` passes: 32 web + 62 sidecar-core + 371 desktop tests, 0 failures.
- New coverage: the value set and guard; store round-trips, precedence (stored > env > default), unknown-voice rejection, cipher-untouched writes, and voice/key writes surviving each other; minter cache invalidation on voice change and fallback on clear.
- `./scripts/verify.sh` (macOS visual evidence) was not run — this change was authored in a Linux cloud workspace. No physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/f418cd82-de4b-4306-9f80-f4a9d30d32c1)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31756877674/artifacts/9203069695) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31756877674)

- Commit: `797252189d46ad69724acce3b91e2d961f4d65ca`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
