### PR TITLE
feat(panel): hold the panel still while Show Desktop sweeps windows aside

### DIFF
--- a/apps/desktop/native/macos/StationaryWindow.m
+++ b/apps/desktop/native/macos/StationaryWindow.m
@@ -56,7 +56,15 @@ static napi_value MakeStationary(napi_env env, napi_callback_info info) {
     napi_throw_error(env, NULL, "The native window handle has no window behind it");
     return undefined;
   }
-  window.collectionBehavior |= NSWindowCollectionBehaviorStationary;
+  // Managed, transient, and stationary are a mutually exclusive group — AppKit
+  // honors at most one, and the window arrives here carrying managed (from its
+  // creation) and transient (from being hidden in Mission Control). Stationary
+  // only takes effect once it is the group's sole member; the panel is an
+  // NSPanel, which Mission Control never tiles, so transient is not missed.
+  window.collectionBehavior =
+      (window.collectionBehavior &
+       ~(NSWindowCollectionBehaviorManaged | NSWindowCollectionBehaviorTransient)) |
+      NSWindowCollectionBehaviorStationary;
 
   napi_value behavior = NULL;
   if (napi_create_double(env, (double)window.collectionBehavior, &behavior) != 0) {

--- a/apps/desktop/native/macos/StationaryWindow.m
+++ b/apps/desktop/native/macos/StationaryWindow.m
@@ -1,0 +1,76 @@
+// Show Desktop scoops every app window aside, but the hardware notch the
+// panel poses as does not move. AppKit's stationary collection behavior is
+// what exempts a window from Exposé, and Electron only sets it on
+// `desktop`-type windows, which can never take keyboard focus — so this
+// Node-API addon sets the flag on the panel's own NSWindow. It has to run in
+// the app's process: no external helper can reach another process's windows.
+//
+// The Node-API surface is declared inline rather than by importing
+// node_api.h: these few declarations are the frozen version-1 C ABI, and
+// vendoring Node's headers to reach them would be the larger liability.
+
+#import <AppKit/AppKit.h>
+#include <stddef.h>
+
+typedef struct napi_env__ *napi_env;
+typedef struct napi_value__ *napi_value;
+typedef struct napi_callback_info__ *napi_callback_info;
+typedef int napi_status;
+typedef napi_value (*napi_callback)(napi_env env, napi_callback_info info);
+
+extern napi_status napi_get_cb_info(napi_env env, napi_callback_info info, size_t *argc,
+                                    napi_value *argv, napi_value *thisArg, void **data);
+extern napi_status napi_get_buffer_info(napi_env env, napi_value value, void **data,
+                                        size_t *length);
+extern napi_status napi_create_function(napi_env env, const char *name, size_t length,
+                                        napi_callback callback, void *data, napi_value *result);
+extern napi_status napi_set_named_property(napi_env env, napi_value object, const char *name,
+                                           napi_value value);
+extern napi_status napi_get_undefined(napi_env env, napi_value *result);
+extern napi_status napi_create_double(napi_env env, double value, napi_value *result);
+extern napi_status napi_throw_error(napi_env env, const char *code, const char *message);
+
+// Returns the window's resulting collection-behavior mask, so a caller can
+// confirm the stationary bit is set on the real NSWindow rather than trust
+// that the call landed.
+static napi_value MakeStationary(napi_env env, napi_callback_info info) {
+  napi_value undefined = NULL;
+  napi_get_undefined(env, &undefined);
+
+  size_t argc = 1;
+  napi_value argv[1] = {NULL};
+  void *handle = NULL;
+  size_t handleLength = 0;
+  // The argument is the Buffer from BrowserWindow.getNativeWindowHandle(),
+  // whose bytes are the NSView pointer itself.
+  if (napi_get_cb_info(env, info, &argc, argv, NULL, NULL) != 0 || argc < 1 ||
+      napi_get_buffer_info(env, argv[0], &handle, &handleLength) != 0 ||
+      handleLength != sizeof(NSView *)) {
+    napi_throw_error(env, NULL, "makeStationary expects a native window handle");
+    return undefined;
+  }
+
+  NSView *view = *(NSView *__unsafe_unretained *)handle;
+  NSWindow *window = view.window;
+  if (window == nil) {
+    napi_throw_error(env, NULL, "The native window handle has no window behind it");
+    return undefined;
+  }
+  window.collectionBehavior |= NSWindowCollectionBehaviorStationary;
+
+  napi_value behavior = NULL;
+  if (napi_create_double(env, (double)window.collectionBehavior, &behavior) != 0) {
+    return undefined;
+  }
+  return behavior;
+}
+
+__attribute__((visibility("default"))) napi_value napi_register_module_v1(napi_env env,
+                                                                          napi_value exports) {
+  napi_value makeStationary = NULL;
+  if (napi_create_function(env, "makeStationary", (size_t)-1, MakeStationary, NULL,
+                           &makeStationary) == 0) {
+    napi_set_named_property(env, exports, "makeStationary", makeStationary);
+  }
+  return exports;
+}

--- a/apps/desktop/scripts/build-native.mjs
+++ b/apps/desktop/scripts/build-native.mjs
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { swiftCompilerArguments } from "./package-config.mjs";
+import { addonCompilerArguments, swiftCompilerArguments } from "./package-config.mjs";
 import { NATIVE_HELPERS } from "./package-layout.mjs";
 
 if (process.platform !== "darwin") {
@@ -19,7 +19,10 @@ fs.mkdirSync(outputDirectory, { recursive: true });
 for (const helper of NATIVE_HELPERS) {
   const source = path.join(appRoot, "native", "macos", helper.source);
   const output = path.join(outputDirectory, helper.binary);
-  const result = spawnSync("xcrun", swiftCompilerArguments(source, output, helper.frameworks), {
+  const compilerArguments = helper.source.endsWith(".swift")
+    ? swiftCompilerArguments(source, output, helper.frameworks)
+    : addonCompilerArguments(source, output, helper.frameworks);
+  const result = spawnSync("xcrun", compilerArguments, {
     stdio: "inherit",
   });
 

--- a/apps/desktop/scripts/package-config.mjs
+++ b/apps/desktop/scripts/package-config.mjs
@@ -34,6 +34,24 @@ export const SIGNING_MODE = {
   DEVELOPER_ID: "developer-id",
 };
 
+export function addonCompilerArguments(source, output, frameworks = ["AppKit"]) {
+  return [
+    "clang",
+    "-target",
+    SWIFT_TARGET_TRIPLE,
+    "-fobjc-arc",
+    "-Wall",
+    "-dynamiclib",
+    // Node-API symbols have no library to link against at build time; they
+    // resolve from the Electron binary the addon is loaded into.
+    "-Wl,-undefined,dynamic_lookup",
+    ...frameworks.flatMap((framework) => ["-framework", framework]),
+    source,
+    "-o",
+    output,
+  ];
+}
+
 export function swiftCompilerArguments(source, output, frameworks = ["AppKit"]) {
   return [
     "swiftc",

--- a/apps/desktop/scripts/package-layout.mjs
+++ b/apps/desktop/scripts/package-layout.mjs
@@ -3,9 +3,12 @@ import path from "node:path";
 export const PACKAGED_ARCHITECTURE = "arm64";
 
 /**
- * The native helpers, named once. Each is a Swift source and the binary it
+ * The native helpers, named once. Each is a native source and the binary it
  * becomes: the build compiles this list and the packager ships it, so a helper
  * cannot be built without reaching the bundle or shipped without being built.
+ * Swift sources become standalone executables the app spawns; the `.m` source
+ * becomes a Node-API addon the main process loads, because it works on the
+ * app's own windows and so has to run inside the app's process.
  */
 export const NATIVE_HELPERS = [
   { source: "MediaDuck.swift", binary: "mac-media-duck", frameworks: ["AppKit"] },
@@ -14,6 +17,11 @@ export const NATIVE_HELPERS = [
     source: "TalkKey.swift",
     binary: "mac-talk-key",
     frameworks: ["AppKit", "Carbon"],
+  },
+  {
+    source: "StationaryWindow.m",
+    binary: "mac-stationary-window.node",
+    frameworks: ["AppKit"],
   },
 ];
 

--- a/apps/desktop/src/macos-stationary-window.ts
+++ b/apps/desktop/src/macos-stationary-window.ts
@@ -1,0 +1,36 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+import { app, type BrowserWindow } from "electron";
+
+interface StationaryWindowAddon {
+  /** Returns the window's resulting collection-behavior mask. */
+  makeStationary(windowHandle: Buffer): number;
+}
+
+// The bundle is CommonJS, but an explicit require keeps esbuild from trying to
+// bundle a path only known at runtime.
+const requireAddon = createRequire(__filename);
+
+function addonPath(): string {
+  if (app.isPackaged) {
+    return path.join(process.resourcesPath, "mac-stationary-window.node");
+  }
+  return path.join(app.getAppPath(), ".build", "native", "mac-stationary-window.node");
+}
+
+/**
+ * Show Desktop scoops every app window aside, but the hardware notch the panel
+ * poses as does not move, so neither may the panel. AppKit's stationary
+ * collection behavior is what exempts a window from Exposé, and Electron only
+ * sets it on `desktop`-type windows, which can never take keyboard focus — so
+ * a small Node-API addon sets the flag on the panel's own NSWindow instead.
+ */
+export function keepWindowStationary(window: BrowserWindow): void {
+  if (process.platform !== "darwin") return;
+  try {
+    const addon = requireAddon(addonPath()) as StationaryWindowAddon;
+    addon.makeStationary(window.getNativeWindowHandle());
+  } catch (error) {
+    console.warn("Stationary behavior unavailable; Show Desktop will move the panel", error);
+  }
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -57,6 +57,7 @@ import { DevinSessionAdapter } from "./devin-adapter";
 import { JulesSessionAdapter } from "./jules-adapter";
 import { LinearIssueTracker } from "./linear-tracker";
 import { readMacScreenGeometry } from "./macos-screen-geometry";
+import { keepWindowStationary } from "./macos-stationary-window";
 import { MediaDuckController } from "./media-duck";
 import { openAiAttentionEvaluatorFromEnvironment } from "./openai-attention-evaluator";
 import {
@@ -465,6 +466,7 @@ function configurePanelBehavior(window: BrowserWindow): void {
     });
     window.setHiddenInMissionControl(true);
     window.setWindowButtonVisibility(false);
+    keepWindowStationary(window);
   }
 }
 

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
+  addonCompilerArguments,
   APPLE_EVENTS_USAGE_DESCRIPTION,
   createPackagerOptions,
   ICONSET_SOURCES,
@@ -39,6 +40,7 @@ function packagerOptions(signing = resolveSigningMode({})) {
       "/repo/apps/desktop/.build/native/mac-media-duck",
       "/repo/apps/desktop/.build/native/mac-screen-geometry",
       "/repo/apps/desktop/.build/native/mac-talk-key",
+      "/repo/apps/desktop/.build/native/mac-stationary-window.node",
     ],
     iconPath,
     licensePath: `/repo/apps/desktop/.build/${LICENSE_RESOURCE_NAME}`,
@@ -132,9 +134,28 @@ test("every native helper is built and shipped, or neither happens", () => {
       // and is simply absent from the app someone downloads.
       `${helper.binary} reaches the bundle`,
     );
-    assert.ok(helper.source.endsWith(".swift"));
+    // A spawned helper is a Swift executable; an in-process addon is
+    // Objective-C, loaded through Node-API, and named so the loader can tell.
+    assert.ok(helper.source.endsWith(".swift") || helper.source.endsWith(".m"));
+    assert.equal(helper.binary.endsWith(".node"), helper.source.endsWith(".m"));
     assert.ok(helper.frameworks.length > 0);
   }
+});
+
+test("the stationary window addon is compiled as a loadable Node-API module", () => {
+  const stationary = NATIVE_HELPERS.find(
+    (helper) => helper.binary === "mac-stationary-window.node",
+  );
+
+  assert.ok(stationary, "the stationary window addon is declared");
+  const compilerArguments = addonCompilerArguments("s", "o", stationary.frameworks);
+  assert.deepEqual(compilerArguments.slice(0, 3), ["clang", "-target", SWIFT_TARGET_TRIPLE]);
+  assert.ok(compilerArguments.includes("-dynamiclib"));
+  // Node-API symbols resolve from the Electron binary at load time, so the
+  // link must be allowed to leave them undefined.
+  assert.ok(compilerArguments.includes("-Wl,-undefined,dynamic_lookup"));
+  // NSWindowCollectionBehaviorStationary is the whole reason the addon exists.
+  assert.ok(compilerArguments.includes("AppKit"));
 });
 
 test("the talk key is compiled against the framework that reads it", () => {

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -4,8 +4,8 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
-  addonCompilerArguments,
   APPLE_EVENTS_USAGE_DESCRIPTION,
+  addonCompilerArguments,
   createPackagerOptions,
   ICONSET_SOURCES,
   iconutilArguments,

--- a/scripts/test-macos.sh
+++ b/scripts/test-macos.sh
@@ -22,6 +22,10 @@ for helper in mac-screen-geometry mac-talk-key; do
         exit 1
     fi
 done
+if [[ ! -f "$PACKAGED_APP/Contents/Resources/mac-stationary-window.node" ]]; then
+    printf 'error: packaged app is missing the mac-stationary-window.node addon\n' >&2
+    exit 1
+fi
 INFO_PLIST="$PACKAGED_APP/Contents/Info.plist"
 BUNDLE_ICON_FILE=$(plutil -extract CFBundleIconFile raw -o - "$INFO_PLIST")
 PACKAGED_ICON="$PACKAGED_APP/Contents/Resources/$BUNDLE_ICON_FILE"


### PR DESCRIPTION
## What

Show Desktop sweeps every app window aside, but the hardware notch the panel poses as does not move — so now the panel doesn't either. AppKit's stationary collection behavior is what exempts a window from Exposé, and Electron only sets it on `desktop`-type windows, which can never take keyboard focus. A new Node-API addon (`StationaryWindow.m`, compiled and shipped exactly like the existing Swift helpers) sets the flag on the panel's own NSWindow, which is why it must run inside the app's process rather than as a spawned helper.

Two details carry the fix:

- Managed, transient, and stationary are a mutually exclusive group — AppKit honors at most one. The window arrives carrying managed (from its creation) and transient (from being hidden in Mission Control), so the addon clears both and leaves stationary the group's sole member. Mission Control hiding is not lost: the panel is an NSPanel, which Mission Control never tiles.
- The addon returns the resulting collection-behavior mask, so a caller can confirm the bit landed on the real NSWindow rather than trust that the call did.

## What doesn't change

- No new dependencies: the addon declares the frozen Node-API version-1 C ABI inline rather than vendoring Node's headers, and links with undefined symbols resolved from the Electron binary at load time.
- The helper list still builds-what-it-ships: `build-native.mjs`, packaging, `test-macos.sh`, and the packaging tests all name the addon once through `NATIVE_HELPERS`.
- A machine where the addon fails to load degrades to a console warning; the panel keeps today's behavior.

## Validation

- `./scripts/check.sh` — passes (exit 0).
- On a physical M-series Mac (macOS 26): the addon compiles, loads into Electron, and reports mask 273 (canJoinAllSpaces + stationary + fullScreenAuxiliary) on a window configured exactly like the panel's — stationary as the sole management-group bit. `./scripts/evidence.sh` passed with all five evidence PNGs validated and codesign verifying; the test-suite half of `verify.sh` hit a pre-existing local realtime-session flake, reproduced identically at the base commit.
- Physical-notch check: performed — with the patched build running live, the Show Desktop gesture on a notched MacBook leaves the panel at the notch while every other window sweeps aside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a1601b60-c528-4506-a009-36bf0cc2e74e)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31814952624/artifacts/9224636831) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31814952624)

- Commit: `dae93e036808b3fddcd37baf61a201961b6cee8c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
