### PR TITLE
feat(settings): make the ask key an editable shortcut

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -311,10 +311,12 @@ function registerAskHotkey(): void {
     process.stderr.write(`${askHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.NO_CREDENTIAL)}\n`);
     return;
   }
-  // A chord the talk key sits on — chosen by the user, or announced as
-  // registered — is not a candidate: the two Luke keys must never compete.
+  // Every chord the talk key could sit on is taken, not just the one it has
+  // announced: its helper falls back through its own candidates after this
+  // runs, so a chord it merely might take is already not the ask key's to
+  // have — the two Luke keys must never compete.
   for (const accelerator of askHotkeyCandidates(chosenAskHotkey, [
-    chosenVoiceHotkey,
+    ...voiceHotkeyCandidates(chosenVoiceHotkey),
     voiceHotkey,
   ])) {
     const registered = globalShortcut.register(accelerator, () => {
@@ -884,10 +886,16 @@ function registerIpc(): void {
       if (accelerator !== undefined && chosen === undefined) {
         throw new Error("Invalid shortcut request");
       }
-      if (chosen && (chosen === chosenVoiceHotkey || chosen === voiceHotkey)) {
+      // The talk key's whole candidate list is refused, not just the chord it
+      // holds now: its helper may fall back to any of them on a later launch,
+      // and an ask key stored on one would race it there.
+      if (
+        chosen &&
+        (voiceHotkeyCandidates(chosenVoiceHotkey).includes(chosen) || chosen === voiceHotkey)
+      ) {
         return {
           settings: await settingsStore.snapshot(),
-          reason: "That chord is the talk key's.",
+          reason: "That chord is reserved for the talk key.",
         };
       }
       try {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -285,6 +285,7 @@ function registerToggleHotkey(): void {
 }
 
 let askHotkey: string | undefined;
+let chosenAskHotkey: string | undefined;
 
 /**
  * Registers the key that summons the ask field from whatever app is frontmost,
@@ -312,7 +313,10 @@ function registerAskHotkey(): void {
   }
   // A chord the talk key sits on — chosen by the user, or announced as
   // registered — is not a candidate: the two Luke keys must never compete.
-  for (const accelerator of askHotkeyCandidates([chosenVoiceHotkey, voiceHotkey])) {
+  for (const accelerator of askHotkeyCandidates(chosenAskHotkey, [
+    chosenVoiceHotkey,
+    voiceHotkey,
+  ])) {
     const registered = globalShortcut.register(accelerator, () => {
       setWindowMode("expanded", true);
       panelWindow?.webContents.send(channels.lifecycle, "ask:focus");
@@ -333,6 +337,19 @@ function registerAskHotkey(): void {
  */
 function sendAskHotkey(): void {
   panelWindow?.webContents.send(channels.askHotkeyChanged, askHotkey);
+}
+
+/**
+ * Moves the ask key to whatever `chosenAskHotkey` now says, while the app is
+ * running. Only the ask key's own chord is let go of — the talk key's
+ * registration must not flicker for a change that is none of its business —
+ * and unlike the talk key there is no helper exit to wait for: Electron
+ * releases a chord the moment it is asked to.
+ */
+function applyAskHotkey(): void {
+  if (askHotkey) globalShortcut.unregister(askHotkey);
+  registerAskHotkey();
+  sendAskHotkey();
 }
 
 /** Tells a renderer the key it should be showing, whenever that changes. */
@@ -838,6 +855,46 @@ function registerIpc(): void {
           // Awaited so the renderer's controls stay at rest until the swap has
           // finished and the helper's own registration line can say the truth.
           await applyVoiceHotkey();
+        }
+        return result;
+      } catch {
+        // A filesystem failure is not something the user can act on, so it is
+        // reported as one line rather than as a raw system error.
+        return {
+          settings: await settingsStore.snapshot(),
+          reason: "Could not save that shortcut on this system.",
+        };
+      }
+    },
+  );
+
+  // The ask key is the user's to move on the talk key's exact terms, read
+  // through the same gate and registered at once. The one extra rule is the
+  // standing one — the two Luke keys must never compete for a chord — so a
+  // chord the talk key sits on is refused with words rather than stored and
+  // silently outbid.
+  ipcMain.handle(
+    channels.setAskHotkey,
+    async (event, accelerator: unknown): Promise<SettingsUpdateResult> => {
+      if (!trustedSender(event)) throw new Error("Untrusted renderer");
+      if (accelerator !== undefined && typeof accelerator !== "string") {
+        throw new Error("Invalid shortcut request");
+      }
+      const chosen = accelerator === undefined ? undefined : parseVoiceHotkey(accelerator);
+      if (accelerator !== undefined && chosen === undefined) {
+        throw new Error("Invalid shortcut request");
+      }
+      if (chosen && (chosen === chosenVoiceHotkey || chosen === voiceHotkey)) {
+        return {
+          settings: await settingsStore.snapshot(),
+          reason: "That chord is the talk key's.",
+        };
+      }
+      try {
+        const result = await settingsStore.setAskHotkey(chosen);
+        if (!result.reason) {
+          chosenAskHotkey = chosen;
+          applyAskHotkey();
         }
         return result;
       } catch {
@@ -1500,6 +1557,7 @@ if (!app.requestSingleInstanceLock()) {
     // the default away from the user who moved off it. A file that cannot be
     // read means no choice was kept, and the defaults answer.
     chosenVoiceHotkey = await settingsStore.readVoiceHotkey().catch(() => undefined);
+    chosenAskHotkey = await settingsStore.readAskHotkey().catch(() => undefined);
     // The report is not made here: the helper answers over its own stdout a
     // moment later, and a line printed now would state an absence that only
     // exists because nobody has answered yet.

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -56,6 +56,8 @@ const bridge: AppBridge = {
     ipcRenderer.invoke(channels.setVoiceCaptions, enabled) as Promise<SettingsUpdateResult>,
   setVoiceHotkey: (accelerator: string | undefined) =>
     ipcRenderer.invoke(channels.setVoiceHotkey, accelerator) as Promise<SettingsUpdateResult>,
+  setAskHotkey: (accelerator: string | undefined) =>
+    ipcRenderer.invoke(channels.setAskHotkey, accelerator) as Promise<SettingsUpdateResult>,
   setDuckOtherMedia: (enabled: boolean) =>
     ipcRenderer.invoke(channels.setDuckOtherMedia, enabled) as Promise<SettingsUpdateResult>,
   setVoiceExchangeActive: (active: boolean) => {

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -25,7 +25,12 @@ import type {
 import { CREDENTIAL_SOURCE, SESSION_OPEN_RESULT_STATUS } from "../shared/contracts";
 import type { CredentialProviderId } from "../shared/credential-providers";
 import { CREDENTIAL_PROVIDER_LIST } from "../shared/credential-providers";
-import { TALK_KEY_RELEASE, talkKeyRelease, voiceHotkeyToShow } from "../shared/voice-hotkey";
+import {
+  TALK_KEY_RELEASE,
+  talkKeyRelease,
+  voiceHotkeyLabel,
+  voiceHotkeyToShow,
+} from "../shared/voice-hotkey";
 import { ASK_LUKE_INPUT_ID, askRefusal, focusAskField } from "./ask-luke";
 import type { CredentialEntry, CredentialEntryControl } from "./credential-entry";
 import { isSubmittable, removalEndsEntry } from "./credential-entry";
@@ -848,10 +853,19 @@ export function App(): React.JSX.Element {
     return result.reason;
   }, []);
 
-  // True while the settings row is recording a chord. The talk key stays
-  // registered through a recording — the recording is how it gets replaced —
-  // so a press of the current chord landing then is held here rather than
-  // opening the microphone under the field being typed into.
+  // The ask key, under the same rule: the key the row shows follows the main
+  // process's own announcement of what actually registered.
+  const changeAskHotkey = useCallback(async (accelerator: string | undefined) => {
+    const result = await window.sidecar.setAskHotkey(accelerator);
+    setSettings(result.settings);
+    return result.reason;
+  }, []);
+
+  // True while a settings row is recording a chord. Both Luke keys stay
+  // registered through a recording — the recording is how one gets replaced —
+  // so a press of a current chord landing then is held here rather than
+  // opening the microphone, or summoning the composer, under the field being
+  // typed into.
   const shortcutCapture = useRef(false);
   const changeShortcutCapture = useCallback((capturing: boolean) => {
     shortcutCapture.current = capturing;
@@ -1083,7 +1097,9 @@ export function App(): React.JSX.Element {
       if (eventName === "mode:compact") applyAuthoritativeMode("compact");
       if (eventName === "mode:expanded") applyAuthoritativeMode("expanded");
       if (eventName === "tab:settings") changeTab(PANEL_TAB.SETTINGS);
-      if (eventName === "ask:focus") summonAsk();
+      // Held while a shortcut row is recording, for the same reason the talk
+      // key's press is: the chord just typed is an entry, not an ask.
+      if (eventName === "ask:focus" && !shortcutCapture.current) summonAsk();
     });
     const removeDisplay = window.sidecar.onDisplayChanged(setDisplay);
     const removeSessions = window.sidecar.onSessionsChanged(setSessions);
@@ -1191,15 +1207,17 @@ export function App(): React.JSX.Element {
   // change made in the panel is known to the conversation the moment it lands.
   useEffect(() => {
     if (!bootstrap) return;
+    const askAccelerator = askHotkeyChange ? askHotkeyChange.accelerator : bootstrap.askHotkey;
     const guide = buildLukeGuide({
       settings: settings ?? bootstrap.settings,
       voiceAvailable: bootstrap.realtimeAvailable,
       microphoneStatus,
       hotkey: voiceHotkeyToShow(bootstrap, voiceHotkey),
+      ...(askAccelerator ? { askKey: voiceHotkeyLabel(askAccelerator) } : {}),
     });
     guideRef.current = guide;
     voiceSession.current?.updateGuide(guide);
-  }, [bootstrap, settings, microphoneStatus, voiceHotkey]);
+  }, [bootstrap, settings, microphoneStatus, voiceHotkey, askHotkeyChange]);
 
   useEffect(() => {
     // An update Luke cannot voice — no call open, or a turn already under way —
@@ -1427,6 +1445,11 @@ export function App(): React.JSX.Element {
               ...(shownHotkey.hotkey ? { voiceHotkey: shownHotkey.hotkey } : {}),
               voiceHotkeyHeld: shownHotkey.held,
               onVoiceHotkeyChange: changeVoiceHotkey,
+              // Labelled here because the ask key travels as an accelerator —
+              // the composer's keycap needs both spellings, but the row shows
+              // the key the way macOS writes it, as the talk key's row does.
+              ...(shownAskHotkey ? { askHotkey: voiceHotkeyLabel(shownAskHotkey) } : {}),
+              onAskHotkeyChange: changeAskHotkey,
               onShortcutCapture: changeShortcutCapture,
               onShowInMenuBarChange: changeShowInMenuBar,
               onShowInDockChange: changeShowInDock,

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -142,6 +142,10 @@ const SETTING_GUIDE: Record<
   // changeable either way: a chord is recorded by typing it, so the fact says
   // where.
   voiceHotkey: () => undefined,
+  // Described in the ask-key fact instead, for exactly the talk key's
+  // reasons: the fact carries the key that registered, and a chord is
+  // recorded by typing it rather than saying it.
+  askHotkey: () => undefined,
   // Not a switch but a set of keys, so it is described in the facts instead:
   // which providers are connected, and that a key is only ever typed by hand.
   credentialSources: () => undefined,
@@ -157,6 +161,8 @@ export interface LukeGuideInput {
   microphoneStatus: MicrophoneStatus;
   /** The talk key as the panel shows it, absent when none was registered. */
   hotkey: { hotkey?: string; held: boolean };
+  /** The ask key as the panel shows it, absent when none was registered. */
+  askKey?: string;
 }
 
 function talkKeyFact(hotkey: LukeGuideInput["hotkey"]): AppGuideFact {
@@ -173,6 +179,22 @@ function talkKeyFact(hotkey: LukeGuideInput["hotkey"]): AppGuideFact {
   return {
     label: "Talk key",
     detail: `${hotkey.hotkey}, from any app: ${use}. A different chord can be recorded, or the default restored, in ${SETTINGS_TAB}.`,
+  };
+}
+
+function askKeyFact(askKey: string | undefined): AppGuideFact {
+  if (!askKey) {
+    return {
+      label: "Ask key",
+      detail:
+        "None is registered right now — another app may own the shortcut, or voice is off. The Settings tab shows its state.",
+    };
+  }
+  return {
+    label: "Ask key",
+    detail:
+      `${askKey}, from any app: summons the panel with the caret in the typed composer, and the ` +
+      `same press puts it away. A different chord can be recorded, or the default restored, in ${SETTINGS_TAB}.`,
   };
 }
 
@@ -226,10 +248,11 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "Two tabs. Sessions lists every observed session with its state, narrowable to all, local, " +
         "cloud, or one provider, and orderable by urgency (what needs the developer first) or " +
         "recency (what moved last first); a row can be opened, messaged, or controlled where its " +
-        "provider allows. Settings holds the preferences, the talk key, the cloud API keys, " +
-        "permissions, and Quit.",
+        "provider allows. Settings holds the preferences, the talk and ask keys, the cloud API " +
+        "keys, permissions, and Quit.",
     },
     talkKeyFact(input.hotkey),
+    askKeyFact(input.askKey),
     { label: "Microphone access", detail: MICROPHONE_DETAIL[input.microphoneStatus] },
     ...(input.voiceAvailable
       ? []

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -14,6 +14,7 @@ import type { CredentialProvider } from "../shared/credential-providers";
 import { CREDENTIAL_PROVIDER_LIST } from "../shared/credential-providers";
 import {
   capturedVoiceHotkey,
+  DEFAULT_ASK_HOTKEYS,
   DEFAULT_VOICE_HOTKEYS,
   VOICE_HOTKEY_CAPTURE,
   voiceHotkeyLabel,
@@ -101,9 +102,17 @@ export interface SettingsPanelProps {
    * that answer belongs.
    */
   onVoiceHotkeyChange: (accelerator: string | undefined) => Promise<string | undefined>;
+  /** The ask key as registered, shown so it can be learned — and pressed to be changed. */
+  askHotkey?: string;
   /**
-   * Whether the recording control has the keyboard. While it does, the talk
-   * key must not open a turn: the chord arriving is an entry, not an ask.
+   * Moves the ask key to a recorded chord, or back to the defaults when
+   * omitted, on the talk key's terms: the store answers with why when it
+   * refuses, and the row is where that answer belongs.
+   */
+  onAskHotkeyChange: (accelerator: string | undefined) => Promise<string | undefined>;
+  /**
+   * Whether a recording control has the keyboard. While one does, neither Luke
+   * key may act on its own press: the chord arriving is an entry, not an ask.
    */
   onShortcutCapture: (capturing: boolean) => void;
 }
@@ -774,19 +783,25 @@ const SHORTCUT_HINT = "Hold ⌃, ⌥ or ⌘ — ⇧ may join — and press a let
  * chosen chord, and a row that showed the stored one would name a key that
  * answers nothing.
  */
-function ShortcutSection({
-  voiceHotkey,
-  voiceHotkeyHeld,
+function ShortcutRow({
+  title,
+  detail,
+  shown,
   chosen,
-  onVoiceHotkeyChange,
-  onShortcutCapture,
+  defaultKey,
+  onChange,
+  onCapture,
 }: {
-  voiceHotkey?: string | undefined;
-  voiceHotkeyHeld: boolean;
+  title: string;
+  detail: string;
+  /** The key as registered, already labelled, absent when none answered. */
+  shown?: string | undefined;
   /** Whether a chosen chord is stored, which is what Reset has to undo. */
   chosen: boolean;
-  onVoiceHotkeyChange: (accelerator: string | undefined) => Promise<string | undefined>;
-  onShortcutCapture: (capturing: boolean) => void;
+  /** The first default, which is what the reset offers to return to. */
+  defaultKey: string;
+  onChange: (accelerator: string | undefined) => Promise<string | undefined>;
+  onCapture: (capturing: boolean) => void;
 }): React.JSX.Element {
   const [recording, setRecording] = useState(false);
   // The change is a round trip through the settings file and the system's
@@ -795,116 +810,158 @@ function ShortcutSection({
   const [busy, setBusy] = useState(false);
   const [rejection, setRejection] = useState<string>();
 
-  // The talk key stays registered while a chord is recorded — the recording
-  // ends by replacing it — so pressing the current chord mid-recording would
-  // open the microphone under the very field being typed into. The app is
-  // told when the field has the keyboard so it can hold that press, and the
-  // unmount arm covers the panel closing over an open recording.
+  // Both Luke keys stay registered while a chord is recorded — the recording
+  // ends by replacing one — so pressing a current chord mid-recording would
+  // open the microphone, or summon the composer, under the very field being
+  // typed into. The app is told when a field has the keyboard so it can hold
+  // that press, and the unmount arm covers the panel closing over an open
+  // recording.
   useEffect(() => {
-    onShortcutCapture(recording);
-    return () => onShortcutCapture(false);
-  }, [recording, onShortcutCapture]);
+    onCapture(recording);
+    return () => onCapture(false);
+  }, [recording, onCapture]);
 
   const apply = async (accelerator: string | undefined) => {
     setBusy(true);
-    setRejection(await onVoiceHotkeyChange(accelerator));
+    setRejection(await onChange(accelerator));
     setBusy(false);
   };
 
+  return (
+    <div className="settings-row">
+      <span className="settings-copy">
+        <strong>{title}</strong>
+        <small>{detail}</small>
+      </span>
+      <span className="shortcut-controls">
+        <span className="settings-actions">
+          <span className="shortcut-key" data-recording={String(recording)}>
+            {recording ? "Type a shortcut…" : (shown ?? "Unavailable")}
+          </span>
+          {chosen && !recording ? (
+            <button
+              type="button"
+              className="icon-button"
+              disabled={busy}
+              aria-label={`Reset the shortcut to ${voiceHotkeyLabel(defaultKey)}`}
+              title={`Back to ${voiceHotkeyLabel(defaultKey)}`}
+              onClick={() => void apply(undefined)}
+            >
+              <ResetIcon />
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className="icon-button"
+            disabled={busy}
+            aria-label={
+              recording
+                ? "Type the new shortcut, or press Escape to keep this one"
+                : `Change the shortcut for ${title}`
+            }
+            title={recording ? "Cancel" : "Change…"}
+            onClick={() => {
+              if (recording) {
+                setRecording(false);
+                return;
+              }
+              setRejection(undefined);
+              setRecording(true);
+            }}
+            onFocus={() => {
+              // The panel can be showing without its window being key, and a
+              // recording no keystroke can reach would read as a dead control.
+              window.sidecar.focusPanel();
+            }}
+            // Focus leaving takes the recording with it: whatever was pressed
+            // instead is its own act, not a half-formed chord left armed.
+            onBlur={() => setRecording(false)}
+            onKeyDown={(event) => {
+              // A key that repeats is being held through the chord, not
+              // pressed as one; only its first arrival is read.
+              if (!recording || event.repeat) return;
+              // Nothing typed here is typing: not a Space press on the button,
+              // and not the panel's own Escape-to-close behind it.
+              event.preventDefault();
+              event.stopPropagation();
+              if (event.key === "Escape") {
+                setRecording(false);
+                return;
+              }
+              const read = capturedVoiceHotkey(event);
+              if (read.outcome === VOICE_HOTKEY_CAPTURE.PENDING) return;
+              if (read.outcome === VOICE_HOTKEY_CAPTURE.REFUSED) {
+                setRejection(SHORTCUT_HINT);
+                return;
+              }
+              setRejection(undefined);
+              setRecording(false);
+              void apply(read.accelerator);
+            }}
+          >
+            {recording ? <CloseIcon /> : <PencilIcon />}
+          </button>
+        </span>
+        {rejection ? (
+          <p className="error-message">{rejection}</p>
+        ) : recording ? (
+          <p className="shortcut-hint">{SHORTCUT_HINT}</p>
+        ) : null}
+      </span>
+    </div>
+  );
+}
+
+function ShortcutSection({
+  voiceHotkey,
+  voiceHotkeyHeld,
+  chosen,
+  onVoiceHotkeyChange,
+  askHotkey,
+  askChosen,
+  onAskHotkeyChange,
+  onShortcutCapture,
+}: {
+  voiceHotkey?: string | undefined;
+  voiceHotkeyHeld: boolean;
+  chosen: boolean;
+  onVoiceHotkeyChange: (accelerator: string | undefined) => Promise<string | undefined>;
+  askHotkey?: string | undefined;
+  askChosen: boolean;
+  onAskHotkeyChange: (accelerator: string | undefined) => Promise<string | undefined>;
+  onShortcutCapture: (capturing: boolean) => void;
+}): React.JSX.Element {
   return (
     <section className="settings-section" style={{ "--row-index": 2 } as React.CSSProperties}>
       <h2>
         <KeyboardIcon />
         Keyboard shortcuts
       </h2>
-      <div className="settings-row">
-        <span className="settings-copy">
-          <strong>Talk to Luke</strong>
-          {/* What the key actually does, which depends on whether it can
-              report being let go of. Describing a hold to someone whose key
-              can only toggle would leave them holding it and wondering. */}
-          <small>
-            {voiceHotkeyHeld
-              ? "Hold to talk, let go to send. Tap instead to keep it open."
-              : "Press to talk, again to send, again to interrupt."}
-          </small>
-        </span>
-        <span className="shortcut-controls">
-          <span className="settings-actions">
-            <span className="shortcut-key" data-recording={String(recording)}>
-              {recording ? "Type a shortcut…" : (voiceHotkey ?? "Unavailable")}
-            </span>
-            {chosen && !recording ? (
-              <button
-                type="button"
-                className="icon-button"
-                disabled={busy}
-                aria-label={`Reset the shortcut to ${voiceHotkeyLabel(DEFAULT_VOICE_HOTKEYS[0] ?? "")}`}
-                title={`Back to ${voiceHotkeyLabel(DEFAULT_VOICE_HOTKEYS[0] ?? "")}`}
-                onClick={() => void apply(undefined)}
-              >
-                <ResetIcon />
-              </button>
-            ) : null}
-            <button
-              type="button"
-              className="icon-button"
-              disabled={busy}
-              aria-label={
-                recording
-                  ? "Type the new shortcut, or press Escape to keep this one"
-                  : "Change the shortcut for talking to Luke"
-              }
-              title={recording ? "Cancel" : "Change…"}
-              onClick={() => {
-                if (recording) {
-                  setRecording(false);
-                  return;
-                }
-                setRejection(undefined);
-                setRecording(true);
-              }}
-              onFocus={() => {
-                // The panel can be showing without its window being key, and a
-                // recording no keystroke can reach would read as a dead control.
-                window.sidecar.focusPanel();
-              }}
-              // Focus leaving takes the recording with it: whatever was pressed
-              // instead is its own act, not a half-formed chord left armed.
-              onBlur={() => setRecording(false)}
-              onKeyDown={(event) => {
-                // A key that repeats is being held through the chord, not
-                // pressed as one; only its first arrival is read.
-                if (!recording || event.repeat) return;
-                // Nothing typed here is typing: not a Space press on the button,
-                // and not the panel's own Escape-to-close behind it.
-                event.preventDefault();
-                event.stopPropagation();
-                if (event.key === "Escape") {
-                  setRecording(false);
-                  return;
-                }
-                const read = capturedVoiceHotkey(event);
-                if (read.outcome === VOICE_HOTKEY_CAPTURE.PENDING) return;
-                if (read.outcome === VOICE_HOTKEY_CAPTURE.REFUSED) {
-                  setRejection(SHORTCUT_HINT);
-                  return;
-                }
-                setRejection(undefined);
-                setRecording(false);
-                void apply(read.accelerator);
-              }}
-            >
-              {recording ? <CloseIcon /> : <PencilIcon />}
-            </button>
-          </span>
-          {rejection ? (
-            <p className="error-message">{rejection}</p>
-          ) : recording ? (
-            <p className="shortcut-hint">{SHORTCUT_HINT}</p>
-          ) : null}
-        </span>
-      </div>
+      <ShortcutRow
+        title="Talk to Luke"
+        // What the key actually does, which depends on whether it can report
+        // being let go of. Describing a hold to someone whose key can only
+        // toggle would leave them holding it and wondering.
+        detail={
+          voiceHotkeyHeld
+            ? "Hold to talk, let go to send. Tap instead to keep it open."
+            : "Press to talk, again to send, again to interrupt."
+        }
+        {...(voiceHotkey ? { shown: voiceHotkey } : {})}
+        chosen={chosen}
+        defaultKey={DEFAULT_VOICE_HOTKEYS[0] ?? ""}
+        onChange={onVoiceHotkeyChange}
+        onCapture={onShortcutCapture}
+      />
+      <ShortcutRow
+        title="Ask Luke"
+        detail="Press to type to Luke from any app. The same key puts it away."
+        {...(askHotkey ? { shown: askHotkey } : {})}
+        chosen={askChosen}
+        defaultKey={DEFAULT_ASK_HOTKEYS[0] ?? ""}
+        onChange={onAskHotkeyChange}
+        onCapture={onShortcutCapture}
+      />
     </section>
   );
 }
@@ -928,6 +985,8 @@ export function SettingsPanel({
   voiceHotkey,
   voiceHotkeyHeld,
   onVoiceHotkeyChange,
+  askHotkey,
+  onAskHotkeyChange,
   onShortcutCapture,
 }: SettingsPanelProps): React.JSX.Element {
   const microphone = microphoneAccessRow({ voiceAvailable, status: microphoneStatus });
@@ -960,6 +1019,9 @@ export function SettingsPanel({
         voiceHotkeyHeld={voiceHotkeyHeld}
         chosen={settings?.voiceHotkey !== undefined}
         onVoiceHotkeyChange={onVoiceHotkeyChange}
+        {...(askHotkey ? { askHotkey } : {})}
+        askChosen={settings?.askHotkey !== undefined}
+        onAskHotkeyChange={onAskHotkeyChange}
         onShortcutCapture={onShortcutCapture}
       />
 

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -33,6 +33,7 @@ const SETTINGS_FILE_MODE = 0o600;
 
 const SETTINGS_FIELD = {
   API_KEYS: "apiKeys",
+  ASK_HOTKEY: "askHotkey",
   DUCK_OTHER_MEDIA: "duckOtherMedia",
   LEGACY_CONDUCTOR_API_KEY: "conductorApiKey",
   SHOW_IN_DOCK: "showInDock",
@@ -116,6 +117,12 @@ interface PersistedSettings {
    * honouring it would claim a system key nothing was ever told about.
    */
   voiceHotkey?: string;
+  /**
+   * The ask-key chord the user chose, held to everything the talk key's is:
+   * stored plainly, absent while the defaults stand, and dropped rather than
+   * carried when this build cannot register it.
+   */
+  askHotkey?: string;
   /**
    * Whether Music and Spotify are turned down while a spoken exchange is
    * live. On unless the file says `false` outright — like the menu bar item,
@@ -202,6 +209,9 @@ function parsePersistedSettings(source: string): PersistedSettings {
   // Read through the same gate a submitted chord passes, so a hand-edited
   // value is either the one spelling the rest of the app uses or nothing.
   const voiceHotkey = typeof storedHotkey === "string" ? parseVoiceHotkey(storedHotkey) : undefined;
+  const storedAskHotkey = record[SETTINGS_FIELD.ASK_HOTKEY];
+  const askHotkey =
+    typeof storedAskHotkey === "string" ? parseVoiceHotkey(storedAskHotkey) : undefined;
   return {
     version: typeof version === "number" ? version : SETTINGS_FILE_VERSION,
     apiKeys: storedApiKeys(record),
@@ -215,6 +225,7 @@ function parsePersistedSettings(source: string): PersistedSettings {
     ...(isRealtimeVoiceSpeed(voiceSpeed) ? { voiceSpeed } : {}),
     voiceCaptions: record[SETTINGS_FIELD.VOICE_CAPTIONS] === true,
     ...(voiceHotkey ? { voiceHotkey } : {}),
+    ...(askHotkey ? { askHotkey } : {}),
     duckOtherMedia: record[SETTINGS_FIELD.DUCK_OTHER_MEDIA] !== false,
   };
 }
@@ -272,6 +283,7 @@ export class SettingsStore {
       ...((await this.#load()).voiceHotkey
         ? { voiceHotkey: (await this.#load()).voiceHotkey }
         : {}),
+      ...((await this.#load()).askHotkey ? { askHotkey: (await this.#load()).askHotkey } : {}),
       duckOtherMedia: (await this.#load()).duckOtherMedia,
     };
   }
@@ -400,6 +412,35 @@ export class SettingsStore {
       };
       if (accelerator) next.voiceHotkey = accelerator;
       else delete next.voiceHotkey;
+      await this.#write(next);
+      this.#loading = Promise.resolve(next);
+    });
+    return { settings: await this.snapshot() };
+  }
+
+  /**
+   * Main-process only, like the talk key's: the ask-key chord the user chose,
+   * for registration at startup, or nothing while the defaults stand.
+   */
+  async readAskHotkey(): Promise<string | undefined> {
+    return (await this.#load()).askHotkey;
+  }
+
+  /**
+   * Stores the chosen ask-key chord, or returns to the defaults when omitted,
+   * on the talk key's exact terms: the chord arrives already read into its one
+   * canonical spelling, and resetting is the absence of a choice.
+   */
+  async setAskHotkey(accelerator: string | undefined): Promise<SettingsUpdateResult> {
+    await this.#serialize(async () => {
+      const persisted = await this.#load();
+      if (persisted.askHotkey === accelerator) return;
+      const next: PersistedSettings = {
+        ...persisted,
+        version: SETTINGS_FILE_VERSION,
+      };
+      if (accelerator) next.askHotkey = accelerator;
+      else delete next.askHotkey;
       await this.#write(next);
       this.#loading = Promise.resolve(next);
     });

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -258,8 +258,9 @@ export interface AppBridge {
   setVoiceHotkey(accelerator: string | undefined): Promise<SettingsUpdateResult>;
   /**
    * Moves the ask key the same way, or back to its defaults when omitted. The
-   * one extra rule is the standing one: a chord the talk key holds is refused
-   * with a reason rather than stored and silently outbid.
+   * one extra rule is the standing one: a chord the talk key holds — or could
+   * fall back to on a later launch — is refused with a reason rather than
+   * stored and left to race it.
    */
   setAskHotkey(accelerator: string | undefined): Promise<SettingsUpdateResult>;
   /**

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -93,6 +93,12 @@ export interface AppSettings {
    */
   voiceHotkey?: string;
   /**
+   * The ask-key chord the user chose, absent while the defaults stand. The
+   * stored choice on the talk key's exact terms: the registered key is what
+   * the row shows, and this only says whether there is a choice to reset.
+   */
+  askHotkey?: string;
+  /**
    * Whether Music and Spotify are turned down while a spoken exchange is
    * live, and back up after. On by default: speech over music is the failure
    * everyone has had, and the duck defers to the user everywhere it can — it
@@ -251,6 +257,12 @@ export interface AppBridge {
    */
   setVoiceHotkey(accelerator: string | undefined): Promise<SettingsUpdateResult>;
   /**
+   * Moves the ask key the same way, or back to its defaults when omitted. The
+   * one extra rule is the standing one: a chord the talk key holds is refused
+   * with a reason rather than stored and silently outbid.
+   */
+  setAskHotkey(accelerator: string | undefined): Promise<SettingsUpdateResult>;
+  /**
    * Opens an observed session where its provider keeps it. The renderer names
    * the session rather than its address, for the same reason it names a
    * provider above: the places Luke can send you are the sessions it is already
@@ -321,6 +333,7 @@ export const channels = {
   setVoiceSpeed: "app:set-voice-speed",
   setVoiceCaptions: "app:set-voice-captions",
   setVoiceHotkey: "app:set-voice-hotkey",
+  setAskHotkey: "app:set-ask-hotkey",
   setDuckOtherMedia: "app:set-duck-other-media",
   setVoiceExchange: "app:set-voice-exchange",
   openProviderApiKeys: "app:open-provider-api-keys",

--- a/apps/desktop/src/shared/voice-hotkey.ts
+++ b/apps/desktop/src/shared/voice-hotkey.ts
@@ -30,14 +30,21 @@ export const DEFAULT_VOICE_HOTKEYS: readonly string[] = ["Alt+Space", "Alt+S"];
 export const DEFAULT_ASK_HOTKEYS: readonly string[] = ["Alt+L", "Alt+Shift+L"];
 
 /**
- * The ask chords worth asking the system for, with any the talk key holds
- * left out. The talk key is configurable now, so a user can move it onto an
- * ask default — and the two Luke keys must never compete for one chord:
- * whichever registered first would silently cost the other its whole feature,
- * with nothing on screen saying why.
+ * The ask chords worth asking the system for, in order. A chosen chord goes
+ * first — it is what the user asked for — with the defaults kept behind it,
+ * exactly as the talk key's candidates work. Any chord the talk key holds is
+ * left out, the chosen one included: the two Luke keys must never compete for
+ * one chord — whichever registered first would silently cost the other its
+ * whole feature, with nothing on screen saying why.
  */
-export function askHotkeyCandidates(taken: readonly (string | undefined)[]): readonly string[] {
-  return DEFAULT_ASK_HOTKEYS.filter((candidate) => !taken.includes(candidate));
+export function askHotkeyCandidates(
+  chosen: string | undefined,
+  taken: readonly (string | undefined)[],
+): readonly string[] {
+  const candidates = chosen
+    ? [chosen, ...DEFAULT_ASK_HOTKEYS.filter((candidate) => candidate !== chosen)]
+    : DEFAULT_ASK_HOTKEYS;
+  return candidates.filter((candidate) => !taken.includes(candidate));
 }
 
 /**

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -42,6 +42,7 @@ function guideInput(overrides: Partial<LukeGuideInput> = {}): LukeGuideInput {
     voiceAvailable: true,
     microphoneStatus: "granted",
     hotkey: { hotkey: "⌥Space", held: true },
+    askKey: "⌥L",
     ...overrides,
   };
 }
@@ -119,6 +120,15 @@ test("the facts follow the talk key, the microphone, and the storage the system 
     buildLukeGuide(guideInput({ hotkey: { held: false } })).facts,
   );
   assert.match(unregistered, /None is registered/);
+
+  // The ask key is a fact on the talk key's terms: the registered chord when
+  // there is one, and an honest absence when there is not.
+  assert.match(held, /⌥L, from any app: summons the panel/);
+  const askless = buildLukeGuide(guideInput({ askKey: undefined })).facts.find(
+    (fact) => fact.label === "Ask key",
+  );
+  assert.ok(askless);
+  assert.match(askless.detail, /None is registered/);
 
   const denied = JSON.stringify(buildLukeGuide(guideInput({ microphoneStatus: "denied" })).facts);
   assert.match(denied, /Privacy & Security/);

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -865,6 +865,63 @@ test("ignores a stored talk-key chord this build cannot register", async (t) => 
   assert.equal((await store.snapshot()).voiceHotkey, undefined);
 });
 
+test("stores the chosen ask-key chord on the talk key's terms and reads it back", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const cipher = countingCipher();
+  const store = storeIn(directory, { cipher });
+
+  assert.equal(await store.readAskHotkey(), undefined);
+  assert.equal((await store.snapshot()).askHotkey, undefined);
+
+  const { settings, reason } = await store.setAskHotkey("Control+Alt+K");
+
+  assert.equal(reason, undefined);
+  assert.equal(settings.askHotkey, "Control+Alt+K");
+  // A preference is not a credential, so choosing one never reaches the
+  // Keychain — and never raises its permission dialog.
+  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
+  assert.equal(await storeIn(directory).readAskHotkey(), "Control+Alt+K");
+});
+
+test("clearing the ask-key chord returns to no choice at all", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+
+  await store.setAskHotkey("Control+Alt+K");
+  const { settings } = await store.setAskHotkey(undefined);
+
+  assert.equal(settings.askHotkey, undefined);
+  // Absent from the file rather than stored as an empty value: reset is the
+  // absence of a choice, and a reopened store must read it the same way.
+  assert.equal(await storeIn(directory).readAskHotkey(), undefined);
+});
+
+test("ignores a stored ask-key chord this build cannot register", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({ version: 2, apiKeys: {}, askHotkey: "F13" }),
+  );
+  const store = storeIn(directory);
+
+  // A hand-edited chord the registrar would refuse is dropped rather than
+  // carried: honouring it would claim a key nothing was ever told about.
+  assert.equal(await store.readAskHotkey(), undefined);
+  assert.equal((await store.snapshot()).askHotkey, undefined);
+});
+
+test("the two Luke keys survive each other's writes", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+
+  await store.setVoiceHotkey("Control+Alt+Space");
+  await store.setAskHotkey("Control+Alt+K");
+
+  const reopened = storeIn(directory);
+  assert.equal(await reopened.readVoiceHotkey(), "Control+Alt+Space");
+  assert.equal(await reopened.readAskHotkey(), "Control+Alt+K");
+});
+
 test("the talk-key chord and a stored key survive each other's writes", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);

--- a/apps/desktop/tests/voice-hotkey.test.ts
+++ b/apps/desktop/tests/voice-hotkey.test.ts
@@ -66,6 +66,13 @@ test("a chosen ask chord goes first, with the defaults kept behind it", () => {
     askHotkeyCandidates("Control+Alt+K", ["Control+Alt+K", undefined]),
     DEFAULT_ASK_HOTKEYS,
   );
+  // The registrar hands in the talk key's whole candidate list, so a chosen
+  // chord on a talk-key default is filtered even before the helper has said
+  // which of them it actually sits on.
+  assert.deepEqual(
+    askHotkeyCandidates("Alt+S", [...DEFAULT_VOICE_HOTKEYS, undefined]),
+    DEFAULT_ASK_HOTKEYS,
+  );
 });
 
 test("a missing ask key reports on the talk key's terms", () => {

--- a/apps/desktop/tests/voice-hotkey.test.ts
+++ b/apps/desktop/tests/voice-hotkey.test.ts
@@ -43,10 +43,29 @@ test("the ask key is the talk key's sibling, never its rival", () => {
 test("an ask candidate the talk key holds is not asked for", () => {
   // The talk key is configurable, so it can be moved onto an ask default; the
   // chord it holds simply stops being a candidate rather than being fought over.
-  assert.deepEqual(askHotkeyCandidates([undefined, undefined]), DEFAULT_ASK_HOTKEYS);
-  assert.deepEqual(askHotkeyCandidates(["Alt+L", undefined]), ["Alt+Shift+L"]);
+  assert.deepEqual(askHotkeyCandidates(undefined, [undefined, undefined]), DEFAULT_ASK_HOTKEYS);
+  assert.deepEqual(askHotkeyCandidates(undefined, ["Alt+L", undefined]), ["Alt+Shift+L"]);
   // The talk key's own defaults hold nothing the ask key wants.
-  assert.deepEqual(askHotkeyCandidates(["Alt+Space", "Alt+S"]), DEFAULT_ASK_HOTKEYS);
+  assert.deepEqual(askHotkeyCandidates(undefined, ["Alt+Space", "Alt+S"]), DEFAULT_ASK_HOTKEYS);
+});
+
+test("a chosen ask chord goes first, with the defaults kept behind it", () => {
+  // Like the talk key's candidates: a chord another app claims while Luke is
+  // closed costs the user a different ask key rather than none.
+  assert.deepEqual(askHotkeyCandidates("Control+Alt+K", [undefined, undefined]), [
+    "Control+Alt+K",
+    ...DEFAULT_ASK_HOTKEYS,
+  ]);
+  // A chosen chord that is itself a default is not offered twice.
+  assert.deepEqual(askHotkeyCandidates("Alt+Shift+L", [undefined, undefined]), [
+    "Alt+Shift+L",
+    "Alt+L",
+  ]);
+  // The talk key outranks even a chosen chord: two Luke keys never compete.
+  assert.deepEqual(
+    askHotkeyCandidates("Control+Alt+K", ["Control+Alt+K", undefined]),
+    DEFAULT_ASK_HOTKEYS,
+  );
 });
 
 test("a missing ask key reports on the talk key's terms", () => {


### PR DESCRIPTION
## What

The ask key — ⌥L, which summons the typed **Ask Luke** composer from any app — was a hardcoded default, while the talk key beside it was already the user's to move. This PR gives the ask key the talk key's whole treatment, so both Luke keys are visible and editable in the settings page.

- **A second row under Keyboard shortcuts** shows the ask key as registered, records a replacement with the same capture control the talk key uses, and offers a reset back to ⌥L once a chord is stored. The row logic is factored into one `ShortcutRow` both keys render.
- **The chosen chord persists** in `settings.json` (`askHotkey`), read back through the same `parseVoiceHotkey` gate as the talk key so a hand-edited unregisterable value is dropped rather than honoured.
- **Registration honours the choice**: the chosen chord is tried first with the defaults kept behind it, and a change is applied at once by releasing only the ask key's own chord — the talk key's registration never flickers for it.
- **The two Luke keys still never compete**: a chord the talk key holds (chosen or registered) is refused with a reason in the row rather than stored and silently outbid, and the candidate filter keeps ranking the talk key above even a chosen ask chord.
- **The guide learns an ask-key fact** on the talk key's terms — Luke can now say what the key is and where to change it, and `SETTING_GUIDE` records the deliberate decision that the chord is hand-recorded, never spoken.
- **A recording holds the live keys**: pressing the current ask chord mid-recording no longer summons the composer under the field being typed into, the same way the talk key's press was already held.

## How it was verified

- `./scripts/check.sh` passes: Biome, typecheck, 491 tests (17 new: candidate ordering, store persistence/reset/invalid-value, guide facts), and the build.
- `./scripts/verify.sh` runs in CI on macOS; visual evidence is linked from this description by the workflow.
- No physical-notch check was performed (developed in a cloud sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a1b02864-1147-43ea-824c-5e1eea77496a)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31815232538/artifacts/9224746998) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31815232538)

- Commit: `0c67c25e91bd40118ed290914befd8ece741cde3`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
