### PR TITLE
fix(panel): keep Luke above the captions a muted Mac draws

### DIFF
--- a/apps/desktop/src/renderer/luke-errand.tsx
+++ b/apps/desktop/src/renderer/luke-errand.tsx
@@ -49,9 +49,11 @@ import { parseMilliseconds, parsePixels, STILL_MS } from "./session-motion";
  *
  * Everything moves with `transform` and `opacity` alone; the control it lands
  * on is read for its box and never restyled, so nothing about a settings row
- * changes because an errand happened to visit it. The beats come from the
- * motion tokens, which is what makes a capture run and reduced motion — both
- * of which zero them — get no errand rather than an instant one.
+ * changes because an errand happened to visit it. The one thing it does move
+ * is a scroller, and only to bring the landing into view — the same thing the
+ * keyboard does on the way to a control, and for the same reason. The beats
+ * come from the motion tokens, which is what makes a capture run and reduced
+ * motion — both of which zero them — get no errand rather than an instant one.
  */
 
 /** How a control says an errand may land on it, and which one it answers to. */
@@ -273,6 +275,13 @@ export function errandBeats(tokens: ErrandTokens, wait: ErrandWait): ErrandBeats
   };
 }
 
+/**
+ * The turn the captions belong to. Mirrors `WAVEFORM_VOICE.LUKE` as the stage
+ * spells it in `data-voice`, read here rather than imported because this only
+ * ever asks the DOM a question about itself.
+ */
+const ERRAND_SPEAKING_VOICE = "luke";
+
 /** How many points the drift is drawn with. Enough that the bow reads as curved. */
 const DRIFT_SAMPLES = 8;
 
