### PR TITLE
fix(panel): draw the provider rule under Conductor's model and effort rows

### DIFF
--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -14,7 +14,7 @@ import {
   type RealtimeVoiceSpeed,
   type WorkspaceAgentSelection,
 } from "@sidecar/core";
-import { Fragment, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { AppSettings, CredentialSource, MicrophoneStatus } from "../shared/contracts";
 import { CREDENTIAL_SOURCE, SECRET_STORAGE } from "../shared/contracts";
 import type { CredentialProvider } from "../shared/credential-providers";
@@ -302,12 +302,19 @@ function ProviderCredential({
   storageUnavailable,
   control,
   panelOpen,
+  children,
 }: {
   provider: CredentialProvider;
   source: CredentialSource;
   storageUnavailable: boolean;
   control: CredentialEntryControl;
   panelOpen: boolean;
+  /**
+   * The provider's own sub-rows — today, the agent defaults a connected
+   * Conductor offers. Drawn inside the credential block so the rule that
+   * separates providers falls under them, not between them and their line.
+   */
+  children?: React.ReactNode;
 }): React.JSX.Element {
   // Deleting is the one act that begins and ends on this line, question and
   // answer both. Entering a credential does not: it can leave for the slot and
@@ -619,6 +626,7 @@ function ProviderCredential({
         </fieldset>
       ) : null}
       {rejection ? <p className="error-message">{rejection}</p> : null}
+      {children}
     </div>
   );
 }
@@ -980,14 +988,14 @@ function CredentialsSection({
             ? provider.id
             : undefined;
         return (
-          <Fragment key={provider.id}>
-            <ProviderCredential
-              provider={provider}
-              source={settings.credentialSources[provider.id]}
-              storageUnavailable={storageUnavailable}
-              control={control}
-              panelOpen={panelOpen}
-            />
+          <ProviderCredential
+            key={provider.id}
+            provider={provider}
+            source={settings.credentialSources[provider.id]}
+            storageUnavailable={storageUnavailable}
+            control={control}
+            panelOpen={panelOpen}
+          >
             {agentRow ? (
               <WorkspaceAgentRow
                 provider={provider}
@@ -998,7 +1006,7 @@ function CredentialsSection({
                 onChange={preferences.onWorkspaceAgentDefaultChange}
               />
             ) : null}
-          </Fragment>
+          </ProviderCredential>
         );
       })}
       {/* True of every key here, so it is said once rather than per provider. */}


### PR DESCRIPTION
## Why

Providers on the Connections settings page are separated by a hairline rule drawn between adjacent credential blocks (`.credential + .credential`). A connected Conductor draws its **New agents run** and **Effort** sub-rows *between* its credential line and the next provider's, so the adjacent-sibling rule stopped matching and the separator between Conductor and Copilot vanished — Conductor's defaults ran straight into the next provider with no line under them.

## What

`ProviderCredential` now accepts children, and `CredentialsSection` renders the `WorkspaceAgentRow` sub-rows inside their provider's `.credential` block instead of beside it. The existing rule then falls under the whole Conductor block — credential line, default model, and default effort — with no new CSS and no change for providers without an agent table. Spacing is unchanged: the credential block and the section column share the same 9px gap.

## Validation

- `./scripts/check.sh` — passed (repository, type, test, and build checks).
- macOS validation (`./scripts/verify.sh`) runs in CI; this was authored in a Linux cloud workspace. No physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/f6dd4891-dcb2-4e3d-9f38-20b229ba69a1)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31967851361/artifacts/9268987864) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31967851361)

- Commit: `1aa16c1bc13676f43f610334e3b585c632209f95`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
