### PR TITLE
fix(panel): use painted menu bar depth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,10 @@ side, which is what the spring overshoots into and the shadow falls in. Anything
 transparent and must stay click-through, so hit regions track the shape rather
 than the window.
 
+The shape's depth is the menu bar's painted depth, not the safe-area inset. The
+inset is the region apps must avoid; macOS may paint the bar deeper than it, and
+a shape built on the inset stops short of the strip it has to pass for.
+
 The window never animates its own frame. An animated `setBounds` re-lays out
 the whole renderer on every frame, because the panel is anchored to the
 viewport's centre. Everything layered on the surface must move with `transform`

--- a/apps/desktop/native/macos/ScreenGeometry.swift
+++ b/apps/desktop/native/macos/ScreenGeometry.swift
@@ -4,6 +4,7 @@ import Foundation
 private struct ScreenGeometry: Codable {
     let displayId: UInt32
     let safeAreaTop: Double
+    let menuBarHeight: Double
     let notchWidth: Double
     let hasNotch: Bool
 }
@@ -32,6 +33,7 @@ private struct ScreenGeometryCommand {
             return ScreenGeometry(
                 displayId: displayNumber.uint32Value,
                 safeAreaTop: screen.safeAreaInsets.top,
+                menuBarHeight: screen.frame.maxY - screen.visibleFrame.maxY,
                 notchWidth: notchWidth,
                 hasNotch: hasNotch
             )

--- a/apps/desktop/src/macos-screen-geometry.ts
+++ b/apps/desktop/src/macos-screen-geometry.ts
@@ -16,6 +16,7 @@ function isNativeGeometry(value: unknown): value is NativeNotchGeometry {
   return (
     typeof geometry.displayId === "number" &&
     typeof geometry.safeAreaTop === "number" &&
+    (geometry.menuBarHeight === undefined || typeof geometry.menuBarHeight === "number") &&
     typeof geometry.notchWidth === "number" &&
     typeof geometry.hasNotch === "boolean"
   );

--- a/apps/desktop/src/panel-manager.ts
+++ b/apps/desktop/src/panel-manager.ts
@@ -301,6 +301,7 @@ export class PanelManager {
       this.#nativeScreens.set(display.id, {
         displayId: display.id,
         safeAreaTop: 38,
+        menuBarHeight: 38,
         notchWidth: 210,
         hasNotch: true,
         source: "fixture",

--- a/packages/sidecar-core/src/geometry.ts
+++ b/packages/sidecar-core/src/geometry.ts
@@ -10,11 +10,13 @@ export interface Rectangle {
 export interface DisplayGeometry {
   bounds: Rectangle;
   workArea: Rectangle;
+  scaleFactor?: number;
 }
 
 export interface NativeNotchGeometry {
   displayId: number;
   safeAreaTop: number;
+  menuBarHeight?: number;
   notchWidth: number;
   hasNotch: boolean;
   source?: "appkit" | "fixture";
@@ -91,6 +93,11 @@ export const SURFACE_MARGIN = 40;
 const peekSideWidth = CAPSULE_SIDE_WIDTH + PEEK_SIDE_GROWTH;
 const panelHeight = 520;
 
+function snapToDevicePixels(value: number, scaleFactor?: number): number {
+  if (scaleFactor === undefined) return value;
+  return Math.round(value * scaleFactor) / scaleFactor;
+}
+
 export function resolveNotchGeometry(
   display: DisplayGeometry,
   native?: NativeNotchGeometry,
@@ -98,7 +105,10 @@ export function resolveNotchGeometry(
 ): ResolvedNotchGeometry {
   const physical: ResolvedNotchGeometry = native
     ? {
-        topInset: Math.max(0, Math.round(native.safeAreaTop)),
+        topInset: snapToDevicePixels(
+          Math.max(0, native.safeAreaTop, native.menuBarHeight ?? 0),
+          display.scaleFactor,
+        ),
         housingWidth: native.hasNotch ? Math.max(0, Math.round(native.notchWidth)) : 0,
         hasNotch: native.hasNotch,
         source: native.source ?? "appkit",
@@ -110,8 +120,8 @@ export function resolveNotchGeometry(
         source: "work-area",
       };
   // A real housing is never argued with; only its absence takes the form
-  // factor's answer. The top inset is carried through untouched — the window
-  // and the stylesheet already hold every housing to the same 32px floor.
+  // factor's answer. Its resolved depth is carried through untouched — the
+  // window and the stylesheet already hold every housing to the same 32px floor.
   if (physical.hasNotch || formFactor !== PANEL_FORM_FACTOR.NOTCH) return physical;
   return {
     topInset: physical.topInset,
@@ -143,7 +153,7 @@ export function positionNotchWindow(
           display.bounds.height,
         )
       : Math.min(
-          Math.max(32, notch.topInset) + VOICE_CAPTION_MAX_HEIGHT + SURFACE_MARGIN,
+          Math.ceil(Math.max(32, notch.topInset)) + VOICE_CAPTION_MAX_HEIGHT + SURFACE_MARGIN,
           display.bounds.height,
         );
   const x = Math.round(display.bounds.x + (display.bounds.width - width) / 2);

--- a/packages/sidecar-core/tests/geometry.test.ts
+++ b/packages/sidecar-core/tests/geometry.test.ts
@@ -14,6 +14,7 @@ import { BUBBLE_LIFT } from "../src/motion-tokens";
 const notchedDisplay = {
   bounds: { x: 0, y: 0, width: 1512, height: 982 },
   workArea: { x: 0, y: 38, width: 1512, height: 944 },
+  scaleFactor: 2,
 };
 
 /** The widest shape a compact window ever draws, before spring overshoot. */
@@ -24,6 +25,7 @@ test("anchors the compact window to the physical top edge", () => {
   const result = positionNotchWindow(notchedDisplay, "compact", {
     displayId: 1,
     safeAreaTop: 38,
+    menuBarHeight: 38,
     notchWidth: 210,
     hasNotch: true,
   });
@@ -48,6 +50,7 @@ test("a compact window holds the peek, the overshoot, and the shadow", () => {
   const result = positionNotchWindow(notchedDisplay, "compact", {
     displayId: 1,
     safeAreaTop: 38,
+    menuBarHeight: 38,
     notchWidth: 210,
     hasNotch: true,
   });
@@ -87,7 +90,7 @@ test("the notch form gives a display without a housing the simulated one", () =>
     plainDisplay,
     "compact",
     // The AppKit helper answered for this display: no housing, no inset.
-    { displayId: 2, safeAreaTop: 0, notchWidth: 0, hasNotch: false },
+    { displayId: 2, safeAreaTop: 0, menuBarHeight: 0, notchWidth: 0, hasNotch: false },
     PANEL_FORM_FACTOR.NOTCH,
   );
 
@@ -107,7 +110,13 @@ test("the notch form never argues with a real housing", () => {
   const result = positionNotchWindow(
     notchedDisplay,
     "compact",
-    { displayId: 1, safeAreaTop: 38, notchWidth: 210, hasNotch: true },
+    {
+      displayId: 1,
+      safeAreaTop: 38,
+      menuBarHeight: 38,
+      notchWidth: 210,
+      hasNotch: true,
+    },
     PANEL_FORM_FACTOR.NOTCH,
   );
 
@@ -152,6 +161,7 @@ test("an expanded bubble window holds the lifted panel's shadow", () => {
     positionNotchWindow(notchedDisplay, "expanded", {
       displayId: 1,
       safeAreaTop: 38,
+      menuBarHeight: 38,
       notchWidth: 210,
       hasNotch: true,
     }).height,
@@ -163,6 +173,7 @@ test("keeps the expanded panel attached to the same display edge", () => {
   const result = positionNotchWindow(notchedDisplay, "expanded", {
     displayId: 1,
     safeAreaTop: 38,
+    menuBarHeight: 38,
     notchWidth: 210,
     hasNotch: true,
   });
@@ -182,4 +193,57 @@ test("never grows a window past the display it is on", () => {
   assert.equal(positionNotchWindow(narrow, "compact").width, 240);
   assert.equal(positionNotchWindow(narrow, "expanded").width, 240);
   assert.equal(positionNotchWindow(narrow, "expanded").height, 480);
+});
+
+test("uses the painted menu bar when it is deeper than the safe area", () => {
+  const reportingMachine = positionNotchWindow(notchedDisplay, "compact", {
+    displayId: 1,
+    safeAreaTop: 33,
+    menuBarHeight: 34,
+    notchWidth: 185,
+    hasNotch: true,
+  });
+  const macBookPro14 = positionNotchWindow(notchedDisplay, "compact", {
+    displayId: 1,
+    safeAreaTop: 34,
+    menuBarHeight: 37,
+    notchWidth: 210,
+    hasNotch: true,
+  });
+
+  assert.equal(reportingMachine.notch.topInset, 34);
+  assert.equal(reportingMachine.height, 34 + VOICE_CAPTION_MAX_HEIGHT + SURFACE_MARGIN);
+  assert.equal(macBookPro14.notch.topInset, 37);
+});
+
+test("keeps the safe-area depth when the menu bar reading is absent", () => {
+  const hiddenMenuBar = positionNotchWindow(notchedDisplay, "compact", {
+    displayId: 1,
+    safeAreaTop: 34,
+    menuBarHeight: 0,
+    notchWidth: 210,
+    hasNotch: true,
+  });
+  const olderHelper = positionNotchWindow(notchedDisplay, "compact", {
+    displayId: 1,
+    safeAreaTop: 34,
+    notchWidth: 210,
+    hasNotch: true,
+  });
+
+  assert.equal(hiddenMenuBar.notch.topInset, 34);
+  assert.equal(olderHelper.notch.topInset, 34);
+});
+
+test("snaps fractional depths to device pixels and ceils the window height", () => {
+  const result = positionNotchWindow(notchedDisplay, "compact", {
+    displayId: 1,
+    safeAreaTop: 33,
+    menuBarHeight: 33.7,
+    notchWidth: 185,
+    hasNotch: true,
+  });
+
+  assert.equal(result.notch.topInset, 33.5);
+  assert.equal(result.height, 34 + VOICE_CAPTION_MAX_HEIGHT + SURFACE_MARGIN);
 });


### PR DESCRIPTION
## Summary

- Measure the painted macOS menu bar depth and use the deeper of it or the safe-area inset so Luke's surface fully meets the top strip.
- Snap fractional depths to device pixels, preserve older-helper fallbacks, and cover the geometry with regression tests and the panel-motion contract.

## Evidence

- Platform-independent checks: `passed via ./scripts/verify.sh` (34 harness tests and 691 sidecar-core tests)
- macOS Electron verification (`./scripts/verify.sh`): `passed`

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31854102158/artifacts/9238486261) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31854102158)

- Commit: `dcdb5938c71d2bd8848ec6740b4500bcca2a3907`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `synthetic 1512 x 982 fixture; physical device not recorded`

## Notes

- Blockers or follow-up verification: Physical-notch confirmation remains pending.


