### PR TITLE
feat(web): add a hosted privacy policy page

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -123,7 +123,7 @@ nests them, and session or change links. The links, model label, and workspace
 identifier are kept out of the optional attention-review request described
 below.
 
-The microphone is optional and is used two ways.
+The microphone is optional.
 
 Without an OpenAI key there is nothing to talk to, so Luke never asks for the
 microphone and never opens it.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@fontsource-variable/bricolage-grotesque": "5.3.0",
     "@sidecar/core": "workspace:*",
+    "marked": "18.0.9",
     "react": "19.2.8",
     "react-dom": "19.2.8"
   },

--- a/apps/web/privacy.html
+++ b/apps/web/privacy.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Privacy — Luke</title>
+    <meta name="description" content="What Luke reads, when, and where it sends it." />
+    <!-- Matches the page background so mobile browser chrome blends into it. -->
+    <meta name="theme-color" content="#08090b" />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Privacy — Luke" />
+    <meta property="og:description" content="What Luke reads, when, and where it sends it." />
+    <!-- Points at the repository until the page has a domain of its own. -->
+    <meta property="og:url" content="https://github.com/ReviewStage/luke" />
+    <!-- Deliberately no og:image: the repository has no 1200x630 card yet, and a
+         missing image renders better than a broken one. -->
+    <meta name="twitter:card" content="summary" />
+
+    <!-- The compact state as a mark: display frame, black notch capsule, cyan
+         status dot. Inline so the page ships no binary asset. -->
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='7' fill='%23131519'/><path d='M7 2h12v6a3 3 0 0 1-3 3h-6a3 3 0 0 1-3-3z' fill='%23000'/><circle cx='23' cy='7' r='3' fill='%2359d6ff'/></svg>"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/privacy.tsx"></script>
+  </body>
+</html>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,67 +1,10 @@
 import { NotchMock } from "./NotchMock";
-
-const REPOSITORY_URL = "https://github.com/ReviewStage/luke";
-
-/**
- * GitHub's mark, drawn in `currentColor` so the stylesheet holds the color in
- * one place. Inlined for the same reason as the favicon: the page ships no
- * binary assets and fetches nothing at runtime.
- */
-const GITHUB_MARK_PATH =
-  "M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.65 7.65 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z";
-
-/**
- * Always decorative: every use either sits beside a visible label or hangs off
- * a link that carries its own `aria-label`, so announcing the mark as well
- * would only repeat what a reader already hears.
- */
-function GitHubMark(): React.JSX.Element {
-  return (
-    <svg className="github-mark" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-      <path d={GITHUB_MARK_PATH} />
-    </svg>
-  );
-}
-
-/**
- * Luke's face, traced from `design/brand/luke-mark-{dark,light}.svg`. Those two
- * files differ only in a hard-coded stroke color, so drawing in `currentColor`
- * collapses them into one inline mark and keeps the page free of fetched
- * assets. Decorative: the wordmark beside it already says "Luke".
- */
-function LukeMark(): React.JSX.Element {
-  return (
-    <svg className="luke-mark" viewBox="53.85 62.67 134.29 122.37" fill="none" aria-hidden="true">
-      <g transform="rotate(-8 120 124)">
-        <path
-          d="M 104 84 V 150 Q 104 164 118 164 Q 140 164 168 142"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="16"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        <circle cx="78" cy="92" r="12" fill="currentColor" />
-        <circle cx="162" cy="92" r="12" fill="currentColor" />
-      </g>
-    </svg>
-  );
-}
+import { GitHubMark, REPOSITORY_URL, SiteFooter, SiteHeader } from "./SiteChrome";
 
 export function App(): React.JSX.Element {
   return (
     <>
-      <header className="shell">
-        <nav className="site-nav">
-          <span className="wordmark">
-            <LukeMark />
-            Luke
-          </span>
-          <a className="nav-link" href={REPOSITORY_URL} aria-label="Luke on GitHub">
-            <GitHubMark />
-          </a>
-        </nav>
-      </header>
+      <SiteHeader />
 
       <main className="shell">
         <section className="hero">
@@ -80,12 +23,7 @@ export function App(): React.JSX.Element {
         </section>
       </main>
 
-      <footer className="site-footer shell">
-        <div className="footer-meta">
-          <span>Apache-2.0</span>
-          <span>macOS 14+</span>
-        </div>
-      </footer>
+      <SiteFooter />
     </>
   );
 }

--- a/apps/web/src/PrivacyPage.tsx
+++ b/apps/web/src/PrivacyPage.tsx
@@ -1,0 +1,26 @@
+import { marked } from "marked";
+import privacyMarkdown from "../../../PRIVACY.md?raw";
+import { SiteFooter, SiteHeader } from "./SiteChrome";
+
+/**
+ * PRIVACY.md at the repo root is the only place this text is written — it
+ * makes claims about what the app does, and a copy pasted into JSX would
+ * drift from it. Parsed once at module load since the document is fixed at
+ * build time.
+ */
+const privacyHtml = marked.parse(privacyMarkdown, { async: false }) as string;
+
+export function PrivacyPage(): React.JSX.Element {
+  return (
+    <>
+      <SiteHeader />
+
+      <main className="shell">
+        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: privacyHtml is parsed from PRIVACY.md, a repository file fixed at build time, not user input. */}
+        <article className="privacy" dangerouslySetInnerHTML={{ __html: privacyHtml }} />
+      </main>
+
+      <SiteFooter />
+    </>
+  );
+}