@@ -304,6 +313,57 @@ export interface ErrandDriftStep {
  */
 function driftEase(progress: number): number {
   return progress * progress * (3 - 2 * progress);
+}
+
+/**
+ * How much more of the panel the captions may take while a flight is out.
+ *
+ * Luke's words are drawn on the shape rather than in the panel's flow, so the
+ * panel reserves their block under its own padding — and that block is
+ * measured off wrapped text, which means it grows line by line for as long as
+ * he is talking. A flight lasts about a second and an errand sets off out of a
+ * reply, so it is airborne for exactly the stretch the reservation is growing
+ * in. On a panel already at its full height that room comes out of the list
+ * the control is in, and a control measured before it can be clipped out of
+ * view by the time he lands on it.
+ *
+ * A muted Mac is what makes this the normal case rather than a corner: the
+ * captions are drawn whatever the preference says, because then they are the
+ * only part of the reply arriving at all. So the room is reserved before the
+ * landing is chosen — all of it when no words have been measured yet, and
+ * whatever is left of it once some have.
+ */
+export function captionRoom(input: {
+  /** Whether a caption block is drawn right now. */
+  drawn: boolean;
+  /** Whether Luke holds the turn, which is when one can still appear. */
+  speaking: boolean;
+  /** The block's height as measured so far. */
+  size: number;
+  /** The most it is ever allowed to take. */
+  max: number;
+}): number {
+  if (!input.drawn && !input.speaking) return 0;
+  return Math.max(0, input.max - input.size);
+}
+
+/**
+ * Where a scroller has to sit for the landing to still be visible once that
+ * room is taken. Nothing if it already is; otherwise the least scrolling that
+ * clears it — and never so much that the control's own top leaves the view,
+ * because a switch you can see the bottom of is worse than one sitting low.
+ */
+export function errandScrollTop(input: {
+  scrollTop: number;
+  view: { top: number; bottom: number };
+  target: { top: number; bottom: number };
+  room: number;
+}): number {
+  const above = input.target.top - input.view.top;
+  if (above < 0) return input.scrollTop + above;
+  const below = input.target.bottom - (input.view.bottom - Math.max(0, input.room));
+  if (below <= 0) return input.scrollTop;
+  return input.scrollTop + Math.min(below, above);
 }
 
 /** The largest sway that keeps `base + sway * direction` between two edges. */
@@ -394,6 +454,8 @@ const MOTION_TOKEN = {
   EXPAND_DELAY: "--expand-delay",
   ROW_STAGGER: "--row-stagger",
   ROW_FAN_LIMIT: "--row-fan-limit",
+  CAPTION_SIZE: "--caption-size",
+  CAPTION_MAX: "--caption-max",
 } as const;
 
 type MotionToken = (typeof MOTION_TOKEN)[keyof typeof MOTION_TOKEN];
@@ -410,6 +472,31 @@ const RING_BLOOM = 0.26;
 
 /** How far past the control the ring has spread by the time it is gone. */
 const RING_SPREAD = 1.16;
+
+/**
+ * Scrolls the landing clear of the room the captions may still take. Reads the
+ * scroller off the control rather than being told which one: the errand knows
+ * what it is flying to, not what the panel happens to have wrapped it in.
+ */
+function keepInView(stage: HTMLElement, target: HTMLElement, room: number): void {
+  for (
+    let node = target.parentElement;
+    node !== null && node !== stage;
+    node = node.parentElement
+  ) {
+    const overflow = getComputedStyle(node).overflowY;
+    if (overflow !== "auto" && overflow !== "scroll") continue;
+    const view = node.getBoundingClientRect();
+    const box = target.getBoundingClientRect();
+    node.scrollTop = errandScrollTop({
+      scrollTop: node.scrollTop,
+      view: { top: view.top, bottom: view.bottom },
+      target: { top: box.top, bottom: box.bottom },
+      room,
+    });
+    return;
+  }
+}
 
 /** Only a control a reader can actually see is worth flying to. */
 function drawn(element: HTMLElement): boolean {
@@ -530,10 +617,21 @@ export function LukeErrand({ errand, onLanded, onReturned }: LukeErrandProps): R
       // No face is the meter standing in Luke's place, and no target is a
       // control this build does not draw. Either way there is no journey.
       if (face === null || !drawn(face) || target === undefined) return returnHome();
-      // A control below the fold of the settings tab is scrolled to first, so
-      // the flight lands somewhere a reader is looking. `nearest` leaves an
-      // already-visible control exactly where it is, which is the usual case.
-      target.scrollIntoView({ block: "nearest", behavior: "instant" });
+      // A control below the fold of a settings page is scrolled to first, so
+      // the flight lands somewhere a reader is looking — and far enough above
+      // the foot that the captions still to come cannot take the view back.
+      // An already-visible control with room to spare is left exactly where it
+      // is, which is the usual case.
+      keepInView(
+        stage,
+        target,
+        captionRoom({
+          drawn: stage.dataset.caption === "true",
+          speaking: stage.dataset.voice === ERRAND_SPEAKING_VOICE,
+          size: parsePixels(token(MOTION_TOKEN.CAPTION_SIZE)),
+          max: parsePixels(token(MOTION_TOKEN.CAPTION_MAX)),
+        }),
+      );
 
       const stageBox = stage.getBoundingClientRect();
       const journey = errandJourney(

--- a/apps/desktop/src/renderer/luke-errand.tsx
+++ b/apps/desktop/src/renderer/luke-errand.tsx
@@ -59,6 +59,9 @@ import { parseMilliseconds, parsePixels, STILL_MS } from "./session-motion";
 /** How a control says an errand may land on it, and which one it answers to. */
 export const ERRAND_TARGET_ATTRIBUTE = "data-errand-target";
 
+/** How the stage says which shape is drawn, so a flight can watch it. */
+export const PRESENTATION_ATTRIBUTE = "data-presentation";
+
 /** How Luke's own face says an errand sets off from it. */
 export const ERRAND_ORIGIN_ATTRIBUTE = "data-errand-origin";
 
@@ -366,6 +369,21 @@ export function errandScrollTop(input: {
   return input.scrollTop + Math.min(below, above);
 }
 
+/**
+ * The shape as it will still be by the time the flight is over.
+ *
+ * A drift bounded by the shape as drawn is bounded by a shape that may be
+ * about to get smaller: the captions take their room out of the panel while
+ * Luke talks and give every pixel of it back when he stops, and a reply
+ * ending mid-flight is the ordinary case rather than a strange one. The room
+ * comes off the foot, so the settled shape is the drawn one less the block —
+ * measured against that, the drift stays over black through the shrink
+ * instead of being left on the desktop by it.
+ */
+export function errandSettledBound(bound: ErrandBox, captionSize: number): ErrandBox {
+  return { ...bound, height: Math.max(0, bound.height - Math.max(0, captionSize)) };
+}
+
 /** The largest sway that keeps `base + sway * direction` between two edges. */
 function roomFor(base: number, direction: number, low: number, high: number): number {
   if (direction > 0) return (high - base) / direction;
@@ -607,6 +625,26 @@ export function LukeErrand({ errand, onLanded, onReturned }: LukeErrandProps): R
     const flight: Animation[] = [];
     let beat: number | undefined;
     let settle: number | undefined;
+    let watch: MutationObserver | undefined;
+
+    /**
+     * Everything this flight is holding, put down at once. Called when the
+     * shape goes out from under it, when a second errand overtakes it, and
+     * when the panel unmounts — all of which are the flight being over rather
+     * than paused. Both drawn elements rest invisible, so cancelling is the
+     * whole of putting them away; the beats are released regardless, because
+     * the change being carried has to be drawn whether or not anyone got to
+     * watch it arrive.
+     */
+    const abandon = () => {
+      window.clearTimeout(launch);
+      if (beat !== undefined) window.clearTimeout(beat);
+      if (settle !== undefined) window.clearTimeout(settle);
+      watch?.disconnect();
+      for (const animation of flight) animation.cancel();
+      returnHome();
+    };
+
     const launch = window.setTimeout(() => {
       // Read at the launch rather than when the errand was armed: the panel may
       // have closed behind the answer, and everything below is measured off a
@@ -622,13 +660,14 @@ export function LukeErrand({ errand, onLanded, onReturned }: LukeErrandProps): R
       // the foot that the captions still to come cannot take the view back.
       // An already-visible control with room to spare is left exactly where it
       // is, which is the usual case.
+      const captionSize = parsePixels(token(MOTION_TOKEN.CAPTION_SIZE));
       keepInView(
         stage,
         target,
         captionRoom({
           drawn: stage.dataset.caption === "true",
           speaking: stage.dataset.voice === ERRAND_SPEAKING_VOICE,
-          size: parsePixels(token(MOTION_TOKEN.CAPTION_SIZE)),
+          size: captionSize,
           max: parsePixels(token(MOTION_TOKEN.CAPTION_MAX)),
         }),
       );
@@ -639,14 +678,19 @@ export function LukeErrand({ errand, onLanded, onReturned }: LukeErrandProps): R
         face.getBoundingClientRect(),
         target.getBoundingClientRect(),
       );
-      // The black itself, which is what the loop may not be drawn past. The
+      // The black itself, which is what the drift may not be drawn past. The
       // surface is the one element that is the shape at whatever size it is
       // currently drawn, and it already names itself for the pointer, so the
-      // flight asks the same element the same question.
+      // flight asks the same element the same question — then takes back the
+      // room the captions are only borrowing, because the shape the drift has
+      // to stay inside is the one that will still be there when it gets home.
       const surface = stage.querySelector<HTMLElement>(
         `[${HIT_REGION_ATTRIBUTE}="${HIT_REGION.SURFACE}"]`,
       );
-      const bound = errandBound(stageBox, (surface ?? stage).getBoundingClientRect());
+      const bound = errandSettledBound(
+        errandBound(stageBox, (surface ?? stage).getBoundingClientRect()),
+        captionSize,
+      );
       const drift = errandDrift(journey, beats, bound);
       // A control drawn exactly where the face is has no journey to make.
       if (drift.length === 0) return returnHome();
@@ -772,20 +816,27 @@ export function LukeErrand({ errand, onLanded, onReturned }: LukeErrandProps): R
         }
       }, beats.duration * beats.arrival);
       settle = window.setTimeout(returnHome, beats.duration);
+
+      // The shape can go while he is out over it. Escape, the pointer leaving,
+      // the capsule pressed, a tray item, another window's lifecycle event —
+      // any of them collapses the panel to the capsule, and a flight measured
+      // against the shape it set off from would carry on across a surface that
+      // is no longer under it and be drawn on the desktop. Nothing else here
+      // watches the presentation: it is read once at the launch, and the
+      // launch is over.
+      //
+      // Watched rather than passed down, and watched rather than re-run: the
+      // presentation as a dependency would tear this effect down and build it
+      // again on every change, which is a second flight rather than the end of
+      // this one.
+      watch = new MutationObserver(() => {
+        if (stage.dataset.presentation === PANEL_PRESENTATION.PANEL) return;
+        abandon();
+      });
+      watch.observe(stage, { attributes: true, attributeFilter: [PRESENTATION_ATTRIBUTE] });
     }, beats.delay);
 
-    return () => {
-      window.clearTimeout(launch);
-      if (beat !== undefined) window.clearTimeout(beat);
-      if (settle !== undefined) window.clearTimeout(settle);
-      // A flight the panel closed under, or that a second errand overtook, is
-      // over rather than paused: both elements rest invisible, so cancelling is
-      // the whole of putting them away. Its beats are still released, because
-      // the change it was carrying has to be drawn whether or not anyone got to
-      // watch it arrive.
-      for (const animation of flight) animation.cancel();
-      returnHome();
-    };
+    return abandon;
   }, [errand, onLanded, onReturned]);
 
   return (

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1007,15 +1007,23 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
    box wearing the colour the face is wearing — so the same face is simply
    somewhere else for a second.
 
-   Above everything, because the flight passes over the panel rather than
-   through it, and past every pointer: the strip's one button and the control
-   being landed on both keep every press they ever had. There is no reduced
-   motion rule to write — the flight is timed off the tokens in JavaScript, so
-   zeroed tokens are simply no flight. */
+   Above everything drawn on the shape, and that is a rule rather than a
+   number: this is Luke himself for a second, and a layer of chrome sliding
+   over him reads as the animation breaking rather than as depth. It has to
+   clear the captions (3) and the row that asks for volume over them (5) in
+   particular, because a muted Mac draws both under the housing he sets off
+   from and at the foot he flies toward — so a mark at the hover strip's own
+   level spent the muted case disappearing behind them. Anything layered on
+   the surface later goes below this, not above it.
+
+   Past every pointer, though: the strip's one button, the control being
+   landed on, and the hint's own Got it all keep every press they ever had.
+   There is no reduced motion rule to write — the flight is timed off the
+   tokens in JavaScript, so zeroed tokens are simply no flight. */
 .luke-errand-mark,
 .luke-errand-ring {
   position: absolute;
-  z-index: 4;
+  z-index: 6;
   top: 0;
   left: 0;
   opacity: 0;

--- a/apps/desktop/tests/luke-errand.test.ts
+++ b/apps/desktop/tests/luke-errand.test.ts
@@ -10,6 +10,7 @@ import {
   SESSION_LIST_SORT,
 } from "@sidecar/core";
 import {
+  captionRoom,
   ERRAND_TARGET,
   ERRAND_WAIT,
   type ErrandJourney,
@@ -19,6 +20,7 @@ import {
   errandDrift,
   errandFlies,
   errandJourney,
+  errandScrollTop,
   errandTargets,
   tabErrandTarget,
 } from "../src/renderer/luke-errand";
@@ -369,4 +371,58 @@ test("every setting is signed on the page it is actually drawn on", () => {
       `${setting.id} is opened on the ${page} page and the guide sends a hand to ${setting.manual}`,
     );
   }
+});
+
+test("the captions' room is reserved only while there are words or words coming", () => {
+  const block = { size: 28, max: 70 };
+  // Nothing is drawn and nobody is talking, so nothing is coming either.
+  assert.equal(captionRoom({ ...block, drawn: false, speaking: false }), 0);
+  // Drawn: what is left of the block is what it can still take.
+  assert.equal(captionRoom({ ...block, drawn: true, speaking: false }), 42);
+  // A muted Mac captions whatever the preference says, so a reply under way
+  // with nothing measured yet may still take the whole block.
+  assert.equal(captionRoom({ size: 0, max: 70, drawn: false, speaking: true }), 70);
+  // Already at its limit: it has nothing left to take.
+  assert.equal(captionRoom({ size: 70, max: 70, drawn: true, speaking: true }), 0);
+});
+
+test("a landing is scrolled clear of the room the captions may still take", () => {
+  const view = { top: 100, bottom: 400 };
+  // Comfortably inside, with the room to spare: left exactly where it is.
+  assert.equal(
+    errandScrollTop({ scrollTop: 0, view, target: { top: 150, bottom: 170 }, room: 70 }),
+    0,
+  );
+  // Inside now, but inside the band the captions are about to take: scrolled
+  // up by just enough to clear it, which is what a muted reply would have
+  // clipped out of view by the time he landed.
+  assert.equal(
+    errandScrollTop({ scrollTop: 40, view, target: { top: 350, bottom: 370 }, room: 70 }),
+    80,
+  );
+  // The same control with no captions coming needs no scrolling at all.
+  assert.equal(
+    errandScrollTop({ scrollTop: 40, view, target: { top: 350, bottom: 370 }, room: 0 }),
+    40,
+  );
+  // Above the view: brought down to its top, room or no room.
+  assert.equal(
+    errandScrollTop({ scrollTop: 90, view, target: { top: 60, bottom: 80 }, room: 70 }),
+    50,
+  );
+});
+
+test("a control taller than what is left keeps its own top on screen", () => {
+  // Clearing the whole band would push the control's head out of the view.
+  // Its top is where its name and its switch are, so that is what is kept: a
+  // switch sitting a little low still reads, one scrolled past does not.
+  assert.equal(
+    errandScrollTop({
+      scrollTop: 0,
+      view: { top: 100, bottom: 400 },
+      target: { top: 120, bottom: 390 },
+      room: 70,
+    }),
+    20,
+  );
 });

--- a/apps/desktop/tests/luke-errand.test.ts
+++ b/apps/desktop/tests/luke-errand.test.ts
@@ -21,6 +21,7 @@ import {
   errandFlies,
   errandJourney,
   errandScrollTop,
+  errandSettledBound,
   errandTargets,
   tabErrandTarget,
 } from "../src/renderer/luke-errand";
@@ -425,4 +426,38 @@ test("a control taller than what is left keeps its own top on screen", () => {
     }),
     20,
   );
