### PR TITLE
feat(desktop): announce session news as a pressable notice popup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,11 +86,13 @@ Trust constraints:
   endpoint — a session whose provider lists none takes no such ask. A session whose provider documents no way in, or whose current state is
   documented for none, advertises nothing and is offered nothing; local
   sessions have no such endpoint and stay entirely read-only. Opening a
-  session — its row pressed, or the same press asked of Luke in conversation —
-  is not a write and needs no endpoint: the address its provider reported is
-  handed to the operating system, and nothing reaches the provider; an open
-  asked of Luke still runs only in a developer-opened turn, and a session that
-  reported no address is offered nowhere to open. Reading a local session's
+  session — its row pressed, the same press asked of Luke in conversation, or
+  the notice popup announcing it pressed under the housing — is not a write
+  and needs no endpoint: the address its provider reported is handed to the
+  operating system, and nothing reaches the provider; an open asked of Luke
+  still runs only in a developer-opened turn, and a session that reported no
+  address is offered nowhere to open — its popup's press opens Luke's own
+  panel instead, which touches no provider at all. Reading a local session's
   transcript in conversation is the same shape of act: asked of Luke in a
   turn the developer opened, validated against the observed roster in the
   renderer and again in the main process, read from the provider's own file
@@ -186,7 +188,12 @@ What Luke may show:
   call. The edge announcements speak whenever voice can; an answered ask
   speaks on the consent of the ask itself, for exactly as long as it stands.
   Widening either set is a product decision, not an implementation detail;
-  make it deliberately.
+  make it deliberately. The same announcements also stand briefly as a notice
+  popup on Luke's own surface, under the housing — worded and drawn on this
+  machine, leaving it never, fed by the same two deciders and nothing else,
+  and needing no voice credential. The popup's press is a row press at one
+  remove: the session's reported address goes to the operating system, or
+  Luke's own panel opens for a session that reported none.
 
 Before handoff, run `./scripts/check.sh` for portable-only changes. For any
 macOS or UI change, `./scripts/verify.sh` is the completion invariant. Report

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -228,6 +228,13 @@ The session roster, workspace projects, app guide, and issue roster named
 above travel only on conversations you open yourself. The call closes itself
 shortly after the announcement is spoken.
 
