### PR TITLE
fix(sessions): date Claude Code sessions by their conversation records alone

### DIFF
--- a/apps/desktop/src/claude-code-adapter.ts
+++ b/apps/desktop/src/claude-code-adapter.ts
@@ -96,6 +96,13 @@ const CLAUDE_ADAPTER_DEFAULTS = {
   READ_HEAD_BYTES: 64 * 1024,
   MAXIMUM_ACTIVITY_LENGTH: 80,
   /**
+   * How far the one deeper read may reach when the bounded tail carries no
+   * conversation clock at all — bookkeeping appended in bulk past the whole
+   * tail, or a single record larger than it. Past this bound the file's date
+   * is the only account left, and the mtime fallback stands.
+   */
+  CLOCK_RESCUE_TAIL_BYTES: 512 * 1024,
+  /**
    * How much older than the transcript's clock a hook event may run and still
    * describe the same moment. The hook fires as a turn boundary happens and
    * the closing records land moments later under their own timestamps, so a
@@ -252,6 +259,17 @@ function cwdFromRecord(record: Record<string, unknown>): string | undefined {
 }
 
 /**
+ * Whether a record belongs to the conversation itself rather than to the
+ * bookkeeping Claude Code writes beside it. Only the conversation may date the
+ * session: bookkeeping is appended in bulk long after a conversation settled,
+ * so its stamps say when something handled the file, not when the session last
+ * moved — the same distinction that keeps mtime from dating it.
+ */
+function isConversationRecord(record: Record<string, unknown>): boolean {
+  return record.type === CLAUDE_RECORD_TYPE.SYSTEM || eventTypeFromRecord(record) !== undefined;
+}
+
+/**
  * Whether a user record carries a tool's output rather than a person's prompt.
  * The two look alike at the top level and mean opposite things: one continues
  * the turn under way, the other opens a new one.
@@ -276,7 +294,9 @@ function turnEnded(parsed: ParsedClaudeSessionTail): boolean {
 function readClaudeRecord(record: Record<string, unknown>, parsed: ParsedClaudeSessionTail): void {
   parsed.cwd = cwdFromRecord(record) ?? parsed.cwd;
   parsed.branch = text(record.gitBranch) ?? parsed.branch;
-  parsed.timestampMs = timestampFromRecord(record) ?? parsed.timestampMs;
+  if (isConversationRecord(record)) {
+    parsed.timestampMs = timestampFromRecord(record) ?? parsed.timestampMs;
+  }
 
   if (record.type === CLAUDE_RECORD_TYPE.AI_TITLE) {
     parsed.aiTitle = oneLine(text(record.aiTitle), maximumSessionTitleLength) ?? parsed.aiTitle;
@@ -440,12 +460,13 @@ function observationFromSessionFile(
   activeSessionFreshnessMs: number,
   hookEvent?: ObservedClaudeHookEvent,
 ): ProviderSessionObservation {
-  // The transcript's own clock, not the file's. Claude Code touches session
+  // The conversation's own clock, not the file's. Claude Code touches session
   // files in bulk long after their conversations ended — appending bookkeeping
-  // records and bumping mtimes — so mtime says when something last handled the
-  // file, while the last timestamped record says when the session last moved.
-  // Trusting mtime made every touched session read as active just now. The
-  // file's date remains the fallback for a tail that carried no timestamp.
+  // records, stamped or not, and bumping mtimes — so mtime says when something
+  // last handled the file, while the last timestamped conversation record says
+  // when the session last moved. Trusting mtime made every touched session
+  // read as active just now. The file's date remains the fallback for a
+  // transcript in which no conversation clock could be found at all.
   const transcriptAt = parsed.timestampMs ?? candidate.mtimeMs;
   // A hook event trailing the transcript's clock by more than the tolerance
   // describes a turn the transcript already moved past, so it is ignored
@@ -521,7 +542,23 @@ export class ClaudeCodeSessionAdapter implements SessionProviderAdapter {
   async #parsedTail(candidate: SessionFileCandidate): Promise<ParsedClaudeSessionTail> {
     const cached = this.#parsedTails.get(candidate.filePath);
     if (cached && cached.mtimeMs === candidate.mtimeMs) return cached.parsed;
-    const parsed = parseClaudeSessionTail(await readTail(candidate.filePath, this.#readTailBytes));
+    const tail = await readTail(candidate.filePath, this.#readTailBytes);
+    let parsed = parseClaudeSessionTail(tail);
+    // A truncated tail holding no conversation clock says nothing about when
+    // the session last moved, and the file's date is exactly what a bulk
+    // touch falsifies — so one deeper read goes looking for the conversation
+    // before the fallback is trusted. A file read whole is never re-read:
+    // there is nothing further back to find.
+    if (
+      parsed.timestampMs === undefined &&
+      Buffer.byteLength(tail, "utf8") >= this.#readTailBytes &&
+      CLAUDE_ADAPTER_DEFAULTS.CLOCK_RESCUE_TAIL_BYTES > this.#readTailBytes
+    ) {
+      const rescued = parseClaudeSessionTail(
+        await readTail(candidate.filePath, CLAUDE_ADAPTER_DEFAULTS.CLOCK_RESCUE_TAIL_BYTES),
+      );
+      if (rescued.timestampMs !== undefined) parsed = rescued;
+    }
     if (!parsed.aiTitle) {
       parsed.aiTitle = titleFromHead(await readHead(candidate.filePath, this.#readHeadBytes));
     }

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -540,8 +540,10 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
     {
       label: "What Luke is",
       detail:
-        "A macOS sidecar living beside the notch. The capsule beside the housing counts observed " +
-        "sessions; hovering it peeks, pressing it opens the panel, and Escape closes what is open. " +
+        "A macOS sidecar living beside the notch. The capsule beside the housing counts the " +
+        "sessions the panel lists — the ones still live or recently settled, not every " +
+        "conversation on disk; hovering it peeks, pressing it opens the panel, and Escape " +
+        "closes what is open. " +
         "Resting the pointer on the face itself earns one trick — most often flying off the strip " +
         "and swooping back — and another only after the pointer leaves and returns; asking the " +
         "system for reduced motion stills the tricks.",

--- a/apps/desktop/tests/claude-code-adapter.test.ts
+++ b/apps/desktop/tests/claude-code-adapter.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test, { type TestContext } from "node:test";
-import { SESSION_STATUS } from "@sidecar/core";
+import { isRosterRelevant, SESSION_STATUS } from "@sidecar/core";
 import { CLAUDE_CODE_PROVIDER, ClaudeCodeSessionAdapter } from "../src/claude-code-adapter";
 
 const TEST_TIME = Date.parse("2026-08-11T23:45:00.000Z");
@@ -68,7 +68,6 @@ test("observes a Claude Code session file and labels it by its workspace", async
   const adapter = new ClaudeCodeSessionAdapter({
     claudeHome,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const observations = await adapter.observe();
 
@@ -101,7 +100,6 @@ test("keeps stale user-tail sessions unknown instead of inventing activity", asy
     activeSessionFreshnessMs: 15 * 60 * 1000,
     claudeHome,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60 * 60 * 1000,
   });
   const observations = await adapter.observe();
 
@@ -129,7 +127,6 @@ test("keeps stale assistant-tail sessions from staying in attention", async (t) 
     activeSessionFreshnessMs: 15 * 60 * 1000,
     claudeHome,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60 * 60 * 1000,
   });
   const observations = await adapter.observe();
 
@@ -162,7 +159,6 @@ test("ignores trailing system records when finding Claude session status", async
   const adapter = new ClaudeCodeSessionAdapter({
     claudeHome,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const observations = await adapter.observe();
 
@@ -197,7 +193,6 @@ test("treats fresh assistant tool use as active work", async (t) => {
   const adapter = new ClaudeCodeSessionAdapter({
     claudeHome,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const observations = await adapter.observe();
 
@@ -241,7 +236,6 @@ test("keeps fresh sessions active when a large tail has no complete status event
   const adapter = new ClaudeCodeSessionAdapter({
     claudeHome,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
     readTailBytes: 128,
   });
   const observations = await adapter.observe();
@@ -388,7 +382,6 @@ test("surfaces the generated title, branch, model, and the tool being run", asyn
   const adapter = new ClaudeCodeSessionAdapter({
     claudeHome,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const [observation] = await adapter.observe();
 
@@ -432,7 +425,6 @@ test("reports a failed request as an error once the retries are spent", async (t
   const adapter = new ClaudeCodeSessionAdapter({
     claudeHome,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const [observation] = await adapter.observe();
 
@@ -470,7 +462,6 @@ test("stays working through a retry the session is still backing off from", asyn
   const adapter = new ClaudeCodeSessionAdapter({
     claudeHome,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const [observation] = await adapter.observe();
 
@@ -504,7 +495,6 @@ test("keeps a spent failure at error after it goes stale", async (t) => {
     activeSessionFreshnessMs: 15 * 60 * 1000,
     claudeHome,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60 * 60 * 1000,
   });
   const [observation] = await adapter.observe();
 
@@ -541,7 +531,6 @@ test("clears a recorded error once the session gets past it", async (t) => {
   const adapter = new ClaudeCodeSessionAdapter({
     claudeHome,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const [observation] = await adapter.observe();
 
@@ -576,7 +565,6 @@ test("recovers a title from a session too long to hold one in its tail", async (
   const adapter = new ClaudeCodeSessionAdapter({
     claudeHome,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
     // Small enough that the title is far behind the tail the status comes from.
     readTailBytes: 256,
   });
@@ -613,7 +601,6 @@ test("carries the away recap Claude Code writes for a developer who stepped out"
   const adapter = new ClaudeCodeSessionAdapter({
     claudeHome,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const [observation] = await adapter.observe();
 
@@ -670,7 +657,6 @@ test("drops the previous turn's recap when a new prompt opens a turn", async (t)
   const adapter = new ClaudeCodeSessionAdapter({
     claudeHome,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const [observation] = await adapter.observe();
 
@@ -701,7 +687,6 @@ test("reports no recap for a turn whose closing words are all it wrote", async (
   const adapter = new ClaudeCodeSessionAdapter({
     claudeHome,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const [observation] = await adapter.observe();
 
@@ -762,7 +747,6 @@ test("stops reporting a tool once the turn that ran it has ended", async (t) => 
   const adapter = new ClaudeCodeSessionAdapter({
     claudeHome,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const [observation] = await adapter.observe();
 
@@ -808,7 +792,6 @@ test("keeps reporting a tool between one call and the next", async (t) => {
   const adapter = new ClaudeCodeSessionAdapter({
     claudeHome,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60_000,
   });
   const [observation] = await adapter.observe();
 
@@ -911,6 +894,104 @@ test("falls back to the file's date when the tail carries no timestamp", async (
   const [observation] = await adapter.observe();
 
   assert.equal(observation?.observedAt, TEST_TIME - 5_000);
+});
+
+test("reads past a tail of appended bookkeeping to the conversation's own clock", async (t) => {
+  const claudeHome = await temporaryClaudeHome(t);
+  const lastConversationTime = "2026-02-14T10:05:00.000Z";
+  await writeSessionFile(
+    claudeHome,
+    "-Users-test-backfilled",
+    "backfilled-session",
+    [
+      {
+        type: TEST_CLAUDE_EVENT_TYPE.USER,
+        cwd: "/Users/test/backfilled",
+        timestamp: "2026-02-14T10:00:00.000Z",
+      },
+      {
+        type: TEST_CLAUDE_EVENT_TYPE.ASSISTANT,
+        cwd: "/Users/test/backfilled",
+        timestamp: lastConversationTime,
+        message: { stop_reason: "end_turn", content: [] },
+      },
+      // The bookkeeping a later Claude Code pass appended in bulk: enough of
+      // it to fill the whole bounded tail, with the same pass bumping mtime.
+      { type: "ai-title", aiTitle: "Old refactor" },
+      { type: "last-prompt", cwd: "/Users/test/backfilled", prompt: "x".repeat(120) },
+    ],
+    TEST_TIME,
+  );
+
+  const adapter = new ClaudeCodeSessionAdapter({
+    claudeHome,
+    now: () => TEST_TIME,
+    readTailBytes: 256,
+  });
+  const [observation] = await adapter.observe();
+
+  // A tail holding only bookkeeping says nothing about when the conversation
+  // last moved, and the touch must not answer for it: the second, deeper read
+  // finds the conversation's own clock months back, so the session reads as
+  // settled history rather than as work happening right now.
+  assert.equal(observation?.observedAt, Date.parse(lastConversationTime));
+  assert.equal(observation?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(observation?.title, "Old refactor");
+  assert.equal(
+    observation &&
+      isRosterRelevant(
+        { status: observation.status, observedAt: observation.observedAt },
+        TEST_TIME,
+      ),
+    false,
+  );
+});
+
+test("keeps a bookkeeping record's timestamp from re-dating the conversation", async (t) => {
+  const claudeHome = await temporaryClaudeHome(t);
+  const lastConversationTime = "2026-02-14T10:05:00.000Z";
+  await writeSessionFile(
+    claudeHome,
+    "-Users-test-redated",
+    "redated-session",
+    [
+      {
+        type: TEST_CLAUDE_EVENT_TYPE.USER,
+        cwd: "/Users/test/redated",
+        timestamp: "2026-02-14T10:00:00.000Z",
+      },
+      {
+        type: TEST_CLAUDE_EVENT_TYPE.ASSISTANT,
+        cwd: "/Users/test/redated",
+        timestamp: lastConversationTime,
+        message: { stop_reason: "end_turn", content: [] },
+      },
+      // Bookkeeping stamped with the moment it was appended rather than the
+      // moment the conversation moved.
+      { type: "queue-operation", operation: "enqueue", timestamp: "2026-08-11T23:44:59.000Z" },
+    ],
+    TEST_TIME,
+  );
+
+  const adapter = new ClaudeCodeSessionAdapter({
+    claudeHome,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  // Only the conversation's own records may date the session: a settled turn
+  // from months ago must not read as waiting for the developer today just
+  // because the provider stamped a bookkeeping line beside it.
+  assert.equal(observation?.observedAt, Date.parse(lastConversationTime));
+  assert.equal(observation?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(
+    observation &&
+      isRosterRelevant(
+        { status: observation.status, observedAt: observation.observedAt },
+        TEST_TIME,
+      ),
+    false,
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -1067,7 +1148,6 @@ test("a stop event keeps a finished turn waiting past the freshness decay", asyn
     claudeHome,
     hookEventsDirectory: () => spool,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60 * 60 * 1000,
   });
   const [observation] = await adapter.observe();
 
@@ -1152,7 +1232,6 @@ test("a session-start event bumps the clock without deciding the status", async 
     claudeHome,
     hookEventsDirectory: () => spool,
     now: () => TEST_TIME,
-    maximumSessionAgeMs: 60 * 60 * 1000,
   });
   const [observation] = await adapter.observe();
 


### PR DESCRIPTION
## What

Old Claude Code local sessions — reported as going back six months — were showing up as current: flooding the panel list and inflating the capsule count beside the housing.

## Why

The roster's retention design hinges entirely on `observedAt` being true: working/waiting rows never expire, settled ones drop two days after they last moved. Claude Code touches old session files in bulk (appending bookkeeping records such as `ai-title` and `last-prompt`, bumping mtimes), and two holes let that touch stand in for work — both reproduced by new tests against the real adapter:

1. **Bookkeeping-filled tail → mtime fallback → immortal row.** When appended bookkeeping (or a single record larger than the 64 KB tail read) fills the bounded tail, the parse found no timestamp, `observedAt` fell back to the just-bumped mtime, and with no conversation event in the tail the status landed on working-fresh — which the roster never expires.
2. **Any stamped record re-dated the session.** The clock was taken from every record type, so bookkeeping stamped with the moment it was appended re-dated a settled conversation to today, making it read as waiting and keeping it on the roster for two more days.

## How

- Only conversation records — `user`, `assistant`, `result`, `system` — may date a session; bookkeeping stamps no longer move its clock, the same distinction that already kept mtime from dating it.
- When a **truncated** tail carries no conversation clock, one deeper bounded read (512 KB) goes looking for when the conversation actually last moved before the file's date is trusted. A file read whole is never re-read, the result is cached by mtime, and the mtime fallback remains for a transcript with no conversation clock anywhere — so a live session mid-write of a giant tool result still reads as working.
- Removes the dead `maximumSessionAgeMs` option the adapter tests still passed (deleted from the adapter in #137, silently ignored since) — it misleadingly implied age filtering was being asserted.
- Corrects the guide's capsule fact: the number counts the sessions the panel lists — still live or recently settled — not every conversation on disk.

## Testing

- Two new adapter tests reproduce the bug (both fail before the fix) and assert end to end that a touched six-month-old transcript reports its real clock, reads unknown, and fails `isRosterRelevant`.
- `./scripts/check.sh` passes: 945 desktop + 206 core + 35 web + 38 repository tests, no failures.
- Logic plus one guide sentence — nothing drawn moved. `./scripts/verify.sh` was not run (Linux environment); no physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a33338de-8e55-4149-9da7-0e97914d766e)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32072787176/artifacts/9302367072) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32072787176)

- Commit: `d88efc4ee298fd4e63383349335471153b0d2245`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
