### PR TITLE
feat(desktop): let the Ask Luke field wrap and reclaim the hint's blank room

### DIFF
--- a/apps/desktop/src/renderer/ask-luke.tsx
+++ b/apps/desktop/src/renderer/ask-luke.tsx
@@ -93,6 +93,12 @@ export function askRefusal(status: RealtimeStatus, microphone: MicrophoneStatus)
  * between the question and its answer. Only a refusal earns a sentence, and it
  * leaves the draft in place, because a refused ask is still the developer's
  * words.
+ *
+ * The field wraps rather than scrolls sideways: an ask long enough to re-read
+ * is worth seeing whole, so the pill grows a line at a time — each new line an
+ * instant layout change the surface answers with one spring — up to the
+ * stylesheet's cap, where the field starts scrolling instead. Enter still
+ * sends; Shift-Enter breaks the line.
  */
 export function AskLuke({
   ask,
@@ -120,7 +126,7 @@ export function AskLuke({
   const [draft, setDraft] = useState("");
   const [asking, setAsking] = useState(false);
   const [refusal, setRefusal] = useState<string>();
-  const field = useRef<HTMLInputElement | null>(null);
+  const field = useRef<HTMLTextAreaElement | null>(null);
   /**
    * One ask at a time, as a ref rather than state for the same reason the row
    * composer holds one: disabling only lands with the next render, and a
@@ -165,7 +171,7 @@ export function AskLuke({
         // someone reaching for the caret, so the caret is what they get.
         onClick={() => field.current?.focus()}
       >
-        <input
+        <textarea
           ref={field}
           id={ASK_LUKE_INPUT_ID}
           className="ask-luke-input"
@@ -174,6 +180,7 @@ export function AskLuke({
           placeholder={ASK_PLACEHOLDER}
           autoComplete="off"
           spellCheck={false}
+          rows={1}
           value={draft}
           onChange={(event) => {
             // Typing again answers the refusal, so the refusal goes.
@@ -193,6 +200,17 @@ export function AskLuke({
             if (event.key === "Escape") {
               event.stopPropagation();
               event.currentTarget.blur();
+              return;
+            }
+            // Enter is the send a one-line field taught, kept now the field
+            // wraps; Shift-Enter is the line break, the way every chat
+            // composer splits the two. A textarea's Enter no longer submits
+            // the form on its own, so the send is asked for here — but not
+            // mid-composition: an IME's Enter is choosing a character, not
+            // taking a turn.
+            if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
+              event.preventDefault();
+              void submit();
             }
           }}
         />

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -568,7 +568,8 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "chip that opens it in the browser; and a row the developer asked Luke to listen for — " +
         "“tell me when this finishes” — wears a small listening mark beside its age, whose hover " +
         "says the ask in the developer's own words. Luke's own composer at the foot of the list " +
-        "takes a typed ask. " +
+        "takes a typed ask — Enter sends it, Shift-Enter breaks the line, and the field grows " +
+        "with what it holds. " +
         "Where a provider nests chats in a workspace — Conductor today — each " +
         "chat is its own row: a workspace holding several draws them inside one tray named by " +
         "the workspace at its top, one holding a single chat stays one row titled by the " +

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -983,15 +983,23 @@ html[data-keyboard="true"] button.row-main:focus-visible {
 
 /* The same pill every row composer draws, sized up a step because it addresses
    Luke rather than one session. A press anywhere in it lands the caret, so the
-   whole pill says text. */
+   whole pill says text.
+
+   The corner radius is written as the resting pill's half-height rather than
+   as the stadium shorthand, because the field inside wraps: at one line the
+   pill is the same stadium it always was, and a grown pill keeps that corner
+   instead of ballooning its ends around the send disc. Everything rides the
+   bottom edge — the field grows upward from the send disc's line, so the disc
+   never drifts away from the Enter it stands for. */
 .ask-luke {
+  position: relative;
   display: flex;
   min-width: 0;
-  align-items: center;
+  align-items: flex-end;
   gap: 7px;
   padding: 4px 4px 4px 14px;
   border: 1px solid var(--hairline);
-  border-radius: 999px;
+  border-radius: 19px;
   background: rgba(0, 0, 0, 0.4);
   cursor: text;
   transition:
@@ -1007,7 +1015,12 @@ html[data-keyboard="true"] button.row-main:focus-visible {
   background: rgba(0, 0, 0, 0.55);
 }
 
-/* The field itself is bare: the pill around it is the drawn edge. */
+/* The field itself is bare: the pill around it is the drawn edge. It sizes to
+   what it holds — each wrap or line break lands as an instant layout change,
+   which is what lets the surface take one clean spring to the new height
+   instead of chasing an animated field — until four lines, where the field
+   scrolls: the pill is a composer at the panel's foot, not a page. The line
+   height is written down because the cap is arithmetic on it. */
 .ask-luke-input {
   min-width: 0;
   flex: 1;
@@ -1015,9 +1028,15 @@ html[data-keyboard="true"] button.row-main:focus-visible {
   border: 0;
   background: transparent;
   color: var(--text-primary);
+  field-sizing: content;
   font-family: inherit;
   font-size: 12px;
+  line-height: 16px;
+  max-height: calc(4 * 16px + 12px);
   outline: none;
+  overflow-y: auto;
+  overflow-wrap: anywhere;
+  resize: none;
 }
 
 .ask-luke-input::placeholder {
@@ -1026,9 +1045,15 @@ html[data-keyboard="true"] button.row-main:focus-visible {
 
 /* How the reach is learned: the keycaps surface while the pointer is over the
    pill and stand down again once the caret is in or a draft holds the field —
-   whoever they could teach already knows. They keep their layout box in every
-   state and only fade, so hovering re-shapes nothing, and they take no
-   pointer: a press on them is a press on the field they name.
+   whoever they could teach already knows. They overlay the field's tail
+   rather than taking a flex slot, so hovering re-shapes nothing and an idle
+   pill holds no blank room between its placeholder and the send disc; they
+   take no pointer: a press on them is a press on the field they name.
+
+   The offsets are the neighbours' own arithmetic: 37px clears the send disc
+   (4px inset + 26px disc + the pill's 7px gap), and 10px centres a 16px cap
+   on the field's 28px single line — the only line there ever is while the
+   caps can show, because a draft stands them down.
 
    A step smaller than a settings row's caps: these ride inside the composer
    beside its placeholder, where a full-size key would read as a control rather
@@ -1036,6 +1061,10 @@ html[data-keyboard="true"] button.row-main:focus-visible {
 .ask-luke-hint {
   --keycap-size: 16px;
   --keycap-text: 9.5px;
+
+  position: absolute;
+  right: 37px;
+  bottom: 10px;
   opacity: 0;
   pointer-events: none;
   transition: opacity var(--duration-hover) ease;


### PR DESCRIPTION
## What

Two changes to the Ask Luke composer at the panel's foot:

- **The blank room before the send disc is gone.** The ask-key hint's keycaps used to hold a flex slot even while invisible, leaving dead space between the field's tail and the send disc. They now overlay the field's tail with absolute positioning — hovering still re-shapes nothing, and the field runs right up to the disc's gap.
- **The field takes multiple lines.** The one-line `<input>` becomes a self-sizing `<textarea>` (`field-sizing: content`): it wraps, Shift-Enter breaks the line, and each new line lands as an instant layout change the surface answers with one clean spring — never an animated height, per DESIGN.md. At four lines the field scrolls instead of growing. Enter still sends, an IME's Enter still chooses a character, and Escape still lets go of the field with the draft intact.

The pill's corner is written as the resting half-height (19px) instead of the stadium shorthand, so the resting pill is pixel-identical and a grown pill keeps its corner instead of ballooning its ends; content rides the bottom edge so the send disc stays on the line being typed. The guide learns the new behavior in the same change.

## Verification

- `./scripts/check.sh` passes (repository checks, types, tests, builds; 0 test failures).
- Headless-Chromium harness over the built stylesheet, replicating the composer's exact DOM, measured every state: resting pill unchanged at 38px/19px radius; field-to-disc gap is the pill's own 7px in every state; hint overlays inside the field's box, 7px off the disc; growth 28 → 44 (two lines) → 60 (wrapped) → capped at 76px with `scrollHeight` 156 scrolling beyond it.
- `./scripts/verify.sh` runs in CI on macOS; its evidence is linked from this description. No physical-notch check was performed (change is inside the panel's composer, below the housing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/128d2b6a-1587-4dfe-b12d-5ffe366792ea)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32070556970/artifacts/9301605508) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32070556970)

- Commit: `a664291bb764e1e3aa87a2a01eb72dd5bdd7cef8`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
