### PR TITLE
feat(voice): make a changed voice or pace heard on the live call

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1127,8 +1127,8 @@ function registerIpc(): void {
       if (!isRealtimeVoice(voice)) throw new Error("Unknown voice");
       try {
         const result = await settingsStore.setVoice(voice);
-        // The next credential is minted for the new voice; a conversation
-        // already open keeps the one it answered with.
+        // The next credential is minted for the new voice; the renderer makes
+        // the change heard now by reopening any conversation already up.
         if (!result.reason) realtimeCredentials?.setVoice(voice);
         broadcastSettings(result.settings, event.sender);
         return result;
@@ -1140,8 +1140,8 @@ function registerIpc(): void {
       }
     },
   );
-  // The pace travels the voice's road exactly: a value from the set fixed by
-  // this build, stored, and handed to the minter for the next conversation.
+  // The pace travels the voice's road: a value from the set fixed by this
+  // build, stored, and handed to the minter for the next conversation.
   ipcMain.handle(
     channels.setVoiceSpeed,
     async (event, speed: unknown): Promise<SettingsUpdateResult> => {
@@ -1149,8 +1149,8 @@ function registerIpc(): void {
       if (!isRealtimeVoiceSpeed(speed)) throw new Error("Unknown voice speed");
       try {
         const result = await settingsStore.setVoiceSpeed(speed);
-        // The next credential is minted for the new pace; a conversation
-        // already open keeps the one it answered at.
+        // The next credential is minted for the new pace; the renderer
+        // carries the change onto a conversation already open itself.
         if (!result.reason) realtimeCredentials?.setSpeed(speed);
         broadcastSettings(result.settings, event.sender);
         return result;

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1190,6 +1190,67 @@ export function App(): React.JSX.Element {
   }, []);
 
   /**
+   * Carries a changed pace onto the call now open, whichever hand changed it:
+   * the settings row and a spoken ask both land in the stored snapshot, so
+   * watching the snapshot covers them equally. The first snapshot is the
+   * stored value rather than a change, and with no call open there is nothing
+   * to do — the next call is minted at the stored pace.
+   */
+  const heardSpeed = useRef<RealtimeVoiceSpeed | undefined>(undefined);
+  useEffect(() => {
+    const speed = settings?.voiceSpeed;
+    if (speed === undefined) return;
+    const previous = heardSpeed.current;
+    heardSpeed.current = speed;
+    if (previous === undefined || previous === speed) return;
+    voiceSession.current?.applySpeed(speed);
+  }, [settings?.voiceSpeed]);
+
+  /**
+   * Makes a changed voice heard now rather than from the next conversation on.
+   * The API locks a session's voice the moment the model first speaks, so the
+   * one way to change it on a live call is to open a new one. The restart
+   * waits for the turn under way to end — a spoken "change your voice" is
+   * confirmed in the old voice before the new one takes over — and the
+   * conversation starts afresh, because the call is the conversation. A call
+   * that ended on its own owes nothing: the next one is minted in the new
+   * voice already.
+   */
+  const heardVoice = useRef<RealtimeVoice | undefined>(undefined);
+  const voiceRestartDue = useRef(false);
+  useEffect(() => {
+    const voice = settings?.voice;
+    if (!voice) return;
+    const previous = heardVoice.current;
+    heardVoice.current = voice;
+    // A call being opened counts as one to reopen: its credential may already
+    // have been minted in the old voice, and a restart is the only answer the
+    // renderer can be sure of from here.
+    if (
+      previous !== undefined &&
+      previous !== voice &&
+      (voiceSession.current?.isConnected || voiceSession.current?.isConnecting)
+    ) {
+      voiceRestartDue.current = true;
+    }
+    if (!voiceRestartDue.current) return;
+    if (
+      voiceStatus === REALTIME_STATUS.IDLE ||
+      voiceStatus === REALTIME_STATUS.FAILED ||
+      voiceStatus === REALTIME_STATUS.UNAVAILABLE
+    ) {
+      voiceRestartDue.current = false;
+      return;
+    }
+    if (voiceStatus !== REALTIME_STATUS.READY) return;
+    voiceRestartDue.current = false;
+    void (async () => {
+      await voiceSession.current?.close();
+      await startMicrophoneRef.current?.();
+    })();
+  }, [settings?.voice, voiceStatus]);
+
+  /**
    * Moves the talk key, or resets it when no chord is named. The key the row
    * shows is not taken from this reply — the main process announces the one
    * that actually registered, the same way it always has — so the reply

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -93,7 +93,8 @@ const SETTING_GUIDE: Record<
   voice: (settings) => ({
     id: APP_SETTING_ID.VOICE,
     label: "Voice",
-    description: "Which voice Luke speaks with; a change is heard from the next conversation on.",
+    description:
+      "Which voice Luke speaks with; a change is heard right away — a conversation under way starts afresh in the new voice.",
     kind: APP_SETTING_KIND.CHOICE,
     value: settings.voice,
     choices: REALTIME_VOICE_LIST,
@@ -104,7 +105,7 @@ const SETTING_GUIDE: Record<
     id: APP_SETTING_ID.VOICE_SPEED,
     label: "Speed",
     description:
-      "How fast Luke talks — slow is 0.75×, normal 1×, quick 1.25×, fast 1.5× the voice's natural rate; a change is heard from the next conversation on.",
+      "How fast Luke talks — slow is 0.75×, normal 1×, quick 1.25×, fast 1.5× the voice's natural rate; a change is heard from the next reply on.",
     kind: APP_SETTING_KIND.CHOICE,
     value: voiceSpeedWord(settings.voiceSpeed),
     choices: VOICE_SPEED_WORDS.map((candidate) => candidate.word),
@@ -439,11 +440,16 @@ export async function applySpokenSetting(
     status: "changed",
     setting: action.setting.label,
     value: action.value,
-    // The two rides on the minted session say so, the same promise their rows
-    // make: the change lands in the next conversation, never a live one.
-    ...(action.setting.id === APP_SETTING_ID.VOICE ||
-    action.setting.id === APP_SETTING_ID.VOICE_SPEED
-      ? { note: "The change is heard from the next conversation on." }
-      : {}),
+    // What each change means for the call now open, so the outcome Luke
+    // voices matches what actually happens. The API locks a session's voice
+    // once the model has spoken, so a changed voice is heard by starting the
+    // conversation afresh; a pace rides a session update and needs no restart.
+    ...(action.setting.id === APP_SETTING_ID.VOICE
+      ? {
+          note: "The new voice takes over as soon as this reply ends, and the conversation starts afresh in it.",
+        }
+      : action.setting.id === APP_SETTING_ID.VOICE_SPEED
+        ? { note: "The new pace is heard from the next reply on." }
+        : {}),
   };
 }

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -406,6 +406,9 @@ export class RealtimeVoiceSession {
       await this.#waitForChannel(channel, deadline);
       if (this.#closed) return this.#abandonConnect();
       this.#setStatus(REALTIME_STATUS.READY);
+      // A pace changed during the handshake could not be sent then, and the
+      // credential this call answered may have been minted before the change.
+      this.#flushPendingSpeed();
       // Whoever pressed the talk key to get here has been waiting through the
       // handshake for their turn to open.
       if (this.#pendingTurn) {
@@ -851,7 +854,14 @@ export class RealtimeVoiceSession {
    * update — the next one is minted at the stored pace already.
    */
   applySpeed(speed: number): void {
-    if (!this.isConnected) return;
+    if (!this.isConnected) {
+      // A call being opened was minted at whatever pace stood when its
+      // credential was asked for, which this change may already have
+      // overtaken: hold it and send it once the channel opens. Sent to a
+      // call that was minted at the new pace after all, it is a no-op.
+      if (this.isConnecting) this.#pendingSpeed = speed;
+      return;
+    }
     if (this.#status === REALTIME_STATUS.RESPONDING) {
       this.#pendingSpeed = speed;
       return;

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -20,6 +20,7 @@ import {
   issueTrackerDisconnectedEvents,
   type NormalizedSession,
   type ObservedWorkspaceProject,
+  outputSpeedUpdateEvents,
   proactiveSpeechEvents,
   pushToTalkCommitEvents,
   REALTIME_DATA_CHANNEL,
@@ -272,6 +273,12 @@ export class RealtimeVoiceSession {
    * a reply the developer is already hearing.
    */
   #turnEpoch = 0;
+  /**
+   * A pace change that arrived mid-reply, waiting for the reply to end. The
+   * API applies a speed only between model turns, so one landing while Luke is
+   * speaking is held here and sent ahead of whatever the call does next.
+   */
+  #pendingSpeed: number | undefined;
 
   constructor(options: RealtimeVoiceSessionOptions) {
     this.#options = options;
@@ -704,6 +711,8 @@ export class RealtimeVoiceSession {
     this.#generationDone = false;
     this.#remoteQuiet = false;
     this.#pendingTurn = false;
+    // The next call is minted at the stored pace, so nothing is owed to it.
+    this.#pendingSpeed = undefined;
     this.#responseItemId = undefined;
     this.#activeResponseId = undefined;
     this.#audibleSince = undefined;
@@ -716,6 +725,11 @@ export class RealtimeVoiceSession {
   }
 
   #startResponse(events: readonly Record<string, unknown>[], toolsArmed = false): void {
+    // A pace still waiting from the last reply lands here, ahead of the
+    // request: the channel is ordered and no response is in progress — a
+    // cancel for the reply being talked over was sent before this — so the
+    // reply about to be asked for is already spoken at the new pace.
+    this.#flushPendingSpeed();
     // The track is deliberately left as it is. A reply that was cut off left it
     // disabled, and re-opening it here would let the tail of that reply — still
     // arriving, because the server sent it before it was told to stop — be
@@ -822,7 +836,36 @@ export class RealtimeVoiceSession {
     // un-silence him.
     this.#unsilenceLuke();
     this.#clearSettleTimer();
+    // The reply is over, so the API is between turns — the one moment it
+    // accepts a pace change that arrived while Luke was speaking.
+    this.#flushPendingSpeed();
     if (this.#status === REALTIME_STATUS.RESPONDING) this.#setStatus(REALTIME_STATUS.READY);
+  }
+
+  /**
+   * Changes how fast Luke speaks on the call now open, from his next reply on.
+   * A call minted at one pace stays a live session, so the change travels as a
+   * session update rather than waiting for the next conversation. The API
+   * applies a pace only between model turns: a change landing mid-reply is
+   * held and sent when the reply ends. With no call open there is nothing to
+   * update — the next one is minted at the stored pace already.
+   */
+  applySpeed(speed: number): void {
+    if (!this.isConnected) return;
+    if (this.#status === REALTIME_STATUS.RESPONDING) {
+      this.#pendingSpeed = speed;
+      return;
+    }
+    this.#pendingSpeed = undefined;
+    this.#send(outputSpeedUpdateEvents(speed));
+  }
+
+  /** Sends the pace change that waited out a reply, once nothing is speaking. */
+  #flushPendingSpeed(): void {
+    const speed = this.#pendingSpeed;
+    if (speed === undefined) return;
+    this.#pendingSpeed = undefined;
+    this.#send(outputSpeedUpdateEvents(speed));
   }
 
   /**

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -717,9 +717,11 @@ function PreferencesSection({
         <span className="settings-copy">
           <strong>Voice</strong>
           {/* When it lands, because a control that seems not to act invites a
-              second press: the change rides the next conversation, and one
-              already open keeps the voice it answered with. */}
-          <small>How Luke sounds, from the next conversation on.</small>
+              second press. The API locks a session's voice once the model has
+              spoken, so a call already open is quietly reopened in the new
+              voice — heard right away, at the price of the conversation
+              starting afresh. */}
+          <small>How Luke sounds; a conversation under way starts afresh.</small>
         </span>
         <span className="voice-select">
           <select
@@ -753,9 +755,9 @@ function PreferencesSection({
       <div className="settings-row">
         <span className="settings-copy">
           <strong>Speed</strong>
-          {/* The same promise as the voice's line, because it lands the same
-              way: minted into the next conversation, never a live one. */}
-          <small>How fast Luke talks, from the next conversation on.</small>
+          {/* Unlike the voice, a pace change rides a session update onto the
+              call already open, so nothing starts over. */}
+          <small>How fast Luke talks, from his next reply on.</small>
         </span>
         <span className="voice-select">
           <select

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -257,13 +257,15 @@ export interface AppBridge {
   ): Promise<SettingsUpdateResult>;
   /**
    * Chooses the voice Luke speaks with, from the set fixed by this build. It
-   * reaches the next conversation to connect; one already open keeps the
-   * voice it answered with.
+   * reaches the next conversation to connect; the renderer makes it heard now
+   * by reopening a call already up, because the API locks a session's voice
+   * once the model has spoken.
    */
   setVoice(voice: RealtimeVoice): Promise<SettingsUpdateResult>;
   /**
    * Chooses the pace Luke speaks at, from the set fixed by this build. It
-   * reaches the next conversation the same way the voice does.
+   * reaches the next conversation the way the voice does, and the renderer
+   * carries it onto a call already open as a session update.
    */
   setVoiceSpeed(speed: RealtimeVoiceSpeed): Promise<SettingsUpdateResult>;
   /**

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -584,6 +584,50 @@ test("a finished response returns the session to ready", async () => {
   assert.equal(context.session.status, REALTIME_STATUS.READY);
 });
 
+test("a changed pace reaches the live call without waiting for the next one", async () => {
+  const context = harness();
+  await context.session.connect();
+
+  context.session.applySpeed(1.25);
+
+  const update = context.sent.find((event) => event.type === REALTIME_CLIENT_EVENT.SESSION_UPDATE);
+  assert.deepEqual(update, {
+    type: REALTIME_CLIENT_EVENT.SESSION_UPDATE,
+    session: { type: "realtime", audio: { output: { speed: 1.25 } } },
+  });
+});
+
+test("a pace changed mid-reply waits for the reply to end", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.session.beginTurn();
+  context.session.endTurn(true);
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+
+  // The API applies a pace only between turns, so nothing may be sent while
+  // Luke is still speaking.
+  context.session.applySpeed(0.75);
+  assert.equal(
+    context.sent.some((event) => event.type === REALTIME_CLIENT_EVENT.SESSION_UPDATE),
+    false,
+  );
+
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_DONE });
+  context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED });
+
+  const update = context.sent.find((event) => event.type === REALTIME_CLIENT_EVENT.SESSION_UPDATE);
+  assert.deepEqual(update?.session, { type: "realtime", audio: { output: { speed: 0.75 } } });
+});
+
+test("a pace change with no call open sends nothing", () => {
+  // Not a loss: the next call is minted at the stored pace already.
+  const context = harness();
+
+  context.session.applySpeed(1.5);
+
+  assert.deepEqual(context.sent, []);
+});
+
 test("a service error is surfaced rather than swallowed", async () => {
   const context = harness();
   await context.session.connect();

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -619,6 +619,20 @@ test("a pace changed mid-reply waits for the reply to end", async () => {
   assert.deepEqual(update?.session, { type: "realtime", audio: { output: { speed: 0.75 } } });
 });
 
+test("a pace changed during the handshake reaches the call it was opening", async () => {
+  const context = harness({ connectionDelayMs: 5 });
+  const opening = context.session.connect();
+
+  // The credential this call answers with may have been minted before the
+  // change reached the minter, so dropping it would leave the live call at
+  // the old pace with the row already showing the new one.
+  context.session.applySpeed(1.25);
+  await opening;
+
+  const update = context.sent.find((event) => event.type === REALTIME_CLIENT_EVENT.SESSION_UPDATE);
+  assert.deepEqual(update?.session, { type: "realtime", audio: { output: { speed: 1.25 } } });
+});
+
 test("a pace change with no call open sends nothing", () => {
   // Not a loss: the next call is minted at the stored pace already.
   const context = harness();

--- a/packages/sidecar-core/src/realtime.ts
+++ b/packages/sidecar-core/src/realtime.ts
@@ -125,6 +125,7 @@ export const REALTIME_STATUS = {
 export type RealtimeStatus = (typeof REALTIME_STATUS)[keyof typeof REALTIME_STATUS];
 
 export const REALTIME_CLIENT_EVENT = {
+  SESSION_UPDATE: "session.update",
   INPUT_AUDIO_BUFFER_COMMIT: "input_audio_buffer.commit",
   INPUT_AUDIO_BUFFER_CLEAR: "input_audio_buffer.clear",
   CONVERSATION_ITEM_CREATE: "conversation.item.create",
@@ -1070,6 +1071,27 @@ export function pushToTalkCommitEvents(): readonly Record<string, unknown>[] {
  */
 export function clearInputAudioEvents(): readonly Record<string, unknown>[] {
   return [{ type: REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_CLEAR }];
+}
+
+/**
+ * Builds the event that changes how fast a live call speaks, from its next
+ * reply on.
+ *
+ * The pace is the one output setting the API lets a running session change —
+ * a session's voice locks the moment the model first speaks, so a changed
+ * voice is heard by opening a new call rather than by any event this module
+ * could build. The API applies a pace only between turns, which the caller is
+ * left to time; a pace that is not a usable number builds nothing rather than
+ * an update the API would refuse.
+ */
+export function outputSpeedUpdateEvents(speed: number): readonly Record<string, unknown>[] {
+  if (!Number.isFinite(speed) || speed <= 0) return [];
+  return [
+    {
+      type: REALTIME_CLIENT_EVENT.SESSION_UPDATE,
+      session: { type: REALTIME_SESSION_TYPE, audio: { output: { speed } } },
+    },
+  ];
 }
 
 /**

--- a/packages/sidecar-core/tests/realtime.test.ts
+++ b/packages/sidecar-core/tests/realtime.test.ts
@@ -26,6 +26,7 @@ import {
   normalizeSession,
   normalizeTrackedIssue,
   type ObservedWorkspaceProject,
+  outputSpeedUpdateEvents,
   proactiveSpeechEvents,
   pushToTalkCommitEvents,
   REALTIME_CLIENT_EVENT,
@@ -230,6 +231,23 @@ test("push-to-talk commits a turn and cancelling discards it", () => {
     clearInputAudioEvents().map((event) => event.type),
     [REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_CLEAR],
   );
+});
+
+test("a changed pace reaches the live session as a session update", () => {
+  const events = outputSpeedUpdateEvents(1.25);
+
+  assert.deepEqual(events, [
+    {
+      type: REALTIME_CLIENT_EVENT.SESSION_UPDATE,
+      session: { type: "realtime", audio: { output: { speed: 1.25 } } },
+    },
+  ]);
+});
+
+test("an unusable pace builds no update rather than one the API refuses", () => {
+  for (const speed of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+    assert.deepEqual(outputSpeedUpdateEvents(speed), []);
+  }
 });
 
 test("a typed ask travels as the developer's own words and asks for a reply", () => {


### PR DESCRIPTION
## What

Makes the **Voice** and **Speed** settings act immediately. A change used to be heard only from the next conversation on — and Luke offers no way to start a new conversation by hand, the call simply stays open — so both controls appeared not to act at all.

## Why

Voice and pace were baked into the ephemeral credential minted for each call (`openai-realtime-credentials.ts`). A settings change updated the minter for *future* credentials, but the live call never heard about it. Since the call is the conversation, the change effectively never landed.

## How

The two settings genuinely differ in what the Realtime API allows, so they take different roads:

- **Pace** (`sidecar-core/realtime.ts`, `realtime-session.ts`): the one output setting a running session may change. A new `outputSpeedUpdateEvents` builder carries it as a `session.update`; `RealtimeVoiceSession.applySpeed` sends it at once when nothing is speaking and holds one arriving mid-reply until the reply ends, because the API applies a speed only between model turns. Luke's next reply speaks at the new pace; nothing restarts.
- **Voice** (`app.tsx`): the API locks a session's voice the moment the model first speaks, so the renderer makes a change heard by quietly reopening the call — waiting out the turn under way, so a spoken "change your voice" is confirmed in the old voice before the new one takes over. The conversation starts afresh, because the call is the conversation. A call being opened counts as one to reopen, so a change racing the handshake still wins.
- **One hook for both hands**: the settings row and the spoken `change_app_setting` ask both land in the stored settings snapshot, so `app.tsx` watches the snapshot and covers them equally.
- **Honest words** (`luke-guide.ts`, `settings-panel.tsx`, `contracts.ts`, `main.ts`): the guide entries, the spoken outcome notes, the settings-row copy, and the stale comments now describe the new behavior — including the restart tradeoff — instead of promising "the next conversation on."

No new write path: the pace update and the reopen both live inside the voice session the renderer already owns, and the settings themselves still travel the same validated bridge calls.

## Checks

- `./scripts/check.sh` — exit 0 (sidecar-core 116/116, desktop 563/563, web 34/34)
- New tests: the `session.update` builder shape and refusal of unusable paces (`realtime.test.ts`); send-now, defer-mid-reply, and no-call-open paths (`realtime-session.test.ts`)
- `./scripts/verify.sh` — left to CI on macOS; the settings rows' helper text changed, no other visual change expected. Physical-notch check: not performed (cloud workspace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/f42506b2-d8be-4a8d-9fce-3a27dcbe2c9b)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31840407822/artifacts/9234058404) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31840407822)

- Commit: `bbb92f6a1f560d172e2beab073506dbed96db445`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
