### PR TITLE
feat(conductor): report workspace lifecycle status on session rows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,14 +118,9 @@ What Luke may show:
   view — is read for a bounded tail of its transcript, and the last message's
   words become the recap only when that message is attributably the agent's
   and the chat is idle or closed: a settled turn's parting words say where the
-  work stands, where half a sentence mid-turn poses as an outcome. The same
-  fixed read returns one more bounded window, around the last pull-request
-  marker the transcript holds, and the address inside it is reported as the
-  session's published change only when it is whole and names the workspace's
-  own repository — an address into anywhere else is somebody else's work
-  being talked about. Both excerpts are inspected in memory and discarded —
-  the bounded recap and that one validated address are all that is ever
-  reported, and the history behind them is never read at all.
+  work stands, where half a sentence mid-turn poses as an outcome. The tail is
+  inspected in memory and discarded — the bounded recap is all that is ever
+  reported, and the history behind it is never read at all.
 - Session material leaves the machine unbidden in exactly two places, each
   with its own narrower rule. An evaluator receives `AttentionContext` — what
   a provider wrote *about* a session — and never the transcript behind it: no

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,9 +118,14 @@ What Luke may show:
   view — is read for a bounded tail of its transcript, and the last message's
   words become the recap only when that message is attributably the agent's
   and the chat is idle or closed: a settled turn's parting words say where the
-  work stands, where half a sentence mid-turn poses as an outcome. The tail is
-  inspected in memory and discarded — the bounded recap is all that is ever
-  reported, and the history behind it is never read at all.
+  work stands, where half a sentence mid-turn poses as an outcome. The same
+  fixed read returns one more bounded window, around the last pull-request
+  marker the transcript holds, and the address inside it is reported as the
+  session's published change only when it is whole and names the workspace's
+  own repository — an address into anywhere else is somebody else's work
+  being talked about. Both excerpts are inspected in memory and discarded —
+  the bounded recap and that one validated address are all that is ever
+  reported, and the history behind them is never read at all.
 - Session material leaves the machine unbidden in exactly two places, each
   with its own narrower rule. An evaluator receives `AttentionContext` — what
   a provider wrote *about* a session — and never the transcript behind it: no

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -56,14 +56,11 @@ describes.
   timestamps; model configuration; archive state; status and reported errors;
   and session deep links. For the sessions it observed, Luke also queries
   Conductor's transcripts view for each chat's agent kind, which speaker wrote
-  the transcript's last message, the bounded opening of that final message —
-  returned only when that speaker is the agent — and a bounded window around
-  the last pull-request address the transcript holds. Luke reports the final message's
-  words as the session's recap only while the chat is idle or closed, and the
-  pull-request address only when it is whole and names the workspace's own
-  repository. The excerpts are inspected in memory and discarded, the
-  conversation behind them is never requested, and nothing but the bounded
-  recap, agent kind, and validated pull-request link is reported.
+  the transcript's last message, and — only when that speaker is the agent —
+  the bounded opening of that final message. Luke reports its words as the
+  session's recap only while the chat is idle or closed. The excerpt is
+  inspected in memory and discarded, the conversation behind it is never
+  requested, and nothing but the bounded recap and agent kind is reported.
 - For Cursor, Luke reads agents owned by the supplied key and their latest runs,
   and — on a much slower cadence, within Cursor's documented limits — the list
   of repositories the key may launch agents in. It processes identifiers, agent

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -48,17 +48,22 @@ endpoint, under the same read-document boundary the Linear section below
 describes.
 
 - For Conductor, Luke reads the authenticated identity, projects, workspaces the
-  authenticated user created, sessions, and session statuses. It processes
+  authenticated user created, sessions, session statuses, and each open
+  workspace's lifecycle status — whether it is still being stood up, and the
+  failure message it carries when standing it up went wrong. It processes
   identifiers; project, workspace, and session names; repository names derived
   from Git remotes (or the project name when no usable remote is available);
   timestamps; model configuration; archive state; status and reported errors;
   and session deep links. For the sessions it observed, Luke also queries
   Conductor's transcripts view for each chat's agent kind, which speaker wrote
-  the transcript's last message, and — only when that speaker is the agent —
-  the bounded opening of that final message. Luke reports its words as the
-  session's recap only while the chat is idle or closed. The excerpt is
-  inspected in memory and discarded, the conversation behind it is never
-  requested, and nothing but the bounded recap and agent kind is reported.
+  the transcript's last message, the bounded opening of that final message —
+  returned only when that speaker is the agent — and a bounded window around
+  the last pull-request address the transcript holds. Luke reports the final message's
+  words as the session's recap only while the chat is idle or closed, and the
+  pull-request address only when it is whole and names the workspace's own
+  repository. The excerpts are inspected in memory and discarded, the
+  conversation behind them is never requested, and nothing but the bounded
+  recap, agent kind, and validated pull-request link is reported.
 - For Cursor, Luke reads agents owned by the supplied key and their latest runs,
   and — on a much slower cadence, within Cursor's documented limits — the list
   of repositories the key may launch agents in. It processes identifiers, agent

--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -52,7 +52,8 @@ const CONDUCTOR_DEFAULT_API_URL = "https://api.conductor.build";
 
 /**
  * Documented public API routes. The reads walk projects, workspaces, and
- * sessions; the writers are `POST …/sessions/{id}/messages`, which is
+ * sessions, and poll the status endpoints both of those document; the writers
+ * are `POST …/sessions/{id}/messages`, which is
  * Conductor's documented way to hand a prompt to an existing session — queued
  * while it is idle, steered into the running turn while it works —
  * `POST …/sessions/{id}/cancel`, which stops the current turn,
@@ -186,6 +187,7 @@ const CONDUCTOR_SQL_FIELD = {
   SESSION_ID: "session_id",
   AGENT_TYPE: "agent_type",
   TRANSCRIPT_TAIL: "transcript_tail",
+  CHANGE_WINDOW: "change_window",
 } as const;
 
 /**
@@ -193,6 +195,35 @@ const CONDUCTOR_SQL_FIELD = {
  * opening words — where an agent puts the outcome — and no more of it.
  */
 const CONDUCTOR_TRANSCRIPT_TAIL_LENGTH = 2_000;
