### PR TITLE
feat(conductor): read the transcripts view for recaps and agent kinds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,11 @@ Trust constraints:
   composer — in a conversation the user is holding — each through the
   provider's own documented endpoint under the same user-supplied credential,
   and each validated against the observed roster before an adapter sees it.
-  Observation passes stay read-only by construction.
+  Observation passes stay read-only by construction; where a provider's
+  documented read answers only a POSTed query — Conductor's transcripts view,
+  like Linear's GraphQL — observation sends a read document fixed by the
+  build, and nothing enters that document's text but identifiers the same
+  pass reported, each validated against the shape its provider documents.
   Nothing that decides on the user's behalf may reach a write path: the
   attention evaluator above all, and every turn Luke opens himself — a
   proactive readout, the reply that voices a tool's outcome — which carries no
@@ -109,11 +113,23 @@ What Luke may show:
 - Label a session by what its provider named it, falling back to the workspace
   or repository only when there is no name yet. Do not compose a sentence in an
   adapter; report the fields and let the surface word them.
+- A recap may be the agent's own parting words. A provider that designates no
+  recap field but hands over the conversation itself — Conductor's transcripts
+  view — is read for a bounded tail of its transcript, and the last message's
+  words become the recap only when that message is attributably the agent's
+  and the chat is idle or closed: a settled turn's parting words say where the
+  work stands, where half a sentence mid-turn poses as an outcome. The tail is
+  inspected in memory and discarded — the bounded recap is all that is ever
+  reported, and the history behind it is never read at all.
 - An evaluator is the one place session material leaves the machine, so it is
   the one place with a narrower rule. It receives `AttentionContext` — what a
   provider wrote *about* a session — and never the transcript behind it: no
-  message history, file contents, or command output. Widening that set is a
-  product decision, not an implementation detail; make it deliberately.
+  message history, file contents, or command output. A recap counts as
+  *about* even when it is the agent's own parting words — the one bounded
+  line saying where the turn ended, the same standing as a recap a provider
+  designated — but the transcript it was read from never travels. Widening
+  that set is a product decision, not an implementation detail; make it
+  deliberately.
 
 Before handoff, run `./scripts/check.sh` for portable-only changes. For any
 macOS or UI change, `./scripts/verify.sh` is the completion invariant. Report

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -42,14 +42,23 @@ running on this machine are read from disk and are unaffected by whether a
 Cursor key exists.
 
 When a key is supplied, Luke sends it as a bearer credential to that provider,
-and observation issues authenticated `GET` requests only:
+and observation issues only reads: authenticated `GET` requests, plus — for
+Conductor — one fixed `SELECT` posted to its documented read-only query
+endpoint, under the same read-document boundary the Linear section below
+describes.
 
 - For Conductor, Luke reads the authenticated identity, projects, workspaces the
   authenticated user created, sessions, and session statuses. It processes
   identifiers; project, workspace, and session names; repository names derived
   from Git remotes (or the project name when no usable remote is available);
   timestamps; model configuration; archive state; status and reported errors;
-  and session deep links.
+  and session deep links. For the sessions it observed, Luke also queries
+  Conductor's transcripts view for each chat's agent kind and a bounded tail
+  of Conductor's own plain-text transcript. From that tail Luke takes only the
+  last message's words — and only while the chat is idle or closed and that
+  message is the agent's — as the session's recap. The tail is inspected in
+  memory and discarded, the transcript behind it is never requested, and
+  nothing but the bounded recap and agent kind is reported.
 - For Cursor, Luke reads agents owned by the supplied key and their latest runs,
   and — on a much slower cadence, within Cursor's documented limits — the list
   of repositories the key may launch agents in. It processes identifiers, agent
@@ -107,7 +116,8 @@ whose policies then govern the request and response data.
 ## Local display and microphone
 
 The local panel may show a session's provider-assigned title, status, current
-activity or error, provider-designated recap, repository, branch, model, and
+activity or error, recap — provider-designated, or for Conductor the agent's
+parting words read from its transcript — repository, branch, model, and
 session or change links. The links and model label are kept out of the optional
 attention-review request described below.
 
@@ -133,9 +143,11 @@ Realtime API over a direct WebRTC connection from your Mac, and plays back the
 spoken reply. OpenAI's policies govern that audio and the reply.
 
 Alongside the audio, Luke sends the same bounded session fields the attention
-review uses — provider name, session title, status, and the provider's own
-summary — so a spoken question about your sessions can be answered. No
-transcript, file content, or command output is ever included.
+review uses — provider name, session title, status, and each session's recap —
+so a spoken question about your sessions can be answered. No message history,
+file content, or command output is ever included: a recap can reflect what a
+session was asked and replied — for Conductor it is the agent's own parting
+words — but the conversation behind it never travels.
 
 Luke also sends the list of projects a new workspace could be created in —
 each project's provider, repository label, and provider-assigned identifier —
@@ -177,15 +189,16 @@ Without `OPENAI_API_KEY`, Luke does not send an attention-review request.
 With `OPENAI_API_KEY`, Luke sends the configured Responses-compatible endpoint
 the provider name, displayed session title, previous and current status, review
 trigger, repository, branch, current tool activity, reported error, and the
-provider-designated session recap. Titles and recaps can reflect task content;
-for a Conductor session, the title can contain the project-name fallback
-described above. The request also includes fixed review instructions and
-synthetic examples. The API key is sent to that endpoint as the request's bearer
-credential.
+session recap — provider-designated, or for Conductor the agent's parting
+words read from its transcript. Titles and recaps can reflect task and reply
+content; for a Conductor session, the title can contain the project-name
+fallback described above. The request also includes fixed review instructions
+and synthetic examples. The API key is sent to that endpoint as the request's
+bearer credential.
 
-Luke does not send message history, command output, file contents, full
-filesystem paths, model labels, session or change links, provider session
-identifiers, or locally observed timestamps in that request.
+Luke does not send message history beyond that recap, command output, file
+contents, full filesystem paths, model labels, session or change links,
+provider session identifiers, or locally observed timestamps in that request.
 
 Requests use `store: false`, which disables Responses application-state
 storage. This does not mean zero retention: ordinary provider abuse-monitoring

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -53,12 +53,12 @@ describes.
   from Git remotes (or the project name when no usable remote is available);
   timestamps; model configuration; archive state; status and reported errors;
   and session deep links. For the sessions it observed, Luke also queries
