### PR TITLE
fix(web): make the hosted functions loadable on Vercel's Node runtime

### DIFF
--- a/apps/web/server/core.ts
+++ b/apps/web/server/core.ts
@@ -1,0 +1,14 @@
+/**
+ * The one door through which server-side code reaches `@sidecar/core`.
+ *
+ * The relative path is deliberate. Vercel's builder compiles every TypeScript
+ * file a function's relative import graph reaches — including these, across
+ * the workspace boundary — but it leaves `package.json` untouched, so the
+ * package's own `exports` still names `./src/index.ts` after compilation has
+ * replaced that file with `index.js`. A bare `@sidecar/core` specifier
+ * therefore resolves to a file that no longer exists and the function dies on
+ * load, while a relative import is extension-rewritten with the rest of the
+ * graph and works. Client code keeps the bare specifier: Vite bundles it at
+ * build time and never resolves it at run time.
+ */
+export * from "../../../packages/sidecar-core/src/index.js";

--- a/apps/web/server/hosted/attention-review.ts
+++ b/apps/web/server/hosted/attention-review.ts
@@ -6,7 +6,7 @@ import {
   attentionResponsesOutputText,
   attentionResponsesRequest,
   text as trimmedText,
-} from "@sidecar/core";
+} from "../core.js";
 import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
 import { type FetchLike, postOpenAi } from "./openai.js";
 import type { HostedSpend } from "./quota.js";