--- a/apps/web/src/SiteChrome.tsx
+++ b/apps/web/src/SiteChrome.tsx
@@ -1,0 +1,79 @@
+export const REPOSITORY_URL = "https://github.com/ReviewStage/luke";
+
+/**
+ * GitHub's mark, drawn in `currentColor` so the stylesheet holds the color in
+ * one place. Inlined for the same reason as the favicon: the page ships no
+ * binary assets and fetches nothing at runtime.
+ */
+const GITHUB_MARK_PATH =
+  "M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.65 7.65 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z";
+
+/**
+ * Always decorative: every use either sits beside a visible label or hangs off
+ * a link that carries its own `aria-label`, so announcing the mark as well
+ * would only repeat what a reader already hears.
+ */
+export function GitHubMark(): React.JSX.Element {
+  return (
+    <svg className="github-mark" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+      <path d={GITHUB_MARK_PATH} />
+    </svg>
+  );
+}
+
+/**
+ * Luke's face, traced from `design/brand/luke-mark-{dark,light}.svg`. Those two
+ * files differ only in a hard-coded stroke color, so drawing in `currentColor`
+ * collapses them into one inline mark and keeps the page free of fetched
+ * assets. Decorative: the wordmark beside it already says "Luke".
+ */
+export function LukeMark(): React.JSX.Element {
+  return (
+    <svg className="luke-mark" viewBox="53.85 62.67 134.29 122.37" fill="none" aria-hidden="true">
+      <g transform="rotate(-8 120 124)">
+        <path
+          d="M 104 84 V 150 Q 104 164 118 164 Q 140 164 168 142"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="16"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <circle cx="78" cy="92" r="12" fill="currentColor" />
+        <circle cx="162" cy="92" r="12" fill="currentColor" />
+      </g>
+    </svg>
+  );
+}
+
+/** Shared between every page so navigation and branding never drift apart. */
+export function SiteHeader(): React.JSX.Element {
+  return (
+    <header className="shell">
+      <nav className="site-nav">
+        <a className="wordmark" href="/">
+          <LukeMark />
+          Luke
+        </a>
+        <a className="nav-link" href={REPOSITORY_URL} aria-label="Luke on GitHub">
+          <GitHubMark />
+        </a>
+      </nav>
+    </header>
+  );
+}
+
+/** Shared between every page so the legal and license links never drift apart. */
+export function SiteFooter(): React.JSX.Element {
+  return (
+    <footer className="site-footer shell">
+      <div className="footer-meta">
+        <span>Apache-2.0</span>
+        <span>macOS 14+</span>
+        <a className="footer-link" href="/privacy">
+          Privacy
+        </a>
+      </div>
+    </footer>
+  );
+}

