### PR TITLE
feat(voice): caption Luke's speech on screen as it streams

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -105,7 +105,10 @@ summary — so a spoken question about your sessions can be answered. No
 transcript, file content, or command output is ever included.
 
 Luke does not record the conversation, write audio to disk, or keep a
-transcript. Audio is not retained by Luke in any form.
+transcript. With captions enabled in Settings — they are off by default — the
+reply's text is drawn on screen while Luke speaks; it is discarded when the
+reply ends and is never written to disk. Audio is not retained by Luke in any
+form.
 
 The standing API key stays in Luke's main process. The renderer receives only a
 short-lived client secret minted for one call, which expires on its own.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,10 @@ Luke's face is the interface: it plays its listening motion while you speak and
 its talking motion while it answers, so the capsule says whose turn it is. Colour
 says the same thing again — the face and the meter beside it are green while you
 have the turn and blue while Luke has it — so a glance is enough even with the
-peek closed. There is no transcript.
+peek closed. Turn on captions under **Preferences** in Settings — they are off
+by default — and Luke's words wrap along the bottom of whatever shape is up as he
+says them — capsule, peek, or panel — and leave when the reply does. Nothing is
+kept: the caption is the reply being said, not a record of it.
 
 ## Privacy
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -583,6 +583,26 @@ function registerIpc(): void {
       }
     },
   );
+  // A plain preference, validated to a boolean the way every renderer value
+  // is validated at this boundary. The reply reports what was actually
+  // stored, so the switch redraws from the settings rather than the press.
+  ipcMain.handle(
+    channels.setVoiceCaptions,
+    async (event, enabled: unknown): Promise<SettingsUpdateResult> => {
+      if (!trustedSender(event)) throw new Error("Untrusted renderer");
+      if (typeof enabled !== "boolean") throw new Error("Invalid caption request");
+      try {
+        return await settingsStore.setVoiceCaptions(enabled);
+      } catch {
+        // A filesystem failure is not something the user can act on, so it is
+        // reported as one line rather than as a raw system error.
+        return {
+          settings: await settingsStore.snapshot(),
+          reason: "Could not save that setting on this system.",
+        };
+      }
+    },
+  );
 
   // Where to get a key is a question the panel cannot answer itself, so it
   // hands the question to the browser. The renderer names a provider rather

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -44,6 +44,8 @@ const bridge: AppBridge = {
   },
   setShowInMenuBar: (show: boolean) =>
     ipcRenderer.invoke(channels.setShowInMenuBar, show) as Promise<SettingsUpdateResult>,
+  setVoiceCaptions: (enabled: boolean) =>
+    ipcRenderer.invoke(channels.setVoiceCaptions, enabled) as Promise<SettingsUpdateResult>,
   openSession: (identity: SessionIdentity) =>
     ipcRenderer.invoke(channels.openSession, identity) as Promise<SessionOpenResult>,
   sendSessionMessage: (identity: SessionIdentity, text: string) =>

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -5,6 +5,7 @@ import {
   type RealtimeStatus,
   type RealtimeVoice,
   type SessionIdentity,
+  VOICE_CAPTION_MAX_HEIGHT,
 } from "@sidecar/core";
 import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
@@ -58,6 +59,37 @@ import { WAVEFORM_VOICE } from "./waveform";
  * into the second one.
  */
 const REMOTE_QUIET_MS = 2_500;
+
+/**
+ * What the speaking evidence run captions the reply with. A capture run never
+ * opens a call, so there are no words to draw unless the fixture supplies
+ * them — and it must, or the caption strip ships unphotographed. Synthetic,
+ * like every fixture, and long enough to wrap: a one-line fixture would leave
+ * the wrapped form of the strip unphotographed too.
+ */
+const FIXTURE_SPEAKING_CAPTION =
+  "Claude Code finished checkout-service, and Codex is still migrating the payments schema. Two sessions are waiting on you.";
+
+/**
+ * The caption block's vertical padding — 5px above the text and 9px keeping
+ * it clear of the shape's bottom edge. Mirrors `.voice-caption`'s padding in
+ * the stylesheet: the measured text plus this is what the surface grows by.
+ */
+const CAPTION_PADDING = 14;
+
+/**
+ * Sizes the caption block to the words it currently holds. The text wraps, so
+ * only a measurement can say how tall it is; the size drives the surface's
+ * growth and the clip that reveals the text, and past the reserved maximum
+ * the remainder becomes scroll, rolling the oldest lines up under the shape.
+ */
+function captionSizeStyle(textHeight: number | undefined): CSSProperties {
+  if (!textHeight) return {};
+  return {
+    "--caption-size": `${Math.min(VOICE_CAPTION_MAX_HEIGHT, textHeight + CAPTION_PADDING)}px`,
+    "--caption-scroll": `${Math.max(0, textHeight - (VOICE_CAPTION_MAX_HEIGHT - CAPTION_PADDING))}px`,
+  } as CSSProperties;
+}
 
 function usePointerPassthrough(
   onHitRegionEnter: () => void,
@@ -196,10 +228,12 @@ export function App(): React.JSX.Element {
   const [, setClock] = useState(0);
   const [panelElement, panelHeight] = useShapeHeight();
   const [slotElement, slotHeight] = useShapeHeight();
+  const [captionTextElement, captionTextHeight] = useShapeHeight();
   const [voiceStatus, setVoiceStatus] = useState<RealtimeStatus>(REALTIME_STATUS.IDLE);
   const [voiceHotkey, setVoiceHotkey] = useState<VoiceHotkeyState>();
   const [localStream, setLocalStream] = useState<MediaStream>();
   const [remoteStream, setRemoteStream] = useState<MediaStream>();
+  const [voiceCaption, setVoiceCaption] = useState<string>();
   const audioContext = useRef<AudioContext | undefined>(undefined);
   const hoverTimer = useRef<number | undefined>(undefined);
   const presentationRef = useRef<PanelPresentation>(PANEL_PRESENTATION.CAPSULE);
@@ -307,6 +341,7 @@ export function App(): React.JSX.Element {
       onLocalStream: setLocalStream,
       onRemoteStream: setRemoteStream,
       onError: setMicrophoneError,
+      onCaption: setVoiceCaption,
     });
     return voiceSession.current;
   }, []);
