### PR TITLE
feat(voice): keep spoken references free of hashes and machine ids

### DIFF
--- a/packages/sidecar-core/src/attention-prompt.ts
+++ b/packages/sidecar-core/src/attention-prompt.ts
@@ -22,6 +22,7 @@ const ATTENTION_INSTRUCTION_LINES: readonly string[] = [
   `- A speaking summary is one short spoken sentence under ${maximumAttentionSummaryLength} characters. Say what the session needs, not merely that it changed.`,
   "- Prefer the session's own recap and title over its status when deciding what to say; the status alone is rarely worth an interruption.",
   "- When the update names a workspace, the session is one chat of it. Name the workspace in a speaking summary — it is the name the developer knows the work by — and the chat only when it tells siblings apart.",
+  "- Leave out identifiers no one says aloud — commit hashes and other machine ids. Name the work by its workspace, title, or branch.",
   "- An error means the session stopped and cannot restart itself. Say what stopped it.",
   "- Use null for the summary whenever the disposition is silent.",
   "- Use only the fields in the update. You receive what a provider wrote about a session, never its transcript, file contents, or command output, so never imply you read any.",

--- a/packages/sidecar-core/src/realtime-protocol.ts
+++ b/packages/sidecar-core/src/realtime-protocol.ts
@@ -127,6 +127,7 @@ const REALTIME_INSTRUCTION_HEAD: readonly string[] = [
   "- Start with the answer. No greetings, no filler, no restating the question, no closing offers of help.",
   '- Answer only the question asked; if there is more to say, ask "want more?" instead of saying it.',
   "- Name the provider and the workspace when you refer to a session, so it is unambiguous out loud.",
+  "- Leave out identifiers no one says aloud — commit hashes, session ids, and the like. Name work by its title, workspace, or branch instead.",
   "- When you do not know something, say so in one sentence rather than guessing or hedging.",
   "",
   "What you can see:",

--- a/packages/sidecar-core/tests/attention.test.ts
+++ b/packages/sidecar-core/tests/attention.test.ts
@@ -725,6 +725,8 @@ test("instructions carry the decision contract and the tuning examples", () => {
     assert.ok(instructions.includes(attentionUpdateInput(example.update)));
   }
   assert.ok(instructions.includes(String(maximumAttentionSummaryLength)));
+  // Spoken summaries stay human: a hash or an id is noise read aloud.
+  assert.match(instructions, /identifiers no one says aloud/i);
   assert.deepEqual(ATTENTION_DECISION_SCHEMA.properties.disposition.enum, [
     ATTENTION_DISPOSITION.SILENT,
     ATTENTION_DISPOSITION.SPEAK_DURING_TURN,

--- a/packages/sidecar-core/tests/realtime.test.ts
+++ b/packages/sidecar-core/tests/realtime.test.ts
@@ -210,6 +210,8 @@ test("the spoken instructions state what Luke cannot see, and when he may act", 
   // Both halves of the developer's side are named, so a typed ask is answered
   // rather than remarked on as something unexpected.
   assert.match(instructions, /speaks to you or types to you/i);
+  // Spoken references stay human: a hash or an id is noise read aloud.
+  assert.match(instructions, /identifiers no one says aloud/i);
 });
 
 test("a mint response yields a credential with a millisecond expiry", () => {


### PR DESCRIPTION
## Summary

Luke could repeat whatever identifiers a recap or title carried — commit hashes, session ids — even though no one wants those read aloud. Both places his speech is worded now say to leave them out:

- The realtime conversation's **How to speak** section tells Luke to skip identifiers no one says aloud and name work by its title, workspace, or branch instead.
- The attention evaluator's rules say the same for proactive speaking summaries, which are read verbatim once approved — so the filter has to happen where the sentence is worded.

Tests pin both lines the way the existing instruction assertions do.

## Validation

- `./scripts/check.sh` — passed (portable-only change: instruction text and tests, no UI or macOS surface touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/dd21ee0a-df5a-448a-98cb-ad37a97f6bb6)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31973491788/artifacts/9270435878) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31973491788)

- Commit: `b1508b520a11788cfe456900d704feaac523ee15`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
