### PR TITLE
fix(brand): put Luke's face back on the Dock tile after every show

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1359,11 +1359,13 @@ const DOCK_ICON_FILES = {
 } as const;
 
 /**
- * Draws Luke's own face in the Dock, matched to the theme. Called once at
- * startup and again whenever the theme changes; macOS remembers the image
- * across `dock.hide()`, so this never needs to wait for the icon to be shown.
- * Artwork missing from a build draws nothing, leaving the bundle icon (or the
- * stock one) in place rather than an empty tile.
+ * Draws Luke's own face in the Dock, matched to the theme. Called at startup,
+ * on every theme change, and after every `dock.show()` — showing the icon
+ * transforms the process, and macOS draws the fresh tile from the bundle's
+ * icon (in a dev run, Electron's stock one), forgetting any image set while
+ * there was no tile to wear it. Artwork missing from a build draws nothing,
+ * leaving the bundle icon (or the stock one) in place rather than an empty
+ * tile.
  */
 function applyDockIcon(): void {
   if (!app.dock) return;
@@ -1405,8 +1407,14 @@ async function settleDock(): Promise<void> {
   dockSettling = true;
   try {
     while (app.dock.isVisible() !== dockDesired) {
-      if (dockDesired) await app.dock.show();
-      else app.dock.hide();
+      if (dockDesired) {
+        await app.dock.show();
+        // The show rebuilt the tile from the bundle icon; put Luke's face
+        // back on it.
+        applyDockIcon();
+      } else {
+        app.dock.hide();
+      }
       // Either direction transforms the process type, which can deactivate
       // the app; the panel the switch was pressed in is brought back forward
       // rather than left to lose its caret.


### PR DESCRIPTION
## Summary

- #82 gave the Dock Luke's own icon, but a `./scripts/run.sh` dev run still showed Electron's stock icon. The bug is ordering, not artwork or paths: `applyDockIcon()` runs at `whenReady`, while the app is still an accessory with no Dock tile, and the opt-in `dock.show()` only comes later — Electron's `DockShow` calls `TransformProcessType(kProcessTransformToForegroundApplication)` and macOS draws the fresh tile from the *bundle's* icon, forgetting the image set while there was no tile to wear it. In a dev run the bundle is Electron's, so the stock icon wins; in a packaged run the same bug quietly pins the dark `.icns` on a light desktop until the next theme change.
- `settleDock()` now re-applies the icon after every `app.dock.show()`, so the tile Luke just stepped onto wears his face. The startup call and the `nativeTheme` listener stay: they cover a tile that is already visible when the theme turns.
- The `applyDockIcon()` doc comment claimed macOS remembers the image across `dock.hide()`; it now states the real constraint.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passes — repository contract checks, typecheck, all test suites, and builds.
- macOS validation: relying on CI's `./scripts/verify.sh` run and the automated visual evidence below.
- Root cause verified against Electron's `shell/browser/browser_mac.mm`: `DockShow` transforms the process type and never re-applies a previously set application icon image.

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed` — the change is Dock-tile timing in the main process and touches no notch or panel UI; worth eyeballing live by enabling "Show in Dock" after a `./scripts/run.sh`
- Device/display configuration: `not recorded`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/e8355d52-4798-4820-9194-fc7cab0dca8d)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31814883574/artifacts/9224625348) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31814883574)

- Commit: `d003862941a584538b02bca84ae3cc0db1199f48`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
