### PR TITLE
feat(settings): add a switch to show Luke in the Dock

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -561,6 +561,29 @@ function registerIpc(): void {
     },
   );
 
+  // The Dock icon follows the stored answer at once, like the status item: a
+  // setting that only took effect on the next launch would read as a toggle
+  // that does nothing.
+  ipcMain.handle(
+    channels.setShowInDock,
+    async (event, show: unknown): Promise<SettingsUpdateResult> => {
+      if (!trustedSender(event)) throw new Error("Untrusted renderer");
+      if (typeof show !== "boolean") throw new Error("Invalid Dock request");
+      try {
+        const result = await settingsStore.setShowInDock(show);
+        applyDockVisibility(result.settings.showInDock);
+        return result;
+      } catch {
+        // A filesystem failure is not something the user can act on, so it is
+        // reported as one line rather than as a raw system error.
+        return {
+          settings: await settingsStore.snapshot(),
+          reason: "Could not save that setting on this system.",
+        };
+      }
+    },
+  );
+
   // The voice is a preference rather than a credential, but it travels the
   // same road: the renderer names a value from a set fixed by this build and
   // hears back the settings as they now stand.
@@ -966,6 +989,21 @@ function applyMenuBarVisibility(show: boolean): void {
   destroyTray();
 }
 
