### PR TITLE
fix(sessions): notice when a session's spawnable agents change

### DIFF
--- a/packages/sidecar-core/src/session-registry.ts
+++ b/packages/sidecar-core/src/session-registry.ts
@@ -6,6 +6,7 @@ import {
   normalizeSession,
   normalizeSessionIdentity,
   type ProviderSessionObservation,
+  type SessionControl,
   type SessionDetail,
   type SessionIdentity,
   type SessionProvider,
@@ -27,8 +28,44 @@ function copySession(session: NormalizedSession): NormalizedSession {
     provider: { ...session.provider },
     detail: { ...session.detail },
     controls: session.controls.map((control) => ({ ...control })),
+    spawnableAgents: [...session.spawnableAgents],
     attention: { ...session.attention },
   };
+}
+
+/**
+ * An equality function from a comparator per field. The `Record` is exhaustive
+ * over `T` on purpose: a new field does not compile until someone decides how
+ * it compares.
+ *
+ * Comparators are collected once at module load, then walked with the same
+ * short-circuit as the old `&&` chain, so `#commit` still does one field
+ * compare per key rather than serializing the session on every observation.
+ */
+function exhaustiveSame<T extends object>(
+  equality: Record<keyof T, (first: T, second: T) => boolean>,
+): (first: T, second: T) => boolean {
+  const comparators = Object.values(equality) as Array<(first: T, second: T) => boolean>;
+  return (first, second) => {
+    for (const compare of comparators) {
+      if (!compare(first, second)) return false;
+    }
+    return true;
+  };
+}
+
+function sameItems<T>(
+  first: readonly T[],
+  second: readonly T[],
+  same: (first: T, second: T) => boolean,
+): boolean {
+  return (
+    first.length === second.length &&
+    first.every((item, index) => {
+      const other = second[index];
+      return other !== undefined && same(item, other);
+    })
+  );
 }
 
 /**
@@ -37,53 +74,51 @@ function copySession(session: NormalizedSession): NormalizedSession {
  * session that moved from one file to the next is still working, and the row
  * has to follow it.
  */
-function sameDetail(first: SessionDetail, second: SessionDetail): boolean {
-  return (
-    first.activity === second.activity &&
-    first.repository === second.repository &&
-    first.branch === second.branch &&
-    first.model === second.model &&
-    first.error === second.error &&
-    first.link === second.link &&
-    first.change === second.change
-  );
-}
+const sameDetail = exhaustiveSame<SessionDetail>({
+  activity: (first, second) => first.activity === second.activity,
+  repository: (first, second) => first.repository === second.repository,
+  branch: (first, second) => first.branch === second.branch,
+  model: (first, second) => first.model === second.model,
+  error: (first, second) => first.error === second.error,
+  link: (first, second) => first.link === second.link,
+  change: (first, second) => first.change === second.change,
+});
 
-function sameControls(
-  first: readonly NormalizedSession["controls"][number][],
-  second: readonly NormalizedSession["controls"][number][],
-): boolean {
-  return (
-    first.length === second.length &&
-    first.every(
-      (control, index) =>
-        control.id === second[index]?.id &&
-        control.label === second[index]?.label &&
-        control.kind === second[index]?.kind &&
-        control.target === second[index]?.target,
-    )
-  );
-}
+const sameControl = exhaustiveSame<SessionControl>({
+  id: (first, second) => first.id === second.id,
+  label: (first, second) => first.label === second.label,
+  kind: (first, second) => first.kind === second.kind,
+  target: (first, second) => first.target === second.target,
+});
 
-function sameSession(first: NormalizedSession, second: NormalizedSession): boolean {
-  return (
-    first.providerId === second.providerId &&
-    first.providerSessionId === second.providerSessionId &&
-    first.provider.id === second.provider.id &&
-    first.provider.displayName === second.provider.displayName &&
-    first.title === second.title &&
-    first.status === second.status &&
-    first.observedAt === second.observedAt &&
-    first.location === second.location &&
-    first.summary === second.summary &&
-    first.canReceiveMessage === second.canReceiveMessage &&
-    sameDetail(first.detail, second.detail) &&
-    first.attention.disposition === second.attention.disposition &&
-    first.attention.decidedAt === second.attention.decidedAt &&
-    first.attention.summary === second.attention.summary &&
-    sameControls(first.controls, second.controls)
-  );
-}
+const sameProvider = exhaustiveSame<SessionProvider>({
+  id: (first, second) => first.id === second.id,
+  displayName: (first, second) => first.displayName === second.displayName,
+});
+
+const sameAttention = exhaustiveSame<AttentionDecision>({
+  disposition: (first, second) => first.disposition === second.disposition,
+  decidedAt: (first, second) => first.decidedAt === second.decidedAt,
+  summary: (first, second) => first.summary === second.summary,
+});
+
+const sameSession = exhaustiveSame<NormalizedSession>({
+  providerId: (first, second) => first.providerId === second.providerId,
+  providerSessionId: (first, second) => first.providerSessionId === second.providerSessionId,
+  provider: (first, second) => sameProvider(first.provider, second.provider),
+  title: (first, second) => first.title === second.title,
+  status: (first, second) => first.status === second.status,
+  observedAt: (first, second) => first.observedAt === second.observedAt,
+  location: (first, second) => first.location === second.location,
+  summary: (first, second) => first.summary === second.summary,
+  detail: (first, second) => sameDetail(first.detail, second.detail),
+  controls: (first, second) => sameItems(first.controls, second.controls, sameControl),
+  canReceiveMessage: (first, second) => first.canReceiveMessage === second.canReceiveMessage,
+  spawnableAgents: (first, second) =>
+    sameItems(first.spawnableAgents, second.spawnableAgents, Object.is),
+  spawnTarget: (first, second) => first.spawnTarget === second.spawnTarget,
+  attention: (first, second) => sameAttention(first.attention, second.attention),
+});
 
 function sameProviderSessions(
   first: ReadonlyMap<string, NormalizedSession>,

--- a/packages/sidecar-core/src/session-registry.ts
+++ b/packages/sidecar-core/src/session-registry.ts
@@ -10,6 +10,7 @@ import {
   type SessionDetail,
   type SessionIdentity,
   type SessionProvider,
+  type SessionWorkspace,
 } from "./session";
 
 export interface SessionRegistrySnapshot {
@@ -29,6 +30,7 @@ function copySession(session: NormalizedSession): NormalizedSession {
     detail: { ...session.detail },
     controls: session.controls.map((control) => ({ ...control })),
     spawnableAgents: [...session.spawnableAgents],
+    ...(session.workspace ? { workspace: { ...session.workspace } } : {}),
     attention: { ...session.attention },
   };
 }
@@ -68,6 +70,15 @@ function sameItems<T>(
   );
 }
 
