### PR TITLE
feat(release): publish the DMG beside the app archive from the tag workflow

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -10,6 +10,10 @@ Pushing a `vX.Y.Z` tag publishes or updates a GitHub Release. A manual
 `workflow_dispatch` run performs the same release rehearsal without publishing; its zip,
 DMG, and checksums are retained as workflow artifacts for 14 days.
 
+While the Apple secrets below are not configured, a tag push skips the workflow cleanly
+and releases are cut by hand instead — see "Manual release" below. Configuring the
+secrets is what turns the tag push into the whole release.
+
 ## Required GitHub Actions secrets
 
 | Secret | Purpose | Source |
@@ -85,10 +89,31 @@ spctl -a -t exec -vv Luke.app
 
 A successful assessment identifies the source as `Notarized Developer ID`.
 
-## Local DMG release
+## Manual release
 
-The same DMG builder the workflow runs is available locally: `pnpm release:macos`
-produces the DMG under `artifacts/release/` using the `luke-notary` keychain
-profile where the workflow decodes the API-key secrets into a key file. The
-local flow does not upload or publish the DMG; distribution remains a separate
-deliberate step.
+Until the workflow's secrets exist, the whole release runs from a Mac holding the
+Developer ID identity and a stored `luke-notary` notarytool profile
+(`xcrun notarytool store-credentials luke-notary`), plus a `gh` login with write access.
+
+```sh
+export LUKE_CODESIGN_IDENTITY='Developer ID Application: …'
+pnpm release:macos                    # signs, notarizes, staples; writes the DMG and zip
+git tag v0.1.1 && git push origin v0.1.1
+./scripts/release/publish-github.sh   # creates the release and uploads every asset
+```
+
+The builder writes both distribution artifacts under `artifacts/release/`, and the
+publish script is what knows the asset set: the versioned DMG and zip with their
+checksums, plus the version-free `Luke.dmg` the website's download link depends on. It
+refuses to publish when the tag does not match `apps/desktop/package.json`, and it
+creates a published, non-draft release — the `releases/latest` link and the app's own
+update check both ignore drafts and prereleases, so a draft is a release nobody can
+reach. Re-running it is safe: assets are replaced with `--clobber`.
+
+Afterwards, confirm the two consumers see the build:
+
+```sh
+curl -sI -o /dev/null -w '%{http_code}\n' \
+  https://github.com/ReviewStage/luke/releases/latest/download/Luke.dmg
+curl -s https://api.github.com/repos/ReviewStage/luke/releases/latest | grep tag_name
+```

--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -1,11 +1,14 @@
 # Releasing Luke for macOS
 
 The release workflow builds, signs, notarizes, staples, and validates an arm64 macOS app. It
-then creates `Luke-X.Y.Z-macos-arm64.zip` and a matching `.sha256` file.
+then creates `Luke-X.Y.Z-macos-arm64.zip` with a matching `.sha256` file, and a notarized
+`Luke-X.Y.Z-arm64.dmg` with its own `.sha256` plus a version-free copy named `Luke.dmg` —
+the asset the website's download button reaches through
+`releases/latest/download/Luke.dmg`, which is why its name must never change.
 
 Pushing a `vX.Y.Z` tag publishes or updates a GitHub Release. A manual
-`workflow_dispatch` run performs the same release rehearsal without publishing; its zip and
-checksum are retained as workflow artifacts for 14 days.
+`workflow_dispatch` run performs the same release rehearsal without publishing; its zip,
+DMG, and checksums are retained as workflow artifacts for 14 days.
 
 ## Required GitHub Actions secrets
 
@@ -63,7 +66,7 @@ git push origin v0.1.0
 
 The tag push is the human release decision. The workflow does not create credentials or
 push tags. It creates a published, non-draft release with generated notes. Re-running the
-workflow is safe: an existing release is reused and its two assets are replaced with
+workflow is safe: an existing release is reused and its assets are replaced with
 `gh release upload --clobber`.
 
 ## Verify a download
@@ -84,7 +87,8 @@ A successful assessment identifies the source as `Notarized Developer ID`.
 
 ## Local DMG release
 
