### PR TITLE
feat(sessions): search the list by what its rows say

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -92,6 +92,7 @@ import {
 } from "./session-model";
 import { parsePixels } from "./session-motion";
 import { SESSION_OPTIONS_BUTTON_ID, SESSION_OPTIONS_ID } from "./session-parts";
+import { focusSearchField } from "./session-search";
 import type { MicrophoneControl, PreferenceWrites, ShortcutControl } from "./settings-panel";
 import {
   credentialSettingsPage,
@@ -220,6 +221,7 @@ export function App(): React.JSX.Element {
   );
   const [sessionView, setSessionView] = useState<SessionView>(DEFAULT_SESSION_VIEW);
   const [optionsOpen, setOptionsOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
   // The latest is needed from the spoken-settings carrier, which cannot wait
   // a render: two changes asked for in one breath arrive as two calls in one
   // turn, and the second composes against whatever the first just stored.
@@ -437,7 +439,13 @@ export function App(): React.JSX.Element {
     entryDrawn: () => credentialHeld.current && tabNow() === PANEL_TAB.SETTINGS,
     composerHeld: () => credentialHeld.current || feedbackHeld.current,
     onNotPanel: () => setOptionsOpen(false),
-    onCapsuleList: () => setSessionView(DEFAULT_SESSION_VIEW),
+    onCapsuleList: () => {
+      // A search is a question about the list as it was, so it closes with
+      // the panel on the same terms the filter does — a remembered query
+      // could hide the very session the capsule is reporting.
+      setSessionView(DEFAULT_SESSION_VIEW);
+      setSearchOpen(false);
+    },
     onCapsuleTab: () => changeTab(PANEL_TAB.SESSIONS),
   });
 
@@ -988,6 +996,28 @@ export function App(): React.JSX.Element {
   }, [cancelHover, changeMode, changeTab, presentationOf]);
 
   /**
+   * The search summons, from its button or Command-F. It lands on the Sessions
+   * tab whatever is showing — the field it opens is that list's — and the
+   * caret follows the same frame-by-frame seek the ask field needs, because
+   * the field may not be drawn until React has answered.
+   */
+  const openSearch = useCallback(() => {
+    changeTab(PANEL_TAB.SESSIONS);
+    setSearchOpen(true);
+    focusSearchField();
+  }, [changeTab]);
+
+  /**
+   * Closing the search lets go of its query in the same act: a field that
+   * left its narrowing in force behind no visible control would be hiding
+   * sessions with nothing on screen admitting it.
+   */
+  const closeSearch = useCallback(() => {
+    setSearchOpen(false);
+    setSessionView((view) => (view.query === "" ? view : { ...view, query: "" }));
+  }, []);
+
+  /**
    * The panel standing back down once an errand it stood up is over. The same
    * rule a saved key follows, for the same reason: the shape was brought
    * forward to show an answer, the answer has been shown, and nothing else
@@ -1504,6 +1534,15 @@ export function App(): React.JSX.Element {
         changeTab(PANEL_TAB.SETTINGS);
         return;
       }
+      // Find, the way every macOS list answers it. Claimed on the same terms
+      // as Command-comma: only while the panel has the keyboard. The lowercase
+      // key is deliberate — with Shift held this is some other app's chord.
+      if (event.key === "f" && (event.metaKey || event.ctrlKey)) {
+        if (presentation !== PANEL_PRESENTATION.PANEL) return;
+        event.preventDefault();
+        openSearch();
+        return;
+      }
       if (event.key !== "Escape") return;
       // Discarding an open turn comes before any of it. Closing the panel
       // or a sheet mid-sentence would strand the microphone open.
@@ -1537,9 +1576,13 @@ export function App(): React.JSX.Element {
       }
       if (presentation !== PANEL_PRESENTATION.PANEL) return;
       // Otherwise it closes the nearest thing that is open, one layer at a
-      // time: the options sheet, then a settings page back to the front page,
-      // then the settings tab, then the panel itself.
+      // time: the options sheet, then the search field, then a settings page
+      // back to the front page, then the settings tab, then the panel itself.
+      // The search field answers its own Escapes while the caret is in it —
+      // clearing before closing — so the press that lands here is one made
+      // from elsewhere in the panel, and it closes the field outright.
       if (optionsOpen) setOptionsOpen(false);
+      else if (tab === PANEL_TAB.SESSIONS && searchOpen) closeSearch();
       else if (tab === PANEL_TAB.SETTINGS && settingsView !== SETTINGS_VIEW.ROOT) {
         setSettingsView(SETTINGS_VIEW.ROOT);
       } else if (tab === PANEL_TAB.SETTINGS) changeTab(PANEL_TAB.SESSIONS);
@@ -1551,10 +1594,13 @@ export function App(): React.JSX.Element {
     credentialsEntry.cancel,
     changeMode,
     changeTab,
+    closeSearch,
     dismissFeedback,
     discardListening,
+    openSearch,
     optionsOpen,
     presentation,
+    searchOpen,
     setSettingsView,
     settingsView,
     stopSpeaking,
@@ -1636,6 +1682,18 @@ export function App(): React.JSX.Element {
   // the next session to arrive would open it again with nothing pressed.
   const offerOptions = tab === PANEL_TAB.SESSIONS && list.total > 1;
   if (optionsOpen && !offerOptions) setOptionsOpen(false);
+  // Search is offered on the options' own terms: one session leaves nothing
+  // to find that is not already on screen. Its being open goes when its button
+  // does — and the query goes with it, by the same rule the emptied filter
+  // follows, because a narrowing left in force behind no visible control would
+  // hide sessions with nothing admitting it. The tab is not part of this gate:
+  // a search held while Settings shows is still the sessions tab's own state,
+  // waiting where the developer left it.
+  const offerSearch = tab === PANEL_TAB.SESSIONS && list.total > 1;
+  if (searchOpen && list.total <= 1) {
+    setSearchOpen(false);
+    if (sessionView.query !== "") setSessionView({ ...sessionView, query: "" });
+  }
   // Which clock the rows' ages are honest against. Fixture observations are
   // measured back from the fixture's own epoch precisely so that no capture
   // run reads them against the time it happened to run at.
@@ -1755,6 +1813,10 @@ export function App(): React.JSX.Element {
             offerOptions={offerOptions}
             optionsOpen={optionsOpen}
             onOptionsToggle={() => setOptionsOpen((open) => !open)}
+            offerSearch={offerSearch}
+            searchOpen={searchOpen}
+            onSearchToggle={() => (searchOpen ? closeSearch() : openSearch())}
+            onSearchClose={closeSearch}
             tab={tab}
             onTabChange={changeTab}
             settings={{

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -510,7 +510,14 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "with its state, narrowable to all, local, " +
         "cloud, or one provider, and orderable by urgency (what needs the developer first) or " +
         "recency (what moved last first) — by its options button, or by the same ask that shows " +
-        "the tab; a row can be opened, messaged, or controlled where its " +
+        "the tab. The list is searchable by hand alone: the magnifier beside the options " +
+        "button, or Command-F while the panel has the keyboard, opens a field that keeps only " +
+        "rows saying every typed word in their title, status line, branch, repository, " +
+        "workspace, agent, or model, marks where the words landed, and counts what it left; a " +
+        "search that matches nothing says so — offering the matches a filter is hiding rather " +
+        "than pretending there are none — Escape clears the query and then closes the field, " +
+        "no spoken ask can search, and no search survives the panel closing. " +
+        "A row can be opened, messaged, or controlled where its " +
         "provider allows, and Luke's own composer at the foot of the list takes a typed ask. " +
         "Where a provider nests chats in a workspace — Conductor today — each " +
         "chat is its own row: a workspace holding several draws them inside one tray named by " +

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -17,6 +17,7 @@ import {
   type SessionListRun,
   type SessionView,
   sessionListRuns,
+  sessionRunKeys,
 } from "./session-model";
 import {
   LEAVING_ATTRIBUTE,
@@ -34,6 +35,13 @@ import {
   SessionsPanel,
   WorkspaceGlyph,
 } from "./session-parts";
+import {
+  Highlighted,
+  SearchEmptyState,
+  SessionSearch,
+  SessionSearchButton,
+  widenedView,
+} from "./session-search";
 import { SendIcon, StopIcon } from "./settings-icons";
 import { SettingsPanel, type SettingsPanelProps } from "./settings-panel";
 
@@ -285,6 +293,7 @@ function SessionRow({
   now,
   leaving,
   inWorkspaceTray = false,
+  highlight,
   onOpen,
   writes,
 }: {
@@ -294,6 +303,8 @@ function SessionRow({
   leaving: boolean;
   /** Whether this row is drawn inside its workspace's tray. */
   inWorkspaceTray?: boolean;