--- a/apps/web/server/hosted/bearer.ts
+++ b/apps/web/server/hosted/bearer.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "@sidecar/core";
+import { isRecord } from "../core.js";
 
 /**
  * The auth service's own userinfo endpoint, called in process. It is the same

--- a/apps/web/server/hosted/voice-mint.ts
+++ b/apps/web/server/hosted/voice-mint.ts
@@ -10,7 +10,7 @@ import {
   realtimeCredentialFromResponse,
   realtimeCredentialIsUsable,
   text as trimmedText,
-} from "@sidecar/core";
+} from "../core.js";
 import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
 import { type FetchLike, HOSTED_OPENAI_DEFAULTS, postOpenAi } from "./openai.js";
 import type { HostedSpend } from "./quota.js";

--- a/packages/sidecar-core/src/attention-examples.ts
+++ b/packages/sidecar-core/src/attention-examples.ts
@@ -1,5 +1,5 @@
-import { ATTENTION_TRIGGER, type AttentionUpdate } from "./attention";
-import { ATTENTION_DISPOSITION, type AttentionDisposition, SESSION_STATUS } from "./session";
+import { ATTENTION_TRIGGER, type AttentionUpdate } from "./attention.js";
+import { ATTENTION_DISPOSITION, type AttentionDisposition, SESSION_STATUS } from "./session.js";
 
 /**
  * One redacted update paired with the decision Luke should reach for it. The

--- a/packages/sidecar-core/src/attention-openai.ts
+++ b/packages/sidecar-core/src/attention-openai.ts
@@ -1,10 +1,10 @@
-import { ATTENTION_DECISION_SCHEMA, ATTENTION_DECISION_SCHEMA_NAME } from "./attention";
+import { ATTENTION_DECISION_SCHEMA, ATTENTION_DECISION_SCHEMA_NAME } from "./attention.js";
 import {
   type AttentionPromptUpdate,
   attentionInstructions,
   attentionUpdateInput,
-} from "./attention-prompt";
-import { isRecord, text } from "./json";
+} from "./attention-prompt.js";
+import { isRecord, text } from "./json.js";
 
 /**
  * The one OpenAI Responses request an attention review may be. The desktop

--- a/packages/sidecar-core/src/attention-prompt.ts
+++ b/packages/sidecar-core/src/attention-prompt.ts
@@ -5,9 +5,9 @@ import {
   attentionRequestText,
   DISPOSITION_GUIDANCE,
   maximumAttentionSummaryLength,
-} from "./attention";
-import { ATTENTION_TUNING_EXAMPLES, type AttentionTuningExample } from "./attention-examples";
-import { isRecord } from "./json";
+} from "./attention.js";
+import { ATTENTION_TUNING_EXAMPLES, type AttentionTuningExample } from "./attention-examples.js";
+import { isRecord } from "./json.js";
 import {
   ATTENTION_DISPOSITION,
   boundedText,
@@ -16,7 +16,7 @@ import {
   maximumSessionTitleLength,
   SESSION_STATUS,
   type SessionStatus,
-} from "./session";
+} from "./session.js";
 
 const NONE_LABEL = "none";
 

--- a/packages/sidecar-core/src/attention.ts
+++ b/packages/sidecar-core/src/attention.ts
@@ -1,4 +1,4 @@
-import { nonNegativeNumber, positiveInteger } from "./json";
+import { nonNegativeNumber, positiveInteger } from "./json.js";
 import {
   ATTENTION_DISPOSITION,
   type AttentionDecision,
@@ -10,7 +10,7 @@ import {
   type SessionIdentity,
   type SessionStatus,
   silentAttention,
-} from "./session";
+} from "./session.js";
 
 export const ATTENTION_TRIGGER = {
   OBSERVED: "observed",

--- a/packages/sidecar-core/src/composite-provider-adapter.ts
+++ b/packages/sidecar-core/src/composite-provider-adapter.ts
@@ -18,8 +18,8 @@ import {
   type WorkspaceAgentCapableSessionProviderAdapter,
   type WorkspaceCapableSessionProviderAdapter,
   type WorkspaceProject,
-} from "./providers";
-import type { ProviderSessionObservation, SessionProvider } from "./session";
+} from "./providers.js";
+import type { ProviderSessionObservation, SessionProvider } from "./session.js";
 
 export interface CompositeProviderAdapterOptions {
   provider: SessionProvider;

--- a/packages/sidecar-core/src/fixtures.ts
+++ b/packages/sidecar-core/src/fixtures.ts
@@ -1,11 +1,11 @@
-import { PROVIDER_ID, type ProviderId } from "./providers";
+import { PROVIDER_ID, type ProviderId } from "./providers.js";
 import {
   SESSION_CONTROL_KIND,
   SESSION_LOCATION,
   type SessionControl,
   type SessionLocation,
-} from "./session";
-import { SESSION_URGENCY, type SessionUrgency } from "./session-display";
+} from "./session.js";
+import { SESSION_URGENCY, type SessionUrgency } from "./session-display.js";
 
 /** The workspace a fixture row is one chat of, shaped as the surface draws it. */
 export interface WorkspaceSnapshot {

--- a/packages/sidecar-core/src/geometry.ts
+++ b/packages/sidecar-core/src/geometry.ts
@@ -3,7 +3,7 @@ import {
   PANEL_WIDTH,
   SESSION_NOTICE_HEIGHT,
   VOICE_CAPTION_MAX_HEIGHT,
-} from "./motion-tokens";
+} from "./motion-tokens.js";
 
 export interface Rectangle {
   x: number;

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -16,7 +16,7 @@ export {
   resolveOptions,
   text,
   wholeNumber,
-} from "./json";
+} from "./json.js";
 
 // Sessions — observed state, identity, and the registry that holds them.
 export {
@@ -45,19 +45,19 @@ export {
   type SessionStatus,
   sessionMessageText,
   UNKNOWN_WORKSPACE_LABEL,
-} from "./session";
-export { InMemorySessionRegistry } from "./session-registry";
+} from "./session.js";
+export { InMemorySessionRegistry } from "./session-registry.js";
 export {
   SESSION_NOTICE_STATUS,
   type SessionNotice,
   type SessionNoticeStatus,
   SessionNoticeTracker,
-} from "./session-notices";
+} from "./session-notices.js";
 export {
   CREATED_WORKSPACE_OPEN_WINDOW_MS,
   CreatedWorkspaceOpenTracker,
-} from "./workspace-opens";
-export { MAXIMUM_HELD_NOTICES, SessionNoticeHold } from "./session-notice-hold";
+} from "./workspace-opens.js";
+export { MAXIMUM_HELD_NOTICES, SessionNoticeHold } from "./session-notice-hold.js";
 
 // Calendar — when meetings start and end, and nothing else about them.
 export {
@@ -67,7 +67,7 @@ export {
   MAXIMUM_MEETING_LENGTH_MS,
   type MeetingInterval,
   meetingsFromBusyIntervals,
-} from "./calendar";
+} from "./calendar.js";
 
 // Providers — adapters and the acts they advertise.
 export {
@@ -101,8 +101,8 @@ export {
   type WorkspaceCapableSessionProviderAdapter,
   type WorkspaceProject,
   workspaceNameText,
-} from "./providers";
-export { CompositeSessionProviderAdapter } from "./composite-provider-adapter";
+} from "./providers.js";
+export { CompositeSessionProviderAdapter } from "./composite-provider-adapter.js";
 
 // Issues — tracked work and the two acts a tracker takes.
 export {
@@ -119,7 +119,7 @@ export {
   type TrackerActionResult,
   type TrackerIssueAction,
   type TrackerIssueObservation,
-} from "./issues";
+} from "./issues.js";
 
 // Attention — whether a session change is worth voicing.
 export {
@@ -137,19 +137,19 @@ export {
   maximumAttentionRequestLength,
   SessionAttentionReviewer,
   type SessionNoticeAsk,
-} from "./attention";
+} from "./attention.js";
 export {
   ATTENTION_RESPONSES_PATH,
   attentionResponsesMissingReason,
   attentionResponsesOutputText,
   attentionResponsesRequest,
-} from "./attention-openai";
+} from "./attention-openai.js";
 export {
   type AttentionPromptUpdate,
   attentionInstructions,
   attentionPromptUpdateFromWire,
   attentionUpdateInput,
-} from "./attention-prompt";
+} from "./attention-prompt.js";
 
 // Guide — what the app knows about itself.
 export {
@@ -167,7 +167,7 @@ export {
   type FeedbackComposerKind,
   SESSION_LIST_SORT,
   type SessionListSort,
-} from "./guide";
+} from "./guide.js";
 
 // Voice — Realtime settings, protocol, credentials, context, and tools.
 export {
@@ -180,7 +180,7 @@ export {
   REALTIME_VOICE_SPEED_LIST,
   type RealtimeVoice,
   type RealtimeVoiceSpeed,
-} from "./realtime-voice-settings";
+} from "./realtime-voice-settings.js";
 export {
   announcementSummaryText,
   ATTENTION_SPEECH_SOURCE,
@@ -203,7 +203,7 @@ export {
   type RealtimeStatus,
   truncateResponseEvents,
   typedAskEvents,
-} from "./realtime-protocol";
+} from "./realtime-protocol.js";
 export {
   REALTIME_CALLS_PATH,
   REALTIME_CLIENT_SECRETS_PATH,
@@ -216,7 +216,7 @@ export {
   realtimeCredentialFromResponse,
   realtimeCredentialIsUsable,
   realtimeMintExplanation,
-} from "./realtime-credentials";
+} from "./realtime-credentials.js";
 export {
   appGuideContextEvents,
   CONTEXT_ITEM_KIND,
@@ -238,7 +238,7 @@ export {
   sessionReferenceWithdrawnEvents,
   workspaceProjectContextEvents,
   workspaceProjectContextText,
-} from "./realtime-context";
+} from "./realtime-context.js";
 export {
   type AppToolAction,
   APP_TOOL_KIND,
@@ -258,7 +258,7 @@ export {
   SESSION_TOOL_KIND,
   type SessionToolAction,
   sessionToolAction,
-} from "./realtime-tools";
+} from "./realtime-tools.js";
 
 // Surface — geometry, motion, marks, and labels.
 export {
@@ -275,14 +275,14 @@ export {
   type ResolvedNotchGeometry,
   resolveNotchGeometry,
   type WindowMode,
-} from "./geometry";
+} from "./geometry.js";
 export {
   MOTION_DELAY_MS,
   MOTION_DURATION_MS,
   PANEL_WIDTH,
   SESSION_NOTICE_HEIGHT,
   VOICE_CAPTION_MAX_HEIGHT,
-} from "./motion-tokens";
+} from "./motion-tokens.js";
 export {
   CLAUDE_CODE_PATH,
   CLOUD_BADGE_PATH,
@@ -297,17 +297,17 @@ export {
   OPENAI_PATH,
   OPENCODE_BLOCK_PATH,
   OPENCODE_FRAME_PATH,
-} from "./provider-mark-paths";
+} from "./provider-mark-paths.js";
 export {
   compareSessionsByUrgency,
   SESSION_URGENCY,
   type SessionUrgency,
   urgencyLabel,
-} from "./session-display";
+} from "./session-display.js";
 
 // Fixtures — synthetic snapshots for evidence runs.
 export {
   FIXTURE_EPOCH_MS,
   type FixtureSnapshot,
   fixtureSnapshot,
-} from "./fixtures";
+} from "./fixtures.js";

