### PR TITLE
fix(panel): sign two settings changed at once one at a time

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -46,6 +46,21 @@ import { ASK_LUKE_INPUT_ID, focusAskField } from "./ask-luke";
 import type { CredentialEntry, CredentialEntryControl } from "./credential-entry";
 import { isSubmittable, removalEndsEntry } from "./credential-entry";
 import {
+  armErrand,
+  EMPTY_ERRAND_RUN,
+  type ErrandHold,
+  type ErrandRun,
+  errandRunIdle,
+  errandWait,
+  finishErrand,
+  flushErrands,
+  landErrand,
+  NOTHING_HELD,
+  nextErrand,
+  type PendingErrand,
+  supersedeErrandSettings,
+} from "./errand-queue";
+import {
   type FeedbackEntry,
   type FeedbackEntryControl,
   IMAGE_REFUSAL,
@@ -55,14 +70,7 @@ import {
 import { encodeFeedbackImage } from "./feedback-images";
 import { FeedbackSlot } from "./feedback-slot";
 import { KeySlot } from "./key-slot";
-import {
-  ERRAND_WAIT,
-  type Errand,
-  type ErrandTarget,
-  type ErrandWait,
-  errandTargets,
-  LukeErrand,
-} from "./luke-errand";
+import { type Errand, errandTargets, LukeErrand } from "./luke-errand";
 import { applySpokenSetting, buildLukeGuide, isAppSettingId } from "./luke-guide";
 import { NotchWings } from "./notch-wings";
 import { PanelBody, type SessionWriteHandlers } from "./panel-body";
@@ -196,7 +204,12 @@ export function App(): React.JSX.Element {
   );
   const [display, setDisplay] = useState<DisplayDiagnostic>();
   const [tab, setTab, tabNow] = useStateWithRef<PanelTab>(PANEL_TAB.SESSIONS);
-  const [settingsView, setSettingsView] = useState<SettingsView>(SETTINGS_VIEW.ROOT);
+  // The drawn page has to be readable from a callback as well as rendered: an
+  // errand coming up for its turn reads it to decide whether a page still has
+  // to be turned before the mark can be measured against anything.
+  const [settingsView, setSettingsView, settingsViewNow] = useStateWithRef<SettingsView>(
+    SETTINGS_VIEW.ROOT,
+  );
   const [sessionView, setSessionView] = useState<SessionView>(DEFAULT_SESSION_VIEW);
   const [optionsOpen, setOptionsOpen] = useState(false);
   // The latest is needed from the spoken-settings carrier, which cannot wait
@@ -280,12 +293,13 @@ export function App(): React.JSX.Element {
    * mistake — the settings snapshot the store answered with, and the narrowing
    * or re-ordering a spoken ask chose for the list.
    *
-   * Refs rather than state: the release runs from a callback that has to stay
-   * stable across the whole flight it is timing, and an errand carries one of
-   * these or the other, never both.
+   * A hold belongs to the act that caught it rather than to the app, because
+   * one reply can ask for several acts and each has its own switch to move.
+   * They ride the run in {@link errandRun}, which is a ref rather than state:
+   * the callbacks that release them have to stay stable across the whole
+   * flight they are timing, and an errand whose callbacks changed identity
+   * would be torn down and rebuilt mid-air.
    */
-  const heldSettings = useRef<AppSettings | undefined>(undefined);
-  const heldView = useRef<Partial<SessionView> | undefined>(undefined);
   /**
    * The way to tell the conversation what the store now holds, for the spoken
    * carrier below. Only the drawing waits for Luke: the guide has to describe
@@ -295,17 +309,38 @@ export function App(): React.JSX.Element {
    * carrier is created before the conversation hook that owns the publisher.
    */
   const publishGuideRef = useRef<(next: AppSettings) => void>(() => {});
-  const releaseErrandChange = useCallback(() => {
-    const settings = heldSettings.current;
-    const view = heldView.current;
-    heldSettings.current = undefined;
-    heldView.current = undefined;
-    if (settings !== undefined) setSettings(settings);
+  /**
+   * The newest snapshot the store has answered with, held back from the panel
+   * or not. What waits for Luke is the drawing; what the next call in the same
+   * turn composes against must be current, or a model and its effort asked for
+   * in one breath would compose the second against the selection the first
+   * replaced. Kept beside the holds rather than in one, because a hold belongs
+   * to a single act and this is what every act after it has to read.
+   */
+  const answeredSettings = useRef<AppSettings | undefined>(undefined);
+  const drawErrandHold = useCallback((hold: ErrandHold) => {
+    if (hold.settings !== undefined) setSettings(hold.settings);
     // Folded into whatever the view is at the moment it lands rather than the
     // moment it was chosen: the list corrects its own filter during render
     // when one empties, and a snapshot taken at the ask would undo that.
+    const view = hold.view;
     if (view !== undefined) setSessionView((current) => ({ ...current, ...view }));
   }, [setSettings]);
+
+  /**
+   * Every act this reply asked Luke to sign, in the order he will sign them.
+   * One flight at a time: a second act handed straight to the flight ends the
+   * first one mid-air, which is both switches flipping at once with nobody
+   * seen doing either.
+   */
+  const errandRun = useRef<ErrandRun>(EMPTY_ERRAND_RUN);
+
+  /** The tap has landed, so the act in the air may finally be drawn. */
+  const releaseErrandChange = useCallback(() => {
+    const landed = landErrand(errandRun.current);
+    errandRun.current = landed.run;
+    drawErrandHold(landed.hold);
+  }, [drawErrandHold]);
 
   /**
    * Whether the panel on screen is one an errand stood up. Only then is it the
@@ -328,7 +363,7 @@ export function App(): React.JSX.Element {
       // starts in it — set their page right after this reset.
       setSettingsView(SETTINGS_VIEW.ROOT);
     },
-    [setTab],
+    [setSettingsView, setTab],
   );
 
   // A choice made in the sheet puts the sheet away. It is drawn over the list
@@ -370,24 +405,74 @@ export function App(): React.JSX.Element {
   });
 
   /**
-   * Sends Luke to sign what he just did, if there is anywhere to sign it, and
-   * answers whether he actually went.
+   * Sends Luke to sign the next act waiting on him, and puts the panel where
+   * that act can be seen.
    *
-   * Only the panel can hold a signature, so both callers stand it up first and
-   * this is the backstop rather than the decision: an act whose panel never
-   * opened, or that named a control this build does not draw, flies nowhere
-   * and the spoken answer reports it the way it always did. A caller holding
-   * something for the flight reads the answer and lets go itself.
+   * Only the panel can hold a signature, so every caller stands it up first
+   * and this is the backstop rather than the decision: a run whose panel never
+   * opened has nobody to show anything to, so everything it was holding is
+   * drawn at once and the run is over. An act that named a control this build
+   * does not draw is over the moment it is taken up, in the same way — which
+   * is why this loops rather than returning: the next act takes its turn
+   * immediately instead of waiting for a flight that will never be made.
+   *
+   * The tab and the page are turned here rather than where the act was asked
+   * for, because a page turned at the ask would take the previous act's
+   * control off screen before Luke had reached it.
    */
-  const runErrand = useCallback(
-    (targets: readonly ErrandTarget[], wait: ErrandWait): boolean => {
-      if (targets.length === 0) return false;
-      if (presentationOf() !== PANEL_PRESENTATION.PANEL) return false;
-      errands.current += 1;
-      setErrand({ targets, wait, run: errands.current });
-      return true;
+  const flyNextErrand = useCallback(() => {
+    while (errandRun.current.flying === undefined && errandRun.current.waiting.length > 0) {
+      if (presentationOf() !== PANEL_PRESENTATION.PANEL) {
+        const flushed = flushErrands(errandRun.current);
+        errandRun.current = flushed.run;
+        drawErrandHold(flushed.hold);
+        return;
+      }
+      const { run, launch } = nextErrand(errandRun.current);
+      errandRun.current = run;
+      if (launch === undefined) return;
+      // What the flight has to wait out, read off the panel as it is drawn
+      // this moment — which is the last moment it is true, because turning the
+      // tab and the page below is the very thing being waited for.
+      const wait = errandWait({
+        opening: launch.opening,
+        tab: launch.tab,
+        ...(launch.page === undefined ? {} : { page: launch.page }),
+        drawnTab: tabNow(),
+        drawnPage: settingsViewNow(),
+      });
+      // The control has to be drawn to be flown to, and a settings page that is
+      // not open is not drawn at all — so the tab comes forward and then the
+      // page the setting lives on, in that order, because arriving at the tab
+      // is arriving at its front page. This is the same move a credential entry
+      // returning from the key slot makes.
+      changeTab(launch.tab);
+      if (launch.page !== undefined) setSettingsView(launch.page);
+      if (launch.targets.length > 0) {
+        errands.current += 1;
+        setErrand({ targets: launch.targets, wait, run: errands.current });
+        // Only a panel an errand borrowed is the errand's to put away, and only
+        // the first act of a run can have been the one that stood it up. Later
+        // acts must not answer "no" on its behalf: a close scheduled by the
+        // first act and then disowned by the second still fires, and it fires
+        // into the middle of the second act's flight.
+        if (launch.opening && launch.borrowsPanel) errandOpenedPanel.current = true;
+        return;
+      }
+      // Nothing flew, so nothing is coming to release it.
+      const finished = finishErrand(errandRun.current);
+      errandRun.current = finished.run;
+      drawErrandHold(finished.hold);
+    }
+  }, [changeTab, drawErrandHold, presentationOf, setSettingsView, settingsViewNow, tabNow]);
+
+  /** Adds an act to the run, and sends Luke off if he is not already out. */
+  const armErrandFlight = useCallback(
+    (pending: PendingErrand) => {
+      errandRun.current = armErrand(errandRun.current, pending);
+      flyNextErrand();
     },
-    [presentationOf],
+    [flyNextErrand],
   );
 
   /**
@@ -403,7 +488,7 @@ export function App(): React.JSX.Element {
     // — would land on a page nobody is looking at.
     setSettingsView(SETTINGS_VIEW.CONNECTIONS);
     expand();
-  }, [changeTab, expand]);
+  }, [changeTab, expand, setSettingsView]);
 
   /**
    * Applies a settings write's reply: the snapshot the store actually holds,
@@ -859,28 +944,26 @@ export function App(): React.JSX.Element {
   }, [cancelHover, heldAgainstPointer, pointerIsInside, settle]);
 
   /**
-   * The same two releases, keyed to the flight reporting them. A flight
-   * overtaken by the next carry in the same turn still fires its beats — a
-   * hold nobody releases is worse — but what the app holds belongs to the
-   * newest errand by then: the settings snapshot was overwritten by the later
-   * change, and the panel is the later flight's to put away. So a stale
-   * flight's beats release nothing, and the newest flight's release
-   * everything, which is also why nothing is ever left held.
+   * One flight over, and the next one away if the reply asked for more than one
+   * act. The panel only stands back down once the whole run is signed: a close
+   * scheduled between two flights would land in the middle of the second, and
+   * a flight whose shape goes out from under it is cut short where it stands.
+   *
+   * Every beat is acted on, with no test for whether the flight reporting it is
+   * still the current one. There is no such thing as a stale flight any more —
+   * a second act waits its turn rather than overtaking the one in the air — and
+   * a guard here would be worse than redundant: this is what advances the run,
+   * so a beat it declined to act on would strand every act still waiting and
+   * every hold they carry.
    */
-  const releaseIfCurrentErrand = useCallback(
-    (finished: Errand) => {
-      if (finished.run !== errands.current) return;
-      releaseErrandChange();
-    },
-    [releaseErrandChange],
-  );
-  const standDownIfCurrentErrand = useCallback(
-    (finished: Errand) => {
-      if (finished.run !== errands.current) return;
-      standDownAfterErrand();
-    },
-    [standDownAfterErrand],
-  );
+  const finishErrandFlight = useCallback(() => {
+    const finished = finishErrand(errandRun.current);
+    errandRun.current = finished.run;
+    drawErrandHold(finished.hold);
+    flyNextErrand();
+    if (!errandRunIdle(errandRun.current)) return;
+    standDownAfterErrand();
+  }, [drawErrandHold, flyNextErrand, standDownAfterErrand]);
 
   /**
    * The spoken asks about Luke himself. A settings change goes through the
@@ -906,29 +989,37 @@ export function App(): React.JSX.Element {
       dispatchByKind(action, {
         [APP_TOOL_KIND.SETTING]: async (action) => {
           // The store's answer is caught rather than drawn: the switch is what
-          // Luke is on his way to move, so it waits for him to reach it. Every
-          // path out of here releases it, and the outcome the conversation is
-          // told is the store's own either way — what is delayed is the drawing,
-          // never the change or the report of it. The guide is the one thing
-          // that must not wait: the next call in this same turn is validated
-          // against it. The freshest settings this window knows ride along so
-          // a spoken model or effort change composes against the selection
-          // actually stored — the held answer first, because a model and its
-          // effort asked for in one breath land as two calls before anything
-          // is released.
+          // Luke is on his way to move, so it waits for him to reach it. It is
+          // caught in a local and handed to this act alone, because one reply
+          // can change two settings and each switch waits for its own tap.
+          // Every path out of here releases it, and the outcome the
+          // conversation is told is the store's own either way — what is
+          // delayed is the drawing, never the change or the report of it.
+          //
+          // Two things must not wait for Luke, and neither is the drawing. The
+          // guide has to describe the store's answer at once, because the next
+          // call in this same turn is validated against it — an effort named in
+          // the same breath as a model only exists in the guide the model
+          // change just made true. And the freshest answer this window has seen
+          // is what that next call composes against, which is why it is
+          // remembered outside the hold: the hold belongs to one act, and every
+          // act after it has to read this.
+          let caught: AppSettings | undefined;
           const outcome = await applySpokenSetting(
             window.sidecar,
             action,
             (next) => {
-              heldSettings.current = next;
+              caught = next;
+              answeredSettings.current = next;
               publishGuideRef.current(next);
             },
-            heldSettings.current ?? settingsNow() ?? bootstrap?.settings,
+            answeredSettings.current ?? settingsNow() ?? bootstrap?.settings,
           );
+          const hold: ErrandHold = caught === undefined ? NOTHING_HELD : { settings: caught };
           // Nothing to show and nothing to sign: a refused change must not stand
           // the panel up in front of a switch that did not move.
           if (outcome.status !== "changed") {
-            releaseErrandChange();
+            drawErrandHold(hold);
             return outcome;
           }
           const opening = presentationOf() !== PANEL_PRESENTATION.PANEL;
@@ -937,41 +1028,26 @@ export function App(): React.JSX.Element {
           const page = isAppSettingId(action.setting.id)
             ? SETTING_PAGE[action.setting.id]
             : undefined;
-          // What the flight has to wait out. A page already drawn under an open
-          // panel costs nothing; anything else is a page of content arriving,
-          // and a page turned under an open panel takes the leaving one's exit
-          // first. Read before any of it is asked for, because all three of
-          // these are about to stop being true.
-          const wait =
-            opening || page === undefined
-              ? ERRAND_WAIT.CONTENT
-              : tabNow() === PANEL_TAB.SETTINGS && settingsView === page
-                ? ERRAND_WAIT.AT_ONCE
-                : ERRAND_WAIT.PAGE;
           try {
-            // The control has to be drawn to be flown to, and a settings page
-            // that is not open is not drawn at all — so the tab comes forward
-            // and then the page the setting lives on, in that order, because
-            // arriving at the tab is arriving at its front page. This is the
-            // same move a credential entry returning from the key slot makes.
-            changeTab(PANEL_TAB.SETTINGS);
-            if (page !== undefined) setSettingsView(page);
             await changeMode(true);
-            if (runErrand(errandTargets(action), wait)) {
-              // Only a panel this errand stood up is the errand's to put away
-              // — and a claim once made survives the rest of the turn, because
-              // the second carry of a paired ask finds the panel open exactly
-              // because the first stood it up.
-              errandOpenedPanel.current ||= opening;
-            } else {
-              releaseErrandChange();
-            }
+            // Queued rather than flown at once. The tab, the page and the wait
+            // are all decided when this act comes up for its turn, because an
+            // earlier act may still be out over the very page this one would
+            // otherwise turn away.
+            armErrandFlight({
+              targets: errandTargets(action),
+              tab: PANEL_TAB.SETTINGS,
+              ...(page === undefined ? {} : { page }),
+              opening,
+              borrowsPanel: true,
+              hold,
+            });
           } catch {
             // Showing the change is not what was asked for — making it is, and it
             // is already made. A window that refused to come forward must not be
             // reported back as a setting that refused to change, and the switch
             // must be drawn whether or not anyone was shown it moving.
-            releaseErrandChange();
+            drawErrandHold(hold);
           }
           return outcome;
         },
@@ -1023,7 +1099,6 @@ export function App(): React.JSX.Element {
           // errand into a shape still growing has to trail the whole opening,
           // and one into a panel already up does not.
           const opening = presentationOf() !== PANEL_PRESENTATION.PANEL;
-          changeTab(action.tab);
           const spoken = action.filter ? sessionFilterFromSpoken(action.filter) : undefined;
           // An agent this build never registered cannot narrow the list, and Luke
           // must not claim it did. The list still has to match the sentence that
@@ -1034,23 +1109,27 @@ export function App(): React.JSX.Element {
           // narrowing is what Luke is on his way to the options button to do, and
           // a list that has already re-sorted itself by the time he gets there
           // makes the flight a report rather than the act.
-          if (filter || action.sort) {
-            heldView.current = {
-              ...(filter ? { filter } : {}),
-              ...(action.sort ? { sort: action.sort } : {}),
-            };
-          }
+          const view =
+            filter || action.sort
+              ? {
+                  ...(filter ? { filter } : {}),
+                  ...(action.sort ? { sort: action.sort } : {}),
+                }
+              : undefined;
           await changeMode(true);
-          // Nothing flew, so nothing is coming to release it. The panel itself is
-          // what was asked for and it is already up, so the list must show what
-          // the answer is about to claim it shows.
-          // The tab bar and the options button are outside the settings pages, so
-          // a page reset behind this tab switch is nothing they wait for.
-          if (
-            !runErrand(errandTargets(action), opening ? ERRAND_WAIT.CONTENT : ERRAND_WAIT.AT_ONCE)
-          ) {
-            releaseErrandChange();
-          }
+          // The tab bar and the options button are drawn outside the settings
+          // pages, so this act names no page and waits for none. An act with
+          // nowhere to land releases what it holds the moment it comes up: the
+          // panel itself is what was asked for and it is already open, so the
+          // list must show what the answer is about to claim it shows.
+          armErrandFlight({
+            targets: errandTargets(action),
+            tab: action.tab,
+            opening,
+            // The panel is what was asked for, so it is nobody's to take away.
+            borrowsPanel: false,
+            hold: view === undefined ? NOTHING_HELD : { view },
+          });
           return {
             status: "shown",
             tab: action.tab,
@@ -1063,16 +1142,13 @@ export function App(): React.JSX.Element {
         },
       }),
     [
+      armErrandFlight,
       changeMode,
-      changeTab,
       settingsNow,
-      settingsView,
       bootstrap,
-      releaseErrandChange,
-      runErrand,
+      drawErrandHold,
       feedbackEntry.latest,
       presentationOf,
-      tabNow,
     ],
   );
 
@@ -1133,10 +1209,10 @@ export function App(): React.JSX.Element {
   const acceptSettingsBootstrap = useBootstrapRacedChannel(
     (onChange) =>
       window.sidecar.onSettingsChanged((pushed) => {
-        // A push is newer than anything an errand is still carrying, so it takes
-        // the hold with it: released afterwards, a snapshot caught before this
-        // arrived would draw the store as it was rather than as it is.
-        heldSettings.current = undefined;
+        // A push is newer than anything the run is still carrying, so it takes
+        // every held snapshot with it: released afterwards, one caught before
+        // this arrived would draw the store as it was rather than as it is.
+        errandRun.current = supersedeErrandSettings(errandRun.current);
         onChange(pushed);
       }),
     setSettings,
@@ -1285,6 +1361,7 @@ export function App(): React.JSX.Element {
     cancelHover,
     changeTab,
     setMicrophoneStatus,
+    setSettingsView,
     startMicrophone,
     stopMicrophone,
     summonAsk,
@@ -1412,6 +1489,7 @@ export function App(): React.JSX.Element {
     discardListening,
     optionsOpen,
     presentation,
+    setSettingsView,
     settingsView,
     stopSpeaking,
     tab,
@@ -1651,8 +1729,8 @@ export function App(): React.JSX.Element {
           the errand stand back down. */}
       <LukeErrand
         {...(errand ? { errand } : {})}
-        onLanded={releaseIfCurrentErrand}
-        onReturned={standDownIfCurrentErrand}
+        onLanded={releaseErrandChange}
+        onReturned={finishErrandFlight}
       />
 
       {/* Luke's words while he says them: one element in every state, under

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -50,6 +50,7 @@ import {
   EMPTY_ERRAND_RUN,
   type ErrandHold,
   type ErrandRun,
+  errandBorrowedPanel,
   errandRunIdle,
   errandWait,
   finishErrand,
@@ -451,12 +452,13 @@ export function App(): React.JSX.Element {
       if (launch.targets.length > 0) {
         errands.current += 1;
         setErrand({ targets: launch.targets, wait, run: errands.current });
-        // Only a panel an errand borrowed is the errand's to put away, and only
-        // the first act of a run can have been the one that stood it up. Later
-        // acts must not answer "no" on its behalf: a close scheduled by the
-        // first act and then disowned by the second still fires, and it fires
-        // into the middle of the second act's flight.
-        if (launch.opening && launch.borrowsPanel) errandOpenedPanel.current = true;
+        // Whether the panel is still the run's to put away, asked of the run
+        // rather than of this act alone. A later act must not answer "no" on
+        // the first one's behalf just for having found the panel already open:
+        // a close the first act scheduled and the second disowned still fires,
+        // into the middle of the second act's flight. But an act that asked for
+        // the panel itself does disclaim it, whichever act stood it up.
+        errandOpenedPanel.current = errandBorrowedPanel(errandOpenedPanel.current, launch);
         return;
       }
       // Nothing flew, so nothing is coming to release it.

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -283,7 +283,44 @@ export function App(): React.JSX.Element {
   const errands = useRef(0);
 
   /**
-   * What the panel is not drawing yet, because Luke has not reached it.
+   * The way to tell the conversation what the store now holds, for the spoken
+   * carrier below. Only the drawing waits for Luke: the guide has to describe
+   * the store's answer at once, because the next call in the same turn is
+   * validated against it — an effort named in the same breath as a model only
+   * exists in the guide the model change just made true. A ref because the
+   * carrier is created before the conversation hook that owns the publisher.
+   */
+  const publishGuideRef = useRef<(next: AppSettings) => void>(() => {});
+  /**
+   * The newest snapshot this window has seen, drawn or still held back.
+   *
+   * What waits for Luke is the drawing alone. What the next call of the same
+   * turn composes against has to be current, or a model and the effort named
+   * in the same breath would compose the second against the selection the
+   * first just replaced. So the spoken carrier writes this the moment the
+   * store answers, before any of it is drawn.
+   *
+   * It cannot be only the spoken answers, though, or a switch pressed by hand
+   * between two spoken changes would be shadowed by a snapshot older than it.
+   * So every write goes through {@link applySettings} and this is always at
+   * least as new as the drawn state, whichever path wrote it.
+   */
+  const answeredSettings = useRef<AppSettings | undefined>(undefined);
+  /**
+   * The one way settings are drawn. Every path travels it — a row's own press,
+   * a key stored or removed, another window's push, and an errand's hold
+   * coming down — so the snapshot the next spoken change composes against is
+   * never older than the panel it is drawn on.
+   */
+  const applySettings = useCallback(
+    (next: AppSettings) => {
+      answeredSettings.current = next;
+      setSettings(next);
+    },
+    [setSettings],
+  );
+  /**
+   * Draws what the panel was not drawing yet, because Luke had not reached it.
    *
    * The change itself is made the moment it is asked for — nothing here delays
    * a write, and the spoken answer reports what actually happened. What waits
@@ -301,32 +338,17 @@ export function App(): React.JSX.Element {
    * flight they are timing, and an errand whose callbacks changed identity
    * would be torn down and rebuilt mid-air.
    */
-  /**
-   * The way to tell the conversation what the store now holds, for the spoken
-   * carrier below. Only the drawing waits for Luke: the guide has to describe
-   * the store's answer at once, because the next call in the same turn is
-   * validated against it — an effort named in the same breath as a model only
-   * exists in the guide the model change just made true. A ref because the
-   * carrier is created before the conversation hook that owns the publisher.
-   */
-  const publishGuideRef = useRef<(next: AppSettings) => void>(() => {});
-  /**
-   * The newest snapshot the store has answered with, held back from the panel
-   * or not. What waits for Luke is the drawing; what the next call in the same
-   * turn composes against must be current, or a model and its effort asked for
-   * in one breath would compose the second against the selection the first
-   * replaced. Kept beside the holds rather than in one, because a hold belongs
-   * to a single act and this is what every act after it has to read.
-   */
-  const answeredSettings = useRef<AppSettings | undefined>(undefined);
-  const drawErrandHold = useCallback((hold: ErrandHold) => {
-    if (hold.settings !== undefined) setSettings(hold.settings);
-    // Folded into whatever the view is at the moment it lands rather than the
-    // moment it was chosen: the list corrects its own filter during render
-    // when one empties, and a snapshot taken at the ask would undo that.
-    const view = hold.view;
-    if (view !== undefined) setSessionView((current) => ({ ...current, ...view }));
-  }, [setSettings]);
+  const drawErrandHold = useCallback(
+    (hold: ErrandHold) => {
+      if (hold.settings !== undefined) applySettings(hold.settings);
+      // Folded into whatever the view is at the moment it lands rather than the
+      // moment it was chosen: the list corrects its own filter during render
+      // when one empties, and a snapshot taken at the ask would undo that.
+      const view = hold.view;
+      if (view !== undefined) setSessionView((current) => ({ ...current, ...view }));
+    },
+    [applySettings],
+  );
 
   /**
    * Every act this reply asked Luke to sign, in the order he will sign them.
@@ -499,10 +521,10 @@ export function App(): React.JSX.Element {
    */
   const applySettingsReply = useCallback(
     (result: SettingsUpdateResult) => {
-      setSettings(result.settings);
+      applySettings(result.settings);
       return result.reason;
     },
-    [setSettings],
+    [applySettings],
   );
 
   const changeVoiceCaptions = useCallback(
@@ -534,7 +556,7 @@ export function App(): React.JSX.Element {
     isSendable: isSubmittable,
     send: async (sending) => {
       const result = await window.sidecar.setProviderApiKey(sending.providerId, sending.draft);
-      setSettings(result.settings);
+      applySettings(result.settings);
       return result.reason ? { rejection: result.reason } : {};
     },
     pointerInside: pointerIsInside,
@@ -578,7 +600,7 @@ export function App(): React.JSX.Element {
   const removeProviderApiKey = useCallback(
     async (providerId: CredentialProviderId) => {
       const result = await window.sidecar.setProviderApiKey(providerId, undefined);
-      setSettings(result.settings);
+      applySettings(result.settings);
       // Delete and the field are on the row together once the panel has been
       // brought back around an entry, and a key that has been removed cannot be
       // replaced.
@@ -587,7 +609,7 @@ export function App(): React.JSX.Element {
       }
       return result.reason;
     },
-    [credentialsEntry.apply, credentialsEntry.latest, setSettings],
+    [applySettings, credentialsEntry.apply, credentialsEntry.latest],
   );
 
   const credentials: CredentialEntryControl = {
@@ -1217,7 +1239,7 @@ export function App(): React.JSX.Element {
         errandRun.current = supersedeErrandSettings(errandRun.current);
         onChange(pushed);
       }),
-    setSettings,
+    applySettings,
   );
   const acceptOutputAudioBootstrap = useBootstrapRacedChannel(
     (onChange) => window.sidecar.onOutputAudioChanged(onChange),

--- a/apps/desktop/src/renderer/errand-queue.ts
+++ b/apps/desktop/src/renderer/errand-queue.ts
@@ -1,0 +1,211 @@
+import type { AppSettings } from "../shared/contracts";
+import { ERRAND_WAIT, type ErrandTarget, type ErrandWait } from "./luke-errand";
+import type { PanelTab } from "./panel-tabs";
+import type { SessionView } from "./session-model";
+import type { SettingsSubview, SettingsView } from "./settings-views";
+
+/**
+ * The order Luke signs his own work in, when one reply asked for more than one
+ * act.
+ *
+ * A reply may carry several tool calls, and they are answered one after
+ * another with nothing between them but a couple of IPC round trips — far
+ * inside the beat an errand waits before it sets off. So the acts arrive as a
+ * burst and the flights cannot: there is only ever one Luke on screen, one
+ * panel, and one settings page drawn at a time, and each of those is something
+ * a second act would take out from under the first. Handed straight to the
+ * flight, the second act ends the first mid-air: the mark never leaves the
+ * strip, both controls flip at once, and only the last act is seen being done
+ * — which is the whole of what an errand is for.
+ *
+ * So the acts queue and the flights run in turn. Each act carries what it is
+ * holding back — the settings snapshot the store answered with, or the
+ * narrowing a spoken ask chose — so a hold belongs to the act that caught it
+ * rather than to whichever flight happens to be out, and each is drawn on its
+ * own tap. Each also carries where it has to be seen, so the panel is turned
+ * to a page when the act that needs it comes up rather than when it was asked
+ * for: a page turned at the ask would take the first act's control off screen
+ * before Luke ever reached it.
+ *
+ * Two flights in sequence cost more than one, and that is the deliberate
+ * choice. A chained flight waits only a beat, and the panel stays up across
+ * the whole run rather than standing down and coming back — so the second act
+ * costs one flight and nothing else. Folding several acts into one flight with
+ * a stop on each control would be shorter still, and it was rejected: the two
+ * settings may live on different pages, a page that is not drawn has nowhere
+ * to land, and the page cannot turn under a mark in the air without the errand
+ * deciding when to turn it — which is exactly the one thing the errand does
+ * not do. A merged flight could therefore only ever cover the same-page case,
+ * leaving two mechanisms where one does. Two acts are also two acts, and each
+ * is worth being seen being done.
+ *
+ * Every function here is pure, and every hold that goes in comes out exactly
+ * once — at the tap that signs it, when the flight it belonged to is over, or
+ * in the flush that ends a run nobody can watch any more. A hold nobody
+ * releases strands a switch showing the wrong state for as long as the panel
+ * is open.
+ */
+
+/** What an act is holding back until Luke's tap lands on the control. */
+export interface ErrandHold {
+  /** The snapshot the settings store answered the write with. */
+  settings?: AppSettings;
+  /** The narrowing or re-ordering a spoken ask chose for the list. */
+  view?: Partial<SessionView>;
+}
+
+/** Holding nothing, which is what a run with everything drawn answers. */
+export const NOTHING_HELD: ErrandHold = {};
+
+/** One act waiting to be signed. */
+export interface PendingErrand {
+  /** Where it should be signed, best first. An act with none flies nowhere. */
+  targets: readonly ErrandTarget[];
+  /** The tab its control is drawn on. */
+  tab: PanelTab;
+  /** The settings page it is drawn on, when it is drawn on one at all. */
+  page?: SettingsSubview;
+  /** Whether this act is what stood the panel up. */
+  opening: boolean;
+  /**
+   * Whether the panel is only borrowed to show this act. A switch has to be
+   * seen moving, so a settings change stands the panel up to show one and
+   * gives it back when the run is over; a panel someone asked for out loud is
+   * the answer itself and stays where it was put.
+   */
+  borrowsPanel: boolean;
+  hold: ErrandHold;
+}
+
+/** Every act one reply asked Luke to sign: the one in the air, then the rest. */
+export interface ErrandRun {
+  /** The act being signed right now, once it has been handed to the flight. */
+  flying?: PendingErrand;
+  /** The acts still waiting their turn, oldest first. */
+  waiting: readonly PendingErrand[];
+}
+
+/** Nothing in the air and nothing waiting. */
+export const EMPTY_ERRAND_RUN: ErrandRun = { waiting: [] };
+
+/** Whether there is nothing left to sign, which is when a panel may stand down. */
+export function errandRunIdle(run: ErrandRun): boolean {
+  return run.flying === undefined && run.waiting.length === 0;
+}
+
+/** Adds an act to the end of the run. */
+export function armErrand(run: ErrandRun, pending: PendingErrand): ErrandRun {
+  return { ...run, waiting: [...run.waiting, pending] };
+}
+
+/**
+ * The next act to hand to the flight, and the run with it in the air. Nothing
+ * while one is already out — that is the whole point — and nothing when there
+ * is none left waiting.
+ */
+export function nextErrand(run: ErrandRun): { run: ErrandRun; launch?: PendingErrand } {
+  if (run.flying !== undefined) return { run };
+  const [next, ...rest] = run.waiting;
+  if (next === undefined) return { run };
+  return { run: { flying: next, waiting: rest }, launch: next };
+}
+
+/**
+ * Several holds drawn as one. The newest snapshot is the only true one — they
+ * are cumulative, so the last carries every change made before it — while the
+ * view patches are folded in the order they were chosen, because each names
+ * only the part of the view it changed.
+ */
+export function foldErrandHolds(holds: readonly ErrandHold[]): ErrandHold {
+  let settings: AppSettings | undefined;
+  let view: Partial<SessionView> | undefined;
+  for (const hold of holds) {
+    if (hold.settings !== undefined) settings = hold.settings;
+    if (hold.view !== undefined) view = { ...view, ...hold.view };
+  }
+  return {
+    ...(settings === undefined ? {} : { settings }),
+    ...(view === undefined ? {} : { view }),
+  };
+}
+
+/**
+ * The tap has landed: what the act in the air was holding is drawn, and it is
+ * left holding nothing, so the end of its own flight draws it no second time.
+ */
+export function landErrand(run: ErrandRun): { run: ErrandRun; hold: ErrandHold } {
+  const flying = run.flying;
+  if (flying === undefined) return { run, hold: NOTHING_HELD };
+  return { run: { ...run, flying: { ...flying, hold: NOTHING_HELD } }, hold: flying.hold };
+}
+
+/**
+ * The flight is over. The act leaves the air, and anything it is somehow still
+ * holding is drawn — a flight that never reached its control still has to
+ * leave the switch showing the truth.
+ */
+export function finishErrand(run: ErrandRun): { run: ErrandRun; hold: ErrandHold } {
+  const flying = run.flying;
+  if (flying === undefined) return { run, hold: NOTHING_HELD };
+  return { run: { waiting: run.waiting }, hold: flying.hold };
+}
+
+/**
+ * The run cannot go on: the panel that was going to show it has gone, so there
+ * is nothing to sign in front of anybody. Everything still held is drawn at
+ * once, in the order it was caught.
+ */
+export function flushErrands(run: ErrandRun): { run: ErrandRun; hold: ErrandHold } {
+  const held = [
+    ...(run.flying === undefined ? [] : [run.flying.hold]),
+    ...run.waiting.map((pending) => pending.hold),
+  ];
+  return { run: EMPTY_ERRAND_RUN, hold: foldErrandHolds(held) };
+}
+
+/**
+ * Another window changed the settings. Its push is newer than anything this
+ * run is still carrying, so it takes every held snapshot with it: released
+ * afterwards, one caught before the push arrived would draw the store as it
+ * was rather than as it is. A held view is left alone — it is this window's own
+ * choice about its own list, and no other window has said anything about it.
+ */
+export function supersedeErrandSettings(run: ErrandRun): ErrandRun {
+  const superseded = (pending: PendingErrand): PendingErrand => {
+    if (pending.hold.settings === undefined) return pending;
+    const { settings: _stale, ...kept } = pending.hold;
+    return { ...pending, hold: kept };
+  };
+  return {
+    ...(run.flying === undefined ? {} : { flying: superseded(run.flying) }),
+    waiting: run.waiting.map(superseded),
+  };
+}
+
+/**
+ * What a flight has to wait out before it can measure anything, read off what
+ * the panel is drawing at the moment the act comes up rather than at the
+ * moment it was asked for. In a run of several, the page drawn when the second
+ * act was spoken is the first act's page, and by the time the second flies it
+ * may be a third — only the reading taken as it launches says what the mark
+ * will actually land on.
+ *
+ * A panel that had to open is a whole page of content arriving. A control
+ * already drawn owes nothing but a beat. Anything else is a page being turned:
+ * the leaving one goes first and the arriving one lands on the panel's own
+ * fan, which is the longest trail of the three.
+ */
+export function errandWait(input: {
+  opening: boolean;
+  tab: PanelTab;
+  page?: SettingsSubview;
+  drawnTab: PanelTab;
+  drawnPage: SettingsView;
+}): ErrandWait {
+  if (input.opening) return ERRAND_WAIT.CONTENT;
+  // The tab bar and the list's own options button are drawn outside the
+  // settings pages, so there is no page to turn to for them.
+  if (input.page === undefined) return ERRAND_WAIT.AT_ONCE;
+  if (input.drawnTab === input.tab && input.drawnPage === input.page) return ERRAND_WAIT.AT_ONCE;
+  return ERRAND_WAIT.PAGE;
+}

--- a/apps/desktop/src/renderer/errand-queue.ts
+++ b/apps/desktop/src/renderer/errand-queue.ts
@@ -183,6 +183,23 @@ export function supersedeErrandSettings(run: ErrandRun): ErrandRun {
 }
 
 /**
+ * Whether the panel is still the run's to put away once this act has been
+ * taken up.
+ *
+ * A run signs its acts in turn under one panel, so the question is asked of
+ * the run rather than of any single act. An act that borrows the panel to show
+ * a switch claims it back only if it is the one that stood it up — a panel
+ * that was already open is somewhere the developer had gone themselves. An act
+ * that asked for the panel in its own right disclaims it outright, whichever
+ * act put it there: once someone has asked out loud to see the panel, closing
+ * it afterwards is taking it from them for having spoken.
+ */
+export function errandBorrowedPanel(borrowed: boolean, launch: PendingErrand): boolean {
+  if (!launch.borrowsPanel) return false;
+  return borrowed || launch.opening;
+}
+
+/**
  * What a flight has to wait out before it can measure anything, read off what
  * the panel is drawing at the moment the act comes up rather than at the
  * moment it was asked for. In a run of several, the page drawn when the second

--- a/apps/desktop/src/renderer/luke-errand.tsx
+++ b/apps/desktop/src/renderer/luke-errand.tsx
@@ -47,6 +47,11 @@ import { parseMilliseconds, parsePixels, STILL_MS } from "./session-motion";
  * is away flies nowhere at all, because attribution is only worth anything to
  * someone who can see what was attributed.
  *
+ * One flight at a time, and that is the caller's to guarantee: a reply may ask
+ * for several acts at once, and a new errand handed over mid-flight abandons
+ * the one in the air wherever it had got to. `errand-queue.ts` is where they
+ * are made to take turns, and the reason each act carries its own hold.
+ *
  * Everything moves with `transform` and `opacity` alone; the control it lands
  * on is read for its box and never restyled, so nothing about a settings row
  * changes because an errand happened to visit it. The one thing it does move
@@ -547,18 +552,20 @@ export interface LukeErrandProps {
   /**
    * The tap has landed, which is the moment the control it flew to should be
    * seen to move. Called once per errand and always — at once when there is
-   * no flight to make — so whatever is waiting on it is never left held. The
-   * errand rides along so the caller can tell a replaced flight's beat from
-   * the current one's: what the app holds belongs to the newest errand, and
-   * an overtaken flight must not release it early.
+   * no flight to make — so whatever is waiting on it is never left held.
+   *
+   * Neither beat says which errand it belongs to, because there is only ever
+   * one it could belong to: a second act waits its turn rather than overtaking
+   * the flight in the air, so no beat is ever a stale flight's.
    */
-  onLanded?: (errand: Errand) => void;
+  onLanded?: () => void;
   /**
    * The flight is over, or was abandoned. Called once per errand and always,
-   * on the same terms and carrying the same errand, so a panel that was stood
-   * up for an errand knows when it may stand back down.
+   * on the same terms, so a panel that was stood up for an errand knows when
+   * it may stand back down — and so the act waiting behind this one knows it
+   * may set off.
    */
-  onReturned?: (errand: Errand) => void;
+  onReturned?: () => void;
 }
 
 /**
@@ -582,9 +589,6 @@ export function LukeErrand({ errand, onLanded, onReturned }: LukeErrandProps): R
 
   useEffect(() => {
     if (errand === undefined) return;
-    // Held by name for the beats below: a closure over the prop would not
-    // survive the narrowing, and each beat reports the errand it belongs to.
-    const flown = errand;
     // Each beat is released once and only once, however this effect leaves —
     // and releasing one that never came due is better than leaving the app
     // holding a switch that will never be allowed to move.
@@ -593,13 +597,13 @@ export function LukeErrand({ errand, onLanded, onReturned }: LukeErrandProps): R
     const land = () => {
       if (landed) return;
       landed = true;
-      onLanded?.(flown);
+      onLanded?.();
     };
     const returnHome = () => {
       land();
       if (returned) return;
       returned = true;
-      onReturned?.(flown);
+      onReturned?.();
     };
 
     const markElement = mark.current;

--- a/apps/desktop/tests/errand-queue.test.ts
+++ b/apps/desktop/tests/errand-queue.test.ts
@@ -6,6 +6,7 @@ import {
   EMPTY_ERRAND_RUN,
   type ErrandHold,
   type ErrandRun,
+  errandBorrowedPanel,
   errandRunIdle,
   errandWait,
   finishErrand,
@@ -219,6 +220,34 @@ test("the run is idle only once there is nothing in the air and nothing waiting"
   const flying = nextErrand(run(only)).run;
   assert.equal(errandRunIdle(flying), false);
   assert.equal(errandRunIdle(finishErrand(flying).run), true);
+});
+
+test("a panel asked for out loud is nobody's to take away afterwards", () => {
+  const shows = (opening: boolean): PendingErrand => ({
+    targets: [ERRAND_TARGET.SESSIONS_TAB],
+    tab: PANEL_TAB.SESSIONS,
+    opening,
+    borrowsPanel: false,
+    hold: NOTHING_HELD,
+  });
+  const changes = (opening: boolean): PendingErrand =>
+    settingAct(APP_SETTING_ID.VOICE_CAPTIONS, SETTINGS_VIEW.VOICE, NOTHING_HELD, opening);
+
+  // A switch has to be seen moving, so a settings change borrows the panel and
+  // gives it back — but only the one it stood up itself.
+  assert.equal(errandBorrowedPanel(false, changes(true)), true);
+  assert.equal(errandBorrowedPanel(false, changes(false)), false);
+
+  // A second settings act finds the panel already open, so its own opening is
+  // false. It must not answer "no" on the first act's behalf: the close the
+  // first one is owed still has to happen, and only once the run is done.
+  assert.equal(errandBorrowedPanel(true, changes(false)), true);
+
+  // The panel someone asked for out loud is the answer itself, so it stays —
+  // and it stays even when an earlier settings act is what stood it up, which
+  // is the whole of this rule.
+  assert.equal(errandBorrowedPanel(true, shows(false)), false);
+  assert.equal(errandBorrowedPanel(false, shows(true)), false);
 });
 
 test("a flight waits out whatever the act it signs has set in motion", () => {

--- a/apps/desktop/tests/errand-queue.test.ts
+++ b/apps/desktop/tests/errand-queue.test.ts
@@ -1,0 +1,267 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { PANEL_FORM_FACTOR, REALTIME_VOICE, REALTIME_VOICE_SPEED } from "@sidecar/core";
+import {
+  armErrand,
+  EMPTY_ERRAND_RUN,
+  type ErrandHold,
+  type ErrandRun,
+  errandRunIdle,
+  errandWait,
+  finishErrand,
+  flushErrands,
+  foldErrandHolds,
+  landErrand,
+  NOTHING_HELD,
+  nextErrand,
+  type PendingErrand,
+  supersedeErrandSettings,
+} from "../src/renderer/errand-queue";
+import { ERRAND_TARGET, ERRAND_WAIT } from "../src/renderer/luke-errand";
+import { APP_SETTING_ID } from "../src/renderer/luke-guide";
+import { PANEL_TAB } from "../src/renderer/panel-tabs";
+import { SESSION_FILTER, SESSION_SORT } from "../src/renderer/session-model";
+import { SETTINGS_VIEW } from "../src/renderer/settings-views";
+import type { AppSettings } from "../src/shared/contracts";
+import { CREDENTIAL_SOURCE, SECRET_STORAGE } from "../src/shared/contracts";
+import { CREDENTIAL_PROVIDER_ID } from "../src/shared/credential-providers";
+
+/** A settings snapshot, told apart from the next only by the switch that moved. */
+function settings(captions: boolean): AppSettings {
+  return {
+    credentialSources: {
+      [CREDENTIAL_PROVIDER_ID.CONDUCTOR]: CREDENTIAL_SOURCE.NONE,
+      [CREDENTIAL_PROVIDER_ID.COPILOT]: CREDENTIAL_SOURCE.NONE,
+      [CREDENTIAL_PROVIDER_ID.CURSOR]: CREDENTIAL_SOURCE.NONE,
+      [CREDENTIAL_PROVIDER_ID.DEVIN]: CREDENTIAL_SOURCE.NONE,
+      [CREDENTIAL_PROVIDER_ID.JULES]: CREDENTIAL_SOURCE.NONE,
+      [CREDENTIAL_PROVIDER_ID.LINEAR]: CREDENTIAL_SOURCE.NONE,
+      [CREDENTIAL_PROVIDER_ID.OPENAI]: CREDENTIAL_SOURCE.NONE,
+    },
+    secretStorage: SECRET_STORAGE.UNKNOWN,
+    showInMenuBar: true,
+    showInDock: false,
+    voice: REALTIME_VOICE.CEDAR,
+    voiceSpeed: REALTIME_VOICE_SPEED.NORMAL,
+    voiceCaptions: captions,
+    duckOtherMedia: true,
+    showOnAllDisplays: false,
+    formFactor: PANEL_FORM_FACTOR.BUBBLE,
+  };
+}
+
+/** A settings change, as the carrier arms one. */
+function settingAct(
+  target: PendingErrand["targets"][number],
+  page: PendingErrand["page"],
+  hold: ErrandHold,
+  opening = false,
+): PendingErrand {
+  return {
+    targets: [target],
+    tab: PANEL_TAB.SETTINGS,
+    ...(page === undefined ? {} : { page }),
+    opening,
+    borrowsPanel: true,
+    hold,
+  };
+}
+
+/** Arms every act of one reply, in the order the calls were answered. */
+function run(...acts: readonly PendingErrand[]): ErrandRun {
+  return acts.reduce(armErrand, EMPTY_ERRAND_RUN);
+}
+
+const CAPTIONS_ON = settings(true);
+const CAPTIONS_OFF = settings(false);
+
+test("a second act waits its turn rather than taking the first out of the air", () => {
+  const first = settingAct(APP_SETTING_ID.VOICE_CAPTIONS, SETTINGS_VIEW.VOICE, {
+    settings: CAPTIONS_ON,
+  });
+  const second = settingAct(APP_SETTING_ID.SHOW_IN_DOCK, SETTINGS_VIEW.APPEARANCE, {
+    settings: CAPTIONS_OFF,
+  });
+
+  const armed = nextErrand(run(first, second));
+  assert.equal(armed.launch, first);
+  assert.equal(armed.run.flying, first);
+
+  // The whole of the fix: while one is out, nothing else is handed to the
+  // flight. A second errand handed over here re-identifies the one in the air,
+  // which ends it before it has left the strip.
+  const overtaking = nextErrand(armed.run);
+  assert.equal(overtaking.launch, undefined);
+  assert.equal(overtaking.run.flying, first);
+  assert.deepEqual(overtaking.run.waiting, [second]);
+});
+
+test("each act's change is drawn on its own tap, and never on another's", () => {
+  const first = settingAct(APP_SETTING_ID.VOICE_CAPTIONS, SETTINGS_VIEW.VOICE, {
+    settings: CAPTIONS_ON,
+  });
+  const second = settingAct(APP_SETTING_ID.SHOW_IN_DOCK, SETTINGS_VIEW.APPEARANCE, {
+    settings: CAPTIONS_OFF,
+  });
+
+  const flying = nextErrand(run(first, second)).run;
+  const landed = landErrand(flying);
+  assert.deepEqual(landed.hold, { settings: CAPTIONS_ON });
+  // The act still waiting is still holding: its switch does not move until
+  // Luke reaches it either.
+  assert.deepEqual(landed.run.waiting, [second]);
+
+  // The tap released it, so the end of that same flight draws it no second
+  // time — a hold drawn twice would re-apply a snapshot the next act's write
+  // has already superseded.
+  const finished = finishErrand(landed.run);
+  assert.deepEqual(finished.hold, NOTHING_HELD);
+  assert.equal(finished.run.flying, undefined);
+
+  const next = nextErrand(finished.run);
+  assert.equal(next.launch, second);
+  assert.deepEqual(landErrand(next.run).hold, { settings: CAPTIONS_OFF });
+});
+
+test("a flight that never reached its control still draws what it was holding", () => {
+  // No tap landed, so nothing was released — and a hold nobody releases leaves
+  // a switch showing the wrong state for as long as the panel is open.
+  const only = settingAct(APP_SETTING_ID.VOICE_CAPTIONS, SETTINGS_VIEW.VOICE, {
+    settings: CAPTIONS_ON,
+  });
+  const finished = finishErrand(nextErrand(run(only)).run);
+  assert.deepEqual(finished.hold, { settings: CAPTIONS_ON });
+  assert.ok(errandRunIdle(finished.run));
+});
+
+test("a panel that has gone draws everything the run was still holding", () => {
+  const flying = settingAct(APP_SETTING_ID.VOICE_CAPTIONS, SETTINGS_VIEW.VOICE, {
+    settings: CAPTIONS_ON,
+  });
+  const waiting = settingAct(APP_SETTING_ID.SHOW_IN_DOCK, SETTINGS_VIEW.APPEARANCE, {
+    settings: CAPTIONS_OFF,
+  });
+  const flushed = flushErrands(nextErrand(run(flying, waiting)).run);
+
+  // The snapshots are cumulative, so the newest is the only true one.
+  assert.deepEqual(flushed.hold, { settings: CAPTIONS_OFF });
+  assert.ok(errandRunIdle(flushed.run));
+});
+
+test("holds folded together keep the last snapshot and every part of the view", () => {
+  assert.deepEqual(
+    foldErrandHolds([
+      { settings: CAPTIONS_ON, view: { filter: SESSION_FILTER.CLOUD } },
+      { view: { sort: SESSION_SORT.RECENCY } },
+      { settings: CAPTIONS_OFF },
+    ]),
+    {
+      settings: CAPTIONS_OFF,
+      view: { filter: SESSION_FILTER.CLOUD, sort: SESSION_SORT.RECENCY },
+    },
+  );
+  assert.deepEqual(foldErrandHolds([]), NOTHING_HELD);
+  assert.deepEqual(foldErrandHolds([NOTHING_HELD, NOTHING_HELD]), NOTHING_HELD);
+});
+
+test("a settings push takes every held snapshot with it and leaves the held view", () => {
+  const flying = settingAct(APP_SETTING_ID.VOICE_CAPTIONS, SETTINGS_VIEW.VOICE, {
+    settings: CAPTIONS_ON,
+  });
+  const narrowing: PendingErrand = {
+    targets: [ERRAND_TARGET.LIST_OPTIONS, ERRAND_TARGET.SESSIONS_TAB],
+    tab: PANEL_TAB.SESSIONS,
+    opening: false,
+    borrowsPanel: false,
+    hold: { view: { filter: SESSION_FILTER.CLOUD } },
+  };
+  const waiting = settingAct(APP_SETTING_ID.SHOW_IN_DOCK, SETTINGS_VIEW.APPEARANCE, {
+    settings: CAPTIONS_OFF,
+  });
+
+  const superseded = supersedeErrandSettings(nextErrand(run(flying, narrowing, waiting)).run);
+
+  // Another window's push is newer than anything caught before it arrived.
+  assert.deepEqual(landErrand(superseded).hold, NOTHING_HELD);
+  // The list is this window's own choice, and no other window said anything
+  // about it.
+  assert.deepEqual(
+    superseded.waiting.map((pending) => pending.hold),
+    [{ view: { filter: SESSION_FILTER.CLOUD } }, NOTHING_HELD],
+  );
+});
+
+test("an act with nowhere to land leaves the run to the next one", () => {
+  // The guide's ids travel as plain text, so an act can name a control this
+  // build does not draw. It is over the moment it is taken up.
+  const nowhere: PendingErrand = {
+    targets: [],
+    tab: PANEL_TAB.SETTINGS,
+    opening: false,
+    borrowsPanel: true,
+    hold: { settings: CAPTIONS_ON },
+  };
+  const second = settingAct(APP_SETTING_ID.SHOW_IN_DOCK, SETTINGS_VIEW.APPEARANCE, {
+    settings: CAPTIONS_OFF,
+  });
+
+  const taken = nextErrand(run(nowhere, second));
+  assert.deepEqual(taken.launch?.targets, []);
+  const finished = finishErrand(taken.run);
+  assert.deepEqual(finished.hold, { settings: CAPTIONS_ON });
+  assert.equal(nextErrand(finished.run).launch, second);
+});
+
+test("the run is idle only once there is nothing in the air and nothing waiting", () => {
+  const only = settingAct(APP_SETTING_ID.VOICE_CAPTIONS, SETTINGS_VIEW.VOICE, NOTHING_HELD);
+  assert.equal(errandRunIdle(EMPTY_ERRAND_RUN), true);
+  assert.equal(errandRunIdle(run(only)), false);
+  const flying = nextErrand(run(only)).run;
+  assert.equal(errandRunIdle(flying), false);
+  assert.equal(errandRunIdle(finishErrand(flying).run), true);
+});
+
+test("a flight waits out whatever the act it signs has set in motion", () => {
+  const drawn = { drawnTab: PANEL_TAB.SETTINGS, drawnPage: SETTINGS_VIEW.VOICE };
+
+  // A panel that had to open is a whole page of content arriving, whatever
+  // else is true.
+  assert.equal(
+    errandWait({ ...drawn, opening: true, tab: PANEL_TAB.SETTINGS, page: SETTINGS_VIEW.VOICE }),
+    ERRAND_WAIT.CONTENT,
+  );
+  // The page the control is on is already the drawn one: a beat, and go.
+  assert.equal(
+    errandWait({ ...drawn, opening: false, tab: PANEL_TAB.SETTINGS, page: SETTINGS_VIEW.VOICE }),
+    ERRAND_WAIT.AT_ONCE,
+  );
+  // The second of two settings, on a page the first was not on: the leaving
+  // page goes before the arriving one is drawn at all.
+  assert.equal(
+    errandWait({
+      ...drawn,
+      opening: false,
+      tab: PANEL_TAB.SETTINGS,
+      page: SETTINGS_VIEW.APPEARANCE,
+    }),
+    ERRAND_WAIT.PAGE,
+  );
+  // Same page, but the panel is showing the sessions: the tab has to come
+  // forward, and it arrives on its own front page first.
+  assert.equal(
+    errandWait({
+      drawnTab: PANEL_TAB.SESSIONS,
+      drawnPage: SETTINGS_VIEW.ROOT,
+      opening: false,
+      tab: PANEL_TAB.SETTINGS,
+      page: SETTINGS_VIEW.VOICE,
+    }),
+    ERRAND_WAIT.PAGE,
+  );
+  // The tab bar and the list's options button are drawn outside the settings
+  // pages, so an act landing on one waits for no page at all.
+  assert.equal(
+    errandWait({ ...drawn, opening: false, tab: PANEL_TAB.SESSIONS }),
+    ERRAND_WAIT.AT_ONCE,
+  );
+});


### PR DESCRIPTION
## The symptom

Ask Luke to change two settings in one breath and only the second one gets an errand. The first switch flips with nobody near it — no flight, no tap — which is exactly the glitch the errand exists to prevent.

## What was happening

`#answerToolCalls` answers a reply's calls in a sequential loop, so the second `carryAppAction` lands a couple of IPC round trips after the first — far inside the first errand's launch delay (140ms at best, 910ms when a page also turns). The second `setErrand` re-identified the errand, React re-ran `LukeErrand`'s effect, and its cleanup called `abandon()` on a flight that had not yet left the strip. `abandon()` releases both beats, so the held snapshot was drawn at once.

Two more things were wrong under it, and both mattered:

- **The page turned at the ask.** `carryAppAction` called `setSettingsView(page)` immediately. With two settings on different pages, the second call took the first act's control off screen before Luke could have reached it — so that pair could never both be signed, queue or no queue.
- **The panel's stand-down was disowned mid-flight.** Errand 1 opened the panel and scheduled a close; errand 2 found the panel already open, so its `opening` was false and it set `errandOpenedPanel.current = false` — but the close still fired, into flight 2. Since a flight aborts when the panel closes under it, that cut flight 2 short too.

## What I built

A queue, in `apps/desktop/src/renderer/errand-queue.ts` — a pure state machine with `node:test` coverage, no DOM.

- **The acts take turns.** One flight at a time; `nextErrand` hands nothing over while one is out. `LukeErrand` itself is unchanged apart from a comment stating that one-at-a-time is the caller's to guarantee.
- **The hold is per-act.** `PendingErrand` carries its own `ErrandHold` (the settings snapshot, or the view patch), so each change is drawn on its own tap. Every hold leaves exactly once, on every path out: `landErrand` at the tap, `finishErrand` if the flight never reached its control, `flushErrands` when the panel goes and there is nobody left to show anything to. Snapshots are cumulative, so a flush keeps the newest and view patches fold in order.
- **The page turns when the act comes up**, not when it was asked for, and `errandWait` is computed from what the panel is drawing at that exact moment. A second setting on another page gets `ERRAND_WAIT.PAGE`'s longer trail; on the same page it gets `AT_ONCE`.
- **The panel stands down once, at the end of the run.** `borrowsPanel` distinguishes a panel borrowed to show a switch (a settings act — give it back) from one that was the answer itself (a spoken `show_panel` — leave it where it was put). That second distinction is new: previously the panel branch never set `errandOpenedPanel` at all, and folding both kinds into one queue would have started closing panels people asked for.
- Another window's settings push still supersedes every held snapshot, and now leaves a held *view* alone — that is this window's own choice about its own list.

## Why a queue and not one flight with two stops

The obvious shorter answer is a single flight that taps both controls before floating home: ~1.66s instead of ~2.4s of flying, and it reads as one continuous act. I rejected it:

- **The two settings may live on different pages.** A page that is not drawn has nowhere to land, and the page cannot turn under a mark in the air without the errand deciding when to turn it — which is the one thing `luke-errand.tsx` is explicitly not allowed to do. So a merged flight could only ever cover the same-page case, leaving two mechanisms where one does.
- **Merging needs the errand to absorb a stop after React has committed it**, which is precisely the re-identification that causes this bug.
- Two acts are two acts. Each is worth being seen being done.

**So, deliberately, on the duration:** two same-page settings from a closed panel cost 820ms (the opening) + 1060ms + 140ms + 1060ms ≈ 3.1s; across pages the second wait is 910ms instead of 140ms, so ≈ 3.9s. Every one of those beats is a token — nothing is shortened by hand — and the chained flight is already at its floor (`AT_ONCE` is one `--duration-quick`). The panel staying up across the whole run is what keeps the second act down to one flight and nothing else. Luke is speaking over all of it, so it reads as accompaniment rather than a wait; if it turns out to drag in Dean's hands, the honest lever is the token, not this code.

## Invariants held

- **Drawn on the tap, released exactly once on every path out** — now per-act, and tested for: released-at-tap is not drawn again at the end of the same flight, an unlanded flight still draws what it held, and a flush after the panel closes draws everything still held.
- **Only ever one Luke.** Unchanged: each flight owns the strip face's fade for exactly its own duration. Between two flights the mark is parked on a fully-drawn face and cancelled there (resting opacity 0 over a face at 1 — no frame with two, none with neither), and the next flight cannot start sooner than its own launch delay.
- **Nothing drawn off the black** — `errandSettledBound` and `errandDrift` untouched.
- **Every beat from the motion tokens** — no literal milliseconds added; `errandFlies()` still gates on `--duration-shape`, so capture runs and reduced motion get no flight at all.
- **Different pages handled** — `SETTING_PAGE` still decides, and `ERRAND_WAIT.PAGE` is now reachable for a *chained* act, which it never was before.

## Verification

- `./scripts/check.sh` — **passes** (lint, typecheck, 707 desktop tests including 9 new, build).
- `./scripts/verify.sh` — **not run: it needs macOS and this work was done in a Linux cloud sandbox.** No visual evidence was captured and no physical-notch check was performed. The motion claim here is a sequencing one rather than a new gesture — no keyframe, token, or bound changed — but the sequencing itself is exactly what wants eyes on a real Mac: ask Luke to change two settings on the same page, then two on different pages, and watch that each switch moves under his tap and that the panel stays up until the second flight is home.

## Not merging

Leaving this unmerged for Dean to test himself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/4d3332c1-fff5-449c-828d-d4aa16b7ed9c)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31967196171/artifacts/9268825863) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31967196171)

- Commit: `2593ffe94ba2ce3f97c624a7e05b3a6581cfb2c0`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
