### PR TITLE
fix(voice): let a paired model-and-effort ask land both halves

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -199,7 +199,10 @@ export function App(): React.JSX.Element {
   const [settingsView, setSettingsView] = useState<SettingsView>(SETTINGS_VIEW.ROOT);
   const [sessionView, setSessionView] = useState<SessionView>(DEFAULT_SESSION_VIEW);
   const [optionsOpen, setOptionsOpen] = useState(false);
-  const [settings, setSettings] = useState<AppSettings>();
+  // The latest is needed from the spoken-settings carrier, which cannot wait
+  // a render: two changes asked for in one breath arrive as two calls in one
+  // turn, and the second composes against whatever the first just stored.
+  const [settings, setSettings, settingsNow] = useStateWithRef<AppSettings | undefined>(undefined);
   const [errand, setErrand] = useState<Errand>();
   const [feedbackNotice, setFeedbackNotice] = useState<string>();
   // Counts for nothing except having changed: each tick re-renders the rows so
@@ -283,6 +286,15 @@ export function App(): React.JSX.Element {
    */
   const heldSettings = useRef<AppSettings | undefined>(undefined);
   const heldView = useRef<Partial<SessionView> | undefined>(undefined);
+  /**
+   * The way to tell the conversation what the store now holds, for the spoken
+   * carrier below. Only the drawing waits for Luke: the guide has to describe
+   * the store's answer at once, because the next call in the same turn is
+   * validated against it — an effort named in the same breath as a model only
+   * exists in the guide the model change just made true. A ref because the
+   * carrier is created before the conversation hook that owns the publisher.
+   */
+  const publishGuideRef = useRef<(next: AppSettings) => void>(() => {});
   const releaseErrandChange = useCallback(() => {
     const settings = heldSettings.current;
     const view = heldView.current;
@@ -293,7 +305,7 @@ export function App(): React.JSX.Element {
     // moment it was chosen: the list corrects its own filter during render
     // when one empties, and a snapshot taken at the ask would undo that.
     if (view !== undefined) setSessionView((current) => ({ ...current, ...view }));
-  }, []);
+  }, [setSettings]);
 
   /**
    * Whether the panel on screen is one an errand stood up. Only then is it the
@@ -398,10 +410,13 @@ export function App(): React.JSX.Element {
    * and any refusal for the row to show. Every settings row travels this
    * road so it redraws from what was stored rather than from the press.
    */
-  const applySettingsReply = useCallback((result: SettingsUpdateResult) => {
-    setSettings(result.settings);
-    return result.reason;
-  }, []);
+  const applySettingsReply = useCallback(
+    (result: SettingsUpdateResult) => {
+      setSettings(result.settings);
+      return result.reason;
+    },
+    [setSettings],
+  );
 
   const changeVoiceCaptions = useCallback(
     async (enabled: boolean) => applySettingsReply(await window.sidecar.setVoiceCaptions(enabled)),
@@ -485,7 +500,7 @@ export function App(): React.JSX.Element {
       }
       return result.reason;
     },
-    [credentialsEntry.apply, credentialsEntry.latest],
+    [credentialsEntry.apply, credentialsEntry.latest, setSettings],
   );
 
   const credentials: CredentialEntryControl = {
@@ -870,16 +885,21 @@ export function App(): React.JSX.Element {
           // Luke is on his way to move, so it waits for him to reach it. Every
           // path out of here releases it, and the outcome the conversation is
           // told is the store's own either way — what is delayed is the drawing,
-          // never the change or the report of it. The settings as this window
-          // holds them ride along so a spoken model or effort change composes
-          // against the selection actually stored.
+          // never the change or the report of it. The guide is the one thing
+          // that must not wait: the next call in this same turn is validated
+          // against it. The freshest settings this window knows ride along so
+          // a spoken model or effort change composes against the selection
+          // actually stored — the held answer first, because a model and its
+          // effort asked for in one breath land as two calls before anything
+          // is released.
           const outcome = await applySpokenSetting(
             window.sidecar,
             action,
             (next) => {
               heldSettings.current = next;
+              publishGuideRef.current(next);
             },
-            settings ?? bootstrap?.settings,
+            heldSettings.current ?? settingsNow() ?? bootstrap?.settings,
           );
           // Nothing to show and nothing to sign: a refused change must not stand
           // the panel up in front of a switch that did not move.
@@ -1018,7 +1038,7 @@ export function App(): React.JSX.Element {
     [
       changeMode,
       changeTab,
-      settings,
+      settingsNow,
       settingsView,
       bootstrap,
       releaseErrandChange,
@@ -1265,35 +1285,43 @@ export function App(): React.JSX.Element {
   // Keep the conversation's view of Luke himself current, so a spoken question
   // about a setting is answered from the value the store actually holds, and a
   // change made in the panel is known to the conversation the moment it lands.
+  const publishGuide = useCallback(
+    (current: AppSettings) => {
+      if (!bootstrap) return;
+      const askAccelerator = askHotkeyChange ? askHotkeyChange.accelerator : bootstrap.askHotkey;
+      const stopAccelerator = stopHotkeyChange
+        ? stopHotkeyChange.accelerator
+        : bootstrap.stopHotkey;
+      // All three keys reach the guide labelled: it is spoken and read, so a
+      // chord belongs there as the one word macOS writes it as rather than as
+      // the keys the panel draws apart.
+      const talkKey = voiceHotkeyToShow(bootstrap, voiceHotkey);
+      const guide = buildLukeGuide({
+        settings: current,
+        voiceAvailable: current.voiceAvailable,
+        microphoneStatus,
+        hotkey: {
+          ...(talkKey.hotkey ? { hotkey: voiceHotkeyLabel(talkKey.hotkey) } : {}),
+          held: talkKey.held,
+        },
+        ...(askAccelerator ? { askKey: voiceHotkeyLabel(askAccelerator) } : {}),
+        ...(stopAccelerator ? { stopKey: voiceHotkeyLabel(stopAccelerator) } : {}),
+      });
+      syncGuide(guide);
+    },
+    [bootstrap, microphoneStatus, voiceHotkey, askHotkeyChange, stopHotkeyChange, syncGuide],
+  );
   useEffect(() => {
     if (!bootstrap) return;
-    const askAccelerator = askHotkeyChange ? askHotkeyChange.accelerator : bootstrap.askHotkey;
-    const stopAccelerator = stopHotkeyChange ? stopHotkeyChange.accelerator : bootstrap.stopHotkey;
-    // All three keys reach the guide labelled: it is spoken and read, so a
-    // chord belongs there as the one word macOS writes it as rather than as
-    // the keys the panel draws apart.
-    const talkKey = voiceHotkeyToShow(bootstrap, voiceHotkey);
-    const guide = buildLukeGuide({
-      settings: settings ?? bootstrap.settings,
-      voiceAvailable: (settings ?? bootstrap.settings).voiceAvailable,
-      microphoneStatus,
-      hotkey: {
-        ...(talkKey.hotkey ? { hotkey: voiceHotkeyLabel(talkKey.hotkey) } : {}),
-        held: talkKey.held,
-      },
-      ...(askAccelerator ? { askKey: voiceHotkeyLabel(askAccelerator) } : {}),
-      ...(stopAccelerator ? { stopKey: voiceHotkeyLabel(stopAccelerator) } : {}),
-    });
-    syncGuide(guide);
-  }, [
-    bootstrap,
-    settings,
-    microphoneStatus,
-    voiceHotkey,
-    askHotkeyChange,
-    stopHotkeyChange,
-    syncGuide,
-  ]);
+    publishGuide(settings ?? bootstrap.settings);
+  }, [bootstrap, settings, publishGuide]);
+  // The spoken carrier publishes the store's answer through this ref the
+  // moment the change is made, because the settings state above it is still
+  // held for Luke's flight — and identical guides are not resent, so the
+  // landing republishing the same snapshot costs nothing.
+  useEffect(() => {
+    publishGuideRef.current = publishGuide;
+  }, [publishGuide]);
 
   useEffect(() => {
     const handleKey = (event: KeyboardEvent) => {

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -859,6 +859,30 @@ export function App(): React.JSX.Element {
   }, [cancelHover, heldAgainstPointer, pointerIsInside, settle]);
 
   /**
+   * The same two releases, keyed to the flight reporting them. A flight
+   * overtaken by the next carry in the same turn still fires its beats — a
+   * hold nobody releases is worse — but what the app holds belongs to the
+   * newest errand by then: the settings snapshot was overwritten by the later
+   * change, and the panel is the later flight's to put away. So a stale
+   * flight's beats release nothing, and the newest flight's release
+   * everything, which is also why nothing is ever left held.
+   */
+  const releaseIfCurrentErrand = useCallback(
+    (finished: Errand) => {
+      if (finished.run !== errands.current) return;
+      releaseErrandChange();
+    },
+    [releaseErrandChange],
+  );
+  const standDownIfCurrentErrand = useCallback(
+    (finished: Errand) => {
+      if (finished.run !== errands.current) return;
+      standDownAfterErrand();
+    },
+    [standDownAfterErrand],
+  );
+
+  /**
    * The spoken asks about Luke himself. A settings change goes through the
    * same bridge calls the settings rows use, and the snapshot that comes back
    * redraws the panel's switches; showing the panel is the capsule's press
@@ -934,8 +958,11 @@ export function App(): React.JSX.Element {
             if (page !== undefined) setSettingsView(page);
             await changeMode(true);
             if (runErrand(errandTargets(action), wait)) {
-              // Only a panel this errand stood up is the errand's to put away.
-              errandOpenedPanel.current = opening;
+              // Only a panel this errand stood up is the errand's to put away
+              // — and a claim once made survives the rest of the turn, because
+              // the second carry of a paired ask finds the panel open exactly
+              // because the first stood it up.
+              errandOpenedPanel.current ||= opening;
             } else {
               releaseErrandChange();
             }
@@ -1624,8 +1651,8 @@ export function App(): React.JSX.Element {
           the errand stand back down. */}
       <LukeErrand
         {...(errand ? { errand } : {})}
-        onLanded={releaseErrandChange}
-        onReturned={standDownAfterErrand}
+        onLanded={releaseIfCurrentErrand}
+        onReturned={standDownIfCurrentErrand}
       />
 
       {/* Luke's words while he says them: one element in every state, under

--- a/apps/desktop/src/renderer/luke-errand.tsx
+++ b/apps/desktop/src/renderer/luke-errand.tsx
@@ -547,15 +547,18 @@ export interface LukeErrandProps {
   /**
    * The tap has landed, which is the moment the control it flew to should be
    * seen to move. Called once per errand and always — at once when there is
-   * no flight to make — so whatever is waiting on it is never left held.
+   * no flight to make — so whatever is waiting on it is never left held. The
+   * errand rides along so the caller can tell a replaced flight's beat from
+   * the current one's: what the app holds belongs to the newest errand, and
+   * an overtaken flight must not release it early.
    */
-  onLanded?: () => void;
+  onLanded?: (errand: Errand) => void;
   /**
    * The flight is over, or was abandoned. Called once per errand and always,
-   * on the same terms, so a panel that was stood up for an errand knows when
-   * it may stand back down.
+   * on the same terms and carrying the same errand, so a panel that was stood
+   * up for an errand knows when it may stand back down.
    */
-  onReturned?: () => void;
+  onReturned?: (errand: Errand) => void;
 }
 
 /**
@@ -578,6 +581,10 @@ export function LukeErrand({ errand, onLanded, onReturned }: LukeErrandProps): R
   const ring = useRef<HTMLSpanElement>(null);
 
   useEffect(() => {
+    if (errand === undefined) return;
+    // Held by name for the beats below: a closure over the prop would not
+    // survive the narrowing, and each beat reports the errand it belongs to.
+    const flown = errand;
     // Each beat is released once and only once, however this effect leaves —
     // and releasing one that never came due is better than leaving the app
     // holding a switch that will never be allowed to move.
@@ -586,18 +593,17 @@ export function LukeErrand({ errand, onLanded, onReturned }: LukeErrandProps): R
     const land = () => {
       if (landed) return;
       landed = true;
-      onLanded?.();
+      onLanded?.(flown);
     };
     const returnHome = () => {
       land();
       if (returned) return;
       returned = true;
-      onReturned?.();
+      onReturned?.(flown);
     };
 
     const markElement = mark.current;
     const ringElement = ring.current;
-    if (errand === undefined) return;
     if (markElement === null || ringElement === null) return returnHome();
     // The stage is the mark's own containing box, so it is found rather than
     // handed down: the two are the same element by construction.

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -328,6 +328,58 @@ test("a spoken model or effort change composes the one stored selection", async 
   assert.equal(carried.length, 5);
 });
 
+test("a model and its effort asked in one breath compose through the held answer", async () => {
+  const carried: (WorkspaceAgentSelection | undefined)[] = [];
+  const bridge = {
+    setWorkspaceAgentDefault: async (
+      _providerId: string,
+      selection: WorkspaceAgentSelection | undefined,
+    ) => {
+      carried.push(selection);
+      return {
+        settings: settings(
+          selection ? { workspaceAgentDefaults: { [PROVIDER_ID.CONDUCTOR]: selection } } : {},
+        ),
+      };
+    },
+  } as unknown as Parameters<typeof applySpokenSetting>[0];
+
+  // Nothing chosen yet, so the guide carries no effort entry at all — the
+  // paired ask arrives as two calls, and everything the second half needs
+  // only becomes true when the first half's answer lands.
+  const unset = settings();
+  let held: AppSettings | undefined;
+  await applySpokenSetting(
+    bridge,
+    {
+      setting: guideSetting(APP_SETTING_ID.WORKSPACE_AGENT_MODEL, guideInput({ settings: unset })),
+      value: "Fable 5",
+    },
+    (next) => {
+      held = next;
+    },
+    unset,
+  );
+  assert.deepEqual(carried.at(-1), { agent: "claude", model: "fable-5" });
+  assert.ok(held);
+
+  // The guide rebuilt from that answer is what the effort half validates
+  // against, and the answer is what it composes with: the effort rides the
+  // model just stored, not the state a panel is still waiting to draw.
+  const effort = guideSetting(
+    APP_SETTING_ID.WORKSPACE_AGENT_EFFORT,
+    guideInput({ settings: held }),
+  );
+  const outcome = await applySpokenSetting(
+    bridge,
+    { setting: effort, value: "high" },
+    () => undefined,
+    held,
+  );
+  assert.equal(outcome.status, "changed");
+  assert.deepEqual(carried.at(-1), { agent: "claude", model: "fable-5", effort: "high" });
+});
+
 test("the guide describes the default workspace provider without offering to change it", () => {
   // Unset reads as the asking state — the default every install starts in —
   // not as a missing value.

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -2255,6 +2255,85 @@ test("a spoken settings change is validated against the guide and carried", asyn
   ]);
 });
 
+const MODEL_GUIDE_ENTRY = {
+  id: "workspace_agent_model",
+  label: "New Conductor agents run",
+  description: "Which model a Conductor workspace or agent created through Luke starts with.",
+  kind: APP_SETTING_KIND.CHOICE,
+  value: "Conductor's default",
+  choices: ["Conductor's default", "Fable 5"],
+  adjustable: true,
+  manual: "the Conductor row under Cloud Agent API keys",
+} as const;
+
+const MODEL_ONLY_GUIDE: AppGuideSnapshot = {
+  facts: CAPTIONS_GUIDE.facts,
+  settings: [MODEL_GUIDE_ENTRY],
+};
+
+const MODEL_AND_EFFORT_GUIDE: AppGuideSnapshot = {
+  facts: CAPTIONS_GUIDE.facts,
+  settings: [
+    { ...MODEL_GUIDE_ENTRY, value: "Fable 5" },
+    {
+      id: "workspace_agent_effort",
+      label: "New Conductor agents' effort",
+      description: "How hard the chosen model thinks.",
+      kind: APP_SETTING_KIND.CHOICE,
+      value: "Conductor's default",
+      choices: ["Conductor's default", "high", "max"],
+      adjustable: true,
+      manual: "the Conductor row under Cloud Agent API keys",
+    },
+  ],
+};
+
+test("the second call of a turn is validated against the guide the first call's carry rewrote", async () => {
+  // A model and its effort asked for in one breath arrive as two calls in one
+  // turn, and the effort entry only exists in the guide once the model is
+  // stored. The renderer republishes the guide from the store's answer before
+  // its carrier returns, so the calls being carried one at a time is what
+  // lets the second half validate — this pins that ordering.
+  const carried: { setting: string; value: string }[] = [];
+  const context = harness({
+    carryAppAction: async (action) => {
+      if (action.kind !== "setting") return { status: "refused" };
+      carried.push({ setting: String(action.setting.id), value: action.value });
+      context.session.updateGuide(MODEL_AND_EFFORT_GUIDE);
+      return { status: "changed" };
+    },
+  });
+  await context.session.connect();
+  context.session.updateGuide(MODEL_ONLY_GUIDE);
+  armDeveloperTurn(context);
+
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: {
+      output: [
+        {
+          type: "function_call",
+          name: "change_app_setting",
+          call_id: "call-paired-model",
+          arguments: '{"setting_id":"workspace_agent_model","value":"Fable 5"}',
+        },
+        {
+          type: "function_call",
+          name: "change_app_setting",
+          call_id: "call-paired-effort",
+          arguments: '{"setting_id":"workspace_agent_effort","value":"high"}',
+        },
+      ],
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.deepEqual(carried, [
+    { setting: "workspace_agent_model", value: "Fable 5" },
+    { setting: "workspace_agent_effort", value: "high" },
+  ]);
+});
+
 test("an app carrier that throws is refused with the error that caused it", async () => {
   const context = harness({
     carryAppAction: async () => {


### PR DESCRIPTION
## What

Asking Luke out loud (or typed) to change the default Conductor model **and** its effort in the same breath left the effort half refused — "the app guide lists no such setting" when no model was chosen yet, or "no model is chosen…" from the composition base. And with a model already chosen, the effort half composed against the stale selection, quietly reverting the model the first half had just stored.

## Why

The two changes arrive as two `change_app_setting` calls in one turn, carried serially. The renderer holds the store's answered settings in `heldSettings` so the switch doesn't redraw until Luke's face reaches it — but the conversation's guide was only rebuilt from React state after that flight landed, so the second call validated against a guide that predates the model change (the effort entry only exists once a model is chosen), and `applySpokenSetting` composed against the same stale state.

## How

Only the drawing may wait for Luke; the conversation's knowledge moves at once:

- The spoken carrier publishes the guide from the store's answer the moment a change is made, through a ref (the carrier is created before the conversation hook that owns `syncGuide`). The landing later republishes the identical snapshot, which `updateGuide` already drops.
- Each change composes against the held answer first, then the lockstep ref `useStateWithRef` keeps — `settings` state moved onto the repo's existing helper for exactly this "callback cannot wait a render" case.

## Tests

- `luke-guide.test.ts`: a paired ask composes the second half through the first half's answered settings — effort rides the model just stored.
- `realtime-session.test.ts`: pins that calls in one turn are carried one at a time, so the second call is validated against the guide the first call's carry rewrote.

## Verification

- `./scripts/check.sh` passes (exit 0): repository checks, types, all workspace tests, builds.
- No visual or motion change — renderer wiring only, so no evidence run and no physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/3bff777a-c9d5-4f75-81cb-39d191943ae1)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31966599609/artifacts/9268659314) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31966599609)

- Commit: `5fd36449f01b4e0b28cad8b83381b495d8dfeaec`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
