### PR TITLE
fix(sessions): date Claude Code sessions by their own records, not mtime

### DIFF
--- a/apps/desktop/src/claude-code-adapter.ts
+++ b/apps/desktop/src/claude-code-adapter.ts
@@ -412,7 +412,13 @@ function observationFromSessionFile(
   now: number,
   activeSessionFreshnessMs: number,
 ): ProviderSessionObservation {
-  const observedAt = Math.max(candidate.mtimeMs, parsed.timestampMs ?? 0);
+  // The transcript's own clock, not the file's. Claude Code touches session
+  // files in bulk long after their conversations ended — appending bookkeeping
+  // records and bumping mtimes — so mtime says when something last handled the
+  // file, while the last timestamped record says when the session last moved.
+  // Trusting mtime made every touched session read as active just now. The
+  // file's date remains the fallback for a tail that carried no timestamp.
+  const observedAt = parsed.timestampMs ?? candidate.mtimeMs;
   const status = statusFromTail(parsed, observedAt, now, activeSessionFreshnessMs);
   return {
     providerSessionId: candidate.providerSessionId,
@@ -493,6 +499,10 @@ export class ClaudeCodeSessionAdapter implements SessionProviderAdapter {
         now,
         this.#activeSessionFreshnessMs,
       );
+      // The mtime check above is only a cheap gate on reading the file. The
+      // observation window is enforced here, against the transcript's clock:
+      // a touch must not carry a long-dead session back into the panel.
+      if (now - observation.observedAt > this.#maximumSessionAgeMs) continue;
       if (!observations.has(observation.providerSessionId)) {
         observations.set(observation.providerSessionId, observation);
       }

--- a/apps/desktop/tests/claude-code-adapter.test.ts
+++ b/apps/desktop/tests/claude-code-adapter.test.ts
@@ -766,3 +766,85 @@ test("returns an empty snapshot when Claude Code has no local project directory"
 
   assert.deepEqual(await adapter.observe(), []);
 });
+
+test("dates a touched transcript by its own records rather than the touch", async (t) => {
+  const claudeHome = await temporaryClaudeHome(t);
+  const lastRecordTime = "2026-08-11T20:45:00.000Z";
+  await writeSessionFile(
+    claudeHome,
+    "-Users-test-touched",
+    "touched-session",
+    [
+      {
+        type: TEST_CLAUDE_EVENT_TYPE.USER,
+        cwd: "/Users/test/touched",
+        timestamp: "2026-08-11T20:44:50.000Z",
+      },
+      {
+        type: TEST_CLAUDE_EVENT_TYPE.ASSISTANT,
+        cwd: "/Users/test/touched",
+        timestamp: lastRecordTime,
+        message: { stop_reason: "end_turn", content: [] },
+      },
+      // The bookkeeping record a later pass appended: no timestamp, and the
+      // same pass is what bumped the file's mtime to the present.
+      { type: "last-prompt", cwd: "/Users/test/touched" },
+    ],
+    TEST_TIME,
+  );
+
+  const adapter = new ClaudeCodeSessionAdapter({
+    claudeHome,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  // Three hours old by its own clock, so the row must say so — and a session
+  // that old has left the freshness window however recently it was touched.
+  assert.equal(observation?.observedAt, Date.parse(lastRecordTime));
+  assert.equal(observation?.status, SESSION_STATUS.UNKNOWN);
+});
+
+test("keeps a touch from carrying a session past the observation window", async (t) => {
+  const claudeHome = await temporaryClaudeHome(t);
+  await writeSessionFile(
+    claudeHome,
+    "-Users-test-ancient",
+    "ancient-session",
+    [
+      {
+        type: TEST_CLAUDE_EVENT_TYPE.ASSISTANT,
+        cwd: "/Users/test/ancient",
+        timestamp: "2026-06-25T08:30:00.000Z",
+        message: { stop_reason: "end_turn", content: [] },
+      },
+    ],
+    TEST_TIME,
+  );
+
+  const adapter = new ClaudeCodeSessionAdapter({
+    claudeHome,
+    now: () => TEST_TIME,
+  });
+
+  assert.deepEqual(await adapter.observe(), []);
+});
+
+test("falls back to the file's date when the tail carries no timestamp", async (t) => {
+  const claudeHome = await temporaryClaudeHome(t);
+  await writeSessionFile(
+    claudeHome,
+    "-Users-test-untimed",
+    "untimed-session",
+    [{ type: TEST_CLAUDE_EVENT_TYPE.USER, cwd: "/Users/test/untimed" }],
+    TEST_TIME - 5_000,
+  );
+
+  const adapter = new ClaudeCodeSessionAdapter({
+    claudeHome,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.observedAt, TEST_TIME - 5_000);
+});


### PR DESCRIPTION
## Problem

Rows for local Claude Code sessions read **"Now"** however old their conversations were.

The adapter computed a session's `observedAt` as `Math.max(file mtime, last record timestamp)`. On a real machine, Claude Code touches transcript files in bulk long after their conversations ended — appending untimestamped bookkeeping records (`last-prompt`, queue operations) and bumping mtimes; transcripts whose last records were days old carried mtimes from the same second as one another. With `Math.max`, the touch always won, so:

- every touched session's row said "Now" (`observedAgoLabel` measures from `observedAt`),
- a long-ended session re-entered the 15-minute freshness window and could read as **Waiting / needs you**,
- the 24-hour discovery window, keyed off mtime, resurfaced conversations that ended weeks ago.

## Fix

- `observedAt` is now the transcript's own last timestamped record, with the file's date kept only as the fallback for a tail that carried no timestamp. Nearly every record Claude Code writes is timestamped, so the transcript's clock is an honest "last moved".
- The observation window is enforced against that value after the tail is parsed, so a touch cannot carry a long-dead session back into the panel. The mtime check stays as a cheap gate on reading the file at all.

The Codex adapter already dates sessions from row timestamps and is unaffected. Cursor-local and OpenCode read provider-owned stores whose mtimes are written by the providers themselves and are left as they are.

## Tests

Three regression tests: a touched transcript is dated by its own records (and has left the freshness window), a touch cannot carry a session past the observation window, and a tail with no timestamped record still falls back to the file's date.

`./scripts/check.sh` passes (repository, type, test, and build checks). Portable-only change — no UI or macOS surface touched, so no visual evidence run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/8661f3b7-f4b7-4d71-8168-d585ec8822da)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31762870821/artifacts/9205252619) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31762870821)

- Commit: `7c517482221fdc2ec999a61f867be3fcd81f0fdf`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
