### PR TITLE
feat(ask): type to Luke, from the panel and from any app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,25 +33,26 @@ Trust constraints:
   the user supplies one and must leave every other provider working without it.
 - The one thing Luke may change about a session is what the user just asked to
   send it: a message typed on its row, a control its provider advertised for
-  it, or the same two acts asked for out loud in a conversation the user is
-  holding — each through the provider's own documented endpoint under the same
-  user-supplied credential, and each validated against the observed roster
-  before an adapter sees it. Observation passes stay read-only by construction.
+  it, or the same two acts asked of Luke — out loud, or typed into his own
+  composer — in a conversation the user is holding — each through the
+  provider's own documented endpoint under the same user-supplied credential,
+  and each validated against the observed roster before an adapter sees it.
+  Observation passes stay read-only by construction.
   Nothing that decides on the user's behalf may reach a write path: the
   attention evaluator above all, and every turn Luke opens himself — a
   proactive readout, the reply that voices a tool's outcome — which carries no
   tools, at the API and again at a runtime gate, so a session summary or a tool
-  output that reads like an instruction can never become an act. A spoken tool
-  call runs only in the turn the developer opened by speaking; a write is the
-  direct product of a turn the developer opened, never of anything Luke read or
-  was told. A session whose provider documents no way in, or whose current state is
+  output that reads like an instruction can never become an act. A tool call
+  in that conversation runs only in a turn the developer opened themselves, by
+  speaking or by typing; a write is the direct product of a turn the developer
+  opened, never of anything Luke read or was told. A session whose provider documents no way in, or whose current state is
   documented for none, advertises nothing and is offered nothing; local
   sessions have no such endpoint and stay entirely read-only. Opening a
-  session — its row pressed, or the same press asked for out loud — is not a
-  write and needs no endpoint: the address its provider reported is handed to
-  the operating system, and nothing reaches the provider; a spoken open still
-  runs only in a developer-opened turn, and a session that reported no address
-  is offered nowhere to open.
+  session — its row pressed, or the same press asked of Luke in conversation —
+  is not a write and needs no endpoint: the address its provider reported is
+  handed to the operating system, and nothing reaches the provider; an open
+  asked of Luke still runs only in a developer-opened turn, and a session that
+  reported no address is offered nowhere to open.
 - Keep unsupported capabilities explicit; do not invent fallback controls.
 - Keep Electron renderers sandboxed with context isolation and narrow IPC.
 - Commit only synthetic fixtures and repository-relative paths. This binds

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -72,6 +72,8 @@ import {
   isCredentialProviderId,
 } from "./shared/credential-providers";
 import {
+  askHotkeyReport,
+  DEFAULT_ASK_HOTKEYS,
   DEFAULT_VOICE_HOTKEYS,
   VOICE_HOTKEY_ABSENCE,
   type VoiceHotkeyAbsence,
@@ -239,6 +241,42 @@ function registerToggleHotkey(): void {
     return;
   }
   voiceHotkeyAbsence = VOICE_HOTKEY_ABSENCE.ALREADY_OWNED;
+}
+
+let askHotkey: string | undefined;
+
+/**
+ * Registers the key that summons the ask field from whatever app is frontmost,
+ * on the talk key's own terms: never during a capture run, and never for a
+ * conversation that cannot open — a system-wide key that answers nothing is a
+ * key taken from every other app for no reason. Electron's registration is
+ * enough here, because a summons has no release edge to hear.
+ *
+ * The press does two things in order: stands the panel up focused, then asks
+ * the renderer to put the caret in the field — or, when the caret is already
+ * there, the renderer reads the same press as the dismissal, so one key
+ * summons and puts away like every launcher does.
+ */
+function registerAskHotkey(): void {
+  if (captureMode) {
+    process.stderr.write(`${askHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.CAPTURE_RUN)}\n`);
+    return;
+  }
+  if (!realtimeCredentials) {
+    process.stderr.write(`${askHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.NO_CREDENTIAL)}\n`);
+    return;
+  }
+  for (const accelerator of DEFAULT_ASK_HOTKEYS) {
+    const registered = globalShortcut.register(accelerator, () => {
+      setWindowMode("expanded", true);
+      panelWindow?.webContents.send(channels.lifecycle, "ask:focus");
+    });
+    if (!registered) continue;
+    askHotkey = accelerator;
+    process.stderr.write(`${askHotkeyReport(askHotkey, VOICE_HOTKEY_ABSENCE.ALREADY_OWNED)}\n`);
+    return;
+  }
+  process.stderr.write(`${askHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.ALREADY_OWNED)}\n`);
 }
 
 /** Tells a renderer the key it should be showing, whenever that changes. */