--- a/packages/sidecar-core/src/providers.ts
+++ b/packages/sidecar-core/src/providers.ts
@@ -1,4 +1,4 @@
-import type { ProviderSessionObservation, SessionControl, SessionProvider } from "./session";
+import type { ProviderSessionObservation, SessionControl, SessionProvider } from "./session.js";
 
 /**
  * Stable provider identifiers shared by adapters, the registry, and the UI.

--- a/packages/sidecar-core/src/realtime-context.ts
+++ b/packages/sidecar-core/src/realtime-context.ts
@@ -1,14 +1,14 @@
-import type { SessionNoticeAsk } from "./attention";
-import { type AppGuideSnapshot, appGuideContextText } from "./guide";
-import type { TrackedIssue } from "./issues";
-import { type ObservedWorkspaceProject, WORKSPACE_TASK_SUPPORT } from "./providers";
+import type { SessionNoticeAsk } from "./attention.js";
+import { type AppGuideSnapshot, appGuideContextText } from "./guide.js";
+import type { TrackedIssue } from "./issues.js";
+import { type ObservedWorkspaceProject, WORKSPACE_TASK_SUPPORT } from "./providers.js";
 import {
   ATTENTION_SPEECH_SOURCE,
   type AttentionSpeech,
   announcementSummaryText,
   REALTIME_CLIENT_EVENT,
-} from "./realtime-protocol";
-import { type NormalizedSession, SESSION_LOCATION } from "./session";
+} from "./realtime-protocol.js";
+import { type NormalizedSession, SESSION_LOCATION } from "./session.js";
 
 /**
  * Roster context serialization: the bounded, redacted view of sessions, issues,

--- a/packages/sidecar-core/src/realtime-credentials.ts
+++ b/packages/sidecar-core/src/realtime-credentials.ts
@@ -1,7 +1,7 @@
-import { isRecord } from "./json";
-import { REALTIME_SESSION_TYPE, realtimeInstructions } from "./realtime-protocol";
-import { realtimeToolDefinitions } from "./realtime-tools";
-import { REALTIME_DEFAULTS } from "./realtime-voice-settings";
+import { isRecord } from "./json.js";
+import { REALTIME_SESSION_TYPE, realtimeInstructions } from "./realtime-protocol.js";
+import { realtimeToolDefinitions } from "./realtime-tools.js";
+import { REALTIME_DEFAULTS } from "./realtime-voice-settings.js";
 
 /**
  * Minting an ephemeral Realtime credential and diagnosing why voice is or is

--- a/packages/sidecar-core/src/realtime-protocol.ts
+++ b/packages/sidecar-core/src/realtime-protocol.ts
@@ -2,15 +2,15 @@ import {
   ATTENTION_REVIEW_OUTCOME,
   type AttentionReview,
   maximumAttentionSummaryLength,
-} from "./attention";
-import { isRecord } from "./json";
-import { spokenRealtimeToolCount } from "./realtime-tools";
+} from "./attention.js";
+import { isRecord } from "./json.js";
+import { spokenRealtimeToolCount } from "./realtime-tools.js";
 import {
   ATTENTION_DISPOSITION,
   type AttentionDisposition,
   maximumSessionMessageLength,
   type SessionIdentity,
-} from "./session";
+} from "./session.js";
 
 /**
  * The Realtime protocol: how far a call has progressed, the events both sides

--- a/packages/sidecar-core/src/realtime-tools.ts
+++ b/packages/sidecar-core/src/realtime-tools.ts
@@ -18,7 +18,7 @@
  * for the main process's. Luke is another way to ask, never a wider one.
  */
 
