### PR TITLE
feat: remember a default workspace project per provider

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -474,14 +474,15 @@ function boundedField(
 }
 
 /**
- * The first workspace that lands chooses the default provider — and a model
- * named for that creation, the default agent — only while nothing is chosen.
- * A default the user holds is theirs to change, never a creation's. Losing
- * the save loses only the remembered default, never the workspace that just
- * landed.
+ * The first workspace that lands chooses the default provider — and its
+ * project, and a model named for that creation, the default agent — only
+ * while nothing is chosen. A default the user holds is theirs to change,
+ * never a creation's. Losing the save loses only the remembered default,
+ * never the workspace that just landed.
  */
 async function rememberWorkspaceDefaults(
   adapter: SessionProviderAdapter,
+  providerProjectId: string,
   namedSelection: WorkspaceAgentSelection | undefined,
 ): Promise<void> {
   if (!isProviderId(adapter.provider.id)) return;
@@ -489,6 +490,15 @@ async function rememberWorkspaceDefaults(
   try {
     if ((await settingsStore.readDefaultWorkspaceProvider()) === undefined) {
       const saved = await settingsStore.setDefaultWorkspaceProvider(providerId);
+      panels.broadcast(channels.settingsChanged, saved.settings);
+    }
+    // The project the workspace landed in becomes that provider's default on
+    // the same first-choice terms, read again for the same overlap reason as
+    // the model below. The id was validated against the adapter's offered
+    // projects before the creation ran, so what is remembered is one the
+    // provider itself listed.
+    if ((await settingsStore.readWorkspaceProjectDefault(providerId)) === undefined) {
+      const saved = await settingsStore.setWorkspaceProjectDefault(providerId, providerProjectId);
       panels.broadcast(channels.settingsChanged, saved.settings);
     }
     // A model named for this creation becomes the default on the same
@@ -726,6 +736,36 @@ function registerIpc(): void {
     },
     save: ({ providerId, selection }) =>
       settingsStore.setWorkspaceAgentDefault(providerId, selection),
+    refusal: "Could not save that setting on this system.",
+  });
+
+  // The project one provider creates nameless-ask workspaces in. Projects are
+  // observed rather than build-fixed, so the value is held to the list the
+  // provider's adapter currently offers — the same list every creation act is
+  // validated against — and clearing needs no list at all.
+  registerSettingHandler(channels.setWorkspaceProjectDefault, {
+    validate(providerId: unknown, providerProjectId: unknown) {
+      if (typeof providerId !== "string" || !isProviderId(providerId)) {
+        throw new Error("Unknown workspace provider");
+      }
+      if (providerProjectId === undefined) {
+        return { providerId, providerProjectId: undefined };
+      }
+      if (typeof providerProjectId !== "string" || !providerProjectId.trim()) {
+        throw new Error("Invalid workspace project");
+      }
+      const adapter = adapterFor(providerId);
+      const offered =
+        adapter && isWorkspaceCapableAdapter(adapter)
+          ? adapter
+              .workspaceProjects()
+              .some((project) => project.providerProjectId === providerProjectId)
+          : false;
+      if (!offered) throw new Error("Unknown workspace project");
+      return { providerId, providerProjectId };
+    },
+    save: ({ providerId, providerProjectId }) =>
+      settingsStore.setWorkspaceProjectDefault(providerId, providerProjectId),
     refusal: "Could not save that setting on this system.",
   });
 
@@ -1105,6 +1145,7 @@ function registerIpc(): void {
       if (result.status === PROVIDER_ACT_RESULT_STATUS.ACCEPTED) {
         await rememberWorkspaceDefaults(
           adapter,
+          providerProjectId,
           namedSelection as WorkspaceAgentSelection | undefined,
         );
       }

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -33,6 +33,7 @@ const bridge: AppBridge = {
   setFormFactor: invoke(channels.setFormFactor),
   setDefaultWorkspaceProvider: invoke(channels.setDefaultWorkspaceProvider),
   setWorkspaceAgentDefault: invoke(channels.setWorkspaceAgentDefault),
+  setWorkspaceProjectDefault: invoke(channels.setWorkspaceProjectDefault),
   setVoiceCaptions: invoke(channels.setVoiceCaptions),
   setVoiceHotkey: invoke(channels.setVoiceHotkey),
   setAskHotkey: invoke(channels.setAskHotkey),

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -4,6 +4,7 @@ import {
   FEEDBACK_COMPOSER_KIND,
   type FeedbackComposerKind,
   FIXTURE_EPOCH_MS,
+  isProviderId,
   type NormalizedSession,
   type ObservedWorkspaceProject,
   type PanelFormFactor,
@@ -535,26 +536,54 @@ export function App(): React.JSX.Element {
     [applySettingsReply],
   );
 
+  // Where a nameless creation ask lands within a provider — the same store
+  // write the first creation there makes on its own, offered by hand so the
+  // choice can be changed or returned to the first creation.
+  const changeWorkspaceProjectDefault = useCallback(
+    async (providerId: ProviderId, providerProjectId: string | undefined) =>
+      applySettingsReply(
+        await window.sidecar.setWorkspaceProjectDefault(providerId, providerProjectId),
+      ),
+    [applySettingsReply],
+  );
+
   /**
-   * The providers the default-workspace row can offer: every provider
+   * The providers the default-workspace rows can offer: every provider
    * currently offering projects, named the way its adapter names itself, plus
-   * a stored default that is not offering right now — the row must show the
-   * choice it holds, or it could be neither seen nor cleared.
+   * one holding a stored default — provider or project — that is not offering
+   * right now: the rows must show the choices they hold, or a choice could be
+   * neither seen nor cleared. Each option carries the projects its
+   * default-project row offers, on the same show-what-is-held terms.
    */
   const storedWorkspaceProvider = settings?.defaultWorkspaceProvider;
+  const storedWorkspaceProjects = settings?.workspaceProjectDefaults;
   const workspaceProviderOptions = useMemo(() => {
+    const fallbackName = (providerId: string) =>
+      isCredentialProviderId(providerId)
+        ? CREDENTIAL_PROVIDERS[providerId].displayName
+        : providerId;
     const names = new Map<string, string>();
     for (const project of workspaceProjects) names.set(project.providerId, project.providerName);
     if (storedWorkspaceProvider && !names.has(storedWorkspaceProvider)) {
-      names.set(
-        storedWorkspaceProvider,
-        isCredentialProviderId(storedWorkspaceProvider)
-          ? CREDENTIAL_PROVIDERS[storedWorkspaceProvider].displayName
-          : storedWorkspaceProvider,
-      );
+      names.set(storedWorkspaceProvider, fallbackName(storedWorkspaceProvider));
     }
-    return [...names.entries()].map(([id, name]) => ({ id, name }));
-  }, [workspaceProjects, storedWorkspaceProvider]);
+    for (const providerId of Object.keys(storedWorkspaceProjects ?? {})) {
+      if (!names.has(providerId)) names.set(providerId, fallbackName(providerId));
+    }
+    return [...names.entries()].map(([id, name]) => {
+      const offered = workspaceProjects
+        .filter((project) => project.providerId === id)
+        .map((project) => ({ id: project.providerProjectId, label: project.repository }));
+      const stored = isProviderId(id) ? storedWorkspaceProjects?.[id] : undefined;
+      // A stored project the provider no longer offers is its own label: the
+      // repository name lived on the observed list that stopped listing it.
+      const projects =
+        stored && !offered.some((project) => project.id === stored)
+          ? [...offered, { id: stored, label: stored }]
+          : offered;
+      return { id, name, projects };
+    });
+  }, [workspaceProjects, storedWorkspaceProvider, storedWorkspaceProjects]);
 
   /**
    * Says a send landed, and stops saying it once it has been readable. Long
@@ -1030,6 +1059,7 @@ export function App(): React.JSX.Element {
   );
 
   const defaultWorkspaceProvider = (settings ?? bootstrap?.settings)?.defaultWorkspaceProvider;
+  const workspaceProjectDefaults = (settings ?? bootstrap?.settings)?.workspaceProjectDefaults;
   const {
     analyser,
     microphoneStatus,
@@ -1054,6 +1084,7 @@ export function App(): React.JSX.Element {
     sessions,
     workspaceProjects,
     defaultWorkspaceProvider,
+    workspaceProjectDefaults,
     voice: settings?.voice,
     voiceSpeed: settings?.voiceSpeed,
     voiceCaptions: settings?.voiceCaptions === true,
@@ -1486,6 +1517,7 @@ export function App(): React.JSX.Element {
     onFormFactorChange: changeFormFactor,
     onDefaultWorkspaceProviderChange: changeDefaultWorkspaceProvider,
     onWorkspaceAgentDefaultChange: changeWorkspaceAgentDefault,
+    onWorkspaceProjectDefaultChange: changeWorkspaceProjectDefault,
   };
   const shortcuts: ShortcutControl = {
     ...(shownHotkey.hotkey ? { voiceHotkey: shownHotkey.hotkey } : {}),

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -322,6 +322,14 @@ const SETTING_GUIDE: Record<
     adjustable: false,
     manual: `${CONNECTIONS_PAGE}, under Workspaces`,
   }),
+  // Described in the workspace projects context instead, for a reason the
+  // provider entry does not have: projects are observed rather than
+  // build-fixed, so the guide's settings half holds only their ids, while the
+  // projects context names each provider's default by the repository a person
+  // knows it as. Kept by hand for the provider default's own reason — the
+  // first creation in a provider saves its project — and the Creating
+  // workspaces fact carries the by-hand path.
+  workspaceProjectDefaults: () => undefined,
   formFactor: (settings) => ({
     id: APP_SETTING_ID.FORM_FACTOR,
     label: "Form factor",
@@ -518,7 +526,11 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "without one, and a provider that reports none takes no ask. An ask that names no " +
         "provider goes to the default workspace provider; until one is chosen Luke asks when " +
         "more than one provider could take it, and the first workspace created saves its " +
-        "provider as the default — changed or cleared by hand in the Settings tab. What a new " +
+        "provider as the default — changed or cleared by hand in the Settings tab. An ask that " +
+        "names no project goes the same way: each provider remembers a default project, filled " +
+        "in by the first workspace created there and changed or cleared by hand on the " +
+        "Connections page, under Workspaces; until one is chosen Luke asks when the provider " +
+        "lists more than one project. What a new " +
         "Conductor agent runs — its model, and its effort where the model's agent takes one — " +
         "follows the choice on the Conductor row under Cloud Agent API keys, or Conductor's own " +
         "defaults while none is made. A model named in a creation ask rides that creation alone " +

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -1035,18 +1035,20 @@ export class RealtimeVoiceSession {
    * Tells the conversation where a workspace can be created, the same way the
    * roster travels: context that must never open Luke's mouth, kept whole
    * because it is what a spoken creation ask is validated against. The default
-   * provider rides along because it is part of the same answer — where a
-   * nameless ask goes — and a changed default is news the way a changed list
-   * is. Identical lists under identical defaults are not resent.
+   * provider and the per-provider default projects ride along because they
+   * are part of the same answer — where a nameless ask goes — and a changed
+   * default is news the way a changed list is. Identical lists under
+   * identical defaults are not resent.
    */
   updateWorkspaceProjects(
     projects: readonly ObservedWorkspaceProject[],
     defaultProviderId?: string,
+    defaultProjectIds?: Readonly<Partial<Record<string, string>>>,
   ): void {
     this.#workspaceProjects = projects;
     this.#sendContext("workspace-projects", () => ({
-      text: workspaceProjectContextText(projects, defaultProviderId),
-      events: workspaceProjectContextEvents(projects, defaultProviderId),
+      text: workspaceProjectContextText(projects, defaultProviderId, defaultProjectIds),
+      events: workspaceProjectContextEvents(projects, defaultProviderId, defaultProjectIds),
     }));
   }
 

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -82,10 +82,16 @@ import {
   settingsNavRowId,
 } from "./settings-views";
 
