### PR TITLE
feat(voice): let the user choose how fast Luke talks

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ control.
 | `OPENAI_BASE_URL` | `https://api.openai.com/v1` | Selects the Responses-compatible endpoint |
 | `LUKE_REALTIME_MODEL` | `gpt-realtime-2.1` | Selects the conversation model |
 | `LUKE_REALTIME_VOICE` | `cedar` | Selects the spoken voice until one is chosen in Settings · Preferences |
+| `LUKE_REALTIME_SPEED` | `1` | Selects the speaking pace (`0.75`, `1`, `1.25`, or `1.5`) until one is chosen in Settings · Preferences |
 
 Changing `OPENAI_BASE_URL` sends attention-review data to that endpoint instead
 of OpenAI. It does not redirect the conversation, which always uses OpenAI's own

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -9,6 +9,7 @@ import {
   isControllableAdapter,
   isMessageCapableAdapter,
   isRealtimeVoice,
+  isRealtimeVoiceSpeed,
   type NativeNotchGeometry,
   PROVIDER_CONTROL_RESULT_STATUS,
   PROVIDER_MESSAGE_RESULT_STATUS,
@@ -455,7 +456,9 @@ function isSessionIdentity(value: unknown): value is SessionIdentity {
 function reportVoiceAvailability(): void {
   const report = realtimeCredentials?.diagnostics() ?? unavailableRealtimeDiagnostics(fixtureMode);
   if (realtimeCredentials) {
-    process.stderr.write(`Luke voice: enabled (model ${report.model}, voice ${report.voice})\n`);
+    process.stderr.write(
+      `Luke voice: enabled (model ${report.model}, voice ${report.voice}, speed ${report.speed}×)\n`,
+    );
     return;
   }
   process.stderr.write(
@@ -579,6 +582,27 @@ function registerIpc(): void {
         return {
           settings: await settingsStore.snapshot(),
           reason: "Could not save that voice on this system.",
+        };
+      }
+    },
+  );
+  // The pace travels the voice's road exactly: a value from the set fixed by
+  // this build, stored, and handed to the minter for the next conversation.
+  ipcMain.handle(
+    channels.setVoiceSpeed,
+    async (event, speed: unknown): Promise<SettingsUpdateResult> => {
+      if (!trustedSender(event)) throw new Error("Untrusted renderer");
+      if (!isRealtimeVoiceSpeed(speed)) throw new Error("Unknown voice speed");
+      try {
+        const result = await settingsStore.setVoiceSpeed(speed);
+        // The next credential is minted for the new pace; a conversation
+        // already open keeps the one it answered at.
+        if (!result.reason) realtimeCredentials?.setSpeed(speed);
+        return result;
+      } catch {
+        return {
+          settings: await settingsStore.snapshot(),
+          reason: "Could not save that speed on this system.",
         };
       }
     },
@@ -1018,6 +1042,9 @@ if (!app.requestSingleInstanceLock()) {
     // must not keep the panel, the hotkey, or observation from starting.
     const storedVoice = await settingsStore.readVoice().catch(() => undefined);
     if (storedVoice) realtimeCredentials?.setVoice(storedVoice);
+    // The chosen pace rides the same await, for the same reason.
+    const storedSpeed = await settingsStore.readVoiceSpeed().catch(() => undefined);
+    if (storedSpeed) realtimeCredentials?.setSpeed(storedSpeed);
     reportVoiceAvailability();
     // The report is not made here: the helper answers over its own stdout a
     // moment later, and a line printed now would state an absence that only

--- a/apps/desktop/src/openai-realtime-credentials.ts
+++ b/apps/desktop/src/openai-realtime-credentials.ts
@@ -1,5 +1,6 @@
 import {
   isRealtimeVoice,
+  isRealtimeVoiceSpeed,
   REALTIME_CALLS_PATH,
   REALTIME_CLIENT_SECRETS_PATH,
   REALTIME_DEFAULTS,
@@ -8,6 +9,7 @@ import {
   type RealtimeDiagnostics,
   type RealtimeMintOutcome,
   type RealtimeVoice,
+  type RealtimeVoiceSpeed,
   realtimeClientSecretRequest,
   realtimeCredentialFromResponse,
   realtimeCredentialIsUsable,
@@ -17,6 +19,7 @@ export const OPENAI_ENVIRONMENT = {
   API_KEY: "OPENAI_API_KEY",
   MODEL: "LUKE_REALTIME_MODEL",
   VOICE: "LUKE_REALTIME_VOICE",
+  SPEED: "LUKE_REALTIME_SPEED",
 } as const;
 
 const OPENAI_DEFAULTS = {
@@ -36,6 +39,7 @@ export interface OpenAiRealtimeCredentialOptions {
   apiKey: string;
   model?: string;
   voice?: string;
+  speed?: number;
   baseUrl?: string;
   fetch?: FetchLike;
   now?: () => number;
@@ -76,6 +80,20 @@ export function environmentRealtimeVoice(
   return isRealtimeVoice(value) ? value : undefined;
 }
 
+/** The launch environment's speaking pace, gated the same way as the voice. */
+export function environmentRealtimeSpeed(
+  environment: NodeJS.ProcessEnv = process.env,
+): RealtimeVoiceSpeed | undefined {
+  const value = environment[OPENAI_ENVIRONMENT.SPEED]?.trim();
+  if (!value) return undefined;
+  const speed = Number(value);
+  return isRealtimeVoiceSpeed(speed) ? speed : undefined;
+}
+
+function positiveSpeed(value: number | undefined): number | undefined {
+  return value !== undefined && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
 /**
  * Mints short-lived Realtime credentials from the standing OpenAI API key.
  *
@@ -91,6 +109,9 @@ export class OpenAiRealtimeCredentialMinter {
   /** The voice from construction, which a cleared setting falls back to. */
   readonly #configuredVoice: string;
   #voice: string;
+  /** The pace from construction, which a cleared setting falls back to. */
+  readonly #configuredSpeed: number;
+  #speed: number;
   readonly #baseUrl: string;
   readonly #fetch: FetchLike;
   readonly #now: () => number;
@@ -108,6 +129,8 @@ export class OpenAiRealtimeCredentialMinter {
     this.#model = trimmedText(options.model) ?? REALTIME_DEFAULTS.MODEL;
     this.#configuredVoice = trimmedText(options.voice) ?? REALTIME_DEFAULTS.VOICE;
     this.#voice = this.#configuredVoice;
+    this.#configuredSpeed = positiveSpeed(options.speed) ?? REALTIME_DEFAULTS.SPEED;
+    this.#speed = this.#configuredSpeed;
     this.#baseUrl = withoutTrailingSlash(trimmedText(options.baseUrl) ?? OPENAI_DEFAULTS.BASE_URL);
     this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
     this.#now = options.now ?? Date.now;
@@ -135,6 +158,18 @@ export class OpenAiRealtimeCredentialMinter {
     const next = trimmedText(voice) ?? this.#configuredVoice;
     if (next === this.#voice) return;
     this.#voice = next;
+    this.#credential = undefined;
+  }
+
+  /**
+   * Changes the pace new credentials are minted for, under the same rule as
+   * the voice: the outstanding credential is discarded, and a call already
+   * open keeps the pace it answered at.
+   */
+  setSpeed(speed: number | undefined): void {
+    const next = positiveSpeed(speed) ?? this.#configuredSpeed;
+    if (next === this.#speed) return;
+    this.#speed = next;
     this.#credential = undefined;
   }
 
@@ -195,6 +230,7 @@ export class OpenAiRealtimeCredentialMinter {
       fixtureMode: false,
       model: this.#model,
       voice: this.#voice,
+      speed: this.#speed,
       endpoint: `${this.#baseUrl}${REALTIME_CLIENT_SECRETS_PATH}`,
       lastOutcome: this.#lastOutcome,
       ...(this.#lastDetail ? { lastDetail: this.#lastDetail } : {}),
@@ -211,7 +247,11 @@ export class OpenAiRealtimeCredentialMinter {
           "content-type": "application/json",
         },
         body: JSON.stringify(
-          realtimeClientSecretRequest({ model: this.#model, voice: this.#voice }),
+          realtimeClientSecretRequest({
+            model: this.#model,
+            voice: this.#voice,
+            speed: this.#speed,
+          }),
         ),
         signal: AbortSignal.timeout(this.#requestTimeoutMs),
       });
@@ -259,6 +299,7 @@ export function unavailableRealtimeDiagnostics(fixtureMode: boolean): RealtimeDi
     fixtureMode,
     model: trimmedText(process.env[OPENAI_ENVIRONMENT.MODEL]) ?? REALTIME_DEFAULTS.MODEL,
     voice: environmentRealtimeVoice() ?? REALTIME_DEFAULTS.VOICE,
+    speed: environmentRealtimeSpeed() ?? REALTIME_DEFAULTS.SPEED,
     endpoint: `${OPENAI_DEFAULTS.BASE_URL}${REALTIME_CLIENT_SECRETS_PATH}`,
     lastOutcome: fixtureMode
       ? REALTIME_MINT_OUTCOME.DISABLED_BY_FIXTURE
@@ -274,11 +315,13 @@ export function openAiRealtimeCredentialsFromEnvironment(
 
   const model = trimmedText(options.model) ?? trimmedText(process.env[OPENAI_ENVIRONMENT.MODEL]);
   const voice = trimmedText(options.voice) ?? environmentRealtimeVoice();
+  const speed = positiveSpeed(options.speed) ?? environmentRealtimeSpeed();
 
   return new OpenAiRealtimeCredentialMinter({
     ...options,
     apiKey,
     ...(model ? { model } : {}),
     ...(voice ? { voice } : {}),
+    ...(speed ? { speed } : {}),
   });
 }

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -5,6 +5,7 @@ import type {
   ProviderMessageResult,
   RealtimeConnection,
   RealtimeVoice,
+  RealtimeVoiceSpeed,
   SessionIdentity,
 } from "@sidecar/core";
 import { contextBridge, ipcRenderer } from "electron";
@@ -39,6 +40,8 @@ const bridge: AppBridge = {
     ) as Promise<SettingsUpdateResult>,
   setVoice: (voice: RealtimeVoice) =>
     ipcRenderer.invoke(channels.setVoice, voice) as Promise<SettingsUpdateResult>,
+  setVoiceSpeed: (speed: RealtimeVoiceSpeed) =>
+    ipcRenderer.invoke(channels.setVoiceSpeed, speed) as Promise<SettingsUpdateResult>,
   openProviderApiKeys: (providerId: CredentialProviderId) => {
     ipcRenderer.send(channels.openProviderApiKeys, providerId);
   },

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -4,6 +4,7 @@ import {
   REALTIME_STATUS,
   type RealtimeStatus,
   type RealtimeVoice,
+  type RealtimeVoiceSpeed,
   type SessionIdentity,
   VOICE_CAPTION_MAX_HEIGHT,
 } from "@sidecar/core";
@@ -710,6 +711,11 @@ export function App(): React.JSX.Element {
     void window.sidecar.setVoice(voice).then((result) => setSettings(result.settings));
   }, []);
 
+  // The pace, under the same rule as the voice above.
+  const changeVoiceSpeed = useCallback((speed: RealtimeVoiceSpeed) => {
+    void window.sidecar.setVoiceSpeed(speed).then((result) => setSettings(result.settings));
+  }, []);
+
   /**
    * Sends a session to its provider and gets out of the way. Luke floats above
    * every window, so a panel left open would be sitting on top of the very chat
@@ -1111,6 +1117,7 @@ export function App(): React.JSX.Element {
               onVoiceCaptionsChange: changeVoiceCaptions,
               credentials,
               onVoiceChange: changeVoice,
+              onVoiceSpeedChange: changeVoiceSpeed,
               panelOpen,
               ...(shownHotkey.hotkey ? { voiceHotkey: shownHotkey.hotkey } : {}),
               voiceHotkeyHeld: shownHotkey.held,

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -1,8 +1,11 @@
 import {
   isRealtimeVoice,
+  isRealtimeVoiceSpeed,
   REALTIME_DEFAULTS,
   REALTIME_VOICE_LIST,
+  REALTIME_VOICE_SPEED_LIST,
   type RealtimeVoice,
+  type RealtimeVoiceSpeed,
 } from "@sidecar/core";
 import { useEffect, useRef, useState } from "react";
 import type { AppSettings, CredentialSource, MicrophoneStatus } from "../shared/contracts";
@@ -59,6 +62,8 @@ export interface SettingsPanelProps {
   credentials: CredentialEntryControl;
   /** Chooses the voice Luke speaks with, from the set fixed by this build. */
   onVoiceChange: (voice: RealtimeVoice) => void;
+  /** Chooses the pace Luke speaks at, from the set fixed by this build. */
+  onVoiceSpeedChange: (speed: RealtimeVoiceSpeed) => void;
   /**
    * True while the panel is the shape on screen. A field can only hold the
    * caret then: everything here sits in an inert stage the rest of the time,
@@ -447,6 +452,13 @@ function voiceOptionLabel(voice: RealtimeVoice): string {
   return voice === REALTIME_DEFAULTS.VOICE ? `${name} (default)` : name;
 }
 
+/* A pace reads as a rate multiple, the way every player writes one. The
+   natural rate carries its status into the menu for the same reason the
+   default voice does. */
+function speedOptionLabel(speed: RealtimeVoiceSpeed): string {
+  return speed === REALTIME_DEFAULTS.SPEED ? `${speed}× (default)` : `${speed}×`;
+}
+
 /**
  * Every provider that can hold a key, one line each. A provider is listed
  * whether or not it has one, because the list is how you learn which services
@@ -505,6 +517,8 @@ function CredentialsSection({
 function PreferencesSection({
   voice,
   onVoiceChange,
+  speed,
+  onVoiceSpeedChange,
   captions,
   onVoiceCaptionsChange,
   shown,
@@ -512,6 +526,8 @@ function PreferencesSection({
 }: {
   voice: RealtimeVoice;
   onVoiceChange: (voice: RealtimeVoice) => void;
+  speed: RealtimeVoiceSpeed;
+  onVoiceSpeedChange: (speed: RealtimeVoiceSpeed) => void;
   captions: boolean;
   onVoiceCaptionsChange: (enabled: boolean) => Promise<string | undefined>;
   shown: boolean;
@@ -580,6 +596,40 @@ function PreferencesSection({
       </div>
       <div className="settings-row">
         <span className="settings-copy">
+          <strong>Speed</strong>
+          {/* The same promise as the voice's line, because it lands the same
+              way: minted into the next conversation, never a live one. */}
+          <small>How fast Luke talks, from the next conversation on.</small>
+        </span>
+        <span className="voice-select">
+          <select
+            aria-label="Speed"
+            value={speed}
+            onChange={(event) => {
+              // A select serializes its value to a string, so the number is
+              // read back out and held to the set fixed by this build.
+              const next = Number(event.target.value);
+              if (isRealtimeVoiceSpeed(next)) onVoiceSpeedChange(next);
+            }}
+            onFocus={() => {
+              // The panel can be showing without its window being key, and a
+              // menu opened then would drop its first choice.
+              window.sidecar.focusPanel();
+            }}
+          >
+            {REALTIME_VOICE_SPEED_LIST.map((candidate) => (
+              <option key={candidate} value={candidate}>
+                {speedOptionLabel(candidate)}
+              </option>
+            ))}
+          </select>
+          <span className="voice-select-badge" aria-hidden="true">
+            <PopUpIcon />
+          </span>
+        </span>
+      </div>
+      <div className="settings-row">
+        <span className="settings-copy">
           <strong>Captions</strong>
           {/* Off by default: the voice experience ships as sound, so the words
               are chosen rather than discovered. What is *not* kept is the one
@@ -629,6 +679,7 @@ export function SettingsPanel({
   onVoiceCaptionsChange,
   credentials,
   onVoiceChange,
+  onVoiceSpeedChange,
   panelOpen,
   onShowInMenuBarChange,
   onQuit,
@@ -647,6 +698,8 @@ export function SettingsPanel({
         <PreferencesSection
           voice={settings.voice}
           onVoiceChange={onVoiceChange}
+          speed={settings.voiceSpeed}
+          onVoiceSpeedChange={onVoiceSpeedChange}
           captions={settings.voiceCaptions}
           onVoiceCaptionsChange={onVoiceCaptionsChange}
           shown={settings.showInMenuBar}

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -1,7 +1,13 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { isRealtimeVoice, REALTIME_DEFAULTS, type RealtimeVoice } from "@sidecar/core";
-import { environmentRealtimeVoice } from "./openai-realtime-credentials";
+import {
+  isRealtimeVoice,
+  isRealtimeVoiceSpeed,
+  REALTIME_DEFAULTS,
+  type RealtimeVoice,
+  type RealtimeVoiceSpeed,
+} from "@sidecar/core";
+import { environmentRealtimeSpeed, environmentRealtimeVoice } from "./openai-realtime-credentials";
 import {
   type AppSettings,
   CREDENTIAL_SOURCE,
@@ -31,6 +37,7 @@ const SETTINGS_FIELD = {
   VERSION: "version",
   VOICE: "voice",
   VOICE_CAPTIONS: "voiceCaptions",
+  VOICE_SPEED: "voiceSpeed",
 } as const;
 
 const API_KEY_LENGTH = {
@@ -81,6 +88,11 @@ interface PersistedSettings {
    * than a credential, so it is stored plainly and never touches the cipher.
    */
   voice?: RealtimeVoice;
+  /**
+   * The pace the user chose for Luke's speech, absent until one has been.
+   * Stored plainly like the voice, and held to the same offered set.
+   */
+  voiceSpeed?: RealtimeVoiceSpeed;
   /**
    * Whether Luke's speech is captioned on screen. Off unless the file says
    * `true` outright, so a missing field, an older file, and a corrupt value
@@ -161,6 +173,7 @@ function parsePersistedSettings(source: string): PersistedSettings {
   const version = record[SETTINGS_FIELD.VERSION];
   const showInMenuBar = record[SETTINGS_FIELD.SHOW_IN_MENU_BAR];
   const voice = record[SETTINGS_FIELD.VOICE];
+  const voiceSpeed = record[SETTINGS_FIELD.VOICE_SPEED];
   return {
     version: typeof version === "number" ? version : SETTINGS_FILE_VERSION,
     apiKeys: storedApiKeys(record),
@@ -169,6 +182,8 @@ function parsePersistedSettings(source: string): PersistedSettings {
     // a credential it has a default to fall back to, and honouring an unknown
     // one would mint sessions the API refuses.
     ...(isRealtimeVoice(voice) ? { voice } : {}),
+    // A pace outside the offered set is dropped for the same reason.
+    ...(isRealtimeVoiceSpeed(voiceSpeed) ? { voiceSpeed } : {}),
     voiceCaptions: record[SETTINGS_FIELD.VOICE_CAPTIONS] === true,
   };
 }
@@ -217,6 +232,10 @@ export class SettingsStore {
         (await this.#load()).voice ??
         environmentRealtimeVoice(this.#environment) ??
         REALTIME_DEFAULTS.VOICE,
+      voiceSpeed:
+        (await this.#load()).voiceSpeed ??
+        environmentRealtimeSpeed(this.#environment) ??
+        REALTIME_DEFAULTS.SPEED,
       voiceCaptions: (await this.#load()).voiceCaptions,
     };
   }
@@ -250,6 +269,32 @@ export class SettingsStore {
       };
       if (voice) next.voice = voice;
       else delete next.voice;
+      await this.#write(next);
+      this.#loading = Promise.resolve(next);
+    });
+    return { settings: await this.snapshot() };
+  }
+
+  /**
+   * Main-process only, like the voice: the pace the user chose, for the minter
+   * at startup. Nothing chosen resolves to nothing — the minter already
+   * carries the environment's pace and the default.
+   */
+  async readVoiceSpeed(): Promise<RealtimeVoiceSpeed | undefined> {
+    return (await this.#load()).voiceSpeed;
+  }
+
+  /** Stores the chosen pace, or returns to the default when omitted. */
+  async setVoiceSpeed(speed: RealtimeVoiceSpeed | undefined): Promise<SettingsUpdateResult> {
+    await this.#serialize(async () => {
+      const persisted = await this.#load();
+      if (persisted.voiceSpeed === speed) return;
+      const next: PersistedSettings = {
+        ...persisted,
+        version: SETTINGS_FILE_VERSION,
+      };
+      if (speed) next.voiceSpeed = speed;
+      else delete next.voiceSpeed;
       await this.#write(next);
       this.#loading = Promise.resolve(next);
     });

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -6,6 +6,7 @@ import type {
   ProviderMessageResult,
   RealtimeConnection,
   RealtimeVoice,
+  RealtimeVoiceSpeed,
   Rectangle,
   ResolvedNotchGeometry,
   SessionIdentity,
@@ -64,6 +65,11 @@ export interface AppSettings {
    * marks the voice that would actually be heard, not just a stored value.
    */
   voice: RealtimeVoice;
+  /**
+   * The pace Luke speaks at, resolved the same way as the voice: the one the
+   * user chose, else the launch environment's, else the natural rate.
+   */
+  voiceSpeed: RealtimeVoiceSpeed;
   /**
    * Whether Luke's words are captioned on screen while he speaks. Off by
    * default: the voice experience ships as sound, and words drawn under the
@@ -177,6 +183,11 @@ export interface AppBridge {
    */
   setVoice(voice: RealtimeVoice): Promise<SettingsUpdateResult>;
   /**
+   * Chooses the pace Luke speaks at, from the set fixed by this build. It
+   * reaches the next conversation the same way the voice does.
+   */
+  setVoiceSpeed(speed: RealtimeVoiceSpeed): Promise<SettingsUpdateResult>;
+  /**
    * Opens a provider's own API-key page in the default browser. The renderer
    * names the provider, not the address, so the set of pages Luke can open is
    * fixed by this build.
@@ -239,6 +250,7 @@ export const channels = {
   openMicrophoneSettings: "app:open-microphone-settings",
   setProviderApiKey: "app:set-provider-api-key",
   setVoice: "app:set-voice",
+  setVoiceSpeed: "app:set-voice-speed",
   setVoiceCaptions: "app:set-voice-captions",
   openProviderApiKeys: "app:open-provider-api-keys",
   setShowInMenuBar: "app:set-show-in-menu-bar",

--- a/apps/desktop/tests/openai-realtime-credentials.test.ts
+++ b/apps/desktop/tests/openai-realtime-credentials.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { REALTIME_DEFAULTS, REALTIME_MINT_OUTCOME, REALTIME_VOICE } from "@sidecar/core";
+import {
+  REALTIME_DEFAULTS,
+  REALTIME_MINT_OUTCOME,
+  REALTIME_VOICE,
+  REALTIME_VOICE_SPEED,
+} from "@sidecar/core";
 import {
   OpenAiRealtimeCredentialMinter,
   openAiRealtimeCredentialsFromEnvironment,
@@ -63,11 +68,12 @@ test("minting posts the realtime session to the client-secrets endpoint", async 
   const body = JSON.parse(String(requests[0]?.init.body)) as {
     session: {
       model: string;
-      audio: { input: { turn_detection: unknown }; output: { voice: string } };
+      audio: { input: { turn_detection: unknown }; output: { voice: string; speed: number } };
     };
   };
   assert.equal(body.session.model, REALTIME_DEFAULTS.MODEL);
   assert.equal(body.session.audio.output.voice, REALTIME_DEFAULTS.VOICE);
+  assert.equal(body.session.audio.output.speed, REALTIME_DEFAULTS.SPEED);
   assert.equal(body.session.audio.input.turn_detection, null);
 });
 
@@ -135,6 +141,42 @@ test("clearing the voice returns to the one the minter was built with", () => {
   assert.equal(instance.diagnostics().voice, REALTIME_DEFAULTS.VOICE);
 });
 
+test("changing the pace discards the outstanding credential and mints for the new one", async () => {
+  const { minter: instance, requests } = minter([mintResponse(), mintResponse()]);
+  await instance.mint();
+
+  instance.setSpeed(REALTIME_VOICE_SPEED.FAST);
+  await instance.mint();
+
+  // The first credential was minted at the old pace, so serving it after the
+  // change would answer the next conversation at the wrong one.
+  assert.equal(requests.length, 2);
+  const body = JSON.parse(String(requests[1]?.init.body)) as {
+    session: { audio: { output: { speed: number } } };
+  };
+  assert.equal(body.session.audio.output.speed, REALTIME_VOICE_SPEED.FAST);
+  assert.equal(instance.diagnostics().speed, REALTIME_VOICE_SPEED.FAST);
+});
+
+test("the same pace again keeps the outstanding credential", async () => {
+  const { minter: instance, requests } = minter([mintResponse(), mintResponse()]);
+  await instance.mint();
+
+  instance.setSpeed(REALTIME_DEFAULTS.SPEED);
+  await instance.mint();
+
+  assert.equal(requests.length, 1);
+});
+
+test("clearing the pace returns to the one the minter was built with", () => {
+  const { minter: instance } = minter([mintResponse()]);
+
+  instance.setSpeed(REALTIME_VOICE_SPEED.FAST);
+  instance.setSpeed(undefined);
+
+  assert.equal(instance.diagnostics().speed, REALTIME_DEFAULTS.SPEED);
+});
+
 test("every failure path leaves the voice experience unavailable", async () => {
   for (const response of [
     new Response("", { status: 401 }),
@@ -197,6 +239,35 @@ test("the model and voice come from the environment when set", () => {
       ["OPENAI_API_KEY", previous.key],
       ["LUKE_REALTIME_MODEL", previous.model],
       ["LUKE_REALTIME_VOICE", previous.voice],
+    ] as const) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
+});
+
+test("the pace comes from the environment when set, and an unoffered one is refused", () => {
+  const previous = { key: process.env.OPENAI_API_KEY, speed: process.env.LUKE_REALTIME_SPEED };
+  try {
+    process.env.OPENAI_API_KEY = API_KEY;
+    process.env.LUKE_REALTIME_SPEED = String(REALTIME_VOICE_SPEED.QUICK);
+    assert.equal(
+      openAiRealtimeCredentialsFromEnvironment()?.diagnostics().speed,
+      REALTIME_VOICE_SPEED.QUICK,
+    );
+
+    // The settings snapshot already refuses it, so honouring it here would
+    // have the panel mark the default while minting at something else.
+    process.env.LUKE_REALTIME_SPEED = "3";
+    assert.equal(
+      openAiRealtimeCredentialsFromEnvironment()?.diagnostics().speed,
+      REALTIME_DEFAULTS.SPEED,
+    );
+    assert.equal(unavailableRealtimeDiagnostics(true).speed, REALTIME_DEFAULTS.SPEED);
+  } finally {
+    for (const [name, value] of [
+      ["OPENAI_API_KEY", previous.key],
+      ["LUKE_REALTIME_SPEED", previous.speed],
     ] as const) {
       if (value === undefined) delete process.env[name];
       else process.env[name] = value;

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test, { type TestContext } from "node:test";
-import { REALTIME_DEFAULTS, REALTIME_VOICE } from "@sidecar/core";
+import { REALTIME_DEFAULTS, REALTIME_VOICE, REALTIME_VOICE_SPEED } from "@sidecar/core";
 import { type SecretCipher, SettingsStore } from "../src/settings-store";
 import { CREDENTIAL_SOURCE, SECRET_STORAGE } from "../src/shared/contracts";
 import {
@@ -647,6 +647,57 @@ test("ignores a stored or environment voice this build does not offer", async (t
 
   assert.equal(await store.readVoice(), undefined);
   assert.equal((await store.snapshot()).voice, REALTIME_DEFAULTS.VOICE);
+});
+
+test("reports the natural pace until one is chosen", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+
+  assert.equal((await store.snapshot()).voiceSpeed, REALTIME_DEFAULTS.SPEED);
+  assert.equal(await store.readVoiceSpeed(), undefined);
+});
+
+test("stores the chosen pace plainly and reads it back from a new store instance", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const cipher = countingCipher();
+  const store = storeIn(directory, { cipher });
+
+  const { settings, reason } = await store.setVoiceSpeed(REALTIME_VOICE_SPEED.QUICK);
+
+  assert.equal(reason, undefined);
+  assert.equal(settings.voiceSpeed, REALTIME_VOICE_SPEED.QUICK);
+  // A preference is not a credential, so choosing one never reaches the
+  // Keychain — and never raises its permission dialog.
+  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
+  assert.equal(await storeIn(directory).readVoiceSpeed(), REALTIME_VOICE_SPEED.QUICK);
+});
+
+test("prefers the chosen pace over the environment, and the environment over the default", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory, {
+    environment: { LUKE_REALTIME_SPEED: String(REALTIME_VOICE_SPEED.SLOW) },
+  });
+
+  assert.equal((await store.snapshot()).voiceSpeed, REALTIME_VOICE_SPEED.SLOW);
+  assert.equal(await store.readVoiceSpeed(), undefined);
+
+  await store.setVoiceSpeed(REALTIME_VOICE_SPEED.FAST);
+  assert.equal((await store.snapshot()).voiceSpeed, REALTIME_VOICE_SPEED.FAST);
+
+  await store.setVoiceSpeed(undefined);
+  assert.equal((await store.snapshot()).voiceSpeed, REALTIME_VOICE_SPEED.SLOW);
+});
+
+test("ignores a stored or environment pace this build does not offer", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({ version: 2, apiKeys: {}, voiceSpeed: 3 }),
+  );
+  const store = storeIn(directory, { environment: { LUKE_REALTIME_SPEED: "0.1" } });
+
+  assert.equal(await store.readVoiceSpeed(), undefined);
+  assert.equal((await store.snapshot()).voiceSpeed, REALTIME_DEFAULTS.SPEED);
 });
 
 test("the voice and a stored key survive each other's writes", async (t) => {

--- a/packages/sidecar-core/src/realtime.ts
+++ b/packages/sidecar-core/src/realtime.ts
@@ -41,9 +41,35 @@ export function isRealtimeVoice(value: unknown): value is RealtimeVoice {
   return typeof value === "string" && REALTIME_VOICE_LIST.includes(value as RealtimeVoice);
 }
 
+/**
+ * Every pace Luke can speak at, as a multiple of the voice's natural rate.
+ * The API accepts anything from 0.25 to 1.5; the offered steps are the ones
+ * that stay intelligible, spaced widely enough to be told apart by ear.
+ */
+export const REALTIME_VOICE_SPEED = {
+  SLOW: 0.75,
+  NORMAL: 1,
+  QUICK: 1.25,
+  FAST: 1.5,
+} as const;
+
+export type RealtimeVoiceSpeed = (typeof REALTIME_VOICE_SPEED)[keyof typeof REALTIME_VOICE_SPEED];
+
+/** Settings offers the speeds in this order, slowest to fastest. */
+export const REALTIME_VOICE_SPEED_LIST: readonly RealtimeVoiceSpeed[] =
+  Object.values(REALTIME_VOICE_SPEED);
+
+/** Guards a speed arriving from storage or IPC. */
+export function isRealtimeVoiceSpeed(value: unknown): value is RealtimeVoiceSpeed {
+  return (
+    typeof value === "number" && REALTIME_VOICE_SPEED_LIST.includes(value as RealtimeVoiceSpeed)
+  );
+}
+
 export const REALTIME_DEFAULTS = {
   MODEL: "gpt-realtime-2.1",
   VOICE: REALTIME_VOICE.CEDAR,
+  SPEED: REALTIME_VOICE_SPEED.NORMAL,
 } as const;
 
 /** The Realtime session shape and the endpoints that mint and open a call. */
@@ -141,6 +167,8 @@ export interface RealtimeConnection extends RealtimeCredential {
 export interface RealtimeSessionOptions {
   model?: string;
   voice?: string;
+  /** A multiple of the voice's natural rate, within the API's 0.25–1.5. */
+  speed?: number;
   instructions?: string;
 }
 
@@ -284,6 +312,12 @@ export function realtimeSessionConfig(options: RealtimeSessionOptions = {}) {
       },
       output: {
         voice: trimmedText(options.voice) ?? REALTIME_DEFAULTS.VOICE,
+        // A pace that is not a usable number falls back rather than minting a
+        // session the API would refuse, the same posture as an unknown voice.
+        speed:
+          options.speed !== undefined && Number.isFinite(options.speed) && options.speed > 0
+            ? options.speed
+            : REALTIME_DEFAULTS.SPEED,
       },
     },
   };
@@ -362,6 +396,8 @@ export interface RealtimeDiagnostics {
   fixtureMode: boolean;
   model: string;
   voice: string;
+  /** The pace new credentials would be minted for, as a rate multiple. */
+  speed: number;
   endpoint: string;
   lastOutcome: RealtimeMintOutcome;
   /** A status code or error name; never a request body or credential. */

--- a/packages/sidecar-core/tests/realtime.test.ts
+++ b/packages/sidecar-core/tests/realtime.test.ts
@@ -11,6 +11,7 @@ import {
   functionCallFollowUpEvents,
   functionCallOutputEvents,
   isRealtimeVoice,
+  isRealtimeVoiceSpeed,
   maximumVoiceContextSessions,
   normalizeSession,
   proactiveSpeechEvents,
@@ -21,6 +22,7 @@ import {
   REALTIME_SESSION_TYPE,
   REALTIME_TOOL,
   REALTIME_VOICE_LIST,
+  REALTIME_VOICE_SPEED_LIST,
   realtimeClientSecretRequest,
   realtimeCredentialFromResponse,
   realtimeCredentialIsUsable,
@@ -136,6 +138,26 @@ test("every offered voice is recognized and anything else is refused", () => {
   for (const voice of REALTIME_VOICE_LIST) assert.equal(isRealtimeVoice(voice), true);
   for (const value of ["baritone", "", "  cedar  ", undefined, null, 3]) {
     assert.equal(isRealtimeVoice(value), false);
+  }
+});
+
+test("the session is minted at the voice's natural pace unless asked otherwise", () => {
+  assert.equal(REALTIME_DEFAULTS.SPEED, 1);
+  assert.equal(realtimeSessionConfig().audio.output.speed, 1);
+  assert.equal(realtimeSessionConfig({ speed: 1.25 }).audio.output.speed, 1.25);
+});
+
+test("a pace that is not a usable number falls back rather than minting a refusal", () => {
+  for (const speed of [Number.NaN, Number.POSITIVE_INFINITY, 0, -1]) {
+    assert.equal(realtimeSessionConfig({ speed }).audio.output.speed, REALTIME_DEFAULTS.SPEED);
+  }
+});
+
+test("every offered pace is recognized and anything else is refused", () => {
+  assert.equal(isRealtimeVoiceSpeed(REALTIME_DEFAULTS.SPEED), true);
+  for (const speed of REALTIME_VOICE_SPEED_LIST) assert.equal(isRealtimeVoiceSpeed(speed), true);
+  for (const value of [0.5, 2, 0, -1, "1", "", undefined, null]) {
+    assert.equal(isRealtimeVoiceSpeed(value), false);
   }
 });
 


### PR DESCRIPTION
## What

The Realtime API speaks at a configurable pace (`audio.output.speed`, 0.25–1.5 of the voice's natural rate), so Settings · Preferences gains a **Speed** row under Voice, offered as the same pop-up as the voice itself: 0.75×, 1× (default), 1.25×, and 1.5×.

The choice travels the voice setting's exact road: a `REALTIME_VOICE_SPEED` value set in sidecar-core with a guard held at every boundary (settings file, environment, IPC), stored plainly in `settings.json`, resolved chosen → environment (`LUKE_REALTIME_SPEED`, documented in the README) → default, and handed to the credential minter — which discards its outstanding credential so the next conversation is minted at the new pace, while a call already open keeps the pace it answered at. The startup diagnostics line now reports the pace beside the model and voice.

## What doesn't change

- Anything mid-call: like the voice, a change lands on the next conversation, and the row's caption says so.
- A stored or environment pace outside the offered set is dropped for the default rather than minting a session the API refuses — the same posture as an unknown voice.
- Choosing a pace never touches the cipher or the Keychain.

## Validation

- `./scripts/check.sh` — passes (lint, typecheck, 527 tests, builds), exit 0. Coverage mirrors the voice's: session config defaults and fallback, guard behavior, credential discard/reuse on pace change, environment resolution, and settings persistence.
- UI change, so CI's `./scripts/verify.sh` on macOS is the completion invariant; evidence is linked from this description by CI. No physical-notch check was performed (working from a cloud workspace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31769589788/artifacts/9207632318) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31769589788)

- Commit: `656b3460748f0393d82570ab46c71db6c652929f`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c37b205a-53b0-4b2a-b3e8-17a80768b809)
