### PR TITLE
feat(providers): archive a workspace where its provider documents it

### DIFF
--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -141,10 +141,12 @@ const CONDUCTOR_ARCHIVE_WORKSPACE_CONTROL_ID = "archive-workspace";
 /**
  * The workspace-level control: Conductor documents archiving a workspace,
  * which files away every chat in it at once. It is advertised on a chat's row
- * only while nothing in that workspace is observed working — a workspace
- * mid-turn has a stop to offer, not a filing away — and the workspace it acts
- * on rides the advertisement as the control's target, so a press archives the
- * workspace the user was shown and nothing an adapter kept on the side.
+ * only once every chat in that workspace was positively seen settled — a
+ * workspace mid-turn has a stop to offer, not a filing away, and one whose
+ * state could not be read is not known to have stopped — and the workspace it
+ * acts on rides the advertisement as the control's target, so a press
+ * archives the workspace the user was shown and nothing an adapter kept on
+ * the side.
  */
 function conductorArchiveWorkspaceControl(workspaceId: string): SessionControl {
   return {
@@ -541,17 +543,21 @@ export class ConductorSessionAdapter
       ),
     ]);
 
-    // The workspaces with a chat observed mid-turn, judged from this pass's
-    // own statuses: an archive is a workspace-level act, so it is held back
-    // from every chat of a workspace where any observed sibling still works —
-    // filing the workspace away would take the running turn with it.
-    const workingWorkspaceIds = new Set(
-      sessions
-        .filter(
-          (session, index) => reportedStatuses[index]?.status === CONDUCTOR_SESSION_STATUS.WORKING,
-        )
-        .map((session) => session.workspace.id),
-    );
+    // The workspaces every observed chat of which was positively seen settled
+    // — closed, or reporting idle or errored — judged from this pass's own
+    // statuses. An archive is a workspace-level act, so it is offered only for
+    // these: a chat still working, and just as much one whose status could not
+    // be read at all, keeps the whole workspace off the list, because filing
+    // away a workspace whose state Luke has not actually seen stop could take
+    // a live turn with it.
+    const settledWorkspaceIds = new Set(sessions.map((session) => session.workspace.id));
+    sessions.forEach((session, index) => {
+      const settled =
+        session.archived ||
+        reportedStatuses[index]?.status === CONDUCTOR_SESSION_STATUS.IDLE ||
+        reportedStatuses[index]?.status === CONDUCTOR_SESSION_STATUS.ERROR;
+      if (!settled) settledWorkspaceIds.delete(session.workspace.id);
+    });
 
     // One row per chat, each grouped under its workspace. Two chats used to
     // collapse into one row because their generated names drew as identical
@@ -565,7 +571,7 @@ export class ConductorSessionAdapter
           session,
           reportedStatuses[index],
           transcripts?.get(session.id),
-          workingWorkspaceIds,
+          settledWorkspaceIds,
           now,
         ),
       )
@@ -770,7 +776,7 @@ export class ConductorSessionAdapter
     session: ConductorSession,
     reported: ConductorReportedStatus | undefined,
     transcript: ConductorTranscript | undefined,