-The GitHub Actions flow above produces a zip and uses App Store Connect API-key
-secrets. The separate local `pnpm release:macos` flow produces a DMG under
-`artifacts/release/` and uses the `luke-notary` keychain profile. It does not
-upload or publish the DMG; distribution remains a separate deliberate step.
+The same DMG builder the workflow runs is available locally: `pnpm release:macos`
+produces the DMG under `artifacts/release/` using the `luke-notary` keychain
+profile where the workflow decodes the API-key secrets into a key file. The
+local flow does not upload or publish the DMG; distribution remains a separate
+deliberate step.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,20 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Whether the signing secrets exist, asked in a step because that is the
+  # only place the `secrets` context is allowed — a job-level `if` cannot
+  # read it, and referencing it there fails the whole workflow at startup.
+  # The expression compares to empty and never prints the secret itself.
+  gate:
+    name: Check for signing secrets
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      signable: ${{ steps.check.outputs.signable }}
+    steps:
+      - id: check
+        run: echo "signable=${{ secrets.MACOS_CERTIFICATE_P12_BASE64 != '' }}" >> "$GITHUB_OUTPUT"
+
   release:
     name: Sign and notarize macOS release
     # Until the Apple secrets are configured, releases are cut by hand with
@@ -20,7 +34,8 @@ jobs:
     # skips this job cleanly instead of failing it. A manual dispatch still
     # runs unconditionally, so asking for a rehearsal without secrets fails
     # loudly at the check below rather than silently doing nothing.
-    if: ${{ github.event_name == 'workflow_dispatch' || secrets.MACOS_CERTIFICATE_P12_BASE64 != '' }}
+    needs: gate
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.gate.outputs.signable == 'true' }}
     runs-on: macos-15
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,12 @@ concurrency:
 jobs:
   release:
     name: Sign and notarize macOS release
+    # Until the Apple secrets are configured, releases are cut by hand with
+    # pnpm release:macos and scripts/release/publish-github.sh — so a tag push
+    # skips this job cleanly instead of failing it. A manual dispatch still
+    # runs unconditionally, so asking for a rehearsal without secrets fails
+    # loudly at the check below rather than silently doing nothing.
+    if: ${{ github.event_name == 'workflow_dispatch' || secrets.MACOS_CERTIFICATE_P12_BASE64 != '' }}
     runs-on: macos-15
     timeout-minutes: 60
     permissions:
@@ -61,7 +67,7 @@ jobs:
           fi
 
           DIST_DIR="$RUNNER_TEMP/luke-release-$VERSION"
