### PR TITLE
feat(providers): widen hook observation to Codex and on-ask transcript reads to every local provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,21 +34,23 @@ Trust constraints:
 - One registration is the exception the previous rule's word "require" leaves
   room for, and it is bounded on every side: Luke may merge an observation
   hook into a provider's own user-level hook configuration — today Claude
-  Code's `settings.json`, and nothing else of the provider's — so local rows
-  can tell a turn that just ended from a session walked away from, and can see
-  a tool call holding for permission at all. The hook itself writes one fixed
-  status token into a spool under Luke's own application data, named by the
-  session's id; the envelope the provider pipes it is read only for that id
-  and never reaches disk. The merge preserves the user's own entries and
-  settings as parsed, recognizes its own entries by the script's name, refuses
-  to rewrite a file it cannot parse, converges at launch rather than
-  accumulating, and skips a machine with no provider home to join. The
-  registration is part of observing at all, like reading the transcripts, so
-  it converges at every launch rather than answering to a preference; an
-  entry outliving Luke is a guarded no-op, and everything the hook sharpens
-  still observes from the transcripts alone wherever the hook is absent.
-  Widening it to another provider or another lifecycle event is a product
-  decision, not an implementation detail.
+  Code's `settings.json` and Codex's `hooks.json`, and nothing else of either
+  provider's — so local rows can tell a turn that just ended from a session
+  walked away from, and can see a tool call holding for permission at all. The
+  hook itself writes one fixed status token into a spool under Luke's own
+  application data, named by the session's id; the envelope the provider hands
+  it — piped in, or passed as an argument — is read only for that id and never
+  reaches disk. The merge preserves the user's own entries and settings as
+  parsed, recognizes its own entries by the script's name, refuses to rewrite
+  a file it cannot parse, converges at launch rather than accumulating, and
+  skips a machine with no provider home to join. The registration is part of
+  observing at all, like reading the transcripts, so it converges at every
+  launch rather than answering to a preference; an entry outliving Luke is a
+  guarded no-op, and everything the hook sharpens still observes from the
+  transcripts alone wherever the hook is absent — including behind Codex's own
+  review gate, which shows a new entry to the user and runs nothing until they
+  trust it. Widening it to another provider or another lifecycle event is a
+  product decision, not an implementation detail.
 - The one thing Luke may change about a session is what the user just asked to
   send it: a message typed on its row, a control its provider advertised for
   it, or the same two acts asked of Luke — out loud, or typed into his own
@@ -95,8 +97,12 @@ Trust constraints:
   on this machine, and rendered into a bounded reply that is kept nowhere —
   the read performs nothing, reaches no provider, and is offered only for a
   local session whose provider's transcript this build documents reading
