### PR TITLE
feat(voice): switch the panel between its tabs on an ask

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1310,7 +1310,8 @@ export function App(): React.JSX.Element {
    * The spoken asks about Luke himself. A settings change goes through the
    * same bridge calls the settings rows use, and the snapshot that comes back
    * redraws the panel's switches; showing the panel is the capsule's press
-   * with a tab, and optionally a narrowing, chosen out loud; opening the
+   * with a tab — or, already open, that tab's own press — and optionally a
+   * narrowing, chosen out loud; opening the
    * composer is the tray item's press, run through the tray's own path. All
    * were validated against their fixed vocabularies before they arrive here,
    * so this only performs and reports.

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -301,7 +301,9 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
     {
       label: "The panel",
       detail:
-        "Two tabs. Sessions lists every observed session with its state, narrowable to all, local, " +
+        "Two tabs, switched by pressing one or by asking Luke — out loud or typed — to show it; " +
+        "asked while the panel is closed, the panel opens on that tab. " +
+        "Sessions lists every observed session with its state, narrowable to all, local, " +
         "cloud, or one provider, and orderable by urgency (what needs the developer first) or " +
         "recency (what moved last first); a row can be opened, messaged, or controlled where its " +
         "provider allows. Settings holds the preferences, the talk and ask keys, the cloud " +

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -187,6 +187,20 @@ test("the facts follow the talk key, the microphone, and the storage the system 
   assert.match(JSON.stringify(unprotected.facts), /no encrypted credential storage/);
 });
 
+test("the panel fact says the tabs answer an ask as well as a press", () => {
+  const fact = buildLukeGuide(guideInput()).facts.find(
+    (candidate) => candidate.label === "The panel",
+  );
+
+  assert.ok(fact);
+  // Switching between Sessions and Settings by asking Luke is a capability,
+  // and a capability the guide does not describe is one Luke will deny.
+  assert.match(fact.detail, /switched by pressing one or by asking Luke/);
+  assert.match(fact.detail, /the panel opens on that tab/);
+  assert.match(fact.detail, /Sessions lists/);
+  assert.match(fact.detail, /Settings holds/);
+});
+
 test("the feedback fact says what a spoken open may do, and that sending stays by hand", () => {
   const fact = buildLukeGuide(guideInput()).facts.find(
     (candidate) => candidate.label === "Feedback and prompts",

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -1962,6 +1962,26 @@ test("a spoken panel ask is validated against the roster and carried", async () 
   assert.deepEqual(carried, [
     { kind: "panel", tab: "sessions", filter: "claude-code", sort: "recency" },
   ]);
+
+  // Switching to the settings tab is the same ask carried with a tab, not a
+  // different act — the carrier presses the tab an open panel already shows.
+  armDeveloperTurn(context);
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: {
+      output: [
+        {
+          type: "function_call",
+          name: "show_panel",
+          call_id: "call-guide-4",
+          arguments: '{"tab":"settings"}',
+        },
+      ],
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.deepEqual(carried.at(-1), { kind: "panel", tab: "settings" });
 });
 
 test("a spoken composer open is validated against the fixed kinds and carried, never sent", async () => {

--- a/packages/sidecar-core/src/realtime.ts
+++ b/packages/sidecar-core/src/realtime.ts
@@ -237,7 +237,7 @@ const REALTIME_INSTRUCTION_LINES: readonly string[] = [
   "- Messages marked [app guide] describe Luke: the facts, and every setting with its current value and where it is changed by hand.",
   "- Answer questions about Luke and its settings from the guide alone; when the guide does not say, say you do not know.",
   "- change_app_setting changes only a setting the guide marks changeable by voice, when the developer asks. For every other setting, tell them the by-hand path the guide gives.",
-  "- show_panel opens Luke's own panel on its sessions or settings tab, and can narrow the session list to one provider or location or reorder it by urgency or recency — use it when the developer asks to see something of Luke's.",
+  "- show_panel opens Luke's own panel on its sessions or settings tab — or switches a panel already open to the tab they name — and can narrow the session list to one provider or location or reorder it by urgency or recency. Use it when the developer asks to see something of Luke's or to move between his tabs.",
   "- open_feedback_composer brings up the composer for a note the developer sends the founders by hand: feedback about Luke, or a prompt they may ship. It can start the note with the developer's own words as a draft — never words they did not say — and it never sends and never overwrites a note already being written: the developer reads, edits, and presses Send themselves.",
   "- When you refuse an ask you cannot carry out — a setting the guide keeps by hand, a capability you do not have, an act outside your tools — refuse honestly in one sentence, then offer once: would they like to send that ask to the founders as a prompt? Only on a clear yes, open the composer on the prompt kind with their ask as the draft, in their own words. Declined or ignored, let it go without another word, and do not repeat the offer for the same ask.",
   "- Never take a credential by voice, and never repeat one: keys are typed into the settings tab, and the guide only ever says whether a provider is connected.",
@@ -520,7 +520,8 @@ export function realtimeToolDefinitions(): readonly Record<string, unknown>[] {
       type: "function",
       name: REALTIME_TOOL.SHOW_PANEL,
       description:
-        "Show Luke's own panel on the developer's screen, the same as pressing the capsule. " +
+        "Show Luke's own panel on the developer's screen, the same as pressing the capsule — or, " +
+        "when the panel is already open, switch it to the named tab, the same as pressing that tab. " +
         "It can open the sessions list — narrowed to one provider or location, ordered by urgency or recency — or the settings tab.",
       parameters: {
         type: "object",
@@ -528,7 +529,7 @@ export function realtimeToolDefinitions(): readonly Record<string, unknown>[] {
           tab: {
             type: "string",
             enum: Object.values(APP_PANEL_TAB),
-            description: "Which tab to open. Defaults to sessions.",
+            description: "Which tab to open or switch to. Defaults to sessions.",
           },
           filter: {
             type: "string",

--- a/packages/sidecar-core/tests/guide.test.ts
+++ b/packages/sidecar-core/tests/guide.test.ts
@@ -115,6 +115,9 @@ test("the standing instructions promise the guide the context actually delivers"
   assert.match(instructions, /\[app guide\]/);
   assert.match(instructions, /change_app_setting/);
   assert.match(instructions, /show_panel/);
+  // Switching an open panel between its tabs is the same ask, and the
+  // instructions must say so or Luke will deny a capability he has.
+  assert.match(instructions, /switches a panel already open/);
   assert.match(instructions, /open_feedback_composer/);
   assert.match(instructions, /create_workspace/);
   assert.match(instructions, /\[workspace projects\]/);


### PR DESCRIPTION
## What

Gives Luke the ability to switch the panel between its **Sessions** and **Settings** tabs when asked in conversation — out loud or typed.

## Why

`show_panel` could already land on either tab, and its carrier already runs through `changeTab` + `changeMode` — the tab's own press. But every description of the act framed it as *opening* the panel: the tool schema, the standing instruction bullet, and the guide's "The panel" fact. Per the repo's own rule, a capability the guide does not describe is one Luke will deny having — so asked to *switch* tabs, Luke would refuse an act he could carry.

## How

Language layer only; no new tool and no new write path:

- **Tool schema** (`realtime.ts`): `show_panel` now says it also switches an already-open panel to the named tab, the same as pressing that tab; the `tab` parameter reads "open or switch to".
- **Standing instructions**: the `show_panel` bullet covers switching and says to use it when the developer asks to move between tabs.
- **Guide fact** (`luke-guide.ts`): "The panel" now opens with how the tabs are switched — by press or by ask — and that an ask while closed opens the panel on that tab.
- **Tests**: the instruction wording and the panel fact are pinned (`guide.test.ts`, `luke-guide.test.ts`), and the dispatch test carries a `{"tab":"settings"}` switch end to end (`realtime-session.test.ts`).

The tool count stays at ten, so the minted-tools test is untouched. Validation is unchanged: the tab vocabulary is still `APP_PANEL_TAB`, checked in `appToolAction` before any carrier runs.

## Checks

- `./scripts/check.sh` — exit 0 (sidecar-core 114/114, desktop 560/560)
- `./scripts/verify.sh` — runs in CI on macOS; no visual change is expected (prose and guide text only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/124a66cc-9c5b-47ed-9a4d-eb0a6c14e8de)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31837650721/artifacts/9233101729) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31837650721)

- Commit: `82855829d89fbc1a0ed72b3d7ba02a8bfecca4af`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