-          ASSET_NAME="Luke-$VERSION-macos-arm64.zip"
+          ASSET_NAME=$(node -e "import('./apps/desktop/scripts/release-config.mjs').then((config) => process.stdout.write(config.releaseZipFileName(process.argv[1])))" "$VERSION")
           DMG_ASSET_NAME=$(node -e "import('./apps/desktop/scripts/release-config.mjs').then((config) => process.stdout.write(config.releaseDmgFileName(process.argv[1])))" "$VERSION")
           LATEST_DMG_ASSET_NAME=$(node -e "import('./apps/desktop/scripts/release-config.mjs').then((config) => process.stdout.write(config.RELEASE_LATEST_DMG_FILE_NAME))")
           {
@@ -131,22 +137,13 @@ jobs:
           grep -q "source=Notarized Developer ID" <<< "$assessment"
           xcrun stapler validate "$APP_PATH"
 
-      - name: Create release archives
-        run: |
-          rm -f "$SUBMISSION_ZIP"
-          mkdir -p "$DIST_DIR"
-          ditto -c -k --keepParent "$APP_PATH" "$DIST_DIR/$ASSET_NAME"
-          (
-            cd "$DIST_DIR"
-            shasum -a 256 "$ASSET_NAME" > "$CHECKSUM_NAME"
-          )
-
-      - name: Build notarized DMG
+      - name: Build notarized DMG and archive
         env:
           APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
         run: |
+          rm -f "$SUBMISSION_ZIP"
           key_directory=$(mktemp -d "$RUNNER_TEMP/luke-notary.XXXXXX")
           trap 'rm -rf "$key_directory"' EXIT
           APPLE_API_KEY_PATH="$key_directory/AuthKey_$APPLE_API_KEY_ID.p8"
@@ -155,12 +152,15 @@ jobs:
           export APPLE_API_KEY_PATH
           node apps/desktop/scripts/release.mjs
 
-      - name: Stage DMG release assets
+      - name: Stage release assets
         run: |
+          mkdir -p "$DIST_DIR"
+          cp "artifacts/release/$ASSET_NAME" "$DIST_DIR/$ASSET_NAME"
           cp "artifacts/release/$DMG_ASSET_NAME" "$DIST_DIR/$DMG_ASSET_NAME"
           cp "artifacts/release/$DMG_ASSET_NAME" "$DIST_DIR/$LATEST_DMG_ASSET_NAME"
           (
             cd "$DIST_DIR"
+            shasum -a 256 "$ASSET_NAME" > "$CHECKSUM_NAME"
             shasum -a 256 "$DMG_ASSET_NAME" > "$DMG_CHECKSUM_NAME"
           )
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,11 +62,16 @@ jobs:
 
           DIST_DIR="$RUNNER_TEMP/luke-release-$VERSION"
           ASSET_NAME="Luke-$VERSION-macos-arm64.zip"
+          DMG_ASSET_NAME=$(node -e "import('./apps/desktop/scripts/release-config.mjs').then((config) => process.stdout.write(config.releaseDmgFileName(process.argv[1])))" "$VERSION")
+          LATEST_DMG_ASSET_NAME=$(node -e "import('./apps/desktop/scripts/release-config.mjs').then((config) => process.stdout.write(config.RELEASE_LATEST_DMG_FILE_NAME))")
           {
             echo "VERSION=$VERSION"
             echo "DIST_DIR=$DIST_DIR"
             echo "ASSET_NAME=$ASSET_NAME"
             echo "CHECKSUM_NAME=$ASSET_NAME.sha256"
+            echo "DMG_ASSET_NAME=$DMG_ASSET_NAME"
+            echo "DMG_CHECKSUM_NAME=$DMG_ASSET_NAME.sha256"
+            echo "LATEST_DMG_ASSET_NAME=$LATEST_DMG_ASSET_NAME"
             echo "APP_PATH=$GITHUB_WORKSPACE/apps/desktop/out/Luke-darwin-arm64/Luke.app"
             echo "SUBMISSION_ZIP=$RUNNER_TEMP/Luke-$VERSION-notarization.zip"
           } >> "$GITHUB_ENV"
@@ -136,6 +141,29 @@ jobs:
             shasum -a 256 "$ASSET_NAME" > "$CHECKSUM_NAME"
           )
 
+      - name: Build notarized DMG
+        env:
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
+        run: |
+          key_directory=$(mktemp -d "$RUNNER_TEMP/luke-notary.XXXXXX")
+          trap 'rm -rf "$key_directory"' EXIT
+          APPLE_API_KEY_PATH="$key_directory/AuthKey_$APPLE_API_KEY_ID.p8"
+          printf '%s' "$APPLE_API_KEY_P8_BASE64" | /usr/bin/base64 -D > "$APPLE_API_KEY_PATH"
+          chmod 600 "$APPLE_API_KEY_PATH"
+          export APPLE_API_KEY_PATH
+          node apps/desktop/scripts/release.mjs
+
+      - name: Stage DMG release assets
+        run: |
+          cp "artifacts/release/$DMG_ASSET_NAME" "$DIST_DIR/$DMG_ASSET_NAME"
+          cp "artifacts/release/$DMG_ASSET_NAME" "$DIST_DIR/$LATEST_DMG_ASSET_NAME"
+          (
+            cd "$DIST_DIR"
+            shasum -a 256 "$DMG_ASSET_NAME" > "$DMG_CHECKSUM_NAME"
+          )
+
       - name: Publish GitHub Release
         if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
         env:
@@ -151,6 +179,9 @@ jobs:
           gh release upload "$TAG" \
             "$DIST_DIR/$ASSET_NAME" \
             "$DIST_DIR/$CHECKSUM_NAME" \
