### PR TITLE
feat(voice): play a sample when the voice or the pace changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,14 +239,22 @@ What Luke may show:
   — or the one answering sentence — alone: never the roster, the guide, the
   issues, or a transcript rendering, which travel only on conversations the
   developer opens, and the rendering only in the turn that asked for it. Its
-  trigger is a deterministic status edge or the evaluator finding an update
-  that satisfies the developer's standing ask — never a model speaking
+  trigger is a deterministic status edge, the evaluator finding an update
+  that satisfies the developer's standing ask, or the developer's own hand
+  changing the voice or the pace on the Voice page — never a model speaking
   unbidden: while no ask stands, nothing a model decided can open Luke's own
-  call. The edge announcements speak whenever voice can; an answered ask
-  speaks on the consent of the ask itself, for exactly as long as it stands.
-  Widening either set is a product decision, not an implementation detail;
-  make it deliberately. While an announcement is being spoken, a notice on
-  Luke's own surface under the housing names the session it is about —
+  call. The third is the narrowest of them and stays that way: choosing a
+  voice from a list of names is choosing blind until it is heard, so the pick
+  is its own ask to hear it, and what is said is one line fixed by this build
+  — who Luke is, and nothing else. No session material travels with a sample,
+  none is asked for, and a change asked for out loud plays none: the spoken
+  reply already confirms itself in words. The edge announcements speak
+  whenever voice can; an answered ask speaks on the consent of the ask
+  itself, for exactly as long as it stands; a sample speaks once, for the
+  hand that just moved the setting. Widening any of the three is a product
+  decision, not an implementation detail; make it deliberately. While an
+  announcement is being spoken, a notice on Luke's own surface under the
+  housing names the session it is about —
   drawn on this machine from the roster and the same roster-validated
   identity the voice was handed, leaving it never, and living exactly as
   long as the spoken reply, so it can never stand for news nobody is

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -135,7 +135,11 @@ import { useBootstrapRacedChannel } from "./use-bootstrap-raced-channel";
 import { panelEntryOpen, usePanelEntry } from "./use-panel-entry";
 import { usePanelPresentation } from "./use-panel-presentation";
 import { useStateWithRef } from "./use-state-with-ref";
