### PR TITLE
fix(web): replace the placeholder favicon with the Luke app icon

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -23,11 +23,13 @@
          missing image renders better than a broken one. -->
     <meta name="twitter:card" content="summary" />
 
-    <!-- The compact state as a mark: display frame, black notch capsule, cyan
-         status dot. Inline so the page ships no binary asset. -->
+    <!-- Luke's app icon: the L-face on its space-black tile, traced from the
+         generated design/brand/icon/luke-icon-dark.svg — the dark set serves
+         both tab themes, the same way the packaged .icns serves both modes.
+         Inline so the page ships no binary asset. -->
     <link
       rel="icon"
-      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='7' fill='%23131519'/><path d='M7 2h12v6a3 3 0 0 1-3 3h-6a3 3 0 0 1-3-3z' fill='%23000'/><circle cx='23' cy='7' r='3' fill='%2359d6ff'/></svg>"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 240 240' fill='none'><defs><linearGradient id='tile' x1='0' y1='0' x2='1' y2='1'><stop offset='0' stop-color='%2348484a'/><stop offset='1' stop-color='%231c1c1e'/></linearGradient></defs><rect x='8' y='8' width='224' height='224' rx='52' fill='url(%23tile)'/><g transform='translate(-8.54 -11.59) scale(1.06)'><g transform='rotate(-8 120 124)'><path d='M 104 84 V 150 Q 104 164 118 164 Q 140 164 168 142' fill='none' stroke='%23f8fafc' stroke-width='16' stroke-linecap='round' stroke-linejoin='round'/><circle cx='78' cy='92' r='12' fill='%23f8fafc'/><circle cx='162' cy='92' r='12' fill='%23f8fafc'/></g></g></svg>"
     />
   </head>
   <body>


### PR DESCRIPTION
## Summary

The landing page's favicon was still the pre-brand placeholder — a grey display frame with a notch capsule and a cyan status dot. This replaces it with Luke's actual app icon: the L-face on its space-black squircle tile, traced from the generated `design/brand/icon/luke-icon-dark.svg`.

- Inlined as a data URI, following the precedent `App.tsx` sets with the header mark, so the page keeps shipping no fetched assets.
- Uses the dark icon set because one favicon has to serve both light and dark browser tabs, the same reasoning the packaged `.icns` follows.
- The generated brand outputs are untouched; the favicon is a traced copy with a comment citing its source.

## Testing

- Rasterized the new data URI and visually confirmed it renders as the L-face icon on the tile.
- `./scripts/check.sh` passes: brand-asset and surface-vocabulary `--check` report all generated files up to date; lint, typecheck, tests, and both app builds succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/f7bd8840-be11-4a0f-88a8-e55e9d08903f)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31981480207/artifacts/9272479136) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31981480207)

- Commit: `a7f49cbf4abd094d93adc1a8d7cb62c405362eab`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
