### PR TITLE
fix(conductor): drop archived chats from the session roster

### DIFF
--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -141,7 +141,8 @@ const CONDUCTOR_ARCHIVE_WORKSPACE_CONTROL_ID = "archive-workspace";
 /**
  * The workspace-level control: Conductor documents archiving a workspace,
  * which files away every chat in it at once. It is advertised on a chat's row
- * only once every chat in that workspace was positively seen settled — a
+ * only once every still-open chat in that workspace was positively seen
+ * settled — a
  * workspace mid-turn has a stop to offer, not a filing away, and one whose
  * state could not be read is not known to have stopped — and the workspace it
  * acts on rides the advertisement as the control's target, so a press
@@ -355,11 +356,16 @@ interface ConductorWorkspace {
   lastActivityAt: number;
 }
 
+/**
+ * A chat still open on Conductor's own surface. An archived chat never becomes
+ * one of these, for the same reason an archived workspace never becomes a
+ * `ConductorWorkspace`: filing a chat away is how a user says that one
+ * conversation is done being watched, so the listing drops it before its
+ * status or transcript is ever asked for.
+ */
 interface ConductorSession {
   id: string;
   workspace: ConductorWorkspace;
-  archived: boolean;
-  archivedAt?: number;
   name?: string;
   model?: string;
   deepLink?: string;
@@ -368,9 +374,11 @@ interface ConductorSession {
 /**
  * Observes Conductor cloud sessions through the documented public API. It reads
  * only workspaces the authenticated user created and left open — a workspace
- * filed away on Conductor's own surface is dropped whole, its chats with it —
- * observation issues no request that can change provider state, and it reports
- * nothing at all without a credential. Beside the roster reads, one fixed query to Conductor's
+ * filed away on Conductor's own surface is dropped whole, its chats with it,
+ * and a chat filed away on its own is dropped the same way from a workspace
+ * that stays — observation issues no request that can change provider state,
+ * and it reports nothing at all without a credential. Beside the roster
+ * reads, one fixed query to Conductor's
  * transcripts view names the sessions the same pass observed and takes back
  * each chat's agent kind and the bounded tail its recap — the settled turn's
  * parting words — is read from; the history behind that tail is never asked
@@ -550,11 +558,7 @@ export class ConductorSessionAdapter
       this.#sessionTranscripts(request, sessions).catch(() => undefined),
       Promise.all(
         sessions.map((session) =>
-          // An archived session is a closed chat, so its state is already
-          // settled and no status request is needed.
-          session.archived
-            ? Promise.resolve(undefined)
-            : this.tolerateItemFailure(() => this.#sessionStatus(request, session.id)),
+          this.tolerateItemFailure(() => this.#sessionStatus(request, session.id)),
         ),
       ),
       Promise.all(
@@ -568,16 +572,16 @@ export class ConductorSessionAdapter
     ]);
 
     // The workspaces every observed chat of which was positively seen settled
-    // — closed, or reporting idle or errored — judged from this pass's own
-    // statuses. An archive is a workspace-level act, so it is offered only for
-    // these: a chat still working, and just as much one whose status could not
-    // be read at all, keeps the whole workspace off the list, because filing
-    // away a workspace whose state Luke has not actually seen stop could take
-    // a live turn with it.
+    // — reporting idle or errored — judged from this pass's own statuses. An
+    // archive is a workspace-level act, so it is offered only for these: a
+    // chat still working, and just as much one whose status could not be read
+    // at all, keeps the whole workspace off the list, because filing away a
+    // workspace whose state Luke has not actually seen stop could take a live
+    // turn with it. The chats already filed away never reached this pass, so
+    // they neither settle a workspace nor hold one open.
     const settledWorkspaceIds = new Set(sessions.map((session) => session.workspace.id));
     sessions.forEach((session, index) => {
       const settled =
-        session.archived ||
         reportedStatuses[index]?.status === CONDUCTOR_SESSION_STATUS.IDLE ||
         reportedStatuses[index]?.status === CONDUCTOR_SESSION_STATUS.ERROR;
       if (!settled) settledWorkspaceIds.delete(session.workspace.id);
@@ -682,40 +686,34 @@ export class ConductorSessionAdapter
       ],
       { [CONDUCTOR_QUERY.LIMIT]: String(CONDUCTOR_ADAPTER_DEFAULTS.SESSION_PAGE_SIZE) },
     );
-    return (
-      recordsFromPage(body, CONDUCTOR_FIELD.DATA)
-        .map((record): ConductorSession | undefined => {
-          const id = textFromRecord(record, CONDUCTOR_FIELD.ID);
-          if (!id) return undefined;
-          const archivedAt = timestampFromRecord(record, CONDUCTOR_FIELD.ARCHIVED_AT);
-          const model = modelLabel(record);
-          const deepLink = textFromRecord(record, CONDUCTOR_FIELD.DEEP_LINK);
-          // The chat's own name tells it from its siblings now that every chat
-          // is a row of its own; the workspace's name moved to the group.
-          const name = textFromRecord(record, CONDUCTOR_FIELD.NAME)?.slice(
-            0,
-            maximumSessionTitleLength,
-          );
-          return {
-            id,
-            workspace,
-            archived: archivedAt !== undefined,
-            ...(archivedAt === undefined ? {} : { archivedAt }),
-            ...(name ? { name } : {}),
-            ...(model ? { model } : {}),
-            ...(deepLink ? { deepLink } : {}),
-          };
-        })
-        .filter(isDefined)
-        // An open chat carries no timestamp until its status is read, so open
-        // chats are ordered before closed ones, then closed ones by how
-        // recently they closed.
-        .sort(
-          (first, second) =>
-            Number(first.archived) - Number(second.archived) ||
-            (second.archivedAt ?? 0) - (first.archivedAt ?? 0),
-        )
-    );
+    return recordsFromPage(body, CONDUCTOR_FIELD.DATA)
+      .map((record): ConductorSession | undefined => {
+        const id = textFromRecord(record, CONDUCTOR_FIELD.ID);
+        if (!id) return undefined;
+        // An archived chat was filed away on Conductor's own surface, so it
+        // does not belong on the roster any more than an archived workspace
+        // does: it is dropped here, before its status or transcript is ever
+        // asked for. Its workspace stays, carrying only the chats still open.
+        if (timestampFromRecord(record, CONDUCTOR_FIELD.ARCHIVED_AT) !== undefined) {
+          return undefined;
+        }
+        const model = modelLabel(record);
+        const deepLink = textFromRecord(record, CONDUCTOR_FIELD.DEEP_LINK);
+        // The chat's own name tells it from its siblings now that every chat
+        // is a row of its own; the workspace's name moved to the group.
+        const name = textFromRecord(record, CONDUCTOR_FIELD.NAME)?.slice(
+          0,
+          maximumSessionTitleLength,
+        );
+        return {
+          id,
+          workspace,
+          ...(name ? { name } : {}),
+          ...(model ? { model } : {}),
+          ...(deepLink ? { deepLink } : {}),
+        };
+      })
+      .filter(isDefined);
   }
 
   protected override workspaceAgentRoute(
@@ -811,38 +809,27 @@ export class ConductorSessionAdapter
   ): ProviderSessionObservation | undefined {
     // A workspace timestamp covers every chat in that workspace, so it would
     // make chats a user left hours ago look like they just stopped. The status
-    // timestamp is per-session, and a closed chat's archive time is the moment
-    // it settled; the workspace timestamp is only the last resort.
-    const observedAt =
-      reported?.updatedAt ?? session.archivedAt ?? session.workspace.lastActivityAt;
-    const status = this.#statusFor(session, reported?.status, observedAt, now);
+    // timestamp is per-session; the workspace timestamp is only the last
+    // resort.
+    const observedAt = reported?.updatedAt ?? session.workspace.lastActivityAt;
+    const status = this.#statusFor(reported?.status, observedAt, now);
     // The parting words are a recap only once the turn has actually parted:
-    // read for an idle or closed chat, they say where the agent left the work;
-    // read mid-turn they are half a sentence posing as an outcome, and read
-    // beside a failure they predate the thing the row now has to say.
+    // read for an idle chat, they say where the agent left the work; read
+    // mid-turn they are half a sentence posing as an outcome, and read beside
+    // a failure they predate the thing the row now has to say.
     const recap =
-      session.archived || reported?.status === CONDUCTOR_SESSION_STATUS.IDLE
-        ? transcript?.recap
-        : undefined;
+      reported?.status === CONDUCTOR_SESSION_STATUS.IDLE ? transcript?.recap : undefined;
     const model = agentAndModelLabel(transcript?.agentKind, session.model);
     // The workspace's own words for why its chats are quiet, and its own
-    // failure message when standing it up went wrong. Both belong only to the
-    // open chats: a closed one is settled, and the machinery around it must
-    // not bump its recap or dress a complete row as newly failed. A session's
-    // reported error is about the turn the user is watching, so it always
-    // outranks the machinery's.
-    const activity =
-      !session.archived && lifecycle?.status
-        ? CONDUCTOR_WORKSPACE_ACTIVITY[lifecycle.status]
-        : undefined;
-    const error = session.archived
-      ? undefined
-      : (reported?.errorMessage ?? lifecycle?.errorMessage);
+    // failure message when standing it up went wrong. A session's reported
+    // error is about the turn the user is watching, so it always outranks the
+    // machinery's.
+    const activity = lifecycle?.status ? CONDUCTOR_WORKSPACE_ACTIVITY[lifecycle.status] : undefined;
+    const error = reported?.errorMessage ?? lifecycle?.errorMessage;
     // The stop belongs to the turn and the archive to the workspace: a chat
     // mid-turn offers the stop alone — its own workspace is by definition
     // unsettled — and any chat of a positively settled workspace offers to
-    // file the whole workspace away, closed chats included, because a closed
-    // chat's row is exactly where tidying up happens. Every workspace here is
+    // file the whole workspace away. Every workspace and every chat here is
     // still open: the filed-away ones never made it past the listing.
     const controls = [
       ...(reported?.status === CONDUCTOR_SESSION_STATUS.WORKING ? [CONDUCTOR_CANCEL_CONTROL] : []),
@@ -869,12 +856,10 @@ export class ConductorSessionAdapter
       },
       // Conductor documents both halves of a send — queued while a session is
       // idle, steered into the turn while it works — so any open chat takes a
-      // message. A closed one is settled, and an errored one is documented for
-      // no writer.
+      // message. An errored one is documented for no writer.
       canReceiveMessage:
-        !session.archived &&
-        (reported?.status === CONDUCTOR_SESSION_STATUS.IDLE ||
-          reported?.status === CONDUCTOR_SESSION_STATUS.WORKING),
+        reported?.status === CONDUCTOR_SESSION_STATUS.IDLE ||
+        reported?.status === CONDUCTOR_SESSION_STATUS.WORKING,
       // Another agent lands in the workspace around this row, whatever state
       // the row's own chat is in: the workspace was observed this pass, and
       // that is the thing the creation endpoint takes. Its id rides the
@@ -895,12 +880,10 @@ export class ConductorSessionAdapter
   }
 
   #statusFor(
-    session: ConductorSession,
     reportedStatus: ConductorSessionStatus | undefined,
     observedAt: number,
     now: number,
   ): SessionStatus {
-    if (session.archived) return SESSION_STATUS.COMPLETE;
     if (!reportedStatus) return SESSION_STATUS.UNKNOWN;
     return agedStatus(
       SESSION_STATUS_BY_CONDUCTOR_STATUS[reportedStatus],

--- a/apps/desktop/tests/conductor-adapter.test.ts
+++ b/apps/desktop/tests/conductor-adapter.test.ts
@@ -380,14 +380,6 @@ test("words a workspace still being built onto its rows, ready and asleep say no
     sessions: [
       { id: "chat-building", workspaceId: "workspace-building", name: TEST_SESSION_NAME },
       { id: "chat-rebuilding", workspaceId: "workspace-rebuilding", name: TEST_SESSION_NAME },
-      // A closed chat beside the one being rebuilt is already settled: the
-      // machinery around it is not its news.
-      {
-        id: "chat-closed-beside",
-        workspaceId: "workspace-rebuilding",
-        name: TEST_SESSION_NAME,
-        archivedAt: isoTimestamp(TEST_TIME - 60_000),
-      },
       { id: "chat-ready", workspaceId: "workspace-ready", name: TEST_SESSION_NAME },
       { id: "chat-asleep", workspaceId: "workspace-asleep", name: TEST_SESSION_NAME },
     ],
@@ -401,7 +393,6 @@ test("words a workspace still being built onto its rows, ready and asleep say no
   // Conductor's own economy, so neither takes the activity slot from a recap.
   assert.equal(byId.get("chat-building")?.detail?.activity, "Workspace initializing");
   assert.equal(byId.get("chat-rebuilding")?.detail?.activity, "Workspace updating");
-  assert.equal(byId.get("chat-closed-beside")?.detail?.activity, undefined);
   assert.equal(byId.get("chat-ready")?.detail?.activity, undefined);
   assert.equal(byId.get("chat-asleep")?.detail?.activity, undefined);
 });
@@ -439,14 +430,6 @@ test("reports the failure that kept a workspace from coming up, behind the chat'
         status: TEST_CONDUCTOR_STATUS.ERROR,
         statusUpdatedAt: TEST_TIME - 1_000,
       },
-      // A closed chat is complete, and a complete row must not be dressed as
-      // newly failed by the workspace around it.
-      {
-        id: "chat-closed-in-failed",
-        workspaceId: "workspace-failed",
-        name: TEST_SESSION_NAME,
-        archivedAt: isoTimestamp(TEST_TIME - 60_000),
-      },
     ],
   });
 
@@ -458,8 +441,6 @@ test("reports the failure that kept a workspace from coming up, behind the chat'
     "The setup script exited with status 1",
   );
   assert.equal(byId.get("chat-loudly-failed")?.detail?.error, TEST_ERROR_MESSAGE);
-  assert.equal(byId.get("chat-closed-in-failed")?.status, SESSION_STATUS.COMPLETE);
-  assert.equal(byId.get("chat-closed-in-failed")?.detail?.error, undefined);
 });
 
 test("a failed lifecycle read costs the workspace's words, never the pass", async () => {
@@ -493,7 +474,7 @@ test("a failed lifecycle read costs the workspace's words, never the pass", asyn
 });
 
 const IDLE_SESSION_UUID = "11111111-1111-4111-8111-111111111111";
-const CLOSED_SESSION_UUID = "22222222-2222-4222-8222-222222222222";
+const SECOND_IDLE_SESSION_UUID = "22222222-2222-4222-8222-222222222222";
 const WORKING_SESSION_UUID = "33333333-3333-4333-8333-333333333333";
 const ERRORED_SESSION_UUID = "44444444-4444-4444-8444-444444444444";
 
@@ -509,7 +490,7 @@ test("reads a settled chat's parting words from the transcripts view as its reca
     projects: [LUKE_PROJECT],
     workspaces: [
       ownedWorkspace("workspace-idle", TEST_TIME - 30_000),
-      ownedWorkspace("workspace-closed", TEST_TIME - 40_000),
+      ownedWorkspace("workspace-second-idle", TEST_TIME - 40_000),
     ],
     sessions: [
       {
@@ -522,14 +503,15 @@ test("reads a settled chat's parting words from the transcripts view as its reca
         status: TEST_CONDUCTOR_STATUS.IDLE,
         statusUpdatedAt: TEST_TIME - 1_000,
       },
-      // A closed chat is settled too, so its parting words still stand.
+      // A settled chat with no model reported still names its agent kind.
       {
-        id: CLOSED_SESSION_UUID,
-        workspaceId: "workspace-closed",
+        id: SECOND_IDLE_SESSION_UUID,
+        workspaceId: "workspace-second-idle",
         name: TEST_SESSION_NAME,
         agentType: "claude",
         transcriptTail: TEST_TRANSCRIPT_TAIL,
-        archivedAt: isoTimestamp(TEST_TIME - 60_000),
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 2_000,
       },
     ],
   });
@@ -538,16 +520,16 @@ test("reads a settled chat's parting words from the transcripts view as its reca
 
   assert.equal(observations.length, 2);
   const idle = observations.find((candidate) => candidate.providerSessionId === IDLE_SESSION_UUID);
-  const closed = observations.find(
-    (candidate) => candidate.providerSessionId === CLOSED_SESSION_UUID,
+  const secondIdle = observations.find(
+    (candidate) => candidate.providerSessionId === SECOND_IDLE_SESSION_UUID,
   );
   // The recap is the last message's words alone: the elision mark is dropped,
   // the header is not part of it, and nothing earlier in the tail survives.
   assert.equal(idle?.recap, TEST_RECAP);
-  assert.equal(closed?.recap, TEST_RECAP);
+  assert.equal(secondIdle?.recap, TEST_RECAP);
   // The agent kind joins the model label, and stands alone when no model came.
   assert.equal(idle?.detail?.model, "codex · gpt-5.5");
-  assert.equal(closed?.detail?.model, "claude");
+  assert.equal(secondIdle?.detail?.model, "claude");
 
   // One read document for the whole pass, fixed by the build: the SELECT this
   // build wrote, naming exactly the observed session ids and nothing else.
@@ -565,7 +547,7 @@ test("reads a settled chat's parting words from the transcripts view as its reca
       "position(reverse(E'\\n## Assistant\\n') in reverse(transcript)) AS assistant_from_end, " +
       "position(reverse(E'\\n## User\\n') in reverse(transcript)) AS user_from_end " +
       "FROM session_transcripts_view WHERE session_id IN " +
-      `('${IDLE_SESSION_UUID}', '${CLOSED_SESSION_UUID}')) AS attributed`,
+      `('${IDLE_SESSION_UUID}', '${SECOND_IDLE_SESSION_UUID}')) AS attributed`,
   });
 });
 
@@ -635,7 +617,7 @@ test("reports no recap for a tail it cannot attribute to the agent", async () =>
       // returns at the final message's own header, so this is a misbehaving
       // answer — attribution is still refused rather than assumed.
       {
-        id: CLOSED_SESSION_UUID,
+        id: SECOND_IDLE_SESSION_UUID,
         workspaceId: "workspace-headerless",
         name: TEST_SESSION_NAME,
         transcriptTail: "words with no header anywhere above them",
@@ -919,51 +901,29 @@ test("titles each chat by its own name and its group by the workspace's", async 
   );
 });
 
-// An open chat idle past the staleness window decays to unknown while an
-// archived sibling reads as complete. Both rows stand: the closed chat may say
-// it finished, but it says so beside the quiet open chat the user would return
-// to, never instead of it.
-test("a closed chat reports beside a quiet open one, not instead of it", async () => {
+// Filing a chat away is how a user says that one conversation is done being
+// watched, so it earns no row at all — however recently it was filed, and
+// whatever it was doing when it was. Its open sibling keeps its own row, and
+// the drop happens before the pass ever asks after the filed chat, so it
+// costs no status request and never enters the transcripts read.
+test("leaves a filed-away chat off the roster while its workspace stays", async () => {
   const api = fakeConductorApi({
     userId: TEST_USER_ID,
     projects: [LUKE_PROJECT],
     workspaces: [ownedWorkspace("workspace-quieted", TEST_TIME - 1_000)],
     sessions: [
       {
-        id: "session-open-stale",
+        id: "session-open",
         workspaceId: "workspace-quieted",
         name: TEST_SESSION_NAME,
         status: TEST_CONDUCTOR_STATUS.IDLE,
-        statusUpdatedAt: TEST_TIME - 2 * 60 * 60 * 1000,
+        statusUpdatedAt: TEST_TIME - 10_000,
       },
       {
         id: "session-archived",
         workspaceId: "workspace-quieted",
         name: TEST_SESSION_NAME,
         archivedAt: isoTimestamp(TEST_TIME - 10_000),
-      },
-    ],
-  });
-
-  const observations = await adapterFor(api.fetch).observe();
-  const byId = new Map(observations.map((entry) => [entry.providerSessionId, entry]));
-
-  assert.equal(observations.length, 2);
-  assert.equal(byId.get("session-open-stale")?.status, SESSION_STATUS.UNKNOWN);
-  assert.equal(byId.get("session-archived")?.status, SESSION_STATUS.COMPLETE);
-});
-
-test("reports an archived session as complete without requesting its status", async () => {
-  const api = fakeConductorApi({
-    userId: TEST_USER_ID,
-    projects: [LUKE_PROJECT],
-    workspaces: [ownedWorkspace("workspace-active", TEST_TIME - 30_000)],
-    sessions: [
-      {
-        id: "session-archived",
-        workspaceId: "workspace-active",
-        name: TEST_SESSION_NAME,
-        archivedAt: isoTimestamp(TEST_TIME - 20_000),
         status: TEST_CONDUCTOR_STATUS.WORKING,
       },
     ],
@@ -971,53 +931,21 @@ test("reports an archived session as complete without requesting its status", as
 
   const observations = await adapterFor(api.fetch).observe();
 
-  assert.equal(observations.length, 1);
-  assert.equal(observations[0]?.status, SESSION_STATUS.COMPLETE);
-  // The archive time is when the chat settled; the workspace timestamp would
-  // date it by whatever a sibling chat did since. The workspace's own
-  // lifecycle is still read; it is the chat's status that has nothing to ask.
-  assert.equal(observations[0]?.observedAt, TEST_TIME - 20_000);
+  assert.deepEqual(
+    observations.map((candidate) => candidate.providerSessionId),
+    ["session-open"],
+  );
+  // The filed-away chat neither settles the workspace nor holds it open: the
+  // open sibling's own settled turn is what offers the archive.
+  assert.deepEqual(observations[0]?.controls, [
+    { id: "archive-workspace", label: "Archive", target: "workspace-quieted" },
+  ]);
+  // Dropped before it is ever asked for: the filed-away chat costs no status
+  // request, not just no row.
   assert.equal(
-    api.requests.some(
-      (request) => request.pathname.includes("/sessions/") && request.pathname.endsWith("/status"),
-    ),
+    api.requests.some((request) => request.pathname.includes("session-archived")),
     false,
   );
-});
-
-test("keeps a long-closed chat beside an open one", async () => {
-  // A closed chat is never hidden for its age, and it costs the open chat in
-  // the quieter workspace nothing: both are rows.
-  const api = fakeConductorApi({
-    userId: TEST_USER_ID,
-    projects: [LUKE_PROJECT],
-    workspaces: [
-      ownedWorkspace("workspace-busy", TEST_TIME - 5_000),
-      ownedWorkspace("workspace-quiet", TEST_TIME - 60_000),
-    ],
-    sessions: [
-      {
-        id: "session-closed-days-ago",
-        workspaceId: "workspace-busy",
-        name: TEST_SESSION_NAME,
-        archivedAt: isoTimestamp(TEST_TIME - 3 * 24 * 60 * 60 * 1000),
-      },
-      {
-        id: "session-open",
-        workspaceId: "workspace-quiet",
-        name: TEST_SESSION_NAME,
-        status: TEST_CONDUCTOR_STATUS.IDLE,
-        statusUpdatedAt: TEST_TIME - 30_000,
-      },
-    ],
-  });
-
-  const observations = await adapterFor(api.fetch).observe();
-
-  assert.deepEqual(observations.map((candidate) => candidate.providerSessionId).sort(), [
-    "session-closed-days-ago",
-    "session-open",
-  ]);
 });
 
 test("keeps reporting a long turn as working", async () => {
@@ -1201,7 +1129,7 @@ test("lets a crowded workspace keep every chat beside its quiet neighbour", asyn
   assert.equal(observations.length, 9);
 });
 
-test("prefers open chats over closed ones inside one workspace", async () => {
+test("keeps only the open chats of a workspace that also holds filed-away ones", async () => {
   const api = fakeConductorApi({
     userId: TEST_USER_ID,
     projects: [LUKE_PROJECT],
@@ -1224,16 +1152,14 @@ test("prefers open chats over closed ones inside one workspace", async () => {
   });
 
   const observations = await adapterFor(api.fetch).observe();
-  const observedIds = observations.map((observation) => observation.providerSessionId);
 
-  // Every chat is a row, and the open one is ordered first: it is the one
-  // that can still change.
-  assert.equal(observations.length, 5);
-  assert.equal(observedIds[0], "open-session");
-  assert.equal(
-    observations.find((entry) => entry.providerSessionId === "open-session")?.status,
-    SESSION_STATUS.WORKING,
+  // The filed-away chats earn no rows; the one still open is the workspace's
+  // only voice, and it reports its own state.
+  assert.deepEqual(
+    observations.map((observation) => observation.providerSessionId),
+    ["open-session"],
   );
+  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
 });
 
 test("reports nothing and issues no request without an API key", async () => {
@@ -1443,7 +1369,6 @@ test("advertises a message for any open chat, a stop mid-turn, and an archive on
       ownedWorkspace("workspace-idle", TEST_TIME - 30_000),
       ownedWorkspace("workspace-working", TEST_TIME - 31_000),
       ownedWorkspace("workspace-failed", TEST_TIME - 32_000),
-      ownedWorkspace("workspace-closed", TEST_TIME - 33_000),
     ],
     sessions: [
       {
@@ -1467,12 +1392,6 @@ test("advertises a message for any open chat, a stop mid-turn, and an archive on
         status: TEST_CONDUCTOR_STATUS.ERROR,
         statusUpdatedAt: TEST_TIME - 7_000,
       },
-      {
-        id: "session-closed",
-        workspaceId: "workspace-closed",
-        name: TEST_SESSION_NAME,
-        archivedAt: new Date(TEST_TIME - 8_000).toISOString(),
-      },
     ],
   });
 
@@ -1481,19 +1400,17 @@ test("advertises a message for any open chat, a stop mid-turn, and an archive on
 
   assert.equal(byId.get("session-idle")?.canReceiveMessage, true);
   assert.equal(byId.get("session-working")?.canReceiveMessage, true);
-  // A failed chat is documented for no writer, and a closed one is settled.
+  // A failed chat is documented for no writer.
   assert.equal(byId.get("session-failed")?.canReceiveMessage, false);
-  assert.equal(byId.get("session-closed")?.canReceiveMessage, false);
   // A chat mid-turn offers its stop and nothing else; every chat of a settled,
-  // still-open workspace — idle, failed, or closed — offers to file that
-  // workspace away, each naming its own workspace as the target.
+  // still-open workspace — idle or failed — offers to file that workspace
+  // away, each naming its own workspace as the target.
   assert.deepEqual(byId.get("session-working")?.controls, [
     { id: "cancel-turn", label: "Stop this turn", kind: "stop" },
   ]);
   for (const [sessionId, workspaceId] of [
     ["session-idle", "workspace-idle"],
     ["session-failed", "workspace-failed"],
-    ["session-closed", "workspace-closed"],
   ] as const) {
     assert.deepEqual(byId.get(sessionId)?.controls, [
       { id: "archive-workspace", label: "Archive", target: workspaceId },


### PR DESCRIPTION
## Why

Archiving a Conductor cloud chat did not clear its row: the adapter read a session's `archivedAt` as "closed" and reported the chat as a complete session, and the roster's settled-retention window then kept that row on the Sessions list for two days after the user had already filed the conversation away on Conductor's own surface. #164 fixed the same leak for archived *workspaces*; archived *chats* still slipped through one level down.

## What

Filing a chat away is the user saying that one conversation is done being watched, so the listing now drops it exactly the way it drops an archived workspace: before its status or transcript is ever asked for.

- `#listSessions` drops any session record carrying `archivedAt`, so a filed-away chat costs no status request, never enters the transcripts read document, and earns no row.
- A workspace holding both open and filed-away chats keeps rows only for the open ones, and its settledness — what offers the workspace archive control — is judged from those open chats alone.
- The now-dead archived branches are gone: the `ConductorSession.archived` fields, the complete-status mapping, the archived recap/error/message guards, and the open-before-closed sort.

## Reproduction

Verified against the live public API from a Conductor cloud workspace:

- Created a session, archived it via `POST /v0/sessions/{id}/archive`: it disappears from `GET /v0/workspaces/{id}/sessions` immediately (while `GET /v0/sessions/{id}` still returns it with `archivedAt` set), and there is no include-archived override.
- Created and archived a workspace: it disappears from the project's workspace listing the same way.

So when a listing hands over an `archivedAt`-bearing chat — the case the adapter's own tests model, and the shape #164 observed for workspaces — this filter is what keeps it off the roster; where the API has already filtered, the drop is inert.

## Tests

Reworked the tests that asserted archived chats appear as complete rows into tests asserting they are dropped: `leaves a filed-away chat off the roster while its workspace stays` (drop, no wasted requests, sibling still offers the archive control) and `keeps only the open chats of a workspace that also holds filed-away ones`, plus the recap, lifecycle, and control tests no longer seat archived chats.

`./scripts/check.sh` passes (desktop 48/48 adapter tests, all suites 0 failures). Portable-only change: no UI or macOS surface touched, so no visual evidence or physical-notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/00c754aa-8d6f-46bb-abb8-68df951b4fcd)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/31999881013/artifacts/9278055638) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/31999881013)

- Commit: `0b8972ed60483ef1414cd094c49778af1a8c3cab`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
