### PR TITLE
docs(git): prefer rebase onto main over merge commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,13 @@ convenience; `./scripts/check.sh` and CI remain authoritative.
   (`feat`, `fix`, `docs`, `chore`, etc.).
 - For Linear work, use its suggested branch name when available and the ticket
   ID as the scope: `feat(LUKE-123): add Codex support`.
+- When a PR branch falls behind or conflicts with origin/main, run
+  `git rebase origin/main` and force-push (`git push --force-with-lease`); do
+  not create merge commits from main on the branch. Main squash-merges
+  through a merge queue, so merge commits never survive to main anyway, and a
+  branch left conflicting with main silently stops all `pull_request` CI runs
+  (GitHub cannot build the merge commit) — keeping branches rebased is what
+  keeps CI running.
 
 ## Panel motion
 


### PR DESCRIPTION
## Summary
- Document Dean's preference: rebase PR branches onto origin/main and force-push with `--force-with-lease` instead of merging main into the branch.
- Explain why: main squash-merges through a merge queue so merge commits never survive to main anyway, and a branch left conflicting with main silently stops all `pull_request` CI runs (GitHub can't build the merge commit) — rebasing is what keeps CI running.

## Test plan
- [x] `./scripts/check.sh` (docs-only change)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/33eb2a35-ab94-4061-a36a-a94fc3021d15)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31844461790/artifacts/9235425375) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31844461790)

- Commit: `dc25d126d568dab5277f816c4bbfb4887db33488`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
