### PR TITLE
feat(web): hosted voice and attention endpoints behind account sign-in

### DIFF
--- a/apps/desktop/src/openai-attention-evaluator.ts
+++ b/apps/desktop/src/openai-attention-evaluator.ts
@@ -1,13 +1,12 @@
 import {
-  ATTENTION_DECISION_SCHEMA,
-  ATTENTION_DECISION_SCHEMA_NAME,
+  ATTENTION_RESPONSES_PATH,
   type AttentionDecision,
   type AttentionEvaluator,
   type AttentionUpdate,
   attentionDecisionFromModel,
-  attentionInstructions,
-  attentionUpdateInput,
-  isRecord,
+  attentionResponsesMissingReason,
+  attentionResponsesOutputText,
+  attentionResponsesRequest,
   positiveInteger,
   text,
 } from "@sidecar/core";
@@ -33,9 +32,6 @@ const OPENAI_DEFAULTS = {
   MAXIMUM_OUTPUT_TOKENS: 4096,
 } as const;
 
-const OPENAI_RESPONSES_PATH = "/responses";
-const OPENAI_TEXT_FORMAT_TYPE = "json_schema";
-const OPENAI_OUTPUT_TEXT_TYPE = "output_text";
 const OPENAI_RATE_LIMIT_STATUS = 429;
 const OPENAI_RETRY_AFTER_HEADER = "retry-after";
 