+The same announcements also appear briefly as a notice popup drawn on Luke's
+own surface under the notch. The popup is worded and drawn entirely on your
+Mac and nothing about it leaves it: it rides no network service and needs no
+OpenAI key, and pressing it only hands the session's provider-reported address
+to macOS — the same thing pressing the session's row does — or opens Luke's
+own panel when the session reported none.
+
 Luke does not record the conversation, write audio to disk, or keep a
 transcript. With captions enabled in Settings — they are off by default — the
 reply's text is drawn on screen while Luke speaks; it is discarded when the

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Visit [tryluke.dev](https://tryluke.dev) to see Luke in action.
 - Filter and sort sessions by location, provider, urgency, or recency.
 - Ask Luke about supported local sessions by voice or text.
 - Send messages and supported controls only when you explicitly ask Luke to.
-- Receive optional spoken announcements when a session needs you.
+- Receive optional spoken announcements — and a pressable notice at the
+  notch — when a session needs you.
 - View assigned Linear issues and, when asked, update their state or add a
   comment.
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -104,7 +104,11 @@ import { readOpenCodeSessionTranscript } from "./opencode-transcript";
 import { OutputVolumeWatcher } from "./output-volume";
 import { PanelManager } from "./panel-manager";
 import { runModeFor } from "./run-mode";
-import { sessionNoticeSpeech } from "./session-notifications";
+import {
+  attentionSpeechPopups,
+  sessionNoticePopup,
+  sessionNoticeSpeech,
+} from "./session-notifications";
 import { createSettingsHandler, SettingsRefusal } from "./settings-handler";
 import { SettingsStore } from "./settings-store";
 import {
@@ -1668,6 +1672,9 @@ async function reviewSessionAttention(): Promise<void> {
     // `outcome` says whether to voice it now, which only these reviews do.
     const speech = attentionSpeechFromReviews(reviews);
     if (speech.length > 0) {
+      // The same decisions, pressable: every display's surface draws the
+      // popup, so the sentence Luke says has somewhere to be pressed.
+      panels.broadcast(channels.sessionNotices, attentionSpeechPopups(speech));
       // Spoken once, by the one window that holds the voice: every display
       // already shows the same session as needing attention.
       panels.voiceHost()?.webContents.send(channels.attentionSpeech, speech);
@@ -1703,6 +1710,13 @@ function announceSessionNotices(sessions: readonly NormalizedSession[]): void {
   // that a deterministic alert is never traded away on a model's judgment.
   const notices = sessionNoticeTracker.notices(sessions, now);
   if (notices.length === 0) return;
+  // The pressable half of the announcement stands whether or not there is a
+  // voice to say it: the popup is drawn on Luke's own surface and needs no
+  // Realtime credential.
+  panels.broadcast(
+    channels.sessionNotices,
+    notices.map((notice) => sessionNoticePopup(notice, now)),
+  );
   // No voice, nothing to say it with: without a Realtime credential the
   // renderer cannot open a call, and the panel still shows every state.
   if (!realtimeCredentials) return;

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -71,6 +71,7 @@ const bridge: AppBridge = {
   onStopHotkeyChanged: subscribe(channels.stopHotkeyChanged),
   onOutputAudioChanged: subscribe(channels.outputAudioChanged),
   onAttentionSpeech: subscribe(channels.attentionSpeech),
+  onSessionNotices: subscribe(channels.sessionNotices),
 };
 
 contextBridge.exposeInMainWorld("sidecar", bridge);

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1294,6 +1294,18 @@ export function App(): React.JSX.Element {
     carryAppAction,
   });
 
+  // Whether the caption strip is holding the band under the housing — Luke's
+  // live words, or the voice-failure notice reported in their place. The gate
+  // reads the same pair the strip is drawn from below, so the popup can never
+  // advance into a band either of them is occupying.
+  const captionDrawn =
+    (lukeCaption ??
+      voiceErrorToShow({
+        fixtureSpeaking: bootstrap?.profile === "speaking" || bootstrap?.profile === "muted",
+        voice: voiceTurn,
+        error: voiceError,
+      })) !== undefined;
+
   // The notice popup: one announcement at a time standing under the housing,
   // pressable, on the room the caption otherwise uses. The queue holds what
   // arrived while the room was taken.
@@ -1356,7 +1368,7 @@ export function App(): React.JSX.Element {
   // the last popup gone, the caption cleared, or the shape back at rest.
   useEffect(() => {
     if (notice || noticeQueue.length === 0) return;
-    if (!noticePopupAllowed({ presentation, captionDrawn: lukeCaption !== undefined })) return;
+    if (!noticePopupAllowed({ presentation, captionDrawn })) return;
     const taken = takeNoticePopup(
       noticeQueue,
       Date.now(),
@@ -1372,7 +1384,7 @@ export function App(): React.JSX.Element {
       setNotice(taken.drawn);
       setNoticeShown(true);
     }
-  }, [notice, noticeQueue, presentation, lukeCaption, sessions]);
+  }, [notice, noticeQueue, presentation, captionDrawn, sessions]);
 
   // The dwell: a shown popup stands for its beat and puts itself away. A
   // pointer resting on it is someone reading; the timer re-arms rather than
@@ -1398,9 +1410,9 @@ export function App(): React.JSX.Element {
   // showing the session's row.
   useEffect(() => {
     if (!notice || !noticeShown) return;
-    if (noticePopupAllowed({ presentation, captionDrawn: lukeCaption !== undefined })) return;
+    if (noticePopupAllowed({ presentation, captionDrawn })) return;
     standDownNotice();
-  }, [notice, noticeShown, presentation, lukeCaption, standDownNotice]);
+  }, [notice, noticeShown, presentation, captionDrawn, standDownNotice]);
 
   /**
    * The popup's press: a row press at one remove. A session its provider gave

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -5,6 +5,7 @@ import {
   type FeedbackComposerKind,
   FIXTURE_EPOCH_MS,
   isProviderId,
+  MOTION_DURATION_MS,
   type NormalizedSession,
   type ObservedWorkspaceProject,
   type PanelFormFactor,
@@ -30,6 +31,7 @@ import type {
   AppSettings,
   DisplayDiagnostic,
   OutputAudioState,
+  SessionNoticePopup,
   SessionOpenResult,
   SettingsUpdateResult,
 } from "../shared/contracts";
@@ -78,6 +80,7 @@ import { NotchWings } from "./notch-wings";
 import { PanelBody, type SessionWriteHandlers } from "./panel-body";
 import { HIT_REGION, PANEL_PRESENTATION } from "./panel-state";
 import { PANEL_TAB, type PanelTab } from "./panel-tabs";
+import { ProviderMark } from "./provider-marks";
 import type { AppActionCarrier } from "./realtime-session";
 import {
   arrangeSessions,
@@ -91,6 +94,13 @@ import {
   tallySummary,
 } from "./session-model";
 import { parsePixels } from "./session-motion";
+import {
+  type DrawnNotice,
+  enqueueNoticePopups,
+  NOTICE_POPUP_MS,
+  noticePopupAllowed,
+  takeNoticePopup,
+} from "./session-notice-popup";
 import { SESSION_OPTIONS_BUTTON_ID, SESSION_OPTIONS_ID } from "./session-parts";
 import { focusSearchField } from "./session-search";
 import type { MicrophoneControl, PreferenceWrites, ShortcutControl } from "./settings-panel";
@@ -1284,6 +1294,140 @@ export function App(): React.JSX.Element {
     carryAppAction,
   });
 
+  // The notice popup: one announcement at a time standing under the housing,
+  // pressable, on the room the caption otherwise uses. The queue holds what
+  // arrived while the room was taken.
+  const [noticeQueue, setNoticeQueue] = useState<readonly SessionNoticePopup[]>([]);
+  // What the popup is drawing. The popup and its exit outlive the roster entry
+  // they were resolved from, so the drawn fields are kept here rather than
+  // looked up on every render.
+  const [notice, setNotice] = useState<DrawnNotice>();
+  // False while the popup is leaving: content leaves first, over the exit
+  // beat, and only the exit timer clearing `notice` releases the room — never
+  // the frame the state changed on.
+  const [noticeShown, setNoticeShown] = useState(false);
+  const noticeDwell = useRef<number | undefined>(undefined);
+  const noticeExit = useRef<number | undefined>(undefined);
+  // A pointer resting on the popup is someone reading it; the dwell timer
+  // fires through the ref so a held popup waits for the pointer to leave.
+  const noticeHeld = useRef(false);
+
+  const cancelNoticeTimers = useCallback(() => {
+    if (noticeDwell.current !== undefined) window.clearTimeout(noticeDwell.current);
+    if (noticeExit.current !== undefined) window.clearTimeout(noticeExit.current);
+    noticeDwell.current = undefined;
+    noticeExit.current = undefined;
+  }, []);
+
+  /**
+   * Puts the popup away: the content's exit runs first, and the drawn fields
+   * are held through it so the words fade in place rather than vanishing on
+   * the frame the state changed. Only after the surface has followed does the
+   * slot clear, which is what lets the next queued popup take the room.
+   */
+  const standDownNotice = useCallback(() => {
+    cancelNoticeTimers();
+    setNoticeShown(false);
+    noticeExit.current = window.setTimeout(() => {
+      noticeExit.current = undefined;
+      setNotice(undefined);
+    }, MOTION_DURATION_MS.EXIT + MOTION_DURATION_MS.SHAPE);
+  }, [cancelNoticeTimers]);
+
+  const holdNotice = useCallback(() => {
+    noticeHeld.current = true;
+  }, []);
+
+  const releaseNotice = useCallback(() => {
+    noticeHeld.current = false;
+  }, []);
+
+  useEffect(() => {
+    const removeNotices = window.sidecar.onSessionNotices((popups) => {
+      setNoticeQueue((waiting) => enqueueNoticePopups(waiting, popups));
+    });
+    return () => {
+      removeNotices();
+      cancelNoticeTimers();
+    };
+  }, [cancelNoticeTimers]);
+
+  // Advances the queue whenever something is waiting and the room is free:
+  // the last popup gone, the caption cleared, or the shape back at rest.
+  useEffect(() => {
+    if (notice || noticeQueue.length === 0) return;
+    if (!noticePopupAllowed({ presentation, captionDrawn: lukeCaption !== undefined })) return;
+    const taken = takeNoticePopup(
+      noticeQueue,
+      Date.now(),
+      (popup) =>
+        sessions.find(
+          (candidate) =>
+            candidate.providerId === popup.providerId &&
+            candidate.providerSessionId === popup.providerSessionId,
+        )?.title,
+    );
+    setNoticeQueue(taken.queue);
+    if (taken.drawn) {
+      setNotice(taken.drawn);
+      setNoticeShown(true);
+    }
+  }, [notice, noticeQueue, presentation, lukeCaption, sessions]);
+
+  // The dwell: a shown popup stands for its beat and puts itself away. A
+  // pointer resting on it is someone reading; the timer re-arms rather than
+  // taking the words out from under them.
+  useEffect(() => {
+    if (!notice || !noticeShown) return;
+    const arm = () => {
+      noticeDwell.current = window.setTimeout(() => {
+        noticeDwell.current = undefined;
+        if (noticeHeld.current) arm();
+        else standDownNotice();
+      }, NOTICE_POPUP_MS);
+    };
+    arm();
+    return () => {
+      if (noticeDwell.current !== undefined) window.clearTimeout(noticeDwell.current);
+      noticeDwell.current = undefined;
+    };
+  }, [notice, noticeShown, standDownNotice]);
+
+  // The room going away stands the popup down: a caption arriving mid-popup
+  // takes the band for the words being spoken, and a panel opening is already
+  // showing the session's row.
+  useEffect(() => {
+    if (!notice || !noticeShown) return;
+    if (noticePopupAllowed({ presentation, captionDrawn: lukeCaption !== undefined })) return;
+    standDownNotice();
+  }, [notice, noticeShown, presentation, lukeCaption, standDownNotice]);
+
+  /**
+   * The popup's press: a row press at one remove. A session its provider gave
+   * an address goes to the system, exactly as pressing the row would; one
+   * with no address — a local session — has the panel opened instead, where
+   * its row is already sorted to the top.
+   */
+  const openNoticedSession = useCallback(() => {
+    if (!notice) return;
+    const identity: SessionIdentity = {
+      providerId: notice.popup.providerId,
+      providerSessionId: notice.popup.providerSessionId,
+    };
+    const openable = sessions.some(
+      (candidate) =>
+        candidate.providerId === identity.providerId &&
+        candidate.providerSessionId === identity.providerSessionId &&
+        candidate.detail.link !== undefined,
+    );
+    standDownNotice();
+    if (openable) {
+      void window.sidecar.openSession(identity);
+      return;
+    }
+    expand();
+  }, [notice, sessions, standDownNotice, expand]);
+
   /**
    * A live push beats a bootstrap snapshot still in flight. The main process
    * will not repeat a list it believes it already announced, so the older
@@ -1782,6 +1926,9 @@ export function App(): React.JSX.Element {
       // Whether those words need the volume hint under them, which shares the
       // caption block's room.
       data-volume-hint={String(volumeHint)}
+      // Whether an announcement is standing under the housing, which grows
+      // the same room the caption does — the two never draw together.
+      data-notice={String(noticeShown && notice !== undefined)}
       data-presentation={presentation}
       data-notch={String(display.notch.hasNotch)}
       data-capture={String(bootstrap.captureMode)}
@@ -1911,6 +2058,35 @@ export function App(): React.JSX.Element {
           Got it
         </button>
       </span>
+
+      {/* An announcement standing under the housing: the session it names,
+          and what just happened to it. One press, and it is a row press at
+          one remove — the session opens where its provider keeps it, or the
+          panel comes forward for one with no page of its own. Always mounted,
+          like the caption, so both edges of its fade can run, and holding the
+          last notice through its own exit so the words leave in place. Inert
+          while away so nothing hidden can be pressed or tabbed to; its own
+          hit region keeps the pointer resting on it from reading as leaving
+          the shape. */}
+      <button
+        type="button"
+        className="session-notice"
+        data-hit-region={HIT_REGION.CAPSULE}
+        inert={!noticeShown || notice === undefined}
+        aria-label={notice ? `Open "${notice.title}"` : undefined}
+        // Keeps the press from moving focus here, like the capsule strip's
+        // own button, so a focused settings field keeps the caret.
+        onMouseDown={(event) => event.preventDefault()}
+        onMouseEnter={holdNotice}
+        onMouseLeave={releaseNotice}
+        onClick={openNoticedSession}
+      >
+        <span className="session-notice-title">
+          {notice ? <ProviderMark providerId={notice.popup.providerId} /> : null}
+          <span className="session-notice-name">{notice?.title}</span>
+        </span>
+        <span className="session-notice-body">{notice?.popup.body}</span>
+      </button>
 
       <div className="compact-stage">
         {/* A button, not a hover target: hovering only peeks, pressing commits.

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -641,7 +641,8 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
               "what it needs, from the agent's parting words or the provider's error line when " +
               "one was reported. No conversation needs to be open, and the microphone stays " +
               "off. Always on while voice is available; the panel and the capsule count show " +
-              "the same states either way.",
+              "the same states either way, and the same news also stands briefly as a " +
+              "pressable notice under the housing.",
           },
           {
             label: "Muted output",
@@ -680,6 +681,18 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
               `The key is entered in ${VOICE_PAGE}, at its top.`,
           },
         ]),
+    {
+      // Stated outside the voice facts because the popup needs no voice: a
+      // status change is drawn under the housing with no OpenAI key at all.
+      label: "Notice popup",
+      detail:
+        "When an observed session starts waiting, stops on an error, or finishes — and when " +
+        "Luke's background review decides one needs a person — a notice stands briefly under " +
+        "the housing naming the session and what happened. Pressing it opens the session where " +
+        "its provider keeps it, or opens the panel for a local session with no page of its own. " +
+        "It puts itself away after a few seconds and waits its turn while Luke's words are on " +
+        "screen; it is always on, and the panel and the capsule count show the same states.",
+    },
     providersFact(input.settings),
     voiceKeyFact(input.settings),
     integrationsFact(input.settings),

--- a/apps/desktop/src/renderer/session-notice-popup.ts
+++ b/apps/desktop/src/renderer/session-notice-popup.ts
@@ -1,0 +1,95 @@
+import type { SessionNoticePopup } from "../shared/contracts";
+import { PANEL_PRESENTATION, type PanelPresentation } from "./panel-state";
+
+/**
+ * The notice popup's own clocks, apart from the motion tokens on purpose:
+ * these are how long news stands, not how anything moves, so a capture run
+ * that zeroes the tokens leaves them alone.
+ */
+
+/** How long one popup stands before putting itself away. */
+export const NOTICE_POPUP_MS = 6_000;
+
+/**
+ * How long a queued popup stays worth drawing — the same span a spoken notice
+ * stays worth saying, for the same reason: news about a session is news for
+ * minutes, not for whenever the caption or the panel happens to clear. The
+ * panel has shown the state the whole time.
+ */
+export const NOTICE_POPUP_MAX_AGE_MS = 2 * 60_000;
+
+/** A backlog is stale news read in order; only this many popups ever wait. */
+export const MAXIMUM_QUEUED_POPUPS = 4;
+
+/**
+ * Whether the surface may draw a popup right now. Only the resting shapes: an
+ * open panel is already showing the session's row, and the slot and the
+ * composer are shapes someone asked for — news must not land in the middle of
+ * a key being typed. The caption shares the popup's band under the housing,
+ * so words on screen hold the popup back too; the queue is what lets the news
+ * wait for the room.
+ */
+export function noticePopupAllowed(input: {
+  presentation: PanelPresentation;
+  captionDrawn: boolean;
+}): boolean {
+  if (input.captionDrawn) return false;
+  return (
+    input.presentation === PANEL_PRESENTATION.CAPSULE ||
+    input.presentation === PANEL_PRESENTATION.PEEK
+  );
+}
+
+/**
+ * Adds announcements to the popups waiting for the surface's room, one per
+ * session: newer news about a session replaces what it had queued —
+ * Notification Center stacks stale news beside current news, and this queue
+ * exists not to — and a backlog sheds its oldest, because the oldest waiting
+ * news is the least newsworthy.
+ */
+export function enqueueNoticePopups(
+  queue: readonly SessionNoticePopup[],
+  popups: readonly SessionNoticePopup[],
+): readonly SessionNoticePopup[] {
+  let next = [...queue];
+  for (const popup of popups) {
+    next = next.filter(
+      (waiting) =>
+        waiting.providerId !== popup.providerId ||
+        waiting.providerSessionId !== popup.providerSessionId,
+    );
+    next.push(popup);
+  }
+  return next.length > MAXIMUM_QUEUED_POPUPS
+    ? next.slice(next.length - MAXIMUM_QUEUED_POPUPS)
+    : next;
+}
+
+/** A popup resolved against the roster: the fields the surface draws. */
+export interface DrawnNotice {
+  popup: SessionNoticePopup;
+  title: string;
+}
+
+/**
+ * Takes the next popup worth drawing, and the queue as it stands after.
+ * Everything inspected is consumed: news delayed past its own relevance is
+ * dropped rather than drawn as though it just happened, and a popup whose
+ * session the roster no longer titles is skipped — there is no row its press
+ * could stand for.
+ */
+export function takeNoticePopup(
+  queue: readonly SessionNoticePopup[],
+  now: number,
+  titleFor: (popup: SessionNoticePopup) => string | undefined,
+): { queue: readonly SessionNoticePopup[]; drawn?: DrawnNotice } {
+  const fresh = queue.filter((popup) => now - popup.decidedAt <= NOTICE_POPUP_MAX_AGE_MS);
+  for (let index = 0; index < fresh.length; index += 1) {
+    const popup = fresh[index];
+    if (!popup) continue;
+    const title = titleFor(popup);
+    if (title === undefined) continue;
+    return { queue: fresh.slice(index + 1), drawn: { popup, title } };
+  }
+  return { queue: [] };
+}

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -171,6 +171,13 @@
      caption states below raise it, and every other state leaves the capsule's
      own height. */
   --caption-growth: 0px;
+  /* The notice popup's band under the housing: a session's name and the line
+     saying what just happened. Fixed rather than measured — the name and the
+     body both truncate into it — so the surface springs to one destination,
+     and small enough to fit inside the `--caption-max` room the compact
+     window already reserves: the popup borrows the caption's band, and the
+     two never draw together. */
+  --notice-size: 52px;
   /* Wide enough for a key, a way out, and a way on, and no wider — the page the
      key was copied from is behind this and has to stay readable. The floor is
      what those three need on a display with no housing to grow from. */
@@ -371,6 +378,7 @@ button:disabled {
    housing: a shape that has left the housing's footprint needs the depth, and
    one still inside it must stay indistinguishable from the hardware. */
 .app-stage[data-presentation="capsule"][data-caption="true"] .panel-surface,
+.app-stage[data-presentation="capsule"][data-notice="true"] .panel-surface,
 .app-stage[data-presentation="peek"] .panel-surface,
 .app-stage[data-presentation="slot"] .panel-surface,
 .app-stage[data-presentation="feedback"] .panel-surface,
@@ -1358,6 +1366,140 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 
 .volume-hint-dismiss:hover {
   background: var(--raised-strong);
+}
+
+/* Session notice popup ----------------------------------------------------- */
+
+/* An announcement standing under the housing: the surface grows the caption's
+   own band to hold the session's name and what just happened to it. The two
+   never draw together — the queue holds a popup back while words are being
+   spoken — so the band is borrowed, never contended, and the compact window
+   already holds the room. */
+.app-stage[data-presentation="capsule"][data-notice="true"],
+.app-stage[data-presentation="peek"][data-notice="true"] {
+  --caption-growth: var(--notice-size);
+}
+
+/* While a notice stands, the capsule holds the peek's width, exactly as the
+   caption's states do: the popup lays out at one width in every state, so a
+   pointer arriving mid-notice morphs the wings and moves the words not at
+   all. Growing leads — the base rule's delay is for leaving. */
+.app-stage[data-presentation="capsule"][data-notice="true"] .panel-surface {
+  width: var(--peek-width);
+  transform: translate(-50%, var(--shape-top, 0px));
+  transition-duration: var(--duration-shape);
+  transition-delay: 0s;
+}
+
+.app-stage[data-presentation="capsule"][data-notice="true"] .compact-hover-target {
+  width: var(--peek-width);
+  transform: translateX(-50%);
+}
+
+/* The press target covers the notice band as well as the strip, for the
+   caption's reason: the popup is drawn on the shape, and a shape the pointer
+   is over must keep taking the pointer. */
+.app-stage[data-presentation="capsule"][data-notice="true"] .compact-hover-target,
+.app-stage[data-presentation="peek"][data-notice="true"] .compact-hover-target {
+  height: calc(var(--capsule-height) + var(--caption-growth));
+}
+
+.app-stage[data-notch="false"][data-presentation="capsule"][data-notice="true"]
+  .compact-hover-target,
+.app-stage[data-notch="false"][data-presentation="peek"][data-notice="true"] .compact-hover-target {
+  height: calc(var(--capsule-height) - var(--shape-top) * 2 + var(--caption-growth));
+}
+
+/* The popup itself: one pressable block in the band the surface grew. The box
+   is the caption's twin — same berth under the housing, same lift carried in
+   the transform — and its reveal is the caption's too: the clip springs to
+   the same edge the surface's height does, so the words are uncovered by the
+   black arriving under them rather than drawn on the desktop. Above the hover
+   strip (z-index 4) because the whole block is the one button on the compact
+   shape besides the strip: the press has to open the session. */
+.session-notice {
+  position: absolute;
+  z-index: 5;
+  top: var(--capsule-height);
+  left: 50%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  width: calc(var(--peek-width) - var(--notch-convex-radius) * 2);
+  height: var(--notice-size);
+  padding: 0 0 6px;
+  background: none;
+  clip-path: inset(0 0 var(--notice-size) 0);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, calc(0px - var(--shape-top, 0px)));
+  /* The clip waits out `--duration-exit` like the surface does: leaving, the
+     words fade first and the edge follows them up under the housing. */
+  transition:
+    opacity var(--duration-exit) var(--motion-exit),
+    clip-path var(--duration-shape) var(--spring) var(--duration-exit);
+}
+
+/* Arrives the way the caption's first words do — the fade crossing the last
+   of the shape's travel, the clip riding the shape's own spring with no
+   delay: it is the shape's twin, not content following it. Takes the pointer
+   only while it is drawn, because everything a hidden button covers is
+   desktop. */
+.app-stage[data-presentation="capsule"][data-notice="true"] .session-notice,
+.app-stage[data-presentation="peek"][data-notice="true"] .session-notice {
+  clip-path: inset(0 0 0 0);
+  opacity: 1;
+  pointer-events: auto;
+  transition:
+    opacity var(--duration-quick) var(--motion-exit)
+    calc(var(--duration-shape) - var(--duration-quick)),
+    clip-path var(--duration-shape) var(--spring);
+}
+
+/* The session's name, marked by its provider the way its row is. The mark
+   rides at the row's own size; the name truncates rather than wrapping, so
+   the band never asks for more height than the surface grew. */
+.session-notice-title {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  max-width: 100%;
+  color: var(--text-primary);
+  font-size: 11px;
+  font-weight: 640;
+  line-height: 14px;
+}
+
+.session-notice-title .provider-mark {
+  flex: 0 0 auto;
+  width: 12px;
+  height: 12px;
+}
+
+.session-notice-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* What just happened, in the caption's own quiet grey: the popup arriving is
+   what asks for the eye, and the session's name above already carries the
+   line's weight. An evaluator's sentence can run long, so it wraps once and
+   then truncates. */
+.session-notice-body {
+  display: -webkit-box;
+  overflow: hidden;
+  max-width: 100%;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1px;
+  line-height: 13px;
+  text-align: center;
 }
 
 /* Waveform --------------------------------------------------------------- */

--- a/apps/desktop/src/session-notifications.ts
+++ b/apps/desktop/src/session-notifications.ts
@@ -6,6 +6,7 @@ import {
   type SessionNotice,
   type SessionNoticeStatus,
 } from "@sidecar/core";
+import type { SessionNoticePopup } from "./shared/contracts";
 
 /**
  * Carries one notice to the voice as the bounded fields it was observed as —
@@ -138,4 +139,59 @@ export function sessionNoticeSpeech(notice: SessionNotice, decidedAt: number): A
     summary: noticeUpdateContext(notice),
     decidedAt,
   };
+}
+
+/** Where the session runs, the way the popup's line takes it, or nothing. */
+function noticePlace(notice: SessionNotice): string {
+  const place = notice.repository ?? notice.branch;
+  return place ? ` on ${flattened(place)}` : "";
+}
+
+/**
+ * The line the notice popup draws under the session's name. The popup titles
+ * itself with the name and the provider from the roster the renderer already
+ * holds, so — unlike the spoken update, which arrives with nothing else on
+ * screen — this line says only what just happened.
+ */
+function noticePopupBody(notice: SessionNotice): string {
+  switch (notice.status) {
+    case SESSION_NOTICE_STATUS.WAITING:
+      return `Waiting on you${noticePlace(notice)}.`;
+    case SESSION_NOTICE_STATUS.ERROR:
+      // The provider's own reason when it gave one — already bounded by
+      // normalization, never a transcript.
+      return notice.error
+        ? `Stopped: ${notice.error}`
+        : `Stopped on an error${noticePlace(notice)}.`;
+    case SESSION_NOTICE_STATUS.COMPLETE:
+      return `Finished${noticePlace(notice)}.`;
+    default:
+      throw new Error(`Unknown notice status: ${String(notice.status)}`);
+  }
+}
+
+/** One status edge as the popup the surface draws under the housing. */
+export function sessionNoticePopup(notice: SessionNotice, decidedAt: number): SessionNoticePopup {
+  return {
+    providerId: notice.providerId,
+    providerSessionId: notice.providerSessionId,
+    body: noticePopupBody(notice),
+    decidedAt,
+  };
+}
+
+/**
+ * An evaluator's speaking decisions as popups. The decided sentence was worded
+ * to be said aloud, so it already carries its own subject; the popup's title
+ * above it only makes the session it names pressable.
+ */
+export function attentionSpeechPopups(
+  speech: readonly AttentionSpeech[],
+): readonly SessionNoticePopup[] {
+  return speech.map((item) => ({
+    providerId: item.providerId,
+    providerSessionId: item.providerSessionId,
+    body: item.summary,
+    decidedAt: item.decidedAt,
+  }));
 }

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -239,6 +239,20 @@ export type SessionTranscriptResult =
   | { status: typeof SESSION_TRANSCRIPT_RESULT_STATUS.REJECTED; reason: string }
   | { status: typeof SESSION_TRANSCRIPT_RESULT_STATUS.UNSUPPORTED; reason: string };
 
+/**
+ * One announcement on its way to the notice popup the surface draws under the
+ * housing. It names the session and carries the line to draw beneath its name;
+ * the renderer looks the name itself up in the roster it already holds, so a
+ * popup for a session no longer worth a row simply finds nothing to draw.
+ * `decidedAt` is when the announcement was decided on — a queued popup older
+ * than the news it carries is dropped rather than shown as though it just
+ * happened.
+ */
+export interface SessionNoticePopup extends SessionIdentity {
+  body: string;
+  decidedAt: number;
+}
+
 export interface DisplayDiagnostic {
   id: number;
   label: string;
@@ -544,6 +558,14 @@ export interface AppBridge {
   /** The issue roster as last observed; `undefined` says no tracker is connected. */
   onIssuesChanged(callback: (issues: readonly TrackedIssue[] | undefined) => void): () => void;
   onAttentionSpeech(callback: (speech: readonly AttentionSpeech[]) => void): () => void;
+  /**
+   * The announcements the main process just decided on, for the notice popup
+   * the surface draws under the housing. The same two deciders that feed the
+   * spoken announcements — the deterministic status edges and the attention
+   * evaluator — and nothing else; unlike the speech, it needs no voice
+   * credential, so a session's news is pressable with no key at all.
+   */
+  onSessionNotices(callback: (popups: readonly SessionNoticePopup[]) => void): () => void;
   /** The talk key going down, from whatever app happened to be frontmost. */
   onVoiceHotkeyPress(callback: () => void): () => void;
   /** The same key being let go of, which is what ends a held turn. */
@@ -615,6 +637,7 @@ export const channels = {
   focusPanel: "app:focus-panel",
   requestRealtimeCredential: "app:request-realtime-credential",
   attentionSpeech: "app:attention-speech",
+  sessionNotices: "app:session-notices",
   voiceHotkeyPress: "app:voice-hotkey-press",
   voiceHotkeyRelease: "app:voice-hotkey-release",
   voiceHotkeyChanged: "app:voice-hotkey-changed",

--- a/apps/desktop/tests/session-notice-popup.test.ts
+++ b/apps/desktop/tests/session-notice-popup.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { PANEL_PRESENTATION } from "../src/renderer/panel-state";
+import {
+  enqueueNoticePopups,
+  MAXIMUM_QUEUED_POPUPS,
+  NOTICE_POPUP_MAX_AGE_MS,
+  noticePopupAllowed,
+  takeNoticePopup,
+} from "../src/renderer/session-notice-popup";
+import type { SessionNoticePopup } from "../src/shared/contracts";
+
+function popup(overrides: Partial<SessionNoticePopup> = {}): SessionNoticePopup {
+  return {
+    providerId: "claude-code",
+    providerSessionId: "run:1",
+    body: "Finished on luke.",
+    decidedAt: 1_000,
+    ...overrides,
+  };
+}
+
+/** Titles every session, the way a roster that still holds them all would. */
+function anyTitle(): string {
+  return "Implement better notifications";
+}
+
+test("the resting shapes may draw a popup; every other state holds it back", () => {
+  assert.equal(
+    noticePopupAllowed({ presentation: PANEL_PRESENTATION.CAPSULE, captionDrawn: false }),
+    true,
+  );
+  assert.equal(
+    noticePopupAllowed({ presentation: PANEL_PRESENTATION.PEEK, captionDrawn: false }),
+    true,
+  );
+  // The open panel is already showing the session's row, and the slot and the
+  // composer are shapes someone asked for.
+  assert.equal(
+    noticePopupAllowed({ presentation: PANEL_PRESENTATION.PANEL, captionDrawn: false }),
+    false,
+  );
+  assert.equal(
+    noticePopupAllowed({ presentation: PANEL_PRESENTATION.SLOT, captionDrawn: false }),
+    false,
+  );
+  assert.equal(
+    noticePopupAllowed({ presentation: PANEL_PRESENTATION.FEEDBACK, captionDrawn: false }),
+    false,
+  );
+});
+
+test("words on screen hold the popup back: the caption owns the same band", () => {
+  assert.equal(
+    noticePopupAllowed({ presentation: PANEL_PRESENTATION.CAPSULE, captionDrawn: true }),
+    false,
+  );
+});
+
+test("popups come back out in arrival order", () => {
+  const queue = enqueueNoticePopups(
+    [],
+    [popup(), popup({ providerSessionId: "run:2", body: "Waiting on you." })],
+  );
+
+  const first = takeNoticePopup(queue, 1_000, anyTitle);
+  assert.equal(first.drawn?.popup.providerSessionId, "run:1");
+  assert.equal(first.drawn?.title, "Implement better notifications");
+  const second = takeNoticePopup(first.queue, 1_000, anyTitle);
+  assert.equal(second.drawn?.popup.providerSessionId, "run:2");
+  assert.equal(second.queue.length, 0);
+});
+
+test("newer news about a session replaces what it had queued", () => {
+  let queue = enqueueNoticePopups([], [popup({ body: "Waiting on you." })]);
+  queue = enqueueNoticePopups(queue, [popup({ body: "Finished on luke.", decidedAt: 2_000 })]);
+
+  const { queue: rest, drawn } = takeNoticePopup(queue, 2_000, anyTitle);
+  assert.equal(drawn?.popup.body, "Finished on luke.");
+  // The stale entry went with its replacement; nothing else waits.
+  assert.equal(rest.length, 0);
+});
+
+test("news delayed past its own relevance is dropped rather than drawn", () => {
+  const queue = enqueueNoticePopups([], [popup({ decidedAt: 1_000 })]);
+
+  const { queue: rest, drawn } = takeNoticePopup(
+    queue,
+    1_000 + NOTICE_POPUP_MAX_AGE_MS + 1,
+    anyTitle,
+  );
+  assert.equal(drawn, undefined);
+  assert.equal(rest.length, 0);
+});
+
+test("a popup whose session the roster no longer titles is skipped", () => {
+  const queue = enqueueNoticePopups(
+    [],
+    [popup(), popup({ providerSessionId: "run:2", body: "Waiting on you." })],
+  );
+
+  const { queue: rest, drawn } = takeNoticePopup(queue, 1_000, (candidate) =>
+    candidate.providerSessionId === "run:2" ? "Still rostered" : undefined,
+  );
+  // There is no row the first popup's press could stand for, so the second is
+  // what gets drawn — and everything inspected was consumed.
+  assert.equal(drawn?.popup.providerSessionId, "run:2");
+  assert.equal(drawn?.title, "Still rostered");
+  assert.equal(rest.length, 0);
+});
+
+test("a backlog sheds its oldest: only so many popups ever wait", () => {
+  const queue = enqueueNoticePopups(
+    [],
+    Array.from({ length: MAXIMUM_QUEUED_POPUPS + 2 }, (_, index) =>
+      popup({ providerSessionId: `run:${index}` }),
+    ),
+  );
+
+  assert.equal(queue.length, MAXIMUM_QUEUED_POPUPS);
+  // The first two are gone; the survivors read out in order.
+  assert.equal(takeNoticePopup(queue, 1_000, anyTitle).drawn?.popup.providerSessionId, "run:2");
+});

--- a/apps/desktop/tests/session-notifications.test.ts
+++ b/apps/desktop/tests/session-notifications.test.ts
@@ -7,7 +7,11 @@ import {
   SESSION_STATUS,
   type SessionNotice,
 } from "@sidecar/core";
-import { sessionNoticeSpeech } from "../src/session-notifications";
+import {
+  attentionSpeechPopups,
+  sessionNoticePopup,
+  sessionNoticeSpeech,
+} from "../src/session-notifications";
 
 function notice(overrides: Partial<SessionNotice> = {}): SessionNotice {
   return {
@@ -211,4 +215,52 @@ test("a value cannot close its own quotes to forge a field", () => {
   // The build's own fields still say what the observation said.
   assert.ok(summary.includes("event: started waiting on the developer"));
   assert.match(summary, /takes a reply now: no$/);
+});
+
+test("a notice becomes a popup whose line leaves the naming to the title", () => {
+  assert.deepEqual(sessionNoticePopup(notice({ repository: "luke" }), 5_000), {
+    providerId: "claude-code",
+    providerSessionId: "run:1",
+    body: "Finished on luke.",
+    decidedAt: 5_000,
+  });
+  assert.equal(
+    sessionNoticePopup(notice({ status: SESSION_NOTICE_STATUS.WAITING, branch: "algiers" }), 0)
+      .body,
+    "Waiting on you on algiers.",
+  );
+  assert.equal(
+    sessionNoticePopup(notice({ status: SESSION_NOTICE_STATUS.ERROR }), 0).body,
+    "Stopped on an error.",
+  );
+  // The provider's own reason rides along when it gave one — already bounded
+  // by normalization, never a transcript.
+  assert.equal(
+    sessionNoticePopup(notice({ status: SESSION_NOTICE_STATUS.ERROR, error: "API rate limit" }), 0)
+      .body,
+    "Stopped: API rate limit",
+  );
+});
+
+test("evaluator speech becomes popups carrying the decided sentence", () => {
+  assert.deepEqual(
+    attentionSpeechPopups([
+      {
+        providerId: "conductor",
+        providerSessionId: "workspace:9",
+        disposition: ATTENTION_DISPOSITION.SPEAK_AT_TURN_END,
+        source: ATTENTION_SPEECH_SOURCE.EVALUATOR,
+        summary: "The tests are failing and the session is waiting on a decision.",
+        decidedAt: 1_000,
+      },
+    ]),
+    [
+      {
+        providerId: "conductor",
+        providerSessionId: "workspace:9",
+        body: "The tests are failing and the session is waiting on a decision.",
+        decidedAt: 1_000,
+      },
+    ],
+  );
 });


### PR DESCRIPTION
## Summary

When an observed session starts waiting, stops on an error, or finishes — and when the attention evaluator decides one needs a person — the surface now grows a **notice popup under the housing** naming the session and what just happened. Pressing it is a row press at one remove: the session's provider-reported address goes to the operating system, or the panel opens for a local session that reported none.

- **Same deciders, no new judgment.** The popup is fed by the deterministic status edges and the evaluator's speaking decisions over a new `app:session-notices` broadcast — the same two sources as the spoken announcements. It needs no voice credential, so status edges are pressable with no OpenAI key at all.
- **DESIGN.md choreography.** The popup rides the caption's band inside the compact window's reserved `--caption-max` room (no window resize, no IPC): a fixed-height block whose room lands at once, revealed by a clip riding the surface's own spring, fading over `--duration-exit` before the surface shrinks. It stays mounted through its exit holding its last notice.
- **One at a time.** Newer news replaces a session's queued news, waited news expires after two minutes, the popup yields to the caption and to any shape someone asked for (panel, slot, composer), holds while the pointer rests on it, and puts itself away after six seconds.
- Subtext is the caption's quiet grey; the title carries the provider mark and truncates.
- Guide facts, AGENTS.md trust language, README, and PRIVACY.md updated; queue logic is a pure module with unit tests.

## Testing

- `./scripts/check.sh` passes: repository checks, typecheck, 172 core + 849 desktop + 5 web + 34 root tests, and builds.
- Not run: `./scripts/verify.sh` (macOS-only; this change was authored in a Linux cloud workspace). The popup's motion should be sampled and eyeballed against a real notch per DESIGN.md's proving rule before/after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/61ed8e24-555d-4214-8024-5bef7b7c258d)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31996289722/artifacts/9276939400) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31996289722)

- Commit: `6420f89b8c9c8ccc8e62b249b6c00ec054d7b5a3`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
