### PR TITLE
fix(web): restore hosted functions broken by an extensionless core import

### DIFF
--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -19,7 +19,7 @@ export {
 } from "./json.js";
 
 // App updates — naming a newer published release than the running build.
-export { isNewerVersion, parseReleaseVersion } from "./app-update";
+export { isNewerVersion, parseReleaseVersion } from "./app-update.js";
 
 // Sessions — observed state, identity, and the registry that holds them.
 export {

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -62,4 +62,19 @@ node "$SIDECAR_REPO_ROOT/design/generate-brand-assets.mjs" --check
 # source, four committed outputs in sidecar-core; --check fails if any drifted.
 node "$SIDECAR_REPO_ROOT/design/generate-surface-shared.mjs" --check
 
+# Every relative import inside sidecar-core must carry its .js extension.
+# Vercel's builder compiles the package's TypeScript into the web functions
+# but leaves the specifiers alone, and Node's ESM loader refuses an
+# extensionless one at run time — a break the build cannot see, which has
+# twice reached production as FUNCTION_INVOCATION_FAILED (#202, and again
+# with app-update). The desktop's esbuild and the web's Vite both accept the
+# .js form, so the stricter spelling costs the other consumers nothing.
+extensionless_imports=$(grep -rEn 'from "\.\.?/[^"]*"' "$SIDECAR_REPO_ROOT/packages/sidecar-core/src" |
+    grep -vE '\.(js|css)"' || true)
+if [[ -n "$extensionless_imports" ]]; then
+    printf 'error: sidecar-core relative imports must end in .js (Node ESM cannot load them compiled otherwise):\n%s\n' \
+        "$extensionless_imports" >&2
+    exit 1
+fi
+
 printf 'Repository contract checks passed.\n'


### PR DESCRIPTION
## What broke

Both hosted endpoints have answered `FUNCTION_INVOCATION_FAILED` (500 to clients) on every request since #186 deployed — the desktop's hosted voice and attention review get 500s, which is how it surfaced in a live `run.sh` session. Auth, feedback, and the site are unaffected.

## Why

#186 exported `./app-update` from sidecar-core's index without the `.js` extension. Vercel's builder compiles the package's TypeScript into the function bundles but leaves import specifiers alone, and Node's ESM loader refuses extensionless relative imports at run time — the same failure class as #202, invisible to CI because the build succeeds and only the lambda's first request dies. Reproduced offline by running `vercel build` against main and importing the compiled function entries.

## Fix and the guard

- `./app-update` → `./app-update.js` (one line).
- `repository-checks.sh` now refuses any extensionless relative import inside `packages/sidecar-core/src`, with a comment explaining the Vercel/Node mechanics — so the third recurrence fails in CI, not in production. Verified the guard catches exactly main's current line when pointed at it.
- Both functions rebuilt with Vercel's own builder offline and load-tested under Node: `LOADED OK`.

`./scripts/check.sh` passes (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/343d02ab-bf79-4850-a697-40e44a08ac75)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32076474018/artifacts/9303632954) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32076474018)

- Commit: `c5aec1ca770592bbac2eafd6efe75086e0a0e7ac`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
