### PR TITLE
fix(desktop): keep the caption clear of settings pages

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -205,7 +205,12 @@ function useShapeHeight(): [(element: HTMLElement | null) => void, number | unde
     if (!element) return;
     const measure = () => setHeight(Math.ceil(element.getBoundingClientRect().height));
     const nextObserver = new ResizeObserver(measure);
-    nextObserver.observe(element);
+    // The border box, because that is the box the bounding rect reports: the
+    // caption's room arrives as padding on the panel, which grows the shape
+    // without ever touching the content box, and a content-box observer would
+    // sleep through it — leaving the surface and the caption's rest position
+    // sized to a height the panel no longer has.
+    nextObserver.observe(element, { box: "border-box" });
     observer.current = nextObserver;
     measure();
   }, []);

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -143,6 +143,23 @@
   --scroll-fade: 26px;
 }
 
+/* How every scroll container in the panel meets its bottom edge: content
+   dissolves into the surface over `--scroll-fade` rather than being sliced,
+   and the fade lifts as the last row arrives. A scroll timeline is exactly
+   the right tool: with nothing to scroll it never becomes active, so content
+   that fits is left alone without asking JavaScript whether it overflows.
+   Shared here because the session list and the settings tab must meet the
+   caption riding below them the same way. */
+@keyframes scroll-edge-fade {
+  from {
+    mask-image: linear-gradient(to bottom, #000 calc(100% - var(--scroll-fade)), transparent 100%);
+  }
+
+  to {
+    mask-image: linear-gradient(to bottom, #000 100%, transparent 100%);
+  }
+}
+
 .app-stage {
   /* Mirrors CAPSULE_SIDE_WIDTH and PEEK_SIDE_GROWTH in
      packages/sidecar-core/src/geometry.ts, so the drawn shapes match the window

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -427,22 +427,11 @@
   overscroll-behavior: contain;
   scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
   scrollbar-width: thin;
-  /* Rows dissolve into the panel rather than being cut off at its edge, and the
-     fade lifts as the last row arrives. A scroll timeline is exactly the right
-     tool: with nothing to scroll it never becomes active, so a list that fits
-     is left alone without asking JavaScript whether it overflows. */
-  animation: session-scroll-fade linear both;
+  /* Rows dissolve into the panel rather than being cut off at its edge — the
+     shared fade in base.css, which the settings tab meets the caption with
+     too. */
+  animation: scroll-edge-fade linear both;
   animation-timeline: scroll(self block);
-}
-
-@keyframes session-scroll-fade {
-  from {
-    mask-image: linear-gradient(to bottom, #000 calc(100% - var(--scroll-fade)), transparent 100%);
-  }
-
-  to {
-    mask-image: linear-gradient(to bottom, #000 100%, transparent 100%);
-  }
 }
 
 /* Both kinds of row: the ones a provider gave an address for are buttons and

--- a/apps/desktop/src/renderer/styles/settings.css
+++ b/apps/desktop/src/renderer/styles/settings.css
@@ -1,7 +1,9 @@
 /* The settings tab: pages of rows, credentials, and the controls that write them. */
 
 /* Scrolls on the same terms as the session list: contained, never chaining out
-   to the root, with the tab bar left outside the scrolling box. */
+   to the root, with the tab bar left outside the scrolling box, and dissolving
+   at its foot through the same shared fade — a page taller than the panel must
+   melt into the surface above Luke's caption, not be sliced off against it. */
 .settings {
   display: flex;
   min-height: 0;
@@ -13,6 +15,8 @@
   overscroll-behavior: contain;
   scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
   scrollbar-width: thin;
+  animation: scroll-edge-fade linear both;
+  animation-timeline: scroll(self block);
 }
 
 .settings-section {


### PR DESCRIPTION
## What

Two fixes for how Luke's caption meets the Settings tab:

- **Short nested pages (Keyboard shortcuts, Appearance): the caption overlapped the rows.** The caption reserves its room as bottom padding on `.expanded-panel`, but `useShapeHeight`'s ResizeObserver watched the default content box, which a padding-only change never touches. `--panel-height` went stale, so the surface stopped short and the caption's rest position landed on top of the page's own content. Tall pages hid the bug because they sit pinned at `max-height: 520px` with or without a caption. The observer now watches the border box — the same box the measurement's `getBoundingClientRect()` already reports.
- **Scrollable pages (Connections, and the front page mid-scroll): content was sliced hard against the caption.** The session list dissolves through a scroll-driven mask before the Ask Luke composer; the settings scroll container had no such fade, so rows were cut off mid-row right above the caption's words. The keyframes move to `base.css` as `scroll-edge-fade`, next to the `--scroll-fade` token they spend, and both scroll containers now share them. Session list behavior is unchanged.

## Verification

- Driven headlessly on Linux (Electron under Xvfb, `--fixture smoke`, CDP): Shortcuts and Appearance with a full-height caption now grow the surface to hold the caption band with the reserved gap intact, and the panel shrinks back when the caption clears; Connections dissolves through the 26px fade mid-scroll and the fade lifts at scroll end; the Sessions tab renders identically before and after.
- `./scripts/check.sh` passes.
- `./scripts/verify.sh` was not run (Linux sandbox); no physical-notch check was performed. CI evidence below is the canonical visual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/34493ddc-f1ab-4cf2-b8ad-d0264ff27018)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31999824713/artifacts/9278031748) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31999824713)

- Commit: `ca2192e97ca4d89260f608e583a6c43b6e0e20fb`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
