### PR TITLE
refactor(desktop): condense the face's motion emission and wiring

### DIFF
--- a/apps/desktop/src/renderer/luke-face.tsx
+++ b/apps/desktop/src/renderer/luke-face.tsx
@@ -15,6 +15,18 @@ interface LukeFaceProps {
 /** Nothing beyond the smile and the eyes, which is what a still face draws. */
 const RESTING_PARTS = { brows: false, lids: false, sleepZ: false } as const;
 
+/** The monoline stroke every drawn line of the face shares. */
+const STROKE = {
+  fill: "none",
+  stroke: "currentColor",
+  strokeLinecap: "round",
+} as const;
+
+/** The paired parts are drawn per side, keyed the way the artwork names them. */
+const SIDES = ["LEFT", "RIGHT"] as const;
+/** Each eye is named so the wink's generated rule can close one of them. */
+const EYE_CLASS = { LEFT: "luke-face-eye-left", RIGHT: "luke-face-eye-right" } as const;
+
 /**
  * Luke's face. The artwork is drawn here rather than loaded, for the same reason
  * the provider marks are — the renderer stays asset-free and the face scales
@@ -25,7 +37,8 @@ const RESTING_PARTS = { brows: false, lids: false, sleepZ: false } as const;
  * cuts the SVGs in `design/brand/` from the same table: the geometry arrives as
  * `luke-face-art.ts` and the motions as `styles/face-motion.css`. Nothing about
  * the face is decided in this file; it only says which parts a motion needs and
- * in what order they nest.
+ * in what order they nest. `luke-face-part` marks everything the artwork moves,
+ * which is what the wiring in base.css plays, pauses, and repeats as one set.
  */
 export function LukeFace({ motion, repeat = false }: LukeFaceProps): React.JSX.Element {
   const parts = motion === undefined ? RESTING_PARTS : FACE_MOTION_PARTS[motion];
@@ -44,75 +57,50 @@ export function LukeFace({ motion, repeat = false }: LukeFaceProps): React.JSX.E
           drawn, and a motion that needs only one simply leaves the outer one
           still. A CSS transform on a layer replaces a transform attribute on the
           same element, so the resting tilt has to be a group of its own. */}
-      <g className="luke-face-layer luke-face-layer-2">
-        <g className="luke-face-layer luke-face-layer-1">
+      <g className="luke-face-part luke-face-layer luke-face-layer-2">
+        <g className="luke-face-part luke-face-layer luke-face-layer-1">
           <g transform={FACE_ART.TILT}>
             <path
               d={FACE_ART.SMILE}
-              fill="none"
-              stroke="currentColor"
+              {...STROKE}
               strokeWidth={FACE_ART.STROKE_WIDTH}
-              strokeLinecap="round"
               strokeLinejoin="round"
             />
-            {parts.lids ? (
-              /* Asleep: closed lids in place of the eyes, not eyes that happen
-                 to be shut — a blink is a squeeze, and a lid is an arc. */
-              <>
-                <path
-                  d={FACE_ART.LID.LEFT}
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth={FACE_ART.LID_WIDTH}
-                  strokeLinecap="round"
-                />
-                <path
-                  d={FACE_ART.LID.RIGHT}
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth={FACE_ART.LID_WIDTH}
-                  strokeLinecap="round"
-                />
-              </>
-            ) : (
-              /* Ellipses rather than circles: blinking, squinting and widening
-                 are all the radius moving, and an ellipse has nothing to
-                 convert. Each is named so the wink can close one of them. */
-              <>
-                <ellipse
-                  className="luke-face-eye luke-face-eye-left"
-                  cx={FACE_ART.EYE_X.LEFT}
-                  cy={FACE_ART.EYE_Y}
-                  rx={FACE_ART.EYE_RADIUS}
-                  ry={FACE_ART.EYE_RADIUS}
-                  fill="currentColor"
-                />
-                <ellipse
-                  className="luke-face-eye luke-face-eye-right"
-                  cx={FACE_ART.EYE_X.RIGHT}
-                  cy={FACE_ART.EYE_Y}
-                  rx={FACE_ART.EYE_RADIUS}
-                  ry={FACE_ART.EYE_RADIUS}
-                  fill="currentColor"
-                />
-              </>
-            )}
+            {parts.lids
+              ? /* Asleep: closed lids in place of the eyes, not eyes that happen
+                   to be shut — a blink is a squeeze, and a lid is an arc. */
+                SIDES.map((side) => (
+                  <path
+                    key={side}
+                    d={FACE_ART.LID[side]}
+                    {...STROKE}
+                    strokeWidth={FACE_ART.LID_WIDTH}
+                  />
+                ))
+              : /* Ellipses rather than circles: blinking, squinting and widening
+                   are all the radius moving, and an ellipse has nothing to
+                   convert. */
+                SIDES.map((side) => (
+                  <ellipse
+                    key={side}
+                    className={`luke-face-part luke-face-eye ${EYE_CLASS[side]}`}
+                    cx={FACE_ART.EYE_X[side]}
+                    cy={FACE_ART.EYE_Y}
+                    rx={FACE_ART.EYE_RADIUS}
+                    ry={FACE_ART.EYE_RADIUS}
+                    fill="currentColor"
+                  />
+                ))}
             {parts.brows ? (
-              <g className="luke-face-brows">
-                <path
-                  d={FACE_ART.BROW.LEFT}
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth={FACE_ART.BROW_WIDTH}
-                  strokeLinecap="round"
-                />
-                <path
-                  d={FACE_ART.BROW.RIGHT}
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth={FACE_ART.BROW_WIDTH}
-                  strokeLinecap="round"
-                />
+              <g className="luke-face-part luke-face-brows">
+                {SIDES.map((side) => (
+                  <path
+                    key={side}
+                    d={FACE_ART.BROW[side]}
+                    {...STROKE}
+                    strokeWidth={FACE_ART.BROW_WIDTH}
+                  />
+                ))}
               </g>
             ) : null}
           </g>
@@ -125,12 +113,10 @@ export function LukeFace({ motion, repeat = false }: LukeFaceProps): React.JSX.E
         ? FACE_ART.SLEEP_Z.map((sleepZ, index) => (
             <g key={sleepZ.path} transform={`translate(${sleepZ.x} ${sleepZ.y})`}>
               <path
-                className={`luke-face-z luke-face-z-${index + 1}`}
+                className={`luke-face-part luke-face-z luke-face-z-${index + 1}`}
                 d={sleepZ.path}
-                fill="none"
-                stroke="currentColor"
+                {...STROKE}
                 strokeWidth={FACE_ART.SLEEP_Z_WIDTH}
-                strokeLinecap="round"
                 strokeLinejoin="round"
               />
             </g>

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -909,19 +909,19 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   color: var(--voice-luke);
 }
 
-/* Everything the artwork moves. Which keyframes each part plays, at what
-   duration and about which pivot, is generated into face-motion.css from the
-   same table the SVGs in design/brand/ are cut from; this is only the wiring
-   those rules assume — how long they run, and what can stop them.
+/* Everything the artwork moves wears `luke-face-part`. Which keyframes each
+   part plays, at what duration and about which pivot, is generated into
+   face-motion.css from the same table the SVGs in design/brand/ are cut from;
+   this is only the wiring those rules assume — how long they run, and what can
+   stop them.
 
    Pivots arrive as points on the artwork's canvas, so the layers measure against
    the viewBox. The eyes squeeze about their own centres instead, which is what
-   `fill-box` means here. Easing is carried per keyframe, because a keySplines
+   `fill-box` means here. Linear is the easing of a part that names none; a part
+   that eases every interval alike carries the curve on its generated rule, and
+   only mixed curves become per-keyframe timing functions, because a keySplines
    list is a curve per interval and `animation-timing-function` is only one. */
-.luke-face-layer,
-.luke-face-eye,
-.luke-face-brows,
-.luke-face-z {
+.luke-face-part {
   animation-play-state: var(--face-motion);
   /* A gesture is something that happens rather than something that is: it plays
      once and leaves the face at the pose it started from, which is the drawn
@@ -934,10 +934,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 /* The exception, and the whole of it: a motion that says something continuously
    true has to keep saying it. An open microphone and a sleeping face are states
    rather than moments, so they repeat for as long as they hold. */
-.luke-face[data-repeat="true"] .luke-face-layer,
-.luke-face[data-repeat="true"] .luke-face-eye,
-.luke-face[data-repeat="true"] .luke-face-brows,
-.luke-face[data-repeat="true"] .luke-face-z {
+.luke-face[data-repeat="true"] .luke-face-part {
   animation-iteration-count: infinite;
 }
 

--- a/apps/desktop/src/renderer/styles/face-motion.css
+++ b/apps/desktop/src/renderer/styles/face-motion.css
@@ -10,17 +10,14 @@
 @keyframes luke-talking-1 {
   0% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   25% {
     transform: rotate(-4deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   75% {
     transform: rotate(4deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -31,12 +28,10 @@
 @keyframes luke-talking-2 {
   0% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   50% {
     transform: translate(0px, 2.5px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -48,11 +43,13 @@
   transform-origin: 120px 150px;
   animation-name: luke-talking-1;
   animation-duration: 0.65s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 .luke-face[data-motion="talking"] .luke-face-layer-2 {
   animation-name: luke-talking-2;
   animation-duration: 0.4s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 /* yes — acknowledged (nod) */
@@ -60,22 +57,18 @@
 @keyframes luke-yes-1 {
   0% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   15% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   45% {
     transform: rotate(8deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   75% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -87,6 +80,7 @@
   transform-origin: 120px 190px;
   animation-name: luke-yes-1;
   animation-duration: 2.2s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 /* error — something went wrong (shimmy) */
@@ -94,37 +88,30 @@
 @keyframes luke-error-1 {
   0% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   5% {
     transform: rotate(6deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   11% {
     transform: rotate(-6deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   17% {
     transform: rotate(4.2deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   23% {
     transform: rotate(-4.2deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   29% {
     transform: rotate(1.8deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   35% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -136,6 +123,7 @@
   transform-origin: 120px 124px;
   animation-name: luke-error-1;
   animation-duration: 3s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 /* reviewing — inspecting a session (wince-like squint) */
@@ -143,27 +131,22 @@
 @keyframes luke-reviewing-1 {
   0% {
     transform: scale(1, 1);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   35% {
     transform: scale(1, 1);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   42% {
     transform: scale(1.03, 1.03);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   68% {
     transform: scale(1.03, 1.03);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   76% {
     transform: scale(1, 1);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -174,27 +157,22 @@
 @keyframes luke-reviewing-eyes {
   0% {
     transform: scaleY(1);
-    animation-timing-function: linear;
   }
 
   35% {
     transform: scaleY(1);
-    animation-timing-function: linear;
   }
 
   42% {
     transform: scaleY(0.18);
-    animation-timing-function: linear;
   }
 
   68% {
     transform: scaleY(0.18);
-    animation-timing-function: linear;
   }
 
   76% {
     transform: scaleY(1);
-    animation-timing-function: linear;
   }
 
   100% {
@@ -206,6 +184,7 @@
   transform-origin: 120px 124px;
   animation-name: luke-reviewing-1;
   animation-duration: 4.4s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 .luke-face[data-motion="reviewing"] .luke-face-eye {
@@ -218,27 +197,22 @@
 @keyframes luke-success-1 {
   0% {
     transform: scale(1, 1);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   25% {
     transform: scale(1.05, 0.93);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   45% {
     transform: scale(0.96, 1.06);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   65% {
     transform: scale(1.07, 0.9);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   75% {
     transform: scale(1, 1);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -249,27 +223,22 @@
 @keyframes luke-success-2 {
   0% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   25% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   45% {
     transform: translate(0px, -14px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   65% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   75% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -281,11 +250,13 @@
   transform-origin: 120px 124px;
   animation-name: luke-success-1;
   animation-duration: 2s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 .luke-face[data-motion="success"] .luke-face-layer-2 {
   animation-name: luke-success-2;
   animation-duration: 2s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 /* listening — curious tilt */
@@ -293,27 +264,22 @@
 @keyframes luke-listening-1 {
   0% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   18% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   32% {
     transform: rotate(-12deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   68% {
     transform: rotate(-12deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   82% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -325,6 +291,7 @@
   transform-origin: 120px 124px;
   animation-name: luke-listening-1;
   animation-duration: 3.6s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 /* idle — double blink */
@@ -332,32 +299,26 @@
 @keyframes luke-idle-eyes {
   0% {
     transform: scaleY(1);
-    animation-timing-function: linear;
   }
 
   55% {
     transform: scaleY(1);
-    animation-timing-function: linear;
   }
 
   58.5% {
     transform: scaleY(0.1);
-    animation-timing-function: linear;
   }
 
   62% {
     transform: scaleY(1);
-    animation-timing-function: linear;
   }
 
   65.5% {
     transform: scaleY(0.1);
-    animation-timing-function: linear;
   }
 
   69% {
     transform: scaleY(1);
-    animation-timing-function: linear;
   }
 
   100% {
@@ -375,27 +336,22 @@
 @keyframes luke-notification-eyes {
   0% {
     transform: scale(1);
-    animation-timing-function: linear;
   }
 
   50% {
     transform: scale(1);
-    animation-timing-function: linear;
   }
 
   55% {
     transform: scale(1.2);
-    animation-timing-function: linear;
   }
 
   72% {
     transform: scale(1.2);
-    animation-timing-function: linear;
   }
 
   77% {
     transform: scale(1);
-    animation-timing-function: linear;
   }
 
   100% {
@@ -406,27 +362,22 @@
 @keyframes luke-notification-brows {
   0% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   50% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   55% {
     transform: translate(0px, -6px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   72% {
     transform: translate(0px, -6px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   77% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -442,6 +393,7 @@
 .luke-face[data-motion="notification"] .luke-face-brows {
   animation-name: luke-notification-brows;
   animation-duration: 4s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 /* wink — confirmation / easter egg */
@@ -449,27 +401,22 @@
 @keyframes luke-wink-1 {
   0% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   50% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   56% {
     transform: rotate(2.5deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   68% {
     transform: rotate(2.5deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   74% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -480,27 +427,22 @@
 @keyframes luke-wink-eyes {
   0% {
     transform: scaleY(1);
-    animation-timing-function: linear;
   }
 
   50% {
     transform: scaleY(1);
-    animation-timing-function: linear;
   }
 
   56% {
     transform: scaleY(0.12);
-    animation-timing-function: linear;
   }
 
   68% {
     transform: scaleY(0.12);
-    animation-timing-function: linear;
   }
 
   74% {
     transform: scaleY(1);
-    animation-timing-function: linear;
   }
 
   100% {
@@ -512,6 +454,7 @@
   transform-origin: 120px 150px;
   animation-name: luke-wink-1;
   animation-duration: 4s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 .luke-face[data-motion="wink"] .luke-face-eye-right {
@@ -524,12 +467,10 @@
 @keyframes luke-sleeping-2 {
   0% {
     transform: scale(1, 1);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   50% {
     transform: scale(1.035, 1.035);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -546,6 +487,7 @@
   transform-origin: 120px 124px;
   animation-name: luke-sleeping-2;
   animation-duration: 4.8s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 /* refresh — relaunch (one pirouette) */
@@ -577,22 +519,18 @@
 @keyframes luke-boop-1 {
   0% {
     transform: scale(1, 1);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   55% {
     transform: scale(1, 1);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   63% {
     transform: scale(1.09, 1.09);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   72% {
     transform: scale(0.985, 0.985);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -604,6 +542,7 @@
   transform-origin: 120px 124px;
   animation-name: luke-boop-1;
   animation-duration: 3.2s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 /* monitoring — humming along (slow sway) */
@@ -611,22 +550,18 @@
 @keyframes luke-monitoring-1 {
   0% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   25% {
     transform: rotate(3.5deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   50% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   75% {
     transform: rotate(-3.5deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -638,6 +573,7 @@
   transform-origin: 120px 196px;
   animation-name: luke-monitoring-1;
   animation-duration: 3.6s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 /* appear — attaching (peek-slide in) */
@@ -645,17 +581,14 @@
 @keyframes luke-appear-1 {
   0% {
     transform: rotate(8deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   15% {
     transform: rotate(8deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   30% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -666,17 +599,14 @@
 @keyframes luke-appear-2 {
   0% {
     transform: translate(-16px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   15% {
     transform: translate(-16px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   30% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -688,11 +618,13 @@
   transform-origin: 76px 190px;
   animation-name: luke-appear-1;
   animation-duration: 4s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 .luke-face[data-motion="appear"] .luke-face-layer-2 {
   animation-name: luke-appear-2;
   animation-duration: 4s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 /* attention — attention caught (perk up) */
@@ -700,32 +632,26 @@
 @keyframes luke-attention-1 {
   0% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   20% {
     transform: rotate(6deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   42% {
     transform: rotate(6deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   50% {
     transform: rotate(-2.5deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   58% {
     transform: rotate(0.8deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   75% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -736,32 +662,26 @@
 @keyframes luke-attention-2 {
   0% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   20% {
     transform: translate(0px, 3px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   42% {
     transform: translate(0px, 3px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   50% {
     transform: translate(0px, -1.5px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   58% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   75% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -773,11 +693,13 @@
   transform-origin: 120px 150px;
   animation-name: luke-attention-1;
   animation-duration: 4.5s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 .luke-face[data-motion="attention"] .luke-face-layer-2 {
   animation-name: luke-attention-2;
   animation-duration: 4.5s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 /* floating — hovering idle */
@@ -785,17 +707,14 @@
 @keyframes luke-floating-1 {
   0% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   25% {
     transform: rotate(-2deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   75% {
     transform: rotate(2deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -806,12 +725,10 @@
 @keyframes luke-floating-2 {
   0% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   50% {
     transform: translate(0px, -8px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -823,11 +740,13 @@
   transform-origin: 120px 124px;
   animation-name: luke-floating-1;
   animation-duration: 4.8s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 .luke-face[data-motion="floating"] .luke-face-layer-2 {
   animation-name: luke-floating-2;
   animation-duration: 4.8s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 /* hiding — minimized (peekaboo duck) */
@@ -835,27 +754,22 @@
 @keyframes luke-hiding-1 {
   0% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   35% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   45% {
     transform: translate(0px, 55px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   65% {
     transform: translate(0px, 55px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   78% {
     transform: translate(0px, -4px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -866,6 +780,7 @@
 .luke-face[data-motion="hiding"] .luke-face-layer-1 {
   animation-name: luke-hiding-1;
   animation-duration: 5s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 /* flyoff — hover flourish (fly off and swoop back) */
@@ -873,42 +788,34 @@
 @keyframes luke-flyoff-1 {
   0% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   10% {
     transform: rotate(-10deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   26% {
     transform: rotate(22deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   34% {
     transform: rotate(10deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   40% {
     transform: rotate(-14deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   46% {
     transform: rotate(-14deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   62% {
     transform: rotate(5deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   72% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -966,6 +873,7 @@
   transform-origin: 120px 124px;
   animation-name: luke-flyoff-1;
   animation-duration: 3s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 .luke-face[data-motion="flyoff"] .luke-face-layer-2 {
@@ -978,32 +886,26 @@
 @keyframes luke-tease-brows {
   0% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   45% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   52% {
     transform: translate(0px, -6px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   59% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   66% {
     transform: translate(0px, -6px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   73% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -1014,6 +916,7 @@
 .luke-face[data-motion="tease"] .luke-face-brows {
   animation-name: luke-tease-brows;
   animation-duration: 4.2s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 /* waiting — needs approval (fidget) */
@@ -1021,27 +924,22 @@
 @keyframes luke-waiting-1 {
   0% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   7% {
     transform: translate(0px, -5px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   14% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   21% {
     transform: translate(0px, -5px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   28% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -1052,6 +950,7 @@
 .luke-face[data-motion="waiting"] .luke-face-layer-1 {
   animation-name: luke-waiting-1;
   animation-duration: 2.4s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 /* shimmy — shaking it off (happy wiggle) */
@@ -1059,37 +958,30 @@
 @keyframes luke-shimmy-1 {
   0% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   12% {
     transform: rotate(-9deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   26% {
     transform: rotate(8deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   40% {
     transform: rotate(-5.5deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   52% {
     transform: rotate(3deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   62% {
     transform: rotate(-1.2deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   70% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -1101,6 +993,7 @@
   transform-origin: 120px 124px;
   animation-name: luke-shimmy-1;
   animation-duration: 2.6s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 /* dizzy — woozy after a flight (decaying wobble) */
@@ -1108,37 +1001,30 @@
 @keyframes luke-dizzy-1 {
   0% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   10% {
     transform: rotate(9deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   24% {
     transform: rotate(-8deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   38% {
     transform: rotate(6deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   52% {
     transform: rotate(-4deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   66% {
     transform: rotate(2deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   78% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -1149,37 +1035,30 @@
 @keyframes luke-dizzy-2 {
   0% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   10% {
     transform: translate(2px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   24% {
     transform: translate(-2px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   38% {
     transform: translate(1.5px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   52% {
     transform: translate(-1px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   66% {
     transform: translate(0.5px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   78% {
     transform: translate(0px, 0px);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -1190,22 +1069,18 @@
 @keyframes luke-dizzy-eyes {
   0% {
     transform: scaleY(1);
-    animation-timing-function: linear;
   }
 
   15% {
     transform: scaleY(0.55);
-    animation-timing-function: linear;
   }
 
   55% {
     transform: scaleY(0.55);
-    animation-timing-function: linear;
   }
 
   75% {
     transform: scaleY(1);
-    animation-timing-function: linear;
   }
 
   100% {
@@ -1217,11 +1092,13 @@
   transform-origin: 120px 150px;
   animation-name: luke-dizzy-1;
   animation-duration: 3.2s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 .luke-face[data-motion="dizzy"] .luke-face-layer-2 {
   animation-name: luke-dizzy-2;
   animation-duration: 3.2s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 .luke-face[data-motion="dizzy"] .luke-face-eye {
@@ -1234,37 +1111,30 @@
 @keyframes luke-glance-1 {
   0% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   12% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   24% {
     transform: rotate(-7deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   42% {
     transform: rotate(-7deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   56% {
     transform: rotate(7deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   74% {
     transform: rotate(7deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   86% {
     transform: rotate(0deg);
-    animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
   }
 
   100% {
@@ -1276,6 +1146,7 @@
   transform-origin: 120px 190px;
   animation-name: luke-glance-1;
   animation-duration: 3.4s;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
 }
 
 /* The z's share one loop, each rising through its own window of it so they
@@ -1287,18 +1158,15 @@
   0% {
     opacity: 0;
     transform: translate(0, 0);
-    animation-timing-function: linear;
   }
 
   30% {
     opacity: 0.85;
-    animation-timing-function: linear;
   }
 
   60% {
     opacity: 0;
     transform: translate(6px, -16px);
-    animation-timing-function: linear;
   }
 
   100% {
@@ -1311,18 +1179,15 @@
   0% {
     opacity: 0;
     transform: translate(0, 0);
-    animation-timing-function: linear;
   }
 
   40% {
     opacity: 0;
     transform: translate(0, 0);
-    animation-timing-function: linear;
   }
 
   70% {
     opacity: 0.85;
-    animation-timing-function: linear;
   }
 
   100% {
@@ -1335,24 +1200,20 @@
   0% {
     opacity: 0;
     transform: translate(0, 0);
-    animation-timing-function: linear;
   }
 
   20% {
     opacity: 0;
     transform: translate(0, 0);
-    animation-timing-function: linear;
   }
 
   50% {
     opacity: 0.85;
-    animation-timing-function: linear;
   }
 
   80% {
     opacity: 0;
     transform: translate(6px, -16px);
-    animation-timing-function: linear;
   }
 
   100% {

--- a/apps/desktop/tests/luke-face-mood.test.ts
+++ b/apps/desktop/tests/luke-face-mood.test.ts
@@ -112,23 +112,29 @@ test("only what stays true for as long as it holds may hold the face", () => {
   }
 });
 
+/**
+ * Every motion that says something about the world: the three rests, the three
+ * moments, and the sway that means work. Nothing fired by a mere timer or a
+ * passing hand may play one, or the face is lying about the sessions.
+ */
+const SPOKEN = [
+  FACE_MOTION.TALKING,
+  FACE_MOTION.LISTENING,
+  FACE_MOTION.SLEEPING,
+  FACE_MOTION.WAITING,
+  FACE_MOTION.SUCCESS,
+  FACE_MOTION.NOTIFICATION,
+  FACE_MOTION.MONITORING,
+];
+
 test("a gesture says nothing a rest or a moment already says", () => {
   // A gesture arrives because a timer fired, so one that carried meaning would
   // be a lie: Luke must not look like a session just started asking, finished,
   // or turned up, and he must not look like he is listening to a closed
   // microphone. The sway is the exception that proves the rule — it means work
   // is happening, so it is only offered while work is happening.
-  const spoken = [
-    FACE_MOTION.TALKING,
-    FACE_MOTION.LISTENING,
-    FACE_MOTION.SLEEPING,
-    FACE_MOTION.WAITING,
-    FACE_MOTION.SUCCESS,
-    FACE_MOTION.NOTIFICATION,
-    FACE_MOTION.MONITORING,
-  ];
   for (const aside of asidePool(false)) {
-    assert.ok(!spoken.includes(aside.motion), `${aside.motion} carries meaning and cannot be idle`);
+    assert.ok(!SPOKEN.includes(aside.motion), `${aside.motion} carries meaning and cannot be idle`);
   }
   const working = asidePool(true).map((aside) => aside.motion);
   assert.ok(working.includes(FACE_MOTION.MONITORING));
@@ -185,18 +191,9 @@ test("a moment is sampled by weight, and the smallest gesture is most of the poo
 test("a hover earns a trick, and the trick says nothing about the sessions", () => {
   // A hand crosses the strip whenever it likes, so nothing a hover plays may
   // mean anything — not a rest, not a moment, not the sway that means work.
-  const spoken = [
-    FACE_MOTION.TALKING,
-    FACE_MOTION.LISTENING,
-    FACE_MOTION.SLEEPING,
-    FACE_MOTION.WAITING,
-    FACE_MOTION.SUCCESS,
-    FACE_MOTION.NOTIFICATION,
-    FACE_MOTION.MONITORING,
-  ];
   for (const aside of HOVER_ASIDES) {
     assert.ok(
-      !spoken.includes(aside.motion),
+      !SPOKEN.includes(aside.motion),
       `${aside.motion} carries meaning and cannot be hover`,
     );
     assert.ok(aside.weight > 0, `${aside.motion} can never be chosen`);

--- a/design/generate-brand-assets.mjs
+++ b/design/generate-brand-assets.mjs
@@ -646,8 +646,10 @@ const MOTIONS = {
 };
 
 const MOTION_NAMES = Object.keys(MOTIONS);
-const layerSplines = (layer) => layer.splines ?? Array(layer.values.length - 1).fill(EASE);
-const partSplines = (part) => Array(part.values.length - 1).fill(EASE);
+// Per-interval easing for anything with `values`: its own splines, or the
+// default ease on every interval. Eyes are the exception — they animate with
+// no splines at all, which SMIL and CSS both read as linear.
+const motionSplines = (part) => part.splines ?? Array(part.values.length - 1).fill(EASE);
 /** The longest loop in a motion: how long a caller must wait to see all of it. */
 function motionCycleMs(motion) {
   const durations = [
@@ -681,7 +683,7 @@ function svgBrows(motion) {
     brow(c1) + brow(c2),
     animT("translate", values.map((pair) => pair.join(" ")).join(";"), dur, {
       keyTimes: keyTimes.join(";"),
-      spline: partSplines(motion.brows).join(";"),
+      spline: motionSplines(motion.brows).join(";"),
     }),
   );
 }
@@ -695,7 +697,7 @@ function motionSvg(motion) {
     }
     const opts = {
       keyTimes: layer.keyTimes ? layer.keyTimes.join(";") : undefined,
-      spline: layerSplines(layer).join(";"),
+      spline: motionSplines(layer).join(";"),
     };
     if (layer.type === "scale") {
       body = scaleAbout(
@@ -719,86 +721,95 @@ function motionSvg(motion) {
 // ---------- Motions as CSS ----------
 // The app cannot use the SMIL above: it needs the renderer's `--face-motion`
 // token to be able to stop every loop at once, which only CSS animation offers.
-// Each layer, each eye, and each brow becomes one @keyframes, and the interval
-// easings become per-keyframe timing functions, which is the only way CSS can
-// express a keySplines list.
+// Each layer, each eye, and each brow becomes one @keyframes and one rule that
+// names it. A part that eases every interval with one curve carries it on the
+// rule; only mixed curves become per-keyframe timing functions, which is the
+// only way CSS can express a keySplines list. No curve at all is linear, which
+// the wiring in base.css already says.
 const cssTime = (fraction) => `${+(fraction * 100).toFixed(4)}%`;
 
-function cssKeyframes(name, steps, splines) {
+// How each transform a part can play is written. Eye factors are scalars: a
+// widen scales the whole eye and everything else squeezes it vertically.
+const TRANSFORM_CSS = {
+  rotate: (angle) => `rotate(${angle}deg)`,
+  scale: ([x, y]) => `scale(${x}, ${y})`,
+  translate: ([x, y]) => `translate(${x}px, ${y}px)`,
+};
+
+const evenTimes = (count) => Array.from({ length: count }, (_, index) => index / (count - 1));
+
+function cssKeyframes(name, steps, easings = []) {
   const blocks = steps.map(({ at, declaration }, index) => {
-    const easing =
-      index < steps.length - 1
-        ? `\n    animation-timing-function: ${splines[index] ? bezier(splines[index]) : "linear"};`
-        : "";
+    const easing = easings[index] ? `\n    animation-timing-function: ${easings[index]};` : "";
     return `  ${cssTime(at)} {\n    ${declaration}${easing}\n  }`;
   });
   return `@keyframes ${name} {\n${blocks.join("\n\n")}\n}`;
 }
 
-const evenTimes = (count) => Array.from({ length: count }, (_, index) => index / (count - 1));
+const originCss = (pivot) =>
+  pivot ? `\n  transform-origin: ${pivot.map((n) => `${n}px`).join(" ")};` : "";
 
-function layerSteps(layer) {
-  const times = layer.keyTimes ?? evenTimes(layer.values.length);
-  return layer.values.map((value, index) => ({
+// One moving part: its @keyframes, and the rule that plays them on `target`.
+// `splines` is per-interval SMIL easing, or undefined for a part with none.
+function partCss({ target, name, part, transform, splines, pivot }) {
+  const times = part.keyTimes ?? evenTimes(part.values.length);
+  const steps = part.values.map((value, index) => ({
     at: times[index],
-    declaration:
-      layer.type === "rotate"
-        ? `transform: rotate(${value}deg);`
-        : layer.type === "scale"
-          ? `transform: scale(${value[0]}, ${value[1]});`
-          : `transform: translate(${value[0]}px, ${value[1]}px);`,
+    declaration: `transform: ${transform(value)};`,
   }));
+  const uniform = splines === undefined || splines.every((spline) => spline === splines[0]);
+  const block = cssKeyframes(name, steps, uniform ? [] : splines.map(bezier));
+  const easing = uniform && splines ? `\n  animation-timing-function: ${bezier(splines[0])};` : "";
+  const rule = `${target} {${originCss(pivot)}\n  animation-name: ${name};\n  animation-duration: ${part.dur}s;${easing}\n}`;
+  return { block, rule };
 }
 
 function motionCss(name, motion) {
   const selector = `.luke-face[data-motion="${name}"]`;
   const blocks = [];
   const rules = [];
+  const emit = (part) => {
+    const { block, rule } = partCss(part);
+    blocks.push(block);
+    rules.push(rule);
+  };
 
   motion.layers.forEach((layer, index) => {
     const target = `${selector} .luke-face-layer-${index + 1}`;
-    const origin =
-      layer.type === "translate"
-        ? ""
-        : `\n  transform-origin: ${(layer.pivot ?? [120, 124]).map((n) => `${n}px`).join(" ")};`;
+    const pivot = layer.type === "translate" ? undefined : (layer.pivot ?? [120, 124]);
     if (layer.hold !== undefined) {
-      rules.push(`${target} {${origin}\n  transform: rotate(${layer.hold}deg);\n}`);
+      rules.push(`${target} {${originCss(pivot)}\n  transform: rotate(${layer.hold}deg);\n}`);
       return;
     }
-    const animation = `luke-${name}-${index + 1}`;
-    blocks.push(cssKeyframes(animation, layerSteps(layer), layerSplines(layer)));
-    rules.push(
-      `${target} {${origin}\n  animation-name: ${animation};\n  animation-duration: ${layer.dur}s;\n}`,
-    );
+    emit({
+      target,
+      name: `luke-${name}-${index + 1}`,
+      part: layer,
+      transform: TRANSFORM_CSS[layer.type],
+      splines: motionSplines(layer),
+      pivot,
+    });
   });
 
   const eyes = motion.eyes;
   if (eyes && eyes.kind !== "lids") {
-    const animation = `luke-${name}-eyes`;
-    const steps = eyes.factors.map((factor, index) => ({
-      at: eyes.keyTimes[index],
-      declaration:
-        eyes.kind === "widen" ? `transform: scale(${factor});` : `transform: scaleY(${factor});`,
-    }));
-    // No keySplines on the SVG's eye animations, so every interval is linear.
-    blocks.push(cssKeyframes(animation, steps, []));
-    // The wink closes one eye; every other motion moves both.
-    const target = eyes.kind === "wink" ? ".luke-face-eye-right" : ".luke-face-eye";
-    rules.push(
-      `${selector} ${target} {\n  animation-name: ${animation};\n  animation-duration: ${eyes.dur}s;\n}`,
-    );
+    emit({
+      // The wink closes one eye; every other motion moves both.
+      target: `${selector} ${eyes.kind === "wink" ? ".luke-face-eye-right" : ".luke-face-eye"}`,
+      name: `luke-${name}-eyes`,
+      part: { values: eyes.factors, keyTimes: eyes.keyTimes, dur: eyes.dur },
+      transform: (factor) => (eyes.kind === "widen" ? `scale(${factor})` : `scaleY(${factor})`),
+    });
   }
 
   if (motion.brows) {
-    const animation = `luke-${name}-brows`;
-    const steps = motion.brows.values.map((pair, index) => ({
-      at: motion.brows.keyTimes[index],
-      declaration: `transform: translate(${pair[0]}px, ${pair[1]}px);`,
-    }));
-    blocks.push(cssKeyframes(animation, steps, partSplines(motion.brows)));
-    rules.push(
-      `${selector} .luke-face-brows {\n  animation-name: ${animation};\n  animation-duration: ${motion.brows.dur}s;\n}`,
-    );
+    emit({
+      target: `${selector} .luke-face-brows`,
+      name: `luke-${name}-brows`,
+      part: motion.brows,
+      transform: TRANSFORM_CSS.translate,
+      splines: motionSplines(motion.brows),
+    });
   }
 
   return [`/* ${name} — ${motion.moment} */`, ...blocks, ...rules].join("\n\n");
@@ -816,7 +827,7 @@ function faceMotionCss() {
       { at: end, declaration: drifted },
       ...(end < 1 ? [{ at: 1, declaration: drifted }] : []),
     ];
-    return cssKeyframes(`luke-sleep-z-${index + 1}`, steps, []);
+    return cssKeyframes(`luke-sleep-z-${index + 1}`, steps);
   });
   const zRules = [
     `.luke-face-z {\n  animation-duration: ${SLEEP_Z_DURATION}s;\n}`,


### PR DESCRIPTION
## What

The face's animation code had grown a copy of the same emission logic per part and a lot of repeated wiring. This condenses it — net −148 lines — with no change to what renders:

- **`design/generate-brand-assets.mjs`**: one `partCss` helper now emits every moving part's `@keyframes` + rule (layers, eyes, and brows each had a near-copy), with a shared `TRANSFORM_CSS` declaration map, and the duplicate `layerSplines`/`partSplines` helpers merged into one `motionSplines`.
- **Generated `face-motion.css`**: a part that eases every interval with one curve (almost all of them) now carries `animation-timing-function` once on its rule instead of inside every keyframe; only the mixed-curve motions (refresh, flyoff) keep per-keyframe easing. 1378 → 1239 lines.
- **`luke-face.tsx`**: the hand-written left/right pairs of lids, eyes, and brows are mapped over a `SIDES` table, the five repeated stroke-attribute blocks share one `STROKE` bundle, and every moving part wears one `luke-face-part` class.
- **`base.css`**: that class collapses the two four-selector wiring groups to one selector each — a future moving part joins the play/pause/repeat wiring by wearing the class.
- **`luke-face-mood.test.ts`**: the twice-written "motions that carry meaning" list is one `SPOKEN` constant.

Deliberately untouched: the `MOTIONS` table (authored data — explicitness is the point), the SMIL helpers (merging risked drifting the committed brand SVGs for a 3-line gain), and the mood hook's gesture-start sites (factoring would add hook ceremony, not remove code).

## Proof of no behavior change

- The brand SVGs and `luke-face-art.ts` regenerate **byte-identical**; only the CSS changed shape.
- Old and new `face-motion.css` parsed and compared semantically: every keyframe's transforms and every interval's *effective* easing (per-keyframe, else rule, else the linear default) match across all 37 keyframes and 39 rules.
- Headless Chrome against the built stylesheet: 11/11 computed-style assertions — rests repeat, gestures play once, the hoisted easing reaches the layers, the wink closes only the right eye, and `--face-motion` still pauses every part.
- `./scripts/check.sh` passes end to end (generator `--check` drift guards, Biome, typecheck, 283 tests, builds).

No visual change is intended, so there is no new visual evidence; a physical-notch check was not performed (authored in a Linux sandbox — the motion is proven equivalent rather than eyeballed, per DESIGN.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/185fba51-a5c3-4276-a37c-3d7bf01c6351)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32076313595/artifacts/9303582184) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32076313595)

- Commit: `96ed868e7684ae5f90526fd2eb35b68ffe6272af`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
