### PR TITLE
feat(panel): left-align the provider marks in the peek and the panel

### DIFF
--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -22,8 +22,10 @@ import { WAVEFORM_VOICE, Waveform, type WaveformVoice } from "./waveform";
 /**
  * The strips beside the camera housing. They are rendered once for both window
  * modes and anchored to the notch rather than to a stage, so growing the window
- * moves nothing here: the face and the count badge stay put and the marks, the
- * meter, and the captions simply unfold into the space the expanded panel adds.
+ * re-lays out nothing here: the face and the count badge stay put, the meter
+ * and the captions unfold into the space the expanded panel adds, and the
+ * marks — resting against the shape's far edge — glide outward with it on the
+ * surface's own spring.
  */
 interface NotchWingsProps {
   tally: SessionTally;
@@ -40,20 +42,21 @@ interface NotchWingsProps {
 }
 
 /**
- * What one wing costs to fill, in the stylesheet's numbers: `--wing-inset` on
- * both sides, then the face and its gap, then a first mark and a gap-and-mark
- * for every mark after it.
+ * What one wing costs to fill, in the stylesheet's numbers: `--panel-inset` on
+ * the far side, where the marks start level with the tab bar and the rows,
+ * `--wing-inset` beside the housing, then the face and its gap, then a first
+ * mark and a gap-and-mark for every mark after it.
  */
-const WING_INSETS = 18;
+const WING_INSETS = 29;
 const FACE_AND_GAP = 26;
 const MARK_WIDTH = 14;
 const MARK_AND_GAP = 21;
 
 /**
  * How many marks fit beside the face in a wing of this width. The peek's side
- * is fixed at 124px whatever the housing measures, which is where the old
- * limit of four came from: the face and its gap cost 26px of the 106px between
- * the wing's insets, and each mark past the first costs 21px of the 80px that
+ * is fixed at 124px whatever the housing measures, which is where its limit of
+ * three comes from: the face and its gap cost 26px of the 95px between the
+ * wing's insets, and each mark past the first costs 21px of the 55px that
  * remain. The panel's side is what is left of `--panel-width` after the
  * housing, so it holds roughly twice as many.
  */
@@ -67,7 +70,7 @@ export function wingMarkCapacity(sideWidth: number): number {
 const PEEK_SIDE_WIDTH = CAPSULE_SIDE_WIDTH + PEEK_SIDE_GROWTH;
 
 /**
- * The strip beside the face, as slots: each provider's mark, then — when the
+ * The wing's strip, as slots: each provider's mark, then — when the
  * providers outnumber the slots — the count standing in for the rest. The
  * marks are a summary, and a summary that hides its own remainder reads as a
  * complete list, so whatever does not fit is counted rather than dropped. The

--- a/apps/desktop/src/renderer/session-motion.ts
+++ b/apps/desktop/src/renderer/session-motion.ts
@@ -254,12 +254,16 @@ function useReorderMotion<T extends HTMLElement>(list: ReorderList): RefObject<T
 
     const plan = planReorder(baseline.current, positions);
     baseline.current = positions;
-    // Whether this commit moved the container's own bound out from under the
-    // list — the wing's `--wing-bound` changing with the presentation is the
-    // one thing that does. Elements measured against the anchored edge read
-    // that as the travel it truly is, and it is a different gesture from a
-    // slot hop: the surface is what moved, so they ride the surface's spring.
-    const width = container.clientWidth;
+    // Whether this commit moved the list's bound out from under it — the
+    // wing's `--wing-bound` changing with the presentation is the one thing
+    // that does. Elements measured against the anchored edge read that as the
+    // travel it truly is, and it is a different gesture from a slot hop: the
+    // surface is what moved, so they ride the surface's spring. The bound is
+    // the box the offsets are measured against — the container's own
+    // `offsetParent`, the same node the elements report theirs from — never
+    // the container, which shrink-wraps its contents and holds its width
+    // while the bound beneath it moves.
+    const width = (container.offsetParent ?? container).clientWidth;
     const boundMoved =
       baselineWidth.current !== undefined &&
       Math.abs(width - baselineWidth.current) > TRAVEL_EPSILON;

--- a/apps/desktop/src/renderer/session-motion.ts
+++ b/apps/desktop/src/renderer/session-motion.ts
@@ -64,7 +64,9 @@ export const WING_SLOT_ID_ATTRIBUTE = "data-slot-id";
 export const LEAVING_ATTRIBUTE = "data-leaving";
 
 const MOTION_TOKEN = {
+  SPRING: "--spring",
   SPRING_FAST: "--spring-fast",
+  SHAPE_DURATION: "--duration-shape",
   FAST_DURATION: "--duration-fast",
   EXIT_DURATION: "--duration-exit",
   EXIT_EASING: "--motion-exit",
@@ -104,20 +106,20 @@ const SESSION_LIST: ReorderList = {
 };
 
 /**
- * The wing's strip: marks laid along the wing. The wing hangs off the housing
- * and grows its far edge as the shape morphs — `--wing-bound` moves the left
- * edge of the very element `offsetLeft` is measured from — so a slot's
- * position is its distance from the anchored edge instead: measured from the
- * moving one, every morph would read as a reorder and spring marks that never
- * moved. The distance is negated so the numbers still grow the way the axis
- * runs and the travel arithmetic stays the plan's. Measuring the slot's own
- * far edge also keeps the overflow count still while only its digits widen,
- * because the digits grow away from the anchor.
+ * The wing's strip: marks laid along the wing, resting against the shape's far
+ * edge. The wing hangs off the housing and grows that edge as the shape
+ * morphs — `--wing-bound` moves the left edge of the very element `offsetLeft`
+ * is measured from, and the marks move with it — so a slot's position is its
+ * distance from the anchored edge instead: measured from the moving one, a
+ * morph would read as stillness and the marks would jump to the new edge in
+ * one frame. The distance is negated so the numbers still grow the way the
+ * axis runs and the travel arithmetic stays the plan's. Measuring the slot's
+ * own near edge also keeps the overflow count still while only its digits
+ * widen, because the digits grow away from the anchor.
  */
 const WING_STRIP: ReorderList = {
   idAttribute: WING_SLOT_ID_ATTRIBUTE,
-  offset: (element) =>
-    element.offsetLeft + element.offsetWidth - (element.offsetParent?.clientWidth ?? 0),
+  offset: (element) => element.offsetLeft - (element.offsetParent?.clientWidth ?? 0),
   translate: (px) => `translateX(${px}px)`,
   arrivesFromFan: false,
 };
@@ -203,6 +205,7 @@ function elementVisible(element: HTMLElement): boolean {
 function useReorderMotion<T extends HTMLElement>(list: ReorderList): RefObject<T | null> {
   const listRef = useRef<T | null>(null);
   const baseline = useRef<Map<string, number> | undefined>(undefined);
+  const baselineWidth = useRef<number | undefined>(undefined);
   const wasLeaving = useRef<Set<string>>(new Set());
   const exitFades = useRef<Map<string, Animation>>(new Map());
 
@@ -213,6 +216,7 @@ function useReorderMotion<T extends HTMLElement>(list: ReorderList): RefObject<T
     const container = listRef.current;
     if (container === null) {
       baseline.current = undefined;
+      baselineWidth.current = undefined;
       wasLeaving.current = new Set();
       exitFades.current.clear();
       return;
@@ -250,6 +254,16 @@ function useReorderMotion<T extends HTMLElement>(list: ReorderList): RefObject<T
 
     const plan = planReorder(baseline.current, positions);
     baseline.current = positions;
+    // Whether this commit moved the container's own bound out from under the
+    // list — the wing's `--wing-bound` changing with the presentation is the
+    // one thing that does. Elements measured against the anchored edge read
+    // that as the travel it truly is, and it is a different gesture from a
+    // slot hop: the surface is what moved, so they ride the surface's spring.
+    const width = container.clientWidth;
+    const boundMoved =
+      baselineWidth.current !== undefined &&
+      Math.abs(width - baselineWidth.current) > TRAVEL_EPSILON;
+    baselineWidth.current = width;
     if (
       plan.travels.size === 0 &&
       plan.arrivals.length === 0 &&
@@ -268,11 +282,19 @@ function useReorderMotion<T extends HTMLElement>(list: ReorderList): RefObject<T
     const quickDuration = parseMilliseconds(token(MOTION_TOKEN.QUICK_DURATION));
     const exitEasing = token(MOTION_TOKEN.EXIT_EASING).trim() || "ease";
     const fan = parsePixels(token(MOTION_TOKEN.ROW_FAN));
+    // A travel the bound caused rides the shape's spring for the shape's whole
+    // beat: the same curve over the same time holds a mark the same distance
+    // inside the surface's edge for every frame of the morph, where the fast
+    // spring would carry it past the edge onto the desktop.
+    const travelDuration = boundMoved
+      ? parseMilliseconds(token(MOTION_TOKEN.SHAPE_DURATION))
+      : fastDuration;
+    const travelSpring = boundMoved ? token(MOTION_TOKEN.SPRING).trim() || "ease" : springFast;
 
     const travel = (element: HTMLElement, from: number, delay: number) => {
       element.animate([{ transform: list.translate(from) }, { transform: list.translate(0) }], {
-        duration: fastDuration,
-        easing: springFast,
+        duration: travelDuration,
+        easing: travelSpring,
         delay,
         fill: "backwards",
         composite: "add",

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -192,6 +192,10 @@
      the panel stood down to one field, not a different object. */
   --slot-radius: 28px;
   --wing-inset: 9px;
+  /* The panel's own content edge: where the tab bar, the rows, and the composer
+     all start. The wing's marks take the same start, so the strip up top reads
+     as the first line of the column below it. */
+  --panel-inset: 20px;
   --scroll-fade: 26px;
   --panel-width: 620px;
   /* How long the slot's contents wait before arriving. The slot is only ever
@@ -667,17 +671,30 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   padding: 0 var(--wing-inset);
 }
 
-/* Reversed so the first provider — the one that needs a person soonest — is the
-   mark nearest the face, and therefore the first to come out from behind it.
-   Every mark holds its place and only fades, so none of them moves during the
-   morph. A re-sort is the one thing that moves them, and session-motion glides
-   each mark to its new slot the way it glides the rows. */
+/* The left wing's inner spans the whole strip rather than shrinking to its
+   contents: the face keeps the notch's edge it always had, and the marks' own
+   auto margin is what holds them against the shape's far edge instead of
+   beside the face. */
+.wing-left .wing-inner {
+  flex: 1;
+  justify-content: flex-end;
+}
+
+/* Anchored to the shape's far edge — the auto margin holds it there — and
+   starting at `--panel-inset` from it, so the first mark lines up with the tab
+   bar and the rows below. The wing already pads `--wing-inset`; the margin
+   makes up the difference. Read the way a list is: the first provider — the
+   one that needs a person soonest — holds the leftmost slot, and the overflow
+   count trails the rest. The far edge is the one a morph moves, so the marks
+   move with it; session-motion glides them there on the surface's own spring,
+   the same way it glides a re-sorted mark to its new slot. */
 .wing-marks {
   display: flex;
   height: 22px;
-  flex-direction: row-reverse;
   align-items: center;
   gap: 7px;
+  margin-right: auto;
+  margin-left: calc(var(--panel-inset) - var(--wing-inset));
 }
 
 .wing-mark {
@@ -711,6 +728,20 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   transition-duration: var(--duration-quick), var(--duration-shape);
   transition-timing-function: var(--motion-exit), var(--spring);
   transition-delay: var(--peek-delay);
+}
+
+/* The marks rest at the shape's far edge, not beside the face, so the peek's
+   early beat would draw them on the desktop ahead of an edge still most of its
+   travel away. They arrive the way the voice meter arrives in the growing
+   capsule: crossing the last of the shape's travel and finishing as it
+   settles, inside the black rather than ahead of it. The meter above keeps the
+   early beat — it stands beside the face, where the shape's edge passes at
+   once. */
+.app-stage[data-presentation="peek"] .wing-mark,
+.app-stage[data-presentation="peek"] .wing-more,
+.app-stage[data-presentation="panel"] .wing-mark,
+.app-stage[data-presentation="panel"] .wing-more {
+  transition-delay: calc(var(--duration-shape) - var(--duration-quick));
 }
 
 /* A mark can mount into a wing that is already unfolded — the panel's wing
@@ -1307,7 +1338,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   display: flex;
   max-height: 520px;
   flex-direction: column;
-  padding: calc(max(var(--notch-top-inset), 32px) + 14px) 20px 18px;
+  padding: calc(max(var(--notch-top-inset), 32px) + 14px) var(--panel-inset) 18px;
   border-radius: 0 0 var(--panel-radius) var(--panel-radius);
 }
 

--- a/apps/desktop/tests/notch-wings.test.ts
+++ b/apps/desktop/tests/notch-wings.test.ts
@@ -7,15 +7,15 @@ import type { ProviderTally } from "../src/renderer/session-model";
 const peekSideWidth = CAPSULE_SIDE_WIDTH + PEEK_SIDE_GROWTH;
 const panelSideWidth = (housingWidth: number) => (PANEL_WIDTH - housingWidth) / 2;
 
-test("the peek's fixed side holds the four marks it always has", () => {
-  assert.equal(wingMarkCapacity(peekSideWidth), 4);
+test("the peek's fixed side holds three marks now they start at the panel's inset", () => {
+  assert.equal(wingMarkCapacity(peekSideWidth), 3);
 });
 
 test("the panel's side holds what is left after the housing", () => {
   // The fixture display's 210px housing: (620 - 210) / 2 = 205px a side.
-  assert.equal(wingMarkCapacity(panelSideWidth(210)), 8);
+  assert.equal(wingMarkCapacity(panelSideWidth(210)), 7);
   // No housing at all — a display without a notch — leaves the most room.
-  assert.equal(wingMarkCapacity(panelSideWidth(0)), 13);
+  assert.equal(wingMarkCapacity(panelSideWidth(0)), 12);
 });
 
 test("a wider housing costs marks rather than clipping them", () => {


### PR DESCRIPTION
## What

The provider marks at the top of the strip now start at the shape's far left edge instead of resting against the face, in both the peek and the expanded panel. In the panel they sit exactly level with the Sessions/Settings toggle and the session rows — the strip reads as the first line of the column below it. The list reads left to right: the provider that needs a person soonest holds the leftmost slot, and the overflow count trails the rest.

## How

- **Layout**: the left wing's inner now spans the whole strip; the marks carry an auto margin toward the face and start at the new `--panel-inset` token — the same 20px `.expanded-panel` pads its content with — while the face and the voice meter keep the housing's edge. The old `row-reverse` is gone with the behind-the-face unfold that justified it.
- **Motion**: the far edge is the one a morph moves, so the marks now move with it. `session-motion` measures the strip against the anchored (housing) edge, so a `--wing-bound` change reads as the travel it truly is — and a bound-caused travel rides the surface's own spring for the shape's whole beat, holding each mark the same distance inside the surface's edge for every frame of the morph. Slot-hop reorders keep `--spring-fast`.
- **Unfold**: marks at the far edge can't take the peek's early beat without being drawn on the desktop ahead of a still-growing shape, so they arrive the way the voice meter arrives in the growing capsule: fading in over the last of the shape's travel (`--duration-shape − --duration-quick`). The meter keeps the early beat — it stands beside the face, where the edge passes at once.
- **Capacity**: `WING_INSETS` budgets the wider far-side inset (20px + 9px), so the peek now holds three marks and the fixture panel seven; the overflow count absorbs the difference, so nothing is dropped or clipped.

## Validation

- `./scripts/check.sh` passes: 486/486 tests, lint, types, build, generator drift clean.
- Packaged fixture captures under Xvfb (Linux) inspected for all five evidence states: peek and panel show the marks starting at the content edge; compact, slot, and speaking are unchanged. Pixel-measured on the expanded capture: tab pill x=60, row card x=60, first mark box x=60.
- `./scripts/verify.sh` was not run (Linux sandbox); no physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/88ae4976-9b0d-4a0b-8177-02ae266168cd)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31814493468/artifacts/9224464514) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31814493468)

- Commit: `067d9f421a72b2b5358d839925725d924eb64fd7`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
