### PR TITLE
fix(voice): answer whole-picture questions across every session

### DIFF
--- a/packages/sidecar-core/src/realtime-protocol.ts
+++ b/packages/sidecar-core/src/realtime-protocol.ts
@@ -137,6 +137,7 @@ const REALTIME_INSTRUCTION_HEAD: readonly string[] = [
   "- The developer is working, not reading: be extremely brief. One short sentence by default, two at most, under twenty-five words.",
   "- Start with the answer. No greetings, no filler, no restating the question, no closing offers of help.",
   '- Answer only the question asked; if there is more to say, ask "want more?" instead of saying it.',
+  '- A question about the work as a whole — "what are we working on?", "how is everything going?" — is about every observed session: answer across the roster, never by asking which session or workspace they mean.',
   "- Name the provider and the workspace when you refer to a session, so it is unambiguous out loud.",
   "- Leave out identifiers no one says aloud — commit hashes, session ids, and the like. Name work by its title, workspace, or branch instead.",
   "- When you do not know something, say so in one sentence rather than guessing or hedging.",

--- a/packages/sidecar-core/tests/realtime.test.ts
+++ b/packages/sidecar-core/tests/realtime.test.ts
@@ -226,6 +226,9 @@ test("the spoken instructions state what Luke cannot see, and when he may act", 
   assert.match(instructions, /speaks to you or types to you/i);
   // Spoken references stay human: a hash or an id is noise read aloud.
   assert.match(instructions, /identifiers no one says aloud/i);
+  // A broad "what are we working on?" spans the roster: Luke answers across
+  // every observed session rather than asking the developer to pick one.
+  assert.match(instructions, /about every observed session/i);
   // A bare "that chat" has a stated resolution order — this conversation's own
   // most recent mention, then the session under discussion — so the reference
   // is followed rather than guessed at.


### PR DESCRIPTION
## Summary

Asking Luke "what are we working on?" made him ask which workspace was meant, because the standing voice instructions push toward disambiguation and never say a whole-picture question is legitimately about everything.

- Add one line to the "How to speak" section of the standing instructions: a question about the work as a whole — "what are we working on?", "how is everything going?" — is about every observed session, answered across the roster rather than by asking which session or workspace is meant.
- Pin the line in the existing instructions test so it cannot silently disappear.

The disambiguation rules are untouched: Luke still asks which chat you mean when asked to act (message, open, control) on a genuinely unclear target.

## Validation

- `./scripts/check.sh` passes (repository contracts, lint, typecheck, all tests, build). Portable-only change; no UI or macOS surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/aa6a107f-0d63-41da-9e82-f19ff73a1d02)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32076615392/artifacts/9303679918) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32076615392)

- Commit: `1fc85d92d2ef4ac77769d56f1537dac6ea3cc9a3`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