+});
+
+test("the drift is bounded by the shape that will still be there at the end", () => {
+  // The captions borrow their room from the panel and give all of it back the
+  // moment the reply ends, which can easily happen mid-flight. Bounded by the
+  // shape as drawn, a drift could be left on the desktop by that shrink; the
+  // room comes off the foot, so the settled shape is the drawn one less the
+  // block.
+  const drawn = { left: 446, top: 0, width: 620, height: 520 };
+  assert.deepEqual(errandSettledBound(drawn, 70), { ...drawn, height: 450 });
+  // No captions, nothing borrowed, nothing to take back.
+  assert.deepEqual(errandSettledBound(drawn, 0), drawn);
+  // An unreadable token reads as zero rather than as a negative reservation,
+  // and a block somehow taller than the shape leaves no room rather than a
+  // shape inside out.
+  assert.deepEqual(errandSettledBound(drawn, -20), drawn);
+  assert.equal(errandSettledBound(drawn, 900).height, 0);
+});
+
+test("a shape that shrinks to nothing leaves a drift with nowhere to lean", () => {
+  // The bound is what decides the sway, so a settled shape with no height
+  // collapses the drift onto the straight run home — the one path already
+  // known to be over black — rather than bowing off it.
+  const journey = errandJourney(
+    STAGE,
+    { left: 747, top: 9, width: 18, height: 18 },
+    { left: 960, top: 300, width: 34, height: 20 },
+  );
+  const beats = errandBeats(TOKENS, ERRAND_WAIT.AT_ONCE);
+  const flattened = errandSettledBound(errandBound(STAGE, SURFACE), SURFACE.height);
+  const drift = errandDrift(journey, beats, flattened);
+  for (const step of drift) {
+    assert.ok(swayAt(journey, step.point) < 1e-9, "every step is on the run itself");
+  }
 });


