### PR TITLE
fix(voice): let a spoken pace ask use the multiple its row shows

### DIFF
--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -110,8 +110,10 @@ const ASK_EACH_TIME_CHOICE = "ask each time";
 
 /**
  * The words a pace is asked for in, slowest to fastest, each paired with the
- * multiple it means. The settings row shows the multiples; a conversation
- * offers the words, because "quick" survives speech where "1.25×" does not.
+ * multiple it means. A conversation offers both spellings: the word because
+ * "quick" survives speech where "1.25×" does not, and the multiple because it
+ * is the label the settings row shows, so it is the name a reader of the row
+ * will ask by.
  */
 const VOICE_SPEED_WORDS: readonly { word: string; speed: RealtimeVoiceSpeed }[] = [
   { word: "slow", speed: REALTIME_VOICE_SPEED.SLOW },
@@ -120,12 +122,19 @@ const VOICE_SPEED_WORDS: readonly { word: string; speed: RealtimeVoiceSpeed }[] 
   { word: "fast", speed: REALTIME_VOICE_SPEED.FAST },
 ];
 
+/** A pace spelt the way its settings row labels it. */
+function voiceSpeedMultiple(speed: RealtimeVoiceSpeed): string {
+  return `${speed}×`;
+}
+
 function voiceSpeedWord(speed: RealtimeVoiceSpeed): string {
   return VOICE_SPEED_WORDS.find((candidate) => candidate.speed === speed)?.word ?? "normal";
 }
 
 function voiceSpeedFromWord(word: string): RealtimeVoiceSpeed | undefined {
-  return VOICE_SPEED_WORDS.find((candidate) => candidate.word === word)?.speed;
+  return VOICE_SPEED_WORDS.find(
+    (candidate) => candidate.word === word || voiceSpeedMultiple(candidate.speed) === word,
+  )?.speed;
 }
 
 /** The name a provider is known by on its rows, falling back to its id. */
@@ -161,11 +170,14 @@ const SETTING_GUIDE: Record<
     id: APP_SETTING_ID.VOICE_SPEED,
     label: "Speed",
     description:
-      "How fast Luke talks — slow is 0.75×, normal 1×, quick 1.25×, fast 1.5× the voice's natural rate; a change is heard from the next reply on.",
+      "How fast Luke talks — slow is 0.75×, normal 1×, quick 1.25×, fast 1.5× the voice's natural rate, and an ask may use the word or the multiple; a change is heard from the next reply on.",
     kind: APP_SETTING_KIND.CHOICE,
     value: voiceSpeedWord(settings.voiceSpeed),
     defaultValue: voiceSpeedWord(REALTIME_DEFAULTS.SPEED),
-    choices: VOICE_SPEED_WORDS.map((candidate) => candidate.word),
+    choices: VOICE_SPEED_WORDS.flatMap((candidate) => [
+      candidate.word,
+      voiceSpeedMultiple(candidate.speed),
+    ]),
     adjustable: true,
     manual: VOICE_PAGE,
   }),

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -93,12 +93,22 @@ test("the guide describes every spoken-adjustable setting with its current value
   assert.equal(dock.value, "off");
   assert.equal(dock.defaultValue, "off");
 
-  // The pace is offered in words a voice can carry, current value included.
+  // The pace is offered in words a voice can carry and in the multiples its
+  // settings row shows, so an ask in either spelling lands.
   const speed = guideSetting(APP_SETTING_ID.VOICE_SPEED);
   assert.equal(speed.kind, APP_SETTING_KIND.CHOICE);
   assert.equal(speed.value, "normal");
   assert.equal(speed.defaultValue, "normal");
-  assert.deepEqual(speed.choices, ["slow", "normal", "quick", "fast"]);
+  assert.deepEqual(speed.choices, [
+    "slow",
+    "0.75×",
+    "normal",
+    "1×",
+    "quick",
+    "1.25×",
+    "fast",
+    "1.5×",
+  ]);
   assert.equal(
     guideSetting(
       APP_SETTING_ID.VOICE_SPEED,
@@ -517,6 +527,27 @@ test("every adjustable setting is carried to the bridge call its row uses", asyn
   // The snapshot the store answered with is handed back either way, so the
   // panel's switches redraw from what was actually stored.
   assert.equal(seen.length, calls.length);
+});
+
+test("a pace asked for by its multiple carries the same as its word", async () => {
+  const calls: string[] = [];
+  const bridge = {
+    setVoiceSpeed: async (speed: number) => {
+      calls.push(`setVoiceSpeed:${speed}`);
+      return { settings: settings() };
+    },
+  };
+
+  for (const value of ["quick", "1.25×"]) {
+    const outcome = await applySpokenSetting(
+      bridge,
+      { setting: guideSetting(APP_SETTING_ID.VOICE_SPEED), value },
+      () => undefined,
+    );
+    assert.equal(outcome.status, "changed");
+  }
+
+  assert.deepEqual(calls, ["setVoiceSpeed:1.25", "setVoiceSpeed:1.25"]);
 });
 
 test("the store's refusal comes back as the spoken outcome", async () => {


### PR DESCRIPTION
## Why

The Voice page labels the speeds `0.75×`, `1×`, `1.25×`, and `1.5×`, but the guide — the outer bound of what a spoken ask can do — offered only the words slow, normal, quick, and fast. Asking Luke for a pace by the very name the settings row taught ("set your speed to 1.25×") was refused, and Luke could not connect the multiples to the paces he does know.

## What

- The speed entry's choices now carry both spellings, paired slowest to fastest: `slow, 0.75×, normal, 1×, quick, 1.25×, fast, 1.5×`. Validation matches choices exactly, so both forms land, and a refusal now lists both.
- `voiceSpeedFromWord` maps either spelling to the stored multiple; the entry's description says an ask may use the word or the multiple.
- The spoken value Luke reports stays the word ("normal"), which survives speech.

Note: the offered steps remain 0.75×–1.5× (`REALTIME_VOICE_SPEED`); no 0.5× step exists today, and adding one would be a product decision about the offered set, not part of this vocabulary fix.

## Testing

- `./scripts/check.sh` passes (lint, typecheck, tests, build).
- New test: a pace asked for as `1.25×` carries to the same `setVoiceSpeed` bridge call as `quick`.
- No pixels move — the settings row is unchanged — so no visual evidence; not run on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/2cfe6f39-a2af-47ad-af0e-5eda2dc5484d)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31966849950/artifacts/9268735228) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31966849950)

- Commit: `13d9e1f729494ba61b3deca4278444f8f2f38efb`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