-import { useVoiceConversation, voiceErrorToShow } from "./use-voice-conversation";
+import {
+  useVoiceConversation,
+  voiceErrorToShow,
+  voicePreviewFollows,
+} from "./use-voice-conversation";
 import {
   outputSilent,
   VOLUME_HINT_HEIGHT,
@@ -1219,21 +1223,40 @@ export function App(): React.JSX.Element {
     commit: feedbackEntry.commit,
   };
 
+  /**
+   * The ask to hear the voice and pace now stored. Changing either by hand is
+   * choosing blind from a list of names otherwise — what was picked is heard
+   * on Luke's next reply, which may be minutes away — so the pick is its own
+   * ask to hear it. It travels as a count rather than a call: the render that
+   * carries the new setting carries the request with it, and the voice
+   * conversation's own effects run in the order a sample needs.
+   */
+  const [voicePreviewRequest, setVoicePreviewRequest] = useState(0);
+
+  /** Applies a voice-row write and asks for the sample it earned, if any. */
+  const applyVoiceSettingsReply = useCallback(
+    (result: SettingsUpdateResult) => {
+      applySettingsReply(result);
+      if (voicePreviewFollows(result)) setVoicePreviewRequest((count) => count + 1);
+    },
+    [applySettingsReply],
+  );
+
   // The row marks the voice the main process reports rather than the one just
   // pressed, so what is shown as chosen is always what was actually saved.
   const changeVoice = useCallback(
     (voice: RealtimeVoice) => {
-      void window.sidecar.setVoice(voice).then(applySettingsReply);
+      void window.sidecar.setVoice(voice).then(applyVoiceSettingsReply);
     },
-    [applySettingsReply],
+    [applyVoiceSettingsReply],
   );
 
   // The pace, under the same rule as the voice above.
   const changeVoiceSpeed = useCallback(
     (speed: RealtimeVoiceSpeed) => {
-      void window.sidecar.setVoiceSpeed(speed).then(applySettingsReply);
+      void window.sidecar.setVoiceSpeed(speed).then(applyVoiceSettingsReply);
     },
-    [applySettingsReply],
+    [applyVoiceSettingsReply],
   );
 
   /**
@@ -1623,6 +1646,7 @@ export function App(): React.JSX.Element {
     voiceSpeed: settings?.voiceSpeed,
     voiceCaptions: settings?.voiceCaptions === true,
     voiceAvailable: settings?.voiceAvailable,
+    voicePreviewRequest,
     outputSilent: outputSilent(outputAudio),
     fixtureSpeaking: bootstrap?.profile === "speaking" || bootstrap?.profile === "muted",
     capturingShortcut: () => shortcutCapture.current,

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -186,7 +186,7 @@ const SETTING_GUIDE: Record<
     id: APP_SETTING_ID.VOICE,
     label: "Voice",
     description:
-      "Which voice Luke speaks with; a change is heard right away — a conversation under way starts afresh in the new voice.",
+      "Which voice Luke speaks with; a change is heard right away — a conversation under way starts afresh in the new voice. Changing it by hand on the Voice page plays a short sample in the new voice.",
     kind: APP_SETTING_KIND.CHOICE,
     value: settings.voice,
     defaultValue: REALTIME_DEFAULTS.VOICE,
@@ -198,7 +198,7 @@ const SETTING_GUIDE: Record<
     id: APP_SETTING_ID.VOICE_SPEED,
     label: "Speed",
     description:
-      "How fast Luke talks — slow is 0.75×, normal 1×, quick 1.25×, fast 1.5× the voice's natural rate, and an ask may use the word or the multiple; a change is heard from the next reply on.",
+      "How fast Luke talks — slow is 0.75×, normal 1×, quick 1.25×, fast 1.5× the voice's natural rate, and an ask may use the word or the multiple; a change is heard from the next reply on. Changing it by hand on the Voice page plays a short sample at the new pace.",
     kind: APP_SETTING_KIND.CHOICE,
     value: voiceSpeedWord(settings.voiceSpeed),
     defaultValue: voiceSpeedWord(REALTIME_DEFAULTS.SPEED),

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -52,6 +52,7 @@ import {
   type TrackedIssue,
   truncateResponseEvents,
   typedAskEvents,
+  voicePreviewEvents,
   workspaceProjectContextEvents,
   workspaceProjectContextText,
 } from "@sidecar/core";
@@ -1124,6 +1125,23 @@ export class RealtimeVoiceSession {
       providerSessionId: speech.providerSessionId,
     };
     this.#emitCaption();
+    return true;
+  }
+
+  /**
+   * Plays the sample of the voice and pace now stored, reporting whether it
+   * could. Refused on the same terms as a notice — one turn at a time — and
+   * dropped rather than held when refused: a sample answers a click, and a
+   * click a reply later is not a click anyone is still waiting on.
+   *
+   * Nothing is assigned to the caption's subject, and that is the whole of it:
+   * `#startResponse` clears the last reply's subject, so a sample's words are
+   * about no session and raise no pressable notice under the housing. A sample
+   * is news about nothing.
+   */
+  speakPreview(): boolean {
+    if (!this.isConnected || this.#turnBusy) return false;
+    this.#startResponse(voicePreviewEvents());
     return true;
   }
 

--- a/apps/desktop/src/renderer/spoken-notices.ts
+++ b/apps/desktop/src/renderer/spoken-notices.ts
@@ -17,6 +17,23 @@ export const SPOKEN_NOTICE_MAX_AGE_MS = 2 * 60_000;
  */
 export const ANNOUNCER_LINGER_MS = 60_000;
 
+/**
+ * How long Luke's own call lingers when a sample is all it has said. A sample
+ * answers a click on a settings row, and rows like that are clicked in runs —
+ * four voices tried against each other — so the call waits for the next pick
+ * rather than paying the handshake for each. Far shorter than a notice's
+ * linger all the same: hearing a voice is not news anyone is owed, and a
+ * settings tweak must not hold a call open for a minute.
+ */
+export const PREVIEW_LINGER_MS = 8_000;
+
+/**
+ * How long a sample stays worth playing. It answers an act the developer just
+ * performed; one that waited out a long reply is answering a click they have
+ * already moved on from, and arrives as an interruption rather than a sample.
+ */
+export const VOICE_PREVIEW_MAX_AGE_MS = 20_000;
+
 /** A backlog is stale news read in order; only this many notices ever wait. */
 export const MAXIMUM_QUEUED_NOTICES = 8;
 
@@ -48,11 +65,22 @@ export interface AnnouncerSession {
   readonly microphoneCall: boolean;
   connect(options: { microphone: false }): Promise<boolean>;
   speak(speech: AttentionSpeech): boolean;
+  /** Says the fixed sample line in the voice and at the pace now stored. */
+  speakPreview(): boolean;
   close(): Promise<void>;
 }
 
 export interface SpokenNoticeAnnouncerOptions {
   session: () => AnnouncerSession;
+  /**
+   * Whether the developer's own call is between a close and the reopen that
+   * follows it — what a changed voice does, since the voice is baked into the
+   * credential. The session answers "not connected, not connecting" across
+   * that gap, and it is the one time that answer must not be taken as silence:
+   * a call of Luke's own opened into it is torn down mid-sentence by the one
+   * coming back, which is also the call anything waiting belongs on.
+   */
+  reopening?: () => boolean;
   now?: () => number;
   schedule?: (callback: () => void, delayMs: number) => unknown;
   cancel?: (timer: unknown) => void;
@@ -75,12 +103,35 @@ export interface SpokenNoticeAnnouncerOptions {
  * per backlog, and every queued sentence ages out of being news regardless.
  * A backlog that outlives its attempts is dropped, because every notice is
  * still standing in the panel.
+ *
+ * The sample a changed voice or pace asks for is said the same way, and lives
+ * here for the same reason: "speak into silence, opening a call if that is
+ * what it takes, and close the call I opened" is one job, and a second owner
+ * racing this one for the same session would be a bug farm. It is not news,
+ * though, so it keeps none of the news rules — a single slot rather than a
+ * queue, since only the latest pick matters; no retry, since a call opening
+ * twenty seconds after a click is a call nobody asked for; and a shorter
+ * linger, since a settings tweak must not hold a call open for a minute.
  */
 export class SpokenNoticeAnnouncer {
   readonly #options: SpokenNoticeAnnouncerOptions;
   #queue: AttentionSpeech[] = [];
+  /**
+   * The sample waiting to be played, if one is. A slot rather than a queue
+   * entry: two picks in a row are one ask to hear the second one.
+   */
+  #preview: { requestedAt: number } | undefined;
   /** Whether the call now up is one this announcer opened, and so must close. */
   #ownsCall = false;
+  /**
+   * Whether the call Luke opened has said nothing but samples. It is what
+   * chooses the linger: a call opened to audition voices puts itself away in
+   * seconds, where one that read out news waits a minute for the cluster that
+   * usually follows. Set true by the connect that opens a call and false by
+   * the first notice spoken on it — the only two moments it can change,
+   * because it describes the call now up and nothing else.
+   */
+  #previewOnlyCall = false;
   #lingerTimer: unknown;
   /** How many times the backlog now queued has tried to open Luke's own call. */
   #connectAttempts = 0;
@@ -99,6 +150,18 @@ export class SpokenNoticeAnnouncer {
     if (this.#queue.length > MAXIMUM_QUEUED_NOTICES) {
       this.#queue = this.#queue.slice(this.#queue.length - MAXIMUM_QUEUED_NOTICES);
     }
+    this.#cancelLinger();
+    this.#flush();
+  }
+
+  /**
+   * Takes the ask to hear the voice and pace the developer just chose. The
+   * slot is filled rather than appended to: a pick made while the last one is
+   * still waiting supersedes it, because the only sample worth hearing is the
+   * one for the setting that now stands.
+   */
+  requestPreview(): void {
+    this.#preview = { requestedAt: this.#options.now?.() ?? Date.now() };
     this.#cancelLinger();
     this.#flush();
   }
@@ -126,6 +189,15 @@ export class SpokenNoticeAnnouncer {
     ) {
       this.#cancelLinger();
       this.#ownsCall = false;
+      // A sample waiting when a call ends is the voice restart's own path: the
+      // call was closed precisely so the next one could be minted in the new
+      // voice, and the sample is what is waiting to be heard in it. It is
+      // asked for again here rather than on the queue's retry clock, which is
+      // twenty seconds the developer would spend wondering.
+      if (this.#preview) {
+        this.#flush();
+        return;
+      }
       // The backlog survives the call it was waiting on — a developer's call
       // that ended mid-queue, or Luke's own that dropped — and the retry clock
       // is what picks it back up. The connect path arms the same clock when an
@@ -136,18 +208,27 @@ export class SpokenNoticeAnnouncer {
 
   #flush(): void {
     const now = this.#options.now?.() ?? Date.now();
+    if (this.#preview && now - this.#preview.requestedAt > VOICE_PREVIEW_MAX_AGE_MS) {
+      this.#preview = undefined;
+    }
     this.#queue = this.#queue.filter((item) => now - item.decidedAt <= SPOKEN_NOTICE_MAX_AGE_MS);
     const session = this.#options.session();
-    if (this.#queue.length === 0) {
+    if (this.#preview === undefined && this.#queue.length === 0) {
       this.#connectAttempts = 0;
       this.#armLinger();
       return;
     }
     if (session.isConnected) {
+      // The sample goes first. It answers something the developer did a moment
+      // ago; the notices behind it are news, and news keeps.
+      if (this.#preview && session.speakPreview()) this.#preview = undefined;
       // One reply at a time: the first speak takes the turn and the second is
       // refused, so the loop stops itself and READY resumes it.
       while (this.#queue.length > 0 && session.speak(this.#queue[0] as AttentionSpeech)) {
         this.#queue.shift();
+        // Something other than a sample has now been said on this call, so it
+        // has earned the full linger.
+        this.#previewOnlyCall = false;
       }
       // A backlog waiting on a refused speak is normally resumed by the READY
       // edge, but that edge is the session's promise, not this class's: the
@@ -157,15 +238,28 @@ export class SpokenNoticeAnnouncer {
       this.#armRetry();
       return;
     }
-    if (session.isConnecting) return;
+    // A call being opened, or one on its way back in a changed voice: either
+    // way there is a call coming, and it is the one to say this on.
+    if (session.isConnecting || this.#options.reopening?.() === true) return;
     // Silence, and something to say into it: open a call of Luke's own.
     this.#connectAttempts += 1;
     this.#ownsCall = true;
+    // Until a notice speaks on it, whatever this call is opened for, it has
+    // said nothing that is owed the long linger.
+    this.#previewOnlyCall = true;
     void session
       .connect({ microphone: false })
       .then((opened) => {
         if (opened) {
           this.#connectAttempts = 0;
+          // The call that just opened is the one this announcer asked for,
+          // whatever status arrived while it was opening: the call it replaced
+          // ending is not this call ending, and taking ownership away on that
+          // would leave the new one with nobody to close it — open for the
+          // session's own idle retirement rather than the few seconds it is
+          // owed. Unless what came up is the developer's own call, which is
+          // never Luke's to close.
+          this.#ownsCall = !session.microphoneCall;
           this.#flush();
           return;
         }
@@ -186,6 +280,11 @@ export class SpokenNoticeAnnouncer {
    * counter. What is dropped is still standing in the panel.
    */
   #retreatOrRetry(): void {
+    // The sample goes with the refusal, whatever the backlog does next. It is
+    // the answer to a click, and the retry clock is twenty seconds long: a
+    // call opening then would be Luke introducing himself to someone who has
+    // gone back to work.
+    this.#preview = undefined;
     if (this.#connectAttempts >= MAXIMUM_CONNECT_ATTEMPTS) {
       this.#queue = [];
       this.#connectAttempts = 0;
@@ -212,10 +311,13 @@ export class SpokenNoticeAnnouncer {
     const session = this.#options.session();
     if (!this.#ownsCall || !session.isConnected || session.microphoneCall) return;
     if (session.status !== REALTIME_STATUS.READY) return;
-    this.#lingerTimer ??= (this.#options.schedule ?? setTimeout)(() => {
-      this.#lingerTimer = undefined;
-      this.#closeOwnCall();
-    }, ANNOUNCER_LINGER_MS);
+    this.#lingerTimer ??= (this.#options.schedule ?? setTimeout)(
+      () => {
+        this.#lingerTimer = undefined;
+        this.#closeOwnCall();
+      },
+      this.#previewOnlyCall ? PREVIEW_LINGER_MS : ANNOUNCER_LINGER_MS,
+    );
   }
 
   #cancelLinger(): void {
@@ -230,7 +332,8 @@ export class SpokenNoticeAnnouncer {
     // long: the developer may have taken the call, or something new may be
     // queued and about to speak.
     if (!this.#ownsCall || !session.isConnected || session.microphoneCall) return;
-    if (this.#queue.length > 0 || session.status !== REALTIME_STATUS.READY) return;
+    if (this.#preview || this.#queue.length > 0) return;
+    if (session.status !== REALTIME_STATUS.READY) return;
     this.#ownsCall = false;
     void session.close();
   }

--- a/apps/desktop/src/renderer/spoken-notices.ts
+++ b/apps/desktop/src/renderer/spoken-notices.ts
@@ -270,7 +270,12 @@ export class SpokenNoticeAnnouncer {
     // way there is a call coming, and it is the one to say this on.
     if (session.isConnecting || this.#options.reopening?.() === true) return;
     // Silence, and something to say into it: open a call of Luke's own.
-    this.#connectAttempts += 1;
+    //
+    // The attempts are the backlog's ledger, so only a call with news behind it
+    // spends one. A sample opens calls too and answers to no retry clock of its
+    // own — a refused sample that drew on this would leave the news it never
+    // shared a queue with fewer tries than a transient refusal is owed.
+    if (this.#queue.length > 0) this.#connectAttempts += 1;
     this.#ownsCall = true;
     // Until a notice speaks on it, whatever this call is opened for, it has
     // said nothing that is owed the long linger.

--- a/apps/desktop/src/renderer/spoken-notices.ts
+++ b/apps/desktop/src/renderer/spoken-notices.ts
@@ -70,6 +70,15 @@ export interface AnnouncerSession {
   close(): Promise<void>;
 }
 
+/**
+ * An ask to hear the voice and pace now stored. Identity is what distinguishes
+ * two of them: every ask is its own object, so a slot still holding the one a
+ * call was opened for is a slot nothing has superseded.
+ */
+interface VoicePreviewRequest {
+  readonly requestedAt: number;
+}
+
 export interface SpokenNoticeAnnouncerOptions {
   session: () => AnnouncerSession;
   /**
@@ -81,6 +90,20 @@ export interface SpokenNoticeAnnouncerOptions {
    * coming back, which is also the call anything waiting belongs on.
    */
   reopening?: () => boolean;
+  /**
+   * Whether the call now up, or the one still coming up, was minted for a
+   * voice that no longer stands. A voice change owed against a call cannot be
+   * paid until the call settles, so between the pick and the teardown there is
+   * a live call speaking in the voice being replaced.
+   *
+   * News may ride such a call: a session that finished is the same news in any
+   * voice. A sample may not, because the sample *is* the voice — played there
+   * it would audition the voice the developer just moved off, and be spent by
+   * the time the call it was actually owed opens. Held instead, it is asked for
+   * again the moment that call ends, which is the path a stranded sample
+   * already takes.
+   */
+  revoicing?: () => boolean;
   now?: () => number;
   schedule?: (callback: () => void, delayMs: number) => unknown;
   cancel?: (timer: unknown) => void;
@@ -120,7 +143,7 @@ export class SpokenNoticeAnnouncer {
    * The sample waiting to be played, if one is. A slot rather than a queue
    * entry: two picks in a row are one ask to hear the second one.
    */
-  #preview: { requestedAt: number } | undefined;
+  #preview: VoicePreviewRequest | undefined;
   /** Whether the call now up is one this announcer opened, and so must close. */
   #ownsCall = false;
   /**
@@ -220,8 +243,13 @@ export class SpokenNoticeAnnouncer {
     }
     if (session.isConnected) {
       // The sample goes first. It answers something the developer did a moment
-      // ago; the notices behind it are news, and news keeps.
-      if (this.#preview && session.speakPreview()) this.#preview = undefined;
+      // ago; the notices behind it are news, and news keeps. Unless this call
+      // is the one a changed voice is already owed against, in which case the
+      // sample waits for the call that replaces it — the voice it exists to
+      // play is not the voice this one would say it in.
+      if (this.#preview && this.#options.revoicing?.() !== true && session.speakPreview()) {
+        this.#preview = undefined;
+      }
       // One reply at a time: the first speak takes the turn and the second is
       // refused, so the loop stops itself and READY resumes it.
       while (this.#queue.length > 0 && session.speak(this.#queue[0] as AttentionSpeech)) {
@@ -247,6 +275,9 @@ export class SpokenNoticeAnnouncer {
     // Until a notice speaks on it, whatever this call is opened for, it has
     // said nothing that is owed the long linger.
     this.#previewOnlyCall = true;
+    // Which sample this call is being opened for, so a refusal can tell it from
+    // one the developer picked while the handshake was still going.
+    const attempted = this.#preview;
     void session
       .connect({ microphone: false })
       .then((opened) => {
@@ -264,11 +295,11 @@ export class SpokenNoticeAnnouncer {
           return;
         }
         this.#ownsCall = false;
-        this.#retreatOrRetry();
+        this.#retreatOrRetry(attempted);
       })
       .catch(() => {
         this.#ownsCall = false;
-        this.#retreatOrRetry();
+        this.#retreatOrRetry(attempted);
       });
   }
 
@@ -279,12 +310,16 @@ export class SpokenNoticeAnnouncer {
    * a fresh backlog with tries of its own rather than dying against a spent
    * counter. What is dropped is still standing in the panel.
    */
-  #retreatOrRetry(): void {
-    // The sample goes with the refusal, whatever the backlog does next. It is
-    // the answer to a click, and the retry clock is twenty seconds long: a
-    // call opening then would be Luke introducing himself to someone who has
-    // gone back to work.
-    this.#preview = undefined;
+  #retreatOrRetry(attempted: VoicePreviewRequest | undefined): void {
+    // The sample this call was opened for goes with the refusal, whatever the
+    // backlog does next. It is the answer to a click, and the retry clock is
+    // twenty seconds long: a call opening then would be Luke introducing
+    // himself to someone who has gone back to work.
+    //
+    // A pick made while the handshake was still going is a different ask, and
+    // not this refusal's to drop — it is the newer click, still waiting on an
+    // answer, and the status this refusal raises is what asks for it again.
+    if (this.#preview === attempted) this.#preview = undefined;
     if (this.#connectAttempts >= MAXIMUM_CONNECT_ATTEMPTS) {
       this.#queue = [];
       this.#connectAttempts = 0;

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -51,6 +51,13 @@ export const VOICE_RESTART = {
   DROP: "drop",
   /** The call is idle enough to close and open again in the new voice. */
   RESTART: "restart",
+  /**
+   * The call up is Luke's own speak-only one, so closing it is the whole of
+   * the restart: the announcer opens the next one — in the new voice — for
+   * whatever is still waiting to be said, and reopening it here would ask for
+   * a microphone nobody pressed a key for.
+   */
+  RELEASE: "release",
 } as const;
 
 export type VoiceRestart = (typeof VOICE_RESTART)[keyof typeof VOICE_RESTART];
@@ -192,6 +199,13 @@ export function liveSpeedApplies(
  * What a changed voice should do to a call already up. A call being opened
  * counts as one to reopen: its credential may already have been minted in the
  * old voice. A call that ended on its own owes nothing.
+ *
+ * Whose call it is decides what a restart means. The developer's own comes
+ * back the way it went down, microphone and all — they are mid-conversation,
+ * and the new voice is what finishes it. Luke's own speak-only call is only
+ * closed: it is the announcer's to open again, for whatever is still waiting
+ * to be said, and bringing it back with a microphone would put a permission
+ * request in front of someone who changed a setting.
  */
 export function voiceRestartAction(input: {
   previous: RealtimeVoice | undefined;
@@ -199,6 +213,7 @@ export function voiceRestartAction(input: {
   live: boolean;
   due: boolean;
   status: RealtimeStatus;
+  microphoneCall: boolean;
 }): { due: boolean; action: VoiceRestart } {
   if (input.next === undefined) return { due: input.due, action: VOICE_RESTART.NONE };
   const due =
@@ -214,7 +229,25 @@ export function voiceRestartAction(input: {
   if (input.status !== REALTIME_STATUS.READY) {
     return { due: true, action: VOICE_RESTART.WAIT };
   }
-  return { due: false, action: VOICE_RESTART.RESTART };
+  return {
+    due: false,
+    action: input.microphoneCall ? VOICE_RESTART.RESTART : VOICE_RESTART.RELEASE,
+  };
+}
+
+/**
+ * Whether a voice-row write has earned a sample of what it stored. Two things
+ * have to be true and both are the write's own answer: it was stored as asked
+ * — a refusal changed nothing to hear — and voice is available, because with
+ * no key there is no call to open and the attempt would only fail quietly.
+ * Typed over the two fields it reads, like the rules around it, so it can be
+ * tested without a settings snapshot.
+ */
+export function voicePreviewFollows(result: {
+  reason?: string;
+  settings: { voiceAvailable: boolean };
+}): boolean {
+  return result.reason === undefined && result.settings.voiceAvailable;
 }
 
 /**
@@ -312,6 +345,16 @@ export interface VoiceConversationOptions {
    * state over a working key.
    */
   voiceAvailable: boolean | undefined;
+  /**
+   * Bumped when the developer changes the voice or the pace by hand, which is
+   * the ask to hear it. A counter rather than a callback on purpose: the same
+   * render that carries the new setting carries the request, and React runs
+   * this hook's effects in declaration order — so the pace update and the
+   * voice restart are both away before the sample is asked for, and the
+   * sample is spoken by the voice that was just chosen rather than the one
+   * being replaced.
+   */
+  voicePreviewRequest: number;
   outputSilent: boolean;
   fixtureSpeaking: boolean;
   /**
@@ -435,6 +478,13 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   const remoteAudio = useRef<HTMLAudioElement | null>(null);
   const voiceSession = useRef<RealtimeVoiceSession | undefined>(undefined);
   const announcer = useRef<SpokenNoticeAnnouncer | undefined>(undefined);
+  /**
+   * Whether the developer's own call is being closed and opened again in a
+   * changed voice. It is the one stretch where a session that answers "no call
+   * and none coming" is lying: one is coming, and it is the one anything
+   * waiting belongs on.
+   */
+  const callReopening = useRef(false);
   /** When the talk key went down, which is what tells a hold from a tap. */
   const talkPressedAt = useRef<number | undefined>(undefined);
   /** Whether a tap has left a turn open for a later press to end. */
@@ -566,6 +616,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   const ensureAnnouncer = useCallback((): SpokenNoticeAnnouncer => {
     announcer.current ??= new SpokenNoticeAnnouncer({
       session: () => ensureVoiceSession(),
+      reopening: () => callReopening.current,
     });
     return announcer.current;
   }, [ensureVoiceSession]);
@@ -789,15 +840,55 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
         voiceSession.current?.isConnected === true || voiceSession.current?.isConnecting === true,
       due: voiceRestartDue.current,
       status: voiceStatus,
+      microphoneCall: voiceSession.current?.microphoneCall === true,
     });
     if (options.voice !== undefined) heardVoice.current = options.voice;
     voiceRestartDue.current = decided.due;
+    // Luke's own call is closed and left closed: the announcer opens the next
+    // one, in the new voice, for the sample or the notice still waiting.
+    if (decided.action === VOICE_RESTART.RELEASE) {
+      void voiceSession.current?.close();
+      return;
+    }
     if (decided.action !== VOICE_RESTART.RESTART) return;
+    // The gap between the close and the call coming back is the announcer's to
+    // stay out of: it sees a session that is neither connected nor connecting,
+    // and a call of Luke's own opened into that gap is one the reopening
+    // microphone call tears down mid-sentence.
+    callReopening.current = true;
     void (async () => {
-      await voiceSession.current?.close();
-      await startMicrophone();
+      try {
+        await voiceSession.current?.close();
+        await startMicrophone();
+      } finally {
+        callReopening.current = false;
+        // Whatever was waiting flushes against the call that actually came
+        // back — or against the silence, if a refused microphone means none
+        // did. Nothing else would nudge it: the status the announcer follows
+        // may have settled while the hold was up.
+        announcer.current?.onStatus(voiceStatusNow());
+      }
     })();
-  }, [options.voice, startMicrophone, voiceStatus]);
+  }, [options.voice, startMicrophone, voiceStatus, voiceStatusNow]);
+
+  /**
+   * The sample a hand-changed voice or pace asks for.
+   *
+   * Declared last of the three on purpose: React runs effects in declaration
+   * order, so the pace update and the voice restart above are both in flight
+   * by the time this runs — and a sample asked for any earlier would be spoken
+   * by the voice being replaced. The announcer takes it from here, since
+   * "say this, opening a call if that is what it takes" is its job and not a
+   * second one racing it.
+   */
+  const heardPreviewRequest = useRef(options.voicePreviewRequest);
+  useEffect(() => {
+    // The mount pass is not a request: the ref starts at whatever count was
+    // already standing, so only a bump made while this hook was alive speaks.
+    if (options.voicePreviewRequest === heardPreviewRequest.current) return;
+    heardPreviewRequest.current = options.voicePreviewRequest;
+    ensureAnnouncer().requestPreview();
+  }, [ensureAnnouncer, options.voicePreviewRequest]);
 
   const activeStream = activeVoiceStream({
     status: voiceStatus,

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -485,6 +485,15 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
    * waiting belongs on.
    */
   const callReopening = useRef(false);
+  /**
+   * Whether a changed voice is owed against the call now up or coming, and
+   * still waiting for it to settle before it can be paid. Declared beside
+   * {@link callReopening} because it is the same kind of fact and told to the
+   * same listener: both are things the announcer cannot see from the session
+   * alone, and both decide whether the call in front of it is the one a sample
+   * belongs on.
+   */
+  const voiceRestartDue = useRef(false);
   /** When the talk key went down, which is what tells a hold from a tap. */
   const talkPressedAt = useRef<number | undefined>(undefined);
   /** Whether a tap has left a turn open for a later press to end. */
@@ -617,6 +626,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     announcer.current ??= new SpokenNoticeAnnouncer({
       session: () => ensureVoiceSession(),
       reopening: () => callReopening.current,
+      revoicing: () => voiceRestartDue.current,
     });
     return announcer.current;
   }, [ensureVoiceSession]);
@@ -831,7 +841,6 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   }, [options.voiceSpeed]);
 
   const heardVoice = useRef<RealtimeVoice | undefined>(undefined);
-  const voiceRestartDue = useRef(false);
   useEffect(() => {
     const decided = voiceRestartAction({
       previous: heardVoice.current,

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -507,6 +507,54 @@ test("a proactive update is spoken once the call is open", async () => {
   );
 });
 
+test("a sample waits for a call, and never talks over a turn", async () => {
+  const context = harness();
+
+  // Nothing to play a sample over yet.
+  assert.equal(context.session.speakPreview(), false);
+
+  await context.session.connect();
+  assert.equal(context.session.speakPreview(), true);
+  // One request and nothing else: the line is the build's own, so no words
+  // are handed over ahead of it.
+  assert.deepEqual(
+    context.sent.map((event) => event.type),
+    [REALTIME_CLIENT_EVENT.RESPONSE_CREATE],
+  );
+
+  // A second pick lands mid-reply and is refused rather than queued — the
+  // announcer decides what a refused sample is worth, and it is the one turn
+  // at a time rule that decides here.
+  assert.equal(context.session.speakPreview(), false);
+});
+
+test("a sample's caption is about no session, so it raises no notice", async () => {
+  const context = harness();
+  await context.session.connect();
+
+  // An announcement first, so the subject the sample has to clear is real.
+  context.session.speak({
+    providerId: "claude-code",
+    providerSessionId: "session-a",
+    disposition: ATTENTION_DISPOSITION.SPEAK_DURING_TURN,
+    source: ATTENTION_SPEECH_SOURCE.STATUS_EDGE,
+    summary: "session: 'checkout'; event: finished",
+    decidedAt: 1_800_000_000_000,
+  });
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_DONE });
+  context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED });
+
+  assert.equal(context.session.speakPreview(), true);
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
+    delta: "Hi, I'm Luke, your personal coding agent manager.",
+  });
+  // The words are drawn, and they stand for nobody: a sample is news about
+  // nothing, so the pressable notice under the housing has nothing to anchor.
+  assert.deepEqual(context.captions.at(-1), ["Hi, I'm Luke, your personal coding agent manager."]);
+  assert.equal(context.captionSubjects.at(-1), undefined);
+});
+
 test("a held turn lasts exactly as long as the key is down", async () => {
   const context = harness();
   await context.session.connect();

--- a/apps/desktop/tests/spoken-notices.test.ts
+++ b/apps/desktop/tests/spoken-notices.test.ts
@@ -12,8 +12,10 @@ import {
   ANNOUNCER_RETRY_DELAY_MS,
   type AnnouncerSession,
   MAXIMUM_CONNECT_ATTEMPTS,
+  PREVIEW_LINGER_MS,
   SPOKEN_NOTICE_MAX_AGE_MS,
   SpokenNoticeAnnouncer,
+  VOICE_PREVIEW_MAX_AGE_MS,
 } from "../src/renderer/spoken-notices";
 
 function speech(id: string, decidedAt = 1_000): AttentionSpeech {
@@ -29,6 +31,8 @@ function speech(id: string, decidedAt = 1_000): AttentionSpeech {
 
 interface FakeSession extends AnnouncerSession {
   spoken: AttentionSpeech[];
+  /** How many samples this call was asked to play. */
+  previews: number;
   connects: number;
   closes: number;
   /** What the next connect resolves to; the call opens when it does. */
@@ -40,6 +44,7 @@ interface FakeSession extends AnnouncerSession {
 function fakeSession(): FakeSession {
   const session: FakeSession = {
     spoken: [],
+    previews: 0,
     connects: 0,
     closes: 0,
     connectOpens: true,
@@ -65,6 +70,12 @@ function fakeSession(): FakeSession {
     speak(item: AttentionSpeech) {
       if (!this.isConnected || this.status === REALTIME_STATUS.RESPONDING) return false;
       this.spoken.push(item);
+      this.setStatus(REALTIME_STATUS.RESPONDING);
+      return true;
+    },
+    speakPreview() {
+      if (!this.isConnected || this.status === REALTIME_STATUS.RESPONDING) return false;
+      this.previews += 1;
       this.setStatus(REALTIME_STATUS.RESPONDING);
       return true;
     },
@@ -109,9 +120,15 @@ function fakeTimers(): Timers {
   };
 }
 
-function announcer(session: FakeSession, timers: Timers, now = () => 1_000) {
+function announcer(
+  session: FakeSession,
+  timers: Timers,
+  now = () => 1_000,
+  reopening: () => boolean = () => false,
+) {
   return new SpokenNoticeAnnouncer({
     session: () => session,
+    reopening,
     now,
     schedule: timers.schedule,
     cancel: timers.cancel,
@@ -338,6 +355,239 @@ test("a notice refused mid-reply keeps a clock of its own beside the READY edge"
     session.spoken.map((item) => item.providerSessionId),
     ["a"],
   );
+});
+
+test("a changed voice is heard: the sample opens a speak-only call of Luke's own", async () => {
+  const session = fakeSession();
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  subject.requestPreview();
+  await Promise.resolve();
+
+  assert.equal(session.connects, 1);
+  assert.equal(session.microphoneCall, false, "a sample never asks for the microphone");
+  assert.equal(session.previews, 1);
+});
+
+test("only the latest pick is heard: a second sample supersedes the first", async () => {
+  const session = fakeSession();
+  session.microphone = true;
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  // Both land while a reply is under way, so neither can speak yet.
+  subject.requestPreview();
+  subject.requestPreview();
+  assert.equal(session.previews, 0);
+
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  // One sample, not two: auditioning four voices quickly is one ask to hear
+  // the fourth, never four replies queued behind each other.
+  assert.equal(session.previews, 1);
+});
+
+test("a sample goes ahead of the news it arrived beside", async () => {
+  const session = fakeSession();
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  subject.enqueue([speech("a")]);
+  subject.requestPreview();
+  await Promise.resolve();
+
+  // The sample answers something the developer did a moment ago; the notice
+  // behind it is news, and news keeps.
+  assert.equal(session.previews, 1);
+  assert.deepEqual(session.spoken, []);
+
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.deepEqual(
+    session.spoken.map((item) => item.providerSessionId),
+    ["a"],
+  );
+});
+
+test("a refused call drops the sample rather than opening one later", async () => {
+  const session = fakeSession();
+  session.connectOpens = false;
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  subject.requestPreview();
+  await Promise.resolve();
+  subject.onStatus(REALTIME_STATUS.UNAVAILABLE);
+
+  // No clock is left ticking: a call opening twenty seconds after a settings
+  // click is Luke introducing himself to someone who went back to work.
+  assert.equal(session.connects, 1);
+  assert.equal(timers.armed(), 0);
+
+  session.connectOpens = true;
+  timers.fire();
+  await Promise.resolve();
+  assert.equal(session.connects, 1);
+  assert.equal(session.previews, 0);
+});
+
+test("a sample that waited out a long reply is dropped, not played late", () => {
+  const session = fakeSession();
+  session.microphone = true;
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  const timers = fakeTimers();
+  let now = 10_000;
+  const subject = announcer(session, timers, () => now);
+
+  subject.requestPreview();
+  assert.equal(session.previews, 0);
+
+  now = 10_000 + VOICE_PREVIEW_MAX_AGE_MS + 1;
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  // The click it answered is long past; arriving now, it would interrupt
+  // rather than demonstrate.
+  assert.equal(session.previews, 0);
+});
+
+test("a call that only played samples puts itself away in seconds", async () => {
+  const session = fakeSession();
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  subject.requestPreview();
+  await Promise.resolve();
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+
+  assert.deepEqual(timers.delays, [PREVIEW_LINGER_MS]);
+  // Long enough to reuse while the next voice is picked.
+  subject.requestPreview();
+  assert.equal(timers.armed(), 0);
+  assert.equal(session.connects, 1);
+  assert.equal(session.previews, 2);
+
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  timers.fire();
+  assert.equal(session.closes, 1);
+});
+
+test("news spoken on the sample's call earns the call the full linger", async () => {
+  const session = fakeSession();
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  subject.requestPreview();
+  await Promise.resolve();
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.deepEqual(timers.delays, [PREVIEW_LINGER_MS]);
+
+  // A session finishing while the call is still up: it is a cluster's first
+  // now, and the call waits for the stragglers as any announcing call does.
+  subject.enqueue([speech("a")]);
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.deepEqual(timers.delays, [PREVIEW_LINGER_MS, ANNOUNCER_LINGER_MS]);
+});
+
+test("a sample rides the developer's own call and never closes it", () => {
+  const session = fakeSession();
+  session.microphone = true;
+  session.setStatus(REALTIME_STATUS.READY);
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  subject.requestPreview();
+  assert.equal(session.connects, 0, "the open call is used, not replaced");
+  assert.equal(session.previews, 1);
+
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.equal(timers.armed(), 0);
+  timers.fire();
+  assert.equal(session.closes, 0);
+});
+
+test("a sample stranded by the voice restart is asked for again at once", async () => {
+  const session = fakeSession();
+  session.setStatus(REALTIME_STATUS.CONNECTING);
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  // The restart is already tearing the old call down, so there is nothing to
+  // speak on and nothing to wait for either.
+  subject.requestPreview();
+  assert.equal(session.previews, 0);
+
+  // The call the new voice is minted for opens from here — on the status,
+  // not on the queue's twenty-second retry clock, which nothing would arm
+  // for a sample anyway.
+  session.setStatus(REALTIME_STATUS.IDLE);
+  subject.onStatus(REALTIME_STATUS.IDLE);
+  await Promise.resolve();
+  assert.equal(session.connects, 1);
+  assert.equal(session.previews, 1);
+});
+
+test("the ending of the call it replaced does not orphan the call Luke just opened", async () => {
+  const session = fakeSession();
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  // The call opens while the one it replaced is still reporting its own
+  // ending — which is what a voice restart looks like from here.
+  subject.requestPreview();
+  subject.onStatus(REALTIME_STATUS.IDLE);
+  await Promise.resolve();
+  assert.equal(session.connects, 1);
+  assert.equal(session.previews, 1);
+
+  // The stale ending must not have taken ownership of the new call with it:
+  // a call nobody owns is a call nobody closes, and it would sit open until
+  // the session's own idle retirement instead of the seconds it is owed.
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  timers.fire();
+  assert.equal(session.closes, 1);
+});
+
+test("a sample waits for the developer's call to come back in the new voice", async () => {
+  const session = fakeSession();
+  session.microphone = true;
+  session.setStatus(REALTIME_STATUS.READY);
+  const timers = fakeTimers();
+  let reopening = false;
+  const subject = announcer(
+    session,
+    timers,
+    () => 1_000,
+    () => reopening,
+  );
+
+  // The voice change tore the developer's call down to mint the next one in
+  // the new voice. Across that gap the session answers "no call, none
+  // coming", and it is the one time that answer must not be believed.
+  reopening = true;
+  session.microphone = false;
+  session.setStatus(REALTIME_STATUS.IDLE);
+  subject.onStatus(REALTIME_STATUS.IDLE);
+  subject.requestPreview();
+  await Promise.resolve();
+  assert.equal(session.connects, 0, "a call opened into the gap is torn down mid-sentence");
+  assert.equal(session.previews, 0);
+
+  // The developer's call is back, in the new voice, and the sample rides it —
+  // which is where a sample belongs while a conversation is being held.
+  reopening = false;
+  session.microphone = true;
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.equal(session.connects, 0);
+  assert.equal(session.previews, 1);
 });
 
 test("a sentence that went stale in the queue is dropped, not read as news", () => {

--- a/apps/desktop/tests/spoken-notices.test.ts
+++ b/apps/desktop/tests/spoken-notices.test.ts
@@ -701,6 +701,32 @@ test("a refusal with no newer pick behind it drops the sample and stops", async 
   assert.equal(session.connects, 1, "a spent sample does not reopen the call it lost");
 });
 
+test("a refused sample does not spend the backlog's tries", async () => {
+  const session = fakeSession();
+  session.connectOpens = false;
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  // A sample is refused. It has no retry clock of its own, so that is the end
+  // of it — and the attempts are the backlog's ledger, not the sample's.
+  subject.requestPreview();
+  await Promise.resolve();
+  assert.equal(session.connects, 1);
+
+  // News arriving afterwards is a fresh backlog, owed every try.
+  subject.enqueue([speech("a")]);
+  await Promise.resolve();
+  for (let attempt = 0; attempt < MAXIMUM_CONNECT_ATTEMPTS + 1; attempt += 1) {
+    timers.fire();
+    await Promise.resolve();
+  }
+  assert.equal(
+    session.connects,
+    1 + MAXIMUM_CONNECT_ATTEMPTS,
+    "the backlog kept the full budget a sample's refusal must not draw on",
+  );
+});
+
 test("a sentence that went stale in the queue is dropped, not read as news", () => {
   const session = fakeSession();
   session.setStatus(REALTIME_STATUS.RESPONDING);

--- a/apps/desktop/tests/spoken-notices.test.ts
+++ b/apps/desktop/tests/spoken-notices.test.ts
@@ -37,17 +37,27 @@ interface FakeSession extends AnnouncerSession {
   closes: number;
   /** What the next connect resolves to; the call opens when it does. */
   connectOpens: boolean;
+  /**
+   * Whether a connect leaves the call CONNECTING and waits, rather than
+   * settling as it is asked. It is what lets a test put a pick inside a
+   * handshake — the stretch a credential is minted across.
+   */
+  slowHandshake: boolean;
+  /** Settles the handshake now waiting, as {@link connectOpens} says. */
+  settleHandshake(): void;
   setStatus(status: RealtimeStatus): void;
   microphone: boolean;
 }
 
 function fakeSession(): FakeSession {
+  let settle: ((opened: boolean) => void) | undefined;
   const session: FakeSession = {
     spoken: [],
     previews: 0,
     connects: 0,
     closes: 0,
     connectOpens: true,
+    slowHandshake: false,
     microphone: false,
     status: REALTIME_STATUS.IDLE,
     get isConnected() {
@@ -64,8 +74,19 @@ function fakeSession(): FakeSession {
     },
     async connect() {
       this.connects += 1;
+      if (this.slowHandshake) {
+        this.setStatus(REALTIME_STATUS.CONNECTING);
+        return await new Promise<boolean>((resolve) => {
+          settle = resolve;
+        });
+      }
       this.setStatus(this.connectOpens ? REALTIME_STATUS.READY : REALTIME_STATUS.UNAVAILABLE);
       return this.connectOpens;
+    },
+    settleHandshake() {
+      this.setStatus(this.connectOpens ? REALTIME_STATUS.READY : REALTIME_STATUS.UNAVAILABLE);
+      settle?.(this.connectOpens);
+      settle = undefined;
     },
     speak(item: AttentionSpeech) {
       if (!this.isConnected || this.status === REALTIME_STATUS.RESPONDING) return false;
@@ -123,13 +144,17 @@ function fakeTimers(): Timers {
 function announcer(
   session: FakeSession,
   timers: Timers,
-  now = () => 1_000,
-  reopening: () => boolean = () => false,
+  told: {
+    now?: () => number;
+    reopening?: () => boolean;
+    revoicing?: () => boolean;
+  } = {},
 ) {
   return new SpokenNoticeAnnouncer({
     session: () => session,
-    reopening,
-    now,
+    reopening: told.reopening ?? (() => false),
+    revoicing: told.revoicing ?? (() => false),
+    now: told.now ?? (() => 1_000),
     schedule: timers.schedule,
     cancel: timers.cancel,
   });
@@ -439,7 +464,7 @@ test("a sample that waited out a long reply is dropped, not played late", () => 
   session.setStatus(REALTIME_STATUS.RESPONDING);
   const timers = fakeTimers();
   let now = 10_000;
-  const subject = announcer(session, timers, () => now);
+  const subject = announcer(session, timers, { now: () => now });
 
   subject.requestPreview();
   assert.equal(session.previews, 0);
@@ -561,12 +586,7 @@ test("a sample waits for the developer's call to come back in the new voice", as
   session.setStatus(REALTIME_STATUS.READY);
   const timers = fakeTimers();
   let reopening = false;
-  const subject = announcer(
-    session,
-    timers,
-    () => 1_000,
-    () => reopening,
-  );
+  const subject = announcer(session, timers, { reopening: () => reopening });
 
   // The voice change tore the developer's call down to mint the next one in
   // the new voice. Across that gap the session answers "no call, none
@@ -590,13 +610,104 @@ test("a sample waits for the developer's call to come back in the new voice", as
   assert.equal(session.previews, 1);
 });
 
+test("a pick made inside the handshake is heard in its own voice, not the replaced one", async () => {
+  const session = fakeSession();
+  session.slowHandshake = true;
+  const timers = fakeTimers();
+  // What the voice restart holds while it waits: a changed voice owed against
+  // the call coming up, which cannot be paid until that call settles.
+  let revoicing = false;
+  const subject = announcer(session, timers, { revoicing: () => revoicing });
+
+  // The first pick opens a call, and its credential is minted for that voice
+  // across the whole handshake.
+  subject.requestPreview();
+  await Promise.resolve();
+  assert.equal(session.connects, 1);
+  assert.equal(session.status, REALTIME_STATUS.CONNECTING);
+
+  // A second pick lands inside that stretch. The restart can only wait — there
+  // is no settled call to tear down yet — so the voice now stored and the voice
+  // the call is coming up in have come apart.
+  revoicing = true;
+  subject.requestPreview();
+
+  // The call opens in the voice being replaced. Auditioning the new pick on it
+  // would play the wrong voice and spend the ask doing it.
+  session.settleHandshake();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(session.previews, 0, "the voice being replaced never speaks the sample");
+
+  // The restart pays what it owed: the call is released, and the sample is
+  // still waiting for the one that replaces it.
+  revoicing = false;
+  session.setStatus(REALTIME_STATUS.IDLE);
+  subject.onStatus(REALTIME_STATUS.IDLE);
+  await Promise.resolve();
+  session.settleHandshake();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(session.connects, 2, "the voice now stored gets a call minted for it");
+  assert.equal(session.previews, 1, "and is heard once, on that call");
+});
+
+test("a refused handshake keeps the pick made while it was going", async () => {
+  const session = fakeSession();
+  session.slowHandshake = true;
+  session.connectOpens = false;
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  subject.requestPreview();
+  await Promise.resolve();
+  assert.equal(session.connects, 1);
+
+  // A newer click lands inside the handshake, and then the handshake is
+  // refused. The sample that refusal belonged to goes with it; this one is a
+  // different click, and still owed an answer.
+  subject.requestPreview();
+  session.settleHandshake();
+  await Promise.resolve();
+  await Promise.resolve();
+
+  session.connectOpens = true;
+  subject.onStatus(REALTIME_STATUS.UNAVAILABLE);
+  await Promise.resolve();
+  assert.equal(session.connects, 2, "the newer pick is tried on its own");
+  session.settleHandshake();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(session.previews, 1);
+});
+
+test("a refusal with no newer pick behind it drops the sample and stops", async () => {
+  const session = fakeSession();
+  session.slowHandshake = true;
+  session.connectOpens = false;
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  subject.requestPreview();
+  await Promise.resolve();
+  session.settleHandshake();
+  await Promise.resolve();
+  await Promise.resolve();
+
+  // Nothing superseded the sample this call was opened for, so the refusal
+  // takes it — the status it raises must not start the attempt over.
+  subject.onStatus(REALTIME_STATUS.UNAVAILABLE);
+  await Promise.resolve();
+  assert.equal(session.connects, 1, "a spent sample does not reopen the call it lost");
+});
+
 test("a sentence that went stale in the queue is dropped, not read as news", () => {
   const session = fakeSession();
   session.setStatus(REALTIME_STATUS.RESPONDING);
   session.microphone = true;
   const timers = fakeTimers();
   let now = 10_000;
-  const subject = announcer(session, timers, () => now);
+  const subject = announcer(session, timers, { now: () => now });
 
   // Arrives during a long reply and waits.
   subject.enqueue([speech("a", 10_000)]);

--- a/apps/desktop/tests/use-voice-conversation.test.ts
+++ b/apps/desktop/tests/use-voice-conversation.test.ts
@@ -25,6 +25,7 @@ import {
   VOICE_RESTART,
   voiceErrorToShow,
   voiceExchangeActive,
+  voicePreviewFollows,
   voiceRestartAction,
   waveformVoice,
 } from "../src/renderer/use-voice-conversation";
@@ -194,6 +195,7 @@ test("a changed voice on a live call waits for the turn to end, then restarts", 
     live: true,
     due: false,
     status: REALTIME_STATUS.RESPONDING,
+    microphoneCall: true,
   };
   assert.deepEqual(voiceRestartAction(change), { due: true, action: VOICE_RESTART.WAIT });
   assert.deepEqual(voiceRestartAction({ ...change, status: REALTIME_STATUS.LISTENING }), {
@@ -206,6 +208,39 @@ test("a changed voice on a live call waits for the turn to end, then restarts", 
   });
 });
 
+test("only a stored change with a key behind it is worth hearing", () => {
+  assert.equal(voicePreviewFollows({ settings: { voiceAvailable: true } }), true);
+  // A refused write changed nothing, so there is nothing new to hear.
+  assert.equal(
+    voicePreviewFollows({
+      reason: "That voice is not offered.",
+      settings: { voiceAvailable: true },
+    }),
+    false,
+  );
+  // No key, no call: the sample would be a connect attempt with nobody able
+  // to hear the answer.
+  assert.equal(voicePreviewFollows({ settings: { voiceAvailable: false } }), false);
+});
+
+test("a restart of Luke's own call closes it and asks for no microphone", () => {
+  // The developer never pressed a key here: the call up is the speak-only one
+  // Luke opened for himself, and the sample the voice change asked for is what
+  // the announcer will open the next one to play. Bringing it back with a
+  // microphone would put a permission request in front of a settings click.
+  assert.deepEqual(
+    voiceRestartAction({
+      previous: REALTIME_VOICE.CEDAR,
+      next: REALTIME_VOICE.MARIN,
+      live: true,
+      due: false,
+      status: REALTIME_STATUS.READY,
+      microphoneCall: false,
+    }),
+    { due: false, action: VOICE_RESTART.RELEASE },
+  );
+});
+
 test("a call that ended on its own owes the new voice nothing", () => {
   const owed = {
     previous: REALTIME_VOICE.CEDAR,
@@ -213,6 +248,7 @@ test("a call that ended on its own owes the new voice nothing", () => {
     live: false,
     due: true,
     status: REALTIME_STATUS.IDLE,
+    microphoneCall: false,
   };
   assert.deepEqual(voiceRestartAction(owed), { due: false, action: VOICE_RESTART.DROP });
   assert.deepEqual(voiceRestartAction({ ...owed, status: REALTIME_STATUS.FAILED }), {
@@ -233,6 +269,7 @@ test("the first snapshot of the voice is stored, not restarted", () => {
       live: true,
       due: false,
       status: REALTIME_STATUS.READY,
+      microphoneCall: true,
     }),
     { due: false, action: VOICE_RESTART.NONE },
   );
@@ -246,6 +283,7 @@ test("a voice change with no call up is not owed a restart", () => {
       live: false,
       due: false,
       status: REALTIME_STATUS.IDLE,
+      microphoneCall: false,
     }),
     { due: false, action: VOICE_RESTART.NONE },
   );
@@ -259,6 +297,7 @@ test("a connecting call counts as one to reopen: its credential may already be t
       live: true,
       due: false,
       status: REALTIME_STATUS.CONNECTING,
+      microphoneCall: true,
     }),
     { due: true, action: VOICE_RESTART.WAIT },
   );

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -206,6 +206,8 @@ export {
   type RealtimeStatus,
   truncateResponseEvents,
   typedAskEvents,
+  VOICE_PREVIEW_LINE,
+  voicePreviewEvents,
 } from "./realtime-protocol.js";
 export {
   HOSTED_API_ERROR,

--- a/packages/sidecar-core/src/realtime-protocol.ts
+++ b/packages/sidecar-core/src/realtime-protocol.ts
@@ -433,6 +433,57 @@ export function proactiveSpeechEvents(speech: AttentionSpeech): readonly Record<
   ];
 }
 
+/**
+ * The line Luke says when the developer changes his voice or his pace by hand.
+ * Fixed by this build and written here, so the one sentence that can be spoken
+ * without anything having happened carries nothing anyone observed: no session,
+ * no roster, no provider's words. Long enough to hear a voice in, short enough
+ * that auditioning four of them is not a wait.
+ */
+export const VOICE_PREVIEW_LINE = "Hi, I'm Luke, your personal coding agent manager.";
+
+/**
+ * What Luke is told to do with a sample. The line is quoted straight into the
+ * instructions rather than travelling as a conversation item, which is exactly
+ * backwards from a proactive readout — and right, for the opposite reason: an
+ * announcement's payload is a provider's words, quarantined into the data
+ * channel so it cannot give orders, while this sentence is the build's own and
+ * has nothing to be quarantined from.
+ */
+const VOICE_PREVIEW_INSTRUCTIONS = [
+  `Say exactly this and nothing else: "${VOICE_PREVIEW_LINE}"`,
+  "Do not add a greeting, a follow-up question, or any other commentary.",
+].join("\n");
+
+/**
+ * Builds the events that play a sample of the voice and pace now stored.
+ *
+ * One request and no conversation item: there is no payload to hand over, only
+ * a sentence to say. `conversation: "none"` makes it an out-of-band response,
+ * so a sample riding the developer's own call is heard without ever becoming
+ * something the conversation can refer back to — the developer changed a
+ * setting, they did not say anything to Luke. The modalities are left to the
+ * session, which is audio: an out-of-band response that came back silent would
+ * be the one reason to drop that field, since a sample present in the
+ * transcript is harmless where a sample nobody hears is the whole feature.
+ */
+export function voicePreviewEvents(): readonly Record<string, unknown>[] {
+  return [
+    {
+      type: REALTIME_CLIENT_EVENT.RESPONSE_CREATE,
+      response: {
+        instructions: VOICE_PREVIEW_INSTRUCTIONS,
+        // Out-of-band: heard, and then not part of anything.
+        conversation: "none",
+        // A turn Luke opens himself carries no tools. Nothing decided this
+        // sample beyond a click on a settings row, and a click on a settings
+        // row is not permission to act on a session.
+        tool_choice: "none",
+      },
+    },
+  ];
+}
+
 /** One tool call the model made, as it arrives inside a finished response. */
 export interface RealtimeFunctionCall {
   name: string;

--- a/packages/sidecar-core/tests/realtime.test.ts
+++ b/packages/sidecar-core/tests/realtime.test.ts
@@ -53,6 +53,8 @@ import {
   sessionToolAction,
   truncateResponseEvents,
   typedAskEvents,
+  VOICE_PREVIEW_LINE,
+  voicePreviewEvents,
   WORKSPACE_TASK_SUPPORT,
   type WorkspaceAgentModels,
   workspaceProjectContextEvents,
@@ -1047,6 +1049,36 @@ test("a proactive turn is opened with its tools withheld", () => {
   // A notice is something to say, never a reason to act — and not only by
   // instruction: the turn itself has nothing to act with.
   assert.equal(responseCreate?.response?.tool_choice, "none");
+});
+
+test("a sample says the build's own line, and asks for nothing else", () => {
+  const events = voicePreviewEvents();
+
+  // One request and nothing before it: a sample hands over no payload, so
+  // there is nothing to quarantine into a conversation item the way an
+  // announcement's provider-written words are.
+  assert.equal(events.length, 1);
+  const [request] = events;
+  assert.equal(request?.type, REALTIME_CLIENT_EVENT.RESPONSE_CREATE);
+  const response = request?.response as {
+    instructions?: string;
+    conversation?: unknown;
+    tool_choice?: unknown;
+  };
+  assert.ok(response?.instructions?.includes(VOICE_PREVIEW_LINE));
+  // Out-of-band, so a sample riding the developer's own call is heard without
+  // becoming something the conversation can refer back to.
+  assert.equal(response?.conversation, "none");
+  // A turn Luke opens himself carries no tools, and a settings click is no
+  // more a reason to act than a notice is.
+  assert.equal(response?.tool_choice, "none");
+});
+
+test("the sample line carries nothing anyone observed", () => {
+  // Fixed by this build: it names Luke and nobody else, so the one sentence
+  // that can be spoken without anything having happened says nothing about a
+  // session, a workspace, or a provider.
+  assert.equal(VOICE_PREVIEW_LINE, "Hi, I'm Luke, your personal coding agent manager.");
 });
 
 test("tool calls are read whole from a finished response", () => {


### PR DESCRIPTION
## Summary

- Changing the voice or the pace **by hand** on the Voice page now plays one line fixed by this build — *"Hi, I'm Luke, your personal coding agent manager."* — in the new voice and at the new pace, because picking from a list of names is picking blind until it is heard. It rides the developer's call when one is open and otherwise opens a speak-only call of Luke's own, which the announcer already owns; the sample carries no session material, opens no turn that can act (`tool_choice: "none"`, out-of-band), and is about no session, so it raises no pressable notice — and a change asked for out loud plays none, since the spoken reply already confirms itself. It keeps none of the news rules: a single slot rather than a queue, no retry clock, and an eight-second linger instead of a minute.
- Two races the sample would have made routine are closed on the way: the voice restart's gap between the close and the reopen no longer reads as silence the announcer may open a call into (the reopening call would tear that one down mid-sentence), and a stale ending from the call it replaced no longer strips ownership from the call just opened, which had left it with nobody to close it.
- `AGENTS.md` widens the speak-only-call trigger set from two to three and states the new one's bounds, and `luke-guide.ts` teaches Luke that the hand change plays a sample, so he neither denies nor misdescribes it.

## Evidence

- Platform-independent checks: `pass` (`./scripts/check.sh`, exit 0)
- macOS Electron verification (`./scripts/verify.sh`): `pass` (exit 0; all four suites at `fail 0`, six fixture PNGs regenerated and inspected)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32169734761/artifacts/9336835445) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32169734761)

- Commit: `f96764f3851759dea0e99788b8692a42f5ba0dc7`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: the hand check with a real key is still owed — `conversation: "none"` is documented for out-of-band responses, but the docs do not state whether audio flows for one (their examples are text-only). If the sample comes back silent, dropping that single field is the fix, noted in the comment on `voicePreviewEvents`.