### PR TITLE
feat(settings): open the tab into pages, and even out its rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ One key runs it, and it answers from whatever app is frontmost:
   is the frontmost window, and discards an open turn instead of sending it.
 
 Settings shows which keys you actually have — or an honest absence, if another
-app already owns a chord — under **Keyboard shortcuts**, one row each for the
+app already owns a chord — on its **Keyboard shortcuts** page, one row each for the
 talk, ask, and stop keys. The pencil beside a row records a chord of your own:
 hold `⌃`, `⌥` or `⌘` — `⇧` may join, but not carry a chord alone, since `⇧S`
 is how capitals are typed — and press a letter or Space, as the row itself
@@ -117,7 +117,7 @@ falls back to a press-to-start, press-to-send toggle and Settings says so.
 
 Settings lists the microphone under **Permissions**, with a green check once
 access is granted and a link to System Settings beside it. The voice Luke
-speaks with is chosen under **Preferences**; a change reaches the next
+speaks with is chosen on Settings' **Voice** page; a change reaches the next
 conversation to connect, and one already open keeps the voice it answered
 with.
 
@@ -131,7 +131,7 @@ Luke's face is the interface: it plays its listening motion while you speak and
 its talking motion while it answers, so the capsule says whose turn it is. Colour
 says the same thing again — the face and the meter beside it are green while you
 have the turn and blue while Luke has it — so a glance is enough even with the
-peek closed. Turn on captions under **Preferences** in Settings — they are off
+peek closed. Turn on captions on the **Voice** page in Settings — they are off
 by default — and Luke's words wrap along the bottom of whatever shape is up as he
 says them — capsule, peek, or panel — and leave when the reply does. Nothing is
 kept: the caption is the reply being said, not a record of it.
@@ -230,7 +230,7 @@ sentence (the session's title, provider, repository or branch, and any
 one-line error reason) is synthesized through the same voice service as the
 spoken conversation, so announcements need `OPENAI_API_KEY` and follow the
 same privacy boundary; see [PRIVACY.md](PRIVACY.md). They can be switched off
-in Settings · Preferences ("Announce when a session needs you"); the panel and
+in Settings · Voice ("Announce when a session needs you"); the panel and
 the capsule count show the same states either way.
 
 ## Optional attention review
@@ -251,8 +251,8 @@ control.
 | `LUKE_ATTENTION_MODEL` | `gpt-5.6-luna` | Selects the review model |
 | `OPENAI_BASE_URL` | `https://api.openai.com/v1` | Selects the Responses-compatible endpoint |
 | `LUKE_REALTIME_MODEL` | `gpt-realtime-2.1` | Selects the conversation model |
-| `LUKE_REALTIME_VOICE` | `cedar` | Selects the spoken voice until one is chosen in Settings · Preferences |
-| `LUKE_REALTIME_SPEED` | `1` | Selects the speaking pace (`0.75`, `1`, `1.25`, or `1.5`) until one is chosen in Settings · Preferences |
+| `LUKE_REALTIME_VOICE` | `cedar` | Selects the spoken voice until one is chosen in Settings · Voice |
+| `LUKE_REALTIME_SPEED` | `1` | Selects the speaking pace (`0.75`, `1`, `1.25`, or `1.5`) until one is chosen in Settings · Voice |
 
 Changing `OPENAI_BASE_URL` sends attention-review data to that endpoint instead
 of OpenAI. It does not redirect the conversation, which always uses OpenAI's own

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -452,9 +452,9 @@ export function App(): React.JSX.Element {
     setOptionsOpen(false);
     // Arriving at the tab is arriving at its front page: a page left open
     // behind a tab switch would greet the next visit with a corner of the
-    // settings rather than the settings. The one flow that needs a deeper
-    // page — a credential entry away in the key slot — never switches tabs
-    // on its way back, so its page survives this reset by never meeting it.
+    // settings rather than the settings. The flows that need a deeper page —
+    // a credential entry returning from the key slot, the evidence run that
+    // starts in it — set their page right after this reset.
     setSettingsView(SETTINGS_VIEW.ROOT);
   }, []);
 
@@ -843,6 +843,11 @@ export function App(): React.JSX.Element {
    */
   const restorePanel = useCallback(() => {
     changeTab(PANEL_TAB.SETTINGS);
+    // The line the entry belongs to lives on the Connections page, and
+    // changeTab has just reset the tab to its front page: without this, the
+    // check appearing beside the provider — the answer to what was just done
+    // — would land on a page nobody is looking at.
+    setSettingsView(SETTINGS_VIEW.CONNECTIONS);
     void changeMode(true);
   }, [changeMode, changeTab]);
 

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -78,6 +78,7 @@ import {
   tallySummary,
 } from "./session-model";
 import { SESSION_OPTIONS_BUTTON_ID, SESSION_OPTIONS_ID } from "./session-parts";
+import { SETTINGS_VIEW, type SettingsView } from "./settings-views";
 import { SpokenNoticeAnnouncer } from "./spoken-notices";
 import {
   outputSilent,
@@ -283,6 +284,7 @@ export function App(): React.JSX.Element {
   const [display, setDisplay] = useState<DisplayDiagnostic>();
   const [presentation, setPresentation] = useState<PanelPresentation>(PANEL_PRESENTATION.CAPSULE);
   const [tab, setTab] = useState<PanelTab>(PANEL_TAB.SESSIONS);
+  const [settingsView, setSettingsView] = useState<SettingsView>(SETTINGS_VIEW.ROOT);
   const [sessionView, setSessionView] = useState<SessionView>(DEFAULT_SESSION_VIEW);
   const [optionsOpen, setOptionsOpen] = useState(false);
   const [settings, setSettings] = useState<AppSettings>();
@@ -448,6 +450,12 @@ export function App(): React.JSX.Element {
     // The sheet belongs to the session list, and it is drawn over the list it
     // belongs to, so leaving for Settings has to take it along.
     setOptionsOpen(false);
+    // Arriving at the tab is arriving at its front page: a page left open
+    // behind a tab switch would greet the next visit with a corner of the
+    // settings rather than the settings. The one flow that needs a deeper
+    // page — a credential entry away in the key slot — never switches tabs
+    // on its way back, so its page survives this reset by never meeting it.
+    setSettingsView(SETTINGS_VIEW.ROOT);
   }, []);
 
   // A choice made in the sheet puts the sheet away. It is drawn over the list
@@ -1515,9 +1523,10 @@ export function App(): React.JSX.Element {
         // the shape with it, as it does anywhere else.
         const [firstProvider] = CREDENTIAL_PROVIDER_LIST;
         if (value.startInSlot && value.mode === "expanded" && firstProvider) {
-          // The tab an entry begins on, so pressing the capsule from here lands
-          // where it would have in the flow this is standing in for.
+          // The tab and page an entry begins on, so pressing the capsule from
+          // here lands where it would have in the flow this is standing in for.
           changeTab(PANEL_TAB.SETTINGS);
+          setSettingsView(SETTINGS_VIEW.CONNECTIONS);
           beginEntry(firstProvider.id);
         }
       }
@@ -1802,9 +1811,12 @@ export function App(): React.JSX.Element {
       }
       if (presentation !== PANEL_PRESENTATION.PANEL) return;
       // Otherwise it closes the nearest thing that is open, one layer at a
-      // time: the options sheet, then the settings tab, then the panel itself.
+      // time: the options sheet, then a settings page back to the front page,
+      // then the settings tab, then the panel itself.
       if (optionsOpen) setOptionsOpen(false);
-      else if (tab === PANEL_TAB.SETTINGS) changeTab(PANEL_TAB.SESSIONS);
+      else if (tab === PANEL_TAB.SETTINGS && settingsView !== SETTINGS_VIEW.ROOT) {
+        setSettingsView(SETTINGS_VIEW.ROOT);
+      } else if (tab === PANEL_TAB.SETTINGS) changeTab(PANEL_TAB.SESSIONS);
       else void changeMode(false);
     };
     window.addEventListener("keydown", handleKey);
@@ -1816,6 +1828,7 @@ export function App(): React.JSX.Element {
     dismissFeedback,
     optionsOpen,
     presentation,
+    settingsView,
     tab,
     voiceStatus,
   ]);
