### PR TITLE
fix(desktop): pace a silent caption for reading and hold it until read

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,9 +162,8 @@ Trust constraints:
   native helper reads the default output device's mute switch and volume —
   nothing else — and can write nothing. What it learns decides only what the
   renderer draws while Luke speaks into that silence: his captions forced on —
-  paced for reading rather than for the voice, and kept on screen after the
-  reply until they could have been read, because into a mute the caption is
-  the speech — and a hint asking for volume. Luke never changes the system
+  paced for reading rather than for the voice, because into a mute the caption
+  is the speech — and a hint asking for volume. Luke never changes the system
   volume himself; turning it up stays the user's own act on their own keys.
 - Keep unsupported capabilities explicit; do not invent fallback controls.
 - Keep Electron renderers sandboxed with context isolation and narrow IPC.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,9 +161,11 @@ Trust constraints:
 - The same shape, smaller still, watches whether Luke can be heard at all: a
   native helper reads the default output device's mute switch and volume —
   nothing else — and can write nothing. What it learns decides only what the
-  renderer draws while Luke speaks into that silence: his captions forced on,
-  and a hint asking for volume. Luke never changes the system volume himself;
-  turning it up stays the user's own act on their own keys.
+  renderer draws while Luke speaks into that silence: his captions forced on —
+  paced for reading rather than for the voice, and kept on screen after the
+  reply until they could have been read, because into a mute the caption is
+  the speech — and a hint asking for volume. Luke never changes the system
+  volume himself; turning it up stays the user's own act on their own keys.
 - Keep unsupported capabilities explicit; do not invent fallback controls.
 - Keep Electron renderers sandboxed with context isolation and narrow IPC.
 - Commit only synthetic fixtures and repository-relative paths. This binds

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1563,7 +1563,6 @@ export function App(): React.JSX.Element {
     voiceTurn,
     lukeCaption,
     captionShownAt,
-    captionHeld,
     announcedSession,
     remoteAudio,
     discardListening,
@@ -1581,7 +1580,6 @@ export function App(): React.JSX.Element {
     voiceCaptions: settings?.voiceCaptions === true,
     voiceAvailable: settings?.voiceAvailable,
     outputSilent: outputSilent(outputAudio),
-    captionHeight: captionTextHeight,
     fixtureSpeaking: bootstrap?.profile === "speaking" || bootstrap?.profile === "muted",
     capturingShortcut: () => shortcutCapture.current,
     openSession: openSessionAloud,
@@ -1864,17 +1862,17 @@ export function App(): React.JSX.Element {
 
   /**
    * The reading clock as last glanced at. Words paced across a silent output
-   * scroll on elapsed time, and between deltas nothing else re-renders — the
-   * hold after a reply is exactly such a stretch — so a tick at half the line
-   * pace keeps the scroll honest without chasing every frame.
+   * scroll on elapsed time, and a quiet stretch between deltas re-renders
+   * nothing else — so a tick at half the line pace keeps the scroll honest
+   * without chasing every frame.
    */
   const [readingNow, setReadingNow] = useState(() => Date.now());
   useEffect(() => {
-    if ((!outputSilent(outputAudio) && !captionHeld) || captionShownAt === undefined) return;
+    if (!outputSilent(outputAudio) || captionShownAt === undefined) return;
     setReadingNow(Date.now());
     const timer = window.setInterval(() => setReadingNow(Date.now()), CAPTION_LINE_READ_MS / 2);
     return () => window.clearInterval(timer);
-  }, [outputAudio, captionShownAt, captionHeld]);
+  }, [outputAudio, captionShownAt]);
 
   /**
    * The hint's own button. It quiets the hint, never the captions: the words
@@ -1967,11 +1965,10 @@ export function App(): React.JSX.Element {
       }
       // Stopping Luke mid-sentence is the same shape one layer on: a reply
       // being spoken is the most open thing there is, and Escape asks for
-      // quiet without opening a turn in its place. Words held for a muted
-      // reader are the tail of a reply and answer the same ask. The session
-      // itself answers whether there was anything to stop, so a press that
-      // found none falls through to the layers below rather than being
-      // swallowed by a reply that had already ended.
+      // quiet without opening a turn in its place. The session itself answers
+      // whether there was a reply to stop, so a press that found none falls
+      // through to the layers below rather than being swallowed by a reply
+      // that had already ended.
       if (stopSpeaking()) return;
       // Escape out of the slot is the entry's own way out, wherever the caret
       // happens to be: the slot is the only thing on screen, so there is nothing
@@ -2138,17 +2135,14 @@ export function App(): React.JSX.Element {
   const captionText = lukeCaption ?? voiceErrorNotice;
   const captionIsError = lukeCaption === undefined && voiceErrorNotice !== undefined;
   // How long the words on screen have been readable, or nothing while the
-  // output is audible: the reading clock only paces words nobody can hear. A
-  // held caption keeps its pace even once the output is back — those words
-  // were delivered into silence, and an unmute mid-read must not leap them.
+  // output is audible: the reading clock only paces words nobody can hear.
   const captionReadingElapsed =
-    (outputIsSilent || captionHeld) && captionShownAt !== undefined
+    outputIsSilent && captionShownAt !== undefined
       ? Math.max(0, readingNow - captionShownAt)
       : undefined;
-  // The hint rides the caption it explains — held words included, which keep
-  // reading Luke by it — and only over a silence the helper actually
-  // reported. "Got it" quiets it for this stretch of silence and any that
-  // follows too soon; the captions above it stay either way.
+  // The hint rides the caption it explains, and only over a silence the
+  // helper actually reported. "Got it" quiets it for this stretch of silence
+  // and any that follows too soon; the captions above it stay either way.
   const volumeHint =
     fixtureMuted ||
     (outputIsSilent &&

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -50,6 +50,7 @@ import { FEEDBACK_KIND, FEEDBACK_LIMITS, feedbackKindForLifecycleEvent } from ".
 import { voiceHotkeyLabel, voiceHotkeyToShow } from "../shared/voice-hotkey";
 import { ASK_LUKE_INPUT_ID, focusAskField } from "./ask-luke";
 import { type CalendarConnectEntry, CalendarConnectSlot } from "./calendar-connect-slot";
+import { CAPTION_LINE_READ_MS, pacedCaptionScroll } from "./caption-reading";
 import type { CredentialEntry, CredentialEntryControl } from "./credential-entry";
 import { isSubmittable, removalEndsEntry } from "./credential-entry";
 import {
@@ -164,12 +165,19 @@ function captionSizeStyle(
   textHeight: number | undefined,
   volumeHint: boolean,
   padding: number,
+  readingElapsedMs: number | undefined,
 ): CSSProperties {
   if (!textHeight) return {};
   const hintHeight = volumeHint ? VOLUME_HINT_HEIGHT : 0;
+  const overflow = Math.max(0, textHeight - (VOICE_CAPTION_MAX_HEIGHT - padding - hintHeight));
+  // Heard words keep the newest line on screen — the half of the reply the
+  // voice has not reached yet. Words landing on a silent output are read, not
+  // heard, so the oldest unread line holds instead, leaving at reading pace.
+  const scroll =
+    readingElapsedMs === undefined ? overflow : pacedCaptionScroll(overflow, readingElapsedMs);
   return {
     "--caption-size": `${Math.min(VOICE_CAPTION_MAX_HEIGHT, textHeight + hintHeight + padding)}px`,
-    "--caption-scroll": `${Math.max(0, textHeight - (VOICE_CAPTION_MAX_HEIGHT - padding - hintHeight))}px`,
+    "--caption-scroll": `${scroll}px`,
   } as CSSProperties;
 }
 
@@ -1554,6 +1562,8 @@ export function App(): React.JSX.Element {
     askLuke,
     voiceTurn,
     lukeCaption,
+    captionShownAt,
+    captionHeld,
     announcedSession,
     remoteAudio,
     discardListening,
@@ -1571,6 +1581,7 @@ export function App(): React.JSX.Element {
     voiceCaptions: settings?.voiceCaptions === true,
     voiceAvailable: settings?.voiceAvailable,
     outputSilent: outputSilent(outputAudio),
+    captionHeight: captionTextHeight,
     fixtureSpeaking: bootstrap?.profile === "speaking" || bootstrap?.profile === "muted",
     capturingShortcut: () => shortcutCapture.current,
     openSession: openSessionAloud,
@@ -1852,6 +1863,20 @@ export function App(): React.JSX.Element {
   }, [outputAudio]);
 
   /**
+   * The reading clock as last glanced at. Words paced across a silent output
+   * scroll on elapsed time, and between deltas nothing else re-renders — the
+   * hold after a reply is exactly such a stretch — so a tick at half the line
+   * pace keeps the scroll honest without chasing every frame.
+   */
+  const [readingNow, setReadingNow] = useState(() => Date.now());
+  useEffect(() => {
+    if ((!outputSilent(outputAudio) && !captionHeld) || captionShownAt === undefined) return;
+    setReadingNow(Date.now());
+    const timer = window.setInterval(() => setReadingNow(Date.now()), CAPTION_LINE_READ_MS / 2);
+    return () => window.clearInterval(timer);
+  }, [outputAudio, captionShownAt, captionHeld]);
+
+  /**
    * The hint's own button. It quiets the hint, never the captions: the words
    * stay for as long as the silence does, because they are what "got it"
    * leaves the user reading Luke by.
@@ -1942,10 +1967,11 @@ export function App(): React.JSX.Element {
       }
       // Stopping Luke mid-sentence is the same shape one layer on: a reply
       // being spoken is the most open thing there is, and Escape asks for
-      // quiet without opening a turn in its place. The session itself answers
-      // whether there was a reply to stop, so a press that found none falls
-      // through to the layers below rather than being swallowed by a reply
-      // that had already ended.
+      // quiet without opening a turn in its place. Words held for a muted
+      // reader are the tail of a reply and answer the same ask. The session
+      // itself answers whether there was anything to stop, so a press that
+      // found none falls through to the layers below rather than being
+      // swallowed by a reply that had already ended.
       if (stopSpeaking()) return;
       // Escape out of the slot is the entry's own way out, wherever the caret
       // happens to be: the slot is the only thing on screen, so there is nothing
@@ -2111,9 +2137,18 @@ export function App(): React.JSX.Element {
   });
   const captionText = lukeCaption ?? voiceErrorNotice;
   const captionIsError = lukeCaption === undefined && voiceErrorNotice !== undefined;
-  // The hint rides the caption it explains, and only over a silence the
-  // helper actually reported. "Got it" quiets it for this stretch of silence
-  // and any that follows too soon; the captions above it stay either way.
+  // How long the words on screen have been readable, or nothing while the
+  // output is audible: the reading clock only paces words nobody can hear. A
+  // held caption keeps its pace even once the output is back — those words
+  // were delivered into silence, and an unmute mid-read must not leap them.
+  const captionReadingElapsed =
+    (outputIsSilent || captionHeld) && captionShownAt !== undefined
+      ? Math.max(0, readingNow - captionShownAt)
+      : undefined;
+  // The hint rides the caption it explains — held words included, which keep
+  // reading Luke by it — and only over a silence the helper actually
+  // reported. "Got it" quiets it for this stretch of silence and any that
+  // follows too soon; the captions above it stay either way.
   const volumeHint =
     fixtureMuted ||
     (outputIsSilent &&
@@ -2199,7 +2234,7 @@ export function App(): React.JSX.Element {
               : slotHeight,
           feedbackHeight,
         ),
-        ...captionSizeStyle(captionTextHeight, volumeHint, captionPadding),
+        ...captionSizeStyle(captionTextHeight, volumeHint, captionPadding, captionReadingElapsed),
       }}
     >
       {/* Capsule, peek, slot and panel are all this one shape at different

--- a/apps/desktop/src/renderer/caption-reading.ts
+++ b/apps/desktop/src/renderer/caption-reading.ts
@@ -1,16 +1,14 @@
 /**
- * The decisions behind reading Luke into silence, kept pure so they can be
+ * The decision behind reading Luke into silence, kept pure so it can be
  * tested: how fast captioned words may leave the screen while the Mac's
- * output is silent, and how long they must stay once the reply that spoke
- * them has ended.
+ * output is silent.
  *
  * Over an audible output the captions defer to the voice: the newest words
- * hold the screen, because the ear has already had the older ones, and the
- * words leave when the speech does. Into a muted output the words are not a
- * caption of the speech — they are the speech, and the reader is the only
- * audience. So the oldest unread line is the one that matters, it may leave
- * only when a reader could have finished it, and a reply that ends before
- * the reading does owes the reader the difference.
+ * hold the screen, because the ear has already had the older ones. Into a
+ * muted output the words are not a caption of the speech — they are the
+ * speech, and the reader is the only audience. So the oldest unread line is
+ * the one that matters, and it may leave only when a reader could have
+ * finished it.
  */
 
 /**
@@ -23,10 +21,9 @@ export const CAPTION_LINE_HEIGHT = 14;
 /**
  * How long a line gets before it may scroll away. A full caption line at the
  * peek's width is a dozen words or so; at a deliberate read that is about
- * three seconds. Luke speaks slower than that, so the reading usually
- * finishes inside the reply and the hold below is the exception — but a pace
- * any faster would scroll words nobody has read yet, which is the one thing
- * a silent caption must never do.
+ * three seconds. Luke speaks slower than that, so the reading finishes inside
+ * the reply — but a pace any faster would scroll words nobody has read yet,
+ * which is the one thing a silent caption must never do.
  */
 export const CAPTION_LINE_READ_MS = 3_000;
 
@@ -41,32 +38,4 @@ export const CAPTION_LINE_READ_MS = 3_000;
 export function pacedCaptionScroll(overflowPx: number, elapsedMs: number): number {
   const readLines = Math.floor(Math.max(0, elapsedMs) / CAPTION_LINE_READ_MS);
   return Math.min(Math.max(0, overflowPx), readLines * CAPTION_LINE_HEIGHT);
-}
-
-/**
- * How long the words must stay on screen, from the moment they first
- * appeared, for every line to have had its reading time. A partial line is a
- * line: it still has to be read.
- */
-export function captionReadingMs(textHeightPx: number): number {
-  return Math.ceil(textHeightPx / CAPTION_LINE_HEIGHT) * CAPTION_LINE_READ_MS;
-}
-
-/**
- * How much longer a caption whose reply just ended must be held. Nothing is
- * owed when the output was audible — the voice already said these words —
- * when the user cut the reply themselves — a stop asked or the turn taken to
- * speak means stop, not "keep showing me" — or when the reading clock has
- * already run out, which is the common case because speech is slower than
- * reading. An unmeasured caption owes nothing either: the hold exists to
- * cover lines the clock knows about, never to guess.
- */
-export function captionHoldMs(input: {
-  outputSilent: boolean;
-  interrupted: boolean;
-  textHeight: number | undefined;
-  elapsedMs: number;
-}): number {
-  if (!input.outputSilent || input.interrupted || input.textHeight === undefined) return 0;
-  return Math.max(0, captionReadingMs(input.textHeight) - input.elapsedMs);
 }

--- a/apps/desktop/src/renderer/caption-reading.ts
+++ b/apps/desktop/src/renderer/caption-reading.ts
@@ -1,0 +1,72 @@
+/**
+ * The decisions behind reading Luke into silence, kept pure so they can be
+ * tested: how fast captioned words may leave the screen while the Mac's
+ * output is silent, and how long they must stay once the reply that spoke
+ * them has ended.
+ *
+ * Over an audible output the captions defer to the voice: the newest words
+ * hold the screen, because the ear has already had the older ones, and the
+ * words leave when the speech does. Into a muted output the words are not a
+ * caption of the speech — they are the speech, and the reader is the only
+ * audience. So the oldest unread line is the one that matters, it may leave
+ * only when a reader could have finished it, and a reply that ends before
+ * the reading does owes the reader the difference.
+ */
+
+/**
+ * The caption's line height, mirrored by `.voice-caption-text` in the
+ * stylesheet — the two must agree. The scroll moves in whole lines, so the
+ * reading pace is stated per line and travels as pixels.
+ */
+export const CAPTION_LINE_HEIGHT = 14;
+
+/**
+ * How long a line gets before it may scroll away. A full caption line at the
+ * peek's width is a dozen words or so; at a deliberate read that is about
+ * three seconds. Luke speaks slower than that, so the reading usually
+ * finishes inside the reply and the hold below is the exception — but a pace
+ * any faster would scroll words nobody has read yet, which is the one thing
+ * a silent caption must never do.
+ */
+export const CAPTION_LINE_READ_MS = 3_000;
+
+/**
+ * How far a silent caption may have scrolled by now: one line per reading
+ * interval, never past the overflow the block actually has. Reading is
+ * sequential — the first line is done one interval after the words appeared,
+ * the second an interval later — so the line at the top leaves exactly when
+ * its turn has passed, and the newest words wait their turn below the clip
+ * instead of shoving the unread ones off the screen.
+ */
+export function pacedCaptionScroll(overflowPx: number, elapsedMs: number): number {
+  const readLines = Math.floor(Math.max(0, elapsedMs) / CAPTION_LINE_READ_MS);
+  return Math.min(Math.max(0, overflowPx), readLines * CAPTION_LINE_HEIGHT);
+}
+
+/**
+ * How long the words must stay on screen, from the moment they first
+ * appeared, for every line to have had its reading time. A partial line is a
+ * line: it still has to be read.
+ */
+export function captionReadingMs(textHeightPx: number): number {
+  return Math.ceil(textHeightPx / CAPTION_LINE_HEIGHT) * CAPTION_LINE_READ_MS;
+}
+
+/**
+ * How much longer a caption whose reply just ended must be held. Nothing is
+ * owed when the output was audible — the voice already said these words —
+ * when the user cut the reply themselves — a stop asked or the turn taken to
+ * speak means stop, not "keep showing me" — or when the reading clock has
+ * already run out, which is the common case because speech is slower than
+ * reading. An unmeasured caption owes nothing either: the hold exists to
+ * cover lines the clock knows about, never to guess.
+ */
+export function captionHoldMs(input: {
+  outputSilent: boolean;
+  interrupted: boolean;
+  textHeight: number | undefined;
+  elapsedMs: number;
+}): number {
+  if (!input.outputSilent || input.interrupted || input.textHeight === undefined) return 0;
+  return Math.max(0, captionReadingMs(input.textHeight) - input.elapsedMs);
+}

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -733,9 +733,11 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
             label: "Muted output",
             detail:
               "While the Mac is muted or its volume is at zero, Luke's replies are captioned on " +
-              "screen even with Captions off, and a hint under the words asks for volume. The " +
-              "hint's Got it button rests it for that stretch of silence and any that begins " +
-              "within fifteen minutes; the captions stay.",
+              "screen even with Captions off, and a hint under the words asks for volume. A " +
+              "reply longer than the caption block scrolls at reading pace, oldest line first, " +
+              "and stays on screen after the reply ends until it could have been read; the stop " +
+              "key dismisses it sooner. The hint's Got it button rests it for that " +
+              "stretch of silence and any that begins within fifteen minutes; the captions stay.",
           },
           {
             label: "How long a conversation lasts",

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -734,10 +734,9 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
             detail:
               "While the Mac is muted or its volume is at zero, Luke's replies are captioned on " +
               "screen even with Captions off, and a hint under the words asks for volume. A " +
-              "reply longer than the caption block scrolls at reading pace, oldest line first, " +
-              "and stays on screen after the reply ends until it could have been read; the stop " +
-              "key dismisses it sooner. The hint's Got it button rests it for that " +
-              "stretch of silence and any that begins within fifteen minutes; the captions stay.",
+              "reply longer than the caption block scrolls at reading pace, oldest line first. " +
+              "The hint's Got it button rests it for that stretch of silence and any that " +
+              "begins within fifteen minutes; the captions stay.",
           },
           {
             label: "How long a conversation lasts",

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1323,9 +1323,12 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 
 /* The translate is how a reply that outgrows the block rolls its oldest lines
    up under the capsule band. The cut lands where black meets black, so lines
-   slide under the shape rather than being sliced in the open; the newest
-   words are always on screen, which is the half of the reply the voice has
-   not reached yet. */
+   slide under the shape rather than being sliced in the open. Heard words
+   keep the newest line on screen — the half of the reply the voice has not
+   reached yet; words landing on a silent output scroll at reading pace
+   instead, oldest unread line first, because there the caption is the speech.
+   The line height is mirrored by CAPTION_LINE_HEIGHT in caption-reading.ts —
+   the two must agree, or the reading clock releases part-lines. */
 .voice-caption-text {
   display: block;
   width: 100%;

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -20,7 +20,6 @@ import { type RefObject, useCallback, useEffect, useRef, useState } from "react"
 import type { MicrophoneStatus, SessionOpenResult, VoiceHotkeyState } from "../shared/contracts";
 import { TALK_KEY_RELEASE, talkKeyRelease } from "../shared/voice-hotkey";
 import { askRefusal } from "./ask-luke";
-import { captionHoldMs } from "./caption-reading";
 import { type AppActionCarrier, RealtimeVoiceSession } from "./realtime-session";
 import { SpokenNoticeAnnouncer } from "./spoken-notices";
 import { useStateWithRef } from "./use-state-with-ref";
@@ -306,12 +305,6 @@ export interface VoiceConversationOptions {
    */
   voiceAvailable: boolean | undefined;
   outputSilent: boolean;
-  /**
-   * The caption text's measured height, from the surface that draws it. The
-   * reading clock is stated in lines, and only a measurement knows how many
-   * lines the wrapped words came to.
-   */
-  captionHeight: number | undefined;
   fixtureSpeaking: boolean;
   /**
    * True while a settings row is recording a chord. Both Luke keys stay
@@ -355,19 +348,12 @@ export interface VoiceConversation {
   voiceTurn: WaveformVoice | undefined;
   lukeCaption: string | undefined;
   /**
-   * When the words now on screen first appeared, live or held. It is the
-   * reading clock's start: the surface paces a silent caption's scroll from
-   * it, so the words scroll as read rather than as generated. Absent whenever
-   * no words are drawn.
+   * When the words now on screen first appeared. It is the reading clock's
+   * start: the surface paces a silent caption's scroll from it, so the words
+   * scroll as read rather than as generated. Absent whenever no words are
+   * drawn.
    */
   captionShownAt: number | undefined;
-  /**
-   * Whether the words on screen are held past their reply's end for a muted
-   * reader. The surface keeps pacing a held caption even if the output has
-   * come back — the words were delivered into silence, and a scroll leaping
-   * to the end mid-read is the thing the hold exists to prevent.
-   */
-  captionHeld: boolean;
   /**
    * The session the reply being spoken is announcing, or nothing for a
    * conversation reply. Present exactly as long as the announcement is — it is
@@ -431,29 +417,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
    * words first drawn mid-reply, by a mute landing while Luke was already
    * speaking, start it then, because that is when reading could have started.
    */
-  const [captionShownAt, setCaptionShownAt, captionShownAtNow] = useStateWithRef<
-    number | undefined
-  >(undefined);
-  /**
-   * Words kept drawn past their reply's end, because the output was silent
-   * and the reading clock says they could not all have been read yet. Into a
-   * mute the caption is the speech, and speech that vanishes mid-sentence was
-   * never delivered. Cleared by its own timer, by the next words arriving, by
-   * the developer taking the turn, or by a stop — read from a callback, so it
-   * shadows a ref.
-   */
-  const [heldCaption, setHeldCaption, heldCaptionNow] = useStateWithRef<string | undefined>(
-    undefined,
-  );
-  const holdTimer = useRef<number | undefined>(undefined);
-  /** The words as last drawn live, for the falling edge that decides a hold. */
-  const lastSpokenCaption = useRef<string | undefined>(undefined);
-  /**
-   * Whether the user themselves asked for quiet — the stop key, or Escape.
-   * Words they silenced are not owed a hold: stop means stop. Cleared when
-   * the next words appear.
-   */
-  const stopAsked = useRef(false);
+  const [captionShownAt, setCaptionShownAt] = useState<number>();
 
   const audioContext = useRef<AudioContext | undefined>(undefined);
   const remoteAudio = useRef<HTMLAudioElement | null>(null);
@@ -768,24 +732,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     voiceSession.current?.stopListening(false);
   }, []);
 
-  const stopSpeaking = useCallback(() => {
-    // Stop means stop: a reply cut mid-word is not owed a hold, and words
-    // already held for reading are dismissed by the same ask. Answering true
-    // for a dismissed hold lets the press be consumed by it, exactly as a
-    // press over live speech is.
-    stopAsked.current = true;
-    const dismissedHold = heldCaptionNow() !== undefined;
-    if (holdTimer.current !== undefined) {
-      window.clearTimeout(holdTimer.current);
-      holdTimer.current = undefined;
-    }
-    if (dismissedHold) {
-      setHeldCaption(undefined);
-      setCaptionShownAt(undefined);
-    }
-    const stoppedReply = voiceSession.current?.stopSpeaking() === true;
-    return stoppedReply || dismissedHold;
-  }, [heldCaptionNow, setHeldCaption, setCaptionShownAt]);
+  const stopSpeaking = useCallback(() => voiceSession.current?.stopSpeaking() === true, []);
 
   const syncGuide = useCallback((guide: AppGuideSnapshot) => {
     guideRef.current = guide;
@@ -975,11 +922,9 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   useEffect(
     () =>
       window.sidecar.onStopHotkeyPress(() => {
-        // Through the wrapper, not the session: the same press that cuts a
-        // reply dismisses words held for a muted reader.
-        if (!optionsRef.current.capturingShortcut()) stopSpeaking();
+        if (!optionsRef.current.capturingShortcut()) voiceSession.current?.stopSpeaking();
       }),
-    [stopSpeaking],
+    [],
   );
 
   useEffect(
@@ -990,7 +935,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   );
 
   const voiceTurn = waveformVoice(voiceStatus);
-  const spokenCaption = lukeCaptionToShow({
+  const lukeCaption = lukeCaptionToShow({
     fixtureSpeaking: options.fixtureSpeaking,
     captionsEnabled: options.voiceCaptions,
     typedAsk,
@@ -999,65 +944,13 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     caption: voiceCaption.text,
   });
 
-  // The caption's edges drive the reading clock and the hold. Words arriving
-  // beat words held — one block of words at a time — and start the clock at
-  // the moment reading could have. Words leaving while the output is silent
-  // are held for whatever reading time the clock still owes, then leave the
-  // way they always did; a fall that arrived with the developer's own turn is
-  // an interruption, which is a choice the way a stop is, and holds nothing.
+  // The reading clock starts when words appear and ends when they leave; the
+  // text growing between those edges is the same block of words, still on its
+  // own clock, however fast the deltas behind it streamed in.
+  const captionDrawn = lukeCaption !== undefined;
   useEffect(() => {
-    const previous = lastSpokenCaption.current;
-    lastSpokenCaption.current = spokenCaption;
-    if (spokenCaption !== undefined && previous === undefined) {
-      if (holdTimer.current !== undefined) {
-        window.clearTimeout(holdTimer.current);
-        holdTimer.current = undefined;
-      }
-      setHeldCaption(undefined);
-      stopAsked.current = false;
-      setCaptionShownAt(Date.now());
-      return;
-    }
-    if (spokenCaption !== undefined || previous === undefined) return;
-    const shownAt = captionShownAtNow();
-    const hold = captionHoldMs({
-      outputSilent: optionsRef.current.outputSilent,
-      interrupted: stopAsked.current || voiceTurn === WAVEFORM_VOICE.DEVELOPER,
-      textHeight: optionsRef.current.captionHeight,
-      elapsedMs: shownAt === undefined ? Number.POSITIVE_INFINITY : Date.now() - shownAt,
-    });
-    if (hold <= 0) {
-      setCaptionShownAt(undefined);
-      return;
-    }
-    setHeldCaption(previous);
-    holdTimer.current = window.setTimeout(() => {
-      holdTimer.current = undefined;
-      setHeldCaption(undefined);
-      setCaptionShownAt(undefined);
-    }, hold);
-  }, [spokenCaption, voiceTurn, captionShownAtNow, setCaptionShownAt, setHeldCaption]);
-
-  // A held caption also yields to the developer taking the turn mid-hold:
-  // they are speaking now, and the exchange is the thing to read.
-  useEffect(() => {
-    if (voiceTurn !== WAVEFORM_VOICE.DEVELOPER || heldCaptionNow() === undefined) return;
-    if (holdTimer.current !== undefined) {
-      window.clearTimeout(holdTimer.current);
-      holdTimer.current = undefined;
-    }
-    setHeldCaption(undefined);
-    setCaptionShownAt(undefined);
-  }, [voiceTurn, heldCaptionNow, setCaptionShownAt, setHeldCaption]);
-
-  useEffect(
-    () => () => {
-      if (holdTimer.current !== undefined) window.clearTimeout(holdTimer.current);
-    },
-    [],
-  );
-
-  const lukeCaption = spokenCaption ?? heldCaption;
+    setCaptionShownAt(captionDrawn ? Date.now() : undefined);
+  }, [captionDrawn]);
 
   return {
     analyser,
@@ -1076,7 +969,6 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     voiceTurn,
     lukeCaption,
     captionShownAt,
-    captionHeld: heldCaption !== undefined,
     announcedSession: voiceCaption.about,
     remoteAudio,
     discardListening,

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -20,6 +20,7 @@ import { type RefObject, useCallback, useEffect, useRef, useState } from "react"
 import type { MicrophoneStatus, SessionOpenResult, VoiceHotkeyState } from "../shared/contracts";
 import { TALK_KEY_RELEASE, talkKeyRelease } from "../shared/voice-hotkey";
 import { askRefusal } from "./ask-luke";
+import { captionHoldMs } from "./caption-reading";
 import { type AppActionCarrier, RealtimeVoiceSession } from "./realtime-session";
 import { SpokenNoticeAnnouncer } from "./spoken-notices";
 import { useStateWithRef } from "./use-state-with-ref";
@@ -305,6 +306,12 @@ export interface VoiceConversationOptions {
    */
   voiceAvailable: boolean | undefined;
   outputSilent: boolean;
+  /**
+   * The caption text's measured height, from the surface that draws it. The
+   * reading clock is stated in lines, and only a measurement knows how many
+   * lines the wrapped words came to.
+   */
+  captionHeight: number | undefined;
   fixtureSpeaking: boolean;
   /**
    * True while a settings row is recording a chord. Both Luke keys stay
@@ -347,6 +354,20 @@ export interface VoiceConversation {
   askLuke: (text: string) => Promise<string | undefined>;
   voiceTurn: WaveformVoice | undefined;
   lukeCaption: string | undefined;
+  /**
+   * When the words now on screen first appeared, live or held. It is the
+   * reading clock's start: the surface paces a silent caption's scroll from
+   * it, so the words scroll as read rather than as generated. Absent whenever
+   * no words are drawn.
+   */
+  captionShownAt: number | undefined;
+  /**
+   * Whether the words on screen are held past their reply's end for a muted
+   * reader. The surface keeps pacing a held caption even if the output has
+   * come back — the words were delivered into silence, and a scroll leaping
+   * to the end mid-read is the thing the hold exists to prevent.
+   */
+  captionHeld: boolean;
   /**
    * The session the reply being spoken is announcing, or nothing for a
    * conversation reply. Present exactly as long as the announcement is — it is
@@ -404,6 +425,35 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
    * developer chose. Cleared the moment the turn moves on.
    */
   const [typedAsk, setTypedAsk] = useState(false);
+  /**
+   * When the words now on screen first appeared — the reading clock a muted
+   * output is captioned against. It is the caption's clock, not the reply's:
+   * words first drawn mid-reply, by a mute landing while Luke was already
+   * speaking, start it then, because that is when reading could have started.
+   */
+  const [captionShownAt, setCaptionShownAt, captionShownAtNow] = useStateWithRef<
+    number | undefined
+  >(undefined);
+  /**
+   * Words kept drawn past their reply's end, because the output was silent
+   * and the reading clock says they could not all have been read yet. Into a
+   * mute the caption is the speech, and speech that vanishes mid-sentence was
+   * never delivered. Cleared by its own timer, by the next words arriving, by
+   * the developer taking the turn, or by a stop — read from a callback, so it
+   * shadows a ref.
+   */
+  const [heldCaption, setHeldCaption, heldCaptionNow] = useStateWithRef<string | undefined>(
+    undefined,
+  );
+  const holdTimer = useRef<number | undefined>(undefined);
+  /** The words as last drawn live, for the falling edge that decides a hold. */
+  const lastSpokenCaption = useRef<string | undefined>(undefined);
+  /**
+   * Whether the user themselves asked for quiet — the stop key, or Escape.
+   * Words they silenced are not owed a hold: stop means stop. Cleared when
+   * the next words appear.
+   */
+  const stopAsked = useRef(false);
 
   const audioContext = useRef<AudioContext | undefined>(undefined);
   const remoteAudio = useRef<HTMLAudioElement | null>(null);
@@ -718,7 +768,24 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     voiceSession.current?.stopListening(false);
   }, []);
 
-  const stopSpeaking = useCallback(() => voiceSession.current?.stopSpeaking() === true, []);
+  const stopSpeaking = useCallback(() => {
+    // Stop means stop: a reply cut mid-word is not owed a hold, and words
+    // already held for reading are dismissed by the same ask. Answering true
+    // for a dismissed hold lets the press be consumed by it, exactly as a
+    // press over live speech is.
+    stopAsked.current = true;
+    const dismissedHold = heldCaptionNow() !== undefined;
+    if (holdTimer.current !== undefined) {
+      window.clearTimeout(holdTimer.current);
+      holdTimer.current = undefined;
+    }
+    if (dismissedHold) {
+      setHeldCaption(undefined);
+      setCaptionShownAt(undefined);
+    }
+    const stoppedReply = voiceSession.current?.stopSpeaking() === true;
+    return stoppedReply || dismissedHold;
+  }, [heldCaptionNow, setHeldCaption, setCaptionShownAt]);
 
   const syncGuide = useCallback((guide: AppGuideSnapshot) => {
     guideRef.current = guide;
@@ -908,9 +975,11 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   useEffect(
     () =>
       window.sidecar.onStopHotkeyPress(() => {
-        if (!optionsRef.current.capturingShortcut()) voiceSession.current?.stopSpeaking();
+        // Through the wrapper, not the session: the same press that cuts a
+        // reply dismisses words held for a muted reader.
+        if (!optionsRef.current.capturingShortcut()) stopSpeaking();
       }),
-    [],
+    [stopSpeaking],
   );
 
   useEffect(
@@ -921,7 +990,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   );
 
   const voiceTurn = waveformVoice(voiceStatus);
-  const lukeCaption = lukeCaptionToShow({
+  const spokenCaption = lukeCaptionToShow({
     fixtureSpeaking: options.fixtureSpeaking,
     captionsEnabled: options.voiceCaptions,
     typedAsk,
@@ -929,6 +998,66 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     voice: voiceTurn,
     caption: voiceCaption.text,
   });
+
+  // The caption's edges drive the reading clock and the hold. Words arriving
+  // beat words held — one block of words at a time — and start the clock at
+  // the moment reading could have. Words leaving while the output is silent
+  // are held for whatever reading time the clock still owes, then leave the
+  // way they always did; a fall that arrived with the developer's own turn is
+  // an interruption, which is a choice the way a stop is, and holds nothing.
+  useEffect(() => {
+    const previous = lastSpokenCaption.current;
+    lastSpokenCaption.current = spokenCaption;
+    if (spokenCaption !== undefined && previous === undefined) {
+      if (holdTimer.current !== undefined) {
+        window.clearTimeout(holdTimer.current);
+        holdTimer.current = undefined;
+      }
+      setHeldCaption(undefined);
+      stopAsked.current = false;
+      setCaptionShownAt(Date.now());
+      return;
+    }
+    if (spokenCaption !== undefined || previous === undefined) return;
+    const shownAt = captionShownAtNow();
+    const hold = captionHoldMs({
+      outputSilent: optionsRef.current.outputSilent,
+      interrupted: stopAsked.current || voiceTurn === WAVEFORM_VOICE.DEVELOPER,
+      textHeight: optionsRef.current.captionHeight,
+      elapsedMs: shownAt === undefined ? Number.POSITIVE_INFINITY : Date.now() - shownAt,
+    });
+    if (hold <= 0) {
+      setCaptionShownAt(undefined);
+      return;
+    }
+    setHeldCaption(previous);
+    holdTimer.current = window.setTimeout(() => {
+      holdTimer.current = undefined;
+      setHeldCaption(undefined);
+      setCaptionShownAt(undefined);
+    }, hold);
+  }, [spokenCaption, voiceTurn, captionShownAtNow, setCaptionShownAt, setHeldCaption]);
+
+  // A held caption also yields to the developer taking the turn mid-hold:
+  // they are speaking now, and the exchange is the thing to read.
+  useEffect(() => {
+    if (voiceTurn !== WAVEFORM_VOICE.DEVELOPER || heldCaptionNow() === undefined) return;
+    if (holdTimer.current !== undefined) {
+      window.clearTimeout(holdTimer.current);
+      holdTimer.current = undefined;
+    }
+    setHeldCaption(undefined);
+    setCaptionShownAt(undefined);
+  }, [voiceTurn, heldCaptionNow, setCaptionShownAt, setHeldCaption]);
+
+  useEffect(
+    () => () => {
+      if (holdTimer.current !== undefined) window.clearTimeout(holdTimer.current);
+    },
+    [],
+  );
+
+  const lukeCaption = spokenCaption ?? heldCaption;
 
   return {
     analyser,
@@ -946,6 +1075,8 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     askLuke,
     voiceTurn,
     lukeCaption,
+    captionShownAt,
+    captionHeld: heldCaption !== undefined,
     announcedSession: voiceCaption.about,
     remoteAudio,
     discardListening,

--- a/apps/desktop/tests/caption-reading.test.ts
+++ b/apps/desktop/tests/caption-reading.test.ts
@@ -3,8 +3,6 @@ import test from "node:test";
 import {
   CAPTION_LINE_HEIGHT,
   CAPTION_LINE_READ_MS,
-  captionHoldMs,
-  captionReadingMs,
   pacedCaptionScroll,
 } from "../src/renderer/caption-reading";
 
@@ -27,48 +25,4 @@ test("the reading pace never scrolls past the overflow the block has", () => {
   assert.equal(pacedCaptionScroll(FOUR_LINES, CAPTION_LINE_READ_MS * 100), FOUR_LINES);
   // A caption that fits its block has nothing to scroll at any elapsed time.
   assert.equal(pacedCaptionScroll(0, CAPTION_LINE_READ_MS * 100), 0);
-});
-
-test("reading time covers every line, part-lines included", () => {
-  // A partial line is a line: it still has to be read.
-  assert.equal(captionReadingMs(CAPTION_LINE_HEIGHT * 4), CAPTION_LINE_READ_MS * 4);
-  assert.equal(captionReadingMs(CAPTION_LINE_HEIGHT * 4 + 1), CAPTION_LINE_READ_MS * 5);
-});
-
-test("a reply that outlived the reading owes no hold", () => {
-  // The common case: speech is slower than reading, so by the time the reply
-  // ends the clock has already run out and the words leave as they always did.
-  const height = CAPTION_LINE_HEIGHT * 4;
-  const hold = captionHoldMs({
-    outputSilent: true,
-    interrupted: false,
-    textHeight: height,
-    elapsedMs: captionReadingMs(height),
-  });
-  assert.equal(hold, 0);
-});
-
-test("a reply ending mid-read is held for exactly the remainder", () => {
-  const height = CAPTION_LINE_HEIGHT * 6;
-  const elapsed = CAPTION_LINE_READ_MS * 2;
-  const hold = captionHoldMs({
-    outputSilent: true,
-    interrupted: false,
-    textHeight: height,
-    elapsedMs: elapsed,
-  });
-  assert.equal(hold, captionReadingMs(height) - elapsed);
-});
-
-test("an audible output, an interruption, or an unmeasured caption owes nothing", () => {
-  const unread = { textHeight: CAPTION_LINE_HEIGHT * 6, elapsedMs: 0 };
-  // Heard words were already delivered by the voice.
-  assert.equal(captionHoldMs({ outputSilent: false, interrupted: false, ...unread }), 0);
-  // Stop means stop — a reply the user cut is not owed a hold.
-  assert.equal(captionHoldMs({ outputSilent: true, interrupted: true, ...unread }), 0);
-  // The hold covers lines the clock knows about; it never guesses.
-  assert.equal(
-    captionHoldMs({ outputSilent: true, interrupted: false, textHeight: undefined, elapsedMs: 0 }),
-    0,
-  );
 });

--- a/apps/desktop/tests/caption-reading.test.ts
+++ b/apps/desktop/tests/caption-reading.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  CAPTION_LINE_HEIGHT,
+  CAPTION_LINE_READ_MS,
+  captionHoldMs,
+  captionReadingMs,
+  pacedCaptionScroll,
+} from "../src/renderer/caption-reading";
+
+// Four lines of overflow: the shape a long announcement leaves once the block
+// is full.
+const FOUR_LINES = CAPTION_LINE_HEIGHT * 4;
+
+test("a silent caption scrolls one line per reading interval", () => {
+  // The first line may leave only once a reader could have finished it; until
+  // then the words hold, however fast the text behind them streamed in.
+  assert.equal(pacedCaptionScroll(FOUR_LINES, 0), 0);
+  assert.equal(pacedCaptionScroll(FOUR_LINES, CAPTION_LINE_READ_MS - 1), 0);
+  assert.equal(pacedCaptionScroll(FOUR_LINES, CAPTION_LINE_READ_MS), CAPTION_LINE_HEIGHT);
+  assert.equal(pacedCaptionScroll(FOUR_LINES, CAPTION_LINE_READ_MS * 3), CAPTION_LINE_HEIGHT * 3);
+});
+
+test("the reading pace never scrolls past the overflow the block has", () => {
+  // The clock keeps counting after the last line has scrolled into place; the
+  // scroll must not follow it off the end of the text.
+  assert.equal(pacedCaptionScroll(FOUR_LINES, CAPTION_LINE_READ_MS * 100), FOUR_LINES);
+  // A caption that fits its block has nothing to scroll at any elapsed time.
+  assert.equal(pacedCaptionScroll(0, CAPTION_LINE_READ_MS * 100), 0);
+});
+
+test("reading time covers every line, part-lines included", () => {
+  // A partial line is a line: it still has to be read.
+  assert.equal(captionReadingMs(CAPTION_LINE_HEIGHT * 4), CAPTION_LINE_READ_MS * 4);
+  assert.equal(captionReadingMs(CAPTION_LINE_HEIGHT * 4 + 1), CAPTION_LINE_READ_MS * 5);
+});
+
+test("a reply that outlived the reading owes no hold", () => {
+  // The common case: speech is slower than reading, so by the time the reply
+  // ends the clock has already run out and the words leave as they always did.
+  const height = CAPTION_LINE_HEIGHT * 4;
+  const hold = captionHoldMs({
+    outputSilent: true,
+    interrupted: false,
+    textHeight: height,
+    elapsedMs: captionReadingMs(height),
+  });
+  assert.equal(hold, 0);
+});
+
+test("a reply ending mid-read is held for exactly the remainder", () => {
+  const height = CAPTION_LINE_HEIGHT * 6;
+  const elapsed = CAPTION_LINE_READ_MS * 2;
+  const hold = captionHoldMs({
+    outputSilent: true,
+    interrupted: false,
+    textHeight: height,
+    elapsedMs: elapsed,
+  });
+  assert.equal(hold, captionReadingMs(height) - elapsed);
+});
+
+test("an audible output, an interruption, or an unmeasured caption owes nothing", () => {
+  const unread = { textHeight: CAPTION_LINE_HEIGHT * 6, elapsedMs: 0 };
+  // Heard words were already delivered by the voice.
+  assert.equal(captionHoldMs({ outputSilent: false, interrupted: false, ...unread }), 0);
+  // Stop means stop — a reply the user cut is not owed a hold.
+  assert.equal(captionHoldMs({ outputSilent: true, interrupted: true, ...unread }), 0);
+  // The hold covers lines the clock knows about; it never guesses.
+  assert.equal(
+    captionHoldMs({ outputSilent: true, interrupted: false, textHeight: undefined, elapsedMs: 0 }),
+    0,
+  );
+});


### PR DESCRIPTION
## What happened

An announcement landing on a muted Mac is delivered by its caption alone, but the caption behaved as if the voice were still doing the work. Text generation runs ahead of speech, so a reply longer than the caption block (~4 lines, ~2 with the volume hint sharing the room) pinned the **newest** words and rolled the start off screen at generation speed. A muted user could not read a long announcement at all.

## The fix

Into a mute the caption is not a caption of the speech — it **is** the speech, and the reader is the only audience. So while the output is silent, the caption **scrolls at reading pace, oldest line first**: a line may leave the top only after a reader could have finished it (`CAPTION_LINE_READ_MS` per line), and the newest words wait their turn below the clip instead of shoving unread ones off screen. Reading at three seconds a line is faster than Luke speaks, so the reading finishes inside the reply and the caption still leaves with its reply, exactly as it always has. While the output is audible nothing changes — the ear already had the older words, so the newest-words behavior stays.

The pacing decision lives in `caption-reading.ts` (pure, tested); the hook stamps when the words appeared; the surface computes the paced scroll from that clock. Renderer-only, no CSS motion changes — the existing spring vocabulary carries the line steps. The notice popup's lifetime is unchanged.

`AGENTS.md`'s mute-watcher constraint and the guide's "Muted output" fact are updated in the same change, so Luke describes the behavior he has.

## Verification

- `./scripts/check.sh` — passes: repository contract checks, types, builds, and 1,190 tests (34 root + 198 sidecar-core + 15 web + 943 desktop, including new `caption-reading` tests), 0 failures.
- `./scripts/verify.sh` — runs in CI's `macOS app and evidence` job, which links the evidence. No physical-notch check was performed. The muted capture profile has no system output to read, so fixture evidence is unchanged by design; the paced path needs a live muted run on a Mac to see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32068203408/artifacts/9300750130) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32068203408)

- Commit: `5f674eea562f8c150851bb0641429a9508b745be`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