@@ -483,6 +521,10 @@ function registerIpc(): void {
       realtimeAvailable: realtimeCredentials !== undefined,
       ...(voiceHotkey ? { voiceHotkey: voiceHotkeyLabel(voiceHotkey) } : {}),
       voiceHotkeyHeld,
+      // The accelerator rather than its label: the renderer needs both
+      // spellings — the keycap's ⌥L and aria's Alt+L — and only the
+      // accelerator can produce the pair.
+      ...(askHotkey ? { askHotkey } : {}),
       display: displayDiagnostic(),
       sessions: fixtureMode ? [] : sessionRegistry.snapshot().sessions,
       settings: await settingsStore.snapshot(),
@@ -1023,6 +1065,7 @@ if (!app.requestSingleInstanceLock()) {
     // moment later, and a line printed now would state an absence that only
     // exists because nobody has answered yet.
     registerVoiceHotkey();
+    registerAskHotkey();
     createPanel();
     configurePermissions();
     startSessionObservation();

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -73,8 +73,8 @@ import {
   isCredentialProviderId,
 } from "./shared/credential-providers";
 import {
+  askHotkeyCandidates,
   askHotkeyReport,
-  DEFAULT_ASK_HOTKEYS,
   parseVoiceHotkey,
   VOICE_HOTKEY_ABSENCE,
   type VoiceHotkeyAbsence,
@@ -266,6 +266,9 @@ let askHotkey: string | undefined;
  * summons and puts away like every launcher does.
  */
 function registerAskHotkey(): void {
+  // Re-runnable: moving the talk key lets everything go and registers afresh,
+  // and a key that could not be re-taken must not still be claimed anywhere.
+  askHotkey = undefined;
   if (captureMode) {
     process.stderr.write(`${askHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.CAPTURE_RUN)}\n`);
     return;
@@ -274,7 +277,9 @@ function registerAskHotkey(): void {
     process.stderr.write(`${askHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.NO_CREDENTIAL)}\n`);
     return;
   }
-  for (const accelerator of DEFAULT_ASK_HOTKEYS) {
+  // A chord the talk key sits on — chosen by the user, or announced as
+  // registered — is not a candidate: the two Luke keys must never compete.
+  for (const accelerator of askHotkeyCandidates([chosenVoiceHotkey, voiceHotkey])) {
     const registered = globalShortcut.register(accelerator, () => {
       setWindowMode("expanded", true);
       panelWindow?.webContents.send(channels.lifecycle, "ask:focus");
@@ -285,6 +290,16 @@ function registerAskHotkey(): void {
     return;
   }
   process.stderr.write(`${askHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.ALREADY_OWNED)}\n`);
+}
+
+/**
+ * Tells a renderer the ask key it should be teaching, whenever that changes.
+ * The raw accelerator travels, as in bootstrap: the renderer needs both its
+ * spellings, and an absent key clears the hint rather than leaving a keycap
+ * up for a chord that answers nothing.
+ */
+function sendAskHotkey(): void {
+  panelWindow?.webContents.send(channels.askHotkeyChanged, askHotkey);
 }
 
 /** Tells a renderer the key it should be showing, whenever that changes. */
@@ -303,14 +318,15 @@ function reportVoiceHotkey(): void {
  * Moves the talk key to whatever `chosenVoiceHotkey` now says, while the app
  * is running. The old key is let go of in full before the new one is asked
  * for, so the two can never race for the same chord — and letting everything
- * go is exact rather than broad, because the talk key candidates are the only
- * global accelerators Luke ever registers. Letting go means waiting: the
- * system releases the old helper's chord when its process exits, not when the
- * kill is asked for, and the defaults sit in both helpers' candidate lists —
- * a successor that starts too early is refused the very fallback it was
- * promised. The panel keeps showing the old key until the new one actually
- * answers: the helper announces its own registration over stdout, and every
- * path without a helper is decided by the time `registerVoiceHotkey` returns.
+ * go takes the ask key down with it, because `unregisterAll` is exactly that,
+ * so the ask key is registered afresh once the talk key has settled. Letting
+ * go means waiting: the system releases the old helper's chord when its
+ * process exits, not when the kill is asked for, and the defaults sit in both
+ * helpers' candidate lists — a successor that starts too early is refused the
+ * very fallback it was promised. The panel keeps showing the old key until
+ * the new one actually answers: the helper announces its own registration
+ * over stdout, and every path without a helper is decided by the time
+ * `registerVoiceHotkey` returns.
  */
 async function applyVoiceHotkey(): Promise<void> {
   const released = talkKeyWatcher?.stop();
@@ -322,6 +338,11 @@ async function applyVoiceHotkey(): Promise<void> {
   voiceHotkeyAbsence = VOICE_HOTKEY_ABSENCE.ALREADY_OWNED;
   registerVoiceHotkey();
   if (!talkKeyWatcher) sendVoiceHotkey();
+  // The ask key went down with `unregisterAll`, and the chord it can have may
+  // itself have changed — the talk key may have moved onto or off of one of
+  // its candidates — so it is re-taken now and the panel told what it teaches.
+  registerAskHotkey();
+  sendAskHotkey();
 }
 
 let windowMode: WindowMode = captureMode

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -107,6 +107,12 @@ const bridge: AppBridge = {
     ipcRenderer.on(channels.voiceHotkeyChanged, listener);
     return () => ipcRenderer.removeListener(channels.voiceHotkeyChanged, listener);
   },
+  onAskHotkeyChanged: (callback: (accelerator: string | undefined) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, accelerator: string | undefined) =>
+      callback(accelerator);
+    ipcRenderer.on(channels.askHotkeyChanged, listener);
+    return () => ipcRenderer.removeListener(channels.askHotkeyChanged, listener);
+  },
   onAttentionSpeech: (callback: (speech: readonly AttentionSpeech[]) => void) => {
     const listener = (_event: Electron.IpcRendererEvent, speech: readonly AttentionSpeech[]) =>
       callback(speech);

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -21,6 +21,7 @@ import { CREDENTIAL_SOURCE, SESSION_OPEN_RESULT_STATUS } from "../shared/contrac
 import type { CredentialProviderId } from "../shared/credential-providers";
 import { CREDENTIAL_PROVIDER_LIST } from "../shared/credential-providers";
 import { TALK_KEY_RELEASE, talkKeyRelease, voiceHotkeyToShow } from "../shared/voice-hotkey";
+import { ASK_LUKE_INPUT_ID, askRefusal, focusAskField } from "./ask-luke";
 import type { CredentialEntry, CredentialEntryControl } from "./credential-entry";
 import { isSubmittable, removalEndsEntry } from "./credential-entry";
 import { KeySlot } from "./key-slot";
@@ -234,11 +235,26 @@ export function App(): React.JSX.Element {
   const [localStream, setLocalStream] = useState<MediaStream>();
   const [remoteStream, setRemoteStream] = useState<MediaStream>();
   const [voiceCaption, setVoiceCaption] = useState<string>();
+  /**
+   * Whether the reply under way answers an ask the developer typed. A typed
+   * ask is read, not only heard, so its reply draws the caption whatever the
+   * captions preference says — the preference is about speech being
+   * duplicated, and here the words are the half of the conversation the
+   * developer chose. Cleared the moment the turn moves on.
+   */
+  const [typedAsk, setTypedAsk] = useState(false);
   const audioContext = useRef<AudioContext | undefined>(undefined);
   const hoverTimer = useRef<number | undefined>(undefined);
   const presentationRef = useRef<PanelPresentation>(PANEL_PRESENTATION.CAPSULE);
   const tabRef = useRef<PanelTab>(PANEL_TAB.SESSIONS);
   const entryRef = useRef<CredentialEntry | undefined>(undefined);
+  /**
+   * Whether the caret is in the ask field. It holds the panel open against the
+   * pointer the way a credential entry does, and for the same reason: the
+   * pointer wandering off is not a decision about the thing someone is in the
+   * middle of typing.
+   */
+  const askEngaged = useRef(false);
   const pointerInside = useRef(false);
   const modeGeneration = useRef(0);
   const remoteAudio = useRef<HTMLAudioElement | null>(null);
@@ -254,7 +270,7 @@ export function App(): React.JSX.Element {
    * anything.
    */
   const heardLuke = useRef(false);
-  const startMicrophoneRef = useRef<(() => Promise<void>) | undefined>(undefined);
+  const startMicrophoneRef = useRef<(() => Promise<MicrophoneStatus>) | undefined>(undefined);
   /**
    * The spoken form of pressing a row, reached through a ref for the same
    * reason `startMicrophoneRef` is: the voice session is built once, and the
@@ -351,7 +367,12 @@ export function App(): React.JSX.Element {
     await voiceSession.current?.close();
   }, []);
 
-  const startMicrophone = useCallback(async () => {
+  /**
+   * Opens the call, answering with what the system said about the microphone —
+   * the one fact a caller that could not send anything needs in order to say
+   * why.
+   */
+  const startMicrophone = useCallback(async (): Promise<MicrophoneStatus> => {
     setMicrophoneError(undefined);
     const session = ensureVoiceSession();
     const permission = await window.sidecar.requestMicrophone();
@@ -360,9 +381,10 @@ export function App(): React.JSX.Element {
       // The press that asked for this is still waiting for a call that is now
       // not coming.
       session.dropPendingTurn();
-      return;
+      return permission;
     }
     if (await session.connect()) session.updateSessions(sessionsRef.current);
+    return permission;
   }, [ensureVoiceSession]);
   startMicrophoneRef.current = startMicrophone;
 
@@ -525,10 +547,10 @@ export function App(): React.JSX.Element {
     // browser, fetching the key it is waiting for — so the pointer being away
     // from it is the normal case rather than a dismissal.
     if (current === PANEL_PRESENTATION.SLOT) return;
-    // A key half-typed is the one thing the pointer must not be allowed to
-    // discard. Everything else on the settings tab closes like the sessions
-    // tab does.
-    if (current === PANEL_PRESENTATION.PANEL && entryIsDrawn()) return;
+    // A key half-typed is one thing the pointer must not be allowed to
+    // discard; an ask being typed to Luke is the other. Everything else on
+    // the settings tab closes like the sessions tab does.
+    if (current === PANEL_PRESENTATION.PANEL && (entryIsDrawn() || askEngaged.current)) return;
     hoverTimer.current = window.setTimeout(() => {
       hoverTimer.current = undefined;
       if (presentationRef.current === PANEL_PRESENTATION.PEEK) {
@@ -538,11 +560,26 @@ export function App(): React.JSX.Element {
         // scheduled: an entry can begin inside the delay — pressing Connect and
         // reaching for the keyboard does exactly that — and a close decided
         // before it began would discard it.
-        if (entryIsDrawn()) return;
+        if (entryIsDrawn() || askEngaged.current) return;
         void changeMode(false);
       }
     }, LEAVE_DELAY_MS);
   }, [applyPresentation, cancelHoverTransition, changeMode, entryIsDrawn]);
+
+  /**
+   * The ask field taking or letting go of the caret. Letting go while the
+   * pointer is already away has to release the hold the caret had on the
+   * panel — the pointer cannot leave a second time — which is the same rule
+   * ending a credential entry follows.
+   */
+  const changeAskEngagement = useCallback(
+    (engaged: boolean) => {
+      const released = askEngaged.current && !engaged;
+      askEngaged.current = engaged;
+      if (released && !pointerInside.current) handleHitRegionLeave();
+    },
+    [handleHitRegionLeave],
+  );
 
   /**
    * The single place an entry changes. A key being entered holds the panel open
@@ -753,6 +790,51 @@ export function App(): React.JSX.Element {
   openSessionAloudRef.current = openSessionAloud;
 
   /**
+   * The ask key, pressed anywhere on the system. The main process has already
+   * stood the panel up focused; what is left is the caret — or the dismissal,
+   * because a summons repeated over its own open field is someone asking the
+   * launcher to go away, the same second press every launcher answers.
+   */
+  const summonAsk = useCallback(() => {
+    const field = document.getElementById(ASK_LUKE_INPUT_ID);
+    if (
+      presentationRef.current === PANEL_PRESENTATION.PANEL &&
+      field !== null &&
+      document.activeElement === field
+    ) {
+      cancelHoverTransition();
+      void changeMode(false);
+      return;
+    }
+    changeTab(PANEL_TAB.SESSIONS);
+    focusAskField();
+  }, [cancelHoverTransition, changeMode, changeTab]);
+
+  /**
+   * A typed ask to Luke himself. It rides the same call the talk key opens —
+   * permission, connect, then the turn — and opens the same kind of turn:
+   * typing is the developer asking in their own words, so the turn may carry
+   * a tool the way a spoken one may, behind the same roster gauntlet. Answers
+   * with why the ask could not go, or nothing when it did — the reply is
+   * spoken, and its words land under the panel as the answer.
+   */
+  const askLuke = useCallback(
+    async (text: string): Promise<string | undefined> => {
+      const session = ensureVoiceSession();
+      let microphone: MicrophoneStatus = "granted";
+      if (!session.isConnected) {
+        microphone = (await startMicrophoneRef.current?.()) ?? microphone;
+      }
+      if (session.sendText(text)) {
+        setTypedAsk(true);
+        return undefined;
+      }
+      return askRefusal(session.status, microphone);
+    },
+    [ensureVoiceSession],
+  );
+
+  /**
    * The two writes a row can ask for, handed to the main process by session
    * identity. Unlike opening, neither closes the panel: the answer lands back
    * on the row that asked, and the user is mid-conversation with it.
@@ -846,6 +928,7 @@ export function App(): React.JSX.Element {
       if (eventName === "mode:compact") applyAuthoritativeMode("compact");
       if (eventName === "mode:expanded") applyAuthoritativeMode("expanded");
       if (eventName === "tab:settings") changeTab(PANEL_TAB.SETTINGS);
+      if (eventName === "ask:focus") summonAsk();
     });
     const removeDisplay = window.sidecar.onDisplayChanged(setDisplay);
     const removeSessions = window.sidecar.onSessionsChanged(setSessions);
@@ -864,6 +947,7 @@ export function App(): React.JSX.Element {
     changeTab,
     startMicrophone,
     stopMicrophone,
+    summonAsk,
   ]);
 
   // The waveform follows whoever is actually talking: the developer while
@@ -897,7 +981,12 @@ export function App(): React.JSX.Element {
   useEffect(() => {
     voiceStatusRef.current = voiceStatus;
     // Each reply is heard from scratch, so the previous one cannot vouch for it.
-    if (voiceStatus !== REALTIME_STATUS.RESPONDING) heardLuke.current = false;
+    if (voiceStatus !== REALTIME_STATUS.RESPONDING) {
+      heardLuke.current = false;
+      // The reply that answered the typed ask is over, so the caption goes
+      // back to being the preference's to grant.
+      setTypedAsk(false);
+    }
   }, [voiceStatus]);
 
   useEffect(() => {
@@ -1044,14 +1133,16 @@ export function App(): React.JSX.Element {
   const shownHotkey = voiceHotkeyToShow(bootstrap, voiceHotkey);
   const fixtureSpeaking = bootstrap.profile === "speaking";
   const hasAudioSignal = fixtureSpeaking || analyser !== undefined;
-  // Luke's words, drawn only when captions are on and the reply they belong
-  // to is his turn: the preference is off by default, the session already
-  // clears the words when a reply ends or is cut off, and the turn gate keeps
-  // a caption that raced a status change from being drawn late. A capture run
-  // draws the fixture's words regardless, or the strip ships unphotographed.
+  // Luke's words, drawn only when there is a reason to read them and the reply
+  // they belong to is his turn: the captions preference, or the reply
+  // answering an ask the developer typed — a typed conversation's answer must
+  // be readable whatever the preference says. The session already clears the
+  // words when a reply ends or is cut off, and the turn gate keeps a caption
+  // that raced a status change from being drawn late. A capture run draws the
+  // fixture's words regardless, or the strip ships unphotographed.
   const lukeCaption = fixtureSpeaking
     ? FIXTURE_SPEAKING_CAPTION
-    : settings?.voiceCaptions === true && voiceTurn === WAVEFORM_VOICE.LUKE
+    : (settings?.voiceCaptions === true || typedAsk) && voiceTurn === WAVEFORM_VOICE.LUKE
       ? voiceCaption
       : undefined;
   const panelOpen = presentation === PANEL_PRESENTATION.PANEL;
@@ -1095,6 +1186,9 @@ export function App(): React.JSX.Element {
             now={now}
             onOpenSession={openSession}
             writes={sessionWrites}
+            ask={askLuke}
+            onAskEngaged={changeAskEngagement}
+            {...(bootstrap.askHotkey ? { askShortcut: bootstrap.askHotkey } : {})}
             offerOptions={offerOptions}
             optionsOpen={optionsOpen}
             onOptionsToggle={() => setOptionsOpen((open) => !open)}

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -247,6 +247,14 @@ export function App(): React.JSX.Element {
    */
   const [talkOpening, setTalkOpening] = useState(false);
   const [voiceHotkey, setVoiceHotkey] = useState<VoiceHotkeyState>();
+  /**
+   * The ask key as last re-taken, superseding bootstrap's once it has changed
+   * at all: moving the talk key re-registers every global chord, and the ask
+   * key can land somewhere new or nowhere. Wrapped so "changed to none" is
+   * told apart from "never changed" — the same reading order the talk key's
+   * own state follows.
+   */
+  const [askHotkeyChange, setAskHotkeyChange] = useState<{ accelerator?: string }>();
   const [localStream, setLocalStream] = useState<MediaStream>();
   const [remoteStream, setRemoteStream] = useState<MediaStream>();
   const [voiceCaption, setVoiceCaption] = useState<string>();
@@ -1212,6 +1220,13 @@ export function App(): React.JSX.Element {
   );
   useEffect(() => window.sidecar.onVoiceHotkeyRelease(endTalk), [endTalk]);
   useEffect(() => window.sidecar.onVoiceHotkeyChanged(setVoiceHotkey), []);
+  useEffect(
+    () =>
+      window.sidecar.onAskHotkeyChanged((accelerator) =>
+        setAskHotkeyChange(accelerator ? { accelerator } : {}),
+      ),
+    [],
+  );
 
   // The rows say how long ago each session was seen, and a label left alone
   // goes stale the moment a minute passes with no session changing — the very
@@ -1285,6 +1300,7 @@ export function App(): React.JSX.Element {
         ? WAVEFORM_VOICE.DEVELOPER
         : undefined;
   const shownHotkey = voiceHotkeyToShow(bootstrap, voiceHotkey);
+  const shownAskHotkey = askHotkeyChange ? askHotkeyChange.accelerator : bootstrap.askHotkey;
   const fixtureSpeaking = bootstrap.profile === "speaking";
   const hasAudioSignal = fixtureSpeaking || analyser !== undefined;
   // Luke's words, drawn only when there is a reason to read them and the reply
@@ -1342,7 +1358,7 @@ export function App(): React.JSX.Element {
             writes={sessionWrites}
             ask={askLuke}
             onAskEngaged={changeAskEngagement}
-            {...(bootstrap.askHotkey ? { askShortcut: bootstrap.askHotkey } : {})}
+            {...(shownAskHotkey ? { askShortcut: shownAskHotkey } : {})}
             offerOptions={offerOptions}
             optionsOpen={optionsOpen}
             onOptionsToggle={() => setOptionsOpen((open) => !open)}

--- a/apps/desktop/src/renderer/ask-luke.tsx
+++ b/apps/desktop/src/renderer/ask-luke.tsx
@@ -1,0 +1,218 @@
+import { REALTIME_STATUS, type RealtimeStatus } from "@sidecar/core";
+import { useCallback, useRef, useState } from "react";
+import type { MicrophoneStatus } from "../shared/contracts";
+import { voiceHotkeyLabel } from "../shared/voice-hotkey";
+import { FOCUS_FRAME_LIMIT } from "./credential-entry";
+import { SendIcon } from "./settings-icons";
+
+/**
+ * What the field is for, in the fewest words that say it. "Ask" rather than
+ * "message": Luke answers rather than receives, and the reply arrives out
+ * loud with its words landing right below the field.
+ */
+const ASK_PLACEHOLDER = "Ask Luke…";
+
+/**
+ * How the ask field is found from outside the component, the way the options
+ * sheet is found by its id: the ask key is answered at the app level, where
+ * the panel it may have to open lives, and the field it lands in is here.
+ */
+export const ASK_LUKE_INPUT_ID = "ask-luke-input";
+
+/**
+ * Puts the caret in the ask field, waiting out the panel's arrival on the way.
+ *
+ * The ask key can arrive with the panel closed or with Settings showing, so
+ * the field it is reaching for may not be drawn until React has answered —
+ * and a hidden stage refuses focus outright, the same trap `focusWhenVisible`
+ * waits out. So this seeks by id, frame by frame, until the field exists and
+ * is visible, and gives up on the same backstop rather than holding an
+ * intention forever.
+ */
+export function focusAskField(): () => void {
+  let frame = 0;
+  let frames = 0;
+  const take = () => {
+    const element = document.getElementById(ASK_LUKE_INPUT_ID);
+    if (element && getComputedStyle(element).visibility === "visible") {
+      element.focus({ preventScroll: true });
+      return;
+    }
+    if (frames++ > FOCUS_FRAME_LIMIT) return;
+    frame = requestAnimationFrame(take);
+  };
+  take();
+  return () => cancelAnimationFrame(frame);
+}
+
+/**
+ * Carries one typed ask to the conversation. Answers with why it could not be
+ * sent, or with nothing when it was — the reply itself is spoken, so a sent
+ * ask needs no confirmation line under a field the answer is about to land
+ * beside.
+ */
+export type AskHandler = (text: string) => Promise<string | undefined>;
+
+/**
+ * Why an ask could not be opened, said in one sentence the field can show.
+ *
+ * The refusal is diagnosed from the same two facts the settings rows draw —
+ * how far the voice loop got, and what the system said about the microphone —
+ * so the sentence under the field and the rows in settings can never tell two
+ * different stories.
+ */
+export function askRefusal(status: RealtimeStatus, microphone: MicrophoneStatus): string {
+  if (status === REALTIME_STATUS.LISTENING) {
+    return "The microphone is open — finish saying it instead.";
+  }
+  if (status === REALTIME_STATUS.UNAVAILABLE) {
+    return "Asking Luke needs an OpenAI API key — connect one in Settings.";
+  }
+  if (status === REALTIME_STATUS.CONNECTING) {
+    return "Still connecting — ask again in a moment.";
+  }
+  if (microphone !== "granted") {
+    return "Luke answers out loud, so the conversation needs the microphone — allow it in Settings.";
+  }
+  if (status === REALTIME_STATUS.FAILED) {
+    return "The conversation could not be opened — Settings says why.";
+  }
+  return "Luke could not take that just now.";
+}
+
+/**
+ * The panel's own composer: one pill under the session list, addressed to Luke
+ * rather than to any session. Typing is the developer's half of the
+ * conversation, so the pill answers in their green — the colour the meter
+ * gives their voice — and the reply lands as Luke's spoken words, captioned at
+ * the panel's foot directly below the field that asked.
+ *
+ * Sending is deliberately quiet. A sent ask clears the field and nothing else:
+ * the reply beginning is the confirmation, and a line saying "sent" would sit
+ * between the question and its answer. Only a refusal earns a sentence, and it
+ * leaves the draft in place, because a refused ask is still the developer's
+ * words.
+ */
+export function AskLuke({
+  ask,
+  onEngagedChange,
+  rowIndex,
+  shortcut,
+}: {
+  ask: AskHandler;
+  /**
+   * Whether someone is part-way through an ask, which is what holds the panel
+   * open against the pointer wandering off — the same hold a half-typed
+   * credential has. The caret is the signal: a draft someone walked away from
+   * is not a reason to pin the panel forever.
+   */
+  onEngagedChange: (engaged: boolean) => void;
+  /** Where the field stands in the panel's arrival stack, after the rows. */
+  rowIndex: number;
+  /**
+   * The accelerator the main process actually registered for summoning this
+   * field, absent when every candidate was refused. The pill teaches only a
+   * key that answers — a hint for a chord another app owns would be a lie.
+   */
+  shortcut?: string;
+}): React.JSX.Element {
+  const [draft, setDraft] = useState("");
+  const [asking, setAsking] = useState(false);
+  const [refusal, setRefusal] = useState<string>();
+  const field = useRef<HTMLInputElement | null>(null);
+  /**
+   * One ask at a time, as a ref rather than state for the same reason the row
+   * composer holds one: disabling only lands with the next render, and a
+   * second Enter inside that window would ask the same question twice.
+   */
+  const askInFlight = useRef(false);
+
+  const submit = useCallback(async () => {
+    const text = draft.trim();
+    if (!text || askInFlight.current) return;
+    askInFlight.current = true;
+    setAsking(true);
+    setRefusal(undefined);
+    try {
+      const reason = await ask(text);
+      if (reason) {
+        // The draft stays: a refused ask is still the developer's words.
+        setRefusal(reason);
+      } else {
+        // The ask has become the conversation's; the field empties for the
+        // next one, and the caret stays for it.
+        setDraft("");
+      }
+    } finally {
+      askInFlight.current = false;
+      setAsking(false);
+    }
+  }, [ask, draft]);
+
+  return (
+    <div className="ask-luke-row" style={{ "--row-index": rowIndex } as React.CSSProperties}>
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: pointer-only by design — the keyboard already lands in the field by tabbing, and the click handler only places the caret. */}
+      <form
+        className="ask-luke"
+        data-asking={String(asking)}
+        data-draft={String(draft.length > 0)}
+        onSubmit={(event) => {
+          event.preventDefault();
+          void submit();
+        }}
+        // The whole pill is the field: a press on its padding or its glow is
+        // someone reaching for the caret, so the caret is what they get.
+        onClick={() => field.current?.focus()}
+      >
+        <input
+          ref={field}
+          id={ASK_LUKE_INPUT_ID}
+          className="ask-luke-input"
+          aria-label="Ask Luke"
+          {...(shortcut ? { "aria-keyshortcuts": shortcut } : {})}
+          placeholder={ASK_PLACEHOLDER}
+          autoComplete="off"
+          spellCheck={false}
+          value={draft}
+          onChange={(event) => {
+            // Typing again answers the refusal, so the refusal goes.
+            setRefusal(undefined);
+            setDraft(event.target.value);
+          }}
+          onFocus={() => {
+            // The panel can be showing without its window being key, and a
+            // field that cannot be typed into is worse than no field.
+            window.sidecar.focusPanel();
+            onEngagedChange(true);
+          }}
+          onBlur={() => onEngagedChange(false)}
+          onKeyDown={(event) => {
+            // Escape lets go of the field rather than closing the panel
+            // behind it. The draft survives: the field is not going anywhere.
+            if (event.key === "Escape") {
+              event.stopPropagation();
+              event.currentTarget.blur();
+            }
+          }}
+        />
+        {/* How the reach is learned: the keycap surfaces under a hovering
+            pointer and stands down once the caret is in or a draft holds the
+            field — whoever it could teach already knows. Drawn only for a key
+            the system actually granted, in the label macOS writes it with.
+            Left readable: a reader announcing the keycap agrees with
+            aria-keyshortcuts. */}
+        {shortcut ? <kbd className="ask-luke-hint">{voiceHotkeyLabel(shortcut)}</kbd> : null}
+        <button
+          type="submit"
+          className="ask-luke-send"
+          aria-label="Ask Luke"
+          title="Ask Luke"
+          disabled={asking || !draft.trim()}
+        >
+          <SendIcon />
+        </button>
+      </form>
+      {refusal ? <small className="ask-luke-refusal">{refusal}</small> : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/credential-entry.ts
+++ b/apps/desktop/src/renderer/credential-entry.ts
@@ -91,7 +91,7 @@ export function removalEndsEntry(
 }
 
 /** Long enough for any stage to arrive, and short enough to be a backstop. */
-const FOCUS_FRAME_LIMIT = 60;
+export const FOCUS_FRAME_LIMIT = 60;
 
 /**
  * Hands focus to an element as soon as it can take it, and answers with the way

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -6,6 +6,7 @@ import {
   SESSION_STATE,
 } from "@sidecar/core";
 import { useCallback, useRef, useState } from "react";
+import { type AskHandler, AskLuke } from "./ask-luke";
 import { PANEL_TAB, type PanelTab, TabBar } from "./panel-tabs";
 import { CloudBadge, ProviderMark } from "./provider-marks";
 import {
@@ -398,6 +399,12 @@ export interface PanelBodyProps {
   onOpenSession: (session: DisplaySession) => void;
   /** Carries a typed reply or an advertised action to the session's provider. */
   writes: SessionWriteHandlers;
+  /** Carries a typed ask to Luke's own conversation, answering why it could not go. */
+  ask: AskHandler;
+  /** Reports someone being part-way through an ask, so the panel holds for them. */
+  onAskEngaged: (engaged: boolean) => void;
+  /** The registered summon key the field should teach, if the system granted one. */
+  askShortcut?: string;
   /**
    * Whether there is anything for the sheet to decide. Decided by the panel
    * rather than here, because whoever offers the button also has to be the one
@@ -419,6 +426,9 @@ export function PanelBody({
   now,
   onOpenSession,
   writes,
+  ask,
+  onAskEngaged,
+  askShortcut,
   offerOptions,
   optionsOpen,
   onOptionsToggle,
@@ -463,6 +473,16 @@ export function PanelBody({
               ))
             )}
           </div>
+          {/* Luke's own composer holds the panel's foot, under whatever the
+              list shows — even an empty one, because "what needs me?" is a
+              question worth typing before any session has appeared. It arrives
+              at the tail of the same fan the rows ride. */}
+          <AskLuke
+            ask={ask}
+            onEngagedChange={onAskEngaged}
+            rowIndex={rows.length + 1}
+            {...(askShortcut ? { shortcut: askShortcut } : {})}
+          />
         </SessionsPanel>
       )}
     </div>

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -187,6 +187,17 @@ export class RealtimeVoiceSession {
    * message to cut, and how much of it reached the room.
    */
   #responseItemId: string | undefined;
+  /**
+   * The response now under way, as the server named it when it confirmed the
+   * reply had started — or nothing between asking for a reply and that
+   * confirmation. It is what tells the current reply's `response.done` from a
+   * cancelled one's: the server had finished composing the old reply before
+   * the cancel landed, so its `done` still arrives, and it can carry tool
+   * calls. Matching the id is what keeps those calls from being answered with
+   * the new turn's arming — the turn that superseded them, not the one that
+   * asked.
+   */
+  #activeResponseId: string | undefined;
   #audibleSince: number | undefined;
   /**
    * The words of the reply being spoken, as far as they have arrived. Kept
@@ -582,6 +593,11 @@ export class RealtimeVoiceSession {
     // stops the transcript still trailing in — the server had produced it
     // before the cancel landed — from ever matching the caption again.
     this.#responseItemId = undefined;
+    // And forgetting its response is what stops its finished form — cancelled
+    // or not, the server may already have completed it — from being read as
+    // the current turn's: a `response.done` that matches nothing can neither
+    // act with the new turn's arming nor end the new turn early.
+    this.#activeResponseId = undefined;
     this.#generationDone = false;
     this.#remoteQuiet = false;
     this.#clearSettleTimer();
@@ -648,6 +664,7 @@ export class RealtimeVoiceSession {
     this.#remoteQuiet = false;
     this.#pendingTurn = false;
     this.#responseItemId = undefined;
+    this.#activeResponseId = undefined;
     this.#audibleSince = undefined;
     this.#setCaption(undefined);
     // Learned about this call, so it does not outlive it.
@@ -668,6 +685,10 @@ export class RealtimeVoiceSession {
     this.#generationDone = false;
     this.#remoteQuiet = false;
     this.#responseItemId = undefined;
+    // Nothing has been confirmed for this turn yet: whatever `response.done`
+    // arrives before the server confirms this reply belongs to a superseded
+    // one, and must find no active response to match.
+    this.#activeResponseId = undefined;
     this.#audibleSince = undefined;
     // A new turn: only a developer-opened one may run a tool, and any tool
     // follow-up still awaiting from the last turn will see this and stand down.
@@ -813,7 +834,12 @@ export class RealtimeVoiceSession {
     }
     if (type === REALTIME_SERVER_EVENT.RESPONSE_CREATED) {
       // The reply being asked for is under way, so anything arriving from here
-      // belongs to it rather than to the one it replaced.
+      // belongs to it rather than to the one it replaced. Its name is what a
+      // `response.done` must present to be read as this reply's: the channel
+      // is ordered, so a cancelled reply's `done` lands before this
+      // confirmation and finds nothing to match.
+      const response = (event as { response?: { id?: unknown } }).response;
+      if (typeof response?.id === "string") this.#activeResponseId = response.id;
       this.#unsilenceLuke();
     }
     if (type === REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA) {
@@ -848,14 +874,24 @@ export class RealtimeVoiceSession {
       return;
     }
     if (type === REALTIME_SERVER_EVENT.RESPONSE_DONE) {
+      // Whether this is the reply now under way, or the finished form of one
+      // the developer already talked or typed over. The server had completed
+      // the old reply before the cancel landed — it generates ahead of the
+      // room — so its `done` still arrives, after the interrupt has already
+      // opened a new turn. Nothing of it may act with that turn's arming or
+      // end that turn early: its calls are answered refused so the model is
+      // not left waiting, and everything else about it is ignored.
+      const doneId = (event as { response?: { id?: unknown } }).response?.id;
+      const fresh = (typeof doneId === "string" ? doneId : undefined) === this.#activeResponseId;
       // A reply that asked for tools has not finished talking: the calls are
       // answered and the reply resumes over their outcomes, so the turn stays
       // open rather than ending on a reply that was only half made.
       const calls = realtimeFunctionCalls(event);
       if (calls.length > 0) {
-        void this.#answerToolCalls(calls);
+        void this.#answerToolCalls(calls, fresh && this.#toolTurnArmed);
         return;
       }
+      if (!fresh) return;
       // Generation is done; the reply is not. The turn ends when Luke stops
       // being audible, which the caller reports from the audio itself rather
       // than from an event — the one that would say so is undocumented.
@@ -893,15 +929,16 @@ export class RealtimeVoiceSession {
    * carrier's own failure is an outcome rather than an exception: the developer
    * asked for something, and what became of it has to be said.
    */
-  async #answerToolCalls(calls: readonly RealtimeFunctionCall[]): Promise<void> {
-    // The hard gate: a write runs only in a turn the developer opened — by
-    // speaking, or by typing. A call on any other turn — one Luke opened to
-    // read a notice or to voice an outcome — is refused whatever it names, so a
-    // session summary or a tool output that reads like an instruction can never
-    // make Luke act.
-    // The turn's tools are also withheld at the API, so this is belt to that
-    // suspenders rather than the only thing holding.
-    const armed = this.#toolTurnArmed;
+  async #answerToolCalls(calls: readonly RealtimeFunctionCall[], armed: boolean): Promise<void> {
+    // `armed` is the hard gate, decided by the caller from two facts together:
+    // a write runs only in a turn the developer opened — by speaking, or by
+    // typing — and only out of the reply that turn actually asked for, never
+    // the finished form of one the developer already interrupted. A call
+    // failing either test is refused whatever it names, so a session summary
+    // or a tool output that reads like an instruction can never make Luke act.
+    // The turn's tools are also withheld at the API on every turn Luke opens
+    // himself, so this is belt to that suspenders rather than the only thing
+    // holding.
     // The turn these calls belong to. If it is no longer the current turn by
     // the time the writes finish, the developer has moved on and the outcome
     // must not be spoken over whatever they are now saying or hearing.

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -19,6 +19,7 @@ import {
   sessionContextText,
   sessionToolAction,
   truncateResponseEvents,
+  typedAskEvents,
 } from "@sidecar/core";
 
 const SDP_CONTENT_TYPE = "application/sdp";
@@ -178,14 +179,15 @@ export class RealtimeVoiceSession {
   #audioEndingsReported = false;
   #settleTimer: ReturnType<typeof setTimeout> | undefined;
   /**
-   * Whether the turn now under way is one the developer opened by speaking, and
-   * so the one and only turn a tool call may run in. It is set true when a
-   * push-to-talk commit opens a response and false for every turn Luke opens
-   * himself — a proactive readout, the reply that voices a tool's outcome — so
-   * a session summary or a tool output that reads like an instruction can never
-   * make Luke act. Nothing that decides on the developer's behalf reaches a
-   * write path; this is the runtime half of that, beside the standing
-   * instructions and the `tool_choice` withheld on every turn but this one.
+   * Whether the turn now under way is one the developer opened themselves — by
+   * speaking, or by typing an ask — and so the one and only kind of turn a tool
+   * call may run in. It is set true when a push-to-talk commit or a typed ask
+   * opens a response and false for every turn Luke opens himself — a proactive
+   * readout, the reply that voices a tool's outcome — so a session summary or a
+   * tool output that reads like an instruction can never make Luke act. Nothing
+   * that decides on the developer's behalf reaches a write path; this is the
+   * runtime half of that, beside the standing instructions and the
+   * `tool_choice` withheld on every turn Luke opens himself.
    */
   #toolTurnArmed = false;
   /**
@@ -468,27 +470,7 @@ export class RealtimeVoiceSession {
     if (this.#status === REALTIME_STATUS.LISTENING) return false;
     // Talking over Luke stops it. The developer's turn always wins, which is
     // the whole point of a key that means "it is my turn now".
-    if (this.#status === REALTIME_STATUS.RESPONDING) {
-      // Stop the words that are already on their way, then stop more being
-      // made. A disabled track drops what is buffered rather than playing it
-      // out, so the cut-off is immediate rather than eventual.
-      this.#silenceLuke();
-      // The caption is cut with the audio. It already held words the room
-      // never heard — the text runs ahead of the speech — and leaving them up
-      // would show Luke finishing a sentence he was just stopped from saying.
-      this.#setCaption(undefined);
-      this.#send(cancelResponseEvents());
-      // Then correct what Luke believes he said, or the next answer is free to
-      // refer back to a sentence that never reached the room.
-      this.#send(this.#truncateEvents());
-      // The trim was this reply's last word: forgetting its item here is what
-      // stops the transcript still trailing in — the server had produced it
-      // before the cancel landed — from ever matching the caption again.
-      this.#responseItemId = undefined;
-      this.#generationDone = false;
-      this.#remoteQuiet = false;
-      this.#clearSettleTimer();
-    }
+    if (this.#status === REALTIME_STATUS.RESPONDING) this.#interruptReply();
     // Start from an empty buffer: a muted track still transmits, and with turn
     // detection off the server keeps everything since the last commit.
     this.#send(clearInputAudioEvents());
@@ -514,9 +496,57 @@ export class RealtimeVoiceSession {
       this.#setStatus(REALTIME_STATUS.READY);
       return;
     }
-    // The one turn a tool may run in: the developer opened it and spoke into
-    // it, so a tool call it emits is the developer's own ask.
+    // A turn a tool may run in: the developer opened it and spoke into it, so
+    // a tool call it emits is the developer's own ask.
     this.#startResponse(pushToTalkCommitEvents(), true);
+  }
+
+  /**
+   * Sends a typed ask and requests the reply to it, reporting whether it
+   * could. Typing is the developer opening a turn, exactly as holding the talk
+   * key is, so the turn is armed for tools on the same terms as a push-to-talk
+   * commit: a write out of it is the developer's own request, made in their
+   * own words.
+   *
+   * An ask arriving over a reply interrupts it — the developer's turn always
+   * wins, however it is taken. The one thing it will not interrupt is the
+   * developer's own open microphone: half a spoken question is still theirs,
+   * and a keystroke is no reason to discard it.
+   */
+  sendText(text: string): boolean {
+    if (!this.isConnected) return false;
+    if (this.#status === REALTIME_STATUS.LISTENING) return false;
+    const events = typedAskEvents(text);
+    if (events.length === 0) return false;
+    if (this.#status === REALTIME_STATUS.RESPONDING) this.#interruptReply();
+    this.#startResponse(events, true);
+    return true;
+  }
+
+  /**
+   * Cuts off the reply under way so the developer's new turn does not land on
+   * top of it.
+   */
+  #interruptReply(): void {
+    // Stop the words that are already on their way, then stop more being
+    // made. A disabled track drops what is buffered rather than playing it
+    // out, so the cut-off is immediate rather than eventual.
+    this.#silenceLuke();
+    // The caption is cut with the audio. It already held words the room
+    // never heard — the text runs ahead of the speech — and leaving them up
+    // would show Luke finishing a sentence he was just stopped from saying.
+    this.#setCaption(undefined);
+    this.#send(cancelResponseEvents());
+    // Then correct what Luke believes he said, or the next answer is free to
+    // refer back to a sentence that never reached the room.
+    this.#send(this.#truncateEvents());
+    // The trim was this reply's last word: forgetting its item here is what
+    // stops the transcript still trailing in — the server had produced it
+    // before the cancel landed — from ever matching the caption again.
+    this.#responseItemId = undefined;
+    this.#generationDone = false;
+    this.#remoteQuiet = false;
+    this.#clearSettleTimer();
   }
 
   /**
@@ -808,10 +838,11 @@ export class RealtimeVoiceSession {
    * asked for something, and what became of it has to be said.
    */
   async #answerToolCalls(calls: readonly RealtimeFunctionCall[]): Promise<void> {
-    // The hard gate: a write runs only in the turn the developer opened by
-    // speaking. A call on any other turn — one Luke opened to read a notice or
-    // to voice an outcome — is refused whatever it names, so a session summary
-    // or a tool output that reads like an instruction can never make Luke act.
+    // The hard gate: a write runs only in a turn the developer opened — by
+    // speaking, or by typing. A call on any other turn — one Luke opened to
+    // read a notice or to voice an outcome — is refused whatever it names, so a
+    // session summary or a tool output that reads like an instruction can never
+    // make Luke act.
     // The turn's tools are also withheld at the API, so this is belt to that
     // suspenders rather than the only thing holding.
     const armed = this.#toolTurnArmed;

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -280,8 +280,11 @@ body,
   user-select: none;
 }
 
-/* The one place a selection is wanted. */
-.settings-input {
+/* The places a selection is wanted: a credential being pasted, and an ask
+   being written — the one field whose contents are worth re-reading and
+   reworking before they are sent. */
+.settings-input,
+.ask-luke-input {
   -webkit-user-select: text;
   user-select: text;
 }
@@ -1360,7 +1363,8 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 .settings-section,
 .quit-button,
 .empty-state,
-.panel-header {
+.panel-header,
+.ask-luke-row {
   --row-delay: 0s;
 
   opacity: 0;
@@ -1388,7 +1392,8 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 .app-stage[data-presentation="panel"] .settings-section,
 .app-stage[data-presentation="panel"] .quit-button,
 .app-stage[data-presentation="panel"] .empty-state,
-.app-stage[data-presentation="panel"] .panel-header {
+.app-stage[data-presentation="panel"] .panel-header,
+.app-stage[data-presentation="panel"] .ask-luke-row {
   --row-delay: calc(
     var(--expand-delay) +
     min(var(--row-index, 0), var(--row-fan-limit)) *

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -698,3 +698,144 @@ html[data-keyboard="true"] button.row-main:focus-visible {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* Ask Luke ----------------------------------------------------------------- */
+
+/* The panel's own composer, pinned under the list. It arrives at the tail of
+   the row fan (the wrapper is in base.css's arrival stack) and holds the
+   panel's foot — which is where Luke's caption rides when he answers, so the
+   question and its answer share an edge. */
+.ask-luke-row {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  gap: 5px;
+  margin-top: 10px;
+}
+
+/* The same pill every row composer draws, sized up a step because it addresses
+   Luke rather than one session. A press anywhere in it lands the caret, so the
+   whole pill says text. */
+.ask-luke {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 7px;
+  padding: 4px 4px 4px 14px;
+  border: 1px solid var(--hairline);
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.4);
+  cursor: text;
+  transition:
+    border-color var(--duration-hover) ease,
+    background-color var(--duration-hover) ease;
+}
+
+/* Typing is the developer's half of the conversation, so the pill takes their
+   green — the colour the meter gives their voice, and nowhere else on the
+   surface — where a session's composer takes the working blue. */
+.ask-luke:focus-within {
+  border-color: color-mix(in srgb, var(--voice-developer) 50%, transparent);
+  background: rgba(0, 0, 0, 0.55);
+}
+
+/* The field itself is bare: the pill around it is the drawn edge. */
+.ask-luke-input {
+  min-width: 0;
+  flex: 1;
+  padding: 6px 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 12px;
+  outline: none;
+}
+
+.ask-luke-input::placeholder {
+  color: var(--text-tertiary);
+}
+
+/* How the reach is learned: the keycap surfaces while the pointer is over the
+   pill and stands down again once the caret is in or a draft holds the field —
+   whoever it could teach already knows. It keeps its layout box in every
+   state and only fades, so hovering re-shapes nothing, and it takes no
+   pointer: a press on it is a press on the field it names. */
+.ask-luke-hint {
+  flex: 0 0 auto;
+  padding: 2.5px 6px;
+  border: 1px solid var(--hairline);
+  border-radius: 6px;
+  background: var(--raised);
+  color: var(--text-tertiary);
+  font-family: inherit;
+  font-size: 9px;
+  font-weight: 620;
+  letter-spacing: 0.4px;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--duration-hover) ease;
+}
+
+.ask-luke[data-draft="false"]:hover:not(:focus-within) .ask-luke-hint {
+  opacity: 1;
+}
+
+/* Lit only once there is something to ask, in the same green the pill focuses
+   with: pressing it is the developer taking their turn. Colour is the whole
+   state change — the button must not grow or move inside an element that
+   reflows the pill. */
+.ask-luke-send {
+  display: grid;
+  width: 26px;
+  height: 26px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.14);
+  color: var(--text-tertiary);
+  place-items: center;
+  transition:
+    background-color var(--duration-hover) ease,
+    color var(--duration-hover) ease;
+}
+
+.ask-luke-send:not(:disabled) {
+  background: var(--voice-developer);
+  color: rgba(0, 0, 0, 0.82);
+}
+
+.ask-luke-send:disabled {
+  cursor: default;
+}
+
+.ask-luke-send .control-icon {
+  width: 12px;
+  height: 12px;
+}
+
+/* An ask on its way to a call that may still be opening: the disc breathes
+   instead of a spinner arriving, because nothing in the pill may change size.
+   It holds still under the same token as every other loop — a capture must
+   land on one frame, and reduced motion asked for stillness. */
+.ask-luke[data-asking="true"] .ask-luke-send {
+  animation: ask-luke-breathe 900ms ease-in-out infinite;
+  animation-play-state: var(--loop-motion);
+}
+
+@keyframes ask-luke-breathe {
+  50% {
+    opacity: 0.45;
+  }
+}
+
+/* Why the ask could not go, said once under the pill and replaced by typing.
+   A sent ask draws nothing here: the reply beginning is the confirmation. */
+.ask-luke-refusal {
+  overflow: hidden;
+  padding: 0 14px;
+  color: var(--text-tertiary);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -143,6 +143,13 @@ export interface AppBootstrap {
    * the panel says which of the two the user actually has.
    */
   voiceHotkeyHeld: boolean;
+  /**
+   * The accelerator that summons the ask field from any app, absent when the
+   * system refused every candidate. The raw accelerator rather than a label,
+   * because the renderer needs both spellings: the keycap's ⌥L and aria's
+   * Alt+L.
+   */
+  askHotkey?: string;
   /** Whether the panel should show the voice diagnostics block. */
   display: DisplayDiagnostic;
   sessions: readonly NormalizedSession[];

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -268,6 +268,12 @@ export interface AppBridge {
    * it means asking a helper, and it can change if that helper stops answering.
    */
   onVoiceHotkeyChanged(callback: (state: VoiceHotkeyState) => void): () => void;
+  /**
+   * The ask key being re-taken — moving the talk key lets every global chord
+   * go, so the ask key can land somewhere new or nowhere. Absent means the
+   * hint comes down: a keycap must not teach a chord that answers nothing.
+   */
+  onAskHotkeyChanged(callback: (accelerator: string | undefined) => void): () => void;
 }
 
 export const channels = {
@@ -293,6 +299,7 @@ export const channels = {
   voiceHotkeyPress: "app:voice-hotkey-press",
   voiceHotkeyRelease: "app:voice-hotkey-release",
   voiceHotkeyChanged: "app:voice-hotkey-changed",
+  askHotkeyChanged: "app:ask-hotkey-changed",
   rendererReady: "app:renderer-ready",
   lifecycle: "app:lifecycle",
   displayChanged: "app:display-changed",

--- a/apps/desktop/src/shared/voice-hotkey.ts
+++ b/apps/desktop/src/shared/voice-hotkey.ts
@@ -30,6 +30,17 @@ export const DEFAULT_VOICE_HOTKEYS: readonly string[] = ["Alt+Space", "Alt+S"];
 export const DEFAULT_ASK_HOTKEYS: readonly string[] = ["Alt+L", "Alt+Shift+L"];
 
 /**
+ * The ask chords worth asking the system for, with any the talk key holds
+ * left out. The talk key is configurable now, so a user can move it onto an
+ * ask default — and the two Luke keys must never compete for one chord:
+ * whichever registered first would silently cost the other its whole feature,
+ * with nothing on screen saying why.
+ */
+export function askHotkeyCandidates(taken: readonly (string | undefined)[]): readonly string[] {
+  return DEFAULT_ASK_HOTKEYS.filter((candidate) => !taken.includes(candidate));
+}
+
+/**
  * The modifiers a talk key may carry, written the way Electron accelerators
  * name them. Their order here is the order macOS writes a chord in — ⌃⌥⇧⌘ —
  * so every accelerator this module produces reads the way the menu bar would

--- a/apps/desktop/src/shared/voice-hotkey.ts
+++ b/apps/desktop/src/shared/voice-hotkey.ts
@@ -17,6 +17,19 @@
 export const DEFAULT_VOICE_HOTKEYS: readonly string[] = ["Alt+Space", "Alt+S"];
 
 /**
+ * The key that summons the ask field from whatever app is frontmost, tried in
+ * order like the talk key's candidates.
+ *
+ * A sibling of the talk key on purpose: hold Option-Space to speak to Luke,
+ * tap Option-L to type to him — one modifier for both halves of the same
+ * conversation. It is deliberately not Command-L, which is the address bar in
+ * every browser and a taken chord in most editors; a global registration
+ * would swallow it machine-wide. Option-L costs the system only the ¬
+ * character, and Option-letter is the family launcher apps already claim.
+ */
+export const DEFAULT_ASK_HOTKEYS: readonly string[] = ["Alt+L", "Alt+Shift+L"];
+
+/**
  * The talk key a panel should show.
  *
  * Two things can say what the key is, and neither is reliably first. The helper
@@ -123,4 +136,14 @@ const ABSENCE_REASONS: Readonly<Record<VoiceHotkeyAbsence, string>> = {
 export function voiceHotkeyReport(hotkey: string | undefined, absence: VoiceHotkeyAbsence): string {
   if (hotkey) return `Luke talk key: ${voiceHotkeyLabel(hotkey)}`;
   return `Luke talk key: unavailable — ${ABSENCE_REASONS[absence]}`;
+}
+
+/**
+ * The startup line for the ask key, on the talk key's exact terms: the two
+ * are the two halves of one conversation, and their absences have the same
+ * three causes.
+ */
+export function askHotkeyReport(hotkey: string | undefined, absence: VoiceHotkeyAbsence): string {
+  if (hotkey) return `Luke ask key: ${voiceHotkeyLabel(hotkey)}`;
+  return `Luke ask key: unavailable — ${ABSENCE_REASONS[absence]}`;
 }

--- a/apps/desktop/tests/ask-luke.test.ts
+++ b/apps/desktop/tests/ask-luke.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { REALTIME_STATUS } from "@sidecar/core";
+import { askRefusal } from "../src/renderer/ask-luke";
+
+test("a refused ask is diagnosed from how far the voice loop got", () => {
+  // No key is the one refusal with a fix the developer can go and do, so it
+  // names where the fix lives.
+  assert.match(askRefusal(REALTIME_STATUS.UNAVAILABLE, "granted"), /API key/);
+  assert.match(askRefusal(REALTIME_STATUS.UNAVAILABLE, "granted"), /Settings/);
+  // An open microphone is the developer's own turn, not a fault.
+  assert.match(askRefusal(REALTIME_STATUS.LISTENING, "granted"), /microphone is open/i);
+  assert.match(askRefusal(REALTIME_STATUS.CONNECTING, "granted"), /connecting/i);
+  assert.match(askRefusal(REALTIME_STATUS.FAILED, "granted"), /Settings/);
+});
+
+test("a missing microphone explains the conversation, not the keystroke", () => {
+  // The reply is spoken, so the call needs the device even though typing does
+  // not — the sentence has to say why a text field wants a microphone.
+  for (const microphone of ["denied", "restricted", "not-determined", "unknown"] as const) {
+    const refusal = askRefusal(REALTIME_STATUS.IDLE, microphone);
+    assert.match(refusal, /microphone/i);
+    assert.match(refusal, /out loud/i);
+  }
+});
+
+test("a failure the loop cannot name still answers with something to do", () => {
+  assert.ok(askRefusal(REALTIME_STATUS.READY, "granted").length > 0);
+});

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -1028,6 +1028,136 @@ function armDeveloperTurn(context: Harness): void {
   context.session.stopListening(true);
 }
 
+test("a typed ask opens a developer turn and asks for the reply to it", async () => {
+  const context = harness();
+  await context.session.connect();
+  const sentBefore = context.sent.length;
+
+  assert.equal(context.session.sendText("What needs me right now?"), true);
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+  // The microphone stays exactly as it was: typing never opens the device.
+  assert.equal(context.microphoneEnabled(), false);
+  const events = context.sent.slice(sentBefore);
+  assert.deepEqual(
+    events.map((event) => event.type),
+    [REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE, REALTIME_CLIENT_EVENT.RESPONSE_CREATE],
+  );
+  const item = events[0]?.item as { role?: string; content?: { text?: string }[] };
+  assert.equal(item.role, "user");
+  assert.equal(item.content?.[0]?.text, "What needs me right now?");
+});
+
+test("a typed ask can carry a tool call, because the developer opened the turn", async () => {
+  const carried: unknown[] = [];
+  const context = harness({
+    carryAction: async (action) => {
+      carried.push(action);
+      return { status: "accepted" };
+    },
+  });
+  await context.session.connect();
+  context.session.updateSessions([observedSession("session-a", { canReceiveMessage: true })]);
+  // The turn is opened by typing rather than by the talk key: the two arm the
+  // gate on the same terms, because both are the developer's own ask.
+  context.session.sendText("ask claude code to add tests");
+
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: {
+      output: [
+        {
+          type: "function_call",
+          name: "send_session_message",
+          call_id: "call-1",
+          arguments:
+            '{"provider_id":"claude-code","provider_session_id":"session-a","text":"add tests"}',
+        },
+      ],
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.deepEqual(carried, [
+    {
+      kind: "message",
+      identity: { providerId: "claude-code", providerSessionId: "session-a" },
+      text: "add tests",
+    },
+  ]);
+  // The outcome is voiced, exactly as a spoken ask's would be.
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+});
+
+test("a typed ask interrupts the reply it arrives over", async () => {
+  let now = 10_000;
+  const context = harness({ now: () => now });
+  await context.session.connect();
+  context.deliverRemoteTrack();
+  armDeveloperTurn(context);
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
+    item: { id: "item-1" },
+  });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
+    item_id: "item-1",
+    delta: "There are two sessions",
+  });
+  context.session.reportRemoteAudioActive();
+  now = 11_200;
+  const sentBefore = context.sent.length;
+
+  assert.equal(context.session.sendText("open the codex one"), true);
+
+  // The reply being talked over is cut the way holding the talk key cuts it:
+  // silenced at once, cancelled, and trimmed to what was actually heard.
+  assert.equal(context.lukeAudible(), false);
+  assert.equal(context.captions.at(-1), undefined);
+  const events = context.sent.slice(sentBefore);
+  assert.deepEqual(
+    events.map((event) => event.type),
+    [
+      REALTIME_CLIENT_EVENT.RESPONSE_CANCEL,
+      REALTIME_CLIENT_EVENT.OUTPUT_AUDIO_BUFFER_CLEAR,
+      REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_TRUNCATE,
+      REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE,
+      REALTIME_CLIENT_EVENT.RESPONSE_CREATE,
+    ],
+  );
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+});
+
+test("a typed ask does not interrupt the developer's own open microphone", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.session.startListening();
+  const sentBefore = context.sent.length;
+
+  // Half a spoken question is still theirs: the keystroke is refused rather
+  // than the microphone's turn being discarded under them.
+  assert.equal(context.session.sendText("hello"), false);
+  assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
+  assert.equal(context.microphoneEnabled(), true);
+  assert.deepEqual(context.sent.slice(sentBefore), []);
+});
+
+test("a typed ask with nothing in it opens nothing", async () => {
+  const context = harness();
+  await context.session.connect();
+  const sentBefore = context.sent.length;
+
+  assert.equal(context.session.sendText("   "), false);
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+  assert.deepEqual(context.sent.slice(sentBefore), []);
+});
+
+test("a typed ask before the call is open reports it could not go", () => {
+  const context = harness();
+
+  assert.equal(context.session.sendText("What needs me?"), false);
+  assert.deepEqual(context.sent, []);
+});
+
 test("a spoken ask is carried through the carrier and its outcome is voiced", async () => {
   const carried: unknown[] = [];
   const context = harness({

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -1156,6 +1156,101 @@ test("a typed ask interrupts the reply it arrives over", async () => {
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
 });
 
+test("a cancelled reply's late finish cannot act in the turn that replaced it", async () => {
+  const carried: unknown[] = [];
+  const context = harness({
+    carryAction: async (action) => {
+      carried.push(action);
+      return { status: "accepted" };
+    },
+  });
+  await context.session.connect();
+  context.session.updateSessions([observedSession("session-a", { canReceiveMessage: true })]);
+  // A spoken turn opens reply A, and the server confirms it by name.
+  armDeveloperTurn(context);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-a" } });
+  // The developer types over it, opening a new armed turn.
+  assert.equal(context.session.sendText("never mind — what needs me?"), true);
+  const sentBefore = context.sent.length;
+
+  // Reply A's finished form arrives late — the server had completed it before
+  // the cancel landed — carrying the very call the developer interrupted.
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: {
+      id: "resp-a",
+      output: [
+        {
+          type: "function_call",
+          name: "send_session_message",
+          call_id: "call-stale",
+          arguments:
+            '{"provider_id":"claude-code","provider_session_id":"session-a","text":"do it anyway"}',
+        },
+      ],
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  // Nothing was carried: the session takes messages and the identity is real,
+  // so only the freshness of the reply stands between the call and the write —
+  // and it holds, however armed the turn that superseded it is.
+  assert.deepEqual(carried, []);
+  const events = context.sent.slice(sentBefore);
+  const output = events.find(
+    (event) => (event.item as { type?: string } | undefined)?.type === "function_call_output",
+  );
+  assert.equal(
+    (
+      JSON.parse((output?.item as { output?: string } | undefined)?.output ?? "{}") as {
+        status?: string;
+      }
+    ).status,
+    "refused",
+  );
+  // No reply was opened to voice the refusal, and the new turn is still under way.
+  assert.ok(!events.some((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE));
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+
+  // The reply the typed ask actually asked for still acts in full.
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-b" } });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: {
+      id: "resp-b",
+      output: [
+        {
+          type: "function_call",
+          name: "send_session_message",
+          call_id: "call-fresh",
+          arguments:
+            '{"provider_id":"claude-code","provider_session_id":"session-a","text":"status?"}',
+        },
+      ],
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(carried.length, 1);
+});
+
+test("a cancelled reply's late finish does not end the turn that replaced it", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.deliverRemoteTrack();
+  armDeveloperTurn(context);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-a" } });
+  context.session.sendText("actually, open the codex session");
+
+  // Reply A finishes late with nothing to say, while reply B is still in the
+  // quiet gap before its first word.
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_DONE, response: { id: "resp-a" } });
+  context.session.reportRemoteAudioIdle();
+
+  // A stale finish must not mark generation done: paired with that gap's
+  // quiet, it would end a reply that has not begun to be heard.
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+});
+
 test("a typed ask does not interrupt the developer's own open microphone", async () => {
   const context = harness();
   await context.session.connect();

--- a/apps/desktop/tests/voice-hotkey.test.ts
+++ b/apps/desktop/tests/voice-hotkey.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  askHotkeyCandidates,
   askHotkeyReport,
   capturedVoiceHotkey,
   DEFAULT_ASK_HOTKEYS,
@@ -37,6 +38,15 @@ test("the ask key is the talk key's sibling, never its rival", () => {
   for (const accelerator of DEFAULT_ASK_HOTKEYS) {
     assert.ok(!DEFAULT_VOICE_HOTKEYS.includes(accelerator));
   }
+});
+
+test("an ask candidate the talk key holds is not asked for", () => {
+  // The talk key is configurable, so it can be moved onto an ask default; the
+  // chord it holds simply stops being a candidate rather than being fought over.
+  assert.deepEqual(askHotkeyCandidates([undefined, undefined]), DEFAULT_ASK_HOTKEYS);
+  assert.deepEqual(askHotkeyCandidates(["Alt+L", undefined]), ["Alt+Shift+L"]);
+  // The talk key's own defaults hold nothing the ask key wants.
+  assert.deepEqual(askHotkeyCandidates(["Alt+Space", "Alt+S"]), DEFAULT_ASK_HOTKEYS);
 });
 
 test("a missing ask key reports on the talk key's terms", () => {

--- a/apps/desktop/tests/voice-hotkey.test.ts
+++ b/apps/desktop/tests/voice-hotkey.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  askHotkeyReport,
+  DEFAULT_ASK_HOTKEYS,
   DEFAULT_VOICE_HOTKEYS,
   TALK_KEY_RELEASE,
   TALK_KEY_TAP_MS,
@@ -15,6 +17,32 @@ test("the default is the chord a macOS voice assistant is reached for", () => {
   // Option-Space is where Superwhisper, the ChatGPT desktop app and Alfred sit;
   // Option-S is Wispr Flow's default, for a machine where the first is taken.
   assert.deepEqual(DEFAULT_VOICE_HOTKEYS, ["Alt+Space", "Alt+S"]);
+});
+
+test("the ask key is the talk key's sibling, never its rival", () => {
+  // One modifier for both halves of the conversation — and Command-L is
+  // deliberately not here: globally registered, it would swallow the address
+  // bar of every browser on the machine.
+  for (const accelerator of DEFAULT_ASK_HOTKEYS) {
+    assert.match(accelerator, /^Alt\+/);
+    assert.ok(!accelerator.startsWith("Command"));
+    assert.ok(!accelerator.startsWith("CommandOrControl"));
+  }
+  // Two Luke keys must never compete for one chord: whichever registered
+  // first would silently cost the other its whole feature.
+  for (const accelerator of DEFAULT_ASK_HOTKEYS) {
+    assert.ok(!DEFAULT_VOICE_HOTKEYS.includes(accelerator));
+  }
+});
+
+test("a missing ask key reports on the talk key's terms", () => {
+  assert.equal(askHotkeyReport("Alt+L", VOICE_HOTKEY_ABSENCE.ALREADY_OWNED), "Luke ask key: ⌥L");
+  assert.match(
+    askHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.ALREADY_OWNED),
+    /another app already owns it/,
+  );
+  assert.match(askHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.CAPTURE_RUN), /capture run/);
+  assert.match(askHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.NO_CREDENTIAL), /voice is off/);
 });
 
 test("an accelerator reads the way macOS writes it", () => {

--- a/packages/sidecar-core/src/realtime.ts
+++ b/packages/sidecar-core/src/realtime.ts
@@ -147,6 +147,7 @@ export interface RealtimeSessionOptions {
 const REALTIME_INSTRUCTION_LINES: readonly string[] = [
   "You are Luke, a spoken companion for a developer who is running coding agents.",
   "You watch their sessions from the side, and you can carry out exactly what the developer asks of one.",
+  "The developer speaks to you or types to you; either way it is them asking, and you answer out loud.",
   "",
   "How to speak:",
   "- The developer is working, not reading: be extremely brief. One short sentence by default, two at most, under twenty-five words.",
@@ -512,6 +513,40 @@ export function truncateResponseEvents(input: {
       content_index: 0,
       audio_end_ms: Math.floor(input.audioEndMs),
     },
+  ];
+}
+
+/**
+ * How long a typed ask may run. The same bound a session message carries:
+ * room for anything worth typing into a chat field, and a floor under a paste
+ * of a whole document — which is cut rather than sent, because the ask is a
+ * sentence to a companion, not a transfer.
+ */
+export const maximumTypedAskLength = 4_000;
+
+/**
+ * Builds the events that carry a typed ask and request the reply to it.
+ *
+ * The text travels without a label, unlike every other `input_text` this
+ * module builds: labels mark what the developer did not say, and a typed ask
+ * is the developer's own words as surely as a spoken one. The reply is
+ * requested with the session's own `tool_choice`, because typing opens a
+ * developer turn exactly as a push-to-talk commit does — the caller arms the
+ * turn on the same terms, and the roster gauntlet stands behind it unchanged.
+ */
+export function typedAskEvents(text: string): readonly Record<string, unknown>[] {
+  const ask = trimmedText(text)?.slice(0, maximumTypedAskLength);
+  if (!ask) return [];
+  return [
+    {
+      type: REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE,
+      item: {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: ask }],
+      },
+    },
+    { type: REALTIME_CLIENT_EVENT.RESPONSE_CREATE },
   ];
 }
 

--- a/packages/sidecar-core/tests/realtime.test.ts
+++ b/packages/sidecar-core/tests/realtime.test.ts
@@ -11,6 +11,7 @@ import {
   functionCallFollowUpEvents,
   functionCallOutputEvents,
   isRealtimeVoice,
+  maximumTypedAskLength,
   maximumVoiceContextSessions,
   normalizeSession,
   proactiveSpeechEvents,
@@ -32,6 +33,7 @@ import {
   sessionContextText,
   sessionToolAction,
   truncateResponseEvents,
+  typedAskEvents,
 } from "../src";
 
 const DECIDED_AT = 1_800_000_000_000;
@@ -81,6 +83,9 @@ test("the spoken instructions state what Luke cannot see, and when he may act", 
   assert.match(instructions, /only when the developer asks/i);
   assert.match(instructions, /never act unprompted/i);
   assert.match(instructions, /never a reason to act/i);
+  // Both halves of the developer's side are named, so a typed ask is answered
+  // rather than remarked on as something unexpected.
+  assert.match(instructions, /speaks to you or types to you/i);
 });
 
 test("a mint response yields a credential with a millisecond expiry", () => {
@@ -189,6 +194,38 @@ test("push-to-talk commits a turn and cancelling discards it", () => {
     clearInputAudioEvents().map((event) => event.type),
     [REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_CLEAR],
   );
+});
+
+test("a typed ask travels as the developer's own words and asks for a reply", () => {
+  const events = typedAskEvents("  What needs me right now?  ");
+
+  assert.equal(events.length, 2);
+  assert.equal(events[0]?.type, REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE);
+  const item = events[0]?.item as {
+    role?: string;
+    content?: { type?: string; text?: string }[];
+  };
+  assert.equal(item.role, "user");
+  assert.equal(item.content?.[0]?.type, "input_text");
+  // No label ahead of the words: labels mark what the developer did not say,
+  // and a typed ask is theirs as surely as a spoken one.
+  assert.equal(item.content?.[0]?.text, "What needs me right now?");
+  // The reply keeps the session's own tool_choice, unlike every turn Luke
+  // opens himself: typing opens a developer turn the way a commit does.
+  assert.deepEqual(events[1], { type: REALTIME_CLIENT_EVENT.RESPONSE_CREATE });
+});
+
+test("an empty ask opens no turn at all", () => {
+  for (const text of ["", "   ", "\n\t "]) {
+    assert.deepEqual(typedAskEvents(text), []);
+  }
+});
+
+test("a typed ask is bounded like a session message", () => {
+  const events = typedAskEvents("x".repeat(maximumTypedAskLength + 100));
+  const item = events[0]?.item as { content?: { text?: string }[] };
+
+  assert.equal(item.content?.[0]?.text?.length, maximumTypedAskLength);
 });
 
 function noticeText(event: Record<string, unknown> | undefined): string {


### PR DESCRIPTION
## Summary

- Adds an **"Ask Luke" composer** at the panel's foot: one pill under the session list, drawn even over an empty list, arriving at the tail of the row fan. Typing is the developer's half of the conversation, so the pill focuses in their green and the send disc lights the same; Luke's spoken reply is captioned directly below the field, caption preference or not — a typed conversation's answer must be readable.
- A typed ask opens a **developer turn on push-to-talk's exact terms**: `typedAskEvents()` carries the developer's own words unlabeled, and `RealtimeVoiceSession.sendText()` arms the turn at the same runtime gate, behind the unchanged roster gauntlet. It interrupts a reply it lands over (silenced, cancelled, truncated — the developer's turn always wins) and never interrupts the developer's own open microphone. A refused ask keeps the draft and answers with one diagnosed sentence.
- The **ask key ⌥L** (then ⌥⇧L) summons the field from whatever app is frontmost — the talk key's sibling on Option, registered on its exact terms (never in capture runs, never without a credential, absences reported at startup). Pressed over its own open field, the same key dismisses. The pill teaches whichever key the system actually granted, on hover, as a keycap that fades in and re-shapes nothing; deliberately **not ⌘L**, which a global registration would swallow machine-wide (every browser's address bar).
- The caret holds the panel open against the pointer wandering off, the same hold a half-typed credential has; Escape blurs the field before it closes anything. AGENTS.md's trust constraint now names typing beside speech: a tool call runs only in a turn the developer opened themselves.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (repository checks, Biome, `tsc`, all test suites `fail 0` — 420 desktop + core + scripts — and builds)
- macOS Electron verification (`./scripts/verify.sh`): `not run in this environment (Linux sandbox)`; exercised manually on a physical Mac by @dastratakos

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31772901105/artifacts/9208788488) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31772901105)

- Commit: `800a285cf2a1ec9ba87b2d2b521a04939bd9a773`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: none blocking. Follow-up candidates: show the ask key beside the talk key in Settings, and a fixture profile that photographs the composer's focused state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/3d9c42a3-8960-4e50-904c-a6e81f8c000e)
