### PR TITLE
feat(desktop): check for updates automatically and on request

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,16 @@ Trust constraints:
   paced for reading rather than for the voice, because into a mute the caption
   is the speech — and a hint asking for volume. Luke never changes the system
   volume himself; turning it up stays the user's own act on their own keys.
+- The update check is the one request Luke makes with no user-supplied key at
+  all: an unauthenticated read of this repository's latest release name from
+  GitHub's public API, on a timer the `automaticUpdates` setting owns and at
+  the press of the Updates row's button — never in a fixture or capture run.
+  It carries nothing about the user, their sessions, or their keys; only the
+  release's version name is read back, and what a check learns changes only
+  what the row says. The way to a newer build is the browser, at the releases
+  page fixed by the build — nothing read from the network chooses that
+  address — and Luke never modifies the running app. Widening what the check
+  sends, reads, or does is a product decision, not an implementation detail.
 - Keep unsupported capabilities explicit; do not invent fallback controls.
 - Keep Electron renderers sandboxed with context isolation and narrow IPC.
 - Commit only synthetic fixtures and repository-relative paths. This binds

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -19,6 +19,22 @@ not make that identity a Copilot credential. Browser sign-out does not sign the
 desktop out; the desktop keeps its own refresh token until you sign out in
 Luke, or the auth service reports that token revoked or invalid.
 
+## Update check
+
+Luke asks GitHub's public API for the name of this repository's latest
+published release, so the Settings tab's Updates row can say whether a newer
+build exists. The request is unauthenticated and carries no account, session,
+transcript, or key material — GitHub sees what any HTTPS request shows it,
+such as the network address it came from, under GitHub's own policies. Only
+the release's version name is read from the answer.
+
+With automatic checks on — the default — Luke asks at launch and a few times a
+day; turning the Updates section's switch off stops the timed check entirely,
+leaving only the row's own Check for Updates button. Fixture and evidence runs
+never check. What a check learns changes only what the row says: fetching an
+update is your own download in the browser, from the repository's releases
+page, and Luke never modifies the running app.
+
 ## What Luke reads locally
 
 - For Claude Code, Luke finds recent session files, opens bounded tails

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -162,6 +162,7 @@ import {
 } from "./shared/feedback";
 import { parseVoiceHotkey } from "./shared/voice-hotkey";
 import { isWorkspaceAgentSelection } from "./shared/workspace-agents";
+import { UPDATE_ENDPOINT, UpdateService } from "./update-service";
 
 const captureOutput = argumentValue("--capture-evidence");
 const profile = argumentValue("--profile") ?? "idle";
@@ -393,6 +394,13 @@ let realtimeCredentials: OpenAiRealtimeCredentialMinter | undefined;
 // anything the renderer does — and only this process may run a helper.
 const mediaDuck = new MediaDuckController();
 const feedbackDelivery = feedbackDeliveryFromEnvironment();
+// Learns whether a newer release exists, and nothing else. It lives here
+// rather than in a renderer because the timer must survive every window, and
+// what it learns reaches them all through the same broadcast settings use.
+const updateService = new UpdateService({
+  currentVersion: app.getVersion(),
+  onChange: (update) => panels.broadcast(channels.updateChanged, update),
+});
 /**
  * The output's switches as last read, and the helper that reads them. The
  * state lives here rather than in the renderer so bootstrap can carry the
@@ -922,6 +930,7 @@ function registerIpc(): void {
       ...(hotkeys.stop ? { stopHotkey: hotkeys.stop } : {}),
       ...(outputAudio ? { outputAudio } : {}),
       display: panels.diagnostic(display),
+      update: updateService.snapshot(),
       // Bootstrapped through the same relevance gate every broadcast passes:
       // a panel that opens late must not learn of rows the roster has already
       // let go and then hold them past the next broadcast's dedupe.
@@ -1476,6 +1485,37 @@ function registerIpc(): void {
       void releaseHeldNotices();
     },
     refusal: "Could not save that setting on this system.",
+  });
+
+  // The check follows the stored answer at once, like the duck: off must stop
+  // the timer now rather than at the next launch. A run that sends no network
+  // never arms it, whatever the file says.
+  registerSettingHandler(channels.setAutomaticUpdates, {
+    validate(enabled: unknown) {
+      if (typeof enabled !== "boolean") throw new Error("Invalid update check request");
+      return enabled;
+    },
+    save: (enabled) => settingsStore.setAutomaticUpdates(enabled),
+    apply: (result) =>
+      updateService.setAutomatic(result.settings.automaticUpdates && runMode.sendsNetwork),
+    refusal: "Could not save that setting on this system.",
+  });
+
+  // The row's button. Answered rather than fire-and-forget so the row that
+  // asked and the broadcast never disagree; a run that sends no network
+  // answers with the standing snapshot rather than make a request it must not.
+  ipcMain.handle(channels.checkForUpdates, (event) => {
+    if (!trustedSender(event)) throw new Error("Untrusted renderer");
+    if (!runMode.sendsNetwork) return updateService.snapshot();
+    return updateService.check();
+  });
+
+  // The newest release's page, in the browser. The address is fixed here like
+  // the microphone pane's, so nothing an update check read can steer where a
+  // press goes.
+  ipcMain.on(channels.openLatestRelease, (event) => {
+    if (!trustedSender(event)) return;
+    void shell.openExternal(UPDATE_ENDPOINT.LATEST_RELEASE_PAGE_URL);
   });
 
   // A statement of state, not a request: the renderer says whether a spoken
@@ -2831,6 +2871,15 @@ if (!app.requestSingleInstanceLock()) {
       (enabled) => mediaDuck.setEnabled(enabled),
       () => mediaDuck.setEnabled(APP_SETTING_DEFAULTS.duckOtherMedia),
     );
+    // Armed from the settings file alone, like the duck — and never in a run
+    // that must stay deterministic: a fixture or capture run sends no network,
+    // so it never asks GitHub anything.
+    if (runMode.sendsNetwork) {
+      void settingsStore.automaticUpdates().then(
+        (enabled) => updateService.setAutomatic(enabled),
+        () => updateService.setAutomatic(APP_SETTING_DEFAULTS.automaticUpdates),
+      );
+    }
     // The hook registrations converge at every launch. Each provider's
     // failure is logged under its own name and absorbed inside — a launch
     // must never hang on another app's configuration file — so this catch is

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -53,6 +53,9 @@ const bridge: AppBridge = {
   },
   removeCalendarAccount: invoke(channels.removeCalendarAccount),
   setCalendarSelected: invoke(channels.setCalendarSelected),
+  setAutomaticUpdates: invoke(channels.setAutomaticUpdates),
+  checkForUpdates: invoke(channels.checkForUpdates),
+  openLatestRelease: () => ipcRenderer.send(channels.openLatestRelease),
   setVoiceExchangeActive: (active) => {
     ipcRenderer.send(channels.setVoiceExchange, active);
   },
@@ -76,6 +79,7 @@ const bridge: AppBridge = {
   onDisplayChanged: subscribe(channels.displayChanged),
   onSettingsChanged: subscribe(channels.settingsChanged),
   onAccountChanged: subscribe(channels.accountChanged),
+  onUpdateChanged: subscribe(channels.updateChanged),
   onSessionsChanged: subscribe(channels.sessionsChanged),
   onNoticeAsksChanged: subscribe(channels.noticeAsksChanged),
   onWorkspaceProjectsChanged: subscribe(channels.workspaceProjectsChanged),

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -37,6 +37,7 @@ import type {
   SessionOpenResult,
   SettingsResetScope,
   SettingsUpdateResult,
+  UpdateSnapshot,
 } from "../shared/contracts";
 import { ACCOUNT_STATUS, CREDENTIAL_SOURCE, SESSION_OPEN_RESULT_STATUS } from "../shared/contracts";
 import type { CredentialProviderId } from "../shared/credential-providers";
@@ -109,7 +110,12 @@ import {
 import { parsePixels } from "./session-motion";
 import { SESSION_OPTIONS_BUTTON_ID, SESSION_OPTIONS_ID } from "./session-parts";
 import { focusSearchField } from "./session-search";
-import type { MicrophoneControl, PreferenceWrites, ShortcutControl } from "./settings-panel";
+import type {
+  MicrophoneControl,
+  PreferenceWrites,
+  ShortcutControl,
+  UpdateControl,
+} from "./settings-panel";
 import {
   credentialSettingsPage,
   SETTING_PAGE,
@@ -311,6 +317,11 @@ export function App(): React.JSX.Element {
   const [calendars, setCalendars] = useState<readonly ObservedAccountCalendars[]>([]);
   /** Whether the calendar's quiet is holding announcements — the face sleeps on it. */
   const [meetingQuiet, setMeetingQuiet] = useState(false);
