### PR TITLE
fix(voice): hold one context item per kind and retire idle calls

### DIFF
--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -621,6 +621,19 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
               "hint's Got it button rests it for that stretch of silence and any that begins " +
               "within fifteen minutes; the captions stay.",
           },
+          {
+            label: "How long a conversation lasts",
+            detail:
+              "One conversation lasts as long as the call it is held on. The call opens on the " +
+              "first press of the talk key or the first typed ask, stays open across as many " +
+              "turns as the developer takes, and is put away after ten minutes with nothing said " +
+              "on it — which releases the microphone rather than holding it all day. The voice " +
+              "service also ends any call at an hour. Either way the next press opens a fresh " +
+              "conversation, and Luke will not remember the last one: what he knows then is what " +
+              "the panel observes, not what was said before. A call that ends underneath a " +
+              "conversation says so rather than quietly forgetting. Nothing is written down " +
+              "between conversations.",
+          },
         ]
       : [
           {

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -7,11 +7,17 @@ import {
   type CarriedAppAction,
   type CarriedIssueAction,
   type CarriedSessionAction,
+  CONTEXT_ITEM_KIND,
+  type ContextItemKind,
   cancelResponseEvents,
   clearInputAudioEvents,
+  contextItemId,
+  contextSupersedeEventId,
+  contextSupersedeEvents,
   EMPTY_APP_GUIDE,
   functionCallFollowUpEvents,
   functionCallOutputEvents,
+  ISSUE_TRACKER_DISCONNECTED_TEXT,
   issueContextEvents,
   issueContextText,
   issueToolAction,
@@ -54,6 +60,56 @@ const CONNECT_TIMEOUT_MS = 15_000;
  * normal path: a spoken reply ends when it goes quiet.
  */
 const REALTIME_SETTLE_TIMEOUT_MS = 20_000;
+
+/**
+ * How long the developer's call stays open with nothing being said on it.
+ *
+ * A call costs something to hold whether or not it is used: the capture device
+ * stays open and the macOS microphone indicator stays lit, which on a sidecar
+ * that sits on a desk all day is the whole difference between a companion and
+ * something listening. The service ends the session at an hour regardless, so
+ * the choice was never between keeping this conversation and losing it — only
+ * between letting go of it deliberately and being cut off mid-sentence.
+ *
+ * Ten minutes is longer than any pause inside a conversation and shorter than
+ * the walk to get a coffee. Coming back costs one handshake.
+ */
+export const VOICE_IDLE_TIMEOUT_MS = 10 * 60_000;
+
+/**
+ * The order context is flushed in, so a turn's items land the same way every
+ * time: what Luke can see, then where he can create, then what he knows about
+ * himself, then what the tracker lists.
+ */
+const CONTEXT_FLUSH_ORDER: readonly ContextItemKind[] = [
+  CONTEXT_ITEM_KIND.SESSIONS,
+  CONTEXT_ITEM_KIND.WORKSPACE_PROJECTS,
+  CONTEXT_ITEM_KIND.APP_GUIDE,
+  CONTEXT_ITEM_KIND.ISSUES,
+];
+
+/**
+ * How many unanswered deletes are worth remembering. One flush issues at most
+ * one per kind, and each is answered within the round trip, so this is already
+ * two turns' worth of room for something that ordinarily clears immediately.
+ */
+const MAXIMUM_PENDING_SUPERSEDES = CONTEXT_FLUSH_ORDER.length * 2;
+
+/**
+ * One kind of context as it is waiting to be said: the words, for telling an
+ * unchanged answer from a fresh one, and how to build the item once it has a
+ * name to occupy.
+ */
+interface PendingContext {
+  text: string;
+  build: (itemId: string) => readonly Record<string, unknown>[];
+}
+
+/** A context item this call put in the conversation, and what it says. */
+interface LiveContext {
+  itemId: string;
+  text: string;
+}
 
 /**
  * The backstop for a reply whose ending never arrives.
@@ -122,6 +178,14 @@ export interface RealtimeVoiceSessionOptions extends RealtimeVoiceSessionCallbac
   requestMicrophoneStream?: () => Promise<MediaStream>;
   exchangeDescription?: (url: string, init: RequestInit) => Promise<Response>;
   connectTimeoutMs?: number;
+  /**
+   * How long a call may sit idle before it is put away. Injectable so the
+   * retirement can be exercised without waiting ten real minutes.
+   */
+  idleTimeoutMs?: number;
+  /** The timer the idle retirement runs on, injectable for the same reason. */
+  schedule?: (callback: () => void, delayMs: number) => unknown;
+  cancel?: (timer: unknown) => void;
   /** Injectable so a test can hold the clock a truncate measures against. */
   now?: () => number;
 }
@@ -197,11 +261,34 @@ export class RealtimeVoiceSession {
    */
   #issues: readonly TrackedIssue[] | undefined;
   /**
-   * The last rendered context sent on this call, keyed by label. Identical
-   * text is not resent; teardown clears the map so the next call starts
-   * current rather than believing the last call already told it.
+   * The context each kind would send if a turn opened now, and the item each
+   * kind actually occupies in the conversation.
+   *
+   * Nothing is sent when it changes. A roster that churns every five seconds
+   * while the developer says nothing would otherwise write a fresh copy of
+   * itself into the conversation every five seconds, and the model's window is
+   * evicted oldest-first — so the developer's own earlier turns are what a pile
+   * of superseded rosters costs. Instead the newest answer waits here and goes
+   * in at the moment a turn opens, which is both the only moment it is read and
+   * the moment it is most nearly true.
+   *
+   * Teardown clears both, so the next call starts current rather than believing
+   * the last call already told it.
    */
-  #contextCache = new Map<string, string>();
+  #contextPending = new Map<ContextItemKind, PendingContext>();
+  #contextLive = new Map<ContextItemKind, LiveContext>();
+  /**
+   * Rises for every context item named, so a replacement never claims the name
+   * of something a failed delete left behind.
+   */
+  #contextSequence = 0;
+  /**
+   * The deletes issued and not yet answered, by the name stamped on each. A
+   * delete is answered with an error when the item is already gone — evicted at
+   * the window's edge, most likely — and that error is this call's own business
+   * rather than a fault to report to the developer.
+   */
+  #pendingSupersedes = new Map<string, string>();
   /**
    * Luke's own audio track. Cancelling stops the model producing more, but what
    * it already produced is on its way down the connection and keeps playing —
@@ -305,6 +392,18 @@ export class RealtimeVoiceSession {
    * speaking is held here and sent ahead of whatever the call does next.
    */
   #pendingSpeed: number | undefined;
+  /**
+   * The timer that puts an idle call away, armed whenever the call settles and
+   * cancelled the moment anything is being said on it.
+   */
+  #idleTimer: unknown;
+  /**
+   * Whether the developer has taken a turn on this call. It is what makes a
+   * dropped connection worth mentioning: a call that carried a conversation
+   * takes the conversation with it, and Luke would otherwise answer the next
+   * question having quietly forgotten the last one.
+   */
+  #conversationBegan = false;
 
   constructor(options: RealtimeVoiceSessionOptions) {
     this.#options = options;
@@ -448,10 +547,24 @@ export class RealtimeVoiceSession {
       channel.onmessage = (event) => this.#handleServerEvent(event.data);
       channel.onclose = () => {
         if (this.#closed) return;
+        // What the call was holding has to be read before the teardown empties
+        // it. A call that carried a conversation takes the conversation with
+        // it, and the service ends every session at an hour whether or not
+        // anyone is finished talking — so this is the ordinary end of a long
+        // one, not an exotic failure.
+        const lost = this.#conversationBegan;
         // A channel that closes on its own still leaves the capture running,
         // so this has to release the device as thoroughly as an explicit stop.
         this.#teardown();
         this.#setStatus(REALTIME_STATUS.IDLE);
+        // Silence here is what made Luke seem to have forgotten on purpose:
+        // the next question was answered by someone who had never heard the
+        // last one, and nothing said so.
+        if (lost) {
+          this.#options.onError(
+            "The voice call ended, so Luke has lost the thread of this conversation. Press the talk key to start a new one.",
+          );
+        }
       };
 
       // One deadline covers the SDP exchange and the channel opening together.
@@ -815,7 +928,14 @@ export class RealtimeVoiceSession {
     this.#guide = EMPTY_APP_GUIDE;
     this.#workspaceProjects = [];
     this.#issues = undefined;
-    this.#contextCache.clear();
+    // What was said on the call goes with the call. The pending answers go too:
+    // they were built from stores this teardown is emptying, and the next call
+    // is filled from the app afresh before it takes a turn.
+    this.#contextPending.clear();
+    this.#contextLive.clear();
+    this.#pendingSupersedes.clear();
+    this.#conversationBegan = false;
+    this.#clearIdleTimer();
     this.#generationDone = false;
     this.#remoteQuiet = false;
     this.#heardLuke = false;
@@ -840,6 +960,15 @@ export class RealtimeVoiceSession {
     // cancel for the reply being talked over was sent before this — so the
     // reply about to be asked for is already spoken at the new pace.
     this.#flushPendingSpeed();
+    // The turn the developer just opened is the one that reads the context, so
+    // it is the moment the context goes in — ahead of the events asking for the
+    // reply, on a channel that keeps them in that order. The turns Luke opens
+    // himself get none: a readout has a sentence to say and nothing to look up,
+    // and a tool follow-up is answering from what this same flush already sent.
+    if (toolsArmed) {
+      this.#conversationBegan = true;
+      this.#flushContext();
+    }
     // The track is deliberately left as it is. A reply that was cut off left it
     // disabled, and re-opening it here would let the tail of that reply — still
     // arriving, because the server sent it before it was told to stop — be
@@ -1025,10 +1154,9 @@ export class RealtimeVoiceSession {
    */
   updateSessions(sessions: readonly NormalizedSession[]): void {
     this.#sessions = sessions;
-    this.#sendContext("sessions", () => ({
-      text: sessionContextText(sessions),
-      events: sessionContextEvents(sessions),
-    }));
+    this.#rememberContext(CONTEXT_ITEM_KIND.SESSIONS, sessionContextText(sessions), (itemId) =>
+      sessionContextEvents(sessions, itemId),
+    );
   }
 
   /**
@@ -1046,10 +1174,12 @@ export class RealtimeVoiceSession {
     defaultProjectIds?: Readonly<Partial<Record<string, string>>>,
   ): void {
     this.#workspaceProjects = projects;
-    this.#sendContext("workspace-projects", () => ({
-      text: workspaceProjectContextText(projects, defaultProviderId, defaultProjectIds),
-      events: workspaceProjectContextEvents(projects, defaultProviderId, defaultProjectIds),
-    }));
+    this.#rememberContext(
+      CONTEXT_ITEM_KIND.WORKSPACE_PROJECTS,
+      workspaceProjectContextText(projects, defaultProviderId, defaultProjectIds),
+      (itemId) =>
+        workspaceProjectContextEvents(projects, itemId, defaultProviderId, defaultProjectIds),
+    );
   }
 
   /**
@@ -1061,10 +1191,9 @@ export class RealtimeVoiceSession {
    */
   updateGuide(guide: AppGuideSnapshot): void {
     this.#guide = guide;
-    this.#sendContext("guide", () => ({
-      text: appGuideContextText(guide),
-      events: appGuideContextEvents(guide),
-    }));
+    this.#rememberContext(CONTEXT_ITEM_KIND.APP_GUIDE, appGuideContextText(guide), (itemId) =>
+      appGuideContextEvents(guide, itemId),
+    );
   }
 
   /**
@@ -1075,37 +1204,120 @@ export class RealtimeVoiceSession {
    */
   updateIssues(issues: readonly TrackedIssue[] | undefined): void {
     this.#issues = issues;
-    if (!issues) {
-      // A conversation that was never told about a board has nothing to
-      // withdraw; one that was must be told the board is gone, or Luke keeps
-      // answering from a tracker nobody is observing.
-      if (!this.#carriesContext()) return;
-      if (!this.#contextCache.has("issues")) return;
-      this.#contextCache.delete("issues");
-      this.#send(issueTrackerDisconnectedEvents());
+    if (issues) {
+      this.#rememberContext(CONTEXT_ITEM_KIND.ISSUES, issueContextText(issues), (itemId) =>
+        issueContextEvents(issues, itemId),
+      );
       return;
     }
-    this.#sendContext("issues", () => ({
-      text: issueContextText(issues),
-      events: issueContextEvents(issues),
-    }));
+    // A conversation that was never going to be told about a board has nothing
+    // to withdraw, and saying a tracker is "no longer" connected when none ever
+    // was is a different and wrong sentence. One that had a board — or was
+    // about to be given one — is told the board is gone, or Luke keeps
+    // answering from a tracker nobody is observing.
+    if (!this.#contextPending.has(CONTEXT_ITEM_KIND.ISSUES)) return;
+    if (!this.#contextLive.has(CONTEXT_ITEM_KIND.ISSUES)) {
+      this.#contextPending.delete(CONTEXT_ITEM_KIND.ISSUES);
+      return;
+    }
+    this.#rememberContext(CONTEXT_ITEM_KIND.ISSUES, ISSUE_TRACKER_DISCONNECTED_TEXT, (itemId) =>
+      issueTrackerDisconnectedEvents(itemId),
+    );
   }
 
   /**
-   * Diffs one labelled context against what this call was last told and sends
-   * it only when the text changed. The stores above still update either way,
-   * so the developer's next call starts current even when this one is
-   * speak-only and carries nothing.
+   * Holds one kind of context until a turn asks for it. Nothing is sent here:
+   * what a turn needs is the newest answer, not every answer on the way to it.
    */
