### PR TITLE
fix(motion): mount Luke's meter behind the capsule's growing edge

### DIFF
--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -180,7 +180,14 @@ export function NotchWings({
             keeps: the rest unfold outward and never displace it. */}
         <div className="wing-inner">
           {meterShown ? (
-            <span className="wing-meter" data-turn={meterVoice}>
+            /* Keyed on whose turn it is, so each voice's meter is a fresh
+               mount: the arrival choreography lives in a starting style, and
+               only a mount reads one. Luke's turn is what grows the capsule,
+               and a meter the developer's turn already had on screen would
+               otherwise relocate beside the returning face on the frame the
+               turn flips — drawn on the desktop, ahead of an edge still most
+               of its travel away. */
+            <span className="wing-meter" data-turn={meterVoice} key={meterVoice}>
               <Waveform
                 analyser={analyser}
                 speaking={fixtureSpeaking}

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -439,6 +439,20 @@ button:disabled {
   transition-delay: calc(var(--duration-shape) - var(--duration-quick));
 }
 
+/* Luke's meter always mounts into this state already live — the turn is what
+   mounts it — and a transition only runs from a style the element has held.
+   This is the pose the meter would have waited in, the same answer the late
+   marks get below, so the crossing above actually runs instead of the meter
+   appearing over desktop the shape is still 300ms from covering. Only Luke's:
+   your own meter takes the face's place, where nothing grows, and must keep
+   appearing at once. */
+@starting-style {
+  .app-stage[data-presentation="capsule"][data-voice="luke"] .wing-meter[data-turn] {
+    opacity: 0;
+    transform: translateX(8px);
+  }
+}
+
 /* Luke's words follow him onto the shape: the compact states grow a caption
    block below the housing while there are words to draw. Gated on the words
    rather than on the turn, because the first of them arrives a beat after the


### PR DESCRIPTION
## What

In collapsed (capsule) mode, the waveform meter for Luke's reply appeared at full opacity on its first frame, ~16px past a black surface edge that was still ~300ms of spring travel away — drawn on the desktop instead of over black.

## Why

`base.css` already choreographs the arrival (`.app-stage[data-presentation="capsule"][data-voice="luke"] .wing-meter[data-turn]`): fade over `--duration-quick`, travel on `--spring`, both delayed by `--duration-shape − --duration-quick` so the meter crosses the last of the shape's travel and finishes as it settles. But that choreography is a **transition**, and in live use the meter never holds the pose it would transition from:

- **Announcement** (Luke speaks with no conversation open): the meter mounts already matching the live-turn rule (`opacity: 1`), so no transition runs.
- **Handoff** (developer releases the talk key, Luke replies): the meter is already on screen in the face's place; when the turn flips it relocates beside the returning face by layout on the frame the state changed, ahead of the growing edge.

Both violate DESIGN.md's rule for content joining a growing shape: *"It becomes visible only over black … delayed until the surface has grown under it."*

## How

Two small changes, both on existing precedent:

- **`base.css`**: a `@starting-style` block gives the freshly mounted meter the waiting pose (`opacity: 0; translateX(8px)`) so the existing arrival transition actually runs. Same mechanism the late-mounting wing marks already use, same two properties (the `@starting-style` caveat in DESIGN.md is about `clip-path`-class skips). Scoped to Luke's turn only — the developer's meter takes the face's place, where nothing grows, and must keep appearing at once.
- **`notch-wings.tsx`**: the meter span is keyed on whose turn it is, so the developer→Luke handoff is a fresh mount and rides the same arrival instead of teleporting into room the shape has not made yet.

## Proving it (per DESIGN.md)

Headless Chrome run sampling the moving edges per frame (real `motion-tokens.css` + `base.css`, the exact DOM the renderer draws), asserting the visible meter's edge never passes the surface's.

Before (both scenarios): meter at `opacity: 1` from t=17ms at x=307 while the surface's left edge is still at x=323 — **7 sampled frames drawn past the edge**.

After:

```
t= 17ms surfaceLeft=323.31 meterLeft=315.00 opacity=0
t=150ms surfaceLeft=305.17 meterLeft=315.00 opacity=0      ← edge passes the meter's slot
t=350ms surfaceLeft=297.62 meterLeft=314.38 opacity=0.099  ← fade begins at 320ms
t=417ms surfaceLeft=297.69 meterLeft=311.35 opacity=0.793
t=483ms surfaceLeft=298.00 meterLeft=308.79 opacity=1      ← lands as the shape settles
PASS: meter never drawn past the surface's edge            (announce and handoff both)
```

A third scenario confirms the developer's meter is unaffected: `opacity: 1` from its first frame.

## Checks

- `./scripts/check.sh`: pass (728 tests, 0 fail).
- `./scripts/verify.sh` requires macOS; not run in this Linux workspace — CI's evidence job covers the macOS run. Physical-notch check: not performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a776c390-8432-4e39-9bae-291b8db28e1a)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31969505066/artifacts/9269398738) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31969505066)

- Commit: `321f58625f2bfc2326048703579043eec8f0cfe2`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
