### PR TITLE
fix(conductor): drop archived workspaces the listing does not mark

### DIFF
--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -300,6 +300,17 @@ const CONDUCTOR_WORKSPACE_ACTIVITY: Readonly<Partial<Record<ConductorWorkspaceSt
   [CONDUCTOR_WORKSPACE_STATUS.UPDATING]: "Workspace updating",
 };
 
+/**
+ * The lifecycle states of a workspace no longer open. Conductor's workspace
+ * listing keeps a filed-away workspace in the page without marking it — the
+ * lifecycle endpoint is the one place the archive shows — so these are what
+ * the roster filters on.
+ */
+const CONDUCTOR_RETIRED_WORKSPACE_STATUSES: ReadonlySet<ConductorWorkspaceStatus> = new Set([
+  CONDUCTOR_WORKSPACE_STATUS.ARCHIVED,
+  CONDUCTOR_WORKSPACE_STATUS.DELETED,
+]);
+
 const CONDUCTOR_ADAPTER_DEFAULTS = {
   MAXIMUM_PROJECTS: 10,
   WORKSPACE_PAGE_SIZE: 100,
@@ -542,9 +553,35 @@ export class ConductorSessionAdapter
       .filter((workspace) => workspace.creatorId === userId)
       .sort((first, second) => second.lastActivityAt - first.lastActivityAt);
 
+    // Conductor's listing keeps a filed-away workspace in the page without
+    // marking it — only the lifecycle endpoint says it was archived — so the
+    // lifecycle reads come before the session listings, one per listed
+    // workspace, and a workspace standing archived or deleted is dropped
+    // here, before its chats are ever asked for. This is what makes a press
+    // of the archive control actually clear the rows it acted on. A
+    // lifecycle that could not be read keeps its workspace: a transient
+    // failure costs that workspace's activity words and failure message,
+    // never its rows.
+    const workspaceLifecycles = new Map(
+      (
+        await Promise.all(
+          workspaces.map(async (workspace) => {
+            const lifecycle = await this.tolerateItemFailure(() =>
+              this.#workspaceLifecycle(request, workspace.id),
+            );
+            return lifecycle ? ([workspace.id, lifecycle] as const) : undefined;
+          }),
+        )
+      ).filter(isDefined),
+    );
+    const openWorkspaces = workspaces.filter((workspace) => {
+      const lifecycleStatus = workspaceLifecycles.get(workspace.id)?.status;
+      return !lifecycleStatus || !CONDUCTOR_RETIRED_WORKSPACE_STATUSES.has(lifecycleStatus);
+    });
+
     const sessions = (
       await Promise.all(
-        workspaces.map((workspace) =>
+        openWorkspaces.map((workspace) =>
           this.tolerateItemFailure(() => this.#listSessions(request, workspace)),
         ),
       )
@@ -558,26 +595,14 @@ export class ConductorSessionAdapter
     // refusal: a key an org scopes away from the query endpoint alone still
     // reads the roster, and the roster reads above are what judge the
     // credential — so this one read swallows everything rather than letting
-    // an enrichment 403 clear every observed row. The lifecycle reads ride
-    // the same way, one per workspace — every listed workspace is open,
-    // because the listing dropped the filed-away ones — and a failed one
-    // costs that workspace's activity words and failure message, never the
-    // pass.
-    const [transcripts, reportedStatuses, workspaceLifecycles] = await Promise.all([
+    // an enrichment 403 clear every observed row.
+    const [transcripts, reportedStatuses] = await Promise.all([
       this.#sessionTranscripts(request, sessions).catch(() => undefined),
       Promise.all(
         sessions.map((session) =>
           this.tolerateItemFailure(() => this.#sessionStatus(request, session.id)),
         ),
       ),
-      Promise.all(
-        workspaces.map(async (workspace) => {
-          const lifecycle = await this.tolerateItemFailure(() =>
-            this.#workspaceLifecycle(request, workspace.id),
-          );
-          return lifecycle ? ([workspace.id, lifecycle] as const) : undefined;
-        }),
-      ).then((entries) => new Map(entries.filter(isDefined))),
     ]);
 
     // The workspaces every observed chat of which was positively seen settled
@@ -659,10 +684,10 @@ export class ConductorSessionAdapter
           timestampFromRecord(record, CONDUCTOR_FIELD.LAST_ACTIVITY_AT) ??
           timestampFromRecord(record, CONDUCTOR_FIELD.CREATED_AT);
         if (!id || lastActivityAt === undefined) return undefined;
-        // An archived workspace was filed away on Conductor's own surface, so
-        // none of its chats belongs on the roster: it is dropped here, before
-        // its sessions are ever asked for. This is what makes a press of the
-        // archive control actually clear the rows it acted on.
+        // Conductor's listing does not mark a filed-away workspace today —
+        // the lifecycle read in the collect pass is what drops those — but a
+        // record that does carry an archive timestamp is honored without
+        // waiting for that read.
         if (timestampFromRecord(record, CONDUCTOR_FIELD.ARCHIVED_AT) !== undefined) {
           return undefined;
         }
@@ -699,10 +724,10 @@ export class ConductorSessionAdapter
       .map((record): ConductorSession | undefined => {
         const id = textFromRecord(record, CONDUCTOR_FIELD.ID);
         if (!id) return undefined;
-        // An archived chat was filed away on Conductor's own surface, so it
-        // does not belong on the roster any more than an archived workspace
-        // does: it is dropped here, before its status or transcript is ever
-        // asked for. Its workspace stays, carrying only the chats still open.
+        // Conductor's listing already leaves an archived chat off the page,
+        // but one that arrives carrying an archive timestamp is dropped all
+        // the same, before its status or transcript is ever asked for. Its
+        // workspace stays, carrying only the chats still open.
         if (timestampFromRecord(record, CONDUCTOR_FIELD.ARCHIVED_AT) !== undefined) {
           return undefined;
         }
@@ -839,7 +864,8 @@ export class ConductorSessionAdapter
     // mid-turn offers the stop alone — its own workspace is by definition
     // unsettled — and any chat of a positively settled workspace offers to
     // file the whole workspace away. Every workspace and every chat here is
-    // still open: the filed-away ones never made it past the listing.
+    // still open: the filed-away workspaces never made it past the lifecycle
+    // read, and the filed-away chats never made it past the listing.
     const controls = [
       ...(reported?.status === CONDUCTOR_SESSION_STATUS.WORKING ? [CONDUCTOR_CANCEL_CONTROL] : []),
       ...(settledWorkspaceIds.has(session.workspace.id)

--- a/apps/desktop/tests/conductor-adapter.test.ts
+++ b/apps/desktop/tests/conductor-adapter.test.ts
@@ -1524,6 +1524,51 @@ test("leaves a filed-away workspace and its chats off the roster entirely", asyn
   );
 });
 
+test("leaves a workspace whose lifecycle stands archived off the roster", async () => {
+  // Conductor's listing keeps a filed-away workspace in the page with no
+  // mark of it — no archive timestamp, nothing — and only the lifecycle
+  // endpoint says it was archived. Without that read deciding the roster,
+  // every chat of every workspace ever archived kept its row, standing gray
+  // forever.
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [
+      { ...ownedWorkspace("workspace-archived", TEST_TIME - 30_000), lifecycleStatus: "archived" },
+      { ...ownedWorkspace("workspace-deleted", TEST_TIME - 40_000), lifecycleStatus: "deleted" },
+      ownedWorkspace("workspace-open", TEST_TIME - 5_000),
+    ],
+    sessions: [
+      { id: "session-filed", workspaceId: "workspace-archived", name: TEST_SESSION_NAME },
+      { id: "session-gone", workspaceId: "workspace-deleted", name: TEST_SESSION_NAME },
+      {
+        id: "session-open",
+        workspaceId: "workspace-open",
+        name: TEST_SESSION_NAME,
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.deepEqual(
+    observations.map((candidate) => candidate.providerSessionId),
+    ["session-open"],
+  );
+  // Dropped before its chats are ever asked for: the retired workspaces cost
+  // one lifecycle read each and nothing more.
+  assert.equal(
+    api.requests.some((request) => request.pathname.endsWith("workspace-archived/sessions")),
+    false,
+  );
+  assert.equal(
+    api.requests.some((request) => request.pathname.includes("session-filed")),
+    false,
+  );
+});
+
 test("hands a user prompt to Conductor's documented message endpoint", async () => {
   const api = fakeConductorApi({
     userId: TEST_USER_ID,


### PR DESCRIPTION
## Summary

Archived Conductor cloud workspaces kept their chats on Luke's roster as gray (`Idle`) rows forever.

Probing the live API (`api.conductor.build`) showed why:

- The workspace listing (`GET /v0/projects/{id}/workspaces`) **keeps archived workspaces in the page and never sends `archivedAt`** — the field the adapter filtered on. The filter simply never fired.
- The only place the archive shows is the lifecycle endpoint, `GET /v0/workspaces/{id}/status` → `{"status":"archived"}`.
- Archived **chats**, by contrast, are already left off `GET /v0/workspaces/{id}/sessions` by Conductor itself (verified with a throwaway probe workspace, archived afterwards), so session-level archiving was never the problem.

The fix moves the per-workspace lifecycle read (already issued every pass) ahead of the session listings and drops any workspace standing `archived` or `deleted` before its chats are asked for. This also cuts the request fan-out substantially: sessions and statuses are no longer fetched for the (large) archived tail of the workspace page. A lifecycle that cannot be read keeps its workspace — a transient failure costs activity words, never rows — matching the existing failure-tolerance test. The listing-time `archivedAt` filters stay as belt-and-braces, with comments corrected to what the API actually sends.

## Testing

- `./scripts/check.sh` passes (exit 0); all 50 conductor-adapter tests pass, including a new one: a workspace whose lifecycle stands `archived`/`deleted` leaves the roster entirely and costs one lifecycle read and nothing more.
- Portable data-layer change only — no UI or macOS surface touched, so no visual evidence run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/10254399-12dd-4adf-953e-a89a3677d983)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32059749582/artifacts/9297720441) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32059749582)

- Commit: `b40e254ad1cc830c3104c55e356cba5e61a5ea65`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
