### PR TITLE
fix(conductor): drop archived workspaces from the session roster

### DIFF
--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -341,14 +341,18 @@ interface ConductorProject {
   repositoryLabel: string;
 }
 
+/**
+ * A workspace still open on Conductor's own surface. An archived workspace
+ * never becomes one of these: filing a workspace away is how a user says its
+ * chats are done being watched, so the listing drops it before its sessions
+ * are ever asked for.
+ */
 interface ConductorWorkspace {
   id: string;
   name?: string;
   repositoryLabel: string;
   creatorId?: string;
   lastActivityAt: number;
-  /** A workspace already filed away has nothing left to archive. */
-  archived: boolean;
 }
 
 interface ConductorSession {
@@ -363,9 +367,10 @@ interface ConductorSession {
 
 /**
  * Observes Conductor cloud sessions through the documented public API. It reads
- * only workspaces the authenticated user created, observation issues no request
- * that can change provider state, and it reports nothing at all without a
- * credential. Beside the roster reads, one fixed query to Conductor's
+ * only workspaces the authenticated user created and left open — a workspace
+ * filed away on Conductor's own surface is dropped whole, its chats with it —
+ * observation issues no request that can change provider state, and it reports
+ * nothing at all without a credential. Beside the roster reads, one fixed query to Conductor's
  * transcripts view names the sessions the same pass observed and takes back
  * each chat's agent kind and the bounded tail its recap — the settled turn's
  * parting words — is read from; the history behind that tail is never asked
@@ -537,10 +542,10 @@ export class ConductorSessionAdapter
     // reads the roster, and the roster reads above are what judge the
     // credential — so this one read swallows everything rather than letting
     // an enrichment 403 clear every observed row. The lifecycle reads ride
-    // the same way, one per still-open workspace — a filed-away workspace's
-    // state is settled — and a failed one costs that workspace's activity
-    // words and failure message, never the pass.
-    const openWorkspaces = workspaces.filter((workspace) => !workspace.archived);
+    // the same way, one per workspace — every listed workspace is open,
+    // because the listing dropped the filed-away ones — and a failed one
+    // costs that workspace's activity words and failure message, never the
+    // pass.
     const [transcripts, reportedStatuses, workspaceLifecycles] = await Promise.all([
       this.#sessionTranscripts(request, sessions).catch(() => undefined),
       Promise.all(
@@ -553,7 +558,7 @@ export class ConductorSessionAdapter
         ),
       ),
       Promise.all(
-        openWorkspaces.map(async (workspace) => {
+        workspaces.map(async (workspace) => {
           const lifecycle = await this.tolerateItemFailure(() =>
             this.#workspaceLifecycle(request, workspace.id),
           );
@@ -641,6 +646,13 @@ export class ConductorSessionAdapter
           timestampFromRecord(record, CONDUCTOR_FIELD.LAST_ACTIVITY_AT) ??
           timestampFromRecord(record, CONDUCTOR_FIELD.CREATED_AT);
         if (!id || lastActivityAt === undefined) return undefined;
+        // An archived workspace was filed away on Conductor's own surface, so
+        // none of its chats belongs on the roster: it is dropped here, before
+        // its sessions are ever asked for. This is what makes a press of the
+        // archive control actually clear the rows it acted on.
+        if (timestampFromRecord(record, CONDUCTOR_FIELD.ARCHIVED_AT) !== undefined) {
+          return undefined;
+        }
         const creatorId = textFromRecord(record, CONDUCTOR_FIELD.CREATOR_ID);
         const name = textFromRecord(record, CONDUCTOR_FIELD.NAME)?.slice(
           0,
@@ -650,7 +662,6 @@ export class ConductorSessionAdapter
           id,
           repositoryLabel: project.repositoryLabel,
           lastActivityAt,
-          archived: timestampFromRecord(record, CONDUCTOR_FIELD.ARCHIVED_AT) !== undefined,
           ...(name ? { name } : {}),
           ...(creatorId ? { creatorId } : {}),
         };
@@ -829,12 +840,13 @@ export class ConductorSessionAdapter
       : (reported?.errorMessage ?? lifecycle?.errorMessage);
     // The stop belongs to the turn and the archive to the workspace: a chat
     // mid-turn offers the stop alone — its own workspace is by definition
-    // unsettled — and any chat of a positively settled, still-open workspace
-    // offers to file the whole workspace away, closed chats included, because
-    // a closed chat's row is exactly where tidying up happens.
+    // unsettled — and any chat of a positively settled workspace offers to
+    // file the whole workspace away, closed chats included, because a closed
+    // chat's row is exactly where tidying up happens. Every workspace here is
+    // still open: the filed-away ones never made it past the listing.
     const controls = [
       ...(reported?.status === CONDUCTOR_SESSION_STATUS.WORKING ? [CONDUCTOR_CANCEL_CONTROL] : []),
-      ...(!session.workspace.archived && settledWorkspaceIds.has(session.workspace.id)
+      ...(settledWorkspaceIds.has(session.workspace.id)
         ? [conductorArchiveWorkspaceControl(session.workspace.id)]
         : []),
     ];

--- a/apps/desktop/tests/conductor-adapter.test.ts
+++ b/apps/desktop/tests/conductor-adapter.test.ts
@@ -472,12 +472,6 @@ test("a failed lifecycle read costs the workspace's words, never the pass", asyn
         lifecycleStatus: "initializing",
         lifecycleHttpStatus: HTTP_STATUS.SERVER_ERROR,
       },
-      // A filed-away workspace's state is settled, so its lifecycle is not
-      // asked after at all.
-      {
-        ...ownedWorkspace("workspace-archived", TEST_TIME - 10_000),
-        archivedAt: isoTimestamp(TEST_TIME - 10_000),
-      },
     ],
     sessions: [
       {
@@ -487,27 +481,15 @@ test("a failed lifecycle read costs the workspace's words, never the pass", asyn
         status: TEST_CONDUCTOR_STATUS.IDLE,
         statusUpdatedAt: TEST_TIME - 1_000,
       },
-      {
-        id: "chat-archived",
-        workspaceId: "workspace-archived",
-        name: TEST_SESSION_NAME,
-        archivedAt: isoTimestamp(TEST_TIME - 10_000),
-      },
     ],
   });
 
   const observations = await adapterFor(api.fetch).observe();
   const byId = new Map(observations.map((entry) => [entry.providerSessionId, entry]));
 
-  assert.equal(observations.length, 2);
+  assert.equal(observations.length, 1);
   assert.equal(byId.get("chat-unreadable")?.detail?.activity, undefined);
   assert.equal(byId.get("chat-unreadable")?.status, SESSION_STATUS.WAITING);
-  assert.equal(
-    api.requests.some((request) =>
-      request.pathname.endsWith("/workspaces/workspace-archived/status"),
-    ),
-    false,
-  );
 });
 
 const IDLE_SESSION_UUID = "11111111-1111-4111-8111-111111111111";
@@ -1579,15 +1561,20 @@ test("keeps the archive off a workspace whose chat's state could not be read", a
   assert.equal(observations[0]?.controls, undefined);
 });
 
-test("offers no archive for a workspace already filed away", async () => {
+test("leaves a filed-away workspace and its chats off the roster entirely", async () => {
   const api = fakeConductorApi({
     userId: TEST_USER_ID,
     projects: [LUKE_PROJECT],
     workspaces: [
+      // Filing a workspace away is how a user says its chats are done being
+      // watched, so nothing of it survives to the roster — this is also what
+      // makes a press of the archive control actually clear the rows it
+      // acted on, come the next pass.
       {
         ...ownedWorkspace("workspace-filed", TEST_TIME - 30_000),
         archivedAt: isoTimestamp(TEST_TIME - 20_000),
       },
+      ownedWorkspace("workspace-open", TEST_TIME - 5_000),
     ],
     sessions: [
       {
@@ -1596,16 +1583,28 @@ test("offers no archive for a workspace already filed away", async () => {
         name: TEST_SESSION_NAME,
         archivedAt: isoTimestamp(TEST_TIME - 20_000),
       },
+      {
+        id: "session-open",
+        workspaceId: "workspace-open",
+        name: TEST_SESSION_NAME,
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
     ],
   });
 
   const observations = await adapterFor(api.fetch).observe();
 
-  // The chat still reads as a settled row, but its workspace has nothing left
-  // to archive, so no control is advertised at all.
-  assert.equal(observations.length, 1);
-  assert.equal(observations[0]?.status, SESSION_STATUS.COMPLETE);
-  assert.equal(observations[0]?.controls, undefined);
+  assert.deepEqual(
+    observations.map((candidate) => candidate.providerSessionId),
+    ["session-open"],
+  );
+  // Dropped before its sessions are ever asked for: the filed-away workspace
+  // costs no requests, not just no rows.
+  assert.equal(
+    api.requests.some((request) => request.pathname.includes("workspace-filed")),
+    false,
+  );
 });
 
 test("hands a user prompt to Conductor's documented message endpoint", async () => {


### PR DESCRIPTION
## Problem

Archived Conductor cloud workspaces were still showing up in Luke's session roster. The adapter recorded each workspace's archived flag but used it only to withhold the archive control and skip lifecycle reads — the workspace's chats were still listed, enriched, and reported as rows. Pressing "Archive this workspace" therefore never cleared the rows it acted on.

## Fix

Drop an archived workspace at listing time in `#listWorkspaces`, before its sessions are ever asked for. Filing a workspace away on Conductor's own surface is how a user says its chats are done being watched, so nothing of it survives to the roster — and it costs no requests, not just no rows. The `archived` field on `ConductorWorkspace` is gone with it: every workspace that reaches `collect` is open, so the `openWorkspaces` split and the `!session.workspace.archived` control check fell away.

Deliberately unchanged: a closed chat inside a still-open workspace keeps its `COMPLETE` row — that is where tidying up (the archive control) happens.

## Tests

- New: `leaves a filed-away workspace and its chats off the roster entirely` — asserts no rows and no requests naming the filed-away workspace, beside an open workspace that still reports.
- Repurposed: the old `offers no archive for a workspace already filed away` asserted a row this change removes; the lifecycle-read test similarly lost its filed-away fixture, now covered by the new test.
- `./scripts/check.sh` passes (exit 0); portable-only change, no UI surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/3545e56b-48af-4aea-aacb-0c9258fcab83)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31982198103/artifacts/9272691904) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31982198103)

- Commit: `f9e1fe74e5531580f9013541f1f78b412a0eab87`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