@@ -373,6 +408,17 @@ export function App(): React.JSX.Element {
    */
   const requestMicrophoneAccess = useCallback(async () => {
     setMicrophoneStatus(await window.sidecar.requestMicrophone());
+  }, []);
+
+  /**
+   * The switch redraws from what was actually stored rather than from the
+   * press, the same way the menu bar's does: the reply is the settings
+   * snapshot either way, and a refusal comes back as the row's own line.
+   */
+  const changeVoiceCaptions = useCallback(async (enabled: boolean) => {
+    const result = await window.sidecar.setVoiceCaptions(enabled);
+    setSettings(result.settings);
+    return result.reason;
   }, []);
 
   /**
@@ -998,6 +1044,16 @@ export function App(): React.JSX.Element {
   const shownHotkey = voiceHotkeyToShow(bootstrap, voiceHotkey);
   const fixtureSpeaking = bootstrap.profile === "speaking";
   const hasAudioSignal = fixtureSpeaking || analyser !== undefined;
+  // Luke's words, drawn only when captions are on and the reply they belong
+  // to is his turn: the preference is off by default, the session already
+  // clears the words when a reply ends or is cut off, and the turn gate keeps
+  // a caption that raced a status change from being drawn late. A capture run
+  // draws the fixture's words regardless, or the strip ships unphotographed.
+  const lukeCaption = fixtureSpeaking
+    ? FIXTURE_SPEAKING_CAPTION
+    : settings?.voiceCaptions === true && voiceTurn === WAVEFORM_VOICE.LUKE
+      ? voiceCaption
+      : undefined;
   const panelOpen = presentation === PANEL_PRESENTATION.PANEL;
   const slotOpen = presentation === PANEL_PRESENTATION.SLOT;
   // What the slot's field is for depends on what answers for that provider now,
@@ -1011,10 +1067,17 @@ export function App(): React.JSX.Element {
       // Whose turn it is, so the capsule can make room for a meter it has to
       // draw beside the face rather than in place of it.
       data-voice={voiceTurn}
+      // Whether there are words to draw under the shape, so the surface can
+      // grow the room they are drawn in.
+      data-caption={String(Boolean(lukeCaption))}
       data-presentation={presentation}
       data-notch={String(display.notch.hasNotch)}
       data-capture={String(bootstrap.captureMode)}
-      style={{ ...notchStyle(display), ...shapeHeightStyle(panelHeight, slotHeight) }}
+      style={{
+        ...notchStyle(display),
+        ...shapeHeightStyle(panelHeight, slotHeight),
+        ...captionSizeStyle(captionTextHeight),
+      }}
     >
       {/* Capsule, peek, slot and panel are all this one shape at different
           sizes, so the surface is never cross-faded — it is only ever resized. */}
