### PR TITLE
feat(voice): report call failures on the caption strip instead of Settings

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -104,7 +104,7 @@ import { useBootstrapRacedChannel } from "./use-bootstrap-raced-channel";
 import { panelEntryOpen, usePanelEntry } from "./use-panel-entry";
 import { usePanelPresentation } from "./use-panel-presentation";
 import { useStateWithRef } from "./use-state-with-ref";
-import { useVoiceConversation } from "./use-voice-conversation";
+import { useVoiceConversation, voiceErrorToShow } from "./use-voice-conversation";
 import {
   outputSilent,
   VOLUME_HINT_HEIGHT,
@@ -1222,7 +1222,7 @@ export function App(): React.JSX.Element {
     analyser,
     microphoneStatus,
     setMicrophoneStatus,
-    microphoneError,
+    voiceError,
     voiceStatus,
     talkOpening,
     voiceHotkey,
@@ -1649,6 +1649,16 @@ export function App(): React.JSX.Element {
   const fixtureSpeaking = bootstrap.profile === "speaking" || fixtureMuted;
   const hasAudioSignal = fixtureSpeaking || analyser !== undefined;
   const outputIsSilent = outputSilent(outputAudio);
+  // A failed call is reported where its reply would have landed: on the
+  // caption strip, under the field or the key press that asked. It yields to
+  // live words, so it can never be drawn over a reply being spoken.
+  const voiceErrorNotice = voiceErrorToShow({
+    fixtureSpeaking,
+    voice: voiceTurn,
+    error: voiceError,
+  });
+  const captionText = lukeCaption ?? voiceErrorNotice;
+  const captionIsError = lukeCaption === undefined && voiceErrorNotice !== undefined;
   // The hint rides the caption it explains, and only over a silence the
   // helper actually reported. "Got it" quiets it for this stretch of silence
   // and any that follows too soon; the captions above it stay either way.
@@ -1668,7 +1678,6 @@ export function App(): React.JSX.Element {
       : CREDENTIAL_SOURCE.NONE;
   const microphone: MicrophoneControl = {
     status: microphoneStatus,
-    ...(microphoneError ? { error: microphoneError } : {}),
     voiceAvailable: (settings ?? bootstrap.settings).voiceAvailable,
     onRequest: () => void requestMicrophoneAccess(),
     onOpenSettings: () => window.sidecar.openMicrophoneSettings(),
@@ -1708,9 +1717,10 @@ export function App(): React.JSX.Element {
       // Whose turn it is, so the capsule can make room for a meter it has to
       // draw beside the face rather than in place of it.
       data-voice={voiceTurn}
-      // Whether there are words to draw under the shape, so the surface can
-      // grow the room they are drawn in.
-      data-caption={String(Boolean(lukeCaption))}
+      // Whether there are words to draw under the shape — a caption or a
+      // failure borrowing its strip — so the surface can grow the room they
+      // are drawn in.
+      data-caption={String(Boolean(captionText))}
       // Whether those words need the volume hint under them, which shares the
       // caption block's room.
       data-volume-hint={String(volumeHint)}
@@ -1806,11 +1816,17 @@ export function App(): React.JSX.Element {
           capsule's height — and always mounted, like the count's caption, so
           both edges of its fade can run. The inner text is what is measured:
           its wrapped height is the only honest answer to how much room the
-          words need. Hidden from readers: it duplicates what is already
-          audible. */}
-      <span className="voice-caption" ref={captionElement} aria-hidden="true">
+          words need. Hidden from readers while it captions speech — it
+          duplicates what is already audible — and announced as a status line
+          when it carries a failure, which was never audible at all. */}
+      <span
+        className="voice-caption"
+        ref={captionElement}
+        data-error={String(captionIsError)}
+        {...(captionIsError ? { role: "status" } : { "aria-hidden": true })}
+      >
         <span className="voice-caption-text" ref={captionTextElement}>
-          {lukeCaption}
+          {captionText}
         </span>
       </span>
 

--- a/apps/desktop/src/renderer/ask-luke.tsx
+++ b/apps/desktop/src/renderer/ask-luke.tsx
@@ -59,7 +59,8 @@ export type AskHandler = (text: string) => Promise<string | undefined>;
  * The refusal is diagnosed from the same two facts the settings rows draw —
  * how far the voice loop got, and what the system said about the microphone —
  * so the sentence under the field and the rows in settings can never tell two
- * different stories.
+ * different stories. A failure's own message is not repeated here: it lands
+ * on the caption strip directly below, where the reply would have.
  */
 export function askRefusal(status: RealtimeStatus, microphone: MicrophoneStatus): string {
   if (status === REALTIME_STATUS.LISTENING) {
@@ -75,7 +76,7 @@ export function askRefusal(status: RealtimeStatus, microphone: MicrophoneStatus)
     return "Luke answers out loud, so the conversation needs the microphone — allow it in Settings.";
   }
   if (status === REALTIME_STATUS.FAILED) {
-    return "The conversation could not be opened — Settings says why.";
+    return "The conversation could not be opened — the notice below says why.";
   }
   return "Luke could not take that just now.";
 }

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -644,6 +644,13 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
               "conversation says so rather than quietly forgetting. Nothing is written down " +
               "between conversations.",
           },
+          {
+            label: "When a call fails",
+            detail:
+              "Why a call failed or ended is shown for a few seconds where the captions are " +
+              "drawn — under the housing, or at the open panel's foot — and then fades. " +
+              "Nothing about it lives in Settings; trying again is the only fix to reach for.",
+          },
         ]
       : [
           {

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -103,7 +103,6 @@ export interface WorkspaceProviderOption {
  */
 export interface MicrophoneControl {
   status: MicrophoneStatus;
-  error?: string;
   /** Whether there is anything to talk to, which is the microphone's only use. */
   voiceAvailable: boolean;
   /** Asks the system for access. Using the microphone is the talk key's job. */
@@ -1836,7 +1835,6 @@ export function SettingsPanel({
                 ) : null}
               </span>
             </div>
-            {microphone.error ? <p className="error-message">{microphone.error}</p> : null}
           </section>
 
           <FeedbackSection control={feedback} />

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1275,6 +1275,13 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   transition: transform var(--duration-fast) var(--spring-fast);
 }
 
+/* A voice failure borrows the caption's strip — same box, same travel — in
+   the `.error-message` red, because it is a fault being reported rather than
+   words being spoken. */
+.voice-caption[data-error="true"] .voice-caption-text {
+  color: #ff8c8c;
+}
+
 /* Volume hint ------------------------------------------------------------- */
 
 /* Why the words above are the only part of Luke arriving: the Mac's output is

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -700,6 +700,14 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     return () => clearTimeout(timer);
   }, [voiceError]);
 
+  // An exchange going live outranks the clock: the conversation has moved on,
+  // and a fault the turn hid must not come back once the words finish.
+  // `startMicrophone` clears the calls that have to reconnect; this clears the
+  // one that carried a mid-call error and never dropped.
+  useEffect(() => {
+    if (voiceExchangeActive(voiceStatus)) setVoiceError(undefined);
+  }, [voiceStatus]);
+
   useEffect(() => {
     window.sidecar.setVoiceExchangeActive(voiceExchangeActive(voiceStatus));
   }, [voiceStatus]);

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -91,6 +91,31 @@ export function voiceExchangeActive(status: RealtimeStatus): boolean {
 }
 
 /**
+ * How long a voice failure stays on the caption strip. The strip takes no
+ * pointer, so time is its only dismissal: long enough to be read twice, short
+ * enough that the shape does not wear a fault all afternoon. The next attempt
+ * clears it sooner — connecting starts by reporting nothing wrong.
+ */
+export const VOICE_ERROR_NOTICE_MS = 12_000;
+
+/**
+ * The failure drawn in the same strip the captions use. A fault is worth
+ * reading where the words it interrupted would have landed — at the shape's
+ * foot, under the field that asked — not on a settings page nobody is
+ * looking at. It yields to a live turn, because words being said are the
+ * thing to read over words that already failed, and a capture run never
+ * draws one: a fixture has no call to fail.
+ */
+export function voiceErrorToShow(input: {
+  fixtureSpeaking: boolean;
+  voice: WaveformVoice | undefined;
+  error: string | undefined;
+}): string | undefined {
+  if (input.fixtureSpeaking || input.voice !== undefined) return undefined;
+  return input.error;
+}
+
+/**
  * The words drawn under the shape. A capture run always draws the fixture's
  * words; otherwise Luke's caption is shown only when there is a reason to
  * read them and the reply they belong to is his turn: the captions preference,
@@ -255,7 +280,12 @@ export interface VoiceConversation {
   analyser: AnalyserNode | undefined;
   microphoneStatus: MicrophoneStatus;
   setMicrophoneStatus: (status: MicrophoneStatus) => void;
-  microphoneError: string | undefined;
+  /**
+   * Why the last call failed or ended, for the caption strip to show. Set by
+   * the session, cleared by the next attempt or by {@link VOICE_ERROR_NOTICE_MS}
+   * running out — whichever comes first.
+   */
+  voiceError: string | undefined;
   voiceStatus: RealtimeStatus;
   setVoiceStatus: (status: RealtimeStatus) => void;
   talkOpening: boolean;
@@ -287,7 +317,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
 
   const [analyser, setAnalyser] = useState<AnalyserNode>();
   const [microphoneStatus, setMicrophoneStatus] = useState<MicrophoneStatus>("not-determined");
-  const [microphoneError, setMicrophoneError] = useState<string>();
+  const [voiceError, setVoiceError] = useState<string>();
   const [voiceStatus, setVoiceStatus, voiceStatusNow] = useStateWithRef<RealtimeStatus>(
     REALTIME_STATUS.IDLE,
   );
@@ -373,7 +403,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       onStatus: setVoiceStatus,
       onLocalStream: setLocalStream,
       onRemoteStream: setRemoteStream,
-      onError: setMicrophoneError,
+      onError: setVoiceError,
       onCaption: setVoiceCaption,
     });
     return voiceSession.current;
@@ -436,7 +466,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
    * why.
    */
   const startMicrophone = useCallback(async (): Promise<MicrophoneStatus> => {
-    setMicrophoneError(undefined);
+    setVoiceError(undefined);
     const session = ensureVoiceSession();
     const permission = await window.sidecar.requestMicrophone();
     setMicrophoneStatus(permission);
@@ -661,6 +691,15 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     }
   }, [voiceStatus]);
 
+  // The strip the error is drawn on takes no pointer, so nothing but time can
+  // dismiss it: a fault left up would sit on the desktop all afternoon. A new
+  // error re-arms the clock — it is a new thing to read.
+  useEffect(() => {
+    if (voiceError === undefined) return;
+    const timer = setTimeout(() => setVoiceError(undefined), VOICE_ERROR_NOTICE_MS);
+    return () => clearTimeout(timer);
+  }, [voiceError]);
+
   useEffect(() => {
     window.sidecar.setVoiceExchangeActive(voiceExchangeActive(voiceStatus));
   }, [voiceStatus]);
@@ -759,7 +798,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     analyser,
     microphoneStatus,
     setMicrophoneStatus,
-    microphoneError,
+    voiceError,
     voiceStatus,
     setVoiceStatus,
     talkOpening,

--- a/apps/desktop/tests/ask-luke.test.ts
+++ b/apps/desktop/tests/ask-luke.test.ts
@@ -11,7 +11,10 @@ test("a refused ask is diagnosed from how far the voice loop got", () => {
   // An open microphone is the developer's own turn, not a fault.
   assert.match(askRefusal(REALTIME_STATUS.LISTENING, "granted"), /microphone is open/i);
   assert.match(askRefusal(REALTIME_STATUS.CONNECTING, "granted"), /connecting/i);
-  assert.match(askRefusal(REALTIME_STATUS.FAILED, "granted"), /Settings/);
+  // The failure's own message lands on the caption strip directly below the
+  // field, so the refusal points there rather than at a settings page.
+  assert.match(askRefusal(REALTIME_STATUS.FAILED, "granted"), /below/);
+  assert.doesNotMatch(askRefusal(REALTIME_STATUS.FAILED, "granted"), /Settings/);
 });
 
 test("a missing microphone explains the conversation, not the keystroke", () => {

--- a/apps/desktop/tests/use-voice-conversation.test.ts
+++ b/apps/desktop/tests/use-voice-conversation.test.ts
@@ -19,6 +19,7 @@ import {
   talkOpeningHolds,
   typedAskHolds,
   VOICE_RESTART,
+  voiceErrorToShow,
   voiceExchangeActive,
   voiceRestartAction,
   waveformVoice,
@@ -95,6 +96,31 @@ test("Luke's caption is drawn only on his turn, and only with a reason to read i
     lukeCaptionToShow({ ...shown, captionsEnabled: false }),
     undefined,
     "the preference is about speech being duplicated, and with it off there is no reason to read",
+  );
+});
+
+test("a voice failure is drawn on the strip, but never over a live turn or a fixture", () => {
+  const failure = {
+    fixtureSpeaking: false,
+    voice: undefined,
+    error: "The voice service refused the call (status 401).",
+  };
+  assert.equal(voiceErrorToShow(failure), failure.error);
+  assert.equal(voiceErrorToShow({ ...failure, error: undefined }), undefined);
+  assert.equal(
+    voiceErrorToShow({ ...failure, voice: WAVEFORM_VOICE.LUKE }),
+    undefined,
+    "words being said are the thing to read over words that already failed",
+  );
+  assert.equal(
+    voiceErrorToShow({ ...failure, voice: WAVEFORM_VOICE.DEVELOPER }),
+    undefined,
+    "the developer's own turn is not the moment to report an old fault",
+  );
+  assert.equal(
+    voiceErrorToShow({ ...failure, fixtureSpeaking: true }),
+    undefined,
+    "a fixture has no call to fail, so a capture run never draws one",
   );
 });
 


### PR DESCRIPTION
## What

Why a voice call failed — or ended underneath a conversation — now shows up in the popup at the shape's foot, the same strip the captions use, instead of as an error line buried in the Settings Permissions section. The ask field's refusal for a failed call no longer says "Settings says why"; it points at the notice directly below.

## Why

"The conversation could not be opened — Settings says why" sent the developer to a settings page to learn something that should have been said where they were already looking. Errors don't belong in Settings: the caption strip is where the reply's words would have landed, so it is where the words about the failure land too.

## How

- `voiceErrorToShow` (pure, tested) decides when the failure is drawn: never over a live turn — words being said beat words that already failed — and never on a capture run, which has no call to fail.
- The strip takes no pointer, so time is its only dismissal: the notice fades after `VOICE_ERROR_NOTICE_MS` (12 s), and the next connect attempt clears it sooner. It rides the existing caption element — same box, same travel, no new motion — in the `.error-message` red, and carries `role="status"` while it holds a failure (a caption merely duplicates what is audible; a failure was never audible at all).
- The hook's `microphoneError` is renamed `voiceError` — it always carried connection and service failures, not just microphone ones — and the Settings error line plus `MicrophoneControl.error` are removed.
- `askRefusal` for `FAILED` now reads "The conversation could not be opened — the notice below says why."
- The guide gains a "When a call fails" fact, so Luke describes where failures show instead of denying it.

## Verification

- `./scripts/check.sh` passes (repository contracts, lint, typecheck, all tests, builds; exit 0, fail 0).
- New tests: `voiceErrorToShow` yields to either live turn and to fixtures; the FAILED refusal points below and no longer at Settings.
- `./scripts/verify.sh` was not run here (Linux environment); CI's macOS job runs it and links the visual evidence below. No physical-notch check performed. The drawn change is confined to the existing caption strip: error-red text in the same box with the same motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/79d4e806-1547-4653-82b0-0ce50a6e10ae)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31982493833/artifacts/9272782607) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31982493833)

- Commit: `b67ac3d972c65b99d210468bc14c9a4a213d83d2`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