-/** One provider the default-workspace row can offer, by id and display name. */
+/** One provider the default-workspace rows can offer, by id and display name. */
 export interface WorkspaceProviderOption {
   id: string;
   name: string;
+  /**
+   * The projects this provider's default-project row can offer: everything
+   * currently observed for it, plus a stored default it no longer offers — a
+   * choice the row cannot show is one that can be neither seen nor cleared.
+   */
+  projects: readonly { id: string; label: string }[];
 }
 
 /**
@@ -160,6 +166,16 @@ export interface PreferenceWrites {
   onWorkspaceAgentDefaultChange: (
     providerId: ProviderId,
     selection: WorkspaceAgentSelection | undefined,
+  ) => Promise<string | undefined>;
+  /**
+   * Chooses the project one provider creates nameless-ask workspaces in, or
+   * returns to letting the first creation there choose when omitted. The
+   * store answers with why when it refuses, and the row is where that answer
+   * belongs.
+   */
+  onWorkspaceProjectDefaultChange: (
+    providerId: ProviderId,
+    providerProjectId: string | undefined,
   ) => Promise<string | undefined>;
 }
 
@@ -266,6 +282,10 @@ const ASK_EACH_TIME = "";
 
 /* The agent row's word for no choice at all: the provider's own default. */
 const PROVIDER_DEFAULT_VALUE = "";