@@ -2020,6 +2033,8 @@ export function App(): React.JSX.Element {
             tab={tab}
             onTabChange={changeTab}
             settings={{
+              view: settingsView,
+              onViewChange: setSettingsView,
               microphoneStatus,
               microphoneError,
               onRequestMicrophone: () => void requestMicrophoneAccess(),

--- a/apps/desktop/src/renderer/feedback-panel.tsx
+++ b/apps/desktop/src/renderer/feedback-panel.tsx
@@ -33,15 +33,15 @@ function FeedbackOffer({
 }
 
 /**
- * The last section of the settings tab: the two ways to write to the people
- * who make Luke. The section only offers — pressing either button stands the
+ * The last section of the settings front page: the two ways to write to the
+ * people who make Luke. The section only offers — pressing either button stands the
  * panel down to the composer's own shape, the way pressing Connect stands it
  * down to the key slot — and the line under the offers is where a landed send
  * reports back.
  */
 export function FeedbackSection({ control }: { control: FeedbackEntryControl }): React.JSX.Element {
   return (
-    <section className="settings-section" style={{ "--row-index": 5 } as React.CSSProperties}>
+    <section className="settings-section" style={{ "--row-index": 3 } as React.CSSProperties}>
       <h2>
         <MegaphoneIcon />
         Feedback

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -62,6 +62,13 @@ export type AppSettingId = (typeof APP_SETTING_ID)[keyof typeof APP_SETTING_ID];
 /** Where the switches live, said once so every entry words it the same way. */
 const SETTINGS_TAB = "the panel's Settings tab";
 
+/* The tab's front page opens pages, and each setting is changed by hand on
+   one of them — so every by-hand path names its page, worded once each. */
+const VOICE_PAGE = `${SETTINGS_TAB}, on its Voice page`;
+const APPEARANCE_PAGE = `${SETTINGS_TAB}, on its Appearance page`;
+const SHORTCUTS_PAGE = `${SETTINGS_TAB}, on its Keyboard shortcuts page`;
+const CONNECTIONS_PAGE = `${SETTINGS_TAB}, on its Connections page`;
+
 /**
  * The words a pace is asked for in, slowest to fastest, each paired with the
  * multiple it means. The settings row shows the multiples; a conversation
@@ -99,7 +106,7 @@ const SETTING_GUIDE: Record<
     value: settings.voice,
     choices: REALTIME_VOICE_LIST,
     adjustable: true,
-    manual: `${SETTINGS_TAB}, under Preferences`,
+    manual: VOICE_PAGE,
   }),
   voiceSpeed: (settings) => ({
     id: APP_SETTING_ID.VOICE_SPEED,
@@ -110,7 +117,7 @@ const SETTING_GUIDE: Record<
     value: voiceSpeedWord(settings.voiceSpeed),
     choices: VOICE_SPEED_WORDS.map((candidate) => candidate.word),
     adjustable: true,
-    manual: `${SETTINGS_TAB}, under Preferences`,
+    manual: VOICE_PAGE,
   }),
   voiceCaptions: (settings) => ({
     id: APP_SETTING_ID.VOICE_CAPTIONS,
@@ -121,7 +128,7 @@ const SETTING_GUIDE: Record<
     kind: APP_SETTING_KIND.TOGGLE,
     value: appToggleText(settings.voiceCaptions),
     adjustable: true,
-    manual: `${SETTINGS_TAB}, under Preferences`,
+    manual: VOICE_PAGE,
   }),
   duckOtherMedia: (settings) => ({
     id: APP_SETTING_ID.DUCK_OTHER_MEDIA,
@@ -131,7 +138,7 @@ const SETTING_GUIDE: Record<
     kind: APP_SETTING_KIND.TOGGLE,
     value: appToggleText(settings.duckOtherMedia),
     adjustable: true,
-    manual: `${SETTINGS_TAB}, under Preferences`,
+    manual: VOICE_PAGE,
   }),
   sessionNotifications: (settings) => ({
     id: APP_SETTING_ID.SESSION_NOTIFICATIONS,
@@ -143,7 +150,7 @@ const SETTING_GUIDE: Record<
     kind: APP_SETTING_KIND.TOGGLE,
     value: appToggleText(settings.sessionNotifications),
     adjustable: true,
-    manual: `${SETTINGS_TAB}, under Preferences`,
+    manual: VOICE_PAGE,
   }),
   showInMenuBar: (settings) => ({
     id: APP_SETTING_ID.SHOW_IN_MENU_BAR,
@@ -152,7 +159,7 @@ const SETTING_GUIDE: Record<
     kind: APP_SETTING_KIND.TOGGLE,
     value: appToggleText(settings.showInMenuBar),
     adjustable: true,
-    manual: `${SETTINGS_TAB}, under Preferences`,
+    manual: APPEARANCE_PAGE,
   }),
   showInDock: (settings) => ({
     id: APP_SETTING_ID.SHOW_IN_DOCK,
@@ -161,7 +168,7 @@ const SETTING_GUIDE: Record<
     kind: APP_SETTING_KIND.TOGGLE,
     value: appToggleText(settings.showInDock),
     adjustable: true,
-    manual: `${SETTINGS_TAB}, under Preferences`,
+    manual: APPEARANCE_PAGE,
   }),
   showOnAllDisplays: (settings) => ({
     id: APP_SETTING_ID.SHOW_ON_ALL_DISPLAYS,
@@ -171,7 +178,7 @@ const SETTING_GUIDE: Record<
     kind: APP_SETTING_KIND.TOGGLE,
     value: appToggleText(settings.showOnAllDisplays),
     adjustable: true,
-    manual: `${SETTINGS_TAB}, under Preferences`,
+    manual: APPEARANCE_PAGE,
   }),
   formFactor: (settings) => ({
     id: APP_SETTING_ID.FORM_FACTOR,
@@ -182,7 +189,7 @@ const SETTING_GUIDE: Record<
     value: settings.formFactor,
     choices: PANEL_FORM_FACTOR_LIST,
     adjustable: true,
-    manual: `${SETTINGS_TAB}, under Preferences`,
+    manual: APPEARANCE_PAGE,
   }),
   // Described in the talk-key fact instead, which carries the key that
   // actually registered — this field is only the stored choice, absent on the
@@ -230,7 +237,7 @@ function talkKeyFact(hotkey: LukeGuideInput["hotkey"]): AppGuideFact {
     return {
       label: "Talk key",
       detail:
-        "None is registered right now — another app may own the shortcut. The Settings tab shows its state.",
+        "None is registered right now — another app may own the shortcut. The Settings tab's Keyboard shortcuts page shows its state.",
     };
   }
   const use = hotkey.held
@@ -238,7 +245,7 @@ function talkKeyFact(hotkey: LukeGuideInput["hotkey"]): AppGuideFact {
     : "press to talk, again to send, again to interrupt";
   return {
     label: "Talk key",
-    detail: `${hotkey.hotkey}, from any app: ${use}. A different chord can be recorded, or the default restored, in ${SETTINGS_TAB}.`,
+    detail: `${hotkey.hotkey}, from any app: ${use}. A different chord can be recorded, or the default restored, in ${SHORTCUTS_PAGE}.`,
   };
 }
 
@@ -247,14 +254,14 @@ function askKeyFact(askKey: string | undefined): AppGuideFact {
     return {
       label: "Ask key",
       detail:
-        "None is registered right now — another app may own the shortcut, or voice is off. The Settings tab shows its state.",
+        "None is registered right now — another app may own the shortcut, or voice is off. The Settings tab's Keyboard shortcuts page shows its state.",
     };
   }
   return {
     label: "Ask key",
     detail:
       `${askKey}, from any app: summons the panel with the caret in the typed composer, and the ` +
-      `same press puts it away. A different chord can be recorded, or the default restored, in ${SETTINGS_TAB}.`,
+      `same press puts it away. A different chord can be recorded, or the default restored, in ${SHORTCUTS_PAGE}.`,
   };
 }
 
@@ -284,9 +291,9 @@ function providersFact(settings: AppSettings): AppGuideFact {
   return {
     label: "Cloud providers",
     detail:
-      `${roster.join(", ")}. Connecting one takes its API key, typed by hand into ${SETTINGS_TAB} ` +
-      "under Cloud Agent API keys — never spoken, and never repeated back. Local providers such " +
-      "as Claude Code need no key and are observed on their own.",
+      `${roster.join(", ")}. Connecting one takes its API key, typed by hand into ` +
+      `${CONNECTIONS_PAGE}, under Cloud Agent API keys — never spoken, and never repeated back. ` +
+      "Local providers such as Claude Code need no key and are observed on their own.",
   };
 }
 
@@ -300,7 +307,7 @@ function integrationsFact(settings: AppSettings): AppGuideFact {
     detail:
       `${roster.join(", ")}. Connecting Linear lets Luke read the developer's issues and, only ` +
       `when asked in a turn the developer opened, move or comment on one. Its key is typed by ` +
-      `hand into ${SETTINGS_TAB} under Integrations — never spoken, and never repeated back.`,
+      `hand into ${CONNECTIONS_PAGE}, under Integrations — never spoken, and never repeated back.`,
   };
 }
 
@@ -327,8 +334,10 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "Sessions lists every observed session with its state, narrowable to all, local, " +
         "cloud, or one provider, and orderable by urgency (what needs the developer first) or " +
         "recency (what moved last first); a row can be opened, messaged, or controlled where its " +
-        "provider allows. Settings holds the preferences, the talk and ask keys, the cloud " +
-        "agent API keys, the integrations, permissions, the Feedback section, and Quit.",
+        "provider allows. Settings holds a front page whose rows open its Voice, Appearance, " +
+        "Keyboard shortcuts, and Connections pages — each led back out by its back button or " +
+        "Escape — and keeps the microphone permission, the Feedback section, and Quit on the " +
+        "front page itself.",
     },
     {
       label: "Feedback and prompts",
@@ -377,7 +386,7 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
                   "may own the shortcut.") +
               " The talk key over a reply interrupts too, but takes the turn: the microphone " +
               `opens with the same press. A different stop chord can be recorded, or the ` +
-              `default restored, in ${SETTINGS_TAB}.`,
+              `default restored, in ${SHORTCUTS_PAGE}.`,
           },
           {
             label: "Muted output",

--- a/apps/desktop/src/renderer/settings-icons.tsx
+++ b/apps/desktop/src/renderer/settings-icons.tsx
@@ -112,6 +112,46 @@ export function PlugIcon(): React.JSX.Element {
   );
 }
 
+/** Points into a page: the row it sits on opens one. */
+export function ChevronIcon(): React.JSX.Element {
+  return (
+    <Glyph className="settings-chevron">
+      <path d="m9.4 5.8 6.2 6.2-6.2 6.2" />
+    </Glyph>
+  );
+}
+
+/** Points back out of one: the control that returns to the front page. */
+export function BackIcon(): React.JSX.Element {
+  return (
+    <Glyph className="icon-button-glyph">
+      <path d="m14.6 5.8-6.2 6.2 6.2 6.2" />
+    </Glyph>
+  );
+}
+
+/** Sound leaving the machine: everything about how Luke is heard. */
+export function SpeakerIcon(): React.JSX.Element {
+  return (
+    <Glyph>
+      <path d="M4 9.4h2.9L11.6 5v14L6.9 14.6H4Z" />
+      <path d="M14.8 9.3a4.1 4.1 0 0 1 0 5.4" />
+      <path d="M17.6 6.9a7.6 7.6 0 0 1 0 10.2" />
+    </Glyph>
+  );
+}
+
+/** The display Luke stands on: everything about where and how he is drawn. */
+export function DisplayIcon(): React.JSX.Element {
+  return (
+    <Glyph>
+      <rect x="3.2" y="4.4" width="17.6" height="12.2" rx="2" />
+      <path d="M9.4 20.2h5.2" />
+      <path d="M12 16.6v3.6" />
+    </Glyph>
+  );
+}
+
 export function KeyboardIcon(): React.JSX.Element {
   return (
     <Glyph>

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -67,7 +67,7 @@ import {
   TrashIcon,
 } from "./settings-icons";
 import {
-  PAGE_EXIT_MS,
+  pageExitMs,
   SETTINGS_SUBVIEW_LIST,
   SETTINGS_VIEW,
   type SettingsSubview,
@@ -1351,7 +1351,10 @@ export function SettingsPanel({
   // The page as drawn, trailing the page as asked: turning one is a leave and
   // then an arrival, and the leaving page must be held mounted through its own
   // exit — the surface never resizes out from under something still drawn.
-  // The swap is timed off the same token the stylesheet fades with.
+  // The swap is timed off the token the stylesheet fades with, read live off
+  // the element: a capture run and reduced motion zero it, and the drawn page
+  // has to swap as fast as the fade they stilled.
+  const box = useRef<HTMLDivElement | null>(null);
   const [drawnView, setDrawnView] = useState(view);
   // Whether a page has turned since this panel mounted, which is what scopes
   // the arrival animation: the tab's first draw belongs to the panel-arrival
@@ -1363,7 +1366,7 @@ export function SettingsPanel({
     const timer = window.setTimeout(() => {
       setDrawnView(view);
       setTurned(true);
-    }, PAGE_EXIT_MS);
+    }, pageExitMs(box.current));
     return () => window.clearTimeout(timer);
   }, [leaving, view]);
   // Moving between pages moves the keyboard with it: into a page, onto its
@@ -1388,6 +1391,7 @@ export function SettingsPanel({
   }, [drawnView, panelOpen]);
   return (
     <div
+      ref={box}
       className="settings"
       role="tabpanel"
       id={panelPanelId(PANEL_TAB.SETTINGS)}

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -49,8 +49,11 @@ import { microphoneAccessRow } from "./microphone-access";
 import { PANEL_TAB, panelPanelId, panelTabId } from "./panel-tabs";
 import { CloudBadge, ProviderMark } from "./provider-marks";
 import {
+  BackIcon,
   CheckIcon,
+  ChevronIcon,
   CloseIcon,
+  DisplayIcon,
   ExternalIcon,
   KeyboardIcon,
   KeyIcon,
@@ -58,13 +61,28 @@ import {
   PlugIcon,
   PopUpIcon,
   PowerIcon,
-  PreferencesIcon,
   ResetIcon,
   ShieldIcon,
+  SpeakerIcon,
   TrashIcon,
 } from "./settings-icons";
+import {
+  SETTINGS_SUBVIEW_LIST,
+  SETTINGS_VIEW,
+  type SettingsSubview,
+  type SettingsView,
+  settingsNavRowId,
+} from "./settings-views";
 
 export interface SettingsPanelProps {
+  /**
+   * Which settings page is showing: the front page, or one of the pages a
+   * front-page row opens. Held by the app rather than here because Escape
+   * unwinds it and a credential entry has to survive a trip to the key slot
+   * with its page intact.
+   */
+  view: SettingsView;
+  onViewChange: (view: SettingsView) => void;
   microphoneStatus: MicrophoneStatus;
   microphoneError?: string;
   /** Asks the system for access. Using the microphone is the talk key's job. */
@@ -564,7 +582,7 @@ function CredentialsSection({
   // about storage nobody has tried to use yet would be a guess.
   const storageUnavailable = settings.secretStorage === SECRET_STORAGE.UNAVAILABLE;
   return (
-    <section className="settings-section" style={{ "--row-index": 3 } as React.CSSProperties}>
+    <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
       <h2>
         <KeyIcon />
         Cloud Agent API keys
@@ -606,7 +624,7 @@ function IntegrationsSection({
 }): React.JSX.Element {
   const storageUnavailable = settings.secretStorage === SECRET_STORAGE.UNAVAILABLE;
   return (
-    <section className="settings-section" style={{ "--row-index": 4 } as React.CSSProperties}>
+    <section className="settings-section" style={{ "--row-index": 2 } as React.CSSProperties}>
       <h2>
         <PlugIcon />
         Integrations
@@ -629,17 +647,108 @@ function IntegrationsSection({
 }
 
 /**
- * The user's own choices about Luke, ahead of the sections about what Luke can
- * reach. The voice he speaks with comes first — it is what Luke *is* to the
- * ear — offered the way macOS offers one value from a small fixed set: a
- * pop-up button whose closed face is drawn here and whose open menu is the
- * system's, which also lets it escape a window sized to the panel rather than
- * being clipped by it. Below it, whether Luke stands in the menu bar and in
- * the Dock as well as at the notch: switches and nothing else, because nothing
- * rides on either answer — Settings and Quit live in this panel, so each is a
- * second door rather than the only one.
+ * What each page is called on the front page and at its own head, with the
+ * line under the name that says what it holds. One table, because the row
+ * that opens a page and the header that leaves it must never disagree about
+ * its name.
  */
-function PreferencesSection({
+const SETTINGS_PAGE: Record<
+  SettingsSubview,
+  { title: string; summary: string; icon: React.JSX.Element }
+> = {
+  [SETTINGS_VIEW.VOICE]: {
+    title: "Voice",
+    summary: "How Luke sounds, captions, and announcements.",
+    icon: <SpeakerIcon />,
+  },
+  [SETTINGS_VIEW.APPEARANCE]: {
+    title: "Appearance",
+    summary: "Menu bar, Dock, displays, and form factor.",
+    icon: <DisplayIcon />,
+  },
+  [SETTINGS_VIEW.SHORTCUTS]: {
+    title: "Keyboard shortcuts",
+    summary: "The talk, ask, and stop keys.",
+    icon: <KeyboardIcon />,
+  },
+  [SETTINGS_VIEW.CONNECTIONS]: {
+    title: "Connections",
+    summary: "Cloud agent API keys and integrations.",
+    icon: <PlugIcon />,
+  },
+};
+
+/**
+ * One front-page row per page: its glyph, its name, what it holds, and the
+ * chevron that promises a page rather than a control. The row is the whole
+ * press target, the way a macOS settings row is.
+ */
+function SettingsNavRow({
+  view,
+  onOpen,
+}: {
+  view: SettingsSubview;
+  onOpen: (view: SettingsSubview) => void;
+}): React.JSX.Element {
+  const page = SETTINGS_PAGE[view];
+  return (
+    <button
+      type="button"
+      id={settingsNavRowId(view)}
+      className="settings-nav"
+      onClick={() => onOpen(view)}
+    >
+      <span className="settings-nav-mark" aria-hidden="true">
+        {page.icon}
+      </span>
+      <span className="settings-copy">
+        <strong>{page.title}</strong>
+        <small>{page.summary}</small>
+      </span>
+      <ChevronIcon />
+    </button>
+  );
+}
+
+/**
+ * A page's head: the way back beside the page's own name. The back button
+ * returns to the front page and nothing else — a page holds no unsaved state
+ * of its own, so leaving one never needs a warning.
+ */
+function SettingsPageHeader({
+  view,
+  onBack,
+  backControl,
+}: {
+  view: SettingsSubview;
+  onBack: () => void;
+  backControl: React.RefObject<HTMLButtonElement | null>;
+}): React.JSX.Element {
+  return (
+    <div className="settings-header" style={{ "--row-index": 0 } as React.CSSProperties}>
+      <button
+        type="button"
+        ref={backControl}
+        className="icon-button"
+        aria-label="Back to Settings"
+        title="Back"
+        onClick={onBack}
+      >
+        <BackIcon />
+      </button>
+      <strong>{SETTINGS_PAGE[view].title}</strong>
+    </div>
+  );
+}
+
+/**
+ * How Luke sounds and what he says unprompted. The voice he speaks with comes
+ * first — it is what Luke *is* to the ear — offered the way macOS offers one
+ * value from a small fixed set: a pop-up button whose closed face is drawn
+ * here and whose open menu is the system's, which also lets it escape a
+ * window sized to the panel rather than being clipped by it.
+ */
+function VoiceSection({
   voice,
   onVoiceChange,
   speed,
@@ -650,14 +759,6 @@ function PreferencesSection({
   onDuckOtherMediaChange,
   notifications,
   onSessionNotificationsChange,
-  shown,
-  onShowInMenuBarChange,
-  dockShown,
-  onShowInDockChange,
-  allDisplays,
-  onShowOnAllDisplaysChange,
-  formFactor,
-  onFormFactorChange,
 }: {
   voice: RealtimeVoice;
   onVoiceChange: (voice: RealtimeVoice) => void;
@@ -669,38 +770,18 @@ function PreferencesSection({
   onDuckOtherMediaChange: (enabled: boolean) => Promise<string | undefined>;
   notifications: boolean;
   onSessionNotificationsChange: (enabled: boolean) => Promise<string | undefined>;
-  shown: boolean;
-  onShowInMenuBarChange: (show: boolean) => Promise<string | undefined>;
-  dockShown: boolean;
-  onShowInDockChange: (show: boolean) => Promise<string | undefined>;
-  allDisplays: boolean;
-  onShowOnAllDisplaysChange: (show: boolean) => Promise<string | undefined>;
-  formFactor: PanelFormFactor;
-  onFormFactorChange: (formFactor: PanelFormFactor) => Promise<string | undefined>;
 }): React.JSX.Element {
-  // The change is a round trip through the settings file, so the switch rests
-  // until the store has answered rather than claiming a state it may not get.
-  const [busy, setBusy] = useState(false);
+  // Each change is a round trip through the settings file, so each switch
+  // rests on its own flag until the store has answered rather than claiming a
+  // state it may not get — one save in flight must not still another switch.
+  // The rejection line is shared: it reports the last answer, whichever row
+  // asked.
   const [rejection, setRejection] = useState<string>();
-  const toggle = async () => {
-    setBusy(true);
-    setRejection(await onShowInMenuBarChange(!shown));
-    setBusy(false);
-  };
-  // Its own rest, because it is its own round trip: one save in flight must
-  // not still the other switch. The rejection line is shared — it reports the
-  // last answer, whichever row asked.
   const [captionsBusy, setCaptionsBusy] = useState(false);
   const toggleCaptions = async () => {
     setCaptionsBusy(true);
     setRejection(await onVoiceCaptionsChange(!captions));
     setCaptionsBusy(false);
-  };
-  const [dockBusy, setDockBusy] = useState(false);
-  const toggleDock = async () => {
-    setDockBusy(true);
-    setRejection(await onShowInDockChange(!dockShown));
-    setDockBusy(false);
   };
   const [duckBusy, setDuckBusy] = useState(false);
   const toggleDucking = async () => {
@@ -714,26 +795,8 @@ function PreferencesSection({
     setRejection(await onSessionNotificationsChange(!notifications));
     setNotificationsBusy(false);
   };
-  // The display and form rows round-trip like the switches above, so each
-  // rests on its own flag and answers on the shared rejection line.
-  const [displayBusy, setDisplayBusy] = useState(false);
-  const toggleAllDisplays = async () => {
-    setDisplayBusy(true);
-    setRejection(await onShowOnAllDisplaysChange(!allDisplays));
-    setDisplayBusy(false);
-  };
-  const [formBusy, setFormBusy] = useState(false);
-  const chooseFormFactor = async (nextFormFactor: PanelFormFactor) => {
-    setFormBusy(true);
-    setRejection(await onFormFactorChange(nextFormFactor));
-    setFormBusy(false);
-  };
   return (
     <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
-      <h2>
-        <PreferencesIcon />
-        Preferences
-      </h2>
       <div className="settings-row">
         <span className="settings-copy">
           <strong>Voice</strong>
@@ -875,6 +938,67 @@ function PreferencesSection({
           <span className="switch-thumb" />
         </button>
       </div>
+      {rejection ? <p className="error-message">{rejection}</p> : null}
+    </section>
+  );
+}
+
+/**
+ * Where Luke stands and how he is drawn: the menu bar and the Dock as second
+ * doors — Settings and Quit live in this panel, so neither is the only one —
+ * every display or just the main one, and the form he takes on a display
+ * without a housing. Switches and one pop-up, because nothing rides on any
+ * answer here.
+ */
+function AppearanceSection({
+  shown,
+  onShowInMenuBarChange,
+  dockShown,
+  onShowInDockChange,
+  allDisplays,
+  onShowOnAllDisplaysChange,
+  formFactor,
+  onFormFactorChange,
+}: {
+  shown: boolean;
+  onShowInMenuBarChange: (show: boolean) => Promise<string | undefined>;
+  dockShown: boolean;
+  onShowInDockChange: (show: boolean) => Promise<string | undefined>;
+  allDisplays: boolean;
+  onShowOnAllDisplaysChange: (show: boolean) => Promise<string | undefined>;
+  formFactor: PanelFormFactor;
+  onFormFactorChange: (formFactor: PanelFormFactor) => Promise<string | undefined>;
+}): React.JSX.Element {
+  // The same resting discipline the Voice page's switches keep: each change is
+  // its own round trip, each control rests on its own flag, and the rejection
+  // line reports the last answer whichever row asked.
+  const [rejection, setRejection] = useState<string>();
+  const [busy, setBusy] = useState(false);
+  const toggle = async () => {
+    setBusy(true);
+    setRejection(await onShowInMenuBarChange(!shown));
+    setBusy(false);
+  };
+  const [dockBusy, setDockBusy] = useState(false);
+  const toggleDock = async () => {
+    setDockBusy(true);
+    setRejection(await onShowInDockChange(!dockShown));
+    setDockBusy(false);
+  };
+  const [displayBusy, setDisplayBusy] = useState(false);
+  const toggleAllDisplays = async () => {
+    setDisplayBusy(true);
+    setRejection(await onShowOnAllDisplaysChange(!allDisplays));
+    setDisplayBusy(false);
+  };
+  const [formBusy, setFormBusy] = useState(false);
+  const chooseFormFactor = async (nextFormFactor: PanelFormFactor) => {
+    setFormBusy(true);
+    setRejection(await onFormFactorChange(nextFormFactor));
+    setFormBusy(false);
+  };
+  return (
+    <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
       <div className="settings-row">
         <span className="settings-copy">
           <strong>Show Luke in the menu bar</strong>
@@ -1150,11 +1274,7 @@ function ShortcutSection({
   onShortcutCapture: (capturing: boolean) => void;
 }): React.JSX.Element {
   return (
-    <section className="settings-section" style={{ "--row-index": 2 } as React.CSSProperties}>
-      <h2>
-        <KeyboardIcon />
-        Keyboard shortcuts
-      </h2>
+    <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
       <ShortcutRow
         title="Talk to Luke"
         // What the key actually does, which depends on whether it can report
@@ -1194,6 +1314,8 @@ function ShortcutSection({
 }
 
 export function SettingsPanel({
+  view,
+  onViewChange,
   microphoneStatus,
   microphoneError,
   onRequestMicrophone,
@@ -1223,6 +1345,25 @@ export function SettingsPanel({
   onShortcutCapture,
 }: SettingsPanelProps): React.JSX.Element {
   const microphone = microphoneAccessRow({ voiceAvailable, status: microphoneStatus });
+  // Moving between pages moves the keyboard with it: into a page, onto its
+  // back button; back out, onto the row that opened the page just left. Only
+  // while the panel is the shape on screen — a view reset behind a closed
+  // panel is housekeeping, and reaching into an inert stage would find
+  // nothing focusable anyway.
+  const backControl = useRef<HTMLButtonElement | null>(null);
+  const heldView = useRef(view);
+  useEffect(() => {
+    const previous = heldView.current;
+    heldView.current = view;
+    if (previous === view || !panelOpen) return;
+    if (view === SETTINGS_VIEW.ROOT) {
+      if (previous !== SETTINGS_VIEW.ROOT) {
+        document.getElementById(settingsNavRowId(previous))?.focus();
+      }
+      return;
+    }
+    backControl.current?.focus();
+  }, [view, panelOpen]);
   return (
     <div
       className="settings"
@@ -1230,8 +1371,27 @@ export function SettingsPanel({
       id={panelPanelId(PANEL_TAB.SETTINGS)}
       aria-labelledby={panelTabId(PANEL_TAB.SETTINGS)}
     >
-      {settings ? (
-        <PreferencesSection
+      {view !== SETTINGS_VIEW.ROOT ? (
+        <SettingsPageHeader
+          view={view}
+          onBack={() => onViewChange(SETTINGS_VIEW.ROOT)}
+          backControl={backControl}
+        />
+      ) : null}
+
+      {view === SETTINGS_VIEW.ROOT ? (
+        /* The front page: one row per page, then the sections that answer at
+           a glance — what Luke is allowed, the way to the founders, and the
+           way out. */
+        <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
+          {SETTINGS_SUBVIEW_LIST.map((subview) => (
+            <SettingsNavRow key={subview} view={subview} onOpen={onViewChange} />
+          ))}
+        </section>
+      ) : null}
+
+      {view === SETTINGS_VIEW.VOICE && settings ? (
+        <VoiceSection
           voice={settings.voice}
           onVoiceChange={onVoiceChange}
           speed={settings.voiceSpeed}
@@ -1242,6 +1402,11 @@ export function SettingsPanel({
           onDuckOtherMediaChange={onDuckOtherMediaChange}
           notifications={settings.sessionNotifications}
           onSessionNotificationsChange={onSessionNotificationsChange}
+        />
+      ) : null}
+
+      {view === SETTINGS_VIEW.APPEARANCE && settings ? (
+        <AppearanceSection
           shown={settings.showInMenuBar}
           onShowInMenuBarChange={onShowInMenuBarChange}
           dockShown={settings.showInDock}
@@ -1253,82 +1418,87 @@ export function SettingsPanel({
         />
       ) : null}
 
-      <ShortcutSection
-        {...(voiceHotkey ? { voiceHotkey } : {})}
-        voiceHotkeyHeld={voiceHotkeyHeld}
-        chosen={settings?.voiceHotkey !== undefined}
-        onVoiceHotkeyChange={onVoiceHotkeyChange}
-        {...(askHotkey ? { askHotkey } : {})}
-        askChosen={settings?.askHotkey !== undefined}
-        onAskHotkeyChange={onAskHotkeyChange}
-        {...(stopHotkey ? { stopHotkey } : {})}
-        stopChosen={settings?.stopHotkey !== undefined}
-        onStopHotkeyChange={onStopHotkeyChange}
-        onShortcutCapture={onShortcutCapture}
-      />
-
-      {settings ? (
-        <CredentialsSection settings={settings} control={credentials} panelOpen={panelOpen} />
+      {view === SETTINGS_VIEW.SHORTCUTS ? (
+        <ShortcutSection
+          {...(voiceHotkey ? { voiceHotkey } : {})}
+          voiceHotkeyHeld={voiceHotkeyHeld}
+          chosen={settings?.voiceHotkey !== undefined}
+          onVoiceHotkeyChange={onVoiceHotkeyChange}
+          {...(askHotkey ? { askHotkey } : {})}
+          askChosen={settings?.askHotkey !== undefined}
+          onAskHotkeyChange={onAskHotkeyChange}
+          {...(stopHotkey ? { stopHotkey } : {})}
+          stopChosen={settings?.stopHotkey !== undefined}
+          onStopHotkeyChange={onStopHotkeyChange}
+          onShortcutCapture={onShortcutCapture}
+        />
       ) : null}
 
-      {settings ? (
-        <IntegrationsSection settings={settings} control={credentials} panelOpen={panelOpen} />
+      {view === SETTINGS_VIEW.CONNECTIONS && settings ? (
+        <>
+          <CredentialsSection settings={settings} control={credentials} panelOpen={panelOpen} />
+          <IntegrationsSection settings={settings} control={credentials} panelOpen={panelOpen} />
+        </>
       ) : null}
 
-      <section className="settings-section" style={{ "--row-index": 5 } as React.CSSProperties}>
-        <h2>
-          <ShieldIcon />
-          Permissions
-        </h2>
-        {/* Access, not use. The talk key is what opens the microphone, so a
+      {view !== SETTINGS_VIEW.ROOT ? null : (
+        <>
+          <section className="settings-section" style={{ "--row-index": 2 } as React.CSSProperties}>
+            <h2>
+              <ShieldIcon />
+              Permissions
+            </h2>
+            {/* Access, not use. The talk key is what opens the microphone, so a
             button here could only ever repeat what the key already does — the
             line answers the one question it can: whether Luke is allowed. */}
-        {/* Named and marked like a provider, because it is the same question in
+            {/* Named and marked like a provider, because it is the same question in
             the same words: what Luke has been let at, and whether it is on.
             Access, not use — the talk key is what opens the microphone, so a
             control here could only repeat what the key already does. */}
-        <div className="settings-row">
-          <span className="settings-copy">
-            <span className="settings-name">
-              <strong>Microphone</strong>
-              {microphone.ready ? <CheckIcon /> : null}
-            </span>
-            <small>{microphone.detail}</small>
-          </span>
-          <span className="settings-actions">
-            {microphone.offerSystemSettings ? (
-              <button
-                type="button"
-                className="icon-button"
-                aria-label="Open Privacy & Security in System Settings"
-                /* The ellipsis is the promise that it opens somewhere else. */
-                title="System Settings…"
-                onClick={onOpenMicrophoneSettings}
-              >
-                <ExternalIcon />
-              </button>
-            ) : null}
-            {microphone.offerAccess ? (
-              <button type="button" className="quiet-button" onClick={onRequestMicrophone}>
-                Allow
-              </button>
-            ) : null}
-          </span>
-        </div>
-        {microphoneError ? <p className="error-message">{microphoneError}</p> : null}
-      </section>
+            <div className="settings-row">
+              <span className="settings-copy">
+                <span className="settings-name">
+                  <strong>Microphone</strong>
+                  {microphone.ready ? <CheckIcon /> : null}
+                </span>
+                <small>{microphone.detail}</small>
+              </span>
+              <span className="settings-actions">
+                {microphone.offerSystemSettings ? (
+                  <button
+                    type="button"
+                    className="icon-button"
+                    aria-label="Open Privacy & Security in System Settings"
+                    /* The ellipsis is the promise that it opens somewhere else. */
+                    title="System Settings…"
+                    onClick={onOpenMicrophoneSettings}
+                  >
+                    <ExternalIcon />
+                  </button>
+                ) : null}
+                {microphone.offerAccess ? (
+                  <button type="button" className="quiet-button" onClick={onRequestMicrophone}>
+                    Allow
+                  </button>
+                ) : null}
+              </span>
+            </div>
+            {microphoneError ? <p className="error-message">{microphoneError}</p> : null}
+          </section>
 
-      <FeedbackSection control={feedback} />
+          <FeedbackSection control={feedback} />
 
-      <button
-        type="button"
-        className="quit-button"
-        style={{ "--row-index": 6 } as React.CSSProperties}
-        onClick={onQuit}
-      >
-        <PowerIcon />
-        Quit Luke
-      </button>
+          <button
+            type="button"
+            className="quit-button"
+            style={{ "--row-index": 4 } as React.CSSProperties}
+            onClick={onQuit}
+          >
+            <PowerIcon />
+            Quit Luke
+          </button>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -648,41 +648,35 @@ function IntegrationsSection({
 }
 
 /**
- * What each page is called on the front page and at its own head, with the
- * line under the name that says what it holds. One table, because the row
- * that opens a page and the header that leaves it must never disagree about
- * its name.
+ * What each page is called on the front page and at its own head. One table,
+ * because the row that opens a page and the header that leaves it must never
+ * disagree about its name. The name and the glyph are the whole row: what a
+ * page holds is one press away, and a sentence under every name made the
+ * front page read as prose rather than as places to go.
  */
-const SETTINGS_PAGE: Record<
-  SettingsSubview,
-  { title: string; summary: string; icon: React.JSX.Element }
-> = {
+const SETTINGS_PAGE: Record<SettingsSubview, { title: string; icon: React.JSX.Element }> = {
   [SETTINGS_VIEW.VOICE]: {
     title: "Voice",
-    summary: "How Luke sounds, captions, and announcements.",
     icon: <SpeakerIcon />,
   },
   [SETTINGS_VIEW.APPEARANCE]: {
     title: "Appearance",
-    summary: "Menu bar, Dock, displays, and form factor.",
     icon: <DisplayIcon />,
   },
   [SETTINGS_VIEW.SHORTCUTS]: {
     title: "Keyboard shortcuts",
-    summary: "The talk, ask, and stop keys.",
     icon: <KeyboardIcon />,
   },
   [SETTINGS_VIEW.CONNECTIONS]: {
     title: "Connections",
-    summary: "Cloud agent API keys and integrations.",
     icon: <PlugIcon />,
   },
 };
 
 /**
- * One front-page row per page: its glyph, its name, what it holds, and the
- * chevron that promises a page rather than a control. The row is the whole
- * press target, the way a macOS settings row is.
+ * One front-page row per page: its glyph, its name, and the chevron that
+ * promises a page rather than a control. The row is the whole press target,
+ * the way a macOS settings row is.
  */
 function SettingsNavRow({
   view,
@@ -704,7 +698,6 @@ function SettingsNavRow({
       </span>
       <span className="settings-copy">
         <strong>{page.title}</strong>
-        <small>{page.summary}</small>
       </span>
       <ChevronIcon />
     </button>

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -67,6 +67,7 @@ import {
   TrashIcon,
 } from "./settings-icons";
 import {
+  PAGE_EXIT_MS,
   SETTINGS_SUBVIEW_LIST,
   SETTINGS_VIEW,
   type SettingsSubview,
@@ -796,7 +797,10 @@ function VoiceSection({
     setNotificationsBusy(false);
   };
   return (
-    <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
+    <section
+      className="settings-section settings-plain"
+      style={{ "--row-index": 1 } as React.CSSProperties}
+    >
       <div className="settings-row">
         <span className="settings-copy">
           <strong>Voice</strong>
@@ -998,7 +1002,10 @@ function AppearanceSection({
     setFormBusy(false);
   };
   return (
-    <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
+    <section
+      className="settings-section settings-plain"
+      style={{ "--row-index": 1 } as React.CSSProperties}
+    >
       <div className="settings-row">
         <span className="settings-copy">
           <strong>Show Luke in the menu bar</strong>
@@ -1274,7 +1281,10 @@ function ShortcutSection({
   onShortcutCapture: (capturing: boolean) => void;
 }): React.JSX.Element {
   return (
-    <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
+    <section
+      className="settings-section settings-plain"
+      style={{ "--row-index": 1 } as React.CSSProperties}
+    >
       <ShortcutRow
         title="Talk to Luke"
         // What the key actually does, which depends on whether it can report
@@ -1345,52 +1355,76 @@ export function SettingsPanel({
   onShortcutCapture,
 }: SettingsPanelProps): React.JSX.Element {
   const microphone = microphoneAccessRow({ voiceAvailable, status: microphoneStatus });
+  // The page as drawn, trailing the page as asked: turning one is a leave and
+  // then an arrival, and the leaving page must be held mounted through its own
+  // exit — the surface never resizes out from under something still drawn.
+  // The swap is timed off the same token the stylesheet fades with.
+  const [drawnView, setDrawnView] = useState(view);
+  // Whether a page has turned since this panel mounted, which is what scopes
+  // the arrival animation: the tab's first draw belongs to the panel-arrival
+  // transition alone.
+  const [turned, setTurned] = useState(false);
+  const leaving = drawnView !== view;
+  useEffect(() => {
+    if (!leaving) return;
+    const timer = window.setTimeout(() => {
+      setDrawnView(view);
+      setTurned(true);
+    }, PAGE_EXIT_MS);
+    return () => window.clearTimeout(timer);
+  }, [leaving, view]);
   // Moving between pages moves the keyboard with it: into a page, onto its
-  // back button; back out, onto the row that opened the page just left. Only
-  // while the panel is the shape on screen — a view reset behind a closed
-  // panel is housekeeping, and reaching into an inert stage would find
-  // nothing focusable anyway.
+  // back button; back out, onto the row that opened the page just left. Keyed
+  // to the drawn page, because the control being reached for only exists once
+  // the new page is mounted. Only while the panel is the shape on screen — a
+  // view reset behind a closed panel is housekeeping, and reaching into an
+  // inert stage would find nothing focusable anyway.
   const backControl = useRef<HTMLButtonElement | null>(null);
-  const heldView = useRef(view);
+  const heldView = useRef(drawnView);
   useEffect(() => {
     const previous = heldView.current;
-    heldView.current = view;
-    if (previous === view || !panelOpen) return;
-    if (view === SETTINGS_VIEW.ROOT) {
+    heldView.current = drawnView;
+    if (previous === drawnView || !panelOpen) return;
+    if (drawnView === SETTINGS_VIEW.ROOT) {
       if (previous !== SETTINGS_VIEW.ROOT) {
         document.getElementById(settingsNavRowId(previous))?.focus();
       }
       return;
     }
     backControl.current?.focus();
-  }, [view, panelOpen]);
+  }, [drawnView, panelOpen]);
   return (
     <div
       className="settings"
       role="tabpanel"
       id={panelPanelId(PANEL_TAB.SETTINGS)}
       aria-labelledby={panelTabId(PANEL_TAB.SETTINGS)}
+      data-page-leaving={String(leaving)}
+      data-page-turned={String(turned)}
     >
-      {view !== SETTINGS_VIEW.ROOT ? (
+      {drawnView !== SETTINGS_VIEW.ROOT ? (
         <SettingsPageHeader
-          view={view}
+          view={drawnView}
           onBack={() => onViewChange(SETTINGS_VIEW.ROOT)}
           backControl={backControl}
         />
       ) : null}
 
-      {view === SETTINGS_VIEW.ROOT ? (
+      {drawnView === SETTINGS_VIEW.ROOT ? (
         /* The front page: one row per page, then the sections that answer at
            a glance — what Luke is allowed, the way to the founders, and the
            way out. */
-        <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
+        <section
+          className="settings-section settings-index"
+          style={{ "--row-index": 1 } as React.CSSProperties}
+        >
           {SETTINGS_SUBVIEW_LIST.map((subview) => (
             <SettingsNavRow key={subview} view={subview} onOpen={onViewChange} />
           ))}
         </section>
       ) : null}
 
-      {view === SETTINGS_VIEW.VOICE && settings ? (
+      {drawnView === SETTINGS_VIEW.VOICE && settings ? (
         <VoiceSection
           voice={settings.voice}
           onVoiceChange={onVoiceChange}
@@ -1405,7 +1439,7 @@ export function SettingsPanel({
         />
       ) : null}
 
-      {view === SETTINGS_VIEW.APPEARANCE && settings ? (
+      {drawnView === SETTINGS_VIEW.APPEARANCE && settings ? (
         <AppearanceSection
           shown={settings.showInMenuBar}
           onShowInMenuBarChange={onShowInMenuBarChange}
@@ -1418,7 +1452,7 @@ export function SettingsPanel({
         />
       ) : null}
 
-      {view === SETTINGS_VIEW.SHORTCUTS ? (
+      {drawnView === SETTINGS_VIEW.SHORTCUTS ? (
         <ShortcutSection
           {...(voiceHotkey ? { voiceHotkey } : {})}
           voiceHotkeyHeld={voiceHotkeyHeld}
@@ -1434,14 +1468,14 @@ export function SettingsPanel({
         />
       ) : null}
 
-      {view === SETTINGS_VIEW.CONNECTIONS && settings ? (
+      {drawnView === SETTINGS_VIEW.CONNECTIONS && settings ? (
         <>
           <CredentialsSection settings={settings} control={credentials} panelOpen={panelOpen} />
           <IntegrationsSection settings={settings} control={credentials} panelOpen={panelOpen} />
         </>
       ) : null}
 
-      {view !== SETTINGS_VIEW.ROOT ? null : (
+      {drawnView !== SETTINGS_VIEW.ROOT ? null : (
         <>
           <section className="settings-section" style={{ "--row-index": 2 } as React.CSSProperties}>
             <h2>

--- a/apps/desktop/src/renderer/settings-views.ts
+++ b/apps/desktop/src/renderer/settings-views.ts
@@ -1,0 +1,41 @@
+/**
+ * Where inside the Settings tab the panel currently is: its front page, or one
+ * of the pages a front-page row opens. App state rather than panel state for
+ * the same reason the tab is — Escape unwinds it one layer at a time from the
+ * app's own key handler, and a credential entry begun on the Connections page
+ * has to bring the panel back to that page after its trip to the key slot.
+ */
+export const SETTINGS_VIEW = {
+  ROOT: "root",
+  VOICE: "voice",
+  APPEARANCE: "appearance",
+  SHORTCUTS: "shortcuts",
+  CONNECTIONS: "connections",
+} as const;
+
+export type SettingsView = (typeof SETTINGS_VIEW)[keyof typeof SETTINGS_VIEW];
+
+/** The pages the front page opens, in the order its rows offer them. */
+export const SETTINGS_SUBVIEW_LIST = [
+  SETTINGS_VIEW.VOICE,
+  SETTINGS_VIEW.APPEARANCE,
+  SETTINGS_VIEW.SHORTCUTS,
+  SETTINGS_VIEW.CONNECTIONS,
+] as const;
+
+export type SettingsSubview = (typeof SETTINGS_SUBVIEW_LIST)[number];
+
+const NAV_ROW_ID: Record<SettingsSubview, string> = {
+  [SETTINGS_VIEW.VOICE]: "settings-nav-voice",
+  [SETTINGS_VIEW.APPEARANCE]: "settings-nav-appearance",
+  [SETTINGS_VIEW.SHORTCUTS]: "settings-nav-shortcuts",
+  [SETTINGS_VIEW.CONNECTIONS]: "settings-nav-connections",
+};
+
+/**
+ * The element id of a page's front-page row, so leaving the page can hand the
+ * keyboard back to the row that opened it.
+ */
+export function settingsNavRowId(view: SettingsSubview): string {
+  return NAV_ROW_ID[view];
+}

--- a/apps/desktop/src/renderer/settings-views.ts
+++ b/apps/desktop/src/renderer/settings-views.ts
@@ -26,12 +26,32 @@ export const SETTINGS_SUBVIEW_LIST = [
 export type SettingsSubview = (typeof SETTINGS_SUBVIEW_LIST)[number];
 
 /**
- * How long a leaving page's content takes to go, in milliseconds — a mirror of
- * the stylesheet's `--duration-exit`, which is what fades it. The drawn page
- * swaps only once the old one has finished leaving, so the surface never
- * resizes out from under content still drawn.
+ * How long a leaving page's content takes to go when the token cannot be
+ * read, in milliseconds — a mirror of the stylesheet's resting
+ * `--duration-exit`, which is what fades it. The live value comes off the
+ * element instead wherever possible, because a capture run and reduced
+ * motion both zero the token, and the drawn page must swap as fast as the
+ * fade they stilled.
  */
 export const PAGE_EXIT_MS = 90;
+
+/**
+ * The stylesheet's `--duration-exit` as milliseconds. A computed time keeps
+ * its authored unit, so both spellings are read; anything unreadable falls
+ * back to the token's resting value rather than to no exit at all.
+ */
+export function pageExitFromToken(token: string): number {
+  const trimmed = token.trim();
+  const scale = trimmed.endsWith("ms") ? 1 : trimmed.endsWith("s") ? 1000 : undefined;
+  const parsed = Number.parseFloat(trimmed);
+  return scale === undefined || Number.isNaN(parsed) ? PAGE_EXIT_MS : parsed * scale;
+}
+
+/** Reads the exit duration off the element the fade actually runs on. */
+export function pageExitMs(element: Element | null): number {
+  if (!element) return PAGE_EXIT_MS;
+  return pageExitFromToken(getComputedStyle(element).getPropertyValue("--duration-exit"));
+}
 
 const NAV_ROW_ID: Record<SettingsSubview, string> = {
   [SETTINGS_VIEW.VOICE]: "settings-nav-voice",

--- a/apps/desktop/src/renderer/settings-views.ts
+++ b/apps/desktop/src/renderer/settings-views.ts
@@ -25,6 +25,14 @@ export const SETTINGS_SUBVIEW_LIST = [
 
 export type SettingsSubview = (typeof SETTINGS_SUBVIEW_LIST)[number];
 
+/**
+ * How long a leaving page's content takes to go, in milliseconds — a mirror of
+ * the stylesheet's `--duration-exit`, which is what fades it. The drawn page
+ * swaps only once the old one has finished leaving, so the surface never
+ * resizes out from under content still drawn.
+ */
+export const PAGE_EXIT_MS = 90;
+
 const NAV_ROW_ID: Record<SettingsSubview, string> = {
   [SETTINGS_VIEW.VOICE]: "settings-nav-voice",
   [SETTINGS_VIEW.APPEARANCE]: "settings-nav-appearance",

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1761,6 +1761,69 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   font-weight: 700;
 }
 
+/* The front page's list of pages. Its rows carry their own padding for the
+   hover pill, so the card keeps less of its own vertically: the pill's inset
+   already stands the first and last names off the card's edges, and the two
+   paddings stacked read as blank space rather than as calm. */
+.settings-index {
+  padding-top: 7px;
+  padding-bottom: 7px;
+}
+
+/* A page that is one nameless group is no group at all: its rows stand on the
+   page itself, under the header that already names it, and a card around them
+   would be a border around nothing. The border goes transparent rather than
+   away and the horizontal padding stays, so the rows sit exactly where the
+   carded pages draw theirs and a page turn moves nothing sideways. */
+.settings-plain {
+  padding-top: 2px;
+  padding-bottom: 2px;
+  border-color: transparent;
+  background: none;
+}
+
+/* Turning a settings page follows the shape contract. Leaving: the old page's
+   content goes first, over `--duration-exit` and with no delay — the state
+   being entered declares its own `--row-delay` — and only its end releases
+   the room, so the surface never resizes out from under something still
+   drawn. The swap is timed off the same token, mirrored in `PAGE_EXIT_MS`. */
+.settings[data-page-leaving="true"] .settings-header,
+.settings[data-page-leaving="true"] .settings-section,
+.settings[data-page-leaving="true"] .quit-button {
+  --row-delay: 0s;
+
+  opacity: 0;
+}
+
+/* Arriving: the new page's room lands at once — the surface takes one clean
+   spring — and its content becomes visible only over black, riding the pair
+   every arriving element rides on the same `--row-delay` the panel's own
+   arrival fans out with. A mount animation with `backwards` fill rather than
+   a transition, because an element cannot transition from a style it never
+   held. Scoped to a panel that has actually turned a page, so the tab's
+   first draw stays the panel-arrival transition's alone. */
+@keyframes settings-page-fade {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes settings-page-travel {
+  from {
+    transform: translateY(
+      calc((min(var(--row-index, 0), var(--row-fan-limit)) + 1) * var(--row-fan) * -1)
+    );
+  }
+}
+
+.settings[data-page-turned="true"] .settings-header,
+.settings[data-page-turned="true"] .settings-section,
+.settings[data-page-turned="true"] .quit-button {
+  animation:
+    settings-page-fade var(--duration-quick) var(--motion-exit) var(--row-delay) backwards,
+    settings-page-travel var(--duration-shape) var(--spring) var(--row-delay) backwards;
+}
+
 /* A front-page row that opens a page rather than holding a control: glyph,
    name, what the page holds, and the chevron that promises somewhere to go.
    The hover bleeds to the section's padding so the pill reads as the row. */

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1603,6 +1603,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
  * its timing from the state being entered, which is what keeps the two apart. */
 .session-row,
 .settings-section,
+.settings-header,
 .quit-button,
 .empty-state,
 .panel-header,
@@ -1632,6 +1633,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 
 .app-stage[data-presentation="panel"] .session-row,
 .app-stage[data-presentation="panel"] .settings-section,
+.app-stage[data-presentation="panel"] .settings-header,
 .app-stage[data-presentation="panel"] .quit-button,
 .app-stage[data-presentation="panel"] .empty-state,
 .app-stage[data-presentation="panel"] .panel-header,
@@ -1732,11 +1734,81 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   opacity: 1;
 }
 
+/* Every row stands at the height a label-and-subtext pair needs, whether or
+   not it carries the subtext: a list where the short rows sit shorter reads as
+   cramped rather than as calm. */
 .settings-row {
   display: flex;
+  min-height: 32px;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+}
+
+/* A page's head: the way back beside the page's own name, above the sections
+   it holds. */
+.settings-header {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 9px;
+  padding: 0 2px;
+}
+
+.settings-header strong {
+  color: var(--text-primary);
+  font-size: 12.5px;
+  font-weight: 700;
+}
+
+/* A front-page row that opens a page rather than holding a control: glyph,
+   name, what the page holds, and the chevron that promises somewhere to go.
+   The hover bleeds to the section's padding so the pill reads as the row. */
+.settings-nav {
+  display: flex;
+  min-height: 32px;
+  align-items: center;
+  gap: 10px;
+  margin: 0 -8px;
+  padding: 6px 8px;
+  border-radius: 10px;
+  background: none;
+  text-align: left;
+  transition: background-color var(--duration-hover) ease;
+}
+
+.settings-nav:hover {
+  background: var(--raised);
+}
+
+.settings-nav .settings-copy {
+  flex: 1;
+}
+
+/* The page's glyph in a small plate, the way macOS marks a settings row. */
+.settings-nav-mark {
+  display: flex;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border-radius: 7px;
+  background: var(--raised-strong);
+  color: var(--text-secondary);
+}
+
+.settings-nav-mark .settings-icon {
+  width: 13px;
+  height: 13px;
+  opacity: 1;
+}
+
+.settings-chevron {
+  width: 11px;
+  height: 11px;
+  flex: 0 0 auto;
+  color: var(--text-tertiary);
 }
 
 .settings-copy {

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1762,23 +1762,24 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 }
 
 /* The front page's list of pages. Its rows carry their own padding for the
-   hover pill, so the card keeps less of its own vertically: the pill's inset
-   already stands the first and last names off the card's edges, and the two
-   paddings stacked read as blank space rather than as calm. */
+   hover pill, so the card keeps less of its own vertically — the pill's inset
+   already stands the first and last names off the card's edges — and the rows
+   sit at a menu's spacing rather than a form's: each is one name, so the 9px
+   a section keeps between rows of copy would read as gaps, not as calm. */
 .settings-index {
-  padding-top: 7px;
-  padding-bottom: 7px;
+  gap: 3px;
+  padding-top: 5px;
+  padding-bottom: 5px;
 }
 
 /* A page that is one nameless group is no group at all: its rows stand on the
    page itself, under the header that already names it, and a card around them
-   would be a border around nothing. The border goes transparent rather than
-   away and the horizontal padding stays, so the rows sit exactly where the
-   carded pages draw theirs and a page turn moves nothing sideways. */
+   would be a border around nothing. With no card there is no card inset
+   either: the rows keep the header's own 2px, flush with the page's left
+   edge, rather than hanging indented where a border used to be. */
 .settings-plain {
-  padding-top: 2px;
-  padding-bottom: 2px;
-  border-color: transparent;
+  padding: 2px;
+  border: 0;
   background: none;
 }
 
@@ -1833,7 +1834,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   align-items: center;
   gap: 10px;
   margin: 0 -8px;
-  padding: 6px 8px;
+  padding: 4px 8px;
   border-radius: 10px;
   background: none;
   text-align: left;

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1761,15 +1761,15 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   font-weight: 700;
 }
 
-/* The front page's list of pages. Its rows carry their own padding for the
-   hover pill, so the card keeps less of its own vertically — the pill's inset
-   already stands the first and last names off the card's edges — and the rows
-   sit at a menu's spacing rather than a form's: each is one name, so the 9px
-   a section keeps between rows of copy would read as gaps, not as calm. */
+/* The front page's list of pages. The rows sit at a menu's spacing rather
+   than a form's — each is one name, so the 9px a section keeps between rows
+   of copy would read as gaps, not as calm — and the card's own padding plus
+   the rows' pill padding puts the first and last rows' content 15px from the
+   card's edge, the same inset the sides keep. */
 .settings-index {
   gap: 3px;
-  padding-top: 5px;
-  padding-bottom: 5px;
+  padding-top: 11px;
+  padding-bottom: 11px;
 }
 
 /* A page that is one nameless group is no group at all: its rows stand on the

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1787,7 +1787,9 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
    content goes first, over `--duration-exit` and with no delay — the state
    being entered declares its own `--row-delay` — and only its end releases
    the room, so the surface never resizes out from under something still
-   drawn. The swap is timed off the same token, mirrored in `PAGE_EXIT_MS`. */
+   drawn. The swap is timed off this same token, read live off the element
+   (`pageExitMs`), so a capture run or reduced motion — which zero it — swap
+   as fast as they stilled the fade. */
 .settings[data-page-leaving="true"] .settings-header,
 .settings[data-page-leaving="true"] .settings-section,
 .settings[data-page-leaving="true"] .quit-button {

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -121,10 +121,21 @@ test("the guide describes every spoken-adjustable setting with its current value
   );
 
   // Every entry says where the same change is made by hand, because guiding
-  // the developer there is half of what the guide is for.
+  // the developer there is half of what the guide is for — and the Settings
+  // tab opens into pages, so a path that stops at the tab strands them on its
+  // front page.
   for (const setting of buildLukeGuide(guideInput()).settings) {
     assert.ok(setting.manual.length > 0, `${setting.id} has a by-hand path`);
+    assert.match(setting.manual, /Settings tab, on its \w[\w ]* page/);
   }
+
+  // The pages are named by what they hold: the voice rows live on the Voice
+  // page and the standing rows on Appearance, so the words Luke says match
+  // the row the developer will find.
+  assert.match(guideSetting(APP_SETTING_ID.VOICE, guideInput()).manual, /Voice page/);
+  assert.match(guideSetting(APP_SETTING_ID.VOICE_CAPTIONS, guideInput()).manual, /Voice page/);
+  assert.match(guideSetting(APP_SETTING_ID.SHOW_IN_DOCK, guideInput()).manual, /Appearance page/);
+  assert.match(guideSetting(APP_SETTING_ID.FORM_FACTOR, guideInput()).manual, /Appearance page/);
 });
 
 test("the facts say what is connected, never what connects it", () => {

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -2020,7 +2020,7 @@ const CAPTIONS_GUIDE: AppGuideSnapshot = {
       kind: APP_SETTING_KIND.TOGGLE,
       value: "off",
       adjustable: true,
-      manual: "the panel's Settings tab, under Preferences",
+      manual: "the panel's Settings tab, on its Voice page",
     },
   ],
 };

--- a/apps/desktop/tests/settings-views.test.ts
+++ b/apps/desktop/tests/settings-views.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { PAGE_EXIT_MS, pageExitFromToken } from "../src/renderer/settings-views";
+
+test("the page swap reads the exit token in either unit", () => {
+  assert.equal(pageExitFromToken("90ms"), 90);
+  assert.equal(pageExitFromToken(" 90ms "), 90);
+  assert.equal(pageExitFromToken("0.09s"), 90);
+});
+
+test("a zeroed token swaps at once, the way capture and reduced motion still the fade", () => {
+  // Capture zeroes the token as a length of seconds; reduced motion leaves a
+  // millisecond so transitions still fire. Either way the swap must not wait
+  // out an exit that is not running.
+  assert.equal(pageExitFromToken("0s"), 0);
+  assert.equal(pageExitFromToken("1ms"), 1);
+});
+
+test("a token that cannot be read falls back to the resting exit, not to none", () => {
+  assert.equal(pageExitFromToken(""), PAGE_EXIT_MS);
+  assert.equal(pageExitFromToken("fast"), PAGE_EXIT_MS);
+});

--- a/packages/sidecar-core/tests/guide.test.ts
+++ b/packages/sidecar-core/tests/guide.test.ts
@@ -36,7 +36,7 @@ const GUIDE: AppGuideSnapshot = {
       kind: APP_SETTING_KIND.TOGGLE,
       value: "off",
       adjustable: true,
-      manual: "the panel's Settings tab, under Preferences",
+      manual: "the panel's Settings tab, on its Voice page",
     },
     {
       id: "voice",
@@ -46,7 +46,7 @@ const GUIDE: AppGuideSnapshot = {
       value: "cedar",
       choices: ["cedar", "marin"],
       adjustable: true,
-      manual: "the panel's Settings tab, under Preferences",
+      manual: "the panel's Settings tab, on its Voice page",
     },
     {
       id: "microphone",


### PR DESCRIPTION
## What

The Settings tab had outgrown one scroll: six sections, always past the panel's 520px cap, with rows that sat shorter wherever they carried no subtext.

- **Pages with a back button.** The tab now opens on a front page of four navigation rows — **Voice** (voice, speed, captions, quiet Music/Spotify, announcements), **Appearance** (menu bar, Dock, all displays, form factor), **Keyboard shortcuts** (talk, ask, stop), and **Connections** (cloud agent API keys + integrations) — each leading to its own page headed by a back button. What is worth a glance stays on the front page: the microphone permission, the Feedback section, and Quit. The front page now fits without scrolling.
- **Uniform row height.** `.settings-row` takes the height a label-and-subtext pair needs even when the subtext is absent, so switch-only rows no longer sit cramped against their neighbours.

## How it holds the existing contracts

- The page is app state like the tab itself: **Escape** unwinds one layer at a time (options sheet → page → tab → panel), a credential entry away in the key slot returns to the Connections page it left, and a closed panel reopens on the front page.
- Moving between pages moves the keyboard with it: into a page onto its back button, back out onto the row that opened it.
- **The guide learns the new geography in the same change**: every by-hand path names its page, the talk/ask/stop facts point at the Keyboard shortcuts page, and the panel fact describes the front page and what it opens. README wording updated to match.
- No new motion: switching pages is the same instant content swap the Sessions/Settings tabs already do, with the surface taking its one spring to the new height; the page header joins the existing arrival stagger.

## Validation

- `./scripts/check.sh` passes (lint, typecheck, all tests, build).
- Each of the five views was server-rendered and screenshotted with the compiled stylesheet in headless Chromium and inspected: front page, all four pages, back headers, nav rows, and the evened-out switch rows all draw as intended.
- `./scripts/verify.sh` runs in CI on macOS and links the generated evidence below. No physical-notch check was performed (developed in a cloud workspace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/9196261b-88b7-4507-9ddc-0175d5cf7384)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31844758009/artifacts/9235516423) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31844758009)

- Commit: `2724a34c048728661ddbebff89be465633d1b9be`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
