### PR TITLE
fix(sessions): scale the count badge down before it crosses the shape's edge

### DIFF
--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -1,5 +1,5 @@
 import { CAPSULE_SIDE_WIDTH, PANEL_WIDTH, PEEK_SIDE_GROWTH } from "@sidecar/core";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { errandOriginProps } from "./luke-errand";
 import { LukeFace } from "./luke-face";
 import {
@@ -69,6 +69,51 @@ export function wingMarkCapacity(sideWidth: number): number {
 }
 
 const PEEK_SIDE_WIDTH = CAPSULE_SIDE_WIDTH + PEEK_SIDE_GROWTH;
+
+/**
+ * What the count badge costs to draw, in the stylesheet's numbers:
+ * `--wing-inset` before the number starts, the caption's own margin between
+ * the number and its words, and the 0.88 the badge rests at outside the
+ * panel. The keep is the last two pixels before the shape's edge, where the
+ * black is already turning its corner.
+ */
+const COUNT_INSET = 9;
+const COUNT_CAPTION_GAP = 9;
+const COUNT_RESTING_SCALE = 0.88;
+const COUNT_EDGE_KEEP = 2;
+
+/**
+ * How much of its resting scale the count badge keeps so the text never
+ * crosses the shape's edge. The number grows with the sessions it counts and
+ * the shape beside the housing does not, so past the width the wing can hold
+ * the text scales down instead of being drawn onto the desktop. The widths
+ * arrive in layout pixels — measured before any transform — so the room is
+ * compared against them at the scale the stylesheet is about to apply; the
+ * factor multiplies that resting scale rather than replacing it, and is 1
+ * whenever the room already suffices. The caption unfolds only in the peek
+ * and the panel, so only those states have to fit it; every other state
+ * draws the number alone inside the capsule's own side.
+ */
+export function countBadgeFit(
+  presentation: PanelPresentation,
+  housingWidth: number,
+  valueWidth: number,
+  captionWidth: number,
+): number {
+  const captioned =
+    presentation === PANEL_PRESENTATION.PEEK || presentation === PANEL_PRESENTATION.PANEL;
+  const textWidth = captioned ? valueWidth + COUNT_CAPTION_GAP + captionWidth : valueWidth;
+  if (textWidth <= 0) return 1;
+  const sideWidth =
+    presentation === PANEL_PRESENTATION.PANEL
+      ? (PANEL_WIDTH - housingWidth) / 2
+      : presentation === PANEL_PRESENTATION.PEEK
+        ? PEEK_SIDE_WIDTH
+        : CAPSULE_SIDE_WIDTH;
+  const restingScale = presentation === PANEL_PRESENTATION.PANEL ? 1 : COUNT_RESTING_SCALE;
+  const room = Math.max(0, sideWidth - COUNT_INSET - COUNT_EDGE_KEEP);
+  return Math.min(1, room / (restingScale * textWidth));
+}
 
 /**
  * The wing's strip, as slots: each provider's mark, then — when the
@@ -173,6 +218,29 @@ export function NotchWings({
   const marksRef = useWingReorderMotion();
   const drawnSlots = useRoster(slots, marksRef);
 
+  // The count's text, measured in layout pixels: `offsetWidth` never sees the
+  // transform about to draw it, so the fit below can divide by the scale the
+  // stylesheet applies without measuring its own answer. No dependency list,
+  // the way the reorder motion measures — the words change with the tally, and
+  // a re-read per commit costs less than proving which commits reworded them —
+  // and the guard keeps an unchanged measurement from re-rendering anything.
+  const countValueElement = useRef<HTMLSpanElement>(null);
+  const countCaptionElement = useRef<HTMLSpanElement>(null);
+  const [countWidths, setCountWidths] = useState({ value: 0, caption: 0 });
+  useLayoutEffect(() => {
+    const value = countValueElement.current?.offsetWidth ?? 0;
+    const caption = countCaptionElement.current?.offsetWidth ?? 0;
+    setCountWidths((held) =>
+      held.value === value && held.caption === caption ? held : { value, caption },
+    );
+  });
+  const countFit = countBadgeFit(
+    presentation,
+    housingWidth,
+    countWidths.value,
+    countWidths.caption,
+  );
+
   return (
     <>
       <div className="wing wing-left" data-audio={String(meterShown)}>
@@ -246,16 +314,17 @@ export function NotchWings({
         <div className="wing-inner">
           <span
             className="count-badge"
+            style={{ "--count-fit": countFit } as React.CSSProperties}
             data-state={tally.urgency}
             data-empty={String(tally.total === 0)}
             role="status"
             aria-live="polite"
             aria-label={tallySummary(tally)}
           >
-            <span className="count-value" aria-hidden="true">
+            <span className="count-value" aria-hidden="true" ref={countValueElement}>
               {tally.total}
             </span>
-            <span className="count-caption" aria-hidden="true">
+            <span className="count-caption" aria-hidden="true" ref={countCaptionElement}>
               {tallyCaption(tally)}
             </span>
           </span>

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1105,7 +1105,13 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 
 /* A number, not a badge. Seventeen sessions overflowed a pill, and a pill was
    never carrying meaning the colour and the caption were not already carrying.
-   The rounded system face is the one macOS uses for glanceable numerals. */
+   The rounded system face is the one macOS uses for glanceable numerals.
+   `--count-fit` is the component's answer to a number that outgrows the shape
+   it sits in: notch-wings measures the text and the wing's own room, and the
+   badge stands down from its resting scale just far enough to stay inside the
+   black — on transform, like everything else that moves, so a count crossing
+   a digit boundary re-shapes no text and rides the same spring as the
+   presentation's own scale change. */
 .count-badge {
   position: relative;
   display: flex;
@@ -1117,7 +1123,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   font-variant-numeric: tabular-nums;
   font-weight: 600;
   letter-spacing: -0.2px;
-  transform: scale(0.88);
+  transform: scale(calc(0.88 * var(--count-fit, 1)));
   transform-origin: left center;
   transition: transform var(--duration-shape) var(--spring);
   will-change: transform;
@@ -1135,7 +1141,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
    not, and growing it there read as a second movement competing with the
    widening. */
 .app-stage[data-presentation="panel"] .count-badge {
-  transform: scale(1);
+  transform: scale(var(--count-fit, 1));
 }
 
 .count-caption {

--- a/apps/desktop/tests/notch-wings.test.ts
+++ b/apps/desktop/tests/notch-wings.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { CAPSULE_SIDE_WIDTH, PANEL_WIDTH, PEEK_SIDE_GROWTH } from "@sidecar/core";
-import { OVERFLOW_SLOT_ID, wingMarkCapacity, wingSlots } from "../src/renderer/notch-wings";
+import {
+  countBadgeFit,
+  OVERFLOW_SLOT_ID,
+  wingMarkCapacity,
+  wingSlots,
+} from "../src/renderer/notch-wings";
+import { PANEL_PRESENTATION } from "../src/renderer/panel-state";
 import type { ProviderTally } from "../src/renderer/session-model";
 
 const peekSideWidth = CAPSULE_SIDE_WIDTH + PEEK_SIDE_GROWTH;
@@ -63,4 +69,54 @@ test("exactly filling the wing needs no count", () => {
     slots.map((slot) => slot.id),
     ["a", "b", "c", "d"],
   );
+});
+
+// The badge's room in the arithmetic below: the capsule's 36px side minus the
+// wing's 9px inset and the 2px kept off the shape's edge, and the peek's 124px
+// side minus the same.
+const capsuleRoom = CAPSULE_SIDE_WIDTH - 11;
+const peekRoom = peekSideWidth - 11;
+
+test("a count that fits keeps its resting scale", () => {
+  // Two tabular digits: about 19 layout pixels, 17 once the 0.88 draws them.
+  assert.equal(countBadgeFit(PANEL_PRESENTATION.CAPSULE, 210, 19, 0), 1);
+});
+
+test("a number wider than the capsule's side stands down to fit it", () => {
+  // Five digits: about 47 layout pixels against the capsule's 25 of room.
+  const fit = countBadgeFit(PANEL_PRESENTATION.CAPSULE, 210, 47, 0);
+  assert.ok(fit < 1);
+  assert.ok(0.88 * fit * 47 <= capsuleRoom + 1e-9);
+});
+
+test("the capsule ignores the caption it never draws", () => {
+  assert.equal(
+    countBadgeFit(PANEL_PRESENTATION.CAPSULE, 210, 19, 400),
+    countBadgeFit(PANEL_PRESENTATION.CAPSULE, 210, 19, 0),
+  );
+});
+
+test("the peek fits the number and its caption together", () => {
+  // A three-digit count beside "121 need you": each fits the peek alone, and
+  // together they outgrow it.
+  const fit = countBadgeFit(PANEL_PRESENTATION.PEEK, 210, 29, 100);
+  assert.ok(fit < 1);
+  assert.ok(0.88 * fit * (29 + 9 + 100) <= peekRoom + 1e-9);
+});
+
+test("the panel's wider side stands the same text down less than the peek's", () => {
+  const peek = countBadgeFit(PANEL_PRESENTATION.PEEK, 210, 38, 160);
+  const panel = countBadgeFit(PANEL_PRESENTATION.PANEL, 210, 38, 160);
+  assert.ok(peek < panel);
+});
+
+test("the slot keeps the capsule's quiet wing, so it keeps the capsule's fit", () => {
+  assert.equal(
+    countBadgeFit(PANEL_PRESENTATION.SLOT, 210, 47, 0),
+    countBadgeFit(PANEL_PRESENTATION.CAPSULE, 210, 47, 0),
+  );
+});
+
+test("text not yet measured is not scaled", () => {
+  assert.equal(countBadgeFit(PANEL_PRESENTATION.CAPSULE, 210, 0, 0), 1);
 });


### PR DESCRIPTION
## What

With enough sessions, the count beside the notch could outgrow the shape it sits in and be drawn past the black onto the desktop: a wide number in the capsule's fixed 36px side, or the number and its caption together in the peek's 124px side. The badge now scales its text down just far enough that it never crosses the shape's edge.

## How

- `countBadgeFit` in `notch-wings.tsx` compares the text's layout width against the wing's room for the current presentation — the capsule's side for the quiet states (which never draw the caption), the peek's fixed side and the panel's post-housing side for the two that draw the number and its caption together — and answers a factor of the badge's resting scale, 1 whenever the room already suffices.
- The number and caption are measured with `offsetWidth` in a guarded layout effect (layout pixels, blind to the transform about to draw them), following the reorder motion's no-dependency-list idiom.
- The factor rides into the stylesheet as `--count-fit`, multiplied into the badge's existing `transform: scale(...)` — text moves on transform only, per DESIGN.md, and a fit change rides the same `--spring` transition the presentation's own 0.88 → 1 scale change already uses.

## Testing

- `./scripts/check.sh` passes (repository contract checks, types, all workspace tests, builds).
- New unit tests in `apps/desktop/tests/notch-wings.test.ts` cover: a fitting count keeps its resting scale, a wide number stands down to the capsule's room, the capsule ignores the caption it never draws, the peek fits number and caption together, the panel stands the same text down less than the peek, the slot keeps the capsule's fit, and unmeasured text is not scaled.
- macOS visual evidence is produced by CI's `verify.sh` run and linked from this description. No physical-notch check was performed (change authored in a cloud sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/26f58473-2cd9-4f65-85f1-9dba0c87fab7)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31995417932/artifacts/9276680621) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31995417932)

- Commit: `a3156d4381ae6e32592151782116364de24e674c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
