### PR TITLE
refactor(desktop): extract App state clusters into hooks

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -82,6 +82,7 @@ import {
 } from "./session-model";
 import { SESSION_OPTIONS_BUTTON_ID, SESSION_OPTIONS_ID } from "./session-parts";
 import { SETTING_PAGE, SETTINGS_VIEW, type SettingsView } from "./settings-views";
+import { panelEntryOpen, usePanelEntry } from "./use-panel-entry";
 import { useVoiceConversation } from "./use-voice-conversation";
 import {
   outputSilent,
@@ -272,8 +273,6 @@ export function App(): React.JSX.Element {
   const [optionsOpen, setOptionsOpen] = useState(false);
   const [settings, setSettings] = useState<AppSettings>();
   const [errand, setErrand] = useState<Errand>();
-  const [entry, setEntry] = useState<CredentialEntry>();
-  const [feedback, setFeedback] = useState<FeedbackEntry>();
   const [feedbackNotice, setFeedbackNotice] = useState<string>();
   // Counts for nothing except having changed: each tick re-renders the rows so
   // their "how long ago" labels stay honest while they are on screen.
@@ -316,7 +315,13 @@ export function App(): React.JSX.Element {
   const hoverTimer = useRef<number | undefined>(undefined);
   const presentationRef = useRef<PanelPresentation>(PANEL_PRESENTATION.CAPSULE);
   const tabRef = useRef<PanelTab>(PANEL_TAB.SESSIONS);
-  const entryRef = useRef<CredentialEntry | undefined>(undefined);
+  /**
+   * Whether a composer is held, mirrored for the presentation cluster: a
+   * capsule close keeps the settings tab for a half-written key or note, and
+   * the pointer holds the panel open for a credential still on screen.
+   */
+  const credentialHeld = useRef(false);
+  const feedbackHeld = useRef(false);
   /**
    * Whether the caret is in the ask field. It holds the panel open against the
    * pointer the way a credential entry does, and for the same reason: the
@@ -324,7 +329,6 @@ export function App(): React.JSX.Element {
    * middle of typing.
    */
   const askEngaged = useRef(false);
-  const feedbackRef = useRef<FeedbackEntry | undefined>(undefined);
   const feedbackNoticeTimer = useRef<number | undefined>(undefined);
   /**
    * The words a spoken open asked to start the note with, waiting for the
@@ -459,7 +463,7 @@ export function App(): React.JSX.Element {
       // it resets either way.
       if (next === PANEL_PRESENTATION.CAPSULE) {
         setSessionView(DEFAULT_SESSION_VIEW);
-        if (entryRef.current === undefined && feedbackRef.current === undefined) {
+        if (!credentialHeld.current && !feedbackHeld.current) {
           changeTab(PANEL_TAB.SESSIONS);
         }
       }
@@ -554,7 +558,7 @@ export function App(): React.JSX.Element {
    * showing nothing but sessions.
    */
   const entryIsDrawn = useCallback(
-    () => entryRef.current !== undefined && tabRef.current === PANEL_TAB.SETTINGS,
+    () => credentialHeld.current && tabRef.current === PANEL_TAB.SETTINGS,
     [],
   );
 
@@ -606,23 +610,6 @@ export function App(): React.JSX.Element {
   );
 
   /**
-   * The single place an entry changes. A key being entered holds the panel open
-   * against the pointer, so ending one has to release that hold: an entry that
-   * ends while the pointer is already away — Escape out of the field, say —
-   * would otherwise leave the panel held open by nothing, because the pointer
-   * cannot leave a second time.
-   */
-  const applyEntry = useCallback(
-    (next: CredentialEntry | undefined) => {
-      const released = entryRef.current !== undefined && next === undefined;
-      entryRef.current = next;
-      setEntry(next);
-      if (released && !pointerInside.current) handleHitRegionLeave();
-    },
-    [handleHitRegionLeave],
-  );
-
-  /**
    * Brings the panel back around the line the entry belongs to, and leaves it
    * open the way every other way of opening it does — the pointer closes it by
    * visiting and leaving.
@@ -637,6 +624,17 @@ export function App(): React.JSX.Element {
     void changeMode(true);
   }, [changeMode, changeTab]);
 
+  const settlePanel = useCallback(() => {
+    hoverTimer.current = window.setTimeout(() => {
+      hoverTimer.current = undefined;
+      if (presentationRef.current === PANEL_PRESENTATION.PANEL) void changeMode(false);
+    }, SETTLE_DELAY_MS);
+  }, [changeMode]);
+
+  const leavePanel = useCallback(() => {
+    void changeMode(false);
+  }, [changeMode]);
+
   /**
    * Asking to write a key is asking for one thing, so the panel gets out of the
    * way of it: the shape goes down to the slot, which is the field and nothing
@@ -644,27 +642,31 @@ export function App(): React.JSX.Element {
    * stored key being replaced, or one standing in front of the environment's —
    * because they are all the same act.
    */
+  const credentialsEntry = usePanelEntry<CredentialEntry>({
+    aside: PANEL_PRESENTATION.SLOT,
+    restoresPanel: (held) => held.away !== true,
+    isSendable: isSubmittable,
+    send: async (sending) => {
+      const result = await window.sidecar.setProviderApiKey(sending.providerId, sending.draft);
+      setSettings(result.settings);
+      return result.reason ? { rejection: result.reason } : {};
+    },
+    pointerInside: () => pointerInside.current,
+    presentation: () => presentationRef.current,
+    onReleasedWhileAway: handleHitRegionLeave,
+    cancelHover: cancelHoverTransition,
+    applyPresentation,
+    restorePanel,
+    leave: leavePanel,
+    settle: settlePanel,
+    heldRef: credentialHeld,
+  });
+
   const beginEntry = useCallback(
     (providerId: CredentialProviderId) => {
-      applyEntry({ providerId, draft: "", busy: false, away: false });
-      cancelHoverTransition();
-      applyPresentation(PANEL_PRESENTATION.SLOT);
+      credentialsEntry.begin({ providerId, draft: "", busy: false, away: false });
     },
-    [applyEntry, applyPresentation, cancelHoverTransition],
-  );
-
-  const changeEntry = useCallback(
-    (draft: string) => {
-      const current = entryRef.current;
-      // A key being written is not a moment to change the entry: the reply on
-      // its way back is answering the entry that was sent, and it is recognised
-      // by being that same entry. Nothing may replace it underneath but ending
-      // it outright, which is a decision to stop listening for the reply.
-      if (!current || current.busy) return;
-      // Typing again answers the refusal, so the refusal goes.
-      applyEntry({ ...current, draft, rejection: undefined });
-    },
-    [applyEntry],
+    [credentialsEntry.begin],
   );
 
   /**
@@ -675,66 +677,17 @@ export function App(): React.JSX.Element {
    * panel is only stood down if the link was pressed from inside it.
    */
   const fetchKey = useCallback(() => {
-    const current = entryRef.current;
+    const current = credentialsEntry.latest();
     // Same rule as typing: the key on its way to the store is what the entry is
     // for, and going to fetch another one is not a reason to disturb it. Both
     // views disable the link while it is in flight, so this is the floor rather
     // than the answer.
-    if (!current || current.busy) return;
+    if (!panelEntryOpen(current)) return;
     window.sidecar.openProviderApiKeys(current.providerId);
-    applyEntry({ ...current, away: true });
+    credentialsEntry.apply({ ...current, away: true });
     if (presentationRef.current === PANEL_PRESENTATION.SLOT) return;
-    cancelHoverTransition();
-    applyPresentation(PANEL_PRESENTATION.SLOT);
-  }, [applyEntry, applyPresentation, cancelHoverTransition]);
-
-  const cancelEntry = useCallback(() => {
-    const away = entryRef.current?.away === true;
-    const aside = presentationRef.current === PANEL_PRESENTATION.SLOT;
-    applyEntry(undefined);
-    if (!aside) return;
-    // Giving up returns you where you were. If the key page was opened, that is
-    // the browser, and Luke leaves; if it was not, it is the panel this entry
-    // was started from.
-    if (away) void changeMode(false);
-    else restorePanel();
-  }, [applyEntry, changeMode, restorePanel]);
-
-  const commitEntry = useCallback(() => {
-    const current = entryRef.current;
-    if (!isSubmittable(current)) return;
-    const sending = { ...current, busy: true, rejection: undefined };
-    applyEntry(sending);
-    void window.sidecar.setProviderApiKey(current.providerId, current.draft).then((result) => {
-      // The store changed either way, so the sources are always taken.
-      setSettings(result.settings);
-      // Whoever is entering a key now is not necessarily whoever sent this one:
-      // Escape reaches the slot while a save is in flight, and so does another
-      // provider's Connect. A reply that outlived its own entry is spent.
-      if (entryRef.current !== sending) return;
-      if (result.reason) {
-        applyEntry({ ...sending, busy: false, rejection: result.reason });
-        return;
-      }
-      applyEntry(undefined);
-      // Saved from the slot: the whole panel comes back around the provider
-      // that is now connected, because the check appearing beside its name is
-      // the answer to what was just done.
-      if (presentationRef.current !== PANEL_PRESENTATION.SLOT) return;
-      restorePanel();
-      // An answer is worth reading and then done with. The pointer is usually
-      // still on the button that was pressed, and where it is not — the key was
-      // sent from the keyboard, or the shape shrank out from under it — nothing
-      // else would ever ask this panel to close, so it shows the answer and then
-      // takes its leave. Nothing else restores the panel this way: giving up has
-      // no answer to show.
-      if (pointerInside.current) return;
-      hoverTimer.current = window.setTimeout(() => {
-        hoverTimer.current = undefined;
-        if (presentationRef.current === PANEL_PRESENTATION.PANEL) void changeMode(false);
-      }, SETTLE_DELAY_MS);
-    });
-  }, [applyEntry, changeMode, restorePanel]);
+    credentialsEntry.standDown();
+  }, [credentialsEntry.apply, credentialsEntry.latest, credentialsEntry.standDown]);
 
   const removeProviderApiKey = useCallback(
     async (providerId: CredentialProviderId) => {
@@ -743,11 +696,23 @@ export function App(): React.JSX.Element {
       // Delete and the field are on the row together once the panel has been
       // brought back around an entry, and a key that has been removed cannot be
       // replaced.
-      if (removalEndsEntry(entryRef.current, providerId, result.reason)) applyEntry(undefined);
+      if (removalEndsEntry(credentialsEntry.latest(), providerId, result.reason)) {
+        credentialsEntry.apply(undefined);
+      }
       return result.reason;
     },
-    [applyEntry],
+    [credentialsEntry.apply, credentialsEntry.latest],
   );
+
+  const credentials: CredentialEntryControl = {
+    entry: credentialsEntry.entry,
+    begin: beginEntry,
+    change: (draft) => credentialsEntry.patch({ draft }),
+    fetchKey,
+    cancel: credentialsEntry.cancel,
+    commit: credentialsEntry.commit,
+    remove: removeProviderApiKey,
+  };
 
   /** Shows or hides the menu bar status item. */
   const changeShowInMenuBar = useCallback(
@@ -807,33 +772,11 @@ export function App(): React.JSX.Element {
     return [...names.entries()].map(([id, name]) => ({ id, name }));
   }, [workspaceProjects, storedWorkspaceProvider]);
 
-  const credentials: CredentialEntryControl = {
-    entry,
-    begin: beginEntry,
-    change: changeEntry,
-    fetchKey,
-    cancel: cancelEntry,
-    commit: commitEntry,
-    remove: removeProviderApiKey,
-  };
-
   /**
-   * The single place a feedback entry changes, for the same reason a
-   * credential's is: writing one holds the panel open against the pointer, so
-   * ending one has to release that hold — an entry that ends while the pointer
-   * is already away would otherwise leave the panel held open by nothing.
+   * Says a send landed, and stops saying it once it has been readable. Long
+   * enough to be read on the way back from the Send button, short enough that
+   * the line is gone before anyone wonders whether it is stuck.
    */
-  const applyFeedback = useCallback(
-    (next: FeedbackEntry | undefined) => {
-      const released = feedbackRef.current !== undefined && next === undefined;
-      feedbackRef.current = next;
-      setFeedback(next);
-      if (released && !pointerInside.current) handleHitRegionLeave();
-    },
-    [handleHitRegionLeave],
-  );
-
-  /** Says a send landed, and stops saying it once it has been readable. */
   const showFeedbackNotice = useCallback((notice: string) => {
     if (feedbackNoticeTimer.current !== undefined) {
       window.clearTimeout(feedbackNoticeTimer.current);
@@ -846,6 +789,41 @@ export function App(): React.JSX.Element {
   }, []);
 
   useEffect(() => () => window.clearTimeout(feedbackNoticeTimer.current), []);
+
+  const feedbackEntry = usePanelEntry<FeedbackEntry>({
+    aside: PANEL_PRESENTATION.FEEDBACK,
+    restoresPanel: (held) => held.fromPanel === true,
+    isSendable,
+    send: async (sending) => {
+      const name = sending.name.trim();
+      const email = sending.email.trim();
+      try {
+        const result = await window.sidecar.sendFeedback({
+          kind: sending.kind,
+          message: sending.message.trim(),
+          ...(name ? { name } : {}),
+          ...(email ? { email } : {}),
+          images: sending.images,
+        });
+        if (!result.delivered) {
+          return { rejection: result.reason ?? "Could not send that. Try again." };
+        }
+        return {};
+      } catch {
+        return { rejection: "Could not send that. Try again." };
+      }
+    },
+    onDelivered: () => showFeedbackNotice("Sent — thank you."),
+    pointerInside: () => pointerInside.current,
+    presentation: () => presentationRef.current,
+    onReleasedWhileAway: handleHitRegionLeave,
+    cancelHover: cancelHoverTransition,
+    applyPresentation,
+    restorePanel,
+    leave: leavePanel,
+    settle: settlePanel,
+    heldRef: feedbackHeld,
+  });
 
   /**
    * Opens the composer for a kind — from the section's own buttons, from the
@@ -861,17 +839,16 @@ export function App(): React.JSX.Element {
   const beginFeedback = useCallback(
     (kind: FeedbackKind, fromPanel: boolean, draft?: string): boolean => {
       setFeedbackNotice(undefined);
-      const opened = openedFeedbackEntry(feedbackRef.current, {
+      const opened = openedFeedbackEntry(feedbackEntry.latest(), {
         kind,
         fromPanel,
         ...(draft !== undefined ? { draft } : {}),
       });
-      if (opened.entry) applyFeedback(opened.entry);
-      cancelHoverTransition();
-      applyPresentation(PANEL_PRESENTATION.FEEDBACK);
+      if (opened.entry) feedbackEntry.apply(opened.entry);
+      feedbackEntry.standDown();
       return opened.drafted;
     },
-    [applyFeedback, applyPresentation, cancelHoverTransition],
+    [feedbackEntry.apply, feedbackEntry.latest, feedbackEntry.standDown],
   );
 
   /**
@@ -883,24 +860,9 @@ export function App(): React.JSX.Element {
    */
   const dismissFeedback = useCallback(() => {
     if (presentationRef.current !== PANEL_PRESENTATION.FEEDBACK) return;
-    if (feedbackRef.current?.fromPanel === true) restorePanel();
-    else void changeMode(false);
-  }, [changeMode, restorePanel]);
-
-  /**
-   * Every field writes through here, under the rule a credential's draft has:
-   * a note being sent is what the reply on its way back is answering, so
-   * nothing may change under it but ending it outright. Typing again answers
-   * the last refusal, so the refusal goes.
-   */
-  const changeFeedback = useCallback(
-    (patch: Partial<Pick<FeedbackEntry, "message" | "name" | "email">>) => {
-      const current = feedbackRef.current;
-      if (!current || current.busy) return;
-      applyFeedback({ ...current, ...patch, rejection: undefined });
-    },
-    [applyFeedback],
-  );
+    if (feedbackEntry.latest()?.fromPanel === true) restorePanel();
+    else leavePanel();
+  }, [feedbackEntry.latest, leavePanel, restorePanel]);
 
   /**
    * Takes picked or pasted files aboard. Encoding happens here on the user's
@@ -910,8 +872,8 @@ export function App(): React.JSX.Element {
    */
   const attachFeedbackImages = useCallback(
     async (files: readonly File[]) => {
-      const current = feedbackRef.current;
-      if (!current || current.busy) return;
+      const current = feedbackEntry.latest();
+      if (!panelEntryOpen(current)) return;
       const room = FEEDBACK_LIMITS.MAX_IMAGES - current.images.length;
       const taken = files.slice(0, Math.max(0, room));
       const encoded: FeedbackImage[] = [];
@@ -923,110 +885,42 @@ export function App(): React.JSX.Element {
       }
       // Read again after the awaits: typing meanwhile replaced the entry
       // object, and Cancel or a send may have ended it altogether.
-      const latest = feedbackRef.current;
-      if (!latest || latest.busy) return;
+      const latest = feedbackEntry.latest();
+      if (!panelEntryOpen(latest)) return;
       const rejection = refused
         ? IMAGE_REFUSAL.UNREADABLE
         : files.length > room
           ? IMAGE_REFUSAL.FULL
           : undefined;
-      applyFeedback({
+      feedbackEntry.apply({
         ...latest,
         images: [...latest.images, ...encoded].slice(0, FEEDBACK_LIMITS.MAX_IMAGES),
         rejection,
       });
     },
-    [applyFeedback],
+    [feedbackEntry.apply, feedbackEntry.latest],
   );
 
-  const removeFeedbackImage = useCallback(
-    (index: number) => {
-      const current = feedbackRef.current;
-      if (!current || current.busy) return;
-      applyFeedback({
+  const feedbackControl: FeedbackEntryControl = {
+    entry: feedbackEntry.entry,
+    ...(feedbackNotice ? { notice: feedbackNotice } : {}),
+    // The section's own buttons are the panel asking, so leaving returns there.
+    begin: (kind) => beginFeedback(kind, true),
+    changeMessage: (message) => feedbackEntry.patch({ message }),
+    changeName: (name) => feedbackEntry.patch({ name }),
+    changeEmail: (email) => feedbackEntry.patch({ email }),
+    attach: (files) => void attachFeedbackImages(files),
+    removeImage: (index) => {
+      const current = feedbackEntry.latest();
+      if (!panelEntryOpen(current)) return;
+      feedbackEntry.apply({
         ...current,
         images: current.images.filter((_, held) => held !== index),
       });
     },
-    [applyFeedback],
-  );
-
-  /** The one way a draft is discarded, and it is the user's own press. */
-  const cancelFeedback = useCallback(() => {
-    const aside = presentationRef.current === PANEL_PRESENTATION.FEEDBACK;
-    const fromPanel = feedbackRef.current?.fromPanel === true;
-    applyFeedback(undefined);
-    if (!aside) return;
-    // Giving up returns you where you were: the panel this was opened from,
-    // or — from the tray — out of the way entirely.
-    if (fromPanel) restorePanel();
-    else void changeMode(false);
-  }, [applyFeedback, changeMode, restorePanel]);
-
-  const commitFeedback = useCallback(() => {
-    const current = feedbackRef.current;
-    if (!isSendable(current)) return;
-    const sending: FeedbackEntry = { ...current, busy: true, rejection: undefined };
-    applyFeedback(sending);
-    const name = sending.name.trim();
-    const email = sending.email.trim();
-    void window.sidecar
-      .sendFeedback({
-        kind: sending.kind,
-        message: sending.message.trim(),
-        ...(name ? { name } : {}),
-        ...(email ? { email } : {}),
-        images: sending.images,
-      })
-      .then((result) => {
-        // A reply that outlived its own entry is spent, exactly as a
-        // credential's is: Cancel reaches the composer while a send is in
-        // flight, and so does beginning again.
-        if (feedbackRef.current !== sending) return;
-        if (!result.delivered) {
-          applyFeedback({
-            ...sending,
-            busy: false,
-            rejection: result.reason ?? "Could not send that. Try again.",
-          });
-          return;
-        }
-        // Sent from the shape: the whole panel comes back around the section
-        // that offered this, because the sent line under the offers is the
-        // answer to what was just done — the same restore a key saved from
-        // the slot gets. An answer is worth reading and then done with, so
-        // with the pointer away nothing else would ever ask this panel to
-        // close, and it shows the answer and then takes its leave.
-        feedbackRef.current = undefined;
-        setFeedback(undefined);
-        showFeedbackNotice("Sent — thank you.");
-        if (presentationRef.current === PANEL_PRESENTATION.FEEDBACK) restorePanel();
-        if (pointerInside.current) return;
-        cancelHoverTransition();
-        hoverTimer.current = window.setTimeout(() => {
-          hoverTimer.current = undefined;
-          if (presentationRef.current === PANEL_PRESENTATION.PANEL) void changeMode(false);
-        }, SETTLE_DELAY_MS);
-      })
-      .catch(() => {
-        if (feedbackRef.current !== sending) return;
-        applyFeedback({ ...sending, busy: false, rejection: "Could not send that. Try again." });
-      });
-  }, [applyFeedback, cancelHoverTransition, changeMode, restorePanel, showFeedbackNotice]);
-
-  const feedbackControl: FeedbackEntryControl = {
-    entry: feedback,
-    ...(feedbackNotice ? { notice: feedbackNotice } : {}),
-    // The section's own buttons are the panel asking, so leaving returns there.
-    begin: (kind) => beginFeedback(kind, true),
-    changeMessage: (message) => changeFeedback({ message }),
-    changeName: (name) => changeFeedback({ name }),
-    changeEmail: (email) => changeFeedback({ email }),
-    attach: (files) => void attachFeedbackImages(files),
-    removeImage: removeFeedbackImage,
     dismiss: dismissFeedback,
-    cancel: cancelFeedback,
-    commit: commitFeedback,
+    cancel: feedbackEntry.cancel,
+    commit: feedbackEntry.commit,
   };
 
   // The row marks the voice the main process reports rather than the one just
@@ -1266,7 +1160,7 @@ export function App(): React.JSX.Element {
         // nothing here sends: the note leaves only by the Send button's own
         // press.
         const kind = FEEDBACK_KIND_FOR_COMPOSER[action.composer];
-        const drafted = openedFeedbackEntry(feedbackRef.current, {
+        const drafted = openedFeedbackEntry(feedbackEntry.latest(), {
           kind,
           fromPanel: false,
           ...(action.draft === undefined ? {} : { draft: action.draft }),
@@ -1335,7 +1229,16 @@ export function App(): React.JSX.Element {
         ...(action.sort ? { sort: action.sort } : {}),
       };
     },
-    [changeMode, changeTab, settings, settingsView, bootstrap, releaseErrandChange, runErrand],
+    [
+      changeMode,
+      changeTab,
+      settings,
+      settingsView,
+      bootstrap,
+      releaseErrandChange,
+      runErrand,
+      feedbackEntry.latest,
+    ],
   );
 
   const defaultWorkspaceProvider = (settings ?? bootstrap?.settings)?.defaultWorkspaceProvider;
@@ -1631,7 +1534,7 @@ export function App(): React.JSX.Element {
       // happens to be: the slot is the only thing on screen, so there is nothing
       // else it could mean.
       if (presentation === PANEL_PRESENTATION.SLOT) {
-        cancelEntry();
+        credentialsEntry.cancel();
         return;
       }
       // Escape out of the composer leaves the shape and keeps the draft: a
@@ -1654,7 +1557,7 @@ export function App(): React.JSX.Element {
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
   }, [
-    cancelEntry,
+    credentialsEntry.cancel,
     changeMode,
     changeTab,
     dismissFeedback,
@@ -1768,7 +1671,9 @@ export function App(): React.JSX.Element {
   // What the slot's field is for depends on what answers for that provider now,
   // and settings resolve after the first render.
   const slotSource =
-    entry && settings ? settings.credentialSources[entry.providerId] : CREDENTIAL_SOURCE.NONE;
+    credentialsEntry.entry && settings
+      ? settings.credentialSources[credentialsEntry.entry.providerId]
+      : CREDENTIAL_SOURCE.NONE;
 
   return (
     <div

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -74,6 +74,7 @@ import { SESSION_OPTIONS_BUTTON_ID, SESSION_OPTIONS_ID } from "./session-parts";
 import { SETTING_PAGE, SETTINGS_VIEW, type SettingsView } from "./settings-views";
 import { panelEntryOpen, usePanelEntry } from "./use-panel-entry";
 import { usePanelPresentation } from "./use-panel-presentation";
+import { useStateWithRef } from "./use-state-with-ref";
 import { useVoiceConversation } from "./use-voice-conversation";
 import {
   outputSilent,
@@ -182,7 +183,7 @@ export function App(): React.JSX.Element {
     [],
   );
   const [display, setDisplay] = useState<DisplayDiagnostic>();
-  const [tab, setTab] = useState<PanelTab>(PANEL_TAB.SESSIONS);
+  const [tab, setTab, tabNow] = useStateWithRef<PanelTab>(PANEL_TAB.SESSIONS);
   const [settingsView, setSettingsView] = useState<SettingsView>(SETTINGS_VIEW.ROOT);
   const [sessionView, setSessionView] = useState<SessionView>(DEFAULT_SESSION_VIEW);
   const [optionsOpen, setOptionsOpen] = useState(false);
@@ -227,7 +228,6 @@ export function App(): React.JSX.Element {
   const [silenceStretch, setSilenceStretch] = useState(0);
   const wasSilent = useRef(false);
   const [hintDismissal, setHintDismissal] = useState<VolumeHintDismissal>();
-  const tabRef = useRef<PanelTab>(PANEL_TAB.SESSIONS);
   /**
    * Whether a composer is held, mirrored for the presentation cluster: a
    * capsule close keeps the settings tab for a half-written key or note, and
@@ -302,19 +302,21 @@ export function App(): React.JSX.Element {
    */
   const errandOpenedPanel = useRef(false);
 
-  const changeTab = useCallback((next: PanelTab) => {
-    tabRef.current = next;
-    setTab(next);
-    // The sheet belongs to the session list, and it is drawn over the list it
-    // belongs to, so leaving for Settings has to take it along.
-    setOptionsOpen(false);
-    // Arriving at the tab is arriving at its front page: a page left open
-    // behind a tab switch would greet the next visit with a corner of the
-    // settings rather than the settings. The flows that need a deeper page —
-    // a credential entry returning from the key slot, the evidence run that
-    // starts in it — set their page right after this reset.
-    setSettingsView(SETTINGS_VIEW.ROOT);
-  }, []);
+  const changeTab = useCallback(
+    (next: PanelTab) => {
+      setTab(next);
+      // The sheet belongs to the session list, and it is drawn over the list it
+      // belongs to, so leaving for Settings has to take it along.
+      setOptionsOpen(false);
+      // Arriving at the tab is arriving at its front page: a page left open
+      // behind a tab switch would greet the next visit with a corner of the
+      // settings rather than the settings. The flows that need a deeper page —
+      // a credential entry returning from the key slot, the evidence run that
+      // starts in it — set their page right after this reset.
+      setSettingsView(SETTINGS_VIEW.ROOT);
+    },
+    [setTab],
+  );
 
   // A choice made in the sheet puts the sheet away. It is drawn over the list
   // and is taller than a row, so a list narrowed to one or two sessions ends up
@@ -347,7 +349,7 @@ export function App(): React.JSX.Element {
     // screen. An entry outlives the tab it was started on now, so holding the
     // panel open for one that is not drawn would leave the pointer unable to
     // close a panel showing nothing but sessions.
-    entryDrawn: () => credentialHeld.current && tabRef.current === PANEL_TAB.SETTINGS,
+    entryDrawn: () => credentialHeld.current && tabNow() === PANEL_TAB.SETTINGS,
     composerHeld: () => credentialHeld.current || feedbackHeld.current,
     onNotPanel: () => setOptionsOpen(false),
     onCapsuleList: () => setSessionView(DEFAULT_SESSION_VIEW),
@@ -897,7 +899,7 @@ export function App(): React.JSX.Element {
         const wait =
           opening || page === undefined
             ? ERRAND_WAIT.CONTENT
-            : tabRef.current === PANEL_TAB.SETTINGS && settingsView === page
+            : tabNow() === PANEL_TAB.SETTINGS && settingsView === page
               ? ERRAND_WAIT.AT_ONCE
               : ERRAND_WAIT.PAGE;
         try {
@@ -1017,6 +1019,7 @@ export function App(): React.JSX.Element {
       runErrand,
       feedbackEntry.latest,
       presentationOf,
+      tabNow,
     ],
   );
 

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -21,7 +21,6 @@ import type {
   OutputAudioState,
   SessionOpenResult,
   SettingsUpdateResult,
-  WindowMode,
 } from "../shared/contracts";
 import { CREDENTIAL_SOURCE, SESSION_OPEN_RESULT_STATUS } from "../shared/contracts";
 import type { CredentialProviderId } from "../shared/credential-providers";
@@ -57,16 +56,7 @@ import {
 import { applySpokenSetting, buildLukeGuide, isAppSettingId } from "./luke-guide";
 import { NotchWings } from "./notch-wings";
 import { PanelBody, type SessionWriteHandlers } from "./panel-body";
-import {
-  HIT_REGION,
-  HIT_REGION_ATTRIBUTE,
-  LEAVE_DELAY_MS,
-  PANEL_PRESENTATION,
-  type PanelPresentation,
-  PEEK_ENTER_DELAY_MS,
-  presentationForMode,
-  SETTLE_DELAY_MS,
-} from "./panel-state";
+import { HIT_REGION, PANEL_PRESENTATION } from "./panel-state";
 import { PANEL_TAB, type PanelTab } from "./panel-tabs";
 import type { AppActionCarrier } from "./realtime-session";
 import {
@@ -83,6 +73,7 @@ import {
 import { SESSION_OPTIONS_BUTTON_ID, SESSION_OPTIONS_ID } from "./session-parts";
 import { SETTING_PAGE, SETTINGS_VIEW, type SettingsView } from "./settings-views";
 import { panelEntryOpen, usePanelEntry } from "./use-panel-entry";
+import { usePanelPresentation } from "./use-panel-presentation";
 import { useVoiceConversation } from "./use-voice-conversation";
 import {
   outputSilent,
@@ -133,81 +124,6 @@ function captionSizeStyle(textHeight: number | undefined, volumeHint: boolean): 
     "--caption-size": `${Math.min(VOICE_CAPTION_MAX_HEIGHT, textHeight + hintHeight + CAPTION_PADDING)}px`,
     "--caption-scroll": `${Math.max(0, textHeight - (VOICE_CAPTION_MAX_HEIGHT - CAPTION_PADDING - hintHeight))}px`,
   } as CSSProperties;
-}
-
-function usePointerPassthrough(
-  onHitRegionEnter: () => void,
-  onHitRegionLeave: () => void,
-  presentation: PanelPresentation,
-): void {
-  const lastValue = useRef<boolean | undefined>(undefined);
-  const lastPoint = useRef<{ x: number; y: number } | undefined>(undefined);
-
-  const update = useCallback(
-    (interceptsPointer: boolean) => {
-      if (lastValue.current === interceptsPointer) return;
-      lastValue.current = interceptsPointer;
-      window.sidecar.setPointerInterception(interceptsPointer);
-      if (interceptsPointer) onHitRegionEnter();
-      else onHitRegionLeave();
-    },
-    [onHitRegionEnter, onHitRegionLeave],
-  );
-
-  const testLastPoint = useCallback(
-    (drawn: PanelPresentation) => {
-      const point = lastPoint.current;
-      if (!point) return;
-      // `elementFromPoint` answers null for a point outside the viewport, which a
-      // forwarded move can carry. Comparing that against null read as "still
-      // inside", so leaving by the edge left the panel open until some other
-      // event closed it.
-      const region = document
-        .elementFromPoint(point.x, point.y)
-        ?.closest(`[${HIT_REGION_ATTRIBUTE}]`);
-      const kind = region?.getAttribute(HIT_REGION_ATTRIBUTE);
-      // The shape takes the pointer wherever it is drawn, which is the whole
-      // rule: the capsule strip and the panel's body are what sit on top of it
-      // and answer first. The surface is what answers in between — the panel's
-      // body is not a target for the first `--expand-delay` of an opening, and
-      // by then the strip has already narrowed from the peek's width back to
-      // the capsule's, so a press out where the marks unfold would otherwise
-      // land on nothing and read as the pointer leaving.
-      update(
-        kind === HIT_REGION.SURFACE ||
-          kind === HIT_REGION.CAPSULE ||
-          (kind === HIT_REGION.PANEL && drawn === PANEL_PRESENTATION.PANEL) ||
-          (kind === HIT_REGION.SLOT && drawn === PANEL_PRESENTATION.SLOT) ||
-          (kind === HIT_REGION.FEEDBACK && drawn === PANEL_PRESENTATION.FEEDBACK),
-      );
-    },
-    [update],
-  );
-
-  useEffect(() => {
-    const handleMove = (event: MouseEvent) => {
-      lastPoint.current = { x: event.clientX, y: event.clientY };
-      testLastPoint(presentation);
-    };
-    const handleLeave = () => {
-      lastPoint.current = undefined;
-      update(false);
-    };
-    window.addEventListener("mousemove", handleMove, { passive: true });
-    document.documentElement.addEventListener("mouseleave", handleLeave);
-    return () => {
-      window.removeEventListener("mousemove", handleMove);
-      document.documentElement.removeEventListener("mouseleave", handleLeave);
-    };
-  }, [presentation, testLastPoint, update]);
-
-  // The shape can change under a pointer that never moves — Escape closes the
-  // panel, and the tray opens it — and what the pointer is over changes with it.
-  // Without this the window keeps intercepting clicks for a shape that is no
-  // longer drawn, and the window is always larger than the shape.
-  useEffect(() => {
-    testLastPoint(presentation);
-  }, [presentation, testLastPoint]);
 }
 
 function notchStyle(display: DisplayDiagnostic): CSSProperties {
@@ -266,7 +182,6 @@ export function App(): React.JSX.Element {
     [],
   );
   const [display, setDisplay] = useState<DisplayDiagnostic>();
-  const [presentation, setPresentation] = useState<PanelPresentation>(PANEL_PRESENTATION.CAPSULE);
   const [tab, setTab] = useState<PanelTab>(PANEL_TAB.SESSIONS);
   const [settingsView, setSettingsView] = useState<SettingsView>(SETTINGS_VIEW.ROOT);
   const [sessionView, setSessionView] = useState<SessionView>(DEFAULT_SESSION_VIEW);
@@ -312,8 +227,6 @@ export function App(): React.JSX.Element {
   const [silenceStretch, setSilenceStretch] = useState(0);
   const wasSilent = useRef(false);
   const [hintDismissal, setHintDismissal] = useState<VolumeHintDismissal>();
-  const hoverTimer = useRef<number | undefined>(undefined);
-  const presentationRef = useRef<PanelPresentation>(PANEL_PRESENTATION.CAPSULE);
   const tabRef = useRef<PanelTab>(PANEL_TAB.SESSIONS);
   /**
    * Whether a composer is held, mirrored for the presentation cluster: a
@@ -322,13 +235,6 @@ export function App(): React.JSX.Element {
    */
   const credentialHeld = useRef(false);
   const feedbackHeld = useRef(false);
-  /**
-   * Whether the caret is in the ask field. It holds the panel open against the
-   * pointer the way a credential entry does, and for the same reason: the
-   * pointer wandering off is not a decision about the thing someone is in the
-   * middle of typing.
-   */
-  const askEngaged = useRef(false);
   const feedbackNoticeTimer = useRef<number | undefined>(undefined);
   /**
    * The words a spoken open asked to start the note with, waiting for the
@@ -337,8 +243,6 @@ export function App(): React.JSX.Element {
    * the developer's own words, under the spoken tool's contract.
    */
   const spokenFeedbackDraft = useRef<string | undefined>(undefined);
-  const pointerInside = useRef(false);
-  const modeGeneration = useRef(0);
   /**
    * Whether a live projects push has arrived. The bootstrap reply resolves
    * whenever the main process gets to it, so a push can land first — and the
@@ -398,24 +302,6 @@ export function App(): React.JSX.Element {
    */
   const errandOpenedPanel = useRef(false);
 
-  /**
-   * Sends Luke to sign what he just did, if there is anywhere to sign it, and
-   * answers whether he actually went.
-   *
-   * Only the panel can hold a signature, so both callers stand it up first and
-   * this is the backstop rather than the decision: an act whose panel never
-   * opened, or that named a control this build does not draw, flies nowhere
-   * and the spoken answer reports it the way it always did. A caller holding
-   * something for the flight reads the answer and lets go itself.
-   */
-  const runErrand = useCallback((targets: readonly ErrandTarget[], wait: ErrandWait): boolean => {
-    if (targets.length === 0) return false;
-    if (presentationRef.current !== PANEL_PRESENTATION.PANEL) return false;
-    errands.current += 1;
-    setErrand({ targets, wait, run: errands.current });
-    return true;
-  }, []);
-
   const changeTab = useCallback((next: PanelTab) => {
     tabRef.current = next;
     setTab(next);
@@ -441,45 +327,68 @@ export function App(): React.JSX.Element {
     setOptionsOpen(false);
   }, []);
 
-  const applyPresentation = useCallback(
-    (next: PanelPresentation) => {
-      presentationRef.current = next;
-      setPresentation(next);
-      // The sheet is only ever drawn inside the panel, so any other shape puts
-      // it away. Left set behind a shape that cannot draw it, it would be over
-      // the list again the next time the panel came forward with nothing having
-      // been pressed — and a key half-entered is the one thing that survives a
-      // close, which the sheet is not.
-      if (next !== PANEL_PRESENTATION.PANEL) setOptionsOpen(false);
-      // A panel that has closed reopens on the session list, showing every
-      // session with whatever needs a person first: settings are somewhere you
-      // go, not a state the capsule remembers, and a filter left in place would
-      // let the panel hide a session the capsule is still counting.
-      //
-      // Something half-written is the one exception, and only to the tab — a
-      // key being entered or a note to the founders alike: it is what someone
-      // is in the middle of, so however the panel closed, it opens again where
-      // they left it. The list is not something anyone is in the middle of, so
-      // it resets either way.
-      if (next === PANEL_PRESENTATION.CAPSULE) {
-        setSessionView(DEFAULT_SESSION_VIEW);
-        if (!credentialHeld.current && !feedbackHeld.current) {
-          changeTab(PANEL_TAB.SESSIONS);
-        }
-      }
+  const {
+    presentation,
+    current: presentationOf,
+    generation: modeGenerationOf,
+    pointerInside: pointerIsInside,
+    heldAgainstPointer,
+    applyPresentation,
+    applyAuthoritativeMode,
+    changeMode,
+    cancelHover,
+    onHitRegionLeave,
+    changeAskEngagement,
+    settle,
+    leave,
+    expand,
+  } = usePanelPresentation({
+    // True while a field someone could be part-way through is actually on
+    // screen. An entry outlives the tab it was started on now, so holding the
+    // panel open for one that is not drawn would leave the pointer unable to
+    // close a panel showing nothing but sessions.
+    entryDrawn: () => credentialHeld.current && tabRef.current === PANEL_TAB.SETTINGS,
+    composerHeld: () => credentialHeld.current || feedbackHeld.current,
+    onNotPanel: () => setOptionsOpen(false),
+    onCapsuleList: () => setSessionView(DEFAULT_SESSION_VIEW),
+    onCapsuleTab: () => changeTab(PANEL_TAB.SESSIONS),
+  });
+
+  /**
+   * Sends Luke to sign what he just did, if there is anywhere to sign it, and
+   * answers whether he actually went.
+   *
+   * Only the panel can hold a signature, so both callers stand it up first and
+   * this is the backstop rather than the decision: an act whose panel never
+   * opened, or that named a control this build does not draw, flies nowhere
+   * and the spoken answer reports it the way it always did. A caller holding
+   * something for the flight reads the answer and lets go itself.
+   */
+  const runErrand = useCallback(
+    (targets: readonly ErrandTarget[], wait: ErrandWait): boolean => {
+      if (targets.length === 0) return false;
+      if (presentationOf() !== PANEL_PRESENTATION.PANEL) return false;
+      errands.current += 1;
+      setErrand({ targets, wait, run: errands.current });
+      return true;
     },
-    [changeTab],
+    [presentationOf],
   );
 
-  const applyAuthoritativeMode = useCallback(
-    (nextMode: WindowMode) => {
-      // A lifecycle notification can originate outside this renderer (for
-      // example from the tray). Ignore an older IPC result that arrives later.
-      modeGeneration.current += 1;
-      applyPresentation(presentationForMode(nextMode));
-    },
-    [applyPresentation],
-  );
+  /**
+   * Brings the panel back around the line the entry belongs to, and leaves it
+   * open the way every other way of opening it does — the pointer closes it by
+   * visiting and leaving.
+   */
+  const restorePanel = useCallback(() => {
+    changeTab(PANEL_TAB.SETTINGS);
+    // The line the entry belongs to lives on the Connections page, and
+    // changeTab has just reset the tab to its front page: without this, the
+    // check appearing beside the provider — the answer to what was just done
+    // — would land on a page nobody is looking at.
+    setSettingsView(SETTINGS_VIEW.CONNECTIONS);
+    expand();
+  }, [changeTab, expand]);
 
   /**
    * Applies a settings write's reply: the snapshot the store actually holds,
@@ -507,134 +416,6 @@ export function App(): React.JSX.Element {
     [applySettingsReply],
   );
 
-  const cancelHoverTransition = useCallback(() => {
-    if (hoverTimer.current === undefined) return;
-    window.clearTimeout(hoverTimer.current);
-    hoverTimer.current = undefined;
-  }, []);
-
-  /**
-   * Only the panel needs the main process. The capsule and the peek share a
-   * window, so hovering never leaves the renderer — which is what lets the peek
-   * answer the pointer immediately.
-   */
-
-  const changeMode = useCallback(
-    async (expanded: boolean) => {
-      const previous = presentationRef.current;
-      const generation = modeGeneration.current + 1;
-      modeGeneration.current = generation;
-      presentationRef.current = expanded ? PANEL_PRESENTATION.PANEL : PANEL_PRESENTATION.CAPSULE;
-      try {
-        // Asking for focus is what makes Escape reach the panel someone opened.
-        const confirmedMode = await window.sidecar.setExpanded(expanded, expanded);
-        if (modeGeneration.current === generation) {
-          applyPresentation(presentationForMode(confirmedMode));
-        }
-      } catch (error) {
-        if (modeGeneration.current === generation) presentationRef.current = previous;
-        throw error;
-      }
-    },
-    [applyPresentation],
-  );
-
-  const handleHitRegionEnter = useCallback(() => {
-    cancelHoverTransition();
-    pointerInside.current = true;
-    if (presentationRef.current !== PANEL_PRESENTATION.CAPSULE) return;
-    hoverTimer.current = window.setTimeout(() => {
-      hoverTimer.current = undefined;
-      if (presentationRef.current === PANEL_PRESENTATION.CAPSULE) {
-        applyPresentation(PANEL_PRESENTATION.PEEK);
-      }
-    }, PEEK_ENTER_DELAY_MS);
-  }, [applyPresentation, cancelHoverTransition]);
-
-  /**
-   * True while a field someone could be part-way through is actually on screen.
-   * An entry outlives the tab it was started on now, so holding the panel open
-   * for one that is not drawn would leave the pointer unable to close a panel
-   * showing nothing but sessions.
-   */
-  const entryIsDrawn = useCallback(
-    () => credentialHeld.current && tabRef.current === PANEL_TAB.SETTINGS,
-    [],
-  );
-
-  const handleHitRegionLeave = useCallback(() => {
-    cancelHoverTransition();
-    pointerInside.current = false;
-    const current = presentationRef.current;
-    if (current === PANEL_PRESENTATION.CAPSULE) return;
-    // The slot is drawn for someone who is somewhere else entirely — in a
-    // browser, fetching the key it is waiting for — so the pointer being away
-    // from it is the normal case rather than a dismissal.
-    if (current === PANEL_PRESENTATION.SLOT) return;
-    // The composer holds words someone is in the middle of, which the pointer
-    // must not be allowed to discard: like the slot, it stays put until it is
-    // dismissed, cancelled, or sent.
-    if (current === PANEL_PRESENTATION.FEEDBACK) return;
-    // A key half-typed is one thing the pointer must not be allowed to
-    // discard; an ask being typed to Luke is the other. Everything else on
-    // the settings tab closes like the sessions tab does.
-    if (current === PANEL_PRESENTATION.PANEL && (entryIsDrawn() || askEngaged.current)) return;
-    hoverTimer.current = window.setTimeout(() => {
-      hoverTimer.current = undefined;
-      if (presentationRef.current === PANEL_PRESENTATION.PEEK) {
-        applyPresentation(PANEL_PRESENTATION.CAPSULE);
-      } else if (presentationRef.current === PANEL_PRESENTATION.PANEL) {
-        // Read again rather than trusting the answer from when this was
-        // scheduled: an entry can begin inside the delay — pressing Connect and
-        // reaching for the keyboard does exactly that — and a close decided
-        // before it began would discard it.
-        if (entryIsDrawn() || askEngaged.current) return;
-        void changeMode(false);
-      }
-    }, LEAVE_DELAY_MS);
-  }, [applyPresentation, cancelHoverTransition, changeMode, entryIsDrawn]);
-
-  /**
-   * The ask field taking or letting go of the caret. Letting go while the
-   * pointer is already away has to release the hold the caret had on the
-   * panel — the pointer cannot leave a second time — which is the same rule
-   * ending a credential entry follows.
-   */
-  const changeAskEngagement = useCallback(
-    (engaged: boolean) => {
-      const released = askEngaged.current && !engaged;
-      askEngaged.current = engaged;
-      if (released && !pointerInside.current) handleHitRegionLeave();
-    },
-    [handleHitRegionLeave],
-  );
-
-  /**
-   * Brings the panel back around the line the entry belongs to, and leaves it
-   * open the way every other way of opening it does — the pointer closes it by
-   * visiting and leaving.
-   */
-  const restorePanel = useCallback(() => {
-    changeTab(PANEL_TAB.SETTINGS);
-    // The line the entry belongs to lives on the Connections page, and
-    // changeTab has just reset the tab to its front page: without this, the
-    // check appearing beside the provider — the answer to what was just done
-    // — would land on a page nobody is looking at.
-    setSettingsView(SETTINGS_VIEW.CONNECTIONS);
-    void changeMode(true);
-  }, [changeMode, changeTab]);
-
-  const settlePanel = useCallback(() => {
-    hoverTimer.current = window.setTimeout(() => {
-      hoverTimer.current = undefined;
-      if (presentationRef.current === PANEL_PRESENTATION.PANEL) void changeMode(false);
-    }, SETTLE_DELAY_MS);
-  }, [changeMode]);
-
-  const leavePanel = useCallback(() => {
-    void changeMode(false);
-  }, [changeMode]);
-
   /**
    * Asking to write a key is asking for one thing, so the panel gets out of the
    * way of it: the shape goes down to the slot, which is the field and nothing
@@ -651,14 +432,14 @@ export function App(): React.JSX.Element {
       setSettings(result.settings);
       return result.reason ? { rejection: result.reason } : {};
     },
-    pointerInside: () => pointerInside.current,
-    presentation: () => presentationRef.current,
-    onReleasedWhileAway: handleHitRegionLeave,
-    cancelHover: cancelHoverTransition,
+    pointerInside: pointerIsInside,
+    presentation: presentationOf,
+    onReleasedWhileAway: onHitRegionLeave,
+    cancelHover,
     applyPresentation,
     restorePanel,
-    leave: leavePanel,
-    settle: settlePanel,
+    leave,
+    settle,
     heldRef: credentialHeld,
   });
 
@@ -685,9 +466,9 @@ export function App(): React.JSX.Element {
     if (!panelEntryOpen(current)) return;
     window.sidecar.openProviderApiKeys(current.providerId);
     credentialsEntry.apply({ ...current, away: true });
-    if (presentationRef.current === PANEL_PRESENTATION.SLOT) return;
+    if (presentationOf() === PANEL_PRESENTATION.SLOT) return;
     credentialsEntry.standDown();
-  }, [credentialsEntry.apply, credentialsEntry.latest, credentialsEntry.standDown]);
+  }, [credentialsEntry.apply, credentialsEntry.latest, credentialsEntry.standDown, presentationOf]);
 
   const removeProviderApiKey = useCallback(
     async (providerId: CredentialProviderId) => {
@@ -814,14 +595,14 @@ export function App(): React.JSX.Element {
       }
     },
     onDelivered: () => showFeedbackNotice("Sent — thank you."),
-    pointerInside: () => pointerInside.current,
-    presentation: () => presentationRef.current,
-    onReleasedWhileAway: handleHitRegionLeave,
-    cancelHover: cancelHoverTransition,
+    pointerInside: pointerIsInside,
+    presentation: presentationOf,
+    onReleasedWhileAway: onHitRegionLeave,
+    cancelHover,
     applyPresentation,
     restorePanel,
-    leave: leavePanel,
-    settle: settlePanel,
+    leave,
+    settle,
     heldRef: feedbackHeld,
   });
 
@@ -859,10 +640,10 @@ export function App(): React.JSX.Element {
    * panel, or — from the tray — nothing at all.
    */
   const dismissFeedback = useCallback(() => {
-    if (presentationRef.current !== PANEL_PRESENTATION.FEEDBACK) return;
+    if (presentationOf() !== PANEL_PRESENTATION.FEEDBACK) return;
     if (feedbackEntry.latest()?.fromPanel === true) restorePanel();
-    else leavePanel();
-  }, [feedbackEntry.latest, leavePanel, restorePanel]);
+    else leave();
+  }, [feedbackEntry.latest, leave, presentationOf, restorePanel]);
 
   /**
    * Takes picked or pasted files aboard. Encoding happens here on the user's
@@ -991,10 +772,10 @@ export function App(): React.JSX.Element {
         providerId: session.providerId,
         providerSessionId: session.id,
       });
-      cancelHoverTransition();
+      cancelHover();
       void changeMode(false);
     },
-    [cancelHoverTransition, changeMode],
+    [cancelHover, changeMode],
   );
 
   /**
@@ -1008,14 +789,14 @@ export function App(): React.JSX.Element {
       const result = await window.sidecar.openSession(identity);
       if (
         result.status === SESSION_OPEN_RESULT_STATUS.OPENED &&
-        presentationRef.current === PANEL_PRESENTATION.PANEL
+        presentationOf() === PANEL_PRESENTATION.PANEL
       ) {
-        cancelHoverTransition();
+        cancelHover();
         void changeMode(false);
       }
       return result;
     },
-    [cancelHoverTransition, changeMode],
+    [cancelHover, changeMode, presentationOf],
   );
 
   /**
@@ -1027,17 +808,17 @@ export function App(): React.JSX.Element {
   const summonAsk = useCallback(() => {
     const field = document.getElementById(ASK_LUKE_INPUT_ID);
     if (
-      presentationRef.current === PANEL_PRESENTATION.PANEL &&
+      presentationOf() === PANEL_PRESENTATION.PANEL &&
       field !== null &&
       document.activeElement === field
     ) {
-      cancelHoverTransition();
+      cancelHover();
       void changeMode(false);
       return;
     }
     changeTab(PANEL_TAB.SESSIONS);
     focusAskField();
-  }, [cancelHoverTransition, changeMode, changeTab]);
+  }, [cancelHover, changeMode, changeTab, presentationOf]);
 
   /**
    * The panel standing back down once an errand it stood up is over. The same
@@ -1054,13 +835,10 @@ export function App(): React.JSX.Element {
   const standDownAfterErrand = useCallback(() => {
     if (!errandOpenedPanel.current) return;
     errandOpenedPanel.current = false;
-    if (pointerInside.current || entryIsDrawn() || askEngaged.current) return;
-    cancelHoverTransition();
-    hoverTimer.current = window.setTimeout(() => {
-      hoverTimer.current = undefined;
-      if (presentationRef.current === PANEL_PRESENTATION.PANEL) void changeMode(false);
-    }, SETTLE_DELAY_MS);
-  }, [cancelHoverTransition, changeMode, entryIsDrawn]);
+    if (pointerIsInside() || heldAgainstPointer()) return;
+    cancelHover();
+    settle();
+  }, [cancelHover, heldAgainstPointer, pointerIsInside, settle]);
 
   /**
    * The spoken asks about Luke himself. A settings change goes through the
@@ -1105,7 +883,7 @@ export function App(): React.JSX.Element {
           releaseErrandChange();
           return outcome;
         }
-        const opening = presentationRef.current !== PANEL_PRESENTATION.PANEL;
+        const opening = presentationOf() !== PANEL_PRESENTATION.PANEL;
         // The guide's ids travel as plain text, so one that names no setting
         // of Luke's names no page either — and nothing will fly to it.
         const page = isAppSettingId(action.setting.id)
@@ -1192,7 +970,7 @@ export function App(): React.JSX.Element {
       // Whether this ask is what opens the panel, read before it does: an
       // errand into a shape still growing has to trail the whole opening,
       // and one into a panel already up does not.
-      const opening = presentationRef.current !== PANEL_PRESENTATION.PANEL;
+      const opening = presentationOf() !== PANEL_PRESENTATION.PANEL;
       changeTab(action.tab);
       const spoken = action.filter ? sessionFilterFromSpoken(action.filter) : undefined;
       // An agent this build never registered cannot narrow the list, and Luke
@@ -1238,6 +1016,7 @@ export function App(): React.JSX.Element {
       releaseErrandChange,
       runErrand,
       feedbackEntry.latest,
+      presentationOf,
     ],
   );
 
@@ -1305,13 +1084,11 @@ export function App(): React.JSX.Element {
       // back. `detail` is 0 when the keyboard activated the button, and there
       // the focus is the point and stays where the keyboard put it.
       if (event.detail > 0) event.currentTarget.blur();
-      cancelHoverTransition();
-      void changeMode(presentationRef.current !== PANEL_PRESENTATION.PANEL);
+      cancelHover();
+      void changeMode(presentationOf() !== PANEL_PRESENTATION.PANEL);
     },
-    [cancelHoverTransition, changeMode],
+    [cancelHover, changeMode, presentationOf],
   );
-
-  usePointerPassthrough(handleHitRegionEnter, handleHitRegionLeave, presentation);
 
   // `:focus-visible` is a heuristic about how focus arrived, and here it guesses
   // wrong: the panel takes focus programmatically when it opens, which the
@@ -1337,7 +1114,7 @@ export function App(): React.JSX.Element {
   }, []);
 
   useEffect(() => {
-    const bootstrapGeneration = modeGeneration.current;
+    const bootstrapGeneration = modeGenerationOf();
     void window.sidecar.getBootstrap().then((value) => {
       setBootstrap(value);
       setSessions(value.sessions);
@@ -1348,7 +1125,7 @@ export function App(): React.JSX.Element {
       if (!issuesPushed.current) syncIssues(value.issues);
       if (!settingsPushed.current) setSettings(value.settings);
       setDisplay(value.display);
-      if (modeGeneration.current === bootstrapGeneration) {
+      if (modeGenerationOf() === bootstrapGeneration) {
         applyAuthoritativeMode(value.mode);
         if (value.startPeeked && value.mode === "compact") {
           applyPresentation(PANEL_PRESENTATION.PEEK);
@@ -1426,7 +1203,7 @@ export function App(): React.JSX.Element {
       syncIssues(issues);
     });
     return () => {
-      cancelHoverTransition();
+      cancelHover();
       removeLifecycle();
       removeDisplay();
       removeSettings();
@@ -1441,7 +1218,7 @@ export function App(): React.JSX.Element {
     applyPresentation,
     beginEntry,
     beginFeedback,
-    cancelHoverTransition,
+    cancelHover,
     changeTab,
     setMicrophoneStatus,
     setVoiceStatus,
@@ -1449,6 +1226,7 @@ export function App(): React.JSX.Element {
     stopMicrophone,
     summonAsk,
     syncIssues,
+    modeGenerationOf,
   ]);
 
   // Silence is counted in stretches — one per unbroken run of muted-or-zero —

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -72,6 +72,7 @@ import {
 } from "./session-model";
 import { SESSION_OPTIONS_BUTTON_ID, SESSION_OPTIONS_ID } from "./session-parts";
 import { SETTING_PAGE, SETTINGS_VIEW, type SettingsView } from "./settings-views";
+import { useBootstrapRacedChannel } from "./use-bootstrap-raced-channel";
 import { panelEntryOpen, usePanelEntry } from "./use-panel-entry";
 import { usePanelPresentation } from "./use-panel-presentation";
 import { useStateWithRef } from "./use-state-with-ref";
@@ -215,12 +216,6 @@ export function App(): React.JSX.Element {
    */
   const [outputAudio, setOutputAudio] = useState<OutputAudioState>();
   /**
-   * Whether a live push has arrived, so the bootstrap's older snapshot does
-   * not clobber one that raced past it — the same reading order the issue
-   * roster follows.
-   */
-  const outputAudioPushed = useRef(false);
-  /**
    * Which stretch of unbroken silence is on screen, advanced each time one
    * begins. A "Got it" is remembered against the stretch it answered, so it
    * holds for that whole mute and lapses naturally with it.
@@ -243,20 +238,6 @@ export function App(): React.JSX.Element {
    * the developer's own words, under the spoken tool's contract.
    */
   const spokenFeedbackDraft = useRef<string | undefined>(undefined);
-  /**
-   * Whether a live projects push has arrived. The bootstrap reply resolves
-   * whenever the main process gets to it, so a push can land first — and the
-   * bootstrap's older snapshot must then not clobber it, because the main
-   * process will not repeat a list it believes it already announced.
-   */
-  const workspaceProjectsPushed = useRef(false);
-  const issuesPushed = useRef(false);
-  /**
-   * Whether another window's settings change has arrived, under the same rule
-   * as the roster above: a push that lands before the bootstrap reply is the
-   * newer truth, and the bootstrap's older snapshot must not clobber it.
-   */
-  const settingsPushed = useRef(false);
   /**
    * How many errands Luke has run. Carried with each one so that asking for
    * the same control twice flies twice, exactly as a repeated face gesture is
@@ -1060,6 +1041,40 @@ export function App(): React.JSX.Element {
   });
 
   /**
+   * A live push beats a bootstrap snapshot still in flight. The main process
+   * will not repeat a list it believes it already announced, so the older
+   * snapshot must not clobber one that raced past it.
+   */
+  const acceptProjectsBootstrap = useBootstrapRacedChannel(
+    (onChange) => window.sidecar.onWorkspaceProjectsChanged(onChange),
+    setWorkspaceProjects,
+  );
+  // Straight to the conversation rather than through state: no panel
+  // surface draws the issue roster, so a re-render would be work for nobody.
+  const acceptIssuesBootstrap = useBootstrapRacedChannel(
+    (onChange) => window.sidecar.onIssuesChanged(onChange),
+    syncIssues,
+  );
+  // Another window's settings change: this window's rows and guide redraw
+  // from the same snapshot its reply carried, so no window describes a
+  // state the store no longer holds.
+  const acceptSettingsBootstrap = useBootstrapRacedChannel(
+    (onChange) =>
+      window.sidecar.onSettingsChanged((pushed) => {
+        // A push is newer than anything an errand is still carrying, so it takes
+        // the hold with it: released afterwards, a snapshot caught before this
+        // arrived would draw the store as it was rather than as it is.
+        heldSettings.current = undefined;
+        onChange(pushed);
+      }),
+    setSettings,
+  );
+  const acceptOutputAudioBootstrap = useBootstrapRacedChannel(
+    (onChange) => window.sidecar.onOutputAudioChanged(onChange),
+    setOutputAudio,
+  );
+
+  /**
    * The two writes a row can ask for, handed to the main process by session
    * identity. Unlike opening, neither closes the panel: the answer lands back
    * on the row that asked, and the user is mid-conversation with it.
@@ -1124,9 +1139,9 @@ export function App(): React.JSX.Element {
       // Only fill in what no push has said yet: the bootstrap snapshot is
       // older than any change that raced past it, and the main process will
       // not repeat a list it believes it already announced.
-      if (!workspaceProjectsPushed.current) setWorkspaceProjects(value.workspaceProjects);
-      if (!issuesPushed.current) syncIssues(value.issues);
-      if (!settingsPushed.current) setSettings(value.settings);
+      acceptProjectsBootstrap(value.workspaceProjects);
+      acceptIssuesBootstrap(value.issues);
+      acceptSettingsBootstrap(value.settings);
       setDisplay(value.display);
       if (modeGenerationOf() === bootstrapGeneration) {
         applyAuthoritativeMode(value.mode);
@@ -1149,7 +1164,7 @@ export function App(): React.JSX.Element {
       setMicrophoneStatus(value.microphoneStatus);
       // Only fill in what no push has said yet, like the issue roster: the
       // bootstrap snapshot is older than any change that raced past it.
-      if (!outputAudioPushed.current && value.outputAudio) setOutputAudio(value.outputAudio);
+      if (value.outputAudio) acceptOutputAudioBootstrap(value.outputAudio);
       if (!value.realtimeAvailable) setVoiceStatus(REALTIME_STATUS.UNAVAILABLE);
       if (value.profile === "microphone") {
         window.setTimeout(() => void startMicrophone(), 500);
@@ -1179,44 +1194,19 @@ export function App(): React.JSX.Element {
       }
     });
     const removeDisplay = window.sidecar.onDisplayChanged(setDisplay);
-    // Another window's settings change: this window's rows and guide redraw
-    // from the same snapshot its reply carried, so no window describes a
-    // state the store no longer holds.
-    const removeSettings = window.sidecar.onSettingsChanged((pushed) => {
-      settingsPushed.current = true;
-      // A push is newer than anything an errand is still carrying, so it takes
-      // the hold with it: released afterwards, a snapshot caught before this
-      // arrived would draw the store as it was rather than as it is.
-      heldSettings.current = undefined;
-      setSettings(pushed);
-    });
     const removeSessions = window.sidecar.onSessionsChanged(setSessions);
-    const removeWorkspaceProjects = window.sidecar.onWorkspaceProjectsChanged((projects) => {
-      workspaceProjectsPushed.current = true;
-      setWorkspaceProjects(projects);
-    });
-    const removeOutputAudio = window.sidecar.onOutputAudioChanged((state) => {
-      outputAudioPushed.current = true;
-      setOutputAudio(state);
-    });
-    // Straight to the conversation rather than through state: no panel
-    // surface draws the issue roster, so a re-render would be work for nobody.
-    const removeIssues = window.sidecar.onIssuesChanged((issues) => {
-      issuesPushed.current = true;
-      syncIssues(issues);
-    });
     return () => {
       cancelHover();
       removeLifecycle();
       removeDisplay();
-      removeSettings();
       removeSessions();
-      removeWorkspaceProjects();
-      removeOutputAudio();
-      removeIssues();
       void stopMicrophone();
     };
   }, [
+    acceptIssuesBootstrap,
+    acceptOutputAudioBootstrap,
+    acceptProjectsBootstrap,
+    acceptSettingsBootstrap,
     applyAuthoritativeMode,
     applyPresentation,
     beginEntry,
@@ -1228,7 +1218,6 @@ export function App(): React.JSX.Element {
     startMicrophone,
     stopMicrophone,
     summonAsk,
-    syncIssues,
     modeGenerationOf,
   ]);
 

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1,7 +1,4 @@
 import {
-  type AppGuideSnapshot,
-  ATTENTION_SPEECH_SOURCE,
-  EMPTY_APP_GUIDE,
   FEEDBACK_COMPOSER_KIND,
   type FeedbackComposerKind,
   FIXTURE_EPOCH_MS,
@@ -10,11 +7,9 @@ import {
   type PanelFormFactor,
   type ProviderId,
   REALTIME_STATUS,
-  type RealtimeStatus,
   type RealtimeVoice,
   type RealtimeVoiceSpeed,
   type SessionIdentity,
-  type TrackedIssue,
   VOICE_CAPTION_MAX_HEIGHT,
   type WorkspaceAgentSelection,
 } from "@sidecar/core";
@@ -23,11 +18,9 @@ import type {
   AppBootstrap,
   AppSettings,
   DisplayDiagnostic,
-  MicrophoneStatus,
   OutputAudioState,
   SessionOpenResult,
   SettingsUpdateResult,
-  VoiceHotkeyState,
   WindowMode,
 } from "../shared/contracts";
 import { CREDENTIAL_SOURCE, SESSION_OPEN_RESULT_STATUS } from "../shared/contracts";
@@ -39,13 +32,8 @@ import {
 } from "../shared/credential-providers";
 import type { FeedbackImage, FeedbackKind } from "../shared/feedback";
 import { FEEDBACK_KIND, FEEDBACK_LIMITS, feedbackKindForLifecycleEvent } from "../shared/feedback";
-import {
-  TALK_KEY_RELEASE,
-  talkKeyRelease,
-  voiceHotkeyLabel,
-  voiceHotkeyToShow,
-} from "../shared/voice-hotkey";
-import { ASK_LUKE_INPUT_ID, askRefusal, focusAskField } from "./ask-luke";
+import { voiceHotkeyLabel, voiceHotkeyToShow } from "../shared/voice-hotkey";
+import { ASK_LUKE_INPUT_ID, focusAskField } from "./ask-luke";
 import type { CredentialEntry, CredentialEntryControl } from "./credential-entry";
 import { isSubmittable, removalEndsEntry } from "./credential-entry";
 import {
@@ -80,7 +68,7 @@ import {
   SETTLE_DELAY_MS,
 } from "./panel-state";
 import { PANEL_TAB, type PanelTab } from "./panel-tabs";
-import { type AppActionCarrier, quietIsLukesOwn, RealtimeVoiceSession } from "./realtime-session";
+import type { AppActionCarrier } from "./realtime-session";
 import {
   arrangeSessions,
   DEFAULT_SESSION_VIEW,
@@ -94,7 +82,7 @@ import {
 } from "./session-model";
 import { SESSION_OPTIONS_BUTTON_ID, SESSION_OPTIONS_ID } from "./session-parts";
 import { SETTING_PAGE, SETTINGS_VIEW, type SettingsView } from "./settings-views";
-import { SpokenNoticeAnnouncer } from "./spoken-notices";
+import { useVoiceConversation } from "./use-voice-conversation";
 import {
   outputSilent,
   VOLUME_HINT_HEIGHT,
@@ -102,28 +90,6 @@ import {
   volumeHintDismissed,
   volumeHintText,
 } from "./volume-hint";
-import { WAVEFORM_VOICE } from "./waveform";
-
-/**
- * The backstop for a reply whose ending never arrives.
- *
- * `output_audio_buffer.stopped` is what actually ends a reply now, so this only
- * has to catch a call where that never came. It is long because the thing it
- * must not mistake for an ending is a pause between two sentences: at 700ms it
- * did exactly that, taking the meter and the face down while Luke talked on
- * into the second one.
- */
-const REMOTE_QUIET_MS = 2_500;
-
-/**
- * What the speaking evidence run captions the reply with. A capture run never
- * opens a call, so there are no words to draw unless the fixture supplies
- * them — and it must, or the caption strip ships unphotographed. Synthetic,
- * like every fixture, and long enough to wrap: a one-line fixture would leave
- * the wrapped form of the strip unphotographed too.
- */
-const FIXTURE_SPEAKING_CAPTION =
-  "Claude Code finished checkout-service, and Codex is still migrating the payments schema. Two sessions are waiting on you.";
 
 /**
  * How long the settings tab keeps saying a note to the founders was sent. Long
@@ -305,9 +271,6 @@ export function App(): React.JSX.Element {
   const [sessionView, setSessionView] = useState<SessionView>(DEFAULT_SESSION_VIEW);
   const [optionsOpen, setOptionsOpen] = useState(false);
   const [settings, setSettings] = useState<AppSettings>();
-  const [microphoneStatus, setMicrophoneStatus] = useState<MicrophoneStatus>("not-determined");
-  const [microphoneError, setMicrophoneError] = useState<string>();
-  const [analyser, setAnalyser] = useState<AnalyserNode>();
   const [errand, setErrand] = useState<Errand>();
   const [entry, setEntry] = useState<CredentialEntry>();
   const [feedback, setFeedback] = useState<FeedbackEntry>();
@@ -319,16 +282,6 @@ export function App(): React.JSX.Element {
   const [slotElement, slotHeight] = useShapeHeight();
   const [feedbackElement, feedbackHeight] = useShapeHeight();
   const [captionTextElement, captionTextHeight] = useShapeHeight();
-  const [voiceStatus, setVoiceStatus] = useState<RealtimeStatus>(REALTIME_STATUS.IDLE);
-  /**
-   * A pressed talk key still waiting for the call it asked to open. The meter
-   * is drawn from this rather than from the connection, because the press is
-   * the moment the developer needs answering: the handshake behind it takes
-   * seconds, and a key that visibly does nothing for that long reads as a key
-   * that did nothing.
-   */
-  const [talkOpening, setTalkOpening] = useState(false);
-  const [voiceHotkey, setVoiceHotkey] = useState<VoiceHotkeyState>();
   /**
    * The ask key as last re-taken, superseding bootstrap's once it has changed
    * at all: moving the talk key re-registers every global chord, and the ask
@@ -339,17 +292,6 @@ export function App(): React.JSX.Element {
   const [askHotkeyChange, setAskHotkeyChange] = useState<{ accelerator?: string }>();
   /** The stop key on the ask key's exact terms, for the guide's sake. */
   const [stopHotkeyChange, setStopHotkeyChange] = useState<{ accelerator?: string }>();
-  const [localStream, setLocalStream] = useState<MediaStream>();
-  const [remoteStream, setRemoteStream] = useState<MediaStream>();
-  const [voiceCaption, setVoiceCaption] = useState<string>();
-  /**
-   * Whether the reply under way answers an ask the developer typed. A typed
-   * ask is read, not only heard, so its reply draws the caption whatever the
-   * captions preference says — the preference is about speech being
-   * duplicated, and here the words are the half of the conversation the
-   * developer chose. Cleared the moment the turn moves on.
-   */
-  const [typedAsk, setTypedAsk] = useState(false);
   /**
    * The Mac's output as last read — its mute switch and volume — absent
    * wherever it cannot be read, which is drawn as audible. While it says
@@ -371,7 +313,6 @@ export function App(): React.JSX.Element {
   const [silenceStretch, setSilenceStretch] = useState(0);
   const wasSilent = useRef(false);
   const [hintDismissal, setHintDismissal] = useState<VolumeHintDismissal>();
-  const audioContext = useRef<AudioContext | undefined>(undefined);
   const hoverTimer = useRef<number | undefined>(undefined);
   const presentationRef = useRef<PanelPresentation>(PANEL_PRESENTATION.CAPSULE);
   const tabRef = useRef<PanelTab>(PANEL_TAB.SESSIONS);
@@ -394,55 +335,6 @@ export function App(): React.JSX.Element {
   const spokenFeedbackDraft = useRef<string | undefined>(undefined);
   const pointerInside = useRef(false);
   const modeGeneration = useRef(0);
-  const remoteAudio = useRef<HTMLAudioElement | null>(null);
-  const voiceSession = useRef<RealtimeVoiceSession | undefined>(undefined);
-  const announcer = useRef<SpokenNoticeAnnouncer | undefined>(undefined);
-  const talking = useRef(false);
-  const quietTimer = useRef<number | undefined>(undefined);
-  const voiceStatusRef = useRef<RealtimeStatus>(REALTIME_STATUS.IDLE);
-  /**
-   * Whether Luke has actually been heard during this reply. Committing a turn
-   * swaps the meter from the microphone to Luke, and the meter reports quiet as
-   * it lets go of the old stream — a silence that belongs to the developer, not
-   * to Luke, and one that would otherwise end his turn before he had said
-   * anything.
-   */
-  const heardLuke = useRef(false);
-  const startMicrophoneRef = useRef<(() => Promise<MicrophoneStatus>) | undefined>(undefined);
-  /**
-   * The spoken form of pressing a row, reached through a ref for the same
-   * reason `startMicrophoneRef` is: the voice session is built once, and the
-   * handler it needs is declared later, beside the press it mirrors.
-   */
-  const openSessionAloudRef = useRef<(identity: SessionIdentity) => Promise<SessionOpenResult>>(
-    (identity) => window.sidecar.openSession(identity),
-  );
-  /**
-   * The guide as last built, so a call that connects after the settings have
-   * already resolved still tells the conversation what Luke knows of himself.
-   */
-  const guideRef = useRef<AppGuideSnapshot>(EMPTY_APP_GUIDE);
-  /**
-   * The spoken asks about Luke himself, reached through a ref for the same
-   * reason the session acts are: the voice session is built once, and the
-   * handlers it needs are declared later, beside the presses they mirror.
-   */
-  const carryAppActionRef = useRef<AppActionCarrier>(async () => ({
-    status: "refused",
-    reason: "Luke is still starting up.",
-  }));
-  /** When the talk key went down, which is what tells a hold from a tap. */
-  const talkPressedAt = useRef<number | undefined>(undefined);
-  /** Whether a tap has left a turn open for a later press to end. */
-  const talkLatched = useRef(false);
-  const sessionsRef = useRef<readonly NormalizedSession[]>([]);
-  const workspaceProjectsRef = useRef<readonly ObservedWorkspaceProject[]>([]);
-  /**
-   * The default provider as last pushed beside the projects, for a
-   * conversation that connects later: the two travel as one context, so the
-   * connect-time push has to carry both.
-   */
-  const defaultWorkspaceProviderRef = useRef<string | undefined>(undefined);
   /**
    * Whether a live projects push has arrived. The bootstrap reply resolves
    * whenever the main process gets to it, so a push can land first — and the
@@ -450,16 +342,6 @@ export function App(): React.JSX.Element {
    * process will not repeat a list it believes it already announced.
    */
   const workspaceProjectsPushed = useRef(false);
-  /**
-   * The issue roster as last pushed, for a conversation that connects later.
-   * Never state: no panel surface draws it — it exists to be spoken from.
-   */
-  const issuesRef = useRef<readonly TrackedIssue[] | undefined>(undefined);
-  /**
-   * Whether a live roster push has arrived. The bootstrap reply resolves
-   * whenever the main process gets to it, so a push can land first — and the
-   * bootstrap's older snapshot must then not clobber it.
-   */
   const issuesPushed = useRef(false);
   /**
    * Whether another window's settings change has arrived, under the same rule
@@ -595,145 +477,6 @@ export function App(): React.JSX.Element {
     [applyPresentation],
   );
 
-  const ensureVoiceSession = useCallback((): RealtimeVoiceSession => {
-    voiceSession.current ??= new RealtimeVoiceSession({
-      requestConnection: () => window.sidecar.requestRealtimeCredential(),
-      // The same bridge calls the rows use — the composer, the chips, and the
-      // press that opens a session: a spoken ask is a third way to ask for the
-      // same act, behind the same gauntlet in the main process.
-      carryAction: (action) =>
-        action.kind === "message"
-          ? window.sidecar.sendSessionMessage(action.identity, action.text)
-          : action.kind === "control"
-            ? window.sidecar.executeSessionControl(action.identity, action.control.id)
-            : action.kind === "create-workspace"
-              ? window.sidecar.createSessionWorkspace(
-                  action.providerId,
-                  action.providerProjectId,
-                  action.name,
-                  action.task,
-                  action.agentSelection,
-                )
-              : action.kind === "add-agent"
-                ? window.sidecar.addWorkspaceAgent(
-                    action.identity,
-                    action.agent,
-                    action.name,
-                    action.task,
-                    action.model,
-                    action.effort,
-                  )
-                : openSessionAloudRef.current(action.identity),
-      // The asks about Luke himself — a settings change, the panel shown —
-      // behind the same gauntlet: validated against the guide before this is
-      // called, and performed by the same handlers the panel's controls use.
-      carryAppAction: (action) => carryAppActionRef.current(action),
-      // The issue acts have no rows to share a bridge call with, but the shape
-      // is the same: validated against the roster here, and again in the main
-      // process against what it observed.
-      carryIssueAction: (action) => window.sidecar.executeIssueAction(action),
-      onStatus: setVoiceStatus,
-      onLocalStream: setLocalStream,
-      onRemoteStream: setRemoteStream,
-      onError: setMicrophoneError,
-      onCaption: setVoiceCaption,
-    });
-    return voiceSession.current;
-  }, []);
-
-  /**
-   * The announcer that lets Luke speak into silence: it queues the notices the
-   * main process decided to voice and, when no conversation is open, opens a
-   * speak-only call of Luke's own to say them through — then closes it. Built
-   * beside the session because it drives nothing else.
-   */
-  const ensureAnnouncer = useCallback((): SpokenNoticeAnnouncer => {
-    announcer.current ??= new SpokenNoticeAnnouncer({
-      session: () => ensureVoiceSession(),
-    });
-    return announcer.current;
-  }, [ensureVoiceSession]);
-
-  const stopMicrophone = useCallback(async () => {
-    talking.current = false;
-    await voiceSession.current?.close();
-  }, []);
-
-  /**
-   * Opens the call, answering with what the system said about the microphone —
-   * the one fact a caller that could not send anything needs in order to say
-   * why.
-   */
-  const startMicrophone = useCallback(async (): Promise<MicrophoneStatus> => {
-    setMicrophoneError(undefined);
-    const session = ensureVoiceSession();
-    const permission = await window.sidecar.requestMicrophone();
-    setMicrophoneStatus(permission);
-    if (permission !== "granted") {
-      // The press that asked for this is still waiting for a call that is now
-      // not coming. The status never changes on this path, so the meter the
-      // press put up is taken down here rather than by a status settling.
-      session.dropPendingTurn();
-      setTalkOpening(false);
-      return permission;
-    }
-    if (await session.connect()) {
-      session.updateSessions(sessionsRef.current);
-      session.updateWorkspaceProjects(
-        workspaceProjectsRef.current,
-        defaultWorkspaceProviderRef.current,
-      );
-      session.updateGuide(guideRef.current);
-      session.updateIssues(issuesRef.current);
-    }
-    return permission;
-  }, [ensureVoiceSession]);
-  startMicrophoneRef.current = startMicrophone;
-
-  /**
-   * What the talk key means, wherever it was pressed. A first press has to open
-   * the call before it can open a turn, which is what lets the key work without
-   * the panel ever being visited.
-   */
-  /**
-   * Luke's reply is over when it stops being audible, not when the model stops
-   * producing it. The meter is already measuring the stream, so the quiet it
-   * reports is what ends the turn.
-   */
-  const handleVoiceActivity = useCallback((active: boolean) => {
-    if (voiceStatusRef.current !== REALTIME_STATUS.RESPONDING) return;
-    if (active) {
-      heardLuke.current = true;
-      voiceSession.current?.reportRemoteAudioActive();
-    }
-    if (quietTimer.current !== undefined) {
-      window.clearTimeout(quietTimer.current);
-      quietTimer.current = undefined;
-    }
-    if (active) return;
-    // The meter calls quiet after a fifth of a second, which is shorter than the
-    // pause between two sentences. Ending a turn on that would take the meter
-    // down mid-reply — the very thing this is here to stop — so the turn waits
-    // for a silence longer than speech leaves behind.
-    quietTimer.current = window.setTimeout(() => {
-      quietTimer.current = undefined;
-      // Only Luke's own silence ends Luke's turn.
-      if (!quietIsLukesOwn({ status: voiceStatusRef.current, heardLuke: heardLuke.current })) {
-        return;
-      }
-      voiceSession.current?.reportRemoteAudioIdle();
-    }, REMOTE_QUIET_MS);
-  }, []);
-
-  /**
-   * Asks the system for access and nothing else. Opening a call here would hold
-   * the capture device and light the microphone indicator without anyone having
-   * pressed the talk key, which is not what the row offers.
-   */
-  const requestMicrophoneAccess = useCallback(async () => {
-    setMicrophoneStatus(await window.sidecar.requestMicrophone());
-  }, []);
-
   /**
    * Applies a settings write's reply: the snapshot the store actually holds,
    * and any refusal for the row to show. Every settings row travels this
@@ -759,56 +502,6 @@ export function App(): React.JSX.Element {
       applySettingsReply(await window.sidecar.setSessionNotifications(enabled)),
     [applySettingsReply],
   );
-
-  /**
-   * The talk key going down. Every press goes to the session, including the one
-   * that has no call to press against yet: the microphone opens with the call,
-   * so a press before then is remembered and applied when it comes up.
-   */
-  const beginTalk = useCallback(async () => {
-    talkPressedAt.current = performance.now();
-    // A latched turn is already open. This press is someone saying they are
-    // done, which is the release's to answer.
-    if (talkLatched.current) return;
-    const session = ensureVoiceSession();
-    session.beginTurn();
-    // A press against no call — or against Luke's own speak-only call, which
-    // has no microphone to offer — has seconds of handshake ahead of it, and
-    // the meter has to answer the press, not the handshake.
-    if (!session.microphoneCall) setTalkOpening(true);
-    // The developer's call is up or already coming; the press waits its turn.
-    if (session.microphoneCall) return;
-    // `connect` inside stands Luke's own call down if one is open: the
-    // developer pressing the key always gets the developer's call.
-    await startMicrophoneRef.current?.();
-  }, [ensureVoiceSession]);
-
-  /**
-   * The talk key coming up. How long it was held is the whole of the decision:
-   * held, the turn was as long as the key was down and is sent; tapped, it
-   * stays open for the question too long to hold through, and the next release
-   * sends it.
-   */
-  const endTalk = useCallback(() => {
-    const pressedAt = talkPressedAt.current;
-    talkPressedAt.current = undefined;
-    // A release with nothing before it is not this key's to answer — a turn
-    // ended by Escape leaves the key still down.
-    if (pressedAt === undefined) return;
-    const release = talkKeyRelease({
-      heldMs: performance.now() - pressedAt,
-      latched: talkLatched.current,
-    });
-    if (release === TALK_KEY_RELEASE.LATCH) {
-      talkLatched.current = true;
-      return;
-    }
-    talkLatched.current = false;
-    // A held press let go of before the call opened is dropped, not sent —
-    // nothing was captured to send — and the meter it put up leaves with it.
-    if (voiceSession.current && !voiceSession.current.isConnected) setTalkOpening(false);
-    voiceSession.current?.endTurn(true);
-  }, []);
 
   const cancelHoverTransition = useCallback(() => {
     if (hoverTimer.current === undefined) return;
@@ -1354,67 +1047,6 @@ export function App(): React.JSX.Element {
   );
 
   /**
-   * Carries a changed pace onto the call now open, whichever hand changed it:
-   * the settings row and a spoken ask both land in the stored snapshot, so
-   * watching the snapshot covers them equally. The first snapshot is the
-   * stored value rather than a change, and with no call open there is nothing
-   * to do — the next call is minted at the stored pace.
-   */
-  const heardSpeed = useRef<RealtimeVoiceSpeed | undefined>(undefined);
-  useEffect(() => {
-    const speed = settings?.voiceSpeed;
-    if (speed === undefined) return;
-    const previous = heardSpeed.current;
-    heardSpeed.current = speed;
-    if (previous === undefined || previous === speed) return;
-    voiceSession.current?.applySpeed(speed);
-  }, [settings?.voiceSpeed]);
-
-  /**
-   * Makes a changed voice heard now rather than from the next conversation on.
-   * The API locks a session's voice the moment the model first speaks, so the
-   * one way to change it on a live call is to open a new one. The restart
-   * waits for the turn under way to end — a spoken "change your voice" is
-   * confirmed in the old voice before the new one takes over — and the
-   * conversation starts afresh, because the call is the conversation. A call
-   * that ended on its own owes nothing: the next one is minted in the new
-   * voice already.
-   */
-  const heardVoice = useRef<RealtimeVoice | undefined>(undefined);
-  const voiceRestartDue = useRef(false);
-  useEffect(() => {
-    const voice = settings?.voice;
-    if (!voice) return;
-    const previous = heardVoice.current;
-    heardVoice.current = voice;
-    // A call being opened counts as one to reopen: its credential may already
-    // have been minted in the old voice, and a restart is the only answer the
-    // renderer can be sure of from here.
-    if (
-      previous !== undefined &&
-      previous !== voice &&
-      (voiceSession.current?.isConnected || voiceSession.current?.isConnecting)
-    ) {
-      voiceRestartDue.current = true;
-    }
-    if (!voiceRestartDue.current) return;
-    if (
-      voiceStatus === REALTIME_STATUS.IDLE ||
-      voiceStatus === REALTIME_STATUS.FAILED ||
-      voiceStatus === REALTIME_STATUS.UNAVAILABLE
-    ) {
-      voiceRestartDue.current = false;
-      return;
-    }
-    if (voiceStatus !== REALTIME_STATUS.READY) return;
-    voiceRestartDue.current = false;
-    void (async () => {
-      await voiceSession.current?.close();
-      await startMicrophoneRef.current?.();
-    })();
-  }, [settings?.voice, voiceStatus]);
-
-  /**
    * Moves the talk key, or resets it when no chord is named. The key the row
    * shows is not taken from this reply — the main process announces the one
    * that actually registered, the same way it always has — so the reply
@@ -1491,7 +1123,6 @@ export function App(): React.JSX.Element {
     },
     [cancelHoverTransition, changeMode],
   );
-  openSessionAloudRef.current = openSessionAloud;
 
   /**
    * The ask key, pressed anywhere on the system. The main process has already
@@ -1513,34 +1144,6 @@ export function App(): React.JSX.Element {
     changeTab(PANEL_TAB.SESSIONS);
     focusAskField();
   }, [cancelHoverTransition, changeMode, changeTab]);
-
-  /**
-   * A typed ask to Luke himself. It rides the same call the talk key opens —
-   * permission, connect, then the turn — and opens the same kind of turn:
-   * typing is the developer asking in their own words, so the turn may carry
-   * a tool the way a spoken one may, behind the same roster gauntlet. Answers
-   * with why the ask could not go, or nothing when it did — the reply is
-   * spoken, and its words land under the panel as the answer.
-   */
-  const askLuke = useCallback(
-    async (text: string): Promise<string | undefined> => {
-      const session = ensureVoiceSession();
-      let microphone: MicrophoneStatus = "granted";
-      // Luke's own speak-only call cannot carry a typed ask — it was sent no
-      // roster to validate one against — so it counts as no call here, and
-      // `connect` inside stands it down for the developer's own. A microphone
-      // call still connecting is awaited exactly as before.
-      if (!session.isConnected || !session.microphoneCall) {
-        microphone = (await startMicrophoneRef.current?.()) ?? microphone;
-      }
-      if (session.sendText(text)) {
-        setTypedAsk(true);
-        return undefined;
-      }
-      return askRefusal(session.status, microphone);
-    },
-    [ensureVoiceSession],
-  );
 
   /**
    * The panel standing back down once an errand it stood up is over. The same
@@ -1734,7 +1337,42 @@ export function App(): React.JSX.Element {
     },
     [changeMode, changeTab, settings, settingsView, bootstrap, releaseErrandChange, runErrand],
   );
-  carryAppActionRef.current = carryAppAction;
+
+  const defaultWorkspaceProvider = (settings ?? bootstrap?.settings)?.defaultWorkspaceProvider;
+  const {
+    analyser,
+    microphoneStatus,
+    setMicrophoneStatus,
+    microphoneError,
+    voiceStatus,
+    setVoiceStatus,
+    talkOpening,
+    voiceHotkey,
+    handleVoiceActivity,
+    requestMicrophoneAccess,
+    startMicrophone,
+    stopMicrophone,
+    askLuke,
+    voiceTurn,
+    lukeCaption,
+    remoteAudio,
+    discardListening,
+    stopSpeaking,
+    syncGuide,
+    syncIssues,
+  } = useVoiceConversation({
+    sessions,
+    workspaceProjects,
+    defaultWorkspaceProvider,
+    voice: settings?.voice,
+    voiceSpeed: settings?.voiceSpeed,
+    voiceCaptions: settings?.voiceCaptions === true,
+    outputSilent: outputSilent(outputAudio),
+    fixtureSpeaking: bootstrap?.profile === "speaking" || bootstrap?.profile === "muted",
+    capturingShortcut: () => shortcutCapture.current,
+    openSession: openSessionAloud,
+    carryAppAction,
+  });
 
   /**
    * The two writes a row can ask for, handed to the main process by session
@@ -1804,7 +1442,7 @@ export function App(): React.JSX.Element {
       // older than any change that raced past it, and the main process will
       // not repeat a list it believes it already announced.
       if (!workspaceProjectsPushed.current) setWorkspaceProjects(value.workspaceProjects);
-      if (!issuesPushed.current) issuesRef.current = value.issues;
+      if (!issuesPushed.current) syncIssues(value.issues);
       if (!settingsPushed.current) setSettings(value.settings);
       setDisplay(value.display);
       if (modeGeneration.current === bootstrapGeneration) {
@@ -1882,8 +1520,7 @@ export function App(): React.JSX.Element {
     // surface draws the issue roster, so a re-render would be work for nobody.
     const removeIssues = window.sidecar.onIssuesChanged((issues) => {
       issuesPushed.current = true;
-      issuesRef.current = issues;
-      voiceSession.current?.updateIssues(issues);
+      syncIssues(issues);
     });
     return () => {
       cancelHoverTransition();
@@ -1903,73 +1540,13 @@ export function App(): React.JSX.Element {
     beginFeedback,
     cancelHoverTransition,
     changeTab,
+    setMicrophoneStatus,
+    setVoiceStatus,
     startMicrophone,
     stopMicrophone,
     summonAsk,
+    syncIssues,
   ]);
-
-  // The waveform follows whoever is actually talking: the developer while
-  // push-to-talk is held, Luke while it answers, nobody otherwise.
-  const activeStream =
-    voiceStatus === REALTIME_STATUS.RESPONDING
-      ? remoteStream
-      : voiceStatus === REALTIME_STATUS.LISTENING
-        ? localStream
-        : undefined;
-
-  useEffect(() => {
-    if (!activeStream) {
-      setAnalyser(undefined);
-      return;
-    }
-    const context = audioContext.current ?? new AudioContext({ latencyHint: "interactive" });
-    audioContext.current = context;
-    // A suspended context reads a flatline whatever the microphone hears, and
-    // the talk key is a system shortcut, so no user gesture in this window has
-    // ever vouched for the context. Resuming is a no-op when it is running.
-    if (context.state === "suspended") void context.resume();
-    const source = context.createMediaStreamSource(activeStream);
-    const nextAnalyser = context.createAnalyser();
-    nextAnalyser.fftSize = 256;
-    nextAnalyser.smoothingTimeConstant = 0.82;
-    source.connect(nextAnalyser);
-    setAnalyser(nextAnalyser);
-    return () => {
-      source.disconnect();
-      setAnalyser(undefined);
-    };
-  }, [activeStream]);
-
-  useEffect(() => {
-    voiceStatusRef.current = voiceStatus;
-    // Each reply is heard from scratch, so the previous one cannot vouch for it.
-    if (voiceStatus !== REALTIME_STATUS.RESPONDING) {
-      heardLuke.current = false;
-      // The reply that answered the typed ask is over, so the caption goes
-      // back to being the preference's to grant.
-      setTypedAsk(false);
-    }
-    // Any settled status ends the wait the press started, however it ended:
-    // listening takes the meter live, ready means the turn was dropped
-    // mid-handshake, and a failure has its own message to show. Unless the
-    // press is still owed a turn — a takeover passes through Luke's own call
-    // settling on its way to the developer's, and the meter must ride across.
-    if (voiceStatus !== REALTIME_STATUS.CONNECTING && !voiceSession.current?.turnPending) {
-      setTalkOpening(false);
-    }
-  }, [voiceStatus]);
-
-  // The exchange is live from the press to the end of the reply — the call
-  // coming up, a turn being held, Luke speaking — and the media duck follows
-  // it. Whether anything actually comes down is the main process's question:
-  // it holds the setting, the hangover between turns, and the helper.
-  useEffect(() => {
-    window.sidecar.setVoiceExchangeActive(
-      voiceStatus === REALTIME_STATUS.CONNECTING ||
-        voiceStatus === REALTIME_STATUS.LISTENING ||
-        voiceStatus === REALTIME_STATUS.RESPONDING,
-    );
-  }, [voiceStatus]);
 
   // Silence is counted in stretches — one per unbroken run of muted-or-zero —
   // because that is the unit a "Got it" answers. The edge into silence is the
@@ -1988,33 +1565,6 @@ export function App(): React.JSX.Element {
   const dismissVolumeHint = useCallback(() => {
     setHintDismissal({ at: Date.now(), stretch: silenceStretch });
   }, [silenceStretch]);
-
-  useEffect(() => {
-    const element = remoteAudio.current;
-    if (!element) return;
-    element.srcObject = remoteStream ?? null;
-    if (remoteStream) void element.play().catch(() => undefined);
-  }, [remoteStream]);
-
-  // Keep the conversation's view of the sessions current, so a spoken question
-  // is answered from what Luke actually observes.
-  useEffect(() => {
-    sessionsRef.current = sessions;
-    voiceSession.current?.updateSessions(sessions);
-  }, [sessions]);
-
-  // Keep the conversation's view of where a workspace can be created current,
-  // for the same reason the roster is: a spoken creation ask is validated
-  // against this list, so it has to be the list the adapters actually offer.
-  // The default provider travels with it — where a nameless ask goes is part
-  // of the same answer — resolved the way the guide resolves settings, so a
-  // default saved before this window's own settings arrived still steers.
-  const defaultWorkspaceProvider = (settings ?? bootstrap?.settings)?.defaultWorkspaceProvider;
-  useEffect(() => {
-    workspaceProjectsRef.current = workspaceProjects;
-    defaultWorkspaceProviderRef.current = defaultWorkspaceProvider;
-    voiceSession.current?.updateWorkspaceProjects(workspaceProjects, defaultWorkspaceProvider);
-  }, [workspaceProjects, defaultWorkspaceProvider]);
 
   // Keep the conversation's view of Luke himself current, so a spoken question
   // about a setting is answered from the value the store actually holds, and a
@@ -2038,36 +1588,16 @@ export function App(): React.JSX.Element {
       ...(askAccelerator ? { askKey: voiceHotkeyLabel(askAccelerator) } : {}),
       ...(stopAccelerator ? { stopKey: voiceHotkeyLabel(stopAccelerator) } : {}),
     });
-    guideRef.current = guide;
-    voiceSession.current?.updateGuide(guide);
-  }, [bootstrap, settings, microphoneStatus, voiceHotkey, askHotkeyChange, stopHotkeyChange]);
-
-  useEffect(() => {
-    // Two kinds of sentence share this channel, and their standing differs.
-    // A status-edge notice — deterministic, worded on this machine — goes to
-    // the announcer, which may open a speak-only call of Luke's own to say
-    // it. An evaluator summary is a model's words, so it keeps its original
-    // bound: spoken only on a call the developer opened themselves, and
-    // dropped otherwise. Either way an unvoiced update is not lost: the
-    // session it belongs to still reads as needing attention in the panel
-    // and in the capsule count.
-    return window.sidecar.onAttentionSpeech((speech) => {
-      const notices = speech.filter((item) => item.source === ATTENTION_SPEECH_SOURCE.STATUS_EDGE);
-      if (notices.length > 0) ensureAnnouncer().enqueue(notices);
-      const session = voiceSession.current;
-      if (!session?.microphoneCall) return;
-      for (const item of speech) {
-        if (item.source !== ATTENTION_SPEECH_SOURCE.STATUS_EDGE) session.speak(item);
-      }
-    });
-  }, [ensureAnnouncer]);
-
-  // The announcer paces itself by the session's status: READY is when a queued
-  // sentence can speak and when an empty queue starts the walk toward closing
-  // the call Luke opened for himself.
-  useEffect(() => {
-    announcer.current?.onStatus(voiceStatus);
-  }, [voiceStatus]);
+    syncGuide(guide);
+  }, [
+    bootstrap,
+    settings,
+    microphoneStatus,
+    voiceHotkey,
+    askHotkeyChange,
+    stopHotkeyChange,
+    syncGuide,
+  ]);
 
   useEffect(() => {
     const handleKey = (event: KeyboardEvent) => {
@@ -2087,9 +1617,7 @@ export function App(): React.JSX.Element {
         // The key may still be down. Forgetting the press as well as the latch
         // means its release lands on a turn that is already gone rather than
         // sending the one Escape just discarded.
-        talkLatched.current = false;
-        talkPressedAt.current = undefined;
-        voiceSession.current?.stopListening(false);
+        discardListening();
         return;
       }
       // Stopping Luke mid-sentence is the same shape one layer on: a reply
@@ -2098,7 +1626,7 @@ export function App(): React.JSX.Element {
       // whether there was a reply to stop, so a press that found none falls
       // through to the layers below rather than being swallowed by a reply
       // that had already ended.
-      if (voiceSession.current?.stopSpeaking()) return;
+      if (stopSpeaking()) return;
       // Escape out of the slot is the entry's own way out, wherever the caret
       // happens to be: the slot is the only thing on screen, so there is nothing
       // else it could mean.
@@ -2130,46 +1658,20 @@ export function App(): React.JSX.Element {
     changeMode,
     changeTab,
     dismissFeedback,
+    discardListening,
     optionsOpen,
     presentation,
     settingsView,
+    stopSpeaking,
     tab,
     voiceStatus,
   ]);
 
-  // The talk key is registered by the main process so it answers from any app,
-  // which is the whole point: no window to find, nothing to focus first. Both
-  // edges arrive, because a turn you hold ends when the key does. Only the
-  // press defers to a chord being recorded: the release always lands, so a
-  // hold opened before the recording began still ends when the key comes up
-  // rather than leaving the microphone open under the field — and a release
-  // whose press was held back finds nothing pressed and answers nothing.
-  useEffect(
-    () =>
-      window.sidecar.onVoiceHotkeyPress(() => {
-        if (!shortcutCapture.current) void beginTalk();
-      }),
-    [beginTalk],
-  );
-  useEffect(() => window.sidecar.onVoiceHotkeyRelease(endTalk), [endTalk]);
-  useEffect(() => window.sidecar.onVoiceHotkeyChanged(setVoiceHotkey), []);
   useEffect(
     () =>
       window.sidecar.onAskHotkeyChanged((accelerator) =>
         setAskHotkeyChange(accelerator ? { accelerator } : {}),
       ),
-    [],
-  );
-  // The stop key asks for quiet from any app, exactly as Escape asks for it
-  // from the panel: the session itself answers whether there is a reply to
-  // stop, so a press over silence simply does nothing. It defers to a chord
-  // being recorded on the talk key's terms — the keystroke there is an answer
-  // to the field, not an ask of Luke.
-  useEffect(
-    () =>
-      window.sidecar.onStopHotkeyPress(() => {
-        if (!shortcutCapture.current) voiceSession.current?.stopSpeaking();
-      }),
     [],
   );
   useEffect(
@@ -2243,14 +1745,6 @@ export function App(): React.JSX.Element {
   // measured back from the fixture's own epoch precisely so that no capture
   // run reads them against the time it happened to run at.
   const now = bootstrap.fixtureMode ? FIXTURE_EPOCH_MS : Date.now();
-  // Read once: the stage grows for it and the wings draw it, and two readings
-  // of the same status could disagree by a frame.
-  const voiceTurn =
-    voiceStatus === REALTIME_STATUS.RESPONDING
-      ? WAVEFORM_VOICE.LUKE
-      : voiceStatus === REALTIME_STATUS.LISTENING
-        ? WAVEFORM_VOICE.DEVELOPER
-        : undefined;
   const shownHotkey = voiceHotkeyToShow(bootstrap, voiceHotkey);
   const shownAskHotkey = askHotkeyChange ? askHotkeyChange.accelerator : bootstrap.askHotkey;
   const shownStopHotkey = stopHotkeyChange ? stopHotkeyChange.accelerator : bootstrap.stopHotkey;
@@ -2260,21 +1754,6 @@ export function App(): React.JSX.Element {
   const fixtureSpeaking = bootstrap.profile === "speaking" || fixtureMuted;
   const hasAudioSignal = fixtureSpeaking || analyser !== undefined;
   const outputIsSilent = outputSilent(outputAudio);
-  // Luke's words, drawn only when there is a reason to read them and the reply
-  // they belong to is his turn: the captions preference, the reply answering
-  // an ask the developer typed — a typed conversation's answer must be
-  // readable whatever the preference says — or an output that would swallow
-  // the reply, where the words are the only part of Luke arriving at all. The
-  // session already clears the words when a reply ends or is cut off, and the
-  // turn gate keeps a caption that raced a status change from being drawn
-  // late. A capture run draws the fixture's words regardless, or the strip
-  // ships unphotographed.
-  const lukeCaption = fixtureSpeaking
-    ? FIXTURE_SPEAKING_CAPTION
-    : (settings?.voiceCaptions === true || typedAsk || outputIsSilent) &&
-        voiceTurn === WAVEFORM_VOICE.LUKE
-      ? voiceCaption
-      : undefined;
   // The hint rides the caption it explains, and only over a silence the
   // helper actually reported. "Got it" quiets it for this stretch of silence
   // and any that follows too soon; the captions above it stay either way.

--- a/apps/desktop/src/renderer/use-bootstrap-raced-channel.ts
+++ b/apps/desktop/src/renderer/use-bootstrap-raced-channel.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * Whether a bootstrap snapshot is still the newest word. A live push that
+ * arrived while the reply was in flight is newer, and the main process will
+ * not repeat a list it believes it already announced.
+ */
+export function staleBootstrap(pushed: boolean): boolean {
+  return pushed;
+}
+
+/**
+ * A channel whose live pushes beat a bootstrap snapshot still in flight.
+ * Subscribe once; apply a bootstrap value only if nothing newer has landed.
+ */
+export function useBootstrapRacedChannel<T>(
+  subscribe: (onChange: (value: T) => void) => () => void,
+  apply: (value: T) => void,
+): (bootstrapValue: T) => void {
+  const pushed = useRef(false);
+  const applyRef = useRef(apply);
+  applyRef.current = apply;
+  const subscribeRef = useRef(subscribe);
+  subscribeRef.current = subscribe;
+
+  useEffect(
+    () =>
+      subscribeRef.current((value) => {
+        pushed.current = true;
+        applyRef.current(value);
+      }),
+    [],
+  );
+
+  return useCallback((bootstrapValue: T) => {
+    if (staleBootstrap(pushed.current)) return;
+    applyRef.current(bootstrapValue);
+  }, []);
+}

--- a/apps/desktop/src/renderer/use-panel-entry.ts
+++ b/apps/desktop/src/renderer/use-panel-entry.ts
@@ -1,0 +1,242 @@
+import { useCallback, useRef, useState } from "react";
+import type { PanelPresentation } from "./panel-state";
+
+/**
+ * What every composer this hook can drive has to say. Busy is the in-flight
+ * bit: a reply on its way back is answering that object, so nothing may
+ * replace it underneath but ending it outright. A rejection is the last
+ * send's reason, cleared by typing again.
+ */
+export interface PanelEntryBase {
+  busy: boolean;
+  rejection?: string;
+}
+
+/** Where giving up from the aside shape goes. */
+export const PANEL_ENTRY_CANCEL = {
+  /** The composer was not the drawn shape, so nothing to put away. */
+  NONE: "none",
+  /** Return to the panel this was opened from. */
+  RESTORE: "restore",
+  /** Leave entirely — the tray, a browser, nothing of Luke's. */
+  LEAVE: "leave",
+} as const;
+
+export type PanelEntryCancel = (typeof PANEL_ENTRY_CANCEL)[keyof typeof PANEL_ENTRY_CANCEL];
+
+/** What a send's reply means for the entry that is still on screen. */
+export const PANEL_ENTRY_REPLY = {
+  /** The entry that was sent is gone; the reply is spent. */
+  IGNORE: "ignore",
+  /** Still that entry, and the send was refused. */
+  REJECT: "reject",
+  /** Still that entry, and the send landed. */
+  DELIVER: "deliver",
+} as const;
+
+export type PanelEntryReply = (typeof PANEL_ENTRY_REPLY)[keyof typeof PANEL_ENTRY_REPLY];
+
+/**
+ * Whether ending an entry released the hold it had on the panel. An entry
+ * that ends while the pointer is already away would otherwise leave the
+ * panel held open by nothing, because the pointer cannot leave a second time.
+ */
+export function panelEntryReleased<T>(previous: T | undefined, next: T | undefined): boolean {
+  return previous !== undefined && next === undefined;
+}
+
+/**
+ * Whether the entry is open to being changed: something is held, and no reply
+ * is on its way back answering it.
+ */
+export function panelEntryOpen<T extends PanelEntryBase>(
+  entry: T | undefined,
+): entry is T & { busy: false } {
+  return entry !== undefined && !entry.busy;
+}
+
+/**
+ * Where cancel goes. Giving up from the aside shape returns you where you
+ * were; giving up from inside the panel has nothing to put away.
+ */
+export function panelEntryCancel(input: { aside: boolean; restore: boolean }): PanelEntryCancel {
+  if (!input.aside) return PANEL_ENTRY_CANCEL.NONE;
+  return input.restore ? PANEL_ENTRY_CANCEL.RESTORE : PANEL_ENTRY_CANCEL.LEAVE;
+}
+
+/**
+ * What a send's reply does. Whoever is writing now is not necessarily whoever
+ * sent this one: Escape reaches the shape while a save is in flight, and so
+ * does beginning again. A reply that outlived its own entry is spent.
+ */
+export function panelEntryReply(input: {
+  stillHeld: boolean;
+  rejection?: string;
+}): PanelEntryReply {
+  if (!input.stillHeld) return PANEL_ENTRY_REPLY.IGNORE;
+  return input.rejection ? PANEL_ENTRY_REPLY.REJECT : PANEL_ENTRY_REPLY.DELIVER;
+}
+
+/**
+ * Whether a delivered send should show its answer and then take its leave.
+ * Saved from the aside shape, the panel comes back around what was just done;
+ * with the pointer away, nothing else would ever ask it to close.
+ */
+export function panelEntrySettles(input: { aside: boolean; pointerInside: boolean }): boolean {
+  return input.aside && !input.pointerInside;
+}
+
+export interface PanelEntryHost {
+  /**
+   * The shape this composer stands the panel down to — the slot, or the
+   * feedback surface. Asking to write one thing is asking for one shape.
+   */
+  aside: PanelPresentation;
+  pointerInside: () => boolean;
+  presentation: () => PanelPresentation;
+  /**
+   * Called when an entry ends while the pointer is already away, so the hold
+   * it had on the panel is released. The pointer cannot leave a second time.
+   */
+  onReleasedWhileAway: () => void;
+  cancelHover: () => void;
+  applyPresentation: (next: PanelPresentation) => void;
+  restorePanel: () => void;
+  leave: () => void;
+  /**
+   * Show the answer, then take the panel's leave — the pointer is usually
+   * still on the button that was pressed, and where it is not, nothing else
+   * would ever ask this panel to close.
+   */
+  settle: () => void;
+  /**
+   * Mirror of whether an entry is held, read by the presentation cluster
+   * without waiting a render: a capsule close keeps the settings tab for a
+   * half-written key or note, and nothing else.
+   */
+  heldRef: { current: boolean };
+}
+
+export interface UsePanelEntryOptions<T extends PanelEntryBase> extends PanelEntryHost {
+  /**
+   * Whether giving up from the aside shape returns to the panel. A key page
+   * that was opened, or a composer asked for from the tray, leaves instead.
+   */
+  restoresPanel: (entry: T) => boolean;
+  isSendable: (entry: T | undefined) => entry is T;
+  send: (entry: T) => Promise<{ rejection?: string }>;
+  /** After a send lands, before the panel is restored — the "Sent" line. */
+  onDelivered?: () => void;
+}
+
+export interface PanelEntry<T extends PanelEntryBase> {
+  entry: T | undefined;
+  latest: () => T | undefined;
+  apply: (next: T | undefined) => void;
+  /** Stands the panel down to the aside shape, with this as what it holds. */
+  begin: (next: T) => void;
+  /** Stands the panel down without replacing what is held. */
+  standDown: () => void;
+  patch: (partial: Partial<T>) => void;
+  cancel: () => void;
+  commit: () => void;
+}
+
+/**
+ * One composer lifecycle: begin, type, send, give up. A credential's slot and
+ * a note to the founders are the same hold on the panel, parameterized by the
+ * shape they stand down to, whether giving up restores the panel, what is
+ * worth sending, and how a send is carried.
+ */
+export function usePanelEntry<T extends PanelEntryBase>(
+  options: UsePanelEntryOptions<T>,
+): PanelEntry<T> {
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const [entry, setEntry] = useState<T>();
+  const entryRef = useRef<T | undefined>(undefined);
+
+  const apply = useCallback((next: T | undefined) => {
+    const host = optionsRef.current;
+    const released = panelEntryReleased(entryRef.current, next);
+    entryRef.current = next;
+    host.heldRef.current = next !== undefined;
+    setEntry(next);
+    if (released && !host.pointerInside()) host.onReleasedWhileAway();
+  }, []);
+
+  const standDown = useCallback(() => {
+    const host = optionsRef.current;
+    host.cancelHover();
+    host.applyPresentation(host.aside);
+  }, []);
+
+  const begin = useCallback(
+    (next: T) => {
+      apply(next);
+      standDown();
+    },
+    [apply, standDown],
+  );
+
+  const patch = useCallback(
+    (partial: Partial<T>) => {
+      const current = entryRef.current;
+      if (!panelEntryOpen(current)) return;
+      apply({ ...current, ...partial, rejection: undefined });
+    },
+    [apply],
+  );
+
+  const cancel = useCallback(() => {
+    const host = optionsRef.current;
+    const current = entryRef.current;
+    const destination = panelEntryCancel({
+      aside: host.presentation() === host.aside,
+      restore: current !== undefined && host.restoresPanel(current),
+    });
+    apply(undefined);
+    if (destination === PANEL_ENTRY_CANCEL.RESTORE) host.restorePanel();
+    else if (destination === PANEL_ENTRY_CANCEL.LEAVE) host.leave();
+  }, [apply]);
+
+  const commit = useCallback(() => {
+    const host = optionsRef.current;
+    const current = entryRef.current;
+    if (!host.isSendable(current)) return;
+    const sending = { ...current, busy: true, rejection: undefined };
+    apply(sending);
+    void host.send(sending).then((result) => {
+      const reply = panelEntryReply({
+        stillHeld: entryRef.current === sending,
+        ...(result.rejection ? { rejection: result.rejection } : {}),
+      });
+      if (reply === PANEL_ENTRY_REPLY.IGNORE) return;
+      if (reply === PANEL_ENTRY_REPLY.REJECT) {
+        apply({ ...sending, busy: false, rejection: result.rejection });
+        return;
+      }
+      apply(undefined);
+      host.onDelivered?.();
+      if (host.presentation() !== host.aside) return;
+      host.restorePanel();
+      if (!panelEntrySettles({ aside: true, pointerInside: host.pointerInside() })) return;
+      host.cancelHover();
+      host.settle();
+    });
+  }, [apply]);
+
+  const latest = useCallback(() => entryRef.current, []);
+
+  return {
+    entry,
+    latest,
+    apply,
+    begin,
+    standDown,
+    patch,
+    cancel,
+    commit,
+  };
+}

--- a/apps/desktop/src/renderer/use-panel-entry.ts
+++ b/apps/desktop/src/renderer/use-panel-entry.ts
@@ -1,5 +1,6 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useRef } from "react";
 import type { PanelPresentation } from "./panel-state";
+import { useStateWithRef } from "./use-state-with-ref";
 
 /**
  * What every composer this hook can drive has to say. Busy is the in-flight
@@ -154,17 +155,18 @@ export function usePanelEntry<T extends PanelEntryBase>(
   const optionsRef = useRef(options);
   optionsRef.current = options;
 
-  const [entry, setEntry] = useState<T>();
-  const entryRef = useRef<T | undefined>(undefined);
+  const [entry, setEntry, latest] = useStateWithRef<T | undefined>(undefined);
 
-  const apply = useCallback((next: T | undefined) => {
-    const host = optionsRef.current;
-    const released = panelEntryReleased(entryRef.current, next);
-    entryRef.current = next;
-    host.heldRef.current = next !== undefined;
-    setEntry(next);
-    if (released && !host.pointerInside()) host.onReleasedWhileAway();
-  }, []);
+  const apply = useCallback(
+    (next: T | undefined) => {
+      const host = optionsRef.current;
+      const released = panelEntryReleased(latest(), next);
+      setEntry(next);
+      host.heldRef.current = next !== undefined;
+      if (released && !host.pointerInside()) host.onReleasedWhileAway();
+    },
+    [latest, setEntry],
+  );
 
   const standDown = useCallback(() => {
     const host = optionsRef.current;
@@ -182,16 +184,16 @@ export function usePanelEntry<T extends PanelEntryBase>(
 
   const patch = useCallback(
     (partial: Partial<T>) => {
-      const current = entryRef.current;
+      const current = latest();
       if (!panelEntryOpen(current)) return;
       apply({ ...current, ...partial, rejection: undefined });
     },
-    [apply],
+    [apply, latest],
   );
 
   const cancel = useCallback(() => {
     const host = optionsRef.current;
-    const current = entryRef.current;
+    const current = latest();
     const destination = panelEntryCancel({
       aside: host.presentation() === host.aside,
       restore: current !== undefined && host.restoresPanel(current),
@@ -199,17 +201,17 @@ export function usePanelEntry<T extends PanelEntryBase>(
     apply(undefined);
     if (destination === PANEL_ENTRY_CANCEL.RESTORE) host.restorePanel();
     else if (destination === PANEL_ENTRY_CANCEL.LEAVE) host.leave();
-  }, [apply]);
+  }, [apply, latest]);
 
   const commit = useCallback(() => {
     const host = optionsRef.current;
-    const current = entryRef.current;
+    const current = latest();
     if (!host.isSendable(current)) return;
     const sending = { ...current, busy: true, rejection: undefined };
     apply(sending);
     void host.send(sending).then((result) => {
       const reply = panelEntryReply({
-        stillHeld: entryRef.current === sending,
+        stillHeld: latest() === sending,
         ...(result.rejection ? { rejection: result.rejection } : {}),
       });
       if (reply === PANEL_ENTRY_REPLY.IGNORE) return;
@@ -225,9 +227,7 @@ export function usePanelEntry<T extends PanelEntryBase>(
       host.cancelHover();
       host.settle();
     });
-  }, [apply]);
-
-  const latest = useCallback(() => entryRef.current, []);
+  }, [apply, latest]);
 
   return {
     entry,

--- a/apps/desktop/src/renderer/use-panel-presentation.ts
+++ b/apps/desktop/src/renderer/use-panel-presentation.ts
@@ -1,0 +1,357 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { WindowMode } from "../shared/contracts";
+import {
+  HIT_REGION,
+  HIT_REGION_ATTRIBUTE,
+  LEAVE_DELAY_MS,
+  PANEL_PRESENTATION,
+  type PanelPresentation,
+  PEEK_ENTER_DELAY_MS,
+  presentationForMode,
+  SETTLE_DELAY_MS,
+} from "./panel-state";
+
+/**
+ * Whether a pointer leave should schedule a close. The slot and the composer
+ * stay put — someone is in the middle of writing, often in a browser — and a
+ * key or ask being typed holds the panel the same way.
+ */
+export function pointerLeaveSchedules(input: {
+  presentation: PanelPresentation;
+  hold: boolean;
+}): boolean {
+  if (input.presentation === PANEL_PRESENTATION.CAPSULE) return false;
+  if (input.presentation === PANEL_PRESENTATION.SLOT) return false;
+  if (input.presentation === PANEL_PRESENTATION.FEEDBACK) return false;
+  if (input.presentation === PANEL_PRESENTATION.PANEL && input.hold) return false;
+  return true;
+}
+
+/** What the leave timer does when it fires, reading the shape as it is now. */
+export const POINTER_LEAVE_FIRE = {
+  IGNORE: "ignore",
+  CAPSULE: "capsule",
+  COLLAPSE: "collapse",
+} as const;
+
+export type PointerLeaveFire = (typeof POINTER_LEAVE_FIRE)[keyof typeof POINTER_LEAVE_FIRE];
+
+export function pointerLeaveFires(input: {
+  presentation: PanelPresentation;
+  hold: boolean;
+}): PointerLeaveFire {
+  if (input.presentation === PANEL_PRESENTATION.PEEK) return POINTER_LEAVE_FIRE.CAPSULE;
+  if (input.presentation === PANEL_PRESENTATION.PANEL) {
+    return input.hold ? POINTER_LEAVE_FIRE.IGNORE : POINTER_LEAVE_FIRE.COLLAPSE;
+  }
+  return POINTER_LEAVE_FIRE.IGNORE;
+}
+
+/** Hovering the capsule peeks; any other shape is already answering the pointer. */
+export function pointerEnterPeeks(presentation: PanelPresentation): boolean {
+  return presentation === PANEL_PRESENTATION.CAPSULE;
+}
+
+/**
+ * Whether closing to the capsule keeps the settings tab. A half-written key
+ * or note is what someone is in the middle of; the list is not.
+ */
+export function capsuleKeepsTab(composerHeld: boolean): boolean {
+  return composerHeld;
+}
+
+/**
+ * Letting go of the ask field while the pointer is already away has to
+ * release the hold the caret had — the pointer cannot leave a second time.
+ */
+export function askDisengageLeaves(input: {
+  wasEngaged: boolean;
+  engaged: boolean;
+  pointerInside: boolean;
+}): boolean {
+  return input.wasEngaged && !input.engaged && !input.pointerInside;
+}
+
+function usePointerPassthrough(
+  onHitRegionEnter: () => void,
+  onHitRegionLeave: () => void,
+  presentation: PanelPresentation,
+): void {
+  const lastValue = useRef<boolean | undefined>(undefined);
+  const lastPoint = useRef<{ x: number; y: number } | undefined>(undefined);
+
+  const update = useCallback(
+    (interceptsPointer: boolean) => {
+      if (lastValue.current === interceptsPointer) return;
+      lastValue.current = interceptsPointer;
+      window.sidecar.setPointerInterception(interceptsPointer);
+      if (interceptsPointer) onHitRegionEnter();
+      else onHitRegionLeave();
+    },
+    [onHitRegionEnter, onHitRegionLeave],
+  );
+
+  const testLastPoint = useCallback(
+    (drawn: PanelPresentation) => {
+      const point = lastPoint.current;
+      if (!point) return;
+      // `elementFromPoint` answers null for a point outside the viewport, which a
+      // forwarded move can carry. Comparing that against null read as "still
+      // inside", so leaving by the edge left the panel open until some other
+      // event closed it.
+      const region = document
+        .elementFromPoint(point.x, point.y)
+        ?.closest(`[${HIT_REGION_ATTRIBUTE}]`);
+      const kind = region?.getAttribute(HIT_REGION_ATTRIBUTE);
+      // The shape takes the pointer wherever it is drawn, which is the whole
+      // rule: the capsule strip and the panel's body are what sit on top of it
+      // and answer first. The surface is what answers in between — the panel's
+      // body is not a target for the first `--expand-delay` of an opening, and
+      // by then the strip has already narrowed from the peek's width back to
+      // the capsule's, so a press out where the marks unfold would otherwise
+      // land on nothing and read as the pointer leaving.
+      update(
+        kind === HIT_REGION.SURFACE ||
+          kind === HIT_REGION.CAPSULE ||
+          (kind === HIT_REGION.PANEL && drawn === PANEL_PRESENTATION.PANEL) ||
+          (kind === HIT_REGION.SLOT && drawn === PANEL_PRESENTATION.SLOT) ||
+          (kind === HIT_REGION.FEEDBACK && drawn === PANEL_PRESENTATION.FEEDBACK),
+      );
+    },
+    [update],
+  );
+
+  useEffect(() => {
+    const handleMove = (event: MouseEvent) => {
+      lastPoint.current = { x: event.clientX, y: event.clientY };
+      testLastPoint(presentation);
+    };
+    const handleLeave = () => {
+      lastPoint.current = undefined;
+      update(false);
+    };
+    window.addEventListener("mousemove", handleMove, { passive: true });
+    document.documentElement.addEventListener("mouseleave", handleLeave);
+    return () => {
+      window.removeEventListener("mousemove", handleMove);
+      document.documentElement.removeEventListener("mouseleave", handleLeave);
+    };
+  }, [presentation, testLastPoint, update]);
+
+  // The shape can change under a pointer that never moves — Escape closes the
+  // panel, and the tray opens it — and what the pointer is over changes with it.
+  // Without this the window keeps intercepting clicks for a shape that is no
+  // longer drawn, and the window is always larger than the shape.
+  useEffect(() => {
+    testLastPoint(presentation);
+  }, [presentation, testLastPoint]);
+}
+
+export interface PanelPresentationOptions {
+  /**
+   * A credential still on the settings tab, which holds the panel open against
+   * the pointer the way the ask field does.
+   */
+  entryDrawn: () => boolean;
+  /** A key or note being written, which keeps the settings tab through a close. */
+  composerHeld: () => boolean;
+  /** The sheet is only ever drawn inside the panel. */
+  onNotPanel: () => void;
+  /** Closing to the capsule resets the list: a filter is not something anyone is in the middle of. */
+  onCapsuleList: () => void;
+  /** And the tab, unless a composer is what they were in the middle of. */
+  onCapsuleTab: () => void;
+}
+
+export interface PanelPresentationApi {
+  presentation: PanelPresentation;
+  current: () => PanelPresentation;
+  generation: () => number;
+  pointerInside: () => boolean;
+  heldAgainstPointer: () => boolean;
+  applyPresentation: (next: PanelPresentation) => void;
+  applyAuthoritativeMode: (mode: WindowMode) => void;
+  changeMode: (expanded: boolean) => Promise<void>;
+  cancelHover: () => void;
+  onHitRegionLeave: () => void;
+  changeAskEngagement: (engaged: boolean) => void;
+  settle: () => void;
+  leave: () => void;
+  expand: () => void;
+}
+
+/**
+ * The surface's shape, and the pointer's hold on it. Hovering peeks, leaving
+ * closes, and a field someone is part-way through holds the panel the way a
+ * hand on the shape does.
+ */
+export function usePanelPresentation(options: PanelPresentationOptions): PanelPresentationApi {
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const [presentation, setPresentation] = useState<PanelPresentation>(PANEL_PRESENTATION.CAPSULE);
+  const presentationRef = useRef<PanelPresentation>(PANEL_PRESENTATION.CAPSULE);
+  const hoverTimer = useRef<number | undefined>(undefined);
+  const pointerInside = useRef(false);
+  const modeGeneration = useRef(0);
+  const askEngaged = useRef(false);
+
+  const heldAgainstPointer = useCallback(
+    () => optionsRef.current.entryDrawn() || askEngaged.current,
+    [],
+  );
+
+  const cancelHover = useCallback(() => {
+    if (hoverTimer.current === undefined) return;
+    window.clearTimeout(hoverTimer.current);
+    hoverTimer.current = undefined;
+  }, []);
+
+  const applyPresentation = useCallback((next: PanelPresentation) => {
+    presentationRef.current = next;
+    setPresentation(next);
+    const host = optionsRef.current;
+    // The sheet is only ever drawn inside the panel, so any other shape puts
+    // it away. Left set behind a shape that cannot draw it, it would be over
+    // the list again the next time the panel came forward with nothing having
+    // been pressed — and a key half-entered is the one thing that survives a
+    // close, which the sheet is not.
+    if (next !== PANEL_PRESENTATION.PANEL) host.onNotPanel();
+    // A panel that has closed reopens on the session list, showing every
+    // session with whatever needs a person first: settings are somewhere you
+    // go, not a state the capsule remembers, and a filter left in place would
+    // let the panel hide a session the capsule is still counting.
+    //
+    // Something half-written is the one exception, and only to the tab — a
+    // key being entered or a note to the founders alike: it is what someone
+    // is in the middle of, so however the panel closed, it opens again where
+    // they left it. The list is not something anyone is in the middle of, so
+    // it resets either way.
+    if (next === PANEL_PRESENTATION.CAPSULE) {
+      host.onCapsuleList();
+      if (!capsuleKeepsTab(host.composerHeld())) host.onCapsuleTab();
+    }
+  }, []);
+
+  const applyAuthoritativeMode = useCallback(
+    (nextMode: WindowMode) => {
+      // A lifecycle notification can originate outside this renderer (for
+      // example from the tray). Ignore an older IPC result that arrives later.
+      modeGeneration.current += 1;
+      applyPresentation(presentationForMode(nextMode));
+    },
+    [applyPresentation],
+  );
+
+  /**
+   * Only the panel needs the main process. The capsule and the peek share a
+   * window, so hovering never leaves the renderer — which is what lets the peek
+   * answer the pointer immediately.
+   */
+  const changeMode = useCallback(
+    async (expanded: boolean) => {
+      const previous = presentationRef.current;
+      const generation = modeGeneration.current + 1;
+      modeGeneration.current = generation;
+      presentationRef.current = expanded ? PANEL_PRESENTATION.PANEL : PANEL_PRESENTATION.CAPSULE;
+      try {
+        // Asking for focus is what makes Escape reach the panel someone opened.
+        const confirmedMode = await window.sidecar.setExpanded(expanded, expanded);
+        if (modeGeneration.current === generation) {
+          applyPresentation(presentationForMode(confirmedMode));
+        }
+      } catch (error) {
+        if (modeGeneration.current === generation) presentationRef.current = previous;
+        throw error;
+      }
+    },
+    [applyPresentation],
+  );
+
+  const onHitRegionEnter = useCallback(() => {
+    cancelHover();
+    pointerInside.current = true;
+    if (!pointerEnterPeeks(presentationRef.current)) return;
+    hoverTimer.current = window.setTimeout(() => {
+      hoverTimer.current = undefined;
+      if (presentationRef.current === PANEL_PRESENTATION.CAPSULE) {
+        applyPresentation(PANEL_PRESENTATION.PEEK);
+      }
+    }, PEEK_ENTER_DELAY_MS);
+  }, [applyPresentation, cancelHover]);
+
+  const onHitRegionLeave = useCallback(() => {
+    cancelHover();
+    pointerInside.current = false;
+    if (
+      !pointerLeaveSchedules({
+        presentation: presentationRef.current,
+        hold: heldAgainstPointer(),
+      })
+    ) {
+      return;
+    }
+    hoverTimer.current = window.setTimeout(() => {
+      hoverTimer.current = undefined;
+      const fire = pointerLeaveFires({
+        presentation: presentationRef.current,
+        hold: heldAgainstPointer(),
+      });
+      if (fire === POINTER_LEAVE_FIRE.CAPSULE) applyPresentation(PANEL_PRESENTATION.CAPSULE);
+      else if (fire === POINTER_LEAVE_FIRE.COLLAPSE) void changeMode(false);
+    }, LEAVE_DELAY_MS);
+  }, [applyPresentation, cancelHover, changeMode, heldAgainstPointer]);
+
+  const changeAskEngagement = useCallback(
+    (engaged: boolean) => {
+      const leave = askDisengageLeaves({
+        wasEngaged: askEngaged.current,
+        engaged,
+        pointerInside: pointerInside.current,
+      });
+      askEngaged.current = engaged;
+      if (leave) onHitRegionLeave();
+    },
+    [onHitRegionLeave],
+  );
+
+  const settle = useCallback(() => {
+    hoverTimer.current = window.setTimeout(() => {
+      hoverTimer.current = undefined;
+      if (presentationRef.current === PANEL_PRESENTATION.PANEL) void changeMode(false);
+    }, SETTLE_DELAY_MS);
+  }, [changeMode]);
+
+  const leave = useCallback(() => {
+    void changeMode(false);
+  }, [changeMode]);
+
+  const expand = useCallback(() => {
+    void changeMode(true);
+  }, [changeMode]);
+
+  const presentationOf = useCallback(() => presentationRef.current, []);
+  const modeGenerationOf = useCallback(() => modeGeneration.current, []);
+  const pointerIsInside = useCallback(() => pointerInside.current, []);
+
+  usePointerPassthrough(onHitRegionEnter, onHitRegionLeave, presentation);
+
+  useEffect(() => () => cancelHover(), [cancelHover]);
+
+  return {
+    presentation,
+    current: presentationOf,
+    generation: modeGenerationOf,
+    pointerInside: pointerIsInside,
+    heldAgainstPointer,
+    applyPresentation,
+    applyAuthoritativeMode,
+    changeMode,
+    cancelHover,
+    onHitRegionLeave,
+    changeAskEngagement,
+    settle,
+    leave,
+    expand,
+  };
+}

--- a/apps/desktop/src/renderer/use-state-with-ref.ts
+++ b/apps/desktop/src/renderer/use-state-with-ref.ts
@@ -1,0 +1,25 @@
+import { useCallback, useRef, useState } from "react";
+
+/**
+ * Keep a ref in lockstep with the value a setter is about to publish, so a
+ * callback can read it before the next render. A close decided inside a timer
+ * has to see the field that was just opened, not the shape last drawn.
+ */
+export function shadowRef<T>(ref: { current: T }, next: T): T {
+  ref.current = next;
+  return next;
+}
+
+/**
+ * State whose latest value is needed from a callback that cannot wait a
+ * render. The setter writes a ref in the same turn; `latest` reads it.
+ */
+export function useStateWithRef<T>(initial: T): [T, (next: T) => void, () => T] {
+  const [state, setState] = useState(initial);
+  const ref = useRef(initial);
+  const set = useCallback((next: T) => {
+    setState(shadowRef(ref, next));
+  }, []);
+  const latest = useCallback(() => ref.current, []);
+  return [state, set, latest];
+}

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -18,6 +18,7 @@ import { TALK_KEY_RELEASE, talkKeyRelease } from "../shared/voice-hotkey";
 import { askRefusal } from "./ask-luke";
 import { type AppActionCarrier, quietIsLukesOwn, RealtimeVoiceSession } from "./realtime-session";
 import { SpokenNoticeAnnouncer } from "./spoken-notices";
+import { useStateWithRef } from "./use-state-with-ref";
 import { WAVEFORM_VOICE, type WaveformVoice } from "./waveform";
 
 /**
@@ -277,7 +278,9 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   const [analyser, setAnalyser] = useState<AnalyserNode>();
   const [microphoneStatus, setMicrophoneStatus] = useState<MicrophoneStatus>("not-determined");
   const [microphoneError, setMicrophoneError] = useState<string>();
-  const [voiceStatus, setVoiceStatus] = useState<RealtimeStatus>(REALTIME_STATUS.IDLE);
+  const [voiceStatus, setVoiceStatus, voiceStatusNow] = useStateWithRef<RealtimeStatus>(
+    REALTIME_STATUS.IDLE,
+  );
   /**
    * A pressed talk key still waiting for the call it asked to open. The meter
    * is drawn from this rather than from the connection, because the press is
@@ -304,7 +307,6 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   const voiceSession = useRef<RealtimeVoiceSession | undefined>(undefined);
   const announcer = useRef<SpokenNoticeAnnouncer | undefined>(undefined);
   const quietTimer = useRef<number | undefined>(undefined);
-  const voiceStatusRef = useRef<RealtimeStatus>(REALTIME_STATUS.IDLE);
   /**
    * Whether Luke has actually been heard during this reply. Committing a turn
    * swaps the meter from the microphone to Luke, and the meter reports quiet as
@@ -367,7 +369,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       onCaption: setVoiceCaption,
     });
     return voiceSession.current;
-  }, []);
+  }, [setVoiceStatus]);
 
   /**
    * The announcer that lets Luke speak into silence: it queues the notices the
@@ -421,30 +423,33 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
    * producing it. The meter is already measuring the stream, so the quiet it
    * reports is what ends the turn.
    */
-  const handleVoiceActivity = useCallback((active: boolean) => {
-    if (voiceStatusRef.current !== REALTIME_STATUS.RESPONDING) return;
-    if (active) {
-      heardLuke.current = true;
-      voiceSession.current?.reportRemoteAudioActive();
-    }
-    if (quietTimer.current !== undefined) {
-      window.clearTimeout(quietTimer.current);
-      quietTimer.current = undefined;
-    }
-    if (active) return;
-    // The meter calls quiet after a fifth of a second, which is shorter than the
-    // pause between two sentences. Ending a turn on that would take the meter
-    // down mid-reply — the very thing this is here to stop — so the turn waits
-    // for a silence longer than speech leaves behind.
-    quietTimer.current = window.setTimeout(() => {
-      quietTimer.current = undefined;
-      // Only Luke's own silence ends Luke's turn.
-      if (!quietIsLukesOwn({ status: voiceStatusRef.current, heardLuke: heardLuke.current })) {
-        return;
+  const handleVoiceActivity = useCallback(
+    (active: boolean) => {
+      if (voiceStatusNow() !== REALTIME_STATUS.RESPONDING) return;
+      if (active) {
+        heardLuke.current = true;
+        voiceSession.current?.reportRemoteAudioActive();
       }
-      voiceSession.current?.reportRemoteAudioIdle();
-    }, REMOTE_QUIET_MS);
-  }, []);
+      if (quietTimer.current !== undefined) {
+        window.clearTimeout(quietTimer.current);
+        quietTimer.current = undefined;
+      }
+      if (active) return;
+      // The meter calls quiet after a fifth of a second, which is shorter than the
+      // pause between two sentences. Ending a turn on that would take the meter
+      // down mid-reply — the very thing this is here to stop — so the turn waits
+      // for a silence longer than speech leaves behind.
+      quietTimer.current = window.setTimeout(() => {
+        quietTimer.current = undefined;
+        // Only Luke's own silence ends Luke's turn.
+        if (!quietIsLukesOwn({ status: voiceStatusNow(), heardLuke: heardLuke.current })) {
+          return;
+        }
+        voiceSession.current?.reportRemoteAudioIdle();
+      }, REMOTE_QUIET_MS);
+    },
+    [voiceStatusNow],
+  );
 
   /**
    * Asks the system for access and nothing else. Opening a call here would hold
@@ -612,7 +617,6 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   }, [activeStream]);
 
   useEffect(() => {
-    voiceStatusRef.current = voiceStatus;
     // Each reply is heard from scratch, so the previous one cannot vouch for it.
     if (!typedAskHolds(voiceStatus)) {
       heardLuke.current = false;

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -1,0 +1,749 @@
+import {
+  type AppGuideSnapshot,
+  ATTENTION_SPEECH_SOURCE,
+  type AttentionSpeech,
+  EMPTY_APP_GUIDE,
+  type NormalizedSession,
+  type ObservedWorkspaceProject,
+  REALTIME_STATUS,
+  type RealtimeStatus,
+  type RealtimeVoice,
+  type RealtimeVoiceSpeed,
+  type SessionIdentity,
+  type TrackedIssue,
+} from "@sidecar/core";
+import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
+import type { MicrophoneStatus, SessionOpenResult, VoiceHotkeyState } from "../shared/contracts";
+import { TALK_KEY_RELEASE, talkKeyRelease } from "../shared/voice-hotkey";
+import { askRefusal } from "./ask-luke";
+import { type AppActionCarrier, quietIsLukesOwn, RealtimeVoiceSession } from "./realtime-session";
+import { SpokenNoticeAnnouncer } from "./spoken-notices";
+import { WAVEFORM_VOICE, type WaveformVoice } from "./waveform";
+
+/**
+ * The backstop for a reply whose ending never arrives.
+ *
+ * `output_audio_buffer.stopped` is what actually ends a reply now, so this only
+ * has to catch a call where that never came. It is long because the thing it
+ * must not mistake for an ending is a pause between two sentences: at 700ms it
+ * did exactly that, taking the meter and the face down while Luke talked on
+ * into the second one.
+ */
+export const REMOTE_QUIET_MS = 2_500;
+
+/**
+ * What the speaking evidence run captions the reply with. A capture run never
+ * opens a call, so there are no words to draw unless the fixture supplies
+ * them — and it must, or the caption strip ships unphotographed. Synthetic,
+ * like every fixture, and long enough to wrap: a one-line fixture would leave
+ * the wrapped form of the strip unphotographed too.
+ */
+export const FIXTURE_SPEAKING_CAPTION =
+  "Claude Code finished checkout-service, and Codex is still migrating the payments schema. Two sessions are waiting on you.";
+
+/**
+ * What a changed voice on a live call should do. The API locks a session's
+ * voice the moment the model first speaks, so the one way to change it now is
+ * to open a new call — but a spoken "change your voice" is confirmed in the
+ * old one, so the restart waits until that turn has ended.
+ */
+export const VOICE_RESTART = {
+  /** Nothing to do: no change, or a change that is not owed a live call. */
+  NONE: "none",
+  /** A restart is owed, but the turn under way has to finish first. */
+  WAIT: "wait",
+  /** The call ended on its own; the next one is minted in the new voice. */
+  DROP: "drop",
+  /** The call is idle enough to close and open again in the new voice. */
+  RESTART: "restart",
+} as const;
+
+export type VoiceRestart = (typeof VOICE_RESTART)[keyof typeof VOICE_RESTART];
+
+/**
+ * Whose voice the meter is drawing. The waveform follows whoever is actually
+ * talking: the developer while push-to-talk is held, Luke while it answers,
+ * nobody otherwise.
+ */
+export function waveformVoice(status: RealtimeStatus): WaveformVoice | undefined {
+  if (status === REALTIME_STATUS.RESPONDING) return WAVEFORM_VOICE.LUKE;
+  if (status === REALTIME_STATUS.LISTENING) return WAVEFORM_VOICE.DEVELOPER;
+  return undefined;
+}
+
+/**
+ * The stream the meter should listen to for this status, or none. Typed over
+ * the stream itself so the rule can be tested without a MediaStream.
+ */
+export function activeVoiceStream<T>(input: {
+  status: RealtimeStatus;
+  local: T | undefined;
+  remote: T | undefined;
+}): T | undefined {
+  if (input.status === REALTIME_STATUS.RESPONDING) return input.remote;
+  if (input.status === REALTIME_STATUS.LISTENING) return input.local;
+  return undefined;
+}
+
+/**
+ * The exchange is live from the press to the end of the reply — the call
+ * coming up, a turn being held, Luke speaking — and the media duck follows it.
+ */
+export function voiceExchangeActive(status: RealtimeStatus): boolean {
+  return (
+    status === REALTIME_STATUS.CONNECTING ||
+    status === REALTIME_STATUS.LISTENING ||
+    status === REALTIME_STATUS.RESPONDING
+  );
+}
+
+/**
+ * The words drawn under the shape. A capture run always draws the fixture's
+ * words; otherwise Luke's caption is shown only when there is a reason to
+ * read them and the reply they belong to is his turn: the captions preference,
+ * a reply answering an ask the developer typed, or an output that would
+ * swallow the speech.
+ */
+export function lukeCaptionToShow(input: {
+  fixtureSpeaking: boolean;
+  captionsEnabled: boolean;
+  typedAsk: boolean;
+  outputSilent: boolean;
+  voice: WaveformVoice | undefined;
+  caption: string | undefined;
+}): string | undefined {
+  if (input.fixtureSpeaking) return FIXTURE_SPEAKING_CAPTION;
+  if (
+    (input.captionsEnabled || input.typedAsk || input.outputSilent) &&
+    input.voice === WAVEFORM_VOICE.LUKE
+  ) {
+    return input.caption;
+  }
+  return undefined;
+}
+
+/**
+ * What a talk-key press does before the session is asked. A latched turn is
+ * already open — this press is someone saying they are done, which is the
+ * release's to answer. Otherwise a press against no microphone call has
+ * seconds of handshake ahead of it, and the meter has to answer the press,
+ * not the handshake.
+ */
+export function talkKeyPress(input: { latched: boolean; microphoneCall: boolean }): {
+  deferToRelease: boolean;
+  openCall: boolean;
+} {
+  if (input.latched) return { deferToRelease: true, openCall: false };
+  return { deferToRelease: false, openCall: !input.microphoneCall };
+}
+
+/**
+ * Whether the press-wait meter should stay up. Connecting is still the
+ * handshake; a pending turn is a takeover still owed a call — the meter must
+ * ride across Luke's own call settling on its way to the developer's.
+ */
+export function talkOpeningHolds(input: { status: RealtimeStatus; turnPending: boolean }): boolean {
+  return input.status === REALTIME_STATUS.CONNECTING || input.turnPending;
+}
+
+/**
+ * Whether a typed ask's reply is still the one being spoken. The caption of a
+ * typed conversation stays readable whatever the preference says, and clears
+ * the moment the turn moves on.
+ */
+export function typedAskHolds(status: RealtimeStatus): boolean {
+  return status === REALTIME_STATUS.RESPONDING;
+}
+
+/**
+ * Whether a changed pace should be carried onto the call now open. The first
+ * snapshot is the stored value rather than a change, and with no next value
+ * there is nothing to apply — the next call is minted at the stored pace.
+ */
+export function liveSpeedApplies(
+  previous: RealtimeVoiceSpeed | undefined,
+  next: RealtimeVoiceSpeed | undefined,
+): boolean {
+  return next !== undefined && previous !== undefined && previous !== next;
+}
+
+/**
+ * What a changed voice should do to a call already up. A call being opened
+ * counts as one to reopen: its credential may already have been minted in the
+ * old voice. A call that ended on its own owes nothing.
+ */
+export function voiceRestartAction(input: {
+  previous: RealtimeVoice | undefined;
+  next: RealtimeVoice | undefined;
+  live: boolean;
+  due: boolean;
+  status: RealtimeStatus;
+}): { due: boolean; action: VoiceRestart } {
+  if (input.next === undefined) return { due: input.due, action: VOICE_RESTART.NONE };
+  const due =
+    input.due || (input.previous !== undefined && input.previous !== input.next && input.live);
+  if (!due) return { due: false, action: VOICE_RESTART.NONE };
+  if (
+    input.status === REALTIME_STATUS.IDLE ||
+    input.status === REALTIME_STATUS.FAILED ||
+    input.status === REALTIME_STATUS.UNAVAILABLE
+  ) {
+    return { due: false, action: VOICE_RESTART.DROP };
+  }
+  if (input.status !== REALTIME_STATUS.READY) {
+    return { due: true, action: VOICE_RESTART.WAIT };
+  }
+  return { due: false, action: VOICE_RESTART.RESTART };
+}
+
+/**
+ * Status-edge notices — deterministic, worded on this machine — go to the
+ * announcer, which may open a speak-only call of Luke's own to say them. An
+ * evaluator summary is a model's words, so it keeps its original bound: spoken
+ * only on a call the developer opened themselves.
+ */
+export function statusEdgeNotices(speech: readonly AttentionSpeech[]): AttentionSpeech[] {
+  return speech.filter((item) => item.source === ATTENTION_SPEECH_SOURCE.STATUS_EDGE);
+}
+
+/** The other half of {@link statusEdgeNotices}: summaries that ride an open call. */
+export function evaluatorSummaries(speech: readonly AttentionSpeech[]): AttentionSpeech[] {
+  return speech.filter((item) => item.source !== ATTENTION_SPEECH_SOURCE.STATUS_EDGE);
+}
+
+export interface VoiceConversationOptions {
+  sessions: readonly NormalizedSession[];
+  workspaceProjects: readonly ObservedWorkspaceProject[];
+  defaultWorkspaceProvider: string | undefined;
+  voice: RealtimeVoice | undefined;
+  voiceSpeed: RealtimeVoiceSpeed | undefined;
+  voiceCaptions: boolean;
+  outputSilent: boolean;
+  fixtureSpeaking: boolean;
+  /**
+   * True while a settings row is recording a chord. Both Luke keys stay
+   * registered through a recording, so a press of a current chord landing then
+   * is held here rather than opening the microphone under the field being
+   * typed into.
+   */
+  capturingShortcut: () => boolean;
+  /**
+   * The spoken form of pressing a row. Passed in rather than reached through a
+   * ref: this hook is called after the handler exists, so there is no
+   * declaration-order cycle to break.
+   */
+  openSession: (identity: SessionIdentity) => Promise<SessionOpenResult>;
+  /**
+   * The spoken asks about Luke himself. Passed in on the same terms as
+   * {@link openSession}.
+   */
+  carryAppAction: AppActionCarrier;
+}
+
+export interface VoiceConversation {
+  analyser: AnalyserNode | undefined;
+  microphoneStatus: MicrophoneStatus;
+  setMicrophoneStatus: (status: MicrophoneStatus) => void;
+  microphoneError: string | undefined;
+  voiceStatus: RealtimeStatus;
+  setVoiceStatus: (status: RealtimeStatus) => void;
+  talkOpening: boolean;
+  voiceHotkey: VoiceHotkeyState | undefined;
+  handleVoiceActivity: (active: boolean) => void;
+  requestMicrophoneAccess: () => Promise<void>;
+  startMicrophone: () => Promise<MicrophoneStatus>;
+  stopMicrophone: () => Promise<void>;
+  askLuke: (text: string) => Promise<string | undefined>;
+  voiceTurn: WaveformVoice | undefined;
+  lukeCaption: string | undefined;
+  remoteAudio: RefObject<HTMLAudioElement | null>;
+  /** Escape out of an open turn: forget the press and the latch, and stop listening. */
+  discardListening: () => void;
+  stopSpeaking: () => boolean;
+  syncGuide: (guide: AppGuideSnapshot) => void;
+  syncIssues: (issues: readonly TrackedIssue[] | undefined) => void;
+}
+
+/**
+ * The spoken conversation: talk key, quiet timer, meter, captions, a changed
+ * voice or pace on a live call, and the announcer that lets Luke speak into
+ * silence. One cluster, so the rules it is made of can be tested apart from
+ * the panel that draws around them.
+ */
+export function useVoiceConversation(options: VoiceConversationOptions): VoiceConversation {
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const [analyser, setAnalyser] = useState<AnalyserNode>();
+  const [microphoneStatus, setMicrophoneStatus] = useState<MicrophoneStatus>("not-determined");
+  const [microphoneError, setMicrophoneError] = useState<string>();
+  const [voiceStatus, setVoiceStatus] = useState<RealtimeStatus>(REALTIME_STATUS.IDLE);
+  /**
+   * A pressed talk key still waiting for the call it asked to open. The meter
+   * is drawn from this rather than from the connection, because the press is
+   * the moment the developer needs answering: the handshake behind it takes
+   * seconds, and a key that visibly does nothing for that long reads as a key
+   * that did nothing.
+   */
+  const [talkOpening, setTalkOpening] = useState(false);
+  const [voiceHotkey, setVoiceHotkey] = useState<VoiceHotkeyState>();
+  const [localStream, setLocalStream] = useState<MediaStream>();
+  const [remoteStream, setRemoteStream] = useState<MediaStream>();
+  const [voiceCaption, setVoiceCaption] = useState<string>();
+  /**
+   * Whether the reply under way answers an ask the developer typed. A typed
+   * ask is read, not only heard, so its reply draws the caption whatever the
+   * captions preference says — the preference is about speech being
+   * duplicated, and here the words are the half of the conversation the
+   * developer chose. Cleared the moment the turn moves on.
+   */
+  const [typedAsk, setTypedAsk] = useState(false);
+
+  const audioContext = useRef<AudioContext | undefined>(undefined);
+  const remoteAudio = useRef<HTMLAudioElement | null>(null);
+  const voiceSession = useRef<RealtimeVoiceSession | undefined>(undefined);
+  const announcer = useRef<SpokenNoticeAnnouncer | undefined>(undefined);
+  const quietTimer = useRef<number | undefined>(undefined);
+  const voiceStatusRef = useRef<RealtimeStatus>(REALTIME_STATUS.IDLE);
+  /**
+   * Whether Luke has actually been heard during this reply. Committing a turn
+   * swaps the meter from the microphone to Luke, and the meter reports quiet as
+   * it lets go of the old stream — a silence that belongs to the developer, not
+   * to Luke, and one that would otherwise end his turn before he had said
+   * anything.
+   */
+  const heardLuke = useRef(false);
+  /** When the talk key went down, which is what tells a hold from a tap. */
+  const talkPressedAt = useRef<number | undefined>(undefined);
+  /** Whether a tap has left a turn open for a later press to end. */
+  const talkLatched = useRef(false);
+  const sessionsRef = useRef(options.sessions);
+  const workspaceProjectsRef = useRef(options.workspaceProjects);
+  const defaultWorkspaceProviderRef = useRef(options.defaultWorkspaceProvider);
+  const guideRef = useRef<AppGuideSnapshot>(EMPTY_APP_GUIDE);
+  const issuesRef = useRef<readonly TrackedIssue[] | undefined>(undefined);
+
+  const ensureVoiceSession = useCallback((): RealtimeVoiceSession => {
+    voiceSession.current ??= new RealtimeVoiceSession({
+      requestConnection: () => window.sidecar.requestRealtimeCredential(),
+      // The same bridge calls the rows use — the composer, the chips, and the
+      // press that opens a session: a spoken ask is a third way to ask for the
+      // same act, behind the same gauntlet in the main process.
+      carryAction: (action) =>
+        action.kind === "message"
+          ? window.sidecar.sendSessionMessage(action.identity, action.text)
+          : action.kind === "control"
+            ? window.sidecar.executeSessionControl(action.identity, action.control.id)
+            : action.kind === "create-workspace"
+              ? window.sidecar.createSessionWorkspace(
+                  action.providerId,
+                  action.providerProjectId,
+                  action.name,
+                  action.task,
+                  action.agentSelection,
+                )
+              : action.kind === "add-agent"
+                ? window.sidecar.addWorkspaceAgent(
+                    action.identity,
+                    action.agent,
+                    action.name,
+                    action.task,
+                    action.model,
+                    action.effort,
+                  )
+                : optionsRef.current.openSession(action.identity),
+      // The asks about Luke himself — a settings change, the panel shown —
+      // behind the same gauntlet: validated against the guide before this is
+      // called, and performed by the same handlers the panel's controls use.
+      carryAppAction: (action) => optionsRef.current.carryAppAction(action),
+      // The issue acts have no rows to share a bridge call with, but the shape
+      // is the same: validated against the roster here, and again in the main
+      // process against what it observed.
+      carryIssueAction: (action) => window.sidecar.executeIssueAction(action),
+      onStatus: setVoiceStatus,
+      onLocalStream: setLocalStream,
+      onRemoteStream: setRemoteStream,
+      onError: setMicrophoneError,
+      onCaption: setVoiceCaption,
+    });
+    return voiceSession.current;
+  }, []);
+
+  /**
+   * The announcer that lets Luke speak into silence: it queues the notices the
+   * main process decided to voice and, when no conversation is open, opens a
+   * speak-only call of Luke's own to say them through — then closes it. Built
+   * beside the session because it drives nothing else.
+   */
+  const ensureAnnouncer = useCallback((): SpokenNoticeAnnouncer => {
+    announcer.current ??= new SpokenNoticeAnnouncer({
+      session: () => ensureVoiceSession(),
+    });
+    return announcer.current;
+  }, [ensureVoiceSession]);
+
+  const stopMicrophone = useCallback(async () => {
+    await voiceSession.current?.close();
+  }, []);
+
+  /**
+   * Opens the call, answering with what the system said about the microphone —
+   * the one fact a caller that could not send anything needs in order to say
+   * why.
+   */
+  const startMicrophone = useCallback(async (): Promise<MicrophoneStatus> => {
+    setMicrophoneError(undefined);
+    const session = ensureVoiceSession();
+    const permission = await window.sidecar.requestMicrophone();
+    setMicrophoneStatus(permission);
+    if (permission !== "granted") {
+      // The press that asked for this is still waiting for a call that is now
+      // not coming. The status never changes on this path, so the meter the
+      // press put up is taken down here rather than by a status settling.
+      session.dropPendingTurn();
+      setTalkOpening(false);
+      return permission;
+    }
+    if (await session.connect()) {
+      session.updateSessions(sessionsRef.current);
+      session.updateWorkspaceProjects(
+        workspaceProjectsRef.current,
+        defaultWorkspaceProviderRef.current,
+      );
+      session.updateGuide(guideRef.current);
+      session.updateIssues(issuesRef.current);
+    }
+    return permission;
+  }, [ensureVoiceSession]);
+
+  /**
+   * Luke's reply is over when it stops being audible, not when the model stops
+   * producing it. The meter is already measuring the stream, so the quiet it
+   * reports is what ends the turn.
+   */
+  const handleVoiceActivity = useCallback((active: boolean) => {
+    if (voiceStatusRef.current !== REALTIME_STATUS.RESPONDING) return;
+    if (active) {
+      heardLuke.current = true;
+      voiceSession.current?.reportRemoteAudioActive();
+    }
+    if (quietTimer.current !== undefined) {
+      window.clearTimeout(quietTimer.current);
+      quietTimer.current = undefined;
+    }
+    if (active) return;
+    // The meter calls quiet after a fifth of a second, which is shorter than the
+    // pause between two sentences. Ending a turn on that would take the meter
+    // down mid-reply — the very thing this is here to stop — so the turn waits
+    // for a silence longer than speech leaves behind.
+    quietTimer.current = window.setTimeout(() => {
+      quietTimer.current = undefined;
+      // Only Luke's own silence ends Luke's turn.
+      if (!quietIsLukesOwn({ status: voiceStatusRef.current, heardLuke: heardLuke.current })) {
+        return;
+      }
+      voiceSession.current?.reportRemoteAudioIdle();
+    }, REMOTE_QUIET_MS);
+  }, []);
+
+  /**
+   * Asks the system for access and nothing else. Opening a call here would hold
+   * the capture device and light the microphone indicator without anyone having
+   * pressed the talk key, which is not what the row offers.
+   */
+  const requestMicrophoneAccess = useCallback(async () => {
+    setMicrophoneStatus(await window.sidecar.requestMicrophone());
+  }, []);
+
+  /**
+   * The talk key going down. Every press goes to the session, including the one
+   * that has no call to press against yet: the microphone opens with the call,
+   * so a press before then is remembered and applied when it comes up.
+   */
+  const beginTalk = useCallback(async () => {
+    talkPressedAt.current = performance.now();
+    // A latched turn is already open. This press is someone saying they are
+    // done, which is the release's to answer.
+    if (talkLatched.current) return;
+    const session = ensureVoiceSession();
+    session.beginTurn();
+    const press = talkKeyPress({ latched: false, microphoneCall: session.microphoneCall });
+    // A press against no call — or against Luke's own speak-only call, which
+    // has no microphone to offer — has seconds of handshake ahead of it, and
+    // the meter has to answer the press, not the handshake.
+    if (press.openCall) setTalkOpening(true);
+    // The developer's call is up or already coming; the press waits its turn.
+    if (!press.openCall) return;
+    // `connect` inside stands Luke's own call down if one is open: the
+    // developer pressing the key always gets the developer's call.
+    await startMicrophone();
+  }, [ensureVoiceSession, startMicrophone]);
+
+  /**
+   * The talk key coming up. How long it was held is the whole of the decision:
+   * held, the turn was as long as the key was down and is sent; tapped, it
+   * stays open for the question too long to hold through, and the next release
+   * sends it.
+   */
+  const endTalk = useCallback(() => {
+    const pressedAt = talkPressedAt.current;
+    talkPressedAt.current = undefined;
+    // A release with nothing before it is not this key's to answer — a turn
+    // ended by Escape leaves the key still down.
+    if (pressedAt === undefined) return;
+    const release = talkKeyRelease({
+      heldMs: performance.now() - pressedAt,
+      latched: talkLatched.current,
+    });
+    if (release === TALK_KEY_RELEASE.LATCH) {
+      talkLatched.current = true;
+      return;
+    }
+    talkLatched.current = false;
+    // A held press let go of before the call opened is dropped, not sent —
+    // nothing was captured to send — and the meter it put up leaves with it.
+    if (voiceSession.current && !voiceSession.current.isConnected) setTalkOpening(false);
+    voiceSession.current?.endTurn(true);
+  }, []);
+
+  /**
+   * A typed ask to Luke himself. It rides the same call the talk key opens —
+   * permission, connect, then the turn — and opens the same kind of turn:
+   * typing is the developer asking in their own words, so the turn may carry
+   * a tool the way a spoken one may, behind the same roster gauntlet. Answers
+   * with why the ask could not go, or nothing when it did — the reply is
+   * spoken, and its words land under the panel as the answer.
+   */
+  const askLuke = useCallback(
+    async (text: string): Promise<string | undefined> => {
+      const session = ensureVoiceSession();
+      let microphone: MicrophoneStatus = "granted";
+      // Luke's own speak-only call cannot carry a typed ask — it was sent no
+      // roster to validate one against — so it counts as no call here, and
+      // `connect` inside stands it down for the developer's own. A microphone
+      // call still connecting is awaited exactly as before.
+      if (!session.isConnected || !session.microphoneCall) {
+        microphone = await startMicrophone();
+      }
+      if (session.sendText(text)) {
+        setTypedAsk(true);
+        return undefined;
+      }
+      return askRefusal(session.status, microphone);
+    },
+    [ensureVoiceSession, startMicrophone],
+  );
+
+  const discardListening = useCallback(() => {
+    talkLatched.current = false;
+    talkPressedAt.current = undefined;
+    voiceSession.current?.stopListening(false);
+  }, []);
+
+  const stopSpeaking = useCallback(() => voiceSession.current?.stopSpeaking() === true, []);
+
+  const syncGuide = useCallback((guide: AppGuideSnapshot) => {
+    guideRef.current = guide;
+    voiceSession.current?.updateGuide(guide);
+  }, []);
+
+  const syncIssues = useCallback((issues: readonly TrackedIssue[] | undefined) => {
+    issuesRef.current = issues;
+    voiceSession.current?.updateIssues(issues);
+  }, []);
+
+  const heardSpeed = useRef<RealtimeVoiceSpeed | undefined>(undefined);
+  useEffect(() => {
+    const speed = options.voiceSpeed;
+    if (speed === undefined) return;
+    const previous = heardSpeed.current;
+    heardSpeed.current = speed;
+    if (!liveSpeedApplies(previous, speed)) return;
+    voiceSession.current?.applySpeed(speed);
+  }, [options.voiceSpeed]);
+
+  const heardVoice = useRef<RealtimeVoice | undefined>(undefined);
+  const voiceRestartDue = useRef(false);
+  useEffect(() => {
+    const decided = voiceRestartAction({
+      previous: heardVoice.current,
+      next: options.voice,
+      live:
+        voiceSession.current?.isConnected === true || voiceSession.current?.isConnecting === true,
+      due: voiceRestartDue.current,
+      status: voiceStatus,
+    });
+    if (options.voice !== undefined) heardVoice.current = options.voice;
+    voiceRestartDue.current = decided.due;
+    if (decided.action !== VOICE_RESTART.RESTART) return;
+    void (async () => {
+      await voiceSession.current?.close();
+      await startMicrophone();
+    })();
+  }, [options.voice, startMicrophone, voiceStatus]);
+
+  const activeStream = activeVoiceStream({
+    status: voiceStatus,
+    local: localStream,
+    remote: remoteStream,
+  });
+
+  useEffect(() => {
+    if (!activeStream) {
+      setAnalyser(undefined);
+      return;
+    }
+    const context = audioContext.current ?? new AudioContext({ latencyHint: "interactive" });
+    audioContext.current = context;
+    // A suspended context reads a flatline whatever the microphone hears, and
+    // the talk key is a system shortcut, so no user gesture in this window has
+    // ever vouched for the context. Resuming is a no-op when it is running.
+    if (context.state === "suspended") void context.resume();
+    const source = context.createMediaStreamSource(activeStream);
+    const nextAnalyser = context.createAnalyser();
+    nextAnalyser.fftSize = 256;
+    nextAnalyser.smoothingTimeConstant = 0.82;
+    source.connect(nextAnalyser);
+    setAnalyser(nextAnalyser);
+    return () => {
+      source.disconnect();
+      setAnalyser(undefined);
+    };
+  }, [activeStream]);
+
+  useEffect(() => {
+    voiceStatusRef.current = voiceStatus;
+    // Each reply is heard from scratch, so the previous one cannot vouch for it.
+    if (!typedAskHolds(voiceStatus)) {
+      heardLuke.current = false;
+      // The reply that answered the typed ask is over, so the caption goes
+      // back to being the preference's to grant.
+      setTypedAsk(false);
+    }
+    // Any settled status ends the wait the press started, however it ended:
+    // listening takes the meter live, ready means the turn was dropped
+    // mid-handshake, and a failure has its own message to show. Unless the
+    // press is still owed a turn — a takeover passes through Luke's own call
+    // settling on its way to the developer's, and the meter must ride across.
+    if (
+      !talkOpeningHolds({
+        status: voiceStatus,
+        turnPending: voiceSession.current?.turnPending === true,
+      })
+    ) {
+      setTalkOpening(false);
+    }
+  }, [voiceStatus]);
+
+  useEffect(() => {
+    window.sidecar.setVoiceExchangeActive(voiceExchangeActive(voiceStatus));
+  }, [voiceStatus]);
+
+  useEffect(() => {
+    const element = remoteAudio.current;
+    if (!element) return;
+    element.srcObject = remoteStream ?? null;
+    if (remoteStream) void element.play().catch(() => undefined);
+  }, [remoteStream]);
+
+  useEffect(() => {
+    sessionsRef.current = options.sessions;
+    voiceSession.current?.updateSessions(options.sessions);
+  }, [options.sessions]);
+
+  useEffect(() => {
+    workspaceProjectsRef.current = options.workspaceProjects;
+    defaultWorkspaceProviderRef.current = options.defaultWorkspaceProvider;
+    voiceSession.current?.updateWorkspaceProjects(
+      options.workspaceProjects,
+      options.defaultWorkspaceProvider,
+    );
+  }, [options.defaultWorkspaceProvider, options.workspaceProjects]);
+
+  useEffect(() => {
+    return window.sidecar.onAttentionSpeech((speech) => {
+      const notices = statusEdgeNotices(speech);
+      if (notices.length > 0) ensureAnnouncer().enqueue(notices);
+      const session = voiceSession.current;
+      if (!session?.microphoneCall) return;
+      for (const item of evaluatorSummaries(speech)) session.speak(item);
+    });
+  }, [ensureAnnouncer]);
+
+  // The announcer paces itself by the session's status: READY is when a queued
+  // sentence can speak and when an empty queue starts the walk toward closing
+  // the call Luke opened for himself.
+  useEffect(() => {
+    announcer.current?.onStatus(voiceStatus);
+  }, [voiceStatus]);
+
+  // The talk key is registered by the main process so it answers from any app,
+  // which is the whole point: no window to find, nothing to focus first. Both
+  // edges arrive, because a turn you hold ends when the key does. Only the
+  // press defers to a chord being recorded: the release always lands, so a
+  // hold opened before the recording began still ends when the key comes up
+  // rather than leaving the microphone open under the field — and a release
+  // whose press was held back finds nothing pressed and answers nothing.
+  useEffect(
+    () =>
+      window.sidecar.onVoiceHotkeyPress(() => {
+        if (!optionsRef.current.capturingShortcut()) void beginTalk();
+      }),
+    [beginTalk],
+  );
+  useEffect(() => window.sidecar.onVoiceHotkeyRelease(endTalk), [endTalk]);
+  useEffect(() => window.sidecar.onVoiceHotkeyChanged(setVoiceHotkey), []);
+  // The stop key asks for quiet from any app, exactly as Escape asks for it
+  // from the panel: the session itself answers whether there is a reply to
+  // stop, so a press over silence simply does nothing. It defers to a chord
+  // being recorded on the talk key's terms — the keystroke there is an answer
+  // to the field, not an ask of Luke.
+  useEffect(
+    () =>
+      window.sidecar.onStopHotkeyPress(() => {
+        if (!optionsRef.current.capturingShortcut()) voiceSession.current?.stopSpeaking();
+      }),
+    [],
+  );
+
+  useEffect(
+    () => () => {
+      if (quietTimer.current !== undefined) window.clearTimeout(quietTimer.current);
+      void voiceSession.current?.close();
+    },
+    [],
+  );
+
+  const voiceTurn = waveformVoice(voiceStatus);
+  const lukeCaption = lukeCaptionToShow({
+    fixtureSpeaking: options.fixtureSpeaking,
+    captionsEnabled: options.voiceCaptions,
+    typedAsk,
+    outputSilent: options.outputSilent,
+    voice: voiceTurn,
+    caption: voiceCaption,
+  });
+
+  return {
+    analyser,
+    microphoneStatus,
+    setMicrophoneStatus,
+    microphoneError,
+    voiceStatus,
+    setVoiceStatus,
+    talkOpening,
+    voiceHotkey,
+    handleVoiceActivity,
+    requestMicrophoneAccess,
+    startMicrophone,
+    stopMicrophone,
+    askLuke,
+    voiceTurn,
+    lukeCaption,
+    remoteAudio,
+    discardListening,
+    stopSpeaking,
+    syncGuide,
+    syncIssues,
+  };
+}

--- a/apps/desktop/tests/use-bootstrap-raced-channel.test.ts
+++ b/apps/desktop/tests/use-bootstrap-raced-channel.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { staleBootstrap } from "../src/renderer/use-bootstrap-raced-channel";
+
+test("a live push makes the bootstrap snapshot stale", () => {
+  assert.equal(
+    staleBootstrap(false),
+    false,
+    "nothing has arrived; the snapshot is still the newest word",
+  );
+  assert.equal(
+    staleBootstrap(true),
+    true,
+    "a push that raced past the reply must not be clobbered by it",
+  );
+});

--- a/apps/desktop/tests/use-panel-entry.test.ts
+++ b/apps/desktop/tests/use-panel-entry.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  PANEL_ENTRY_CANCEL,
+  PANEL_ENTRY_REPLY,
+  panelEntryCancel,
+  panelEntryOpen,
+  panelEntryReleased,
+  panelEntryReply,
+  panelEntrySettles,
+} from "../src/renderer/use-panel-entry";
+
+test("ending an entry is what releases the hold it had on the panel", () => {
+  assert.equal(panelEntryReleased({ busy: false }, undefined), true);
+  assert.equal(panelEntryReleased(undefined, { busy: false }), false);
+  assert.equal(panelEntryReleased({ busy: false }, { busy: true }), false);
+  assert.equal(panelEntryReleased(undefined, undefined), false);
+});
+
+test("a reply in flight is not a moment to change the entry underneath it", () => {
+  assert.equal(panelEntryOpen(undefined), false);
+  assert.equal(panelEntryOpen({ busy: true }), false);
+  assert.equal(panelEntryOpen({ busy: false }), true);
+});
+
+test("giving up from the aside shape returns you where you were", () => {
+  assert.equal(
+    panelEntryCancel({ aside: true, restore: true }),
+    PANEL_ENTRY_CANCEL.RESTORE,
+    "a key started from the panel, or a note from settings, goes back there",
+  );
+  assert.equal(
+    panelEntryCancel({ aside: true, restore: false }),
+    PANEL_ENTRY_CANCEL.LEAVE,
+    "a key page that was opened, or a composer from the tray, leaves entirely",
+  );
+  assert.equal(
+    panelEntryCancel({ aside: false, restore: true }),
+    PANEL_ENTRY_CANCEL.NONE,
+    "giving up from inside the panel has no shape to put away",
+  );
+});
+
+test("a reply that outlived its own entry is spent", () => {
+  assert.equal(panelEntryReply({ stillHeld: false, rejection: "taken" }), PANEL_ENTRY_REPLY.IGNORE);
+  assert.equal(panelEntryReply({ stillHeld: false }), PANEL_ENTRY_REPLY.IGNORE);
+});
+
+test("a send still held is refused or delivered, never both", () => {
+  assert.equal(panelEntryReply({ stillHeld: true, rejection: "taken" }), PANEL_ENTRY_REPLY.REJECT);
+  assert.equal(panelEntryReply({ stillHeld: true }), PANEL_ENTRY_REPLY.DELIVER);
+});
+
+test("a delivered send from the aside shape settles only with the pointer away", () => {
+  assert.equal(panelEntrySettles({ aside: true, pointerInside: false }), true);
+  assert.equal(
+    panelEntrySettles({ aside: true, pointerInside: true }),
+    false,
+    "the pointer is still on the button that was pressed, and will close by leaving",
+  );
+  assert.equal(
+    panelEntrySettles({ aside: false, pointerInside: false }),
+    false,
+    "saved from inside the panel: there is no shape to restore, and no leave to schedule",
+  );
+});

--- a/apps/desktop/tests/use-panel-presentation.test.ts
+++ b/apps/desktop/tests/use-panel-presentation.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { PANEL_PRESENTATION } from "../src/renderer/panel-state";
+import {
+  askDisengageLeaves,
+  capsuleKeepsTab,
+  POINTER_LEAVE_FIRE,
+  pointerEnterPeeks,
+  pointerLeaveFires,
+  pointerLeaveSchedules,
+} from "../src/renderer/use-panel-presentation";
+
+test("hovering the capsule peeks; any other shape is already answering", () => {
+  assert.equal(pointerEnterPeeks(PANEL_PRESENTATION.CAPSULE), true);
+  assert.equal(pointerEnterPeeks(PANEL_PRESENTATION.PEEK), false);
+  assert.equal(pointerEnterPeeks(PANEL_PRESENTATION.PANEL), false);
+});
+
+test("the slot and the composer stay put when the pointer leaves", () => {
+  assert.equal(
+    pointerLeaveSchedules({ presentation: PANEL_PRESENTATION.SLOT, hold: false }),
+    false,
+    "someone fetching a key is in a browser; the pointer being away is the normal case",
+  );
+  assert.equal(
+    pointerLeaveSchedules({ presentation: PANEL_PRESENTATION.FEEDBACK, hold: false }),
+    false,
+    "a note being written must not be discarded by the pointer wandering off",
+  );
+  assert.equal(
+    pointerLeaveSchedules({ presentation: PANEL_PRESENTATION.CAPSULE, hold: false }),
+    false,
+  );
+});
+
+test("a key or ask being typed holds the panel against the pointer", () => {
+  assert.equal(
+    pointerLeaveSchedules({ presentation: PANEL_PRESENTATION.PANEL, hold: true }),
+    false,
+  );
+  assert.equal(
+    pointerLeaveSchedules({ presentation: PANEL_PRESENTATION.PANEL, hold: false }),
+    true,
+  );
+  assert.equal(pointerLeaveSchedules({ presentation: PANEL_PRESENTATION.PEEK, hold: false }), true);
+});
+
+test("the leave timer peeks back to the capsule, or collapses a panel that is not held", () => {
+  assert.equal(
+    pointerLeaveFires({ presentation: PANEL_PRESENTATION.PEEK, hold: false }),
+    POINTER_LEAVE_FIRE.CAPSULE,
+  );
+  assert.equal(
+    pointerLeaveFires({ presentation: PANEL_PRESENTATION.PANEL, hold: false }),
+    POINTER_LEAVE_FIRE.COLLAPSE,
+  );
+  assert.equal(
+    pointerLeaveFires({ presentation: PANEL_PRESENTATION.PANEL, hold: true }),
+    POINTER_LEAVE_FIRE.IGNORE,
+    "an entry can begin inside the delay — pressing Connect does exactly that",
+  );
+  assert.equal(
+    pointerLeaveFires({ presentation: PANEL_PRESENTATION.SLOT, hold: false }),
+    POINTER_LEAVE_FIRE.IGNORE,
+  );
+});
+
+test("a half-written key or note keeps the settings tab through a close", () => {
+  assert.equal(capsuleKeepsTab(true), true);
+  assert.equal(capsuleKeepsTab(false), false);
+});
+
+test("letting go of the ask field while the pointer is away releases the hold", () => {
+  assert.equal(
+    askDisengageLeaves({ wasEngaged: true, engaged: false, pointerInside: false }),
+    true,
+  );
+  assert.equal(
+    askDisengageLeaves({ wasEngaged: true, engaged: false, pointerInside: true }),
+    false,
+    "the pointer is still on the shape and will close by leaving",
+  );
+  assert.equal(
+    askDisengageLeaves({ wasEngaged: false, engaged: true, pointerInside: false }),
+    false,
+  );
+});

--- a/apps/desktop/tests/use-state-with-ref.test.ts
+++ b/apps/desktop/tests/use-state-with-ref.test.ts
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { shadowRef } from "../src/renderer/use-state-with-ref";
+
+test("the ref holds what was last written, before any render", () => {
+  const ref = { current: "capsule" };
+  assert.equal(shadowRef(ref, "panel"), "panel");
+  assert.equal(ref.current, "panel", "a timer firing now must see the shape just asked for");
+});

--- a/apps/desktop/tests/use-voice-conversation.test.ts
+++ b/apps/desktop/tests/use-voice-conversation.test.ts
@@ -1,0 +1,251 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ATTENTION_DISPOSITION,
+  ATTENTION_SPEECH_SOURCE,
+  type AttentionSpeech,
+  REALTIME_STATUS,
+  REALTIME_VOICE,
+  REALTIME_VOICE_SPEED,
+} from "@sidecar/core";
+import {
+  activeVoiceStream,
+  evaluatorSummaries,
+  FIXTURE_SPEAKING_CAPTION,
+  liveSpeedApplies,
+  lukeCaptionToShow,
+  statusEdgeNotices,
+  talkKeyPress,
+  talkOpeningHolds,
+  typedAskHolds,
+  VOICE_RESTART,
+  voiceExchangeActive,
+  voiceRestartAction,
+  waveformVoice,
+} from "../src/renderer/use-voice-conversation";
+import { WAVEFORM_VOICE } from "../src/renderer/waveform";
+
+test("the meter follows whoever is actually talking", () => {
+  assert.equal(waveformVoice(REALTIME_STATUS.RESPONDING), WAVEFORM_VOICE.LUKE);
+  assert.equal(waveformVoice(REALTIME_STATUS.LISTENING), WAVEFORM_VOICE.DEVELOPER);
+  for (const status of [
+    REALTIME_STATUS.IDLE,
+    REALTIME_STATUS.CONNECTING,
+    REALTIME_STATUS.READY,
+    REALTIME_STATUS.FAILED,
+    REALTIME_STATUS.UNAVAILABLE,
+  ] as const) {
+    assert.equal(waveformVoice(status), undefined);
+  }
+});
+
+test("the analyser listens to the stream of whoever holds the turn", () => {
+  assert.equal(
+    activeVoiceStream({ status: REALTIME_STATUS.RESPONDING, local: "mic", remote: "luke" }),
+    "luke",
+  );
+  assert.equal(
+    activeVoiceStream({ status: REALTIME_STATUS.LISTENING, local: "mic", remote: "luke" }),
+    "mic",
+  );
+  assert.equal(
+    activeVoiceStream({ status: REALTIME_STATUS.READY, local: "mic", remote: "luke" }),
+    undefined,
+  );
+});
+
+test("the media duck follows the exchange, not a settled call", () => {
+  assert.equal(voiceExchangeActive(REALTIME_STATUS.CONNECTING), true);
+  assert.equal(voiceExchangeActive(REALTIME_STATUS.LISTENING), true);
+  assert.equal(voiceExchangeActive(REALTIME_STATUS.RESPONDING), true);
+  assert.equal(voiceExchangeActive(REALTIME_STATUS.READY), false);
+  assert.equal(voiceExchangeActive(REALTIME_STATUS.IDLE), false);
+});
+
+test("a capture run always captions the fixture's words", () => {
+  assert.equal(
+    lukeCaptionToShow({
+      fixtureSpeaking: true,
+      captionsEnabled: false,
+      typedAsk: false,
+      outputSilent: false,
+      voice: WAVEFORM_VOICE.LUKE,
+      caption: "live words",
+    }),
+    FIXTURE_SPEAKING_CAPTION,
+  );
+});
+
+test("Luke's caption is drawn only on his turn, and only with a reason to read it", () => {
+  const shown = {
+    fixtureSpeaking: false,
+    captionsEnabled: true,
+    typedAsk: false,
+    outputSilent: false,
+    voice: WAVEFORM_VOICE.LUKE,
+    caption: "two sessions are waiting on you.",
+  };
+  assert.equal(lukeCaptionToShow(shown), "two sessions are waiting on you.");
+  assert.equal(
+    lukeCaptionToShow({ ...shown, voice: WAVEFORM_VOICE.DEVELOPER }),
+    undefined,
+    "a caption that raced a status change must not be drawn on the developer's turn",
+  );
+  assert.equal(
+    lukeCaptionToShow({ ...shown, captionsEnabled: false }),
+    undefined,
+    "the preference is about speech being duplicated, and with it off there is no reason to read",
+  );
+});
+
+test("a typed ask, or an output that would swallow the reply, captions whatever the preference says", () => {
+  const hidden = {
+    fixtureSpeaking: false,
+    captionsEnabled: false,
+    typedAsk: false,
+    outputSilent: false,
+    voice: WAVEFORM_VOICE.LUKE,
+    caption: "the words",
+  };
+  assert.equal(lukeCaptionToShow({ ...hidden, typedAsk: true }), "the words");
+  assert.equal(lukeCaptionToShow({ ...hidden, outputSilent: true }), "the words");
+});
+
+test("a latched press is the release's to answer, and does not open a second call", () => {
+  assert.deepEqual(talkKeyPress({ latched: true, microphoneCall: false }), {
+    deferToRelease: true,
+    openCall: false,
+  });
+  assert.deepEqual(talkKeyPress({ latched: true, microphoneCall: true }), {
+    deferToRelease: true,
+    openCall: false,
+  });
+});
+
+test("a press against no microphone call has to open one, and the meter answers the press", () => {
+  assert.deepEqual(talkKeyPress({ latched: false, microphoneCall: false }), {
+    deferToRelease: false,
+    openCall: true,
+  });
+  assert.deepEqual(talkKeyPress({ latched: false, microphoneCall: true }), {
+    deferToRelease: false,
+    openCall: false,
+  });
+});
+
+test("the press-wait meter rides a handshake and a pending takeover, nothing else", () => {
+  assert.equal(talkOpeningHolds({ status: REALTIME_STATUS.CONNECTING, turnPending: false }), true);
+  assert.equal(talkOpeningHolds({ status: REALTIME_STATUS.READY, turnPending: true }), true);
+  assert.equal(talkOpeningHolds({ status: REALTIME_STATUS.LISTENING, turnPending: false }), false);
+  assert.equal(talkOpeningHolds({ status: REALTIME_STATUS.READY, turnPending: false }), false);
+  assert.equal(talkOpeningHolds({ status: REALTIME_STATUS.FAILED, turnPending: false }), false);
+});
+
+test("a typed ask's caption holds only for the reply it opened", () => {
+  assert.equal(typedAskHolds(REALTIME_STATUS.RESPONDING), true);
+  assert.equal(typedAskHolds(REALTIME_STATUS.READY), false);
+  assert.equal(typedAskHolds(REALTIME_STATUS.LISTENING), false);
+});
+
+test("the first stored pace is not a change, and a later one is", () => {
+  assert.equal(liveSpeedApplies(undefined, REALTIME_VOICE_SPEED.QUICK), false);
+  assert.equal(liveSpeedApplies(REALTIME_VOICE_SPEED.NORMAL, REALTIME_VOICE_SPEED.NORMAL), false);
+  assert.equal(liveSpeedApplies(REALTIME_VOICE_SPEED.NORMAL, REALTIME_VOICE_SPEED.QUICK), true);
+  assert.equal(liveSpeedApplies(REALTIME_VOICE_SPEED.QUICK, undefined), false);
+});
+
+test("a changed voice on a live call waits for the turn to end, then restarts", () => {
+  const change = {
+    previous: REALTIME_VOICE.CEDAR,
+    next: REALTIME_VOICE.MARIN,
+    live: true,
+    due: false,
+    status: REALTIME_STATUS.RESPONDING,
+  };
+  assert.deepEqual(voiceRestartAction(change), { due: true, action: VOICE_RESTART.WAIT });
+  assert.deepEqual(voiceRestartAction({ ...change, status: REALTIME_STATUS.LISTENING }), {
+    due: true,
+    action: VOICE_RESTART.WAIT,
+  });
+  assert.deepEqual(voiceRestartAction({ ...change, status: REALTIME_STATUS.READY }), {
+    due: false,
+    action: VOICE_RESTART.RESTART,
+  });
+});
+
+test("a call that ended on its own owes the new voice nothing", () => {
+  const owed = {
+    previous: REALTIME_VOICE.CEDAR,
+    next: REALTIME_VOICE.MARIN,
+    live: false,
+    due: true,
+    status: REALTIME_STATUS.IDLE,
+  };
+  assert.deepEqual(voiceRestartAction(owed), { due: false, action: VOICE_RESTART.DROP });
+  assert.deepEqual(voiceRestartAction({ ...owed, status: REALTIME_STATUS.FAILED }), {
+    due: false,
+    action: VOICE_RESTART.DROP,
+  });
+  assert.deepEqual(voiceRestartAction({ ...owed, status: REALTIME_STATUS.UNAVAILABLE }), {
+    due: false,
+    action: VOICE_RESTART.DROP,
+  });
+});
+
+test("the first snapshot of the voice is stored, not restarted", () => {
+  assert.deepEqual(
+    voiceRestartAction({
+      previous: undefined,
+      next: REALTIME_VOICE.CEDAR,
+      live: true,
+      due: false,
+      status: REALTIME_STATUS.READY,
+    }),
+    { due: false, action: VOICE_RESTART.NONE },
+  );
+});
+
+test("a voice change with no call up is not owed a restart", () => {
+  assert.deepEqual(
+    voiceRestartAction({
+      previous: REALTIME_VOICE.CEDAR,
+      next: REALTIME_VOICE.MARIN,
+      live: false,
+      due: false,
+      status: REALTIME_STATUS.IDLE,
+    }),
+    { due: false, action: VOICE_RESTART.NONE },
+  );
+});
+
+test("a connecting call counts as one to reopen: its credential may already be the old voice", () => {
+  assert.deepEqual(
+    voiceRestartAction({
+      previous: REALTIME_VOICE.CEDAR,
+      next: REALTIME_VOICE.MARIN,
+      live: true,
+      due: false,
+      status: REALTIME_STATUS.CONNECTING,
+    }),
+    { due: true, action: VOICE_RESTART.WAIT },
+  );
+});
+
+function speech(source: AttentionSpeech["source"], id: string): AttentionSpeech {
+  return {
+    providerId: "claude-code",
+    providerSessionId: id,
+    disposition: ATTENTION_DISPOSITION.SPEAK_AT_TURN_END,
+    source,
+    summary: `${id} finished.`,
+    decidedAt: 1_000,
+  };
+}
+
+test("status-edge notices go to the announcer; evaluator summaries keep to an open call", () => {
+  const edge = speech(ATTENTION_SPEECH_SOURCE.STATUS_EDGE, "checkout");
+  const summary = speech(ATTENTION_SPEECH_SOURCE.EVALUATOR, "payments");
+  const mixed = [edge, summary];
+  assert.deepEqual(statusEdgeNotices(mixed), [edge]);
+  assert.deepEqual(evaluatorSummaries(mixed), [summary]);
+});


### PR DESCRIPTION
## Summary

- `App()` held the conversation, composers, surface shape, and bootstrap race in one closure. These commits pull each cluster into its own hook so the rules can be tested without rendering the panel.
- `useVoiceConversation`, `usePanelEntry`, `usePanelPresentation`, `useStateWithRef`, and `useBootstrapRacedChannel` each ship with tests of their pure companions.

## Evidence

- Platform-independent checks: `passed` (`./scripts/check.sh`)
- macOS Electron verification (`./scripts/verify.sh`): `passed`

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31849946754/artifacts/9237199008) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31849946754)

- Commit: `3ebd459ddd45e25b018424e50346f9f0b655973d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: None


Made with [Cursor](https://cursor.com)