+/**
+ * Puts Luke in the Dock or takes him back out, to match the setting. He ships
+ * as an accessory app — the notch is his fixed point — so the icon is a second
+ * door like the status item, losing nothing when it is hidden. Either
+ * direction transforms the process type, which can deactivate the app, so the
+ * panel the switch was pressed in is brought back forward rather than left to
+ * lose its caret.
+ */
+function applyDockVisibility(show: boolean): void {
+  if (process.platform !== "darwin") return;
+  if (show) void app.dock?.show();
+  else app.dock?.hide();
+  if (windowMode === "expanded") focusPanelWindow();
+}
+
 function handleDisplayChange(): void {
   setTimeout(() => {
     refreshNativeGeometry();
@@ -1011,6 +1049,15 @@ if (!app.requestSingleInstanceLock()) {
     void settingsStore.showInMenuBar().then(
       (show) => applyMenuBarVisibility(show),
       () => applyMenuBarVisibility(true),
+    );
+    // The Dock icon reads the same file under the opposite default: it is
+    // opt-in, so a file that cannot be read leaves Luke out of the Dock — the
+    // accessory app the launch just asserted. Nothing to do until it says so.
+    void settingsStore.showInDock().then(
+      (show) => {
+        if (show) applyDockVisibility(true);
+      },
+      () => undefined,
     );
     // Awaited, so the chosen voice reaches the minter before the renderer
     // exists to ask for a credential: the first conversation must already

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -990,18 +990,49 @@ function applyMenuBarVisibility(show: boolean): void {
 }
 
 /**
+ * macOS ignores a `dock.hide()` within a second of the last Dock change, so a
+ * switch pressed twice cannot be honoured call by call; the applier below
+ * paces itself to this instead, which is Electron's documented floor.
+ */
+const DOCK_SETTLE_MS = 1100;
+
+/** The Dock state last asked for, and whether the applier is chasing it. */
+let dockDesired = false;
+let dockSettling = false;
+
+/**
  * Puts Luke in the Dock or takes him back out, to match the setting. He ships
  * as an accessory app — the notch is his fixed point — so the icon is a second
- * door like the status item, losing nothing when it is hidden. Either
- * direction transforms the process type, which can deactivate the app, so the
- * panel the switch was pressed in is brought back forward rather than left to
- * lose its caret.
+ * door like the status item, losing nothing when it is hidden.
  */
 function applyDockVisibility(show: boolean): void {
   if (process.platform !== "darwin") return;
-  if (show) void app.dock?.show();
-  else app.dock?.hide();
-  if (windowMode === "expanded") focusPanelWindow();
+  dockDesired = show;
+  void settleDock();
+}
+
+/**
+ * Chases the desired state rather than relaying each press: a hide within a
+ * second of the last Dock change is silently ignored by macOS, so the icon is
+ * re-checked after every change and asked again until it matches — the switch
+ * and the file must not end a quick on-and-off disagreeing with the Dock.
+ */
+async function settleDock(): Promise<void> {
+  if (dockSettling || !app.dock) return;
+  dockSettling = true;
+  try {
+    while (app.dock.isVisible() !== dockDesired) {
+      if (dockDesired) await app.dock.show();
+      else app.dock.hide();
+      // Either direction transforms the process type, which can deactivate
+      // the app; the panel the switch was pressed in is brought back forward
+      // rather than left to lose its caret.
+      if (windowMode === "expanded") focusPanelWindow();
+      await new Promise((resolve) => setTimeout(resolve, DOCK_SETTLE_MS));
+    }
+  } finally {
+    dockSettling = false;
+  }
 }
 
 function handleDisplayChange(): void {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -44,6 +44,8 @@ const bridge: AppBridge = {
   },
   setShowInMenuBar: (show: boolean) =>
     ipcRenderer.invoke(channels.setShowInMenuBar, show) as Promise<SettingsUpdateResult>,
+  setShowInDock: (show: boolean) =>
+    ipcRenderer.invoke(channels.setShowInDock, show) as Promise<SettingsUpdateResult>,
   setVoiceCaptions: (enabled: boolean) =>
     ipcRenderer.invoke(channels.setVoiceCaptions, enabled) as Promise<SettingsUpdateResult>,
   openSession: (identity: SessionIdentity) =>

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -694,6 +694,14 @@ export function App(): React.JSX.Element {
     return result.reason;
   }, []);
 
+  // The Dock icon, on the same round trip: the row reads the state the store
+  // actually holds rather than the one the press hoped for.
+  const changeShowInDock = useCallback(async (show: boolean) => {
+    const result = await window.sidecar.setShowInDock(show);
+    setSettings(result.settings);
+    return result.reason;
+  }, []);
+
   const credentials: CredentialEntryControl = {
     entry,
     begin: beginEntry,
@@ -1115,6 +1123,7 @@ export function App(): React.JSX.Element {
               ...(shownHotkey.hotkey ? { voiceHotkey: shownHotkey.hotkey } : {}),
               voiceHotkeyHeld: shownHotkey.held,
               onShowInMenuBarChange: changeShowInMenuBar,
+              onShowInDockChange: changeShowInDock,
               onQuit: () => window.sidecar.quit(),
             }}
           />

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -70,6 +70,11 @@ export interface SettingsPanelProps {
    * refuses, and the row is where that answer belongs.
    */
   onShowInMenuBarChange: (show: boolean) => Promise<string | undefined>;
+  /**
+   * Shows or hides the Dock icon. The store answers with why when it refuses,
+   * and the row is where that answer belongs.
+   */
+  onShowInDockChange: (show: boolean) => Promise<string | undefined>;
   onQuit: () => void;
   /** The talk key, shown so it can be learned. It is not editable yet. */
   voiceHotkey?: string;
@@ -497,9 +502,9 @@ function CredentialsSection({
  * ear — offered the way macOS offers one value from a small fixed set: a
  * pop-up button whose closed face is drawn here and whose open menu is the
  * system's, which also lets it escape a window sized to the panel rather than
- * being clipped by it. Below it, whether the status item stands in the menu
- * bar as well as at the notch: a switch and nothing else, because nothing
- * rides on the answer — Settings and Quit live in this panel, so the item is a
+ * being clipped by it. Below it, whether Luke stands in the menu bar and in
+ * the Dock as well as at the notch: switches and nothing else, because nothing
+ * rides on either answer — Settings and Quit live in this panel, so each is a
  * second door rather than the only one.
  */
 function PreferencesSection({
@@ -509,6 +514,8 @@ function PreferencesSection({
   onVoiceCaptionsChange,
   shown,
   onShowInMenuBarChange,
+  dockShown,
+  onShowInDockChange,
 }: {
   voice: RealtimeVoice;
   onVoiceChange: (voice: RealtimeVoice) => void;
@@ -516,6 +523,8 @@ function PreferencesSection({
   onVoiceCaptionsChange: (enabled: boolean) => Promise<string | undefined>;
   shown: boolean;
   onShowInMenuBarChange: (show: boolean) => Promise<string | undefined>;
+  dockShown: boolean;
+  onShowInDockChange: (show: boolean) => Promise<string | undefined>;
 }): React.JSX.Element {
   // The change is a round trip through the settings file, so the switch rests
   // until the store has answered rather than claiming a state it may not get.
@@ -534,6 +543,12 @@ function PreferencesSection({
     setCaptionsBusy(true);
     setRejection(await onVoiceCaptionsChange(!captions));
     setCaptionsBusy(false);
+  };
+  const [dockBusy, setDockBusy] = useState(false);
+  const toggleDock = async () => {
+    setDockBusy(true);
+    setRejection(await onShowInDockChange(!dockShown));
+    setDockBusy(false);
   };
   return (
     <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
@@ -614,6 +629,22 @@ function PreferencesSection({
           <span className="switch-thumb" />
         </button>
       </div>
+      <div className="settings-row">
+        <span className="settings-copy">
+          <strong>Show Luke in the Dock</strong>
+        </span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={dockShown}
+          aria-label="Show Luke in the Dock"
+          className="switch"
+          disabled={dockBusy}
+          onClick={() => void toggleDock()}
+        >
+          <span className="switch-thumb" />
+        </button>
+      </div>
       {rejection ? <p className="error-message">{rejection}</p> : null}
     </section>
   );
@@ -631,6 +662,7 @@ export function SettingsPanel({
   onVoiceChange,
   panelOpen,
   onShowInMenuBarChange,
+  onShowInDockChange,
   onQuit,
   voiceHotkey,
   voiceHotkeyHeld,
@@ -651,6 +683,8 @@ export function SettingsPanel({
           onVoiceCaptionsChange={onVoiceCaptionsChange}
           shown={settings.showInMenuBar}
           onShowInMenuBarChange={onShowInMenuBarChange}
+          dockShown={settings.showInDock}
+          onShowInDockChange={onShowInDockChange}
         />
       ) : null}
 

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1517,7 +1517,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   margin: 0;
 }
 
-/* The one switch in the panel. On is the palette connected and complete
+/* The panel's switches. On is the palette connected and complete
    already use, so an item that is drawn reads the same way a provider that is
    reachable does. Only the thumb moves, only by transform, and on
    `--spring-fast` — the bounce every small element in the app rides. */

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -27,6 +27,7 @@ const SETTINGS_FILE_MODE = 0o600;
 const SETTINGS_FIELD = {
   API_KEYS: "apiKeys",
   LEGACY_CONDUCTOR_API_KEY: "conductorApiKey",
+  SHOW_IN_DOCK: "showInDock",
   SHOW_IN_MENU_BAR: "showInMenuBar",
   VERSION: "version",
   VOICE: "voice",
@@ -70,6 +71,12 @@ interface PersistedSettings {
    * through untouched so an older build cannot discard a newer one's key.
    */
   apiKeys: Readonly<Record<string, string>>;
+  /**
+   * Whether Luke stands in the Dock. Off unless the file says `true` outright,
+   * so a missing field, an older file, and a corrupt value all land on the
+   * accessory app Luke ships as rather than putting an icon somewhere new.
+   */
+  showInDock: boolean;
   /**
    * Whether the menu bar status item is drawn. A file that has never said —
    * written before the choice existed, or hand-edited into nonsense — means the
@@ -164,6 +171,7 @@ function parsePersistedSettings(source: string): PersistedSettings {
   return {
     version: typeof version === "number" ? version : SETTINGS_FILE_VERSION,
     apiKeys: storedApiKeys(record),
+    showInDock: record[SETTINGS_FIELD.SHOW_IN_DOCK] === true,
     showInMenuBar: typeof showInMenuBar === "boolean" ? showInMenuBar : true,
     // A voice this build does not offer is dropped rather than carried: unlike
     // a credential it has a default to fall back to, and honouring an unknown
@@ -210,6 +218,7 @@ export class SettingsStore {
       // its own: a snapshot is taken on every launch, and most of them are for
       // a user with no key to protect.
       secretStorage: this.#secretStorage,
+      showInDock: (await this.#load()).showInDock,
       showInMenuBar: (await this.#load()).showInMenuBar,
       // Resolved the way the minter resolves it, so the panel marks the voice
       // that would actually be heard.
@@ -228,6 +237,15 @@ export class SettingsStore {
    */
   async showInMenuBar(): Promise<boolean> {
     return (await this.#load()).showInMenuBar;
+  }
+
+  /**
+   * Shallow for the same reason as `showInMenuBar()`: the Dock icon is decided
+   * at launch from the settings file alone, never the keychain behind the
+   * stored keys.
+   */
+  async showInDock(): Promise<boolean> {
+    return (await this.#load()).showInDock;
   }
 
   /**
@@ -352,6 +370,25 @@ export class SettingsStore {
   }
 
   /**
+   * Remembers whether Luke stands in the Dock. A preference like the menu
+   * bar's, and held to the same rule: nothing here touches the cipher.
+   */
+  async setShowInDock(show: boolean): Promise<SettingsUpdateResult> {
+    await this.#serialize(async () => {
+      const persisted = await this.#load();
+      if (persisted.showInDock === show) return;
+      const next: PersistedSettings = {
+        ...persisted,
+        version: SETTINGS_FILE_VERSION,
+        showInDock: show,
+      };
+      await this.#write(next);
+      this.#loading = Promise.resolve(next);
+    });
+    return { settings: await this.snapshot() };
+  }
+
+  /**
    * Runs one settings change at a time. Serializing only the file write is not
    * enough: a user with more than one provider row can start a second save
    * before the first lands, and both would read the same stored keys before
@@ -439,6 +476,7 @@ export class SettingsStore {
     let persisted: PersistedSettings = {
       version: SETTINGS_FILE_VERSION,
       apiKeys: {},
+      showInDock: false,
       showInMenuBar: true,
       voiceCaptions: false,
     };

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -53,6 +53,12 @@ export interface AppSettings {
    */
   secretStorage: SecretStorage;
   /**
+   * Whether Luke stands in the Dock as well as at the notch. Off by default:
+   * an accessory app is what Luke ships as, so an icon among the user's apps
+   * is opted into rather than discovered.
+   */
+  showInDock: boolean;
+  /**
    * Whether Luke stands in the menu bar as well as at the notch. Hiding the
    * status item costs nothing it alone provides — Settings and Quit are both in
    * the panel — so the choice is the user's to make and to keep.
@@ -184,6 +190,8 @@ export interface AppBridge {
   openProviderApiKeys(providerId: CredentialProviderId): void;
   /** Shows or hides the menu bar status item, and remembers the choice. */
   setShowInMenuBar(show: boolean): Promise<SettingsUpdateResult>;
+  /** Shows or hides the Dock icon, and remembers the choice. */
+  setShowInDock(show: boolean): Promise<SettingsUpdateResult>;
   /** Turns the on-screen caption of Luke's speech on or off. */
   setVoiceCaptions(enabled: boolean): Promise<SettingsUpdateResult>;
   /**
@@ -242,6 +250,7 @@ export const channels = {
   setVoiceCaptions: "app:set-voice-captions",
   openProviderApiKeys: "app:open-provider-api-keys",
   setShowInMenuBar: "app:set-show-in-menu-bar",
+  setShowInDock: "app:set-show-in-dock",
   openSession: "app:open-session",
   sendSessionMessage: "app:send-session-message",
   executeSessionControl: "app:execute-session-control",

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -293,8 +293,9 @@ test("keeps both keys when two providers are saved at once", async (t) => {
       [FIRST_CLOUD]: sealed("first-cloud-key"),
       [SECOND_CLOUD]: sealed("second-cloud-key"),
     },
-    // Written even at its default, so the file states what it is rather than
-    // leaving it to be inferred from an absence.
+    // Written even at their defaults, so the file states what they are rather
+    // than leaving them to be inferred from an absence.
+    showInDock: false,
     showInMenuBar: true,
     voiceCaptions: false,
   });
@@ -492,6 +493,7 @@ test("keeps a Conductor key stored by an earlier version working", async (t) => 
   assert.deepEqual(persisted, {
     version: 2,
     apiKeys: { [CONDUCTOR]: sealed("conductor-replacement-key") },
+    showInDock: false,
     showInMenuBar: true,
     voiceCaptions: false,
   });
@@ -512,6 +514,7 @@ test("carries a key belonging to a provider this build does not know", async (t)
   assert.deepEqual(persisted, {
     version: 2,
     apiKeys: { "later-cloud": sealed("later-cloud-key"), [CONDUCTOR]: sealed(TEST_API_KEY) },
+    showInDock: false,
     showInMenuBar: true,
     voiceCaptions: false,
   });
@@ -530,6 +533,7 @@ test("shows the menu bar item until asked otherwise, and remembers the answer", 
   assert.deepEqual(JSON.parse(await readSettingsFile(directory)), {
     version: 2,
     apiKeys: {},
+    showInDock: false,
     showInMenuBar: false,
     voiceCaptions: false,
   });
@@ -594,6 +598,71 @@ test("shows the menu bar item when the file says something a boolean is not", as
   );
 
   assert.equal((await storeIn(directory).snapshot()).showInMenuBar, true);
+});
+
+test("keeps Luke out of the Dock until asked, and remembers the answer", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+
+  assert.equal((await store.snapshot()).showInDock, false);
+
+  const { settings, reason } = await store.setShowInDock(true);
+
+  assert.equal(reason, undefined);
+  assert.equal(settings.showInDock, true);
+  assert.deepEqual(JSON.parse(await readSettingsFile(directory)), {
+    version: 2,
+    apiKeys: {},
+    showInDock: true,
+    showInMenuBar: true,
+    voiceCaptions: false,
+  });
+  // The choice outlives the run that heard it.
+  assert.equal((await storeIn(directory).snapshot()).showInDock, true);
+});
+
+test("changes the Dock preference without touching the cipher", async (t) => {
+  // A preference is not a credential, so storing one must never be the reason
+  // the Keychain dialog appears.
+  const directory = await temporaryDirectory(t);
+  const cipher = countingCipher();
+  const store = storeIn(directory, { cipher });
+
+  const { settings } = await store.setShowInDock(true);
+
+  assert.equal(settings.showInDock, true);
+  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
+  assert.equal(settings.secretStorage, SECRET_STORAGE.UNKNOWN);
+});
+
+test("decides the Dock icon from the file alone, never the keychain", async (t) => {
+  // The icon is drawn at launch from this answer, so a locked or slow
+  // Keychain — which decrypting a stored key can wait on — must not be able to
+  // delay it.
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({
+      version: 2,
+      apiKeys: { [CONDUCTOR]: sealed(TEST_API_KEY) },
+      showInDock: true,
+    }),
+  );
+  const cipher = countingCipher();
+  const store = storeIn(directory, { cipher });
+
+  assert.equal(await store.showInDock(), true);
+  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
+});
+
+test("keeps Luke out of the Dock when the file says something a boolean is not", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({ version: 2, apiKeys: {}, showInDock: "always" }),
+  );
+
+  assert.equal((await storeIn(directory).snapshot()).showInDock, false);
 });
 
 test("reports the default voice until one is chosen", async (t) => {


### PR DESCRIPTION
## What

Luke ships as an accessory app — `LSUIElement` in the bundle, `setActivationPolicy("accessory")` at launch — so he has never stood in the Dock. This adds the choice: **Show Luke in the Dock**, a switch under Preferences beside the menu bar's, off by default.

The preference travels the same road as `showInMenuBar` end-to-end:

- `settings-store.ts` — a `showInDock` field in the settings file, written through the same serialized mutation queue. Like captions it is off unless the file says `true` outright, so an older file, a missing field, and a corrupt value all land on the accessory app Luke ships as. A shallow `showInDock()` reader answers from the file alone, never the keychain.
- `main.ts` — `applyDockVisibility()` beside `applyMenuBarVisibility()`, calling `app.dock.show()/hide()` so the toggle acts at once rather than on the next launch. Either direction transforms the process type, which can deactivate the app, so an expanded panel is re-focused after the change. At launch the icon is asserted only when the file says so; a file that cannot be read leaves Luke out of the Dock.
- Contracts, preload, and renderer — `AppSettings.showInDock`, a `setShowInDock` bridge method over its own channel, and a third switch row in `PreferencesSection` with its own busy state, sharing the section's rejection line.

## What doesn't change

- The default: a fresh install and every existing settings file stay out of the Dock.
- The menu bar item, the tray menu, and the panel's behavior — the Dock icon is a second door like the status item; nothing rides on it.
- Read-only observation: this is app chrome, not a session write path.

## Validation

- `./scripts/check.sh` — passes (lint, typecheck, 420 desktop tests, builds), exit 0. Four new settings-store tests cover the default, persistence, cipher isolation, and corrupt-value handling.
- UI change, so CI's `./scripts/verify.sh` on macOS is the completion invariant; evidence is linked from this description by CI. No physical-notch check was performed (working from a cloud workspace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/afe54eee-4e57-4268-861f-8a52d045347a)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31769191525/artifacts/9207483881) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31769191525)

- Commit: `eb76a35c077d8e192fb250c4bab0f4ca9bbebb9b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
