### PR TITLE
feat(settings): move the microphone permission onto the Voice page

### DIFF
--- a/apps/desktop/src/renderer/feedback-panel.tsx
+++ b/apps/desktop/src/renderer/feedback-panel.tsx
@@ -41,7 +41,7 @@ function FeedbackOffer({
  */
 export function FeedbackSection({ control }: { control: FeedbackEntryControl }): React.JSX.Element {
   return (
-    <section className="settings-section" style={{ "--row-index": 3 } as React.CSSProperties}>
+    <section className="settings-section" style={{ "--row-index": 2 } as React.CSSProperties}>
       <h2>
         <MegaphoneIcon />
         Feedback

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -436,8 +436,8 @@ const MICROPHONE_DETAIL: Record<MicrophoneStatus, string> = {
     "Denied. It can only be granted back in System Settings, under Privacy & Security, Microphone.",
   restricted: "Restricted by a system policy, which only the system's manager can change.",
   "not-determined":
-    "Not asked yet. The Settings tab's Permissions section can ask once an OpenAI key is connected.",
-  unknown: "Unknown. The Settings tab's Permissions section shows its state.",
+    "Not asked yet. The Permissions section on the Settings tab's Voice page can ask once an OpenAI key is connected.",
+  unknown: "Unknown. The Permissions section on the Settings tab's Voice page shows its state.",
 };
 
 /** The same three answers a credential row gives, in words a fact can carry. */
@@ -539,7 +539,10 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "workspace, and every chat can be seen, opened, and messaged individually. Settings " +
         "holds a front page whose rows open its Voice, Appearance, Keyboard shortcuts, and " +
         "Connections pages — each led back out by its back button or Escape — and keeps the " +
-        "microphone permission, the Feedback section, and Quit on the front page itself; the " +
+        "Feedback section and Quit on the front page itself; the microphone permission lives " +
+        "on the Voice page, under the OpenAI key it waits on, and the front page's Voice row " +
+        "wears a small exclamation mark while voice is still missing that key or the " +
+        "microphone permission; the " +
         "menu bar item's Settings… opens the same tab, and Command-comma switches to it while " +
         "the panel has the keyboard. A dot beside a settings row marks a value changed from " +
         "its default, and a page holding one ends its head with a reset, pressed by hand and " +

--- a/apps/desktop/src/renderer/microphone-access.ts
+++ b/apps/desktop/src/renderer/microphone-access.ts
@@ -41,9 +41,9 @@ export function microphoneAccessRow(input: {
   if (!input.voiceAvailable) {
     return {
       // Names what to do rather than what is missing, and what to do is
-      // something the panel offers: the OpenAI key, at the top of the Voice page.
+      // something this same page offers: the OpenAI key, at its top.
       detail:
-        "Luke opens the microphone only to talk, which needs the OpenAI key on the Voice page.",
+        "Luke opens the microphone only to talk, which needs the OpenAI key at the top of this page.",
       offerAccess: false,
       offerSystemSettings: false,
       ready: false,
@@ -55,4 +55,25 @@ export function microphoneAccessRow(input: {
     offerSystemSettings: input.status === "granted" || input.status === "denied",
     ready: input.status === "granted",
   };
+}
+
+/**
+ * Why the front page's Voice row wears its exclamation mark, or nothing while
+ * voice is ready to run. One sentence naming the first thing still missing —
+ * the key before the microphone, because the key is what makes the microphone
+ * worth asking for — worded for the hover and the screen reader alike. The
+ * Voice page itself is where the missing thing is explained and supplied, so
+ * the mark only has to say that something there still needs a hand.
+ */
+export function voiceAttentionNote(input: {
+  voiceAvailable: boolean;
+  status: MicrophoneStatus;
+}): string | undefined {
+  if (!input.voiceAvailable) {
+    return "Voice is off: it needs an OpenAI key.";
+  }
+  if (!microphoneAccessRow(input).ready) {
+    return "Luke cannot listen: the microphone is not allowed yet.";
+  }
+  return undefined;
 }

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -66,7 +66,7 @@ import { FeedbackSection } from "./feedback-panel";
 import { Keycaps } from "./keycaps";
 import { type ErrandTarget, errandTargetProps } from "./luke-errand";
 import { APP_SETTING_ID } from "./luke-guide";
-import { microphoneAccessRow } from "./microphone-access";
+import { microphoneAccessRow, voiceAttentionNote } from "./microphone-access";
 import { PANEL_TAB, panelPanelId, panelTabId } from "./panel-tabs";
 import { CloudBadge, ProviderMark } from "./provider-marks";
 import {
@@ -1235,14 +1235,20 @@ const SETTINGS_PAGE: Record<SettingsSubview, { title: string; icon: React.JSX.El
 /**
  * One front-page row per page: its glyph, its name, and the chevron that
  * promises a page rather than a control. The row is the whole press target,
- * the way a macOS settings row is.
+ * the way a macOS settings row is. The one thing a row may add is the
+ * attention mark: a state, not a sentence, saying the page holds something
+ * that needs a hand before its feature can run — the mark's words are the
+ * hover's, and the page itself is where they are explained.
  */
 function SettingsNavRow({
   view,
   onOpen,
+  attention,
 }: {
   view: SettingsSubview;
   onOpen: (view: SettingsSubview) => void;
+  /** Why the page needs a hand, absent while nothing on it does. */
+  attention?: string;
 }): React.JSX.Element {
   const page = SETTINGS_PAGE[view];
   return (
@@ -1258,6 +1264,12 @@ function SettingsNavRow({
       <span className="settings-copy">
         <strong>{page.title}</strong>
       </span>
+      {attention ? (
+        <span className="settings-attention" title={attention}>
+          <span aria-hidden="true">!</span>
+          <span className="visually-hidden">({attention})</span>
+        </span>
+      ) : null}
       <ChevronIcon />
     </button>
   );
@@ -1316,13 +1328,19 @@ function VoiceSection({
   preferences,
   credentials,
   panelOpen,
+  microphone,
 }: {
   settings: AppSettings;
   preferences: PreferenceWrites;
   credentials: CredentialEntryControl;
   panelOpen: boolean;
+  microphone: MicrophoneControl;
 }): React.JSX.Element {
   const storageUnavailable = settings.secretStorage === SECRET_STORAGE.UNAVAILABLE;
+  const microphoneRow = microphoneAccessRow({
+    voiceAvailable: microphone.voiceAvailable,
+    status: microphone.status,
+  });
   return (
     <>
       <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
@@ -1356,6 +1374,47 @@ function VoiceSection({
           </p>
         )}
       </section>
+      <section className="settings-section" style={{ "--row-index": 2 } as React.CSSProperties}>
+        <h2>
+          <ShieldIcon />
+          Permissions
+        </h2>
+        {/* Access, not use. The talk key is what opens the microphone, so a
+            button here could only ever repeat what the key already does — the
+            line answers the one question it can: whether Luke is allowed. It
+            lives on this page, under the key it waits on, because the
+            microphone's one use is the voice that key turns on. */}
+        {/* Named and marked like a provider, because it is the same question in
+            the same words: what Luke has been let at, and whether it is on. */}
+        <div className="settings-row">
+          <span className="settings-copy">
+            <span className="settings-name">
+              <strong>Microphone</strong>
+              {microphoneRow.ready ? <CheckIcon /> : null}
+            </span>
+            <small>{microphoneRow.detail}</small>
+          </span>
+          <span className="settings-actions">
+            {microphoneRow.offerSystemSettings ? (
+              <button
+                type="button"
+                className="icon-button"
+                aria-label="Open Privacy & Security in System Settings"
+                /* The ellipsis is the promise that it opens somewhere else. */
+                title="System Settings…"
+                onClick={microphone.onOpenSettings}
+              >
+                <ExternalIcon />
+              </button>
+            ) : null}
+            {microphoneRow.offerAccess ? (
+              <button type="button" className="quiet-button" onClick={microphone.onRequest}>
+                Allow
+              </button>
+            ) : null}
+          </span>
+        </div>
+      </section>
       <VoiceControlsSection settings={settings} preferences={preferences} />
     </>
   );
@@ -1372,7 +1431,7 @@ function VoiceControlsSection({
   return (
     <section
       className="settings-section settings-plain"
-      style={{ "--row-index": 2 } as React.CSSProperties}
+      style={{ "--row-index": 3 } as React.CSSProperties}
     >
       <SelectRow
         label="Voice"
@@ -1863,7 +1922,7 @@ function AccountSection({
   };
 
   return (
-    <section className="settings-section" style={{ "--row-index": 4 } as React.CSSProperties}>
+    <section className="settings-section" style={{ "--row-index": 3 } as React.CSSProperties}>
       <h2>
         <UserIcon />
         Account
@@ -2014,7 +2073,11 @@ export function SettingsPanel({
   onQuit,
   shortcuts,
 }: SettingsPanelProps): React.JSX.Element {
-  const microphoneRow = microphoneAccessRow({
+  // Why the front page's Voice row wears its mark, or nothing while voice is
+  // fully set up. Judged here rather than on the Voice page because the mark
+  // has to stand while that page is not drawn: it is the front page saying a
+  // page one press away still needs a hand.
+  const voiceNote = voiceAttentionNote({
     voiceAvailable: microphone.voiceAvailable,
     status: microphone.status,
   });
@@ -2089,7 +2152,12 @@ export function SettingsPanel({
           style={{ "--row-index": 1 } as React.CSSProperties}
         >
           {SETTINGS_SUBVIEW_LIST.map((subview) => (
-            <SettingsNavRow key={subview} view={subview} onOpen={onViewChange} />
+            <SettingsNavRow
+              key={subview}
+              view={subview}
+              onOpen={onViewChange}
+              {...(subview === SETTINGS_VIEW.VOICE && voiceNote ? { attention: voiceNote } : {})}
+            />
           ))}
         </section>
       ) : null}
@@ -2100,6 +2168,7 @@ export function SettingsPanel({
           preferences={preferences}
           credentials={credentials}
           panelOpen={panelOpen}
+          microphone={microphone}
         />
       ) : null}
 
@@ -2128,48 +2197,6 @@ export function SettingsPanel({
 
       {drawnView !== SETTINGS_VIEW.ROOT ? null : (
         <>
-          <section className="settings-section" style={{ "--row-index": 2 } as React.CSSProperties}>
-            <h2>
-              <ShieldIcon />
-              Permissions
-            </h2>
-            {/* Access, not use. The talk key is what opens the microphone, so a
-            button here could only ever repeat what the key already does — the
-            line answers the one question it can: whether Luke is allowed. */}
-            {/* Named and marked like a provider, because it is the same question in
-            the same words: what Luke has been let at, and whether it is on.
-            Access, not use — the talk key is what opens the microphone, so a
-            control here could only repeat what the key already does. */}
-            <div className="settings-row">
-              <span className="settings-copy">
-                <span className="settings-name">
-                  <strong>Microphone</strong>
-                  {microphoneRow.ready ? <CheckIcon /> : null}
-                </span>
-                <small>{microphoneRow.detail}</small>
-              </span>
-              <span className="settings-actions">
-                {microphoneRow.offerSystemSettings ? (
-                  <button
-                    type="button"
-                    className="icon-button"
-                    aria-label="Open Privacy & Security in System Settings"
-                    /* The ellipsis is the promise that it opens somewhere else. */
-                    title="System Settings…"
-                    onClick={microphone.onOpenSettings}
-                  >
-                    <ExternalIcon />
-                  </button>
-                ) : null}
-                {microphoneRow.offerAccess ? (
-                  <button type="button" className="quiet-button" onClick={microphone.onRequest}>
-                    Allow
-                  </button>
-                ) : null}
-              </span>
-            </div>
-          </section>
-
           <FeedbackSection control={feedback} />
 
           {/* The account stands last before the way out: signing out and
@@ -2182,7 +2209,7 @@ export function SettingsPanel({
           <button
             type="button"
             className="quit-button"
-            style={{ "--row-index": 5 } as React.CSSProperties}
+            style={{ "--row-index": 4 } as React.CSSProperties}
             onClick={onQuit}
           >
             <PowerIcon />

--- a/apps/desktop/src/renderer/styles/settings.css
+++ b/apps/desktop/src/renderer/styles/settings.css
@@ -283,6 +283,26 @@
   vertical-align: 2px;
 }
 
+/* The mark a front-page row wears while its page holds something that needs a
+   hand before its feature can run — today the Voice row, missing its key or
+   the microphone. The attention tint on purpose: unlike the changed dot this
+   is an urgency, the same standing a session waiting on a person has. The
+   words are the hover's and the hidden text's; the glyph alone is the mark. */
+.settings-attention {
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--state-attention) 22%, transparent);
+  color: var(--state-attention);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+}
+
 .settings-copy small,
 .settings-note {
   margin: 0;

--- a/apps/desktop/tests/microphone-access.test.ts
+++ b/apps/desktop/tests/microphone-access.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { microphoneAccessRow } from "../src/renderer/microphone-access";
+import { microphoneAccessRow, voiceAttentionNote } from "../src/renderer/microphone-access";
 
 test("access is offered only where it can be used", () => {
   const offered = microphoneAccessRow({
@@ -23,8 +23,8 @@ test("access is offered only where it can be used", () => {
   assert.equal(unavailable.offerAccess, false);
   assert.ok(!unavailable.detail.includes("macOS will ask"));
   // The row names the way out as well as the reason: the key's own row, at
-  // the top of the Voice page.
-  assert.match(unavailable.detail, /Voice page/);
+  // the top of the same page the row now lives on.
+  assert.match(unavailable.detail, /OpenAI key at the top of this page/);
 });
 
 test("a permission already granted is not a microphone in use", () => {
@@ -69,4 +69,46 @@ test("System Settings is offered only where macOS has an answer to change", () =
     microphoneAccessRow({ voiceAvailable: false, status: "granted" }).offerSystemSettings,
     false,
   );
+});
+
+test("the Voice row's mark stands while either half of voice is missing", () => {
+  // The key first: without one the microphone is not worth asking for, so the
+  // mark names the key even while the permission is also ungranted.
+  const keyless = voiceAttentionNote({ voiceAvailable: false, status: "not-determined" });
+  assert.ok(keyless);
+  assert.match(keyless, /OpenAI key/);
+  assert.equal(
+    voiceAttentionNote({ voiceAvailable: false, status: "granted" }),
+    keyless,
+    "a granted microphone does not quiet a missing key",
+  );
+
+  // Key connected: every state but granted is a microphone Luke cannot open.
+  for (const status of ["not-determined", "denied", "restricted", "unknown"] as const) {
+    const note = voiceAttentionNote({ voiceAvailable: true, status });
+    assert.ok(note, `${status} still needs a hand`);
+    assert.match(note, /microphone/);
+  }
+
+  // Both halves met is the one quiet state.
+  assert.equal(voiceAttentionNote({ voiceAvailable: true, status: "granted" }), undefined);
+});
+
+test("the mark and the row agree on what ready means", () => {
+  // The mark is drawn exactly while the row would not report itself ready:
+  // one judgement, read twice, so the front page and the Voice page never
+  // disagree about whether voice still needs a hand.
+  for (const voiceAvailable of [true, false]) {
+    for (const status of [
+      "not-determined",
+      "granted",
+      "denied",
+      "restricted",
+      "unknown",
+    ] as const) {
+      const row = microphoneAccessRow({ voiceAvailable, status });
+      const note = voiceAttentionNote({ voiceAvailable, status });
+      assert.equal(note === undefined, row.ready, `${voiceAvailable}/${status}`);
+    }
+  }
 });


### PR DESCRIPTION
## Summary

- The Microphone permission row leaves the Settings front page for the Voice page, where it stands under the OpenAI key it waits on — between the key section and the voice controls, since the microphone's one use is the voice that key turns on. The row itself is unchanged: same detail lines, same Allow and System Settings offers, same check when granted.
- The front page's Voice row now wears a small exclamation mark while voice still needs a hand: the OpenAI key missing, or the microphone permission not granted (any state but `granted`). The judgement is a new pure helper, `voiceAttentionNote`, which agrees with `microphoneAccessRow`'s own `ready` by construction — one rule read twice, so the front page and the Voice page never disagree. The mark carries its reason as the hover title and as visually-hidden text; it uses the `--state-attention` tint, unlike the neutral changed-dot, because this is an urgency rather than a preference.
- Copy that pointed at the old home follows the move: the keyless microphone detail now says "the OpenAI key at the top of this page", and the guide's facts (`MICROPHONE_DETAIL`, the panel fact) teach the new home and the mark in the same change.
- Front-page row indices close over the departed Permissions section (Feedback 2, Account 3, Quit 4); the Voice page numbers key 1, Permissions 2, controls 3.

## Evidence

- Platform-independent checks: `./scripts/check.sh` green (exit 0 — Biome, tsc, 918 workspace tests including three new `microphone-access` tests, esbuild + web build)
- macOS Electron verification (`./scripts/verify.sh`): `not run` locally (authored in a Linux cloud workspace) — runs in CI on this PR

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32065187097/artifacts/9299658130) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32065187097)

- Commit: `0ddecef27e0cd98e4121ae8c4f64a37b45f1f18e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- The mark is static — no animation added, so no motion proof applies; the nav row's layout gains one fixed-size flex child before the chevron and animates nothing.
- In the fixture/evidence run voice is unavailable, so the Voice row's exclamation mark should be visible in CI's settings screenshot — that is the feature, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/995e37ac-7ee3-494b-8e78-3a8a6a114e9c)
