### PR TITLE
fix(voice): answer the talk key on the press, not the handshake

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -230,6 +230,14 @@ export function App(): React.JSX.Element {
   const [slotElement, slotHeight] = useShapeHeight();
   const [captionTextElement, captionTextHeight] = useShapeHeight();
   const [voiceStatus, setVoiceStatus] = useState<RealtimeStatus>(REALTIME_STATUS.IDLE);
+  /**
+   * A pressed talk key still waiting for the call it asked to open. The meter
+   * is drawn from this rather than from the connection, because the press is
+   * the moment the developer needs answering: the handshake behind it takes
+   * seconds, and a key that visibly does nothing for that long reads as a key
+   * that did nothing.
+   */
+  const [talkOpening, setTalkOpening] = useState(false);
   const [voiceHotkey, setVoiceHotkey] = useState<VoiceHotkeyState>();
   const [localStream, setLocalStream] = useState<MediaStream>();
   const [remoteStream, setRemoteStream] = useState<MediaStream>();
@@ -358,8 +366,10 @@ export function App(): React.JSX.Element {
     setMicrophoneStatus(permission);
     if (permission !== "granted") {
       // The press that asked for this is still waiting for a call that is now
-      // not coming.
+      // not coming. The status never changes on this path, so the meter the
+      // press put up is taken down here rather than by a status settling.
       session.dropPendingTurn();
+      setTalkOpening(false);
       return;
     }
     if (await session.connect()) session.updateSessions(sessionsRef.current);
@@ -433,6 +443,9 @@ export function App(): React.JSX.Element {
     if (talkLatched.current) return;
     const session = ensureVoiceSession();
     session.beginTurn();
+    // A press against no call has seconds of handshake ahead of it, and the
+    // meter has to answer the press, not the handshake.
+    if (!session.isConnected) setTalkOpening(true);
     if (session.isConnected || session.isConnecting) return;
     await startMicrophoneRef.current?.();
   }, [ensureVoiceSession]);
@@ -458,6 +471,9 @@ export function App(): React.JSX.Element {
       return;
     }
     talkLatched.current = false;
+    // A held press let go of before the call opened is dropped, not sent —
+    // nothing was captured to send — and the meter it put up leaves with it.
+    if (voiceSession.current && !voiceSession.current.isConnected) setTalkOpening(false);
     voiceSession.current?.endTurn(true);
   }, []);
 
@@ -882,6 +898,10 @@ export function App(): React.JSX.Element {
     }
     const context = audioContext.current ?? new AudioContext({ latencyHint: "interactive" });
     audioContext.current = context;
+    // A suspended context reads a flatline whatever the microphone hears, and
+    // the talk key is a system shortcut, so no user gesture in this window has
+    // ever vouched for the context. Resuming is a no-op when it is running.
+    if (context.state === "suspended") void context.resume();
     const source = context.createMediaStreamSource(activeStream);
     const nextAnalyser = context.createAnalyser();
     nextAnalyser.fftSize = 256;
