### PR TITLE
feat(voice): quiet Music and Spotify while talking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,16 @@ Trust constraints:
   in the main process before the tracker client sees anything. Observation
   sends only the read document; the write documents are fixed by the build and
   issued only for a validated act.
+- Quieting other media is bounded the way the talk key is: a native helper that
+  can do one narrow thing. While a spoken exchange is live, Luke may lower the
+  volume of the players the helper names — Music and Spotify, through their own
+  scripting interfaces, behind the system's per-app consent — and restore it
+  afterwards. He never pauses them and reads nothing beyond whether each is
+  playing and how loud; a volume the user moved during the duck stays where
+  their hand put it; and the whole behavior is a setting. The trigger is the
+  exchange itself — a deterministic status edge, never anything Luke read,
+  heard, or decided — so no model output can reach it. Widening the player
+  list is a product decision, not an implementation detail.
 - Keep unsupported capabilities explicit; do not invent fallback controls.
 - Keep Electron renderers sandboxed with context isolation and narrow IPC.
 - Commit only synthetic fixtures and repository-relative paths. This binds

--- a/apps/desktop/native/macos/MediaDuck.swift
+++ b/apps/desktop/native/macos/MediaDuck.swift
@@ -174,13 +174,20 @@ private struct MediaDuckCommand {
 
     /// Only what `duck` changed goes back, and only if it is still where the
     /// duck left it: a volume the user moved meanwhile — or a player they
-    /// quit — is theirs, not this helper's to overrule.
+    /// quit — is theirs, not this helper's to overrule. A read that merely
+    /// failed is neither of those: it says nothing about the user's intent,
+    /// so the memory is kept for the next restore rather than the player
+    /// being stranded quiet with nothing left to bring it back.
     static func restore() {
         let restoring = ducked
         ducked = [:]
         var restored = 0
-        for entry in restoring.values {
-            guard isRunning(entry.player), let current = volume(of: entry.player) else { continue }
+        for (key, entry) in restoring {
+            guard isRunning(entry.player) else { continue }
+            guard let current = volume(of: entry.player) else {
+                ducked[key] = entry
+                continue
+            }
             guard abs(current - entry.ducked) <= RESTORE_TOLERANCE else { continue }
             fade(entry.player, from: current, to: entry.original, stepSeconds: RESTORE_STEP_SECONDS)
             restored += 1

--- a/apps/desktop/native/macos/MediaDuck.swift
+++ b/apps/desktop/native/macos/MediaDuck.swift
@@ -1,0 +1,190 @@
+import AppKit
+import Foundation
+
+/// Turns the media players Luke knows how to speak to down while a spoken
+/// exchange is happening, and back up afterwards.
+///
+/// Apple Events are the reason this exists, and their bounds are the feature's
+/// bounds. macOS offers no way to duck every app's audio; what it offers is a
+/// scripting interface per app, behind a consent dialog per app. So the players
+/// are named here — Music and Spotify — and a switch upstream describes exactly
+/// these two rather than "other media". Each is asked only whether it is
+/// playing and how loud, and told only a volume: nothing is paused, nothing is
+/// read beyond that, and an app the user never granted simply stays at its own
+/// volume.
+///
+/// The one command language: `duck` fades every playing player down, `restore`
+/// fades back whatever `duck` changed. Stdin closing is the app going away, so
+/// it restores on the way out — a crash upstream must not leave the user's
+/// music quiet with nothing left to bring it back.
+private struct MediaPlayer {
+    let bundleIdentifier: String
+}
+
+/// The players Luke may quiet. Deliberately small, like the talk key's chord
+/// table: each entry is a consent dialog and a promise, not a pattern.
+private let PLAYERS = [
+    MediaPlayer(bundleIdentifier: "com.apple.Music"),
+    MediaPlayer(bundleIdentifier: "com.spotify.client"),
+]
+
+/// Where a player's volume was, and where the duck put it. The second value is
+/// what decides whether the first may be restored: a volume that no longer
+/// reads as the ducked one was moved by the user's own hand, and their hand
+/// wins.
+private struct DuckedPlayer {
+    let player: MediaPlayer
+    let original: Int
+    let ducked: Int
+}
+
+/// A quarter of the user's own level: audible, so a duck never reads as the
+/// player having stopped, but clearly under speech.
+private let DUCK_FACTOR = 0.25
+/// Fading rather than stepping is what makes the duck read as polite; a small
+/// number of steps is enough because each Apple Event round trip smooths it.
+private let FADE_STEPS = 4
+/// Down fast — Luke is about to speak — and back up more gently.
+private let DUCK_STEP_SECONDS = 0.04
+private let RESTORE_STEP_SECONDS = 0.08
+/// Spotify reports a volume one below the one it was just set to, so "still
+/// where the duck put it" has to allow the reading to sit slightly off.
+private let RESTORE_TOLERANCE = 2
+
+private let MEDIA_DUCK_COMMAND = (duck: "duck", restore: "restore")
+
+private func emit(_ line: String) {
+    guard let payload = "\(line)\n".data(using: .utf8) else { return }
+    FileHandle.standardOutput.write(payload)
+}
+
+/// One Apple Event, or nothing. A player that refuses — consent denied, the
+/// app quitting mid-question — is skipped rather than retried: every path here
+/// runs again on the next exchange anyway. The refusal is said aloud, because
+/// the commonest one is invisible otherwise: -1743 is macOS refusing on the
+/// user's behalf, and it looks exactly like silence until it is printed.
+private func runAppleScript(_ source: String) -> NSAppleEventDescriptor? {
+    guard let script = NSAppleScript(source: source) else { return nil }
+    var failure: NSDictionary?
+    let result = script.executeAndReturnError(&failure)
+    guard let failure else { return result }
+    let number = failure[NSAppleScript.errorNumber] ?? "unknown"
+    emit("refused \(number)")
+    return nil
+}
+
+/// Asked of the system, not of the player: an Apple Event sent to an app that
+/// is not running launches it, and starting the user's music player is the
+/// opposite of quieting it.
+private func isRunning(_ player: MediaPlayer) -> Bool {
+    !NSRunningApplication.runningApplications(
+        withBundleIdentifier: player.bundleIdentifier
+    ).isEmpty
+}
+
+private func isPlaying(_ player: MediaPlayer) -> Bool {
+    runAppleScript(
+        "tell application id \"\(player.bundleIdentifier)\" to player state is playing"
+    )?.booleanValue ?? false
+}
+
+private func volume(of player: MediaPlayer) -> Int? {
+    guard let result = runAppleScript(
+        "tell application id \"\(player.bundleIdentifier)\" to sound volume"
+    ) else { return nil }
+    return Int(result.int32Value)
+}
+
+private func setVolume(of player: MediaPlayer, to volume: Int) {
+    _ = runAppleScript(
+        "tell application id \"\(player.bundleIdentifier)\" to set sound volume to \(volume)"
+    )
+}
+
+private func fade(_ player: MediaPlayer, from: Int, to: Int, stepSeconds: Double) {
+    guard from != to else { return }
+    for step in 1...FADE_STEPS {
+        let value = from + (to - from) * step / FADE_STEPS
+        setVolume(of: player, to: value)
+        if step < FADE_STEPS { Thread.sleep(forTimeInterval: stepSeconds) }
+    }
+    // Integer steps can land shy of the target; the last word is exact.
+    setVolume(of: player, to: to)
+}
+
+@main
+@MainActor
+private struct MediaDuckCommand {
+    static var buffer = ""
+    static var ducked: [String: DuckedPlayer] = [:]
+
+    static func main() {
+        FileHandle.standardInput.readabilityHandler = { handle in
+            let data = handle.availableData
+            DispatchQueue.main.async {
+                MainActor.assumeIsolated {
+                    // Stdin closing is the app going away, deliberately or not.
+                    // Restoring here is what makes a duck impossible to strand.
+                    if data.isEmpty {
+                        FileHandle.standardInput.readabilityHandler = nil
+                        restore()
+                        exit(0)
+                    }
+                    read(data)
+                }
+            }
+        }
+        emit("ready")
+        dispatchMain()
+    }
+
+    static func read(_ data: Data) {
+        buffer += String(decoding: data, as: UTF8.self)
+        var lines = buffer.components(separatedBy: "\n")
+        // Whatever follows the last newline is the start of a line still
+        // arriving, exactly as the talk key's reader holds it.
+        buffer = lines.removeLast()
+        for line in lines {
+            handle(line.trimmingCharacters(in: .whitespaces))
+        }
+    }
+
+    static func handle(_ line: String) {
+        if line == MEDIA_DUCK_COMMAND.duck { duck() }
+        if line == MEDIA_DUCK_COMMAND.restore { restore() }
+    }
+
+    /// Every playing player comes down, each from its own level. A player
+    /// already ducked is left alone — a repeated `duck` must not read the
+    /// ducked volume back as the one to restore to.
+    static func duck() {
+        for player in PLAYERS where ducked[player.bundleIdentifier] == nil {
+            guard isRunning(player), isPlaying(player) else { continue }
+            guard let original = volume(of: player), original > 0 else { continue }
+            let target = Int((Double(original) * DUCK_FACTOR).rounded())
+            fade(player, from: original, to: target, stepSeconds: DUCK_STEP_SECONDS)
+            ducked[player.bundleIdentifier] = DuckedPlayer(
+                player: player,
+                original: original,
+                ducked: target
+            )
+        }
+        emit("ducked \(ducked.count)")
+    }
+
+    /// Only what `duck` changed goes back, and only if it is still where the
+    /// duck left it: a volume the user moved meanwhile — or a player they
+    /// quit — is theirs, not this helper's to overrule.
+    static func restore() {
+        let restoring = ducked
+        ducked = [:]
+        var restored = 0
+        for entry in restoring.values {
+            guard isRunning(entry.player), let current = volume(of: entry.player) else { continue }
+            guard abs(current - entry.ducked) <= RESTORE_TOLERANCE else { continue }
+            fade(entry.player, from: current, to: entry.original, stepSeconds: RESTORE_STEP_SECONDS)
+            restored += 1
+        }
+        emit("restored \(restored)")
+    }
+}

--- a/apps/desktop/native/macos/entitlements.plist
+++ b/apps/desktop/native/macos/entitlements.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.device.audio-input</key>

--- a/apps/desktop/scripts/package-config.mjs
+++ b/apps/desktop/scripts/package-config.mjs
@@ -9,6 +9,11 @@ export const LICENSE_RESOURCE_NAME = "LUKE-LICENSE.txt";
 // what consent is given against. It has to say where the audio goes.
 export const MICROPHONE_USAGE_DESCRIPTION =
   "Luke uses the microphone for spoken conversation. Audio from a turn you start is sent to OpenAI to answer it, and is never recorded or written to disk.";
+// The sentence macOS shows when it asks whether Luke may speak to Music or
+// Spotify, so it is what consent is given against. It has to say what is done
+// to them, and what is not.
+export const APPLE_EVENTS_USAGE_DESCRIPTION =
+  "Luke turns Music and Spotify down while you are having a spoken conversation, and back up afterwards. He never pauses them, and reads nothing beyond whether each is playing and how loud.";
 export const ICONSET_SOURCES = Object.freeze({
   "icon_16x16.png": "luke-icon-16.png",
   "icon_16x16@2x.png": "luke-icon-32.png",
@@ -78,6 +83,7 @@ export function createPackagerOptions({
       CFBundleDisplayName: "Luke",
       LSMinimumSystemVersion: MACOS_DEPLOYMENT_TARGET,
       LSUIElement: true,
+      NSAppleEventsUsageDescription: APPLE_EVENTS_USAGE_DESCRIPTION,
       NSMicrophoneUsageDescription: MICROPHONE_USAGE_DESCRIPTION,
       NSPrefersDisplaySafeAreaCompatibilityMode: false,
     },

--- a/apps/desktop/scripts/package-layout.mjs
+++ b/apps/desktop/scripts/package-layout.mjs
@@ -8,6 +8,7 @@ export const PACKAGED_ARCHITECTURE = "arm64";
  * cannot be built without reaching the bundle or shipped without being built.
  */
 export const NATIVE_HELPERS = [
+  { source: "MediaDuck.swift", binary: "mac-media-duck", frameworks: ["AppKit"] },
   { source: "ScreenGeometry.swift", binary: "mac-screen-geometry", frameworks: ["AppKit"] },
   {
     source: "TalkKey.swift",

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -56,6 +56,7 @@ import { DevinSessionAdapter } from "./devin-adapter";
 import { JulesSessionAdapter } from "./jules-adapter";
 import { LinearIssueTracker } from "./linear-tracker";
 import { readMacScreenGeometry } from "./macos-screen-geometry";
+import { MediaDuckController } from "./media-duck";
 import { openAiAttentionEvaluatorFromEnvironment } from "./openai-attention-evaluator";
 import {
   openAiRealtimeCredentialsFromEnvironment,
@@ -194,6 +195,10 @@ const attentionReviewer = attentionEvaluator
 // A fixture run stays credential-free for the same reason attention review
 // does: evidence must be reproducible without a key and without a network.
 const realtimeCredentials = fixtureMode ? undefined : openAiRealtimeCredentialsFromEnvironment();
+// Quiets Music and Spotify while a spoken exchange is live. It lives here
+// rather than in the renderer because letting the players back up must survive
+// anything the renderer does — and only this process may run a helper.
+const mediaDuck = new MediaDuckController();
 let voiceHotkey: string | undefined;
 /**
  * The chord the user chose over the defaults, if any. Read from the settings
@@ -845,6 +850,36 @@ function registerIpc(): void {
     },
   );
 
+  // The duck follows the stored answer at once, like the menu bar item: off
+  // must let a duck currently held go rather than waiting for the next launch.
+  ipcMain.handle(
+    channels.setDuckOtherMedia,
+    async (event, enabled: unknown): Promise<SettingsUpdateResult> => {
+      if (!trustedSender(event)) throw new Error("Untrusted renderer");
+      if (typeof enabled !== "boolean") throw new Error("Invalid media duck request");
+      try {
+        const result = await settingsStore.setDuckOtherMedia(enabled);
+        mediaDuck.setEnabled(result.settings.duckOtherMedia);
+        return result;
+      } catch {
+        // A filesystem failure is not something the user can act on, so it is
+        // reported as one line rather than as a raw system error.
+        return {
+          settings: await settingsStore.snapshot(),
+          reason: "Could not save that setting on this system.",
+        };
+      }
+    },
+  );
+
+  // A statement of state, not a request: the renderer says whether a spoken
+  // exchange is live, and the duck holds every other decision — the setting,
+  // the hangover after an exchange, which players are playing at all.
+  ipcMain.on(channels.setVoiceExchange, (event, active: unknown) => {
+    if (!trustedSender(event) || typeof active !== "boolean") return;
+    mediaDuck.setExchangeActive(active);
+  });
+
   // Where to get a key is a question the panel cannot answer itself, so it
   // hands the question to the browser. The renderer names a provider rather
   // than an address: the pages Luke can open are the ones in the provider
@@ -1412,6 +1447,13 @@ if (!app.requestSingleInstanceLock()) {
       },
       () => undefined,
     );
+    // Armed from the settings file alone, like the status item, and for the
+    // same reason. A file that cannot be read leaves the duck on, the same
+    // answer a file that has never said gives.
+    void settingsStore.duckOtherMedia().then(
+      (enabled) => mediaDuck.setEnabled(enabled),
+      () => mediaDuck.setEnabled(true),
+    );
     // Awaited, so the chosen voice reaches the minter before the renderer
     // exists to ask for a credential: the first conversation must already
     // speak with it. A file that cannot be read means no choice was kept — it
@@ -1463,6 +1505,10 @@ app.on("will-quit", () => {
   // during quit, so its exit is not waited on.
   void talkKeyWatcher?.stop();
   talkKeyWatcher = undefined;
+  // The duck helper outlives this by one fade: closing its stdin is what asks
+  // it to bring the players back up, so quitting mid-sentence costs the user
+  // nothing.
+  mediaDuck.stop();
 });
 
 app.on("before-quit", () => {

--- a/apps/desktop/src/media-duck.ts
+++ b/apps/desktop/src/media-duck.ts
@@ -1,0 +1,161 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { app } from "electron";
+
+/**
+ * The two words the helper takes. It holds the player-facing knowledge — which
+ * apps, what levels, whose volume changes are the user's to keep — so this side
+ * only ever says which of the two states the exchange is in.
+ */
+export const MEDIA_DUCK_COMMAND = {
+  DUCK: "duck",
+  RESTORE: "restore",
+} as const;
+
+/**
+ * How long quiet is held after an exchange ends before the players come back
+ * up. A conversation is turns with gaps in them, and a volume that climbed in
+ * every gap only to dive at the next word would pump; the hangover is longer
+ * than the pause between a reply and the follow-up press.
+ */
+export const MEDIA_DUCK_RELEASE_DELAY_MS = 1_000;
+
+/** Only the parts of a child process this needs, so a test can supply them. */
+export interface MediaDuckProcess {
+  stdin?: { write(chunk: string): void; end(): void };
+  on(event: "error" | "exit", listener: () => void): void;
+  removeAllListeners(): void;
+}
+
+export interface MediaDuckControllerOptions {
+  /** Injectable so the ordering can be exercised without a Mac or a binary. */
+  spawnHelper?: () => MediaDuckProcess | undefined;
+  releaseDelayMs?: number;
+}
+
+function spawnMediaDuckHelper(): MediaDuckProcess | undefined {
+  // The helper speaks to Music and Spotify through Apple Events, which only
+  // macOS has; elsewhere the setting can be held but never acts.
+  if (process.platform !== "darwin") return undefined;
+  const helperPath = app.isPackaged
+    ? path.join(process.resourcesPath, "mac-media-duck")
+    : path.join(app.getAppPath(), ".build", "native", "mac-media-duck");
+  return spawn(helperPath, [], {
+    // Stdin is the whole protocol — its closing is what tells the helper to
+    // restore and go. What the helper says back is diagnostic, so it rides
+    // through to the app's own stdout: one line per act in a terminal run,
+    // nowhere at all in a packaged one.
+    stdio: ["pipe", "inherit", "ignore"],
+  }) as unknown as MediaDuckProcess;
+}
+
+/**
+ * Holds the one decision — should the players be quiet right now — and tells
+ * the helper only when the answer changes. The two inputs are the user's
+ * setting and whether a spoken exchange is live; the asymmetry between them is
+ * deliberate. An exchange ending waits out the hangover, because the next turn
+ * is usually moments away. The setting going off restores at once, because
+ * that is the user's own hand asking for their volume back.
+ */
+export class MediaDuckController {
+  readonly #spawnHelper: () => MediaDuckProcess | undefined;
+  readonly #releaseDelayMs: number;
+  #child: MediaDuckProcess | undefined;
+  #enabled = false;
+  #exchangeActive = false;
+  #ducked = false;
+  #releaseTimer: NodeJS.Timeout | undefined;
+
+  constructor(options: MediaDuckControllerOptions = {}) {
+    this.#spawnHelper = options.spawnHelper ?? spawnMediaDuckHelper;
+    this.#releaseDelayMs = options.releaseDelayMs ?? MEDIA_DUCK_RELEASE_DELAY_MS;
+  }
+
+  setEnabled(enabled: boolean): void {
+    this.#enabled = enabled;
+    this.#apply();
+  }
+
+  setExchangeActive(active: boolean): void {
+    this.#exchangeActive = active;
+    this.#apply();
+  }
+
+  /**
+   * Lets the helper go on the app's way out. Its stdin closing is what asks it
+   * to restore whatever is still ducked, so nothing is written first and
+   * nothing waits for an answer: the helper outlives this call by exactly the
+   * fade it owes the user.
+   */
+  stop(): void {
+    this.#clearReleaseTimer();
+    const child = this.#child;
+    this.#child = undefined;
+    this.#ducked = false;
+    child?.removeAllListeners();
+    child?.stdin?.end();
+  }
+
+  #apply(): void {
+    if (this.#enabled && this.#exchangeActive) {
+      // A turn beginning inside the hangover keeps the duck held: the players
+      // never started back up, so there is nothing to send.
+      this.#clearReleaseTimer();
+      if (this.#ducked) return;
+      const child = this.#ensureChild();
+      if (!child) return;
+      this.#ducked = true;
+      child.stdin?.write(`${MEDIA_DUCK_COMMAND.DUCK}\n`);
+      return;
+    }
+    if (!this.#ducked) {
+      this.#clearReleaseTimer();
+      return;
+    }
+    if (!this.#enabled) {
+      this.#clearReleaseTimer();
+      this.#restore();
+      return;
+    }
+    if (this.#releaseTimer) return;
+    this.#releaseTimer = setTimeout(() => {
+      this.#releaseTimer = undefined;
+      this.#restore();
+    }, this.#releaseDelayMs);
+  }
+
+  #restore(): void {
+    this.#ducked = false;
+    this.#child?.stdin?.write(`${MEDIA_DUCK_COMMAND.RESTORE}\n`);
+  }
+
+  #ensureChild(): MediaDuckProcess | undefined {
+    if (this.#child) return this.#child;
+    let child: MediaDuckProcess | undefined;
+    try {
+      child = this.#spawnHelper();
+    } catch {
+      child = undefined;
+    }
+    if (!child) return undefined;
+    this.#child = child;
+    // A helper that dies mid-duck takes its memory of the volumes with it, so
+    // there is nothing to say and no one to say it to: the state resets and
+    // the next exchange starts a fresh helper from the players' own levels.
+    const drop = () => {
+      if (this.#child !== child) return;
+      this.#child = undefined;
+      this.#ducked = false;
+      this.#clearReleaseTimer();
+    };
+    child.on("error", drop);
+    child.on("exit", drop);
+    return child;
+  }
+
+  #clearReleaseTimer(): void {
+    if (this.#releaseTimer === undefined) return;
+    clearTimeout(this.#releaseTimer);
+    this.#releaseTimer = undefined;
+  }
+}

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -56,6 +56,11 @@ const bridge: AppBridge = {
     ipcRenderer.invoke(channels.setVoiceCaptions, enabled) as Promise<SettingsUpdateResult>,
   setVoiceHotkey: (accelerator: string | undefined) =>
     ipcRenderer.invoke(channels.setVoiceHotkey, accelerator) as Promise<SettingsUpdateResult>,
+  setDuckOtherMedia: (enabled: boolean) =>
+    ipcRenderer.invoke(channels.setDuckOtherMedia, enabled) as Promise<SettingsUpdateResult>,
+  setVoiceExchangeActive: (active: boolean) => {
+    ipcRenderer.send(channels.setVoiceExchange, active);
+  },
   openSession: (identity: SessionIdentity) =>
     ipcRenderer.invoke(channels.openSession, identity) as Promise<SessionOpenResult>,
   sendSessionMessage: (identity: SessionIdentity, text: string) =>

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -506,6 +506,13 @@ export function App(): React.JSX.Element {
     return result.reason;
   }, []);
 
+  /** The same road the captions switch travels, for the media duck. */
+  const changeDuckOtherMedia = useCallback(async (enabled: boolean) => {
+    const result = await window.sidecar.setDuckOtherMedia(enabled);
+    setSettings(result.settings);
+    return result.reason;
+  }, []);
+
   /**
    * The talk key going down. Every press goes to the session, including the one
    * that has no call to press against yet: the microphone opens with the call,
@@ -1153,6 +1160,18 @@ export function App(): React.JSX.Element {
     if (voiceStatus !== REALTIME_STATUS.CONNECTING) setTalkOpening(false);
   }, [voiceStatus]);
 
+  // The exchange is live from the press to the end of the reply — the call
+  // coming up, a turn being held, Luke speaking — and the media duck follows
+  // it. Whether anything actually comes down is the main process's question:
+  // it holds the setting, the hangover between turns, and the helper.
+  useEffect(() => {
+    window.sidecar.setVoiceExchangeActive(
+      voiceStatus === REALTIME_STATUS.CONNECTING ||
+        voiceStatus === REALTIME_STATUS.LISTENING ||
+        voiceStatus === REALTIME_STATUS.RESPONDING,
+    );
+  }, [voiceStatus]);
+
   useEffect(() => {
     const element = remoteAudio.current;
     if (!element) return;
@@ -1400,6 +1419,7 @@ export function App(): React.JSX.Element {
               voiceAvailable: bootstrap.realtimeAvailable,
               settings,
               onVoiceCaptionsChange: changeVoiceCaptions,
+              onDuckOtherMediaChange: changeDuckOtherMedia,
               credentials,
               onVoiceChange: changeVoice,
               onVoiceSpeedChange: changeVoiceSpeed,

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -39,6 +39,7 @@ export const APP_SETTING_ID = {
   VOICE: "voice",
   VOICE_SPEED: "voice_speed",
   VOICE_CAPTIONS: "voice_captions",
+  DUCK_OTHER_MEDIA: "duck_other_media",
   SHOW_IN_MENU_BAR: "show_in_menu_bar",
   SHOW_IN_DOCK: "show_in_dock",
 } as const;
@@ -104,6 +105,16 @@ const SETTING_GUIDE: Record<
     description: "Luke's words on screen while he speaks; nothing is kept.",
     kind: APP_SETTING_KIND.TOGGLE,
     value: appToggleText(settings.voiceCaptions),
+    adjustable: true,
+    manual: `${SETTINGS_TAB}, under Preferences`,
+  }),
+  duckOtherMedia: (settings) => ({
+    id: APP_SETTING_ID.DUCK_OTHER_MEDIA,
+    label: "Quiet Music and Spotify",
+    description:
+      "Whether Music and Spotify are turned down while a spoken exchange is live, and back up after.",
+    kind: APP_SETTING_KIND.TOGGLE,
+    value: appToggleText(settings.duckOtherMedia),
     adjustable: true,
     manual: `${SETTINGS_TAB}, under Preferences`,
   }),
@@ -261,7 +272,12 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
 export async function applySpokenSetting(
   bridge: Pick<
     AppBridge,
-    "setVoice" | "setVoiceSpeed" | "setVoiceCaptions" | "setShowInMenuBar" | "setShowInDock"
+    | "setVoice"
+    | "setVoiceSpeed"
+    | "setVoiceCaptions"
+    | "setDuckOtherMedia"
+    | "setShowInMenuBar"
+    | "setShowInDock"
   >,
   action: { setting: AppGuideSetting; value: string },
   onSettings: (settings: AppSettings) => void,
@@ -271,15 +287,17 @@ export async function applySpokenSetting(
   const result =
     action.setting.id === APP_SETTING_ID.VOICE_CAPTIONS
       ? await bridge.setVoiceCaptions(enabled)
-      : action.setting.id === APP_SETTING_ID.SHOW_IN_MENU_BAR
-        ? await bridge.setShowInMenuBar(enabled)
-        : action.setting.id === APP_SETTING_ID.SHOW_IN_DOCK
-          ? await bridge.setShowInDock(enabled)
-          : action.setting.id === APP_SETTING_ID.VOICE_SPEED && speed !== undefined
-            ? await bridge.setVoiceSpeed(speed)
-            : action.setting.id === APP_SETTING_ID.VOICE && isRealtimeVoice(action.value)
-              ? await bridge.setVoice(action.value)
-              : undefined;
+      : action.setting.id === APP_SETTING_ID.DUCK_OTHER_MEDIA
+        ? await bridge.setDuckOtherMedia(enabled)
+        : action.setting.id === APP_SETTING_ID.SHOW_IN_MENU_BAR
+          ? await bridge.setShowInMenuBar(enabled)
+          : action.setting.id === APP_SETTING_ID.SHOW_IN_DOCK
+            ? await bridge.setShowInDock(enabled)
+            : action.setting.id === APP_SETTING_ID.VOICE_SPEED && speed !== undefined
+              ? await bridge.setVoiceSpeed(speed)
+              : action.setting.id === APP_SETTING_ID.VOICE && isRealtimeVoice(action.value)
+                ? await bridge.setVoice(action.value)
+                : undefined;
   if (!result) {
     // An adjustable entry with no carrier is a guide ahead of its wiring;
     // refuse honestly rather than claim a change that never happened.

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -66,6 +66,8 @@ export interface SettingsPanelProps {
    * with why when it refuses, and the row is where that answer belongs.
    */
   onVoiceCaptionsChange: (enabled: boolean) => Promise<string | undefined>;
+  /** Turns the quieting of Music and Spotify during a spoken exchange on or off. */
+  onDuckOtherMediaChange: (enabled: boolean) => Promise<string | undefined>;
   /** The one credential being entered anywhere, and everything that can be done to it. */
   credentials: CredentialEntryControl;
   /** Chooses the voice Luke speaks with, from the set fixed by this build. */
@@ -545,6 +547,8 @@ function PreferencesSection({
   onVoiceSpeedChange,
   captions,
   onVoiceCaptionsChange,
+  ducking,
+  onDuckOtherMediaChange,
   shown,
   onShowInMenuBarChange,
   dockShown,
@@ -556,6 +560,8 @@ function PreferencesSection({
   onVoiceSpeedChange: (speed: RealtimeVoiceSpeed) => void;
   captions: boolean;
   onVoiceCaptionsChange: (enabled: boolean) => Promise<string | undefined>;
+  ducking: boolean;
+  onDuckOtherMediaChange: (enabled: boolean) => Promise<string | undefined>;
   shown: boolean;
   onShowInMenuBarChange: (show: boolean) => Promise<string | undefined>;
   dockShown: boolean;
@@ -584,6 +590,12 @@ function PreferencesSection({
     setDockBusy(true);
     setRejection(await onShowInDockChange(!dockShown));
     setDockBusy(false);
+  };
+  const [duckBusy, setDuckBusy] = useState(false);
+  const toggleDucking = async () => {
+    setDuckBusy(true);
+    setRejection(await onDuckOtherMediaChange(!ducking));
+    setDuckBusy(false);
   };
   return (
     <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
@@ -678,6 +690,27 @@ function PreferencesSection({
           className="switch"
           disabled={captionsBusy}
           onClick={() => void toggleCaptions()}
+        >
+          <span className="switch-thumb" />
+        </button>
+      </div>
+      <div className="settings-row">
+        <span className="settings-copy">
+          <strong>Quiet Music and Spotify</strong>
+          {/* Named by app rather than as "other media": these two are the ones
+              macOS lets Luke turn down, and a switch claiming more would claim
+              a capability the system does not grant. The first duck is also
+              when macOS asks whether Luke may speak to each player at all. */}
+          <small>Their volume dips while you and Luke are talking, and returns after.</small>
+        </span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={ducking}
+          aria-label="Quiet Music and Spotify while talking with Luke"
+          className="switch"
+          disabled={duckBusy}
+          onClick={() => void toggleDucking()}
         >
           <span className="switch-thumb" />
         </button>
@@ -884,6 +917,7 @@ export function SettingsPanel({
   voiceAvailable,
   settings,
   onVoiceCaptionsChange,
+  onDuckOtherMediaChange,
   credentials,
   onVoiceChange,
   onVoiceSpeedChange,
@@ -912,6 +946,8 @@ export function SettingsPanel({
           onVoiceSpeedChange={onVoiceSpeedChange}
           captions={settings.voiceCaptions}
           onVoiceCaptionsChange={onVoiceCaptionsChange}
+          ducking={settings.duckOtherMedia}
+          onDuckOtherMediaChange={onDuckOtherMediaChange}
           shown={settings.showInMenuBar}
           onShowInMenuBarChange={onShowInMenuBarChange}
           dockShown={settings.showInDock}

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -33,6 +33,7 @@ const SETTINGS_FILE_MODE = 0o600;
 
 const SETTINGS_FIELD = {
   API_KEYS: "apiKeys",
+  DUCK_OTHER_MEDIA: "duckOtherMedia",
   LEGACY_CONDUCTOR_API_KEY: "conductorApiKey",
   SHOW_IN_DOCK: "showInDock",
   SHOW_IN_MENU_BAR: "showInMenuBar",
@@ -115,6 +116,13 @@ interface PersistedSettings {
    * honouring it would claim a system key nothing was ever told about.
    */
   voiceHotkey?: string;
+  /**
+   * Whether Music and Spotify are turned down while a spoken exchange is
+   * live. On unless the file says `false` outright — like the menu bar item,
+   * this is what Luke does until the user asks otherwise, so a missing field
+   * and a corrupt value both land on doing it.
+   */
+  duckOtherMedia: boolean;
 }
 
 interface ResolvedApiKey {
@@ -207,6 +215,7 @@ function parsePersistedSettings(source: string): PersistedSettings {
     ...(isRealtimeVoiceSpeed(voiceSpeed) ? { voiceSpeed } : {}),
     voiceCaptions: record[SETTINGS_FIELD.VOICE_CAPTIONS] === true,
     ...(voiceHotkey ? { voiceHotkey } : {}),
+    duckOtherMedia: record[SETTINGS_FIELD.DUCK_OTHER_MEDIA] !== false,
   };
 }
 
@@ -263,6 +272,7 @@ export class SettingsStore {
       ...((await this.#load()).voiceHotkey
         ? { voiceHotkey: (await this.#load()).voiceHotkey }
         : {}),
+      duckOtherMedia: (await this.#load()).duckOtherMedia,
     };
   }
 
@@ -282,6 +292,14 @@ export class SettingsStore {
    */
   async showInDock(): Promise<boolean> {
     return (await this.#load()).showInDock;
+  }
+
+  /**
+   * Shallow for the same reason `showInMenuBar()` is: the media duck arms at
+   * startup, and arming it must never be what wakes the OS keychain.
+   */
+  async duckOtherMedia(): Promise<boolean> {
+    return (await this.#load()).duckOtherMedia;
   }
 
   /**
@@ -382,6 +400,26 @@ export class SettingsStore {
       };
       if (accelerator) next.voiceHotkey = accelerator;
       else delete next.voiceHotkey;
+      await this.#write(next);
+      this.#loading = Promise.resolve(next);
+    });
+    return { settings: await this.snapshot() };
+  }
+
+  /**
+   * Turns the quieting of Music and Spotify during a spoken exchange on or
+   * off. A plain preference like the caption's: no cipher, no invalid value,
+   * so the write either lands or throws.
+   */
+  async setDuckOtherMedia(enabled: boolean): Promise<SettingsUpdateResult> {
+    await this.#serialize(async () => {
+      const persisted = await this.#load();
+      if (persisted.duckOtherMedia === enabled) return;
+      const next: PersistedSettings = {
+        ...persisted,
+        version: SETTINGS_FILE_VERSION,
+        duckOtherMedia: enabled,
+      };
       await this.#write(next);
       this.#loading = Promise.resolve(next);
     });
@@ -572,6 +610,7 @@ export class SettingsStore {
       showInDock: false,
       showInMenuBar: true,
       voiceCaptions: false,
+      duckOtherMedia: true,
     };
     if (source) {
       try {

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -92,6 +92,14 @@ export interface AppSettings {
    * choice to reset, and the row keeps showing the key that actually answers.
    */
   voiceHotkey?: string;
+  /**
+   * Whether Music and Spotify are turned down while a spoken exchange is
+   * live, and back up after. On by default: speech over music is the failure
+   * everyone has had, and the duck defers to the user everywhere it can — it
+   * touches only a player that was playing, and a volume moved by hand during
+   * the duck is left where the hand put it.
+   */
+  duckOtherMedia: boolean;
 }
 
 /** A rejected update reports why without echoing the submitted value. */
@@ -227,6 +235,15 @@ export interface AppBridge {
   setShowInDock(show: boolean): Promise<SettingsUpdateResult>;
   /** Turns the on-screen caption of Luke's speech on or off. */
   setVoiceCaptions(enabled: boolean): Promise<SettingsUpdateResult>;
+  /** Turns the quieting of Music and Spotify during a spoken exchange on or off. */
+  setDuckOtherMedia(enabled: boolean): Promise<SettingsUpdateResult>;
+  /**
+   * Whether a spoken exchange is live — a turn being held, a reply being
+   * spoken, or the call coming up between them. It drives the media duck and
+   * nothing else, and it is a statement rather than a request: fire-and-forget,
+   * because the exchange must never wait on the players.
+   */
+  setVoiceExchangeActive(active: boolean): void;
   /**
    * Moves the talk key to a chord of the user's own, or back to the defaults
    * when omitted. The change is registered with the system at once, and the
@@ -304,6 +321,8 @@ export const channels = {
   setVoiceSpeed: "app:set-voice-speed",
   setVoiceCaptions: "app:set-voice-captions",
   setVoiceHotkey: "app:set-voice-hotkey",
+  setDuckOtherMedia: "app:set-duck-other-media",
+  setVoiceExchange: "app:set-voice-exchange",
   openProviderApiKeys: "app:open-provider-api-keys",
   setShowInMenuBar: "app:set-show-in-menu-bar",
   setShowInDock: "app:set-show-in-dock",

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -148,6 +148,10 @@ test("every adjustable setting is carried to the bridge call its row uses", asyn
       calls.push(`setVoiceCaptions:${enabled}`);
       return answered;
     },
+    setDuckOtherMedia: async (enabled: boolean) => {
+      calls.push(`setDuckOtherMedia:${enabled}`);
+      return answered;
+    },
     setShowInMenuBar: async (show: boolean) => {
       calls.push(`setShowInMenuBar:${show}`);
       return answered;
@@ -169,6 +173,7 @@ test("every adjustable setting is carried to the bridge call its row uses", asyn
   }
 
   assert.deepEqual(calls.sort(), [
+    "setDuckOtherMedia:true",
     "setShowInDock:true",
     "setShowInMenuBar:true",
     "setVoice",

--- a/apps/desktop/tests/media-duck.test.ts
+++ b/apps/desktop/tests/media-duck.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { MediaDuckController, type MediaDuckProcess } from "../src/media-duck";
+
+/** Short enough to wait out for real, long enough to act inside of. */
+const RELEASE_DELAY_MS = 40;
+
+interface Harness {
+  controller: MediaDuckController;
+  /** Every line written to every helper, in order, newlines stripped. */
+  commands: string[];
+  spawns: () => number;
+  stdinEnded: () => boolean;
+  die: () => void;
+}
+
+function harness(options: { spawns?: (() => MediaDuckProcess | undefined)[] } = {}): Harness {
+  const commands: string[] = [];
+  let spawned = 0;
+  let ended = false;
+  const exits: (() => void)[] = [];
+
+  const spawnHelper = (): MediaDuckProcess | undefined => {
+    const scripted = options.spawns?.[spawned];
+    spawned += 1;
+    if (scripted) return scripted();
+    return {
+      stdin: {
+        write: (chunk: string) => commands.push(chunk.trim()),
+        end: () => {
+          ended = true;
+        },
+      },
+      on: (event, listener) => {
+        if (event === "exit") exits.push(listener);
+      },
+      removeAllListeners: () => {
+        exits.length = 0;
+      },
+    };
+  };
+
+  return {
+    controller: new MediaDuckController({ spawnHelper, releaseDelayMs: RELEASE_DELAY_MS }),
+    commands,
+    spawns: () => spawned,
+    stdinEnded: () => ended,
+    die: () => {
+      for (const exit of [...exits]) exit();
+    },
+  };
+}
+
+function settle(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, RELEASE_DELAY_MS * 2));
+}
+
+test("an exchange ducks at once and restores only after the hangover", async () => {
+  const context = harness();
+  context.controller.setEnabled(true);
+
+  context.controller.setExchangeActive(true);
+  assert.deepEqual(context.commands, ["duck"]);
+
+  context.controller.setExchangeActive(false);
+  // The reply just ended; the players stay down through the pause a follow-up
+  // question would arrive in.
+  assert.deepEqual(context.commands, ["duck"]);
+
+  await settle();
+  assert.deepEqual(context.commands, ["duck", "restore"]);
+});
+
+test("a turn beginning inside the hangover keeps the duck held", async () => {
+  const context = harness();
+  context.controller.setEnabled(true);
+
+  context.controller.setExchangeActive(true);
+  context.controller.setExchangeActive(false);
+  context.controller.setExchangeActive(true);
+  await settle();
+
+  // Neither a restore — the conversation never stopped — nor a second duck,
+  // which would read the ducked volume back as the one to restore to.
+  assert.deepEqual(context.commands, ["duck"]);
+
+  context.controller.setExchangeActive(false);
+  await settle();
+  assert.deepEqual(context.commands, ["duck", "restore"]);
+});
+
+test("disabled, an exchange never touches the helper at all", async () => {
+  const context = harness();
+  context.controller.setEnabled(false);
+
+  context.controller.setExchangeActive(true);
+  context.controller.setExchangeActive(false);
+  await settle();
+
+  assert.equal(context.spawns(), 0);
+  assert.deepEqual(context.commands, []);
+});
+
+test("turning the setting off mid-duck restores at once, without the hangover", () => {
+  const context = harness();
+  context.controller.setEnabled(true);
+  context.controller.setExchangeActive(true);
+
+  context.controller.setEnabled(false);
+
+  // The hangover exists so a conversation does not pump; this is not a pause
+  // in a conversation but the user asking for their volume back.
+  assert.deepEqual(context.commands, ["duck", "restore"]);
+});
+
+test("enabling mid-exchange ducks the exchange already underway", () => {
+  const context = harness();
+  context.controller.setExchangeActive(true);
+  assert.deepEqual(context.commands, []);
+
+  context.controller.setEnabled(true);
+  assert.deepEqual(context.commands, ["duck"]);
+});
+
+test("a helper that dies is replaced for the next exchange", async () => {
+  const context = harness();
+  context.controller.setEnabled(true);
+  context.controller.setExchangeActive(true);
+  context.die();
+
+  // The dead helper took its memory of the volumes with it; nothing is owed a
+  // restore, and the next exchange starts fresh.
+  context.controller.setExchangeActive(false);
+  await settle();
+  assert.deepEqual(context.commands, ["duck"]);
+
+  context.controller.setExchangeActive(true);
+  assert.equal(context.spawns(), 2);
+  assert.deepEqual(context.commands, ["duck", "duck"]);
+});
+
+test("a helper that cannot be spawned leaves the exchange unharmed", () => {
+  const context = harness({
+    spawns: [
+      () => {
+        throw new Error("no helper on this platform");
+      },
+    ],
+  });
+  context.controller.setEnabled(true);
+
+  context.controller.setExchangeActive(true);
+  context.controller.setExchangeActive(false);
+
+  assert.deepEqual(context.commands, []);
+});
+
+test("stopping closes stdin rather than writing, and writes nothing after", async () => {
+  const context = harness();
+  context.controller.setEnabled(true);
+  context.controller.setExchangeActive(true);
+
+  context.controller.stop();
+
+  // Stdin closing is itself the restore request — the helper brings the
+  // players back up on EOF — so a written restore would say it twice.
+  assert.equal(context.stdinEnded(), true);
+  await settle();
+  assert.deepEqual(context.commands, ["duck"]);
+});

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -245,6 +245,47 @@ test("a corrupt captions value reads as off rather than switching them on", asyn
   assert.equal((await storeIn(directory).snapshot()).voiceCaptions, false);
 });
 
+test("other media is quieted until asked otherwise, and the choice survives a reopen", async (t) => {
+  const directory = await temporaryDirectory(t);
+  // A preference is not a credential, so choosing it must reach the Keychain
+  // not at all.
+  const cipher = countingCipher();
+  const store = storeIn(directory, { cipher });
+
+  assert.equal((await store.snapshot()).duckOtherMedia, true);
+  const disabled = await store.setDuckOtherMedia(false);
+
+  assert.equal(disabled.settings.duckOtherMedia, false);
+  assert.equal((await storeIn(directory).snapshot()).duckOtherMedia, false);
+  assert.equal(cipher.calls.isAvailable, 0);
+  assert.equal(cipher.calls.encrypt, 0);
+});
+
+test("switching the media duck never disturbs a stored key", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+  await store.setApiKey(CONDUCTOR, TEST_API_KEY);
+
+  await store.setDuckOtherMedia(false);
+  const on = await store.setDuckOtherMedia(true);
+
+  assert.equal(on.settings.duckOtherMedia, true);
+  assert.equal(await storeIn(directory).readApiKey(CONDUCTOR), TEST_API_KEY);
+});
+
+test("a corrupt media duck value reads as the default rather than as off", async (t) => {
+  const directory = await temporaryDirectory(t);
+  // The mirror of the captions rule: each lands on its own default, and this
+  // one's default is on.
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({ version: 2, apiKeys: {}, duckOtherMedia: "no" }),
+    "utf8",
+  );
+
+  assert.equal((await storeIn(directory).snapshot()).duckOtherMedia, true);
+});
+
 test("keeps each provider's key, environment fallback, and reported source separate", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory, {
@@ -298,6 +339,7 @@ test("keeps both keys when two providers are saved at once", async (t) => {
     showInDock: false,
     showInMenuBar: true,
     voiceCaptions: false,
+    duckOtherMedia: true,
   });
   const reopened = storeIn(directory, { providers: TEST_PROVIDERS });
   assert.equal(await reopened.readApiKey(FIRST_CLOUD), "first-cloud-key");
@@ -496,6 +538,7 @@ test("keeps a Conductor key stored by an earlier version working", async (t) => 
     showInDock: false,
     showInMenuBar: true,
     voiceCaptions: false,
+    duckOtherMedia: true,
   });
   assert.equal(await storeIn(directory).readApiKey(CONDUCTOR), "conductor-replacement-key");
 });
@@ -517,6 +560,7 @@ test("carries a key belonging to a provider this build does not know", async (t)
     showInDock: false,
     showInMenuBar: true,
     voiceCaptions: false,
+    duckOtherMedia: true,
   });
 });
 
@@ -536,6 +580,7 @@ test("shows the menu bar item until asked otherwise, and remembers the answer", 
     showInDock: false,
     showInMenuBar: false,
     voiceCaptions: false,
+    duckOtherMedia: true,
   });
   // The choice outlives the run that heard it.
   assert.equal((await storeIn(directory).snapshot()).showInMenuBar, false);
@@ -616,6 +661,7 @@ test("keeps Luke out of the Dock until asked, and remembers the answer", async (
     showInDock: true,
     showInMenuBar: true,
     voiceCaptions: false,
+    duckOtherMedia: true,
   });
   // The choice outlives the run that heard it.
   assert.equal((await storeIn(directory).snapshot()).showInDock, true);

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
+  APPLE_EVENTS_USAGE_DESCRIPTION,
   createPackagerOptions,
   ICONSET_SOURCES,
   iconutilArguments,
@@ -35,6 +36,7 @@ function packagerOptions(signing = resolveSigningMode({})) {
     appRoot: "/repo/apps/desktop",
     outputRoot: "/repo/apps/desktop/out",
     helperPaths: [
+      "/repo/apps/desktop/.build/native/mac-media-duck",
       "/repo/apps/desktop/.build/native/mac-screen-geometry",
       "/repo/apps/desktop/.build/native/mac-talk-key",
     ],
@@ -162,6 +164,19 @@ test("packaging includes the Luke license and approved microphone description", 
   assert.equal(options.extendInfo.NSMicrophoneUsageDescription, MICROPHONE_USAGE_DESCRIPTION);
 });
 
+test("packaging includes the approved Apple Events description", () => {
+  const options = packagerOptions();
+
+  // Spelled out for the same reason the microphone's is: this is the sentence
+  // macOS shows when it asks whether Luke may speak to Music or Spotify, so a
+  // change to it is a change to what the user consented to.
+  assert.equal(
+    options.extendInfo.NSAppleEventsUsageDescription,
+    "Luke turns Music and Spotify down while you are having a spoken conversation, and back up afterwards. He never pauses them, and reads nothing beyond whether each is playing and how loud.",
+  );
+  assert.equal(options.extendInfo.NSAppleEventsUsageDescription, APPLE_EVENTS_USAGE_DESCRIPTION);
+});
+
 test("packaging uses the generated Luke application icon", () => {
   assert.equal(packagerOptions().icon, iconPath);
 });
@@ -239,4 +254,7 @@ test("release entitlements allow required capabilities without unsigned executab
   );
   assert.match(entitlements, /<key>com\.apple\.security\.cs\.allow-jit<\/key>/);
   assert.match(entitlements, /<key>com\.apple\.security\.device\.audio-input<\/key>/);
+  // Apple Events are what the media duck speaks: without this, a hardened
+  // build fails the first duck rather than asking the user.
+  assert.match(entitlements, /<key>com\.apple\.security\.automation\.apple-events<\/key>/);
 });


### PR DESCRIPTION
## Summary

Turns Music and Spotify down while a spoken exchange is live, and back up after — behind a new **Quiet Music and Spotify** switch in the Preferences group, on by default.

- A new native helper, `MediaDuck.swift`, follows the TalkKey pattern: a long-lived process speaking a two-word stdin protocol (`duck` / `restore`). It reaches each player through its own scripting interface behind the system's per-app Automation consent, touches only a player that is actually running and playing (guarded by `NSRunningApplication`, so a duck never launches anyone's music player), fades to a quarter of the player's own volume, and never pauses. On restore, a volume the user moved during the duck stays where their hand put it; stdin closing makes the helper restore whatever is still ducked on its way out, so a crash or quit upstream cannot strand the user's music quiet.
- The main process holds the one decision (`media-duck.ts`): duck when the setting is on and an exchange is live, hold a one-second hangover after the exchange ends so back-to-back turns don't pump, restore immediately when the user flips the setting off. The renderer only states the exchange edge — `connecting`/`listening`/`responding` against the existing `RealtimeStatus` — over one new fire-and-forget IPC channel. The trigger is that deterministic status edge and nothing else; no model output can reach it.
- The preference is a plain boolean beside the captions switch — stored in `settings.json`, never touching the cipher, validated at the IPC boundary. On unless the file says `false` outright, matching the menu bar item's default semantics.
- Packaging grows the `com.apple.security.automation.apple-events` entitlement and an `NSAppleEventsUsageDescription` that states exactly what is done and what is not, both pinned verbatim in `packaging.test.mjs` the way the microphone sentence is. The helper is registered in `NATIVE_HELPERS`, so it cannot be built without shipping or shipped without building.
- The trust constraints in `AGENTS.md` gain a bullet bounding the capability: named players only, volume only, user's hand wins, deterministic trigger, and widening the player list is a product decision.
- Deliberately out of scope: browser audio (YouTube, web players). macOS offers no supported way to reach it, so the switch names the two apps it actually controls rather than claiming "other media".

## Testing

- `./scripts/check.sh` passes: 0 failures across the packaging, sidecar-core, and desktop suites (33 + 72 + 423).
- New coverage: eight controller tests (duck on exchange start, hangover before restore, duck held across back-to-back turns, disabled-never-spawns, immediate restore on toggle-off, dead-helper recovery, unspawnable-helper safety, stop-closes-stdin-without-writing) and three settings tests (default-on with cipher untouched, persistence across reopen without disturbing a stored key, corrupt-value fallback to the default), plus packaging assertions for the helper, entitlement, and usage description.
- Validated end-to-end on a physical Mac: with Spotify playing at volume 100, the helper reported `ducked 1` / `restored 1` and the dip and recovery were audible; the full app path was then exercised live through a spoken exchange after granting the Automation consent. The helper prints `ready` / `ducked N` / `restored N` / `refused <code>` on stdout, so a terminal run shows exactly what it did and a denied consent (`-1743`) can never masquerade as a no-op.
- UI change (one new Preferences row), so CI's `./scripts/verify.sh` on macOS is the completion invariant; evidence is linked from this description by CI. No physical-notch check was performed (working from a cloud workspace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b1bb3061-85f6-4060-9d03-7429fb6a5dca)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31774854872/artifacts/9209504169) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31774854872)

- Commit: `91d7e3ce8b922f91836dc68cfbe3a4cfc44923ab`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