+function sameOptional<T extends object>(
+  first: T | undefined,
+  second: T | undefined,
+  same: (first: T, second: T) => boolean,
+): boolean {
+  if (first === undefined || second === undefined) return first === second;
+  return same(first, second);
+}
+
 /**
  * Compares the observed context field by field. A detail that changed without
  * the status changing is exactly the case the registry exists to notice — a
@@ -102,6 +113,11 @@ const sameAttention = exhaustiveSame<AttentionDecision>({
   summary: (first, second) => first.summary === second.summary,
 });
 
+const sameWorkspace = exhaustiveSame<SessionWorkspace>({
+  providerWorkspaceId: (first, second) => first.providerWorkspaceId === second.providerWorkspaceId,
+  name: (first, second) => first.name === second.name,
+});
+
 const sameSession = exhaustiveSame<NormalizedSession>({
   providerId: (first, second) => first.providerId === second.providerId,
   providerSessionId: (first, second) => first.providerSessionId === second.providerSessionId,
@@ -117,6 +133,7 @@ const sameSession = exhaustiveSame<NormalizedSession>({
   spawnableAgents: (first, second) =>
     sameItems(first.spawnableAgents, second.spawnableAgents, Object.is),
   spawnTarget: (first, second) => first.spawnTarget === second.spawnTarget,
+  workspace: (first, second) => sameOptional(first.workspace, second.workspace, sameWorkspace),
   attention: (first, second) => sameAttention(first.attention, second.attention),
 });
 

--- a/packages/sidecar-core/tests/session-registry.test.ts
+++ b/packages/sidecar-core/tests/session-registry.test.ts
@@ -79,6 +79,27 @@ test("a session takes messages only when its adapter said so explicitly", () => 
   assert.notEqual(registry.revision, before);
 });
 
+test("a change in the agents a session can start is a revision the surface hears", () => {
+  const registry = new InMemorySessionRegistry();
+  const identity = { providerId: codex.id, providerSessionId: "run:spawn" };
+  const revisions: number[] = [];
+  registry.subscribe((snapshot) => {
+    revisions.push(snapshot.revision);
+  });
+
+  registry.upsert(codex, observation("run:spawn", 100));
+  assert.deepEqual(registry.get(identity)?.spawnableAgents, []);
+
+  // The roster flipping is a change the registry must notice on its own: the
+  // agents a row offers to start appear and disappear with it while nothing
+  // else moves.
+  const before = registry.revision;
+  registry.upsert(codex, observation("run:spawn", 100, { spawnableAgents: ["claude", "cursor"] }));
+  assert.deepEqual(registry.get(identity)?.spawnableAgents, ["claude", "cursor"]);
+  assert.equal(registry.revision, before + 1);
+  assert.deepEqual(revisions, [before, before + 1]);
+});
+
 test("keeps only the addresses Luke would open, and never a shortened one", () => {
   const registry = new InMemorySessionRegistry();
   const linkFor = (link: string) =>

--- a/packages/sidecar-core/tests/session-registry.test.ts
+++ b/packages/sidecar-core/tests/session-registry.test.ts
@@ -86,6 +86,17 @@ test("a workspace grouping is bounded, and one without an id is dropped whole", 
 
   const ungrouped = registry.upsert(codex, observation("run:ungrouped", 100));
   assert.equal(ungrouped.workspace, undefined);
+
+  // Grouping a session that was ungrouped is a change the registry must
+  // notice on its own: the tray appears while nothing else moves.
+  const before = registry.revision;
+  registry.upsert(
+    codex,
+    observation("run:ungrouped", 100, {
+      workspace: { providerWorkspaceId: "workspace-1", name: "lisbon-v2" },
+    }),
+  );
+  assert.notEqual(registry.revision, before);
 });
 
 test("a session takes messages only when its adapter said so explicitly", () => {


### PR DESCRIPTION
## Summary

- The registry compared sessions field by field but skipped `spawnableAgents` and `spawnTarget`, so a roster-only observation never bumped revision or notified listeners.
- Those fields are compared now, and equality is a compile-enforced `Record` per key so a new session field fails the build until someone decides how it compares.

## Evidence

- Platform-independent checks: `not run` (sidecar-core `npm test` and `tsc` passed)
- macOS Electron verification (`./scripts/verify.sh`): `not run`

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31848164031/artifacts/9236633014) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31848164031)

- Commit: `b51dfa0fd422e55f71dd54402052d018d3796e07`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: None


Made with [Cursor](https://cursor.com)