### PR TITLE
feat(calendar): carry the registered OAuth client without a secret in source

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -23,6 +23,7 @@ secrets is what turns the tag push into the whole release.
 | `APPLE_API_KEY_P8_BASE64` | Base64-encoded App Store Connect API private key | The downloaded `.p8` file from App Store Connect |
 | `APPLE_API_KEY_ID` | Identifies the App Store Connect API key | App Store Connect, Users and Access, Integrations |
 | `APPLE_API_ISSUER_ID` | Identifies the App Store Connect API key issuer | App Store Connect, Users and Access, Integrations |
+| `GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET` | Google Calendar desktop OAuth client secret, baked into the app bundle at package time — a build without it ships no calendar sign-in | Google Cloud console, the Luke project's Desktop client under APIs & Services → Credentials |
 
 ### Export the signing certificate
 
@@ -43,6 +44,7 @@ printf '%s' 'the-p12-password' | gh secret set MACOS_CERTIFICATE_PASSWORD
 base64 -i AuthKey_KEYID.p8 | gh secret set APPLE_API_KEY_P8_BASE64
 printf '%s' 'KEYID' | gh secret set APPLE_API_KEY_ID
 printf '%s' 'issuer-uuid' | gh secret set APPLE_API_ISSUER_ID
+gh secret set GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET
 ```
 
 The commands use macOS `base64`, where `-i` names an input file. Entering the certificate
@@ -97,10 +99,17 @@ Developer ID identity and a stored `luke-notary` notarytool profile
 
 ```sh
 export LUKE_CODESIGN_IDENTITY='Developer ID Application: …'
