### PR TITLE
chore(voice): log only the model id when voice is enabled

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -387,9 +387,7 @@ function isIssueActionAsk(value: unknown): value is {
 function reportVoiceAvailability(apiKeyConfigured: boolean): void {
   if (realtimeCredentials) {
     const report = realtimeCredentials.diagnostics();
-    process.stderr.write(
-      `Luke voice: enabled (model ${report.model}, voice ${report.voice}, speed ${report.speed}×)\n`,
-    );
+    process.stderr.write(`Luke voice: enabled (${report.model})\n`);
     return;
   }
   const report = unavailableRealtimeDiagnostics({


### PR DESCRIPTION
## Summary
Simplifies the startup voice-availability log: when voice is enabled, the line now reads `Luke voice: enabled (gpt-realtime-2.1)` — just the model identifier in parentheses, dropping the voice and speed fields and the `model`/`voice`/`speed` labels. The unavailable branch is unchanged.

## Testing
- `./scripts/check.sh` passes (lint, typecheck, tests, build; 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/43085ecd-970a-4ccb-8504-f553debc1fb1)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31974385911/artifacts/9270661271) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31974385911)

- Commit: `0dec7107cd16c62014a065bff53bedfd873ac9e0`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
