### PR TITLE
refactor(adapters): unify act-result status and restore honest capability probes

### DIFF
--- a/apps/desktop/src/cloud-session-adapter.ts
+++ b/apps/desktop/src/cloud-session-adapter.ts
@@ -1,10 +1,9 @@
 import {
-  type ControllableSessionProviderAdapter,
   isRecord,
-  type MessageCapableSessionProviderAdapter,
   nonNegativeNumber,
   OBSERVATION_WINDOW,
-  PROVIDER_MESSAGE_RESULT_STATUS,
+  PROVIDER_ACT_RESULT_STATUS,
+  type ProviderActResult,
   type ProviderControlRequest,
   type ProviderControlResult,
   type ProviderMessageResult,
@@ -18,14 +17,13 @@ import {
   SESSION_STATUS,
   type SessionControl,
   type SessionProvider,
+  type SessionProviderAdapter,
   type SessionStatus,
   sessionMessageText,
   text,
   UNKNOWN_WORKSPACE_LABEL,
   WORKSPACE_TASK_SUPPORT,
-  type WorkspaceAgentCapableSessionProviderAdapter,
   type WorkspaceAgentSelection,
-  type WorkspaceCapableSessionProviderAdapter,
   type WorkspaceProject,
   workspaceNameText,
 } from "@sidecar/core";
@@ -242,22 +240,19 @@ function resolveBaseUrl(profile: CloudAdapterProfile, configured: string | undef
 /**
  * The shared half of every cloud provider adapter: credential handling, its own
  * refresh cadence, the failure rules that decide whether a snapshot survives,
- * and bounded read-only requests. A subclass supplies only the provider's
- * routes and how its reported state maps onto Luke's.
+ * and bounded read-only requests. A subclass supplies the provider's routes,
+ * how its reported state maps onto Luke's, and — by declaring the matching
+ * interfaces — which writes it actually routes.
  *
- * The only writes any of this can make are `sendMessage`, `executeControl`,
- * and `createWorkspace`, and each acts on nothing but what a user asked for
- * against something the last pass observed — a session that advertised the
- * capability being used, or a project the provider itself listed.
- * Observation itself stays read-only.
+ * Write machinery lives here as protected helpers so a subclass that does not
+ * route a capability does not grow the method the probe looks for: capability
+ * is which interfaces the adapter declares, the same meaning local adapters
+ * already have. Each helper acts on nothing but what a user asked for against
+ * something the last pass observed — a session that advertised the capability
+ * being used, or a project the provider itself listed. Observation itself
+ * stays read-only.
  */
-export abstract class CloudSessionAdapter
-  implements
-    MessageCapableSessionProviderAdapter,
-    ControllableSessionProviderAdapter,
-    WorkspaceCapableSessionProviderAdapter,
-    WorkspaceAgentCapableSessionProviderAdapter
-{
+export abstract class CloudSessionAdapter implements SessionProviderAdapter {
   readonly provider: SessionProvider;
 
   readonly #readApiKey: () => Promise<string | undefined>;
@@ -346,18 +341,20 @@ export abstract class CloudSessionAdapter
    * text outside the message bound, and a missing credential all answer
    * without touching the network.
    */
-  async sendMessage(message: ProviderSessionMessage): Promise<ProviderMessageResult> {
+  protected async sendObservedMessage(
+    message: ProviderSessionMessage,
+  ): Promise<ProviderMessageResult> {
     const observation = this.#observations.find(
       (candidate) => candidate.providerSessionId === message.providerSessionId,
     );
     if (!observation?.canReceiveMessage) {
-      return { status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED };
+      return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
     }
 
     const text = sessionMessageText(message.text);
     if (!text) {
       return {
-        status: PROVIDER_MESSAGE_RESULT_STATUS.REJECTED,
+        status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
         reason: "A message has to be shorter than a document and longer than nothing.",
       };
     }
@@ -371,13 +368,13 @@ export abstract class CloudSessionAdapter
     if (!apiKey) return this.#missingKeyRejection();
 
     const route = this.messageRoute(message.providerSessionId, text);
-    if (!route) return { status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED };
+    if (!route) return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
     return this.#postWrite(apiKey, route);
   }
 
-  #missingKeyRejection(): ProviderMessageResult {
+  #missingKeyRejection(): ProviderActResult {
     return {
-      status: PROVIDER_MESSAGE_RESULT_STATUS.REJECTED,
+      status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
       reason: `${this.provider.displayName}'s API key is no longer configured.`,
     };
   }
@@ -389,7 +386,9 @@ export abstract class CloudSessionAdapter
    * not observe, for a control that session did not advertise, or without a
    * credential.
    */
-  async executeControl(request: ProviderControlRequest): Promise<ProviderControlResult> {
+  protected async executeObservedControl(
+    request: ProviderControlRequest,
+  ): Promise<ProviderControlResult> {
     const observation = this.#observations.find(
       (candidate) => candidate.providerSessionId === request.providerSessionId,
     );
@@ -397,23 +396,14 @@ export abstract class CloudSessionAdapter
     // is built from, so whatever it targets is the thing the last pass actually
     // saw, and nothing a caller sends can redirect it.
     const advertised = observation?.controls?.find((control) => control.id === request.control.id);
-    if (!advertised) return { status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED };
+    if (!advertised) return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
 
     const apiKey = await this.#readApiKey().catch(() => undefined);
     if (!apiKey) return this.#missingKeyRejection();
 
     const route = this.controlRoute(request.providerSessionId, advertised);
-    if (!route) return { status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED };
+    if (!route) return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
     return this.#postWrite(apiKey, route);
-  }
-
-  /**
-   * The projects the latest pass reported this provider will create a
-   * workspace in. Empty by default, so a provider that documents no creation
-   * endpoint offers nowhere — the same posture as the write routes below.
-   */
-  workspaceProjects(): readonly WorkspaceProject[] {
-    return [];
   }
 
   /**
@@ -423,29 +413,29 @@ export abstract class CloudSessionAdapter
    * its observation did not list, a name or task outside its bound, and a
    * missing credential all answer without touching the network.
    */
-  async spawnWorkspaceAgent(
+  protected async spawnObservedWorkspaceAgent(
     request: ProviderWorkspaceAgentRequest,
   ): Promise<ProviderWorkspaceResult> {
     const observation = this.#observations.find(
       (candidate) => candidate.providerSessionId === request.providerSessionId,
     );
-    if (!observation) return { status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED };
+    if (!observation) return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
     // The advertised list — not the caller's word — is what the route is
     // built from, so an agent kind is only ever one the last pass promised.
     const agent = observation.spawnableAgents?.find((candidate) => candidate === request.agent);
-    if (!agent) return { status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED };
+    if (!agent) return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
 
     const name = request.name === undefined ? undefined : workspaceNameText(request.name);
     if (request.name !== undefined && !name) {
       return {
-        status: PROVIDER_MESSAGE_RESULT_STATUS.REJECTED,
+        status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
         reason: "A session name has to be short enough to say and longer than nothing.",
       };
     }
     const task = request.task === undefined ? undefined : sessionMessageText(request.task);
     if (request.task !== undefined && !task) {
       return {
-        status: PROVIDER_MESSAGE_RESULT_STATUS.REJECTED,
+        status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
         reason: "A task has to be shorter than a document and longer than nothing.",
       };
     }
@@ -461,7 +451,7 @@ export abstract class CloudSessionAdapter
       request.model,
       request.effort,
     );
-    if (!route) return { status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED };
+    if (!route) return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
 
     const apiKey = await this.#readApiKey().catch(() => undefined);
     if (!apiKey) return this.#missingKeyRejection();
@@ -497,16 +487,19 @@ export abstract class CloudSessionAdapter
    * outside its bound, a task a project does not take or the absence of one it
    * needs, and a missing credential all answer without touching the network.
    */
-  async createWorkspace(request: ProviderWorkspaceRequest): Promise<ProviderWorkspaceResult> {
-    const project = this.workspaceProjects().find(
+  protected async createObservedWorkspace(
+    request: ProviderWorkspaceRequest,
+    projects: readonly WorkspaceProject[],
+  ): Promise<ProviderWorkspaceResult> {
+    const project = projects.find(
       (candidate) => candidate.providerProjectId === request.providerProjectId,
     );
-    if (!project) return { status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED };
+    if (!project) return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
 
     const name = request.name === undefined ? undefined : workspaceNameText(request.name);
     if (request.name !== undefined && !name) {
       return {
-        status: PROVIDER_MESSAGE_RESULT_STATUS.REJECTED,
+        status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
         reason: "A workspace name has to be short enough to say and longer than nothing.",
       };
     }
@@ -517,19 +510,19 @@ export abstract class CloudSessionAdapter
     const task = request.task === undefined ? undefined : sessionMessageText(request.task);
     if (request.task !== undefined && !task) {
       return {
-        status: PROVIDER_MESSAGE_RESULT_STATUS.REJECTED,
+        status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
         reason: "A task has to be shorter than a document and longer than nothing.",
       };
     }
     if (task && project.taskSupport === WORKSPACE_TASK_SUPPORT.NONE) {
       return {
-        status: PROVIDER_MESSAGE_RESULT_STATUS.REJECTED,
+        status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
         reason: "This project takes no opening task.",
       };
     }
     if (!task && project.taskSupport === WORKSPACE_TASK_SUPPORT.REQUIRED) {
       return {
-        status: PROVIDER_MESSAGE_RESULT_STATUS.REJECTED,
+        status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
         reason: "This project needs an opening task to create a workspace.",
       };
     }
@@ -538,9 +531,9 @@ export abstract class CloudSessionAdapter
     if (!apiKey) return this.#missingKeyRejection();
 
     const route = this.workspaceCreationRoute(project, name, task, request.agentSelection);
-    if (!route) return { status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED };
+    if (!route) return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
     const created = await this.#postWriteDetailed(apiKey, route, WRITE_SUBJECT.PROJECT);
-    if (created.outcome.status !== PROVIDER_MESSAGE_RESULT_STATUS.ACCEPTED || !task) {
+    if (created.outcome.status !== PROVIDER_ACT_RESULT_STATUS.ACCEPTED || !task) {
       return created.outcome;
     }
 
@@ -552,18 +545,18 @@ export abstract class CloudSessionAdapter
     if (followUp === undefined) return created.outcome;
     if ("undeliverable" in followUp) {
       return {
-        status: PROVIDER_MESSAGE_RESULT_STATUS.REJECTED,
+        status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
         reason: `The workspace was created, but its opening task was not delivered: ${followUp.undeliverable}`,
       };
     }
     const delivered = await this.#postWriteDetailed(apiKey, followUp, WRITE_SUBJECT.SESSION);
-    if (delivered.outcome.status === PROVIDER_MESSAGE_RESULT_STATUS.ACCEPTED) {
+    if (delivered.outcome.status === PROVIDER_ACT_RESULT_STATUS.ACCEPTED) {
       return created.outcome;
     }
     return {
-      status: PROVIDER_MESSAGE_RESULT_STATUS.REJECTED,
+      status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
       reason: `The workspace was created, but its opening task was not delivered: ${
-        delivered.outcome.status === PROVIDER_MESSAGE_RESULT_STATUS.REJECTED
+        delivered.outcome.status === PROVIDER_ACT_RESULT_STATUS.REJECTED
           ? delivered.outcome.reason
           : "the provider documents no way to hand it over."
       }`,
@@ -773,7 +766,7 @@ export abstract class CloudSessionAdapter
     apiKey: string,
     route: CloudWriteRoute,
     subject: WriteSubject = WRITE_SUBJECT.SESSION,
-  ): Promise<ProviderMessageResult> {
+  ): Promise<ProviderActResult> {
     return (await this.#postWriteDetailed(apiKey, route, subject)).outcome;
   }
 
@@ -786,7 +779,7 @@ export abstract class CloudSessionAdapter
     apiKey: string,
     route: CloudWriteRoute,
     subject: WriteSubject,
-  ): Promise<{ outcome: ProviderMessageResult; body?: Record<string, unknown> }> {
+  ): Promise<{ outcome: ProviderActResult; body?: Record<string, unknown> }> {
     const name = this.provider.displayName;
     let response: Response;
     try {
@@ -807,7 +800,7 @@ export abstract class CloudSessionAdapter
     } catch {
       return {
         outcome: {
-          status: PROVIDER_MESSAGE_RESULT_STATUS.REJECTED,
+          status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
           reason: `${name} could not be reached, so nothing was sent.`,
         },
       };
@@ -823,14 +816,14 @@ export abstract class CloudSessionAdapter
       // yes, so only a follow-up that needed the body has anything to miss.
       const body = await response.json().catch(() => undefined);
       return {
-        outcome: { status: PROVIDER_MESSAGE_RESULT_STATUS.ACCEPTED },
+        outcome: { status: PROVIDER_ACT_RESULT_STATUS.ACCEPTED },
         ...(isRecord(body) ? { body } : {}),
       };
     }
     if (response.status === HTTP_STATUS.UNAUTHORIZED || response.status === HTTP_STATUS.FORBIDDEN) {
       return {
         outcome: {
-          status: PROVIDER_MESSAGE_RESULT_STATUS.REJECTED,
+          status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
           reason: `${name} rejected the configured API key.`,
         },
       };
@@ -838,7 +831,7 @@ export abstract class CloudSessionAdapter
     if (response.status === HTTP_STATUS.NOT_FOUND) {
       return {
         outcome: {
-          status: PROVIDER_MESSAGE_RESULT_STATUS.REJECTED,
+          status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
           reason: `${name} no longer has this ${subject}.`,
         },
       };
@@ -846,14 +839,14 @@ export abstract class CloudSessionAdapter
     if (response.status === HTTP_STATUS.CONFLICT) {
       return {
         outcome: {
-          status: PROVIDER_MESSAGE_RESULT_STATUS.REJECTED,
+          status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
           reason: `${name} says this ${subject} has moved on since Luke last looked.`,
         },
       };
     }
     return {
       outcome: {
-        status: PROVIDER_MESSAGE_RESULT_STATUS.REJECTED,
+        status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
         reason: `${name} answered with status ${response.status}, so the request may not have landed.`,
       },
     };

--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -1,9 +1,18 @@
 import {
   agedStatus,
+  type ControllableSessionProviderAdapter,
+  type MessageCapableSessionProviderAdapter,
   maximumSessionSummaryLength,
   maximumSessionTitleLength,
   OBSERVATION_WINDOW,
+  type ProviderControlRequest,
+  type ProviderControlResult,
+  type ProviderMessageResult,
+  type ProviderSessionMessage,
   type ProviderSessionObservation,
+  type ProviderWorkspaceAgentRequest,
+  type ProviderWorkspaceRequest,
+  type ProviderWorkspaceResult,
   positiveInteger,
   SESSION_CONTROL_KIND,
   SESSION_STATUS,
@@ -11,7 +20,9 @@ import {
   type SessionProvider,
   type SessionStatus,
   WORKSPACE_TASK_SUPPORT,
+  type WorkspaceAgentCapableSessionProviderAdapter,
   type WorkspaceAgentSelection,
+  type WorkspaceCapableSessionProviderAdapter,
   type WorkspaceProject,
 } from "@sidecar/core";
 import {
@@ -313,7 +324,14 @@ interface ConductorSession {
  * own endpoint on a chat that advertised it, and a new workspace in a project
  * the latest pass listed, through Conductor's documented creation endpoint.
  */
-export class ConductorSessionAdapter extends CloudSessionAdapter {
+export class ConductorSessionAdapter
+  extends CloudSessionAdapter
+  implements
+    MessageCapableSessionProviderAdapter,
+    ControllableSessionProviderAdapter,
+    WorkspaceCapableSessionProviderAdapter,
+    WorkspaceAgentCapableSessionProviderAdapter
+{
   readonly #maximumObservedWorkspaces: number;
   readonly #maximumObservedSessions: number;
 
@@ -344,6 +362,24 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
     );
   }
 
+  async sendMessage(message: ProviderSessionMessage): Promise<ProviderMessageResult> {
+    return this.sendObservedMessage(message);
+  }
+
+  async executeControl(request: ProviderControlRequest): Promise<ProviderControlResult> {
+    return this.executeObservedControl(request);
+  }
+
+  async createWorkspace(request: ProviderWorkspaceRequest): Promise<ProviderWorkspaceResult> {
+    return this.createObservedWorkspace(request, this.workspaceProjects());
+  }
+
+  async spawnWorkspaceAgent(
+    request: ProviderWorkspaceAgentRequest,
+  ): Promise<ProviderWorkspaceResult> {
+    return this.spawnObservedWorkspaceAgent(request);
+  }
+
   protected override forgetCachedIdentity(): void {
     this.#userId = undefined;
     this.#projects = [];
@@ -355,7 +391,7 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
    * happily — and is handed over after creation, through the documented
    * message endpoint on the first session the creation response names.
    */
-  override workspaceProjects(): readonly WorkspaceProject[] {
+  workspaceProjects(): readonly WorkspaceProject[] {
     return this.#projects.map((project) => ({
       providerProjectId: project.id,
       repository: project.repositoryLabel,

--- a/apps/desktop/src/cursor-adapter.ts
+++ b/apps/desktop/src/cursor-adapter.ts
@@ -1,11 +1,19 @@
 import {
   agedStatus,
+  type ControllableSessionProviderAdapter,
   isRecord,
+  type MessageCapableSessionProviderAdapter,
   maximumObservedWorkspaceProjects,
   maximumSessionSummaryLength,
   maximumSessionTitleLength,
   OBSERVATION_WINDOW,
+  type ProviderControlRequest,
+  type ProviderControlResult,
+  type ProviderMessageResult,
+  type ProviderSessionMessage,
   type ProviderSessionObservation,
+  type ProviderWorkspaceRequest,
+  type ProviderWorkspaceResult,
   positiveInteger,
   SESSION_CONTROL_KIND,
   SESSION_STATUS,
@@ -13,6 +21,7 @@ import {
   type SessionProvider,
   type SessionStatus,
   WORKSPACE_TASK_SUPPORT,
+  type WorkspaceCapableSessionProviderAdapter,
   type WorkspaceProject,
 } from "@sidecar/core";
 import {
@@ -262,7 +271,13 @@ function agentFromRecord(record: Record<string, unknown>): CursorAgent | undefin
  * for with the user's own opening task — in a repository Cursor listed for
  * this key, through its documented creation endpoint.
  */
-export class CursorSessionAdapter extends CloudSessionAdapter {
+export class CursorSessionAdapter
+  extends CloudSessionAdapter
+  implements
+    MessageCapableSessionProviderAdapter,
+    ControllableSessionProviderAdapter,
+    WorkspaceCapableSessionProviderAdapter
+{
   readonly #maximumObservedSessions: number;
 
   /**
@@ -287,6 +302,18 @@ export class CursorSessionAdapter extends CloudSessionAdapter {
       options.maximumObservedSessions,
       CURSOR_ADAPTER_DEFAULTS.MAXIMUM_OBSERVED_SESSIONS,
     );
+  }
+
+  async sendMessage(message: ProviderSessionMessage): Promise<ProviderMessageResult> {
+    return this.sendObservedMessage(message);
+  }
+
+  async executeControl(request: ProviderControlRequest): Promise<ProviderControlResult> {
+    return this.executeObservedControl(request);
+  }
+
+  async createWorkspace(request: ProviderWorkspaceRequest): Promise<ProviderWorkspaceResult> {
+    return this.createObservedWorkspace(request, this.workspaceProjects());
   }
 
   protected override forgetCachedIdentity(): void {
@@ -409,7 +436,7 @@ export class CursorSessionAdapter extends CloudSessionAdapter {
    * the identifier because it is the identifier Cursor's own API uses; it is
    * still one the provider reported, never one an ask composed.
    */
-  override workspaceProjects(): readonly WorkspaceProject[] {
+  workspaceProjects(): readonly WorkspaceProject[] {
     return this.#repositories.map((url) => ({
       providerProjectId: url,
       repository: repositoryLabel(url, undefined),

--- a/apps/desktop/src/devin-adapter.ts
+++ b/apps/desktop/src/devin-adapter.ts
@@ -1,7 +1,10 @@
 import {
   agedStatus,
   isRecord,
+  type MessageCapableSessionProviderAdapter,
   OBSERVATION_WINDOW,
+  type ProviderMessageResult,
+  type ProviderSessionMessage,
   type ProviderSessionObservation,
   positiveInteger,
   SESSION_STATUS,
@@ -268,7 +271,10 @@ function sessionFromRecord(
  * The one write it supports is a user-typed message, through Devin's own
  * message endpoint, to a session it advertised as taking one.
  */
-export class DevinSessionAdapter extends CloudSessionAdapter {
+export class DevinSessionAdapter
+  extends CloudSessionAdapter
+  implements MessageCapableSessionProviderAdapter
+{
   readonly #maximumObservedSessions: number;
 
   /** The identity, or `null` once Devin has named one Luke cannot observe as. */
@@ -287,6 +293,10 @@ export class DevinSessionAdapter extends CloudSessionAdapter {
       options.maximumObservedSessions,
       DEVIN_ADAPTER_DEFAULTS.MAXIMUM_OBSERVED_SESSIONS,
     );
+  }
+
+  async sendMessage(message: ProviderSessionMessage): Promise<ProviderMessageResult> {
+    return this.sendObservedMessage(message);
   }
 
   protected override forgetCachedIdentity(): void {

--- a/apps/desktop/src/jules-adapter.ts
+++ b/apps/desktop/src/jules-adapter.ts
@@ -1,7 +1,13 @@
 import {
   agedStatus,
+  type ControllableSessionProviderAdapter,
   isRecord,
+  type MessageCapableSessionProviderAdapter,
   OBSERVATION_WINDOW,
+  type ProviderControlRequest,
+  type ProviderControlResult,
+  type ProviderMessageResult,
+  type ProviderSessionMessage,
   type ProviderSessionObservation,
   positiveInteger,
   SESSION_STATUS,
@@ -200,7 +206,10 @@ const JULES_MESSAGEABLE_STATES: ReadonlySet<JulesState> = new Set([
  * approval, each through Jules's own custom method on a session that
  * advertised it.
  */
-export class JulesSessionAdapter extends CloudSessionAdapter {
+export class JulesSessionAdapter
+  extends CloudSessionAdapter
+  implements MessageCapableSessionProviderAdapter, ControllableSessionProviderAdapter
+{
   readonly #maximumObservedSessions: number;
 
   constructor(options: JulesAdapterOptions) {
@@ -219,6 +228,14 @@ export class JulesSessionAdapter extends CloudSessionAdapter {
       options.maximumObservedSessions,
       JULES_ADAPTER_DEFAULTS.MAXIMUM_OBSERVED_SESSIONS,
     );
+  }
+
+  async sendMessage(message: ProviderSessionMessage): Promise<ProviderMessageResult> {
+    return this.sendObservedMessage(message);
+  }
+
+  async executeControl(request: ProviderControlRequest): Promise<ProviderControlResult> {
+    return this.executeObservedControl(request);
   }
 
   protected async collect(

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -24,8 +24,7 @@ import {
   normalizeTrackedIssue,
   type ObservedWorkspaceProject,
   type PanelFormFactor,
-  PROVIDER_CONTROL_RESULT_STATUS,
-  PROVIDER_MESSAGE_RESULT_STATUS,
+  PROVIDER_ACT_RESULT_STATUS,
   type ProviderControlResult,
   type ProviderMessageResult,
   type ProviderWorkspaceResult,
@@ -1520,7 +1519,7 @@ function registerIpc(): void {
       const messageText = sessionMessageText(text);
       if (!messageText) {
         return {
-          status: PROVIDER_MESSAGE_RESULT_STATUS.REJECTED,
+          status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
           reason: "A message has to be shorter than a document and longer than nothing.",
         };
       }
@@ -1528,13 +1527,13 @@ function registerIpc(): void {
       // deterministic capture must not reach any provider.
       const session = sessionRegistry.get(identity);
       if (!session?.canReceiveMessage) {
-        return { status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED };
+        return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
       }
       const adapter = sessionAdapters.find(
         (candidate) => candidate.provider.id === identity.providerId,
       );
       if (!adapter || !isMessageCapableAdapter(adapter)) {
-        return { status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED };
+        return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
       }
       const result = await adapter.sendMessage({
         providerSessionId: identity.providerSessionId,
@@ -1542,7 +1541,7 @@ function registerIpc(): void {
       });
       // A message that landed changes what the session is doing, so the row
       // should catch up as soon as its provider will say.
-      if (result.status === PROVIDER_MESSAGE_RESULT_STATUS.ACCEPTED) {
+      if (result.status === PROVIDER_ACT_RESULT_STATUS.ACCEPTED) {
         void sessionRegistry.refresh(adapter);
       }
       return result;
@@ -1562,18 +1561,18 @@ function registerIpc(): void {
       }
       const session = sessionRegistry.get(identity);
       const control = session?.controls.find((candidate) => candidate.id === controlId);
-      if (!control) return { status: PROVIDER_CONTROL_RESULT_STATUS.UNSUPPORTED };
+      if (!control) return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
       const adapter = sessionAdapters.find(
         (candidate) => candidate.provider.id === identity.providerId,
       );
       if (!adapter || !isControllableAdapter(adapter)) {
-        return { status: PROVIDER_CONTROL_RESULT_STATUS.UNSUPPORTED };
+        return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
       }
       const result = await adapter.executeControl({
         providerSessionId: identity.providerSessionId,
         control,
       });
-      if (result.status === PROVIDER_CONTROL_RESULT_STATUS.ACCEPTED) {
+      if (result.status === PROVIDER_ACT_RESULT_STATUS.ACCEPTED) {
         void sessionRegistry.refresh(adapter);
       }
       return result;
@@ -1612,19 +1611,19 @@ function registerIpc(): void {
       if (namedSelection !== undefined && !isWorkspaceAgentSelection(providerId, namedSelection)) {
         throw new Error("Invalid workspace creation request");
       }
-      if (fixtureMode) return { status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED };
+      if (fixtureMode) return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
       const adapter = sessionAdapters.find((candidate) => candidate.provider.id === providerId);
       if (!adapter || !isWorkspaceCapableAdapter(adapter)) {
-        return { status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED };
+        return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
       }
       const offered = adapter
         .workspaceProjects()
         .some((project) => project.providerProjectId === providerProjectId);
-      if (!offered) return { status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED };
+      if (!offered) return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
       const workspaceName = name === undefined ? undefined : workspaceNameText(name);
       if (name !== undefined && workspaceName === undefined) {
         return {
-          status: PROVIDER_MESSAGE_RESULT_STATUS.REJECTED,
+          status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
           reason: "A workspace name has to be short enough to say and longer than nothing.",
         };
       }
@@ -1633,7 +1632,7 @@ function registerIpc(): void {
       const openingTask = task === undefined ? undefined : sessionMessageText(task);
       if (task !== undefined && openingTask === undefined) {
         return {
-          status: PROVIDER_MESSAGE_RESULT_STATUS.REJECTED,
+          status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
           reason: "A task has to be shorter than a document and longer than nothing.",
         };
       }
@@ -1657,7 +1656,7 @@ function registerIpc(): void {
       // rejection refreshes too: a workspace can stand with its opening task
       // undelivered, and the adapter answers a rejection that never reached
       // the network from its cache anyway.
-      if (result.status !== PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED) {
+      if (result.status !== PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED) {
         void sessionRegistry.refresh(adapter);
       }
       // The first workspace that actually lands chooses the default provider,
@@ -1667,7 +1666,7 @@ function registerIpc(): void {
       // model composed decides this — and losing the save loses only the
       // remembered default, never the workspace that just landed.
       if (
-        result.status === PROVIDER_MESSAGE_RESULT_STATUS.ACCEPTED &&
+        result.status === PROVIDER_ACT_RESULT_STATUS.ACCEPTED &&
         isProviderId(adapter.provider.id)
       ) {
         try {
@@ -1788,7 +1787,7 @@ function registerIpc(): void {
       // A fixture run has an empty registry, so it refuses every ask.
       const session = sessionRegistry.get(identity);
       const advertised = session?.spawnableAgents.find((candidate) => candidate === agent.trim());
-      if (!advertised) return { status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED };
+      if (!advertised) return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
       // A model named for this one agent must be a documented pairing of
       // exactly the asked-for kind: the user's chosen agent is never
       // re-decided by the model named beside it.
@@ -1806,19 +1805,19 @@ function registerIpc(): void {
         (candidate) => candidate.provider.id === identity.providerId,
       );
       if (!adapter || !isWorkspaceAgentCapableAdapter(adapter)) {
-        return { status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED };
+        return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
       }
       const sessionName = name === undefined ? undefined : workspaceNameText(name);
       if (name !== undefined && sessionName === undefined) {
         return {
-          status: PROVIDER_MESSAGE_RESULT_STATUS.REJECTED,
+          status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
           reason: "A session name has to be short enough to say and longer than nothing.",
         };
       }
       const openingTask = task === undefined ? undefined : sessionMessageText(task);
       if (task !== undefined && openingTask === undefined) {
         return {
-          status: PROVIDER_MESSAGE_RESULT_STATUS.REJECTED,
+          status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
           reason: "A task has to be shorter than a document and longer than nothing.",
         };
       }
@@ -1845,7 +1844,7 @@ function registerIpc(): void {
       // A new agent is a session the panel should be showing, so the next
       // look must actually ask rather than serve the cache — on a rejection
       // too, for the same reason a partial workspace creation refreshes.
-      if (result.status !== PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED) {
+      if (result.status !== PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED) {
         void sessionRegistry.refresh(adapter);
       }
       return result;

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -1,6 +1,6 @@
 import type { ProviderControlResult, ProviderMessageResult } from "@sidecar/core";
 import {
-  PROVIDER_MESSAGE_RESULT_STATUS,
+  PROVIDER_ACT_RESULT_STATUS,
   SESSION_CONTROL_KIND,
   SESSION_LOCATION,
   SESSION_STATE,
@@ -53,8 +53,8 @@ const COMPOSE_PLACEHOLDER = "Send a follow-up…";
 
 /** One outcome line under the actions, said once and replaced by the next. */
 function feedbackFor(result: ProviderMessageResult | ProviderControlResult): string | undefined {
-  if (result.status === PROVIDER_MESSAGE_RESULT_STATUS.REJECTED) return result.reason;
-  if (result.status === PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED) {
+  if (result.status === PROVIDER_ACT_RESULT_STATUS.REJECTED) return result.reason;
+  if (result.status === PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED) {
     return "The session has moved on and no longer takes this.";
   }
   return undefined;
@@ -147,7 +147,7 @@ function SessionRowActions({
     setFeedback(undefined);
     try {
       const result = await writes.sendMessage(session, text);
-      if (result.status === PROVIDER_MESSAGE_RESULT_STATUS.ACCEPTED) {
+      if (result.status === PROVIDER_ACT_RESULT_STATUS.ACCEPTED) {
         // The draft has become the session's; the field empties for the next.
         setDraft("");
         setFeedback(`Sent to ${session.provider}`);
@@ -173,7 +173,7 @@ function SessionRowActions({
         // until its provider is observed again, and a control that seems to have
         // done nothing would be pressed a second time.
         setFeedback(
-          result.status === PROVIDER_MESSAGE_RESULT_STATUS.ACCEPTED
+          result.status === PROVIDER_ACT_RESULT_STATUS.ACCEPTED
             ? `${session.provider} accepted`
             : feedbackFor(result),
         );

--- a/apps/desktop/tests/cloud-session-adapter.test.ts
+++ b/apps/desktop/tests/cloud-session-adapter.test.ts
@@ -1,6 +1,16 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  type ControllableSessionProviderAdapter,
+  isControllableAdapter,
+  isMessageCapableAdapter,
+  isWorkspaceAgentCapableAdapter,
+  isWorkspaceCapableAdapter,
+  type MessageCapableSessionProviderAdapter,
+  type ProviderControlRequest,
+  type ProviderControlResult,
+  type ProviderMessageResult,
+  type ProviderSessionMessage,
   type ProviderSessionObservation,
   SESSION_LOCATION,
   SESSION_STATUS,
@@ -76,13 +86,24 @@ function observation(
 const STUB_APPROVE_CONTROL = { id: "approve", label: "Approve" } as const;
 
 /** Stands in for a real provider so the shared half can be tested on its own. */
-class StubCloudAdapter extends CloudSessionAdapter {
+class StubCloudAdapter
+  extends CloudSessionAdapter
+  implements MessageCapableSessionProviderAdapter, ControllableSessionProviderAdapter
+{
   passes = 0;
   forgottenIdentities = 0;
   collected: readonly ProviderSessionObservation[] = [];
 
   constructor(options: CloudAdapterOptions) {
     super({ provider: STUB_PROVIDER, defaultBaseUrl: TEST_BASE_URL }, options);
+  }
+
+  async sendMessage(message: ProviderSessionMessage): Promise<ProviderMessageResult> {
+    return this.sendObservedMessage(message);
+  }
+
+  async executeControl(request: ProviderControlRequest): Promise<ProviderControlResult> {
+    return this.executeObservedControl(request);
   }
 
   protected override forgetCachedIdentity(): void {
@@ -132,6 +153,34 @@ function adapterFor(
     minimumRefreshIntervalMs: 0,
   });
 }
+
+/** A cloud adapter that observes and routes nothing. */
+class ObservationOnlyAdapter extends CloudSessionAdapter {
+  constructor(options: CloudAdapterOptions) {
+    super({ provider: STUB_PROVIDER, defaultBaseUrl: TEST_BASE_URL }, options);
+  }
+
+  protected async collect(): Promise<readonly ProviderSessionObservation[]> {
+    return [];
+  }
+}
+
+test("advertises only the writes a subclass has routed", () => {
+  const stub = adapterFor(stubFetch().fetch);
+  assert.equal(isMessageCapableAdapter(stub), true);
+  assert.equal(isControllableAdapter(stub), true);
+  assert.equal(isWorkspaceCapableAdapter(stub), false);
+  assert.equal(isWorkspaceAgentCapableAdapter(stub), false);
+
+  const observer = new ObservationOnlyAdapter({
+    readApiKey: async () => TEST_API_KEY,
+    baseUrl: TEST_BASE_URL,
+  });
+  assert.equal(isMessageCapableAdapter(observer), false);
+  assert.equal(isControllableAdapter(observer), false);
+  assert.equal(isWorkspaceCapableAdapter(observer), false);
+  assert.equal(isWorkspaceAgentCapableAdapter(observer), false);
+});
 
 test("accepts only a state this build knows", () => {
   const REPORTED_STATE = { IDLE: "idle", WORKING: "working" } as const;

--- a/apps/desktop/tests/conductor-adapter.test.ts
+++ b/apps/desktop/tests/conductor-adapter.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { SESSION_STATUS } from "@sidecar/core";
+import {
+  isControllableAdapter,
+  isMessageCapableAdapter,
+  isWorkspaceAgentCapableAdapter,
+  isWorkspaceCapableAdapter,
+  SESSION_STATUS,
+} from "@sidecar/core";
 import type { CloudFetch } from "../src/cloud-session-adapter";
 import { CONDUCTOR_PROVIDER, ConductorSessionAdapter } from "../src/conductor-adapter";
 
@@ -264,6 +270,14 @@ function adapterFor(
       : { maximumObservedSessions: overrides.maximumObservedSessions }),
   });
 }
+
+test("routes every write Conductor documents", () => {
+  const adapter = adapterFor(async () => new Response("{}", { status: 200 }));
+  assert.equal(isMessageCapableAdapter(adapter), true);
+  assert.equal(isControllableAdapter(adapter), true);
+  assert.equal(isWorkspaceCapableAdapter(adapter), true);
+  assert.equal(isWorkspaceAgentCapableAdapter(adapter), true);
+});
 
 const LUKE_PROJECT: TestProject = {
   id: "project-luke",

--- a/apps/desktop/tests/copilot-adapter.test.ts
+++ b/apps/desktop/tests/copilot-adapter.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { SESSION_STATUS } from "@sidecar/core";
+import {
+  isControllableAdapter,
+  isMessageCapableAdapter,
+  isWorkspaceAgentCapableAdapter,
+  isWorkspaceCapableAdapter,
+  SESSION_STATUS,
+} from "@sidecar/core";
 import type { CloudFetch } from "../src/cloud-session-adapter";
 import { COPILOT_PROVIDER, CopilotSessionAdapter } from "../src/copilot-adapter";
 
@@ -169,6 +175,14 @@ function adapterFor(
 function workingTask(id: string, updatedAt: number): TestTask {
   return { id, state: TEST_STATE.IN_PROGRESS, createdAt: updatedAt, updatedAt };
 }
+
+test("is read-only at the adapter probe, matching the writes it does not route", () => {
+  const adapter = adapterFor(fakeAgentTasksApi([]).fetch);
+  assert.equal(isMessageCapableAdapter(adapter), false);
+  assert.equal(isControllableAdapter(adapter), false);
+  assert.equal(isWorkspaceCapableAdapter(adapter), false);
+  assert.equal(isWorkspaceAgentCapableAdapter(adapter), false);
+});
 
 test("observes a task in progress without exposing prompt-derived text", async () => {
   const api = fakeAgentTasksApi([

--- a/apps/desktop/tests/cursor-adapter.test.ts
+++ b/apps/desktop/tests/cursor-adapter.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { SESSION_STATUS } from "@sidecar/core";
+import {
+  isControllableAdapter,
+  isMessageCapableAdapter,
+  isWorkspaceAgentCapableAdapter,
+  isWorkspaceCapableAdapter,
+  SESSION_STATUS,
+} from "@sidecar/core";
 import type { CloudFetch } from "../src/cloud-session-adapter";
 import { CURSOR_PROVIDER, CursorSessionAdapter } from "../src/cursor-adapter";
 
@@ -244,6 +250,14 @@ function adapterFor(
       : { maximumObservedSessions: overrides.maximumObservedSessions }),
   });
 }
+
+test("routes messages, controls, and workspace creation, and nothing else", () => {
+  const adapter = adapterFor(async () => new Response("{}", { status: 200 }));
+  assert.equal(isMessageCapableAdapter(adapter), true);
+  assert.equal(isControllableAdapter(adapter), true);
+  assert.equal(isWorkspaceCapableAdapter(adapter), true);
+  assert.equal(isWorkspaceAgentCapableAdapter(adapter), false);
+});
 
 function runningAgent(id: string, updatedAt: number): TestAgent {
   return {

--- a/apps/desktop/tests/devin-adapter.test.ts
+++ b/apps/desktop/tests/devin-adapter.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { SESSION_STATUS } from "@sidecar/core";
+import {
+  isControllableAdapter,
+  isMessageCapableAdapter,
+  isWorkspaceAgentCapableAdapter,
+  isWorkspaceCapableAdapter,
+  SESSION_STATUS,
+} from "@sidecar/core";
 import type { CloudFetch } from "../src/cloud-session-adapter";
 import { DEVIN_PROVIDER, DevinSessionAdapter } from "../src/devin-adapter";
 
@@ -200,6 +206,14 @@ function adapterFor(
 function workingSession(id: string, updatedAt: number): TestSession {
   return { id, status: TEST_STATUS.RUNNING, detail: TEST_DETAIL.WORKING, updatedAt };
 }
+
+test("routes messages and no other write", () => {
+  const adapter = adapterFor(async () => new Response("{}", { status: 200 }));
+  assert.equal(isMessageCapableAdapter(adapter), true);
+  assert.equal(isControllableAdapter(adapter), false);
+  assert.equal(isWorkspaceCapableAdapter(adapter), false);
+  assert.equal(isWorkspaceAgentCapableAdapter(adapter), false);
+});
 
 test("observes a working session and labels it the way Devin named it", async () => {
   const api = fakeDevinApi([workingSession("devin-working", TEST_TIME - 30_000)]);

--- a/apps/desktop/tests/jules-adapter.test.ts
+++ b/apps/desktop/tests/jules-adapter.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { SESSION_STATUS } from "@sidecar/core";
+import {
+  isControllableAdapter,
+  isMessageCapableAdapter,
+  isWorkspaceAgentCapableAdapter,
+  isWorkspaceCapableAdapter,
+  SESSION_STATUS,
+} from "@sidecar/core";
 import type { CloudFetch } from "../src/cloud-session-adapter";
 import { JULES_PROVIDER, JulesSessionAdapter } from "../src/jules-adapter";
 
@@ -165,6 +171,14 @@ function adapterFor(
 function workingSession(id: string, updateTime: number): TestSession {
   return { id, state: TEST_STATE.IN_PROGRESS, createTime: updateTime, updateTime };
 }
+
+test("routes messages and controls, and no other write", () => {
+  const adapter = adapterFor(async () => new Response("{}", { status: 200 }));
+  assert.equal(isMessageCapableAdapter(adapter), true);
+  assert.equal(isControllableAdapter(adapter), true);
+  assert.equal(isWorkspaceCapableAdapter(adapter), false);
+  assert.equal(isWorkspaceAgentCapableAdapter(adapter), false);
+});
 
 test("observes a session in progress without exposing prompt-derived text", async () => {
   const api = fakeJulesApi([

--- a/packages/sidecar-core/src/composite-provider-adapter.ts
+++ b/packages/sidecar-core/src/composite-provider-adapter.ts
@@ -5,8 +5,8 @@ import {
   isWorkspaceAgentCapableAdapter,
   isWorkspaceCapableAdapter,
   type MessageCapableSessionProviderAdapter,
-  PROVIDER_CONTROL_RESULT_STATUS,
-  PROVIDER_MESSAGE_RESULT_STATUS,
+  PROVIDER_ACT_RESULT_STATUS,
+  type ProviderActResult,
   type ProviderControlRequest,
   type ProviderControlResult,
   type ProviderMessageResult,
@@ -86,22 +86,12 @@ export class CompositeSessionProviderAdapter
    * answer, accepted or rejected, is the session's own and ends the search.
    */
   async sendMessage(message: ProviderSessionMessage): Promise<ProviderMessageResult> {
-    for (const adapter of this.#adapters) {
-      if (!isMessageCapableAdapter(adapter)) continue;
-      const result = await adapter.sendMessage(message);
-      if (result.status !== PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED) return result;
-    }
-    return { status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED };
+    return this.#dispatchAct(isMessageCapableAdapter, (adapter) => adapter.sendMessage(message));
   }
 
   /** A control finds its observer the same way a message does. */
   async executeControl(request: ProviderControlRequest): Promise<ProviderControlResult> {
-    for (const adapter of this.#adapters) {
-      if (!isControllableAdapter(adapter)) continue;
-      const result = await adapter.executeControl(request);
-      if (result.status !== PROVIDER_CONTROL_RESULT_STATUS.UNSUPPORTED) return result;
-    }
-    return { status: PROVIDER_CONTROL_RESULT_STATUS.UNSUPPORTED };
+    return this.#dispatchAct(isControllableAdapter, (adapter) => adapter.executeControl(request));
   }
 
   /** Every project any observer offered, in the order the observers stand in. */
@@ -117,23 +107,34 @@ export class CompositeSessionProviderAdapter
    * and any firm answer is the project's own and ends the search.
    */
   async createWorkspace(request: ProviderWorkspaceRequest): Promise<ProviderWorkspaceResult> {
-    for (const adapter of this.#adapters) {
-      if (!isWorkspaceCapableAdapter(adapter)) continue;
-      const result = await adapter.createWorkspace(request);
-      if (result.status !== PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED) return result;
-    }
-    return { status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED };
+    return this.#dispatchAct(isWorkspaceCapableAdapter, (adapter) =>
+      adapter.createWorkspace(request),
+    );
   }
 
   /** A new agent finds the observer holding its workspace the same way. */
   async spawnWorkspaceAgent(
     request: ProviderWorkspaceAgentRequest,
   ): Promise<ProviderWorkspaceResult> {
+    return this.#dispatchAct(isWorkspaceAgentCapableAdapter, (adapter) =>
+      adapter.spawnWorkspaceAgent(request),
+    );
+  }
+
+  /**
+   * Ask each capable observer in turn. Unsupported means this observer has
+   * never seen the subject, so the question moves on; any firm answer is the
+   * subject's own and ends the search.
+   */
+  async #dispatchAct<Capable extends SessionProviderAdapter>(
+    isCapable: (adapter: SessionProviderAdapter) => adapter is Capable,
+    act: (adapter: Capable) => Promise<ProviderActResult>,
+  ): Promise<ProviderActResult> {
     for (const adapter of this.#adapters) {
-      if (!isWorkspaceAgentCapableAdapter(adapter)) continue;
-      const result = await adapter.spawnWorkspaceAgent(request);
-      if (result.status !== PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED) return result;
+      if (!isCapable(adapter)) continue;
+      const result = await act(adapter);
+      if (result.status !== PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED) return result;
     }
-    return { status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED };
+    return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
   }
 }

--- a/packages/sidecar-core/src/providers.ts
+++ b/packages/sidecar-core/src/providers.ts
@@ -32,20 +32,32 @@ export function isProviderId(value: string): value is ProviderId {
   return PROVIDER_IDS.has(value);
 }
 
-export const PROVIDER_CONTROL_RESULT_STATUS = {
-  ACCEPTED: "accepted",
-  REJECTED: "rejected",
-  UNSUPPORTED: "unsupported",
-} as const;
-
-export type ProviderControlResultStatus =
-  (typeof PROVIDER_CONTROL_RESULT_STATUS)[keyof typeof PROVIDER_CONTROL_RESULT_STATUS];
-
 /** A provider adapter has no dependency on Electron, a renderer, or live UI state. */
 export interface SessionProviderAdapter {
   readonly provider: SessionProvider;
   observe(): Promise<readonly ProviderSessionObservation[]>;
 }
+
+/**
+ * What became of a write the user asked for. Every adapter capability answers
+ * with the same three: accepted, rejected with a reason the user can act on,
+ * or unsupported — the adapter has no documented way to do this, which is an
+ * answer rather than a failure. One status set, because two identical triples
+ * would be an API break the moment they diverged.
+ */
+export const PROVIDER_ACT_RESULT_STATUS = {
+  ACCEPTED: "accepted",
+  REJECTED: "rejected",
+  UNSUPPORTED: "unsupported",
+} as const;
+
+export type ProviderActResultStatus =
+  (typeof PROVIDER_ACT_RESULT_STATUS)[keyof typeof PROVIDER_ACT_RESULT_STATUS];
+
+export type ProviderActResult =
+  | { status: typeof PROVIDER_ACT_RESULT_STATUS.ACCEPTED }
+  | { status: typeof PROVIDER_ACT_RESULT_STATUS.REJECTED; reason: string }
+  | { status: typeof PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
 
 /** A provider-local request for a control that was previously exposed by observation. */
 export interface ProviderControlRequest {
@@ -54,13 +66,11 @@ export interface ProviderControlRequest {
 }
 
 /**
- * Providers must report unsupported or rejected controls explicitly; the core
- * deliberately provides no fallback path such as terminal input injection.
+ * What became of a control. Providers must report unsupported or rejected
+ * controls explicitly; the core deliberately provides no fallback path such
+ * as terminal input injection.
  */
-export type ProviderControlResult =
-  | { status: typeof PROVIDER_CONTROL_RESULT_STATUS.ACCEPTED }
-  | { status: typeof PROVIDER_CONTROL_RESULT_STATUS.REJECTED; reason: string }
-  | { status: typeof PROVIDER_CONTROL_RESULT_STATUS.UNSUPPORTED };
+export type ProviderControlResult = ProviderActResult;
 
 /**
  * Optional extension for adapters with a reliable provider-owned control path.
@@ -75,19 +85,8 @@ export interface ControllableSessionProviderAdapter extends SessionProviderAdapt
 export function isControllableAdapter(
   adapter: SessionProviderAdapter,
 ): adapter is ControllableSessionProviderAdapter {
-  return (
-    typeof (adapter as Partial<ControllableSessionProviderAdapter>).executeControl === "function"
-  );
+  return adapterHasFunctions(adapter, "executeControl");
 }
-
-export const PROVIDER_MESSAGE_RESULT_STATUS = {
-  ACCEPTED: "accepted",
-  REJECTED: "rejected",
-  UNSUPPORTED: "unsupported",
-} as const;
-
-export type ProviderMessageResultStatus =
-  (typeof PROVIDER_MESSAGE_RESULT_STATUS)[keyof typeof PROVIDER_MESSAGE_RESULT_STATUS];
 
 /** A user-authored message for one session the adapter has already observed. */
 export interface ProviderSessionMessage {
@@ -100,10 +99,7 @@ export interface ProviderSessionMessage {
  * never the message itself; unsupported means the adapter has no documented
  * way to message this session, which is an answer rather than a failure.
  */
-export type ProviderMessageResult =
-  | { status: typeof PROVIDER_MESSAGE_RESULT_STATUS.ACCEPTED }
-  | { status: typeof PROVIDER_MESSAGE_RESULT_STATUS.REJECTED; reason: string }
-  | { status: typeof PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED };
+export type ProviderMessageResult = ProviderActResult;
 
 /**
  * Optional extension for adapters whose provider documents a way to hand a
@@ -121,9 +117,7 @@ export interface MessageCapableSessionProviderAdapter extends SessionProviderAda
 export function isMessageCapableAdapter(
   adapter: SessionProviderAdapter,
 ): adapter is MessageCapableSessionProviderAdapter {
-  return (
-    typeof (adapter as Partial<MessageCapableSessionProviderAdapter>).sendMessage === "function"
-  );
+  return adapterHasFunctions(adapter, "sendMessage");
 }
 
 /**
@@ -285,7 +279,7 @@ export interface ProviderWorkspaceRequest {
  * the same reasons: a rejection carries a reason the user can act on, and
  * unsupported means the provider documents no way to create one here.
  */
-export type ProviderWorkspaceResult = ProviderMessageResult;
+export type ProviderWorkspaceResult = ProviderActResult;
 
 /**
  * Optional extension for adapters whose provider documents an endpoint that
@@ -304,11 +298,7 @@ export interface WorkspaceCapableSessionProviderAdapter extends SessionProviderA
 export function isWorkspaceCapableAdapter(
   adapter: SessionProviderAdapter,
 ): adapter is WorkspaceCapableSessionProviderAdapter {
-  const candidate = adapter as Partial<WorkspaceCapableSessionProviderAdapter>;
-  return (
-    typeof candidate.workspaceProjects === "function" &&
-    typeof candidate.createWorkspace === "function"
-  );
+  return adapterHasFunctions(adapter, "workspaceProjects", "createWorkspace");
 }
 
 /**
@@ -351,8 +341,14 @@ export interface WorkspaceAgentCapableSessionProviderAdapter extends SessionProv
 export function isWorkspaceAgentCapableAdapter(
   adapter: SessionProviderAdapter,
 ): adapter is WorkspaceAgentCapableSessionProviderAdapter {
-  return (
-    typeof (adapter as Partial<WorkspaceAgentCapableSessionProviderAdapter>).spawnWorkspaceAgent ===
-    "function"
-  );
+  return adapterHasFunctions(adapter, "spawnWorkspaceAgent");
+}
+
+/** Whether every named method is actually a function on this adapter. */
+function adapterHasFunctions(
+  adapter: SessionProviderAdapter,
+  ...methods: readonly string[]
+): boolean {
+  const candidate = adapter as unknown as Record<string, unknown>;
+  return methods.every((method) => typeof candidate[method] === "function");
 }

--- a/packages/sidecar-core/tests/composite-provider-adapter.test.ts
+++ b/packages/sidecar-core/tests/composite-provider-adapter.test.ts
@@ -4,7 +4,7 @@ import {
   CompositeSessionProviderAdapter,
   InMemorySessionRegistry,
   type MessageCapableSessionProviderAdapter,
-  PROVIDER_MESSAGE_RESULT_STATUS,
+  PROVIDER_ACT_RESULT_STATUS,
   type ProviderMessageResult,
   type ProviderSessionMessage,
   type ProviderSessionObservation,
@@ -160,17 +160,17 @@ test("carries a message past observers that have never seen the session", async 
     adapters: [
       // The local observer can carry no message at all, and must not stop one.
       observerOf(cursor, [observation("local-session")]),
-      messenger(cursor, () => ({ status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED })),
+      messenger(cursor, () => ({ status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED })),
       messenger(cursor, (message) => {
         sent.push(message);
-        return { status: PROVIDER_MESSAGE_RESULT_STATUS.ACCEPTED };
+        return { status: PROVIDER_ACT_RESULT_STATUS.ACCEPTED };
       }),
     ],
   });
 
   const result = await adapter.sendMessage({ providerSessionId: "cloud-agent", text: "go on" });
 
-  assert.deepEqual(result, { status: PROVIDER_MESSAGE_RESULT_STATUS.ACCEPTED });
+  assert.deepEqual(result, { status: PROVIDER_ACT_RESULT_STATUS.ACCEPTED });
   assert.deepEqual(sent, [{ providerSessionId: "cloud-agent", text: "go on" }]);
 });
 
@@ -180,12 +180,12 @@ test("lets the observer that holds the session refuse for itself", async () => {
     provider: cursor,
     adapters: [
       messenger(cursor, () => ({
-        status: PROVIDER_MESSAGE_RESULT_STATUS.REJECTED,
+        status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
         reason: "Cursor is still busy with the current run",
       })),
       messenger(cursor, (message) => {
         unreachable.push(message);
-        return { status: PROVIDER_MESSAGE_RESULT_STATUS.ACCEPTED };
+        return { status: PROVIDER_ACT_RESULT_STATUS.ACCEPTED };
       }),
     ],
   });
@@ -194,7 +194,7 @@ test("lets the observer that holds the session refuse for itself", async () => {
 
   // A rejection is the session's own answer, so it must not be shopped past
   // the observer that gave it to one that would say yes to a different session.
-  assert.equal(result.status, PROVIDER_MESSAGE_RESULT_STATUS.REJECTED);
+  assert.equal(result.status, PROVIDER_ACT_RESULT_STATUS.REJECTED);
   assert.deepEqual(unreachable, []);
 });
 
@@ -206,7 +206,7 @@ test("answers unsupported when no observer can carry a message", async () => {
 
   const result = await adapter.sendMessage({ providerSessionId: "local-session", text: "go on" });
 
-  assert.deepEqual(result, { status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED });
+  assert.deepEqual(result, { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED });
 });
 
 function workspaceCreator(
@@ -239,7 +239,7 @@ test("offers every observer's projects and carries a creation ask to the one tha
           },
         ],
         () => ({
-          status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED,
+          status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED,
         }),
       ),
       workspaceCreator(
@@ -253,7 +253,7 @@ test("offers every observer's projects and carries a creation ask to the one tha
         ],
         (request) => {
           created.push(request);
-          return { status: PROVIDER_MESSAGE_RESULT_STATUS.ACCEPTED };
+          return { status: PROVIDER_ACT_RESULT_STATUS.ACCEPTED };
         },
       ),
     ],
@@ -274,7 +274,7 @@ test("offers every observer's projects and carries a creation ask to the one tha
 
   const result = await adapter.createWorkspace({ providerProjectId: "proj-2" });
 
-  assert.deepEqual(result, { status: PROVIDER_MESSAGE_RESULT_STATUS.ACCEPTED });
+  assert.deepEqual(result, { status: PROVIDER_ACT_RESULT_STATUS.ACCEPTED });
   assert.deepEqual(created, [{ providerProjectId: "proj-2" }]);
 });
 
@@ -286,6 +286,6 @@ test("answers unsupported when no observer offers workspace creation", async () 
 
   assert.deepEqual(adapter.workspaceProjects(), []);
   assert.deepEqual(await adapter.createWorkspace({ providerProjectId: "proj-1" }), {
-    status: PROVIDER_MESSAGE_RESULT_STATUS.UNSUPPORTED,
+    status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED,
   });
 });


### PR DESCRIPTION
## Summary

- Unify the identical control/message accepted/rejected/unsupported triples into one `PROVIDER_ACT_RESULT_STATUS`, so accidental divergence cannot become an API break.
- Give the composite adapter one dispatch helper parameterized by guard and method, keeping per-capability documentation on the thin wrappers.
- Split cloud write machinery into protected helpers so each subclass declares only the interfaces it actually routes. Capability probes mean "can do X" again — Copilot is read-only at the adapter, matching its own class comment — without changing which write acts any provider permits. Per-session observation-flag validation is unchanged.

## Evidence

- Platform-independent checks: `passed` (`./scripts/check.sh`)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — portable-only change (constant rename in the renderer; no layout or motion)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31852315637/artifacts/9237902870) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31852315637)

- Commit: `bae060e8c2e22fd2c991dc420d9143807ff7d698`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: None

Made with [Cursor](https://cursor.com)