### PR TITLE
feat(sessions): put more of what Luke already observes to work

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -202,11 +202,19 @@ spoken reply. OpenAI's policies govern that audio and the reply.
 
 Alongside the audio, Luke sends the same bounded session fields the attention
 review uses — provider name, session title, status, the name of the workspace
-a chat belongs to where its provider groups them, and each session's recap —
-so a spoken question about your sessions can be answered. No message history,
-file content, or command output is ever included: a recap can reflect what a
-session was asked and replied — for Conductor it is the agent's own parting
-words — but the conversation behind it never travels.
+a chat belongs to where its provider groups them, repository or branch, the
+tool a session is currently running, the provider's reported error line, and
+each session's recap — so a spoken question about your sessions can be
+answered with what a session is doing or stuck on, not only that it works or
+waits. Each roster line also states what the session can be asked to do —
+whether it takes messages, can be opened, is a local session whose transcript
+can be read on ask, has a pull request, and which controls its provider
+advertised — as facts, never as addresses. A standing ask you have made about
+a session (described below under the attention review) rides its roster line
+in your own words, so Luke can say what he is already listening for. No
+message history, file content, or command output is ever included: a recap
+can reflect what a session was asked and replied — for Conductor it is the
+agent's own parting words — but the conversation behind it never travels.
 
 Luke also sends the list of projects a new workspace could be created in —
 each project's provider, repository label, and provider-assigned identifier —
@@ -277,7 +285,11 @@ the provider name, displayed session title, the name of the workspace a chat
 belongs to where its provider groups them, previous and current status, review
 trigger, repository, branch, current tool activity, reported error, and the
 session recap — provider-designated, or for Conductor the agent's parting
-words read from its transcript. Titles, workspace names, and recaps can
+words read from its transcript. When you have asked Luke to keep a standing
+ask about a session — "tell me when this finishes" — that ask also travels
+with that session's updates, in your own words, so the review can answer it;
+it is withdrawn the same way it was made and dropped with the session it was
+about. Titles, workspace names, and recaps can
 reflect task and reply content; for a Conductor chat, the title is the chat's
 own name and the workspace name can contain the project-name fallback
 described above. The request also includes fixed review instructions and