@@ -1044,6 +1107,7 @@ export function App(): React.JSX.Element {
               onOpenMicrophoneSettings: () => window.sidecar.openMicrophoneSettings(),
               voiceAvailable: bootstrap.realtimeAvailable,
               settings,
+              onVoiceCaptionsChange: changeVoiceCaptions,
               credentials,
               onVoiceChange: changeVoice,
               panelOpen,
@@ -1075,6 +1139,21 @@ export function App(): React.JSX.Element {
         presentation={presentation}
         housingWidth={display.notch.housingWidth}
       />
+
+      {/* Luke's words while he says them: one element in every state, under
+          the housing while the shape is compact and carried to the panel's
+          foot when it opens, so the words travel with the morph instead of
+          jumping between two copies. Not in a wing — the wings clip at the
+          capsule's height — and always mounted, like the count's caption, so
+          both edges of its fade can run. The inner text is what is measured:
+          its wrapped height is the only honest answer to how much room the
+          words need. Hidden from readers: it duplicates what is already
+          audible. */}
+      <span className="voice-caption" aria-hidden="true">
+        <span className="voice-caption-text" ref={captionTextElement}>
+          {lukeCaption}
+        </span>
+      </span>
 
       <div className="compact-stage">
         {/* A button, not a hover target: hovering only peeks, pressing commits.

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -48,6 +48,13 @@ export interface RealtimeVoiceSessionCallbacks {
   onLocalStream(stream: MediaStream | undefined): void;
   onRemoteStream(stream: MediaStream | undefined): void;
   onError(message: string | undefined): void;
+  /**
+   * The text of the reply Luke is currently speaking, growing as it is
+   * generated, or undefined once there is nothing being spoken. The session
+   * owns the whole lifecycle — the caption clears when the reply ends, is cut
+   * off, or the call closes — so the caller only ever draws what it is handed.
+   */
+  onCaption(text: string | undefined): void;
 }
 
 export interface RealtimeVoiceSessionOptions extends RealtimeVoiceSessionCallbacks {
@@ -154,6 +161,13 @@ export class RealtimeVoiceSession {
    */
   #responseItemId: string | undefined;
   #audibleSince: number | undefined;
+  /**
+   * The words of the reply being spoken, as far as they have arrived. Kept
+   * here rather than in the caller so every path that ends a reply — finishing,
+   * being talked over, the call dropping — clears the words with it, and a
+   * caption can never outlive the speech it captions.
+   */
+  #caption: string | undefined;
   /**
    * Whether this call has ever reported a reply's audio running out. Once it
    * has, silence stops being evidence of anything: the server says when Luke is
@@ -459,10 +473,18 @@ export class RealtimeVoiceSession {
       // made. A disabled track drops what is buffered rather than playing it
       // out, so the cut-off is immediate rather than eventual.
       this.#silenceLuke();
+      // The caption is cut with the audio. It already held words the room
+      // never heard — the text runs ahead of the speech — and leaving them up
+      // would show Luke finishing a sentence he was just stopped from saying.
+      this.#setCaption(undefined);
       this.#send(cancelResponseEvents());
       // Then correct what Luke believes he said, or the next answer is free to
       // refer back to a sentence that never reached the room.
       this.#send(this.#truncateEvents());
+      // The trim was this reply's last word: forgetting its item here is what
+      // stops the transcript still trailing in — the server had produced it
+      // before the cancel landed — from ever matching the caption again.
+      this.#responseItemId = undefined;
       this.#generationDone = false;
       this.#remoteQuiet = false;
       this.#clearSettleTimer();
@@ -557,6 +579,7 @@ export class RealtimeVoiceSession {
     this.#pendingTurn = false;
     this.#responseItemId = undefined;
     this.#audibleSince = undefined;
+    this.#setCaption(undefined);
     // Learned about this call, so it does not outlive it.
     this.#audioEndingsReported = false;
     this.#clearSettleTimer();
@@ -580,6 +603,7 @@ export class RealtimeVoiceSession {
     // follow-up still awaiting from the last turn will see this and stand down.
     this.#toolTurnArmed = toolsArmed;
     this.#turnEpoch += 1;
+    this.#setCaption(undefined);
     this.#clearSettleTimer();
     this.#send(events);
     this.#setStatus(REALTIME_STATUS.RESPONDING);
@@ -647,9 +671,19 @@ export class RealtimeVoiceSession {
     this.#settleTimer = undefined;
   }
 
+  #setCaption(text: string | undefined): void {
+    if (this.#caption === text) return;
+    this.#caption = text;
+    this.#options.onCaption(text);
+  }
+
   /** Ends the turn once the reply is done, so the next one can start. */
   #finishResponse(): void {
     this.#generationDone = false;
+    // The caption is of speech, and the speech is over. Whatever ended the
+    // reply — the audio draining, an error, the settle timer — the words leave
+    // with the meter and the face rather than lingering under a quiet capsule.
+    this.#setCaption(undefined);
     // Whatever ended the reply — an error, the settle timer, Luke simply
     // stopping — the next one has to be audible. Without this a reply that
     // failed before it started would leave Luke silenced with nothing to
@@ -695,6 +729,28 @@ export class RealtimeVoiceSession {
       // The reply being asked for is under way, so anything arriving from here
       // belongs to it rather than to the one it replaced.
       this.#unsilenceLuke();
+    }
+    if (type === REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA) {
+      const { delta, item_id } = event as { delta?: unknown; item_id?: unknown };
+      // Only the reply being spoken may write the caption. A cancelled reply's
+      // transcript keeps arriving after the interrupt that cleared it — the
+      // server had already produced it — and without this check a late piece
+      // would draw the words Luke was just stopped from saying, or splice them
+      // onto the next reply's.
+      if (item_id === this.#responseItemId && typeof delta === "string" && delta) {
+        this.#setCaption((this.#caption ?? "") + delta);
+      }
+    }
+    if (type === REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DONE) {
+      // The server's own rendering of the whole reply, which the deltas only
+      // approximate: a delta lost to the channel would otherwise leave a hole
+      // in the sentence for as long as it stayed up. Held to the same item as
+      // the deltas, because the cancelled reply's `done` is the likeliest
+      // straggler of all.
+      const { transcript, item_id } = event as { transcript?: unknown; item_id?: unknown };
+      if (item_id === this.#responseItemId && typeof transcript === "string" && transcript) {
+        this.#setCaption(transcript);
+      }
     }
     if (type === REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED) {
       this.#audioEndingsReported = true;

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -50,6 +50,11 @@ export interface SettingsPanelProps {
   /** Whether there is anything to talk to, which is the microphone's only use. */
   voiceAvailable: boolean;
   settings?: AppSettings;
+  /**
+   * Turns the on-screen caption of Luke's speech on or off. The store answers
+   * with why when it refuses, and the row is where that answer belongs.
+   */
+  onVoiceCaptionsChange: (enabled: boolean) => Promise<string | undefined>;
   /** The one credential being entered anywhere, and everything that can be done to it. */
   credentials: CredentialEntryControl;
   /** Chooses the voice Luke speaks with, from the set fixed by this build. */
@@ -500,11 +505,15 @@ function CredentialsSection({
 function PreferencesSection({
   voice,
   onVoiceChange,
+  captions,
+  onVoiceCaptionsChange,
   shown,
   onShowInMenuBarChange,
 }: {
   voice: RealtimeVoice;
   onVoiceChange: (voice: RealtimeVoice) => void;
+  captions: boolean;
+  onVoiceCaptionsChange: (enabled: boolean) => Promise<string | undefined>;
   shown: boolean;
   onShowInMenuBarChange: (show: boolean) => Promise<string | undefined>;
 }): React.JSX.Element {
@@ -516,6 +525,15 @@ function PreferencesSection({
     setBusy(true);
     setRejection(await onShowInMenuBarChange(!shown));
     setBusy(false);
+  };
+  // Its own rest, because it is its own round trip: one save in flight must
+  // not still the other switch. The rejection line is shared — it reports the
+  // last answer, whichever row asked.
+  const [captionsBusy, setCaptionsBusy] = useState(false);
+  const toggleCaptions = async () => {
+    setCaptionsBusy(true);
+    setRejection(await onVoiceCaptionsChange(!captions));
+    setCaptionsBusy(false);
   };
   return (
     <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
@@ -562,6 +580,26 @@ function PreferencesSection({
       </div>
       <div className="settings-row">
         <span className="settings-copy">
+          <strong>Captions</strong>
+          {/* Off by default: the voice experience ships as sound, so the words
+              are chosen rather than discovered. What is *not* kept is the one
+              thing worth a line — the caption is the reply being said. */}
+          <small>Luke&rsquo;s words on screen as he speaks. Nothing is kept.</small>
+        </span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={captions}
+          aria-label="Caption Luke's speech on screen"
+          className="switch"
+          disabled={captionsBusy}
+          onClick={() => void toggleCaptions()}
+        >
+          <span className="switch-thumb" />
+        </button>
+      </div>
+      <div className="settings-row">
+        <span className="settings-copy">
           <strong>Show Luke in the menu bar</strong>
         </span>
         <button
@@ -588,6 +626,7 @@ export function SettingsPanel({
   onOpenMicrophoneSettings,
   voiceAvailable,
   settings,
+  onVoiceCaptionsChange,
   credentials,
   onVoiceChange,
   panelOpen,
@@ -608,6 +647,8 @@ export function SettingsPanel({
         <PreferencesSection
           voice={settings.voice}
           onVoiceChange={onVoiceChange}
+          captions={settings.voiceCaptions}
+          onVoiceCaptionsChange={onVoiceCaptionsChange}
           shown={settings.showInMenuBar}
           onShowInMenuBarChange={onShowInMenuBarChange}
         />

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -219,6 +219,16 @@
   /* Growing one side moves the shape's centre half the growth away from it, so
      the right edge stays exactly where it was and only the left one travels. */
   --capsule-voice-shift: calc(var(--capsule-voice-growth) / 2);
+  /* Luke's words under the housing, wrapping to at most four lines as they
+     stream in. Mirrors VOICE_CAPTION_MAX_HEIGHT in
+     packages/sidecar-core/src/geometry.ts: the compact window already holds
+     this much room below the capsule, so growing into it costs no IPC.
+     `--caption-size` is the block's height right now — measured off the
+     wrapped text by the renderer, padding included, never past the max. */
+  --caption-max: 70px;
+  /* How much of that room the shape is currently using: the caption states
+     below raise it, and every other state leaves the capsule's own height. */
+  --caption-growth: 0px;
   /* Wide enough for a key, a way out, and a way on, and no wider — the page the
      key was copied from is behind this and has to stay readable. The floor is
      what those three need on a display with no housing to grow from. */
@@ -317,7 +327,7 @@ button:disabled {
   top: 0;
   left: 50%;
   width: var(--capsule-width);
-  height: var(--capsule-height);
+  height: calc(var(--capsule-height) + var(--caption-growth));
   /* The spring undershoots on the way back, and the capsule is the floor: a
      shape that dips inside the housing's footprint opens a gap where there is
      a physical camera, not a screen. Clamping the used size lets the spring
@@ -394,6 +404,10 @@ button:disabled {
   transition-delay: 0s, 0s, 0s;
 }
 
+/* The capsule joins the list only once the caption has grown it past the
+   housing: a shape that has left the housing's footprint needs the depth, and
+   one still inside it must stay indistinguishable from the hardware. */
+.app-stage[data-presentation="capsule"][data-caption="true"] .panel-surface,
 .app-stage[data-presentation="peek"] .panel-surface,
 .app-stage[data-presentation="slot"] .panel-surface,
 .app-stage[data-presentation="panel"] .panel-surface {
@@ -450,6 +464,55 @@ button:disabled {
   transition-duration: var(--duration-quick), var(--duration-shape);
   transition-timing-function: var(--motion-exit), var(--spring);
   transition-delay: calc(var(--duration-shape) - var(--duration-quick));
+}
+
+/* Luke's words follow him onto the shape: the compact states grow a caption
+   block below the housing while there are words to draw. Gated on the words
+   rather than on the turn, because the first of them arrives a beat after the
+   reply starts and a shape grown around nothing reads as a twitch. */
+.app-stage[data-presentation="capsule"][data-caption="true"],
+.app-stage[data-presentation="peek"][data-caption="true"] {
+  --caption-growth: var(--caption-size, 28px);
+}
+
+/* While there are words, the capsule holds the peek's width whatever the
+   pointer is doing. The caption wraps at one width in every state, so no
+   change of shape ever re-flows a line mid-morph — hovering a captioned
+   capsule unfolds the wings and moves the words not at all. Written after the
+   voice rules above so the wider shape wins their tie, and centred again: the
+   asymmetric growth was room for the meter, which the peek's width dwarfs.
+   Growing leads, exactly as the voice growth does — the base rule's delay is
+   for leaving — and stated against the caption rather than inherited from the
+   voice rule, because the speaking fixture draws words without a live turn. */
+.app-stage[data-presentation="capsule"][data-caption="true"] .panel-surface {
+  width: var(--peek-width);
+  transform: translate(-50%, var(--shape-top, 0px));
+  transition-duration: var(--duration-shape);
+  transition-delay: 0s;
+}
+
+.app-stage[data-presentation="capsule"][data-caption="true"] .compact-hover-target {
+  width: var(--peek-width);
+  transform: translateX(-50%);
+}
+
+/* The press target covers the caption block as well as the strip: the words
+   are drawn on the shape, and a shape the pointer is over must keep taking
+   the pointer. Without this the block belongs to the stage around the strip,
+   which carries no hit region, so resting on the words read as leaving the
+   shape — collapsing the peek under the cursor. Like every hover-target rule
+   it snaps rather than animating, and the pill's variant carries the lift the
+   way the pill's own height does, so the target ends where the shape ends. */
+.app-stage[data-presentation="capsule"][data-caption="true"] .compact-hover-target,
+.app-stage[data-presentation="peek"][data-caption="true"] .compact-hover-target {
+  height: calc(var(--capsule-height) + var(--caption-growth));
+}
+
+.app-stage[data-notch="false"][data-presentation="capsule"][data-caption="true"]
+  .compact-hover-target,
+.app-stage[data-notch="false"][data-presentation="peek"][data-caption="true"]
+  .compact-hover-target {
+  height: calc(var(--capsule-height) - var(--shape-top) * 2 + var(--caption-growth));
 }
 
 /* Under the pointer: wide enough to say what the count means. */
@@ -852,7 +915,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 }
 
 .app-stage[data-notch="false"] .panel-surface {
-  height: calc(var(--capsule-height) - var(--shape-top) * 2);
+  height: calc(var(--capsule-height) - var(--shape-top) * 2 + var(--caption-growth));
   min-height: calc(var(--capsule-height) - var(--shape-top) * 2);
   border-radius: 999px;
 }
@@ -976,6 +1039,114 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   transition-duration: var(--duration-quick), var(--duration-shape);
   transition-timing-function: var(--motion-exit), var(--spring);
   transition-delay: var(--peek-delay);
+}
+
+/* Voice caption ----------------------------------------------------------- */
+
+/* Luke's words, wrapping as they stream so the whole reply can be read — the
+   text is not timed to the speech (the protocol carries no word timing, and
+   generation runs ahead of the voice), so showing everything is what lets
+   reading catch up.
+
+   One element for every state, and one wrap width for every state: the
+   peek's, inset by the capsule's corner. A caption that re-wrapped at each
+   shape's own width would re-set its lines at the instant of every morph,
+   which reads as a jump; at one width the words never re-flow, and every
+   change of shape moves them on `transform` alone — under the housing in the
+   compact states, riding down to the panel's foot when the shape opens.
+
+   The box is always the full block the window reserves; what tracks the text
+   is the clip. It springs to the same edge the surface's height does, from
+   the same `--caption-size`, so a line that wraps into existence is revealed
+   by the black arriving under it rather than being drawn on the desktop. The
+   lift off the top edge rides in the transform rather than in `top` for the
+   same reason the surface carries it there: it changes between states, and
+   only a transform travels on the spring. It takes no pointer — the surface
+   under it is what answers, so hovering the words holds the peek like
+   hovering the shape does. */
+.voice-caption {
+  position: absolute;
+  z-index: 3;
+  top: var(--capsule-height);
+  left: 50%;
+  overflow: hidden;
+  width: calc(var(--peek-width) - var(--notch-convex-radius) * 2);
+  height: var(--caption-max);
+  padding: 5px 0 9px;
+  clip-path: inset(0 0 calc(var(--caption-max) - var(--caption-size, 28px)) 0);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, calc(var(--caption-rest, 0px) - var(--shape-top, 0px)));
+  /* The transform and the clip wait out `--duration-exit` like the surface
+     does: leaving a state, the words travel with the shape rather than ahead
+     of it. */
+  transition:
+    opacity var(--duration-exit) var(--motion-exit),
+    transform var(--duration-shape) var(--spring) var(--duration-exit),
+    clip-path var(--duration-shape) var(--spring) var(--duration-exit);
+}
+
+/* First words arrive the way the meter does — crossing the last of the
+   shape's travel, so they land inside the black rather than ahead of the edge
+   still springing toward them. The clip alone takes no delay while the
+   caption is up: it is the shape's twin, not content following it. */
+.app-stage[data-presentation="capsule"][data-caption="true"] .voice-caption,
+.app-stage[data-presentation="peek"][data-caption="true"] .voice-caption {
+  opacity: 1;
+  transition:
+    opacity var(--duration-quick) var(--motion-exit)
+    calc(var(--duration-shape) - var(--duration-quick)),
+    transform var(--duration-shape) var(--spring) var(--duration-exit),
+    clip-path var(--duration-shape) var(--spring);
+}
+
+/* The open panel keeps the same words at its foot: `--caption-rest` is the
+   travel from under the housing to the bottom edge the panel's measured
+   height puts there. Expanding, the words lead with the surface — no delay,
+   the panel's own timing — and collapsing, the compact rule above holds them
+   back by `--duration-exit` so they leave with the shape. */
+.app-stage[data-presentation="panel"][data-caption="true"] {
+  --caption-rest: calc(
+    var(--panel-height, 520px) -
+    var(--capsule-height) -
+    var(--caption-size, 28px)
+  );
+}
+
+.app-stage[data-presentation="panel"][data-caption="true"] .voice-caption {
+  opacity: 1;
+  transition:
+    opacity var(--duration-quick) var(--motion-exit)
+    calc(var(--duration-shape) - var(--duration-quick)),
+    transform var(--duration-shape) var(--spring),
+    clip-path var(--duration-shape) var(--spring);
+}
+
+/* The words are drawn on the shape, not in the panel's flow, so the body
+   reserves the block's height under its own padding and the rows never
+   collide with it. Reserved whenever there are words rather than only while
+   the panel is up, so the height the panel reports is already right when a
+   captioned expand begins. */
+.app-stage[data-caption="true"] .expanded-panel {
+  padding-bottom: calc(18px + var(--caption-size, 28px));
+}
+
+/* The translate is how a reply that outgrows the block rolls its oldest lines
+   up under the capsule band. The cut lands where black meets black, so lines
+   slide under the shape rather than being sliced in the open; the newest
+   words are always on screen, which is the half of the reply the voice has
+   not reached yet. */
+.voice-caption-text {
+  display: block;
+  width: 100%;
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1px;
+  line-height: 14px;
+  text-align: center;
+  transform: translateY(calc(var(--caption-scroll, 0px) * -1));
+  transition: transform var(--duration-fast) var(--spring-fast);
 }
 
 /* Waveform --------------------------------------------------------------- */

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -30,6 +30,7 @@ const SETTINGS_FIELD = {
   SHOW_IN_MENU_BAR: "showInMenuBar",
   VERSION: "version",
   VOICE: "voice",
+  VOICE_CAPTIONS: "voiceCaptions",
 } as const;
 
 const API_KEY_LENGTH = {
@@ -80,6 +81,12 @@ interface PersistedSettings {
    * than a credential, so it is stored plainly and never touches the cipher.
    */
   voice?: RealtimeVoice;
+  /**
+   * Whether Luke's speech is captioned on screen. Off unless the file says
+   * `true` outright, so a missing field, an older file, and a corrupt value
+   * all land on the default rather than switching something on.
+   */
+  voiceCaptions: boolean;
 }
 
 interface ResolvedApiKey {
@@ -162,6 +169,7 @@ function parsePersistedSettings(source: string): PersistedSettings {
     // a credential it has a default to fall back to, and honouring an unknown
     // one would mint sessions the API refuses.
     ...(isRealtimeVoice(voice) ? { voice } : {}),
+    voiceCaptions: record[SETTINGS_FIELD.VOICE_CAPTIONS] === true,
   };
 }
 
@@ -209,6 +217,7 @@ export class SettingsStore {
         (await this.#load()).voice ??
         environmentRealtimeVoice(this.#environment) ??
         REALTIME_DEFAULTS.VOICE,
+      voiceCaptions: (await this.#load()).voiceCaptions,
     };
   }
 
@@ -241,6 +250,27 @@ export class SettingsStore {
       };
       if (voice) next.voice = voice;
       else delete next.voice;
+      await this.#write(next);
+      this.#loading = Promise.resolve(next);
+    });
+    return { settings: await this.snapshot() };
+  }
+
+  /**
+   * Turns the on-screen caption of Luke's speech on or off. A plain preference
+   * like the menu bar's, and the same shape of change: nothing here needs the
+   * cipher, and there is no way to enter an invalid value, so the write either
+   * lands or throws.
+   */
+  async setVoiceCaptions(enabled: boolean): Promise<SettingsUpdateResult> {
+    await this.#serialize(async () => {
+      const persisted = await this.#load();
+      if (persisted.voiceCaptions === enabled) return;
+      const next: PersistedSettings = {
+        ...persisted,
+        version: SETTINGS_FILE_VERSION,
+        voiceCaptions: enabled,
+      };
       await this.#write(next);
       this.#loading = Promise.resolve(next);
     });
@@ -410,6 +440,7 @@ export class SettingsStore {
       version: SETTINGS_FILE_VERSION,
       apiKeys: {},
       showInMenuBar: true,
+      voiceCaptions: false,
     };
     if (source) {
       try {

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -64,6 +64,12 @@ export interface AppSettings {
    * marks the voice that would actually be heard, not just a stored value.
    */
   voice: RealtimeVoice;
+  /**
+   * Whether Luke's words are captioned on screen while he speaks. Off by
+   * default: the voice experience ships as sound, and words drawn under the
+   * housing all day are something to opt into rather than discover.
+   */
+  voiceCaptions: boolean;
 }
 
 /** A rejected update reports why without echoing the submitted value. */
@@ -178,6 +184,8 @@ export interface AppBridge {
   openProviderApiKeys(providerId: CredentialProviderId): void;
   /** Shows or hides the menu bar status item, and remembers the choice. */
   setShowInMenuBar(show: boolean): Promise<SettingsUpdateResult>;
+  /** Turns the on-screen caption of Luke's speech on or off. */
+  setVoiceCaptions(enabled: boolean): Promise<SettingsUpdateResult>;
   /**
    * Opens an observed session where its provider keeps it. The renderer names
    * the session rather than its address, for the same reason it names a
@@ -231,6 +239,7 @@ export const channels = {
   openMicrophoneSettings: "app:open-microphone-settings",
   setProviderApiKey: "app:set-provider-api-key",
   setVoice: "app:set-voice",
+  setVoiceCaptions: "app:set-voice-captions",
   openProviderApiKeys: "app:open-provider-api-keys",
   setShowInMenuBar: "app:set-show-in-menu-bar",
   openSession: "app:open-session",

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -28,6 +28,7 @@ interface Harness {
   session: RealtimeVoiceSession;
   sent: Record<string, unknown>[];
   errors: (string | undefined)[];
+  captions: (string | undefined)[];
   microphoneEnabled: () => boolean;
   microphoneStopped: () => boolean;
   emit: (event: unknown) => void;
@@ -71,6 +72,7 @@ function harness(
 ): Harness {
   const sent: Record<string, unknown>[] = [];
   const errors: (string | undefined)[] = [];
+  const captions: (string | undefined)[] = [];
   const requests: { url: string; init: RequestInit }[] = [];
   let enabled = false;
   let stopped = false;
@@ -147,12 +149,14 @@ function harness(
     onLocalStream: () => undefined,
     onRemoteStream: () => undefined,
     onError: (message) => errors.push(message),
+    onCaption: (text) => captions.push(text),
   });
 
   return {
     session,
     sent,
     errors,
+    captions,
     microphoneEnabled: () => enabled,
     microphoneStopped: () => stopped,
     lukeAudible: () => remoteTrack.enabled,
@@ -1018,7 +1022,6 @@ test("closing stops the microphone track", async () => {
   assert.equal(context.microphoneStopped(), true);
   assert.equal(context.session.status, REALTIME_STATUS.IDLE);
 });
-
 /** Opens and commits a developer turn, which is the only turn a tool may run in. */
 function armDeveloperTurn(context: Harness): void {
   context.session.startListening();
@@ -1282,4 +1285,120 @@ test("a tool outcome is not spoken over a turn the developer has taken", async (
   // ...but no reply was opened to voice it over the microphone now open.
   assert.ok(!events.some((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE));
   assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
+});
+
+test("the caption grows with the deltas and the final text supersedes them", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.session.beginTurn();
+  context.session.endTurn(true);
+
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
+    delta: "Two sessions ",
+  });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
+    delta: "need review.",
+  });
+  // The server's own rendering of the reply corrects whatever the deltas
+  // built, so a delta lost to the channel cannot leave a hole on screen.
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DONE,
+    transcript: "Two sessions need review, and one failed.",
+  });
+
+  assert.deepEqual(context.captions, [
+    "Two sessions ",
+    "Two sessions need review.",
+    "Two sessions need review, and one failed.",
+  ]);
+});
+
+test("the caption leaves when the reply does", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.session.beginTurn();
+  context.session.endTurn(true);
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
+    delta: "All quiet.",
+  });
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_DONE });
+  // Generation finishing is not speech finishing: the words stay up while
+  // Luke is still saying them.
+  assert.deepEqual(context.captions, ["All quiet."]);
+
+  context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED });
+
+  assert.deepEqual(context.captions, ["All quiet.", undefined]);
+});
+
+test("taking the turn cuts the caption with the audio", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.deliverRemoteTrack();
+  context.session.beginTurn();
+  context.session.endTurn(true);
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
+    delta: "A sentence the developer is about to talk over",
+  });
+
+  // The caption already holds words the room has not heard — the text runs
+  // ahead of the speech — so an interrupt must take it down at once rather
+  // than leaving Luke finishing a sentence he was stopped from saying.
+  context.session.startListening();
+
+  assert.equal(context.captions.at(-1), undefined);
+  assert.equal(context.captions.length, 2);
+});
+
+test("a cancelled reply's late transcript cannot pollute the next caption", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.deliverRemoteTrack();
+  context.session.beginTurn();
+  context.session.endTurn(true);
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
+    item: { id: "item-first" },
+  });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
+    item_id: "item-first",
+    delta: "The first reply",
+  });
+
+  // Talking over the reply cuts it, but the server had already produced the
+  // rest of its transcript, which keeps arriving — around the interrupt, and
+  // even after the next reply has been asked for.
+  context.session.startListening();
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
+    item_id: "item-first",
+    delta: ", still streaming in",
+  });
+  context.session.stopListening(true);
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DONE,
+    item_id: "item-first",
+    transcript: "The first reply, finished anyway.",
+  });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
+    item: { id: "item-second" },
+  });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
+    item_id: "item-second",
+    delta: "The second reply",
+  });
+
+  assert.equal(context.captions.at(-1), "The second reply");
+  assert.equal(context.captions.includes("The first reply, finished anyway."), false);
+  assert.equal(
+    context.captions.some((caption) => caption?.includes("still streaming in")),
+    false,
+  );
 });

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -206,6 +206,45 @@ test("clears a stored key", async (t) => {
   assert.equal((await readSettingsFile(directory)).includes(CONDUCTOR), false);
 });
 
