### PR TITLE
feat(panel): send Luke to the control he was asked to change

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1,5 +1,4 @@
 import {
-  APP_PANEL_TAB,
   type AppGuideSnapshot,
   ATTENTION_SPEECH_SOURCE,
   EMPTY_APP_GUIDE,
@@ -58,11 +57,20 @@ import {
 import { encodeFeedbackImage } from "./feedback-images";
 import { FeedbackSlot } from "./feedback-slot";
 import { KeySlot } from "./key-slot";
-import { applySpokenSetting, buildLukeGuide } from "./luke-guide";
+import {
+  ERRAND_WAIT,
+  type Errand,
+  type ErrandTarget,
+  type ErrandWait,
+  errandTargets,
+  LukeErrand,
+} from "./luke-errand";
+import { applySpokenSetting, buildLukeGuide, isAppSettingId } from "./luke-guide";
 import { NotchWings } from "./notch-wings";
 import { PanelBody, type SessionWriteHandlers } from "./panel-body";
 import {
   HIT_REGION,
+  HIT_REGION_ATTRIBUTE,
   LEAVE_DELAY_MS,
   PANEL_PRESENTATION,
   type PanelPresentation,
@@ -84,7 +92,7 @@ import {
   tallySummary,
 } from "./session-model";
 import { SESSION_OPTIONS_BUTTON_ID, SESSION_OPTIONS_ID } from "./session-parts";
-import { SETTINGS_VIEW, type SettingsView } from "./settings-views";
+import { SETTING_PAGE, SETTINGS_VIEW, type SettingsView } from "./settings-views";
 import { SpokenNoticeAnnouncer } from "./spoken-notices";
 import {
   outputSilent,
@@ -186,8 +194,10 @@ function usePointerPassthrough(
       // forwarded move can carry. Comparing that against null read as "still
       // inside", so leaving by the edge left the panel open until some other
       // event closed it.
-      const region = document.elementFromPoint(point.x, point.y)?.closest("[data-hit-region]");
-      const kind = region?.getAttribute("data-hit-region");
+      const region = document
+        .elementFromPoint(point.x, point.y)
+        ?.closest(`[${HIT_REGION_ATTRIBUTE}]`);
+      const kind = region?.getAttribute(HIT_REGION_ATTRIBUTE);
       // The shape takes the pointer wherever it is drawn, which is the whole
       // rule: the capsule strip and the panel's body are what sit on top of it
       // and answer first. The surface is what answers in between — the panel's
@@ -297,6 +307,7 @@ export function App(): React.JSX.Element {
   const [microphoneStatus, setMicrophoneStatus] = useState<MicrophoneStatus>("not-determined");
   const [microphoneError, setMicrophoneError] = useState<string>();
   const [analyser, setAnalyser] = useState<AnalyserNode>();
+  const [errand, setErrand] = useState<Errand>();
   const [entry, setEntry] = useState<CredentialEntry>();
   const [feedback, setFeedback] = useState<FeedbackEntry>();
   const [feedbackNotice, setFeedbackNotice] = useState<string>();
@@ -455,6 +466,68 @@ export function App(): React.JSX.Element {
    * newer truth, and the bootstrap's older snapshot must not clobber it.
    */
   const settingsPushed = useRef(false);
+  /**
+   * How many errands Luke has run. Carried with each one so that asking for
+   * the same control twice flies twice, exactly as a repeated face gesture is
+   * replayed by counting its plays.
+   */
+  const errands = useRef(0);
+
+  /**
+   * What the panel is not drawing yet, because Luke has not reached it.
+   *
+   * The change itself is made the moment it is asked for — nothing here delays
+   * a write, and the spoken answer reports what actually happened. What waits
+   * is only the drawing of it: a switch that has already flipped, or a list
+   * already narrowed, by the time Luke arrives makes the act look like
+   * something he flew over to inspect, and the whole point of the errand is
+   * that he is the one doing it. Both kinds wait, because both are the same
+   * mistake — the settings snapshot the store answered with, and the narrowing
+   * or re-ordering a spoken ask chose for the list.
+   *
+   * Refs rather than state: the release runs from a callback that has to stay
+   * stable across the whole flight it is timing, and an errand carries one of
+   * these or the other, never both.
+   */
+  const heldSettings = useRef<AppSettings | undefined>(undefined);
+  const heldView = useRef<Partial<SessionView> | undefined>(undefined);
+  const releaseErrandChange = useCallback(() => {
+    const settings = heldSettings.current;
+    const view = heldView.current;
+    heldSettings.current = undefined;
+    heldView.current = undefined;
+    if (settings !== undefined) setSettings(settings);
+    // Folded into whatever the view is at the moment it lands rather than the
+    // moment it was chosen: the list corrects its own filter during render
+    // when one empties, and a snapshot taken at the ask would undo that.
+    if (view !== undefined) setSessionView((current) => ({ ...current, ...view }));
+  }, []);
+
+  /**
+   * Whether the panel on screen is one an errand stood up. Only then is it the
+   * errand's to put away again — a panel that was already open is somewhere
+   * the developer had gone themselves, and closing it would be taking it from
+   * them for having spoken.
+   */
+  const errandOpenedPanel = useRef(false);
+
+  /**
+   * Sends Luke to sign what he just did, if there is anywhere to sign it, and
+   * answers whether he actually went.
+   *
+   * Only the panel can hold a signature, so both callers stand it up first and
+   * this is the backstop rather than the decision: an act whose panel never
+   * opened, or that named a control this build does not draw, flies nowhere
+   * and the spoken answer reports it the way it always did. A caller holding
+   * something for the flight reads the answer and lets go itself.
+   */
+  const runErrand = useCallback((targets: readonly ErrandTarget[], wait: ErrandWait): boolean => {
+    if (targets.length === 0) return false;
+    if (presentationRef.current !== PANEL_PRESENTATION.PANEL) return false;
+    errands.current += 1;
+    setErrand({ targets, wait, run: errands.current });
+    return true;
+  }, []);
 
   const changeTab = useCallback((next: PanelTab) => {
     tabRef.current = next;
@@ -1480,26 +1553,111 @@ export function App(): React.JSX.Element {
   );
 
   /**
+   * The panel standing back down once an errand it stood up is over. The same
+   * rule a saved key follows, for the same reason: the shape was brought
+   * forward to show an answer, the answer has been shown, and nothing else
+   * would ever ask it to close — the pointer is not on it, because the
+   * developer was talking rather than reaching for it.
+   *
+   * Everything that holds a panel open against the pointer holds it open
+   * against this too. A key half-typed and an ask half-written are both things
+   * someone is in the middle of, and a panel someone's hands have arrived in
+   * is theirs now rather than the errand's.
+   */
+  const standDownAfterErrand = useCallback(() => {
+    if (!errandOpenedPanel.current) return;
+    errandOpenedPanel.current = false;
+    if (pointerInside.current || entryIsDrawn() || askEngaged.current) return;
+    cancelHoverTransition();
+    hoverTimer.current = window.setTimeout(() => {
+      hoverTimer.current = undefined;
+      if (presentationRef.current === PANEL_PRESENTATION.PANEL) void changeMode(false);
+    }, SETTLE_DELAY_MS);
+  }, [cancelHoverTransition, changeMode, entryIsDrawn]);
+
+  /**
    * The spoken asks about Luke himself. A settings change goes through the
    * same bridge calls the settings rows use, and the snapshot that comes back
    * redraws the panel's switches; showing the panel is the capsule's press
    * with a tab — or, already open, that tab's own press — and optionally a
-   * narrowing, chosen out loud; opening the
-   * composer is the tray item's press, run through the tray's own path. All
-   * were validated against their fixed vocabularies before they arrive here,
-   * so this only performs and reports.
+   * narrowing, chosen out loud; opening the composer is the tray item's press,
+   * run through the tray's own path. All were validated against their fixed
+   * vocabularies before they arrive here, so this only performs and reports.
+   *
+   * A settings change and a change of view are also the two acts nobody
+   * watched anyone make, so both end by showing the control that moved and
+   * sending Luke to it. A settings change stands the panel up on the Settings
+   * tab to do it: the switch is the whole report, and a switch flipped behind
+   * a closed panel is a change the developer is only ever told about. The
+   * errand is drawing over what already happened — it runs after the change,
+   * it carries nothing to the store, and a refusal takes both the showing and
+   * the flight with it. The composer is neither: it is a shape of its own
+   * standing where the panel was, so there is nothing for a mark to land on.
    */
   const carryAppAction = useCallback<AppActionCarrier>(
     async (action) => {
       if (action.kind === "setting") {
-        // The settings as this window holds them ride along so a spoken model
-        // or effort change composes against the selection actually stored.
-        return applySpokenSetting(
+        // The store's answer is caught rather than drawn: the switch is what
+        // Luke is on his way to move, so it waits for him to reach it. Every
+        // path out of here releases it, and the outcome the conversation is
+        // told is the store's own either way — what is delayed is the drawing,
+        // never the change or the report of it. The settings as this window
+        // holds them ride along so a spoken model or effort change composes
+        // against the selection actually stored.
+        const outcome = await applySpokenSetting(
           window.sidecar,
           action,
-          setSettings,
+          (next) => {
+            heldSettings.current = next;
+          },
           settings ?? bootstrap?.settings,
         );
+        // Nothing to show and nothing to sign: a refused change must not stand
+        // the panel up in front of a switch that did not move.
+        if (outcome.status !== "changed") {
+          releaseErrandChange();
+          return outcome;
+        }
+        const opening = presentationRef.current !== PANEL_PRESENTATION.PANEL;
+        // The guide's ids travel as plain text, so one that names no setting
+        // of Luke's names no page either — and nothing will fly to it.
+        const page = isAppSettingId(action.setting.id)
+          ? SETTING_PAGE[action.setting.id]
+          : undefined;
+        // What the flight has to wait out. A page already drawn under an open
+        // panel costs nothing; anything else is a page of content arriving,
+        // and a page turned under an open panel takes the leaving one's exit
+        // first. Read before any of it is asked for, because all three of
+        // these are about to stop being true.
+        const wait =
+          opening || page === undefined
+            ? ERRAND_WAIT.CONTENT
+            : tabRef.current === PANEL_TAB.SETTINGS && settingsView === page
+              ? ERRAND_WAIT.AT_ONCE
+              : ERRAND_WAIT.PAGE;
+        try {
+          // The control has to be drawn to be flown to, and a settings page
+          // that is not open is not drawn at all — so the tab comes forward
+          // and then the page the setting lives on, in that order, because
+          // arriving at the tab is arriving at its front page. This is the
+          // same move a credential entry returning from the key slot makes.
+          changeTab(PANEL_TAB.SETTINGS);
+          if (page !== undefined) setSettingsView(page);
+          await changeMode(true);
+          if (runErrand(errandTargets(action), wait)) {
+            // Only a panel this errand stood up is the errand's to put away.
+            errandOpenedPanel.current = opening;
+          } else {
+            releaseErrandChange();
+          }
+        } catch {
+          // Showing the change is not what was asked for — making it is, and it
+          // is already made. A window that refused to come forward must not be
+          // reported back as a setting that refused to change, and the switch
+          // must be drawn whether or not anyone was shown it moving.
+          releaseErrandChange();
+        }
+        return outcome;
       }
       if (action.kind === "feedback") {
         // The main process expands the window and sends the composer's
@@ -1544,21 +1702,36 @@ export function App(): React.JSX.Element {
                 }),
         };
       }
-      changeTab(action.tab === APP_PANEL_TAB.SETTINGS ? PANEL_TAB.SETTINGS : PANEL_TAB.SESSIONS);
+      // Whether this ask is what opens the panel, read before it does: an
+      // errand into a shape still growing has to trail the whole opening,
+      // and one into a panel already up does not.
+      const opening = presentationRef.current !== PANEL_PRESENTATION.PANEL;
+      changeTab(action.tab);
       const spoken = action.filter ? sessionFilterFromSpoken(action.filter) : undefined;
       // An agent this build never registered cannot narrow the list, and Luke
       // must not claim it did. The list still has to match the sentence that
       // says every session is shown, so an unmappable ask widens the view to
       // All rather than leaving whatever narrowing was already in force.
       const filter = action.filter ? (spoken ?? SESSION_FILTER.ALL) : undefined;
+      // Caught rather than applied, on the settings switch's terms: the
+      // narrowing is what Luke is on his way to the options button to do, and
+      // a list that has already re-sorted itself by the time he gets there
+      // makes the flight a report rather than the act.
       if (filter || action.sort) {
-        setSessionView((view) => ({
-          ...view,
+        heldView.current = {
           ...(filter ? { filter } : {}),
           ...(action.sort ? { sort: action.sort } : {}),
-        }));
+        };
       }
       await changeMode(true);
+      // Nothing flew, so nothing is coming to release it. The panel itself is
+      // what was asked for and it is already up, so the list must show what
+      // the answer is about to claim it shows.
+      // The tab bar and the options button are outside the settings pages, so
+      // a page reset behind this tab switch is nothing they wait for.
+      if (!runErrand(errandTargets(action), opening ? ERRAND_WAIT.CONTENT : ERRAND_WAIT.AT_ONCE)) {
+        releaseErrandChange();
+      }
       return {
         status: "shown",
         tab: action.tab,
@@ -1569,7 +1742,7 @@ export function App(): React.JSX.Element {
         ...(action.sort ? { sort: action.sort } : {}),
       };
     },
-    [changeMode, changeTab, settings, bootstrap],
+    [changeMode, changeTab, settings, settingsView, bootstrap, releaseErrandChange, runErrand],
   );
   carryAppActionRef.current = carryAppAction;
 
@@ -1700,6 +1873,10 @@ export function App(): React.JSX.Element {
     // state the store no longer holds.
     const removeSettings = window.sidecar.onSettingsChanged((pushed) => {
       settingsPushed.current = true;
+      // A push is newer than anything an errand is still carrying, so it takes
+      // the hold with it: released afterwards, a snapshot caught before this
+      // arrived would draw the store as it was rather than as it is.
+      heldSettings.current = undefined;
       setSettings(pushed);
     });
     const removeSessions = window.sidecar.onSessionsChanged(setSessions);
@@ -2230,6 +2407,18 @@ export function App(): React.JSX.Element {
         voiceOpening={talkOpening}
         presentation={presentation}
         housingWidth={display.notch.housingWidth}
+      />
+
+      {/* Luke crossing his own panel to sign a control he moved. Drawn over
+          everything, because it passes over the panel it is crossing, and
+          answering no pointer at all — the strip's one button and the control
+          it lands on both keep every press. The tap is what lets the switch
+          be seen to move, and the way home is what lets a panel stood up for
+          the errand stand back down. */}
+      <LukeErrand
+        {...(errand ? { errand } : {})}
+        onLanded={releaseErrandChange}
+        onReturned={standDownAfterErrand}
       />
 
       {/* Luke's words while he says them: one element in every state, under

--- a/apps/desktop/src/renderer/luke-errand.tsx
+++ b/apps/desktop/src/renderer/luke-errand.tsx
@@ -1,0 +1,702 @@
+import { APP_PANEL_TAB, type AppPanelTab, type AppToolAction } from "@sidecar/core";
+import { useEffect, useRef } from "react";
+import { flushSync } from "react-dom";
+import { LukeFace } from "./luke-face";
+import { type AppSettingId, isAppSettingId } from "./luke-guide";
+import { HIT_REGION, HIT_REGION_ATTRIBUTE, PANEL_PRESENTATION } from "./panel-state";
+import { parseMilliseconds, parsePixels, STILL_MS } from "./session-motion";
+
+/**
+ * Luke signing his own work.
+ *
+ * A setting or a view changes two ways: a hand on the control, or Luke acting
+ * on something asked of him. The control answers identically either way — and
+ * a switch that flips with nobody near it reads as a glitch rather than as an
+ * answer. So Luke goes and does it in the open: he leaves the strip under the
+ * housing, dives to the very control that changed, taps it, and floats back.
+ *
+ * The dive and the tap are the whole of the emphasis. The way home is the
+ * quietest motion that still reads as something moving under its own power,
+ * because by then the point has been made and all that is left is to get out
+ * of the way of the control he was pointing at.
+ *
+ * **There is only ever one Luke on screen.** The strip's own face is held
+ * invisible for exactly as long as the flight lasts, so what crosses the panel
+ * reads as the face itself having left its post rather than as a second copy
+ * of it. The flying element is a stand-in — the strip's face is remounted
+ * whenever a gesture plays, and an animation running on a node React is about
+ * to replace would die mid-air — but it is an exact one: it sets off from the
+ * face's own measured box, at the face's own measured size, wearing the colour
+ * the face is wearing that moment, and it is parked back on top of the face
+ * before the face fades back in underneath it. Neither handover has a frame
+ * where two are drawn or none is.
+ *
+ * The colour is answered in the stylesheet off the same `data-voice` the face
+ * takes its own from, rather than measured here and carried: it is the one
+ * report the capsule makes of whose turn it is — blue while Luke is talking,
+ * green while he is listening — and an errand flies out of a reply, so it
+ * would be the wrong moment of all moments to drop it. Keyed off the one
+ * attribute, the two cannot disagree even mid-flight, which is what the
+ * handover needs: a colour snapshotted at launch would swap to a different one
+ * the instant the face came back underneath.
+ *
+ * The errand is drawing and nothing else. It is armed by the tool-call carrier
+ * alone — a row someone pressed themselves needs no attribution, and an act
+ * that was refused has nothing to sign — and it decides nothing: it reads
+ * where two elements are and moves between them. An act made while the panel
+ * is away flies nowhere at all, because attribution is only worth anything to
+ * someone who can see what was attributed.
+ *
+ * Everything moves with `transform` and `opacity` alone; the control it lands
+ * on is read for its box and never restyled, so nothing about a settings row
+ * changes because an errand happened to visit it. The beats come from the
+ * motion tokens, which is what makes a capture run and reduced motion — both
+ * of which zero them — get no errand rather than an instant one.
+ */
+
+/** How a control says an errand may land on it, and which one it answers to. */
+export const ERRAND_TARGET_ATTRIBUTE = "data-errand-target";
+
+/** How Luke's own face says an errand sets off from it. */
+export const ERRAND_ORIGIN_ATTRIBUTE = "data-errand-origin";
+
+/**
+ * The landing places that are not a setting's own control. A setting is named
+ * by the very id a spoken change names it by, so it needs no entry here; these
+ * are the parts of the panel that say what you are looking at rather than what
+ * it is set to.
+ */
+export const ERRAND_TARGET = {
+  SESSIONS_TAB: "tab-sessions",
+  SETTINGS_TAB: "tab-settings",
+  LIST_OPTIONS: "list-options",
+} as const;
+
+export type ErrandTarget = AppSettingId | (typeof ERRAND_TARGET)[keyof typeof ERRAND_TARGET];
+
+const TAB_ERRAND_TARGET: Record<AppPanelTab, ErrandTarget> = {
+  [APP_PANEL_TAB.SESSIONS]: ERRAND_TARGET.SESSIONS_TAB,
+  [APP_PANEL_TAB.SETTINGS]: ERRAND_TARGET.SETTINGS_TAB,
+};
+
+/** Which landing place a tab is. Exhaustive over the tabs a spoken ask names. */
+export function tabErrandTarget(tab: AppPanelTab): ErrandTarget {
+  return TAB_ERRAND_TARGET[tab];
+}
+
+/**
+ * What a control spreads onto itself to be somewhere an errand can land.
+ *
+ * Mark the element that is *drawn* as the control, not a box that happens to
+ * hold it. The errand measures what it marks and outlines it in the element's
+ * own corners, so a wrapper positioning something rounded — with no radius of
+ * its own, because it draws nothing — earns a ring with square corners around
+ * a control that has none. A control whose roundness lives on a child, or
+ * behind it, either declares that radius itself or hands the mark down.
+ */
+export function errandTargetProps(target: ErrandTarget): Record<string, string> {
+  return { [ERRAND_TARGET_ATTRIBUTE]: target };
+}
+
+/** What Luke's own face spreads onto itself to be where one sets off from. */
+export function errandOriginProps(): Record<string, string> {
+  return { [ERRAND_ORIGIN_ATTRIBUTE]: "true" };
+}
+
+/**
+ * Where an act should be signed, best first. More than one because the panel
+ * does not always draw the best answer: the options button carries both the
+ * narrowing and the ordering, but it is only offered beside a list with
+ * something to choose between, so the tab stands behind it. The flight takes
+ * the first candidate actually drawn, and an act with none flies nowhere.
+ */
+export function errandTargets(action: AppToolAction): readonly ErrandTarget[] {
+  if (action.kind === "setting") {
+    // The guide's ids travel as plain text, so one that names no setting of
+    // Luke's is no landing place either.
+    return isAppSettingId(action.setting.id) ? [action.setting.id] : [];
+  }
+  if (action.kind !== "panel") return [];
+  const tab = tabErrandTarget(action.tab);
+  // A narrowing or a re-ordering is the news; the tab is only where it
+  // happened, and it may not have changed at all.
+  if (action.filter !== undefined || action.sort !== undefined) {
+    return [ERRAND_TARGET.LIST_OPTIONS, tab];
+  }
+  return [tab];
+}
+
+/**
+ * What has to have finished happening before an errand can measure anything.
+ *
+ * Everything the flight reads — where the face is, where the control is, how
+ * wide the shape is — is read off elements that may still be arriving, and a
+ * measurement taken mid-arrival lands the mark where a row was passing rather
+ * than where it came to rest. So the errand waits out whatever the act it is
+ * signing has set in motion.
+ */
+export const ERRAND_WAIT = {
+  /** The panel is up and already showing the control: a beat, and go. */
+  AT_ONCE: "at-once",
+  /** The panel opened for this, so a whole page of content is arriving. */
+  CONTENT: "content",
+  /** A settings page is being turned too, and one leaves before the next arrives. */
+  PAGE: "page",
+} as const;
+
+export type ErrandWait = (typeof ERRAND_WAIT)[keyof typeof ERRAND_WAIT];
+
+/** One errand, as the app asks for it. */
+export interface Errand {
+  targets: readonly ErrandTarget[];
+  wait: ErrandWait;
+  /** Which run this is, so asking twice for one control flies twice. */
+  run: number;
+}
+
+/** A box, as either a `DOMRect` or a plain reading of one. */
+export interface ErrandBox {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/** Where a flight starts, where it lands, and what it lands on. */
+export interface ErrandJourney {
+  /** The mark's top-left at the strip, in the stage's own coordinates. */
+  from: { x: number; y: number };
+  /** The mark's top-left once centred on the control. */
+  to: { x: number; y: number };
+  /** The mark's size, taken from the face it peels off rather than chosen. */
+  size: { width: number; height: number };
+}
+
+/**
+ * One measured box in the stage's own coordinates. Everything is read against
+ * the stage rather than the viewport because that is what the flight is drawn
+ * in: the strip, the panel, the black itself, and both drawn elements share
+ * one containing box, so a single subtraction puts every reading in one frame.
+ */
+export function errandBound(stage: ErrandBox, box: ErrandBox): ErrandBox {
+  return {
+    left: box.left - stage.left,
+    top: box.top - stage.top,
+    width: box.width,
+    height: box.height,
+  };
+}
+
+/** The flight, in the stage's coordinates. */
+export function errandJourney(stage: ErrandBox, face: ErrandBox, target: ErrandBox): ErrandJourney {
+  const landing = errandBound(stage, target);
+  const home = errandBound(stage, face);
+  return {
+    from: { x: home.left, y: home.top },
+    // Centred on the control, so a wide switch and a narrow tab are both
+    // landed on rather than beside.
+    to: {
+      x: landing.left + (landing.width - home.width) / 2,
+      y: landing.top + (landing.height - home.height) / 2,
+    },
+    size: { width: home.width, height: home.height },
+  };
+}
+
+/** The motion tokens a flight is timed by, already read as milliseconds. */
+export interface ErrandTokens {
+  shape: number;
+  quick: number;
+  exit: number;
+  expand: number;
+  stagger: number;
+  /** How many rows the stack still staggers before it stops accumulating. */
+  fanLimit: number;
+}
+
+/** When a flight sets off, how long it lasts, and where its moments fall in it. */
+export interface ErrandBeats {
+  delay: number;
+  duration: number;
+  /** The fraction of the flight at which the mark reaches the control. */
+  arrival: number;
+  /** The fraction at which it sets off home again. */
+  departure: number;
+  /**
+   * The fraction at which it is back on the face's own box. It is parked there
+   * for what is left, which is the window the strip's face fades back in
+   * underneath it — so the handover has no frame with two Lukes drawn, and
+   * none with neither.
+   */
+  home: number;
+}
+
+/**
+ * Whether there is a flight to run at all. Read off the shape token itself
+ * rather than off the total the beats add up to: a capture run zeroes the
+ * tokens and reduced motion leaves each of them a millisecond, and three of
+ * those summed would clear a floor that every one of them individually asked
+ * to stay under. Neither wants a face crossing the panel at any speed.
+ */
+export function errandFlies(tokens: ErrandTokens): boolean {
+  return tokens.shape >= STILL_MS;
+}
+
+/**
+ * The flight's shape in time: out on the surface's own spring, a beat on the
+ * control, and the same journey back. Nothing is written in milliseconds here
+ * — every number is derived from a token — which is how a capture run and
+ * reduced motion silence the errand without knowing it exists.
+ *
+ * The wait before setting off is the whole of what the act it signs has set in
+ * motion. A panel that had to open costs the shape's travel plus the delay and
+ * stagger its content arrives on; a settings page turned as well costs that
+ * again — the pages arrive on the very same fan — behind the exit the leaving
+ * page takes first. An errand that set off inside either would be crossing a
+ * surface still growing and landing where a row had not finished arriving.
+ */
+export function errandBeats(tokens: ErrandTokens, wait: ErrandWait): ErrandBeats {
+  const duration = tokens.shape * 2 + tokens.quick;
+  const arrival = tokens.shape / duration;
+  const arriving = tokens.expand + tokens.stagger * tokens.fanLimit + tokens.shape;
+  return {
+    delay:
+      wait === ERRAND_WAIT.AT_ONCE
+        ? tokens.quick
+        : wait === ERRAND_WAIT.PAGE
+          ? tokens.exit + arriving
+          : arriving,
+    duration,
+    arrival,
+    departure: (tokens.shape + tokens.quick) / duration,
+    home: (duration - tokens.exit) / duration,
+  };
+}
+
+/** How many points the drift is drawn with. Enough that the bow reads as curved. */
+const DRIFT_SAMPLES = 8;
+
+/**
+ * How far off the straight run the drift bows, as a share of the way home.
+ * Proportional, so a short hop and a long climb bow alike — and small, because
+ * this is a drift rather than a manoeuvre: it is there to keep the way home
+ * from being a ruled line, not to be noticed as a shape of its own.
+ */
+const DRIFT_SWAY_SHARE = 0.09;
+
+/** No smaller than he is, or a short hop would bow invisibly. */
+const DRIFT_SWAY_MIN_MARKS = 1;
+
+/** One sampled point of the way home. */
+export interface ErrandDriftStep {
+  /** Where in the whole flight this point falls. */
+  offset: number;
+  point: { x: number; y: number };
+}
+
+/**
+ * How far along the way home he is at a given moment of it. Smoothstep: level
+ * at both ends and quickest in the middle, so he lifts off the control rather
+ * than snapping away from it and settles onto the strip rather than arriving
+ * at it. The speed is carried here rather than in the keyframes' easing
+ * because the path is sampled — an easing per segment would ease at every
+ * sample and read as a series of small hesitations.
+ */
+function driftEase(progress: number): number {
+  return progress * progress * (3 - 2 * progress);
+}
+
+/** The largest sway that keeps `base + sway * direction` between two edges. */
+function roomFor(base: number, direction: number, low: number, high: number): number {
+  if (direction > 0) return (high - base) / direction;
+  if (direction < 0) return (low - base) / direction;
+  return Number.POSITIVE_INFINITY;
+}
+
+/**
+ * The way home, as a float rather than a line.
+ *
+ * The job on the way down is to be seen arriving at one control; the job on
+ * the way back is only to get out of the way, so it is the quietest motion
+ * that still reads as a thing moving under its own power. He eases off the
+ * control, bows gently to one side, and settles onto the strip — one half of a
+ * sine's worth of sway, zero at both ends, so the drift joins the straight run
+ * without a corner at either.
+ *
+ * Which side he leans is chosen rather than fixed: toward the side the strip
+ * is on rather than the side the desktop is on. `bound` is the drawn shape,
+ * and it decides how far he may lean at all — the run itself is between two
+ * points already on the black, so only the sway can leave it, and each sampled
+ * point moves off the run by the sway times a fixed direction. The widest
+ * drift the shape will hold is therefore just the tightest of those limits,
+ * solved rather than guessed at.
+ */
+export function errandDrift(
+  journey: ErrandJourney,
+  beats: ErrandBeats,
+  bound: ErrandBox,
+): readonly ErrandDriftStep[] {
+  const away = { x: journey.from.x - journey.to.x, y: journey.from.y - journey.to.y };
+  const distance = Math.hypot(away.x, away.y);
+  // Nowhere to go is no drift, and no flight: every step would be one point.
+  if (distance === 0) return [];
+  const along = { x: away.x / distance, y: away.y / distance };
+  // A quarter turn off the run, taken on whichever side leans toward the strip.
+  const acrossX = -along.y;
+  const facing = away.x !== 0 && acrossX !== 0 && Math.sign(acrossX) !== Math.sign(away.x) ? -1 : 1;
+  const across = { x: acrossX * facing, y: along.x * facing };
+
+  const baseAt = (travelled: number) => ({
+    x: journey.to.x + away.x * travelled,
+    y: journey.to.y + away.y * travelled,
+  });
+  // Half a sine, so the bow is widest at the middle of the run and nothing at
+  // either end of it.
+  const leanAt = (travelled: number) => Math.sin(Math.PI * travelled);
+
+  let sway = Math.max(distance * DRIFT_SWAY_SHARE, journey.size.width * DRIFT_SWAY_MIN_MARKS);
+  for (let index = 0; index <= DRIFT_SAMPLES; index += 1) {
+    const travelled = driftEase(index / DRIFT_SAMPLES);
+    const base = baseAt(travelled);
+    const lean = leanAt(travelled);
+    sway = Math.min(
+      sway,
+      roomFor(base.x, across.x * lean, bound.left, bound.left + bound.width - journey.size.width),
+      roomFor(base.y, across.y * lean, bound.top, bound.top + bound.height - journey.size.height),
+    );
+  }
+  // A run whose own ends are outside the shape can ask for a negative sway.
+  // Nothing is the right answer there: the drift collapses onto the run, which
+  // is the one path already known to be on the black.
+  sway = Math.max(0, sway);
+
+  const steps: ErrandDriftStep[] = [];
+  for (let index = 0; index <= DRIFT_SAMPLES; index += 1) {
+    const progress = index / DRIFT_SAMPLES;
+    const travelled = driftEase(progress);
+    const base = baseAt(travelled);
+    const lean = leanAt(travelled) * sway;
+    steps.push({
+      offset: beats.departure + (beats.home - beats.departure) * progress,
+      point: { x: base.x + across.x * lean, y: base.y + across.y * lean },
+    });
+  }
+  return steps;
+}
+
+const MOTION_TOKEN = {
+  SPRING: "--spring",
+  SPRING_FAST: "--spring-fast",
+  SHAPE_DURATION: "--duration-shape",
+  QUICK_DURATION: "--duration-quick",
+  EXIT_DURATION: "--duration-exit",
+  EXIT_EASING: "--motion-exit",
+  EXPAND_DELAY: "--expand-delay",
+  ROW_STAGGER: "--row-stagger",
+  ROW_FAN_LIMIT: "--row-fan-limit",
+} as const;
+
+type MotionToken = (typeof MOTION_TOKEN)[keyof typeof MOTION_TOKEN];
+
+/**
+ * How far past its own size the mark swells as it lands. The tap is the whole
+ * point of the landing, and a mark that only stopped would read as having
+ * drifted there.
+ */
+const LANDING_SCALE = 1.32;
+
+/** How far into its own life the ring is at full strength, as a fraction. */
+const RING_BLOOM = 0.26;
+
+/** How far past the control the ring has spread by the time it is gone. */
+const RING_SPREAD = 1.16;
+
+/** Only a control a reader can actually see is worth flying to. */
+function drawn(element: HTMLElement): boolean {
+  return element.checkVisibility({ opacityProperty: true });
+}
+
+/**
+ * The first candidate the panel is actually drawing. Read as one pass over the
+ * marked elements rather than a selector per candidate, so the document is
+ * queried once and the candidates are matched by their own ids.
+ */
+function landingPlace(
+  stage: HTMLElement,
+  targets: readonly ErrandTarget[],
+): HTMLElement | undefined {
+  const marked = new Map<string, HTMLElement>();
+  for (const element of stage.querySelectorAll<HTMLElement>(`[${ERRAND_TARGET_ATTRIBUTE}]`)) {
+    const target = element.getAttribute(ERRAND_TARGET_ATTRIBUTE);
+    if (target !== null && !marked.has(target) && drawn(element)) marked.set(target, element);
+  }
+  for (const target of targets) {
+    const element = marked.get(target);
+    if (element !== undefined) return element;
+  }
+  return undefined;
+}
+
+export interface LukeErrandProps {
+  errand?: Errand;
+  /**
+   * The tap has landed, which is the moment the control it flew to should be
+   * seen to move. Called once per errand and always — at once when there is
+   * no flight to make — so whatever is waiting on it is never left held.
+   */
+  onLanded?: () => void;
+  /**
+   * The flight is over, or was abandoned. Called once per errand and always,
+   * on the same terms, so a panel that was stood up for an errand knows when
+   * it may stand back down.
+   */
+  onReturned?: () => void;
+}
+
+/**
+ * Luke on his way to a control, and the ring he leaves when he gets there.
+ * Both are always mounted and both rest invisible: an element that arrived
+ * with the flight would have no size or place to set off from, and mounting
+ * one is a commit the panel does not need in the middle of a spoken answer.
+ * Neither is a second Luke — the strip's own face is held invisible for
+ * exactly as long as this one is drawn.
+ *
+ * The two callbacks are what let the act look like Luke's doing rather than
+ * something he arrived to inspect. Both fire exactly once per errand, on every
+ * path out — the flight running its course, a target that was never drawn,
+ * tokens held still, a panel closing underneath it — because each of them
+ * releases something the app is holding, and a hold nobody releases is worse
+ * than a beat landing early.
+ */
+export function LukeErrand({ errand, onLanded, onReturned }: LukeErrandProps): React.JSX.Element {
+  const mark = useRef<HTMLSpanElement>(null);
+  const ring = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    // Each beat is released once and only once, however this effect leaves —
+    // and releasing one that never came due is better than leaving the app
+    // holding a switch that will never be allowed to move.
+    let landed = false;
+    let returned = false;
+    const land = () => {
+      if (landed) return;
+      landed = true;
+      onLanded?.();
+    };
+    const returnHome = () => {
+      land();
+      if (returned) return;
+      returned = true;
+      onReturned?.();
+    };
+
+    const markElement = mark.current;
+    const ringElement = ring.current;
+    if (errand === undefined) return;
+    if (markElement === null || ringElement === null) return returnHome();
+    // The stage is the mark's own containing box, so it is found rather than
+    // handed down: the two are the same element by construction.
+    const stage = markElement.offsetParent;
+    if (!(stage instanceof HTMLElement)) return returnHome();
+
+    const style = getComputedStyle(stage);
+    const token = (name: MotionToken) => style.getPropertyValue(name);
+    const tokens: ErrandTokens = {
+      shape: parseMilliseconds(token(MOTION_TOKEN.SHAPE_DURATION)),
+      quick: parseMilliseconds(token(MOTION_TOKEN.QUICK_DURATION)),
+      exit: parseMilliseconds(token(MOTION_TOKEN.EXIT_DURATION)),
+      expand: parseMilliseconds(token(MOTION_TOKEN.EXPAND_DELAY)),
+      stagger: parseMilliseconds(token(MOTION_TOKEN.ROW_STAGGER)),
+      // A count rather than a length, but the same reading of a number off a
+      // token, so it shares the reader.
+      fanLimit: parsePixels(token(MOTION_TOKEN.ROW_FAN_LIMIT)),
+    };
+    if (!errandFlies(tokens)) return returnHome();
+    const beats = errandBeats(tokens, errand.wait);
+    const spring = token(MOTION_TOKEN.SPRING).trim() || "ease";
+    const springFast = token(MOTION_TOKEN.SPRING_FAST).trim() || "ease";
+    const exitEasing = token(MOTION_TOKEN.EXIT_EASING).trim() || "ease";
+
+    const flight: Animation[] = [];
+    let beat: number | undefined;
+    let settle: number | undefined;
+    const launch = window.setTimeout(() => {
+      // Read at the launch rather than when the errand was armed: the panel may
+      // have closed behind the answer, and everything below is measured off a
+      // shape that has finished moving.
+      if (stage.dataset.presentation !== PANEL_PRESENTATION.PANEL) return returnHome();
+      const face = stage.querySelector<HTMLElement>(`[${ERRAND_ORIGIN_ATTRIBUTE}]`);
+      const target = landingPlace(stage, errand.targets);
+      // No face is the meter standing in Luke's place, and no target is a
+      // control this build does not draw. Either way there is no journey.
+      if (face === null || !drawn(face) || target === undefined) return returnHome();
+      // A control below the fold of the settings tab is scrolled to first, so
+      // the flight lands somewhere a reader is looking. `nearest` leaves an
+      // already-visible control exactly where it is, which is the usual case.
+      target.scrollIntoView({ block: "nearest", behavior: "instant" });
+
+      const stageBox = stage.getBoundingClientRect();
+      const journey = errandJourney(
+        stageBox,
+        face.getBoundingClientRect(),
+        target.getBoundingClientRect(),
+      );
+      // The black itself, which is what the loop may not be drawn past. The
+      // surface is the one element that is the shape at whatever size it is
+      // currently drawn, and it already names itself for the pointer, so the
+      // flight asks the same element the same question.
+      const surface = stage.querySelector<HTMLElement>(
+        `[${HIT_REGION_ATTRIBUTE}="${HIT_REGION.SURFACE}"]`,
+      );
+      const bound = errandBound(stageBox, (surface ?? stage).getBoundingClientRect());
+      const drift = errandDrift(journey, beats, bound);
+      // A control drawn exactly where the face is has no journey to make.
+      if (drift.length === 0) return returnHome();
+
+      markElement.style.width = `${journey.size.width}px`;
+      markElement.style.height = `${journey.size.height}px`;
+
+      // Translate, then swell: the origin is the mark's own centre, so the tap
+      // happens about the middle of the face rather than dragging it off
+      // wherever it has travelled to.
+      const at = (point: { x: number; y: number }, scale: number) =>
+        `translate3d(${point.x}px, ${point.y}px, 0) scale(${scale})`;
+
+      // Kept one at a time, so a malformed token throwing out of a later
+      // `animate` still leaves nothing running: a half-built flight would send
+      // the mark across the panel over a face that never went invisible.
+      const play = (
+        element: HTMLElement,
+        keyframes: Keyframe[],
+        options: KeyframeAnimationOptions,
+      ) => {
+        flight.push(element.animate(keyframes, options));
+      };
+
+      // Nothing moving is the better failure, and there is nothing else to
+      // unwind because both of these elements rest invisible.
+      try {
+        play(
+          markElement,
+          [
+            // Out on the surface's own spring, which is what makes the dive
+            // read as part of the same object as the panel.
+            { offset: 0, transform: at(journey.from, 1), easing: spring },
+            // The tap: he overshoots his own size on landing and settles out
+            // of it over the beat, so the arrival is a press rather than a
+            // drift to a halt. This is the moment that carries the meaning,
+            // and it is the only emphatic one in the flight.
+            { offset: beats.arrival, transform: at(journey.to, LANDING_SCALE), easing: springFast },
+            // The float home. Linear between the drift's own steps, because
+            // its speed is already in where those steps fall — an easing per
+            // segment would ease at every sample and read as a series of small
+            // hesitations rather than as one unhurried drift.
+            ...drift.map((step) => ({
+              offset: step.offset,
+              transform: at(step.point, 1),
+              easing: "linear",
+            })),
+            // Parked on the face's own box for what is left, while the face
+            // fades back in under him.
+            { offset: 1, transform: at(journey.from, 1) },
+          ],
+          { duration: beats.duration },
+        );
+        // Drawn for exactly as long as the flight lasts and cut on the frame
+        // it ends, rather than faded out: by then he is parked on a face that
+        // is already fully drawn underneath him, so there is nothing for a
+        // fade to cover and a fade would only make two of him visible.
+        play(markElement, [{ opacity: 1 }, { opacity: 1 }], { duration: beats.duration });
+        // The other half of the same trick, and the reason there is only ever
+        // one Luke: the strip's face is held invisible for the flight and
+        // brought back over the window he spends parked on top of it. The
+        // wrapper rather than the drawing, because the drawing is remounted
+        // for every gesture and an animation on it would die with the node.
+        play(
+          face,
+          [
+            { offset: 0, opacity: 0 },
+            { offset: beats.home, opacity: 0, easing: exitEasing },
+            { offset: 1, opacity: 1 },
+          ],
+          { duration: beats.duration },
+        );
+      } catch {
+        for (const animation of flight) animation.cancel();
+        returnHome();
+        return;
+      }
+
+      // The two beats the app is waiting on, timed off the same flight rather
+      // than guessed at alongside it. The tap is where the control is allowed
+      // to move — before it, the change has been made and is simply not drawn
+      // yet — and the end of the flight is where a panel stood up for this
+      // errand may stand back down.
+      beat = window.setTimeout(() => {
+        // The control changes shape at the tap and not before: the options
+        // button grows a label as the list narrows — by a provider's whole
+        // name and mark, which is the widest it gets — and a pop-up is as wide
+        // as the value it is showing. So the ring is measured after the change
+        // is in the DOM rather than at the launch, when it would be the
+        // outline of a control that is about to stop existing.
+        //
+        // Flushed rather than waited a frame for. The release is a React state
+        // change made from a timer, which React is free to commit on its own
+        // schedule — and a frame is not that schedule, so a ring drawn in the
+        // next one measured the button as it was. This is the one place the
+        // errand needs the DOM to have caught up before it reads it, so it is
+        // the one place that says so outright.
+        flushSync(land);
+        const landing = errandBound(stage.getBoundingClientRect(), target.getBoundingClientRect());
+        // A control the change took off the panel has no outline worth
+        // drawing, and a zero box would draw a ring at the stage's corner.
+        if (landing.width === 0 || landing.height === 0) return;
+        ringElement.style.left = `${landing.left}px`;
+        ringElement.style.top = `${landing.top}px`;
+        ringElement.style.width = `${landing.width}px`;
+        ringElement.style.height = `${landing.height}px`;
+        // The ring is the control's own outline, so it takes the control's own
+        // corners rather than a radius of its own.
+        ringElement.style.borderRadius = getComputedStyle(target).borderRadius;
+        try {
+          play(
+            ringElement,
+            [
+              { offset: 0, opacity: 0, transform: "scale(0.84)", easing: springFast },
+              { offset: RING_BLOOM, opacity: 1, transform: "scale(1)", easing: exitEasing },
+              { offset: 1, opacity: 0, transform: `scale(${RING_SPREAD})` },
+            ],
+            { duration: beats.duration * (1 - beats.arrival) },
+          );
+        } catch {
+          // The mark is already home and dry without it; a ring that cannot be
+          // drawn is not worth taking the rest of the flight down for.
+        }
+      }, beats.duration * beats.arrival);
+      settle = window.setTimeout(returnHome, beats.duration);
+    }, beats.delay);
+
+    return () => {
+      window.clearTimeout(launch);
+      if (beat !== undefined) window.clearTimeout(beat);
+      if (settle !== undefined) window.clearTimeout(settle);
+      // A flight the panel closed under, or that a second errand overtook, is
+      // over rather than paused: both elements rest invisible, so cancelling is
+      // the whole of putting them away. Its beats are still released, because
+      // the change it was carrying has to be drawn whether or not anyone got to
+      // watch it arrive.
+      for (const animation of flight) animation.cancel();
+      returnHome();
+    };
+  }, [errand, onLanded, onReturned]);
+
+  return (
+    <>
+      {/* Under him, so the tap is drawn over the ring it makes. */}
+      <span className="luke-errand-ring" ref={ring} aria-hidden="true" />
+      <span className="luke-errand-mark" ref={mark} aria-hidden="true">
+        <LukeFace />
+      </span>
+    </>
+  );
+}

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -71,6 +71,17 @@ export const APP_SETTING_ID = {
 
 export type AppSettingId = (typeof APP_SETTING_ID)[keyof typeof APP_SETTING_ID];
 
+const APP_SETTING_ID_LIST: readonly AppSettingId[] = Object.values(APP_SETTING_ID);
+
+/**
+ * Whether an id read back off a guide entry is one of Luke's own settings. A
+ * guide entry carries its id as plain text — the snapshot is data on its way
+ * out to a conversation — so anything reading one back has to ask.
+ */
+export function isAppSettingId(value: string): value is AppSettingId {
+  return APP_SETTING_ID_LIST.includes(value as AppSettingId);
+}
+
 /** Where the switches live, said once so every entry words it the same way. */
 const SETTINGS_TAB = "the panel's Settings tab";
 
@@ -469,7 +480,9 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "provider allows. Settings holds a front page whose rows open its Voice, Appearance, " +
         "Keyboard shortcuts, and Connections pages — each led back out by its back button or " +
         "Escape — and keeps the microphone permission, the Feedback section, and Quit on the " +
-        "front page itself.",
+        "front page itself. A change Luke makes himself is shown as it is made: the panel " +
+        "comes forward on the tab, and the page, the change belongs to, and his face leaves " +
+        "the strip under the housing, dives to the control that moved, and floats back.",
     },
     {
       label: "Feedback and prompts",

--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -1,5 +1,6 @@
 import { CAPSULE_SIDE_WIDTH, PANEL_WIDTH, PEEK_SIDE_GROWTH } from "@sidecar/core";
 import { useCallback, useMemo, useRef, useState } from "react";
+import { errandOriginProps } from "./luke-errand";
 import { LukeFace } from "./luke-face";
 import {
   faceYieldsToMeter,
@@ -221,7 +222,13 @@ export function NotchWings({
               hover is measured against, so it holds still across those
               remounts — and hovering it is a moment the face reacts to. */}
           {yieldToMeter ? null : (
-            <span className="wing-face" ref={faceElement}>
+            /* The wrapper is also where an errand sets off from, for the same
+               reason the hover is measured against it: it holds still while a
+               motion transforms layers inside the drawing, so a mark peeling
+               off it starts exactly where the face is drawn. It is not
+               rendered at all while the meter has this place, which is how an
+               errand knows there is no face to leave from. */
+            <span className="wing-face" ref={faceElement} {...errandOriginProps()}>
               <LukeFace key={face.play} motion={face.motion} repeat={face.repeat} />
             </span>
           )}

--- a/apps/desktop/src/renderer/panel-state.ts
+++ b/apps/desktop/src/renderer/panel-state.ts
@@ -19,6 +19,9 @@ export const PANEL_PRESENTATION = {
 
 export type PanelPresentation = (typeof PANEL_PRESENTATION)[keyof typeof PANEL_PRESENTATION];
 
+/** How an element says which region it is, for whoever is asking. */
+export const HIT_REGION_ATTRIBUTE = "data-hit-region";
+
 /** What takes the pointer, named so the test can tell one from another. */
 export const HIT_REGION = {
   /** The black shape itself, whatever size it is drawn at. */

--- a/apps/desktop/src/renderer/panel-tabs.tsx
+++ b/apps/desktop/src/renderer/panel-tabs.tsx
@@ -1,9 +1,14 @@
-export const PANEL_TAB = {
-  SESSIONS: "sessions",
-  SETTINGS: "settings",
-} as const;
+import { APP_PANEL_TAB, type AppPanelTab } from "@sidecar/core";
+import { errandTargetProps, tabErrandTarget } from "./luke-errand";
 
-export type PanelTab = (typeof PANEL_TAB)[keyof typeof PANEL_TAB];
+/**
+ * The panel's two tabs, aliased from the core's set rather than declared here
+ * — the same rule the sort follows: a spoken ask names a tab in the same words
+ * this bar does, and the two must not drift into separate vocabularies.
+ */
+export const PANEL_TAB = APP_PANEL_TAB;
+
+export type PanelTab = AppPanelTab;
 
 interface PanelTabDescriptor {
   id: PanelTab;
@@ -52,6 +57,9 @@ export function TabBar({
           key={candidate.id}
           id={panelTabId(candidate.id)}
           className="tab"
+          // Where an errand lands when Luke was the one who brought this tab
+          // forward, so the press he made on your behalf is drawn as a press.
+          {...errandTargetProps(tabErrandTarget(candidate.id))}
           data-active={String(candidate.id === tab)}
           aria-selected={candidate.id === tab}
           aria-controls={panelPanelId(candidate.id)}

--- a/apps/desktop/src/renderer/session-parts.tsx
+++ b/apps/desktop/src/renderer/session-parts.tsx
@@ -1,3 +1,4 @@
+import { ERRAND_TARGET, errandTargetProps } from "./luke-errand";
 import { PANEL_TAB, panelPanelId, panelTabId } from "./panel-tabs";
 import { ProviderMark } from "./provider-marks";
 import {
@@ -146,6 +147,9 @@ export function SessionOptionsButton({
       type="button"
       id={SESSION_OPTIONS_BUTTON_ID}
       className="options-button"
+      // The button already says how the list is being shown, so it is where a
+      // narrowing or a re-ordering Luke made himself is signed.
+      {...errandTargetProps(ERRAND_TARGET.LIST_OPTIONS)}
       data-active={String(open)}
       data-narrowed={String(narrowed !== undefined)}
       aria-expanded={open}

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -49,6 +49,8 @@ import {
 import type { FeedbackEntryControl } from "./feedback-entry";
 import { FeedbackSection } from "./feedback-panel";
 import { Keycaps } from "./keycaps";
+import { errandTargetProps } from "./luke-errand";
+import { APP_SETTING_ID } from "./luke-guide";
 import { microphoneAccessRow } from "./microphone-access";
 import { PANEL_TAB, panelPanelId, panelTabId } from "./panel-tabs";
 import { CloudBadge, ProviderMark } from "./provider-marks";
@@ -1035,8 +1037,16 @@ function VoiceSection({
               starting afresh. */}
           <small>How Luke sounds; a conversation under way starts afresh.</small>
         </span>
+        {/* Every control a spoken change can reach carries the id that change
+            names it by, so an errand lands on the control itself rather than
+            somewhere near it. The control is marked rather than the row — the
+            switch is what moved, and the row is only what explains it — and,
+            here, the `select` rather than the box positioning it: the errand
+            outlines what it lands on, and only the `select` is drawn with the
+            corners that outline has to take. */}
         <span className="voice-select">
           <select
+            {...errandTargetProps(APP_SETTING_ID.VOICE)}
             aria-label="Voice"
             value={voice}
             onChange={(event) => {
@@ -1073,6 +1083,7 @@ function VoiceSection({
         </span>
         <span className="voice-select">
           <select
+            {...errandTargetProps(APP_SETTING_ID.VOICE_SPEED)}
             aria-label="Speed"
             value={speed}
             onChange={(event) => {
@@ -1117,6 +1128,7 @@ function VoiceSection({
           aria-checked={captions}
           aria-label="Caption Luke's speech on screen"
           className="switch"
+          {...errandTargetProps(APP_SETTING_ID.VOICE_CAPTIONS)}
           disabled={captionsBusy}
           onClick={() => void toggleCaptions()}
         >
@@ -1138,6 +1150,7 @@ function VoiceSection({
           aria-checked={ducking}
           aria-label="Quiet Music and Spotify while talking with Luke"
           className="switch"
+          {...errandTargetProps(APP_SETTING_ID.DUCK_OTHER_MEDIA)}
           disabled={duckBusy}
           onClick={() => void toggleDucking()}
         >
@@ -1162,6 +1175,7 @@ function VoiceSection({
           aria-checked={notifications}
           aria-label="Announce when a session needs you"
           className="switch"
+          {...errandTargetProps(APP_SETTING_ID.SESSION_NOTIFICATIONS)}
           disabled={notificationsBusy}
           onClick={() => void toggleNotifications()}
         >
@@ -1242,6 +1256,7 @@ function AppearanceSection({
           aria-checked={shown}
           aria-label="Show Luke in the menu bar"
           className="switch"
+          {...errandTargetProps(APP_SETTING_ID.SHOW_IN_MENU_BAR)}
           disabled={busy}
           onClick={() => void toggle()}
         >
@@ -1258,6 +1273,7 @@ function AppearanceSection({
           aria-checked={dockShown}
           aria-label="Show Luke in the Dock"
           className="switch"
+          {...errandTargetProps(APP_SETTING_ID.SHOW_IN_DOCK)}
           disabled={dockBusy}
           onClick={() => void toggleDock()}
         >
@@ -1274,6 +1290,7 @@ function AppearanceSection({
           aria-checked={allDisplays}
           aria-label="Show Luke on all displays"
           className="switch"
+          {...errandTargetProps(APP_SETTING_ID.SHOW_ON_ALL_DISPLAYS)}
           disabled={displayBusy}
           onClick={() => void toggleAllDisplays()}
         >
@@ -1289,6 +1306,7 @@ function AppearanceSection({
         </span>
         <span className="voice-select">
           <select
+            {...errandTargetProps(APP_SETTING_ID.FORM_FACTOR)}
             aria-label="Form factor"
             value={formFactor}
             disabled={formBusy}

--- a/apps/desktop/src/renderer/settings-views.ts
+++ b/apps/desktop/src/renderer/settings-views.ts
@@ -1,3 +1,5 @@
+import { APP_SETTING_ID, type AppSettingId } from "./luke-guide";
+
 /**
  * Where inside the Settings tab the panel currently is: its front page, or one
  * of the pages a front-page row opens. App state rather than panel state for
@@ -52,6 +54,46 @@ export function pageExitMs(element: Element | null): number {
   if (!element) return PAGE_EXIT_MS;
   return pageExitFromToken(getComputedStyle(element).getPropertyValue("--duration-exit"));
 }
+
+/**
+ * Which page each setting is drawn on.
+ *
+ * A page that is not open is not rendered at all, so this is what anything
+ * reaching for a control by hand has to consult first — an errand flying to a
+ * switch on a closed page would find nothing there and quietly go nowhere. A
+ * `Record` over every id on purpose: the same lever the guide uses, so a
+ * setting added later does not build until someone says where it lives.
+ *
+ * The guide says the same thing in prose, in the by-hand path it offers for
+ * each setting. That the two agree is a test rather than a type, because one
+ * is a sentence and the other is a page.
+ */
+export const SETTING_PAGE: Record<AppSettingId, SettingsSubview> = {
+  [APP_SETTING_ID.VOICE]: SETTINGS_VIEW.VOICE,
+  [APP_SETTING_ID.VOICE_SPEED]: SETTINGS_VIEW.VOICE,
+  [APP_SETTING_ID.VOICE_CAPTIONS]: SETTINGS_VIEW.VOICE,
+  [APP_SETTING_ID.DUCK_OTHER_MEDIA]: SETTINGS_VIEW.VOICE,
+  [APP_SETTING_ID.SESSION_NOTIFICATIONS]: SETTINGS_VIEW.VOICE,
+  [APP_SETTING_ID.SHOW_IN_MENU_BAR]: SETTINGS_VIEW.APPEARANCE,
+  [APP_SETTING_ID.SHOW_IN_DOCK]: SETTINGS_VIEW.APPEARANCE,
+  [APP_SETTING_ID.SHOW_ON_ALL_DISPLAYS]: SETTINGS_VIEW.APPEARANCE,
+  [APP_SETTING_ID.FORM_FACTOR]: SETTINGS_VIEW.APPEARANCE,
+  // The three the guide describes but marks by-hand-only. Nothing flies to
+  // them — a spoken ask is refused before it reaches a page — but where they
+  // are drawn is a fact about the settings either way, and answering it here
+  // is what keeps the answer right if one of them is ever opened up.
+  [APP_SETTING_ID.DEFAULT_WORKSPACE_PROVIDER]: SETTINGS_VIEW.CONNECTIONS,
+  [APP_SETTING_ID.WORKSPACE_AGENT_MODEL]: SETTINGS_VIEW.CONNECTIONS,
+  [APP_SETTING_ID.WORKSPACE_AGENT_EFFORT]: SETTINGS_VIEW.CONNECTIONS,
+};
+
+/** How each page names itself, which is how the guide's by-hand paths word it. */
+export const SETTINGS_PAGE_LABEL: Record<SettingsSubview, string> = {
+  [SETTINGS_VIEW.VOICE]: "Voice",
+  [SETTINGS_VIEW.APPEARANCE]: "Appearance",
+  [SETTINGS_VIEW.SHORTCUTS]: "Keyboard shortcuts",
+  [SETTINGS_VIEW.CONNECTIONS]: "Connections",
+};
 
 const NAV_ROW_ID: Record<SettingsSubview, string> = {
   [SETTINGS_VIEW.VOICE]: "settings-nav-voice",

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -995,6 +995,73 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   transform-origin: center;
 }
 
+/* Luke's errand ---------------------------------------------------------- */
+
+/* Luke crossing his own panel to sign a control he was asked to move, and the
+   ring he leaves on it when he gets there. Both are always mounted and both
+   rest invisible: an element that arrived with the flight would have no place
+   to set off from, and every frame of it is `transform` and `opacity` alone.
+
+   This is not a second Luke. The strip's face is held invisible for exactly as
+   long as the flight lasts, and this sets off from that face's own measured
+   box wearing the colour the face is wearing — so the same face is simply
+   somewhere else for a second.
+
+   Above everything, because the flight passes over the panel rather than
+   through it, and past every pointer: the strip's one button and the control
+   being landed on both keep every press they ever had. There is no reduced
+   motion rule to write — the flight is timed off the tokens in JavaScript, so
+   zeroed tokens are simply no flight. */
+.luke-errand-mark,
+.luke-errand-ring {
+  position: absolute;
+  z-index: 4;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* The size arrives from the flight, measured off the face this stands in for
+   rather than restated here. The ink is the resting one, for the stretches
+   with no turn to report — the two rules below are what answer a turn. */
+.luke-errand-mark {
+  display: flex;
+  color: var(--text-primary);
+}
+
+/* The drawing states its own ink, and would otherwise win over the wrapper's
+   — the artwork paints in `currentColor`, resolved against the svg rather than
+   against whatever holds it. Inside a flight it defers, so the wrapper below is
+   the one place the errand's colour is decided. */
+.luke-errand-mark .luke-face {
+  width: 100%;
+  height: 100%;
+  color: inherit;
+}
+
+/* Whose turn it is, on him as on the face he stands in for: blue while Luke is
+   talking, green while he is listening. Taken from the same `data-voice` the
+   face's own two rules are, rather than measured off the face and carried, so
+   the two cannot drift apart mid-flight — which is what the handover at the
+   strip depends on, since a colour fixed at launch would swap for a different
+   one the moment the face came back underneath him. */
+.app-stage[data-voice="luke"] .luke-errand-mark {
+  color: var(--voice-luke);
+}
+
+.app-stage[data-voice="developer"] .luke-errand-mark {
+  color: var(--voice-developer);
+}
+
+/* The control's own outline for a moment, so what was touched is unmistakable
+   without the control itself being restyled to say so. Its box and its corners
+   are measured off the control; only the strength and the spread are decided
+   here. */
+.luke-errand-ring {
+  border: 1.5px solid color-mix(in srgb, var(--text-primary) 62%, transparent);
+}
+
 /* Nothing to blend into on a display without a housing, so the shape stops
    pretending: it lifts off the edge and closes into a free-floating pill. The
    lift is `BUBBLE_LIFT` in packages/sidecar-core/src/geometry.ts — the two
@@ -1530,10 +1597,17 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   transition: transform var(--duration-fast) var(--spring-fast);
 }
 
+/* The radius is the thumb's, not a shape of its own: the tab draws no
+   background, so this changes nothing about how it looks and everything about
+   how it is ringed. A focus ring follows the border radius of the box it is
+   drawn around, so a control that is drawn round by something behind it — and
+   declares no radius itself — takes a ring with square corners around a shape
+   that has none. */
 .tab {
   position: relative;
   flex: 1;
   padding: 6px 0;
+  border-radius: 8px;
   background: none;
   color: var(--text-secondary);
   font-size: 10.5px;
@@ -2285,11 +2359,16 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 .link-button {
   display: inline;
   padding: 0;
+  /* Rounded for the ring's sake rather than its own, the way the tab is: with
+     no radius the ring is a hard rectangle around a run of text. The offset is
+     what keeps it off the glyphs, since the box hugs them. */
   border: 0;
+  border-radius: 5px;
   background: none;
   color: var(--state-working);
   font-size: inherit;
   font-weight: 640;
+  outline-offset: 3px;
   white-space: nowrap;
   transition: color var(--duration-hover) ease;
 }

--- a/apps/desktop/tests/luke-errand.test.ts
+++ b/apps/desktop/tests/luke-errand.test.ts
@@ -1,0 +1,372 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  APP_PANEL_TAB,
+  APP_SETTING_KIND,
+  type AppGuideSetting,
+  PANEL_FORM_FACTOR,
+  REALTIME_VOICE,
+  REALTIME_VOICE_SPEED,
+  SESSION_LIST_SORT,
+} from "@sidecar/core";
+import {
+  ERRAND_TARGET,
+  ERRAND_WAIT,
+  type ErrandJourney,
+  type ErrandTokens,
+  errandBeats,
+  errandBound,
+  errandDrift,
+  errandFlies,
+  errandJourney,
+  errandTargets,
+  tabErrandTarget,
+} from "../src/renderer/luke-errand";
+import {
+  APP_SETTING_ID,
+  buildLukeGuide,
+  isAppSettingId,
+  type LukeGuideInput,
+} from "../src/renderer/luke-guide";
+import { SETTING_PAGE, SETTINGS_PAGE_LABEL } from "../src/renderer/settings-views";
+import type { AppSettings } from "../src/shared/contracts";
+import { CREDENTIAL_SOURCE, SECRET_STORAGE } from "../src/shared/contracts";
+import { CREDENTIAL_PROVIDER_ID } from "../src/shared/credential-providers";
+
+function settings(): AppSettings {
+  return {
+    credentialSources: {
+      [CREDENTIAL_PROVIDER_ID.CONDUCTOR]: CREDENTIAL_SOURCE.NONE,
+      [CREDENTIAL_PROVIDER_ID.COPILOT]: CREDENTIAL_SOURCE.NONE,
+      [CREDENTIAL_PROVIDER_ID.CURSOR]: CREDENTIAL_SOURCE.NONE,
+      [CREDENTIAL_PROVIDER_ID.DEVIN]: CREDENTIAL_SOURCE.NONE,
+      [CREDENTIAL_PROVIDER_ID.JULES]: CREDENTIAL_SOURCE.NONE,
+      [CREDENTIAL_PROVIDER_ID.LINEAR]: CREDENTIAL_SOURCE.NONE,
+    },
+    secretStorage: SECRET_STORAGE.UNKNOWN,
+    showInMenuBar: true,
+    showInDock: false,
+    voice: REALTIME_VOICE.CEDAR,
+    voiceSpeed: REALTIME_VOICE_SPEED.NORMAL,
+    voiceCaptions: false,
+    duckOtherMedia: true,
+    showOnAllDisplays: false,
+    formFactor: PANEL_FORM_FACTOR.BUBBLE,
+  };
+}
+
+const guideInput: LukeGuideInput = {
+  settings: settings(),
+  voiceAvailable: true,
+  microphoneStatus: "granted",
+  hotkey: { hotkey: "⌥Space", held: true },
+  askKey: "⌥L",
+};
+
+function guideSetting(id: string): AppGuideSetting {
+  const setting = buildLukeGuide(guideInput).settings.find((candidate) => candidate.id === id);
+  assert.ok(setting, `the guide lists ${id}`);
+  return setting;
+}
+
+test("a settings change is signed on the control that setting names", () => {
+  assert.deepEqual(
+    errandTargets({
+      kind: "setting",
+      setting: guideSetting(APP_SETTING_ID.VOICE_CAPTIONS),
+      value: "on",
+    }),
+    [APP_SETTING_ID.VOICE_CAPTIONS],
+  );
+});
+
+test("every setting a spoken ask may change has somewhere to be signed", () => {
+  for (const setting of buildLukeGuide(guideInput).settings) {
+    if (!setting.adjustable) continue;
+    assert.deepEqual(
+      errandTargets({ kind: "setting", setting, value: setting.value }),
+      [setting.id],
+      `${setting.id} has a landing place`,
+    );
+  }
+});
+
+test("a setting the guide never listed is signed nowhere", () => {
+  const setting: AppGuideSetting = {
+    id: "invented",
+    label: "Invented",
+    description: "",
+    kind: APP_SETTING_KIND.TOGGLE,
+    value: "on",
+    adjustable: true,
+    manual: "nowhere",
+  };
+  assert.deepEqual(errandTargets({ kind: "setting", setting, value: "on" }), []);
+});
+
+test("showing a tab is signed on that tab", () => {
+  assert.deepEqual(errandTargets({ kind: "panel", tab: APP_PANEL_TAB.SESSIONS }), [
+    ERRAND_TARGET.SESSIONS_TAB,
+  ]);
+  assert.deepEqual(errandTargets({ kind: "panel", tab: APP_PANEL_TAB.SETTINGS }), [
+    ERRAND_TARGET.SETTINGS_TAB,
+  ]);
+  // The record behind it is exhaustive over the tabs a spoken ask can name.
+  assert.equal(tabErrandTarget(APP_PANEL_TAB.SETTINGS), ERRAND_TARGET.SETTINGS_TAB);
+});
+
+test("a narrowing or a re-ordering is signed on the control that carries it", () => {
+  // The options button says how the list is being shown, so it comes first —
+  // and it is only drawn beside a list with something to choose between, which
+  // is why the tab stands behind it rather than instead of it.
+  assert.deepEqual(errandTargets({ kind: "panel", tab: APP_PANEL_TAB.SESSIONS, filter: "cloud" }), [
+    ERRAND_TARGET.LIST_OPTIONS,
+    ERRAND_TARGET.SESSIONS_TAB,
+  ]);
+  assert.deepEqual(
+    errandTargets({
+      kind: "panel",
+      tab: APP_PANEL_TAB.SESSIONS,
+      sort: SESSION_LIST_SORT.RECENCY,
+    }),
+    [ERRAND_TARGET.LIST_OPTIONS, ERRAND_TARGET.SESSIONS_TAB],
+  );
+});
+
+test("a refused act is signed nowhere", () => {
+  assert.deepEqual(errandTargets({ kind: "refused", reason: "No such tool exists." }), []);
+});
+
+test("the flight starts on the face and lands centred on the control", () => {
+  const journey = errandJourney(
+    { left: 0, top: 0, width: 1000, height: 600 },
+    { left: 480, top: 8, width: 18, height: 18 },
+    { left: 300, top: 200, width: 34, height: 20 },
+  );
+
+  assert.deepEqual(journey.from, { x: 480, y: 8 });
+  assert.deepEqual(journey.to, { x: 308, y: 201 });
+  assert.deepEqual(journey.size, { width: 18, height: 18 });
+});
+
+test("a stage offset from the viewport is subtracted out of every reading", () => {
+  const journey = errandJourney(
+    { left: 40, top: 12, width: 1000, height: 600 },
+    { left: 480, top: 20, width: 18, height: 18 },
+    { left: 300, top: 200, width: 18, height: 18 },
+  );
+
+  assert.deepEqual(journey.from, { x: 440, y: 8 });
+  assert.deepEqual(journey.to, { x: 260, y: 188 });
+});
+
+const TOKENS: ErrandTokens = {
+  shape: 460,
+  quick: 140,
+  exit: 90,
+  expand: 200,
+  stagger: 32,
+  fanLimit: 5,
+};
+
+test("the flight is out, a beat, and back, all measured off the tokens", () => {
+  const beats = errandBeats(TOKENS, ERRAND_WAIT.AT_ONCE);
+
+  assert.equal(beats.duration, 460 * 2 + 140);
+  // He reaches the control after one shape's travel and leaves after the beat.
+  assert.equal(beats.arrival * beats.duration, 460);
+  assert.equal(beats.departure * beats.duration, 600);
+  // He is back on the face's own box an exit's worth before the end, which is
+  // the window the face fades back in under him: the handover needs a stretch
+  // where both are drawn in the same place rather than an instant where the
+  // one is swapped for the other.
+  assert.equal(Math.round((1 - beats.home) * beats.duration), 90);
+  assert.ok(beats.home > beats.departure);
+  // A panel already open owes the errand no wait beyond a beat.
+  assert.equal(beats.delay, TOKENS.quick);
+});
+
+test("an errand that opened the panel trails the whole opening", () => {
+  // The shape's travel plus the delay and stagger its content arrives on: an
+  // errand setting off inside that would cross a surface still growing.
+  assert.equal(errandBeats(TOKENS, ERRAND_WAIT.CONTENT).delay, 200 + 32 * 5 + 460);
+});
+
+test("an errand that turned a settings page waits for the page it turned to", () => {
+  // A settings page is not drawn until the page it replaced has finished
+  // leaving, and then it arrives on the very fan the panel's own content
+  // does — so the wait is that arrival with the leaving page's exit in front
+  // of it. Measured any sooner, the mark lands where a row was passing.
+  assert.equal(
+    errandBeats(TOKENS, ERRAND_WAIT.PAGE).delay,
+    90 + errandBeats(TOKENS, ERRAND_WAIT.CONTENT).delay,
+  );
+  // Only the wait changes: the flight itself is one flight however it started.
+  const page = errandBeats(TOKENS, ERRAND_WAIT.PAGE);
+  const content = errandBeats(TOKENS, ERRAND_WAIT.CONTENT);
+  assert.equal(page.duration, content.duration);
+  assert.equal(page.arrival, content.arrival);
+  assert.equal(page.home, content.home);
+});
+
+/** The window, and the black drawn in the middle of it: a 620-wide open panel. */
+const STAGE = { left: 0, top: 0, width: 1512, height: 600 };
+const SURFACE = { left: 446, top: 0, width: 620, height: 520 };
+
+/** The way home for a control below and to the right of the strip's face. */
+function homeward(target = { left: 960, top: 300, width: 34, height: 20 }) {
+  const beats = errandBeats(TOKENS, ERRAND_WAIT.AT_ONCE);
+  const journey = errandJourney(STAGE, { left: 747, top: 9, width: 18, height: 18 }, target);
+  return { journey, beats, drift: errandDrift(journey, beats, errandBound(STAGE, SURFACE)) };
+}
+
+/** How far off the straight run back a point of the drift sits. */
+function swayAt(journey: ErrandJourney, point: { x: number; y: number }): number {
+  const run = { x: journey.from.x - journey.to.x, y: journey.from.y - journey.to.y };
+  const distance = Math.hypot(run.x, run.y);
+  return Math.abs(run.x * (point.y - journey.to.y) - run.y * (point.x - journey.to.x)) / distance;
+}
+
+/** Whether a point of the flight is drawn entirely on the black. */
+function onTheBlack(point: { x: number; y: number }, size: { width: number; height: number }) {
+  return (
+    point.x >= SURFACE.left &&
+    point.x + size.width <= SURFACE.left + SURFACE.width &&
+    point.y >= SURFACE.top &&
+    point.y + size.height <= SURFACE.top + SURFACE.height
+  );
+}
+
+test("the float leaves the control and reaches the strip on the line itself", () => {
+  const { journey, beats, drift } = homeward();
+  const first = drift.at(0);
+  const last = drift.at(-1);
+  assert.ok(first && last);
+
+  // The sway is zero at both ends, so the drift joins the straight run without
+  // a corner at either — he leaves the control on the line and arrives on it.
+  assert.deepEqual(first.point, journey.to);
+  assert.ok(Math.abs(last.point.x - journey.from.x) < 1e-9);
+  assert.ok(Math.abs(last.point.y - journey.from.y) < 1e-9);
+
+  // The steps span exactly the way home, in order.
+  assert.equal(first.offset, beats.departure);
+  assert.equal(last.offset, beats.home);
+  for (let index = 1; index < drift.length; index += 1) {
+    const step = drift[index];
+    const previous = drift[index - 1];
+    assert.ok(step && previous && step.offset > previous.offset, "offsets only ever rise");
+  }
+});
+
+test("the float is a gentle bow, never a manoeuvre", () => {
+  const { journey, drift } = homeward();
+  const sways = drift.map((step) => swayAt(journey, step.point));
+  const widest = Math.max(...sways);
+
+  // Wide enough not to be a ruled line, and nothing like the excursion a loop
+  // would make: this is a drift out of the way, not a shape worth watching.
+  assert.ok(widest > journey.size.width / 2, "the way home is not a ruled line");
+  assert.ok(widest < journey.size.width * 3, "and it is not a manoeuvre either");
+
+  // It never doubles back on itself: every step is further along the run than
+  // the one before, which is what separates a drift from a loop.
+  const run = { x: journey.from.x - journey.to.x, y: journey.from.y - journey.to.y };
+  const distance = Math.hypot(run.x, run.y);
+  const alongRun = drift.map(
+    (step) =>
+      ((step.point.x - journey.to.x) * run.x + (step.point.y - journey.to.y) * run.y) / distance,
+  );
+  for (let index = 1; index < alongRun.length; index += 1) {
+    assert.ok((alongRun[index] ?? 0) > (alongRun[index - 1] ?? 0), "he only ever heads home");
+  }
+
+  // And he eases off the control and onto the strip rather than crossing at one
+  // speed: the first and last steps cover less ground than the middle ones.
+  const strides = alongRun.slice(1).map((reach, index) => reach - (alongRun[index] ?? 0));
+  const middle = strides[Math.floor(strides.length / 2)] ?? 0;
+  assert.ok((strides.at(0) ?? 0) < middle, "he lifts off rather than snapping away");
+  assert.ok((strides.at(-1) ?? 0) < middle, "and settles rather than arriving at speed");
+});
+
+test("the float leans toward the strip rather than out over the desktop", () => {
+  // A control right of the face sends him home leftward, so the bow leans left
+  // as well: leaning right would carry it toward the panel's edge.
+  const rightward = homeward();
+  assert.ok(rightward.journey.from.x < rightward.journey.to.x);
+  const widest = rightward.drift.reduce((furthest, step) =>
+    swayAt(rightward.journey, step.point) > swayAt(rightward.journey, furthest.point)
+      ? step
+      : furthest,
+  );
+  assert.ok(widest.point.x < rightward.journey.to.x);
+
+  // And the mirror image leans the other way.
+  const leftward = homeward({ left: 500, top: 300, width: 34, height: 20 });
+  const mirrored = leftward.drift.reduce((furthest, step) =>
+    swayAt(leftward.journey, step.point) > swayAt(leftward.journey, furthest.point)
+      ? step
+      : furthest,
+  );
+  assert.ok(mirrored.point.x > leftward.journey.to.x);
+});
+
+test("no point of the float is ever drawn past the edge of the black", () => {
+  // Every corner the panel has, including the ones with no room to lean into:
+  // the shape is what bounds the sway, so a control tucked against an edge
+  // gets whatever drift fits rather than one drawn onto the desktop.
+  const corners = [
+    { left: 456, top: 60, width: 34, height: 20 },
+    { left: 1022, top: 60, width: 34, height: 20 },
+    { left: 456, top: 490, width: 34, height: 20 },
+    { left: 1022, top: 490, width: 34, height: 20 },
+    { left: 960, top: 300, width: 34, height: 20 },
+    { left: 500, top: 120, width: 34, height: 20 },
+  ];
+  for (const corner of corners) {
+    const { journey, drift } = homeward(corner);
+    assert.ok(drift.length > 0, `a control at ${corner.left},${corner.top} still has a way home`);
+    for (const step of drift) {
+      assert.ok(
+        onTheBlack(step.point, journey.size),
+        `a step at ${step.point.x.toFixed(1)},${step.point.y.toFixed(1)} stays on the black`,
+      );
+    }
+  }
+});
+
+test("a control drawn where the face already is has no way home to float", () => {
+  const face = { left: 747, top: 9, width: 18, height: 18 };
+  const journey = errandJourney(STAGE, face, face);
+  assert.deepEqual(
+    errandDrift(journey, errandBeats(TOKENS, ERRAND_WAIT.AT_ONCE), errandBound(STAGE, SURFACE)),
+    [],
+  );
+});
+
+test("tokens held still leave no flight to run", () => {
+  assert.equal(errandFlies(TOKENS), true);
+  // What a capture run zeroes, so every PNG lands on the same frame.
+  assert.equal(errandFlies({ ...TOKENS, shape: 0, quick: 0, exit: 0, expand: 0 }), false);
+  // What reduced motion collapses to. The three durations still sum past the
+  // stillness floor, which is exactly why the flight is decided on the shape
+  // token rather than on the total: someone who asked for no motion must not
+  // get a face crossing the panel in three milliseconds.
+  assert.equal(errandFlies({ ...TOKENS, shape: 1, quick: 1, exit: 1 }), false);
+});
+
+test("every setting is signed on the page it is actually drawn on", () => {
+  // A page that is not open is not rendered, so a flight to a control on the
+  // wrong page finds nothing and quietly goes nowhere. The page each setting
+  // lives on is stated twice — once as the page an errand opens, and once as
+  // the by-hand path the guide offers — and the two have to be the same
+  // answer, which a `Record` cannot enforce because one of them is a sentence.
+  for (const setting of buildLukeGuide(guideInput).settings) {
+    assert.ok(isAppSettingId(setting.id), `${setting.id} is one of Luke's own settings`);
+    const page = SETTING_PAGE[setting.id];
+    assert.ok(
+      setting.manual.includes(SETTINGS_PAGE_LABEL[page]),
+      `${setting.id} is opened on the ${page} page and the guide sends a hand to ${setting.manual}`,
+    );
+  }
+});


### PR DESCRIPTION
## What

When Luke changes a setting or the view himself — a `change_app_setting` or
`show_panel` tool call, spoken or typed into his composer — his face now leaves
the strip under the housing, dives to the very control that changed, taps it,
and floats back.

A setting and a view change two ways: a hand on the control, or Luke acting on
something asked of him. The control answered identically either way, and a
switch that flips with nobody near it reads as a glitch rather than as an
answer. So he does it in the open.

## How it behaves

**The change lands on the tap.** The change itself is made the moment it is
asked for, and the spoken answer reports what actually happened — what waits is
only the drawing of it. The switch flips, and the list narrows, on the frame he
presses the control. Before that it is stored and simply not drawn yet.

**A settings change shows its own work.** The panel comes forward on the
Settings tab so the switch is somewhere it can be seen moving, and stands back
down afterwards on the same terms a saved key does — unless the pointer has
arrived, or a key is half-typed, or an ask is half-written, in which case the
panel is yours now rather than the errand's. `show_panel` leaves the panel up,
because there the panel was the ask.

**There is only ever one Luke on screen.** The strip's face is held invisible
for exactly as long as the flight lasts. The flying mark sets off from that
face's own measured box, at its measured size, wearing the colour it is
wearing — blue while he is talking — and parks back on top of it before it
fades in underneath, so neither handover has a frame with two drawn or none. It
stands in for the face rather than being it because the face is remounted
whenever a gesture plays, and an animation on a node React is about to replace
would die mid-air.

Where he lands: a setting's own control, the tab a `show_panel` brought
forward, or the options button when a narrowing or re-ordering was named (the
tab stands behind it, since that button is only drawn beside a list with
something to choose between). Session and issue acts do not fly — opening a
session closes the panel, and issues have no surface in the panel at all.

## Motion

Every beat comes from the tokens in `base.css`, so a capture run and reduced
motion — both of which zero them — get no errand rather than an instant one.
The dive rides `--spring`; the tap overshoots on `--spring-fast` and is the only
emphatic moment; the way home is a gentle bow on a smoothstep, since by then
the point is made and all that is left is to get out of the way.

Nothing is drawn off the black: the run home is between two points already on
the surface, so only its sway can leave it, and the widest sway the shape will
hold is solved against the surface's own measured box rather than guessed at.
When the panel had to open, the flight trails the whole opening — shape, then
content — rather than crossing a surface still growing.

## Also

- Focus rings drawn with square corners around round controls: `.tab` took its
  roundness from the thumb behind it and declared none of its own, and
  `.link-button` had none. Same rule the errand's own ring follows — it takes
  its corners from the element it is measured on.
- The panel's tabs now alias the core's set the way the sort already did, which
  removes a duplicated vocabulary and the conversion it needed.
- `HIT_REGION` gains the attribute name its readers were spelling out.
- The guide learned about the errand, so Luke will not deny doing it.

## Verification

`./scripts/check.sh` passes — lint, typecheck, 537 desktop tests plus core and
harness, and the build. New pure tests cover the landing places, the flight's
beats, the drift's shape, and that it stays inside the shape at every corner of
the panel.

**`./scripts/verify.sh` was not run locally and no physical-notch check was
performed** — this branch was written in a Linux environment, and
`scripts/evidence.sh` requires macOS. The macOS job here is the first run of it;
its visual evidence wants inspecting before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/76cadb19-5410-4a8e-b045-54178e85f4b0)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31845841310/artifacts/9235879652) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31845841310)

- Commit: `f75bd84419d27044372f08b7a6b6ef36eeca7990`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
