### PR TITLE
feat(desktop): sign a fresh feedback note from the signed-in account

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -66,6 +66,7 @@ import {
   supersedeErrandSettings,
 } from "./errand-queue";
 import {
+  accountSignature,
   type FeedbackEntry,
   type FeedbackEntryControl,
   IMAGE_REFUSAL,
@@ -220,7 +221,10 @@ function useShapeHeight(): [(element: HTMLElement | null) => void, number | unde
 
 export function App(): React.JSX.Element {
   const [bootstrap, setBootstrap] = useState<AppBootstrap>();
-  const [account, setAccount] = useState<AccountSnapshot>();
+  // Readable from a callback as well as rendered: opening the feedback
+  // composer signs a fresh note from the account without re-wiring the
+  // lifecycle subscription to every sign-in change.
+  const [account, setAccount, accountNow] = useStateWithRef<AccountSnapshot | undefined>(undefined);
   const [sessions, setSessions] = useState<readonly NormalizedSession[]>([]);
   const [noticeAsks, setNoticeAsks] = useState<readonly SessionNoticeAsk[]>([]);
   const [workspaceProjects, setWorkspaceProjects] = useState<readonly ObservedWorkspaceProject[]>(
@@ -897,12 +901,15 @@ export function App(): React.JSX.Element {
         kind,
         fromPanel,
         ...(draft !== undefined ? { draft } : {}),
+        // A fresh note starts signed with the account; a note already there
+        // keeps its fields as its author left them, cleared ones included.
+        signature: accountSignature(accountNow()),
       });
       if (opened.entry) feedbackEntry.apply(opened.entry);
       feedbackEntry.standDown();
       return opened.drafted;
     },
-    [feedbackEntry.apply, feedbackEntry.latest, feedbackEntry.standDown],
+    [accountNow, feedbackEntry.apply, feedbackEntry.latest, feedbackEntry.standDown],
   );
 
   /**
@@ -1261,6 +1268,7 @@ export function App(): React.JSX.Element {
             kind,
             fromPanel: false,
             ...(action.draft === undefined ? {} : { draft: action.draft }),
+            signature: accountSignature(accountNow()),
           }).drafted;
           spokenFeedbackDraft.current = action.draft;
           try {
@@ -1334,6 +1342,7 @@ export function App(): React.JSX.Element {
         },
       }),
     [
+      accountNow,
       armErrandFlight,
       changeMode,
       settingsNow,

--- a/apps/desktop/src/renderer/feedback-entry.ts
+++ b/apps/desktop/src/renderer/feedback-entry.ts
@@ -1,3 +1,4 @@
+import { ACCOUNT_STATUS, type AccountSnapshot } from "../shared/contracts";
 import type { FeedbackImage, FeedbackKind } from "../shared/feedback";
 import { FEEDBACK_KIND, FEEDBACK_LIMITS } from "../shared/feedback";
 
@@ -14,7 +15,11 @@ export interface FeedbackEntry {
   kind: FeedbackKind;
   /** What has been written so far. Empty until it has been. */
   message: string;
-  /** Optional credit, kept as typed; empty means unsigned. */
+  /**
+   * Optional credit. A fresh note starts signed with the account the user is
+   * signed in as; both fields stay theirs to edit or clear, and empty means
+   * unsigned. Kept as edited for the life of the note.
+   */
   name: string;
   email: string;
   images: readonly FeedbackImage[];
@@ -56,8 +61,39 @@ export interface FeedbackEntryControl {
   commit(): void;
 }
 
-export function freshFeedbackEntry(kind: FeedbackKind, fromPanel: boolean): FeedbackEntry {
-  return { kind, message: "", name: "", email: "", images: [], busy: false, fromPanel };
+/**
+ * The credit a fresh note starts with: the signed-in account's own name and
+ * address. It lands in the composer's visible fields rather than riding a
+ * send, so what a submission carries is always exactly what its fields
+ * showed — prefilled, but the user's to edit or clear before anything leaves.
+ */
+export interface FeedbackSignature {
+  name?: string;
+  email?: string;
+}
+
+/** What the account offers a fresh note as its signature: nothing, signed out. */
+export function accountSignature(
+  account: AccountSnapshot | undefined,
+): FeedbackSignature | undefined {
+  if (account?.status !== ACCOUNT_STATUS.SIGNED_IN) return undefined;
+  return { ...(account.name ? { name: account.name } : {}), email: account.email };
+}
+
+export function freshFeedbackEntry(
+  kind: FeedbackKind,
+  fromPanel: boolean,
+  signature?: FeedbackSignature,
+): FeedbackEntry {
+  return {
+    kind,
+    message: "",
+    name: signature?.name ?? "",
+    email: signature?.email ?? "",
+    images: [],
+    busy: false,
+    fromPanel,
+  };
 }
 
 /**
@@ -65,12 +101,16 @@ export function freshFeedbackEntry(kind: FeedbackKind, fromPanel: boolean): Feed
  * section's buttons, the tray, or a spoken ask carried through the same path.
  * `draft` is starting text for the note, and it is only ever the user's own
  * words: the section and the tray never send one, and the spoken tool's
- * contract forbids anything the user did not say.
+ * contract forbids anything the user did not say. `signature` is the
+ * signed-in account's credit, and it seeds only a note that does not exist
+ * yet: a note already there keeps its fields exactly as its author left
+ * them, cleared ones included.
  */
 export interface FeedbackOpenAsk {
   kind: FeedbackKind;
   fromPanel: boolean;
   draft?: string;
+  signature?: FeedbackSignature;
 }
 
 /**
@@ -91,7 +131,7 @@ export function openedFeedbackEntry(
   if (current?.busy) return { drafted: false };
   const blank = (current?.message ?? "").trim().length === 0;
   const drafted = ask.draft !== undefined && blank;
-  const base = current ?? freshFeedbackEntry(ask.kind, ask.fromPanel);
+  const base = current ?? freshFeedbackEntry(ask.kind, ask.fromPanel, ask.signature);
   return {
     entry: {
       ...base,

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -560,7 +560,8 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "Feedback… and Submit a Prompt… — opens a composer under the notch. Send feedback is for " +
         "bugs and ideas; Submit a prompt sends a prompt to a coding agent, and one the founders " +
         "like ships in the next release. Either goes by email to the founders with an optional " +
-        "name and email for credit and up to three screenshots. A spoken ask can open the " +
+        "name and email for credit — a fresh note starts them from the signed-in account, and " +
+        "both stay free to edit or clear before sending — and up to three screenshots. A spoken ask can open the " +
         "composer and start it with the developer's own words — Luke offers exactly that, once, " +
         "after refusing something he cannot do — but a note already being written is never " +
         "overwritten, and sending is always the Send button's own press, by hand: no spoken ask " +

--- a/apps/desktop/src/shared/feedback.ts
+++ b/apps/desktop/src/shared/feedback.ts
@@ -4,7 +4,9 @@
  * Luke should have handled better. Both travel the same way — typed in the
  * panel, carried by the main process to one fixed endpoint, and forwarded from
  * there as email to the founders. Nothing observed ever rides along: a
- * submission holds only what the user typed and the screenshots they chose.
+ * submission holds only what the composer's fields showed the user — their
+ * words, the signature those fields started with from their own signed-in
+ * account and left theirs to edit or clear, and the screenshots they chose.
  */
 export const FEEDBACK_KIND = {
   FEEDBACK: "feedback",

--- a/apps/desktop/tests/feedback-entry.test.ts
+++ b/apps/desktop/tests/feedback-entry.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  accountSignature,
   type FeedbackEntry,
   feedbackImageUrl,
   freshFeedbackEntry,
@@ -8,6 +9,7 @@ import {
   openedFeedbackEntry,
 } from "../src/renderer/feedback-entry";
 import { IMAGE_INTAKE, imageIntake, recodedImageName } from "../src/renderer/feedback-images";
+import { ACCOUNT_PROVIDER, ACCOUNT_STATUS } from "../src/shared/contracts";
 import { FEEDBACK_KIND, FEEDBACK_LIMITS } from "../src/shared/feedback";
 
 function entry(overrides: Partial<FeedbackEntry> = {}): FeedbackEntry {
@@ -84,6 +86,58 @@ test("a note mid-send is not touched by an open", () => {
 
   assert.equal(opened.drafted, false);
   assert.equal(opened.entry, undefined);
+});
+
+test("a signed-in account signs a fresh note; signed out, it starts unsigned", () => {
+  const signature = accountSignature({
+    status: ACCOUNT_STATUS.SIGNED_IN,
+    email: "ada@example.com",
+    name: "Ada",
+    provider: ACCOUNT_PROVIDER.GITHUB,
+  });
+  assert.deepEqual(signature, { name: "Ada", email: "ada@example.com" });
+  assert.deepEqual(freshFeedbackEntry(FEEDBACK_KIND.FEEDBACK, true, signature), {
+    ...freshFeedbackEntry(FEEDBACK_KIND.FEEDBACK, true),
+    name: "Ada",
+    email: "ada@example.com",
+  });
+
+  // An account without a name still signs with its address.
+  assert.deepEqual(
+    accountSignature({
+      status: ACCOUNT_STATUS.SIGNED_IN,
+      email: "ada@example.com",
+      provider: ACCOUNT_PROVIDER.GOOGLE,
+    }),
+    { email: "ada@example.com" },
+  );
+
+  assert.equal(accountSignature(undefined), undefined);
+  assert.equal(accountSignature({ status: ACCOUNT_STATUS.SIGNED_OUT }), undefined);
+  assert.equal(accountSignature({ status: ACCOUNT_STATUS.SIGNING_IN }), undefined);
+});
+
+test("opening with nothing there starts the note signed with the account", () => {
+  const opened = openedFeedbackEntry(undefined, {
+    kind: FEEDBACK_KIND.FEEDBACK,
+    fromPanel: true,
+    signature: { name: "Ada", email: "ada@example.com" },
+  });
+
+  assert.equal(opened.entry?.name, "Ada");
+  assert.equal(opened.entry?.email, "ada@example.com");
+});
+
+test("a note already there keeps its fields as its author left them, cleared ones included", () => {
+  const cleared = entry({ message: "the capsule count is wrong", name: "", email: "" });
+  const opened = openedFeedbackEntry(cleared, {
+    kind: FEEDBACK_KIND.FEEDBACK,
+    fromPanel: true,
+    signature: { name: "Ada", email: "ada@example.com" },
+  });
+
+  assert.equal(opened.entry?.name, "");
+  assert.equal(opened.entry?.email, "");
 });
 
 test("a small screenshot in a native format rides untouched", () => {


### PR DESCRIPTION
## Summary

The feedback composer's name and email fields started empty on every note, so credit was retyped or skipped and most submissions arrived without a reply-to. This signs a fresh note from the signed-in account, keeping the trust story intact:

- **A fresh note starts signed.** `freshFeedbackEntry` takes an optional `FeedbackSignature`, and `openedFeedbackEntry` seeds it only into a note that does not exist yet. The account's name and email land in the composer's visible fields — prefilled, but the user's to edit or clear before anything leaves, so a submission still carries exactly what its fields showed at send.
- **A note already there is never touched.** Reopening a draft keeps its fields as its author left them, cleared ones included; clearing lasts for the life of that note, and the next fresh note starts signed again. A note mid-send stays untouched, as before.
- **Read through a ref, not a re-subscription.** `account` in `app.tsx` moves to `useStateWithRef`, so `beginFeedback` and the spoken open's drafted-prediction read the account at call time without re-wiring the lifecycle subscription on every sign-in change. Signed out, a note starts unsigned exactly as before.
- **Honesty kept in the same change:** the guide's Feedback fact now teaches the prefill and that both fields stay free to edit or clear, and the submission contract's comments in `shared/feedback.ts` and `feedback-entry.ts` say what the fields now start with. No endpoint or main-process changes — the send path is untouched.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passes — repository contracts, lint (same pre-existing warning count as main), typecheck, all test suites (890 pass, including three new `feedback-entry` tests covering the signature from each account state, seeding a fresh note, and a held note keeping cleared fields), and both builds.
- macOS Electron verification (`./scripts/verify.sh`): `not run` (authored in a Linux cloud workspace). No drawn surface changes — the composer's fields, layout, and motion are untouched; only the initial value of two existing fields changes, and only while signed in, which the sandbox's OAuth-less environment cannot reach.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32042644789/artifacts/9292239375) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32042644789)

- Commit: `95a5af33732a48b56037bfbaa496c0e890223541`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed` (no visual change)
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: worth one signed-in open of the composer on a real Mac to see the fields arrive filled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)