+  /** The search's words, marked on the row's lines so it says why it matched. */
+  highlight?: readonly string[] | undefined;
   onOpen: (session: DisplaySession) => void;
   writes: SessionWriteHandlers;
 }): React.JSX.Element {
@@ -332,7 +343,9 @@ function SessionRow({
         {session.location === SESSION_LOCATION.CLOUD ? <CloudBadge /> : null}
       </span>
       <span className="row-copy">
-        <strong>{title}</strong>
+        <strong>
+          <Highlighted text={title} tokens={highlight} />
+        </strong>
         <small className="row-doing">
           {session.urgency === SESSION_URGENCY.WORKING ? (
             <span className="row-spinner" aria-hidden="true" />
@@ -342,13 +355,15 @@ function SessionRow({
             {session.detail === session.label ? null : (
               <span className="visually-hidden">{session.label}. </span>
             )}
-            {session.detail}
+            <Highlighted text={session.detail} tokens={highlight} />
           </span>
         </small>
         {place ? (
           <small className="row-place">
             {session.branch ? <BranchGlyph /> : null}
-            <span>{place}</span>
+            <span>
+              <Highlighted text={place} tokens={highlight} />
+            </span>
           </small>
         ) : null}
       </span>
@@ -426,9 +441,12 @@ export function runDrawsTray(run: SessionListRun): boolean {
  */
 function SessionRun({
   run,
+  highlight,
   children,
 }: {
   run: SessionListRun;
+  /** The search's words, marked on the tray's own header lines too. */
+  highlight?: readonly string[] | undefined;
   children: React.ReactNode;
 }): React.JSX.Element {
   const tray = runDrawsTray(run);
@@ -449,10 +467,16 @@ function SessionRun({
           never reseat the keyed rows beside it. */}
       {tray ? (
         <header className="workspace-tray-header">
-          <span className="workspace-tray-name">{run.workspace?.name}</span>
+          <span className="workspace-tray-name">
+            <Highlighted text={run.workspace?.name ?? ""} tokens={highlight} />
+          </span>
           <span className="workspace-tray-meta">
             <WorkspaceGlyph />
-            {run.repository ? <span>{run.repository}</span> : null}
+            {run.repository ? (
+              <span>
+                <Highlighted text={run.repository} tokens={highlight} />
+              </span>
+            ) : null}
           </span>
         </header>
       ) : null}
@@ -489,6 +513,13 @@ export interface PanelBodyProps {
   offerOptions: boolean;
   optionsOpen: boolean;
   onOptionsToggle: () => void;
+  /** Whether there is anything to search, on the same terms as the options. */
+  offerSearch: boolean;
+  searchOpen: boolean;
+  /** Opens the field focused, or closes it and lets go of its query. */
+  onSearchToggle: () => void;
+  /** The field's own way out — Escape on an empty query — which also clears. */
+  onSearchClose: () => void;
   tab: PanelTab;
   onTabChange: (tab: PanelTab) => void;
   /**
@@ -512,21 +543,35 @@ export function PanelBody({
   offerOptions,
   optionsOpen,
   onOptionsToggle,
+  offerSearch,
+  searchOpen,
+  onSearchToggle,
+  onSearchClose,
   tab,
   onTabChange,
   settings,
 }: PanelBodyProps): React.JSX.Element {
   const sessionListRef = useSessionReorderMotion();
   const rows = useRoster(list.sessions, sessionListRef);
+  const highlight = list.search?.tokens;
+  const runs = sessionListRuns(rows.map((row) => row.item));
+  const runKeys = sessionRunKeys(runs, rows);
   return (
     <div className="body">
-      {/* The tab bar says what you are looking at; the options button says how
-          it is being shown. One line, because the second is only ever a
+      {/* The tab bar says what you are looking at; the buttons beside it say
+          how it is being shown. One line, because the second is only ever a
           qualifier on the first. */}
       <div className="panel-header">
         <TabBar tab={tab} onTabChange={onTabChange} />
-        {offerOptions ? (
-          <SessionOptionsButton list={list} open={optionsOpen} onToggle={onOptionsToggle} />
+        {offerSearch || offerOptions ? (
+          <span className="header-controls">
+            {offerSearch ? (
+              <SessionSearchButton open={searchOpen} onToggle={onSearchToggle} />
+            ) : null}
+            {offerOptions ? (
+              <SessionOptionsButton list={list} open={optionsOpen} onToggle={onOptionsToggle} />
+            ) : null}
+          </span>
         ) : null}
       </div>
       {tab === PANEL_TAB.SETTINGS ? (
@@ -536,23 +581,36 @@ export function PanelBody({
           {offerOptions && optionsOpen ? (
             <SessionOptions list={list} view={view} onViewChange={onViewChange} />
           ) : null}
+          {searchOpen ? (
+            <SessionSearch
+              list={list}
+              view={view}
+              onViewChange={onViewChange}
+              onClose={onSearchClose}
+              onEngagedChange={onAskEngaged}
+            />
+          ) : null}
           <div className="session-list" ref={sessionListRef}>
             {rows.length === 0 ? (
-              <EmptyState />
+              list.search ? (
+                <SearchEmptyState
+                  query={view.query}
+                  beyondFilter={list.search.beyondFilter}
+                  onWiden={() => onViewChange(widenedView(view))}
+                />
+              ) : (
+                <EmptyState />
+              )
             ) : (
               // Runs are read over the drawn order, leaving rows and all: a
               // fading chat still holds its slot in its tray, and the tray
-              // may not close around it until it has gone.
-              sessionListRuns(rows.map((row) => row.item)).map((run) => {
+              // may not close around it until it has gone. Keys are resolved
+              // over the whole list at once, because a run's key depends on
+              // the other runs of its workspace.
+              runs.map((run, at) => {
                 const tray = runDrawsTray(run);
-                const lead = rows[run.indexes[0] ?? 0];
-                // A workspace run is keyed by the workspace however many chats
-                // it holds, so crossing between one and several keeps the same
-                // wrapper — and the rows inside it — mounted. An ungrouped
-                // session is its own run, keyed by itself.
-                const runKey = run.workspace?.id ?? lead?.item.id ?? "";
                 return (
-                  <SessionRun key={runKey} run={run}>
+                  <SessionRun key={runKeys[at]} run={run} highlight={highlight}>
                     {run.indexes.map((index) => {
                       const row = rows[index];
                       return row ? (
@@ -563,6 +621,7 @@ export function PanelBody({
                           now={now}
                           leaving={row.leaving}
                           inWorkspaceTray={tray}
+                          highlight={highlight}
                           onOpen={onOpenSession}
                           writes={writes}
                         />

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -73,17 +73,21 @@ export type SessionSort = SessionListSort;
 export interface SessionView {
   filter: SessionFilter;
   sort: SessionSort;
+  /** The words the list is searched by; empty when nothing is being searched. */
+  query: string;
 }
 
 /**
  * What the panel opens on, every time. A filter is not remembered across a
  * closing, because a remembered one could hide the very session the capsule is
  * reporting; the order is not remembered with it, so the top row keeps matching
- * the mark the capsule kept.
+ * the mark the capsule kept. A search is forgotten on the same terms — it is a
+ * question about the list as it was, not a standing way of viewing it.
  */
 export const DEFAULT_SESSION_VIEW: SessionView = {
   filter: SESSION_FILTER.ALL,
   sort: SESSION_SORT.URGENCY,
+  query: "",
 };
 
 /** One provider-advertised action, exactly as the adapter advertised it. */
@@ -155,6 +159,20 @@ export interface SessionFilterOption {
   providerId?: string;
 }
 
+/** What became of the query, reported so no narrowing is ever silent. */
+export interface SessionSearchOutcome {
+  /** The query's words, lowercased — what each row was actually read against. */
+  tokens: readonly string[];
+  /** How many sessions the query was read against: the filtered set. */
+  searched: number;
+  /**
+   * Sessions the query matches that the filter is hiding. The count is what
+   * lets an emptied search offer the matches instead of implying there are
+   * none anywhere.
+   */
+  beyondFilter: number;
+}
+
 export interface ArrangedSessions {
   /** The rows the list draws, narrowed and ordered. */
   sessions: readonly DisplaySession[];
@@ -163,6 +181,8 @@ export interface ArrangedSessions {
   /** The filter actually in force, which is All whenever the chosen one emptied. */
   filter: SessionFilter;
   options: readonly SessionFilterOption[];
+  /** Present only while a query is in force. */
+  search?: SessionSearchOutcome;
 }
 
 export interface ProviderTally {
@@ -220,6 +240,74 @@ function sessionUrgency(session: NormalizedSession): SessionUrgency {
   if (session.status === SESSION_STATUS.COMPLETE) return SESSION_URGENCY.COMPLETE;
   if (session.status === SESSION_STATUS.UNKNOWN) return SESSION_URGENCY.UNKNOWN;
   return SESSION_URGENCY.WORKING;
+}
+
+/**
+ * A query read into the words it asks for: lowercased and split on whitespace,
+ * because matching is case-blind and every word must be found somewhere. A
+ * blank query has no words, which is what makes it no search at all.
+ */
+function searchTokens(query: string): readonly string[] {
+  return query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((token) => token.length > 0);
+}
+
+/**
+ * The lines a query is read against: everything the row itself can say — its
+ * title, the sentence under it, the branch and repository, the workspace it is
+ * a chat of — plus the two identifiers the row keeps on the mark's hover, the
+ * agent's name and its model. Search finds rows by what they show, so a match
+ * is always something the developer can see once the row is on screen.
+ */
+function searchableLines(session: DisplaySession): readonly string[] {
+  const lines = [
+    session.title,
+    session.detail,
+    session.branch,
+    session.repository,
+    session.workspace?.name,
+    session.provider,
+    session.model,
+  ];
+  return lines.filter((line): line is string => line !== undefined);
+}
+
+/** Every word somewhere on the row: words narrow, they never widen. */
+function matchesQuery(session: DisplaySession, tokens: readonly string[]): boolean {
+  const lines = searchableLines(session).map((line) => line.toLowerCase());
+  return tokens.every((token) => lines.some((line) => line.includes(token)));
+}
+
+/** One stretch of a drawn line that a query's word landed on. */
+export interface MatchRange {
+  start: number;
+  end: number;
+}
+
+/**
+ * Where a query's words sit in one drawn line, so the row can show why it
+ * matched. Every occurrence of every word is taken and overlapping stretches
+ * are merged, because two words landing on one stretch of text should read as
+ * one mark rather than nested ones.
+ */
+export function matchRanges(text: string, tokens: readonly string[]): readonly MatchRange[] {
+  const lowered = text.toLowerCase();
+  const found: MatchRange[] = [];
+  for (const token of tokens) {
+    for (let from = lowered.indexOf(token); from !== -1; from = lowered.indexOf(token, from + 1)) {
+      found.push({ start: from, end: from + token.length });
+    }
+  }
+  found.sort((first, second) => first.start - second.start || first.end - second.end);
+  const merged: MatchRange[] = [];
+  for (const range of found) {
+    const last = merged.at(-1);
+    if (last && range.start <= last.end) last.end = Math.max(last.end, range.end);
+    else merged.push({ ...range });
+  }
+  return merged;
 }
 
 /** Most urgent first, and within one state the one that moved most recently. */
@@ -404,6 +492,39 @@ export interface SessionListRun {
   indexes: readonly number[];
 }
 
+/**
+ * One React key per run. A workspace run is keyed by the workspace so that a
+ * tray crossing between one chat and several keeps the same wrapper — and the
+ * rows inside it, and their half-typed drafts — mounted. But a workspace can
+ * briefly hold two runs at once: a chat fading out of a narrowed list keeps
+ * the slot it was seen in, and a stranger's slot between it and its living
+ * siblings splits the workspace in two. Two wrappers sharing a key would make
+ * React track one and abandon the other's DOM — a blank row left in the list —
+ * so the workspace's key belongs to one run at a time: the first with a
+ * living row, whose drafts are the thing worth keeping, or the first outright
+ * while every chat is leaving, so an undisturbed fade keeps its wrapper. Any
+ * other run of that workspace is keyed by its lead session instead.
+ */
+export function sessionRunKeys(
+  runs: readonly SessionListRun[],
+  rows: readonly { item: { id: string }; leaving: boolean }[],
+): readonly string[] {
+  const owner = new Map<string, { at: number; living: boolean }>();
+  runs.forEach((run, at) => {
+    if (!run.workspace) return;
+    const living = run.indexes.some((index) => rows[index]?.leaving === false);
+    const held = owner.get(run.workspace.id);
+    if (held === undefined || (living && !held.living)) {
+      owner.set(run.workspace.id, { at, living });
+    }
+  });
+  return runs.map((run, at) => {
+    if (run.workspace && owner.get(run.workspace.id)?.at === at) return run.workspace.id;
+    const lead = run.indexes[0];
+    return (lead !== undefined ? rows[lead]?.item.id : undefined) ?? "";
+  });
+}
+
 export function sessionListRuns(sessions: readonly DisplaySession[]): readonly SessionListRun[] {
   const runs: SessionListRun[] = [];
   for (let index = 0; index < sessions.length; index += 1) {
@@ -443,6 +564,13 @@ export function sessionListRuns(sessions: readonly DisplaySession[]): readonly S
  * asked to watch one. While the filter is chipless it hides nothing (every
  * session matches), and as soon as another value exists its chip and the
  * options button's "showing X only" badge both appear.
+ *
+ * A query is the one narrowing allowed to empty the list, because it is a
+ * question rather than a way of viewing: "nothing matches" is its honest
+ * answer, where a filter falling to nothing is a stale choice to be dropped.
+ * It reads within the filter — search narrows what is being shown — and what
+ * the filter hides is counted rather than swallowed, so an emptied search can
+ * offer the matches sitting behind the chip instead of denying they exist.
  */
 export function arrangeSessions(
   sessions: readonly DisplaySession[],
@@ -456,11 +584,29 @@ export function arrangeSessions(
   const filter = chosen.length > 0 ? view.filter : SESSION_FILTER.ALL;
   const matching = filter === view.filter ? chosen : sessions;
 
+  const tokens = searchTokens(view.query);
+  const found =
+    tokens.length === 0 ? matching : matching.filter((session) => matchesQuery(session, tokens));
+  const search: SessionSearchOutcome | undefined =
+    tokens.length === 0
+      ? undefined
+      : {
+          tokens,
+          searched: matching.length,
+          beyondFilter:
+            matching.length === sessions.length
+              ? 0
+              : sessions.filter(
+                  (session) => !matchesFilter(session, filter) && matchesQuery(session, tokens),
+                ).length,
+        };
+
   return {
-    sessions: seatWorkspacesTogether([...matching].sort(bySort(view.sort))),
+    sessions: seatWorkspacesTogether([...found].sort(bySort(view.sort))),
     total: sessions.length,
     filter,
     options,
+    ...(search ? { search } : {}),
   };
 }
 

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -257,9 +257,12 @@ function searchTokens(query: string): readonly string[] {
 /**
  * The lines a query is read against: everything the row itself can say — its
  * title, the sentence under it, the branch and repository, the workspace it is
- * a chat of — plus the two identifiers the row keeps on the mark's hover, the
- * agent's name and its model. Search finds rows by what they show, so a match
- * is always something the developer can see once the row is on screen.
+ * a chat of — plus identifiers the row does not always spend a line on: the
+ * agent's name and its model, kept on the mark's hover, and a chat's own name,
+ * which a lone chat cedes its title line to its workspace for. Those still
+ * find the session — each is a name the provider's own surface knows it by —
+ * so a row can match without a mark to show for it; the marks only ever land
+ * on the lines the row draws.
  */
 function searchableLines(session: DisplaySession): readonly string[] {
   const lines = [

--- a/apps/desktop/src/renderer/session-motion.ts
+++ b/apps/desktop/src/renderer/session-motion.ts
@@ -102,9 +102,19 @@ interface ReorderList {
    */
   groupAttribute?: string;
   /** The element's layout position along the axis the list stacks in. */
-  offset: (element: HTMLElement) => number;
+  offset: (element: HTMLElement, container: HTMLElement) => number;
   /** A transform moving an element by so many pixels along that axis. */
   translate: (px: number) => string;
+  /**
+   * The container's own seat along that axis, when the list wants a shove of
+   * the whole box run as one travel. Content arriving above the session list —
+   * the search field — moves the container out from under every row at once;
+   * rows measured within the container read that as stillness, and the
+   * container itself makes the one move. Rows translated one by one would
+   * cross the scrollport's top edge and be clipped mid-flight, which is why
+   * the box travels rather than its contents.
+   */
+  origin?: (container: HTMLElement) => number;
   /**
    * Whether an arrival also travels in from one `--row-fan` step back, the way
    * the row stack arrives. The wing's marks do not: an arriving mark already
@@ -114,12 +124,18 @@ interface ReorderList {
   arrivesFromFan: boolean;
 }
 
-/** The session list: rows stacked top to bottom, arriving the way the stack arrives. */
+/**
+ * The session list: rows stacked top to bottom, arriving the way the stack
+ * arrives. Rows are measured within their scroll container rather than from
+ * the shared offset parent, so the search field standing the container aside
+ * is the container's travel and never the rows'.
+ */
 const SESSION_LIST: ReorderList = {
   idAttribute: SESSION_ROW_ID_ATTRIBUTE,
   groupAttribute: WORKSPACE_TRAY_ID_ATTRIBUTE,
-  offset: (element) => element.offsetTop,
+  offset: (element, container) => element.offsetTop - container.offsetTop,
   translate: (px) => `translateY(${px}px)`,
+  origin: (container) => container.offsetTop,
   arrivesFromFan: true,
 };
 
@@ -137,7 +153,7 @@ const SESSION_LIST: ReorderList = {
  */
 const WING_STRIP: ReorderList = {
   idAttribute: WING_SLOT_ID_ATTRIBUTE,
-  offset: (element) => element.offsetLeft - (element.offsetParent?.clientWidth ?? 0),
+  offset: (element, _container) => element.offsetLeft - (element.offsetParent?.clientWidth ?? 0),
   translate: (px) => `translateX(${px}px)`,
   arrivesFromFan: false,
 };
@@ -225,6 +241,7 @@ function useReorderMotion<T extends HTMLElement>(list: ReorderList): RefObject<T
   const baseline = useRef<Map<string, number> | undefined>(undefined);
   const groupBaseline = useRef<Map<string, number> | undefined>(undefined);
   const baselineWidth = useRef<number | undefined>(undefined);
+  const baselineOrigin = useRef<number | undefined>(undefined);
   const wasLeaving = useRef<Set<string>>(new Set());
   const exitFades = useRef<Map<string, Animation>>(new Map());
 
@@ -237,6 +254,7 @@ function useReorderMotion<T extends HTMLElement>(list: ReorderList): RefObject<T
       baseline.current = undefined;
       groupBaseline.current = undefined;
       baselineWidth.current = undefined;
+      baselineOrigin.current = undefined;
       wasLeaving.current = new Set();
       exitFades.current.clear();
       return;
@@ -251,7 +269,7 @@ function useReorderMotion<T extends HTMLElement>(list: ReorderList): RefObject<T
       const id = element.getAttribute(list.idAttribute);
       if (id === null) continue;
       elements.set(id, element);
-      positions.set(id, list.offset(element));
+      positions.set(id, list.offset(element, container));
     }
 
     // The groups are slots too, measured in their own namespace: a group's
@@ -265,7 +283,7 @@ function useReorderMotion<T extends HTMLElement>(list: ReorderList): RefObject<T
         const id = element.getAttribute(list.groupAttribute);
         if (id === null) continue;
         groupElements.set(id, element);
-        groupPositions.set(id, list.offset(element));
+        groupPositions.set(id, list.offset(element, container));
       }
     }
 
@@ -307,12 +325,23 @@ function useReorderMotion<T extends HTMLElement>(list: ReorderList): RefObject<T
       baselineWidth.current !== undefined &&
       Math.abs(width - baselineWidth.current) > TRAVEL_EPSILON;
     baselineWidth.current = width;
+    // The container's own seat, for a list that asked to ride its shoves as
+    // one object. The first measurement is a baseline like every other: a
+    // freshly built list simply is where it is.
+    const origin = list.origin?.(container);
+    const originTravel =
+      origin !== undefined && baselineOrigin.current !== undefined
+        ? baselineOrigin.current - origin
+        : 0;
+    baselineOrigin.current = origin;
+    const containerShoved = Math.abs(originTravel) > TRAVEL_EPSILON;
     if (
       plan.travels.size === 0 &&
       groupPlan.travels.size === 0 &&
       plan.arrivals.length === 0 &&
       departed.length === 0 &&
-      returned.length === 0
+      returned.length === 0 &&
+      !containerShoved
     ) {
       return;
     }
@@ -376,6 +405,12 @@ function useReorderMotion<T extends HTMLElement>(list: ReorderList): RefObject<T
           });
         }
       }
+      // The shove itself: the box makes the one move its contents were
+      // spared, springing from where it sat to where it now is. Rows and
+      // trays ride it — any travel of their own below is movement within it —
+      // and nothing is ever drawn past the box's own edges, because the
+      // scrollport clips in the box's coordinates and moves with it.
+      if (containerShoved && elementVisible(container)) travel(container, originTravel, 0);
       for (const [id, from] of groupPlan.travels) {
         const element = groupElements.get(id);
         if (element !== undefined && elementVisible(element)) travel(element, from, 0);

--- a/apps/desktop/src/renderer/session-search.tsx
+++ b/apps/desktop/src/renderer/session-search.tsx
@@ -1,0 +1,232 @@
+import { useRef } from "react";
+import { FOCUS_FRAME_LIMIT } from "./credential-entry";
+import {
+  type ArrangedSessions,
+  matchRanges,
+  SESSION_FILTER,
+  type SessionView,
+} from "./session-model";
+import { CloseIcon, SearchIcon } from "./settings-icons";
+
+/**
+ * What the field is for, in the words the rows themselves use: it finds
+ * sessions, and it finds them by anything a row says.
+ */
+const SEARCH_PLACEHOLDER = "Search sessions…";
+
+/**
+ * How the search field is found from outside the component, the way the ask
+ * field is: the search key is answered at the app level, where the tab it may
+ * have to switch lives, and the field it lands in is here.
+ */
+export const SESSION_SEARCH_INPUT_ID = "session-search-input";
+
+/**
+ * Puts the caret in the search field, waiting out its arrival on the way — the
+ * same frame-by-frame seek the ask field needs, because the key can arrive
+ * with Settings showing and the field not yet drawn. What is already typed is
+ * selected rather than kept, so a repeated summons types the next question
+ * over the last one instead of appending to it.
+ */
+export function focusSearchField(): () => void {
+  let frame = 0;
+  let frames = 0;
+  const take = () => {
+    const element = document.getElementById(SESSION_SEARCH_INPUT_ID);
+    if (element instanceof HTMLInputElement && getComputedStyle(element).visibility === "visible") {
+      element.focus({ preventScroll: true });
+      element.select();
+      return;
+    }
+    if (frames++ > FOCUS_FRAME_LIMIT) return;
+    frame = requestAnimationFrame(take);
+  };
+  take();
+  return () => cancelAnimationFrame(frame);
+}
+
+/**
+ * The button that opens the search field, beside the options button because
+ * both are ways of narrowing the same list. It stays lit while the field is
+ * open, so the control and its effect cannot be read apart.
+ */
+export function SessionSearchButton({
+  open,
+  onToggle,
+}: {
+  open: boolean;
+  onToggle: () => void;
+}): React.JSX.Element {
+  return (
+    <button
+      type="button"
+      className="search-button"
+      data-active={String(open)}
+      aria-expanded={open}
+      aria-label="Search sessions"
+      aria-keyshortcuts="Meta+F"
+      title="Search sessions (⌘F)"
+      onClick={onToggle}
+    >
+      <SearchIcon />
+    </button>
+  );
+}
+
+/**
+ * The search field itself: one pill above the list, holding the query, the
+ * running count of what it left, and the way out. The count is the pill's
+ * honesty — a field that narrows the list must say how far — and it counts
+ * against the filtered set, because that is what the query was read over.
+ *
+ * Escape unwinds one layer at a time, the way it does everywhere else in the
+ * panel: a held query is cleared first, and only an empty field closes the
+ * search — both stopped here, so neither press falls through and closes the
+ * panel behind the field.
+ */
+export function SessionSearch({
+  list,
+  view,
+  onViewChange,
+  onClose,
+  onEngagedChange,
+}: {
+  list: ArrangedSessions;
+  view: SessionView;
+  onViewChange: (view: SessionView) => void;
+  onClose: () => void;
+  /**
+   * Reports someone being part-way through a search, which holds the panel
+   * open against the pointer wandering off — the same hold a half-typed ask
+   * has, for the same reason: the caret is the signal that hands are here.
+   */
+  onEngagedChange: (engaged: boolean) => void;
+}): React.JSX.Element {
+  const field = useRef<HTMLInputElement | null>(null);
+  const matched = list.sessions.length;
+
+  return (
+    // The element is a real `search`, so the landmark comes from the markup
+    // rather than a role on a bare box.
+    // biome-ignore lint/a11y/useKeyWithClickEvents: pointer-only by design — the keyboard already lands in the field by tabbing, and the click handler only places the caret.
+    <search
+      className="session-search"
+      // The whole pill is the field: a press on its padding or its count is
+      // someone reaching for the caret, so the caret is what they get.
+      onClick={() => field.current?.focus()}
+    >
+      <SearchIcon />
+      <input
+        ref={field}
+        id={SESSION_SEARCH_INPUT_ID}
+        className="session-search-input"
+        aria-label="Search sessions"
+        placeholder={SEARCH_PLACEHOLDER}
+        autoComplete="off"
+        spellCheck={false}
+        value={view.query}
+        onChange={(event) => onViewChange({ ...view, query: event.target.value })}
+        onFocus={() => {
+          // The panel can be showing without its window being key, and a
+          // field that cannot be typed into is worse than no field.
+          window.sidecar.focusPanel();
+          onEngagedChange(true);
+        }}
+        onBlur={() => onEngagedChange(false)}
+        onKeyDown={(event) => {
+          if (event.key !== "Escape") return;
+          event.stopPropagation();
+          if (view.query.length > 0) onViewChange({ ...view, query: "" });
+          else onClose();
+        }}
+      />
+      {list.search ? (
+        <span className="session-search-count" aria-live="polite">
+          {matched === 0 ? "No matches" : `${matched} of ${list.search.searched}`}
+        </span>
+      ) : null}
+      {list.search ? (
+        <button
+          type="button"
+          className="session-search-clear"
+          aria-label="Clear search"
+          title="Clear search"
+          onClick={(event) => {
+            // The pill's own click would re-place the caret after this — let
+            // it: a cleared field with the caret in it is ready for the next
+            // question, which is what pressing clear asks for.
+            event.stopPropagation();
+            onViewChange({ ...view, query: "" });
+            field.current?.focus();
+          }}
+        >
+          <CloseIcon />
+        </button>
+      ) : null}
+    </search>
+  );
+}
+
+/**
+ * What an emptied search says instead of rows. It never just shrugs: when the
+ * filter is hiding sessions the query would find, the way to them is offered
+ * as a button, because "no matches" while matches sit behind a chip would be
+ * the silent narrowing this list refuses everywhere else.
+ */
+export function SearchEmptyState({
+  query,
+  beyondFilter,
+  onWiden,
+}: {
+  query: string;
+  beyondFilter: number;
+  /** Widens the view to All, which is where the hidden matches are. */
+  onWiden: () => void;
+}): React.JSX.Element {
+  return (
+    <div className="empty-state">
+      <strong>No sessions match</strong>
+      <small>Nothing shown says “{query.trim()}”.</small>
+      {beyondFilter > 0 ? (
+        <button type="button" className="empty-state-action" onClick={onWiden}>
+          Show {beyondFilter} {beyondFilter === 1 ? "match" : "matches"} from all sessions
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * One drawn line with the query's words marked where they landed, so a row
+ * says why it matched. A line the words did not land on is returned as it
+ * was — plenty of rows match on a field another line carries.
+ */
+export function Highlighted({
+  text,
+  tokens,
+}: {
+  text: string;
+  tokens?: readonly string[] | undefined;
+}): React.JSX.Element {
+  if (!tokens || tokens.length === 0) return <>{text}</>;
+  const ranges = matchRanges(text, tokens);
+  if (ranges.length === 0) return <>{text}</>;
+  const parts: React.ReactNode[] = [];
+  let from = 0;
+  for (const range of ranges) {
+    if (range.start > from) parts.push(text.slice(from, range.start));
+    parts.push(
+      <mark className="row-match" key={range.start}>
+        {text.slice(range.start, range.end)}
+      </mark>,
+    );
+    from = range.end;
+  }
+  if (from < text.length) parts.push(text.slice(from));
+  return <>{parts}</>;
+}
+
+/** The widened view an emptied search's button asks for. */
+export function widenedView(view: SessionView): SessionView {
+  return { ...view, filter: SESSION_FILTER.ALL };
+}

--- a/apps/desktop/src/renderer/settings-icons.tsx
+++ b/apps/desktop/src/renderer/settings-icons.tsx
@@ -225,6 +225,16 @@ function SliderMarks(): React.JSX.Element {
   );
 }
 
+/** A magnifier: the list read for the rows that say the typed words. */
+export function SearchIcon(): React.JSX.Element {
+  return (
+    <Glyph className="search-glyph">
+      <circle cx="10.6" cy="10.6" r="6.1" />
+      <path d="M15.2 15.2L20.2 20.2" />
+    </Glyph>
+  );
+}
+
 /**
  * Two sliders rather than a funnel: the control it opens holds an order as well
  * as a filter, and a funnel would promise only the second.

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1599,6 +1599,27 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   font-size: 10px;
 }
 
+/* The way out of an emptied search whose matches sit behind the filter: one
+   quiet chip in the same voice the filter chips speak, because pressing it is
+   pressing All. */
+.empty-state-action {
+  margin-top: 6px;
+  padding: 5px 11px;
+  border-radius: 999px;
+  background: var(--raised);
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 620;
+  transition:
+    background-color var(--duration-hover) ease,
+    color var(--duration-hover) ease;
+}
+
+.empty-state-action:hover {
+  background: var(--raised-strong);
+  color: var(--text-primary);
+}
+
 /* Content arrives behind the surface, never in front of it, and it arrives on
    the same spring the surface is riding. Each row starts further up than the
    one above it, so the stack is compressed and the gaps spring open — the

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -21,6 +21,43 @@
   gap: 12px;
 }
 
+/* The two ways of narrowing the list, seated together at the header's end so
+   `space-between` keeps reading tab bar on the left, qualifiers on the right. */
+.header-controls {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 7px;
+}
+
+/* The search button is the options button without a word: an icon that opens
+   a field, lit while the field is open so the control and its effect cannot be
+   read apart. */
+.search-button {
+  display: inline-flex;
+  min-height: 28px;
+  align-items: center;
+  padding: 0 8px;
+  border-radius: 10px;
+  background: var(--raised);
+  color: var(--text-secondary);
+  transition:
+    background-color var(--duration-hover) ease,
+    color var(--duration-hover) ease;
+}
+
+.search-button:hover,
+.search-button[data-active="true"] {
+  background: var(--raised-strong);
+  color: var(--text-primary);
+}
+
+.search-button .search-glyph {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+}
+
 .options-button {
   display: inline-flex;
   min-height: 28px;
@@ -246,6 +283,130 @@
   box-shadow: inset 0 0 0 1px var(--selected-edge);
   background: var(--selected);
   color: var(--text-primary);
+}
+
+/* The search field: the same pill every composer draws, holding a question
+   about the list instead of words for it, so it sits above the rows it
+   narrows. In the flow rather than floating — unlike the options sheet it is
+   not a menu to be put away by its own choice, and the surface follows the
+   measured height wherever content moves it. It arrives on the sheet's own
+   short curve — transform and opacity only, on the shared tokens — while the
+   list it shoved springs aside as one object (`session-motion` runs that
+   travel), so the top row slides out from beneath the arriving pill. The
+   pill is layered above that travel and its ground is the surface's own
+   opaque black — which over a black surface is exactly the recessed well the
+   composers draw — so a row mid-slide passes under it, never through it. */
+.session-search {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  min-width: 0;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 9px;
+  padding: 4px 6px 4px 12px;
+  border: 1px solid var(--hairline);
+  border-radius: 999px;
+  background: var(--surface-fill);
+  cursor: text;
+  animation: search-enter var(--duration-quick) var(--motion-exit) both;
+  transition: border-color var(--duration-hover) ease;
+}
+
+@keyframes search-enter {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* Focus answers in the panel's own neutral voice: searching is neither a
+   message to a session (the working blue) nor the developer's half of a
+   conversation (their green) — it is looking, and looking has no state. The
+   edge alone answers; the ground has to stay the surface's opaque black, or a
+   row travelling beneath a focused pill would show through it. */
+.session-search:focus-within {
+  border-color: rgba(255, 255, 255, 0.28);
+}
+
+.session-search .search-glyph {
+  width: 13px;
+  height: 13px;
+  flex: 0 0 auto;
+  color: var(--text-tertiary);
+}
+
+/* The field itself is bare: the pill around it is the drawn edge. */
+.session-search-input {
+  min-width: 0;
+  flex: 1;
+  padding: 5px 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 11.5px;
+  outline: none;
+}
+
+.session-search-input::placeholder {
+  color: var(--text-tertiary);
+}
+
+/* What the query left, said beside it: the count is the pill's honesty about
+   how far it has narrowed the list the capsule is still counting in full. */
+.session-search-count {
+  flex: 0 0 auto;
+  color: var(--text-tertiary);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+/* The way out of a held query without leaving the field. Colour is the whole
+   hover: the button must not grow or move inside an element that reflows the
+   pill. Padding is zeroed by hand — the engine's own button padding is
+   asymmetric, and in a 20px disc it reads as the glyph leaning to one side. */
+.session-search-clear {
+  display: grid;
+  width: 20px;
+  height: 20px;
+  flex: 0 0 auto;
+  padding: 0;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.14);
+  color: var(--text-tertiary);
+  place-items: center;
+  transition:
+    background-color var(--duration-hover) ease,
+    color var(--duration-hover) ease;
+}
+
+.session-search-clear:hover {
+  background: rgba(255, 255, 255, 0.22);
+  color: var(--text-primary);
+}
+
+.session-search-clear .icon-button-glyph {
+  width: 10px;
+  height: 10px;
+}
+
+/* Where the query's words landed, so a row says why it matched. A wash rather
+   than the engine's yellow: the mark identifies text, and the row's own
+   colours keep saying everything else. No padding — these lines ellipsize,
+   and a mark that widened its text would push the truncation around as the
+   query changed. */
+.row-match {
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.16);
+  color: inherit;
 }
 
 /* The one scroll container in the app. The root stays `overflow: clip` so a

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -496,6 +496,23 @@ test("the panel fact says the tabs answer an ask as well as a press", () => {
   assert.match(fact.detail, /Settings holds/);
 });
 
+test("the panel fact describes the search, and says it is by hand alone", () => {
+  const fact = buildLukeGuide(guideInput()).facts.find(
+    (candidate) => candidate.label === "The panel",
+  );
+
+  assert.ok(fact);
+  // A capability the guide does not describe is one Luke will deny having —
+  // and a search Luke claimed he could run himself would be a capability the
+  // spoken tools deliberately do not have.
+  assert.match(fact.detail, /searchable by hand alone/);
+  assert.match(fact.detail, /magnifier/);
+  assert.match(fact.detail, /Command-F/);
+  assert.match(fact.detail, /title, status line, branch, repository, workspace, agent, or model/);
+  assert.match(fact.detail, /no spoken ask can search/);
+  assert.match(fact.detail, /no search survives the panel closing/);
+});
+
 test("the feedback fact says what a spoken open may do, and that sending stays by hand", () => {
   const fact = buildLukeGuide(guideInput()).facts.find(
     (candidate) => candidate.label === "Feedback and prompts",

--- a/apps/desktop/tests/session-model.test.ts
+++ b/apps/desktop/tests/session-model.test.ts
@@ -14,10 +14,12 @@ import {
   arrangeSessions,
   DEFAULT_SESSION_VIEW,
   displaySessions,
+  matchRanges,
   observedAgoLabel,
   SESSION_FILTER,
   SESSION_SORT,
   sessionListRuns,
+  sessionRunKeys,
   sessionTally,
   tallyCaption,
   tallySummary,
@@ -518,6 +520,7 @@ test("the two orderings answer different questions about the same sessions", () 
 
 test("filtering leaves the chosen ordering in force", () => {
   const recentCloud = arrangeSessions(FIXTURE_SESSIONS, {
+    ...DEFAULT_SESSION_VIEW,
     filter: SESSION_FILTER.CLOUD,
     sort: SESSION_SORT.RECENCY,
   });
@@ -672,4 +675,206 @@ test("a row offers writes only where its provider promised them", () => {
     if (row.id === "devin-session") continue;
     assert.equal(row.canMessage, false);
   }
+});
+
+test("a query keeps only rows saying every word, wherever each word lands", () => {
+  const rows = displaySessions(bootstrap(false), [
+    normalizeSession(CLAUDE_PROVIDER, {
+      providerSessionId: "parser",
+      title: "Rework the parser",
+      status: SESSION_STATUS.WORKING,
+      observedAt: 1_000,
+      detail: { branch: "feat/LUKE-123-parser" },
+    }),
+    normalizeSession(CLAUDE_PROVIDER, {
+      providerSessionId: "login",
+      title: "Fix the login flow",
+      status: SESSION_STATUS.WORKING,
+      observedAt: 2_000,
+    }),
+  ]);
+
+  // The words match together across fields — the ticket sits on the branch and
+  // the noun in the title — and case never matters: a query is typed, not
+  // quoted back at the row.
+  const found = arrangeSessions(rows, { ...DEFAULT_SESSION_VIEW, query: "Parser LUKE-123" });
+
+  assert.deepEqual(
+    found.sessions.map((session) => session.id),
+    ["parser"],
+  );
+  assert.equal(found.total, 2);
+  assert.deepEqual(found.search, {
+    tokens: ["parser", "luke-123"],
+    searched: 2,
+    beyondFilter: 0,
+  });
+});
+
+test("a query is read against everything the row can say", () => {
+  const rows = displaySessions(bootstrap(false), [
+    normalizeSession(CONDUCTOR_PROVIDER, {
+      providerSessionId: "chat",
+      title: "Chat chat",
+      status: SESSION_STATUS.ERROR,
+      observedAt: 1_000,
+      detail: { repository: "sidecar", model: "claude-opus-5", error: "The build broke" },
+      workspace: { providerWorkspaceId: "workspace-1", name: "lisbon-v2" },
+    }),
+    liveSession(CODEX_PROVIDER, "other", SESSION_STATUS.WORKING),
+  ]);
+
+  // The repository, the model on the mark's hover, the workspace the row is a
+  // chat of, the agent's own name, and the failure worded under the title.
+  for (const query of ["sidecar", "OPUS", "lisbon", "conductor", "build broke"]) {
+    const found = arrangeSessions(rows, { ...DEFAULT_SESSION_VIEW, query });
+    assert.deepEqual(
+      found.sessions.map((session) => session.id),
+      ["chat"],
+      `query: ${query}`,
+    );
+  }
+});
+
+test("a blank query is no search at all", () => {
+  const list = arrangeSessions(FIXTURE_SESSIONS, { ...DEFAULT_SESSION_VIEW, query: "   " });
+
+  assert.equal(list.search, undefined);
+  assert.equal(list.sessions.length, FIXTURE_SESSIONS.length);
+});
+
+test("a query that matches nothing empties the list and says so", () => {
+  const list = arrangeSessions(FIXTURE_SESSIONS, { ...DEFAULT_SESSION_VIEW, query: "zanzibar" });
+
+  // The one narrowing allowed to empty the list: "nothing matches" is a
+  // search's honest answer, where a filter falling to nothing is a stale
+  // choice to be dropped. What is tracked is still counted in full.
+  assert.deepEqual(list.sessions, []);
+  assert.equal(list.total, FIXTURE_SESSIONS.length);
+  assert.deepEqual(list.search, {
+    tokens: ["zanzibar"],
+    searched: FIXTURE_SESSIONS.length,
+    beyondFilter: 0,
+  });
+});
+
+test("a query reads within the filter and counts what the filter hides", () => {
+  const rows = displaySessions(bootstrap(false), [
+    normalizeSession(CLAUDE_PROVIDER, {
+      providerSessionId: "claude-alpha",
+      title: "Alpha rework",
+      status: SESSION_STATUS.WORKING,
+      observedAt: 1_000,
+    }),
+    normalizeSession(CODEX_PROVIDER, {
+      providerSessionId: "codex-alpha",
+      title: "Alpha cleanup",
+      status: SESSION_STATUS.WORKING,
+      observedAt: 2_000,
+    }),
+    liveSession(CODEX_PROVIDER, "codex-other", SESSION_STATUS.WORKING, 3_000),
+  ]);
+
+  const narrowed = arrangeSessions(rows, {
+    ...DEFAULT_SESSION_VIEW,
+    filter: PROVIDER_ID.CLAUDE_CODE,
+    query: "alpha",
+  });
+  assert.deepEqual(
+    narrowed.sessions.map((session) => session.id),
+    ["claude-alpha"],
+  );
+  // The Codex match is not shown, but it is never swallowed either.
+  assert.deepEqual(narrowed.search, { tokens: ["alpha"], searched: 1, beyondFilter: 1 });
+
+  const emptied = arrangeSessions(rows, {
+    ...DEFAULT_SESSION_VIEW,
+    filter: PROVIDER_ID.CLAUDE_CODE,
+    query: "cleanup",
+  });
+  assert.deepEqual(emptied.sessions, []);
+  assert.deepEqual(emptied.search, { tokens: ["cleanup"], searched: 1, beyondFilter: 1 });
+});
+
+test("searching leaves the chosen ordering and the workspace seating in force", () => {
+  // The agent's name finds both Conductor chats, in the order the sort chose.
+  const recent = arrangeSessions(FIXTURE_SESSIONS, {
+    ...DEFAULT_SESSION_VIEW,
+    sort: SESSION_SORT.RECENCY,
+    query: "conductor",
+  });
+  assert.deepEqual(
+    recent.sessions.map((session) => session.id),
+    ["conductor-chat-tidy", "conductor-chat-package"],
+  );
+
+  // Seated as one tray run, exactly as they would be unsearched.
+  assert.deepEqual(
+    sessionListRuns(recent.sessions).map((run) => ({
+      workspaceId: run.workspace?.id,
+      indexes: run.indexes,
+    })),
+    [{ workspaceId: "conductor-lisbon", indexes: [0, 1] }],
+  );
+});
+
+test("match ranges are found case-blind and merged where words overlap", () => {
+  // Two words landing on one stretch read as one mark, not nested ones.
+  assert.deepEqual(matchRanges("Feat/LUKE-123-parser", ["luke", "ke-123"]), [
+    { start: 5, end: 13 },
+  ]);
+  // Every occurrence is marked, not only the first.
+  assert.deepEqual(matchRanges("alpha alpha", ["alpha"]), [
+    { start: 0, end: 5 },
+    { start: 6, end: 11 },
+  ]);
+  // A line the words did not land on yields nothing to mark.
+  assert.deepEqual(matchRanges("nothing here", ["zeta"]), []);
+});
+
+// A chat fading out of a narrowed list keeps the slot it was seen in, and a
+// stranger's held slot can split it from its workspace's living siblings —
+// two runs of one workspace, drawn at once. React abandons the DOM of a child
+// whose key another child also wears, which is a blank row left in the list,
+// so the keys have to come apart exactly there.
+test("a workspace split by a held slot gets one key per run", () => {
+  const workspace = { id: "ws-da-nang", name: "da-nang" };
+  const rows = [
+    { item: { id: "chat-a1" }, leaving: true },
+    { item: { id: "codex-1" }, leaving: false },
+    { item: { id: "chat-a2" }, leaving: false },
+  ];
+  const runs = [{ workspace, indexes: [0] }, { indexes: [1] }, { workspace, indexes: [2] }];
+
+  // The living run keeps the workspace's key — the wrapper whose rows hold
+  // half-typed drafts is the one that must survive the split healing — and
+  // the fading run is keyed by its own chat.
+  assert.deepEqual(sessionRunKeys(runs, rows), ["chat-a1", "codex-1", "ws-da-nang"]);
+});
+
+test("an unsplit workspace and a lone fading chat both keep the workspace key", () => {
+  const workspace = { id: "ws-1", name: "lisbon-v2" };
+
+  // The tray, with one chat mid-fade: still one run, still the workspace's.
+  assert.deepEqual(
+    sessionRunKeys(
+      [{ workspace, indexes: [0, 1] }],
+      [
+        { item: { id: "chat-1" }, leaving: false },
+        { item: { id: "chat-2" }, leaving: true },
+      ],
+    ),
+    ["ws-1"],
+  );
+  // A workspace whose only chat is leaving keeps its key too, so the fade
+  // finishes in the wrapper it started in.
+  assert.deepEqual(
+    sessionRunKeys([{ workspace, indexes: [0] }], [{ item: { id: "chat-1" }, leaving: true }]),
+    ["ws-1"],
+  );
+  // Ungrouped sessions are their own keys, as they always were.
+  assert.deepEqual(
+    sessionRunKeys([{ indexes: [0] }], [{ item: { id: "codex-1" }, leaving: false }]),
+    ["codex-1"],
+  );
 });


### PR DESCRIPTION
## What

The Sessions tab gains a search field for finding the session you mean among everything Luke is watching.

- The magnifier beside the options button — or **⌘F** while the panel has the keyboard, from either tab — opens a pill above the list, focused, with the previous query selected for typing over.
- A query keeps only rows saying **every typed word**, case-blind, in anything a row can show: title, status line (activity/error/recap), branch, repository, workspace name, agent, or model. Words match across fields, so `parser LUKE-123` finds the session whose title says one and whose branch carries the other.
- Matching rows **mark where the words landed** (title, status line, place line, tray headers), and the pill counts what the query left ("4 of 6").
- Search reads **within the filter, never silently**: an emptied search says so, and when the filter is hiding matches it offers a one-press "Show N matches from all sessions" instead of implying there are none.
- **Escape unwinds one layer at a time**: a held query clears, an empty field closes, and only then does Escape reach the layers below. A search in progress holds the panel open the way a half-typed ask does, and no search survives the panel closing — the same rule the filter follows.
- The guide teaches the capability in the panel fact, as by-hand-alone: no spoken ask can search.

## Motion and rendering repairs

Found by driving the real renderer bundle headlessly and sampling frames:

- **Top row clipped during the field's entrance.** Rows were measured from the shared offset parent, so the field mounting read as every row travelling — and the top row sprang down from above the scrollport's clip edge. Rows are now measured within their scroll container, and a shove of the container travels as one object on the same machinery (`session-motion`), so the top session slides out from beneath the arriving pill and nothing can clip.
- **Blank row wedged mid-results** (e.g. searching "Codex"). A chat fading out of a narrowed list holds the slot it was seen in, and a held slot can split it from its workspace's living siblings — two runs of one workspace, both keyed by the workspace id. React abandons the DOM of a child whose key another child wears, leaving an orphaned invisible card in the list. Run keys are now resolved over the whole list at once (`sessionRunKeys`): the workspace's key belongs to its first living run — the one whose composer drafts must survive — and any other run of that workspace is keyed by its lead session.
- The clear button's glyph sat off-centre: the engine's own asymmetric button padding, now zeroed, with the glyph sized by its real class.

## Verification

- `./scripts/check.sh` passes end to end: lint, typecheck, builds, and all tests (750 desktop, 0 failures), including new coverage for the query predicate, filter interplay and `beyondFilter`, ordering/tray seating under search, match-range merging, run-key resolution, and the guide fact.
- Entrance, exit, and release behavior verified by frame-sampling the real renderer in headless Chromium against both fixture and live-shaped rosters (workspace splits included).
- **Not performed:** `./scripts/verify.sh` and the physical-notch check — this change was authored in a cloud sandbox without macOS. The macOS visual pass is still owed before this ships in a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/555c7f82-39e0-4312-be39-ce8d38cab2cb)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31984029039/artifacts/9273214651) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31984029039)

- Commit: `53838ab7a77a53c36eeb1527adf608b6ecf064ed`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
