### PR TITLE
feat(settings): draw Linear apart in an Integrations section

### DIFF
--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -32,9 +32,17 @@ import {
   REALTIME_VOICE_SPEED,
   type RealtimeVoiceSpeed,
 } from "@sidecar/core";
-import type { AppBridge, AppSettings, MicrophoneStatus } from "../shared/contracts";
+import type {
+  AppBridge,
+  AppSettings,
+  CredentialSource,
+  MicrophoneStatus,
+} from "../shared/contracts";
 import { CREDENTIAL_SOURCE, SECRET_STORAGE } from "../shared/contracts";
-import { CREDENTIAL_PROVIDER_LIST } from "../shared/credential-providers";
+import {
+  CLOUD_AGENT_PROVIDER_LIST,
+  INTEGRATION_PROVIDER_LIST,
+} from "../shared/credential-providers";
 
 /** The ids a spoken change names Luke's settings by. */
 export const APP_SETTING_ID = {
@@ -232,23 +240,40 @@ const MICROPHONE_DETAIL: Record<MicrophoneStatus, string> = {
   unknown: "Unknown. The Settings tab's Permissions section shows its state.",
 };
 
+/** The same three answers a credential row gives, in words a fact can carry. */
+function connectionWord(source: CredentialSource): string {
+  return source === CREDENTIAL_SOURCE.NONE
+    ? "not connected"
+    : source === CREDENTIAL_SOURCE.ENVIRONMENT
+      ? "connected from the environment"
+      : "connected";
+}
+
 function providersFact(settings: AppSettings): AppGuideFact {
-  const roster = CREDENTIAL_PROVIDER_LIST.map((provider) => {
-    const source = settings.credentialSources[provider.id];
-    const connected =
-      source === CREDENTIAL_SOURCE.NONE
-        ? "not connected"
-        : source === CREDENTIAL_SOURCE.ENVIRONMENT
-          ? "connected from the environment"
-          : "connected";
-    return `${provider.displayName} (${connected})`;
-  });
+  const roster = CLOUD_AGENT_PROVIDER_LIST.map(
+    (provider) =>
+      `${provider.displayName} (${connectionWord(settings.credentialSources[provider.id])})`,
+  );
   return {
     label: "Cloud providers",
     detail:
       `${roster.join(", ")}. Connecting one takes its API key, typed by hand into ${SETTINGS_TAB} ` +
-      "on the provider's row — never spoken, and never repeated back. Local providers such as " +
-      "Claude Code need no key and are observed on their own.",
+      "under Cloud Agent API keys — never spoken, and never repeated back. Local providers such " +
+      "as Claude Code need no key and are observed on their own.",
+  };
+}
+
+function integrationsFact(settings: AppSettings): AppGuideFact {
+  const roster = INTEGRATION_PROVIDER_LIST.map(
+    (provider) =>
+      `${provider.displayName} (${connectionWord(settings.credentialSources[provider.id])})`,
+  );
+  return {
+    label: "Integrations",
+    detail:
+      `${roster.join(", ")}. Connecting Linear lets Luke read the developer's issues and, only ` +
+      `when asked in a turn the developer opened, move or comment on one. Its key is typed by ` +
+      `hand into ${SETTINGS_TAB} under Integrations — never spoken, and never repeated back.`,
   };
 }
 
@@ -273,8 +298,8 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "Two tabs. Sessions lists every observed session with its state, narrowable to all, local, " +
         "cloud, or one provider, and orderable by urgency (what needs the developer first) or " +
         "recency (what moved last first); a row can be opened, messaged, or controlled where its " +
-        "provider allows. Settings holds the preferences, the talk and ask keys, the cloud API " +
-        "keys, permissions, and Quit.",
+        "provider allows. Settings holds the preferences, the talk and ask keys, the cloud " +
+        "agent API keys, the integrations, permissions, and Quit.",
     },
     talkKeyFact(input.hotkey),
     askKeyFact(input.askKey),
@@ -289,6 +314,7 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
           },
         ]),
     providersFact(input.settings),
