### PR TITLE
refactor(desktop): extract the four main-process seams that own real state

### DIFF
--- a/apps/desktop/src/dock-presence.ts
+++ b/apps/desktop/src/dock-presence.ts
@@ -1,0 +1,148 @@
+import path from "node:path";
+import { app, nativeImage, nativeTheme } from "electron";
+
+/**
+ * The Dock tile per theme: the porcelain tile for a light desktop, the
+ * space-black one for a dark. The bundle's `.icns` is cut from the dark tile
+ * and cannot follow the theme, and an unpackaged run has only Electron's stock
+ * icon, so the running app draws the Dock image itself from these.
+ */
+export const DOCK_ICON_FILES = {
+  LIGHT: "luke-icon-light.png",
+  DARK: "luke-icon-dark.png",
+} as const;
+
+/**
+ * macOS ignores a `dock.hide()` within a second of the last Dock change, so a
+ * switch pressed twice cannot be honoured call by call; the applier below
+ * paces itself to this instead, which is Electron's documented floor.
+ */
+export const DOCK_SETTLE_MS = 1100;
+
+/** Only the Dock surface this needs, so a test can supply one. */
+export interface DockTile {
+  isVisible(): boolean;
+  show(): Promise<void>;
+  hide(): void;
+  setIcon(image: Electron.NativeImage): void;
+}
+
+export interface DockTheme {
+  readonly shouldUseDarkColors: boolean;
+  on(event: "updated", listener: () => void): void;
+}
+
+export interface DockPresenceOptions {
+  /** The display whose panel held the switch is brought back forward. */
+  focusExpanded: (displayId?: number) => void;
+  /** Directory holding the two theme tiles. */
+  iconDirectory: string;
+  dock?: DockTile;
+  theme?: DockTheme;
+  loadIcon?: (file: string) => Electron.NativeImage;
+  delay?: (ms: number) => Promise<void>;
+  settleMs?: number;
+}
+
+function defaultDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Luke's Dock tile: the desired visibility, the settle loop that chases it
+ * because macOS will ignore a hide too soon after a show, and the theme-matched
+ * face redrawn after every `dock.show()` that forgets it.
+ */
+export class DockPresence {
+  readonly #focusExpanded: (displayId?: number) => void;
+  readonly #iconDirectory: string;
+  readonly #dock: DockTile | undefined;
+  readonly #theme: DockTheme;
+  readonly #loadIcon: (file: string) => Electron.NativeImage;
+  readonly #delay: (ms: number) => Promise<void>;
+  readonly #settleMs: number;
+  readonly #enforcePlatform: boolean;
+  /** The Dock state last asked for, and whether the applier is chasing it. */
+  #desired = false;
+  #settling = false;
+  /** The display whose panel asked for the last Dock change, when one did. */
+  #askedFrom: number | undefined;
+
+  constructor(options: DockPresenceOptions) {
+    this.#focusExpanded = options.focusExpanded;
+    this.#iconDirectory = options.iconDirectory;
+    this.#dock = options.dock ?? app.dock;
+    this.#theme = options.theme ?? nativeTheme;
+    this.#loadIcon =
+      options.loadIcon ??
+      ((file) => nativeImage.createFromPath(path.join(this.#iconDirectory, file)));
+    this.#delay = options.delay ?? defaultDelay;
+    this.#settleMs = options.settleMs ?? DOCK_SETTLE_MS;
+    this.#enforcePlatform = options.dock === undefined;
+  }
+
+  /**
+   * Draws Luke's own face in the Dock, matched to the theme. Called at startup,
+   * on every theme change, and after every `dock.show()` — showing the icon
+   * transforms the process, and macOS draws the fresh tile from the bundle's
+   * icon (in a dev run, Electron's stock one), forgetting any image set while
+   * there was no tile to wear it. Artwork missing from a build draws nothing,
+   * leaving the bundle icon (or the stock one) in place rather than an empty
+   * tile.
+   */
+  applyIcon(): void {
+    if (!this.#dock) return;
+    const file = this.#theme.shouldUseDarkColors ? DOCK_ICON_FILES.DARK : DOCK_ICON_FILES.LIGHT;
+    const image = this.#loadIcon(file);
+    if (!image.isEmpty()) this.#dock.setIcon(image);
+  }
+
+  /** Keeps the tile matched as the desktop changes mode. */
+  watchTheme(): void {
+    this.#theme.on("updated", () => this.applyIcon());
+  }
+
+  /**
+   * Puts Luke in the Dock or takes him back out, to match the setting. He ships
+   * as an accessory app — the notch is his fixed point — so the icon is a second
+   * door like the status item, losing nothing when it is hidden. `askedFrom` is
+   * the display whose panel held the switch, so the caret goes back where the
+   * press was made rather than to whichever panel stands first.
+   */
+  apply(show: boolean, askedFrom?: number): void {
+    if (this.#enforcePlatform && process.platform !== "darwin") return;
+    this.#desired = show;
+    this.#askedFrom = askedFrom;
+    void this.#settle();
+  }
+
+  /**
+   * Chases the desired state rather than relaying each press: a hide within a
+   * second of the last Dock change is silently ignored by macOS, so the icon is
+   * re-checked after every change and asked again until it matches — the switch
+   * and the file must not end a quick on-and-off disagreeing with the Dock.
+   */
+  async #settle(): Promise<void> {
+    if (this.#settling || !this.#dock) return;
+    this.#settling = true;
+    try {
+      while (this.#dock.isVisible() !== this.#desired) {
+        if (this.#desired) {
+          await this.#dock.show();
+          // The show rebuilt the tile from the bundle icon; put Luke's face
+          // back on it.
+          this.applyIcon();
+        } else {
+          this.#dock.hide();
+        }
+        // Either direction transforms the process type, which can deactivate
+        // the app; the panel the switch was pressed in is brought back forward
+        // rather than left to lose its caret.
+        this.#focusExpanded(this.#askedFrom);
+        await this.#delay(this.#settleMs);
+      }
+    } finally {
+      this.#settling = false;
+    }
+  }
+}

--- a/apps/desktop/src/hotkey-registrar.ts
+++ b/apps/desktop/src/hotkey-registrar.ts
@@ -1,0 +1,443 @@
+import { type BrowserWindow, globalShortcut, type WebContents } from "electron";
+import { channels, type WindowMode } from "./shared/contracts";
+import {
+  askHotkeyCandidates,
+  askHotkeyReport,
+  stopHotkeyCandidates,
+  stopHotkeyReport,
+  VOICE_HOTKEY_ABSENCE,
+  type VoiceHotkeyAbsence,
+  voiceHotkeyCandidates,
+  voiceHotkeyReport,
+} from "./shared/voice-hotkey";
+import { type TalkKeyEdges, TalkKeyWatcher } from "./talk-key";
+
+/**
+ * The three Luke keys, in the order they outrank one another. Talk takes any
+ * chord it can sit on; ask yields to talk; stop yields to both — it alone has
+ * Escape standing behind it.
+ */
+export const HOTKEY_RANK = {
+  TALK: "talk",
+  ASK: "ask",
+  STOP: "stop",
+} as const;
+
+export type HotkeyRank = (typeof HOTKEY_RANK)[keyof typeof HOTKEY_RANK];
+
+/** Only the shortcut surface this needs, so a test can supply one. */
+export interface ShortcutSurface {
+  register(accelerator: string, callback: () => void): boolean;
+  unregister(accelerator: string): void;
+  unregisterAll(): void;
+}
+
+export interface TalkKeyHandle {
+  start(candidates: readonly string[]): boolean;
+  stop(): Promise<void> | undefined;
+}
+
+/**
+ * The panel surface the keys talk to: the voice host answers a press, and
+ * every window is told which chord to teach when one of them moves.
+ */
+export interface HotkeyHost {
+  voiceHost(): BrowserWindow | undefined;
+  displayIdFor(sender: WebContents): number | undefined;
+  setMode(displayId: number, mode: WindowMode, requestFocus: boolean): void;
+  broadcast(channel: string, payload: unknown): void;
+}
+
+export interface HotkeyRegistrarOptions {
+  host: HotkeyHost;
+  /** A capture run drives the panel itself and must not grab a system key. */
+  registersGlobalKeys: boolean;
+  hasCredentials: () => boolean;
+  shortcut?: ShortcutSurface;
+  createTalkKeyWatcher?: (edges: TalkKeyEdges) => TalkKeyHandle;
+  report?: (line: string) => void;
+}
+
+/**
+ * Owns the talk, ask, and stop keys and the pecking order between them.
+ *
+ * Eight pieces of state that used to live beside each other in the main
+ * process — the registered chord, the stored choice, and the talk-key helper —
+ * are one reservation table here: `reserve` is the answer the settings
+ * handlers ask instead of re-deriving who sits on a chord, and `reapply`
+ * is the one operation that knows `unregisterAll` takes the lower keys down
+ * and puts them back in rank order.
+ */
+export class HotkeyRegistrar {
+  readonly #host: HotkeyHost;
+  readonly #registersGlobalKeys: boolean;
+  readonly #hasCredentials: () => boolean;
+  readonly #shortcut: ShortcutSurface;
+  readonly #createTalkKeyWatcher: (edges: TalkKeyEdges) => TalkKeyHandle;
+  readonly #report: (line: string) => void;
+
+  #talk: string | undefined;
+  #chosenTalk: string | undefined;
+  #talkKeyWatcher: TalkKeyHandle | undefined;
+  /**
+   * Whether the key reports being let go of. The helper does and the Electron
+   * fallback cannot, and that is the difference between holding a turn and
+   * toggling one — so the panel is told which key it actually has rather than
+   * describing the one it hoped for.
+   */
+  #held = true;
+  // Only read when no key was registered, so it starts at the case that needs no
+  // explaining beyond itself: every candidate was refused.
+  #absence: VoiceHotkeyAbsence = VOICE_HOTKEY_ABSENCE.ALREADY_OWNED;
+
+  #ask: string | undefined;
+  #chosenAsk: string | undefined;
+  #stop: string | undefined;
+  #chosenStop: string | undefined;
+
+  constructor(options: HotkeyRegistrarOptions) {
+    this.#host = options.host;
+    this.#registersGlobalKeys = options.registersGlobalKeys;
+    this.#hasCredentials = options.hasCredentials;
+    this.#shortcut = options.shortcut ?? globalShortcut;
+    this.#createTalkKeyWatcher =
+      options.createTalkKeyWatcher ?? ((edges) => new TalkKeyWatcher(edges));
+    this.#report = options.report ?? ((line) => process.stderr.write(`${line}\n`));
+  }
+
+  get talk(): string | undefined {
+    return this.#talk;
+  }
+
+  get held(): boolean {
+    return this.#held;
+  }
+
+  get ask(): string | undefined {
+    return this.#ask;
+  }
+
+  get stop(): string | undefined {
+    return this.#stop;
+  }
+
+  /** The stored choice for a rank, absent while the defaults stand. */
+  setChosen(rank: HotkeyRank, chord: string | undefined): void {
+    if (rank === HOTKEY_RANK.TALK) this.#chosenTalk = chord;
+    else if (rank === HOTKEY_RANK.ASK) this.#chosenAsk = chord;
+    else this.#chosenStop = chord;
+  }
+
+  /**
+   * Whether `chord` is spoken for by a key that outranks `forKey`. Talk's
+   * whole candidate list is reserved, not just the chord it holds now: its
+   * helper may fall back to any of them on a later launch. Ask's candidates
+   * are reserved the same way for the stop key.
+   */
+  reserve(chord: string, forKey: HotkeyRank): HotkeyRank | undefined {
+    if (forKey !== HOTKEY_RANK.TALK && this.#talkOwns(chord)) return HOTKEY_RANK.TALK;
+    if (forKey === HOTKEY_RANK.STOP && this.#askOwns(chord)) return HOTKEY_RANK.ASK;
+    return undefined;
+  }
+
+  /**
+   * Re-registers from `fromRank` down the pecking order. Talk lets everything
+   * go — `unregisterAll` takes the lower keys down with it — then ask and
+   * stop are taken afresh once it has settled. Ask lets only itself and stop
+   * go; stop lets only itself go, because nothing yields to it.
+   */
+  async reapply(fromRank: HotkeyRank): Promise<void> {
+    if (fromRank === HOTKEY_RANK.TALK) {
+      await this.#applyTalk();
+      return;
+    }
+    if (fromRank === HOTKEY_RANK.ASK) {
+      this.#applyAsk();
+      return;
+    }
+    this.#applyStop();
+  }
+
+  /**
+   * The helper is a process of Luke's own, so it does not outlive the app that
+   * spawned it and leave a key registered against nothing. Nothing succeeds it
+   * during quit, so its exit is not waited on.
+   */
+  release(): void {
+    this.#shortcut.unregisterAll();
+    void this.#talkKeyWatcher?.stop();
+    this.#talkKeyWatcher = undefined;
+  }
+
+  #talkOwns(chord: string): boolean {
+    return voiceHotkeyCandidates(this.#chosenTalk).includes(chord) || chord === this.#talk;
+  }
+
+  #askOwns(chord: string): boolean {
+    return askHotkeyCandidates(this.#chosenAsk, []).includes(chord) || chord === this.#ask;
+  }
+
+  #send(webContents: WebContents | undefined, channel: string, payload?: unknown): void {
+    if (!webContents) return;
+    if (payload === undefined) webContents.send(channel);
+    else webContents.send(channel, payload);
+  }
+
+  #voiceHostContents(): WebContents | undefined {
+    return this.#host.voiceHost()?.webContents;
+  }
+
+  /**
+   * Registers the talk key with the system so it answers from whatever app is
+   * frontmost. Electron reports only the press and never the release, so the key
+   * is a toggle rather than a hold — which is also what lets one key interrupt a
+   * reply that is already playing.
+   */
+  #registerTalk(): void {
+    if (!this.#registersGlobalKeys) {
+      this.#absence = VOICE_HOTKEY_ABSENCE.CAPTURE_RUN;
+      this.#report(voiceHotkeyReport(this.#talk, this.#absence));
+      return;
+    }
+    // Taking a system-wide key for a feature that cannot run would make every
+    // press somewhere else in macOS do nothing, visibly.
+    if (!this.#hasCredentials()) {
+      this.#absence = VOICE_HOTKEY_ABSENCE.NO_CREDENTIAL;
+      this.#report(voiceHotkeyReport(this.#talk, this.#absence));
+      return;
+    }
+    // The helper first, because it is the only one of the two that reports the
+    // key being let go of, and a key you hold is the whole point.
+    this.#talkKeyWatcher = this.#createTalkKeyWatcher({
+      onPress: () => this.#send(this.#voiceHostContents(), channels.voiceHotkeyPress),
+      onRelease: () => this.#send(this.#voiceHostContents(), channels.voiceHotkeyRelease),
+      onRegistered: (accelerator) => {
+        this.#talk = accelerator;
+        this.#report(voiceHotkeyReport(this.#talk, this.#absence));
+        this.#sendTalk();
+      },
+      onUnavailable: () => {
+        this.#talkKeyWatcher = undefined;
+        this.#registerToggle();
+        this.#report(voiceHotkeyReport(this.#talk, this.#absence));
+        this.#sendTalk();
+      },
+    });
+    if (this.#talkKeyWatcher.start(voiceHotkeyCandidates(this.#chosenTalk))) return;
+    this.#talkKeyWatcher = undefined;
+    this.#registerToggle();
+    this.#report(voiceHotkeyReport(this.#talk, this.#absence));
+  }
+
+  /**
+   * The talk key without a release: a press toggles the turn instead of holding
+   * it. This is what answers when the helper cannot — another platform, a build
+   * without it — and it is a lesser thing rather than a broken one, so it is
+   * worth standing up rather than leaving the user with no key at all.
+   */
+  #registerToggle(): void {
+    for (const accelerator of voiceHotkeyCandidates(this.#chosenTalk)) {
+      const registered = this.#shortcut.register(accelerator, () => {
+        this.#send(this.#voiceHostContents(), channels.voiceHotkeyPress);
+        // A toggle has only the one edge, so it reports a release immediately and
+        // one short enough to read as a tap. Every press then latches or ends a
+        // turn, which is the old behaviour exactly.
+        this.#send(this.#voiceHostContents(), channels.voiceHotkeyRelease);
+      });
+      if (!registered) continue;
+      this.#talk = accelerator;
+      this.#held = false;
+      return;
+    }
+    this.#absence = VOICE_HOTKEY_ABSENCE.ALREADY_OWNED;
+  }
+
+  /**
+   * Registers the key that summons the ask field from whatever app is frontmost,
+   * on the talk key's own terms: never during a capture run, and never for a
+   * conversation that cannot open — a system-wide key that answers nothing is a
+   * key taken from every other app for no reason. Electron's registration is
+   * enough here, because a summons has no release edge to hear.
+   *
+   * The press does two things in order: stands the panel up focused, then asks
+   * the renderer to put the caret in the field — or, when the caret is already
+   * there, the renderer reads the same press as the dismissal, so one key
+   * summons and puts away like every launcher does. The panel that answers is
+   * the voice host's, the same window every other app-level ask lands in.
+   */
+  #registerAsk(): void {
+    // Re-runnable: moving the talk key lets everything go and registers afresh,
+    // and a key that could not be re-taken must not still be claimed anywhere.
+    this.#ask = undefined;
+    if (!this.#registersGlobalKeys) {
+      this.#report(askHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.CAPTURE_RUN));
+      return;
+    }
+    if (!this.#hasCredentials()) {
+      this.#report(askHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.NO_CREDENTIAL));
+      return;
+    }
+    // Every chord the talk key could sit on is taken, not just the one it has
+    // announced: its helper falls back through its own candidates after this
+    // runs, so a chord it merely might take is already not the ask key's to
+    // have — the two Luke keys must never compete.
+    for (const accelerator of askHotkeyCandidates(this.#chosenAsk, [
+      ...voiceHotkeyCandidates(this.#chosenTalk),
+      this.#talk,
+    ])) {
+      const registered = this.#shortcut.register(accelerator, () => {
+        const host = this.#host.voiceHost();
+        const displayId = host ? this.#host.displayIdFor(host.webContents) : undefined;
+        if (displayId === undefined) return;
+        this.#host.setMode(displayId, "expanded", true);
+        this.#send(host?.webContents, channels.lifecycle, "ask:focus");
+      });
+      if (!registered) continue;
+      this.#ask = accelerator;
+      this.#report(askHotkeyReport(this.#ask, VOICE_HOTKEY_ABSENCE.ALREADY_OWNED));
+      return;
+    }
+    this.#report(askHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.ALREADY_OWNED));
+  }
+
+  /**
+   * Registers the key that stops a reply mid-sentence from whatever app is
+   * frontmost, on the ask key's exact terms: never during a capture run, never
+   * without a credential, and never on a chord the other two Luke keys could
+   * sit on — three keys must not compete any more than two, and the stop key
+   * is the one that yields, because it alone has Escape standing behind it.
+   * Electron's registration is enough here, because a stop has no release edge
+   * to hear. The press carries no decision of its own: the renderer's session
+   * answers whether there is a reply to stop, exactly as it answers Escape.
+   */
+  #registerStop(): void {
+    // Re-runnable on the ask key's terms: moving another key registers afresh,
+    // and a chord that could not be re-taken must not still be claimed anywhere.
+    this.#stop = undefined;
+    if (!this.#registersGlobalKeys) {
+      this.#report(stopHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.CAPTURE_RUN));
+      return;
+    }
+    if (!this.#hasCredentials()) {
+      this.#report(stopHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.NO_CREDENTIAL));
+      return;
+    }
+    // Every chord the other two keys could sit on is taken, not just the ones
+    // they have announced: the talk key's helper falls back through its own
+    // candidates on its own clock, and the ask key re-registers behind it.
+    for (const accelerator of stopHotkeyCandidates(this.#chosenStop, [
+      ...voiceHotkeyCandidates(this.#chosenTalk),
+      this.#talk,
+      ...askHotkeyCandidates(this.#chosenAsk, []),
+      this.#ask,
+    ])) {
+      const registered = this.#shortcut.register(accelerator, () => {
+        this.#send(this.#voiceHostContents(), channels.stopHotkeyPress);
+      });
+      if (!registered) continue;
+      this.#stop = accelerator;
+      this.#report(stopHotkeyReport(this.#stop, VOICE_HOTKEY_ABSENCE.ALREADY_OWNED));
+      return;
+    }
+    this.#report(stopHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.ALREADY_OWNED));
+  }
+
+  /**
+   * Tells every renderer the ask key it should be teaching, whenever that
+   * changes. The raw accelerator travels, as in bootstrap: the renderer needs
+   * both its spellings, and an absent key clears the hint rather than leaving a
+   * keycap up for a chord that answers nothing.
+   */
+  #sendAsk(): void {
+    this.#host.broadcast(channels.askHotkeyChanged, this.#ask);
+  }
+
+  /**
+   * Tells every renderer the stop key it should be describing, whenever that
+   * changes. An absence travels too, for the guide's sake: a chord that answers
+   * nothing must not be one Luke claims to have.
+   */
+  #sendStop(): void {
+    this.#host.broadcast(channels.stopHotkeyChanged, this.#stop);
+  }
+
+  /**
+   * Tells every renderer the key it should be showing, whenever that changes.
+   * The accelerator rather than its label, on the ask key's terms: the renderer
+   * draws the chord as its separate keys and says it as one word, and only the
+   * accelerator produces both.
+   */
+  #sendTalk(): void {
+    this.#host.broadcast(channels.voiceHotkeyChanged, {
+      ...(this.#talk ? { hotkey: this.#talk } : {}),
+      held: this.#held,
+    });
+  }
+
+  /**
+   * Moves the talk key to whatever the stored choice now says, while the app
+   * is running. The old key is let go of in full before the new one is asked
+   * for, so the two can never race for the same chord — and letting everything
+   * go takes the ask key down with it, because `unregisterAll` is exactly that,
+   * so the ask key is registered afresh once the talk key has settled. Letting
+   * go means waiting: the system releases the old helper's chord when its
+   * process exits, not when the kill is asked for, and the defaults sit in both
+   * helpers' candidate lists — a successor that starts too early is refused the
+   * very fallback it was promised. The panel keeps showing the old key until
+   * the new one actually answers: the helper announces its own registration
+   * over stdout, and every path without a helper is decided by the time
+   * `#registerTalk` returns.
+   */
+  async #applyTalk(): Promise<void> {
+    const released = this.#talkKeyWatcher?.stop();
+    this.#talkKeyWatcher = undefined;
+    this.#shortcut.unregisterAll();
+    await released;
+    this.#talk = undefined;
+    this.#held = true;
+    this.#absence = VOICE_HOTKEY_ABSENCE.ALREADY_OWNED;
+    this.#registerTalk();
+    if (!this.#talkKeyWatcher) this.#sendTalk();
+    // The ask key went down with `unregisterAll`, and the chord it can have may
+    // itself have changed — the talk key may have moved onto or off of one of
+    // its candidates — so it is re-taken now and the panel told what it teaches.
+    this.#registerAsk();
+    this.#sendAsk();
+    // The stop key went down with it and yields to both, so it goes last: a
+    // talk key moving onto Option-S must win the chord, and one moving off must
+    // give it back.
+    this.#registerStop();
+    this.#sendStop();
+  }
+
+  /**
+   * Moves the ask key to whatever the stored choice now says, while the app is
+   * running. Only the ask key's own chord is let go of — the talk key's
+   * registration must not flicker for a change that is none of its business —
+   * and unlike the talk key there is no helper exit to wait for: Electron
+   * releases a chord the moment it is asked to. The stop key is let go of and
+   * re-taken behind it, because the chord it may have is decided by where the
+   * ask key lands: an ask key moving onto Option-S must win it, and one moving
+   * off must give it back.
+   */
+  #applyAsk(): void {
+    if (this.#ask) this.#shortcut.unregister(this.#ask);
+    if (this.#stop) this.#shortcut.unregister(this.#stop);
+    this.#registerAsk();
+    this.#sendAsk();
+    this.#registerStop();
+    this.#sendStop();
+  }
+
+  /**
+   * Moves the stop key to whatever the stored choice now says, while the app
+   * is running. Only its own chord is let go of: the stop key is the bottom of
+   * the pecking order, so where it lands is decided by the other two keys and
+   * moving it can never oblige either of them to move.
+   */
+  #applyStop(): void {
+    if (this.#stop) this.#shortcut.unregister(this.#stop);
+    this.#registerStop();
+    this.#sendStop();
+  }
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -17,20 +17,15 @@ import {
   issueCommentText,
   isWorkspaceAgentCapableAdapter,
   isWorkspaceCapableAdapter,
-  MOTION_DURATION_MS,
-  type NativeNotchGeometry,
   type NormalizedSession,
   normalizeObservedWorkspaceProjects,
   normalizeTrackedIssue,
   type ObservedWorkspaceProject,
-  type PanelFormFactor,
   PROVIDER_ACT_RESULT_STATUS,
   type ProviderControlResult,
   type ProviderMessageResult,
   type ProviderWorkspaceResult,
-  positionNotchWindow,
   realtimeMintExplanation,
-  resolveNotchGeometry,
   SessionAttentionReviewer,
   type SessionIdentity,
   SessionNoticeTracker,
@@ -46,14 +41,11 @@ import {
 import {
   app,
   BrowserWindow,
-  type Display,
-  globalShortcut,
   type IpcMainEvent,
   type IpcMainInvokeEvent,
   ipcMain,
   Menu,
   nativeImage,
-  nativeTheme,
   powerMonitor,
   safeStorage,
   screen,
@@ -69,11 +61,11 @@ import { CopilotSessionAdapter } from "./copilot-adapter";
 import { CURSOR_PROVIDER, CursorSessionAdapter } from "./cursor-adapter";
 import { CursorLocalSessionAdapter } from "./cursor-local-adapter";
 import { DevinSessionAdapter } from "./devin-adapter";
+import { DockPresence } from "./dock-presence";
 import { feedbackDeliveryFromEnvironment } from "./feedback-delivery";
+import { HOTKEY_RANK, HotkeyRegistrar } from "./hotkey-registrar";
 import { JulesSessionAdapter } from "./jules-adapter";
 import { LinearIssueTracker } from "./linear-tracker";
-import { readMacScreenGeometry } from "./macos-screen-geometry";
-import { keepWindowStationary } from "./macos-stationary-window";
 import { MediaDuckController } from "./media-duck";
 import { openAiAttentionEvaluator } from "./openai-attention-evaluator";
 import {
@@ -83,20 +75,19 @@ import {
 } from "./openai-realtime-credentials";
 import { OpenCodeSessionAdapter } from "./opencode-adapter";
 import { OutputVolumeWatcher } from "./output-volume";
+import { PanelManager } from "./panel-manager";
+import { runModeFor } from "./run-mode";
 import { sessionNoticeSpeech } from "./session-notifications";
+import { createSettingsHandler, SettingsRefusal } from "./settings-handler";
 import { SettingsStore } from "./settings-store";
 import {
   APP_SETTING_DEFAULTS,
   type AppBootstrap,
-  type AppSettings,
   channels,
-  type DisplayDiagnostic,
   type MicrophoneStatus,
   type OutputAudioState,
   SESSION_OPEN_RESULT_STATUS,
   type SessionOpenResult,
-  type SettingsUpdateResult,
-  type WindowMode,
 } from "./shared/contracts";
 import {
   CREDENTIAL_PROVIDER_ID,
@@ -112,19 +103,8 @@ import {
   feedbackSubmission,
   isFeedbackKind,
 } from "./shared/feedback";
-import {
-  askHotkeyCandidates,
-  askHotkeyReport,
-  parseVoiceHotkey,
-  stopHotkeyCandidates,
-  stopHotkeyReport,
-  VOICE_HOTKEY_ABSENCE,
-  type VoiceHotkeyAbsence,
-  voiceHotkeyCandidates,
-  voiceHotkeyReport,
-} from "./shared/voice-hotkey";
+import { parseVoiceHotkey } from "./shared/voice-hotkey";
 import { isWorkspaceAgentSelection } from "./shared/workspace-agents";
-import { TalkKeyWatcher } from "./talk-key";
 
 const captureOutput = argumentValue("--capture-evidence");
 const profile = argumentValue("--profile") ?? "idle";
@@ -139,6 +119,7 @@ const captureMode = captureOutput !== undefined;
 // `--fixture` is enough on its own to make a run deterministic: the panel renders
 // the fixture snapshot and no provider is observed. Capture runs always imply it.
 const fixtureMode = captureMode || fixtureName !== undefined;
+const runMode = runModeFor({ capture: captureMode, fixture: fixtureName !== undefined });
 const SESSION_REFRESH_INTERVAL_MS = 5_000;
 const sessionRegistry = new InMemorySessionRegistry();
 // `directory` and the cipher are read lazily so the store can be declared before
@@ -147,7 +128,7 @@ const settingsStore = new SettingsStore({
   directory: () => app.getPath("userData"),
   // A fixture or evidence run refuses the credentials it resolves, so nothing is
   // reported as available that would not actually happen.
-  credentialsUsable: !fixtureMode,
+  credentialsUsable: runMode.observesProviders,
   cipher: {
     isAvailable: () => safeStorage.isEncryptionAvailable(),
     encrypt: (plainText) => safeStorage.encryptString(plainText),
@@ -256,6 +237,34 @@ const feedbackDelivery = feedbackDeliveryFromEnvironment();
 let outputAudio: OutputAudioState | undefined;
 let outputVolumeWatcher: OutputVolumeWatcher | undefined;
 
+function rendererUrl(): string {
+  return pathToFileURL(path.join(__dirname, "renderer", "index.html")).href;
+}
+
+const panels = new PanelManager({
+  runMode,
+  mediaDuck,
+  preloadPath: path.join(__dirname, "preload.js"),
+  rendererHtmlPath: path.join(__dirname, "renderer", "index.html"),
+  rendererUrl: rendererUrl(),
+});
+const hotkeys = new HotkeyRegistrar({
+  registersGlobalKeys: runMode.registersGlobalKeys,
+  hasCredentials: () => realtimeCredentials !== undefined,
+  host: {
+    voiceHost: () => panels.voiceHost(),
+    displayIdFor: (sender) => panels.displayIdFor(sender),
+    setMode: (displayId, mode, requestFocus) => {
+      panels.setMode(displayId, mode, requestFocus);
+    },
+    broadcast: (channel, payload) => panels.broadcast(channel, payload),
+  },
+});
+const dock = new DockPresence({
+  focusExpanded: (displayId) => panels.focusExpanded(displayId),
+  iconDirectory: path.join(__dirname, "icon"),
+});
+
 /**
  * Starts watching whether the Mac's output would let Luke be heard. Not in a
  * fixture or capture run: evidence must not read the machine it happens to
@@ -263,13 +272,11 @@ let outputVolumeWatcher: OutputVolumeWatcher | undefined;
  * profile asks the renderer for the state directly instead.
  */
 function startOutputVolumeWatch(): void {
-  if (fixtureMode) return;
+  if (!runMode.observesProviders) return;
   const send = (state: OutputAudioState | undefined) => {
     outputAudio = state;
     // Every display's panel captions the same voice, so every one is told.
-    for (const window of panelWindows.values()) {
-      window.webContents.send(channels.outputAudioChanged, state);
-    }
+    panels.broadcast(channels.outputAudioChanged, state);
   };
   outputVolumeWatcher = new OutputVolumeWatcher({
     onState: send,
@@ -278,323 +285,7 @@ function startOutputVolumeWatch(): void {
   if (!outputVolumeWatcher.start()) outputVolumeWatcher = undefined;
 }
 
-let voiceHotkey: string | undefined;
-/**
- * The chord the user chose over the defaults, if any. Read from the settings
- * file before the key is first registered, and moved by the settings panel
- * afterwards; the defaults stay behind it as fallbacks either way.
- */
-let chosenVoiceHotkey: string | undefined;
-let talkKeyWatcher: TalkKeyWatcher | undefined;
-/**
- * Whether the key reports being let go of. The helper does and the Electron
- * fallback cannot, and that is the difference between holding a turn and
- * toggling one — so the panel is told which key it actually has rather than
- * describing the one it hoped for.
- */
-let voiceHotkeyHeld = true;
-// Only read when no key was registered, so it starts at the case that needs no
-// explaining beyond itself: every candidate was refused.
-let voiceHotkeyAbsence: VoiceHotkeyAbsence = VOICE_HOTKEY_ABSENCE.ALREADY_OWNED;
-
-/**
- * Registers the talk key with the system so it answers from whatever app is
- * frontmost. Electron reports only the press and never the release, so the key
- * is a toggle rather than a hold — which is also what lets one key interrupt a
- * reply that is already playing.
- */
-function registerVoiceHotkey(): void {
-  if (captureMode) {
-    voiceHotkeyAbsence = VOICE_HOTKEY_ABSENCE.CAPTURE_RUN;
-    reportVoiceHotkey();
-    return;
-  }
-  // Taking a system-wide key for a feature that cannot run would make every
-  // press somewhere else in macOS do nothing, visibly.
-  if (!realtimeCredentials) {
-    voiceHotkeyAbsence = VOICE_HOTKEY_ABSENCE.NO_CREDENTIAL;
-    reportVoiceHotkey();
-    return;
-  }
-  // The helper first, because it is the only one of the two that reports the
-  // key being let go of, and a key you hold is the whole point.
-  talkKeyWatcher = new TalkKeyWatcher({
-    onPress: () => voiceHostWindow()?.webContents.send(channels.voiceHotkeyPress),
-    onRelease: () => voiceHostWindow()?.webContents.send(channels.voiceHotkeyRelease),
-    onRegistered: (accelerator) => {
-      voiceHotkey = accelerator;
-      reportVoiceHotkey();
-      sendVoiceHotkey();
-    },
-    onUnavailable: () => {
-      talkKeyWatcher = undefined;
-      registerToggleHotkey();
-      reportVoiceHotkey();
-      sendVoiceHotkey();
-    },
-  });
-  if (talkKeyWatcher.start(voiceHotkeyCandidates(chosenVoiceHotkey))) return;
-  talkKeyWatcher = undefined;
-  registerToggleHotkey();
-  reportVoiceHotkey();
-}
-
-/**
- * The talk key without a release: a press toggles the turn instead of holding
- * it. This is what answers when the helper cannot — another platform, a build
- * without it — and it is a lesser thing rather than a broken one, so it is
- * worth standing up rather than leaving the user with no key at all.
- */
-function registerToggleHotkey(): void {
-  for (const accelerator of voiceHotkeyCandidates(chosenVoiceHotkey)) {
-    const registered = globalShortcut.register(accelerator, () => {
-      voiceHostWindow()?.webContents.send(channels.voiceHotkeyPress);
-      // A toggle has only the one edge, so it reports a release immediately and
-      // one short enough to read as a tap. Every press then latches or ends a
-      // turn, which is the old behaviour exactly.
-      voiceHostWindow()?.webContents.send(channels.voiceHotkeyRelease);
-    });
-    if (!registered) continue;
-    voiceHotkey = accelerator;
-    voiceHotkeyHeld = false;
-    return;
-  }
-  voiceHotkeyAbsence = VOICE_HOTKEY_ABSENCE.ALREADY_OWNED;
-}
-
-let askHotkey: string | undefined;
-let chosenAskHotkey: string | undefined;
-
-/**
- * Registers the key that summons the ask field from whatever app is frontmost,
- * on the talk key's own terms: never during a capture run, and never for a
- * conversation that cannot open — a system-wide key that answers nothing is a
- * key taken from every other app for no reason. Electron's registration is
- * enough here, because a summons has no release edge to hear.
- *
- * The press does two things in order: stands the panel up focused, then asks
- * the renderer to put the caret in the field — or, when the caret is already
- * there, the renderer reads the same press as the dismissal, so one key
- * summons and puts away like every launcher does. The panel that answers is
- * the voice host's, the same window every other app-level ask lands in.
- */
-function registerAskHotkey(): void {
-  // Re-runnable: moving the talk key lets everything go and registers afresh,
-  // and a key that could not be re-taken must not still be claimed anywhere.
-  askHotkey = undefined;
-  if (captureMode) {
-    process.stderr.write(`${askHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.CAPTURE_RUN)}\n`);
-    return;
-  }
-  if (!realtimeCredentials) {
-    process.stderr.write(`${askHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.NO_CREDENTIAL)}\n`);
-    return;
-  }
-  // Every chord the talk key could sit on is taken, not just the one it has
-  // announced: its helper falls back through its own candidates after this
-  // runs, so a chord it merely might take is already not the ask key's to
-  // have — the two Luke keys must never compete.
-  for (const accelerator of askHotkeyCandidates(chosenAskHotkey, [
-    ...voiceHotkeyCandidates(chosenVoiceHotkey),
-    voiceHotkey,
-  ])) {
-    const registered = globalShortcut.register(accelerator, () => {
-      const host = voiceHostWindow();
-      const displayId = host ? displayIdFor(host.webContents) : undefined;
-      if (displayId === undefined) return;
-      setWindowMode(displayId, "expanded", true);
-      host?.webContents.send(channels.lifecycle, "ask:focus");
-    });
-    if (!registered) continue;
-    askHotkey = accelerator;
-    process.stderr.write(`${askHotkeyReport(askHotkey, VOICE_HOTKEY_ABSENCE.ALREADY_OWNED)}\n`);
-    return;
-  }
-  process.stderr.write(`${askHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.ALREADY_OWNED)}\n`);
-}
-
-/**
- * Tells every renderer the ask key it should be teaching, whenever that
- * changes. The raw accelerator travels, as in bootstrap: the renderer needs
- * both its spellings, and an absent key clears the hint rather than leaving a
- * keycap up for a chord that answers nothing.
- */
-function sendAskHotkey(): void {
-  for (const window of panelWindows.values()) {
-    window.webContents.send(channels.askHotkeyChanged, askHotkey);
-  }
-}
-
-let stopHotkey: string | undefined;
-let chosenStopHotkey: string | undefined;
-
-/**
- * Registers the key that stops a reply mid-sentence from whatever app is
- * frontmost, on the ask key's exact terms: never during a capture run, never
- * without a credential, and never on a chord the other two Luke keys could
- * sit on — three keys must not compete any more than two, and the stop key
- * is the one that yields, because it alone has Escape standing behind it.
- * Electron's registration is enough here, because a stop has no release edge
- * to hear. The press carries no decision of its own: the renderer's session
- * answers whether there is a reply to stop, exactly as it answers Escape.
- */
-function registerStopHotkey(): void {
-  // Re-runnable on the ask key's terms: moving another key registers afresh,
-  // and a chord that could not be re-taken must not still be claimed anywhere.
-  stopHotkey = undefined;
-  if (captureMode) {
-    process.stderr.write(`${stopHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.CAPTURE_RUN)}\n`);
-    return;
-  }
-  if (!realtimeCredentials) {
-    process.stderr.write(`${stopHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.NO_CREDENTIAL)}\n`);
-    return;
-  }
-  // Every chord the other two keys could sit on is taken, not just the ones
-  // they have announced: the talk key's helper falls back through its own
-  // candidates on its own clock, and the ask key re-registers behind it.
-  for (const accelerator of stopHotkeyCandidates(chosenStopHotkey, [
-    ...voiceHotkeyCandidates(chosenVoiceHotkey),
-    voiceHotkey,
-    ...askHotkeyCandidates(chosenAskHotkey, []),
-    askHotkey,
-  ])) {
-    const registered = globalShortcut.register(accelerator, () => {
-      voiceHostWindow()?.webContents.send(channels.stopHotkeyPress);
-    });
-    if (!registered) continue;
-    stopHotkey = accelerator;
-    process.stderr.write(`${stopHotkeyReport(stopHotkey, VOICE_HOTKEY_ABSENCE.ALREADY_OWNED)}\n`);
-    return;
-  }
-  process.stderr.write(`${stopHotkeyReport(undefined, VOICE_HOTKEY_ABSENCE.ALREADY_OWNED)}\n`);
-}
-
-/**
- * Tells every renderer the stop key it should be describing, whenever that
- * changes. An absence travels too, for the guide's sake: a chord that answers
- * nothing must not be one Luke claims to have.
- */
-function sendStopHotkey(): void {
-  for (const window of panelWindows.values()) {
-    window.webContents.send(channels.stopHotkeyChanged, stopHotkey);
-  }
-}
-
-/**
- * Moves the ask key to whatever `chosenAskHotkey` now says, while the app is
- * running. Only the ask key's own chord is let go of — the talk key's
- * registration must not flicker for a change that is none of its business —
- * and unlike the talk key there is no helper exit to wait for: Electron
- * releases a chord the moment it is asked to. The stop key is let go of and
- * re-taken behind it, because the chord it may have is decided by where the
- * ask key lands: an ask key moving onto Option-S must win it, and one moving
- * off must give it back.
- */
-function applyAskHotkey(): void {
-  if (askHotkey) globalShortcut.unregister(askHotkey);
-  if (stopHotkey) globalShortcut.unregister(stopHotkey);
-  registerAskHotkey();
-  sendAskHotkey();
-  registerStopHotkey();
-  sendStopHotkey();
-}
-
-/**
- * Moves the stop key to whatever `chosenStopHotkey` now says, while the app
- * is running. Only its own chord is let go of: the stop key is the bottom of
- * the pecking order, so where it lands is decided by the other two keys and
- * moving it can never oblige either of them to move.
- */
-function applyStopHotkey(): void {
-  if (stopHotkey) globalShortcut.unregister(stopHotkey);
-  registerStopHotkey();
-  sendStopHotkey();
-}
-
-/**
- * Tells every renderer the key it should be showing, whenever that changes.
- * The accelerator rather than its label, on the ask key's terms: the renderer
- * draws the chord as its separate keys and says it as one word, and only the
- * accelerator produces both.
- */
-function sendVoiceHotkey(): void {
-  for (const window of panelWindows.values()) {
-    window.webContents.send(channels.voiceHotkeyChanged, {
-      ...(voiceHotkey ? { hotkey: voiceHotkey } : {}),
-      held: voiceHotkeyHeld,
-    });
-  }
-}
-
-function reportVoiceHotkey(): void {
-  process.stderr.write(`${voiceHotkeyReport(voiceHotkey, voiceHotkeyAbsence)}\n`);
-}
-
-/**
- * Moves the talk key to whatever `chosenVoiceHotkey` now says, while the app
- * is running. The old key is let go of in full before the new one is asked
- * for, so the two can never race for the same chord — and letting everything
- * go takes the ask key down with it, because `unregisterAll` is exactly that,
- * so the ask key is registered afresh once the talk key has settled. Letting
- * go means waiting: the system releases the old helper's chord when its
- * process exits, not when the kill is asked for, and the defaults sit in both
- * helpers' candidate lists — a successor that starts too early is refused the
- * very fallback it was promised. The panel keeps showing the old key until
- * the new one actually answers: the helper announces its own registration
- * over stdout, and every path without a helper is decided by the time
- * `registerVoiceHotkey` returns.
- */
-async function applyVoiceHotkey(): Promise<void> {
-  const released = talkKeyWatcher?.stop();
-  talkKeyWatcher = undefined;
-  globalShortcut.unregisterAll();
-  await released;
-  voiceHotkey = undefined;
-  voiceHotkeyHeld = true;
-  voiceHotkeyAbsence = VOICE_HOTKEY_ABSENCE.ALREADY_OWNED;
-  registerVoiceHotkey();
-  if (!talkKeyWatcher) sendVoiceHotkey();
-  // The ask key went down with `unregisterAll`, and the chord it can have may
-  // itself have changed — the talk key may have moved onto or off of one of
-  // its candidates — so it is re-taken now and the panel told what it teaches.
-  registerAskHotkey();
-  sendAskHotkey();
-  // The stop key went down with it and yields to both, so it goes last: a
-  // talk key moving onto Option-S must win the chord, and one moving off must
-  // give it back.
-  registerStopHotkey();
-  sendStopHotkey();
-}
-
-/** The mode every window is born in; only the dev and capture flags change it. */
-const initialWindowMode: WindowMode = captureMode
-  ? process.argv.includes("--compact")
-    ? "compact"
-    : "expanded"
-  : process.argv.includes("--expanded")
-    ? "expanded"
-    : "compact";
-/**
- * One panel window per display Luke stands on, keyed by the display's id, each
- * with its own mode: a panel opened on one monitor must not resize the capsule
- * on another. The collapse timers ride the same key, because a collapse is a
- * single window's affair.
- */
-const panelWindows = new Map<number, BrowserWindow>();
-const windowModes = new Map<number, WindowMode>();
-const collapseTimers = new Map<number, NodeJS.Timeout>();
 let tray: Tray | undefined;
-/**
- * Whether Luke stands on every display, mirroring the settings file the way
- * the minter mirrors the chosen voice: read once before any panel exists,
- * updated by the same handler that stores a new choice, so every layout
- * decision stays synchronous. Off means the system's main display alone.
- */
-let showOnAllDisplays = false;
-/** The chosen form for displays without a housing, mirrored the same way. */
-let panelFormFactor: PanelFormFactor = DEFAULT_PANEL_FORM_FACTOR;
-let nativeScreens = new Map<number, NativeNotchGeometry>();
 let sessionRefreshTimer: NodeJS.Timeout | undefined;
 let sessionRefreshRunning = false;
 let attentionReviewRunning = false;
@@ -617,310 +308,12 @@ function broadcastWorkspaceProjects(): void {
   const serialized = JSON.stringify(projects);
   if (serialized === lastWorkspaceProjects) return;
   lastWorkspaceProjects = serialized;
-  for (const window of panelWindows.values()) {
-    window.webContents.send(channels.workspaceProjectsChanged, projects);
-  }
+  panels.broadcast(channels.workspaceProjectsChanged, projects);
 }
 
 function argumentValue(name: string): string | undefined {
   const index = process.argv.indexOf(name);
   return index >= 0 ? process.argv[index + 1] : undefined;
-}
-
-/**
- * Where Luke stands right now: every connected display when asked to stand on
- * all of them, the system's main display alone otherwise. A capture run stays
- * on the main display regardless, where its fixture housing is pinned.
- */
-function effectiveDisplayIds(): number[] {
-  if (!captureMode && showOnAllDisplays) {
-    return screen.getAllDisplays().map((display) => display.id);
-  }
-  return [screen.getPrimaryDisplay().id];
-}
-
-function displayById(displayId: number): Display | undefined {
-  return screen.getAllDisplays().find((display) => display.id === displayId);
-}
-
-function windowModeFor(displayId: number): WindowMode {
-  return windowModes.get(displayId) ?? initialWindowMode;
-}
-
-function layoutFor(display: Display, mode: WindowMode) {
-  return positionNotchWindow(display, mode, nativeScreens.get(display.id), panelFormFactor);
-}
-
-function displayDiagnostic(display: Display): DisplayDiagnostic {
-  return {
-    id: display.id,
-    label: display.label || `Display ${display.id}`,
-    bounds: display.bounds,
-    workArea: display.workArea,
-    scaleFactor: display.scaleFactor,
-    notch: resolveNotchGeometry(display, nativeScreens.get(display.id), panelFormFactor),
-  };
-}
-
-/**
- * The one window a spoken conversation lives in. Voice is a single thing —
- * one microphone, one reply, one face speaking — so the talk key and the
- * attention readouts go to a single renderer rather than opening one
- * conversation per display: the main display's window when Luke stands there,
- * else the first window standing anywhere.
- */
-function voiceHostWindow(): BrowserWindow | undefined {
-  const primary = panelWindows.get(screen.getPrimaryDisplay().id);
-  if (primary && !primary.isDestroyed()) return primary;
-  for (const window of panelWindows.values()) {
-    if (!window.isDestroyed()) return window;
-  }
-  return undefined;
-}
-
-/** The display a renderer message came from, so each window answers for itself. */
-function displayIdFor(sender: Electron.WebContents): number | undefined {
-  for (const [displayId, window] of panelWindows) {
-    if (!window.isDestroyed() && window.webContents === sender) return displayId;
-  }
-  return undefined;
-}
-
-function refreshNativeGeometry(): void {
-  nativeScreens = readMacScreenGeometry();
-  if (captureMode) {
-    const display = screen.getPrimaryDisplay();
-    nativeScreens.set(display.id, {
-      displayId: display.id,
-      safeAreaTop: 38,
-      notchWidth: 210,
-      hasNotch: true,
-      source: "fixture",
-    });
-  }
-}
-
-/**
- * Resizes without AppKit's frame animation. An animated setBounds re-lays out
- * the renderer at a new viewport width on every frame — and its duration scales
- * with the distance moved, so a 482px growth ran far longer than the panel's
- * own motion. The window now snaps to the size the mode needs and the renderer
- * animates the capsule into the panel inside it, where the viewport is constant
- * and the work stays on the compositor.
- */
-function positionPanel(displayId: number): void {
-  const window = panelWindows.get(displayId);
-  if (!window || window.isDestroyed()) return;
-  const display = displayById(displayId);
-  // A window whose display has gone is the reconciler's to take down, not
-  // this function's to guess a home for.
-  if (!display) return;
-  const layout = layoutFor(display, windowModeFor(displayId));
-  window.setBounds({
-    x: layout.x,
-    y: layout.y,
-    width: layout.width,
-    height: layout.height,
-  });
-  window.webContents.send(channels.displayChanged, displayDiagnostic(display));
-}
-
-function positionPanels(): void {
-  for (const displayId of panelWindows.keys()) positionPanel(displayId);
-}
-
-/**
- * Hands a fresh settings snapshot to every window but the one that asked —
- * that one already holds it in its reply, and must redraw from the reply
- * rather than race a broadcast. One window's change would otherwise leave
- * every other window's rows and guide describing a state the store no longer
- * holds. A change with no asking window — the first workspace creation saving
- * its provider as the default — names no exception and reaches them all.
- */
-function broadcastSettings(settings: AppSettings, except?: Electron.WebContents): void {
-  for (const window of panelWindows.values()) {
-    if (window.isDestroyed() || window.webContents === except) continue;
-    window.webContents.send(channels.settingsChanged, settings);
-  }
-}
-
-/**
- * Makes the windows match the chosen displays: one raised on every chosen
- * display that is connected, none anywhere else. A window whose display went
- * away is moved to a display that needs one rather than destroyed beside a
- * fresh create — a swap of the main display must carry the conversation and
- * the panel's state across, not drop them on the floor. Raising before razing
- * is load-bearing for what remains — a swap must never pass through zero
- * windows, because all windows closed is how this process decides it is done.
- * Everything that changes what the set should be lands here: a switch
- * pressed, a display plugged or unplugged, the stored choice read at launch.
- */
-function reconcilePanels(): void {
-  const wanted = effectiveDisplayIds();
-  const wantedSet = new Set(wanted);
-  const missing = wanted.filter((displayId) => !panelWindows.has(displayId));
-  const excess = [...panelWindows.keys()].filter((displayId) => !wantedSet.has(displayId));
-  // Pair each display that needs a window with a window that lost its display.
-  while (missing.length > 0 && excess.length > 0) {
-    const toDisplayId = missing.shift();
-    const fromDisplayId = excess.shift();
-    if (toDisplayId === undefined || fromDisplayId === undefined) break;
-    rebindPanel(fromDisplayId, toDisplayId);
-  }
-  for (const displayId of missing) createPanel(displayId);
-  for (const displayId of excess) {
-    const window = panelWindows.get(displayId);
-    panelWindows.delete(displayId);
-    windowModes.delete(displayId);
-    clearCollapseTimer(displayId);
-    // A window taken down takes its exchange report with it, so a host that
-    // goes mid-conversation releases the duck rather than pinning it forever.
-    voiceExchanges.delete(displayId);
-    applyVoiceExchanges();
-    window?.destroy();
-  }
-  positionPanels();
-}
-
-/**
- * Moves a living window to another display, state and all: its mode, its
- * collapse-in-flight, its exchange report, and the renderer behind it — which
- * learns its new ground from the `displayChanged` the repositioning sends,
- * exactly as it would for a geometry change in place.
- */
-function rebindPanel(fromDisplayId: number, toDisplayId: number): void {
-  const window = panelWindows.get(fromDisplayId);
-  if (!window) return;
-  panelWindows.delete(fromDisplayId);
-  panelWindows.set(toDisplayId, window);
-  windowModes.set(toDisplayId, windowModeFor(fromDisplayId));
-  windowModes.delete(fromDisplayId);
-  // The timer's closure names the old display; the reposition below redraws
-  // whatever a cancelled collapse would have.
-  clearCollapseTimer(fromDisplayId);
-  const exchange = voiceExchanges.get(fromDisplayId);
-  voiceExchanges.delete(fromDisplayId);
-  if (exchange !== undefined) voiceExchanges.set(toDisplayId, exchange);
-  applyVoiceExchanges();
-}
-
-function clearCollapseTimer(displayId: number): void {
-  const timer = collapseTimers.get(displayId);
-  if (!timer) return;
-  clearTimeout(timer);
-  collapseTimers.delete(displayId);
-}
-
-function configurePanelBehavior(window: BrowserWindow): void {
-  window.setAlwaysOnTop(true, "pop-up-menu");
-  if (process.platform === "darwin") {
-    window.setVisibleOnAllWorkspaces(true, {
-      visibleOnFullScreen: true,
-      skipTransformProcessType: true,
-    });
-    window.setHiddenInMissionControl(true);
-    window.setWindowButtonVisibility(false);
-    keepWindowStationary(window);
-  }
-}
-
-/**
- * Brings one panel forward as the key window. An accessory app has no Dock
- * presence, so the app itself has to come forward before one of its windows can
- * take keyboard focus.
- */
-function focusPanelWindow(window: BrowserWindow | undefined): void {
-  if (!window || window.isDestroyed() || captureMode) return;
-  if (process.platform === "darwin") app.focus({ steal: true });
-  window.show();
-  window.focus();
-}
-
-/**
- * The expanded panel owed the keyboard: the one that asked, when the asker is
- * known and still expanded, else whichever panel stands expanded. With two
- * panels open, focus must return to the one the user was typing in rather
- * than to whichever the map happens to list first.
- */
-function focusExpandedPanel(preferredDisplayId?: number): void {
-  if (preferredDisplayId !== undefined && windowModeFor(preferredDisplayId) === "expanded") {
-    const preferred = panelWindows.get(preferredDisplayId);
-    if (preferred && !preferred.isDestroyed()) {
-      focusPanelWindow(preferred);
-      return;
-    }
-  }
-  for (const [displayId, window] of panelWindows) {
-    if (windowModeFor(displayId) !== "expanded") continue;
-    focusPanelWindow(window);
-    return;
-  }
-}
-
-/**
- * Which windows hold a live spoken exchange, and the single answer the media
- * duck is given: live anywhere is live. Only the voice host ever actually
- * opens one, but every window reports, so the union is what keeps a
- * bystander's idle from ending the host's exchange.
- */
-const voiceExchanges = new Map<number, boolean>();
-
-function applyVoiceExchanges(): void {
-  mediaDuck.setExchangeActive([...voiceExchanges.values()].some(Boolean));
-}
-
-/**
- * `--duration-exit` plus `--duration-shape` in the shared motion tokens: the
- * content leaves, then the surface closes on the spring, and only then may the
- * window follow.
- */
-const COLLAPSE_ANIMATION_MS = MOTION_DURATION_MS.EXIT + MOTION_DURATION_MS.SHAPE;
-
-function collapseDelay(): number {
-  if (captureMode) return 0;
-  return systemPreferences.getAnimationSettings().prefersReducedMotion ? 0 : COLLAPSE_ANIMATION_MS;
-}
-
-/**
- * The two directions are sequenced differently, and the ordering lives here so
- * every caller gets it — the panel, the tray, and the motion recorder alike.
- * Growing needs the window first, or the panel has nowhere to unfold into.
- * Shrinking needs the capsule drawn first, or the window clips the panel out
- * from under its own collapse. One display's window at a time: a panel opened
- * on one monitor is no reason to resize the capsule on another.
- */
-function setWindowMode(displayId: number, mode: WindowMode, requestFocus: boolean): WindowMode {
-  windowModes.set(displayId, mode);
-  const window = panelWindows.get(displayId);
-  if (!window || window.isDestroyed()) return mode;
-
-  const expanded = mode === "expanded";
-  window.setFocusable(expanded && !captureMode);
-  clearCollapseTimer(displayId);
-  if (expanded) {
-    positionPanel(displayId);
-    window.webContents.send(channels.lifecycle, `mode:${mode}`);
-  } else {
-    window.webContents.send(channels.lifecycle, `mode:${mode}`);
-    const delay = collapseDelay();
-    if (delay === 0) positionPanel(displayId);
-    else {
-      collapseTimers.set(
-        displayId,
-        setTimeout(() => {
-          collapseTimers.delete(displayId);
-          if (windowModeFor(displayId) === "compact") positionPanel(displayId);
-        }, delay),
-      );
-    }
-  }
-
-  if (expanded && requestFocus && !captureMode) {
-    focusPanelWindow(window);
-  } else {
-    window.showInactive();
-  }
-  return mode;
 }
 
 function microphoneStatus(): MicrophoneStatus {
@@ -934,10 +327,6 @@ async function requestMicrophone(): Promise<MicrophoneStatus> {
     await systemPreferences.askForMediaAccess("microphone");
   }
   return microphoneStatus();
-}
-
-function rendererUrl(): string {
-  return pathToFileURL(path.join(__dirname, "renderer", "index.html")).href;
 }
 
 function trustedSender(event: IpcMainEvent | IpcMainInvokeEvent): boolean {
@@ -1002,7 +391,10 @@ function reportVoiceAvailability(apiKeyConfigured: boolean): void {
     );
     return;
   }
-  const report = unavailableRealtimeDiagnostics({ fixtureMode, apiKeyConfigured });
+  const report = unavailableRealtimeDiagnostics({
+    fixtureMode: !runMode.sendsNetwork,
+    apiKeyConfigured,
+  });
   process.stderr.write(
     `Luke voice: unavailable — ${realtimeMintExplanation(report.lastOutcome)}\n`,
   );
@@ -1016,16 +408,16 @@ function reportVoiceAvailability(apiKeyConfigured: boolean): void {
  * where it was pasted rather than on the next launch — and a key deleted there
  * takes voice away just as immediately, ephemeral secret included. The talk key
  * is not moved here: only a change while the app is running needs that, and
- * `applyVoiceHotkey` is what does it.
+ * `hotkeys.reapply` is what does it.
  */
 async function applyVoiceCredential(): Promise<void> {
   // A fixture run does not ask for the key at all: reading a stored one means a
   // Keychain decrypt, which a run that would refuse to use it has no business
   // asking for. That is also why the report says no key resolved — for this run,
   // none did.
-  const apiKey = fixtureMode
-    ? undefined
-    : await settingsStore.readApiKey(VOICE_CREDENTIAL_PROVIDER_ID);
+  const apiKey = runMode.sendsNetwork
+    ? await settingsStore.readApiKey(VOICE_CREDENTIAL_PROVIDER_ID)
+    : undefined;
   const evaluator = openAiAttentionEvaluator(apiKey);
   attentionReviewer = evaluator
     ? new SessionAttentionReviewer({
@@ -1050,65 +442,6 @@ async function applyVoiceCredential(): Promise<void> {
 }
 
 /**
- * A validate step that answers with words instead of a value. The refusal is
- * its own type so the factory can tell it from anything a setting might one
- * day validate to — a shape sniffed for a `settings` key would turn such a
- * value into a silent no-op the day the two collide.
- */
-class SettingsRefusal {
-  constructor(readonly result: SettingsUpdateResult) {}
-}
-
-/**
- * One write path for every settings change the renderer can ask for. Trust,
- * catch, snapshot, and broadcast are identical on every channel — only what
- * is valid, what is stored, and what the write sets in motion differ. A
- * malformed request still throws: that is a broken caller, not a choice the
- * user can correct.
- */
-function registerSettingHandler<Value>(
-  channel: string,
-  {
-    validate,
-    save,
-    apply,
-    refusal,
-  }: {
-    validate: (...args: unknown[]) => Value | SettingsRefusal | Promise<Value | SettingsRefusal>;
-    save: (value: Value) => Promise<SettingsUpdateResult>;
-    apply?: (
-      result: SettingsUpdateResult,
-      value: Value,
-      event: IpcMainInvokeEvent,
-    ) => void | Promise<void>;
-    refusal: string;
-  },
-): void {
-  ipcMain.handle(channel, async (event, ...args: unknown[]): Promise<SettingsUpdateResult> => {
-    if (!trustedSender(event)) throw new Error("Untrusted renderer");
-    const value = await validate(...args);
-    // A validate step that already answered — a chord spoken for, refused with
-    // words — leaves without a write, a side effect, or a broadcast.
-    if (value instanceof SettingsRefusal) {
-      return value.result;
-    }
-    try {
-      const result = await save(value);
-      await apply?.(result, value, event);
-      broadcastSettings(result.settings, event.sender);
-      return result;
-    } catch {
-      // A filesystem failure is not something the user can act on, so it is
-      // reported as one line rather than as a raw system error.
-      return {
-        settings: await settingsStore.snapshot(),
-        reason: refusal,
-      };
-    }
-  });
-}
-
-/**
  * The renderer records chords through the same reader, so one that does
  * not parse is a malformed request rather than a choice to answer.
  */
@@ -1123,16 +456,76 @@ function parsedVoiceHotkey(accelerator: unknown): string | undefined {
   return chosen;
 }
 
+function adapterFor(providerId: string) {
+  return sessionAdapters.find((candidate) => candidate.provider.id === providerId);
+}
+
+/**
+ * A renderer-supplied string that must survive its bound, or be refused.
+ * Omitted stays omitted: the field was not offered.
+ */
+function boundedField(
+  raw: unknown,
+  bound: (value: unknown) => string | undefined,
+): { ok: true; value: string | undefined } | { ok: false } {
+  if (raw === undefined) return { ok: true, value: undefined };
+  const value = bound(raw);
+  return value === undefined ? { ok: false } : { ok: true, value };
+}
+
+/**
+ * The first workspace that lands chooses the default provider — and a model
+ * named for that creation, the default agent — only while nothing is chosen.
+ * A default the user holds is theirs to change, never a creation's. Losing
+ * the save loses only the remembered default, never the workspace that just
+ * landed.
+ */
+async function rememberWorkspaceDefaults(
+  adapter: SessionProviderAdapter,
+  namedSelection: WorkspaceAgentSelection | undefined,
+): Promise<void> {
+  if (!isProviderId(adapter.provider.id)) return;
+  const providerId = adapter.provider.id;
+  try {
+    if ((await settingsStore.readDefaultWorkspaceProvider()) === undefined) {
+      const saved = await settingsStore.setDefaultWorkspaceProvider(providerId);
+      panels.broadcast(channels.settingsChanged, saved.settings);
+    }
+    // A model named for this creation becomes the default on the same
+    // first-choice terms as the provider: only while nothing is chosen.
+    // A default already held is the user's, changed by asking for the
+    // setting itself — never as a side effect of one creation. Read
+    // again here rather than trusting the pre-creation snapshot: a
+    // choice made by hand while the provider was answering is already
+    // held, and must not lose to the request it overlapped.
+    if (
+      namedSelection !== undefined &&
+      (await settingsStore.readWorkspaceAgentDefault(providerId)) === undefined
+    ) {
+      const saved = await settingsStore.setWorkspaceAgentDefault(providerId, namedSelection);
+      panels.broadcast(channels.settingsChanged, saved.settings);
+    }
+  } catch {
+    // The reply is the creation's; a failed remember has no line in it.
+  }
+}
+
 function registerIpc(): void {
+  const registerSettingHandler = createSettingsHandler({
+    trustedSender,
+    snapshot: () => settingsStore.snapshot(),
+    broadcast: (settings, except) => panels.broadcast(channels.settingsChanged, settings, except),
+  });
   ipcMain.handle(channels.bootstrap, async (event): Promise<AppBootstrap> => {
     if (!trustedSender(event)) throw new Error("Untrusted renderer");
     // Each window bootstraps as itself: its own display, its own mode. The
     // roster and the settings are the same everywhere.
-    const displayId = displayIdFor(event.sender) ?? effectiveDisplayIds()[0];
+    const displayId = panels.displayIdFor(event.sender);
     const display =
-      (displayId !== undefined ? displayById(displayId) : undefined) ?? screen.getPrimaryDisplay();
+      (displayId !== undefined ? panels.display(displayId) : undefined) ??
+      screen.getPrimaryDisplay();
     return {
-      mode: displayId !== undefined ? windowModeFor(displayId) : initialWindowMode,
+      mode: displayId !== undefined ? panels.modeFor(displayId) : panels.initialMode,
       startPeeked,
       startInSlot,
       profile,
@@ -1148,15 +541,15 @@ function registerIpc(): void {
       // Both keys travel as accelerators rather than labels: the renderer needs
       // both spellings — the keycaps' ⌥ and L drawn apart, and aria's Alt+L —
       // and only the accelerator can produce the pair.
-      ...(voiceHotkey ? { voiceHotkey } : {}),
-      voiceHotkeyHeld,
-      ...(askHotkey ? { askHotkey } : {}),
-      ...(stopHotkey ? { stopHotkey } : {}),
+      ...(hotkeys.talk ? { voiceHotkey: hotkeys.talk } : {}),
+      voiceHotkeyHeld: hotkeys.held,
+      ...(hotkeys.ask ? { askHotkey: hotkeys.ask } : {}),
+      ...(hotkeys.stop ? { stopHotkey: hotkeys.stop } : {}),
       ...(outputAudio ? { outputAudio } : {}),
-      display: displayDiagnostic(display),
-      sessions: fixtureMode ? [] : sessionRegistry.snapshot().sessions,
+      display: panels.diagnostic(display),
+      sessions: runMode.observesProviders ? sessionRegistry.snapshot().sessions : [],
       workspaceProjects: observedWorkspaceProjects(),
-      ...(trackedIssues && !fixtureMode ? { issues: trackedIssues } : {}),
+      ...(trackedIssues && runMode.observesProviders ? { issues: trackedIssues } : {}),
       settings: await settingsStore.snapshot(),
     };
   });
@@ -1167,14 +560,14 @@ function registerIpc(): void {
     }
     // The ask is the sender's own window's: expanding a panel on one display
     // must not unfold one on every other.
-    const displayId = displayIdFor(event.sender);
+    const displayId = panels.displayIdFor(event.sender);
     if (displayId === undefined) throw new Error("Invalid window mode request");
-    return setWindowMode(displayId, expanded ? "expanded" : "compact", focus === true);
+    return panels.setMode(displayId, expanded ? "expanded" : "compact", focus === true);
   });
 
   // The tray items' feedback gesture, asked for from a renderer — the spoken
   // open rides this so the ordering stays owned here for every caller: the
-  // mode event setWindowMode sends and the composer event that follows travel
+  // mode event the panel manager sends and the composer event that follows travel
   // the same lifecycle channel, so the shape that wins is always the
   // composer, never a panel racing it in from another channel. Opening is all
   // this does; a note still arrives only through channels.sendFeedback, from
@@ -1183,9 +576,9 @@ function registerIpc(): void {
     if (!trustedSender(event) || !isFeedbackKind(kind)) {
       throw new Error("Invalid composer request");
     }
-    const displayId = displayIdFor(event.sender);
+    const displayId = panels.displayIdFor(event.sender);
     if (displayId === undefined) throw new Error("Invalid composer request");
-    setWindowMode(displayId, "expanded", true);
+    panels.setMode(displayId, "expanded", true);
     event.sender.send(channels.lifecycle, FEEDBACK_LIFECYCLE_EVENT[kind]);
   });
 
@@ -1235,7 +628,7 @@ function registerIpc(): void {
       // because a press right after the save has to find a minter.
       if (!result.reason && providerId === VOICE_CREDENTIAL_PROVIDER_ID) {
         await applyVoiceCredential();
-        await applyVoiceHotkey();
+        await hotkeys.reapply(HOTKEY_RANK.TALK);
       }
     },
     refusal: "Could not save that API key on this system.",
@@ -1263,7 +656,7 @@ function registerIpc(): void {
     },
     save: (show) => settingsStore.setShowInDock(show),
     apply: (result, _show, event) =>
-      applyDockVisibility(result.settings.showInDock, displayIdFor(event.sender)),
+      dock.apply(result.settings.showInDock, panels.displayIdFor(event.sender)),
     refusal: "Could not save that setting on this system.",
   });
 
@@ -1277,8 +670,8 @@ function registerIpc(): void {
     },
     save: (show) => settingsStore.setShowOnAllDisplays(show),
     apply(result) {
-      showOnAllDisplays = result.settings.showOnAllDisplays;
-      reconcilePanels();
+      panels.setShowOnAllDisplays(result.settings.showOnAllDisplays);
+      panels.reconcile();
     },
     refusal: "Could not save that setting on this system.",
   });
@@ -1292,8 +685,8 @@ function registerIpc(): void {
     },
     save: (formFactor) => settingsStore.setFormFactor(formFactor),
     apply(result) {
-      panelFormFactor = result.settings.formFactor;
-      positionPanels();
+      panels.setFormFactor(result.settings.formFactor);
+      panels.positionAll();
     },
     refusal: "Could not save that setting on this system.",
   });
@@ -1391,10 +784,10 @@ function registerIpc(): void {
     save: (chosen) => settingsStore.setVoiceHotkey(chosen),
     async apply(result, chosen) {
       if (!result.reason) {
-        chosenVoiceHotkey = chosen;
+        hotkeys.setChosen(HOTKEY_RANK.TALK, chosen);
         // Awaited so the renderer's controls stay at rest until the swap has
         // finished and the helper's own registration line can say the truth.
-        await applyVoiceHotkey();
+        await hotkeys.reapply(HOTKEY_RANK.TALK);
       }
     },
     refusal: "Could not save that shortcut on this system.",
@@ -1411,10 +804,7 @@ function registerIpc(): void {
       // The talk key's whole candidate list is refused, not just the chord it
       // holds now: its helper may fall back to any of them on a later launch,
       // and an ask key stored on one would race it there.
-      if (
-        chosen &&
-        (voiceHotkeyCandidates(chosenVoiceHotkey).includes(chosen) || chosen === voiceHotkey)
-      ) {
+      if (chosen && hotkeys.reserve(chosen, HOTKEY_RANK.ASK) === HOTKEY_RANK.TALK) {
         return new SettingsRefusal({
           settings: await settingsStore.snapshot(),
           reason: "That chord is reserved for the talk key.",
@@ -1425,8 +815,8 @@ function registerIpc(): void {
     save: (chosen) => settingsStore.setAskHotkey(chosen),
     apply(result, chosen) {
       if (!result.reason) {
-        chosenAskHotkey = chosen;
-        applyAskHotkey();
+        hotkeys.setChosen(HOTKEY_RANK.ASK, chosen);
+        void hotkeys.reapply(HOTKEY_RANK.ASK);
       }
     },
     refusal: "Could not save that shortcut on this system.",
@@ -1440,19 +830,14 @@ function registerIpc(): void {
   registerSettingHandler<string | undefined>(channels.setStopHotkey, {
     async validate(accelerator: unknown) {
       const chosen = parsedVoiceHotkey(accelerator);
-      if (
-        chosen &&
-        (voiceHotkeyCandidates(chosenVoiceHotkey).includes(chosen) || chosen === voiceHotkey)
-      ) {
+      const owner = chosen ? hotkeys.reserve(chosen, HOTKEY_RANK.STOP) : undefined;
+      if (owner === HOTKEY_RANK.TALK) {
         return new SettingsRefusal({
           settings: await settingsStore.snapshot(),
           reason: "That chord is reserved for the talk key.",
         });
       }
-      if (
-        chosen &&
-        (askHotkeyCandidates(chosenAskHotkey, []).includes(chosen) || chosen === askHotkey)
-      ) {
+      if (owner === HOTKEY_RANK.ASK) {
         return new SettingsRefusal({
           settings: await settingsStore.snapshot(),
           reason: "That chord is reserved for the ask key.",
@@ -1463,8 +848,8 @@ function registerIpc(): void {
     save: (chosen) => settingsStore.setStopHotkey(chosen),
     apply(result, chosen) {
       if (!result.reason) {
-        chosenStopHotkey = chosen;
-        applyStopHotkey();
+        hotkeys.setChosen(HOTKEY_RANK.STOP, chosen);
+        void hotkeys.reapply(HOTKEY_RANK.STOP);
       }
     },
     refusal: "Could not save that shortcut on this system.",
@@ -1504,10 +889,9 @@ function registerIpc(): void {
   // the speaking window opened, so the duck follows the union of them all.
   ipcMain.on(channels.setVoiceExchange, (event, active: unknown) => {
     if (!trustedSender(event) || typeof active !== "boolean") return;
-    const displayId = displayIdFor(event.sender);
+    const displayId = panels.displayIdFor(event.sender);
     if (displayId === undefined) return;
-    voiceExchanges.set(displayId, active);
-    applyVoiceExchanges();
+    panels.setVoiceExchange(displayId, active);
   });
 
   // The system's own answer is the user's to change, and this is where macOS
@@ -1573,8 +957,8 @@ function registerIpc(): void {
     async (event, identity: unknown, text: unknown): Promise<ProviderMessageResult> => {
       if (!trustedSender(event)) throw new Error("Untrusted renderer");
       if (!isSessionIdentity(identity)) throw new Error("Invalid session message request");
-      const messageText = sessionMessageText(text);
-      if (!messageText) {
+      const message = boundedField(text, sessionMessageText);
+      if (!message.ok || message.value === undefined) {
         return {
           status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
           reason: "A message has to be shorter than a document and longer than nothing.",
@@ -1586,15 +970,13 @@ function registerIpc(): void {
       if (!session?.canReceiveMessage) {
         return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
       }
-      const adapter = sessionAdapters.find(
-        (candidate) => candidate.provider.id === identity.providerId,
-      );
+      const adapter = adapterFor(identity.providerId);
       if (!adapter || !isMessageCapableAdapter(adapter)) {
         return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
       }
       const result = await adapter.sendMessage({
         providerSessionId: identity.providerSessionId,
-        text: messageText,
+        text: message.value,
       });
       // A message that landed changes what the session is doing, so the row
       // should catch up as soon as its provider will say.
@@ -1619,9 +1001,7 @@ function registerIpc(): void {
       const session = sessionRegistry.get(identity);
       const control = session?.controls.find((candidate) => candidate.id === controlId);
       if (!control) return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
-      const adapter = sessionAdapters.find(
-        (candidate) => candidate.provider.id === identity.providerId,
-      );
+      const adapter = adapterFor(identity.providerId);
       if (!adapter || !isControllableAdapter(adapter)) {
         return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
       }
@@ -1668,8 +1048,8 @@ function registerIpc(): void {
       if (namedSelection !== undefined && !isWorkspaceAgentSelection(providerId, namedSelection)) {
         throw new Error("Invalid workspace creation request");
       }
-      if (fixtureMode) return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
-      const adapter = sessionAdapters.find((candidate) => candidate.provider.id === providerId);
+      if (!runMode.sendsNetwork) return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
+      const adapter = adapterFor(providerId);
       if (!adapter || !isWorkspaceCapableAdapter(adapter)) {
         return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
       }
@@ -1677,8 +1057,8 @@ function registerIpc(): void {
         .workspaceProjects()
         .some((project) => project.providerProjectId === providerProjectId);
       if (!offered) return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
-      const workspaceName = name === undefined ? undefined : workspaceNameText(name);
-      if (name !== undefined && workspaceName === undefined) {
+      const workspaceName = boundedField(name, workspaceNameText);
+      if (!workspaceName.ok) {
         return {
           status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
           reason: "A workspace name has to be short enough to say and longer than nothing.",
@@ -1686,8 +1066,8 @@ function registerIpc(): void {
       }
       // The task's own bound, and its fit to the project, are answered by the
       // adapter, which validates both against the projects it actually offers.
-      const openingTask = task === undefined ? undefined : sessionMessageText(task);
-      if (task !== undefined && openingTask === undefined) {
+      const openingTask = boundedField(task, sessionMessageText);
+      if (!openingTask.ok) {
         return {
           status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
           reason: "A task has to be shorter than a document and longer than nothing.",
@@ -1704,8 +1084,8 @@ function registerIpc(): void {
       const agentSelection = namedSelection ?? stored;
       const result = await adapter.createWorkspace({
         providerProjectId,
-        ...(workspaceName ? { name: workspaceName } : {}),
-        ...(openingTask ? { task: openingTask } : {}),
+        ...(workspaceName.value ? { name: workspaceName.value } : {}),
+        ...(openingTask.value ? { task: openingTask.value } : {}),
         ...(agentSelection ? { agentSelection } : {}),
       });
       // A workspace that landed is a session the panel should be showing, so
@@ -1722,35 +1102,11 @@ function registerIpc(): void {
       // never a creation's. Deterministic on the validated act — nothing a
       // model composed decides this — and losing the save loses only the
       // remembered default, never the workspace that just landed.
-      if (
-        result.status === PROVIDER_ACT_RESULT_STATUS.ACCEPTED &&
-        isProviderId(adapter.provider.id)
-      ) {
-        try {
-          if ((await settingsStore.readDefaultWorkspaceProvider()) === undefined) {
-            const saved = await settingsStore.setDefaultWorkspaceProvider(adapter.provider.id);
-            broadcastSettings(saved.settings);
-          }
-          // A model named for this creation becomes the default on the same
-          // first-choice terms as the provider: only while nothing is chosen.
-          // A default already held is the user's, changed by asking for the
-          // setting itself — never as a side effect of one creation. Read
-          // again here rather than trusting the pre-creation snapshot: a
-          // choice made by hand while the provider was answering is already
-          // held, and must not lose to the request it overlapped.
-          if (
-            namedSelection !== undefined &&
-            (await settingsStore.readWorkspaceAgentDefault(adapter.provider.id)) === undefined
-          ) {
-            const saved = await settingsStore.setWorkspaceAgentDefault(
-              adapter.provider.id,
-              namedSelection,
-            );
-            broadcastSettings(saved.settings);
-          }
-        } catch {
-          // The reply is the creation's; a failed remember has no line in it.
-        }
+      if (result.status === PROVIDER_ACT_RESULT_STATUS.ACCEPTED) {
+        void rememberWorkspaceDefaults(
+          adapter,
+          namedSelection as WorkspaceAgentSelection | undefined,
+        );
       }
       return result;
     },
@@ -1791,8 +1147,8 @@ function registerIpc(): void {
         });
       } else {
         if (!issue.canComment) return { status: TRACKER_ACTION_RESULT_STATUS.UNSUPPORTED };
-        const body = issueCommentText(action.body);
-        if (!body) {
+        const body = boundedField(action.body, issueCommentText);
+        if (!body.ok || body.value === undefined) {
           return {
             status: TRACKER_ACTION_RESULT_STATUS.REJECTED,
             reason: "A comment has to be shorter than a document and longer than nothing.",
@@ -1801,7 +1157,7 @@ function registerIpc(): void {
         result = await tracker.execute({
           kind: ISSUE_ACTION_KIND.COMMENT,
           trackerIssueId: issue.trackerIssueId,
-          body,
+          body: body.value,
         });
       }
       // An act that landed changes the board, so the roster should catch up
@@ -1858,21 +1214,19 @@ function registerIpc(): void {
       ) {
         throw new Error("Invalid workspace agent request");
       }
-      const adapter = sessionAdapters.find(
-        (candidate) => candidate.provider.id === identity.providerId,
-      );
+      const adapter = adapterFor(identity.providerId);
       if (!adapter || !isWorkspaceAgentCapableAdapter(adapter)) {
         return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
       }
-      const sessionName = name === undefined ? undefined : workspaceNameText(name);
-      if (name !== undefined && sessionName === undefined) {
+      const sessionName = boundedField(name, workspaceNameText);
+      if (!sessionName.ok) {
         return {
           status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
           reason: "A session name has to be short enough to say and longer than nothing.",
         };
       }
-      const openingTask = task === undefined ? undefined : sessionMessageText(task);
-      if (task !== undefined && openingTask === undefined) {
+      const openingTask = boundedField(task, sessionMessageText);
+      if (!openingTask.ok) {
         return {
           status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
           reason: "A task has to be shorter than a document and longer than nothing.",
@@ -1893,8 +1247,8 @@ function registerIpc(): void {
       const result = await adapter.spawnWorkspaceAgent({
         providerSessionId: identity.providerSessionId,
         agent: advertised,
-        ...(sessionName ? { name: sessionName } : {}),
-        ...(openingTask ? { task: openingTask } : {}),
+        ...(sessionName.value ? { name: sessionName.value } : {}),
+        ...(openingTask.value ? { task: openingTask.value } : {}),
         ...(model ? { model } : {}),
         ...(effort ? { effort } : {}),
       });
@@ -1922,7 +1276,7 @@ function registerIpc(): void {
       if (!parsed) throw new Error("Invalid feedback submission");
       // A fixture run must be reproducible without a network, so it refuses
       // rather than sending — and says so, because the composer still draws.
-      if (fixtureMode) {
+      if (!runMode.sendsNetwork) {
         return { delivered: false, reason: "A fixture run sends nothing." };
       }
       return feedbackDelivery.deliver(parsed);
@@ -1934,9 +1288,9 @@ function registerIpc(): void {
   // for its own window, which is the one holding the field.
   ipcMain.on(channels.focusPanel, (event) => {
     if (!trustedSender(event)) return;
-    const displayId = displayIdFor(event.sender);
-    if (displayId === undefined || windowModeFor(displayId) !== "expanded") return;
-    focusPanelWindow(panelWindows.get(displayId));
+    const displayId = panels.displayIdFor(event.sender);
+    if (displayId === undefined) return;
+    panels.focusIfExpanded(displayId);
   });
 
   ipcMain.handle(channels.requestRealtimeCredential, async (event) => {
@@ -1975,7 +1329,7 @@ function registerIpc(): void {
  * fixture run offers nothing, for the same reason it observes nothing.
  */
 function observedWorkspaceProjects(): readonly ObservedWorkspaceProject[] {
-  if (fixtureMode) return [];
+  if (!runMode.observesProviders) return [];
   return normalizeObservedWorkspaceProjects(
     sessionAdapters.flatMap((adapter) =>
       isWorkspaceCapableAdapter(adapter)
@@ -1990,7 +1344,7 @@ function observedWorkspaceProjects(): readonly ObservedWorkspaceProject[] {
 }
 
 async function refreshProviderSessions(): Promise<void> {
-  if (fixtureMode || sessionRefreshRunning) return;
+  if (!runMode.observesProviders || sessionRefreshRunning) return;
   sessionRefreshRunning = true;
   try {
     // Providers are observed concurrently and reported independently: the
@@ -2032,7 +1386,7 @@ async function reviewSessionAttention(): Promise<void> {
     if (speech.length > 0) {
       // Spoken once, by the one window that holds the voice: every display
       // already shows the same session as needing attention.
-      voiceHostWindow()?.webContents.send(channels.attentionSpeech, speech);
+      panels.voiceHost()?.webContents.send(channels.attentionSpeech, speech);
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -2062,15 +1416,13 @@ function announceSessionNotices(sessions: readonly NormalizedSession[]): void {
   // renderer cannot open a call, and the panel still shows every state.
   if (!realtimeCredentials) return;
   const speech = notices.map((notice) => sessionNoticeSpeech(notice, now));
-  voiceHostWindow()?.webContents.send(channels.attentionSpeech, speech);
+  panels.voiceHost()?.webContents.send(channels.attentionSpeech, speech);
 }
 
 function startSessionObservation(): void {
-  if (fixtureMode) return;
+  if (!runMode.observesProviders) return;
   sessionRegistry.subscribe((snapshot) => {
-    for (const window of panelWindows.values()) {
-      window.webContents.send(channels.sessionsChanged, snapshot.sessions);
-    }
+    panels.broadcast(channels.sessionsChanged, snapshot.sessions);
     // The registry only speaks on an effective change, which is exactly when
     // a status edge can exist to announce.
     announceSessionNotices(snapshot.sessions);
@@ -2092,7 +1444,7 @@ function startSessionObservation(): void {
  * which is how the renderer knows there is nothing to advertise.
  */
 async function refreshTrackedIssues(): Promise<void> {
-  if (fixtureMode) return;
+  if (!runMode.observesProviders) return;
   if (issueRefreshRunning) {
     issueRefreshQueued = true;
     return;
@@ -2111,9 +1463,7 @@ async function refreshTrackedIssues(): Promise<void> {
       }
     }
     trackedIssues = connected ? collected : undefined;
-    for (const window of panelWindows.values()) {
-      window.webContents.send(channels.issuesChanged, trackedIssues);
-    }
+    panels.broadcast(channels.issuesChanged, trackedIssues);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     process.stderr.write(`Issue observation failed: ${message}\n`);
@@ -2127,7 +1477,7 @@ async function refreshTrackedIssues(): Promise<void> {
 }
 
 function startIssueObservation(): void {
-  if (fixtureMode) return;
+  if (!runMode.observesProviders) return;
   void refreshTrackedIssues();
   issueRefreshTimer = setInterval(() => {
     void refreshTrackedIssues();
@@ -2135,19 +1485,11 @@ function startIssueObservation(): void {
   issueRefreshTimer.unref();
 }
 
-/** Whether some panel window's renderer is asking, whichever display it is on. */
-function isPanelWebContents(webContents: Electron.WebContents): boolean {
-  for (const window of panelWindows.values()) {
-    if (!window.isDestroyed() && window.webContents === webContents) return true;
-  }
-  return false;
-}
-
 function configurePermissions(): void {
   session.defaultSession.setPermissionCheckHandler(
     (webContents, permission, _origin, details) =>
       webContents !== null &&
-      isPanelWebContents(webContents) &&
+      panels.owns(webContents) &&
       permission === "media" &&
       details.mediaType === "audio",
   );
@@ -2155,79 +1497,13 @@ function configurePermissions(): void {
     (webContents, permission, callback, details) => {
       const mediaTypes = "mediaTypes" in details ? (details.mediaTypes ?? []) : [];
       callback(
-        isPanelWebContents(webContents) &&
+        panels.owns(webContents) &&
           permission === "media" &&
           mediaTypes.length > 0 &&
           mediaTypes.every((mediaType: string) => mediaType === "audio"),
       );
     },
   );
-}
-
-function createPanel(displayId: number): void {
-  const display = displayById(displayId);
-  if (!display) return;
-  windowModes.set(displayId, initialWindowMode);
-  const layout = layoutFor(display, initialWindowMode);
-
-  const window = new BrowserWindow({
-    x: layout.x,
-    y: layout.y,
-    width: layout.width,
-    height: layout.height,
-    title: "Luke",
-    show: false,
-    frame: false,
-    transparent: true,
-    backgroundColor: "#00000000",
-    hasShadow: false,
-    roundedCorners: false,
-    resizable: false,
-    movable: false,
-    minimizable: false,
-    maximizable: false,
-    fullscreenable: false,
-    skipTaskbar: true,
-    alwaysOnTop: true,
-    focusable: initialWindowMode === "expanded" && !captureMode,
-    acceptFirstMouse: true,
-    type: process.platform === "darwin" ? "panel" : undefined,
-    webPreferences: {
-      preload: path.join(__dirname, "preload.js"),
-      contextIsolation: true,
-      nodeIntegration: false,
-      sandbox: true,
-      webSecurity: true,
-      devTools: !captureMode,
-      backgroundThrottling: false,
-    },
-  });
-  panelWindows.set(displayId, window);
-
-  configurePanelBehavior(window);
-  window.setIgnoreMouseEvents(true, { forward: true });
-  window.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
-  window.webContents.on("will-navigate", (event, url) => {
-    if (url !== rendererUrl()) event.preventDefault();
-  });
-  window.once("ready-to-show", () => {
-    if (!captureMode && !window.isDestroyed()) window.showInactive();
-  });
-  // The reconciler deletes before it destroys, so this answers only a window
-  // that went down some other way — and it must not leave a ghost in the map,
-  // nor a phantom exchange holding the duck down. Found by the window rather
-  // than the id it was born under, because a rebind may have moved it.
-  window.on("closed", () => {
-    for (const [id, candidate] of [...panelWindows]) {
-      if (candidate !== window) continue;
-      panelWindows.delete(id);
-      windowModes.delete(id);
-      clearCollapseTimer(id);
-      voiceExchanges.delete(id);
-      applyVoiceExchanges();
-    }
-  });
-  void window.loadFile(path.join(__dirname, "renderer", "index.html"));
 }
 
 function trayMenu(): Electron.Menu {
@@ -2249,10 +1525,10 @@ function trayMenu(): Electron.Menu {
         // The menu bar item lives on whichever display the user opened it
         // from, but the panel it opens is the voice host's: one Settings, on
         // the same window every other app-level ask lands in.
-        const host = voiceHostWindow();
-        const displayId = host ? displayIdFor(host.webContents) : undefined;
+        const host = panels.voiceHost();
+        const displayId = host ? panels.displayIdFor(host.webContents) : undefined;
         if (displayId === undefined) return;
-        setWindowMode(displayId, "expanded", true);
+        panels.setMode(displayId, "expanded", true);
         host?.webContents.send(channels.lifecycle, "tab:settings");
       },
     },
@@ -2264,10 +1540,10 @@ function trayMenu(): Electron.Menu {
       // same one every other app-level ask lands in.
       label: "Send Feedback…",
       click: () => {
-        const host = voiceHostWindow();
-        const displayId = host ? displayIdFor(host.webContents) : undefined;
+        const host = panels.voiceHost();
+        const displayId = host ? panels.displayIdFor(host.webContents) : undefined;
         if (displayId === undefined) return;
-        setWindowMode(displayId, "expanded", true);
+        panels.setMode(displayId, "expanded", true);
         host?.webContents.send(
           channels.lifecycle,
           FEEDBACK_LIFECYCLE_EVENT[FEEDBACK_KIND.FEEDBACK],
@@ -2277,10 +1553,10 @@ function trayMenu(): Electron.Menu {
     {
       label: "Submit a Prompt…",
       click: () => {
-        const host = voiceHostWindow();
-        const displayId = host ? displayIdFor(host.webContents) : undefined;
+        const host = panels.voiceHost();
+        const displayId = host ? panels.displayIdFor(host.webContents) : undefined;
         if (displayId === undefined) return;
-        setWindowMode(displayId, "expanded", true);
+        panels.setMode(displayId, "expanded", true);
         host?.webContents.send(channels.lifecycle, FEEDBACK_LIFECYCLE_EVENT[FEEDBACK_KIND.PROMPT]);
       },
     },
@@ -2334,96 +1610,12 @@ function applyMenuBarVisibility(show: boolean): void {
   destroyTray();
 }
 
-/**
- * The Dock tile per theme: the porcelain tile for a light desktop, the
- * space-black one for a dark. The bundle's `.icns` is cut from the dark tile
- * and cannot follow the theme, and an unpackaged run has only Electron's stock
- * icon, so the running app draws the Dock image itself from these.
- */
-const DOCK_ICON_FILES = {
-  LIGHT: "luke-icon-light.png",
-  DARK: "luke-icon-dark.png",
-} as const;
-
-/**
- * Draws Luke's own face in the Dock, matched to the theme. Called at startup,
- * on every theme change, and after every `dock.show()` — showing the icon
- * transforms the process, and macOS draws the fresh tile from the bundle's
- * icon (in a dev run, Electron's stock one), forgetting any image set while
- * there was no tile to wear it. Artwork missing from a build draws nothing,
- * leaving the bundle icon (or the stock one) in place rather than an empty
- * tile.
- */
-function applyDockIcon(): void {
-  if (!app.dock) return;
-  const file = nativeTheme.shouldUseDarkColors ? DOCK_ICON_FILES.DARK : DOCK_ICON_FILES.LIGHT;
-  const image = nativeImage.createFromPath(path.join(__dirname, "icon", file));
-  if (!image.isEmpty()) app.dock.setIcon(image);
-}
-
-/**
- * macOS ignores a `dock.hide()` within a second of the last Dock change, so a
- * switch pressed twice cannot be honoured call by call; the applier below
- * paces itself to this instead, which is Electron's documented floor.
- */
-const DOCK_SETTLE_MS = 1100;
-
-/** The Dock state last asked for, and whether the applier is chasing it. */
-let dockDesired = false;
-let dockSettling = false;
-/** The display whose panel asked for the last Dock change, when one did. */
-let dockAskedFrom: number | undefined;
-
-/**
- * Puts Luke in the Dock or takes him back out, to match the setting. He ships
- * as an accessory app — the notch is his fixed point — so the icon is a second
- * door like the status item, losing nothing when it is hidden. `askedFrom` is
- * the display whose panel held the switch, so the caret goes back where the
- * press was made rather than to whichever panel stands first.
- */
-function applyDockVisibility(show: boolean, askedFrom?: number): void {
-  if (process.platform !== "darwin") return;
-  dockDesired = show;
-  dockAskedFrom = askedFrom;
-  void settleDock();
-}
-
-/**
- * Chases the desired state rather than relaying each press: a hide within a
- * second of the last Dock change is silently ignored by macOS, so the icon is
- * re-checked after every change and asked again until it matches — the switch
- * and the file must not end a quick on-and-off disagreeing with the Dock.
- */
-async function settleDock(): Promise<void> {
-  if (dockSettling || !app.dock) return;
-  dockSettling = true;
-  try {
-    while (app.dock.isVisible() !== dockDesired) {
-      if (dockDesired) {
-        await app.dock.show();
-        // The show rebuilt the tile from the bundle icon; put Luke's face
-        // back on it.
-        applyDockIcon();
-      } else {
-        app.dock.hide();
-      }
-      // Either direction transforms the process type, which can deactivate
-      // the app; the panel the switch was pressed in is brought back forward
-      // rather than left to lose its caret.
-      focusExpandedPanel(dockAskedFrom);
-      await new Promise((resolve) => setTimeout(resolve, DOCK_SETTLE_MS));
-    }
-  } finally {
-    dockSettling = false;
-  }
-}
-
 function handleDisplayChange(): void {
   setTimeout(() => {
-    refreshNativeGeometry();
+    panels.refreshGeometry();
     // The set of displays may have changed, not just their geometry: a chosen
     // display arriving raises its window, one leaving takes its window down.
-    reconcilePanels();
+    panels.reconcile();
   }, 100);
 }
 
@@ -2440,22 +1632,20 @@ if (!app.requestSingleInstanceLock()) {
   // the one thing the relaunch was meant to show. An explicit `--expanded` is a
   // stated intent rather than a side effect, so it is still honoured.
   app.on("second-instance", (_event, argv) => {
-    refreshNativeGeometry();
+    panels.refreshGeometry();
     if (argv.includes("--expanded")) {
-      const host = voiceHostWindow();
-      const displayId = host ? displayIdFor(host.webContents) : undefined;
-      if (displayId !== undefined) setWindowMode(displayId, "expanded", true);
+      const host = panels.voiceHost();
+      const displayId = host ? panels.displayIdFor(host.webContents) : undefined;
+      if (displayId !== undefined) panels.setMode(displayId, "expanded", true);
       return;
     }
-    reconcilePanels();
-    for (const window of panelWindows.values()) {
-      if (!window.isDestroyed()) window.showInactive();
-    }
+    panels.reconcile();
+    panels.showInactiveAll();
   });
   void app.whenReady().then(async () => {
     if (process.platform === "darwin") app.setActivationPolicy("accessory");
     Menu.setApplicationMenu(null);
-    refreshNativeGeometry();
+    panels.refreshGeometry();
     registerIpc();
     // Resolving settings touches the filesystem, and the OS keychain only for a
     // provider that already has a stored key to decrypt. Starting it here keeps
@@ -2473,14 +1663,14 @@ if (!app.requestSingleInstanceLock()) {
     // The Dock wears Luke's own face from the start, and keeps wearing the
     // right one as the desktop changes mode — whether the icon is shown yet
     // is a separate question, answered by the setting below.
-    applyDockIcon();
-    nativeTheme.on("updated", applyDockIcon);
+    dock.applyIcon();
+    dock.watchTheme();
     // The Dock icon reads the same file under the opposite default: it is
     // opt-in, so a file that cannot be read leaves Luke out of the Dock — the
     // accessory app the launch just asserted. Nothing to do until it says so.
     void settingsStore.showInDock().then(
       (show) => {
-        if (show) applyDockVisibility(true);
+        if (show) dock.apply(true);
       },
       () => undefined,
     );
@@ -2510,28 +1700,35 @@ if (!app.requestSingleInstanceLock()) {
     // chosen form, rather than appearing on the main display and jumping. A
     // file that cannot be read means no choice was kept — the main display,
     // the default form — and must not keep the panels from starting.
-    showOnAllDisplays = await settingsStore
-      .readShowOnAllDisplays()
-      .catch(() => APP_SETTING_DEFAULTS.showOnAllDisplays);
-    panelFormFactor =
-      (await settingsStore.readFormFactor().catch(() => undefined)) ?? DEFAULT_PANEL_FORM_FACTOR;
+    panels.setShowOnAllDisplays(
+      await settingsStore
+        .readShowOnAllDisplays()
+        .catch(() => APP_SETTING_DEFAULTS.showOnAllDisplays),
+    );
+    panels.setFormFactor(
+      (await settingsStore.readFormFactor().catch(() => undefined)) ?? DEFAULT_PANEL_FORM_FACTOR,
+    );
     // Awaited for the same reason the voice is: the chosen chord has to be in
     // hand before the key is registered, or the first registration would take
     // the default away from the user who moved off it. A file that cannot be
     // read means no choice was kept, and the defaults answer.
-    chosenVoiceHotkey = await settingsStore.readVoiceHotkey().catch(() => undefined);
-    chosenAskHotkey = await settingsStore.readAskHotkey().catch(() => undefined);
-    chosenStopHotkey = await settingsStore.readStopHotkey().catch(() => undefined);
+    hotkeys.setChosen(
+      HOTKEY_RANK.TALK,
+      await settingsStore.readVoiceHotkey().catch(() => undefined),
+    );
+    hotkeys.setChosen(HOTKEY_RANK.ASK, await settingsStore.readAskHotkey().catch(() => undefined));
+    hotkeys.setChosen(
+      HOTKEY_RANK.STOP,
+      await settingsStore.readStopHotkey().catch(() => undefined),
+    );
     // The report is not made here: the helper answers over its own stdout a
     // moment later, and a line printed now would state an absence that only
     // exists because nobody has answered yet.
-    registerVoiceHotkey();
-    registerAskHotkey();
-    registerStopHotkey();
+    await hotkeys.reapply(HOTKEY_RANK.TALK);
     // Read-only, like everything else that watches: what it learns decides
     // what the renderer draws while Luke speaks unheard, and nothing more.
     startOutputVolumeWatch();
-    reconcilePanels();
+    panels.reconcile();
     configurePermissions();
     startSessionObservation();
     startIssueObservation();
@@ -2542,9 +1739,7 @@ if (!app.requestSingleInstanceLock()) {
     for (const eventName of ["resume", "unlock-screen", "user-did-become-active"] as const) {
       const handlePowerEvent = () => {
         handleDisplayChange();
-        for (const window of panelWindows.values()) {
-          window.webContents.send(channels.lifecycle, eventName);
-        }
+        panels.broadcast(channels.lifecycle, eventName);
       };
       if (eventName === "resume") powerMonitor.on("resume", handlePowerEvent);
       if (eventName === "unlock-screen") {
@@ -2558,12 +1753,10 @@ if (!app.requestSingleInstanceLock()) {
 }
 
 app.on("will-quit", () => {
-  globalShortcut.unregisterAll();
   // The helper is a process of Luke's own, so it does not outlive the app that
   // spawned it and leave a key registered against nothing. Nothing succeeds it
   // during quit, so its exit is not waited on.
-  void talkKeyWatcher?.stop();
-  talkKeyWatcher = undefined;
+  hotkeys.release();
   // The same rule: a process of Luke's own does not outlive the app.
   outputVolumeWatcher?.stop();
   outputVolumeWatcher = undefined;
@@ -2576,7 +1769,7 @@ app.on("will-quit", () => {
 app.on("before-quit", () => {
   if (sessionRefreshTimer) clearInterval(sessionRefreshTimer);
   if (issueRefreshTimer) clearInterval(issueRefreshTimer);
-  for (const displayId of [...collapseTimers.keys()]) clearCollapseTimer(displayId);
+  panels.clearCollapseTimers();
 });
 
 app.on("window-all-closed", () => app.quit());

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1103,7 +1103,7 @@ function registerIpc(): void {
       // model composed decides this — and losing the save loses only the
       // remembered default, never the workspace that just landed.
       if (result.status === PROVIDER_ACT_RESULT_STATUS.ACCEPTED) {
-        void rememberWorkspaceDefaults(
+        await rememberWorkspaceDefaults(
           adapter,
           namedSelection as WorkspaceAgentSelection | undefined,
         );

--- a/apps/desktop/src/panel-manager.ts
+++ b/apps/desktop/src/panel-manager.ts
@@ -1,0 +1,497 @@
+import {
+  DEFAULT_PANEL_FORM_FACTOR,
+  MOTION_DURATION_MS,
+  type NativeNotchGeometry,
+  type PanelFormFactor,
+  positionNotchWindow,
+  resolveNotchGeometry,
+} from "@sidecar/core";
+import {
+  app,
+  BrowserWindow,
+  type Display,
+  screen,
+  systemPreferences,
+  type WebContents,
+} from "electron";
+import { readMacScreenGeometry } from "./macos-screen-geometry";
+import { keepWindowStationary } from "./macos-stationary-window";
+import type { RunMode } from "./run-mode";
+import { channels, type DisplayDiagnostic, type WindowMode } from "./shared/contracts";
+
+export interface PanelDuck {
+  setExchangeActive(active: boolean): void;
+}
+
+export interface PanelManagerOptions {
+  runMode: RunMode;
+  mediaDuck: PanelDuck;
+  preloadPath: string;
+  rendererHtmlPath: string;
+  rendererUrl: string;
+  argv?: readonly string[];
+}
+
+/**
+ * `--duration-exit` plus `--duration-shape` in the shared motion tokens: the
+ * content leaves, then the surface closes on the spring, and only then may the
+ * window follow.
+ */
+const COLLAPSE_ANIMATION_MS = MOTION_DURATION_MS.EXIT + MOTION_DURATION_MS.SHAPE;
+
+/** The mode every window is born in; only the dev and capture flags change it. */
+function initialWindowMode(runMode: RunMode, argv: readonly string[]): WindowMode {
+  if (!runMode.takesFocus) {
+    return argv.includes("--compact") ? "compact" : "expanded";
+  }
+  return argv.includes("--expanded") ? "expanded" : "compact";
+}
+
+/**
+ * One panel window per display Luke stands on, each with its own mode, collapse
+ * timer, and exchange report. Reconcile, rebind, and the sequenced resize live
+ * here so a display arriving or leaving cannot drop a conversation, and so
+ * every caller — the panel, the tray, the talk key — gets the same ordering
+ * when a window grows or shrinks.
+ */
+export class PanelManager {
+  readonly #runMode: RunMode;
+  readonly #mediaDuck: PanelDuck;
+  readonly #preloadPath: string;
+  readonly #rendererHtmlPath: string;
+  readonly #rendererUrl: string;
+  readonly initialMode: WindowMode;
+  /**
+   * One panel window per display Luke stands on, keyed by the display's id, each
+   * with its own mode: a panel opened on one monitor must not resize the capsule
+   * on another. The collapse timers ride the same key, because a collapse is a
+   * single window's affair.
+   */
+  readonly #windows = new Map<number, BrowserWindow>();
+  readonly #modes = new Map<number, WindowMode>();
+  readonly #collapseTimers = new Map<number, NodeJS.Timeout>();
+  /**
+   * Which windows hold a live spoken exchange, and the single answer the media
+   * duck is given: live anywhere is live. Only the voice host ever actually
+   * opens one, but every window reports, so the union is what keeps a
+   * bystander's idle from ending the host's exchange.
+   */
+  readonly #voiceExchanges = new Map<number, boolean>();
+  /**
+   * Whether Luke stands on every display, mirroring the settings file the way
+   * the minter mirrors the chosen voice: read once before any panel exists,
+   * updated by the same handler that stores a new choice, so every layout
+   * decision stays synchronous. Off means the system's main display alone.
+   */
+  #showOnAllDisplays = false;
+  /** The chosen form for displays without a housing, mirrored the same way. */
+  #panelFormFactor: PanelFormFactor = DEFAULT_PANEL_FORM_FACTOR;
+  #nativeScreens = new Map<number, NativeNotchGeometry>();
+
+  constructor(options: PanelManagerOptions) {
+    this.#runMode = options.runMode;
+    this.#mediaDuck = options.mediaDuck;
+    this.#preloadPath = options.preloadPath;
+    this.#rendererHtmlPath = options.rendererHtmlPath;
+    this.#rendererUrl = options.rendererUrl;
+    this.initialMode = initialWindowMode(options.runMode, options.argv ?? process.argv);
+  }
+
+  /**
+   * Makes the windows match the chosen displays: one raised on every chosen
+   * display that is connected, none anywhere else. A window whose display went
+   * away is moved to a display that needs one rather than destroyed beside a
+   * fresh create — a swap of the main display must carry the conversation and
+   * the panel's state across, not drop them on the floor. Raising before razing
+   * is load-bearing for what remains — a swap must never pass through zero
+   * windows, because all windows closed is how this process decides it is done.
+   * Everything that changes what the set should be lands here: a switch
+   * pressed, a display plugged or unplugged, the stored choice read at launch.
+   */
+  reconcile(): void {
+    const wanted = this.#effectiveDisplayIds();
+    const wantedSet = new Set(wanted);
+    const missing = wanted.filter((displayId) => !this.#windows.has(displayId));
+    const excess = [...this.#windows.keys()].filter((displayId) => !wantedSet.has(displayId));
+    // Pair each display that needs a window with a window that lost its display.
+    while (missing.length > 0 && excess.length > 0) {
+      const toDisplayId = missing.shift();
+      const fromDisplayId = excess.shift();
+      if (toDisplayId === undefined || fromDisplayId === undefined) break;
+      this.#rebind(fromDisplayId, toDisplayId);
+    }
+    for (const displayId of missing) this.#create(displayId);
+    for (const displayId of excess) {
+      const window = this.#windows.get(displayId);
+      this.#windows.delete(displayId);
+      this.#modes.delete(displayId);
+      this.#clearCollapseTimer(displayId);
+      // A window taken down takes its exchange report with it, so a host that
+      // goes mid-conversation releases the duck rather than pinning it forever.
+      this.#voiceExchanges.delete(displayId);
+      this.#applyVoiceExchanges();
+      window?.destroy();
+    }
+    this.positionAll();
+  }
+
+  /**
+   * The two directions are sequenced differently, and the ordering lives here so
+   * every caller gets it — the panel, the tray, and the motion recorder alike.
+   * Growing needs the window first, or the panel has nowhere to unfold into.
+   * Shrinking needs the capsule drawn first, or the window clips the panel out
+   * from under its own collapse. One display's window at a time: a panel opened
+   * on one monitor is no reason to resize the capsule on another.
+   */
+  setMode(displayId: number, mode: WindowMode, requestFocus: boolean): WindowMode {
+    this.#modes.set(displayId, mode);
+    const window = this.#windows.get(displayId);
+    if (!window || window.isDestroyed()) return mode;
+
+    const expanded = mode === "expanded";
+    window.setFocusable(expanded && this.#runMode.takesFocus);
+    this.#clearCollapseTimer(displayId);
+    if (expanded) {
+      this.#position(displayId);
+      window.webContents.send(channels.lifecycle, `mode:${mode}`);
+    } else {
+      window.webContents.send(channels.lifecycle, `mode:${mode}`);
+      const delay = this.#collapseDelay();
+      if (delay === 0) this.#position(displayId);
+      else {
+        this.#collapseTimers.set(
+          displayId,
+          setTimeout(() => {
+            this.#collapseTimers.delete(displayId);
+            if (this.modeFor(displayId) === "compact") this.#position(displayId);
+          }, delay),
+        );
+      }
+    }
+
+    if (expanded && requestFocus && this.#runMode.takesFocus) {
+      this.#focusWindow(window);
+    } else {
+      window.showInactive();
+    }
+    return mode;
+  }
+
+  /**
+   * Hands a payload to every living window, optionally skipping the one that
+   * already holds the answer in its reply and must redraw from that rather
+   * than race a broadcast.
+   */
+  broadcast(channel: string, payload: unknown, except?: WebContents): void {
+    for (const window of this.#windows.values()) {
+      if (window.isDestroyed() || window.webContents === except) continue;
+      window.webContents.send(channel, payload);
+    }
+  }
+
+  /**
+   * The one window a spoken conversation lives in. Voice is a single thing —
+   * one microphone, one reply, one face speaking — so the talk key and the
+   * attention readouts go to a single renderer rather than opening one
+   * conversation per display: the main display's window when Luke stands there,
+   * else the first window standing anywhere.
+   */
+  voiceHost(): BrowserWindow | undefined {
+    const primary = this.#windows.get(screen.getPrimaryDisplay().id);
+    if (primary && !primary.isDestroyed()) return primary;
+    for (const window of this.#windows.values()) {
+      if (!window.isDestroyed()) return window;
+    }
+    return undefined;
+  }
+
+  /** The display a renderer message came from, so each window answers for itself. */
+  displayIdFor(sender: WebContents): number | undefined {
+    for (const [displayId, window] of this.#windows) {
+      if (!window.isDestroyed() && window.webContents === sender) return displayId;
+    }
+    return undefined;
+  }
+
+  modeFor(displayId: number): WindowMode {
+    return this.#modes.get(displayId) ?? this.initialMode;
+  }
+
+  display(displayId: number): Display | undefined {
+    return screen.getAllDisplays().find((candidate) => candidate.id === displayId);
+  }
+
+  diagnostic(display: Display): DisplayDiagnostic {
+    return {
+      id: display.id,
+      label: display.label || `Display ${display.id}`,
+      bounds: display.bounds,
+      workArea: display.workArea,
+      scaleFactor: display.scaleFactor,
+      notch: resolveNotchGeometry(
+        display,
+        this.#nativeScreens.get(display.id),
+        this.#panelFormFactor,
+      ),
+    };
+  }
+
+  /**
+   * The expanded panel owed the keyboard: the one that asked, when the asker is
+   * known and still expanded, else whichever panel stands expanded. With two
+   * panels open, focus must return to the one the user was typing in rather
+   * than to whichever the map happens to list first.
+   */
+  focusExpanded(preferredDisplayId?: number): void {
+    if (preferredDisplayId !== undefined && this.modeFor(preferredDisplayId) === "expanded") {
+      const preferred = this.#windows.get(preferredDisplayId);
+      if (preferred && !preferred.isDestroyed()) {
+        this.#focusWindow(preferred);
+        return;
+      }
+    }
+    for (const [displayId, window] of this.#windows) {
+      if (this.modeFor(displayId) !== "expanded") continue;
+      this.#focusWindow(window);
+      return;
+    }
+  }
+
+  /**
+   * Brings the named panel forward when it is the expanded one holding a field.
+   * A compact window has nothing to type into.
+   */
+  focusIfExpanded(displayId: number): void {
+    if (this.modeFor(displayId) !== "expanded") return;
+    this.#focusWindow(this.#windows.get(displayId));
+  }
+
+  positionAll(): void {
+    for (const displayId of this.#windows.keys()) this.#position(displayId);
+  }
+
+  setShowOnAllDisplays(show: boolean): void {
+    this.#showOnAllDisplays = show;
+  }
+
+  setFormFactor(formFactor: PanelFormFactor): void {
+    this.#panelFormFactor = formFactor;
+  }
+
+  setVoiceExchange(displayId: number, active: boolean): void {
+    this.#voiceExchanges.set(displayId, active);
+    this.#applyVoiceExchanges();
+  }
+
+  /** Whether some panel window's renderer is asking, whichever display it is on. */
+  owns(webContents: WebContents): boolean {
+    for (const window of this.#windows.values()) {
+      if (!window.isDestroyed() && window.webContents === webContents) return true;
+    }
+    return false;
+  }
+
+  refreshGeometry(): void {
+    this.#nativeScreens = readMacScreenGeometry();
+    // A capture run pins a fixture housing on the main display, where the
+    // evidence is taken; an interactive fixture still stands on the real
+    // screen, because it is a person looking, not a camera.
+    if (!this.#runMode.takesFocus) {
+      const display = screen.getPrimaryDisplay();
+      this.#nativeScreens.set(display.id, {
+        displayId: display.id,
+        safeAreaTop: 38,
+        notchWidth: 210,
+        hasNotch: true,
+        source: "fixture",
+      });
+    }
+  }
+
+  showInactiveAll(): void {
+    for (const window of this.#windows.values()) {
+      if (!window.isDestroyed()) window.showInactive();
+    }
+  }
+
+  clearCollapseTimers(): void {
+    for (const displayId of [...this.#collapseTimers.keys()]) this.#clearCollapseTimer(displayId);
+  }
+
+  /**
+   * Where Luke stands right now: every connected display when asked to stand on
+   * all of them, the system's main display alone otherwise. A capture run stays
+   * on the main display regardless, where its fixture housing is pinned.
+   */
+  #effectiveDisplayIds(): number[] {
+    if (this.#runMode.takesFocus && this.#showOnAllDisplays) {
+      return screen.getAllDisplays().map((display) => display.id);
+    }
+    return [screen.getPrimaryDisplay().id];
+  }
+
+  #layoutFor(display: Display, mode: WindowMode) {
+    return positionNotchWindow(
+      display,
+      mode,
+      this.#nativeScreens.get(display.id),
+      this.#panelFormFactor,
+    );
+  }
+
+  /**
+   * Resizes without AppKit's frame animation. An animated setBounds re-lays out
+   * the renderer at a new viewport width on every frame — and its duration scales
+   * with the distance moved, so a 482px growth ran far longer than the panel's
+   * own motion. The window now snaps to the size the mode needs and the renderer
+   * animates the capsule into the panel inside it, where the viewport is constant
+   * and the work stays on the compositor.
+   */
+  #position(displayId: number): void {
+    const window = this.#windows.get(displayId);
+    if (!window || window.isDestroyed()) return;
+    const display = this.display(displayId);
+    // A window whose display has gone is the reconciler's to take down, not
+    // this function's to guess a home for.
+    if (!display) return;
+    const layout = this.#layoutFor(display, this.modeFor(displayId));
+    window.setBounds({
+      x: layout.x,
+      y: layout.y,
+      width: layout.width,
+      height: layout.height,
+    });
+    window.webContents.send(channels.displayChanged, this.diagnostic(display));
+  }
+
+  /**
+   * Moves a living window to another display, state and all: its mode, its
+   * collapse-in-flight, its exchange report, and the renderer behind it — which
+   * learns its new ground from the `displayChanged` the repositioning sends,
+   * exactly as it would for a geometry change in place.
+   */
+  #rebind(fromDisplayId: number, toDisplayId: number): void {
+    const window = this.#windows.get(fromDisplayId);
+    if (!window) return;
+    this.#windows.delete(fromDisplayId);
+    this.#windows.set(toDisplayId, window);
+    this.#modes.set(toDisplayId, this.modeFor(fromDisplayId));
+    this.#modes.delete(fromDisplayId);
+    // The timer's closure names the old display; the reposition below redraws
+    // whatever a cancelled collapse would have.
+    this.#clearCollapseTimer(fromDisplayId);
+    const exchange = this.#voiceExchanges.get(fromDisplayId);
+    this.#voiceExchanges.delete(fromDisplayId);
+    if (exchange !== undefined) this.#voiceExchanges.set(toDisplayId, exchange);
+    this.#applyVoiceExchanges();
+  }
+
+  #clearCollapseTimer(displayId: number): void {
+    const timer = this.#collapseTimers.get(displayId);
+    if (!timer) return;
+    clearTimeout(timer);
+    this.#collapseTimers.delete(displayId);
+  }
+
+  #configure(window: BrowserWindow): void {
+    window.setAlwaysOnTop(true, "pop-up-menu");
+    if (process.platform === "darwin") {
+      window.setVisibleOnAllWorkspaces(true, {
+        visibleOnFullScreen: true,
+        skipTransformProcessType: true,
+      });
+      window.setHiddenInMissionControl(true);
+      window.setWindowButtonVisibility(false);
+      keepWindowStationary(window);
+    }
+  }
+
+  /**
+   * Brings one panel forward as the key window. An accessory app has no Dock
+   * presence, so the app itself has to come forward before one of its windows can
+   * take keyboard focus.
+   */
+  #focusWindow(window: BrowserWindow | undefined): void {
+    if (!window || window.isDestroyed() || !this.#runMode.takesFocus) return;
+    if (process.platform === "darwin") app.focus({ steal: true });
+    window.show();
+    window.focus();
+  }
+
+  #applyVoiceExchanges(): void {
+    this.#mediaDuck.setExchangeActive([...this.#voiceExchanges.values()].some(Boolean));
+  }
+
+  #collapseDelay(): number {
+    if (!this.#runMode.animates) return 0;
+    return systemPreferences.getAnimationSettings().prefersReducedMotion
+      ? 0
+      : COLLAPSE_ANIMATION_MS;
+  }
+
+  #create(displayId: number): void {
+    const display = this.display(displayId);
+    if (!display) return;
+    this.#modes.set(displayId, this.initialMode);
+    const layout = this.#layoutFor(display, this.initialMode);
+
+    const window = new BrowserWindow({
+      x: layout.x,
+      y: layout.y,
+      width: layout.width,
+      height: layout.height,
+      title: "Luke",
+      show: false,
+      frame: false,
+      transparent: true,
+      backgroundColor: "#00000000",
+      hasShadow: false,
+      roundedCorners: false,
+      resizable: false,
+      movable: false,
+      minimizable: false,
+      maximizable: false,
+      fullscreenable: false,
+      skipTaskbar: true,
+      alwaysOnTop: true,
+      focusable: this.initialMode === "expanded" && this.#runMode.takesFocus,
+      acceptFirstMouse: true,
+      type: process.platform === "darwin" ? "panel" : undefined,
+      webPreferences: {
+        preload: this.#preloadPath,
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: true,
+        webSecurity: true,
+        devTools: this.#runMode.takesFocus,
+        backgroundThrottling: false,
+      },
+    });
+    this.#windows.set(displayId, window);
+
+    this.#configure(window);
+    window.setIgnoreMouseEvents(true, { forward: true });
+    window.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+    window.webContents.on("will-navigate", (event, url) => {
+      if (url !== this.#rendererUrl) event.preventDefault();
+    });
+    window.once("ready-to-show", () => {
+      if (this.#runMode.takesFocus && !window.isDestroyed()) window.showInactive();
+    });
+    // The reconciler deletes before it destroys, so this answers only a window
+    // that went down some other way — and it must not leave a ghost in the map,
+    // nor a phantom exchange holding the duck down. Found by the window rather
+    // than the id it was born under, because a rebind may have moved it.
+    window.on("closed", () => {
+      for (const [id, candidate] of [...this.#windows]) {
+        if (candidate !== window) continue;
+        this.#windows.delete(id);
+        this.#modes.delete(id);
+        this.#clearCollapseTimer(id);
+        this.#voiceExchanges.delete(id);
+        this.#applyVoiceExchanges();
+      }
+    });
+    void window.loadFile(this.#rendererHtmlPath);
+  }
+}

--- a/apps/desktop/src/run-mode.ts
+++ b/apps/desktop/src/run-mode.ts
@@ -1,0 +1,36 @@
+/**
+ * What this process is allowed to do, decided once from how it was launched.
+ *
+ * A fixture run must be deterministic and credential-free; a capture run is
+ * that and also unattended — no system keys, no focus, no motion the camera
+ * did not ask for. Call sites test a capability rather than re-deriving those
+ * two booleans, so a third launch mode cannot silently inherit the wrong half.
+ */
+export interface RunMode {
+  /** Watch session providers, issue trackers, and the machine's own output. */
+  readonly observesProviders: boolean;
+  /** Claim system-wide shortcuts. A capture run drives the panel itself. */
+  readonly registersGlobalKeys: boolean;
+  /** Wait for the panel's own collapse before shrinking the window. */
+  readonly animates: boolean;
+  /** Steal keyboard focus, raise windows, stand on more than the main display. */
+  readonly takesFocus: boolean;
+  /** Mint credentials, evaluate attention, create workspaces, send notes. */
+  readonly sendsNetwork: boolean;
+}
+
+/**
+ * Computes the capabilities for this launch. `capture` is `--capture-evidence`;
+ * `fixture` is `--fixture` or a capture run, which always implies it.
+ */
+export function runModeFor(input: { capture: boolean; fixture: boolean }): RunMode {
+  const deterministic = input.capture || input.fixture;
+  const interactive = !input.capture;
+  return {
+    observesProviders: !deterministic,
+    registersGlobalKeys: interactive,
+    animates: interactive,
+    takesFocus: interactive,
+    sendsNetwork: !deterministic,
+  };
+}

--- a/apps/desktop/src/settings-handler.ts
+++ b/apps/desktop/src/settings-handler.ts
@@ -1,0 +1,75 @@
+import { type IpcMainInvokeEvent, ipcMain } from "electron";
+import type { AppSettings, SettingsUpdateResult } from "./shared/contracts";
+
+/**
+ * A validate step that answers with words instead of a value. The refusal is
+ * its own type so the factory can tell it from anything a setting might one
+ * day validate to — a shape sniffed for a `settings` key would turn such a
+ * value into a silent no-op the day the two collide.
+ */
+export class SettingsRefusal {
+  constructor(readonly result: SettingsUpdateResult) {}
+}
+
+export interface SettingsHandlerSpec<Value> {
+  validate: (...args: unknown[]) => Value | SettingsRefusal | Promise<Value | SettingsRefusal>;
+  save: (value: Value) => Promise<SettingsUpdateResult>;
+  apply?: (
+    result: SettingsUpdateResult,
+    value: Value,
+    event: IpcMainInvokeEvent,
+  ) => void | Promise<void>;
+  refusal: string;
+}
+
+export interface SettingsHandlerDeps {
+  trustedSender: (event: IpcMainInvokeEvent) => boolean;
+  snapshot: () => Promise<AppSettings>;
+  broadcast: (settings: AppSettings, except?: Electron.WebContents) => void;
+  /**
+   * Injectable so the factory can be exercised without standing up Electron's
+   * IPC bus. Production uses `ipcMain.handle`.
+   */
+  handle?: (
+    channel: string,
+    listener: (event: IpcMainInvokeEvent, ...args: unknown[]) => Promise<SettingsUpdateResult>,
+  ) => void;
+}
+
+/**
+ * One write path for every settings change the renderer can ask for. Trust,
+ * catch, snapshot, and broadcast are identical on every channel — only what
+ * is valid, what is stored, and what the write sets in motion differ. A
+ * malformed request still throws: that is a broken caller, not a choice the
+ * user can correct.
+ */
+export function createSettingsHandler(deps: SettingsHandlerDeps) {
+  const handle = deps.handle ?? ipcMain.handle.bind(ipcMain);
+  return function registerSettingHandler<Value>(
+    channel: string,
+    spec: SettingsHandlerSpec<Value>,
+  ): void {
+    handle(channel, async (event, ...args: unknown[]): Promise<SettingsUpdateResult> => {
+      if (!deps.trustedSender(event)) throw new Error("Untrusted renderer");
+      const value = await spec.validate(...args);
+      // A validate step that already answered — a chord spoken for, refused with
+      // words — leaves without a write, a side effect, or a broadcast.
+      if (value instanceof SettingsRefusal) {
+        return value.result;
+      }
+      try {
+        const result = await spec.save(value);
+        await spec.apply?.(result, value, event);
+        deps.broadcast(result.settings, event.sender);
+        return result;
+      } catch {
+        // A filesystem failure is not something the user can act on, so it is
+        // reported as one line rather than as a raw system error.
+        return {
+          settings: await deps.snapshot(),
+          reason: spec.refusal,
+        };
+      }
+    });
+  };
+}

--- a/apps/desktop/tests/dock-presence.test.ts
+++ b/apps/desktop/tests/dock-presence.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { DOCK_ICON_FILES, DockPresence, type DockTile } from "../src/dock-presence";
+
+function harness(options: { visible?: boolean; ignoreFirstHide?: boolean } = {}) {
+  let visible = options.visible ?? false;
+  let hideAttempts = 0;
+  const icons: string[] = [];
+  const focused: Array<number | undefined> = [];
+  const delays: number[] = [];
+  let themeUpdated: (() => void) | undefined;
+  let dark = false;
+
+  const dock: DockTile = {
+    isVisible: () => visible,
+    show: async () => {
+      visible = true;
+    },
+    hide: () => {
+      hideAttempts += 1;
+      if (options.ignoreFirstHide && hideAttempts < 2) return;
+      visible = false;
+    },
+    setIcon: () => {
+      icons.push(dark ? DOCK_ICON_FILES.DARK : DOCK_ICON_FILES.LIGHT);
+    },
+  };
+
+  const presence = new DockPresence({
+    focusExpanded: (displayId) => focused.push(displayId),
+    iconDirectory: "/unused",
+    dock,
+    theme: {
+      get shouldUseDarkColors() {
+        return dark;
+      },
+      on: (_event, listener) => {
+        themeUpdated = listener;
+      },
+    },
+    loadIcon: () =>
+      ({
+        isEmpty: () => false,
+      }) as Electron.NativeImage,
+    delay: async (ms) => {
+      delays.push(ms);
+    },
+    settleMs: 11,
+  });
+
+  return {
+    presence,
+    icons: () => icons,
+    focused: () => focused,
+    delays: () => delays,
+    hideAttempts: () => hideAttempts,
+    isVisible: () => visible,
+    setDark(next: boolean) {
+      dark = next;
+    },
+    themeChange() {
+      themeUpdated?.();
+    },
+  };
+}
+
+test("a hide macOS ignores is asked again until the Dock matches", async () => {
+  const context = harness({ visible: true, ignoreFirstHide: true });
+  context.presence.apply(false, 7);
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(context.hideAttempts(), 2);
+  assert.equal(context.isVisible(), false);
+  assert.deepEqual(context.focused(), [7, 7]);
+  assert.deepEqual(context.delays(), [11, 11]);
+});
+
+test("a show puts Luke's face back on the tile the show forgot", async () => {
+  const context = harness({ visible: false });
+  context.presence.apply(true);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(context.isVisible(), true);
+  assert.deepEqual(context.icons(), [DOCK_ICON_FILES.LIGHT]);
+});
+
+test("the tile follows the desktop through light and dark", () => {
+  const context = harness();
+  context.presence.applyIcon();
+  assert.deepEqual(context.icons(), [DOCK_ICON_FILES.LIGHT]);
+  context.setDark(true);
+  context.presence.watchTheme();
+  context.themeChange();
+  assert.deepEqual(context.icons(), [DOCK_ICON_FILES.LIGHT, DOCK_ICON_FILES.DARK]);
+});

--- a/apps/desktop/tests/hotkey-registrar.test.ts
+++ b/apps/desktop/tests/hotkey-registrar.test.ts
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  HOTKEY_RANK,
+  HotkeyRegistrar,
+  type ShortcutSurface,
+  type TalkKeyHandle,
+} from "../src/hotkey-registrar";
+import type { TalkKeyEdges } from "../src/talk-key";
+
+interface RecordedShortcut {
+  accelerator: string;
+  callback: () => void;
+}
+
+function harness(options: { credentials?: boolean; registers?: boolean } = {}) {
+  const registered: RecordedShortcut[] = [];
+  const unregistered: string[] = [];
+  let unregisterAllCount = 0;
+  const broadcasts: { channel: string; payload: unknown }[] = [];
+  const reports: string[] = [];
+  const talkStops: number[] = [];
+  let talkEdges: TalkKeyEdges | undefined;
+  let talkStart = true;
+
+  const shortcut: ShortcutSurface = {
+    register(accelerator, callback) {
+      registered.push({ accelerator, callback });
+      return true;
+    },
+    unregister(accelerator) {
+      unregistered.push(accelerator);
+    },
+    unregisterAll() {
+      unregisterAllCount += 1;
+      registered.length = 0;
+    },
+  };
+
+  const registrar = new HotkeyRegistrar({
+    registersGlobalKeys: options.registers ?? true,
+    hasCredentials: () => options.credentials ?? true,
+    shortcut,
+    report: (line) => reports.push(line),
+    createTalkKeyWatcher: (edges): TalkKeyHandle => {
+      talkEdges = edges;
+      return {
+        start: () => talkStart,
+        stop: () => {
+          talkStops.push(1);
+          return Promise.resolve();
+        },
+      };
+    },
+    host: {
+      voiceHost: () => undefined,
+      displayIdFor: () => undefined,
+      setMode: () => undefined,
+      broadcast: (channel, payload) => broadcasts.push({ channel, payload }),
+    },
+  });
+
+  return {
+    registrar,
+    registered: () => registered.map((entry) => entry.accelerator),
+    unregistered: () => unregistered,
+    unregisterAllCount: () => unregisterAllCount,
+    broadcasts: () => broadcasts,
+    reports: () => reports,
+    talkStops: () => talkStops,
+    failTalkStart() {
+      talkStart = false;
+    },
+    announceTalk(accelerator: string) {
+      talkEdges?.onRegistered(accelerator);
+    },
+  };
+}
+
+test("reserve answers from the pecking order instead of re-deriving it", async () => {
+  const context = harness();
+  await context.registrar.reapply(HOTKEY_RANK.TALK);
+  context.announceTalk("Alt+Space");
+
+  // Talk's whole candidate list is reserved, not just the chord it holds.
+  assert.equal(context.registrar.reserve("Alt+Space", HOTKEY_RANK.ASK), HOTKEY_RANK.TALK);
+  assert.equal(context.registrar.reserve("Alt+L", HOTKEY_RANK.ASK), undefined);
+
+  // Stop yields to both: talk first, then ask's own candidates.
+  assert.equal(context.registrar.reserve("Alt+Space", HOTKEY_RANK.STOP), HOTKEY_RANK.TALK);
+  assert.equal(context.registrar.reserve("Alt+L", HOTKEY_RANK.STOP), HOTKEY_RANK.ASK);
+  assert.equal(context.registrar.reserve("Alt+S", HOTKEY_RANK.STOP), undefined);
+});
+
+test("reapply from talk unregisters everything, then ask and stop in order", async () => {
+  const context = harness();
+  await context.registrar.reapply(HOTKEY_RANK.TALK);
+  context.announceTalk("Alt+Space");
+
+  assert.equal(context.unregisterAllCount(), 1);
+  // Ask then stop: Option-L before Option-S, and never a chord talk sits on.
+  assert.deepEqual(context.registered(), ["Alt+L", "Alt+S"]);
+  assert.equal(context.registrar.ask, "Alt+L");
+  assert.equal(context.registrar.stop, "Alt+S");
+});
+
+test("reapply from ask leaves talk alone and re-takes stop behind it", async () => {
+  const context = harness();
+  await context.registrar.reapply(HOTKEY_RANK.TALK);
+  context.announceTalk("Alt+Space");
+  const afterTalk = context.unregisterAllCount();
+
+  context.registrar.setChosen(HOTKEY_RANK.ASK, "Control+Alt+K");
+  await context.registrar.reapply(HOTKEY_RANK.ASK);
+
+  assert.equal(context.unregisterAllCount(), afterTalk);
+  assert.ok(context.unregistered().includes("Alt+L"));
+  assert.ok(context.unregistered().includes("Alt+S"));
+  assert.deepEqual(context.registered().slice(-2), ["Control+Alt+K", "Alt+S"]);
+  assert.equal(context.registrar.ask, "Control+Alt+K");
+});
+
+test("reapply from stop lets only itself go", async () => {
+  const context = harness();
+  await context.registrar.reapply(HOTKEY_RANK.TALK);
+  context.announceTalk("Alt+Space");
+  const afterTalk = context.unregistered().length;
+
+  context.registrar.setChosen(HOTKEY_RANK.STOP, "Control+Alt+X");
+  await context.registrar.reapply(HOTKEY_RANK.STOP);
+
+  assert.equal(context.unregisterAllCount(), 1);
+  assert.deepEqual(context.unregistered().slice(afterTalk), ["Alt+S"]);
+  assert.equal(context.registrar.stop, "Control+Alt+X");
+  assert.equal(context.registrar.ask, "Alt+L");
+});
+
+test("a capture run takes no system key", async () => {
+  const context = harness({ registers: false });
+  await context.registrar.reapply(HOTKEY_RANK.TALK);
+  assert.deepEqual(context.registered(), []);
+  assert.match(context.reports().join("\n"), /capture run/);
+});
+
+test("no credential takes no system key", async () => {
+  const context = harness({ credentials: false });
+  await context.registrar.reapply(HOTKEY_RANK.TALK);
+  assert.deepEqual(context.registered(), []);
+  assert.match(context.reports().join("\n"), /voice is off/);
+});
+
+test("a helper that cannot start falls back to a toggle", async () => {
+  const context = harness();
+  context.failTalkStart();
+  await context.registrar.reapply(HOTKEY_RANK.TALK);
+  assert.equal(context.registrar.talk, "Alt+Space");
+  assert.equal(context.registrar.held, false);
+});

--- a/apps/desktop/tests/run-mode.test.ts
+++ b/apps/desktop/tests/run-mode.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { runModeFor } from "../src/run-mode";
+
+test("a live launch observes, talks, animates, focuses, and may send", () => {
+  assert.deepEqual(runModeFor({ capture: false, fixture: false }), {
+    observesProviders: true,
+    registersGlobalKeys: true,
+    animates: true,
+    takesFocus: true,
+    sendsNetwork: true,
+  });
+});
+
+test("a fixture launch is deterministic and credential-free, still interactive", () => {
+  // `--fixture` without a capture is a person looking: no providers, no
+  // network, but the panel still takes focus and the keys still register.
+  assert.deepEqual(runModeFor({ capture: false, fixture: true }), {
+    observesProviders: false,
+    registersGlobalKeys: true,
+    animates: true,
+    takesFocus: true,
+    sendsNetwork: false,
+  });
+});
+
+test("a capture launch is unattended: no keys, no focus, no motion, no network", () => {
+  assert.deepEqual(runModeFor({ capture: true, fixture: false }), {
+    observesProviders: false,
+    registersGlobalKeys: false,
+    animates: false,
+    takesFocus: false,
+    sendsNetwork: false,
+  });
+  // Capture always implies fixture, and saying so twice must not change the
+  // answer — call sites test a capability, not which flag produced it.
+  assert.deepEqual(
+    runModeFor({ capture: true, fixture: true }),
+    runModeFor({ capture: true, fixture: false }),
+  );
+});

--- a/apps/desktop/tests/settings-handler.test.ts
+++ b/apps/desktop/tests/settings-handler.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { IpcMainInvokeEvent } from "electron";
+import { createSettingsHandler, SettingsRefusal } from "../src/settings-handler";
+import type { AppSettings, SettingsUpdateResult } from "../src/shared/contracts";
+
+const SETTINGS = { showInDock: false } as AppSettings;
+
+function event(sender: object = { id: 1 }): IpcMainInvokeEvent {
+  return { sender } as IpcMainInvokeEvent;
+}
+
+test("an untrusted sender is refused before validate or save run", async () => {
+  const calls: string[] = [];
+  const handlers = new Map<
+    string,
+    (event: IpcMainInvokeEvent, ...args: unknown[]) => Promise<SettingsUpdateResult>
+  >();
+  const register = createSettingsHandler({
+    trustedSender: () => false,
+    snapshot: async () => SETTINGS,
+    broadcast: () => {
+      calls.push("broadcast");
+    },
+    handle: (channel, listener) => {
+      handlers.set(channel, listener);
+    },
+  });
+  register("app:set-x", {
+    validate: () => {
+      calls.push("validate");
+      return true;
+    },
+    save: async () => {
+      calls.push("save");
+      return { settings: SETTINGS };
+    },
+    refusal: "Could not save.",
+  });
+  await assert.rejects(() => handlers.get("app:set-x")?.(event()), /Untrusted renderer/);
+  assert.deepEqual(calls, []);
+});
+
+test("a SettingsRefusal leaves without a write, a side effect, or a broadcast", async () => {
+  const calls: string[] = [];
+  const handlers = new Map<
+    string,
+    (event: IpcMainInvokeEvent, ...args: unknown[]) => Promise<SettingsUpdateResult>
+  >();
+  const register = createSettingsHandler({
+    trustedSender: () => true,
+    snapshot: async () => SETTINGS,
+    broadcast: () => {
+      calls.push("broadcast");
+    },
+    handle: (channel, listener) => {
+      handlers.set(channel, listener);
+    },
+  });
+  register("app:set-x", {
+    validate: () =>
+      new SettingsRefusal({
+        settings: SETTINGS,
+        reason: "That chord is reserved for the talk key.",
+      }),
+    save: async () => {
+      calls.push("save");
+      return { settings: SETTINGS };
+    },
+    apply: () => {
+      calls.push("apply");
+    },
+    refusal: "Could not save.",
+  });
+  const result = await handlers.get("app:set-x")?.(event());
+  assert.equal(result?.reason, "That chord is reserved for the talk key.");
+  assert.deepEqual(calls, []);
+});
+
+test("a successful write applies and broadcasts, skipping the asking window", async () => {
+  const broadcasts: object[] = [];
+  const handlers = new Map<
+    string,
+    (event: IpcMainInvokeEvent, ...args: unknown[]) => Promise<SettingsUpdateResult>
+  >();
+  const register = createSettingsHandler({
+    trustedSender: () => true,
+    snapshot: async () => SETTINGS,
+    broadcast: (settings, except) => {
+      broadcasts.push({ settings, except });
+    },
+    handle: (channel, listener) => {
+      handlers.set(channel, listener);
+    },
+  });
+  const sender = { id: "asker" };
+  register("app:set-x", {
+    validate: (value: unknown) => value === true,
+    save: async (value) => {
+      assert.equal(value, true);
+      return { settings: SETTINGS };
+    },
+    apply: async (result, value) => {
+      assert.equal(value, true);
+      assert.equal(result.settings, SETTINGS);
+    },
+    refusal: "Could not save.",
+  });
+  const invokeEvent = event(sender);
+  const result = await handlers.get("app:set-x")?.(invokeEvent, true);
+  assert.deepEqual(result, { settings: SETTINGS });
+  assert.deepEqual(broadcasts, [{ settings: SETTINGS, except: sender }]);
+});
+
+test("a filesystem failure is reported as the refusal, not a thrown error", async () => {
+  const handlers = new Map<
+    string,
+    (event: IpcMainInvokeEvent, ...args: unknown[]) => Promise<SettingsUpdateResult>
+  >();
+  const register = createSettingsHandler({
+    trustedSender: () => true,
+    snapshot: async () => SETTINGS,
+    broadcast: () => {
+      throw new Error("must not broadcast a failed write");
+    },
+    handle: (channel, listener) => {
+      handlers.set(channel, listener);
+    },
+  });
+  register("app:set-x", {
+    validate: () => true,
+    save: async () => {
+      throw new Error("EACCES");
+    },
+    refusal: "Could not save that setting on this system.",
+  });
+  const result = await handlers.get("app:set-x")?.(event());
+  assert.deepEqual(result, {
+    settings: SETTINGS,
+    reason: "Could not save that setting on this system.",
+  });
+});


### PR DESCRIPTION
## Summary

- Extract the four `main.ts` seams that own real state into deep modules: `HotkeyRegistrar` (talk > ask > stop, with one `reserve`/`reapply`), `PanelManager`, `DockPresence`, and the settings-handler factory.
- Collapse `fixtureMode`/`captureMode` into a `runMode` object with named capabilities so call sites test policy instead of re-deriving it. Observation loops, write gauntlets, and the tray stay inline.

## Test plan

- [x] `./scripts/verify.sh` — capture correctly skips all three keys; expanded and compact evidence still draw
- [x] Desktop unit tests for `runMode`, reservation pecking order, settings-handler factory, and Dock settle loop
- [ ] CI macOS evidence

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed as part of verify
- macOS Electron verification (`./scripts/verify.sh`): passed locally after rebase onto main
- Physical-notch check: not performed (main-process extract, not a surface change)


Made with [Cursor](https://cursor.com)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31853295864/artifacts/9238222351) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31853295864)

- Commit: `c1d6b9c219ed769c4087ab61857e44ccea270c82`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