+
+/**
+ * How a GitHub pull-request address marks itself inside a transcript. The
+ * window is anchored at the marker's last occurrence, because the freshest
+ * pull request a chat names is the one that says what it published.
+ */
+const CONDUCTOR_CHANGE_MARKER = "/pull/";
+
+/**
+ * How far a pull-request address can reach around its marker: GitHub bounds an
+ * owner at 39 characters and a repository at 100, so `https://github.com/` plus
+ * both names fits in 160 characters before the marker, and a pull number in 12
+ * after it. The window is sized to hold one whole address and nothing more.
+ */
+const CONDUCTOR_CHANGE_PREFIX_LENGTH = 160;
+const CONDUCTOR_CHANGE_SUFFIX_LENGTH = 12;
+
+/**
+ * A GitHub pull-request address, whole: the only shape the change window may
+ * yield. The owner and repository groups are what the address is validated
+ * against — it is reported only when it names the workspace's own repository,
+ * so a link an agent merely mentioned in passing about somewhere else never
+ * poses as this session's published work.
+ */
+const GITHUB_PULL_URL_PATTERN =
+  /https:\/\/github\.com\/([A-Za-z0-9-]+)\/([A-Za-z0-9._-]+)\/pull\/\d{1,10}/g;
+
+/** Where a GitHub remote names its owner and repository, however it is written. */
+const GITHUB_REMOTE_PATTERN = /github\.com[/:]([A-Za-z0-9-]+)\/([A-Za-z0-9._-]+?)(?:\.git)?\/?$/i;
 
 /**
  * How Conductor's plain-text transcript marks who is speaking. A line inside a
@@ -222,25 +253,34 @@ function sqlHeaderLiteral(header: string): string {
  * same pass reported — each validated as a UUID first, so no name, title, or
  * message a provider controls can ever be spliced into the document.
  *
- * The columns ask for the agent kind and the opening of the transcript's
- * final message — the settled turn's parting words — and never the
- * conversation behind it. Who wrote that message is computed in the view,
- * from whichever speaker header stands nearest the transcript's end, and the
- * returned tail is anchored at that header rather than cut at a fixed
- * distance: a fixed cut left any final message longer than the cut without
- * its header, which read as unattributable and silently cost most long-form
- * agents their recap. A chat whose user spoke last answers with no tail at
- * all.
+ * The columns ask for the agent kind, the opening of the transcript's final
+ * message — the settled turn's parting words — and a window around the last
+ * pull-request marker the transcript holds, and never the conversation behind
+ * them. Who wrote that message is computed in the view, from whichever
+ * speaker header stands nearest the transcript's end, and the returned tail
+ * is anchored at that header rather than cut at a fixed distance: a fixed cut
+ * left any final message longer than the cut without its header, which read
+ * as unattributable and silently cost most long-form agents their recap. A
+ * chat whose user spoke last answers with no tail at all. The change window
+ * is anchored the same way, at the marker's own last occurrence, and sized to
+ * one whole address: an agent that opened a pull request turns ago and kept
+ * working would otherwise have published work its final message no longer
+ * names.
  */
 const CONDUCTOR_READ_TRANSCRIPT_TAILS_PREFIX =
   `SELECT ${CONDUCTOR_SQL_FIELD.SESSION_ID}, ${CONDUCTOR_SQL_FIELD.AGENT_TYPE}, ` +
   `CASE WHEN assistant_from_end > 0 AND (user_from_end = 0 OR assistant_from_end < user_from_end) ` +
   `THEN SUBSTRING(transcript FROM GREATEST(LENGTH(transcript) - assistant_from_end - ${CONDUCTOR_ASSISTANT_HEADER.length - 2}, 1) ` +
   `FOR ${CONDUCTOR_ASSISTANT_HEADER.length + CONDUCTOR_TRANSCRIPT_TAIL_LENGTH}) ` +
-  `END AS ${CONDUCTOR_SQL_FIELD.TRANSCRIPT_TAIL} ` +
+  `END AS ${CONDUCTOR_SQL_FIELD.TRANSCRIPT_TAIL}, ` +
+  `CASE WHEN pull_from_end > 0 ` +
+  `THEN SUBSTRING(transcript FROM GREATEST(LENGTH(transcript) - pull_from_end - ${CONDUCTOR_CHANGE_MARKER.length - 2 + CONDUCTOR_CHANGE_PREFIX_LENGTH}, 1) ` +
+  `FOR ${CONDUCTOR_CHANGE_PREFIX_LENGTH + CONDUCTOR_CHANGE_MARKER.length + CONDUCTOR_CHANGE_SUFFIX_LENGTH}) ` +
+  `END AS ${CONDUCTOR_SQL_FIELD.CHANGE_WINDOW} ` +
   `FROM (SELECT ${CONDUCTOR_SQL_FIELD.SESSION_ID}, ${CONDUCTOR_SQL_FIELD.AGENT_TYPE}, transcript, ` +
   `position(reverse(${sqlHeaderLiteral(CONDUCTOR_ASSISTANT_HEADER)}) in reverse(transcript)) AS assistant_from_end, ` +
-  `position(reverse(${sqlHeaderLiteral(CONDUCTOR_USER_HEADER)}) in reverse(transcript)) AS user_from_end ` +
+  `position(reverse(${sqlHeaderLiteral(CONDUCTOR_USER_HEADER)}) in reverse(transcript)) AS user_from_end, ` +
+  `position(reverse('${CONDUCTOR_CHANGE_MARKER}') in reverse(transcript)) AS pull_from_end ` +
   `FROM session_transcripts_view WHERE ${CONDUCTOR_SQL_FIELD.SESSION_ID} IN (`;
 
 const CONDUCTOR_READ_TRANSCRIPT_TAILS_SUFFIX = ")) AS attributed";
@@ -272,6 +312,32 @@ const SESSION_STATUS_BY_CONDUCTOR_STATUS: Readonly<Record<ConductorSessionStatus
     [CONDUCTOR_SESSION_STATUS.ERROR]: SESSION_STATUS.ERROR,
   };
 
