### PR TITLE
refactor(desktop): share HTTP test fakes across adapter tests

### DIFF
--- a/apps/desktop/src/cloud-session-adapter.ts
+++ b/apps/desktop/src/cloud-session-adapter.ts
@@ -37,7 +37,8 @@ const HTTP_METHOD = {
   POST: "POST",
 } as const;
 
-const HTTP_STATUS = {
+/** HTTP statuses the adapter names when a response is not simply ok. */
+export const HTTP_STATUS = {
   UNAUTHORIZED: 401,
   FORBIDDEN: 403,
   NOT_FOUND: 404,

--- a/apps/desktop/tests/cloud-session-adapter.test.ts
+++ b/apps/desktop/tests/cloud-session-adapter.test.ts
@@ -14,50 +14,16 @@ import {
   isDefined,
   knownValue,
 } from "../src/cloud-session-adapter";
+import { HTTP_STATUS, jsonResponse, recordingFetch } from "./support/http-fake";
 
 const TEST_TIME = Date.parse("2026-08-12T02:45:00.000Z");
 const TEST_BASE_URL = "https://api.provider.test";
 const TEST_API_KEY = "provider-test-key";
 
-const HTTP_STATUS = {
-  OK: 200,
-  UNAUTHORIZED: 401,
-} as const;
-
 const STUB_PROVIDER = { id: "stub", displayName: "Stub" };
 
-interface RecordedRequest {
-  method: string;
-  url: string;
-  authorization: string | undefined;
-  accept: string | undefined;
-  contentType: string | undefined;
-  body: string | undefined;
-}
-
-interface StubFetch {
-  fetch: CloudFetch;
-  requests: RecordedRequest[];
-}
-
-function stubFetch(status: () => number = () => HTTP_STATUS.OK): StubFetch {
-  const requests: RecordedRequest[] = [];
-  const fetch: CloudFetch = async (url, init) => {
-    const headers = new Headers(init.headers);
-    requests.push({
-      method: init.method ?? "",
-      url,
-      authorization: headers.get("authorization") ?? undefined,
-      accept: headers.get("accept") ?? undefined,
-      contentType: headers.get("content-type") ?? undefined,
-      body: typeof init.body === "string" ? init.body : undefined,
-    });
-    return new Response(JSON.stringify({}), {
-      status: status(),
-      headers: { "content-type": "application/json" },
-    });
-  };
-  return { fetch, requests };
+function stubFetch(status: () => number = () => HTTP_STATUS.OK) {
+  return recordingFetch(() => jsonResponse({}, status()));
 }
 
 function observation(
@@ -153,16 +119,14 @@ test("authenticates a bounded read and encodes the route a subclass asked for", 
 
   assert.equal(adapter.provider.id, "stub");
   assert.equal(observations.length, 1);
-  assert.deepEqual(stub.requests, [
-    {
-      method: "GET",
-      url: `${TEST_BASE_URL}/v0/sessions/id%20with%2Fslash?limit=2`,
-      authorization: `Bearer ${TEST_API_KEY}`,
-      accept: "application/json",
-      contentType: undefined,
-      body: undefined,
-    },
-  ]);
+  const [request] = stub.requests;
+  assert.ok(request);
+  assert.equal(request.method, "GET");
+  assert.equal(request.url, `${TEST_BASE_URL}/v0/sessions/id%20with%2Fslash?limit=2`);
+  assert.equal(request.authorization, `Bearer ${TEST_API_KEY}`);
+  assert.equal(request.accept, "application/json");
+  assert.equal(request.contentType, undefined);
+  assert.equal(request.body, undefined);
 });
 
 /** Stands in for a provider that asks for its own media type and version pin. */
@@ -173,20 +137,7 @@ class PinnedHeaderAdapter extends StubCloudAdapter {
 }
 
 test("lets a subclass pin its own request headers without touching the credential", async () => {
-  const requests: {
-    accept: string | undefined;
-    version: string | undefined;
-    auth: string | undefined;
-  }[] = [];
-  const fetch: CloudFetch = async (_url, init) => {
-    const headers = new Headers(init.headers);
-    requests.push({
-      accept: headers.get("accept") ?? undefined,
-      version: headers.get("x-stub-api-version") ?? undefined,
-      auth: headers.get("authorization") ?? undefined,
-    });
-    return new Response(JSON.stringify({}), { status: HTTP_STATUS.OK });
-  };
+  const { fetch, requests } = recordingFetch(() => jsonResponse({}));
   const adapter = new PinnedHeaderAdapter({
     readApiKey: async () => TEST_API_KEY,
     baseUrl: TEST_BASE_URL,
@@ -197,13 +148,11 @@ test("lets a subclass pin its own request headers without touching the credentia
 
   await adapter.observe();
 
-  assert.deepEqual(requests, [
-    {
-      accept: "application/vnd.stub+json",
-      version: "2026-03-10",
-      auth: `Bearer ${TEST_API_KEY}`,
-    },
-  ]);
+  const [request] = requests;
+  assert.ok(request);
+  assert.equal(request.accept, "application/vnd.stub+json");
+  assert.equal(request.headers.get("x-stub-api-version"), "2026-03-10");
+  assert.equal(request.authorization, `Bearer ${TEST_API_KEY}`);
 });
 
 test("reports every session it serves as running in the cloud", async () => {
@@ -337,9 +286,7 @@ function accountBoundFetch(options: { oldKeyGate: Promise<void>; oldKeyStatus?: 
       await options.oldKeyGate;
       status = options.oldKeyStatus ?? HTTP_STATUS.OK;
     }
-    return new Response(JSON.stringify({ session: sessionByAuthorization[authorization] }), {
-      status,
-    });
+    return jsonResponse({ session: sessionByAuthorization[authorization] }, status);
   };
   return { fetch, authorizations };
 }
@@ -510,13 +457,13 @@ test("reports what became of a send the provider refused", async () => {
   await adapter.observe();
   const message = { providerSessionId: "session-one", text: "go on" };
 
-  status = 401;
+  status = HTTP_STATUS.UNAUTHORIZED;
   const unauthorized = await adapter.sendMessage(message);
-  status = 404;
+  status = HTTP_STATUS.NOT_FOUND;
   const missing = await adapter.sendMessage(message);
-  status = 409;
+  status = HTTP_STATUS.CONFLICT;
   const conflicted = await adapter.sendMessage(message);
-  status = 500;
+  status = HTTP_STATUS.SERVER_ERROR;
   const failed = await adapter.sendMessage(message);
 
   assert.equal(unauthorized.status, "rejected");

--- a/apps/desktop/tests/conductor-adapter.test.ts
+++ b/apps/desktop/tests/conductor-adapter.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { SESSION_STATUS } from "@sidecar/core";
 import type { CloudFetch } from "../src/cloud-session-adapter";
 import { CONDUCTOR_PROVIDER, ConductorSessionAdapter } from "../src/conductor-adapter";
+import { HTTP_STATUS, jsonResponse, recordingFetch } from "./support/http-fake";
 
 const TEST_TIME = Date.parse("2026-08-12T02:45:00.000Z");
 const TEST_BASE_URL = "https://api.conductor.test";
@@ -17,12 +18,6 @@ const TEST_CONDUCTOR_STATUS = {
   IDLE: "idle",
   WORKING: "working",
   ERROR: "error",
-} as const;
-
-const HTTP_STATUS = {
-  OK: 200,
-  UNAUTHORIZED: 401,
-  SERVER_ERROR: 500,
 } as const;
 
 interface TestProject {
@@ -64,28 +59,8 @@ interface TestApi {
   sqlHttpStatus?: number;
 }
 
-interface RecordedRequest {
-  method: string;
-  pathname: string;
-  authorization: string | undefined;
-  contentType: string | undefined;
-  body: string | undefined;
-}
-
-interface FakeConductorApi {
-  fetch: CloudFetch;
-  requests: RecordedRequest[];
-}
-
 function isoTimestamp(timestampMs: number): string {
   return new Date(timestampMs).toISOString();
-}
-
-function jsonResponse(body: unknown, status = HTTP_STATUS.OK): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "content-type": "application/json" },
-  });
 }
 
 function page(data: readonly unknown[]): unknown {
@@ -114,26 +89,16 @@ function sessionPayload(session: TestSession): Record<string, unknown> {
 }
 
 /** Serves the read-only subset of the public API the adapter is allowed to use. */
-function fakeConductorApi(api: TestApi): FakeConductorApi {
-  const requests: RecordedRequest[] = [];
+function fakeConductorApi(api: TestApi) {
   const createdSessionIds = new Set<string>();
-  const fetch: CloudFetch = async (url, init) => {
-    const { pathname } = new URL(url);
-    const headers = new Headers(init.headers);
-    requests.push({
-      method: init.method ?? "",
-      pathname,
-      authorization: headers.get("authorization") ?? undefined,
-      contentType: headers.get("content-type") ?? undefined,
-      body: typeof init.body === "string" ? init.body : undefined,
-    });
-
+  return recordingFetch((request) => {
+    const { pathname, method, body: rawBody } = request;
     const segments = pathname.split("/").filter((segment) => segment.length > 0);
-    if (init.method === "POST") {
+    if (method === "POST") {
       // The transcripts view: the one read that rides as a POSTed document.
       if (segments[1] === "sql" && segments.length === 2) {
         if (api.sqlHttpStatus) return jsonResponse({}, api.sqlHttpStatus);
-        const body = JSON.parse(typeof init.body === "string" ? init.body : "{}") as {
+        const body = JSON.parse(rawBody ?? "{}") as {
           query?: string;
         };
         const query = body.query ?? "";
@@ -151,7 +116,7 @@ function fakeConductorApi(api: TestApi): FakeConductorApi {
       // The three documented writers: a prompt for one session, a cancel for
       // the turn it is working, and a new workspace in one project.
       if (segments[1] === "workspaces" && segments.length === 2) {
-        const body = JSON.parse(typeof init.body === "string" ? init.body : "{}") as {
+        const body = JSON.parse(rawBody ?? "{}") as {
           projectId?: string;
         };
         if (!api.projects.some((project) => project.id === body.projectId)) {
@@ -171,7 +136,7 @@ function fakeConductorApi(api: TestApi): FakeConductorApi {
         );
       }
       if (segments[1] === "sessions" && segments.length === 2) {
-        const body = JSON.parse(typeof init.body === "string" ? init.body : "{}") as {
+        const body = JSON.parse(rawBody ?? "{}") as {
           workspaceId?: string;
           agent?: string;
         };
@@ -234,8 +199,7 @@ function fakeConductorApi(api: TestApi): FakeConductorApi {
       });
     }
     return jsonResponse({}, HTTP_STATUS.SERVER_ERROR);
-  };
-  return { fetch, requests };
+  });
 }
 
 function adapterFor(

--- a/apps/desktop/tests/copilot-adapter.test.ts
+++ b/apps/desktop/tests/copilot-adapter.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { SESSION_STATUS } from "@sidecar/core";
 import type { CloudFetch } from "../src/cloud-session-adapter";
 import { COPILOT_PROVIDER, CopilotSessionAdapter } from "../src/copilot-adapter";
+import { HTTP_STATUS, jsonResponse, recordingFetch } from "./support/http-fake";
 
 const TEST_TIME = Date.parse("2026-08-13T02:45:00.000Z");
 const TEST_BASE_URL = "https://github.test";
@@ -23,12 +24,6 @@ const TEST_STATE = {
   CANCELLED: "cancelled",
 } as const;
 
-const HTTP_STATUS = {
-  OK: 200,
-  UNAUTHORIZED: 401,
-  SERVER_ERROR: 500,
-} as const;
-
 interface TestTask {
   id: string;
   state?: string;
@@ -41,29 +36,8 @@ interface TestTask {
   updatedAt?: number;
 }
 
-interface RecordedRequest {
-  method: string;
-  pathname: string;
-  search: string;
-  authorization: string | undefined;
-  accept: string | undefined;
-  apiVersion: string | undefined;
-}
-
-interface FakeAgentTasksApi {
-  fetch: CloudFetch;
-  requests: RecordedRequest[];
-}
-
 function isoTimestamp(timestampMs: number): string {
   return new Date(timestampMs).toISOString();
-}
-
-function jsonResponse(body: unknown, status = HTTP_STATUS.OK): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "content-type": "application/json" },
-  });
 }
 
 function lastActivityAt(task: TestTask): number {
@@ -111,20 +85,9 @@ function taskPayload(task: TestTask): Record<string, unknown> {
 }
 
 /** Serves the read-only subset of the agent-tasks API the adapter may use. */
-function fakeAgentTasksApi(tasks: readonly TestTask[]): FakeAgentTasksApi {
-  const requests: RecordedRequest[] = [];
-  const fetch: CloudFetch = async (url, init) => {
-    const { pathname, searchParams, search } = new URL(url);
-    const headers = new Headers(init.headers);
-    requests.push({
-      method: init.method ?? "",
-      pathname,
-      search,
-      authorization: headers.get("authorization") ?? undefined,
-      accept: headers.get("accept") ?? undefined,
-      apiVersion: headers.get("x-github-api-version") ?? undefined,
-    });
-
+function fakeAgentTasksApi(tasks: readonly TestTask[]) {
+  return recordingFetch((request) => {
+    const { pathname, searchParams } = request;
     const segments = pathname.split("/").filter((segment) => segment.length > 0);
     if (segments.length !== 2 || segments[0] !== "agents" || segments[1] !== "tasks") {
       return jsonResponse({}, HTTP_STATUS.SERVER_ERROR);
@@ -139,8 +102,7 @@ function fakeAgentTasksApi(tasks: readonly TestTask[]): FakeAgentTasksApi {
       total_active_count: tasks.length,
       total_archived_count: 0,
     });
-  };
-  return { fetch, requests };
+  });
 }
 
 function adapterFor(
@@ -220,7 +182,7 @@ test("reads the whole pass with one pinned, GitHub-typed list call", async () =>
   // GitHub's own media type rather than plain JSON, and the endpoint is in
   // public preview, so the dated API version must ride every request.
   assert.equal(api.requests[0]?.accept, "application/vnd.github+json");
-  assert.equal(api.requests[0]?.apiVersion, "2026-03-10");
+  assert.equal(api.requests[0]?.headers.get("x-github-api-version"), "2026-03-10");
 });
 
 test("maps every state GitHub reports onto a state Luke can show", async () => {

--- a/apps/desktop/tests/cursor-adapter.test.ts
+++ b/apps/desktop/tests/cursor-adapter.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { SESSION_STATUS } from "@sidecar/core";
 import type { CloudFetch } from "../src/cloud-session-adapter";
 import { CURSOR_PROVIDER, CursorSessionAdapter } from "../src/cursor-adapter";
+import { HTTP_STATUS, jsonResponse, recordingFetch } from "./support/http-fake";
 
 const TEST_TIME = Date.parse("2026-08-12T02:45:00.000Z");
 const TEST_BASE_URL = "https://api.cursor.test";
@@ -29,12 +30,6 @@ const TEST_RUN_STATUS = {
   ERROR: "ERROR",
 } as const;
 
-const HTTP_STATUS = {
-  OK: 200,
-  UNAUTHORIZED: 401,
-  SERVER_ERROR: 500,
-} as const;
-
 interface TestRun {
   id: string;
   status?: string;
@@ -55,29 +50,8 @@ interface TestAgent {
   run?: TestRun;
 }
 
-interface RecordedRequest {
-  method: string;
-  pathname: string;
-  search: string;
-  authorization: string | undefined;
-  contentType: string | undefined;
-  body: string | undefined;
-}
-
-interface FakeCursorApi {
-  fetch: CloudFetch;
-  requests: RecordedRequest[];
-}
-
 function isoTimestamp(timestampMs: number): string {
   return new Date(timestampMs).toISOString();
-}
-
-function jsonResponse(body: unknown, status = HTTP_STATUS.OK): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "content-type": "application/json" },
-  });
 }
 
 function lastActivityAt(agent: TestAgent): number {
@@ -135,21 +109,10 @@ function fakeCursorApi(
     /** Holds the first repositories answer until released, like a slow org. */
     gateFirstRepositoriesRead?: Promise<void>;
   } = {},
-): FakeCursorApi {
+) {
   let repositoriesReads = 0;
-  const requests: RecordedRequest[] = [];
-  const fetch: CloudFetch = async (url, init) => {
-    const { pathname, searchParams, search } = new URL(url);
-    const headers = new Headers(init.headers);
-    requests.push({
-      method: init.method ?? "",
-      pathname,
-      search,
-      authorization: headers.get("authorization") ?? undefined,
-      contentType: headers.get("content-type") ?? undefined,
-      body: typeof init.body === "string" ? init.body : undefined,
-    });
-
+  return recordingFetch(async (request) => {
+    const { pathname, searchParams, method, body: rawBody } = request;
     const segments = pathname.split("/").filter((segment) => segment.length > 0);
     if (segments[0] === "v1" && segments[1] === "repositories" && segments.length === 2) {
       if (!options.repositories) return jsonResponse({}, HTTP_STATUS.SERVER_ERROR);
@@ -167,9 +130,9 @@ function fakeCursorApi(
 
     // The three documented writers: a new agent, a follow-up run for an
     // existing one, and a cancel for the run it is still working.
-    if (init.method === "POST") {
+    if (method === "POST") {
       if (segments.length === 2) {
-        const body = JSON.parse(typeof init.body === "string" ? init.body : "{}") as {
+        const body = JSON.parse(rawBody ?? "{}") as {
           prompt?: { text?: string };
           repos?: { url?: string }[];
         };
@@ -218,8 +181,7 @@ function fakeCursorApi(
       return jsonResponse(runPayload(agent, run));
     }
     return jsonResponse({}, HTTP_STATUS.SERVER_ERROR);
-  };
-  return { fetch, requests };
+  });
 }
 
 function adapterFor(

--- a/apps/desktop/tests/devin-adapter.test.ts
+++ b/apps/desktop/tests/devin-adapter.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { SESSION_STATUS } from "@sidecar/core";
 import type { CloudFetch } from "../src/cloud-session-adapter";
 import { DEVIN_PROVIDER, DevinSessionAdapter } from "../src/devin-adapter";
+import { HTTP_STATUS, jsonResponse, recordingFetch } from "./support/http-fake";
 
 const TEST_TIME = Date.parse("2026-08-13T02:45:00.000Z");
 const TEST_BASE_URL = "https://api.devin.test";
@@ -40,12 +41,6 @@ const TEST_DETAIL = {
   OUT_OF_CREDITS: "out_of_credits",
 } as const;
 
-const HTTP_STATUS = {
-  OK: 200,
-  UNAUTHORIZED: 401,
-  SERVER_ERROR: 500,
-} as const;
-
 interface TestSession {
   id: string;
   status?: string;
@@ -61,28 +56,8 @@ interface TestSession {
   updatedAt: number;
 }
 
-interface RecordedRequest {
-  method: string;
-  pathname: string;
-  search: string;
-  authorization: string | undefined;
-  body: string | undefined;
-}
-
-interface FakeDevinApi {
-  fetch: CloudFetch;
-  requests: RecordedRequest[];
-}
-
 function seconds(timestampMs: number): number {
   return Math.floor(timestampMs / 1000);
-}
-
-function jsonResponse(body: unknown, status = HTTP_STATUS.OK): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "content-type": "application/json" },
-  });
 }
 
 function sessionPayload(session: TestSession): Record<string, unknown> {
@@ -115,21 +90,12 @@ function sessionPayload(session: TestSession): Record<string, unknown> {
 function fakeDevinApi(
   sessions: readonly TestSession[],
   options: { principal?: string; orgId?: string | undefined; userId?: string } = {},
-): FakeDevinApi {
-  const requests: RecordedRequest[] = [];
-  const fetch: CloudFetch = async (url, init) => {
-    const { pathname, searchParams, search } = new URL(url);
-    const headers = new Headers(init.headers);
-    requests.push({
-      method: init.method ?? "",
-      pathname,
-      search,
-      authorization: headers.get("authorization") ?? undefined,
-      body: typeof init.body === "string" ? init.body : undefined,
-    });
+) {
+  return recordingFetch((request) => {
+    const { pathname, searchParams, method } = request;
 
     // The one documented writer: a message for one existing session.
-    if (init.method === "POST") {
+    if (method === "POST") {
       const match = pathname.match(
         new RegExp(`^/v3/organizations/${TEST_ORG_ID}/sessions/([^/]+)/messages$`),
       );
@@ -170,8 +136,7 @@ function fakeDevinApi(
       has_next_page: after + first < visible.length,
       end_cursor: after + first < visible.length ? String(after + first) : null,
     });
-  };
-  return { fetch, requests };
+  });
 }
 
 function adapterFor(

--- a/apps/desktop/tests/jules-adapter.test.ts
+++ b/apps/desktop/tests/jules-adapter.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { SESSION_STATUS } from "@sidecar/core";
 import type { CloudFetch } from "../src/cloud-session-adapter";
 import { JULES_PROVIDER, JulesSessionAdapter } from "../src/jules-adapter";
+import { HTTP_STATUS, jsonResponse, recordingFetch } from "./support/http-fake";
 
 const TEST_TIME = Date.parse("2026-08-13T02:45:00.000Z");
 const TEST_BASE_URL = "https://jules.test";
@@ -24,12 +25,6 @@ const TEST_STATE = {
   COMPLETED: "COMPLETED",
 } as const;
 
-const HTTP_STATUS = {
-  OK: 200,
-  UNAUTHORIZED: 401,
-  SERVER_ERROR: 500,
-} as const;
-
 interface TestSession {
   id: string;
   state?: string;
@@ -40,30 +35,8 @@ interface TestSession {
   updateTime?: number;
 }
 
-interface RecordedRequest {
-  method: string;
-  pathname: string;
-  search: string;
-  apiKey: string | undefined;
-  authorization: string | undefined;
-  contentType: string | undefined;
-  body: string | undefined;
-}
-
-interface FakeJulesApi {
-  fetch: CloudFetch;
-  requests: RecordedRequest[];
-}
-
 function isoTimestamp(timestampMs: number): string {
   return new Date(timestampMs).toISOString();
-}
-
-function jsonResponse(body: unknown, status = HTTP_STATUS.OK): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "content-type": "application/json" },
-  });
 }
 
 function lastActivityAt(session: TestSession): number {
@@ -97,25 +70,13 @@ function sessionPayload(session: TestSession): Record<string, unknown> {
 }
 
 /** Serves the subset of the alpha API the adapter is allowed to use. */
-function fakeJulesApi(sessions: readonly TestSession[]): FakeJulesApi {
-  const requests: RecordedRequest[] = [];
-  const fetch: CloudFetch = async (url, init) => {
-    const { pathname, searchParams, search } = new URL(url);
-    const headers = new Headers(init.headers);
-    requests.push({
-      method: init.method ?? "",
-      pathname,
-      search,
-      apiKey: headers.get(GOOGLE_API_KEY_HEADER) ?? undefined,
-      authorization: headers.get("authorization") ?? undefined,
-      contentType: headers.get("content-type") ?? undefined,
-      body: typeof init.body === "string" ? init.body : undefined,
-    });
-
+function fakeJulesApi(sessions: readonly TestSession[]) {
+  return recordingFetch((request) => {
+    const { pathname, searchParams, method } = request;
     const segments = pathname.split("/").filter((segment) => segment.length > 0);
     // The two documented writers are Google custom methods on one session:
     // `POST /v1alpha/sessions/{id}:sendMessage` and `…:approvePlan`.
-    if (init.method === "POST" && segments[0] === "v1alpha" && segments.length === 3) {
+    if (method === "POST" && segments[0] === "v1alpha" && segments.length === 3) {
       const [id, action] = (segments[2] ?? "").split(":");
       const known = sessions.some((session) => session.id === id);
       if (!known || (action !== "sendMessage" && action !== "approvePlan")) {
@@ -135,8 +96,7 @@ function fakeJulesApi(sessions: readonly TestSession[]): FakeJulesApi {
       sessions: page.map(sessionPayload),
       ...(page.length < sessions.length ? { nextPageToken: "next-page" } : {}),
     });
-  };
-  return { fetch, requests };
+  });
 }
 
 function adapterFor(
@@ -213,7 +173,7 @@ test("reads the whole pass with one list call authenticated by Google's key head
   assert.equal(api.requests[0]?.method, "GET");
   // Jules rejects a bearer token, so the key must travel in its own header and
   // nowhere else.
-  assert.equal(api.requests[0]?.apiKey, TEST_API_KEY);
+  assert.equal(api.requests[0]?.headers.get(GOOGLE_API_KEY_HEADER), TEST_API_KEY);
   assert.equal(api.requests[0]?.authorization, undefined);
 });
 
@@ -437,7 +397,7 @@ test("observes again immediately after the API key changes", async () => {
   assert.ok(api.requests.length > requestsAfterFirstPass);
   assert.equal(observations.length, 1);
   assert.equal(
-    api.requests.at(-1)?.apiKey,
+    api.requests.at(-1)?.headers.get(GOOGLE_API_KEY_HEADER),
     "jules-replacement-key",
     "the replacement key was not used",
   );
@@ -521,7 +481,7 @@ test("hands a user message to Jules through its documented custom method", async
   assert.equal(write?.method, "POST");
   // The colon is part of the route: `%3AsendMessage` would name nothing.
   assert.equal(write?.pathname, "/v1alpha/sessions/session-ask:sendMessage");
-  assert.equal(write?.apiKey, TEST_API_KEY);
+  assert.equal(write?.headers.get(GOOGLE_API_KEY_HEADER), TEST_API_KEY);
   assert.deepEqual(JSON.parse(write?.body ?? ""), { prompt: "Use the existing fixture instead" });
 });
 

--- a/apps/desktop/tests/linear-tracker.test.ts
+++ b/apps/desktop/tests/linear-tracker.test.ts
@@ -2,36 +2,39 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { ISSUE_ACTION_KIND, TRACKER_ACTION_RESULT_STATUS } from "@sidecar/core";
 import { LinearIssueTracker } from "../src/linear-tracker";
+import {
+  HTTP_STATUS,
+  jsonResponse,
+  type RecordedRequest,
+  recordingFetch,
+} from "./support/http-fake";
 
 const OBSERVED_AT = 1_800_000_000_000;
 
-interface RecordedRequest {
-  url: string;
-  method?: string;
-  headers: Record<string, string>;
-  body: { query: string; variables: Record<string, unknown> };
+function graphqlDocument(request: RecordedRequest | undefined): {
+  query: string;
+  variables: Record<string, unknown>;
+} {
+  return JSON.parse(request?.body ?? "{}") as {
+    query: string;
+    variables: Record<string, unknown>;
+  };
 }
 
 function trackerWith(
   payloads: readonly unknown[],
   options: { apiKey?: string; status?: number } = {},
 ): { tracker: LinearIssueTracker; requests: RecordedRequest[] } {
-  const requests: RecordedRequest[] = [];
   let call = 0;
+  const { fetch, requests } = recordingFetch(() => {
+    const payload = payloads[Math.min(call, payloads.length - 1)];
+    call += 1;
+    return jsonResponse(payload, options.status ?? HTTP_STATUS.OK);
+  });
   const tracker = new LinearIssueTracker({
     readApiKey: async () => options.apiKey,
     now: () => OBSERVED_AT,
-    fetchImplementation: (async (url: unknown, init?: RequestInit) => {
-      requests.push({
-        url: String(url),
-        ...(init?.method ? { method: init.method } : {}),
-        headers: (init?.headers as Record<string, string>) ?? {},
-        body: JSON.parse(String(init?.body)) as RecordedRequest["body"],
-      });
-      const payload = payloads[Math.min(call, payloads.length - 1)];
-      call += 1;
-      return new Response(JSON.stringify(payload), { status: options.status ?? 200 });
-    }) as typeof fetch,
+    fetchImplementation: fetch as typeof fetch,
   });
   return { tracker, requests };
 }
@@ -109,15 +112,15 @@ test("observing reads the assigned issues and advertises the rest of the workflo
   });
 
   // The key authorizes as itself: a personal API key takes no Bearer prefix.
-  assert.equal(requests[0]?.headers.authorization, "lin_api_test");
+  assert.equal(requests[0]?.authorization, "lin_api_test");
   // An observation pass sends the one read document and nothing else.
   assert.equal(requests.length, 1);
-  assert.match(requests[0]?.body.query ?? "", /^query AssignedIssues/);
-  assert.doesNotMatch(requests[0]?.body.query ?? "", /mutation/);
+  assert.match(graphqlDocument(requests[0]).query, /^query AssignedIssues/);
+  assert.doesNotMatch(graphqlDocument(requests[0]).query, /mutation/);
 });
 
 test("a failed or malformed read is an error, never a quieter roster", async () => {
-  const failed = trackerWith([{}], { apiKey: "lin_api_test", status: 500 });
+  const failed = trackerWith([{}], { apiKey: "lin_api_test", status: HTTP_STATUS.SERVER_ERROR });
   await assert.rejects(() => failed.tracker.observe());
 
   const errored = trackerWith([{ errors: [{ message: "rate limited" }] }], {
@@ -139,8 +142,11 @@ test("moving an issue posts the one documented write and reads its answer", asyn
 
   assert.deepEqual(result, { status: TRACKER_ACTION_RESULT_STATUS.ACCEPTED });
   assert.equal(requests.length, 1);
-  assert.match(requests[0]?.body.query ?? "", /^mutation SetIssueState/);
-  assert.deepEqual(requests[0]?.body.variables, { id: "issue-uuid-1", stateId: "state-done" });
+  assert.match(graphqlDocument(requests[0]).query, /^mutation SetIssueState/);
+  assert.deepEqual(graphqlDocument(requests[0]).variables, {
+    id: "issue-uuid-1",
+    stateId: "state-done",
+  });
 });
 
 test("a comment posts the other documented write", async () => {
@@ -155,8 +161,8 @@ test("a comment posts the other documented write", async () => {
   });
 
   assert.deepEqual(result, { status: TRACKER_ACTION_RESULT_STATUS.ACCEPTED });
-  assert.match(requests[0]?.body.query ?? "", /^mutation CommentOnIssue/);
-  assert.deepEqual(requests[0]?.body.variables, {
+  assert.match(graphqlDocument(requests[0]).query, /^mutation CommentOnIssue/);
+  assert.deepEqual(graphqlDocument(requests[0]).variables, {
     issueId: "issue-uuid-1",
     body: "Deferred to next release.",
   });

--- a/apps/desktop/tests/openai-attention-evaluator.test.ts
+++ b/apps/desktop/tests/openai-attention-evaluator.test.ts
@@ -10,16 +10,12 @@ import {
   OpenAiAttentionEvaluator,
   openAiAttentionEvaluator,
 } from "../src/openai-attention-evaluator";
+import { type RecordedRequest, recordingFetch } from "./support/http-fake";
 
 const DECIDED_AT = 1_800_000_000_000;
 const API_KEY = "test-openai-key";
 const SPOKEN_SUMMARY = "Claude Code is waiting on you in checkout-service.";
 const TRANSCRIPT_SECRET = "SECRET_TRANSCRIPT_TEXT";
-
-interface RecordedRequest {
-  url: string;
-  init: RequestInit;
-}
 
 function update(overrides: Partial<AttentionUpdate> = {}): AttentionUpdate {
   return {
@@ -51,22 +47,18 @@ function evaluatorWith(respond: (request: RecordedRequest) => Promise<Response> 
   evaluator: OpenAiAttentionEvaluator;
   requests: RecordedRequest[];
 } {
-  const requests: RecordedRequest[] = [];
+  const { fetch, requests } = recordingFetch(respond);
   const evaluator = new OpenAiAttentionEvaluator({
     apiKey: API_KEY,
     now: () => DECIDED_AT,
-    fetch: async (url, init) => {
-      const request = { url, init };
-      requests.push(request);
-      return respond(request);
-    },
+    fetch,
   });
   return { evaluator, requests };
 }
 
 function requestBody(request: RecordedRequest): Record<string, unknown> {
-  assert.equal(typeof request.init.body, "string");
-  return JSON.parse(String(request.init.body)) as Record<string, unknown>;
+  assert.equal(typeof request.body, "string");
+  return JSON.parse(String(request.body)) as Record<string, unknown>;
 }
 
 function silenceStderr(t: TestContext): void {
@@ -136,7 +128,7 @@ test("sends only the bounded update and no provider transcript", async (t) => {
 
   const [request] = requests;
   assert.ok(request);
-  const serialized = String(request.init.body);
+  const serialized = String(request.body);
   assert.ok(!serialized.includes(TRANSCRIPT_SECRET));
   assert.ok(!serialized.includes("providerSessionId"));
   assert.ok(!serialized.includes("review"));
@@ -229,15 +221,14 @@ test("builds an evaluator only when there is a key to build one from", (t) => {
 
 test("honors a configured base URL without doubling its separator", async (t) => {
   silenceStderr(t);
-  const requests: RecordedRequest[] = [];
+  const { fetch, requests } = recordingFetch(() =>
+    structuredResponse({ disposition: ATTENTION_DISPOSITION.SILENT, summary: null }),
+  );
   const evaluator = new OpenAiAttentionEvaluator({
     apiKey: API_KEY,
     baseUrl: "https://gateway.test/v1/",
     now: () => DECIDED_AT,
-    fetch: async (url, init) => {
-      requests.push({ url, init });
-      return structuredResponse({ disposition: ATTENTION_DISPOSITION.SILENT, summary: null });
-    },
+    fetch,
   });
 
   await evaluator.evaluate(update());

--- a/apps/desktop/tests/openai-realtime-credentials.test.ts
+++ b/apps/desktop/tests/openai-realtime-credentials.test.ts
@@ -12,15 +12,11 @@ import {
   openAiRealtimeCredentials,
   unavailableRealtimeDiagnostics,
 } from "../src/openai-realtime-credentials";
+import { type RecordedRequest, recordingFetch } from "./support/http-fake";
 
 const API_KEY = "sk-test-standing-key";
 const NOW = 1_800_000_000_000;
 const EXPIRES_AT_SECONDS = NOW / 1000 + 60;
-
-interface RecordedRequest {
-  url: string;
-  init: RequestInit;
-}
 
 function mintResponse(overrides: Record<string, unknown> = {}): Response {
   return new Response(
@@ -38,19 +34,18 @@ function minter(
   responses: readonly (Response | Error)[],
   options: { now?: () => number } = {},
 ): { minter: OpenAiRealtimeCredentialMinter; requests: RecordedRequest[] } {
-  const requests: RecordedRequest[] = [];
   let index = 0;
+  const { fetch, requests } = recordingFetch(() => {
+    const next = responses[Math.min(index, responses.length - 1)];
+    index += 1;
+    if (next instanceof Error) throw next;
+    if (!next) throw new Error("No response configured");
+    return next;
+  });
   const instance = new OpenAiRealtimeCredentialMinter({
     apiKey: API_KEY,
     now: options.now ?? (() => NOW),
-    fetch: async (url, init) => {
-      requests.push({ url, init });
-      const next = responses[Math.min(index, responses.length - 1)];
-      index += 1;
-      if (next instanceof Error) throw next;
-      if (!next) throw new Error("No response configured");
-      return next;
-    },
+    fetch,
   });
   return { minter: instance, requests };
 }

--- a/apps/desktop/tests/support/http-fake.ts
+++ b/apps/desktop/tests/support/http-fake.ts
@@ -1,0 +1,73 @@
+import { HTTP_STATUS as CLOUD_HTTP_STATUS, type CloudFetch } from "../../src/cloud-session-adapter";
+
+/**
+ * Statuses a fake answers with, plus the ones product code names, so a test
+ * never restates 401. `OK` and `SERVER_ERROR` are what a route table returns;
+ * the rest are the failures the adapter already branches on.
+ */
+export const HTTP_STATUS = {
+  OK: 200,
+  ...CLOUD_HTTP_STATUS,
+  SERVER_ERROR: 500,
+} as const;
+
+/**
+ * One recorded fetch, with the URL and headers already parsed. Provider tests
+ * that need a header of their own — Jules's API key, GitHub's version pin —
+ * read it from `headers`; everything else is here because every fake asked
+ * for it.
+ */
+export interface RecordedRequest {
+  method: string;
+  url: string;
+  pathname: string;
+  search: string;
+  searchParams: URLSearchParams;
+  authorization: string | undefined;
+  accept: string | undefined;
+  contentType: string | undefined;
+  body: string | undefined;
+  headers: Headers;
+  init: RequestInit;
+}
+
+export function jsonResponse(body: unknown, status = HTTP_STATUS.OK): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function header(headers: Headers, name: string): string | undefined {
+  return headers.get(name) ?? undefined;
+}
+
+/**
+ * A fetch that records every call, then answers through `respond`. The
+ * per-provider route table is `respond`; this only keeps the log.
+ */
+export function recordingFetch(
+  respond: (request: RecordedRequest) => Response | Promise<Response>,
+): { fetch: CloudFetch; requests: RecordedRequest[] } {
+  const requests: RecordedRequest[] = [];
+  const fetch: CloudFetch = async (url, init) => {
+    const parsed = new URL(url);
+    const headers = new Headers(init.headers);
+    const request: RecordedRequest = {
+      method: init.method ?? "",
+      url,
+      pathname: parsed.pathname,
+      search: parsed.search,
+      searchParams: parsed.searchParams,
+      authorization: header(headers, "authorization"),
+      accept: header(headers, "accept"),
+      contentType: header(headers, "content-type"),
+      body: typeof init.body === "string" ? init.body : undefined,
+      headers,
+      init,
+    };
+    requests.push(request);
+    return respond(request);
+  };
+  return { fetch, requests };
+}


### PR DESCRIPTION
## Summary
- Extract `jsonResponse`, `RecordedRequest`, and a recording-fetch factory into `apps/desktop/tests/support/http-fake.ts`, and re-export `HTTP_STATUS` from product code so adapter tests stop restating 401.
- Leave each provider's route table beside the adapter it describes; those tables genuinely differ.
- `RealtimeVoiceSession` is not split in this PR. The WebRTC transport looks separable from conversation logic, but `#startResponse` must stay the single enforcement point for "only a developer-opened turn may act."

## Evidence
- Platform-independent checks: `./scripts/check.sh` passed locally (661 desktop tests)
- macOS Electron verification (`./scripts/verify.sh`): `not run` (test-only change)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31852382877/artifacts/9237924561) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31852382877)

- Commit: `b8008614308cbcb8e854f1beb4ea0ec07255b74f`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence
- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes
- Blockers or follow-up verification: None
- Split recommendation is recorded for a follow-up; this PR only lands the shared HTTP fakes.

Made with [Cursor](https://cursor.com)