### PR TITLE
feat(shortcuts): draw a chord as the separate keys it is

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -107,7 +107,6 @@ import {
   VOICE_HOTKEY_ABSENCE,
   type VoiceHotkeyAbsence,
   voiceHotkeyCandidates,
-  voiceHotkeyLabel,
   voiceHotkeyReport,
 } from "./shared/voice-hotkey";
 import { TalkKeyWatcher } from "./talk-key";
@@ -380,11 +379,16 @@ function applyAskHotkey(): void {
   sendAskHotkey();
 }
 
-/** Tells every renderer the key it should be showing, whenever that changes. */
+/**
+ * Tells every renderer the key it should be showing, whenever that changes.
+ * The accelerator rather than its label, on the ask key's terms: the renderer
+ * draws the chord as its separate keys and says it as one word, and only the
+ * accelerator produces both.
+ */
 function sendVoiceHotkey(): void {
   for (const window of panelWindows.values()) {
     window.webContents.send(channels.voiceHotkeyChanged, {
-      ...(voiceHotkey ? { hotkey: voiceHotkeyLabel(voiceHotkey) } : {}),
+      ...(voiceHotkey ? { hotkey: voiceHotkey } : {}),
       held: voiceHotkeyHeld,
     });
   }
@@ -887,11 +891,11 @@ function registerIpc(): void {
       nodeVersion: process.versions.node,
       microphoneStatus: microphoneStatus(),
       realtimeAvailable: realtimeCredentials !== undefined,
-      ...(voiceHotkey ? { voiceHotkey: voiceHotkeyLabel(voiceHotkey) } : {}),
+      // Both keys travel as accelerators rather than labels: the renderer needs
+      // both spellings — the keycaps' ⌥ and L drawn apart, and aria's Alt+L —
+      // and only the accelerator can produce the pair.
+      ...(voiceHotkey ? { voiceHotkey } : {}),
       voiceHotkeyHeld,
-      // The accelerator rather than its label: the renderer needs both
-      // spellings — the keycap's ⌥L and aria's Alt+L — and only the
-      // accelerator can produce the pair.
       ...(askHotkey ? { askHotkey } : {}),
       display: displayDiagnostic(display),
       sessions: fixtureMode ? [] : sessionRegistry.snapshot().sessions,

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1527,11 +1527,18 @@ export function App(): React.JSX.Element {
   useEffect(() => {
     if (!bootstrap) return;
     const askAccelerator = askHotkeyChange ? askHotkeyChange.accelerator : bootstrap.askHotkey;
+    // Both keys reach the guide labelled: it is spoken and read, so a chord
+    // belongs there as the one word macOS writes it as rather than as the keys
+    // the panel draws apart.
+    const talkKey = voiceHotkeyToShow(bootstrap, voiceHotkey);
     const guide = buildLukeGuide({
       settings: settings ?? bootstrap.settings,
       voiceAvailable: bootstrap.realtimeAvailable,
       microphoneStatus,
-      hotkey: voiceHotkeyToShow(bootstrap, voiceHotkey),
+      hotkey: {
+        ...(talkKey.hotkey ? { hotkey: voiceHotkeyLabel(talkKey.hotkey) } : {}),
+        held: talkKey.held,
+      },
       ...(askAccelerator ? { askKey: voiceHotkeyLabel(askAccelerator) } : {}),
     });
     guideRef.current = guide;
@@ -1782,10 +1789,9 @@ export function App(): React.JSX.Element {
               ...(shownHotkey.hotkey ? { voiceHotkey: shownHotkey.hotkey } : {}),
               voiceHotkeyHeld: shownHotkey.held,
               onVoiceHotkeyChange: changeVoiceHotkey,
-              // Labelled here because the ask key travels as an accelerator —
-              // the composer's keycap needs both spellings, but the row shows
-              // the key the way macOS writes it, as the talk key's row does.
-              ...(shownAskHotkey ? { askHotkey: voiceHotkeyLabel(shownAskHotkey) } : {}),
+              // Both rows take the accelerator: they draw the keys apart and
+              // label the chord whole for the buttons beside them.
+              ...(shownAskHotkey ? { askHotkey: shownAskHotkey } : {}),
               onAskHotkeyChange: changeAskHotkey,
               onShortcutCapture: changeShortcutCapture,
               onShowInMenuBarChange: changeShowInMenuBar,

--- a/apps/desktop/src/renderer/ask-luke.tsx
+++ b/apps/desktop/src/renderer/ask-luke.tsx
@@ -1,8 +1,8 @@
 import { REALTIME_STATUS, type RealtimeStatus } from "@sidecar/core";
 import { useCallback, useRef, useState } from "react";
 import type { MicrophoneStatus } from "../shared/contracts";
-import { voiceHotkeyLabel } from "../shared/voice-hotkey";
 import { FOCUS_FRAME_LIMIT } from "./credential-entry";
+import { Keycaps } from "./keycaps";
 import { SendIcon } from "./settings-icons";
 
 /**
@@ -195,13 +195,13 @@ export function AskLuke({
             }
           }}
         />
-        {/* How the reach is learned: the keycap surfaces under a hovering
-            pointer and stands down once the caret is in or a draft holds the
-            field — whoever it could teach already knows. Drawn only for a key
-            the system actually granted, in the label macOS writes it with.
-            Left readable: a reader announcing the keycap agrees with
+        {/* How the reach is learned: the keycaps surface under a hovering
+            pointer and stand down once the caret is in or a draft holds the
+            field — whoever they could teach already knows. Drawn only for a key
+            the system actually granted, as the separate keys a hand presses.
+            Left readable: a reader announcing the caps agrees with
             aria-keyshortcuts. */}
-        {shortcut ? <kbd className="ask-luke-hint">{voiceHotkeyLabel(shortcut)}</kbd> : null}
+        {shortcut ? <Keycaps className="ask-luke-hint" accelerator={shortcut} /> : null}
         <button
           type="submit"
           className="ask-luke-send"

--- a/apps/desktop/src/renderer/keycaps.tsx
+++ b/apps/desktop/src/renderer/keycaps.tsx
@@ -1,0 +1,34 @@
+/**
+ * A chord drawn as the keys it is: one cap per key, the way a keyboard has
+ * them and the way developer tools print them, rather than one chip holding
+ * ⌥Space as though it were a word.
+ *
+ * Nested `kbd` is the element's own idiom for a combination — the outer one is
+ * the chord, each inner one is a key — so a reader still announces the chord in
+ * one piece and the gaps between the caps are drawn rather than spelled.
+ */
+
+import type React from "react";
+import { voiceHotkeyKeycaps } from "../shared/voice-hotkey";
+
+export function Keycaps({
+  accelerator,
+  className,
+}: {
+  /** The chord as the system registered it, e.g. `Alt+Space`. */
+  accelerator: string;
+  /** What the surface around the caps calls them, if it needs to say. */
+  className?: string;
+}): React.JSX.Element {
+  return (
+    <kbd className={className ? `keycap-chord ${className}` : "keycap-chord"}>
+      {/* A chord holds each modifier once and ends in a key no modifier
+          spells, so the cap itself is the identity. */}
+      {voiceHotkeyKeycaps(accelerator).map((cap) => (
+        <kbd className="keycap" key={cap}>
+          {cap}
+        </kbd>
+      ))}
+    </kbd>
+  );
+}

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -192,9 +192,13 @@ export interface LukeGuideInput {
   /** Whether a Realtime credential can be minted at all. */
   voiceAvailable: boolean;
   microphoneStatus: MicrophoneStatus;
-  /** The talk key as the panel shows it, absent when none was registered. */
+  /**
+   * The talk key labelled the way macOS writes it, absent when none was
+   * registered. Labelled rather than drawn as keys: the guide is spoken and
+   * read, and a chord said aloud is one thing to press.
+   */
   hotkey: { hotkey?: string; held: boolean };
-  /** The ask key as the panel shows it, absent when none was registered. */
+  /** The ask key labelled on the same terms, absent when none was registered. */
   askKey?: string;
 }
 

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -43,6 +43,7 @@ import {
 } from "./credential-removal";
 import type { FeedbackEntryControl } from "./feedback-entry";
 import { FeedbackSection } from "./feedback-panel";
+import { Keycaps } from "./keycaps";
 import { microphoneAccessRow } from "./microphone-access";
 import { PANEL_TAB, panelPanelId, panelTabId } from "./panel-tabs";
 import { CloudBadge, ProviderMark } from "./provider-marks";
@@ -112,7 +113,10 @@ export interface SettingsPanelProps {
   /** Chooses how Luke stands on a display without a camera housing. */
   onFormFactorChange: (formFactor: PanelFormFactor) => Promise<string | undefined>;
   onQuit: () => void;
-  /** The talk key as registered, shown so it can be learned — and pressed to be changed. */
+  /**
+   * The talk key as registered, as an accelerator: the row draws it as its
+   * separate keys and says it whole in the labels its buttons carry.
+   */
   voiceHotkey?: string;
   /** Whether that key can be held, which is what the row has to describe. */
   voiceHotkeyHeld: boolean;
@@ -122,7 +126,7 @@ export interface SettingsPanelProps {
    * that answer belongs.
    */
   onVoiceHotkeyChange: (accelerator: string | undefined) => Promise<string | undefined>;
-  /** The ask key as registered, shown so it can be learned — and pressed to be changed. */
+  /** The ask key as registered, an accelerator on the talk key's terms. */
   askHotkey?: string;
   /**
    * Moves the ask key to a recorded chord, or back to the defaults when
@@ -914,8 +918,9 @@ function PreferencesSection({
 const SHORTCUT_HINT = "Hold ⌃, ⌥ or ⌘ — ⇧ may join — and press a letter or Space.";
 
 /**
- * How Luke is reached rather than what he can see. The chord stays the plain
- * key chip it always was; the pencil beside it is the control. Pressing it
+ * How Luke is reached rather than what he can see. The chord is drawn as the
+ * keys it is — one cap each, the way a keyboard has them — and is a statement
+ * rather than a control; the pencil beside it is what moves it. Pressing it
  * starts a recording — what a chord may be is shown under the controls at
  * once, the next whole chord is stored and registered at once, and Escape (or
  * the pencil, now a cross) keeps the key that was already there. Recording
@@ -942,7 +947,7 @@ function ShortcutRow({
 }: {
   title: string;
   detail: string;
-  /** The key as registered, already labelled, absent when none answered. */
+  /** The accelerator as registered, absent when no candidate answered. */
   shown?: string | undefined;
   /** Whether a chosen chord is stored, which is what Reset has to undo. */
   chosen: boolean;
@@ -983,9 +988,18 @@ function ShortcutRow({
       </span>
       <span className="shortcut-controls">
         <span className="settings-actions">
-          <span className="shortcut-key" data-recording={String(recording)}>
-            {recording ? "Type a shortcut…" : (shown ?? "Unavailable")}
-          </span>
+          {/* The chord as its own keys while there is one to press, and a
+              sentence when there is not: "Type a shortcut…" and "Unavailable"
+              are things being said about the key, not keys to draw. */}
+          {recording ? (
+            <span className="shortcut-state" data-recording="true">
+              Type a shortcut…
+            </span>
+          ) : shown ? (
+            <Keycaps className="shortcut-chord" accelerator={shown} />
+          ) : (
+            <span className="shortcut-state">Unavailable</span>
+          )}
           {chosen && !recording ? (
             <button
               type="button"

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -65,6 +65,21 @@
   --selected-edge: rgba(255, 255, 255, 0.32);
   --hairline: rgba(255, 255, 255, 0.08);
 
+  /* A key drawn on screen is a physical thing quoted, so it gets what the
+     hairline deliberately withholds: an edge bright enough to close the shape
+     on its own, a face lifted off the surface, and a lit top and dark underside
+     that put a couple of pixels of depth under it. The edge is the load-bearing
+     one — the caps of a chord sit a few pixels apart, and it is the edge rather
+     than the gap that says where one key ends and the next begins. */
+  --keycap-face: rgba(255, 255, 255, 0.07);
+  --keycap-edge: rgba(255, 255, 255, 0.17);
+  --keycap-relief: inset 0 1px 0 rgba(255, 255, 255, 0.09), 0 1px 1px rgba(0, 0, 0, 0.4);
+  /* Squares a lone glyph and lets a word key ride out past it on the padding.
+     Both are set per surface: the settings row draws the chord full size, the
+     composer's hint draws the same keys smaller than the words beside it. */
+  --keycap-size: 18px;
+  --keycap-text: 10.5px;
+
   /* One motion vocabulary. The black surface is the only thing that changes
      size; everything layered on it moves with `transform` and `opacity` alone,
      so a frame costs a composite rather than a relayout and a text re-shape.

--- a/apps/desktop/src/renderer/styles/index.css
+++ b/apps/desktop/src/renderer/styles/index.css
@@ -1,5 +1,8 @@
 /* The renderer ships one stylesheet; esbuild inlines these imports. */
 @import "./base.css";
+/* Before the surfaces that hold keycaps, so each can size its own without
+   out-specifying the cap itself. */
+@import "./keycaps.css";
 @import "./sessions.css";
 @import "./voice.css";
 /* Generated from design/generate-brand-assets.mjs; base.css holds the wiring it

--- a/apps/desktop/src/renderer/styles/keycaps.css
+++ b/apps/desktop/src/renderer/styles/keycaps.css
@@ -1,0 +1,44 @@
+/* The keys a chord is made of, drawn as keys.
+
+   One cap per key, spaced apart and each closed by its own edge, because that
+   is what the hand is being told to do: ⌥ and Space are two keys pressed
+   together, and a single chip reading "⌥Space" draws them as one word. Every
+   surface that shows a chord — the settings row, the composer's hint — draws
+   the same cap, and sizes it with `--keycap-size` and `--keycap-text` rather
+   than restyling it.
+
+   Nothing here animates: caps appear and disappear with the surface that holds
+   them, and a cap that grew on hover would re-shape text inside a pill that is
+   already the panel's most crowded row. */
+
+.keycap-chord {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  /* Wide enough to read as separate keys, tight enough to read as one chord. */
+  gap: 3px;
+}
+
+.keycap {
+  display: inline-flex;
+  min-width: var(--keycap-size);
+  height: var(--keycap-size);
+  align-items: center;
+  justify-content: center;
+  /* Only ever pays out on a key whose glyph is wider than the square: ⌥ and K
+     stay square, Space and Enter grow sideways from it. */
+  padding: 0 5px;
+  border: 1px solid var(--keycap-edge);
+  border-radius: 5px;
+  background: var(--keycap-face);
+  box-shadow: var(--keycap-relief);
+  color: var(--text-secondary);
+  font-family: inherit;
+  font-size: var(--keycap-text);
+  font-weight: 600;
+  /* The glyph sits on the cap's own centre line: ⌥ and ⇧ have far more room
+     above them than a letter does, and any leading at all would stack the two
+     kinds of key differently. */
+  line-height: 1;
+  white-space: nowrap;
+}

--- a/apps/desktop/src/renderer/styles/keycaps.css
+++ b/apps/desktop/src/renderer/styles/keycaps.css
@@ -25,9 +25,15 @@
   height: var(--keycap-size);
   align-items: center;
   justify-content: center;
-  /* Only ever pays out on a key whose glyph is wider than the square: ⌥ and K
-     stay square, Space and Enter grow sideways from it. */
-  padding: 0 5px;
+  /* Derived from the two numbers above rather than fixed, because it is what
+     decides whether a lone glyph still fits inside the square: the square is
+     border-box, so a fixed inset that is comfortable at 20px leaves a 16px cap
+     with less room than a glyph is wide, and ⌥ — which is nearly as wide as
+     the type is tall, where a letter is not — would push the cap out into a
+     rectangle. At a quarter of the difference, every key that is one glyph
+     stays square at either size, and only a worded key like Space pays the
+     inset out and grows sideways. */
+  padding: 0 calc((var(--keycap-size) - var(--keycap-text)) / 4);
   border: 1px solid var(--keycap-edge);
   border-radius: 5px;
   background: var(--keycap-face);

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -756,23 +756,18 @@ html[data-keyboard="true"] button.row-main:focus-visible {
   color: var(--text-tertiary);
 }
 
-/* How the reach is learned: the keycap surfaces while the pointer is over the
-   pill and stands down again once the caret is in or a draft holds the field —
-   whoever it could teach already knows. It keeps its layout box in every
-   state and only fades, so hovering re-shapes nothing, and it takes no
-   pointer: a press on it is a press on the field it names. */
+/* How the reach is learned: the keycaps surface while the pointer is over the
+   pill and stand down again once the caret is in or a draft holds the field —
+   whoever they could teach already knows. They keep their layout box in every
+   state and only fade, so hovering re-shapes nothing, and they take no
+   pointer: a press on them is a press on the field they name.
+
+   A step smaller than a settings row's caps: these ride inside the composer
+   beside its placeholder, where a full-size key would read as a control rather
+   than as the hint it is. */
 .ask-luke-hint {
-  flex: 0 0 auto;
-  padding: 2.5px 6px;
-  border: 1px solid var(--hairline);
-  border-radius: 6px;
-  background: var(--raised);
-  color: var(--text-tertiary);
-  font-family: inherit;
-  font-size: 9px;
-  font-weight: 620;
-  letter-spacing: 0.4px;
-  white-space: nowrap;
+  --keycap-size: 16px;
+  --keycap-text: 9.5px;
   opacity: 0;
   pointer-events: none;
   transition: opacity var(--duration-hover) ease;

--- a/apps/desktop/src/renderer/styles/voice.css
+++ b/apps/desktop/src/renderer/styles/voice.css
@@ -18,32 +18,47 @@
   flex-direction: column;
   align-items: flex-end;
   gap: 6px;
+  /* The size a chord reads at in a row of settings, kept here rather than on
+     the caps: what stands where the keys would be is sized by the same two
+     numbers, so the row keeps one height whichever it is drawing. */
+  --keycap-size: 20px;
+  --keycap-text: 11px;
 }
 
 .shortcut-controls .error-message {
   text-align: right;
 }
 
-/* A statement, not a control: the pencil beside it is what moves the key.
-   The chip only brightens while a recording holds it open. */
-.shortcut-key {
-  padding: 4px 8px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+/* A statement, not a control: the pencil beside it is what moves the key. The
+   caps are the shared ones, lit the way a key the user actually has should be
+   — the composer's hint teaches a reach, this one reports a setting. */
+.shortcut-chord .keycap {
+  color: var(--text-primary);
+}
+
+/* What is said where the keys would be, when there are none to draw: the chord
+   being typed, or none having registered. Shaped like a lone cap so the row
+   keeps its height, and lettered rather than keyed because neither is
+   something to press. */
+.shortcut-state {
+  display: inline-flex;
+  height: var(--keycap-size);
+  align-items: center;
+  padding: 0 8px;
+  border: 1px solid var(--hairline);
   border-radius: 6px;
-  background: rgba(255, 255, 255, 0.04);
-  color: rgba(255, 255, 255, 0.86);
-  font-family: "SF Mono", Menlo, monospace;
-  font-size: 11px;
+  background: var(--raised);
+  color: var(--text-tertiary);
+  font-size: var(--keycap-text);
   white-space: nowrap;
   transition:
     border-color var(--duration-hover) ease,
     color var(--duration-hover) ease;
 }
 
-/* Recording holds the chip open rather than swapping it for a field: the
-   border brightening is the whole state, and the words inside say what to
-   type. */
-.shortcut-key[data-recording="true"] {
+/* Recording brightens the words rather than swapping them for a field: the
+   edge lighting up is the whole state, and what it says is what to type. */
+.shortcut-state[data-recording="true"] {
   border-color: rgba(255, 255, 255, 0.35);
   color: var(--text-secondary);
 }

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -184,9 +184,10 @@ export interface AppBootstrap {
    */
   realtimeAvailable: boolean;
   /**
-   * The talk key as the user should read it, absent when the system refused to
-   * register one — a shortcut nothing can trigger must not be shown as though
-   * it works.
+   * The accelerator the talk key was registered as, absent when the system
+   * refused to register one — a shortcut nothing can trigger must not be shown
+   * as though it works. Raw rather than labelled for the ask key's reason
+   * below: the renderer draws the keys apart and says the chord whole.
    */
   voiceHotkey?: string;
   /**
@@ -198,8 +199,8 @@ export interface AppBootstrap {
   /**
    * The accelerator that summons the ask field from any app, absent when the
    * system refused every candidate. The raw accelerator rather than a label,
-   * because the renderer needs both spellings: the keycap's ⌥L and aria's
-   * Alt+L.
+   * because the renderer needs both spellings: the keycaps' ⌥ and L, drawn as
+   * the two keys they are, and aria's Alt+L.
    */
   askHotkey?: string;
   /** Whether the panel should show the voice diagnostics block. */
@@ -215,7 +216,7 @@ export interface AppBootstrap {
 /** One validated issue act on its way to the main process. */
 export type IssueActionAsk = Extract<IssueToolAction, { kind: "issue-state" | "issue-comment" }>;
 
-/** The talk key as the panel should describe it. */
+/** The talk key as the panel should describe it, as an accelerator. */
 export interface VoiceHotkeyState {
   hotkey?: string;
   held: boolean;

--- a/apps/desktop/src/shared/voice-hotkey.ts
+++ b/apps/desktop/src/shared/voice-hotkey.ts
@@ -284,6 +284,22 @@ export function voiceHotkeyLabel(accelerator: string): string {
 }
 
 /**
+ * The same chord as the keys a hand actually presses, in the order macOS
+ * writes them: one entry per key, so a surface can draw a cap each rather than
+ * one chip for the whole chord.
+ *
+ * The label stays what a sentence, a menu item, or a screen reader gets — a
+ * chord read aloud is one thing to press, and only a drawn keyboard needs the
+ * keys apart.
+ */
+export function voiceHotkeyKeycaps(accelerator: string): readonly string[] {
+  const parts = accelerator.split("+");
+  const key = parts[parts.length - 1] ?? "";
+  const modifiers = parts.slice(0, -1).map((modifier) => MODIFIER_SYMBOLS[modifier] ?? modifier);
+  return [...modifiers, key];
+}
+
+/**
  * Why there is no talk key. Each of these is a different thing to go and do
  * about it, so a startup line that names the wrong one sends the reader after
  * a conflict that was never there.

--- a/apps/desktop/tests/voice-hotkey.test.ts
+++ b/apps/desktop/tests/voice-hotkey.test.ts
@@ -13,6 +13,7 @@ import {
   VOICE_HOTKEY_ABSENCE,
   VOICE_HOTKEY_CAPTURE,
   voiceHotkeyCandidates,
+  voiceHotkeyKeycaps,
   voiceHotkeyLabel,
   voiceHotkeyReport,
   voiceHotkeyToShow,
@@ -89,6 +90,24 @@ test("an accelerator reads the way macOS writes it", () => {
   assert.equal(voiceHotkeyLabel("Alt+Space"), "⌥Space");
   assert.equal(voiceHotkeyLabel("Alt+S"), "⌥S");
   assert.equal(voiceHotkeyLabel("Command+Shift+K"), "⌘⇧K");
+});
+
+test("a chord drawn as keys comes apart into the keys a hand presses", () => {
+  // The same glyphs the label is written with, one entry per key, in the order
+  // macOS prints them — the caps are the label taken apart, never a second
+  // spelling of it.
+  assert.deepEqual(voiceHotkeyKeycaps("Alt+Space"), ["⌥", "Space"]);
+  assert.deepEqual(voiceHotkeyKeycaps("Alt+S"), ["⌥", "S"]);
+  assert.deepEqual(voiceHotkeyKeycaps("Control+Alt+Shift+Command+K"), ["⌃", "⌥", "⇧", "⌘", "K"]);
+  for (const accelerator of ["Alt+Space", "Command+Shift+K"]) {
+    assert.equal(voiceHotkeyKeycaps(accelerator).join(""), voiceHotkeyLabel(accelerator));
+  }
+
+  // Every cap in a chord is distinct, which is what lets a surface draw them
+  // keyed by the glyph itself: a modifier appears once, and the key it ends in
+  // is never one of the modifier glyphs.
+  const caps = voiceHotkeyKeycaps("Control+Alt+Shift+Command+K");
+  assert.equal(new Set(caps).size, caps.length);
 });
 
 test("a missing talk key says which absence it is", () => {
@@ -229,25 +248,25 @@ test("the key survives the message that announces it being lost", () => {
   // The helper registers while the renderer is still loading, so the message
   // saying which key it got is sent to a window with nothing listening yet.
   // Bootstrap is the one the renderer asks for, so it is what answers.
-  assert.deepEqual(voiceHotkeyToShow({ voiceHotkey: "⌥Space", voiceHotkeyHeld: true }, undefined), {
-    hotkey: "⌥Space",
-    held: true,
-  });
+  assert.deepEqual(
+    voiceHotkeyToShow({ voiceHotkey: "Alt+Space", voiceHotkeyHeld: true }, undefined),
+    { hotkey: "Alt+Space", held: true },
+  );
 
   // A change only arrives when the helper stopped answering and the toggle took
   // over, which is news bootstrap cannot have.
   assert.deepEqual(
     voiceHotkeyToShow(
-      { voiceHotkey: "⌥Space", voiceHotkeyHeld: true },
-      { hotkey: "⌥S", held: false },
+      { voiceHotkey: "Alt+Space", voiceHotkeyHeld: true },
+      { hotkey: "Alt+S", held: false },
     ),
-    { hotkey: "⌥S", held: false },
+    { hotkey: "Alt+S", held: false },
   );
 
   // No key anywhere is the only way the panel should read "Unavailable".
   assert.deepEqual(voiceHotkeyToShow({ voiceHotkeyHeld: false }, undefined), { held: false });
   assert.deepEqual(
-    voiceHotkeyToShow({ voiceHotkey: "⌥Space", voiceHotkeyHeld: true }, { held: true }),
+    voiceHotkeyToShow({ voiceHotkey: "Alt+Space", voiceHotkeyHeld: true }, { held: true }),
     {
       held: true,
     },


### PR DESCRIPTION
## Summary

- Shortcut chords are drawn as the keys they are: one cap per key, spaced apart and closed by its own edge, the way developer tools and macOS print them, instead of a single chip holding `⌥Space` as though it were a word.
- One shared cap for both surfaces that show a chord — the two Keyboard shortcuts rows and the Ask Luke composer's hint — in `styles/keycaps.css` and `renderer/keycaps.tsx`, sized per surface with `--keycap-size` and `--keycap-text` rather than restyled. The cap's inset is derived from those two, so every one-glyph key stays square at either size and only a worded key like `Space` grows sideways.
- `voiceHotkeyKeycaps` takes an accelerator apart into the same glyphs `voiceHotkeyLabel` writes it with, so the caps are the label split rather than a second spelling of it (a test asserts the two agree).
- The talk key now travels to the renderer as an accelerator, as the ask key already did: the panel draws the keys apart, while the app guide, `aria-keyshortcuts`, and the Reset/Change button labels keep the chord whole.
- What is said where the keys would be — "Type a shortcut…" while recording, "Unavailable" when nothing registered — stays lettered rather than keyed, because neither is something to press, and takes the cap's height so the row keeps one shape whichever it draws.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — passed on the current head (527 desktop tests, 105 core, 34 scripts; Biome 19 warnings, the same count `main` reports today).
- macOS Electron verification (`./scripts/verify.sh`): `not run locally` — this workspace is Linux. CI's `macOS app and evidence` job runs it on `macos-15`; it passed on the first commit (app packaged, all five deterministic screenshots validated) and runs again for the fix commit.
- **The deterministic screenshots do not show this change, and cannot.** They capture the Sessions tab, the peek, the capsule, and the slot — never the Settings tab — and a capture run deliberately registers no global key, so the composer's hint has nothing to teach and the settings rows would read "Unavailable". The artifact was downloaded and inspected to confirm nothing else regressed; it is not evidence of the caps.
- What did check the caps: the shipped `styles.css` rendered against the real markup in headless Chromium — caps read as separate keys, both message states hold the row's height — and measured there, since no font in that container covers ⌥⌘⇧. Standing a box exactly one em wide in for those glyphs, each one-glyph cap measures 20x20 in the settings row and 16x16 in the hint, with `Space` at 37.8x20 and 32.3x16. That measurement is what caught the Bugbot finding on the first commit: the old fixed inset gave 23.0x20 and 21.5x16.
- Unit coverage asserts the caps are exactly the label split apart, that they arrive in the order macOS prints them, and that each cap in a chord is distinct.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31826873616/artifacts/9229164240) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31826873616)

- Commit: `effdc3b80b1867f6ff1736c9bc5cb73f1337c88e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Rebased onto `main` after #80 and #87 landed; the only conflict was an import line in `settings-panel.tsx`.
- No new setting, so `luke-guide.ts` gains no entry; its two shortcut facts keep the labelled chord, which is what a spoken answer should say.
- Follow-up worth considering: the evidence harness has no way to capture the Settings tab, and no way to show a registered chord during a capture run, so any change to these rows is unverifiable by CI screenshots. Giving it one is a tooling decision rather than part of this change.
- Remaining verification: opening Settings on a physical Mac to read the caps in SF, and a physical-notch check — though nothing here changes the window's shape or the panel's motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)