### PR TITLE
feat(desktop): log every AI call to the console

### DIFF
--- a/apps/desktop/src/openai-attention-evaluator.ts
+++ b/apps/desktop/src/openai-attention-evaluator.ts
@@ -156,6 +156,9 @@ export class OpenAiAttentionEvaluator implements AttentionEvaluator {
   }
 
   async #request(update: AttentionUpdate): Promise<Response | undefined> {
+    // The model and nothing else: the update, the key, and the decision stay
+    // out of the log.
+    console.log(`AI call: attention review (model ${this.#model})`);
     try {
       return await this.#fetch(`${this.#baseUrl}${ATTENTION_RESPONSES_PATH}`, {
         method: "POST",

--- a/apps/desktop/src/openai-realtime-credentials.ts
+++ b/apps/desktop/src/openai-realtime-credentials.ts
@@ -206,6 +206,9 @@ export class OpenAiRealtimeCredentialMinter {
   }
 
   async #request(): Promise<Response | undefined> {
+    // The model and nothing else: the key and the minted secret stay out of
+    // the log.
+    console.log(`AI call: realtime voice credential mint (model ${this.#model})`);
     try {
       return await this.#fetch(`${this.#baseUrl}${REALTIME_CLIENT_SECRETS_PATH}`, {
         method: "POST",

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -659,6 +659,11 @@ export class RealtimeVoiceSession {
       body: offer,
       signal: deadline,
     };
+    // The kind of call and nothing else: the ephemeral secret and the SDP
+    // stay out of the log.
+    console.log(
+      `AI call: opening realtime voice call (${this.#withMicrophone ? "conversation" : "speak-only"})`,
+    );
     const response = await (this.#options.exchangeDescription?.(connection.callsUrl, init) ??
       fetch(connection.callsUrl, init));
     if (!response.ok) {
@@ -1033,6 +1038,12 @@ export class RealtimeVoiceSession {
     this.#turnEpoch += 1;
     this.#setCaption(undefined);
     this.#clearSettleTimer();
+    // Every reply request passes through here, so this one line logs each
+    // voice-model turn. The turn's kind and nothing else: what was said stays
+    // out of the log.
+    console.log(
+      `AI call: realtime voice reply requested (${toolsArmed ? "developer turn" : "Luke's own turn"})`,
+    );
     this.#send(events);
     this.#setStatus(REALTIME_STATUS.RESPONDING);
   }


### PR DESCRIPTION
## Summary

Adds one console log line at each point the desktop app makes an AI call, so every request is visible in the console:

- **Attention model** — `OpenAiAttentionEvaluator` logs each attention review request with the model name (main process).
- **Voice chat** — the credential mint logs with the model name (main process); the renderer logs each realtime call opening (conversation vs speak-only) and each voice reply requested (developer turn vs Luke's own turn). Every reply request funnels through `#startResponse`, so one line there covers push-to-talk commits, typed asks, proactive announcements, and tool follow-ups.

Each line carries the kind of call and the model or turn kind only — no update contents, keys, minted secrets, or spoken words reach the log, in keeping with the existing rule that status alone is what gets diagnosed.

## Validation

- `./scripts/check.sh` — passed (repository contract checks, lint, typecheck, tests, build all green).
- No UI or macOS-specific change; no visual evidence required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/3b4aff1a-5ba5-47a3-b7be-f821591fc981)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32072799890/artifacts/9302372506) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32072799890)

- Commit: `a60ec77fbbf8985a2820e65a8557a4b6dfc4732f`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
