### PR TITLE
feat(settings): move the OpenAI key onto the Voice page it turns on

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -83,7 +83,13 @@ import {
 import { parsePixels } from "./session-motion";
 import { SESSION_OPTIONS_BUTTON_ID, SESSION_OPTIONS_ID } from "./session-parts";
 import type { MicrophoneControl, PreferenceWrites, ShortcutControl } from "./settings-panel";
-import { SETTING_PAGE, SETTINGS_VIEW, type SettingsView } from "./settings-views";
+import {
+  credentialSettingsPage,
+  SETTING_PAGE,
+  SETTINGS_VIEW,
+  type SettingsSubview,
+  type SettingsView,
+} from "./settings-views";
 import { useBootstrapRacedChannel } from "./use-bootstrap-raced-channel";
 import { panelEntryOpen, usePanelEntry } from "./use-panel-entry";
 import { usePanelPresentation } from "./use-panel-presentation";
@@ -252,6 +258,13 @@ export function App(): React.JSX.Element {
    * the pointer holds the panel open for a credential still on screen.
    */
   const credentialHeld = useRef(false);
+  /**
+   * The settings page the held credential's row is drawn on — Voice for the
+   * OpenAI key, Connections for every other — so the trip to the key slot
+   * ends back on the page it began on. A ref rather than state: it is read
+   * only when the panel is restored, by a callback that has to stay stable.
+   */
+  const credentialPage = useRef<SettingsSubview>(SETTINGS_VIEW.CONNECTIONS);
   const feedbackHeld = useRef(false);
   const feedbackNoticeTimer = useRef<number | undefined>(undefined);
   /**
@@ -397,11 +410,12 @@ export function App(): React.JSX.Element {
    */
   const restorePanel = useCallback(() => {
     changeTab(PANEL_TAB.SETTINGS);
-    // The line the entry belongs to lives on the Connections page, and
-    // changeTab has just reset the tab to its front page: without this, the
-    // check appearing beside the provider — the answer to what was just done
-    // — would land on a page nobody is looking at.
-    setSettingsView(SETTINGS_VIEW.CONNECTIONS);
+    // The line the entry belongs to lives on the page it was begun from —
+    // Voice for the OpenAI key, Connections for the rest — and changeTab has
+    // just reset the tab to its front page: without this, the check appearing
+    // beside the provider — the answer to what was just done — would land on
+    // a page nobody is looking at.
+    setSettingsView(credentialPage.current);
     expand();
   }, [changeTab, expand]);
 
@@ -463,6 +477,9 @@ export function App(): React.JSX.Element {
 
   const beginEntry = useCallback(
     (providerId: CredentialProviderId) => {
+      // Where the entry's row is drawn, remembered before the trip to the
+      // slot so coming back lands on the page the entry began on.
+      credentialPage.current = credentialSettingsPage(providerId);
       credentialsEntry.begin({ providerId, draft: "", busy: false, away: false });
     },
     [credentialsEntry.begin],
@@ -1229,7 +1246,7 @@ export function App(): React.JSX.Element {
           // The tab and page an entry begins on, so pressing the capsule from
           // here lands where it would have in the flow this is standing in for.
           changeTab(PANEL_TAB.SETTINGS);
-          setSettingsView(SETTINGS_VIEW.CONNECTIONS);
+          setSettingsView(credentialSettingsPage(firstProvider.id));
           beginEntry(firstProvider.id);
         }
       }

--- a/apps/desktop/src/renderer/key-slot.tsx
+++ b/apps/desktop/src/renderer/key-slot.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 import type { CredentialSource } from "../shared/contracts";
-import { CREDENTIAL_PROVIDERS } from "../shared/credential-providers";
+import { CREDENTIAL_PROVIDERS, providerRunsSessionsInCloud } from "../shared/credential-providers";
 import {
   CREDENTIAL_PLACEHOLDER,
   type CredentialEntryControl,
@@ -100,14 +100,14 @@ export function KeySlot({
             beneath is the one both share, so neither has to repeat the other. */}
         <span className="settings-label key-slot-label">{credential}</span>
         <div className="key-slot-row">
-          {/* Whose key this is, said the way the settings line says it — mark
-              and cloud badge together, because a service that needs a key is
-              one that lives in a cloud — a provider's sessions or the issue
-              tracker alike — and the same mark cannot differ between the line
-              and the slot it opens. */}
+          {/* Whose key this is, said exactly the way the settings line says
+              it: an agent provider's mark keeps the cloud badge its session
+              rows wear, and a service Luke merely uses — Linear, OpenAI —
+              stands bare, because the same mark cannot differ between the
+              line and the slot it opens. */}
           <span className="key-slot-mark">
             <ProviderMark providerId={provider.id} />
-            <CloudBadge />
+            {providerRunsSessionsInCloud(provider.id) ? <CloudBadge /> : null}
           </span>
           <input
             ref={field}

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -50,6 +50,7 @@ import {
   CREDENTIAL_PROVIDERS,
   INTEGRATION_PROVIDER_LIST,
   isCredentialProviderId,
+  VOICE_CREDENTIAL_PROVIDER_ID,
 } from "../shared/credential-providers";
 import { workspaceAgentModelLabel, workspaceAgentModels } from "../shared/workspace-agents";
 
@@ -466,9 +467,24 @@ function integrationsFact(settings: AppSettings): AppGuideFact {
     label: "Integrations",
     detail:
       `${roster.join(", ")}. Connecting Linear lets Luke read the developer's issues and, only ` +
-      `when asked in a turn the developer opened, move or comment on one. Connecting OpenAI is ` +
-      `what lets Luke speak, and review which sessions need a person. Each key is typed by ` +
+      `when asked in a turn the developer opened, move or comment on one. Its key is typed by ` +
       `hand into ${CONNECTIONS_PAGE}, under Integrations — never spoken, and never repeated back.`,
+  };
+}
+
+/**
+ * The one key that is neither an agent's nor an integration's, described where
+ * its row lives: at the top of the Voice page, beside the feature it turns on.
+ */
+function voiceKeyFact(settings: AppSettings): AppGuideFact {
+  const openai = CREDENTIAL_PROVIDERS[VOICE_CREDENTIAL_PROVIDER_ID];
+  return {
+    label: "OpenAI",
+    detail:
+      `${openai.displayName} (${connectionWord(settings.credentialSources[openai.id])}). ` +
+      `Connecting OpenAI is what lets Luke speak, and review which sessions need a person. ` +
+      `Its key is typed by hand into ${VOICE_PAGE}, at its top — never spoken, and never ` +
+      `repeated back.`,
   };
 }
 
@@ -574,10 +590,13 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       : [
           {
             label: "Voice",
-            detail: "Off: no OpenAI key is connected, so no conversation can be opened.",
+            detail:
+              "Off: no OpenAI key is connected, so no conversation can be opened. " +
+              `The key is entered in ${VOICE_PAGE}, at its top.`,
           },
         ]),
     providersFact(input.settings),
+    voiceKeyFact(input.settings),
     integrationsFact(input.settings),
     ...(input.settings.secretStorage === SECRET_STORAGE.UNAVAILABLE
       ? [

--- a/apps/desktop/src/renderer/microphone-access.ts
+++ b/apps/desktop/src/renderer/microphone-access.ts
@@ -40,9 +40,10 @@ export function microphoneAccessRow(input: {
 }): MicrophoneAccessRow {
   if (!input.voiceAvailable) {
     return {
-      // Names what to do rather than what is missing, and what to do is now
-      // something the panel offers: the OpenAI key, under Integrations.
-      detail: "Luke opens the microphone only to talk, which needs the OpenAI key.",
+      // Names what to do rather than what is missing, and what to do is
+      // something the panel offers: the OpenAI key, at the top of the Voice page.
+      detail:
+        "Luke opens the microphone only to talk, which needs the OpenAI key on the Voice page.",
       offerAccess: false,
       offerSystemSettings: false,
       ready: false,

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -21,6 +21,8 @@ import type { CredentialProvider } from "../shared/credential-providers";
 import {
   CLOUD_AGENT_PROVIDER_LIST,
   INTEGRATION_PROVIDER_LIST,
+  providerRunsSessionsInCloud,
+  VOICE_CREDENTIAL_PROVIDER,
 } from "../shared/credential-providers";
 import {
   capturedVoiceHotkey,
@@ -420,14 +422,15 @@ function ProviderCredential({
       <div className="credential-row">
         <span className="credential-identity">
           {/* The provider's own mark, so a list is read by brand rather than by
-              a word every line would have to repeat. Every provider that can
-              hold a key is one whose sessions live in a cloud service — that is
-              what makes the key necessary — so each mark carries the same badge
-              its session rows do, rather than one line's mark differing from
-              the same mark elsewhere. */}
+              a word every line would have to repeat. An agent provider's mark
+              carries the same cloud badge its session rows do — the key buys
+              the observation of cloud sessions, and the same mark cannot
+              differ between the row and the sessions it stands for. Linear and
+              OpenAI are services Luke uses rather than sessions he watches, so
+              their marks stand alone. */}
           <span className="credential-mark">
             <ProviderMark providerId={provider.id} />
-            <CloudBadge />
+            {providerRunsSessionsInCloud(provider.id) ? <CloudBadge /> : null}
           </span>
           <span className="credential-name">{provider.displayName}</span>
           {connected ? <CheckIcon /> : null}
@@ -1015,7 +1018,8 @@ function CredentialsSection({
  * The services Luke connects to that are not agents: today, the issue tracker.
  * Each row is the same credential line an agent provider gets — same entry,
  * same trash, same environment fallback — with its own one-line answer to what
- * connecting it buys, because the rows here do not all buy the same thing.
+ * connecting it buys. The OpenAI key is not here: it lives at the top of the
+ * Voice page, beside the feature it turns on.
  */
 function IntegrationsSection({
   settings,
@@ -1139,13 +1143,60 @@ function SettingsPageHeader({
 }
 
 /**
- * How Luke sounds and what he says unprompted. The voice he speaks with comes
- * first — it is what Luke *is* to the ear — offered the way macOS offers one
- * value from a small fixed set: a pop-up button whose closed face is drawn
- * here and whose open menu is the system's, which also lets it escape a
- * window sized to the panel rather than being clipped by it.
+ * How Luke sounds and what he says unprompted — led by the key it all runs
+ * on. The OpenAI credential stands at the top of this page rather than under
+ * Connections because voice is what the key turns on: the page that goes
+ * quiet without one is where its absence has to be explained, or every
+ * control below reads as broken rather than as waiting. The voice he speaks
+ * with comes next — it is what Luke *is* to the ear — offered the way macOS
+ * offers one value from a small fixed set: a pop-up button whose closed face
+ * is drawn here and whose open menu is the system's, which also lets it
+ * escape a window sized to the panel rather than being clipped by it.
  */
 function VoiceSection({
+  settings,
+  preferences,
+  credentials,
+  panelOpen,
+}: {
+  settings: AppSettings;
+  preferences: PreferenceWrites;
+  credentials: CredentialEntryControl;
+  panelOpen: boolean;
+}): React.JSX.Element {
+  return (
+    <>
+      <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
+        <h2>
+          <KeyIcon />
+          OpenAI API key
+        </h2>
+        <ProviderCredential
+          provider={VOICE_CREDENTIAL_PROVIDER}
+          source={settings.credentialSources[VOICE_CREDENTIAL_PROVIDER.id]}
+          storageUnavailable={settings.secretStorage === SECRET_STORAGE.UNAVAILABLE}
+          control={credentials}
+          panelOpen={panelOpen}
+        />
+        {/* Said only while it is true, and as a state rather than an error:
+            nothing is broken, the page is waiting on the one thing that turns
+            it on. `voiceAvailable` rather than the credential source, because
+            availability is the store's own answer — a fixture run or a key
+            that failed to resolve leaves voice off however the row reads. */}
+        {settings.voiceAvailable ? null : (
+          <p className="settings-note">
+            Voice is off until a key is connected — Luke cannot talk, listen, or announce sessions.
+            The settings below will take effect once it is.
+          </p>
+        )}
+      </section>
+      <VoiceControlsSection settings={settings} preferences={preferences} />
+    </>
+  );
+}
+
+/** The voice controls themselves, below the key that powers them. */
+function VoiceControlsSection({
   settings,
   preferences,
 }: {
@@ -1155,7 +1206,7 @@ function VoiceSection({
   return (
     <section
       className="settings-section settings-plain"
-      style={{ "--row-index": 1 } as React.CSSProperties}
+      style={{ "--row-index": 2 } as React.CSSProperties}
     >
       <SelectRow
         label="Voice"
@@ -1658,7 +1709,12 @@ export function SettingsPanel({
       ) : null}
 
       {drawnView === SETTINGS_VIEW.VOICE && settings ? (
-        <VoiceSection settings={settings} preferences={preferences} />
+        <VoiceSection
+          settings={settings}
+          preferences={preferences}
+          credentials={credentials}
+          panelOpen={panelOpen}
+        />
       ) : null}
 
       {drawnView === SETTINGS_VIEW.APPEARANCE && settings ? (

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -1164,6 +1164,7 @@ function VoiceSection({
   credentials: CredentialEntryControl;
   panelOpen: boolean;
 }): React.JSX.Element {
+  const storageUnavailable = settings.secretStorage === SECRET_STORAGE.UNAVAILABLE;
   return (
     <>
       <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
@@ -1174,7 +1175,7 @@ function VoiceSection({
         <ProviderCredential
           provider={VOICE_CREDENTIAL_PROVIDER}
           source={settings.credentialSources[VOICE_CREDENTIAL_PROVIDER.id]}
-          storageUnavailable={settings.secretStorage === SECRET_STORAGE.UNAVAILABLE}
+          storageUnavailable={storageUnavailable}
           control={credentials}
           panelOpen={panelOpen}
         />
@@ -1182,8 +1183,15 @@ function VoiceSection({
             nothing is broken, the page is waiting on the one thing that turns
             it on. `voiceAvailable` rather than the credential source, because
             availability is the store's own answer — a fixture run or a key
-            that failed to resolve leaves voice off however the row reads. */}
-        {settings.voiceAvailable ? null : (
+            that failed to resolve leaves voice off however the row reads.
+            While this system cannot store a key at all, the storage refusal
+            replaces the invitation: a Connect stilled by missing storage
+            needs its why here exactly as it does in the other key sections,
+            and a note urging a key the panel will not store would only send
+            someone to a disabled control. */}
+        {storageUnavailable ? (
+          <p className="settings-note">{STORAGE_UNAVAILABLE_NOTE}</p>
+        ) : settings.voiceAvailable ? null : (
           <p className="settings-note">
             Voice is off until a key is connected — Luke cannot talk, listen, or announce sessions.
             The settings below will take effect once it is.

--- a/apps/desktop/src/renderer/settings-views.ts
+++ b/apps/desktop/src/renderer/settings-views.ts
@@ -1,11 +1,15 @@
+import {
+  type CredentialProviderId,
+  VOICE_CREDENTIAL_PROVIDER_ID,
+} from "../shared/credential-providers";
 import { APP_SETTING_ID, type AppSettingId } from "./luke-guide";
 
 /**
  * Where inside the Settings tab the panel currently is: its front page, or one
  * of the pages a front-page row opens. App state rather than panel state for
  * the same reason the tab is — Escape unwinds it one layer at a time from the
- * app's own key handler, and a credential entry begun on the Connections page
- * has to bring the panel back to that page after its trip to the key slot.
+ * app's own key handler, and a credential entry begun on a settings page has
+ * to bring the panel back to that page after its trip to the key slot.
  */
 export const SETTINGS_VIEW = {
   ROOT: "root",
@@ -86,6 +90,20 @@ export const SETTING_PAGE: Record<AppSettingId, SettingsSubview> = {
   [APP_SETTING_ID.WORKSPACE_AGENT_MODEL]: SETTINGS_VIEW.CONNECTIONS,
   [APP_SETTING_ID.WORKSPACE_AGENT_EFFORT]: SETTINGS_VIEW.CONNECTIONS,
 };
+
+/**
+ * Which page draws a provider's credential row. Every key lives under
+ * Connections except the one voice runs on: the OpenAI row stands at the top
+ * of the Voice page, beside the feature it turns on. This is what brings a
+ * credential entry back from the key slot to the page it began on — restoring
+ * Connections around an entry begun on Voice would land the answer on a page
+ * nobody was looking at.
+ */
+export function credentialSettingsPage(providerId: CredentialProviderId): SettingsSubview {
+  return providerId === VOICE_CREDENTIAL_PROVIDER_ID
+    ? SETTINGS_VIEW.VOICE
+    : SETTINGS_VIEW.CONNECTIONS;
+}
 
 /** How each page names itself, which is how the guide's by-hand paths word it. */
 export const SETTINGS_PAGE_LABEL: Record<SettingsSubview, string> = {

--- a/apps/desktop/src/shared/credential-providers.ts
+++ b/apps/desktop/src/shared/credential-providers.ts
@@ -210,27 +210,41 @@ export const CREDENTIAL_PROVIDER_LIST: readonly CredentialProvider[] =
 
 /* A key is a key, so every service lives in the one provider registry — but
    Settings draws these apart: an integration is a service Luke uses, not an
-   agent whose sessions he observes. The tracker is one he reads and acts on;
-   OpenAI is the one he speaks through. */
-const INTEGRATION_IDS: ReadonlySet<CredentialProviderId> = new Set([
-  CREDENTIAL_PROVIDER_ID.LINEAR,
-  CREDENTIAL_PROVIDER_ID.OPENAI,
-]);
+   agent whose sessions he observes. The tracker is one he reads and acts on. */
+const INTEGRATION_IDS: ReadonlySet<CredentialProviderId> = new Set([CREDENTIAL_PROVIDER_ID.LINEAR]);
 
 /**
  * The one key Luke speaks through, and asks about a session with. Named here so
  * the main process reads it by what it is for rather than by an id spelled out
- * at each of the places that build something from it.
+ * at each of the places that build something from it. Its row lives on the
+ * Voice page rather than under Connections, because the key is what turns
+ * voice on and the page that goes quiet without one is where that is learned.
  */
 export const VOICE_CREDENTIAL_PROVIDER_ID = CREDENTIAL_PROVIDER_ID.OPENAI;
 
+/** The one provider the Voice page holds a key for. */
+export const VOICE_CREDENTIAL_PROVIDER: CredentialProvider =
+  CREDENTIAL_PROVIDERS[VOICE_CREDENTIAL_PROVIDER_ID];
+
 /** The coding-agent providers, in the order the Cloud Agent API keys section lists them. */
 export const CLOUD_AGENT_PROVIDER_LIST: readonly CredentialProvider[] =
-  CREDENTIAL_PROVIDER_LIST.filter((provider) => !INTEGRATION_IDS.has(provider.id));
+  CREDENTIAL_PROVIDER_LIST.filter(
+    (provider) => !INTEGRATION_IDS.has(provider.id) && provider.id !== VOICE_CREDENTIAL_PROVIDER_ID,
+  );
 
 /** The services beyond the agents, in the order the Integrations section lists them. */
 export const INTEGRATION_PROVIDER_LIST: readonly CredentialProvider[] =
   CREDENTIAL_PROVIDER_LIST.filter((provider) => INTEGRATION_IDS.has(provider.id));
+
+/**
+ * Whether this provider's key buys the observation of cloud sessions, which is
+ * what the cloud badge on a mark says. Linear's issues and OpenAI's voice are
+ * services Luke uses rather than sessions he watches, so their marks carry no
+ * badge — a badge there would claim sessions neither service has.
+ */
+export function providerRunsSessionsInCloud(id: CredentialProviderId): boolean {
+  return !INTEGRATION_IDS.has(id) && id !== VOICE_CREDENTIAL_PROVIDER_ID;
+}
 
 /**
  * Guards the provider id an IPC message carries. `hasOwn` rather than `in`: an

--- a/apps/desktop/tests/credential-providers.test.ts
+++ b/apps/desktop/tests/credential-providers.test.ts
@@ -7,6 +7,8 @@ import {
   CREDENTIAL_PROVIDERS,
   INTEGRATION_PROVIDER_LIST,
   isCredentialProviderId,
+  providerRunsSessionsInCloud,
+  VOICE_CREDENTIAL_PROVIDER,
   VOICE_CREDENTIAL_PROVIDER_ID,
 } from "../src/shared/credential-providers";
 
@@ -41,23 +43,36 @@ test("describes every provider it lists", () => {
 });
 
 test("splits the settings sections without losing a provider", () => {
-  // The two sections together are exactly the registry: a provider missing
-  // from both would hold a key no row can enter, and one in both would be
-  // asked for the same key twice.
+  // The sections together are exactly the registry: a provider missing from
+  // all of them would hold a key no row can enter, and one in two would be
+  // asked for the same key twice. The voice key stands apart because its row
+  // is drawn on the Voice page rather than under Connections.
   assert.deepEqual(
-    [...CLOUD_AGENT_PROVIDER_LIST, ...INTEGRATION_PROVIDER_LIST]
+    [...CLOUD_AGENT_PROVIDER_LIST, ...INTEGRATION_PROVIDER_LIST, VOICE_CREDENTIAL_PROVIDER]
       .map((provider) => provider.id)
       .sort(),
     CREDENTIAL_PROVIDER_LIST.map((provider) => provider.id).sort(),
   );
   assert.deepEqual(
     INTEGRATION_PROVIDER_LIST.map((provider) => provider.id),
-    [CREDENTIAL_PROVIDER_ID.LINEAR, CREDENTIAL_PROVIDER_ID.OPENAI],
+    [CREDENTIAL_PROVIDER_ID.LINEAR],
   );
-  // An integration's row carries its own answer to what connecting it buys.
-  for (const provider of INTEGRATION_PROVIDER_LIST) {
+  // A row outside the agents' section carries its own answer to what
+  // connecting it buys.
+  for (const provider of [...INTEGRATION_PROVIDER_LIST, VOICE_CREDENTIAL_PROVIDER]) {
     assert.ok(provider.description, `${provider.id} says what connecting it allows`);
   }
+});
+
+test("the cloud badge belongs to the agents alone", () => {
+  // The badge says a provider's sessions run in a cloud service. Linear's
+  // issues and OpenAI's voice are services Luke uses rather than sessions he
+  // watches, so a badge on their marks would claim sessions neither has.
+  for (const provider of CLOUD_AGENT_PROVIDER_LIST) {
+    assert.equal(providerRunsSessionsInCloud(provider.id), true, provider.id);
+  }
+  assert.equal(providerRunsSessionsInCloud(CREDENTIAL_PROVIDER_ID.LINEAR), false);
+  assert.equal(providerRunsSessionsInCloud(CREDENTIAL_PROVIDER_ID.OPENAI), false);
 });
 
 test("sends the user to the one GitHub token kind the agent-tasks API answers", () => {
@@ -129,10 +144,12 @@ test("holds the key Luke speaks through, apart from the agents he observes", () 
   // nothing a working key would not also be refused by.
   assert.equal(openai.keyFormat, undefined);
 
-  // An integration rather than an agent: Luke speaks through it and asks it
+  // Neither an agent nor an integration: Luke speaks through it and asks it
   // about sessions, and observes nothing of it — there are no OpenAI sessions
-  // for a row to belong to, and no adapter for a saved key to refresh.
-  assert.ok(INTEGRATION_PROVIDER_LIST.includes(openai));
+  // for a row to belong to, and no adapter for a saved key to refresh. Its
+  // row stands at the top of the Voice page, beside the feature it turns on.
+  assert.equal(VOICE_CREDENTIAL_PROVIDER, openai);
+  assert.equal(INTEGRATION_PROVIDER_LIST.includes(openai), false);
   assert.equal(CLOUD_AGENT_PROVIDER_LIST.includes(openai), false);
   // Both things the key buys are said on the row that holds it, because a
   // credential that quietly enables an outbound request should not have to be

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -177,11 +177,14 @@ test("the facts say what is connected, never what connects it", () => {
   assert.match(rendered, /Devin \(connected from the environment\)/);
   // The tracker stands in its own fact, the way it stands in its own section.
   assert.match(rendered, /Linear \(not connected\)/);
-  assert.match(rendered, /OpenAI \(not connected\)/);
   assert.match(rendered, /Integrations/);
-  // Each integration says what connecting it buys, so a spoken ask about the
-  // page cannot leave OpenAI sounding like a second Linear.
+  // The voice key stands in a fact of its own, saying what connecting it buys
+  // and naming the page its row actually lives on — the Voice page, not the
+  // Integrations section it once shared with Linear.
+  assert.match(rendered, /OpenAI \(not connected\)/);
   assert.match(rendered, /Connecting OpenAI is what lets Luke speak/);
+  assert.match(rendered, /Voice page, at its top/);
+  assert.doesNotMatch(rendered, /OpenAI[^"]*under Integrations/);
   // The guide leaves the machine, so no key, prefix, or environment variable
   // value has any business in it.
   assert.doesNotMatch(rendered, /API key:/);
@@ -461,6 +464,9 @@ test("the facts follow the talk key, the microphone, and the storage the system 
 
   const voiceless = buildLukeGuide(guideInput({ voiceAvailable: false }));
   assert.match(JSON.stringify(voiceless.facts), /no OpenAI key is connected/);
+  // The refusal carries the way out: the key's row is at the top of the Voice
+  // page, and a fact that stopped at "off" would leave the ask unanswerable.
+  assert.match(JSON.stringify(voiceless.facts), /Voice page, at its top/);
   // The muted-output behavior belongs to speech, so it is described exactly
   // where speech exists: with a voice it is a fact, without one it would
   // describe captions no reply will ever draw.

--- a/apps/desktop/tests/microphone-access.test.ts
+++ b/apps/desktop/tests/microphone-access.test.ts
@@ -22,6 +22,9 @@ test("access is offered only where it can be used", () => {
   });
   assert.equal(unavailable.offerAccess, false);
   assert.ok(!unavailable.detail.includes("macOS will ask"));
+  // The row names the way out as well as the reason: the key's own row, at
+  // the top of the Voice page.
+  assert.match(unavailable.detail, /Voice page/);
 });
 
 test("a permission already granted is not a microphone in use", () => {

--- a/apps/desktop/tests/settings-views.test.ts
+++ b/apps/desktop/tests/settings-views.test.ts
@@ -1,6 +1,15 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { PAGE_EXIT_MS, pageExitFromToken } from "../src/renderer/settings-views";
+import {
+  credentialSettingsPage,
+  PAGE_EXIT_MS,
+  pageExitFromToken,
+  SETTINGS_VIEW,
+} from "../src/renderer/settings-views";
+import {
+  CREDENTIAL_PROVIDER_LIST,
+  VOICE_CREDENTIAL_PROVIDER_ID,
+} from "../src/shared/credential-providers";
 
 test("the page swap reads the exit token in either unit", () => {
   assert.equal(pageExitFromToken("90ms"), 90);
@@ -19,4 +28,20 @@ test("a zeroed token swaps at once, the way capture and reduced motion still the
 test("a token that cannot be read falls back to the resting exit, not to none", () => {
   assert.equal(pageExitFromToken(""), PAGE_EXIT_MS);
   assert.equal(pageExitFromToken("fast"), PAGE_EXIT_MS);
+});
+
+test("a credential entry returns to the page its row is drawn on", () => {
+  // The OpenAI row lives at the top of the Voice page — it is what turns
+  // voice on — and every other key lives under Connections. An entry's trip
+  // to the key slot has to end back on the page it began on, or the check
+  // beside the provider lands on a page nobody is looking at.
+  for (const provider of CREDENTIAL_PROVIDER_LIST) {
+    assert.equal(
+      credentialSettingsPage(provider.id),
+      provider.id === VOICE_CREDENTIAL_PROVIDER_ID
+        ? SETTINGS_VIEW.VOICE
+        : SETTINGS_VIEW.CONNECTIONS,
+      provider.id,
+    );
+  }
 });

--- a/packages/sidecar-core/src/realtime-credentials.ts
+++ b/packages/sidecar-core/src/realtime-credentials.ts
@@ -160,7 +160,7 @@ const REALTIME_MINT_EXPLANATIONS: Record<RealtimeMintOutcome, string> = {
   [REALTIME_MINT_OUTCOME.NOT_ATTEMPTED]: "No credential has been requested yet.",
   [REALTIME_MINT_OUTCOME.SUCCEEDED]: "A short-lived credential was minted.",
   [REALTIME_MINT_OUTCOME.NO_API_KEY]:
-    "No OpenAI key has been given. Connect one in Settings, under Integrations. Exporting OPENAI_API_KEY in a shell also works, but does not reach an app opened from Finder.",
+    "No OpenAI key has been given. Connect one in Settings, at the top of the Voice page. Exporting OPENAI_API_KEY in a shell also works, but does not reach an app opened from Finder.",
   [REALTIME_MINT_OUTCOME.DISABLED_BY_FIXTURE]:
     "This is a fixture or evidence run, which never uses credentials.",
   [REALTIME_MINT_OUTCOME.HTTP_ERROR]: "The API rejected the mint request.",


### PR DESCRIPTION
## Summary

The best home for the OpenAI key is next to the feature it powers, and the Connections page should stop implying Linear and OpenAI run sessions in a cloud.

- **OpenAI key moves to the top of the Voice page.** Voice is what the key turns on, so its credential row — same entry, trash, environment fallback, and key-slot trip as everywhere else — now leads the page, under its own "OpenAI API key" heading. The Connections page's Integrations section keeps Linear alone.
- **Voice no longer looks broken without a key.** While no key resolves, a note under the row says voice is off until one is connected — Luke cannot talk, listen, or announce sessions — and that the settings below wait on it. The state is worded as waiting, not as an error.
- **Cloud badges come off Linear and OpenAI.** The badge says a provider's sessions run in a cloud service; Linear's issues and OpenAI's voice are services Luke uses, not sessions he watches. Agent providers keep the badge, in their rows and in the key slot alike (`providerRunsSessionsInCloud`).
- **A credential entry returns to the page it began on.** `credentialSettingsPage` maps the OpenAI key to Voice and every other key to Connections; the key-slot round trip restores that page instead of hard-coding Connections.
- **Every description of the old location follows the row.** The guide gains an OpenAI fact naming the Voice page (and its voiceless fact points the way there), the Integrations fact covers Linear alone, the microphone permission row names the Voice page, and the `NO_API_KEY` mint explanation sends people there instead of "under Integrations".

## Evidence

- Platform-independent checks: `./scripts/check.sh` passes (exit 0) — repository checks, types, all workspace tests, builds.
- macOS Electron verification (`./scripts/verify.sh`): `not run` — this workspace is a Linux sandbox with no macOS host.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31967663957/artifacts/9268935783) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31967663957)

- Commit: `d714b9b20f9da85b786cd21f97d05db65894602e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- UI change: the Voice page gains the credential card and the Connections page loses the OpenAI row — please eyeball CI's automated visual evidence (and a physical Mac if handy) before merging.
- New tests pin the section split, the badge predicate, the entry's return page, and the guide/microphone wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ae1906f6-d549-439e-802c-0acddd85155f)
