### PR TITLE
feat(voice): stop a reply on demand with an editable global stop key

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,17 +93,21 @@ One key runs it, and it answers from whatever app is frontmost:
 - **Tap** it instead — under a quarter of a second — to leave the turn open for
   a question too long to hold through. Tap again to send.
 - **Press while Luke is talking** to cut him off and take the turn back.
-- **Escape** discards an open turn instead of sending it, while the panel is the
-  frontmost window.
+- **`⌥S`** stops Luke mid-sentence and asks for nothing in its place — S is for
+  stop, and it answers from any app. **Escape** does the same while the panel
+  is the frontmost window, and discards an open turn instead of sending it.
 
-If another app already owns `⌥Space`, Luke falls back to `⌥S`. Settings shows
-which key you actually have, under **Keyboard shortcuts** — and the pencil
-beside it records a chord of your own: hold `⌃`, `⌥` or `⌘` — `⇧` may join,
-but not carry a chord alone, since `⇧S` is how capitals are typed — and press
-a letter or Space, as the row itself explains while it listens. The change takes effect
-at once, the reset arrow beside it returns the defaults, and if something else
-owns your chord Luke falls back to the defaults and shows the key that
-actually answered.
+Settings shows which keys you actually have — or an honest absence, if another
+app already owns a chord — under **Keyboard shortcuts**, one row each for the
+talk, ask, and stop keys. The pencil beside a row records a chord of your own:
+hold `⌃`, `⌥` or `⌘` — `⇧` may join, but not carry a chord alone, since `⇧S`
+is how capitals are typed — and press a letter or Space, as the row itself
+explains while it listens. The change takes effect at once, the reset arrow
+beside it returns the defaults, and if something else owns your chord Luke
+falls back to the defaults and shows the key that actually answered. The keys
+never compete for one chord: the stop key refuses a chord the other two hold,
+and a talk or ask key moved onto the stop key's chord wins it — the stop key
+stands down, and Escape remains its fallback.
 
 Holding is read by a small helper Luke ships beside the app, because Electron
 reports a global key being pressed but never released. The helper is told the

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -108,6 +108,8 @@ import {
   askHotkeyCandidates,
   askHotkeyReport,
   parseVoiceHotkey,
+  stopHotkeyCandidates,
+  stopHotkeyReport,
   VOICE_HOTKEY_ABSENCE,
   type VoiceHotkeyAbsence,
   voiceHotkeyCandidates,
@@ -401,17 +403,91 @@ function sendAskHotkey(): void {
   }
 }
 
+let stopHotkey: string | undefined;
+let chosenStopHotkey: string | undefined;
+
+/**
+ * Registers the key that stops a reply mid-sentence from whatever app is
+ * frontmost, on the ask key's exact terms: never during a capture run, never
+ * without a credential, and never on a chord the other two Luke keys could
+ * sit on — three keys must not compete any more than two, and the stop key
+ * is the one that yields, because it alone has Escape standing behind it.
+ * Electron's registration is enough here, because a stop has no release edge
+ * to hear. The press carries no decision of its own: the renderer's session
+ * answers whether there is a reply to stop, exactly as it answers Escape.
+ */
+function registerStopHotkey(): void {
+  // Re-runnable on the ask key's terms: moving another key registers afresh,
+  // and a chord that could not be re-taken must not still be claimed anywhere.
+  stopHotkey = undefined;
+  if (captureMode) {
+    process.stderr.write(`${stopHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.CAPTURE_RUN)}\n`);
+    return;
+  }
+  if (!realtimeCredentials) {
+    process.stderr.write(`${stopHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.NO_CREDENTIAL)}\n`);
+    return;
+  }
+  // Every chord the other two keys could sit on is taken, not just the ones
+  // they have announced: the talk key's helper falls back through its own
+  // candidates on its own clock, and the ask key re-registers behind it.
+  for (const accelerator of stopHotkeyCandidates(chosenStopHotkey, [
+    ...voiceHotkeyCandidates(chosenVoiceHotkey),
+    voiceHotkey,
+    ...askHotkeyCandidates(chosenAskHotkey, []),
+    askHotkey,
+  ])) {
+    const registered = globalShortcut.register(accelerator, () => {
+      voiceHostWindow()?.webContents.send(channels.stopHotkeyPress);
+    });
+    if (!registered) continue;
+    stopHotkey = accelerator;
+    process.stderr.write(`${stopHotkeyReport(stopHotkey, VOICE_HOTKEY_ABSENCE.ALREADY_OWNED)}\n`);
+    return;
+  }
+  process.stderr.write(`${stopHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.ALREADY_OWNED)}\n`);
+}
+
+/**
+ * Tells every renderer the stop key it should be describing, whenever that
+ * changes. An absence travels too, for the guide's sake: a chord that answers
+ * nothing must not be one Luke claims to have.
+ */
+function sendStopHotkey(): void {
+  for (const window of panelWindows.values()) {
+    window.webContents.send(channels.stopHotkeyChanged, stopHotkey);
+  }
+}
+
 /**
  * Moves the ask key to whatever `chosenAskHotkey` now says, while the app is
  * running. Only the ask key's own chord is let go of — the talk key's
  * registration must not flicker for a change that is none of its business —
  * and unlike the talk key there is no helper exit to wait for: Electron
- * releases a chord the moment it is asked to.
+ * releases a chord the moment it is asked to. The stop key is let go of and
+ * re-taken behind it, because the chord it may have is decided by where the
+ * ask key lands: an ask key moving onto Option-S must win it, and one moving
+ * off must give it back.
  */
 function applyAskHotkey(): void {
   if (askHotkey) globalShortcut.unregister(askHotkey);
+  if (stopHotkey) globalShortcut.unregister(stopHotkey);
   registerAskHotkey();
   sendAskHotkey();
+  registerStopHotkey();
+  sendStopHotkey();
+}
+
+/**
+ * Moves the stop key to whatever `chosenStopHotkey` now says, while the app
+ * is running. Only its own chord is let go of: the stop key is the bottom of
+ * the pecking order, so where it lands is decided by the other two keys and
+ * moving it can never oblige either of them to move.
+ */
+function applyStopHotkey(): void {
+  if (stopHotkey) globalShortcut.unregister(stopHotkey);
+  registerStopHotkey();
+  sendStopHotkey();
 }
 
 /**
@@ -462,6 +538,11 @@ async function applyVoiceHotkey(): Promise<void> {
   // its candidates — so it is re-taken now and the panel told what it teaches.
   registerAskHotkey();
   sendAskHotkey();
+  // The stop key went down with it and yields to both, so it goes last: a
+  // talk key moving onto Option-S must win the chord, and one moving off must
+  // give it back.
+  registerStopHotkey();
+  sendStopHotkey();
 }
 
 /** The mode every window is born in; only the dev and capture flags change it. */
