### PR TITLE
fix(voice): settle a captioned reply's sub-line overflow at once

### DIFF
--- a/apps/desktop/src/renderer/caption-reading.ts
+++ b/apps/desktop/src/renderer/caption-reading.ts
@@ -34,8 +34,17 @@ export const CAPTION_LINE_READ_MS = 3_000;
  * the second an interval later — so the line at the top leaves exactly when
  * its turn has passed, and the newest words wait their turn below the clip
  * instead of shoving the unread ones off the screen.
+ *
+ * The clock paces lines, so only whole lines wait on it. The volume hint's
+ * row is not a whole number of lines, so a block it shares can overflow by
+ * less than one — a remainder that is spacing, not words: it tucks the text
+ * up into the block's own top padding and hides nothing. It settles at once,
+ * because words that shift after they were readable read as a stutter, not
+ * as a line leaving.
  */
 export function pacedCaptionScroll(overflowPx: number, elapsedMs: number): number {
+  const overflow = Math.max(0, overflowPx);
+  const remainder = overflow % CAPTION_LINE_HEIGHT;
   const readLines = Math.floor(Math.max(0, elapsedMs) / CAPTION_LINE_READ_MS);
-  return Math.min(Math.max(0, overflowPx), readLines * CAPTION_LINE_HEIGHT);
+  return Math.min(overflow, remainder + readLines * CAPTION_LINE_HEIGHT);
 }

--- a/apps/desktop/tests/caption-reading.test.ts
+++ b/apps/desktop/tests/caption-reading.test.ts
@@ -19,6 +19,21 @@ test("a silent caption scrolls one line per reading interval", () => {
   assert.equal(pacedCaptionScroll(FOUR_LINES, CAPTION_LINE_READ_MS * 3), CAPTION_LINE_HEIGHT * 3);
 });
 
+test("a sub-line remainder settles at once instead of waiting on the clock", () => {
+  // The volume hint's row is not a whole number of lines, so a block it
+  // shares overflows by spacing before it overflows by words — three lines
+  // beside the hint leave 8px too little room. That tuck hides nothing, so
+  // it must not appear as a delayed shift once the words are already up.
+  const remainder = 8;
+  assert.equal(pacedCaptionScroll(remainder, 0), remainder);
+  // The whole lines above a remainder still wait their reading turns.
+  assert.equal(pacedCaptionScroll(FOUR_LINES + remainder, 0), remainder);
+  assert.equal(
+    pacedCaptionScroll(FOUR_LINES + remainder, CAPTION_LINE_READ_MS),
+    CAPTION_LINE_HEIGHT + remainder,
+  );
+});
+
 test("the reading pace never scrolls past the overflow the block has", () => {
   // The clock keeps counting after the last line has scrolled into place; the
   // scroll must not follow it off the end of the text.


### PR DESCRIPTION
## Why

With captions up and the volume hint ("Unmute your Mac to hear Luke") drawn, a three-line reply appeared and then visibly shifted up about three seconds later — even though all three lines fit fine in the shifted position, which is also the position that looks right.

## What was happening

The caption block reserves `--caption-max` (70px); minus its 14px of padding, the words' budget is 56px — exactly four 14px lines, so overflow is normally a whole number of lines and the reading clock (`pacedCaptionScroll`) releases one line per interval. The volume hint's 22px row is **not** a whole number of lines, so a block it shares can overflow by a sub-line remainder: 8px for a three-line reply. That remainder is spacing, not words — it tucks the text up into the block's own 5px top padding plus the first line box's leading, hiding nothing — yet it sat on the reading clock like a line, releasing only after the first 3-second interval. That release was the delayed shift.

## The fix

`pacedCaptionScroll` now settles the sub-line remainder immediately and keeps only whole lines on the clock. The words sit in their settled position from the first frame — including when the hint arrives mid-reply, where the 8px tuck now rides in with the hint's own entrance — and unread lines still wait their full reading turns before scrolling away.

## Validation

- `./scripts/check.sh` passes (exit 0); `caption-reading.test.ts` grew a case for the remainder settling at once while whole lines above it still wait their turns.
- Renderer behavior change, so `./scripts/verify.sh` needs a macOS run — relying on the CI macOS job for the packaged validation and linked visual evidence. No physical-notch check was performed (change authored in a Linux cloud workspace); the motion in question is time-based, so the still evidence shows the muted-profile layout rather than the shift itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/e3d2ab02-1fea-432c-9497-d21328d4edab)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32080260893/artifacts/9304892981) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32080260893)

- Commit: `fa9a893e07032710a2f3a4d4a230d6ac2d5e94d6`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