-  #sendContext(
-    label: string,
-    render: () => { text: string; events: readonly Record<string, unknown>[] },
+  #rememberContext(
+    kind: ContextItemKind,
+    text: string,
+    build: (itemId: string) => readonly Record<string, unknown>[],
   ): void {
+    this.#contextPending.set(kind, { text, build });
+  }
+
+  /**
+   * Puts the context a turn is about to be answered from into the conversation,
+   * each kind replacing whatever it said before.
+   *
+   * Two things happen per changed kind, in this order: the item holding the old
+   * answer is deleted, and the new one is created under a fresh name. Ordered
+   * that way because the channel is ordered — the conversation is never briefly
+   * holding two rosters, and never briefly holding none.
+   *
+   * An answer that has not changed since it was last said is left alone
+   * entirely, which is what keeps a quiet stretch of the conversation cached.
+   */
+  #flushContext(): void {
     if (!this.#carriesContext()) return;
-    const { text, events } = render();
-    if (text === this.#contextCache.get(label)) return;
-    this.#contextCache.set(label, text);
-    this.#send(events);
+    for (const kind of CONTEXT_FLUSH_ORDER) {
+      const pending = this.#contextPending.get(kind);
+      if (!pending) continue;
+      const live = this.#contextLive.get(kind);
+      if (live?.text === pending.text) continue;
+      this.#contextSequence += 1;
+      const itemId = contextItemId(kind, this.#contextSequence);
+      if (live) this.#supersede(live.itemId);
+      this.#send(pending.build(itemId));
+      this.#contextLive.set(kind, { itemId, text: pending.text });
+    }
+  }
+
+  /** Removes the item a fresher answer is replacing, and remembers asking. */
+  #supersede(itemId: string): void {
+    const eventId = contextSupersedeEventId(this.#contextSequence);
+    // A delete is answered within the round trip or not at all, so anything
+    // still waiting after this many is an answer that was never coming — and a
+    // record kept for the length of a call is one that grows for the length of
+    // a call. The oldest goes; insertion order is what makes it the oldest.
+    while (this.#pendingSupersedes.size >= MAXIMUM_PENDING_SUPERSEDES) {
+      const [oldest] = this.#pendingSupersedes.keys();
+      if (oldest === undefined) break;
+      this.#pendingSupersedes.delete(oldest);
+    }
+    this.#pendingSupersedes.set(eventId, itemId);
+    this.#send(contextSupersedeEvents({ itemId, eventId }));
+  }
+
+  /** Forgets a delete that has been answered, however it was answered. */
+  #settleSupersede(itemId: string): void {
+    for (const [eventId, pending] of this.#pendingSupersedes) {
+      if (pending === itemId) this.#pendingSupersedes.delete(eventId);
+    }
+  }
+
+  /**
+   * Whether an error is one of this call's own deletes coming back refused.
+   *
+   * The event is named when it is sent, so the answer naming it back is the
+   * reliable half of this. The item id is checked too because the field
+   * carrying the name back is not one the API reference states plainly, and a
+   * silent mismatch here would put an error on screen for something the
+   * developer neither did nor can do anything about.
+   */
+  #supersedeError(event: { message: string; eventId?: string }): boolean {
+    if (this.#pendingSupersedes.size === 0) return false;
+    if (event.eventId !== undefined && this.#pendingSupersedes.has(event.eventId)) {
+      this.#pendingSupersedes.delete(event.eventId);
+      return true;
+    }
+    for (const [eventId, itemId] of this.#pendingSupersedes) {
+      if (event.message.includes(itemId)) {
+        this.#pendingSupersedes.delete(eventId);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * The context items this call currently holds, by kind — what the
+   * conversation would be answered from if a turn opened now. Exposed for the
+   * tests that hold this class to its one-item-per-kind promise.
+   */
+  get liveContextItemIds(): ReadonlyMap<ContextItemKind, string> {
+    return new Map([...this.#contextLive].map(([kind, live]) => [kind, live.itemId] as const));
   }
 
   /**
@@ -1206,7 +1418,16 @@ export class RealtimeVoiceSession {
         }, REALTIME_SETTLE_TIMEOUT_MS);
         return;
       }
+      case REALTIME_SERVER_EVENT.CONVERSATION_ITEM_DELETED:
+        if (event.itemId) this.#settleSupersede(event.itemId);
+        return;
       case REALTIME_SERVER_EVENT.ERROR:
+        // A delete this call issued can be answered with an error rather than a
+        // deletion, because the item was already gone — evicted at the window's
+        // edge is the way that happens. It is nothing the developer did and
+        // nothing they can act on, and reporting it would both put a fault on
+        // screen and, below, end a reply that is still being spoken.
+        if (this.#supersedeError(event)) return;
         this.#options.onError(event.message);
         // An error can arrive *instead of* `response.done` — an empty push-to-talk
         // commit is the common case — which would otherwise leave the session
@@ -1357,6 +1578,37 @@ export class RealtimeVoiceSession {
   #setStatus(status: RealtimeStatus): void {
     if (this.#status === status) return;
     this.#status = status;
+    this.#restIdleTimer(status);
     this.#options.onStatus(status);
+  }
+
+  /**
+   * Starts the clock on an idle call, or stops it because the call is in use.
+   *
+   * Only the developer's own call is retired this way. The call Luke opens to
+   * read a notice out already puts itself away once the queue is quiet, and it
+   * holds no capture device to be worth hurrying.
+   *
+   * A settled call restarts the clock however it settled, so a notice read out
+   * counts as the call being used. It reached the developer, and a call that
+   * just spoke to someone is not one nobody is having.
+   */
+  #restIdleTimer(status: RealtimeStatus): void {
+    this.#clearIdleTimer();
+    if (status !== REALTIME_STATUS.READY || !this.#microphone) return;
+    const timeoutMs = positiveInteger(this.#options.idleTimeoutMs, VOICE_IDLE_TIMEOUT_MS);
+    this.#idleTimer = (this.#options.schedule ?? setTimeout)(() => {
+      this.#idleTimer = undefined;
+      // Re-checked at the moment of closing, because ten minutes is long: a
+      // turn may have opened, or the call may already be gone.
+      if (this.#status !== REALTIME_STATUS.READY || !this.#microphone) return;
+      void this.close();
+    }, timeoutMs);
+  }
+
+  #clearIdleTimer(): void {
+    if (this.#idleTimer === undefined) return;
+    (this.#options.cancel ?? clearTimeout)(this.#idleTimer as Parameters<typeof clearTimeout>[0]);
+    this.#idleTimer = undefined;
   }
 }

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -6,6 +6,7 @@ import {
   type AppGuideSnapshot,
   ATTENTION_DISPOSITION,
   ATTENTION_SPEECH_SOURCE,
+  CONTEXT_ITEM_KIND,
   ISSUE_TRACKER_ID,
   type NormalizedSession,
   normalizeSession,
@@ -26,6 +27,7 @@ import {
   REMOTE_QUIET_MS,
   RealtimeVoiceSession,
   type SessionActionCarrier,
+  VOICE_IDLE_TIMEOUT_MS,
 } from "../src/renderer/realtime-session";
 
 const CONNECTION: RealtimeConnection = {
@@ -54,6 +56,20 @@ interface Harness {
   calls: string[];
   /** The transceivers declared instead of tracks, as a speak-only call does. */
   transceivers: { kind: string; direction?: string }[];
+  /**
+   * The idle retirement, held rather than run: every test connects and few
+   * close, so a real ten-minute timer would keep the run alive for ten minutes
+   * apiece. `fireIdle` runs whatever is currently armed, if anything.
+   */
+  idleArmed: () => boolean;
+  idleDelayMs: () => number | undefined;
+  fireIdle: () => void;
+}
+
+interface HeldTimer {
+  callback: () => void;
+  delayMs: number;
+  cancelled: boolean;
 }
 
 function observedSession(
@@ -86,8 +102,11 @@ function harness(
     carryAction?: SessionActionCarrier;
     carryAppAction?: AppActionCarrier;
     carryIssueAction?: IssueActionCarrier;
+    idleTimeoutMs?: number;
   } = {},
 ): Harness {
+  const timers: HeldTimer[] = [];
+  const armedTimer = (): HeldTimer | undefined => timers.findLast((timer) => !timer.cancelled);
   const sent: Record<string, unknown>[] = [];
   const errors: (string | undefined)[] = [];
   const captions: (string | undefined)[] = [];
@@ -175,6 +194,15 @@ function harness(
       ? {}
       : { connectTimeoutMs: options.connectTimeoutMs }),
     ...(options.now ? { now: options.now } : {}),
+    ...(options.idleTimeoutMs === undefined ? {} : { idleTimeoutMs: options.idleTimeoutMs }),
+    schedule: (callback, delayMs) => {
+      const timer: HeldTimer = { callback, delayMs, cancelled: false };
+      timers.push(timer);
+      return timer;
+    },
+    cancel: (timer) => {
+      (timer as HeldTimer).cancelled = true;
+    },
     ...(options.carryAction ? { carryAction: options.carryAction } : {}),
     ...(options.carryAppAction ? { carryAppAction: options.carryAppAction } : {}),
     ...(options.carryIssueAction ? { carryIssueAction: options.carryIssueAction } : {}),
@@ -220,8 +248,37 @@ function harness(
     },
     requests,
     calls,
+    idleArmed: () => armedTimer() !== undefined,
+    idleDelayMs: () => armedTimer()?.delayMs,
+    fireIdle: () => {
+      armedTimer()?.callback();
+    },
     transceivers,
   };
+}
+
+const CONVERSATION_ITEM_DELETE = REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_DELETE;
+
+/** The words one context item carries, or nothing when the event is not one. */
+function itemText(event: Record<string, unknown> | undefined): string {
+  const item = event?.item as { content?: { text?: string }[] } | undefined;
+  return item?.content?.[0]?.text ?? "";
+}
+
+/** The context items of one kind that were sent, named by their own label. */
+function contextItems(context: Harness, label: string, from = 0): Record<string, unknown>[] {
+  return context.sent
+    .slice(from)
+    .filter(
+      (event) =>
+        event.type === REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE &&
+        itemText(event).startsWith(label),
+    );
+}
+
+/** The errors actually shown, past the clearing every connect starts with. */
+function reportedErrors(context: Harness): string[] {
+  return context.errors.filter((message): message is string => message !== undefined);
 }
 
 test("connecting opens the call and leaves the microphone closed", async () => {
@@ -775,13 +832,20 @@ test("an error instead of response.done still frees the turn", async () => {
   assert.equal(context.session.startListening(), true);
 });
 
-test("the conversation is told which sessions Luke can see", async () => {
+test("the conversation is told which sessions Luke can see, at the turn that reads them", async () => {
   const context = harness();
   await context.session.connect();
 
   context.session.updateSessions([
     observedSession("session-a", { status: SESSION_STATUS.WAITING, recap: "Waiting on input." }),
   ]);
+
+  // Nothing yet: a roster nobody has asked about is an answer waiting to be
+  // given, not an item to keep in the conversation.
+  assert.deepEqual(context.sent, []);
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+
+  armDeveloperTurn(context);
 
   const item = context.sent.find(
     (event) => event.type === REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE,
@@ -790,26 +854,129 @@ test("the conversation is told which sessions Luke can see", async () => {
   assert.ok(text.includes("Claude Code"));
   assert.ok(text.includes("waiting"));
   assert.ok(text.includes("Waiting on input."));
-  // Context must not make Luke start talking on its own.
-  assert.equal(
-    context.sent.filter((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE).length,
-    0,
+  // And it goes in ahead of the turn it is answering, not after it.
+  const rosterIndex = context.sent.indexOf(item as Record<string, unknown>);
+  const commitIndex = context.sent.findIndex(
+    (event) => event.type === REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_COMMIT,
   );
+  assert.ok(rosterIndex >= 0 && rosterIndex < commitIndex);
+});
+
+test("a roster that churns between turns is only ever said once", async () => {
+  const context = harness();
+  await context.session.connect();
+
+  // Five seconds apart, all day: the poll sees a working session tick over and
+  // the rendered roster differs every time. None of it is worth an item until
+  // somebody asks — otherwise the developer's own earlier turns are what gets
+  // evicted to make room for a status that has already changed again.
+  for (const recap of ["Reading files.", "Editing.", "Running tests.", "Waiting on input."]) {
+    context.session.updateSessions([observedSession("session-a", { recap })]);
+  }
+  assert.deepEqual(context.sent, []);
+
+  armDeveloperTurn(context);
+
+  const rosters = contextItems(context, "[observed session status");
+  assert.equal(rosters.length, 1);
+  // The newest one, not the first: the turn is answered from what is true now.
+  assert.match(itemText(rosters[0]), /Waiting on input\./);
+});
+
+test("a fresh roster replaces the item the last one occupied", async () => {
+  const context = harness();
+  await context.session.connect();
+
+  context.session.updateSessions([observedSession("session-a", { recap: "Editing." })]);
+  armDeveloperTurn(context);
+  const first = context.session.liveContextItemIds.get(CONTEXT_ITEM_KIND.SESSIONS);
+  assert.ok(first);
+
+  context.session.updateSessions([observedSession("session-a", { recap: "Waiting on input." })]);
+  context.session.stopSpeaking();
+  const sentBefore = context.sent.length;
+  armDeveloperTurn(context);
+
+  // The old item is deleted, then the new one created — in that order, on a
+  // channel that keeps it, so the conversation never holds two rosters.
+  const events = context.sent.slice(sentBefore);
+  const deleteIndex = events.findIndex((event) => event.type === CONVERSATION_ITEM_DELETE);
+  const createIndex = events.findIndex(
+    (event) => event.type === REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE,
+  );
+  assert.ok(deleteIndex >= 0 && deleteIndex < createIndex);
+  assert.equal((events[deleteIndex] as { item_id?: string }).item_id, first);
+
+  const second = context.session.liveContextItemIds.get(CONTEXT_ITEM_KIND.SESSIONS);
+  assert.ok(second);
+  assert.notEqual(second, first);
+});
+
+test("a supersede the server refuses is this call's own business", async () => {
+  const context = harness();
+  await context.session.connect();
+
+  context.session.updateSessions([observedSession("session-a", { recap: "Editing." })]);
+  armDeveloperTurn(context);
+  const superseded = context.session.liveContextItemIds.get(CONTEXT_ITEM_KIND.SESSIONS);
+
+  context.session.updateSessions([observedSession("session-a", { recap: "Waiting." })]);
+  context.session.stopSpeaking();
+  armDeveloperTurn(context);
+  const supersede = context.sent.findLast((event) => event.type === CONVERSATION_ITEM_DELETE) as {
+    event_id?: string;
+  };
+
+  // The item was already gone — evicted at the window's edge is how that
+  // happens — so the delete is answered with an error naming the event we sent.
+  // It is not a fault of the developer's and must not be shown as one, nor end
+  // the reply they are listening to.
+  context.emit({
+    type: REALTIME_SERVER_EVENT.ERROR,
+    error: {
+      type: "invalid_request_error",
+      message: `Item with id '${superseded}' not found.`,
+      event_id: supersede.event_id,
+    },
+  });
+
+  assert.deepEqual(reportedErrors(context), []);
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+});
+
+test("an error that is not ours is still reported and still ends the turn", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.session.updateSessions([observedSession("session-a")]);
+  armDeveloperTurn(context);
+
+  context.emit({
+    type: REALTIME_SERVER_EVENT.ERROR,
+    error: { type: "invalid_request_error", message: "The commit held no audio." },
+  });
+
+  assert.deepEqual(reportedErrors(context), ["The commit held no audio."]);
   assert.equal(context.session.status, REALTIME_STATUS.READY);
 });
 
 test("an unchanged session roster is not resent", async () => {
   const context = harness();
   await context.session.connect();
-  const roster = [observedSession("session-a")];
 
-  context.session.updateSessions(roster);
   context.session.updateSessions([observedSession("session-a")]);
+  armDeveloperTurn(context);
+  const sentBefore = context.sent.length;
 
+  // The same roster again, and another turn: there is nothing new to say, so
+  // nothing is said and the item already standing keeps its place.
+  context.session.updateSessions([observedSession("session-a")]);
+  context.session.stopSpeaking();
+  armDeveloperTurn(context);
+
+  assert.deepEqual(contextItems(context, "[observed session status", sentBefore), []);
   assert.equal(
-    context.sent.filter((event) => event.type === REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE)
-      .length,
-    1,
+    context.sent.slice(sentBefore).some((event) => event.type === CONVERSATION_ITEM_DELETE),
+    false,
   );
 });
 
@@ -1737,56 +1904,30 @@ test("a spoken ask for a new workspace is carried, and an unlisted project is re
     },
   });
   await context.session.connect();
-  const sentBeforeContext = context.sent.length;
-  context.session.updateWorkspaceProjects([
-    {
-      providerId: "conductor",
-      providerName: "Conductor",
-      providerProjectId: "proj-1",
-      repository: "luke",
-      taskSupport: "optional",
-    },
-  ]);
+  const project = {
+    providerId: "conductor",
+    providerName: "Conductor",
+    providerProjectId: "proj-1",
+    repository: "luke",
+    taskSupport: "optional",
+  } as const;
+  context.session.updateWorkspaceProjects([project]);
   // The projects travel as context the way the roster does, and an identical
   // list is not resent.
-  const contextEvent = context.sent.slice(sentBeforeContext).at(0);
-  assert.match(
-    ((contextEvent?.item as { content?: { text?: string }[] } | undefined)?.content?.[0]?.text ??
-      "") as string,
-    /^\[workspace projects, sent automatically\]/,
-  );
-  context.session.updateWorkspaceProjects([
-    {
-      providerId: "conductor",
-      providerName: "Conductor",
-      providerProjectId: "proj-1",
-      repository: "luke",
-      taskSupport: "optional",
-    },
-  ]);
-  assert.equal(context.sent.length, sentBeforeContext + 1);
+  context.session.updateWorkspaceProjects([project]);
+  armDeveloperTurn(context);
+  assert.equal(contextItems(context, "[workspace projects").length, 1);
+
   // The default provider is part of the same answer, so choosing one is news
   // even while the list itself has not moved.
-  context.session.updateWorkspaceProjects(
-    [
-      {
-        providerId: "conductor",
-        providerName: "Conductor",
-        providerProjectId: "proj-1",
-        repository: "luke",
-        taskSupport: "optional",
-      },
-    ],
-    "conductor",
-  );
-  assert.equal(context.sent.length, sentBeforeContext + 2);
-  assert.match(
-    ((context.sent.at(-1)?.item as { content?: { text?: string }[] } | undefined)?.content?.[0]
-      ?.text ?? "") as string,
-    /default provider for new workspaces is Conductor/,
-  );
-
+  const sentBeforeDefault = context.sent.length;
+  context.session.updateWorkspaceProjects([project], "conductor");
+  context.session.stopSpeaking();
   armDeveloperTurn(context);
+  const chosen = contextItems(context, "[workspace projects", sentBeforeDefault);
+  assert.equal(chosen.length, 1);
+  assert.match(itemText(chosen[0]), /default provider for new workspaces is Conductor/);
+
   const sentBefore = context.sent.length;
 
   context.emit({
@@ -2197,30 +2338,27 @@ const CAPTIONS_GUIDE: AppGuideSnapshot = {
 test("the app guide reaches the conversation, and identical guides are not resent", async () => {
   const context = harness();
   await context.session.connect();
-  const sentBefore = context.sent.length;
 
   context.session.updateGuide(CAPTIONS_GUIDE);
-  // The same knowledge again is not news; a changed value is.
+  // The same knowledge again is not news; a changed value is. Neither is worth
+  // an item on its own — the turn that asks is what collects the latest.
   context.session.updateGuide({ ...CAPTIONS_GUIDE });
+  armDeveloperTurn(context);
+  assert.equal(contextItems(context, "[app guide").length, 1);
+
+  const sentBefore = context.sent.length;
   context.session.updateGuide({
     ...CAPTIONS_GUIDE,
     settings: [
       { ...CAPTIONS_GUIDE.settings[0], value: "on" } as (typeof CAPTIONS_GUIDE.settings)[0],
     ],
   });
+  context.session.stopSpeaking();
+  armDeveloperTurn(context);
 
-  const guideEvents = context.sent.slice(sentBefore).filter((event) => {
-    const item = event.item as { content?: { text?: string }[] } | undefined;
-    return item?.content?.[0]?.text?.startsWith("[app guide") === true;
-  });
-  assert.equal(guideEvents.length, 2);
-  // Context, not a prompt: telling Luke about himself never opens his mouth.
-  assert.equal(
-    context.sent
-      .slice(sentBefore)
-      .some((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE),
-    false,
-  );
+  const guideEvents = contextItems(context, "[app guide", sentBefore);
+  assert.equal(guideEvents.length, 1);
+  assert.match(itemText(guideEvents[0]), /on/);
 });
 
 test("a spoken settings change is validated against the guide and carried", async () => {
@@ -2547,26 +2685,19 @@ test("the conversation is told which issues the tracker lists", async () => {
   await context.session.connect();
 
   context.session.updateIssues([trackedIssue()]);
+  armDeveloperTurn(context);
 
-  const contextEvent = context.sent.find((event) => {
-    const item = event.item as { content?: { text?: string }[] } | undefined;
-    return item?.content?.[0]?.text?.includes("[observed issue tracker, sent automatically]");
-  });
+  const [contextEvent] = contextItems(context, "[observed issue tracker");
   assert.ok(contextEvent, "the issue roster was sent");
-  const text =
-    (contextEvent?.item as { content?: { text?: string }[] } | undefined)?.content?.[0]?.text ?? "";
-  assert.match(text, /LUKE-123/);
-  assert.match(text, /states: Done/);
-  // Context is never a prompt: nothing here asks Luke to start talking.
-  assert.equal(
-    context.sent.some((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE),
-    false,
-  );
+  assert.match(itemText(contextEvent), /LUKE-123/);
+  assert.match(itemText(contextEvent), /states: Done/);
 
-  // An unchanged roster is not resent.
+  // An unchanged roster is not resent, however many turns go by.
   const sentBefore = context.sent.length;
   context.session.updateIssues([trackedIssue()]);
-  assert.equal(context.sent.length, sentBefore);
+  context.session.stopSpeaking();
+  armDeveloperTurn(context);
+  assert.deepEqual(contextItems(context, "[observed issue tracker", sentBefore), []);
 });
 
 test("a spoken issue ask is carried through its own carrier and voiced", async () => {
@@ -2783,33 +2914,51 @@ test("a tracker that disconnects withdraws the roster, and a reconnect resends i
   const context = harness();
   await context.session.connect();
   context.session.updateIssues([trackedIssue()]);
+  armDeveloperTurn(context);
+  const board = context.session.liveContextItemIds.get(CONTEXT_ITEM_KIND.ISSUES);
+  assert.ok(board);
   const sentBefore = context.sent.length;
 
   // Disconnecting is news once; staying disconnected is not.
   context.session.updateIssues(undefined);
   context.session.updateIssues(undefined);
+  context.session.stopSpeaking();
+  armDeveloperTurn(context);
 
-  const withdrawals = context.sent.slice(sentBefore).filter((event) => {
-    const item = event.item as { content?: { text?: string }[] } | undefined;
-    return item?.content?.[0]?.text?.includes("no longer connected") === true;
-  });
+  const withdrawals = contextItems(context, "[observed issue tracker", sentBefore).filter((event) =>
+    itemText(event).includes("no longer connected"),
+  );
   assert.equal(withdrawals.length, 1);
+  // The withdrawal takes the board's place rather than sitting beside it: an
+  // answer of "none" is still the answer to the standing question.
+  assert.equal(
+    context.sent
+      .slice(sentBefore)
+      .some(
+        (event) =>
+          event.type === CONVERSATION_ITEM_DELETE &&
+          (event as { item_id?: string }).item_id === board,
+      ),
+    true,
+  );
 
-  // The same roster arriving again after a reconnect is news again: the
-  // conversation was told to disregard it, so it has to be retold.
+  // The same roster arriving again after a reconnect is news again.
+  const reconnectBefore = context.sent.length;
   context.session.updateIssues([trackedIssue()]);
-  const rosters = context.sent.slice(sentBefore).filter((event) => {
-    const item = event.item as { content?: { text?: string }[] } | undefined;
-    return item?.content?.[0]?.text?.includes("LUKE-123") === true;
-  });
+  context.session.stopSpeaking();
+  armDeveloperTurn(context);
+  const rosters = contextItems(context, "[observed issue tracker", reconnectBefore).filter(
+    (event) => itemText(event).includes("LUKE-123"),
+  );
   assert.equal(rosters.length, 1);
 
-  // A conversation never told about a board has nothing to withdraw.
+  // A conversation never told about a board has nothing to withdraw, and must
+  // not say a tracker is "no longer" connected when none ever was.
   const fresh = harness();
   await fresh.session.connect();
-  const freshBefore = fresh.sent.length;
   fresh.session.updateIssues(undefined);
-  assert.equal(fresh.sent.length, freshBefore);
+  armDeveloperTurn(fresh);
+  assert.deepEqual(contextItems(fresh, "[observed issue tracker"), []);
 });
 
 test("a speak-only connect never asks for the microphone", async () => {
@@ -2875,6 +3024,86 @@ test("the rosters and the guide never travel on Luke's own call", async () => {
   // The stores still updated — the developer's next call starts current — but
   // nothing left on this one beyond the sentence it exists to say.
   assert.equal(context.sent.length, before);
+});
+
+test("an idle call is put away, and a call being used is not", async () => {
+  const context = harness();
+  await context.session.connect();
+
+  // Settled and unused: the clock is running.
+  assert.equal(context.idleArmed(), true);
+  assert.equal(context.idleDelayMs(), VOICE_IDLE_TIMEOUT_MS);
+
+  // A turn stops it. A call someone is talking on is never put away underneath
+  // them, however long the turn runs.
+  context.session.startListening();
+  assert.equal(context.idleArmed(), false);
+  context.session.stopListening(false);
+  assert.equal(context.idleArmed(), true);
+
+  context.fireIdle();
+
+  // The device is released with the call: the whole point of retiring one is
+  // that the macOS microphone indicator stops standing for nothing.
+  assert.equal(context.session.status, REALTIME_STATUS.IDLE);
+  assert.equal(context.microphoneStopped(), true);
+});
+
+test("an idle call that was taken up in the meantime is left alone", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.session.startListening();
+
+  // Ten minutes is long enough for the timer to fire against a call that has
+  // since been taken up, so the decision is made again at the moment of it.
+  context.fireIdle();
+
+  assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
+});
+
+test("Luke's own call is not on the developer's idle clock", async () => {
+  const context = harness();
+
+  await context.session.connect({ microphone: false });
+
+  // It holds no device and already puts itself away once its queue is quiet.
+  assert.equal(context.idleArmed(), false);
+});
+
+test("a call that drops mid-conversation says the thread is lost", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.session.updateSessions([observedSession("session-a")]);
+  armDeveloperTurn(context);
+
+  // The service ends every session at an hour, so this is how a long
+  // conversation ordinarily ends rather than an exotic failure.
+  context.closeChannel();
+
+  assert.equal(context.session.status, REALTIME_STATUS.IDLE);
+  assert.match(reportedErrors(context).at(-1) ?? "", /lost the thread/i);
+});
+
+test("a call that drops before anything was said goes quietly", async () => {
+  const context = harness();
+  await context.session.connect();
+
+  context.closeChannel();
+
+  // Nothing was lost, so there is nothing to report: a notice here would be a
+  // fault shown for a conversation that never happened.
+  assert.equal(context.session.status, REALTIME_STATUS.IDLE);
+  assert.deepEqual(reportedErrors(context), []);
+});
+
+test("a call put away on purpose does not report itself as lost", async () => {
+  const context = harness();
+  await context.session.connect();
+  armDeveloperTurn(context);
+
+  await context.session.close();
+
+  assert.deepEqual(reportedErrors(context), []);
 });
 
 test("the developer's call replaces Luke's own and keeps the waiting press", async () => {

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -172,6 +172,7 @@ export {
   REALTIME_CALLS_PATH,
   REALTIME_CLIENT_SECRETS_PATH,
   REALTIME_MINT_OUTCOME,
+  REALTIME_TRUNCATION,
   type RealtimeConnection,
   type RealtimeDiagnostics,
   type RealtimeMintOutcome,
@@ -182,6 +183,12 @@ export {
 } from "./realtime-credentials";
 export {
   appGuideContextEvents,
+  CONTEXT_ITEM_KIND,
+  type ContextItemKind,
+  contextItemId,
+  contextSupersedeEventId,
+  contextSupersedeEvents,
+  ISSUE_TRACKER_DISCONNECTED_TEXT,
   issueContextEvents,
   issueContextText,
   issueTrackerDisconnectedEvents,

--- a/packages/sidecar-core/src/realtime-context.ts
+++ b/packages/sidecar-core/src/realtime-context.ts
@@ -85,14 +85,80 @@ export function sessionContextText(sessions: readonly NormalizedSession[]): stri
 }
 
 /**
+ * The kinds of context a conversation is told, each of which answers exactly
+ * one standing question: what Luke can see, where he can create, what he knows
+ * about himself, and what the tracker lists.
+ *
+ * A kind holds one live item at a time. Saying it again replaces the item that
+ * said it before rather than adding a second answer beside the first, because
+ * a conversation holding nine rosters is holding eight wrong ones — and paying
+ * for all nine out of a window the developer's own turns are evicted from.
+ */
+export const CONTEXT_ITEM_KIND = {
+  SESSIONS: "sessions",
+  WORKSPACE_PROJECTS: "workspace-projects",
+  APP_GUIDE: "app-guide",
+  ISSUES: "issues",
+} as const;
+
+export type ContextItemKind = (typeof CONTEXT_ITEM_KIND)[keyof typeof CONTEXT_ITEM_KIND];
+
+/**
+ * Names the item one context update will occupy, so the update after it has
+ * something to delete. The Realtime API lets the client name an item on
+ * creation, which is what makes a replacement possible without waiting to be
+ * told the server's own name for it.
+ *
+ * The sequence rises rather than the name being reused: a delete that failed
+ * would otherwise leave the old item sitting under the name the new one is
+ * about to claim. This composes a wire identifier, not a lookup key — nothing
+ * indexes on it, and both halves are the build's own.
+ */
+export function contextItemId(kind: ContextItemKind, sequence: number): string {
+  return `luke_ctx_${kind}_${sequence}`;
+}
+
+/** Names the delete itself, so the error a failed one answers with is known as ours. */
+export function contextSupersedeEventId(sequence: number): string {
+  return `luke_supersede_${sequence}`;
+}
+
+/**
+ * Builds the event that removes the context item a fresher one is replacing.
+ *
+ * Only ever aimed at an item this build named and created. Deleting an item
+ * the conversation does not hold is answered with an error rather than
+ * silence, which is why the event is named: the caller keeps the name and
+ * knows the answer for its own rather than reporting it to the developer as a
+ * fault in their call.
+ */
+export function contextSupersedeEvents(input: {
+  itemId: string;
+  eventId: string;
+}): readonly Record<string, unknown>[] {
+  if (!input.itemId.trim() || !input.eventId.trim()) return [];
+  return [
+    {
+      type: REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_DELETE,
+      event_id: input.eventId,
+      item_id: input.itemId,
+    },
+  ];
+}
+
+/**
  * The conversation.item.create envelope every roster update travels in. A
  * user-role item is universally accepted by the Realtime API, and the explicit
  * label keeps it from reading as something the developer said.
+ *
+ * The item is named on creation so a fresher answer of the same kind can take
+ * its place rather than pile up beside it.
  */
-function labeledContextEvent(label: string, text: string): Record<string, unknown> {
+function labeledContextEvent(label: string, text: string, itemId: string): Record<string, unknown> {
   return {
     type: REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE,
     item: {
+      id: itemId,
       type: "message",
       role: "user",
       content: [{ type: "input_text", text: `[${label}]\n${text}` }],
@@ -110,11 +176,13 @@ function labeledContextEvent(label: string, text: string): Record<string, unknow
  */
 export function sessionContextEvents(
   sessions: readonly NormalizedSession[],
+  itemId: string,
 ): readonly Record<string, unknown>[] {
   return [
     labeledContextEvent(
       "observed session status, sent automatically",
       sessionContextText(sessions),
+      itemId,
     ),
   ];
 }
@@ -170,9 +238,14 @@ export function issueContextText(issues: readonly TrackedIssue[]): string {
  */
 export function issueContextEvents(
   issues: readonly TrackedIssue[],
+  itemId: string,
 ): readonly Record<string, unknown>[] {
   return [
-    labeledContextEvent("observed issue tracker, sent automatically", issueContextText(issues)),
+    labeledContextEvent(
+      "observed issue tracker, sent automatically",
+      issueContextText(issues),
+      itemId,
+    ),
   ];
 }
 
@@ -182,11 +255,14 @@ export function issueContextEvents(
  * board would keep answering from it — so the disconnection is news the same
  * way the roster was, and just as deliberately not a prompt.
  */
-export function issueTrackerDisconnectedEvents(): readonly Record<string, unknown>[] {
+export const ISSUE_TRACKER_DISCONNECTED_TEXT = "The issue tracker is no longer connected.";
+
+export function issueTrackerDisconnectedEvents(itemId: string): readonly Record<string, unknown>[] {
   return [
     labeledContextEvent(
       "observed issue tracker, sent automatically",
-      "The issue tracker is no longer connected. Disregard earlier issue rosters.",
+      ISSUE_TRACKER_DISCONNECTED_TEXT,
+      itemId,
     ),
   ];
 }
@@ -329,6 +405,7 @@ const TASK_SUPPORT_TEXT: Readonly<Record<string, string>> = {
  */
 export function workspaceProjectContextEvents(
   projects: readonly ObservedWorkspaceProject[],
+  itemId: string,
   defaultProviderId?: string,
   defaultProjectIds?: Readonly<Partial<Record<string, string>>>,
 ): readonly Record<string, unknown>[] {
@@ -336,6 +413,7 @@ export function workspaceProjectContextEvents(
     labeledContextEvent(
       "workspace projects, sent automatically",
       workspaceProjectContextText(projects, defaultProviderId, defaultProjectIds),
+      itemId,
     ),
   ];
 }
@@ -346,6 +424,9 @@ export function workspaceProjectContextEvents(
  * standing instructions describe a guide, so one has to actually arrive, and
  * it must never open Luke's mouth by itself — context, not a prompt.
  */
-export function appGuideContextEvents(guide: AppGuideSnapshot): readonly Record<string, unknown>[] {
-  return [labeledContextEvent("app guide, sent automatically", appGuideContextText(guide))];
+export function appGuideContextEvents(
+  guide: AppGuideSnapshot,
+  itemId: string,
+): readonly Record<string, unknown>[] {
+  return [labeledContextEvent("app guide, sent automatically", appGuideContextText(guide), itemId)];
 }

--- a/packages/sidecar-core/src/realtime-credentials.ts
+++ b/packages/sidecar-core/src/realtime-credentials.ts
@@ -44,6 +44,24 @@ function trimmedText(value: string | undefined): string | undefined {
 }
 
 /**
+ * How the conversation gives way at the edge of the model's window.
+ *
+ * Eviction happens either way; the only question is whether the build chose
+ * it. Left unset, the service trims the least it can get away with, which
+ * means a conversation sitting at the ceiling trims again on every single turn
+ * and moves the cached prefix every time it does. Trimming a fifth of the
+ * window in one go instead is one cache miss rather than a run of them.
+ *
+ * What is evicted is the oldest of what remains, and the oldest of what remains
+ * is the developer's own earlier turns — which is the argument for the context
+ * items superseding themselves rather than piling up beside those turns.
+ */
+export const REALTIME_TRUNCATION = {
+  TYPE: "retention_ratio",
+  RETENTION_RATIO: 0.8,
+} as const;
+
+/**
  * Builds the session a client secret is minted against. Turn detection is
  * disabled outright so the developer, not a voice-activity heuristic, decides
  * when Luke is listening — an always-open microphone is exactly what a sidecar
@@ -57,6 +75,10 @@ export function realtimeSessionConfig(options: RealtimeSessionOptions = {}) {
     tools: realtimeToolDefinitions(),
     // Auto for the conversation; each proactive readout narrows itself to none.
     tool_choice: "auto",
+    truncation: {
+      type: REALTIME_TRUNCATION.TYPE,
+      retention_ratio: REALTIME_TRUNCATION.RETENTION_RATIO,
+    },
     audio: {
       input: {
         turn_detection: null,

--- a/packages/sidecar-core/src/realtime-protocol.ts
+++ b/packages/sidecar-core/src/realtime-protocol.ts
@@ -44,6 +44,13 @@ export const REALTIME_CLIENT_EVENT = {
   INPUT_AUDIO_BUFFER_COMMIT: "input_audio_buffer.commit",
   INPUT_AUDIO_BUFFER_CLEAR: "input_audio_buffer.clear",
   CONVERSATION_ITEM_CREATE: "conversation.item.create",
+  /**
+   * Removes an item from the conversation. Only ever used on context Luke
+   * himself put there — a roster, a guide, a projects list, an issue board —
+   * and only to make room for the same context said again. Nothing the
+   * developer said is ever deleted.
+   */
+  CONVERSATION_ITEM_DELETE: "conversation.item.delete",
   RESPONSE_CREATE: "response.create",
   RESPONSE_CANCEL: "response.cancel",
   /**
@@ -63,6 +70,8 @@ export const REALTIME_CLIENT_EVENT = {
 
 export const REALTIME_SERVER_EVENT = {
   RESPONSE_CREATED: "response.created",
+  /** The server confirming a superseded context item is gone. */
+  CONVERSATION_ITEM_DELETED: "conversation.item.deleted",
   /** The server confirming it dropped the audio it had queued for us. */
   OUTPUT_AUDIO_BUFFER_CLEARED: "output_audio_buffer.cleared",
   /** Names the message a reply is being spoken into, which is what a truncate cuts. */
@@ -382,7 +391,13 @@ export type ParsedRealtimeServerEvent =
       responseId?: string;
       calls: readonly RealtimeFunctionCall[];
     }
-  | { type: typeof REALTIME_SERVER_EVENT.ERROR; message: string };
+  | { type: typeof REALTIME_SERVER_EVENT.CONVERSATION_ITEM_DELETED; itemId?: string }
+  /**
+   * `eventId` names the client event the service is complaining about, when it
+   * says. It is what lets a caller tell an error meant for the developer from
+   * the answer to something it asked for itself.
+   */
+  | { type: typeof REALTIME_SERVER_EVENT.ERROR; message: string; eventId?: string };
 
 function optionalString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
@@ -480,11 +495,21 @@ export function parseRealtimeServerEvent(data: unknown): ParsedRealtimeServerEve
         ...(responseId ? { responseId } : {}),
       };
     }
+    case REALTIME_SERVER_EVENT.CONVERSATION_ITEM_DELETED: {
+      const itemId = optionalString(event.item_id);
+      return {
+        type: REALTIME_SERVER_EVENT.CONVERSATION_ITEM_DELETED,
+        ...(itemId ? { itemId } : {}),
+      };
+    }
     case REALTIME_SERVER_EVENT.ERROR: {
-      const message = optionalString(recordField(event, "error")?.message);
+      const error = recordField(event, "error");
+      const message = optionalString(error?.message);
+      const eventId = optionalString(error?.event_id);
       return {
         type: REALTIME_SERVER_EVENT.ERROR,
         message: message ?? "The voice service reported an error.",
+        ...(eventId ? { eventId } : {}),
       };
     }
     default:

--- a/packages/sidecar-core/tests/guide.test.ts
+++ b/packages/sidecar-core/tests/guide.test.ts
@@ -105,7 +105,7 @@ test("an empty guide says so rather than describing an app it was never told abo
 });
 
 test("the guide travels as context and never opens Luke's mouth", () => {
-  const events = appGuideContextEvents(GUIDE);
+  const events = appGuideContextEvents(GUIDE, "luke_ctx_app-guide_1");
 
   assert.equal(events.length, 1);
   assert.equal(events[0]?.type, REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE);

--- a/packages/sidecar-core/tests/realtime.test.ts
+++ b/packages/sidecar-core/tests/realtime.test.ts
@@ -4,9 +4,15 @@ import {
   ATTENTION_DISPOSITION,
   ATTENTION_SPEECH_SOURCE,
   ATTENTION_TRIGGER,
+  appGuideContextEvents,
   attentionSpeechFromReviews,
+  CONTEXT_ITEM_KIND,
   cancelResponseEvents,
   clearInputAudioEvents,
+  contextItemId,
+  contextSupersedeEventId,
+  contextSupersedeEvents,
+  EMPTY_APP_GUIDE,
   functionCallFollowUpEvents,
   functionCallOutputEvents,
   ISSUE_TRACKER_ID,
@@ -51,7 +57,7 @@ import {
   maximumVoiceContextSessions,
   maximumVoiceContextWorkspaceProjects,
 } from "../src/realtime-context";
-import { realtimeSessionConfig } from "../src/realtime-credentials";
+import { REALTIME_TRUNCATION, realtimeSessionConfig } from "../src/realtime-credentials";
 import {
   maximumTypedAskLength,
   REALTIME_SESSION_TYPE,
@@ -101,6 +107,89 @@ test("the minted session closes the microphone until push-to-talk opens it", () 
   // An always-open microphone is the one thing a desk-side sidecar must not have.
   assert.equal(config.audio.input.turn_detection, null);
   assert.equal(realtimeClientSecretRequest().session.type, REALTIME_SESSION_TYPE);
+});
+
+test("the minted session chooses how it gives way at the edge of the window", () => {
+  const config = realtimeSessionConfig();
+
+  // Eviction happens either way; left unset the service trims the least it can,
+  // which means trimming again on every turn once the ceiling is reached and
+  // moving the cached prefix every time. One larger trim is one cache miss.
+  assert.equal(config.truncation.type, REALTIME_TRUNCATION.TYPE);
+  assert.equal(config.truncation.retention_ratio, REALTIME_TRUNCATION.RETENTION_RATIO);
+  assert.ok(config.truncation.retention_ratio > 0 && config.truncation.retention_ratio <= 1);
+  assert.equal(realtimeClientSecretRequest().session.truncation.type, REALTIME_TRUNCATION.TYPE);
+});
+
+test("a context item is named so the next one can take its place", () => {
+  const first = contextItemId(CONTEXT_ITEM_KIND.SESSIONS, 1);
+  const second = contextItemId(CONTEXT_ITEM_KIND.SESSIONS, 2);
+
+  // The sequence rises rather than the name being reused: a delete that failed
+  // would otherwise leave the old item sitting under the new one's name.
+  assert.notEqual(first, second);
+  assert.notEqual(first, contextItemId(CONTEXT_ITEM_KIND.ISSUES, 1));
+
+  const [supersede] = contextSupersedeEvents({ itemId: first, eventId: "luke_supersede_2" });
+  assert.equal(supersede?.type, REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_DELETE);
+  assert.equal(supersede?.item_id, first);
+  // Named, so the error a refused delete answers with is known as ours rather
+  // than shown to the developer as a fault in their call.
+  assert.equal(supersede?.event_id, "luke_supersede_2");
+  assert.notEqual(contextSupersedeEventId(1), contextSupersedeEventId(2));
+
+  // Nothing to delete builds nothing, rather than an event the API would refuse.
+  assert.deepEqual(contextSupersedeEvents({ itemId: "", eventId: "luke_supersede_3" }), []);
+  assert.deepEqual(contextSupersedeEvents({ itemId: first, eventId: " " }), []);
+});
+
+test("every kind of context travels as one nameable item and never as a prompt", () => {
+  const built = [
+    sessionContextEvents([], contextItemId(CONTEXT_ITEM_KIND.SESSIONS, 1)),
+    workspaceProjectContextEvents([], contextItemId(CONTEXT_ITEM_KIND.WORKSPACE_PROJECTS, 2)),
+    appGuideContextEvents(EMPTY_APP_GUIDE, contextItemId(CONTEXT_ITEM_KIND.APP_GUIDE, 3)),
+    issueContextEvents([], contextItemId(CONTEXT_ITEM_KIND.ISSUES, 4)),
+    issueTrackerDisconnectedEvents(contextItemId(CONTEXT_ITEM_KIND.ISSUES, 5)),
+  ];
+
+  for (const events of built) {
+    assert.equal(events.length, 1);
+    const [event] = events;
+    assert.equal(event?.type, REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE);
+    const item = event?.item as { id?: string; role?: string };
+    // Named on creation, which is what makes a replacement possible without
+    // waiting to be told the server's own name for it.
+    assert.match(item?.id ?? "", /^luke_ctx_/);
+    assert.equal(item?.role, "user");
+    assert.equal(
+      events.some((candidate) => candidate.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE),
+      false,
+    );
+  }
+});
+
+test("a refused delete is read back with the event it names", () => {
+  // The caller tells its own delete's refusal from a fault meant for the
+  // developer by this name, so the wire has to carry it through.
+  const parsed = parseRealtimeServerEvent({
+    type: REALTIME_SERVER_EVENT.ERROR,
+    error: {
+      type: "invalid_request_error",
+      message: "Item with id 'luke_ctx_sessions_1' not found.",
+      event_id: "luke_supersede_2",
+    },
+  });
+
+  assert.equal(parsed?.type, REALTIME_SERVER_EVENT.ERROR);
+  assert.equal(parsed?.eventId, "luke_supersede_2");
+  assert.match(parsed?.message ?? "", /not found/);
+
+  const deleted = parseRealtimeServerEvent({
+    type: REALTIME_SERVER_EVENT.CONVERSATION_ITEM_DELETED,
+    item_id: "luke_ctx_sessions_1",
+  });
+  assert.equal(deleted?.type, REALTIME_SERVER_EVENT.CONVERSATION_ITEM_DELETED);
+  assert.equal(deleted?.itemId, "luke_ctx_sessions_1");
 });
 
 test("the standing instructions count the tools from the table", () => {
@@ -479,7 +568,7 @@ test("an empty roster says so rather than implying Luke sees nothing at all", ()
 });
 
 test("session context never asks Luke to start talking", () => {
-  const events = sessionContextEvents([]);
+  const events = sessionContextEvents([], "luke_ctx_sessions_1");
 
   assert.equal(events.length, 1);
   assert.equal(events[0]?.type, REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE);
@@ -797,13 +886,13 @@ test("the projects context lists each project with the identity a call names", (
   // imagine somewhere a workspace could go.
   assert.match(workspaceProjectContextText([]), /No provider currently offers/);
 
-  const [event] = workspaceProjectContextEvents([OFFERED_PROJECT]);
+  const [event] = workspaceProjectContextEvents([OFFERED_PROJECT], "luke_ctx_workspace-projects_1");
   assert.equal(event?.type, REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE);
   const item = (event as { item?: { content?: { text?: string }[] } }).item;
   assert.match(item?.content?.[0]?.text ?? "", /^\[workspace projects, sent automatically\]/);
   // Context, never a prompt: nothing here may open Luke's mouth.
   assert.equal(
-    workspaceProjectContextEvents([OFFERED_PROJECT]).some(
+    workspaceProjectContextEvents([OFFERED_PROJECT], "luke_ctx_workspace-projects_1").some(
       (candidate) => candidate.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE,
     ),
     false,
@@ -846,7 +935,11 @@ test("the projects context says where a nameless creation ask goes", () => {
   assert.doesNotMatch(away, /default provider/);
 
   // The default rides the same context event the list does.
-  const [event] = workspaceProjectContextEvents([OFFERED_PROJECT], "conductor");
+  const [event] = workspaceProjectContextEvents(
+    [OFFERED_PROJECT],
+    "luke_ctx_workspace-projects_2",
+    "conductor",
+  );
   const item = (event as { item?: { content?: { text?: string }[] } }).item;
   assert.match(item?.content?.[0]?.text ?? "", /default provider for new workspaces is Conductor/);
 });
@@ -890,9 +983,12 @@ test("the projects context says which project a nameless ask lands in", () => {
   assert.doesNotMatch(away, /No default Conductor project/);
 
   // The default rides the same context event the list does.
-  const [event] = workspaceProjectContextEvents([OFFERED_PROJECT, secondProject], undefined, {
-    conductor: "proj-2",
-  });
+  const [event] = workspaceProjectContextEvents(
+    [OFFERED_PROJECT, secondProject],
+    "luke_ctx_workspace-projects_3",
+    undefined,
+    { conductor: "proj-2" },
+  );
   const item = (event as { item?: { content?: { text?: string }[] } }).item;
   assert.match(item?.content?.[0]?.text ?? "", /default Conductor project is acme\/other/);
 });
@@ -1300,7 +1396,7 @@ test("issue context carries the roster and what each issue will take", () => {
 });
 
 test("issue context never asks Luke to start talking", () => {
-  const events = issueContextEvents([actionableIssue()]);
+  const events = issueContextEvents([actionableIssue()], "luke_ctx_issues_1");
 
   assert.equal(events.length, 1);
   assert.equal(events[0]?.type, REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE);
@@ -1415,7 +1511,7 @@ test("the session and issue tools answer to their own validators", () => {
 });
 
 test("a disconnected tracker withdraws the roster without starting a reply", () => {
-  const events = issueTrackerDisconnectedEvents();
+  const events = issueTrackerDisconnectedEvents("luke_ctx_issues_2");
 
   assert.equal(events.length, 1);
   assert.equal(events[0]?.type, REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE);


### PR DESCRIPTION
## What was wrong

The conversation between the developer and Luke *is* the Realtime call. There is no local transcript and no compaction — everything it holds lives server-side until the call ends.

Four kinds of context were appended to that conversation whenever they changed. Sessions refresh every five seconds and the rendered roster includes each session's status and recap, so during real work a fresh, full copy of the roster was written into the conversation every few seconds. Three consequences, in a `gpt-realtime` window of 32,768 tokens / 28,672 max input:

- Dozens of mutually contradictory rosters accumulate, and nothing marked the old ones dead. (The issue tracker had this right — `"Disregard earlier issue rosters"` — the session roster, guide, and projects list did not.)
- Eviction is oldest-first, so **what gets evicted to make room for churn is the developer's own earlier turns**.
- `truncation` was never set, so the service trimmed the least it could: once at the ceiling, it re-trims every turn and moves the cached prefix each time.

Separately, the developer's call had no idle timeout — one press of the talk key held a call, and the macOS microphone indicator, indefinitely. And when a call ended on its own, it went to idle silently. Realtime sessions hard-cap at **60 minutes**, so that ending was always coming, and Luke's answer to the next question came from someone who had never heard the last one.

## What changed

**One item per kind.** Context items are now named by the client on creation (`contextItemId`), and a fresh answer deletes the item it replaces before creating its replacement. The conversation holds exactly one roster, one guide, one projects list, one issue board — ever.

**Context is sent at the turn that reads it,** not when it changes. Item count is now bounded by turns the developer took rather than by roster churn, and the roster answering a question is the roster as of the moment it was asked.

**Truncation is a build decision** — `retention_ratio: 0.8`, one larger trim instead of a re-trim per turn.

**Idle calls are retired** after ten minutes with nothing said, releasing the capture device.

**A call that drops mid-conversation says so** rather than leaving Luke silently amnesic.

A delete the server refuses — because the item was already evicted — is recognised as ours by the `event_id` stamped on it and swallowed, rather than surfacing as a fault the developer neither caused nor can act on. `parseRealtimeServerEvent` now carries that `event_id` and `conversation.item.deleted` through. (The item id in the message is checked too, because the reference does not state the `error.event_id` field plainly, and a mismatch there would both show an error and end a reply mid-sentence.)

The guide learns how long a conversation lasts, since a fact it does not describe is one Luke denies having.

## Checks

`./scripts/check.sh` passes locally, exit 0 — lint, typecheck, 927 tests (34 harness + 155 core + 738 desktop), build.

**`./scripts/verify.sh` was not run locally: it requires macOS and this work was done on Linux.** No physical-notch check was performed by hand. There are no drawing, layout, or motion changes; the only visible surface is the new dropped-call message where `microphoneError` already renders, and the spoken guide fact. The `macOS app and evidence` CI job covers the packaged path.

## Notes

- Rebased onto current main twice: the branch was originally cut from a commit before #121 split `realtime.ts` into five files and before #142 added per-provider default projects, so the change was re-applied against both. Worth knowing that while the branch was conflicting, **no `pull_request` CI ran at all** — `TypeScript checks` and `macOS app and evidence` only appeared once the rebase made it mergeable.
- Sources for the API facts: [session truncation / retention_ratio](https://developers.openai.com/api/reference/resources/realtime/subresources/sessions/methods/create), [context management cookbook](https://developers.openai.com/cookbook/examples/context_summarization_with_realtime_api), [60-minute session cap](https://developers.openai.com/api/docs/guides/realtime-conversations).
- `git config user.email` was set repo-locally to the GitHub noreply address — the first push was rejected under your email privacy setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31968980142/artifacts/9269270687) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31968980142)

- Commit: `5ca70816e00530577fac092bbc6f3de0663c29d8`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