-import { attentionRequestText, maximumAttentionRequestLength } from "./attention";
+import { attentionRequestText, maximumAttentionRequestLength } from "./attention.js";
 import {
   APP_PANEL_TAB,
   APP_SETTING_KIND,
@@ -34,14 +34,14 @@ import {
   isSessionListSort,
   SESSION_LIST_SORT,
   type SessionListSort,
-} from "./guide";
+} from "./guide.js";
 import {
   type IssueIdentity,
   type IssueTransition,
   issueCommentText,
   type TrackedIssue,
-} from "./issues";
-import { isRecord } from "./json";
+} from "./issues.js";
+import { isRecord } from "./json.js";
 import {
   maximumWorkspaceNameLength,
   type ObservedWorkspaceProject,
@@ -49,8 +49,8 @@ import {
   type WorkspaceAgentModels,
   type WorkspaceAgentSelection,
   workspaceNameText,
-} from "./providers";
-import type { RealtimeFunctionCall } from "./realtime-protocol";
+} from "./providers.js";
+import type { RealtimeFunctionCall } from "./realtime-protocol.js";
 import {
   maximumSessionMessageLength,
   type NormalizedSession,
@@ -59,7 +59,7 @@ import {
   type SessionIdentity,
   sessionMessageText,
   supportsSessionControl,
-} from "./session";
+} from "./session.js";
 
 /** Which process a tool call is about: a session, an issue, or Luke himself. */
 export const REALTIME_TOOL_FAMILY = {

--- a/packages/sidecar-core/src/session-notice-hold.ts
+++ b/packages/sidecar-core/src/session-notice-hold.ts
@@ -1,4 +1,4 @@
-import type { SessionNotice } from "./session-notices";
+import type { SessionNotice } from "./session-notices.js";
 
 /**
  * The most notices a hold keeps. It matches the announcer's own backlog

--- a/packages/sidecar-core/src/session-notices.ts
+++ b/packages/sidecar-core/src/session-notices.ts
@@ -1,5 +1,5 @@
-import type { NormalizedSession, SessionStatus } from "./session";
-import { SESSION_STATUS } from "./session";
+import type { NormalizedSession, SessionStatus } from "./session.js";
+import { SESSION_STATUS } from "./session.js";
 
 /**
  * The statuses worth telling the user about when a session arrives at one.

--- a/packages/sidecar-core/src/session-registry.ts
+++ b/packages/sidecar-core/src/session-registry.ts
@@ -1,4 +1,4 @@
-import type { SessionProviderAdapter } from "./providers";
+import type { SessionProviderAdapter } from "./providers.js";
 import {
   type AttentionDecision,
   type NormalizedSession,
@@ -11,7 +11,7 @@ import {
   type SessionIdentity,
   type SessionProvider,
   type SessionWorkspace,
-} from "./session";
+} from "./session.js";
 
 export interface SessionRegistrySnapshot {
   revision: number;

--- a/packages/sidecar-core/src/workspace-opens.ts
+++ b/packages/sidecar-core/src/workspace-opens.ts
@@ -1,4 +1,4 @@
-import type { NormalizedSession, SessionIdentity } from "./session";
+import type { NormalizedSession, SessionIdentity } from "./session.js";
 
 /**
  * How long a created workspace stays worth opening. The identity arrives the


### PR DESCRIPTION
## What broke

Both hosted endpoints from #182 die at module load in production — `FUNCTION_INVOCATION_FAILED` on every request, before any gate runs. Nothing user-facing is affected: no client calls these endpoints until the desktop work lands, and auth, feedback, and the site are healthy.

## Why

Reproduced offline by running Vercel's own builder (`vercel build`) and loading the compiled function entries under Node 22 semantics. Two stacked resolution failures, invisible to CI:

1. The builder compiles every TypeScript file a function's import graph reaches — including `packages/sidecar-core/src/*` across the workspace boundary — but leaves `package.json` untouched. `@sidecar/core`'s `exports` still names `./src/index.ts` after compilation replaced that file with `index.js`, so the bare specifier resolves to a dangling path at run time.
2. Underneath that, sidecar-core's relative imports were extensionless (`from "./json"`), which Node's ESM loader refuses even in compiled output.

## Fix

- `apps/web/server/core.ts` is the one door server-side code takes to the core: a relative re-export whose path gets extension-rewritten with the rest of the graph. The three hosted modules import through it; client code keeps the bare specifier because Vite bundles it and never resolves it at run time.
- Every relative import inside `packages/sidecar-core/src` now carries the `.js` extension the rest of the workspace already uses. Mechanical sweep; the three generated files carry no relative imports and are untouched (`--check` passes).

## Verification

- Rebuilt both functions with Vercel's builder offline and imported the compiled entries under Node 22: both now resolve fully (load stops only at the expected `DATABASE_URL` demand, satisfied with a placeholder — pg pools are lazy).
- `./scripts/check.sh` passes (exit 0): all 206 core tests, web tests, desktop build (esbuild resolves the `.js`-extension imports), generator drift checks.
- Post-merge smoke test on production: `GET /api/voice/mint` → 405 `method-not-allowed`, unauthenticated `POST` → 401 `invalid-token`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/343d02ab-bf79-4850-a697-40e44a08ac75)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32067742689/artifacts/9300578760) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32067742689)

- Commit: `39eca970612bbdd5adb8be74e659a1f8f4b27222`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
