### PR TITLE
fix(web): restore production sign-in routing

### DIFF
--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -27,6 +27,12 @@ The auth service also needs `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`,
 `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GITHUB_CLIENT_ID`, and
 `GITHUB_CLIENT_SECRET`.
 
+`vercel.json` uses a legacy `routes` entry for `/api/auth/(.*)` because Vercel's
+zero-config `api/` detection treats `[...all].ts` as a single dynamic segment and
+adds a hard 404 for deeper API paths. A `rewrites` entry runs after that detected
+filesystem routing phase, so it cannot reach the Better Auth handler; keep this
+rule in `routes`, ahead of the detected routes.
+
 Each deployment build runs `pnpm auth:seed` after the migration and before Vite,
 so every database the application reaches already carries the client — including
 the branch database Neon creates for a Preview deployment, which would otherwise

--- a/apps/web/tests/database-workflow.test.ts
+++ b/apps/web/tests/database-workflow.test.ts
@@ -26,3 +26,11 @@ test("Vercel migrates and seeds a deployment's database before it builds", () =>
   assert.equal(vercelConfig.buildCommand, "pnpm db:migrate && pnpm auth:seed && pnpm build");
   assert.doesNotMatch(vercelConfig.buildCommand, /drizzle-kit push/);
 });
+
+test("Vercel routes nested auth paths before its detected API 404", () => {
+  assert.deepEqual(vercelConfig.routes, [
+    { src: "/api/auth/(.*)", dest: "/api/auth/[...all].ts" },
+    { src: "/privacy", dest: "/privacy.html" },
+  ]);
+  assert.equal("rewrites" in vercelConfig, false);
+});

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,10 +1,8 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "pnpm db:migrate && pnpm auth:seed && pnpm build",
-  "rewrites": [
-    {
-      "source": "/privacy",
-      "destination": "/privacy.html"
-    }
+  "routes": [
+    { "src": "/api/auth/(.*)", "dest": "/api/auth/[...all].ts" },
+    { "src": "/privacy", "dest": "/privacy.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- route every nested `/api/auth/*` request to the Better Auth catch-all before Vercel’s detected API 404
- preserve the `/privacy` route in the legacy `routes` array
- document the route-order constraint and add a regression test that rejects `rewrites`

## Test plan
- [x] `pnpm --dir apps/web test` (15 passed)
- [x] `./scripts/check.sh`
- [x] `git diff --check`

## Review
Pre-landing review found no issues.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32000816152/artifacts/9278347065) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32000816152)

- Commit: `4dd2eb0ea90c884e7ef9518b71eec1732770eed6`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