-  Conductor's transcripts view for each chat's agent kind and a bounded tail
-  of Conductor's own plain-text transcript. From that tail Luke takes only the
-  last message's words — and only while the chat is idle or closed and that
-  message is the agent's — as the session's recap. The tail is inspected in
-  memory and discarded, the transcript behind it is never requested, and
-  nothing but the bounded recap and agent kind is reported.
+  Conductor's transcripts view for each chat's agent kind, which speaker wrote
+  the transcript's last message, and — only when that speaker is the agent —
+  the bounded opening of that final message. Luke reports its words as the
+  session's recap only while the chat is idle or closed. The excerpt is
+  inspected in memory and discarded, the conversation behind it is never
+  requested, and nothing but the bounded recap and agent kind is reported.
 - For Cursor, Luke reads agents owned by the supplied key and their latest runs,
   and — on a much slower cadence, within Cursor's documented limits — the list
   of repositories the key may launch agents in. It processes identifiers, agent

--- a/apps/desktop/src/cloud-session-adapter.ts
+++ b/apps/desktop/src/cloud-session-adapter.ts
@@ -64,6 +64,13 @@ const DEFAULT_REQUEST_HEADERS: Readonly<Record<string, string>> = {
   Accept: "application/json",
 };
 
+/**
+ * The one body key a POSTed read document rides under. Linear's GraphQL and
+ * Conductor's transcripts view both name it `query`, and a provider that names
+ * it something else is asking for its own client rather than an option here.
+ */
+const READ_DOCUMENT_FIELD = "query";
+
 export const CLOUD_FAILURE = {
   UNAUTHORIZED: "unauthorized",
   TRANSIENT: "transient",
@@ -133,11 +140,18 @@ export interface CloudAdapterProfile {
  * but a read, so no observation pass built on it can change provider state.
  * The deadline can be widened only to the slow bound, and only for a read the
  * provider itself documents as slow.
+ *
+ * A read the provider answers only at a POSTed query endpoint — Conductor's
+ * transcripts view — names its document here, and the separation a GET gives
+ * for free is held the way the Linear tracker holds it: the document's text is
+ * fixed by the build, observation only ever sends a read, and an adapter
+ * interpolates nothing into it beyond identifiers the same pass reported, each
+ * validated against the shape its provider documents.
  */
 export type CloudRequest = (
   segments: readonly string[],
   query?: Readonly<Record<string, string>>,
-  options?: Readonly<{ timeoutMs?: number }>,
+  options?: Readonly<{ timeoutMs?: number; document?: string }>,
 ) => Promise<Record<string, unknown>>;
 
 /**
@@ -856,7 +870,7 @@ export abstract class CloudSessionAdapter
     apiKey: string,
     segments: readonly string[],
     query: Readonly<Record<string, string>> = {},
-    options: Readonly<{ timeoutMs?: number }> = {},
+    options: Readonly<{ timeoutMs?: number; document?: string }> = {},
   ): Promise<Record<string, unknown>> {
     const name = this.provider.displayName;
     // A widened deadline never widens past the slow bound: the option exists
@@ -865,14 +879,22 @@ export abstract class CloudSessionAdapter
       positiveInteger(options.timeoutMs, CLOUD_ADAPTER_DEFAULTS.REQUEST_TIMEOUT_MS),
       CLOUD_ADAPTER_DEFAULTS.SLOW_REQUEST_TIMEOUT_MS,
     );
+    // A read document rides as a POST because that is how its endpoint is
+    // documented, not because it writes: the body carries the document and
+    // nothing else, so the request can still express nothing but a read.
+    const document = options.document;
     let response: Response;
     try {
       response = await this.#fetch(this.#url(segments, query), {
-        method: HTTP_METHOD.GET,
+        method: document === undefined ? HTTP_METHOD.GET : HTTP_METHOD.POST,
         headers: {
           ...this.requestHeaders(),
           ...this.#authorizationHeaders(apiKey),
+          ...(document === undefined ? {} : { "Content-Type": "application/json" }),
         },
+        ...(document === undefined
+          ? {}
+          : { body: JSON.stringify({ [READ_DOCUMENT_FIELD]: document }) }),
         signal: AbortSignal.timeout(timeoutMs),
       });
     } catch {

--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -421,9 +421,13 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
 
     // The transcripts read rides beside the status reads: one bounded query
     // for every observed session, so a failed or missing answer costs a recap
-    // and an agent kind, never the pass.
+    // and an agent kind, never the pass. That holds even for a credential
+    // refusal: a key an org scopes away from the query endpoint alone still
+    // reads the roster, and the roster reads above are what judge the
+    // credential — so this one read swallows everything rather than letting
+    // an enrichment 403 clear every observed row.
     const [transcripts, reportedStatuses] = await Promise.all([
-      this.tolerateItemFailure(() => this.#sessionTranscripts(request, sessions)),
+      this.#sessionTranscripts(request, sessions).catch(() => undefined),
       Promise.all(
         sessions.map((session) =>
           // An archived session is a closed chat, so its state is already

--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -1,4 +1,5 @@
 import {
+  maximumSessionSummaryLength,
   maximumSessionTitleLength,
   type ProviderSessionObservation,
   SESSION_CONTROL_KIND,
@@ -48,6 +49,8 @@ const CONDUCTOR_DEFAULT_API_URL = "https://api.conductor.build";
 const CONDUCTOR_ROUTE = {
   IDENTITY: ["me"],
   PROJECTS: ["v0", "projects"],
+  /** The documented read-only query endpoint over the transcripts view. */
+  SQL: ["v0", "sql"],
 } as const;
 
 const CONDUCTOR_ROUTE_SEGMENT = {
@@ -131,6 +134,52 @@ const CONDUCTOR_FIELD = {
   USER_ID: "userId",
 } as const;
 
+/** The columns the transcripts read asks for, named as the view answers them. */
+const CONDUCTOR_SQL_FIELD = {
+  ROWS: "rows",
+  SESSION_ID: "session_id",
+  AGENT_TYPE: "agent_type",
+  TRANSCRIPT_TAIL: "transcript_tail",
+} as const;
+
+/**
+ * How much of a transcript's end is read: enough to hold the last message's
+ * header and a recap's worth of parting words, and no more of the history.
+ */
+const CONDUCTOR_TRANSCRIPT_TAIL_LENGTH = 2_000;
+
+/**
+ * The one query document this adapter ever sends, fixed by this build. The
+ * endpoint takes a read as a POSTed document rather than a GET, so the
+ * separation is held the way the Linear tracker holds it: observation only
+ * ever sends this SELECT, and nothing reaches its text but session ids the
+ * same pass reported — each validated as a UUID first, so no name, title, or
+ * message a provider controls can ever be spliced into the document.
+ *
+ * The columns ask for the agent kind and the transcript's bounded tail — the
+ * settled turn's parting words — and never the conversation behind them.
+ */
+const CONDUCTOR_READ_TRANSCRIPT_TAILS =
+  `SELECT ${CONDUCTOR_SQL_FIELD.SESSION_ID}, ${CONDUCTOR_SQL_FIELD.AGENT_TYPE}, ` +
+  `RIGHT(transcript, ${CONDUCTOR_TRANSCRIPT_TAIL_LENGTH}) AS ${CONDUCTOR_SQL_FIELD.TRANSCRIPT_TAIL} ` +
+  `FROM session_transcripts_view WHERE ${CONDUCTOR_SQL_FIELD.SESSION_ID} IN`;
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * How Conductor's plain-text transcript marks who is speaking. A line inside a
+ * message can imitate a header, so the parse can misattribute the tail of a
+ * chat whose agent wrote one — the cost is a recap dropped or drawn from the
+ * wrong words, never anything acted on.
+ */
+const CONDUCTOR_TRANSCRIPT_SPEAKER = {
+  USER: "## User",
+  ASSISTANT: "## Assistant",
+} as const;
+
+/** The view's own mark for history it left out of the concise transcript. */
+const CONDUCTOR_TRANSCRIPT_ELIDED = /^\[\d+ messages? elided\]$/;
+
 const CONDUCTOR_SESSION_STATUS = {
   IDLE: "idle",
   WORKING: "working",
@@ -182,12 +231,19 @@ const CONDUCTOR_ADAPTER_DEFAULTS = {
   MAXIMUM_OBSERVED_SESSIONS: 12,
   MAXIMUM_MODEL_LABEL_LENGTH: 60,
   MAXIMUM_ERROR_LENGTH: 120,
+  MAXIMUM_AGENT_KIND_LENGTH: 40,
 } as const;
 
 interface ConductorReportedStatus {
   status: ConductorSessionStatus | undefined;
   updatedAt: number | undefined;
   errorMessage?: string;
+}
+
+/** What the transcripts view said about one session: who runs it, and how it left off. */
+interface ConductorTranscript {
+  agentKind?: string;
+  recap?: string;
 }
 
 export const CONDUCTOR_PROVIDER: SessionProvider = {
@@ -226,7 +282,12 @@ interface ConductorSession {
  * Observes Conductor cloud sessions through the documented public API. It reads
  * only workspaces the authenticated user created, observation issues no request
  * that can change provider state, and it reports nothing at all without a
- * credential. Each workspace is reported as one session — the workspace is the
+ * credential. Beside the roster reads, one fixed query to Conductor's
+ * transcripts view names the sessions the same pass observed and takes back
+ * each chat's agent kind and the bounded tail its recap — the settled turn's
+ * parting words — is read from; the history behind that tail is never asked
+ * for, and the tail itself never leaves this adapter. Each workspace is
+ * reported as one session — the workspace is the
  * unit Conductor's own surface shows, and the one its name names — in the state
  * of whichever chat inside it most needs a person, and that chat is the one a
  * write reaches: the writes it supports are a user-typed prompt and a stop for
@@ -358,13 +419,21 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
       .flat()
       .slice(0, this.#maximumObservedSessions);
 
-    const observed = await Promise.all(
-      sessions.map((session) =>
-        this.#observationFor(request, session, now).then(
-          (observation) => observation && { workspaceId: session.workspace.id, observation },
+    // The transcripts read rides beside the status reads: one bounded query
+    // for every observed session, so a failed or missing answer costs a recap
+    // and an agent kind, never the pass.
+    const [transcripts, reportedStatuses] = await Promise.all([
+      this.tolerateItemFailure(() => this.#sessionTranscripts(request, sessions)),
+      Promise.all(
+        sessions.map((session) =>
+          // An archived session is a closed chat, so its state is already
+          // settled and no status request is needed.
+          session.archived
+            ? Promise.resolve(undefined)
+            : this.tolerateItemFailure(() => this.#sessionStatus(request, session.id)),
         ),
       ),
-    );
+    ]);
 
     // One row per workspace. The workspace is the session the user knows —
     // it is what titles the row — so two chats inside it would draw as
@@ -373,12 +442,19 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
     // chat is in; that chat is the one the row reports and the one a press
     // opens.
     const byWorkspace = new Map<string, ProviderSessionObservation>();
-    for (const { workspaceId, observation } of observed.filter(isDefined)) {
-      const held = byWorkspace.get(workspaceId);
+    sessions.forEach((session, index) => {
+      const observation = this.#observationFor(
+        session,
+        reportedStatuses[index],
+        transcripts?.get(session.id),
+        now,
+      );
+      if (!observation) return;
+      const held = byWorkspace.get(session.workspace.id);
       if (!held || urgencyOrder(observation, held) < 0) {
-        byWorkspace.set(workspaceId, observation);
+        byWorkspace.set(session.workspace.id, observation);
       }
-    }
+    });
     return [...byWorkspace.values()];
   }
 
@@ -548,16 +624,12 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
     };
   }
 
-  async #observationFor(
-    request: CloudRequest,
+  #observationFor(
     session: ConductorSession,
+    reported: ConductorReportedStatus | undefined,
+    transcript: ConductorTranscript | undefined,
     now: number,
-  ): Promise<ProviderSessionObservation | undefined> {
-    // An archived session is a closed chat, so its state is already settled and
-    // no status request is needed.
-    const reported = session.archived
-      ? undefined
-      : await this.tolerateItemFailure(() => this.#sessionStatus(request, session.id));
+  ): ProviderSessionObservation | undefined {
     // A workspace timestamp covers every chat in that workspace, so it would
     // make chats a user left hours ago look like they just stopped. The status
     // timestamp is per-session, and a closed chat's archive time is the moment
@@ -567,6 +639,15 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
     if (now - observedAt > CLOUD_ADAPTER_DEFAULTS.MAXIMUM_SESSION_AGE_MS) return undefined;
 
     const status = this.#statusFor(session, reported?.status, observedAt, now);
+    // The parting words are a recap only once the turn has actually parted:
+    // read for an idle or closed chat, they say where the agent left the work;
+    // read mid-turn they are half a sentence posing as an outcome, and read
+    // beside a failure they predate the thing the row now has to say.
+    const recap =
+      session.archived || reported?.status === CONDUCTOR_SESSION_STATUS.IDLE
+        ? transcript?.recap
+        : undefined;
+    const model = agentAndModelLabel(transcript?.agentKind, session.model);
     return {
       providerSessionId: session.id,
       // The workspace's name is the name the user knows this work by — it is
@@ -595,9 +676,10 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
       ...(reported?.status === CONDUCTOR_SESSION_STATUS.WORKING
         ? { controls: [CONDUCTOR_CANCEL_CONTROL] }
         : {}),
+      ...(recap ? { summary: recap } : {}),
       detail: {
         repository: session.workspace.repositoryLabel,
-        ...(session.model ? { model: session.model } : {}),
+        ...(model ? { model } : {}),
         ...(reported?.errorMessage ? { error: reported.errorMessage } : {}),
         ...(session.deepLink ? { link: session.deepLink } : {}),
       },
@@ -656,6 +738,80 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
       ...(errorMessage ? { errorMessage } : {}),
     };
   }
+
+  /**
+   * One bounded read of the transcripts view for every session this pass
+   * observed: which agent runs each chat, and the tail its recap is taken
+   * from. Only ids that are actually UUIDs may enter the fixed document — an
+   * id that is anything else is a shape this build does not know, so it is
+   * left out rather than sent — and with none there is no read at all.
+   */
+  async #sessionTranscripts(
+    request: CloudRequest,
+    sessions: readonly ConductorSession[],
+  ): Promise<ReadonlyMap<string, ConductorTranscript>> {
+    const transcripts = new Map<string, ConductorTranscript>();
+    const ids = sessions.map((session) => session.id).filter((id) => UUID_PATTERN.test(id));
+    if (ids.length === 0) return transcripts;
+
+    const document = `${CONDUCTOR_READ_TRANSCRIPT_TAILS} (${ids.map((id) => `'${id}'`).join(", ")})`;
+    const body = await request(CONDUCTOR_ROUTE.SQL, undefined, { document });
+    for (const row of recordsFromPage(body, CONDUCTOR_SQL_FIELD.ROWS)) {
+      const sessionId = textFromRecord(row, CONDUCTOR_SQL_FIELD.SESSION_ID);
+      if (!sessionId) continue;
+      const agentKind = textFromRecord(row, CONDUCTOR_SQL_FIELD.AGENT_TYPE)?.slice(
+        0,
+        CONDUCTOR_ADAPTER_DEFAULTS.MAXIMUM_AGENT_KIND_LENGTH,
+      );
+      const recap = recapFromTranscriptTail(
+        textFromRecord(row, CONDUCTOR_SQL_FIELD.TRANSCRIPT_TAIL),
+      );
+      transcripts.set(sessionId, {
+        ...(agentKind ? { agentKind } : {}),
+        ...(recap ? { recap } : {}),
+      });
+    }
+    return transcripts;
+  }
+}
+
+/**
+ * The parting words of the transcript's last message, only when that message
+ * is attributably the agent's: the tail must still hold the message's own
+ * header, and a chat whose user spoke last has no parting words to report.
+ * The view's elision markers are dropped, whitespace is flattened to the one
+ * line a recap is drawn as, and everything earlier in the tail is discarded
+ * unread — the recap is what leaves this function, never the history.
+ */
+function recapFromTranscriptTail(tail: string | undefined): string | undefined {
+  if (!tail) return undefined;
+  const lines = tail.split("\n").map((line) => line.trim());
+  const lastHeader = lines.findLastIndex(
+    (line) =>
+      line === CONDUCTOR_TRANSCRIPT_SPEAKER.ASSISTANT || line === CONDUCTOR_TRANSCRIPT_SPEAKER.USER,
+  );
+  if (lastHeader < 0 || lines[lastHeader] !== CONDUCTOR_TRANSCRIPT_SPEAKER.ASSISTANT) {
+    return undefined;
+  }
+  const recap = lines
+    .slice(lastHeader + 1)
+    .filter((line) => !CONDUCTOR_TRANSCRIPT_ELIDED.test(line))
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return recap ? recap.slice(0, maximumSessionSummaryLength) : undefined;
+}
+
+/**
+ * The agent kind joins the model label — `codex · gpt-5.5 · high` — because
+ * which agent runs a chat is as much its configuration as which model does.
+ */
+function agentAndModelLabel(
+  agentKind: string | undefined,
+  model: string | undefined,
+): string | undefined {
+  const label = [agentKind, model].filter(isDefined).join(" · ");
+  return label || undefined;
 }
 
 /** Most urgent first, and between two equally urgent chats, the one that moved last. */

--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -143,28 +143,10 @@ const CONDUCTOR_SQL_FIELD = {
 } as const;
 
 /**
- * How much of a transcript's end is read: enough to hold the last message's
- * header and a recap's worth of parting words, and no more of the history.
+ * How much of the final message is read: enough for a recap's worth of its
+ * opening words — where an agent puts the outcome — and no more of it.
  */
 const CONDUCTOR_TRANSCRIPT_TAIL_LENGTH = 2_000;
-
-/**
- * The one query document this adapter ever sends, fixed by this build. The
- * endpoint takes a read as a POSTed document rather than a GET, so the
- * separation is held the way the Linear tracker holds it: observation only
- * ever sends this SELECT, and nothing reaches its text but session ids the
- * same pass reported — each validated as a UUID first, so no name, title, or
- * message a provider controls can ever be spliced into the document.
- *
- * The columns ask for the agent kind and the transcript's bounded tail — the
- * settled turn's parting words — and never the conversation behind them.
- */
-const CONDUCTOR_READ_TRANSCRIPT_TAILS =
-  `SELECT ${CONDUCTOR_SQL_FIELD.SESSION_ID}, ${CONDUCTOR_SQL_FIELD.AGENT_TYPE}, ` +
-  `RIGHT(transcript, ${CONDUCTOR_TRANSCRIPT_TAIL_LENGTH}) AS ${CONDUCTOR_SQL_FIELD.TRANSCRIPT_TAIL} ` +
-  `FROM session_transcripts_view WHERE ${CONDUCTOR_SQL_FIELD.SESSION_ID} IN`;
-
-const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
  * How Conductor's plain-text transcript marks who is speaking. A line inside a
@@ -176,6 +158,48 @@ const CONDUCTOR_TRANSCRIPT_SPEAKER = {
   USER: "## User",
   ASSISTANT: "## Assistant",
 } as const;
+
+/** A header as the transcript embeds it: its own line between two messages. */
+const CONDUCTOR_ASSISTANT_HEADER = `\n${CONDUCTOR_TRANSCRIPT_SPEAKER.ASSISTANT}\n`;
+const CONDUCTOR_USER_HEADER = `\n${CONDUCTOR_TRANSCRIPT_SPEAKER.USER}\n`;
+
+/** The header as a Postgres string literal, its newlines written as escapes. */
+function sqlHeaderLiteral(header: string): string {
+  return `E'${header.replaceAll("\n", "\\n")}'`;
+}
+
+/**
+ * The one query document this adapter ever sends, fixed by this build. The
+ * endpoint takes a read as a POSTed document rather than a GET, so the
+ * separation is held the way the Linear tracker holds it: observation only
+ * ever sends this SELECT, and nothing reaches its text but session ids the
+ * same pass reported — each validated as a UUID first, so no name, title, or
+ * message a provider controls can ever be spliced into the document.
+ *
+ * The columns ask for the agent kind and the opening of the transcript's
+ * final message — the settled turn's parting words — and never the
+ * conversation behind it. Who wrote that message is computed in the view,
+ * from whichever speaker header stands nearest the transcript's end, and the
+ * returned tail is anchored at that header rather than cut at a fixed
+ * distance: a fixed cut left any final message longer than the cut without
+ * its header, which read as unattributable and silently cost most long-form
+ * agents their recap. A chat whose user spoke last answers with no tail at
+ * all.
+ */
+const CONDUCTOR_READ_TRANSCRIPT_TAILS_PREFIX =
+  `SELECT ${CONDUCTOR_SQL_FIELD.SESSION_ID}, ${CONDUCTOR_SQL_FIELD.AGENT_TYPE}, ` +
+  `CASE WHEN assistant_from_end > 0 AND (user_from_end = 0 OR assistant_from_end < user_from_end) ` +
+  `THEN SUBSTRING(transcript FROM GREATEST(LENGTH(transcript) - assistant_from_end - ${CONDUCTOR_ASSISTANT_HEADER.length - 2}, 1) ` +
+  `FOR ${CONDUCTOR_ASSISTANT_HEADER.length + CONDUCTOR_TRANSCRIPT_TAIL_LENGTH}) ` +
+  `END AS ${CONDUCTOR_SQL_FIELD.TRANSCRIPT_TAIL} ` +
+  `FROM (SELECT ${CONDUCTOR_SQL_FIELD.SESSION_ID}, ${CONDUCTOR_SQL_FIELD.AGENT_TYPE}, transcript, ` +
+  `position(reverse(${sqlHeaderLiteral(CONDUCTOR_ASSISTANT_HEADER)}) in reverse(transcript)) AS assistant_from_end, ` +
+  `position(reverse(${sqlHeaderLiteral(CONDUCTOR_USER_HEADER)}) in reverse(transcript)) AS user_from_end ` +
+  `FROM session_transcripts_view WHERE ${CONDUCTOR_SQL_FIELD.SESSION_ID} IN (`;
+
+const CONDUCTOR_READ_TRANSCRIPT_TAILS_SUFFIX = ")) AS attributed";
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /** The view's own mark for history it left out of the concise transcript. */
 const CONDUCTOR_TRANSCRIPT_ELIDED = /^\[\d+ messages? elided\]$/;
@@ -758,7 +782,9 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
     const ids = sessions.map((session) => session.id).filter((id) => UUID_PATTERN.test(id));
     if (ids.length === 0) return transcripts;
 
-    const document = `${CONDUCTOR_READ_TRANSCRIPT_TAILS} (${ids.map((id) => `'${id}'`).join(", ")})`;
+    const document = `${CONDUCTOR_READ_TRANSCRIPT_TAILS_PREFIX}${ids
+      .map((id) => `'${id}'`)
+      .join(", ")}${CONDUCTOR_READ_TRANSCRIPT_TAILS_SUFFIX}`;
     const body = await request(CONDUCTOR_ROUTE.SQL, undefined, { document });
     for (const row of recordsFromPage(body, CONDUCTOR_SQL_FIELD.ROWS)) {
       const sessionId = textFromRecord(row, CONDUCTOR_SQL_FIELD.SESSION_ID);

--- a/apps/desktop/tests/conductor-adapter.test.ts
+++ b/apps/desktop/tests/conductor-adapter.test.ts
@@ -49,6 +49,8 @@ interface TestSession {
   statusUpdatedAt?: number;
   statusHttpStatus?: number;
   lastError?: string;
+  agentType?: string;
+  transcriptTail?: string;
 }
 
 interface TestApi {
@@ -58,6 +60,8 @@ interface TestApi {
   sessions: readonly TestSession[];
   /** Misbehave: answer a creation without naming the first session. */
   createWithoutSessionId?: boolean;
+  /** Misbehave: refuse the transcripts-view read. */
+  sqlHttpStatus?: number;
 }
 
 interface RecordedRequest {
@@ -125,9 +129,27 @@ function fakeConductorApi(api: TestApi): FakeConductorApi {
     });
 
     const segments = pathname.split("/").filter((segment) => segment.length > 0);
-    // The three documented writers: a prompt for one session, a cancel for the
-    // turn it is working, and a new workspace in one project.
     if (init.method === "POST") {
+      // The transcripts view: the one read that rides as a POSTed document.
+      if (segments[1] === "sql" && segments.length === 2) {
+        if (api.sqlHttpStatus) return jsonResponse({}, api.sqlHttpStatus);
+        const body = JSON.parse(typeof init.body === "string" ? init.body : "{}") as {
+          query?: string;
+        };
+        const query = body.query ?? "";
+        if (!query.startsWith("SELECT ")) return jsonResponse({}, HTTP_STATUS.SERVER_ERROR);
+        const ids = [...query.matchAll(/'([^']*)'/g)].map((match) => match[1]);
+        const rows = api.sessions
+          .filter((session) => ids.includes(session.id) && session.transcriptTail !== undefined)
+          .map((session) => ({
+            session_id: session.id,
+            agent_type: session.agentType ?? null,
+            transcript_tail: session.transcriptTail,
+          }));
+        return jsonResponse({ rows, rowCount: rows.length, truncated: false });
+      }
+      // The three documented writers: a prompt for one session, a cancel for
+      // the turn it is working, and a new workspace in one project.
       if (segments[1] === "workspaces" && segments.length === 2) {
         const body = JSON.parse(typeof init.body === "string" ? init.body : "{}") as {
           projectId?: string;
@@ -339,6 +361,266 @@ test("reports an idle session as waiting and an errored session with its reason"
   assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
   assert.equal(observations[1]?.status, SESSION_STATUS.ERROR);
   assert.equal(observations[1]?.detail?.error, TEST_ERROR_MESSAGE);
+});
+
+const IDLE_SESSION_UUID = "11111111-1111-4111-8111-111111111111";
+const CLOSED_SESSION_UUID = "22222222-2222-4222-8222-222222222222";
+const WORKING_SESSION_UUID = "33333333-3333-4333-8333-333333333333";
+const ERRORED_SESSION_UUID = "44444444-4444-4444-8444-444444444444";
+
+/** A tail the way the view writes one: headers, an elision mark, parting words. */
+const TEST_TRANSCRIPT_TAIL =
+  "st half of a message the tail cut into\n\n## User\n\nWire the panel.\n\n## Assistant\n\n" +
+  "[12 messages elided]\n\nAll checks pass;\nnext, say whether to ship it.";
+const TEST_RECAP = "All checks pass; next, say whether to ship it.";
+
+test("reads a settled chat's parting words from the transcripts view as its recap", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [
+      ownedWorkspace("workspace-idle", TEST_TIME - 30_000),
+      ownedWorkspace("workspace-closed", TEST_TIME - 40_000),
+    ],
+    sessions: [
+      {
+        id: IDLE_SESSION_UUID,
+        workspaceId: "workspace-idle",
+        name: TEST_SESSION_NAME,
+        resolvedModel: "gpt-5.5",
+        agentType: "codex",
+        transcriptTail: TEST_TRANSCRIPT_TAIL,
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+      // A closed chat is settled too, so its parting words still stand.
+      {
+        id: CLOSED_SESSION_UUID,
+        workspaceId: "workspace-closed",
+        name: TEST_SESSION_NAME,
+        agentType: "claude",
+        transcriptTail: TEST_TRANSCRIPT_TAIL,
+        archivedAt: isoTimestamp(TEST_TIME - 60_000),
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations.length, 2);
+  const idle = observations.find((candidate) => candidate.providerSessionId === IDLE_SESSION_UUID);
+  const closed = observations.find(
+    (candidate) => candidate.providerSessionId === CLOSED_SESSION_UUID,
+  );
+  // The recap is the last message's words alone: the elision mark is dropped,
+  // the header is not part of it, and nothing earlier in the tail survives.
+  assert.equal(idle?.summary, TEST_RECAP);
+  assert.equal(closed?.summary, TEST_RECAP);
+  // The agent kind joins the model label, and stands alone when no model came.
+  assert.equal(idle?.detail?.model, "codex · gpt-5.5");
+  assert.equal(closed?.detail?.model, "claude");
+
+  // One read document for the whole pass, fixed by the build: the SELECT this
+  // build wrote, naming exactly the observed session ids and nothing else.
+  const reads = api.requests.filter((request) => request.method === "POST");
+  assert.equal(reads.length, 1);
+  assert.equal(reads[0]?.pathname, "/v0/sql");
+  assert.equal(reads[0]?.authorization, `Bearer ${TEST_API_KEY}`);
+  assert.deepEqual(JSON.parse(reads[0]?.body ?? ""), {
+    query:
+      "SELECT session_id, agent_type, RIGHT(transcript, 2000) AS transcript_tail " +
+      "FROM session_transcripts_view WHERE session_id IN " +
+      `('${IDLE_SESSION_UUID}', '${CLOSED_SESSION_UUID}')`,
+  });
+});
+
+test("keeps parting words off a chat that is still working or newly failed", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [
+      ownedWorkspace("workspace-working", TEST_TIME - 30_000),
+      ownedWorkspace("workspace-errored", TEST_TIME - 40_000),
+    ],
+    sessions: [
+      // Mid-turn the words are half a sentence, not an outcome.
+      {
+        id: WORKING_SESSION_UUID,
+        workspaceId: "workspace-working",
+        name: TEST_SESSION_NAME,
+        agentType: "cursor",
+        transcriptTail: TEST_TRANSCRIPT_TAIL,
+        status: TEST_CONDUCTOR_STATUS.WORKING,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+      // Beside a failure the parting words predate what the row has to say.
+      {
+        id: ERRORED_SESSION_UUID,
+        workspaceId: "workspace-errored",
+        name: TEST_SESSION_NAME,
+        transcriptTail: TEST_TRANSCRIPT_TAIL,
+        status: TEST_CONDUCTOR_STATUS.ERROR,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations.length, 2);
+  for (const observation of observations) {
+    assert.equal(observation.summary, undefined);
+  }
+  // The agent kind is configuration, not conversation, so it rides regardless.
+  const working = observations.find(
+    (candidate) => candidate.providerSessionId === WORKING_SESSION_UUID,
+  );
+  assert.equal(working?.detail?.model, "cursor");
+});
+
+test("reports no recap for a tail it cannot attribute to the agent", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [
+      ownedWorkspace("workspace-user-last", TEST_TIME - 30_000),
+      ownedWorkspace("workspace-headerless", TEST_TIME - 40_000),
+    ],
+    sessions: [
+      // The user spoke last, so there are no parting words to report.
+      {
+        id: IDLE_SESSION_UUID,
+        workspaceId: "workspace-user-last",
+        name: TEST_SESSION_NAME,
+        transcriptTail: `${TEST_TRANSCRIPT_TAIL}\n\n## User\n\nPlease also update the docs.`,
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+      // A tail cut inside one long message holds no header naming its speaker.
+      {
+        id: CLOSED_SESSION_UUID,
+        workspaceId: "workspace-headerless",
+        name: TEST_SESSION_NAME,
+        transcriptTail: "words with no header anywhere above them",
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations.length, 2);
+  for (const observation of observations) {
+    assert.equal(observation.summary, undefined);
+  }
+});
+
+test("cuts a recap at the summary bound", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-idle", TEST_TIME - 30_000)],
+    sessions: [
+      {
+        id: IDLE_SESSION_UUID,
+        workspaceId: "workspace-idle",
+        name: TEST_SESSION_NAME,
+        transcriptTail: `## Assistant\n\n${"a word ".repeat(200)}`,
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations[0]?.summary?.length, 500);
+});
+
+test("keeps a session id that is not a UUID out of the read document", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [
+      ownedWorkspace("workspace-idle", TEST_TIME - 30_000),
+      ownedWorkspace("workspace-odd", TEST_TIME - 40_000),
+    ],
+    sessions: [
+      {
+        id: IDLE_SESSION_UUID,
+        workspaceId: "workspace-idle",
+        name: TEST_SESSION_NAME,
+        transcriptTail: TEST_TRANSCRIPT_TAIL,
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+      // An id of a shape this build does not know may not enter the document.
+      {
+        id: "session'); DROP VIEW session_transcripts_view; --",
+        workspaceId: "workspace-odd",
+        name: TEST_SESSION_NAME,
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+    ],
+  });
+
+  await adapterFor(api.fetch).observe();
+
+  const reads = api.requests.filter((request) => request.pathname === "/v0/sql");
+  assert.equal(reads.length, 1);
+  assert.ok(reads[0]?.body?.includes(IDLE_SESSION_UUID));
+  assert.equal(reads[0]?.body?.includes("DROP"), false);
+
+  // With no UUID ids at all there is nothing to ask, so nothing is asked.
+  const uuidlessApi = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-odd", TEST_TIME - 30_000)],
+    sessions: [
+      {
+        id: "session-plain",
+        workspaceId: "workspace-odd",
+        name: TEST_SESSION_NAME,
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+    ],
+  });
+  await adapterFor(uuidlessApi.fetch).observe();
+  assert.equal(
+    uuidlessApi.requests.every((request) => request.method === "GET"),
+    true,
+  );
+});
+
+test("a refused transcripts read costs the recap and agent kind, never the pass", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-idle", TEST_TIME - 30_000)],
+    sessions: [
+      {
+        id: IDLE_SESSION_UUID,
+        workspaceId: "workspace-idle",
+        name: TEST_SESSION_NAME,
+        resolvedModel: "gpt-5.5",
+        agentType: "codex",
+        transcriptTail: TEST_TRANSCRIPT_TAIL,
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+    ],
+    sqlHttpStatus: HTTP_STATUS.SERVER_ERROR,
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
+  assert.equal(observations[0]?.summary, undefined);
+  assert.equal(observations[0]?.detail?.model, "gpt-5.5");
 });
 
 // Rows are titled by their workspace, so two chats in one workspace would draw

--- a/apps/desktop/tests/conductor-adapter.test.ts
+++ b/apps/desktop/tests/conductor-adapter.test.ts
@@ -428,9 +428,15 @@ test("reads a settled chat's parting words from the transcripts view as its reca
   assert.equal(reads[0]?.authorization, `Bearer ${TEST_API_KEY}`);
   assert.deepEqual(JSON.parse(reads[0]?.body ?? ""), {
     query:
-      "SELECT session_id, agent_type, RIGHT(transcript, 2000) AS transcript_tail " +
+      "SELECT session_id, agent_type, " +
+      "CASE WHEN assistant_from_end > 0 AND (user_from_end = 0 OR assistant_from_end < user_from_end) " +
+      "THEN SUBSTRING(transcript FROM GREATEST(LENGTH(transcript) - assistant_from_end - 12, 1) FOR 2014) " +
+      "END AS transcript_tail " +
+      "FROM (SELECT session_id, agent_type, transcript, " +
+      "position(reverse(E'\\n## Assistant\\n') in reverse(transcript)) AS assistant_from_end, " +
+      "position(reverse(E'\\n## User\\n') in reverse(transcript)) AS user_from_end " +
       "FROM session_transcripts_view WHERE session_id IN " +
-      `('${IDLE_SESSION_UUID}', '${CLOSED_SESSION_UUID}')`,
+      `('${IDLE_SESSION_UUID}', '${CLOSED_SESSION_UUID}')) AS attributed`,
   });
 });
 
@@ -496,7 +502,9 @@ test("reports no recap for a tail it cannot attribute to the agent", async () =>
         status: TEST_CONDUCTOR_STATUS.IDLE,
         statusUpdatedAt: TEST_TIME - 1_000,
       },
-      // A tail cut inside one long message holds no header naming its speaker.
+      // A tail with no header names no speaker. The view anchors what it
+      // returns at the final message's own header, so this is a misbehaving
+      // answer — attribution is still refused rather than assumed.
       {
         id: CLOSED_SESSION_UUID,
         workspaceId: "workspace-headerless",

--- a/apps/desktop/tests/conductor-adapter.test.ts
+++ b/apps/desktop/tests/conductor-adapter.test.ts
@@ -621,6 +621,32 @@ test("a refused transcripts read costs the recap and agent kind, never the pass"
   assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
   assert.equal(observations[0]?.summary, undefined);
   assert.equal(observations[0]?.detail?.model, "gpt-5.5");
+
+  // Even a credential refusal on this one endpoint costs only the recap: a
+  // key an org scopes away from the query endpoint still reads the roster,
+  // and only the roster reads may judge the credential.
+  const scopedKeyApi = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-idle", TEST_TIME - 30_000)],
+    sessions: [
+      {
+        id: IDLE_SESSION_UUID,
+        workspaceId: "workspace-idle",
+        name: TEST_SESSION_NAME,
+        transcriptTail: TEST_TRANSCRIPT_TAIL,
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+    ],
+    sqlHttpStatus: HTTP_STATUS.UNAUTHORIZED,
+  });
+
+  const scopedKeyObservations = await adapterFor(scopedKeyApi.fetch).observe();
+
+  assert.equal(scopedKeyObservations.length, 1);
+  assert.equal(scopedKeyObservations[0]?.status, SESSION_STATUS.WAITING);
+  assert.equal(scopedKeyObservations[0]?.summary, undefined);
 });
 
 // Rows are titled by their workspace, so two chats in one workspace would draw

--- a/packages/sidecar-core/src/realtime.ts
+++ b/packages/sidecar-core/src/realtime.ts
@@ -704,8 +704,14 @@ export function realtimeMintExplanation(outcome: RealtimeMintOutcome): string {
   return REALTIME_MINT_EXPLANATIONS[outcome];
 }
 
-/** How many sessions one context update may describe. */
-export const maximumVoiceContextSessions = 10;
+/**
+ * How many sessions one context update may describe. A session the roster
+ * omits is one Luke denies exists, and eight Conductor workspaces beside a
+ * few local agents overflowed the original ten, so the bound is set past any
+ * roster the adapters' own caps can produce; every line is already bounded,
+ * so the update stays a bounded read either way.
+ */
+export const maximumVoiceContextSessions = 25;
 
 /**
  * What one session can be asked to do, said in the roster so Luke offers only
@@ -742,6 +748,7 @@ function sessionCapabilityText(session: NormalizedSession): string {
 export function sessionContextText(sessions: readonly NormalizedSession[]): string {
   if (sessions.length === 0) return "No coding-agent sessions are currently observed.";
 
+  const overflow = sessions.length - maximumVoiceContextSessions;
   return [
     "Currently observed sessions:",
     ...sessions
@@ -755,6 +762,14 @@ export function sessionContextText(sessions: readonly NormalizedSession[]): stri
           `[${sessionCapabilityText(session)}]`,
         ].join(" — "),
       ),
+    // A session past the bound must read as unlisted, never as nonexistent:
+    // denying a session the panel plainly shows teaches the user that Luke
+    // cannot be asked about their work at all.
+    ...(overflow > 0
+      ? [
+          `(${overflow} more observed ${overflow === 1 ? "session is" : "sessions are"} not listed here; the panel shows them all.)`,
+        ]
+      : []),
   ].join("\n");
 }
 

--- a/packages/sidecar-core/tests/realtime.test.ts
+++ b/packages/sidecar-core/tests/realtime.test.ts
@@ -418,7 +418,16 @@ test("session context stays bounded when many sessions are observed", () => {
 
   const lines = sessionContextText(sessions).split("\n").slice(1);
 
-  assert.equal(lines.length, maximumVoiceContextSessions);
+  // The bound holds, and what it cut is said: a session past it must read as
+  // unlisted, never as nonexistent.
+  assert.equal(lines.length, maximumVoiceContextSessions + 1);
+  assert.match(lines.at(-1) ?? "", /5 more observed sessions are not listed/);
+
+  const exactlyAtBound = sessionContextText(sessions.slice(0, maximumVoiceContextSessions))
+    .split("\n")
+    .slice(1);
+  assert.equal(exactlyAtBound.length, maximumVoiceContextSessions);
+  assert.doesNotMatch(exactlyAtBound.at(-1) ?? "", /not listed/);
 });
 
 test("a resting-point update is voiced just like a blocking one", () => {


### PR DESCRIPTION
## Summary

- Conductor rows were the emptiest in the panel — no activity, branch, or recap, so the detail line always fell back to the bare state label and the `SUMMARY_CHANGED` attention trigger could never fire. Conductor's public API also documents `POST /v0/sql`, a read-only query endpoint over its `session_transcripts_view`; observation now reads it.
- One fixed `SELECT` per pass — the document's text is fixed by the build, and nothing enters it but the session ids the same pass reported, each validated as a UUID first, so no name, title, or message a provider controls can be spliced in. A session id of any other shape stays out of the document, and with none there is no read at all. The query asks for each chat's `agent_type` and `RIGHT(transcript, 2000)` — never the conversation behind the tail.
- The tail becomes the row's recap (`summary`) only when the chat is idle or closed and the tail's last message is attributably the agent's (its `## Assistant` header still in the tail): a settled turn's parting words say where the work stands, where half a sentence mid-turn poses as an outcome, and words beside a failure predate what the row now has to say. Elision markers are dropped, whitespace flattens to the one line a recap is drawn as, and the tail itself never leaves the adapter.
- The agent kind joins the model label — `codex · gpt-5.5 · high` — the way effort and fast mode already do.
- The cloud base gains the read-document form the Linear tracker established: a `CloudRequest` may carry a query document, riding as a `POST` only because that is how its endpoint is documented; the body carries the document and nothing else.
- AGENTS.md records both policies: observation may send a build-fixed read document, and an agent's parting words count as the recap a provider wrote *about* a session — the same standing as Codex's `last_agent_message` — while the transcript behind them never travels. PRIVACY.md describes the new read and the recap's path into the voice roster and the attention review.
- Fixtures are deliberately untouched: the Conductor fixture row remains the one that proves the surface's fallback wording for a provider that reported no recap, which a working Conductor chat still is.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — pass (exit 0). Biome clean; typecheck clean; desktop tests 565 pass / 0 fail (6 new: the recap read, its settled-chat and attribution gates, the summary bound, the UUID gate on the read document, and a refused read costing only the recap); sidecar-core and web suites unchanged and passing.
- Live read-only validation against the real Conductor API from this sandbox: an `observe()` pass returned rows where only waiting/closed chats carry a `summary`, working chats carry none, and every model label gained its agent kind (e.g. `claude · claude-fable-5 · high`).
- macOS Electron verification (`./scripts/verify.sh`): not run — this change was produced on Linux; CI's macOS job covers it. No drawn surface changed (adapter data and docs only), so the fixture evidence is expected to be identical; no physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a7e5c731-7279-457f-91f1-12e97396c568)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31843328173/artifacts/9235044179) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31843328173)

- Commit: `d8eb9e293fe6c0acd0d31f0acb9767673d5b489a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
