### PR TITLE
fix(sessions): observe local sessions accurately

### DIFF
--- a/apps/desktop/src/claude-code-adapter.ts
+++ b/apps/desktop/src/claude-code-adapter.ts
@@ -20,6 +20,7 @@ import {
 } from "@sidecar/core";
 import {
   discoverSessionFiles,
+  existingWorkspaceDirectory,
   LOCAL_ADAPTER_DEFAULTS,
   readDirectory,
   readHead,
@@ -322,16 +323,19 @@ function parseClaudeSessionTail(tail: string): ParsedClaudeSessionTail {
   return parsed;
 }
 
-/** Recovers only the generated title from a session too long to hold one in its tail. */
-function titleFromHead(head: string): string | undefined {
-  let title: string | undefined;
+/** Recovers only identity fields from a session too long to hold them in its tail. */
+function identityFromHead(head: string): Pick<ParsedClaudeSessionTail, "aiTitle" | "cwd"> {
+  const identity: Pick<ParsedClaudeSessionTail, "aiTitle" | "cwd"> = {};
   for (const line of head.split(/\r?\n/)) {
     const record = recordFromJsonLine(line);
+    if (!record) continue;
+    identity.cwd = cwdFromRecord(record) ?? identity.cwd;
     if (record?.type === CLAUDE_RECORD_TYPE.AI_TITLE) {
-      title = oneLine(text(record.aiTitle), maximumSessionTitleLength) ?? title;
+      identity.aiTitle =
+        oneLine(text(record.aiTitle), maximumSessionTitleLength) ?? identity.aiTitle;
     }
   }
-  return title;
+  return identity;
 }
 
 /**
@@ -475,9 +479,12 @@ export class ClaudeCodeSessionAdapter implements SessionProviderAdapter {
       if (now - candidate.mtimeMs > this.#maximumSessionAgeMs) continue;
       const tail = await readTail(candidate.filePath, this.#readTailBytes);
       const parsed = parseClaudeSessionTail(tail);
-      if (!parsed.aiTitle) {
-        parsed.aiTitle = titleFromHead(await readHead(candidate.filePath, this.#readHeadBytes));
+      if (!parsed.aiTitle || !parsed.cwd) {
+        const identity = identityFromHead(await readHead(candidate.filePath, this.#readHeadBytes));
+        parsed.aiTitle ??= identity.aiTitle;
+        parsed.cwd ??= identity.cwd;
       }
+      if (!(await existingWorkspaceDirectory(parsed.cwd))) continue;
       const observation = observationFromSessionFile(
         candidate,
         parsed,

--- a/apps/desktop/src/codex-adapter.ts
+++ b/apps/desktop/src/codex-adapter.ts
@@ -17,7 +17,13 @@ import {
   text,
   wholeNumber,
 } from "@sidecar/core";
-import { readTail, readTextFile, uniquePaths, workspaceLabel } from "./local-session-adapter";
+import {
+  existingWorkspaceDirectory,
+  readTail,
+  readTextFile,
+  uniquePaths,
+  workspaceLabel,
+} from "./local-session-adapter";
 import {
   canIgnoreSqliteError,
   defaultSqliteModule,
@@ -459,10 +465,20 @@ export class CodexSessionAdapter implements SessionProviderAdapter {
         database.close();
       }
 
+      const existingRows = (
+        await Promise.all(
+          rows.map(async (row) =>
+            (await existingWorkspaceDirectory(textFromRow(row, CODEX_THREAD_COLUMN.CWD)))
+              ? row
+              : undefined,
+          ),
+        )
+      ).filter((row): row is CodexThreadRow => row !== undefined);
+
       // The rollout read happens with the database already closed, so a slow
       // disk never holds a read lock on state Codex itself is writing.
-      const rollouts = await this.#rollouts(rows);
-      return rows
+      const rollouts = await this.#rollouts(existingRows);
+      return existingRows
         .map((row) =>
           observationFromThreadRow(
             row,

--- a/apps/desktop/src/cursor-local-adapter.ts
+++ b/apps/desktop/src/cursor-local-adapter.ts
@@ -54,14 +54,31 @@ const CURSOR_WORKSPACE_FIELD = {
 } as const;
 
 const CURSOR_RECORD_FIELD = {
+  MESSAGE: "message",
   ROLE: "role",
   STATUS: "status",
+  TYPE: "type",
+} as const;
+
+const CURSOR_MESSAGE_FIELD = {
+  CONTENT: "content",
+} as const;
+
+const CURSOR_CONTENT_BLOCK_FIELD = {
   TYPE: "type",
 } as const;
 
 /** The one record type Luke reads: Cursor marking the end of a turn. */
 const CURSOR_RECORD_TYPE = {
   TURN_ENDED: "turn_ended",
+} as const;
+
+/** Block kinds by which Cursor records an assistant asking a tool to continue. */
+const CURSOR_CONTENT_BLOCK = {
+  TOOL_CALL: "tool_call",
+  TOOL_CALL_HYPHENATED: "tool-call",
+  TOOL_USE: "tool_use",
+  TOOL_USE_HYPHENATED: "tool-use",
 } as const;
 
 /**
@@ -81,6 +98,8 @@ const CURSOR_ROLE = {
 const CURSOR_LOCAL_ADAPTER_DEFAULTS = {
   MAXIMUM_PROJECT_DIRECTORIES: 200,
   MAXIMUM_SESSION_FILES: 40,
+  MAXIMUM_WORKSPACE_RESOLUTION_DIRECTORY_READS: 128,
+  MAXIMUM_WORKSPACE_RESOLUTION_FRONTIER_WIDTH: 32,
 } as const;
 
 export interface CursorLocalAdapterOptions {
@@ -145,6 +164,7 @@ function folderPathFromWorkspaceRecord(source: string): string | undefined {
 class CursorWorkspaceLabels {
   readonly #directory: string;
   readonly #labelsByProjectName = new Map<string, string | undefined>();
+  readonly #filesystemLabelsByProjectDirectoryName = new Map<string, string | undefined>();
   readonly #readWorkspaceRecords = new Set<string>();
 
   constructor(directory: string) {
@@ -158,26 +178,36 @@ class CursorWorkspaceLabels {
    */
   async resolve(projectDirectoryNames: readonly string[]): Promise<void> {
     if (
-      projectDirectoryNames.every((name) =>
-        this.#labelsByProjectName.has(canonicalProjectName(name)),
+      projectDirectoryNames.some(
+        (name) => !this.#labelsByProjectName.has(canonicalProjectName(name)),
       )
     ) {
-      return;
+      for (const entry of await readDirectory(this.#directory)) {
+        if (this.#readWorkspaceRecords.has(entry.name)) continue;
+        this.#readWorkspaceRecords.add(entry.name);
+        const record = await readTextFile(
+          path.join(this.#directory, entry.name, CURSOR_WORKSPACE_FILE),
+        );
+        const folderPath = record ? folderPathFromWorkspaceRecord(record) : undefined;
+        if (folderPath) this.#record(folderPath);
+      }
     }
-    for (const entry of await readDirectory(this.#directory)) {
-      if (this.#readWorkspaceRecords.has(entry.name)) continue;
-      this.#readWorkspaceRecords.add(entry.name);
-      const record = await readTextFile(
-        path.join(this.#directory, entry.name, CURSOR_WORKSPACE_FILE),
+
+    for (const projectDirectoryName of new Set(projectDirectoryNames)) {
+      if (this.#labelsByProjectName.get(canonicalProjectName(projectDirectoryName))) continue;
+      if (this.#filesystemLabelsByProjectDirectoryName.has(projectDirectoryName)) continue;
+      const folderPath = await resolveProjectDirectory(projectDirectoryName);
+      this.#filesystemLabelsByProjectDirectoryName.set(
+        projectDirectoryName,
+        folderPath ? workspaceLabel(folderPath) : undefined,
       );
-      const folderPath = record ? folderPathFromWorkspaceRecord(record) : undefined;
-      if (folderPath) this.#record(folderPath);
     }
   }
 
   label(projectDirectoryName: string): string {
     return (
       this.#labelsByProjectName.get(canonicalProjectName(projectDirectoryName)) ??
+      this.#filesystemLabelsByProjectDirectoryName.get(projectDirectoryName) ??
       UNKNOWN_WORKSPACE_LABEL
     );
   }
@@ -195,6 +225,68 @@ class CursorWorkspaceLabels {
       this.#labelsByProjectName.set(projectName, undefined);
     }
   }
+}
+
+interface ProjectPathFrontierEntry {
+  directoryPath: string;
+  nextSegmentIndex: number;
+}
+
+/**
+ * Recovers a project path only when Cursor's flattened directory name has one
+ * interpretation that exists on disk. A hyphen may have been either a path
+ * separator or part of a directory name, so every surviving interpretation is
+ * kept until it fails against the real directory tree. Bounds turn an
+ * unusually ambiguous name into no label rather than unbounded filesystem work.
+ */
+async function resolveProjectDirectory(projectDirectoryName: string): Promise<string | undefined> {
+  const segments = projectDirectoryName.split("-").filter(Boolean);
+  if (segments.length === 0) return undefined;
+
+  const frontier: ProjectPathFrontierEntry[] = [
+    { directoryPath: path.parse(path.resolve(path.sep)).root, nextSegmentIndex: 0 },
+  ];
+  const queued = new Set(
+    frontier.map((entry) => `${entry.directoryPath}\0${entry.nextSegmentIndex}`),
+  );
+  const resolvedPaths = new Set<string>();
+  let directoryReads = 0;
+
+  while (
+    frontier.length > 0 &&
+    directoryReads < CURSOR_LOCAL_ADAPTER_DEFAULTS.MAXIMUM_WORKSPACE_RESOLUTION_DIRECTORY_READS
+  ) {
+    const current = frontier.shift();
+    if (!current) break;
+    const entries = await readDirectory(current.directoryPath);
+    directoryReads += 1;
+    const entriesByName = new Map(entries.map((entry) => [entry.name, entry]));
+
+    for (let end = current.nextSegmentIndex + 1; end <= segments.length; end += 1) {
+      const name = segments.slice(current.nextSegmentIndex, end).join("-");
+      const entry = entriesByName.get(name);
+      if (!entry || (!entry.isDirectory() && !entry.isSymbolicLink())) continue;
+      const candidatePath = path.join(current.directoryPath, name);
+      if (end === segments.length) {
+        const stats = await fileStats(candidatePath);
+        if (stats?.isDirectory()) resolvedPaths.add(candidatePath);
+        if (resolvedPaths.size > 1) return undefined;
+        continue;
+      }
+      const queueKey = `${candidatePath}\0${end}`;
+      if (queued.has(queueKey)) continue;
+      queued.add(queueKey);
+      frontier.push({ directoryPath: candidatePath, nextSegmentIndex: end });
+      if (
+        frontier.length > CURSOR_LOCAL_ADAPTER_DEFAULTS.MAXIMUM_WORKSPACE_RESOLUTION_FRONTIER_WIDTH
+      ) {
+        return undefined;
+      }
+    }
+  }
+
+  if (frontier.length > 0 || resolvedPaths.size !== 1) return undefined;
+  return resolvedPaths.values().next().value;
 }
 
 async function transcriptsIn(
@@ -235,19 +327,36 @@ function isMessageRecord(record: Record<string, unknown>): boolean {
   return Object.values(CURSOR_ROLE).some((knownRole) => knownRole === role);
 }
 
+function messageHasToolCall(record: Record<string, unknown>): boolean {
+  const message = record[CURSOR_RECORD_FIELD.MESSAGE];
+  if (message === null || typeof message !== "object" || Array.isArray(message)) return false;
+  const content = (message as Record<string, unknown>)[CURSOR_MESSAGE_FIELD.CONTENT];
+  if (!Array.isArray(content)) return false;
+  const toolCallKinds = Object.values(CURSOR_CONTENT_BLOCK);
+  return content.some((block) => {
+    if (block === null || typeof block !== "object" || Array.isArray(block)) return false;
+    return toolCallKinds.some(
+      (kind) => kind === (block as Record<string, unknown>)[CURSOR_CONTENT_BLOCK_FIELD.TYPE],
+    );
+  });
+}
+
 /**
- * How the newest turn ended, or nothing while one is still open. Cursor marks
- * the end of a turn explicitly, so an open turn is read from the absence of
- * that mark rather than inferred from what the assistant last said — which is
- * transcript content, and is not read here at all. A record this build does not
- * know is passed over rather than taken for either.
+ * How the newest turn ended, or nothing while one is still open. Older Cursor
+ * builds mark the end explicitly. Current builds do not, so only the kinds of
+ * blocks in the newest message are inspected: an assistant tool call means the
+ * turn will continue, an assistant without one has settled, and a user message
+ * is waiting for the assistant. No content text is read. A record this build
+ * does not know is passed over rather than taken for either.
  */
 function closedTurn(tail: string): { failed: boolean } | undefined {
   for (const record of tailRecords(tail).toReversed()) {
     if (record[CURSOR_RECORD_FIELD.TYPE] === CURSOR_RECORD_TYPE.TURN_ENDED) {
       return { failed: record[CURSOR_RECORD_FIELD.STATUS] === CURSOR_TURN_STATUS.ERROR };
     }
-    if (isMessageRecord(record)) return undefined;
+    if (!isMessageRecord(record)) continue;
+    if (record[CURSOR_RECORD_FIELD.ROLE] === CURSOR_ROLE.USER) return undefined;
+    return messageHasToolCall(record) ? undefined : { failed: false };
   }
   return undefined;
 }
@@ -302,7 +411,7 @@ function defaultWorkspaceStorageDirectory(): string {
 
 /**
  * Observes the Cursor sessions that run on this machine, from the transcripts
- * Cursor already writes for itself. It reads no message content, needs no
+ * Cursor already writes for itself. It reads no message text, needs no
  * credential, and reports nothing that Cursor has not written down.
  */
 export class CursorLocalSessionAdapter implements SessionProviderAdapter {

--- a/apps/desktop/src/cursor-local-adapter.ts
+++ b/apps/desktop/src/cursor-local-adapter.ts
@@ -15,6 +15,7 @@ import { CURSOR_PROVIDER } from "./cursor-adapter";
 import {
   type DirectoryEntry,
   discoverSessionFiles,
+  existingWorkspaceDirectory,
   fileStats,
   LOCAL_ADAPTER_DEFAULTS,
   readDirectory,
@@ -196,8 +197,7 @@ class CursorWorkspaceLabels {
       if (this.#resolvedFoldersByProjectDirectoryName.has(projectDirectoryName)) {
         const cachedPath = this.#resolvedFoldersByProjectDirectoryName.get(projectDirectoryName);
         if (!cachedPath) continue;
-        const stats = await fileStats(cachedPath);
-        if (stats?.isDirectory()) continue;
+        if (await existingWorkspaceDirectory(cachedPath)) continue;
         this.#resolvedFoldersByProjectDirectoryName.set(projectDirectoryName, undefined);
         continue;
       }
@@ -205,10 +205,8 @@ class CursorWorkspaceLabels {
       const recordedPath = this.#folderPathsByProjectName.get(
         canonicalProjectName(projectDirectoryName),
       );
-      const recordedStats = recordedPath ? await fileStats(recordedPath) : undefined;
-      const folderPath = recordedStats?.isDirectory()
-        ? recordedPath
-        : await resolveProjectDirectory(projectDirectoryName);
+      const recordedFolder = await existingWorkspaceDirectory(recordedPath);
+      const folderPath = recordedFolder ?? (await resolveProjectDirectory(projectDirectoryName));
       this.#resolvedFoldersByProjectDirectoryName.set(projectDirectoryName, folderPath);
     }
   }
@@ -273,8 +271,8 @@ async function resolveProjectDirectory(projectDirectoryName: string): Promise<st
       if (!entry || (!entry.isDirectory() && !entry.isSymbolicLink())) continue;
       const candidatePath = path.join(current.directoryPath, name);
       if (end === segments.length) {
-        const stats = await fileStats(candidatePath);
-        if (stats?.isDirectory()) resolvedPaths.add(candidatePath);
+        const resolvedDirectory = await existingWorkspaceDirectory(candidatePath);
+        if (resolvedDirectory) resolvedPaths.add(resolvedDirectory);
         if (resolvedPaths.size > 1) return undefined;
         continue;
       }

--- a/apps/desktop/src/cursor-local-adapter.ts
+++ b/apps/desktop/src/cursor-local-adapter.ts
@@ -10,7 +10,6 @@ import {
   type SessionDetail,
   type SessionProviderAdapter,
   type SessionStatus,
-  UNKNOWN_WORKSPACE_LABEL,
 } from "@sidecar/core";
 import { CURSOR_PROVIDER } from "./cursor-adapter";
 import {
@@ -163,8 +162,8 @@ function folderPathFromWorkspaceRecord(source: string): string | undefined {
  */
 class CursorWorkspaceLabels {
   readonly #directory: string;
-  readonly #labelsByProjectName = new Map<string, string | undefined>();
-  readonly #filesystemLabelsByProjectDirectoryName = new Map<string, string | undefined>();
+  readonly #folderPathsByProjectName = new Map<string, string | undefined>();
+  readonly #resolvedFoldersByProjectDirectoryName = new Map<string, string | undefined>();
   readonly #readWorkspaceRecords = new Set<string>();
 
   constructor(directory: string) {
@@ -172,14 +171,14 @@ class CursorWorkspaceLabels {
   }
 
   /**
-   * Reads Cursor's workspace records for any project this pass cannot already
-   * name. A record is read once; a project that stays unnamed is looked for
-   * again, because the folder it belongs to may be opened later.
+   * Reads each Cursor workspace record once, then resolves each project once.
+   * A resolved folder is still checked on every pass so deleting or archiving
+   * its workspace withdraws the sessions that belonged to it.
    */
   async resolve(projectDirectoryNames: readonly string[]): Promise<void> {
     if (
       projectDirectoryNames.some(
-        (name) => !this.#labelsByProjectName.has(canonicalProjectName(name)),
+        (name) => !this.#folderPathsByProjectName.has(canonicalProjectName(name)),
       )
     ) {
       for (const entry of await readDirectory(this.#directory)) {
@@ -194,35 +193,41 @@ class CursorWorkspaceLabels {
     }
 
     for (const projectDirectoryName of new Set(projectDirectoryNames)) {
-      if (this.#labelsByProjectName.get(canonicalProjectName(projectDirectoryName))) continue;
-      if (this.#filesystemLabelsByProjectDirectoryName.has(projectDirectoryName)) continue;
-      const folderPath = await resolveProjectDirectory(projectDirectoryName);
-      this.#filesystemLabelsByProjectDirectoryName.set(
-        projectDirectoryName,
-        folderPath ? workspaceLabel(folderPath) : undefined,
+      if (this.#resolvedFoldersByProjectDirectoryName.has(projectDirectoryName)) {
+        const cachedPath = this.#resolvedFoldersByProjectDirectoryName.get(projectDirectoryName);
+        if (!cachedPath) continue;
+        const stats = await fileStats(cachedPath);
+        if (stats?.isDirectory()) continue;
+        this.#resolvedFoldersByProjectDirectoryName.set(projectDirectoryName, undefined);
+        continue;
+      }
+
+      const recordedPath = this.#folderPathsByProjectName.get(
+        canonicalProjectName(projectDirectoryName),
       );
+      const recordedStats = recordedPath ? await fileStats(recordedPath) : undefined;
+      const folderPath = recordedStats?.isDirectory()
+        ? recordedPath
+        : await resolveProjectDirectory(projectDirectoryName);
+      this.#resolvedFoldersByProjectDirectoryName.set(projectDirectoryName, folderPath);
     }
   }
 
-  label(projectDirectoryName: string): string {
-    return (
-      this.#labelsByProjectName.get(canonicalProjectName(projectDirectoryName)) ??
-      this.#filesystemLabelsByProjectDirectoryName.get(projectDirectoryName) ??
-      UNKNOWN_WORKSPACE_LABEL
-    );
+  label(projectDirectoryName: string): string | undefined {
+    const folderPath = this.#resolvedFoldersByProjectDirectoryName.get(projectDirectoryName);
+    return folderPath ? workspaceLabel(folderPath) : undefined;
   }
 
   #record(folderPath: string): void {
     const projectName = canonicalProjectName(folderPath);
-    const label = workspaceLabel(folderPath);
-    if (!this.#labelsByProjectName.has(projectName)) {
-      this.#labelsByProjectName.set(projectName, label);
+    if (!this.#folderPathsByProjectName.has(projectName)) {
+      this.#folderPathsByProjectName.set(projectName, folderPath);
       return;
     }
-    // Two folders can reduce to one project name. When they disagree about
-    // what to call it, Luke names neither.
-    if (this.#labelsByProjectName.get(projectName) !== label) {
-      this.#labelsByProjectName.set(projectName, undefined);
+    // Two folders can reduce to one project name. Luke reports neither rather
+    // than choosing which real folder the transcript belonged to.
+    if (this.#folderPathsByProjectName.get(projectName) !== folderPath) {
+      this.#folderPathsByProjectName.set(projectName, undefined);
     }
   }
 }
@@ -472,7 +477,12 @@ export class CursorLocalSessionAdapter implements SessionProviderAdapter {
     const observations = new Map<string, ProviderSessionObservation>();
     for (const candidate of candidates) {
       if (observations.has(candidate.providerSessionId)) continue;
-      observations.set(candidate.providerSessionId, await this.#observationFor(candidate, now));
+      const label = this.#workspaceLabels.label(candidate.projectDirectoryName);
+      if (!label) continue;
+      observations.set(
+        candidate.providerSessionId,
+        await this.#observationFor(candidate, label, now),
+      );
     }
     return [...observations.values()];
   }
@@ -485,9 +495,9 @@ export class CursorLocalSessionAdapter implements SessionProviderAdapter {
    */
   async #observationFor(
     candidate: CursorTranscriptCandidate,
+    label: string,
     now: number,
   ): Promise<ProviderSessionObservation> {
-    const label = this.#workspaceLabels.label(candidate.projectDirectoryName);
     const tail = await readTail(candidate.filePath, this.#readTailBytes);
     const status = statusFromTurn(
       closedTurn(tail),

--- a/apps/desktop/src/cursor-local-adapter.ts
+++ b/apps/desktop/src/cursor-local-adapter.ts
@@ -172,9 +172,9 @@ class CursorWorkspaceLabels {
   }
 
   /**
-   * Reads each Cursor workspace record once, then resolves each project once.
-   * A resolved folder is still checked on every pass so deleting or archiving
-   * its workspace withdraws the sessions that belonged to it.
+   * Reads each Cursor workspace record once, then keeps only successful
+   * project resolutions. A missing folder is retried on later passes so a
+   * workspace record or directory that appears again restores its sessions.
    */
   async resolve(projectDirectoryNames: readonly string[]): Promise<void> {
     if (
@@ -194,20 +194,20 @@ class CursorWorkspaceLabels {
     }
 
     for (const projectDirectoryName of new Set(projectDirectoryNames)) {
-      if (this.#resolvedFoldersByProjectDirectoryName.has(projectDirectoryName)) {
-        const cachedPath = this.#resolvedFoldersByProjectDirectoryName.get(projectDirectoryName);
-        if (!cachedPath) continue;
-        if (await existingWorkspaceDirectory(cachedPath)) continue;
-        this.#resolvedFoldersByProjectDirectoryName.set(projectDirectoryName, undefined);
-        continue;
-      }
+      const cachedPath = this.#resolvedFoldersByProjectDirectoryName.get(projectDirectoryName);
+      if (cachedPath && (await existingWorkspaceDirectory(cachedPath))) continue;
+      this.#resolvedFoldersByProjectDirectoryName.delete(projectDirectoryName);
 
-      const recordedPath = this.#folderPathsByProjectName.get(
-        canonicalProjectName(projectDirectoryName),
-      );
+      const projectName = canonicalProjectName(projectDirectoryName);
+      const hasRecordedPath = this.#folderPathsByProjectName.has(projectName);
+      const recordedPath = this.#folderPathsByProjectName.get(projectName);
       const recordedFolder = await existingWorkspaceDirectory(recordedPath);
-      const folderPath = recordedFolder ?? (await resolveProjectDirectory(projectDirectoryName));
-      this.#resolvedFoldersByProjectDirectoryName.set(projectDirectoryName, folderPath);
+      const folderPath = hasRecordedPath
+        ? recordedFolder
+        : await resolveProjectDirectory(projectDirectoryName);
+      if (folderPath) {
+        this.#resolvedFoldersByProjectDirectoryName.set(projectDirectoryName, folderPath);
+      }
     }
   }
 

--- a/apps/desktop/src/local-session-adapter.ts
+++ b/apps/desktop/src/local-session-adapter.ts
@@ -83,6 +83,20 @@ export async function fileStats(filePath: string): Promise<Stats | undefined> {
   }
 }
 
+/**
+ * A local session belongs on the surface only while the directory it ran in
+ * still exists. Providers retain session metadata after a workspace is
+ * deleted, so trusting that stored path would keep an orphaned row forever.
+ */
+export async function existingWorkspaceDirectory(
+  directoryPath: string | undefined,
+): Promise<string | undefined> {
+  const normalized = directoryPath?.trim();
+  if (!normalized) return undefined;
+  const stats = await fileStats(normalized);
+  return stats?.isDirectory() ? normalized : undefined;
+}
+
 /** `lstat`, so a link out of a provider directory is never followed. */
 export async function statDirectoryEntry(
   directoryPath: string,

--- a/apps/desktop/src/opencode-adapter.ts
+++ b/apps/desktop/src/opencode-adapter.ts
@@ -20,6 +20,7 @@ import {
 } from "@sidecar/core";
 import {
   discoverSessionFiles,
+  existingWorkspaceDirectory,
   readDirectory,
   readTextFile,
   type SessionFileCandidate,
@@ -470,7 +471,14 @@ export class OpenCodeSessionAdapter implements SessionProviderAdapter {
       // A database whose schema was unusable answers nothing; the next
       // candidate, or the legacy files, may still answer.
       if (snapshots === undefined) continue;
-      return snapshots.map((snapshot) =>
+      const existingSnapshots = (
+        await Promise.all(
+          snapshots.map(async (snapshot) =>
+            (await existingWorkspaceDirectory(snapshot.directory)) ? snapshot : undefined,
+          ),
+        )
+      ).filter((snapshot): snapshot is OpenCodeSessionSnapshot => snapshot !== undefined);
+      return existingSnapshots.map((snapshot) =>
         observationFromSnapshot(snapshot, now, this.#activeSessionFreshnessMs),
       );
     }
@@ -604,6 +612,7 @@ export class OpenCodeSessionAdapter implements SessionProviderAdapter {
           wholeNumber(time?.created) ?? 0,
         ),
       };
+      if (!(await existingWorkspaceDirectory(snapshot.directory))) continue;
       // Read for every reported session, not a capped few: a session without
       // its turn would default to working on freshness alone. Each read is one
       // directory listing and one small file, against the same session cap the

--- a/apps/desktop/tests/claude-code-adapter.test.ts
+++ b/apps/desktop/tests/claude-code-adapter.test.ts
@@ -28,6 +28,12 @@ async function temporaryClaudeHome(t: TestContext): Promise<string> {
   return directory;
 }
 
+async function testWorkspaceDirectory(root: string, directory: string): Promise<string> {
+  const workspace = path.join(root, "test-workspaces", path.basename(directory));
+  await fs.mkdir(workspace, { recursive: true });
+  return workspace;
+}
+
 async function writeSessionFile(
   claudeHome: string,
   projectDirectoryName: string,
@@ -37,8 +43,17 @@ async function writeSessionFile(
 ): Promise<void> {
   const projectDirectory = path.join(claudeHome, CLAUDE_PROJECTS_DIRECTORY, projectDirectoryName);
   await fs.mkdir(projectDirectory, { recursive: true });
+  const materializedRecords = await Promise.all(
+    records.map(async (record) => {
+      const cwd = typeof record.cwd === "string" ? record.cwd : undefined;
+      return cwd ? { ...record, cwd: await testWorkspaceDirectory(claudeHome, cwd) } : record;
+    }),
+  );
   const filePath = path.join(projectDirectory, `${sessionFileName}.jsonl`);
-  await fs.writeFile(filePath, `${records.map((record) => JSON.stringify(record)).join("\n")}\n`);
+  await fs.writeFile(
+    filePath,
+    `${materializedRecords.map((record) => JSON.stringify(record)).join("\n")}\n`,
+  );
   await fs.utimes(filePath, mtimeMs / 1000, mtimeMs / 1000);
 }
 
@@ -847,4 +862,26 @@ test("falls back to the file's date when the tail carries no timestamp", async (
   const [observation] = await adapter.observe();
 
   assert.equal(observation?.observedAt, TEST_TIME - 5_000);
+});
+
+test("withdraws a Claude Code session when its workspace is deleted", async (t) => {
+  const claudeHome = await temporaryClaudeHome(t);
+  await writeSessionFile(
+    claudeHome,
+    "-Users-test-deleted",
+    "deleted-workspace",
+    [
+      {
+        type: TEST_CLAUDE_EVENT_TYPE.USER,
+        cwd: "/Users/test/deleted",
+        timestamp: "2026-08-11T23:44:55.000Z",
+      },
+    ],
+    TEST_TIME - 1_000,
+  );
+  const adapter = new ClaudeCodeSessionAdapter({ claudeHome, now: () => TEST_TIME });
+
+  assert.equal((await adapter.observe()).length, 1);
+  await fs.rm(path.join(claudeHome, "test-workspaces", "deleted"), { recursive: true });
+  assert.deepEqual(await adapter.observe(), []);
 });

--- a/apps/desktop/tests/codex-adapter.test.ts
+++ b/apps/desktop/tests/codex-adapter.test.ts
@@ -51,6 +51,12 @@ async function temporaryCodexHome(t: TestContext): Promise<string> {
   return directory;
 }
 
+async function testWorkspaceDirectory(root: string, directory: string): Promise<string> {
+  const workspace = path.join(root, "test-workspaces", path.basename(directory));
+  await fs.mkdir(workspace, { recursive: true });
+  return workspace;
+}
+
 function writeThread(database: DatabaseSync, thread: TestThread): void {
   database
     .prepare(`
@@ -101,6 +107,12 @@ function writeThread(database: DatabaseSync, thread: TestThread): void {
 
 async function writeCodexState(codexHome: string, threads: readonly TestThread[]): Promise<void> {
   await fs.mkdir(codexHome, { recursive: true });
+  const materializedThreads = await Promise.all(
+    threads.map(async (thread) => ({
+      ...thread,
+      cwd: await testWorkspaceDirectory(codexHome, thread.cwd),
+    })),
+  );
   const database = new DatabaseSync(path.join(codexHome, CODEX_STATE_DATABASE), {});
   try {
     database.exec(`
@@ -126,7 +138,7 @@ async function writeCodexState(codexHome: string, threads: readonly TestThread[]
         reasoning_effort TEXT
       )
     `);
-    for (const thread of threads) writeThread(database, thread);
+    for (const thread of materializedThreads) writeThread(database, thread);
   } finally {
     database.close();
   }
@@ -647,5 +659,21 @@ test("returns an empty snapshot when node sqlite is unavailable", async (t) => {
     },
   });
 
+  assert.deepEqual(await adapter.observe(), []);
+});
+
+test("withdraws a Codex thread when its workspace is deleted", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeCodexState(codexHome, [
+    {
+      id: "codex-deleted-workspace",
+      cwd: "/Users/test/deleted",
+      observedAt: TEST_TIME - 1_000,
+    },
+  ]);
+  const adapter = new CodexSessionAdapter({ codexHome, now: () => TEST_TIME });
+
+  assert.equal((await adapter.observe()).length, 1);
+  await fs.rm(path.join(codexHome, "test-workspaces", "deleted"), { recursive: true });
   assert.deepEqual(await adapter.observe(), []);
 });

--- a/apps/desktop/tests/cursor-local-adapter.test.ts
+++ b/apps/desktop/tests/cursor-local-adapter.test.ts
@@ -30,8 +30,13 @@ const TEST_TURN_STATUS = {
 } as const;
 
 const TEST_CONTENT_TYPE = {
+  CUSTOM: "custom_block",
   TEXT: "text",
+  THINKING: "thinking",
+  TOOL_CALL: "tool_call",
+  TOOL_CALL_HYPHENATED: "tool-call",
   TOOL_USE: "tool_use",
+  TOOL_USE_HYPHENATED: "tool-use",
 } as const;
 
 interface CursorState {
@@ -55,7 +60,9 @@ function turnEndedRecord(status: string): Record<string, unknown> {
 }
 
 async function temporaryCursorState(t: TestContext): Promise<CursorState> {
-  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-cursor-local-"));
+  const directory = await fs.realpath(
+    await fs.mkdtemp(path.join(os.tmpdir(), "luke-cursor-local-")),
+  );
   t.after(async () => {
     await fs.rm(directory, { recursive: true, force: true });
   });
@@ -112,6 +119,10 @@ async function writeSubagentTranscript(
 
 function projectDirectory(state: CursorState, projectDirectoryName: string): string {
   return path.join(state.cursorHome, CURSOR_PROJECTS_DIRECTORY, projectDirectoryName);
+}
+
+function cursorProjectName(folderPath: string): string {
+  return folderPath.split(path.sep).filter(Boolean).join("-");
 }
 
 /**
@@ -186,6 +197,94 @@ test("observes an open turn as work, labelled by its folder and free of transcri
   // Nothing says this session runs anywhere but here, which is what leaves it
   // local once the registry normalizes it.
   assert.equal(observations[0]?.location, undefined);
+  assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);
+});
+
+test("observes a current-format assistant reply as a settled turn", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "session-settled",
+    [
+      messageRecord(TEST_ROLE.USER, TEST_CONTENT_TYPE.TEXT),
+      messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TEXT),
+    ],
+    TEST_TIME - 5_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
+  assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);
+});
+
+test("keeps a current-format turn open for every known tool-call spelling", async (t) => {
+  const state = await temporaryCursorState(t);
+  for (const [index, contentType] of [
+    TEST_CONTENT_TYPE.TOOL_USE,
+    TEST_CONTENT_TYPE.TOOL_USE_HYPHENATED,
+    TEST_CONTENT_TYPE.TOOL_CALL,
+    TEST_CONTENT_TYPE.TOOL_CALL_HYPHENATED,
+  ].entries()) {
+    await writeTranscript(
+      state,
+      "Users-test-luke",
+      `session-tool-${index}`,
+      [messageRecord(TEST_ROLE.ASSISTANT, contentType)],
+      TEST_TIME - (index + 1) * 1_000,
+    );
+  }
+
+  const observations = await adapterFor(state).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.status),
+    Array.from({ length: 4 }, () => SESSION_STATUS.WORKING),
+  );
+});
+
+test("settles on assistant messages with thinking, unknown, or string content", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "session-thinking",
+    [
+      {
+        role: TEST_ROLE.ASSISTANT,
+        message: {
+          content: [
+            { type: TEST_CONTENT_TYPE.THINKING, text: SECRET_TRANSCRIPT_TEXT },
+            { type: TEST_CONTENT_TYPE.TEXT, text: SECRET_TRANSCRIPT_TEXT },
+          ],
+        },
+      },
+    ],
+    TEST_TIME - 1_000,
+  );
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "session-unknown-block",
+    [messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.CUSTOM)],
+    TEST_TIME - 2_000,
+  );
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "session-string-content",
+    [{ role: TEST_ROLE.ASSISTANT, message: { content: SECRET_TRANSCRIPT_TEXT } }],
+    TEST_TIME - 3_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.status),
+    Array.from({ length: 3 }, () => SESSION_STATUS.WAITING),
+  );
   assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);
 });
 
@@ -385,6 +484,83 @@ test("names a folder whose project directory kept a character Luke would rewrite
   );
 });
 
+test("names an existing folder without a Cursor workspace record", async (t) => {
+  const state = await temporaryCursorState(t);
+  const folderPath = path.join(path.dirname(state.cursorHome), "workspaces", "luke");
+  await fs.mkdir(folderPath, { recursive: true });
+  await writeTranscript(
+    state,
+    cursorProjectName(folderPath),
+    "session-filesystem-labelled",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 1_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.title, "luke");
+  assert.deepEqual(observations[0]?.detail, { repository: "luke" });
+});
+
+test("refuses a project directory name that resolves to two folders", async (t) => {
+  const state = await temporaryCursorState(t);
+  const root = path.join(path.dirname(state.cursorHome), "ambiguous");
+  const firstFolder = path.join(root, "alpha", "beta-gamma");
+  const secondFolder = path.join(root, "alpha-beta", "gamma");
+  await Promise.all([
+    fs.mkdir(firstFolder, { recursive: true }),
+    fs.mkdir(secondFolder, { recursive: true }),
+  ]);
+  await writeTranscript(
+    state,
+    cursorProjectName(firstFolder),
+    "session-ambiguous-filesystem",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 1_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.title, "workspace");
+});
+
+test("refuses a project directory name that resolves to no folder", async (t) => {
+  const state = await temporaryCursorState(t);
+  const missingFolder = path.join(path.dirname(state.cursorHome), "missing", "folder");
+  await writeTranscript(
+    state,
+    cursorProjectName(missingFolder),
+    "session-missing-filesystem",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 1_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.title, "workspace");
+});
+
+test("keeps a literal hyphen in the uniquely resolved folder label", async (t) => {
+  const state = await temporaryCursorState(t);
+  const folderPath = path.join(path.dirname(state.cursorHome), "workspaces", "little-rock");
+  await fs.mkdir(folderPath, { recursive: true });
+  await writeTranscript(
+    state,
+    cursorProjectName(folderPath),
+    "session-hyphenated-filesystem",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 1_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.title, "little-rock");
+});
+
 test("labels a session neutrally rather than guessing at a folder", async (t) => {
   const state = await temporaryCursorState(t);
   // A window with no folder, and two folders that share one project directory
@@ -477,6 +653,29 @@ test("finds the newest records when only the end of a long transcript is read", 
 
   assert.equal(observations.length, 1);
   assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
+});
+
+test("keeps working when a bounded tail contains no whole record", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "session-oversized-record",
+    [
+      {
+        role: TEST_ROLE.ASSISTANT,
+        message: {
+          content: [{ type: TEST_CONTENT_TYPE.TEXT, text: SECRET_TRANSCRIPT_TEXT.repeat(128) }],
+        },
+      },
+    ],
+    TEST_TIME - 1_000,
+  );
+
+  const observations = await adapterFor(state, { readTailBytes: 128 }).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
 });
 
 test("bounds how many sessions one pass reports, keeping the newest", async (t) => {

--- a/apps/desktop/tests/cursor-local-adapter.test.ts
+++ b/apps/desktop/tests/cursor-local-adapter.test.ts
@@ -571,6 +571,46 @@ test("omits a project directory name that resolves to no folder", async (t) => {
   assert.deepEqual(observations, []);
 });
 
+test("observes a project after its missing folder appears", async (t) => {
+  const state = await temporaryCursorState(t);
+  const folderPath = path.join(path.dirname(state.cursorHome), "restored", "folder");
+  await writeTranscript(
+    state,
+    cursorProjectName(folderPath),
+    "session-restored-folder",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 1_000,
+  );
+  const adapter = adapterFor(state);
+
+  assert.deepEqual(await adapter.observe(), []);
+
+  await fs.mkdir(folderPath, { recursive: true });
+
+  assert.equal((await adapter.observe())[0]?.title, "folder");
+});
+
+test("observes a project after Cursor writes its workspace record", async (t) => {
+  const state = await temporaryCursorState(t);
+  const folderPath = path.join(path.dirname(state.cursorHome), "restored", "luke.github.io");
+  const projectDirectoryName = canonicalCursorProjectName(folderPath);
+  await writeTranscript(
+    state,
+    projectDirectoryName,
+    "session-restored-record",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 1_000,
+  );
+  const adapter = adapterFor(state);
+
+  assert.deepEqual(await adapter.observe(), []);
+
+  await fs.mkdir(folderPath, { recursive: true });
+  await writeWorkspaceRecord(state, "restored-record", folderPath);
+
+  assert.equal((await adapter.observe())[0]?.title, "luke.github.io");
+});
+
 test("withdraws sessions when their workspace folder is deleted", async (t) => {
   const state = await temporaryCursorState(t);
   await writeTranscript(
@@ -587,6 +627,31 @@ test("withdraws sessions when their workspace folder is deleted", async (t) => {
   await fs.rm(state.defaultFolderPath, { recursive: true });
 
   assert.deepEqual(await adapter.observe(), []);
+
+  await fs.mkdir(state.defaultFolderPath, { recursive: true });
+
+  assert.equal((await adapter.observe())[0]?.title, "luke");
+});
+
+test("does not replace ambiguous workspace records with a filesystem match", async (t) => {
+  const state = await temporaryCursorState(t);
+  const root = path.join(path.dirname(state.cursorHome), "recorded-ambiguity");
+  const existingFolder = path.join(root, "alpha", "beta-gamma");
+  const absentFolder = path.join(root, "alpha-beta", "gamma");
+  await fs.mkdir(existingFolder, { recursive: true });
+  await writeWorkspaceRecord(state, "first-record", existingFolder);
+  await writeWorkspaceRecord(state, "second-record", absentFolder);
+  await writeTranscript(
+    state,
+    canonicalCursorProjectName(existingFolder),
+    "session-ambiguous-records",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 1_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.deepEqual(observations, []);
 });
 
 test("keeps a literal hyphen in the uniquely resolved folder label", async (t) => {

--- a/apps/desktop/tests/cursor-local-adapter.test.ts
+++ b/apps/desktop/tests/cursor-local-adapter.test.ts
@@ -41,6 +41,8 @@ const TEST_CONTENT_TYPE = {
 
 interface CursorState {
   cursorHome: string;
+  defaultFolderPath: string;
+  defaultProjectDirectoryName: string;
   workspaceStorageDirectory: string;
 }
 
@@ -63,11 +65,15 @@ async function temporaryCursorState(t: TestContext): Promise<CursorState> {
   const directory = await fs.realpath(
     await fs.mkdtemp(path.join(os.tmpdir(), "luke-cursor-local-")),
   );
+  const defaultFolderPath = path.join(directory, "workspaces", "luke");
+  await fs.mkdir(defaultFolderPath, { recursive: true });
   t.after(async () => {
     await fs.rm(directory, { recursive: true, force: true });
   });
   return {
     cursorHome: path.join(directory, "cursor-home"),
+    defaultFolderPath,
+    defaultProjectDirectoryName: cursorProjectName(defaultFolderPath),
     workspaceStorageDirectory: path.join(directory, "workspace-storage"),
   };
 }
@@ -125,6 +131,12 @@ function cursorProjectName(folderPath: string): string {
   return folderPath.split(path.sep).filter(Boolean).join("-");
 }
 
+function canonicalCursorProjectName(folderPath: string): string {
+  return cursorProjectName(folderPath)
+    .replace(/[^A-Za-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
 /**
  * Backdates a directory the way the filesystem would have. A directory's mtime
  * moves when it gains or loses an entry and at no other time, so a project's
@@ -170,10 +182,10 @@ function adapterFor(
 
 test("observes an open turn as work, labelled by its folder and free of transcript text", async (t) => {
   const state = await temporaryCursorState(t);
-  await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  await writeWorkspaceRecord(state, "9f1c", state.defaultFolderPath);
   await writeTranscript(
     state,
-    "Users-test-luke",
+    state.defaultProjectDirectoryName,
     "0b1f4b0e-2c5a-4d1e-9a3c-6d5f7e8a9b0c",
     [
       messageRecord(TEST_ROLE.USER, TEST_CONTENT_TYPE.TEXT),
@@ -204,7 +216,7 @@ test("observes a current-format assistant reply as a settled turn", async (t) =>
   const state = await temporaryCursorState(t);
   await writeTranscript(
     state,
-    "Users-test-luke",
+    state.defaultProjectDirectoryName,
     "session-settled",
     [
       messageRecord(TEST_ROLE.USER, TEST_CONTENT_TYPE.TEXT),
@@ -230,7 +242,7 @@ test("keeps a current-format turn open for every known tool-call spelling", asyn
   ].entries()) {
     await writeTranscript(
       state,
-      "Users-test-luke",
+      state.defaultProjectDirectoryName,
       `session-tool-${index}`,
       [messageRecord(TEST_ROLE.ASSISTANT, contentType)],
       TEST_TIME - (index + 1) * 1_000,
@@ -249,7 +261,7 @@ test("settles on assistant messages with thinking, unknown, or string content", 
   const state = await temporaryCursorState(t);
   await writeTranscript(
     state,
-    "Users-test-luke",
+    state.defaultProjectDirectoryName,
     "session-thinking",
     [
       {
@@ -266,14 +278,14 @@ test("settles on assistant messages with thinking, unknown, or string content", 
   );
   await writeTranscript(
     state,
-    "Users-test-luke",
+    state.defaultProjectDirectoryName,
     "session-unknown-block",
     [messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.CUSTOM)],
     TEST_TIME - 2_000,
   );
   await writeTranscript(
     state,
-    "Users-test-luke",
+    state.defaultProjectDirectoryName,
     "session-string-content",
     [{ role: TEST_ROLE.ASSISTANT, message: { content: SECRET_TRANSCRIPT_TEXT } }],
     TEST_TIME - 3_000,
@@ -290,10 +302,10 @@ test("settles on assistant messages with thinking, unknown, or string content", 
 
 test("tells a turn that finished from one that failed", async (t) => {
   const state = await temporaryCursorState(t);
-  await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  await writeWorkspaceRecord(state, "9f1c", state.defaultFolderPath);
   await writeTranscript(
     state,
-    "Users-test-luke",
+    state.defaultProjectDirectoryName,
     "session-finished",
     [
       messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TEXT),
@@ -303,7 +315,7 @@ test("tells a turn that finished from one that failed", async (t) => {
   );
   await writeTranscript(
     state,
-    "Users-test-luke",
+    state.defaultProjectDirectoryName,
     "session-failed",
     [
       messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TOOL_USE),
@@ -333,7 +345,7 @@ test("passes over trailing records this build does not know", async (t) => {
   const state = await temporaryCursorState(t);
   await writeTranscript(
     state,
-    "Users-test-luke",
+    state.defaultProjectDirectoryName,
     "session-annotated",
     [
       messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TEXT),
@@ -353,14 +365,14 @@ test("leaves a transcript that has gone quiet unknown instead of inventing activ
   const state = await temporaryCursorState(t);
   await writeTranscript(
     state,
-    "Users-test-luke",
+    state.defaultProjectDirectoryName,
     "session-quiet",
     [messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TOOL_USE)],
     TEST_TIME - 20 * 60 * 1000,
   );
   await writeTranscript(
     state,
-    "Users-test-luke",
+    state.defaultProjectDirectoryName,
     "session-abandoned",
     [
       messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TEXT),
@@ -383,7 +395,7 @@ test("keeps reporting a failure that has gone quiet, because it has not healed",
   const state = await temporaryCursorState(t);
   await writeTranscript(
     state,
-    "Users-test-luke",
+    state.defaultProjectDirectoryName,
     "session-stuck",
     [
       messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TOOL_USE),
@@ -406,7 +418,7 @@ test("ignores sessions older than the maximum session age", async (t) => {
   const state = await temporaryCursorState(t);
   await writeTranscript(
     state,
-    "Users-test-luke",
+    state.defaultProjectDirectoryName,
     "session-yesterday",
     [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
     TEST_TIME - 25 * 60 * 60 * 1000,
@@ -421,26 +433,39 @@ test("ignores sessions older than the maximum session age", async (t) => {
 
 test("names a folder its project directory can no longer spell", async (t) => {
   const state = await temporaryCursorState(t);
-  await writeWorkspaceRecord(state, "6a20", "/Users/test/luke.github.io");
-  await writeWorkspaceRecord(state, "77b8", "/Users/test/Documents/[00] Notes:Archive");
-  await writeWorkspaceRecord(state, "c4d1", "/Users/test/workspaces/luke/sidecar-v2");
+  const siteFolder = path.join(path.dirname(state.cursorHome), "folders", "luke.github.io");
+  const notesFolder = path.join(path.dirname(state.cursorHome), "folders", "[00] Notes:Archive");
+  const workspaceFolder = path.join(
+    path.dirname(state.cursorHome),
+    "folders",
+    "luke",
+    "sidecar-v2",
+  );
+  await Promise.all(
+    [siteFolder, notesFolder, workspaceFolder].map((folder) =>
+      fs.mkdir(folder, { recursive: true }),
+    ),
+  );
+  await writeWorkspaceRecord(state, "6a20", siteFolder);
+  await writeWorkspaceRecord(state, "77b8", notesFolder);
+  await writeWorkspaceRecord(state, "c4d1", workspaceFolder);
   await writeTranscript(
     state,
-    "Users-test-luke-github-io",
+    canonicalCursorProjectName(siteFolder),
     "session-site",
     [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
     TEST_TIME - 1_000,
   );
   await writeTranscript(
     state,
-    "Users-test-Documents-00-Notes-Archive",
+    canonicalCursorProjectName(notesFolder),
     "session-notes",
     [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
     TEST_TIME - 2_000,
   );
   await writeTranscript(
     state,
-    "Users-test-workspaces-luke-sidecar-v2",
+    canonicalCursorProjectName(workspaceFolder),
     "session-workspace",
     [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
     TEST_TIME - 3_000,
@@ -456,21 +481,26 @@ test("names a folder its project directory can no longer spell", async (t) => {
 
 test("names a folder whose project directory kept a character Luke would rewrite", async (t) => {
   const state = await temporaryCursorState(t);
-  await writeWorkspaceRecord(state, "4d5e", "/Users/test/my_project");
-  await writeWorkspaceRecord(state, "8f9a", "/Users/test/Notes (2026)");
+  const underscoredFolder = path.join(path.dirname(state.cursorHome), "folders", "my_project");
+  const bracketedFolder = path.join(path.dirname(state.cursorHome), "folders", "Notes (2026)");
+  await Promise.all(
+    [underscoredFolder, bracketedFolder].map((folder) => fs.mkdir(folder, { recursive: true })),
+  );
+  await writeWorkspaceRecord(state, "4d5e", underscoredFolder);
+  await writeWorkspaceRecord(state, "8f9a", bracketedFolder);
   // Cursor decides for itself which characters it will not put in a directory
   // name, so these keep an underscore and a bracket that Luke's own reduction
   // would have rewritten. Matching must not depend on agreeing with it.
   await writeTranscript(
     state,
-    "Users-test-my_project",
+    cursorProjectName(underscoredFolder),
     "session-underscored",
     [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
     TEST_TIME - 1_000,
   );
   await writeTranscript(
     state,
-    "Users-test-Notes (2026)",
+    cursorProjectName(bracketedFolder),
     "session-bracketed",
     [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
     TEST_TIME - 2_000,
@@ -503,7 +533,7 @@ test("names an existing folder without a Cursor workspace record", async (t) => 
   assert.deepEqual(observations[0]?.detail, { repository: "luke" });
 });
 
-test("refuses a project directory name that resolves to two folders", async (t) => {
+test("omits a project directory name that resolves to two folders", async (t) => {
   const state = await temporaryCursorState(t);
   const root = path.join(path.dirname(state.cursorHome), "ambiguous");
   const firstFolder = path.join(root, "alpha", "beta-gamma");
@@ -522,11 +552,10 @@ test("refuses a project directory name that resolves to two folders", async (t) 
 
   const observations = await adapterFor(state).observe();
 
-  assert.equal(observations.length, 1);
-  assert.equal(observations[0]?.title, "workspace");
+  assert.deepEqual(observations, []);
 });
 
-test("refuses a project directory name that resolves to no folder", async (t) => {
+test("omits a project directory name that resolves to no folder", async (t) => {
   const state = await temporaryCursorState(t);
   const missingFolder = path.join(path.dirname(state.cursorHome), "missing", "folder");
   await writeTranscript(
@@ -539,8 +568,25 @@ test("refuses a project directory name that resolves to no folder", async (t) =>
 
   const observations = await adapterFor(state).observe();
 
-  assert.equal(observations.length, 1);
-  assert.equal(observations[0]?.title, "workspace");
+  assert.deepEqual(observations, []);
+});
+
+test("withdraws sessions when their workspace folder is deleted", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeTranscript(
+    state,
+    state.defaultProjectDirectoryName,
+    "session-deleted-workspace",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 1_000,
+  );
+  const adapter = adapterFor(state);
+
+  assert.equal((await adapter.observe()).length, 1);
+
+  await fs.rm(state.defaultFolderPath, { recursive: true });
+
+  assert.deepEqual(await adapter.observe(), []);
 });
 
 test("keeps a literal hyphen in the uniquely resolved folder label", async (t) => {
@@ -561,13 +607,19 @@ test("keeps a literal hyphen in the uniquely resolved folder label", async (t) =
   assert.equal(observations[0]?.title, "little-rock");
 });
 
-test("labels a session neutrally rather than guessing at a folder", async (t) => {
+test("omits sessions rather than guessing at a folder", async (t) => {
   const state = await temporaryCursorState(t);
+  const firstFolder = path.join(path.dirname(state.cursorHome), "ambiguous", "luke-v2");
+  const secondFolder = path.join(path.dirname(state.cursorHome), "ambiguous", "luke", "v2");
+  await Promise.all([
+    fs.mkdir(firstFolder, { recursive: true }),
+    fs.mkdir(secondFolder, { recursive: true }),
+  ]);
   // A window with no folder, and two folders that share one project directory
-  // name while disagreeing about what it should be called.
+  // name. Neither gives Luke one verified folder to report.
   await writeWorkspaceRecord(state, "1a2b", undefined);
-  await writeWorkspaceRecord(state, "3c4d", "/Users/test/luke-v2");
-  await writeWorkspaceRecord(state, "5e6f", "/Users/test/luke/v2");
+  await writeWorkspaceRecord(state, "3c4d", firstFolder);
+  await writeWorkspaceRecord(state, "5e6f", secondFolder);
   await writeTranscript(
     state,
     "empty-window",
@@ -577,7 +629,7 @@ test("labels a session neutrally rather than guessing at a folder", async (t) =>
   );
   await writeTranscript(
     state,
-    "Users-test-luke-v2",
+    canonicalCursorProjectName(firstFolder),
     "session-ambiguous",
     [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
     TEST_TIME - 2_000,
@@ -585,10 +637,7 @@ test("labels a session neutrally rather than guessing at a folder", async (t) =>
 
   const observations = await adapterFor(state).observe();
 
-  assert.deepEqual(
-    observations.map((observation) => observation.title),
-    ["workspace", "workspace"],
-  );
+  assert.deepEqual(observations, []);
 });
 
 test("a workspace record that is not JSON does not fail the observation pass", async (t) => {
@@ -598,7 +647,7 @@ test("a workspace record that is not JSON does not fail the observation pass", a
   await fs.writeFile(path.join(entryDirectory, CURSOR_WORKSPACE_FILE), "{");
   await writeTranscript(
     state,
-    "Users-test-luke",
+    state.defaultProjectDirectoryName,
     "session-labelled",
     [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
     TEST_TIME - 1_000,
@@ -607,22 +656,22 @@ test("a workspace record that is not JSON does not fail the observation pass", a
   const observations = await adapterFor(state).observe();
 
   assert.equal(observations.length, 1);
-  assert.equal(observations[0]?.title, "workspace");
+  assert.equal(observations[0]?.title, "luke");
 });
 
 test("observes a session and not the subagents it ran", async (t) => {
   const state = await temporaryCursorState(t);
-  await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  await writeWorkspaceRecord(state, "9f1c", state.defaultFolderPath);
   await writeTranscript(
     state,
-    "Users-test-luke",
+    state.defaultProjectDirectoryName,
     "session-with-subagents",
     [messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TOOL_USE)],
     TEST_TIME - 5_000,
   );
   await writeSubagentTranscript(
     state,
-    "Users-test-luke",
+    state.defaultProjectDirectoryName,
     "session-with-subagents",
     "subagent-explore",
     TEST_TIME - 1_000,
@@ -640,7 +689,7 @@ test("finds the newest records when only the end of a long transcript is read", 
   const state = await temporaryCursorState(t);
   await writeTranscript(
     state,
-    "Users-test-luke",
+    state.defaultProjectDirectoryName,
     "session-long",
     [
       { role: TEST_ROLE.ASSISTANT, message: { content: [{ text: "x".repeat(512) }] } },
@@ -659,7 +708,7 @@ test("keeps working when a bounded tail contains no whole record", async (t) => 
   const state = await temporaryCursorState(t);
   await writeTranscript(
     state,
-    "Users-test-luke",
+    state.defaultProjectDirectoryName,
     "session-oversized-record",
     [
       {
@@ -687,7 +736,7 @@ test("bounds how many sessions one pass reports, keeping the newest", async (t) 
   ].entries()) {
     await writeTranscript(
       state,
-      "Users-test-luke",
+      state.defaultProjectDirectoryName,
       sessionId,
       [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
       TEST_TIME - (index + 1) * 1_000,
@@ -704,18 +753,26 @@ test("bounds how many sessions one pass reports, keeping the newest", async (t) 
 
 test("keeps the projects that most recently started a session", async (t) => {
   const state = await temporaryCursorState(t);
-  await writeWorkspaceRecord(state, "9f1c", "/Users/test/daily");
-  await writeWorkspaceRecord(state, "7b2e", "/Users/test/dormant");
+  const dailyFolder = path.join(path.dirname(state.cursorHome), "folders", "daily");
+  const dormantFolder = path.join(path.dirname(state.cursorHome), "folders", "dormant");
+  await Promise.all([
+    fs.mkdir(dailyFolder, { recursive: true }),
+    fs.mkdir(dormantFolder, { recursive: true }),
+  ]);
+  const dailyProject = cursorProjectName(dailyFolder);
+  const dormantProject = cursorProjectName(dormantFolder);
+  await writeWorkspaceRecord(state, "9f1c", dailyFolder);
+  await writeWorkspaceRecord(state, "7b2e", dormantFolder);
   await writeTranscript(
     state,
-    "Users-test-daily",
+    dailyProject,
     "session-today",
     [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
     TEST_TIME - 1_000,
   );
   await writeTranscript(
     state,
-    "Users-test-dormant",
+    dormantProject,
     "session-long-ago",
     [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
     TEST_TIME - 2_000,
@@ -723,15 +780,15 @@ test("keeps the projects that most recently started a session", async (t) => {
   // The project Cursor wrote to first holds the newer session, and a folder
   // opened moments ago has never run an agent at all. A project directory's own
   // mtime tells all three apart backwards.
-  await setDirectoryMtime(projectDirectory(state, "Users-test-daily"), TEST_TIME - YEAR_MS);
-  await setDirectoryMtime(projectDirectory(state, "Users-test-dormant"), TEST_TIME - 60_000);
+  await setDirectoryMtime(projectDirectory(state, dailyProject), TEST_TIME - YEAR_MS);
+  await setDirectoryMtime(projectDirectory(state, dormantProject), TEST_TIME - 60_000);
   await setDirectoryMtime(projectDirectory(state, "Users-test-opened-today"), TEST_TIME);
   await setDirectoryMtime(
-    path.join(projectDirectory(state, "Users-test-daily"), CURSOR_TRANSCRIPTS_DIRECTORY),
+    path.join(projectDirectory(state, dailyProject), CURSOR_TRANSCRIPTS_DIRECTORY),
     TEST_TIME - 1_000,
   );
   await setDirectoryMtime(
-    path.join(projectDirectory(state, "Users-test-dormant"), CURSOR_TRANSCRIPTS_DIRECTORY),
+    path.join(projectDirectory(state, dormantProject), CURSOR_TRANSCRIPTS_DIRECTORY),
     TEST_TIME - YEAR_MS,
   );
 

--- a/apps/desktop/tests/opencode-adapter.test.ts
+++ b/apps/desktop/tests/opencode-adapter.test.ts
@@ -51,6 +51,12 @@ async function temporaryDataDirectory(t: TestContext): Promise<string> {
   return directory;
 }
 
+async function testWorkspaceDirectory(root: string, directory: string): Promise<string> {
+  const workspace = path.join(root, "test-workspaces", path.basename(directory));
+  await fs.mkdir(workspace, { recursive: true });
+  return workspace;
+}
+
 function writeSession(database: DatabaseSync, session: TestSession): void {
   database
     .prepare(`
@@ -115,6 +121,12 @@ async function writeOpenCodeState(
   } = {},
 ): Promise<void> {
   await fs.mkdir(dataDirectory, { recursive: true });
+  const materializedSessions = await Promise.all(
+    sessions.map(async (session) => ({
+      ...session,
+      directory: await testWorkspaceDirectory(dataDirectory, session.directory),
+    })),
+  );
   const database = new DatabaseSync(
     path.join(dataDirectory, options.databaseFile ?? OPENCODE_DATABASE),
     {},
@@ -152,7 +164,7 @@ async function writeOpenCodeState(
         data TEXT NOT NULL
       );
     `);
-    for (const session of sessions) writeSession(database, session);
+    for (const session of materializedSessions) writeSession(database, session);
     for (const message of options.messages ?? []) writeMessage(database, message);
     for (const part of options.parts ?? []) writePart(database, part);
   } finally {
@@ -179,6 +191,12 @@ async function writeEarlyOpenCodeState(
   sessions: readonly { id: string; directory: string; observedAt: number; title: string }[],
 ): Promise<void> {
   await fs.mkdir(dataDirectory, { recursive: true });
+  const materializedSessions = await Promise.all(
+    sessions.map(async (session) => ({
+      ...session,
+      directory: await testWorkspaceDirectory(dataDirectory, session.directory),
+    })),
+  );
   const database = new DatabaseSync(path.join(dataDirectory, OPENCODE_DATABASE), {});
   try {
     database.exec(`
@@ -191,7 +209,7 @@ async function writeEarlyOpenCodeState(
         time_updated INTEGER NOT NULL
       )
     `);
-    for (const session of sessions) {
+    for (const session of materializedSessions) {
       database
         .prepare("INSERT INTO session VALUES (?, ?, ?, ?, ?, ?)")
         .run(
@@ -215,7 +233,14 @@ async function writeLegacySession(
 ): Promise<void> {
   const sessionDirectory = path.join(dataDirectory, "storage", "session", projectId);
   await fs.mkdir(sessionDirectory, { recursive: true });
-  await fs.writeFile(path.join(sessionDirectory, `${info.id}.json`), JSON.stringify(info));
+  const directory = typeof info.directory === "string" ? info.directory : undefined;
+  const materializedInfo = directory
+    ? { ...info, directory: await testWorkspaceDirectory(dataDirectory, directory) }
+    : info;
+  await fs.writeFile(
+    path.join(sessionDirectory, `${info.id}.json`),
+    JSON.stringify(materializedInfo),
+  );
 }
 
 async function writeLegacyMessage(
@@ -815,5 +840,35 @@ test("returns an empty snapshot when OpenCode has no local state", async (t) => 
     now: () => TEST_TIME,
   });
 
+  assert.deepEqual(await adapter.observe(), []);
+});
+
+test("withdraws a database session when its workspace is deleted", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  await writeOpenCodeState(dataDirectory, [
+    {
+      id: "ses_deleted_workspace",
+      directory: "/Users/test/deleted",
+      observedAt: TEST_TIME - 1_000,
+    },
+  ]);
+  const adapter = new OpenCodeSessionAdapter({ dataDirectory, now: () => TEST_TIME });
+
+  assert.equal((await adapter.observe()).length, 1);
+  await fs.rm(path.join(dataDirectory, "test-workspaces", "deleted"), { recursive: true });
+  assert.deepEqual(await adapter.observe(), []);
+});
+
+test("withdraws a legacy session when its workspace is deleted", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  await writeLegacySession(dataDirectory, "project-one", {
+    id: "ses_legacy_deleted_workspace",
+    directory: "/Users/test/deleted",
+    time: { created: TEST_TIME - 5_000, updated: TEST_TIME - 1_000 },
+  });
+  const adapter = new OpenCodeSessionAdapter({ dataDirectory, now: () => TEST_TIME });
+
+  assert.equal((await adapter.observe()).length, 1);
+  await fs.rm(path.join(dataDirectory, "test-workspaces", "deleted"), { recursive: true });
   assert.deepEqual(await adapter.observe(), []);
 });


### PR DESCRIPTION
## Summary

- Recognize current Cursor role/message transcripts and tool-call variants so local sessions report `Working` versus `Waiting` without exposing message text.
- Resolve Cursor workspace labels against the filesystem and omit sessions whose folder is deleted or ambiguous.
- Apply the same existing-folder rule to local Codex, Claude Code, and OpenCode sessions, including OpenCode's current database and legacy JSON storage.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed
- macOS Electron verification (`./scripts/verify.sh`): passed; expanded visual evidence inspected cleanly

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31856514483/artifacts/9239197909) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31856514483)

- Commit: `6bfa33b880e8a40ea24f34cac29f63ebef0c3dc9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: None
