### PR TITLE
feat(sessions): show each Conductor chat as its own row, grouped by workspace

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -117,9 +117,11 @@ whose policies then govern the request and response data.
 
 The local panel may show a session's provider-assigned title, status, current
 activity or error, recap — provider-designated, or for Conductor the agent's
-parting words read from its transcript — repository, branch, model, and
-session or change links. The links and model label are kept out of the optional
-attention-review request described below.
+parting words read from its transcript — repository, branch, model, the name
+and identifier of the workspace a chat is grouped under where its provider
+nests them, and session or change links. The links, model label, and workspace
+identifier are kept out of the optional attention-review request described
+below.
 
 The microphone is optional and is used two ways.
 
@@ -143,7 +145,8 @@ Realtime API over a direct WebRTC connection from your Mac, and plays back the
 spoken reply. OpenAI's policies govern that audio and the reply.
 
 Alongside the audio, Luke sends the same bounded session fields the attention
-review uses — provider name, session title, status, and each session's recap —
+review uses — provider name, session title, status, the name of the workspace
+a chat belongs to where its provider groups them, and each session's recap —
 so a spoken question about your sessions can be answered. No message history,
 file content, or command output is ever included: a recap can reflect what a
 session was asked and replied — for Conductor it is the agent's own parting
@@ -198,13 +201,15 @@ short-lived client secret minted for one call, which expires on its own.
 Without `OPENAI_API_KEY`, Luke does not send an attention-review request.
 
 With `OPENAI_API_KEY`, Luke sends the configured Responses-compatible endpoint
-the provider name, displayed session title, previous and current status, review
+the provider name, displayed session title, the name of the workspace a chat
+belongs to where its provider groups them, previous and current status, review
 trigger, repository, branch, current tool activity, reported error, and the
 session recap — provider-designated, or for Conductor the agent's parting
-words read from its transcript. Titles and recaps can reflect task and reply
-content; for a Conductor session, the title can contain the project-name
-fallback described above. The request also includes fixed review instructions
-and synthetic examples. The API key is sent to that endpoint as the request's
+words read from its transcript. Titles, workspace names, and recaps can
+reflect task and reply content; for a Conductor chat, the title is the chat's
+own name and the workspace name can contain the project-name fallback
+described above. The request also includes fixed review instructions and
+synthetic examples. The API key is sent to that endpoint as the request's
 bearer credential.
 
 Luke does not send message history beyond that recap, command output, file

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ ask, out loud or typed, through Linear's own GraphQL API under your key.
 - Rows show the provider-assigned title (with a workspace fallback), current
   activity, error or turn recap, repository context, and whether the session is
   working, waiting, complete, failed, or merely observed.
+- A provider that nests chats in a workspace — Conductor today — gets one row
+  per chat: several chats sit inside one tray named by the workspace at its
+  top, a workspace holding a single chat stays one row titled by the
+  workspace, and each chat can be opened, messaged, or controlled on its own.
 - Sessions that appear to need attention are placed first.
 - An options button beside the tabs opens filtering and sorting: the list can be
   narrowed to the sessions running locally, to those running in the cloud, or to

--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -222,26 +222,6 @@ const CONDUCTOR_SESSION_STATUS = {
   ERROR: "error",
 } as const;
 
-/**
- * Which chat gets to speak for its workspace, most urgent first. A failure
- * outranks a question — both want a person, but only one of them is stuck —
- * and a question outranks work still running.
- *
- * Unknown outranks complete, which reads backwards until the provider's shapes
- * are laid over it: complete only ever comes from an archived chat, and unknown
- * is an open one — idle long enough to decay, or with a status that could not
- * be read. However quiet, the open chat is where the user would return, so a
- * closed sibling must not make the workspace read as finished or take the
- * press that would have landed there.
- */
-const STATUS_URGENCY: readonly SessionStatus[] = [
-  SESSION_STATUS.ERROR,
-  SESSION_STATUS.WAITING,
-  SESSION_STATUS.WORKING,
-  SESSION_STATUS.UNKNOWN,
-  SESSION_STATUS.COMPLETE,
-];
-
 type ConductorSessionStatus =
   (typeof CONDUCTOR_SESSION_STATUS)[keyof typeof CONDUCTOR_SESSION_STATUS];
 
@@ -310,6 +290,7 @@ interface ConductorSession {
   workspace: ConductorWorkspace;
   archived: boolean;
   archivedAt?: number;
+  name?: string;
   model?: string;
   deepLink?: string;
 }
@@ -322,14 +303,14 @@ interface ConductorSession {
  * transcripts view names the sessions the same pass observed and takes back
  * each chat's agent kind and the bounded tail its recap — the settled turn's
  * parting words — is read from; the history behind that tail is never asked
- * for, and the tail itself never leaves this adapter. Each workspace is
- * reported as one session — the workspace is the
- * unit Conductor's own surface shows, and the one its name names — in the state
- * of whichever chat inside it most needs a person, and that chat is the one a
- * write reaches: the writes it supports are a user-typed prompt and a stop for
- * the running turn, each through Conductor's own endpoint on a chat that
- * advertised it, and a new workspace in a project the latest pass listed,
- * through Conductor's documented creation endpoint.
+ * for, and the tail itself never leaves this adapter. Each chat is reported
+ * as its own session, carrying the workspace around it as its group — the
+ * workspace is the unit Conductor's own surface shows, but the chat is the
+ * thing a press opens and a write reaches, and a workspace holding two chats
+ * in two states is two facts, not one. The writes it supports are a
+ * user-typed prompt and a stop for the running turn, each through Conductor's
+ * own endpoint on a chat that advertised it, and a new workspace in a project
+ * the latest pass listed, through Conductor's documented creation endpoint.
  */
 export class ConductorSessionAdapter extends CloudSessionAdapter {
   readonly #maximumObservedWorkspaces: number;
@@ -492,27 +473,17 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
       ),
     ]);
 
-    // One row per workspace. The workspace is the session the user knows —
-    // it is what titles the row — so two chats inside it would draw as
-    // identical lines that open different places. Every chat's status is
-    // still read, because the workspace is in whatever state its neediest
-    // chat is in; that chat is the one the row reports and the one a press
-    // opens.
-    const byWorkspace = new Map<string, ProviderSessionObservation>();
-    sessions.forEach((session, index) => {
-      const observation = this.#observationFor(
-        session,
-        reportedStatuses[index],
-        transcripts?.get(session.id),
-        now,
-      );
-      if (!observation) return;
-      const held = byWorkspace.get(session.workspace.id);
-      if (!held || urgencyOrder(observation, held) < 0) {
-        byWorkspace.set(session.workspace.id, observation);
-      }
-    });
-    return [...byWorkspace.values()];
+    // One row per chat, each grouped under its workspace. Two chats used to
+    // collapse into one row because their generated names drew as identical
+    // lines — but the workspace grouping now names the group once, which
+    // leaves each chat free to say what it alone is doing, be opened where it
+    // alone lives, and take the message meant for it rather than for whichever
+    // sibling most needed a person.
+    return sessions
+      .map((session, index) =>
+        this.#observationFor(session, reportedStatuses[index], transcripts?.get(session.id), now),
+      )
+      .filter(isDefined);
   }
 
   async #identity(request: CloudRequest): Promise<string | undefined> {
@@ -596,14 +567,18 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
           const archivedAt = timestampFromRecord(record, CONDUCTOR_FIELD.ARCHIVED_AT);
           const model = modelLabel(record);
           const deepLink = textFromRecord(record, CONDUCTOR_FIELD.DEEP_LINK);
-          // The chat's own `name` is deliberately not read: Conductor generates
-          // it, nobody chose it, and the one thing it ever did here — titling
-          // the row — belongs to the workspace's name instead.
+          // The chat's own name tells it from its siblings now that every chat
+          // is a row of its own; the workspace's name moved to the group.
+          const name = textFromRecord(record, CONDUCTOR_FIELD.NAME)?.slice(
+            0,
+            maximumSessionTitleLength,
+          );
           return {
             id,
             workspace,
-            archived: textFromRecord(record, CONDUCTOR_FIELD.ARCHIVED_AT) !== undefined,
+            archived: archivedAt !== undefined,
             ...(archivedAt === undefined ? {} : { archivedAt }),
+            ...(name ? { name } : {}),
             ...(model ? { model } : {}),
             ...(deepLink ? { deepLink } : {}),
           };
