### PR TITLE
fix(panel): read the wing's marks in the sort the list is in

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1010,9 +1010,10 @@ export function App(): React.JSX.Element {
   if (!bootstrap || !display) return <div />;
 
   const visibleSessions = displaySessions(bootstrap, sessions);
-  // The tally is taken before the list is narrowed: the capsule reports what
-  // Luke is watching, not what the panel is currently showing.
-  const tally = sessionTally(visibleSessions);
+  // The tally is taken before the list is narrowed — the capsule reports what
+  // Luke is watching, not what the panel is currently showing — but it reads
+  // in the list's own sort, so the wing's marks sit in the order the rows do.
+  const tally = sessionTally(visibleSessions, sessionView.sort);
   const list = arrangeSessions(visibleSessions, sessionView);
   // Dropping an emptied filter is a change of view, not a way of drawing one.
   // Left in state it would lie dormant behind an All that only looks chosen,

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -168,6 +168,7 @@ export interface SessionTally {
   idle: number;
   /** The state the count badge and the notch capsule adopt. */
   state: SessionState;
+  /** One agent each, seated where its first session reads under the sort. */
   providers: readonly ProviderTally[];
 }
 
@@ -212,6 +213,11 @@ function byUrgency(first: DisplaySession, second: DisplaySession): number {
 /** What moved last, with urgency deciding sessions observed in the same tick. */
 function byRecency(first: DisplaySession, second: DisplaySession): number {
   return second.observedAt - first.observedAt || byUrgency(first, second);
+}
+
+/** The comparator a sort names — one answer for the list and the wing's marks. */
+function bySort(sort: SessionSort): (first: DisplaySession, second: DisplaySession) => number {
+  return sort === SESSION_SORT.RECENCY ? byRecency : byUrgency;
 }
 
 export function displaySessions(
@@ -341,19 +347,29 @@ export function arrangeSessions(
       : sessions.filter((session) => matchesFilter(session, filter));
 
   return {
-    sessions: [...matching].sort(view.sort === SESSION_SORT.RECENCY ? byRecency : byUrgency),
+    sessions: [...matching].sort(bySort(view.sort)),
     total: sessions.length,
     filter,
     options,
   };
 }
 
-export function sessionTally(sessions: readonly DisplaySession[]): SessionTally {
+/**
+ * Counted across everything tracked, whatever the list is narrowed to — but
+ * read in the sort the list is read in, so the providers sit in the order
+ * their first sessions do and the wing's marks match the rows. With no view in
+ * force — the capsule, say — the sessions read by urgency, which is also the
+ * sort the panel opens on.
+ */
+export function sessionTally(
+  sessions: readonly DisplaySession[],
+  sort: SessionSort = SESSION_SORT.URGENCY,
+): SessionTally {
   const providers = new Map<string, ProviderTally>();
   const counts = { attention: 0, working: 0, complete: 0, idle: 0 };
   const attentionIds: string[] = [];
 
-  for (const session of sessions) {
+  for (const session of [...sessions].sort(bySort(sort))) {
     if (session.state === SESSION_STATE.ATTENTION) {
       counts.attention += 1;
       attentionIds.push(session.id);

--- a/apps/desktop/tests/session-model.test.ts
+++ b/apps/desktop/tests/session-model.test.ts
@@ -231,6 +231,29 @@ test("the tally counts per state and per provider", () => {
   ]);
 });
 
+// The wing's marks and the rows are two drawings of the same order, so
+// choosing the other sort re-seats the providers with the sessions: a mark
+// that stayed put while the rows re-sorted would name the top row's agent
+// wrong. The counts are counts, and no ordering may change them.
+test("the providers re-seat with the rows when the other sort is chosen", () => {
+  const recent = sessionTally(FIXTURE_SESSIONS, SESSION_SORT.RECENCY);
+
+  assert.deepEqual(
+    recent.providers.map((provider) => provider.providerId),
+    [
+      PROVIDER_ID.CONDUCTOR,
+      PROVIDER_ID.CODEX,
+      PROVIDER_ID.CLAUDE_CODE,
+      PROVIDER_ID.CURSOR,
+      PROVIDER_ID.DEVIN,
+    ],
+  );
+  assert.deepEqual(
+    { ...recent, providers: undefined },
+    { ...sessionTally(FIXTURE_SESSIONS), providers: undefined },
+  );
+});
+
 test("the badge state follows the most urgent session", () => {
   const working = sessionTally(
     displaySessions(bootstrap(false), [liveSession(CODEX_PROVIDER, "a", SESSION_STATUS.WORKING)]),


### PR DESCRIPTION
## What

Choosing **Recency** in the panel's sort re-orders the session rows, but the provider marks in the wing kept reading by urgency: the tally that seats them was always taken over the urgency-sorted roster, so the first mark stopped naming the top row's agent.

`sessionTally` now takes the sort the view holds and reads the sessions through the same comparator `arrangeSessions` applies, so the providers re-seat with the rows — and the reorder motion the marks already have (#69) glides them there.

## What doesn't change

- The counts: ordering cannot touch them, and the new test asserts the recency tally differs from the urgency one only in provider order.
- The capsule: a closing panel resets the view, so a compact wing still reads by urgency, which is also the sort the panel opens on.
- The filter: the tally is still taken before the list is narrowed.

## Validation

- `./scripts/check.sh` — passes (lint, typecheck, 516 tests, builds), exit 0.
- UI change, so CI's `./scripts/verify.sh` on macOS is the completion invariant; evidence is linked from this description by CI. No physical-notch check was performed (working from a cloud workspace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/3000a4c8-9cd8-4224-9817-ccb355274bac)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31767440302/artifacts/9206843717) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31767440302)

- Commit: `a99d7fdd3e3a7a7941e4c2f7f2818622cba3b42a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