+/** The lifecycle states `GET …/workspaces/{id}/status` documents. */
+const CONDUCTOR_WORKSPACE_STATUS = {
+  INITIALIZING: "initializing",
+  READY: "ready",
+  SLEEPING: "sleeping",
+  ARCHIVED: "archived",
+  DELETED: "deleted",
+  UPDATING: "updating",
+} as const;
+
+type ConductorWorkspaceStatus =
+  (typeof CONDUCTOR_WORKSPACE_STATUS)[keyof typeof CONDUCTOR_WORKSPACE_STATUS];
+
+/**
+ * The lifecycle states worth a row's activity slot: a workspace still being
+ * built or rebuilt is why its chats are quiet, and without the words a
+ * just-created session reads as unaccountably idle. A ready workspace is the
+ * normal case and says nothing, and a sleeping one is Conductor's own economy
+ * — it wakes on the next message — so wording it would bump the recap off the
+ * row to report a non-event.
+ */
+const CONDUCTOR_WORKSPACE_ACTIVITY: Readonly<Partial<Record<ConductorWorkspaceStatus, string>>> = {
+  [CONDUCTOR_WORKSPACE_STATUS.INITIALIZING]: "Workspace initializing",
+  [CONDUCTOR_WORKSPACE_STATUS.UPDATING]: "Workspace updating",
+};
+
 const CONDUCTOR_ADAPTER_DEFAULTS = {
   MAXIMUM_PROJECTS: 10,
   WORKSPACE_PAGE_SIZE: 100,
@@ -287,10 +353,23 @@ interface ConductorReportedStatus {
   errorMessage?: string;
 }
 
-/** What the transcripts view said about one session: who runs it, and how it left off. */
+/**
+ * What the lifecycle endpoint said about one workspace: where it stands, and
+ * the failure message it carries when standing it up went wrong.
+ */
+interface ConductorWorkspaceLifecycle {
+  status?: ConductorWorkspaceStatus;
+  errorMessage?: string;
+}
+
+/**
+ * What the transcripts view said about one session: who runs it, how it left
+ * off, and the pull request it published in its own repository.
+ */
 interface ConductorTranscript {
   agentKind?: string;
   recap?: string;
+  change?: string;
 }
 
 export const CONDUCTOR_PROVIDER: SessionProvider = {
@@ -303,12 +382,19 @@ export type ConductorAdapterOptions = CloudAdapterOptions;
 interface ConductorProject {
   id: string;
   repositoryLabel: string;
+  /**
+   * The project's GitHub repository as `owner/name`, lowercased, when its git
+   * remote names one. It is what a pull-request address found in a transcript
+   * is validated against before it may be reported as a session's change.
+   */
+  gitHubRepository?: string;
 }
 
 interface ConductorWorkspace {
   id: string;
   name?: string;
   repositoryLabel: string;
+  gitHubRepository?: string;
   creatorId?: string;
   lastActivityAt: number;
   /** A workspace already filed away has nothing left to archive. */
@@ -500,8 +586,12 @@ export class ConductorSessionAdapter
     // refusal: a key an org scopes away from the query endpoint alone still
     // reads the roster, and the roster reads above are what judge the
     // credential — so this one read swallows everything rather than letting
-    // an enrichment 403 clear every observed row.
-    const [transcripts, reportedStatuses] = await Promise.all([
+    // an enrichment 403 clear every observed row. The lifecycle reads ride
+    // the same way, one per still-open workspace — a filed-away workspace's
+    // state is settled — and a failed one costs that workspace's activity
+    // words and failure message, never the pass.
+    const openWorkspaces = workspaces.filter((workspace) => !workspace.archived);
+    const [transcripts, reportedStatuses, workspaceLifecycles] = await Promise.all([
       this.#sessionTranscripts(request, sessions).catch(() => undefined),
       Promise.all(
         sessions.map((session) =>
@@ -512,6 +602,14 @@ export class ConductorSessionAdapter
             : this.tolerateItemFailure(() => this.#sessionStatus(request, session.id)),
         ),
       ),
+      Promise.all(
+        openWorkspaces.map(async (workspace) => {
+          const lifecycle = await this.tolerateItemFailure(() =>
+            this.#workspaceLifecycle(request, workspace.id),
+          );
+          return lifecycle ? ([workspace.id, lifecycle] as const) : undefined;
+        }),
+      ).then((entries) => new Map(entries.filter(isDefined))),
     ]);
 
     // The workspaces every observed chat of which was positively seen settled
@@ -542,6 +640,7 @@ export class ConductorSessionAdapter
           session,
           reportedStatuses[index],
           transcripts?.get(session.id),
+          workspaceLifecycles.get(session.workspace.id),
           settledWorkspaceIds,
           now,
         ),
@@ -563,15 +662,14 @@ export class ConductorSessionAdapter
     return recordsFromPage(body, CONDUCTOR_FIELD.DATA)
       .map((record): ConductorProject | undefined => {
         const id = textFromRecord(record, CONDUCTOR_FIELD.ID);
-        return id
-          ? {
-              id,
-              repositoryLabel: repositoryLabel(
-                textFromRecord(record, CONDUCTOR_FIELD.GIT_REMOTE),
-                textFromRecord(record, CONDUCTOR_FIELD.NAME),
-              ),
-            }
-          : undefined;
+        if (!id) return undefined;
+        const gitRemote = textFromRecord(record, CONDUCTOR_FIELD.GIT_REMOTE);
+        const gitHubRepository = gitHubRepositoryFromRemote(gitRemote);
+        return {
+          id,
+          repositoryLabel: repositoryLabel(gitRemote, textFromRecord(record, CONDUCTOR_FIELD.NAME)),
+          ...(gitHubRepository ? { gitHubRepository } : {}),
+        };
       })
       .filter(isDefined)
       .slice(0, CONDUCTOR_ADAPTER_DEFAULTS.MAXIMUM_PROJECTS);
@@ -600,6 +698,7 @@ export class ConductorSessionAdapter
         return {
           id,
           repositoryLabel: project.repositoryLabel,
+          ...(project.gitHubRepository ? { gitHubRepository: project.gitHubRepository } : {}),
           lastActivityAt,
           archived: timestampFromRecord(record, CONDUCTOR_FIELD.ARCHIVED_AT) !== undefined,
           ...(name ? { name } : {}),
@@ -745,6 +844,7 @@ export class ConductorSessionAdapter
     session: ConductorSession,
     reported: ConductorReportedStatus | undefined,
     transcript: ConductorTranscript | undefined,
+    lifecycle: ConductorWorkspaceLifecycle | undefined,
     settledWorkspaceIds: ReadonlySet<string>,
     now: number,
   ): ProviderSessionObservation | undefined {
@@ -764,6 +864,12 @@ export class ConductorSessionAdapter
         ? transcript?.recap
         : undefined;
     const model = agentAndModelLabel(transcript?.agentKind, session.model);
+    // The workspace's own words for why its chats are quiet, and its own
+    // failure message when standing it up went wrong. A session's reported
+    // error is about the turn the user is watching, so it always outranks the
+    // machinery's.
+    const activity = lifecycle?.status ? CONDUCTOR_WORKSPACE_ACTIVITY[lifecycle.status] : undefined;
+    const error = reported?.errorMessage ?? lifecycle?.errorMessage;
     // The stop belongs to the turn and the archive to the workspace: a chat
     // mid-turn offers the stop alone — its own workspace is by definition
     // unsettled — and any chat of a positively settled, still-open workspace
@@ -812,8 +918,13 @@ export class ConductorSessionAdapter
       detail: {
         repository: session.workspace.repositoryLabel,
         ...(model ? { model } : {}),
-        ...(reported?.errorMessage ? { error: reported.errorMessage } : {}),
+        ...(activity ? { activity } : {}),
+        ...(error ? { error } : {}),
         ...(session.deepLink ? { link: session.deepLink } : {}),
+        // The pull request this chat published in its own repository: found in
+        // the transcript, validated against the workspace's remote, and a fact
+        // about the work whatever the turn is doing now.
+        ...(transcript?.change ? { change: transcript.change } : {}),
       },
     };
   }
@@ -866,22 +977,57 @@ export class ConductorSessionAdapter
   }
 
   /**
+   * Where one workspace stands in its lifecycle, from the endpoint Conductor
+   * documents for polling exactly that. A workspace still being built or
+   * rebuilt explains why its chats sit quiet, and the failure message it
+   * carries is the one thing that says a workspace never came up at all —
+   * nothing else reports it, because every chat inside just reads idle.
+   */
+  async #workspaceLifecycle(
+    request: CloudRequest,
+    workspaceId: string,
+  ): Promise<ConductorWorkspaceLifecycle> {
+    const body = await request([
+      CONDUCTOR_ROUTE_SEGMENT.V0,
+      CONDUCTOR_ROUTE_SEGMENT.WORKSPACES,
+      workspaceId,
+      CONDUCTOR_ROUTE_SEGMENT.STATUS,
+    ]);
+    const status = knownValue(
+      CONDUCTOR_WORKSPACE_STATUS,
+      textFromRecord(body, CONDUCTOR_FIELD.STATUS),
+    );
+    const errorMessage = textFromRecord(body, CONDUCTOR_FIELD.ERROR_MESSAGE)?.slice(
+      0,
+      CONDUCTOR_ADAPTER_DEFAULTS.MAXIMUM_ERROR_LENGTH,
+    );
+    return {
+      ...(status ? { status } : {}),
+      ...(errorMessage ? { errorMessage } : {}),
+    };
+  }
+
+  /**
    * One bounded read of the transcripts view for every session this pass
-   * observed: which agent runs each chat, and the tail its recap is taken
-   * from. Only ids that are actually UUIDs may enter the fixed document — an
-   * id that is anything else is a shape this build does not know, so it is
-   * left out rather than sent — and with none there is no read at all.
+   * observed: which agent runs each chat, the tail its recap is taken from,
+   * and the window its published pull request is read out of. Only ids that
+   * are actually UUIDs may enter the fixed document — an id that is anything
+   * else is a shape this build does not know, so it is left out rather than
+   * sent — and with none there is no read at all.
    */
   async #sessionTranscripts(
     request: CloudRequest,
     sessions: readonly ConductorSession[],
   ): Promise<ReadonlyMap<string, ConductorTranscript>> {
     const transcripts = new Map<string, ConductorTranscript>();
-    const ids = sessions.map((session) => session.id).filter((id) => UUID_PATTERN.test(id));
-    if (ids.length === 0) return transcripts;
+    const observed = sessions.filter((session) => UUID_PATTERN.test(session.id));
+    if (observed.length === 0) return transcripts;
+    const repositories = new Map(
+      observed.map((session) => [session.id, session.workspace.gitHubRepository]),
+    );
 
-    const document = `${CONDUCTOR_READ_TRANSCRIPT_TAILS_PREFIX}${ids
-      .map((id) => `'${id}'`)
+    const document = `${CONDUCTOR_READ_TRANSCRIPT_TAILS_PREFIX}${observed
+      .map((session) => `'${session.id}'`)
       .join(", ")}${CONDUCTOR_READ_TRANSCRIPT_TAILS_SUFFIX}`;
     const body = await request(CONDUCTOR_ROUTE.SQL, undefined, { document });
     for (const row of recordsFromPage(body, CONDUCTOR_SQL_FIELD.ROWS)) {
@@ -894,9 +1040,14 @@ export class ConductorSessionAdapter
       const recap = recapFromTranscriptTail(
         textFromRecord(row, CONDUCTOR_SQL_FIELD.TRANSCRIPT_TAIL),
       );
+      const change = changeFromWindow(
+        textFromRecord(row, CONDUCTOR_SQL_FIELD.CHANGE_WINDOW),
+        repositories.get(sessionId),
+      );
       transcripts.set(sessionId, {
         ...(agentKind ? { agentKind } : {}),
         ...(recap ? { recap } : {}),
+        ...(change ? { change } : {}),
       });
     }
     return transcripts;
@@ -928,6 +1079,36 @@ function recapFromTranscriptTail(tail: string | undefined): string | undefined {
     .replace(/\s+/g, " ")
     .trim();
   return recap ? recap.slice(0, maximumSessionRecapLength) : undefined;
+}
+
+/**
+ * The GitHub repository a git remote names, as lowercase `owner/name`, in any
+ * of the ways a remote is written — `https://…`, `git@…:`, with or without
+ * `.git`. Anything that is not recognisably GitHub answers nothing, and with
+ * nothing to validate against, no pull-request address is ever reported.
+ */
+function gitHubRepositoryFromRemote(gitRemote: string | undefined): string | undefined {
+  const match = gitRemote?.trim().match(GITHUB_REMOTE_PATTERN);
+  return match ? `${match[1]}/${match[2]}`.toLowerCase() : undefined;
+}
+
+/**
+ * The pull request a transcript names as this session's published work: the
+ * last whole address in the window, and only when it points into the
+ * workspace's own repository — GitHub treats owner and repository names
+ * case-insensitively, so the comparison does too. An address for anywhere
+ * else is somebody else's work being talked about, and a window whose opening
+ * was cut mid-address simply yields no whole address to consider.
+ */
+function changeFromWindow(
+  window: string | undefined,
+  gitHubRepository: string | undefined,
+): string | undefined {
+  if (!window || !gitHubRepository) return undefined;
+  const addresses = [...window.matchAll(GITHUB_PULL_URL_PATTERN)];
+  const last = addresses.at(-1);
+  if (!last) return undefined;
+  return `${last[1]}/${last[2]}`.toLowerCase() === gitHubRepository ? last[0] : undefined;
 }
 
 /**

--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -865,11 +865,18 @@ export class ConductorSessionAdapter
         : undefined;
     const model = agentAndModelLabel(transcript?.agentKind, session.model);
     // The workspace's own words for why its chats are quiet, and its own
-    // failure message when standing it up went wrong. A session's reported
-    // error is about the turn the user is watching, so it always outranks the
-    // machinery's.
-    const activity = lifecycle?.status ? CONDUCTOR_WORKSPACE_ACTIVITY[lifecycle.status] : undefined;
-    const error = reported?.errorMessage ?? lifecycle?.errorMessage;
+    // failure message when standing it up went wrong. Both belong only to the
+    // open chats: a closed one is settled, and the machinery around it must
+    // not bump its recap or dress a complete row as newly failed. A session's
+    // reported error is about the turn the user is watching, so it always
+    // outranks the machinery's.
+    const activity =
+      !session.archived && lifecycle?.status
+        ? CONDUCTOR_WORKSPACE_ACTIVITY[lifecycle.status]
+        : undefined;
+    const error = session.archived
+      ? undefined
+      : (reported?.errorMessage ?? lifecycle?.errorMessage);
     // The stop belongs to the turn and the archive to the workspace: a chat
     // mid-turn offers the stop alone — its own workspace is by definition
     // unsettled — and any chat of a positively settled, still-open workspace

--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -187,7 +187,6 @@ const CONDUCTOR_SQL_FIELD = {
   SESSION_ID: "session_id",
   AGENT_TYPE: "agent_type",
   TRANSCRIPT_TAIL: "transcript_tail",
-  CHANGE_WINDOW: "change_window",
 } as const;
 
 /**
@@ -195,35 +194,6 @@ const CONDUCTOR_SQL_FIELD = {
  * opening words — where an agent puts the outcome — and no more of it.
  */
 const CONDUCTOR_TRANSCRIPT_TAIL_LENGTH = 2_000;
-
-/**
- * How a GitHub pull-request address marks itself inside a transcript. The
- * window is anchored at the marker's last occurrence, because the freshest
- * pull request a chat names is the one that says what it published.
- */
-const CONDUCTOR_CHANGE_MARKER = "/pull/";
-
-/**
- * How far a pull-request address can reach around its marker: GitHub bounds an
- * owner at 39 characters and a repository at 100, so `https://github.com/` plus
- * both names fits in 160 characters before the marker, and a pull number in 12
- * after it. The window is sized to hold one whole address and nothing more.
- */
-const CONDUCTOR_CHANGE_PREFIX_LENGTH = 160;
-const CONDUCTOR_CHANGE_SUFFIX_LENGTH = 12;
-
-/**
- * A GitHub pull-request address, whole: the only shape the change window may
- * yield. The owner and repository groups are what the address is validated
- * against — it is reported only when it names the workspace's own repository,
- * so a link an agent merely mentioned in passing about somewhere else never
- * poses as this session's published work.
- */
-const GITHUB_PULL_URL_PATTERN =
-  /https:\/\/github\.com\/([A-Za-z0-9-]+)\/([A-Za-z0-9._-]+)\/pull\/\d{1,10}/g;
-
-/** Where a GitHub remote names its owner and repository, however it is written. */
-const GITHUB_REMOTE_PATTERN = /github\.com[/:]([A-Za-z0-9-]+)\/([A-Za-z0-9._-]+?)(?:\.git)?\/?$/i;
 
 /**
  * How Conductor's plain-text transcript marks who is speaking. A line inside a
@@ -253,34 +223,25 @@ function sqlHeaderLiteral(header: string): string {
  * same pass reported — each validated as a UUID first, so no name, title, or
  * message a provider controls can ever be spliced into the document.
  *
- * The columns ask for the agent kind, the opening of the transcript's final
- * message — the settled turn's parting words — and a window around the last
- * pull-request marker the transcript holds, and never the conversation behind
- * them. Who wrote that message is computed in the view, from whichever
- * speaker header stands nearest the transcript's end, and the returned tail
- * is anchored at that header rather than cut at a fixed distance: a fixed cut
- * left any final message longer than the cut without its header, which read
- * as unattributable and silently cost most long-form agents their recap. A
- * chat whose user spoke last answers with no tail at all. The change window
- * is anchored the same way, at the marker's own last occurrence, and sized to
- * one whole address: an agent that opened a pull request turns ago and kept
- * working would otherwise have published work its final message no longer
- * names.
+ * The columns ask for the agent kind and the opening of the transcript's
+ * final message — the settled turn's parting words — and never the
+ * conversation behind it. Who wrote that message is computed in the view,
+ * from whichever speaker header stands nearest the transcript's end, and the
+ * returned tail is anchored at that header rather than cut at a fixed
+ * distance: a fixed cut left any final message longer than the cut without
+ * its header, which read as unattributable and silently cost most long-form
+ * agents their recap. A chat whose user spoke last answers with no tail at
+ * all.
  */
 const CONDUCTOR_READ_TRANSCRIPT_TAILS_PREFIX =
   `SELECT ${CONDUCTOR_SQL_FIELD.SESSION_ID}, ${CONDUCTOR_SQL_FIELD.AGENT_TYPE}, ` +
   `CASE WHEN assistant_from_end > 0 AND (user_from_end = 0 OR assistant_from_end < user_from_end) ` +
   `THEN SUBSTRING(transcript FROM GREATEST(LENGTH(transcript) - assistant_from_end - ${CONDUCTOR_ASSISTANT_HEADER.length - 2}, 1) ` +
   `FOR ${CONDUCTOR_ASSISTANT_HEADER.length + CONDUCTOR_TRANSCRIPT_TAIL_LENGTH}) ` +
-  `END AS ${CONDUCTOR_SQL_FIELD.TRANSCRIPT_TAIL}, ` +
-  `CASE WHEN pull_from_end > 0 ` +
-  `THEN SUBSTRING(transcript FROM GREATEST(LENGTH(transcript) - pull_from_end - ${CONDUCTOR_CHANGE_MARKER.length - 2 + CONDUCTOR_CHANGE_PREFIX_LENGTH}, 1) ` +
-  `FOR ${CONDUCTOR_CHANGE_PREFIX_LENGTH + CONDUCTOR_CHANGE_MARKER.length + CONDUCTOR_CHANGE_SUFFIX_LENGTH}) ` +
-  `END AS ${CONDUCTOR_SQL_FIELD.CHANGE_WINDOW} ` +
+  `END AS ${CONDUCTOR_SQL_FIELD.TRANSCRIPT_TAIL} ` +
   `FROM (SELECT ${CONDUCTOR_SQL_FIELD.SESSION_ID}, ${CONDUCTOR_SQL_FIELD.AGENT_TYPE}, transcript, ` +
   `position(reverse(${sqlHeaderLiteral(CONDUCTOR_ASSISTANT_HEADER)}) in reverse(transcript)) AS assistant_from_end, ` +
-  `position(reverse(${sqlHeaderLiteral(CONDUCTOR_USER_HEADER)}) in reverse(transcript)) AS user_from_end, ` +
-  `position(reverse('${CONDUCTOR_CHANGE_MARKER}') in reverse(transcript)) AS pull_from_end ` +
+  `position(reverse(${sqlHeaderLiteral(CONDUCTOR_USER_HEADER)}) in reverse(transcript)) AS user_from_end ` +
   `FROM session_transcripts_view WHERE ${CONDUCTOR_SQL_FIELD.SESSION_ID} IN (`;
 
 const CONDUCTOR_READ_TRANSCRIPT_TAILS_SUFFIX = ")) AS attributed";
@@ -362,14 +323,10 @@ interface ConductorWorkspaceLifecycle {
   errorMessage?: string;
 }
 
-/**
- * What the transcripts view said about one session: who runs it, how it left
- * off, and the pull request it published in its own repository.
- */
+/** What the transcripts view said about one session: who runs it, and how it left off. */
 interface ConductorTranscript {
   agentKind?: string;
   recap?: string;
-  change?: string;
 }
 
 export const CONDUCTOR_PROVIDER: SessionProvider = {
@@ -382,19 +339,12 @@ export type ConductorAdapterOptions = CloudAdapterOptions;
 interface ConductorProject {
   id: string;
   repositoryLabel: string;
-  /**
-   * The project's GitHub repository as `owner/name`, lowercased, when its git
-   * remote names one. It is what a pull-request address found in a transcript
-   * is validated against before it may be reported as a session's change.
-   */
-  gitHubRepository?: string;
 }
 
 interface ConductorWorkspace {
   id: string;
   name?: string;
   repositoryLabel: string;
-  gitHubRepository?: string;
   creatorId?: string;
   lastActivityAt: number;
   /** A workspace already filed away has nothing left to archive. */
@@ -662,14 +612,15 @@ export class ConductorSessionAdapter
     return recordsFromPage(body, CONDUCTOR_FIELD.DATA)
       .map((record): ConductorProject | undefined => {
         const id = textFromRecord(record, CONDUCTOR_FIELD.ID);
-        if (!id) return undefined;
-        const gitRemote = textFromRecord(record, CONDUCTOR_FIELD.GIT_REMOTE);
-        const gitHubRepository = gitHubRepositoryFromRemote(gitRemote);
-        return {
-          id,
-          repositoryLabel: repositoryLabel(gitRemote, textFromRecord(record, CONDUCTOR_FIELD.NAME)),
-          ...(gitHubRepository ? { gitHubRepository } : {}),
-        };
+        return id
+          ? {
+              id,
+              repositoryLabel: repositoryLabel(
+                textFromRecord(record, CONDUCTOR_FIELD.GIT_REMOTE),
+                textFromRecord(record, CONDUCTOR_FIELD.NAME),
+              ),
+            }
+          : undefined;
       })
       .filter(isDefined)
       .slice(0, CONDUCTOR_ADAPTER_DEFAULTS.MAXIMUM_PROJECTS);
@@ -698,7 +649,6 @@ export class ConductorSessionAdapter
         return {
           id,
           repositoryLabel: project.repositoryLabel,
-          ...(project.gitHubRepository ? { gitHubRepository: project.gitHubRepository } : {}),
           lastActivityAt,
           archived: timestampFromRecord(record, CONDUCTOR_FIELD.ARCHIVED_AT) !== undefined,
           ...(name ? { name } : {}),
@@ -928,10 +878,6 @@ export class ConductorSessionAdapter
         ...(activity ? { activity } : {}),
         ...(error ? { error } : {}),
         ...(session.deepLink ? { link: session.deepLink } : {}),
-        // The pull request this chat published in its own repository: found in
-        // the transcript, validated against the workspace's remote, and a fact
-        // about the work whatever the turn is doing now.
-        ...(transcript?.change ? { change: transcript.change } : {}),
       },
     };
   }
@@ -1016,25 +962,21 @@ export class ConductorSessionAdapter
 
   /**
    * One bounded read of the transcripts view for every session this pass
-   * observed: which agent runs each chat, the tail its recap is taken from,
-   * and the window its published pull request is read out of. Only ids that
-   * are actually UUIDs may enter the fixed document — an id that is anything
-   * else is a shape this build does not know, so it is left out rather than
-   * sent — and with none there is no read at all.
+   * observed: which agent runs each chat, and the tail its recap is taken
+   * from. Only ids that are actually UUIDs may enter the fixed document — an
+   * id that is anything else is a shape this build does not know, so it is
+   * left out rather than sent — and with none there is no read at all.
    */
   async #sessionTranscripts(
     request: CloudRequest,
     sessions: readonly ConductorSession[],
   ): Promise<ReadonlyMap<string, ConductorTranscript>> {
     const transcripts = new Map<string, ConductorTranscript>();
-    const observed = sessions.filter((session) => UUID_PATTERN.test(session.id));
-    if (observed.length === 0) return transcripts;
-    const repositories = new Map(
-      observed.map((session) => [session.id, session.workspace.gitHubRepository]),
-    );
+    const ids = sessions.map((session) => session.id).filter((id) => UUID_PATTERN.test(id));
+    if (ids.length === 0) return transcripts;
 
-    const document = `${CONDUCTOR_READ_TRANSCRIPT_TAILS_PREFIX}${observed
-      .map((session) => `'${session.id}'`)
+    const document = `${CONDUCTOR_READ_TRANSCRIPT_TAILS_PREFIX}${ids
+      .map((id) => `'${id}'`)
       .join(", ")}${CONDUCTOR_READ_TRANSCRIPT_TAILS_SUFFIX}`;
     const body = await request(CONDUCTOR_ROUTE.SQL, undefined, { document });
     for (const row of recordsFromPage(body, CONDUCTOR_SQL_FIELD.ROWS)) {
@@ -1047,14 +989,9 @@ export class ConductorSessionAdapter
       const recap = recapFromTranscriptTail(
         textFromRecord(row, CONDUCTOR_SQL_FIELD.TRANSCRIPT_TAIL),
       );
-      const change = changeFromWindow(
-        textFromRecord(row, CONDUCTOR_SQL_FIELD.CHANGE_WINDOW),
-        repositories.get(sessionId),
-      );
       transcripts.set(sessionId, {
         ...(agentKind ? { agentKind } : {}),
         ...(recap ? { recap } : {}),
-        ...(change ? { change } : {}),
       });
     }
     return transcripts;
@@ -1086,36 +1023,6 @@ function recapFromTranscriptTail(tail: string | undefined): string | undefined {
     .replace(/\s+/g, " ")
     .trim();
   return recap ? recap.slice(0, maximumSessionRecapLength) : undefined;
-}
-
-/**
- * The GitHub repository a git remote names, as lowercase `owner/name`, in any
- * of the ways a remote is written — `https://…`, `git@…:`, with or without
- * `.git`. Anything that is not recognisably GitHub answers nothing, and with
- * nothing to validate against, no pull-request address is ever reported.
- */
-function gitHubRepositoryFromRemote(gitRemote: string | undefined): string | undefined {
-  const match = gitRemote?.trim().match(GITHUB_REMOTE_PATTERN);
-  return match ? `${match[1]}/${match[2]}`.toLowerCase() : undefined;
-}
-
-/**
- * The pull request a transcript names as this session's published work: the
- * last whole address in the window, and only when it points into the
- * workspace's own repository — GitHub treats owner and repository names
- * case-insensitively, so the comparison does too. An address for anywhere
- * else is somebody else's work being talked about, and a window whose opening
- * was cut mid-address simply yields no whole address to consider.
- */
-function changeFromWindow(
-  window: string | undefined,
-  gitHubRepository: string | undefined,
-): string | undefined {
-  if (!window || !gitHubRepository) return undefined;
-  const addresses = [...window.matchAll(GITHUB_PULL_URL_PATTERN)];
-  const last = addresses.at(-1);
-  if (!last) return undefined;
-  return `${last[1]}/${last[2]}`.toLowerCase() === gitHubRepository ? last[0] : undefined;
 }
 
 /**

--- a/apps/desktop/tests/conductor-adapter.test.ts
+++ b/apps/desktop/tests/conductor-adapter.test.ts
@@ -56,7 +56,6 @@ interface TestSession {
   lastError?: string;
   agentType?: string;
   transcriptTail?: string;
-  changeWindow?: string;
 }
 
 interface TestApi {
@@ -117,16 +116,11 @@ function fakeConductorApi(api: TestApi) {
         if (!query.startsWith("SELECT ")) return jsonResponse({}, HTTP_STATUS.SERVER_ERROR);
         const ids = [...query.matchAll(/'([^']*)'/g)].map((match) => match[1]);
         const rows = api.sessions
-          .filter(
-            (session) =>
-              ids.includes(session.id) &&
-              (session.transcriptTail !== undefined || session.changeWindow !== undefined),
-          )
+          .filter((session) => ids.includes(session.id) && session.transcriptTail !== undefined)
           .map((session) => ({
             session_id: session.id,
             agent_type: session.agentType ?? null,
-            transcript_tail: session.transcriptTail ?? null,
-            change_window: session.changeWindow ?? null,
+            transcript_tail: session.transcriptTail,
           }));
         return jsonResponse({ rows, rowCount: rows.length, truncated: false });
       }
@@ -584,14 +578,10 @@ test("reads a settled chat's parting words from the transcripts view as its reca
       "SELECT session_id, agent_type, " +
       "CASE WHEN assistant_from_end > 0 AND (user_from_end = 0 OR assistant_from_end < user_from_end) " +
       "THEN SUBSTRING(transcript FROM GREATEST(LENGTH(transcript) - assistant_from_end - 12, 1) FOR 2014) " +
-      "END AS transcript_tail, " +
-      "CASE WHEN pull_from_end > 0 " +
-      "THEN SUBSTRING(transcript FROM GREATEST(LENGTH(transcript) - pull_from_end - 164, 1) FOR 178) " +
-      "END AS change_window " +
+      "END AS transcript_tail " +
       "FROM (SELECT session_id, agent_type, transcript, " +
       "position(reverse(E'\\n## Assistant\\n') in reverse(transcript)) AS assistant_from_end, " +
-      "position(reverse(E'\\n## User\\n') in reverse(transcript)) AS user_from_end, " +
-      "position(reverse('/pull/') in reverse(transcript)) AS pull_from_end " +
+      "position(reverse(E'\\n## User\\n') in reverse(transcript)) AS user_from_end " +
       "FROM session_transcripts_view WHERE session_id IN " +
       `('${IDLE_SESSION_UUID}', '${CLOSED_SESSION_UUID}')) AS attributed`,
   });
@@ -701,89 +691,6 @@ test("cuts a recap at the recap bound", async () => {
   const observations = await adapterFor(api.fetch).observe();
 
   assert.equal(observations[0]?.recap?.length, 500);
-});
-
-test("reports the pull request a transcript names in the workspace's own repository", async () => {
-  const api = fakeConductorApi({
-    userId: TEST_USER_ID,
-    projects: [LUKE_PROJECT],
-    workspaces: [
-      ownedWorkspace("workspace-published", TEST_TIME - 30_000),
-      ownedWorkspace("workspace-elsewhere", TEST_TIME - 40_000),
-    ],
-    sessions: [
-      // The last whole address in the window wins, GitHub's case-insensitive
-      // names are honoured, and published work is a fact about the session
-      // whatever its turn is doing now — so a working chat reports it too.
-      {
-        id: WORKING_SESSION_UUID,
-        workspaceId: "workspace-published",
-        name: TEST_SESSION_NAME,
-        changeWindow:
-          "opened https://github.com/reviewstage/luke/pull/9 first, superseded by " +
-          "[#151](https://github.com/ReviewStage/luke/pull/151) which is green",
-        status: TEST_CONDUCTOR_STATUS.WORKING,
-        statusUpdatedAt: TEST_TIME - 1_000,
-      },
-      // An address into somebody else's repository is work being talked
-      // about, not work this session published.
-      {
-        id: IDLE_SESSION_UUID,
-        workspaceId: "workspace-elsewhere",
-        name: TEST_SESSION_NAME,
-        changeWindow: "have a look at https://github.com/vendor/toolkit/pull/12 for the idiom",
-        status: TEST_CONDUCTOR_STATUS.IDLE,
-        statusUpdatedAt: TEST_TIME - 1_000,
-      },
-    ],
-  });
-
-  const observations = await adapterFor(api.fetch).observe();
-  const byId = new Map(observations.map((entry) => [entry.providerSessionId, entry]));
-
-  assert.equal(
-    byId.get(WORKING_SESSION_UUID)?.detail?.change,
-    "https://github.com/ReviewStage/luke/pull/151",
-  );
-  assert.equal(byId.get(IDLE_SESSION_UUID)?.detail?.change, undefined);
-});
-
-test("reports no change for a workspace whose remote does not name GitHub", async () => {
-  const api = fakeConductorApi({
-    userId: TEST_USER_ID,
-    projects: [
-      {
-        id: "project-hosted",
-        name: "hosted",
-        gitRemote: "https://gitlab.com/reviewstage/luke.git",
-      },
-    ],
-    workspaces: [
-      {
-        id: "workspace-hosted",
-        projectId: "project-hosted",
-        name: TEST_WORKSPACE_NAME,
-        creatorId: TEST_USER_ID,
-        lastActivityAt: TEST_TIME - 30_000,
-      },
-    ],
-    sessions: [
-      // With no GitHub repository to validate against, even a GitHub address
-      // in the window has nothing to prove it is this session's work.
-      {
-        id: IDLE_SESSION_UUID,
-        workspaceId: "workspace-hosted",
-        name: TEST_SESSION_NAME,
-        changeWindow: "see https://github.com/reviewstage/luke/pull/151",
-        status: TEST_CONDUCTOR_STATUS.IDLE,
-        statusUpdatedAt: TEST_TIME - 1_000,
-      },
-    ],
-  });
-
-  const observations = await adapterFor(api.fetch).observe();
-
-  assert.equal(observations[0]?.detail?.change, undefined);
 });
 
 test("keeps a session id that is not a UUID out of the read document", async () => {

--- a/apps/desktop/tests/conductor-adapter.test.ts
+++ b/apps/desktop/tests/conductor-adapter.test.ts
@@ -39,6 +39,9 @@ interface TestWorkspace {
   creatorId?: string;
   lastActivityAt: number;
   archivedAt?: string;
+  lifecycleStatus?: string;
+  lifecycleErrorMessage?: string;
+  lifecycleHttpStatus?: number;
 }
 
 interface TestSession {
@@ -53,6 +56,7 @@ interface TestSession {
   lastError?: string;
   agentType?: string;
   transcriptTail?: string;
+  changeWindow?: string;
 }
 
 interface TestApi {
@@ -113,11 +117,16 @@ function fakeConductorApi(api: TestApi) {
         if (!query.startsWith("SELECT ")) return jsonResponse({}, HTTP_STATUS.SERVER_ERROR);
         const ids = [...query.matchAll(/'([^']*)'/g)].map((match) => match[1]);
         const rows = api.sessions
-          .filter((session) => ids.includes(session.id) && session.transcriptTail !== undefined)
+          .filter(
+            (session) =>
+              ids.includes(session.id) &&
+              (session.transcriptTail !== undefined || session.changeWindow !== undefined),
+          )
           .map((session) => ({
             session_id: session.id,
             agent_type: session.agentType ?? null,
-            transcript_tail: session.transcriptTail,
+            transcript_tail: session.transcriptTail ?? null,
+            change_window: session.changeWindow ?? null,
           }));
         return jsonResponse({ rows, rowCount: rows.length, truncated: false });
       }
@@ -196,6 +205,19 @@ function fakeConductorApi(api: TestApi) {
           api.sessions.filter((session) => session.workspaceId === segments[2]).map(sessionPayload),
         ),
       );
+    }
+    if (segments[1] === "workspaces" && segments[3] === "status") {
+      const workspace = api.workspaces.find((candidate) => candidate.id === segments[2]);
+      if (!workspace) return jsonResponse({}, HTTP_STATUS.SERVER_ERROR);
+      if (workspace.lifecycleHttpStatus) return jsonResponse({}, workspace.lifecycleHttpStatus);
+      return jsonResponse({
+        workspaceId: workspace.id,
+        status: workspace.lifecycleStatus ?? "ready",
+        updatedAt: isoTimestamp(workspace.lastActivityAt),
+        ...(workspace.lifecycleErrorMessage
+          ? { errorMessage: workspace.lifecycleErrorMessage }
+          : {}),
+      });
     }
     if (segments[1] === "sessions" && segments[3] === "status") {
       const session = api.sessions.find((candidate) => candidate.id === segments[2]);
@@ -345,6 +367,136 @@ test("reports an idle session as waiting and an errored session with its reason"
   assert.equal(observations[1]?.detail?.error, TEST_ERROR_MESSAGE);
 });
 
+test("words a workspace still being built onto its rows, ready and asleep say nothing", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [
+      {
+        ...ownedWorkspace("workspace-building", TEST_TIME - 5_000),
+        lifecycleStatus: "initializing",
+      },
+      {
+        ...ownedWorkspace("workspace-rebuilding", TEST_TIME - 10_000),
+        lifecycleStatus: "updating",
+      },
+      { ...ownedWorkspace("workspace-ready", TEST_TIME - 20_000) },
+      { ...ownedWorkspace("workspace-asleep", TEST_TIME - 30_000), lifecycleStatus: "sleeping" },
+    ],
+    sessions: [
+      { id: "chat-building", workspaceId: "workspace-building", name: TEST_SESSION_NAME },
+      { id: "chat-rebuilding", workspaceId: "workspace-rebuilding", name: TEST_SESSION_NAME },
+      { id: "chat-ready", workspaceId: "workspace-ready", name: TEST_SESSION_NAME },
+      { id: "chat-asleep", workspaceId: "workspace-asleep", name: TEST_SESSION_NAME },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+  const byId = new Map(observations.map((entry) => [entry.providerSessionId, entry]));
+
+  // A workspace being stood up or rebuilt is why its chat sits quiet, so the
+  // row says so; a ready workspace is the normal case and a sleeping one is
+  // Conductor's own economy, so neither takes the activity slot from a recap.
+  assert.equal(byId.get("chat-building")?.detail?.activity, "Workspace initializing");
+  assert.equal(byId.get("chat-rebuilding")?.detail?.activity, "Workspace updating");
+  assert.equal(byId.get("chat-ready")?.detail?.activity, undefined);
+  assert.equal(byId.get("chat-asleep")?.detail?.activity, undefined);
+});
+
+test("reports the failure that kept a workspace from coming up, behind the chat's own", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [
+      {
+        ...ownedWorkspace("workspace-failed", TEST_TIME - 5_000),
+        lifecycleStatus: "initializing",
+        lifecycleErrorMessage: "The setup script exited with status 1",
+      },
+      {
+        ...ownedWorkspace("workspace-both-failed", TEST_TIME - 10_000),
+        lifecycleStatus: "ready",
+        lifecycleErrorMessage: "The snapshot could not be restored",
+      },
+    ],
+    sessions: [
+      {
+        id: "chat-quietly-failed",
+        workspaceId: "workspace-failed",
+        name: TEST_SESSION_NAME,
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+      // A chat with a failure of its own is telling the user about the turn
+      // they are watching, which outranks the machinery around it.
+      {
+        id: "chat-loudly-failed",
+        workspaceId: "workspace-both-failed",
+        name: TEST_SESSION_NAME,
+        status: TEST_CONDUCTOR_STATUS.ERROR,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+  const byId = new Map(observations.map((entry) => [entry.providerSessionId, entry]));
+
+  assert.equal(
+    byId.get("chat-quietly-failed")?.detail?.error,
+    "The setup script exited with status 1",
+  );
+  assert.equal(byId.get("chat-loudly-failed")?.detail?.error, TEST_ERROR_MESSAGE);
+});
+
+test("a failed lifecycle read costs the workspace's words, never the pass", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [
+      {
+        ...ownedWorkspace("workspace-unreadable", TEST_TIME - 5_000),
+        lifecycleStatus: "initializing",
+        lifecycleHttpStatus: HTTP_STATUS.SERVER_ERROR,
+      },
+      // A filed-away workspace's state is settled, so its lifecycle is not
+      // asked after at all.
+      {
+        ...ownedWorkspace("workspace-archived", TEST_TIME - 10_000),
+        archivedAt: isoTimestamp(TEST_TIME - 10_000),
+      },
+    ],
+    sessions: [
+      {
+        id: "chat-unreadable",
+        workspaceId: "workspace-unreadable",
+        name: TEST_SESSION_NAME,
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+      {
+        id: "chat-archived",
+        workspaceId: "workspace-archived",
+        name: TEST_SESSION_NAME,
+        archivedAt: isoTimestamp(TEST_TIME - 10_000),
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+  const byId = new Map(observations.map((entry) => [entry.providerSessionId, entry]));
+
+  assert.equal(observations.length, 2);
+  assert.equal(byId.get("chat-unreadable")?.detail?.activity, undefined);
+  assert.equal(byId.get("chat-unreadable")?.status, SESSION_STATUS.WAITING);
+  assert.equal(
+    api.requests.some((request) =>
+      request.pathname.endsWith("/workspaces/workspace-archived/status"),
+    ),
+    false,
+  );
+});
+
 const IDLE_SESSION_UUID = "11111111-1111-4111-8111-111111111111";
 const CLOSED_SESSION_UUID = "22222222-2222-4222-8222-222222222222";
 const WORKING_SESSION_UUID = "33333333-3333-4333-8333-333333333333";
@@ -413,10 +565,14 @@ test("reads a settled chat's parting words from the transcripts view as its reca
       "SELECT session_id, agent_type, " +
       "CASE WHEN assistant_from_end > 0 AND (user_from_end = 0 OR assistant_from_end < user_from_end) " +
       "THEN SUBSTRING(transcript FROM GREATEST(LENGTH(transcript) - assistant_from_end - 12, 1) FOR 2014) " +
-      "END AS transcript_tail " +
+      "END AS transcript_tail, " +
+      "CASE WHEN pull_from_end > 0 " +
+      "THEN SUBSTRING(transcript FROM GREATEST(LENGTH(transcript) - pull_from_end - 164, 1) FOR 178) " +
+      "END AS change_window " +
       "FROM (SELECT session_id, agent_type, transcript, " +
       "position(reverse(E'\\n## Assistant\\n') in reverse(transcript)) AS assistant_from_end, " +
-      "position(reverse(E'\\n## User\\n') in reverse(transcript)) AS user_from_end " +
+      "position(reverse(E'\\n## User\\n') in reverse(transcript)) AS user_from_end, " +
+      "position(reverse('/pull/') in reverse(transcript)) AS pull_from_end " +
       "FROM session_transcripts_view WHERE session_id IN " +
       `('${IDLE_SESSION_UUID}', '${CLOSED_SESSION_UUID}')) AS attributed`,
   });
@@ -526,6 +682,89 @@ test("cuts a recap at the recap bound", async () => {
   const observations = await adapterFor(api.fetch).observe();
 
   assert.equal(observations[0]?.recap?.length, 500);
+});
+
+test("reports the pull request a transcript names in the workspace's own repository", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [
+      ownedWorkspace("workspace-published", TEST_TIME - 30_000),
+      ownedWorkspace("workspace-elsewhere", TEST_TIME - 40_000),
+    ],
+    sessions: [
+      // The last whole address in the window wins, GitHub's case-insensitive
+      // names are honoured, and published work is a fact about the session
+      // whatever its turn is doing now — so a working chat reports it too.
+      {
+        id: WORKING_SESSION_UUID,
+        workspaceId: "workspace-published",
+        name: TEST_SESSION_NAME,
+        changeWindow:
+          "opened https://github.com/reviewstage/luke/pull/9 first, superseded by " +
+          "[#151](https://github.com/ReviewStage/luke/pull/151) which is green",
+        status: TEST_CONDUCTOR_STATUS.WORKING,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+      // An address into somebody else's repository is work being talked
+      // about, not work this session published.
+      {
+        id: IDLE_SESSION_UUID,
+        workspaceId: "workspace-elsewhere",
+        name: TEST_SESSION_NAME,
+        changeWindow: "have a look at https://github.com/vendor/toolkit/pull/12 for the idiom",
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+  const byId = new Map(observations.map((entry) => [entry.providerSessionId, entry]));
+
+  assert.equal(
+    byId.get(WORKING_SESSION_UUID)?.detail?.change,
+    "https://github.com/ReviewStage/luke/pull/151",
+  );
+  assert.equal(byId.get(IDLE_SESSION_UUID)?.detail?.change, undefined);
+});
+
+test("reports no change for a workspace whose remote does not name GitHub", async () => {
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [
+      {
+        id: "project-hosted",
+        name: "hosted",
+        gitRemote: "https://gitlab.com/reviewstage/luke.git",
+      },
+    ],
+    workspaces: [
+      {
+        id: "workspace-hosted",
+        projectId: "project-hosted",
+        name: TEST_WORKSPACE_NAME,
+        creatorId: TEST_USER_ID,
+        lastActivityAt: TEST_TIME - 30_000,
+      },
+    ],
+    sessions: [
+      // With no GitHub repository to validate against, even a GitHub address
+      // in the window has nothing to prove it is this session's work.
+      {
+        id: IDLE_SESSION_UUID,
+        workspaceId: "workspace-hosted",
+        name: TEST_SESSION_NAME,
+        changeWindow: "see https://github.com/reviewstage/luke/pull/151",
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.equal(observations[0]?.detail?.change, undefined);
 });
 
 test("keeps a session id that is not a UUID out of the read document", async () => {
@@ -827,10 +1066,13 @@ test("reports an archived session as complete without requesting its status", as
   assert.equal(observations.length, 1);
   assert.equal(observations[0]?.status, SESSION_STATUS.COMPLETE);
   // The archive time is when the chat settled; the workspace timestamp would
-  // date it by whatever a sibling chat did since.
+  // date it by whatever a sibling chat did since. The workspace's own
+  // lifecycle is still read; it is the chat's status that has nothing to ask.
   assert.equal(observations[0]?.observedAt, TEST_TIME - 20_000);
   assert.equal(
-    api.requests.some((request) => request.pathname.endsWith("/status")),
+    api.requests.some(
+      (request) => request.pathname.includes("/sessions/") && request.pathname.endsWith("/status"),
+    ),
     false,
   );
 });

--- a/apps/desktop/tests/conductor-adapter.test.ts
+++ b/apps/desktop/tests/conductor-adapter.test.ts
@@ -386,6 +386,14 @@ test("words a workspace still being built onto its rows, ready and asleep say no
     sessions: [
       { id: "chat-building", workspaceId: "workspace-building", name: TEST_SESSION_NAME },
       { id: "chat-rebuilding", workspaceId: "workspace-rebuilding", name: TEST_SESSION_NAME },
+      // A closed chat beside the one being rebuilt is already settled: the
+      // machinery around it is not its news.
+      {
+        id: "chat-closed-beside",
+        workspaceId: "workspace-rebuilding",
+        name: TEST_SESSION_NAME,
+        archivedAt: isoTimestamp(TEST_TIME - 60_000),
+      },
       { id: "chat-ready", workspaceId: "workspace-ready", name: TEST_SESSION_NAME },
       { id: "chat-asleep", workspaceId: "workspace-asleep", name: TEST_SESSION_NAME },
     ],
@@ -399,6 +407,7 @@ test("words a workspace still being built onto its rows, ready and asleep say no
   // Conductor's own economy, so neither takes the activity slot from a recap.
   assert.equal(byId.get("chat-building")?.detail?.activity, "Workspace initializing");
   assert.equal(byId.get("chat-rebuilding")?.detail?.activity, "Workspace updating");
+  assert.equal(byId.get("chat-closed-beside")?.detail?.activity, undefined);
   assert.equal(byId.get("chat-ready")?.detail?.activity, undefined);
   assert.equal(byId.get("chat-asleep")?.detail?.activity, undefined);
 });
@@ -436,6 +445,14 @@ test("reports the failure that kept a workspace from coming up, behind the chat'
         status: TEST_CONDUCTOR_STATUS.ERROR,
         statusUpdatedAt: TEST_TIME - 1_000,
       },
+      // A closed chat is complete, and a complete row must not be dressed as
+      // newly failed by the workspace around it.
+      {
+        id: "chat-closed-in-failed",
+        workspaceId: "workspace-failed",
+        name: TEST_SESSION_NAME,
+        archivedAt: isoTimestamp(TEST_TIME - 60_000),
+      },
     ],
   });
 
@@ -447,6 +464,8 @@ test("reports the failure that kept a workspace from coming up, behind the chat'
     "The setup script exited with status 1",
   );
   assert.equal(byId.get("chat-loudly-failed")?.detail?.error, TEST_ERROR_MESSAGE);
+  assert.equal(byId.get("chat-closed-in-failed")?.status, SESSION_STATUS.COMPLETE);
+  assert.equal(byId.get("chat-closed-in-failed")?.detail?.error, undefined);
 });
 
 test("a failed lifecycle read costs the workspace's words, never the pass", async () => {


### PR DESCRIPTION
## What

Research pass over Conductor's public API (`/v0/openapi.json`, the official CLI, and live probing) to find metadata Luke isn't reading yet, implementing only what the documented surface attributes itself:

- **Workspace lifecycle → activity and error.** `GET /v0/workspaces/{id}/status` (documented: `initializing / ready / sleeping / archived / deleted / updating` + `errorMessage`; `conductor workspace status` in the CLI) is now polled once per still-open workspace, beside the per-session status reads, each read tolerated so a failure costs words, never the pass. `initializing`/`updating` land on open chats' activity slot — a just-created workspace's session otherwise reads as unaccountably idle — and the lifecycle failure message becomes an open chat's error when it has none of its own (a session's own error always wins). `ready` and `sleeping` deliberately say nothing so a recap is never bumped for a non-event, and closed chats take neither: they are settled, and the machinery around them is not their news.

## Research notes — what the API does *not* offer

- The OpenAPI spec is exhaustive (21 routes, all `x-conductor-stability: experimental`); there is **no PR/branch/checks/CI endpoint** — probing `…/pull-request`, `…/git`, `…/branch`, `…/checks` all 404. GitHub PR status is not extractable from officially attributed fields; it would need Conductor to expose one, or a GitHub credential (a product decision left untouched).
- An earlier revision of this PR derived a PR link from transcript text via the documented `/v0/sql` view; that was reverted (d51b9a5) — the endpoint is official but the attribution was inference, and this PR keeps to provider-attributed fields only.
- Also available but deliberately skipped: `POST …/workspaces/{id}/sleep` and `…/unarchive` (new write controls — product decision), `lastErrorAt`, and `lifecycleStep` granularity.

## Testing

- `./scripts/check.sh` passes (types, Biome, desktop tests including new lifecycle coverage, builds).
- No renderer changes — the activity/error land through fields the panel already draws; no macOS visual evidence applies, and no physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31974121012/artifacts/9270597956) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31974121012)

- Commit: `5b3d4921de15a1219341619ea6695300ce6344c4`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