@@ -725,14 +700,21 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
     const model = agentAndModelLabel(transcript?.agentKind, session.model);
     return {
       providerSessionId: session.id,
-      // The workspace's name is the name the user knows this work by — it is
-      // what Conductor itself shows them — where a chat's own name is generated
-      // and identifies nothing. So the workspace titles the row, and it is not
-      // reported as a branch: it never was one, and the surface now draws a
-      // branch under a glyph that says so.
-      title: session.workspace.name ?? session.workspace.repositoryLabel,
+      // The chat's own name titles the row, because the row is the chat; the
+      // workspace's name — the name the user knows the work by — rides the
+      // grouping below and names all of its chats at once. A chat Conductor
+      // never named still falls back to those, and none of them is reported
+      // as a branch: a workspace name never was one.
+      title: session.name ?? session.workspace.name ?? session.workspace.repositoryLabel,
       status,
       observedAt,
+      // The workspace this chat is one voice of. Its name falls back to the
+      // repository so an unnamed workspace still groups under something a
+      // person can say out loud.
+      workspace: {
+        providerWorkspaceId: session.workspace.id,
+        name: session.workspace.name ?? session.workspace.repositoryLabel,
+      },
       // Conductor documents both halves of a send — queued while a session is
       // idle, steered into the turn while it works — so any open chat takes a
       // message. A closed one is settled, and an errored one is documented for
@@ -889,17 +871,6 @@ function agentAndModelLabel(
 ): string | undefined {
   const label = [agentKind, model].filter(isDefined).join(" · ");
   return label || undefined;
-}
-
-/** Most urgent first, and between two equally urgent chats, the one that moved last. */
-function urgencyOrder(
-  first: ProviderSessionObservation,
-  second: ProviderSessionObservation,
-): number {
-  return (
-    STATUS_URGENCY.indexOf(first.status) - STATUS_URGENCY.indexOf(second.status) ||
-    second.observedAt - first.observedAt
-  );
 }
 
 /** Conductor reports the model it resolved as well as the one that was asked for. */

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -477,12 +477,16 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "Sessions lists every observed session with its state, narrowable to all, local, " +
         "cloud, or one provider, and orderable by urgency (what needs the developer first) or " +
         "recency (what moved last first); a row can be opened, messaged, or controlled where its " +
-        "provider allows. Settings holds a front page whose rows open its Voice, Appearance, " +
-        "Keyboard shortcuts, and Connections pages — each led back out by its back button or " +
-        "Escape — and keeps the microphone permission, the Feedback section, and Quit on the " +
-        "front page itself. A change Luke makes himself is shown as it is made: the panel " +
-        "comes forward on the tab, and the page, the change belongs to, and his face leaves " +
-        "the strip under the housing, dives to the control that moved, and floats back.",
+        "provider allows. Where a provider nests chats in a workspace — Conductor today — each " +
+        "chat is its own row: a workspace holding several draws them inside one tray named by " +
+        "the workspace at its top, one holding a single chat stays one row titled by the " +
+        "workspace, and every chat can be seen, opened, and messaged individually. Settings " +
+        "holds a front page whose rows open its Voice, Appearance, Keyboard shortcuts, and " +
+        "Connections pages — each led back out by its back button or Escape — and keeps the " +
+        "microphone permission, the Feedback section, and Quit on the front page itself. A " +
+        "change Luke makes himself is shown as it is made: the panel comes forward on the tab, " +
+        "and the page, the change belongs to, and his face leaves the strip under the housing, " +
+        "dives to the control that moved, and floats back.",
     },
     {
       label: "Feedback and prompts",

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -14,13 +14,16 @@ import {
   type DisplaySession,
   observedAgoLabel,
   type SessionAction,
+  type SessionListRun,
   type SessionView,
+  sessionListRuns,
 } from "./session-model";
 import {
   LEAVING_ATTRIBUTE,
   SESSION_ROW_ID_ATTRIBUTE,
   useRoster,
   useSessionReorderMotion,
+  WORKSPACE_TRAY_ID_ATTRIBUTE,
 } from "./session-motion";
 import {
   BranchGlyph,
@@ -29,6 +32,7 @@ import {
   SessionOptions,
   SessionOptionsButton,
   SessionsPanel,
+  WorkspaceGlyph,
 } from "./session-parts";
 import { SendIcon, StopIcon } from "./settings-icons";
 import { SettingsPanel, type SettingsPanelProps } from "./settings-panel";
@@ -280,6 +284,7 @@ function SessionRow({
   index,
   now,
   leaving,
+  inWorkspaceTray = false,
   onOpen,
   writes,
 }: {
@@ -287,6 +292,8 @@ function SessionRow({
   index: number;
   now: number;
   leaving: boolean;
+  /** Whether this row is drawn inside its workspace's tray. */
+  inWorkspaceTray?: boolean;
   onOpen: (session: DisplaySession) => void;
   writes: SessionWriteHandlers;
 }): React.JSX.Element {
@@ -305,8 +312,15 @@ function SessionRow({
   };
   // The identifier that tells this row from its neighbours: the branch, or the
   // repository where a provider reported no branch. The glyph belongs to the
-  // branch alone — under a repository name it would say the wrong thing.
-  const place = session.branch ?? session.repository;
+  // branch alone — under a repository name it would say the wrong thing. A row
+  // inside a tray leaves a bare repository unsaid: the tray's own header has
+  // already named it, once, for every chat it holds.
+  const place = session.branch ?? (inWorkspaceTray ? undefined : session.repository);
+  // A lone chat is its workspace: with no tray to name it, the row takes the
+  // workspace's name — the name the user knows the work by — because the
+  // chat's own generated name only earns a line once there is a sibling to
+  // tell it from.
+  const title = !inWorkspaceTray && session.workspace ? session.workspace.name : session.title;
   const content = (
     <>
       <span
@@ -318,7 +332,7 @@ function SessionRow({
         {session.location === SESSION_LOCATION.CLOUD ? <CloudBadge /> : null}
       </span>
       <span className="row-copy">
-        <strong>{session.title}</strong>
+        <strong>{title}</strong>
         <small className="row-doing">
           {session.state === SESSION_STATE.WORKING ? (
             <span className="row-spinner" aria-hidden="true" />
@@ -382,6 +396,68 @@ function SessionRow({
       )}
       <SessionRowActions session={session} writes={writes} />
     </article>
+  );
+}
+
+/** Whether a run draws the tray: only several chats earn its chrome. */
+export function runDrawsTray(run: SessionListRun): boolean {
+  return run.workspace !== undefined && run.indexes.length > 1;
+}
+
+/**
+ * One run of the list, tray or not. Several of one workspace's chats sit in
+ * the tray: a single card that visibly contains them, named once at its top —
+ * the workspace's name on the left, and at the far end the glyph leading the
+ * repository — with the chats divided by hairlines inside.
+ * A workspace holding one chat earns no tray — its row already says
+ * everything the tray would — and an ungrouped session never does; either
+ * way the wrapper stays, drawing as nothing. It has to: a workspace crosses
+ * between one chat and several as siblings come and go, and if that crossing
+ * changed the row's parent element, React would remount the row and wipe a
+ * follow-up someone was typing into it. The chrome is a class, never a
+ * different tree.
+ *
+ * The header is furniture rather than a session — it opens nothing and takes
+ * nothing — and it names the tray in the reading order the same way it does
+ * on screen: the workspace once, then its chats. A tray is a member of the
+ * arrival stack in its rows' stead: it fans in at its lead row's turn, and
+ * the rows ride it rather than fanning a second time inside it. A wrapper
+ * that draws as nothing leaves its row in the stack exactly as before.
+ */
+function SessionRun({
+  run,
+  children,
+}: {
+  run: SessionListRun;
+  children: React.ReactNode;
+}): React.JSX.Element {
+  const tray = runDrawsTray(run);
+  return (
+    <section
+      className={tray ? "workspace-tray" : "session-run"}
+      {...(tray && run.workspace
+        ? {
+            // The tray is a slot of the list in its own right: measured by
+            // this id, it travels to a re-sorted seat carrying its rows,
+            // which are translated only by their movement within it.
+            [WORKSPACE_TRAY_ID_ATTRIBUTE]: run.workspace.id,
+            style: { "--row-index": (run.indexes[0] ?? 0) + 1 } as React.CSSProperties,
+          }
+        : {})}
+    >
+      {/* Held in its slot by the null, so the header appearing or leaving can
+          never reseat the keyed rows beside it. */}
+      {tray ? (
+        <header className="workspace-tray-header">
+          <span className="workspace-tray-name">{run.workspace?.name}</span>
+          <span className="workspace-tray-meta">
+            <WorkspaceGlyph />
+            {run.repository ? <span>{run.repository}</span> : null}
+          </span>
+        </header>
+      ) : null}
+      {children}
+    </section>
   );
 }
 
@@ -460,17 +536,37 @@ export function PanelBody({
             {rows.length === 0 ? (
               <EmptyState />
             ) : (
-              rows.map((row, index) => (
-                <SessionRow
-                  key={row.item.id}
-                  session={row.item}
-                  index={index}
-                  now={now}
-                  leaving={row.leaving}
-                  onOpen={onOpenSession}
-                  writes={writes}
-                />
-              ))
+              // Runs are read over the drawn order, leaving rows and all: a
+              // fading chat still holds its slot in its tray, and the tray
+              // may not close around it until it has gone.
+              sessionListRuns(rows.map((row) => row.item)).map((run) => {
+                const tray = runDrawsTray(run);
+                const lead = rows[run.indexes[0] ?? 0];
+                // A workspace run is keyed by the workspace however many chats
+                // it holds, so crossing between one and several keeps the same
+                // wrapper — and the rows inside it — mounted. An ungrouped
+                // session is its own run, keyed by itself.
+                const runKey = run.workspace?.id ?? lead?.item.id ?? "";
+                return (
+                  <SessionRun key={runKey} run={run}>
+                    {run.indexes.map((index) => {
+                      const row = rows[index];
+                      return row ? (
+                        <SessionRow
+                          key={row.item.id}
+                          session={row.item}
+                          index={index}
+                          now={now}
+                          leaving={row.leaving}
+                          inWorkspaceTray={tray}
+                          onOpen={onOpenSession}
+                          writes={writes}
+                        />
+                      ) : null;
+                    })}
+                  </SessionRun>
+                );
+              })
             )}
           </div>
           {/* Luke's own composer holds the panel's foot, under whatever the

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -107,6 +107,17 @@ export interface SessionAction {
   kind?: SessionControlKind;
 }
 
+/**
+ * The workspace a row's session is one chat of, when its provider nests them.
+ * The id is what rows are grouped by — always beside the provider id, because
+ * two providers' workspace ids share no namespace — and the name is what the
+ * group is titled.
+ */
+export interface DisplayWorkspace {
+  id: string;
+  name: string;
+}
+
 export interface DisplaySession {
   id: string;
   title: string;
@@ -141,6 +152,8 @@ export interface DisplaySession {
   canMessage: boolean;
   /** Actions the provider advertised for this session, in its own words. */
   actions: readonly SessionAction[];
+  /** The workspace this row is one chat of, when its provider nests them. */
+  workspace?: DisplayWorkspace;
 }
 
 /** One filter someone can choose, and how many sessions it would leave. */
@@ -280,6 +293,17 @@ export function displaySessions(
           openable: session.detail.link !== undefined,
           canMessage: session.canReceiveMessage,
           actions: session.controls,
+          // A workspace the provider left unnamed still groups its chats; the
+          // id is at least stable, where a made-up name would claim knowledge
+          // the provider never reported.
+          ...(session.workspace
+            ? {
+                workspace: {
+                  id: session.workspace.providerWorkspaceId,
+                  name: session.workspace.name ?? session.workspace.providerWorkspaceId,
+                },
+              }
+            : {}),
         };
       });
 
@@ -347,6 +371,82 @@ function filterOptions(sessions: readonly DisplaySession[]): readonly SessionFil
   ];
 }
 
+/** Whether two rows are chats of one workspace. The provider id rides the
+ * comparison because two providers' workspace ids share no namespace. */
+function sameWorkspace(first: DisplaySession, second: DisplaySession): boolean {
+  return (
+    first.workspace !== undefined &&
+    second.workspace !== undefined &&
+    first.providerId === second.providerId &&
+    first.workspace.id === second.workspace.id
+  );
+}
+
+/**
+ * Seats every workspace's chats together without disturbing what the sort
+ * decided: a workspace sits where its best-read chat sorted, and its other
+ * chats follow in their own sorted order, so the group is exactly as urgent —
+ * or as recent — as the chat that earned its seat. Ungrouped sessions keep
+ * their seats, and a group whose sibling would have sat between two strangers
+ * simply closes the gap.
+ */
+function seatWorkspacesTogether(sessions: readonly DisplaySession[]): readonly DisplaySession[] {
+  const seated: DisplaySession[] = [];
+  const taken = new Set<string>();
+  for (const session of sessions) {
+    if (taken.has(session.id)) continue;
+    taken.add(session.id);
+    seated.push(session);
+    if (!session.workspace) continue;
+    for (const sibling of sessions) {
+      if (taken.has(sibling.id) || !sameWorkspace(session, sibling)) continue;
+      taken.add(sibling.id);
+      seated.push(sibling);
+    }
+  }
+  return seated;
+}
+
+/**
+ * One stretch of the drawn list: a workspace's adjacent chats — the tray the
+ * panel draws around them, named once at its top — or a single ungrouped
+ * session. Runs are read off the arranged order rather than kept as state, so
+ * a re-sort that reseats a workspace can never leave a stale tray behind.
+ */
+export interface SessionListRun {
+  /** The tray's workspace; absent for a session no provider grouped. */
+  workspace?: DisplayWorkspace;
+  /** The checkout the tray's chats work in, when any of them reported one. */
+  repository?: string;
+  /** Indexes into the arranged list, adjacent and in order. */
+  indexes: readonly number[];
+}
+
+export function sessionListRuns(sessions: readonly DisplaySession[]): readonly SessionListRun[] {
+  const runs: SessionListRun[] = [];
+  for (let index = 0; index < sessions.length; index += 1) {
+    const session = sessions[index];
+    if (!session) continue;
+    const previous = index > 0 ? sessions[index - 1] : undefined;
+    const held = runs.at(-1);
+    if (held?.workspace && previous && sameWorkspace(session, previous)) {
+      const repository = held.repository ?? session.repository;
+      runs[runs.length - 1] = {
+        ...held,
+        ...(repository ? { repository } : {}),
+        indexes: [...held.indexes, index],
+      };
+      continue;
+    }
+    runs.push({
+      ...(session.workspace ? { workspace: session.workspace } : {}),
+      ...(session.workspace && session.repository ? { repository: session.repository } : {}),
+      indexes: [index],
+    });
+  }
+  return runs;
+}
+
 /**
  * The list as it is drawn. A chosen filter whose last session has since left —
  * an agent's only session finished, say — falls back to All rather than leaving
@@ -375,7 +475,7 @@ export function arrangeSessions(
   const matching = filter === view.filter ? chosen : sessions;
 
   return {
-    sessions: [...matching].sort(bySort(view.sort)),
+    sessions: seatWorkspacesTogether([...matching].sort(bySort(view.sort))),
     total: sessions.length,
     filter,
     options,

--- a/apps/desktop/src/renderer/session-motion.ts
+++ b/apps/desktop/src/renderer/session-motion.ts
@@ -53,6 +53,17 @@ export const SESSION_ROW_ID_ATTRIBUTE = "data-session-id";
 export const WING_SLOT_ID_ATTRIBUTE = "data-slot-id";
 
 /**
+ * How a workspace tray names itself to the measurement pass. A tray is a slot
+ * of the list in its own right: when a re-sort moves the whole group, the
+ * tray travels and its rows ride it — measured rows inside a measured tray
+ * are translated only by their movement within it, which is usually nothing.
+ * Without this the card would teleport to its new seat while its rows sprang
+ * from their old one, clipped invisible outside the box they had not yet
+ * caught up with.
+ */
+export const WORKSPACE_TRAY_ID_ATTRIBUTE = "data-tray-id";
+
+/**
  * How an element says it is on its way out, in either list. The fade it
  * announces is drawn here rather than in the stylesheet, because the element's
  * own opacity transition carries an entrance of its own — the row's
@@ -84,6 +95,12 @@ type MotionToken = (typeof MOTION_TOKEN)[keyof typeof MOTION_TOKEN];
 interface ReorderList {
   /** The attribute each element of this list names itself with. */
   idAttribute: string;
+  /**
+   * The attribute a group of this list's elements travels as one under, when
+   * the list has such groups at all. A grouped element's own travel is only
+   * its movement within the group; the group's element carries the rest.
+   */
+  groupAttribute?: string;
   /** The element's layout position along the axis the list stacks in. */
   offset: (element: HTMLElement) => number;
   /** A transform moving an element by so many pixels along that axis. */
@@ -100,6 +117,7 @@ interface ReorderList {
 /** The session list: rows stacked top to bottom, arriving the way the stack arrives. */
 const SESSION_LIST: ReorderList = {
   idAttribute: SESSION_ROW_ID_ATTRIBUTE,
+  groupAttribute: WORKSPACE_TRAY_ID_ATTRIBUTE,
   offset: (element) => element.offsetTop,
   translate: (px) => `translateY(${px}px)`,
   arrivesFromFan: true,
@@ -205,6 +223,7 @@ function elementVisible(element: HTMLElement): boolean {
 function useReorderMotion<T extends HTMLElement>(list: ReorderList): RefObject<T | null> {
   const listRef = useRef<T | null>(null);
   const baseline = useRef<Map<string, number> | undefined>(undefined);
+  const groupBaseline = useRef<Map<string, number> | undefined>(undefined);
   const baselineWidth = useRef<number | undefined>(undefined);
   const wasLeaving = useRef<Set<string>>(new Set());
   const exitFades = useRef<Map<string, Animation>>(new Map());
@@ -216,6 +235,7 @@ function useReorderMotion<T extends HTMLElement>(list: ReorderList): RefObject<T
     const container = listRef.current;
     if (container === null) {
       baseline.current = undefined;
+      groupBaseline.current = undefined;
       baselineWidth.current = undefined;
       wasLeaving.current = new Set();
       exitFades.current.clear();
@@ -232,6 +252,21 @@ function useReorderMotion<T extends HTMLElement>(list: ReorderList): RefObject<T
       if (id === null) continue;
       elements.set(id, element);
       positions.set(id, list.offset(element));
+    }
+
+    // The groups are slots too, measured in their own namespace: a group's
+    // travel is applied to the group's element, and the elements inside it
+    // are translated only by their movement within it — riding the group is
+    // the usual case, and it is a travel of nothing.
+    const groupElements = new Map<string, HTMLElement>();
+    const groupPositions = new Map<string, number>();
+    if (list.groupAttribute !== undefined) {
+      for (const element of container.querySelectorAll<HTMLElement>(`[${list.groupAttribute}]`)) {
+        const id = element.getAttribute(list.groupAttribute);
+        if (id === null) continue;
+        groupElements.set(id, element);
+        groupPositions.set(id, list.offset(element));
+      }
     }
 
     // Elements whose leaving mark changed this commit: the newly departed
@@ -254,6 +289,10 @@ function useReorderMotion<T extends HTMLElement>(list: ReorderList): RefObject<T
 
     const plan = planReorder(baseline.current, positions);
     baseline.current = positions;
+    // A group with no baseline is chrome that just appeared — its rows carry
+    // their own entrances — so only its travels are ever animated.
+    const groupPlan = planReorder(groupBaseline.current ?? new Map(), groupPositions);
+    groupBaseline.current = groupPositions;
     // Whether this commit moved the list's bound out from under it — the
     // wing's `--wing-bound` changing with the presentation is the one thing
     // that does. Elements measured against the anchored edge read that as the
@@ -270,6 +309,7 @@ function useReorderMotion<T extends HTMLElement>(list: ReorderList): RefObject<T
     baselineWidth.current = width;
     if (
       plan.travels.size === 0 &&
+      groupPlan.travels.size === 0 &&
       plan.arrivals.length === 0 &&
       departed.length === 0 &&
       returned.length === 0
@@ -336,9 +376,26 @@ function useReorderMotion<T extends HTMLElement>(list: ReorderList): RefObject<T
           });
         }
       }
+      for (const [id, from] of groupPlan.travels) {
+        const element = groupElements.get(id);
+        if (element !== undefined && elementVisible(element)) travel(element, from, 0);
+      }
+      // How far the group an element rides in is already travelling. Its own
+      // travel is what remains: usually nothing, because a group's elements
+      // move with it, and the remainder when they also reordered inside it.
+      const groupTravelOf = (element: HTMLElement): number => {
+        if (list.groupAttribute === undefined) return 0;
+        const group = element.closest<HTMLElement>(`[${list.groupAttribute}]`);
+        const groupId = group?.getAttribute(list.groupAttribute);
+        return groupId === null || groupId === undefined
+          ? 0
+          : (groupPlan.travels.get(groupId) ?? 0);
+      };
       for (const [id, from] of plan.travels) {
         const element = elements.get(id);
-        if (element !== undefined && elementVisible(element)) travel(element, from, 0);
+        if (element === undefined || !elementVisible(element)) continue;
+        const within = from - groupTravelOf(element);
+        if (Math.abs(within) > TRAVEL_EPSILON) travel(element, within, 0);
       }
       // The entrance waits only when it has something to wait for. The beat
       // exists so an arrival is never seen crossing a neighbour still leaving

--- a/apps/desktop/src/renderer/session-parts.tsx
+++ b/apps/desktop/src/renderer/session-parts.tsx
@@ -30,6 +30,23 @@ export function BranchGlyph(): React.JSX.Element {
   );
 }
 
+/**
+ * Rides beside a workspace's name to say what kind of thing the tray is. The
+ * shape is the tray itself in miniature — one box with its name line across
+ * the top — drawn in whatever text colour the line already has, like the
+ * branch glyph beside a branch.
+ */
+export function WorkspaceGlyph(): React.JSX.Element {
+  return (
+    <svg className="workspace-glyph" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+      <g fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round">
+        <rect x="2.2" y="2.8" width="11.6" height="10.4" rx="2.6" />
+        <path d="M2.8 6.5h10.4" />
+      </g>
+    </svg>
+  );
+}
+
 /** Leads a finished session's sentence, the way a spinner leads a working one. */
 export function CheckGlyph(): React.JSX.Element {
   return (

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1676,6 +1676,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
  * immediate, and the stagger below, so arriving fans out. A transition reads
  * its timing from the state being entered, which is what keeps the two apart. */
 .session-row,
+.workspace-tray,
 .settings-section,
 .settings-header,
 .quit-button,
@@ -1706,6 +1707,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 }
 
 .app-stage[data-presentation="panel"] .session-row,
+.app-stage[data-presentation="panel"] .workspace-tray,
 .app-stage[data-presentation="panel"] .settings-section,
 .app-stage[data-presentation="panel"] .settings-header,
 .app-stage[data-presentation="panel"] .quit-button,
@@ -1720,6 +1722,19 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 
   opacity: 1;
   transform: none;
+}
+
+/* Rows inside a workspace tray ride the tray's arrival. The tray is the
+   member of the stack in their stead — it fans in at its lead row's turn — so
+   a row inside it must not fan a second time within the card, which would
+   read as the chats sliding around inside their own tray. The hover pair
+   stays, because the tray answers nothing and its rows still do. */
+.workspace-tray .session-row {
+  opacity: 1;
+  transform: none;
+  transition:
+    border-color var(--duration-hover) ease,
+    background-color var(--duration-hover) ease;
 }
 
 /* A departing session's fade is drawn by session-motion rather than here: the

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -384,6 +384,112 @@ html[data-keyboard="true"] button.session-row:focus-visible {
   white-space: nowrap;
 }
 
+/* A workspace's chats sit in a tray: one card that visibly contains them,
+   named once at its top, its chats divided by hairlines inside. One border
+   does all the containing — the rows inside give up their own — so membership
+   is a fact of the drawing rather than an inference from a narrowed gap. The
+   tray must not be positioned: the reorder measurement reads each row's
+   offsetTop, and a positioned tray would become the offset parent and make a
+   row's position read as its place inside the tray instead of in the list. */
+.workspace-tray {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  border: 1px solid var(--hairline);
+  border-radius: 15px;
+  background: var(--card);
+  overflow: clip;
+}
+
+/* The same wrapper when its run earns no tray. It generates no box at all, so
+   the row inside is a flex child of the list exactly as a bare row was — the
+   wrapper exists only so a workspace crossing between one chat and several
+   never changes the row's parent, which would remount it and wipe a follow-up
+   being typed. */
+.session-run {
+  display: contents;
+}
+
+/* The tray's name line: the workspace's name on the left, and at the far end
+   the glyph leading the checkout. Everything here is in the panel's own face —
+   the line is what the user calls the work, not an identifier to be
+   consulted. */
+.workspace-tray-header {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 9px 14px 8px;
+  border-bottom: 1px solid var(--hairline);
+}
+
+.workspace-glyph {
+  width: 11px;
+  height: 11px;
+  flex: 0 0 auto;
+  color: var(--text-tertiary);
+}
+
+.workspace-tray-name {
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 560;
+  letter-spacing: -0.05px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-tray-meta {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 5px;
+  margin-left: auto;
+  color: var(--text-tertiary);
+  font-size: 10px;
+  white-space: nowrap;
+}
+
+/* Rows inside the tray hand their box to it: no border, no radius, no fill of
+   their own, a hairline seam between neighbours. The attention tint keeps its
+   ground — a chat that needs a person says so inside a tray exactly as loudly
+   as outside one — and hover keeps working through the rules the plain row
+   already has, because a borderless row's border-color simply draws nothing. */
+.workspace-tray .session-row {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.workspace-tray .session-row + .session-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.workspace-tray .session-row[data-state="attention"] {
+  background: color-mix(in srgb, var(--accent) 9%, transparent);
+}
+
+/* Hover inside the tray answers on the ground alone. The row hover rules
+   recolor `border-color`, and a nested chat's only border is the hairline
+   seam to the sibling above it — recolored, the second chat's seam would
+   flare on hover while the first chat, seamless under the header, showed no
+   border at all. The seam is furniture, so it holds still under every hover
+   path, the attention rows' included: each selector here outweighs the hover
+   rule it pins by exactly the tray class, so the grounds those rules raise
+   still land while the border colour stays the seam's own. */
+.workspace-tray button.session-row:hover,
+.workspace-tray button.session-row[data-state="attention"]:hover,
+.workspace-tray
+  .session-row[data-actions][data-openable]:hover:not(
+    :has(.row-compose:hover, .row-action:hover, .row-stop:hover)
+  ),
+.workspace-tray
+  .session-row[data-actions][data-openable][data-state="attention"]:hover:not(
+    :has(.row-compose:hover, .row-action:hover, .row-stop:hover)
+  ) {
+  border-color: rgba(255, 255, 255, 0.05);
+}
+
 /* What the session is doing, worded to carry the state. The glyph ahead of it
    answers at a glance — a spinner turning, a check — and the attention colour
    is spent here and nowhere else on the line, because a person being needed is

--- a/apps/desktop/tests/conductor-adapter.test.ts
+++ b/apps/desktop/tests/conductor-adapter.test.ts
@@ -303,10 +303,14 @@ test("observes cloud sessions the signed-in user created, under their own names"
   assert.deepEqual(CONDUCTOR_PROVIDER, { id: "conductor", displayName: "Conductor" });
   assert.equal(observations.length, 1);
   assert.equal(observations[0]?.providerSessionId, "session-working");
-  // Titled by the workspace, which carries the name the user knows the work
-  // by; the chat's generated name is not read, and the workspace name is not a
-  // branch, so no branch is reported at all.
-  assert.equal(observations[0]?.title, TEST_WORKSPACE_NAME);
+  // Titled by the chat's own name, grouped under the workspace's — the name
+  // the user knows the work by — and neither is a branch, so no branch is
+  // reported at all.
+  assert.equal(observations[0]?.title, TEST_SESSION_NAME);
+  assert.deepEqual(observations[0]?.workspace, {
+    providerWorkspaceId: "workspace-active",
+    name: TEST_WORKSPACE_NAME,
+  });
   assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
   assert.equal(observations[0]?.observedAt, TEST_TIME - 5_000);
   // A working session can be stopped and can take a message, both documented.
@@ -657,11 +661,11 @@ test("a refused transcripts read costs the recap and agent kind, never the pass"
   assert.equal(scopedKeyObservations[0]?.summary, undefined);
 });
 
-// Rows are titled by their workspace, so two chats in one workspace would draw
-// as identical lines that open different places. The workspace reports once,
-// in the state of whichever chat most needs a person — a failure over a
-// question, a question over work still running.
-test("reports one row per workspace, carried by the chat that most needs a person", async () => {
+// Every chat of a workspace is its own row, so no chat has to speak for a
+// sibling: a workspace holding a failure and work still running is two facts,
+// and each row reports its own state, opens its own place, and carries the
+// workspace as the group a surface seats them together by.
+test("reports every chat in a workspace, each grouped under it", async () => {
   const api = fakeConductorApi({
     userId: TEST_USER_ID,
     projects: [LUKE_PROJECT],
@@ -670,14 +674,14 @@ test("reports one row per workspace, carried by the chat that most needs a perso
       {
         id: "session-working",
         workspaceId: "workspace-shared",
-        name: TEST_SESSION_NAME,
+        name: "Revamp the notch panel",
         status: TEST_CONDUCTOR_STATUS.WORKING,
         statusUpdatedAt: TEST_TIME - 1_000,
       },
       {
         id: "session-errored",
         workspaceId: "workspace-shared",
-        name: TEST_SESSION_NAME,
+        name: "Chase the memory leak",
         status: TEST_CONDUCTOR_STATUS.ERROR,
         statusUpdatedAt: TEST_TIME - 5_000,
       },
@@ -685,14 +689,24 @@ test("reports one row per workspace, carried by the chat that most needs a perso
   });
 
   const observations = await adapterFor(api.fetch).observe();
+  const byId = new Map(observations.map((entry) => [entry.providerSessionId, entry]));
 
-  assert.equal(observations.length, 1);
-  assert.equal(observations[0]?.providerSessionId, "session-errored");
-  assert.equal(observations[0]?.status, SESSION_STATUS.ERROR);
-  assert.equal(observations[0]?.title, TEST_WORKSPACE_NAME);
-  // The row opens the chat it reports, not whichever chat happened to be
-  // listed first.
-  assert.equal(observations[0]?.detail?.link, "conductor://workspace?session=session-errored");
+  assert.equal(observations.length, 2);
+  assert.equal(byId.get("session-working")?.title, "Revamp the notch panel");
+  assert.equal(byId.get("session-working")?.status, SESSION_STATUS.WORKING);
+  assert.equal(byId.get("session-errored")?.title, "Chase the memory leak");
+  assert.equal(byId.get("session-errored")?.status, SESSION_STATUS.ERROR);
+  // Each row opens its own chat, and both carry the same workspace group.
+  assert.equal(
+    byId.get("session-errored")?.detail?.link,
+    "conductor://workspace?session=session-errored",
+  );
+  for (const observation of observations) {
+    assert.deepEqual(observation.workspace, {
+      providerWorkspaceId: "workspace-shared",
+      name: TEST_WORKSPACE_NAME,
+    });
+  }
 });
 
 test("does not carry a past failure into a session that recovered", async () => {
@@ -742,7 +756,7 @@ test("keeps an errored session errored after it goes stale", async () => {
   assert.equal(observations[0]?.status, SESSION_STATUS.ERROR);
 });
 
-test("separates sessions that share one project by their workspaces' names", async () => {
+test("titles each chat by its own name and its group by the workspace's", async () => {
   const api = fakeConductorApi({
     userId: TEST_USER_ID,
     projects: [LUKE_PROJECT],
@@ -751,8 +765,8 @@ test("separates sessions that share one project by their workspaces' names", asy
       { ...ownedWorkspace("workspace-two", TEST_TIME - 40_000), name: "porto-v1" },
     ],
     sessions: [
-      // Each chat carries a generated name, which must not become the title:
-      // the workspace's name is the one the user chose or accepted.
+      // The chat's name tells it from its siblings; the workspace's name — the
+      // one the user chose or accepted — names the group around it.
       {
         id: "session-one",
         workspaceId: "workspace-one",
@@ -772,16 +786,19 @@ test("separates sessions that share one project by their workspaces' names", asy
 
   assert.deepEqual(
     observations.map((observation) => observation.title),
+    ["Revamp the notch panel", "Observe Cursor cloud agents"],
+  );
+  assert.deepEqual(
+    observations.map((observation) => observation.workspace?.name),
     ["lisbon-v2", "porto-v1"],
   );
 });
 
-// The inverse trap of the one above: an open chat idle past the staleness
-// window decays to unknown, and an archived sibling reads as complete. The
-// open chat is still the one the user would return to, so it keeps the row —
-// a closed chat must not make the workspace read as finished, or take the
-// press that would have landed in the open one.
-test("a closed chat does not speak for a workspace whose open chat went quiet", async () => {
+// An open chat idle past the staleness window decays to unknown while an
+// archived sibling reads as complete. Both rows stand: the closed chat may say
+// it finished, but it says so beside the quiet open chat the user would return
+// to, never instead of it.
+test("a closed chat reports beside a quiet open one, not instead of it", async () => {
   const api = fakeConductorApi({
     userId: TEST_USER_ID,
     projects: [LUKE_PROJECT],
@@ -804,10 +821,11 @@ test("a closed chat does not speak for a workspace whose open chat went quiet", 
   });
 
   const observations = await adapterFor(api.fetch).observe();
+  const byId = new Map(observations.map((entry) => [entry.providerSessionId, entry]));
 
-  assert.equal(observations.length, 1);
-  assert.equal(observations[0]?.providerSessionId, "session-open-stale");
-  assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(observations.length, 2);
+  assert.equal(byId.get("session-open-stale")?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(byId.get("session-archived")?.status, SESSION_STATUS.COMPLETE);
 });
 
 test("reports an archived session as complete without requesting its status", async () => {
@@ -1051,12 +1069,12 @@ test("spreads a bounded session budget across workspaces", async () => {
   const observations = await adapterFor(api.fetch).observe();
   const observedIds = observations.map((observation) => observation.providerSessionId);
 
-  // The crowded workspace spent four of the session budget's slots on its
-  // chats — the cap is what kept it from spending all of them — but it still
-  // reports as one row beside its quiet neighbour.
-  assert.equal(observedIds.filter((id) => id.startsWith("crowded-")).length, 1);
+  // The crowded workspace holds four of the session budget's slots — the
+  // per-workspace cap is what kept it from spending all of them — and its
+  // quiet neighbour's chat still has a slot of its own.
+  assert.equal(observedIds.filter((id) => id.startsWith("crowded-")).length, 4);
   assert.equal(observedIds.includes("quiet-session"), true);
-  assert.equal(observations.length, 2);
+  assert.equal(observations.length, 5);
 });
 
 test("prefers open chats over closed ones inside one workspace", async () => {
@@ -1082,12 +1100,16 @@ test("prefers open chats over closed ones inside one workspace", async () => {
   });
 
   const observations = await adapterFor(api.fetch).observe();
+  const observedIds = observations.map((observation) => observation.providerSessionId);
 
-  // The open chat takes the budget ahead of the closed ones, and it is the one
-  // that speaks for the workspace: work still running outranks work settled.
-  assert.equal(observations.length, 1);
-  assert.equal(observations[0]?.providerSessionId, "open-session");
-  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
+  // The open chat takes a budget slot ahead of the closed ones: the
+  // per-workspace cap trims the oldest closed chat, never the one still going.
+  assert.equal(observations.length, 4);
+  assert.equal(observedIds.includes("open-session"), true);
+  assert.equal(
+    observations.find((entry) => entry.providerSessionId === "open-session")?.status,
+    SESSION_STATUS.WORKING,
+  );
 });
 
 test("reports nothing and issues no request without an API key", async () => {
@@ -1277,17 +1299,19 @@ test("keeps observing when one session's status cannot be read", async () => {
   });
 
   const observations = await adapterFor(api.fetch).observe();
+  const byId = new Map(observations.map((entry) => [entry.providerSessionId, entry]));
 
-  // One chat's unreadable status does not cost the workspace its row, and the
-  // chat whose state is known is the one that speaks for it.
-  assert.equal(observations.length, 1);
-  assert.equal(observations[0]?.providerSessionId, "session-readable");
-  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
+  // One chat's unreadable status costs nobody a row: the readable sibling
+  // reports what it knows, and the unreadable one stands as unknown rather
+  // than being dropped as though it were not there.
+  assert.equal(observations.length, 2);
+  assert.equal(byId.get("session-readable")?.status, SESSION_STATUS.WORKING);
+  assert.equal(byId.get("session-unreadable")?.status, SESSION_STATUS.UNKNOWN);
 });
 
 test("advertises a message for any open chat and a stop only while one works", async () => {
-  // One workspace per chat: a workspace is one row, reported through its
-  // neediest chat, so each state under test needs a workspace of its own.
+  // One workspace per chat, so each state under test reads on its own row
+  // without any sibling beside it.
   const api = fakeConductorApi({
     userId: TEST_USER_ID,
     projects: [LUKE_PROJECT],

--- a/apps/desktop/tests/session-model.test.ts
+++ b/apps/desktop/tests/session-model.test.ts
@@ -17,6 +17,7 @@ import {
   observedAgoLabel,
   SESSION_FILTER,
   SESSION_SORT,
+  sessionListRuns,
   sessionTally,
   tallyCaption,
   tallySummary,
@@ -55,6 +56,7 @@ test("the most urgent sessions are listed first in either data source", () => {
     SESSION_STATE.ATTENTION,
     SESSION_STATE.WORKING,
     SESSION_STATE.WORKING,
+    SESSION_STATE.WORKING,
     SESSION_STATE.COMPLETE,
     SESSION_STATE.UNKNOWN,
   ]);
@@ -78,7 +80,7 @@ test("a row carries where its session runs, from either data source", () => {
   );
 
   assert.equal(fixture.get("cursor-agent"), SESSION_LOCATION.CLOUD);
-  assert.equal(fixture.get("conductor-workspace"), SESSION_LOCATION.CLOUD);
+  assert.equal(fixture.get("conductor-chat-tidy"), SESSION_LOCATION.CLOUD);
   assert.equal(fixture.get("codex-bootstrap"), SESSION_LOCATION.LOCAL);
 
   const live = displaySessions(bootstrap(false), [
@@ -141,7 +143,7 @@ test("the line under the title says the state when the provider said nothing", (
   assert.equal(spoken?.detail, "Running tests");
 
   // The fixture's silent row proves the same fallback in the visual evidence.
-  const conductor = FIXTURE_SESSIONS.find((session) => session.id === "conductor-workspace");
+  const conductor = FIXTURE_SESSIONS.find((session) => session.id === "conductor-chat-tidy");
   assert.equal(conductor?.detail, "Complete");
 });
 
@@ -206,27 +208,28 @@ test("the tally counts per state and per provider", () => {
   assert.deepEqual(
     { ...tally, providers: undefined },
     {
-      total: 5,
+      total: 6,
       attention: 1,
       // Named as well as counted: Luke's face reacts to a session that has just
       // started asking, which the count alone cannot report.
       attentionIds: ["claude-review"],
-      working: 2,
+      working: 3,
       complete: 1,
       idle: 1,
       state: SESSION_STATE.ATTENTION,
       providers: undefined,
     },
   );
-  // Providers follow the order their most urgent session takes, so Cursor's
-  // working agent is listed ahead of Conductor's completed session and Devin's
-  // suspended one. Five is one more than the wings hold, so the fixture also
-  // proves the remainder is counted rather than dropped.
+  // Providers follow the order their most urgent session takes, so Conductor's
+  // working chat seats it ahead of Cursor's older one and Devin's suspended
+  // session — and its two chats count as two sessions under one mark. Five is
+  // one more than the wings hold, so the fixture also proves the remainder is
+  // counted rather than dropped.
   assert.deepEqual(tally.providers, [
     { providerId: PROVIDER_ID.CLAUDE_CODE, provider: "Claude Code", total: 1, attention: 1 },
     { providerId: PROVIDER_ID.CODEX, provider: "Codex", total: 1, attention: 0 },
+    { providerId: PROVIDER_ID.CONDUCTOR, provider: "Conductor", total: 2, attention: 0 },
     { providerId: PROVIDER_ID.CURSOR, provider: "Cursor", total: 1, attention: 0 },
-    { providerId: PROVIDER_ID.CONDUCTOR, provider: "Conductor", total: 1, attention: 0 },
     { providerId: PROVIDER_ID.DEVIN, provider: "Devin", total: 1, attention: 0 },
   ]);
 });
@@ -272,7 +275,7 @@ test("the caption names its own number so the count is never misread", () => {
   const tally = sessionTally(displaySessions(bootstrap(true), []));
 
   assert.equal(tallyCaption(tally), "1 needs you");
-  assert.equal(tallySummary(tally), "5 sessions tracked, 1 needing you");
+  assert.equal(tallySummary(tally), "6 sessions tracked, 1 needing you");
   assert.equal(tallyCaption({ ...tally, attention: 2 }), "2 need you");
   assert.equal(tallyCaption({ ...tally, attention: 0, working: 3 }), "3 working");
   assert.equal(tallyCaption({ ...tally, attention: 0, working: 0 }), "1 complete");
@@ -285,9 +288,9 @@ test("the filters offered run from everything to one agent, counted", () => {
   const list = arrangeSessions(FIXTURE_SESSIONS, DEFAULT_SESSION_VIEW);
 
   assert.deepEqual(list.options, [
-    { filter: SESSION_FILTER.ALL, label: "All", count: 5 },
+    { filter: SESSION_FILTER.ALL, label: "All", count: 6 },
     { filter: SESSION_FILTER.LOCAL, label: "Local", count: 2 },
-    { filter: SESSION_FILTER.CLOUD, label: "Cloud", count: 3 },
+    { filter: SESSION_FILTER.CLOUD, label: "Cloud", count: 4 },
     {
       filter: PROVIDER_ID.CLAUDE_CODE,
       label: "Claude Code",
@@ -298,7 +301,7 @@ test("the filters offered run from everything to one agent, counted", () => {
     {
       filter: PROVIDER_ID.CONDUCTOR,
       label: "Conductor",
-      count: 1,
+      count: 2,
       providerId: PROVIDER_ID.CONDUCTOR,
     },
     { filter: PROVIDER_ID.CURSOR, label: "Cursor", count: 1, providerId: PROVIDER_ID.CURSOR },
@@ -378,15 +381,15 @@ test("a filter narrows the list without changing what is tracked", () => {
 
   assert.deepEqual(
     cloud.sessions.map((session) => session.id),
-    ["cursor-agent", "conductor-workspace", "devin-session"],
+    ["conductor-chat-package", "conductor-chat-tidy", "cursor-agent", "devin-session"],
   );
   assert.deepEqual(
     agent.sessions.map((session) => session.id),
     ["claude-review"],
   );
   assert.equal(cloud.filter, SESSION_FILTER.CLOUD);
-  assert.equal(cloud.total, 5);
-  assert.equal(agent.total, 5);
+  assert.equal(cloud.total, 6);
+  assert.equal(agent.total, 6);
 });
 
 test("a filter whose last session has left falls back to showing everything", () => {
@@ -486,13 +489,30 @@ test("the two orderings answer different questions about the same sessions", () 
     sort: SESSION_SORT.RECENCY,
   });
 
+  // In either order Conductor's two chats sit together: under urgency the
+  // working chat earns the seat and its finished sibling follows; under
+  // recency the finished chat, seen last, leads and the working one follows.
   assert.deepEqual(
     urgent.sessions.map((session) => session.id),
-    ["claude-review", "codex-bootstrap", "cursor-agent", "conductor-workspace", "devin-session"],
+    [
+      "claude-review",
+      "codex-bootstrap",
+      "conductor-chat-package",
+      "conductor-chat-tidy",
+      "cursor-agent",
+      "devin-session",
+    ],
   );
   assert.deepEqual(
     recent.sessions.map((session) => session.id),
-    ["conductor-workspace", "codex-bootstrap", "claude-review", "cursor-agent", "devin-session"],
+    [
+      "conductor-chat-tidy",
+      "conductor-chat-package",
+      "codex-bootstrap",
+      "claude-review",
+      "cursor-agent",
+      "devin-session",
+    ],
   );
 });
 
@@ -504,7 +524,7 @@ test("filtering leaves the chosen ordering in force", () => {
 
   assert.deepEqual(
     recentCloud.sessions.map((session) => session.id),
-    ["conductor-workspace", "cursor-agent", "devin-session"],
+    ["conductor-chat-tidy", "conductor-chat-package", "cursor-agent", "devin-session"],
   );
 });
 
@@ -518,6 +538,108 @@ test("sessions of one state are ordered by which moved most recently", () => {
     arrangeSessions(working, DEFAULT_SESSION_VIEW).sessions.map((session) => session.id),
     ["fresh", "stale"],
   );
+});
+
+const CONDUCTOR_PROVIDER = { id: PROVIDER_ID.CONDUCTOR, displayName: "Conductor" };
+
+test("chats of one workspace sit together and read as one tray run", () => {
+  const chatOf = (
+    id: string,
+    status: (typeof SESSION_STATUS)[keyof typeof SESSION_STATUS],
+    observedAt: number,
+  ) =>
+    normalizeSession(CONDUCTOR_PROVIDER, {
+      providerSessionId: id,
+      title: `Chat ${id}`,
+      status,
+      observedAt,
+      detail: { repository: "luke" },
+      workspace: { providerWorkspaceId: "workspace-lisbon", name: "lisbon-v2" },
+    });
+
+  const rows = displaySessions(bootstrap(false), [
+    chatOf("chat-asking", SESSION_STATUS.WAITING, 1_000),
+    liveSession(CODEX_PROVIDER, "codex-between", SESSION_STATUS.WORKING, 5_000),
+    chatOf("chat-finished", SESSION_STATUS.COMPLETE, 9_000),
+  ]);
+  const arranged = arrangeSessions(rows, DEFAULT_SESSION_VIEW).sessions;
+
+  // The finished chat would have sorted below the stranger; the run pulls it
+  // up beside its asking sibling instead, seated where that sibling earned.
+  assert.deepEqual(
+    arranged.map((session) => session.id),
+    ["chat-asking", "chat-finished", "codex-between"],
+  );
+  // The tray is one run holding both chats — carrying the checkout its header
+  // names — and the stranger is a run of one with no workspace at all.
+  assert.deepEqual(sessionListRuns(arranged), [
+    {
+      workspace: { id: "workspace-lisbon", name: "lisbon-v2" },
+      repository: "luke",
+      indexes: [0, 1],
+    },
+    { indexes: [2] },
+  ]);
+});
+
+test("a lone chat is a run of one, and namesake workspaces never join", () => {
+  // Two workspaces wearing one name: the id is what groups, so each stays a
+  // run of its own — drawn as a plain row, not a tray — rather than joining
+  // under the name they happen to share.
+  const chatOf = (id: string, workspaceId: string) =>
+    normalizeSession(CONDUCTOR_PROVIDER, {
+      providerSessionId: id,
+      title: `Chat ${id}`,
+      status: SESSION_STATUS.WORKING,
+      observedAt: 1_000,
+      workspace: { providerWorkspaceId: workspaceId, name: "lisbon-v2" },
+    });
+
+  const rows = displaySessions(bootstrap(false), [
+    chatOf("chat-one", "workspace-one"),
+    chatOf("chat-two", "workspace-two"),
+  ]);
+  const arranged = arrangeSessions(rows, DEFAULT_SESSION_VIEW).sessions;
+
+  assert.deepEqual(
+    sessionListRuns(arranged).map((run) => ({
+      workspaceId: run.workspace?.id,
+      indexes: run.indexes,
+    })),
+    [
+      { workspaceId: "workspace-one", indexes: [0] },
+      { workspaceId: "workspace-two", indexes: [1] },
+    ],
+  );
+});
+
+test("a row carries its workspace by name, falling back to the id", () => {
+  const [named] = displaySessions(bootstrap(false), [
+    normalizeSession(CONDUCTOR_PROVIDER, {
+      providerSessionId: "chat-named",
+      title: "Chat named",
+      status: SESSION_STATUS.WORKING,
+      observedAt: 1_000,
+      workspace: { providerWorkspaceId: "workspace-1", name: "lisbon-v2" },
+    }),
+  ]);
+  assert.deepEqual(named?.workspace, { id: "workspace-1", name: "lisbon-v2" });
+
+  const [unnamed] = displaySessions(bootstrap(false), [
+    normalizeSession(CONDUCTOR_PROVIDER, {
+      providerSessionId: "chat-unnamed",
+      title: "Chat unnamed",
+      status: SESSION_STATUS.WORKING,
+      observedAt: 1_000,
+      workspace: { providerWorkspaceId: "workspace-2" },
+    }),
+  ]);
+  assert.deepEqual(unnamed?.workspace, { id: "workspace-2", name: "workspace-2" });
+
+  const [ungrouped] = displaySessions(bootstrap(false), [
+    liveSession(CODEX_PROVIDER, "codex-1", SESSION_STATUS.WORKING),
+  ]);
+  assert.equal(ungrouped?.workspace, undefined);
 });
 
 test("a row offers writes only where its provider promised them", () => {

--- a/packages/sidecar-core/src/attention-prompt.ts
+++ b/packages/sidecar-core/src/attention-prompt.ts
@@ -17,6 +17,7 @@ const ATTENTION_INSTRUCTION_LINES: readonly string[] = [
   "- Default to silence when the update is routine, ambiguous, or merely continues work already underway.",
   `- A speaking summary is one short spoken sentence under ${maximumAttentionSummaryLength} characters. Say what the session needs, not merely that it changed.`,
   "- Prefer the session's own recap and title over its status when deciding what to say; the status alone is rarely worth an interruption.",
+  "- When the update names a workspace, the session is one chat of it. Name the workspace in a speaking summary — it is the name the developer knows the work by — and the chat only when it tells siblings apart.",
   "- An error means the session stopped and cannot restart itself. Say what stopped it.",
   "- Use null for the summary whenever the disposition is silent.",
   "- Use only the fields in the update. You receive what a provider wrote about a session, never its transcript, file contents, or command output, so never imply you read any.",
@@ -38,6 +39,7 @@ export function attentionUpdateInput(update: AttentionUpdate): string {
   return [
     `Provider: ${update.providerName}`,
     `Session: ${update.title}`,
+    `Workspace: ${update.workspace ?? NONE_LABEL}`,
     `Trigger: ${update.trigger}`,
     `Previous status: ${update.previousStatus ?? NONE_LABEL}`,
     `Status: ${update.status}`,

--- a/packages/sidecar-core/src/attention.ts
+++ b/packages/sidecar-core/src/attention.ts
@@ -83,6 +83,13 @@ export interface AttentionUpdate extends SessionIdentity {
   trigger: AttentionTrigger;
   providerName: string;
   title: string;
+  /**
+   * The workspace the session is one chat of, by name, when its provider
+   * groups them. A deliberate widening: this name used to leave the machine as
+   * the title itself when a workspace was one row, and a readout that cannot
+   * say which workspace a chat belongs to cannot identify the work out loud.
+   */
+  workspace?: string;
   status: SessionStatus;
   previousStatus?: SessionStatus;
   summary?: string;
@@ -207,12 +214,14 @@ export function attentionUpdate(
   if (!trigger) return undefined;
 
   const context = attentionContext(session.detail);
+  const workspace = session.workspace?.name;
   return {
     providerId: session.providerId,
     providerSessionId: session.providerSessionId,
     trigger,
     providerName: session.provider.displayName,
     title: session.title,
+    ...(workspace ? { workspace } : {}),
     status: session.status,
     ...(previous ? { previousStatus: previous.status } : {}),
     ...(session.summary ? { summary: session.summary } : {}),

--- a/packages/sidecar-core/src/fixtures.ts
+++ b/packages/sidecar-core/src/fixtures.ts
@@ -15,6 +15,12 @@ export const SESSION_STATE = {
 
 export type SessionState = (typeof SESSION_STATE)[keyof typeof SESSION_STATE];
 
+/** The workspace a fixture row is one chat of, shaped as the surface draws it. */
+export interface WorkspaceSnapshot {
+  id: string;
+  name: string;
+}
+
 export interface SessionSnapshot {
   id: string;
   title: string;
@@ -44,6 +50,8 @@ export interface SessionSnapshot {
   canMessage?: boolean;
   /** Drawn only, like the composer: the controls a live session would show. */
   actions?: readonly SessionControl[];
+  /** The workspace this row is one chat of, when its provider nests them. */
+  workspace?: WorkspaceSnapshot;
 }
 
 export interface FixtureSnapshot {
@@ -95,24 +103,40 @@ const smokeFixture: FixtureSnapshot = {
       location: SESSION_LOCATION.LOCAL,
       observedAt: minutesBeforeEpoch(9),
     },
-    // The most recently observed session is also the least urgent one, so the
-    // fixture tells the two orderings apart rather than agreeing with both.
+    // Two Conductor chats of one workspace, titled by their own names and
+    // grouped under the workspace's — the name the user knows the work by,
+    // which never was a branch. The pair is what proves a run of chats joins
+    // into one card in the one screenshot the evidence is reviewed from.
     {
-      id: "conductor-workspace",
-      // Conductor sessions are titled by the workspace's own name — the name
-      // the user knows the work by — and carry no branch, because the
-      // workspace name never was one.
-      title: "lisbon-v2",
+      id: "conductor-chat-package",
+      title: "amber-shoal",
       providerId: PROVIDER_ID.CONDUCTOR,
       provider: "Conductor",
-      // A provider that reported no activity, failure, or recap: the surface
-      // words the state itself, and this row is what proves it does.
+      detail: "Packaging the macOS build.",
+      repository: "luke",
+      model: "claude-opus-5",
+      state: SESSION_STATE.WORKING,
+      location: SESSION_LOCATION.CLOUD,
+      observedAt: minutesBeforeEpoch(6),
+      workspace: { id: "conductor-lisbon", name: "lisbon-v2" },
+    },
+    // The complete chat is also the most recently observed session while being
+    // among the least urgent, so the fixture tells the two orderings apart
+    // rather than agreeing with both. A provider that reported no activity,
+    // failure, or recap: the surface words the state itself, and this row is
+    // what proves it does.
+    {
+      id: "conductor-chat-tidy",
+      title: "gentle-cove",
+      providerId: PROVIDER_ID.CONDUCTOR,
+      provider: "Conductor",
       detail: "",
       repository: "luke",
       model: "claude-opus-5",
       state: SESSION_STATE.COMPLETE,
       location: SESSION_LOCATION.CLOUD,
       observedAt: minutesBeforeEpoch(1),
+      workspace: { id: "conductor-lisbon", name: "lisbon-v2" },
     },
     {
       id: "cursor-agent",

--- a/packages/sidecar-core/src/realtime.ts
+++ b/packages/sidecar-core/src/realtime.ts
@@ -233,7 +233,8 @@ const REALTIME_INSTRUCTION_LINES: readonly string[] = [
   "- When you do not know something, say so in one sentence rather than guessing or hedging.",
   "",
   "What you can see:",
-  "- Only a session's provider, title, status, and a redacted summary.",
+  "- Only a session's provider, title, status, a redacted summary, and the workspace it is one chat of when its provider groups chats that way.",
+  "- Chats sharing a workspace are still separate sessions: each is opened, messaged, and controlled on its own, so say which chat you mean, not just whose workspace it is in.",
   "- The issue roster, when a tracker is connected: each tracked issue's identifier, title, and state.",
   "- You never receive transcripts, file contents, or command output, so never imply you read any.",
   "",
@@ -786,8 +787,9 @@ function sessionCapabilityText(session: NormalizedSession): string {
  * Renders the session roster the conversation is allowed to know about.
  *
  * These are the same bounded, redacted fields the attention layer already
- * sends — provider, title, status, and the provider's own summary — plus what
- * each session can be asked to do and the identity a tool call names it by.
+ * sends — provider, title, status, and the provider's own summary — plus the
+ * workspace a chat belongs to when its provider groups them, what each
+ * session can be asked to do, and the identity a tool call names it by.
  * No transcript, file path, or command output is ever included.
  */
 export function sessionContextText(sessions: readonly NormalizedSession[]): string {
@@ -796,17 +798,21 @@ export function sessionContextText(sessions: readonly NormalizedSession[]): stri
   const overflow = sessions.length - maximumVoiceContextSessions;
   return [
     "Currently observed sessions:",
-    ...sessions
-      .slice(0, maximumVoiceContextSessions)
-      .map((session) =>
-        [
-          `- ${session.provider.displayName}`,
-          session.title,
-          session.status,
-          session.summary ?? "no summary reported",
-          `[${sessionCapabilityText(session)}]`,
-        ].join(" — "),
-      ),
+    ...sessions.slice(0, maximumVoiceContextSessions).map((session) =>
+      [
+        `- ${session.provider.displayName}`,
+        session.title,
+        // The workspace tells siblings' chats apart out loud, so it rides
+        // beside the title wherever a provider named one — and only by its
+        // name: an internal workspace id identifies nothing out loud, so an
+        // unnamed workspace goes unmentioned rather than leaking the id off
+        // the machine, the same rule the attention update follows.
+        ...(session.workspace?.name ? [`a chat in workspace ${session.workspace.name}`] : []),
+        session.status,
+        session.summary ?? "no summary reported",
+        `[${sessionCapabilityText(session)}]`,
+      ].join(" — "),
+    ),
     // A session past the bound must read as unlisted, never as nonexistent:
     // denying a session the panel plainly shows teaches the user that Luke
     // cannot be asked about their work at all.

--- a/packages/sidecar-core/src/session.ts
+++ b/packages/sidecar-core/src/session.ts
@@ -147,6 +147,20 @@ export interface SessionDetail {
 }
 
 /**
+ * The place a provider groups several sessions under — a workspace holding
+ * more than one chat. It is identity plus a name, nothing else: the id is what
+ * a surface groups rows by and the name is what it titles the group, and a
+ * session without one is simply ungrouped. Only an adapter whose provider
+ * actually nests chats inside a shared workspace reports it; inventing a
+ * group around a provider's lone sessions would draw structure that is not
+ * there.
+ */
+export interface SessionWorkspace {
+  providerWorkspaceId: string;
+  name?: string;
+}
+
+/**
  * Provider-owned data observed for a session. Provider adapters are responsible
  * for observing without writing provider files, and for bounding every field
  * they report so one session cannot crowd out the rest of the panel.
@@ -184,6 +198,8 @@ export interface ProviderSessionObservation {
    * promised it, the way state an adapter kept on the side could.
    */
   spawnTarget?: string;
+  /** The workspace this session is one chat of, when its provider nests them. */
+  workspace?: SessionWorkspace;
 }
 
 /**
@@ -205,6 +221,8 @@ export interface NormalizedSession extends SessionIdentity {
   spawnableAgents: readonly string[];
   /** Where a started agent lands, when narrower than the session itself. */
   spawnTarget?: string;
+  /** The workspace this session is one chat of, when its provider nests them. */
+  workspace?: SessionWorkspace;
   attention: AttentionDecision;
 }
 
@@ -346,6 +364,21 @@ function normalizeSpawnableAgents(agents: readonly string[] | undefined): readon
   return [...unique];
 }
 
+/**
+ * The workspace a session reported around itself, or nothing. A workspace
+ * without an id cannot group anything, so it is dropped whole rather than
+ * kept as a group no sibling chat could ever be matched to.
+ */
+function normalizeWorkspace(workspace: SessionWorkspace | undefined): SessionWorkspace | undefined {
+  const providerWorkspaceId = boundedText(
+    workspace?.providerWorkspaceId,
+    maximumSessionDetailLength,
+  );
+  if (!providerWorkspaceId) return undefined;
+  const name = boundedText(workspace?.name, maximumSessionTitleLength);
+  return { providerWorkspaceId, ...(name ? { name } : {}) };
+}
+
 /** Normalizes the two-part identity used to locate a session in the registry. */
 export function normalizeSessionIdentity(identity: SessionIdentity): SessionIdentity {
   return {
@@ -392,6 +425,7 @@ export function normalizeSession(
   const observedAt = timestamp(observation.observedAt, "observedAt");
   const summary = boundedText(observation.summary, maximumSessionSummaryLength);
   const spawnTarget = boundedText(observation.spawnTarget, maximumSessionDetailLength);
+  const workspace = normalizeWorkspace(observation.workspace);
 
   return {
     providerId,
@@ -412,6 +446,7 @@ export function normalizeSession(
     canReceiveMessage: observation.canReceiveMessage === true,
     spawnableAgents: normalizeSpawnableAgents(observation.spawnableAgents),
     ...(spawnTarget ? { spawnTarget } : {}),
+    ...(workspace ? { workspace } : {}),
     attention: normalizeAttention(attention),
   };
 }

--- a/packages/sidecar-core/tests/attention.test.ts
+++ b/packages/sidecar-core/tests/attention.test.ts
@@ -98,6 +98,21 @@ test("derives an update only when a session reports something new", () => {
   );
 });
 
+test("the update names the workspace a chat belongs to, and only by its name", () => {
+  const grouped = session(claude, "chat", {
+    workspace: { providerWorkspaceId: "workspace-1", name: "lisbon-v2" },
+  });
+  // The name is the part a readout says; the id identifies nothing out loud
+  // and stays on the machine.
+  assert.equal(attentionUpdate(grouped)?.workspace, "lisbon-v2");
+
+  const unnamed = session(claude, "chat", {
+    workspace: { providerWorkspaceId: "workspace-1" },
+  });
+  assert.equal(attentionUpdate(unnamed)?.workspace, undefined);
+  assert.equal(attentionUpdate(session(claude, "chat"))?.workspace, undefined);
+});
+
 test("rejects model output that does not satisfy the decision contract", () => {
   assert.equal(attentionDecisionFromModel(undefined, DECIDED_AT), undefined);
   assert.equal(attentionDecisionFromModel("silent", DECIDED_AT), undefined);

--- a/packages/sidecar-core/tests/realtime.test.ts
+++ b/packages/sidecar-core/tests/realtime.test.ts
@@ -411,6 +411,52 @@ test("session context carries only bounded, redacted fields", () => {
   assert.doesNotMatch(linkedText, /https:/);
 });
 
+test("a chat carries its workspace in the roster, so siblings read apart out loud", () => {
+  const chat = normalizeSession(
+    { id: "conductor", displayName: "Conductor" },
+    {
+      providerSessionId: "chat-1",
+      title: "Revamp the notch panel",
+      status: SESSION_STATUS.WORKING,
+      observedAt: DECIDED_AT,
+      workspace: { providerWorkspaceId: "workspace-1", name: "lisbon-v2" },
+    },
+  );
+
+  const text = sessionContextText([chat]);
+
+  assert.match(text, /Revamp the notch panel/);
+  assert.match(text, /a chat in workspace lisbon-v2/);
+
+  // An unnamed workspace goes unmentioned rather than leaking its internal id
+  // off the machine: the id identifies nothing out loud.
+  const unnamed = normalizeSession(
+    { id: "conductor", displayName: "Conductor" },
+    {
+      providerSessionId: "chat-2",
+      title: "Chase the memory leak",
+      status: SESSION_STATUS.WORKING,
+      observedAt: DECIDED_AT,
+      workspace: { providerWorkspaceId: "workspace-internal-uuid" },
+    },
+  );
+  const unnamedText = sessionContextText([unnamed]);
+  assert.doesNotMatch(unnamedText, /workspace-internal-uuid/);
+  assert.doesNotMatch(unnamedText, /a chat in workspace/);
+
+  // A session no provider grouped says nothing about workspaces at all.
+  const ungrouped = normalizeSession(
+    { id: "claude-code", displayName: "Claude Code" },
+    {
+      providerSessionId: "session-b",
+      title: "checkout-service",
+      status: SESSION_STATUS.WORKING,
+      observedAt: DECIDED_AT,
+    },
+  );
+  assert.doesNotMatch(sessionContextText([ungrouped]), /workspace/);
+});
+
 test("an empty roster says so rather than implying Luke sees nothing at all", () => {
   assert.match(sessionContextText([]), /No coding-agent sessions/);
 });

--- a/packages/sidecar-core/tests/session-registry.test.ts
+++ b/packages/sidecar-core/tests/session-registry.test.ts
@@ -64,6 +64,30 @@ test("normalizes provider observations without conflating provider-local identit
   assert.equal(registry.list().length, 2);
 });
 
+test("a workspace grouping is bounded, and one without an id is dropped whole", () => {
+  const registry = new InMemorySessionRegistry();
+
+  const grouped = registry.upsert(
+    codex,
+    observation("run:grouped", 100, {
+      workspace: { providerWorkspaceId: "  workspace-1  ", name: "  lisbon-v2  " },
+    }),
+  );
+  assert.deepEqual(grouped.workspace, { providerWorkspaceId: "workspace-1", name: "lisbon-v2" });
+
+  // A workspace no sibling could ever be matched to groups nothing.
+  const unidentified = registry.upsert(
+    codex,
+    observation("run:unidentified", 100, {
+      workspace: { providerWorkspaceId: "   ", name: "lisbon-v2" },
+    }),
+  );
+  assert.equal(unidentified.workspace, undefined);
+
+  const ungrouped = registry.upsert(codex, observation("run:ungrouped", 100));
+  assert.equal(ungrouped.workspace, undefined);
+});
+
 test("a session takes messages only when its adapter said so explicitly", () => {
   const registry = new InMemorySessionRegistry();
   const identity = { providerId: codex.id, providerSessionId: "run:message" };


### PR DESCRIPTION
## Summary

- A Conductor workspace used to collapse to one row carried by whichever chat most needed a person, leaving its other chats invisible and unaddressable. The adapter now reports every chat as its own session — titled by the chat's own name, individually openable, messageable, and stoppable — stamped with a `workspace` grouping the core session model now carries (`SessionWorkspace`: provider workspace id + name, bounded like every other observed field).
- The panel draws a workspace's chats inside one tray: a single card named at its top by a workspace glyph and the workspace's name (regular face), with the repository in mono at the far end and the chats divided by hairlines inside. The tray seats where its best chat sorted (under urgency or recency alike), joins the arrival stack in its rows' stead so nothing fans twice, and stays unpositioned so the reorder measurement's `offsetTop` contract holds. A workspace holding one chat earns no tray — it stays a single row titled by the workspace, exactly the row it was before chats were drawn at all.
- Luke can now see the individual chats: the voice roster line names the workspace a chat belongs to (`a chat in workspace lisbon-v2`), the standing instructions say chats sharing a workspace are separate sessions to be addressed by chat, and the attention update carries the workspace name — a deliberate widening documented in `AttentionUpdate`, since that name previously left the machine as the row title itself. The panel guide fact teaches Luke to describe the grouped rows.
- The smoke fixture now holds two Conductor chats of one workspace (one working, one complete) so the evidence screenshot proves the card treatment, and PRIVACY.md / README.md describe the new field everywhere it travels.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (lint, typecheck, all tests, build) on Linux
- macOS Electron verification (`./scripts/verify.sh`): `not run` (authored in a Linux cloud workspace; see automated visual evidence below)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31846563811/artifacts/9236126059) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31846563811)

- Commit: `e2a9f9d4c23c47237789ce1f9617e21d024818f9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: the automated visual evidence should be inspected for the joined Conductor card (workspace overline on the leading row, seam corners between the two chats) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/69c7285b-ddbf-4a41-a296-b9e1e186cdbd)

