### PR TITLE
feat(sessions): shorten the archive control label to "Archive"

### DIFF
--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -151,7 +151,7 @@ const CONDUCTOR_ARCHIVE_WORKSPACE_CONTROL_ID = "archive-workspace";
 function conductorArchiveWorkspaceControl(workspaceId: string): SessionControl {
   return {
     id: CONDUCTOR_ARCHIVE_WORKSPACE_CONTROL_ID,
-    label: "Archive this workspace",
+    label: "Archive",
     target: workspaceId,
   };
 }

--- a/apps/desktop/src/cursor-adapter.ts
+++ b/apps/desktop/src/cursor-adapter.ts
@@ -128,7 +128,7 @@ function cursorCancelRunControl(runId: string): SessionControl {
  */
 const CURSOR_ARCHIVE_AGENT_CONTROL = {
   id: "archive-agent",
-  label: "Archive this agent",
+  label: "Archive",
 } as const;
 
 const CURSOR_QUERY = {

--- a/apps/desktop/src/devin-adapter.ts
+++ b/apps/desktop/src/devin-adapter.ts
@@ -79,7 +79,7 @@ const DEVIN_MESSAGE_FIELD = {
  */
 const DEVIN_ARCHIVE_SESSION_CONTROL = {
   id: "archive-session",
-  label: "Archive this session",
+  label: "Archive",
 } as const;
 
 const DEVIN_FIELD = {

--- a/apps/desktop/tests/conductor-adapter.test.ts
+++ b/apps/desktop/tests/conductor-adapter.test.ts
@@ -1496,7 +1496,7 @@ test("advertises a message for any open chat, a stop mid-turn, and an archive on
     ["session-closed", "workspace-closed"],
   ] as const) {
     assert.deepEqual(byId.get(sessionId)?.controls, [
-      { id: "archive-workspace", label: "Archive this workspace", target: workspaceId },
+      { id: "archive-workspace", label: "Archive", target: workspaceId },
     ]);
   }
 });
@@ -1694,7 +1694,7 @@ test("archives the workspace the user saw through Conductor's archive endpoint, 
   // the adapter itself advertised, never from the caller's copy of it.
   const result = await adapter.executeControl({
     providerSessionId: "session-idle",
-    control: { id: "archive-workspace", label: "Archive this workspace" },
+    control: { id: "archive-workspace", label: "Archive" },
   });
 
   assert.deepEqual(result, { status: "accepted" });
@@ -1733,7 +1733,7 @@ test("refuses to archive a workspace no row advertised, before any request exist
     providerSessionId: "session-working",
     control: {
       id: "archive-workspace",
-      label: "Archive this workspace",
+      label: "Archive",
       target: "workspace-active",
     },
   });

--- a/apps/desktop/tests/cursor-adapter.test.ts
+++ b/apps/desktop/tests/cursor-adapter.test.ts
@@ -686,10 +686,10 @@ test("advertises a follow-up only for an agent whose run has finished", async ()
     { id: "cancel-run", label: "Stop this run", kind: "stop", target: "run-agent-running" },
   ]);
   assert.deepEqual(byId.get("agent-finished")?.controls, [
-    { id: "archive-agent", label: "Archive this agent" },
+    { id: "archive-agent", label: "Archive" },
   ]);
   assert.deepEqual(byId.get("agent-errored")?.controls, [
-    { id: "archive-agent", label: "Archive this agent" },
+    { id: "archive-agent", label: "Archive" },
   ]);
   assert.equal(byId.get("agent-filed")?.controls, undefined);
 });
@@ -756,7 +756,7 @@ test("keeps the archive off an agent whose run could not be read", async () => {
   // positive observation, so it still offers the archive.
   assert.equal(byId.get("agent-unreadable")?.controls, undefined);
   assert.deepEqual(byId.get("agent-never-ran")?.controls, [
-    { id: "archive-agent", label: "Archive this agent" },
+    { id: "archive-agent", label: "Archive" },
   ]);
 });
 
@@ -767,7 +767,7 @@ test("files a settled agent away through Cursor's archive endpoint, sending no b
 
   const result = await adapter.executeControl({
     providerSessionId: "agent-finished",
-    control: { id: "archive-agent", label: "Archive this agent" },
+    control: { id: "archive-agent", label: "Archive" },
   });
 
   assert.deepEqual(result, { status: "accepted" });
@@ -790,7 +790,7 @@ test("refuses to archive an agent whose row never advertised it", async () => {
   // behind it and no request exists.
   const result = await adapter.executeControl({
     providerSessionId: "agent-running",
-    control: { id: "archive-agent", label: "Archive this agent" },
+    control: { id: "archive-agent", label: "Archive" },
   });
 
   assert.deepEqual(result, { status: "unsupported" });

--- a/apps/desktop/tests/devin-adapter.test.ts
+++ b/apps/desktop/tests/devin-adapter.test.ts
@@ -204,9 +204,7 @@ test("advertises the archive only for a session positively seen settled", async 
   const byId = new Map(observations.map((entry) => [entry.providerSessionId, entry]));
 
   for (const sessionId of ["devin-exited", "devin-errored", "devin-suspended", "devin-holding"]) {
-    assert.deepEqual(byId.get(sessionId)?.controls, [
-      { id: "archive-session", label: "Archive this session" },
-    ]);
+    assert.deepEqual(byId.get(sessionId)?.controls, [{ id: "archive-session", label: "Archive" }]);
   }
   for (const sessionId of ["devin-working", "devin-detailless", "devin-new", "devin-filed"]) {
     assert.equal(byId.get(sessionId)?.controls, undefined);
@@ -222,7 +220,7 @@ test("files a settled session away through Devin's archive endpoint, sending no 
 
   const result = await adapter.executeControl({
     providerSessionId: "devin-suspended",
-    control: { id: "archive-session", label: "Archive this session" },
+    control: { id: "archive-session", label: "Archive" },
   });
 
   assert.deepEqual(result, { status: "accepted" });
@@ -248,7 +246,7 @@ test("refuses to archive a session whose row never advertised it", async () => {
   // and no request exists.
   const result = await adapter.executeControl({
     providerSessionId: "devin-working",
-    control: { id: "archive-session", label: "Archive this session" },
+    control: { id: "archive-session", label: "Archive" },
   });
 
   assert.deepEqual(result, { status: "unsupported" });


### PR DESCRIPTION
The archive control on session rows now reads "Archive" instead of "Archive this workspace" / "Archive this agent" / "Archive this session" — the row already says what the session is, so the button only needs to say what pressing it does. Applies to the Conductor, Cursor, and Devin adapters, with tests updated to match.

`./scripts/check.sh` passes (portable-only string change; no UI layout or macOS behavior touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/97b9afe8-1918-4eff-b47a-3ce469d83649)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31983763832/artifacts/9273147043) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31983763832)

- Commit: `99abca21b407e8a8e89aee9a667d42f0c4c1b016`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