+
+/* The default-project rows' word for no default at all. An empty value for
+   the ASK_EACH_TIME reason: no provider's project id can collide with it. */
+const FIRST_CREATION_SETS_IT = "";
 
 /* The safe answer arrives first and the one that cannot be taken back lands a
    beat behind it, on the same stagger the panel's rows fan open with. Their
@@ -1358,7 +1378,61 @@ function WorkspacesSection({
           if (isProviderId(next)) return preferences.onDefaultWorkspaceProviderChange(next);
         }}
       />
+      {workspaceProviders.map((provider) => (
+        <WorkspaceProjectRow
+          key={provider.id}
+          provider={provider}
+          settings={settings}
+          preferences={preferences}
+        />
+      ))}
     </section>
+  );
+}
+
+/**
+ * Where one provider's nameless creation ask lands: a row per provider with
+ * projects to choose between, filled in the way the provider default is — by
+ * the first creation there — and this select is where that choice is seen,
+ * changed, or returned to the first creation.
+ */
+function WorkspaceProjectRow({
+  provider,
+  settings,
+  preferences,
+}: {
+  provider: WorkspaceProviderOption;
+  settings: AppSettings;
+  preferences: PreferenceWrites;
+}): React.JSX.Element | null {
+  const providerId = provider.id;
+  // A provider this build cannot store a choice for, or one with no projects
+  // to choose between, has nothing for the row to say.
+  if (!isProviderId(providerId) || provider.projects.length === 0) return null;
+  const stored = settings.workspaceProjectDefaults?.[providerId];
+  return (
+    <SelectRow
+      label={`Default ${provider.name} project`}
+      ariaLabel={`The project a nameless ask creates ${provider.name} workspaces in`}
+      detail="Where an ask that names no project creates a workspace. Your first creation there sets it."
+      value={stored ?? FIRST_CREATION_SETS_IT}
+      options={[
+        { value: FIRST_CREATION_SETS_IT, label: "First creation sets it" },
+        ...provider.projects.map((project) => ({ value: project.id, label: project.label })),
+      ]}
+      parse={(raw) => {
+        if (raw === FIRST_CREATION_SETS_IT) return raw;
+        // The set is the one this row offered, so anything else arriving out
+        // of the select is a broken control rather than a choice.
+        return provider.projects.some((project) => project.id === raw) ? raw : undefined;
+      }}
+      onChange={(next) =>
+        preferences.onWorkspaceProjectDefaultChange(
+          providerId,
+          next === FIRST_CREATION_SETS_IT ? undefined : next,
+        )
+      }
+    />
   );
 }
 

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -208,6 +208,8 @@ export interface VoiceConversationOptions {
   sessions: readonly NormalizedSession[];
   workspaceProjects: readonly ObservedWorkspaceProject[];
   defaultWorkspaceProvider: string | undefined;
+  /** The per-provider default projects, riding the projects context they steer. */
+  workspaceProjectDefaults: Readonly<Partial<Record<string, string>>> | undefined;
   voice: RealtimeVoice | undefined;
   voiceSpeed: RealtimeVoiceSpeed | undefined;
   voiceCaptions: boolean;
@@ -311,6 +313,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   const sessionsRef = useRef(options.sessions);
   const workspaceProjectsRef = useRef(options.workspaceProjects);
   const defaultWorkspaceProviderRef = useRef(options.defaultWorkspaceProvider);
+  const workspaceProjectDefaultsRef = useRef(options.workspaceProjectDefaults);
   const guideRef = useRef<AppGuideSnapshot>(EMPTY_APP_GUIDE);
   const issuesRef = useRef<readonly TrackedIssue[] | undefined>(undefined);
 
@@ -436,6 +439,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       session.updateWorkspaceProjects(
         workspaceProjectsRef.current,
         defaultWorkspaceProviderRef.current,
+        workspaceProjectDefaultsRef.current,
       );
       session.updateGuide(guideRef.current);
       session.updateIssues(issuesRef.current);
@@ -662,11 +666,17 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   useEffect(() => {
     workspaceProjectsRef.current = options.workspaceProjects;
     defaultWorkspaceProviderRef.current = options.defaultWorkspaceProvider;
+    workspaceProjectDefaultsRef.current = options.workspaceProjectDefaults;
     voiceSession.current?.updateWorkspaceProjects(
       options.workspaceProjects,
       options.defaultWorkspaceProvider,
+      options.workspaceProjectDefaults,
     );
-  }, [options.defaultWorkspaceProvider, options.workspaceProjects]);
+  }, [
+    options.defaultWorkspaceProvider,
+    options.workspaceProjectDefaults,
+    options.workspaceProjects,
+  ]);
 
   useEffect(() => {
     return window.sidecar.onAttentionSpeech((speech) => {

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -58,6 +58,7 @@ const SETTINGS_FIELD = {
   VOICE_SPEED: "voiceSpeed",
   VOICE_HOTKEY: "voiceHotkey",
   WORKSPACE_AGENT_DEFAULTS: "workspaceAgentDefaults",
+  WORKSPACE_PROJECT_DEFAULTS: "workspaceProjectDefaults",
 } as const;
 
 const API_KEY_LENGTH = {
@@ -191,6 +192,15 @@ interface PersistedSettings {
    * pairing are both dropped, because each names something no endpoint takes.
    */
   workspaceAgentDefaults?: Readonly<Partial<Record<ProviderId, WorkspaceAgentSelection>>>;
+  /**
+   * The project a nameless creation ask lands in, per provider, each entry
+   * absent until the user's first creation there chooses it. Projects are
+   * observed rather than build-fixed, so only the value's shape can be held
+   * here — an unknown provider or a malformed id is dropped, and whether the
+   * project is still offered is answered where the list lives: the id only
+   * ever steers, and every creation is validated against the observed list.
+   */
+  workspaceProjectDefaults?: Readonly<Partial<Record<ProviderId, string>>>;
 }
 
 interface ResolvedApiKey {
@@ -291,6 +301,41 @@ function storedWorkspaceAgentDefaults(
   return Object.keys(defaults).length > 0 ? defaults : undefined;
 }
 
+/** A stored project id reads like one wire value; anything longer is not an id. */
+const MAXIMUM_WORKSPACE_PROJECT_ID_LENGTH = 200;
+
+/** A provider's project id as this store will keep it, or nothing. */
+function workspaceProjectIdText(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim();
+  if (!normalized || normalized.length > MAXIMUM_WORKSPACE_PROJECT_ID_LENGTH) return undefined;
+  return normalized;
+}
+
+/**
+ * Reads the stored per-provider project choices, keeping only entries whose
+ * provider this build knows and whose value has an id's shape. Whether the
+ * project is still offered cannot be answered here — the list is observed at
+ * run time — so a stale id is carried and simply steers nothing until its
+ * provider offers that project again.
+ */
+function storedWorkspaceProjectDefaults(
+  record: Record<string, unknown>,
+): Partial<Record<ProviderId, string>> | undefined {
+  const persisted = record[SETTINGS_FIELD.WORKSPACE_PROJECT_DEFAULTS];
+  if (persisted === null || typeof persisted !== "object" || Array.isArray(persisted)) {
+    return undefined;
+  }
+  const defaults: Partial<Record<ProviderId, string>> = {};
+  for (const [providerId, value] of Object.entries(persisted)) {
+    if (!isProviderId(providerId)) continue;
+    const providerProjectId = workspaceProjectIdText(value);
+    if (!providerProjectId) continue;
+    defaults[providerId] = providerProjectId;
+  }
+  return Object.keys(defaults).length > 0 ? defaults : undefined;
+}
+
 function parsePersistedSettings(source: string): PersistedSettings {
   const parsed: unknown = JSON.parse(source);
   if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
@@ -303,6 +348,7 @@ function parsePersistedSettings(source: string): PersistedSettings {
   const formFactor = record[SETTINGS_FIELD.FORM_FACTOR];
   const defaultWorkspaceProvider = record[SETTINGS_FIELD.DEFAULT_WORKSPACE_PROVIDER];
   const workspaceAgentDefaults = storedWorkspaceAgentDefaults(record);
+  const workspaceProjectDefaults = storedWorkspaceProjectDefaults(record);
   const storedHotkey = record[SETTINGS_FIELD.VOICE_HOTKEY];
   // Read through the same gate a submitted chord passes, so a hand-edited
   // value is either the one spelling the rest of the app uses or nothing.
@@ -357,6 +403,7 @@ function parsePersistedSettings(source: string): PersistedSettings {
       ? { defaultWorkspaceProvider }
       : {}),
     ...(workspaceAgentDefaults ? { workspaceAgentDefaults } : {}),
+    ...(workspaceProjectDefaults ? { workspaceProjectDefaults } : {}),
   };
 }
 
@@ -429,6 +476,9 @@ export class SettingsStore {
         : {}),
       ...(persisted.workspaceAgentDefaults
         ? { workspaceAgentDefaults: persisted.workspaceAgentDefaults }
+        : {}),
+      ...(persisted.workspaceProjectDefaults
+        ? { workspaceProjectDefaults: persisted.workspaceProjectDefaults }
         : {}),
     };
   }
@@ -715,6 +765,35 @@ export class SettingsStore {
       const next: PersistedSettings = { ...persisted };
       if (Object.keys(defaults).length > 0) next.workspaceAgentDefaults = defaults;
       else delete next.workspaceAgentDefaults;
+      return next;
+    });
+  }
+
+  /**
+   * Shallow like the agent default's read, and read at the same moment: a
+   * creation ask must not wake the keychain to learn which project it prefers.
+   */
+  async readWorkspaceProjectDefault(providerId: ProviderId): Promise<string | undefined> {
+    return (await this.#load()).workspaceProjectDefaults?.[providerId];
+  }
+
+  /**
+   * Stores the project one provider creates nameless-ask workspaces in, or
+   * returns to letting the first creation choose when omitted. One provider's
+   * choice never disturbs another's, the way the agent defaults keep apart.
+   */
+  async setWorkspaceProjectDefault(
+    providerId: ProviderId,
+    providerProjectId: string | undefined,
+  ): Promise<SettingsUpdateResult> {
+    return this.#setField((persisted) => {
+      if (persisted.workspaceProjectDefaults?.[providerId] === providerProjectId) return;
+      const defaults = { ...persisted.workspaceProjectDefaults };
+      if (providerProjectId) defaults[providerId] = providerProjectId;
+      else delete defaults[providerId];
+      const next: PersistedSettings = { ...persisted };
+      if (Object.keys(defaults).length > 0) next.workspaceProjectDefaults = defaults;
+      else delete next.workspaceProjectDefaults;
       return next;
     });
   }

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -178,6 +178,16 @@ export interface AppSettings {
    * provider's endpoints take.
    */
   workspaceAgentDefaults?: Readonly<Partial<Record<ProviderId, WorkspaceAgentSelection>>>;
+  /**
+   * The project a conversational ask creates a workspace in when the ask
+   * names none, per provider, each entry absent until one has been chosen. It
+   * starts unset the way the provider does: the first workspace the user
+   * creates in a provider saves its project here, so the default is always a
+   * choice they made rather than one made for them. Projects are observed
+   * rather than build-fixed, so the value is the provider's own project id,
+   * and it steers an ask only while its provider still offers that project.
+   */
+  workspaceProjectDefaults?: Readonly<Partial<Record<ProviderId, string>>>;
 }
 
 /**
@@ -357,6 +367,16 @@ export interface AppBridge {
   setWorkspaceAgentDefault(
     providerId: ProviderId,
     selection: WorkspaceAgentSelection | undefined,
+  ): Promise<SettingsUpdateResult>;
+  /**
+   * Chooses the project one provider creates nameless-ask workspaces in, or
+   * returns to letting the first creation choose when omitted. The project
+   * must be one the provider's adapter currently offers; the main process
+   * validates that again before the store keeps it.
+   */
+  setWorkspaceProjectDefault(
+    providerId: ProviderId,
+    providerProjectId: string | undefined,
   ): Promise<SettingsUpdateResult>;
   /** Turns the on-screen caption of Luke's speech on or off. */
   setVoiceCaptions(enabled: boolean): Promise<SettingsUpdateResult>;
@@ -558,6 +578,7 @@ export const channels = {
   setFormFactor: "app:set-form-factor",
   setDefaultWorkspaceProvider: "app:set-default-workspace-provider",
   setWorkspaceAgentDefault: "app:set-workspace-agent-default",
+  setWorkspaceProjectDefault: "app:set-workspace-project-default",
   openSession: "app:open-session",
   sendSessionMessage: "app:send-session-message",
   executeSessionControl: "app:execute-session-control",

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -187,6 +187,10 @@ test("the facts describe creating a workspace, so Luke does not deny the capabil
   // choice is something Luke explains rather than something that surprises.
   assert.match(rendered, /default workspace provider/);
   assert.match(rendered, /first workspace created saves its provider/);
+  // The project a nameless ask lands in rides the same way, so the remembered
+  // first choice within a provider is explained rather than a surprise.
+  assert.match(rendered, /default project/);
+  assert.match(rendered, /first workspace created there/);
   // And so is what the new agent runs, because a model the user never chose
   // is exactly the surprise this setting exists to end.
   assert.match(rendered, /its model, and its effort/);

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -1190,6 +1190,90 @@ test("changes a workspace agent pairing without touching the cipher", async (t) 
   assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
 });
 
+test("lets the first creation choose each provider's project until one is chosen", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+
+  // Unset on purpose, the provider default's own terms: the default is always
+  // a choice the user made — by hand or by their first creation there.
+  assert.equal((await store.snapshot()).workspaceProjectDefaults, undefined);
+  assert.equal(await store.readWorkspaceProjectDefault(PROVIDER_ID.CONDUCTOR), undefined);
+
+  const { settings, reason } = await store.setWorkspaceProjectDefault(
+    PROVIDER_ID.CONDUCTOR,
+    "proj-1",
+  );
+
+  assert.equal(reason, undefined);
+  assert.deepEqual(settings.workspaceProjectDefaults, { [PROVIDER_ID.CONDUCTOR]: "proj-1" });
+  // The choice outlives the run that heard it.
+  assert.equal(
+    await storeIn(directory).readWorkspaceProjectDefault(PROVIDER_ID.CONDUCTOR),
+    "proj-1",
+  );
+
+  // Clearing returns that one provider to its first creation choosing.
+  const cleared = await store.setWorkspaceProjectDefault(PROVIDER_ID.CONDUCTOR, undefined);
+  assert.equal(cleared.settings.workspaceProjectDefaults, undefined);
+  assert.equal(
+    await storeIn(directory).readWorkspaceProjectDefault(PROVIDER_ID.CONDUCTOR),
+    undefined,
+  );
+});
+
+test("changes a default project without touching the cipher", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const cipher = countingCipher();
+  const store = storeIn(directory, { cipher });
+
+  const { settings } = await store.setWorkspaceProjectDefault(PROVIDER_ID.CURSOR, "proj-2");
+
+  assert.deepEqual(settings.workspaceProjectDefaults, { [PROVIDER_ID.CURSOR]: "proj-2" });
+  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
+});
+
+test("keeps one provider's default project apart from another's", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+
+  await store.setWorkspaceProjectDefault(PROVIDER_ID.CONDUCTOR, "proj-1");
+  const { settings } = await store.setWorkspaceProjectDefault(PROVIDER_ID.CURSOR, "proj-2");
+
+  assert.deepEqual(settings.workspaceProjectDefaults, {
+    [PROVIDER_ID.CONDUCTOR]: "proj-1",
+    [PROVIDER_ID.CURSOR]: "proj-2",
+  });
+
+  const cleared = await store.setWorkspaceProjectDefault(PROVIDER_ID.CONDUCTOR, undefined);
+  assert.deepEqual(cleared.settings.workspaceProjectDefaults, {
+    [PROVIDER_ID.CURSOR]: "proj-2",
+  });
+});
+
+test("ignores stored default projects this store cannot hold", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({
+      version: 2,
+      apiKeys: {},
+      workspaceProjectDefaults: {
+        // A provider this build does not know, a value that is not an id at
+        // all, an empty one, and one too long to be an id: each names nowhere
+        // a creation ask could be steered.
+        "someone-else": "proj-1",
+        conductor: 7,
+        cursor: "   ",
+        codex: "x".repeat(500),
+      },
+    }),
+  );
+
+  const store = storeIn(directory);
+  assert.equal(await store.readWorkspaceProjectDefault(PROVIDER_ID.CONDUCTOR), undefined);
+  assert.equal((await store.snapshot()).workspaceProjectDefaults, undefined);
+});
+
 test("ignores a stored pairing this build's table does not list", async (t) => {
   const directory = await temporaryDirectory(t);
   await fs.writeFile(

--- a/packages/sidecar-core/src/providers.ts
+++ b/packages/sidecar-core/src/providers.ts
@@ -180,8 +180,11 @@ export function workspaceNameText(value: unknown): string | undefined {
 }
 
 /**
- * Bounds and deduplicates the projects adapters offered, so the surface and
- * the conversation are handed the same capped, display-safe list.
+ * Bounds, deduplicates, and alphabetizes the projects adapters offered, so
+ * the surface and the conversation are handed the same capped, display-safe
+ * list. Ordered by the repository label a person scans for — not by which
+ * adapter answered first — and capped after the sort, so a list too long to
+ * keep whole loses its alphabetical tail rather than an arbitrary provider.
  */
 export function normalizeObservedWorkspaceProjects(
   projects: readonly ObservedWorkspaceProject[],
@@ -208,9 +211,22 @@ export function normalizeObservedWorkspaceProjects(
         ? project.taskSupport
         : WORKSPACE_TASK_SUPPORT.NONE,
     });
-    if (normalized.length >= maximumObservedWorkspaceProjects) break;
   }
-  return normalized;
+  return normalized
+    .sort(
+      (left, right) =>
+        compareRepositoryLabels(left.repository, right.repository) ||
+        // Two providers can offer one repository label; the provider and then
+        // the id keep the order deterministic rather than arrival-dependent.
+        left.providerName.localeCompare(right.providerName) ||
+        left.providerProjectId.localeCompare(right.providerProjectId),
+    )
+    .slice(0, maximumObservedWorkspaceProjects);
+}
+
+/** Alphabetical the way a person reads labels: case-blind, digits as numbers. */
+function compareRepositoryLabels(left: string, right: string): number {
+  return left.localeCompare(right, undefined, { sensitivity: "base", numeric: true });
 }
 
 /**

--- a/packages/sidecar-core/src/realtime-context.ts
+++ b/packages/sidecar-core/src/realtime-context.ts
@@ -205,10 +205,14 @@ export const maximumVoiceContextWorkspaceProjects = 10;
  * chosen and offering, and while none is chosen the context says that the
  * first creation decides — the saving itself is the main process's, done on
  * the validated act, so the sentence here is a description and never a lever.
+ * The default projects ride on the same terms, one tie-break per provider:
+ * an ask that names no project goes to that provider's default when one is
+ * chosen and still offered.
  */
 export function workspaceProjectContextText(
   projects: readonly ObservedWorkspaceProject[],
   defaultProviderId?: string,
+  defaultProjectIds?: Readonly<Partial<Record<string, string>>>,
 ): string {
   if (projects.length === 0) return "No provider currently offers workspace creation.";
   const listed = projects.slice(0, maximumVoiceContextWorkspaceProjects);
@@ -219,6 +223,7 @@ export function workspaceProjectContextText(
         `- ${project.providerName} — ${project.repository} [provider_id=${project.providerId} project_id=${project.providerProjectId}]; ${TASK_SUPPORT_TEXT[project.taskSupport]}`,
     ),
     ...workspaceDefaultProviderLines(listed, defaultProviderId),
+    ...workspaceDefaultProjectLines(listed, defaultProjectIds),
   ].join("\n");
 }
 