+  /**
+   * Where the app stands against the latest release, as last pushed or
+   * answered. Absent until bootstrap carries the main process's snapshot.
+   */
+  const [update, setUpdate] = useState<UpdateSnapshot>();
   /**
    * Which stretch of unbroken silence is on screen, advanced each time one
    * begins. A "Got it" is remembered against the stretch it answered, so it
@@ -714,6 +725,12 @@ export function App(): React.JSX.Element {
     if (calendarConnect.latest()?.busy) window.sidecar.cancelGoogleCalendarSignIn();
     calendarConnect.cancel();
   }, [calendarConnect.cancel, calendarConnect.latest]);
+
+  const changeAutomaticUpdates = useCallback(
+    async (enabled: boolean) =>
+      applySettingsReply(await window.sidecar.setAutomaticUpdates(enabled)),
+    [applySettingsReply],
+  );
 
   /**
    * Asking to write a key is asking for one thing, so the panel gets out of the
@@ -1416,9 +1433,11 @@ export function App(): React.JSX.Element {
           const opening = presentationOf() !== PANEL_PRESENTATION.PANEL;
           // The guide's ids travel as plain text, so one that names no setting
           // of Luke's names no page either — and nothing will fly to it.
-          const page = isAppSettingId(action.setting.id)
+          const settingPage = isAppSettingId(action.setting.id)
             ? SETTING_PAGE[action.setting.id]
             : undefined;
+          // A front-page setting opens no page at all: the tab is the flight.
+          const page = settingPage === SETTINGS_VIEW.ROOT ? undefined : settingPage;
           try {
             await changeMode(true);
             // Queued rather than flown at once. The tab, the page and the wait
@@ -1663,6 +1682,12 @@ export function App(): React.JSX.Element {
     (onChange) => window.sidecar.onAccountChanged(onChange),
     setAccount,
   );
+  // Where the app stands against the latest release: the timed check's
+  // pushes beat a bootstrap snapshot still in flight, like the settings'.
+  const acceptUpdateBootstrap = useBootstrapRacedChannel(
+    (onChange) => window.sidecar.onUpdateChanged(onChange),
+    setUpdate,
+  );
   const acceptOutputAudioBootstrap = useBootstrapRacedChannel(
     (onChange) => window.sidecar.onOutputAudioChanged(onChange),
     setOutputAudio,
@@ -1755,6 +1780,7 @@ export function App(): React.JSX.Element {
       acceptMeetingQuietBootstrap(value.meetingQuiet);
       acceptSettingsBootstrap(value.settings);
       acceptAccountBootstrap(value.account);
+      acceptUpdateBootstrap(value.update);
       setDisplay(value.display);
       if (modeGenerationOf() === bootstrapGeneration) {
         applyAuthoritativeMode(value.mode);
@@ -1824,6 +1850,7 @@ export function App(): React.JSX.Element {
     acceptOutputAudioBootstrap,
     acceptProjectsBootstrap,
     acceptSettingsBootstrap,
+    acceptUpdateBootstrap,
     applyAuthoritativeMode,
     applyPresentation,
     beginEntry,
@@ -2164,10 +2191,20 @@ export function App(): React.JSX.Element {
     onRequest: () => void requestMicrophoneAccess(),
     onOpenSettings: () => window.sidecar.openMicrophoneSettings(),
   };
+  const updates: UpdateControl = {
+    update: update ?? bootstrap.update,
+    // Answered rather than fire-and-forget so the row that asked redraws from
+    // the same snapshot the broadcast carries to every other window.
+    onCheck: async () => {
+      setUpdate(await window.sidecar.checkForUpdates());
+    },
+    onOpenLatest: () => window.sidecar.openLatestRelease(),
+  };
   const preferences: PreferenceWrites = {
     onVoiceCaptionsChange: changeVoiceCaptions,
     onDuckOtherMediaChange: changeDuckOtherMedia,
     onQuietDuringMeetingsChange: changeQuietDuringMeetings,
+    onAutomaticUpdatesChange: changeAutomaticUpdates,
     onVoiceChange: changeVoice,
     onVoiceSpeedChange: changeVoiceSpeed,
     onShowInMenuBarChange: changeShowInMenuBar,
@@ -2271,6 +2308,7 @@ export function App(): React.JSX.Element {
               view: settingsView,
               onViewChange: setSettingsView,
               microphone,
+              updates,
               settings,
               preferences,
               credentials,

--- a/apps/desktop/src/renderer/feedback-panel.tsx
+++ b/apps/desktop/src/renderer/feedback-panel.tsx
@@ -41,7 +41,7 @@ function FeedbackOffer({
  */
 export function FeedbackSection({ control }: { control: FeedbackEntryControl }): React.JSX.Element {
   return (
-    <section className="settings-section" style={{ "--row-index": 2 } as React.CSSProperties}>
+    <section className="settings-section" style={{ "--row-index": 3 } as React.CSSProperties}>
       <h2>
         <MegaphoneIcon />
         Feedback

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -75,6 +75,7 @@ export const APP_SETTING_ID = {
   DEFAULT_WORKSPACE_PROVIDER: "default_workspace_provider",
   WORKSPACE_AGENT_MODEL: "workspace_agent_model",
   WORKSPACE_AGENT_EFFORT: "workspace_agent_effort",
+  AUTOMATIC_UPDATES: "automatic_updates",
 } as const;
 
 export type AppSettingId = (typeof APP_SETTING_ID)[keyof typeof APP_SETTING_ID];
@@ -99,6 +100,8 @@ const VOICE_PAGE = `${SETTINGS_TAB}, on its Voice page`;
 const APPEARANCE_PAGE = `${SETTINGS_TAB}, on its Appearance page`;
 const SHORTCUTS_PAGE = `${SETTINGS_TAB}, on its Keyboard shortcuts page`;
 const CONNECTIONS_PAGE = `${SETTINGS_TAB}, on its Connections page`;
+/* The one switch drawn on the front page itself, beside Feedback. */
+const FRONT_PAGE = `${SETTINGS_TAB}, on its front page`;
 
 /** Where the Conductor agent choices live, said once for both their entries. */
 const CONDUCTOR_ROW_PATH = `the Conductor row under Cloud Agent API keys, in ${CONNECTIONS_PAGE} — drawn once Conductor is connected`;
@@ -223,6 +226,19 @@ const SETTING_GUIDE: Record<
     defaultValue: appToggleText(APP_SETTING_DEFAULTS.quietDuringMeetings),
     adjustable: true,
     manual: `${CONNECTIONS_PAGE} — drawn once a calendar account is connected`,
+  }),
+  automaticUpdates: (settings) => ({
+    id: APP_SETTING_ID.AUTOMATIC_UPDATES,
+    label: "Automatic update checks",
+    description:
+      "Whether Luke asks GitHub for the latest release name a few times a day, so the Updates " +
+      "row can say a newer one exists. Nothing about the developer or their sessions is sent, " +
+      "and fetching an update stays a by-hand download in the browser.",
+    kind: APP_SETTING_KIND.TOGGLE,
+    value: appToggleText(settings.automaticUpdates),
+    defaultValue: appToggleText(APP_SETTING_DEFAULTS.automaticUpdates),
+    adjustable: true,
+    manual: FRONT_PAGE,
   }),
   showInMenuBar: (settings) => ({
     id: APP_SETTING_ID.SHOW_IN_MENU_BAR,
@@ -780,6 +796,14 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         ]
       : []),
     {
+      label: "Updates",
+      detail:
+        `The Updates section on ${FRONT_PAGE} says which version this is and whether a newer ` +
+        "release exists. Its button checks GitHub on the spot; with automatic checks on — the " +
+        "default — Luke also asks a few times a day. A newer release is fetched by hand in the " +
+        "browser, from the fixed releases page: Luke never changes the running build himself.",
+    },
+    {
       label: "Quitting",
       detail: `The Quit button at the foot of ${SETTINGS_TAB}, on the sign-in screen when it is shown, or the menu bar item when it is shown.`,
     },
