### PR TITLE
feat(auth): polish the signed-out experience end to end

### DIFF
--- a/apps/desktop/src/account-client.ts
+++ b/apps/desktop/src/account-client.ts
@@ -8,7 +8,29 @@ export interface AccountTokens {
 export interface AccountIdentity {
   email: string;
   name?: string;
+  pictureUrl?: string;
   provider: AccountProvider;
+}
+
+/**
+ * The only hosts an avatar may be loaded from, matching the renderer's image
+ * policy exactly: Google serves profile photos from `googleusercontent.com`
+ * and GitHub from `avatars.githubusercontent.com`. A picture anywhere else is
+ * dropped rather than handed to a renderer whose CSP would refuse it — and the
+ * set is fixed by this build, like every address the renderer is given.
+ */
+export function accountPictureUrl(value: unknown): string | undefined {
+  if (typeof value !== "string" || !value) return undefined;
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return undefined;
+  }
+  if (url.protocol !== "https:") return undefined;
+  const host = url.hostname;
+  const googleHosted = host === "googleusercontent.com" || host.endsWith(".googleusercontent.com");
+  return googleHosted || host === "avatars.githubusercontent.com" ? url.toString() : undefined;
 }
 
 export type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
@@ -140,9 +162,11 @@ export class AccountClient {
     if (typeof body.email !== "string") {
       throw new AccountClientError("Account service returned an invalid identity");
     }
+    const pictureUrl = accountPictureUrl(body.picture);
     return {
       email: body.email,
       ...(typeof body.name === "string" && body.name ? { name: body.name } : {}),
+      ...(pictureUrl ? { pictureUrl } : {}),
       provider,
     };
   }

--- a/apps/desktop/src/account-loopback-page.ts
+++ b/apps/desktop/src/account-loopback-page.ts
@@ -1,0 +1,97 @@
+import { FACE_ART } from "./renderer/luke-face-art";
+
+/**
+ * The page the browser is left on after the OAuth redirect lands on the
+ * loopback. It is the last thing the sign-in shows, so it dresses like the
+ * landing page — one dark card, the mark, a status pill, and a line saying
+ * where things stand — rather than a line of bare text. Self-contained on
+ * purpose: the ephemeral 127.0.0.1 server serves exactly one document, so
+ * nothing here may fetch a font, a script, or an image from anywhere.
+ *
+ * Every string on the page is fixed by the build. Nothing the redirect
+ * carried — code, state, error — is ever interpolated into the document.
+ */
+export const LOOPBACK_PAGE_TONE = {
+  /** The sign-in reached a resting state worth a green pill. */
+  SETTLED: "settled",
+  /** Something needs the user back in Luke. */
+  ATTENTION: "attention",
+} as const;
+
+export type LoopbackPageTone = (typeof LOOPBACK_PAGE_TONE)[keyof typeof LOOPBACK_PAGE_TONE];
+
+export interface LoopbackPage {
+  tone: LoopbackPageTone;
+  /** The pill's one word or two: "Signed in", "Not completed". */
+  badge: string;
+  title: string;
+  body: string;
+}
+
+/**
+ * The face, drawn from the same generated constants the renderer draws it
+ * from, so this copy cannot drift from the artwork. The tight viewBox is the
+ * mark's own, as the landing page crops it.
+ */
+function markSvg(): string {
+  const { TILT, SMILE, STROKE_WIDTH, EYE_X, EYE_Y, EYE_RADIUS } = FACE_ART;
+  return (
+    `<svg class="mark" viewBox="53.85 62.67 134.29 122.37" fill="none" aria-hidden="true">` +
+    `<g transform="${TILT}">` +
+    `<path d="${SMILE}" fill="none" stroke="currentColor" stroke-width="${STROKE_WIDTH}" stroke-linecap="round" stroke-linejoin="round"/>` +
+    `<circle cx="${EYE_X.LEFT}" cy="${EYE_Y}" r="${EYE_RADIUS}" fill="currentColor"/>` +
+    `<circle cx="${EYE_X.RIGHT}" cy="${EYE_Y}" r="${EYE_RADIUS}" fill="currentColor"/>` +
+    `</g></svg>`
+  );
+}
+
+const PAGE_STYLE = `
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: #08090b;
+    color: rgba(255, 255, 255, 0.92);
+    font-family: -apple-system, blinkmacsystemfont, "SF Pro Display", "Segoe UI", sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  .shell { min-height: 100vh; display: grid; place-items: center; padding: 24px; }
+  .card {
+    width: min(100%, 390px);
+    padding: 48px 32px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 17px;
+    background: #000;
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.42);
+    text-align: center;
+  }
+  .mark { width: 52px; height: auto; color: rgba(255, 255, 255, 0.92); }
+  .pill {
+    display: inline-block;
+    margin-top: 16px;
+    padding: 3px 11px;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 650;
+    letter-spacing: 0.2px;
+    background: rgba(111, 220, 164, 0.14);
+    color: #6fdca4;
+  }
+  .pill[data-tone="attention"] { background: rgba(255, 160, 73, 0.14); color: #ffa049; }
+  h1 { margin: 12px 0 8px; font-size: 1.375rem; line-height: 1.2; }
+  p { margin: 0; color: rgba(255, 255, 255, 0.56); font-size: 0.9375rem; line-height: 1.6; }
+`;
+
+export function accountLoopbackPage(page: LoopbackPage): string {
+  return (
+    `<!doctype html><html lang="en"><head><meta charset="utf-8">` +
+    `<meta name="viewport" content="width=device-width, initial-scale=1">` +
+    `<meta name="color-scheme" content="dark">` +
+    `<title>${page.title}</title><style>${PAGE_STYLE}</style></head>` +
+    `<body><main class="shell"><section class="card">` +
+    markSvg() +
+    `<div><span class="pill" data-tone="${page.tone}">${page.badge}</span></div>` +
+    `<h1>${page.title}</h1><p>${page.body}</p>` +
+    `</section></main></body></html>`
+  );
+}

--- a/apps/desktop/src/account-loopback.ts
+++ b/apps/desktop/src/account-loopback.ts
@@ -1,10 +1,73 @@
 import { randomBytes } from "node:crypto";
-import { createServer, type Server } from "node:http";
+import { createServer, type Server, type ServerResponse } from "node:http";
+import { accountLoopbackPage, LOOPBACK_PAGE_TONE } from "./account-loopback-page";
 import { codeChallenge, createCodeVerifier } from "./account-pkce";
 import type { AccountProvider } from "./shared/contracts";
 
 const CALLBACK_PATH = "/callback";
 const LOOPBACK_HOST = "127.0.0.1";
+
+/**
+ * Every answer the callback can give, drawn as the same card the landing page
+ * would draw it. The words are fixed by the build; nothing the redirect
+ * carried reaches the document.
+ */
+const LOOPBACK_ANSWER = {
+  SIGNED_IN: {
+    status: 200,
+    page: {
+      tone: LOOPBACK_PAGE_TONE.SETTLED,
+      badge: "Signed in",
+      title: "Signed in to Luke",
+      body: "You can close this tab and return to Luke.",
+    },
+  },
+  NOT_VERIFIED: {
+    status: 400,
+    page: {
+      tone: LOOPBACK_PAGE_TONE.ATTENTION,
+      badge: "Not verified",
+      title: "Luke could not verify this sign-in",
+      body: "Return to Luke and try again.",
+    },
+  },
+  NOT_COMPLETED: {
+    status: 400,
+    page: {
+      tone: LOOPBACK_PAGE_TONE.ATTENTION,
+      badge: "Not completed",
+      title: "Sign-in was not completed",
+      body: "Return to Luke and try again.",
+    },
+  },
+  ALREADY_USED: {
+    status: 409,
+    page: {
+      tone: LOOPBACK_PAGE_TONE.SETTLED,
+      badge: "Already used",
+      title: "This sign-in has already been used",
+      body: "You can close this tab and return to Luke.",
+    },
+  },
+} as const;
+
+function answer(
+  response: ServerResponse,
+  { status, page }: (typeof LOOPBACK_ANSWER)[keyof typeof LOOPBACK_ANSWER],
+): void {
+  response.writeHead(status, { "content-type": "text/html; charset=utf-8" });
+  response.end(accountLoopbackPage(page));
+}
+
+/**
+ * The one message a withdrawn sign-in ends with, so the flow's owner can tell
+ * a cancellation — a normal outcome — from a failure worth reporting.
+ */
+export const SIGN_IN_CANCELLED_MESSAGE = "Sign-in was cancelled";
+
+export function isSignInCancellation(error: unknown): boolean {
+  return error instanceof Error && error.message === SIGN_IN_CANCELLED_MESSAGE;
+}
 
 export interface AccountLoopback {
   redirectUri: string;
@@ -12,6 +75,12 @@ export interface AccountLoopback {
   codeVerifier: string;
   codeChallenge: string;
   waitForCode: Promise<string>;
+  /**
+   * Withdraws the wait: `waitForCode` rejects as cancelled and the server
+   * closes. A code that already arrived has settled the promise, so a late
+   * cancel changes nothing.
+   */
+  cancel(): void;
   close(): Promise<void>;
 }
 
@@ -41,31 +110,26 @@ export async function startAccountLoopback(
     const oauthError = url.searchParams.get("error");
     const returnedState = url.searchParams.get("state");
     if (url.pathname !== CALLBACK_PATH || returnedState !== state) {
-      response.writeHead(400, { "content-type": "text/plain; charset=utf-8" });
-      response.end("Luke could not verify this sign-in. Return to Luke and try again.");
+      answer(response, LOOPBACK_ANSWER.NOT_VERIFIED);
       return;
     }
     if (accepted) {
-      response.writeHead(409, { "content-type": "text/plain; charset=utf-8" });
-      response.end("This sign-in has already been used.");
+      answer(response, LOOPBACK_ANSWER.ALREADY_USED);
       return;
     }
     if (oauthError) {
       accepted = true;
-      response.writeHead(400, { "content-type": "text/plain; charset=utf-8" });
-      response.end("Sign-in was not completed. Return to Luke and try again.");
+      answer(response, LOOPBACK_ANSWER.NOT_COMPLETED);
       reject?.(new Error(`Sign-in was not completed (${oauthError})`));
       reject = undefined;
       return;
     }
     if (!code) {
-      response.writeHead(400, { "content-type": "text/plain; charset=utf-8" });
-      response.end("Luke could not verify this sign-in. Return to Luke and try again.");
+      answer(response, LOOPBACK_ANSWER.NOT_VERIFIED);
       return;
     }
     accepted = true;
-    response.writeHead(200, { "content-type": "text/plain; charset=utf-8" });
-    response.end("Signed in to Luke. You can close this window.");
+    answer(response, LOOPBACK_ANSWER.SIGNED_IN);
     settle?.(code);
     settle = undefined;
   });
