### PR TITLE
refactor(voice): derive tool families, count, and dispatch from one table

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1,4 +1,6 @@
 import {
+  APP_TOOL_KIND,
+  dispatchByKind,
   FEEDBACK_COMPOSER_KIND,
   type FeedbackComposerKind,
   FIXTURE_EPOCH_MS,
@@ -861,153 +863,158 @@ export function App(): React.JSX.Element {
    * standing where the panel was, so there is nothing for a mark to land on.
    */
   const carryAppAction = useCallback<AppActionCarrier>(
-    async (action) => {
-      if (action.kind === "setting") {
-        // The store's answer is caught rather than drawn: the switch is what
-        // Luke is on his way to move, so it waits for him to reach it. Every
-        // path out of here releases it, and the outcome the conversation is
-        // told is the store's own either way — what is delayed is the drawing,
-        // never the change or the report of it. The settings as this window
-        // holds them ride along so a spoken model or effort change composes
-        // against the selection actually stored.
-        const outcome = await applySpokenSetting(
-          window.sidecar,
-          action,
-          (next) => {
-            heldSettings.current = next;
-          },
-          settings ?? bootstrap?.settings,
-        );
-        // Nothing to show and nothing to sign: a refused change must not stand
-        // the panel up in front of a switch that did not move.
-        if (outcome.status !== "changed") {
-          releaseErrandChange();
-          return outcome;
-        }
-        const opening = presentationOf() !== PANEL_PRESENTATION.PANEL;
-        // The guide's ids travel as plain text, so one that names no setting
-        // of Luke's names no page either — and nothing will fly to it.
-        const page = isAppSettingId(action.setting.id)
-          ? SETTING_PAGE[action.setting.id]
-          : undefined;
-        // What the flight has to wait out. A page already drawn under an open
-        // panel costs nothing; anything else is a page of content arriving,
-        // and a page turned under an open panel takes the leaving one's exit
-        // first. Read before any of it is asked for, because all three of
-        // these are about to stop being true.
-        const wait =
-          opening || page === undefined
-            ? ERRAND_WAIT.CONTENT
-            : tabNow() === PANEL_TAB.SETTINGS && settingsView === page
-              ? ERRAND_WAIT.AT_ONCE
-              : ERRAND_WAIT.PAGE;
-        try {
-          // The control has to be drawn to be flown to, and a settings page
-          // that is not open is not drawn at all — so the tab comes forward
-          // and then the page the setting lives on, in that order, because
-          // arriving at the tab is arriving at its front page. This is the
-          // same move a credential entry returning from the key slot makes.
-          changeTab(PANEL_TAB.SETTINGS);
-          if (page !== undefined) setSettingsView(page);
-          await changeMode(true);
-          if (runErrand(errandTargets(action), wait)) {
-            // Only a panel this errand stood up is the errand's to put away.
-            errandOpenedPanel.current = opening;
-          } else {
+    async (action) =>
+      dispatchByKind(action, {
+        [APP_TOOL_KIND.SETTING]: async (action) => {
+          // The store's answer is caught rather than drawn: the switch is what
+          // Luke is on his way to move, so it waits for him to reach it. Every
+          // path out of here releases it, and the outcome the conversation is
+          // told is the store's own either way — what is delayed is the drawing,
+          // never the change or the report of it. The settings as this window
+          // holds them ride along so a spoken model or effort change composes
+          // against the selection actually stored.
+          const outcome = await applySpokenSetting(
+            window.sidecar,
+            action,
+            (next) => {
+              heldSettings.current = next;
+            },
+            settings ?? bootstrap?.settings,
+          );
+          // Nothing to show and nothing to sign: a refused change must not stand
+          // the panel up in front of a switch that did not move.
+          if (outcome.status !== "changed") {
+            releaseErrandChange();
+            return outcome;
+          }
+          const opening = presentationOf() !== PANEL_PRESENTATION.PANEL;
+          // The guide's ids travel as plain text, so one that names no setting
+          // of Luke's names no page either — and nothing will fly to it.
+          const page = isAppSettingId(action.setting.id)
+            ? SETTING_PAGE[action.setting.id]
+            : undefined;
+          // What the flight has to wait out. A page already drawn under an open
+          // panel costs nothing; anything else is a page of content arriving,
+          // and a page turned under an open panel takes the leaving one's exit
+          // first. Read before any of it is asked for, because all three of
+          // these are about to stop being true.
+          const wait =
+            opening || page === undefined
+              ? ERRAND_WAIT.CONTENT
+              : tabNow() === PANEL_TAB.SETTINGS && settingsView === page
+                ? ERRAND_WAIT.AT_ONCE
+                : ERRAND_WAIT.PAGE;
+          try {
+            // The control has to be drawn to be flown to, and a settings page
+            // that is not open is not drawn at all — so the tab comes forward
+            // and then the page the setting lives on, in that order, because
+            // arriving at the tab is arriving at its front page. This is the
+            // same move a credential entry returning from the key slot makes.
+            changeTab(PANEL_TAB.SETTINGS);
+            if (page !== undefined) setSettingsView(page);
+            await changeMode(true);
+            if (runErrand(errandTargets(action), wait)) {
+              // Only a panel this errand stood up is the errand's to put away.
+              errandOpenedPanel.current = opening;
+            } else {
+              releaseErrandChange();
+            }
+          } catch {
+            // Showing the change is not what was asked for — making it is, and it
+            // is already made. A window that refused to come forward must not be
+            // reported back as a setting that refused to change, and the switch
+            // must be drawn whether or not anyone was shown it moving.
             releaseErrandChange();
           }
-        } catch {
-          // Showing the change is not what was asked for — making it is, and it
-          // is already made. A window that refused to come forward must not be
-          // reported back as a setting that refused to change, and the switch
-          // must be drawn whether or not anyone was shown it moving.
-          releaseErrandChange();
-        }
-        return outcome;
-      }
-      if (action.kind === "feedback") {
-        // The main process expands the window and sends the composer's
-        // lifecycle event down the same ordered channel as the mode event —
-        // exactly the tray items' gesture — so the composer's shape can never
-        // lose a race to the panel apply the expansion causes. The draft
-        // rides this ref because the lifecycle channel carries event names,
-        // not payloads: set before the ask, consumed when the event lands.
-        // Whether it will be placed is decided here with the same pure
-        // decision the open itself makes, on the same entry — the open lands
-        // a beat later on the event, and nothing else writes the entry in
-        // between — so the spoken outcome says what actually happens. And
-        // nothing here sends: the note leaves only by the Send button's own
-        // press.
-        const kind = FEEDBACK_KIND_FOR_COMPOSER[action.composer];
-        const drafted = openedFeedbackEntry(feedbackEntry.latest(), {
-          kind,
-          fromPanel: false,
-          ...(action.draft === undefined ? {} : { draft: action.draft }),
-        }).drafted;
-        spokenFeedbackDraft.current = action.draft;
-        try {
-          await window.sidecar.summonFeedback(kind);
-        } catch (error) {
-          // The composer is not coming, so the event that would consume the
-          // draft is not coming either; a stale one must not season some
-          // later tray press.
-          spokenFeedbackDraft.current = undefined;
-          throw error;
-        }
-        return {
-          status: "opened",
-          kind: action.composer,
-          ...(action.draft === undefined
-            ? {}
-            : drafted
-              ? {
-                  note: "The ask is drafted in the composer; the developer edits and sends it by hand.",
-                }
-              : {
-                  note: "A note was already being written, so it was kept and nothing was drafted over it.",
-                }),
-        };
-      }
-      // Whether this ask is what opens the panel, read before it does: an
-      // errand into a shape still growing has to trail the whole opening,
-      // and one into a panel already up does not.
-      const opening = presentationOf() !== PANEL_PRESENTATION.PANEL;
-      changeTab(action.tab);
-      const spoken = action.filter ? sessionFilterFromSpoken(action.filter) : undefined;
-      // An agent this build never registered cannot narrow the list, and Luke
-      // must not claim it did. The list still has to match the sentence that
-      // says every session is shown, so an unmappable ask widens the view to
-      // All rather than leaving whatever narrowing was already in force.
-      const filter = action.filter ? (spoken ?? SESSION_FILTER.ALL) : undefined;
-      // Caught rather than applied, on the settings switch's terms: the
-      // narrowing is what Luke is on his way to the options button to do, and
-      // a list that has already re-sorted itself by the time he gets there
-      // makes the flight a report rather than the act.
-      if (filter || action.sort) {
-        heldView.current = {
-          ...(filter ? { filter } : {}),
-          ...(action.sort ? { sort: action.sort } : {}),
-        };
-      }
-      await changeMode(true);
-      // Nothing flew, so nothing is coming to release it. The panel itself is
-      // what was asked for and it is already up, so the list must show what
-      // the answer is about to claim it shows.
-      // The tab bar and the options button are outside the settings pages, so
-      // a page reset behind this tab switch is nothing they wait for.
-      if (!runErrand(errandTargets(action), opening ? ERRAND_WAIT.CONTENT : ERRAND_WAIT.AT_ONCE)) {
-        releaseErrandChange();
-      }
-      return {
-        status: "shown",
-        tab: action.tab,
-        ...(spoken ? { filter: action.filter } : {}),
-        ...(action.filter && !spoken
-          ? { note: "That agent has no filter of its own here, so every session is shown." }
-          : {}),
-        ...(action.sort ? { sort: action.sort } : {}),
-      };
-    },
+          return outcome;
+        },
+        [APP_TOOL_KIND.FEEDBACK]: async (action) => {
+          // The main process expands the window and sends the composer's
+          // lifecycle event down the same ordered channel as the mode event —
+          // exactly the tray items' gesture — so the composer's shape can never
+          // lose a race to the panel apply the expansion causes. The draft
+          // rides this ref because the lifecycle channel carries event names,
+          // not payloads: set before the ask, consumed when the event lands.
+          // Whether it will be placed is decided here with the same pure
+          // decision the open itself makes, on the same entry — the open lands
+          // a beat later on the event, and nothing else writes the entry in
+          // between — so the spoken outcome says what actually happens. And
+          // nothing here sends: the note leaves only by the Send button's own
+          // press.
+          const kind = FEEDBACK_KIND_FOR_COMPOSER[action.composer];
+          const drafted = openedFeedbackEntry(feedbackEntry.latest(), {
+            kind,
+            fromPanel: false,
+            ...(action.draft === undefined ? {} : { draft: action.draft }),
+          }).drafted;
+          spokenFeedbackDraft.current = action.draft;
+          try {
+            await window.sidecar.summonFeedback(kind);
+          } catch (error) {
+            // The composer is not coming, so the event that would consume the
+            // draft is not coming either; a stale one must not season some
+            // later tray press.
+            spokenFeedbackDraft.current = undefined;
+            throw error;
+          }
+          return {
+            status: "opened",
+            kind: action.composer,
+            ...(action.draft === undefined
+              ? {}
+              : drafted
+                ? {
+                    note: "The ask is drafted in the composer; the developer edits and sends it by hand.",
+                  }
+                : {
+                    note: "A note was already being written, so it was kept and nothing was drafted over it.",
+                  }),
+          };
+        },
+        [APP_TOOL_KIND.PANEL]: async (action) => {
+          // Whether this ask is what opens the panel, read before it does: an
+          // errand into a shape still growing has to trail the whole opening,
+          // and one into a panel already up does not.
+          const opening = presentationOf() !== PANEL_PRESENTATION.PANEL;
+          changeTab(action.tab);
+          const spoken = action.filter ? sessionFilterFromSpoken(action.filter) : undefined;
+          // An agent this build never registered cannot narrow the list, and Luke
+          // must not claim it did. The list still has to match the sentence that
+          // says every session is shown, so an unmappable ask widens the view to
+          // All rather than leaving whatever narrowing was already in force.
+          const filter = action.filter ? (spoken ?? SESSION_FILTER.ALL) : undefined;
+          // Caught rather than applied, on the settings switch's terms: the
+          // narrowing is what Luke is on his way to the options button to do, and
+          // a list that has already re-sorted itself by the time he gets there
+          // makes the flight a report rather than the act.
+          if (filter || action.sort) {
+            heldView.current = {
+              ...(filter ? { filter } : {}),
+              ...(action.sort ? { sort: action.sort } : {}),
+            };
+          }
+          await changeMode(true);
+          // Nothing flew, so nothing is coming to release it. The panel itself is
+          // what was asked for and it is already up, so the list must show what
+          // the answer is about to claim it shows.
+          // The tab bar and the options button are outside the settings pages, so
+          // a page reset behind this tab switch is nothing they wait for.
+          if (
+            !runErrand(errandTargets(action), opening ? ERRAND_WAIT.CONTENT : ERRAND_WAIT.AT_ONCE)
+          ) {
+            releaseErrandChange();
+          }
+          return {
+            status: "shown",
+            tab: action.tab,
+            ...(spoken ? { filter: action.filter } : {}),
+            ...(action.filter && !spoken
+              ? { note: "That agent has no filter of its own here, so every session is shown." }
+              : {}),
+            ...(action.sort ? { sort: action.sort } : {}),
+          };
+        },
+      }),
     [
       changeMode,
       changeTab,

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -1,19 +1,17 @@
 import {
   type AppGuideSnapshot,
-  type AppToolAction,
   type AttentionSpeech,
   appGuideContextEvents,
   appGuideContextText,
   appToolAction,
+  type CarriedAppAction,
+  type CarriedIssueAction,
+  type CarriedSessionAction,
   cancelResponseEvents,
   clearInputAudioEvents,
   EMPTY_APP_GUIDE,
   functionCallFollowUpEvents,
   functionCallOutputEvents,
-  type IssueToolAction,
-  isAppToolCall,
-  isIssueToolName,
-  isSessionToolName,
   issueContextEvents,
   issueContextText,
   issueToolAction,
@@ -28,10 +26,12 @@ import {
   REALTIME_DATA_CHANNEL,
   REALTIME_SERVER_EVENT,
   REALTIME_STATUS,
+  REALTIME_TOOL_FAMILY,
   type RealtimeConnection,
   type RealtimeFunctionCall,
   type RealtimeStatus,
-  type SessionToolAction,
+  type RealtimeToolFamily,
+  realtimeToolFamily,
   sessionContextEvents,
   sessionContextText,
   sessionToolAction,
@@ -62,10 +62,7 @@ const REALTIME_SETTLE_TIMEOUT_MS = 20_000;
  * again against its registry — the carrier is a courier, not a gate.
  */
 export type SessionActionCarrier = (
-  action: Extract<
-    SessionToolAction,
-    { kind: "message" | "control" | "open" | "create-workspace" | "add-agent" }
-  >,
+  action: CarriedSessionAction,
 ) => Promise<Record<string, unknown>>;
 
 /**
@@ -76,14 +73,10 @@ export type SessionActionCarrier = (
  * reports. Nothing here sends a note: the feedback act opens the composer,
  * and what it holds leaves only by its own Send button.
  */
-export type AppActionCarrier = (
-  action: Extract<AppToolAction, { kind: "setting" | "panel" | "feedback" }>,
-) => Promise<Record<string, unknown>>;
+export type AppActionCarrier = (action: CarriedAppAction) => Promise<Record<string, unknown>>;
 
 /** The issue half of the same courier: validated here, validated again in main. */
-export type IssueActionCarrier = (
-  action: Extract<IssueToolAction, { kind: "issue-state" | "issue-comment" }>,
-) => Promise<Record<string, unknown>>;
+export type IssueActionCarrier = (action: CarriedIssueAction) => Promise<Record<string, unknown>>;
 
 export interface RealtimeVoiceSessionCallbacks {
   onStatus(status: RealtimeStatus): void;
@@ -1210,28 +1203,38 @@ export class RealtimeVoiceSession {
         reason: "Only a request you make yourself can act on a session or an issue.",
       };
     }
+    const family = realtimeToolFamily(call.name);
+    if (family === undefined) {
+      return { status: "refused", reason: "No such tool exists." };
+    }
+    const outputForFamily = {
+      [REALTIME_TOOL_FAMILY.APP]: () => this.#appToolCallOutput(call),
+      [REALTIME_TOOL_FAMILY.ISSUE]: () => this.#issueToolCallOutput(call),
+      [REALTIME_TOOL_FAMILY.SESSION]: () => this.#sessionToolCallOutput(call),
+    } as const satisfies Record<RealtimeToolFamily, () => Promise<Record<string, unknown>>>;
+    return outputForFamily[family]();
+  }
+
+  async #appToolCallOutput(call: RealtimeFunctionCall): Promise<Record<string, unknown>> {
     // An ask about Luke himself is validated against the guide the app
     // actually provided, then carried by the renderer the same way a session
     // act is: perform, and answer with what became of it.
-    if (isAppToolCall(call)) {
-      const appAction = appToolAction(call, this.#guide, this.#sessions);
-      if (appAction.kind === "refused") return { status: "refused", reason: appAction.reason };
-      if (!this.#options.carryAppAction) {
-        return { status: "refused", reason: "Acting on Luke's own settings is not available." };
-      }
-      try {
-        return await this.#options.carryAppAction(appAction);
-      } catch (error) {
-        return {
-          status: "refused",
-          reason: error instanceof Error ? error.message : "The change could not be made.",
-        };
-      }
+    const appAction = appToolAction(call, this.#guide, this.#sessions);
+    if (appAction.kind === "refused") return { status: "refused", reason: appAction.reason };
+    if (!this.#options.carryAppAction) {
+      return { status: "refused", reason: "Acting on Luke's own settings is not available." };
     }
-    if (isIssueToolName(call.name)) return this.#issueToolCallOutput(call);
-    if (!isSessionToolName(call.name)) {
-      return { status: "refused", reason: "No such tool exists." };
+    try {
+      return await this.#options.carryAppAction(appAction);
+    } catch (error) {
+      return {
+        status: "refused",
+        reason: error instanceof Error ? error.message : "The change could not be made.",
+      };
     }
+  }
+
+  async #sessionToolCallOutput(call: RealtimeFunctionCall): Promise<Record<string, unknown>> {
     // The build's own model tables ride into validation, so a creation ask
     // that names a model is held to the same set the settings rows offer.
     const action = sessionToolAction(

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -2,6 +2,8 @@ import {
   type AppGuideSnapshot,
   ATTENTION_SPEECH_SOURCE,
   type AttentionSpeech,
+  type CarriedSessionAction,
+  dispatchByKind,
   EMPTY_APP_GUIDE,
   type NormalizedSession,
   type ObservedWorkspaceProject,
@@ -9,6 +11,7 @@ import {
   type RealtimeStatus,
   type RealtimeVoice,
   type RealtimeVoiceSpeed,
+  SESSION_TOOL_KIND,
   type SessionIdentity,
   type TrackedIssue,
 } from "@sidecar/core";
@@ -337,29 +340,31 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       // The same bridge calls the rows use — the composer, the chips, and the
       // press that opens a session: a spoken ask is a third way to ask for the
       // same act, behind the same gauntlet in the main process.
-      carryAction: (action) =>
-        action.kind === "message"
-          ? window.sidecar.sendSessionMessage(action.identity, action.text)
-          : action.kind === "control"
-            ? window.sidecar.executeSessionControl(action.identity, action.control.id)
-            : action.kind === "create-workspace"
-              ? window.sidecar.createSessionWorkspace(
-                  action.providerId,
-                  action.providerProjectId,
-                  action.name,
-                  action.task,
-                  action.agentSelection,
-                )
-              : action.kind === "add-agent"
-                ? window.sidecar.addWorkspaceAgent(
-                    action.identity,
-                    action.agent,
-                    action.name,
-                    action.task,
-                    action.model,
-                    action.effort,
-                  )
-                : optionsRef.current.openSession(action.identity),
+      carryAction: (action: CarriedSessionAction) =>
+        dispatchByKind(action, {
+          [SESSION_TOOL_KIND.MESSAGE]: (act) =>
+            window.sidecar.sendSessionMessage(act.identity, act.text),
+          [SESSION_TOOL_KIND.CONTROL]: (act) =>
+            window.sidecar.executeSessionControl(act.identity, act.control.id),
+          [SESSION_TOOL_KIND.CREATE_WORKSPACE]: (act) =>
+            window.sidecar.createSessionWorkspace(
+              act.providerId,
+              act.providerProjectId,
+              act.name,
+              act.task,
+              act.agentSelection,
+            ),
+          [SESSION_TOOL_KIND.ADD_AGENT]: (act) =>
+            window.sidecar.addWorkspaceAgent(
+              act.identity,
+              act.agent,
+              act.name,
+              act.task,
+              act.model,
+              act.effort,
+            ),
+          [SESSION_TOOL_KIND.OPEN]: (act) => optionsRef.current.openSession(act.identity),
+        }),
       // The asks about Luke himself — a settings change, the panel shown —
       // behind the same gauntlet: validated against the guide before this is
       // called, and performed by the same handlers the panel's controls use.

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 import {
   APP_SETTING_KIND,
@@ -2784,4 +2785,25 @@ test("the developer's call replaces Luke's own and keeps the waiting press", asy
   assert.ok(context.calls.includes("microphone-requested"));
   assert.equal(context.microphoneEnabled(), true);
   assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
+});
+
+test("a spoken tool call is still validated in both processes", () => {
+  const renderer = readFileSync(
+    new URL("../src/renderer/realtime-session.ts", import.meta.url),
+    "utf8",
+  );
+  const main = readFileSync(new URL("../src/main.ts", import.meta.url), "utf8");
+
+  // The renderer validates against the roster and the guide before a carrier runs.
+  assert.match(renderer, /\bsessionToolAction\b/);
+  assert.match(renderer, /\bissueToolAction\b/);
+  assert.match(renderer, /\bappToolAction\b/);
+
+  // The main process must not share those validators: it re-checks against its
+  // own registry before an adapter or tracker sees anything.
+  assert.doesNotMatch(main, /\bsessionToolAction\b/);
+  assert.doesNotMatch(main, /\bissueToolAction\b/);
+  assert.doesNotMatch(main, /\bappToolAction\b/);
+  assert.match(main, /sessionRegistry\.get/);
+  assert.match(main, /channels\.executeIssueAction/);
 });

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -191,12 +191,21 @@ export {
 } from "./realtime-context";
 export {
   type AppToolAction,
+  APP_TOOL_KIND,
   appToolAction,
+  type CarriedAppAction,
+  type CarriedIssueAction,
+  type CarriedSessionAction,
+  dispatchByKind,
   type IssueToolAction,
   isAppToolCall,
   isIssueToolName,
   isSessionToolName,
   issueToolAction,
+  REALTIME_TOOL_FAMILY,
+  type RealtimeToolFamily,
+  realtimeToolFamily,
+  SESSION_TOOL_KIND,
   type SessionToolAction,
   sessionToolAction,
 } from "./realtime-tools";

--- a/packages/sidecar-core/src/realtime-protocol.ts
+++ b/packages/sidecar-core/src/realtime-protocol.ts
@@ -4,6 +4,7 @@ import {
   maximumAttentionSummaryLength,
 } from "./attention";
 import { isRecord } from "./json";
+import { spokenRealtimeToolCount } from "./realtime-tools";
 import {
   ATTENTION_DISPOSITION,
   type AttentionDisposition,
@@ -107,7 +108,7 @@ export interface AttentionSpeech extends SessionIdentity {
   decidedAt: number;
 }
 
-const REALTIME_INSTRUCTION_LINES: readonly string[] = [
+const REALTIME_INSTRUCTION_HEAD: readonly string[] = [
   "You are Luke, a spoken companion for a developer who is running coding agents.",
   "You watch their sessions from the side, and you can carry out exactly what the developer asks of one.",
   "The developer speaks to you or types to you; either way it is them asking, and you answer out loud.",
@@ -126,7 +127,12 @@ const REALTIME_INSTRUCTION_LINES: readonly string[] = [
   "- You never receive transcripts, file contents, or command output, so never imply you read any.",
   "",
   "What you can do:",
-  "- You have ten tools: send a message to a session, run a control a session advertises, open a session on the developer's screen, create a new workspace where a provider allows it, add another agent to an observed workspace, move a tracked issue to a state it lists, comment on a tracked issue, change one of Luke's own settings, show Luke's panel, and open the feedback composer.",
+];
+
+const REALTIME_INSTRUCTION_TOOL_ACTS =
+  "send a message to a session, run a control a session advertises, open a session on the developer's screen, create a new workspace where a provider allows it, add another agent to an observed workspace, move a tracked issue to a state it lists, comment on a tracked issue, change one of Luke's own settings, show Luke's panel, and open the feedback composer.";
+
+const REALTIME_INSTRUCTION_TAIL: readonly string[] = [
   "- Use a tool only when the developer asks you to in this conversation, for the thing they asked.",
   "- Only sessions the roster marks as taking messages, carrying a control, or able to be opened can be acted on. Say so when one cannot.",
   "- Opening a session brings it up in its provider's own window, the same as pressing its row. It shows you nothing new.",
@@ -158,7 +164,11 @@ function trimmedText(value: string | undefined): string | undefined {
 
 /** The standing instructions that give Luke its spoken voice and its limits. */
 export function realtimeInstructions(): string {
-  return REALTIME_INSTRUCTION_LINES.join("\n");
+  return [
+    ...REALTIME_INSTRUCTION_HEAD,
+    `- You have ${spokenRealtimeToolCount()} tools: ${REALTIME_INSTRUCTION_TOOL_ACTS}`,
+    ...REALTIME_INSTRUCTION_TAIL,
+  ].join("\n");
 }
 
 /**

--- a/packages/sidecar-core/src/realtime-tools.ts
+++ b/packages/sidecar-core/src/realtime-tools.ts
@@ -1,3 +1,22 @@
+/**
+ * The acts Luke can carry for the developer, named as Realtime tools, in one
+ * table. Family membership, the spoken tool count, and the schema list are
+ * derived from it; adding a tool is adding a row.
+ *
+ * The session trio are the same acts the panel's rows offer — the two writes,
+ * and the press that opens a session where its provider keeps it — and the
+ * issue pair are the two acts a connected tracker takes. Creating a workspace
+ * is the one act with no row yet to mirror. The last three are the same
+ * presses turned toward the app itself: a settings change, showing the panel,
+ * and opening the feedback composer.
+ *
+ * All run the same gauntlet: a call is validated against the observed roster
+ * (or the guide) before anything leaves the renderer, and the main process
+ * validates it again against what it observed before anything happens. The
+ * `validate` on each row is the renderer's half of that, never a substitute
+ * for the main process's. Luke is another way to ask, never a wider one.
+ */
+
 import {
   APP_PANEL_TAB,
   APP_SETTING_KIND,
@@ -29,8 +48,9 @@ import {
   type WorkspaceAgentSelection,
   workspaceNameText,
 } from "./providers";
-import { maximumFeedbackDraftLength, type RealtimeFunctionCall } from "./realtime-protocol";
+import type { RealtimeFunctionCall } from "./realtime-protocol";
 import {
+  maximumSessionMessageLength,
   type NormalizedSession,
   SESSION_LOCATION,
   type SessionControl,
@@ -39,69 +59,167 @@ import {
   supportsSessionControl,
 } from "./session";
 
-/**
- * The acts Luke can carry for the developer, named as Realtime tools. The
- * session trio are the same acts the panel's rows offer — the two writes, and
- * the press that opens a session where its provider keeps it — and the issue
- * pair are the two acts a connected tracker takes. All run the same gauntlet:
- * a call is validated against the observed roster before anything leaves the
- * renderer, and the main process validates it again against what it observed
- * before anything happens. Luke is another way to ask, never a wider one.
- *
- * Creating a workspace is the one act with no row yet to mirror, and it keeps
- * the same posture: a call can only name a project its provider reported on
- * the latest observation pass — sent to the conversation as [workspace
- * projects] the way the roster is — and the main process validates it again
- * against what its adapters actually offered.
- *
- * The last three are the same presses turned toward the app itself: a settings
- * change goes through the bridge call the setting's own row uses, validated
- * against the app guide first; showing the panel is the capsule's press with a
- * tab chosen out loud; and opening the feedback composer is the tray item's
- * press, carrying at most the developer's own words as a starting draft — it
- * can never send, because sending is the composer's own button, pressed by
- * hand. None of the three reaches a provider.
- */
-export const REALTIME_TOOL = {
-  SEND_SESSION_MESSAGE: "send_session_message",
-  RUN_SESSION_CONTROL: "run_session_control",
-  OPEN_SESSION: "open_session",
-  CREATE_WORKSPACE: "create_workspace",
-  ADD_WORKSPACE_AGENT: "add_workspace_agent",
-  UPDATE_ISSUE_STATE: "update_issue_state",
-  COMMENT_ON_ISSUE: "comment_on_issue",
-  CHANGE_APP_SETTING: "change_app_setting",
-  SHOW_PANEL: "show_panel",
-  OPEN_FEEDBACK_COMPOSER: "open_feedback_composer",
+/** Which process a tool call is about: a session, an issue, or Luke himself. */
+export const REALTIME_TOOL_FAMILY = {
+  SESSION: "session",
+  ISSUE: "issue",
+  APP: "app",
 } as const;
 
-export type RealtimeToolName = (typeof REALTIME_TOOL)[keyof typeof REALTIME_TOOL];
+export type RealtimeToolFamily = (typeof REALTIME_TOOL_FAMILY)[keyof typeof REALTIME_TOOL_FAMILY];
 
-const SESSION_TOOL_NAMES: ReadonlySet<string> = new Set([
-  REALTIME_TOOL.SEND_SESSION_MESSAGE,
-  REALTIME_TOOL.RUN_SESSION_CONTROL,
-  REALTIME_TOOL.OPEN_SESSION,
-  // A workspace ask names a provider's project rather than a session, but it
-  // is the same family of act — carried by the session carrier, validated in
-  // sessionToolAction against the projects the conversation was shown.
-  REALTIME_TOOL.CREATE_WORKSPACE,
-  REALTIME_TOOL.ADD_WORKSPACE_AGENT,
-]);
+/** What a validated session tool call asks for, as the bridge names it. */
+export const SESSION_TOOL_KIND = {
+  MESSAGE: "message",
+  CONTROL: "control",
+  OPEN: "open",
+  CREATE_WORKSPACE: "create-workspace",
+  ADD_AGENT: "add-agent",
+} as const;
 
-const ISSUE_TOOL_NAMES: ReadonlySet<string> = new Set([
-  REALTIME_TOOL.UPDATE_ISSUE_STATE,
-  REALTIME_TOOL.COMMENT_ON_ISSUE,
-]);
+export type SessionToolKind = (typeof SESSION_TOOL_KIND)[keyof typeof SESSION_TOOL_KIND];
 
-/** Whether a tool call names one of the two session acts. */
-export function isSessionToolName(name: string): boolean {
-  return SESSION_TOOL_NAMES.has(name);
+/** What a validated issue tool call asks for, as the bridge names it. */
+export const ISSUE_TOOL_KIND = {
+  ISSUE_STATE: "issue-state",
+  ISSUE_COMMENT: "issue-comment",
+} as const;
+
+export type IssueToolKind = (typeof ISSUE_TOOL_KIND)[keyof typeof ISSUE_TOOL_KIND];
+
+/** What a validated app tool call asks for, as the app performs it. */
+export const APP_TOOL_KIND = {
+  SETTING: "setting",
+  PANEL: "panel",
+  FEEDBACK: "feedback",
+} as const;
+
+export type AppToolKind = (typeof APP_TOOL_KIND)[keyof typeof APP_TOOL_KIND];
+
+/**
+ * The whole-list scope a spoken panel ask may name. The rest of the filter
+ * vocabulary is not this module's to define: a location is a session's own
+ * `location`, and a provider is its `provider_id`, so a spoken filter is
+ * validated against the observed roster rather than against a second list.
+ */
+export const SESSION_LIST_ALL = "all";
+
+/** What one validated tool call asks for, ready for the bridge that carries it. */
+export type SessionToolAction =
+  | { kind: typeof SESSION_TOOL_KIND.MESSAGE; identity: SessionIdentity; text: string }
+  | { kind: typeof SESSION_TOOL_KIND.CONTROL; identity: SessionIdentity; control: SessionControl }
+  | { kind: typeof SESSION_TOOL_KIND.OPEN; identity: SessionIdentity }
+  | {
+      kind: typeof SESSION_TOOL_KIND.CREATE_WORKSPACE;
+      providerId: string;
+      providerProjectId: string;
+      name?: string;
+      task?: string;
+      /** The model the developer named for this one creation, resolved to ids. */
+      agentSelection?: WorkspaceAgentSelection;
+    }
+  | {
+      kind: typeof SESSION_TOOL_KIND.ADD_AGENT;
+      identity: SessionIdentity;
+      agent: string;
+      name?: string;
+      task?: string;
+      /** The model the developer named for this one agent, as its wire id. */
+      model?: string;
+      /** The effort riding that model, when the developer named both. */
+      effort?: string;
+    }
+  | { kind: "refused"; reason: string };
+
+/** A session act that passed the renderer's half of the gauntlet. */
+export type CarriedSessionAction = Exclude<SessionToolAction, { kind: "refused" }>;
+
+/** What one validated issue tool call asks for, ready for the bridge that carries it. */
+export type IssueToolAction =
+  | {
+      kind: typeof ISSUE_TOOL_KIND.ISSUE_STATE;
+      identity: IssueIdentity;
+      transition: IssueTransition;
+    }
+  | { kind: typeof ISSUE_TOOL_KIND.ISSUE_COMMENT; identity: IssueIdentity; body: string }
+  | { kind: "refused"; reason: string };
+
+/** An issue act that passed the renderer's half of the gauntlet. */
+export type CarriedIssueAction = Exclude<IssueToolAction, { kind: "refused" }>;
+
+/**
+ * What one validated app tool call asks for, ready for the app to perform.
+ * The feedback action opens the composer and nothing else: `draft` is at most
+ * the developer's own words, placed only into an empty note, and what the
+ * composer holds leaves only by its own Send button — no action here sends.
+ */
+export type AppToolAction =
+  | { kind: typeof APP_TOOL_KIND.SETTING; setting: AppGuideSetting; value: string }
+  | { kind: typeof APP_TOOL_KIND.PANEL; tab: AppPanelTab; filter?: string; sort?: SessionListSort }
+  | { kind: typeof APP_TOOL_KIND.FEEDBACK; composer: FeedbackComposerKind; draft?: string }
+  | { kind: "refused"; reason: string };
+
+/** An app act that passed the renderer's half of the gauntlet. */
+export type CarriedAppAction = Exclude<AppToolAction, { kind: "refused" }>;
+
+export interface SessionToolContext {
+  sessions: readonly NormalizedSession[];
+  workspaceProjects: readonly ObservedWorkspaceProject[];
+  agentModels: (providerId: string) => readonly WorkspaceAgentModels[];
 }
 
-/** Whether a tool call names one of the two issue acts. */
-export function isIssueToolName(name: string): boolean {
-  return ISSUE_TOOL_NAMES.has(name);
+export interface IssueToolContext {
+  issues: readonly TrackedIssue[];
 }
+
+export interface AppToolContext {
+  guide: AppGuideSnapshot;
+  sessions: readonly NormalizedSession[];
+}
+
+type SessionToolValidate = (
+  parsed: Record<string, unknown>,
+  context: SessionToolContext,
+) => SessionToolAction;
+
+type IssueToolValidate = (
+  parsed: Record<string, unknown>,
+  context: IssueToolContext,
+) => IssueToolAction;
+
+type AppToolValidate = (parsed: Record<string, unknown>, context: AppToolContext) => AppToolAction;
+
+interface RealtimeToolSchema {
+  description: string;
+  parameters: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required: readonly string[];
+  };
+}
+
+type SessionToolSpec = {
+  name: string;
+  family: typeof REALTIME_TOOL_FAMILY.SESSION;
+  schema: RealtimeToolSchema;
+  validate: SessionToolValidate;
+};
+
+type IssueToolSpec = {
+  name: string;
+  family: typeof REALTIME_TOOL_FAMILY.ISSUE;
+  schema: RealtimeToolSchema;
+  validate: IssueToolValidate;
+};
+
+type AppToolSpec = {
+  name: string;
+  family: typeof REALTIME_TOOL_FAMILY.APP;
+  schema: RealtimeToolSchema;
+  validate: AppToolValidate;
+};
+
+type RealtimeToolSpec = SessionToolSpec | IssueToolSpec | AppToolSpec;
 
 const SESSION_IDENTITY_PARAMETERS = {
   provider_id: {
@@ -126,12 +244,456 @@ const ISSUE_IDENTITY_PARAMETERS = {
   },
 } as const;
 
-/** The tool schemas a Realtime session is configured with. */
-export function realtimeToolDefinitions(): readonly Record<string, unknown>[] {
-  return [
-    {
-      type: "function",
-      name: REALTIME_TOOL.SEND_SESSION_MESSAGE,
+function textArgument(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  const normalized = typeof value === "string" ? value.trim() : "";
+  return normalized || undefined;
+}
+
+function parseToolArguments(
+  call: RealtimeFunctionCall,
+): { ok: true; value: Record<string, unknown> } | { ok: false; reason: string } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(call.argumentsJson);
+  } catch {
+    return { ok: false, reason: "The tool call's arguments were not readable." };
+  }
+  if (!isRecord(parsed)) {
+    return { ok: false, reason: "The tool call's arguments were not readable." };
+  }
+  return { ok: true, value: parsed };
+}
+
+function sessionFromArguments(
+  parsed: Record<string, unknown>,
+  sessions: readonly NormalizedSession[],
+): { session: NormalizedSession; identity: SessionIdentity } | { kind: "refused"; reason: string } {
+  const providerId = textArgument(parsed, "provider_id");
+  const providerSessionId = textArgument(parsed, "provider_session_id");
+  const session = sessions.find(
+    (candidate) =>
+      candidate.providerId === providerId && candidate.providerSessionId === providerSessionId,
+  );
+  if (!session) {
+    return { kind: "refused", reason: "No observed session matches that identity." };
+  }
+  return {
+    session,
+    identity: {
+      providerId: session.providerId,
+      providerSessionId: session.providerSessionId,
+    },
+  };
+}
+
+function issueFromArguments(
+  parsed: Record<string, unknown>,
+  issues: readonly TrackedIssue[],
+): { issue: TrackedIssue; identity: IssueIdentity } | { kind: "refused"; reason: string } {
+  const trackerId = textArgument(parsed, "tracker_id");
+  const issueId = textArgument(parsed, "issue_id");
+  const issue = issues.find(
+    (candidate) => candidate.trackerId === trackerId && candidate.identifier === issueId,
+  );
+  if (!issue) {
+    return { kind: "refused", reason: "No tracked issue matches that identity." };
+  }
+  return {
+    issue,
+    identity: {
+      trackerId: issue.trackerId,
+      identifier: issue.identifier,
+    },
+  };
+}
+
+/**
+ * Resolves a model the developer named — by the label the guide lists it
+ * under, or its id — to the wire pairing an endpoint takes, held to the
+ * build's documented entries for the provider. The effort, when named, must
+ * be one the resolved model's own agent documents: the pairing is validated
+ * as the whole it will be sent as.
+ */
+function resolveWorkspaceAgentModel(
+  entries: readonly WorkspaceAgentModels[],
+  modelWord: string,
+  effortWord: string | undefined,
+): { selection: WorkspaceAgentSelection } | { refused: string } {
+  const normalizedModel = modelWord.trim().toLowerCase();
+  const named = entries
+    .flatMap((entry) => entry.models.map((model) => ({ entry, model })))
+    .find(
+      ({ model }) =>
+        model.label.toLowerCase() === normalizedModel || model.id.toLowerCase() === normalizedModel,
+    );
+  if (!named) return { refused: "No documented model goes by that name here." };
+  let effort: string | undefined;
+  if (effortWord !== undefined) {
+    const normalizedEffort = effortWord.trim().toLowerCase();
+    effort = named.entry.efforts.find((candidate) => candidate.toLowerCase() === normalizedEffort);
+    if (!effort) {
+      return {
+        refused:
+          named.entry.efforts.length > 0
+            ? `That model's effort is one of ${named.entry.efforts.join(", ")}.`
+            : "That model takes no effort level.",
+      };
+    }
+  }
+  return {
+    selection: { agent: named.entry.agent, model: named.model.id, ...(effort ? { effort } : {}) },
+  };
+}
+
+function validateSendSessionMessage(
+  parsed: Record<string, unknown>,
+  context: SessionToolContext,
+): SessionToolAction {
+  const found = sessionFromArguments(parsed, context.sessions);
+  if ("kind" in found) return found;
+  const { session, identity } = found;
+  if (!session.canReceiveMessage) {
+    return { kind: "refused", reason: "That session does not take messages right now." };
+  }
+  const text = sessionMessageText(parsed.text);
+  if (!text) {
+    return {
+      kind: "refused",
+      reason: "A message has to be shorter than a document and longer than nothing.",
+    };
+  }
+  return { kind: SESSION_TOOL_KIND.MESSAGE, identity, text };
+}
+
+function validateRunSessionControl(
+  parsed: Record<string, unknown>,
+  context: SessionToolContext,
+): SessionToolAction {
+  const found = sessionFromArguments(parsed, context.sessions);
+  if ("kind" in found) return found;
+  const { session, identity } = found;
+  const controlId = textArgument(parsed, "control_id");
+  const control = session.controls.find((candidate) => candidate.id === controlId);
+  if (!controlId || !control || !supportsSessionControl(session, controlId)) {
+    return { kind: "refused", reason: "That session advertises no such control." };
+  }
+  return { kind: SESSION_TOOL_KIND.CONTROL, identity, control };
+}
+
+function validateOpenSession(
+  parsed: Record<string, unknown>,
+  context: SessionToolContext,
+): SessionToolAction {
+  const found = sessionFromArguments(parsed, context.sessions);
+  if ("kind" in found) return found;
+  const { session, identity } = found;
+  // The action carries the identity, never the address: the main process
+  // reads the link back out of its own registry, the same as a pressed row.
+  if (!session.detail.link) {
+    return { kind: "refused", reason: "That session has no address to open." };
+  }
+  return { kind: SESSION_TOOL_KIND.OPEN, identity };
+}
+
+function validateCreateWorkspace(
+  parsed: Record<string, unknown>,
+  context: SessionToolContext,
+): SessionToolAction {
+  // A creation ask names a project rather than a session, so it is validated
+  // against the projects the conversation was shown — the same discipline,
+  // against the list that actually offered it.
+  const project = context.workspaceProjects.find(
+    (candidate) =>
+      candidate.providerId === textArgument(parsed, "provider_id") &&
+      candidate.providerProjectId === textArgument(parsed, "project_id"),
+  );
+  if (!project) {
+    return { kind: "refused", reason: "No listed project matches that identity." };
+  }
+  let name: string | undefined;
+  if (parsed.name !== undefined) {
+    name = workspaceNameText(parsed.name);
+    if (!name) {
+      return {
+        kind: "refused",
+        reason: `A workspace name has to be under ${maximumWorkspaceNameLength} characters and longer than nothing.`,
+      };
+    }
+  }
+  // The task is held to the project's own word for it: a project that takes
+  // none cannot be handed one, a project that needs one cannot be created
+  // without it, and the text itself is bounded like the message it is.
+  let task: string | undefined;
+  if (parsed.task !== undefined) {
+    if (project.taskSupport === WORKSPACE_TASK_SUPPORT.NONE) {
+      return { kind: "refused", reason: "That project takes no opening task." };
+    }
+    task = sessionMessageText(parsed.task);
+    if (!task) {
+      return {
+        kind: "refused",
+        reason: "A task has to be shorter than a document and longer than nothing.",
+      };
+    }
+  } else if (project.taskSupport === WORKSPACE_TASK_SUPPORT.REQUIRED) {
+    return {
+      kind: "refused",
+      reason: "That project needs an opening task to create a workspace.",
+    };
+  }
+  // A model named for this one creation resolves against the provider's own
+  // documented table, and the effort only ever rides a model: alone it has
+  // nothing documented to attach to.
+  const spokenModel = textArgument(parsed, "model");
+  const spokenEffort = textArgument(parsed, "effort");
+  if (spokenEffort !== undefined && spokenModel === undefined) {
+    return { kind: "refused", reason: "An effort rides a model; name the model too." };
+  }
+  let agentSelection: WorkspaceAgentSelection | undefined;
+  if (spokenModel !== undefined) {
+    const resolved = resolveWorkspaceAgentModel(
+      context.agentModels(project.providerId),
+      spokenModel,
+      spokenEffort,
+    );
+    if ("refused" in resolved) return { kind: "refused", reason: resolved.refused };
+    agentSelection = resolved.selection;
+  }
+  return {
+    kind: SESSION_TOOL_KIND.CREATE_WORKSPACE,
+    providerId: project.providerId,
+    providerProjectId: project.providerProjectId,
+    ...(name ? { name } : {}),
+    ...(task ? { task } : {}),
+    ...(agentSelection ? { agentSelection } : {}),
+  };
+}
+
+function validateAddWorkspaceAgent(
+  parsed: Record<string, unknown>,
+  context: SessionToolContext,
+): SessionToolAction {
+  const found = sessionFromArguments(parsed, context.sessions);
+  if ("kind" in found) return found;
+  const { session, identity } = found;
+  // The agent must be one this session's own roster entry listed: the list
+  // is the provider's word for what its endpoint takes, so an ask outside it
+  // is refused rather than forwarded to be refused.
+  const agent = textArgument(parsed, "agent");
+  if (!agent || !session.spawnableAgents.includes(agent)) {
+    return { kind: "refused", reason: "That session lists no such agent to add." };
+  }
+  let name: string | undefined;
+  if (parsed.name !== undefined) {
+    name = workspaceNameText(parsed.name);
+    if (!name) {
+      return {
+        kind: "refused",
+        reason: `A session name has to be under ${maximumWorkspaceNameLength} characters and longer than nothing.`,
+      };
+    }
+  }
+  let task: string | undefined;
+  if (parsed.task !== undefined) {
+    task = sessionMessageText(parsed.task);
+    if (!task) {
+      return {
+        kind: "refused",
+        reason: "A task has to be shorter than a document and longer than nothing.",
+      };
+    }
+  }
+  // A model named for this one agent resolves within the asked-for kind
+  // alone: the developer's chosen agent is never re-decided by the model
+  // they named beside it, so a mismatch is a refusal rather than a swap.
+  const spokenModel = textArgument(parsed, "model");
+  const spokenEffort = textArgument(parsed, "effort");
+  if (spokenEffort !== undefined && spokenModel === undefined) {
+    return { kind: "refused", reason: "An effort rides a model; name the model too." };
+  }
+  let selection: WorkspaceAgentSelection | undefined;
+  if (spokenModel !== undefined) {
+    const entries = context
+      .agentModels(session.providerId)
+      .filter((candidate) => candidate.agent === agent);
+    const resolved = resolveWorkspaceAgentModel(entries, spokenModel, spokenEffort);
+    if ("refused" in resolved) {
+      return {
+        kind: "refused",
+        reason: resolved.refused.startsWith("No documented model")
+          ? `A ${agent} agent runs no model by that name.`
+          : resolved.refused,
+      };
+    }
+    selection = resolved.selection;
+  }
+  return {
+    kind: SESSION_TOOL_KIND.ADD_AGENT,
+    identity,
+    agent,
+    ...(name ? { name } : {}),
+    ...(task ? { task } : {}),
+    ...(selection ? { model: selection.model } : {}),
+    ...(selection?.effort ? { effort: selection.effort } : {}),
+  };
+}
+
+function validateUpdateIssueState(
+  parsed: Record<string, unknown>,
+  context: IssueToolContext,
+): IssueToolAction {
+  const found = issueFromArguments(parsed, context.issues);
+  if ("kind" in found) return found;
+  const { issue, identity } = found;
+  const state = textArgument(parsed, "state");
+  // Spoken names arrive with their case retold rather than copied, so the
+  // match forgives case alone — never spelling — and only while it stays
+  // unambiguous. Two advertised states apart only in case are not a guess
+  // Luke gets to make.
+  const named = state
+    ? issue.transitions.filter((candidate) => candidate.name.toLowerCase() === state.toLowerCase())
+    : [];
+  const transition =
+    named.find((candidate) => candidate.name === state) ??
+    (named.length === 1 ? named[0] : undefined);
+  if (!transition) {
+    return { kind: "refused", reason: "That issue lists no such state." };
+  }
+  return { kind: ISSUE_TOOL_KIND.ISSUE_STATE, identity, transition };
+}
+
+function validateCommentOnIssue(
+  parsed: Record<string, unknown>,
+  context: IssueToolContext,
+): IssueToolAction {
+  const found = issueFromArguments(parsed, context.issues);
+  if ("kind" in found) return found;
+  const { issue, identity } = found;
+  if (!issue.canComment) {
+    return { kind: "refused", reason: "That issue does not take comments." };
+  }
+  const body = issueCommentText(parsed.body);
+  if (!body) {
+    return {
+      kind: "refused",
+      reason: "A comment has to be shorter than a document and longer than nothing.",
+    };
+  }
+  return { kind: ISSUE_TOOL_KIND.ISSUE_COMMENT, identity, body };
+}
+
+/**
+ * Validates the value a spoken change carries against the setting it names.
+ * A toggle takes the guide's own two words (and their unambiguous synonyms);
+ * a choice takes exactly one of the values the guide listed. Anything else is
+ * refused with the accepted set, so the refusal is also the correction.
+ */
+function appSettingValue(setting: AppGuideSetting, value: unknown): string | undefined {
+  if (setting.kind === APP_SETTING_KIND.TOGGLE) return appToggleValue(value);
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  return setting.choices?.find((choice) => choice.toLowerCase() === normalized);
+}
+
+/**
+ * Validates a spoken session-list filter against the sessions actually being
+ * observed. A filter that would show nothing is refused rather than applied:
+ * the panel would quietly fall back to showing everything, and Luke would have
+ * reported a narrowing that never happened.
+ */
+function panelFilterAction(
+  filter: string,
+  sessions: readonly NormalizedSession[],
+): { filter: string } | { reason: string } {
+  if (filter === SESSION_LIST_ALL) return { filter };
+  if (filter === SESSION_LOCATION.LOCAL || filter === SESSION_LOCATION.CLOUD) {
+    if (sessions.some((session) => session.location === filter)) return { filter };
+    return { reason: `No ${filter} sessions are observed right now.` };
+  }
+  if (sessions.some((session) => session.providerId === filter)) return { filter };
+  return { reason: "No observed session belongs to that provider." };
+}
+
+function validateChangeAppSetting(
+  parsed: Record<string, unknown>,
+  context: AppToolContext,
+): AppToolAction {
+  const setting = appGuideSetting(context.guide, textArgument(parsed, "setting_id"));
+  if (!setting) {
+    return { kind: "refused", reason: "The app guide lists no such setting." };
+  }
+  if (!setting.adjustable) {
+    return {
+      kind: "refused",
+      reason: `${setting.label} can only be changed by hand: ${setting.manual}`,
+    };
+  }
+  const value = appSettingValue(setting, parsed.value);
+  if (value === undefined) {
+    const accepted =
+      setting.kind === APP_SETTING_KIND.TOGGLE ? "on or off" : (setting.choices ?? []).join(", ");
+    return { kind: "refused", reason: `${setting.label} takes ${accepted}.` };
+  }
+  return { kind: APP_TOOL_KIND.SETTING, setting, value };
+}
+
+function validateShowPanel(
+  parsed: Record<string, unknown>,
+  context: AppToolContext,
+): AppToolAction {
+  const tab = parsed.tab ?? APP_PANEL_TAB.SESSIONS;
+  if (!isAppPanelTab(tab)) {
+    return { kind: "refused", reason: "The panel has no such tab." };
+  }
+  const sort = textArgument(parsed, "sort");
+  if (sort !== undefined && !isSessionListSort(sort)) {
+    return { kind: "refused", reason: "The list orders by urgency or by recency." };
+  }
+  const filter = textArgument(parsed, "filter");
+  if (filter === undefined) {
+    return {
+      kind: APP_TOOL_KIND.PANEL,
+      tab,
+      ...(sort !== undefined ? { sort } : {}),
+    };
+  }
+  const outcome = panelFilterAction(filter, context.sessions);
+  if ("reason" in outcome) return { kind: "refused", reason: outcome.reason };
+  return {
+    kind: APP_TOOL_KIND.PANEL,
+    tab,
+    filter: outcome.filter,
+    ...(sort !== undefined ? { sort } : {}),
+  };
+}
+
+function validateOpenFeedbackComposer(
+  parsed: Record<string, unknown>,
+  _context: AppToolContext,
+): AppToolAction {
+  const composer = parsed.kind;
+  if (!isFeedbackComposerKind(composer)) {
+    return { kind: "refused", reason: "The composer writes feedback or a prompt, nothing else." };
+  }
+  // The draft is the developer's ask restated, so it is bounded like a typed
+  // one; a blank draft is no draft, and the composer simply opens empty.
+  // Same bound as maximumFeedbackDraftLength: the draft is the developer's
+  // ask restated in their words, not a document.
+  const draft = textArgument(parsed, "draft")?.slice(0, maximumSessionMessageLength);
+  return { kind: APP_TOOL_KIND.FEEDBACK, composer, ...(draft ? { draft } : {}) };
+}
+
+/**
+ * The acts Luke can carry, keyed the way a value set is: adding a tool is
+ * adding a key, and the family sets, the spoken count, and the schema list
+ * follow. Each row's `validate` is the renderer's half of the gauntlet — the
+ * main process still validates the same act against what it observed.
+ */
+export const REALTIME_TOOLS = {
+  SEND_SESSION_MESSAGE: {
+    name: "send_session_message",
+    family: REALTIME_TOOL_FAMILY.SESSION,
+    schema: {
       description:
         "Send a message the developer just asked you to send to one observed session. " +
         "Only sessions the roster marks as taking messages can receive one.",
@@ -147,9 +709,12 @@ export function realtimeToolDefinitions(): readonly Record<string, unknown>[] {
         required: ["provider_id", "provider_session_id", "text"],
       },
     },
-    {
-      type: "function",
-      name: REALTIME_TOOL.RUN_SESSION_CONTROL,
+    validate: validateSendSessionMessage,
+  },
+  RUN_SESSION_CONTROL: {
+    name: "run_session_control",
+    family: REALTIME_TOOL_FAMILY.SESSION,
+    schema: {
       description:
         "Run a control one observed session advertises, such as stopping its current run. " +
         "Only controls the roster lists for that session exist.",
@@ -165,9 +730,12 @@ export function realtimeToolDefinitions(): readonly Record<string, unknown>[] {
         required: ["provider_id", "provider_session_id", "control_id"],
       },
     },
-    {
-      type: "function",
-      name: REALTIME_TOOL.OPEN_SESSION,
+    validate: validateRunSessionControl,
+  },
+  OPEN_SESSION: {
+    name: "open_session",
+    family: REALTIME_TOOL_FAMILY.SESSION,
+    schema: {
       description:
         "Open one observed session on the developer's screen, the same as pressing its row. " +
         "Only sessions the roster marks as able to be opened have somewhere to open.",
@@ -177,9 +745,12 @@ export function realtimeToolDefinitions(): readonly Record<string, unknown>[] {
         required: ["provider_id", "provider_session_id"],
       },
     },
-    {
-      type: "function",
-      name: REALTIME_TOOL.CREATE_WORKSPACE,
+    validate: validateOpenSession,
+  },
+  CREATE_WORKSPACE: {
+    name: "create_workspace",
+    family: REALTIME_TOOL_FAMILY.SESSION,
+    schema: {
       description:
         "Create a new workspace — a new agent — the developer just asked for, in one project " +
         "a provider listed. Only projects the [workspace projects] context lists exist.",
@@ -223,9 +794,12 @@ export function realtimeToolDefinitions(): readonly Record<string, unknown>[] {
         required: ["provider_id", "project_id"],
       },
     },
-    {
-      type: "function",
-      name: REALTIME_TOOL.ADD_WORKSPACE_AGENT,
+    validate: validateCreateWorkspace,
+  },
+  ADD_WORKSPACE_AGENT: {
+    name: "add_workspace_agent",
+    family: REALTIME_TOOL_FAMILY.SESSION,
+    schema: {
       description:
         "Start another agent in the workspace one observed session runs in. Only sessions " +
         "whose roster entry lists new agents can take one, only as an agent kind it lists.",
@@ -264,9 +838,12 @@ export function realtimeToolDefinitions(): readonly Record<string, unknown>[] {
         required: ["provider_id", "provider_session_id", "agent"],
       },
     },
-    {
-      type: "function",
-      name: REALTIME_TOOL.UPDATE_ISSUE_STATE,
+    validate: validateAddWorkspaceAgent,
+  },
+  UPDATE_ISSUE_STATE: {
+    name: "update_issue_state",
+    family: REALTIME_TOOL_FAMILY.ISSUE,
+    schema: {
       description:
         "Move one tracked issue to a state the developer just asked for. " +
         "Only issues the issue roster lists exist, and only the states it lists for one.",
@@ -282,9 +859,12 @@ export function realtimeToolDefinitions(): readonly Record<string, unknown>[] {
         required: ["tracker_id", "issue_id", "state"],
       },
     },
-    {
-      type: "function",
-      name: REALTIME_TOOL.COMMENT_ON_ISSUE,
+    validate: validateUpdateIssueState,
+  },
+  COMMENT_ON_ISSUE: {
+    name: "comment_on_issue",
+    family: REALTIME_TOOL_FAMILY.ISSUE,
+    schema: {
       description:
         "Add a comment the developer just asked you to add to one tracked issue. " +
         "Only issues the issue roster marks as taking comments can receive one.",
@@ -300,9 +880,12 @@ export function realtimeToolDefinitions(): readonly Record<string, unknown>[] {
         required: ["tracker_id", "issue_id", "body"],
       },
     },
-    {
-      type: "function",
-      name: REALTIME_TOOL.CHANGE_APP_SETTING,
+    validate: validateCommentOnIssue,
+  },
+  CHANGE_APP_SETTING: {
+    name: "change_app_setting",
+    family: REALTIME_TOOL_FAMILY.APP,
+    schema: {
       description:
         "Change one of Luke's own settings the developer just asked for. " +
         "Only settings the app guide marks as changeable by voice can be changed.",
@@ -322,9 +905,12 @@ export function realtimeToolDefinitions(): readonly Record<string, unknown>[] {
         required: ["setting_id", "value"],
       },
     },
-    {
-      type: "function",
-      name: REALTIME_TOOL.SHOW_PANEL,
+    validate: validateChangeAppSetting,
+  },
+  SHOW_PANEL: {
+    name: "show_panel",
+    family: REALTIME_TOOL_FAMILY.APP,
+    schema: {
       description:
         "Show Luke's own panel on the developer's screen, the same as pressing the capsule — or, " +
         "when the panel is already open, switch it to the named tab, the same as pressing that tab. " +
@@ -352,9 +938,12 @@ export function realtimeToolDefinitions(): readonly Record<string, unknown>[] {
         required: [],
       },
     },
-    {
-      type: "function",
-      name: REALTIME_TOOL.OPEN_FEEDBACK_COMPOSER,
+    validate: validateShowPanel,
+  },
+  OPEN_FEEDBACK_COMPOSER: {
+    name: "open_feedback_composer",
+    family: REALTIME_TOOL_FAMILY.APP,
+    schema: {
       description:
         "Open the composer for a note the developer sends the founders by hand. " +
         "It opens and may draft; it never sends — the developer edits and presses Send themselves.",
@@ -376,78 +965,99 @@ export function realtimeToolDefinitions(): readonly Record<string, unknown>[] {
         required: ["kind"],
       },
     },
-  ];
-}
+    validate: validateOpenFeedbackComposer,
+  },
+} as const satisfies Record<string, RealtimeToolSpec>;
 
-/** What one validated tool call asks for, ready for the bridge that carries it. */
-export type SessionToolAction =
-  | { kind: "message"; identity: SessionIdentity; text: string }
-  | { kind: "control"; identity: SessionIdentity; control: SessionControl }
-  | { kind: "open"; identity: SessionIdentity }
-  | {
-      kind: "create-workspace";
-      providerId: string;
-      providerProjectId: string;
-      name?: string;
-      task?: string;
-      /** The model the developer named for this one creation, resolved to ids. */
-      agentSelection?: WorkspaceAgentSelection;
-    }
-  | {
-      kind: "add-agent";
-      identity: SessionIdentity;
-      agent: string;
-      name?: string;
-      task?: string;
-      /** The model the developer named for this one agent, as its wire id. */
-      model?: string;
-      /** The effort riding that model, when the developer named both. */
-      effort?: string;
-    }
-  | { kind: "refused"; reason: string };
-
-function textArgument(record: Record<string, unknown>, key: string): string | undefined {
-  const value = record[key];
-  const normalized = typeof value === "string" ? value.trim() : "";
-  return normalized || undefined;
-}
-
-/**
- * Resolves a model the developer named — by the label the guide lists it
- * under, or its id — to the wire pairing an endpoint takes, held to the
- * build's documented entries for the provider. The effort, when named, must
- * be one the resolved model's own agent documents: the pairing is validated
- * as the whole it will be sent as.
- */
-function resolveWorkspaceAgentModel(
-  entries: readonly WorkspaceAgentModels[],
-  modelWord: string,
-  effortWord: string | undefined,
-): { selection: WorkspaceAgentSelection } | { refused: string } {
-  const normalizedModel = modelWord.trim().toLowerCase();
-  const named = entries
-    .flatMap((entry) => entry.models.map((model) => ({ entry, model })))
-    .find(
-      ({ model }) =>
-        model.label.toLowerCase() === normalizedModel || model.id.toLowerCase() === normalizedModel,
-    );
-  if (!named) return { refused: "No documented model goes by that name here." };
-  let effort: string | undefined;
-  if (effortWord !== undefined) {
-    const normalizedEffort = effortWord.trim().toLowerCase();
-    effort = named.entry.efforts.find((candidate) => candidate.toLowerCase() === normalizedEffort);
-    if (!effort) {
-      return {
-        refused:
-          named.entry.efforts.length > 0
-            ? `That model's effort is one of ${named.entry.efforts.join(", ")}.`
-            : "That model takes no effort level.",
-      };
-    }
+function namesFromToolTable<T extends Record<string, { readonly name: string }>>(
+  table: T,
+): { [K in keyof T]: T[K]["name"] } {
+  const names = {} as { [K in keyof T]: T[K]["name"] };
+  for (const key of Object.keys(table) as (keyof T)[]) {
+    const tool = table[key];
+    if (tool) names[key] = tool.name;
   }
-  return {
-    selection: { agent: named.entry.agent, model: named.model.id, ...(effort ? { effort } : {}) },
-  };
+  return names;
+}
+
+export const REALTIME_TOOL = namesFromToolTable(REALTIME_TOOLS);
+
+export type RealtimeToolName = (typeof REALTIME_TOOL)[keyof typeof REALTIME_TOOL];
+
+const REALTIME_TOOL_LIST: readonly RealtimeToolSpec[] = Object.values(REALTIME_TOOLS);
+
+const REALTIME_TOOLS_BY_NAME = new Map<string, RealtimeToolSpec>(
+  REALTIME_TOOL_LIST.map((tool) => [tool.name, tool]),
+);
+
+function toolNamesOfFamily(family: RealtimeToolFamily): ReadonlySet<string> {
+  return new Set(
+    REALTIME_TOOL_LIST.filter((tool) => tool.family === family).map((tool) => tool.name),
+  );
+}
+
+const SESSION_TOOL_NAMES = toolNamesOfFamily(REALTIME_TOOL_FAMILY.SESSION);
+const ISSUE_TOOL_NAMES = toolNamesOfFamily(REALTIME_TOOL_FAMILY.ISSUE);
+const APP_TOOL_NAMES = toolNamesOfFamily(REALTIME_TOOL_FAMILY.APP);
+
+/** Whether a tool call names one of the session acts. */
+export function isSessionToolName(name: string): boolean {
+  return SESSION_TOOL_NAMES.has(name);
+}
+
+/** Whether a tool call names one of the issue acts. */
+export function isIssueToolName(name: string): boolean {
+  return ISSUE_TOOL_NAMES.has(name);
+}
+
+/** Whether a tool call is about the app itself rather than about a session. */
+export function isAppToolCall(call: RealtimeFunctionCall): boolean {
+  return APP_TOOL_NAMES.has(call.name);
+}
+
+/** The family a named tool belongs to, or nothing when no such tool exists. */
+export function realtimeToolFamily(name: string): RealtimeToolFamily | undefined {
+  return REALTIME_TOOLS_BY_NAME.get(name)?.family;
+}
+
+const SPOKEN_CARDINAL = {
+  0: "zero",
+  1: "one",
+  2: "two",
+  3: "three",
+  4: "four",
+  5: "five",
+  6: "six",
+  7: "seven",
+  8: "eight",
+  9: "nine",
+  10: "ten",
+  11: "eleven",
+  12: "twelve",
+  13: "thirteen",
+  14: "fourteen",
+  15: "fifteen",
+  16: "sixteen",
+  17: "seventeen",
+  18: "eighteen",
+  19: "nineteen",
+  20: "twenty",
+} as const;
+
+/** How many tools Luke has, as he says it in the standing instructions. */
+export function spokenRealtimeToolCount(): string {
+  const count = REALTIME_TOOL_LIST.length;
+  return SPOKEN_CARDINAL[count as keyof typeof SPOKEN_CARDINAL] ?? String(count);
+}
+
+/** The tool schemas a Realtime session is configured with. */
+export function realtimeToolDefinitions(): readonly Record<string, unknown>[] {
+  return REALTIME_TOOL_LIST.map((tool) => ({
+    type: "function",
+    name: tool.name,
+    description: tool.schema.description,
+    parameters: tool.schema.parameters,
+  }));
 }
 
 /**
@@ -467,204 +1077,14 @@ export function sessionToolAction(
   // forwarded unchecked.
   agentModels: (providerId: string) => readonly WorkspaceAgentModels[] = () => [],
 ): SessionToolAction {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(call.argumentsJson);
-  } catch {
-    return { kind: "refused", reason: "The tool call's arguments were not readable." };
+  const parsed = parseToolArguments(call);
+  if (!parsed.ok) return { kind: "refused", reason: parsed.reason };
+  const tool = REALTIME_TOOLS_BY_NAME.get(call.name);
+  if (!tool || tool.family !== REALTIME_TOOL_FAMILY.SESSION) {
+    return { kind: "refused", reason: "No such tool exists." };
   }
-  if (!isRecord(parsed)) {
-    return { kind: "refused", reason: "The tool call's arguments were not readable." };
-  }
-
-  // A creation ask names a project rather than a session, so it is validated
-  // against the projects the conversation was shown before the roster is even
-  // consulted — the same discipline, against the list that actually offered it.
-  if (call.name === REALTIME_TOOL.CREATE_WORKSPACE) {
-    const project = workspaceProjects.find(
-      (candidate) =>
-        candidate.providerId === textArgument(parsed, "provider_id") &&
-        candidate.providerProjectId === textArgument(parsed, "project_id"),
-    );
-    if (!project) {
-      return { kind: "refused", reason: "No listed project matches that identity." };
-    }
-    let name: string | undefined;
-    if (parsed.name !== undefined) {
-      name = workspaceNameText(parsed.name);
-      if (!name) {
-        return {
-          kind: "refused",
-          reason: `A workspace name has to be under ${maximumWorkspaceNameLength} characters and longer than nothing.`,
-        };
-      }
-    }
-    // The task is held to the project's own word for it: a project that takes
-    // none cannot be handed one, a project that needs one cannot be created
-    // without it, and the text itself is bounded like the message it is.
-    let task: string | undefined;
-    if (parsed.task !== undefined) {
-      if (project.taskSupport === WORKSPACE_TASK_SUPPORT.NONE) {
-        return { kind: "refused", reason: "That project takes no opening task." };
-      }
-      task = sessionMessageText(parsed.task);
-      if (!task) {
-        return {
-          kind: "refused",
-          reason: "A task has to be shorter than a document and longer than nothing.",
-        };
-      }
-    } else if (project.taskSupport === WORKSPACE_TASK_SUPPORT.REQUIRED) {
-      return {
-        kind: "refused",
-        reason: "That project needs an opening task to create a workspace.",
-      };
-    }
-    // A model named for this one creation resolves against the provider's own
-    // documented table, and the effort only ever rides a model: alone it has
-    // nothing documented to attach to.
-    const spokenModel = textArgument(parsed, "model");
-    const spokenEffort = textArgument(parsed, "effort");
-    if (spokenEffort !== undefined && spokenModel === undefined) {
-      return { kind: "refused", reason: "An effort rides a model; name the model too." };
-    }
-    let agentSelection: WorkspaceAgentSelection | undefined;
-    if (spokenModel !== undefined) {
-      const resolved = resolveWorkspaceAgentModel(
-        agentModels(project.providerId),
-        spokenModel,
-        spokenEffort,
-      );
-      if ("refused" in resolved) return { kind: "refused", reason: resolved.refused };
-      agentSelection = resolved.selection;
-    }
-    return {
-      kind: "create-workspace",
-      providerId: project.providerId,
-      providerProjectId: project.providerProjectId,
-      ...(name ? { name } : {}),
-      ...(task ? { task } : {}),
-      ...(agentSelection ? { agentSelection } : {}),
-    };
-  }
-
-  const providerId = textArgument(parsed, "provider_id");
-  const providerSessionId = textArgument(parsed, "provider_session_id");
-  const session = sessions.find(
-    (candidate) =>
-      candidate.providerId === providerId && candidate.providerSessionId === providerSessionId,
-  );
-  if (!session) {
-    return { kind: "refused", reason: "No observed session matches that identity." };
-  }
-  const identity: SessionIdentity = {
-    providerId: session.providerId,
-    providerSessionId: session.providerSessionId,
-  };
-
-  if (call.name === REALTIME_TOOL.SEND_SESSION_MESSAGE) {
-    if (!session.canReceiveMessage) {
-      return { kind: "refused", reason: "That session does not take messages right now." };
-    }
-    const text = sessionMessageText(parsed.text);
-    if (!text) {
-      return {
-        kind: "refused",
-        reason: "A message has to be shorter than a document and longer than nothing.",
-      };
-    }
-    return { kind: "message", identity, text };
-  }
-
-  if (call.name === REALTIME_TOOL.RUN_SESSION_CONTROL) {
-    const controlId = textArgument(parsed, "control_id");
-    const control = session.controls.find((candidate) => candidate.id === controlId);
-    if (!controlId || !control || !supportsSessionControl(session, controlId)) {
-      return { kind: "refused", reason: "That session advertises no such control." };
-    }
-    return { kind: "control", identity, control };
-  }
-
-  if (call.name === REALTIME_TOOL.OPEN_SESSION) {
-    // The action carries the identity, never the address: the main process
-    // reads the link back out of its own registry, the same as a pressed row.
-    if (!session.detail.link) {
-      return { kind: "refused", reason: "That session has no address to open." };
-    }
-    return { kind: "open", identity };
-  }
-
-  if (call.name === REALTIME_TOOL.ADD_WORKSPACE_AGENT) {
-    // The agent must be one this session's own roster entry listed: the list
-    // is the provider's word for what its endpoint takes, so an ask outside it
-    // is refused rather than forwarded to be refused.
-    const agent = textArgument(parsed, "agent");
-    if (!agent || !session.spawnableAgents.includes(agent)) {
-      return { kind: "refused", reason: "That session lists no such agent to add." };
-    }
-    let name: string | undefined;
-    if (parsed.name !== undefined) {
-      name = workspaceNameText(parsed.name);
-      if (!name) {
-        return {
-          kind: "refused",
-          reason: `A session name has to be under ${maximumWorkspaceNameLength} characters and longer than nothing.`,
-        };
-      }
-    }
-    let task: string | undefined;
-    if (parsed.task !== undefined) {
-      task = sessionMessageText(parsed.task);
-      if (!task) {
-        return {
-          kind: "refused",
-          reason: "A task has to be shorter than a document and longer than nothing.",
-        };
-      }
-    }
-    // A model named for this one agent resolves within the asked-for kind
-    // alone: the developer's chosen agent is never re-decided by the model
-    // they named beside it, so a mismatch is a refusal rather than a swap.
-    const spokenModel = textArgument(parsed, "model");
-    const spokenEffort = textArgument(parsed, "effort");
-    if (spokenEffort !== undefined && spokenModel === undefined) {
-      return { kind: "refused", reason: "An effort rides a model; name the model too." };
-    }
-    let selection: WorkspaceAgentSelection | undefined;
-    if (spokenModel !== undefined) {
-      const entries = agentModels(session.providerId).filter(
-        (candidate) => candidate.agent === agent,
-      );
-      const resolved = resolveWorkspaceAgentModel(entries, spokenModel, spokenEffort);
-      if ("refused" in resolved) {
-        return {
-          kind: "refused",
-          reason: resolved.refused.startsWith("No documented model")
-            ? `A ${agent} agent runs no model by that name.`
-            : resolved.refused,
-        };
-      }
-      selection = resolved.selection;
-    }
-    return {
-      kind: "add-agent",
-      identity,
-      agent,
-      ...(name ? { name } : {}),
-      ...(task ? { task } : {}),
-      ...(selection ? { model: selection.model } : {}),
-      ...(selection?.effort ? { effort: selection.effort } : {}),
-    };
-  }
-
-  return { kind: "refused", reason: "No such tool exists." };
+  return tool.validate(parsed.value, { sessions, workspaceProjects, agentModels });
 }
-
-/** What one validated issue tool call asks for, ready for the bridge that carries it. */
-export type IssueToolAction =
-  | { kind: "issue-state"; identity: IssueIdentity; transition: IssueTransition }
-  | { kind: "issue-comment"; identity: IssueIdentity; body: string }
-  | { kind: "refused"; reason: string };
 
 /**
  * Validates one issue tool call against the issues actually observed. The
@@ -678,124 +1098,13 @@ export function issueToolAction(
   call: RealtimeFunctionCall,
   issues: readonly TrackedIssue[],
 ): IssueToolAction {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(call.argumentsJson);
-  } catch {
-    return { kind: "refused", reason: "The tool call's arguments were not readable." };
+  const parsed = parseToolArguments(call);
+  if (!parsed.ok) return { kind: "refused", reason: parsed.reason };
+  const tool = REALTIME_TOOLS_BY_NAME.get(call.name);
+  if (!tool || tool.family !== REALTIME_TOOL_FAMILY.ISSUE) {
+    return { kind: "refused", reason: "No such tool exists." };
   }
-  if (!isRecord(parsed)) {
-    return { kind: "refused", reason: "The tool call's arguments were not readable." };
-  }
-
-  const trackerId = textArgument(parsed, "tracker_id");
-  const issueId = textArgument(parsed, "issue_id");
-  const issue = issues.find(
-    (candidate) => candidate.trackerId === trackerId && candidate.identifier === issueId,
-  );
-  if (!issue) {
-    return { kind: "refused", reason: "No tracked issue matches that identity." };
-  }
-  const identity: IssueIdentity = {
-    trackerId: issue.trackerId,
-    identifier: issue.identifier,
-  };
-
-  if (call.name === REALTIME_TOOL.UPDATE_ISSUE_STATE) {
-    const state = textArgument(parsed, "state");
-    // Spoken names arrive with their case retold rather than copied, so the
-    // match forgives case alone — never spelling — and only while it stays
-    // unambiguous. Two advertised states apart only in case are not a guess
-    // Luke gets to make.
-    const named = state
-      ? issue.transitions.filter(
-          (candidate) => candidate.name.toLowerCase() === state.toLowerCase(),
-        )
-      : [];
-    const transition =
-      named.find((candidate) => candidate.name === state) ??
-      (named.length === 1 ? named[0] : undefined);
-    if (!transition) {
-      return { kind: "refused", reason: "That issue lists no such state." };
-    }
-    return { kind: "issue-state", identity, transition };
-  }
-
-  if (call.name === REALTIME_TOOL.COMMENT_ON_ISSUE) {
-    if (!issue.canComment) {
-      return { kind: "refused", reason: "That issue does not take comments." };
-    }
-    const body = issueCommentText(parsed.body);
-    if (!body) {
-      return {
-        kind: "refused",
-        reason: "A comment has to be shorter than a document and longer than nothing.",
-      };
-    }
-    return { kind: "issue-comment", identity, body };
-  }
-
-  return { kind: "refused", reason: "No such tool exists." };
-}
-
-/**
- * The whole-list scope a spoken panel ask may name. The rest of the filter
- * vocabulary is not this module's to define: a location is a session's own
- * `location`, and a provider is its `provider_id`, so a spoken filter is
- * validated against the observed roster rather than against a second list.
- */
-export const SESSION_LIST_ALL = "all";
-
-/**
- * What one validated app tool call asks for, ready for the app to perform.
- * The feedback action opens the composer and nothing else: `draft` is at most
- * the developer's own words, placed only into an empty note, and what the
- * composer holds leaves only by its own Send button — no action here sends.
- */
-export type AppToolAction =
-  | { kind: "setting"; setting: AppGuideSetting; value: string }
-  | { kind: "panel"; tab: AppPanelTab; filter?: string; sort?: SessionListSort }
-  | { kind: "feedback"; composer: FeedbackComposerKind; draft?: string }
-  | { kind: "refused"; reason: string };
-
-/** Whether a tool call is about the app itself rather than about a session. */
-export function isAppToolCall(call: RealtimeFunctionCall): boolean {
-  return (
-    call.name === REALTIME_TOOL.CHANGE_APP_SETTING ||
-    call.name === REALTIME_TOOL.SHOW_PANEL ||
-    call.name === REALTIME_TOOL.OPEN_FEEDBACK_COMPOSER
-  );
-}
-
-/**
- * Validates the value a spoken change carries against the setting it names.
- * A toggle takes the guide's own two words (and their unambiguous synonyms);
- * a choice takes exactly one of the values the guide listed. Anything else is
- * refused with the accepted set, so the refusal is also the correction.
- */
-function appSettingValue(setting: AppGuideSetting, value: unknown): string | undefined {
-  if (setting.kind === APP_SETTING_KIND.TOGGLE) return appToggleValue(value);
-  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
-  return setting.choices?.find((choice) => choice.toLowerCase() === normalized);
-}
-
-/**
- * Validates a spoken session-list filter against the sessions actually being
- * observed. A filter that would show nothing is refused rather than applied:
- * the panel would quietly fall back to showing everything, and Luke would have
- * reported a narrowing that never happened.
- */
-function panelFilterAction(
-  filter: string,
-  sessions: readonly NormalizedSession[],
-): { filter: string } | { reason: string } {
-  if (filter === SESSION_LIST_ALL) return { filter };
-  if (filter === SESSION_LOCATION.LOCAL || filter === SESSION_LOCATION.CLOUD) {
-    if (sessions.some((session) => session.location === filter)) return { filter };
-    return { reason: `No ${filter} sessions are observed right now.` };
-  }
-  if (sessions.some((session) => session.providerId === filter)) return { filter };
-  return { reason: "No observed session belongs to that provider." };
+  return tool.validate(parsed.value, { issues });
 }
 
 /**
@@ -812,64 +1121,25 @@ export function appToolAction(
   guide: AppGuideSnapshot,
   sessions: readonly NormalizedSession[],
 ): AppToolAction {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(call.argumentsJson);
-  } catch {
-    return { kind: "refused", reason: "The tool call's arguments were not readable." };
+  const parsed = parseToolArguments(call);
+  if (!parsed.ok) return { kind: "refused", reason: parsed.reason };
+  const tool = REALTIME_TOOLS_BY_NAME.get(call.name);
+  if (!tool || tool.family !== REALTIME_TOOL_FAMILY.APP) {
+    return { kind: "refused", reason: "No such tool exists." };
   }
-  if (!isRecord(parsed)) {
-    return { kind: "refused", reason: "The tool call's arguments were not readable." };
-  }
+  return tool.validate(parsed.value, { guide, sessions });
+}
 
-  if (call.name === REALTIME_TOOL.CHANGE_APP_SETTING) {
-    const setting = appGuideSetting(guide, textArgument(parsed, "setting_id"));
-    if (!setting) {
-      return { kind: "refused", reason: "The app guide lists no such setting." };
-    }
-    if (!setting.adjustable) {
-      return {
-        kind: "refused",
-        reason: `${setting.label} can only be changed by hand: ${setting.manual}`,
-      };
-    }
-    const value = appSettingValue(setting, parsed.value);
-    if (value === undefined) {
-      const accepted =
-        setting.kind === APP_SETTING_KIND.TOGGLE ? "on or off" : (setting.choices ?? []).join(", ");
-      return { kind: "refused", reason: `${setting.label} takes ${accepted}.` };
-    }
-    return { kind: "setting", setting, value };
-  }
-
-  if (call.name === REALTIME_TOOL.OPEN_FEEDBACK_COMPOSER) {
-    const composer = parsed.kind;
-    if (!isFeedbackComposerKind(composer)) {
-      return { kind: "refused", reason: "The composer writes feedback or a prompt, nothing else." };
-    }
-    // The draft is the developer's ask restated, so it is bounded like a typed
-    // one; a blank draft is no draft, and the composer simply opens empty.
-    const draft = textArgument(parsed, "draft")?.slice(0, maximumFeedbackDraftLength);
-    return { kind: "feedback", composer, ...(draft ? { draft } : {}) };
-  }
-
-  if (call.name === REALTIME_TOOL.SHOW_PANEL) {
-    const tab = parsed.tab ?? APP_PANEL_TAB.SESSIONS;
-    if (!isAppPanelTab(tab)) {
-      return { kind: "refused", reason: "The panel has no such tab." };
-    }
-    const sort = textArgument(parsed, "sort");
-    if (sort !== undefined && !isSessionListSort(sort)) {
-      return { kind: "refused", reason: "The list orders by urgency or by recency." };
-    }
-    const filter = textArgument(parsed, "filter");
-    if (filter === undefined) {
-      return { kind: "panel", tab, ...(sort !== undefined ? { sort } : {}) };
-    }
-    const outcome = panelFilterAction(filter, sessions);
-    if ("reason" in outcome) return { kind: "refused", reason: outcome.reason };
-    return { kind: "panel", tab, filter: outcome.filter, ...(sort !== undefined ? { sort } : {}) };
-  }
-
-  return { kind: "refused", reason: "No such tool exists." };
+/**
+ * Picks the handler for a discriminated `kind`. The map is exhaustive over
+ * the union, so a new kind does not compile until its handler is written.
+ */
+export function dispatchByKind<
+  T extends { kind: string },
+  M extends { [K in T["kind"]]: (action: Extract<T, { kind: K }>) => unknown },
+>(action: T, handlers: M): ReturnType<M[T["kind"] & keyof M]> {
+  const handle = handlers[action.kind as T["kind"] & keyof M] as unknown as (
+    next: T,
+  ) => ReturnType<M[T["kind"] & keyof M]>;
+  return handle(action);
 }

--- a/packages/sidecar-core/tests/realtime.test.ts
+++ b/packages/sidecar-core/tests/realtime.test.ts
@@ -53,7 +53,12 @@ import {
   REALTIME_SESSION_TYPE,
   realtimeInstructions,
 } from "../src/realtime-protocol";
-import { REALTIME_TOOL } from "../src/realtime-tools";
+import {
+  REALTIME_TOOL,
+  REALTIME_TOOL_FAMILY,
+  REALTIME_TOOLS,
+  spokenRealtimeToolCount,
+} from "../src/realtime-tools";
 import { maximumSessionMessageLength } from "../src/session";
 
 const DECIDED_AT = 1_800_000_000_000;
@@ -92,6 +97,12 @@ test("the minted session closes the microphone until push-to-talk opens it", () 
   // An always-open microphone is the one thing a desk-side sidecar must not have.
   assert.equal(config.audio.input.turn_detection, null);
   assert.equal(realtimeClientSecretRequest().session.type, REALTIME_SESSION_TYPE);
+});
+
+test("the standing instructions count the tools from the table", () => {
+  const instructions = realtimeInstructions();
+  assert.equal(Object.keys(REALTIME_TOOLS).length, 10);
+  assert.match(instructions, new RegExp(`You have ${spokenRealtimeToolCount()} tools:`));
 });
 
 test("the spoken instructions state what Luke cannot see, and when he may act", () => {
@@ -1323,6 +1334,9 @@ test("the session and issue tools answer to their own validators", () => {
   assert.equal(isIssueToolName(REALTIME_TOOL.UPDATE_ISSUE_STATE), true);
   assert.equal(isIssueToolName(REALTIME_TOOL.COMMENT_ON_ISSUE), true);
   assert.equal(isIssueToolName("delete_everything"), false);
+  assert.equal(REALTIME_TOOLS.CHANGE_APP_SETTING.family, REALTIME_TOOL_FAMILY.APP);
+  assert.equal(REALTIME_TOOLS.SEND_SESSION_MESSAGE.family, REALTIME_TOOL_FAMILY.SESSION);
+  assert.equal(REALTIME_TOOLS.UPDATE_ISSUE_STATE.family, REALTIME_TOOL_FAMILY.ISSUE);
 });
 
 test("a disconnected tracker withdraws the roster without starting a reply", () => {


### PR DESCRIPTION
## Summary
- Adding a spoken tool was eight parallel sites, including a hardcoded "You have ten tools" that silently went stale.
- One table now owns name, family, schema, and renderer validation; family sets, the spoken count, and kind/family dispatches follow from it.
- Main-process validation stays its own gauntlet — the renderer still validates before a carrier runs, and main still re-checks against its registry.

## Evidence
- Platform-independent checks: `./scripts/check.sh` passed locally after rebase onto origin/main
- macOS Electron verification (`./scripts/verify.sh`): `not run` (no UI change)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31854236168/artifacts/9238533327) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31854236168)

- Commit: `4dbfae69b2cb0d1fed871e5a6de7a3beb3c8ecf7`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Test plan
- [ ] Spoken tool calls still refuse off-roster identities in the renderer before any carrier runs
- [ ] Main process still re-validates session/issue acts against its own registry (does not import renderer validators)
- [ ] Instruction prose says "You have ten tools" and stays in lockstep with the table length
- [ ] A settings/panel/feedback ask still carries through the existing app handlers

## Notes
- Blockers or follow-up verification: None

Made with [Cursor](https://cursor.com)