@@ -932,6 +1013,7 @@ function registerIpc(): void {
       ...(voiceHotkey ? { voiceHotkey } : {}),
       voiceHotkeyHeld,
       ...(askHotkey ? { askHotkey } : {}),
+      ...(stopHotkey ? { stopHotkey } : {}),
       ...(outputAudio ? { outputAudio } : {}),
       display: displayDiagnostic(display),
       sessions: fixtureMode ? [] : sessionRegistry.snapshot().sessions,
@@ -1259,6 +1341,59 @@ function registerIpc(): void {
         if (!result.reason) {
           chosenAskHotkey = chosen;
           applyAskHotkey();
+        }
+        broadcastSettings(result.settings, event.sender);
+        return result;
+      } catch {
+        // A filesystem failure is not something the user can act on, so it is
+        // reported as one line rather than as a raw system error.
+        return {
+          settings: await settingsStore.snapshot(),
+          reason: "Could not save that shortcut on this system.",
+        };
+      }
+    },
+  );
+
+  // The stop key is the user's to move on the other two keys' exact terms,
+  // read through the same gate and registered at once. It sits at the bottom
+  // of the pecking order, so both standing rules point up: a chord the talk
+  // key or the ask key sits on — or could fall back to — is refused with
+  // words rather than stored and silently outbid.
+  ipcMain.handle(
+    channels.setStopHotkey,
+    async (event, accelerator: unknown): Promise<SettingsUpdateResult> => {
+      if (!trustedSender(event)) throw new Error("Untrusted renderer");
+      if (accelerator !== undefined && typeof accelerator !== "string") {
+        throw new Error("Invalid shortcut request");
+      }
+      const chosen = accelerator === undefined ? undefined : parseVoiceHotkey(accelerator);
+      if (accelerator !== undefined && chosen === undefined) {
+        throw new Error("Invalid shortcut request");
+      }
+      if (
+        chosen &&
+        (voiceHotkeyCandidates(chosenVoiceHotkey).includes(chosen) || chosen === voiceHotkey)
+      ) {
+        return {
+          settings: await settingsStore.snapshot(),
+          reason: "That chord is reserved for the talk key.",
+        };
+      }
+      if (
+        chosen &&
+        (askHotkeyCandidates(chosenAskHotkey, []).includes(chosen) || chosen === askHotkey)
+      ) {
+        return {
+          settings: await settingsStore.snapshot(),
+          reason: "That chord is reserved for the ask key.",
+        };
+      }
+      try {
+        const result = await settingsStore.setStopHotkey(chosen);
+        if (!result.reason) {
+          chosenStopHotkey = chosen;
+          applyStopHotkey();
         }
         broadcastSettings(result.settings, event.sender);
         return result;
@@ -2204,11 +2339,13 @@ if (!app.requestSingleInstanceLock()) {
     // read means no choice was kept, and the defaults answer.
     chosenVoiceHotkey = await settingsStore.readVoiceHotkey().catch(() => undefined);
     chosenAskHotkey = await settingsStore.readAskHotkey().catch(() => undefined);
+    chosenStopHotkey = await settingsStore.readStopHotkey().catch(() => undefined);
     // The report is not made here: the helper answers over its own stdout a
     // moment later, and a line printed now would state an absence that only
     // exists because nobody has answered yet.
     registerVoiceHotkey();
     registerAskHotkey();
+    registerStopHotkey();
     // Read-only, like everything else that watches: what it learns decides
     // what the renderer draws while Luke speaks unheard, and nothing more.
     startOutputVolumeWatch();

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -68,6 +68,8 @@ const bridge: AppBridge = {
     ipcRenderer.invoke(channels.setVoiceHotkey, accelerator) as Promise<SettingsUpdateResult>,
   setAskHotkey: (accelerator: string | undefined) =>
     ipcRenderer.invoke(channels.setAskHotkey, accelerator) as Promise<SettingsUpdateResult>,
+  setStopHotkey: (accelerator: string | undefined) =>
+    ipcRenderer.invoke(channels.setStopHotkey, accelerator) as Promise<SettingsUpdateResult>,
   setDuckOtherMedia: (enabled: boolean) =>
     ipcRenderer.invoke(channels.setDuckOtherMedia, enabled) as Promise<SettingsUpdateResult>,
   setVoiceExchangeActive: (active: boolean) => {
@@ -183,6 +185,17 @@ const bridge: AppBridge = {
       callback(accelerator);
     ipcRenderer.on(channels.askHotkeyChanged, listener);
     return () => ipcRenderer.removeListener(channels.askHotkeyChanged, listener);
+  },
+  onStopHotkeyPress: (callback: () => void) => {
+    const listener = () => callback();
+    ipcRenderer.on(channels.stopHotkeyPress, listener);
+    return () => ipcRenderer.removeListener(channels.stopHotkeyPress, listener);
+  },
+  onStopHotkeyChanged: (callback: (accelerator: string | undefined) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, accelerator: string | undefined) =>
+      callback(accelerator);
+    ipcRenderer.on(channels.stopHotkeyChanged, listener);
+    return () => ipcRenderer.removeListener(channels.stopHotkeyChanged, listener);
   },
   onOutputAudioChanged: (callback: (state: OutputAudioState | undefined) => void) => {
     const listener = (_event: Electron.IpcRendererEvent, state: OutputAudioState | undefined) =>

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -315,6 +315,8 @@ export function App(): React.JSX.Element {
    * own state follows.
    */
   const [askHotkeyChange, setAskHotkeyChange] = useState<{ accelerator?: string }>();
+  /** The stop key on the ask key's exact terms, for the guide's sake. */
+  const [stopHotkeyChange, setStopHotkeyChange] = useState<{ accelerator?: string }>();
   const [localStream, setLocalStream] = useState<MediaStream>();
   const [remoteStream, setRemoteStream] = useState<MediaStream>();
   const [voiceCaption, setVoiceCaption] = useState<string>();
@@ -1209,6 +1211,13 @@ export function App(): React.JSX.Element {
     return result.reason;
   }, []);
 
+  // The stop key, under the same rule again.
+  const changeStopHotkey = useCallback(async (accelerator: string | undefined) => {
+    const result = await window.sidecar.setStopHotkey(accelerator);
+    setSettings(result.settings);
+    return result.reason;
+  }, []);
+
   // True while a settings row is recording a chord. Both Luke keys stay
   // registered through a recording — the recording is how one gets replaced —
   // so a press of a current chord landing then is held here rather than
@@ -1664,9 +1673,10 @@ export function App(): React.JSX.Element {
   useEffect(() => {
     if (!bootstrap) return;
     const askAccelerator = askHotkeyChange ? askHotkeyChange.accelerator : bootstrap.askHotkey;
-    // Both keys reach the guide labelled: it is spoken and read, so a chord
-    // belongs there as the one word macOS writes it as rather than as the keys
-    // the panel draws apart.
+    const stopAccelerator = stopHotkeyChange ? stopHotkeyChange.accelerator : bootstrap.stopHotkey;
+    // All three keys reach the guide labelled: it is spoken and read, so a
+    // chord belongs there as the one word macOS writes it as rather than as
+    // the keys the panel draws apart.
     const talkKey = voiceHotkeyToShow(bootstrap, voiceHotkey);
     const guide = buildLukeGuide({
       settings: settings ?? bootstrap.settings,
@@ -1677,10 +1687,11 @@ export function App(): React.JSX.Element {
         held: talkKey.held,
       },
       ...(askAccelerator ? { askKey: voiceHotkeyLabel(askAccelerator) } : {}),
+      ...(stopAccelerator ? { stopKey: voiceHotkeyLabel(stopAccelerator) } : {}),
     });
     guideRef.current = guide;
     voiceSession.current?.updateGuide(guide);
-  }, [bootstrap, settings, microphoneStatus, voiceHotkey, askHotkeyChange]);
+  }, [bootstrap, settings, microphoneStatus, voiceHotkey, askHotkeyChange, stopHotkeyChange]);
 
   useEffect(() => {
     // An update Luke cannot voice — no call open, or a turn already under way —
@@ -1714,6 +1725,13 @@ export function App(): React.JSX.Element {
         voiceSession.current?.stopListening(false);
         return;
       }
+      // Stopping Luke mid-sentence is the same shape one layer on: a reply
+      // being spoken is the most open thing there is, and Escape asks for
+      // quiet without opening a turn in its place. The session itself answers
+      // whether there was a reply to stop, so a press that found none falls
+      // through to the layers below rather than being swallowed by a reply
+      // that had already ended.
+      if (voiceSession.current?.stopSpeaking()) return;
       // Escape out of the slot is the entry's own way out, wherever the caret
       // happens to be: the slot is the only thing on screen, so there is nothing
       // else it could mean.
@@ -1768,6 +1786,25 @@ export function App(): React.JSX.Element {
     () =>
       window.sidecar.onAskHotkeyChanged((accelerator) =>
         setAskHotkeyChange(accelerator ? { accelerator } : {}),
+      ),
+    [],
+  );
+  // The stop key asks for quiet from any app, exactly as Escape asks for it
+  // from the panel: the session itself answers whether there is a reply to
+  // stop, so a press over silence simply does nothing. It defers to a chord
+  // being recorded on the talk key's terms — the keystroke there is an answer
+  // to the field, not an ask of Luke.
+  useEffect(
+    () =>
+      window.sidecar.onStopHotkeyPress(() => {
+        if (!shortcutCapture.current) voiceSession.current?.stopSpeaking();
+      }),
+    [],
+  );
+  useEffect(
+    () =>
+      window.sidecar.onStopHotkeyChanged((accelerator) =>
+        setStopHotkeyChange(accelerator ? { accelerator } : {}),
       ),
     [],
   );
@@ -1845,6 +1882,7 @@ export function App(): React.JSX.Element {
         : undefined;
   const shownHotkey = voiceHotkeyToShow(bootstrap, voiceHotkey);
   const shownAskHotkey = askHotkeyChange ? askHotkeyChange.accelerator : bootstrap.askHotkey;
+  const shownStopHotkey = stopHotkeyChange ? stopHotkeyChange.accelerator : bootstrap.stopHotkey;
   // The muted evidence run is the speaking run with the hint drawn over it: a
   // capture has no system output to read, so the state is asked for directly.
   const fixtureMuted = bootstrap.profile === "muted";
@@ -1948,6 +1986,8 @@ export function App(): React.JSX.Element {
               // label the chord whole for the buttons beside them.
               ...(shownAskHotkey ? { askHotkey: shownAskHotkey } : {}),
               onAskHotkeyChange: changeAskHotkey,
+              ...(shownStopHotkey ? { stopHotkey: shownStopHotkey } : {}),
+              onStopHotkeyChange: changeStopHotkey,
               onShortcutCapture: changeShortcutCapture,
               onShowInMenuBarChange: changeShowInMenuBar,
               onShowInDockChange: changeShowInDock,

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -181,6 +181,9 @@ const SETTING_GUIDE: Record<
   // reasons: the fact carries the key that registered, and a chord is
   // recorded by typing it rather than saying it.
   askHotkey: () => undefined,
+  // Described in the stopping-a-reply fact instead, on the same terms as the
+  // other two keys' stored choices.
+  stopHotkey: () => undefined,
   // Not a switch but a set of keys, so it is described in the facts instead:
   // which providers are connected, and that a key is only ever typed by hand.
   credentialSources: () => undefined,
@@ -202,6 +205,11 @@ export interface LukeGuideInput {
   hotkey: { hotkey?: string; held: boolean };
   /** The ask key labelled on the same terms, absent when none was registered. */
   askKey?: string;
+  /**
+   * The stop key labelled on the same terms, absent when none was registered
+   * — another app owns Option-S, or another Luke key was moved onto it.
+   */
+  stopKey?: string;
 }
 
 function talkKeyFact(hotkey: LukeGuideInput["hotkey"]): AppGuideFact {
@@ -343,6 +351,19 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
     { label: "Microphone access", detail: MICROPHONE_DETAIL[input.microphoneStatus] },
     ...(input.voiceAvailable
       ? [
+          {
+            label: "Stopping a reply",
+            detail:
+              (input.stopKey
+                ? `${input.stopKey}, from any app, cuts the reply off and asks for nothing in ` +
+                  "its place; Escape does the same while Luke's panel has the keyboard."
+                : "Escape while Luke is speaking cuts the reply off and asks for nothing in " +
+                  "its place. No system-wide stop key is registered right now — another app " +
+                  "may own the shortcut.") +
+              " The talk key over a reply interrupts too, but takes the turn: the microphone " +
+              `opens with the same press. A different stop chord can be recorded, or the ` +
+              `default restored, in ${SETTINGS_TAB}.`,
+          },
           {
             label: "Muted output",
             detail:

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -641,6 +641,26 @@ export class RealtimeVoiceSession {
   }
 
   /**
+   * Cuts off the reply under way without opening anything in its place — the
+   * developer asking for quiet rather than for a turn. The cut is the same
+   * one talking or typing over Luke makes: silenced at once, cancelled, and
+   * trimmed to what was actually heard, so the next answer cannot refer back
+   * to words that never reached the room. Reports whether there was a reply
+   * to stop, so the key that asked keeps its other meanings when there was
+   * not.
+   */
+  stopSpeaking(): boolean {
+    if (this.#status !== REALTIME_STATUS.RESPONDING) return false;
+    this.#interruptReply();
+    // A stop opens no reply of its own, so the turn moves on here: a tool
+    // follow-up still awaiting its write finds an epoch that is no longer its
+    // own and stands down, rather than speaking over the quiet just asked for.
+    this.#turnEpoch += 1;
+    this.#setStatus(REALTIME_STATUS.READY);
+    return true;
+  }
+
+  /**
    * Voices a proactive update that the attention layer already approved,
    * reporting whether it could. A refusal is not a loss: the caller shows the
    * sentence instead, which is the same thing it does when voice is off. That

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -635,6 +635,10 @@ export class RealtimeVoiceSession {
     // the current turn's: a `response.done` that matches nothing can neither
     // act with the new turn's arming nor end the new turn early.
     this.#activeResponseId = undefined;
+    // The turn the arming belonged to is over with the reply. Every caller
+    // that opens a new developer turn arms it afresh in #startResponse; left
+    // true here, the cancelled reply's late calls would find it still standing.
+    this.#toolTurnArmed = false;
     this.#generationDone = false;
     this.#remoteQuiet = false;
     this.#clearSettleTimer();
@@ -933,6 +937,12 @@ export class RealtimeVoiceSession {
       if (typeof item?.id === "string") this.#responseItemId = item.id;
     }
     if (type === REALTIME_SERVER_EVENT.RESPONSE_CREATED) {
+      // Only a reply the session is still waiting on may be adopted. A
+      // confirmation arriving after the developer stopped or took the turn is
+      // the cancelled reply's own, landing late — the stop raced the server's
+      // confirmation — and adopting it would re-open the track over the quiet
+      // just asked for, and let its finished form read as the current reply's.
+      if (this.#status !== REALTIME_STATUS.RESPONDING) return;
       // The reply being asked for is under way, so anything arriving from here
       // belongs to it rather than to the one it replaced. Its name is what a
       // `response.done` must present to be read as this reply's: the channel

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -22,6 +22,7 @@ import {
 import {
   capturedVoiceHotkey,
   DEFAULT_ASK_HOTKEYS,
+  DEFAULT_STOP_HOTKEYS,
   DEFAULT_VOICE_HOTKEYS,
   VOICE_HOTKEY_CAPTURE,
   voiceHotkeyLabel,
@@ -134,8 +135,16 @@ export interface SettingsPanelProps {
    * refuses, and the row is where that answer belongs.
    */
   onAskHotkeyChange: (accelerator: string | undefined) => Promise<string | undefined>;
+  /** The stop key as registered, an accelerator on the talk key's terms. */
+  stopHotkey?: string;
   /**
-   * Whether a recording control has the keyboard. While one does, neither Luke
+   * Moves the stop key to a recorded chord, or back to the default when
+   * omitted, on the other rows' terms: the store answers with why when it
+   * refuses, and the row is where that answer belongs.
+   */
+  onStopHotkeyChange: (accelerator: string | undefined) => Promise<string | undefined>;
+  /**
+   * Whether a recording control has the keyboard. While one does, no Luke
    * key may act on its own press: the chord arriving is an entry, not an ask.
    */
   onShortcutCapture: (capturing: boolean) => void;
@@ -1087,6 +1096,9 @@ function ShortcutSection({
   askHotkey,
   askChosen,
   onAskHotkeyChange,
+  stopHotkey,
+  stopChosen,
+  onStopHotkeyChange,
   onShortcutCapture,
 }: {
   voiceHotkey?: string | undefined;
@@ -1096,6 +1108,9 @@ function ShortcutSection({
   askHotkey?: string | undefined;
   askChosen: boolean;
   onAskHotkeyChange: (accelerator: string | undefined) => Promise<string | undefined>;
+  stopHotkey?: string | undefined;
+  stopChosen: boolean;
+  onStopHotkeyChange: (accelerator: string | undefined) => Promise<string | undefined>;
   onShortcutCapture: (capturing: boolean) => void;
 }): React.JSX.Element {
   return (
@@ -1129,6 +1144,15 @@ function ShortcutSection({
         onChange={onAskHotkeyChange}
         onCapture={onShortcutCapture}
       />
+      <ShortcutRow
+        title="Stop Luke"
+        detail="Press to cut off a reply mid-sentence, from any app. Escape does the same here."
+        {...(stopHotkey ? { shown: stopHotkey } : {})}
+        chosen={stopChosen}
+        defaultKey={DEFAULT_STOP_HOTKEYS[0] ?? ""}
+        onChange={onStopHotkeyChange}
+        onCapture={onShortcutCapture}
+      />
     </section>
   );
 }
@@ -1157,6 +1181,8 @@ export function SettingsPanel({
   onVoiceHotkeyChange,
   askHotkey,
   onAskHotkeyChange,
+  stopHotkey,
+  onStopHotkeyChange,
   onShortcutCapture,
 }: SettingsPanelProps): React.JSX.Element {
   const microphone = microphoneAccessRow({ voiceAvailable, status: microphoneStatus });
@@ -1196,6 +1222,9 @@ export function SettingsPanel({
         {...(askHotkey ? { askHotkey } : {})}
         askChosen={settings?.askHotkey !== undefined}
         onAskHotkeyChange={onAskHotkeyChange}
+        {...(stopHotkey ? { stopHotkey } : {})}
+        stopChosen={settings?.stopHotkey !== undefined}
+        onStopHotkeyChange={onStopHotkeyChange}
         onShortcutCapture={onShortcutCapture}
       />
 

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -43,6 +43,7 @@ const SETTINGS_FIELD = {
   SHOW_IN_DOCK: "showInDock",
   SHOW_IN_MENU_BAR: "showInMenuBar",
   SHOW_ON_ALL_DISPLAYS: "showOnAllDisplays",
+  STOP_HOTKEY: "stopHotkey",
   VERSION: "version",
   VOICE: "voice",
   VOICE_CAPTIONS: "voiceCaptions",
@@ -128,6 +129,11 @@ interface PersistedSettings {
    * carried when this build cannot register it.
    */
   askHotkey?: string;
+  /**
+   * The stop-key chord the user chose, held to the same terms as the other
+   * two keys' choices.
+   */
+  stopHotkey?: string;
   /**
    * Whether Music and Spotify are turned down while a spoken exchange is
    * live. On unless the file says `false` outright — like the menu bar item,
@@ -231,6 +237,9 @@ function parsePersistedSettings(source: string): PersistedSettings {
   const storedAskHotkey = record[SETTINGS_FIELD.ASK_HOTKEY];
   const askHotkey =
     typeof storedAskHotkey === "string" ? parseVoiceHotkey(storedAskHotkey) : undefined;
+  const storedStopHotkey = record[SETTINGS_FIELD.STOP_HOTKEY];
+  const stopHotkey =
+    typeof storedStopHotkey === "string" ? parseVoiceHotkey(storedStopHotkey) : undefined;
   return {
     version: typeof version === "number" ? version : SETTINGS_FILE_VERSION,
     apiKeys: storedApiKeys(record),
@@ -245,6 +254,7 @@ function parsePersistedSettings(source: string): PersistedSettings {
     voiceCaptions: record[SETTINGS_FIELD.VOICE_CAPTIONS] === true,
     ...(voiceHotkey ? { voiceHotkey } : {}),
     ...(askHotkey ? { askHotkey } : {}),
+    ...(stopHotkey ? { stopHotkey } : {}),
     duckOtherMedia: record[SETTINGS_FIELD.DUCK_OTHER_MEDIA] !== false,
     showOnAllDisplays: record[SETTINGS_FIELD.SHOW_ON_ALL_DISPLAYS] === true,
     // A form this build does not draw is dropped like an unknown voice.
@@ -306,6 +316,7 @@ export class SettingsStore {
         ? { voiceHotkey: (await this.#load()).voiceHotkey }
         : {}),
       ...((await this.#load()).askHotkey ? { askHotkey: (await this.#load()).askHotkey } : {}),
+      ...((await this.#load()).stopHotkey ? { stopHotkey: (await this.#load()).stopHotkey } : {}),
       duckOtherMedia: (await this.#load()).duckOtherMedia,
       showOnAllDisplays: (await this.#load()).showOnAllDisplays,
       formFactor: (await this.#load()).formFactor ?? DEFAULT_PANEL_FORM_FACTOR,
@@ -465,6 +476,35 @@ export class SettingsStore {
       };
       if (accelerator) next.askHotkey = accelerator;
       else delete next.askHotkey;
+      await this.#write(next);
+      this.#loading = Promise.resolve(next);
+    });
+    return { settings: await this.snapshot() };
+  }
+
+  /**
+   * Main-process only, like the other two keys': the stop-key chord the user
+   * chose, for registration at startup, or nothing while the default stands.
+   */
+  async readStopHotkey(): Promise<string | undefined> {
+    return (await this.#load()).stopHotkey;
+  }
+
+  /**
+   * Stores the chosen stop-key chord, or returns to the default when omitted,
+   * on the other two keys' exact terms: the chord arrives already read into
+   * its one canonical spelling, and resetting is the absence of a choice.
+   */
+  async setStopHotkey(accelerator: string | undefined): Promise<SettingsUpdateResult> {
+    await this.#serialize(async () => {
+      const persisted = await this.#load();
+      if (persisted.stopHotkey === accelerator) return;
+      const next: PersistedSettings = {
+        ...persisted,
+        version: SETTINGS_FILE_VERSION,
+      };
+      if (accelerator) next.stopHotkey = accelerator;
+      else delete next.stopHotkey;
       await this.#write(next);
       this.#loading = Promise.resolve(next);
     });

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -103,6 +103,11 @@ export interface AppSettings {
    */
   askHotkey?: string;
   /**
+   * The stop-key chord the user chose, on the same terms as the other two:
+   * only whether there is a choice to reset, never the key the row shows.
+   */
+  stopHotkey?: string;
+  /**
    * Whether Music and Spotify are turned down while a spoken exchange is
    * live, and back up after. On by default: speech over music is the failure
    * everyone has had, and the duck defers to the user everywhere it can — it
@@ -217,6 +222,12 @@ export interface AppBootstrap {
    */
   askHotkey?: string;
   /**
+   * The accelerator that stops a reply mid-sentence from any app, absent when
+   * the system refused it or another Luke key sits on its chord. Raw for the
+   * same reason the other two are.
+   */
+  stopHotkey?: string;
+  /**
    * The output's switches as last read, absent until the helper's first line
    * arrives — or forever, where there is no helper to ask.
    */
@@ -307,6 +318,13 @@ export interface AppBridge {
    * stored and left to race it.
    */
   setAskHotkey(accelerator: string | undefined): Promise<SettingsUpdateResult>;
+  /**
+   * Moves the stop key the same way, or back to its default when omitted,
+   * under the same standing rule one rung further down: a chord either other
+   * Luke key holds — or could fall back to — is refused with a reason rather
+   * than stored and left to race it.
+   */
+  setStopHotkey(accelerator: string | undefined): Promise<SettingsUpdateResult>;
   /**
    * Opens an observed session where its provider keeps it. The renderer names
    * the session rather than its address, for the same reason it names a
@@ -418,6 +436,18 @@ export interface AppBridge {
    */
   onAskHotkeyChanged(callback: (accelerator: string | undefined) => void): () => void;
   /**
+   * The stop key going down, from whatever app happened to be frontmost. The
+   * press carries no decision: the renderer's session answers whether there
+   * is a reply to stop, exactly as Escape's press does.
+   */
+  onStopHotkeyPress(callback: () => void): () => void;
+  /**
+   * The stop key being re-taken, on the ask key's terms: moving another Luke
+   * key can put it up, take it down, or leave it — and an absence must reach
+   * the guide, or Luke describes a chord that answers nothing.
+   */
+  onStopHotkeyChanged(callback: (accelerator: string | undefined) => void): () => void;
+  /**
    * The output's switches changing under the user's own hand — or becoming
    * unreadable, which arrives as `undefined` and must be drawn as audible.
    */
@@ -436,6 +466,7 @@ export const channels = {
   setVoiceCaptions: "app:set-voice-captions",
   setVoiceHotkey: "app:set-voice-hotkey",
   setAskHotkey: "app:set-ask-hotkey",
+  setStopHotkey: "app:set-stop-hotkey",
   setDuckOtherMedia: "app:set-duck-other-media",
   setVoiceExchange: "app:set-voice-exchange",
   openProviderApiKeys: "app:open-provider-api-keys",
@@ -458,6 +489,8 @@ export const channels = {
   voiceHotkeyRelease: "app:voice-hotkey-release",
   voiceHotkeyChanged: "app:voice-hotkey-changed",
   askHotkeyChanged: "app:ask-hotkey-changed",
+  stopHotkeyPress: "app:stop-hotkey-press",
+  stopHotkeyChanged: "app:stop-hotkey-changed",
   outputAudioChanged: "app:output-audio-changed",
   rendererReady: "app:renderer-ready",
   lifecycle: "app:lifecycle",

--- a/apps/desktop/src/shared/voice-hotkey.ts
+++ b/apps/desktop/src/shared/voice-hotkey.ts
@@ -10,11 +10,41 @@
  * Tried in order when the user has not chosen one.
  *
  * Option-Space is where a macOS user reaches for a voice assistant —
- * Superwhisper, the ChatGPT desktop app and Alfred all sit there. Option-S is
- * Wispr Flow's default, and is the fallback for a machine where something
- * already owns Option-Space.
+ * Superwhisper, the ChatGPT desktop app and Alfred all sit there. It stands
+ * alone: Option-S used to be its fallback, and was given to the stop key
+ * instead — S is for stop, and a talk key that sometimes lands on the stop
+ * key's chord would make which key does what depend on what else is
+ * installed.
  */
-export const DEFAULT_VOICE_HOTKEYS: readonly string[] = ["Alt+Space", "Alt+S"];
+export const DEFAULT_VOICE_HOTKEYS: readonly string[] = ["Alt+Space"];
+
+/**
+ * The key that cuts off a reply being spoken, from whatever app is frontmost.
+ *
+ * Option-S because S is for stop, and Option-letter is the family the other
+ * Luke keys already live in. A sibling of Escape rather than of the talk key:
+ * it asks for quiet and nothing in its place, where the talk key over a reply
+ * interrupts by taking the turn.
+ */
+export const DEFAULT_STOP_HOTKEYS: readonly string[] = ["Alt+S"];
+
+/**
+ * The stop chords worth asking the system for, in order, on the ask key's
+ * exact terms: a chosen chord goes first — it is what the user asked for —
+ * with the default kept behind it, and any chord the other Luke keys could
+ * sit on is left out, because the keys must never compete for one chord —
+ * whichever registered first would silently cost the other its whole
+ * feature, with nothing on screen saying why.
+ */
+export function stopHotkeyCandidates(
+  chosen: string | undefined,
+  taken: readonly (string | undefined)[],
+): readonly string[] {
+  const candidates = chosen
+    ? [chosen, ...DEFAULT_STOP_HOTKEYS.filter((candidate) => candidate !== chosen)]
+    : DEFAULT_STOP_HOTKEYS;
+  return candidates.filter((candidate) => !taken.includes(candidate));
+}
 
 /**
  * The key that summons the ask field from whatever app is frontmost, tried in
@@ -335,4 +365,13 @@ export function voiceHotkeyReport(hotkey: string | undefined, absence: VoiceHotk
 export function askHotkeyReport(hotkey: string | undefined, absence: VoiceHotkeyAbsence): string {
   if (hotkey) return `Luke ask key: ${voiceHotkeyLabel(hotkey)}`;
   return `Luke ask key: unavailable — ${ABSENCE_REASONS[absence]}`;
+}
+
+/**
+ * The startup line for the stop key, completing the set: three keys, three
+ * lines, the same three causes of absence.
+ */
+export function stopHotkeyReport(hotkey: string | undefined, absence: VoiceHotkeyAbsence): string {
+  if (hotkey) return `Luke stop key: ${voiceHotkeyLabel(hotkey)}`;
+  return `Luke stop key: unavailable — ${ABSENCE_REASONS[absence]}`;
 }

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -48,6 +48,7 @@ function guideInput(overrides: Partial<LukeGuideInput> = {}): LukeGuideInput {
     microphoneStatus: "granted",
     hotkey: { hotkey: "⌥Space", held: true },
     askKey: "⌥L",
+    stopKey: "⌥S",
     ...overrides,
   };
 }
@@ -145,6 +146,29 @@ test("the facts describe creating a workspace, so Luke does not deny the capabil
   assert.match(rendered, /Creating workspaces/);
   // The refusal shape rides with the offer: only reported projects exist.
   assert.match(rendered, /Only reported projects/);
+});
+
+test("the facts describe stopping a reply, exactly where a reply can exist", () => {
+  const rendered = JSON.stringify(buildLukeGuide(guideInput()).facts);
+
+  assert.match(rendered, /Stopping a reply/);
+  // The registered key leads, and Escape rides with it: the stop key answers
+  // from any app, Escape only while the panel has the keyboard.
+  assert.match(rendered, /⌥S, from any app/);
+  assert.match(rendered, /Escape does the same/);
+  // Guiding the developer to the row is half of what the guide is for.
+  assert.match(rendered, /A different stop chord can be recorded/);
+
+  // No key registered — another app owns ⌥S, or a Luke key was moved onto
+  // it — leaves Escape as the whole of the capability, said honestly.
+  const keyless = JSON.stringify(buildLukeGuide(guideInput({ stopKey: undefined })).facts);
+  assert.match(keyless, /Escape while Luke is speaking/);
+  assert.match(keyless, /No system-wide stop key is registered/);
+
+  // Without a voice there is no reply to stop, so the fact would describe a
+  // key that does nothing.
+  const voiceless = JSON.stringify(buildLukeGuide(guideInput({ voiceAvailable: false })).facts);
+  assert.doesNotMatch(voiceless, /Stopping a reply/);
 });
 
 test("the facts follow the talk key, the microphone, and the storage the system offers", () => {

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -1048,6 +1048,120 @@ test("taking the turn cuts Luke off mid-reply", async () => {
   assert.equal(context.microphoneEnabled(), true);
 });
 
+test("a stop cuts the reply where it stands and opens nothing in its place", async () => {
+  let clock = 1_000;
+  const context = harness({ now: () => clock });
+  await context.session.connect();
+  context.deliverRemoteTrack();
+  context.session.beginTurn();
+  context.session.endTurn(true);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
+    item: { id: "item_reply" },
+  });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
+    item_id: "item_reply",
+    delta: "There are two sessions",
+  });
+  context.session.reportRemoteAudioActive();
+  clock = 2_500;
+  const before = context.sent.length;
+
+  assert.equal(context.session.stopSpeaking(), true);
+
+  // The cut is the same one talking over him makes — silenced at once,
+  // cancelled, and trimmed to the second and a half that was heard — but the
+  // turn ends there: no microphone opens and no reply is asked for.
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+  assert.equal(context.lukeAudible(), false);
+  assert.equal(context.microphoneEnabled(), false);
+  assert.equal(context.captions.at(-1), undefined);
+  const events = context.sent.slice(before);
+  assert.deepEqual(
+    events.map((event) => event.type),
+    [
+      REALTIME_CLIENT_EVENT.RESPONSE_CANCEL,
+      REALTIME_CLIENT_EVENT.OUTPUT_AUDIO_BUFFER_CLEAR,
+      REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_TRUNCATE,
+    ],
+  );
+  assert.equal(events.at(-1)?.audio_end_ms, 1_500);
+
+  // The next reply has to be audible again.
+  context.session.beginTurn();
+  context.session.endTurn(true);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED });
+  assert.equal(context.lukeAudible(), true);
+});
+
+test("a stop with nothing being spoken reports so and sends nothing", async () => {
+  const context = harness();
+  await context.session.connect();
+  const before = context.sent.length;
+
+  // Ready is not a reply, and neither is the developer's own open microphone:
+  // the key that asked keeps its other meanings.
+  assert.equal(context.session.stopSpeaking(), false);
+  context.session.startListening();
+  assert.equal(context.session.stopSpeaking(), false);
+  assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
+
+  assert.deepEqual(
+    context.sent.slice(before).map((event) => event.type),
+    [REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_CLEAR],
+  );
+});
+
+test("a stopped reply's tool follow-up stands down instead of speaking over the quiet", async () => {
+  let resolveCarry: ((outcome: Record<string, unknown>) => void) | undefined;
+  const context = harness({
+    carryAction: () =>
+      new Promise((resolve) => {
+        resolveCarry = resolve;
+      }),
+  });
+  await context.session.connect();
+  context.session.updateSessions([observedSession("session-a", { canReceiveMessage: true })]);
+  armDeveloperTurn(context);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-a" } });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: {
+      id: "resp-a",
+      output: [
+        {
+          type: "function_call",
+          name: "send_session_message",
+          call_id: "call-1",
+          arguments:
+            '{"provider_id":"claude-code","provider_session_id":"session-a","text":"add tests"}',
+        },
+      ],
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.ok(resolveCarry, "the write is under way when the stop lands");
+
+  // The developer asks for quiet while the write is still in flight.
+  assert.equal(context.session.stopSpeaking(), true);
+  const before = context.sent.length;
+  resolveCarry?.({ status: "accepted" });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  // The outcome is still delivered as an item, so the next turn has it — but
+  // no reply opens to voice it: the quiet just asked for holds.
+  const events = context.sent.slice(before);
+  assert.ok(
+    events.some(
+      (event) => (event.item as { type?: string } | undefined)?.type === "function_call_output",
+    ),
+  );
+  assert.ok(!events.some((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE));
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+});
+
 test("closing stops the microphone track", async () => {
   const context = harness();
   await context.session.connect();

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -1114,6 +1114,70 @@ test("a stop with nothing being spoken reports so and sends nothing", async () =
   );
 });
 
+test("a stop that races the reply's confirmation still holds", async () => {
+  const carried: unknown[] = [];
+  const context = harness({
+    carryAction: async (action) => {
+      carried.push(action);
+      return { status: "accepted" };
+    },
+  });
+  await context.session.connect();
+  context.deliverRemoteTrack();
+  context.session.updateSessions([observedSession("session-a", { canReceiveMessage: true })]);
+  // The stop lands in the gap between asking for the reply and the server
+  // confirming it: the cancel and the confirmation cross on the wire.
+  armDeveloperTurn(context);
+  assert.equal(context.session.stopSpeaking(), true);
+
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-a" } });
+
+  // The late confirmation is the cancelled reply's own. Adopting it would
+  // re-open the track over the quiet just asked for.
+  assert.equal(context.lukeAudible(), false);
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+
+  // And its finished form must not act: the turn its arming belonged to
+  // ended with the stop, however armed it was when the reply was asked for.
+  const before = context.sent.length;
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: {
+      id: "resp-a",
+      output: [
+        {
+          type: "function_call",
+          name: "send_session_message",
+          call_id: "call-late",
+          arguments:
+            '{"provider_id":"claude-code","provider_session_id":"session-a","text":"do it anyway"}',
+        },
+      ],
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.deepEqual(carried, []);
+  const events = context.sent.slice(before);
+  const output = events.find(
+    (event) => (event.item as { type?: string } | undefined)?.type === "function_call_output",
+  );
+  assert.equal(
+    (
+      JSON.parse((output?.item as { output?: string } | undefined)?.output ?? "{}") as {
+        status?: string;
+      }
+    ).status,
+    "refused",
+  );
+  assert.ok(!events.some((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE));
+
+  // The next reply the developer actually asks for is heard again.
+  context.session.sendText("what needs me?");
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-b" } });
+  assert.equal(context.lukeAudible(), true);
+});
+
 test("a stopped reply's tool follow-up stands down instead of speaking over the quiet", async () => {
   let resolveCarry: ((outcome: Record<string, unknown>) => void) | undefined;
   const context = harness({

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -920,16 +920,63 @@ test("ignores a stored ask-key chord this build cannot register", async (t) => {
   assert.equal((await store.snapshot()).askHotkey, undefined);
 });
 
-test("the two Luke keys survive each other's writes", async (t) => {
+test("stores the chosen stop-key chord on the other keys' terms and reads it back", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const cipher = countingCipher();
+  const store = storeIn(directory, { cipher });
+
+  assert.equal(await store.readStopHotkey(), undefined);
+  assert.equal((await store.snapshot()).stopHotkey, undefined);
+
+  const { settings, reason } = await store.setStopHotkey("Control+Alt+X");
+
+  assert.equal(reason, undefined);
+  assert.equal(settings.stopHotkey, "Control+Alt+X");
+  // A preference is not a credential, so choosing one never reaches the
+  // Keychain — and never raises its permission dialog.
+  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
+  assert.equal(await storeIn(directory).readStopHotkey(), "Control+Alt+X");
+});
+
+test("clearing the stop-key chord returns to no choice at all", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+
+  await store.setStopHotkey("Control+Alt+X");
+  const { settings } = await store.setStopHotkey(undefined);
+
+  assert.equal(settings.stopHotkey, undefined);
+  // Absent from the file rather than stored as an empty value: reset is the
+  // absence of a choice, and a reopened store must read it the same way.
+  assert.equal(await storeIn(directory).readStopHotkey(), undefined);
+});
+
+test("ignores a stored stop-key chord this build cannot register", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({ version: 2, apiKeys: {}, stopHotkey: "F13" }),
+  );
+  const store = storeIn(directory);
+
+  // A hand-edited chord the registrar would refuse is dropped rather than
+  // carried: honouring it would claim a key nothing was ever told about.
+  assert.equal(await store.readStopHotkey(), undefined);
+  assert.equal((await store.snapshot()).stopHotkey, undefined);
+});
+
+test("the three Luke keys survive each other's writes", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);
 
   await store.setVoiceHotkey("Control+Alt+Space");
   await store.setAskHotkey("Control+Alt+K");
+  await store.setStopHotkey("Control+Alt+X");
 
   const reopened = storeIn(directory);
   assert.equal(await reopened.readVoiceHotkey(), "Control+Alt+Space");
   assert.equal(await reopened.readAskHotkey(), "Control+Alt+K");
+  assert.equal(await reopened.readStopHotkey(), "Control+Alt+X");
 });
 
 test("the talk-key chord and a stored key survive each other's writes", async (t) => {

--- a/apps/desktop/tests/voice-hotkey.test.ts
+++ b/apps/desktop/tests/voice-hotkey.test.ts
@@ -5,8 +5,11 @@ import {
   askHotkeyReport,
   capturedVoiceHotkey,
   DEFAULT_ASK_HOTKEYS,
+  DEFAULT_STOP_HOTKEYS,
   DEFAULT_VOICE_HOTKEYS,
   parseVoiceHotkey,
+  stopHotkeyCandidates,
+  stopHotkeyReport,
   TALK_KEY_RELEASE,
   TALK_KEY_TAP_MS,
   talkKeyRelease,
@@ -20,9 +23,47 @@ import {
 } from "../src/shared/voice-hotkey";
 
 test("the default is the chord a macOS voice assistant is reached for", () => {
-  // Option-Space is where Superwhisper, the ChatGPT desktop app and Alfred sit;
-  // Option-S is Wispr Flow's default, for a machine where the first is taken.
-  assert.deepEqual(DEFAULT_VOICE_HOTKEYS, ["Alt+Space", "Alt+S"]);
+  // Option-Space is where Superwhisper, the ChatGPT desktop app and Alfred
+  // sit. It stands alone: Option-S belongs to the stop key now, and a talk
+  // key that sometimes fell back onto it would make which key does what
+  // depend on what else is installed.
+  assert.deepEqual(DEFAULT_VOICE_HOTKEYS, ["Alt+Space"]);
+});
+
+test("the stop key is Option-S, and yields any chord another Luke key could hold", () => {
+  // S is for stop, in the Option-letter family the other Luke keys live in —
+  // and never a chord they could sit on: three keys must not compete any more
+  // than two.
+  assert.deepEqual(DEFAULT_STOP_HOTKEYS, ["Alt+S"]);
+  for (const accelerator of DEFAULT_STOP_HOTKEYS) {
+    assert.ok(!DEFAULT_VOICE_HOTKEYS.includes(accelerator));
+    assert.ok(!DEFAULT_ASK_HOTKEYS.includes(accelerator));
+  }
+  assert.deepEqual(stopHotkeyCandidates(undefined, [undefined, undefined]), DEFAULT_STOP_HOTKEYS);
+  // A talk or ask key moved onto Option-S wins it; the stop key stands down
+  // rather than racing, because it alone has Escape standing behind it.
+  assert.deepEqual(stopHotkeyCandidates(undefined, ["Alt+Space", "Alt+S"]), []);
+});
+
+test("a chosen stop chord goes first, with the default kept behind it", () => {
+  assert.deepEqual(stopHotkeyCandidates("Control+Alt+X", [undefined]), [
+    "Control+Alt+X",
+    ...DEFAULT_STOP_HOTKEYS,
+  ]);
+  // A chosen chord that is itself the default is not offered twice.
+  assert.deepEqual(stopHotkeyCandidates("Alt+S", [undefined]), DEFAULT_STOP_HOTKEYS);
+  // The other keys outrank even a chosen chord: no two Luke keys compete.
+  assert.deepEqual(stopHotkeyCandidates("Control+Alt+X", ["Control+Alt+X"]), DEFAULT_STOP_HOTKEYS);
+});
+
+test("a missing stop key reports on the talk key's terms", () => {
+  assert.equal(stopHotkeyReport("Alt+S", VOICE_HOTKEY_ABSENCE.ALREADY_OWNED), "Luke stop key: ⌥S");
+  assert.match(
+    stopHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.ALREADY_OWNED),
+    /another app already owns it/,
+  );
+  assert.match(stopHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.CAPTURE_RUN), /capture run/);
+  assert.match(stopHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.NO_CREDENTIAL), /voice is off/);
 });
 
 test("the ask key is the talk key's sibling, never its rival", () => {
@@ -46,8 +87,11 @@ test("an ask candidate the talk key holds is not asked for", () => {
   // chord it holds simply stops being a candidate rather than being fought over.
   assert.deepEqual(askHotkeyCandidates(undefined, [undefined, undefined]), DEFAULT_ASK_HOTKEYS);
   assert.deepEqual(askHotkeyCandidates(undefined, ["Alt+L", undefined]), ["Alt+Shift+L"]);
-  // The talk key's own defaults hold nothing the ask key wants.
-  assert.deepEqual(askHotkeyCandidates(undefined, ["Alt+Space", "Alt+S"]), DEFAULT_ASK_HOTKEYS);
+  // The talk and stop keys' own defaults hold nothing the ask key wants.
+  assert.deepEqual(
+    askHotkeyCandidates(undefined, [...DEFAULT_VOICE_HOTKEYS, ...DEFAULT_STOP_HOTKEYS]),
+    DEFAULT_ASK_HOTKEYS,
+  );
 });
 
 test("a chosen ask chord goes first, with the defaults kept behind it", () => {
@@ -71,7 +115,7 @@ test("a chosen ask chord goes first, with the defaults kept behind it", () => {
   // chord on a talk-key default is filtered even before the helper has said
   // which of them it actually sits on.
   assert.deepEqual(
-    askHotkeyCandidates("Alt+S", [...DEFAULT_VOICE_HOTKEYS, undefined]),
+    askHotkeyCandidates("Alt+Space", [...DEFAULT_VOICE_HOTKEYS, undefined]),
     DEFAULT_ASK_HOTKEYS,
   );
 });
@@ -160,9 +204,9 @@ test("a chord the helper cannot register is refused rather than guessed at", () 
 
 test("a chosen chord is tried first and the defaults stay behind it", () => {
   assert.deepEqual(voiceHotkeyCandidates(undefined), DEFAULT_VOICE_HOTKEYS);
-  assert.deepEqual(voiceHotkeyCandidates("Command+L"), ["Command+L", "Alt+Space", "Alt+S"]);
+  assert.deepEqual(voiceHotkeyCandidates("Command+L"), ["Command+L", "Alt+Space"]);
   // Choosing a default outright must not ask the system for it twice.
-  assert.deepEqual(voiceHotkeyCandidates("Alt+S"), ["Alt+S", "Alt+Space"]);
+  assert.deepEqual(voiceHotkeyCandidates("Alt+Space"), ["Alt+Space"]);
 });
 
 test("a keystroke is read as a chord from the physical key", () => {


### PR DESCRIPTION
## Summary

- Luke could only be interrupted by taking the turn — talking or typing over him. A new public `RealtimeVoiceSession.stopSpeaking()` cuts the reply where it stands: the local track is silenced at once (buffered audio is dropped, not played out), the caption clears with the speech, the generation is cancelled, and the conversation record is trimmed to the words actually heard — and nothing opens in its place. A tool follow-up still in flight when the stop lands finds a new turn epoch and stands down rather than speaking over the quiet.
- **Escape** asks for it while Luke's panel has the keyboard — the sibling of Escape discarding an open microphone turn, one layer on. A new **global stop key** asks for it from any app: `⌥S` by default (S is for stop), registered on the ask key's terms — never during a capture run, never without a credential — and its press carries no decision; the renderer's session answers whether there is a reply to stop.
- The stop key is a third row under **Keyboard shortcuts**, recordable and resettable exactly like the talk and ask keys, its chosen chord stored beside theirs in the settings file. It sits at the bottom of the pecking order: it refuses a chord the other two keys hold or could fall back to ("reserved for the talk/ask key"), and a talk or ask key moved onto its chord wins it — the stop key stands down deterministically, with Escape behind it. `⌥S` therefore leaves the talk key's fallback list (`DEFAULT_VOICE_HOTKEYS` is `⌥Space` alone), so which key does what never depends on what else is installed.
- The guide learns all of it in the same change — the "Stopping a reply" fact carries the registered key, the honest absence, and the by-hand path — so a spoken question about stopping Luke gets a true answer. README's voice section documents the key and the precedence.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (717 tests, 0 failures)
- macOS Electron verification (`./scripts/verify.sh`): `not run locally — this change was authored in a Linux cloud workspace; CI's macOS job runs it`

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Manual verification worth doing on a Mac: while Luke is speaking, press `⌥S` from another app — the audio should cut immediately with no new turn opening; recording a chord onto the stop row should register at once, and trying to record the talk key's chord there should be refused with words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/2716c47c-ee62-4307-8da9-074a5cc3632e)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31838846571/artifacts/9233527666) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31838846571)

- Commit: `84f971b9b1132dbc98ea11e3bb483e8b09ce86b6`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
