### PR TITLE
feat(voice): run voice and session review on the signed-in account without a key

### DIFF
--- a/apps/desktop/src/account-token-lifecycle.ts
+++ b/apps/desktop/src/account-token-lifecycle.ts
@@ -1,5 +1,24 @@
 import type { AccountTokens } from "./account-client";
 
+/**
+ * Collapses concurrent asks for a refresh into one in-flight run, and every
+ * caller awaits that run's outcome. The refresh token rotates when spent, so
+ * two refreshes racing — a hosted mint and a review both answering 401 at the
+ * hour mark — would have the loser spend an already-rotated token, and the
+ * token endpoint's `invalid_grant` for it reads as revocation: a sign-out
+ * right after a successful refresh. A run that ends, ends the flight; the next
+ * ask starts a fresh one holding the newly rotated token.
+ */
+export function singleFlight(run: () => Promise<void>): () => Promise<void> {
+  let running: Promise<void> | undefined;
+  return () => {
+    running ??= run().finally(() => {
+      running = undefined;
+    });
+    return running;
+  };
+}
+
 /** Ensures credentials rejected before sign-in completes do not outlive the failed attempt. */
 export async function withIssuedAccountTokens<T>(options: {
   issue: () => Promise<AccountTokens>;

--- a/apps/desktop/src/hosted-attention-evaluator.ts
+++ b/apps/desktop/src/hosted-attention-evaluator.ts
@@ -152,6 +152,10 @@ export class HostedAttentionEvaluator implements AttentionEvaluator {
   }
 
   async #request(token: string, update: AttentionUpdate): Promise<Response | undefined> {
+    // The kind of call and nothing else: the update, the token, and the
+    // decision stay out of the log. The model is the service's choice, so it
+    // has no name to log.
+    console.log("AI call: hosted attention review");
     try {
       return await this.#fetch(this.#endpoint, {
         method: "POST",

--- a/apps/desktop/src/hosted-attention-evaluator.ts
+++ b/apps/desktop/src/hosted-attention-evaluator.ts
@@ -1,0 +1,176 @@
+import {
+  type AttentionDecision,
+  type AttentionEvaluator,
+  type AttentionPromptUpdate,
+  type AttentionUpdate,
+  HOSTED_SERVICE_PATH,
+  hostedQuotaFromWire,
+  hostedReviewAnswerFromWire,
+  isRecord,
+  positiveInteger,
+  text,
+} from "@sidecar/core";
+
+const HOSTED_DEFAULTS = {
+  REQUEST_TIMEOUT_MS: 15_000,
+  /** The keyed evaluator's cooldown, for a 429 that names no reset of its own. */
+  RATE_LIMIT_COOLDOWN_MS: 60_000,
+} as const;
+
+const UNAUTHORIZED_STATUS = 401;
+const QUOTA_STATUS = 429;
+
+type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
+
+export interface HostedAttentionEvaluatorOptions {
+  /** The hosted service origin, without a trailing slash. */
+  serviceBaseUrl: string;
+  readAccessToken: () => Promise<string | undefined>;
+  refreshAccount: () => Promise<void>;
+  fetch?: FetchLike;
+  now?: () => number;
+  requestTimeoutMs?: number;
+}
+
+function withoutTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+/**
+ * Exactly the fields the review's prompt reads, picked rather than spread: an
+ * update also carries the session's identifiers and clock, and neither has any
+ * business leaving the machine — the hosted service renders the same prompt
+ * the keyed evaluator would have, from the same bounded fields.
+ */
+function promptFields(update: AttentionUpdate): AttentionPromptUpdate {
+  return {
+    trigger: update.trigger,
+    providerName: update.providerName,
+    title: update.title,
+    status: update.status,
+    ...(update.workspace ? { workspace: update.workspace } : {}),
+    ...(update.previousStatus ? { previousStatus: update.previousStatus } : {}),
+    ...(update.recap ? { recap: update.recap } : {}),
+    ...(update.context ? { context: update.context } : {}),
+    ...(update.noticeRequest ? { noticeRequest: update.noticeRequest } : {}),
+  };
+}
+
+/**
+ * Reviews bounded session updates through Luke's hosted service on the
+ * signed-in account, for a developer with no OpenAI key of their own. What
+ * leaves the machine is identical to the keyed evaluator's input — the bounded
+ * update, nothing behind it — it merely travels by way of Luke's service,
+ * which holds the instructions and the decision schema fixed by its own build.
+ * A failure answers nothing, and a spent allowance stands the evaluator down
+ * until the day's counters reset rather than spending refusals on it.
+ */
+export class HostedAttentionEvaluator implements AttentionEvaluator {
+  readonly #endpoint: string;
+  readonly #readAccessToken: () => Promise<string | undefined>;
+  readonly #refreshAccount: () => Promise<void>;
+  readonly #fetch: FetchLike;
+  readonly #now: () => number;
+  readonly #requestTimeoutMs: number;
+  /** Until when reviews stay unsent, as epoch milliseconds. */
+  #quietUntil = 0;
+
+  constructor(options: HostedAttentionEvaluatorOptions) {
+    const baseUrl = text(options.serviceBaseUrl);
+    if (!baseUrl) throw new Error("Hosted service base URL must not be empty");
+    this.#endpoint = `${withoutTrailingSlash(baseUrl)}${HOSTED_SERVICE_PATH.ATTENTION_REVIEW}`;
+    this.#readAccessToken = options.readAccessToken;
+    this.#refreshAccount = options.refreshAccount;
+    this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
+    this.#now = options.now ?? Date.now;
+    this.#requestTimeoutMs = positiveInteger(
+      options.requestTimeoutMs,
+      HOSTED_DEFAULTS.REQUEST_TIMEOUT_MS,
+    );
+  }
+
+  /** The moment held-back reviews resume, for the reviewer to ask before a pass. */
+  quietUntil(): number | undefined {
+    return this.#quietUntil > this.#now() ? this.#quietUntil : undefined;
+  }
+
+  async evaluate(update: AttentionUpdate): Promise<AttentionDecision | undefined> {
+    if (this.#now() < this.#quietUntil) return undefined;
+
+    const token = await this.#readAccessToken();
+    if (!token) return undefined;
+
+    let response = await this.#request(token, update);
+    if (response?.status === UNAUTHORIZED_STATUS) {
+      // Routine expiry of an hour-lived token inside a day-lived app: refresh
+      // and retry once, like the hosted mint.
+      await this.#refreshAccount().catch(() => undefined);
+      const refreshed = await this.#readAccessToken();
+      if (refreshed && refreshed !== token) {
+        response = await this.#request(refreshed, update);
+      }
+    }
+    if (!response) return undefined;
+
+    if (!response.ok) {
+      if (response.status === QUOTA_STATUS) {
+        await this.#quiet(response);
+        return undefined;
+      }
+      // Status alone diagnoses the refusal without writing session material.
+      this.#report(`Hosted attention review failed with status ${response.status}`);
+      return undefined;
+    }
+
+    const payload: unknown = await response.json().catch(() => undefined);
+    const answer =
+      payload === undefined ? undefined : hostedReviewAnswerFromWire(payload, this.#now());
+    if (!answer) {
+      this.#report("Hosted attention review answered outside the decision contract");
+      return undefined;
+    }
+    return answer.decision;
+  }
+
+  /**
+   * Stands reviews down until the day's counters reset, taking the refusal's
+   * own word for when that is. Updates held back stay derivable and are
+   * reviewed once the quiet ends, exactly like the keyed evaluator's 429.
+   */
+  async #quiet(response: Response): Promise<void> {
+    const payload: unknown = await response.json().catch(() => undefined);
+    const quota = isRecord(payload) ? hostedQuotaFromWire(payload.quota) : undefined;
+    const resetsAt = quota?.resetsAt;
+    this.#quietUntil =
+      resetsAt !== undefined && resetsAt > this.#now()
+        ? resetsAt
+        : this.#now() + HOSTED_DEFAULTS.RATE_LIMIT_COOLDOWN_MS;
+    const waitMs = Math.max(0, this.#quietUntil - this.#now());
+    this.#report(
+      `Hosted attention reviews are out of today's allowance; pausing for ${Math.round(waitMs / 1000)}s`,
+    );
+  }
+
+  async #request(token: string, update: AttentionUpdate): Promise<Response | undefined> {
+    try {
+      return await this.#fetch(this.#endpoint, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(promptFields(update)),
+        signal: AbortSignal.timeout(this.#requestTimeoutMs),
+      });
+    } catch (error) {
+      this.#report(
+        `Hosted attention review did not complete: ${error instanceof Error ? error.name : "unknown error"}`,
+      );
+      return undefined;
+    }
+  }
+
+  #report(message: string): void {
+    process.stderr.write(`${message}\n`);
+  }
+}

--- a/apps/desktop/src/hosted-realtime-credentials.ts
+++ b/apps/desktop/src/hosted-realtime-credentials.ts
@@ -191,6 +191,10 @@ export class HostedRealtimeCredentialMinter implements RealtimeCredentialMinter 
   }
 
   async #request(token: string): Promise<Response | undefined> {