+    integrationsFact(input.settings),
     ...(input.settings.secretStorage === SECRET_STORAGE.UNAVAILABLE
       ? [
           {

--- a/apps/desktop/src/renderer/settings-icons.tsx
+++ b/apps/desktop/src/renderer/settings-icons.tsx
@@ -100,6 +100,18 @@ export function PopUpIcon(): React.JSX.Element {
   );
 }
 
+/** A plug: the services Luke connects to beyond the agents themselves. */
+export function PlugIcon(): React.JSX.Element {
+  return (
+    <Glyph>
+      <path d="M9 2.6v5.2" />
+      <path d="M15 2.6v5.2" />
+      <path d="M6 7.8h12v4.4a4.4 4.4 0 0 1-4.4 4.4h-3.2A4.4 4.4 0 0 1 6 12.2Z" />
+      <path d="M12 16.6v4.8" />
+    </Glyph>
+  );
+}
+
 export function KeyboardIcon(): React.JSX.Element {
   return (
     <Glyph>

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -521,6 +521,11 @@ function formFactorOptionLabel(formFactor: PanelFormFactor): string {
   return formFactor === DEFAULT_PANEL_FORM_FACTOR ? `${name} (default)` : name;
 }
 
+/* Why every Connect in a key-holding section is refusing, said once per
+   section: a disabled control with no words beside it reads as broken. */
+const STORAGE_UNAVAILABLE_NOTE =
+  "This system offers no encrypted credential storage, so Luke will not store a key here.";
+
 /**
  * Every agent provider that can hold a key, one line each. A provider is
  * listed whether or not it has one, because the list is how you learn which
@@ -558,7 +563,7 @@ function CredentialsSection({
       {/* True of every key here, so it is said once rather than per provider. */}
       <p className="settings-note">
         {storageUnavailable
-          ? "This system offers no encrypted credential storage, so Luke will not store a key here."
+          ? STORAGE_UNAVAILABLE_NOTE
           : "Luke reads only cloud workspaces you created, and never sends a prompt or any other change."}
       </p>
     </section>
@@ -597,6 +602,9 @@ function IntegrationsSection({
           panelOpen={panelOpen}
         />
       ))}
+      {/* The same refusal the agents' section explains: a Connect stilled by
+          missing storage needs its why in this section too. */}
+      {storageUnavailable ? <p className="settings-note">{STORAGE_UNAVAILABLE_NOTE}</p> : null}
     </section>
   );
 }

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -15,7 +15,10 @@ import { useEffect, useRef, useState } from "react";
 import type { AppSettings, CredentialSource, MicrophoneStatus } from "../shared/contracts";
 import { CREDENTIAL_SOURCE, SECRET_STORAGE } from "../shared/contracts";
 import type { CredentialProvider } from "../shared/credential-providers";
