### PR TITLE
feat(web): offer the DMG download from the landing page

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { NotchMock } from "./NotchMock";
-import { GitHubMark, REPOSITORY_URL, SiteFooter, SiteHeader } from "./SiteChrome";
+import { GitHubMark, LATEST_DMG_URL, REPOSITORY_URL, SiteFooter, SiteHeader } from "./SiteChrome";
 
 export function App(): React.JSX.Element {
   return (
@@ -13,11 +13,15 @@ export function App(): React.JSX.Element {
             Luke watches your coding agent sessions and notifies you when they need your attention.
           </p>
           <div className="cta-row">
-            <a className="cta-primary" href={REPOSITORY_URL}>
+            <a className="cta-primary" href={LATEST_DMG_URL}>
+              Download for macOS
+            </a>
+            <a className="cta-secondary" href={REPOSITORY_URL}>
               <GitHubMark />
               View on GitHub
             </a>
           </div>
+          <p className="cta-fineprint">For Apple Silicon Macs running macOS 14 or later.</p>
 
           <NotchMock />
         </section>

--- a/apps/web/src/SiteChrome.tsx
+++ b/apps/web/src/SiteChrome.tsx
@@ -1,6 +1,14 @@
 export const REPOSITORY_URL = "https://github.com/ReviewStage/luke";
 
 /**
+ * Every release uploads a version-free `Luke.dmg` beside the versioned one
+ * (`RELEASE_LATEST_DMG_FILE_NAME` in `apps/desktop/scripts/release-config.mjs`),
+ * so this link always fetches the latest release without the page knowing any
+ * version. The two names may not drift apart.
+ */
+export const LATEST_DMG_URL = `${REPOSITORY_URL}/releases/latest/download/Luke.dmg`;
+
+/**
  * GitHub's mark, drawn in `currentColor` so the stylesheet holds the color in
  * one place. Inlined for the same reason as the favicon: the page ships no
  * binary assets and fetches nothing at runtime.

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -317,6 +317,39 @@ button {
   transform: translateY(1px);
 }
 
+.cta-secondary {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-3) var(--space-5);
+  border: 1px solid var(--hairline-strong);
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--text);
+  font-size: var(--text-sm);
+  font-weight: 650;
+  gap: var(--space-2);
+  text-decoration: none;
+  transition:
+    border-color 140ms ease,
+    transform 180ms var(--swift);
+}
+
+.cta-secondary:hover {
+  border-color: rgba(255, 255, 255, 0.24);
+}
+
+.cta-secondary:active {
+  transform: translateY(1px);
+}
+
+/* What the DMG runs on, said before the download rather than after a failed
+   launch: the app ships arm64-only against macOS 14. */
+.cta-fineprint {
+  margin: var(--space-3) auto 0;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
 /* Notch mock
    Ported from apps/desktop/src/renderer/styles/base.css and styles/sessions.css.
    The class names are the renderer's own so the two sheets stay diffable; the
@@ -1271,6 +1304,7 @@ button {
   .mock .session-row,
   .mock .panel-header,
   .cta-primary,
+  .cta-secondary,
   .nav-link {
     transition-duration: 1ms;
     transition-delay: 0ms;


### PR DESCRIPTION
## Summary

- The hero linked only to the repository, so downloading Luke meant finding the right asset among a release's archives. It now leads with **Download for macOS**, pointing at `${REPOSITORY_URL}/releases/latest/download/Luke.dmg` — the version-free asset every release uploads (see #183) — so the link never moves between releases.
- GitHub becomes the secondary CTA (new `.cta-secondary`, hairline-bordered, added to the reduced-motion list beside `.cta-primary`).
- A fine-print line states the requirements — Apple Silicon, macOS 14 or later — before the download rather than after a failed launch on an Intel Mac.

Merge after #183 has produced a release carrying `Luke.dmg`, or upload the asset to the current release first, so the button never 404s.

## Evidence

- Platform-independent checks: `./scripts/check.sh` exit 0 (Linux); `pnpm --filter @luke/web build` and `typecheck` pass
- macOS Electron verification (`./scripts/verify.sh`): `not run` — web-only change
- Web UI inspected via `vite preview` + headless Chrome; screenshot below

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32005103937/artifacts/9279761540) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32005103937)

- Commit: `b69425bcb3a26306a7c32ffcefcf731e50c3f09a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: attached below

![Landing page with the download button](https://raw.githubusercontent.com/ReviewStage/luke/pr-assets/pr-185/landing-page.png)
- Physical-notch check: `not performed` (web page, no notch surface)
- Device/display configuration: headless Chrome 1440×900

## Notes

- Blockers or follow-up verification: hold merge until `Luke.dmg` exists on the latest release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d2288aaa-3db1-4ede-9fc2-9d0cb6e0035b)

