### PR TITLE
fix(voice): announce only status edges whose events are fresh

### DIFF
--- a/packages/sidecar-core/src/session-notices.ts
+++ b/packages/sidecar-core/src/session-notices.ts
@@ -43,6 +43,19 @@ export const SESSION_NOTICE_REPEAT_WINDOW_MS = 5 * 60_000;
 export const MAXIMUM_NOTICES_PER_PASS = 6;
 
 /**
+ * How recently a status must have been entered to be announced as news. The
+ * tracker sees the edge between two readings, not the event itself, and the
+ * two usually coincide only because passes run every few seconds: a Mac
+ * waking from hours of sleep, or a provider back from an outage, delivers
+ * edges whose events happened long ago. `observedAt` is the provider's own
+ * timestamp for when the status was entered, so an edge older than this is
+ * history arriving late — the panel's to show, not a banner's to announce as
+ * though it just happened. Generous next to the refresh cadence, so a fresh
+ * finish is never lost to one slow pass.
+ */
+export const SESSION_NOTICE_FRESH_AGE_MS = 5 * 60_000;
+
+/**
  * One session arriving at a status the user may want to know about. Fields,
  * not sentences: the surface that shows a notice words it, the way it words a
  * row. Everything here is already bounded by `normalizeSession`.
@@ -92,6 +105,10 @@ function sessionNotice(session: NormalizedSession, previousStatus: SessionStatus
  * Derives notices from the edges between one observation pass and the next: a
  * session already waiting when Luke first sees it is the panel's to show, not
  * a banner's to announce, so only a change of status while watched is news.
+ * A watched edge speaks only while its event is fresh — the status's own
+ * timestamp within `SESSION_NOTICE_FRESH_AGE_MS` of now — so a wake from
+ * sleep or a provider back from an outage never reads out the afternoon's
+ * history as though it just happened.
  * Deterministic by construction — nothing a model wrote can reach it — and
  * purely derived from the roster, so it can never act on a session, only
  * describe one.
@@ -131,6 +148,8 @@ export class SessionNoticeTracker {
       if (!previous || previous.status === session.status) continue;
       const status = noticeStatus(session.status);
       if (!status) continue;
+      // The edge is still tracked above — it just is not news any more.
+      if (now - session.observedAt > SESSION_NOTICE_FRESH_AGE_MS) continue;
       const lastNoticed = state.noticedAt.get(status);
       if (lastNoticed !== undefined && now - lastNoticed < SESSION_NOTICE_REPEAT_WINDOW_MS) {
         continue;

--- a/packages/sidecar-core/tests/session-notices.test.ts
+++ b/packages/sidecar-core/tests/session-notices.test.ts
@@ -9,7 +9,11 @@ import {
   type SessionProvider,
   type SessionStatus,
 } from "../src";
-import { MAXIMUM_NOTICES_PER_PASS, SESSION_NOTICE_REPEAT_WINDOW_MS } from "../src/session-notices";
+import {
+  MAXIMUM_NOTICES_PER_PASS,
+  SESSION_NOTICE_FRESH_AGE_MS,
+  SESSION_NOTICE_REPEAT_WINDOW_MS,
+} from "../src/session-notices";
 
 const claude: SessionProvider = { id: "claude-code", displayName: "Claude Code" };
 const conductor: SessionProvider = { id: "conductor", displayName: "Conductor" };
@@ -113,13 +117,73 @@ test("a flapping status is noticed once per repeat window, then again after it",
   // A different status is its own ledger entry.
   assert.equal(tracker.notices([session(claude, "flap", SESSION_STATUS.ERROR)], 5_000).length, 1);
   tracker.notices([session(claude, "flap", SESSION_STATUS.WORKING)], 6_000);
-  // And past the window the same status may speak again.
+  // And past the window the same status may speak again — the ask is fresh,
+  // not a stale reading resurfacing.
   assert.equal(
     tracker.notices(
-      [session(claude, "flap", SESSION_STATUS.WAITING)],
+      [
+        session(claude, "flap", SESSION_STATUS.WAITING, {
+          observedAt: 1_000 + SESSION_NOTICE_REPEAT_WINDOW_MS,
+        }),
+      ],
       1_000 + SESSION_NOTICE_REPEAT_WINDOW_MS,
     ).length,
     1,
+  );
+});
+
+test("an edge whose event is old is tracked but never announced", () => {
+  const tracker = new SessionNoticeTracker();
+  const slept = 4 * 60 * 60 * 1_000;
+  tracker.notices([session(claude, "asleep", SESSION_STATUS.WORKING)], 1_000);
+
+  // The Mac slept for hours; the session finished minutes into the nap. The
+  // edge only becomes visible on the first pass after waking, but the event
+  // it describes is old news the panel has shown the whole time.
+  assert.deepEqual(
+    tracker.notices(
+      [session(claude, "asleep", SESSION_STATUS.COMPLETE, { observedAt: 10 * 60 * 1_000 })],
+      1_000 + slept,
+    ),
+    [],
+  );
+  // The suppressed edge was still recorded: the unchanged status is no edge,
+  // so the stale event does not resurface on a later pass either.
+  assert.deepEqual(
+    tracker.notices(
+      [session(claude, "asleep", SESSION_STATUS.COMPLETE, { observedAt: 10 * 60 * 1_000 })],
+      2_000 + slept,
+    ),
+    [],
+  );
+});
+
+test("a stale edge stays quiet while a fresh one in the same pass announces", () => {
+  const tracker = new SessionNoticeTracker();
+  const now = SESSION_NOTICE_FRESH_AGE_MS * 10;
+  tracker.notices(
+    [
+      session(claude, "stale", SESSION_STATUS.WORKING),
+      session(claude, "fresh", SESSION_STATUS.WORKING),
+    ],
+    1_000,
+  );
+
+  const notices = tracker.notices(
+    [
+      session(claude, "stale", SESSION_STATUS.COMPLETE, {
+        observedAt: now - SESSION_NOTICE_FRESH_AGE_MS - 1,
+      }),
+      session(claude, "fresh", SESSION_STATUS.COMPLETE, {
+        observedAt: now - SESSION_NOTICE_FRESH_AGE_MS,
+      }),
+    ],
+    now,
+  );
+
+  assert.deepEqual(
+    notices.map((notice) => [notice.providerSessionId, notice.status]),
+    [["fresh", SESSION_NOTICE_STATUS.COMPLETE]],
   );
 });
 


### PR DESCRIPTION
## Why

A status edge the notice tracker sees is the difference between two observation passes, not the event itself — the two coincide only because passes run every five seconds. When that assumption breaks, Luke over-announces stale news:

- a Mac waking from hours of sleep diffs the pre-sleep roster against the post-sleep one, and every session that settled during the nap is announced as though it just happened;
- a provider back from an outage delivers the same late edges.

The renderer's `SPOKEN_NOTICE_MAX_AGE_MS` filter cannot catch this: it measures staleness against `decidedAt`, which is stamped at the moment the edge is noticed, not when the event occurred.

## What

Every adapter reports `observedAt` as the provider's own timestamp for when the current status was entered (parsed transcript timestamps, file mtimes, cloud `updatedAt`). `SessionNoticeTracker` now gates each edge on that timestamp against a new `SESSION_NOTICE_FRESH_AGE_MS` window (5 minutes — generous next to the 5-second refresh cadence, so a genuinely fresh finish is never lost to one slow pass).

A stale edge is still tracked — the status map updates as before — so the suppressed event never resurfaces on a later pass, and only the newest relevant items are announced. The panel has shown the state the whole time; announcements were always a banner for what just happened.

## Tests

- New: an edge whose event is hours old is tracked but never announced, and does not resurface on subsequent passes.
- New: a stale edge and a fresh edge in the same pass — only the fresh one speaks, with boundary values on both sides of the window.
- Adjusted: the repeat-window flapping test's final pass now carries a fresh `observedAt`, since the scenario it describes is a genuinely fresh second stop, not a stale reading resurfacing.

`./scripts/check.sh` passes (portable-only change; no UI or macOS surface touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/8c296540-e1d3-4009-93a0-dbc5b84c65e5)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31973875379/artifacts/9270529212) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31973875379)

- Commit: `329029d5623ccc3858ddec0d0f7fd0378abd9a62`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