-    workingWorkspaceIds: ReadonlySet<string>,
+    settledWorkspaceIds: ReadonlySet<string>,
     now: number,
   ): ProviderSessionObservation | undefined {
     // A workspace timestamp covers every chat in that workspace, so it would
@@ -791,14 +797,14 @@ export class ConductorSessionAdapter
     const model = agentAndModelLabel(transcript?.agentKind, session.model);
     // The stop belongs to the turn and the archive to the workspace: a chat
     // mid-turn offers the stop alone — its own workspace is by definition
-    // working — and any chat of a settled, still-open workspace offers to
-    // file the whole workspace away, closed chats included, because a closed
-    // chat's row is exactly where tidying up happens.
+    // unsettled — and any chat of a positively settled, still-open workspace
+    // offers to file the whole workspace away, closed chats included, because
+    // a closed chat's row is exactly where tidying up happens.
     const controls = [
       ...(reported?.status === CONDUCTOR_SESSION_STATUS.WORKING ? [CONDUCTOR_CANCEL_CONTROL] : []),
-      ...(session.workspace.archived || workingWorkspaceIds.has(session.workspace.id)
-        ? []
-        : [conductorArchiveWorkspaceControl(session.workspace.id)]),
+      ...(!session.workspace.archived && settledWorkspaceIds.has(session.workspace.id)
+        ? [conductorArchiveWorkspaceControl(session.workspace.id)]
+        : []),
     ];
     return {
       providerSessionId: session.id,

--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -56,9 +56,11 @@ const CONDUCTOR_DEFAULT_API_URL = "https://api.conductor.build";
  * sessions; the writers are `POST …/sessions/{id}/messages`, which is
  * Conductor's documented way to hand a prompt to an existing session — queued
  * while it is idle, steered into the running turn while it works —
- * `POST …/sessions/{id}/cancel`, which stops the current turn, and
+ * `POST …/sessions/{id}/cancel`, which stops the current turn,
  * `POST /v0/workspaces`, which is its documented way to create a workspace in
- * a project the user already connected.
+ * a project the user already connected, and
+ * `POST …/workspaces/{id}/archive`, which is its documented way to file a
+ * workspace away.
  */
 const CONDUCTOR_ROUTE = {
   IDENTITY: ["me"],
@@ -68,6 +70,7 @@ const CONDUCTOR_ROUTE = {
 } as const;
 
 const CONDUCTOR_ROUTE_SEGMENT = {
+  ARCHIVE: "archive",
   CANCEL: "cancel",
   MESSAGES: "messages",
   SESSIONS: "sessions",
@@ -124,14 +127,32 @@ const CONDUCTOR_SPAWNABLE_AGENTS: readonly string[] = workspaceAgentModels(
 ).map((entry) => entry.agent);
 
 /**
- * The one control this adapter can honour, advertised only while a session is
- * actually working a turn there is something to stop.
+ * The turn-level control, advertised only while a session is actually working
+ * a turn there is something to stop.
  */
 const CONDUCTOR_CANCEL_CONTROL = {
   id: "cancel-turn",
   label: "Stop this turn",
   kind: SESSION_CONTROL_KIND.STOP,
 } as const;
+
+const CONDUCTOR_ARCHIVE_WORKSPACE_CONTROL_ID = "archive-workspace";
+
+/**
+ * The workspace-level control: Conductor documents archiving a workspace,
+ * which files away every chat in it at once. It is advertised on a chat's row
+ * only while nothing in that workspace is observed working — a workspace
+ * mid-turn has a stop to offer, not a filing away — and the workspace it acts
+ * on rides the advertisement as the control's target, so a press archives the
+ * workspace the user was shown and nothing an adapter kept on the side.
+ */
+function conductorArchiveWorkspaceControl(workspaceId: string): SessionControl {
+  return {
+    id: CONDUCTOR_ARCHIVE_WORKSPACE_CONTROL_ID,
+    label: "Archive this workspace",
+    target: workspaceId,
+  };
+}
 
 const CONDUCTOR_QUERY = {
   LIMIT: "limit",
@@ -295,6 +316,8 @@ interface ConductorWorkspace {
   repositoryLabel: string;
   creatorId?: string;
   lastActivityAt: number;
+  /** A workspace already filed away has nothing left to archive. */
+  archived: boolean;
 }
 
 interface ConductorSession {
@@ -320,9 +343,10 @@ interface ConductorSession {
  * workspace is the unit Conductor's own surface shows, but the chat is the
  * thing a press opens and a write reaches, and a workspace holding two chats
  * in two states is two facts, not one. The writes it supports are a
- * user-typed prompt and a stop for the running turn, each through Conductor's
- * own endpoint on a chat that advertised it, and a new workspace in a project
- * the latest pass listed, through Conductor's documented creation endpoint.
+ * user-typed prompt, a stop for the running turn, and an archive for the
+ * settled workspace around a chat, each through Conductor's own endpoint on a
+ * chat that advertised it, and a new workspace in a project the latest pass
+ * listed, through Conductor's documented creation endpoint.
  */
 export class ConductorSessionAdapter
   extends CloudSessionAdapter
@@ -517,6 +541,18 @@ export class ConductorSessionAdapter
       ),
     ]);
 
+    // The workspaces with a chat observed mid-turn, judged from this pass's
+    // own statuses: an archive is a workspace-level act, so it is held back
+    // from every chat of a workspace where any observed sibling still works —
+    // filing the workspace away would take the running turn with it.
+    const workingWorkspaceIds = new Set(
+      sessions
+        .filter(
+          (session, index) => reportedStatuses[index]?.status === CONDUCTOR_SESSION_STATUS.WORKING,
+        )
+        .map((session) => session.workspace.id),
+    );
+
     // One row per chat, each grouped under its workspace. Two chats used to
     // collapse into one row because their generated names drew as identical
     // lines — but the workspace grouping now names the group once, which
@@ -525,7 +561,13 @@ export class ConductorSessionAdapter
     // sibling most needed a person.
     return sessions
       .map((session, index) =>
-        this.#observationFor(session, reportedStatuses[index], transcripts?.get(session.id), now),
+        this.#observationFor(
+          session,
+          reportedStatuses[index],
+          transcripts?.get(session.id),
+          workingWorkspaceIds,
+          now,
+        ),
       )
       .filter(isDefined);
   }
@@ -582,6 +624,7 @@ export class ConductorSessionAdapter
           id,
           repositoryLabel: project.repositoryLabel,
           lastActivityAt,
+          archived: timestampFromRecord(record, CONDUCTOR_FIELD.ARCHIVED_AT) !== undefined,
           ...(name ? { name } : {}),
           ...(creatorId ? { creatorId } : {}),
         };
@@ -694,22 +737,40 @@ export class ConductorSessionAdapter
     providerSessionId: string,
     control: SessionControl,
   ): CloudWriteRoute | undefined {
-    if (control.id !== CONDUCTOR_CANCEL_CONTROL.id) return undefined;
-    return {
-      segments: [
-        CONDUCTOR_ROUTE_SEGMENT.V0,
-        CONDUCTOR_ROUTE_SEGMENT.SESSIONS,
-        providerSessionId,
-        CONDUCTOR_ROUTE_SEGMENT.CANCEL,
-      ],
-      // Conductor documents no body for a cancel, so none is sent.
-    };
+    if (control.id === CONDUCTOR_CANCEL_CONTROL.id) {
+      return {
+        segments: [
+          CONDUCTOR_ROUTE_SEGMENT.V0,
+          CONDUCTOR_ROUTE_SEGMENT.SESSIONS,
+          providerSessionId,
+          CONDUCTOR_ROUTE_SEGMENT.CANCEL,
+        ],
+        // Conductor documents no body for a cancel, so none is sent.
+      };
+    }
+    if (control.id === CONDUCTOR_ARCHIVE_WORKSPACE_CONTROL_ID) {
+      // The workspace to archive is the advertised control's own target, so it
+      // is the workspace of the observation the user pressed, under the
+      // credential that observed it.
+      if (!control.target) return undefined;
+      return {
+        segments: [
+          CONDUCTOR_ROUTE_SEGMENT.V0,
+          CONDUCTOR_ROUTE_SEGMENT.WORKSPACES,
+          control.target,
+          CONDUCTOR_ROUTE_SEGMENT.ARCHIVE,
+        ],
+        // Conductor documents no body for an archive, so none is sent.
+      };
+    }
+    return undefined;
   }
 
   #observationFor(
     session: ConductorSession,
     reported: ConductorReportedStatus | undefined,
     transcript: ConductorTranscript | undefined,
