### PR TITLE
feat(updates): retire the automatic-check switch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,8 +167,9 @@ Trust constraints:
   volume himself; turning it up stays the user's own act on their own keys.
 - The update check is the one request Luke makes with no user-supplied key at
   all: an unauthenticated read of this repository's latest release name from
-  GitHub's public API, on a timer the `automaticUpdates` setting owns and at
-  the press of the Updates row's button — never in a fixture or capture run.
+  GitHub's public API, on a timer of its own — always on, like the
+  announcements, answering only to the run mode — and at the press of the
+  Updates row's button; never in a fixture or capture run.
   It carries nothing about the user, their sessions, or their keys; only the
   release's version name is read back, and what a check learns changes only
   what the row says. The way to a newer build is the browser, at the releases

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -28,12 +28,11 @@ transcript, or key material — GitHub sees what any HTTPS request shows it,
 such as the network address it came from, under GitHub's own policies. Only
 the release's version name is read from the answer.
 
-With automatic checks on — the default — Luke asks at launch and a few times a
-day; turning the Updates section's switch off stops the timed check entirely,
-leaving only the row's own Check for Updates button. Fixture and evidence runs
-never check. What a check learns changes only what the row says: fetching an
-update is your own download in the browser, from the repository's releases
-page, and Luke never modifies the running app.
+Luke asks at launch and a few times a day while running, and at the press of
+the Updates row's Check for Updates button. Fixture and evidence runs never
+check. What a check learns changes only what the row says: fetching an update
+is your own download in the browser, from the repository's releases page, and
+Luke never modifies the running app.
 
 ## What Luke reads locally
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1487,20 +1487,6 @@ function registerIpc(): void {
     refusal: "Could not save that setting on this system.",
   });
 
-  // The check follows the stored answer at once, like the duck: off must stop
-  // the timer now rather than at the next launch. A run that sends no network
-  // never arms it, whatever the file says.
-  registerSettingHandler(channels.setAutomaticUpdates, {
-    validate(enabled: unknown) {
-      if (typeof enabled !== "boolean") throw new Error("Invalid update check request");
-      return enabled;
-    },
-    save: (enabled) => settingsStore.setAutomaticUpdates(enabled),
-    apply: (result) =>
-      updateService.setAutomatic(result.settings.automaticUpdates && runMode.sendsNetwork),
-    refusal: "Could not save that setting on this system.",
-  });
-
   // The row's button. Answered rather than fire-and-forget so the row that
   // asked and the broadcast never disagree; a run that sends no network
   // answers with the standing snapshot rather than make a request it must not.
@@ -2871,15 +2857,10 @@ if (!app.requestSingleInstanceLock()) {
       (enabled) => mediaDuck.setEnabled(enabled),
       () => mediaDuck.setEnabled(APP_SETTING_DEFAULTS.duckOtherMedia),
     );
-    // Armed from the settings file alone, like the duck — and never in a run
-    // that must stay deterministic: a fixture or capture run sends no network,
+    // Always on, like the announcements: the timed check answers to no
+    // setting, only to the run — a fixture or capture run sends no network,
     // so it never asks GitHub anything.
-    if (runMode.sendsNetwork) {
-      void settingsStore.automaticUpdates().then(
-        (enabled) => updateService.setAutomatic(enabled),
-        () => updateService.setAutomatic(APP_SETTING_DEFAULTS.automaticUpdates),
-      );
-    }
+    if (runMode.sendsNetwork) updateService.start();
     // The hook registrations converge at every launch. Each provider's
     // failure is logged under its own name and absorbed inside — a launch
     // must never hang on another app's configuration file — so this catch is

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -53,7 +53,6 @@ const bridge: AppBridge = {
   },
   removeCalendarAccount: invoke(channels.removeCalendarAccount),
   setCalendarSelected: invoke(channels.setCalendarSelected),
-  setAutomaticUpdates: invoke(channels.setAutomaticUpdates),
   checkForUpdates: invoke(channels.checkForUpdates),
   openLatestRelease: () => ipcRenderer.send(channels.openLatestRelease),
   setVoiceExchangeActive: (active) => {

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -726,12 +726,6 @@ export function App(): React.JSX.Element {
     calendarConnect.cancel();
   }, [calendarConnect.cancel, calendarConnect.latest]);
 