@@ -855,6 +879,7 @@ export async function applySpokenSetting(
     | "setVoiceCaptions"
     | "setDuckOtherMedia"
     | "setQuietDuringMeetings"
+    | "setAutomaticUpdates"
     | "setShowInMenuBar"
     | "setShowInDock"
     | "setShowOnAllDisplays"
@@ -892,20 +917,22 @@ export async function applySpokenSetting(
         ? await bridge.setDuckOtherMedia(enabled)
         : action.setting.id === APP_SETTING_ID.QUIET_DURING_MEETINGS
           ? await bridge.setQuietDuringMeetings(enabled)
-          : action.setting.id === APP_SETTING_ID.SHOW_IN_MENU_BAR
-            ? await bridge.setShowInMenuBar(enabled)
-            : action.setting.id === APP_SETTING_ID.SHOW_IN_DOCK
-              ? await bridge.setShowInDock(enabled)
-              : action.setting.id === APP_SETTING_ID.SHOW_ON_ALL_DISPLAYS
-                ? await bridge.setShowOnAllDisplays(enabled)
-                : action.setting.id === APP_SETTING_ID.VOICE_SPEED && speed !== undefined
-                  ? await bridge.setVoiceSpeed(speed)
-                  : action.setting.id === APP_SETTING_ID.VOICE && isRealtimeVoice(action.value)
-                    ? await bridge.setVoice(action.value)
-                    : action.setting.id === APP_SETTING_ID.FORM_FACTOR &&
-                        isPanelFormFactor(action.value)
-                      ? await bridge.setFormFactor(action.value)
-                      : undefined;
+          : action.setting.id === APP_SETTING_ID.AUTOMATIC_UPDATES
+            ? await bridge.setAutomaticUpdates(enabled)
+            : action.setting.id === APP_SETTING_ID.SHOW_IN_MENU_BAR
+              ? await bridge.setShowInMenuBar(enabled)
+              : action.setting.id === APP_SETTING_ID.SHOW_IN_DOCK
+                ? await bridge.setShowInDock(enabled)
+                : action.setting.id === APP_SETTING_ID.SHOW_ON_ALL_DISPLAYS
+                  ? await bridge.setShowOnAllDisplays(enabled)
+                  : action.setting.id === APP_SETTING_ID.VOICE_SPEED && speed !== undefined
+                    ? await bridge.setVoiceSpeed(speed)
+                    : action.setting.id === APP_SETTING_ID.VOICE && isRealtimeVoice(action.value)
+                      ? await bridge.setVoice(action.value)
+                      : action.setting.id === APP_SETTING_ID.FORM_FACTOR &&
+                          isPanelFormFactor(action.value)
+                        ? await bridge.setFormFactor(action.value)
+                        : undefined;
   if (!result) {
     // An adjustable entry with no carrier is a guide ahead of its wiring;
     // refuse honestly rather than claim a change that never happened.

--- a/apps/desktop/src/renderer/settings-icons.tsx
+++ b/apps/desktop/src/renderer/settings-icons.tsx
@@ -192,6 +192,17 @@ export function MicrophoneIcon(): React.JSX.Element {
 }
 
 /** Drawn rather than typed: a ↗ character depends on a font having one. */
+/** Heads the Updates section: the arrival a newer release waits as. */
+export function DownloadIcon(): React.JSX.Element {
+  return (
+    <Glyph>
+      <path d="M12 4.2v9.6" />
+      <path d="m7.6 10 4.4 4.4L16.4 10" />
+      <path d="M4.8 19.2h14.4" />
+    </Glyph>
+  );
+}
+
 export function ExternalIcon(): React.JSX.Element {
   return (
     <Glyph className="link-icon">

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -24,6 +24,7 @@ import type {
   MicrophoneStatus,
   ObservedAccountCalendars,
   SettingsResetScope,
+  UpdateSnapshot,
 } from "../shared/contracts";
 import {
   ACCOUNT_PROVIDER,
@@ -79,6 +80,7 @@ import {
   ChevronIcon,
   CloseIcon,
   DisplayIcon,
+  DownloadIcon,
   ExternalIcon,
   FolderIcon,
   KeyboardIcon,
@@ -101,6 +103,7 @@ import {
   type SettingsView,
   settingsNavRowId,
 } from "./settings-views";
+import { UPDATE_ROW_ACTION, updateRow } from "./update-row";
 
 /** One provider the default-workspace rows can offer, by id and display name. */
 export interface WorkspaceProviderOption {
@@ -130,6 +133,20 @@ export interface MicrophoneControl {
 }
 
 /**
+ * Where the app stands against the latest release, and the two things the row
+ * can do about that: ask GitHub now, or open the newer release's page in the
+ * browser. Fetching an update stays the user's own act there — the row never
+ * changes the running build.
+ */
+export interface UpdateControl {
+  update: UpdateSnapshot;
+  /** Asks GitHub for the latest release name, right now. */
+  onCheck: () => Promise<void>;
+  /** Opens the latest release's page, fixed by the build, in the browser. */
+  onOpenLatest: () => void;
+}
+
+/**
  * The one way to write a stored preference. Every settings row that keeps a
  * choice travels through this, so the panel redraws from what was stored
  * rather than from the press — the same shape a credential's control is, for
@@ -149,6 +166,8 @@ export interface PreferenceWrites {
    * answer belongs.
    */
   onQuietDuringMeetingsChange: (enabled: boolean) => Promise<string | undefined>;
+  /** Turns the timed update check on or off. */
+  onAutomaticUpdatesChange: (enabled: boolean) => Promise<string | undefined>;
   /** Chooses the voice Luke speaks with, from the set fixed by this build. */
   onVoiceChange: (voice: RealtimeVoice) => void;
   /** Chooses the pace Luke speaks at, from the set fixed by this build. */
@@ -275,6 +294,7 @@ export interface SettingsPanelProps {
   view: SettingsView;
   onViewChange: (view: SettingsView) => void;
   microphone: MicrophoneControl;
+  updates: UpdateControl;
   settings?: AppSettings;
   preferences: PreferenceWrites;
   /** The one credential being entered anywhere, and everything that can be done to it. */
@@ -2174,7 +2194,7 @@ function AccountSection({
   };
 
   return (
-    <section className="settings-section" style={{ "--row-index": 3 } as React.CSSProperties}>
+    <section className="settings-section" style={{ "--row-index": 4 } as React.CSSProperties}>
       <h2>
         <UserIcon />
         Account
@@ -2310,12 +2330,63 @@ function pageResetControl(
   return undefined;
 }
 
+function UpdatesSection({
+  control,
+  automaticUpdates,
+  onAutomaticUpdatesChange,
+}: {
+  control: UpdateControl;
+  automaticUpdates: boolean;
+  onAutomaticUpdatesChange: (enabled: boolean) => Promise<string | undefined>;
+}): React.JSX.Element {
+  const row = updateRow(control.update);
+  return (
+    <section className="settings-section" style={{ "--row-index": 2 } as React.CSSProperties}>
+      <h2>
+        <DownloadIcon />
+        Updates
+      </h2>
+      <div className="settings-row">
+        <span className="settings-copy">
+          <span className="settings-name">
+            <strong>Version {control.update.currentVersion}</strong>
+            {row.current ? <CheckIcon /> : null}
+          </span>
+          <small>{row.detail}</small>
+        </span>
+        {row.action === UPDATE_ROW_ACTION.GET ? (
+          <button type="button" className="quiet-button" onClick={control.onOpenLatest}>
+            Download
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="quiet-button"
+            disabled={row.action === UPDATE_ROW_ACTION.CHECKING}
+            onClick={() => void control.onCheck()}
+          >
+            {row.action === UPDATE_ROW_ACTION.CHECKING ? "Checking…" : "Check for Updates"}
+          </button>
+        )}
+      </div>
+      <SwitchRow
+        label="Check for updates automatically"
+        detail="Asks GitHub for the latest release name a few times a day. Nothing about you or your sessions is sent."
+        errand={APP_SETTING_ID.AUTOMATIC_UPDATES}
+        checked={automaticUpdates}
+        onChange={onAutomaticUpdatesChange}
+      />
+    </section>
+  );
+}
+
 export function SettingsPanel({
   account,
   onSignOut,
   view,
   onViewChange,
   microphone,
+  updates,
   settings,
   preferences,
   credentials,
@@ -2456,6 +2527,14 @@ export function SettingsPanel({
 
       {drawnView !== SETTINGS_VIEW.ROOT ? null : (
         <>
+          {settings ? (
+            <UpdatesSection
+              control={updates}
+              automaticUpdates={settings.automaticUpdates}
+              onAutomaticUpdatesChange={preferences.onAutomaticUpdatesChange}
+            />
+          ) : null}
+
           <FeedbackSection control={feedback} />
 
           {/* The account stands last before the way out: signing out and
@@ -2468,7 +2547,7 @@ export function SettingsPanel({
           <button
             type="button"
             className="quit-button"
-            style={{ "--row-index": 4 } as React.CSSProperties}
+            style={{ "--row-index": 5 } as React.CSSProperties}
             onClick={onQuit}
           >
             <PowerIcon />

--- a/apps/desktop/src/renderer/settings-views.ts
+++ b/apps/desktop/src/renderer/settings-views.ts
@@ -72,7 +72,7 @@ export function pageExitMs(element: Element | null): number {
  * each setting. That the two agree is a test rather than a type, because one
  * is a sentence and the other is a page.
  */
-export const SETTING_PAGE: Record<AppSettingId, SettingsSubview> = {
+export const SETTING_PAGE: Record<AppSettingId, SettingsView> = {
   [APP_SETTING_ID.VOICE]: SETTINGS_VIEW.VOICE,
   [APP_SETTING_ID.VOICE_SPEED]: SETTINGS_VIEW.VOICE,
   [APP_SETTING_ID.VOICE_CAPTIONS]: SETTINGS_VIEW.VOICE,
@@ -84,6 +84,9 @@ export const SETTING_PAGE: Record<AppSettingId, SettingsSubview> = {
   [APP_SETTING_ID.SHOW_IN_DOCK]: SETTINGS_VIEW.APPEARANCE,
   [APP_SETTING_ID.SHOW_ON_ALL_DISPLAYS]: SETTINGS_VIEW.APPEARANCE,
   [APP_SETTING_ID.FORM_FACTOR]: SETTINGS_VIEW.APPEARANCE,
+  // Drawn on the front page itself, beside Feedback: a flight
+  // to it opens no page at all, only the tab.
+  [APP_SETTING_ID.AUTOMATIC_UPDATES]: SETTINGS_VIEW.ROOT,
   // The three the guide describes but marks by-hand-only. Nothing flies to
   // them — a spoken ask is refused before it reaches a page — but where they
   // are drawn is a fact about the settings either way, and answering it here
@@ -108,7 +111,8 @@ export function credentialSettingsPage(providerId: CredentialProviderId): Settin
 }
 
 /** How each page names itself, which is how the guide's by-hand paths word it. */
-export const SETTINGS_PAGE_LABEL: Record<SettingsSubview, string> = {
+export const SETTINGS_PAGE_LABEL: Record<SettingsView, string> = {
+  [SETTINGS_VIEW.ROOT]: "front page",
   [SETTINGS_VIEW.VOICE]: "Voice",
   [SETTINGS_VIEW.APPEARANCE]: "Appearance",
   [SETTINGS_VIEW.SHORTCUTS]: "Keyboard shortcuts",

--- a/apps/desktop/src/renderer/update-row.ts
+++ b/apps/desktop/src/renderer/update-row.ts
@@ -1,0 +1,64 @@
+import { UPDATE_STATUS, type UpdateSnapshot } from "../shared/contracts";
+
+/** The one act the row's button offers in each state. */
+export const UPDATE_ROW_ACTION = {
+  /** Ask GitHub for the latest release name. */
+  CHECK: "check",
+  /** Nothing to press: a check is already out. */
+  CHECKING: "checking",
+  /** Open the latest release's page in the browser. */
+  GET: "get",
+} as const;
+
+export type UpdateRowAction = (typeof UPDATE_ROW_ACTION)[keyof typeof UPDATE_ROW_ACTION];
+
+/** What the update row says, and what its button does. */
+export interface UpdateRow {
+  detail: string;
+  action: UpdateRowAction;
+  /** Whether the running build is positively the latest, for the check mark. */
+  current: boolean;
+}
+
+/**
+ * Reads the row from the last learned answer. Fetching an update is the
+ * user's own act in the browser — the row only ever says where the build
+ * stands and offers the next honest step: check again, wait for the check
+ * already out, or go get the newer release.
+ */
+export function updateRow(update: UpdateSnapshot): UpdateRow {
+  switch (update.status) {
+    case UPDATE_STATUS.CHECKING:
+      return {
+        detail: "Checking the latest release…",
+        action: UPDATE_ROW_ACTION.CHECKING,
+        current: false,
+      };
+    case UPDATE_STATUS.UP_TO_DATE:
+      return {
+        detail: "This is the latest release.",
+        action: UPDATE_ROW_ACTION.CHECK,
+        current: true,
+      };
+    case UPDATE_STATUS.UPDATE_AVAILABLE:
+      return {
+        detail: `Version ${update.latestVersion} is available to download.`,
+        action: UPDATE_ROW_ACTION.GET,
+        current: false,
+      };
+    case UPDATE_STATUS.UNREACHABLE:
+      return {
+        detail: "Could not reach GitHub to check. Try again in a moment.",
+        action: UPDATE_ROW_ACTION.CHECK,
+        current: false,
+      };
+    default:
+      return {
+        // Not an answer: nothing has been learned yet, so the row only offers
+        // to ask rather than posing an unknown as up to date.
+        detail: "The latest release has not been checked for yet.",
+        action: UPDATE_ROW_ACTION.CHECK,
+        current: false,
+      };
+  }
+}

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -55,6 +55,7 @@ const SETTINGS_FIELD = {
   API_KEYS: "apiKeys",
   CALENDAR_ACCOUNTS: "calendarAccounts",
   ASK_HOTKEY: "askHotkey",
+  AUTOMATIC_UPDATES: "automaticUpdates",
   DEFAULT_WORKSPACE_PROVIDER: "defaultWorkspaceProvider",
   DUCK_OTHER_MEDIA: "duckOtherMedia",
   FEEDBACK_SENDS: "feedbackSends",
@@ -207,6 +208,13 @@ interface PersistedSettings {
    * windows somewhere new.
    */
   showOnAllDisplays: boolean;
+  /**
+   * Whether the timed update check runs. On unless the file says `false`
+   * outright, like the media duck: a missing field and a corrupt value both
+   * land on checking, because a build left silently behind is the failure
+   * this setting exists to prevent.
+   */
+  automaticUpdates: boolean;
   /**
    * How Luke stands on a display without a housing, absent until the user has
    * chosen. Held to the offered set like the voice: a value this build does
@@ -528,6 +536,10 @@ function parsePersistedSettings(source: string): PersistedSettings {
       record[SETTINGS_FIELD.SHOW_ON_ALL_DISPLAYS],
       APP_SETTING_DEFAULTS.showOnAllDisplays,
     ),
+    automaticUpdates: booleanSetting(
+      record[SETTINGS_FIELD.AUTOMATIC_UPDATES],
+      APP_SETTING_DEFAULTS.automaticUpdates,
+    ),
     // A form this build does not draw is dropped like an unknown voice.
     ...(isPanelFormFactor(formFactor) ? { formFactor } : {}),
     // A provider this build does not know is dropped the same way: it names
@@ -616,6 +628,7 @@ export class SettingsStore {
       duckOtherMedia: persisted.duckOtherMedia,
       quietDuringMeetings: persisted.quietDuringMeetings,
       showOnAllDisplays: persisted.showOnAllDisplays,
+      automaticUpdates: persisted.automaticUpdates,
       formFactor: persisted.formFactor ?? DEFAULT_PANEL_FORM_FACTOR,
       ...(persisted.defaultWorkspaceProvider
         ? { defaultWorkspaceProvider: persisted.defaultWorkspaceProvider }
@@ -734,6 +747,14 @@ export class SettingsStore {
    */
   async duckOtherMedia(): Promise<boolean> {
     return (await this.#load()).duckOtherMedia;
+  }
+
+  /**
+   * Shallow for the same reason `duckOtherMedia()` is: the update check arms
+   * at startup, and arming it must never be what wakes the OS keychain.
+   */
+  async automaticUpdates(): Promise<boolean> {
+    return (await this.#load()).automaticUpdates;
   }
 
   /**
@@ -912,6 +933,17 @@ export class SettingsStore {
     return this.#setField((persisted) => {
       if (persisted.quietDuringMeetings === enabled) return;
       return { ...persisted, quietDuringMeetings: enabled };
+    });
+  }
+
+  /**
+   * Turns the timed update check on or off. A plain preference like the media
+   * duck's: no cipher, no invalid value, so the write either lands or throws.
+   */
+  async setAutomaticUpdates(enabled: boolean): Promise<SettingsUpdateResult> {
+    return this.#setField((persisted) => {
+      if (persisted.automaticUpdates === enabled) return;
+      return { ...persisted, automaticUpdates: enabled };
     });
   }
 

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -123,6 +123,7 @@ export const APP_SETTING_DEFAULTS = {
   duckOtherMedia: true,
   quietDuringMeetings: true,
   showOnAllDisplays: false,
+  automaticUpdates: true,
 } as const satisfies Partial<Record<keyof AppSettings, boolean>>;
 
 /**
@@ -148,6 +149,39 @@ const SETTINGS_RESET_SCOPE_LIST: readonly SettingsResetScope[] =
 export function isSettingsResetScope(value: unknown): value is SettingsResetScope {
   return SETTINGS_RESET_SCOPE_LIST.includes(value as SettingsResetScope);
 }
+
+/**
+ * Where the app stands against the latest published release, as last learned.
+ * `UNKNOWN` is the state before any check has answered — at launch, and
+ * forever in a run that sends no network — and must be drawn as an offer to
+ * check rather than as an answer.
+ */
+export const UPDATE_STATUS = {
+  UNKNOWN: "unknown",
+  CHECKING: "checking",
+  UP_TO_DATE: "up-to-date",
+  UPDATE_AVAILABLE: "update-available",
+  UNREACHABLE: "unreachable",
+} as const;
+
+export type UpdateStatus = (typeof UPDATE_STATUS)[keyof typeof UPDATE_STATUS];
+
+/**
+ * What the update row draws from. The latest version travels only on the one
+ * state that learned it, and no address ever travels: the page an update is
+ * fetched from is fixed in the main process, so nothing a check read can
+ * steer where a press goes.
+ */
+export type UpdateSnapshot =
+  | { status: typeof UPDATE_STATUS.UNKNOWN; currentVersion: string }
+  | { status: typeof UPDATE_STATUS.CHECKING; currentVersion: string }
+  | { status: typeof UPDATE_STATUS.UP_TO_DATE; currentVersion: string }
+  | {
+      status: typeof UPDATE_STATUS.UPDATE_AVAILABLE;
+      currentVersion: string;
+      latestVersion: string;
+    }
+  | { status: typeof UPDATE_STATUS.UNREACHABLE; currentVersion: string };
 
 /** Renderer-safe settings. Credentials are never sent to a renderer. */
 export interface AppSettings {
@@ -248,6 +282,14 @@ export interface AppSettings {
    * again is what brings him back to it.
    */
   showOnAllDisplays: boolean;
+  /**
+   * Whether Luke asks GitHub for the latest release name on a timer, so the
+   * settings row can say an update exists. On by default and bounded on every
+   * side: the check carries nothing about the user or their sessions, learns
+   * only a version name, and changes only what the row says. Off, the only
+   * check is the row's own button being pressed.
+   */
+  automaticUpdates: boolean;
   /**
    * How Luke stands on a display without a camera housing: a drawn notch
    * pressed into the top edge, or the free-floating bubble every such display
@@ -400,6 +442,8 @@ export interface AppBootstrap {
    */
   outputAudio?: OutputAudioState;
   display: DisplayDiagnostic;
+  /** Where the app stands against the latest release, as last learned. */
+  update: UpdateSnapshot;
   sessions: readonly NormalizedSession[];
   /**
    * The standing asks the developer has made about sessions, so a panel that
@@ -519,6 +563,20 @@ export interface AppBridge {
   resetSettings(scope: SettingsResetScope): Promise<SettingsUpdateResult>;
   /** Turns the quieting of Music and Spotify during a spoken exchange on or off. */
   setDuckOtherMedia(enabled: boolean): Promise<SettingsUpdateResult>;
+  /** Turns the timed update check on or off, and remembers the choice. */
+  setAutomaticUpdates(enabled: boolean): Promise<SettingsUpdateResult>;
+  /**
+   * Asks GitHub for the latest release name, right now, because the row's
+   * button was pressed. The answer is the same snapshot the broadcast
+   * carries, so the row that asked and every other window agree.
+   */
+  checkForUpdates(): Promise<UpdateSnapshot>;
+  /**
+   * Opens the latest release's page in the default browser. The renderer
+   * names an intent and never an address — the page is fixed in the main
+   * process, so nothing an update check read can steer where this goes.
+   */
+  openLatestRelease(): void;
   /**
    * Turns the holding of announcements during calendar meetings on or off.
    * The hold itself lives in the main process, beside the calendar it reads.
@@ -711,6 +769,8 @@ export interface AppBridge {
    */
   onSettingsChanged(callback: (settings: AppSettings) => void): () => void;
   onAccountChanged(callback: (account: AccountSnapshot) => void): () => void;
+  /** Where the app stands against the latest release, whenever that changes. */
+  onUpdateChanged(callback: (update: UpdateSnapshot) => void): () => void;
   onSessionsChanged(callback: (sessions: readonly NormalizedSession[]) => void): () => void;
   /** The standing asks as they change — made, withdrawn, or let go with their sessions. */
   onNoticeAsksChanged(callback: (noticeAsks: readonly SessionNoticeAsk[]) => void): () => void;
@@ -792,6 +852,10 @@ export const channels = {
   setCalendarSelected: "app:set-calendar-selected",
   calendarsChanged: "app:calendars-changed",
   meetingQuietChanged: "app:meeting-quiet-changed",
+  setAutomaticUpdates: "app:set-automatic-updates",
+  checkForUpdates: "app:check-for-updates",
+  openLatestRelease: "app:open-latest-release",
+  updateChanged: "app:update-changed",
   setVoiceExchange: "app:set-voice-exchange",
   openProviderApiKeys: "app:open-provider-api-keys",
   setShowInMenuBar: "app:set-show-in-menu-bar",

--- a/apps/desktop/src/update-service.ts
+++ b/apps/desktop/src/update-service.ts
@@ -1,0 +1,161 @@
+import { isNewerVersion, isRecord, parseReleaseVersion, text } from "@sidecar/core";
+import { UPDATE_STATUS, type UpdateSnapshot } from "./shared/contracts";
+
+/**
+ * The two addresses updating ever touches, fixed here rather than passed in,
+ * so the renderer names an intent and never an address — and nothing a check
+ * read can steer where a press goes. The check is the one request Luke makes
+ * with no user-supplied key at all: an unauthenticated read of the latest
+ * published release's name, carrying nothing about the user or their
+ * sessions.
+ */
+export const UPDATE_ENDPOINT = {
+  LATEST_RELEASE_URL: "https://api.github.com/repos/ReviewStage/luke/releases/latest",
+  LATEST_RELEASE_PAGE_URL: "https://github.com/ReviewStage/luke/releases/latest",
+} as const;
+
+/** GitHub's documented media type and version pin, as the Copilot adapter sends them. */
+const GITHUB_REQUEST_HEADERS: Readonly<Record<string, string>> = {
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2026-03-10",
+};
+
+const UPDATE_CHECK_DEFAULTS = {
+  REQUEST_TIMEOUT_MS: 10_000,
+  /**
+   * Six hours between timed checks: a release lands at most every few days,
+   * and an unauthenticated GitHub read is rate-limited by address, so asking
+   * more often buys nothing but requests.
+   */
+  INTERVAL_MS: 6 * 60 * 60 * 1000,
+} as const;
+
+type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
+
+export interface UpdateServiceOptions {
+  /** The running build's version, as the packaged app reports it. */
+  currentVersion: string;
+  /** Every state the service moves through, for the broadcast to carry. */
+  onChange: (update: UpdateSnapshot) => void;
+  fetch?: FetchLike;
+  requestTimeoutMs?: number;
+  intervalMs?: number;
+}
+
+/**
+ * Learns whether a newer release than the running build has been published,
+ * and nothing else. A failed check is an answer for the row — `unreachable`
+ * — never a throw: status codes alone diagnose the path, and the response's
+ * only read field is the release's tag name, validated as a version before
+ * it is compared or kept. What the service learns changes only what the
+ * settings row says; fetching the update stays the user's own press, on a
+ * page fixed by the build.
+ */
+export class UpdateService {
+  readonly #currentVersion: string;
+  readonly #onChange: (update: UpdateSnapshot) => void;
+  readonly #fetch: FetchLike;
+  readonly #requestTimeoutMs: number;
+  readonly #intervalMs: number;
+  #snapshot: UpdateSnapshot;
+  #inFlight: Promise<UpdateSnapshot> | undefined;
+  #timer: NodeJS.Timeout | undefined;
+
+  constructor(options: UpdateServiceOptions) {
+    this.#currentVersion = options.currentVersion;
+    this.#onChange = options.onChange;
+    this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
+    this.#requestTimeoutMs = options.requestTimeoutMs ?? UPDATE_CHECK_DEFAULTS.REQUEST_TIMEOUT_MS;
+    this.#intervalMs = options.intervalMs ?? UPDATE_CHECK_DEFAULTS.INTERVAL_MS;
+    this.#snapshot = { status: UPDATE_STATUS.UNKNOWN, currentVersion: this.#currentVersion };
+  }
+
+  snapshot(): UpdateSnapshot {
+    return this.#snapshot;
+  }
+
+  /**
+   * Asks for the latest release name once. A check already in flight answers
+   * the new asker too, rather than doubling the request — the timer and the
+   * row's button land on the same read.
+   */
+  check(): Promise<UpdateSnapshot> {
+    this.#inFlight ??= this.#read().then((snapshot) => {
+      this.#inFlight = undefined;
+      this.#move(snapshot);
+      return snapshot;
+    });
+    return this.#inFlight;
+  }
+
+  /**
+   * Starts or stops the timed check. Starting checks at once — a build that
+   * only ever checked hours after launch would spend its first day behind —
+   * and the timer never holds the process open.
+   */
+  setAutomatic(enabled: boolean): void {
+    if (!enabled) {
+      if (this.#timer) clearInterval(this.#timer);
+      this.#timer = undefined;
+      return;
+    }
+    if (this.#timer) return;
+    void this.check();
+    this.#timer = setInterval(() => void this.check(), this.#intervalMs);
+    this.#timer.unref();
+  }
+
+  stop(): void {
+    this.setAutomatic(false);
+  }
+
+  async #read(): Promise<UpdateSnapshot> {
+    this.#move({ status: UPDATE_STATUS.CHECKING, currentVersion: this.#currentVersion });
+    let response: Response;
+    try {
+      response = await this.#fetch(UPDATE_ENDPOINT.LATEST_RELEASE_URL, {
+        headers: GITHUB_REQUEST_HEADERS,
+        signal: AbortSignal.timeout(this.#requestTimeoutMs),
+      });
+    } catch (error) {
+      this.#report(
+        `Update check did not complete: ${error instanceof Error ? error.name : "unknown error"}`,
+      );
+      return { status: UPDATE_STATUS.UNREACHABLE, currentVersion: this.#currentVersion };
+    }
+    if (!response.ok) {
+      this.#report(`Update check failed with status ${response.status}`);
+      return { status: UPDATE_STATUS.UNREACHABLE, currentVersion: this.#currentVersion };
+    }
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch {
+      this.#report("Update check answered with an unreadable body");
+      return { status: UPDATE_STATUS.UNREACHABLE, currentVersion: this.#currentVersion };
+    }
+    const tag = isRecord(payload) ? text(payload.tag_name) : undefined;
+    const latest = tag && parseReleaseVersion(tag) ? tag.trim().replace(/^v/, "") : undefined;
+    if (!latest) {
+      // A release this build cannot name is not an update it can offer.
+      this.#report("Update check answered without a readable release version");
+      return { status: UPDATE_STATUS.UNREACHABLE, currentVersion: this.#currentVersion };
+    }
+    return isNewerVersion(latest, this.#currentVersion)
+      ? {
+          status: UPDATE_STATUS.UPDATE_AVAILABLE,
+          currentVersion: this.#currentVersion,
+          latestVersion: latest,
+        }
+      : { status: UPDATE_STATUS.UP_TO_DATE, currentVersion: this.#currentVersion };
+  }
+
+  #move(snapshot: UpdateSnapshot): void {
+    this.#snapshot = snapshot;
+    this.#onChange(snapshot);
+  }
+
+  #report(message: string): void {
+    process.stderr.write(`${message}\n`);
+  }
+}

--- a/apps/desktop/src/update-service.ts
+++ b/apps/desktop/src/update-service.ts
@@ -80,11 +80,22 @@ export class UpdateService {
    * row's button land on the same read.
    */
   check(): Promise<UpdateSnapshot> {
-    this.#inFlight ??= this.#read().then((snapshot) => {
-      this.#inFlight = undefined;
-      this.#move(snapshot);
-      return snapshot;
-    });
+    this.#inFlight ??= this.#read()
+      .catch((error): UpdateSnapshot => {
+        // A throw anywhere in the read must not leave a dead check parked in
+        // flight, where every later ask would reuse the failure and the row
+        // would say "checking" forever. It lands on the same honest answer an
+        // unreachable service gives, and the next ask is a fresh read.
+        this.#report(
+          `Update check failed: ${error instanceof Error ? error.name : "unknown error"}`,
+        );
+        return { status: UPDATE_STATUS.UNREACHABLE, currentVersion: this.#currentVersion };
+      })
+      .then((snapshot) => {
+        this.#inFlight = undefined;
+        this.#move(snapshot);
+        return snapshot;
+      });
     return this.#inFlight;
   }
 
@@ -152,7 +163,12 @@ export class UpdateService {
 
   #move(snapshot: UpdateSnapshot): void {
     this.#snapshot = snapshot;
-    this.#onChange(snapshot);
+    try {
+      this.#onChange(snapshot);
+    } catch {
+      // A listener's failure is its own — a window torn down mid-broadcast
+      // must not fail the check whose snapshot has already moved.
+    }
   }
 
   #report(message: string): void {

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -612,6 +612,10 @@ test("every adjustable setting is carried to the bridge call its row uses", asyn
       calls.push(`setQuietDuringMeetings:${enabled}`);
       return answered;
     },
+    setAutomaticUpdates: async (enabled: boolean) => {
+      calls.push(`setAutomaticUpdates:${enabled}`);
+      return answered;
+    },
     setShowInMenuBar: async (show: boolean) => {
       calls.push(`setShowInMenuBar:${show}`);
       return answered;
@@ -648,6 +652,7 @@ test("every adjustable setting is carried to the bridge call its row uses", asyn
   }
 
   assert.deepEqual(calls.sort(), [
+    "setAutomaticUpdates:true",
     "setDuckOtherMedia:true",
     "setFormFactor:notch",
     "setQuietDuringMeetings:true",

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -467,6 +467,22 @@ test("announcements wait out meetings until asked otherwise, and the choice surv
   assert.equal(cipher.calls.encrypt, 0);
 });
 
+test("updates are checked for until asked otherwise, and the choice survives a reopen", async (t) => {
+  const directory = await temporaryDirectory(t);
+  // A preference is not a credential, so choosing it must reach the Keychain
+  // not at all.
+  const cipher = countingCipher();
+  const store = storeIn(directory, { cipher });
+
+  assert.equal((await store.snapshot()).automaticUpdates, true);
+  const disabled = await store.setAutomaticUpdates(false);
+
+  assert.equal(disabled.settings.automaticUpdates, false);
+  assert.equal((await storeIn(directory).snapshot()).automaticUpdates, false);
+  assert.equal(cipher.calls.isAvailable, 0);
+  assert.equal(cipher.calls.encrypt, 0);
+});
+
 test("switching the meeting quiet never disturbs a stored key", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);
@@ -489,6 +505,20 @@ test("a corrupt meeting quiet value reads as the default rather than as off", as
   );
 
   assert.equal((await storeIn(directory).snapshot()).quietDuringMeetings, true);
+});
+
+test("a corrupt update check value reads as the default rather than as off", async (t) => {
+  const directory = await temporaryDirectory(t);
+  // The media duck's rule: each lands on its own default, and this one's
+  // default is on — a build left silently behind is the failure the setting
+  // exists to prevent.
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({ version: 2, apiKeys: {}, automaticUpdates: "no" }),
+    "utf8",
+  );
+
+  assert.equal((await storeIn(directory).snapshot()).automaticUpdates, true);
 });
 
 test("keeps each provider's key, environment fallback, and reported source separate", async (t) => {
@@ -547,6 +577,7 @@ test("keeps both keys when two providers are saved at once", async (t) => {
     duckOtherMedia: true,
     quietDuringMeetings: true,
     showOnAllDisplays: false,
+    automaticUpdates: true,
   });
   const reopened = storeIn(directory, { providers: TEST_PROVIDERS });
   assert.equal(await reopened.readApiKey(FIRST_CLOUD), "first-cloud-key");
@@ -748,6 +779,7 @@ test("keeps a Conductor key stored by an earlier version working", async (t) => 
     duckOtherMedia: true,
     quietDuringMeetings: true,
     showOnAllDisplays: false,
+    automaticUpdates: true,
   });
   assert.equal(await storeIn(directory).readApiKey(CONDUCTOR), "conductor-replacement-key");
 });
@@ -772,6 +804,7 @@ test("carries a key belonging to a provider this build does not know", async (t)
     duckOtherMedia: true,
     quietDuringMeetings: true,
     showOnAllDisplays: false,
+    automaticUpdates: true,
   });
 });
 
@@ -794,6 +827,7 @@ test("shows the menu bar item until asked otherwise, and remembers the answer", 
     duckOtherMedia: true,
     quietDuringMeetings: true,
     showOnAllDisplays: false,
+    automaticUpdates: true,
   });
   // The choice outlives the run that heard it.
   assert.equal((await storeIn(directory).snapshot()).showInMenuBar, false);
@@ -877,6 +911,7 @@ test("keeps Luke out of the Dock until asked, and remembers the answer", async (
     duckOtherMedia: true,
     quietDuringMeetings: true,
     showOnAllDisplays: false,
+    automaticUpdates: true,
   });
   // The choice outlives the run that heard it.
   assert.equal((await storeIn(directory).snapshot()).showInDock, true);

--- a/apps/desktop/tests/update-row.test.ts
+++ b/apps/desktop/tests/update-row.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { UPDATE_ROW_ACTION, updateRow } from "../src/renderer/update-row";
+import { UPDATE_STATUS } from "../src/shared/contracts";
+
+test("an unasked question is an offer to ask, never an answer", () => {
+  const row = updateRow({ status: UPDATE_STATUS.UNKNOWN, currentVersion: "0.1.0" });
+  assert.equal(row.action, UPDATE_ROW_ACTION.CHECK);
+  assert.equal(row.current, false);
+});
+
+test("a check under way offers nothing to press", () => {
+  const row = updateRow({ status: UPDATE_STATUS.CHECKING, currentVersion: "0.1.0" });
+  assert.equal(row.action, UPDATE_ROW_ACTION.CHECKING);
+  assert.equal(row.current, false);
+});
+
+test("only a positively latest build earns the check mark", () => {
+  const row = updateRow({ status: UPDATE_STATUS.UP_TO_DATE, currentVersion: "0.1.0" });
+  assert.equal(row.action, UPDATE_ROW_ACTION.CHECK);
+  assert.equal(row.current, true);
+});
+
+test("a newer release is named, and the button becomes the way to it", () => {
+  const row = updateRow({
+    status: UPDATE_STATUS.UPDATE_AVAILABLE,
+    currentVersion: "0.1.0",
+    latestVersion: "0.2.0",
+  });
+  assert.equal(row.action, UPDATE_ROW_ACTION.GET);
+  assert.ok(row.detail.includes("0.2.0"), "the newer version is said on the row");
+  assert.equal(row.current, false);
+});
+
+test("an unreachable check says so and offers to try again", () => {
+  const row = updateRow({ status: UPDATE_STATUS.UNREACHABLE, currentVersion: "0.1.0" });
+  assert.equal(row.action, UPDATE_ROW_ACTION.CHECK);
+  assert.equal(row.current, false);
+});

--- a/apps/desktop/tests/update-service.test.ts
+++ b/apps/desktop/tests/update-service.test.ts
@@ -130,6 +130,31 @@ test("the timer and the button share a check already in flight", async () => {
   await third;
 });
 
+test("a listener that throws neither fails the check nor jams the next one", async () => {
+  // The broadcast can outlive the window it reaches. A throw there must not
+  // park a dead check in flight — the row would say "checking" forever and
+  // every later ask would reuse the failure.
+  let requests = 0;
+  const service = new UpdateService({
+    currentVersion: "0.1.0",
+    onChange: () => {
+      throw new Error("window already torn down");
+    },
+    fetch: async () => {
+      requests += 1;
+      return releaseResponse({ tag_name: "v0.2.0" });
+    },
+  });
+
+  const first = await service.check();
+  assert.equal(first.status, UPDATE_STATUS.UPDATE_AVAILABLE);
+  assert.equal(service.snapshot().status, UPDATE_STATUS.UPDATE_AVAILABLE);
+
+  const second = await service.check();
+  assert.equal(second.status, UPDATE_STATUS.UPDATE_AVAILABLE);
+  assert.equal(requests, 2);
+});
+
 test("the timed check starts at once and stops when asked", async () => {
   let requests = 0;
   const service = new UpdateService({

--- a/apps/desktop/tests/update-service.test.ts
+++ b/apps/desktop/tests/update-service.test.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { UPDATE_STATUS, type UpdateSnapshot } from "../src/shared/contracts";
+import { UPDATE_ENDPOINT, UpdateService } from "../src/update-service";
+
+function releaseResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+test("a newer published release is offered by its version, without the tag's v", async () => {
+  const requests: { url: string; headers: Record<string, string> }[] = [];
+  const states: UpdateSnapshot[] = [];
+  const service = new UpdateService({
+    currentVersion: "0.1.0",
+    onChange: (update) => states.push(update),
+    fetch: async (url, init) => {
+      requests.push({ url, headers: (init.headers ?? {}) as Record<string, string> });
+      return releaseResponse({ tag_name: "v0.2.0" });
+    },
+  });
+
+  const answered = await service.check();
+
+  assert.deepEqual(answered, {
+    status: UPDATE_STATUS.UPDATE_AVAILABLE,
+    currentVersion: "0.1.0",
+    latestVersion: "0.2.0",
+  });
+  assert.deepEqual(service.snapshot(), answered);
+  // The row is told about the check under way as well as its answer.
+  assert.deepEqual(
+    states.map((state) => state.status),
+    [UPDATE_STATUS.CHECKING, UPDATE_STATUS.UPDATE_AVAILABLE],
+  );
+  // One read, of the fixed address, spoken in GitHub's documented media type.
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0]?.url, UPDATE_ENDPOINT.LATEST_RELEASE_URL);
+  assert.equal(requests[0]?.headers.Accept, "application/vnd.github+json");
+});
+
+test("the running release reads as up to date", async () => {
+  const service = new UpdateService({
+    currentVersion: "0.2.0",
+    onChange: () => undefined,
+    fetch: async () => releaseResponse({ tag_name: "v0.2.0" }),
+  });
+
+  assert.deepEqual(await service.check(), {
+    status: UPDATE_STATUS.UP_TO_DATE,
+    currentVersion: "0.2.0",
+  });
+});
+
+test("a refusal, an unreachable service, and an unreadable answer all read as unreachable", async () => {
+  const refused = new UpdateService({
+    currentVersion: "0.1.0",
+    onChange: () => undefined,
+    fetch: async () => new Response("", { status: 503 }),
+  });
+  assert.equal((await refused.check()).status, UPDATE_STATUS.UNREACHABLE);
+
+  const unreachable = new UpdateService({
+    currentVersion: "0.1.0",
+    onChange: () => undefined,
+    fetch: async () => {
+      throw new Error("offline");
+    },
+  });
+  assert.equal((await unreachable.check()).status, UPDATE_STATUS.UNREACHABLE);
+
+  const unreadable = new UpdateService({
+    currentVersion: "0.1.0",
+    onChange: () => undefined,
+    fetch: async () => new Response("not json", { status: 200 }),
+  });
+  assert.equal((await unreadable.check()).status, UPDATE_STATUS.UNREACHABLE);
+});
+
+test("a release this build cannot name is not offered as an update", async () => {
+  // A prerelease suffix and a missing tag both leave nothing to compare, and
+  // an unnamed update would send someone to fetch an unknown.
+  const prerelease = new UpdateService({
+    currentVersion: "0.1.0",
+    onChange: () => undefined,
+    fetch: async () => releaseResponse({ tag_name: "v0.2.0-beta.1" }),
+  });
+  assert.equal((await prerelease.check()).status, UPDATE_STATUS.UNREACHABLE);
+
+  const unnamed = new UpdateService({
+    currentVersion: "0.1.0",
+    onChange: () => undefined,
+    fetch: async () => releaseResponse({}),
+  });
+  assert.equal((await unnamed.check()).status, UPDATE_STATUS.UNREACHABLE);
+});
+
+test("the timer and the button share a check already in flight", async () => {
+  let requests = 0;
+  let release: ((response: Response) => void) | undefined;
+  const service = new UpdateService({
+    currentVersion: "0.1.0",
+    onChange: () => undefined,
+    fetch: () => {
+      requests += 1;
+      return new Promise((resolve) => {
+        release = resolve;
+      });
+    },
+  });
+
+  const first = service.check();
+  const second = service.check();
+  release?.(releaseResponse({ tag_name: "v0.1.1" }));
+
+  assert.equal((await first).status, UPDATE_STATUS.UPDATE_AVAILABLE);
+  assert.equal((await second).status, UPDATE_STATUS.UPDATE_AVAILABLE);
+  assert.equal(requests, 1);
+
+  // A finished check is let go of, so the next ask is a fresh read.
+  const third = service.check();
+  assert.equal(requests, 2);
+  release?.(releaseResponse({ tag_name: "v0.1.1" }));
+  await third;
+});
+
+test("the timed check starts at once and stops when asked", async () => {
+  let requests = 0;
+  const service = new UpdateService({
+    currentVersion: "0.1.0",
+    onChange: () => undefined,
+    intervalMs: 10,
+    fetch: async () => {
+      requests += 1;
+      return releaseResponse({ tag_name: "v0.1.0" });
+    },
+  });
+
+  service.setAutomatic(true);
+  await sleep(35);
+  assert.ok(requests >= 2, `expected the timer to have checked again, saw ${requests}`);
+
+  service.setAutomatic(false);
+  const settled = requests;
+  await sleep(30);
+  assert.equal(requests, settled);
+});

--- a/packages/sidecar-core/src/app-update.ts
+++ b/packages/sidecar-core/src/app-update.ts
@@ -1,0 +1,31 @@
+/**
+ * Whether a published release is newer than the running app.
+ *
+ * Releases are named by plain three-part versions, optionally led by the tag
+ * convention's `v`. Anything else — a prerelease suffix, a truncated tag, a
+ * sentence — does not parse, and an unparseable version never reads as newer:
+ * offering an update the build cannot name would send someone to fetch
+ * something this comparison never understood.
+ */
+
+const RELEASE_VERSION_PATTERN = /^v?(\d+)\.(\d+)\.(\d+)$/;
+
+export function parseReleaseVersion(
+  text: string,
+): readonly [major: number, minor: number, patch: number] | undefined {
+  const match = RELEASE_VERSION_PATTERN.exec(text.trim());
+  if (!match) return undefined;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+/** True only when both versions parse and the candidate is strictly newer. */
+export function isNewerVersion(candidate: string, current: string): boolean {
+  const parsedCandidate = parseReleaseVersion(candidate);
+  const parsedCurrent = parseReleaseVersion(current);
+  if (!parsedCandidate || !parsedCurrent) return false;
+  const [candidateMajor, candidateMinor, candidatePatch] = parsedCandidate;
+  const [currentMajor, currentMinor, currentPatch] = parsedCurrent;
+  if (candidateMajor !== currentMajor) return candidateMajor > currentMajor;
+  if (candidateMinor !== currentMinor) return candidateMinor > currentMinor;
+  return candidatePatch > currentPatch;
+}

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -18,6 +18,9 @@ export {
   wholeNumber,
 } from "./json.js";
 
+// App updates — naming a newer published release than the running build.
+export { isNewerVersion, parseReleaseVersion } from "./app-update";
+
 // Sessions — observed state, identity, and the registry that holds them.
 export {
   ATTENTION_DISPOSITION,

--- a/packages/sidecar-core/tests/app-update.test.ts
+++ b/packages/sidecar-core/tests/app-update.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isNewerVersion, parseReleaseVersion } from "../src/app-update";
+
+test("release versions parse with or without the tag convention's v", () => {
+  assert.deepEqual(parseReleaseVersion("0.1.0"), [0, 1, 0]);
+  assert.deepEqual(parseReleaseVersion("v12.34.56"), [12, 34, 56]);
+  assert.deepEqual(parseReleaseVersion(" v0.2.0 "), [0, 2, 0]);
+});
+
+test("anything but a plain three-part version does not parse", () => {
+  assert.equal(parseReleaseVersion("0.1"), undefined);
+  assert.equal(parseReleaseVersion("0.1.0-beta.1"), undefined);
+  assert.equal(parseReleaseVersion("0.1.0.0"), undefined);
+  assert.equal(parseReleaseVersion("latest"), undefined);
+  assert.equal(parseReleaseVersion(""), undefined);
+});
+
+test("a release is newer only when it is strictly newer, part by part", () => {
+  assert.equal(isNewerVersion("0.1.1", "0.1.0"), true);
+  assert.equal(isNewerVersion("0.2.0", "0.1.9"), true);
+  assert.equal(isNewerVersion("1.0.0", "0.9.9"), true);
+  assert.equal(isNewerVersion("v0.1.1", "0.1.0"), true);
+  assert.equal(isNewerVersion("0.1.0", "0.1.0"), false);
+  assert.equal(isNewerVersion("0.1.0", "0.1.1"), false);
+  assert.equal(isNewerVersion("0.9.9", "1.0.0"), false);
+});
+
+test("an unparseable version never reads as newer", () => {
+  assert.equal(isNewerVersion("0.2.0-beta.1", "0.1.0"), false);
+  assert.equal(isNewerVersion("latest", "0.1.0"), false);
+  assert.equal(isNewerVersion("0.2.0", "not-a-version"), false);
+});


### PR DESCRIPTION
## Summary

- Luke had no way to say a newer release exists, so a launch-day install would stay on its build forever. This adds the check-and-notify half of updating; wiring Squirrel.Mac behind the same UI can follow as its own change.
- **Main process**: a new `UpdateService` (`update-service.ts`, modeled on `feedback-delivery.ts`) reads the repository's latest release name from GitHub's public API — unauthenticated, GitHub's documented media-type headers, `AbortSignal.timeout`, failures answered as `unreachable` rather than thrown. Both addresses (API read, releases page) are fixed by the build; nothing read from the network can steer where a press goes. Fixture/capture runs never check (`runMode.sendsNetwork` gates both the timer and the manual handler).
- **Setting**: new `automaticUpdates` (default on) through the standard path — `APP_SETTING_DEFAULTS`, `settings-store` (shallow reader so arming never wakes the Keychain; corrupt value lands on the default), `registerSettingHandler`, applied at once like the media duck.
- **Renderer**: an Updates section on the Settings front page — version row whose button is Check for Updates / Checking… / Download (opens the fixed releases page in the browser), with the pure `updateRow()` helper mirroring `microphone-access.ts`, plus the automatic-check switch. Update state travels on `app:update-changed` with a bootstrap-raced channel, like settings.
- **Guide**: `APP_SETTING_ID.AUTOMATIC_UPDATES` wired into `applySpokenSetting` (compile- and test-enforced), an Updates fact, and a front-page `manual` path — `SETTING_PAGE`/`SETTINGS_PAGE_LABEL` widened to name the front page, with an errand to a front-page setting opening the tab alone.
- **Core**: `parseReleaseVersion`/`isNewerVersion` in `@sidecar/core` (brand-neutral; the repo URL stays in the desktop app). An unparseable release never reads as newer.
- **Docs**: PRIVACY.md gains an "Update check" section; AGENTS.md's trust constraints state the new request's bounds (the one request Luke makes with no user-supplied key, and why widening it is a product decision).

## Evidence

- Platform-independent checks: `./scripts/check.sh` exit 0 (Linux) — 899 desktop tests, 191 core tests, harness, lint, typecheck, builds all pass
- macOS Electron verification: CI's `macOS app and evidence` job passed (packaged app + deterministic captures); all six smoke PNGs inspected — the panel renders cleanly, but no smoke fixture opens the Settings tab, so the Updates section itself is not in the captured set. Please eyeball it once on a Mac (`./scripts/run.sh --fixture smoke`, open Settings) before merge.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32070260341/artifacts/9301487483) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32070260341)

- Commit: `8f83c53d9d2a0e0a19022818bbde5e7f2063db85`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` — needs a physical-Mac pass
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- A fresh build shows `unknown` ("has not been checked for yet") until the launch check answers, so capture runs stay deterministic.
- Follow-up, not in this PR: Squirrel.Mac auto-install behind the same row (needs the ZIP asset from #183), and PRIVACY.md has a pre-existing gap — the feedback endpoint (`tryluke.dev/api/feedback`) is not disclosed — worth its own small docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d2288aaa-3db1-4ede-9fc2-9d0cb6e0035b)