--- a/apps/web/src/privacy.tsx
+++ b/apps/web/src/privacy.tsx
@@ -1,0 +1,14 @@
+import "@fontsource-variable/bricolage-grotesque/wght.css";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { PrivacyPage } from "./PrivacyPage";
+import "./styles.css";
+
+const rootElement = document.getElementById("root");
+if (!rootElement) throw new Error("Root element is missing");
+
+createRoot(rootElement).render(
+  <StrictMode>
+    <PrivacyPage />
+  </StrictMode>,
+);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -142,6 +142,7 @@ button {
   font-weight: 700;
   gap: var(--space-2);
   letter-spacing: -0.01em;
+  text-decoration: none;
 }
 
 /* Wider than tall, and the default `xMidYMid meet` letterboxes it inside the

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1024,9 +1024,81 @@ button {
   gap: var(--space-2);
 }
 
-.footer-meta span + span::before {
+.footer-meta > * + *::before {
   margin-right: var(--space-2);
   content: "·";
+}
+
+.footer-link {
+  text-decoration: none;
+  transition: color 140ms ease;
+}
+
+.footer-link:hover {
+  color: var(--text);
+}
+
+/* Privacy
+   A legal document read start to finish, so it gets a narrower measure and
+   more vertical rhythm than the marketing copy above: constrained width,
+   a clear step between h1/h2, and generous paragraph spacing.
+   ------------------------------------------------------------------------- */
+
+.privacy {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: var(--space-8) 0 var(--space-9);
+}
+
+.privacy h1 {
+  margin: 0 0 var(--space-6);
+  font-size: 2rem;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+}
+
+.privacy h2 {
+  margin: var(--space-8) 0 var(--space-4);
+  font-size: var(--text-lg);
+  font-weight: 650;
+  letter-spacing: -0.01em;
+}
+
+.privacy p {
+  margin: 0 0 var(--space-4);
+  color: var(--text-secondary);
+}
+
+.privacy ul {
+  margin: 0 0 var(--space-4);
+  padding-left: var(--space-5);
+  color: var(--text-secondary);
+}
+
+.privacy li {
+  margin-bottom: var(--space-2);
+}
+
+.privacy li:last-child {
+  margin-bottom: 0;
+}
+
+.privacy strong {
+  color: var(--text);
+}
+
+.privacy a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.privacy code {
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  background: var(--raised);
+  font-size: 0.9em;
 }
 
 /* Responsive

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    {
+      "source": "/privacy",
+      "destination": "/privacy.html"
+    }
+  ]
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,6 +1,17 @@
+import { fileURLToPath } from "node:url";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
+const resolveEntry = (path: string) => fileURLToPath(new URL(path, import.meta.url));
+
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolveEntry("./index.html"),
+        privacy: resolveEntry("./privacy.html"),
+      },
+    },
+  },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@sidecar/core':
         specifier: workspace:*
         version: link:../../packages/sidecar-core
+      marked:
+        specifier: 18.0.9
+        version: 18.0.9
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -1070,6 +1073,11 @@ packages:
   macos-alias@0.2.12:
     resolution: {integrity: sha512-yiLHa7cfJcGRFq4FrR4tMlpNHb4Vy4mWnpajlSSIFM5k4Lv8/7BbbDLzCAVogWNl0LlLhizRp1drXv0hK9h0Yw==}
     os: [darwin]
+
+  marked@18.0.9:
+    resolution: {integrity: sha512-/Sa4qiiHZxf0/FQdBBowr9q4r10krCwMvpK48FUBdXdUXScDxiQGR9zCPrFgRVR5LU3iySOiIjy09ZQvADir1w==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
@@ -2086,6 +2094,8 @@ snapshots:
     dependencies:
       nan: 2.28.0
     optional: true
+
+  marked@18.0.9: {}
 
   minimatch@10.2.6:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds a `/privacy` page that renders `PRIVACY.md` at build time via `marked`, as a second Vite entry point (`privacy.html`) so the markdown parser never reaches the landing page's bundle — verified by grepping build output.
- Extracts `SiteHeader`/`SiteFooter` into `SiteChrome.tsx` so the landing page and the new privacy page share nav/footer markup instead of duplicating it.
- Adds a targeted Vercel rewrite (`/privacy` → `/privacy.html`, no global `cleanUrls`) and links the new page from the site footer.
- Styles the privacy content with a constrained measure and clear heading rhythm to match the landing page's look.

## Evidence

- Platform-independent checks: `./scripts/check.sh`: passed (lint, typecheck, full test suite, build)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — portable, non-macOS change

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31981224777/artifacts/9272399182) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31981224777)

- Commit: `b3b797227c0c197df7fcc9b6b6ac23564eda56db`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: None. This branch does not include the Google OAuth sign-in/consent scaffolding referenced in the original task — that work is landing on a separate branch.