@@ -251,6 +256,41 @@ function workspaceDefaultProviderLines(
 }
 
 /**
+ * How each provider's default project reads under the projects list, on the
+ * provider default's own terms. A default that is chosen but no longer
+ * offered earns no line at all; a provider with exactly one project earns
+ * none either while nothing is chosen, because there is nothing to steer —
+ * only a provider actually offering a choice is said to be decided by the
+ * first creation there.
+ */
+function workspaceDefaultProjectLines(
+  projects: readonly ObservedWorkspaceProject[],
+  defaultProjectIds: Readonly<Partial<Record<string, string>>> | undefined,
+): readonly string[] {
+  const lines: string[] = [];
+  const said = new Set<string>();
+  for (const project of projects) {
+    if (said.has(project.providerId)) continue;
+    said.add(project.providerId);
+    const offered = projects.filter((candidate) => candidate.providerId === project.providerId);
+    const chosenId = defaultProjectIds?.[project.providerId];
+    const chosen = chosenId
+      ? offered.find((candidate) => candidate.providerProjectId === chosenId)
+      : undefined;
+    if (chosen) {
+      lines.push(
+        `The developer's default ${chosen.providerName} project is ${chosen.repository}: an ask that names no project creates there.`,
+      );
+    } else if (chosenId === undefined && offered.length > 1) {
+      lines.push(
+        `No default ${project.providerName} project is chosen yet: when an ask names no project there, ask which listed project it should be. The first workspace created in ${project.providerName} saves its project as the default.`,
+      );
+    }
+  }
+  return lines;
+}
+
+/**
  * How each support level reads in the projects list. Said beside the identity
  * so the ask and its validation share one vocabulary: the sentence Luke reads
  * is the rule the call is held to.
@@ -269,11 +309,12 @@ const TASK_SUPPORT_TEXT: Readonly<Record<string, string>> = {
 export function workspaceProjectContextEvents(
   projects: readonly ObservedWorkspaceProject[],
   defaultProviderId?: string,
+  defaultProjectIds?: Readonly<Partial<Record<string, string>>>,
 ): readonly Record<string, unknown>[] {
   return [
     labeledContextEvent(
       "workspace projects, sent automatically",
-      workspaceProjectContextText(projects, defaultProviderId),
+      workspaceProjectContextText(projects, defaultProviderId, defaultProjectIds),
     ),
   ];
 }

--- a/packages/sidecar-core/src/realtime-context.ts
+++ b/packages/sidecar-core/src/realtime-context.ts
@@ -215,7 +215,7 @@ export function workspaceProjectContextText(
   defaultProjectIds?: Readonly<Partial<Record<string, string>>>,
 ): string {
   if (projects.length === 0) return "No provider currently offers workspace creation.";
-  const listed = projects.slice(0, maximumVoiceContextWorkspaceProjects);
+  const listed = listedWorkspaceProjects(projects, defaultProjectIds);
   return [
     "Projects a new workspace can be created in:",
     ...listed.map(
@@ -225,6 +225,27 @@ export function workspaceProjectContextText(
     ...workspaceDefaultProviderLines(listed, defaultProviderId),
     ...workspaceDefaultProjectLines(listed, defaultProjectIds),
   ].join("\n");
+}
+
+/**
+ * The bounded slice the conversation is shown, kept default-aware: a chosen
+ * default project that survived observation must survive this cap too, or
+ * the alphabetical order could push the one project a nameless ask should
+ * land in off the list — unnamed, unlisted, and unsteerable. Each provider's
+ * chosen default rides past the cut instead, so the cap still bounds the
+ * list at the maximum plus at most one project per provider.
+ */
+function listedWorkspaceProjects(
+  projects: readonly ObservedWorkspaceProject[],
+  defaultProjectIds: Readonly<Partial<Record<string, string>>> | undefined,
+): readonly ObservedWorkspaceProject[] {
+  const listed = projects.slice(0, maximumVoiceContextWorkspaceProjects);
+  for (const project of projects.slice(maximumVoiceContextWorkspaceProjects)) {
+    if (defaultProjectIds?.[project.providerId] === project.providerProjectId) {
+      listed.push(project);
+    }
+  }
+  return listed;
 }
 
 /**

--- a/packages/sidecar-core/tests/providers.test.ts
+++ b/packages/sidecar-core/tests/providers.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  maximumObservedWorkspaceProjects,
+  normalizeObservedWorkspaceProjects,
+  type ObservedWorkspaceProject,
+  WORKSPACE_TASK_SUPPORT,
+} from "../src";
+
+function project(overrides: Partial<ObservedWorkspaceProject>): ObservedWorkspaceProject {
+  return {
+    providerId: "conductor",
+    providerName: "Conductor",
+    providerProjectId: "proj-1",
+    repository: "luke",
+    taskSupport: WORKSPACE_TASK_SUPPORT.OPTIONAL,
+    ...overrides,
+  };
+}
+
+test("workspace projects are offered alphabetically, however adapters answered", () => {
+  const normalized = normalizeObservedWorkspaceProjects([
+    project({ providerProjectId: "proj-z", repository: "zephyr" }),
+    project({
+      providerId: "cursor",
+      providerName: "Cursor",
+      providerProjectId: "https://github.com/acme/api",
+      repository: "acme/api",
+      taskSupport: WORKSPACE_TASK_SUPPORT.REQUIRED,
+    }),
+    project({ providerProjectId: "proj-l", repository: "Luke" }),
+  ]);
+
+  // Alphabetical by the repository label a person scans for — case-blind, and
+  // across providers rather than grouped by whichever adapter answered first.
+  assert.deepEqual(
+    normalized.map((entry) => entry.repository),
+    ["acme/api", "Luke", "zephyr"],
+  );
+});
+
+test("labels that differ only by number sort as a person counts", () => {
+  const normalized = normalizeObservedWorkspaceProjects([
+    project({ providerProjectId: "proj-10", repository: "repo-10" }),
+    project({ providerProjectId: "proj-2", repository: "repo-2" }),
+  ]);
+
+  assert.deepEqual(
+    normalized.map((entry) => entry.repository),
+    ["repo-2", "repo-10"],
+  );
+});
+
+test("one repository label offered twice keeps a deterministic provider order", () => {
+  const normalized = normalizeObservedWorkspaceProjects([
+    project({
+      providerId: "cursor",
+      providerName: "Cursor",
+      providerProjectId: "https://github.com/acme/luke",
+    }),
+    project({ providerProjectId: "proj-1" }),
+  ]);
+
+  assert.deepEqual(
+    normalized.map((entry) => entry.providerName),
+    ["Conductor", "Cursor"],
+  );
+});
+
+test("a list past the cap keeps its alphabetical head, not an arbitrary provider's", () => {
+  const overflowing = Array.from({ length: maximumObservedWorkspaceProjects + 5 }, (_, index) =>
+    // Zero-padded so plain and numeric comparisons agree on the expectation.
+    project({
+      providerProjectId: `proj-${String(index).padStart(2, "0")}`,
+      repository: `repo-${String(index).padStart(2, "0")}`,
+    }),
+  );
+
+  const normalized = normalizeObservedWorkspaceProjects([...overflowing].reverse());
+
+  assert.equal(normalized.length, maximumObservedWorkspaceProjects);
+  assert.equal(normalized[0]?.repository, "repo-00");
+  assert.equal(
+    normalized.at(-1)?.repository,
+    `repo-${String(maximumObservedWorkspaceProjects - 1).padStart(2, "0")}`,
+  );
+});
+
+test("normalizing still drops blanks and duplicates before it sorts", () => {
+  const normalized = normalizeObservedWorkspaceProjects([
+    project({ providerProjectId: "proj-1", repository: "beta" }),
+    // The same provider project again, under a different label: one row.
+    project({ providerProjectId: "proj-1", repository: "alpha" }),
+    project({ providerProjectId: "   ", repository: "gamma" }),
+    project({ providerProjectId: "proj-2", repository: "   " }),
+  ]);
+
+  assert.deepEqual(
+    normalized.map((entry) => entry.repository),
+    ["beta"],
+  );
+});

--- a/packages/sidecar-core/tests/realtime.test.ts
+++ b/packages/sidecar-core/tests/realtime.test.ts
@@ -847,6 +847,52 @@ test("the projects context says where a nameless creation ask goes", () => {
   assert.match(item?.content?.[0]?.text ?? "", /default provider for new workspaces is Conductor/);
 });
 
+test("the projects context says which project a nameless ask lands in", () => {
+  const secondProject: ObservedWorkspaceProject = {
+    providerId: "conductor",
+    providerName: "Conductor",
+    providerProjectId: "proj-2",
+    repository: "acme/other",
+    taskSupport: WORKSPACE_TASK_SUPPORT.OPTIONAL,
+  };
+
+  // A chosen default that is still offered is named by its repository, as
+  // where a nameless ask goes.
+  const chosen = workspaceProjectContextText([OFFERED_PROJECT, secondProject], undefined, {
+    conductor: "proj-1",
+  });
+  assert.match(chosen, /default Conductor project is luke/);
+  assert.doesNotMatch(chosen, /No default Conductor project/);
+
+  // Nothing chosen and more than one project listed: ask first, and say that
+  // the first creation there decides — that sentence is how the developer
+  // learns their answer will be remembered.
+  const open = workspaceProjectContextText([OFFERED_PROJECT, secondProject]);
+  assert.match(open, /No default Conductor project is chosen yet/);
+  assert.match(open, /ask which listed project/);
+  assert.match(open, /first workspace created in Conductor saves its project/);
+
+  // One project alone leaves nothing to steer, so nothing is said of it.
+  const single = workspaceProjectContextText([OFFERED_PROJECT]);
+  assert.doesNotMatch(single, /default Conductor project/);
+
+  // A default the provider no longer offers earns no line at all: it is not
+  // somewhere an ask can go, and the choice already made is not re-offered to
+  // the first creation.
+  const away = workspaceProjectContextText([OFFERED_PROJECT, secondProject], undefined, {
+    conductor: "proj-gone",
+  });
+  assert.doesNotMatch(away, /default Conductor project/);
+  assert.doesNotMatch(away, /No default Conductor project/);
+
+  // The default rides the same context event the list does.
+  const [event] = workspaceProjectContextEvents([OFFERED_PROJECT, secondProject], undefined, {
+    conductor: "proj-2",
+  });
+  const item = (event as { item?: { content?: { text?: string }[] } }).item;
+  assert.match(item?.content?.[0]?.text ?? "", /default Conductor project is acme\/other/);
+});
+
 /**
  * A build-documented table the way the app declares one: labels for people,
  * ids for the wire, efforts per agent.

--- a/packages/sidecar-core/tests/realtime.test.ts
+++ b/packages/sidecar-core/tests/realtime.test.ts
@@ -46,7 +46,11 @@ import {
 } from "../src";
 import { ATTENTION_REVIEW_OUTCOME, type AttentionReview } from "../src/attention";
 import { maximumWorkspaceNameLength } from "../src/providers";
-import { maximumVoiceContextIssues, maximumVoiceContextSessions } from "../src/realtime-context";
+import {
+  maximumVoiceContextIssues,
+  maximumVoiceContextSessions,
+  maximumVoiceContextWorkspaceProjects,
+} from "../src/realtime-context";
 import { realtimeSessionConfig } from "../src/realtime-credentials";
 import {
   maximumTypedAskLength,
@@ -891,6 +895,31 @@ test("the projects context says which project a nameless ask lands in", () => {
   });
   const item = (event as { item?: { content?: { text?: string }[] } }).item;
   assert.match(item?.content?.[0]?.text ?? "", /default Conductor project is acme\/other/);
+});
+
+test("a chosen default project survives the context cap", () => {
+  // One more project than the context will list, alphabetical like the
+  // normalizer hands them over, with the developer's chosen default sorted
+  // dead last — exactly the project the cap would otherwise cut.
+  const crowd = Array.from({ length: maximumVoiceContextWorkspaceProjects + 1 }, (_, index) => ({
+    ...OFFERED_PROJECT,
+    providerProjectId: `proj-${String(index).padStart(2, "0")}`,
+    repository: `repo-${String(index).padStart(2, "0")}`,
+  }));
+  const last = crowd.at(-1);
+  assert.ok(last);
+
+  // Uncapped by the choice: without a default the tail stays cut.
+  const capless = workspaceProjectContextText(crowd);
+  assert.doesNotMatch(capless, new RegExp(last.providerProjectId));
+
+  // The chosen default rides past the cut, listed and steered both — a
+  // default the sentence names but the list omits would be unaskable.
+  const kept = workspaceProjectContextText(crowd, undefined, {
+    conductor: last.providerProjectId,
+  });
+  assert.match(kept, new RegExp(`project_id=${last.providerProjectId}`));
+  assert.match(kept, new RegExp(`default Conductor project is ${last.repository}`));
 });
 
 /**


### PR DESCRIPTION
## Summary

- Luke now remembers a default project for workspace creation, per provider, the way he remembers the default provider and the agent/model pairing: the first workspace created in a provider saves its project as that provider's default, only while nothing is chosen, and the choice is changed or cleared by hand in the Workspaces settings section (Connections page).
- The voice conversation learns each provider's default through the same `[workspace projects]` context a creation ask is validated against, so a spoken or typed ask that names no project lands somewhere the developer chose; while none is chosen and a provider lists several projects, Luke asks and says the first creation decides.
- A hand change travels a new `setWorkspaceProjectDefault` bridge call, validated in the main process against the projects the provider's adapter currently offers — the same list every creation act is checked against. The guide describes the setting through the projects context and the Creating workspaces fact; it is deliberately not spoken-adjustable, like the default provider.
- Workspace projects are now offered alphabetically by repository label (case-blind, digits as numbers) wherever they appear — the default-project rows and the spoken projects list — with the shared normalizer capping after the sort.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (lint, typecheck, all tests, builds)
- macOS Electron verification (`./scripts/verify.sh`): `not run`

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31968158048/artifacts/9269058999) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31968158048)

- Commit: `96c0a3af3f5e6c3649ac8889d2c7b7736251dec9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Developed in a Linux cloud workspace, so the macOS verification and physical-notch check could not be performed here; the new "Default project" settings row would benefit from a macOS visual pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/9b83e98b-9864-442c-923f-c6b3ed6ad49a)