-  (Claude Code today); a cloud session's conversation lives with its provider
-  and is never fetched.
+  (Claude Code, Codex, OpenCode, and Cursor's local agents today); a cloud
+  session's conversation lives with its provider and is never fetched. The
+  read renders only what the provider actually wrote down — Cursor keeps tool
+  outputs out of its transcripts, so a Cursor reading carries none — and a
+  provider whose stored shape this build cannot render faithfully keeps the
+  honest refusal instead.
 - The issue tracker follows the same rule at one remove. Luke reads the issues
   a tracker lists for the user under a user-supplied key and observes nothing
   without one, exactly like a cloud session provider. The two acts a tracker

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -12,15 +12,15 @@ the current implementation; it is not a promise about third-party services.
 - For OpenCode, Luke opens the local session database in read-only mode and
   reads session records plus the bookkeeping of a session's newest message and
   tool records — roles, timestamps, tool names and inputs, and recorded
-  errors — not the message text, which is never opened. Installs from before
-  OpenCode moved its sessions into that database are read from its session and
-  message JSON files with the same boundary.
+  errors — not the message text, which observation never opens. Installs from
+  before OpenCode moved its sessions into that database are read from its
+  session and message JSON files with the same boundary.
 - For the Cursor agents running on this machine, Luke finds recent transcripts,
   opens bounded tails read-only, and reads only the markers around a turn — its
-  end and how it ended. It does not read message content, and reports the fact
-  of a failed turn rather than the reason Cursor recorded for it. A session is
-  labelled by the folder it runs in, which Luke reads from Cursor's own record
-  of that folder, not from the chat's generated name.
+  end and how it ended. Observation does not read message content, and reports
+  the fact of a failed turn rather than the reason Cursor recorded for it. A
+  session is labelled by the folder it runs in, which Luke reads from Cursor's
+  own record of that folder, not from the chat's generated name.
 
 Luke processes bounded fields needed to identify and display a session:
 provider and session identifiers, provider-generated titles, the workspace
@@ -35,26 +35,34 @@ display. Observation itself never controls a provider session; see Optional
 cloud-provider reads and Optional issue-tracker reads and spoken acts below
 for the narrow, user-requested writes Luke makes elsewhere.
 
-One provider file is the exception to "does not modify", and it is
-configuration rather than session data: Luke merges an observation hook into
-Claude Code's user-level `settings.json` at every launch, preserving whatever
-the user put there and refusing to rewrite a file it cannot parse. The hook
-runs at a session's turn boundaries and writes one fixed status token — such
-as `stop` or `notification` — into a file named by the session's id under
-Luke's own application data. It reads the event envelope Claude Code pipes it
-only to find that id; no prompt text, message content, or transcript ever
-reaches the file. The registered command is a guarded no-op wherever Luke is
-gone, and removing the entries by hand costs only the sharper status:
-observation continues from the transcripts alone.
+One provider file per provider is the exception to "does not modify", and it
+is configuration rather than session data: Luke merges an observation hook
+into Claude Code's user-level `settings.json` and Codex's user-level
+`hooks.json` at every launch, preserving whatever the user put there and
+refusing to rewrite a file it cannot parse. Each hook runs at a session's turn
+boundaries and writes one fixed status token — such as `stop` or
+`notification` — into a file named by the session's id under Luke's own
+application data. It reads the event envelope the provider hands it only to
+find that id; no prompt text, message content, or transcript ever reaches the
+file. The registered command is a guarded no-op wherever Luke is gone, and
+removing the entries by hand costs only the sharper status: observation
+continues from the transcripts and state databases alone. Codex additionally
+shows a newly merged hook to you at its own startup and runs nothing until you
+trust it there; declining costs the same sharper status and nothing else.
 
-"Does not retain raw records or message history" has one bounded, on-demand
-counterpart: in a conversation you are holding with Luke, you can ask what a
-local session did, said, or is stuck on, and Luke reads that session's own
-transcript — Claude Code sessions today — from the provider's file on this
-machine. The read happens when you ask, is validated against the observed
-roster, renders a bounded excerpt into that conversation's reply, and keeps
-nothing: no history is stored, watched, or indexed, and nothing is fetched
-from any provider. Because the voice conversation runs on OpenAI's Realtime
+"Does not retain raw records or message history" — and, for OpenCode and
+Cursor, "observation never opens message content" — have one bounded,
+on-demand counterpart: in a conversation you are holding with Luke, you can
+ask what a local session did, said, or is stuck on, and Luke reads that
+session's own transcript — Claude Code, Codex, OpenCode, and Cursor's local
+agents today — from the provider's own file or database on this machine. The
+read happens when you ask, is validated against the observed roster, renders a
+bounded excerpt into that conversation's reply, and keeps nothing: no history
+is stored, watched, or indexed, and nothing is fetched from any provider.
+Observation passes stay content-blind exactly as described above; this read is
+the one path to a local session's words, and it renders only what the provider
+wrote down — Cursor stores no tool outputs in its transcripts, so a Cursor
+excerpt carries none. Because the voice conversation runs on OpenAI's Realtime
 API, an excerpt read into it leaves the machine the same way your spoken words
 do — only in the conversation you opened, never unbidden. The attention
 evaluator still never receives transcript content.

--- a/README.md
+++ b/README.md
@@ -54,9 +54,13 @@ Settings. Voice and optional attention review require an OpenAI API key.
 ## Privacy
 
 Luke observes provider state without changing provider transcripts or session
-files. Local session data stays on your Mac unless you start a feature that
+files. Its one provider-side write is an observation hook registered for
+Claude Code and Codex in their own hook settings — it records a session's
+status, never its conversation, and Codex asks you to trust it before it
+runs. Local session data stays on your Mac unless you start a feature that
 requires an external service. Messages, controls, workspace creation, and issue
-updates run only when you explicitly request them.
+updates run only when you explicitly request them, and Luke reads a local
+session's transcript only when you ask about that session.
 
 See [PRIVACY.md](PRIVACY.md) for the data sent by each optional integration and
 how credentials are stored.

--- a/apps/desktop/src/claude-code-hooks.ts
+++ b/apps/desktop/src/claude-code-hooks.ts
@@ -1,28 +1,26 @@
-import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { isRecord } from "@sidecar/core";
-import { canIgnoreFilesystemError } from "./local-session-adapter";
+import {
+  HOOK_SPOOL_MAXIMUM_AGE_MS,
+  installObservationHooks,
+  type ObservationHookInstallation,
+  type ObservationHookSpec,
+  type ObservedHookEvent,
+  pruneObservationHookSpool,
+  readObservationHookEvent,
+  removeObservationHooks,
+} from "./observation-hooks";
 
 /**
- * Hook-fed observation for Claude Code, strictly additive to the transcript
- * tail the adapter already reads. Claude Code runs a registered command at a
- * session's turn boundaries; ours writes one fixed token into a spool Luke
- * owns, and the adapter reads that token back to answer what the tail alone
- * cannot: a turn that just ended versus a session someone walked away from, a
- * tool call holding for permission, a session that was closed. Everything
- * here degrades to the tail: no registration, no script, and no spool ever
- * costs an observation — they only cost the sharper status.
- *
- * The registration is the one file of a provider's Luke writes, and it is
- * bounded the way the trust constraints demand: entries are merged into
- * `settings.json` beside whatever the user put there, recognized by the
- * script's own name, stripped cleanly on removal, and never written at all
- * when the existing file cannot be parsed — a file Luke cannot read back is a
- * file Luke must not rewrite.
+ * Claude Code's observation hooks, described for the shared machinery in
+ * `observation-hooks.ts`: which file the registration merges into, which
+ * lifecycle moments are registered, and what the envelope Claude Code pipes
+ * the script looks like. Everything the arrangement guarantees — the merge
+ * beside the user's entries, the refusal to rewrite an unparseable file, the
+ * fixed token as the only thing that reaches disk — is the shared module's;
+ * this file only says what Claude Code calls things.
  */
 
-const CLAUDE_SETTINGS_FILE_NAME = "settings.json";
 const CLAUDE_ENVIRONMENT = {
   CONFIG_DIRECTORY: "CLAUDE_CONFIG_DIR",
 } as const;
@@ -37,18 +35,7 @@ export const CLAUDE_HOOK_SCRIPT_NAME = "luke-claude-observation-hook.sh";
 /** How long Claude Code lets the spool write run before giving up on it. */
 const CLAUDE_HOOK_TIMEOUT_SECONDS = 10;
 
-/** The spool file holds one fixed token, so anything longer is not ours. */
-const HOOK_EVENT_FILE_READ_BYTES = 256;
-
-const HOOK_EVENT_FILE_EXTENSION = ".json";
-
-/**
- * How old a spool file may grow before pruning drops it. An event this far
- * behind cannot out-date any transcript it would refine, and the session
- * behind it has almost always closed for good; a day keeps the spool sized
- * to the sessions actually moving rather than every session ever observed.
- */
-export const CLAUDE_HOOK_SPOOL_MAXIMUM_AGE_MS = 24 * 60 * 60 * 1000;
+export const CLAUDE_HOOK_SPOOL_MAXIMUM_AGE_MS = HOOK_SPOOL_MAXIMUM_AGE_MS;
 
 /**
  * The tokens the script may write, fixed at registration: each hook entry
@@ -66,17 +53,8 @@ export const CLAUDE_HOOK_EVENT = {
 
 export type ClaudeHookEvent = (typeof CLAUDE_HOOK_EVENT)[keyof typeof CLAUDE_HOOK_EVENT];
 
-const CLAUDE_HOOK_EVENT_LIST: readonly ClaudeHookEvent[] = Object.values(CLAUDE_HOOK_EVENT);
-
-function isClaudeHookEvent(value: unknown): value is ClaudeHookEvent {
-  return typeof value === "string" && CLAUDE_HOOK_EVENT_LIST.includes(value as ClaudeHookEvent);
-}
-
 /** The latest thing the hook reported about one session, dated by the spool. */
-export interface ObservedClaudeHookEvent {
-  event: ClaudeHookEvent;
-  atMs: number;
-}
+export type ObservedClaudeHookEvent = ObservedHookEvent<ClaudeHookEvent>;
 
 /**
  * Which Claude Code lifecycle moments are registered, and the token each one
@@ -87,17 +65,27 @@ export interface ObservedClaudeHookEvent {
  * permission prompt and an open question — because those are exactly the
  * moments the transcript shows nothing new.
  */
-const CLAUDE_HOOK_REGISTRATION = {
-  SessionStart: { event: CLAUDE_HOOK_EVENT.SESSION_START },
-  UserPromptSubmit: { event: CLAUDE_HOOK_EVENT.PROMPT },
-  Stop: { event: CLAUDE_HOOK_EVENT.STOP },
-  StopFailure: { event: CLAUDE_HOOK_EVENT.STOP_FAILURE },
-  Notification: {
-    event: CLAUDE_HOOK_EVENT.NOTIFICATION,
-    matcher: "permission_prompt|elicitation_dialog",
+const CLAUDE_HOOK_SPEC: ObservationHookSpec<ClaudeHookEvent> = {
+  scriptName: CLAUDE_HOOK_SCRIPT_NAME,
+  configurationFileName: "settings.json",
+  scriptTitle: "Luke Claude Code observation hook v1",
+  registration: {
+    SessionStart: { event: CLAUDE_HOOK_EVENT.SESSION_START },
+    UserPromptSubmit: { event: CLAUDE_HOOK_EVENT.PROMPT },
+    Stop: { event: CLAUDE_HOOK_EVENT.STOP },
+    StopFailure: { event: CLAUDE_HOOK_EVENT.STOP_FAILURE },
+    Notification: {
+      event: CLAUDE_HOOK_EVENT.NOTIFICATION,
+      matcher: "permission_prompt|elicitation_dialog",
+    },
+    SessionEnd: { event: CLAUDE_HOOK_EVENT.SESSION_END },
   },
-  SessionEnd: { event: CLAUDE_HOOK_EVENT.SESSION_END },
-} as const satisfies Record<string, { event: ClaudeHookEvent; matcher?: string }>;
+  timeoutSeconds: CLAUDE_HOOK_TIMEOUT_SECONDS,
+  sessionIdField: "session_id",
+  // The shape Claude Code mints: hex and hyphens.
+  sessionIdPattern: "[0-9a-fA-F-]{8,64}",
+  subagentField: "agent_id",
+};
 
 /** Where Claude Code keeps its transcripts and its user-level settings. */
 export function defaultClaudeHome(): string {
@@ -114,372 +102,37 @@ export interface ClaudeCodeHookInstallation {
   spoolDirectory: string;
 }
 
-/**
- * The script Claude Code runs. It writes one fixed token into the spool and
- * nothing else: the envelope on stdin is read only to name the session, its
- * text never reaches disk, and a token or session id it does not recognize
- * ends it without a write. A missing spool ends it too — that is what turning
- * the setting off means — so a stale registration is an instant no-op.
- */
-function claudeHookScript(spoolDirectory: string): string {
-  return `#!/bin/sh
-# Luke Claude Code observation hook v1
-#
-# Claude Code runs this at a session's turn boundaries. It writes one fixed
-# status token into Luke's own spool — never into any provider file — naming
-# the file by the session's own id. The envelope piped in is read only for
-# that id; its text never reaches disk. Luke installs and removes this file.
-
-SPOOL_DIRECTORY="${spoolDirectory}"
-
-# The token is fixed at registration, one per hook entry, so nothing piped in
-# can choose what is written.
-case "$1" in
-  ${CLAUDE_HOOK_EVENT_LIST.join("|")}) EVENT_TOKEN="$1" ;;
-  *) exit 0 ;;
-esac
-
-# No spool means observation hooks are off or Luke is gone; leave quietly.
-[ -d "$SPOOL_DIRECTORY" ] || exit 0
-
-ENVELOPE=$(cat)
-
-# A subagent's turns are not the session's: they start and stop while the
-# main loop is mid-turn, so recording them would flap the row. The envelope
-# names an agent only inside one, at the price that a prompt quoting the
-# field's name is skipped too — the transcript still carries that turn.
-case "$ENVELOPE" in
-  *'"agent_id"'*) exit 0 ;;
-esac
-
-# The id becomes the spool file's name, so only the shape Claude Code mints —
-# hex and hyphens — is accepted at all.
-SESSION_ID=$(printf '%s' "$ENVELOPE" \\
-  | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[0-9a-fA-F-]{8,64}"' \\
-  | head -n 1 | grep -oE '[0-9a-fA-F-]{8,64}')
-[ -n "$SESSION_ID" ] || exit 0
-
-# One tiny file per session, replaced on every event: only the newest event
-# matters, and replacement is what bounds the spool. Writing beside the spool
-# file and moving over it keeps a concurrent reader off half a write.
-TEMPORARY_FILE="$SPOOL_DIRECTORY/.$SESSION_ID.$$.tmp"
-printf '{"event":"%s"}' "$EVENT_TOKEN" > "$TEMPORARY_FILE" || exit 0
-mv -f "$TEMPORARY_FILE" "$SPOOL_DIRECTORY/$SESSION_ID${HOOK_EVENT_FILE_EXTENSION}"
-`;
+function sharedInstallation(installation: ClaudeCodeHookInstallation): ObservationHookInstallation {
+  return {
+    providerHome: installation.claudeHome,
+    hookScriptPath: installation.hookScriptPath,
+    spoolDirectory: installation.spoolDirectory,
+  };
 }
 
-/**
- * The command registered in Claude Code's settings. Guarded on the script
- * being present and executable, so an entry outliving an uninstalled Luke is
- * an instant no-op rather than a "not found" in every session on the machine.
- */
-function claudeHookCommand(hookScriptPath: string, event: ClaudeHookEvent): string {
-  return `[ -x "${hookScriptPath}" ] && "${hookScriptPath}" ${event} || true`;
-}
-
-/**
- * Whether a hook command is one of ours. The script's distinctive file name is
- * the marker, so entries written by an older build — a different data path, a
- * different guard — are still recognized and reconciled rather than left to
- * pile up beside the current one.
- */
-function isLukeHookCommand(command: unknown): boolean {
-  return typeof command === "string" && command.includes(CLAUDE_HOOK_SCRIPT_NAME);
-}
-
-/**
- * Strips Luke's inner hooks from one settings entry, returning the entry
- * unchanged when it is entirely the user's, a copy when it mixed the user's
- * hooks with ours, and nothing when nothing of the user's remains.
- */
-function withoutLukeHooks(entry: Record<string, unknown>): Record<string, unknown> | undefined {
-  const hooks = entry.hooks;
-  if (!Array.isArray(hooks)) return entry;
-  const kept = hooks.filter((hook) => !(isRecord(hook) && isLukeHookCommand(hook.command)));
-  if (kept.length === hooks.length) return entry;
-  if (kept.length === 0) return undefined;
-  return { ...entry, hooks: kept };
-}
-
-/**
- * Strips Luke's entries from every event in place — including events this
- * build no longer registers, so an entry from an older build is cleaned up by
- * the newer one rather than left behind. Anything that is not the nested
- * shape Claude Code documents is preserved verbatim: a malformed entry is the
- * user's problem to notice, never ours to discard. Answers whether anything
- * of Luke's was actually there, so removal can decline to rewrite a file it
- * only ever read — a formatting difference must not read as a change.
- */
-function stripLukeEntries(events: Record<string, unknown>): boolean {
-  let stripped = false;
-  for (const [eventName, entries] of Object.entries(events)) {
-    if (!Array.isArray(entries)) continue;
-    let strippedHere = false;
-    const kept = entries.flatMap((entry) => {
-      if (!isRecord(entry)) return [entry];
-      const cleaned = withoutLukeHooks(entry);
-      if (cleaned !== entry) strippedHere = true;
-      return cleaned === undefined ? [] : [cleaned];
-    });
-    if (!strippedHere) continue;
-    stripped = true;
-    if (kept.length === 0) delete events[eventName];
-    else events[eventName] = kept;
-  }
-  return stripped;
-}
-
-/**
- * The settings content with Luke's current entries in place: the user's own
- * settings and hooks are preserved as parsed, stale Luke entries are stripped
- * everywhere, and one entry per registered event is appended. Nothing is
- * returned for a file that cannot be read as a JSON object — never rewrite a
- * file that cannot be read back.
- */
-export function claudeSettingsWithObservationHooks(
-  source: string | undefined,
-  hookScriptPath: string,
-): string | undefined {
-  let root: Record<string, unknown> = {};
-  if (source !== undefined) {
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(source);
-    } catch {
-      return undefined;
-    }
-    if (!isRecord(parsed)) return undefined;
-    root = parsed;
-  }
-
-  const events = isRecord(root.hooks) ? root.hooks : {};
-  root.hooks = events;
-  stripLukeEntries(events);
-
-  for (const [eventName, registration] of Object.entries(CLAUDE_HOOK_REGISTRATION)) {
-    const existing = events[eventName];
-    const kept = Array.isArray(existing) ? existing : [];
-    events[eventName] = [
-      ...kept,
-      {
-        ...("matcher" in registration ? { matcher: registration.matcher } : {}),
-        hooks: [
-          {
-            type: "command",
-            command: claudeHookCommand(hookScriptPath, registration.event),
-            timeout: CLAUDE_HOOK_TIMEOUT_SECONDS,
-          },
-        ],
-      },
-    ];
-  }
-
-  return `${JSON.stringify(root, undefined, 2)}\n`;
-}
-
-/**
- * The settings content with every Luke entry stripped, or nothing when there
- * is nothing to change — including a file that cannot be parsed, which is
- * left exactly as found for the same reason the merge leaves it.
- */
-export function claudeSettingsWithoutObservationHooks(source: string): string | undefined {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(source);
-  } catch {
-    return undefined;
-  }
-  if (!isRecord(parsed)) return undefined;
-
-  const events = parsed.hooks;
-  if (!isRecord(events)) return undefined;
-  // Only a file that actually held Luke's entries is written at all. Removal
-  // runs at every disabled launch, and a file that merely formats its JSON
-  // differently than this module would must be left byte-for-byte alone.
-  if (!stripLukeEntries(events)) return undefined;
-  if (Object.keys(events).length === 0) delete parsed.hooks;
-
-  return `${JSON.stringify(parsed, undefined, 2)}\n`;
-}
-
-async function readFileIfPresent(filePath: string): Promise<string | undefined> {
-  try {
-    return await fs.readFile(filePath, "utf8");
-  } catch (error) {
-    if (canIgnoreFilesystemError(error)) return undefined;
-    throw error;
-  }
-}
-
-/**
- * Replaces the settings file through a sibling temporary file and a rename,
- * because a write interrupted halfway would leave behind the one thing this
- * module refuses to touch again: an unparseable `settings.json` would break
- * the user's own configuration, not just the registration. The original
- * file's mode is carried over — the file is the user's, and so is however
- * they protected it.
- *
- * The rename lands on the file the path finally names, not the path itself: a
- * dotfiles-managed `settings.json` is often a symlink, and renaming over the
- * link would quietly swap it for a plain copy while the synced original went
- * stale. A path that does not resolve yet is a file being created, placed by
- * its directory's own resolution for the same reason.
- */
-async function replaceSettingsFile(settingsPath: string, content: string): Promise<void> {
-  let targetPath: string;
-  try {
-    targetPath = await fs.realpath(settingsPath);
-  } catch (error) {
-    if (!canIgnoreFilesystemError(error)) throw error;
-    const directory = await fs
-      .realpath(path.dirname(settingsPath))
-      .catch(() => path.dirname(settingsPath));
-    targetPath = path.join(directory, path.basename(settingsPath));
-  }
-  let mode = 0o644;
-  try {
-    mode = (await fs.stat(targetPath)).mode & 0o777;
-  } catch (error) {
-    if (!canIgnoreFilesystemError(error)) throw error;
-  }
-  const temporaryPath = `${targetPath}.luke-tmp`;
-  await fs.writeFile(temporaryPath, content, { encoding: "utf8", mode });
-  // `mode` only applies when the file is created, so a temporary file left
-  // behind by an interrupted write keeps whatever mode it already had.
-  await fs.chmod(temporaryPath, mode);
-  await fs.rename(temporaryPath, targetPath);
-}
-
-async function writeFileIfChanged(filePath: string, content: string, mode: number): Promise<void> {
-  const existing = await readFileIfPresent(filePath);
-  if (existing === content) {
-    await fs.chmod(filePath, mode);
-    return;
-  }
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.writeFile(filePath, content, { encoding: "utf8", mode });
-  // `mode` only applies when the file is created; an existing script must not
-  // keep whatever mode an older write left it.
-  await fs.chmod(filePath, mode);
-}
-
-/**
- * Puts the whole arrangement in place: the script, the spool it writes into,
- * and the registration naming the script. Run at every launch while the
- * setting is on — like every other managed piece of Luke's own state, the
- * installation is converged rather than performed once — and safe to run
- * again at any time: an unchanged file is left untouched down to its mtime.
- */
-export async function installClaudeCodeObservationHooks(
+export function installClaudeCodeObservationHooks(
   installation: ClaudeCodeHookInstallation,
 ): Promise<void> {
-  // A machine with no Claude Code home gets nothing at all: registering would
-  // create another product's directory on its behalf, for sessions that do
-  // not exist. Installation converges at every launch, so a Claude Code that
-  // arrives later is picked up the next time Luke starts.
-  try {
-    await fs.stat(installation.claudeHome);
-  } catch (error) {
-    if (canIgnoreFilesystemError(error)) return;
-    throw error;
-  }
-
-  await fs.mkdir(installation.spoolDirectory, { recursive: true });
-  await writeFileIfChanged(
-    installation.hookScriptPath,
-    claudeHookScript(installation.spoolDirectory),
-    0o755,
-  );
-
-  const settingsPath = path.join(installation.claudeHome, CLAUDE_SETTINGS_FILE_NAME);
-  const source = await readFileIfPresent(settingsPath);
-  const merged = claudeSettingsWithObservationHooks(source, installation.hookScriptPath);
-  if (merged === undefined || merged === source) return;
-  await replaceSettingsFile(settingsPath, merged);
+  return installObservationHooks(CLAUDE_HOOK_SPEC, sharedInstallation(installation));
 }
 
-/**
- * Takes the whole arrangement back out: the registration entries, the script,
- * and the spool with whatever events it held. The settings file is the one
- * thing never created here — a teardown that leaves new files behind has the
- * relationship backwards — and a file that cannot be parsed is left as found.
- */
-export async function removeClaudeCodeObservationHooks(
+export function removeClaudeCodeObservationHooks(
   installation: ClaudeCodeHookInstallation,
 ): Promise<void> {
-  const settingsPath = path.join(installation.claudeHome, CLAUDE_SETTINGS_FILE_NAME);
-  const source = await readFileIfPresent(settingsPath);
-  if (source !== undefined) {
-    const stripped = claudeSettingsWithoutObservationHooks(source);
-    if (stripped !== undefined) await replaceSettingsFile(settingsPath, stripped);
-  }
-  await fs.rm(installation.hookScriptPath, { force: true });
-  await fs.rm(installation.spoolDirectory, { recursive: true, force: true });
+  return removeObservationHooks(CLAUDE_HOOK_SPEC, sharedInstallation(installation));
 }
 
-/**
- * Reads what the hook last said about one session: the token, dated by the
- * spool file's own mtime — the one clock the script and the reader share
- * without writing timestamps at all. Only Luke's script writes here, so the
- * mtime cannot suffer the bulk-touch problem the transcripts do. Anything
- * unexpected — no file, a foreign shape, an unknown token — reads as no event,
- * because the tail this refines is always there to fall back on.
- */
-export async function readClaudeHookEvent(
+export function readClaudeHookEvent(
   spoolDirectory: string,
   providerSessionId: string,
 ): Promise<ObservedClaudeHookEvent | undefined> {
-  const filePath = path.join(spoolDirectory, `${providerSessionId}${HOOK_EVENT_FILE_EXTENSION}`);
-  let handle: fs.FileHandle;
-  try {
-    handle = await fs.open(filePath, "r");
-  } catch (error) {
-    if (canIgnoreFilesystemError(error)) return undefined;
-    throw error;
-  }
-  try {
-    const stats = await handle.stat();
-    if (stats.size > HOOK_EVENT_FILE_READ_BYTES) return undefined;
-    const content = await handle.readFile({ encoding: "utf8" });
-    let record: unknown;
-    try {
-      record = JSON.parse(content);
-    } catch {
-      return undefined;
-    }
-    if (!isRecord(record) || !isClaudeHookEvent(record.event)) return undefined;
-    return { event: record.event, atMs: stats.mtimeMs };
-  } finally {
-    await handle.close();
-  }
+  return readObservationHookEvent(CLAUDE_HOOK_SPEC, spoolDirectory, providerSessionId);
 }
 
-/**
- * Drops spool files old enough that the adapter would no longer read them:
- * an event beyond the observation window refines nothing, and the sessions
- * behind such files are mostly gone for good. Run where install is run, so
- * the spool's size tracks the sessions actually alive rather than every
- * session ever observed.
- */
-export async function pruneClaudeHookSpool(
+export function pruneClaudeHookSpool(
   spoolDirectory: string,
   maximumAgeMs: number,
   now: number,
 ): Promise<void> {
-  let entries: string[];
-  try {
-    entries = await fs.readdir(spoolDirectory);
-  } catch (error) {
-    if (canIgnoreFilesystemError(error)) return;
-    throw error;
-  }
-  for (const entry of entries) {
-    const filePath = path.join(spoolDirectory, entry);
-    try {
-      const stats = await fs.stat(filePath);
-      if (now - stats.mtimeMs > maximumAgeMs) await fs.rm(filePath, { force: true });
-    } catch (error) {
-      if (!canIgnoreFilesystemError(error)) throw error;
-    }
-  }
+  return pruneObservationHookSpool(spoolDirectory, maximumAgeMs, now);
 }

--- a/apps/desktop/src/claude-code-transcript.ts
+++ b/apps/desktop/src/claude-code-transcript.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { isRecord, oneLine, text } from "@sidecar/core";
 import { readDirectory, readTail, statDirectoryEntry, tailRecords } from "./local-session-adapter";
+import { boundedTranscript, TRANSCRIPT_BOUNDS } from "./local-transcript";
 
 /**
  * On-demand reading of one Claude Code session's transcript, for a question
@@ -18,23 +19,6 @@ const CLAUDE_SESSION_FILE_EXTENSION = ".jsonl";
 
 /** The same shape the observation hook accepts: the ids Claude Code mints. */
 const CLAUDE_SESSION_ID_SHAPE = /^[0-9a-fA-F-]{8,64}$/;
-
-const TRANSCRIPT_BOUNDS = {
-  /** How much of the file's end one read may load. */
-  READ_TAIL_BYTES: 256 * 1024,
-  /** A rendered message line: enough to carry meaning, not a document. */
-  MAXIMUM_MESSAGE_LENGTH: 400,
-  /** A rendered tool call or its result: the gist, never the payload. */
-  MAXIMUM_TOOL_LENGTH: 200,
-  /**
-   * The whole rendering. It enters a live conversation as one tool output,
-   * so it is sized for answering a question about the session, not for
-   * carrying the session.
-   */
-  MAXIMUM_RENDERED_LENGTH: 8_000,
-} as const;
-
-const OMISSION_MARKER = "[earlier turns omitted]";
 
 /** Tool inputs whose value names the work, in the order they read best. */
 const TOOL_INPUT_KEYS = ["description", "file_path", "pattern", "command", "prompt"] as const;
@@ -176,9 +160,7 @@ async function transcriptFilePath(
 
 /**
  * Reads one session's recent transcript into a bounded rendering, or nothing
- * when no transcript file exists for that id. The newest turns win the space:
- * a question about a session is almost always about where it is now, so the
- * rendering is cut from the front, at a line, and says so.
+ * when no transcript file exists for that id.
  */
 export async function readClaudeSessionTranscript(
   request: ClaudeTranscriptRequest,
@@ -188,14 +170,8 @@ export async function readClaudeSessionTranscript(
 
   const tail = await readTail(filePath, request.readTailBytes ?? TRANSCRIPT_BOUNDS.READ_TAIL_BYTES);
   const lines = tailRecords(tail).flatMap(linesFromRecord);
-  if (lines.length === 0) return undefined;
-
-  const maximumLength = request.maximumRenderedLength ?? TRANSCRIPT_BOUNDS.MAXIMUM_RENDERED_LENGTH;
-  let rendered = lines.join("\n");
-  if (rendered.length > maximumLength) {
-    const kept = rendered.slice(rendered.length - maximumLength);
-    const firstWholeLine = kept.indexOf("\n");
-    rendered = `${OMISSION_MARKER}\n${firstWholeLine >= 0 ? kept.slice(firstWholeLine + 1) : kept}`;
-  }
-  return rendered;
+  return boundedTranscript(
+    lines,
+    request.maximumRenderedLength ?? TRANSCRIPT_BOUNDS.MAXIMUM_RENDERED_LENGTH,
+  );
 }

--- a/apps/desktop/src/codex-adapter.ts
+++ b/apps/desktop/src/codex-adapter.ts
@@ -17,6 +17,12 @@ import {
   text,
   wholeNumber,
 } from "@sidecar/core";
+import {
+  CODEX_HOOK_EVENT,
+  type CodexHookEvent,
+  type ObservedCodexHookEvent,
+  readCodexHookEvent,
+} from "./codex-hooks";
 import { readTail, readTextFile, uniquePaths, workspaceLabel } from "./local-session-adapter";
 import {
   canIgnoreSqliteError,
@@ -94,7 +100,7 @@ const CODEX_RESPONSE_PAYLOAD = {
  * best. `cmd` leads because `exec_command` is by far the most common call Codex
  * makes and that is what it calls its command line.
  */
-const CODEX_CALL_ARGUMENT_KEY = [
+export const CODEX_CALL_ARGUMENT_KEY = [
   "cmd",
   "command",
   "path",
@@ -110,6 +116,15 @@ const CODEX_ADAPTER_DEFAULTS = {
   /** Only the threads that can still change are worth a second file read. */
   MAXIMUM_ROLLOUT_READS: 12,
   MAXIMUM_ACTIVITY_LENGTH: 80,
+  /**
+   * How much older than the thread row's clock a hook event may run and still
+   * describe the same moment. The hook fires as a turn boundary happens and
+   * Codex touches the row moments later under its own clock, so a boundary's
+   * event usually trails the row it belongs with by a breath — never by more
+   * than this. An event further behind describes a turn the thread has
+   * already moved past, and refines nothing.
+   */
+  HOOK_EVENT_TOLERANCE_MS: 5_000,
 } as const;
 
 // Every column is read defensively from the row, so the projection stays `*`:
@@ -145,6 +160,14 @@ export interface CodexAdapterOptions {
   now?: () => number;
   activeSessionFreshnessMs?: number;
   sqlite?: SqliteModuleLoader;
+  /**
+   * Where the observation hook spools its events, when hooks are on at all.
+   * Read lazily like the cloud adapters' credentials, because the app decides
+   * the path after this adapter is declared. Absent — or answering nothing —
+   * the adapter reads the state database and rollouts alone, exactly as it
+   * always has: the hooks only ever sharpen what those already showed.
+   */
+  hookEventsDirectory?: () => string | undefined;
 }
 
 /**
@@ -153,7 +176,7 @@ export interface CodexAdapterOptions {
  * so a list of plain values is joined instead of dropped. A list of anything
  * else, such as a plan's steps, is not a phrase and is left alone.
  */
-function argumentPhrase(value: unknown): string | undefined {
+export function argumentPhrase(value: unknown): string | undefined {
   if (typeof value === "string") return text(value);
   if (typeof value === "number") return String(value);
   if (!Array.isArray(value) || value.length === 0) return undefined;
@@ -303,7 +326,12 @@ async function sqliteHomeFromConfig(codexHome: string): Promise<string | undefin
     : undefined;
 }
 
-async function stateDatabasePaths(
+/**
+ * Where Codex's state database may be, most authoritative first: an explicit
+ * home, then the one `config.toml` names, then wherever `CODEX_SQLITE_HOME`
+ * points, then the paths Codex writes by default.
+ */
+export async function stateDatabasePaths(
   codexHome: string,
   configuredSqliteHome: string | undefined,
 ): Promise<string[]> {
@@ -359,6 +387,33 @@ function statusFromRow(
   return isFresh ? SESSION_STATUS.WORKING : SESSION_STATUS.UNKNOWN;
 }
 
+/**
+ * Sharpens the row's verdict with what the observation hook last said, in the
+ * order the meanings bind. A closed session is definite: the hook saying so
+ * outranks the row, and an archived thread is never talked out of complete by
+ * a softer event. Past those, the events refine only a fresh session — the
+ * decay to `UNKNOWN` exists because a hook can go silent (a killed process
+ * fires no `SessionEnd`), so an old "waiting" must age the same way an old
+ * row does. What the refinement actually buys is the states the state
+ * database cannot show: a tool call holding for approval writes no records
+ * while it holds, and a turn's true end can sit past the rollout's read.
+ */
+function statusWithHookEvent(
+  status: ProviderSessionObservation["status"],
+  event: CodexHookEvent,
+  isFresh: boolean,
+): ProviderSessionObservation["status"] {
+  if (event === CODEX_HOOK_EVENT.SESSION_END) return SESSION_STATUS.COMPLETE;
+  if (status === SESSION_STATUS.COMPLETE) return status;
+  if (!isFresh) return status;
+  if (event === CODEX_HOOK_EVENT.PROMPT) return SESSION_STATUS.WORKING;
+  if (event === CODEX_HOOK_EVENT.STOP) return SESSION_STATUS.WAITING;
+  if (event === CODEX_HOOK_EVENT.NOTIFICATION) return SESSION_STATUS.WAITING;
+  // A session that started or resumed proves only that it moved: the bumped
+  // clock above is the whole refinement, and the row says the rest.
+  return status;
+}
+
 function detailFromRow(
   row: CodexThreadRow,
   rollout: ParsedCodexRollout | undefined,
@@ -381,12 +436,30 @@ function observationFromThreadRow(
   rollout: ParsedCodexRollout | undefined,
   now: number,
   activeSessionFreshnessMs: number,
+  hookEvent?: ObservedCodexHookEvent,
 ): ProviderSessionObservation | undefined {
   const providerSessionId = textFromRow(row, CODEX_THREAD_COLUMN.ID);
   if (!providerSessionId) return undefined;
 
-  const observedAt = timestampFromRow(row);
-  const status = statusFromRow(row, rollout, observedAt, now, activeSessionFreshnessMs);
+  // A hook event trailing the row's clock by more than the tolerance
+  // describes a turn the thread has already moved past, so it is ignored
+  // whole. One that stands is proof the session moved — only Luke's own
+  // script writes the spool — and dates the session for the freshness decay
+  // as well. A notification alone gets no tolerance: it means the session is
+  // holding for approval, and holding writes nothing, so a row touched at or
+  // past the event is itself the news that the hold ended.
+  const rowAt = timestampFromRow(row);
+  const toleranceMs =
+    hookEvent?.event === CODEX_HOOK_EVENT.NOTIFICATION
+      ? 0
+      : CODEX_ADAPTER_DEFAULTS.HOOK_EVENT_TOLERANCE_MS;
+  const eventStands = hookEvent !== undefined && hookEvent.atMs + toleranceMs >= rowAt;
+  const observedAt = eventStands ? Math.max(rowAt, hookEvent.atMs) : rowAt;
+  let status = statusFromRow(row, rollout, observedAt, now, activeSessionFreshnessMs);
+  if (eventStands) {
+    const isFresh = now - observedAt <= activeSessionFreshnessMs;
+    status = statusWithHookEvent(status, hookEvent.event, isFresh);
+  }
   return {
     providerSessionId,
     title: titleFromRow(row),
@@ -397,7 +470,7 @@ function observationFromThreadRow(
   };
 }
 
-function defaultCodexHome(): string {
+export function defaultCodexHome(): string {
   const configuredHome = process.env[CODEX_ENVIRONMENT.CONFIG_DIRECTORY]?.trim();
   return configuredHome || path.join(os.homedir(), ".codex");
 }
@@ -410,6 +483,7 @@ export class CodexSessionAdapter implements SessionProviderAdapter {
   readonly #now: () => number;
   readonly #activeSessionFreshnessMs: number;
   readonly #sqlite: SqliteModuleLoader;
+  readonly #hookEventsDirectory: (() => string | undefined) | undefined;
 
   constructor(options: CodexAdapterOptions = {}) {
     this.#codexHome = options.codexHome ?? defaultCodexHome();
@@ -426,6 +500,7 @@ export class CodexSessionAdapter implements SessionProviderAdapter {
     );
     this.#activeSessionFreshnessMs = resolved.activeSessionFreshnessMs;
     this.#sqlite = options.sqlite ?? defaultSqliteModule;
+    this.#hookEventsDirectory = options.hookEventsDirectory;
   }
 
   async observe(): Promise<readonly ProviderSessionObservation[]> {
@@ -447,9 +522,11 @@ export class CodexSessionAdapter implements SessionProviderAdapter {
         database.close();
       }
 
-      // The rollout read happens with the database already closed, so a slow
-      // disk never holds a read lock on state Codex itself is writing.
+      // The rollout and spool reads happen with the database already closed,
+      // so a slow disk never holds a read lock on state Codex itself is
+      // writing.
       const rollouts = await this.#rollouts(rows);
+      const hookEvents = await this.#hookEvents(rows);
       return rows
         .map((row) =>
           observationFromThreadRow(
@@ -457,6 +534,7 @@ export class CodexSessionAdapter implements SessionProviderAdapter {
             rollouts.get(textFromRow(row, CODEX_THREAD_COLUMN.ID) ?? ""),
             now,
             this.#activeSessionFreshnessMs,
+            hookEvents.get(textFromRow(row, CODEX_THREAD_COLUMN.ID) ?? ""),
           ),
         )
         .filter(
@@ -494,5 +572,26 @@ export class CodexSessionAdapter implements SessionProviderAdapter {
       }),
     );
     return new Map(parsed);
+  }
+
+  /**
+   * Reads what the observation hook last said about each thread. The spool is
+   * a refinement, never a dependency: a directory that is missing, unreadable,
+   * or holding something unexpected reads as no event, and the row's own
+   * verdict stands.
+   */
+  async #hookEvents(rows: readonly CodexThreadRow[]): Promise<Map<string, ObservedCodexHookEvent>> {
+    const events = new Map<string, ObservedCodexHookEvent>();
+    const hookEventsDirectory = this.#hookEventsDirectory?.();
+    if (!hookEventsDirectory) return events;
+    await Promise.all(
+      rows.map(async (row) => {
+        const id = textFromRow(row, CODEX_THREAD_COLUMN.ID);
+        if (!id) return;
+        const event = await readCodexHookEvent(hookEventsDirectory, id).catch(() => undefined);
+        if (event) events.set(id, event);
+      }),
+    );
+    return events;
   }
 }

--- a/apps/desktop/src/codex-adapter.ts
+++ b/apps/desktop/src/codex-adapter.ts
@@ -405,10 +405,18 @@ function statusWithHookEvent(
 ): ProviderSessionObservation["status"] {
   if (event === CODEX_HOOK_EVENT.SESSION_END) return SESSION_STATUS.COMPLETE;
   if (status === SESSION_STATUS.COMPLETE) return status;
+  // A notification still standing means the approval is still open — its zero
+  // staleness tolerance drops it the moment the thread moves — so it outranks
+  // a mid-turn row however long the hold has run: Codex holds a long turn at
+  // working, and a long hold must not read as active work. It still ages the
+  // way every waiting verdict does, because a Codex killed mid-hold fires
+  // nothing further, and a hold that old is a session left behind.
+  if (event === CODEX_HOOK_EVENT.NOTIFICATION) {
+    return isFresh ? SESSION_STATUS.WAITING : SESSION_STATUS.UNKNOWN;
+  }
   if (!isFresh) return status;
   if (event === CODEX_HOOK_EVENT.PROMPT) return SESSION_STATUS.WORKING;
   if (event === CODEX_HOOK_EVENT.STOP) return SESSION_STATUS.WAITING;
-  if (event === CODEX_HOOK_EVENT.NOTIFICATION) return SESSION_STATUS.WAITING;
   // A session that started or resumed proves only that it moved: the bumped
   // clock above is the whole refinement, and the row says the rest.
   return status;

--- a/apps/desktop/src/codex-hooks.ts
+++ b/apps/desktop/src/codex-hooks.ts
@@ -1,0 +1,123 @@
+import {
+  HOOK_SPOOL_MAXIMUM_AGE_MS,
+  installObservationHooks,
+  type ObservationHookInstallation,
+  type ObservationHookSpec,
+  type ObservedHookEvent,
+  pruneObservationHookSpool,
+  readObservationHookEvent,
+  removeObservationHooks,
+} from "./observation-hooks";
+
+/**
+ * Codex's observation hooks, described for the shared machinery in
+ * `observation-hooks.ts`. Codex keeps user-level hooks in a `hooks.json` of
+ * their own inside its home, nested the same way Claude Code's are, and hands
+ * a registered command its envelope as JSON on stdin. The envelope's
+ * `session_id` is the same thread id the adapter reads from `threads.id`, so
+ * the spool token lands under the name the roster already knows.
+ *
+ * Codex reviews foreign hooks before running them: a new entry is shown to
+ * the user at startup and runs only once they trust it. That gate is Codex's
+ * own consent mechanism and Luke leaves it alone — until the user trusts the
+ * entry, everything here observes from the state database and rollouts
+ * exactly as before, which is also what the entry costs when declined.
+ */
+
+/**
+ * The script's name is also the marker a managed entry is recognized by, so
+ * renaming it is a migration: an entry naming the old script would stop being
+ * recognized as ours and would be left behind.
+ */
+export const CODEX_HOOK_SCRIPT_NAME = "luke-codex-observation-hook.sh";
+
+/** How long Codex lets the spool write run before giving up on it. */
+const CODEX_HOOK_TIMEOUT_SECONDS = 10;
+
+export const CODEX_HOOK_SPOOL_MAXIMUM_AGE_MS = HOOK_SPOOL_MAXIMUM_AGE_MS;
+
+/**
+ * The tokens the script may write, fixed at registration: each hook entry
+ * passes its own token as the script's one argument, so nothing in the
+ * envelope Codex hands in can choose what lands in the spool. The same
+ * vocabulary Claude Code's spool speaks, minus the failure token — Codex
+ * fires no hook for a turn that failed, so the rollout keeps that verdict.
+ */
+export const CODEX_HOOK_EVENT = {
+  SESSION_START: "session-start",
+  PROMPT: "prompt",
+  STOP: "stop",
+  NOTIFICATION: "notification",
+  SESSION_END: "session-end",
+} as const;
+
+export type CodexHookEvent = (typeof CODEX_HOOK_EVENT)[keyof typeof CODEX_HOOK_EVENT];
+
+/** The latest thing the hook reported about one session, dated by the spool. */
+export type ObservedCodexHookEvent = ObservedHookEvent<CodexHookEvent>;
+
+/**
+ * Which Codex lifecycle moments are registered, and the token each one hands
+ * the script. Turn boundaries and lifecycle edges only, for the same reason
+ * Claude Code's registration stops there. `PermissionRequest` is Codex's own
+ * name for a tool call holding for approval — the one moment the state
+ * database shows nothing new — and the entry only observes it: the command
+ * always exits zero, so nothing here can answer the request.
+ */
+const CODEX_HOOK_SPEC: ObservationHookSpec<CodexHookEvent> = {
+  scriptName: CODEX_HOOK_SCRIPT_NAME,
+  configurationFileName: "hooks.json",
+  scriptTitle: "Luke Codex observation hook v1",
+  registration: {
+    SessionStart: { event: CODEX_HOOK_EVENT.SESSION_START },
+    UserPromptSubmit: { event: CODEX_HOOK_EVENT.PROMPT },
+    Stop: { event: CODEX_HOOK_EVENT.STOP },
+    PermissionRequest: { event: CODEX_HOOK_EVENT.NOTIFICATION },
+    SessionEnd: { event: CODEX_HOOK_EVENT.SESSION_END },
+  },
+  timeoutSeconds: CODEX_HOOK_TIMEOUT_SECONDS,
+  sessionIdField: "session_id",
+  // Codex thread ids are UUIDs: hex and hyphens, like Claude Code's.
+  sessionIdPattern: "[0-9a-fA-F-]{8,64}",
+  subagentField: "agent_id",
+};
+
+export interface CodexHookInstallation {
+  /** Codex's own home, holding the `hooks.json` entries merge into. */
+  codexHome: string;
+  /** Where Luke keeps the script, under Luke's own application data. */
+  hookScriptPath: string;
+  /** Where the script writes its event files, under Luke's own data too. */
+  spoolDirectory: string;
+}
+
+function sharedInstallation(installation: CodexHookInstallation): ObservationHookInstallation {
+  return {
+    providerHome: installation.codexHome,
+    hookScriptPath: installation.hookScriptPath,
+    spoolDirectory: installation.spoolDirectory,
+  };
+}
+
+export function installCodexObservationHooks(installation: CodexHookInstallation): Promise<void> {
+  return installObservationHooks(CODEX_HOOK_SPEC, sharedInstallation(installation));
+}
+
+export function removeCodexObservationHooks(installation: CodexHookInstallation): Promise<void> {
+  return removeObservationHooks(CODEX_HOOK_SPEC, sharedInstallation(installation));
+}
+
+export function readCodexHookEvent(
+  spoolDirectory: string,
+  providerSessionId: string,
+): Promise<ObservedCodexHookEvent | undefined> {
+  return readObservationHookEvent(CODEX_HOOK_SPEC, spoolDirectory, providerSessionId);
+}
+
+export function pruneCodexHookSpool(
+  spoolDirectory: string,
+  maximumAgeMs: number,
+  now: number,
+): Promise<void> {
+  return pruneObservationHookSpool(spoolDirectory, maximumAgeMs, now);
+}

--- a/apps/desktop/src/codex-transcript.ts
+++ b/apps/desktop/src/codex-transcript.ts
@@ -1,0 +1,272 @@
+import { isRecord, oneLine, recordFromJsonLine, text } from "@sidecar/core";
+import {
+  argumentPhrase,
+  CODEX_CALL_ARGUMENT_KEY,
+  defaultCodexHome,
+  stateDatabasePaths,
+} from "./codex-adapter";
+import { readTail, tailRecords } from "./local-session-adapter";
+import {
+  canIgnoreSqliteError,
+  defaultSqliteModule,
+  openReadOnlyDatabase,
+  type SqliteModuleLoader,
+} from "./local-sqlite";
+import { boundedTranscript, TRANSCRIPT_BOUNDS } from "./local-transcript";
+
+/**
+ * On-demand reading of one Codex session's transcript, for a question the
+ * developer just asked. The rollout JSONL named by the thread's own
+ * `rollout_path` is the transcript — the same file the adapter already reads
+ * a boundary event from, and the one the hook envelope's `transcript_path`
+ * names — so this reads it the way the adapter reads its tail, only deeper: a
+ * bounded slice, parsed in memory, rendered into a bounded conversation, and
+ * discarded. Nothing here is retained, watched, or written; a session is
+ * re-read the next time it is asked about.
+ */
+
+const CODEX_SPEAKER_NAME = "Codex";
+
+/** The rollout line kinds a rendering reads; everything else is bookkeeping. */
+const CODEX_ROLLOUT_LINE_TYPE = {
+  RESPONSE_ITEM: "response_item",
+  EVENT_MSG: "event_msg",
+} as const;
+
+/**
+ * The response items a conversation is made of. Messages and calls are read
+ * from these alone — the `event_msg` lines duplicate them for Codex's own
+ * UI, and rendering both would say everything twice.
+ */
+const CODEX_ITEM_TYPE = {
+  MESSAGE: "message",
+  FUNCTION_CALL: "function_call",
+  FUNCTION_CALL_OUTPUT: "function_call_output",
+  CUSTOM_TOOL_CALL: "custom_tool_call",
+  CUSTOM_TOOL_CALL_OUTPUT: "custom_tool_call_output",
+  LOCAL_SHELL_CALL: "local_shell_call",
+  WEB_SEARCH_CALL: "web_search_call",
+} as const;
+
+const CODEX_MESSAGE_ROLE = {
+  USER: "user",
+  ASSISTANT: "assistant",
+} as const;
+
+/** The one event kind rendered: the failure that ended a turn early. */
+const CODEX_EVENT_TYPE = {
+  ERROR: "error",
+  TASK_COMPLETE: "task_complete",
+} as const;
+
+/**
+ * The marker Codex writes between its injected context and the words the
+ * developer actually typed, when it folds both into one user message.
+ */
+const CODEX_USER_MESSAGE_MARKER = "## My request for Codex:";
+
+/**
+ * A user message that is entirely one XML-tagged block is Codex's own
+ * scaffolding — instructions, environment context, and their relatives —
+ * not something the developer said.
+ */
+const CODEX_SCAFFOLDING_SHAPE = /^<([a-z_]+)>[\s\S]*<\/\1>$/;
+
+const CODEX_ROLLOUT_TAIL_BYTES = TRANSCRIPT_BOUNDS.READ_TAIL_BYTES;
+
+const CODEX_THREAD_ROLLOUT_QUERY = `
+  SELECT rollout_path
+  FROM threads
+  WHERE id = ?
+`;
+
+export interface CodexTranscriptRequest {
+  codexHome?: string;
+  sqliteHome?: string;
+  providerSessionId: string;
+  sqlite?: SqliteModuleLoader;
+  maximumRenderedLength?: number;
+}
+
+/** The words of one message's content blocks, whichever direction they face. */
+function messageWords(content: unknown): string | undefined {
+  if (!Array.isArray(content)) return undefined;
+  const parts = content
+    .filter(isRecord)
+    .filter((block) => block.type === "input_text" || block.type === "output_text")
+    .map((block) => text(block.text))
+    .filter((part): part is string => part !== undefined);
+  return parts.length > 0 ? parts.join(" ") : undefined;
+}
+
+/**
+ * The developer's own words in a user message, or nothing when the message is
+ * Codex's scaffolding. Codex wraps instructions and environment context in
+ * XML-tagged user messages, and sometimes folds context and prompt into one
+ * message with a marker between them; only what follows the marker — or the
+ * whole message when there is neither wrapper nor marker — was typed.
+ */
+function developerWords(words: string): string | undefined {
+  const markerIndex = words.indexOf(CODEX_USER_MESSAGE_MARKER);
+  if (markerIndex >= 0) {
+    return text(words.slice(markerIndex + CODEX_USER_MESSAGE_MARKER.length));
+  }
+  if (CODEX_SCAFFOLDING_SHAPE.test(words.trim())) return undefined;
+  return text(words);
+}
+
+/** Names the tool Codex called, preferring whichever argument says what it is for. */
+function callLine(payload: Record<string, unknown>): string | undefined {
+  const name = text(payload.name);
+  if (!name) return undefined;
+  const parsedArguments = text(payload.arguments)
+    ? recordFromJsonLine(payload.arguments as string)
+    : undefined;
+  for (const key of CODEX_CALL_ARGUMENT_KEY) {
+    const detail = oneLine(
+      argumentPhrase(parsedArguments?.[key]),
+      TRANSCRIPT_BOUNDS.MAXIMUM_TOOL_LENGTH,
+    );
+    if (detail) return `→ ${name}: ${detail}`;
+  }
+  return `→ ${name}`;
+}
+
+/**
+ * The words a call answered with, wherever this build finds them. Codex wrote
+ * the output as a plain string for years, then as a list of text blocks; the
+ * string itself often holds one more JSON layer whose `output` key carries
+ * the human-readable text of a shell call.
+ */
+function callOutputText(output: unknown): string | undefined {
+  if (typeof output === "string") {
+    const wrapped = recordFromJsonLine(output);
+    if (wrapped && typeof wrapped.output === "string") return text(wrapped.output);
+    return text(output);
+  }
+  if (Array.isArray(output)) {
+    const parts = output
+      .filter(isRecord)
+      .filter((block) => block.type === "input_text")
+      .map((block) => text(block.text))
+      .filter((part): part is string => part !== undefined);
+    return parts.length > 0 ? parts.join(" ") : undefined;
+  }
+  return undefined;
+}
+
+function linesFromResponseItem(payload: Record<string, unknown>): string[] {
+  if (payload.type === CODEX_ITEM_TYPE.MESSAGE) {
+    const words = messageWords(payload.content);
+    if (!words) return [];
+    if (payload.role === CODEX_MESSAGE_ROLE.USER) {
+      const typed = oneLine(developerWords(words), TRANSCRIPT_BOUNDS.MAXIMUM_MESSAGE_LENGTH);
+      return typed ? [`Developer: ${typed}`] : [];
+    }
+    if (payload.role === CODEX_MESSAGE_ROLE.ASSISTANT) {
+      const said = oneLine(words, TRANSCRIPT_BOUNDS.MAXIMUM_MESSAGE_LENGTH);
+      return said ? [`${CODEX_SPEAKER_NAME}: ${said}`] : [];
+    }
+    return [];
+  }
+  if (payload.type === CODEX_ITEM_TYPE.FUNCTION_CALL) {
+    const line = callLine(payload);
+    return line ? [line] : [];
+  }
+  if (payload.type === CODEX_ITEM_TYPE.CUSTOM_TOOL_CALL) {
+    const name = text(payload.name);
+    if (!name) return [];
+    const detail = oneLine(text(payload.input), TRANSCRIPT_BOUNDS.MAXIMUM_TOOL_LENGTH);
+    return [detail ? `→ ${name}: ${detail}` : `→ ${name}`];
+  }
+  if (
+    payload.type === CODEX_ITEM_TYPE.FUNCTION_CALL_OUTPUT ||
+    payload.type === CODEX_ITEM_TYPE.CUSTOM_TOOL_CALL_OUTPUT
+  ) {
+    const answer = oneLine(callOutputText(payload.output), TRANSCRIPT_BOUNDS.MAXIMUM_TOOL_LENGTH);
+    return answer ? [`← ${answer}`] : [];
+  }
+  if (payload.type === CODEX_ITEM_TYPE.LOCAL_SHELL_CALL) {
+    const action = isRecord(payload.action) ? payload.action : undefined;
+    const command = oneLine(argumentPhrase(action?.command), TRANSCRIPT_BOUNDS.MAXIMUM_TOOL_LENGTH);
+    return command ? [`→ shell: ${command}`] : [`→ shell`];
+  }
+  if (payload.type === CODEX_ITEM_TYPE.WEB_SEARCH_CALL) {
+    const action = isRecord(payload.action) ? payload.action : undefined;
+    const query = oneLine(text(action?.query), TRANSCRIPT_BOUNDS.MAXIMUM_TOOL_LENGTH);
+    return query ? [`→ web_search: ${query}`] : [`→ web_search`];
+  }
+  return [];
+}
+
+/**
+ * The failure an event line recorded, when it recorded one. Errors ride
+ * `task_complete` in current builds and stood alone in older ones; either
+ * way the message is the one thing worth a line, because the response items
+ * around it never say why a turn stopped.
+ */
+function linesFromEvent(payload: Record<string, unknown>): string[] {
+  if (payload.type === CODEX_EVENT_TYPE.ERROR) {
+    const words = oneLine(text(payload.message), TRANSCRIPT_BOUNDS.MAXIMUM_TOOL_LENGTH);
+    return words ? [`Error: ${words}`] : [];
+  }
+  if (payload.type === CODEX_EVENT_TYPE.TASK_COMPLETE && isRecord(payload.error)) {
+    const words = oneLine(text(payload.error.message), TRANSCRIPT_BOUNDS.MAXIMUM_TOOL_LENGTH);
+    return words ? [`Error: ${words}`] : [];
+  }
+  return [];
+}
+
+/** Renders one rollout line into the lines a conversation can carry. */
+function linesFromRecord(record: Record<string, unknown>): string[] {
+  const payload = isRecord(record.payload) ? record.payload : undefined;
+  if (!payload) return [];
+  if (record.type === CODEX_ROLLOUT_LINE_TYPE.RESPONSE_ITEM) {
+    return linesFromResponseItem(payload);
+  }
+  if (record.type === CODEX_ROLLOUT_LINE_TYPE.EVENT_MSG) return linesFromEvent(payload);
+  return [];
+}
+
+/**
+ * Finds the session's rollout file the way observation does: named by the
+ * thread's own row in the state database, read through a parameterized
+ * lookup, never composed from the id. A compressed rollout is left unread —
+ * a bounded tail cannot be cut from it — and answers as no transcript.
+ */
+async function rolloutPathForThread(request: CodexTranscriptRequest): Promise<string | undefined> {
+  const codexHome = request.codexHome ?? defaultCodexHome();
+  const sqlite = request.sqlite ?? defaultSqliteModule;
+  for (const databasePath of await stateDatabasePaths(codexHome, request.sqliteHome)) {
+    const database = await openReadOnlyDatabase(sqlite, databasePath);
+    if (!database) continue;
+    try {
+      const row = database.prepare(CODEX_THREAD_ROLLOUT_QUERY).all(request.providerSessionId)[0];
+      const rolloutPath = isRecord(row) ? text(row.rollout_path) : undefined;
+      if (rolloutPath) return rolloutPath.endsWith(".zst") ? undefined : rolloutPath;
+    } catch (error) {
+      if (!canIgnoreSqliteError(error)) throw error;
+    } finally {
+      database.close();
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Reads one session's recent transcript into a bounded rendering, or nothing
+ * when no rollout file exists for that id.
+ */
+export async function readCodexSessionTranscript(
+  request: CodexTranscriptRequest,
+): Promise<string | undefined> {
+  const rolloutPath = await rolloutPathForThread(request);
+  if (!rolloutPath) return undefined;
+
+  const tail = await readTail(rolloutPath, CODEX_ROLLOUT_TAIL_BYTES);
+  const lines = tailRecords(tail).flatMap(linesFromRecord);
+  return boundedTranscript(
+    lines,
+    request.maximumRenderedLength ?? TRANSCRIPT_BOUNDS.MAXIMUM_RENDERED_LENGTH,
+  );
+}

--- a/apps/desktop/src/cursor-transcript.ts
+++ b/apps/desktop/src/cursor-transcript.ts
@@ -1,0 +1,207 @@
+import os from "node:os";
+import path from "node:path";
+import { isRecord, oneLine, text } from "@sidecar/core";
+import { readDirectory, readTail, statDirectoryEntry, tailRecords } from "./local-session-adapter";
+import { boundedTranscript, TRANSCRIPT_BOUNDS } from "./local-transcript";
+
+/**
+ * On-demand reading of one local Cursor session's transcript, for a question
+ * the developer just asked. The JSONL file under Cursor's own projects
+ * directory is the transcript — the same file the adapter reads its turn
+ * markers from — so this reads it the way the adapter reads its tail, only
+ * deeper: a bounded slice, parsed in memory, rendered into a bounded
+ * conversation, and discarded. Nothing here is retained, watched, or written;
+ * a session is re-read the next time it is asked about.
+ *
+ * Cursor deliberately keeps tool outputs out of these files, so the rendering
+ * carries the developer's words, the agent's replies, its tool calls, and how
+ * a failed turn failed — and no `←` lines, because there is honestly nothing
+ * to put on them.
+ */
+
+const CURSOR_SPEAKER_NAME = "Cursor";
+
+const CURSOR_PROJECTS_DIRECTORY = "projects";
+const CURSOR_TRANSCRIPTS_DIRECTORY = "agent-transcripts";
+const CURSOR_TRANSCRIPT_FILE_EXTENSION = ".jsonl";
+
+/**
+ * The id becomes path segments under Cursor's home, so only a plain file-name
+ * shape is accepted at all: it must start on a letter or digit, and nothing
+ * that could climb a directory gets past the first character.
+ */
+const CURSOR_SESSION_ID_SHAPE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+const CURSOR_RECORD_ROLE = {
+  USER: "user",
+  ASSISTANT: "assistant",
+} as const;
+
+/** The turn marker the adapter already reads, here for how a turn failed. */
+const CURSOR_RECORD_TYPE = {
+  TURN_ENDED: "turn_ended",
+} as const;
+
+const CURSOR_TURN_STATUS = {
+  ERROR: "error",
+} as const;
+
+const CURSOR_CONTENT_TYPE = {
+  TEXT: "text",
+  TOOL_USE: "tool_use",
+} as const;
+
+/** Tool inputs whose value names the work, in the order they read best. */
+const CURSOR_TOOL_INPUT_KEY = [
+  "description",
+  "file_path",
+  "pattern",
+  "command",
+  "query",
+  "prompt",
+] as const;
+
+/**
+ * The tags Cursor wraps around what the developer typed. The words live
+ * inside `user_query`; everything else a user record carries — timestamps,
+ * attached files, reminders — is Cursor's own scaffolding.
+ */
+const CURSOR_USER_QUERY_SHAPE = /<user_query>([\s\S]*?)<\/user_query>/g;
+
+/**
+ * A user message that is entirely XML-tagged blocks with no query among them
+ * is scaffolding alone, not something the developer said.
+ */
+const CURSOR_SCAFFOLDING_SHAPE = /^(?:<([a-z_]+)>[\s\S]*?<\/\1>\s*)+$/;
+
+export interface CursorTranscriptRequest {
+  cursorHome?: string;
+  providerSessionId: string;
+  readTailBytes?: number;
+  maximumRenderedLength?: number;
+}
+
+function defaultCursorHome(): string {
+  return path.join(os.homedir(), ".cursor");
+}
+
+function contentBlocks(record: Record<string, unknown>): Record<string, unknown>[] {
+  const message = record.message;
+  const content = isRecord(message) ? message.content : undefined;
+  return Array.isArray(content) ? content.filter(isRecord) : [];
+}
+
+/** The words of a message, whether the content is a string or text blocks. */
+function messageText(record: Record<string, unknown>): string | undefined {
+  const message = record.message;
+  const content = isRecord(message) ? message.content : undefined;
+  if (typeof content === "string") return text(content);
+  const parts = contentBlocks(record)
+    .filter((block) => block.type === CURSOR_CONTENT_TYPE.TEXT)
+    .map((block) => text(block.text))
+    .filter((part): part is string => part !== undefined);
+  return parts.length > 0 ? parts.join(" ") : undefined;
+}
+
+/**
+ * The developer's own words in a user record: the `user_query` blocks when
+ * Cursor wrapped them, the whole text when it did not, and nothing when the
+ * record is scaffolding alone.
+ */
+function developerWords(words: string): string | undefined {
+  const queries = [...words.matchAll(CURSOR_USER_QUERY_SHAPE)]
+    .map((match) => text(match[1]))
+    .filter((query): query is string => query !== undefined);
+  if (queries.length > 0) return queries.join(" ");
+  if (CURSOR_SCAFFOLDING_SHAPE.test(words.trim())) return undefined;
+  return text(words);
+}
+
+function toolLine(block: Record<string, unknown>): string | undefined {
+  const name = text(block.name);
+  if (!name) return undefined;
+  const input = isRecord(block.input) ? block.input : {};
+  for (const key of CURSOR_TOOL_INPUT_KEY) {
+    const detail = oneLine(text(input[key]), TRANSCRIPT_BOUNDS.MAXIMUM_TOOL_LENGTH);
+    if (detail) return `→ ${name}: ${detail}`;
+  }
+  return `→ ${name}`;
+}
+
+/** Renders one record into the lines a conversation can carry, oldest first. */
+function linesFromRecord(record: Record<string, unknown>): string[] {
+  if (record.type === CURSOR_RECORD_TYPE.TURN_ENDED) {
+    if (record.status !== CURSOR_TURN_STATUS.ERROR) return [];
+    const reason = isRecord(record.error)
+      ? oneLine(text(record.error.message), TRANSCRIPT_BOUNDS.MAXIMUM_TOOL_LENGTH)
+      : undefined;
+    return [reason ? `Error: ${reason}` : "Error: The turn failed"];
+  }
+  if (record.role === CURSOR_RECORD_ROLE.USER) {
+    const words = messageText(record);
+    const typed = words
+      ? oneLine(developerWords(words), TRANSCRIPT_BOUNDS.MAXIMUM_MESSAGE_LENGTH)
+      : undefined;
+    return typed ? [`Developer: ${typed}`] : [];
+  }
+  if (record.role === CURSOR_RECORD_ROLE.ASSISTANT) {
+    const lines: string[] = [];
+    const words = oneLine(messageText(record), TRANSCRIPT_BOUNDS.MAXIMUM_MESSAGE_LENGTH);
+    if (words) lines.push(`${CURSOR_SPEAKER_NAME}: ${words}`);
+    for (const block of contentBlocks(record)) {
+      if (block.type !== CURSOR_CONTENT_TYPE.TOOL_USE) continue;
+      const line = toolLine(block);
+      if (line) lines.push(line);
+    }
+    return lines;
+  }
+  return [];
+}
+
+/**
+ * Finds the session's transcript file the way discovery does — the file named
+ * by the session's own id, inside that session's directory under one of the
+ * project directories — without trusting the id as a path: an id outside a
+ * plain file-name shape names nothing.
+ */
+async function transcriptFilePath(
+  cursorHome: string,
+  providerSessionId: string,
+): Promise<string | undefined> {
+  if (!CURSOR_SESSION_ID_SHAPE.test(providerSessionId)) return undefined;
+  const projectsDirectory = path.join(cursorHome, CURSOR_PROJECTS_DIRECTORY);
+  const fileName = `${providerSessionId}${CURSOR_TRANSCRIPT_FILE_EXTENSION}`;
+  for (const entry of await readDirectory(projectsDirectory)) {
+    const projectDirectory = await statDirectoryEntry(projectsDirectory, entry.name);
+    if (!projectDirectory?.stats.isDirectory()) continue;
+    const sessionDirectory = await statDirectoryEntry(
+      path.join(projectDirectory.directoryPath, CURSOR_TRANSCRIPTS_DIRECTORY),
+      providerSessionId,
+    );
+    if (!sessionDirectory?.stats.isDirectory()) continue;
+    const candidate = await statDirectoryEntry(sessionDirectory.directoryPath, fileName);
+    if (candidate?.stats.isFile()) return candidate.directoryPath;
+  }
+  return undefined;
+}
+
+/**
+ * Reads one session's recent transcript into a bounded rendering, or nothing
+ * when no transcript file exists for that id.
+ */
+export async function readCursorSessionTranscript(
+  request: CursorTranscriptRequest,
+): Promise<string | undefined> {
+  const filePath = await transcriptFilePath(
+    request.cursorHome ?? defaultCursorHome(),
+    request.providerSessionId,
+  );
+  if (!filePath) return undefined;
+
+  const tail = await readTail(filePath, request.readTailBytes ?? TRANSCRIPT_BOUNDS.READ_TAIL_BYTES);
+  const lines = tailRecords(tail).flatMap(linesFromRecord);
+  return boundedTranscript(
+    lines,
+    request.maximumRenderedLength ?? TRANSCRIPT_BOUNDS.MAXIMUM_RENDERED_LENGTH,
+  );
+}

--- a/apps/desktop/src/local-transcript.ts
+++ b/apps/desktop/src/local-transcript.ts
@@ -1,0 +1,45 @@
+/**
+ * The shared half of every on-demand transcript read: the bounds a rendering
+ * must fit and the cut that enforces them. Each provider maps its own records
+ * into the one line vocabulary — `Developer:` for the person, the agent's own
+ * name for its replies, `→` for a tool call, `←` for its answer, `Error:` for
+ * a failure the provider recorded — and this module keeps every rendering the
+ * same bounded size however the records differ.
+ */
+
+export const TRANSCRIPT_BOUNDS = {
+  /** How much of the file's end one read may load. */
+  READ_TAIL_BYTES: 256 * 1024,
+  /** A rendered message line: enough to carry meaning, not a document. */
+  MAXIMUM_MESSAGE_LENGTH: 400,
+  /** A rendered tool call or its result: the gist, never the payload. */
+  MAXIMUM_TOOL_LENGTH: 200,
+  /**
+   * The whole rendering. It enters a live conversation as one tool output,
+   * so it is sized for answering a question about the session, not for
+   * carrying the session.
+   */
+  MAXIMUM_RENDERED_LENGTH: 8_000,
+} as const;
+
+export const OMISSION_MARKER = "[earlier turns omitted]";
+
+/**
+ * Joins rendered lines into one bounded rendering, or nothing when there are
+ * no lines to render. The newest turns win the space: a question about a
+ * session is almost always about where it is now, so the rendering is cut
+ * from the front, at a line, and says so.
+ */
+export function boundedTranscript(
+  lines: readonly string[],
+  maximumLength: number,
+): string | undefined {
+  if (lines.length === 0) return undefined;
+  let rendered = lines.join("\n");
+  if (rendered.length > maximumLength) {
+    const kept = rendered.slice(rendered.length - maximumLength);
+    const firstWholeLine = kept.indexOf("\n");
+    rendered = `${OMISSION_MARKER}\n${firstWholeLine >= 0 ? kept.slice(firstWholeLine + 1) : kept}`;
+  }
+  return rendered;
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -28,10 +28,12 @@ import {
   PROVIDER_ACT_RESULT_STATUS,
   PROVIDER_ID,
   type ProviderControlResult,
+  type ProviderId,
   type ProviderMessageResult,
   type ProviderWorkspaceResult,
   realtimeMintExplanation,
   rosterRelevantSessions,
+  SESSION_LOCATION,
   SessionAttentionReviewer,
   type SessionIdentity,
   SessionNoticeTracker,
@@ -70,11 +72,20 @@ import {
   pruneClaudeHookSpool,
 } from "./claude-code-hooks";
 import { readClaudeSessionTranscript } from "./claude-code-transcript";
-import { CodexSessionAdapter } from "./codex-adapter";
+import { CodexSessionAdapter, defaultCodexHome } from "./codex-adapter";
+import {
+  CODEX_HOOK_SCRIPT_NAME,
+  CODEX_HOOK_SPOOL_MAXIMUM_AGE_MS,
+  type CodexHookInstallation,
+  installCodexObservationHooks,
+  pruneCodexHookSpool,
+} from "./codex-hooks";
+import { readCodexSessionTranscript } from "./codex-transcript";
 import { ConductorSessionAdapter } from "./conductor-adapter";
 import { CopilotSessionAdapter } from "./copilot-adapter";
 import { CURSOR_PROVIDER, CursorSessionAdapter } from "./cursor-adapter";
 import { CursorLocalSessionAdapter } from "./cursor-local-adapter";
+import { readCursorSessionTranscript } from "./cursor-transcript";
 import { DevinSessionAdapter } from "./devin-adapter";
 import { DockPresence } from "./dock-presence";
 import { feedbackDeliveryFromEnvironment } from "./feedback-delivery";
@@ -89,6 +100,7 @@ import {
   unavailableRealtimeDiagnostics,
 } from "./openai-realtime-credentials";
 import { OpenCodeSessionAdapter } from "./opencode-adapter";
+import { readOpenCodeSessionTranscript } from "./opencode-transcript";
 import { OutputVolumeWatcher } from "./output-volume";
 import { PanelManager } from "./panel-manager";
 import { runModeFor } from "./run-mode";
@@ -188,25 +200,36 @@ const adapterByCredentialProvider: ReadonlyMap<CredentialProviderId, SessionProv
     [CREDENTIAL_PROVIDER_ID.DEVIN, devinAdapter],
     [CREDENTIAL_PROVIDER_ID.JULES, julesAdapter],
   ]);
-// Luke's own corner of the application data, holding the observation hook
-// script and the spool it writes into. Resolved lazily like the settings
-// store's directory, and reproduced by `claudeHookInstallation()` whenever the
-// registration converges.
+// Luke's own corners of the application data, holding each provider's
+// observation hook script and the spool it writes into. Resolved lazily like
+// the settings store's directory, and reproduced by the installation
+// functions whenever the registrations converge.
 const CLAUDE_HOOKS_DIRECTORY_NAME = "claude-code-hooks";
-const CLAUDE_HOOK_SPOOL_DIRECTORY_NAME = "events";
+const CODEX_HOOKS_DIRECTORY_NAME = "codex-hooks";
+const HOOK_SPOOL_DIRECTORY_NAME = "events";
 function claudeHookInstallation(): ClaudeCodeHookInstallation {
   const directory = path.join(app.getPath("userData"), CLAUDE_HOOKS_DIRECTORY_NAME);
   return {
     claudeHome: defaultClaudeHome(),
     hookScriptPath: path.join(directory, CLAUDE_HOOK_SCRIPT_NAME),
-    spoolDirectory: path.join(directory, CLAUDE_HOOK_SPOOL_DIRECTORY_NAME),
+    spoolDirectory: path.join(directory, HOOK_SPOOL_DIRECTORY_NAME),
+  };
+}
+function codexHookInstallation(): CodexHookInstallation {
+  const directory = path.join(app.getPath("userData"), CODEX_HOOKS_DIRECTORY_NAME);
+  return {
+    codexHome: defaultCodexHome(),
+    hookScriptPath: path.join(directory, CODEX_HOOK_SCRIPT_NAME),
+    spoolDirectory: path.join(directory, HOOK_SPOOL_DIRECTORY_NAME),
   };
 }
 const sessionAdapters = [
   new ClaudeCodeSessionAdapter({
     hookEventsDirectory: () => claudeHookInstallation().spoolDirectory,
   }),
-  new CodexSessionAdapter(),
+  new CodexSessionAdapter({
+    hookEventsDirectory: () => codexHookInstallation().spoolDirectory,
+  }),
   conductorAdapter,
   copilotAdapter,
   cursorAdapter,
@@ -1010,36 +1033,70 @@ function registerIpc(): void {
   );
 
   // Reading a session's transcript is a conversational act that returns
-  // session content instead of performing anything: the file Claude Code
+  // session content instead of performing anything: the file its provider
   // wrote is read on this machine, rendered into a bounded conversation, and
   // discarded — nothing reaches a provider, and nothing is kept. The renderer
   // names a session rather than a path, validated here against the registry
   // like every session act, so the set of transcripts Luke can read is the
-  // set of sessions currently observed. Claude Code is the one provider this
-  // build reads a transcript for; the others answer honestly rather than
-  // guessing at files they never documented.
+  // set of sessions currently observed. The readers below are the providers
+  // whose local transcripts this build documents reading; everything else —
+  // above all a cloud session, whose conversation lives with its provider —
+  // answers honestly rather than guessing at files never documented.
+  const transcriptReaders: ReadonlyMap<
+    ProviderId,
+    (providerSessionId: string) => Promise<string | undefined>
+  > = new Map([
+    [
+      PROVIDER_ID.CLAUDE_CODE,
+      (providerSessionId: string) =>
+        readClaudeSessionTranscript({ claudeHome: defaultClaudeHome(), providerSessionId }),
+    ],
+    [
+      PROVIDER_ID.CODEX,
+      (providerSessionId: string) => readCodexSessionTranscript({ providerSessionId }),
+    ],
+    [
+      PROVIDER_ID.CURSOR,
+      (providerSessionId: string) => readCursorSessionTranscript({ providerSessionId }),
+    ],
+    [
+      PROVIDER_ID.OPENCODE,
+      (providerSessionId: string) => readOpenCodeSessionTranscript({ providerSessionId }),
+    ],
+  ]);
   ipcMain.handle(
     channels.readSessionTranscript,
     async (event, identity: unknown): Promise<SessionTranscriptResult> => {
       if (!trustedSender(event)) throw new Error("Untrusted renderer");
       if (!isSessionIdentity(identity)) throw new Error("Invalid transcript request");
-      if (!sessionRegistry.get(identity)) {
+      const session = sessionRegistry.get(identity);
+      if (!session) {
         return {
           status: SESSION_TRANSCRIPT_RESULT_STATUS.REJECTED,
           reason: "No observed session matches that identity.",
         };
       }
-      if (identity.providerId !== PROVIDER_ID.CLAUDE_CODE) {
+      // Checked here as well as in the reader's own lookup, because one
+      // provider observes both halves: a cloud Cursor agent shares its
+      // provider id with the sessions on this machine, and only the local
+      // half has a file here to read.
+      if (session.location !== SESSION_LOCATION.LOCAL) {
         return {
           status: SESSION_TRANSCRIPT_RESULT_STATUS.UNSUPPORTED,
-          reason: "Only Claude Code sessions keep a transcript this build can read.",
+          reason: "A cloud session's conversation lives with its provider, not on this machine.",
+        };
+      }
+      const readTranscript = isProviderId(identity.providerId)
+        ? transcriptReaders.get(identity.providerId)
+        : undefined;
+      if (!readTranscript) {
+        return {
+          status: SESSION_TRANSCRIPT_RESULT_STATUS.UNSUPPORTED,
+          reason: "That session's provider keeps no transcript this build can read.",
         };
       }
       try {
-        const transcript = await readClaudeSessionTranscript({
-          claudeHome: defaultClaudeHome(),
-          providerSessionId: identity.providerSessionId,
-        });
+        const transcript = await readTranscript(identity.providerSessionId);
         if (!transcript) {
           return {
             status: SESSION_TRANSCRIPT_RESULT_STATUS.REJECTED,
@@ -1517,23 +1574,43 @@ function observedWorkspaceProjects(): readonly ObservedWorkspaceProject[] {
 }
 
 /**
- * Converges the Claude Code hook registration: the script, the spool, and the
- * settings entries are put in place, and spool files past the observation
- * window are dropped. Run once at every launch — the registration is part of
- * observing at all, like reading the transcripts, rather than a preference —
- * and never in a fixture or capture run: a deterministic run must not touch
- * the developer's real provider configuration. Failure costs only the sharper
- * status: the transcript tail is observed either way.
+ * Converges the local providers' hook registrations: each provider's script,
+ * spool, and configuration entries are put in place, and spool files past the
+ * observation window are dropped. Run once at every launch — the registration
+ * is part of observing at all, like reading the transcripts, rather than a
+ * preference — and never in a fixture or capture run: a deterministic run
+ * must not touch the developer's real provider configuration. Failure costs
+ * only the sharper status: the transcripts and state databases are observed
+ * either way, and one provider's failure never reaches the other's — that is
+ * the same independence the observation passes keep.
  */
 async function applyLocalSessionHooks(): Promise<void> {
   if (fixtureMode) return;
-  const installation = claudeHookInstallation();
-  await installClaudeCodeObservationHooks(installation);
-  await pruneClaudeHookSpool(
-    installation.spoolDirectory,
-    CLAUDE_HOOK_SPOOL_MAXIMUM_AGE_MS,
-    Date.now(),
+  const registrations = [
+    async () => {
+      const installation = claudeHookInstallation();
+      await installClaudeCodeObservationHooks(installation);
+      await pruneClaudeHookSpool(
+        installation.spoolDirectory,
+        CLAUDE_HOOK_SPOOL_MAXIMUM_AGE_MS,
+        Date.now(),
+      );
+    },
+    async () => {
+      const installation = codexHookInstallation();
+      await installCodexObservationHooks(installation);
+      await pruneCodexHookSpool(
+        installation.spoolDirectory,
+        CODEX_HOOK_SPOOL_MAXIMUM_AGE_MS,
+        Date.now(),
+      );
+    },
+  ];
+  const outcomes = await Promise.allSettled(registrations.map((register) => register()));
+  const failure = outcomes.find(
+    (outcome): outcome is PromiseRejectedResult => outcome.status === "rejected",
   );
+  if (failure) throw failure.reason;
 }
 
 async function refreshProviderSessions(): Promise<void> {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -62,7 +62,7 @@ import {
   systemPreferences,
   Tray,
 } from "electron";
-import { ClaudeCodeSessionAdapter } from "./claude-code-adapter";
+import { CLAUDE_CODE_PROVIDER, ClaudeCodeSessionAdapter } from "./claude-code-adapter";
 import {
   CLAUDE_HOOK_SCRIPT_NAME,
   CLAUDE_HOOK_SPOOL_MAXIMUM_AGE_MS,
@@ -72,7 +72,7 @@ import {
   pruneClaudeHookSpool,
 } from "./claude-code-hooks";
 import { readClaudeSessionTranscript } from "./claude-code-transcript";
-import { CodexSessionAdapter, defaultCodexHome } from "./codex-adapter";
+import { CODEX_PROVIDER, CodexSessionAdapter, defaultCodexHome } from "./codex-adapter";
 import {
   CODEX_HOOK_SCRIPT_NAME,
   CODEX_HOOK_SPOOL_MAXIMUM_AGE_MS,
@@ -1587,30 +1587,44 @@ function observedWorkspaceProjects(): readonly ObservedWorkspaceProject[] {
 async function applyLocalSessionHooks(): Promise<void> {
   if (fixtureMode) return;
   const registrations = [
-    async () => {
-      const installation = claudeHookInstallation();
-      await installClaudeCodeObservationHooks(installation);
-      await pruneClaudeHookSpool(
-        installation.spoolDirectory,
-        CLAUDE_HOOK_SPOOL_MAXIMUM_AGE_MS,
-        Date.now(),
-      );
+    {
+      providerName: CLAUDE_CODE_PROVIDER.displayName,
+      register: async () => {
+        const installation = claudeHookInstallation();
+        await installClaudeCodeObservationHooks(installation);
+        await pruneClaudeHookSpool(
+          installation.spoolDirectory,
+          CLAUDE_HOOK_SPOOL_MAXIMUM_AGE_MS,
+          Date.now(),
+        );
+      },
     },
-    async () => {
-      const installation = codexHookInstallation();
-      await installCodexObservationHooks(installation);
-      await pruneCodexHookSpool(
-        installation.spoolDirectory,
-        CODEX_HOOK_SPOOL_MAXIMUM_AGE_MS,
-        Date.now(),
-      );
+    {
+      providerName: CODEX_PROVIDER.displayName,
+      register: async () => {
+        const installation = codexHookInstallation();
+        await installCodexObservationHooks(installation);
+        await pruneCodexHookSpool(
+          installation.spoolDirectory,
+          CODEX_HOOK_SPOOL_MAXIMUM_AGE_MS,
+          Date.now(),
+        );
+      },
     },
   ];
-  const outcomes = await Promise.allSettled(registrations.map((register) => register()));
-  const failure = outcomes.find(
-    (outcome): outcome is PromiseRejectedResult => outcome.status === "rejected",
+  // Failures are logged under the provider they belong to and absorbed here:
+  // one provider's broken configuration must neither reach the other's
+  // registration nor the launch, and either costs only the sharper status.
+  await Promise.all(
+    registrations.map(async ({ providerName, register }) => {
+      try {
+        await register();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        process.stderr.write(`${providerName} hook registration failed: ${message}\n`);
+      }
+    }),
   );
-  if (failure) throw failure.reason;
 }
 
 async function refreshProviderSessions(): Promise<void> {
@@ -1991,12 +2005,13 @@ if (!app.requestSingleInstanceLock()) {
       (enabled) => mediaDuck.setEnabled(enabled),
       () => mediaDuck.setEnabled(APP_SETTING_DEFAULTS.duckOtherMedia),
     );
-    // The hook registration converges at every launch. Failure here is logged
-    // and absorbed — a launch must never hang on another app's configuration
-    // file.
+    // The hook registrations converge at every launch. Each provider's
+    // failure is logged under its own name and absorbed inside — a launch
+    // must never hang on another app's configuration file — so this catch is
+    // only the backstop for the arrangement itself failing.
     void applyLocalSessionHooks().catch((error) => {
       const message = error instanceof Error ? error.message : String(error);
-      process.stderr.write(`Claude Code hook registration failed: ${message}
+      process.stderr.write(`Local session hook registration failed: ${message}
 `);
     });
     // Awaited, so the key and the voice it speaks with are both in hand before

--- a/apps/desktop/src/observation-hooks.ts
+++ b/apps/desktop/src/observation-hooks.ts
@@ -1,0 +1,515 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { isRecord } from "@sidecar/core";
+import { canIgnoreFilesystemError } from "./local-session-adapter";
+
+/**
+ * Hook-fed observation for the local providers that register hooks at all,
+ * strictly additive to the state their adapters already read. A provider runs
+ * a registered command at a session's turn boundaries; ours writes one fixed
+ * token into a spool Luke owns, and the adapter reads that token back to
+ * answer what the provider's own files alone cannot: a turn that just ended
+ * versus a session someone walked away from, a session that was closed.
+ * Everything here degrades to those files: no registration, no script, and no
+ * spool ever costs an observation — they only cost the sharper status.
+ *
+ * The registration is the one file of a provider's Luke writes, and it is
+ * bounded the way the trust constraints demand: entries are merged into the
+ * provider's own hook configuration beside whatever the user put there,
+ * recognized by the script's own name, stripped cleanly on removal, and never
+ * written at all when the existing file cannot be parsed — a file Luke cannot
+ * read back is a file Luke must not rewrite.
+ *
+ * One module, described per provider: everything a provider decides — its
+ * hook file, its event names, how it hands the script its envelope — lives in
+ * an {@link ObservationHookSpec}, and everything this module guarantees holds
+ * for every spec alike. Widening to another provider is a product decision;
+ * this module only keeps the widened set to one discipline.
+ */
+
+/** The spool file holds one fixed token, so anything longer is not ours. */
+const HOOK_EVENT_FILE_READ_BYTES = 256;
+
+const HOOK_EVENT_FILE_EXTENSION = ".json";
+
+/**
+ * How old a spool file may grow before pruning drops it. An event this far
+ * behind cannot out-date any state it would refine, and the session behind it
+ * has almost always closed for good; a day keeps the spool sized to the
+ * sessions actually moving rather than every session ever observed.
+ */
+export const HOOK_SPOOL_MAXIMUM_AGE_MS = 24 * 60 * 60 * 1000;
+
+/** One registered entry: the lifecycle event, and the token its hook writes. */
+export interface ObservationHookRegistration<Event extends string> {
+  event: Event;
+  /** The provider-defined matcher narrowing which occurrences fire at all. */
+  matcher?: string;
+}
+
+/**
+ * Everything one provider decides about its observation hooks. The guarantees
+ * — merge beside the user's entries, refuse an unparseable file, converge at
+ * every launch, no envelope text on disk — are the module's; the spec only
+ * names the provider's shapes.
+ */
+export interface ObservationHookSpec<Event extends string> {
+  /**
+   * The script's file name, which is also the marker a managed entry is
+   * recognized by — so renaming it is a migration: an entry naming the old
+   * script would stop being recognized as ours and would be left behind.
+   */
+  scriptName: string;
+  /** The provider's own hook-configuration file, inside its home directory. */
+  configurationFileName: string;
+  /** The first line of the script's comment header, naming the provider. */
+  scriptTitle: string;
+  /**
+   * Which lifecycle moments are registered, keyed by the provider's own event
+   * names, and the token each one hands the script.
+   */
+  registration: Readonly<Record<string, ObservationHookRegistration<Event>>>;
+  /**
+   * How long the provider lets the spool write run before giving up on it,
+   * for a provider whose entries take a timeout at all.
+   */
+  timeoutSeconds?: number;
+  /** The envelope field naming the session the event belongs to. */
+  sessionIdField: string;
+  /**
+   * The shape the provider's session ids take, as a POSIX ERE. The id becomes
+   * the spool file's name, so nothing outside this shape is accepted at all.
+   */
+  sessionIdPattern: string;
+  /**
+   * An envelope field whose presence marks a subagent's event, skipped whole
+   * — a subagent's turns start and stop while the main loop is mid-turn, so
+   * recording them would flap the row.
+   */
+  subagentField?: string;
+}
+
+/** Where one installed arrangement lives: the provider's home, and Luke's own. */
+export interface ObservationHookInstallation {
+  /** The provider's own home, holding the configuration entries merge into. */
+  providerHome: string;
+  /** Where Luke keeps the script, under Luke's own application data. */
+  hookScriptPath: string;
+  /** Where the script writes its event files, under Luke's own data too. */
+  spoolDirectory: string;
+}
+
+/** The latest thing a hook reported about one session, dated by the spool. */
+export interface ObservedHookEvent<Event extends string> {
+  event: Event;
+  atMs: number;
+}
+
+function eventTokens<Event extends string>(spec: ObservationHookSpec<Event>): Event[] {
+  return [...new Set(Object.values(spec.registration).map((entry) => entry.event))];
+}
+
+/**
+ * The script a provider runs. It writes one fixed token into the spool and
+ * nothing else: the envelope is read only to name the session, its text never
+ * reaches disk, and a token or session id it does not recognize ends it
+ * without a write. A missing spool ends it too — that is what turning
+ * observation hooks off means — so a stale registration is an instant no-op.
+ *
+ * The envelope arrives however the provider hands it over — piped on stdin,
+ * or passed as the argument after the token — so one script text serves every
+ * spec: a provider that passes nothing on stdin must not leave the script
+ * waiting on a pipe that never closes.
+ */
+function observationHookScript<Event extends string>(
+  spec: ObservationHookSpec<Event>,
+  spoolDirectory: string,
+): string {
+  const subagentSkip = spec.subagentField
+    ? `
+# A subagent's turns are not the session's: they start and stop while the
+# main loop is mid-turn, so recording them would flap the row. The envelope
+# names an agent only inside one, at the price that a prompt quoting the
+# field with a value is skipped too — the session's own files still carry
+# that turn.
+if printf '%s' "$ENVELOPE" \\
+  | grep -qE '"${spec.subagentField}"[[:space:]]*:[[:space:]]*"[^"]+"'; then
+  exit 0
+fi
+`
+    : "";
+  return `#!/bin/sh
+# ${spec.scriptTitle}
+#
+# The provider runs this at a session's turn boundaries. It writes one fixed
+# status token into Luke's own spool — never into any provider file — naming
+# the file by the session's own id. The envelope handed in is read only for
+# that id; its text never reaches disk. Luke installs and removes this file.
+
+SPOOL_DIRECTORY="${spoolDirectory}"
+
+# The token is fixed at registration, one per hook entry, so nothing handed in
+# can choose what is written.
+case "$1" in
+  ${eventTokens(spec).join("|")}) EVENT_TOKEN="$1" ;;
+  *) exit 0 ;;
+esac
+
+# No spool means observation hooks are off or Luke is gone; leave quietly.
+[ -d "$SPOOL_DIRECTORY" ] || exit 0
+
+# The envelope rides in as the argument after the token where the provider
+# passes one, and on stdin where it pipes instead.
+if [ "$#" -ge 2 ]; then ENVELOPE="$2"; else ENVELOPE=$(cat); fi
+${subagentSkip}
+# The id becomes the spool file's name, so only the shape the provider mints
+# is accepted at all.
+SESSION_ID=$(printf '%s' "$ENVELOPE" \\
+  | grep -oE '"${spec.sessionIdField}"[[:space:]]*:[[:space:]]*"${spec.sessionIdPattern}"' \\
+  | head -n 1 | grep -oE '${spec.sessionIdPattern}')
+[ -n "$SESSION_ID" ] || exit 0
+
+# One tiny file per session, replaced on every event: only the newest event
+# matters, and replacement is what bounds the spool. Writing beside the spool
+# file and moving over it keeps a concurrent reader off half a write.
+TEMPORARY_FILE="$SPOOL_DIRECTORY/.$SESSION_ID.$$.tmp"
+printf '{"event":"%s"}' "$EVENT_TOKEN" > "$TEMPORARY_FILE" || exit 0
+mv -f "$TEMPORARY_FILE" "$SPOOL_DIRECTORY/$SESSION_ID${HOOK_EVENT_FILE_EXTENSION}"
+`;
+}
+
+/**
+ * The command registered in the provider's configuration. Guarded on the
+ * script being present and executable, so an entry outliving an uninstalled
+ * Luke is an instant no-op rather than a "not found" in every session on the
+ * machine — and always exiting zero, so no provider can read a missing spool
+ * as a decision.
+ */
+function observationHookCommand<Event extends string>(
+  hookScriptPath: string,
+  event: Event,
+): string {
+  return `[ -x "${hookScriptPath}" ] && "${hookScriptPath}" ${event} || true`;
+}
+
+/**
+ * Whether a hook command is one of ours. The script's distinctive file name is
+ * the marker, so entries written by an older build — a different data path, a
+ * different guard — are still recognized and reconciled rather than left to
+ * pile up beside the current one.
+ */
+function isLukeHookCommand(command: unknown, scriptName: string): boolean {
+  return typeof command === "string" && command.includes(scriptName);
+}
+
+/**
+ * Strips Luke's inner hooks from one settings entry, returning the entry
+ * unchanged when it is entirely the user's, a copy when it mixed the user's
+ * hooks with ours, and nothing when nothing of the user's remains.
+ */
+function withoutLukeHooks(
+  entry: Record<string, unknown>,
+  scriptName: string,
+): Record<string, unknown> | undefined {
+  const hooks = entry.hooks;
+  if (!Array.isArray(hooks)) return entry;
+  const kept = hooks.filter(
+    (hook) => !(isRecord(hook) && isLukeHookCommand(hook.command, scriptName)),
+  );
+  if (kept.length === hooks.length) return entry;
+  if (kept.length === 0) return undefined;
+  return { ...entry, hooks: kept };
+}
+
+/**
+ * Strips Luke's entries from every event in place — including events this
+ * build no longer registers, so an entry from an older build is cleaned up by
+ * the newer one rather than left behind. Anything that is not the nested
+ * shape the provider documents is preserved verbatim: a malformed entry is
+ * the user's problem to notice, never ours to discard. Answers whether
+ * anything of Luke's was actually there, so removal can decline to rewrite a
+ * file it only ever read — a formatting difference must not read as a change.
+ */
+function stripLukeEntries(events: Record<string, unknown>, scriptName: string): boolean {
+  let stripped = false;
+  for (const [eventName, entries] of Object.entries(events)) {
+    if (!Array.isArray(entries)) continue;
+    let strippedHere = false;
+    const kept = entries.flatMap((entry) => {
+      if (!isRecord(entry)) return [entry];
+      const cleaned = withoutLukeHooks(entry, scriptName);
+      if (cleaned !== entry) strippedHere = true;
+      return cleaned === undefined ? [] : [cleaned];
+    });
+    if (!strippedHere) continue;
+    stripped = true;
+    if (kept.length === 0) delete events[eventName];
+    else events[eventName] = kept;
+  }
+  return stripped;
+}
+
+/**
+ * The configuration content with Luke's current entries in place: the user's
+ * own settings and hooks are preserved as parsed, stale Luke entries are
+ * stripped everywhere, and one entry per registered event is appended.
+ * Nothing is returned for a file that cannot be read as a JSON object — never
+ * rewrite a file that cannot be read back.
+ */
+export function configurationWithObservationHooks<Event extends string>(
+  spec: ObservationHookSpec<Event>,
+  source: string | undefined,
+  hookScriptPath: string,
+): string | undefined {
+  let root: Record<string, unknown> = {};
+  if (source !== undefined) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(source);
+    } catch {
+      return undefined;
+    }
+    if (!isRecord(parsed)) return undefined;
+    root = parsed;
+  }
+
+  const events = isRecord(root.hooks) ? root.hooks : {};
+  root.hooks = events;
+  stripLukeEntries(events, spec.scriptName);
+
+  for (const [eventName, registration] of Object.entries(spec.registration)) {
+    const existing = events[eventName];
+    const kept = Array.isArray(existing) ? existing : [];
+    events[eventName] = [
+      ...kept,
+      {
+        ...(registration.matcher !== undefined ? { matcher: registration.matcher } : {}),
+        hooks: [
+          {
+            type: "command",
+            command: observationHookCommand(hookScriptPath, registration.event),
+            ...(spec.timeoutSeconds !== undefined ? { timeout: spec.timeoutSeconds } : {}),
+          },
+        ],
+      },
+    ];
+  }
+
+  return `${JSON.stringify(root, undefined, 2)}\n`;
+}
+
+/**
+ * The configuration content with every Luke entry stripped, or nothing when
+ * there is nothing to change — including a file that cannot be parsed, which
+ * is left exactly as found for the same reason the merge leaves it.
+ */
+export function configurationWithoutObservationHooks<Event extends string>(
+  spec: ObservationHookSpec<Event>,
+  source: string,
+): string | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch {
+    return undefined;
+  }
+  if (!isRecord(parsed)) return undefined;
+
+  const events = parsed.hooks;
+  if (!isRecord(events)) return undefined;
+  // Only a file that actually held Luke's entries is written at all. Removal
+  // runs at every disabled launch, and a file that merely formats its JSON
+  // differently than this module would must be left byte-for-byte alone.
+  if (!stripLukeEntries(events, spec.scriptName)) return undefined;
+  if (Object.keys(events).length === 0) delete parsed.hooks;
+
+  return `${JSON.stringify(parsed, undefined, 2)}\n`;
+}
+
+async function readFileIfPresent(filePath: string): Promise<string | undefined> {
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch (error) {
+    if (canIgnoreFilesystemError(error)) return undefined;
+    throw error;
+  }
+}
+
+/**
+ * Replaces the configuration file through a sibling temporary file and a
+ * rename, because a write interrupted halfway would leave behind the one
+ * thing this module refuses to touch again: an unparseable configuration
+ * would break the user's own setup, not just the registration. The original
+ * file's mode is carried over — the file is the user's, and so is however
+ * they protected it.
+ *
+ * The rename lands on the file the path finally names, not the path itself: a
+ * dotfiles-managed configuration is often a symlink, and renaming over the
+ * link would quietly swap it for a plain copy while the synced original went
+ * stale. A path that does not resolve yet is a file being created, placed by
+ * its directory's own resolution for the same reason.
+ */
+async function replaceConfigurationFile(configurationPath: string, content: string): Promise<void> {
+  let targetPath: string;
+  try {
+    targetPath = await fs.realpath(configurationPath);
+  } catch (error) {
+    if (!canIgnoreFilesystemError(error)) throw error;
+    const directory = await fs
+      .realpath(path.dirname(configurationPath))
+      .catch(() => path.dirname(configurationPath));
+    targetPath = path.join(directory, path.basename(configurationPath));
+  }
+  let mode = 0o644;
+  try {
+    mode = (await fs.stat(targetPath)).mode & 0o777;
+  } catch (error) {
+    if (!canIgnoreFilesystemError(error)) throw error;
+  }
+  const temporaryPath = `${targetPath}.luke-tmp`;
+  await fs.writeFile(temporaryPath, content, { encoding: "utf8", mode });
+  // `mode` only applies when the file is created, so a temporary file left
+  // behind by an interrupted write keeps whatever mode it already had.
+  await fs.chmod(temporaryPath, mode);
+  await fs.rename(temporaryPath, targetPath);
+}
+
+async function writeFileIfChanged(filePath: string, content: string, mode: number): Promise<void> {
+  const existing = await readFileIfPresent(filePath);
+  if (existing === content) {
+    await fs.chmod(filePath, mode);
+    return;
+  }
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, { encoding: "utf8", mode });
+  // `mode` only applies when the file is created; an existing script must not
+  // keep whatever mode an older write left it.
+  await fs.chmod(filePath, mode);
+}
+
+/**
+ * Puts the whole arrangement in place: the script, the spool it writes into,
+ * and the registration naming the script. Run at every launch — like every
+ * other managed piece of Luke's own state, the installation is converged
+ * rather than performed once — and safe to run again at any time: an
+ * unchanged file is left untouched down to its mtime.
+ */
+export async function installObservationHooks<Event extends string>(
+  spec: ObservationHookSpec<Event>,
+  installation: ObservationHookInstallation,
+): Promise<void> {
+  // A machine with no provider home gets nothing at all: registering would
+  // create another product's directory on its behalf, for sessions that do
+  // not exist. Installation converges at every launch, so a provider that
+  // arrives later is picked up the next time Luke starts.
+  try {
+    await fs.stat(installation.providerHome);
+  } catch (error) {
+    if (canIgnoreFilesystemError(error)) return;
+    throw error;
+  }
+
+  await fs.mkdir(installation.spoolDirectory, { recursive: true });
+  await writeFileIfChanged(
+    installation.hookScriptPath,
+    observationHookScript(spec, installation.spoolDirectory),
+    0o755,
+  );
+
+  const configurationPath = path.join(installation.providerHome, spec.configurationFileName);
+  const source = await readFileIfPresent(configurationPath);
+  const merged = configurationWithObservationHooks(spec, source, installation.hookScriptPath);
+  if (merged === undefined || merged === source) return;
+  await replaceConfigurationFile(configurationPath, merged);
+}
+
+/**
+ * Takes the whole arrangement back out: the registration entries, the script,
+ * and the spool with whatever events it held. The configuration file is the
+ * one thing never created here — a teardown that leaves new files behind has
+ * the relationship backwards — and a file that cannot be parsed is left as
+ * found.
+ */
+export async function removeObservationHooks<Event extends string>(
+  spec: ObservationHookSpec<Event>,
+  installation: ObservationHookInstallation,
+): Promise<void> {
+  const configurationPath = path.join(installation.providerHome, spec.configurationFileName);
+  const source = await readFileIfPresent(configurationPath);
+  if (source !== undefined) {
+    const stripped = configurationWithoutObservationHooks(spec, source);
+    if (stripped !== undefined) await replaceConfigurationFile(configurationPath, stripped);
+  }
+  await fs.rm(installation.hookScriptPath, { force: true });
+  await fs.rm(installation.spoolDirectory, { recursive: true, force: true });
+}
+
+/**
+ * Reads what the hook last said about one session: the token, dated by the
+ * spool file's own mtime — the one clock the script and the reader share
+ * without writing timestamps at all. Only Luke's script writes here, so the
+ * mtime cannot suffer the bulk-touch problem a provider's own files do.
+ * Anything unexpected — no file, a foreign shape, an unknown token — reads as
+ * no event, because the state this refines is always there to fall back on.
+ */
+export async function readObservationHookEvent<Event extends string>(
+  spec: ObservationHookSpec<Event>,
+  spoolDirectory: string,
+  providerSessionId: string,
+): Promise<ObservedHookEvent<Event> | undefined> {
+  const filePath = path.join(spoolDirectory, `${providerSessionId}${HOOK_EVENT_FILE_EXTENSION}`);
+  let handle: fs.FileHandle;
+  try {
+    handle = await fs.open(filePath, "r");
+  } catch (error) {
+    if (canIgnoreFilesystemError(error)) return undefined;
+    throw error;
+  }
+  try {
+    const stats = await handle.stat();
+    if (stats.size > HOOK_EVENT_FILE_READ_BYTES) return undefined;
+    const content = await handle.readFile({ encoding: "utf8" });
+    let record: unknown;
+    try {
+      record = JSON.parse(content);
+    } catch {
+      return undefined;
+    }
+    if (!isRecord(record)) return undefined;
+    const tokens: readonly string[] = eventTokens(spec);
+    if (typeof record.event !== "string" || !tokens.includes(record.event)) return undefined;
+    return { event: record.event as Event, atMs: stats.mtimeMs };
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * Drops spool files old enough that the adapter would no longer read them:
+ * an event beyond the observation window refines nothing, and the sessions
+ * behind such files are mostly gone for good. Run where install is run, so
+ * the spool's size tracks the sessions actually alive rather than every
+ * session ever observed.
+ */
+export async function pruneObservationHookSpool(
+  spoolDirectory: string,
+  maximumAgeMs: number,
+  now: number,
+): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(spoolDirectory);
+  } catch (error) {
+    if (canIgnoreFilesystemError(error)) return;
+    throw error;
+  }
+  for (const entry of entries) {
+    const filePath = path.join(spoolDirectory, entry);
+    try {
+      const stats = await fs.stat(filePath);
+      if (now - stats.mtimeMs > maximumAgeMs) await fs.rm(filePath, { force: true });
+    } catch (error) {
+      if (!canIgnoreFilesystemError(error)) throw error;
+    }
+  }
+}

--- a/apps/desktop/src/opencode-adapter.ts
+++ b/apps/desktop/src/opencode-adapter.ts
@@ -123,7 +123,7 @@ const OPENCODE_PLACEHOLDER_TITLE_PREFIX = "New session - ";
  * deliberately not in it, because a signed URL is a credential and no other
  * adapter sends one anywhere; a fetch is named by its tool alone.
  */
-const OPENCODE_TOOL_INPUT_KEY = [
+export const OPENCODE_TOOL_INPUT_KEY = [
   "description",
   "command",
   "filePath",
@@ -408,10 +408,32 @@ async function legacySessionFilesIn(projectDirectory: string): Promise<SessionFi
   );
 }
 
-function defaultDataDirectory(): string {
+export function defaultOpenCodeDataDirectory(): string {
   const dataHome = process.env[OPENCODE_ENVIRONMENT.DATA_HOME]?.trim();
   if (dataHome) return path.join(dataHome, OPENCODE_DATA_DIRECTORY_NAME);
   return path.join(os.homedir(), ...OPENCODE_DATA_HOME_SEGMENTS, OPENCODE_DATA_DIRECTORY_NAME);
+}
+
+/**
+ * Where the database may be, most authoritative first: wherever `OPENCODE_DB`
+ * points, then the file every release channel writes, then the one
+ * prod-channel builds briefly wrote.
+ */
+export function openCodeDatabasePaths(dataDirectory: string): string[] {
+  const configured = process.env[OPENCODE_ENVIRONMENT.DATABASE_FILE]?.trim();
+  const configuredPath =
+    configured && configured !== OPENCODE_MEMORY_DATABASE
+      ? path.isAbsolute(configured)
+        ? configured
+        : path.join(dataDirectory, configured)
+      : undefined;
+  return uniquePaths(
+    [
+      configuredPath,
+      path.join(dataDirectory, OPENCODE_DATABASE_FILE.CURRENT),
+      path.join(dataDirectory, OPENCODE_DATABASE_FILE.PROD_CHANNEL),
+    ].filter((candidate): candidate is string => candidate !== undefined),
+  );
 }
 
 /**
@@ -444,7 +466,7 @@ export class OpenCodeSessionAdapter implements SessionProviderAdapter {
   >();
 
   constructor(options: OpenCodeAdapterOptions = {}) {
-    this.#dataDirectory = options.dataDirectory ?? defaultDataDirectory();
+    this.#dataDirectory = options.dataDirectory ?? defaultOpenCodeDataDirectory();
     this.#now = options.now ?? Date.now;
     const resolved = resolveOptions(
       options,
@@ -460,7 +482,7 @@ export class OpenCodeSessionAdapter implements SessionProviderAdapter {
   }
 
   async observe(): Promise<readonly ProviderSessionObservation[]> {
-    for (const databasePath of this.#databasePaths()) {
+    for (const databasePath of openCodeDatabasePaths(this.#dataDirectory)) {
       const database = await openReadOnlyDatabase(this.#sqlite, databasePath);
       if (!database) continue;
       let snapshots: OpenCodeSessionSnapshot[] | undefined;
@@ -479,28 +501,6 @@ export class OpenCodeSessionAdapter implements SessionProviderAdapter {
       );
     }
     return this.#legacyObservations();
-  }
-
-  /**
-   * Where the database may be, most authoritative first: wherever
-   * `OPENCODE_DB` points, then the file every release channel writes, then the
-   * one prod-channel builds briefly wrote.
-   */
-  #databasePaths(): string[] {
-    const configured = process.env[OPENCODE_ENVIRONMENT.DATABASE_FILE]?.trim();
-    const configuredPath =
-      configured && configured !== OPENCODE_MEMORY_DATABASE
-        ? path.isAbsolute(configured)
-          ? configured
-          : path.join(this.#dataDirectory, configured)
-        : undefined;
-    return uniquePaths(
-      [
-        configuredPath,
-        path.join(this.#dataDirectory, OPENCODE_DATABASE_FILE.CURRENT),
-        path.join(this.#dataDirectory, OPENCODE_DATABASE_FILE.PROD_CHANNEL),
-      ].filter((candidate): candidate is string => candidate !== undefined),
-    );
   }
 
   /** The session rows, or nothing when neither query fits this database. */

--- a/apps/desktop/src/opencode-transcript.ts
+++ b/apps/desktop/src/opencode-transcript.ts
@@ -1,0 +1,227 @@
+import { isRecord, oneLine, recordFromJsonLine, text } from "@sidecar/core";
+import {
+  canIgnoreSqliteError,
+  defaultSqliteModule,
+  openReadOnlyDatabase,
+  type SqliteDatabase,
+  type SqliteModuleLoader,
+} from "./local-sqlite";
+import { boundedTranscript, TRANSCRIPT_BOUNDS } from "./local-transcript";
+import {
+  defaultOpenCodeDataDirectory,
+  OPENCODE_TOOL_INPUT_KEY,
+  openCodeDatabasePaths,
+} from "./opencode-adapter";
+
+/**
+ * On-demand reading of one OpenCode session's transcript, for a question the
+ * developer just asked. The message and part rows in OpenCode's own database
+ * are the transcript — the same tables the adapter reads bookkeeping from,
+ * here opened for their words: a bounded slice of the newest messages, read
+ * through parameterized point queries against the read-only handle, rendered
+ * into a bounded conversation, and discarded. Nothing here is retained,
+ * watched, or written; a session is re-read the next time it is asked about.
+ *
+ * Installs from before OpenCode moved its sessions into the database keep
+ * their conversations in per-part JSON files this build does not read, so a
+ * legacy session answers as no transcript rather than a partial one.
+ */
+
+const OPENCODE_SPEAKER_NAME = "OpenCode";
+
+const OPENCODE_DATA_COLUMN = "data";
+
+const OPENCODE_MESSAGE_ROLE = {
+  USER: "user",
+  ASSISTANT: "assistant",
+} as const;
+
+const OPENCODE_PART_TYPE = {
+  TEXT: "text",
+  TOOL: "tool",
+} as const;
+
+/** The tool states whose bookkeeping carries an answer worth a line. */
+const OPENCODE_TOOL_STATUS = {
+  COMPLETED: "completed",
+  ERROR: "error",
+} as const;
+
+/**
+ * The error OpenCode records when its own user stops a turn. A stopped turn
+ * is something the developer did, not something that happened to them, so it
+ * takes no error line.
+ */
+const OPENCODE_ABORT_ERROR_NAME = "MessageAbortedError";
+
+const OPENCODE_TRANSCRIPT_BOUNDS = {
+  /** How many of the session's newest messages one read may load. */
+  MAXIMUM_MESSAGES: 40,
+  /** How many of a message's parts one read may load. */
+  MAXIMUM_PARTS: 32,
+} as const;
+
+/** Newest first, so the bound keeps the turns the question is about. */
+const OPENCODE_RECENT_MESSAGE_QUERY = `
+  SELECT *
+  FROM message
+  WHERE session_id = ?
+  ORDER BY time_created DESC, id DESC
+  LIMIT ?
+`;
+
+const OPENCODE_MESSAGE_PART_QUERY = `
+  SELECT *
+  FROM part
+  WHERE message_id = ?
+  ORDER BY id ASC
+  LIMIT ?
+`;
+
+type OpenCodeRow = Record<string, unknown>;
+
+export interface OpenCodeTranscriptRequest {
+  dataDirectory?: string;
+  providerSessionId: string;
+  sqlite?: SqliteModuleLoader;
+  maximumRenderedLength?: number;
+}
+
+function rowData(row: OpenCodeRow): Record<string, unknown> | undefined {
+  return recordFromJsonLine(text(row[OPENCODE_DATA_COLUMN]) ?? "");
+}
+
+function toolLine(part: Record<string, unknown>): string[] {
+  const name = text(part.tool);
+  if (!name) return [];
+  const state = isRecord(part.state) ? part.state : {};
+  const input = isRecord(state.input) ? state.input : {};
+  let call = `→ ${name}`;
+  for (const key of OPENCODE_TOOL_INPUT_KEY) {
+    const detail = oneLine(text(input[key]), TRANSCRIPT_BOUNDS.MAXIMUM_TOOL_LENGTH);
+    if (detail) {
+      call = `→ ${name}: ${detail}`;
+      break;
+    }
+  }
+  const answer =
+    state.status === OPENCODE_TOOL_STATUS.COMPLETED
+      ? oneLine(text(state.output), TRANSCRIPT_BOUNDS.MAXIMUM_TOOL_LENGTH)
+      : state.status === OPENCODE_TOOL_STATUS.ERROR
+        ? oneLine(text(state.error), TRANSCRIPT_BOUNDS.MAXIMUM_TOOL_LENGTH)
+        : undefined;
+  return answer ? [call, `← ${answer}`] : [call];
+}
+
+/**
+ * The failure that ended a message's turn early, in the provider's words. An
+ * abort is left out: the developer stopping a turn is not news to them.
+ */
+function errorLine(data: Record<string, unknown>): string | undefined {
+  const error = isRecord(data.error) ? data.error : undefined;
+  if (!error || error.name === OPENCODE_ABORT_ERROR_NAME) return undefined;
+  const errorData = isRecord(error.data) ? error.data : undefined;
+  const words = oneLine(
+    text(errorData?.message) ?? text(error.name),
+    TRANSCRIPT_BOUNDS.MAXIMUM_TOOL_LENGTH,
+  );
+  return words ? `Error: ${words}` : undefined;
+}
+
+/**
+ * Renders one message and its parts into the lines a conversation can carry.
+ * A text part's words are the message's own — the role rides the message row,
+ * not the part — and a synthetic or ignored text part is OpenCode's own
+ * scaffolding, not something anyone said.
+ */
+function linesFromMessage(data: Record<string, unknown>, parts: readonly OpenCodeRow[]): string[] {
+  const role = text(data.role);
+  if (role !== OPENCODE_MESSAGE_ROLE.USER && role !== OPENCODE_MESSAGE_ROLE.ASSISTANT) return [];
+  const speaker = role === OPENCODE_MESSAGE_ROLE.USER ? "Developer" : OPENCODE_SPEAKER_NAME;
+
+  const lines: string[] = [];
+  const spokenParts: string[] = [];
+  for (const row of parts) {
+    const part = rowData(row);
+    if (!part) continue;
+    if (part.type === OPENCODE_PART_TYPE.TEXT) {
+      if (part.synthetic === true || part.ignored === true) continue;
+      const words = text(part.text);
+      if (words) spokenParts.push(words);
+      continue;
+    }
+    if (part.type === OPENCODE_PART_TYPE.TOOL && role === OPENCODE_MESSAGE_ROLE.ASSISTANT) {
+      lines.push(...toolLine(part));
+    }
+  }
+  const said = oneLine(spokenParts.join(" "), TRANSCRIPT_BOUNDS.MAXIMUM_MESSAGE_LENGTH);
+  if (said) lines.unshift(`${speaker}: ${said}`);
+
+  const failure = errorLine(data);
+  if (failure) lines.push(failure);
+  return lines;
+}
+
+function readRows(
+  database: SqliteDatabase,
+  query: string,
+  parameters: readonly unknown[],
+): OpenCodeRow[] {
+  try {
+    return database
+      .prepare(query)
+      .all(...parameters)
+      .filter((row): row is OpenCodeRow => isRecord(row));
+  } catch (error) {
+    if (canIgnoreSqliteError(error)) return [];
+    throw error;
+  }
+}
+
+function renderedFromDatabase(
+  database: SqliteDatabase,
+  providerSessionId: string,
+  maximumLength: number,
+): string | undefined {
+  const messages = readRows(database, OPENCODE_RECENT_MESSAGE_QUERY, [
+    providerSessionId,
+    OPENCODE_TRANSCRIPT_BOUNDS.MAXIMUM_MESSAGES,
+  ]).toReversed();
+  const lines = messages.flatMap((message) => {
+    const data = rowData(message);
+    const messageId = text(message.id);
+    if (!data || !messageId) return [];
+    const parts = readRows(database, OPENCODE_MESSAGE_PART_QUERY, [
+      messageId,
+      OPENCODE_TRANSCRIPT_BOUNDS.MAXIMUM_PARTS,
+    ]);
+    return linesFromMessage(data, parts);
+  });
+  return boundedTranscript(lines, maximumLength);
+}
+
+/**
+ * Reads one session's recent transcript into a bounded rendering, or nothing
+ * when no database holds messages for that id.
+ */
+export async function readOpenCodeSessionTranscript(
+  request: OpenCodeTranscriptRequest,
+): Promise<string | undefined> {
+  const dataDirectory = request.dataDirectory ?? defaultOpenCodeDataDirectory();
+  const sqlite = request.sqlite ?? defaultSqliteModule;
+  for (const databasePath of openCodeDatabasePaths(dataDirectory)) {
+    const database = await openReadOnlyDatabase(sqlite, databasePath);
+    if (!database) continue;
+    try {
+      const rendered = renderedFromDatabase(
+        database,
+        request.providerSessionId,
+        request.maximumRenderedLength ?? TRANSCRIPT_BOUNDS.MAXIMUM_RENDERED_LENGTH,
+      );
+      if (rendered) return rendered;
+    } finally {
+      database.close();
+    }
+  }
+  return undefined;
+}

--- a/apps/desktop/src/opencode-transcript.ts
+++ b/apps/desktop/src/opencode-transcript.ts
@@ -70,11 +70,14 @@ const OPENCODE_RECENT_MESSAGE_QUERY = `
   LIMIT ?
 `;
 
+// Newest first here too: a tool-heavy turn can outgrow the bound, and the
+// concluding words sit on its newest parts. The rows are put back in the
+// order they were said before rendering.
 const OPENCODE_MESSAGE_PART_QUERY = `
   SELECT *
   FROM part
   WHERE message_id = ?
-  ORDER BY id ASC
+  ORDER BY id DESC
   LIMIT ?
 `;
 
@@ -194,7 +197,7 @@ function renderedFromDatabase(
     const parts = readRows(database, OPENCODE_MESSAGE_PART_QUERY, [
       messageId,
       OPENCODE_TRANSCRIPT_BOUNDS.MAXIMUM_PARTS,
-    ]);
+    ]).toReversed();
     return linesFromMessage(data, parts);
   });
   return boundedTranscript(lines, maximumLength);

--- a/apps/desktop/src/opencode-transcript.ts
+++ b/apps/desktop/src/opencode-transcript.ts
@@ -71,13 +71,15 @@ const OPENCODE_RECENT_MESSAGE_QUERY = `
 `;
 
 // Newest first here too: a tool-heavy turn can outgrow the bound, and the
-// concluding words sit on its newest parts. The rows are put back in the
+// concluding words sit on its newest parts. Ordered by the row's own clock
+// before its id, like every other query over these tables — ids sort in
+// creation order only until their timestamp half wraps — and put back in the
 // order they were said before rendering.
 const OPENCODE_MESSAGE_PART_QUERY = `
   SELECT *
   FROM part
   WHERE message_id = ?
-  ORDER BY id DESC
+  ORDER BY time_created DESC, id DESC
   LIMIT ?
 `;
 

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -549,7 +549,9 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       label: "Reading a session's transcript",
       detail:
         "Asked what a local session did, said, or is stuck on, Luke can read that session's own " +
-        "recent transcript — Claude Code sessions today — on this machine, and answer from it. " +
+        "recent transcript — Claude Code, Codex, OpenCode, and the Cursor agents running on " +
+        "this machine today — and answer from it. Cursor keeps tool outputs out of its own " +
+        "transcripts, so those readings carry the words and the calls but no results. " +
         "The reading happens when asked and is kept nowhere; cloud sessions keep their " +
         "conversations with their provider, so Luke answers about those from their roster " +
         "fields alone.",

--- a/apps/desktop/tests/codex-adapter.test.ts
+++ b/apps/desktop/tests/codex-adapter.test.ts
@@ -849,3 +849,32 @@ test("a spool that cannot be read costs only the refinement", async (t) => {
 
   assert.equal(observation?.status, SESSION_STATUS.WORKING);
 });
+
+test("a permission hold that outlives the freshness window never reads as work", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const spool = await temporaryHookSpool(t);
+  const rolloutPath = path.join(codexHome, "rollout-long-hold.jsonl");
+  // Codex deliberately holds a long open turn at working, so without this
+  // rule a hold past the window would flip from waiting back to active work.
+  await writeCodexState(codexHome, [
+    {
+      id: "codex-long-hold",
+      cwd: "/Users/test/luke",
+      observedAt: TEST_TIME - 30 * 60 * 1000,
+      rolloutPath,
+    },
+  ]);
+  await writeRollout(rolloutPath, [{ type: "event_msg", payload: { type: "task_started" } }]);
+  await writeHookEvent(spool, "codex-long-hold", "notification", TEST_TIME - 20 * 60 * 1000);
+
+  const adapter = new CodexSessionAdapter({
+    activeSessionFreshnessMs: 15 * 60 * 1000,
+    codexHome,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60 * 60 * 1000,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.UNKNOWN);
+});

--- a/apps/desktop/tests/codex-adapter.test.ts
+++ b/apps/desktop/tests/codex-adapter.test.ts
@@ -653,3 +653,199 @@ test("returns an empty snapshot when node sqlite is unavailable", async (t) => {
 
   assert.deepEqual(await adapter.observe(), []);
 });
+
+// ---------------------------------------------------------------------------
+// Hook-event refinement. Every test here layers a spool the observation hook
+// would have written over the state database, because that is the arrangement
+// in production: the rows and rollouts are always read, and the event only
+// sharpens them.
+// ---------------------------------------------------------------------------
+
+async function temporaryHookSpool(t: TestContext): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-codex-spool-"));
+  t.after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  return directory;
+}
+
+async function writeHookEvent(
+  spoolDirectory: string,
+  providerSessionId: string,
+  event: string,
+  mtimeMs: number,
+): Promise<void> {
+  const filePath = path.join(spoolDirectory, `${providerSessionId}.json`);
+  await fs.writeFile(filePath, JSON.stringify({ event }));
+  await fs.utimes(filePath, mtimeMs / 1000, mtimeMs / 1000);
+}
+
+test("a permission request the database cannot show turns the row to waiting", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const spool = await temporaryHookSpool(t);
+  // Mid-turn by every record: a call holding for approval writes nothing
+  // further, so without the event this thread reads as working.
+  const rolloutPath = path.join(codexHome, "rollout-held.jsonl");
+  await writeCodexState(codexHome, [
+    {
+      id: "codex-held",
+      cwd: "/Users/test/luke",
+      observedAt: TEST_TIME - 5 * 60 * 1000,
+      rolloutPath,
+    },
+  ]);
+  await writeRollout(rolloutPath, [{ type: "event_msg", payload: { type: "task_started" } }]);
+  await writeHookEvent(spool, "codex-held", "notification", TEST_TIME - 60_000);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WAITING);
+  // The event also dates the session: the spool is written only by Luke's own
+  // script, so its clock is the moment the session actually moved.
+  assert.equal(observation?.observedAt, TEST_TIME - 60_000);
+});
+
+test("a session-end event settles a row the rollout would leave waiting", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const spool = await temporaryHookSpool(t);
+  const rolloutPath = path.join(codexHome, "rollout-ended.jsonl");
+  await writeCodexState(codexHome, [
+    {
+      id: "codex-ended",
+      cwd: "/Users/test/luke",
+      observedAt: TEST_TIME - 5 * 60 * 1000,
+      rolloutPath,
+    },
+  ]);
+  await writeRollout(rolloutPath, [
+    { type: "event_msg", payload: { type: "task_complete", last_agent_message: "Done." } },
+  ]);
+  await writeHookEvent(spool, "codex-ended", "session-end", TEST_TIME - 60_000);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.COMPLETE);
+});
+
+test("a stop event keeps a finished turn waiting past the freshness decay", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const spool = await temporaryHookSpool(t);
+  const rolloutPath = path.join(codexHome, "rollout-still-waiting.jsonl");
+  // Twenty minutes past the row's clock, the database alone decays to unknown.
+  await writeCodexState(codexHome, [
+    {
+      id: "codex-still-waiting",
+      cwd: "/Users/test/luke",
+      observedAt: TEST_TIME - 20 * 60 * 1000,
+      rolloutPath,
+    },
+  ]);
+  await writeRollout(rolloutPath, [
+    { type: "event_msg", payload: { type: "task_complete", last_agent_message: "Done." } },
+  ]);
+  await writeHookEvent(spool, "codex-still-waiting", "stop", TEST_TIME - 60_000);
+
+  const adapter = new CodexSessionAdapter({
+    activeSessionFreshnessMs: 15 * 60 * 1000,
+    codexHome,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60 * 60 * 1000,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WAITING);
+});
+
+test("an event the thread has moved past refines nothing", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const spool = await temporaryHookSpool(t);
+  const rolloutPath = path.join(codexHome, "rollout-moved-on.jsonl");
+  await writeCodexState(codexHome, [
+    { id: "codex-moved-on", cwd: "/Users/test/luke", observedAt: TEST_TIME - 60_000, rolloutPath },
+  ]);
+  await writeRollout(rolloutPath, [{ type: "event_msg", payload: { type: "task_started" } }]);
+  // A stop from a minute before the row's clock: hooks were off, or the write
+  // raced. The thread is demonstrably mid-turn again.
+  await writeHookEvent(spool, "codex-moved-on", "stop", TEST_TIME - 2 * 60 * 1000);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WORKING);
+  assert.equal(observation?.observedAt, TEST_TIME - 60_000);
+});
+
+test("a prompt event reads a fresh turn as working before the rollout shows it", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const spool = await temporaryHookSpool(t);
+  const rolloutPath = path.join(codexHome, "rollout-prompted.jsonl");
+  await writeCodexState(codexHome, [
+    { id: "codex-prompted", cwd: "/Users/test/luke", observedAt: TEST_TIME - 60_000, rolloutPath },
+  ]);
+  await writeRollout(rolloutPath, [
+    { type: "event_msg", payload: { type: "task_complete", last_agent_message: "Earlier." } },
+  ]);
+  await writeHookEvent(spool, "codex-prompted", "prompt", TEST_TIME - 5_000);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WORKING);
+});
+
+test("a notification the thread has answered stands down at once", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const spool = await temporaryHookSpool(t);
+  const rolloutPath = path.join(codexHome, "rollout-approved.jsonl");
+  // The approval was granted and the call ran: a row touched after the
+  // notification, though within the tolerance the other events enjoy.
+  await writeCodexState(codexHome, [
+    { id: "codex-approved", cwd: "/Users/test/luke", observedAt: TEST_TIME - 1_000, rolloutPath },
+  ]);
+  await writeRollout(rolloutPath, [{ type: "event_msg", payload: { type: "task_started" } }]);
+  await writeHookEvent(spool, "codex-approved", "notification", TEST_TIME - 3_000);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WORKING);
+});
+
+test("a spool that cannot be read costs only the refinement", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeCodexState(codexHome, [
+    { id: "codex-unrefined", cwd: "/Users/test/luke", observedAt: TEST_TIME - 1_000 },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    hookEventsDirectory: () => path.join(codexHome, "no-such-spool"),
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WORKING);
+});

--- a/apps/desktop/tests/codex-hooks.test.ts
+++ b/apps/desktop/tests/codex-hooks.test.ts
@@ -1,0 +1,347 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test, { type TestContext } from "node:test";
+import { promisify } from "node:util";
+import {
+  CODEX_HOOK_EVENT,
+  CODEX_HOOK_SCRIPT_NAME,
+  type CodexHookInstallation,
+  installCodexObservationHooks,
+  readCodexHookEvent,
+  removeCodexObservationHooks,
+} from "../src/codex-hooks";
+
+const execFileAsync = promisify(execFile);
+
+const TEST_TIME = Date.parse("2026-08-16T20:15:00.000Z");
+const TEST_SESSION_ID = "0198c1f2-4d5e-7789-abcd-ef0123456789";
+const SECRET_ENVELOPE_TEXT = "SECRET_ENVELOPE_TEXT";
+const CODEX_HOOKS_FILE_NAME = "hooks.json";
+
+/** Every lifecycle event the build registers, as hooks.json names them. */
+const REGISTERED_EVENT_NAMES = [
+  "SessionStart",
+  "UserPromptSubmit",
+  "Stop",
+  "PermissionRequest",
+  "SessionEnd",
+] as const;
+
+async function temporaryInstallation(t: TestContext): Promise<CodexHookInstallation> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-codex-hooks-"));
+  t.after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  const codexHome = path.join(directory, "codex-home");
+  await fs.mkdir(codexHome, { recursive: true });
+  return {
+    codexHome,
+    hookScriptPath: path.join(directory, "luke-data", CODEX_HOOK_SCRIPT_NAME),
+    spoolDirectory: path.join(directory, "luke-data", "events"),
+  };
+}
+
+function hooksPath(installation: CodexHookInstallation): string {
+  return path.join(installation.codexHome, CODEX_HOOKS_FILE_NAME);
+}
+
+async function readHooksFile(
+  installation: CodexHookInstallation,
+): Promise<Record<string, unknown>> {
+  return JSON.parse(await fs.readFile(hooksPath(installation), "utf8"));
+}
+
+function hookEntries(configuration: Record<string, unknown>, eventName: string): unknown[] {
+  const events = configuration.hooks as Record<string, unknown>;
+  const entries = events[eventName];
+  return Array.isArray(entries) ? entries : [];
+}
+
+function entryCommands(entries: unknown[]): string[] {
+  return entries.flatMap((entry) => {
+    const hooks = (entry as { hooks?: { command?: unknown }[] }).hooks;
+    if (!Array.isArray(hooks)) return [];
+    return hooks
+      .map((hook) => hook.command)
+      .filter((command): command is string => typeof command === "string");
+  });
+}
+
+/**
+ * Runs the installed script the way Codex would: the event as its one
+ * argument, the envelope as JSON on stdin. `execFile` cannot feed stdin, so
+ * the envelope rides in from a file beside the script through `sh -c`.
+ */
+async function pipeToHookScript(
+  installation: CodexHookInstallation,
+  eventArgument: string,
+  envelope: string,
+): Promise<void> {
+  const envelopeFile = path.join(path.dirname(installation.hookScriptPath), "envelope.json");
+  await fs.writeFile(envelopeFile, envelope, "utf8");
+  await execFileAsync("sh", [
+    "-c",
+    `"${installation.hookScriptPath}" "${eventArgument}" < "${envelopeFile}"`,
+  ]);
+  await fs.rm(envelopeFile, { force: true });
+}
+
+/**
+ * Runs the installed script the other way an agent can hand an envelope over:
+ * as the argument after the token, with nothing on stdin at all. The script
+ * must not sit waiting on a pipe no one is writing.
+ */
+async function callHookScript(
+  installation: CodexHookInstallation,
+  eventArgument: string,
+  envelope: string,
+): Promise<void> {
+  await execFileAsync("sh", [
+    "-c",
+    `"${installation.hookScriptPath}" "$1" "$2" < /dev/null`,
+    "sh",
+    eventArgument,
+    envelope,
+  ]);
+}
+
+test("registers every lifecycle event beside the user's own hooks", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.writeFile(
+    hooksPath(installation),
+    JSON.stringify({
+      hooks: {
+        Stop: [{ hooks: [{ type: "command", command: "afplay /System/done.aiff" }] }],
+      },
+    }),
+  );
+
+  await installCodexObservationHooks(installation);
+
+  const configuration = await readHooksFile(installation);
+  // The user's own hook survives the merge untouched.
+  const stopCommands = entryCommands(hookEntries(configuration, "Stop"));
+  assert.ok(stopCommands.includes("afplay /System/done.aiff"));
+  for (const eventName of REGISTERED_EVENT_NAMES) {
+    const commands = entryCommands(hookEntries(configuration, eventName)).filter((command) =>
+      command.includes(CODEX_HOOK_SCRIPT_NAME),
+    );
+    assert.equal(commands.length, 1, `${eventName} carries exactly one Luke entry`);
+    // Guarded on the script's own presence and always exiting zero, so an
+    // entry outliving an uninstalled Luke is a no-op — and a PermissionRequest
+    // hook can never read as a decision.
+    assert.ok(commands[0]?.startsWith(`[ -x "${installation.hookScriptPath}" ]`));
+    assert.ok(commands[0]?.endsWith("|| true"));
+  }
+
+  const script = await fs.readFile(installation.hookScriptPath, "utf8");
+  assert.ok(script.includes(installation.spoolDirectory));
+  const mode = (await fs.stat(installation.hookScriptPath)).mode & 0o777;
+  assert.equal(mode, 0o755);
+});
+
+test("touches nothing on a machine with no Codex home at all", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.rm(installation.codexHome, { recursive: true, force: true });
+
+  await installCodexObservationHooks(installation);
+
+  await assert.rejects(fs.stat(installation.codexHome));
+  await assert.rejects(fs.stat(installation.hookScriptPath));
+  await assert.rejects(fs.stat(installation.spoolDirectory));
+});
+
+test("leaves a hooks file it cannot parse exactly as it was", async (t) => {
+  const installation = await temporaryInstallation(t);
+  const corrupt = "{ this is not json";
+  await fs.writeFile(hooksPath(installation), corrupt);
+
+  await installCodexObservationHooks(installation);
+
+  assert.equal(await fs.readFile(hooksPath(installation), "utf8"), corrupt);
+});
+
+test("converges rather than accumulates: reinstalling changes nothing", async (t) => {
+  const installation = await temporaryInstallation(t);
+
+  await installCodexObservationHooks(installation);
+  const first = await fs.readFile(hooksPath(installation), "utf8");
+  await installCodexObservationHooks(installation);
+
+  assert.equal(await fs.readFile(hooksPath(installation), "utf8"), first);
+});
+
+test("appends its entries after the user's, so their trust anchors hold still", async (t) => {
+  const installation = await temporaryInstallation(t);
+  // Codex trusts a hook by its position in the file as well as its content,
+  // so a merge that slid a user's entry down a slot would silently stop it.
+  await fs.writeFile(
+    hooksPath(installation),
+    JSON.stringify({
+      hooks: {
+        Stop: [{ hooks: [{ type: "command", command: "afplay /System/done.aiff" }] }],
+      },
+    }),
+  );
+
+  await installCodexObservationHooks(installation);
+  await installCodexObservationHooks(installation);
+
+  const stopCommands = entryCommands(hookEntries(await readHooksFile(installation), "Stop"));
+  assert.equal(stopCommands[0], "afplay /System/done.aiff");
+  assert.equal(stopCommands.length, 2);
+});
+
+test("removal strips Luke's entries and leaves the user's hooks standing", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.writeFile(
+    hooksPath(installation),
+    JSON.stringify({
+      hooks: {
+        Stop: [{ hooks: [{ type: "command", command: "afplay /System/done.aiff" }] }],
+      },
+    }),
+  );
+  await installCodexObservationHooks(installation);
+
+  await removeCodexObservationHooks(installation);
+
+  const configuration = await readHooksFile(installation);
+  assert.deepEqual(entryCommands(hookEntries(configuration, "Stop")), ["afplay /System/done.aiff"]);
+  for (const eventName of REGISTERED_EVENT_NAMES) {
+    const lukeCommands = entryCommands(hookEntries(configuration, eventName)).filter((command) =>
+      command.includes(CODEX_HOOK_SCRIPT_NAME),
+    );
+    assert.equal(lukeCommands.length, 0, `${eventName} carries no Luke entry after removal`);
+  }
+  await assert.rejects(fs.stat(installation.hookScriptPath));
+  await assert.rejects(fs.stat(installation.spoolDirectory));
+});
+
+test("the script writes one fixed token from a piped envelope", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await installCodexObservationHooks(installation);
+  const envelope = JSON.stringify({
+    hook_event_name: "Stop",
+    session_id: TEST_SESSION_ID,
+    transcript_path: `/somewhere/rollout-${TEST_SESSION_ID}.jsonl`,
+    last_assistant_message: SECRET_ENVELOPE_TEXT,
+  });
+
+  await pipeToHookScript(installation, CODEX_HOOK_EVENT.STOP, envelope);
+
+  const spooled = await fs.readFile(
+    path.join(installation.spoolDirectory, `${TEST_SESSION_ID}.json`),
+    "utf8",
+  );
+  // The whole file is the fixed token: the envelope's text never reaches disk.
+  assert.equal(spooled, '{"event":"stop"}');
+  for (const entry of await fs.readdir(installation.spoolDirectory)) {
+    const content = await fs.readFile(path.join(installation.spoolDirectory, entry), "utf8");
+    assert.ok(!content.includes(SECRET_ENVELOPE_TEXT));
+  }
+});
+
+test("the script accepts an envelope passed as its argument too", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await installCodexObservationHooks(installation);
+  const envelope = JSON.stringify({ session_id: TEST_SESSION_ID, prompt: SECRET_ENVELOPE_TEXT });
+
+  await callHookScript(installation, CODEX_HOOK_EVENT.PROMPT, envelope);
+
+  const spooled = await fs.readFile(
+    path.join(installation.spoolDirectory, `${TEST_SESSION_ID}.json`),
+    "utf8",
+  );
+  assert.equal(spooled, '{"event":"prompt"}');
+  for (const entry of await fs.readdir(installation.spoolDirectory)) {
+    const content = await fs.readFile(path.join(installation.spoolDirectory, entry), "utf8");
+    assert.ok(!content.includes(SECRET_ENVELOPE_TEXT));
+  }
+});
+
+test("the script refuses a token the build never registered", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await installCodexObservationHooks(installation);
+
+  // Claude Code's spool speaks this token; Codex's build must not.
+  await pipeToHookScript(
+    installation,
+    "stop-failure",
+    JSON.stringify({ session_id: TEST_SESSION_ID }),
+  );
+
+  assert.deepEqual(await fs.readdir(installation.spoolDirectory), []);
+});
+
+test("the script skips a subagent's events", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await installCodexObservationHooks(installation);
+
+  await pipeToHookScript(
+    installation,
+    CODEX_HOOK_EVENT.STOP,
+    JSON.stringify({ session_id: TEST_SESSION_ID, agent_id: "subagent-1" }),
+  );
+
+  assert.deepEqual(await fs.readdir(installation.spoolDirectory), []);
+});
+
+test("an empty agent_id does not read as a subagent", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await installCodexObservationHooks(installation);
+
+  // A provider that serializes the field on every envelope, empty outside a
+  // subagent, must not silence the hook whole.
+  await pipeToHookScript(
+    installation,
+    CODEX_HOOK_EVENT.STOP,
+    JSON.stringify({ session_id: TEST_SESSION_ID, agent_id: null }),
+  );
+
+  const spooled = await fs.readFile(
+    path.join(installation.spoolDirectory, `${TEST_SESSION_ID}.json`),
+    "utf8",
+  );
+  assert.equal(spooled, '{"event":"stop"}');
+});
+
+test("the script refuses a session id outside the shape Codex mints", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await installCodexObservationHooks(installation);
+
+  await pipeToHookScript(
+    installation,
+    CODEX_HOOK_EVENT.STOP,
+    JSON.stringify({ session_id: "../../../etc/passwd" }),
+  );
+
+  assert.deepEqual(await fs.readdir(installation.spoolDirectory), []);
+});
+
+test("reads the spooled event back with the file's own clock", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.mkdir(installation.spoolDirectory, { recursive: true });
+  const filePath = path.join(installation.spoolDirectory, `${TEST_SESSION_ID}.json`);
+  await fs.writeFile(filePath, '{"event":"notification"}');
+  await fs.utimes(filePath, TEST_TIME / 1000, TEST_TIME / 1000);
+
+  const event = await readCodexHookEvent(installation.spoolDirectory, TEST_SESSION_ID);
+
+  assert.equal(event?.event, CODEX_HOOK_EVENT.NOTIFICATION);
+  assert.equal(event?.atMs, TEST_TIME);
+});
+
+test("reads nothing from a token outside Codex's own vocabulary", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.mkdir(installation.spoolDirectory, { recursive: true });
+  await fs.writeFile(
+    path.join(installation.spoolDirectory, `${TEST_SESSION_ID}.json`),
+    '{"event":"stop-failure"}',
+  );
+
+  assert.equal(await readCodexHookEvent(installation.spoolDirectory, TEST_SESSION_ID), undefined);
+});

--- a/apps/desktop/tests/codex-transcript.test.ts
+++ b/apps/desktop/tests/codex-transcript.test.ts
@@ -1,0 +1,296 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import test, { type TestContext } from "node:test";
+import { readCodexSessionTranscript } from "../src/codex-transcript";
+
+const TEST_SESSION_ID = "0198c1f2-4d5e-7789-abcd-ef0123456789";
+const CODEX_STATE_DATABASE = "state_5.sqlite";
+
+async function temporaryCodexHome(t: TestContext): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-codex-transcript-"));
+  t.after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  return directory;
+}
+
+async function writeThreadRow(
+  codexHome: string,
+  threadId: string,
+  rolloutPath: string,
+): Promise<void> {
+  const database = new DatabaseSync(path.join(codexHome, CODEX_STATE_DATABASE), {});
+  try {
+    database.exec(`
+      CREATE TABLE IF NOT EXISTS threads (
+        id TEXT PRIMARY KEY,
+        rollout_path TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        cwd TEXT NOT NULL,
+        archived INTEGER NOT NULL DEFAULT 0
+      )
+    `);
+    database
+      .prepare(
+        "INSERT INTO threads (id, rollout_path, created_at, updated_at, cwd) VALUES (?, ?, 1, 1, ?)",
+      )
+      .run(threadId, rolloutPath, "/Users/test/luke");
+  } finally {
+    database.close();
+  }
+}
+
+async function writeRollout(
+  filePath: string,
+  records: readonly Record<string, unknown>[],
+): Promise<void> {
+  await fs.writeFile(filePath, `${records.map((record) => JSON.stringify(record)).join("\n")}\n`);
+}
+
+async function writeSession(
+  codexHome: string,
+  records: readonly Record<string, unknown>[],
+): Promise<void> {
+  const rolloutPath = path.join(codexHome, `rollout-${TEST_SESSION_ID}.jsonl`);
+  await writeThreadRow(codexHome, TEST_SESSION_ID, rolloutPath);
+  await writeRollout(rolloutPath, records);
+}
+
+test("renders a session's turns as a bounded conversation", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeSession(codexHome, [
+    {
+      timestamp: "2026-08-16T20:00:00.000Z",
+      type: "response_item",
+      payload: {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "Fix the flaky test" }],
+      },
+    },
+    {
+      timestamp: "2026-08-16T20:00:01.000Z",
+      type: "response_item",
+      payload: {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "Looking at the failure now." }],
+      },
+    },
+    {
+      timestamp: "2026-08-16T20:00:02.000Z",
+      type: "response_item",
+      payload: {
+        type: "function_call",
+        name: "exec_command",
+        arguments: '{"cmd":"pnpm test"}',
+        call_id: "call-1",
+      },
+    },
+    {
+      timestamp: "2026-08-16T20:00:03.000Z",
+      type: "response_item",
+      payload: { type: "function_call_output", call_id: "call-1", output: "1 failing: retries" },
+    },
+    {
+      timestamp: "2026-08-16T20:00:04.000Z",
+      type: "response_item",
+      payload: {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "Fixed and green." }],
+      },
+    },
+  ]);
+
+  const rendered = await readCodexSessionTranscript({
+    codexHome,
+    providerSessionId: TEST_SESSION_ID,
+  });
+
+  assert.equal(
+    rendered,
+    [
+      "Developer: Fix the flaky test",
+      "Codex: Looking at the failure now.",
+      "→ exec_command: pnpm test",
+      "← 1 failing: retries",
+      "Codex: Fixed and green.",
+    ].join("\n"),
+  );
+});
+
+test("skips Codex's scaffolding and keeps the developer's own words", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeSession(codexHome, [
+    {
+      type: "response_item",
+      payload: {
+        type: "message",
+        role: "user",
+        content: [
+          {
+            type: "input_text",
+            text: "<user_instructions>\nAlways be brief.\n</user_instructions>",
+          },
+        ],
+      },
+    },
+    {
+      type: "response_item",
+      payload: {
+        type: "message",
+        role: "user",
+        content: [
+          { type: "input_text", text: "<environment_context>cwd=/x</environment_context>" },
+        ],
+      },
+    },
+    {
+      type: "response_item",
+      payload: {
+        type: "message",
+        role: "user",
+        content: [
+          {
+            type: "input_text",
+            text: "<environment_context>cwd=/x</environment_context>\n\n## My request for Codex:\nShip the release",
+          },
+        ],
+      },
+    },
+  ]);
+
+  const rendered = await readCodexSessionTranscript({
+    codexHome,
+    providerSessionId: TEST_SESSION_ID,
+  });
+
+  assert.equal(rendered, "Developer: Ship the release");
+});
+
+test("reads a shell call's answer out of the wrapped output shape", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeSession(codexHome, [
+    {
+      type: "response_item",
+      payload: {
+        type: "function_call_output",
+        call_id: "call-1",
+        output: '{"output":"2 passed, 0 failed","metadata":{"exit_code":0,"duration_seconds":0.2}}',
+      },
+    },
+    {
+      type: "response_item",
+      payload: {
+        type: "function_call_output",
+        call_id: "call-2",
+        output: [{ type: "input_text", text: "listed 3 files" }],
+      },
+    },
+  ]);
+
+  const rendered = await readCodexSessionTranscript({
+    codexHome,
+    providerSessionId: TEST_SESSION_ID,
+  });
+
+  assert.equal(rendered, ["← 2 passed, 0 failed", "← listed 3 files"].join("\n"));
+});
+
+test("names a shell call and a search by what they ran", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeSession(codexHome, [
+    {
+      type: "response_item",
+      payload: {
+        type: "local_shell_call",
+        status: "completed",
+        action: { type: "exec", command: ["pnpm", "test"] },
+      },
+    },
+    {
+      type: "response_item",
+      payload: { type: "web_search_call", action: { type: "search", query: "electron notch" } },
+    },
+  ]);
+
+  const rendered = await readCodexSessionTranscript({
+    codexHome,
+    providerSessionId: TEST_SESSION_ID,
+  });
+
+  assert.equal(rendered, ["→ shell: pnpm test", "→ web_search: electron notch"].join("\n"));
+});
+
+test("reports the failure that ended a turn, from either event shape", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeSession(codexHome, [
+    { type: "event_msg", payload: { type: "error", message: "stream disconnected" } },
+    {
+      type: "event_msg",
+      payload: {
+        type: "task_complete",
+        last_agent_message: null,
+        error: { message: "rate limited" },
+      },
+    },
+    // The boundary events that carry no failure say nothing a message
+    // does not already say.
+    { type: "event_msg", payload: { type: "task_started" } },
+    { type: "event_msg", payload: { type: "agent_message", message: "duplicate words" } },
+  ]);
+
+  const rendered = await readCodexSessionTranscript({
+    codexHome,
+    providerSessionId: TEST_SESSION_ID,
+  });
+
+  assert.equal(rendered, ["Error: stream disconnected", "Error: rate limited"].join("\n"));
+});
+
+test("reads nothing for a thread the state database does not name", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeSession(codexHome, [
+    {
+      type: "response_item",
+      payload: { type: "message", role: "user", content: [{ type: "input_text", text: "hello" }] },
+    },
+  ]);
+
+  const rendered = await readCodexSessionTranscript({
+    codexHome,
+    providerSessionId: "0000aaaa-1111-7222-3333-444455556666",
+  });
+
+  assert.equal(rendered, undefined);
+});
+
+test("leaves a compressed rollout unread rather than half-read", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const rolloutPath = path.join(codexHome, `rollout-${TEST_SESSION_ID}.jsonl.zst`);
+  await writeThreadRow(codexHome, TEST_SESSION_ID, rolloutPath);
+  await fs.writeFile(rolloutPath, "not actually zstd");
+
+  const rendered = await readCodexSessionTranscript({
+    codexHome,
+    providerSessionId: TEST_SESSION_ID,
+  });
+
+  assert.equal(rendered, undefined);
+});
+
+test("reads nothing when Codex has no state database at all", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+
+  const rendered = await readCodexSessionTranscript({
+    codexHome,
+    providerSessionId: TEST_SESSION_ID,
+  });
+
+  assert.equal(rendered, undefined);
+});

--- a/apps/desktop/tests/cursor-transcript.test.ts
+++ b/apps/desktop/tests/cursor-transcript.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test, { type TestContext } from "node:test";
+import { readCursorSessionTranscript } from "../src/cursor-transcript";
+
+const TEST_SESSION_ID = "8b21b0b2-98c1-4f52-a1c1-0f9a53b2f001";
+const TEST_PROJECT_DIRECTORY = "Users-test-luke";
+
+async function temporaryCursorHome(t: TestContext): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-cursor-transcript-"));
+  t.after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  return directory;
+}
+
+async function writeTranscript(
+  cursorHome: string,
+  sessionId: string,
+  records: readonly Record<string, unknown>[],
+): Promise<void> {
+  const sessionDirectory = path.join(
+    cursorHome,
+    "projects",
+    TEST_PROJECT_DIRECTORY,
+    "agent-transcripts",
+    sessionId,
+  );
+  await fs.mkdir(sessionDirectory, { recursive: true });
+  await fs.writeFile(
+    path.join(sessionDirectory, `${sessionId}.jsonl`),
+    `${records.map((record) => JSON.stringify(record)).join("\n")}\n`,
+  );
+}
+
+test("renders a session's turns without inventing the results Cursor never stores", async (t) => {
+  const cursorHome = await temporaryCursorHome(t);
+  await writeTranscript(cursorHome, TEST_SESSION_ID, [
+    {
+      role: "user",
+      message: { content: [{ type: "text", text: "<user_query>Fix the flaky test</user_query>" }] },
+    },
+    {
+      role: "assistant",
+      message: {
+        content: [
+          { type: "thinking", thinking: "internal words that are not a reply" },
+          { type: "text", text: "Looking at the failure now." },
+          { type: "tool_use", id: "tu_1", name: "Edit", input: { file_path: "main.go" } },
+        ],
+      },
+    },
+    { role: "assistant", message: { content: "Fixed and green." } },
+    { type: "turn_ended", status: "completed" },
+  ]);
+
+  const rendered = await readCursorSessionTranscript({
+    cursorHome,
+    providerSessionId: TEST_SESSION_ID,
+  });
+
+  assert.equal(
+    rendered,
+    [
+      "Developer: Fix the flaky test",
+      "Cursor: Looking at the failure now.",
+      "→ Edit: main.go",
+      "Cursor: Fixed and green.",
+    ].join("\n"),
+  );
+  assert.ok(!rendered?.includes("internal words"), "thinking never renders");
+});
+
+test("keeps the developer's words and drops the scaffolding around them", async (t) => {
+  const cursorHome = await temporaryCursorHome(t);
+  await writeTranscript(cursorHome, TEST_SESSION_ID, [
+    {
+      role: "user",
+      message: {
+        content: [
+          {
+            type: "text",
+            text:
+              "<timestamp>2026-08-16</timestamp><attached_files>secret.ts</attached_files>" +
+              "<user_query>Ship the release</user_query>",
+          },
+        ],
+      },
+    },
+    // A record that is scaffolding alone was never something the developer said.
+    {
+      role: "user",
+      message: {
+        content: [{ type: "text", text: "<system_reminder>be careful</system_reminder>" }],
+      },
+    },
+    // A bare string prompt has no wrapper to strip.
+    { role: "user", message: { content: "And update the changelog" } },
+  ]);
+
+  const rendered = await readCursorSessionTranscript({
+    cursorHome,
+    providerSessionId: TEST_SESSION_ID,
+  });
+
+  assert.equal(
+    rendered,
+    ["Developer: Ship the release", "Developer: And update the changelog"].join("\n"),
+  );
+});
+
+test("reports how a failed turn failed, in Cursor's own words", async (t) => {
+  const cursorHome = await temporaryCursorHome(t);
+  await writeTranscript(cursorHome, TEST_SESSION_ID, [
+    { role: "assistant", message: { content: [{ type: "text", text: "Trying the build." }] } },
+    { type: "turn_ended", status: "error", error: { message: "model stream disconnected" } },
+    { type: "turn_ended", status: "error" },
+  ]);
+
+  const rendered = await readCursorSessionTranscript({
+    cursorHome,
+    providerSessionId: TEST_SESSION_ID,
+  });
+
+  assert.equal(
+    rendered,
+    [
+      "Cursor: Trying the build.",
+      "Error: model stream disconnected",
+      "Error: The turn failed",
+    ].join("\n"),
+  );
+});
+
+test("reads nothing for a session that has no transcript file", async (t) => {
+  const cursorHome = await temporaryCursorHome(t);
+  await writeTranscript(cursorHome, TEST_SESSION_ID, [
+    { role: "user", message: { content: "hello" } },
+  ]);
+
+  const rendered = await readCursorSessionTranscript({
+    cursorHome,
+    providerSessionId: "0000aaaa-1111-2222-3333-444455556666",
+  });
+
+  assert.equal(rendered, undefined);
+});
+
+test("refuses an id that could climb out of Cursor's directories", async (t) => {
+  const cursorHome = await temporaryCursorHome(t);
+
+  const rendered = await readCursorSessionTranscript({
+    cursorHome,
+    providerSessionId: "../../../etc/passwd",
+  });
+
+  assert.equal(rendered, undefined);
+});

--- a/apps/desktop/tests/opencode-transcript.test.ts
+++ b/apps/desktop/tests/opencode-transcript.test.ts
@@ -287,3 +287,50 @@ test("reads nothing when OpenCode has no database at all", async (t) => {
 
   assert.equal(rendered, undefined);
 });
+
+test("a turn that outgrows the part bound keeps its newest parts", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  // Forty tool calls and then the concluding words: the bound must cut the
+  // oldest calls, never the answer the turn actually ended on.
+  const toolParts = Array.from({ length: 40 }, (_, index) => ({
+    id: `prt_${String(index).padStart(3, "0")}`,
+    messageId: "msg_01",
+    time: index,
+    data: {
+      type: "tool",
+      callID: `call-${index}`,
+      tool: "bash",
+      state: {
+        status: "completed",
+        input: { command: `step ${index}` },
+        output: `output ${index}`,
+        title: `step ${index}`,
+        metadata: {},
+        time: { start: index, end: index },
+      },
+    },
+  }));
+  await writeOpenCodeState(
+    dataDirectory,
+    [{ id: "msg_01", time: 1, data: { role: "assistant", time: { created: 1, completed: 50 } } }],
+    [
+      ...toolParts,
+      {
+        id: "prt_999",
+        messageId: "msg_01",
+        time: 50,
+        data: { type: "text", text: "All forty steps passed." },
+      },
+    ],
+  );
+
+  const rendered = await readOpenCodeSessionTranscript({
+    dataDirectory,
+    providerSessionId: TEST_SESSION_ID,
+  });
+
+  assert.ok(rendered?.includes("OpenCode: All forty steps passed."));
+  const lines = rendered?.split("\n") ?? [];
+  assert.ok(lines.includes("→ bash: step 39"), "the newest call survives the cut");
+  assert.ok(!lines.includes("→ bash: step 0"), "the oldest call is what goes");
+});

--- a/apps/desktop/tests/opencode-transcript.test.ts
+++ b/apps/desktop/tests/opencode-transcript.test.ts
@@ -293,7 +293,7 @@ test("a turn that outgrows the part bound keeps its newest parts", async (t) => 
   // Forty tool calls and then the concluding words: the bound must cut the
   // oldest calls, never the answer the turn actually ended on.
   const toolParts = Array.from({ length: 40 }, (_, index) => ({
-    id: `prt_${String(index).padStart(3, "0")}`,
+    id: `prt_${String(index + 100)}`,
     messageId: "msg_01",
     time: index,
     data: {
@@ -316,7 +316,10 @@ test("a turn that outgrows the part bound keeps its newest parts", async (t) => 
     [
       ...toolParts,
       {
-        id: "prt_999",
+        // An id that sorts before every call's: OpenCode ids only sort in
+        // creation order until their timestamp half wraps, so the row's own
+        // clock — the newest here — is what has to decide the cut.
+        id: "prt_000",
         messageId: "msg_01",
         time: 50,
         data: { type: "text", text: "All forty steps passed." },

--- a/apps/desktop/tests/opencode-transcript.test.ts
+++ b/apps/desktop/tests/opencode-transcript.test.ts
@@ -1,0 +1,289 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import test, { type TestContext } from "node:test";
+import { readOpenCodeSessionTranscript } from "../src/opencode-transcript";
+
+const TEST_SESSION_ID = "ses_8f2f6a01aa";
+const OPENCODE_DATABASE = "opencode.db";
+
+interface TestMessage {
+  id: string;
+  time: number;
+  data: Record<string, unknown>;
+}
+
+interface TestPart {
+  id: string;
+  messageId: string;
+  time: number;
+  data: Record<string, unknown>;
+}
+
+async function temporaryDataDirectory(t: TestContext): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-opencode-transcript-"));
+  t.after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  return directory;
+}
+
+async function writeOpenCodeState(
+  dataDirectory: string,
+  messages: readonly TestMessage[],
+  parts: readonly TestPart[],
+): Promise<void> {
+  await fs.mkdir(dataDirectory, { recursive: true });
+  const database = new DatabaseSync(path.join(dataDirectory, OPENCODE_DATABASE), {});
+  try {
+    database.exec(`
+      CREATE TABLE message (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        time_created INTEGER NOT NULL,
+        time_updated INTEGER NOT NULL,
+        data TEXT NOT NULL
+      );
+      CREATE TABLE part (
+        id TEXT PRIMARY KEY,
+        message_id TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        time_created INTEGER NOT NULL,
+        time_updated INTEGER NOT NULL,
+        data TEXT NOT NULL
+      );
+    `);
+    for (const message of messages) {
+      database
+        .prepare(
+          "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+        )
+        .run(message.id, TEST_SESSION_ID, message.time, message.time, JSON.stringify(message.data));
+    }
+    for (const part of parts) {
+      database
+        .prepare(
+          "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .run(
+          part.id,
+          part.messageId,
+          TEST_SESSION_ID,
+          part.time,
+          part.time,
+          JSON.stringify(part.data),
+        );
+    }
+  } finally {
+    database.close();
+  }
+}
+
+test("renders a session's turns as a bounded conversation", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  await writeOpenCodeState(
+    dataDirectory,
+    [
+      { id: "msg_01", time: 1, data: { role: "user", time: { created: 1 } } },
+      { id: "msg_02", time: 2, data: { role: "assistant", time: { created: 2, completed: 5 } } },
+    ],
+    [
+      {
+        id: "prt_01",
+        messageId: "msg_01",
+        time: 1,
+        data: { type: "text", text: "Fix the flaky test" },
+      },
+      {
+        id: "prt_02",
+        messageId: "msg_02",
+        time: 2,
+        data: { type: "text", text: "Looking at the failure now." },
+      },
+      {
+        id: "prt_03",
+        messageId: "msg_02",
+        time: 3,
+        data: {
+          type: "tool",
+          callID: "call-1",
+          tool: "bash",
+          state: {
+            status: "completed",
+            input: { command: "pnpm test" },
+            output: "1 failing: retries",
+            title: "pnpm test",
+            metadata: {},
+            time: { start: 3, end: 4 },
+          },
+        },
+      },
+      // A reasoning part is the model's own scratchpad, never a reply.
+      { id: "prt_04", messageId: "msg_02", time: 4, data: { type: "reasoning", text: "hmm" } },
+    ],
+  );
+
+  const rendered = await readOpenCodeSessionTranscript({
+    dataDirectory,
+    providerSessionId: TEST_SESSION_ID,
+  });
+
+  assert.equal(
+    rendered,
+    [
+      "Developer: Fix the flaky test",
+      "OpenCode: Looking at the failure now.",
+      "→ bash: pnpm test",
+      "← 1 failing: retries",
+    ].join("\n"),
+  );
+  assert.ok(!rendered?.includes("hmm"));
+});
+
+test("keeps synthetic text and injected scaffolding out of the developer's mouth", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  await writeOpenCodeState(
+    dataDirectory,
+    [{ id: "msg_01", time: 1, data: { role: "user", time: { created: 1 } } }],
+    [
+      {
+        id: "prt_01",
+        messageId: "msg_01",
+        time: 1,
+        data: { type: "text", text: "injected context", synthetic: true },
+      },
+      {
+        id: "prt_02",
+        messageId: "msg_01",
+        time: 2,
+        data: { type: "text", text: "ignored words", ignored: true },
+      },
+      {
+        id: "prt_03",
+        messageId: "msg_01",
+        time: 3,
+        data: { type: "text", text: "Ship the release" },
+      },
+    ],
+  );
+
+  const rendered = await readOpenCodeSessionTranscript({
+    dataDirectory,
+    providerSessionId: TEST_SESSION_ID,
+  });
+
+  assert.equal(rendered, "Developer: Ship the release");
+});
+
+test("reports a turn's failure but never the stop the developer asked for", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  await writeOpenCodeState(
+    dataDirectory,
+    [
+      {
+        id: "msg_01",
+        time: 1,
+        data: {
+          role: "assistant",
+          time: { created: 1 },
+          error: { name: "APIError", data: { message: "rate limited" } },
+        },
+      },
+      {
+        id: "msg_02",
+        time: 2,
+        data: {
+          role: "assistant",
+          time: { created: 2 },
+          error: { name: "MessageAbortedError", data: { message: "aborted" } },
+        },
+      },
+    ],
+    [
+      {
+        id: "prt_01",
+        messageId: "msg_01",
+        time: 1,
+        data: { type: "text", text: "Trying the build." },
+      },
+      {
+        id: "prt_02",
+        messageId: "msg_02",
+        time: 2,
+        data: { type: "text", text: "Starting over." },
+      },
+    ],
+  );
+
+  const rendered = await readOpenCodeSessionTranscript({
+    dataDirectory,
+    providerSessionId: TEST_SESSION_ID,
+  });
+
+  assert.equal(
+    rendered,
+    ["OpenCode: Trying the build.", "Error: rate limited", "OpenCode: Starting over."].join("\n"),
+  );
+});
+
+test("renders a failed tool call's own error as its answer", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  await writeOpenCodeState(
+    dataDirectory,
+    [{ id: "msg_01", time: 1, data: { role: "assistant", time: { created: 1 } } }],
+    [
+      {
+        id: "prt_01",
+        messageId: "msg_01",
+        time: 1,
+        data: {
+          type: "tool",
+          callID: "call-1",
+          tool: "bash",
+          state: {
+            status: "error",
+            input: { command: "pnpm test" },
+            error: "command timed out",
+            time: { start: 1, end: 2 },
+          },
+        },
+      },
+    ],
+  );
+
+  const rendered = await readOpenCodeSessionTranscript({
+    dataDirectory,
+    providerSessionId: TEST_SESSION_ID,
+  });
+
+  assert.equal(rendered, ["→ bash: pnpm test", "← command timed out"].join("\n"));
+});
+
+test("reads nothing for a session the database does not hold", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  await writeOpenCodeState(
+    dataDirectory,
+    [{ id: "msg_01", time: 1, data: { role: "user", time: { created: 1 } } }],
+    [{ id: "prt_01", messageId: "msg_01", time: 1, data: { type: "text", text: "hello" } }],
+  );
+
+  const rendered = await readOpenCodeSessionTranscript({
+    dataDirectory,
+    providerSessionId: "ses_nowhere",
+  });
+
+  assert.equal(rendered, undefined);
+});
+
+test("reads nothing when OpenCode has no database at all", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+
+  const rendered = await readOpenCodeSessionTranscript({
+    dataDirectory,
+    providerSessionId: TEST_SESSION_ID,
+  });
+
+  assert.equal(rendered, undefined);
+});


### PR DESCRIPTION
## Summary

- Generalizes the Claude Code observation-hook machinery (PR #119) into a shared `observation-hooks.ts` module driven by a per-provider spec, preserving every stated guarantee: entries merge beside the user's own and are recognized by the script's name, an unparseable file is never rewritten, installation converges at every launch, removal strips cleanly and never creates files, the settings write lands through symlinks preserving mode, and the envelope a provider hands the script never reaches disk. `claude-code-hooks.ts` becomes the Claude spec plus thin wrappers with an unchanged public API; all 21 pre-existing hook tests pass unmodified.
- Adds Codex observation hooks (`codex-hooks.ts`): a second spec merging into `~/.codex/hooks.json` (same nested shape as Claude's, verified against `openai/codex` source). Registered edges: `SessionStart`, `UserPromptSubmit`, `Stop`, `PermissionRequest` (Codex's name for a tool call holding for approval — the notification analog), and `SessionEnd`. Codex delivers native hook payloads as JSON on **stdin** (the argv delivery belongs to its legacy `notify` mechanism); the shared script now accepts both, and the subagent skip was sharpened to require a non-empty `agent_id` value so a provider serializing the field as `null` cannot silence the hook. The registered command is guarded and always exits zero, so a `PermissionRequest` hook can never read as a decision. Codex reviews foreign hooks at its own startup and runs nothing until the user trusts them — Luke leaves that consent gate alone (entries append after the user's so their trust anchors keep their positions), and observation degrades to the state database exactly as before while untrusted.
- The Codex adapter refines row status with the spool token the way the Claude adapter refines the transcript tail: stop → waiting, notification → waiting with zero staleness tolerance, prompt → working, session-end → complete, session-start → clock bump only; stale events are ignored and an archived thread is never unsaid.
- Widens on-ask transcript reading from Claude Code to every local provider whose stored shape renders faithfully, through the same roster-validated IPC path and conversation tool:
  - **Codex** (`codex-transcript.ts`): renders rollout `response_item` records (messages, function/custom/shell/web-search calls, call outputs in both the years-long string-wrapped-JSON shape and the newer content-block list) plus the error events; `event_msg` message duplicates are skipped so nothing renders twice, and `<user_instructions>`/`<environment_context>`-style scaffolding is stripped down to the developer's own words (`## My request for Codex:` marker honored). The rollout path comes from a parameterized lookup in the state database, never composed from the id; a `.jsonl.zst`-compressed rollout answers as no transcript rather than a half-read one.
  - **Cursor local** (`cursor-transcript.ts`): renders the Claude-Code-compatible JSONL Cursor writes under `agent-transcripts/` — `user_query` extraction with injected context tags dropped, assistant text, `tool_use` calls, and `turn_ended` failures in Cursor's own words. Cursor deliberately stores no tool outputs, so the rendering carries no `←` lines and the docs say so.
  - **OpenCode** (`opencode-transcript.ts`): renders message/part rows from the same read-only SQLite handle the adapter opens — roles from message data, text parts (synthetic/ignored skipped), tool calls with their completed output or error, and non-abort turn failures. Pre-v1.2.0 legacy JSON installs answer as no transcript rather than a partial one.
- The IPC gate now validates location as well as identity: a cloud session (including Cursor's cloud agents, which share the `cursor` provider id with local ones) answers that its conversation lives with its provider.
- Docs move with the behavior: AGENTS.md trust constraints (hook registration names both files; the transcript-read set names all four providers and the no-tool-outputs bound), PRIVACY.md (per-provider hook paragraph including Codex's trust review; the on-ask carve-out now covers the OpenCode/Cursor "observation never opens message content" promises explicitly), README.md, and the guide fact in `luke-guide.ts` so Luke describes what he can actually do.

Cursor hooks and OpenCode hooks are deliberately not added: Cursor's CLI agents expose no user-level hook config equivalent to Claude/Codex, and OpenCode uses plugins, which the trust constraints treat differently. Cloud providers stay out of scope; their honest refusals stand.

Verified against primary sources: Codex hook schema, event names, payload delivery, trust gate, and rollout record shapes from the `openai/codex` Rust source (hooks/config/rollout crates, tags v0.44.0 → main); Codex hook failure modes cross-checked against superset's HOOKS_INVESTIGATION.md; OpenCode message/part schemas from `sst/opencode` at v1.2.0; Cursor transcript shapes from Cursor's CLI changelog ("Claude Code-compatible JSONL"), Cursor staff forum statements (tool outputs intentionally not persisted), and three independent open-source parsers of the format.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passes (repository checks, types, lint, all workspace tests, builds)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — this change was authored in a cloud (Linux) workspace where the macOS packaging pipeline cannot run; no UI or motion surface changed. CI's macOS job attaches the visual evidence below.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31994267498/artifacts/9276331352) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31994267498)

- Commit: `bf3759c2fa090273d37221e350bf99e26b1c7c43`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` (no visual change)
- Physical-notch check: `not performed` (no UI change)
- Device/display configuration: `not recorded`

## Notes

- Codex's hook trust review means the sharper Codex status arrives only after the user trusts the merged entry in Codex's own UI; until then (and wherever hooks are absent) observation is unchanged.
- OpenCode legacy (pre-v1.2.0) installs and compressed (`.zst`) Codex rollouts answer "transcript could not be found" — deliberate honest bounds, stated in the module comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/89b1a082-45ff-439b-8fb1-842782782814)
