### PR TITLE
fix(voice): let announcements through — retry refused calls, stop the evaluator's 429 storm

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1660,7 +1660,14 @@ async function reviewSessionAttention(): Promise<void> {
   if (!attentionReviewer || attentionReviewRunning) return;
   attentionReviewRunning = true;
   try {
-    const reviews = await attentionReviewer.review(sessionRegistry.list());
+    // Only sessions still worth a row are worth a model call: an attention
+    // decision about a session with no row surfaces nowhere, and the registry
+    // holds every conversation ever observed — reviewing all of it sent an
+    // update about each one to OpenAI on every launch, hundreds of requests
+    // that rate-limited the same key the voice opens calls with.
+    const reviews = await attentionReviewer.review(
+      rosterRelevantSessions(sessionRegistry.list(), Date.now()),
+    );
     for (const review of reviews) {
       sessionRegistry.setAttention(review, review.decision);
     }

--- a/apps/desktop/src/openai-attention-evaluator.ts
+++ b/apps/desktop/src/openai-attention-evaluator.ts
@@ -36,6 +36,19 @@ const OPENAI_DEFAULTS = {
 const OPENAI_RESPONSES_PATH = "/responses";
 const OPENAI_TEXT_FORMAT_TYPE = "json_schema";
 const OPENAI_OUTPUT_TEXT_TYPE = "output_text";
+const OPENAI_RATE_LIMIT_STATUS = 429;
+const OPENAI_RETRY_AFTER_HEADER = "retry-after";
+
+/**
+ * How long attention requests stay quiet after the API rate-limits one, when
+ * the refusal names no wait of its own. Reviews run four to a pass and a pass
+ * every few seconds, so without this one 429 becomes a sustained storm: every
+ * failed review stays derivable and is re-sent at full rate, which starves
+ * the same key the voice opens calls with — the announcement that cannot get
+ * through is the visible half of that. An update held back here is not lost;
+ * it stays derivable and is reviewed once the quiet ends.
+ */
+export const ATTENTION_RATE_LIMIT_COOLDOWN_MS = 60_000;
 
 type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
 
@@ -118,6 +131,8 @@ export class OpenAiAttentionEvaluator implements AttentionEvaluator {
   readonly #now: () => number;
   readonly #requestTimeoutMs: number;
   readonly #maximumOutputTokens: number;
+  /** Until when rate-limited requests stay unsent, as epoch milliseconds. */
+  #quietUntil = 0;
 
   constructor(options: OpenAiAttentionEvaluatorOptions) {
     const apiKey = text(options.apiKey);
@@ -142,10 +157,18 @@ export class OpenAiAttentionEvaluator implements AttentionEvaluator {
   }
 
   async evaluate(update: AttentionUpdate): Promise<AttentionDecision | undefined> {
+    // Answering with nothing is how an evaluator stays silent, and staying
+    // silent is free: the update stays derivable and returns once the API is
+    // taking requests again.
+    if (this.#now() < this.#quietUntil) return undefined;
     const response = await this.#request(update);
     if (!response) return undefined;
 
     if (!response.ok) {
+      if (response.status === OPENAI_RATE_LIMIT_STATUS) {
+        this.#quiet(response);
+        return undefined;
+      }
       // Status alone is enough to diagnose credentials or rate limits without
       // writing the request, the key, or any session material to the log.
       this.#report(`OpenAI attention request failed with status ${response.status}`);
@@ -199,6 +222,23 @@ export class OpenAiAttentionEvaluator implements AttentionEvaluator {
       );
       return undefined;
     }
+  }
+
+  /**
+   * Starts the quiet a rate limit asked for, taking the API's own word for
+   * how long when it gives one. Reported once, at the moment the quiet
+   * begins: the requests held back during it are not failures to log.
+   */
+  #quiet(response: Response): void {
+    const retryAfterSeconds = Number(response.headers.get(OPENAI_RETRY_AFTER_HEADER));
+    const waitMs =
+      Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
+        ? retryAfterSeconds * 1000
+        : ATTENTION_RATE_LIMIT_COOLDOWN_MS;
+    this.#quietUntil = this.#now() + waitMs;
+    this.#report(
+      `OpenAI attention requests are rate limited; pausing reviews for ${Math.round(waitMs / 1000)}s`,
+    );
   }
 
   async #payload(response: Response): Promise<unknown> {

--- a/apps/desktop/src/openai-attention-evaluator.ts
+++ b/apps/desktop/src/openai-attention-evaluator.ts
@@ -156,6 +156,15 @@ export class OpenAiAttentionEvaluator implements AttentionEvaluator {
     return this.#model;
   }
 
+  /**
+   * The moment rate-limited requests resume, for the reviewer to ask before a
+   * pass. A reviewer that asks skips the pass without spending anything; the
+   * guard inside {@link evaluate} still answers a caller that did not.
+   */
+  quietUntil(): number | undefined {
+    return this.#quietUntil > this.#now() ? this.#quietUntil : undefined;
+  }
+
   async evaluate(update: AttentionUpdate): Promise<AttentionDecision | undefined> {
     // Answering with nothing is how an evaluator stays silent, and staying
     // silent is free: the update stays derivable and returns once the API is

--- a/apps/desktop/src/openai-realtime-credentials.ts
+++ b/apps/desktop/src/openai-realtime-credentials.ts
@@ -1,7 +1,6 @@
 import {
   isRealtimeVoice,
   isRealtimeVoiceSpeed,
-  nonNegativeNumber,
   positiveInteger,
   REALTIME_CALLS_PATH,
   REALTIME_CLIENT_SECRETS_PATH,
@@ -28,12 +27,6 @@ export const OPENAI_ENVIRONMENT = {
 const OPENAI_DEFAULTS = {
   BASE_URL: "https://api.openai.com/v1",
   REQUEST_TIMEOUT_MS: 10_000,
-  /**
-   * Re-mint slightly before a credential actually expires. The renderer still
-   * has to complete an SDP round trip after it receives one, and a secret that
-   * dies mid-handshake fails in a way that looks like a network fault.
-   */
-  EXPIRY_MARGIN_MS: 5_000,
 } as const;
 
 type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
@@ -47,7 +40,6 @@ export interface OpenAiRealtimeCredentialOptions {
   fetch?: FetchLike;
   now?: () => number;
   requestTimeoutMs?: number;
-  expiryMarginMs?: number;
 }
 
 export type OpenAiRealtimeMinterOptions = Omit<OpenAiRealtimeCredentialOptions, "apiKey">;
@@ -104,8 +96,6 @@ export class OpenAiRealtimeCredentialMinter {
   readonly #fetch: FetchLike;
   readonly #now: () => number;
   readonly #requestTimeoutMs: number;
-  readonly #expiryMarginMs: number;
-  #credential: RealtimeConnection | undefined;
   #lastOutcome: RealtimeMintOutcome = REALTIME_MINT_OUTCOME.NOT_ATTEMPTED;
   #lastDetail: string | undefined;
   #lastAttemptAt: number | undefined;
@@ -126,10 +116,6 @@ export class OpenAiRealtimeCredentialMinter {
       options.requestTimeoutMs,
       OPENAI_DEFAULTS.REQUEST_TIMEOUT_MS,
     );
-    this.#expiryMarginMs = nonNegativeNumber(
-      options.expiryMarginMs,
-      OPENAI_DEFAULTS.EXPIRY_MARGIN_MS,
-    );
   }
 
   get model(): string {
@@ -137,37 +123,31 @@ export class OpenAiRealtimeCredentialMinter {
   }
 
   /**
-   * Changes the voice new credentials are minted for. The outstanding
-   * credential was minted against the old voice, so it is discarded rather
-   * than served speaking the wrong one; a call already open keeps the voice it
-   * answered with, because a credential already handed out cannot be recalled.
+   * Changes the voice new credentials are minted for. A call already open
+   * keeps the voice it answered with, because a credential already handed out
+   * cannot be recalled.
    */
   setVoice(voice: string | undefined): void {
-    const next = text(voice) ?? this.#configuredVoice;
-    if (next === this.#voice) return;
-    this.#voice = next;
-    this.#credential = undefined;
+    this.#voice = text(voice) ?? this.#configuredVoice;
   }
 
   /**
    * Changes the pace new credentials are minted for, under the same rule as
-   * the voice: the outstanding credential is discarded, and a call already
-   * open keeps the pace it answered at.
+   * the voice: a call already open keeps the pace it answered at.
    */
   setSpeed(speed: number | undefined): void {
-    const next = positiveSpeed(speed) ?? this.#configuredSpeed;
-    if (next === this.#speed) return;
-    this.#speed = next;
-    this.#credential = undefined;
+    this.#speed = positiveSpeed(speed) ?? this.#configuredSpeed;
   }
 
-  /** Returns a usable credential, reusing the outstanding one until it nears expiry. */
+  /**
+   * Mints a fresh credential for every call. A minted secret is deliberately
+   * never kept to serve a later call: the service has been seen to refuse a
+   * reused secret at the calls endpoint (status 401) even inside its stated
+   * expiry, and a refused call in the announcer's path is an announcement
+   * lost. One extra POST per call open is cheap; a secret that answers only
+   * the call it was minted for cannot go stale in anyone's hands.
+   */
   async mint(): Promise<RealtimeConnection | undefined> {
-    const existing = this.#credential;
-    if (existing && realtimeCredentialIsUsable(existing, this.#now() + this.#expiryMarginMs)) {
-      return existing;
-    }
-    this.#credential = undefined;
     this.#lastAttemptAt = this.#now();
 
     const response = await this.#request();
@@ -202,7 +182,6 @@ export class OpenAiRealtimeCredentialMinter {
       ...credential,
       callsUrl: `${this.#baseUrl}${REALTIME_CALLS_PATH}`,
     };
-    this.#credential = connection;
     this.#record(REALTIME_MINT_OUTCOME.SUCCEEDED);
     return connection;
   }

--- a/apps/desktop/src/renderer/spoken-notices.ts
+++ b/apps/desktop/src/renderer/spoken-notices.ts
@@ -152,12 +152,6 @@ export class SpokenNoticeAnnouncer {
       return;
     }
     if (session.isConnecting) return;
-    // The backlog has had its tries; what is left is the panel's to show.
-    if (this.#connectAttempts >= MAXIMUM_CONNECT_ATTEMPTS) {
-      this.#queue = [];
-      this.#connectAttempts = 0;
-      return;
-    }
     // Silence, and something to say into it: open a call of Luke's own.
     this.#connectAttempts += 1;
     this.#ownsCall = true;
@@ -170,19 +164,35 @@ export class SpokenNoticeAnnouncer {
           return;
         }
         this.#ownsCall = false;
-        this.#armRetry();
+        this.#retreatOrRetry();
       })
       .catch(() => {
         this.#ownsCall = false;
-        this.#armRetry();
+        this.#retreatOrRetry();
       });
+  }
+
+  /**
+   * Decides what a refused connect leaves behind. A backlog still owed a try
+   * keeps it, on the retry clock; one that has had its tries is dropped here,
+   * at the moment of the final refusal, so notices arriving afterwards start
+   * a fresh backlog with tries of its own rather than dying against a spent
+   * counter. What is dropped is still standing in the panel.
+   */
+  #retreatOrRetry(): void {
+    if (this.#connectAttempts >= MAXIMUM_CONNECT_ATTEMPTS) {
+      this.#queue = [];
+      this.#connectAttempts = 0;
+      return;
+    }
+    this.#armRetry();
   }
 
   /**
    * Starts the clock on another try at a backlog whose call could not open or
    * did not last. Idempotent, because a refused connect and the failed status
    * it causes both land here; the queue's own age filter and the attempt cap
-   * in {@link #flush} are what keep the clock from ticking forever.
+   * in {@link #retreatOrRetry} are what keep the clock from ticking forever.
    */
   #armRetry(): void {
     if (this.#queue.length === 0) return;

--- a/apps/desktop/src/renderer/spoken-notices.ts
+++ b/apps/desktop/src/renderer/spoken-notices.ts
@@ -21,6 +21,22 @@ export const ANNOUNCER_LINGER_MS = 60_000;
 export const MAXIMUM_QUEUED_NOTICES = 8;
 
 /**
+ * How long a backlog waits after a refused call before trying again. The
+ * refusal this exists for is the transient kind — a rate limit at the voice
+ * service, a network mid-blink — where seconds are the difference between an
+ * announcement arriving late and not arriving at all.
+ */
+export const ANNOUNCER_RETRY_DELAY_MS = 20_000;
+
+/**
+ * How many times one backlog may try to open Luke's own call. Together with
+ * {@link SPOKEN_NOTICE_MAX_AGE_MS} this is what keeps a persistent refusal
+ * from becoming a loop: the attempts run out, and anything still queued has
+ * aged out of being news long before a fourth try could matter.
+ */
+export const MAXIMUM_CONNECT_ATTEMPTS = 3;
+
+/**
  * The slice of the voice session the announcer drives. `microphoneCall` is the
  * ownership question: true means the call up or coming is the developer's own,
  * which the announcer may speak on but must never close.
@@ -50,9 +66,15 @@ export interface SpokenNoticeAnnouncerOptions {
  * exists for: it opens a call of Luke's own — speak-only, no microphone, no
  * context — reads the queue out one reply at a time, lingers briefly for the
  * cluster of finishes that usually follows the first, and closes the call it
- * opened. It never closes the developer's call, and it never retries a
- * connection that answered: a queue that cannot be delivered is dropped,
- * because every notice is still standing in the panel.
+ * opened. It never closes the developer's call.
+ *
+ * A call that is refused keeps the backlog and tries again on a short clock,
+ * because the refusal this path actually meets is transient — a rate limit,
+ * a network mid-blink — and a first-try-only announcer turns each one into
+ * permanent silence. The retry cannot become a loop: the attempts are capped
+ * per backlog, and every queued sentence ages out of being news regardless.
+ * A backlog that outlives its attempts is dropped, because every notice is
+ * still standing in the panel.
  */
 export class SpokenNoticeAnnouncer {
   readonly #options: SpokenNoticeAnnouncerOptions;
@@ -60,6 +82,9 @@ export class SpokenNoticeAnnouncer {
   /** Whether the call now up is one this announcer opened, and so must close. */
   #ownsCall = false;
   #lingerTimer: unknown;
+  /** How many times the backlog now queued has tried to open Luke's own call. */
+  #connectAttempts = 0;
+  #retryTimer: unknown;
 
   constructor(options: SpokenNoticeAnnouncerOptions) {
     this.#options = options;
@@ -101,9 +126,11 @@ export class SpokenNoticeAnnouncer {
     ) {
       this.#cancelLinger();
       this.#ownsCall = false;
-      // A call that failed or was refused is not retried into a loop; the
-      // notices it would have carried are still shown in the panel.
-      if (status !== REALTIME_STATUS.IDLE) this.#queue = [];
+      // The backlog survives the call it was waiting on — a developer's call
+      // that ended mid-queue, or Luke's own that dropped — and the retry clock
+      // is what picks it back up. The connect path arms the same clock when an
+      // open is refused, so arming here is idempotent.
+      this.#armRetry();
     }
   }
 
@@ -112,6 +139,7 @@ export class SpokenNoticeAnnouncer {
     this.#queue = this.#queue.filter((item) => now - item.decidedAt <= SPOKEN_NOTICE_MAX_AGE_MS);
     const session = this.#options.session();
     if (this.#queue.length === 0) {
+      this.#connectAttempts = 0;
       this.#armLinger();
       return;
     }
@@ -124,22 +152,44 @@ export class SpokenNoticeAnnouncer {
       return;
     }
     if (session.isConnecting) return;
+    // The backlog has had its tries; what is left is the panel's to show.
+    if (this.#connectAttempts >= MAXIMUM_CONNECT_ATTEMPTS) {
+      this.#queue = [];
+      this.#connectAttempts = 0;
+      return;
+    }
     // Silence, and something to say into it: open a call of Luke's own.
+    this.#connectAttempts += 1;
     this.#ownsCall = true;
     void session
       .connect({ microphone: false })
       .then((opened) => {
         if (opened) {
+          this.#connectAttempts = 0;
           this.#flush();
           return;
         }
         this.#ownsCall = false;
-        this.#queue = [];
+        this.#armRetry();
       })
       .catch(() => {
         this.#ownsCall = false;
-        this.#queue = [];
+        this.#armRetry();
       });
+  }
+
+  /**
+   * Starts the clock on another try at a backlog whose call could not open or
+   * did not last. Idempotent, because a refused connect and the failed status
+   * it causes both land here; the queue's own age filter and the attempt cap
+   * in {@link #flush} are what keep the clock from ticking forever.
+   */
+  #armRetry(): void {
+    if (this.#queue.length === 0) return;
+    this.#retryTimer ??= (this.#options.schedule ?? setTimeout)(() => {
+      this.#retryTimer = undefined;
+      this.#flush();
+    }, ANNOUNCER_RETRY_DELAY_MS);
   }
 
   #armLinger(): void {

--- a/apps/desktop/tests/openai-attention-evaluator.test.ts
+++ b/apps/desktop/tests/openai-attention-evaluator.test.ts
@@ -165,16 +165,22 @@ test("a rate limit quiets requests for the cooldown instead of retrying at full 
   const { fetch, requests } = recordingFetch(() => new Response("rate limited", { status: 429 }));
   const evaluator = new OpenAiAttentionEvaluator({ apiKey: API_KEY, now: () => now, fetch });
 
+  assert.equal(evaluator.quietUntil(), undefined);
   assert.equal(await evaluator.evaluate(update()), undefined);
   assert.equal(requests.length, 1);
+
+  // The quiet is visible to the reviewer, so a pass can be skipped whole
+  // rather than spending per-session retries on refusals.
+  assert.equal(evaluator.quietUntil(), now + ATTENTION_RATE_LIMIT_COOLDOWN_MS);
 
   // Inside the cooldown nothing is even sent; the update stays derivable.
   now += ATTENTION_RATE_LIMIT_COOLDOWN_MS - 1;
   assert.equal(await evaluator.evaluate(update()), undefined);
   assert.equal(requests.length, 1);
 
-  // The cooldown over, requests resume.
+  // The cooldown over, requests resume and the quiet reads as lifted.
   now += 1;
+  assert.equal(evaluator.quietUntil(), undefined);
   assert.equal(await evaluator.evaluate(update()), undefined);
   assert.equal(requests.length, 2);
 });

--- a/apps/desktop/tests/openai-attention-evaluator.test.ts
+++ b/apps/desktop/tests/openai-attention-evaluator.test.ts
@@ -7,6 +7,7 @@ import {
   SESSION_STATUS,
 } from "@sidecar/core";
 import {
+  ATTENTION_RATE_LIMIT_COOLDOWN_MS,
   OpenAiAttentionEvaluator,
   openAiAttentionEvaluator,
 } from "../src/openai-attention-evaluator";
@@ -156,6 +157,44 @@ test("stays silent when the API is unavailable or answers outside the contract",
     const { evaluator } = evaluatorWith(failure);
     assert.equal(await evaluator.evaluate(update()), undefined);
   }
+});
+
+test("a rate limit quiets requests for the cooldown instead of retrying at full rate", async (t) => {
+  silenceStderr(t);
+  let now = DECIDED_AT;
+  const { fetch, requests } = recordingFetch(() => new Response("rate limited", { status: 429 }));
+  const evaluator = new OpenAiAttentionEvaluator({ apiKey: API_KEY, now: () => now, fetch });
+
+  assert.equal(await evaluator.evaluate(update()), undefined);
+  assert.equal(requests.length, 1);
+
+  // Inside the cooldown nothing is even sent; the update stays derivable.
+  now += ATTENTION_RATE_LIMIT_COOLDOWN_MS - 1;
+  assert.equal(await evaluator.evaluate(update()), undefined);
+  assert.equal(requests.length, 1);
+
+  // The cooldown over, requests resume.
+  now += 1;
+  assert.equal(await evaluator.evaluate(update()), undefined);
+  assert.equal(requests.length, 2);
+});
+
+test("a rate limit that names its own wait is taken at its word", async (t) => {
+  silenceStderr(t);
+  let now = DECIDED_AT;
+  const { fetch, requests } = recordingFetch(
+    () => new Response("rate limited", { status: 429, headers: { "retry-after": "5" } }),
+  );
+  const evaluator = new OpenAiAttentionEvaluator({ apiKey: API_KEY, now: () => now, fetch });
+
+  assert.equal(await evaluator.evaluate(update()), undefined);
+  now += 4_999;
+  await evaluator.evaluate(update());
+  assert.equal(requests.length, 1);
+
+  now += 1;
+  await evaluator.evaluate(update());
+  assert.equal(requests.length, 2);
 });
 
 test("reports a response that carried no decision instead of failing quietly", async (t) => {

--- a/apps/desktop/tests/openai-realtime-credentials.test.ts
+++ b/apps/desktop/tests/openai-realtime-credentials.test.ts
@@ -85,47 +85,30 @@ test("the standing key authorizes the mint and never appears in the response", a
   assert.ok(!JSON.stringify(credential).includes(API_KEY));
 });
 
-test("an outstanding credential is reused until it nears expiry", async () => {
-  let now = NOW;
-  const { minter: instance, requests } = minter([mintResponse(), mintResponse()], {
-    now: () => now,
-  });
+test("every call is minted its own credential, never a reused one", async () => {
+  const { minter: instance, requests } = minter([mintResponse(), mintResponse()]);
 
-  await instance.mint();
-  await instance.mint();
-  assert.equal(requests.length, 1);
-
-  // Inside the expiry margin the credential can no longer survive a handshake.
-  now = EXPIRES_AT_SECONDS * 1000 - 1_000;
-  await instance.mint();
+  // The service has been seen to refuse a reused secret at the calls endpoint
+  // (status 401) even inside its stated expiry, so a secret answers only the
+  // call it was minted for.
+  assert.equal((await instance.mint())?.value, "ek_test_secret");
+  assert.equal((await instance.mint())?.value, "ek_test_secret");
   assert.equal(requests.length, 2);
 });
 
-test("changing the voice discards the outstanding credential and mints for the new one", async () => {
+test("changing the voice mints the next credential for the new one", async () => {
   const { minter: instance, requests } = minter([mintResponse(), mintResponse()]);
   await instance.mint();
 
   instance.setVoice(REALTIME_VOICE.MARIN);
   await instance.mint();
 
-  // The first credential was minted against the old voice, so serving it after
-  // the change would answer the next conversation with the wrong one.
   assert.equal(requests.length, 2);
   const body = JSON.parse(String(requests[1]?.init.body)) as {
     session: { audio: { output: { voice: string } } };
   };
   assert.equal(body.session.audio.output.voice, REALTIME_VOICE.MARIN);
   assert.equal(instance.diagnostics().voice, REALTIME_VOICE.MARIN);
-});
-
-test("the same voice again keeps the outstanding credential", async () => {
-  const { minter: instance, requests } = minter([mintResponse(), mintResponse()]);
-  await instance.mint();
-
-  instance.setVoice(REALTIME_DEFAULTS.VOICE);
-  await instance.mint();
-
-  assert.equal(requests.length, 1);
 });
 
 test("clearing the voice returns to the one the minter was built with", () => {
@@ -137,31 +120,19 @@ test("clearing the voice returns to the one the minter was built with", () => {
   assert.equal(instance.diagnostics().voice, REALTIME_DEFAULTS.VOICE);
 });
 
-test("changing the pace discards the outstanding credential and mints for the new one", async () => {
+test("changing the pace mints the next credential for the new one", async () => {
   const { minter: instance, requests } = minter([mintResponse(), mintResponse()]);
   await instance.mint();
 
   instance.setSpeed(REALTIME_VOICE_SPEED.FAST);
   await instance.mint();
 
-  // The first credential was minted at the old pace, so serving it after the
-  // change would answer the next conversation at the wrong one.
   assert.equal(requests.length, 2);
   const body = JSON.parse(String(requests[1]?.init.body)) as {
     session: { audio: { output: { speed: number } } };
   };
   assert.equal(body.session.audio.output.speed, REALTIME_VOICE_SPEED.FAST);
   assert.equal(instance.diagnostics().speed, REALTIME_VOICE_SPEED.FAST);
-});
-
-test("the same pace again keeps the outstanding credential", async () => {
-  const { minter: instance, requests } = minter([mintResponse(), mintResponse()]);
-  await instance.mint();
-
-  instance.setSpeed(REALTIME_DEFAULTS.SPEED);
-  await instance.mint();
-
-  assert.equal(requests.length, 1);
 });
 
 test("clearing the pace returns to the one the minter was built with", () => {

--- a/apps/desktop/tests/spoken-notices.test.ts
+++ b/apps/desktop/tests/spoken-notices.test.ts
@@ -247,13 +247,39 @@ test("a backlog that outlives its attempts is dropped, not retried into a loop",
   }
   assert.equal(session.connects, MAXIMUM_CONNECT_ATTEMPTS);
 
-  // The attempts are spent: the next tick empties the queue and stops asking.
+  // The final refusal spent the attempts: the backlog is already dropped and
+  // no clock is left ticking for it.
+  assert.equal(timers.armed(), 0);
   timers.fire();
   await Promise.resolve();
   assert.equal(session.connects, MAXIMUM_CONNECT_ATTEMPTS);
-  assert.equal(timers.armed(), 0);
 
   // A later notice is a fresh backlog with fresh attempts.
+  session.connectOpens = true;
+  subject.enqueue([speech("b")]);
+  await Promise.resolve();
+  assert.deepEqual(
+    session.spoken.map((item) => item.providerSessionId),
+    ["b"],
+  );
+});
+
+test("a notice arriving right after a spent backlog is kept, not dropped with it", async () => {
+  const session = fakeSession();
+  session.connectOpens = false;
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  subject.enqueue([speech("a")]);
+  await Promise.resolve();
+  for (let attempt = 1; attempt < MAXIMUM_CONNECT_ATTEMPTS; attempt += 1) {
+    timers.fire();
+    await Promise.resolve();
+  }
+  assert.equal(session.connects, MAXIMUM_CONNECT_ATTEMPTS);
+
+  // Fresh news arriving before any clock ticks must find a fresh counter,
+  // not die against the one the spent backlog left behind.
   session.connectOpens = true;
   subject.enqueue([speech("b")]);
   await Promise.resolve();

--- a/apps/desktop/tests/spoken-notices.test.ts
+++ b/apps/desktop/tests/spoken-notices.test.ts
@@ -9,7 +9,9 @@ import {
 } from "@sidecar/core";
 import {
   ANNOUNCER_LINGER_MS,
+  ANNOUNCER_RETRY_DELAY_MS,
   type AnnouncerSession,
+  MAXIMUM_CONNECT_ATTEMPTS,
   SPOKEN_NOTICE_MAX_AGE_MS,
   SpokenNoticeAnnouncer,
 } from "../src/renderer/spoken-notices";
@@ -203,7 +205,7 @@ test("a notice riding the developer's call never closes it", () => {
   assert.equal(session.closes, 0);
 });
 
-test("a call that cannot open drops the queue rather than retrying into a loop", async () => {
+test("a refused call keeps the backlog and speaks it on the retry", async () => {
   const session = fakeSession();
   session.connectOpens = false;
   const timers = fakeTimers();
@@ -213,13 +215,77 @@ test("a call that cannot open drops the queue rather than retrying into a loop",
   await Promise.resolve();
   subject.onStatus(REALTIME_STATUS.UNAVAILABLE);
 
-  // A later notice tries again fresh; the stale queue did not accumulate.
+  // The refusal armed the retry clock instead of emptying the queue.
+  assert.equal(session.connects, 1);
+  assert.equal(timers.armed(), 1);
+  assert.deepEqual(timers.delays, [ANNOUNCER_RETRY_DELAY_MS]);
+
+  // The rate limit lifted; the retry delivers the same notice.
+  session.connectOpens = true;
+  timers.fire();
+  await Promise.resolve();
+  assert.equal(session.connects, 2);
+  assert.deepEqual(
+    session.spoken.map((item) => item.providerSessionId),
+    ["a"],
+  );
+});
+
+test("a backlog that outlives its attempts is dropped, not retried into a loop", async () => {
+  const session = fakeSession();
+  session.connectOpens = false;
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  subject.enqueue([speech("a")]);
+  await Promise.resolve();
+  subject.onStatus(REALTIME_STATUS.UNAVAILABLE);
+  for (let attempt = 1; attempt < MAXIMUM_CONNECT_ATTEMPTS; attempt += 1) {
+    timers.fire();
+    await Promise.resolve();
+    subject.onStatus(REALTIME_STATUS.UNAVAILABLE);
+  }
+  assert.equal(session.connects, MAXIMUM_CONNECT_ATTEMPTS);
+
+  // The attempts are spent: the next tick empties the queue and stops asking.
+  timers.fire();
+  await Promise.resolve();
+  assert.equal(session.connects, MAXIMUM_CONNECT_ATTEMPTS);
+  assert.equal(timers.armed(), 0);
+
+  // A later notice is a fresh backlog with fresh attempts.
   session.connectOpens = true;
   subject.enqueue([speech("b")]);
   await Promise.resolve();
   assert.deepEqual(
     session.spoken.map((item) => item.providerSessionId),
     ["b"],
+  );
+});
+
+test("a backlog stranded by a call that ended is picked up by the retry clock", async () => {
+  const session = fakeSession();
+  session.microphone = true;
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  // Arrives mid-reply on the developer's call and waits its turn.
+  subject.enqueue([speech("a")]);
+  assert.deepEqual(session.spoken, []);
+
+  // The developer hangs up before the turn ends; the backlog survives.
+  session.microphone = false;
+  session.setStatus(REALTIME_STATUS.IDLE);
+  subject.onStatus(REALTIME_STATUS.IDLE);
+  assert.equal(timers.armed(), 1);
+
+  timers.fire();
+  await Promise.resolve();
+  assert.equal(session.connects, 1);
+  assert.deepEqual(
+    session.spoken.map((item) => item.providerSessionId),
+    ["a"],
   );
 });
 

--- a/packages/sidecar-core/src/attention.ts
+++ b/packages/sidecar-core/src/attention.ts
@@ -155,6 +155,14 @@ export function attentionContext(detail: SessionDetail): AttentionContext | unde
 /** Reviews one bounded update and decides whether Luke should speak. */
 export interface AttentionEvaluator {
   evaluate(update: AttentionUpdate): Promise<AttentionDecision | undefined>;
+  /**
+   * When the evaluator has stood itself down — a rate limit's quiet — the
+   * moment it will take requests again, as epoch milliseconds. A reviewer
+   * that asks first skips the pass whole: nothing is sent, no baseline
+   * advances, and no per-session retry is spent on a refusal that was never
+   * about the session. Absent or in the past means requests are welcome.
+   */
+  quietUntil?(): number | undefined;
 }
 
 /** Why a reviewed update ended up with the decision it carries. */
@@ -518,6 +526,12 @@ export class SessionAttentionReviewer {
   }
 
   async review(sessions: readonly NormalizedSession[]): Promise<readonly AttentionReview[]> {
+    // An evaluator in its own quiet would answer every update with nothing,
+    // and each nothing costs a per-session retry budgeted for real failures.
+    // Skipping the pass before any baseline advances spends none of them:
+    // every development stays derivable and is reviewed once the quiet ends.
+    const quietUntil = this.#evaluator.quietUntil?.();
+    if (quietUntil !== undefined && quietUntil > this.#now()) return [];
     this.#ledger.retain(sessions);
 
     const candidates: AttentionCandidate[] = [];

--- a/packages/sidecar-core/tests/attention.test.ts
+++ b/packages/sidecar-core/tests/attention.test.ts
@@ -278,6 +278,36 @@ test("stays silent when an evaluator fails or answers outside the contract", asy
   assert.equal(emptyReview?.outcome, ATTENTION_REVIEW_OUTCOME.UNAVAILABLE);
 });
 
+test("a quiet evaluator skips the pass whole, spending nothing", async () => {
+  let now = DECIDED_AT;
+  const quietUntil = DECIDED_AT + 60_000;
+  const updates: AttentionUpdate[] = [];
+  const reviewer = new SessionAttentionReviewer({
+    evaluator: {
+      quietUntil: () => quietUntil,
+      evaluate: async (update) => {
+        updates.push(update);
+        return speakDecision();
+      },
+    },
+    now: () => now,
+    // With no retries budgeted, one pass counted as unavailable would drop
+    // the development — which is exactly what a skipped pass must not do.
+    maximumUnavailableRetries: 0,
+  });
+
+  const waiting = session(claude, "review", { status: SESSION_STATUS.WAITING });
+  await reviewer.review([waiting]);
+  await reviewer.review([waiting]);
+  assert.equal(updates.length, 0, "nothing is sent while the evaluator is quiet");
+
+  // The quiet over, the development that waited through it is reviewed.
+  now = quietUntil;
+  const [review] = await reviewer.review([waiting]);
+  assert.equal(review?.outcome, ATTENTION_REVIEW_OUTCOME.DECIDED);
+  assert.equal(updates.length, 1);
+});
+
 test("drops a decision about a failure the session has already replaced", async () => {
   const rateLimited = session(claude, "review", {
     status: SESSION_STATUS.ERROR,


### PR DESCRIPTION
## The report

"Luke isn't talking to me on launch until I talk to him first."

And, mid-investigation: "I think I'm getting a 'The voice service refused the call (status 401)' error."

## What was found, live on a physical Mac

The announcement pipeline was instrumented end to end and run against real sessions. A Conductor session flipped `working → waiting` while no conversation was open, and the trace showed every stage working — and exactly one failing:

```
tracker:   edge conductor working->waiting: NOTICE
main:      sending 1 notice(s) to voice host (host=yes)
renderer:  attention speech received (1, sources=status-edge)
announcer: opening Luke's own speak-only call
session:   credential minted
session:   SDP exchange refused (status 429)   ← the failure
announcer: own call connect resolved: false    ← queue dropped, forever
```

The same log then named the source of the 429: `OpenAI attention request failed with status 429`, **376 times in under 8 minutes — 100% of attention requests, at 48/minute, indefinitely**. The chain:

1. The registry now holds every conversation ever observed (~360 sessions after #144), and **every session produces a first-sight (`observed`) update at launch**.
2. Reviews run 4 to a pass, a pass every ~5 seconds, and **a failed review stays derivable and is re-sent at full rate** — so the launch backlog never drains and the key is rate-limited continuously.
3. The announcer's speak-only call lands in that storm, gets 429'd at `/v1/realtime/calls`, and **dropped its whole backlog on the first refusal, never retrying**.

Talking first "fixes" it because a notice arriving while the developer's call is up rides that call and never opens one of its own — the only path exposed to the refusal is exactly the proactive one #97 promised.

The 401 is the third head of the same animal: the minter kept a minted client secret and served it to every later call until it neared expiry, and the calls endpoint has been seen to refuse a reused secret even inside its stated expiry. On the developer's call that surfaces as the caption-strip 401; on the announcer's it was another silently dropped backlog.

## The fixes

**`fix(voice)` — the announcer retries a refused call instead of dropping the backlog.** A short clock (20s), capped attempts per backlog (3), and the existing 2-minute staleness filter keep it from ever looping or reading old news as new. A backlog stranded when the developer's call ends mid-queue is picked up by the same clock. A spent backlog is dropped at the moment of its final refusal — not on the next flush — so a notice arriving right after it starts a fresh backlog with tries of its own.

**`fix(attention)` — the evaluator stops feeding the storm.** A 429 now quiets attention requests for a cooldown (the `Retry-After` header's word when it gives one, 60s otherwise) instead of retrying at full rate. The evaluator exposes the quiet through an optional `quietUntil`, and the reviewer asks before a pass and skips it whole: nothing is sent, no baseline advances, and none of the per-session unavailable retries are spent, so held-back updates stay derivable for when the quiet ends. And the review pass reads `rosterRelevantSessions` rather than the whole registry: an attention decision about a session with no row surfaces nowhere, and reviewing all of history sent a bounded update about every old session to OpenAI on each launch — hundreds of requests, and wider egress than the feature needs.

**`fix(voice)` — a fresh credential for every call.** A minted secret now answers only the call it was minted for; nothing is kept to be served stale later. One extra POST per call open, and a retry after any refusal is guaranteed a brand-new secret.

## What was ruled out (verified live)

- Edge detection, the #156 freshness gate, the repeat window, main-process send, renderer receipt, announcer queueing, credential minting — all correct with 360 sessions on the roster.
- Dead quota: with the storm quiet, the same key mints and the calls endpoint answers (a deliberately malformed probe got `400 invalid_offer`, not 429).
- Conductor `updatedAt` semantics — it moves to the flip time on `working → idle`, so fresh edges pass the freshness gate.

## Testing

- `./scripts/check.sh` passes, exit 0 — lint, typecheck, 173 core + 843 desktop + 5 web tests, builds. New coverage: refused call keeps the backlog and speaks it on retry; a spent backlog is dropped at the final refusal and a notice arriving right after it is kept; a 429 quiets evaluator requests for the cooldown, `Retry-After` is honored, and the quiet is visible through `quietUntil`; a quiet reviewer pass is skipped whole without spending unavailable retries; every call is minted its own credential, never a reused one.
- `./scripts/verify.sh` was not run: Linux cloud workspace, no drawing changes. No physical-notch check.
- Live end-to-end listen on a Mac with the fixed build: attempted; result reported in the PR conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31996257463/artifacts/9276929031) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31996257463)

- Commit: `bfe976e4dfbab755b5b02f56a27b2b04c31848f0`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
