### PR TITLE
fix(voice): put the capture device away when the call settles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,18 @@ Trust constraints:
   paced for reading rather than for the voice, because into a mute the caption
   is the speech — and a hint asking for volume. Luke never changes the system
   volume himself; turning it up stays the user's own act on their own keys.
+- The input side is read the same way: a native helper reports where the
+  developer's voice would be captured from — the default input device's
+  transport, whether the machine has a built-in microphone and what it is
+  named, and whether the lid over it is open — nothing else, and it can write
+  nothing. No audio is ever read. What it learns decides exactly one act:
+  which device the renderer asks the browser to open when a press takes a
+  turn, so a Bluetooth headset is not pulled onto its call codec while the
+  Mac's own microphone can listen, and is listened to itself when a shut lid
+  would muffle the Mac's. The capture device itself stays bound to the turn
+  the press opened — opened by the press, closed when the exchange settles —
+  and never outlives it; typed asks never open one at all. An unreadable
+  route means the browser's default device, never a refusal to listen.
 - The update check is the one request Luke makes with no user-supplied key at
   all: an unauthenticated read of this repository's latest release name from
   GitHub's public API, on a timer of its own — always on, like the

--- a/apps/desktop/native/macos/MicrophoneRoute.swift
+++ b/apps/desktop/native/macos/MicrophoneRoute.swift
@@ -1,0 +1,197 @@
+import CoreAudio
+import Foundation
+import IOKit
+
+/// Reports where the developer's voice would be captured from — and nothing
+/// else. Three read-only facts: the default input device's transport, whether
+/// this Mac has a built-in microphone (and its name, so the renderer can find
+/// the same device in the browser's list), and whether the lid that microphone
+/// sits under is open. No audio is ever read, and nothing is ever written
+/// back: what the facts decide is only which device the renderer asks the
+/// browser to open when a press takes a turn, so a Bluetooth headset is not
+/// pulled onto its call codec when the Mac's own microphone can listen
+/// instead — and is left alone when a shut lid would muffle that microphone.
+///
+/// One line per state: `input transport=<built-in|bluetooth|other|none>
+/// lid=<open|shut|unknown> builtin=<name>` — emitted once on start, on every
+/// default-input change, and in answer to `probe` on stdin. The app probes at
+/// each press because a lid can close without any device changing. The
+/// `builtin` token is omitted on a machine with no built-in microphone, and it
+/// is always the line's tail, so the name may contain anything.
+private let MICROPHONE_ROUTE_COMMAND = "probe"
+
+private let TRANSPORT_WORD = (
+    builtIn: "built-in",
+    bluetooth: "bluetooth",
+    other: "other",
+    none: "none"
+)
+
+private let LID_WORD = (open: "open", shut: "shut", unknown: "unknown")
+
+private func emit(_ line: String) {
+    guard let payload = "\(line)\n".data(using: .utf8) else { return }
+    FileHandle.standardOutput.write(payload)
+}
+
+private func address(
+    _ selector: AudioObjectPropertySelector,
+    scope: AudioObjectPropertyScope = kAudioObjectPropertyScopeGlobal
+) -> AudioObjectPropertyAddress {
+    AudioObjectPropertyAddress(
+        mSelector: selector,
+        mScope: scope,
+        mElement: kAudioObjectPropertyElementMain
+    )
+}
+
+private func readDefaultInputDevice() -> AudioObjectID? {
+    var query = address(kAudioHardwarePropertyDefaultInputDevice)
+    var device = AudioObjectID(kAudioObjectUnknown)
+    var size = UInt32(MemoryLayout<AudioObjectID>.size)
+    let status = AudioObjectGetPropertyData(
+        AudioObjectID(kAudioObjectSystemObject), &query, 0, nil, &size, &device
+    )
+    guard status == noErr, device != kAudioObjectUnknown else { return nil }
+    return device
+}
+
+private func transportType(of device: AudioObjectID) -> UInt32? {
+    var query = address(kAudioDevicePropertyTransportType)
+    guard AudioObjectHasProperty(device, &query) else { return nil }
+    var transport = UInt32(0)
+    var size = UInt32(MemoryLayout<UInt32>.size)
+    guard AudioObjectGetPropertyData(device, &query, 0, nil, &size, &transport) == noErr else {
+        return nil
+    }
+    return transport
+}
+
+private func transportWord(of device: AudioObjectID) -> String {
+    switch transportType(of: device) {
+    case kAudioDeviceTransportTypeBuiltIn:
+        return TRANSPORT_WORD.builtIn
+    case kAudioDeviceTransportTypeBluetooth, kAudioDeviceTransportTypeBluetoothLE:
+        return TRANSPORT_WORD.bluetooth
+    default:
+        return TRANSPORT_WORD.other
+    }
+}
+
+/// Whether the device can capture at all: a built-in device list holds
+/// speakers too, and the microphone is the one with input streams.
+private func hasInputStreams(_ device: AudioObjectID) -> Bool {
+    var query = address(kAudioDevicePropertyStreams, scope: kAudioDevicePropertyScopeInput)
+    var size = UInt32(0)
+    guard AudioObjectGetPropertyDataSize(device, &query, 0, nil, &size) == noErr else {
+        return false
+    }
+    return size > 0
+}
+
+private func name(of device: AudioObjectID) -> String? {
+    var query = address(kAudioObjectPropertyName)
+    guard AudioObjectHasProperty(device, &query) else { return nil }
+    var value: Unmanaged<CFString>?
+    var size = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
+    let status = withUnsafeMutablePointer(to: &value) { pointer in
+        AudioObjectGetPropertyData(device, &query, 0, nil, &size, pointer)
+    }
+    guard status == noErr, let value else { return nil }
+    return value.takeRetainedValue() as String
+}
+
+private func allDevices() -> [AudioObjectID] {
+    var query = address(kAudioHardwarePropertyDevices)
+    var size = UInt32(0)
+    let system = AudioObjectID(kAudioObjectSystemObject)
+    guard AudioObjectGetPropertyDataSize(system, &query, 0, nil, &size) == noErr, size > 0 else {
+        return []
+    }
+    var devices = [AudioObjectID](
+        repeating: AudioObjectID(kAudioObjectUnknown),
+        count: Int(size) / MemoryLayout<AudioObjectID>.size
+    )
+    guard AudioObjectGetPropertyData(system, &query, 0, nil, &size, &devices) == noErr else {
+        return []
+    }
+    return devices
+}
+
+private func builtInInputDevice() -> AudioObjectID? {
+    allDevices().first { device in
+        transportType(of: device) == kAudioDeviceTransportTypeBuiltIn && hasInputStreams(device)
+    }
+}
+
+/// The lid, read from the power domain's own record of it. A machine that
+/// keeps no such record — a desktop — answers `unknown`, which the reader
+/// treats as open: an iMac's microphone has no lid to be shut under.
+private func lidWord() -> String {
+    let service = IOServiceGetMatchingService(
+        kIOMainPortDefault, IOServiceMatching("IOPMrootDomain")
+    )
+    guard service != 0 else { return LID_WORD.unknown }
+    defer { IOObjectRelease(service) }
+    guard
+        let value = IORegistryEntryCreateCFProperty(
+            service, "AppleClamshellState" as CFString, kCFAllocatorDefault, 0
+        )?.takeRetainedValue()
+    else { return LID_WORD.unknown }
+    guard let shut = value as? Bool else { return LID_WORD.unknown }
+    return shut ? LID_WORD.shut : LID_WORD.open
+}
+
+@main
+@MainActor
+private struct MicrophoneRouteCommand {
+    static var buffer = ""
+
+    static func main() {
+        var defaultInput = address(kAudioHardwarePropertyDefaultInputDevice)
+        // AirPods connecting, a USB interface unplugged: the answer follows
+        // whichever device the system would hand a capture to next.
+        AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject), &defaultInput, DispatchQueue.main
+        ) { _, _ in
+            MainActor.assumeIsolated { report() }
+        }
+        FileHandle.standardInput.readabilityHandler = { handle in
+            let data = handle.availableData
+            DispatchQueue.main.async {
+                MainActor.assumeIsolated {
+                    // Stdin closing is the app going away; there is nothing to
+                    // restore, because nothing was ever changed.
+                    if data.isEmpty {
+                        FileHandle.standardInput.readabilityHandler = nil
+                        exit(0)
+                    }
+                    read(data)
+                }
+            }
+        }
+        report()
+        dispatchMain()
+    }
+
+    static func read(_ data: Data) {
+        buffer += String(decoding: data, as: UTF8.self)
+        var lines = buffer.components(separatedBy: "\n")
+        // Whatever follows the last newline is the start of a line still
+        // arriving, exactly as the media duck's reader holds it.
+        buffer = lines.removeLast()
+        for line in lines
+        where line.trimmingCharacters(in: .whitespaces) == MICROPHONE_ROUTE_COMMAND {
+            report()
+        }
+    }
+
+    static func report() {
+        let transport = readDefaultInputDevice().map { transportWord(of: $0) }
+        var line = "input transport=\(transport ?? TRANSPORT_WORD.none) lid=\(lidWord())"
+        if let builtIn = builtInInputDevice(), let builtInName = name(of: builtIn) {
+            line += " builtin=\(builtInName)"
+        }
+        emit(line)
+    }
+}