-  const changeAutomaticUpdates = useCallback(
-    async (enabled: boolean) =>
-      applySettingsReply(await window.sidecar.setAutomaticUpdates(enabled)),
-    [applySettingsReply],
-  );
-
   /**
    * Asking to write a key is asking for one thing, so the panel gets out of the
    * way of it: the shape goes down to the slot, which is the field and nothing
@@ -1433,11 +1427,9 @@ export function App(): React.JSX.Element {
           const opening = presentationOf() !== PANEL_PRESENTATION.PANEL;
           // The guide's ids travel as plain text, so one that names no setting
           // of Luke's names no page either — and nothing will fly to it.
-          const settingPage = isAppSettingId(action.setting.id)
+          const page = isAppSettingId(action.setting.id)
             ? SETTING_PAGE[action.setting.id]
             : undefined;
-          // A front-page setting opens no page at all: the tab is the flight.
-          const page = settingPage === SETTINGS_VIEW.ROOT ? undefined : settingPage;
           try {
             await changeMode(true);
             // Queued rather than flown at once. The tab, the page and the wait
@@ -2204,7 +2196,6 @@ export function App(): React.JSX.Element {
     onVoiceCaptionsChange: changeVoiceCaptions,
     onDuckOtherMediaChange: changeDuckOtherMedia,
     onQuietDuringMeetingsChange: changeQuietDuringMeetings,
-    onAutomaticUpdatesChange: changeAutomaticUpdates,
     onVoiceChange: changeVoice,
     onVoiceSpeedChange: changeVoiceSpeed,
     onShowInMenuBarChange: changeShowInMenuBar,

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -75,7 +75,6 @@ export const APP_SETTING_ID = {
   DEFAULT_WORKSPACE_PROVIDER: "default_workspace_provider",
   WORKSPACE_AGENT_MODEL: "workspace_agent_model",
   WORKSPACE_AGENT_EFFORT: "workspace_agent_effort",
-  AUTOMATIC_UPDATES: "automatic_updates",
 } as const;
 
 export type AppSettingId = (typeof APP_SETTING_ID)[keyof typeof APP_SETTING_ID];
@@ -100,7 +99,7 @@ const VOICE_PAGE = `${SETTINGS_TAB}, on its Voice page`;
 const APPEARANCE_PAGE = `${SETTINGS_TAB}, on its Appearance page`;
 const SHORTCUTS_PAGE = `${SETTINGS_TAB}, on its Keyboard shortcuts page`;
 const CONNECTIONS_PAGE = `${SETTINGS_TAB}, on its Connections page`;
-/* The one switch drawn on the front page itself, beside Feedback. */
+/* Where the Updates section stands, for the fact that describes it. */
 const FRONT_PAGE = `${SETTINGS_TAB}, on its front page`;
 
 /** Where the Conductor agent choices live, said once for both their entries. */
@@ -226,19 +225,6 @@ const SETTING_GUIDE: Record<
     defaultValue: appToggleText(APP_SETTING_DEFAULTS.quietDuringMeetings),
     adjustable: true,
     manual: `${CONNECTIONS_PAGE} — drawn once a calendar account is connected`,