+export GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET='GOCSPX-…'   # from the Google Cloud console
 pnpm release:macos                    # signs, notarizes, staples; writes the DMG and zip
 git tag v0.1.1 && git push origin v0.1.1
 ./scripts/release/publish-github.sh   # creates the release and uploads every asset
 ```
+
+The calendar secret is baked into the app bundle while packaging — the Google Calendar
+sign-in exists only in builds carrying it, so the builder refuses to run without the
+variable rather than shipping a DMG the integration is silently missing from. It is the
+same value the Actions secret holds; take it from the Luke project's Desktop OAuth
+client under **APIs & Services → Credentials**.
 
 The builder writes both distribution artifacts under `artifacts/release/`, and the
 publish script is what knows the asset set: the versioned DMG and zip with their

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,13 +60,15 @@ jobs:
           APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
           MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
           MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET }}
         run: |
           for secret_name in \
             MACOS_CERTIFICATE_P12_BASE64 \
             MACOS_CERTIFICATE_PASSWORD \
             APPLE_API_KEY_P8_BASE64 \
             APPLE_API_KEY_ID \
-            APPLE_API_ISSUER_ID; do
+            APPLE_API_ISSUER_ID \
+            GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET; do
             if [[ -z "${!secret_name:-}" ]]; then
               echo "error: required GitHub Actions secret is missing: $secret_name" >&2
               exit 1
@@ -110,6 +112,10 @@ jobs:
         run: ./scripts/release/setup-keychain.sh
 
       - name: Package signed application
+        env:
+          # Injected into the main-process bundle by build.mjs; a release
+          # packaged without it would ship no calendar sign-in at all.
+          GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET }}
         run: pnpm package
 
       - name: Verify signed application

--- a/README.md
+++ b/README.md
@@ -64,10 +64,12 @@ two things only — your availability (`calendar.freebusy`) and your calendar
 list — so Google answers Luke with busy intervals, and meeting titles cannot
 even reach the machine. Several accounts can be connected side by side with
 **Add account**, and under each account a checkbox per calendar chooses which
-ones count. The integration appears only in builds carrying a registered
-Google OAuth client (set `GOOGLE_CALENDAR_OAUTH_CLIENT_ID` — and
-`GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET` — to supply your own in development).
-Register that Desktop-app client in the **same Google Cloud project** as the
+ones count. The project's registered client id stands in the source, and packaging a
+release injects its secret from the release environment — so shipped builds
+always offer the integration, while a bare checkout offers it once
+`GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET` is set (with
+`GOOGLE_CALENDAR_OAUTH_CLIENT_ID` to develop against your own registration).
+Register such a Desktop-app client in the **same Google Cloud project** as the
 Luke sign-in's web client: Google's consent-screen branding — the app name,
 logo, and links — is configured per project, so one project is what makes
 both consent pages introduce themselves identically as Luke. The clients

--- a/apps/desktop/scripts/build.mjs
+++ b/apps/desktop/scripts/build.mjs
@@ -33,6 +33,15 @@ await Promise.all([
     format: "cjs",
     target: "node22",
     external: ["electron"],
+    define: {
+      // The Google Calendar client secret rides into the bundle from the
+      // packaging environment rather than sitting in source, where secret
+      // scanners cannot tell a desktop client's published "secret" from a
+      // real one; see google-calendar-oauth.ts.
+      PACKAGED_GOOGLE_CALENDAR_CLIENT_SECRET: JSON.stringify(
+        process.env.GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET ?? "",
+      ),
+    },
     sourcemap: true,
     logLevel: "info",
   }),

--- a/apps/desktop/src/google-calendar-oauth.ts
+++ b/apps/desktop/src/google-calendar-oauth.ts
@@ -17,20 +17,20 @@ import { codeChallenge, createCodeVerifier } from "./account-pkce";
  * this build; what the flow produces is a grant scoped to availability and
  * the calendar list alone, and storing it is the caller's act, not this one's.
  *
- * The flow exists only when a build carries an OAuth client id. A client id
- * is an app registration rather than a secret — installed apps publish theirs
- * in every authorization URL — but registering one is a release act, so a
- * build without one does not offer the integration at all.
+ * The flow exists only when a run holds the whole registration: the client id
+ * standing in source below, and the client secret packaging injects — or the
+ * environment variables that stand in for either during development. A bare
+ * checkout with neither offers the integration not at all.
  */
 
 export interface GoogleCalendarSignInConfig {
   clientId: string;
   /**
    * Google issues desktop OAuth clients a "secret" it documents as not
-   * confidential — every installed copy carries it — but the token endpoint
-   * still expects it for that client type, so it rides along when configured.
+   * confidential — every installed copy carries it — and the token endpoint
+   * expects it for that client type, so a config without one is not offered.
    */
-  clientSecret?: string;
+  clientSecret: string;
 }
 
 const SIGN_IN_ENVIRONMENT = {
@@ -39,22 +39,42 @@ const SIGN_IN_ENVIRONMENT = {
 } as const;
 
 /**
- * The OAuth client a release bakes in. Empty until the project registers one
- * with Google — the environment variables above stand in for development —
- * and while it is empty the sign-in button is not offered at all.
+ * The Google Calendar OAuth client this project registered with Google — the
+ * "Luke" desktop client in the project's own Google Cloud console. A client
+ * id is published in every authorization URL, so it stands in source; the
+ * environment variable above overrides it for development against another
+ * registration.
  */
-const BUILD_CLIENT_ID = "";
-const BUILD_CLIENT_SECRET = "";
+const REGISTERED_GOOGLE_CALENDAR_CLIENT_ID =
+  "346664327893-mg16fmbgb2qtt41fe4kn860kbv6bsaaf.apps.googleusercontent.com";
+
+/**
+ * The registration's secret half. Google documents a desktop client's secret
+ * as not confidential — every installed copy carries it, and PKCE over the
+ * loopback is what actually protects the flow — but repository scanners
+ * cannot tell it from a web client's real one, so it never sits in source:
+ * `build.mjs` defines this identifier from the packaging environment, and a
+ * build packaged without it offers the sign-in only where the environment
+ * variables supply one.
+ */
+declare const PACKAGED_GOOGLE_CALENDAR_CLIENT_SECRET: string | undefined;
+const packagedClientSecret =
+  typeof PACKAGED_GOOGLE_CALENDAR_CLIENT_SECRET === "string"
+    ? PACKAGED_GOOGLE_CALENDAR_CLIENT_SECRET
+    : "";
 
 /** The sign-in this run can offer, or nothing — which hides the button. */
 export function googleCalendarSignInConfig(
   environment: NodeJS.ProcessEnv = process.env,
 ): GoogleCalendarSignInConfig | undefined {
-  const clientId = environment[SIGN_IN_ENVIRONMENT.CLIENT_ID]?.trim() || BUILD_CLIENT_ID;
-  if (!clientId) return undefined;
+  const clientId =
+    environment[SIGN_IN_ENVIRONMENT.CLIENT_ID]?.trim() || REGISTERED_GOOGLE_CALENDAR_CLIENT_ID;
   const clientSecret =
-    environment[SIGN_IN_ENVIRONMENT.CLIENT_SECRET]?.trim() || BUILD_CLIENT_SECRET;
-  return { clientId, ...(clientSecret ? { clientSecret } : {}) };
+    environment[SIGN_IN_ENVIRONMENT.CLIENT_SECRET]?.trim() || packagedClientSecret;
+  // Google's token endpoint expects a desktop client's secret; a flow that
+  // would fail mid-exchange is not offered at all.
+  if (!clientId || !clientSecret) return undefined;
+  return { clientId, clientSecret };
 }
 
 /** Google's documented endpoints for an installed app, fixed by this build. */
@@ -270,7 +290,7 @@ export class GoogleCalendarSignIn {
     const body = new URLSearchParams({
       code,
       client_id: config.clientId,
-      ...(config.clientSecret ? { client_secret: config.clientSecret } : {}),
+      client_secret: config.clientSecret,
       redirect_uri: redirectUri,
       grant_type: "authorization_code",
       code_verifier: verifier,

--- a/apps/desktop/src/google-calendar.ts
+++ b/apps/desktop/src/google-calendar.ts
@@ -275,7 +275,7 @@ export class GoogleCalendarReader {
       grant_type: "refresh_token",
       refresh_token: account.refreshToken,
       client_id: config.clientId,
-      ...(config.clientSecret ? { client_secret: config.clientSecret } : {}),
+      client_secret: config.clientSecret,
     });
     const response = await this.#fetch(GOOGLE_TOKEN_URL, {
       method: "POST",

--- a/apps/desktop/tests/google-calendar-oauth.test.ts
+++ b/apps/desktop/tests/google-calendar-oauth.test.ts
@@ -13,7 +13,11 @@ import { HTTP_STATUS, type RecordedRequest, recordingFetch } from "./support/htt
 const CLIENT_ID = "324871084874-test.apps.googleusercontent.com";
 
 function environment(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
-  return { GOOGLE_CALENDAR_OAUTH_CLIENT_ID: CLIENT_ID, ...overrides };
+  return {
+    GOOGLE_CALENDAR_OAUTH_CLIENT_ID: CLIENT_ID,
+    GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET: "GOCSPX-test-secret",
+    ...overrides,
+  };
 }
 
 /** Follows the redirect the browser would make, code and all. */
@@ -38,11 +42,23 @@ function tokenResponse(): Response {
   );
 }
 
-test("offers no sign-in without a client id", async () => {
+test("the sign-in is offered exactly when the whole registration is held", () => {
+  // A bare checkout holds the registered client id but no secret — packaging
+  // injects that — so it offers no sign-in rather than one that would fail
+  // mid-exchange.
   assert.equal(googleCalendarSignInConfig({}), undefined);
 
-  const signIn = new GoogleCalendarSignIn({ openExternal: () => undefined, environment: {} });
-  assert.deepEqual(await signIn.signIn(), { reason: "Sign-in is not configured in this build." });
+  // The registered id stands in source, so a secret alone — the one thing
+  // packaging injects — completes the registration.
+  const completed = googleCalendarSignInConfig({
+    GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET: "GOCSPX-supplied",
+  });
+  assert.match(completed?.clientId ?? "", /\.apps\.googleusercontent\.com$/);
+  assert.equal(completed?.clientSecret, "GOCSPX-supplied");
+
+  // The variables stand in for development against another registration.
+  const overridden = googleCalendarSignInConfig(environment());
+  assert.equal(overridden?.clientId, CLIENT_ID);
 });
 
 test("runs the documented installed-app flow end to end", async () => {

--- a/apps/desktop/tests/google-calendar.test.ts
+++ b/apps/desktop/tests/google-calendar.test.ts
@@ -60,7 +60,10 @@ function readerWith(
   const { fetch, requests } = recordingFetch(respond);
   const reader = new GoogleCalendarReader({
     readAccounts: async () => accounts,
-    signInConfig: () => ({ clientId: "test-client.apps.googleusercontent.com" }),
+    signInConfig: () => ({
+      clientId: "test-client.apps.googleusercontent.com",
+      clientSecret: "GOCSPX-test-secret",
+    }),
     fetchImplementation: fetch as typeof globalThis.fetch,
     now: () => NOW,
   });

--- a/scripts/release-macos.sh
+++ b/scripts/release-macos.sh
@@ -10,6 +10,12 @@ if [[ -z "${LUKE_CODESIGN_IDENTITY:-}" ]]; then
     printf 'error: LUKE_CODESIGN_IDENTITY must name a Developer ID Application identity\n' >&2
     exit 1
 fi
+# The packaging step bakes this into the app bundle; without it the DMG would
+# ship with no Google Calendar sign-in at all, silently. See .github/RELEASE.md.
+if [[ -z "${GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET:-}" ]]; then
+    printf 'error: GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET must hold the Google Calendar client secret\n' >&2
+    exit 1
+fi
 
 "$SCRIPT_DIRECTORY/check.sh"
 


### PR DESCRIPTION
## What

Makes shipped builds offer the Google Calendar integration without any environment, while keeping the client secret out of the repository (GitHub push protection rightly blocks the `GOCSPX-` pattern — it cannot tell a desktop client's [non-confidential](https://developers.google.com/identity/protocols/oauth2#installed) "secret" from a web client's real one).

- The registered client id is baked into `google-calendar-oauth.ts` under a name that says what it is (`REGISTERED_GOOGLE_CALENDAR_CLIENT_ID`) — a client id is published in every authorization URL, so source is a fine home for it.
- The secret is injected at package time: `build.mjs` defines `PACKAGED_GOOGLE_CALENDAR_CLIENT_SECRET` from `GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET` in the build environment. Verified both ways: a build with the variable carries the secret in `dist/main.js`; a bare build carries neither the secret nor an unreplaced identifier.
- A run holding no secret offers no sign-in at all — Google's token endpoint requires a desktop client's secret, so a flow that would fail mid-exchange is not offered — which makes `clientSecret` required on the config and drops two conditional spreads.
- The release workflow requires the new `GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET` Actions secret (added to the check-secrets gate and the package step), so a release can never silently ship without the integration.
- The environment variables remain the development override for both halves; README updated to match.

## Tests

`./scripts/check.sh` green. The config test now pins the three states: bare checkout → no sign-in; secret alone (what packaging supplies) → completes the registration standing in source; both variables → develop against your own registration.

⚠️ Requires the `GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET` repository Actions secret to exist before the next release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/f759d445-9c57-44b2-bfe6-03fc68476782)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32070598049/artifacts/9301611486) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32070598049)

- Commit: `1f001633fae7f56e96e0b2e18f994afd60b806f7`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