--- a/apps/desktop/scripts/package-layout.mjs
+++ b/apps/desktop/scripts/package-layout.mjs
@@ -12,6 +12,11 @@ export const PACKAGED_ARCHITECTURE = "arm64";
  */
 export const NATIVE_HELPERS = [
   { source: "MediaDuck.swift", binary: "mac-media-duck", frameworks: ["AppKit"] },
+  {
+    source: "MicrophoneRoute.swift",
+    binary: "mac-microphone-route",
+    frameworks: ["CoreAudio", "IOKit"],
+  },
   { source: "OutputVolume.swift", binary: "mac-output-volume", frameworks: ["CoreAudio"] },
   { source: "ScreenGeometry.swift", binary: "mac-screen-geometry", frameworks: ["AppKit"] },
   {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -117,6 +117,7 @@ import { HOTKEY_RANK, HotkeyRegistrar } from "./hotkey-registrar";
 import { JulesSessionAdapter } from "./jules-adapter";
 import { LinearIssueTracker } from "./linear-tracker";
 import { MediaDuckController } from "./media-duck";
+import { MicrophoneRouteWatcher } from "./microphone-route";
 import { openAiAttentionEvaluator } from "./openai-attention-evaluator";
 import {
   openAiRealtimeCredentials,
@@ -140,6 +141,7 @@ import {
   type AppBootstrap,
   channels,
   isSettingsResetScope,
+  type MicrophoneRoute,
   type MicrophoneStatus,
   type ObservedAccountCalendars,
   type OutputAudioState,
@@ -425,6 +427,14 @@ const updateService = new UpdateService({
  */
 let outputAudio: OutputAudioState | undefined;
 let outputVolumeWatcher: OutputVolumeWatcher | undefined;
+/**
+ * Where the developer's voice would be captured from, as last read, and the
+ * helper that reads it. The state lives here so the renderer's ask can be
+ * answered at once while a fresh probe rides behind it; `undefined` is
+ * "cannot be read", which the renderer must take as the browser's default.
+ */
+let microphoneRoute: MicrophoneRoute | undefined;
+let microphoneRouteWatcher: MicrophoneRouteWatcher | undefined;
 
 function rendererUrl(): string {
   return pathToFileURL(path.join(__dirname, "renderer", "index.html")).href;
@@ -472,6 +482,25 @@ function startOutputVolumeWatch(): void {
     onUnavailable: () => send(undefined),
   });
   if (!outputVolumeWatcher.start()) outputVolumeWatcher = undefined;
+}
+
+/**
+ * Starts watching where the developer's voice would be captured from, under
+ * the same rule as the output watch: read-only, and not in a fixture or
+ * capture run. What it learns decides only which device the renderer asks the
+ * browser to open when a press takes a turn.
+ */
+function startMicrophoneRouteWatch(): void {
+  if (!runMode.observesProviders) return;
+  microphoneRouteWatcher = new MicrophoneRouteWatcher({
+    onRoute: (route) => {
+      microphoneRoute = route;
+    },
+    onUnavailable: () => {
+      microphoneRoute = undefined;
+    },
+  });
+  if (!microphoneRouteWatcher.start()) microphoneRouteWatcher = undefined;
 }
 
 let tray: Tray | undefined;
@@ -1106,6 +1135,14 @@ function registerIpc(): void {
   ipcMain.handle(channels.requestMicrophone, async (event) => {
     if (!trustedSender(event)) throw new Error("Untrusted renderer");
     return requestMicrophone();
+  });
+
+  ipcMain.handle(channels.microphoneRoute, (event) => {
+    if (!trustedSender(event)) throw new Error("Untrusted renderer");
+    // Answer with what is known and ask again behind the answer: the next
+    // press then sees a lid that closed with no device change to announce it.
+    microphoneRouteWatcher?.probe();
+    return microphoneRoute;
   });
 
   // The renderer can replace or clear a provider's credential but never reads
@@ -3004,6 +3041,7 @@ if (!app.requestSingleInstanceLock()) {
     // Read-only, like everything else that watches: what it learns decides
     // what the renderer draws while Luke speaks unheard, and nothing more.
     startOutputVolumeWatch();
+    startMicrophoneRouteWatch();
     panels.reconcile();
     configurePermissions();
     startSessionObservation();
@@ -3040,6 +3078,8 @@ app.on("will-quit", () => {
   // The same rule: a process of Luke's own does not outlive the app.
   outputVolumeWatcher?.stop();
   outputVolumeWatcher = undefined;
+  microphoneRouteWatcher?.stop();
+  microphoneRouteWatcher = undefined;
   // The duck helper outlives this by one fade: closing its stdin is what asks
   // it to bring the players back up, so quitting mid-sentence costs the user
   // nothing.

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -495,9 +495,12 @@ function startMicrophoneRouteWatch(): void {
   microphoneRouteWatcher = new MicrophoneRouteWatcher({
     onRoute: (route) => {
       microphoneRoute = route;
+      // Every display's panel says the same "listens through", so all are told.
+      panels.broadcast(channels.microphoneRouteChanged, route);
     },
     onUnavailable: () => {
       microphoneRoute = undefined;
+      panels.broadcast(channels.microphoneRouteChanged, undefined);
     },
   });
   if (!microphoneRouteWatcher.start()) microphoneRouteWatcher = undefined;
@@ -1050,6 +1053,7 @@ function registerIpc(): void {
       ...(hotkeys.ask ? { askHotkey: hotkeys.ask } : {}),
       ...(hotkeys.stop ? { stopHotkey: hotkeys.stop } : {}),
       ...(outputAudio ? { outputAudio } : {}),
+      ...(microphoneRoute ? { microphoneRoute } : {}),
       display: panels.diagnostic(display),
       update: updateService.snapshot(),
       // Bootstrapped through the same relevance gate every broadcast passes:
@@ -1435,6 +1439,15 @@ function registerIpc(): void {
 
   // The duck follows the stored answer at once, like the menu bar item: off
   // must let a duck currently held go rather than waiting for the next launch.
+  registerSettingHandler(channels.setPreferBuiltInMicrophone, {
+    validate(enabled: unknown) {
+      if (typeof enabled !== "boolean") throw new Error("Invalid microphone preference request");
+      return enabled;
+    },
+    save: (enabled) => settingsStore.setPreferBuiltInMicrophone(enabled),
+    refusal: "Could not save that setting on this system.",
+  });
+
   registerSettingHandler(channels.setDuckOtherMedia, {
     validate(enabled: unknown) {
       if (typeof enabled !== "boolean") throw new Error("Invalid media duck request");

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -495,12 +495,9 @@ function startMicrophoneRouteWatch(): void {
   microphoneRouteWatcher = new MicrophoneRouteWatcher({
     onRoute: (route) => {
       microphoneRoute = route;
-      // Every display's panel says the same "listens through", so all are told.
-      panels.broadcast(channels.microphoneRouteChanged, route);
     },
     onUnavailable: () => {
       microphoneRoute = undefined;
-      panels.broadcast(channels.microphoneRouteChanged, undefined);
     },
   });
   if (!microphoneRouteWatcher.start()) microphoneRouteWatcher = undefined;
@@ -1053,7 +1050,6 @@ function registerIpc(): void {
       ...(hotkeys.ask ? { askHotkey: hotkeys.ask } : {}),
       ...(hotkeys.stop ? { stopHotkey: hotkeys.stop } : {}),
       ...(outputAudio ? { outputAudio } : {}),
-      ...(microphoneRoute ? { microphoneRoute } : {}),
       display: panels.diagnostic(display),
       update: updateService.snapshot(),
       // Bootstrapped through the same relevance gate every broadcast passes:

--- a/apps/desktop/src/microphone-route.ts
+++ b/apps/desktop/src/microphone-route.ts
@@ -1,0 +1,155 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { app } from "electron";
+import {
+  LID_STATE,
+  type LidState,
+  MICROPHONE_TRANSPORT,
+  type MicrophoneRoute,
+  type MicrophoneTransport,
+} from "./shared/contracts";
+
+/** The one word the helper takes; its one line is read by the parser below. */
+export const MICROPHONE_ROUTE_PROBE = "probe";
+
+export interface MicrophoneRouteEdges {
+  /** The route as read, on start, on every input change, and per probe. */
+  onRoute(route: MicrophoneRoute): void;
+  /** The route cannot be read — no helper, or the helper died. */
+  onUnavailable(): void;
+}
+
+/** Only the parts of a child process this needs, so a test can supply them. */
+export interface MicrophoneRouteProcess {
+  stdin?: { write(chunk: string): void };
+  stdout?: { setEncoding(encoding: string): void; on(event: "data", listener: LineListener): void };
+  on(event: "error" | "exit", listener: () => void): void;
+  removeAllListeners(): void;
+  kill(): void;
+}
+
+type LineListener = (chunk: string) => void;
+
+export interface MicrophoneRouteWatcherOptions extends MicrophoneRouteEdges {
+  /** Injectable so the reader can be exercised without a Mac or a binary. */
+  spawnHelper?: () => MicrophoneRouteProcess | undefined;
+}
+
+function spawnMicrophoneRouteHelper(): MicrophoneRouteProcess | undefined {
+  // The helper asks CoreAudio and the power domain, which only macOS has;
+  // elsewhere the route is simply never read and the browser's default holds.
+  if (process.platform !== "darwin") return undefined;
+  const helperPath = app.isPackaged
+    ? path.join(process.resourcesPath, "mac-microphone-route")
+    : path.join(app.getAppPath(), ".build", "native", "mac-microphone-route");
+  return spawn(helperPath, [], {
+    stdio: ["pipe", "pipe", "ignore"],
+  }) as unknown as MicrophoneRouteProcess;
+}
+
+/**
+ * Watches where the developer's voice would be captured from: the default
+ * input's transport, the built-in microphone's name, and the lid over it —
+ * read by a helper that reads nothing else and can write nothing. What the
+ * answer decides is bounded to one act: which device the renderer asks the
+ * browser to open when a press takes a turn.
+ */
+export class MicrophoneRouteWatcher {
+  readonly #options: MicrophoneRouteWatcherOptions;
+  #child: MicrophoneRouteProcess | undefined;
+  #done = false;
+  #buffer = "";
+
+  constructor(options: MicrophoneRouteWatcherOptions) {
+    this.#options = options;
+  }
+
+  /**
+   * Starts the helper, reporting whether it could be launched at all. A `true`
+   * is not yet a readable route — that arrives on the helper's first line.
+   */
+  start(): boolean {
+    let child: MicrophoneRouteProcess | undefined;
+    try {
+      child = this.#options.spawnHelper
+        ? this.#options.spawnHelper()
+        : spawnMicrophoneRouteHelper();
+    } catch {
+      child = undefined;
+    }
+    if (!child) {
+      this.#unavailable();
+      return false;
+    }
+    this.#child = child;
+    child.stdout?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk) => this.#read(chunk));
+    // A helper that dies takes its answer with it. Saying so is what lets the
+    // app fall back to the browser's default rather than trust a stale route.
+    child.on("error", () => this.#unavailable());
+    child.on("exit", () => this.#unavailable());
+    return true;
+  }
+
+  /**
+   * Asks for a fresh read. The lid can close without any device changing, so
+   * the app probes when a press is about to choose a device; the answer rides
+   * the same line every change does.
+   */
+  probe(): void {
+    if (this.#done) return;
+    this.#child?.stdin?.write(`${MICROPHONE_ROUTE_PROBE}\n`);
+  }
+
+  /**
+   * Stops the helper. Detached before killing: this exit is the app's own
+   * doing, and nothing succeeds a watcher during shutdown, so no one waits.
+   */
+  stop(): void {
+    const child = this.#child;
+    this.#child = undefined;
+    this.#done = true;
+    if (!child) return;
+    child.removeAllListeners();
+    child.kill();
+  }
+
+  #read(chunk: string): void {
+    if (this.#done) return;
+    this.#buffer += chunk;
+    const lines = this.#buffer.split("\n");
+    // Whatever follows the last newline is the start of a line still arriving.
+    this.#buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      const route = parseMicrophoneRouteLine(line.trim());
+      if (route) this.#options.onRoute(route);
+    }
+  }
+
+  #unavailable(): void {
+    if (this.#done) return;
+    this.#done = true;
+    this.#child = undefined;
+    this.#options.onUnavailable();
+  }
+}
+
+const TRANSPORT_WORDS: readonly MicrophoneTransport[] = Object.values(MICROPHONE_TRANSPORT);
+const LID_WORDS: readonly LidState[] = Object.values(LID_STATE);
+
+/**
+ * Reads one `input transport=<word> lid=<word> builtin=<name…>` line. The
+ * name is the line's tail — it may contain spaces or anything else CoreAudio
+ * lets a device be called — and a line that does not parse is dropped rather
+ * than guessed at: the cost of missing one is the browser's default device,
+ * which is exactly what no helper at all would mean.
+ */
+export function parseMicrophoneRouteLine(line: string): MicrophoneRoute | undefined {
+  const match = /^input transport=(\S+) lid=(\S+)(?: builtin=(.+))?$/.exec(line);
+  if (!match?.[1] || !match[2]) return undefined;
+  const transport = TRANSPORT_WORDS.find((word) => word === match[1]);
+  const lid = LID_WORDS.find((word) => word === match[2]);
+  if (!transport || !lid) return undefined;
+  const builtInName = match[3]?.trim();
+  return { defaultTransport: transport, lid, ...(builtInName ? { builtInName } : {}) };
+}

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -44,6 +44,7 @@ const bridge: AppBridge = {
   setAskHotkey: invoke(channels.setAskHotkey),
   setStopHotkey: invoke(channels.setStopHotkey),
   setDuckOtherMedia: invoke(channels.setDuckOtherMedia),
+  setPreferBuiltInMicrophone: invoke(channels.setPreferBuiltInMicrophone),
   setQuietDuringMeetings: invoke(channels.setQuietDuringMeetings),
   connectGoogleCalendar: invoke(channels.connectGoogleCalendar),
   cancelGoogleCalendarSignIn: () => {
@@ -94,6 +95,7 @@ const bridge: AppBridge = {
   onStopHotkeyPress: subscribe(channels.stopHotkeyPress),
   onStopHotkeyChanged: subscribe(channels.stopHotkeyChanged),
   onOutputAudioChanged: subscribe(channels.outputAudioChanged),
+  onMicrophoneRouteChanged: subscribe(channels.microphoneRouteChanged),
   onAttentionSpeech: subscribe(channels.attentionSpeech),
 };
 

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -23,6 +23,7 @@ const bridge: AppBridge = {
     ipcRenderer.send(channels.setPointerInterception, interceptsPointer);
   },
   requestMicrophone: invoke(channels.requestMicrophone),
+  getMicrophoneRoute: invoke(channels.microphoneRoute),
   openMicrophoneSettings: () => ipcRenderer.send(channels.openMicrophoneSettings),
   setProviderApiKey: invoke(channels.setProviderApiKey),
   setVoice: invoke(channels.setVoice),

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -95,7 +95,6 @@ const bridge: AppBridge = {
   onStopHotkeyPress: subscribe(channels.stopHotkeyPress),
   onStopHotkeyChanged: subscribe(channels.stopHotkeyChanged),
   onOutputAudioChanged: subscribe(channels.outputAudioChanged),
-  onMicrophoneRouteChanged: subscribe(channels.microphoneRouteChanged),
   onAttentionSpeech: subscribe(channels.attentionSpeech),
 };
 

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -33,7 +33,6 @@ import type {
   AppBootstrap,
   AppSettings,
   DisplayDiagnostic,
-  MicrophoneRoute,
   ObservedAccountCalendars,
   OutputAudioState,
   SessionOpenResult,
@@ -92,7 +91,6 @@ import { type Errand, errandTargets, LukeErrand } from "./luke-errand";
 import { LukeFace } from "./luke-face";
 import { usePrefersReducedMotion } from "./luke-face-mood";
 import { applySpokenSetting, buildLukeGuide, isAppSettingId } from "./luke-guide";
-import { listeningThroughDetail } from "./microphone-choice";
 import { NotchWings } from "./notch-wings";
 import { PanelBody, type SessionWriteHandlers } from "./panel-body";
 import { HIT_REGION, PANEL_PRESENTATION } from "./panel-state";
@@ -316,8 +314,6 @@ export function App(): React.JSX.Element {
    * preference says, and a hint under them asks for volume.
    */
   const [outputAudio, setOutputAudio] = useState<OutputAudioState>();
-  /** Which device a press would open, for the Voice page's own line about it. */
-  const [microphoneRoute, setMicrophoneRoute] = useState<MicrophoneRoute>();
   /** Each connected account's calendars, for the settings rows' checkboxes. */
   const [calendars, setCalendars] = useState<readonly ObservedAccountCalendars[]>([]);
   /** Whether the calendar's quiet is holding announcements — the face sleeps on it. */
@@ -1696,11 +1692,6 @@ export function App(): React.JSX.Element {
     (onChange) => window.sidecar.onOutputAudioChanged(onChange),
     setOutputAudio,
   );
-  // Which device a press would open, for the line under the Microphone row.
-  const acceptMicrophoneRouteBootstrap = useBootstrapRacedChannel(
-    (onChange) => window.sidecar.onMicrophoneRouteChanged(onChange),
-    setMicrophoneRoute,
-  );
   // Each connected account's calendars, for the checkboxes on its rows.
   const acceptCalendarsBootstrap = useBootstrapRacedChannel(
     (onChange) => window.sidecar.onCalendarsChanged(onChange),
@@ -1813,7 +1804,6 @@ export function App(): React.JSX.Element {
       // Only fill in what no push has said yet, like the issue roster: the
       // bootstrap snapshot is older than any change that raced past it.
       if (value.outputAudio) acceptOutputAudioBootstrap(value.outputAudio);
-      if (value.microphoneRoute) acceptMicrophoneRouteBootstrap(value.microphoneRoute);
       if (value.profile === "microphone") {
         window.setTimeout(() => void startMicrophone(), 500);
       }
@@ -1857,7 +1847,6 @@ export function App(): React.JSX.Element {
     acceptCalendarsBootstrap,
     acceptIssuesBootstrap,
     acceptMeetingQuietBootstrap,
-    acceptMicrophoneRouteBootstrap,
     acceptOutputAudioBootstrap,
     acceptProjectsBootstrap,
     acceptSettingsBootstrap,
@@ -2219,14 +2208,9 @@ export function App(): React.JSX.Element {
     credentialsEntry.entry && settings
       ? settings.credentialSources[credentialsEntry.entry.providerId]
       : CREDENTIAL_SOURCE.NONE;
-  const listensThrough = listeningThroughDetail(
-    microphoneRoute,
-    (settings ?? bootstrap.settings).preferBuiltInMicrophone,
-  );
   const microphone: MicrophoneControl = {
     status: microphoneStatus,
     voiceAvailable: (settings ?? bootstrap.settings).voiceAvailable,
-    ...(listensThrough ? { listensThrough } : {}),
     onRequest: () => void requestMicrophoneAccess(),
     onOpenSettings: () => window.sidecar.openMicrophoneSettings(),
   };

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -2219,13 +2219,14 @@ export function App(): React.JSX.Element {
     credentialsEntry.entry && settings
       ? settings.credentialSources[credentialsEntry.entry.providerId]
       : CREDENTIAL_SOURCE.NONE;
+  const listensThrough = listeningThroughDetail(
+    microphoneRoute,
+    (settings ?? bootstrap.settings).preferBuiltInMicrophone,
+  );
   const microphone: MicrophoneControl = {
     status: microphoneStatus,
     voiceAvailable: (settings ?? bootstrap.settings).voiceAvailable,
-    listensThrough: listeningThroughDetail(
-      microphoneRoute,
-      (settings ?? bootstrap.settings).preferBuiltInMicrophone,
-    ),
+    ...(listensThrough ? { listensThrough } : {}),
     onRequest: () => void requestMicrophoneAccess(),
     onOpenSettings: () => window.sidecar.openMicrophoneSettings(),
   };

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -33,6 +33,7 @@ import type {
   AppBootstrap,
   AppSettings,
   DisplayDiagnostic,
+  MicrophoneRoute,
   ObservedAccountCalendars,
   OutputAudioState,
   SessionOpenResult,
@@ -91,6 +92,7 @@ import { type Errand, errandTargets, LukeErrand } from "./luke-errand";
 import { LukeFace } from "./luke-face";
 import { usePrefersReducedMotion } from "./luke-face-mood";
 import { applySpokenSetting, buildLukeGuide, isAppSettingId } from "./luke-guide";
+import { listeningThroughDetail } from "./microphone-choice";
 import { NotchWings } from "./notch-wings";
 import { PanelBody, type SessionWriteHandlers } from "./panel-body";
 import { HIT_REGION, PANEL_PRESENTATION } from "./panel-state";
@@ -314,6 +316,8 @@ export function App(): React.JSX.Element {
    * preference says, and a hint under them asks for volume.
    */
   const [outputAudio, setOutputAudio] = useState<OutputAudioState>();
+  /** Which device a press would open, for the Voice page's own line about it. */
+  const [microphoneRoute, setMicrophoneRoute] = useState<MicrophoneRoute>();
   /** Each connected account's calendars, for the settings rows' checkboxes. */
   const [calendars, setCalendars] = useState<readonly ObservedAccountCalendars[]>([]);
   /** Whether the calendar's quiet is holding announcements — the face sleeps on it. */
@@ -660,6 +664,12 @@ export function App(): React.JSX.Element {
 
   const changeDuckOtherMedia = useCallback(
     async (enabled: boolean) => applySettingsReply(await window.sidecar.setDuckOtherMedia(enabled)),
+    [applySettingsReply],
+  );
+
+  const changePreferBuiltInMicrophone = useCallback(
+    async (enabled: boolean) =>
+      applySettingsReply(await window.sidecar.setPreferBuiltInMicrophone(enabled)),
     [applySettingsReply],
   );
 
@@ -1582,6 +1592,7 @@ export function App(): React.JSX.Element {
     syncGuide,
     syncIssues,
   } = useVoiceConversation({
+    preferBuiltInMicrophone: (settings ?? bootstrap?.settings)?.preferBuiltInMicrophone ?? true,
     sessions,
     noticeAsks,
     workspaceProjects,
@@ -1684,6 +1695,11 @@ export function App(): React.JSX.Element {
   const acceptOutputAudioBootstrap = useBootstrapRacedChannel(
     (onChange) => window.sidecar.onOutputAudioChanged(onChange),
     setOutputAudio,
+  );
+  // Which device a press would open, for the line under the Microphone row.
+  const acceptMicrophoneRouteBootstrap = useBootstrapRacedChannel(
+    (onChange) => window.sidecar.onMicrophoneRouteChanged(onChange),
+    setMicrophoneRoute,
   );
   // Each connected account's calendars, for the checkboxes on its rows.
   const acceptCalendarsBootstrap = useBootstrapRacedChannel(
@@ -1797,6 +1813,7 @@ export function App(): React.JSX.Element {
       // Only fill in what no push has said yet, like the issue roster: the
       // bootstrap snapshot is older than any change that raced past it.
       if (value.outputAudio) acceptOutputAudioBootstrap(value.outputAudio);
+      if (value.microphoneRoute) acceptMicrophoneRouteBootstrap(value.microphoneRoute);
       if (value.profile === "microphone") {
         window.setTimeout(() => void startMicrophone(), 500);
       }
@@ -1840,6 +1857,7 @@ export function App(): React.JSX.Element {
     acceptCalendarsBootstrap,
     acceptIssuesBootstrap,
     acceptMeetingQuietBootstrap,
+    acceptMicrophoneRouteBootstrap,
     acceptOutputAudioBootstrap,
     acceptProjectsBootstrap,
     acceptSettingsBootstrap,
@@ -2204,6 +2222,10 @@ export function App(): React.JSX.Element {
   const microphone: MicrophoneControl = {
     status: microphoneStatus,
     voiceAvailable: (settings ?? bootstrap.settings).voiceAvailable,
+    listensThrough: listeningThroughDetail(
+      microphoneRoute,
+      (settings ?? bootstrap.settings).preferBuiltInMicrophone,
+    ),
     onRequest: () => void requestMicrophoneAccess(),
     onOpenSettings: () => window.sidecar.openMicrophoneSettings(),
   };
@@ -2219,6 +2241,7 @@ export function App(): React.JSX.Element {
   const preferences: PreferenceWrites = {
     onVoiceCaptionsChange: changeVoiceCaptions,
     onDuckOtherMediaChange: changeDuckOtherMedia,
+    onPreferBuiltInMicrophoneChange: changePreferBuiltInMicrophone,
     onQuietDuringMeetingsChange: changeQuietDuringMeetings,
     onVoiceChange: changeVoice,
     onVoiceSpeedChange: changeVoiceSpeed,

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -455,8 +455,8 @@ function askKeyFact(askKey: string | undefined): AppGuideFact {
 
 const MICROPHONE_DETAIL: Record<MicrophoneStatus, string> = {
   granted:
-    "Granted. The microphone opens with a conversation, sends nothing except while the talk " +
-    "key holds a turn, and is put away once the conversation sits quiet for about a minute.",
+    "Granted. The microphone opens only while the talk key holds a turn, and closes the " +
+    "moment the turn ends. Typing to Luke never opens it.",
   denied:
     "Denied. It can only be granted back in System Settings, under Privacy & Security, Microphone.",
   restricted: "Restricted by a system policy, which only the system's manager can change.",

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -454,7 +454,9 @@ function askKeyFact(askKey: string | undefined): AppGuideFact {
 }
 
 const MICROPHONE_DETAIL: Record<MicrophoneStatus, string> = {
-  granted: "Granted. The microphone only opens while the talk key holds a turn.",
+  granted:
+    "Granted. The microphone opens with a conversation, sends nothing except while the talk " +
+    "key holds a turn, and is put away once the conversation sits quiet for about a minute.",
   denied:
     "Denied. It can only be granted back in System Settings, under Privacy & Security, Microphone.",
   restricted: "Restricted by a system policy, which only the system's manager can change.",

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -456,7 +456,9 @@ function askKeyFact(askKey: string | undefined): AppGuideFact {
 const MICROPHONE_DETAIL: Record<MicrophoneStatus, string> = {
   granted:
     "Granted. The microphone opens only when the talk key takes a turn, sends nothing after " +
-    "the key comes up, and closes once the exchange settles. Typing to Luke never opens it.",
+    "the key comes up, and closes once the exchange settles. Typing to Luke never opens it. " +
+    "When the system input is a Bluetooth headset and the Mac's lid is open, Luke listens " +
+    "through the Mac's own microphone so the headset keeps its full music quality.",
   denied:
     "Denied. It can only be granted back in System Settings, under Privacy & Security, Microphone.",
   restricted: "Restricted by a system policy, which only the system's manager can change.",

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -455,8 +455,8 @@ function askKeyFact(askKey: string | undefined): AppGuideFact {
 
 const MICROPHONE_DETAIL: Record<MicrophoneStatus, string> = {
   granted:
-    "Granted. The microphone opens only while the talk key holds a turn, and closes the " +
-    "moment the turn ends. Typing to Luke never opens it.",
+    "Granted. The microphone opens only when the talk key takes a turn, sends nothing after " +
+    "the key comes up, and closes once the exchange settles. Typing to Luke never opens it.",
   denied:
     "Denied. It can only be granted back in System Settings, under Privacy & Security, Microphone.",
   restricted: "Restricted by a system policy, which only the system's manager can change.",

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -67,6 +67,7 @@ export const APP_SETTING_ID = {
   VOICE_SPEED: "voice_speed",
   VOICE_CAPTIONS: "voice_captions",
   DUCK_OTHER_MEDIA: "duck_other_media",
+  PREFER_BUILT_IN_MICROPHONE: "prefer_built_in_microphone",
   QUIET_DURING_MEETINGS: "quiet_during_meetings",
   SHOW_IN_MENU_BAR: "show_in_menu_bar",
   SHOW_IN_DOCK: "show_in_dock",
@@ -212,6 +213,19 @@ const SETTING_GUIDE: Record<
     kind: APP_SETTING_KIND.TOGGLE,
     value: appToggleText(settings.duckOtherMedia),
     defaultValue: appToggleText(APP_SETTING_DEFAULTS.duckOtherMedia),
+    adjustable: true,
+    manual: VOICE_PAGE,
+  }),
+  preferBuiltInMicrophone: (settings) => ({
+    id: APP_SETTING_ID.PREFER_BUILT_IN_MICROPHONE,
+    label: "Prefer the Mac's microphone",
+    description:
+      "Whether Luke listens through the Mac's own microphone when the system input is a " +
+      "Bluetooth headset, so the headset keeps its full music quality. A shut lid keeps the " +
+      "headset's microphone either way.",
+    kind: APP_SETTING_KIND.TOGGLE,
+    value: appToggleText(settings.preferBuiltInMicrophone),
+    defaultValue: appToggleText(APP_SETTING_DEFAULTS.preferBuiltInMicrophone),
     adjustable: true,
     manual: VOICE_PAGE,
   }),
@@ -457,8 +471,7 @@ const MICROPHONE_DETAIL: Record<MicrophoneStatus, string> = {
   granted:
     "Granted. The microphone opens only when the talk key takes a turn, sends nothing after " +
     "the key comes up, and closes once the exchange settles. Typing to Luke never opens it. " +
-    "When the system input is a Bluetooth headset and the Mac's lid is open, Luke listens " +
-    "through the Mac's own microphone so the headset keeps its full music quality.",
+    "Which device it opens is the Prefer the Mac's microphone setting's to say.",
   denied:
     "Denied. It can only be granted back in System Settings, under Privacy & Security, Microphone.",
   restricted: "Restricted by a system policy, which only the system's manager can change.",
@@ -891,6 +904,7 @@ export async function applySpokenSetting(
     | "setVoiceSpeed"
     | "setVoiceCaptions"
     | "setDuckOtherMedia"
+    | "setPreferBuiltInMicrophone"
     | "setQuietDuringMeetings"
     | "setShowInMenuBar"
     | "setShowInDock"
@@ -927,22 +941,24 @@ export async function applySpokenSetting(
       ? await bridge.setVoiceCaptions(enabled)
       : action.setting.id === APP_SETTING_ID.DUCK_OTHER_MEDIA
         ? await bridge.setDuckOtherMedia(enabled)
-        : action.setting.id === APP_SETTING_ID.QUIET_DURING_MEETINGS
-          ? await bridge.setQuietDuringMeetings(enabled)
-          : action.setting.id === APP_SETTING_ID.SHOW_IN_MENU_BAR
-            ? await bridge.setShowInMenuBar(enabled)
-            : action.setting.id === APP_SETTING_ID.SHOW_IN_DOCK
-              ? await bridge.setShowInDock(enabled)
-              : action.setting.id === APP_SETTING_ID.SHOW_ON_ALL_DISPLAYS
-                ? await bridge.setShowOnAllDisplays(enabled)
-                : action.setting.id === APP_SETTING_ID.VOICE_SPEED && speed !== undefined
-                  ? await bridge.setVoiceSpeed(speed)
-                  : action.setting.id === APP_SETTING_ID.VOICE && isRealtimeVoice(action.value)
-                    ? await bridge.setVoice(action.value)
-                    : action.setting.id === APP_SETTING_ID.FORM_FACTOR &&
-                        isPanelFormFactor(action.value)
-                      ? await bridge.setFormFactor(action.value)
-                      : undefined;
+        : action.setting.id === APP_SETTING_ID.PREFER_BUILT_IN_MICROPHONE
+          ? await bridge.setPreferBuiltInMicrophone(enabled)
+          : action.setting.id === APP_SETTING_ID.QUIET_DURING_MEETINGS
+            ? await bridge.setQuietDuringMeetings(enabled)
+            : action.setting.id === APP_SETTING_ID.SHOW_IN_MENU_BAR
+              ? await bridge.setShowInMenuBar(enabled)
+              : action.setting.id === APP_SETTING_ID.SHOW_IN_DOCK
+                ? await bridge.setShowInDock(enabled)
+                : action.setting.id === APP_SETTING_ID.SHOW_ON_ALL_DISPLAYS
+                  ? await bridge.setShowOnAllDisplays(enabled)
+                  : action.setting.id === APP_SETTING_ID.VOICE_SPEED && speed !== undefined
+                    ? await bridge.setVoiceSpeed(speed)
+                    : action.setting.id === APP_SETTING_ID.VOICE && isRealtimeVoice(action.value)
+                      ? await bridge.setVoice(action.value)
+                      : action.setting.id === APP_SETTING_ID.FORM_FACTOR &&
+                          isPanelFormFactor(action.value)
+                        ? await bridge.setFormFactor(action.value)
+                        : undefined;
   if (!result) {
     // An adjustable entry with no carrier is a guide ahead of its wiring;
     // refuse honestly rather than claim a change that never happened.

--- a/apps/desktop/src/renderer/microphone-choice.ts
+++ b/apps/desktop/src/renderer/microphone-choice.ts
@@ -71,6 +71,31 @@ export function microphoneConstraints(
   return { ...MICROPHONE_PROCESSING, deviceId: { exact: device.deviceId } };
 }
 
+/**
+ * The sentence the settings page says under the Microphone row: which device
+ * a press would open right now, and why. Worded from the same facts the
+ * choice runs on, so the line and the behavior can never disagree.
+ */
+export function listeningThroughDetail(
+  route: MicrophoneRoute | undefined,
+  preferBuiltIn: boolean,
+): string {
+  if (!route) return "The system's default microphone.";
+  if (route.defaultTransport !== MICROPHONE_TRANSPORT.BLUETOOTH) {
+    return "The system's default microphone.";
+  }
+  if (!preferBuiltIn) {
+    return "The Bluetooth headset's microphone, exactly as the system default is set.";
+  }
+  if (!route.builtInName) {
+    return "The Bluetooth headset's microphone — this Mac has no microphone of its own.";
+  }
+  if (route.lid === LID_STATE.SHUT) {
+    return "The Bluetooth headset's microphone — the Mac's own sits under a shut lid.";
+  }
+  return `${route.builtInName}, so the Bluetooth headset keeps its full music quality.`;
+}
+
 /** The three browser and bridge acts the opener composes, injectable. */
 export interface MicrophoneOpener {
   route(): Promise<MicrophoneRoute | undefined>;

--- a/apps/desktop/src/renderer/microphone-choice.ts
+++ b/apps/desktop/src/renderer/microphone-choice.ts
@@ -1,0 +1,104 @@
+import { LID_STATE, MICROPHONE_TRANSPORT, type MicrophoneRoute } from "../shared/contracts";
+
+/**
+ * How every capture is processed, wherever it is opened from.
+ *
+ * Echo cancellation is deliberately off. Push-to-talk is half-duplex by
+ * construction — a press interrupts the reply before the track enables, and
+ * `speak` refuses a busy turn — so Luke is never audible while the microphone
+ * is, and there is no echo to cancel. What the constraint would buy instead
+ * is Chromium's system echo canceller, which on macOS runs the capture
+ * through the OS's own voice processing — and the OS then ducks and thins
+ * every other app's audio for as long as the device is open. That processing,
+ * not the media duck (which only moves a volume and puts it back), is what
+ * made music sound degraded whenever a conversation was up, so the capture
+ * stays on the plain path. Gain and noise handling are Chromium's own
+ * in-process passes and touch nothing but this stream.
+ */
+export const MICROPHONE_PROCESSING = {
+  autoGainControl: true,
+  echoCancellation: false,
+  noiseSuppression: true,
+} as const;
+
+/** The parts of an enumerated media device the choice reads. */
+export interface EnumeratedMicrophone {
+  kind: string;
+  label: string;
+  deviceId: string;
+}
+
+/**
+ * The built-in microphone's name, when it is the better device to open.
+ *
+ * Capturing from a Bluetooth headset's own microphone pulls the whole headset
+ * onto its narrow call codec, so everything it plays — Luke's answer, the
+ * music the duck is about to restore — turns phone-grade for as long as the
+ * device is open. The Mac's own microphone costs none of that, so it is
+ * preferred exactly when the system default would be a Bluetooth headset and
+ * the lid over the Mac's microphone is not shut: a closed lid muffles it, and
+ * a muffled question is worse than a degraded song. A desktop keeps no lid
+ * and answers `unknown`, which counts as open — an iMac's microphone has
+ * nothing to be shut under.
+ */
+export function preferredBuiltInLabel(route: MicrophoneRoute | undefined): string | undefined {
+  if (!route?.builtInName) return undefined;
+  if (route.defaultTransport !== MICROPHONE_TRANSPORT.BLUETOOTH) return undefined;
+  if (route.lid === LID_STATE.SHUT) return undefined;
+  return route.builtInName;
+}
+
+/**
+ * The constraints a press opens the device with: the processing above, plus
+ * the built-in device when the route says it is the better one and the
+ * browser's list actually offers it. CoreAudio's name for the device is the
+ * browser's label for it, which is what lets a fact read natively choose
+ * among devices the web API names only by string.
+ */
+export function microphoneConstraints(
+  route: MicrophoneRoute | undefined,
+  devices: readonly EnumeratedMicrophone[],
+): MediaTrackConstraints {
+  const label = preferredBuiltInLabel(route);
+  if (!label) return { ...MICROPHONE_PROCESSING };
+  const device = devices.find(
+    (candidate) =>
+      candidate.kind === "audioinput" &&
+      candidate.deviceId !== "" &&
+      candidate.label.includes(label),
+  );
+  if (!device) return { ...MICROPHONE_PROCESSING };
+  return { ...MICROPHONE_PROCESSING, deviceId: { exact: device.deviceId } };
+}
+
+/** The three browser and bridge acts the opener composes, injectable. */
+export interface MicrophoneOpener {
+  route(): Promise<MicrophoneRoute | undefined>;
+  enumerate(): Promise<readonly EnumeratedMicrophone[]>;
+  open(audio: MediaTrackConstraints): Promise<MediaStream>;
+}
+
+/**
+ * Opens the capture device for a press, preferring the Mac's own microphone
+ * where the route says a Bluetooth headset would otherwise pay for it. The
+ * route is an optimization and never a gate: unreadable, unmatched, or
+ * vanished between the read and the open, the browser's default answers the
+ * press exactly as it would with no route at all.
+ */
+export async function openPreferredMicrophone(opener: MicrophoneOpener): Promise<MediaStream> {
+  let audio: MediaTrackConstraints = { ...MICROPHONE_PROCESSING };
+  try {
+    const route = await opener.route();
+    if (preferredBuiltInLabel(route)) {
+      audio = microphoneConstraints(route, await opener.enumerate());
+    }
+  } catch {
+    audio = { ...MICROPHONE_PROCESSING };
+  }
+  if (audio.deviceId === undefined) return opener.open(audio);
+  try {
+    return await opener.open(audio);
+  } catch {
+    return opener.open({ ...MICROPHONE_PROCESSING });
+  }
+}

--- a/apps/desktop/src/renderer/microphone-choice.ts
+++ b/apps/desktop/src/renderer/microphone-choice.ts
@@ -71,27 +71,6 @@ export function microphoneConstraints(
   return { ...MICROPHONE_PROCESSING, deviceId: { exact: device.deviceId } };
 }
 
-/**
- * One added clause for the Microphone row's small text, said only while the
- * routing decision is actually in play — a Bluetooth headset standing as the
- * system input with the preference on. Everywhere else the row stays exactly
- * as it always read: a page should not narrate the obvious. Worded from the
- * same facts the choice runs on, so the clause and the behavior can never
- * disagree.
- */
-export function listeningThroughDetail(
-  route: MicrophoneRoute | undefined,
-  preferBuiltIn: boolean,
-): string | undefined {
-  if (!preferBuiltIn) return undefined;
-  if (route?.defaultTransport !== MICROPHONE_TRANSPORT.BLUETOOTH) return undefined;
-  if (!route.builtInName) return undefined;
-  if (route.lid === LID_STATE.SHUT) {
-    return "With the lid shut, Luke listens through the Bluetooth headset.";
-  }
-  return "With a Bluetooth headset connected, Luke listens through the Mac's own microphone.";
-}
-
 /** The three browser and bridge acts the opener composes, injectable. */
 export interface MicrophoneOpener {
   route(): Promise<MicrophoneRoute | undefined>;

--- a/apps/desktop/src/renderer/microphone-choice.ts
+++ b/apps/desktop/src/renderer/microphone-choice.ts
@@ -72,28 +72,24 @@ export function microphoneConstraints(
 }
 
 /**
- * The sentence the settings page says under the Microphone row: which device
- * a press would open right now, and why. Worded from the same facts the
- * choice runs on, so the line and the behavior can never disagree.
+ * One added clause for the Microphone row's small text, said only while the
+ * routing decision is actually in play — a Bluetooth headset standing as the
+ * system input with the preference on. Everywhere else the row stays exactly
+ * as it always read: a page should not narrate the obvious. Worded from the
+ * same facts the choice runs on, so the clause and the behavior can never
+ * disagree.
  */
 export function listeningThroughDetail(
   route: MicrophoneRoute | undefined,
   preferBuiltIn: boolean,
-): string {
-  if (!route) return "The system's default microphone.";
-  if (route.defaultTransport !== MICROPHONE_TRANSPORT.BLUETOOTH) {
-    return "The system's default microphone.";
-  }
-  if (!preferBuiltIn) {
-    return "The Bluetooth headset's microphone, exactly as the system default is set.";
-  }
-  if (!route.builtInName) {
-    return "The Bluetooth headset's microphone — this Mac has no microphone of its own.";
-  }
+): string | undefined {
+  if (!preferBuiltIn) return undefined;
+  if (route?.defaultTransport !== MICROPHONE_TRANSPORT.BLUETOOTH) return undefined;
+  if (!route.builtInName) return undefined;
   if (route.lid === LID_STATE.SHUT) {
-    return "The Bluetooth headset's microphone — the Mac's own sits under a shut lid.";
+    return "With the lid shut, Luke listens through the Bluetooth headset.";
   }
-  return `${route.builtInName}, so the Bluetooth headset keeps its full music quality.`;
+  return "With a Bluetooth headset connected, Luke listens through the Mac's own microphone.";
 }
 
 /** The three browser and bridge acts the opener composes, injectable. */

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -72,17 +72,32 @@ const REALTIME_SETTLE_TIMEOUT_MS = 20_000;
 /**
  * How long the developer's call stays open with nothing being said on it.
  *
- * A call costs something to hold whether or not it is used: the capture device
- * stays open and the macOS microphone indicator stays lit, which on a sidecar
- * that sits on a desk all day is the whole difference between a companion and
- * something listening. The service ends the session at an hour regardless, so
- * the choice was never between keeping this conversation and losing it — only
- * between letting go of it deliberately and being cut off mid-sentence.
+ * The capture device does not ride this clock — it is let go on its own, much
+ * shorter one below — so what ten minutes buys is the conversation itself: the
+ * thread Luke would otherwise lose. The service ends the session at an hour
+ * regardless, so the choice was never between keeping this conversation and
+ * losing it — only between letting go of it deliberately and being cut off
+ * mid-sentence.
  *
  * Ten minutes is longer than any pause inside a conversation and shorter than
  * the walk to get a coffee. Coming back costs one handshake.
  */
 export const VOICE_IDLE_TIMEOUT_MS = 10 * 60_000;
+
+/**
+ * How long a settled call keeps the capture device before letting it go.
+ *
+ * Holding the device is what makes a follow-up turn instant, and it is also
+ * the one cost of a warm call the rest of the machine can hear: while any app
+ * captures, macOS keeps Bluetooth headphones on their narrow call codec and
+ * its voice processing engaged, so Music and Spotify play degraded long after
+ * the media duck has restored their volume — and the microphone indicator
+ * stays lit over a device nothing can be said into. A minute is longer than
+ * the pause between a reply and the follow-up it provokes; past it the device
+ * is put away — the call, and the conversation on it, stay — and the next
+ * press opens a fresh track onto the same call.
+ */
+export const MICROPHONE_RELEASE_TIMEOUT_MS = 60_000;
 
 /**
  * The order context is flushed in, so a turn's items land the same way every
@@ -197,6 +212,8 @@ export interface RealtimeVoiceSessionOptions extends RealtimeVoiceSessionCallbac
    * retirement can be exercised without waiting ten real minutes.
    */
   idleTimeoutMs?: number;
+  /** How long a settled call holds the capture device, injectable the same way. */
+  microphoneReleaseTimeoutMs?: number;
   /** The timer the idle retirement runs on, injectable for the same reason. */
   schedule?: (callback: () => void, delayMs: number) => unknown;
   cancel?: (timer: unknown) => void;
@@ -228,10 +245,15 @@ export function quietIsLukesOwn(input: { status: RealtimeStatus; heardLuke: bool
 /**
  * Drives one Realtime conversation over WebRTC.
  *
- * The microphone track is created once and kept disabled, so push-to-talk
- * enables an existing track rather than reopening the device. That keeps the
- * macOS microphone indicator honest: it lights up while Luke is connected, and
- * the UI states separately whether audio is actually being sent.
+ * The microphone track is created with the call and kept disabled between
+ * turns, so push-to-talk enables an existing track rather than reopening the
+ * device — for as long as the conversation is actually moving. A call that
+ * settles lets the device go on `MICROPHONE_RELEASE_TIMEOUT_MS` and keeps its
+ * sender, so the next press puts a fresh track onto the same call without
+ * renegotiating it. That keeps the macOS microphone indicator honest both
+ * ways: lit while a press could be heard soon, dark once the device is truly
+ * closed — and it hands Bluetooth headphones back to their music codec
+ * instead of parking them on the call one for the whole warm call.
  */
 export class RealtimeVoiceSession {
   readonly #options: RealtimeVoiceSessionOptions;
@@ -239,6 +261,14 @@ export class RealtimeVoiceSession {
   #channel: RTCDataChannel | undefined;
   #microphone: MediaStreamTrack | undefined;
   #stream: MediaStream | undefined;
+  /**
+   * The sender the microphone track rides. It outlives the track on purpose:
+   * a released device leaves the sender on the call, silent, which is what
+   * lets the next press attach a fresh track without renegotiating.
+   */
+  #microphoneSender: RTCRtpSender | undefined;
+  /** The device being reopened, held so two presses cannot open it twice. */
+  #acquiring: Promise<void> | undefined;
   /**
    * Whether the current connect attempt — and the call it opens — includes the
    * microphone. A developer's call does; one Luke opens for himself, to read a
@@ -430,6 +460,13 @@ export class RealtimeVoiceSession {
    */
   #idleTimer: unknown;
   /**
+   * The timer that lets go of the capture device on a settled call, armed and
+   * cancelled the way the idle timer is but on a much shorter clock: the
+   * device is what keeps Bluetooth audio degraded and the indicator lit, and
+   * neither should ride out the ten minutes the conversation is worth keeping.
+   */
+  #microphoneTimer: unknown;
+  /**
    * Whether the developer has taken a turn on this call. It is what makes a
    * dropped connection worth mentioning: a call that carried a conversation
    * takes the conversation with it, and Luke would otherwise answer the next
@@ -453,10 +490,12 @@ export class RealtimeVoiceSession {
    * Whether the call that is up — or coming up — is one the developer can take
    * a turn on. A call Luke opened to read a notice out has no microphone and
    * answers false, which is how a talk-key press knows it still has a call of
-   * its own to open.
+   * its own to open. The developer's call whose device is resting between
+   * turns still answers true: the call can take the turn, and the device
+   * rejoins it on the press rather than a fresh call replacing it.
    */
   get microphoneCall(): boolean {
-    if (this.isConnected) return this.#microphone !== undefined;
+    if (this.isConnected) return this.#withMicrophone;
     if (this.isConnecting) return this.#withMicrophone;
     return false;
   }
@@ -511,13 +550,7 @@ export class RealtimeVoiceSession {
     // nothing to consent to and nothing to hold.
     const [connectionResult, streamResult] = await Promise.allSettled([
       this.#options.requestConnection(),
-      this.#withMicrophone
-        ? (this.#options.requestMicrophoneStream?.() ??
-          navigator.mediaDevices.getUserMedia({
-            audio: { autoGainControl: true, echoCancellation: true, noiseSuppression: true },
-            video: false,
-          }))
-        : Promise.resolve(undefined),
+      this.#withMicrophone ? this.#requestStream() : Promise.resolve(undefined),
     ]);
     // Adopt the device before deciding anything, so every exit from here — a
     // stop that landed mid-mint, a failed mint, no credential at all — releases
@@ -554,7 +587,7 @@ export class RealtimeVoiceSession {
         microphone.enabled = false;
         this.#microphone = microphone;
         this.#options.onLocalStream(stream);
-        peer.addTrack(microphone, stream);
+        this.#microphoneSender = peer.addTrack(microphone, stream);
       } else {
         // Luke's own call receives audio and offers none: the transceiver says
         // so up front, so the connection is speak-only by shape rather than by
@@ -645,6 +678,17 @@ export class RealtimeVoiceSession {
     return false;
   }
 
+  /** One way to ask for the device, whether the call is opening or warm. */
+  #requestStream(): Promise<MediaStream> {
+    return (
+      this.#options.requestMicrophoneStream?.() ??
+      navigator.mediaDevices.getUserMedia({
+        audio: { autoGainControl: true, echoCancellation: true, noiseSuppression: true },
+        video: false,
+      })
+    );
+  }
+
   async #exchangeDescription(
     connection: RealtimeConnection,
     offer: string,
@@ -705,9 +749,11 @@ export class RealtimeVoiceSession {
   beginTurn(): void {
     // A call without a microphone cannot take the turn, however open it is:
     // the press waits as an intention while the developer's own call — the
-    // one that will replace Luke's — comes up.
+    // one that will replace Luke's — comes up, or while the device this call
+    // put away between turns is reopened.
     if (!this.isConnected || !this.#microphone) {
       this.#pendingTurn = true;
+      this.#acquireMicrophone();
       return;
     }
     this.startListening();
@@ -720,6 +766,14 @@ export class RealtimeVoiceSession {
    */
   endTurn(commit: boolean): void {
     if (!this.isConnected) {
+      this.#pendingTurn = false;
+      return;
+    }
+    // A press let go of while this call's own device was still reopening held
+    // nothing to send: the turn it was owed is dropped rather than opened
+    // under a key that is already up. A press against Luke's speak-only call
+    // is a different wait — for the developer's call — and keeps its meaning.
+    if (!this.#microphone && this.#withMicrophone) {
       this.#pendingTurn = false;
       return;
     }
@@ -737,6 +791,7 @@ export class RealtimeVoiceSession {
     // the one that can.
     if (!this.isConnected || !this.#microphone) {
       this.#pendingTurn = !this.#pendingTurn;
+      if (this.#pendingTurn) this.#acquireMicrophone();
       return;
     }
     if (this.#status === REALTIME_STATUS.LISTENING) {
@@ -768,6 +823,88 @@ export class RealtimeVoiceSession {
    */
   dropPendingTurn(): void {
     this.#pendingTurn = false;
+    // A device already reopened for that press has no turn left to serve, so
+    // it goes back on the settle clock rather than being held for nothing.
+    this.#restMicrophoneTimer();
+  }
+
+  /**
+   * Reopens the capture device on the call it already belongs to — the one
+   * that put it away while the conversation sat settled. One request at a
+   * time: a second press mid-open joins the first rather than racing it.
+   */
+  #acquireMicrophone(): void {
+    if (!this.isConnected || !this.#withMicrophone || this.#microphone) return;
+    if (this.#acquiring) return;
+    this.#acquiring = this.#reopenMicrophone().finally(() => {
+      this.#acquiring = undefined;
+    });
+  }
+
+  async #reopenMicrophone(): Promise<void> {
+    let stream: MediaStream;
+    try {
+      stream = await this.#requestStream();
+    } catch (error) {
+      // The same answer a denied device gets at connect: a microphone call
+      // that cannot open its microphone is failed rather than left looking
+      // able to listen, and `FAILED` offers "Start voice" again.
+      this.#fail(errorMessage(error));
+      return;
+    }
+    // The call may have gone away — or been replaced, bringing its own device
+    // — while this one was opening. A device nobody adopts is released here,
+    // or it would hold the indicator lit with nothing left to close it.
+    const sender = this.#microphoneSender;
+    if (this.#closed || !this.isConnected || !sender || this.#microphone) {
+      for (const track of stream.getTracks()) track.stop();
+      return;
+    }
+    const [microphone] = stream.getAudioTracks();
+    if (!microphone) {
+      for (const track of stream.getTracks()) track.stop();
+      this.#fail("No microphone track was available");
+      return;
+    }
+    // Closed until a turn opens it, exactly as a connect-time track starts.
+    microphone.enabled = false;
+    this.#stream = stream;
+    this.#microphone = microphone;
+    this.#options.onLocalStream(stream);
+    try {
+      // Onto the sender the released track vacated: no renegotiation, the
+      // same m-line, the same call.
+      await sender.replaceTrack(microphone);
+    } catch (error) {
+      this.#fail(errorMessage(error));
+      return;
+    }
+    if (this.#closed || !this.isConnected) return;
+    if (this.#pendingTurn) {
+      this.#pendingTurn = false;
+      this.startListening();
+      return;
+    }
+    // Reopened for a press that has since been let go: the device sits on the
+    // same settle clock it would ride after any turn.
+    this.#restMicrophoneTimer();
+  }
+
+  /**
+   * Puts the capture device away without touching the call: the tracks stop,
+   * the sender stays to take the next track, and the meter lets go of a
+   * stream that no longer exists. From here the microphone indicator is dark
+   * and Bluetooth audio is back on its music codec.
+   */
+  #releaseMicrophone(): void {
+    const stream = this.#stream;
+    this.#stream = undefined;
+    this.#microphone = undefined;
+    stream?.getTracks().forEach((track) => {
+      track.stop();
+    });
+    void this.#microphoneSender?.replaceTrack(null);
+    this.#options.onLocalStream(undefined);
   }
 
   /**
@@ -841,8 +978,9 @@ export class RealtimeVoiceSession {
     // A typed ask runs only on the developer's own call. Luke's speak-only
     // call has been sent no roster, no guide, and no issues, so a turn armed
     // for tools has nothing real to validate against there — the caller
-    // stands that call down and opens the full one before asking.
-    if (!this.isConnected || !this.#microphone) return false;
+    // stands that call down and opens the full one before asking. A typed ask
+    // needs no capture device, so one this call put away stays put away.
+    if (!this.isConnected || !this.#withMicrophone) return false;
     if (this.#status === REALTIME_STATUS.LISTENING) return false;
     const events = typedAskEvents(text);
     if (events.length === 0) return false;
@@ -965,6 +1103,7 @@ export class RealtimeVoiceSession {
     this.#peer = undefined;
     this.#remoteTrack = undefined;
     this.#microphone = undefined;
+    this.#microphoneSender = undefined;
     this.#stream?.getTracks().forEach((track) => {
       track.stop();
     });
@@ -982,6 +1121,7 @@ export class RealtimeVoiceSession {
     this.#pendingSupersedes.clear();
     this.#conversationBegan = false;
     this.#clearIdleTimer();
+    this.#clearMicrophoneTimer();
     this.#generationDone = false;
     this.#remoteQuiet = false;
     this.#heardLuke = false;
@@ -1722,6 +1862,7 @@ export class RealtimeVoiceSession {
     if (this.#status === status) return;
     this.#status = status;
     this.#restIdleTimer(status);
+    this.#restMicrophoneTimer();
     this.#options.onStatus(status);
   }
 
@@ -1730,7 +1871,7 @@ export class RealtimeVoiceSession {
    *
    * Only the developer's own call is retired this way. The call Luke opens to
    * read a notice out already puts itself away once the queue is quiet, and it
-   * holds no capture device to be worth hurrying.
+   * holds no conversation worth a clock of its own.
    *
    * A settled call restarts the clock however it settled, so a notice read out
    * counts as the call being used. It reached the developer, and a call that
@@ -1738,13 +1879,13 @@ export class RealtimeVoiceSession {
    */
   #restIdleTimer(status: RealtimeStatus): void {
     this.#clearIdleTimer();
-    if (status !== REALTIME_STATUS.READY || !this.#microphone) return;
+    if (status !== REALTIME_STATUS.READY || !this.#withMicrophone) return;
     const timeoutMs = positiveInteger(this.#options.idleTimeoutMs, VOICE_IDLE_TIMEOUT_MS);
     this.#idleTimer = (this.#options.schedule ?? setTimeout)(() => {
       this.#idleTimer = undefined;
       // Re-checked at the moment of closing, because ten minutes is long: a
       // turn may have opened, or the call may already be gone.
-      if (this.#status !== REALTIME_STATUS.READY || !this.#microphone) return;
+      if (this.#status !== REALTIME_STATUS.READY || !this.#withMicrophone) return;
       void this.close();
     }, timeoutMs);
   }
@@ -1753,5 +1894,35 @@ export class RealtimeVoiceSession {
     if (this.#idleTimer === undefined) return;
     (this.#options.cancel ?? clearTimeout)(this.#idleTimer as Parameters<typeof clearTimeout>[0]);
     this.#idleTimer = undefined;
+  }
+
+  /**
+   * Starts the clock on a device a settled call is still holding, or stops it
+   * because a turn is under way or already spoken for. The same edges the
+   * retirement runs on, a much shorter clock: the conversation is worth ten
+   * minutes, and the device — the part other audio can hear — is not.
+   */
+  #restMicrophoneTimer(): void {
+    this.#clearMicrophoneTimer();
+    if (this.#status !== REALTIME_STATUS.READY || !this.#microphone || this.#pendingTurn) return;
+    const timeoutMs = positiveInteger(
+      this.#options.microphoneReleaseTimeoutMs,
+      MICROPHONE_RELEASE_TIMEOUT_MS,
+    );
+    this.#microphoneTimer = (this.#options.schedule ?? setTimeout)(() => {
+      this.#microphoneTimer = undefined;
+      // Re-checked at the moment of release: a turn may have opened, or a
+      // press may be waiting on this very device.
+      if (this.#status !== REALTIME_STATUS.READY || this.#pendingTurn) return;
+      this.#releaseMicrophone();
+    }, timeoutMs);
+  }
+
+  #clearMicrophoneTimer(): void {
+    if (this.#microphoneTimer === undefined) return;
+    (this.#options.cancel ?? clearTimeout)(
+      this.#microphoneTimer as Parameters<typeof clearTimeout>[0],
+    );
+    this.#microphoneTimer = undefined;
   }
 }

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -72,32 +72,17 @@ const REALTIME_SETTLE_TIMEOUT_MS = 20_000;
 /**
  * How long the developer's call stays open with nothing being said on it.
  *
- * The capture device does not ride this clock — it is let go on its own, much
- * shorter one below — so what ten minutes buys is the conversation itself: the
- * thread Luke would otherwise lose. The service ends the session at an hour
- * regardless, so the choice was never between keeping this conversation and
- * losing it — only between letting go of it deliberately and being cut off
- * mid-sentence.
+ * The capture device never rides this clock — it opens with a press and
+ * closes with the turn — so what ten minutes buys is the conversation itself:
+ * the thread Luke would otherwise lose. The service ends the session at an
+ * hour regardless, so the choice was never between keeping this conversation
+ * and losing it — only between letting go of it deliberately and being cut
+ * off mid-sentence.
  *
  * Ten minutes is longer than any pause inside a conversation and shorter than
  * the walk to get a coffee. Coming back costs one handshake.
  */
 export const VOICE_IDLE_TIMEOUT_MS = 10 * 60_000;
-
-/**
- * How long a settled call keeps the capture device before letting it go.
- *
- * Holding the device is what makes a follow-up turn instant, and it is also
- * the one cost of a warm call the rest of the machine can hear: while any app
- * captures, macOS keeps Bluetooth headphones on their narrow call codec and
- * its voice processing engaged, so Music and Spotify play degraded long after
- * the media duck has restored their volume — and the microphone indicator
- * stays lit over a device nothing can be said into. A minute is longer than
- * the pause between a reply and the follow-up it provokes; past it the device
- * is put away — the call, and the conversation on it, stay — and the next
- * press opens a fresh track onto the same call.
- */
-export const MICROPHONE_RELEASE_TIMEOUT_MS = 60_000;
 
 /**
  * The order context is flushed in, so a turn's items land the same way every
@@ -212,8 +197,6 @@ export interface RealtimeVoiceSessionOptions extends RealtimeVoiceSessionCallbac
    * retirement can be exercised without waiting ten real minutes.
    */
   idleTimeoutMs?: number;
-  /** How long a settled call holds the capture device, injectable the same way. */
-  microphoneReleaseTimeoutMs?: number;
   /** The timer the idle retirement runs on, injectable for the same reason. */
   schedule?: (callback: () => void, delayMs: number) => unknown;
   cancel?: (timer: unknown) => void;
@@ -245,15 +228,16 @@ export function quietIsLukesOwn(input: { status: RealtimeStatus; heardLuke: bool
 /**
  * Drives one Realtime conversation over WebRTC.
  *
- * The microphone track is created with the call and kept disabled between
- * turns, so push-to-talk enables an existing track rather than reopening the
- * device — for as long as the conversation is actually moving. A call that
- * settles lets the device go on `MICROPHONE_RELEASE_TIMEOUT_MS` and keeps its
- * sender, so the next press puts a fresh track onto the same call without
- * renegotiating it. That keeps the macOS microphone indicator honest both
- * ways: lit while a press could be heard soon, dark once the device is truly
- * closed — and it hands Bluetooth headphones back to their music codec
- * instead of parking them on the call one for the whole warm call.
+ * The capture device is the developer's, not the call's: it opens when a
+ * press takes a turn and closes the moment the turn ends, and nothing else —
+ * not connecting, not typing, not an announcement — ever touches it. The call
+ * negotiates its sending half up front as a bare transceiver, so each turn's
+ * fresh track rides the same sender without renegotiating. The press is held
+ * as a pending intention while the device opens, exactly as a press that
+ * beats the call's handshake is. What this buys is that the microphone
+ * indicator and the capture are user-driven to the second — and that other
+ * audio, Bluetooth codecs included, is never degraded by a device being held
+ * while nobody is talking.
  */
 export class RealtimeVoiceSession {
   readonly #options: RealtimeVoiceSessionOptions;
@@ -460,13 +444,6 @@ export class RealtimeVoiceSession {
    */
   #idleTimer: unknown;
   /**
-   * The timer that lets go of the capture device on a settled call, armed and
-   * cancelled the way the idle timer is but on a much shorter clock: the
-   * device is what keeps Bluetooth audio degraded and the indicator lit, and
-   * neither should ride out the ten minutes the conversation is worth keeping.
-   */
-  #microphoneTimer: unknown;
-  /**
    * Whether the developer has taken a turn on this call. It is what makes a
    * dropped connection worth mentioning: a call that carried a conversation
    * takes the conversation with it, and Luke would otherwise answer the next
@@ -541,53 +518,36 @@ export class RealtimeVoiceSession {
     this.#setStatus(REALTIME_STATUS.CONNECTING);
     this.#options.onError(undefined);
 
-    // The whole of the wait before the handshake is these two, and neither
-    // needs the other: the credential is minted over the network while the
-    // capture device opens. `allSettled` rather than `all`, because whichever
-    // one loses still has to be dealt with — a device that opened after a
-    // failed mint would be held with nobody left to release it. A speak-only
-    // call never asks for the device at all: nothing is captured, so there is
-    // nothing to consent to and nothing to hold.
-    const [connectionResult, streamResult] = await Promise.allSettled([
-      this.#options.requestConnection(),
-      this.#withMicrophone ? this.#requestStream() : Promise.resolve(undefined),
-    ]);
-    // Adopt the device before deciding anything, so every exit from here — a
-    // stop that landed mid-mint, a failed mint, no credential at all — releases
-    // it through the same teardown as the rest.
-    if (streamResult.status === "fulfilled") this.#stream = streamResult.value;
-
-    // A stop that lands while the credential is being minted is not a fault
-    // to report. Every exit from here has to ask, not just the ones after the
-    // handshake starts.
-    if (this.#closed) return this.#abandonConnect();
-    if (connectionResult.status === "rejected") {
-      return this.#fail(
-        `Could not reach the main process: ${errorMessage(connectionResult.reason)}`,
-      );
+    // Connecting opens no capture device: the microphone is the developer's,
+    // not the call's, and it opens only when a press takes a turn. All the
+    // wait before the handshake is the credential being minted.
+    let connection: RealtimeConnection | undefined;
+    try {
+      connection = await this.#options.requestConnection();
+    } catch (error) {
+      // A stop that lands while the credential is being minted is not a fault
+      // to report. Every exit from here has to ask, not just the ones after
+      // the handshake starts.
+      if (this.#closed) return this.#abandonConnect();
+      return this.#fail(`Could not reach the main process: ${errorMessage(error)}`);
     }
-    const connection = connectionResult.value;
+    if (this.#closed) return this.#abandonConnect();
     if (!connection) {
       this.#teardown();
       this.#setStatus(REALTIME_STATUS.UNAVAILABLE);
       return false;
     }
-    if (streamResult.status === "rejected") {
-      return this.#fail(errorMessage(streamResult.reason));
-    }
 
     try {
       const peer = this.#options.createPeerConnection?.() ?? new RTCPeerConnection();
       this.#peer = peer;
-      const stream = streamResult.value;
       if (this.#withMicrophone) {
-        const [microphone] = stream?.getAudioTracks() ?? [];
-        if (!microphone || !stream) throw new Error("No microphone track was available");
-        // Push-to-talk starts closed. Nothing is sent until the developer asks.
-        microphone.enabled = false;
-        this.#microphone = microphone;
-        this.#options.onLocalStream(stream);
-        this.#microphoneSender = peer.addTrack(microphone, stream);
+        // The developer's call declares its sending half as a bare
+        // transceiver: the line is negotiated now, and each turn's track
+        // joins the kept sender later without renegotiating. No track, no
+        // device, no consent asked — until a press asks for a turn.
+        const transceiver = peer.addTransceiver("audio", { direction: "sendrecv" });
+        this.#microphoneSender = transceiver.sender;
       } else {
         // Luke's own call receives audio and offers none: the transceiver says
         // so up front, so the connection is speak-only by shape rather than by
@@ -654,13 +614,11 @@ export class RealtimeVoiceSession {
       // credential this call answered may have been minted before the change.
       this.#flushPendingSpeed();
       // Whoever pressed the talk key to get here has been waiting through the
-      // handshake for their turn to open. A speak-only call leaves the press
-      // pending instead — it has no microphone to open a turn with, and the
-      // developer's own call is already replacing it.
-      if (this.#pendingTurn && this.#microphone) {
-        this.#pendingTurn = false;
-        this.startListening();
-      }
+      // handshake for their turn to open, and the device opens now, for that
+      // press. A speak-only call leaves the press pending instead — it has no
+      // sending half to open a turn with, and the developer's own call is
+      // already replacing it.
+      if (this.#pendingTurn && this.#withMicrophone) this.#acquireMicrophone();
       return true;
     } catch (error) {
       if (this.#closed) return this.#abandonConnect();
@@ -678,7 +636,7 @@ export class RealtimeVoiceSession {
     return false;
   }
 
-  /** One way to ask for the device, whether the call is opening or warm. */
+  /** How the device is asked for — only ever on behalf of a press. */
   #requestStream(): Promise<MediaStream> {
     return (
       this.#options.requestMicrophoneStream?.() ??
@@ -759,11 +717,15 @@ export class RealtimeVoiceSession {
    * key is held cannot be left open by forgetting to press again.
    */
   beginTurn(): void {
-    // A call without a microphone cannot take the turn, however open it is:
-    // the press waits as an intention while the developer's own call — the
-    // one that will replace Luke's — comes up, or while the device this call
-    // put away between turns is reopened.
+    // Every press opens the device: it lives exactly as long as the turn it
+    // was pressed for. Until the device is live — and, on a first press, the
+    // call it rides — the press waits as an intention and the turn opens the
+    // moment both exist.
     if (!this.isConnected || !this.#microphone) {
+      // The developer's turn wins at the press, not at the device: a reply
+      // under way is cut off now, exactly as the stop key cuts one, and the
+      // turn itself opens when the device arrives.
+      this.stopSpeaking();
       this.#pendingTurn = true;
       this.#acquireMicrophone();
       return;
@@ -774,17 +736,18 @@ export class RealtimeVoiceSession {
   /**
    * The talk key coming up on a held turn, or a second press ending a latched
    * one. A turn that never opened is dropped rather than committed: the
-   * microphone opens with the call, so there is nothing behind it to send.
+   * microphone opens with the press, and one that was let go of before the
+   * device arrived captured nothing to send.
    */
   endTurn(commit: boolean): void {
     if (!this.isConnected) {
       this.#pendingTurn = false;
       return;
     }
-    // A press let go of while this call's own device was still reopening held
-    // nothing to send: the turn it was owed is dropped rather than opened
-    // under a key that is already up. A press against Luke's speak-only call
-    // is a different wait — for the developer's call — and keeps its meaning.
+    // A press let go of while its device was still opening held nothing to
+    // send: the turn it was owed is dropped rather than opened under a key
+    // that is already up. A press against Luke's speak-only call is a
+    // different wait — for the developer's call — and keeps its meaning.
     if (!this.#microphone && this.#withMicrophone) {
       this.#pendingTurn = false;
       return;
@@ -793,17 +756,21 @@ export class RealtimeVoiceSession {
   }
 
   toggleTurn(): void {
-    // Before the call is up there is no turn to take: the microphone is enabled
-    // only once the connection exists, so a press here cannot have captured
-    // anything. It is remembered and applied when the call opens — and a second
-    // press cancels the first rather than queueing another, because two presses
-    // have always meant a turn opened and closed, and one that held nothing is
-    // one with nothing to send. A connected call without a microphone is the
-    // same case: Luke's own call cannot take a turn, so the press waits for
-    // the one that can.
+    // Until the device this press opens is live — and, before the call is up,
+    // the call too — there is no turn to take yet: the press is remembered
+    // and applied the moment there is. A second press cancels the first
+    // rather than queueing another, because two presses have always meant a
+    // turn opened and closed, and one that held nothing is one with nothing
+    // to send. A connected speak-only call is the waiting case too: Luke's
+    // own call cannot take a turn, so the press waits for the one that can.
     if (!this.isConnected || !this.#microphone) {
       this.#pendingTurn = !this.#pendingTurn;
-      if (this.#pendingTurn) this.#acquireMicrophone();
+      if (this.#pendingTurn) {
+        // The same early cut a held press makes: the reply stops at the
+        // press, and the turn opens when the device arrives.
+        this.stopSpeaking();
+        this.#acquireMicrophone();
+      }
       return;
     }
     if (this.#status === REALTIME_STATUS.LISTENING) {
@@ -835,32 +802,31 @@ export class RealtimeVoiceSession {
    */
   dropPendingTurn(): void {
     this.#pendingTurn = false;
-    // A device already reopened for that press has no turn left to serve, so
-    // it goes back on the settle clock rather than being held for nothing.
-    this.#restMicrophoneTimer();
+    // A device already opened for that press has no turn left to serve, and
+    // nobody is talking into it: it closes now, not on any clock.
+    if (this.#status !== REALTIME_STATUS.LISTENING) this.#releaseMicrophone();
   }
 
   /**
-   * Reopens the capture device on the call it already belongs to — the one
-   * that put it away while the conversation sat settled. One request at a
+   * Opens the capture device for the press waiting on it. One request at a
    * time: a second press mid-open joins the first rather than racing it.
    */
   #acquireMicrophone(): void {
     if (!this.isConnected || !this.#withMicrophone || this.#microphone) return;
     if (this.#acquiring) return;
-    this.#acquiring = this.#reopenMicrophone().finally(() => {
+    this.#acquiring = this.#openMicrophone().finally(() => {
       this.#acquiring = undefined;
     });
   }
 
-  async #reopenMicrophone(): Promise<void> {
+  async #openMicrophone(): Promise<void> {
     let stream: MediaStream;
     try {
       stream = await this.#requestStream();
     } catch (error) {
-      // The same answer a denied device gets at connect: a microphone call
-      // that cannot open its microphone is failed rather than left looking
-      // able to listen, and `FAILED` offers "Start voice" again.
+      // A microphone call that cannot open its microphone is failed rather
+      // than left looking able to listen, and `FAILED` offers "Start voice"
+      // again.
       this.#fail(errorMessage(error));
       return;
     }
@@ -878,14 +844,15 @@ export class RealtimeVoiceSession {
       this.#fail("No microphone track was available");
       return;
     }
-    // Closed until a turn opens it, exactly as a connect-time track starts.
+    // Closed until the turn opens it, so nothing is sent before the state
+    // machine says the turn is on.
     microphone.enabled = false;
     this.#stream = stream;
     this.#microphone = microphone;
     this.#options.onLocalStream(stream);
     try {
-      // Onto the sender the released track vacated: no renegotiation, the
-      // same m-line, the same call.
+      // Onto the sender the call has kept since its handshake: no
+      // renegotiation, the same line, the same call.
       await sender.replaceTrack(microphone);
     } catch (error) {
       this.#fail(errorMessage(error));
@@ -897,9 +864,9 @@ export class RealtimeVoiceSession {
       this.startListening();
       return;
     }
-    // Reopened for a press that has since been let go: the device sits on the
-    // same settle clock it would ride after any turn.
-    this.#restMicrophoneTimer();
+    // Opened for a press that has since been let go: nobody is talking, so
+    // the device closes as fast as it arrived.
+    this.#releaseMicrophone();
   }
 
   /**
@@ -909,6 +876,7 @@ export class RealtimeVoiceSession {
    * and Bluetooth audio is back on its music codec.
    */
   #releaseMicrophone(): void {
+    if (!this.#stream && !this.#microphone) return;
     const stream = this.#stream;
     this.#stream = undefined;
     this.#microphone = undefined;
@@ -966,12 +934,18 @@ export class RealtimeVoiceSession {
     this.#microphone.enabled = false;
     if (!commit) {
       this.#send(clearInputAudioEvents());
+      // The turn is over, so the device is too: what was pressed for ends
+      // with the press.
+      this.#releaseMicrophone();
       this.#setStatus(REALTIME_STATUS.READY);
       return;
     }
     // A turn a tool may run in: the developer opened it and spoke into it, so
     // a tool call it emits is the developer's own ask.
     this.#startResponse(pushToTalkCommitEvents(), true);
+    // Released after the commit is on its way. Everything spoken has already
+    // streamed live during the turn; the device has nothing left to add.
+    this.#releaseMicrophone();
   }
 
   /**
@@ -1133,7 +1107,6 @@ export class RealtimeVoiceSession {
     this.#pendingSupersedes.clear();
     this.#conversationBegan = false;
     this.#clearIdleTimer();
-    this.#clearMicrophoneTimer();
     this.#generationDone = false;
     this.#remoteQuiet = false;
     this.#heardLuke = false;
@@ -1874,7 +1847,6 @@ export class RealtimeVoiceSession {
     if (this.#status === status) return;
     this.#status = status;
     this.#restIdleTimer(status);
-    this.#restMicrophoneTimer();
     this.#options.onStatus(status);
   }
 
@@ -1906,35 +1878,5 @@ export class RealtimeVoiceSession {
     if (this.#idleTimer === undefined) return;
     (this.#options.cancel ?? clearTimeout)(this.#idleTimer as Parameters<typeof clearTimeout>[0]);
     this.#idleTimer = undefined;
-  }
-
-  /**
-   * Starts the clock on a device a settled call is still holding, or stops it
-   * because a turn is under way or already spoken for. The same edges the
-   * retirement runs on, a much shorter clock: the conversation is worth ten
-   * minutes, and the device — the part other audio can hear — is not.
-   */
-  #restMicrophoneTimer(): void {
-    this.#clearMicrophoneTimer();
-    if (this.#status !== REALTIME_STATUS.READY || !this.#microphone || this.#pendingTurn) return;
-    const timeoutMs = positiveInteger(
-      this.#options.microphoneReleaseTimeoutMs,
-      MICROPHONE_RELEASE_TIMEOUT_MS,
-    );
-    this.#microphoneTimer = (this.#options.schedule ?? setTimeout)(() => {
-      this.#microphoneTimer = undefined;
-      // Re-checked at the moment of release: a turn may have opened, or a
-      // press may be waiting on this very device.
-      if (this.#status !== REALTIME_STATUS.READY || this.#pendingTurn) return;
-      this.#releaseMicrophone();
-    }, timeoutMs);
-  }
-
-  #clearMicrophoneTimer(): void {
-    if (this.#microphoneTimer === undefined) return;
-    (this.#options.cancel ?? clearTimeout)(
-      this.#microphoneTimer as Parameters<typeof clearTimeout>[0],
-    );
-    this.#microphoneTimer = undefined;
   }
 }

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -683,7 +683,19 @@ export class RealtimeVoiceSession {
     return (
       this.#options.requestMicrophoneStream?.() ??
       navigator.mediaDevices.getUserMedia({
-        audio: { autoGainControl: true, echoCancellation: true, noiseSuppression: true },
+        // Echo cancellation is deliberately off. Push-to-talk is half-duplex
+        // by construction — a press interrupts the reply before the track
+        // enables, and `speak` refuses a busy turn — so Luke is never audible
+        // while the microphone is, and there is no echo to cancel. What the
+        // constraint would buy instead is Chromium's system echo canceller,
+        // which on macOS runs the capture through the OS's own voice
+        // processing — and the OS then ducks and thins every other app's
+        // audio for as long as the device is open. That processing, not the
+        // media duck (which only moves a volume and puts it back), is what
+        // made music sound degraded from the moment a conversation began, so
+        // the capture stays on the plain path. Gain and noise handling are
+        // Chromium's own in-process passes and touch nothing but this stream.
+        audio: { autoGainControl: true, echoCancellation: false, noiseSuppression: true },
         video: false,
       })
     );

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -56,6 +56,7 @@ import {
   workspaceProjectContextText,
 } from "@sidecar/core";
 import { workspaceAgentModels } from "../shared/workspace-agents";
+import { MICROPHONE_PROCESSING } from "./microphone-choice";
 
 const SDP_CONTENT_TYPE = "application/sdp";
 
@@ -640,26 +641,16 @@ export class RealtimeVoiceSession {
     return false;
   }
 
-  /** How the device is asked for — only ever on behalf of a press. */
+  /**
+   * How the device is asked for — only ever on behalf of a press. The caller
+   * usually injects the route-aware opener; the fallback opens the browser's
+   * default with the same processing (`MICROPHONE_PROCESSING` says why echo
+   * cancellation is off), so a bare session still captures correctly.
+   */
   #requestStream(): Promise<MediaStream> {
     return (
       this.#options.requestMicrophoneStream?.() ??
-      navigator.mediaDevices.getUserMedia({
-        // Echo cancellation is deliberately off. Push-to-talk is half-duplex
-        // by construction — a press interrupts the reply before the track
-        // enables, and `speak` refuses a busy turn — so Luke is never audible
-        // while the microphone is, and there is no echo to cancel. What the
-        // constraint would buy instead is Chromium's system echo canceller,
-        // which on macOS runs the capture through the OS's own voice
-        // processing — and the OS then ducks and thins every other app's
-        // audio for as long as the device is open. That processing, not the
-        // media duck (which only moves a volume and puts it back), is what
-        // made music sound degraded from the moment a conversation began, so
-        // the capture stays on the plain path. Gain and noise handling are
-        // Chromium's own in-process passes and touch nothing but this stream.
-        audio: { autoGainControl: true, echoCancellation: false, noiseSuppression: true },
-        video: false,
-      })
+      navigator.mediaDevices.getUserMedia({ audio: { ...MICROPHONE_PROCESSING }, video: false })
     );
   }
 

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -811,25 +811,42 @@ export class RealtimeVoiceSession {
     if (this.#acquiring) return;
     this.#acquiring = this.#openMicrophone().finally(() => {
       this.#acquiring = undefined;
+      // A press that arrived while a stale open was still in flight was told
+      // to wait by the guard above; with the flight over, it is served now.
+      if (this.#pendingTurn && !this.#microphone) this.#acquireMicrophone();
     });
   }
 
   async #openMicrophone(): Promise<void> {
+    // The sender names the call this open belongs to, captured before the
+    // wait: a call closed and replaced while the device was opening keeps its
+    // own fresh sender, which is how this open knows it has gone stale.
+    const sender = this.#microphoneSender;
     let stream: MediaStream;
     try {
       stream = await this.#requestStream();
     } catch (error) {
-      // A microphone call that cannot open its microphone is failed rather
-      // than left looking able to listen, and `FAILED` offers "Start voice"
-      // again.
-      this.#fail(errorMessage(error));
+      // A refusal belongs to the call whose press asked for the device. If
+      // that call is gone — closed, or replaced mid-open — the refusal died
+      // with it, and the call now up must not be torn down for it. For the
+      // call still standing, it is failed rather than left looking able to
+      // listen, and `FAILED` offers "Start voice" again.
+      if (!this.#closed && this.isConnected && sender === this.#microphoneSender) {
+        this.#fail(errorMessage(error));
+      }
       return;
     }
-    // The call may have gone away — or been replaced, bringing its own device
-    // — while this one was opening. A device nobody adopts is released here,
-    // or it would hold the indicator lit with nothing left to close it.
-    const sender = this.#microphoneSender;
-    if (this.#closed || !this.isConnected || !sender || this.#microphone) {
+    // The call may have gone away — or been replaced, bringing a fresh
+    // sender — while this one was opening. A device nobody adopts is
+    // released here, or it would hold the indicator lit with nothing left to
+    // close it.
+    if (
+      this.#closed ||
+      !this.isConnected ||
+      !sender ||
+      sender !== this.#microphoneSender ||
+      this.#microphone
+    ) {
       for (const track of stream.getTracks()) track.stop();
       return;
     }
@@ -850,7 +867,11 @@ export class RealtimeVoiceSession {
       // renegotiation, the same line, the same call.
       await sender.replaceTrack(microphone);
     } catch (error) {
-      this.#fail(errorMessage(error));
+      // Guarded like the open's own refusal: a sender that rejected because
+      // its call was torn down mid-replace is not the live call's fault.
+      if (!this.#closed && this.isConnected && sender === this.#microphoneSender) {
+        this.#fail(errorMessage(error));
+      }
       return;
     }
     if (this.#closed || !this.isConnected) return;

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -229,15 +229,19 @@ export function quietIsLukesOwn(input: { status: RealtimeStatus; heardLuke: bool
  * Drives one Realtime conversation over WebRTC.
  *
  * The capture device is the developer's, not the call's: it opens when a
- * press takes a turn and closes the moment the turn ends, and nothing else —
- * not connecting, not typing, not an announcement — ever touches it. The call
- * negotiates its sending half up front as a bare transceiver, so each turn's
- * fresh track rides the same sender without renegotiating. The press is held
- * as a pending intention while the device opens, exactly as a press that
- * beats the call's handshake is. What this buys is that the microphone
- * indicator and the capture are user-driven to the second — and that other
- * audio, Bluetooth codecs included, is never degraded by a device being held
- * while nobody is talking.
+ * press takes a turn and closes when the exchange that press started settles,
+ * and nothing else — not connecting, not typing, not an announcement — ever
+ * touches it. The call negotiates its sending half up front as a bare
+ * transceiver, so each turn's fresh track rides the same sender without
+ * renegotiating. The press is held as a pending intention while the device
+ * opens, exactly as a press that beats the call's handshake is. The close
+ * waits for the settle rather than the key coming up because closing a
+ * capture device is itself audible on shared hardware — a Bluetooth headset
+ * renegotiates its codec — and the key comes up exactly as Luke starts to
+ * answer; the track is disabled at that moment, and the device follows in
+ * the quiet after the reply. What this buys is that the microphone and its
+ * indicator are user-driven — one exchange, opened by one press — and that
+ * other audio is never degraded by a device held while nobody is talking.
  */
 export class RealtimeVoiceSession {
   readonly #options: RealtimeVoiceSessionOptions;
@@ -934,18 +938,19 @@ export class RealtimeVoiceSession {
     this.#microphone.enabled = false;
     if (!commit) {
       this.#send(clearInputAudioEvents());
-      // The turn is over, so the device is too: what was pressed for ends
-      // with the press.
-      this.#releaseMicrophone();
+      // Settling to READY is what releases the device: nothing is coming
+      // that its closing could talk over.
       this.#setStatus(REALTIME_STATUS.READY);
       return;
     }
     // A turn a tool may run in: the developer opened it and spoke into it, so
-    // a tool call it emits is the developer's own ask.
+    // a tool call it emits is the developer's own ask. The device is NOT
+    // released here, deliberately: closing a capture device is itself audible
+    // on shared hardware — a Bluetooth headset renegotiates its codec and
+    // playback drops out for a beat — and this is the very moment Luke starts
+    // to answer. The track is disabled, so nothing is sent; the device itself
+    // is let go when the exchange settles, in the quiet after the reply.
     this.#startResponse(pushToTalkCommitEvents(), true);
-    // Released after the commit is on its way. Everything spoken has already
-    // streamed live during the turn; the device has nothing left to add.
-    this.#releaseMicrophone();
   }
 
   /**
@@ -1847,6 +1852,13 @@ export class RealtimeVoiceSession {
     if (this.#status === status) return;
     this.#status = status;
     this.#restIdleTimer(status);
+    // The exchange settling is what closes the device the press opened — not
+    // the commit itself, because closing a capture device is audible on
+    // shared hardware (a Bluetooth headset renegotiates its codec), and at
+    // the commit Luke is just starting to answer. Here the reply is over and
+    // the blip lands in the quiet. A press already waiting keeps the device:
+    // its turn is about to reuse it.
+    if (status === REALTIME_STATUS.READY && !this.#pendingTurn) this.#releaseMicrophone();
     this.#options.onStatus(status);
   }
 

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -133,6 +133,8 @@ export interface MicrophoneControl {
   status: MicrophoneStatus;
   /** Whether there is anything to talk to, which is the microphone's only use. */
   voiceAvailable: boolean;
+  /** Which device a press would open right now, and why, in one sentence. */
+  listensThrough: string;
   /** Asks the system for access. Using the microphone is the talk key's job. */
   onRequest: () => void;
   /** Opens the one place the system's own grant can be changed. */
@@ -167,6 +169,8 @@ export interface PreferenceWrites {
   onVoiceCaptionsChange: (enabled: boolean) => Promise<string | undefined>;
   /** Turns the quieting of Music and Spotify during a spoken exchange on or off. */
   onDuckOtherMediaChange: (enabled: boolean) => Promise<string | undefined>;
+  /** Turns the Mac-microphone-over-Bluetooth-headset preference on or off. */
+  onPreferBuiltInMicrophoneChange: (enabled: boolean) => Promise<string | undefined>;
   /**
    * Turns the holding of announcements during calendar meetings on or off.
    * The store answers with why when it refuses, and the row is where that
@@ -782,7 +786,8 @@ function voiceSettingsChanged(settings: AppSettings): boolean {
     settings.voice !== REALTIME_DEFAULTS.VOICE ||
     settings.voiceSpeed !== REALTIME_DEFAULTS.SPEED ||
     settings.voiceCaptions !== APP_SETTING_DEFAULTS.voiceCaptions ||
-    settings.duckOtherMedia !== APP_SETTING_DEFAULTS.duckOtherMedia
+    settings.duckOtherMedia !== APP_SETTING_DEFAULTS.duckOtherMedia ||
+    settings.preferBuiltInMicrophone !== APP_SETTING_DEFAULTS.preferBuiltInMicrophone
   );
 }
 
@@ -1822,6 +1827,20 @@ function VoiceControlsSection({
         changed={settings.duckOtherMedia !== APP_SETTING_DEFAULTS.duckOtherMedia}
         checked={settings.duckOtherMedia}
         onChange={preferences.onDuckOtherMediaChange}
+      />
+      <SwitchRow
+        label="Prefer the Mac's microphone"
+        ariaLabel="Listen through the Mac's own microphone instead of a Bluetooth headset's"
+        errand={APP_SETTING_ID.PREFER_BUILT_IN_MICROPHONE}
+        detail={
+          /* The why is the headset's music codec: capturing from its own
+             microphone turns everything it plays phone-grade. The Permissions
+             section above says which device would actually open right now. */
+          "With a Bluetooth headset connected, Luke listens through the Mac so the headset keeps its music quality."
+        }
+        changed={settings.preferBuiltInMicrophone !== APP_SETTING_DEFAULTS.preferBuiltInMicrophone}
+        checked={settings.preferBuiltInMicrophone}
+        onChange={preferences.onPreferBuiltInMicrophoneChange}
       />
     </section>
   );

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -133,8 +133,11 @@ export interface MicrophoneControl {
   status: MicrophoneStatus;
   /** Whether there is anything to talk to, which is the microphone's only use. */
   voiceAvailable: boolean;
-  /** Which device a press would open right now, and why, in one sentence. */
-  listensThrough: string;
+  /**
+   * One added clause for the row's small text while a Bluetooth headset is
+   * the system input — the only moment the routing is worth a word.
+   */
+  listensThrough?: string;
   /** Asks the system for access. Using the microphone is the talk key's job. */
   onRequest: () => void;
   /** Opens the one place the system's own grant can be changed. */
@@ -1834,9 +1837,9 @@ function VoiceControlsSection({
         errand={APP_SETTING_ID.PREFER_BUILT_IN_MICROPHONE}
         detail={
           /* The why is the headset's music codec: capturing from its own
-             microphone turns everything it plays phone-grade. The Permissions
-             section above says which device would actually open right now. */
-          "With a Bluetooth headset connected, Luke listens through the Mac so the headset keeps its music quality."
+             microphone turns everything it plays phone-grade. The Microphone
+             row above says so while the case is live. */
+          "Keeps Bluetooth headphones on their full music quality while you talk."
         }
         changed={settings.preferBuiltInMicrophone !== APP_SETTING_DEFAULTS.preferBuiltInMicrophone}
         checked={settings.preferBuiltInMicrophone}

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -133,11 +133,6 @@ export interface MicrophoneControl {
   status: MicrophoneStatus;
   /** Whether there is anything to talk to, which is the microphone's only use. */
   voiceAvailable: boolean;
-  /**
-   * One added clause for the row's small text while a Bluetooth headset is
-   * the system input — the only moment the routing is worth a word.
-   */
-  listensThrough?: string;
   /** Asks the system for access. Using the microphone is the talk key's job. */
   onRequest: () => void;
   /** Opens the one place the system's own grant can be changed. */

--- a/apps/desktop/src/renderer/settings-views.ts
+++ b/apps/desktop/src/renderer/settings-views.ts
@@ -77,6 +77,7 @@ export const SETTING_PAGE: Record<AppSettingId, SettingsSubview> = {
   [APP_SETTING_ID.VOICE_SPEED]: SETTINGS_VIEW.VOICE,
   [APP_SETTING_ID.VOICE_CAPTIONS]: SETTINGS_VIEW.VOICE,
   [APP_SETTING_ID.DUCK_OTHER_MEDIA]: SETTINGS_VIEW.VOICE,
+  [APP_SETTING_ID.PREFER_BUILT_IN_MICROPHONE]: SETTINGS_VIEW.VOICE,
   // Beside the calendar row whose connection gives it meaning, not with the
   // voice switches: the quiet is a fact about the calendar integration.
   [APP_SETTING_ID.QUIET_DURING_MEETINGS]: SETTINGS_VIEW.CONNECTIONS,

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -635,9 +635,9 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   }, []);
 
   /**
-   * Asks the system for access and nothing else. Opening a call here would hold
-   * the capture device and light the microphone indicator without anyone having
-   * pressed the talk key, which is not what the row offers.
+   * Asks the system for access and nothing else. The capture device itself is
+   * the talk key's own act: it opens with a press and closes with the turn,
+   * and this row must not be a second way to it.
    */
   const requestMicrophoneAccess = useCallback(async () => {
     setMicrophoneStatus(await window.sidecar.requestMicrophone());
@@ -649,8 +649,8 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
    * the panel ever being visited.
    *
    * The talk key going down. Every press goes to the session, including the one
-   * that has no call to press against yet: the microphone opens with the call,
-   * so a press before then is remembered and applied when it comes up.
+   * that has no call to press against yet: the microphone opens for the press,
+   * so one that beats the call is remembered and applied when it comes up.
    */
   const beginTalk = useCallback(async () => {
     talkPressedAt.current = performance.now();

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -286,6 +286,12 @@ export function evaluatorSummaries(speech: readonly AttentionSpeech[]): Attentio
 }
 
 export interface VoiceConversationOptions {
+  /**
+   * Whether a press may open the Mac's own microphone instead of a Bluetooth
+   * headset's. Off means the route is never even read: the system default is
+   * the user's exact choice.
+   */
+  preferBuiltInMicrophone: boolean;
   sessions: readonly NormalizedSession[];
   /**
    * The standing asks riding the roster they annotate, so a conversation can
@@ -480,9 +486,13 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       // The press's device, chosen by facts read natively: the Mac's own
       // microphone where a Bluetooth headset would otherwise pay for the
       // capture with its music codec, the browser's default everywhere else.
+      // The switch reads at the press, so flipping it needs no reconnect.
       requestMicrophoneStream: () =>
         openPreferredMicrophone({
-          route: () => window.sidecar.getMicrophoneRoute(),
+          route: () =>
+            optionsRef.current.preferBuiltInMicrophone
+              ? window.sidecar.getMicrophoneRoute()
+              : Promise.resolve(undefined),
           enumerate: () => navigator.mediaDevices.enumerateDevices(),
           open: (audio) => navigator.mediaDevices.getUserMedia({ audio, video: false }),
         }),

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -20,6 +20,7 @@ import { type RefObject, useCallback, useEffect, useRef, useState } from "react"
 import type { MicrophoneStatus, SessionOpenResult, VoiceHotkeyState } from "../shared/contracts";
 import { TALK_KEY_RELEASE, talkKeyRelease } from "../shared/voice-hotkey";
 import { askRefusal } from "./ask-luke";
+import { openPreferredMicrophone } from "./microphone-choice";
 import { type AppActionCarrier, RealtimeVoiceSession } from "./realtime-session";
 import { SpokenNoticeAnnouncer } from "./spoken-notices";
 import { useStateWithRef } from "./use-state-with-ref";
@@ -476,6 +477,15 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   const ensureVoiceSession = useCallback((): RealtimeVoiceSession => {
     voiceSession.current ??= new RealtimeVoiceSession({
       requestConnection: () => window.sidecar.requestRealtimeCredential(),
+      // The press's device, chosen by facts read natively: the Mac's own
+      // microphone where a Bluetooth headset would otherwise pay for the
+      // capture with its music codec, the browser's default everywhere else.
+      requestMicrophoneStream: () =>
+        openPreferredMicrophone({
+          route: () => window.sidecar.getMicrophoneRoute(),
+          enumerate: () => navigator.mediaDevices.enumerateDevices(),
+          open: (audio) => navigator.mediaDevices.getUserMedia({ audio, video: false }),
+        }),
       // The same bridge calls the rows use — the composer, the chips, and the
       // press that opens a session: a spoken ask is a third way to ask for the
       // same act, behind the same gauntlet in the main process.

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -57,6 +57,7 @@ const SETTINGS_FIELD = {
   ASK_HOTKEY: "askHotkey",
   DEFAULT_WORKSPACE_PROVIDER: "defaultWorkspaceProvider",
   DUCK_OTHER_MEDIA: "duckOtherMedia",
+  PREFER_BUILT_IN_MICROPHONE: "preferBuiltInMicrophone",
   FEEDBACK_SENDS: "feedbackSends",
   FORM_FACTOR: "formFactor",
   LEGACY_CONDUCTOR_API_KEY: "conductorApiKey",
@@ -185,6 +186,7 @@ interface PersistedSettings {
    * and a corrupt value both land on doing it.
    */
   duckOtherMedia: boolean;
+  preferBuiltInMicrophone: boolean;
   /**
    * How many feedback sends have landed from this machine, so the composer's
    * confirmation can pick which little celebration each delivery gets.
@@ -517,6 +519,10 @@ function parsePersistedSettings(source: string): PersistedSettings {
       record[SETTINGS_FIELD.DUCK_OTHER_MEDIA],
       APP_SETTING_DEFAULTS.duckOtherMedia,
     ),
+    preferBuiltInMicrophone: booleanSetting(
+      record[SETTINGS_FIELD.PREFER_BUILT_IN_MICROPHONE],
+      APP_SETTING_DEFAULTS.preferBuiltInMicrophone,
+    ),
     // A count that is not a whole non-negative number reads as none yet: the
     // worst a corrupt value can cost is replaying the first send's scene.
     ...(feedbackSends !== undefined ? { feedbackSends } : {}),
@@ -614,6 +620,7 @@ export class SettingsStore {
       ...(persisted.askHotkey ? { askHotkey: persisted.askHotkey } : {}),
       ...(persisted.stopHotkey ? { stopHotkey: persisted.stopHotkey } : {}),
       duckOtherMedia: persisted.duckOtherMedia,
+      preferBuiltInMicrophone: persisted.preferBuiltInMicrophone,
       quietDuringMeetings: persisted.quietDuringMeetings,
       showOnAllDisplays: persisted.showOnAllDisplays,
       formFactor: persisted.formFactor ?? DEFAULT_PANEL_FORM_FACTOR,
@@ -865,6 +872,13 @@ export class SettingsStore {
    * off. A plain preference like the caption's: no cipher, no invalid value,
    * so the write either lands or throws.
    */
+  async setPreferBuiltInMicrophone(enabled: boolean): Promise<SettingsUpdateResult> {
+    return this.#setField((persisted) => {
+      if (persisted.preferBuiltInMicrophone === enabled) return;
+      return { ...persisted, preferBuiltInMicrophone: enabled };
+    });
+  }
+
   async setDuckOtherMedia(enabled: boolean): Promise<SettingsUpdateResult> {
     return this.#setField((persisted) => {
       if (persisted.duckOtherMedia === enabled) return;
@@ -1299,6 +1313,7 @@ export class SettingsStore {
           delete next.voiceSpeed;
           next.voiceCaptions = APP_SETTING_DEFAULTS.voiceCaptions;
           next.duckOtherMedia = APP_SETTING_DEFAULTS.duckOtherMedia;
+          next.preferBuiltInMicrophone = APP_SETTING_DEFAULTS.preferBuiltInMicrophone;
           break;
         case SETTINGS_RESET_SCOPE.APPEARANCE:
           next.showInMenuBar = APP_SETTING_DEFAULTS.showInMenuBar;

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -479,8 +479,6 @@ export interface AppBootstrap {
    * arrives — or forever, where there is no helper to ask.
    */
   outputAudio?: OutputAudioState;
-  /** The capture route as first read, absent wherever it cannot be read. */
-  microphoneRoute?: MicrophoneRoute;
   display: DisplayDiagnostic;
   /** Where the app stands against the latest release, as last learned. */
   update: UpdateSnapshot;
@@ -877,12 +875,6 @@ export interface AppBridge {
    * unreadable, which arrives as `undefined` and must be drawn as audible.
    */
   onOutputAudioChanged(callback: (state: OutputAudioState | undefined) => void): () => void;
-  /**
-   * The capture route changing under the machine's own life — a headset
-   * connecting, a lid closing — or becoming unreadable, which arrives as
-   * `undefined` and must be drawn as the system's default microphone.
-   */
-  onMicrophoneRouteChanged(callback: (route: MicrophoneRoute | undefined) => void): () => void;
 }
 
 export const channels = {
@@ -905,7 +897,6 @@ export const channels = {
   setStopHotkey: "app:set-stop-hotkey",
   setDuckOtherMedia: "app:set-duck-other-media",
   setPreferBuiltInMicrophone: "app:set-prefer-built-in-microphone",
-  microphoneRouteChanged: "app:microphone-route-changed",
   setQuietDuringMeetings: "app:set-quiet-during-meetings",
   connectGoogleCalendar: "app:connect-google-calendar",
   cancelGoogleCalendarSignIn: "app:cancel-google-calendar-sign-in",

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -122,6 +122,7 @@ export const APP_SETTING_DEFAULTS = {
   showInMenuBar: true,
   voiceCaptions: false,
   duckOtherMedia: true,
+  preferBuiltInMicrophone: true,
   quietDuringMeetings: true,
   showOnAllDisplays: false,
 } as const satisfies Partial<Record<keyof AppSettings, boolean>>;
@@ -267,6 +268,15 @@ export interface AppSettings {
    * the duck is left where the hand put it.
    */
   duckOtherMedia: boolean;
+  /**
+   * Whether a press listens through the Mac's own microphone when the system
+   * input is a Bluetooth headset. On by default: capturing from a headset's
+   * microphone pulls the whole headset onto its call codec, so everything it
+   * plays turns phone-grade for the exchange. Off means the system default is
+   * used exactly as chosen. A shut lid keeps the headset microphone either
+   * way, because a muffled question is worse than a degraded song.
+   */
+  preferBuiltInMicrophone: boolean;
   /**
    * Whether announcements wait out the user's meetings. While the connected
    * calendar shows a meeting on, a session's spoken notices are held and read
@@ -469,6 +479,8 @@ export interface AppBootstrap {
    * arrives — or forever, where there is no helper to ask.
    */
   outputAudio?: OutputAudioState;
+  /** The capture route as first read, absent wherever it cannot be read. */
+  microphoneRoute?: MicrophoneRoute;
   display: DisplayDiagnostic;
   /** Where the app stands against the latest release, as last learned. */
   update: UpdateSnapshot;
@@ -598,6 +610,8 @@ export interface AppBridge {
   resetSettings(scope: SettingsResetScope): Promise<SettingsUpdateResult>;
   /** Turns the quieting of Music and Spotify during a spoken exchange on or off. */
   setDuckOtherMedia(enabled: boolean): Promise<SettingsUpdateResult>;
+  /** Turns the Mac-microphone-over-Bluetooth-headset preference on or off. */
+  setPreferBuiltInMicrophone(enabled: boolean): Promise<SettingsUpdateResult>;
   /**
    * Asks GitHub for the latest release name, right now, because the row's
    * button was pressed. The answer is the same snapshot the broadcast
@@ -863,6 +877,12 @@ export interface AppBridge {
    * unreadable, which arrives as `undefined` and must be drawn as audible.
    */
   onOutputAudioChanged(callback: (state: OutputAudioState | undefined) => void): () => void;
+  /**
+   * The capture route changing under the machine's own life — a headset
+   * connecting, a lid closing — or becoming unreadable, which arrives as
+   * `undefined` and must be drawn as the system's default microphone.
+   */
+  onMicrophoneRouteChanged(callback: (route: MicrophoneRoute | undefined) => void): () => void;
 }
 
 export const channels = {
@@ -884,6 +904,8 @@ export const channels = {
   setAskHotkey: "app:set-ask-hotkey",
   setStopHotkey: "app:set-stop-hotkey",
   setDuckOtherMedia: "app:set-duck-other-media",
+  setPreferBuiltInMicrophone: "app:set-prefer-built-in-microphone",
+  microphoneRouteChanged: "app:microphone-route-changed",
   setQuietDuringMeetings: "app:set-quiet-during-meetings",
   connectGoogleCalendar: "app:connect-google-calendar",
   cancelGoogleCalendarSignIn: "app:cancel-google-calendar-sign-in",

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -328,6 +328,42 @@ export interface OutputAudioState {
   volume: number;
 }
 
+/** How the default input device reaches the Mac, as CoreAudio classifies it. */
+export const MICROPHONE_TRANSPORT = {
+  BUILT_IN: "built-in",
+  BLUETOOTH: "bluetooth",
+  OTHER: "other",
+  /** No input device at all. */
+  NONE: "none",
+} as const;
+
+export type MicrophoneTransport = (typeof MICROPHONE_TRANSPORT)[keyof typeof MICROPHONE_TRANSPORT];
+
+/** The lid over the built-in microphone. A desktop keeps no lid: `unknown`. */
+export const LID_STATE = {
+  OPEN: "open",
+  SHUT: "shut",
+  UNKNOWN: "unknown",
+} as const;
+
+export type LidState = (typeof LID_STATE)[keyof typeof LID_STATE];
+
+/**
+ * Where the developer's voice would be captured from: the default input's
+ * transport, the built-in microphone's name when the machine has one, and
+ * whether the lid over it is open. Read by a helper that reads nothing else
+ * and can write nothing. What it decides is bounded to one act — which device
+ * the renderer asks the browser to open when a press takes a turn, so a
+ * Bluetooth headset keeps its music codec while the Mac's own microphone
+ * listens, and is listened to itself when a shut lid would muffle the Mac's.
+ * Absent wherever it cannot be read, and absence means the browser's default.
+ */
+export interface MicrophoneRoute {
+  defaultTransport: MicrophoneTransport;
+  lid: LidState;
+  builtInName?: string;
+}
+
 /** A rejected update reports why without echoing the submitted value. */
 export interface SettingsUpdateResult {
   settings: AppSettings;
@@ -476,6 +512,13 @@ export interface AppBridge {
   setExpanded(expanded: boolean, focus?: boolean): Promise<WindowMode>;
   setPointerInterception(interceptsPointer: boolean): void;
   requestMicrophone(): Promise<MicrophoneStatus>;
+  /**
+   * Where the developer's voice would be captured from, as last read — and a
+   * fresh read is asked for behind the answer, so the next press sees a lid
+   * that has closed meanwhile. `undefined` wherever the route cannot be read,
+   * which the caller must take as "use the browser's default".
+   */
+  getMicrophoneRoute(): Promise<MicrophoneRoute | undefined>;
   /**
    * Opens Privacy & Security in System Settings, where the system's own grant
    * lives. Luke can ask for the microphone and stop using it; only the user can
@@ -831,6 +874,7 @@ export const channels = {
   setExpanded: "app:set-expanded",
   setPointerInterception: "app:set-pointer-interception",
   requestMicrophone: "app:request-microphone",
+  microphoneRoute: "app:microphone-route",
   openMicrophoneSettings: "app:open-microphone-settings",
   setProviderApiKey: "app:set-provider-api-key",
   setVoice: "app:set-voice",

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -613,6 +613,10 @@ test("every adjustable setting is carried to the bridge call its row uses", asyn
       calls.push(`setDuckOtherMedia:${enabled}`);
       return answered;
     },
+    setPreferBuiltInMicrophone: async (enabled: boolean) => {
+      calls.push(`setPreferBuiltInMicrophone:${enabled}`);
+      return answered;
+    },
     setQuietDuringMeetings: async (enabled: boolean) => {
       calls.push(`setQuietDuringMeetings:${enabled}`);
       return answered;
@@ -655,6 +659,7 @@ test("every adjustable setting is carried to the bridge call its row uses", asyn
   assert.deepEqual(calls.sort(), [
     "setDuckOtherMedia:true",
     "setFormFactor:notch",
+    "setPreferBuiltInMicrophone:true",
     "setQuietDuringMeetings:true",
     "setShowInDock:true",
     "setShowInMenuBar:true",

--- a/apps/desktop/tests/microphone-choice.test.ts
+++ b/apps/desktop/tests/microphone-choice.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   type EnumeratedMicrophone,
+  listeningThroughDetail,
   MICROPHONE_PROCESSING,
   microphoneConstraints,
   openPreferredMicrophone,
@@ -132,6 +133,36 @@ test("an unreadable route is the browser's default, never a gate", async () => {
 
   assert.equal(result, stream);
   assert.deepEqual(asked, [{ ...MICROPHONE_PROCESSING }]);
+});
+
+test("the listens-through line says the same thing the choice does", () => {
+  assert.equal(
+    listeningThroughDetail(BLUETOOTH_DEFAULT, true),
+    "MacBook Pro Microphone, so the Bluetooth headset keeps its full music quality.",
+  );
+  assert.equal(
+    listeningThroughDetail({ ...BLUETOOTH_DEFAULT, lid: LID_STATE.SHUT }, true),
+    "The Bluetooth headset's microphone \u2014 the Mac's own sits under a shut lid.",
+  );
+  assert.equal(
+    listeningThroughDetail(BLUETOOTH_DEFAULT, false),
+    "The Bluetooth headset's microphone, exactly as the system default is set.",
+  );
+  assert.equal(
+    listeningThroughDetail(
+      { defaultTransport: MICROPHONE_TRANSPORT.BLUETOOTH, lid: LID_STATE.OPEN },
+      true,
+    ),
+    "The Bluetooth headset's microphone \u2014 this Mac has no microphone of its own.",
+  );
+  assert.equal(listeningThroughDetail(undefined, true), "The system's default microphone.");
+  assert.equal(
+    listeningThroughDetail(
+      { ...BLUETOOTH_DEFAULT, defaultTransport: MICROPHONE_TRANSPORT.BUILT_IN },
+      true,
+    ),
+    "The system's default microphone.",
+  );
 });
 
 test("a default already on the Mac's microphone never enumerates at all", async () => {

--- a/apps/desktop/tests/microphone-choice.test.ts
+++ b/apps/desktop/tests/microphone-choice.test.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  type EnumeratedMicrophone,
+  MICROPHONE_PROCESSING,
+  microphoneConstraints,
+  openPreferredMicrophone,
+  preferredBuiltInLabel,
+} from "../src/renderer/microphone-choice";
+import { LID_STATE, MICROPHONE_TRANSPORT, type MicrophoneRoute } from "../src/shared/contracts";
+
+const BLUETOOTH_DEFAULT: MicrophoneRoute = {
+  defaultTransport: MICROPHONE_TRANSPORT.BLUETOOTH,
+  lid: LID_STATE.OPEN,
+  builtInName: "MacBook Pro Microphone",
+};
+
+const DEVICES: readonly EnumeratedMicrophone[] = [
+  { kind: "audioinput", label: "", deviceId: "default" },
+  { kind: "audiooutput", label: "MacBook Pro Speakers", deviceId: "speakers" },
+  { kind: "audioinput", label: "AirPods Pro", deviceId: "airpods" },
+  { kind: "audioinput", label: "MacBook Pro Microphone (Built-in)", deviceId: "built-in-id" },
+];
+
+test("the capture never asks for echo cancellation", () => {
+  // Half-duplex by construction means there is no echo to cancel, and the
+  // constraint is what pulls macOS's own voice processing — the thing that
+  // degrades every other app's audio — onto the capture.
+  assert.equal(MICROPHONE_PROCESSING.echoCancellation, false);
+  assert.equal(microphoneConstraints(undefined, DEVICES).echoCancellation, false);
+});
+
+test("a Bluetooth default with the lid open prefers the Mac's own microphone", () => {
+  assert.equal(preferredBuiltInLabel(BLUETOOTH_DEFAULT), "MacBook Pro Microphone");
+  assert.deepEqual(microphoneConstraints(BLUETOOTH_DEFAULT, DEVICES).deviceId, {
+    exact: "built-in-id",
+  });
+});
+
+test("a shut lid keeps the headset microphone, muffled beats degraded", () => {
+  const shut = { ...BLUETOOTH_DEFAULT, lid: LID_STATE.SHUT };
+  assert.equal(preferredBuiltInLabel(shut), undefined);
+  assert.equal(microphoneConstraints(shut, DEVICES).deviceId, undefined);
+});
+
+test("a desktop with no lid to read counts as open", () => {
+  const unknown = { ...BLUETOOTH_DEFAULT, lid: LID_STATE.UNKNOWN };
+  assert.equal(preferredBuiltInLabel(unknown), "MacBook Pro Microphone");
+});
+
+test("a non-Bluetooth default is left exactly where the user put it", () => {
+  for (const defaultTransport of [
+    MICROPHONE_TRANSPORT.BUILT_IN,
+    MICROPHONE_TRANSPORT.OTHER,
+    MICROPHONE_TRANSPORT.NONE,
+  ] as const) {
+    assert.equal(preferredBuiltInLabel({ ...BLUETOOTH_DEFAULT, defaultTransport }), undefined);
+  }
+});
+
+test("no route, no built-in, or no matching device all mean the default", () => {
+  assert.equal(preferredBuiltInLabel(undefined), undefined);
+  assert.equal(
+    preferredBuiltInLabel({
+      defaultTransport: MICROPHONE_TRANSPORT.BLUETOOTH,
+      lid: LID_STATE.OPEN,
+    }),
+    undefined,
+  );
+  // The browser's list does not offer the named device: nothing to pin.
+  assert.equal(microphoneConstraints(BLUETOOTH_DEFAULT, []).deviceId, undefined);
+  // Labels hidden (no permission yet) cannot be matched either.
+  assert.equal(
+    microphoneConstraints(BLUETOOTH_DEFAULT, [
+      { kind: "audioinput", label: "", deviceId: "mystery" },
+    ]).deviceId,
+    undefined,
+  );
+});
+
+test("the opener pins the preferred device and reports what it asked for", async () => {
+  const asked: MediaTrackConstraints[] = [];
+  const stream = {} as MediaStream;
+
+  const result = await openPreferredMicrophone({
+    route: async () => BLUETOOTH_DEFAULT,
+    enumerate: async () => DEVICES,
+    open: async (audio) => {
+      asked.push(audio);
+      return stream;
+    },
+  });
+
+  assert.equal(result, stream);
+  assert.equal(asked.length, 1);
+  assert.deepEqual(asked[0]?.deviceId, { exact: "built-in-id" });
+});
+
+test("a pinned device that vanished falls back to the default, not a refusal", async () => {
+  const asked: MediaTrackConstraints[] = [];
+  const stream = {} as MediaStream;
+
+  const result = await openPreferredMicrophone({
+    route: async () => BLUETOOTH_DEFAULT,
+    enumerate: async () => DEVICES,
+    open: async (audio) => {
+      asked.push(audio);
+      if (audio.deviceId !== undefined) throw new Error("device vanished");
+      return stream;
+    },
+  });
+
+  assert.equal(result, stream);
+  assert.equal(asked.length, 2);
+  assert.equal(asked[1]?.deviceId, undefined);
+});
+
+test("an unreadable route is the browser's default, never a gate", async () => {
+  const asked: MediaTrackConstraints[] = [];
+  const stream = {} as MediaStream;
+
+  const result = await openPreferredMicrophone({
+    route: async () => {
+      throw new Error("no bridge in this harness");
+    },
+    enumerate: async () => DEVICES,
+    open: async (audio) => {
+      asked.push(audio);
+      return stream;
+    },
+  });
+
+  assert.equal(result, stream);
+  assert.deepEqual(asked, [{ ...MICROPHONE_PROCESSING }]);
+});
+
+test("a default already on the Mac's microphone never enumerates at all", async () => {
+  let enumerated = 0;
+  await openPreferredMicrophone({
+    route: async () => ({
+      defaultTransport: MICROPHONE_TRANSPORT.BUILT_IN,
+      lid: LID_STATE.OPEN,
+      builtInName: "MacBook Pro Microphone",
+    }),
+    enumerate: async () => {
+      enumerated += 1;
+      return DEVICES;
+    },
+    open: async () => ({}) as MediaStream,
+  });
+
+  assert.equal(enumerated, 0);
+});

--- a/apps/desktop/tests/microphone-choice.test.ts
+++ b/apps/desktop/tests/microphone-choice.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   type EnumeratedMicrophone,
-  listeningThroughDetail,
   MICROPHONE_PROCESSING,
   microphoneConstraints,
   openPreferredMicrophone,
@@ -133,35 +132,6 @@ test("an unreadable route is the browser's default, never a gate", async () => {
 
   assert.equal(result, stream);
   assert.deepEqual(asked, [{ ...MICROPHONE_PROCESSING }]);
-});
-
-test("the listens-through clause speaks only while the routing is in play", () => {
-  assert.equal(
-    listeningThroughDetail(BLUETOOTH_DEFAULT, true),
-    "With a Bluetooth headset connected, Luke listens through the Mac's own microphone.",
-  );
-  assert.equal(
-    listeningThroughDetail({ ...BLUETOOTH_DEFAULT, lid: LID_STATE.SHUT }, true),
-    "With the lid shut, Luke listens through the Bluetooth headset.",
-  );
-  // Everywhere else the row reads exactly as it always did: the switch off,
-  // no headset in play, no Mac microphone to stand in, or no route at all.
-  assert.equal(listeningThroughDetail(BLUETOOTH_DEFAULT, false), undefined);
-  assert.equal(
-    listeningThroughDetail(
-      { ...BLUETOOTH_DEFAULT, defaultTransport: MICROPHONE_TRANSPORT.BUILT_IN },
-      true,
-    ),
-    undefined,
-  );
-  assert.equal(
-    listeningThroughDetail(
-      { defaultTransport: MICROPHONE_TRANSPORT.BLUETOOTH, lid: LID_STATE.OPEN },
-      true,
-    ),
-    undefined,
-  );
-  assert.equal(listeningThroughDetail(undefined, true), undefined);
 });
 
 test("a default already on the Mac's microphone never enumerates at all", async () => {

--- a/apps/desktop/tests/microphone-choice.test.ts
+++ b/apps/desktop/tests/microphone-choice.test.ts
@@ -135,34 +135,33 @@ test("an unreadable route is the browser's default, never a gate", async () => {
   assert.deepEqual(asked, [{ ...MICROPHONE_PROCESSING }]);
 });
 
-test("the listens-through line says the same thing the choice does", () => {
+test("the listens-through clause speaks only while the routing is in play", () => {
   assert.equal(
     listeningThroughDetail(BLUETOOTH_DEFAULT, true),
-    "MacBook Pro Microphone, so the Bluetooth headset keeps its full music quality.",
+    "With a Bluetooth headset connected, Luke listens through the Mac's own microphone.",
   );
   assert.equal(
     listeningThroughDetail({ ...BLUETOOTH_DEFAULT, lid: LID_STATE.SHUT }, true),
-    "The Bluetooth headset's microphone \u2014 the Mac's own sits under a shut lid.",
+    "With the lid shut, Luke listens through the Bluetooth headset.",
   );
+  // Everywhere else the row reads exactly as it always did: the switch off,
+  // no headset in play, no Mac microphone to stand in, or no route at all.
+  assert.equal(listeningThroughDetail(BLUETOOTH_DEFAULT, false), undefined);
   assert.equal(
-    listeningThroughDetail(BLUETOOTH_DEFAULT, false),
-    "The Bluetooth headset's microphone, exactly as the system default is set.",
+    listeningThroughDetail(
+      { ...BLUETOOTH_DEFAULT, defaultTransport: MICROPHONE_TRANSPORT.BUILT_IN },
+      true,
+    ),
+    undefined,
   );
   assert.equal(
     listeningThroughDetail(
       { defaultTransport: MICROPHONE_TRANSPORT.BLUETOOTH, lid: LID_STATE.OPEN },
       true,
     ),
-    "The Bluetooth headset's microphone \u2014 this Mac has no microphone of its own.",
+    undefined,
   );
-  assert.equal(listeningThroughDetail(undefined, true), "The system's default microphone.");
-  assert.equal(
-    listeningThroughDetail(
-      { ...BLUETOOTH_DEFAULT, defaultTransport: MICROPHONE_TRANSPORT.BUILT_IN },
-      true,
-    ),
-    "The system's default microphone.",
-  );
+  assert.equal(listeningThroughDetail(undefined, true), undefined);
 });
 
 test("a default already on the Mac's microphone never enumerates at all", async () => {

--- a/apps/desktop/tests/microphone-route.test.ts
+++ b/apps/desktop/tests/microphone-route.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  MICROPHONE_ROUTE_PROBE,
+  type MicrophoneRouteProcess,
+  MicrophoneRouteWatcher,
+  parseMicrophoneRouteLine,
+} from "../src/microphone-route";
+import { LID_STATE, MICROPHONE_TRANSPORT, type MicrophoneRoute } from "../src/shared/contracts";
+
+test("a route line parses into its three facts", () => {
+  assert.deepEqual(
+    parseMicrophoneRouteLine("input transport=bluetooth lid=open builtin=MacBook Pro Microphone"),
+    {
+      defaultTransport: MICROPHONE_TRANSPORT.BLUETOOTH,
+      lid: LID_STATE.OPEN,
+      builtInName: "MacBook Pro Microphone",
+    },
+  );
+});
+
+test("the built-in name is the line's tail, whatever it contains", () => {
+  const route = parseMicrophoneRouteLine(
+    "input transport=built-in lid=shut builtin=Microphone (Built-in) = odd name",
+  );
+  assert.equal(route?.builtInName, "Microphone (Built-in) = odd name");
+});
+
+test("a machine with no built-in microphone reports none", () => {
+  assert.deepEqual(parseMicrophoneRouteLine("input transport=other lid=unknown"), {
+    defaultTransport: MICROPHONE_TRANSPORT.OTHER,
+    lid: LID_STATE.UNKNOWN,
+  });
+});
+
+test("a line outside the vocabulary is dropped rather than guessed at", () => {
+  assert.equal(parseMicrophoneRouteLine("input transport=telepathy lid=open"), undefined);
+  assert.equal(parseMicrophoneRouteLine("input transport=bluetooth lid=ajar"), undefined);
+  assert.equal(parseMicrophoneRouteLine("output muted=0 volume=1.00"), undefined);
+  assert.equal(parseMicrophoneRouteLine(""), undefined);
+});
+
+interface Harness {
+  watcher: MicrophoneRouteWatcher;
+  routes: MicrophoneRoute[];
+  unavailable: () => number;
+  written: string[];
+  emit: (chunk: string) => void;
+  die: () => void;
+}
+
+function harness(): Harness {
+  const routes: MicrophoneRoute[] = [];
+  const written: string[] = [];
+  let unavailable = 0;
+  let listener: ((chunk: string) => void) | undefined;
+  const exits: (() => void)[] = [];
+
+  const child: MicrophoneRouteProcess = {
+    stdin: {
+      write: (chunk) => {
+        written.push(chunk);
+      },
+    },
+    stdout: {
+      setEncoding: () => undefined,
+      on: (_event, dataListener) => {
+        listener = dataListener;
+      },
+    },
+    on: (event, exitListener) => {
+      if (event === "exit") exits.push(exitListener);
+    },
+    removeAllListeners: () => {
+      exits.length = 0;
+    },
+    kill: () => undefined,
+  };
+
+  const watcher = new MicrophoneRouteWatcher({
+    spawnHelper: () => child,
+    onRoute: (route) => {
+      routes.push(route);
+    },
+    onUnavailable: () => {
+      unavailable += 1;
+    },
+  });
+
+  return {
+    watcher,
+    routes,
+    unavailable: () => unavailable,
+    written,
+    emit: (chunk) => listener?.(chunk),
+    die: () => {
+      for (const exit of [...exits]) exit();
+    },
+  };
+}
+
+test("routes arrive as lines, split however the pipe delivered them", () => {
+  const context = harness();
+  assert.equal(context.watcher.start(), true);
+
+  context.emit("input transport=bluetooth ");
+  context.emit("lid=open builtin=MacBook Pro Microphone\ninput transport=built-in lid=open\n");
+
+  assert.equal(context.routes.length, 2);
+  assert.equal(context.routes[0]?.builtInName, "MacBook Pro Microphone");
+  assert.equal(context.routes[1]?.defaultTransport, MICROPHONE_TRANSPORT.BUILT_IN);
+});
+
+test("a probe is one word to the helper", () => {
+  const context = harness();
+  context.watcher.start();
+
+  context.watcher.probe();
+
+  assert.deepEqual(context.written, [`${MICROPHONE_ROUTE_PROBE}\n`]);
+});
+
+test("a helper that dies withdraws the route rather than freezing it", () => {
+  const context = harness();
+  context.watcher.start();
+  context.emit("input transport=bluetooth lid=open\n");
+
+  context.die();
+
+  assert.equal(context.unavailable(), 1);
+  // A probe after the death asks nobody and says nothing.
+  context.watcher.probe();
+  assert.deepEqual(context.written, []);
+});
+
+test("a watcher that cannot spawn says so once", () => {
+  let unavailable = 0;
+  const watcher = new MicrophoneRouteWatcher({
+    spawnHelper: () => undefined,
+    onRoute: () => undefined,
+    onUnavailable: () => {
+      unavailable += 1;
+    },
+  });
+
+  assert.equal(watcher.start(), false);
+  assert.equal(unavailable, 1);
+});

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -304,6 +304,12 @@ async function holdTurn(context: Harness): Promise<void> {
   await deviceArrives();
 }
 
+/** Ends the reply the server was producing, settling the exchange to READY. */
+function settleReply(context: Harness): void {
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_DONE });
+  context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED });
+}
+
 /** The words one context item carries, or nothing when the event is not one. */
 function itemText(event: Record<string, unknown> | undefined): string {
   const item = event?.item as { content?: { text?: string }[] } | undefined;
@@ -404,8 +410,14 @@ test("push-to-talk opens the microphone only while held, then asks for a reply",
   context.session.stopListening(true);
   assert.equal(context.microphoneEnabled(), false);
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
-  // The turn's end is the device's end: the tracks stop and the sender is
-  // emptied, so nothing is held while Luke answers.
+  // The device is not closed at the commit — closing it is audible on shared
+  // hardware, and Luke is just starting to answer — but the track is off, so
+  // nothing is sent while he speaks.
+  assert.equal(context.microphoneStopped(), false);
+
+  settleReply(context);
+
+  // The exchange settling is what closes it, in the quiet after the reply.
   assert.equal(context.microphoneStopped(), true);
   assert.equal(context.replacedTracks().at(-1), null);
   assert.deepEqual(
@@ -3401,15 +3413,16 @@ test("Luke's own call is not on the developer's idle clock", async () => {
   assert.equal(context.idleArmed(), false);
 });
 
-test("the device closes with the turn and the conversation stays", async () => {
+test("the device closes with the exchange and the conversation stays", async () => {
   const context = harness();
   await context.session.connect();
   await holdTurn(context);
   assert.equal(context.microphoneEnabled(), true);
 
   context.session.stopListening(true);
+  settleReply(context);
 
-  // The turn's end is the device's end — tracks stopped, the sender emptied —
+  // The settle is the device's end — tracks stopped, the sender emptied —
   // while the call, and the conversation on it, stay warm and stay the
   // developer's: the next press reopens the device, never replaces the call.
   assert.equal(context.microphoneStopped(), true);
@@ -3418,11 +3431,12 @@ test("the device closes with the turn and the conversation stays", async () => {
   assert.equal(context.session.microphoneCall, true);
 });
 
-test("each turn opens its own device on the same call", async () => {
+test("each exchange opens its own device on the same call", async () => {
   const context = harness();
   await context.session.connect();
   await holdTurn(context);
   context.session.endTurn(true);
+  settleReply(context);
   const before = context.calls.length;
 
   context.session.beginTurn();
@@ -3483,6 +3497,7 @@ test("a device that vanishes mid-conversation fails the call at the press", asyn
   const context = harness();
   await context.session.connect();
   await armDeveloperTurn(context);
+  settleReply(context);
   context.failMicrophone();
 
   context.session.beginTurn();

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -23,7 +23,6 @@ import {
 import {
   type AppActionCarrier,
   type IssueActionCarrier,
-  MICROPHONE_RELEASE_TIMEOUT_MS,
   quietIsLukesOwn,
   REMOTE_QUIET_MS,
   RealtimeVoiceSession,
@@ -60,17 +59,13 @@ interface Harness {
   /** The transceivers declared instead of tracks, as a speak-only call does. */
   transceivers: { kind: string; direction?: string }[];
   /**
-   * The idle retirement and the device release, held rather than run: every
-   * test connects and few close, so real timers would keep the run alive for
-   * minutes apiece. The two clocks are told apart by their delays, and firing
-   * one retires it the way the session's own re-arm would.
+   * The idle retirement, held rather than run: every test connects and few
+   * close, so a real ten-minute timer would keep the run alive for ten
+   * minutes apiece. Firing one retires it the way the session's re-arm would.
    */
   idleArmed: () => boolean;
   idleDelayMs: () => number | undefined;
   fireIdle: () => void;
-  releaseArmed: () => boolean;
-  releaseDelayMs: () => number | undefined;
-  fireRelease: () => void;
   /** Every track handed to the sender, `null` standing for the device let go. */
   replacedTracks: () => (object | null)[];
   /** Makes the next device request refuse, as a vanished microphone would. */
@@ -114,16 +109,12 @@ function harness(
     carryAppAction?: AppActionCarrier;
     carryIssueAction?: IssueActionCarrier;
     idleTimeoutMs?: number;
-    microphoneReleaseTimeoutMs?: number;
   } = {},
 ): Harness {
   const timers: HeldTimer[] = [];
-  const idleTimeoutMs = options.idleTimeoutMs ?? VOICE_IDLE_TIMEOUT_MS;
-  const releaseTimeoutMs = options.microphoneReleaseTimeoutMs ?? MICROPHONE_RELEASE_TIMEOUT_MS;
-  const armedTimer = (delayMs: number): HeldTimer | undefined =>
-    timers.findLast((timer) => !timer.cancelled && timer.delayMs === delayMs);
-  const fireTimer = (delayMs: number): void => {
-    const timer = armedTimer(delayMs);
+  const armedTimer = (): HeldTimer | undefined => timers.findLast((timer) => !timer.cancelled);
+  const fireTimer = (): void => {
+    const timer = armedTimer();
     if (!timer) return;
     // A fired timer is spent: only a re-arm by the session makes a new one.
     timer.cancelled = true;
@@ -177,6 +168,8 @@ function harness(
     addTrack: () => sender,
     addTransceiver: (kind: string, init?: { direction?: string }) => {
       transceivers.push({ kind, ...(init?.direction ? { direction: init.direction } : {}) });
+      // The sending half the session keeps: each turn's track rides it.
+      return { sender };
     },
     createDataChannel: () => {
       // A fresh channel per connect, so a call opened after another was torn
@@ -225,9 +218,6 @@ function harness(
       : { connectTimeoutMs: options.connectTimeoutMs }),
     ...(options.now ? { now: options.now } : {}),
     ...(options.idleTimeoutMs === undefined ? {} : { idleTimeoutMs: options.idleTimeoutMs }),
-    ...(options.microphoneReleaseTimeoutMs === undefined
-      ? {}
-      : { microphoneReleaseTimeoutMs: options.microphoneReleaseTimeoutMs }),
     schedule: (callback, delayMs) => {
       const timer: HeldTimer = { callback, delayMs, cancelled: false };
       timers.push(timer);
@@ -285,15 +275,10 @@ function harness(
     },
     requests,
     calls,
-    idleArmed: () => armedTimer(idleTimeoutMs) !== undefined,
-    idleDelayMs: () => armedTimer(idleTimeoutMs)?.delayMs,
+    idleArmed: () => armedTimer() !== undefined,
+    idleDelayMs: () => armedTimer()?.delayMs,
     fireIdle: () => {
-      fireTimer(idleTimeoutMs);
-    },
-    releaseArmed: () => armedTimer(releaseTimeoutMs) !== undefined,
-    releaseDelayMs: () => armedTimer(releaseTimeoutMs)?.delayMs,
-    fireRelease: () => {
-      fireTimer(releaseTimeoutMs);
+      fireTimer();
     },
     replacedTracks: () => replacedTracks,
     failMicrophone: () => {
@@ -304,6 +289,20 @@ function harness(
 }
 
 const CONVERSATION_ITEM_DELETE = REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_DELETE;
+
+/** Lets the device a press asked for arrive: one macrotask drains the open. */
+function deviceArrives(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * Presses the talk key and waits for the device it opens. The microphone is
+ * the developer's, not the call's, so every turn starts with this ask.
+ */
+async function holdTurn(context: Harness): Promise<void> {
+  context.session.beginTurn();
+  await deviceArrives();
+}
 
 /** The words one context item carries, or nothing when the event is not one. */
 function itemText(event: Record<string, unknown> | undefined): string {
@@ -332,8 +331,10 @@ test("connecting opens the call and leaves the microphone closed", async () => {
 
   assert.equal(await context.session.connect(), true);
   assert.equal(context.session.status, REALTIME_STATUS.READY);
-  // Connected is not the same as listening. Nothing is sent until asked.
+  // Connected is not the same as listening: the device is the developer's,
+  // not the call's, so connecting asks for no microphone at all.
   assert.equal(context.microphoneEnabled(), false);
+  assert.ok(!context.calls.includes("microphone-requested"));
 
   const request = context.requests[0];
   assert.equal(request?.url, CONNECTION.callsUrl);
@@ -349,23 +350,22 @@ test("no credential leaves the voice experience explicitly unavailable", async (
   assert.equal(await context.session.connect(), false);
   assert.equal(context.session.status, REALTIME_STATUS.UNAVAILABLE);
   assert.deepEqual(context.sent, []);
-  // The device was opened alongside the mint that came back empty, and nothing
-  // else is left to let go of it.
-  assert.equal(context.microphoneStopped(), true);
+  // No device was opened for a call that never came: there is nothing held
+  // and nothing to let go of.
+  assert.ok(!context.calls.includes("microphone-requested"));
 });
 
-test("the credential and the device are asked for together, not in turn", async () => {
-  // The mint is a network round trip and the device open is a hardware one.
-  // The press that started the connect is waiting on both, so the device must
-  // not queue behind the mint.
+test("the press asks for the device; the connect asks only for the credential", async () => {
+  // The microphone is user-driven: opening a call — for a typed ask, say —
+  // must not touch the device. Only the press that takes a turn opens it.
   const context = harness({ connectionDelayMs: 20 });
 
   assert.equal(await context.session.connect(), true);
-  assert.deepEqual(context.calls, [
-    "credential-requested",
-    "microphone-requested",
-    "credential-resolved",
-  ]);
+  assert.deepEqual(context.calls, ["credential-requested", "credential-resolved"]);
+
+  await holdTurn(context);
+  assert.deepEqual(context.calls.at(-1), "microphone-requested");
+  assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
 });
 
 test("a refused call fails without leaking the ephemeral secret", async () => {
@@ -378,11 +378,18 @@ test("a refused call fails without leaking the ephemeral secret", async () => {
   assert.ok(!reported.includes(CONNECTION.value));
 });
 
-test("a denied microphone fails the connection rather than half-opening it", async () => {
+test("a denied microphone fails the call at the press, not before", async () => {
   const context = harness({ microphoneError: new Error("Permission denied") });
 
-  assert.equal(await context.session.connect(), false);
+  // The call itself opens fine: no device is asked for until a turn is.
+  assert.equal(await context.session.connect(), true);
+
+  await holdTurn(context);
+
+  // The press found the device refused, and a call that cannot listen is
+  // failed rather than left looking able to.
   assert.equal(context.session.status, REALTIME_STATUS.FAILED);
+  assert.equal(context.session.turnPending, false);
   assert.ok(context.errors.includes("Permission denied"));
 });
 
@@ -390,13 +397,17 @@ test("push-to-talk opens the microphone only while held, then asks for a reply",
   const context = harness();
   await context.session.connect();
 
-  context.session.startListening();
+  await holdTurn(context);
   assert.equal(context.microphoneEnabled(), true);
   assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
 
   context.session.stopListening(true);
   assert.equal(context.microphoneEnabled(), false);
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+  // The turn's end is the device's end: the tracks stop and the sender is
+  // emptied, so nothing is held while Luke answers.
+  assert.equal(context.microphoneStopped(), true);
+  assert.equal(context.replacedTracks().at(-1), null);
   assert.deepEqual(
     context.sent.map((event) => event.type),
     [
@@ -411,7 +422,7 @@ test("an abandoned turn clears the buffer instead of answering it", async () => 
   const context = harness();
   await context.session.connect();
 
-  context.session.startListening();
+  await holdTurn(context);
   context.session.stopListening(false);
 
   assert.equal(context.microphoneEnabled(), false);
@@ -463,7 +474,7 @@ test("a held turn lasts exactly as long as the key is down", async () => {
   const context = harness();
   await context.session.connect();
 
-  context.session.beginTurn();
+  await holdTurn(context);
   assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
   assert.equal(context.microphoneEnabled(), true);
 
@@ -480,9 +491,9 @@ test("a turn let go of before the call opened is dropped, not sent", async () =>
 
   context.session.beginTurn();
   const opening = context.session.connect();
-  // The microphone opens with the call, so a key held and released during the
-  // handshake was held over nothing. Committing it would ask the server to
-  // answer an empty buffer, which comes back as an error rather than a reply.
+  // The microphone opens for the press's turn, and neither the call nor the
+  // device was up yet: the key was held over nothing. Committing it would ask
+  // the server to answer an empty buffer, which comes back as an error.
   context.session.endTurn(true);
   await opening;
 
@@ -498,11 +509,11 @@ test("holding the key through a reply takes the turn back", async () => {
   const context = harness();
   await context.session.connect();
   context.deliverRemoteTrack();
-  context.session.beginTurn();
+  await holdTurn(context);
   context.session.endTurn(true);
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
 
-  context.session.beginTurn();
+  await holdTurn(context);
 
   assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
   assert.equal(context.lukeAudible(), false);
@@ -515,6 +526,7 @@ test("a press during the handshake opens the turn it was asking for", async () =
   // it starts. Nothing is captured until the microphone opens at the far end.
   context.session.toggleTurn();
   await context.session.connect();
+  await deviceArrives();
 
   assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
   assert.equal(context.microphoneEnabled(), true);
@@ -558,6 +570,7 @@ test("a reply that runs out before the model says so still ends", async () => {
   const context = harness();
   await context.session.connect();
   context.session.toggleTurn();
+  await deviceArrives();
   context.session.toggleTurn();
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
 
@@ -574,7 +587,7 @@ test("a reply that runs out before the model says so still ends", async () => {
 test("the reply ends when the server says the audio ran out", async () => {
   const context = harness();
   await context.session.connect();
-  context.session.beginTurn();
+  await holdTurn(context);
   context.session.endTurn(true);
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
 
@@ -589,7 +602,7 @@ test("the reply ends when the server says the audio ran out", async () => {
 test("a reply the server says made no sound ends at response.done", async () => {
   const context = harness();
   await context.session.connect();
-  context.session.beginTurn();
+  await holdTurn(context);
   context.session.endTurn(true);
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
 
@@ -611,14 +624,14 @@ test("two sentences are one reply, whatever the pause between them", async () =>
 
   // One reply that ends properly, which is how this call shows it reports the
   // end of its own audio.
-  context.session.beginTurn();
+  await holdTurn(context);
   context.session.endTurn(true);
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_DONE });
   context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED });
   assert.equal(context.session.status, REALTIME_STATUS.READY);
 
   // A longer one. Generation finishes while he is still on the first sentence.
-  context.session.beginTurn();
+  await holdTurn(context);
   context.session.endTurn(true);
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED });
   context.session.reportRemoteAudioActive();
@@ -639,7 +652,7 @@ test("a call that never reports an ending still ends its replies", async () => {
   const context = harness();
   await context.session.connect();
   context.deliverRemoteTrack();
-  context.session.beginTurn();
+  await holdTurn(context);
   context.session.endTurn(true);
   context.session.reportRemoteAudioActive();
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_DONE });
@@ -655,6 +668,7 @@ test("a pause mid-reply is not the reply running out", async () => {
   const context = harness();
   await context.session.connect();
   context.session.toggleTurn();
+  await deviceArrives();
   context.session.toggleTurn();
 
   // Long enough between two sentences for the meter to call it quiet, and then
@@ -674,7 +688,7 @@ test("a sentence pause is not the reply running out", async (t) => {
   const context = harness();
   await context.session.connect();
   context.deliverRemoteTrack();
-  context.session.beginTurn();
+  await holdTurn(context);
   context.session.endTurn(true);
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED });
   context.session.reportRemoteAudioLevel(true);
@@ -720,6 +734,7 @@ test("a reply is not over when the model stops producing it", async () => {
   const context = harness();
   await context.session.connect();
   context.session.toggleTurn();
+  await deviceArrives();
   context.session.toggleTurn();
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
 
@@ -736,6 +751,7 @@ test("quiet before the model has finished is a pause, not the end", async () => 
   const context = harness();
   await context.session.connect();
   context.session.toggleTurn();
+  await deviceArrives();
   context.session.toggleTurn();
 
   // Luke draws breath mid-sentence; the reply is still coming.
@@ -748,6 +764,7 @@ test("a finished response returns the session to ready", async () => {
   const context = harness();
   await context.session.connect();
   context.session.toggleTurn();
+  await deviceArrives();
   context.session.toggleTurn();
 
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_DONE });
@@ -772,7 +789,7 @@ test("a changed pace reaches the live call without waiting for the next one", as
 test("a pace changed mid-reply waits for the reply to end", async () => {
   const context = harness();
   await context.session.connect();
-  context.session.beginTurn();
+  await holdTurn(context);
   context.session.endTurn(true);
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
 
@@ -834,9 +851,12 @@ test("malformed server data never breaks the session", async () => {
 });
 
 test("a failed call releases the microphone instead of stranding it", async () => {
-  const context = harness({ sdpResponse: new Response("nope", { status: 403 }) });
-
+  const context = harness();
   await context.session.connect();
+  await holdTurn(context);
+  assert.equal(context.microphoneEnabled(), true);
+
+  context.setConnectionState("failed");
 
   assert.equal(context.session.status, REALTIME_STATUS.FAILED);
   // FAILED offers "Start voice" again, so nothing may still hold the device.
@@ -849,7 +869,8 @@ test("a stalled handshake times out instead of hanging on connecting", async () 
 
   assert.equal(await context.session.connect(), false);
   assert.equal(context.session.status, REALTIME_STATUS.FAILED);
-  assert.equal(context.microphoneStopped(), true);
+  // No press, no device: the stall held nothing that needs releasing.
+  assert.ok(!context.calls.includes("microphone-requested"));
   assert.ok(context.errors.some((message) => message?.includes("timed out")));
 });
 
@@ -870,6 +891,7 @@ test("a recoverable disconnect does not end the call", async () => {
 test("an unexpected channel close releases the microphone", async () => {
   const context = harness();
   await context.session.connect();
+  await holdTurn(context);
 
   context.closeChannel();
 
@@ -882,6 +904,7 @@ test("an error instead of response.done still frees the turn", async () => {
   const context = harness();
   await context.session.connect();
   context.session.toggleTurn();
+  await deviceArrives();
   context.session.toggleTurn();
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
 
@@ -893,7 +916,8 @@ test("an error instead of response.done still frees the turn", async () => {
 
   assert.equal(context.session.status, REALTIME_STATUS.READY);
   // Turn-taking still works rather than being stuck forever.
-  assert.equal(context.session.startListening(), true);
+  await holdTurn(context);
+  assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
 });
 
 test("the conversation is told which sessions Luke can see, at the turn that reads them", async () => {
@@ -909,7 +933,7 @@ test("the conversation is told which sessions Luke can see, at the turn that rea
   assert.deepEqual(context.sent, []);
   assert.equal(context.session.status, REALTIME_STATUS.READY);
 
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
 
   const item = context.sent.find(
     (event) => event.type === REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE,
@@ -939,7 +963,7 @@ test("a roster that churns between turns is only ever said once", async () => {
   }
   assert.deepEqual(context.sent, []);
 
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
 
   const rosters = contextItems(context, "[observed session status");
   assert.equal(rosters.length, 1);
@@ -952,14 +976,14 @@ test("a fresh roster replaces the item the last one occupied", async () => {
   await context.session.connect();
 
   context.session.updateSessions([observedSession("session-a", { recap: "Editing." })]);
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   const first = context.session.liveContextItemIds.get(CONTEXT_ITEM_KIND.SESSIONS);
   assert.ok(first);
 
   context.session.updateSessions([observedSession("session-a", { recap: "Waiting on input." })]);
   context.session.stopSpeaking();
   const sentBefore = context.sent.length;
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
 
   // The old item is deleted, then the new one created — in that order, on a
   // channel that keeps it, so the conversation never holds two rosters.
@@ -981,12 +1005,12 @@ test("a supersede the server refuses is this call's own business", async () => {
   await context.session.connect();
 
   context.session.updateSessions([observedSession("session-a", { recap: "Editing." })]);
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   const superseded = context.session.liveContextItemIds.get(CONTEXT_ITEM_KIND.SESSIONS);
 
   context.session.updateSessions([observedSession("session-a", { recap: "Waiting." })]);
   context.session.stopSpeaking();
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   const supersede = context.sent.findLast((event) => event.type === CONVERSATION_ITEM_DELETE) as {
     event_id?: string;
   };
@@ -1012,7 +1036,7 @@ test("an error that is not ours is still reported and still ends the turn", asyn
   const context = harness();
   await context.session.connect();
   context.session.updateSessions([observedSession("session-a")]);
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
 
   context.emit({
     type: REALTIME_SERVER_EVENT.ERROR,
@@ -1028,14 +1052,14 @@ test("an unchanged session roster is not resent", async () => {
   await context.session.connect();
 
   context.session.updateSessions([observedSession("session-a")]);
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   const sentBefore = context.sent.length;
 
   // The same roster again, and another turn: there is nothing new to say, so
   // nothing is said and the item already standing keeps its place.
   context.session.updateSessions([observedSession("session-a")]);
   context.session.stopSpeaking();
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
 
   assert.deepEqual(contextItems(context, "[observed session status", sentBefore), []);
   assert.equal(
@@ -1061,7 +1085,7 @@ test("the session under discussion travels with the roster, carrying its identit
   });
   assert.deepEqual(context.sent, []);
 
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
 
   const items = contextItems(context, "[session under discussion");
   assert.equal(items.length, 1);
@@ -1083,7 +1107,7 @@ test("a reference to a session Luke was never shown says nothing", async () => {
     providerId: "claude-code",
     providerSessionId: "session-unknown",
   });
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
 
   assert.deepEqual(contextItems(context, "[session under discussion"), []);
 });
@@ -1097,7 +1121,7 @@ test("the reference is rendered from the roster as it now stands", async () => {
     providerId: "claude-code",
     providerSessionId: "session-a",
   });
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
 
   // Providers rewrite titles as work moves — the very churn that makes a
   // title a bad anchor — so the line is re-rendered rather than kept as the
@@ -1107,7 +1131,7 @@ test("the reference is rendered from the roster as it now stands", async () => {
   ]);
   context.session.stopSpeaking();
   const sentBefore = context.sent.length;
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
 
   const items = contextItems(context, "[session under discussion", sentBefore);
   assert.equal(items.length, 1);
@@ -1124,12 +1148,12 @@ test("a reference whose session leaves the roster is withdrawn", async () => {
     providerId: "claude-code",
     providerSessionId: "session-a",
   });
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
 
   context.session.updateSessions([]);
   context.session.stopSpeaking();
   const sentBefore = context.sent.length;
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
 
   // The conversation held a line pointing at the session, so it is told the
   // line no longer stands rather than left resolving "that chat" to an
@@ -1164,7 +1188,7 @@ test("the last announcement travels with the roster, carrying the words said", a
   // Remembered, not sent: the words go in at the turn that reads them.
   assert.deepEqual(context.sent, []);
 
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
 
   const items = contextItems(context, "[last announcement");
   assert.equal(items.length, 1);
@@ -1183,14 +1207,14 @@ test("a fresh announcement replaces the one before it", async () => {
   context.session.updateLastAnnouncement(
     announcementSpeech("Claude Code finished checkout-service."),
   );
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   const first = context.session.liveContextItemIds.get(CONTEXT_ITEM_KIND.LAST_ANNOUNCEMENT);
   assert.ok(first);
 
   context.session.stopSpeaking();
   context.session.updateLastAnnouncement(announcementSpeech("Codex failed in payments."));
   const sentBefore = context.sent.length;
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
 
   // One live item per kind: the old words are deleted before the new go in,
   // so the conversation never holds two last announcements.
@@ -1216,7 +1240,7 @@ test("a fresh announcement replaces the one before it", async () => {
   context.session.stopSpeaking();
   context.session.updateLastAnnouncement(announcementSpeech("Codex failed in payments."));
   const repeatBefore = context.sent.length;
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   assert.deepEqual(contextItems(context, "[last announcement", repeatBefore), []);
 });
 
@@ -1241,7 +1265,8 @@ test("a deadline that fired during the exchange does not hang the handshake", as
 
   assert.equal(await context.session.connect(), false);
   assert.equal(context.session.status, REALTIME_STATUS.FAILED);
-  assert.equal(context.microphoneStopped(), true);
+  // No press was waiting, so the stalled handshake held no device either.
+  assert.ok(!context.calls.includes("microphone-requested"));
 });
 
 test("a stop during minting is not reported as unavailable", async () => {
@@ -1279,21 +1304,26 @@ test("push-to-talk reports whether it opened a turn", async () => {
   assert.equal(context.session.startListening(), false);
 
   await context.session.connect();
-  assert.equal(context.session.startListening(), true);
+  // Connected but deviceless is still not a turn: the press opens the device
+  // first, and only a device already at hand opens a turn on the spot.
+  assert.equal(context.session.startListening(), false);
+  await holdTurn(context);
+  assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
 });
 
-test("stopping after the device is open still releases it", async () => {
-  // The mint resolves immediately and the SDP exchange is slow, so the stop
-  // lands once the microphone exists but before the call is up. Closing during
-  // the mint is a different case, covered above, where nothing is held yet.
-  const context = harness({ sdpDelayMs: 40 });
+test("a stop that beats the device still releases it", async () => {
+  // The press asks for the device and the stop lands before it arrives, so
+  // the device shows up with nobody left to hold it. Adopting it would leave
+  // the indicator lit with nothing to close it; it is stopped instead.
+  const context = harness();
+  await context.session.connect();
 
-  const connecting = context.session.connect();
-  await new Promise((resolve) => setTimeout(resolve, 5));
+  context.session.beginTurn();
   await context.session.close();
+  await deviceArrives();
 
-  assert.equal(await connecting, false);
   assert.equal(context.microphoneStopped(), true);
+  assert.equal(context.microphoneEnabled(), false);
   assert.equal(context.session.status, REALTIME_STATUS.IDLE);
   assert.equal(context.session.isConnected, false);
 });
@@ -1311,7 +1341,7 @@ test("a turn is refused while another is already under way", async () => {
   };
 
   // While the developer holds the microphone open.
-  context.session.startListening();
+  await holdTurn(context);
   assert.equal(context.session.speak(speech), false);
   assert.equal(context.session.startListening(), false);
 
@@ -1343,6 +1373,7 @@ test("a turn opens from an empty buffer and the key ends it", async () => {
 
   // One key: press to open a turn, press again to send it.
   context.session.toggleTurn();
+  await deviceArrives();
   assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
   assert.equal(context.microphoneEnabled(), true);
   // A muted track still transmits, so a turn has to start from an empty buffer.
@@ -1367,14 +1398,16 @@ test("the tail of an interrupted reply is not heard as the answer to the next", 
   const context = harness();
   await context.session.connect();
   context.deliverRemoteTrack();
-  context.session.beginTurn();
+  await holdTurn(context);
   context.session.endTurn(true);
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED });
   assert.equal(context.lukeAudible(), true);
 
-  // Cut him off, say something else, and send it.
+  // Cut him off, say something else, and send it. The cut lands at the
+  // press; the turn itself opens once its device does.
   context.session.beginTurn();
   assert.equal(context.lukeAudible(), false);
+  await deviceArrives();
   context.session.endTurn(true);
 
   // The rest of the old reply is still arriving — the server sent it before it
@@ -1391,7 +1424,7 @@ test("an interrupted reply is trimmed to the part that was heard", async () => {
   const context = harness({ now: () => clock });
   await context.session.connect();
   context.deliverRemoteTrack();
-  context.session.beginTurn();
+  await holdTurn(context);
   context.session.endTurn(true);
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED });
   context.emit({
@@ -1422,7 +1455,7 @@ test("a reply cut off before it was heard leaves nothing to correct", async () =
   const context = harness({ now: () => clock });
   await context.session.connect();
   context.deliverRemoteTrack();
-  context.session.beginTurn();
+  await holdTurn(context);
   context.session.endTurn(true);
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED });
   context.emit({
@@ -1449,14 +1482,14 @@ test("each reply is measured from its own first word", async () => {
   await context.session.connect();
   context.deliverRemoteTrack();
 
-  context.session.beginTurn();
+  await holdTurn(context);
   context.session.endTurn(true);
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED });
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED, item: { id: "first" } });
   clock = 1_100;
   context.session.reportRemoteAudioActive();
   clock = 5_000;
-  context.session.beginTurn();
+  await holdTurn(context);
 
   // A second reply, and the clock starts again with it.
   context.session.endTurn(true);
@@ -1480,7 +1513,7 @@ test("an interrupt asks the server to drop what it already sent", async () => {
   const context = harness();
   await context.session.connect();
   context.deliverRemoteTrack();
-  context.session.beginTurn();
+  await holdTurn(context);
   context.session.endTurn(true);
   const before = context.sent.length;
 
@@ -1502,10 +1535,10 @@ test("a reply that never starts does not leave Luke silenced", async () => {
   const context = harness();
   await context.session.connect();
   context.deliverRemoteTrack();
-  context.session.beginTurn();
+  await holdTurn(context);
   context.session.endTurn(true);
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED });
-  context.session.beginTurn();
+  await holdTurn(context);
   context.session.endTurn(true);
   assert.equal(context.lukeAudible(), false);
 
@@ -1521,6 +1554,7 @@ test("taking the turn silences Luke rather than only stopping generation", async
   await context.session.connect();
   context.deliverRemoteTrack();
   context.session.toggleTurn();
+  await deviceArrives();
   context.session.toggleTurn();
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
   // Audible once the server says the reply is under way, rather than when it
@@ -1531,8 +1565,10 @@ test("taking the turn silences Luke rather than only stopping generation", async
   context.session.toggleTurn();
 
   // Cancelling stops the model producing more; it does not stop what is already
-  // on its way down the connection. Only this end can.
+  // on its way down the connection. Only this end can — and at the press, not
+  // once the device arrives.
   assert.equal(context.lukeAudible(), false);
+  await deviceArrives();
   assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
 
   // The next reply has to be audible again.
@@ -1545,11 +1581,13 @@ test("taking the turn cuts Luke off mid-reply", async () => {
   const context = harness();
   await context.session.connect();
   context.session.toggleTurn();
+  await deviceArrives();
   context.session.toggleTurn();
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
   context.sent.length = 0;
 
   context.session.toggleTurn();
+  await deviceArrives();
 
   // The developer's turn always wins: the reply is stopped, not queued behind.
   assert.deepEqual(
@@ -1571,7 +1609,7 @@ test("a stop cuts the reply where it stands and opens nothing in its place", asy
   const context = harness({ now: () => clock });
   await context.session.connect();
   context.deliverRemoteTrack();
-  context.session.beginTurn();
+  await holdTurn(context);
   context.session.endTurn(true);
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED });
   context.emit({
@@ -1608,7 +1646,7 @@ test("a stop cuts the reply where it stands and opens nothing in its place", asy
   assert.equal(events.at(-1)?.audio_end_ms, 1_500);
 
   // The next reply has to be audible again.
-  context.session.beginTurn();
+  await holdTurn(context);
   context.session.endTurn(true);
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED });
   assert.equal(context.lukeAudible(), true);
@@ -1622,7 +1660,7 @@ test("a stop with nothing being spoken reports so and sends nothing", async () =
   // Ready is not a reply, and neither is the developer's own open microphone:
   // the key that asked keeps its other meanings.
   assert.equal(context.session.stopSpeaking(), false);
-  context.session.startListening();
+  await holdTurn(context);
   assert.equal(context.session.stopSpeaking(), false);
   assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
 
@@ -1645,7 +1683,7 @@ test("a stop that races the reply's confirmation still holds", async () => {
   context.session.updateSessions([observedSession("session-a", { canReceiveMessage: true })]);
   // The stop lands in the gap between asking for the reply and the server
   // confirming it: the cancel and the confirmation cross on the wire.
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   assert.equal(context.session.stopSpeaking(), true);
 
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-a" } });
@@ -1706,7 +1744,7 @@ test("a stopped reply's tool follow-up stands down instead of speaking over the 
   });
   await context.session.connect();
   context.session.updateSessions([observedSession("session-a", { canReceiveMessage: true })]);
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-a" } });
   context.emit({
     type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
@@ -1747,6 +1785,7 @@ test("a stopped reply's tool follow-up stands down instead of speaking over the 
 test("closing stops the microphone track", async () => {
   const context = harness();
   await context.session.connect();
+  await holdTurn(context);
 
   await context.session.close();
 
@@ -1754,8 +1793,8 @@ test("closing stops the microphone track", async () => {
   assert.equal(context.session.status, REALTIME_STATUS.IDLE);
 });
 /** Opens and commits a developer turn, which is the only turn a tool may run in. */
-function armDeveloperTurn(context: Harness): void {
-  context.session.startListening();
+async function armDeveloperTurn(context: Harness): Promise<void> {
+  await holdTurn(context);
   context.session.stopListening(true);
 }
 
@@ -1824,7 +1863,7 @@ test("a typed ask interrupts the reply it arrives over", async () => {
   const context = harness({ now: () => now });
   await context.session.connect();
   context.deliverRemoteTrack();
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   context.emit({
     type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
     item: { id: "item-1" },
@@ -1869,7 +1908,7 @@ test("a cancelled reply's late finish cannot act in the turn that replaced it", 
   await context.session.connect();
   context.session.updateSessions([observedSession("session-a", { canReceiveMessage: true })]);
   // A spoken turn opens reply A, and the server confirms it by name.
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-a" } });
   // The developer types over it, opening a new armed turn.
   assert.equal(context.session.sendText("never mind — what needs me?"), true);
@@ -1939,7 +1978,7 @@ test("a cancelled reply's late finish does not end the turn that replaced it", a
   const context = harness();
   await context.session.connect();
   context.deliverRemoteTrack();
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-a" } });
   context.session.sendText("actually, open the codex session");
 
@@ -1956,7 +1995,7 @@ test("a cancelled reply's late finish does not end the turn that replaced it", a
 test("a typed ask does not interrupt the developer's own open microphone", async () => {
   const context = harness();
   await context.session.connect();
-  context.session.startListening();
+  await holdTurn(context);
   const sentBefore = context.sent.length;
 
   // Half a spoken question is still theirs: the keystroke is refused rather
@@ -1995,7 +2034,7 @@ test("a spoken ask is carried through the carrier and its outcome is voiced", as
   await context.session.connect();
   context.session.updateSessions([observedSession("session-a", { canReceiveMessage: true })]);
   // The tool call arrives inside a turn the developer opened by speaking.
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   const sentBefore = context.sent.length;
 
   context.emit({
@@ -2043,7 +2082,7 @@ test("a session carrier that throws is refused with the error that caused it", a
   });
   await context.session.connect();
   context.session.updateSessions([observedSession("session-a", { canReceiveMessage: true })]);
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   const sentBefore = context.sent.length;
 
   context.emit({
@@ -2090,7 +2129,7 @@ test("a spoken ask to open a session is carried, and one with no address is refu
     observedSession("session-a", { detail: { link: "https://claude.ai/session/session-a" } }),
     observedSession("session-b"),
   ]);
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   const sentBefore = context.sent.length;
 
   context.emit({
@@ -2155,7 +2194,7 @@ test("a spoken ask for a new workspace is carried, and an unlisted project is re
   // The projects travel as context the way the roster does, and an identical
   // list is not resent.
   context.session.updateWorkspaceProjects([project]);
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   assert.equal(contextItems(context, "[workspace projects").length, 1);
 
   // The default provider is part of the same answer, so choosing one is news
@@ -2163,7 +2202,7 @@ test("a spoken ask for a new workspace is carried, and an unlisted project is re
   const sentBeforeDefault = context.sent.length;
   context.session.updateWorkspaceProjects([project], "conductor");
   context.session.stopSpeaking();
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   const chosen = contextItems(context, "[workspace projects", sentBeforeDefault);
   assert.equal(chosen.length, 1);
   assert.match(itemText(chosen[0]), /default provider for new workspaces is Conductor/);
@@ -2245,7 +2284,7 @@ test("a spoken ask to add an agent is carried, and an unlisted kind is refused",
   context.session.updateSessions([
     observedSession("chat-1", { spawnableAgents: ["claude", "codex", "cursor"] }),
   ]);
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   const sentBefore = context.sent.length;
 
   context.emit({
@@ -2307,7 +2346,7 @@ test("a tool call outside the roster is refused before any carrier runs", async 
   await context.session.connect();
   // The roster names one session that takes nothing.
   context.session.updateSessions([observedSession("session-a")]);
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   const sentBefore = context.sent.length;
 
   context.emit({
@@ -2408,7 +2447,7 @@ test("a tool outcome is not spoken over a turn the developer has taken", async (
   });
   await context.session.connect();
   context.session.updateSessions([observedSession("session-a", { canReceiveMessage: true })]);
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   const sentBefore = context.sent.length;
 
   context.emit({
@@ -2428,7 +2467,8 @@ test("a tool outcome is not spoken over a turn the developer has taken", async (
   // Let the answer reach the point where it is awaiting the write.
   await Promise.resolve();
   // The developer takes the turn while the write is still in flight.
-  context.session.startListening();
+  context.session.beginTurn();
+  await deviceArrives();
   resolveWrite?.({ status: "accepted" });
   await new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -2447,7 +2487,7 @@ test("a tool outcome is not spoken over a turn the developer has taken", async (
 test("the caption grows with the deltas and the final text supersedes them", async () => {
   const context = harness();
   await context.session.connect();
-  context.session.beginTurn();
+  await holdTurn(context);
   context.session.endTurn(true);
 
   context.emit({
@@ -2475,7 +2515,7 @@ test("the caption grows with the deltas and the final text supersedes them", asy
 test("the caption leaves when the reply does", async () => {
   const context = harness();
   await context.session.connect();
-  context.session.beginTurn();
+  await holdTurn(context);
   context.session.endTurn(true);
   context.emit({
     type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
@@ -2521,7 +2561,7 @@ test("an announcement's caption names its session; a conversation's names none",
   assert.equal(context.captionSubjects.at(-1), undefined);
 
   // A conversation reply is nobody's announcement, whatever was said before.
-  context.session.beginTurn();
+  await holdTurn(context);
   context.session.endTurn(true);
   context.emit({
     type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
@@ -2535,7 +2575,7 @@ test("taking the turn cuts the caption with the audio", async () => {
   const context = harness();
   await context.session.connect();
   context.deliverRemoteTrack();
-  context.session.beginTurn();
+  await holdTurn(context);
   context.session.endTurn(true);
   context.emit({
     type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
@@ -2544,8 +2584,9 @@ test("taking the turn cuts the caption with the audio", async () => {
 
   // The caption already holds words the room has not heard — the text runs
   // ahead of the speech — so an interrupt must take it down at once rather
-  // than leaving Luke finishing a sentence he was stopped from saying.
-  context.session.startListening();
+  // than leaving Luke finishing a sentence he was stopped from saying. The
+  // cut lands at the press, before the device has even opened.
+  context.session.beginTurn();
 
   assert.equal(context.captions.at(-1), undefined);
   assert.equal(context.captions.length, 2);
@@ -2555,7 +2596,7 @@ test("a cancelled reply's late transcript cannot pollute the next caption", asyn
   const context = harness();
   await context.session.connect();
   context.deliverRemoteTrack();
-  context.session.beginTurn();
+  await holdTurn(context);
   context.session.endTurn(true);
   context.emit({
     type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
@@ -2570,12 +2611,13 @@ test("a cancelled reply's late transcript cannot pollute the next caption", asyn
   // Talking over the reply cuts it, but the server had already produced the
   // rest of its transcript, which keeps arriving — around the interrupt, and
   // even after the next reply has been asked for.
-  context.session.startListening();
+  context.session.beginTurn();
   context.emit({
     type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
     item_id: "item-first",
     delta: ", still streaming in",
   });
+  await deviceArrives();
   context.session.stopListening(true);
   context.emit({
     type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DONE,
@@ -2623,7 +2665,7 @@ test("the app guide reaches the conversation, and identical guides are not resen
   // The same knowledge again is not news; a changed value is. Neither is worth
   // an item on its own — the turn that asks is what collects the latest.
   context.session.updateGuide({ ...CAPTIONS_GUIDE });
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   assert.equal(contextItems(context, "[app guide").length, 1);
 
   const sentBefore = context.sent.length;
@@ -2634,7 +2676,7 @@ test("the app guide reaches the conversation, and identical guides are not resen
     ],
   });
   context.session.stopSpeaking();
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
 
   const guideEvents = contextItems(context, "[app guide", sentBefore);
   assert.equal(guideEvents.length, 1);
@@ -2651,7 +2693,7 @@ test("a spoken settings change is validated against the guide and carried", asyn
   });
   await context.session.connect();
   context.session.updateGuide(CAPTIONS_GUIDE);
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
 
   context.emit({
     type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
@@ -2723,7 +2765,7 @@ test("the second call of a turn is validated against the guide the first call's 
   });
   await context.session.connect();
   context.session.updateGuide(MODEL_ONLY_GUIDE);
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
 
   context.emit({
     type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
@@ -2760,7 +2802,7 @@ test("an app carrier that throws is refused with the error that caused it", asyn
   });
   await context.session.connect();
   context.session.updateGuide(CAPTIONS_GUIDE);
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   const sentBefore = context.sent.length;
 
   context.emit({
@@ -2801,7 +2843,7 @@ test("a spoken ask about a setting the guide does not carry is refused before th
   });
   await context.session.connect();
   // The guide was never provided, so the conversation was told about nothing.
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   const sentBefore = context.sent.length;
 
   context.emit({
@@ -2841,7 +2883,7 @@ test("a spoken panel ask is validated against the roster and carried", async () 
   await context.session.connect();
   context.session.updateGuide(CAPTIONS_GUIDE);
   context.session.updateSessions([observedSession("session-a")]);
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
 
   context.emit({
     type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
@@ -2864,7 +2906,7 @@ test("a spoken panel ask is validated against the roster and carried", async () 
 
   // Switching to the settings tab is the same ask carried with a tab, not a
   // different act — the carrier presses the tab an open panel already shows.
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   context.emit({
     type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
     response: {
@@ -2893,7 +2935,7 @@ test("a spoken composer open is validated against the fixed kinds and carried, n
   });
   await context.session.connect();
   context.session.updateGuide(CAPTIONS_GUIDE);
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   const sentBefore = context.sent.length;
 
   context.emit({
@@ -2965,7 +3007,7 @@ test("the conversation is told which issues the tracker lists", async () => {
   await context.session.connect();
 
   context.session.updateIssues([trackedIssue()]);
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
 
   const [contextEvent] = contextItems(context, "[observed issue tracker");
   assert.ok(contextEvent, "the issue roster was sent");
@@ -2976,7 +3018,7 @@ test("the conversation is told which issues the tracker lists", async () => {
   const sentBefore = context.sent.length;
   context.session.updateIssues([trackedIssue()]);
   context.session.stopSpeaking();
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   assert.deepEqual(contextItems(context, "[observed issue tracker", sentBefore), []);
 });
 
@@ -2990,7 +3032,7 @@ test("a spoken issue ask is carried through its own carrier and voiced", async (
   });
   await context.session.connect();
   context.session.updateIssues([trackedIssue()]);
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   const sentBefore = context.sent.length;
 
   context.emit({
@@ -3035,7 +3077,7 @@ test("an issue carrier that throws is refused with the error that caused it", as
   });
   await context.session.connect();
   context.session.updateIssues([trackedIssue()]);
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   const sentBefore = context.sent.length;
 
   context.emit({
@@ -3076,7 +3118,7 @@ test("an issue call with no tracker connected is refused before any carrier runs
   });
   await context.session.connect();
   // No updateIssues call: no roster was ever sent.
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   const sentBefore = context.sent.length;
 
   context.emit({
@@ -3116,7 +3158,7 @@ test("an issue call outside the roster is refused before any carrier runs", asyn
   });
   await context.session.connect();
   context.session.updateIssues([trackedIssue({ canComment: false })]);
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   const sentBefore = context.sent.length;
 
   context.emit({
@@ -3194,7 +3236,7 @@ test("a tracker that disconnects withdraws the roster, and a reconnect resends i
   const context = harness();
   await context.session.connect();
   context.session.updateIssues([trackedIssue()]);
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   const board = context.session.liveContextItemIds.get(CONTEXT_ITEM_KIND.ISSUES);
   assert.ok(board);
   const sentBefore = context.sent.length;
@@ -3203,7 +3245,7 @@ test("a tracker that disconnects withdraws the roster, and a reconnect resends i
   context.session.updateIssues(undefined);
   context.session.updateIssues(undefined);
   context.session.stopSpeaking();
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
 
   const withdrawals = contextItems(context, "[observed issue tracker", sentBefore).filter((event) =>
     itemText(event).includes("no longer connected"),
@@ -3226,7 +3268,7 @@ test("a tracker that disconnects withdraws the roster, and a reconnect resends i
   const reconnectBefore = context.sent.length;
   context.session.updateIssues([trackedIssue()]);
   context.session.stopSpeaking();
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
   const rosters = contextItems(context, "[observed issue tracker", reconnectBefore).filter(
     (event) => itemText(event).includes("LUKE-123"),
   );
@@ -3237,7 +3279,7 @@ test("a tracker that disconnects withdraws the roster, and a reconnect resends i
   const fresh = harness();
   await fresh.session.connect();
   fresh.session.updateIssues(undefined);
-  armDeveloperTurn(fresh);
+  await armDeveloperTurn(fresh);
   assert.deepEqual(contextItems(fresh, "[observed issue tracker"), []);
 });
 
@@ -3325,23 +3367,23 @@ test("an idle call is put away, and a call being used is not", async () => {
 
   // A turn stops it. A call someone is talking on is never put away underneath
   // them, however long the turn runs.
-  context.session.startListening();
+  await holdTurn(context);
   assert.equal(context.idleArmed(), false);
   context.session.stopListening(false);
   assert.equal(context.idleArmed(), true);
+  // The device never waits for the retirement: it left with the turn.
+  assert.equal(context.microphoneStopped(), true);
 
   context.fireIdle();
 
-  // The device is released with the call: the whole point of retiring one is
-  // that the macOS microphone indicator stops standing for nothing.
+  // What the retirement puts away is the conversation; the device is long gone.
   assert.equal(context.session.status, REALTIME_STATUS.IDLE);
-  assert.equal(context.microphoneStopped(), true);
 });
 
 test("an idle call that was taken up in the meantime is left alone", async () => {
   const context = harness();
   await context.session.connect();
-  context.session.startListening();
+  await holdTurn(context);
 
   // Ten minutes is long enough for the timer to fire against a call that has
   // since been taken up, so the decision is made again at the moment of it.
@@ -3357,115 +3399,94 @@ test("Luke's own call is not on the developer's idle clock", async () => {
 
   // It holds no device and already puts itself away once its queue is quiet.
   assert.equal(context.idleArmed(), false);
-  assert.equal(context.releaseArmed(), false);
 });
 
-test("a settled call lets the capture device go and keeps the conversation", async () => {
+test("the device closes with the turn and the conversation stays", async () => {
   const context = harness();
   await context.session.connect();
+  await holdTurn(context);
+  assert.equal(context.microphoneEnabled(), true);
 
-  // Settled: the device is on its own, much shorter clock than the call. It
-  // is what keeps Bluetooth audio on the call codec and the indicator lit, so
-  // it must not ride out the ten minutes the conversation is worth.
-  assert.equal(context.releaseArmed(), true);
-  assert.equal(context.releaseDelayMs(), MICROPHONE_RELEASE_TIMEOUT_MS);
+  context.session.stopListening(true);
 
-  context.fireRelease();
-
-  // The device is closed — tracks stopped, the sender emptied, nothing sent —
+  // The turn's end is the device's end — tracks stopped, the sender emptied —
   // while the call, and the conversation on it, stay warm and stay the
-  // developer's: a later press must reopen the device, not replace the call.
+  // developer's: the next press reopens the device, never replaces the call.
   assert.equal(context.microphoneStopped(), true);
-  assert.deepEqual(context.replacedTracks(), [null]);
+  assert.equal(context.replacedTracks().at(-1), null);
   assert.equal(context.session.isConnected, true);
   assert.equal(context.session.microphoneCall, true);
-  assert.equal(context.session.status, REALTIME_STATUS.READY);
-  // The retirement still runs: a bare call is not kept forever either.
-  assert.equal(context.idleArmed(), true);
 });
 
-test("a turn under way keeps the device off the release clock", async () => {
+test("each turn opens its own device on the same call", async () => {
   const context = harness();
   await context.session.connect();
-
-  context.session.startListening();
-  assert.equal(context.releaseArmed(), false);
-  context.session.stopListening(false);
-  assert.equal(context.releaseArmed(), true);
-});
-
-test("a press after the device was let go reopens it on the same call", async () => {
-  const context = harness();
-  await context.session.connect();
-  context.fireRelease();
+  await holdTurn(context);
+  context.session.endTurn(true);
   const before = context.calls.length;
 
   context.session.beginTurn();
-  // The press is an intention while the device reopens, not a turn yet.
+  // The press is an intention while the device opens, not a turn yet.
   assert.equal(context.session.turnPending, true);
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  await deviceArrives();
 
   assert.deepEqual(context.calls.slice(before), ["microphone-requested"]);
   assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
   assert.equal(context.microphoneEnabled(), true);
-  // The fresh track rode the sender the released one vacated: no new call.
+  // The fresh track rode the sender the last one vacated: no new call.
   assert.notEqual(context.replacedTracks().at(-1), null);
   assert.equal(context.session.isConnected, true);
 });
 
-test("two presses while the device reopens ask for it once", async () => {
+test("two presses while the device opens ask for it once", async () => {
   const context = harness();
   await context.session.connect();
-  context.fireRelease();
   const before = context.calls.length;
 
   context.session.beginTurn();
   context.session.beginTurn();
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  await deviceArrives();
 
   assert.deepEqual(context.calls.slice(before), ["microphone-requested"]);
   assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
 });
 
-test("a press let go while the device reopens drops the turn", async () => {
+test("a press let go while the device opens drops the turn", async () => {
   const context = harness();
   await context.session.connect();
-  context.fireRelease();
 
   context.session.beginTurn();
   context.session.endTurn(true);
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  await deviceArrives();
 
   // Nothing was captured, so nothing is sent — and the device that arrived
-  // for the dropped press sits back on the settle clock.
+  // for the dropped press closes as fast as it came.
   assert.deepEqual(context.sent, []);
   assert.equal(context.session.status, REALTIME_STATUS.READY);
   assert.equal(context.microphoneEnabled(), false);
-  assert.equal(context.releaseArmed(), true);
+  assert.equal(context.microphoneStopped(), true);
 });
 
-test("typing while the device rests does not reopen it", async () => {
+test("typing never opens the device", async () => {
   const context = harness();
   await context.session.connect();
-  context.fireRelease();
-  const before = context.calls.length;
 
   assert.equal(context.session.sendText("How is the checkout fix going?"), true);
 
   // A typed ask needs no capture device: the ask went, and the device — the
-  // part other audio can hear — stayed put away.
-  assert.equal(context.calls.length, before);
+  // part other audio can hear — was never touched.
+  assert.ok(!context.calls.includes("microphone-requested"));
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
 });
 
-test("a device that cannot reopen fails the call rather than listening to nothing", async () => {
+test("a device that vanishes mid-conversation fails the call at the press", async () => {
   const context = harness();
   await context.session.connect();
-  context.fireRelease();
+  await armDeveloperTurn(context);
   context.failMicrophone();
 
   context.session.beginTurn();
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  await deviceArrives();
 
   assert.equal(context.session.status, REALTIME_STATUS.FAILED);
   assert.equal(context.session.turnPending, false);
@@ -3476,7 +3497,7 @@ test("a call that drops mid-conversation says the thread is lost", async () => {
   const context = harness();
   await context.session.connect();
   context.session.updateSessions([observedSession("session-a")]);
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
 
   // The service ends every session at an hour, so this is how a long
   // conversation ordinarily ends rather than an exotic failure.
@@ -3501,7 +3522,7 @@ test("a call that drops before anything was said goes quietly", async () => {
 test("a call put away on purpose does not report itself as lost", async () => {
   const context = harness();
   await context.session.connect();
-  armDeveloperTurn(context);
+  await armDeveloperTurn(context);
 
   await context.session.close();
 

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -70,6 +70,9 @@ interface Harness {
   replacedTracks: () => (object | null)[];
   /** Makes the next device request refuse, as a vanished microphone would. */
   failMicrophone: () => void;
+  /** Holds device opens in flight until `ungateMicrophone` lets them land. */
+  gateMicrophone: () => void;
+  ungateMicrophone: () => void;
 }
 
 interface HeldTimer {
@@ -157,19 +160,20 @@ function harness(
   const remoteTrack = { enabled: true };
   const transceivers: { kind: string; direction?: string }[] = [];
   const replacedTracks: (object | null)[] = [];
-  const sender = {
-    replaceTrack: async (next: object | null) => {
-      replacedTracks.push(next);
-    },
-  };
   const peer: Record<string, unknown> = {
     localDescription: { type: "offer", sdp: "v=0 local" },
     connectionState: "connected",
-    addTrack: () => sender,
     addTransceiver: (kind: string, init?: { direction?: string }) => {
       transceivers.push({ kind, ...(init?.direction ? { direction: init.direction } : {}) });
-      // The sending half the session keeps: each turn's track rides it.
-      return { sender };
+      // A fresh sender per call, exactly as a fresh peer would give: sender
+      // identity is how a device opened for a closed call is told apart.
+      return {
+        sender: {
+          replaceTrack: async (next: object | null) => {
+            replacedTracks.push(next);
+          },
+        },
+      };
     },
     createDataChannel: () => {
       // A fresh channel per connect, so a call opened after another was torn
@@ -190,6 +194,7 @@ function harness(
 
   let connection = "connection" in options ? options.connection : CONNECTION;
   let microphoneError = options.microphoneError;
+  let microphoneGate: (() => void)[] | undefined;
   const session = new RealtimeVoiceSession({
     requestConnection: async () => {
       calls.push("credential-requested");
@@ -203,6 +208,11 @@ function harness(
     requestMicrophoneStream: async () => {
       calls.push("microphone-requested");
       if (microphoneError) throw microphoneError;
+      if (microphoneGate) {
+        await new Promise<void>((resolve) => {
+          microphoneGate?.push(resolve);
+        });
+      }
       return stream as unknown as MediaStream;
     },
     createPeerConnection: () => peer as unknown as RTCPeerConnection,
@@ -283,6 +293,14 @@ function harness(
     replacedTracks: () => replacedTracks,
     failMicrophone: () => {
       microphoneError = new Error("The microphone went away");
+    },
+    gateMicrophone: () => {
+      microphoneGate = [];
+    },
+    ungateMicrophone: () => {
+      const held = microphoneGate ?? [];
+      microphoneGate = undefined;
+      for (const release of held) release();
     },
     transceivers,
   };
@@ -3491,6 +3509,57 @@ test("typing never opens the device", async () => {
   // part other audio can hear — was never touched.
   assert.ok(!context.calls.includes("microphone-requested"));
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+});
+
+test("a device that arrives for a replaced call is stopped, not adopted", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.gateMicrophone();
+  context.session.beginTurn();
+  // The call is closed and a fresh one opened while the device is still on
+  // its way; the old press's device belongs to nobody.
+  await context.session.close();
+  await context.session.connect();
+  context.ungateMicrophone();
+  await deviceArrives();
+
+  assert.equal(context.microphoneStopped(), true);
+  assert.equal(context.microphoneEnabled(), false);
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+  // Nothing rode the fresh call's sender: no track, not even a release.
+  assert.deepEqual(context.replacedTracks(), []);
+});
+
+test("a device refused after its call was replaced fails nothing", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.failMicrophone();
+  context.session.beginTurn();
+  await context.session.close();
+  await context.session.connect();
+  await deviceArrives();
+
+  // The refusal belonged to the closed call and died with it: the call now
+  // up keeps standing, ready for its own press.
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+  assert.ok(!reportedErrors(context).some((message) => /microphone went away/i.test(message)));
+});
+
+test("a press against a fresh call is served once a stale open clears", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.gateMicrophone();
+  context.session.beginTurn();
+  await context.session.close();
+  await context.session.connect();
+  // The new call's own press lands while the stale open still holds the
+  // single-flight slot; it must wait its turn, not be dropped.
+  context.session.beginTurn();
+  context.ungateMicrophone();
+  await deviceArrives();
+
+  assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
+  assert.equal(context.microphoneEnabled(), true);
 });
 
 test("a device that vanishes mid-conversation fails the call at the press", async () => {

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -23,6 +23,7 @@ import {
 import {
   type AppActionCarrier,
   type IssueActionCarrier,
+  MICROPHONE_RELEASE_TIMEOUT_MS,
   quietIsLukesOwn,
   REMOTE_QUIET_MS,
   RealtimeVoiceSession,
@@ -59,13 +60,21 @@ interface Harness {
   /** The transceivers declared instead of tracks, as a speak-only call does. */
   transceivers: { kind: string; direction?: string }[];
   /**
-   * The idle retirement, held rather than run: every test connects and few
-   * close, so a real ten-minute timer would keep the run alive for ten minutes
-   * apiece. `fireIdle` runs whatever is currently armed, if anything.
+   * The idle retirement and the device release, held rather than run: every
+   * test connects and few close, so real timers would keep the run alive for
+   * minutes apiece. The two clocks are told apart by their delays, and firing
+   * one retires it the way the session's own re-arm would.
    */
   idleArmed: () => boolean;
   idleDelayMs: () => number | undefined;
   fireIdle: () => void;
+  releaseArmed: () => boolean;
+  releaseDelayMs: () => number | undefined;
+  fireRelease: () => void;
+  /** Every track handed to the sender, `null` standing for the device let go. */
+  replacedTracks: () => (object | null)[];
+  /** Makes the next device request refuse, as a vanished microphone would. */
+  failMicrophone: () => void;
 }
 
 interface HeldTimer {
@@ -105,10 +114,21 @@ function harness(
     carryAppAction?: AppActionCarrier;
     carryIssueAction?: IssueActionCarrier;
     idleTimeoutMs?: number;
+    microphoneReleaseTimeoutMs?: number;
   } = {},
 ): Harness {
   const timers: HeldTimer[] = [];
-  const armedTimer = (): HeldTimer | undefined => timers.findLast((timer) => !timer.cancelled);
+  const idleTimeoutMs = options.idleTimeoutMs ?? VOICE_IDLE_TIMEOUT_MS;
+  const releaseTimeoutMs = options.microphoneReleaseTimeoutMs ?? MICROPHONE_RELEASE_TIMEOUT_MS;
+  const armedTimer = (delayMs: number): HeldTimer | undefined =>
+    timers.findLast((timer) => !timer.cancelled && timer.delayMs === delayMs);
+  const fireTimer = (delayMs: number): void => {
+    const timer = armedTimer(delayMs);
+    if (!timer) return;
+    // A fired timer is spent: only a re-arm by the session makes a new one.
+    timer.cancelled = true;
+    timer.callback();
+  };
   const sent: Record<string, unknown>[] = [];
   const errors: (string | undefined)[] = [];
   const captions: (string | undefined)[] = [];
@@ -145,10 +165,16 @@ function harness(
 
   const remoteTrack = { enabled: true };
   const transceivers: { kind: string; direction?: string }[] = [];
+  const replacedTracks: (object | null)[] = [];
+  const sender = {
+    replaceTrack: async (next: object | null) => {
+      replacedTracks.push(next);
+    },
+  };
   const peer: Record<string, unknown> = {
     localDescription: { type: "offer", sdp: "v=0 local" },
     connectionState: "connected",
-    addTrack: () => undefined,
+    addTrack: () => sender,
     addTransceiver: (kind: string, init?: { direction?: string }) => {
       transceivers.push({ kind, ...(init?.direction ? { direction: init.direction } : {}) });
     },
@@ -170,6 +196,7 @@ function harness(
   };
 
   let connection = "connection" in options ? options.connection : CONNECTION;
+  let microphoneError = options.microphoneError;
   const session = new RealtimeVoiceSession({
     requestConnection: async () => {
       calls.push("credential-requested");
@@ -182,7 +209,7 @@ function harness(
     },
     requestMicrophoneStream: async () => {
       calls.push("microphone-requested");
-      if (options.microphoneError) throw options.microphoneError;
+      if (microphoneError) throw microphoneError;
       return stream as unknown as MediaStream;
     },
     createPeerConnection: () => peer as unknown as RTCPeerConnection,
@@ -198,6 +225,9 @@ function harness(
       : { connectTimeoutMs: options.connectTimeoutMs }),
     ...(options.now ? { now: options.now } : {}),
     ...(options.idleTimeoutMs === undefined ? {} : { idleTimeoutMs: options.idleTimeoutMs }),
+    ...(options.microphoneReleaseTimeoutMs === undefined
+      ? {}
+      : { microphoneReleaseTimeoutMs: options.microphoneReleaseTimeoutMs }),
     schedule: (callback, delayMs) => {
       const timer: HeldTimer = { callback, delayMs, cancelled: false };
       timers.push(timer);
@@ -255,10 +285,19 @@ function harness(
     },
     requests,
     calls,
-    idleArmed: () => armedTimer() !== undefined,
-    idleDelayMs: () => armedTimer()?.delayMs,
+    idleArmed: () => armedTimer(idleTimeoutMs) !== undefined,
+    idleDelayMs: () => armedTimer(idleTimeoutMs)?.delayMs,
     fireIdle: () => {
-      armedTimer()?.callback();
+      fireTimer(idleTimeoutMs);
+    },
+    releaseArmed: () => armedTimer(releaseTimeoutMs) !== undefined,
+    releaseDelayMs: () => armedTimer(releaseTimeoutMs)?.delayMs,
+    fireRelease: () => {
+      fireTimer(releaseTimeoutMs);
+    },
+    replacedTracks: () => replacedTracks,
+    failMicrophone: () => {
+      microphoneError = new Error("The microphone went away");
     },
     transceivers,
   };
@@ -3318,6 +3357,119 @@ test("Luke's own call is not on the developer's idle clock", async () => {
 
   // It holds no device and already puts itself away once its queue is quiet.
   assert.equal(context.idleArmed(), false);
+  assert.equal(context.releaseArmed(), false);
+});
+
+test("a settled call lets the capture device go and keeps the conversation", async () => {
+  const context = harness();
+  await context.session.connect();
+
+  // Settled: the device is on its own, much shorter clock than the call. It
+  // is what keeps Bluetooth audio on the call codec and the indicator lit, so
+  // it must not ride out the ten minutes the conversation is worth.
+  assert.equal(context.releaseArmed(), true);
+  assert.equal(context.releaseDelayMs(), MICROPHONE_RELEASE_TIMEOUT_MS);
+
+  context.fireRelease();
+
+  // The device is closed — tracks stopped, the sender emptied, nothing sent —
+  // while the call, and the conversation on it, stay warm and stay the
+  // developer's: a later press must reopen the device, not replace the call.
+  assert.equal(context.microphoneStopped(), true);
+  assert.deepEqual(context.replacedTracks(), [null]);
+  assert.equal(context.session.isConnected, true);
+  assert.equal(context.session.microphoneCall, true);
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+  // The retirement still runs: a bare call is not kept forever either.
+  assert.equal(context.idleArmed(), true);
+});
+
+test("a turn under way keeps the device off the release clock", async () => {
+  const context = harness();
+  await context.session.connect();
+
+  context.session.startListening();
+  assert.equal(context.releaseArmed(), false);
+  context.session.stopListening(false);
+  assert.equal(context.releaseArmed(), true);
+});
+
+test("a press after the device was let go reopens it on the same call", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.fireRelease();
+  const before = context.calls.length;
+
+  context.session.beginTurn();
+  // The press is an intention while the device reopens, not a turn yet.
+  assert.equal(context.session.turnPending, true);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.deepEqual(context.calls.slice(before), ["microphone-requested"]);
+  assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
+  assert.equal(context.microphoneEnabled(), true);
+  // The fresh track rode the sender the released one vacated: no new call.
+  assert.notEqual(context.replacedTracks().at(-1), null);
+  assert.equal(context.session.isConnected, true);
+});
+
+test("two presses while the device reopens ask for it once", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.fireRelease();
+  const before = context.calls.length;
+
+  context.session.beginTurn();
+  context.session.beginTurn();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.deepEqual(context.calls.slice(before), ["microphone-requested"]);
+  assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
+});
+
+test("a press let go while the device reopens drops the turn", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.fireRelease();
+
+  context.session.beginTurn();
+  context.session.endTurn(true);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  // Nothing was captured, so nothing is sent — and the device that arrived
+  // for the dropped press sits back on the settle clock.
+  assert.deepEqual(context.sent, []);
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+  assert.equal(context.microphoneEnabled(), false);
+  assert.equal(context.releaseArmed(), true);
+});
+
+test("typing while the device rests does not reopen it", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.fireRelease();
+  const before = context.calls.length;
+
+  assert.equal(context.session.sendText("How is the checkout fix going?"), true);
+
+  // A typed ask needs no capture device: the ask went, and the device — the
+  // part other audio can hear — stayed put away.
+  assert.equal(context.calls.length, before);
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+});
+
+test("a device that cannot reopen fails the call rather than listening to nothing", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.fireRelease();
+  context.failMicrophone();
+
+  context.session.beginTurn();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(context.session.status, REALTIME_STATUS.FAILED);
+  assert.equal(context.session.turnPending, false);
+  assert.ok(reportedErrors(context).some((message) => /microphone went away/i.test(message)));
 });
 
 test("a call that drops mid-conversation says the thread is lost", async () => {

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -325,6 +325,28 @@ test("a corrupt media duck value reads as the default rather than as off", async
   assert.equal((await storeIn(directory).snapshot()).duckOtherMedia, true);
 });
 
+test("the microphone preference persists, defaults on, and shrugs off corruption", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+
+  assert.equal((await store.snapshot()).preferBuiltInMicrophone, true);
+  const disabled = await store.setPreferBuiltInMicrophone(false);
+
+  assert.equal(disabled.settings.preferBuiltInMicrophone, false);
+  assert.equal((await storeIn(directory).snapshot()).preferBuiltInMicrophone, false);
+});
+
+test("a corrupt microphone preference reads as the default rather than as off", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({ version: 2, apiKeys: {}, preferBuiltInMicrophone: "no" }),
+    "utf8",
+  );
+
+  assert.equal((await storeIn(directory).snapshot()).preferBuiltInMicrophone, true);
+});
+
 test("counts feedback sends from none, and the count survives a reopen", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);
@@ -545,6 +567,7 @@ test("keeps both keys when two providers are saved at once", async (t) => {
     showInMenuBar: true,
     voiceCaptions: false,
     duckOtherMedia: true,
+    preferBuiltInMicrophone: true,
     quietDuringMeetings: true,
     showOnAllDisplays: false,
   });
@@ -746,6 +769,7 @@ test("keeps a Conductor key stored by an earlier version working", async (t) => 
     showInMenuBar: true,
     voiceCaptions: false,
     duckOtherMedia: true,
+    preferBuiltInMicrophone: true,
     quietDuringMeetings: true,
     showOnAllDisplays: false,
   });
@@ -770,6 +794,7 @@ test("carries a key belonging to a provider this build does not know", async (t)
     showInMenuBar: true,
     voiceCaptions: false,
     duckOtherMedia: true,
+    preferBuiltInMicrophone: true,
     quietDuringMeetings: true,
     showOnAllDisplays: false,
   });
@@ -792,6 +817,7 @@ test("shows the menu bar item until asked otherwise, and remembers the answer", 
     showInMenuBar: false,
     voiceCaptions: false,
     duckOtherMedia: true,
+    preferBuiltInMicrophone: true,
     quietDuringMeetings: true,
     showOnAllDisplays: false,
   });
@@ -875,6 +901,7 @@ test("keeps Luke out of the Dock until asked, and remembers the answer", async (
     showInMenuBar: true,
     voiceCaptions: false,
     duckOtherMedia: true,
+    preferBuiltInMicrophone: true,
     quietDuringMeetings: true,
     showOnAllDisplays: false,
   });
@@ -1619,6 +1646,7 @@ test("a reset leaves a stored key standing", async (t) => {
       apiKeys: { [CONDUCTOR]: sealed(TEST_API_KEY) },
       voiceCaptions: true,
       duckOtherMedia: true,
+      preferBuiltInMicrophone: true,
       showInDock: false,
       showInMenuBar: true,
       showOnAllDisplays: false,

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -38,6 +38,7 @@ function packagerOptions(signing = resolveSigningMode({})) {
     outputRoot: "/repo/apps/desktop/out",
     helperPaths: [
       "/repo/apps/desktop/.build/native/mac-media-duck",
+      "/repo/apps/desktop/.build/native/mac-microphone-route",
       "/repo/apps/desktop/.build/native/mac-output-volume",
       "/repo/apps/desktop/.build/native/mac-screen-geometry",
       "/repo/apps/desktop/.build/native/mac-talk-key",


### PR DESCRIPTION
## Summary

Fixes **degraded Spotify audio quality from the first time Luke lowers the volume**, makes the microphone fully user-driven, and removes the last degradation Bluetooth listeners could hear — with one switch as the entire new settings surface.

1. **`echoCancellation: false`.** Push-to-talk is half-duplex by construction — a press interrupts the reply before the track enables, and `speak` refuses a busy turn — so there is never an echo to cancel. The constraint bought only Chromium's system echo canceller, whose macOS voice processing ducks and thins every other app's audio while a capture is open. That, not the media duck, was the original degradation.
2. **The capture device is bound to the exchange, driven by the user.** Connecting negotiates the call's sending half as a bare transceiver and opens no device; the talk-key press opens it, and it closes when the exchange settles — after Luke's reply, because closing a capture device is itself audible on shared hardware and must not land under his first words. Typed asks never open it; a press over a reply cuts Luke off at the press; a discarded turn releases at once. The macOS indicator now tracks actual use.
3. **The Mac's own microphone stands in for a Bluetooth headset's.** Capturing from a Bluetooth headset's mic pulls the whole headset onto its call codec — the one degradation no constraint avoids. A read-only helper (`mac-microphone-route`) reports the default input's transport, the built-in microphone's name, and whether the lid over it is open (from the power domain's `AppleClamshellState`, re-probed at each press). When the default input is Bluetooth and the lid is not shut, the press opens the built-in microphone instead, and the headset keeps its music codec through the whole exchange.
4. **Clamshell honesty.** A shut lid muffles the built-in mics, so the preference stands down and the headset mic is used — a muffled question is worse than a degraded song. A desktop with no lid counts as open. An unreadable route, an unmatched name, or a vanished device all fall back to the browser's default — the route is an optimization, never a gate.
5. **One switch, nothing else.** Beside the duck on the Voice page: **"Prefer the Mac's microphone — Keeps Bluetooth headphones on their full music quality while you talk."** On by default; off means the route is never even read and the system default is the user's exact choice. Guide-taught and speakable like every other toggle, resets with the Voice group, reads at the press so flipping it needs no reconnect. No status rows, no device picker: macOS's Sound settings stay the one place a default device is chosen, and the guide lets Luke explain the behavior out loud when asked.

The trust constraints gained a bullet bounding the route reader: transport, built-in name, and lid — nothing else, no audio ever read, nothing writable, deciding exactly one act. 

## Testing

- `./scripts/check.sh` passes: **1248 tests, 0 failures.** Coverage: the setting persists, defaults on, shrugs off corruption, resets with the Voice group, and is carried to its own bridge call by the adjustable-settings sweep; device choice across every route shape (Bluetooth+open prefers built-in, shut lid keeps the headset, unknown lid counts as open, non-Bluetooth defaults untouched, hidden labels and vanished devices fall back); the route gate reads at the press; route-line parsing and watcher lifecycle; capture bound to press/settle across commit, discard, drop, stop, interrupt, teardown.
- The Swift helper follows `OutputVolume.swift`'s patterns and is registered in `NATIVE_HELPERS` (built ⇔ shipped); the macOS CI job compiles and validates it.
- Physical verification on a Mac with AirPods playing Spotify: talk to Luke — Spotify keeps full fidelity throughout, the orange indicator tracks your turns, and the switch off restores capturing from the headset (with its codec cost) on the next press.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32085025314/artifacts/9306427514) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32085025314)

- Commit: `1cbc963311c94f35d7ecfb524fbd2faaf4751c07`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
