### PR TITLE
feat(settings): offer per-group reset to defaults and mark changed rows

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -125,10 +125,12 @@ import {
   APP_SETTING_DEFAULTS,
   type AppBootstrap,
   channels,
+  isSettingsResetScope,
   type MicrophoneStatus,
   type OutputAudioState,
   SESSION_OPEN_RESULT_STATUS,
   SESSION_TRANSCRIPT_RESULT_STATUS,
+  SETTINGS_RESET_SCOPE,
   type SessionOpenResult,
   type SessionTranscriptResult,
 } from "./shared/contracts";
@@ -1178,6 +1180,58 @@ function registerIpc(): void {
     save: (enabled) => settingsStore.setDuckOtherMedia(enabled),
     apply: (result) => mediaDuck.setEnabled(result.settings.duckOtherMedia),
     refusal: "Could not save that setting on this system.",
+  });
+
+  // One group of preferences returned to its defaults in a single stored
+  // write. The renderer names a scope from the set fixed by this build —
+  // never a field list — and the store forgets the choices behind it, so
+  // what stands afterwards is the default itself rather than a copy of it.
+  // No scope reaches a credential or an account. The side effects each row's
+  // own save runs are re-run here from the stored answer, so a reset takes
+  // effect at once the way every other settings change does.
+  registerSettingHandler(channels.resetSettings, {
+    validate(scope: unknown) {
+      if (!isSettingsResetScope(scope)) throw new Error("Invalid settings reset request");
+      return scope;
+    },
+    save: (scope) => settingsStore.resetSettings(scope),
+    async apply(result, scope, event) {
+      if (result.reason) return;
+      switch (scope) {
+        case SETTINGS_RESET_SCOPE.VOICE:
+          // The next credential is minted for the default voice and pace; the
+          // renderer carries the change onto a conversation already open the
+          // same way it does for the rows' own saves.
+          realtimeCredentials?.setVoice(result.settings.voice);
+          realtimeCredentials?.setSpeed(result.settings.voiceSpeed);
+          mediaDuck.setEnabled(result.settings.duckOtherMedia);
+          break;
+        case SETTINGS_RESET_SCOPE.APPEARANCE:
+          applyMenuBarVisibility(result.settings.showInMenuBar);
+          dock.apply(result.settings.showInDock, panels.displayIdFor(event.sender));
+          panels.setShowOnAllDisplays(result.settings.showOnAllDisplays);
+          panels.reconcile();
+          panels.setFormFactor(result.settings.formFactor);
+          panels.positionAll();
+          break;
+        case SETTINGS_RESET_SCOPE.SHORTCUTS:
+          // All three keys back to their defaults, re-registered in rank
+          // order and awaited, so the renderer's controls stay at rest until
+          // the keys the rows are about to show have actually answered.
+          hotkeys.setChosen(HOTKEY_RANK.TALK, undefined);
+          hotkeys.setChosen(HOTKEY_RANK.ASK, undefined);
+          hotkeys.setChosen(HOTKEY_RANK.STOP, undefined);
+          await hotkeys.reapply(HOTKEY_RANK.TALK);
+          await hotkeys.reapply(HOTKEY_RANK.ASK);
+          await hotkeys.reapply(HOTKEY_RANK.STOP);
+          break;
+        case SETTINGS_RESET_SCOPE.WORKSPACES:
+          // Nothing to re-run: the workspace defaults only steer the next
+          // creation ask, which reads the store when it happens.
+          break;
+      }
+    },
+    refusal: "Could not reset those settings on this system.",
   });
 
   // A statement of state, not a request: the renderer says whether a spoken

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -37,6 +37,7 @@ const bridge: AppBridge = {
   setWorkspaceAgentDefault: invoke(channels.setWorkspaceAgentDefault),
   setWorkspaceProjectDefault: invoke(channels.setWorkspaceProjectDefault),
   setVoiceCaptions: invoke(channels.setVoiceCaptions),
+  resetSettings: invoke(channels.resetSettings),
   setVoiceHotkey: invoke(channels.setVoiceHotkey),
   setAskHotkey: invoke(channels.setAskHotkey),
   setStopHotkey: invoke(channels.setStopHotkey),

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -33,6 +33,7 @@ import type {
   DisplayDiagnostic,
   OutputAudioState,
   SessionOpenResult,
+  SettingsResetScope,
   SettingsUpdateResult,
 } from "../shared/contracts";
 import { CREDENTIAL_SOURCE, SESSION_OPEN_RESULT_STATUS } from "../shared/contracts";
@@ -686,6 +687,15 @@ export function App(): React.JSX.Element {
   const changeWorkspaceAgentDefault = useCallback(
     async (providerId: ProviderId, selection: WorkspaceAgentSelection | undefined) =>
       applySettingsReply(await window.sidecar.setWorkspaceAgentDefault(providerId, selection)),
+    [applySettingsReply],
+  );
+
+  // One group of settings back to its defaults — the same store forgetting
+  // each row's own clear performs, done as one write so a page's reset is one
+  // act rather than a race of four.
+  const changeSettingsReset = useCallback(
+    async (scope: SettingsResetScope) =>
+      applySettingsReply(await window.sidecar.resetSettings(scope)),
     [applySettingsReply],
   );
 
@@ -1831,6 +1841,7 @@ export function App(): React.JSX.Element {
     onDefaultWorkspaceProviderChange: changeDefaultWorkspaceProvider,
     onWorkspaceAgentDefaultChange: changeWorkspaceAgentDefault,
     onWorkspaceProjectDefaultChange: changeWorkspaceProjectDefault,
+    onSettingsReset: changeSettingsReset,
   };
   const shortcuts: ShortcutControl = {
     ...(shownHotkey.hotkey ? { voiceHotkey: shownHotkey.hotkey } : {}),

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -541,7 +541,12 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "Connections pages — each led back out by its back button or Escape — and keeps the " +
         "microphone permission, the Feedback section, and Quit on the front page itself; the " +
         "menu bar item's Settings… opens the same tab, and Command-comma switches to it while " +
-        "the panel has the keyboard. A " +
+        "the panel has the keyboard. A dot beside a settings row marks a value changed from " +
+        "its default, and a page holding one ends its head with a reset, pressed by hand and " +
+        "never spoken, that returns that page's settings to their defaults in one act — the " +
+        "Workspaces group on the Connections page carries its own reset on its heading, and " +
+        "no reset touches a key, an account, or the Conductor agent choice, whose own menu " +
+        "already offers Conductor's default. A " +
         "change Luke makes himself is shown as it is made: the panel comes forward on the tab, " +
         "and the page, the change belongs to, and his face leaves the strip beside the housing, " +
         "dives to the control that moved, and floats back.",

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -20,12 +20,15 @@ import type {
   AppSettings,
   CredentialSource,
   MicrophoneStatus,
+  SettingsResetScope,
 } from "../shared/contracts";
 import {
   ACCOUNT_PROVIDER,
   ACCOUNT_STATUS,
+  APP_SETTING_DEFAULTS,
   CREDENTIAL_SOURCE,
   SECRET_STORAGE,
+  SETTINGS_RESET_SCOPE,
 } from "../shared/contracts";
 import type { CredentialProvider } from "../shared/credential-providers";
 import {
@@ -186,6 +189,13 @@ export interface PreferenceWrites {
     providerId: ProviderId,
     providerProjectId: string | undefined,
   ) => Promise<string | undefined>;
+  /**
+   * Returns one group of settings to its defaults, in one stored write: the
+   * scope names a page, or the Workspaces group, from the set fixed by this
+   * build, and no scope reaches a credential. The store answers with why when
+   * it refuses, and the control that asked is where that answer belongs.
+   */
+  onSettingsReset: (scope: SettingsResetScope) => Promise<string | undefined>;
 }
 
 /**
@@ -686,6 +696,95 @@ function formFactorOptionLabel(formFactor: PanelFormFactor): string {
 }
 
 /**
+ * The small mark beside a row's name while its value differs from the
+ * default: what a page's reset would change, said row by row rather than
+ * only by the reset appearing. A statement, not a control — the row's own
+ * control is where the value moves — so it carries its meaning as words for
+ * a reader and a hover alike.
+ */
+function ChangedMark(): React.JSX.Element {
+  return (
+    <span className="settings-changed" title="Changed from its default">
+      <span className="visually-hidden">(changed from its default)</span>
+    </span>
+  );
+}
+
+/* Whether each group holds a value its reset would change, judged from the
+   same resolved settings the rows draw — so the mark, the reset, and the row
+   always agree on what is standing. The voice and pace compare against the
+   shipped defaults the way their menus label them; a launch-environment
+   override reads as changed, which is what the row shows too. */
+function voiceSettingsChanged(settings: AppSettings): boolean {
+  return (
+    settings.voice !== REALTIME_DEFAULTS.VOICE ||
+    settings.voiceSpeed !== REALTIME_DEFAULTS.SPEED ||
+    settings.voiceCaptions !== APP_SETTING_DEFAULTS.voiceCaptions ||
+    settings.duckOtherMedia !== APP_SETTING_DEFAULTS.duckOtherMedia
+  );
+}
+
+function appearanceSettingsChanged(settings: AppSettings): boolean {
+  return (
+    settings.showInMenuBar !== APP_SETTING_DEFAULTS.showInMenuBar ||
+    settings.showInDock !== APP_SETTING_DEFAULTS.showInDock ||
+    settings.showOnAllDisplays !== APP_SETTING_DEFAULTS.showOnAllDisplays ||
+    settings.formFactor !== DEFAULT_PANEL_FORM_FACTOR
+  );
+}
+
+/* The keys' terms are the rows' own: a chord is changed while one is stored,
+   whatever key the row is showing for it. */
+function shortcutSettingsChanged(shortcuts: ShortcutControl): boolean {
+  return shortcuts.voiceChosen || shortcuts.askChosen || shortcuts.stopChosen;
+}
+
+/* Only the choices the Workspaces group itself draws: the Conductor agent
+   pairing lives on the Conductor row, whose own menu already offers the
+   provider's default, so no reset here may reach it. */
+function workspaceSettingsChanged(settings: AppSettings): boolean {
+  return (
+    settings.defaultWorkspaceProvider !== undefined ||
+    Object.keys(settings.workspaceProjectDefaults ?? {}).length > 0
+  );
+}
+
+/**
+ * The one control that returns a whole group to its defaults, drawn only
+ * while the group holds something to return — until then it could only offer
+ * to change nothing, the same reason a shortcut's own reset waits for a
+ * chord. One press is one ask of the store; the control rests until the
+ * store answers, and a refusal is worded where the press was.
+ */
+function ResetGroupButton({
+  scope,
+  label,
+  onReset,
+}: {
+  scope: SettingsResetScope;
+  /** The group as the button names it aloud: "the Voice page's settings". */
+  label: string;
+  onReset: (scope: SettingsResetScope) => Promise<string | undefined>;
+}): React.JSX.Element {
+  const { busy, rejection, run } = useSettingWrite(onReset);
+  return (
+    <>
+      <button
+        type="button"
+        className="icon-button settings-reset"
+        disabled={busy}
+        aria-label={`Reset ${label} to the defaults`}
+        title="Back to the defaults"
+        onClick={() => run(scope)}
+      >
+        <ResetIcon />
+      </button>
+      {rejection ? <p className="error-message settings-reset-refusal">{rejection}</p> : null}
+    </>
+  );
+}
+
+/**
  * The round trip a settings control waits on. Each change is asked of the
  * store, the control rests until it answers rather than claiming a state it
  * may not get, and a refusal is kept here — under this control — rather than
@@ -728,6 +827,7 @@ function SwitchRow({
   checked,
   ariaLabel,
   errand,
+  changed,
   onChange,
 }: {
   label: string;
@@ -737,6 +837,8 @@ function SwitchRow({
   ariaLabel?: string;
   /** The id a spoken change names this switch by, so an errand lands on it. */
   errand?: ErrandTarget;
+  /** Whether the stored value differs from the default, which earns the mark. */
+  changed?: boolean;
   onChange: (enabled: boolean) => Promise<string | undefined>;
 }): React.JSX.Element {
   const { busy, rejection, run } = useSettingWrite(onChange);
@@ -744,7 +846,10 @@ function SwitchRow({
     <>
       <div className="settings-row">
         <span className="settings-copy">
-          <strong>{label}</strong>
+          <strong>
+            {label}
+            {changed ? <ChangedMark /> : null}
+          </strong>
           {detail ? <small>{detail}</small> : null}
         </span>
         <button
@@ -781,6 +886,7 @@ function SelectRow<Value extends string | number>({
   parse,
   ariaLabel,
   errand,
+  changed,
   busy: restBusy,
   onChange,
 }: {
@@ -797,6 +903,8 @@ function SelectRow<Value extends string | number>({
    * and only the `select` is drawn with the corners that outline has to take.
    */
   errand?: ErrandTarget;
+  /** Whether the stored value differs from the default, which earns the mark. */
+  changed?: boolean;
   /**
    * A sibling write in flight. Two pop-ups that store one setting share a
    * rest so one save cannot finish behind the other.
@@ -810,7 +918,10 @@ function SelectRow<Value extends string | number>({
     <>
       <div className="settings-row">
         <span className="settings-copy">
-          <strong>{label}</strong>
+          <strong>
+            {label}
+            {changed ? <ChangedMark /> : null}
+          </strong>
           {detail ? <small>{detail}</small> : null}
         </span>
         <span className="voice-select">
@@ -925,6 +1036,7 @@ function WorkspaceAgentRow({
           // out of the select is a broken control rather than a choice.
           return choices[Number(raw)] ? raw : undefined;
         }}
+        changed={selection !== undefined}
         busy={write.busy}
         onChange={(next) => {
           if (next === PROVIDER_DEFAULT_VALUE) {
@@ -967,6 +1079,7 @@ function WorkspaceAgentRow({
             // stored selection is always one whole the table lists.
             return chosen.efforts.includes(raw) ? raw : undefined;
           }}
+          changed={selection?.effort !== undefined}
           busy={write.busy}
           onChange={(next) => {
             const effort = next !== PROVIDER_DEFAULT_VALUE ? next : undefined;
@@ -1152,16 +1265,21 @@ function SettingsNavRow({
 /**
  * A page's head: the way back beside the page's own name. The back button
  * returns to the front page and nothing else — a page holds no unsaved state
- * of its own, so leaving one never needs a warning.
+ * of its own, so leaving one never needs a warning. A page whose settings can
+ * be returned to their defaults ends the line with that reset, drawn only
+ * while something on the page differs from them.
  */
 function SettingsPageHeader({
   view,
   onBack,
   backControl,
+  reset,
 }: {
   view: SettingsSubview;
   onBack: () => void;
   backControl: React.RefObject<HTMLButtonElement | null>;
+  /** The page's reset control, absent while the page stands at its defaults. */
+  reset?: React.JSX.Element;
 }): React.JSX.Element {
   return (
     <div className="settings-header" style={{ "--row-index": 0 } as React.CSSProperties}>
@@ -1176,6 +1294,7 @@ function SettingsPageHeader({
         <BackIcon />
       </button>
       <strong>{SETTINGS_PAGE[view].title}</strong>
+      {reset}
     </div>
   );
 }
@@ -1257,6 +1376,7 @@ function VoiceControlsSection({
       <SelectRow
         label="Voice"
         errand={APP_SETTING_ID.VOICE}
+        changed={settings.voice !== REALTIME_DEFAULTS.VOICE}
         value={settings.voice}
         options={REALTIME_VOICE_LIST.map((candidate) => ({
           value: candidate,
@@ -1272,6 +1392,7 @@ function VoiceControlsSection({
       <SelectRow
         label="Speed"
         errand={APP_SETTING_ID.VOICE_SPEED}
+        changed={settings.voiceSpeed !== REALTIME_DEFAULTS.SPEED}
         value={settings.voiceSpeed}
         options={REALTIME_VOICE_SPEED_LIST.map((candidate) => ({
           value: candidate,
@@ -1289,6 +1410,7 @@ function VoiceControlsSection({
         label="Captions"
         ariaLabel="Caption Luke's speech on screen"
         errand={APP_SETTING_ID.VOICE_CAPTIONS}
+        changed={settings.voiceCaptions !== APP_SETTING_DEFAULTS.voiceCaptions}
         checked={settings.voiceCaptions}
         onChange={preferences.onVoiceCaptionsChange}
       />
@@ -1303,6 +1425,7 @@ function VoiceControlsSection({
              when macOS asks whether Luke may speak to each player at all. */
           "Their volume dips while you and Luke are talking, and returns after."
         }
+        changed={settings.duckOtherMedia !== APP_SETTING_DEFAULTS.duckOtherMedia}
         checked={settings.duckOtherMedia}
         onChange={preferences.onDuckOtherMediaChange}
       />
@@ -1332,24 +1455,28 @@ function AppearanceSection({
       <SwitchRow
         label="Show Luke in the menu bar"
         errand={APP_SETTING_ID.SHOW_IN_MENU_BAR}
+        changed={settings.showInMenuBar !== APP_SETTING_DEFAULTS.showInMenuBar}
         checked={settings.showInMenuBar}
         onChange={preferences.onShowInMenuBarChange}
       />
       <SwitchRow
         label="Show Luke in the Dock"
         errand={APP_SETTING_ID.SHOW_IN_DOCK}
+        changed={settings.showInDock !== APP_SETTING_DEFAULTS.showInDock}
         checked={settings.showInDock}
         onChange={preferences.onShowInDockChange}
       />
       <SwitchRow
         label="Show Luke on all displays"
         errand={APP_SETTING_ID.SHOW_ON_ALL_DISPLAYS}
+        changed={settings.showOnAllDisplays !== APP_SETTING_DEFAULTS.showOnAllDisplays}
         checked={settings.showOnAllDisplays}
         onChange={preferences.onShowOnAllDisplaysChange}
       />
       <SelectRow
         label="Form factor"
         errand={APP_SETTING_ID.FORM_FACTOR}
+        changed={settings.formFactor !== DEFAULT_PANEL_FORM_FACTOR}
         detail={
           /* Where the choice applies, because on a notched display this row
              visibly does nothing: the real housing always wins. */
@@ -1387,10 +1514,22 @@ function WorkspacesSection({
 }): React.JSX.Element {
   return (
     <section className="settings-section" style={{ "--row-index": 3 } as React.CSSProperties}>
-      <h2>
-        <FolderIcon />
-        Workspaces
-      </h2>
+      {/* The heading and the group's reset share a line: the reset stands
+          over exactly the rows below it, and nothing else on the Connections
+          page — the keys above are not settings and are never reset. */}
+      <div className="settings-heading">
+        <h2>
+          <FolderIcon />
+          Workspaces
+        </h2>
+        {workspaceSettingsChanged(settings) ? (
+          <ResetGroupButton
+            scope={SETTINGS_RESET_SCOPE.WORKSPACES}
+            label="the workspace defaults"
+            onReset={preferences.onSettingsReset}
+          />
+        ) : null}
+      </div>
       <SelectRow
         label="Default workspace provider"
         detail={
@@ -1400,6 +1539,7 @@ function WorkspacesSection({
              that choice is seen, changed, or returned to asking. */
           "Where an ask that names no provider creates a workspace. Your first creation sets it."
         }
+        changed={settings.defaultWorkspaceProvider !== undefined}
         value={settings.defaultWorkspaceProvider ?? ASK_EACH_TIME}
         options={[
           { value: ASK_EACH_TIME, label: "Ask each time" },
@@ -1457,6 +1597,7 @@ function WorkspaceProjectRow({
       label={`Default ${provider.name} project`}
       ariaLabel={`The project a nameless ask creates ${provider.name} workspaces in`}
       detail="Where an ask that names no project creates a workspace. Your first creation there sets it."
+      changed={stored !== undefined}
       value={stored ?? FIRST_CREATION_SETS_IT}
       options={[
         { value: FIRST_CREATION_SETS_IT, label: "First creation sets it" },
@@ -1548,7 +1689,12 @@ function ShortcutRow({
   return (
     <div className="settings-row">
       <span className="settings-copy">
-        <strong>{title}</strong>
+        <strong>
+          {title}
+          {/* A stored chord is a changed value on the other rows' terms; the
+              flag that shows Reset is the flag that earns the mark. */}
+          {chosen ? <ChangedMark /> : null}
+        </strong>
         <small>{detail}</small>
       </span>
       <span className="shortcut-controls">
@@ -1722,6 +1868,49 @@ function AccountSection({
   );
 }
 
+/**
+ * The reset a page's header carries, absent while everything the page draws
+ * stands at its defaults. Voice, Appearance, and Keyboard shortcuts each
+ * offer their own; Connections offers none — the page holds keys and rows
+ * that are not settings, and its one resettable group, Workspaces, carries
+ * its own control on its own heading instead.
+ */
+function pageResetControl(
+  view: SettingsView,
+  settings: AppSettings | undefined,
+  shortcuts: ShortcutControl,
+  preferences: PreferenceWrites,
+): React.JSX.Element | undefined {
+  if (view === SETTINGS_VIEW.VOICE && settings && voiceSettingsChanged(settings)) {
+    return (
+      <ResetGroupButton
+        scope={SETTINGS_RESET_SCOPE.VOICE}
+        label="the Voice settings"
+        onReset={preferences.onSettingsReset}
+      />
+    );
+  }
+  if (view === SETTINGS_VIEW.APPEARANCE && settings && appearanceSettingsChanged(settings)) {
+    return (
+      <ResetGroupButton
+        scope={SETTINGS_RESET_SCOPE.APPEARANCE}
+        label="the Appearance settings"
+        onReset={preferences.onSettingsReset}
+      />
+    );
+  }
+  if (view === SETTINGS_VIEW.SHORTCUTS && shortcutSettingsChanged(shortcuts)) {
+    return (
+      <ResetGroupButton
+        scope={SETTINGS_RESET_SCOPE.SHORTCUTS}
+        label="the keyboard shortcuts"
+        onReset={preferences.onSettingsReset}
+      />
+    );
+  }
+  return undefined;
+}
+
 export function SettingsPanel({
   account,
   onSignOut,
@@ -1782,6 +1971,8 @@ export function SettingsPanel({
     }
     backControl.current?.focus();
   }, [drawnView, panelOpen]);
+  // The drawn page's reset, absent while that page stands at its defaults.
+  const pageReset = pageResetControl(drawnView, settings, shortcuts, preferences);
   return (
     <div
       ref={box}
@@ -1797,6 +1988,7 @@ export function SettingsPanel({
           view={drawnView}
           onBack={() => onViewChange(SETTINGS_VIEW.ROOT)}
           backControl={backControl}
+          {...(pageReset ? { reset: pageReset } : {})}
         />
       ) : null}
 

--- a/apps/desktop/src/renderer/styles/settings.css
+++ b/apps/desktop/src/renderer/styles/settings.css
@@ -94,10 +94,12 @@
 }
 
 /* A page's head: the way back beside the page's own name, above the sections
-   it holds. */
+   it holds. It wraps so the reset's refusal, when there is one, lands on a
+   line of its own under the controls rather than crowding the title. */
 .settings-header {
   display: flex;
   flex: 0 0 auto;
+  flex-wrap: wrap;
   align-items: center;
   gap: 9px;
   padding: 0 2px;
@@ -107,6 +109,35 @@
   color: var(--text-primary);
   font-size: 12.5px;
   font-weight: 700;
+}
+
+/* The control that returns a group to its defaults rides the right edge,
+   wherever the group's name stands — a page's head or a section's heading. */
+.settings-reset {
+  margin-left: auto;
+}
+
+/* A group heading that carries the group's reset: the words keep their line
+   and the control keeps the right edge the page head's reset keeps. The
+   button is pulled toward the heading's own height with negative margins so
+   the heading keeps the section's rhythm rather than growing a row of its
+   own around one control. */
+.settings-heading {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.settings-heading .settings-reset {
+  width: 22px;
+  height: 22px;
+  margin-top: -5px;
+  margin-bottom: -5px;
+}
+
+/* A reset's refusal takes the wrap's next line whole. */
+.settings-reset-refusal {
+  flex-basis: 100%;
 }
 
 /* The front page's list of pages. The rows sit at a menu's spacing rather
@@ -236,6 +267,20 @@
   color: var(--text-primary);
   font-size: 12px;
   font-weight: 620;
+}
+
+/* The mark a row wears while its value differs from the default: a small dot
+   riding the name's line, said in words for a reader by the hidden text
+   inside it. The secondary text colour rather than a state colour on
+   purpose — changed is a fact about a preference, never an urgency. */
+.settings-changed {
+  display: inline-block;
+  width: 4px;
+  height: 4px;
+  margin-left: 6px;
+  border-radius: 50%;
+  background: var(--text-secondary);
+  vertical-align: 2px;
 }
 
 .settings-copy small,

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -24,7 +24,9 @@ import {
   CREDENTIAL_SOURCE,
   type CredentialSource,
   SECRET_STORAGE,
+  SETTINGS_RESET_SCOPE,
   type SecretStorage,
+  type SettingsResetScope,
   type SettingsUpdateResult,
 } from "./shared/contracts";
 import {
@@ -974,6 +976,50 @@ export class SettingsStore {
     return this.#setField((persisted) => {
       if (persisted.showInDock === show) return;
       return { ...persisted, showInDock: show };
+    });
+  }
+
+  /**
+   * Returns one group of preferences to its defaults in a single write, by
+   * forgetting the choices rather than storing copies of the defaults: an
+   * optional field is deleted the way its own clear deletes it, and a plain
+   * boolean goes back to the value `APP_SETTING_DEFAULTS` states — so a
+   * default that moves in a later build moves these settings with it. The
+   * scopes are fixed by this build and none reaches a credential, an account,
+   * or the agent pairing, whose own row already offers the provider's default.
+   * A scope already at its defaults writes nothing, like any other setter
+   * asked for the value it holds.
+   */
+  async resetSettings(scope: SettingsResetScope): Promise<SettingsUpdateResult> {
+    return this.#setField((persisted) => {
+      const next: PersistedSettings = { ...persisted };
+      switch (scope) {
+        case SETTINGS_RESET_SCOPE.VOICE:
+          delete next.voice;
+          delete next.voiceSpeed;
+          next.voiceCaptions = APP_SETTING_DEFAULTS.voiceCaptions;
+          next.duckOtherMedia = APP_SETTING_DEFAULTS.duckOtherMedia;
+          break;
+        case SETTINGS_RESET_SCOPE.APPEARANCE:
+          next.showInMenuBar = APP_SETTING_DEFAULTS.showInMenuBar;
+          next.showInDock = APP_SETTING_DEFAULTS.showInDock;
+          next.showOnAllDisplays = APP_SETTING_DEFAULTS.showOnAllDisplays;
+          delete next.formFactor;
+          break;
+        case SETTINGS_RESET_SCOPE.SHORTCUTS:
+          delete next.voiceHotkey;
+          delete next.askHotkey;
+          delete next.stopHotkey;
+          break;
+        case SETTINGS_RESET_SCOPE.WORKSPACES:
+          delete next.defaultWorkspaceProvider;
+          delete next.workspaceProjectDefaults;
+          break;
+      }
+      const changed = (Object.keys(persisted) as (keyof PersistedSettings)[]).some(
+        (field) => next[field] !== persisted[field],
+      );
+      return changed ? next : undefined;
     });
   }
 

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -94,6 +94,30 @@ export const APP_SETTING_DEFAULTS = {
   showOnAllDisplays: false,
 } as const satisfies Partial<Record<keyof AppSettings, boolean>>;
 
+/**
+ * The groups of preferences a reset control returns to their defaults, each
+ * scoped to exactly the rows the control stands over: a settings page, or the
+ * Workspaces group on the Connections page. A fixed vocabulary rather than a
+ * field list on the wire, so a renderer can only ever name a grouping this
+ * build documents — and no scope reaches a credential, an account, or the
+ * Conductor agent pairing, whose own row already offers its default.
+ */
+export const SETTINGS_RESET_SCOPE = {
+  VOICE: "voice",
+  APPEARANCE: "appearance",
+  SHORTCUTS: "shortcuts",
+  WORKSPACES: "workspaces",
+} as const;
+
+export type SettingsResetScope = (typeof SETTINGS_RESET_SCOPE)[keyof typeof SETTINGS_RESET_SCOPE];
+
+const SETTINGS_RESET_SCOPE_LIST: readonly SettingsResetScope[] =
+  Object.values(SETTINGS_RESET_SCOPE);
+
+export function isSettingsResetScope(value: unknown): value is SettingsResetScope {
+  return SETTINGS_RESET_SCOPE_LIST.includes(value as SettingsResetScope);
+}
+
 /** Renderer-safe settings. Credentials are never sent to a renderer. */
 export interface AppSettings {
   /** Where each provider's key comes from, keyed by provider id. */
@@ -424,6 +448,14 @@ export interface AppBridge {
   ): Promise<SettingsUpdateResult>;
   /** Turns the on-screen caption of Luke's speech on or off. */
   setVoiceCaptions(enabled: boolean): Promise<SettingsUpdateResult>;
+  /**
+   * Returns one group of preferences to its defaults in a single stored write:
+   * the choices behind the named scope are forgotten, the way each row's own
+   * clear forgets one, so what stands afterwards is the default itself rather
+   * than a copy of it pinned down. The renderer names a scope from the set
+   * fixed by this build, never a field list, and no scope reaches a credential.
+   */
+  resetSettings(scope: SettingsResetScope): Promise<SettingsUpdateResult>;
   /** Turns the quieting of Music and Spotify during a spoken exchange on or off. */
   setDuckOtherMedia(enabled: boolean): Promise<SettingsUpdateResult>;
   /**
@@ -650,6 +682,7 @@ export const channels = {
   setDefaultWorkspaceProvider: "app:set-default-workspace-provider",
   setWorkspaceAgentDefault: "app:set-workspace-agent-default",
   setWorkspaceProjectDefault: "app:set-workspace-project-default",
+  resetSettings: "app:reset-settings",
   openSession: "app:open-session",
   openSessionChange: "app:open-session-change",
   readSessionTranscript: "app:read-session-transcript",

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -11,7 +11,12 @@ import {
   REALTIME_VOICE_SPEED,
 } from "@sidecar/core";
 import { type SecretCipher, SettingsStore } from "../src/settings-store";
-import { ACCOUNT_STATUS, CREDENTIAL_SOURCE, SECRET_STORAGE } from "../src/shared/contracts";
+import {
+  ACCOUNT_STATUS,
+  CREDENTIAL_SOURCE,
+  SECRET_STORAGE,
+  SETTINGS_RESET_SCOPE,
+} from "../src/shared/contracts";
 import {
   CREDENTIAL_PROVIDER_ID,
   type CredentialProvider,
@@ -1312,5 +1317,152 @@ test("recovers from a corrupt settings file", async (t) => {
   const { settings } = await store.setApiKey(CONDUCTOR, TEST_API_KEY);
 
   assert.equal(settings.credentialSources[CONDUCTOR], CREDENTIAL_SOURCE.ENCRYPTED_FILE);
+  assert.equal(await store.readApiKey(CONDUCTOR), TEST_API_KEY);
+});
+
+test("a voice reset forgets the voice, pace, captions, and duck in one act", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+  await store.setVoice(REALTIME_VOICE.MARIN);
+  await store.setVoiceSpeed(REALTIME_VOICE_SPEED.QUICK);
+  await store.setVoiceCaptions(true);
+  await store.setDuckOtherMedia(false);
+
+  const { settings, reason } = await store.resetSettings(SETTINGS_RESET_SCOPE.VOICE);
+
+  assert.equal(reason, undefined);
+  assert.equal(settings.voice, REALTIME_DEFAULTS.VOICE);
+  assert.equal(settings.voiceSpeed, REALTIME_DEFAULTS.SPEED);
+  assert.equal(settings.voiceCaptions, false);
+  assert.equal(settings.duckOtherMedia, true);
+  // The choices are forgotten rather than restated, so a default that moves
+  // in a later build moves these settings with it.
+  assert.equal(await storeIn(directory).readVoice(), undefined);
+  assert.equal(await storeIn(directory).readVoiceSpeed(), undefined);
+});
+
+test("a voice reset returns to the environment's voice where one stands behind the choice", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory, {
+    environment: { LUKE_REALTIME_VOICE: REALTIME_VOICE.SAGE },
+  });
+  await store.setVoice(REALTIME_VOICE.MARIN);
+
+  const { settings } = await store.resetSettings(SETTINGS_RESET_SCOPE.VOICE);
+
+  // Forgetting the choice is the reset's whole meaning: what stands afterwards
+  // is whatever would have stood had none been made.
+  assert.equal(settings.voice, REALTIME_VOICE.SAGE);
+  assert.equal(await store.readVoice(), undefined);
+});
+
+test("an appearance reset returns Luke's stances without touching the voice page", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+  await store.setShowInMenuBar(false);
+  await store.setShowInDock(true);
+  await store.setShowOnAllDisplays(true);
+  await store.setFormFactor(PANEL_FORM_FACTOR.NOTCH);
+  await store.setVoice(REALTIME_VOICE.MARIN);
+
+  const { settings, reason } = await store.resetSettings(SETTINGS_RESET_SCOPE.APPEARANCE);
+
+  assert.equal(reason, undefined);
+  assert.equal(settings.showInMenuBar, true);
+  assert.equal(settings.showInDock, false);
+  assert.equal(settings.showOnAllDisplays, false);
+  assert.equal(settings.formFactor, PANEL_FORM_FACTOR.BUBBLE);
+  assert.equal(await storeIn(directory).readFormFactor(), undefined);
+  // One scope's reset is that scope's alone.
+  assert.equal(settings.voice, REALTIME_VOICE.MARIN);
+});
+
+test("a shortcuts reset forgets all three chords at once", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+  await store.setVoiceHotkey("Shift+Command+L");
+  await store.setAskHotkey("Control+Alt+K");
+  await store.setStopHotkey("Control+Alt+X");
+
+  const { settings, reason } = await store.resetSettings(SETTINGS_RESET_SCOPE.SHORTCUTS);
+
+  assert.equal(reason, undefined);
+  assert.equal(settings.voiceHotkey, undefined);
+  assert.equal(settings.askHotkey, undefined);
+  assert.equal(settings.stopHotkey, undefined);
+  assert.equal(await storeIn(directory).readVoiceHotkey(), undefined);
+  assert.equal(await storeIn(directory).readAskHotkey(), undefined);
+  assert.equal(await storeIn(directory).readStopHotkey(), undefined);
+});
+
+test("a workspaces reset forgets the provider and project defaults but never the agent pairing", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+  const pairing = { agent: "claude", model: "sonnet" };
+  await store.setDefaultWorkspaceProvider(PROVIDER_ID.CONDUCTOR);
+  await store.setWorkspaceProjectDefault(PROVIDER_ID.CONDUCTOR, "proj-1");
+  await store.setWorkspaceAgentDefault(PROVIDER_ID.CONDUCTOR, pairing);
+
+  const { settings, reason } = await store.resetSettings(SETTINGS_RESET_SCOPE.WORKSPACES);
+
+  assert.equal(reason, undefined);
+  assert.equal(settings.defaultWorkspaceProvider, undefined);
+  assert.equal(settings.workspaceProjectDefaults, undefined);
+  // The pairing lives on the Conductor row, whose own menu already offers the
+  // provider's default — no reset here may reach it.
+  assert.deepEqual(settings.workspaceAgentDefaults, { [PROVIDER_ID.CONDUCTOR]: pairing });
+});
+
+test("a reset of settings already at their defaults writes nothing", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+
+  const { settings, reason } = await store.resetSettings(SETTINGS_RESET_SCOPE.VOICE);
+
+  assert.equal(reason, undefined);
+  assert.equal(settings.voice, REALTIME_DEFAULTS.VOICE);
+  // Nothing changed, so no file was created — the same silence every setter
+  // keeps when asked for the value it already holds.
+  await assert.rejects(readSettingsFile(directory));
+});
+
+test("a reset never touches the cipher", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const cipher = countingCipher();
+  const store = storeIn(directory, { cipher });
+  await store.setVoiceCaptions(true);
+
+  await store.resetSettings(SETTINGS_RESET_SCOPE.VOICE);
+
+  // A preference is not a credential, so resetting a page of them never
+  // reaches the Keychain — and never raises its permission dialog.
+  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
+});
+
+test("a reset leaves a stored key standing", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({
+      version: 2,
+      apiKeys: { [CONDUCTOR]: sealed(TEST_API_KEY) },
+      voiceCaptions: true,
+      duckOtherMedia: true,
+      showInDock: false,
+      showInMenuBar: true,
+      showOnAllDisplays: false,
+    }),
+  );
+  const store = storeIn(directory);
+
+  await store.resetSettings(SETTINGS_RESET_SCOPE.VOICE);
+
+  // No scope reaches a credential: the ciphertext rides the write untouched.
+  const contents = JSON.parse(await readSettingsFile(directory)) as {
+    apiKeys: Record<string, string>;
+    voiceCaptions: boolean;
+  };
+  assert.deepEqual(contents.apiKeys, { [CONDUCTOR]: sealed(TEST_API_KEY) });
+  assert.equal(contents.voiceCaptions, false);
   assert.equal(await store.readApiKey(CONDUCTOR), TEST_API_KEY);
 });


### PR DESCRIPTION
## Summary

Users had no way back to the defaults short of remembering each one: only the three shortcut rows offered a reset, and nothing said which values had drifted at all. This adds both halves:

- **A dot beside a changed row's name.** Every preference row — switches, pop-ups, the shortcut chords, and the workspace-default rows — wears a small `--text-secondary` dot while its value differs from the default, with the meaning carried in hidden text and a hover title. The dot is judged from the same resolved settings the rows draw, so the mark, the reset, and the row always agree.
- **A reset per group, drawn only while it would change something.** Voice, Appearance, and Keyboard shortcuts each end their page head with a reset icon-button (the same vocabulary as the shortcut rows' existing per-row reset); the Workspaces group on the Connections page carries its own on its heading. The Connections page itself gets none on purpose — it holds keys and accounts, which are not settings and are never reset.
- **One channel, one write.** `app:reset-settings` takes a scope from `SETTINGS_RESET_SCOPE` — a build-fixed vocabulary, never a field list — validated in the main process; `SettingsStore.resetSettings` forgets the choices behind the scope in a single atomic write, so the reset stores absence rather than a copy of the defaults (a default that moves in a later build moves these settings with it, and an environment override stands back in where one exists). A scope already at its defaults writes nothing. The side effects each row's own save runs — menu bar, Dock, displays, form factor, hotkey re-registration, the media duck, the voice minter — are re-run from the stored answer.
- **Boundaries kept:** no scope reaches a credential, an account, or the Conductor agent pairing (its own menu already offers "Conductor's default", and it now wears the dot while chosen). The reset is by-hand only — it is not a spoken tool — and the guide's panel fact teaches the dots, the resets, and that refusal, in the same change.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passes — repository contracts, lint (same warning count as main), typecheck, all test suites, and both builds. Eight new `settings-store` tests cover each scope, the no-op write, the environment-override return, cipher silence, and a stored key riding a reset untouched.
- macOS Electron verification (`./scripts/verify.sh`): `not run` (authored in a Linux cloud workspace). The built app was run headless under Xvfb against the smoke fixture and driven over CDP: dots drew on exactly the changed rows of the Voice, Appearance, Shortcuts, and Workspaces groups; each page head grew its reset only while something differed; pressing the Voice reset cleared all four rows and the control itself in one round trip; the Workspaces heading reset returned the provider row to "Ask each time" and left the Conductor agent pairing standing; the Connections head stayed bare.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32042526432/artifacts/9292251303) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32042526432)

- Commit: `424010ede1cb9efcc630e33382e9364cb5c61b0a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: the capture scenarios don't visit the settings pages, so the header reset and dots deserve one eyeball on a real Mac; the Linux CDP pass above covered layout and behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/26fe838a-ac12-4df5-8eb8-b39a995e8b86)