+    // The kind of call and nothing else: the token, the preferences, and the
+    // minted secret stay out of the log. The model is the service's choice, so
+    // it has no name to log until the answer arrives.
+    console.log("AI call: hosted realtime voice credential mint");
     try {
       return await this.#fetch(this.#endpoint, {
         method: "POST",

--- a/apps/desktop/src/hosted-realtime-credentials.ts
+++ b/apps/desktop/src/hosted-realtime-credentials.ts
@@ -1,0 +1,238 @@
+import {
+  HOSTED_API_ERROR,
+  HOSTED_SERVICE_PATH,
+  type HostedQuota,
+  hostedErrorFromWire,
+  hostedMintAnswerFromWire,
+  hostedQuotaFromWire,
+  isRealtimeVoice,
+  isRealtimeVoiceSpeed,
+  isRecord,
+  nonNegativeNumber,
+  positiveInteger,
+  REALTIME_DEFAULTS,
+  REALTIME_MINT_OUTCOME,
+  type RealtimeConnection,
+  type RealtimeDiagnostics,
+  type RealtimeMintOutcome,
+  realtimeCredentialIsUsable,
+  text,
+} from "@sidecar/core";
+import type { RealtimeCredentialMinter } from "./realtime-minter";
+
+const HOSTED_DEFAULTS = {
+  REQUEST_TIMEOUT_MS: 10_000,
+  /** The same pre-expiry margin the keyed minter keeps, for the same SDP round trip. */
+  EXPIRY_MARGIN_MS: 5_000,
+} as const;
+
+const UNAUTHORIZED_STATUS = 401;
+const QUOTA_STATUS = 429;
+const UNAVAILABLE_STATUS = 503;
+
+type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
+
+export interface HostedRealtimeCredentialOptions {
+  /** The hosted service origin, without a trailing slash. */
+  serviceBaseUrl: string;
+  /** The signed-in account's current access token, read fresh for every mint. */
+  readAccessToken: () => Promise<string | undefined>;
+  /**
+   * Asks the account lifecycle to refresh its tokens. Access tokens outlive a
+   * mint by an hour at most while the app runs for days, so a 401 here is
+   * routine — the mint retries once with whatever the refresh produced, and
+   * only a second refusal is reported.
+   */
+  refreshAccount: () => Promise<void>;
+  voice?: string;
+  speed?: number;
+  fetch?: FetchLike;
+  now?: () => number;
+  requestTimeoutMs?: number;
+  expiryMarginMs?: number;
+}
+
+function withoutTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+/**
+ * Mints ephemeral Realtime credentials from Luke's hosted service on the
+ * signed-in account, for a developer who has not connected an OpenAI key of
+ * their own. The shape mirrors the keyed minter deliberately: the renderer
+ * still receives only an ephemeral secret aimed at OpenAI's canonical calls
+ * endpoint, a failure resolves to nothing rather than an error, and the
+ * diagnostics say why — including the day's allowance, which is what the
+ * refusal a spent quota answers with is diagnosed from.
+ */
+export class HostedRealtimeCredentialMinter implements RealtimeCredentialMinter {
+  readonly #endpoint: string;
+  readonly #readAccessToken: () => Promise<string | undefined>;
+  readonly #refreshAccount: () => Promise<void>;
+  /** The voice from construction, which a cleared setting falls back to. */
+  readonly #configuredVoice: string | undefined;
+  #voice: string | undefined;
+  readonly #configuredSpeed: number | undefined;
+  #speed: number | undefined;
+  readonly #fetch: FetchLike;
+  readonly #now: () => number;
+  readonly #requestTimeoutMs: number;
+  readonly #expiryMarginMs: number;
+  #credential: RealtimeConnection | undefined;
+  #lastModel: string | undefined;
+  #lastOutcome: RealtimeMintOutcome = REALTIME_MINT_OUTCOME.NOT_ATTEMPTED;
+  #lastDetail: string | undefined;
+  #lastAttemptAt: number | undefined;
+  #quota: HostedQuota | undefined;
+
+  constructor(options: HostedRealtimeCredentialOptions) {
+    const baseUrl = text(options.serviceBaseUrl);
+    if (!baseUrl) throw new Error("Hosted service base URL must not be empty");
+    this.#endpoint = `${withoutTrailingSlash(baseUrl)}${HOSTED_SERVICE_PATH.VOICE_MINT}`;
+    this.#readAccessToken = options.readAccessToken;
+    this.#refreshAccount = options.refreshAccount;
+    this.#configuredVoice = text(options.voice);
+    this.#voice = this.#configuredVoice;
+    this.#configuredSpeed = options.speed;
+    this.#speed = this.#configuredSpeed;
+    this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
+    this.#now = options.now ?? Date.now;
+    this.#requestTimeoutMs = positiveInteger(
+      options.requestTimeoutMs,
+      HOSTED_DEFAULTS.REQUEST_TIMEOUT_MS,
+    );
+    this.#expiryMarginMs = nonNegativeNumber(
+      options.expiryMarginMs,
+      HOSTED_DEFAULTS.EXPIRY_MARGIN_MS,
+    );
+  }
+
+  /** The same discard rule as the keyed minter: an outstanding credential was minted for the old voice. */
+  setVoice(voice: string | undefined): void {
+    const next = text(voice) ?? this.#configuredVoice;
+    if (next === this.#voice) return;
+    this.#voice = next;
+    this.#credential = undefined;
+  }
+
+  setSpeed(speed: number | undefined): void {
+    const next = speed ?? this.#configuredSpeed;
+    if (next === this.#speed) return;
+    this.#speed = next;
+    this.#credential = undefined;
+  }
+
+  /** Returns a usable credential, reusing the outstanding one until it nears expiry. */
+  async mint(): Promise<RealtimeConnection | undefined> {
+    const existing = this.#credential;
+    if (existing && realtimeCredentialIsUsable(existing, this.#now() + this.#expiryMarginMs)) {
+      return existing;
+    }
+    this.#credential = undefined;
+    this.#lastAttemptAt = this.#now();
+
+    const token = await this.#readAccessToken();
+    if (!token) {
+      this.#record(REALTIME_MINT_OUTCOME.NOT_SIGNED_IN, "no access token");
+      return undefined;
+    }
+
+    let response = await this.#request(token);
+    if (response?.status === UNAUTHORIZED_STATUS) {
+      // Routine expiry of an hour-lived token inside a day-lived app: refresh
+      // and retry once. A retry on the same token would only repeat the no.
+      await this.#refreshAccount().catch(() => undefined);
+      const refreshed = await this.#readAccessToken();
+      if (refreshed && refreshed !== token) {
+        response = await this.#request(refreshed);
+      }
+    }
+    if (!response) return undefined;
+
+    const payload: unknown = await response.json().catch(() => undefined);
+    if (!response.ok) {
+      this.#refuse(response.status, payload);
+      return undefined;
+    }
+
+    const answer =
+      payload === undefined ? undefined : hostedMintAnswerFromWire(payload, this.#now());
+    if (!answer) {
+      this.#record(REALTIME_MINT_OUTCOME.MALFORMED_RESPONSE, "no usable hosted credential");
+      return undefined;
+    }
+
+    this.#credential = answer.connection;
+    this.#lastModel = answer.connection.model;
+    this.#quota = answer.quota ?? this.#quota;
+    this.#record(REALTIME_MINT_OUTCOME.SUCCEEDED);
+    return answer.connection;
+  }
+
+  diagnostics(): RealtimeDiagnostics {
+    return {
+      apiKeyConfigured: false,
+      hosted: true,
+      fixtureMode: false,
+      model: this.#lastModel ?? REALTIME_DEFAULTS.MODEL,
+      voice: this.#voice ?? REALTIME_DEFAULTS.VOICE,
+      speed: this.#speed ?? REALTIME_DEFAULTS.SPEED,
+      endpoint: this.#endpoint,
+      lastOutcome: this.#lastOutcome,
+      ...(this.#lastDetail ? { lastDetail: this.#lastDetail } : {}),
+      ...(this.#lastAttemptAt === undefined ? {} : { lastAttemptAt: this.#lastAttemptAt }),
+      ...(this.#quota ? { quota: this.#quota } : {}),
+    };
+  }
+
+  /** Names a refusal from its status and reason, keeping the quota a 429 carries. */
+  #refuse(status: number, payload: unknown): void {
+    const reason = hostedErrorFromWire(payload);
+    if (status === QUOTA_STATUS && reason === HOSTED_API_ERROR.QUOTA_EXHAUSTED) {
+      this.#quota = isRecord(payload) ? hostedQuotaFromWire(payload.quota) : undefined;
+      this.#record(REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED);
+      return;
+    }
+    if (status === UNAVAILABLE_STATUS) {
+      this.#record(REALTIME_MINT_OUTCOME.HOSTED_UNAVAILABLE);
+      return;
+    }
+    if (status === UNAUTHORIZED_STATUS) {
+      this.#record(REALTIME_MINT_OUTCOME.NOT_SIGNED_IN, `status ${status}`);
+      return;
+    }
+    this.#record(REALTIME_MINT_OUTCOME.HTTP_ERROR, `status ${status}`);
+  }
+
+  async #request(token: string): Promise<Response | undefined> {
+    try {
+      return await this.#fetch(this.#endpoint, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        // Only values inside the build's own sets travel; anything else lets
+        // the service mint its default rather than sending a refusable field.
+        body: JSON.stringify({
+          ...(isRealtimeVoice(this.#voice) ? { voice: this.#voice } : {}),
+          ...(isRealtimeVoiceSpeed(this.#speed) ? { speed: this.#speed } : {}),
+        }),
+        signal: AbortSignal.timeout(this.#requestTimeoutMs),
+      });
+    } catch (error) {
+      this.#record(
+        REALTIME_MINT_OUTCOME.NETWORK_ERROR,
+        error instanceof Error ? error.name : "unknown error",
+      );
+      return undefined;
+    }
+  }
+
+  #record(outcome: RealtimeMintOutcome, detail?: string): void {
+    this.#lastOutcome = outcome;
+    this.#lastDetail = detail;
+    if (outcome === REALTIME_MINT_OUTCOME.SUCCEEDED) return;
+    process.stderr.write(`Hosted realtime mint: ${outcome}${detail ? ` (${detail})` : ""}\n`);
+  }
+}

--- a/apps/desktop/src/hosted-realtime-credentials.ts
+++ b/apps/desktop/src/hosted-realtime-credentials.ts
@@ -8,22 +8,18 @@ import {
   isRealtimeVoice,
   isRealtimeVoiceSpeed,
   isRecord,
-  nonNegativeNumber,
   positiveInteger,
   REALTIME_DEFAULTS,
   REALTIME_MINT_OUTCOME,
   type RealtimeConnection,
   type RealtimeDiagnostics,
   type RealtimeMintOutcome,
-  realtimeCredentialIsUsable,
   text,
 } from "@sidecar/core";
 import type { RealtimeCredentialMinter } from "./realtime-minter";
 
 const HOSTED_DEFAULTS = {
   REQUEST_TIMEOUT_MS: 10_000,
-  /** The same pre-expiry margin the keyed minter keeps, for the same SDP round trip. */
-  EXPIRY_MARGIN_MS: 5_000,
 } as const;
 
 const UNAUTHORIZED_STATUS = 401;
@@ -49,7 +45,6 @@ export interface HostedRealtimeCredentialOptions {
   fetch?: FetchLike;
   now?: () => number;
   requestTimeoutMs?: number;
-  expiryMarginMs?: number;
 }
 
 function withoutTrailingSlash(value: string): string {
@@ -77,8 +72,6 @@ export class HostedRealtimeCredentialMinter implements RealtimeCredentialMinter 
   readonly #fetch: FetchLike;
   readonly #now: () => number;
   readonly #requestTimeoutMs: number;
-  readonly #expiryMarginMs: number;
-  #credential: RealtimeConnection | undefined;
   #lastModel: string | undefined;
   #lastOutcome: RealtimeMintOutcome = REALTIME_MINT_OUTCOME.NOT_ATTEMPTED;
   #lastDetail: string | undefined;
@@ -101,34 +94,28 @@ export class HostedRealtimeCredentialMinter implements RealtimeCredentialMinter 
       options.requestTimeoutMs,
       HOSTED_DEFAULTS.REQUEST_TIMEOUT_MS,
     );
-    this.#expiryMarginMs = nonNegativeNumber(
-      options.expiryMarginMs,
-      HOSTED_DEFAULTS.EXPIRY_MARGIN_MS,
-    );
   }
 
-  /** The same discard rule as the keyed minter: an outstanding credential was minted for the old voice. */
+  /**
+   * Changes the voice new credentials are minted for. A call already open
+   * keeps the voice it answered with, the keyed minter's own rule.
+   */
   setVoice(voice: string | undefined): void {
-    const next = text(voice) ?? this.#configuredVoice;
-    if (next === this.#voice) return;
-    this.#voice = next;
-    this.#credential = undefined;
+    this.#voice = text(voice) ?? this.#configuredVoice;
   }
 
   setSpeed(speed: number | undefined): void {
-    const next = speed ?? this.#configuredSpeed;
-    if (next === this.#speed) return;
-    this.#speed = next;
-    this.#credential = undefined;
+    this.#speed = speed ?? this.#configuredSpeed;
   }
 
-  /** Returns a usable credential, reusing the outstanding one until it nears expiry. */
+  /**
+   * Mints a fresh credential for every call, the keyed minter's own rule: the
+   * service has been seen to refuse a reused secret at the calls endpoint
+   * (status 401) even inside its stated expiry, and a refused call in the
+   * announcer's path is an announcement lost. This is also what the hosted
+   * allowance counts — each mint answers exactly one call.
+   */
   async mint(): Promise<RealtimeConnection | undefined> {
-    const existing = this.#credential;
-    if (existing && realtimeCredentialIsUsable(existing, this.#now() + this.#expiryMarginMs)) {
-      return existing;
-    }
-    this.#credential = undefined;
     this.#lastAttemptAt = this.#now();
 
     const token = await this.#readAccessToken();
@@ -162,7 +149,6 @@ export class HostedRealtimeCredentialMinter implements RealtimeCredentialMinter 
       return undefined;
     }
 
-    this.#credential = answer.connection;
     this.#lastModel = answer.connection.model;
     this.#quota = answer.quota ?? this.#quota;
     this.#record(REALTIME_MINT_OUTCOME.SUCCEEDED);

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -80,7 +80,7 @@ import {
   SIGN_IN_CANCELLED_MESSAGE,
   startAccountLoopback,
 } from "./account-loopback";
-import { withIssuedAccountTokens } from "./account-token-lifecycle";
+import { singleFlight, withIssuedAccountTokens } from "./account-token-lifecycle";
 import { CLAUDE_CODE_PROVIDER, ClaudeCodeSessionAdapter } from "./claude-code-adapter";
 import {
   CLAUDE_HOOK_SCRIPT_NAME,
@@ -791,12 +791,17 @@ function reportVoiceAvailability(apiKeyConfigured: boolean): void {
  * The seams the hosted clients reach the account through. The token is read
  * fresh from the store on every use — the lifecycle owns rotation — and a 401
  * asks that same lifecycle for a refresh rather than growing a second one.
+ * The refresh is single-flighted because its token rotates when spent: a mint
+ * and a review both answering 401 at the hour mark must share one refresh, or
+ * the loser's spent token reads as revocation and signs the account out.
  */
+const refreshStoredAccountOnce = singleFlight(() => refreshStoredAccount());
+
 function hostedServiceSeams() {
   return {
     serviceBaseUrl: HOSTED_SERVICE_BASE_URL,
     readAccessToken: async () => (await settingsStore.readAccount())?.accessToken,
-    refreshAccount: () => refreshStoredAccount(),
+    refreshAccount: refreshStoredAccountOnce,
   };
 }
 
@@ -2953,7 +2958,7 @@ if (!app.requestSingleInstanceLock()) {
     startCalendarObservation();
     // Reconcile in the background. Only an explicit invalid_grant removes the
     // stored account; network failures and service outages leave it active.
-    void refreshStoredAccount();
+    void refreshStoredAccountOnce();
 
     screen.on("display-added", handleDisplayChange);
     screen.on("display-removed", handleDisplayChange);

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -395,6 +395,15 @@ const attentionRequests = new AttentionRequestRegistry();
  */
 let attentionReviewer: SessionAttentionReviewer | undefined;
 let realtimeCredentials: RealtimeCredentialMinter | undefined;
+/**
+ * What the diagnostics ask answers while no minter exists. Kept current by
+ * `applyVoiceCredential`, which is the only place that knows whether a key
+ * failed to resolve or a run refuses credentials outright.
+ */
+let voiceUnavailableDiagnostics = unavailableRealtimeDiagnostics({
+  fixtureMode: !runMode.sendsNetwork,
+  apiKeyConfigured: false,
+});
 // Quiets Music and Spotify while a spoken exchange is live. It lives here
 // rather than in the renderer because letting the players back up must survive
 // anything the renderer does — and only this process may run a helper.
@@ -853,6 +862,10 @@ async function applyVoiceCredential(): Promise<void> {
           ...(speed ? { speed } : {}),
         })
       : undefined;
+  voiceUnavailableDiagnostics = unavailableRealtimeDiagnostics({
+    fixtureMode: !runMode.sendsNetwork,
+    apiKeyConfigured: apiKey !== undefined,
+  });
   reportVoiceAvailability(apiKey !== undefined);
 }
 
@@ -2160,6 +2173,11 @@ function registerIpc(): void {
     // Returning nothing rather than throwing keeps "no credentials configured"
     // and "the mint failed" on the same explicit, non-fatal path.
     return realtimeCredentials?.mint();
+  });
+
+  ipcMain.handle(channels.requestRealtimeDiagnostics, (event) => {
+    if (!trustedSender(event)) throw new Error("Untrusted renderer");
+    return realtimeCredentials?.diagnostics() ?? voiceUnavailableDiagnostics;
   });
 
   ipcMain.on(channels.quit, (event) => {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -14,6 +14,7 @@ import {
   CreatedWorkspaceOpenTracker,
   DEFAULT_PANEL_FORM_FACTOR,
   fixtureSnapshot,
+  HOSTED_SERVICE_PATH,
   InMemorySessionRegistry,
   ISSUE_ACTION_KIND,
   isControllableAdapter,
@@ -802,6 +803,23 @@ function reportVoiceAvailability(apiKeyConfigured: boolean): void {
 }
 
 /**
+ * Pays the mint function's cold start before the first press needs it. The
+ * hosted mint runs in a serverless function that unloads between uses, and a
+ * cold one adds seconds to exactly the moment someone is already speaking —
+ * a press released mid-connect abandons the attempt by design, so the first
+ * exchange after launch was being lost to startup the developer never sees.
+ * The GET carries nothing, authenticates nothing, and spends nothing: the
+ * endpoint answers it 405 by design, and loading the module to say no is the
+ * entire point.
+ */
+function warmHostedVoice(): void {
+  fetch(`${HOSTED_SERVICE_BASE_URL}${HOSTED_SERVICE_PATH.VOICE_MINT}`, {
+    method: "GET",
+    signal: AbortSignal.timeout(10_000),
+  }).catch(() => undefined);
+}
+
+/**
  * Reads the OpenAI key and rebuilds everything that runs on it.
  *
  * This is the whole of turning voice on and off. It runs once at startup and
@@ -881,6 +899,8 @@ async function applyVoiceCredential(): Promise<void> {
     fixtureMode: !runMode.sendsNetwork,
     apiKeyConfigured: apiKey !== undefined,
   });
+  // Warm only when the next press would actually mint through the service.
+  if (hosted) warmHostedVoice();
   reportVoiceAvailability(apiKey !== undefined);
 }
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -110,13 +110,14 @@ import { DockPresence } from "./dock-presence";
 import { feedbackDeliveryFromEnvironment } from "./feedback-delivery";
 import { GoogleCalendarReader } from "./google-calendar";
 import { GoogleCalendarSignIn } from "./google-calendar-oauth";
+import { HostedAttentionEvaluator } from "./hosted-attention-evaluator";
+import { HostedRealtimeCredentialMinter } from "./hosted-realtime-credentials";
 import { HOTKEY_RANK, HotkeyRegistrar } from "./hotkey-registrar";
 import { JulesSessionAdapter } from "./jules-adapter";
 import { LinearIssueTracker } from "./linear-tracker";
 import { MediaDuckController } from "./media-duck";
 import { openAiAttentionEvaluator } from "./openai-attention-evaluator";
 import {
-  type OpenAiRealtimeCredentialMinter,
   openAiRealtimeCredentials,
   unavailableRealtimeDiagnostics,
 } from "./openai-realtime-credentials";
@@ -124,6 +125,7 @@ import { OpenCodeSessionAdapter } from "./opencode-adapter";
 import { readOpenCodeSessionTranscript } from "./opencode-transcript";
 import { OutputVolumeWatcher } from "./output-volume";
 import { PanelManager } from "./panel-manager";
+import type { RealtimeCredentialMinter } from "./realtime-minter";
 import { runModeFor } from "./run-mode";
 import { sessionNoticeSpeech } from "./session-notifications";
 import { createSettingsHandler, SettingsRefusal } from "./settings-handler";
@@ -185,6 +187,10 @@ const runMode = runModeFor({ capture: captureMode, fixture: fixtureName !== unde
 const ACCOUNT_BASE_URL =
   (app.isPackaged ? undefined : process.env.LUKE_ACCOUNT_BASE_URL) ??
   "https://tryluke.dev/api/auth";
+// The hosted voice and attention endpoints live on the same origin as the
+// account service, so the one development override redirects both together —
+// a build pointed at a local account service reviews and mints against it too.
+const HOSTED_SERVICE_BASE_URL = ACCOUNT_BASE_URL.replace(/\/api\/auth\/?$/, "");
 const ACCOUNT_CLIENT_ID = "luke-desktop";
 const SESSION_REFRESH_INTERVAL_MS = 5_000;
 const sessionRegistry = new InMemorySessionRegistry();
@@ -388,7 +394,7 @@ const attentionRequests = new AttentionRequestRegistry();
  * without a network.
  */
 let attentionReviewer: SessionAttentionReviewer | undefined;
-let realtimeCredentials: OpenAiRealtimeCredentialMinter | undefined;
+let realtimeCredentials: RealtimeCredentialMinter | undefined;
 // Quiets Music and Spotify while a spoken exchange is live. It lives here
 // rather than in the renderer because letting the players back up must survive
 // anything the renderer does — and only this process may run a helper.
@@ -757,7 +763,9 @@ function isIssueActionAsk(value: unknown): value is {
 function reportVoiceAvailability(apiKeyConfigured: boolean): void {
   if (realtimeCredentials) {
     const report = realtimeCredentials.diagnostics();
-    process.stderr.write(`Luke voice: enabled (${report.model})\n`);
+    process.stderr.write(
+      `Luke voice: enabled (${report.hosted ? "hosted, " : ""}${report.model})\n`,
+    );
     return;
   }
   const report = unavailableRealtimeDiagnostics({
@@ -779,6 +787,19 @@ function reportVoiceAvailability(apiKeyConfigured: boolean): void {
  * is not moved here: only a change while the app is running needs that, and
  * `hotkeys.reapply` is what does it.
  */
+/**
+ * The seams the hosted clients reach the account through. The token is read
+ * fresh from the store on every use — the lifecycle owns rotation — and a 401
+ * asks that same lifecycle for a refresh rather than growing a second one.
+ */
+function hostedServiceSeams() {
+  return {
+    serviceBaseUrl: HOSTED_SERVICE_BASE_URL,
+    readAccessToken: async () => (await settingsStore.readAccount())?.accessToken,
+    refreshAccount: () => refreshStoredAccount(),
+  };
+}
+
 async function applyVoiceCredential(): Promise<void> {
   // A fixture run does not ask for the key at all: reading a stored one means a
   // Keychain decrypt, which a run that would refuse to use it has no business
@@ -788,7 +809,17 @@ async function applyVoiceCredential(): Promise<void> {
     runMode.sendsNetwork && accountCapabilitiesActive()
       ? await settingsStore.readApiKey(VOICE_CREDENTIAL_PROVIDER_ID)
       : undefined;
-  const evaluator = openAiAttentionEvaluator(apiKey);
+  // The hosted service stands in exactly where a key could have: a run that
+  // sends network traffic, signed in, with no key of the developer's own. The
+  // developer's key wins when both are present — it is unmetered, and it keeps
+  // voice and review off Luke's servers entirely.
+  const hosted =
+    apiKey === undefined && runMode.sendsNetwork && account.status === ACCOUNT_STATUS.SIGNED_IN;
+  const evaluator = apiKey
+    ? openAiAttentionEvaluator(apiKey)
+    : hosted
+      ? new HostedAttentionEvaluator(hostedServiceSeams())
+      : undefined;
   attentionReviewer = evaluator
     ? new SessionAttentionReviewer({
         evaluator,
@@ -805,10 +836,18 @@ async function applyVoiceCredential(): Promise<void> {
     settingsStore.readVoice().catch(() => undefined),
     settingsStore.readVoiceSpeed().catch(() => undefined),
   ]);
-  realtimeCredentials = openAiRealtimeCredentials(apiKey, {
-    ...(voice ? { voice } : {}),
-    ...(speed ? { speed } : {}),
-  });
+  realtimeCredentials = apiKey
+    ? openAiRealtimeCredentials(apiKey, {
+        ...(voice ? { voice } : {}),
+        ...(speed ? { speed } : {}),
+      })
+    : hosted
+      ? new HostedRealtimeCredentialMinter({
+          ...hostedServiceSeams(),
+          ...(voice ? { voice } : {}),
+          ...(speed ? { speed } : {}),
+        })
+      : undefined;
   reportVoiceAvailability(apiKey !== undefined);
 }
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -535,9 +535,21 @@ function broadcastAccount(): void {
   panels.broadcast(channels.accountChanged, account);
 }
 
+/**
+ * Tells every panel what an account transition just did to the settings.
+ * `voiceAvailable` rides the settings snapshot and now moves with the account
+ * — a sign-in carries the hosted allowance, a sign-out takes it — but the
+ * transitions themselves only broadcast `accountChanged`, so without this the
+ * renderer keeps drawing the voice state of the account it no longer has.
+ */
+async function broadcastVoiceAvailability(): Promise<void> {
+  panels.broadcast(channels.settingsChanged, await settingsStore.snapshot());
+}
+
 async function startAccountCapabilities(generation = accountGeneration): Promise<void> {
   if (generation !== accountGeneration || !accountCapabilitiesActive()) return;
   await applyVoiceCredential();
+  await broadcastVoiceAvailability();
   if (generation !== accountGeneration || !accountCapabilitiesActive()) return;
   await hotkeys.reapply(HOTKEY_RANK.TALK);
   if (generation !== accountGeneration || !accountCapabilitiesActive()) return;
@@ -566,6 +578,9 @@ async function signOutAccount(options: { revokeRemote?: boolean } = {}): Promise
   await stopAccountCapabilities();
   account = await clearingAccount;
   broadcastAccount();
+  // Only after the clear has settled: a snapshot taken while it was in flight
+  // could still see the account and say voice survives the sign-out.
+  await broadcastVoiceAvailability();
   const refreshToken = (await storedAccount)?.refreshToken;
   if (refreshToken) {
     await accountClient.revoke(refreshToken).catch((error) => {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -72,6 +72,7 @@ const bridge: AppBridge = {
   summonFeedback: invoke(channels.summonFeedback),
   focusPanel: () => ipcRenderer.send(channels.focusPanel),
   requestRealtimeCredential: invoke(channels.requestRealtimeCredential),
+  requestRealtimeDiagnostics: invoke(channels.requestRealtimeDiagnostics),
   notifyReady: () => ipcRenderer.send(channels.rendererReady),
   quit: () => ipcRenderer.send(channels.quit),
   onLifecycle: subscribe(channels.lifecycle),

--- a/apps/desktop/src/realtime-minter.ts
+++ b/apps/desktop/src/realtime-minter.ts
@@ -1,0 +1,14 @@
+import type { RealtimeConnection, RealtimeDiagnostics } from "@sidecar/core";
+
+/**
+ * What the main process asks of whichever credential source voice runs on —
+ * the developer's own OpenAI key or the signed-in hosted service. The renderer
+ * never sees the difference: either way it receives an ephemeral connection
+ * aimed at OpenAI's own calls endpoint, and diagnostics that can say why not.
+ */
+export interface RealtimeCredentialMinter {
+  mint(): Promise<RealtimeConnection | undefined>;
+  setVoice(voice: string | undefined): void;
+  setSpeed(speed: number | undefined): void;
+  diagnostics(): RealtimeDiagnostics;
+}

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -10,6 +10,7 @@ import {
   type PanelFormFactor,
   type ProviderId,
   REALTIME_STATUS,
+  type RealtimeDiagnostics,
   type RealtimeVoice,
   type RealtimeVoiceSpeed,
   type SessionIdentity,
@@ -2095,6 +2096,29 @@ export function App(): React.JSX.Element {
     return () => window.removeEventListener("pointerdown", handlePointerDown, { capture: true });
   }, [optionsOpen]);
 
+  // How voice stands right now — whose credential it runs on and what remains
+  // of a hosted day's allowance — asked while the Settings tab is up. Asked
+  // again on every settings change because the answer moves with the key and
+  // the account; a call spent while the tab was away is caught by the next
+  // change or visit. Gated on the tab alone: the ask is one local IPC round
+  // trip answering from memory, and the tab is what decides whether the
+  // answer can be seen.
+  const [voiceService, setVoiceService] = useState<RealtimeDiagnostics | undefined>();
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the settings snapshot is not read here — its arrival is the signal the held answer went stale, because the key or the account may have moved with it.
+  useEffect(() => {
+    if (tab !== PANEL_TAB.SETTINGS || !bootstrap) return;
+    let stale = false;
+    void window.sidecar
+      .requestRealtimeDiagnostics()
+      .then((report) => {
+        if (!stale) setVoiceService(report);
+      })
+      .catch(() => undefined);
+    return () => {
+      stale = true;
+    };
+  }, [tab, settings, bootstrap]);
+
   if (!bootstrap || !display) return <div />;
 
   const visibleSessions = displaySessions(bootstrap, sessions, noticeAsks);
@@ -2301,6 +2325,7 @@ export function App(): React.JSX.Element {
               microphone,
               updates,
               settings,
+              ...(voiceService ? { voiceService } : {}),
               preferences,
               credentials,
               feedback: feedbackControl,

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -588,11 +588,14 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "holds a front page whose rows open its Voice, Appearance, Keyboard shortcuts, and " +
         "Connections pages — each led back out by its back button or Escape — and keeps the " +
         "Feedback section and Quit on the front page itself; the Voice page reveals itself in " +
-        "stages — the OpenAI key alone until one is connected, then the microphone permission " +
-        "under it, and the voice settings only once both stand — and a small exclamation mark " +
-        "sits on whichever stage still needs a hand, on the front page's Voice row while " +
-        "either does, and on the Keyboard shortcuts rows while voice is off, where each key's " +
-        "chord stays shown and changeable but answers nothing until the key connects; the " +
+        "stages — the OpenAI key section alone until voice is available at all (the signed-in " +
+        "account includes it, so for most people the page opens whole, with a note saying " +
+        "whose allowance voice runs on and how much of today's remains), then the microphone " +
+        "permission under it, and the voice settings only once both stand — and a small " +
+        "exclamation mark sits on whichever stage still needs a hand, on the front page's " +
+        "Voice row while either does, and on the Keyboard shortcuts rows while voice is off, " +
+        "where each key's chord stays shown and changeable but answers nothing until voice is " +
+        "available; the " +
         "menu bar item's Settings… opens the same tab, and Command-comma switches to it while " +
         "the panel has the keyboard. A dot beside a settings row marks a value changed from " +
         "its default, and a page holding one ends its head with a reset, pressed by hand and " +

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -459,7 +459,7 @@ const MICROPHONE_DETAIL: Record<MicrophoneStatus, string> = {
     "Denied. It can only be granted back in System Settings, under Privacy & Security, Microphone.",
   restricted: "Restricted by a system policy, which only the system's manager can change.",
   "not-determined":
-    "Not asked yet. The Permissions section on the Settings tab's Voice page can ask once an OpenAI key is connected.",
+    "Not asked yet. The Permissions section on the Settings tab's Voice page can ask while voice is available — a signed-in account includes it, and an OpenAI key also provides it.",
   unknown: "Unknown. The Permissions section on the Settings tab's Voice page shows its state.",
 };
 
@@ -519,14 +519,21 @@ function integrationsFact(settings: AppSettings): AppGuideFact {
  * The one key that is neither an agent's nor an integration's, described where
  * its row lives: at the top of the Voice page, beside the feature it turns on.
  */
-function voiceKeyFact(settings: AppSettings): AppGuideFact {
+function voiceKeyFact(settings: AppSettings, voiceAvailable: boolean): AppGuideFact {
   const openai = CREDENTIAL_PROVIDERS[VOICE_CREDENTIAL_PROVIDER_ID];
+  const source = settings.credentialSources[openai.id];
+  const hosted = voiceAvailable && source === CREDENTIAL_SOURCE.NONE;
   return {
     label: "OpenAI",
     detail:
-      `${openai.displayName} (${connectionWord(settings.credentialSources[openai.id])}). ` +
-      `Connecting OpenAI is what lets Luke speak, and review which sessions need a person. ` +
-      `Its key is typed by hand into ${VOICE_PAGE}, at its top — never spoken, and never ` +
+      `${openai.displayName} (${connectionWord(source)}). ` +
+      (hosted
+        ? `Voice and session review currently run on the signed-in Luke account, which includes ` +
+          `a daily allowance. Connecting a personal OpenAI key lifts the allowance and runs ` +
+          `voice on that key instead. `
+        : `Connecting OpenAI is what lets Luke speak, and review which sessions need a person; ` +
+          `a signed-in Luke account also includes both under a daily allowance without one. `) +
+      `The key is typed by hand into ${VOICE_PAGE}, at its top — never spoken, and never ` +
       `repeated back.`,
   };
 }
@@ -690,7 +697,8 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "the ask itself is the consent. One ask stands per session, a new one replaces it, asking Luke to drop " +
         "it withdraws it, and an ask ends with the session it was about. A row with an ask standing wears a " +
         "small listening mark beside its age, and the conversation roster carries each standing ask, so Luke " +
-        "can say what he is already listening for. It needs the OpenAI connection, " +
+        "can say what he is already listening for. It needs voice to be available — the " +
+        "signed-in account includes it, and a personal OpenAI key also provides it — " +
         "changes nothing about the session itself, and is never sent to a provider.",
     },
     talkKeyFact(input.hotkey),
@@ -775,7 +783,7 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
           },
         ]),
     providersFact(input.settings),
-    voiceKeyFact(input.settings),
+    voiceKeyFact(input.settings, input.voiceAvailable),
     integrationsFact(input.settings),
     ...(input.settings.secretStorage === SECRET_STORAGE.UNAVAILABLE
       ? [

--- a/apps/desktop/src/renderer/microphone-access.ts
+++ b/apps/desktop/src/renderer/microphone-access.ts
@@ -1,13 +1,34 @@
+import { REALTIME_MINT_OUTCOME, type RealtimeDiagnostics } from "@sidecar/core";
 import type { MicrophoneStatus } from "../shared/contracts";
 
 /**
- * Why voice as a whole is off: the one key it runs on is not connected. One
- * sentence, shared by every mark that stands for the same missing key — the
+ * Why voice as a whole is off: nothing it can run on stands — no signed-in
+ * account carrying the hosted allowance, and no key of the developer's own.
+ * One sentence, shared by every mark that stands for the same absence — the
  * front page's Voice row, the key's own heading, and the shortcut rows whose
- * chords answer nothing without it — so the same absence never reads as two
- * different problems.
+ * chords answer nothing without it — so it never reads as two different
+ * problems.
  */
-export const VOICE_KEYLESS_NOTE = "Voice is off: it needs an OpenAI key.";
+export const VOICE_KEYLESS_NOTE = "Voice is off: sign in, or connect an OpenAI key.";
+
+/**
+ * What the key section says while voice runs on the signed-in account: whose
+ * allowance is speaking, how much of today's remains once a mint has said,
+ * and what connecting a key of one's own changes. The refusal a spent
+ * allowance answers with is a state here, not an error — nothing is broken,
+ * and the sentence says when voice returns on its own.
+ */
+export function hostedVoiceNote(diagnostics: RealtimeDiagnostics | undefined): string {
+  const lift = "Connecting your own OpenAI key lifts the allowance and runs voice on it instead.";
+  if (diagnostics?.lastOutcome === REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED) {
+    return `Today's included voice is used up — it returns at midnight UTC. ${lift}`;
+  }
+  const quota = diagnostics?.quota;
+  if (quota) {
+    return `Voice is included with your Luke account — ${quota.remaining} of ${quota.limit} calls left today. ${lift}`;
+  }
+  return `Voice is included with your Luke account, under a daily allowance. ${lift}`;
+}
 
 /** Why Luke can speak but not listen: the system's grant is still missing. */
 export const MICROPHONE_UNGRANTED_NOTE = "Luke cannot listen: the microphone is not allowed yet.";

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -10,6 +10,7 @@ import {
   REALTIME_DEFAULTS,
   REALTIME_VOICE_LIST,
   REALTIME_VOICE_SPEED_LIST,
+  type RealtimeDiagnostics,
   type RealtimeVoice,
   type RealtimeVoiceSpeed,
   type WorkspaceAgentSelection,
@@ -72,6 +73,7 @@ import { Keycaps } from "./keycaps";
 import { type ErrandTarget, errandTargetProps } from "./luke-errand";
 import { APP_SETTING_ID } from "./luke-guide";
 import {
+  hostedVoiceNote,
   MICROPHONE_UNGRANTED_NOTE,
   microphoneAccessRow,
   VOICE_KEYLESS_NOTE,
@@ -299,6 +301,13 @@ export interface SettingsPanelProps {
   microphone: MicrophoneControl;
   updates: UpdateControl;
   settings?: AppSettings;
+  /**
+   * How voice stands right now, asked of the main process while the panel is
+   * up: whose credential it runs on and what remains of a hosted day's
+   * allowance. Absent until the first answer lands; the Voice page words its
+   * hosted note without it until then.
+   */
+  voiceService?: RealtimeDiagnostics;
   preferences: PreferenceWrites;
   /** The one credential being entered anywhere, and everything that can be done to it. */
   credentials: CredentialEntryControl;
@@ -1600,13 +1609,16 @@ function SettingsPageHeader({
 }
 
 /**
- * How Luke sounds and what he says unprompted — led by the key it all runs
- * on. The OpenAI credential stands at the top of this page rather than under
- * Connections because voice is what the key turns on: the page that goes
- * quiet without one is where its absence has to be explained. The page
- * reveals itself in stages rather than all at once: the key alone until one
- * is connected, the microphone permission beneath it once there is a voice
- * for the microphone to reach, and the voice controls only once both stand —
+ * How Luke sounds and what he says unprompted — led by what voice runs on.
+ * The OpenAI credential stands at the top of this page rather than under
+ * Connections because voice is what the key changes: included with the
+ * signed-in account under a daily allowance, and run unmetered on the
+ * developer's own key the moment one is connected — so the section that
+ * explains whose credential is speaking is the section a key is typed into.
+ * The page reveals itself in stages rather than all at once: the key section
+ * alone until voice is available at all, the microphone permission beneath it
+ * once there is a voice for the microphone to reach, and the voice controls
+ * only once both stand —
  * a page of settings for a feature two steps from running reads as work
  * already done, and the one thing to do next reads clearest standing alone.
  * Whichever stage is missing wears the same exclamation mark the front
@@ -1623,12 +1635,14 @@ function VoiceSection({
   credentials,
   panelOpen,
   microphone,
+  voiceService,
 }: {
   settings: AppSettings;
   preferences: PreferenceWrites;
   credentials: CredentialEntryControl;
   panelOpen: boolean;
   microphone: MicrophoneControl;
+  voiceService?: RealtimeDiagnostics;
 }): React.JSX.Element {
   const storageUnavailable = settings.secretStorage === SECRET_STORAGE.UNAVAILABLE;
   const microphoneRow = microphoneAccessRow({
@@ -1658,18 +1672,24 @@ function VoiceSection({
             it on. `voiceAvailable` rather than the credential source, because
             availability is the store's own answer — a fixture run or a key
             that failed to resolve leaves voice off however the row reads.
-            While this system cannot store a key at all, the storage refusal
-            replaces the invitation: a Connect stilled by missing storage
-            needs its why here exactly as it does in the other key sections,
-            and a note urging a key the panel will not store would only send
-            someone to a disabled control. */}
+            While voice runs on the account instead, the note says whose
+            allowance is speaking and what a key of one's own changes, so an
+            unconnected row above a working feature does not read as a step
+            still owed. While this system cannot store a key at all, the
+            storage refusal replaces the invitation: a Connect stilled by
+            missing storage needs its why here exactly as it does in the other
+            key sections, and a note urging a key the panel will not store
+            would only send someone to a disabled control. */}
         {storageUnavailable ? (
           <p className="settings-note">{STORAGE_UNAVAILABLE_NOTE}</p>
-        ) : settings.voiceAvailable ? null : (
+        ) : !settings.voiceAvailable ? (
           <p className="settings-note">
-            Voice is off until a key is connected — Luke cannot talk, listen, or announce sessions.
+            Voice is off until you sign in or connect a key — Luke cannot talk, listen, or announce
+            sessions.
           </p>
-        )}
+        ) : settings.credentialSources[VOICE_CREDENTIAL_PROVIDER.id] === CREDENTIAL_SOURCE.NONE ? (
+          <p className="settings-note">{hostedVoiceNote(voiceService)}</p>
+        ) : null}
       </section>
       {/* Drawn only once there is a voice for the microphone to reach: until
           the key connects, the permission guards a feature that cannot run,
@@ -2452,6 +2472,7 @@ export function SettingsPanel({
   microphone,
   updates,
   settings,
+  voiceService,
   preferences,
   credentials,
   feedback,
@@ -2557,6 +2578,7 @@ export function SettingsPanel({
           credentials={credentials}
           panelOpen={panelOpen}
           microphone={microphone}
+          {...(voiceService ? { voiceService } : {})}
         />
       ) : null}
 

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -1056,7 +1056,11 @@ export class SettingsStore {
    */
   async #voiceAvailable(): Promise<boolean> {
     if (!this.#credentialsUsable) return false;
-    return (await this.readApiKey(VOICE_CREDENTIAL_PROVIDER_ID)) !== undefined;
+    if ((await this.readApiKey(VOICE_CREDENTIAL_PROVIDER_ID)) !== undefined) return true;
+    // A signed-in account carries the hosted allowance, so voice is on without
+    // a key of the developer's own — the same resolution the main process makes
+    // when it builds the minter.
+    return (await this.readAccount()) !== undefined;
   }
 
   /**

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -11,6 +11,7 @@ import type {
   ProviderMessageResult,
   ProviderWorkspaceResult,
   RealtimeConnection,
+  RealtimeDiagnostics,
   RealtimeVoice,
   RealtimeVoiceSpeed,
   Rectangle,
@@ -746,6 +747,12 @@ export interface AppBridge {
   focusPanel(): void;
   /** Mints a short-lived Realtime credential; the standing API key never crosses. */
   requestRealtimeCredential(): Promise<RealtimeConnection | undefined>;
+  /**
+   * How voice stands right now — whose credential it runs on, why the last
+   * mint ended the way it did, and what remains of a hosted day's allowance.
+   * It carries no credential material, which is what lets it cross at all.
+   */
+  requestRealtimeDiagnostics(): Promise<RealtimeDiagnostics>;
   notifyReady(): void;
   quit(): void;
   onLifecycle(callback: (eventName: string) => void): () => void;
@@ -868,6 +875,7 @@ export const channels = {
   summonFeedback: "app:summon-feedback",
   focusPanel: "app:focus-panel",
   requestRealtimeCredential: "app:request-realtime-credential",
+  requestRealtimeDiagnostics: "app:request-realtime-diagnostics",
   attentionSpeech: "app:attention-speech",
   voiceHotkeyPress: "app:voice-hotkey-press",
   voiceHotkeyRelease: "app:voice-hotkey-release",

--- a/apps/desktop/tests/account-token-lifecycle.test.ts
+++ b/apps/desktop/tests/account-token-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { withIssuedAccountTokens } from "../src/account-token-lifecycle";
+import { singleFlight, withIssuedAccountTokens } from "../src/account-token-lifecycle";
 
 const TOKENS = { accessToken: "issued-access", refreshToken: "issued-refresh" };
 
@@ -54,4 +54,47 @@ test("revocation failure preserves the sign-in failure", async () => {
 
   assert.equal(revokeFailures.length, 1);
   assert.match(String(revokeFailures[0]), /revocation failed/);
+});
+
+test("concurrent refresh asks share one in-flight run, so a rotated token is never spent twice", async () => {
+  let runs = 0;
+  let release: (() => void) | undefined;
+  const refresh = singleFlight(
+    () =>
+      new Promise<void>((resolve) => {
+        runs += 1;
+        release = resolve;
+      }),
+  );
+
+  const first = refresh();
+  const second = refresh();
+  assert.equal(runs, 1);
+
+  release?.();
+  await Promise.all([first, second]);
+
+  // A finished flight is over: the next ask holds the newly rotated token and
+  // may start a refresh of its own.
+  const third = refresh();
+  assert.equal(runs, 2);
+  release?.();
+  await third;
+});
+
+test("a failed flight rejects every waiter and still ends, so the next ask can try again", async () => {
+  let runs = 0;
+  const refresh = singleFlight(async () => {
+    runs += 1;
+    throw new Error("token endpoint unreachable");
+  });
+
+  const first = refresh();
+  const second = refresh();
+  await assert.rejects(first, /unreachable/);
+  await assert.rejects(second, /unreachable/);
+  assert.equal(runs, 1);
+
+  await assert.rejects(refresh(), /unreachable/);
+  assert.equal(runs, 2);
 });

--- a/apps/desktop/tests/hosted-attention-evaluator.test.ts
+++ b/apps/desktop/tests/hosted-attention-evaluator.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ATTENTION_DISPOSITION,
+  ATTENTION_TRIGGER,
+  type AttentionUpdate,
+  SESSION_STATUS,
+} from "@sidecar/core";
+import { HostedAttentionEvaluator } from "../src/hosted-attention-evaluator";
+
+const NOW = 1_800_000_000_000;
+const SERVICE = "https://tryluke.dev";
+const TRANSCRIPT_SECRET = "WITHHELD_SESSION_IDENTIFIER";
+
+const UPDATE: AttentionUpdate = {
+  providerId: "claude-code",
+  providerSessionId: TRANSCRIPT_SECRET,
+  trigger: ATTENTION_TRIGGER.STATUS_CHANGED,
+  providerName: "Claude Code",
+  title: "checkout-service",
+  status: SESSION_STATUS.WAITING,
+  previousStatus: SESSION_STATUS.WORKING,
+  recap: "Waiting on a permission decision.",
+  context: { branch: "main" },
+  noticeRequest: "tell me when this finishes",
+  observedAt: NOW - 1_000,
+};
+
+const SPOKEN_ANSWER = {
+  decision: {
+    disposition: ATTENTION_DISPOSITION.SPEAK_DURING_TURN,
+    decidedAt: NOW - 99_999,
+    summary: "Claude Code is waiting on you in checkout-service.",
+    answersAsk: true,
+  },
+  quota: { used: 9, limit: 500, remaining: 491, resetsAt: NOW + 3_600_000 },
+};
+
+interface RecordedRequest {
+  url: string;
+  init: RequestInit;
+}
+
+function service(answers: Array<() => Response>) {
+  const requests: RecordedRequest[] = [];
+  let call = 0;
+  const fetchLike = async (url: string, init: RequestInit): Promise<Response> => {
+    requests.push({ url, init });
+    const answer = answers[Math.min(call, answers.length - 1)];
+    call += 1;
+    if (!answer) throw new Error("no scripted answer");
+    return answer();
+  };
+  return { requests, fetchLike };
+}
+
+function evaluator(
+  options: Partial<ConstructorParameters<typeof HostedAttentionEvaluator>[0]> = {},
+) {
+  return new HostedAttentionEvaluator({
+    serviceBaseUrl: SERVICE,
+    readAccessToken: async () => "token-1",
+    refreshAccount: async () => undefined,
+    now: () => NOW,
+    ...options,
+  });
+}
+
+test("sends only what the prompt reads — never the session's identifiers or clock", async () => {
+  const { requests, fetchLike } = service([
+    () => new Response(JSON.stringify(SPOKEN_ANSWER), { status: 200 }),
+  ]);
+  const hosted = evaluator({ fetch: fetchLike });
+
+  const decision = await hosted.evaluate(UPDATE);
+  assert.deepEqual(decision, {
+    disposition: ATTENTION_DISPOSITION.SPEAK_DURING_TURN,
+    decidedAt: NOW,
+    summary: SPOKEN_ANSWER.decision.summary,
+    answersAsk: true,
+  });
+
+  const [request] = requests;
+  assert.equal(request?.url, "https://tryluke.dev/api/attention/review");
+  assert.equal(new Headers(request?.init.headers).get("authorization"), "Bearer token-1");
+  const sent = String(request?.init.body);
+  assert.doesNotMatch(sent, new RegExp(TRANSCRIPT_SECRET));
+  assert.deepEqual(JSON.parse(sent), {
+    trigger: UPDATE.trigger,
+    providerName: UPDATE.providerName,
+    title: UPDATE.title,
+    status: UPDATE.status,
+    previousStatus: UPDATE.previousStatus,
+    recap: UPDATE.recap,
+    context: UPDATE.context,
+    noticeRequest: UPDATE.noticeRequest,
+  });
+});
+
+test("a spent allowance quiets reviews until the day's counters reset", async () => {
+  const { requests, fetchLike } = service([
+    () =>
+      new Response(
+        JSON.stringify({
+          error: "quota-exhausted",
+          quota: { used: 501, limit: 500, remaining: 0, resetsAt: NOW + 3_600_000 },
+        }),
+        { status: 429 },
+      ),
+  ]);
+  const hosted = evaluator({ fetch: fetchLike });
+
+  assert.equal(await hosted.evaluate(UPDATE), undefined);
+  assert.equal(hosted.quietUntil(), NOW + 3_600_000);
+
+  // Held back without another request until the reset.
+  assert.equal(await hosted.evaluate(UPDATE), undefined);
+  assert.equal(requests.length, 1);
+});
+
+test("a 401 refreshes the account and retries once", async () => {
+  const tokens = ["stale-token", "fresh-token"];
+  let refreshes = 0;
+  const { requests, fetchLike } = service([
+    () => new Response(JSON.stringify({ error: "invalid-token" }), { status: 401 }),
+    () => new Response(JSON.stringify(SPOKEN_ANSWER), { status: 200 }),
+  ]);
+  const hosted = evaluator({
+    fetch: fetchLike,
+    readAccessToken: async () => tokens[Math.min(refreshes, tokens.length - 1)],
+    refreshAccount: async () => {
+      refreshes += 1;
+    },
+  });
+
+  const decision = await hosted.evaluate(UPDATE);
+  assert.ok(decision);
+  assert.equal(refreshes, 1);
+  assert.equal(new Headers(requests[1]?.init.headers).get("authorization"), "Bearer fresh-token");
+});
+
+test("stays silent on failures, contract violations, and a missing account", async () => {
+  const failing = evaluator({
+    fetch: service([() => new Response("oops", { status: 502 })]).fetchLike,
+  });
+  assert.equal(await failing.evaluate(UPDATE), undefined);
+
+  const malformed = evaluator({
+    fetch: service([
+      () => new Response(JSON.stringify({ decision: { disposition: "shout" } }), { status: 200 }),
+    ]).fetchLike,
+  });
+  assert.equal(await malformed.evaluate(UPDATE), undefined);
+
+  const signedOut = evaluator({
+    fetch: service([]).fetchLike,
+    readAccessToken: async () => undefined,
+  });
+  assert.equal(await signedOut.evaluate(UPDATE), undefined);
+});

--- a/apps/desktop/tests/hosted-realtime-credentials.test.ts
+++ b/apps/desktop/tests/hosted-realtime-credentials.test.ts
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  HOSTED_CALLS_URL,
+  REALTIME_MINT_OUTCOME,
+  REALTIME_VOICE,
+  REALTIME_VOICE_SPEED,
+} from "@sidecar/core";
+import { HostedRealtimeCredentialMinter } from "../src/hosted-realtime-credentials";
+
+const NOW = 1_800_000_000_000;
+const SERVICE = "https://tryluke.dev";
+const QUOTA = { used: 3, limit: 50, remaining: 47, resetsAt: NOW + 3_600_000 };
+
+function mintedBody(overrides: Record<string, unknown> = {}) {
+  return {
+    connection: {
+      value: "eph-secret",
+      expiresAt: NOW + 60_000,
+      model: "gpt-realtime-2.1",
+      callsUrl: HOSTED_CALLS_URL,
+      ...overrides,
+    },
+    quota: QUOTA,
+  };
+}
+
+interface RecordedRequest {
+  url: string;
+  init: RequestInit;
+}
+
+function service(answers: Array<() => Response>) {
+  const requests: RecordedRequest[] = [];
+  let call = 0;
+  const fetchLike = async (url: string, init: RequestInit): Promise<Response> => {
+    requests.push({ url, init });
+    const answer = answers[Math.min(call, answers.length - 1)];
+    call += 1;
+    if (!answer) throw new Error("no scripted answer");
+    return answer();
+  };
+  return { requests, fetchLike };
+}
+
+function minter(options: Partial<ConstructorParameters<typeof HostedRealtimeCredentialMinter>[0]>) {
+  return new HostedRealtimeCredentialMinter({
+    serviceBaseUrl: SERVICE,
+    readAccessToken: async () => "token-1",
+    refreshAccount: async () => undefined,
+    now: () => NOW,
+    ...options,
+  });
+}
+
+test("mints through the hosted service on the account's bearer token", async () => {
+  const { requests, fetchLike } = service([
+    () => new Response(JSON.stringify(mintedBody()), { status: 200 }),
+  ]);
+  const hosted = minter({
+    fetch: fetchLike,
+    voice: REALTIME_VOICE.MARIN,
+    speed: REALTIME_VOICE_SPEED.QUICK,
+  });
+
+  const connection = await hosted.mint();
+  assert.deepEqual(connection, {
+    value: "eph-secret",
+    expiresAt: NOW + 60_000,
+    model: "gpt-realtime-2.1",
+    callsUrl: HOSTED_CALLS_URL,
+  });
+
+  const [request] = requests;
+  assert.equal(request?.url, "https://tryluke.dev/api/voice/mint");
+  assert.equal(new Headers(request?.init.headers).get("authorization"), "Bearer token-1");
+  assert.deepEqual(JSON.parse(String(request?.init.body)), {
+    voice: REALTIME_VOICE.MARIN,
+    speed: REALTIME_VOICE_SPEED.QUICK,
+  });
+
+  const report = hosted.diagnostics();
+  assert.equal(report.hosted, true);
+  assert.equal(report.apiKeyConfigured, false);
+  assert.equal(report.lastOutcome, REALTIME_MINT_OUTCOME.SUCCEEDED);
+  assert.deepEqual(report.quota, QUOTA);
+});
+
+test("reuses the outstanding credential and discards it when the voice changes", async () => {
+  const { requests, fetchLike } = service([
+    () => new Response(JSON.stringify(mintedBody()), { status: 200 }),
+  ]);
+  const hosted = minter({ fetch: fetchLike });
+
+  await hosted.mint();
+  await hosted.mint();
+  assert.equal(requests.length, 1);
+
+  hosted.setVoice(REALTIME_VOICE.SAGE);
+  await hosted.mint();
+  assert.equal(requests.length, 2);
+});
+
+test("no access token asks the service nothing and says why voice is off", async () => {
+  const { requests, fetchLike } = service([]);
+  const hosted = minter({ fetch: fetchLike, readAccessToken: async () => undefined });
+
+  assert.equal(await hosted.mint(), undefined);
+  assert.equal(requests.length, 0);
+  assert.equal(hosted.diagnostics().lastOutcome, REALTIME_MINT_OUTCOME.NOT_SIGNED_IN);
+});
+
+test("a 401 refreshes the account and retries once with the new token", async () => {
+  const tokens = ["stale-token", "fresh-token"];
+  let refreshes = 0;
+  const { requests, fetchLike } = service([
+    () => new Response(JSON.stringify({ error: "invalid-token" }), { status: 401 }),
+    () => new Response(JSON.stringify(mintedBody()), { status: 200 }),
+  ]);
+  const hosted = minter({
+    fetch: fetchLike,
+    readAccessToken: async () => tokens[Math.min(refreshes, tokens.length - 1)],
+    refreshAccount: async () => {
+      refreshes += 1;
+    },
+  });
+
+  const connection = await hosted.mint();
+  assert.ok(connection);
+  assert.equal(refreshes, 1);
+  assert.equal(requests.length, 2);
+  assert.equal(new Headers(requests[1]?.init.headers).get("authorization"), "Bearer fresh-token");
+});
+
+test("a refresh that changes nothing is not retried and reads as signed out", async () => {
+  let refreshes = 0;
+  const { requests, fetchLike } = service([
+    () => new Response(JSON.stringify({ error: "invalid-token" }), { status: 401 }),
+  ]);
+  const hosted = minter({
+    fetch: fetchLike,
+    refreshAccount: async () => {
+      refreshes += 1;
+    },
+  });
+
+  assert.equal(await hosted.mint(), undefined);
+  assert.equal(refreshes, 1);
+  assert.equal(requests.length, 1);
+  assert.equal(hosted.diagnostics().lastOutcome, REALTIME_MINT_OUTCOME.NOT_SIGNED_IN);
+});
+
+test("a spent allowance is diagnosed with the quota the refusal carried", async () => {
+  const spent = { used: 51, limit: 50, remaining: 0, resetsAt: NOW + 3_600_000 };
+  const { fetchLike } = service([
+    () => new Response(JSON.stringify({ error: "quota-exhausted", quota: spent }), { status: 429 }),
+  ]);
+  const hosted = minter({ fetch: fetchLike });
+
+  assert.equal(await hosted.mint(), undefined);
+  const report = hosted.diagnostics();
+  assert.equal(report.lastOutcome, REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED);
+  assert.deepEqual(report.quota, spent);
+});
+
+test("a switched-off service and a plain failure are told apart", async () => {
+  const unavailable = minter({
+    fetch: service([() => new Response(JSON.stringify({ error: "unavailable" }), { status: 503 })])
+      .fetchLike,
+  });
+  assert.equal(await unavailable.mint(), undefined);
+  assert.equal(unavailable.diagnostics().lastOutcome, REALTIME_MINT_OUTCOME.HOSTED_UNAVAILABLE);
+
+  const failing = minter({
+    fetch: service([() => new Response("oops", { status: 500 })]).fetchLike,
+  });
+  assert.equal(await failing.mint(), undefined);
+  assert.equal(failing.diagnostics().lastOutcome, REALTIME_MINT_OUTCOME.HTTP_ERROR);
+});
+
+test("a credential aimed anywhere but OpenAI's calls endpoint is refused", async () => {
+  const { fetchLike } = service([
+    () =>
+      new Response(
+        JSON.stringify(mintedBody({ callsUrl: "https://evil.example/v1/realtime/calls" })),
+        { status: 200 },
+      ),
+  ]);
+  const hosted = minter({ fetch: fetchLike });
+
+  assert.equal(await hosted.mint(), undefined);
+  assert.equal(hosted.diagnostics().lastOutcome, REALTIME_MINT_OUTCOME.MALFORMED_RESPONSE);
+});

--- a/apps/desktop/tests/hosted-realtime-credentials.test.ts
+++ b/apps/desktop/tests/hosted-realtime-credentials.test.ts
@@ -86,19 +86,23 @@ test("mints through the hosted service on the account's bearer token", async () 
   assert.deepEqual(report.quota, QUOTA);
 });
 
-test("reuses the outstanding credential and discards it when the voice changes", async () => {
+test("mints a fresh secret for every call and follows a voice change on the next", async () => {
   const { requests, fetchLike } = service([
     () => new Response(JSON.stringify(mintedBody()), { status: 200 }),
   ]);
   const hosted = minter({ fetch: fetchLike });
 
+  // Never reused: the service refuses a reused secret at the calls endpoint,
+  // so each call is answered by its own mint — which is also what the hosted
+  // allowance counts.
   await hosted.mint();
   await hosted.mint();
-  assert.equal(requests.length, 1);
+  assert.equal(requests.length, 2);
 
   hosted.setVoice(REALTIME_VOICE.SAGE);
   await hosted.mint();
-  assert.equal(requests.length, 2);
+  assert.equal(requests.length, 3);
+  assert.equal(JSON.parse(String(requests[2]?.init.body)).voice, REALTIME_VOICE.SAGE);
 });
 
 test("no access token asks the service nothing and says why voice is off", async () => {

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -221,10 +221,15 @@ test("the facts say what is connected, never what connects it", () => {
   assert.match(connected, /checkboxes under each account/);
   // The voice key stands in a fact of its own, saying what connecting it buys
   // and naming the page its row actually lives on — the Voice page, not the
-  // Integrations section it once shared with Linear.
+  // Integrations section it once shared with Linear. With voice available and
+  // no key connected, the fact says whose account voice is running on; with
+  // voice unavailable, it says what connecting a key would turn on.
   assert.match(rendered, /OpenAI \(not connected\)/);
-  assert.match(rendered, /Connecting OpenAI is what lets Luke speak/);
+  assert.match(rendered, /run on the signed-in Luke account/);
+  assert.match(rendered, /daily allowance/);
   assert.match(rendered, /Voice page, at its top/);
+  const voiceless = JSON.stringify(buildLukeGuide(guideInput({ voiceAvailable: false })).facts);
+  assert.match(voiceless, /Connecting OpenAI is what lets Luke speak/);
   assert.doesNotMatch(rendered, /OpenAI[^"]*under Integrations/);
   // The guide leaves the machine, so no key, prefix, or environment variable
   // value has any business in it.

--- a/apps/desktop/tests/microphone-access.test.ts
+++ b/apps/desktop/tests/microphone-access.test.ts
@@ -1,6 +1,26 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { microphoneAccessRow, voiceAttentionNote } from "../src/renderer/microphone-access";
+import { REALTIME_DEFAULTS, REALTIME_MINT_OUTCOME, type RealtimeDiagnostics } from "@sidecar/core";
+import {
+  hostedVoiceNote,
+  microphoneAccessRow,
+  voiceAttentionNote,
+} from "../src/renderer/microphone-access";
+
+/** A hosted diagnostics report with only what a test wants to vary. */
+function diagnostics(overrides: Partial<RealtimeDiagnostics>): RealtimeDiagnostics {
+  return {
+    apiKeyConfigured: false,
+    hosted: true,
+    fixtureMode: false,
+    model: REALTIME_DEFAULTS.MODEL,
+    voice: REALTIME_DEFAULTS.VOICE,
+    speed: REALTIME_DEFAULTS.SPEED,
+    endpoint: "https://tryluke.dev/api/voice/mint",
+    lastOutcome: REALTIME_MINT_OUTCOME.NOT_ATTEMPTED,
+    ...overrides,
+  };
+}
 
 test("access is offered only where it can be used", () => {
   const offered = microphoneAccessRow({
@@ -112,4 +132,31 @@ test("the mark and the row agree on what ready means", () => {
       assert.equal(note === undefined, row.ready, `${voiceAvailable}/${status}`);
     }
   }
+});
+
+test("the hosted note says whose allowance voice runs on, and what remains once known", () => {
+  // Before any mint has answered, the note promises only the allowance.
+  assert.match(
+    hostedVoiceNote(undefined),
+    /included with your Luke account, under a daily allowance/,
+  );
+  assert.match(hostedVoiceNote(undefined), /your own OpenAI key lifts the allowance/i);
+
+  const counted = hostedVoiceNote(
+    diagnostics({
+      lastOutcome: REALTIME_MINT_OUTCOME.SUCCEEDED,
+      quota: { used: 3, limit: 50, remaining: 47, resetsAt: 1_800_003_600_000 },
+    }),
+  );
+  assert.match(counted, /47 of 50 calls left today/);
+
+  // A spent allowance is a state with its own return time, not an error.
+  const spent = hostedVoiceNote(
+    diagnostics({
+      lastOutcome: REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED,
+      quota: { used: 51, limit: 50, remaining: 0, resetsAt: 1_800_003_600_000 },
+    }),
+  );
+  assert.match(spent, /used up — it returns at midnight UTC/);
+  assert.doesNotMatch(spent, /left today/);
 });

--- a/apps/web/server/hosted/http.ts
+++ b/apps/web/server/hosted/http.ts
@@ -1,24 +1,13 @@
+import type { HostedApiError } from "../core.js";
+
 /**
  * The response vocabulary the hosted endpoints share. Every answer is JSON,
- * and every refusal names its reason from one fixed set so the desktop can
- * diagnose "voice is off" without the server writing anything sensitive.
+ * and every refusal names its reason from the wire contract in
+ * `@sidecar/core`'s `hosted-service` — the same module the desktop's hosted
+ * clients validate against, so an error slug cannot drift between the two.
  */
 
-export const HOSTED_API_ERROR = {
-  /** The bearer token is missing, expired, or revoked. */
-  INVALID_TOKEN: "invalid-token",
-  /** The request body is not what this endpoint takes. */
-  INVALID_REQUEST: "invalid-request",
-  /** Today's free allowance for this meter is spent. */
-  QUOTA_EXHAUSTED: "quota-exhausted",
-  /** The deployment holds no OpenAI key: the hosted tier is switched off. */
-  UNAVAILABLE: "unavailable",
-  /** OpenAI refused or failed; the status travels, the bodies never do. */
-  UPSTREAM_ERROR: "upstream-error",
-  METHOD_NOT_ALLOWED: "method-not-allowed",
-} as const;
-
-export type HostedApiError = (typeof HOSTED_API_ERROR)[keyof typeof HOSTED_API_ERROR];
+export { HOSTED_API_ERROR, type HostedApiError } from "../core.js";
 
 export const HOSTED_HTTP_STATUS = {
   OK: 200,

--- a/packages/sidecar-core/src/hosted-service.ts
+++ b/packages/sidecar-core/src/hosted-service.ts
@@ -1,0 +1,142 @@
+import { attentionDecisionFromModel } from "./attention.js";
+import { isRecord } from "./json.js";
+import {
+  REALTIME_CALLS_PATH,
+  type RealtimeConnection,
+  realtimeCredentialIsUsable,
+} from "./realtime-credentials.js";
+import type { AttentionDecision } from "./session.js";
+
+/**
+ * The wire contract between Luke's hosted service and the desktop. The web
+ * endpoints answer with these shapes and the desktop's hosted clients validate
+ * against them, both importing from here, so the two sides cannot drift — the
+ * same standing the attention request construction has.
+ */
+
+/** The hosted endpoints, rooted at the service origin. */
+export const HOSTED_SERVICE_PATH = {
+  VOICE_MINT: "/api/voice/mint",
+  ATTENTION_REVIEW: "/api/attention/review",
+} as const;
+
+/** Every refusal a hosted endpoint answers with, by its reason. */
+export const HOSTED_API_ERROR = {
+  /** The bearer token is missing, expired, or revoked. */
+  INVALID_TOKEN: "invalid-token",
+  /** The request body is not what this endpoint takes. */
+  INVALID_REQUEST: "invalid-request",
+  /** Today's free allowance for this meter is spent. */
+  QUOTA_EXHAUSTED: "quota-exhausted",
+  /** The deployment holds no OpenAI key: the hosted tier is switched off. */
+  UNAVAILABLE: "unavailable",
+  /** OpenAI refused or failed; the status travels, the bodies never do. */
+  UPSTREAM_ERROR: "upstream-error",
+  METHOD_NOT_ALLOWED: "method-not-allowed",
+} as const;
+
+export type HostedApiError = (typeof HOSTED_API_ERROR)[keyof typeof HOSTED_API_ERROR];
+
+/** What one day's allowance looked like when the service last answered. */
+export interface HostedQuota {
+  used: number;
+  limit: number;
+  remaining: number;
+  /** When the day's counters reset, as epoch milliseconds. */
+  resetsAt: number;
+}
+
+function wholeNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+/** Reads a quota out of an untrusted hosted answer, or nothing. */
+export function hostedQuotaFromWire(value: unknown): HostedQuota | undefined {
+  if (!isRecord(value)) return undefined;
+  const used = wholeNumber(value.used);
+  const limit = wholeNumber(value.limit);
+  const remaining = wholeNumber(value.remaining);
+  const resetsAt = wholeNumber(value.resetsAt);
+  if (used === undefined || limit === undefined || remaining === undefined) return undefined;
+  if (resetsAt === undefined) return undefined;
+  return { used, limit, remaining, resetsAt };
+}
+
+/**
+ * The one address a hosted credential may point a call at. The renderer's
+ * content-security policy only permits the canonical OpenAI host, so a
+ * credential aimed anywhere else could not work — validating it here means a
+ * mis-answering service reads as a malformed response rather than as a call
+ * that dies mid-handshake.
+ */
+export const HOSTED_CALLS_URL = `https://api.openai.com/v1${REALTIME_CALLS_PATH}`;
+
+export interface HostedMintAnswer {
+  connection: RealtimeConnection;
+  quota?: HostedQuota;
+}
+
+/**
+ * Validates a hosted mint answer. Anything without a usable, canonically
+ * addressed credential is discarded rather than repaired, the same posture as
+ * the OpenAI mint response reader.
+ */
+export function hostedMintAnswerFromWire(
+  value: unknown,
+  now: number,
+): HostedMintAnswer | undefined {
+  if (!isRecord(value) || !isRecord(value.connection)) return undefined;
+  const { connection } = value;
+  const secret = typeof connection.value === "string" ? connection.value.trim() : "";
+  const expiresAt = connection.expiresAt;
+  const model = typeof connection.model === "string" ? connection.model.trim() : "";
+  if (!secret || !model) return undefined;
+  if (typeof expiresAt !== "number" || !Number.isFinite(expiresAt)) return undefined;
+  if (connection.callsUrl !== HOSTED_CALLS_URL) return undefined;
+  const credential: RealtimeConnection = {
+    value: secret,
+    expiresAt,
+    model,
+    callsUrl: HOSTED_CALLS_URL,
+  };
+  if (!realtimeCredentialIsUsable(credential, now)) return undefined;
+  const quota = hostedQuotaFromWire(value.quota);
+  return { connection: credential, ...(quota ? { quota } : {}) };
+}
+
+export interface HostedReviewAnswer {
+  decision: AttentionDecision;
+  quota?: HostedQuota;
+}
+
+/**
+ * Validates a hosted attention answer through the same contract a model's own
+ * decision passes, and stamps it with the reader's clock: `decidedAt` feeds
+ * local dedup windows, so the service's clock has no business in it.
+ */
+export function hostedReviewAnswerFromWire(
+  value: unknown,
+  decidedAt: number,
+): HostedReviewAnswer | undefined {
+  if (!isRecord(value) || !isRecord(value.decision)) return undefined;
+  const wire = value.decision;
+  const decision = attentionDecisionFromModel(
+    {
+      disposition: wire.disposition,
+      summary: typeof wire.summary === "string" ? wire.summary : null,
+      answers_ask: wire.answersAsk === true,
+    },
+    decidedAt,
+  );
+  if (!decision) return undefined;
+  const quota = hostedQuotaFromWire(value.quota);
+  return { decision, ...(quota ? { quota } : {}) };
+}
+
+/** Reads the error reason out of a refused hosted answer, or nothing. */
+export function hostedErrorFromWire(value: unknown): HostedApiError | undefined {
+  if (!isRecord(value) || typeof value.error !== "string") return undefined;
+  return (Object.values(HOSTED_API_ERROR) as string[]).includes(value.error)
+    ? (value.error as HostedApiError)
+    : undefined;
+}

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -208,6 +208,19 @@ export {
   typedAskEvents,
 } from "./realtime-protocol.js";
 export {
+  HOSTED_API_ERROR,
+  HOSTED_CALLS_URL,
+  HOSTED_SERVICE_PATH,
+  type HostedApiError,
+  type HostedMintAnswer,
+  type HostedQuota,
+  type HostedReviewAnswer,
+  hostedErrorFromWire,
+  hostedMintAnswerFromWire,
+  hostedQuotaFromWire,
+  hostedReviewAnswerFromWire,
+} from "./hosted-service.js";
+export {
   REALTIME_CALLS_PATH,
   REALTIME_CLIENT_SECRETS_PATH,
   REALTIME_MINT_OUTCOME,

--- a/packages/sidecar-core/src/realtime-credentials.ts
+++ b/packages/sidecar-core/src/realtime-credentials.ts
@@ -152,6 +152,12 @@ export const REALTIME_MINT_OUTCOME = {
   NETWORK_ERROR: "network-error",
   MALFORMED_RESPONSE: "malformed-response",
   EXPIRED_CREDENTIAL: "expired-credential",
+  /** The hosted service found no signed-in account behind the request. */
+  NOT_SIGNED_IN: "not-signed-in",
+  /** Today's included voice is spent; the diagnostics carry the quota that says when it returns. */
+  QUOTA_EXHAUSTED: "quota-exhausted",
+  /** The hosted tier is switched off service-side. */
+  HOSTED_UNAVAILABLE: "hosted-unavailable",
 } as const;
 
 export type RealtimeMintOutcome =
@@ -167,6 +173,8 @@ export interface RealtimeDiagnostics {
   apiKeyConfigured: boolean;
   /** A fixture or evidence run never mints, regardless of credentials. */
   fixtureMode: boolean;
+  /** Whether voice runs on the hosted service rather than the developer's own key. */
+  hosted?: boolean;
   model: string;
   voice: string;
   /** The pace new credentials would be minted for, as a rate multiple. */
@@ -176,6 +184,13 @@ export interface RealtimeDiagnostics {
   /** A status code or error name; never a request body or credential. */
   lastDetail?: string;
   lastAttemptAt?: number;
+  /** The hosted allowance as the service last reported it; absent on a keyed run. */
+  quota?: {
+    used: number;
+    limit: number;
+    remaining: number;
+    resetsAt: number;
+  };
 }
 
 const REALTIME_MINT_EXPLANATIONS: Record<RealtimeMintOutcome, string> = {
@@ -190,6 +205,12 @@ const REALTIME_MINT_EXPLANATIONS: Record<RealtimeMintOutcome, string> = {
   [REALTIME_MINT_OUTCOME.MALFORMED_RESPONSE]: "The API answered without a usable client secret.",
   [REALTIME_MINT_OUTCOME.EXPIRED_CREDENTIAL]:
     "The API returned a client secret that had already expired, which usually means the local clock is wrong.",
+  [REALTIME_MINT_OUTCOME.NOT_SIGNED_IN]:
+    "The Luke account behind hosted voice did not authenticate. Signing out and back in usually repairs it.",
+  [REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED]:
+    "Today's included voice is used up. It returns at midnight UTC, and a personal OpenAI key in Settings removes the daily allowance.",
+  [REALTIME_MINT_OUTCOME.HOSTED_UNAVAILABLE]:
+    "Luke's hosted voice service is not answering right now. A personal OpenAI key in Settings works independently of it.",
 };
 
 /** Explains a mint outcome in one sentence, for the panel and for logs. */

--- a/packages/sidecar-core/src/realtime-credentials.ts
+++ b/packages/sidecar-core/src/realtime-credentials.ts
@@ -197,7 +197,7 @@ const REALTIME_MINT_EXPLANATIONS: Record<RealtimeMintOutcome, string> = {
   [REALTIME_MINT_OUTCOME.NOT_ATTEMPTED]: "No credential has been requested yet.",
   [REALTIME_MINT_OUTCOME.SUCCEEDED]: "A short-lived credential was minted.",
   [REALTIME_MINT_OUTCOME.NO_API_KEY]:
-    "No OpenAI key has been given. Connect one in Settings, at the top of the Voice page. Exporting OPENAI_API_KEY in a shell also works, but does not reach an app opened from Finder.",
+    "Voice has nothing to run on: no signed-in Luke account, and no OpenAI key. Signing in turns voice on with its included allowance; a key connected in Settings, at the top of the Voice page, also works. Exporting OPENAI_API_KEY in a shell works too, but does not reach an app opened from Finder.",
   [REALTIME_MINT_OUTCOME.DISABLED_BY_FIXTURE]:
     "This is a fixture or evidence run, which never uses credentials.",
   [REALTIME_MINT_OUTCOME.HTTP_ERROR]: "The API rejected the mint request.",


### PR DESCRIPTION
## What

The desktop half of the hosted free tier (#182 shipped the service half). A signed-in Luke with no OpenAI key now gets voice and attention review through the hosted endpoints; a personal key still wins outright.

- **Resolution, in `applyVoiceCredential`**: the developer's own key → today's exact direct-to-OpenAI path, untouched. No key but signed in → `HostedRealtimeCredentialMinter` and `HostedAttentionEvaluator`. Neither → voice off with the same diagnostics as before. BYOK wins because it is unmetered and keeps voice and review off Luke's servers entirely.
- **`HostedRealtimeCredentialMinter`** mirrors the keyed minter: ephemeral secret cached until near expiry, voice/pace changes discard it, failures resolve to nothing with a named outcome. The renderer is indifferent — it still receives an ephemeral connection aimed at OpenAI's canonical calls endpoint, and a credential aimed anywhere else is refused as malformed before the renderer ever sees it.
- **`HostedAttentionEvaluator`** sends **exactly the fields the prompt reads** — picked, never spread, so a session's identifiers and clock never leave the machine (tested by asserting the serialized body). A spent allowance stands reviews down until the day's counters reset, taking the 429's own `resetsAt` for when; updates held back stay derivable, the same shape as the keyed evaluator's rate-limit quiet.
- **Token lifecycle**: access tokens are read fresh from the settings store per request; a 401 asks the existing account lifecycle to refresh and retries once with the new token — an hour-lived token inside a day-lived app is routine, not an error.
- **Shared wire contract** (`sidecar-core/hosted-service.ts`): error slugs, endpoint paths, and quota/mint/review validators, now imported by the web endpoints too, so client and server cannot drift — the same standing the attention request construction got in #182.
- **Diagnostics**: new mint outcomes `not-signed-in`, `quota-exhausted` (carrying the day's quota for the panel), and `hosted-unavailable`, each with a `realtimeMintExplanation` sentence; `voiceAvailable` in the settings snapshot now counts a signed-in account, so the panel stops marking voice as missing a key it no longer needs.
- **The guide learns it in the same change**: the OpenAI fact says whose account voice currently runs on and what a personal key changes; the standing-ask and microphone facts stop claiming a key is required.

## Testing

- 12 new tests for the hosted clients: bearer/mint request shape, credential caching and discard-on-voice-change, 401 refresh-retry (and no retry when the refresh changes nothing), quota diagnostics, unavailable-vs-failure, callsUrl pinning, prompt-fields-only body, quiet-until-reset, contract violations.
- `./scripts/check.sh` passes (exit 0); all 953 desktop tests, 206 core tests, and web tests green.
- Not exercised live: an end-to-end hosted call against production needs a packaged signed-in build — the next `./scripts/run.sh` session on a Mac with no OpenAI key is the real-world check, and `Luke voice: enabled (hosted, …)` on stderr is its first line of evidence.

No UI drawing changed (the Voice page quota display is the planned follow-up), so no visual evidence run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/343d02ab-bf79-4850-a697-40e44a08ac75)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32078288411/artifacts/9304225465) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32078288411)

- Commit: `447418e88568c35131777418dabcd39b048f8311`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->


## Voice page (added after #206 landed)

The staged Voice page reveals on `voiceAvailable`, which a signed-in account now satisfies — so the page opens whole for hosted users. This PR adds the missing story: the key section says whose allowance voice runs on ("Voice is included with your Luke account — 47 of 50 calls left today") via a new `requestRealtimeDiagnostics` bridge ask (no credential material crosses), a spent allowance reads as a state with its own return time, the keyless mark says "sign in, or connect an OpenAI key," and the guide's staging description follows.

**UI change note:** this touches the renderer, so the CI-generated visual evidence should be inspected before merge; no physical-notch check was performed (developed in a cloud workspace). The Voice page's hosted note only draws with a signed-in account and no key, which the fixture evidence run (signed-out, keyless) does not capture — the first packaged signed-in run is where it shows.