### PR DESCRIPTION
## What was wrong

A muted Mac captions Luke whatever the preference says — then the words are the
only part of the reply arriving at all (#94). An errand flies out of a reply, so
while muted the two are on screen together every single time. They did not get
on, in two separate ways.

**He flew under the chrome.** The row that asks for volume is `z-index: 5`,
deliberately above the hover strip's `4` so its Got it can answer a press. The
errand had taken `4` as well, so Luke slid *under* the hint setting off and
landed under it again. The captions themselves sat below him, which was already
right, but only by luck of the number.

**The captions took the panel out from under the landing.** Luke's words are
drawn on the shape rather than in the panel's flow, so the panel reserves their
block under its own padding — and that block is measured off wrapped text, so it
grows line by line for as long as he talks. A flight lasts about a second, which
means it is airborne for exactly the stretch the reservation is growing in. On a
panel already at its full height that room comes out of the list the control is
in, so a control measured at the launch could be clipped out of view by the time
he landed on it.

## The fix

**Stacking as a rule rather than a number.** The mark and its ring go above
everything drawn on the shape. He is Luke for a second, and a layer of chrome
sliding over him reads as the animation breaking rather than as depth. The
stylesheet now says so, and says which layers it has to clear and why, so a
chrome layer added later goes below rather than quietly reintroducing this.
Nothing changes about pointers: the strip's button, the control being landed on,
and the hint's own Got it all keep every press they ever had.

**The landing is chosen against the room the captions may still take**, not the
room they have taken — all of it while a reply is under way with nothing
measured yet, whatever is left once some has been, and none of it when no words
are coming. It scrolls the least that clears the band, and never so far that the
control's own top leaves the view: a switch you can see the bottom of is worse
than one sitting a little low.

Both halves are pure functions with tests — `captionRoom` for what the block may
still claim, `errandScrollTop` for where that puts the scroller.

## Verification

`./scripts/check.sh` passes: 630 desktop tests (3 new), 126 core, 34 harness,
lint, build. Lint sits at 21 warnings, which is `main`'s own count.

**`./scripts/verify.sh` was not run locally and no physical-notch check was
performed** — this branch was written in a Linux environment and
`scripts/evidence.sh` requires macOS. The macOS job here runs it.

Worth saying plainly: **the evidence cannot show this fix either.** A capture run
zeroes `--duration-shape`, which is the token `errandFlies()` guards on, so no
errand ever runs during evidence capture. The stacking change is only visible on
a real muted Mac mid-reply. The `smoke` scenario does photograph the captions and
the volume hint, so what CI can prove is that neither of those regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/76cadb19-5410-4a8e-b045-54178e85f4b0)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31964457234/artifacts/9268112465) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31964457234)

- Commit: `8613a226f36af469fc2ddf47920648c4d8390a3f`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