@@ -898,6 +918,10 @@ export function App(): React.JSX.Element {
     voiceStatusRef.current = voiceStatus;
     // Each reply is heard from scratch, so the previous one cannot vouch for it.
     if (voiceStatus !== REALTIME_STATUS.RESPONDING) heardLuke.current = false;
+    // Any settled status ends the wait the press started, however it ended:
+    // listening takes the meter live, ready means the turn was dropped
+    // mid-handshake, and a failure has its own message to show.
+    if (voiceStatus !== REALTIME_STATUS.CONNECTING) setTalkOpening(false);
   }, [voiceStatus]);
 
   useEffect(() => {
@@ -1137,6 +1161,7 @@ export function App(): React.JSX.Element {
         {...(voiceTurn ? { voice: voiceTurn } : {})}
         fixtureSpeaking={fixtureSpeaking}
         hasAudioSignal={hasAudioSignal}
+        voiceOpening={talkOpening}
         presentation={presentation}
         housingWidth={display.notch.housingWidth}
       />

--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -16,7 +16,7 @@ import {
   useWingReorderMotion,
   WING_SLOT_ID_ATTRIBUTE,
 } from "./session-motion";
-import { Waveform, type WaveformVoice } from "./waveform";
+import { WAVEFORM_VOICE, Waveform, type WaveformVoice } from "./waveform";
 
 /**
  * The strips beside the camera housing. They are rendered once for both window
@@ -32,6 +32,8 @@ interface NotchWingsProps {
   onVoiceActivity?: (active: boolean) => void;
   fixtureSpeaking: boolean;
   hasAudioSignal: boolean;
+  /** A pressed talk key still waiting for the call it asked to open. */
+  voiceOpening: boolean;
   presentation: PanelPresentation;
   housingWidth: number;
 }
@@ -102,6 +104,7 @@ export function NotchWings({
   onVoiceActivity,
   fixtureSpeaking,
   hasAudioSignal,
+  voiceOpening,
   presentation,
   housingWidth,
 }: NotchWingsProps): React.JSX.Element {
@@ -113,9 +116,20 @@ export function NotchWings({
     },
     [onVoiceActivity],
   );
+  // The meter is the developer's from the press, not from the handshake: while
+  // the call is opening it already stands where it will stand once live, so the
+  // key answers on the frame it lands rather than when the network does. It
+  // also holds through the turn itself rather than following the analyser,
+  // which arrives an effect-tick after the turn opens and would blink the
+  // meter out for that frame.
+  const meterVoice = voice ?? (voiceOpening ? WAVEFORM_VOICE.DEVELOPER : undefined);
+  const meterShown = hasAudioSignal || voiceOpening || meterVoice === WAVEFORM_VOICE.DEVELOPER;
   // While the developer holds the turn the meter takes the face's place, which
   // is the only place the capsule has.
-  const yieldToMeter = faceYieldsToMeter({ ...(voice ? { turn: voice } : {}), hasAudioSignal });
+  const yieldToMeter = faceYieldsToMeter({
+    ...(meterVoice ? { turn: meterVoice } : {}),
+    hasAudioSignal: meterShown,
+  });
   const face = useFaceMotion(
     {
       ...speechFaceInputs({
@@ -152,17 +166,18 @@ export function NotchWings({
 
   return (
     <>
-      <div className="wing wing-left" data-audio={String(hasAudioSignal)}>
+      <div className="wing wing-left" data-audio={String(meterShown)}>
         {/* Ordered so the element nearest the notch is the one the capsule
             keeps: the rest unfold outward and never displace it. */}
         <div className="wing-inner">
-          {hasAudioSignal ? (
-            <span className="wing-meter" data-turn={voice}>
+          {meterShown ? (
+            <span className="wing-meter" data-turn={meterVoice}>
               <Waveform
                 analyser={analyser}
                 speaking={fixtureSpeaking}
-                voice={voice}
+                voice={meterVoice}
                 voiceActive={voiceActive}
+                connecting={voiceOpening && !analyser}
                 onVoiceActivity={reportVoiceActivity}
               />
             </span>

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -232,39 +232,51 @@ export class RealtimeVoiceSession {
     this.#setStatus(REALTIME_STATUS.CONNECTING);
     this.#options.onError(undefined);
 
-    let connection: RealtimeConnection | undefined;
-    try {
-      connection = await this.#options.requestConnection();
-    } catch (error) {
-      // A stop that lands while the credential is being minted is not a fault
-      // to report. Every exit from here has to ask, not just the ones after the
-      // device exists.
-      if (this.#closed) return this.#abandonConnect();
-      return this.#fail(`Could not reach the main process: ${errorMessage(error)}`);
-    }
-    if (this.#closed) return this.#abandonConnect();
-    if (!connection) {
-      this.#setStatus(REALTIME_STATUS.UNAVAILABLE);
-      return false;
-    }
-
-    try {
-      const stream = await (this.#options.requestMicrophoneStream?.() ??
+    // The whole of the wait before the handshake is these two, and neither
+    // needs the other: the credential is minted over the network while the
+    // capture device opens. `allSettled` rather than `all`, because whichever
+    // one loses still has to be dealt with — a device that opened after a
+    // failed mint would be held with nobody left to release it.
+    const [connectionResult, streamResult] = await Promise.allSettled([
+      this.#options.requestConnection(),
+      this.#options.requestMicrophoneStream?.() ??
         navigator.mediaDevices.getUserMedia({
           audio: { autoGainControl: true, echoCancellation: true, noiseSuppression: true },
           video: false,
-        }));
-      this.#stream = stream;
+        }),
+    ]);
+    // Adopt the device before deciding anything, so every exit from here — a
+    // stop that landed mid-mint, a failed mint, no credential at all — releases
+    // it through the same teardown as the rest.
+    if (streamResult.status === "fulfilled") this.#stream = streamResult.value;
+
+    // A stop that lands while the credential is being minted is not a fault
+    // to report. Every exit from here has to ask, not just the ones after the
+    // handshake starts.
+    if (this.#closed) return this.#abandonConnect();
+    if (connectionResult.status === "rejected") {
+      return this.#fail(
+        `Could not reach the main process: ${errorMessage(connectionResult.reason)}`,
+      );
+    }
+    const connection = connectionResult.value;
+    if (!connection) {
+      this.#teardown();
+      this.#setStatus(REALTIME_STATUS.UNAVAILABLE);
+      return false;
+    }
+    if (streamResult.status === "rejected") {
+      return this.#fail(errorMessage(streamResult.reason));
+    }
+
+    try {
+      const stream = streamResult.value;
       const [microphone] = stream.getAudioTracks();
       if (!microphone) throw new Error("No microphone track was available");
       // Push-to-talk starts closed. Nothing is sent until the developer asks.
       microphone.enabled = false;
       this.#microphone = microphone;
       this.#options.onLocalStream(stream);
-      // `close()` can land while this is still awaiting. The device now exists,
-      // so bailing out without releasing it would leave the microphone held by
-      // a session the caller already stopped.
-      if (this.#closed) return this.#abandonConnect();
 
       const peer = this.#options.createPeerConnection?.() ?? new RTCPeerConnection();
       this.#peer = peer;

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1182,6 +1182,16 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   transform: scale(1);
 }
 
+/* Your own meter is fully drawn from its first frame. It stands where the face
+   stood as the answer to "am I being heard", and a half-faded answer reads as
+   no — the quiet-versus-speaking distinction stays with the bars, which move
+   to the voice. Luke's meter keeps the fade: it sits beside the face, and dim
+   at rest is how a pause mid-reply should read. */
+.wing-meter[data-turn="developer"] .waveform {
+  opacity: 1;
+  transform: scale(1);
+}
+
 .waveform-bar {
   width: 2px;
   height: var(--bar-height, 19px);
@@ -1202,6 +1212,37 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 }
 .waveform-bar:nth-child(3) {
   --bar-height: 23px;
+}
+
+/* The press answered before the call is: while the handshake runs the bars
+   pulse on their own clock — they cannot yet hear anything and must not
+   pretend to — and the pulse hands over to the analyser the moment the turn
+   opens. Negative delays start every bar mid-cycle, so the meter arrives
+   already breathing instead of standing up bar by bar. */
+.waveform[data-connecting="true"] .waveform-bar {
+  animation: waveform-opening 1100ms ease-in-out infinite;
+  animation-play-state: var(--loop-motion);
+}
+
+.waveform[data-connecting="true"] .waveform-bar:nth-child(2),
+.waveform[data-connecting="true"] .waveform-bar:nth-child(4) {
+  animation-delay: -140ms;
+}
+
+.waveform[data-connecting="true"] .waveform-bar:nth-child(1),
+.waveform[data-connecting="true"] .waveform-bar:nth-child(5) {
+  animation-delay: -280ms;
+}
+
+@keyframes waveform-opening {
+  0%,
+  100% {
+    transform: scaleY(0.2);
+  }
+
+  50% {
+    transform: scaleY(0.55);
+  }
 }
 
 /* Expanded panel --------------------------------------------------------- */

--- a/apps/desktop/src/renderer/waveform.tsx
+++ b/apps/desktop/src/renderer/waveform.tsx
@@ -26,6 +26,7 @@ export function Waveform({
   speaking = false,
   voice,
   voiceActive = false,
+  connecting = false,
   onVoiceActivity,
 }: {
   analyser?: AnalyserNode;
@@ -33,6 +34,13 @@ export function Waveform({
   /** Whose turn the bars are drawing, which is what colours them. */
   voice?: WaveformVoice;
   voiceActive?: boolean;
+  /**
+   * The press has landed but the call is still opening, so there is nothing to
+   * hear yet. The bars pulse on their own clock rather than sit at the floor —
+   * a press that changes nothing on screen reads as a press that did nothing —
+   * and stop pretending the moment an analyser takes over.
+   */
+  connecting?: boolean;
   onVoiceActivity?: (active: boolean) => void;
 }): React.JSX.Element {
   const bars = useRef<Array<HTMLSpanElement | null>>([]);
@@ -88,9 +96,16 @@ export function Waveform({
     <span
       className="waveform"
       role="img"
-      aria-label={voice === WAVEFORM_VOICE.LUKE ? "Luke is speaking" : "Live speech activity"}
-      aria-hidden={!isSpeaking}
+      aria-label={
+        connecting
+          ? "Voice is connecting"
+          : voice === WAVEFORM_VOICE.LUKE
+            ? "Luke is speaking"
+            : "Live speech activity"
+      }
+      aria-hidden={!isSpeaking && !connecting}
       data-speaking={String(isSpeaking)}
+      data-connecting={String(connecting)}
       data-voice={voice}
     >
       {BAR_INDEXES.map((index) => (

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -38,6 +38,8 @@ interface Harness {
   setConnectionState: (state: RTCPeerConnectionState) => void;
   closeChannel: () => void;
   requests: { url: string; init: RequestInit }[];
+  /** The order the credential and the device were asked for and answered in. */
+  calls: string[];
 }
 
 function observedSession(
@@ -74,6 +76,7 @@ function harness(
   const errors: (string | undefined)[] = [];
   const captions: (string | undefined)[] = [];
   const requests: { url: string; init: RequestInit }[] = [];
+  const calls: string[] = [];
   let enabled = false;
   let stopped = false;
 
@@ -122,13 +125,16 @@ function harness(
   let connection = "connection" in options ? options.connection : CONNECTION;
   const session = new RealtimeVoiceSession({
     requestConnection: async () => {
+      calls.push("credential-requested");
       if (options.connectionDelayMs) {
         await new Promise((resolve) => setTimeout(resolve, options.connectionDelayMs));
       }
       if (options.connectionError) throw options.connectionError;
+      calls.push("credential-resolved");
       return connection;
     },
     requestMicrophoneStream: async () => {
+      calls.push("microphone-requested");
       if (options.microphoneError) throw options.microphoneError;
       return stream as unknown as MediaStream;
     },
@@ -182,6 +188,7 @@ function harness(
       (channel.onclose as (() => void) | undefined)?.();
     },
     requests,
+    calls,
   };
 }
 
@@ -207,6 +214,23 @@ test("no credential leaves the voice experience explicitly unavailable", async (
   assert.equal(await context.session.connect(), false);
   assert.equal(context.session.status, REALTIME_STATUS.UNAVAILABLE);
   assert.deepEqual(context.sent, []);
+  // The device was opened alongside the mint that came back empty, and nothing
+  // else is left to let go of it.
+  assert.equal(context.microphoneStopped(), true);
+});
+
+test("the credential and the device are asked for together, not in turn", async () => {
+  // The mint is a network round trip and the device open is a hardware one.
+  // The press that started the connect is waiting on both, so the device must
+  // not queue behind the mint.
+  const context = harness({ connectionDelayMs: 20 });
+
+  assert.equal(await context.session.connect(), true);
+  assert.deepEqual(context.calls, [
+    "credential-requested",
+    "microphone-requested",
+    "credential-resolved",
+  ]);
 });
 
 test("a refused call fails without leaking the ephemeral secret", async () => {


### PR DESCRIPTION
## What

Pressing the talk key on a fresh app showed nothing until the whole connect handshake finished — credential mint, device open, SDP exchange, data channel — and the waveform seemed to appear only "when I start making noise." Three causes, three fixes:

- **The meter answered the handshake, not the press.** It now takes the face's place the moment the key goes down, pulsing on its own clock while the call opens — the bars cannot hear anything yet and do not pretend to — and hands over to the live, voice-driven bars the instant the turn opens.
- **A press held and let go of mid-handshake was dropped without a trace.** The turn is still dropped (nothing was captured to send), but the meter it put up now leaves with it, so a press that sent nothing visibly says so. The invisible version of this is what made the meter seem to appear only on the *second* press — usually made as the developer started talking again.
- **The live meter was nearly invisible at rest** — half opacity, 86% scale, bars at the floor. Your own meter is now fully drawn from its first frame; Luke's keeps the dim-at-rest fade, since a pause mid-reply should read quiet.

Two latency fixes ride along: the credential mint and the capture-device open run concurrently (neither needs the other, and the press waits on both), and the analyser's `AudioContext` is resumed if it starts suspended — the talk key is a system shortcut, so no gesture in the window ever vouched for audio.

## What doesn't change

- Nothing spoken during the handshake is sent; the pulse makes that visible instead of silent.
- Push-to-talk still starts closed: the microphone track is created disabled and nothing is sent until the developer asks.
- Every failure combination of mint and device open releases the device through the same teardown, including a mint that comes back empty.
- The opening pulse holds still under reduced motion and capture runs via the existing `--loop-motion` token.

## Validation

- `./scripts/check.sh` — passes (repository contract, lint, typecheck, all tests, builds), exit 0.
- 59 realtime-session tests pass, including two new ones: the credential and the device are asked for together rather than in turn, and a mint that comes back empty releases the device it opened alongside.
- UI change, so CI's `./scripts/verify.sh` on macOS is the completion invariant; evidence is linked from this description by CI. No physical-notch check was performed (working from a cloud workspace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/1c44993d-8f35-4781-b87d-a52b68b0d98a)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31770715097/artifacts/9208024921) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31770715097)

- Commit: `c654f472af7ccd56d6e82ac1b8516700001b91a9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
