### PR TITLE
feat(voice): let the talk shortcut be changed, with reset to default

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ One key runs it, and it answers from whatever app is frontmost:
 
 If another app already owns `⌥Space`, Luke falls back to `⌥S`. Settings shows
 which key you actually have, under **Keyboard shortcuts** — and the pencil
-beside it records a chord of your own: hold any of `⌃⌥⇧⌘` and press a letter
-or Space, as the row itself explains while it listens. The change takes effect
+beside it records a chord of your own: hold `⌃`, `⌥` or `⌘` — `⇧` may join,
+but not carry a chord alone, since `⇧S` is how capitals are typed — and press
+a letter or Space, as the row itself explains while it listens. The change takes effect
 at once, the reset arrow beside it returns the defaults, and if something else
 owns your chord Luke falls back to the defaults and shows the key that
 actually answered.

--- a/README.md
+++ b/README.md
@@ -85,8 +85,12 @@ One key runs it, and it answers from whatever app is frontmost:
   frontmost window.
 
 If another app already owns `⌥Space`, Luke falls back to `⌥S`. Settings shows
-which key you actually have, under **Keyboard shortcuts**. It is not
-configurable yet.
+which key you actually have, under **Keyboard shortcuts** — and the pencil
+beside it records a chord of your own: hold any of `⌃⌥⇧⌘` and press a letter
+or Space, as the row itself explains while it listens. The change takes effect
+at once, the reset arrow beside it returns the defaults, and if something else
+owns your chord Luke falls back to the defaults and shows the key that
+actually answered.
 
 Holding is read by a small helper Luke ships beside the app, because Electron
 reports a global key being pressed but never released. The helper is told the

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -266,15 +266,19 @@ function reportVoiceHotkey(): void {
  * is running. The old key is let go of in full before the new one is asked
  * for, so the two can never race for the same chord — and letting everything
  * go is exact rather than broad, because the talk key candidates are the only
- * global accelerators Luke ever registers. The panel keeps showing the old
- * key until the new one actually answers: the helper announces its own
- * registration over stdout, and every path without a helper is decided by the
- * time `registerVoiceHotkey` returns.
+ * global accelerators Luke ever registers. Letting go means waiting: the
+ * system releases the old helper's chord when its process exits, not when the
+ * kill is asked for, and the defaults sit in both helpers' candidate lists —
+ * a successor that starts too early is refused the very fallback it was
+ * promised. The panel keeps showing the old key until the new one actually
+ * answers: the helper announces its own registration over stdout, and every
+ * path without a helper is decided by the time `registerVoiceHotkey` returns.
  */
-function applyVoiceHotkey(): void {
-  talkKeyWatcher?.stop();
+async function applyVoiceHotkey(): Promise<void> {
+  const released = talkKeyWatcher?.stop();
   talkKeyWatcher = undefined;
   globalShortcut.unregisterAll();
+  await released;
   voiceHotkey = undefined;
   voiceHotkeyHeld = true;
   voiceHotkeyAbsence = VOICE_HOTKEY_ABSENCE.ALREADY_OWNED;
@@ -703,7 +707,9 @@ function registerIpc(): void {
         const result = await settingsStore.setVoiceHotkey(chosen);
         if (!result.reason) {
           chosenVoiceHotkey = chosen;
-          applyVoiceHotkey();
+          // Awaited so the renderer's controls stay at rest until the swap has
+          // finished and the helper's own registration line can say the truth.
+          await applyVoiceHotkey();
         }
         return result;
       } catch {
@@ -1225,8 +1231,9 @@ if (!app.requestSingleInstanceLock()) {
 app.on("will-quit", () => {
   globalShortcut.unregisterAll();
   // The helper is a process of Luke's own, so it does not outlive the app that
-  // spawned it and leave a key registered against nothing.
-  talkKeyWatcher?.stop();
+  // spawned it and leave a key registered against nothing. Nothing succeeds it
+  // during quit, so its exit is not waited on.
+  void talkKeyWatcher?.stop();
   talkKeyWatcher = undefined;
 });
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -73,9 +73,10 @@ import {
   isCredentialProviderId,
 } from "./shared/credential-providers";
 import {
-  DEFAULT_VOICE_HOTKEYS,
+  parseVoiceHotkey,
   VOICE_HOTKEY_ABSENCE,
   type VoiceHotkeyAbsence,
+  voiceHotkeyCandidates,
   voiceHotkeyLabel,
   voiceHotkeyReport,
 } from "./shared/voice-hotkey";
@@ -165,6 +166,12 @@ const attentionReviewer = attentionEvaluator
 // does: evidence must be reproducible without a key and without a network.
 const realtimeCredentials = fixtureMode ? undefined : openAiRealtimeCredentialsFromEnvironment();
 let voiceHotkey: string | undefined;
+/**
+ * The chord the user chose over the defaults, if any. Read from the settings
+ * file before the key is first registered, and moved by the settings panel
+ * afterwards; the defaults stay behind it as fallbacks either way.
+ */
+let chosenVoiceHotkey: string | undefined;
 let talkKeyWatcher: TalkKeyWatcher | undefined;
 /**
  * Whether the key reports being let go of. The helper does and the Electron
@@ -213,7 +220,7 @@ function registerVoiceHotkey(): void {
       sendVoiceHotkey();
     },
   });
-  if (talkKeyWatcher.start(DEFAULT_VOICE_HOTKEYS)) return;
+  if (talkKeyWatcher.start(voiceHotkeyCandidates(chosenVoiceHotkey))) return;
   talkKeyWatcher = undefined;
   registerToggleHotkey();
   reportVoiceHotkey();
@@ -226,7 +233,7 @@ function registerVoiceHotkey(): void {
  * worth standing up rather than leaving the user with no key at all.
  */
 function registerToggleHotkey(): void {
-  for (const accelerator of DEFAULT_VOICE_HOTKEYS) {
+  for (const accelerator of voiceHotkeyCandidates(chosenVoiceHotkey)) {
     const registered = globalShortcut.register(accelerator, () => {
       panelWindow?.webContents.send(channels.voiceHotkeyPress);
       // A toggle has only the one edge, so it reports a release immediately and
@@ -252,6 +259,27 @@ function sendVoiceHotkey(): void {
 
 function reportVoiceHotkey(): void {
   process.stderr.write(`${voiceHotkeyReport(voiceHotkey, voiceHotkeyAbsence)}\n`);
+}
+
+/**
+ * Moves the talk key to whatever `chosenVoiceHotkey` now says, while the app
+ * is running. The old key is let go of in full before the new one is asked
+ * for, so the two can never race for the same chord — and letting everything
+ * go is exact rather than broad, because the talk key candidates are the only
+ * global accelerators Luke ever registers. The panel keeps showing the old
+ * key until the new one actually answers: the helper announces its own
+ * registration over stdout, and every path without a helper is decided by the
+ * time `registerVoiceHotkey` returns.
+ */
+function applyVoiceHotkey(): void {
+  talkKeyWatcher?.stop();
+  talkKeyWatcher = undefined;
+  globalShortcut.unregisterAll();
+  voiceHotkey = undefined;
+  voiceHotkeyHeld = true;
+  voiceHotkeyAbsence = VOICE_HOTKEY_ABSENCE.ALREADY_OWNED;
+  registerVoiceHotkey();
+  if (!talkKeyWatcher) sendVoiceHotkey();
 }
 
 let windowMode: WindowMode = captureMode
@@ -646,6 +674,44 @@ function registerIpc(): void {
         return {
           settings: await settingsStore.snapshot(),
           reason: "Could not save that setting on this system.",
+        };
+      }
+    },
+  );
+
+  // The talk key is the user's to move — a chord another tool already holds,
+  // or a hand that does not reach ⌥Space. What arrives is read through the
+  // same gate the stored value passes, so only a chord the registrars can
+  // actually take is ever stored; omitting one returns the defaults, making
+  // reset the absence of a choice rather than a second stored value. The new
+  // chord is registered at once — a shortcut that only moved on the next
+  // launch would read as a control that does nothing.
+  ipcMain.handle(
+    channels.setVoiceHotkey,
+    async (event, accelerator: unknown): Promise<SettingsUpdateResult> => {
+      if (!trustedSender(event)) throw new Error("Untrusted renderer");
+      if (accelerator !== undefined && typeof accelerator !== "string") {
+        throw new Error("Invalid shortcut request");
+      }
+      const chosen = accelerator === undefined ? undefined : parseVoiceHotkey(accelerator);
+      // The renderer records chords through the same reader, so one that does
+      // not parse is a malformed request rather than a choice to answer.
+      if (accelerator !== undefined && chosen === undefined) {
+        throw new Error("Invalid shortcut request");
+      }
+      try {
+        const result = await settingsStore.setVoiceHotkey(chosen);
+        if (!result.reason) {
+          chosenVoiceHotkey = chosen;
+          applyVoiceHotkey();
+        }
+        return result;
+      } catch {
+        // A filesystem failure is not something the user can act on, so it is
+        // reported as one line rather than as a raw system error.
+        return {
+          settings: await settingsStore.snapshot(),
+          reason: "Could not save that shortcut on this system.",
         };
       }
     },
@@ -1124,6 +1190,11 @@ if (!app.requestSingleInstanceLock()) {
     const storedSpeed = await settingsStore.readVoiceSpeed().catch(() => undefined);
     if (storedSpeed) realtimeCredentials?.setSpeed(storedSpeed);
     reportVoiceAvailability();
+    // Awaited for the same reason the voice is: the chosen chord has to be in
+    // hand before the key is registered, or the first registration would take
+    // the default away from the user who moved off it. A file that cannot be
+    // read means no choice was kept, and the defaults answer.
+    chosenVoiceHotkey = await settingsStore.readVoiceHotkey().catch(() => undefined);
     // The report is not made here: the helper answers over its own stdout a
     // moment later, and a line printed now would state an absence that only
     // exists because nobody has answered yet.

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -51,6 +51,8 @@ const bridge: AppBridge = {
     ipcRenderer.invoke(channels.setShowInDock, show) as Promise<SettingsUpdateResult>,
   setVoiceCaptions: (enabled: boolean) =>
     ipcRenderer.invoke(channels.setVoiceCaptions, enabled) as Promise<SettingsUpdateResult>,
+  setVoiceHotkey: (accelerator: string | undefined) =>
+    ipcRenderer.invoke(channels.setVoiceHotkey, accelerator) as Promise<SettingsUpdateResult>,
   openSession: (identity: SessionIdentity) =>
     ipcRenderer.invoke(channels.openSession, identity) as Promise<SessionOpenResult>,
   sendSessionMessage: (identity: SessionIdentity, text: string) =>

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -752,6 +752,27 @@ export function App(): React.JSX.Element {
   }, []);
 
   /**
+   * Moves the talk key, or resets it when no chord is named. The key the row
+   * shows is not taken from this reply — the main process announces the one
+   * that actually registered, the same way it always has — so the reply
+   * carries only the stored choice and any refusal.
+   */
+  const changeVoiceHotkey = useCallback(async (accelerator: string | undefined) => {
+    const result = await window.sidecar.setVoiceHotkey(accelerator);
+    setSettings(result.settings);
+    return result.reason;
+  }, []);
+
+  // True while the settings row is recording a chord. The talk key stays
+  // registered through a recording — the recording is how it gets replaced —
+  // so a press of the current chord landing then is held here rather than
+  // opening the microphone under the field being typed into.
+  const shortcutCapture = useRef(false);
+  const changeShortcutCapture = useCallback((capturing: boolean) => {
+    shortcutCapture.current = capturing;
+  }, []);
+
+  /**
    * Sends a session to its provider and gets out of the way. Luke floats above
    * every window, so a panel left open would be sitting on top of the very chat
    * it was just asked to bring forward — the same reason fetching a key stands
@@ -1065,8 +1086,20 @@ export function App(): React.JSX.Element {
   // The talk key is registered by the main process so it answers from any app,
   // which is the whole point: no window to find, nothing to focus first. Both
   // edges arrive, because a turn you hold ends when the key does.
-  useEffect(() => window.sidecar.onVoiceHotkeyPress(() => void beginTalk()), [beginTalk]);
-  useEffect(() => window.sidecar.onVoiceHotkeyRelease(() => endTalk()), [endTalk]);
+  useEffect(
+    () =>
+      window.sidecar.onVoiceHotkeyPress(() => {
+        if (!shortcutCapture.current) void beginTalk();
+      }),
+    [beginTalk],
+  );
+  useEffect(
+    () =>
+      window.sidecar.onVoiceHotkeyRelease(() => {
+        if (!shortcutCapture.current) endTalk();
+      }),
+    [endTalk],
+  );
   useEffect(() => window.sidecar.onVoiceHotkeyChanged(setVoiceHotkey), []);
 
   // The rows say how long ago each session was seen, and a label left alone
@@ -1213,6 +1246,8 @@ export function App(): React.JSX.Element {
               panelOpen,
               ...(shownHotkey.hotkey ? { voiceHotkey: shownHotkey.hotkey } : {}),
               voiceHotkeyHeld: shownHotkey.held,
+              onVoiceHotkeyChange: changeVoiceHotkey,
+              onShortcutCapture: changeShortcutCapture,
               onShowInMenuBarChange: changeShowInMenuBar,
               onShowInDockChange: changeShowInDock,
               onQuit: () => window.sidecar.quit(),

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1085,7 +1085,11 @@ export function App(): React.JSX.Element {
 
   // The talk key is registered by the main process so it answers from any app,
   // which is the whole point: no window to find, nothing to focus first. Both
-  // edges arrive, because a turn you hold ends when the key does.
+  // edges arrive, because a turn you hold ends when the key does. Only the
+  // press defers to a chord being recorded: the release always lands, so a
+  // hold opened before the recording began still ends when the key comes up
+  // rather than leaving the microphone open under the field — and a release
+  // whose press was held back finds nothing pressed and answers nothing.
   useEffect(
     () =>
       window.sidecar.onVoiceHotkeyPress(() => {
@@ -1093,13 +1097,7 @@ export function App(): React.JSX.Element {
       }),
     [beginTalk],
   );
-  useEffect(
-    () =>
-      window.sidecar.onVoiceHotkeyRelease(() => {
-        if (!shortcutCapture.current) endTalk();
-      }),
-    [endTalk],
-  );
+  useEffect(() => window.sidecar.onVoiceHotkeyRelease(endTalk), [endTalk]);
   useEffect(() => window.sidecar.onVoiceHotkeyChanged(setVoiceHotkey), []);
 
   // The rows say how long ago each session was seen, and a label left alone

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -125,6 +125,12 @@ const SETTING_GUIDE: Record<
     adjustable: true,
     manual: `${SETTINGS_TAB}, under Preferences`,
   }),
+  // Described in the talk-key fact instead, which carries the key that
+  // actually registered — this field is only the stored choice, absent on the
+  // defaults and silently outbid when another app owns the chord. Not spoken-
+  // changeable either way: a chord is recorded by typing it, so the fact says
+  // where.
+  voiceHotkey: () => undefined,
   // Not a switch but a set of keys, so it is described in the facts instead:
   // which providers are connected, and that a key is only ever typed by hand.
   credentialSources: () => undefined,
@@ -150,11 +156,12 @@ function talkKeyFact(hotkey: LukeGuideInput["hotkey"]): AppGuideFact {
         "None is registered right now — another app may own the shortcut. The Settings tab shows its state.",
     };
   }
+  const use = hotkey.held
+    ? "hold to talk, let go to send; tap instead to keep the turn open"
+    : "press to talk, again to send, again to interrupt";
   return {
     label: "Talk key",
-    detail: hotkey.held
-      ? `${hotkey.hotkey}, from any app: hold to talk, let go to send; tap instead to keep the turn open.`
-      : `${hotkey.hotkey}, from any app: press to talk, again to send, again to interrupt.`,
+    detail: `${hotkey.hotkey}, from any app: ${use}. A different chord can be recorded, or the default restored, in ${SETTINGS_TAB}.`,
   };
 }
 

--- a/apps/desktop/src/renderer/settings-icons.tsx
+++ b/apps/desktop/src/renderer/settings-icons.tsx
@@ -70,6 +70,26 @@ export function TrashIcon(): React.JSX.Element {
   );
 }
 
+/** An arrow turning back on itself: returns a setting to its default. */
+export function ResetIcon(): React.JSX.Element {
+  return (
+    <Glyph className="icon-button-glyph">
+      <path d="M2.5 5.1v5.2h5.2" />
+      <path d="M4.6 14.6a7.8 7.8 0 1 0 1.9-8.1L2.5 10.3" />
+    </Glyph>
+  );
+}
+
+/** Stands down without choosing: the cancel a control becomes mid-act. */
+export function CloseIcon(): React.JSX.Element {
+  return (
+    <Glyph className="icon-button-glyph">
+      <path d="M6.8 6.8 17.2 17.2" />
+      <path d="M17.2 6.8 6.8 17.2" />
+    </Glyph>
+  );
+}
+
 /** The up-and-down pair macOS badges a pop-up button with. */
 export function PopUpIcon(): React.JSX.Element {
   return (

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -721,7 +721,7 @@ function PreferencesSection({
 
 /* What a talk key may be: offered the moment recording starts, and restated
    in the error line for the keystroke that was not one. */
-const SHORTCUT_HINT = "Hold ⌃, ⌥, ⇧ or ⌘ and press a letter or Space.";
+const SHORTCUT_HINT = "Hold ⌃, ⌥ or ⌘ — ⇧ may join — and press a letter or Space.";
 
 /**
  * How Luke is reached rather than what he can see. The chord stays the plain

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -13,6 +13,12 @@ import { CREDENTIAL_SOURCE, SECRET_STORAGE } from "../shared/contracts";
 import type { CredentialProvider } from "../shared/credential-providers";
 import { CREDENTIAL_PROVIDER_LIST } from "../shared/credential-providers";
 import {
+  capturedVoiceHotkey,
+  DEFAULT_VOICE_HOTKEYS,
+  VOICE_HOTKEY_CAPTURE,
+  voiceHotkeyLabel,
+} from "../shared/voice-hotkey";
+import {
   CREDENTIAL_PLACEHOLDER,
   type CredentialEntryControl,
   entryForProvider,
@@ -32,6 +38,7 @@ import { PANEL_TAB, panelPanelId, panelTabId } from "./panel-tabs";
 import { CloudBadge, ProviderMark } from "./provider-marks";
 import {
   CheckIcon,
+  CloseIcon,
   ExternalIcon,
   KeyboardIcon,
   KeyIcon,
@@ -39,6 +46,7 @@ import {
   PopUpIcon,
   PowerIcon,
   PreferencesIcon,
+  ResetIcon,
   ShieldIcon,
   TrashIcon,
 } from "./settings-icons";
@@ -81,10 +89,21 @@ export interface SettingsPanelProps {
    */
   onShowInDockChange: (show: boolean) => Promise<string | undefined>;
   onQuit: () => void;
-  /** The talk key, shown so it can be learned. It is not editable yet. */
+  /** The talk key as registered, shown so it can be learned — and pressed to be changed. */
   voiceHotkey?: string;
   /** Whether that key can be held, which is what the row has to describe. */
   voiceHotkeyHeld: boolean;
+  /**
+   * Moves the talk key to a recorded chord, or back to the defaults when
+   * omitted. The store answers with why when it refuses, and the row is where
+   * that answer belongs.
+   */
+  onVoiceHotkeyChange: (accelerator: string | undefined) => Promise<string | undefined>;
+  /**
+   * Whether the recording control has the keyboard. While it does, the talk
+   * key must not open a turn: the chord arriving is an entry, not an ask.
+   */
+  onShortcutCapture: (capturing: boolean) => void;
 }
 
 /* What nothing else on the line can say on its own. A key kept here needs no
@@ -700,6 +719,163 @@ function PreferencesSection({
   );
 }
 
+/* What a talk key may be: offered the moment recording starts, and restated
+   in the error line for the keystroke that was not one. */
+const SHORTCUT_HINT = "Hold ⌃, ⌥, ⇧ or ⌘ and press a letter or Space.";
+
+/**
+ * How Luke is reached rather than what he can see. The chord stays the plain
+ * key chip it always was; the pencil beside it is the control. Pressing it
+ * starts a recording — what a chord may be is shown under the controls at
+ * once, the next whole chord is stored and registered at once, and Escape (or
+ * the pencil, now a cross) keeps the key that was already there. Recording
+ * happens in that focused button rather than anywhere global, so a keystroke
+ * can only become a shortcut while the user is visibly holding the control
+ * that asks for one.
+ *
+ * Reset stands beside the chip only while a chosen chord is stored and no
+ * recording is underway: until a chord is stored it could only offer to
+ * change nothing, and during a recording the chord it would return to is
+ * exactly what typing nothing already keeps. What the row shows is the
+ * key as registered, not as stored — the two differ when another app owns the
+ * chosen chord, and a row that showed the stored one would name a key that
+ * answers nothing.
+ */
+function ShortcutSection({
+  voiceHotkey,
+  voiceHotkeyHeld,
+  chosen,
+  onVoiceHotkeyChange,
+  onShortcutCapture,
+}: {
+  voiceHotkey?: string | undefined;
+  voiceHotkeyHeld: boolean;
+  /** Whether a chosen chord is stored, which is what Reset has to undo. */
+  chosen: boolean;
+  onVoiceHotkeyChange: (accelerator: string | undefined) => Promise<string | undefined>;
+  onShortcutCapture: (capturing: boolean) => void;
+}): React.JSX.Element {
+  const [recording, setRecording] = useState(false);
+  // The change is a round trip through the settings file and the system's
+  // registrar, so the controls rest until the store has answered rather than
+  // claiming a chord they may not get.
+  const [busy, setBusy] = useState(false);
+  const [rejection, setRejection] = useState<string>();
+
+  // The talk key stays registered while a chord is recorded — the recording
+  // ends by replacing it — so pressing the current chord mid-recording would
+  // open the microphone under the very field being typed into. The app is
+  // told when the field has the keyboard so it can hold that press, and the
+  // unmount arm covers the panel closing over an open recording.
+  useEffect(() => {
+    onShortcutCapture(recording);
+    return () => onShortcutCapture(false);
+  }, [recording, onShortcutCapture]);
+
+  const apply = async (accelerator: string | undefined) => {
+    setBusy(true);
+    setRejection(await onVoiceHotkeyChange(accelerator));
+    setBusy(false);
+  };
+
+  return (
+    <section className="settings-section" style={{ "--row-index": 2 } as React.CSSProperties}>
+      <h2>
+        <KeyboardIcon />
+        Keyboard shortcuts
+      </h2>
+      <div className="settings-row">
+        <span className="settings-copy">
+          <strong>Talk to Luke</strong>
+          {/* What the key actually does, which depends on whether it can
+              report being let go of. Describing a hold to someone whose key
+              can only toggle would leave them holding it and wondering. */}
+          <small>
+            {voiceHotkeyHeld
+              ? "Hold to talk, let go to send. Tap instead to keep it open."
+              : "Press to talk, again to send, again to interrupt."}
+          </small>
+        </span>
+        <span className="shortcut-controls">
+          <span className="settings-actions">
+            <span className="shortcut-key" data-recording={String(recording)}>
+              {recording ? "Type a shortcut…" : (voiceHotkey ?? "Unavailable")}
+            </span>
+            {chosen && !recording ? (
+              <button
+                type="button"
+                className="icon-button"
+                disabled={busy}
+                aria-label={`Reset the shortcut to ${voiceHotkeyLabel(DEFAULT_VOICE_HOTKEYS[0] ?? "")}`}
+                title={`Back to ${voiceHotkeyLabel(DEFAULT_VOICE_HOTKEYS[0] ?? "")}`}
+                onClick={() => void apply(undefined)}
+              >
+                <ResetIcon />
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className="icon-button"
+              disabled={busy}
+              aria-label={
+                recording
+                  ? "Type the new shortcut, or press Escape to keep this one"
+                  : "Change the shortcut for talking to Luke"
+              }
+              title={recording ? "Cancel" : "Change…"}
+              onClick={() => {
+                if (recording) {
+                  setRecording(false);
+                  return;
+                }
+                setRejection(undefined);
+                setRecording(true);
+              }}
+              onFocus={() => {
+                // The panel can be showing without its window being key, and a
+                // recording no keystroke can reach would read as a dead control.
+                window.sidecar.focusPanel();
+              }}
+              // Focus leaving takes the recording with it: whatever was pressed
+              // instead is its own act, not a half-formed chord left armed.
+              onBlur={() => setRecording(false)}
+              onKeyDown={(event) => {
+                // A key that repeats is being held through the chord, not
+                // pressed as one; only its first arrival is read.
+                if (!recording || event.repeat) return;
+                // Nothing typed here is typing: not a Space press on the button,
+                // and not the panel's own Escape-to-close behind it.
+                event.preventDefault();
+                event.stopPropagation();
+                if (event.key === "Escape") {
+                  setRecording(false);
+                  return;
+                }
+                const read = capturedVoiceHotkey(event);
+                if (read.outcome === VOICE_HOTKEY_CAPTURE.PENDING) return;
+                if (read.outcome === VOICE_HOTKEY_CAPTURE.REFUSED) {
+                  setRejection(SHORTCUT_HINT);
+                  return;
+                }
+                setRejection(undefined);
+                setRecording(false);
+                void apply(read.accelerator);
+              }}
+            >
+              {recording ? <CloseIcon /> : <PencilIcon />}
+            </button>
+          </span>
+          {rejection ? (
+            <p className="error-message">{rejection}</p>
+          ) : recording ? (
+            <p className="shortcut-hint">{SHORTCUT_HINT}</p>
+          ) : null}
+        </span>
+      </div>
+    </section>
+  );
+}
+
 export function SettingsPanel({
   microphoneStatus,
   microphoneError,
@@ -717,6 +893,8 @@ export function SettingsPanel({
   onQuit,
   voiceHotkey,
   voiceHotkeyHeld,
+  onVoiceHotkeyChange,
+  onShortcutCapture,
 }: SettingsPanelProps): React.JSX.Element {
   const microphone = microphoneAccessRow({ voiceAvailable, status: microphoneStatus });
   return (
@@ -741,29 +919,13 @@ export function SettingsPanel({
         />
       ) : null}
 
-      {/* How Luke is reached rather than what he can see. Shown rather than
-          offered: the key is fixed for now, and a control that cannot change
-          anything is worse than a plain statement of it. */}
-      <section className="settings-section" style={{ "--row-index": 2 } as React.CSSProperties}>
-        <h2>
-          <KeyboardIcon />
-          Keyboard shortcuts
-        </h2>
-        <div className="settings-row">
-          <span className="settings-copy">
-            <strong>Talk to Luke</strong>
-            {/* What the key actually does, which depends on whether it can
-                report being let go of. Describing a hold to someone whose key
-                can only toggle would leave them holding it and wondering. */}
-            <small>
-              {voiceHotkeyHeld
-                ? "From any app: hold to talk, let go to send. Tap instead to keep it open."
-                : "From any app: press to talk, again to send, again to interrupt."}
-            </small>
-          </span>
-          <span className="shortcut-key">{voiceHotkey ?? "Unavailable"}</span>
-        </div>
-      </section>
+      <ShortcutSection
+        {...(voiceHotkey ? { voiceHotkey } : {})}
+        voiceHotkeyHeld={voiceHotkeyHeld}
+        chosen={settings?.voiceHotkey !== undefined}
+        onVoiceHotkeyChange={onVoiceHotkeyChange}
+        onShortcutCapture={onShortcutCapture}
+      />
 
       {settings ? (
         <CredentialsSection settings={settings} control={credentials} panelOpen={panelOpen} />

--- a/apps/desktop/src/renderer/styles/voice.css
+++ b/apps/desktop/src/renderer/styles/voice.css
@@ -9,8 +9,23 @@
   background: var(--voice-luke);
 }
 
-/* Stated, not offered: the key cannot be changed yet, so it is set as text
-   rather than dressed up as a control that would do nothing. */
+/* The chip, the buttons that move it, and the line that explains them: one
+   right-aligned column, so the rule for what a chord may be appears directly
+   under the controls it governs rather than across the whole row. */
+.shortcut-controls {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+.shortcut-controls .error-message {
+  text-align: right;
+}
+
+/* A statement, not a control: the pencil beside it is what moves the key.
+   The chip only brightens while a recording holds it open. */
 .shortcut-key {
   padding: 4px 8px;
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -20,4 +35,24 @@
   font-family: "SF Mono", Menlo, monospace;
   font-size: 11px;
   white-space: nowrap;
+  transition:
+    border-color var(--duration-hover) ease,
+    color var(--duration-hover) ease;
+}
+
+/* Recording holds the chip open rather than swapping it for a field: the
+   border brightening is the whole state, and the words inside say what to
+   type. */
+.shortcut-key[data-recording="true"] {
+  border-color: rgba(255, 255, 255, 0.35);
+  color: var(--text-secondary);
+}
+
+/* The error line's shape without its alarm: what a chord may be, told while
+   one is being typed rather than after a keystroke has been refused. */
+.shortcut-hint {
+  margin: 0;
+  color: var(--text-tertiary);
+  font-size: 10px;
+  text-align: right;
 }

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -23,6 +23,7 @@ import {
   type CredentialProvider,
   type CredentialProviderId,
 } from "./shared/credential-providers";
+import { parseVoiceHotkey } from "./shared/voice-hotkey";
 
 const SETTINGS_FILE_NAME = "settings.json";
 const SETTINGS_TEMPORARY_FILE_NAME = "settings.json.tmp";
@@ -39,6 +40,7 @@ const SETTINGS_FIELD = {
   VOICE: "voice",
   VOICE_CAPTIONS: "voiceCaptions",
   VOICE_SPEED: "voiceSpeed",
+  VOICE_HOTKEY: "voiceHotkey",
 } as const;
 
 const API_KEY_LENGTH = {
@@ -106,6 +108,13 @@ interface PersistedSettings {
    * all land on the default rather than switching something on.
    */
   voiceCaptions: boolean;
+  /**
+   * The talk-key chord the user chose, absent while the defaults stand. A
+   * preference like the voice, stored plainly — and like the voice, a value
+   * this build cannot register is dropped rather than carried, because
+   * honouring it would claim a system key nothing was ever told about.
+   */
+  voiceHotkey?: string;
 }
 
 interface ResolvedApiKey {
@@ -181,6 +190,10 @@ function parsePersistedSettings(source: string): PersistedSettings {
   const showInMenuBar = record[SETTINGS_FIELD.SHOW_IN_MENU_BAR];
   const voice = record[SETTINGS_FIELD.VOICE];
   const voiceSpeed = record[SETTINGS_FIELD.VOICE_SPEED];
+  const storedHotkey = record[SETTINGS_FIELD.VOICE_HOTKEY];
+  // Read through the same gate a submitted chord passes, so a hand-edited
+  // value is either the one spelling the rest of the app uses or nothing.
+  const voiceHotkey = typeof storedHotkey === "string" ? parseVoiceHotkey(storedHotkey) : undefined;
   return {
     version: typeof version === "number" ? version : SETTINGS_FILE_VERSION,
     apiKeys: storedApiKeys(record),
@@ -193,6 +206,7 @@ function parsePersistedSettings(source: string): PersistedSettings {
     // A pace outside the offered set is dropped for the same reason.
     ...(isRealtimeVoiceSpeed(voiceSpeed) ? { voiceSpeed } : {}),
     voiceCaptions: record[SETTINGS_FIELD.VOICE_CAPTIONS] === true,
+    ...(voiceHotkey ? { voiceHotkey } : {}),
   };
 }
 
@@ -246,6 +260,9 @@ export class SettingsStore {
         environmentRealtimeSpeed(this.#environment) ??
         REALTIME_DEFAULTS.SPEED,
       voiceCaptions: (await this.#load()).voiceCaptions,
+      ...((await this.#load()).voiceHotkey
+        ? { voiceHotkey: (await this.#load()).voiceHotkey }
+        : {}),
     };
   }
 
@@ -334,6 +351,37 @@ export class SettingsStore {
         version: SETTINGS_FILE_VERSION,
         voiceCaptions: enabled,
       };
+      await this.#write(next);
+      this.#loading = Promise.resolve(next);
+    });
+    return { settings: await this.snapshot() };
+  }
+
+  /**
+   * Main-process only, for registration at startup: the talk-key chord the
+   * user chose, or nothing while the defaults stand — the registrar already
+   * carries those.
+   */
+  async readVoiceHotkey(): Promise<string | undefined> {
+    return (await this.#load()).voiceHotkey;
+  }
+
+  /**
+   * Stores the chosen talk-key chord, or returns to the defaults when
+   * omitted. The caller hands in a chord already read into its one canonical
+   * spelling; what arrives here is written as given, so resetting is the
+   * absence of a choice rather than a second stored value.
+   */
+  async setVoiceHotkey(accelerator: string | undefined): Promise<SettingsUpdateResult> {
+    await this.#serialize(async () => {
+      const persisted = await this.#load();
+      if (persisted.voiceHotkey === accelerator) return;
+      const next: PersistedSettings = {
+        ...persisted,
+        version: SETTINGS_FILE_VERSION,
+      };
+      if (accelerator) next.voiceHotkey = accelerator;
+      else delete next.voiceHotkey;
       await this.#write(next);
       this.#loading = Promise.resolve(next);
     });

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -82,6 +82,13 @@ export interface AppSettings {
    * housing all day are something to opt into rather than discover.
    */
   voiceCaptions: boolean;
+  /**
+   * The talk-key chord the user chose, absent while the defaults stand. This
+   * is the stored choice rather than the registered key — the two differ when
+   * another app owns the chosen chord — so it says only whether there is a
+   * choice to reset, and the row keeps showing the key that actually answers.
+   */
+  voiceHotkey?: string;
 }
 
 /** A rejected update reports why without echoing the submitted value. */
@@ -206,6 +213,12 @@ export interface AppBridge {
   /** Turns the on-screen caption of Luke's speech on or off. */
   setVoiceCaptions(enabled: boolean): Promise<SettingsUpdateResult>;
   /**
+   * Moves the talk key to a chord of the user's own, or back to the defaults
+   * when omitted. The change is registered with the system at once, and the
+   * key the panel shows follows the same announcement it always has.
+   */
+  setVoiceHotkey(accelerator: string | undefined): Promise<SettingsUpdateResult>;
+  /**
    * Opens an observed session where its provider keeps it. The renderer names
    * the session rather than its address, for the same reason it names a
    * provider above: the places Luke can send you are the sessions it is already
@@ -260,6 +273,7 @@ export const channels = {
   setVoice: "app:set-voice",
   setVoiceSpeed: "app:set-voice-speed",
   setVoiceCaptions: "app:set-voice-captions",
+  setVoiceHotkey: "app:set-voice-hotkey",
   openProviderApiKeys: "app:open-provider-api-keys",
   setShowInMenuBar: "app:set-show-in-menu-bar",
   setShowInDock: "app:set-show-in-dock",

--- a/apps/desktop/src/shared/voice-hotkey.ts
+++ b/apps/desktop/src/shared/voice-hotkey.ts
@@ -69,10 +69,22 @@ function joinVoiceHotkey(held: ReadonlySet<VoiceHotkeyModifier>, key: string): s
 }
 
 /**
+ * Whether the modifiers held cannot anchor a talk key: none at all, or Shift
+ * alone. Shift-and-a-letter is how every app types a capital, and
+ * Shift-and-Space is typed mid-sentence, so a chord Shift carries by itself
+ * takes plain typing away exactly as a bare key would. Shift may still join a
+ * chord another modifier anchors.
+ */
+function tooLightToHold(held: ReadonlySet<VoiceHotkeyModifier>): boolean {
+  return held.size === 0 || (held.size === 1 && held.has(VOICE_HOTKEY_MODIFIER.SHIFT));
+}
+
+/**
  * Reads an accelerator into the one spelling the rest of the app uses, or
  * refuses it. This is the gate a stored or submitted chord passes on its way to
- * the system: one key from the helper's table behind at least one modifier —
- * a bare key would take plain typing away from every app on the machine.
+ * the system: one key from the helper's table behind at least one modifier
+ * heavier than Shift — a bare key, or a Shift-only chord, would take plain
+ * typing away from every app on the machine.
  */
 export function parseVoiceHotkey(value: string): string | undefined {
   const held = new Set<VoiceHotkeyModifier>();
@@ -89,7 +101,7 @@ export function parseVoiceHotkey(value: string): string | undefined {
     if (!candidate || key !== undefined) return undefined;
     key = candidate;
   }
-  if (!key || held.size === 0) return undefined;
+  if (!key || tooLightToHold(held)) return undefined;
   return joinVoiceHotkey(held, key);
 }
 
@@ -110,7 +122,7 @@ export const VOICE_HOTKEY_CAPTURE = {
   CAPTURED: "captured",
   /** Only modifiers so far — the chord is still being formed, not refused. */
   PENDING: "pending",
-  /** A key the talk key cannot be, or one pressed with no modifier at all. */
+  /** A key the talk key cannot be, or one held by nothing heavier than Shift. */
   REFUSED: "refused",
 } as const;
 
@@ -155,7 +167,7 @@ export function capturedVoiceHotkey(chord: VoiceHotkeyChord): VoiceHotkeyCapture
   if (chord.altKey) held.add(VOICE_HOTKEY_MODIFIER.ALT);
   if (chord.shiftKey) held.add(VOICE_HOTKEY_MODIFIER.SHIFT);
   if (chord.metaKey) held.add(VOICE_HOTKEY_MODIFIER.COMMAND);
-  if (!key || held.size === 0) return { outcome: VOICE_HOTKEY_CAPTURE.REFUSED };
+  if (!key || tooLightToHold(held)) return { outcome: VOICE_HOTKEY_CAPTURE.REFUSED };
   return { outcome: VOICE_HOTKEY_CAPTURE.CAPTURED, accelerator: joinVoiceHotkey(held, key) };
 }
 

--- a/apps/desktop/src/shared/voice-hotkey.ts
+++ b/apps/desktop/src/shared/voice-hotkey.ts
@@ -17,6 +17,149 @@
 export const DEFAULT_VOICE_HOTKEYS: readonly string[] = ["Alt+Space", "Alt+S"];
 
 /**
+ * The modifiers a talk key may carry, written the way Electron accelerators
+ * name them. Their order here is the order macOS writes a chord in — ⌃⌥⇧⌘ —
+ * so every accelerator this module produces reads the way the menu bar would
+ * print it.
+ */
+export const VOICE_HOTKEY_MODIFIER = {
+  CONTROL: "Control",
+  ALT: "Alt",
+  SHIFT: "Shift",
+  COMMAND: "Command",
+} as const;
+
+export type VoiceHotkeyModifier =
+  (typeof VOICE_HOTKEY_MODIFIER)[keyof typeof VOICE_HOTKEY_MODIFIER];
+
+const MODIFIER_ORDER: readonly VoiceHotkeyModifier[] = [
+  VOICE_HOTKEY_MODIFIER.CONTROL,
+  VOICE_HOTKEY_MODIFIER.ALT,
+  VOICE_HOTKEY_MODIFIER.SHIFT,
+  VOICE_HOTKEY_MODIFIER.COMMAND,
+];
+
+/** Every name the native helper's own table answers to, folded to one each. */
+const MODIFIER_ALIASES: Readonly<Record<string, VoiceHotkeyModifier>> = {
+  control: VOICE_HOTKEY_MODIFIER.CONTROL,
+  ctrl: VOICE_HOTKEY_MODIFIER.CONTROL,
+  alt: VOICE_HOTKEY_MODIFIER.ALT,
+  option: VOICE_HOTKEY_MODIFIER.ALT,
+  shift: VOICE_HOTKEY_MODIFIER.SHIFT,
+  command: VOICE_HOTKEY_MODIFIER.COMMAND,
+  cmd: VOICE_HOTKEY_MODIFIER.COMMAND,
+  commandorcontrol: VOICE_HOTKEY_MODIFIER.COMMAND,
+  cmdorctrl: VOICE_HOTKEY_MODIFIER.COMMAND,
+};
+
+/**
+ * The keys a talk key may end in: Space or a letter, because that is the whole
+ * of the native helper's table. Anything wider stored here would register
+ * through the helper as nothing and silently fall back to the defaults, so the
+ * limit is enforced where the chord is chosen rather than discovered where it
+ * fails.
+ */
+function voiceHotkeyKey(name: string): string | undefined {
+  if (name === "space") return "Space";
+  return /^[a-z]$/.test(name) ? name.toUpperCase() : undefined;
+}
+
+function joinVoiceHotkey(held: ReadonlySet<VoiceHotkeyModifier>, key: string): string {
+  return [...MODIFIER_ORDER.filter((modifier) => held.has(modifier)), key].join("+");
+}
+
+/**
+ * Reads an accelerator into the one spelling the rest of the app uses, or
+ * refuses it. This is the gate a stored or submitted chord passes on its way to
+ * the system: one key from the helper's table behind at least one modifier —
+ * a bare key would take plain typing away from every app on the machine.
+ */
+export function parseVoiceHotkey(value: string): string | undefined {
+  const held = new Set<VoiceHotkeyModifier>();
+  let key: string | undefined;
+  for (const part of value.split("+")) {
+    const name = part.trim().toLowerCase();
+    const modifier = MODIFIER_ALIASES[name];
+    if (modifier) {
+      held.add(modifier);
+      continue;
+    }
+    // A second key in one chord is not a chord anything here can register.
+    const candidate = voiceHotkeyKey(name);
+    if (!candidate || key !== undefined) return undefined;
+    key = candidate;
+  }
+  if (!key || held.size === 0) return undefined;
+  return joinVoiceHotkey(held, key);
+}
+
+/**
+ * The chords to try, in order. A chosen key goes first — it is what the user
+ * asked for — and the defaults stay behind it, so a chord another app claims
+ * while Luke is closed costs the user a different talk key rather than none.
+ * The panel shows whichever one actually registered.
+ */
+export function voiceHotkeyCandidates(chosen: string | undefined): readonly string[] {
+  if (!chosen) return DEFAULT_VOICE_HOTKEYS;
+  return [chosen, ...DEFAULT_VOICE_HOTKEYS.filter((candidate) => candidate !== chosen)];
+}
+
+/** What became of one keystroke offered to the recording control. */
+export const VOICE_HOTKEY_CAPTURE = {
+  /** A whole chord: modifiers held and a key from the table pressed. */
+  CAPTURED: "captured",
+  /** Only modifiers so far — the chord is still being formed, not refused. */
+  PENDING: "pending",
+  /** A key the talk key cannot be, or one pressed with no modifier at all. */
+  REFUSED: "refused",
+} as const;
+
+export type VoiceHotkeyCaptureOutcome =
+  (typeof VOICE_HOTKEY_CAPTURE)[keyof typeof VOICE_HOTKEY_CAPTURE];
+
+export type VoiceHotkeyCaptureResult =
+  | { outcome: typeof VOICE_HOTKEY_CAPTURE.CAPTURED; accelerator: string }
+  | { outcome: typeof VOICE_HOTKEY_CAPTURE.PENDING }
+  | { outcome: typeof VOICE_HOTKEY_CAPTURE.REFUSED };
+
+/** The fields of a `KeyboardEvent` a chord is read from, so a test needs no DOM. */
+export interface VoiceHotkeyChord {
+  /** `KeyboardEvent.code`: the physical key, unmoved by the modifiers held. */
+  code: string;
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+}
+
+const MODIFIER_CODE_PREFIXES = ["Alt", "Control", "Meta", "Shift"] as const;
+
+/**
+ * Reads one keystroke as a talk-key chord. `code` rather than `key`, because
+ * on macOS Option moves letters — Option-S arrives as `ß` — and the chord
+ * being recorded is the physical one the helper will watch for.
+ */
+export function capturedVoiceHotkey(chord: VoiceHotkeyChord): VoiceHotkeyCaptureResult {
+  // A modifier going down on its own is a chord being formed, not an answer.
+  if (MODIFIER_CODE_PREFIXES.some((prefix) => chord.code.startsWith(prefix))) {
+    return { outcome: VOICE_HOTKEY_CAPTURE.PENDING };
+  }
+  const key =
+    chord.code === "Space"
+      ? "Space"
+      : /^Key[A-Z]$/.test(chord.code)
+        ? chord.code.slice("Key".length)
+        : undefined;
+  const held = new Set<VoiceHotkeyModifier>();
+  if (chord.ctrlKey) held.add(VOICE_HOTKEY_MODIFIER.CONTROL);
+  if (chord.altKey) held.add(VOICE_HOTKEY_MODIFIER.ALT);
+  if (chord.shiftKey) held.add(VOICE_HOTKEY_MODIFIER.SHIFT);
+  if (chord.metaKey) held.add(VOICE_HOTKEY_MODIFIER.COMMAND);
+  if (!key || held.size === 0) return { outcome: VOICE_HOTKEY_CAPTURE.REFUSED };
+  return { outcome: VOICE_HOTKEY_CAPTURE.CAPTURED, accelerator: joinVoiceHotkey(held, key) };
+}
+
+/**
  * The talk key a panel should show.
  *
  * Two things can say what the key is, and neither is reliably first. The helper

--- a/apps/desktop/src/talk-key.ts
+++ b/apps/desktop/src/talk-key.ts
@@ -49,6 +49,13 @@ function helperPath(): string {
 }
 
 /**
+ * Longer than a SIGTERM takes to land, far shorter than a user notices. The
+ * wait for a stopped helper's exit is capped so a process that ignores the
+ * signal cannot wedge every later change of the talk key.
+ */
+const EXIT_WAIT_MS = 1000;
+
+/**
  * Watches the talk key being held down and let go of, from whatever app is
  * frontmost.
  *
@@ -95,18 +102,34 @@ export class TalkKeyWatcher {
     }
   }
 
-  stop(): void {
-    // Detached before killing: this exit is the app's own doing, and reporting
-    // it as the key becoming unavailable would stand up a fallback during
-    // shutdown.
+  /**
+   * Stops the helper, reporting when its process is actually gone. Detached
+   * before killing: this exit is the app's own doing, and reporting it as the
+   * key becoming unavailable would stand up a fallback during shutdown. The
+   * answer matters to a successor — the system releases the chord with the
+   * process, not with the kill that asked for it, so a new helper that claims
+   * a chord this one still holds would be refused.
+   */
+  stop(): Promise<void> {
     const child = this.#child;
     this.#child = undefined;
     this.#done = true;
-    child?.removeAllListeners();
-    child?.kill();
+    if (!child) return Promise.resolve();
+    child.removeAllListeners();
+    const gone = new Promise<void>((resolve) => {
+      child.on("exit", resolve);
+      setTimeout(resolve, EXIT_WAIT_MS).unref();
+    });
+    child.kill();
+    return gone;
   }
 
   #read(chunk: string): void {
+    // Stopping leaves the pipe's listener attached, so a line the dying helper
+    // got out — a late press, its own registration — still lands here. Acting
+    // on it would open the microphone, or redraw the shown key, under a chord
+    // the app has already let go of; a stopped reader drops everything.
+    if (this.#done) return;
     this.#buffer += chunk;
     const lines = this.#buffer.split("\n");
     // Whatever follows the last newline is the start of a line still arriving.

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -769,6 +769,69 @@ test("ignores a stored or environment pace this build does not offer", async (t)
   assert.equal((await store.snapshot()).voiceSpeed, REALTIME_DEFAULTS.SPEED);
 });
 
+test("reports no talk-key chord until one is chosen", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+
+  assert.equal(await store.readVoiceHotkey(), undefined);
+  assert.equal((await store.snapshot()).voiceHotkey, undefined);
+});
+
+test("stores the chosen talk-key chord plainly and reads it back from a new store instance", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const cipher = countingCipher();
+  const store = storeIn(directory, { cipher });
+
+  const { settings, reason } = await store.setVoiceHotkey("Shift+Command+L");
+
+  assert.equal(reason, undefined);
+  assert.equal(settings.voiceHotkey, "Shift+Command+L");
+  // A preference is not a credential, so choosing one never reaches the
+  // Keychain — and never raises its permission dialog.
+  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
+  assert.equal(await storeIn(directory).readVoiceHotkey(), "Shift+Command+L");
+});
+
+test("clearing the talk-key chord returns to no choice at all", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+
+  await store.setVoiceHotkey("Shift+Command+L");
+  const { settings } = await store.setVoiceHotkey(undefined);
+
+  assert.equal(settings.voiceHotkey, undefined);
+  // Absent from the file rather than stored as an empty value: reset is the
+  // absence of a choice, and a reopened store must read it the same way.
+  assert.equal(await storeIn(directory).readVoiceHotkey(), undefined);
+});
+
+test("ignores a stored talk-key chord this build cannot register", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({ version: 2, apiKeys: {}, voiceHotkey: "F13" }),
+  );
+  const store = storeIn(directory);
+
+  // A hand-edited chord the registrars would refuse is dropped rather than
+  // carried: honouring it would claim a key nothing was ever told about.
+  assert.equal(await store.readVoiceHotkey(), undefined);
+  assert.equal((await store.snapshot()).voiceHotkey, undefined);
+});
+
+test("the talk-key chord and a stored key survive each other's writes", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+
+  await store.setApiKey(CONDUCTOR, TEST_API_KEY);
+  await store.setVoiceHotkey("Control+Alt+Space");
+  await store.setApiKey(CONDUCTOR, "conductor-replacement-key");
+
+  const reopened = storeIn(directory);
+  assert.equal(await reopened.readApiKey(CONDUCTOR), "conductor-replacement-key");
+  assert.equal(await reopened.readVoiceHotkey(), "Control+Alt+Space");
+});
+
 test("the voice and a stored key survive each other's writes", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);

--- a/apps/desktop/tests/talk-key.test.ts
+++ b/apps/desktop/tests/talk-key.test.ts
@@ -115,11 +115,44 @@ test("stopping is the app's own doing and is not a key becoming unavailable", ()
   const context = harness();
   context.watcher.start(["Alt+Space"]);
   context.emit("registered Alt+Space\n");
-  context.watcher.stop();
+  void context.watcher.stop();
   context.die();
 
   assert.equal(context.killed(), true);
   // Falling back to another key during shutdown would register a global
   // shortcut on the way out of the app.
   assert.deepEqual(context.edges, ["registered:Alt+Space"]);
+});
+
+test("a line the dying helper got out after a stop is dropped, not acted on", () => {
+  const context = harness();
+  context.watcher.start(["Alt+Space"]);
+  context.emit("registered Alt+Space\n");
+  void context.watcher.stop();
+  // The pipe outlives the kill by however long the process takes to die, so a
+  // press in that window still arrives here. Acting on it would open the
+  // microphone under a chord the app has already let go of.
+  context.emit("down\nregistered Alt+Space\n");
+
+  assert.deepEqual(context.edges, ["registered:Alt+Space"]);
+});
+
+test("stopping reports when the helper's process is actually gone", async () => {
+  const context = harness();
+  context.watcher.start(["Alt+Space"]);
+  context.emit("registered Alt+Space\n");
+
+  let gone = false;
+  const stopped = context.watcher.stop().then(() => {
+    gone = true;
+  });
+  // The kill is asked for at once, but the chord is only released when the
+  // process exits — which is what a successor has to wait for.
+  assert.equal(context.killed(), true);
+  await Promise.resolve();
+  assert.equal(gone, false);
+
+  context.die();
+  await stopped;
+  assert.equal(gone, true);
 });

--- a/apps/desktop/tests/voice-hotkey.test.ts
+++ b/apps/desktop/tests/voice-hotkey.test.ts
@@ -63,6 +63,11 @@ test("a chord the helper cannot register is refused rather than guessed at", () 
   assert.equal(parseVoiceHotkey("K"), undefined);
   // A bare modifier cannot be a Carbon hot key at all.
   assert.equal(parseVoiceHotkey("Alt"), undefined);
+  // Shift alone is a bare key in disguise: Shift+S is how capitals are typed,
+  // and Shift+Space lands mid-sentence. Shift may only join a heavier chord.
+  assert.equal(parseVoiceHotkey("Shift+S"), undefined);
+  assert.equal(parseVoiceHotkey("Shift+Space"), undefined);
+  assert.equal(parseVoiceHotkey("Shift+Command+S"), "Shift+Command+S");
   // Keys outside the helper's table: digits, function keys, two keys at once.
   assert.equal(parseVoiceHotkey("Alt+1"), undefined);
   assert.equal(parseVoiceHotkey("Alt+F5"), undefined);
@@ -104,6 +109,11 @@ test("a keystroke is read as a chord from the physical key", () => {
 
   // A bare key, or one outside the helper's table, is an answer — a wrong one.
   assert.deepEqual(capturedVoiceHotkey({ ...chord, code: "KeyS" }), {
+    outcome: VOICE_HOTKEY_CAPTURE.REFUSED,
+  });
+  // So is a key Shift alone is holding: recording it would fire the talk key
+  // on every capital S typed anywhere.
+  assert.deepEqual(capturedVoiceHotkey({ ...chord, code: "KeyS", shiftKey: true }), {
     outcome: VOICE_HOTKEY_CAPTURE.REFUSED,
   });
   assert.deepEqual(capturedVoiceHotkey({ ...chord, code: "Digit1", altKey: true }), {

--- a/apps/desktop/tests/voice-hotkey.test.ts
+++ b/apps/desktop/tests/voice-hotkey.test.ts
@@ -1,11 +1,15 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  capturedVoiceHotkey,
   DEFAULT_VOICE_HOTKEYS,
+  parseVoiceHotkey,
   TALK_KEY_RELEASE,
   TALK_KEY_TAP_MS,
   talkKeyRelease,
   VOICE_HOTKEY_ABSENCE,
+  VOICE_HOTKEY_CAPTURE,
+  voiceHotkeyCandidates,
   voiceHotkeyLabel,
   voiceHotkeyReport,
   voiceHotkeyToShow,
@@ -40,6 +44,90 @@ test("a missing talk key says which absence it is", () => {
     /another app already owns it/,
   );
   assert.match(voiceHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.CAPTURE_RUN), /capture run/);
+});
+
+test("a chord is read into one canonical spelling", () => {
+  // Whatever a caller writes, one spelling comes out: aliases folded, the key
+  // cased the way the defaults are, modifiers in the order macOS prints them.
+  assert.equal(parseVoiceHotkey("Alt+Space"), "Alt+Space");
+  assert.equal(parseVoiceHotkey("option+space"), "Alt+Space");
+  assert.equal(parseVoiceHotkey("CommandOrControl+SHIFT+k"), "Shift+Command+K");
+  assert.equal(parseVoiceHotkey("Command+Ctrl+a"), "Control+Command+A");
+  // Naming a modifier twice under two aliases is still one modifier held.
+  assert.equal(parseVoiceHotkey("Alt+Option+S"), "Alt+S");
+});
+
+test("a chord the helper cannot register is refused rather than guessed at", () => {
+  // A bare key would take plain typing away from every app on the machine.
+  assert.equal(parseVoiceHotkey("Space"), undefined);
+  assert.equal(parseVoiceHotkey("K"), undefined);
+  // A bare modifier cannot be a Carbon hot key at all.
+  assert.equal(parseVoiceHotkey("Alt"), undefined);
+  // Keys outside the helper's table: digits, function keys, two keys at once.
+  assert.equal(parseVoiceHotkey("Alt+1"), undefined);
+  assert.equal(parseVoiceHotkey("Alt+F5"), undefined);
+  assert.equal(parseVoiceHotkey("Alt+A+B"), undefined);
+  assert.equal(parseVoiceHotkey(""), undefined);
+});
+
+test("a chosen chord is tried first and the defaults stay behind it", () => {
+  assert.deepEqual(voiceHotkeyCandidates(undefined), DEFAULT_VOICE_HOTKEYS);
+  assert.deepEqual(voiceHotkeyCandidates("Command+L"), ["Command+L", "Alt+Space", "Alt+S"]);
+  // Choosing a default outright must not ask the system for it twice.
+  assert.deepEqual(voiceHotkeyCandidates("Alt+S"), ["Alt+S", "Alt+Space"]);
+});
+
+test("a keystroke is read as a chord from the physical key", () => {
+  const chord = { altKey: false, ctrlKey: false, metaKey: false, shiftKey: false };
+
+  // `code` rather than `key`: Option moves letters on macOS, and Option-S is
+  // the chord being recorded even while the event says `ß`.
+  assert.deepEqual(capturedVoiceHotkey({ ...chord, code: "KeyS", altKey: true }), {
+    outcome: VOICE_HOTKEY_CAPTURE.CAPTURED,
+    accelerator: "Alt+S",
+  });
+  assert.deepEqual(
+    capturedVoiceHotkey({ ...chord, code: "Space", metaKey: true, shiftKey: true }),
+    {
+      outcome: VOICE_HOTKEY_CAPTURE.CAPTURED,
+      accelerator: "Shift+Command+Space",
+    },
+  );
+
+  // A modifier going down on its own is a chord still being formed.
+  assert.deepEqual(capturedVoiceHotkey({ ...chord, code: "AltLeft", altKey: true }), {
+    outcome: VOICE_HOTKEY_CAPTURE.PENDING,
+  });
+  assert.deepEqual(capturedVoiceHotkey({ ...chord, code: "MetaRight", metaKey: true }), {
+    outcome: VOICE_HOTKEY_CAPTURE.PENDING,
+  });
+
+  // A bare key, or one outside the helper's table, is an answer — a wrong one.
+  assert.deepEqual(capturedVoiceHotkey({ ...chord, code: "KeyS" }), {
+    outcome: VOICE_HOTKEY_CAPTURE.REFUSED,
+  });
+  assert.deepEqual(capturedVoiceHotkey({ ...chord, code: "Digit1", altKey: true }), {
+    outcome: VOICE_HOTKEY_CAPTURE.REFUSED,
+  });
+  assert.deepEqual(capturedVoiceHotkey({ ...chord, code: "Enter", metaKey: true }), {
+    outcome: VOICE_HOTKEY_CAPTURE.REFUSED,
+  });
+});
+
+test("a recorded chord and a stored one pass the same gate", () => {
+  // What recording produces is what parsing accepts, spelled identically —
+  // otherwise a chord could be registered today and dropped on next launch.
+  const recorded = capturedVoiceHotkey({
+    code: "KeyK",
+    altKey: false,
+    ctrlKey: true,
+    metaKey: true,
+    shiftKey: false,
+  });
+  assert.equal(recorded.outcome, VOICE_HOTKEY_CAPTURE.CAPTURED);
+  if (recorded.outcome === VOICE_HOTKEY_CAPTURE.CAPTURED) {
+    assert.equal(parseVoiceHotkey(recorded.accelerator), recorded.accelerator);
+  }
 });
 
 test("holding sends on release and tapping leaves the turn open", () => {


### PR DESCRIPTION
## Summary

- The **Keyboard shortcuts** row in Settings now edits the key that talks to Luke instead of only stating it. A pencil button beside the key chip records the next chord typed; while the row listens it explains the rule — hold any of `⌃⌥⇧⌘` and press a letter or Space, exactly the set the native `RegisterEventHotKey` helper can register — as a quiet hint under the controls, which turns into the error line for a refused keystroke. Escape, the pencil (a cross while recording), or focus leaving keeps the current key.
- A reset arrow appears beside the chip while a chosen chord is stored (and steps aside during a recording), returning the defaults `⌥Space` → `⌥S`.
- New pure logic in `shared/voice-hotkey.ts`: `parseVoiceHotkey` canonicalizes and validates a chord against the helper's table; `capturedVoiceHotkey` reads a `KeyboardEvent` by `event.code` (so ⌥S records even though macOS types `ß`), distinguishing captured / still-forming / refused; `voiceHotkeyCandidates` keeps the defaults behind a chosen chord, so a key another app owns costs a different talk key rather than none — the row shows the key that actually registered.
- The chord persists plainly in `settings.json` (never the Keychain) with reset deleting the field; the `setVoiceHotkey` IPC channel is trusted-sender-checked and re-validates, and `applyVoiceHotkey` fully releases the old key (helper stopped, `globalShortcut` cleared) before claiming the new one. While the recording control has the keyboard, presses of the still-registered current hotkey are held back so the microphone can't open under the field.
- Recording lives on the focused pencil button, never anywhere global, so a keystroke can only become a shortcut while the user visibly holds the control asking for one.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passes — lint, typecheck, 498 tests (426 desktop + 72 sidecar-core, 0 failures), and builds, on the rebased branch.
- macOS Electron verification (`./scripts/verify.sh`): `not run` — developed in a Linux sandbox; relying on CI's automated visual evidence below.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31771467768/artifacts/9208293825) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31771467768)

- Commit: `cb1627b2b1fc9f535137cd11d82a105d61a3c64f`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: the settings row (chip + icon buttons + hint) is new UI — worth a visual pass on a physical Mac; the reset-arrow glyph is the one brand-new drawing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/3383030b-2d10-4db0-848c-ba748fbad338)