@@ -66,47 +62,6 @@ export type OpenAiAttentionOptions = Omit<OpenAiAttentionEvaluatorOptions, "apiK
 
 function withoutTrailingSlash(value: string): string {
   return value.endsWith("/") ? value.slice(0, -1) : value;
-}
-
-function outputTextFromContent(content: unknown): string {
-  if (!Array.isArray(content)) return "";
-  return content
-    .map((entry) =>
-      isRecord(entry) && entry.type === OPENAI_OUTPUT_TEXT_TYPE && typeof entry.text === "string"
-        ? entry.text
-        : "",
-    )
-    .join("");
-}
-
-/**
- * Reads the structured decision out of a Responses payload without depending on
- * where a given API version places it.
- */
-function outputText(payload: unknown): string | undefined {
-  if (!isRecord(payload)) return undefined;
-  if (typeof payload.output_text === "string") return text(payload.output_text);
-  if (!Array.isArray(payload.output)) return undefined;
-  return text(
-    payload.output
-      .map((item) => (isRecord(item) ? outputTextFromContent(item.content) : ""))
-      .join(""),
-  );
-}
-
-/**
- * Describes why a payload carried no decision. A model that spends its output
- * budget on reasoning returns `incomplete` with empty output, which would
- * otherwise look identical to a healthy silent pass.
- */
-function missingDecisionReason(payload: unknown): string {
-  if (!isRecord(payload)) return "";
-  const status = typeof payload.status === "string" ? payload.status : undefined;
-  const details = isRecord(payload.incomplete_details) ? payload.incomplete_details : undefined;
-  const reason = typeof details?.reason === "string" ? details.reason : undefined;
-  if (status && reason) return ` (${status}: ${reason})`;
-  if (status) return ` (${status})`;
-  return "";
 }
 
 function parsedJson(text: string): unknown {
@@ -187,10 +142,10 @@ export class OpenAiAttentionEvaluator implements AttentionEvaluator {
     const payload = await this.#payload(response);
     if (payload === undefined) return undefined;
 
-    const text = outputText(payload);
+    const text = attentionResponsesOutputText(payload);
     if (!text) {
       this.#report(
-        `OpenAI attention response carried no decision${missingDecisionReason(payload)}`,
+        `OpenAI attention response carried no decision${attentionResponsesMissingReason(payload)}`,
       );
       return undefined;
     }
@@ -202,27 +157,18 @@ export class OpenAiAttentionEvaluator implements AttentionEvaluator {
 
   async #request(update: AttentionUpdate): Promise<Response | undefined> {
     try {
-      return await this.#fetch(`${this.#baseUrl}${OPENAI_RESPONSES_PATH}`, {
+      return await this.#fetch(`${this.#baseUrl}${ATTENTION_RESPONSES_PATH}`, {
         method: "POST",
         headers: {
           authorization: `Bearer ${this.#apiKey}`,
           "content-type": "application/json",
         },
-        body: JSON.stringify({
-          model: this.#model,
-          instructions: attentionInstructions(),
-          input: attentionUpdateInput(update),
-          max_output_tokens: this.#maximumOutputTokens,
-          store: false,
-          text: {
-            format: {
-              type: OPENAI_TEXT_FORMAT_TYPE,
-              name: ATTENTION_DECISION_SCHEMA_NAME,
-              schema: ATTENTION_DECISION_SCHEMA,
-              strict: true,
-            },
-          },
-        }),
+        body: JSON.stringify(
+          attentionResponsesRequest(update, {
+            model: this.#model,
+            maximumOutputTokens: this.#maximumOutputTokens,
+          }),
+        ),
         signal: AbortSignal.timeout(this.#requestTimeoutMs),
       });
     } catch (error) {

--- a/apps/web/api/attention/review.ts
+++ b/apps/web/api/attention/review.ts
@@ -1,0 +1,30 @@
+import { auth } from "../../server/auth.js";
+import { getDatabase } from "../../server/db/index.js";
+import { handleAttentionReview } from "../../server/hosted/attention-review.js";
+import { hostedUserId } from "../../server/hosted/bearer.js";
+import { HOSTED_OPENAI_ENVIRONMENT } from "../../server/hosted/openai.js";
+import { HOSTED_METER, spendHostedMeter } from "../../server/hosted/quota.js";
+
+/**
+ * Reviews one bounded session update for the signed-in desktop, on the key
+ * this deployment holds. The logic lives in
+ * `server/hosted/attention-review.ts`; this file only hands it the
+ * deployment's real seams.
+ */
+export default {
+  fetch(request: Request): Promise<Response> {
+    return handleAttentionReview({
+      request,
+      apiKey: process.env[HOSTED_OPENAI_ENVIRONMENT.API_KEY],
+      model: process.env[HOSTED_OPENAI_ENVIRONMENT.ATTENTION_MODEL],
+      resolveUserId: (incoming) =>
+        hostedUserId(incoming, (input) => auth.api.oauth2UserInfo(input)),
+      spend: (userId) =>
+        spendHostedMeter(getDatabase(), {
+          userId,
+          meter: HOSTED_METER.ATTENTION_REVIEW,
+          now: Date.now(),
+        }),
+    });
+  },
+};

--- a/apps/web/api/voice/mint.ts
+++ b/apps/web/api/voice/mint.ts
@@ -1,0 +1,29 @@
+import { auth } from "../../server/auth.js";
+import { getDatabase } from "../../server/db/index.js";
+import { hostedUserId } from "../../server/hosted/bearer.js";
+import { HOSTED_OPENAI_ENVIRONMENT } from "../../server/hosted/openai.js";
+import { HOSTED_METER, spendHostedMeter } from "../../server/hosted/quota.js";
+import { handleVoiceMint } from "../../server/hosted/voice-mint.js";
+
+/**
+ * Mints one ephemeral Realtime credential for the signed-in desktop, on the
+ * key this deployment holds. The logic lives in `server/hosted/voice-mint.ts`;
+ * this file only hands it the deployment's real seams.
+ */
+export default {
+  fetch(request: Request): Promise<Response> {
+    return handleVoiceMint({
+      request,
+      apiKey: process.env[HOSTED_OPENAI_ENVIRONMENT.API_KEY],
+      model: process.env[HOSTED_OPENAI_ENVIRONMENT.REALTIME_MODEL],
+      resolveUserId: (incoming) =>
+        hostedUserId(incoming, (input) => auth.api.oauth2UserInfo(input)),
+      spend: (userId) =>
+        spendHostedMeter(getDatabase(), {
+          userId,
+          meter: HOSTED_METER.VOICE_CALL,
+          now: Date.now(),
+        }),
+    });
+  },
+};

--- a/apps/web/drizzle/0001_bright_morbius.sql
+++ b/apps/web/drizzle/0001_bright_morbius.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "hosted_usage" (
+	"user_id" text NOT NULL,
+	"day" text NOT NULL,
+	"voice_calls" integer DEFAULT 0 NOT NULL,
+	"attention_reviews" integer DEFAULT 0 NOT NULL,
+	CONSTRAINT "hosted_usage_user_id_day_pk" PRIMARY KEY("user_id","day")
+);
+--> statement-breakpoint
+ALTER TABLE "hosted_usage" ADD CONSTRAINT "hosted_usage_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/apps/web/drizzle/meta/0001_snapshot.json
+++ b/apps/web/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,1132 @@
+{
+  "id": "f3013dca-5b2a-4992-9d97-f51e2e6f562d",
+  "prevId": "87c0d6d6-4734-42e5-8d60-c13f9d3a6742",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": ["refresh_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_login_method": {
+          "name": "last_login_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosted_usage": {
+      "name": "hosted_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voice_calls": {
+          "name": "voice_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attention_reviews": {
+          "name": "attention_reviews",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hosted_usage_user_id_user_id_fk": {
+          "name": "hosted_usage_user_id_user_id_fk",
+          "tableFrom": "hosted_usage",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "hosted_usage_user_id_day_pk": {
+          "name": "hosted_usage_user_id_day_pk",
+          "columns": ["user_id", "day"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1786937985558,
       "tag": "0000_absent_green_goblin",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1786949863756,
+      "tag": "0001_bright_morbius",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -53,3 +53,26 @@ Google's callback is `${BETTER_AUTH_URL}/api/auth/callback/google`; GitHub's is
 
 `api/feedback.mjs` deliberately remains plain ESM so Vercel's builder has nothing
 to transpile.
+
+# Hosted voice and attention
+
+`api/voice/mint.ts` and `api/attention/review.ts` run Luke's voice and
+attention review on the deployment's own OpenAI key for a signed-in desktop.
+Both are exact-path files, so Vercel's zero-config `api/` detection routes
+them without a `routes` entry; only the bracketed auth catch-all needs one.
+The logic lives in `server/hosted/` behind injected seams, and each request is
+resolved to a user through the auth service's own `/oauth2/userinfo` endpoint,
+called in process.
+
+The endpoints need one secret: `OPENAI_API_KEY`. Without it both answer 503
+and the hosted tier is simply off — the same kill switch as the feedback
+endpoint — which is the intended state for Preview deployments, so a preview
+never spends the production key. `LUKE_REALTIME_MODEL` and
+`LUKE_ATTENTION_MODEL` optionally override the models, under the same names
+the desktop honours; a blank value is treated as absent.
+
+Use is metered per user per UTC day in the Luke-owned `hosted_usage` table —
+one atomic upsert before each upstream call, checked against the ceilings in
+`server/hosted/quota.ts`. The ceilings bound how often calls open, not how
+long they run; a spend limit on the OpenAI project behind the key is the
+backstop and should be configured with it.

--- a/apps/web/server/db/schema.ts
+++ b/apps/web/server/db/schema.ts
@@ -1,3 +1,4 @@
 // Better Auth owns its generated schema; Luke-owned tables can join this
 // aggregate from their own schema modules without being overwritten by it.
 export * from "./auth-schema.js";
+export * from "./usage-schema.js";

--- a/apps/web/server/db/usage-schema.ts
+++ b/apps/web/server/db/usage-schema.ts
@@ -1,0 +1,25 @@
+import { integer, pgTable, primaryKey, text } from "drizzle-orm/pg-core";
+import { user } from "./auth-schema.js";
+
+/**
+ * What one signed-in user spent of the hosted allowance on one UTC day. The
+ * hosted endpoints run on Luke's own OpenAI key, so this row is the durable
+ * brake that keeps one account from spending everyone's: each counter is
+ * incremented atomically before the upstream call and checked against the
+ * day's ceiling. One row per user per day; a day with no use has no row.
+ */
+export const hostedUsage = pgTable(
+  "hosted_usage",
+  {
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    /** The UTC day the counters cover, as YYYY-MM-DD. */
+    day: text("day").notNull(),
+    /** Realtime calls opened: each mint answers exactly one call. */
+    voiceCalls: integer("voice_calls").default(0).notNull(),
+    /** Attention reviews forwarded to the Responses API. */
+    attentionReviews: integer("attention_reviews").default(0).notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.userId, table.day] })],
+);

--- a/apps/web/server/hosted/attention-review.ts
+++ b/apps/web/server/hosted/attention-review.ts
@@ -1,0 +1,111 @@
+import {
+  ATTENTION_RESPONSES_PATH,
+  type AttentionDecision,
+  attentionDecisionFromModel,
+  attentionPromptUpdateFromWire,
+  attentionResponsesOutputText,
+  attentionResponsesRequest,
+} from "@sidecar/core";
+import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
+import { type FetchLike, postOpenAi } from "./openai.js";
+import type { HostedSpend } from "./quota.js";
+
+/**
+ * Reviews one bounded session update on Luke's own key for a signed-in user.
+ * This is not a proxy: the instructions, the decision schema, and the refusal
+ * to store come from the same shared construction the desktop evaluator sends,
+ * and the request's whole say is the update's bounded fields, validated here
+ * against the bounds the local roster holds them to. What travels onward is
+ * exactly what would have travelled from the desktop under the developer's own
+ * key — never more.
+ */
+
+export const HOSTED_ATTENTION_DEFAULTS = {
+  // The desktop evaluator's own default: a three-way classification with a
+  // fixed prompt fits the cost-optimized tier, and its lower latency means
+  // fewer decisions are discarded as superseded before they can be used.
+  MODEL: "gpt-5.6-luna",
+  MAXIMUM_OUTPUT_TOKENS: 4096,
+} as const;
+
+export interface AttentionReviewOptions {
+  request: Request;
+  /** Luke's own OpenAI key, from the deployment environment; absent means the tier is off. */
+  apiKey: string | undefined;
+  /** A deployment-configured model override; the shared default otherwise. */
+  model?: string;
+  resolveUserId: (request: Request) => Promise<string | undefined>;
+  spend: (userId: string) => Promise<HostedSpend>;
+  fetch?: FetchLike;
+  now?: () => number;
+  timeoutMs?: number;
+}
+
+export interface AttentionReviewAnswer {
+  decision: AttentionDecision;
+  quota: HostedSpend["quota"];
+}
+
+export async function handleAttentionReview(options: AttentionReviewOptions): Promise<Response> {
+  const { request } = options;
+  if (request.method !== "POST") {
+    return errorResponse(
+      HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
+      HOSTED_API_ERROR.METHOD_NOT_ALLOWED,
+    );
+  }
+  if (!options.apiKey) {
+    return errorResponse(HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE, HOSTED_API_ERROR.UNAVAILABLE);
+  }
+
+  const userId = await options.resolveUserId(request);
+  if (!userId) {
+    return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
+  }
+
+  const payload: unknown = await request.json().catch(() => undefined);
+  const update = payload === undefined ? undefined : attentionPromptUpdateFromWire(payload);
+  if (!update) {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+
+  const spend = await options.spend(userId);
+  if (!spend.allowed) {
+    return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED, {
+      quota: spend.quota,
+    });
+  }
+
+  const response = await postOpenAi(
+    ATTENTION_RESPONSES_PATH,
+    attentionResponsesRequest(update, {
+      model: options.model ?? HOSTED_ATTENTION_DEFAULTS.MODEL,
+      maximumOutputTokens: HOSTED_ATTENTION_DEFAULTS.MAXIMUM_OUTPUT_TOKENS,
+    }),
+    { apiKey: options.apiKey, fetch: options.fetch, timeoutMs: options.timeoutMs },
+  );
+  if (!response || !response.ok) {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_GATEWAY, HOSTED_API_ERROR.UPSTREAM_ERROR, {
+      ...(response ? { upstreamStatus: response.status } : {}),
+    });
+  }
+
+  const body: unknown = await response.json().catch(() => undefined);
+  const text = body === undefined ? undefined : attentionResponsesOutputText(body);
+  const now = options.now ?? Date.now;
+  const decision = text ? attentionDecisionFromModel(parsedJson(text), now()) : undefined;
+  if (!decision) {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_GATEWAY, HOSTED_API_ERROR.UPSTREAM_ERROR);
+  }
+
+  const answer: AttentionReviewAnswer = { decision, quota: spend.quota };
+  return jsonResponse(HOSTED_HTTP_STATUS.OK, answer);
+}
+
+function parsedJson(text: string): unknown {
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/web/server/hosted/attention-review.ts
+++ b/apps/web/server/hosted/attention-review.ts
@@ -5,6 +5,7 @@ import {
   attentionPromptUpdateFromWire,
   attentionResponsesOutputText,
   attentionResponsesRequest,
+  text as trimmedText,
 } from "@sidecar/core";
 import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
 import { type FetchLike, postOpenAi } from "./openai.js";
@@ -54,7 +55,10 @@ export async function handleAttentionReview(options: AttentionReviewOptions): Pr
       HOSTED_API_ERROR.METHOD_NOT_ALLOWED,
     );
   }
-  if (!options.apiKey) {
+  // Trimmed like the desktop's own key reads: a whitespace credential is the
+  // kill switch, not a key, and a blank model override is no override at all.
+  const apiKey = trimmedText(options.apiKey);
+  if (!apiKey) {
     return errorResponse(HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE, HOSTED_API_ERROR.UNAVAILABLE);
   }
 
@@ -79,10 +83,10 @@ export async function handleAttentionReview(options: AttentionReviewOptions): Pr
   const response = await postOpenAi(
     ATTENTION_RESPONSES_PATH,
     attentionResponsesRequest(update, {
-      model: options.model ?? HOSTED_ATTENTION_DEFAULTS.MODEL,
+      model: trimmedText(options.model) ?? HOSTED_ATTENTION_DEFAULTS.MODEL,
       maximumOutputTokens: HOSTED_ATTENTION_DEFAULTS.MAXIMUM_OUTPUT_TOKENS,
     }),
-    { apiKey: options.apiKey, fetch: options.fetch, timeoutMs: options.timeoutMs },
+    { apiKey, fetch: options.fetch, timeoutMs: options.timeoutMs },
   );
   if (!response || !response.ok) {
     return errorResponse(HOSTED_HTTP_STATUS.BAD_GATEWAY, HOSTED_API_ERROR.UPSTREAM_ERROR, {

--- a/apps/web/server/hosted/bearer.ts
+++ b/apps/web/server/hosted/bearer.ts
@@ -1,0 +1,30 @@
+import { isRecord } from "@sidecar/core";
+
+/**
+ * The auth service's own userinfo endpoint, called in process. It is the same
+ * validation the desktop's identity request goes through over HTTP: expiry,
+ * revocation, and scope are all the OAuth provider's answer, never a second
+ * implementation here.
+ */
+export type UserInfoEndpoint = (input: { headers: Headers }) => Promise<unknown>;
+
+/**
+ * Resolves the signed-in user behind a request's bearer token, or nothing.
+ * Nothing distinguishes a missing header from an expired or revoked token on
+ * purpose: every failure is one 401, and the desktop's existing refresh
+ * machinery is what answers it.
+ */
+export async function hostedUserId(
+  request: Request,
+  userInfo: UserInfoEndpoint,
+): Promise<string | undefined> {
+  const authorization = request.headers.get("authorization")?.trim();
+  if (!authorization) return undefined;
+  try {
+    const identity = await userInfo({ headers: new Headers({ authorization }) });
+    const subject = isRecord(identity) && typeof identity.sub === "string" ? identity.sub : "";
+    return subject || undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/web/server/hosted/http.ts
+++ b/apps/web/server/hosted/http.ts
@@ -1,0 +1,46 @@
+/**
+ * The response vocabulary the hosted endpoints share. Every answer is JSON,
+ * and every refusal names its reason from one fixed set so the desktop can
+ * diagnose "voice is off" without the server writing anything sensitive.
+ */
+
+export const HOSTED_API_ERROR = {
+  /** The bearer token is missing, expired, or revoked. */
+  INVALID_TOKEN: "invalid-token",
+  /** The request body is not what this endpoint takes. */
+  INVALID_REQUEST: "invalid-request",
+  /** Today's free allowance for this meter is spent. */
+  QUOTA_EXHAUSTED: "quota-exhausted",
+  /** The deployment holds no OpenAI key: the hosted tier is switched off. */
+  UNAVAILABLE: "unavailable",
+  /** OpenAI refused or failed; the status travels, the bodies never do. */
+  UPSTREAM_ERROR: "upstream-error",
+  METHOD_NOT_ALLOWED: "method-not-allowed",
+} as const;
+
+export type HostedApiError = (typeof HOSTED_API_ERROR)[keyof typeof HOSTED_API_ERROR];
+
+export const HOSTED_HTTP_STATUS = {
+  OK: 200,
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  METHOD_NOT_ALLOWED: 405,
+  TOO_MANY_REQUESTS: 429,
+  BAD_GATEWAY: 502,
+  SERVICE_UNAVAILABLE: 503,
+} as const;
+
+export function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export function errorResponse(
+  status: number,
+  error: HostedApiError,
+  extra: Record<string, unknown> = {},
+): Response {
+  return jsonResponse(status, { error, ...extra });
+}

--- a/apps/web/server/hosted/openai.ts
+++ b/apps/web/server/hosted/openai.ts
@@ -1,0 +1,52 @@
+/**
+ * How the hosted endpoints reach OpenAI on Luke's own key. The key comes from
+ * the deployment's environment and never appears in a response, a log line, or
+ * an error; without one the endpoints answer 503 and the hosted tier is simply
+ * off, the same kill switch the feedback endpoint uses.
+ */
+
+export const HOSTED_OPENAI_ENVIRONMENT = {
+  API_KEY: "OPENAI_API_KEY",
+  /** The same override names the desktop honours, so one convention configures both. */
+  REALTIME_MODEL: "LUKE_REALTIME_MODEL",
+  ATTENTION_MODEL: "LUKE_ATTENTION_MODEL",
+} as const;
+
+export const HOSTED_OPENAI_DEFAULTS = {
+  BASE_URL: "https://api.openai.com/v1",
+  REQUEST_TIMEOUT_MS: 15_000,
+} as const;
+
+export type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
+
+export interface OpenAiUpstreamOptions {
+  apiKey: string;
+  fetch?: FetchLike;
+  timeoutMs?: number;
+}
+
+/**
+ * Posts one build-fixed document to OpenAI, resolving to nothing on a network
+ * fault so a caller answers 502 without ever holding an error that could name
+ * the key.
+ */
+export async function postOpenAi(
+  path: string,
+  body: unknown,
+  options: OpenAiUpstreamOptions,
+): Promise<Response | undefined> {
+  const send = options.fetch ?? ((input: string, init: RequestInit) => fetch(input, init));
+  try {
+    return await send(`${HOSTED_OPENAI_DEFAULTS.BASE_URL}${path}`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${options.apiKey}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(options.timeoutMs ?? HOSTED_OPENAI_DEFAULTS.REQUEST_TIMEOUT_MS),
+    });
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/web/server/hosted/quota.ts
+++ b/apps/web/server/hosted/quota.ts
@@ -1,0 +1,92 @@
+import { sql } from "drizzle-orm";
+import type { createDatabase } from "../db/index.js";
+import { hostedUsage } from "../db/usage-schema.js";
+
+/** The two things the hosted tier spends, each metered on its own ceiling. */
+export const HOSTED_METER = {
+  VOICE_CALL: "voice-call",
+  ATTENTION_REVIEW: "attention-review",
+} as const;
+
+export type HostedMeter = (typeof HOSTED_METER)[keyof typeof HOSTED_METER];
+
+/**
+ * The free tier's daily ceilings. Product knobs, not implementation details:
+ * a voice call is a conversation opened or an announcement spoken, and an
+ * attention review is one session update weighed. The OpenAI project budget
+ * behind the key is the backstop these ceilings exist to keep distant.
+ */
+export const HOSTED_DAILY_LIMIT: Record<HostedMeter, number> = {
+  [HOSTED_METER.VOICE_CALL]: 50,
+  [HOSTED_METER.ATTENTION_REVIEW]: 500,
+};
+
+export interface HostedQuota {
+  used: number;
+  limit: number;
+  remaining: number;
+  /** When the day's counters reset, as epoch milliseconds. */
+  resetsAt: number;
+}
+
+export interface HostedSpend {
+  allowed: boolean;
+  quota: HostedQuota;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** The UTC day a moment falls on, as the usage table's YYYY-MM-DD key. */
+export function utcDayKey(now: number): string {
+  return new Date(now).toISOString().slice(0, 10);
+}
+
+/** The moment a UTC day's counters reset, as epoch milliseconds. */
+export function utcDayEnd(dayKey: string): number {
+  return Date.parse(`${dayKey}T00:00:00.000Z`) + DAY_MS;
+}
+
+type UsageDatabase = Pick<ReturnType<typeof createDatabase>, "insert">;
+
+/**
+ * Spends one use of a meter and answers whether it fit inside the day. The
+ * increment is a single atomic upsert taken before the upstream call, so two
+ * racing requests cannot both be the fiftieth: whichever lands second reads
+ * fifty-one and is refused. A refused attempt still counts — the counter
+ * records what was asked, and past the ceiling every answer is the same no.
+ */
+export async function spendHostedMeter(
+  database: UsageDatabase,
+  input: { userId: string; meter: HostedMeter; now: number },
+): Promise<HostedSpend> {
+  const day = utcDayKey(input.now);
+  const spendsVoice = input.meter === HOSTED_METER.VOICE_CALL;
+  const [row] = await database
+    .insert(hostedUsage)
+    .values({
+      userId: input.userId,
+      day,
+      voiceCalls: spendsVoice ? 1 : 0,
+      attentionReviews: spendsVoice ? 0 : 1,
+    })
+    .onConflictDoUpdate({
+      target: [hostedUsage.userId, hostedUsage.day],
+      set: spendsVoice
+        ? { voiceCalls: sql`${hostedUsage.voiceCalls} + 1` }
+        : { attentionReviews: sql`${hostedUsage.attentionReviews} + 1` },
+    })
+    .returning();
+  if (!row) throw new Error("The usage upsert returned no row.");
+
+  const used = spendsVoice ? row.voiceCalls : row.attentionReviews;
+  const limit = HOSTED_DAILY_LIMIT[input.meter];
+  return {
+    allowed: used <= limit,
+    quota: {
+      used,
+      limit,
+      remaining: Math.max(0, limit - used),
+      resetsAt: utcDayEnd(day),
+    },
+  };
+}

--- a/apps/web/server/hosted/voice-mint.ts
+++ b/apps/web/server/hosted/voice-mint.ts
@@ -1,0 +1,136 @@
+import {
+  isRealtimeVoice,
+  isRealtimeVoiceSpeed,
+  isRecord,
+  REALTIME_CALLS_PATH,
+  REALTIME_CLIENT_SECRETS_PATH,
+  type RealtimeVoice,
+  type RealtimeVoiceSpeed,
+  realtimeClientSecretRequest,
+  realtimeCredentialFromResponse,
+  realtimeCredentialIsUsable,
+} from "@sidecar/core";
+import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
+import { type FetchLike, HOSTED_OPENAI_DEFAULTS, postOpenAi } from "./openai.js";
+import type { HostedSpend } from "./quota.js";
+
+/**
+ * Mints one ephemeral Realtime credential on Luke's own key for a signed-in
+ * user. The session document is built here from the same shared code the
+ * desktop mints with — the client's whole say is a voice and a pace, each
+ * validated against the set the build ships — so nothing a caller sends can
+ * reshape what the credential is for. The renderer's call still goes straight
+ * to OpenAI: only the mint transits this deployment, never the audio.
+ */
+
+export interface VoiceMintPreferences {
+  voice?: RealtimeVoice;
+  speed?: RealtimeVoiceSpeed;
+}
+
+/**
+ * Reads the caller's voice and pace, tolerating an empty body — the defaults
+ * are a complete request. A value outside the build's own sets refuses the
+ * request rather than being repaired: the desktop only sends values it
+ * validated, so anything else is a bug or an impostor, and both should hear no.
+ */
+export async function voiceMintPreferences(
+  request: Request,
+): Promise<VoiceMintPreferences | undefined> {
+  const raw = await request.text().catch(() => undefined);
+  if (raw === undefined) return undefined;
+  if (!raw.trim()) return {};
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (!isRecord(payload)) return undefined;
+
+  if (payload.voice !== undefined && !isRealtimeVoice(payload.voice)) return undefined;
+  if (payload.speed !== undefined && !isRealtimeVoiceSpeed(payload.speed)) return undefined;
+
+  return {
+    ...(payload.voice !== undefined ? { voice: payload.voice } : {}),
+    ...(payload.speed !== undefined ? { speed: payload.speed } : {}),
+  };
+}
+
+export interface VoiceMintOptions {
+  request: Request;
+  /** Luke's own OpenAI key, from the deployment environment; absent means the tier is off. */
+  apiKey: string | undefined;
+  /** A deployment-configured model override; the shared default otherwise. */
+  model?: string;
+  resolveUserId: (request: Request) => Promise<string | undefined>;
+  spend: (userId: string) => Promise<HostedSpend>;
+  fetch?: FetchLike;
+  now?: () => number;
+  timeoutMs?: number;
+}
+
+export async function handleVoiceMint(options: VoiceMintOptions): Promise<Response> {
+  const { request } = options;
+  if (request.method !== "POST") {
+    return errorResponse(
+      HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
+      HOSTED_API_ERROR.METHOD_NOT_ALLOWED,
+    );
+  }
+  if (!options.apiKey) {
+    return errorResponse(HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE, HOSTED_API_ERROR.UNAVAILABLE);
+  }
+
+  const userId = await options.resolveUserId(request);
+  if (!userId) {
+    return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
+  }
+
+  const preferences = await voiceMintPreferences(request);
+  if (!preferences) {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+
+  const spend = await options.spend(userId);
+  if (!spend.allowed) {
+    return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED, {
+      quota: spend.quota,
+    });
+  }
+
+  const response = await postOpenAi(
+    REALTIME_CLIENT_SECRETS_PATH,
+    realtimeClientSecretRequest({
+      ...(options.model ? { model: options.model } : {}),
+      ...(preferences.voice ? { voice: preferences.voice } : {}),
+      ...(preferences.speed ? { speed: preferences.speed } : {}),
+    }),
+    { apiKey: options.apiKey, fetch: options.fetch, timeoutMs: options.timeoutMs },
+  );
+  if (!response) {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_GATEWAY, HOSTED_API_ERROR.UPSTREAM_ERROR);
+  }
+  if (!response.ok) {
+    // Status alone diagnoses the upstream without carrying its body onward.
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_GATEWAY, HOSTED_API_ERROR.UPSTREAM_ERROR, {
+      upstreamStatus: response.status,
+    });
+  }
+
+  const payload: unknown = await response.json().catch(() => undefined);
+  const credential = payload === undefined ? undefined : realtimeCredentialFromResponse(payload);
+  const now = options.now ?? Date.now;
+  if (!credential || !realtimeCredentialIsUsable(credential, now())) {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_GATEWAY, HOSTED_API_ERROR.UPSTREAM_ERROR);
+  }
+
+  return jsonResponse(HOSTED_HTTP_STATUS.OK, {
+    connection: {
+      ...credential,
+      callsUrl: `${HOSTED_OPENAI_DEFAULTS.BASE_URL}${REALTIME_CALLS_PATH}`,
+    },
+    quota: spend.quota,
+  });
+}

--- a/apps/web/server/hosted/voice-mint.ts
+++ b/apps/web/server/hosted/voice-mint.ts
@@ -9,6 +9,7 @@ import {
   realtimeClientSecretRequest,
   realtimeCredentialFromResponse,
   realtimeCredentialIsUsable,
+  text as trimmedText,
 } from "@sidecar/core";
 import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
 import { type FetchLike, HOSTED_OPENAI_DEFAULTS, postOpenAi } from "./openai.js";
@@ -79,7 +80,11 @@ export async function handleVoiceMint(options: VoiceMintOptions): Promise<Respon
       HOSTED_API_ERROR.METHOD_NOT_ALLOWED,
     );
   }
-  if (!options.apiKey) {
+  // Trimmed like the desktop's own key reads: a whitespace credential is the
+  // kill switch, not a key, and a blank model override is no override at all.
+  const apiKey = trimmedText(options.apiKey);
+  const model = trimmedText(options.model);
+  if (!apiKey) {
     return errorResponse(HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE, HOSTED_API_ERROR.UNAVAILABLE);
   }
 
@@ -103,11 +108,11 @@ export async function handleVoiceMint(options: VoiceMintOptions): Promise<Respon
   const response = await postOpenAi(
     REALTIME_CLIENT_SECRETS_PATH,
     realtimeClientSecretRequest({
-      ...(options.model ? { model: options.model } : {}),
+      ...(model ? { model } : {}),
       ...(preferences.voice ? { voice: preferences.voice } : {}),
       ...(preferences.speed ? { speed: preferences.speed } : {}),
     }),
-    { apiKey: options.apiKey, fetch: options.fetch, timeoutMs: options.timeoutMs },
+    { apiKey, fetch: options.fetch, timeoutMs: options.timeoutMs },
   );
   if (!response) {
     return errorResponse(HOSTED_HTTP_STATUS.BAD_GATEWAY, HOSTED_API_ERROR.UPSTREAM_ERROR);

--- a/apps/web/server/hosted/voice-mint.ts
+++ b/apps/web/server/hosted/voice-mint.ts
@@ -125,7 +125,11 @@ export async function handleVoiceMint(options: VoiceMintOptions): Promise<Respon
   }
 
   const payload: unknown = await response.json().catch(() => undefined);
-  const credential = payload === undefined ? undefined : realtimeCredentialFromResponse(payload);
+  // The resolved model rides along as the fallback, like the desktop's own
+  // minter: a payload that omits its model still labels the credential with
+  // the model it was actually minted for.
+  const credential =
+    payload === undefined ? undefined : realtimeCredentialFromResponse(payload, model);
   const now = options.now ?? Date.now;
   if (!credential || !realtimeCredentialIsUsable(credential, now())) {
     return errorResponse(HOSTED_HTTP_STATUS.BAD_GATEWAY, HOSTED_API_ERROR.UPSTREAM_ERROR);

--- a/apps/web/tests/hosted-attention-review.test.ts
+++ b/apps/web/tests/hosted-attention-review.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ATTENTION_DECISION_SCHEMA_NAME,
+  ATTENTION_TRIGGER,
+  attentionInstructions,
+  SESSION_STATUS,
+} from "@sidecar/core";
+import {
+  HOSTED_ATTENTION_DEFAULTS,
+  handleAttentionReview,
+} from "../server/hosted/attention-review";
+import { HOSTED_API_ERROR } from "../server/hosted/http";
+import type { HostedSpend } from "../server/hosted/quota";
+
+const NOW = Date.parse("2026-08-17T12:00:00.000Z");
+const API_KEY = "sk-hosted-secret";
+
+const OPEN_SPEND: HostedSpend = {
+  allowed: true,
+  quota: { used: 2, limit: 500, remaining: 498, resetsAt: NOW + 43_200_000 },
+};
+
+const UPDATE = {
+  trigger: ATTENTION_TRIGGER.STATUS_CHANGED,
+  providerName: "Claude Code",
+  title: "checkout-service",
+  status: SESSION_STATUS.WAITING,
+  recap: "Waiting on a permission decision.",
+};
+
+const SPOKEN_DECISION = {
+  disposition: "speak-during-turn",
+  summary: "Claude Code is waiting on you in checkout-service.",
+  answers_ask: false,
+};
+
+function reviewRequest(body: unknown): Request {
+  return new Request("https://luke.test/api/attention/review", {
+    method: "POST",
+    headers: { authorization: "Bearer token-1" },
+    body: JSON.stringify(body),
+  });
+}
+
+interface UpstreamCall {
+  url?: string;
+  init?: RequestInit;
+}
+
+function upstream(call: UpstreamCall, response: () => Response) {
+  return async (url: string, init: RequestInit): Promise<Response> => {
+    call.url = url;
+    call.init = init;
+    return response();
+  };
+}
+
+function decisionPayload() {
+  return new Response(JSON.stringify({ output_text: JSON.stringify(SPOKEN_DECISION) }), {
+    status: 200,
+  });
+}
+
+function options(overrides: Partial<Parameters<typeof handleAttentionReview>[0]> = {}) {
+  return {
+    request: reviewRequest(UPDATE),
+    apiKey: API_KEY,
+    resolveUserId: async () => "user-1",
+    spend: async () => OPEN_SPEND,
+    now: () => NOW,
+    ...overrides,
+  };
+}
+
+test("a review sends the build's own construction and answers the parsed decision", async () => {
+  const call: UpstreamCall = {};
+  const response = await handleAttentionReview(options({ fetch: upstream(call, decisionPayload) }));
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.deepEqual(body.decision, {
+    disposition: SPOKEN_DECISION.disposition,
+    summary: SPOKEN_DECISION.summary,
+    decidedAt: NOW,
+  });
+  assert.deepEqual(body.quota, OPEN_SPEND.quota);
+
+  assert.equal(call.url, "https://api.openai.com/v1/responses");
+  const sent = JSON.parse(String(call.init?.body));
+  assert.equal(sent.model, HOSTED_ATTENTION_DEFAULTS.MODEL);
+  assert.equal(sent.instructions, attentionInstructions());
+  assert.equal(sent.store, false);
+  assert.equal(sent.text.format.name, ATTENTION_DECISION_SCHEMA_NAME);
+  assert.match(sent.input, /checkout-service/);
+  assert.equal(
+    String(call.init?.headers && new Headers(call.init.headers).get("authorization")),
+    `Bearer ${API_KEY}`,
+  );
+});
+
+test("an update that fails the wire contract is refused before anything is spent", async () => {
+  let spent = 0;
+  const spend = async () => {
+    spent += 1;
+    return OPEN_SPEND;
+  };
+
+  const malformed = await handleAttentionReview(
+    options({ request: reviewRequest({ ...UPDATE, status: "sleeping" }), spend }),
+  );
+  assert.equal(malformed.status, 400);
+  assert.equal((await malformed.json()).error, HOSTED_API_ERROR.INVALID_REQUEST);
+  assert.equal(spent, 0);
+});
+
+test("the gate order is method, kill switch, token, body, quota", async () => {
+  const wrongMethod = await handleAttentionReview(
+    options({ request: new Request("https://luke.test/api/attention/review") }),
+  );
+  assert.equal(wrongMethod.status, 405);
+
+  const keyless = await handleAttentionReview(options({ apiKey: undefined }));
+  assert.equal(keyless.status, 503);
+
+  const anonymous = await handleAttentionReview(options({ resolveUserId: async () => undefined }));
+  assert.equal(anonymous.status, 401);
+
+  const exhausted = await handleAttentionReview(
+    options({
+      spend: async () => ({
+        allowed: false,
+        quota: { used: 501, limit: 500, remaining: 0, resetsAt: NOW + 43_200_000 },
+      }),
+    }),
+  );
+  assert.equal(exhausted.status, 429);
+  assert.equal((await exhausted.json()).error, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
+});
+
+test("an upstream failure or a decision outside the contract answers 502, never the key", async () => {
+  const refused = await handleAttentionReview(
+    options({ fetch: upstream({}, () => new Response("denied", { status: 429 })) }),
+  );
+  assert.equal(refused.status, 502);
+  const refusedText = await refused.text();
+  assert.equal(JSON.parse(refusedText).upstreamStatus, 429);
+  assert.doesNotMatch(refusedText, /sk-hosted-secret/);
+
+  const undecided = await handleAttentionReview(
+    options({
+      fetch: upstream(
+        {},
+        () => new Response(JSON.stringify({ output_text: "not json" }), { status: 200 }),
+      ),
+    }),
+  );
+  assert.equal(undecided.status, 502);
+});

--- a/apps/web/tests/hosted-attention-review.test.ts
+++ b/apps/web/tests/hosted-attention-review.test.ts
@@ -99,6 +99,17 @@ test("a review sends the build's own construction and answers the parsed decisio
   );
 });
 
+test("a blank model override is no override at all", async () => {
+  const call: UpstreamCall = {};
+  const response = await handleAttentionReview(
+    options({ model: "   ", fetch: upstream(call, decisionPayload) }),
+  );
+
+  assert.equal(response.status, 200);
+  const sent = JSON.parse(String(call.init?.body));
+  assert.equal(sent.model, HOSTED_ATTENTION_DEFAULTS.MODEL);
+});
+
 test("an update that fails the wire contract is refused before anything is spent", async () => {
   let spent = 0;
   const spend = async () => {
@@ -122,6 +133,9 @@ test("the gate order is method, kill switch, token, body, quota", async () => {
 
   const keyless = await handleAttentionReview(options({ apiKey: undefined }));
   assert.equal(keyless.status, 503);
+
+  const blankKey = await handleAttentionReview(options({ apiKey: "   " }));
+  assert.equal(blankKey.status, 503);
 
   const anonymous = await handleAttentionReview(options({ resolveUserId: async () => undefined }));
   assert.equal(anonymous.status, 401);

--- a/apps/web/tests/hosted-bearer.test.ts
+++ b/apps/web/tests/hosted-bearer.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { hostedUserId } from "../server/hosted/bearer";
+
+function request(headers: Record<string, string> = {}): Request {
+  return new Request("https://luke.test/api/voice/mint", { method: "POST", headers });
+}
+
+test("a request without a bearer header resolves nobody and asks the auth service nothing", async () => {
+  let asked = 0;
+  const userId = await hostedUserId(request(), async () => {
+    asked += 1;
+    return { sub: "user-1" };
+  });
+  assert.equal(userId, undefined);
+  assert.equal(asked, 0);
+});
+
+test("a valid token resolves to the auth service's own subject", async () => {
+  let forwarded: string | null = null;
+  const userId = await hostedUserId(request({ authorization: "Bearer token-1" }), async (input) => {
+    forwarded = input.headers.get("authorization");
+    return { sub: "user-1", email: "dev@example.com" };
+  });
+  assert.equal(userId, "user-1");
+  assert.equal(forwarded, "Bearer token-1");
+});
+
+test("a rejected, malformed, or subjectless answer is one indistinguishable no", async () => {
+  const rejected = await hostedUserId(request({ authorization: "Bearer expired" }), async () => {
+    throw new Error("invalid_token");
+  });
+  assert.equal(rejected, undefined);
+
+  const malformed = await hostedUserId(
+    request({ authorization: "Bearer odd" }),
+    async () => "not a record",
+  );
+  assert.equal(malformed, undefined);
+
+  const subjectless = await hostedUserId(request({ authorization: "Bearer odd" }), async () => ({
+    sub: "",
+  }));
+  assert.equal(subjectless, undefined);
+});

--- a/apps/web/tests/hosted-quota.test.ts
+++ b/apps/web/tests/hosted-quota.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { hostedUsage } from "../server/db/usage-schema";
+import {
+  HOSTED_DAILY_LIMIT,
+  HOSTED_METER,
+  spendHostedMeter,
+  utcDayEnd,
+  utcDayKey,
+} from "../server/hosted/quota";
+
+const NOON_UTC = Date.parse("2026-08-17T12:00:00.000Z");
+
+/**
+ * A database that answers the one upsert the meter makes, recording what was
+ * asked. The chain mirrors drizzle's fluent insert; the cast is the same seam
+ * the migration tests use for `pg.Client`.
+ */
+function usageDatabase(row: { voiceCalls: number; attentionReviews: number }) {
+  const calls: { values?: Record<string, unknown>; set?: Record<string, unknown> } = {};
+  const database = {
+    insert(table: unknown) {
+      assert.equal(table, hostedUsage);
+      return {
+        values(values: Record<string, unknown>) {
+          calls.values = values;
+          return {
+            onConflictDoUpdate(update: { set: Record<string, unknown> }) {
+              calls.set = update.set;
+              return {
+                returning: async () => [{ ...values, ...row }],
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+  return { database: database as Parameters<typeof spendHostedMeter>[0], calls };
+}
+
+test("a day key is the UTC date and resets at the following midnight", () => {
+  assert.equal(utcDayKey(NOON_UTC), "2026-08-17");
+  assert.equal(utcDayEnd("2026-08-17"), Date.parse("2026-08-18T00:00:00.000Z"));
+});
+
+test("spending a voice call increments only its own counter", async () => {
+  const { database, calls } = usageDatabase({ voiceCalls: 1, attentionReviews: 0 });
+  const spend = await spendHostedMeter(database, {
+    userId: "user-1",
+    meter: HOSTED_METER.VOICE_CALL,
+    now: NOON_UTC,
+  });
+
+  assert.deepEqual(
+    { userId: calls.values?.userId, day: calls.values?.day },
+    { userId: "user-1", day: "2026-08-17" },
+  );
+  assert.equal(calls.values?.voiceCalls, 1);
+  assert.equal(calls.values?.attentionReviews, 0);
+  assert.deepEqual(Object.keys(calls.set ?? {}), ["voiceCalls"]);
+  assert.equal(spend.allowed, true);
+  assert.deepEqual(spend.quota, {
+    used: 1,
+    limit: HOSTED_DAILY_LIMIT[HOSTED_METER.VOICE_CALL],
+    remaining: HOSTED_DAILY_LIMIT[HOSTED_METER.VOICE_CALL] - 1,
+    resetsAt: utcDayEnd("2026-08-17"),
+  });
+});
+
+test("an attention review spends its own meter, not the voice one", async () => {
+  const { database, calls } = usageDatabase({ voiceCalls: 0, attentionReviews: 3 });
+  const spend = await spendHostedMeter(database, {
+    userId: "user-1",
+    meter: HOSTED_METER.ATTENTION_REVIEW,
+    now: NOON_UTC,
+  });
+
+  assert.equal(calls.values?.voiceCalls, 0);
+  assert.equal(calls.values?.attentionReviews, 1);
+  assert.deepEqual(Object.keys(calls.set ?? {}), ["attentionReviews"]);
+  assert.equal(spend.allowed, true);
+  assert.equal(spend.quota.used, 3);
+});
+
+test("the ceiling itself is allowed and the next use is refused with nothing left", async () => {
+  const limit = HOSTED_DAILY_LIMIT[HOSTED_METER.VOICE_CALL];
+
+  const atLimit = await spendHostedMeter(
+    usageDatabase({ voiceCalls: limit, attentionReviews: 0 }).database,
+    { userId: "user-1", meter: HOSTED_METER.VOICE_CALL, now: NOON_UTC },
+  );
+  assert.equal(atLimit.allowed, true);
+  assert.equal(atLimit.quota.remaining, 0);
+
+  const overLimit = await spendHostedMeter(
+    usageDatabase({ voiceCalls: limit + 1, attentionReviews: 0 }).database,
+    { userId: "user-1", meter: HOSTED_METER.VOICE_CALL, now: NOON_UTC },
+  );
+  assert.equal(overLimit.allowed, false);
+  assert.equal(overLimit.quota.remaining, 0);
+});

--- a/apps/web/tests/hosted-voice-mint.test.ts
+++ b/apps/web/tests/hosted-voice-mint.test.ts
@@ -93,6 +93,17 @@ test("an empty body mints the build's own defaults", async () => {
   assert.equal(sent.session.audio.output.speed, REALTIME_DEFAULTS.SPEED);
 });
 
+test("a blank model override is no override at all", async () => {
+  const call: UpstreamCall = {};
+  const response = await handleVoiceMint(
+    options({ model: "   ", fetch: upstream(call, mintedPayload) }),
+  );
+
+  assert.equal(response.status, 200);
+  const sent = JSON.parse(String(call.init?.body));
+  assert.equal(sent.session.model, REALTIME_DEFAULTS.MODEL);
+});
+
 test("a voice or pace outside the build's sets is refused before anything is spent", async () => {
   let spent = 0;
   const spend = async () => {
@@ -119,6 +130,10 @@ test("the gate order is method, kill switch, token, body, quota", async () => {
   const keyless = await handleVoiceMint(options({ apiKey: undefined }));
   assert.equal(keyless.status, 503);
   assert.equal((await keyless.json()).error, HOSTED_API_ERROR.UNAVAILABLE);
+
+  const blankKey = await handleVoiceMint(options({ apiKey: "   " }));
+  assert.equal(blankKey.status, 503);
+  assert.equal((await blankKey.json()).error, HOSTED_API_ERROR.UNAVAILABLE);
 
   const anonymous = await handleVoiceMint(options({ resolveUserId: async () => undefined }));
   assert.equal(anonymous.status, 401);

--- a/apps/web/tests/hosted-voice-mint.test.ts
+++ b/apps/web/tests/hosted-voice-mint.test.ts
@@ -93,6 +93,18 @@ test("an empty body mints the build's own defaults", async () => {
   assert.equal(sent.session.audio.output.speed, REALTIME_DEFAULTS.SPEED);
 });
 
+test("a configured model labels the credential even when the payload omits its own", async () => {
+  const call: UpstreamCall = {};
+  const response = await handleVoiceMint(
+    options({ model: "gpt-realtime-next", fetch: upstream(call, mintedPayload) }),
+  );
+
+  assert.equal(response.status, 200);
+  const sent = JSON.parse(String(call.init?.body));
+  assert.equal(sent.session.model, "gpt-realtime-next");
+  assert.equal((await response.json()).connection.model, "gpt-realtime-next");
+});
+
 test("a blank model override is no override at all", async () => {
   const call: UpstreamCall = {};
   const response = await handleVoiceMint(

--- a/apps/web/tests/hosted-voice-mint.test.ts
+++ b/apps/web/tests/hosted-voice-mint.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { REALTIME_DEFAULTS, REALTIME_VOICE, REALTIME_VOICE_SPEED } from "@sidecar/core";
+import { HOSTED_API_ERROR } from "../server/hosted/http";
+import type { HostedSpend } from "../server/hosted/quota";
+import { handleVoiceMint } from "../server/hosted/voice-mint";
+
+const NOW = Date.parse("2026-08-17T12:00:00.000Z");
+const API_KEY = "sk-hosted-secret";
+
+const OPEN_SPEND: HostedSpend = {
+  allowed: true,
+  quota: { used: 1, limit: 50, remaining: 49, resetsAt: NOW + 43_200_000 },
+};
+
+const SPENT: HostedSpend = {
+  allowed: false,
+  quota: { used: 51, limit: 50, remaining: 0, resetsAt: NOW + 43_200_000 },
+};
+
+function mintRequest(body?: unknown, headers: Record<string, string> = {}): Request {
+  return new Request("https://luke.test/api/voice/mint", {
+    method: "POST",
+    headers: { authorization: "Bearer token-1", ...headers },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+}
+
+interface UpstreamCall {
+  url?: string;
+  init?: RequestInit;
+}
+
+function upstream(call: UpstreamCall, response: () => Response) {
+  return async (url: string, init: RequestInit): Promise<Response> => {
+    call.url = url;
+    call.init = init;
+    return response();
+  };
+}
+
+function mintedPayload() {
+  return new Response(JSON.stringify({ value: "eph-secret", expires_at: (NOW + 60_000) / 1000 }), {
+    status: 200,
+  });
+}
+
+function options(overrides: Partial<Parameters<typeof handleVoiceMint>[0]> = {}) {
+  return {
+    request: mintRequest(),
+    apiKey: API_KEY,
+    resolveUserId: async () => "user-1",
+    spend: async () => OPEN_SPEND,
+    now: () => NOW,
+    ...overrides,
+  };
+}
+
+test("a mint hands back an ephemeral credential aimed at OpenAI's own calls endpoint", async () => {
+  const call: UpstreamCall = {};
+  const response = await handleVoiceMint(
+    options({
+      request: mintRequest({ voice: REALTIME_VOICE.MARIN, speed: REALTIME_VOICE_SPEED.QUICK }),
+      fetch: upstream(call, mintedPayload),
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.deepEqual(body.connection, {
+    value: "eph-secret",
+    expiresAt: NOW + 60_000,
+    model: REALTIME_DEFAULTS.MODEL,
+    callsUrl: "https://api.openai.com/v1/realtime/calls",
+  });
+  assert.deepEqual(body.quota, OPEN_SPEND.quota);
+
+  assert.equal(call.url, "https://api.openai.com/v1/realtime/client_secrets");
+  const sent = JSON.parse(String(call.init?.body));
+  assert.equal(sent.session.model, REALTIME_DEFAULTS.MODEL);
+  assert.equal(sent.session.audio.output.voice, REALTIME_VOICE.MARIN);
+  assert.equal(sent.session.audio.output.speed, REALTIME_VOICE_SPEED.QUICK);
+  assert.equal(sent.session.audio.input.turn_detection, null);
+});
+
+test("an empty body mints the build's own defaults", async () => {
+  const call: UpstreamCall = {};
+  const response = await handleVoiceMint(options({ fetch: upstream(call, mintedPayload) }));
+
+  assert.equal(response.status, 200);
+  const sent = JSON.parse(String(call.init?.body));
+  assert.equal(sent.session.audio.output.voice, REALTIME_DEFAULTS.VOICE);
+  assert.equal(sent.session.audio.output.speed, REALTIME_DEFAULTS.SPEED);
+});
+
+test("a voice or pace outside the build's sets is refused before anything is spent", async () => {
+  let spent = 0;
+  const spend = async () => {
+    spent += 1;
+    return OPEN_SPEND;
+  };
+  const badVoice = await handleVoiceMint(
+    options({ request: mintRequest({ voice: "not-a-voice" }), spend }),
+  );
+  const badSpeed = await handleVoiceMint(options({ request: mintRequest({ speed: 9 }), spend }));
+
+  assert.equal(badVoice.status, 400);
+  assert.equal((await badVoice.json()).error, HOSTED_API_ERROR.INVALID_REQUEST);
+  assert.equal(badSpeed.status, 400);
+  assert.equal(spent, 0);
+});
+
+test("the gate order is method, kill switch, token, body, quota", async () => {
+  const wrongMethod = await handleVoiceMint(
+    options({ request: new Request("https://luke.test/api/voice/mint", { method: "GET" }) }),
+  );
+  assert.equal(wrongMethod.status, 405);
+
+  const keyless = await handleVoiceMint(options({ apiKey: undefined }));
+  assert.equal(keyless.status, 503);
+  assert.equal((await keyless.json()).error, HOSTED_API_ERROR.UNAVAILABLE);
+
+  const anonymous = await handleVoiceMint(options({ resolveUserId: async () => undefined }));
+  assert.equal(anonymous.status, 401);
+  assert.equal((await anonymous.json()).error, HOSTED_API_ERROR.INVALID_TOKEN);
+
+  const exhausted = await handleVoiceMint(options({ spend: async () => SPENT }));
+  assert.equal(exhausted.status, 429);
+  const body = await exhausted.json();
+  assert.equal(body.error, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
+  assert.deepEqual(body.quota, SPENT.quota);
+});
+
+test("an upstream refusal answers with its status and never the key", async () => {
+  const call: UpstreamCall = {};
+  const response = await handleVoiceMint(
+    options({ fetch: upstream(call, () => new Response("denied", { status: 401 })) }),
+  );
+
+  assert.equal(response.status, 502);
+  const text = await response.text();
+  assert.equal(JSON.parse(text).error, HOSTED_API_ERROR.UPSTREAM_ERROR);
+  assert.equal(JSON.parse(text).upstreamStatus, 401);
+  assert.doesNotMatch(text, /sk-hosted-secret/);
+});
+
+test("a credential that is malformed or already dead is refused rather than served", async () => {
+  const malformed = await handleVoiceMint(
+    options({
+      fetch: upstream({}, () => new Response(JSON.stringify({ odd: true }), { status: 200 })),
+    }),
+  );
+  assert.equal(malformed.status, 502);
+
+  const expired = await handleVoiceMint(
+    options({
+      fetch: upstream(
+        {},
+        () =>
+          new Response(JSON.stringify({ value: "eph-secret", expires_at: (NOW - 1_000) / 1000 }), {
+            status: 200,
+          }),
+      ),
+    }),
+  );
+  assert.equal(expired.status, 502);
+});

--- a/packages/sidecar-core/src/attention-openai.ts
+++ b/packages/sidecar-core/src/attention-openai.ts
@@ -1,0 +1,89 @@
+import { ATTENTION_DECISION_SCHEMA, ATTENTION_DECISION_SCHEMA_NAME } from "./attention";
+import {
+  type AttentionPromptUpdate,
+  attentionInstructions,
+  attentionUpdateInput,
+} from "./attention-prompt";
+import { isRecord, text } from "./json";
+
+/**
+ * The one OpenAI Responses request an attention review may be. The desktop
+ * evaluator sends it on the developer's own key and the hosted endpoint sends
+ * it on Luke's, so it is built here once: the instructions, the decision
+ * schema, and the refusal to store are fixed by the build on both paths, and
+ * only the bounded update varies between two requests.
+ */
+
+export const ATTENTION_RESPONSES_PATH = "/responses";
+
+const RESPONSES_TEXT_FORMAT_TYPE = "json_schema";
+const RESPONSES_OUTPUT_TEXT_TYPE = "output_text";
+
+export interface AttentionResponsesOptions {
+  model: string;
+  maximumOutputTokens: number;
+}
+
+/** Builds the Responses request body one bounded update is reviewed with. */
+export function attentionResponsesRequest(
+  update: AttentionPromptUpdate,
+  options: AttentionResponsesOptions,
+) {
+  return {
+    model: options.model,
+    instructions: attentionInstructions(),
+    input: attentionUpdateInput(update),
+    max_output_tokens: options.maximumOutputTokens,
+    // The update is reviewed and discarded; the API is never asked to keep it.
+    store: false,
+    text: {
+      format: {
+        type: RESPONSES_TEXT_FORMAT_TYPE,
+        name: ATTENTION_DECISION_SCHEMA_NAME,
+        schema: ATTENTION_DECISION_SCHEMA,
+        strict: true,
+      },
+    },
+  };
+}
+
+function outputTextFromContent(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((entry) =>
+      isRecord(entry) && entry.type === RESPONSES_OUTPUT_TEXT_TYPE && typeof entry.text === "string"
+        ? entry.text
+        : "",
+    )
+    .join("");
+}
+
+/**
+ * Reads the structured decision out of a Responses payload without depending on
+ * where a given API version places it.
+ */
+export function attentionResponsesOutputText(payload: unknown): string | undefined {
+  if (!isRecord(payload)) return undefined;
+  if (typeof payload.output_text === "string") return text(payload.output_text);
+  if (!Array.isArray(payload.output)) return undefined;
+  return text(
+    payload.output
+      .map((item) => (isRecord(item) ? outputTextFromContent(item.content) : ""))
+      .join(""),
+  );
+}
+
+/**
+ * Describes why a payload carried no decision. A model that spends its output
+ * budget on reasoning returns `incomplete` with empty output, which would
+ * otherwise look identical to a healthy silent pass.
+ */
+export function attentionResponsesMissingReason(payload: unknown): string {
+  if (!isRecord(payload)) return "";
+  const status = typeof payload.status === "string" ? payload.status : undefined;
+  const details = isRecord(payload.incomplete_details) ? payload.incomplete_details : undefined;
+  const reason = typeof details?.reason === "string" ? details.reason : undefined;
+  if (status && reason) return ` (${status}: ${reason})`;
+  if (status) return ` (${status})`;
+  return "";
+}

--- a/packages/sidecar-core/src/attention-prompt.ts
+++ b/packages/sidecar-core/src/attention-prompt.ts
@@ -147,9 +147,10 @@ export function attentionPromptUpdateFromWire(value: unknown): AttentionPromptUp
 
   const trigger = attentionTriggerFromWire(value.trigger);
   const status = sessionStatusFromWire(value.status);
+  // The roster bounds a provider's display name like a title, so the wire does too.
   const providerName = boundedText(
     typeof value.providerName === "string" ? value.providerName : undefined,
-    maximumSessionDetailLength,
+    maximumSessionTitleLength,
   );
   const title = boundedText(
     typeof value.title === "string" ? value.title : undefined,

--- a/packages/sidecar-core/src/attention-prompt.ts
+++ b/packages/sidecar-core/src/attention-prompt.ts
@@ -1,10 +1,22 @@
 import {
-  type AttentionUpdate,
+  ATTENTION_TRIGGER,
+  type AttentionContext,
+  type AttentionTrigger,
+  attentionRequestText,
   DISPOSITION_GUIDANCE,
   maximumAttentionSummaryLength,
 } from "./attention";
 import { ATTENTION_TUNING_EXAMPLES, type AttentionTuningExample } from "./attention-examples";
-import { ATTENTION_DISPOSITION } from "./session";
+import { isRecord } from "./json";
+import {
+  ATTENTION_DISPOSITION,
+  boundedText,
+  maximumSessionDetailLength,
+  maximumSessionRecapLength,
+  maximumSessionTitleLength,
+  SESSION_STATUS,
+  type SessionStatus,
+} from "./session";
 
 const NONE_LABEL = "none";
 
@@ -42,8 +54,27 @@ function renderExample(example: AttentionTuningExample): string {
   ].join("\n");
 }
 
+/**
+ * The fields of an update that enter the evaluator's prompt, and nothing else.
+ * `AttentionUpdate` satisfies this structurally; the narrowing exists so a
+ * hosted review can be asked with exactly what the prompt reads — a session's
+ * identifiers and clock never need to travel, because they never enter the
+ * rendered input.
+ */
+export interface AttentionPromptUpdate {
+  trigger: AttentionTrigger;
+  providerName: string;
+  title: string;
+  workspace?: string;
+  status: SessionStatus;
+  previousStatus?: SessionStatus;
+  recap?: string;
+  context?: AttentionContext;
+  noticeRequest?: string;
+}
+
 /** Renders one bounded update as the only session material a model receives. */
-export function attentionUpdateInput(update: AttentionUpdate): string {
+export function attentionUpdateInput(update: AttentionPromptUpdate): string {
   return [
     `Provider: ${update.providerName}`,
     `Session: ${update.title}`,
@@ -71,4 +102,97 @@ export function attentionInstructions(
   return [...ATTENTION_INSTRUCTION_LINES, "", "Examples:", ...examples.map(renderExample)].join(
     "\n",
   );
+}
+
+const SESSION_STATUS_VALUES: readonly SessionStatus[] = Object.values(SESSION_STATUS);
+const ATTENTION_TRIGGER_VALUES: readonly AttentionTrigger[] = Object.values(ATTENTION_TRIGGER);
+
+function sessionStatusFromWire(value: unknown): SessionStatus | undefined {
+  return typeof value === "string" && SESSION_STATUS_VALUES.includes(value as SessionStatus)
+    ? (value as SessionStatus)
+    : undefined;
+}
+
+function attentionTriggerFromWire(value: unknown): AttentionTrigger | undefined {
+  return typeof value === "string" && ATTENTION_TRIGGER_VALUES.includes(value as AttentionTrigger)
+    ? (value as AttentionTrigger)
+    : undefined;
+}
+
+/**
+ * An optional wire field: absent is fine, a string is trimmed and cut to the
+ * same bound the local surface holds it to, and anything else marks the whole
+ * update malformed rather than being repaired into silence.
+ */
+function optionalWireText(
+  value: unknown,
+  maximumLength: number,
+): { valid: boolean; text?: string } {
+  if (value === undefined) return { valid: true };
+  if (typeof value !== "string") return { valid: false };
+  const bounded = boundedText(value, maximumLength);
+  return { valid: true, ...(bounded !== undefined ? { text: bounded } : {}) };
+}
+
+/**
+ * Validates an update arriving as untrusted JSON — a hosted review request —
+ * down to the fields the prompt reads, each held to the same bound the local
+ * roster holds it to. A value set is checked against the set itself, a
+ * malformed field refuses the whole update rather than being repaired, and the
+ * developer's ask is refused outright when it fails the registry's own rule,
+ * because a cut ask asks for something its author did not.
+ */
+export function attentionPromptUpdateFromWire(value: unknown): AttentionPromptUpdate | undefined {
+  if (!isRecord(value)) return undefined;
+
+  const trigger = attentionTriggerFromWire(value.trigger);
+  const status = sessionStatusFromWire(value.status);
+  const providerName = boundedText(
+    typeof value.providerName === "string" ? value.providerName : undefined,
+    maximumSessionDetailLength,
+  );
+  const title = boundedText(
+    typeof value.title === "string" ? value.title : undefined,
+    maximumSessionTitleLength,
+  );
+  if (!trigger || !status || !providerName || !title) return undefined;
+
+  const previousStatus =
+    value.previousStatus === undefined ? undefined : sessionStatusFromWire(value.previousStatus);
+  if (value.previousStatus !== undefined && !previousStatus) return undefined;
+
+  const workspace = optionalWireText(value.workspace, maximumSessionTitleLength);
+  const recap = optionalWireText(value.recap, maximumSessionRecapLength);
+  if (!workspace.valid || !recap.valid) return undefined;
+
+  if (value.context !== undefined && !isRecord(value.context)) return undefined;
+  const contextRecord = isRecord(value.context) ? value.context : {};
+  const repository = optionalWireText(contextRecord.repository, maximumSessionDetailLength);
+  const branch = optionalWireText(contextRecord.branch, maximumSessionDetailLength);
+  const activity = optionalWireText(contextRecord.activity, maximumSessionDetailLength);
+  const error = optionalWireText(contextRecord.error, maximumSessionDetailLength);
+  if (!repository.valid || !branch.valid || !activity.valid || !error.valid) return undefined;
+
+  const noticeRequest =
+    value.noticeRequest === undefined ? undefined : attentionRequestText(value.noticeRequest);
+  if (value.noticeRequest !== undefined && !noticeRequest) return undefined;
+
+  const context: AttentionContext = {
+    ...(repository.text ? { repository: repository.text } : {}),
+    ...(branch.text ? { branch: branch.text } : {}),
+    ...(activity.text ? { activity: activity.text } : {}),
+    ...(error.text ? { error: error.text } : {}),
+  };
+
+  return {
+    trigger,
+    providerName,
+    title,
+    status,
+    ...(workspace.text ? { workspace: workspace.text } : {}),
+    ...(previousStatus ? { previousStatus } : {}),
+    ...(recap.text ? { recap: recap.text } : {}),
+    ...(Object.keys(context).length > 0 ? { context } : {}),
+    ...(noticeRequest ? { noticeRequest } : {}),
+  };
 }

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -128,7 +128,15 @@ export {
   type SessionNoticeAsk,
 } from "./attention";
 export {
+  ATTENTION_RESPONSES_PATH,
+  attentionResponsesMissingReason,
+  attentionResponsesOutputText,
+  attentionResponsesRequest,
+} from "./attention-openai";
+export {
+  type AttentionPromptUpdate,
   attentionInstructions,
+  attentionPromptUpdateFromWire,
   attentionUpdateInput,
 } from "./attention-prompt";
 

--- a/packages/sidecar-core/src/session.ts
+++ b/packages/sidecar-core/src/session.ts
@@ -349,7 +349,8 @@ function requiredText(value: string, field: string): string {
   return normalized;
 }
 
-function boundedText(value: string | undefined, maximumLength: number): string | undefined {
+/** Trims and cuts a provider-written field to its bound, or drops an empty one. */
+export function boundedText(value: string | undefined, maximumLength: number): string | undefined {
   const normalized = value?.trim();
   if (!normalized) return undefined;
   return normalized.slice(0, maximumLength);

--- a/packages/sidecar-core/tests/attention-openai.test.ts
+++ b/packages/sidecar-core/tests/attention-openai.test.ts
@@ -104,11 +104,12 @@ test("a wire update outside the build's value sets is refused, not repaired", ()
 test("wire fields are cut to the bounds the local roster holds them to", () => {
   const parsed = attentionPromptUpdateFromWire({
     trigger: ATTENTION_TRIGGER.OBSERVED,
-    providerName: "Claude Code",
+    providerName: "p".repeat(maximumSessionTitleLength + 40),
     title: `  ${"t".repeat(maximumSessionTitleLength + 40)}  `,
     status: SESSION_STATUS.WORKING,
     recap: "r".repeat(maximumSessionRecapLength + 40),
   });
+  assert.equal(parsed?.providerName.length, maximumSessionTitleLength);
   assert.equal(parsed?.title.length, maximumSessionTitleLength);
   assert.equal(parsed?.recap?.length, maximumSessionRecapLength);
 });

--- a/packages/sidecar-core/tests/attention-openai.test.ts
+++ b/packages/sidecar-core/tests/attention-openai.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ATTENTION_DECISION_SCHEMA,
+  ATTENTION_DECISION_SCHEMA_NAME,
+  ATTENTION_TRIGGER,
+  type AttentionPromptUpdate,
+  attentionInstructions,
+  attentionPromptUpdateFromWire,
+  attentionResponsesMissingReason,
+  attentionResponsesOutputText,
+  attentionResponsesRequest,
+  attentionUpdateInput,
+  SESSION_STATUS,
+} from "../src";
+import { maximumAttentionRequestLength } from "../src/attention";
+import { maximumSessionRecapLength, maximumSessionTitleLength } from "../src/session";
+
+const UPDATE: AttentionPromptUpdate = {
+  trigger: ATTENTION_TRIGGER.STATUS_CHANGED,
+  providerName: "Claude Code",
+  title: "checkout-service",
+  status: SESSION_STATUS.WAITING,
+  previousStatus: SESSION_STATUS.WORKING,
+  recap: "Waiting on a permission decision.",
+  context: { branch: "main" },
+  noticeRequest: "tell me when this finishes",
+};
+
+test("the responses request is the shared construction with only the update varying", () => {
+  const request = attentionResponsesRequest(UPDATE, { model: "gpt-test", maximumOutputTokens: 64 });
+
+  assert.equal(request.model, "gpt-test");
+  assert.equal(request.instructions, attentionInstructions());
+  assert.equal(request.input, attentionUpdateInput(UPDATE));
+  assert.equal(request.max_output_tokens, 64);
+  assert.equal(request.store, false);
+  assert.deepEqual(request.text.format, {
+    type: "json_schema",
+    name: ATTENTION_DECISION_SCHEMA_NAME,
+    schema: ATTENTION_DECISION_SCHEMA,
+    strict: true,
+  });
+});
+
+test("output text is read from either place a Responses payload carries it", () => {
+  assert.equal(attentionResponsesOutputText({ output_text: ' {"a":1} ' }), '{"a":1}');
+  assert.equal(
+    attentionResponsesOutputText({
+      output: [{ content: [{ type: "output_text", text: '{"b":2}' }] }],
+    }),
+    '{"b":2}',
+  );
+  assert.equal(attentionResponsesOutputText({ output: [{ content: [] }] }), undefined);
+  assert.equal(attentionResponsesOutputText("not a record"), undefined);
+});
+
+test("a missing decision explains itself from the payload's own status", () => {
+  assert.equal(
+    attentionResponsesMissingReason({
+      status: "incomplete",
+      incomplete_details: { reason: "max_output_tokens" },
+    }),
+    " (incomplete: max_output_tokens)",
+  );
+  assert.equal(attentionResponsesMissingReason({ status: "failed" }), " (failed)");
+  assert.equal(attentionResponsesMissingReason({}), "");
+});
+
+test("a wire update round-trips with every bounded field intact", () => {
+  const parsed = attentionPromptUpdateFromWire(JSON.parse(JSON.stringify(UPDATE)));
+  assert.deepEqual(parsed, UPDATE);
+});
+
+test("a wire update needs only its required fields", () => {
+  const parsed = attentionPromptUpdateFromWire({
+    trigger: ATTENTION_TRIGGER.OBSERVED,
+    providerName: "Codex",
+    title: "billing",
+    status: SESSION_STATUS.COMPLETE,
+  });
+  assert.deepEqual(parsed, {
+    trigger: ATTENTION_TRIGGER.OBSERVED,
+    providerName: "Codex",
+    title: "billing",
+    status: SESSION_STATUS.COMPLETE,
+  });
+});
+
+test("a wire update outside the build's value sets is refused, not repaired", () => {
+  const valid = JSON.parse(JSON.stringify(UPDATE)) as Record<string, unknown>;
+
+  assert.equal(attentionPromptUpdateFromWire({ ...valid, trigger: "made-up" }), undefined);
+  assert.equal(attentionPromptUpdateFromWire({ ...valid, status: "sleeping" }), undefined);
+  assert.equal(attentionPromptUpdateFromWire({ ...valid, previousStatus: "sleeping" }), undefined);
+  assert.equal(attentionPromptUpdateFromWire({ ...valid, title: undefined }), undefined);
+  assert.equal(attentionPromptUpdateFromWire({ ...valid, title: "   " }), undefined);
+  assert.equal(attentionPromptUpdateFromWire({ ...valid, recap: 7 }), undefined);
+  assert.equal(attentionPromptUpdateFromWire({ ...valid, context: "not a record" }), undefined);
+  assert.equal(attentionPromptUpdateFromWire({ ...valid, context: { error: 9 } }), undefined);
+  assert.equal(attentionPromptUpdateFromWire("not a record"), undefined);
+});
+
+test("wire fields are cut to the bounds the local roster holds them to", () => {
+  const parsed = attentionPromptUpdateFromWire({
+    trigger: ATTENTION_TRIGGER.OBSERVED,
+    providerName: "Claude Code",
+    title: `  ${"t".repeat(maximumSessionTitleLength + 40)}  `,
+    status: SESSION_STATUS.WORKING,
+    recap: "r".repeat(maximumSessionRecapLength + 40),
+  });
+  assert.equal(parsed?.title.length, maximumSessionTitleLength);
+  assert.equal(parsed?.recap?.length, maximumSessionRecapLength);
+});
+
+test("an overlong ask refuses the whole update, because a cut ask is a different ask", () => {
+  const overlong = {
+    trigger: ATTENTION_TRIGGER.OBSERVED,
+    providerName: "Claude Code",
+    title: "checkout-service",
+    status: SESSION_STATUS.WORKING,
+    noticeRequest: "a".repeat(maximumAttentionRequestLength + 1),
+  };
+  assert.equal(attentionPromptUpdateFromWire(overlong), undefined);
+  assert.equal(attentionPromptUpdateFromWire({ ...overlong, noticeRequest: 5 }), undefined);
+});


### PR DESCRIPTION
## What

The server half of the hosted free tier: a signed-in desktop no longer needs its own `OPENAI_API_KEY` to get voice and attention review. Two new Vercel endpoints run on the deployment's key, and BYOK stays exactly as it is — the desktop wiring lands in the next PR.

- **`POST /api/voice/mint`** — mints one ephemeral Realtime client secret and returns it with `callsUrl` still pointing at OpenAI, so audio never transits this deployment; only the mint does. The session document is built server-side from the same `realtimeClientSecretRequest` the desktop mints with; the caller's whole say is a voice and a pace, each validated against the sets the build ships.
- **`POST /api/attention/review`** — reviews one bounded `AttentionUpdate` and returns the parsed `AttentionDecision`. Not a proxy: the instructions, decision schema, `store: false`, and output-token cap come from a construction now shared with the desktop evaluator, and the request body is validated field-by-field (`attentionPromptUpdateFromWire`) against the same bounds the local roster holds — value sets refuse rather than repair, and an overlong developer ask refuses the whole update.

## Auth, quota, and the kill switch

- Both endpoints resolve the desktop's OAuth bearer token through the auth service's own `oauth2UserInfo`, in process — expiry, revocation, and scope stay the OAuth provider's answers, never a second implementation.
- A new `hosted_usage` table (migration included) meters each user per UTC day: 50 voice calls, 500 attention reviews. The increment is one atomic upsert taken **before** the upstream call, so racing requests cannot slip past the ceiling; 429 answers carry `{used, limit, remaining, resetsAt}` so the panel can eventually say what ran out. The ceilings are product knobs; the OpenAI project budget behind the key is the backstop.
- Without `OPENAI_API_KEY` in the environment both endpoints answer 503 — the same unset-key kill switch as the feedback endpoint. Upstream failures answer 502 with the status only; no upstream body, no key, and no request material is ever logged or forwarded.

## Core refactor

The desktop evaluator's OpenAI Responses construction moved to `sidecar-core` (`attention-openai.ts`), and `attentionUpdateInput` now takes `AttentionPromptUpdate` — exactly the fields the prompt reads, so a hosted review sends no session identifiers or clocks. The desktop evaluator consumes the shared construction; its behavior is unchanged.

## Environment (deployment)

`OPENAI_API_KEY` (new, enables the tier), optional `LUKE_REALTIME_MODEL` / `LUKE_ATTENTION_MODEL` overrides — the same names the desktop honours.

## Testing

- `./scripts/check.sh` passes (exit 0): repository checks, typecheck, tests, builds.
- New tests: core wire-contract and shared-construction tests (8), plus web tests for bearer resolution, quota arithmetic and racing-ceiling behavior, and both handlers' gate order, upstream failure paths, and key-never-leaks assertions (17).
- Portable-only change: no macOS or UI surface touched, so no `verify.sh` / visual evidence run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/343d02ab-bf79-4850-a697-40e44a08ac75)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32065478029/artifacts/9299765627) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32065478029)

- Commit: `3361ee54a0f603fd3b0d6f607df25e08732d3ef7`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
