### PR TITLE
fix(sessions): never hide a conversation for being old

### DIFF
--- a/apps/desktop/src/claude-code-adapter.ts
+++ b/apps/desktop/src/claude-code-adapter.ts
@@ -106,7 +106,6 @@ export interface ClaudeCodeAdapterOptions {
   now?: () => number;
   maximumProjectDirectories?: number;
   maximumSessionFiles?: number;
-  maximumSessionAgeMs?: number;
   activeSessionFreshnessMs?: number;
   readTailBytes?: number;
   readHeadBytes?: number;
@@ -425,7 +424,6 @@ export class ClaudeCodeSessionAdapter implements SessionProviderAdapter {
   readonly #now: () => number;
   readonly #maximumProjectDirectories: number;
   readonly #maximumSessionFiles: number;
-  readonly #maximumSessionAgeMs: number;
   readonly #activeSessionFreshnessMs: number;
   readonly #readTailBytes: number;
   readonly #readHeadBytes: number;
@@ -438,7 +436,6 @@ export class ClaudeCodeSessionAdapter implements SessionProviderAdapter {
       {
         maximumProjectDirectories: CLAUDE_ADAPTER_DEFAULTS.MAXIMUM_PROJECT_DIRECTORIES,
         maximumSessionFiles: CLAUDE_ADAPTER_DEFAULTS.MAXIMUM_SESSION_FILES,
-        maximumSessionAgeMs: OBSERVATION_WINDOW.MAXIMUM_SESSION_AGE_MS,
         activeSessionFreshnessMs: OBSERVATION_WINDOW.ACTIVE_SESSION_FRESHNESS_MS,
         readTailBytes: LOCAL_ADAPTER_DEFAULTS.READ_TAIL_BYTES,
         readHeadBytes: CLAUDE_ADAPTER_DEFAULTS.READ_HEAD_BYTES,
@@ -450,12 +447,11 @@ export class ClaudeCodeSessionAdapter implements SessionProviderAdapter {
           "readTailBytes",
           "readHeadBytes",
         ],
-        nonNegative: ["maximumSessionAgeMs", "activeSessionFreshnessMs"],
+        nonNegative: ["activeSessionFreshnessMs"],
       },
     );
     this.#maximumProjectDirectories = resolved.maximumProjectDirectories;
     this.#maximumSessionFiles = resolved.maximumSessionFiles;
-    this.#maximumSessionAgeMs = resolved.maximumSessionAgeMs;
     this.#activeSessionFreshnessMs = resolved.activeSessionFreshnessMs;
     this.#readTailBytes = resolved.readTailBytes;
     this.#readHeadBytes = resolved.readHeadBytes;
@@ -472,7 +468,6 @@ export class ClaudeCodeSessionAdapter implements SessionProviderAdapter {
     const observations = new Map<string, ProviderSessionObservation>();
 
     for (const candidate of candidates) {
-      if (now - candidate.mtimeMs > this.#maximumSessionAgeMs) continue;
       const tail = await readTail(candidate.filePath, this.#readTailBytes);
       const parsed = parseClaudeSessionTail(tail);
       if (!parsed.aiTitle) {
@@ -484,10 +479,6 @@ export class ClaudeCodeSessionAdapter implements SessionProviderAdapter {
         now,
         this.#activeSessionFreshnessMs,
       );
-      // The mtime check above is only a cheap gate on reading the file. The
-      // observation window is enforced here, against the transcript's clock:
-      // a touch must not carry a long-dead session back into the panel.
-      if (now - observation.observedAt > this.#maximumSessionAgeMs) continue;
       if (!observations.has(observation.providerSessionId)) {
         observations.set(observation.providerSessionId, observation);
       }

--- a/apps/desktop/src/cloud-session-adapter.ts
+++ b/apps/desktop/src/cloud-session-adapter.ts
@@ -92,8 +92,8 @@ type WriteSubject = (typeof WRITE_SUBJECT)[keyof typeof WRITE_SUBJECT];
 export type CloudFailure = (typeof CLOUD_FAILURE)[keyof typeof CLOUD_FAILURE];
 
 /**
- * Cloud-only request bounds. The observation window itself is shared with
- * every local provider.
+ * Cloud-only request bounds. The freshness bound in `OBSERVATION_WINDOW` is
+ * shared with every local provider.
  */
 export const CLOUD_ADAPTER_DEFAULTS = {
   MINIMUM_REFRESH_INTERVAL_MS: 15 * 1000,

--- a/apps/desktop/src/codex-adapter.ts
+++ b/apps/desktop/src/codex-adapter.ts
@@ -146,7 +146,6 @@ export interface CodexAdapterOptions {
   sqliteHome?: string;
   now?: () => number;
   maximumSessionRows?: number;
-  maximumSessionAgeMs?: number;
   activeSessionFreshnessMs?: number;
   sqlite?: SqliteModuleLoader;
 }
@@ -413,7 +412,6 @@ export class CodexSessionAdapter implements SessionProviderAdapter {
   readonly #sqliteHome: string | undefined;
   readonly #now: () => number;
   readonly #maximumSessionRows: number;
-  readonly #maximumSessionAgeMs: number;
   readonly #activeSessionFreshnessMs: number;
   readonly #sqlite: SqliteModuleLoader;
 
@@ -425,16 +423,14 @@ export class CodexSessionAdapter implements SessionProviderAdapter {
       options,
       {
         maximumSessionRows: CODEX_ADAPTER_DEFAULTS.MAXIMUM_SESSION_ROWS,
-        maximumSessionAgeMs: OBSERVATION_WINDOW.MAXIMUM_SESSION_AGE_MS,
         activeSessionFreshnessMs: OBSERVATION_WINDOW.ACTIVE_SESSION_FRESHNESS_MS,
       },
       {
         positive: ["maximumSessionRows"],
-        nonNegative: ["maximumSessionAgeMs", "activeSessionFreshnessMs"],
+        nonNegative: ["activeSessionFreshnessMs"],
       },
     );
     this.#maximumSessionRows = resolved.maximumSessionRows;
-    this.#maximumSessionAgeMs = resolved.maximumSessionAgeMs;
     this.#activeSessionFreshnessMs = resolved.activeSessionFreshnessMs;
     this.#sqlite = options.sqlite ?? defaultSqliteModule;
   }
@@ -450,8 +446,7 @@ export class CodexSessionAdapter implements SessionProviderAdapter {
         rows = database
           .prepare(CODEX_THREAD_QUERY)
           .all(this.#maximumSessionRows)
-          .filter((row): row is CodexThreadRow => row !== null && typeof row === "object")
-          .filter((row) => now - timestampFromRow(row) <= this.#maximumSessionAgeMs);
+          .filter((row): row is CodexThreadRow => row !== null && typeof row === "object");
       } catch (error) {
         if (canIgnoreSqliteError(error)) continue;
         throw error;

--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -474,21 +474,27 @@ export class ConductorSessionAdapter
       // user unless it reports a creator, and unattributed org workspaces stay
       // out of a personal sidecar.
       .filter((workspace) => workspace.creatorId === userId)
-      .filter(
-        (workspace) => now - workspace.lastActivityAt <= OBSERVATION_WINDOW.MAXIMUM_SESSION_AGE_MS,
-      )
       .sort((first, second) => second.lastActivityAt - first.lastActivityAt)
       .slice(0, this.#maximumObservedWorkspaces);
 
     const sessions = (
       await Promise.all(
         workspaces.map((workspace) =>
-          this.tolerateItemFailure(() => this.#listSessions(request, workspace, now)),
+          this.tolerateItemFailure(() => this.#listSessions(request, workspace)),
         ),
       )
     )
       .filter(isDefined)
       .flat()
+      // An open chat can still change, so it takes the budget before any
+      // closed one however old the closed chat is; closed chats spend what
+      // remains, newest first. Open chats carry no timestamp of their own
+      // yet, and the stable sort keeps them in workspace-recency order.
+      .sort(
+        (first, second) =>
+          Number(first.archived) - Number(second.archived) ||
+          (second.archivedAt ?? 0) - (first.archivedAt ?? 0),
+      )
       .slice(0, this.#maximumObservedSessions);
 
     // The transcripts read rides beside the status reads: one bounded query
@@ -586,7 +592,6 @@ export class ConductorSessionAdapter
   async #listSessions(
     request: CloudRequest,
     workspace: ConductorWorkspace,
-    now: number,
   ): Promise<ConductorSession[]> {
     const body = await request(
       [
@@ -622,13 +627,6 @@ export class ConductorSessionAdapter
           };
         })
         .filter(isDefined)
-        // A chat closed before the observation window opened is already
-        // outside it, so it must not spend budget a live session could hold.
-        .filter(
-          (session) =>
-            session.archivedAt === undefined ||
-            now - session.archivedAt <= OBSERVATION_WINDOW.MAXIMUM_SESSION_AGE_MS,
-        )
         // An open chat carries no timestamp until its status is read, so open
         // chats are preferred over closed ones, then closed ones by how
         // recently they closed. Capping here keeps one crowded workspace from
@@ -720,8 +718,6 @@ export class ConductorSessionAdapter
     // it settled; the workspace timestamp is only the last resort.
     const observedAt =
       reported?.updatedAt ?? session.archivedAt ?? session.workspace.lastActivityAt;
-    if (now - observedAt > OBSERVATION_WINDOW.MAXIMUM_SESSION_AGE_MS) return undefined;
-
     const status = this.#statusFor(session, reported?.status, observedAt, now);
     // The parting words are a recap only once the turn has actually parted:
     // read for an idle or closed chat, they say where the agent left the work;

--- a/apps/desktop/src/copilot-adapter.ts
+++ b/apps/desktop/src/copilot-adapter.ts
@@ -44,7 +44,6 @@ const COPILOT_ROUTE = {
 
 const COPILOT_QUERY = {
   PER_PAGE: "per_page",
-  SINCE: "since",
 } as const;
 
 const COPILOT_FIELD = {
@@ -127,7 +126,7 @@ const SESSION_STATUS_BY_COPILOT_STATE: Readonly<Record<CopilotTaskState, Session
 };
 
 const COPILOT_ADAPTER_DEFAULTS = {
-  /** The documented maximum, so one call covers as much of a day as it can. */
+  /** The documented maximum, so one call reaches as deep into the history as it can. */
   TASK_PAGE_SIZE: 100,
   MAXIMUM_OBSERVED_TASKS: 12,
   MAXIMUM_BRANCH_LABEL_LENGTH: 60,
@@ -256,19 +255,15 @@ export class CopilotSessionAdapter extends CloudSessionAdapter {
   ): Promise<readonly ProviderSessionObservation[]> {
     // One call per pass. The list projection already carries the state, the
     // timestamps, and the task's own addresses, so there is nothing a
-    // per-task read would add. `since` asks GitHub for the observation window,
-    // and the filter below holds it against whatever comes back.
+    // per-task read would add. Tasks are never aged out — the newest-first
+    // cap below is the only bound on what the page yields.
     const body = await request(COPILOT_ROUTE.TASKS, {
       [COPILOT_QUERY.PER_PAGE]: String(COPILOT_ADAPTER_DEFAULTS.TASK_PAGE_SIZE),
-      [COPILOT_QUERY.SINCE]: new Date(
-        now - OBSERVATION_WINDOW.MAXIMUM_SESSION_AGE_MS,
-      ).toISOString(),
     });
 
     return recordsFromPage(body, COPILOT_FIELD.TASKS)
       .map(taskFromRecord)
       .filter(isDefined)
-      .filter((task) => now - task.observedAt <= OBSERVATION_WINDOW.MAXIMUM_SESSION_AGE_MS)
       .sort((first, second) => second.observedAt - first.observedAt)
       .slice(0, this.#maximumObservedTasks)
       .map((task) => this.#observationFor(task, now));

--- a/apps/desktop/src/cursor-adapter.ts
+++ b/apps/desktop/src/cursor-adapter.ts
@@ -179,7 +179,7 @@ const SESSION_STATUS_BY_CURSOR_RUN_STATUS: Readonly<Record<CursorRunStatus, Sess
 };
 
 const CURSOR_ADAPTER_DEFAULTS = {
-  /** The documented maximum, so one call covers as much of a day as it can. */
+  /** The documented maximum, so one call reaches as deep into the history as it can. */
   AGENT_PAGE_SIZE: 100,
   MAXIMUM_OBSERVED_SESSIONS: 12,
   MAXIMUM_REFERENCE_LABEL_LENGTH: 60,
@@ -232,7 +232,7 @@ function firstRunBranch(record: Record<string, unknown>): Record<string, unknown
 function agentFromRecord(record: Record<string, unknown>): CursorAgent | undefined {
   const id = textFromRecord(record, CURSOR_FIELD.ID);
   // An agent is a standing definition that can be run again months later, so
-  // the time it was last touched is what places it in the observation window.
+  // the time it was last touched is what orders it against the budget.
   const lastActivityAt =
     timestampFromRecord(record, CURSOR_FIELD.UPDATED_AT) ??
     timestampFromRecord(record, CURSOR_FIELD.CREATED_AT);
@@ -341,13 +341,12 @@ export class CursorSessionAdapter
     });
 
     // Cursor lists agents newest-first, so a full first page already reaches
-    // past the observation window and the `cursor` page after it could only
-    // hold agents Luke has already aged out.
+    // past anything the caps below would keep and the `cursor` page after it
+    // could only hold agents the budget has already passed over.
     const agents = recordsFromPage(body, CURSOR_FIELD.ITEMS)
       .map(agentFromRecord)
       .filter(isDefined)
-      .filter((agent) => now - agent.lastActivityAt <= OBSERVATION_WINDOW.MAXIMUM_SESSION_AGE_MS)
-      // When a day holds more agents than Luke observes, the ones that can
+      // When the page holds more agents than Luke observes, the ones that can
       // still change take the budget: an agent the user filed away has nothing
       // left to say, however recently it was touched.
       .sort(
@@ -508,8 +507,6 @@ export class CursorSessionAdapter
     // The run's timestamp is the moment its state was entered; the agent's is
     // only the last resort, because it also moves for edits that are not work.
     const observedAt = run?.updatedAt ?? agent.lastActivityAt;
-    if (now - observedAt > OBSERVATION_WINDOW.MAXIMUM_SESSION_AGE_MS) return undefined;
-
     const status = this.#statusFor(agent, run, observedAt, now);
     // A run names the repository it pushed to, so a list item that carries no
     // `repos` still resolves to something better than "workspace".

--- a/apps/desktop/src/cursor-local-adapter.ts
+++ b/apps/desktop/src/cursor-local-adapter.ts
@@ -89,7 +89,6 @@ export interface CursorLocalAdapterOptions {
   now?: () => number;
   maximumProjectDirectories?: number;
   maximumSessionFiles?: number;
-  maximumSessionAgeMs?: number;
   activeSessionFreshnessMs?: number;
   readTailBytes?: number;
 }
@@ -313,7 +312,6 @@ export class CursorLocalSessionAdapter implements SessionProviderAdapter {
   readonly #now: () => number;
   readonly #maximumProjectDirectories: number;
   readonly #maximumSessionFiles: number;
-  readonly #maximumSessionAgeMs: number;
   readonly #activeSessionFreshnessMs: number;
   readonly #readTailBytes: number;
 
@@ -328,33 +326,29 @@ export class CursorLocalSessionAdapter implements SessionProviderAdapter {
       {
         maximumProjectDirectories: CURSOR_LOCAL_ADAPTER_DEFAULTS.MAXIMUM_PROJECT_DIRECTORIES,
         maximumSessionFiles: CURSOR_LOCAL_ADAPTER_DEFAULTS.MAXIMUM_SESSION_FILES,
-        maximumSessionAgeMs: OBSERVATION_WINDOW.MAXIMUM_SESSION_AGE_MS,
         activeSessionFreshnessMs: OBSERVATION_WINDOW.ACTIVE_SESSION_FRESHNESS_MS,
         readTailBytes: LOCAL_ADAPTER_DEFAULTS.READ_TAIL_BYTES,
       },
       {
         positive: ["maximumProjectDirectories", "maximumSessionFiles", "readTailBytes"],
-        nonNegative: ["maximumSessionAgeMs", "activeSessionFreshnessMs"],
+        nonNegative: ["activeSessionFreshnessMs"],
       },
     );
     this.#maximumProjectDirectories = resolved.maximumProjectDirectories;
     this.#maximumSessionFiles = resolved.maximumSessionFiles;
-    this.#maximumSessionAgeMs = resolved.maximumSessionAgeMs;
     this.#activeSessionFreshnessMs = resolved.activeSessionFreshnessMs;
     this.#readTailBytes = resolved.readTailBytes;
   }
 
   async observe(): Promise<readonly ProviderSessionObservation[]> {
     const now = this.#now();
-    const candidates = (
-      await discoverSessionFiles({
-        projectsDirectory: path.join(this.#cursorHome, CURSOR_DIRECTORY.PROJECTS),
-        sessionsDirectoryName: CURSOR_DIRECTORY.TRANSCRIPTS,
-        maximumProjectDirectories: this.#maximumProjectDirectories,
-        maximumSessionFiles: this.#maximumSessionFiles,
-        sessionFilesIn: transcriptsIn,
-      })
-    ).filter((candidate) => now - candidate.mtimeMs <= this.#maximumSessionAgeMs);
+    const candidates = await discoverSessionFiles({
+      projectsDirectory: path.join(this.#cursorHome, CURSOR_DIRECTORY.PROJECTS),
+      sessionsDirectoryName: CURSOR_DIRECTORY.TRANSCRIPTS,
+      maximumProjectDirectories: this.#maximumProjectDirectories,
+      maximumSessionFiles: this.#maximumSessionFiles,
+      sessionFilesIn: transcriptsIn,
+    });
     // Only the sessions this pass reports are worth naming a folder for.
     await this.#workspaceLabels.resolve(
       candidates.map((candidate) => candidate.projectDirectoryName),

--- a/apps/desktop/src/devin-adapter.ts
+++ b/apps/desktop/src/devin-adapter.ts
@@ -55,7 +55,6 @@ const DEVIN_ROUTE_SEGMENT = {
 
 const DEVIN_QUERY = {
   FIRST: "first",
-  UPDATED_AFTER: "updated_after",
   USER_IDS: "user_ids",
 } as const;
 
@@ -168,7 +167,7 @@ const PULL_REQUEST_PATH_SEGMENTS: ReadonlySet<string> = new Set(
 );
 
 const DEVIN_ADAPTER_DEFAULTS = {
-  /** The documented maximum, so one call covers as much of a day as it can. */
+  /** The documented maximum, so one call reaches as deep into the history as it can. */
   SESSION_PAGE_SIZE: 200,
   MAXIMUM_OBSERVED_SESSIONS: 12,
 } as const;
@@ -314,7 +313,7 @@ export class DevinSessionAdapter
     // work. It reports nothing rather than a teammate's.
     if (!identity) return [];
 
-    return (await this.#listSessions(request, identity, now))
+    return (await this.#listSessions(request, identity))
       .sort((first, second) => second.observedAt - first.observedAt)
       .slice(0, this.#maximumObservedSessions)
       .map((session) => this.#observationFor(session, now));
@@ -347,15 +346,10 @@ export class DevinSessionAdapter
   /**
    * The whole pass after identity, in one request: a session record carries its
    * own state and timestamp, so unlike the other cloud providers Luke needs no
-   * second request per session, and asking for one person's sessions inside the
-   * observation window leaves a full page far past anything it would report.
+   * second request per session, and one person's page of newest sessions
+   * reaches far past anything the observation cap would keep.
    */
-  async #listSessions(
-    request: CloudRequest,
-    identity: DevinIdentity,
-    now: number,
-  ): Promise<DevinSession[]> {
-    const openedAt = now - OBSERVATION_WINDOW.MAXIMUM_SESSION_AGE_MS;
+  async #listSessions(request: CloudRequest, identity: DevinIdentity): Promise<DevinSession[]> {
     const body = await request(
       [
         DEVIN_ROUTE_SEGMENT.V3,
@@ -366,19 +360,12 @@ export class DevinSessionAdapter
       {
         [DEVIN_QUERY.FIRST]: String(DEVIN_ADAPTER_DEFAULTS.SESSION_PAGE_SIZE),
         [DEVIN_QUERY.USER_IDS]: identity.userId,
-        // Seconds rather than milliseconds, and deliberately so: Devin types
-        // this as an integer without naming the unit, and of the two ways to be
-        // wrong, a value read as milliseconds only asks for more than the window
-        // — which the filter below discards anyway — while one read as seconds
-        // would sit in the far future and match nothing at all.
-        [DEVIN_QUERY.UPDATED_AFTER]: String(Math.floor(openedAt / 1000)),
       },
     );
 
     return recordsFromPage(body, DEVIN_FIELD.ITEMS)
       .map((record) => sessionFromRecord(record, identity))
-      .filter(isDefined)
-      .filter((session) => session.observedAt >= openedAt);
+      .filter(isDefined);
   }
 
   /**

--- a/apps/desktop/src/jules-adapter.ts
+++ b/apps/desktop/src/jules-adapter.ts
@@ -130,7 +130,7 @@ const SESSION_STATUS_BY_JULES_STATE: Readonly<Record<JulesState, SessionStatus>>
 };
 
 const JULES_ADAPTER_DEFAULTS = {
-  /** The documented maximum, so one call covers as much of a day as it can. */
+  /** The documented maximum, so one call reaches as deep into the history as it can. */
   SESSION_PAGE_SIZE: 100,
   MAXIMUM_OBSERVED_SESSIONS: 12,
   MAXIMUM_BRANCH_LABEL_LENGTH: 60,
@@ -246,8 +246,8 @@ export class JulesSessionAdapter
   ): Promise<readonly ProviderSessionObservation[]> {
     // One call per pass. The list projection already carries the state, the
     // timestamps, and the source, so there is nothing a per-session read would
-    // add, and Jules documents no ordering — the window filter and the sort
-    // below are what bound the page rather than the order it arrives in.
+    // add, and Jules documents no ordering — the sort and the cap below are
+    // what bound the page rather than the order it arrives in.
     const body = await request(JULES_ROUTE.SESSIONS, {
       [JULES_QUERY.PAGE_SIZE]: String(JULES_ADAPTER_DEFAULTS.SESSION_PAGE_SIZE),
     });
@@ -255,7 +255,6 @@ export class JulesSessionAdapter
     return recordsFromPage(body, JULES_FIELD.SESSIONS)
       .map(sessionFromRecord)
       .filter(isDefined)
-      .filter((session) => now - session.observedAt <= OBSERVATION_WINDOW.MAXIMUM_SESSION_AGE_MS)
       .sort((first, second) => second.observedAt - first.observedAt)
       .slice(0, this.#maximumObservedSessions)
       .map((session) => this.#observationFor(session, now));

--- a/apps/desktop/src/opencode-adapter.ts
+++ b/apps/desktop/src/opencode-adapter.ts
@@ -188,7 +188,6 @@ export interface OpenCodeAdapterOptions {
   dataDirectory?: string;
   now?: () => number;
   maximumSessionRows?: number;
-  maximumSessionAgeMs?: number;
   activeSessionFreshnessMs?: number;
   sqlite?: SqliteModuleLoader;
 }
@@ -430,7 +429,6 @@ export class OpenCodeSessionAdapter implements SessionProviderAdapter {
   readonly #dataDirectory: string;
   readonly #now: () => number;
   readonly #maximumSessionRows: number;
-  readonly #maximumSessionAgeMs: number;
   readonly #activeSessionFreshnessMs: number;
   readonly #sqlite: SqliteModuleLoader;
 
@@ -441,16 +439,14 @@ export class OpenCodeSessionAdapter implements SessionProviderAdapter {
       options,
       {
         maximumSessionRows: OPENCODE_ADAPTER_DEFAULTS.MAXIMUM_SESSION_ROWS,
-        maximumSessionAgeMs: OBSERVATION_WINDOW.MAXIMUM_SESSION_AGE_MS,
         activeSessionFreshnessMs: OBSERVATION_WINDOW.ACTIVE_SESSION_FRESHNESS_MS,
       },
       {
         positive: ["maximumSessionRows"],
-        nonNegative: ["maximumSessionAgeMs", "activeSessionFreshnessMs"],
+        nonNegative: ["activeSessionFreshnessMs"],
       },
     );
     this.#maximumSessionRows = resolved.maximumSessionRows;
-    this.#maximumSessionAgeMs = resolved.maximumSessionAgeMs;
     this.#activeSessionFreshnessMs = resolved.activeSessionFreshnessMs;
     this.#sqlite = options.sqlite ?? defaultSqliteModule;
   }
@@ -521,8 +517,7 @@ export class OpenCodeSessionAdapter implements SessionProviderAdapter {
     const snapshots = rows
       .filter(isObservableSessionRow)
       .map(snapshotFromSessionRow)
-      .filter((snapshot): snapshot is OpenCodeSessionSnapshot => snapshot !== undefined)
-      .filter((snapshot) => now - snapshot.observedAt <= this.#maximumSessionAgeMs);
+      .filter((snapshot): snapshot is OpenCodeSessionSnapshot => snapshot !== undefined);
 
     // Every reported session gets its turn read, because a session without one
     // would default to working on freshness alone — inventing live work for a
@@ -575,14 +570,12 @@ export class OpenCodeSessionAdapter implements SessionProviderAdapter {
   async #legacyObservations(): Promise<readonly ProviderSessionObservation[]> {
     const now = this.#now();
     const storageDirectory = path.join(this.#dataDirectory, OPENCODE_STORAGE_DIRECTORY);
-    const candidates = (
-      await discoverSessionFiles({
-        projectsDirectory: path.join(storageDirectory, OPENCODE_STORAGE_SEGMENT.SESSION),
-        maximumProjectDirectories: OPENCODE_ADAPTER_DEFAULTS.MAXIMUM_PROJECT_DIRECTORIES,
-        maximumSessionFiles: this.#maximumSessionRows,
-        sessionFilesIn: legacySessionFilesIn,
-      })
-    ).filter((candidate) => now - candidate.mtimeMs <= this.#maximumSessionAgeMs);
+    const candidates = await discoverSessionFiles({
+      projectsDirectory: path.join(storageDirectory, OPENCODE_STORAGE_SEGMENT.SESSION),
+      maximumProjectDirectories: OPENCODE_ADAPTER_DEFAULTS.MAXIMUM_PROJECT_DIRECTORIES,
+      maximumSessionFiles: this.#maximumSessionRows,
+      sessionFilesIn: legacySessionFilesIn,
+    });
 
     const observations = new Map<string, ProviderSessionObservation>();
     for (const candidate of candidates) {

--- a/apps/desktop/tests/claude-code-adapter.test.ts
+++ b/apps/desktop/tests/claude-code-adapter.test.ts
@@ -250,7 +250,7 @@ test("keeps fresh sessions active when a large tail has no complete status event
   assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
 });
 
-test("filters old sessions and preserves the newest duplicate provider id", async (t) => {
+test("keeps old sessions and preserves the newest duplicate provider id", async (t) => {
   const claudeHome = await temporaryClaudeHome(t);
   await writeSessionFile(
     claudeHome,
@@ -277,7 +277,6 @@ test("filters old sessions and preserves the newest duplicate provider id", asyn
   const adapter = new ClaudeCodeSessionAdapter({
     claudeHome,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const observations = await adapter.observe();
 
@@ -292,6 +291,11 @@ test("filters old sessions and preserves the newest duplicate provider id", asyn
         providerSessionId: "duplicate-session",
         status: SESSION_STATUS.COMPLETE,
         title: "duplicate-new",
+      },
+      {
+        providerSessionId: "old-session",
+        status: SESSION_STATUS.WAITING,
+        title: "old",
       },
     ],
   );
@@ -805,7 +809,7 @@ test("dates a touched transcript by its own records rather than the touch", asyn
   assert.equal(observation?.status, SESSION_STATUS.UNKNOWN);
 });
 
-test("keeps a touch from carrying a session past the observation window", async (t) => {
+test("keeps a touch from making a long-settled session look recent", async (t) => {
   const claudeHome = await temporaryClaudeHome(t);
   await writeSessionFile(
     claudeHome,
@@ -826,8 +830,13 @@ test("keeps a touch from carrying a session past the observation window", async 
     claudeHome,
     now: () => TEST_TIME,
   });
+  const [observation] = await adapter.observe();
 
-  assert.deepEqual(await adapter.observe(), []);
+  // A session is never hidden for being old, but the touch must not stand in
+  // for work: the row reports the transcript's own clock, weeks back, and a
+  // wait that stale has long since decayed to unknown.
+  assert.equal(observation?.observedAt, Date.parse("2026-06-25T08:30:00.000Z"));
+  assert.equal(observation?.status, SESSION_STATUS.UNKNOWN);
 });
 
 test("falls back to the file's date when the tail carries no timestamp", async (t) => {

--- a/apps/desktop/tests/codex-adapter.test.ts
+++ b/apps/desktop/tests/codex-adapter.test.ts
@@ -573,7 +573,7 @@ test("keeps stale unarchived Codex sessions unknown instead of inventing activit
   assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
 });
 
-test("filters old and archived Codex threads while preserving newest sessions", async (t) => {
+test("filters archived Codex threads while keeping sessions however old", async (t) => {
   const codexHome = await temporaryCodexHome(t);
   await writeCodexState(codexHome, [
     {
@@ -597,7 +597,6 @@ test("filters old and archived Codex threads while preserving newest sessions", 
   const adapter = new CodexSessionAdapter({
     codexHome,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const observations = await adapter.observe();
 
@@ -612,6 +611,11 @@ test("filters old and archived Codex threads while preserving newest sessions", 
         providerSessionId: "new-session",
         status: SESSION_STATUS.WORKING,
         title: "new",
+      },
+      {
+        providerSessionId: "old-session",
+        status: SESSION_STATUS.WORKING,
+        title: "old",
       },
     ],
   );

--- a/apps/desktop/tests/conductor-adapter.test.ts
+++ b/apps/desktop/tests/conductor-adapter.test.ts
@@ -835,11 +835,10 @@ test("reports an archived session as complete without requesting its status", as
   );
 });
 
-test("drops a long-closed chat instead of letting a busy workspace make it look recent", async () => {
-  // A closed chat carries no timestamp of its own except archivedAt. Falling
-  // back to the workspace timestamp would make a chat closed days ago read as
-  // freshly complete whenever a sibling chat is active — and let it spend a
-  // budget slot a live session needed.
+test("spends a tight budget on an open chat before a long-closed one", async () => {
+  // A closed chat is never hidden for its age, but it must not spend a budget
+  // slot a live session needed just because its workspace is busy: open chats
+  // take the budget first, wherever they live.
   const api = fakeConductorApi({
     userId: TEST_USER_ID,
     projects: [LUKE_PROJECT],
@@ -973,7 +972,7 @@ test("ignores workspaces created by another user and workspaces without a creato
   );
 });
 
-test("ignores workspaces older than the maximum session age", async () => {
+test("keeps a workspace untouched since the day before yesterday", async () => {
   const api = fakeConductorApi({
     userId: TEST_USER_ID,
     projects: [LUKE_PROJECT],
@@ -985,7 +984,10 @@ test("ignores workspaces older than the maximum session age", async () => {
 
   const observations = await adapterFor(api.fetch).observe();
 
-  assert.deepEqual(observations, []);
+  assert.deepEqual(
+    observations.map((candidate) => candidate.providerSessionId),
+    ["session-yesterday"],
+  );
 });
 
 test("bounds the workspaces and sessions a single pass observes", async () => {

--- a/apps/desktop/tests/copilot-adapter.test.ts
+++ b/apps/desktop/tests/copilot-adapter.test.ts
@@ -189,8 +189,7 @@ test("reads the whole pass with one pinned, GitHub-typed list call", async () =>
     api.requests.map((request) => request.pathname),
     ["/agents/tasks"],
   );
-  const since = isoTimestamp(TEST_TIME - 24 * 60 * 60 * 1000);
-  assert.equal(api.requests[0]?.search, `?per_page=100&since=${encodeURIComponent(since)}`);
+  assert.equal(api.requests[0]?.search, "?per_page=100");
   assert.equal(api.requests[0]?.method, "GET");
   assert.equal(api.requests[0]?.authorization, `Bearer ${TEST_API_KEY}`);
   // GitHub's own media type rather than plain JSON, and the endpoint is in
@@ -301,12 +300,15 @@ test("reports a task the user filed away as settled whatever it was doing", asyn
   assert.equal(observations[0]?.status, SESSION_STATUS.COMPLETE);
 });
 
-test("ignores tasks untouched for longer than the maximum session age", async () => {
+test("keeps a task untouched since the day before yesterday", async () => {
   const api = fakeAgentTasksApi([workingTask("task-last-week", TEST_TIME - 48 * 60 * 60 * 1000)]);
 
   const observations = await adapterFor(api.fetch).observe();
 
-  assert.deepEqual(observations, []);
+  assert.deepEqual(
+    observations.map((observation) => observation.providerSessionId),
+    ["task-last-week"],
+  );
 });
 
 test("orders the pass itself rather than trusting the order GitHub answers in", async () => {

--- a/apps/desktop/tests/cursor-adapter.test.ts
+++ b/apps/desktop/tests/cursor-adapter.test.ts
@@ -446,15 +446,14 @@ test("keeps observing when one agent's run cannot be read", async () => {
   assert.equal(observations[1]?.status, SESSION_STATUS.WORKING);
 });
 
-test("ignores agents untouched for longer than the maximum session age", async () => {
+test("keeps an agent untouched since the day before yesterday", async () => {
   const api = fakeCursorApi([runningAgent("agent-last-week", TEST_TIME - 48 * 60 * 60 * 1000)]);
 
   const observations = await adapterFor(api.fetch).observe();
 
-  assert.deepEqual(observations, []);
   assert.deepEqual(
-    api.requests.map((request) => request.pathname),
-    ["/v1/repositories", "/v1/agents"],
+    observations.map((observation) => observation.providerSessionId),
+    ["agent-last-week"],
   );
 });
 

--- a/apps/desktop/tests/cursor-local-adapter.test.ts
+++ b/apps/desktop/tests/cursor-local-adapter.test.ts
@@ -142,7 +142,6 @@ function adapterFor(
   state: CursorState,
   overrides: {
     now?: () => number;
-    maximumSessionAgeMs?: number;
     activeSessionFreshnessMs?: number;
     maximumProjectDirectories?: number;
     maximumSessionFiles?: number;
@@ -152,7 +151,6 @@ function adapterFor(
   return new CursorLocalSessionAdapter({
     ...state,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60 * 60 * 1000,
     ...overrides,
   });
 }
@@ -303,7 +301,7 @@ test("keeps reporting a failure that has gone quiet, because it has not healed",
   );
 });
 
-test("ignores sessions older than the maximum session age", async (t) => {
+test("keeps a session from yesterday on the roster", async (t) => {
   const state = await temporaryCursorState(t);
   await writeTranscript(
     state,
@@ -313,11 +311,12 @@ test("ignores sessions older than the maximum session age", async (t) => {
     TEST_TIME - 25 * 60 * 60 * 1000,
   );
 
-  const observations = await adapterFor(state, {
-    maximumSessionAgeMs: 24 * 60 * 60 * 1000,
-  }).observe();
+  const [observation] = await adapterFor(state).observe();
 
-  assert.deepEqual(observations, []);
+  // Never hidden for its age — but a wait that stale has decayed to unknown,
+  // so the row says nothing it can no longer vouch for.
+  assert.equal(observation?.providerSessionId, "session-yesterday");
+  assert.equal(observation?.status, SESSION_STATUS.UNKNOWN);
 });
 
 test("names a folder its project directory can no longer spell", async (t) => {

--- a/apps/desktop/tests/devin-adapter.test.ts
+++ b/apps/desktop/tests/devin-adapter.test.ts
@@ -198,15 +198,12 @@ test("observes a working session and labels it the way Devin named it", async ()
   // The session's structured output is shaped by its prompt, so it stays out.
   assert.equal(JSON.stringify(observations).includes("SECRET_STRUCTURED_OUTPUT"), false);
   // Devin is asked who the credential belongs to, then for that person's
-  // sessions since the observation window opened. Nothing else.
+  // sessions. Nothing else.
   assert.deepEqual(
     api.requests.map((request) => request.pathname),
     ["/v3/self", `/v3/organizations/${TEST_ORG_ID}/sessions`],
   );
-  assert.equal(
-    api.requests[1]?.search,
-    `?first=200&user_ids=${TEST_USER_ID}&updated_after=${seconds(TEST_TIME - 24 * 60 * 60 * 1000)}`,
-  );
+  assert.equal(api.requests[1]?.search, `?first=200&user_ids=${TEST_USER_ID}`);
   assert.equal(
     api.requests.every(
       (request) => request.method === "GET" && request.authorization === `Bearer ${TEST_API_KEY}`,
@@ -387,25 +384,17 @@ test("reads a timestamp Devin reports in seconds as the moment it means", async 
   const observations = await adapterFor(api.fetch).observe();
 
   assert.equal(observations[0]?.observedAt, TEST_TIME - 60_000);
-  // The window is asked for in the same unit, so a page cannot come back empty
-  // because Luke asked for sessions updated after the year 5138.
-  const requested = Number(
-    new URL(api.requests[1]?.search ?? "", TEST_BASE_URL).searchParams.get("updated_after"),
-  );
-  assert.ok(requested > 0 && requested < seconds(TEST_TIME));
 });
 
-test("ignores sessions untouched for longer than the maximum session age", async () => {
-  // The request already excludes them, so this covers a provider that answers
-  // more broadly than it was asked to.
+test("keeps a session untouched since the day before yesterday", async () => {
   const api = fakeDevinApi([workingSession("devin-last-week", TEST_TIME - 48 * 60 * 60 * 1000)]);
-  const unfiltered: CloudFetch = async (url, init) => {
-    const address = new URL(url);
-    address.searchParams.delete("updated_after");
-    return api.fetch(address.href, init);
-  };
 
-  assert.deepEqual(await adapterFor(unfiltered).observe(), []);
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.providerSessionId),
+    ["devin-last-week"],
+  );
 });
 
 test("falls back to the repository its pull request is in when Devin named nothing", async () => {

--- a/apps/desktop/tests/jules-adapter.test.ts
+++ b/apps/desktop/tests/jules-adapter.test.ts
@@ -278,12 +278,15 @@ test("keeps a completed session complete however long ago it finished", async ()
   assert.equal(observations[0]?.status, SESSION_STATUS.COMPLETE);
 });
 
-test("ignores sessions untouched for longer than the maximum session age", async () => {
+test("keeps a session untouched since the day before yesterday", async () => {
   const api = fakeJulesApi([workingSession("session-last-week", TEST_TIME - 48 * 60 * 60 * 1000)]);
 
   const observations = await adapterFor(api.fetch).observe();
 
-  assert.deepEqual(observations, []);
+  assert.deepEqual(
+    observations.map((observation) => observation.providerSessionId),
+    ["session-last-week"],
+  );
 });
 
 test("orders the pass itself rather than trusting the order Jules answers in", async () => {

--- a/apps/desktop/tests/opencode-adapter.test.ts
+++ b/apps/desktop/tests/opencode-adapter.test.ts
@@ -258,7 +258,6 @@ test("observes an OpenCode session under the name OpenCode gave it", async (t) =
   const adapter = new OpenCodeSessionAdapter({
     dataDirectory,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const observations = await adapter.observe();
 
@@ -289,7 +288,6 @@ test("falls back to the workspace while OpenCode has not named the session", asy
   const adapter = new OpenCodeSessionAdapter({
     dataDirectory,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const [observation] = await adapter.observe();
 
@@ -334,7 +332,6 @@ test("reports a finished OpenCode turn as waiting for its developer", async (t) 
   const adapter = new OpenCodeSessionAdapter({
     dataDirectory,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const [observation] = await adapter.observe();
 
@@ -366,7 +363,6 @@ test("reports a stopped OpenCode turn as waiting when its user aborted it", asyn
   const adapter = new OpenCodeSessionAdapter({
     dataDirectory,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const [observation] = await adapter.observe();
 
@@ -406,7 +402,6 @@ test("reports a failed OpenCode turn with the failure it recorded", async (t) =>
     dataDirectory,
     now: () => TEST_TIME,
     activeSessionFreshnessMs: 15 * 60 * 1000,
-    maximumSessionAgeMs: 60 * 60 * 1000,
   });
   const [observation] = await adapter.observe();
 
@@ -458,7 +453,6 @@ test("names the tool an OpenCode session is running", async (t) => {
   const adapter = new OpenCodeSessionAdapter({
     dataDirectory,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const [observation] = await adapter.observe();
 
@@ -512,7 +506,6 @@ test("names the tool still running behind one that already settled", async (t) =
   const adapter = new OpenCodeSessionAdapter({
     dataDirectory,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const [observation] = await adapter.observe();
 
@@ -546,7 +539,6 @@ test("skips OpenCode subagent and archived sessions", async (t) => {
   const adapter = new OpenCodeSessionAdapter({
     dataDirectory,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const observations = await adapter.observe();
 
@@ -581,7 +573,6 @@ test("reads every session's turn rather than a capped few", async (t) => {
   const adapter = new OpenCodeSessionAdapter({
     dataDirectory,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const observations = await adapter.observe();
 
@@ -591,7 +582,7 @@ test("reads every session's turn rather than a capped few", async (t) => {
   }
 });
 
-test("filters old OpenCode sessions while preserving the newest", async (t) => {
+test("keeps old OpenCode sessions beside the newest", async (t) => {
   const dataDirectory = await temporaryDataDirectory(t);
   await writeOpenCodeState(dataDirectory, [
     { id: "ses_old", directory: "/Users/test/old", observedAt: TEST_TIME - 90_000 },
@@ -601,7 +592,6 @@ test("filters old OpenCode sessions while preserving the newest", async (t) => {
   const adapter = new OpenCodeSessionAdapter({
     dataDirectory,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const observations = await adapter.observe();
 
@@ -610,7 +600,10 @@ test("filters old OpenCode sessions while preserving the newest", async (t) => {
       providerSessionId: observation.providerSessionId,
       title: observation.title,
     })),
-    [{ providerSessionId: "ses_new", title: "new" }],
+    [
+      { providerSessionId: "ses_new", title: "new" },
+      { providerSessionId: "ses_old", title: "old" },
+    ],
   );
 });
 
@@ -636,7 +629,6 @@ test("keeps stale open OpenCode turns unknown instead of inventing activity", as
     dataDirectory,
     now: () => TEST_TIME,
     activeSessionFreshnessMs: 15 * 60 * 1000,
-    maximumSessionAgeMs: 60 * 60 * 1000,
   });
   const [observation] = await adapter.observe();
 
@@ -664,7 +656,6 @@ test("observes the database OPENCODE_DB names", async (t) => {
   const adapter = new OpenCodeSessionAdapter({
     dataDirectory,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const observations = await adapter.observe();
 
@@ -684,7 +675,6 @@ test("falls back to the prod-channel database when the current one is unusable",
   const adapter = new OpenCodeSessionAdapter({
     dataDirectory,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const observations = await adapter.observe();
 
@@ -707,7 +697,6 @@ test("observes sessions from a database predating the archive column", async (t)
   const adapter = new OpenCodeSessionAdapter({
     dataDirectory,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const observations = await adapter.observe();
 
@@ -742,7 +731,6 @@ test("observes legacy JSON sessions when no database exists", async (t) => {
   const adapter = new OpenCodeSessionAdapter({
     dataDirectory,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const observations = await adapter.observe();
 
@@ -773,7 +761,6 @@ test("reads the newest legacy message by its ordered identifier", async (t) => {
   const adapter = new OpenCodeSessionAdapter({
     dataDirectory,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const [observation] = await adapter.observe();
 
@@ -797,7 +784,6 @@ test("observes legacy JSON sessions when node sqlite is unavailable", async (t) 
   const adapter = new OpenCodeSessionAdapter({
     dataDirectory,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
     sqlite: async () => {
       throw error;
     },

--- a/packages/sidecar-core/src/session.ts
+++ b/packages/sidecar-core/src/session.ts
@@ -43,10 +43,12 @@ export function agedStatus(
 
 /**
  * Shared bounds for every provider. A session reads the same whether Luke
- * observed it on disk or over the network.
+ * observed it on disk or over the network. There is deliberately no maximum
+ * session age: a conversation is never hidden for being old, only crowded out
+ * by newer ones when a provider's count budget fills. Each adapter's budget —
+ * newest first — is what bounds the roster and the observation pass.
  */
 export const OBSERVATION_WINDOW = {
-  MAXIMUM_SESSION_AGE_MS: 24 * 60 * 60 * 1000,
   ACTIVE_SESSION_FRESHNESS_MS: 15 * 60 * 1000,
 } as const;
 


### PR DESCRIPTION
## What

Removes the 24-hour observation window (`OBSERVATION_WINDOW.MAXIMUM_SESSION_AGE_MS`) that every provider adapter applied, so a conversation is never hidden from the panel for being old.

## Why

A session untouched for a day simply vanished from the roster, even though the user still cared about it — a workspace picked back up after a weekend, an agent babysitting a slow PR. The age filter was a relevance proxy layered on top of bounds that already do the real work: every adapter sorts newest-first and caps what one pass observes (12 cloud sessions, 8 Conductor workspaces, 40 local session files, one page per cloud request). Dropping the filter leaves the roster and every observation pass exactly as bounded as before; old conversations are only ever crowded out by newer ones, never aged out. The session list is the one scroll container in the app, so more rows cost nothing.

## How

- `OBSERVATION_WINDOW` keeps only `ACTIVE_SESSION_FRESHNESS_MS`; the 15-minute freshness bound is untouched, so a stale wait still decays to unknown and an old row never claims a state Luke cannot vouch for.
- Local adapters (Claude Code, Codex, Cursor local, OpenCode) drop the `maximumSessionAgeMs` option and mtime/observedAt gates; `discoverSessionFiles`' newest-first file cap already bounds what a pass reads.
- Cloud adapters (Conductor, Cursor, Copilot, Devin, Jules) drop the window filters; Copilot stops sending `since` and Devin stops sending `updated_after`, each fetching its newest page and capping client-side as before.
- Conductor's global session budget was spent in workspace order, so once closed chats stopped aging out, a days-old closed chat in a busy workspace could take the slot an open chat in a quieter one needed. The flatten now sorts open chats ahead of closed ones — the preference each workspace already applied internally — before the cap.
- The age-out tests are inverted to pin the new behavior: a session from the day before yesterday stays on the roster for every provider.

## Verification

`./scripts/check.sh` passes (lint, typecheck, all tests, build). Portable-only change — no UI or macOS-specific behavior touched, so no visual evidence run; no physical-notch check performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ba839d95-02dd-45cd-84ba-3f2501fcd250)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31966439396/artifacts/9268618068) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31966439396)

- Commit: `0e67eea6bb108d4ec8e477cfcc4f7708239c3d0e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