-import { CREDENTIAL_PROVIDER_LIST } from "../shared/credential-providers";
+import {
+  CLOUD_AGENT_PROVIDER_LIST,
+  INTEGRATION_PROVIDER_LIST,
+} from "../shared/credential-providers";
 import {
   capturedVoiceHotkey,
   DEFAULT_ASK_HOTKEYS,
@@ -48,6 +51,7 @@ import {
   KeyboardIcon,
   KeyIcon,
   PencilIcon,
+  PlugIcon,
   PopUpIcon,
   PowerIcon,
   PreferencesIcon,
@@ -410,6 +414,10 @@ function ProviderCredential({
         </span>
       </div>
 
+      {/* What connecting this one buys, for a provider whose section cannot
+          say it once for every row. */}
+      {provider.description ? <p className="settings-note">{provider.description}</p> : null}
+
       {entry ? (
         /* Named as a group, because Cancel, Save, and the link to the
            provider's own page are the same three words on every row. */
@@ -514,9 +522,9 @@ function formFactorOptionLabel(formFactor: PanelFormFactor): string {
 }
 
 /**
- * Every provider that can hold a key, one line each. A provider is listed
- * whether or not it has one, because the list is how you learn which services
- * Luke can watch at all.
+ * Every agent provider that can hold a key, one line each. A provider is
+ * listed whether or not it has one, because the list is how you learn which
+ * services Luke can watch at all.
  */
 function CredentialsSection({
   settings,
@@ -535,9 +543,9 @@ function CredentialsSection({
     <section className="settings-section" style={{ "--row-index": 3 } as React.CSSProperties}>
       <h2>
         <KeyIcon />
-        Cloud API keys
+        Cloud Agent API keys
       </h2>
-      {CREDENTIAL_PROVIDER_LIST.map((provider) => (
+      {CLOUD_AGENT_PROVIDER_LIST.map((provider) => (
         <ProviderCredential
           key={provider.id}
           provider={provider}
@@ -553,6 +561,42 @@ function CredentialsSection({
           ? "This system offers no encrypted credential storage, so Luke will not store a key here."
           : "Luke reads only cloud workspaces you created, and never sends a prompt or any other change."}
       </p>
+    </section>
+  );
+}
+
+/**
+ * The services Luke connects to that are not agents: today, the issue tracker.
+ * Each row is the same credential line an agent provider gets — same entry,
+ * same trash, same environment fallback — with its own one-line answer to what
+ * connecting it buys, because the rows here do not all buy the same thing.
+ */
+function IntegrationsSection({
+  settings,
+  control,
+  panelOpen,
+}: {
+  settings: AppSettings;
+  control: CredentialEntryControl;
+  panelOpen: boolean;
+}): React.JSX.Element {
+  const storageUnavailable = settings.secretStorage === SECRET_STORAGE.UNAVAILABLE;
+  return (
+    <section className="settings-section" style={{ "--row-index": 4 } as React.CSSProperties}>
+      <h2>
+        <PlugIcon />
+        Integrations
+      </h2>
+      {INTEGRATION_PROVIDER_LIST.map((provider) => (
+        <ProviderCredential
+          key={provider.id}
+          provider={provider}
+          source={settings.credentialSources[provider.id]}
+          storageUnavailable={storageUnavailable}
+          control={control}
+          panelOpen={panelOpen}
+        />
+      ))}
     </section>
   );
 }
@@ -1127,7 +1171,11 @@ export function SettingsPanel({
         <CredentialsSection settings={settings} control={credentials} panelOpen={panelOpen} />
       ) : null}
 
-      <section className="settings-section" style={{ "--row-index": 4 } as React.CSSProperties}>
+      {settings ? (
+        <IntegrationsSection settings={settings} control={credentials} panelOpen={panelOpen} />
+      ) : null}
+
+      <section className="settings-section" style={{ "--row-index": 5 } as React.CSSProperties}>
         <h2>
           <ShieldIcon />
           Permissions
@@ -1173,7 +1221,7 @@ export function SettingsPanel({
       <button
         type="button"
         className="quit-button"
-        style={{ "--row-index": 5 } as React.CSSProperties}
+        style={{ "--row-index": 6 } as React.CSSProperties}
         onClick={onQuit}
       >
         <PowerIcon />

--- a/apps/desktop/src/shared/credential-providers.ts
+++ b/apps/desktop/src/shared/credential-providers.ts
@@ -82,6 +82,12 @@ export interface CredentialProvider {
   environmentVariables: readonly string[];
   /** Present only for a provider that publishes more than one kind of key. */
   keyFormat?: CredentialFormat;
+  /**
+   * What connecting this service lets Luke do, said in one line under its row.
+   * Only an integration carries one: an agent provider's rows say it once for
+   * the whole section, because every key there buys the same observation.
+   */
+  description?: string;
 }
 
 /** Keyed by provider id so no caller has to build a key from an identifier. */
@@ -148,6 +154,7 @@ export const CREDENTIAL_PROVIDERS: Readonly<Record<CredentialProviderId, Credent
   [CREDENTIAL_PROVIDER_ID.LINEAR]: {
     id: CREDENTIAL_PROVIDER_ID.LINEAR,
     displayName: "Linear",
+    description: "Luke reads your issues and can move or comment on them when you ask.",
     hint: "Create a personal API key in Linear under Settings · Security & access.",
     apiKeysUrl: "https://linear.app/settings/account/security",
     environmentVariables: [LINEAR_ENVIRONMENT.API_KEY],
@@ -163,9 +170,22 @@ export const CREDENTIAL_PROVIDERS: Readonly<Record<CredentialProviderId, Credent
   },
 };
 
-/** Settings lists providers in this order. */
+/** Every provider that can hold a key, in the order Settings lists them. */
 export const CREDENTIAL_PROVIDER_LIST: readonly CredentialProvider[] =
   Object.values(CREDENTIAL_PROVIDERS);
+
+/* A key is a key, so the tracker lives in the one provider registry — but
+   Settings draws it apart: an issue tracker is an integration Luke reads and
+   acts on, not an agent whose sessions he observes. */
+const INTEGRATION_IDS: ReadonlySet<CredentialProviderId> = new Set([CREDENTIAL_PROVIDER_ID.LINEAR]);
+
+/** The coding-agent providers, in the order the Cloud Agent API keys section lists them. */
+export const CLOUD_AGENT_PROVIDER_LIST: readonly CredentialProvider[] =
+  CREDENTIAL_PROVIDER_LIST.filter((provider) => !INTEGRATION_IDS.has(provider.id));
+
+/** The services beyond the agents, in the order the Integrations section lists them. */
+export const INTEGRATION_PROVIDER_LIST: readonly CredentialProvider[] =
+  CREDENTIAL_PROVIDER_LIST.filter((provider) => INTEGRATION_IDS.has(provider.id));
 
 /**
  * Guards the provider id an IPC message carries. `hasOwn` rather than `in`: an

--- a/apps/desktop/tests/credential-providers.test.ts
+++ b/apps/desktop/tests/credential-providers.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  CLOUD_AGENT_PROVIDER_LIST,
   CREDENTIAL_PROVIDER_ID,
   CREDENTIAL_PROVIDER_LIST,
   CREDENTIAL_PROVIDERS,
+  INTEGRATION_PROVIDER_LIST,
   isCredentialProviderId,
 } from "../src/shared/credential-providers";
 
@@ -34,6 +36,26 @@ test("describes every provider it lists", () => {
     assert.ok(provider.keyFormat.prefix.length > 0, provider.id);
     assert.ok(provider.keyFormat.label.length > 0, provider.id);
     assert.ok(provider.keyFormat.rejection.includes(provider.keyFormat.prefix), provider.id);
+  }
+});
+
+test("splits the settings sections without losing a provider", () => {
+  // The two sections together are exactly the registry: a provider missing
+  // from both would hold a key no row can enter, and one in both would be
+  // asked for the same key twice.
+  assert.deepEqual(
+    [...CLOUD_AGENT_PROVIDER_LIST, ...INTEGRATION_PROVIDER_LIST]
+      .map((provider) => provider.id)
+      .sort(),
+    CREDENTIAL_PROVIDER_LIST.map((provider) => provider.id).sort(),
+  );
+  assert.deepEqual(
+    INTEGRATION_PROVIDER_LIST.map((provider) => provider.id),
+    [CREDENTIAL_PROVIDER_ID.LINEAR],
+  );
+  // An integration's row carries its own answer to what connecting it buys.
+  for (const provider of INTEGRATION_PROVIDER_LIST) {
+    assert.ok(provider.description, `${provider.id} says what connecting it allows`);
   }
 });
 

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -26,6 +26,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
       [CREDENTIAL_PROVIDER_ID.CURSOR]: CREDENTIAL_SOURCE.NONE,
       [CREDENTIAL_PROVIDER_ID.DEVIN]: CREDENTIAL_SOURCE.ENVIRONMENT,
       [CREDENTIAL_PROVIDER_ID.JULES]: CREDENTIAL_SOURCE.NONE,
+      [CREDENTIAL_PROVIDER_ID.LINEAR]: CREDENTIAL_SOURCE.NONE,
     },
     secretStorage: SECRET_STORAGE.UNKNOWN,
     showInMenuBar: true,
@@ -130,6 +131,9 @@ test("the facts say what is connected, never what connects it", () => {
   assert.match(rendered, /Conductor \(connected\)/);
   assert.match(rendered, /Copilot \(not connected\)/);
   assert.match(rendered, /Devin \(connected from the environment\)/);
+  // The tracker stands in its own fact, the way it stands in its own section.
+  assert.match(rendered, /Linear \(not connected\)/);
+  assert.match(rendered, /Integrations/);
   // The guide leaves the machine, so no key, prefix, or environment variable
   // value has any business in it.
   assert.doesNotMatch(rendered, /API key:/);


### PR DESCRIPTION
## What

- **New Integrations section** in the Settings tab, under a plug icon, holding Linear's credential row — the same row it had before, with the same entry, trash, and environment fallback.
- **Cloud API keys → Cloud Agent API keys**: the section now holds only the agent providers (Conductor, Copilot, Cursor, Devin, Jules), and its name says what they have in common.
- **One-line description under Linear** of what connecting it allows: *"Luke reads your issues and can move or comment on them when you ask."*

## How

- The credential registry stays one list — a key is a key — and `credential-providers.ts` now derives the two section rosters (`CLOUD_AGENT_PROVIDER_LIST`, `INTEGRATION_PROVIDER_LIST`) from it. A new optional `description` field carries an integration's one-liner; agent providers keep their shared section note instead.
- `ProviderCredential` renders the description under the row when a provider carries one.
- The guide learns the layout in the same change: the panel fact names both sections, the cloud-providers fact drops the tracker, and a new Integrations fact says what connecting Linear allows and where its key is typed.
- Tests: a partition invariant (the two rosters together are exactly the registry, integrations carry descriptions), and guide-fact assertions for Linear.

## Verification

- `./scripts/check.sh` passes: 621 tests (33 + 101 sidecar-core + 487 desktop), 0 failures.
- UI change: relying on CI's `./scripts/verify.sh` on macOS for visual evidence (linked below by CI). No physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a96b396b-2de3-4ca8-8805-863a9828bb86)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31821207990/artifacts/9227034915) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31821207990)

- Commit: `7c617524d8fa0eae97fe00c4274e489e8f4b755e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