+            "$DIST_DIR/$DMG_ASSET_NAME" \
+            "$DIST_DIR/$DMG_CHECKSUM_NAME" \
+            "$DIST_DIR/$LATEST_DMG_ASSET_NAME" \
             --clobber
 
       - name: Preserve rehearsal artifacts
@@ -161,6 +192,9 @@ jobs:
           path: |
             ${{ env.DIST_DIR }}/${{ env.ASSET_NAME }}
             ${{ env.DIST_DIR }}/${{ env.CHECKSUM_NAME }}
+            ${{ env.DIST_DIR }}/${{ env.DMG_ASSET_NAME }}
+            ${{ env.DIST_DIR }}/${{ env.DMG_CHECKSUM_NAME }}
+            ${{ env.DIST_DIR }}/${{ env.LATEST_DMG_ASSET_NAME }}
           if-no-files-found: error
           retention-days: 14
 

--- a/apps/desktop/scripts/release-config.mjs
+++ b/apps/desktop/scripts/release-config.mjs
@@ -3,6 +3,13 @@ import { DMG_WINDOW } from "../../../design/dmg-window.mjs";
 import { PACKAGED_ARCHITECTURE, resolveSigningMode, SIGNING_MODE } from "./package-config.mjs";
 
 export const NOTARY_KEYCHAIN_PROFILE = "luke-notary";