+test("captions are off until switched on, and the choice survives a reopen", async (t) => {
+  const directory = await temporaryDirectory(t);
+  // A preference is not a credential, so choosing it must reach the Keychain
+  // not at all.
+  const cipher = countingCipher();
+  const store = storeIn(directory, { cipher });
+
+  assert.equal((await store.snapshot()).voiceCaptions, false);
+  const enabled = await store.setVoiceCaptions(true);
+
+  assert.equal(enabled.settings.voiceCaptions, true);
+  assert.equal((await storeIn(directory).snapshot()).voiceCaptions, true);
+  assert.equal(cipher.calls.isAvailable, 0);
+  assert.equal(cipher.calls.encrypt, 0);
+});
+
+test("switching captions never disturbs a stored key", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+  await store.setApiKey(CONDUCTOR, TEST_API_KEY);
+
+  await store.setVoiceCaptions(true);
+  const off = await store.setVoiceCaptions(false);
+
+  assert.equal(off.settings.voiceCaptions, false);
+  assert.equal(await storeIn(directory).readApiKey(CONDUCTOR), TEST_API_KEY);
+});
+
+test("a corrupt captions value reads as off rather than switching them on", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({ version: 2, apiKeys: {}, voiceCaptions: "yes" }),
+    "utf8",
+  );
+
+  assert.equal((await storeIn(directory).snapshot()).voiceCaptions, false);
+});
+
 test("keeps each provider's key, environment fallback, and reported source separate", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory, {
@@ -257,6 +296,7 @@ test("keeps both keys when two providers are saved at once", async (t) => {
     // Written even at its default, so the file states what it is rather than
     // leaving it to be inferred from an absence.
     showInMenuBar: true,
+    voiceCaptions: false,
   });
   const reopened = storeIn(directory, { providers: TEST_PROVIDERS });
   assert.equal(await reopened.readApiKey(FIRST_CLOUD), "first-cloud-key");
@@ -453,6 +493,7 @@ test("keeps a Conductor key stored by an earlier version working", async (t) => 
     version: 2,
     apiKeys: { [CONDUCTOR]: sealed("conductor-replacement-key") },
     showInMenuBar: true,
+    voiceCaptions: false,
   });
   assert.equal(await storeIn(directory).readApiKey(CONDUCTOR), "conductor-replacement-key");
 });
