### PR TITLE
docs: correct capability and privacy claims to match trust constraints

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -31,7 +31,10 @@ calls, and stop reasons to derive those fields and the session status.
 
 Luke does not modify provider files, retain raw records or message history,
 inject input, or require provider hooks or plugins. Observed fields are held in
-memory for the local display. Luke does not control provider sessions.
+memory for the local display. Observation itself never controls a provider
+session; see Optional cloud-provider reads and Optional issue-tracker reads
+and spoken acts below for the narrow, user-requested writes Luke makes
+elsewhere.
 
 ## Optional cloud-provider reads
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,12 @@ it takes a personal access token (`cog_…`, created under **Devin API · PATs**
 and refuses the deprecated `apk_` keys of v1 and v2. A token that belongs to a
 service user rather than to a person is refused too — Devin lists an
 organization's sessions, and Luke reports only the sessions belonging to whoever
-the token authenticates as. Every provider integration is read-only. None
-requires hooks, plugins, wrappers, or changes to how a session is launched.
+the token authenticates as. Every provider integration observes read-only, and
+none requires hooks, plugins, wrappers, or changes to how a session is
+launched. The only writes Luke makes are ones you directly ask for — a
+message, a control the provider advertised, or a new workspace, described
+below — sent through that provider's own documented endpoint and checked
+against the latest observed roster.
 
 ## Issue tracker support
 
@@ -79,8 +83,10 @@ ask, out loud or typed, through Linear's own GraphQL API under your key.
 - An optional spoken conversation, described below, lets you ask Luke about your
   sessions and hear the answer.
 
-Luke does not send commands to agents, inject terminal input, or expose agent
-controls.
+Luke never injects terminal input or simulates keystrokes. The messaging,
+controls, and workspace creation described above happen only when you
+directly ask for them, out loud or typed, through each provider's own
+documented endpoint.
 
 ## Talking to Luke
 
@@ -257,7 +263,10 @@ include the session title, recap, repository, branch, current tool activity, and
 reported error; see [PRIVACY.md](PRIVACY.md) for the exact boundary. It is the
 same one key as the spoken conversation described above, wherever you put it:
 connecting OpenAI in Settings enables both, and deleting it there disables both.
-The row says so where the key is entered. Neither enables agent control.
+The row says so where the key is entered. Attention review only classifies;
+nothing it decides reaches a write path. The spoken conversation can send a
+message or run a control, but only when you directly ask it to in a turn you
+open yourself.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |


### PR DESCRIPTION
## Summary

- README.md and PRIVACY.md carried blanket "read-only" / "no agent control" claims that contradicted the narrowly authorized, user-requested writes (messages, provider-advertised controls, workspace creation, issue-tracker actions) documented elsewhere in the same files and in AGENTS.md.
- Rewrote four claims: provider integration read-only scope (README), "exposes no agent controls" (README), "neither enables agent control" for attention review/voice (README), and "Luke does not control provider sessions" (PRIVACY.md) — each now precisely states that observation stays read-only while writes occur only on direct developer request, through documented provider endpoints, validated against the latest observed roster.
- No implementation changes; this is a documentation-only correction.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (lint, types, 724/724 tests, build)
- macOS Electron verification (`./scripts/verify.sh`): `not run` (docs-only change)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31968550577/artifacts/9269164169) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31968550577)

- Commit: `05334d861de6c813fdb43db08cd08feceaf573a7`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: None