+// The version-free asset name every release carries beside the versioned DMG,
+// so the download link on the website can point at the latest release forever.
+export const RELEASE_LATEST_DMG_FILE_NAME = "Luke.dmg";
+export const NOTARY_CREDENTIAL_SOURCE = {
+  KEYCHAIN_PROFILE: "keychain-profile",
+  KEY_FILE: "key-file",
+};
 export const RELEASE_VOLUME_NAME = "Luke";
 export const DMG_MOUNT_POINT = `/Volumes/${RELEASE_VOLUME_NAME}`;
 export const DMG_STAGING_ENTRIES = [
@@ -169,13 +176,45 @@ export function dmgCodesignArguments(identity, dmgPath) {
   return ["--sign", identity, "--timestamp", dmgPath];
 }
 
-export function notarySubmitArguments(dmgPath) {
+// A developer's Mac holds a stored notarytool profile; a CI runner has only
+// the repository secrets, decoded into a key file for the run. Either form
+// names the same App Store Connect key — the env only says where it lives.
+export function resolveNotaryCredentials(env) {
+  const keyPath = env.APPLE_API_KEY_PATH?.trim();
+  const keyId = env.APPLE_API_KEY_ID?.trim();
+  const issuerId = env.APPLE_API_ISSUER_ID?.trim();
+  const provided = [keyPath, keyId, issuerId].filter(Boolean);
+  if (provided.length === 0) {
+    return { source: NOTARY_CREDENTIAL_SOURCE.KEYCHAIN_PROFILE };
+  }
+  if (provided.length < 3) {
+    throw new Error(
+      "APPLE_API_KEY_PATH, APPLE_API_KEY_ID, and APPLE_API_ISSUER_ID must be provided together",
+    );
+  }
+  return { source: NOTARY_CREDENTIAL_SOURCE.KEY_FILE, keyPath, keyId, issuerId };
+}
+
+function notaryCredentialArguments(credentials) {
+  if (credentials.source === NOTARY_CREDENTIAL_SOURCE.KEY_FILE) {
+    return [
+      "--key",
+      credentials.keyPath,
+      "--key-id",
+      credentials.keyId,
+      "--issuer",
+      credentials.issuerId,
+    ];
+  }
+  return ["--keychain-profile", NOTARY_KEYCHAIN_PROFILE];
+}
+
+export function notarySubmitArguments(dmgPath, credentials) {
   return [
     "notarytool",
     "submit",
     dmgPath,
-    "--keychain-profile",
-    NOTARY_KEYCHAIN_PROFILE,
+    ...notaryCredentialArguments(credentials),
     "--wait",
     "--timeout",
     "20m",
@@ -184,8 +223,8 @@ export function notarySubmitArguments(dmgPath) {
   ];
 }
 
-export function notaryLogArguments(submissionId) {
-  return ["notarytool", "log", submissionId, "--keychain-profile", NOTARY_KEYCHAIN_PROFILE];
+export function notaryLogArguments(submissionId, credentials) {
+  return ["notarytool", "log", submissionId, ...notaryCredentialArguments(credentials)];
 }
 
 export function stapleArguments(dmgPath) {

--- a/apps/desktop/scripts/release-config.mjs
+++ b/apps/desktop/scripts/release-config.mjs
@@ -21,6 +21,13 @@ export function releaseDmgFileName(version) {
   return `Luke-${version}-${PACKAGED_ARCHITECTURE}.dmg`;
 }
 
+// The zip is the future auto-update path's food — Squirrel.Mac updates from
+// an archive of the app, never a DMG — so every release carries it beside the
+// DMG people actually open.
+export function releaseZipFileName(version) {
+  return `Luke-${version}-macos-${PACKAGED_ARCHITECTURE}.zip`;
+}
+
 export function releaseArtifactDirectory(repoRoot) {
   return path.join(repoRoot, "artifacts", "release");
 }

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -22,6 +22,7 @@ import {
   releaseArtifactDirectory,
   releaseDmgFileName,
   releaseSignatureMatchesIdentity,
+  resolveNotaryCredentials,
   resolveReleaseSigning,
   stapleArguments,
   tiffutilHiDpiArguments,
@@ -43,6 +44,7 @@ if (unknownArguments.length > 0) {
 
 const skipNotarization = process.argv.includes("--skip-notarization");
 const signing = resolveReleaseSigning(process.env);
+const notaryCredentials = skipNotarization ? undefined : resolveNotaryCredentials(process.env);
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const appRoot = path.resolve(scriptDirectory, "..");
 const repoRoot = path.resolve(appRoot, "../..");
@@ -203,7 +205,7 @@ try {
   } else {
     let notaryOutput;
     try {
-      notaryOutput = execFileSync("xcrun", notarySubmitArguments(dmgPath), {
+      notaryOutput = execFileSync("xcrun", notarySubmitArguments(dmgPath, notaryCredentials), {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "inherit"],
       });
@@ -218,14 +220,16 @@ try {
     } catch {
       process.stderr.write(notaryOutput);
       throw new Error(
-        "Could not parse the notarization response. Configure credentials with: xcrun notarytool store-credentials luke-notary",
+        "Could not parse the notarization response. Configure credentials with: xcrun notarytool store-credentials luke-notary, or set APPLE_API_KEY_PATH, APPLE_API_KEY_ID, and APPLE_API_ISSUER_ID",
       );
     }
 
     if (submission.status !== "Accepted") {
       process.stderr.write(`Notarization failed with status: ${submission.status ?? "unknown"}\n`);
       if (submission.id) {
-        execFileSync("xcrun", notaryLogArguments(submission.id), { stdio: "inherit" });
+        execFileSync("xcrun", notaryLogArguments(submission.id, notaryCredentials), {
+          stdio: "inherit",
+        });
       }
       throw new Error("Apple did not accept the DMG for notarization");
     }

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -22,6 +22,7 @@ import {
   releaseArtifactDirectory,
   releaseDmgFileName,
   releaseSignatureMatchesIdentity,
+  releaseZipFileName,
   resolveNotaryCredentials,
   resolveReleaseSigning,
   stapleArguments,
@@ -236,6 +237,16 @@ try {
 
     execFileSync("xcrun", stapleArguments(dmgPath), { stdio: "inherit" });
     runVerificationCommands(verificationCommands);
+
+    // The DMG's notarization covers the app inside it, so the app can carry
+    // its own ticket too — and the zip archived from it is what Squirrel.Mac
+    // will one day update from, so it exists only on the notarized path: an
+    // archive that Gatekeeper would refuse is not a release asset.
+    execFileSync("xcrun", stapleArguments(appPath), { stdio: "inherit" });
+    const zipPath = path.join(artifactDirectory, releaseZipFileName(desktopPackage.version));
+    fs.rmSync(zipPath, { force: true });
+    execFileSync("ditto", ["-c", "-k", "--keepParent", appPath, zipPath], { stdio: "inherit" });
+    process.stdout.write(`Released macOS archive: ${zipPath}\n`);
   }
 
   const sizeInMegabytes = (fs.statSync(dmgPath).size / 1_000_000).toFixed(1);

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -23,6 +23,7 @@ import {
   releaseArtifactDirectory,
   releaseDmgFileName,
   releaseSignatureMatchesIdentity,
+  releaseZipFileName,
   resolveNotaryCredentials,
   resolveReleaseSigning,
   stapleArguments,
@@ -274,6 +275,10 @@ test("release DMG store layout is branded and bounded", () => {
   assert.equal(DMG_WINDOW.BOUNDS.WIDTH, DMG_WINDOW.BACKGROUND.PNG.WIDTH);
   assert.equal(DMG_WINDOW.BOUNDS.HEIGHT, DMG_WINDOW.BACKGROUND.PNG.HEIGHT);
   assert.ok(DMG_WINDOW.BACKGROUND.DIRECTORY.startsWith("."));
+});
+
+test("release zip names include the desktop version and packaged architecture", () => {
+  assert.equal(releaseZipFileName("0.1.0"), "Luke-0.1.0-macos-arm64.zip");
 });
 
 test("the latest-DMG asset name carries no version, so its download URL never moves", () => {

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -15,12 +15,15 @@ import {
   hdiutilConvertArguments,
   hdiutilCreateArguments,
   hdiutilDetachArguments,
+  NOTARY_CREDENTIAL_SOURCE,
   notaryLogArguments,
   notarySubmitArguments,
   parseHdiutilAttachPlist,
+  RELEASE_LATEST_DMG_FILE_NAME,
   releaseArtifactDirectory,
   releaseDmgFileName,
   releaseSignatureMatchesIdentity,
+  resolveNotaryCredentials,
   resolveReleaseSigning,
   stapleArguments,
   tiffutilHiDpiArguments,
@@ -273,8 +276,81 @@ test("release DMG store layout is branded and bounded", () => {
   assert.ok(DMG_WINDOW.BACKGROUND.DIRECTORY.startsWith("."));
 });
 
+test("the latest-DMG asset name carries no version, so its download URL never moves", () => {
+  assert.equal(RELEASE_LATEST_DMG_FILE_NAME, "Luke.dmg");
+  assert.ok(!RELEASE_LATEST_DMG_FILE_NAME.includes(PACKAGED_ARCHITECTURE));
+});
+
+test("notary credentials come from the keychain profile unless a key file is provided whole", () => {
+  assert.deepEqual(resolveNotaryCredentials({}), {
+    source: NOTARY_CREDENTIAL_SOURCE.KEYCHAIN_PROFILE,
+  });
+  assert.deepEqual(resolveNotaryCredentials({ APPLE_API_KEY_PATH: "  " }), {
+    source: NOTARY_CREDENTIAL_SOURCE.KEYCHAIN_PROFILE,
+  });
+  assert.deepEqual(
+    resolveNotaryCredentials({
+      APPLE_API_KEY_PATH: "/tmp/AuthKey_KEYID.p8",
+      APPLE_API_KEY_ID: "KEYID",
+      APPLE_API_ISSUER_ID: "issuer-id",
+    }),
+    {
+      source: NOTARY_CREDENTIAL_SOURCE.KEY_FILE,
+      keyPath: "/tmp/AuthKey_KEYID.p8",
+      keyId: "KEYID",
+      issuerId: "issuer-id",
+    },
+  );
+  assert.throws(() => resolveNotaryCredentials({ APPLE_API_KEY_ID: "KEYID" }), /together/);
+  assert.throws(
+    () =>
+      resolveNotaryCredentials({
+        APPLE_API_KEY_PATH: "/tmp/AuthKey_KEYID.p8",
+        APPLE_API_ISSUER_ID: "issuer-id",
+      }),
+    /together/,
+  );
+});
+
+test("release notarization commands carry key-file credentials", () => {
+  const credentials = {
+    source: NOTARY_CREDENTIAL_SOURCE.KEY_FILE,
+    keyPath: "/tmp/AuthKey_KEYID.p8",
+    keyId: "KEYID",
+    issuerId: "issuer-id",
+  };
+  assert.deepEqual(notarySubmitArguments("/tmp/Luke.dmg", credentials), [
+    "notarytool",
+    "submit",
+    "/tmp/Luke.dmg",
+    "--key",
+    "/tmp/AuthKey_KEYID.p8",
+    "--key-id",
+    "KEYID",
+    "--issuer",
+    "issuer-id",
+    "--wait",
+    "--timeout",
+    "20m",
+    "--output-format",
+    "json",
+  ]);
+  assert.deepEqual(notaryLogArguments("submission-id", credentials), [
+    "notarytool",
+    "log",
+    "submission-id",
+    "--key",
+    "/tmp/AuthKey_KEYID.p8",
+    "--key-id",
+    "KEYID",
+    "--issuer",
+    "issuer-id",
+  ]);
+});
+
 test("release notarization commands use the local keychain profile", () => {
-  assert.deepEqual(notarySubmitArguments("/tmp/Luke.dmg"), [
+  const credentials = { source: NOTARY_CREDENTIAL_SOURCE.KEYCHAIN_PROFILE };
+  assert.deepEqual(notarySubmitArguments("/tmp/Luke.dmg", credentials), [
     "notarytool",
     "submit",
     "/tmp/Luke.dmg",
@@ -286,7 +362,7 @@ test("release notarization commands use the local keychain profile", () => {
     "--output-format",
     "json",
   ]);
-  assert.deepEqual(notaryLogArguments("submission-id"), [
+  assert.deepEqual(notaryLogArguments("submission-id", credentials), [
     "notarytool",
     "log",
     "submission-id",

--- a/scripts/release/publish-github.sh
+++ b/scripts/release/publish-github.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Publishes a manual macOS release from what pnpm release:macos just built.
+# The asset set is load-bearing on both ends and encoded here so a by-hand
+# release cannot break either: the version-free Luke.dmg is what the website's
+# download link reaches through releases/latest, and the app's own update
+# check reads the latest release's tag name — so the release must be a
+# published, non-draft, non-prerelease one whose tag matches the desktop
+# version exactly.
+
+SCRIPT_DIRECTORY=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIRECTORY/../.." && pwd)
+cd "$REPO_ROOT"
+
+VERSION=$(node -p "require('./apps/desktop/package.json').version")
+TAG="v$VERSION"
+DMG_ASSET_NAME=$(node -e "import('./apps/desktop/scripts/release-config.mjs').then((config) => process.stdout.write(config.releaseDmgFileName(process.argv[1])))" "$VERSION")
+ZIP_ASSET_NAME=$(node -e "import('./apps/desktop/scripts/release-config.mjs').then((config) => process.stdout.write(config.releaseZipFileName(process.argv[1])))" "$VERSION")
+LATEST_DMG_ASSET_NAME=$(node -e "import('./apps/desktop/scripts/release-config.mjs').then((config) => process.stdout.write(config.RELEASE_LATEST_DMG_FILE_NAME))")
+ARTIFACT_DIRECTORY="artifacts/release"
+DMG_PATH="$ARTIFACT_DIRECTORY/$DMG_ASSET_NAME"
+ZIP_PATH="$ARTIFACT_DIRECTORY/$ZIP_ASSET_NAME"
+
+for artifact_path in "$DMG_PATH" "$ZIP_PATH"; do
+    if [[ ! -f "$artifact_path" ]]; then
+        printf 'error: %s does not exist. Run pnpm release:macos for version %s first.\n' \
+            "$artifact_path" "$VERSION" >&2
+        exit 1
+    fi
+done
+
+if ! git rev-parse -q --verify "refs/tags/$TAG" > /dev/null; then
+    printf 'error: tag %s does not exist. The tag push is the release decision:\n' "$TAG" >&2
+    printf '  git tag %s && git push origin %s\n' "$TAG" "$TAG" >&2
+    exit 1
+fi
+
+staging_directory=$(mktemp -d)
+trap 'rm -rf "$staging_directory"' EXIT
+cp "$DMG_PATH" "$staging_directory/$DMG_ASSET_NAME"
+cp "$DMG_PATH" "$staging_directory/$LATEST_DMG_ASSET_NAME"
+cp "$ZIP_PATH" "$staging_directory/$ZIP_ASSET_NAME"
+(
+    cd "$staging_directory"
+    shasum -a 256 "$DMG_ASSET_NAME" > "$DMG_ASSET_NAME.sha256"
+    shasum -a 256 "$ZIP_ASSET_NAME" > "$ZIP_ASSET_NAME.sha256"
+)
+
+if ! gh release view "$TAG" > /dev/null 2>&1; then
+    gh release create "$TAG" \
+        --verify-tag \
+        --title "Luke $VERSION" \
+        --generate-notes
+fi
+gh release upload "$TAG" \
+    "$staging_directory/$DMG_ASSET_NAME" \
+    "$staging_directory/$DMG_ASSET_NAME.sha256" \
+    "$staging_directory/$LATEST_DMG_ASSET_NAME" \
+    "$staging_directory/$ZIP_ASSET_NAME" \
+    "$staging_directory/$ZIP_ASSET_NAME.sha256" \
+    --clobber
+
+printf 'Published %s. The website reaches this build at:\n' "$TAG"
+printf '  https://github.com/ReviewStage/luke/releases/latest/download/%s\n' "$LATEST_DMG_ASSET_NAME"


### PR DESCRIPTION
## Summary

- The tag-triggered release workflow notarized and published only the `Luke-<version>-macos-arm64.zip` archive; the human-facing DMG had to be built with `pnpm release:macos` and uploaded by hand (which is how v0.1.0 got its lone asset).
- `resolveNotaryCredentials` now reads either credential form from the environment: the stored `luke-notary` keychain profile on a developer's Mac (unchanged local flow), or an App Store Connect key file (`APPLE_API_KEY_PATH` / `APPLE_API_KEY_ID` / `APPLE_API_ISSUER_ID`) decoded from the repository secrets on CI. `notarySubmitArguments`/`notaryLogArguments` take the resolved credentials.
- The workflow now runs the existing DMG builder (`apps/desktop/scripts/release.mjs`) after the app is stapled — so the shipped DMG carries a stapled app — and uploads the versioned DMG, its sha256, and a version-free `Luke.dmg` whose `releases/latest/download/Luke.dmg` URL the website can link forever. Asset names are resolved from `release-config.mjs` in the workflow, so the two cannot drift.
- New `RELEASE_LATEST_DMG_FILE_NAME` constant; rehearsal (`workflow_dispatch`) artifacts include the DMG set.

**Manual release flow (current path).** The Apple secrets stay on Charles's Mac for now, so this PR also makes the by-hand release first-class:
- A tag push **skips** the workflow cleanly while `MACOS_CERTIFICATE_P12_BASE64` is absent (no more red run per tag); a `workflow_dispatch` still fails loudly on the missing-secrets check. Configuring the secrets later is what turns the tag push back into the whole release — no further changes needed.
- `pnpm release:macos` now also staples the app (the DMG's notarization already covers it) and emits `Luke-<version>-macos-arm64.zip` beside the DMG, so a local build produces the full asset set; the workflow stages both archives from the builder's output instead of ditto-ing its own.
- New `scripts/release/publish-github.sh` encodes the by-hand publish: refuses a tag that does not match `apps/desktop/package.json`, creates a published (non-draft) release, uploads versioned DMG + zip + checksums + the version-free `Luke.dmg`, and is safe to re-run (`--clobber`). `.github/RELEASE.md` documents the flow.

## Evidence

- Platform-independent checks: `./scripts/check.sh` exit 0 (Linux); `node --test scripts/release.test.mjs` 17/17 pass
- macOS Electron verification (`./scripts/verify.sh`): `not run` — no app-code change; the workflow change is exercised by the next tag push or a `workflow_dispatch` rehearsal

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32066406528/artifacts/9300110612) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32066406528)

- Commit: `55f044cef418e4dc4b0ad8cd46d9c9a751d8d0d8`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` (no UI change)
- Physical-notch check: `not performed` (no UI change)
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: run the Release workflow via `workflow_dispatch` once the Apple secrets are configured to rehearse the DMG path before tagging v0.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d2288aaa-3db1-4ede-9fc2-9d0cb6e0035b)