@@ -472,6 +513,7 @@ test("carries a key belonging to a provider this build does not know", async (t)
     version: 2,
     apiKeys: { "later-cloud": sealed("later-cloud-key"), [CONDUCTOR]: sealed(TEST_API_KEY) },
     showInMenuBar: true,
+    voiceCaptions: false,
   });
 });
 
@@ -489,6 +531,7 @@ test("shows the menu bar item until asked otherwise, and remembers the answer", 
     version: 2,
     apiKeys: {},
     showInMenuBar: false,
+    voiceCaptions: false,
   });
   // The choice outlives the run that heard it.
   assert.equal((await storeIn(directory).snapshot()).showInMenuBar, false);

--- a/packages/sidecar-core/src/geometry.ts
+++ b/packages/sidecar-core/src/geometry.ts
@@ -50,6 +50,14 @@ export interface NotchWindowLayout extends Rectangle {
 export const CAPSULE_SIDE_WIDTH = 36;
 export const PEEK_SIDE_GROWTH = 88;
 export const SURFACE_MARGIN = 40;
+/**
+ * `--caption-max` in the renderer's stylesheet; the two must agree. The
+ * tallest compact shape is the capsule or peek grown a caption block below
+ * the housing — Luke's words while he speaks, wrapping to as many as four
+ * lines as they stream in — and the window holds that whole block for the
+ * same reason it holds the peek's width: speech must never cost an IPC resize.
+ */
+export const VOICE_CAPTION_MAX_HEIGHT = 70;
 /** `--panel-width` in the renderer's stylesheet; the two must agree. */
 export const PANEL_WIDTH = 620;
 const peekSideWidth = CAPSULE_SIDE_WIDTH + PEEK_SIDE_GROWTH;
@@ -90,7 +98,10 @@ export function positionNotchWindow(
   const height =
     mode === "expanded"
       ? Math.min(panelHeight + SURFACE_MARGIN, display.bounds.height)
-      : Math.min(Math.max(32, notch.topInset) + SURFACE_MARGIN, display.bounds.height);
+      : Math.min(
+          Math.max(32, notch.topInset) + VOICE_CAPTION_MAX_HEIGHT + SURFACE_MARGIN,
+          display.bounds.height,
+        );
   const x = Math.round(display.bounds.x + (display.bounds.width - width) / 2);
 
   return {

--- a/packages/sidecar-core/src/realtime.ts
+++ b/packages/sidecar-core/src/realtime.ts
@@ -102,6 +102,14 @@ export const REALTIME_SERVER_EVENT = {
    * behind it as a backstop rather than being replaced outright.
    */
   OUTPUT_AUDIO_BUFFER_STOPPED: "output_audio_buffer.stopped",
+  /**
+   * The words of the reply, arriving as they are generated. They run ahead of
+   * the audio — the model produces text faster than it speaks it — so they
+   * caption the reply in progress rather than subtitling word by word.
+   */
+  RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA: "response.output_audio_transcript.delta",
+  /** The reply's complete text, which supersedes whatever the deltas built. */
+  RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DONE: "response.output_audio_transcript.done",
   RESPONSE_DONE: "response.done",
   ERROR: "error",
 } as const;

--- a/packages/sidecar-core/tests/geometry.test.ts
+++ b/packages/sidecar-core/tests/geometry.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { CAPSULE_SIDE_WIDTH, PEEK_SIDE_GROWTH, positionNotchWindow, SURFACE_MARGIN } from "../src";
+import {
+  CAPSULE_SIDE_WIDTH,
+  PEEK_SIDE_GROWTH,
+  positionNotchWindow,
+  SURFACE_MARGIN,
+  VOICE_CAPTION_MAX_HEIGHT,
+} from "../src";
 
 const notchedDisplay = {
   bounds: { x: 0, y: 0, width: 1512, height: 982 },
@@ -23,7 +29,9 @@ test("anchors the compact window to the physical top edge", () => {
     x: 487,
     y: 0,
     width: 538,
-    height: 78,
+    // The top inset, the caption block Luke's words wrap into below it, and
+    // the margin the overshoot and the shadow fall in.
+    height: 148,
     notch: {
       topInset: 38,
       housingWidth: 210,
@@ -61,7 +69,7 @@ test("uses a top-center fallback without inventing a notch", () => {
   assert.equal(result.x, -1124);
   assert.equal(result.y, -200);
   assert.equal(result.width, peekWidth(0) + SURFACE_MARGIN * 2);
-  assert.equal(result.height, 32 + SURFACE_MARGIN);
+  assert.equal(result.height, 32 + VOICE_CAPTION_MAX_HEIGHT + SURFACE_MARGIN);
   assert.equal(result.notch.hasNotch, false);
   assert.equal(result.notch.topInset, 25);
   assert.equal(result.notch.source, "work-area");

--- a/scripts/evidence.sh
+++ b/scripts/evidence.sh
@@ -99,12 +99,12 @@ validate_evidence() {
 # The window is a stage, not the shape: a compact window holds the peek the
 # capsule grows into, and both carry room for a spring to overshoot.
 validate_evidence "$SIDECAR_EXPANDED_EVIDENCE_PATH" 700 560
-validate_evidence "$SIDECAR_COMPACT_EVIDENCE_PATH" 538 78
-validate_evidence "$SIDECAR_PEEK_EVIDENCE_PATH" 538 78
+validate_evidence "$SIDECAR_COMPACT_EVIDENCE_PATH" 538 148
+validate_evidence "$SIDECAR_PEEK_EVIDENCE_PATH" 538 148
 # The slot is drawn in the expanded window, which is why stepping aside for a
 # browser costs no resize at all.
 validate_evidence "$SIDECAR_SLOT_EVIDENCE_PATH" 700 560
-validate_evidence "$SIDECAR_SPEAKING_EVIDENCE_PATH" 538 78
+validate_evidence "$SIDECAR_SPEAKING_EVIDENCE_PATH" 538 148
 
 printf 'Expanded visual evidence: %s\n' "$SIDECAR_EXPANDED_EVIDENCE_PATH"
 printf 'Compact visual evidence: %s\n' "$SIDECAR_COMPACT_EVIDENCE_PATH"


### PR DESCRIPTION
## Summary

Draws the words of Luke's reply while he says them, behind a new **Captions** switch in the Preferences group — off by default.

- The session driver subscribes to the Realtime output-audio transcript events (`response.output_audio_transcript.delta`/`.done`) on the existing data channel — renderer-local, no new IPC, nothing new leaves the machine. The session owns the caption's whole lifecycle: it clears when the reply ends, when the developer talks over Luke (the text runs ahead of the audio, so an interrupt cuts the words with the sound), and when the call closes.
- One caption element serves every shape, wrapping at one constant width (the peek's) so no morph ever re-flows a line: the compact states grow up to four lines below the housing (the surface's height and a `clip-path` spring in lockstep from the same measured size, so a line that wraps into existence is revealed by black rather than drawn on the desktop), a captioned capsule holds the peek's width, and opening the panel carries the words to its foot on a transform spring. Replies past four lines roll their oldest lines up under the housing, newest words always on screen.
- The words are deliberately not word-timed to the voice: the protocol carries no output timing, so the caption is the reply streaming in, which lets reading catch up at its own pace.
- The preference is a plain boolean beside the menu bar and voice choices — stored in `settings.json`, never touching the cipher, validated at the IPC boundary, off unless the file says `true` outright. The capture profile draws a synthetic fixture caption regardless, so the strip stays photographed.
- The compact window reserves the caption block permanently (`VOICE_CAPTION_MAX_HEIGHT`, mirrored by `--caption-max`), so speech never costs an IPC resize; compact evidence sizes moved from 538×78 to 538×146.
- README and PRIVACY now state the opt-in and that the caption is discarded when the reply ends — never written to disk.

## Testing

- `./scripts/check.sh` passes on the rebased branch: 0 failures across web, sidecar-core, and desktop suites.
- New coverage: caption accumulation from deltas and the final-text correction; clearing on reply end and on interruption; the preference's default-off, persistence across reopen, cipher-untouched writes, key/preference writes surviving each other, and corrupt-value fallback; compact window geometry.
- `./scripts/evidence.sh` was run on a physical Mac against this exact tree: all five PNGs captured and size-validated, and the speaking peek was visually inspected mid-development (two wrapped caption lines under the housing, corners and shadow intact). No physical-notch check was performed — captures use fixture display geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/e3d38fd6-a3ac-48ae-873d-79043e34d357)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31761201625/artifacts/9204680338) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31761201625)

- Commit: `4f0cf12067e030c731a0b29fd328701762b502df`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