--- a/apps/desktop/src/codex-adapter.ts
+++ b/apps/desktop/src/codex-adapter.ts
@@ -89,6 +89,12 @@ const CODEX_ROLLOUT_TYPE = {
 const CODEX_EVENT_PAYLOAD = {
   TASK_STARTED: "task_started",
   TASK_COMPLETE: "task_complete",
+  /**
+   * The failure that ended a turn early. Current Codex builds carry the error
+   * on `task_complete` itself; older ones wrote this event standing alone, so
+   * both shapes are read — the same pair the transcript reader renders.
+   */
+  ERROR: "error",
 } as const;
 
 const CODEX_RESPONSE_PAYLOAD = {
@@ -205,6 +211,7 @@ function activityFromCall(payload: Record<string, unknown>): string | undefined 
 
 interface ParsedCodexRollout {
   activity?: string;
+  error?: string;
   lastAgentMessage?: string;
   turnComplete?: boolean;
 }
@@ -230,14 +237,36 @@ function parseCodexRolloutTail(tail: string): ParsedCodexRollout {
         // A new turn is not running the previous turn's last call, and holding
         // it would keep a stale line on the row until some other tool runs.
         parsed.activity = undefined;
+        // A new turn is also not stuck on the previous turn's failure, and
+        // holding it would keep the row at error while the session works.
+        parsed.error = undefined;
+      }
+      if (payload.type === CODEX_EVENT_PAYLOAD.ERROR) {
+        parsed.error =
+          oneLine(text(payload.message), CODEX_ADAPTER_DEFAULTS.MAXIMUM_ACTIVITY_LENGTH) ??
+          parsed.error;
       }
       if (payload.type === CODEX_EVENT_PAYLOAD.TASK_COMPLETE) {
         parsed.turnComplete = true;
         parsed.activity = undefined;
-        parsed.lastAgentMessage = oneLine(
-          text(payload.last_agent_message),
-          maximumSessionRecapLength,
-        );
+        if (isRecord(payload.error)) {
+          // A turn that ended on a failure gets no recap: the agent's parting
+          // words predate what went wrong, and the error is what the row now
+          // has to say. The fallback keeps a standalone error event's message
+          // when the boundary's own error carries none.
+          parsed.error =
+            oneLine(text(payload.error.message), CODEX_ADAPTER_DEFAULTS.MAXIMUM_ACTIVITY_LENGTH) ??
+            parsed.error;
+          parsed.lastAgentMessage = undefined;
+        } else {
+          // A turn that settled cleanly got past any failure it recorded on
+          // the way, so a stale error must not outlive it.
+          parsed.error = undefined;
+          parsed.lastAgentMessage = oneLine(
+            text(payload.last_agent_message),
+            maximumSessionRecapLength,
+          );
+        }
       }
       continue;
     }
@@ -376,6 +405,11 @@ function statusFromRow(
   if ((numberFromRow(row, CODEX_THREAD_COLUMN.ARCHIVED) ?? 0) !== 0) {
     return SESSION_STATUS.COMPLETE;
   }
+  // A turn that failed is stuck until someone comes back to it, so the error
+  // outranks freshness: going stale is exactly what a session waiting on a
+  // rescue looks like, and decaying it to unknown would hide the one row
+  // that most needs a person.
+  if (rollout?.error) return SESSION_STATUS.ERROR;
   const isFresh = now - observedAt <= activeSessionFreshnessMs;
   // A turn that ended is holding for the developer however the row's timestamp
   // reads, but once it is stale Luke cannot tell a turn that just finished from
@@ -389,10 +423,11 @@ function statusFromRow(
 
 /**
  * Sharpens the row's verdict with what the observation hook last said, in the
- * order the meanings bind. A closed session is definite: the hook saying so
- * outranks the row, and an archived thread is never talked out of complete by
- * a softer event. Past those, the events refine only a fresh session — the
- * decay to `UNKNOWN` exists because a hook can go silent (a killed process
+ * order the meanings bind. A closed or failed session is definite: the hook
+ * saying closed outranks the row, and a row that says complete or error is
+ * never talked out of it by a softer event. Past those, the events refine
+ * only a fresh session — the decay to `UNKNOWN` exists because a hook can go
+ * silent (a killed process
  * fires no `SessionEnd`), so an old "waiting" must age the same way an old
  * row does. What the refinement actually buys is the states the state
  * database cannot show: a tool call holding for approval writes no records
@@ -404,7 +439,12 @@ function statusWithHookEvent(
   isFresh: boolean,
 ): ProviderSessionObservation["status"] {
   if (event === CODEX_HOOK_EVENT.SESSION_END) return SESSION_STATUS.COMPLETE;
-  if (status === SESSION_STATUS.COMPLETE) return status;
+  // Codex fires no failure hook, so `stop` fires for a failed turn too: a
+  // stop or prompt standing for the same turn the rollout saw fail must not
+  // talk the row out of the error. The rollout itself is what clears it — the
+  // next pass reads the new turn's `task_started` — so a genuinely newer turn
+  // costs one observation pass, never the failure.
+  if (status === SESSION_STATUS.COMPLETE || status === SESSION_STATUS.ERROR) return status;
   // A notification still standing means the approval is still open — its zero
   // staleness tolerance drops it the moment the thread moves — so it outranks
   // a mid-turn row however long the hold has run: Codex holds a long turn at
@@ -429,12 +469,14 @@ function detailFromRow(
   const activity = rollout?.activity;
   const branch = textFromRow(row, CODEX_THREAD_COLUMN.GIT_BRANCH);
   const model = modelFromRow(row);
+  const error = rollout?.error;
   const threadId = textFromRow(row, CODEX_THREAD_COLUMN.ID);
   return {
     ...(activity ? { activity } : {}),
     repository: workspaceLabel(textFromRow(row, CODEX_THREAD_COLUMN.CWD)),
     ...(branch ? { branch } : {}),
     ...(model ? { model } : {}),
+    ...(error ? { error } : {}),
     ...(threadId ? { link: `${CODEX_THREAD_LINK_PREFIX}${encodeURIComponent(threadId)}` } : {}),
   };
 }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -817,6 +817,10 @@ function registerIpc(): void {
         runMode.observesProviders && accountCapabilitiesActive()
           ? rosterRelevantSessions(sessionRegistry.snapshot().sessions, Date.now())
           : [],
+      // Asks are about observed sessions, so they ride the same gate the
+      // roster does: a panel shown no sessions is shown no asks about them.
+      noticeAsks:
+        runMode.observesProviders && accountCapabilitiesActive() ? attentionRequests.list() : [],
       workspaceProjects: accountCapabilitiesActive() ? observedWorkspaceProjects() : [],
       ...(trackedIssues && runMode.observesProviders && accountCapabilitiesActive()
         ? { issues: trackedIssues }
@@ -1244,6 +1248,29 @@ function registerIpc(): void {
     },
   );
 
+  // Opening a session's pull request is the same act one field over: the
+  // renderer names a session it is already drawing, and the address handed to
+  // the system is read back out of the registry, where normalization admitted
+  // nothing but a bounded https address. Nothing reaches the provider.
+  ipcMain.handle(
+    channels.openSessionChange,
+    async (event, identity: unknown): Promise<SessionOpenResult> => {
+      if (!trustedSender(event)) throw new Error("Untrusted renderer");
+      if (!isSessionIdentity(identity)) throw new Error("Invalid session open request");
+      const change = sessionRegistry.get(identity)?.detail.change;
+      if (!change) return { status: SESSION_OPEN_RESULT_STATUS.UNSUPPORTED };
+      try {
+        await shell.openExternal(change);
+        return { status: SESSION_OPEN_RESULT_STATUS.OPENED };
+      } catch {
+        return {
+          status: SESSION_OPEN_RESULT_STATUS.REJECTED,
+          reason: "The system could not open that pull request.",
+        };
+      }
+    },
+  );
+
   // Reading a session's transcript is a conversational act that returns
   // session content instead of performing anything: the file its provider
   // wrote is read on this machine, rendered into a bounded conversation, and
@@ -1428,6 +1455,7 @@ function registerIpc(): void {
         };
       }
       attentionRequests.set(identity, ask);
+      broadcastNoticeAsks();
       // The status rides the acceptance because the ask may already be
       // answered: a session asked about after it finished has no later finish
       // coming, and the reply should say so rather than promise one.
@@ -1453,6 +1481,7 @@ function registerIpc(): void {
           reason: "No ask was standing for that session.",
         };
       }
+      broadcastNoticeAsks();
       return { status: ATTENTION_REQUEST_RESULT_STATUS.ACCEPTED, sessionStatus: session.status };
     },
   );
@@ -1952,8 +1981,9 @@ async function reviewSessionAttention(generation = observationGeneration): Promi
  */
 function announceSessionNotices(sessions: readonly NormalizedSession[]): void {
   // Asks about sessions no longer reported have nothing left to be about, and
-  // this commit is the earliest that can be known.
-  attentionRequests.retain(sessions);
+  // this commit is the earliest that can be known. The rows marking asks are
+  // told only when one was actually let go.
+  if (attentionRequests.retain(sessions)) broadcastNoticeAsks();
   const now = Date.now();
   // A standing ask never quiets an edge. The ask licenses more speech about
   // its session, not less: an edge the ask did not name — an error under a
@@ -2014,6 +2044,15 @@ let lastRosterIds = "";
  * no longer age out or cap anything, so this one gate is where a session that
  * settled long ago stops being a row.
  */
+/**
+ * Hands every panel the standing asks as they now stand, so the rows marking
+ * them never describe an ask already withdrawn or let go. The words are the
+ * developer's own; nothing here reaches a provider or leaves the machine.
+ */
+function broadcastNoticeAsks(): void {
+  panels.broadcast(channels.noticeAsksChanged, attentionRequests.list());
+}
+
 function broadcastRelevantSessions(): void {
   const snapshot = sessionRegistry.snapshot();
   const roster = rosterRelevantSessions(snapshot.sessions, Date.now());

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -45,6 +45,7 @@ const bridge: AppBridge = {
     ipcRenderer.send(channels.setVoiceExchange, active);
   },
   openSession: invoke(channels.openSession),
+  openSessionChange: invoke(channels.openSessionChange),
   readSessionTranscript: invoke(channels.readSessionTranscript),
   sendSessionMessage: invoke(channels.sendSessionMessage),
   executeSessionControl: invoke(channels.executeSessionControl),
@@ -64,6 +65,7 @@ const bridge: AppBridge = {
   onSettingsChanged: subscribe(channels.settingsChanged),
   onAccountChanged: subscribe(channels.accountChanged),
   onSessionsChanged: subscribe(channels.sessionsChanged),
+  onNoticeAsksChanged: subscribe(channels.noticeAsksChanged),
   onWorkspaceProjectsChanged: subscribe(channels.workspaceProjectsChanged),
   onIssuesChanged: subscribe(channels.issuesChanged),
   onVoiceHotkeyPress: subscribe(channels.voiceHotkeyPress),

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -14,6 +14,7 @@ import {
   type RealtimeVoice,
   type RealtimeVoiceSpeed,
   type SessionIdentity,
+  type SessionNoticeAsk,
   VOICE_CAPTION_MAX_HEIGHT,
   type WorkspaceAgentSelection,
 } from "@sidecar/core";
@@ -225,6 +226,7 @@ export function App(): React.JSX.Element {
   const [bootstrap, setBootstrap] = useState<AppBootstrap>();
   const [account, setAccount] = useState<AccountSnapshot>();
   const [sessions, setSessions] = useState<readonly NormalizedSession[]>([]);
+  const [noticeAsks, setNoticeAsks] = useState<readonly SessionNoticeAsk[]>([]);
   const [workspaceProjects, setWorkspaceProjects] = useState<readonly ObservedWorkspaceProject[]>(
     [],
   );
@@ -1287,6 +1289,7 @@ export function App(): React.JSX.Element {
     syncIssues,
   } = useVoiceConversation({
     sessions,
+    noticeAsks,
     workspaceProjects,
     defaultWorkspaceProvider,
     workspaceProjectDefaults,
@@ -1502,6 +1505,11 @@ export function App(): React.JSX.Element {
           { providerId: session.providerId, providerSessionId: session.id },
           actionId,
         ),
+      openChange: (session) =>
+        window.sidecar.openSessionChange({
+          providerId: session.providerId,
+          providerSessionId: session.id,
+        }),
     }),
     [],
   );
@@ -1547,6 +1555,7 @@ export function App(): React.JSX.Element {
     void window.sidecar.getBootstrap().then((value) => {
       setBootstrap(value);
       setSessions(value.sessions);
+      setNoticeAsks(value.noticeAsks);
       // Only fill in what no push has said yet: the bootstrap snapshot is
       // older than any change that raced past it, and the main process will
       // not repeat a list it believes it already announced.
@@ -1606,11 +1615,13 @@ export function App(): React.JSX.Element {
     });
     const removeDisplay = window.sidecar.onDisplayChanged(setDisplay);
     const removeSessions = window.sidecar.onSessionsChanged(setSessions);
+    const removeNoticeAsks = window.sidecar.onNoticeAsksChanged(setNoticeAsks);
     return () => {
       cancelHover();
       removeLifecycle();
       removeDisplay();
       removeSessions();
+      removeNoticeAsks();
       void stopMicrophone();
     };
   }, [
@@ -1839,7 +1850,7 @@ export function App(): React.JSX.Element {
 
   if (!bootstrap || !display) return <div />;
 
-  const visibleSessions = displaySessions(bootstrap, sessions);
+  const visibleSessions = displaySessions(bootstrap, sessions, noticeAsks);
   // The tally is taken before the list is narrowed — the capsule reports what
   // Luke is watching, not what the panel is currently showing — but it reads
   // in the list's own sort, so the wing's marks sit in the order the rows do.

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -528,7 +528,11 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "than pretending there are none — Escape clears the query and then closes the field, " +
         "no spoken ask can search, and no search survives the panel closing. " +
         "A row can be opened, messaged, or controlled where its " +
-        "provider allows, and Luke's own composer at the foot of the list takes a typed ask. " +
+        "provider allows; a session whose provider reported a pull request grows a Pull request " +
+        "chip that opens it in the browser; and a row the developer asked Luke to listen for — " +
+        "“tell me when this finishes” — wears a small listening mark beside its age, whose hover " +
+        "says the ask in the developer's own words. Luke's own composer at the foot of the list " +
+        "takes a typed ask. " +
         "Where a provider nests chats in a workspace — Conductor today — each " +
         "chat is its own row: a workspace holding several draws them inside one tray named by " +
         "the workspace at its top, one holding a single chat stays one row titled by the " +
@@ -630,7 +634,9 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "words. Luke's background review weighs each of that session's updates against the ask " +
         "and speaks when one satisfies it, opening a speak-only call if no conversation is up; " +
         "the ask itself is the consent. One ask stands per session, a new one replaces it, asking Luke to drop " +
-        "it withdraws it, and an ask ends with the session it was about. It needs the OpenAI connection, " +
+        "it withdraws it, and an ask ends with the session it was about. A row with an ask standing wears a " +
+        "small listening mark beside its age, and the conversation roster carries each standing ask, so Luke " +
+        "can say what he is already listening for. It needs the OpenAI connection, " +
         "changes nothing about the session itself, and is never sent to a provider.",
     },
     talkKeyFact(input.hotkey),

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -6,7 +6,12 @@ import {
   SESSION_URGENCY,
 } from "@sidecar/core";
 import { useCallback, useRef, useState } from "react";
-import { ACCOUNT_STATUS, type AccountSnapshot } from "../shared/contracts";
+import {
+  ACCOUNT_STATUS,
+  type AccountSnapshot,
+  SESSION_OPEN_RESULT_STATUS,
+  type SessionOpenResult,
+} from "../shared/contracts";
 import { type AskHandler, AskLuke } from "./ask-luke";
 import { PANEL_TAB, type PanelTab, TabBar } from "./panel-tabs";
 import { CloudBadge, ProviderMark } from "./provider-marks";
@@ -31,6 +36,7 @@ import {
   BranchGlyph,
   CheckGlyph,
   EmptyState,
+  ListeningGlyph,
   SessionOptions,
   SessionOptionsButton,
   SessionsPanel,
@@ -51,6 +57,12 @@ import { SignInGate } from "./sign-in-gate";
 export interface SessionWriteHandlers {
   sendMessage: (session: DisplaySession, text: string) => Promise<ProviderMessageResult>;
   runAction: (session: DisplaySession, actionId: string) => Promise<ProviderControlResult>;
+  /**
+   * Not a provider write — the address is handed to the operating system —
+   * but it rides the same shape so the chip can report a refusal on the same
+   * line the other acts answer on.
+   */
+  openChange: (session: DisplaySession) => Promise<SessionOpenResult>;
 }
 
 /**
@@ -195,6 +207,17 @@ function SessionRowActions({
     [session, writes],
   );
 
+  const openChange = useCallback(async () => {
+    const result = await writes.openChange(session);
+    // An opened page is its own answer; only a failure needs the line.
+    if (result.status === SESSION_OPEN_RESULT_STATUS.OPENED) return;
+    setFeedback(
+      result.status === SESSION_OPEN_RESULT_STATUS.REJECTED
+        ? result.reason
+        : "The session no longer reports a pull request.",
+    );
+  }, [session, writes]);
+
   return (
     <div className="row-actions">
       {session.canMessage ? (
@@ -259,6 +282,22 @@ function SessionRowActions({
           onRun={(actionId) => void runAction(actionId)}
         />
       ))}
+      {session.hasChange ? (
+        <button
+          type="button"
+          className="row-action"
+          title="Open the pull request this session published"
+          // Opening the pull request hands an address to the system, not a
+          // write to a provider, so it stays offered while a provider write is
+          // in flight — only the row's open-on-press must not fire with it.
+          onClick={(event) => {
+            event.stopPropagation();
+            void openChange();
+          }}
+        >
+          Pull request
+        </button>
+      ) : null}
       {feedback ? <small className="row-feedback">{feedback}</small> : null}
     </div>
   );
@@ -310,7 +349,7 @@ function SessionRow({
   onOpen: (session: DisplaySession) => void;
   writes: SessionWriteHandlers;
 }): React.JSX.Element {
-  const withActions = session.canMessage || session.actions.length > 0;
+  const withActions = session.canMessage || session.actions.length > 0 || session.hasChange;
   const shared = {
     className: "session-row",
     "data-state": session.urgency,
@@ -353,7 +392,9 @@ function SessionRow({
             <span className="row-spinner" aria-hidden="true" />
           ) : null}
           {session.urgency === SESSION_URGENCY.COMPLETE ? <CheckGlyph /> : null}
-          <span className="row-doing-text">
+          {/* The line truncates without a disclosure, so the hover is the one
+              way the rest of a long sentence can be read at all. */}
+          <span className="row-doing-text" title={session.detail}>
             {session.detail === session.label ? null : (
               <span className="visually-hidden">{session.label}. </span>
             )}
@@ -361,7 +402,7 @@ function SessionRow({
           </span>
         </small>
         {place ? (
-          <small className="row-place">
+          <small className="row-place" title={place}>
             {session.branch ? <BranchGlyph /> : null}
             <span>
               <Highlighted text={place} tokens={highlight} />
@@ -369,7 +410,10 @@ function SessionRow({
           </small>
         ) : null}
       </span>
-      <small className="row-when">{observedAgoLabel(session.observedAt, now)}</small>
+      <small className="row-when">
+        {session.noticeAsk ? <ListeningGlyph ask={session.noticeAsk} /> : null}
+        {observedAgoLabel(session.observedAt, now)}
+      </small>
     </>
   );
 

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -42,6 +42,7 @@ import {
   realtimeToolFamily,
   SESSION_REFERENCE_WITHDRAWN_TEXT,
   type SessionIdentity,
+  type SessionNoticeAsk,
   sessionContextEvents,
   sessionContextText,
   sessionReferenceContextEvents,
@@ -1173,10 +1174,15 @@ export class RealtimeVoiceSession {
    * provides and a question about live work could not be answered from real
    * data. Identical rosters are not resent.
    */
-  updateSessions(sessions: readonly NormalizedSession[]): void {
+  updateSessions(
+    sessions: readonly NormalizedSession[],
+    noticeAsks: readonly SessionNoticeAsk[] = [],
+  ): void {
     this.#sessions = sessions;
-    this.#rememberContext(CONTEXT_ITEM_KIND.SESSIONS, sessionContextText(sessions), (itemId) =>
-      sessionContextEvents(sessions, itemId),
+    this.#rememberContext(
+      CONTEXT_ITEM_KIND.SESSIONS,
+      sessionContextText(sessions, noticeAsks),
+      (itemId) => sessionContextEvents(sessions, itemId, noticeAsks),
     );
     // The reference is rendered from the roster, so a fresh roster re-renders
     // it: a renamed session keeps its line true, and one that left the roster

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -12,6 +12,7 @@ import {
   type SessionControlKind,
   type SessionListSort,
   type SessionLocation,
+  type SessionNoticeAsk,
   type SessionUrgency,
   urgencyLabel,
 } from "@sidecar/core";
@@ -143,6 +144,18 @@ export interface DisplaySession {
   canMessage: boolean;
   /** Actions the provider advertised for this session, in its own words. */
   actions: readonly SessionAction[];
+  /**
+   * Whether the provider reported published work — a pull request — for this
+   * session. Like the session's own address, the URL stays in the main
+   * process; the row only has to know the chip would open something.
+   */
+  hasChange: boolean;
+  /**
+   * The developer's standing ask about this session, when one stands, so the
+   * row can mark that Luke is listening for it. The words are the developer's
+   * own, drawn only on this machine.
+   */
+  noticeAsk?: string;
   /** The workspace this row is one chat of, when its provider nests them. */
   workspace?: DisplayWorkspace;
 }
@@ -223,8 +236,11 @@ function sessionNeedsAttention(session: NormalizedSession): boolean {
 }
 
 /**
- * The line under the title. What stopped a session outranks what it was doing,
- * and what it was doing outranks the recap of a turn that has already ended.
+ * The line under the title. What stopped a session outranks everything; while
+ * the evaluator has flagged the session, its one-line reason outranks what the
+ * session was doing — the row lit up for that reason, and a stale recap under
+ * an attention colour says the wrong thing — and what a session was doing
+ * outranks the recap of a turn that has already ended.
  *
  * When a provider reported none of them, the line says the state in so many
  * words. This sentence is the one place the row states it — there is no chip at
@@ -232,7 +248,33 @@ function sessionNeedsAttention(session: NormalizedSession): boolean {
  * as Working or Complete rather than as a row with a line missing.
  */
 function sessionDetail(session: NormalizedSession, urgency: SessionUrgency): string {
-  return session.detail.error ?? session.detail.activity ?? session.recap ?? urgencyLabel(urgency);
+  const flaggedSummary =
+    session.attention.disposition === ATTENTION_DISPOSITION.SILENT
+      ? undefined
+      : session.attention.summary;
+  return (
+    session.detail.error ??
+    flaggedSummary ??
+    session.detail.activity ??
+    session.recap ??
+    urgencyLabel(urgency)
+  );
+}
+
+/**
+ * The standing asks by the identity each is about — nested maps rather than a
+ * composed key — so each row can pick up the one ask that names it.
+ */
+function noticeAsksByIdentity(
+  noticeAsks: readonly SessionNoticeAsk[],
+): ReadonlyMap<string, ReadonlyMap<string, string>> {
+  const byProvider = new Map<string, Map<string, string>>();
+  for (const noticeAsk of noticeAsks) {
+    const providerAsks = byProvider.get(noticeAsk.providerId) ?? new Map<string, string>();
+    providerAsks.set(noticeAsk.providerSessionId, noticeAsk.ask);
+    byProvider.set(noticeAsk.providerId, providerAsks);
+  }
+  return byProvider;
 }
 
 function sessionUrgency(session: NormalizedSession): SessionUrgency {
@@ -329,7 +371,9 @@ function bySort(sort: SessionSort): (first: DisplaySession, second: DisplaySessi
 export function displaySessions(
   bootstrap: AppBootstrap,
   sessions: readonly NormalizedSession[],
+  noticeAsks: readonly SessionNoticeAsk[] = [],
 ): readonly DisplaySession[] {
+  const asks = noticeAsksByIdentity(noticeAsks);
   const visible: readonly DisplaySession[] = bootstrap.fixtureMode
     ? bootstrap.fixture.sessions.map((session) => ({
         ...session,
@@ -347,9 +391,11 @@ export function displaySessions(
         openable: false,
         canMessage: session.canMessage === true,
         actions: session.actions ?? [],
+        hasChange: session.hasChange === true,
       }))
     : sessions.map((session) => {
         const urgency = sessionUrgency(session);
+        const noticeAsk = asks.get(session.providerId)?.get(session.providerSessionId);
         return {
           id: session.providerSessionId,
           title: session.title,
@@ -366,6 +412,8 @@ export function displaySessions(
           openable: session.detail.link !== undefined,
           canMessage: session.canReceiveMessage,
           actions: session.controls,
+          hasChange: session.detail.change !== undefined,
+          ...(noticeAsk ? { noticeAsk } : {}),
           // A workspace the provider left unnamed still groups its chats; the
           // id is at least stable, where a made-up name would claim knowledge
           // the provider never reported.

--- a/apps/desktop/src/renderer/session-parts.tsx
+++ b/apps/desktop/src/renderer/session-parts.tsx
@@ -47,6 +47,31 @@ export function WorkspaceGlyph(): React.JSX.Element {
   );
 }
 
+/**
+ * Marks a row the developer asked Luke to listen for — a small ear-like arc
+ * pair, drawn in the line's own colour like every row glyph. The ask itself is
+ * the hover and the accessible name, so the mark says what is being listened
+ * for rather than only that something is.
+ */
+export function ListeningGlyph({ ask }: { ask: string }): React.JSX.Element {
+  const label = `Luke is listening: ${ask}`;
+  return (
+    <svg
+      className="row-listening"
+      viewBox="0 0 16 16"
+      role="img"
+      aria-label={label}
+      focusable="false"
+    >
+      <title>{label}</title>
+      <g fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round">
+        <circle cx="8" cy="8" r="1.3" fill="currentColor" stroke="none" />
+        <path d="M4.6 4.6a4.8 4.8 0 0 0 0 6.8M11.4 4.6a4.8 4.8 0 0 1 0 6.8" />
+      </g>
+    </svg>
+  );
+}
+
 /** Leads a finished session's sentence, the way a spinner leads a working one. */
 export function CheckGlyph(): React.JSX.Element {
   return (

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -730,13 +730,25 @@ html[data-keyboard="true"] button.session-row:focus-visible {
    against the title's line rather than centred on the row, so two-line and
    three-line rows hold it at the same height. */
 .row-when {
+  display: flex;
   flex: 0 0 auto;
   align-self: flex-start;
+  align-items: center;
+  gap: 4px;
   padding-top: 2px;
   color: var(--text-tertiary);
   font-size: 10px;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
+}
+
+/* The mark for a row Luke was asked to listen for, riding beside the age in
+   the age's own quiet colour: the ask changes what Luke says, not the row's
+   urgency, so it must not read as a state. The ask itself is the hover. */
+.row-listening {
+  width: 11px;
+  height: 11px;
+  flex: 0 0 auto;
 }
 
 /* A row with a second line stacks, and hands its box's padding down: the first

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -13,6 +13,7 @@ import {
   type RealtimeVoiceSpeed,
   SESSION_TOOL_KIND,
   type SessionIdentity,
+  type SessionNoticeAsk,
   type TrackedIssue,
 } from "@sidecar/core";
 import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
@@ -285,6 +286,11 @@ export function evaluatorSummaries(speech: readonly AttentionSpeech[]): Attentio
 
 export interface VoiceConversationOptions {
   sessions: readonly NormalizedSession[];
+  /**
+   * The standing asks riding the roster they annotate, so a conversation can
+   * say — and withdraw — what Luke is already listening for.
+   */
+  noticeAsks: readonly SessionNoticeAsk[];
   workspaceProjects: readonly ObservedWorkspaceProject[];
   defaultWorkspaceProvider: string | undefined;
   /** The per-provider default projects, riding the projects context they steer. */
@@ -395,6 +401,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   /** Whether a tap has left a turn open for a later press to end. */
   const talkLatched = useRef(false);
   const sessionsRef = useRef(options.sessions);
+  const noticeAsksRef = useRef(options.noticeAsks);
   const workspaceProjectsRef = useRef(options.workspaceProjects);
   const defaultWorkspaceProviderRef = useRef(options.defaultWorkspaceProvider);
   const workspaceProjectDefaultsRef = useRef(options.workspaceProjectDefaults);
@@ -568,7 +575,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       return permission;
     }
     if (await session.connect()) {
-      session.updateSessions(sessionsRef.current);
+      session.updateSessions(sessionsRef.current, noticeAsksRef.current);
       // After the roster, which it is rendered against. The reference outlives
       // the calls themselves on purpose: the announcement it points back at
       // may have been read out on the speak-only call this one just replaced.
@@ -820,8 +827,9 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
 
   useEffect(() => {
     sessionsRef.current = options.sessions;
-    voiceSession.current?.updateSessions(options.sessions);
-  }, [options.sessions]);
+    noticeAsksRef.current = options.noticeAsks;
+    voiceSession.current?.updateSessions(options.sessions, options.noticeAsks);
+  }, [options.sessions, options.noticeAsks]);
 
   useEffect(() => {
     workspaceProjectsRef.current = options.workspaceProjects;

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -16,6 +16,7 @@ import type {
   Rectangle,
   ResolvedNotchGeometry,
   SessionIdentity,
+  SessionNoticeAsk,
   TrackedIssue,
   TrackerActionResult,
   WindowMode,
@@ -339,6 +340,12 @@ export interface AppBootstrap {
   outputAudio?: OutputAudioState;
   display: DisplayDiagnostic;
   sessions: readonly NormalizedSession[];
+  /**
+   * The standing asks the developer has made about sessions, so a panel that
+   * opens late still marks the rows Luke is listening for. The words are the
+   * developer's own and never a provider's.
+   */
+  noticeAsks: readonly SessionNoticeAsk[];
   /** Where a new workspace can be created, as the adapters currently offer it. */
   workspaceProjects: readonly ObservedWorkspaceProject[];
   /** Absent while no issue tracker is connected, which is its own answer. */
@@ -469,6 +476,13 @@ export interface AppBridge {
    */
   openSession(identity: SessionIdentity): Promise<SessionOpenResult>;
   /**
+   * Opens the pull request an observed session published, on the row's own
+   * terms: the renderer names the session, never the address, and the main
+   * process reads the change back out of its registry — an address that never
+   * passed normalization never reached it.
+   */
+  openSessionChange(identity: SessionIdentity): Promise<SessionOpenResult>;
+  /**
    * Reads the recent transcript of one observed local session into a bounded
    * rendering, for a conversation the developer is holding. The renderer
    * names a session it was shown; the main process validates it against its
@@ -581,6 +595,8 @@ export interface AppBridge {
   onSettingsChanged(callback: (settings: AppSettings) => void): () => void;
   onAccountChanged(callback: (account: AccountSnapshot) => void): () => void;
   onSessionsChanged(callback: (sessions: readonly NormalizedSession[]) => void): () => void;
+  /** The standing asks as they change — made, withdrawn, or let go with their sessions. */
+  onNoticeAsksChanged(callback: (noticeAsks: readonly SessionNoticeAsk[]) => void): () => void;
   /** The projects a workspace can be created in, whenever the set changes. */
   onWorkspaceProjectsChanged(
     callback: (projects: readonly ObservedWorkspaceProject[]) => void,
@@ -657,6 +673,7 @@ export const channels = {
   setWorkspaceAgentDefault: "app:set-workspace-agent-default",
   setWorkspaceProjectDefault: "app:set-workspace-project-default",
   openSession: "app:open-session",
+  openSessionChange: "app:open-session-change",
   readSessionTranscript: "app:read-session-transcript",
   sendSessionMessage: "app:send-session-message",
   executeSessionControl: "app:execute-session-control",
@@ -683,6 +700,7 @@ export const channels = {
   displayChanged: "app:display-changed",
   settingsChanged: "app:settings-changed",
   sessionsChanged: "app:sessions-changed",
+  noticeAsksChanged: "app:notice-asks-changed",
   workspaceProjectsChanged: "app:workspace-projects-changed",
   issuesChanged: "app:issues-changed",
   quit: "app:quit",

--- a/apps/desktop/tests/codex-adapter.test.ts
+++ b/apps/desktop/tests/codex-adapter.test.ts
@@ -360,6 +360,136 @@ test("drops the previous turn's call when a new Codex turn starts", async (t) =>
   assert.equal(observation?.recap, undefined);
 });
 
+test("reports a Codex turn that stopped on an error", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const rolloutPath = path.join(codexHome, "rollout-error-event.jsonl");
+  await writeCodexState(codexHome, [
+    { id: "codex-errored", cwd: "/Users/test/luke", observedAt: TEST_TIME - 1_000, rolloutPath },
+  ]);
+  await writeRollout(rolloutPath, [
+    { type: "event_msg", payload: { type: "task_started" } },
+    {
+      type: "event_msg",
+      payload: { type: "error", message: "stream disconnected before completion" },
+    },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.ERROR);
+  assert.equal(observation?.detail?.error, "stream disconnected before completion");
+});
+
+test("reports a failed turn's error instead of its parting words", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const rolloutPath = path.join(codexHome, "rollout-failed-complete.jsonl");
+  await writeCodexState(codexHome, [
+    { id: "codex-failed", cwd: "/Users/test/luke", observedAt: TEST_TIME - 1_000, rolloutPath },
+  ]);
+  await writeRollout(rolloutPath, [
+    { type: "event_msg", payload: { type: "task_started" } },
+    {
+      type: "event_msg",
+      payload: {
+        type: "task_complete",
+        // Parting words beside a failure predate what went wrong, so the row
+        // must carry the error and no recap at all.
+        last_agent_message: "I was about to run the tests.",
+        error: { message: "exceeded usage quota" },
+      },
+    },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.ERROR);
+  assert.equal(observation?.detail?.error, "exceeded usage quota");
+  assert.equal(observation?.recap, undefined);
+});
+
+test("keeps a failed Codex turn at error past the freshness decay", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const rolloutPath = path.join(codexHome, "rollout-stale-error.jsonl");
+  // A failed turn is stuck until someone comes back to it, and going stale is
+  // exactly what waiting on a rescue looks like.
+  await writeCodexState(codexHome, [
+    {
+      id: "codex-stale-error",
+      cwd: "/Users/test/luke",
+      observedAt: TEST_TIME - 20 * 60 * 1000,
+      rolloutPath,
+    },
+  ]);
+  await writeRollout(rolloutPath, [
+    { type: "event_msg", payload: { type: "task_started" } },
+    { type: "event_msg", payload: { type: "error", message: "stream disconnected" } },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    activeSessionFreshnessMs: 15 * 60 * 1000,
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60 * 60 * 1000,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.ERROR);
+});
+
+test("drops the previous turn's error when a new Codex turn starts", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const rolloutPath = path.join(codexHome, "rollout-error-retried.jsonl");
+  await writeCodexState(codexHome, [
+    { id: "codex-retried", cwd: "/Users/test/luke", observedAt: TEST_TIME - 1_000, rolloutPath },
+  ]);
+  await writeRollout(rolloutPath, [
+    { type: "event_msg", payload: { type: "task_started" } },
+    { type: "event_msg", payload: { type: "error", message: "stream disconnected" } },
+    { type: "event_msg", payload: { type: "task_started" } },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WORKING);
+  assert.equal(observation?.detail?.error, undefined);
+});
+
+test("bounds a Codex error to one row-sized line", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const rolloutPath = path.join(codexHome, "rollout-long-error.jsonl");
+  await writeCodexState(codexHome, [
+    { id: "codex-long-error", cwd: "/Users/test/luke", observedAt: TEST_TIME - 1_000, rolloutPath },
+  ]);
+  await writeRollout(rolloutPath, [
+    { type: "event_msg", payload: { type: "task_started" } },
+    { type: "event_msg", payload: { type: "error", message: "x".repeat(200) } },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.detail?.error, `${"x".repeat(79)}…`);
+});
+
 test("holds a long Codex turn at working however stale its row is", async (t) => {
   const codexHome = await temporaryCodexHome(t);
   const rolloutPath = path.join(codexHome, "rollout-long.jsonl");
@@ -765,6 +895,40 @@ test("a stop event keeps a finished turn waiting past the freshness decay", asyn
   const [observation] = await adapter.observe();
 
   assert.equal(observation?.status, SESSION_STATUS.WAITING);
+});
+
+test("a stop event does not talk a failed turn out of its error", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const spool = await temporaryHookSpool(t);
+  const rolloutPath = path.join(codexHome, "rollout-stopped-error.jsonl");
+  await writeCodexState(codexHome, [
+    {
+      id: "codex-stopped-error",
+      cwd: "/Users/test/luke",
+      observedAt: TEST_TIME - 60_000,
+      rolloutPath,
+    },
+  ]);
+  await writeRollout(rolloutPath, [
+    { type: "event_msg", payload: { type: "task_started" } },
+    {
+      type: "event_msg",
+      payload: { type: "task_complete", error: { message: "exceeded usage quota" } },
+    },
+  ]);
+  // Codex fires no failure hook, so `stop` fires for the failed turn too: an
+  // event standing for the same turn must not read the failure as waiting.
+  await writeHookEvent(spool, "codex-stopped-error", "stop", TEST_TIME - 30_000);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.ERROR);
+  assert.equal(observation?.detail?.error, "exceeded usage quota");
 });
 
 test("an event the thread has moved past refines nothing", async (t) => {

--- a/packages/sidecar-core/src/attention.ts
+++ b/packages/sidecar-core/src/attention.ts
@@ -452,6 +452,22 @@ export type AttentionRequestResult =
 export class AttentionRequestRegistry {
   #requests = new Map<string, Map<string, string>>();
 
+  /**
+   * Every standing ask, flattened for the surfaces that show them: the panel's
+   * row marks and the roster a developer-opened conversation carries. The
+   * identity rides each entry because the ask means nothing apart from the
+   * session it is about.
+   */
+  list(): readonly SessionNoticeAsk[] {
+    return [...this.#requests].flatMap(([providerId, providerRequests]) =>
+      [...providerRequests].map(([providerSessionId, ask]) => ({
+        providerId,
+        providerSessionId,
+        ask,
+      })),
+    );
+  }
+
   set(identity: SessionIdentity, request: string): void {
     const normalizedIdentity = normalizeSessionIdentity(identity);
     const providerRequests =
@@ -476,8 +492,12 @@ export class AttentionRequestRegistry {
     return true;
   }
 
-  /** Drops asks about sessions a provider no longer reports. */
-  retain(identities: readonly SessionIdentity[]): void {
+  /**
+   * Drops asks about sessions a provider no longer reports, and answers
+   * whether any were dropped so the surfaces showing asks can be told exactly
+   * when the set changed.
+   */
+  retain(identities: readonly SessionIdentity[]): boolean {
     const live = new Map<string, Set<string>>();
     for (const identity of identities) {
       const normalizedIdentity = normalizeSessionIdentity(identity);
@@ -486,19 +506,30 @@ export class AttentionRequestRegistry {
       live.set(normalizedIdentity.providerId, providerSessionIds);
     }
 
+    let dropped = false;
     const retained = new Map<string, Map<string, string>>();
     for (const [providerId, providerRequests] of this.#requests) {
       const providerSessionIds = live.get(providerId);
-      if (!providerSessionIds) continue;
       const kept = new Map(
         [...providerRequests].filter(([providerSessionId]) =>
-          providerSessionIds.has(providerSessionId),
+          providerSessionIds?.has(providerSessionId),
         ),
       );
+      if (kept.size < providerRequests.size) dropped = true;
       if (kept.size > 0) retained.set(providerId, kept);
     }
     this.#requests = retained;
+    return dropped;
   }
+}
+
+/**
+ * One standing ask beside the session it is about, as the flattened entry the
+ * panel's rows and the conversation roster consume. The words are the
+ * developer's own, already bounded by {@link attentionRequestText}.
+ */
+export interface SessionNoticeAsk extends SessionIdentity {
+  ask: string;
 }
 
 /**

--- a/packages/sidecar-core/src/fixtures.ts
+++ b/packages/sidecar-core/src/fixtures.ts
@@ -42,6 +42,10 @@ export interface SessionSnapshot {
   canMessage?: boolean;
   /** Drawn only, like the composer: the controls a live session would show. */
   actions?: readonly SessionControl[];
+  /** Drawn only: the pull-request chip a live session's published work earns. */
+  hasChange?: boolean;
+  /** Drawn only: the standing ask a live row would be marked as listened for. */
+  noticeAsk?: string;
   /** The workspace this row is one chat of, when its provider nests them. */
   workspace?: WorkspaceSnapshot;
 }
@@ -81,6 +85,9 @@ const smokeFixture: FixtureSnapshot = {
       urgency: SESSION_URGENCY.WORKING,
       location: SESSION_LOCATION.LOCAL,
       observedAt: minutesBeforeEpoch(4),
+      // A synthetic standing ask, so the one screenshot the evidence is
+      // reviewed from also proves the listening mark is drawn.
+      noticeAsk: "Tell me when the build finishes.",
     },
     {
       id: "claude-review",
@@ -142,8 +149,10 @@ const smokeFixture: FixtureSnapshot = {
       location: SESSION_LOCATION.CLOUD,
       observedAt: minutesBeforeEpoch(18),
       // What a working Cursor agent advertises live, so the one screenshot the
-      // evidence is reviewed from also proves the stop control is drawn.
+      // evidence is reviewed from also proves the stop control is drawn — and
+      // the pull-request chip beside it, on the row whose sentence names one.
       actions: [{ id: "cancel-run", label: "Stop this run", kind: SESSION_CONTROL_KIND.STOP }],
+      hasChange: true,
     },
     // A fifth session keeps every state and every provider mark visible in the
     // one screenshot the visual evidence is reviewed from. It is also one more

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -125,6 +125,7 @@ export {
   attentionDecisionFromModel,
   maximumAttentionRequestLength,
   SessionAttentionReviewer,
+  type SessionNoticeAsk,
 } from "./attention";
 export {
   attentionInstructions,

--- a/packages/sidecar-core/src/realtime-context.ts
+++ b/packages/sidecar-core/src/realtime-context.ts
@@ -1,3 +1,4 @@
+import type { SessionNoticeAsk } from "./attention";
 import { type AppGuideSnapshot, appGuideContextText } from "./guide";
 import type { TrackedIssue } from "./issues";
 import { type ObservedWorkspaceProject, WORKSPACE_TASK_SUPPORT } from "./providers";
@@ -7,7 +8,7 @@ import {
   announcementSummaryText,
   REALTIME_CLIENT_EVENT,
 } from "./realtime-protocol";
-import type { NormalizedSession } from "./session";
+import { type NormalizedSession, SESSION_LOCATION } from "./session";
 
 /**
  * Roster context serialization: the bounded, redacted view of sessions, issues,
@@ -36,6 +37,14 @@ function sessionCapabilityText(session: NormalizedSession): string {
     // Openability is the link's presence, never the link: an address has no
     // business in a conversation when the identity is what a tool call names.
     session.detail.link ? "can be opened" : "cannot be opened",
+    // Readability is stated up front so Luke offers a transcript read only
+    // where one can answer, instead of learning the boundary by being refused.
+    session.location === SESSION_LOCATION.LOCAL
+      ? "local, transcript readable on ask"
+      : "cloud, no transcript to read",
+    // Like the link, the pull request travels as a fact and never an address:
+    // the row is where it opens from.
+    ...(session.detail.change ? ["has a pull request"] : []),
     ...(session.controls.length > 0
       ? [
           `controls: ${session.controls.map((control) => `${control.label} (${control.id})`).join(", ")}`,
@@ -49,22 +58,63 @@ function sessionCapabilityText(session: NormalizedSession): string {
 }
 
 /**
+ * The checkout, current tool, and reported failure a session's line carries —
+ * the same bounded about-fields the attention update already sends, worded as
+ * short labelled phrases so Luke can say what a session is doing or stuck on
+ * rather than only that it works or waits.
+ */
+function sessionAboutText(session: NormalizedSession): readonly string[] {
+  return [
+    ...(session.detail.branch
+      ? [`on branch ${session.detail.branch}`]
+      : session.detail.repository
+        ? [`in repository ${session.detail.repository}`]
+        : []),
+    ...(session.detail.activity ? [`running ${session.detail.activity}`] : []),
+    ...(session.detail.error ? [`error: ${session.detail.error}`] : []),
+  ];
+}
+
+/**
+ * The standing asks by the identity each is about, nested rather than keyed by
+ * a composed string, so a roster line can carry the one ask that names it.
+ */
+function noticeAsksByIdentity(
+  noticeAsks: readonly SessionNoticeAsk[],
+): ReadonlyMap<string, ReadonlyMap<string, string>> {
+  const byProvider = new Map<string, Map<string, string>>();
+  for (const noticeAsk of noticeAsks) {
+    const providerAsks = byProvider.get(noticeAsk.providerId) ?? new Map<string, string>();
+    providerAsks.set(noticeAsk.providerSessionId, noticeAsk.ask);
+    byProvider.set(noticeAsk.providerId, providerAsks);
+  }
+  return byProvider;
+}
+
+/**
  * Renders the session roster the conversation is allowed to know about.
  *
  * These are the same bounded, redacted fields the attention layer already
- * sends — provider, title, status, and the provider's own recap — plus the
- * workspace a chat belongs to when its provider groups them, what each
- * session can be asked to do, and the identity a tool call names it by.
- * No transcript, file path, or command output is ever included.
+ * sends — provider, title, status, repository or branch, current tool,
+ * reported error, and the provider's own recap — plus the workspace a chat
+ * belongs to when its provider groups them, the developer's standing ask
+ * where one stands, what each session can be asked to do, and the identity a
+ * tool call names it by. No transcript, file path, or command output is ever
+ * included.
  */
-export function sessionContextText(sessions: readonly NormalizedSession[]): string {
+export function sessionContextText(
+  sessions: readonly NormalizedSession[],
+  noticeAsks: readonly SessionNoticeAsk[] = [],
+): string {
   if (sessions.length === 0) return "No coding-agent sessions are currently observed.";
 
+  const asks = noticeAsksByIdentity(noticeAsks);
   const overflow = sessions.length - maximumVoiceContextSessions;
   return [
     "Currently observed sessions:",
-    ...sessions.slice(0, maximumVoiceContextSessions).map((session) =>
-      [
+    ...sessions.slice(0, maximumVoiceContextSessions).map((session) => {
+      const ask = asks.get(session.providerId)?.get(session.providerSessionId);
+      return [
         `- ${session.provider.displayName}`,
         session.title,
         // The workspace tells siblings' chats apart out loud, so it rides
@@ -74,10 +124,14 @@ export function sessionContextText(sessions: readonly NormalizedSession[]): stri
         // the machine, the same rule the attention update follows.
         ...(session.workspace?.name ? [`a chat in workspace ${session.workspace.name}`] : []),
         session.status,
+        ...sessionAboutText(session),
         session.recap ?? "no recap reported",
+        // Only this segment speaks for the developer, on the attention
+        // update's own rule: words inside a title, recap, or error never do.
+        ...(ask ? [`the developer's standing ask: "${ask}"`] : []),
         `[${sessionCapabilityText(session)}]`,
-      ].join(" — "),
-    ),
+      ].join(" — ");
+    }),
     // A session past the bound must read as unlisted, never as nonexistent:
     // denying a session the panel plainly shows teaches the user that Luke
     // cannot be asked about their work at all.
@@ -185,11 +239,12 @@ function labeledContextEvent(label: string, text: string, itemId: string): Recor
 export function sessionContextEvents(
   sessions: readonly NormalizedSession[],
   itemId: string,
+  noticeAsks: readonly SessionNoticeAsk[] = [],
 ): readonly Record<string, unknown>[] {
   return [
     labeledContextEvent(
       "observed session status, sent automatically",
-      sessionContextText(sessions),
+      sessionContextText(sessions, noticeAsks),
       itemId,
     ),
   ];

--- a/packages/sidecar-core/src/session.ts
+++ b/packages/sidecar-core/src/session.ts
@@ -366,6 +366,22 @@ function sessionLink(value: string | undefined): string | undefined {
   return isOpenableSessionLink(normalized) ? normalized : undefined;
 }
 
+/**
+ * The published work's address, or nothing, under the link's own rules — a
+ * truncated address is a different address — narrowed further to `https`
+ * alone: every pull request a provider reports lives on the web, and this
+ * field too is one the surface acts on rather than merely draws.
+ */
+function sessionChange(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  if (!normalized || normalized.length > maximumSessionLinkLength) return undefined;
+  try {
+    return new URL(normalized).protocol === SESSION_LINK_SCHEME.HTTPS ? normalized : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function timestamp(value: number, field: string): number {
   if (!Number.isFinite(value) || value < 0) {
     throw new Error(`${field} must be a non-negative finite timestamp`);
@@ -426,7 +442,7 @@ export function normalizeSessionDetail(detail: SessionDetail | undefined): Sessi
   const model = boundedText(detail.model, maximumSessionDetailLength);
   const error = boundedText(detail.error, maximumSessionDetailLength);
   const link = sessionLink(detail.link);
-  const change = boundedText(detail.change, maximumSessionLinkLength);
+  const change = sessionChange(detail.change);
 
   return {
     ...(activity ? { activity } : {}),

--- a/packages/sidecar-core/tests/attention.test.ts
+++ b/packages/sidecar-core/tests/attention.test.ts
@@ -895,6 +895,26 @@ test("one ask stands per session: replaced whole, withdrawn honestly, dropped wi
   assert.equal(requests.get(identity), undefined);
 });
 
+test("the ask list carries every standing ask, and retain says whether it changed", () => {
+  const requests = new AttentionRequestRegistry();
+  const watched = { providerId: claude.id, providerSessionId: "watched" };
+  const other = { providerId: "codex", providerSessionId: "thread-1" };
+
+  assert.deepEqual(requests.list(), []);
+  requests.set(watched, "Tell me when this finishes.");
+  requests.set(other, "Warn me if it fails.");
+  assert.deepEqual(requests.list(), [
+    { ...watched, ask: "Tell me when this finishes." },
+    { ...other, ask: "Warn me if it fails." },
+  ]);
+
+  // The surfaces marking asks are told only on a real change, so retain has
+  // to answer honestly in both directions.
+  assert.equal(requests.retain([watched, other]), false, "nothing dropped is no change");
+  assert.equal(requests.retain([watched]), true, "a dropped ask is a change");
+  assert.deepEqual(requests.list(), [{ ...watched, ask: "Tell me when this finishes." }]);
+});
+
 test("a standing ask rides the update of the session it was made about, and no other", async () => {
   const requests = new AttentionRequestRegistry();
   requests.set(

--- a/packages/sidecar-core/tests/realtime.test.ts
+++ b/packages/sidecar-core/tests/realtime.test.ts
@@ -770,6 +770,117 @@ test("the last announcement is context, never a prompt", () => {
   assert.match(item.content?.[0]?.text ?? "", /^\[last announcement, sent automatically\]\n/);
 });
 
+test("the roster says what a session is doing and where, in the attention update's own fields", () => {
+  const working = normalizeSession(
+    { id: "claude-code", displayName: "Claude Code" },
+    {
+      providerSessionId: "session-doing",
+      title: "checkout-service",
+      status: SESSION_STATUS.WORKING,
+      observedAt: DECIDED_AT,
+      detail: {
+        repository: "luke",
+        branch: "dean/desktop-shell",
+        activity: "Bash: pnpm test",
+        error: "The request failed",
+      },
+    },
+  );
+
+  const text = sessionContextText([working]);
+  // The branch outranks the repository the way the row's own place line reads:
+  // one identifier per line, the most specific one.
+  assert.match(text, /on branch dean\/desktop-shell/);
+  assert.doesNotMatch(text, /in repository luke/);
+  assert.match(text, /running Bash: pnpm test/);
+  assert.match(text, /error: The request failed/);
+
+  const bare = normalizeSession(
+    { id: "claude-code", displayName: "Claude Code" },
+    {
+      providerSessionId: "session-bare",
+      title: "checkout-service",
+      status: SESSION_STATUS.WORKING,
+      observedAt: DECIDED_AT,
+      detail: { repository: "luke" },
+    },
+  );
+  const bareText = sessionContextText([bare]);
+  assert.match(bareText, /in repository luke/);
+  assert.doesNotMatch(bareText, /running/);
+  assert.doesNotMatch(bareText, /error:/);
+});
+
+test("the roster says which sessions keep a readable transcript and a pull request, never an address", () => {
+  const local = normalizeSession(
+    { id: "codex", displayName: "Codex" },
+    {
+      providerSessionId: "thread-local",
+      title: "luke",
+      status: SESSION_STATUS.WAITING,
+      observedAt: DECIDED_AT,
+    },
+  );
+  assert.match(sessionContextText([local]), /local, transcript readable on ask/);
+
+  const cloud = normalizeSession(
+    { id: "devin", displayName: "Devin" },
+    {
+      providerSessionId: "devin-1",
+      title: "luke",
+      status: SESSION_STATUS.WAITING,
+      observedAt: DECIDED_AT,
+      location: SESSION_LOCATION.CLOUD,
+      detail: { change: "https://github.com/example/luke/pull/7" },
+    },
+  );
+  const cloudText = sessionContextText([cloud]);
+  assert.match(cloudText, /cloud, no transcript to read/);
+  // The pull request travels as a fact, like openability: the row is where it
+  // opens from, and no address belongs in a conversation.
+  assert.match(cloudText, /has a pull request/);
+  assert.doesNotMatch(cloudText, /github\.com/);
+  assert.doesNotMatch(sessionContextText([local]), /has a pull request/);
+});
+
+test("a standing ask rides its own session's roster line, in the developer's words", () => {
+  const watched = normalizeSession(
+    { id: "claude-code", displayName: "Claude Code" },
+    {
+      providerSessionId: "session-watched",
+      title: "checkout-service",
+      status: SESSION_STATUS.WORKING,
+      observedAt: DECIDED_AT,
+    },
+  );
+  const unwatched = normalizeSession(
+    { id: "claude-code", displayName: "Claude Code" },
+    {
+      providerSessionId: "session-unwatched",
+      title: "billing-service",
+      status: SESSION_STATUS.WORKING,
+      observedAt: DECIDED_AT,
+    },
+  );
+
+  const text = sessionContextText(
+    [watched, unwatched],
+    [
+      {
+        providerId: "claude-code",
+        providerSessionId: "session-watched",
+        ask: "Tell me when this finishes.",
+      },
+    ],
+  );
+
+  const lines = text.split("\n");
+  const watchedLine = lines.find((line) => line.includes("session-watched"));
+  const unwatchedLine = lines.find((line) => line.includes("session-unwatched"));
+  assert.match(watchedLine ?? "", /the developer's standing ask: "Tell me when this finishes\."/);
+  assert.doesNotMatch(unwatchedLine ?? "", /standing ask/);
+});
+
 test("session context never asks Luke to start talking", () => {
   const events = sessionContextEvents([], "luke_ctx_sessions_1");
 

--- a/packages/sidecar-core/tests/session-registry.test.ts
+++ b/packages/sidecar-core/tests/session-registry.test.ts
@@ -166,6 +166,30 @@ test("keeps only the addresses Luke would open, and never a shortened one", () =
   assert.equal(linkFor(`https://example.com/${"a".repeat(maximumSessionLinkLength)}`), undefined);
 });
 
+test("a change is held to the web alone, and never a shortened one", () => {
+  const registry = new InMemorySessionRegistry();
+  const changeFor = (change: string) =>
+    registry.upsert(codex, observation("run:change", 100, { detail: { change } })).detail.change;
+
+  // The pull-request chip acts on this field the way pressing a row acts on
+  // the link, so the same rule guards it — narrowed to https because every
+  // pull request a provider reports lives on the web.
+  assert.equal(
+    changeFor("https://github.com/example/luke/pull/7"),
+    "https://github.com/example/luke/pull/7",
+  );
+  for (const change of [
+    "codex://threads/019ff315-8735-7382-9fbe-16b0ea8ad990",
+    "file:///Users/dean/luke/pull.diff",
+    "javascript:void 0",
+    "not a url",
+    "",
+  ]) {
+    assert.equal(changeFor(change), undefined, `${change} is not a change Luke may open`);
+  }
+  assert.equal(changeFor(`https://example.com/${"a".repeat(maximumSessionLinkLength)}`), undefined);
+});
+
 test("a session runs on this machine unless its provider observed it elsewhere", () => {
   const registry = new InMemorySessionRegistry();
   const local = registry.upsert(codex, observation("local", 100));


### PR DESCRIPTION
## Summary

An investigation of what each provider adapter can see (local and cloud) found several places where data is already observed, bounded, and shipped — then dropped one step before the user or Luke can benefit. This PR closes the four gaps that were reasonable, useful, and not overly complex. Everything stays within the standing trust boundaries; the two egress-adjacent widenings ride fields the attention update and announcements already carry, and PRIVACY.md moves in the same change.

- **Codex failures become visible.** Observation already reads a bounded rollout tail, but parsed only `task_started`/`task_complete` — so a failed Codex turn could never report an error anywhere (row, announcement, or attention evaluator). It now also reads the `error` event_msg and `task_complete.error` (the same records the transcript reader renders), reports `SESSION_STATUS.ERROR` with the provider's own line bounded to 80 chars, survives staleness the way Claude Code's errors do, refuses a recap beside a failure, and cannot be talked out of the error by a hook `stop` (Codex fires no failure hook, so `stop` fires for failed turns too). A following `task_started` clears it.
- **The pull request a session published gets pixels and a press.** `detail.change` (populated by Claude Code, Cursor cloud, and Devin) was received by the renderer and dropped at the display projection. It is now held to `https:` at normalization — dropped whole, never cut, like the session link — carried to the row as a presence fact, and drawn as a "Pull request" chip in the row's actions line. The press goes through a new `openSessionChange` IPC handler that validates the identity against the registry and reads the address back out of its own observation, mirroring `openSession` exactly. The URL never crosses into the renderer.
- **Standing asks become legible.** Asks lived only in the main process: no way to see which sessions Luke was listening for, and a fresh conversation couldn't enumerate them. The main process now pushes the ask list over a new subscription (on make, withdraw, and retain-drop), a watched row wears a small listening mark beside its age whose hover carries the ask verbatim, and each conversation roster line carries its session's standing ask in the developer's own words — only that segment speaks for the developer, on the attention update's existing rule.
- **The voice roster says what a session is doing, not only that it works or waits.** Roster lines now carry branch or repository, the current tool, and the reported error — the same about-fields the attention request and edge announcements already send — plus two capability facts: whether the session is local with a transcript readable on ask (so Luke stops discovering that boundary by being refused) and whether a pull request exists. Facts, never addresses, matching the existing openability convention.

Two smaller row improvements ride along: while the evaluator has flagged a session, the row's detail line prefers the evaluator's one-line reason over a stale recap; and the truncating detail/place lines carry their full text as a hover title, so a 500-char recap is no longer unreadable.

Deliberately not done: splitting error from waiting in the urgency vocabulary (ripples through the generated surface vocabulary, sort, badge, and motion contract), an OpenCode recap (would breach its observation's content-blind boundary), and a live "age" segment in the roster (it would defeat the identical-roster dedupe or go stale in the pending context).

Docs and self-knowledge move with the behavior: PRIVACY.md's spoken-conversation section enumerates the widened roster, and its attention-review section now documents the standing ask that already traveled with updates (a pre-existing doc gap found during the investigation); `luke-guide.ts` learns the chip, the listening mark, and the roster's ask lines so Luke describes what he can actually do.

The smoke fixture gains a `hasChange` chip on the Cursor row and a synthetic standing ask on the Codex row, so the one screenshot the evidence is reviewed from proves both new marks draw.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passes (repository checks, generated-file drift, types, lint, all workspace tests — 178 core + 862 desktop — and builds)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — authored in a cloud (Linux) workspace where the macOS pipeline cannot run; CI's macOS job attaches the visual evidence below and should be inspected for the new chip and listening mark before merge.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32004067558/artifacts/9279424338) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32004067558)

- Commit: `b9145f7014f7ea35dee973ae24b13ca5d40af770`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: inspect CI's visual evidence for the Pull request chip (Cursor row) and the listening mark (Codex row) once the macOS job uploads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/1a8a7b26-637b-4a6d-a66b-5f3ad822aa03)
