### PR TITLE
fix(settings): simplify the OpenAI key subtext

### DIFF
--- a/apps/desktop/src/shared/credential-providers.ts
+++ b/apps/desktop/src/shared/credential-providers.ts
@@ -183,15 +183,10 @@ export const CREDENTIAL_PROVIDERS: Readonly<Record<CredentialProviderId, Credent
   [CREDENTIAL_PROVIDER_ID.OPENAI]: {
     id: CREDENTIAL_PROVIDER_ID.OPENAI,
     displayName: "OpenAI",
-    // Both things the key buys, said on the row that holds it: talking is the
-    // one feature that sends your voice off the Mac, and the review is the one
-    // that sends what a provider wrote about a session. Neither should be
-    // learned from a settings file or a README.
-    // No apostrophe on purpose: the panel writes one as `&rsquo;` in JSX, and
-    // this string is read as text, so a straight quote here would be the one
-    // typewriter apostrophe on the surface.
-    description:
-      "The voice Luke speaks with, and the review that decides which sessions need you. Nothing is spoken or sent without this key.",
+    // The panel writes apostrophes as `&rsquo;` in JSX and this string is read
+    // as text, so the apostrophe here is the typographic one rather than a
+    // straight quote.
+    description: "The API key for Luke’s voice capabilities.",
     // Realtime is what a spoken turn runs on, and an account that cannot reach
     // it fails at the first word rather than at the paste — so the line says so
     // before the key is entered rather than after.

--- a/apps/desktop/tests/credential-providers.test.ts
+++ b/apps/desktop/tests/credential-providers.test.ts
@@ -151,9 +151,8 @@ test("holds the key Luke speaks through, apart from the agents he observes", () 
   assert.equal(VOICE_CREDENTIAL_PROVIDER, openai);
   assert.equal(INTEGRATION_PROVIDER_LIST.includes(openai), false);
   assert.equal(CLOUD_AGENT_PROVIDER_LIST.includes(openai), false);
-  // Both things the key buys are said on the row that holds it, because a
-  // credential that quietly enables an outbound request should not have to be
-  // learned from a README.
+  // The row that holds the key says what it is for, because a credential that
+  // quietly enables an outbound request should not have to be learned from a
+  // README.
   assert.match(openai.description ?? "", /voice/i);
-  assert.match(openai.description ?? "", /review/i);
 });


### PR DESCRIPTION
## Summary

The subtext under the OpenAI API key row on the Voice settings page now reads simply "The API key for Luke's voice capabilities." instead of the longer two-clause description of voice and the attention review.

- `credential-providers.ts`: replaced the description; the apostrophe is the typographic one, matching how the panel writes apostrophes elsewhere.
- `credential-providers.test.ts`: the test pinned the old wording (required "review" in the description); it now asserts only that the description names voice.

## Testing

- `./scripts/check.sh` passes (lint, typecheck, tests, build).
- macOS validation (`verify.sh`) left to CI — this change was made in a Linux cloud workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a333298d-9764-4083-93ae-4488b8655407)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31974151733/artifacts/9270602788) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31974151733)

- Commit: `9bd7452987c4fc277e8f3713b84f58f43f479a0e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