@@ -94,6 +158,11 @@ export async function startAccountLoopback(
     codeVerifier,
     codeChallenge: codeChallenge(codeVerifier),
     waitForCode,
+    cancel: () => {
+      reject?.(new Error(SIGN_IN_CANCELLED_MESSAGE));
+      reject = undefined;
+      void closeServer(server);
+    },
     close: () => closeServer(server),
   };
 }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -63,14 +63,18 @@ import {
   systemPreferences,
   Tray,
 } from "electron";
-import { AccountClient, type AccountTokens } from "./account-client";
+import { AccountClient, type AccountIdentity, type AccountTokens } from "./account-client";
 import {
   ACCOUNT_FAILURE_ACTION,
   accessTokenNeedsRefresh,
   accountFailureAction,
   accountGateOpen,
 } from "./account-gate";
-import { startAccountLoopback } from "./account-loopback";
+import {
+  isSignInCancellation,
+  SIGN_IN_CANCELLED_MESSAGE,
+  startAccountLoopback,
+} from "./account-loopback";
 import { withIssuedAccountTokens } from "./account-token-lifecycle";
 import { CLAUDE_CODE_PROVIDER, ClaudeCodeSessionAdapter } from "./claude-code-adapter";
 import {
@@ -189,6 +193,12 @@ const settingsStore = new SettingsStore({
 const accountClient = new AccountClient({ baseUrl: ACCOUNT_BASE_URL, clientId: ACCOUNT_CLIENT_ID });
 let account: AccountSnapshot = { status: ACCOUNT_STATUS.SIGNED_OUT };
 let signInRunning: Promise<AccountSnapshot> | undefined;
+/**
+ * Withdraws the sign-in currently waiting on the browser, when there is one.
+ * Set for exactly the life of `signInRunning`: cancelling rejects the loopback
+ * wait, and the attempt's own error path signs the account back out.
+ */
+let signInCancel: (() => void) | undefined;
 let accountGeneration = 0;
 let observationGeneration = 0;
 const conductorAdapter = new ConductorSessionAdapter({
@@ -494,9 +504,12 @@ async function refreshStoredAccount(): Promise<void> {
     if (
       identity.email !== stored.email ||
       identity.name !== stored.name ||
+      identity.pictureUrl !== stored.pictureUrl ||
       identity.provider !== stored.provider
     ) {
-      if (!(await storeCurrentAccount(generation, { ...stored, ...identity }))) return;
+      if (!(await storeCurrentAccount(generation, mergedAccountIdentity(stored, identity)))) {
+        return;
+      }
       broadcastAccount();
     }
     return;
@@ -524,9 +537,29 @@ async function refreshStoredAccount(): Promise<void> {
     // cannot strand the account with the now-revoked previous token.
     if (!(await storeCurrentAccount(generation, { ...stored, ...tokens }))) return;
     const identity = await accountClient.userInfo(tokens.accessToken, stored.provider);
-    if (!(await storeCurrentAccount(generation, { ...tokens, ...identity }))) return;
+    if (
+      !(await storeCurrentAccount(
+        generation,
+        mergedAccountIdentity({ ...stored, ...tokens }, identity),
+      ))
+    ) {
+      return;
+    }
     broadcastAccount();
   } catch {}
+}
+
+/**
+ * A fresh identity replaces the stored one outright: a name or picture the
+ * provider no longer reports must fall away rather than surviving as a stale
+ * spread-over field.
+ */
+function mergedAccountIdentity(stored: StoredAccount, identity: AccountIdentity): StoredAccount {
+  return {
+    accessToken: stored.accessToken,
+    refreshToken: stored.refreshToken,
+    ...identity,
+  };
 }
 
 function beginAccountSignIn(provider: AccountProvider): Promise<AccountSnapshot> {
@@ -535,11 +568,20 @@ function beginAccountSignIn(provider: AccountProvider): Promise<AccountSnapshot>
   account = { status: ACCOUNT_STATUS.SIGNING_IN };
   const generation = ++accountGeneration;
   broadcastAccount();
+  // Cancellable from the first moment the renderer can ask: before the
+  // loopback exists the cancel is remembered, and once it exists the cancel
+  // rejects its wait — either way the attempt below ends as cancelled.
+  let cancelled = false;
+  signInCancel = () => {
+    cancelled = true;
+  };
   signInRunning = (async () => {
     let loopback: Awaited<ReturnType<typeof startAccountLoopback>> | undefined;
     try {
       const activeLoopback = await startAccountLoopback({ providerHint: provider });
       loopback = activeLoopback;
+      signInCancel = () => activeLoopback.cancel();
+      if (cancelled) activeLoopback.cancel();
       const authorizeUrl = accountClient.authorizeUrl({
         redirectUri: activeLoopback.redirectUri,
         state: activeLoopback.state,
@@ -557,10 +599,10 @@ function beginAccountSignIn(provider: AccountProvider): Promise<AccountSnapshot>
         use: async (tokens) => {
           const identity = await accountClient.userInfo(tokens.accessToken, provider);
           if (!(await storeCurrentAccount(generation, { ...tokens, ...identity }))) {
-            throw new Error("Sign-in was cancelled");
+            throw new Error(SIGN_IN_CANCELLED_MESSAGE);
           }
           await startAccountCapabilities(generation);
-          if (generation !== accountGeneration) throw new Error("Sign-in was cancelled");
+          if (generation !== accountGeneration) throw new Error(SIGN_IN_CANCELLED_MESSAGE);
         },
         revoke: (refreshToken) => accountClient.revoke(refreshToken),
         onRevokeFailure: (revokeError) => {
@@ -572,8 +614,13 @@ function beginAccountSignIn(provider: AccountProvider): Promise<AccountSnapshot>
       return account;
     } catch (error) {
       if (generation === accountGeneration) await signOutAccount();
+      // A withdrawn sign-in is a normal outcome, not a failure: it resolves
+      // with the signed-out account rather than rejecting the renderer's
+      // invoke, which Electron would otherwise report as a handler error.
+      if (isSignInCancellation(error)) return account;
       throw error;
     } finally {
+      signInCancel = undefined;
       await loopback?.close();
       signInRunning = undefined;
     }
@@ -830,6 +877,13 @@ function registerIpc(): void {
       throw new Error("Invalid sign-in request");
     }
     return beginAccountSignIn(provider);
+  });
+
+  ipcMain.handle(channels.cancelSignIn, (event) => {
+    if (!trustedSender(event)) throw new Error("Untrusted renderer");
+    // A cancel with nothing waiting is a no-op rather than an error: the
+    // sign-in it meant to withdraw may have just finished or failed on its own.
+    signInCancel?.();
   });
 
   ipcMain.handle(channels.signOut, async (event) => {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -16,6 +16,7 @@ function subscribe<T>(channel: string) {
 const bridge: AppBridge = {
   getBootstrap: invoke(channels.bootstrap),
   beginSignIn: invoke(channels.beginSignIn),
+  cancelSignIn: invoke(channels.cancelSignIn),
   signOut: invoke(channels.signOut),
   setExpanded: invoke(channels.setExpanded),
   setPointerInterception: (interceptsPointer) => {

--- a/apps/desktop/src/renderer/account-marks.tsx
+++ b/apps/desktop/src/renderer/account-marks.tsx
@@ -1,0 +1,56 @@
+import { ACCOUNT_PROVIDER, type AccountProvider } from "../shared/contracts";
+
+/**
+ * The two identity providers' own marks, traced for the sign-in surface. They
+ * are brand marks like a session provider's, not glyphs of ours: the Google G
+ * keeps its four official colours, and the GitHub mark rides `currentColor`
+ * the way GitHub's own guidance draws it on a dark ground. They live here
+ * rather than in the shared surface vocabulary because only the desktop's
+ * sign-in flow names an identity provider — session-provider marks are what
+ * the drawing and the mock share.
+ */
+export function GoogleMark(): React.JSX.Element {
+  return (
+    <svg className="account-mark" viewBox="0 0 18 18" aria-hidden="true" focusable="false">
+      <path
+        fill="#4285F4"
+        d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z"
+      />
+      <path
+        fill="#34A853"
+        d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332z"
+      />
+      <path
+        fill="#EA4335"
+        d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z"
+      />
+    </svg>
+  );
+}
+
+export function GitHubMark(): React.JSX.Element {
+  return (
+    <svg
+      className="account-mark"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+    </svg>
+  );
+}
+
+/** The pressed provider's own mark, for the surfaces that name one by id. */
+export function AccountProviderMark({
+  provider,
+}: {
+  provider: AccountProvider;
+}): React.JSX.Element {
+  return provider === ACCOUNT_PROVIDER.GITHUB ? <GitHubMark /> : <GoogleMark />;
+}

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -27,6 +27,7 @@ import {
   useState,
 } from "react";
 import type {
+  AccountProvider,
   AccountSnapshot,
   AppBootstrap,
   AppSettings,
@@ -35,7 +36,7 @@ import type {
   SessionOpenResult,
   SettingsUpdateResult,
 } from "../shared/contracts";
-import { CREDENTIAL_SOURCE, SESSION_OPEN_RESULT_STATUS } from "../shared/contracts";
+import { ACCOUNT_STATUS, CREDENTIAL_SOURCE, SESSION_OPEN_RESULT_STATUS } from "../shared/contracts";
 import type { CredentialProviderId } from "../shared/credential-providers";
 import {
   CREDENTIAL_PROVIDER_LIST,
@@ -75,6 +76,8 @@ import { encodeFeedbackImage } from "./feedback-images";
 import { FeedbackSlot } from "./feedback-slot";
 import { KeySlot } from "./key-slot";
 import { type Errand, errandTargets, LukeErrand } from "./luke-errand";
+import { LukeFace } from "./luke-face";
+import { usePrefersReducedMotion } from "./luke-face-mood";
 import { applySpokenSetting, buildLukeGuide, isAppSettingId } from "./luke-guide";
 import { NotchWings } from "./notch-wings";
 import { PanelBody, type SessionWriteHandlers } from "./panel-body";
@@ -104,6 +107,8 @@ import {
   type SettingsSubview,
   type SettingsView,
 } from "./settings-views";
+import { useSignInFaceCycle } from "./sign-in-gate";
+import { SignInSlot } from "./sign-in-slot";
 import { useBootstrapRacedChannel } from "./use-bootstrap-raced-channel";
 import { panelEntryOpen, usePanelEntry } from "./use-panel-entry";
 import { usePanelPresentation } from "./use-panel-presentation";
@@ -243,6 +248,7 @@ export function App(): React.JSX.Element {
   const [, setClock] = useState(0);
   const [panelElement, panelHeight] = useShapeHeight();
   const [slotElement, slotHeight] = useShapeHeight();
+  const [signInSlotElement, signInSlotHeight] = useShapeHeight();
   const [feedbackElement, feedbackHeight] = useShapeHeight();
   const [captionTextElement, captionTextHeight] = useShapeHeight();
   const captionElement = useRef<HTMLSpanElement>(null);
@@ -425,6 +431,27 @@ export function App(): React.JSX.Element {
     setSessionView(next);
     setOptionsOpen(false);
   }, []);
+
+  /**
+   * True while sign-in stands between Luke and anything to watch. The gate is
+   * then what the panel shows, the wings hide the face and the count, and the
+   * badge's place wears a quiet "Sign in" instead — the honest word for why
+   * Luke is idle, at capsule scale.
+   */
+  const accountGated =
+    bootstrap?.accountRequired === true &&
+    (account ?? bootstrap.account).status !== ACCOUNT_STATUS.SIGNED_IN;
+
+  /** Whether this window has already opened its one sign-in greeting. */
+  const greeted = useRef(false);
+
+  /**
+   * The one signed-out Luke's introduction cycle — sway, pirouette, double
+   * blink, curious tilt, nod — walking whichever pose the face is drawn at:
+   * large over the gate, small in the peek's strip. Still while signed in, so
+   * the timer is not left running under the roster.
+   */
+  const signInFace = useSignInFaceCycle(usePrefersReducedMotion() || !accountGated);
 
   const {
     presentation,
@@ -651,6 +678,67 @@ export function App(): React.JSX.Element {
     commit: credentialsEntry.commit,
     remove: removeProviderApiKey,
   };
+
+  /**
+   * Whose sign-in the surface is waiting on. Choosing a provider on the gate
+   * sends the browser to it and stands the panel down to a small waiting
+   * popup, the way fetching an API key stands it down to the slot: the real
+   * work is in the browser, and Luke floats above the page it needs. Held as
+   * app state with a ref because the attempt's own reply has to read whether
+   * it is still the one being waited on.
+   */
+  const [signInWait, setSignInWait, signInWaitNow] = useStateWithRef<AccountProvider | undefined>(
+    undefined,
+  );
+  /**
+   * Which attempt any reply answers. Cancel advances it, so the outcome of a
+   * sign-in already withdrawn is spent rather than moving the shape again.
+   */
+  const signInAttempt = useRef(0);
+  const [signInFailure, setSignInFailure] = useState<string>();
+
+  const beginSignIn = useCallback(
+    (provider: AccountProvider) => {
+      if (signInWaitNow() !== undefined) return;
+      const attempt = ++signInAttempt.current;
+      setSignInFailure(undefined);
+      setSignInWait(provider);
+      cancelHover();
+      applyPresentation(PANEL_PRESENTATION.SLOT);
+      window.sidecar.beginSignIn(provider).then(
+        () => {
+          if (signInAttempt.current !== attempt) return;
+          setSignInWait(undefined);
+          if (presentationOf() !== PANEL_PRESENTATION.SLOT) return;
+          // The panel comes forward around what was just unlocked — the
+          // session roster — and stays open like any other opened panel:
+          // signing in is an arrival, not an errand to settle and leave.
+          expand();
+        },
+        () => {
+          if (signInAttempt.current !== attempt) return;
+          setSignInWait(undefined);
+          setSignInFailure("Sign-in did not finish. Try again when you’re ready.");
+          if (presentationOf() === PANEL_PRESENTATION.SLOT) expand();
+        },
+      );
+    },
+    [applyPresentation, cancelHover, expand, presentationOf, setSignInWait, signInWaitNow],
+  );
+
+  /**
+   * Takes the wait back. The main process withdraws the loopback and signs the
+   * attempt back out; the panel returns to the gate at once rather than
+   * waiting for that round trip, and the attempt's eventual rejection finds
+   * itself already spent.
+   */
+  const cancelSignIn = useCallback(() => {
+    if (signInWaitNow() === undefined) return;
+    signInAttempt.current += 1;
+    setSignInWait(undefined);
+    void window.sidecar.cancelSignIn();
+    if (presentationOf() === PANEL_PRESENTATION.SLOT) expand();
+  }, [expand, presentationOf, setSignInWait, signInWaitNow]);
 
   /** Shows or hides the menu bar status item. */
   const changeShowInMenuBar = useCallback(
@@ -1534,6 +1622,19 @@ export function App(): React.JSX.Element {
     modeGenerationOf,
   ]);
 
+  // The one greeting an unauthed launch gets: the panel opens on the sign-in
+  // gate exactly once, then behaves like any panel — Escape, the pointer, and
+  // the capsule all close it, and it stays a hover away. Locking it open would
+  // fight what a sidecar is; after the greeting leaves, the peek's face and
+  // "Sign in" label are what keep the reason Luke is idle on screen. Signing
+  // out later opens no new greeting — the panel is already forward, showing
+  // the gate the sign-out left behind.
+  useEffect(() => {
+    if (!accountGated || greeted.current) return;
+    greeted.current = true;
+    void changeMode(true);
+  }, [accountGated, changeMode]);
+
   // Silence is counted in stretches — one per unbroken run of muted-or-zero —
   // because that is the unit a "Got it" answers. The edge into silence is the
   // only thing counted; every reading inside one stretch leaves it alone.
@@ -1641,9 +1742,11 @@ export function App(): React.JSX.Element {
       if (stopSpeaking()) return;
       // Escape out of the slot is the entry's own way out, wherever the caret
       // happens to be: the slot is the only thing on screen, so there is nothing
-      // else it could mean.
+      // else it could mean. The sign-in wait borrows the same shape, so the
+      // same key withdraws whichever of the two is holding it.
       if (presentation === PANEL_PRESENTATION.SLOT) {
-        credentialsEntry.cancel();
+        if (signInWaitNow() !== undefined) cancelSignIn();
+        else credentialsEntry.cancel();
         return;
       }
       // Escape out of the composer leaves the shape and keeps the draft: a
@@ -1670,6 +1773,7 @@ export function App(): React.JSX.Element {
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
   }, [
+    cancelSignIn,
     credentialsEntry.cancel,
     changeMode,
     changeTab,
@@ -1682,6 +1786,7 @@ export function App(): React.JSX.Element {
     searchOpen,
     setSettingsView,
     settingsView,
+    signInWaitNow,
     stopSpeaking,
     tab,
     voiceStatus,
@@ -1870,7 +1975,11 @@ export function App(): React.JSX.Element {
       data-capture={String(bootstrap.captureMode)}
       style={{
         ...notchStyle(display),
-        ...shapeHeightStyle(panelHeight, slotHeight, feedbackHeight),
+        ...shapeHeightStyle(
+          panelHeight,
+          signInWait !== undefined ? signInSlotHeight : slotHeight,
+          feedbackHeight,
+        ),
         ...captionSizeStyle(captionTextHeight, volumeHint, captionPadding),
       }}
     >
@@ -1886,6 +1995,8 @@ export function App(): React.JSX.Element {
           <PanelBody
             accountRequired={bootstrap.accountRequired}
             account={account ?? bootstrap.account}
+            onBeginSignIn={beginSignIn}
+            {...(signInFailure ? { signInFailure } : {})}
             list={list}
             view={sessionView}
             onViewChange={changeSessionView}
@@ -1927,7 +2038,22 @@ export function App(): React.JSX.Element {
 
       {/* The panel stood down to its field. It shares the expanded window, so
           standing down to it costs no more than the peek does. */}
-      <KeySlot control={credentials} source={slotSource} drawn={slotOpen} measure={slotElement} />
+      {/* The two shapes that borrow the slot never draw together: the gate and
+          the settings tab are never on screen at once, so whichever one is
+          holding the slot suppresses the other outright — a pill held through
+          an old exit must not resurface under the other's wait. */}
+      {signInWait === undefined ? (
+        <KeySlot control={credentials} source={slotSource} drawn={slotOpen} measure={slotElement} />
+      ) : null}
+      {credentialsEntry.entry === undefined ? (
+        /* The panel stood down to the sign-in it is waiting on. */
+        <SignInSlot
+          {...(signInWait ? { provider: signInWait } : {})}
+          drawn={slotOpen}
+          onCancel={cancelSignIn}
+          measure={signInSlotElement}
+        />
+      ) : null}
       {/* The panel stood down to the composer, on the same terms. */}
       <FeedbackSlot control={feedbackControl} drawn={feedbackOpen} measure={feedbackElement} />
       {/* Luke's own voice. Muted playback would defeat the point, so this is
@@ -1946,7 +2072,23 @@ export function App(): React.JSX.Element {
         voiceOpening={talkOpening}
         presentation={presentation}
         housingWidth={display.notch.housingWidth}
+        accountGated={accountGated}
       />
+
+      {/* The one signed-out Luke. Like the caption, he is a single element in
+          every state so the morph carries him instead of trading two copies:
+          over the gate's reserved box while the panel is up, and down to the
+          peek's strip — the wing spot the authed face holds — when it closes.
+          Keyed on the play so each gesture of the introduction cycle is a
+          fresh drawing, exactly as the wing remounts its own. */}
+      {accountGated ? (
+        <span className="sign-in-luke" aria-hidden="true">
+          <LukeFace
+            key={signInFace.play}
+            {...(signInFace.motion ? { motion: signInFace.motion } : {})}
+          />
+        </span>
+      ) : null}
 
       {/* Luke crossing his own panel to sign a control he moved. Drawn over
           everything, because it passes over the panel it is crossing, and

--- a/apps/desktop/src/renderer/feedback-panel.tsx
+++ b/apps/desktop/src/renderer/feedback-panel.tsx
@@ -41,7 +41,7 @@ function FeedbackOffer({
  */
 export function FeedbackSection({ control }: { control: FeedbackEntryControl }): React.JSX.Element {
   return (
-    <section className="settings-section" style={{ "--row-index": 4 } as React.CSSProperties}>
+    <section className="settings-section" style={{ "--row-index": 3 } as React.CSSProperties}>
       <h2>
         <MegaphoneIcon />
         Feedback

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; media-src 'self' blob: mediastream:; connect-src https://api.openai.com; object-src 'none'; frame-src 'none'"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https://*.googleusercontent.com https://avatars.githubusercontent.com; media-src 'self' blob: mediastream:; connect-src https://api.openai.com; object-src 'none'; frame-src 'none'"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Luke</title>

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -547,16 +547,16 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "dives to the control that moved, and floats back.",
     },
     {
-      label: "Your account",
+      label: "Account",
       detail:
         account.status === ACCOUNT_STATUS.SIGNED_IN
-          ? `Signed in as ${account.email} through ${account.provider === ACCOUNT_PROVIDER.GITHUB ? "GitHub" : "Google"}. Sign out by hand from Your account on the Settings tab's front page.`
-          : "Not signed in. Live sessions and Luke's controls stay off until Google or GitHub sign-in finishes.",
+          ? `Signed in as ${account.email} through ${account.provider === ACCOUNT_PROVIDER.GITHUB ? "GitHub" : "Google"}. Sign out by hand from Account, at the foot of the Settings tab's front page just above Quit — it asks before acting.`
+          : "Not signed in. The sign-in screen greets the launch once with Google and GitHub, then closes like any panel. While signed out the strip beside the housing keeps Luke's face and a small Sign in label in place of the session count, and hovering or pressing it brings the sign-in screen back. Live sessions and Luke's controls stay off until sign-in finishes. Choosing a provider stands the panel down to a small waiting popup with a Cancel button while the browser finishes, and the panel opens itself once the sign-in lands.",
     },
     {
       label: "Feedback and prompts",
       detail:
-        "The Feedback section near the foot of the Settings tab, just above Quit — or the menu bar item's Send " +
+        "The Feedback section near the foot of the Settings tab, just above the Account section and Quit — or the menu bar item's Send " +
         "Feedback… and Submit a Prompt… — opens a composer under the notch. Send feedback is for " +
         "bugs and ideas; Submit a prompt sends a prompt to a coding agent, and one the founders " +
         "like ships in the next release. Either goes by email to the founders with an optional " +

--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -40,6 +40,13 @@ interface NotchWingsProps {
   voiceOpening: boolean;
   presentation: PanelPresentation;
   housingWidth: number;
+  /**
+   * True while sign-in stands between Luke and anything to watch. The strip
+   * stays deliberately bare — no face, no count — so the gate in the panel is
+   * the one thing introducing him, and a zero that means "not looking yet"
+   * never poses as a zero that means "nothing happening".
+   */
+  accountGated: boolean;
 }
 
 /**
@@ -83,6 +90,16 @@ const COUNT_RESTING_SCALE = 0.88;
 const COUNT_EDGE_KEEP = 2;
 
 /**
+ * The sign-in label's own margins, in the stylesheet's numbers. It starts at
+ * the housing's edge itself — black on black, the notch is indistinguishable
+ * from padding, so the inset a numeral keeps buys nothing here — and keeps
+ * more from the strip's outer end, where the shape is already turning its
+ * corner and words pressed into the curve read as clipped.
+ */
+const SIGN_IN_INSET = 0;
+const SIGN_IN_EDGE_KEEP = 6;
+
+/**
  * How much of its resting scale the count badge keeps so the text never
  * crosses the shape's edge. The number grows with the sessions it counts and
  * the shape beside the housing does not, so past the width the wing can hold
@@ -99,6 +116,8 @@ export function countBadgeFit(
   housingWidth: number,
   valueWidth: number,
   captionWidth: number,
+  /** True for the sign-in label, which starts flush at the housing's edge. */
+  flushToHousing = false,
 ): number {
   const captioned =
     presentation === PANEL_PRESENTATION.PEEK || presentation === PANEL_PRESENTATION.PANEL;
@@ -111,7 +130,9 @@ export function countBadgeFit(
         ? PEEK_SIDE_WIDTH
         : CAPSULE_SIDE_WIDTH;
   const restingScale = presentation === PANEL_PRESENTATION.PANEL ? 1 : COUNT_RESTING_SCALE;
-  const room = Math.max(0, sideWidth - COUNT_INSET - COUNT_EDGE_KEEP);
+  const inset = flushToHousing ? SIGN_IN_INSET : COUNT_INSET;
+  const keep = flushToHousing ? SIGN_IN_EDGE_KEEP : COUNT_EDGE_KEEP;
+  const room = Math.max(0, sideWidth - inset - keep);
   return Math.min(1, room / (restingScale * textWidth));
 }
 
@@ -157,6 +178,7 @@ export function NotchWings({
   voiceOpening,
   presentation,
   housingWidth,
+  accountGated,
 }: NotchWingsProps): React.JSX.Element {
   const [voiceActive, setVoiceActive] = useState(false);
   const reportVoiceActivity = useCallback(
@@ -239,6 +261,7 @@ export function NotchWings({
     housingWidth,
     countWidths.value,
     countWidths.caption,
+    accountGated,
   );
 
   return (
@@ -296,7 +319,7 @@ export function NotchWings({
               replay it on being handed the same one. The wrapper is what the
               hover is measured against, so it holds still across those
               remounts — and hovering it is a moment the face reacts to. */}
-          {yieldToMeter ? null : (
+          {yieldToMeter || accountGated ? null : (
             /* The wrapper is also where an errand sets off from, for the same
                reason the hover is measured against it: it holds still while a
                motion transforms layers inside the drawing, so a mark peeling
@@ -312,20 +335,29 @@ export function NotchWings({
 
       <div className="wing wing-right">
         <div className="wing-inner">
+          {/* While sign-in stands between Luke and anything to watch, the
+              badge's place says the one honest thing instead of a zero that
+              would pose as "nothing happening": why Luke is idle, and the one
+              act that wakes him. It shares the count's element and fit, so it
+              scales into the capsule's side exactly as a wide number does. */}
           <span
             className="count-badge"
             style={{ "--count-fit": countFit } as React.CSSProperties}
             data-state={tally.urgency}
-            data-empty={String(tally.total === 0)}
+            data-empty={String(accountGated || tally.total === 0)}
+            data-sign-in={String(accountGated)}
             role="status"
             aria-live="polite"
-            aria-label={tallySummary(tally)}
+            aria-label={accountGated ? "Sign in" : tallySummary(tally)}
           >
             <span className="count-value" aria-hidden="true" ref={countValueElement}>
-              {tally.total}
+              {accountGated ? "Sign in" : tally.total}
             </span>
             <span className="count-caption" aria-hidden="true" ref={countCaptionElement}>
-              {tallyCaption(tally)}
+              {/* No caption while signed out: the two words are the label
+                  entire, and with nothing beside them the fit keeps their
+                  natural size inside the peek's side. */}
+              {accountGated ? null : tallyCaption(tally)}
             </span>
           </span>
         </div>

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -8,6 +8,7 @@ import {
 import { useCallback, useRef, useState } from "react";
 import {
   ACCOUNT_STATUS,
+  type AccountProvider,
   type AccountSnapshot,
   SESSION_OPEN_RESULT_STATUS,
   type SessionOpenResult,
@@ -534,6 +535,10 @@ function SessionRun({
 export interface PanelBodyProps {
   accountRequired: boolean;
   account: AccountSnapshot;
+  /** Starts a sign-in; the app stands the panel down to the waiting popup. */
+  onBeginSignIn: (provider: AccountProvider) => void;
+  /** Why the last sign-in ended without landing, for the gate to show. */
+  signInFailure?: string;
   list: ArrangedSessions;
   view: SessionView;
   onViewChange: (view: SessionView) => void;
@@ -581,6 +586,8 @@ export interface PanelBodyProps {
 export function PanelBody({
   accountRequired,
   account,
+  onBeginSignIn,
+  signInFailure,
   list,
   view,
   onViewChange,
@@ -606,7 +613,12 @@ export function PanelBody({
   if (accountRequired && account.status !== ACCOUNT_STATUS.SIGNED_IN) {
     return (
       <div className="body">
-        <SignInGate account={account} onQuit={settings.onQuit} />
+        <SignInGate
+          account={account}
+          {...(signInFailure ? { failure: signInFailure } : {})}
+          onBegin={onBeginSignIn}
+          onQuit={settings.onQuit}
+        />
       </div>
     );
   }

--- a/apps/desktop/src/renderer/settings-icons.tsx
+++ b/apps/desktop/src/renderer/settings-icons.tsx
@@ -202,6 +202,16 @@ export function ExternalIcon(): React.JSX.Element {
   );
 }
 
+/** A person: the account the app is signed in as. */
+export function UserIcon(): React.JSX.Element {
+  return (
+    <Glyph>
+      <circle cx="12" cy="8.2" r="3.6" />
+      <path d="M5.4 19.8a6.6 6.6 0 0 1 13.2 0" />
+    </Glyph>
+  );
+}
+
 export function PowerIcon(): React.JSX.Element {
   return (
     <Glyph>

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -84,6 +84,7 @@ import {
   ShieldIcon,
   SpeakerIcon,
   TrashIcon,
+  UserIcon,
 } from "./settings-icons";
 import {
   pageExitMs,
@@ -1686,37 +1687,124 @@ function ShortcutSection({ shortcuts }: { shortcuts: ShortcutControl }): React.J
 function AccountSection({
   account,
   onSignOut,
+  panelOpen,
 }: {
   account: Extract<AccountSnapshot, { status: typeof ACCOUNT_STATUS.SIGNED_IN }>;
   onSignOut: () => Promise<void>;
+  panelOpen: boolean;
 }): React.JSX.Element {
+  // Signing out asks first, the way deleting a key does: getting back in costs
+  // a whole trip through the browser, so the button asks and only the answer
+  // acts. The question follows the removal confirm's one rule about surfaces —
+  // it does not survive the panel closing — corrected during the render that
+  // discovers it rather than from an effect.
+  const [asking, setAsking] = useState(false);
   const [busy, setBusy] = useState(false);
+  const keep = useRef<HTMLButtonElement | null>(null);
+  if (asking && !panelOpen && !busy) setAsking(false);
+
+  // The question takes the focus to the answer that changes nothing, exactly
+  // as the delete confirm does: the control that asked is inert by the time
+  // the confirm is drawn.
+  useStagedFocus(keep, asking && !busy);
+
+  const signOut = () => {
+    setBusy(true);
+    void onSignOut().finally(() => {
+      setBusy(false);
+      setAsking(false);
+    });
+  };
+
   return (
-    <section className="settings-section" style={{ "--row-index": 2 } as React.CSSProperties}>
+    <section className="settings-section" style={{ "--row-index": 4 } as React.CSSProperties}>
       <h2>
-        <CheckIcon />
-        Your account
+        <UserIcon />
+        Account
       </h2>
       <div className="settings-row">
-        <span className="settings-copy">
-          <span className="settings-name">
-            <strong>{account.email}</strong>
+        <span className="settings-copy account-identity">
+          {/* The provider's own picture of the person, when their identity
+              carried one from a host this build pins — otherwise the same
+              glyph the heading wears, so the line never shows a broken image. */}
+          {account.pictureUrl ? (
+            <img
+              className="account-avatar"
+              src={account.pictureUrl}
+              alt=""
+              referrerPolicy="no-referrer"
+              draggable={false}
+            />
+          ) : (
+            <span className="account-avatar account-avatar-fallback" aria-hidden="true">
+              <UserIcon />
+            </span>
+          )}
+          <span className="account-words">
+            <span className="settings-name">
+              <strong>{account.email}</strong>
+            </span>
+            <small>
+              Signed in with {account.provider === ACCOUNT_PROVIDER.GITHUB ? "GitHub" : "Google"}
+            </small>
           </span>
-          <small>
-            Signed in with {account.provider === ACCOUNT_PROVIDER.GITHUB ? "GitHub" : "Google"}
-          </small>
         </span>
-        <button
-          type="button"
-          className="quiet-button"
-          disabled={busy}
-          onClick={() => {
-            setBusy(true);
-            void onSignOut().finally(() => setBusy(false));
-          }}
-        >
-          {busy ? "Signing out…" : "Sign out"}
-        </button>
+        {/* The control and the confirm that stands in for it are the same cell
+            of one grid, exactly as a credential row's are, so the line never
+            re-shapes as they trade places. */}
+        <span className="credential-actions">
+          <span
+            className="settings-actions credential-controls"
+            data-drawn={String(!asking)}
+            aria-hidden={asking}
+            inert={asking}
+          >
+            <button
+              type="button"
+              className="quiet-button account-signout"
+              disabled={busy}
+              /* The ellipsis is the promise that it asks first. */
+              title="Sign out…"
+              onClick={() => setAsking(true)}
+            >
+              Sign out
+            </button>
+          </span>
+          <fieldset
+            className="settings-actions credential-confirm"
+            aria-label={`Sign out of ${account.email}?`}
+            data-drawn={String(asking)}
+            aria-hidden={!asking}
+            inert={!asking}
+            onKeyDown={(event) => {
+              // Escape withdraws the question rather than closing the panel it
+              // was asked on — but only while it is still a question.
+              if (event.key !== "Escape" || busy) return;
+              event.stopPropagation();
+              setAsking(false);
+            }}
+          >
+            <button
+              type="button"
+              ref={keep}
+              className="quiet-button"
+              style={answerOrder(REMOVAL_ANSWER_INDEX.KEEP)}
+              disabled={busy}
+              onClick={() => setAsking(false)}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="danger-button"
+              style={answerOrder(REMOVAL_ANSWER_INDEX.DELETE)}
+              disabled={busy}
+              onClick={signOut}
+            >
+              {busy ? "Signing out…" : "Sign out"}
+            </button>
+          </fieldset>
+        </span>
       </div>
     </section>
   );
@@ -1848,10 +1936,7 @@ export function SettingsPanel({
 
       {drawnView !== SETTINGS_VIEW.ROOT ? null : (
         <>
-          {account.status === ACCOUNT_STATUS.SIGNED_IN ? (
-            <AccountSection account={account} onSignOut={onSignOut} />
-          ) : null}
-          <section className="settings-section" style={{ "--row-index": 3 } as React.CSSProperties}>
+          <section className="settings-section" style={{ "--row-index": 2 } as React.CSSProperties}>
             <h2>
               <ShieldIcon />
               Permissions
@@ -1894,6 +1979,13 @@ export function SettingsPanel({
           </section>
 
           <FeedbackSection control={feedback} />
+
+          {/* The account stands last before the way out: signing out and
+              quitting are the two acts that end the session, so they live
+              together at the foot rather than above the sections still in use. */}
+          {account.status === ACCOUNT_STATUS.SIGNED_IN ? (
+            <AccountSection account={account} onSignOut={onSignOut} panelOpen={panelOpen} />
+          ) : null}
 
           <button
             type="button"

--- a/apps/desktop/src/renderer/sign-in-gate.tsx
+++ b/apps/desktop/src/renderer/sign-in-gate.tsx
@@ -1,61 +1,106 @@
-import { useState } from "react";
-import {
-  ACCOUNT_PROVIDER,
-  ACCOUNT_STATUS,
-  type AccountProvider,
-  type AccountSnapshot,
-} from "../shared/contracts";
+import { useEffect, useState } from "react";
+import type { AccountSnapshot } from "../shared/contracts";
+import { ACCOUNT_PROVIDER, ACCOUNT_STATUS, type AccountProvider } from "../shared/contracts";
+import { GitHubMark, GoogleMark } from "./account-marks";
+import { FACE_MOTION, FACE_MOTION_CYCLE_MS, type FaceMotion } from "./luke-face-art";
+
+/**
+ * The introductions Luke makes while nobody is signed in, in the order he
+ * makes them: a slow sway, one pirouette, a double blink, the curious tilt,
+ * and a nod — then around again. Every one is a gesture from his own motion
+ * table, so each plays once and hands the face back to the resting pose the
+ * next one starts from.
+ */
+const SIGN_IN_FACE_CYCLE = [
+  FACE_MOTION.MONITORING,
+  FACE_MOTION.REFRESH,
+  FACE_MOTION.IDLE,
+  FACE_MOTION.LISTENING,
+  FACE_MOTION.YES,
+] as const;
+
+/**
+ * The stillness between gestures. Long enough that each reads as something
+ * Luke did rather than one long fidget, short enough that the face never looks
+ * switched off while it is the only thing introducing him.
+ */
+const SIGN_IN_FACE_REST_MS = 1_100;
+
+/** Which gesture a step of the cycle plays, wrapping forever. */
+export function signInFaceMotion(step: number): FaceMotion {
+  return SIGN_IN_FACE_CYCLE[step % SIGN_IN_FACE_CYCLE.length] ?? FACE_MOTION.IDLE;
+}
+
+/**
+ * Walks the introduction cycle: each gesture runs its own generated length,
+ * rests, and yields to the next. The face this drives is the one Luke the
+ * signed-out surface has — large over the gate, small in the peek's strip —
+ * so the cycle keeps walking through the morph between the two. Reduced
+ * motion holds the resting face instead — the pose every gesture starts and
+ * ends at.
+ */
+export function useSignInFaceCycle(still: boolean): { motion?: FaceMotion; play: number } {
+  const [step, setStep] = useState(0);
+  useEffect(() => {
+    if (still) return;
+    const timer = window.setTimeout(
+      () => setStep((current) => current + 1),
+      FACE_MOTION_CYCLE_MS[signInFaceMotion(step)] + SIGN_IN_FACE_REST_MS,
+    );
+    return () => window.clearTimeout(timer);
+  }, [step, still]);
+  if (still) return { play: 0 };
+  return { motion: signInFaceMotion(step), play: step };
+}
 
 export function SignInGate({
   account,
+  failure,
+  onBegin,
   onQuit,
 }: {
   account: AccountSnapshot;
+  /** Why the last attempt ended without landing, from the flow's owner. */
+  failure?: string;
+  /** Starts the flow; the app stands the panel down to the waiting popup. */
+  onBegin: (provider: AccountProvider) => void;
   onQuit: () => void;
 }): React.JSX.Element {
-  const [chosen, setChosen] = useState<AccountProvider>();
-  const [failure, setFailure] = useState<string>();
-  const pending = account.status === ACCOUNT_STATUS.SIGNING_IN || chosen !== undefined;
-
-  const begin = async (provider: AccountProvider) => {
-    if (pending) return;
-    setChosen(provider);
-    setFailure(undefined);
-    try {
-      await window.sidecar.beginSignIn(provider);
-    } catch {
-      setChosen(undefined);
-      setFailure("Sign-in did not finish. Try again when you’re ready.");
-    }
-  };
+  const pending = account.status === ACCOUNT_STATUS.SIGNING_IN;
 
   return (
     <section className="sign-in-gate" aria-labelledby="sign-in-title">
-      <div className="sign-in-eyes" aria-hidden="true">
-        <span />
-        <span />
-      </div>
+      {/* The face's room, not the face: the one signed-out Luke is drawn on
+          the stage above, where he can travel to the peek's strip and back
+          without there ever being a second of him. This box is what he stands
+          over while the panel is the shape on screen. */}
+      <span className="sign-in-face" aria-hidden="true" />
       <h1 id="sign-in-title">Meet Luke</h1>
       <p>Sign in before Luke starts watching your coding agents.</p>
       <div className="sign-in-actions">
         <button
           type="button"
+          className="sign-in-provider"
           disabled={pending}
-          onClick={() => void begin(ACCOUNT_PROVIDER.GOOGLE)}
+          onClick={() => onBegin(ACCOUNT_PROVIDER.GOOGLE)}
         >
-          {chosen === ACCOUNT_PROVIDER.GOOGLE ? "Waiting for Google…" : "Continue with Google"}
+          <GoogleMark />
+          Continue with Google
         </button>
         <button
           type="button"
+          className="sign-in-provider"
           disabled={pending}
-          onClick={() => void begin(ACCOUNT_PROVIDER.GITHUB)}
+          onClick={() => onBegin(ACCOUNT_PROVIDER.GITHUB)}
         >
-          {chosen === ACCOUNT_PROVIDER.GITHUB ? "Waiting for GitHub…" : "Continue with GitHub"}
+          <GitHubMark />
+          Continue with GitHub
         </button>
       </div>
       {failure ? <small className="sign-in-error">{failure}</small> : null}
-      {pending ? <small>Finish signing in in your browser.</small> : null}
-      <button type="button" className="quit-button sign-in-quit" onClick={onQuit}>
+      {/* The way out, quiet on purpose: it is the one control here that is not
+          the reason the screen exists. */}
+      <button type="button" className="sign-in-quit" onClick={onQuit}>
         Quit Luke
       </button>
     </section>

--- a/apps/desktop/src/renderer/sign-in-slot.tsx
+++ b/apps/desktop/src/renderer/sign-in-slot.tsx
@@ -1,0 +1,61 @@
+import { useRef } from "react";
+import { ACCOUNT_PROVIDER, type AccountProvider } from "../shared/contracts";
+import { AccountProviderMark } from "./account-marks";
+import { useStagedFocus } from "./credential-entry";
+import { HIT_REGION } from "./panel-state";
+
+/**
+ * The panel stood down to the sign-in it is waiting on, the way it stands down
+ * to the key slot: the browser holds the actual work, so Luke gets out of its
+ * way and leaves one small shape saying what he is waiting for — and the one
+ * control that can take the wait back. Nothing the pointer does dismisses it;
+ * Cancel and the sign-in landing are its only ways out.
+ */
+export function SignInSlot({
+  provider,
+  drawn,
+  onCancel,
+  measure,
+}: {
+  /** Whose sign-in is being waited on; absent once the wait has ended. */
+  provider?: AccountProvider;
+  /** True while the slot is the shape the surface is drawn as. */
+  drawn: boolean;
+  onCancel: () => void;
+  /** Reports the slot's height, so the surface can end where it does. */
+  measure: (element: HTMLElement | null) => void;
+}): React.JSX.Element | null {
+  const cancel = useRef<HTMLButtonElement | null>(null);
+  // The slot outlives the wait that filled it, like the key slot does: it
+  // keeps saying what it was saying until the shape has left it behind.
+  const held = useRef(provider);
+  if (provider) held.current = provider;
+  const shown = held.current;
+  const live = drawn && provider !== undefined;
+
+  // The one control is what the keyboard lands on, so Escape and Enter both
+  // answer the shape that is actually on screen.
+  useStagedFocus(cancel, live);
+
+  if (!shown) return null;
+
+  const name = shown === ACCOUNT_PROVIDER.GITHUB ? "GitHub" : "Google";
+  return (
+    <div className="slot-stage" aria-hidden={!live} inert={!live}>
+      <div className="key-slot sign-in-slot" ref={measure} data-hit-region={HIT_REGION.SLOT}>
+        <div className="key-slot-row">
+          <span className="key-slot-mark sign-in-slot-mark">
+            <AccountProviderMark provider={shown} />
+          </span>
+          <span className="sign-in-slot-copy" role="status">
+            <strong>Waiting for {name}…</strong>
+            <small>Finish signing in in your browser.</small>
+          </span>
+          <button type="button" ref={cancel} className="quiet-button" onClick={onCancel}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1160,6 +1160,34 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   color: var(--text-tertiary);
 }
 
+/* The signed-out label wears words, not a numeral: the count's rounded
+   tabular face at label length reads as a button that is not one, so it
+   steps down to the panel's own text voice at a quieter size. It reads in
+   both compact shapes — inside the capsule's side it stands down to fit,
+   exactly as a wide count does — and hides over the open panel, where the
+   gate itself says it larger. The base rule declares only the transform
+   pair, so this restates it beside the fade rather than adding to it. */
+.count-badge[data-sign-in="true"] {
+  /* Flush to the housing's edge: the notch is black on black, so the inset a
+     numeral keeps reads as nothing here, and every pixel of it is room the
+     words need. The fit arithmetic mirrors this with `SIGN_IN_INSET`. */
+  margin-left: calc(-1 * var(--wing-inset));
+  font-family: inherit;
+  font-size: 12px;
+  font-variant-numeric: normal;
+  font-weight: 640;
+  letter-spacing: 0.1px;
+  opacity: 0;
+  transition:
+    transform var(--duration-shape) var(--spring),
+    opacity var(--duration-quick) var(--motion-exit);
+}
+
+.app-stage[data-presentation="capsule"] .count-badge[data-sign-in="true"],
+.app-stage[data-presentation="peek"] .count-badge[data-sign-in="true"] {
+  opacity: 1;
+}
+
 /* The panel has room for it to sit at full size; the capsule and the peek do
    not, and growing it there read as a second movement competing with the
    widening. */

--- a/apps/desktop/src/renderer/styles/settings.css
+++ b/apps/desktop/src/renderer/styles/settings.css
@@ -451,6 +451,50 @@
   gap: 7px;
 }
 
+/* The signed-in identity: the provider's picture of the person beside their
+   address, or our own glyph where no picture travelled. */
+.account-identity {
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  gap: 10px;
+}
+
+.account-avatar {
+  width: 26px;
+  height: 26px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.account-avatar-fallback {
+  display: grid;
+  background: var(--raised);
+  color: var(--text-secondary);
+  place-items: center;
+}
+
+.account-avatar-fallback .settings-icon {
+  width: 14px;
+  height: 14px;
+}
+
+.account-words {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/* Signing out is destructive the way deleting a key is — getting back in costs
+   a trip through the browser — so it says so on hover rather than sitting in
+   red beside the identity it would end. */
+.account-signout:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  color: var(--danger-text);
+}
+
 /* Deleting a key is the one act in this panel that cannot be undone from inside
    it: nothing here can hand a key back, so a trash pressed by mistake costs a
    trip to the provider's own site. The trash asks instead of acting, and the

--- a/apps/desktop/src/renderer/styles/sign-in.css
+++ b/apps/desktop/src/renderer/styles/sign-in.css
@@ -1,9 +1,11 @@
+/* The panel's own padding already clears the housing by `--notch-top-inset`
+   plus a margin, so the gate adds almost nothing of its own on top. */
 .sign-in-gate {
   display: grid;
   justify-items: center;
   gap: 10px;
   min-height: 250px;
-  padding: 28px 24px 26px;
+  padding: 4px 24px 18px;
   text-align: center;
 }
 
@@ -21,18 +23,77 @@
   color: var(--text-secondary);
 }
 
-.sign-in-eyes {
-  display: flex;
-  gap: 24px;
-  padding: 7px 0;
-  transform: rotate(-8deg);
+/* The face's reserved room on the gate. The face itself is `.sign-in-luke`,
+   drawn once on the stage so the same Luke can travel between the gate and
+   the peek's strip; this box is where he rests while the panel is up. */
+.sign-in-face {
+  width: 56px;
+  height: 56px;
+  margin: 4px 0 2px;
 }
 
-.sign-in-eyes span {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: currentColor;
+/* The one signed-out Luke, like the caption a single element in every state so
+   the morph carries him rather than trading two copies. At rest he stands over
+   the gate's reserved box — `--sign-in-face-rest` is that box's top, restated
+   from the panel's own padding (14px) plus the gate's (4px) and the box's
+   margin (4px) — and in the compact shapes he takes the wing spot the authed
+   face holds: against the housing, past `--wing-inset` and half his drawn
+   width, at the strip's centre. Only `transform` and `opacity` move him, on
+   the caption's own beat: leaving a state, he travels with the shape rather
+   than ahead of it. 0.3214 is 18/56 — the wing face's size over the gate's. */
+.sign-in-luke {
+  --sign-in-face-rest: calc(var(--capsule-height) + 22px);
+
+  position: absolute;
+  z-index: 3;
+  top: var(--sign-in-face-rest);
+  left: calc(50% - 28px);
+  display: flex;
+  width: 56px;
+  height: 56px;
+  pointer-events: none;
+  transform-origin: center;
+  transition:
+    opacity var(--duration-exit) var(--motion-exit),
+    transform var(--duration-shape) var(--spring) var(--duration-exit);
+  will-change: transform;
+}
+
+/* A notchless display shifts the drawn shapes down by `--shape-top`; the rest
+   pose follows the panel it stands over. */
+.app-stage[data-notch="false"] .sign-in-luke {
+  --sign-in-face-rest: calc(var(--capsule-height) + 22px + var(--shape-top, 0px));
+}
+
+.sign-in-luke .luke-face {
+  width: 56px;
+  height: 56px;
+}
+
+/* He keeps the panel's own ink through every gesture: the wing recolours
+   listening and talking because there the colour reports whose turn a
+   conversation is, and here there is no conversation for it to report. */
+.sign-in-luke .luke-face[data-motion="listening"],
+.sign-in-luke .luke-face[data-motion="talking"] {
+  color: var(--text-primary);
+}
+
+/* The compact pose, shared by the capsule and the peek: the wing spot, at the
+   wing face's size — where the authed strip keeps Luke in the same states. */
+.app-stage[data-presentation="capsule"] .sign-in-luke,
+.app-stage[data-presentation="peek"] .sign-in-luke {
+  transform: translate(
+      calc(var(--notch-housing-width) / -2 - 18px),
+      calc(var(--capsule-height) / 2 - var(--sign-in-face-rest) - 28px)
+    )
+    scale(0.3214);
+}
+
+/* The waiting popup has its own words; the face steps out of their way and
+   comes back when the panel does. */
+.app-stage[data-presentation="slot"] .sign-in-luke,
+.app-stage[data-presentation="feedback"] .sign-in-luke {
+  opacity: 0;
 }
 
 .sign-in-actions {
@@ -42,28 +103,83 @@
   margin-top: 8px;
 }
 
-.sign-in-actions button {
+.sign-in-provider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
   min-height: 38px;
   border: 1px solid var(--hairline);
   border-radius: 10px;
   background: var(--raised);
-  color: var(--text);
+  color: var(--text-primary);
   font-weight: 650;
 }
 
-.sign-in-actions button:hover:not(:disabled) {
+.sign-in-provider:hover:not(:disabled) {
   background: var(--raised-strong);
 }
 
-.sign-in-actions button:disabled {
+.sign-in-provider:disabled {
   opacity: 0.55;
+}
+
+/* The provider's own mark, at the size its guidelines draw beside a label. */
+.account-mark {
+  width: 15px;
+  height: 15px;
+  flex: 0 0 auto;
 }
 
 .sign-in-gate .sign-in-error {
   color: var(--state-attention);
 }
 
+/* Quiet on purpose: leaving is the one act here that is not the reason the
+   screen exists, so it reads as a footnote until it is asked after — and then
+   admits what it is the way every destructive control does. */
 .sign-in-quit {
-  width: 100%;
-  margin-top: 8px;
+  padding: 6px 10px;
+  border: 0;
+  border-radius: 8px;
+  margin-top: 4px;
+  background: none;
+  color: var(--text-tertiary);
+  font-size: 10.5px;
+  font-weight: 620;
+  transition:
+    background-color var(--duration-hover) ease,
+    color var(--duration-hover) ease;
+}
+
+.sign-in-quit:hover {
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  color: var(--danger-text);
+}
+
+/* The waiting popup's one line: whose sign-in, what is being waited for, and
+   the way to take it back. */
+.sign-in-slot-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 2px;
+  text-align: left;
+}
+
+.sign-in-slot-copy strong {
+  color: var(--text-primary);
+  font-size: 11.5px;
+  font-weight: 650;
+}
+
+.sign-in-slot-copy small {
+  color: var(--text-secondary);
+  font-size: 10px;
+}
+
+.sign-in-slot-mark .account-mark {
+  width: 16px;
+  height: 16px;
 }

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -114,6 +114,7 @@ interface PersistedSettings {
     tokenCipher: string;
     email: string;
     name?: string;
+    pictureUrl?: string;
     provider: AccountProvider;
   };
   /**
@@ -217,6 +218,7 @@ export interface StoredAccount {
   refreshToken: string;
   email: string;
   name?: string;
+  pictureUrl?: string;
   provider: AccountProvider;
 }
 
@@ -241,6 +243,9 @@ function storedAccount(record: Record<string, unknown>): PersistedSettings["acco
     tokenCipher: account.tokenCipher,
     email: account.email,
     ...(typeof account.name === "string" && account.name ? { name: account.name } : {}),
+    ...(typeof account.pictureUrl === "string" && account.pictureUrl
+      ? { pictureUrl: account.pictureUrl }
+      : {}),
     provider: account.provider,
   };
 }
@@ -532,6 +537,7 @@ export class SettingsStore {
         refreshToken,
         email: account.email,
         ...(account.name ? { name: account.name } : {}),
+        ...(account.pictureUrl ? { pictureUrl: account.pictureUrl } : {}),
         provider: account.provider,
       };
     } catch {
@@ -546,6 +552,7 @@ export class SettingsStore {
           status: ACCOUNT_STATUS.SIGNED_IN,
           email: account.email,
           ...(account.name ? { name: account.name } : {}),
+          ...(account.pictureUrl ? { pictureUrl: account.pictureUrl } : {}),
           provider: account.provider,
         }
       : { status: ACCOUNT_STATUS.SIGNED_OUT };
@@ -573,6 +580,7 @@ export class SettingsStore {
           tokenCipher,
           email: account.email,
           ...(account.name ? { name: account.name } : {}),
+          ...(account.pictureUrl ? { pictureUrl: account.pictureUrl } : {}),
           provider: account.provider,
         },
       };

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -48,6 +48,11 @@ export type AccountSnapshot =
       status: typeof ACCOUNT_STATUS.SIGNED_IN;
       email: string;
       name?: string;
+      /**
+       * The provider's own avatar for the signed-in user, kept only when it
+       * lives on a host this build pins in the renderer's image policy.
+       */
+      pictureUrl?: string;
       provider: AccountProvider;
     };
 
@@ -351,6 +356,12 @@ export interface VoiceHotkeyState {
 export interface AppBridge {
   getBootstrap(): Promise<AppBootstrap>;
   beginSignIn(provider: AccountProvider): Promise<AccountSnapshot>;
+  /**
+   * Withdraws a sign-in still waiting on the browser. The attempt ends where
+   * it stands — the loopback closes and the account returns to signed-out —
+   * and a sign-in that already landed is left signed in.
+   */
+  cancelSignIn(): Promise<void>;
   signOut(): Promise<AccountSnapshot>;
   setExpanded(expanded: boolean, focus?: boolean): Promise<WindowMode>;
   setPointerInterception(interceptsPointer: boolean): void;
@@ -627,6 +638,7 @@ export interface AppBridge {
 export const channels = {
   bootstrap: "app:bootstrap",
   beginSignIn: "app:begin-sign-in",
+  cancelSignIn: "app:cancel-sign-in",
   signOut: "app:sign-out",
   accountChanged: "app:account-changed",
   setExpanded: "app:set-expanded",

--- a/apps/desktop/tests/account-client.test.ts
+++ b/apps/desktop/tests/account-client.test.ts
@@ -128,6 +128,40 @@ test("userinfo returns only the renderer-safe identity fields", async () => {
   });
 });
 
+test("userinfo keeps a picture only from the hosts the renderer's policy pins", async () => {
+  const clientFor = (picture: string) =>
+    new AccountClient({
+      baseUrl: "https://tryluke.dev/api/auth",
+      clientId: "luke-desktop",
+      fetch: async () => json({ email: "developer@example.com", picture }),
+    });
+
+  const google = await clientFor("https://lh3.googleusercontent.com/a/portrait").userInfo(
+    "access",
+    ACCOUNT_PROVIDER.GOOGLE,
+  );
+  assert.equal(google.pictureUrl, "https://lh3.googleusercontent.com/a/portrait");
+
+  const github = await clientFor("https://avatars.githubusercontent.com/u/1?v=4").userInfo(
+    "access",
+    ACCOUNT_PROVIDER.GITHUB,
+  );
+  assert.equal(github.pictureUrl, "https://avatars.githubusercontent.com/u/1?v=4");
+
+  // Anywhere else — another host, a scheme downgrade, a suffix imposter, or
+  // no URL at all — the identity simply travels without a picture.
+  for (const refused of [
+    "https://example.com/avatar.png",
+    "http://lh3.googleusercontent.com/a/portrait",
+    "https://evilgoogleusercontent.com/a/portrait",
+    "https://avatars.githubusercontent.com.evil.example/u/1",
+    "not a url",
+  ]) {
+    const identity = await clientFor(refused).userInfo("access", ACCOUNT_PROVIDER.GOOGLE);
+    assert.equal(identity.pictureUrl, undefined, refused);
+  }
+});
+
 test("OAuth errors preserve their status and machine-readable code", async () => {
   const client = new AccountClient({
     baseUrl: "https://tryluke.dev/api/auth",

--- a/apps/desktop/tests/account-loopback.test.ts
+++ b/apps/desktop/tests/account-loopback.test.ts
@@ -13,6 +13,12 @@ test("a mismatched state is refused without consuming the callback", async () =>
       `${loopback.redirectUri}?code=accepted&state=${encodeURIComponent(loopback.state)}`,
     );
     assert.equal(accepted.status, 200);
+    // The last thing a sign-in shows is a page, not a line of bare text — and
+    // nothing the redirect carried may appear in it.
+    assert.match(accepted.headers.get("content-type") ?? "", /text\/html/);
+    const body = await accepted.text();
+    assert.match(body, /Signed in to Luke/);
+    assert.doesNotMatch(body, /accepted/);
     assert.equal(await loopback.waitForCode, "accepted");
   } finally {
     await loopback.close();
@@ -38,6 +44,30 @@ test("a matching OAuth refusal ends the sign-in immediately", async () => {
     assert.equal((await fetch(`${callback}&error=access_denied`)).status, 400);
     await assert.rejects(loopback.waitForCode, /access_denied/);
     assert.equal((await fetch(`${callback}&code=too-late`)).status, 409);
+  } finally {
+    await loopback.close();
+  }
+});
+
+test("cancel rejects the wait and closes the callback", async () => {
+  const loopback = await startAccountLoopback({ timeoutMs: 2_000 });
+  loopback.cancel();
+  await assert.rejects(loopback.waitForCode, /cancelled/);
+  // The server is gone with the wait: the redirect has nowhere left to land.
+  await assert.rejects(
+    fetch(`${loopback.redirectUri}?code=late&state=${encodeURIComponent(loopback.state)}`),
+  );
+});
+
+test("a cancel after the code landed changes nothing", async () => {
+  const loopback = await startAccountLoopback({ timeoutMs: 2_000 });
+  try {
+    const response = await fetch(
+      `${loopback.redirectUri}?code=accepted&state=${encodeURIComponent(loopback.state)}`,
+    );
+    assert.equal(response.status, 200);
+    loopback.cancel();
+    assert.equal(await loopback.waitForCode, "accepted");
   } finally {
     await loopback.close();
   }

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -209,7 +209,7 @@ test("the guide names the signed-in identity and keeps sign-out manual", () => {
       },
     }),
   ).facts;
-  const account = facts.find((fact) => fact.label === "Your account");
+  const account = facts.find((fact) => fact.label === "Account");
 
   assert.match(account?.detail ?? "", /developer@example.com/);
   assert.match(account?.detail ?? "", /GitHub/);

--- a/apps/desktop/tests/notch-wings.test.ts
+++ b/apps/desktop/tests/notch-wings.test.ts
@@ -77,6 +77,17 @@ test("exactly filling the wing needs no count", () => {
 const capsuleRoom = CAPSULE_SIDE_WIDTH - 11;
 const peekRoom = peekSideWidth - 11;
 
+test("the sign-in label starts at the housing and keeps clear of the strip's corner", () => {
+  // Flush to the housing, the label spends no inset and keeps more from the
+  // outer corner, so the same words render larger than a numeral's margins
+  // would allow — and still inside the capsule's side.
+  const width = 42;
+  const label = countBadgeFit(PANEL_PRESENTATION.CAPSULE, 180, width, 0, true);
+  const count = countBadgeFit(PANEL_PRESENTATION.CAPSULE, 180, width, 0);
+  assert.ok(label > count);
+  assert.ok(label * 0.88 * width <= 36 - 6);
+});
+
 test("a count that fits keeps its resting scale", () => {
   // Two tabular digits: about 19 layout pixels, 17 once the 0.88 draws them.
   assert.equal(countBadgeFit(PANEL_PRESENTATION.CAPSULE, 210, 19, 0), 1);

--- a/apps/web/src/consent.tsx
+++ b/apps/web/src/consent.tsx
@@ -3,6 +3,7 @@ import { oauthProviderClient } from "@better-auth/oauth-provider/client";
 import { createAuthClient } from "better-auth/react";
 import { StrictMode, useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
+import { LukeMark } from "./SiteChrome";
 import "./styles.css";
 
 const authClient = createAuthClient({ plugins: [oauthProviderClient()] });
@@ -17,6 +18,14 @@ function Consent(): React.JSX.Element {
   return (
     <main className="auth-shell">
       <section className="auth-card">
+        <div className="auth-mark" aria-hidden="true">
+          <LukeMark />
+        </div>
+        <div>
+          <span className="auth-pill" data-tone={failure ? "attention" : "settled"}>
+            {failure ? "Not completed" : "Confirming"}
+          </span>
+        </div>
         <h1>{failure ? "Luke could not continue" : "Continuing to Luke…"}</h1>
         <p>
           {failure ? "Return to Luke and start sign-in again." : "This window will close soon."}

--- a/apps/web/src/sign-in.tsx
+++ b/apps/web/src/sign-in.tsx
@@ -3,6 +3,7 @@ import { oauthProviderClient } from "@better-auth/oauth-provider/client";
 import { createAuthClient } from "better-auth/react";
 import { StrictMode, useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
+import { LukeMark } from "./SiteChrome";
 import {
   SOCIAL_PROVIDER_LABEL,
   type SocialProvider,
@@ -51,8 +52,7 @@ function SignIn(): React.JSX.Element {
     <main className="auth-shell">
       <section className="auth-card" aria-labelledby="auth-title">
         <div className="auth-mark" aria-hidden="true">
-          <span />
-          <span />
+          <LukeMark />
         </div>
         <h1 id="auth-title">Sign in to Luke</h1>
         <p>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -138,17 +138,35 @@ button {
   color: var(--text-secondary);
 }
 
+/* The full mark, not a pair of dots: the card is the one thing on the page,
+   so it carries the same face the product and the landing page wear. */
 .auth-mark {
   display: inline-flex;
-  gap: 22px;
-  transform: rotate(-8deg);
+  width: 52px;
+  color: var(--text);
 }
 
-.auth-mark span {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: var(--text);
+.auth-mark svg {
+  width: 100%;
+  height: auto;
+}
+
+/* One word saying where things stand, in the state palette the product uses. */
+.auth-pill {
+  display: inline-block;
+  margin-top: var(--space-4);
+  padding: 3px 11px;
+  border-radius: var(--radius-pill);
+  background: rgba(111, 220, 164, 0.14);
+  color: var(--complete);
+  font-size: var(--text-xs);
+  font-weight: 650;
+  letter-spacing: 0.2px;
+}
+
+.auth-pill[data-tone="attention"] {
+  background: rgba(255, 160, 73, 0.14);
+  color: var(--attention);
 }
 
 .auth-actions {


### PR DESCRIPTION
## Summary

- The sign-in gate draws the real Luke face (the hand-rolled two-dot mark had no nose or mouth) cycling five gestures — sway, pirouette, double blink, curious tilt, nod — with the official Google and GitHub marks on the provider buttons and a quiet, text-only Quit control.
- An unauthed launch greets once with the panel, then behaves like any panel. While signed out the strip beside the housing keeps the one signed-out Luke — the same element the gate draws at 56px, traveling to the wing spot on the caption's beat (`--spring`/`--duration-shape`, delayed by `--duration-exit`) — and a "Sign in" label in place of the session count, flush to the housing's edge and stood down to fit the capsule's side exactly as a wide count is. The session count and authed face never draw while signed out, so a zero that means "not looking yet" never poses as "nothing happening".
- Choosing a provider stands the panel down to a persistent waiting popup (the key slot's shape) with a Cancel button; cancel withdraws the loopback without rejecting the invoke, so nothing is logged as a handler error. The panel opens itself once the sign-in lands.
- The loopback callback pages and the hosted sign-in/consent pages dress as centered dark cards matching the landing page — full mark, status pill, title, quiet subline — with nothing from the redirect's query ever interpolated into the document.
- The settings Account section is renamed "Account", moves to just above Quit, wears the OAuth profile photo (host-pinned to `*.googleusercontent.com` / `avatars.githubusercontent.com`, mirrored in the renderer CSP) with a person-icon fallback, and Sign out turns red on hover and asks before acting, on the credential-delete confirm's own pattern.
- The account snapshot carries an optional `pictureUrl`, sign-in is cancellable end to end (`cancelSignIn` IPC, loopback `cancel()`), and the guide facts describe all of it so Luke does not misdescribe himself.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — pass (exit 0; sidecar-core, web, and desktop suites all green, desktop 890/890)
- macOS Electron verification (`./scripts/verify.sh`): fails in the desktop test stage on a pre-existing `realtime-session.test.ts` hang (80 cancellations on macOS/node 22.23.1) that reproduces identically on the unmodified branch tip; the packaging and evidence stages run clean, and all six deterministic fixture screenshots were byte-identical between the clean tree and this branch when compared during development

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32041482352/artifacts/9292045432) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32041482352)

- Commit: `60e67ca142ab9a0ba86abf14fb3c3f31057491b5`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- The signed-out surfaces (gate, waiting popup, capsule label, traveling face) are not covered by fixture captures, because fixture and evidence runs bypass auth by design — a physical pass over the gate morph via `./scripts/run.sh` is the remaining eyeball.
- The macOS `realtime-session.test.ts` hang predates this branch and deserves its own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)