+    workingWorkspaceIds: ReadonlySet<string>,
     now: number,
   ): ProviderSessionObservation | undefined {
     // A workspace timestamp covers every chat in that workspace, so it would
@@ -728,6 +789,17 @@ export class ConductorSessionAdapter
         ? transcript?.recap
         : undefined;
     const model = agentAndModelLabel(transcript?.agentKind, session.model);
+    // The stop belongs to the turn and the archive to the workspace: a chat
+    // mid-turn offers the stop alone — its own workspace is by definition
+    // working — and any chat of a settled, still-open workspace offers to
+    // file the whole workspace away, closed chats included, because a closed
+    // chat's row is exactly where tidying up happens.
+    const controls = [
+      ...(reported?.status === CONDUCTOR_SESSION_STATUS.WORKING ? [CONDUCTOR_CANCEL_CONTROL] : []),
+      ...(session.workspace.archived || workingWorkspaceIds.has(session.workspace.id)
+        ? []
+        : [conductorArchiveWorkspaceControl(session.workspace.id)]),
+    ];
     return {
       providerSessionId: session.id,
       // The chat's own name titles the row, because the row is the chat; the
@@ -760,9 +832,7 @@ export class ConductorSessionAdapter
       // snapshot that promised it.
       spawnableAgents: CONDUCTOR_SPAWNABLE_AGENTS,
       spawnTarget: session.workspace.id,
-      ...(reported?.status === CONDUCTOR_SESSION_STATUS.WORKING
-        ? { controls: [CONDUCTOR_CANCEL_CONTROL] }
-        : {}),
+      ...(controls.length > 0 ? { controls } : {}),
       ...(recap ? { recap } : {}),
       detail: {
         repository: session.workspace.repositoryLabel,

--- a/apps/desktop/src/cursor-adapter.ts
+++ b/apps/desktop/src/cursor-adapter.ts
@@ -178,6 +178,18 @@ const CURSOR_RUN_STATUS = {
 type CursorRunStatus = (typeof CURSOR_RUN_STATUS)[keyof typeof CURSOR_RUN_STATUS];
 
 /**
+ * The run states in which a run has positively stopped. The archive is offered
+ * only over one of these — never over a run still moving, one still being
+ * created, or one whose state could not be read at all.
+ */
+const CURSOR_SETTLED_RUN_STATUSES: ReadonlySet<CursorRunStatus> = new Set([
+  CURSOR_RUN_STATUS.FINISHED,
+  CURSOR_RUN_STATUS.CANCELLED,
+  CURSOR_RUN_STATUS.EXPIRED,
+  CURSOR_RUN_STATUS.ERROR,
+]);
+
+/**
  * A finished run has stopped and is holding for the user, which is what Luke
  * reports as waiting. A run that was cancelled or expired stopped for good. One
  * that is still being created, or that failed, is left unknown rather than
@@ -405,12 +417,18 @@ export class CursorSessionAdapter
 
   /**
    * Cursor documents archiving an agent in any state, but the offer waits for
-   * the latest run to settle: filing an agent away mid-run would take the run
-   * with it, and the running row already has the one control that ends a run
-   * on purpose. An agent already archived has nothing left to archive.
+   * the latest run to positively settle: filing an agent away mid-run would
+   * take the run with it, and the running row already has the one control
+   * that ends a run on purpose. An agent that has never run has no run to
+   * take; one whose run could not be read, or reports a state this build does
+   * not know, is not known to have stopped, so it is offered nothing rather
+   * than a filing away that could land on a live turn. An agent already
+   * archived has nothing left to archive.
    */
   #agentTakesArchive(agent: CursorAgent, run: CursorRun | undefined): boolean {
-    return !agent.archived && !this.#agentTakesCancel(agent, run);
+    if (agent.archived) return false;
+    if (!agent.latestRunId) return true;
+    return run?.status !== undefined && CURSOR_SETTLED_RUN_STATUSES.has(run.status);
   }
 
   /**

--- a/apps/desktop/src/cursor-adapter.ts
+++ b/apps/desktop/src/cursor-adapter.ts
@@ -55,6 +55,7 @@ const CURSOR_DEFAULT_API_URL = "https://api.cursor.com";
 
 const CURSOR_ROUTE_SEGMENT = {
   AGENTS: "agents",
+  ARCHIVE: "archive",
   CANCEL: "cancel",
   REPOSITORIES: "repositories",
   RUNS: "runs",
@@ -66,9 +67,10 @@ const CURSOR_ROUTE_SEGMENT = {
  * repositories the key may launch agents in; the writers are
  * `POST …/agents/{id}/runs`, which is Cursor's documented follow-up — a new
  * run on the agent's existing conversation and workspace state —
- * `POST …/runs/{runId}/cancel`, which stops one that is active, and
+ * `POST …/runs/{runId}/cancel`, which stops one that is active,
  * `POST /v1/agents`, which is its documented way to launch a new agent on a
- * repository the key can reach.
+ * repository the key can reach, and `POST …/agents/{id}/archive`, which is
+ * its documented way to file an agent away.
  */
 const CURSOR_ROUTE = {
   AGENTS: [CURSOR_ROUTE_SEGMENT.V1, CURSOR_ROUTE_SEGMENT.AGENTS],
@@ -103,11 +105,11 @@ const CURSOR_REPOSITORY_RETRY_MS = 5 * 60 * 1000;
 const CURSOR_CANCEL_RUN_CONTROL_ID = "cancel-run";
 
 /**
- * The one control this adapter can honour, advertised per session and only in
- * the state Cursor documents it for. The run it would cancel rides the
- * advertisement as the control's target, so a press stops the run the user
- * was shown — state an adapter kept on the side could outlive the snapshot
- * that promised it, but a control cannot.
+ * The run-level control, advertised per session and only in the state Cursor
+ * documents it for. The run it would cancel rides the advertisement as the
+ * control's target, so a press stops the run the user was shown — state an
+ * adapter kept on the side could outlive the snapshot that promised it, but a
+ * control cannot.
  */
 function cursorCancelRunControl(runId: string): SessionControl {
   return {
@@ -117,6 +119,18 @@ function cursorCancelRunControl(runId: string): SessionControl {
     target: runId,
   };
 }
+
+/**
+ * The agent-level control: Cursor documents archiving an agent — it stays
+ * readable but takes no new runs — and the agent is the whole unit of a
+ * Cursor cloud workspace, so filing it away is this provider's workspace
+ * archive. It is advertised only once the latest run has settled: an agent
+ * mid-run has a stop to offer, not a filing away.
+ */
+const CURSOR_ARCHIVE_AGENT_CONTROL = {
+  id: "archive-agent",
+  label: "Archive this agent",
+} as const;
 
 const CURSOR_QUERY = {
   LIMIT: "limit",
@@ -267,9 +281,10 @@ function agentFromRecord(record: Record<string, unknown>): CursorAgent | undefin
  * the agents the supplied key owns, observation issues no request that can
  * change provider state, and it reports nothing at all without a credential.
  * The writes it supports are a user-typed follow-up, through Cursor's own run
- * endpoint, to an agent it advertised as taking one, and a new agent — asked
- * for with the user's own opening task — in a repository Cursor listed for
- * this key, through its documented creation endpoint.
+ * endpoint, to an agent it advertised as taking one, a stop for an active run
+ * and an archive for a settled agent — each on a row that advertised it — and
+ * a new agent — asked for with the user's own opening task — in a repository
+ * Cursor listed for this key, through its documented creation endpoint.
  */
 export class CursorSessionAdapter
   extends CloudSessionAdapter
@@ -389,6 +404,16 @@ export class CursorSessionAdapter
   }
 
   /**
+   * Cursor documents archiving an agent in any state, but the offer waits for
+   * the latest run to settle: filing an agent away mid-run would take the run
+   * with it, and the running row already has the one control that ends a run
+   * on purpose. An agent already archived has nothing left to archive.
+   */
+  #agentTakesArchive(agent: CursorAgent, run: CursorRun | undefined): boolean {
+    return !agent.archived && !this.#agentTakesCancel(agent, run);
+  }
+
+  /**
    * Reads `GET /v1/repositories` on its own cadence, keeping only usable
    * entries. Every failure is swallowed here — including a rejected key, which
    * the agents read in the same pass will surface — because nothing awaits
@@ -480,17 +505,25 @@ export class CursorSessionAdapter
     // The run to cancel is the advertised control's own target, so it is the
     // run of the observation the user pressed, under the credential that
     // observed it.
-    if (control.id !== CURSOR_CANCEL_RUN_CONTROL_ID || !control.target) return undefined;
-    return {
-      segments: [
-        ...CURSOR_ROUTE.AGENTS,
-        providerSessionId,
-        CURSOR_ROUTE_SEGMENT.RUNS,
-        control.target,
-        CURSOR_ROUTE_SEGMENT.CANCEL,
-      ],
-      // Cursor documents no body for a cancel, so none is sent.
-    };
+    if (control.id === CURSOR_CANCEL_RUN_CONTROL_ID && control.target) {
+      return {
+        segments: [
+          ...CURSOR_ROUTE.AGENTS,
+          providerSessionId,
+          CURSOR_ROUTE_SEGMENT.RUNS,
+          control.target,
+          CURSOR_ROUTE_SEGMENT.CANCEL,
+        ],
+        // Cursor documents no body for a cancel, so none is sent.
+      };
+    }
+    if (control.id === CURSOR_ARCHIVE_AGENT_CONTROL.id) {
+      return {
+        segments: [...CURSOR_ROUTE.AGENTS, providerSessionId, CURSOR_ROUTE_SEGMENT.ARCHIVE],
+        // Cursor documents no body for an archive, so none is sent.
+      };
+    }
+    return undefined;
   }
 
   async #observationFor(
@@ -517,9 +550,14 @@ export class CursorSessionAdapter
       status,
       observedAt,
       canReceiveMessage: this.#agentTakesMessages(agent, run),
+      // The two controls are exclusive by construction: an active run offers
+      // its stop, a settled agent offers to be filed away, and an archived one
+      // offers nothing.
       ...(latestRunId && this.#agentTakesCancel(agent, run)
         ? { controls: [cursorCancelRunControl(latestRunId)] }
-        : {}),
+        : this.#agentTakesArchive(agent, run)
+          ? { controls: [CURSOR_ARCHIVE_AGENT_CONTROL] }
+          : {}),
       ...(run?.result ? { recap: run.result } : {}),
       detail: {
         ...(repository ? { repository } : {}),

--- a/apps/desktop/src/devin-adapter.ts
+++ b/apps/desktop/src/devin-adapter.ts
@@ -1,13 +1,17 @@
 import {
   agedStatus,
+  type ControllableSessionProviderAdapter,
   isRecord,
   type MessageCapableSessionProviderAdapter,
   OBSERVATION_WINDOW,
+  type ProviderControlRequest,
+  type ProviderControlResult,
   type ProviderMessageResult,
   type ProviderSessionMessage,
   type ProviderSessionObservation,
   resolveOptions,
   SESSION_STATUS,
+  type SessionControl,
   type SessionProvider,
   type SessionStatus,
 } from "@sidecar/core";
@@ -41,9 +45,11 @@ const DEVIN_SESSION_FAILED_MESSAGE = "The session stopped on an error";
 /**
  * Documented public API routes, read with v3 rather than the deprecated v1 the
  * older `apk_` keys are for: v3 is the only version that says who a credential
- * belongs to and that can narrow a list to one person. The one writer among
- * them is `messages`, which is Devin's documented way to hand a message to an
- * existing session.
+ * belongs to and that can narrow a list to one person. The writers among them
+ * are `messages`, which is Devin's documented way to hand a message to an
+ * existing session, and `archive`, which files one away — putting it to sleep
+ * if it was still running, which is why the control is only offered once a
+ * session's turn has settled.
  */
 const DEVIN_ROUTE_SEGMENT = {
   SELF: "self",
@@ -51,6 +57,7 @@ const DEVIN_ROUTE_SEGMENT = {
   ORGANIZATIONS: "organizations",
   SESSIONS: "sessions",
   MESSAGES: "messages",
+  ARCHIVE: "archive",
 } as const;
 
 const DEVIN_QUERY = {
@@ -61,6 +68,19 @@ const DEVIN_QUERY = {
 /** The body `POST …/sessions/{id}/messages` documents. */
 const DEVIN_MESSAGE_FIELD = {
   MESSAGE: "message",
+} as const;
+
+/**
+ * The session-level control: Devin documents archiving a session, after which
+ * it can be viewed but not modified or resumed — and a Devin session is the
+ * whole unit of its cloud workspace, so filing it away is this provider's
+ * workspace archive. It is advertised only for a session positively observed
+ * as settled: one that exited, failed, was suspended, or whose running
+ * machine reports the turn is holding for the user.
+ */
+const DEVIN_ARCHIVE_SESSION_CONTROL = {
+  id: "archive-session",
+  label: "Archive this session",
 } as const;
 
 const DEVIN_FIELD = {
@@ -267,12 +287,14 @@ function sessionFromRecord(
  * person's sessions. Observation issues no request that can change provider
  * state, reports nothing at all without a credential, and reports nothing for
  * a service-user credential, which names an organization rather than a person.
- * The one write it supports is a user-typed message, through Devin's own
- * message endpoint, to a session it advertised as taking one.
+ * The writes it supports are a user-typed message, through Devin's own
+ * message endpoint, to a session it advertised as taking one, and an archive
+ * for a settled session, through Devin's own archive endpoint on a session
+ * that advertised it.
  */
 export class DevinSessionAdapter
   extends CloudSessionAdapter
-  implements MessageCapableSessionProviderAdapter
+  implements MessageCapableSessionProviderAdapter, ControllableSessionProviderAdapter
 {
   readonly #maximumObservedSessions: number;
 
@@ -298,6 +320,10 @@ export class DevinSessionAdapter
 
   async sendMessage(message: ProviderSessionMessage): Promise<ProviderMessageResult> {
     return this.sendObservedMessage(message);
+  }
+
+  async executeControl(request: ProviderControlRequest): Promise<ProviderControlResult> {
+    return this.executeObservedControl(request);
   }
 
   protected override forgetCachedIdentity(): void {
@@ -383,6 +409,31 @@ export class DevinSessionAdapter
     );
   }
 
+  /**
+   * Devin documents archiving a session in any state — a running one is put to
+   * sleep — but the offer waits for the turn to positively settle: a session
+   * that exited, failed, or was suspended, or a running machine whose reported
+   * detail says the turn is holding for the user. A state this build does not
+   * know, or one still mid-turn or mid-transition, advertises nothing: filing
+   * a session away must never be offered over work Luke has not actually seen
+   * stop. An archived session has nothing left to archive.
+   */
+  #sessionTakesArchive(session: DevinSession): boolean {
+    if (session.archived) return false;
+    if (
+      session.status === DEVIN_SESSION_STATUS.EXIT ||
+      session.status === DEVIN_SESSION_STATUS.ERROR ||
+      session.status === DEVIN_SESSION_STATUS.SUSPENDED
+    ) {
+      return true;
+    }
+    return (
+      session.status === DEVIN_SESSION_STATUS.RUNNING &&
+      session.detail !== undefined &&
+      session.detail !== DEVIN_RUNNING_DETAIL.WORKING
+    );
+  }
+
   protected override messageRoute(
     providerSessionId: string,
     text: string,
@@ -404,6 +455,28 @@ export class DevinSessionAdapter
     };
   }
 
+  protected override controlRoute(
+    providerSessionId: string,
+    control: SessionControl,
+  ): CloudWriteRoute | undefined {
+    if (control.id !== DEVIN_ARCHIVE_SESSION_CONTROL.id) return undefined;
+    // The identity was learned when the session was observed, and only a
+    // session that was observed can be archived; no identity, no route.
+    const identity = this.#principal;
+    if (!identity) return undefined;
+    return {
+      segments: [
+        DEVIN_ROUTE_SEGMENT.V3,
+        DEVIN_ROUTE_SEGMENT.ORGANIZATIONS,
+        identity.orgId,
+        DEVIN_ROUTE_SEGMENT.SESSIONS,
+        providerSessionId,
+        DEVIN_ROUTE_SEGMENT.ARCHIVE,
+      ],
+      // Devin documents no body for an archive, so none is sent.
+    };
+  }
+
   #observationFor(session: DevinSession, now: number): ProviderSessionObservation {
     const status = this.#statusFor(session, now);
     return {
@@ -414,6 +487,7 @@ export class DevinSessionAdapter
       status,
       observedAt: session.observedAt,
       canReceiveMessage: this.#sessionTakesMessages(session),
+      ...(this.#sessionTakesArchive(session) ? { controls: [DEVIN_ARCHIVE_SESSION_CONTROL] } : {}),
       detail: {
         ...(session.repository ? { repository: session.repository } : {}),
         ...(status === SESSION_STATUS.ERROR ? { error: DEVIN_SESSION_FAILED_MESSAGE } : {}),

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -533,6 +533,18 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "kinds that session's roster entry lists, optionally named and optionally with an " +
         "opening task. A session whose entry lists no new agents takes no such ask.",
     },
+    {
+      label: "Archiving",
+      detail:
+        "Where a provider documents an archive endpoint — a Conductor workspace and a Cursor " +
+        "cloud agent today — a row offers Archive as a control once nothing there is still " +
+        "working: pressed on the row, or asked of Luke in conversation, it files the work away " +
+        "through the provider's own endpoint. Archiving a Conductor workspace files away every " +
+        "chat in it at once; archiving a Cursor agent leaves it readable but taking no new " +
+        "runs. A row mid-turn offers a stop instead, a session whose roster entry lists no " +
+        "archive control takes no such ask, and local sessions — which Luke only reads — are " +
+        "never archived.",
+    },
     talkKeyFact(input.hotkey),
     askKeyFact(input.askKey),
     { label: "Microphone access", detail: MICROPHONE_DETAIL[input.microphoneStatus] },

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -536,14 +536,15 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
     {
       label: "Archiving",
       detail:
-        "Where a provider documents an archive endpoint — a Conductor workspace and a Cursor " +
-        "cloud agent today — a row offers Archive as a control once nothing there is still " +
-        "working: pressed on the row, or asked of Luke in conversation, it files the work away " +
-        "through the provider's own endpoint. Archiving a Conductor workspace files away every " +
-        "chat in it at once; archiving a Cursor agent leaves it readable but taking no new " +
-        "runs. A row mid-turn offers a stop instead, a session whose roster entry lists no " +
-        "archive control takes no such ask, and local sessions — which Luke only reads — are " +
-        "never archived.",
+        "Where a provider documents an archive endpoint — a Conductor workspace, a Cursor " +
+        "cloud agent, and a Devin session today — a row offers Archive as a control once the " +
+        "work there was positively seen to settle: pressed on the row, or asked of Luke in " +
+        "conversation, it files the work away through the provider's own endpoint. Archiving a " +
+        "Conductor workspace files away every chat in it at once; an archived Cursor agent " +
+        "stays readable but takes no new runs; an archived Devin session can be viewed but not " +
+        "resumed. A row mid-turn — or one whose state could not be read — offers no archive, a " +
+        "session whose roster entry lists no archive control takes no such ask, and local " +
+        "sessions — which Luke only reads — are never archived.",
     },
     talkKeyFact(input.hotkey),
     askKeyFact(input.askKey),

--- a/apps/desktop/tests/conductor-adapter.test.ts
+++ b/apps/desktop/tests/conductor-adapter.test.ts
@@ -1400,6 +1400,31 @@ test("keeps the archive off every chat of a workspace while a sibling works", as
   assert.equal(byId.get("session-idle")?.controls, undefined);
 });
 
+test("keeps the archive off a workspace whose chat's state could not be read", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-active", TEST_TIME - 30_000)],
+    sessions: [
+      {
+        id: "session-unreadable",
+        workspaceId: "workspace-active",
+        name: TEST_SESSION_NAME,
+        statusHttpStatus: HTTP_STATUS.SERVER_ERROR,
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  // An unread status is not a settled one: the chat stands as unknown rather
+  // than being dropped, and a workspace not positively seen settled offers no
+  // filing away — the turn Luke could not read may still be running.
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(observations[0]?.controls, undefined);
+});
+
 test("offers no archive for a workspace already filed away", async () => {
   const api = fakeConductorApi({
     userId: TEST_USER_ID,

--- a/apps/desktop/tests/conductor-adapter.test.ts
+++ b/apps/desktop/tests/conductor-adapter.test.ts
@@ -38,6 +38,7 @@ interface TestWorkspace {
   name: string;
   creatorId?: string;
   lastActivityAt: number;
+  archivedAt?: string;
 }
 
 interface TestSession {
@@ -81,6 +82,7 @@ function workspacePayload(workspace: TestWorkspace): Record<string, unknown> {
     deepLink: `conductor://workspace?id=${workspace.id}`,
     lastActivityAt: isoTimestamp(workspace.lastActivityAt),
     ...(workspace.creatorId ? { creatorId: workspace.creatorId } : {}),
+    ...(workspace.archivedAt ? { archivedAt: workspace.archivedAt } : {}),
   };
 }
 
@@ -119,8 +121,14 @@ function fakeConductorApi(api: TestApi) {
           }));
         return jsonResponse({ rows, rowCount: rows.length, truncated: false });
       }
-      // The three documented writers: a prompt for one session, a cancel for
-      // the turn it is working, and a new workspace in one project.
+      // The four documented writers: a prompt for one session, a cancel for
+      // the turn it is working, a new workspace in one project, and an
+      // archive for one workspace.
+      if (segments[1] === "workspaces" && segments.length === 4 && segments[3] === "archive") {
+        const workspace = api.workspaces.find((candidate) => candidate.id === segments[2]);
+        if (!workspace) return jsonResponse({}, HTTP_STATUS.SERVER_ERROR);
+        return jsonResponse({ workspaceId: workspace.id, status: "archived" });
+      }
       if (segments[1] === "workspaces" && segments.length === 2) {
         const body = JSON.parse(rawBody ?? "{}") as {
           projectId?: string;
@@ -1289,7 +1297,7 @@ test("keeps observing when one session's status cannot be read", async () => {
   assert.equal(byId.get("session-unreadable")?.status, SESSION_STATUS.UNKNOWN);
 });
 
-test("advertises a message for any open chat and a stop only while one works", async () => {
+test("advertises a message for any open chat, a stop mid-turn, and an archive once settled", async () => {
   // One workspace per chat, so each state under test reads on its own row
   // without any sibling beside it.
   const api = fakeConductorApi({
@@ -1340,10 +1348,85 @@ test("advertises a message for any open chat and a stop only while one works", a
   // A failed chat is documented for no writer, and a closed one is settled.
   assert.equal(byId.get("session-failed")?.canReceiveMessage, false);
   assert.equal(byId.get("session-closed")?.canReceiveMessage, false);
-  assert.equal(byId.get("session-idle")?.controls, undefined);
+  // A chat mid-turn offers its stop and nothing else; every chat of a settled,
+  // still-open workspace — idle, failed, or closed — offers to file that
+  // workspace away, each naming its own workspace as the target.
   assert.deepEqual(byId.get("session-working")?.controls, [
     { id: "cancel-turn", label: "Stop this turn", kind: "stop" },
   ]);
+  for (const [sessionId, workspaceId] of [
+    ["session-idle", "workspace-idle"],
+    ["session-failed", "workspace-failed"],
+    ["session-closed", "workspace-closed"],
+  ] as const) {
+    assert.deepEqual(byId.get(sessionId)?.controls, [
+      { id: "archive-workspace", label: "Archive this workspace", target: workspaceId },
+    ]);
+  }
+});
+
+test("keeps the archive off every chat of a workspace while a sibling works", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-active", TEST_TIME - 30_000)],
+    sessions: [
+      {
+        id: "session-working",
+        workspaceId: "workspace-active",
+        name: TEST_SESSION_NAME,
+        status: TEST_CONDUCTOR_STATUS.WORKING,
+        statusUpdatedAt: TEST_TIME - 5_000,
+      },
+      {
+        id: "session-idle",
+        workspaceId: "workspace-active",
+        name: TEST_SESSION_NAME,
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 6_000,
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+  const byId = new Map(observations.map((entry) => [entry.providerSessionId, entry]));
+
+  // The idle chat's own turn is settled, but the workspace an archive acts on
+  // is not: filing it away would take the sibling's running turn with it, so
+  // no row of this workspace offers the archive.
+  assert.deepEqual(byId.get("session-working")?.controls, [
+    { id: "cancel-turn", label: "Stop this turn", kind: "stop" },
+  ]);
+  assert.equal(byId.get("session-idle")?.controls, undefined);
+});
+
+test("offers no archive for a workspace already filed away", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [
+      {
+        ...ownedWorkspace("workspace-filed", TEST_TIME - 30_000),
+        archivedAt: isoTimestamp(TEST_TIME - 20_000),
+      },
+    ],
+    sessions: [
+      {
+        id: "session-closed",
+        workspaceId: "workspace-filed",
+        name: TEST_SESSION_NAME,
+        archivedAt: isoTimestamp(TEST_TIME - 20_000),
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  // The chat still reads as a settled row, but its workspace has nothing left
+  // to archive, so no control is advertised at all.
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.status, SESSION_STATUS.COMPLETE);
+  assert.equal(observations[0]?.controls, undefined);
 });
 
 test("hands a user prompt to Conductor's documented message endpoint", async () => {
@@ -1409,6 +1492,76 @@ test("stops a working turn through Conductor's cancel endpoint, sending no body"
   // Conductor documents no body for a cancel.
   assert.equal(write?.contentType, undefined);
   assert.equal(write?.body, undefined);
+});
+
+test("archives the workspace the user saw through Conductor's archive endpoint, sending no body", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-active", TEST_TIME - 30_000)],
+    sessions: [
+      {
+        id: "session-idle",
+        workspaceId: "workspace-active",
+        name: TEST_SESSION_NAME,
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 5_000,
+      },
+    ],
+  });
+  const adapter = adapterFor(api.fetch);
+  await adapter.observe();
+
+  // Deliberately without a target: the route must be built from the control
+  // the adapter itself advertised, never from the caller's copy of it.
+  const result = await adapter.executeControl({
+    providerSessionId: "session-idle",
+    control: { id: "archive-workspace", label: "Archive this workspace" },
+  });
+
+  assert.deepEqual(result, { status: "accepted" });
+  const write = api.requests.at(-1);
+  assert.equal(write?.method, "POST");
+  assert.equal(write?.pathname, "/v0/workspaces/workspace-active/archive");
+  assert.equal(write?.authorization, `Bearer ${TEST_API_KEY}`);
+  // Conductor documents no body for an archive.
+  assert.equal(write?.contentType, undefined);
+  assert.equal(write?.body, undefined);
+});
+
+test("refuses to archive a workspace no row advertised, before any request exists", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [ownedWorkspace("workspace-active", TEST_TIME - 30_000)],
+    sessions: [
+      {
+        id: "session-working",
+        workspaceId: "workspace-active",
+        name: TEST_SESSION_NAME,
+        status: TEST_CONDUCTOR_STATUS.WORKING,
+        statusUpdatedAt: TEST_TIME - 5_000,
+      },
+    ],
+  });
+  const adapter = adapterFor(api.fetch);
+  await adapter.observe();
+  const requestsBefore = api.requests.length;
+
+  // A working workspace advertised only the turn's stop, so an archive ask
+  // has nothing behind it and no request exists — whatever target the caller
+  // writes into their copy of the control.
+  const result = await adapter.executeControl({
+    providerSessionId: "session-working",
+    control: {
+      id: "archive-workspace",
+      label: "Archive this workspace",
+      target: "workspace-active",
+    },
+  });
+
+  assert.deepEqual(result, { status: "unsupported" });
+  assert.equal(api.requests.length, requestsBefore);
 });
 
 test("offers the projects the last pass listed as places a workspace can be created", async () => {

--- a/apps/desktop/tests/cursor-adapter.test.ts
+++ b/apps/desktop/tests/cursor-adapter.test.ts
@@ -134,8 +134,9 @@ function fakeCursorApi(
       return jsonResponse({}, HTTP_STATUS.SERVER_ERROR);
     }
 
-    // The three documented writers: a new agent, a follow-up run for an
-    // existing one, and a cancel for the run it is still working.
+    // The four documented writers: a new agent, a follow-up run for an
+    // existing one, a cancel for the run it is still working, and an archive
+    // for the agent itself.
     if (method === "POST") {
       if (segments.length === 2) {
         const body = JSON.parse(rawBody ?? "{}") as {
@@ -154,6 +155,9 @@ function fakeCursorApi(
       const agent = agents.find((candidate) => candidate.id === segments[2]);
       if (agent && segments[3] === "runs" && segments.length === 4) {
         return jsonResponse({ run: { id: "run-followup", agentId: agent.id } }, 201);
+      }
+      if (agent && segments[3] === "archive" && segments.length === 4) {
+        return jsonResponse({ id: agent.id, status: "ARCHIVED" });
       }
       if (
         agent &&
@@ -680,11 +684,18 @@ test("advertises a follow-up only for an agent whose run has finished", async ()
   assert.equal(byId.get("agent-running")?.canReceiveMessage, false);
   assert.equal(byId.get("agent-errored")?.canReceiveMessage, false);
   assert.equal(byId.get("agent-filed")?.canReceiveMessage, false);
-  // The stoppable one is the one still running.
+  // The stoppable one is the one still running; every settled agent offers to
+  // be filed away instead, and one already filed offers nothing.
   assert.deepEqual(byId.get("agent-running")?.controls, [
     { id: "cancel-run", label: "Stop this run", kind: "stop", target: "run-agent-running" },
   ]);
-  assert.equal(byId.get("agent-finished")?.controls, undefined);
+  assert.deepEqual(byId.get("agent-finished")?.controls, [
+    { id: "archive-agent", label: "Archive this agent" },
+  ]);
+  assert.deepEqual(byId.get("agent-errored")?.controls, [
+    { id: "archive-agent", label: "Archive this agent" },
+  ]);
+  assert.equal(byId.get("agent-filed")?.controls, undefined);
 });
 
 test("hands a follow-up to Cursor's documented run endpoint", async () => {
@@ -727,6 +738,43 @@ test("stops the run the user saw through Cursor's cancel endpoint, sending no bo
   // Cursor documents no body for a cancel.
   assert.equal(write?.contentType, undefined);
   assert.equal(write?.body, undefined);
+});
+
+test("files a settled agent away through Cursor's archive endpoint, sending no body", async () => {
+  const api = fakeCursorApi([finishedAgent("agent-finished", TEST_TIME - 1_000)]);
+  const adapter = adapterFor(api.fetch);
+  await adapter.observe();
+
+  const result = await adapter.executeControl({
+    providerSessionId: "agent-finished",
+    control: { id: "archive-agent", label: "Archive this agent" },
+  });
+
+  assert.deepEqual(result, { status: "accepted" });
+  const write = api.requests.at(-1);
+  assert.equal(write?.method, "POST");
+  assert.equal(write?.pathname, "/v1/agents/agent-finished/archive");
+  assert.equal(write?.authorization, `Bearer ${TEST_API_KEY}`);
+  // Cursor documents no body for an archive.
+  assert.equal(write?.contentType, undefined);
+  assert.equal(write?.body, undefined);
+});
+
+test("refuses to archive an agent whose row never advertised it", async () => {
+  const api = fakeCursorApi([runningAgent("agent-running", TEST_TIME - 1_000)]);
+  const adapter = adapterFor(api.fetch);
+  await adapter.observe();
+  const requestsBefore = api.requests.length;
+
+  // A running agent advertised only its stop, so an archive ask has nothing
+  // behind it and no request exists.
+  const result = await adapter.executeControl({
+    providerSessionId: "agent-running",
+    control: { id: "archive-agent", label: "Archive this agent" },
+  });
+
+  assert.deepEqual(result, { status: "unsupported" });
+  assert.equal(api.requests.length, requestsBefore);
 });
 
 test("offers the repositories Cursor lists, on a cadence far below the observation pass", async () => {

--- a/apps/desktop/tests/cursor-adapter.test.ts
+++ b/apps/desktop/tests/cursor-adapter.test.ts
@@ -740,6 +740,30 @@ test("stops the run the user saw through Cursor's cancel endpoint, sending no bo
   assert.equal(write?.body, undefined);
 });
 
+test("keeps the archive off an agent whose run could not be read", async () => {
+  const api = fakeCursorApi([
+    {
+      id: "agent-unreadable",
+      name: TEST_AGENT_NAME,
+      createdAt: TEST_TIME - 1_000,
+      run: { id: "run-agent-unreadable", httpStatus: HTTP_STATUS.SERVER_ERROR },
+    },
+    { id: "agent-never-ran", name: TEST_AGENT_NAME, createdAt: TEST_TIME - 2_000 },
+  ]);
+
+  const observations = await adapterFor(api.fetch).observe();
+  const byId = new Map(observations.map((entry) => [entry.providerSessionId, entry]));
+
+  // A run that could not be read is not known to have stopped, so that agent
+  // is offered nothing rather than a filing away that could land on a live
+  // turn. An agent that never ran has no run to take: its own record is the
+  // positive observation, so it still offers the archive.
+  assert.equal(byId.get("agent-unreadable")?.controls, undefined);
+  assert.deepEqual(byId.get("agent-never-ran")?.controls, [
+    { id: "archive-agent", label: "Archive this agent" },
+  ]);
+});
+
 test("files a settled agent away through Cursor's archive endpoint, sending no body", async () => {
   const api = fakeCursorApi([finishedAgent("agent-finished", TEST_TIME - 1_000)]);
   const adapter = adapterFor(api.fetch);

--- a/apps/desktop/tests/devin-adapter.test.ts
+++ b/apps/desktop/tests/devin-adapter.test.ts
@@ -100,13 +100,17 @@ function fakeDevinApi(
   return recordingFetch((request) => {
     const { pathname, searchParams, method } = request;
 
-    // The one documented writer: a message for one existing session.
+    // The two documented writers: a message for one existing session, and an
+    // archive that files one away.
     if (method === "POST") {
       const match = pathname.match(
-        new RegExp(`^/v3/organizations/${TEST_ORG_ID}/sessions/([^/]+)/messages$`),
+        new RegExp(`^/v3/organizations/${TEST_ORG_ID}/sessions/([^/]+)/(messages|archive)$`),
       );
       const known = match && sessions.some((session) => session.id === match[1]);
-      return known ? jsonResponse({}) : jsonResponse({}, HTTP_STATUS.SERVER_ERROR);
+      if (!known) return jsonResponse({}, HTTP_STATUS.SERVER_ERROR);
+      return match[2] === "archive"
+        ? jsonResponse({ session_id: match[1], is_archived: true })
+        : jsonResponse({});
     }
 
     if (pathname === "/v3/self") {
@@ -172,12 +176,87 @@ function workingSession(id: string, updatedAt: number): TestSession {
   return { id, status: TEST_STATUS.RUNNING, detail: TEST_DETAIL.WORKING, updatedAt };
 }
 
-test("routes messages and no other write", () => {
+test("routes messages and the archive control, and no other write", () => {
   const adapter = adapterFor(async () => new Response("{}", { status: 200 }));
   assert.equal(isMessageCapableAdapter(adapter), true);
-  assert.equal(isControllableAdapter(adapter), false);
+  assert.equal(isControllableAdapter(adapter), true);
   assert.equal(isWorkspaceCapableAdapter(adapter), false);
   assert.equal(isWorkspaceAgentCapableAdapter(adapter), false);
+});
+
+test("advertises the archive only for a session positively seen settled", async () => {
+  const settled = TEST_TIME - 1_000;
+  const api = fakeDevinApi([
+    { id: "devin-exited", status: TEST_STATUS.EXIT, updatedAt: settled },
+    { id: "devin-errored", status: TEST_STATUS.ERROR, updatedAt: settled },
+    { id: "devin-suspended", status: TEST_STATUS.SUSPENDED, updatedAt: settled },
+    {
+      id: "devin-holding",
+      status: TEST_STATUS.RUNNING,
+      detail: TEST_DETAIL.WAITING_FOR_USER,
+      updatedAt: settled,
+    },
+    workingSession("devin-working", settled),
+    // A running session whose machine reports no detail may be mid-turn, and
+    // a state this build does not know is not a settled one.
+    { id: "devin-detailless", status: TEST_STATUS.RUNNING, updatedAt: settled },
+    { id: "devin-new", status: TEST_STATUS.NEW, updatedAt: settled },
+    { id: "devin-filed", status: TEST_STATUS.EXIT, archived: true, updatedAt: settled },
+  ]);
+
+  const observations = await adapterFor(api.fetch).observe();
+  const byId = new Map(observations.map((entry) => [entry.providerSessionId, entry]));
+
+  for (const sessionId of ["devin-exited", "devin-errored", "devin-suspended", "devin-holding"]) {
+    assert.deepEqual(byId.get(sessionId)?.controls, [
+      { id: "archive-session", label: "Archive this session" },
+    ]);
+  }
+  for (const sessionId of ["devin-working", "devin-detailless", "devin-new", "devin-filed"]) {
+    assert.equal(byId.get(sessionId)?.controls, undefined);
+  }
+});
+
+test("files a settled session away through Devin's archive endpoint, sending no body", async () => {
+  const api = fakeDevinApi([
+    { id: "devin-suspended", status: TEST_STATUS.SUSPENDED, updatedAt: TEST_TIME - 1_000 },
+  ]);
+  const adapter = adapterFor(api.fetch);
+  await adapter.observe();
+
+  const result = await adapter.executeControl({
+    providerSessionId: "devin-suspended",
+    control: { id: "archive-session", label: "Archive this session" },
+  });
+
+  assert.deepEqual(result, { status: "accepted" });
+  const write = api.requests.at(-1);
+  assert.equal(write?.method, "POST");
+  assert.equal(
+    write?.pathname,
+    `/v3/organizations/${TEST_ORG_ID}/sessions/devin-suspended/archive`,
+  );
+  assert.equal(write?.authorization, `Bearer ${TEST_API_KEY}`);
+  // Devin documents no body for an archive.
+  assert.equal(write?.contentType, undefined);
+  assert.equal(write?.body, undefined);
+});
+
+test("refuses to archive a session whose row never advertised it", async () => {
+  const api = fakeDevinApi([workingSession("devin-working", TEST_TIME - 1_000)]);
+  const adapter = adapterFor(api.fetch);
+  await adapter.observe();
+  const requestsBefore = api.requests.length;
+
+  // A working session advertised no archive, so the ask has nothing behind it
+  // and no request exists.
+  const result = await adapter.executeControl({
+    providerSessionId: "devin-working",
+    control: { id: "archive-session", label: "Archive this session" },
+  });
+
+  assert.deepEqual(result, { status: "unsupported" });
+  assert.equal(api.requests.length, requestsBefore);
 });
 
 test("observes a working session and labels it the way Devin named it", async () => {

--- a/packages/sidecar-core/src/realtime-tools.ts
+++ b/packages/sidecar-core/src/realtime-tools.ts
@@ -716,7 +716,8 @@ export const REALTIME_TOOLS = {
     family: REALTIME_TOOL_FAMILY.SESSION,
     schema: {
       description:
-        "Run a control one observed session advertises, such as stopping its current run. " +
+        "Run a control one observed session advertises, such as stopping its current run or " +
+        "archiving the settled workspace around it. " +
         "Only controls the roster lists for that session exist.",
       parameters: {
         type: "object",

--- a/packages/sidecar-core/src/session.ts
+++ b/packages/sidecar-core/src/session.ts
@@ -109,10 +109,10 @@ export interface SessionControl {
   kind?: SessionControlKind;
   /**
    * The provider-owned identifier of the thing this control acts on, when that
-   * is narrower than the session — the run a stop stops, say. It rides the
-   * advertisement so it is replaced with every observation and can never
-   * outlive the snapshot that promised it, the way state an adapter kept on
-   * the side could.
+   * is not the session itself — the run a stop stops, or the workspace an
+   * archive files away. It rides the advertisement so it is replaced with
+   * every observation and can never outlive the snapshot that promised it,
+   * the way state an adapter kept on the side could.
    */
   target?: string;
 }


### PR DESCRIPTION
## What

Luke can now archive a workspace, everywhere a provider documents a way to do it — as a session control, advertised on the roster row, pressed on the row or asked of Luke in conversation.

- **Conductor** — every chat of a settled, still-open workspace advertises **Archive this workspace**, with the workspace riding the advertisement as the control's `target` (the same shape as Cursor's `cancel-run` target). It routes to Conductor's documented `POST /v0/workspaces/{id}/archive`, with no body. The control is offered only for a workspace whose every observed chat was positively seen settled — closed, idle, or errored; a chat still working, or one whose status could not be read, keeps the whole workspace off the offer, because filing it away could take a live turn with it.
- **Cursor** — a settled agent advertises **Archive this agent**, routed to the documented `POST /v1/agents/{id}/archive`. The agent is the whole unit of a Cursor cloud workspace (it is what `createWorkspace` makes). The offer requires a run positively read as stopped (finished, cancelled, expired, or errored) or an agent that never ran; an active run keeps its stop control instead, and a run that could not be read advertises nothing.
- **Devin** — a settled session advertises **Archive this session**, routed to the documented v3 `POST /v3/organizations/{org_id}/sessions/{devin_id}/archive` under the same PAT and cached org id the adapter already observes with. Offered for a session positively seen settled: exited, failed, suspended, or a running machine whose reported detail says the turn is holding for the user. Devin puts a running session to sleep on archive, which is exactly why the offer waits for the turn to settle.

No new machinery: the archive is an advertised `SessionControl`, so it travels the existing gauntlet — roster validation in the main process and by the spoken `run_session_control` tool, and adapter-side routing built from the *advertised* control, never the caller's copy. The panel draws it with the existing plain-action chip (the same path Jules' approve-plan uses), so there are no renderer code changes.

## The survey (why these three)

| Provider | Documented archive? | Decision |
|---|---|---|
| Conductor | `POST /v0/workspaces/{id}/archive` | **Implemented** |
| Cursor (cloud) | `POST /v1/agents/{id}/archive` | **Implemented** |
| Devin | `POST /v3/organizations/{org}/sessions/{id}/archive` — the v3 API the adapter already reads with a PAT, org id cached from `/v3/self` | **Implemented** |
| Jules | Only `DELETE /v1alpha/sessions/{id}` — destructive delete, not archive | Unsupported — mapping archive onto delete would be inventing a fallback control |
| Copilot | No session-management API; archiving is UI-only | Unsupported |
| Claude Code / Codex / OpenCode / Cursor local | Local session files (Codex has an `archived` SQLite column) | Never — local sessions are read-only by construction; Luke never writes provider state files |

## Guide

The app guide gains an **Archiving** fact so Luke can describe the capability (and its refusals) out loud, and the `run_session_control` tool description now names archiving as an example.

## Testing

- `./scripts/check.sh` passes (repository checks, types, all tests, builds).
- New adapter tests per provider: advertisement in each state (settled / working / already-archived), the unread-state cases (a failed Conductor status read and a failed Cursor run read advertise no archive), the exact documented route with no body, route built from the advertised control rather than the caller's copy, and refusal without a request for a row that never advertised the control.
- No renderer or motion changes; the committed fixture and its evidence are unchanged (the fixture's Conductor workspace has a working chat, which correctly advertises no archive). The macOS packaging and evidence job runs in CI; no physical-notch check was performed — this change was made in a Linux cloud workspace, and none of the surfaces that check proves were altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31967637853/artifacts/9268931479) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31967637853)

- Commit: `9117bdf49bde38afc9451b326ce76b432c0f262b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