-  }),
-  automaticUpdates: (settings) => ({
-    id: APP_SETTING_ID.AUTOMATIC_UPDATES,
-    label: "Automatic update checks",
-    description:
-      "Whether Luke asks GitHub for the latest release name a few times a day, so the Updates " +
-      "row can say a newer one exists. Nothing about the developer or their sessions is sent, " +
-      "and fetching an update stays a by-hand download in the browser.",
-    kind: APP_SETTING_KIND.TOGGLE,
-    value: appToggleText(settings.automaticUpdates),
-    defaultValue: appToggleText(APP_SETTING_DEFAULTS.automaticUpdates),
-    adjustable: true,
-    manual: FRONT_PAGE,
   }),
   showInMenuBar: (settings) => ({
     id: APP_SETTING_ID.SHOW_IN_MENU_BAR,
@@ -797,11 +783,15 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       : []),
     {
       label: "Updates",
+      // A behavior rather than a setting, like the announcements: stated so
+      // Luke neither denies checking nor offers a switch that does not exist.
       detail:
         `The Updates section on ${FRONT_PAGE} says which version this is and whether a newer ` +
-        "release exists. Its button checks GitHub on the spot; with automatic checks on — the " +
-        "default — Luke also asks a few times a day. A newer release is fetched by hand in the " +
-        "browser, from the fixed releases page: Luke never changes the running build himself.",
+        "release exists. Its button checks GitHub on the spot, and Luke also checks on his own " +
+        "a few times a day — always on; nothing about the developer or their sessions is sent, " +
+        "and only the release's version name is read back. A newer release is fetched by hand " +
+        "in the browser, from the fixed releases page: Luke never changes the running build " +
+        "himself.",
     },
     {
       label: "Quitting",
@@ -879,7 +869,6 @@ export async function applySpokenSetting(
     | "setVoiceCaptions"
     | "setDuckOtherMedia"
     | "setQuietDuringMeetings"
-    | "setAutomaticUpdates"
     | "setShowInMenuBar"
     | "setShowInDock"
     | "setShowOnAllDisplays"
@@ -917,22 +906,20 @@ export async function applySpokenSetting(
         ? await bridge.setDuckOtherMedia(enabled)
         : action.setting.id === APP_SETTING_ID.QUIET_DURING_MEETINGS
           ? await bridge.setQuietDuringMeetings(enabled)
-          : action.setting.id === APP_SETTING_ID.AUTOMATIC_UPDATES
-            ? await bridge.setAutomaticUpdates(enabled)
-            : action.setting.id === APP_SETTING_ID.SHOW_IN_MENU_BAR
-              ? await bridge.setShowInMenuBar(enabled)
-              : action.setting.id === APP_SETTING_ID.SHOW_IN_DOCK
-                ? await bridge.setShowInDock(enabled)
-                : action.setting.id === APP_SETTING_ID.SHOW_ON_ALL_DISPLAYS
-                  ? await bridge.setShowOnAllDisplays(enabled)
-                  : action.setting.id === APP_SETTING_ID.VOICE_SPEED && speed !== undefined
-                    ? await bridge.setVoiceSpeed(speed)
-                    : action.setting.id === APP_SETTING_ID.VOICE && isRealtimeVoice(action.value)
-                      ? await bridge.setVoice(action.value)
-                      : action.setting.id === APP_SETTING_ID.FORM_FACTOR &&
-                          isPanelFormFactor(action.value)
-                        ? await bridge.setFormFactor(action.value)
-                        : undefined;
+          : action.setting.id === APP_SETTING_ID.SHOW_IN_MENU_BAR
+            ? await bridge.setShowInMenuBar(enabled)
+            : action.setting.id === APP_SETTING_ID.SHOW_IN_DOCK
+              ? await bridge.setShowInDock(enabled)
+              : action.setting.id === APP_SETTING_ID.SHOW_ON_ALL_DISPLAYS
+                ? await bridge.setShowOnAllDisplays(enabled)
+                : action.setting.id === APP_SETTING_ID.VOICE_SPEED && speed !== undefined
+                  ? await bridge.setVoiceSpeed(speed)
+                  : action.setting.id === APP_SETTING_ID.VOICE && isRealtimeVoice(action.value)
+                    ? await bridge.setVoice(action.value)
+                    : action.setting.id === APP_SETTING_ID.FORM_FACTOR &&
+                        isPanelFormFactor(action.value)
+                      ? await bridge.setFormFactor(action.value)
+                      : undefined;
   if (!result) {
     // An adjustable entry with no carrier is a guide ahead of its wiring;
     // refuse honestly rather than claim a change that never happened.

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -166,8 +166,6 @@ export interface PreferenceWrites {
    * answer belongs.
    */
   onQuietDuringMeetingsChange: (enabled: boolean) => Promise<string | undefined>;
-  /** Turns the timed update check on or off. */
-  onAutomaticUpdatesChange: (enabled: boolean) => Promise<string | undefined>;
   /** Chooses the voice Luke speaks with, from the set fixed by this build. */
   onVoiceChange: (voice: RealtimeVoice) => void;
   /** Chooses the pace Luke speaks at, from the set fixed by this build. */
@@ -2330,15 +2328,7 @@ function pageResetControl(
   return undefined;
 }
 
-function UpdatesSection({
-  control,
-  automaticUpdates,
-  onAutomaticUpdatesChange,
-}: {
-  control: UpdateControl;
-  automaticUpdates: boolean;
-  onAutomaticUpdatesChange: (enabled: boolean) => Promise<string | undefined>;
-}): React.JSX.Element {
+function UpdatesSection({ control }: { control: UpdateControl }): React.JSX.Element {
   const row = updateRow(control.update);
   return (
     <section className="settings-section" style={{ "--row-index": 2 } as React.CSSProperties}>
@@ -2369,13 +2359,11 @@ function UpdatesSection({
           </button>
         )}
       </div>
-      <SwitchRow
-        label="Check for updates automatically"
-        detail="Asks GitHub for the latest release name a few times a day. Nothing about you or your sessions is sent."
-        errand={APP_SETTING_ID.AUTOMATIC_UPDATES}
-        checked={automaticUpdates}
-        onChange={onAutomaticUpdatesChange}
-      />
+      {/* Always on, like the announcements — stated rather than switched, so
+          the disclosure the retired switch carried is still on the row. */}
+      <p className="settings-note">
+        Luke checks on his own a few times a day. Nothing about you or your sessions is sent.
+      </p>
     </section>
   );
 }
@@ -2527,13 +2515,7 @@ export function SettingsPanel({
 
       {drawnView !== SETTINGS_VIEW.ROOT ? null : (
         <>
-          {settings ? (
-            <UpdatesSection
-              control={updates}
-              automaticUpdates={settings.automaticUpdates}
-              onAutomaticUpdatesChange={preferences.onAutomaticUpdatesChange}
-            />
-          ) : null}
+          <UpdatesSection control={updates} />
 
           <FeedbackSection control={feedback} />
 

--- a/apps/desktop/src/renderer/settings-views.ts
+++ b/apps/desktop/src/renderer/settings-views.ts
@@ -72,7 +72,7 @@ export function pageExitMs(element: Element | null): number {
  * each setting. That the two agree is a test rather than a type, because one
  * is a sentence and the other is a page.
  */
-export const SETTING_PAGE: Record<AppSettingId, SettingsView> = {
+export const SETTING_PAGE: Record<AppSettingId, SettingsSubview> = {
   [APP_SETTING_ID.VOICE]: SETTINGS_VIEW.VOICE,
   [APP_SETTING_ID.VOICE_SPEED]: SETTINGS_VIEW.VOICE,
   [APP_SETTING_ID.VOICE_CAPTIONS]: SETTINGS_VIEW.VOICE,
@@ -84,9 +84,6 @@ export const SETTING_PAGE: Record<AppSettingId, SettingsView> = {
   [APP_SETTING_ID.SHOW_IN_DOCK]: SETTINGS_VIEW.APPEARANCE,
   [APP_SETTING_ID.SHOW_ON_ALL_DISPLAYS]: SETTINGS_VIEW.APPEARANCE,
   [APP_SETTING_ID.FORM_FACTOR]: SETTINGS_VIEW.APPEARANCE,
-  // Drawn on the front page itself, beside Feedback: a flight
-  // to it opens no page at all, only the tab.
-  [APP_SETTING_ID.AUTOMATIC_UPDATES]: SETTINGS_VIEW.ROOT,
   // The three the guide describes but marks by-hand-only. Nothing flies to
   // them — a spoken ask is refused before it reaches a page — but where they
   // are drawn is a fact about the settings either way, and answering it here
@@ -111,8 +108,7 @@ export function credentialSettingsPage(providerId: CredentialProviderId): Settin
 }
 
 /** How each page names itself, which is how the guide's by-hand paths word it. */
-export const SETTINGS_PAGE_LABEL: Record<SettingsView, string> = {
-  [SETTINGS_VIEW.ROOT]: "front page",
+export const SETTINGS_PAGE_LABEL: Record<SettingsSubview, string> = {
   [SETTINGS_VIEW.VOICE]: "Voice",
   [SETTINGS_VIEW.APPEARANCE]: "Appearance",
   [SETTINGS_VIEW.SHORTCUTS]: "Keyboard shortcuts",

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -55,7 +55,6 @@ const SETTINGS_FIELD = {
   API_KEYS: "apiKeys",
   CALENDAR_ACCOUNTS: "calendarAccounts",
   ASK_HOTKEY: "askHotkey",
-  AUTOMATIC_UPDATES: "automaticUpdates",
   DEFAULT_WORKSPACE_PROVIDER: "defaultWorkspaceProvider",
   DUCK_OTHER_MEDIA: "duckOtherMedia",
   FEEDBACK_SENDS: "feedbackSends",
@@ -208,13 +207,6 @@ interface PersistedSettings {
    * windows somewhere new.
    */
   showOnAllDisplays: boolean;
-  /**
-   * Whether the timed update check runs. On unless the file says `false`
-   * outright, like the media duck: a missing field and a corrupt value both
-   * land on checking, because a build left silently behind is the failure
-   * this setting exists to prevent.
-   */
-  automaticUpdates: boolean;
   /**
    * How Luke stands on a display without a housing, absent until the user has
    * chosen. Held to the offered set like the voice: a value this build does
@@ -536,10 +528,6 @@ function parsePersistedSettings(source: string): PersistedSettings {
       record[SETTINGS_FIELD.SHOW_ON_ALL_DISPLAYS],
       APP_SETTING_DEFAULTS.showOnAllDisplays,
     ),
-    automaticUpdates: booleanSetting(
-      record[SETTINGS_FIELD.AUTOMATIC_UPDATES],
-      APP_SETTING_DEFAULTS.automaticUpdates,
-    ),
     // A form this build does not draw is dropped like an unknown voice.
     ...(isPanelFormFactor(formFactor) ? { formFactor } : {}),
     // A provider this build does not know is dropped the same way: it names
@@ -628,7 +616,6 @@ export class SettingsStore {
       duckOtherMedia: persisted.duckOtherMedia,
       quietDuringMeetings: persisted.quietDuringMeetings,
       showOnAllDisplays: persisted.showOnAllDisplays,
-      automaticUpdates: persisted.automaticUpdates,
       formFactor: persisted.formFactor ?? DEFAULT_PANEL_FORM_FACTOR,
       ...(persisted.defaultWorkspaceProvider
         ? { defaultWorkspaceProvider: persisted.defaultWorkspaceProvider }
@@ -747,14 +734,6 @@ export class SettingsStore {
    */
   async duckOtherMedia(): Promise<boolean> {
     return (await this.#load()).duckOtherMedia;
-  }
-
-  /**
-   * Shallow for the same reason `duckOtherMedia()` is: the update check arms
-   * at startup, and arming it must never be what wakes the OS keychain.
-   */
-  async automaticUpdates(): Promise<boolean> {
-    return (await this.#load()).automaticUpdates;
   }
 
   /**
@@ -933,17 +912,6 @@ export class SettingsStore {
     return this.#setField((persisted) => {
       if (persisted.quietDuringMeetings === enabled) return;
       return { ...persisted, quietDuringMeetings: enabled };
-    });
-  }
-
-  /**
-   * Turns the timed update check on or off. A plain preference like the media
-   * duck's: no cipher, no invalid value, so the write either lands or throws.
-   */
-  async setAutomaticUpdates(enabled: boolean): Promise<SettingsUpdateResult> {
-    return this.#setField((persisted) => {
-      if (persisted.automaticUpdates === enabled) return;
-      return { ...persisted, automaticUpdates: enabled };
     });
   }
 

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -123,7 +123,6 @@ export const APP_SETTING_DEFAULTS = {
   duckOtherMedia: true,
   quietDuringMeetings: true,
   showOnAllDisplays: false,
-  automaticUpdates: true,
 } as const satisfies Partial<Record<keyof AppSettings, boolean>>;
 
 /**
@@ -282,14 +281,6 @@ export interface AppSettings {
    * again is what brings him back to it.
    */
   showOnAllDisplays: boolean;
-  /**
-   * Whether Luke asks GitHub for the latest release name on a timer, so the
-   * settings row can say an update exists. On by default and bounded on every
-   * side: the check carries nothing about the user or their sessions, learns
-   * only a version name, and changes only what the row says. Off, the only
-   * check is the row's own button being pressed.
-   */
-  automaticUpdates: boolean;
   /**
    * How Luke stands on a display without a camera housing: a drawn notch
    * pressed into the top edge, or the free-floating bubble every such display
@@ -563,8 +554,6 @@ export interface AppBridge {
   resetSettings(scope: SettingsResetScope): Promise<SettingsUpdateResult>;
   /** Turns the quieting of Music and Spotify during a spoken exchange on or off. */
   setDuckOtherMedia(enabled: boolean): Promise<SettingsUpdateResult>;
-  /** Turns the timed update check on or off, and remembers the choice. */
-  setAutomaticUpdates(enabled: boolean): Promise<SettingsUpdateResult>;
   /**
    * Asks GitHub for the latest release name, right now, because the row's
    * button was pressed. The answer is the same snapshot the broadcast
@@ -852,7 +841,6 @@ export const channels = {
   setCalendarSelected: "app:set-calendar-selected",
   calendarsChanged: "app:calendars-changed",
   meetingQuietChanged: "app:meeting-quiet-changed",
-  setAutomaticUpdates: "app:set-automatic-updates",
   checkForUpdates: "app:check-for-updates",
   openLatestRelease: "app:open-latest-release",
   updateChanged: "app:update-changed",

--- a/apps/desktop/src/update-service.ts
+++ b/apps/desktop/src/update-service.ts
@@ -100,16 +100,11 @@ export class UpdateService {
   }
 
   /**
-   * Starts or stops the timed check. Starting checks at once — a build that
-   * only ever checked hours after launch would spend its first day behind —
-   * and the timer never holds the process open.
+   * Starts the timed check. It checks at once — a build that only ever
+   * checked hours after launch would spend its first day behind — and the
+   * timer never holds the process open.
    */
-  setAutomatic(enabled: boolean): void {
-    if (!enabled) {
-      if (this.#timer) clearInterval(this.#timer);
-      this.#timer = undefined;
-      return;
-    }
+  start(): void {
     if (this.#timer) return;
     void this.check();
     this.#timer = setInterval(() => void this.check(), this.#intervalMs);
@@ -117,7 +112,8 @@ export class UpdateService {
   }
 
   stop(): void {
-    this.setAutomatic(false);
+    if (this.#timer) clearInterval(this.#timer);
+    this.#timer = undefined;
   }
 
   async #read(): Promise<UpdateSnapshot> {

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -612,10 +612,6 @@ test("every adjustable setting is carried to the bridge call its row uses", asyn
       calls.push(`setQuietDuringMeetings:${enabled}`);
       return answered;
     },
-    setAutomaticUpdates: async (enabled: boolean) => {
-      calls.push(`setAutomaticUpdates:${enabled}`);
-      return answered;
-    },
     setShowInMenuBar: async (show: boolean) => {
       calls.push(`setShowInMenuBar:${show}`);
       return answered;
@@ -652,7 +648,6 @@ test("every adjustable setting is carried to the bridge call its row uses", asyn
   }
 
   assert.deepEqual(calls.sort(), [
-    "setAutomaticUpdates:true",
     "setDuckOtherMedia:true",
     "setFormFactor:notch",
     "setQuietDuringMeetings:true",

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -467,22 +467,6 @@ test("announcements wait out meetings until asked otherwise, and the choice surv
   assert.equal(cipher.calls.encrypt, 0);
 });
 
-test("updates are checked for until asked otherwise, and the choice survives a reopen", async (t) => {
-  const directory = await temporaryDirectory(t);
-  // A preference is not a credential, so choosing it must reach the Keychain
-  // not at all.
-  const cipher = countingCipher();
-  const store = storeIn(directory, { cipher });
-
-  assert.equal((await store.snapshot()).automaticUpdates, true);
-  const disabled = await store.setAutomaticUpdates(false);
-
-  assert.equal(disabled.settings.automaticUpdates, false);
-  assert.equal((await storeIn(directory).snapshot()).automaticUpdates, false);
-  assert.equal(cipher.calls.isAvailable, 0);
-  assert.equal(cipher.calls.encrypt, 0);
-});
-
 test("switching the meeting quiet never disturbs a stored key", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);
@@ -505,20 +489,6 @@ test("a corrupt meeting quiet value reads as the default rather than as off", as
   );
 
   assert.equal((await storeIn(directory).snapshot()).quietDuringMeetings, true);
-});
-
-test("a corrupt update check value reads as the default rather than as off", async (t) => {
-  const directory = await temporaryDirectory(t);
-  // The media duck's rule: each lands on its own default, and this one's
-  // default is on — a build left silently behind is the failure the setting
-  // exists to prevent.
-  await fs.writeFile(
-    path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({ version: 2, apiKeys: {}, automaticUpdates: "no" }),
-    "utf8",
-  );
-
-  assert.equal((await storeIn(directory).snapshot()).automaticUpdates, true);
 });
 
 test("keeps each provider's key, environment fallback, and reported source separate", async (t) => {
@@ -577,7 +547,6 @@ test("keeps both keys when two providers are saved at once", async (t) => {
     duckOtherMedia: true,
     quietDuringMeetings: true,
     showOnAllDisplays: false,
-    automaticUpdates: true,
   });
   const reopened = storeIn(directory, { providers: TEST_PROVIDERS });
   assert.equal(await reopened.readApiKey(FIRST_CLOUD), "first-cloud-key");
@@ -779,7 +748,6 @@ test("keeps a Conductor key stored by an earlier version working", async (t) => 
     duckOtherMedia: true,
     quietDuringMeetings: true,
     showOnAllDisplays: false,
-    automaticUpdates: true,
   });
   assert.equal(await storeIn(directory).readApiKey(CONDUCTOR), "conductor-replacement-key");
 });
@@ -804,7 +772,6 @@ test("carries a key belonging to a provider this build does not know", async (t)
     duckOtherMedia: true,
     quietDuringMeetings: true,
     showOnAllDisplays: false,
-    automaticUpdates: true,
   });
 });
 
@@ -827,7 +794,6 @@ test("shows the menu bar item until asked otherwise, and remembers the answer", 
     duckOtherMedia: true,
     quietDuringMeetings: true,
     showOnAllDisplays: false,
-    automaticUpdates: true,
   });
   // The choice outlives the run that heard it.
   assert.equal((await storeIn(directory).snapshot()).showInMenuBar, false);
@@ -911,7 +877,6 @@ test("keeps Luke out of the Dock until asked, and remembers the answer", async (
     duckOtherMedia: true,
     quietDuringMeetings: true,
     showOnAllDisplays: false,
-    automaticUpdates: true,
   });
   // The choice outlives the run that heard it.
   assert.equal((await storeIn(directory).snapshot()).showInDock, true);

--- a/apps/desktop/tests/update-service.test.ts
+++ b/apps/desktop/tests/update-service.test.ts
@@ -167,11 +167,11 @@ test("the timed check starts at once and stops when asked", async () => {
     },
   });
 
-  service.setAutomatic(true);
+  service.start();
   await sleep(35);
   assert.ok(requests >= 2, `expected the timer to have checked again, saw ${requests}`);
 
-  service.setAutomatic(false);
+  service.stop();
   const settled = requests;
   await sleep(30);
   assert.equal(requests, settled);


### PR DESCRIPTION
## Summary

- The timed update check reads one version name over an unauthenticated request, so a switch bought nothing but a way to fall silently behind — the same grounds on which the announcements retired theirs. Checking is now always on while the run sends network at all (fixture/capture runs still never check).
- `automaticUpdates` leaves `AppSettings`, the defaults, the store (field, parse, shallow reader, writer — a stale key in an existing settings.json is dropped on the next write), the `app:set-automatic-updates` channel, the bridge, and the preload.
- The Updates section keeps the version row and its button; a `settings-note` beneath now states the behavior the retired switch's detail used to disclose. `UpdatesSection` no longer needs `settings`, so it draws unconditionally.
- The guide entry, `APP_SETTING_ID.AUTOMATIC_UPDATES`, and the `applySpokenSetting` branch go; the Updates **fact** now says the check is always on — stated rather than switched, so Luke neither denies checking nor offers a switch that does not exist (the announcements' precedent, per the guide's own comment style).
- `SETTING_PAGE`/`SETTINGS_PAGE_LABEL` revert to subview-only (nothing flies to the front page anymore), and `UpdateService.setAutomatic(boolean)` simplifies to `start()`/`stop()`.
- PRIVACY.md and AGENTS.md reworded: the check runs on a timer of its own, answering only to the run mode.

## Evidence

- Platform-independent checks: `./scripts/check.sh` exit 0 (Linux); 955 desktop tests pass, including the guide's adjustable-carrier and settings-file exact-content assertions with the setting gone
- macOS Electron verification (`./scripts/verify.sh`): `not run` locally (Linux sandbox) — the smoke fixtures do not open the Settings tab; the Updates section still needs its one physical-Mac eyeball, unchanged from #186

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32072303870/artifacts/9302202320) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32072303870)

- Commit: `ea6c53d8f822415175a670bb375fbc71ecd6b935`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: none — behavior-wise this only removes the ability to turn the timed check off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d2288aaa-3db1-4ede-9fc2-9d0cb6e0035b)
