### PR TITLE
feat(voice): put today's included allowance in front of the user, and let them choose what it runs on

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -281,11 +281,23 @@ microphone on its own.
 
 ## Optional spoken conversation
 
-Voice runs one of two ways. Signed in with no OpenAI key of your own, calls
-open through the hosted service described above, under its daily allowance.
-With a key connected, everything below runs on that key directly against
-OpenAI, and Luke's service sees none of it. The key is connected by hand in
-Settings, under Account and usage at the top of its front page — alone among
+Voice runs one of two ways, and which one is yours to choose. Running on your
+Luke account, calls open through the hosted service described above, under its
+daily allowance. Running on an OpenAI key of your own, everything below runs on
+that key directly against OpenAI, and Luke's service sees none of it. The
+choice is the two-way toggle under What Luke runs on, at the top of the
+Settings tab's front page: with no key stored the account is the only source
+there is, connecting a key chooses it, and choosing the account again parks a
+stored key without deleting it — so trying your own key does not cost you the
+free allowance, and returning to the allowance does not cost you the key.
+
+The choice can only ever move spending away from your key, never onto it. A
+key that is stored but not chosen is not read at all, and if the account it was
+parked in favour of stops being able to answer — you sign out — the stored key
+is what is left rather than voice going off. Nothing else falls back: a chosen
+account with no key behind it simply has no key to fall back to.
+
+The key is connected by hand in the same section — alone among
 Luke's credentials it is never read from the environment, because an
 `OPENAI_API_KEY` exported for some other tool must not silently start being
 spent on voice or move the review path. A stored key is held encrypted through

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -284,10 +284,12 @@ microphone on its own.
 Voice runs one of two ways. Signed in with no OpenAI key of your own, calls
 open through the hosted service described above, under its daily allowance.
 With a key connected, everything below runs on that key directly against
-OpenAI, and Luke's service sees none of it. The key can be connected in
-Settings, at the top of the Voice page, or read from `OPENAI_API_KEY` in the
-environment when nothing is stored; a stored key is held encrypted through the
-macOS Keychain, is never sent to the panel, and can be deleted in the same
+OpenAI, and Luke's service sees none of it. The key is connected by hand in
+Settings, under Account and usage at the top of its front page — alone among
+Luke's credentials it is never read from the environment, because an
+`OPENAI_API_KEY` exported for some other tool must not silently start being
+spent on voice or move the review path. A stored key is held encrypted through
+the macOS Keychain, is never sent to the panel, and can be deleted in the same
 place it was entered. Deleting it returns voice to the hosted path while you
 are signed in, and turns voice off entirely otherwise — along with the
 attention review described below, which follows the same two paths.
@@ -382,9 +384,8 @@ bounded fields listed below go to Luke's review endpoint instead, as the
 Hosted voice and review section describes, and the service forwards them to
 OpenAI under Luke's key with the same fixed instructions.
 
-With a key of your own — the same key the spoken conversation uses, from
-either place it can come from — Luke sends the configured Responses-compatible
-endpoint
+With a key of your own — the same stored key the spoken conversation uses —
+Luke sends the configured Responses-compatible endpoint
 the provider name, displayed session title, the name of the workspace a chat
 belongs to where its provider groups them, previous and current status, review
 trigger, repository, branch, current tool activity, reported error, and the

--- a/apps/desktop/src/hosted-usage.ts
+++ b/apps/desktop/src/hosted-usage.ts
@@ -1,0 +1,87 @@
+import {
+  HOSTED_SERVICE_PATH,
+  type HostedUsageAnswer,
+  hostedUsageAnswerFromWire,
+  positiveInteger,
+  text,
+} from "@sidecar/core";
+
+const HOSTED_DEFAULTS = {
+  REQUEST_TIMEOUT_MS: 10_000,
+} as const;
+
+const UNAUTHORIZED_STATUS = 401;
+
+type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
+
+export interface HostedUsageReaderOptions {
+  /** The hosted service origin, without a trailing slash. */
+  serviceBaseUrl: string;
+  readAccessToken: () => Promise<string | undefined>;
+  refreshAccount: () => Promise<void>;
+  fetch?: FetchLike;
+  requestTimeoutMs?: number;
+}
+
+function withoutTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+/**
+ * Reads where today's hosted allowance stands, spending nothing: the one ask
+ * that lets the Voice page show what remains before the first call of the day
+ * rather than only after one has answered. The shape follows the hosted mint —
+ * token read fresh per ask, a 401 refreshed and retried once — and a failure
+ * resolves to nothing, leaving the page's wording to the allowance sentence
+ * that promises no numbers.
+ */
+export class HostedUsageReader {
+  readonly #endpoint: string;
+  readonly #readAccessToken: () => Promise<string | undefined>;
+  readonly #refreshAccount: () => Promise<void>;
+  readonly #fetch: FetchLike;
+  readonly #requestTimeoutMs: number;
+
+  constructor(options: HostedUsageReaderOptions) {
+    const baseUrl = text(options.serviceBaseUrl);
+    if (!baseUrl) throw new Error("Hosted service base URL must not be empty");
+    this.#endpoint = `${withoutTrailingSlash(baseUrl)}${HOSTED_SERVICE_PATH.USAGE}`;
+    this.#readAccessToken = options.readAccessToken;
+    this.#refreshAccount = options.refreshAccount;
+    this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
+    this.#requestTimeoutMs = positiveInteger(
+      options.requestTimeoutMs,
+      HOSTED_DEFAULTS.REQUEST_TIMEOUT_MS,
+    );
+  }
+
+  async read(): Promise<HostedUsageAnswer | undefined> {
+    const token = await this.#readAccessToken();
+    if (!token) return undefined;
+
+    let response = await this.#request(token);
+    if (response?.status === UNAUTHORIZED_STATUS) {
+      await this.#refreshAccount().catch(() => undefined);
+      const refreshed = await this.#readAccessToken();
+      if (refreshed && refreshed !== token) {
+        response = await this.#request(refreshed);
+      }
+    }
+    if (!response?.ok) return undefined;
+
+    const payload: unknown = await response.json().catch(() => undefined);
+    return payload === undefined ? undefined : hostedUsageAnswerFromWire(payload);
+  }
+
+  async #request(token: string): Promise<Response | undefined> {
+    try {
+      return await this.#fetch(this.#endpoint, {
+        method: "GET",
+        headers: { authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(this.#requestTimeoutMs),
+      });
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -925,13 +925,13 @@ async function applyVoiceCredential(): Promise<void> {
   // asking for. That is also why the report says no key resolved — for this run,
   // none did.
   // Which of the two the store resolved — the user's choice where it can be
-  // honoured — decides whether the key is read at all. Asked before the read
-  // for the reason above: a run that would not use the key has no business
-  // decrypting it, and a developer parked on the free allowance is such a run.
-  const runsOnKey =
-    runMode.sendsNetwork && (await settingsStore.readVoiceSource()) === VOICE_SOURCE.KEY;
+  // honoured — decides whether the key is read at all, and it is asked last of
+  // the three for the reason above: every gate a run can fail is checked
+  // before anything reaches the Keychain.
   const apiKey =
-    runsOnKey && accountCapabilitiesActive()
+    runMode.sendsNetwork &&
+    accountCapabilitiesActive() &&
+    (await settingsStore.readVoiceSource()) === VOICE_SOURCE.KEY
       ? await settingsStore.readApiKey(VOICE_CREDENTIAL_PROVIDER_ID)
       : undefined;
   // The hosted service stands in exactly where a key could have: a run that

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -143,6 +143,7 @@ import {
   type AppBootstrap,
   channels,
   isSettingsResetScope,
+  isVoiceSource,
   type MicrophoneRoute,
   type MicrophoneStatus,
   type ObservedAccountCalendars,
@@ -152,6 +153,7 @@ import {
   SETTINGS_RESET_SCOPE,
   type SessionOpenResult,
   type SessionTranscriptResult,
+  VOICE_SOURCE,
 } from "./shared/contracts";
 import {
   CREDENTIAL_PROVIDER_ID,
@@ -922,14 +924,20 @@ async function applyVoiceCredential(): Promise<void> {
   // Keychain decrypt, which a run that would refuse to use it has no business
   // asking for. That is also why the report says no key resolved — for this run,
   // none did.
+  // Which of the two the store resolved — the user's choice where it can be
+  // honoured — decides whether the key is read at all. Asked before the read
+  // for the reason above: a run that would not use the key has no business
+  // decrypting it, and a developer parked on the free allowance is such a run.
+  const runsOnKey =
+    runMode.sendsNetwork && (await settingsStore.readVoiceSource()) === VOICE_SOURCE.KEY;
   const apiKey =
-    runMode.sendsNetwork && accountCapabilitiesActive()
+    runsOnKey && accountCapabilitiesActive()
       ? await settingsStore.readApiKey(VOICE_CREDENTIAL_PROVIDER_ID)
       : undefined;
   // The hosted service stands in exactly where a key could have: a run that
-  // sends network traffic, signed in, with no key of the developer's own. The
-  // developer's key wins when both are present — it is unmetered, and it keeps
-  // voice and review off Luke's servers entirely.
+  // sends network traffic, signed in, and not running on a key of the
+  // developer's own — because none is stored, or because they chose the
+  // allowance over the one that is.
   const hosted =
     apiKey === undefined && runMode.sendsNetwork && account.status === ACCOUNT_STATUS.SIGNED_IN;
   const evaluator = apiKey
@@ -1498,6 +1506,21 @@ function registerIpc(): void {
     },
     save: (enabled) => settingsStore.setDuckOtherMedia(enabled),
     apply: (result) => mediaDuck.setEnabled(result.settings.duckOtherMedia),
+    refusal: "Could not save that setting on this system.",
+  });
+
+  // Which credential Luke runs on, rebuilt at once rather than at the next
+  // launch: the whole point of the choice is that the next thing said runs on
+  // what was just chosen. The rebuild is the same one a key being saved or
+  // deleted triggers, so the minter, the reviewer, and the usage reader can
+  // never be left built for the source that was just switched away from.
+  registerSettingHandler(channels.setVoiceSource, {
+    validate(source: unknown) {
+      if (!isVoiceSource(source)) throw new Error("Invalid voice source request");
+      return source;
+    },
+    save: (source) => settingsStore.setVoiceSource(source),
+    apply: () => void applyVoiceCredential(),
     refusal: "Could not save that setting on this system.",
   });
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -114,6 +114,7 @@ import { GoogleCalendarReader } from "./google-calendar";
 import { GoogleCalendarSignIn } from "./google-calendar-oauth";
 import { HostedAttentionEvaluator } from "./hosted-attention-evaluator";
 import { HostedRealtimeCredentialMinter } from "./hosted-realtime-credentials";
+import { HostedUsageReader } from "./hosted-usage";
 import { HOTKEY_RANK, HotkeyRegistrar } from "./hotkey-registrar";
 import { JulesSessionAdapter } from "./jules-adapter";
 import { LinearIssueTracker } from "./linear-tracker";
@@ -408,6 +409,8 @@ let voiceUnavailableDiagnostics = unavailableRealtimeDiagnostics({
   fixtureMode: !runMode.sendsNetwork,
   apiKeyConfigured: false,
 });
+/** Reads the hosted allowance; exists exactly while the hosted minter does. */
+let hostedUsageReader: HostedUsageReader | undefined;
 // Quiets Music and Spotify while a spoken exchange is live. It lives here
 // rather than in the renderer because letting the players back up must survive
 // anything the renderer does — and only this process may run a helper.
@@ -966,6 +969,7 @@ async function applyVoiceCredential(): Promise<void> {
     fixtureMode: !runMode.sendsNetwork,
     apiKeyConfigured: apiKey !== undefined,
   });
+  hostedUsageReader = hosted ? new HostedUsageReader(hostedServiceSeams()) : undefined;
   // Warm only when the next press would actually mint through the service.
   if (hosted) warmHostedVoice();
   reportVoiceAvailability(apiKey !== undefined);
@@ -2296,6 +2300,13 @@ function registerIpc(): void {
   ipcMain.handle(channels.requestRealtimeDiagnostics, (event) => {
     if (!trustedSender(event)) throw new Error("Untrusted renderer");
     return realtimeCredentials?.diagnostics() ?? voiceUnavailableDiagnostics;
+  });
+
+  ipcMain.handle(channels.requestHostedUsage, async (event) => {
+    if (!trustedSender(event)) throw new Error("Untrusted renderer");
+    // Nothing rather than an error on a keyed or signed-out run: no allowance
+    // is in play, and the page words itself without numbers.
+    return hostedUsageReader?.read();
   });
 
   ipcMain.on(channels.quit, (event) => {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -45,6 +45,7 @@ const bridge: AppBridge = {
   setAskHotkey: invoke(channels.setAskHotkey),
   setStopHotkey: invoke(channels.setStopHotkey),
   setDuckOtherMedia: invoke(channels.setDuckOtherMedia),
+  setVoiceSource: invoke(channels.setVoiceSource),
   setPreferBuiltInMicrophone: invoke(channels.setPreferBuiltInMicrophone),
   setQuietDuringMeetings: invoke(channels.setQuietDuringMeetings),
   connectGoogleCalendar: invoke(channels.connectGoogleCalendar),

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -76,6 +76,7 @@ const bridge: AppBridge = {
   focusPanel: () => ipcRenderer.send(channels.focusPanel),
   requestRealtimeCredential: invoke(channels.requestRealtimeCredential),
   requestRealtimeDiagnostics: invoke(channels.requestRealtimeDiagnostics),
+  requestHostedUsage: invoke(channels.requestHostedUsage),
   notifyReady: () => ipcRenderer.send(channels.rendererReady),
   quit: () => ipcRenderer.send(channels.quit),
   onLifecycle: subscribe(channels.lifecycle),

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -4,6 +4,7 @@ import {
   FEEDBACK_COMPOSER_KIND,
   type FeedbackComposerKind,
   FIXTURE_EPOCH_MS,
+  type HostedUsageAnswer,
   isProviderId,
   type NormalizedSession,
   type ObservedWorkspaceProject,
@@ -2117,7 +2118,8 @@ export function App(): React.JSX.Element {
   // trip answering from memory, and the tab is what decides whether the
   // answer can be seen.
   const [voiceService, setVoiceService] = useState<RealtimeDiagnostics | undefined>();
-  // biome-ignore lint/correctness/useExhaustiveDependencies: the settings snapshot is not read here — its arrival is the signal the held answer went stale, because the key or the account may have moved with it.
+  const [hostedUsage, setHostedUsage] = useState<HostedUsageAnswer | undefined>();
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the settings snapshot is not read here — its arrival is the signal the held answers went stale, because the key or the account may have moved with it.
   useEffect(() => {
     if (tab !== PANEL_TAB.SETTINGS || !bootstrap) return;
     let stale = false;
@@ -2125,6 +2127,15 @@ export function App(): React.JSX.Element {
       .requestRealtimeDiagnostics()
       .then((report) => {
         if (!stale) setVoiceService(report);
+      })
+      .catch(() => undefined);
+    // Nothing on a keyed or signed-out run clears the numbers rather than
+    // holding the last hosted day's: an allowance no longer in play must not
+    // keep being shown.
+    void window.sidecar
+      .requestHostedUsage()
+      .then((usage) => {
+        if (!stale) setHostedUsage(usage);
       })
       .catch(() => undefined);
     return () => {
@@ -2350,6 +2361,7 @@ export function App(): React.JSX.Element {
               updates,
               settings,
               ...(voiceService ? { voiceService } : {}),
+              ...(hostedUsage ? { hostedUsage } : {}),
               preferences,
               credentials,
               feedback: feedbackControl,

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -47,6 +47,7 @@ import {
   CREDENTIAL_PROVIDER_LIST,
   CREDENTIAL_PROVIDERS,
   isCredentialProviderId,
+  VOICE_CREDENTIAL_PROVIDER,
 } from "../shared/credential-providers";
 import type { FeedbackImage, FeedbackKind } from "../shared/feedback";
 import { FEEDBACK_KIND, FEEDBACK_LIMITS, feedbackKindForLifecycleEvent } from "../shared/feedback";
@@ -2129,13 +2130,21 @@ export function App(): React.JSX.Element {
         if (!stale) setVoiceService(report);
       })
       .catch(() => undefined);
-    // Nothing on a keyed or signed-out run clears the numbers rather than
-    // holding the last hosted day's: an allowance no longer in play must not
-    // keep being shown.
+    // An empty answer means two different things, told apart by the settings
+    // in hand: with no allowance in play — a key connected, or voice off — it
+    // clears the numbers, because an allowance no longer bought must not keep
+    // being shown; while the account is still hosted it is a failed refresh,
+    // and the meters keep the last read rather than collapsing to prose over
+    // one dropped request.
+    const snapshot = settings ?? bootstrap.settings;
+    const hostedNow =
+      snapshot.voiceAvailable &&
+      snapshot.credentialSources[VOICE_CREDENTIAL_PROVIDER.id] === CREDENTIAL_SOURCE.NONE;
     void window.sidecar
       .requestHostedUsage()
       .then((usage) => {
-        if (!stale) setHostedUsage(usage);
+        if (stale) return;
+        setHostedUsage((held) => usage ?? (hostedNow ? held : undefined));
       })
       .catch(() => undefined);
     return () => {

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -121,9 +121,12 @@ import type {
 } from "./settings-panel";
 import {
   credentialSettingsPage,
+  PANEL_STAND_DOWN,
   SETTING_PAGE,
   SETTINGS_VIEW,
   type SettingsView,
+  type SlotOccupant,
+  standDownReturnPage,
 } from "./settings-views";
 import { useSignInFaceCycle } from "./sign-in-gate";
 import { SignInSlot } from "./sign-in-slot";
@@ -339,12 +342,16 @@ export function App(): React.JSX.Element {
    */
   const credentialHeld = useRef(false);
   /**
-   * The settings page the held credential's row is drawn on — Voice for the
-   * OpenAI key, Connections for every other — so the trip to the key slot
-   * ends back on the page it began on. A ref rather than state: it is read
+   * The settings page whatever is standing in the panel's place was begun
+   * from — a key's provider row, the calendar's block under Integrations, or
+   * the Feedback section on the front page — so leaving that shape ends back
+   * on the page it began on. Written by each begin, because the return is a
+   * fact about what was begun rather than about what was begun last: one page
+   * remembered for all three landed a cancelled note on Connections, wherever
+   * the note had actually been started. A ref rather than state: it is read
    * only when the panel is restored, by a callback that has to stay stable.
    */
-  const credentialPage = useRef<SettingsView>(SETTINGS_VIEW.CONNECTIONS);
+  const standDownPage = useRef<SettingsView>(SETTINGS_VIEW.ROOT);
   const feedbackHeld = useRef(false);
   /** Whether a calendar sign-in holds the slot, mirrored like the other two. */
   const calendarConnectHeld = useRef(false);
@@ -353,7 +360,7 @@ export function App(): React.JSX.Element {
    * sign-in being waited out. One shape, two occupants, never both: beginning
    * either is refused while the other is held.
    */
-  const slotOccupant = useRef<"key" | "calendar">("key");
+  const slotOccupant = useRef<SlotOccupant>(PANEL_STAND_DOWN.KEY);
   const feedbackNoticeTimer = useRef<number | undefined>(undefined);
   /**
    * The landing the latest send drew, held so the confirmation's hold waits
@@ -636,12 +643,11 @@ export function App(): React.JSX.Element {
    */
   const restorePanel = useCallback(() => {
     changeTab(PANEL_TAB.SETTINGS);
-    // The line the entry belongs to lives on the page it was begun from —
-    // Voice for the OpenAI key, Connections for the rest — and changeTab has
-    // just reset the tab to its front page: without this, the check appearing
-    // beside the provider — the answer to what was just done — would land on
-    // a page nobody is looking at.
-    setSettingsView(credentialPage.current);
+    // The row this shape was begun from lives on one page, and changeTab has
+    // just reset the tab to its front page: without this, the answer to what
+    // was just done — the check beside a provider, the thank-you where the
+    // note was written — would land on a page nobody is looking at.
+    setSettingsView(standDownPage.current);
     expand();
   }, [changeTab, expand, setSettingsView]);
 
@@ -726,7 +732,10 @@ export function App(): React.JSX.Element {
   const beginCalendarSignIn = useCallback(() => {
     // One slot, one occupant: a key mid-paste is not disturbed by a sign-in.
     if (credentialHeld.current || calendarConnectHeld.current) return;
-    slotOccupant.current = "calendar";
+    slotOccupant.current = PANEL_STAND_DOWN.CALENDAR;
+    // The calendar's block stands under Integrations, so that is where a
+    // cancelled or refused sign-in comes back to.
+    standDownPage.current = standDownReturnPage({ kind: PANEL_STAND_DOWN.CALENDAR });
     calendarConnect.begin({ busy: false });
     calendarConnect.commit();
   }, [calendarConnect.begin, calendarConnect.commit]);
@@ -769,8 +778,8 @@ export function App(): React.JSX.Element {
     (providerId: CredentialProviderId) => {
       // Where the entry's row is drawn, remembered before the trip to the
       // slot so coming back lands on the page the entry began on.
-      credentialPage.current = credentialSettingsPage(providerId);
-      slotOccupant.current = "key";
+      standDownPage.current = standDownReturnPage({ kind: PANEL_STAND_DOWN.KEY, providerId });
+      slotOccupant.current = PANEL_STAND_DOWN.KEY;
       credentialsEntry.begin({ providerId, draft: "", busy: false, away: false });
     },
     [credentialsEntry.begin],
@@ -1097,6 +1106,9 @@ export function App(): React.JSX.Element {
   const beginFeedback = useCallback(
     (kind: FeedbackKind, fromPanel: boolean, draft?: string): boolean => {
       setFeedbackNotice(undefined);
+      // The Feedback section is on the front page, so that is where leaving
+      // the composer — or the thank-you the send lands in — comes back to.
+      standDownPage.current = standDownReturnPage({ kind: PANEL_STAND_DOWN.FEEDBACK });
       // Asking to write again is the confirmation's end: the composer takes
       // the shape back, and the return the landing held is dropped unrun.
       dropFeedbackConfirmation();
@@ -2312,7 +2324,7 @@ export function App(): React.JSX.Element {
           panelHeight,
           signInWait !== undefined
             ? signInSlotHeight
-            : slotOccupant.current === "calendar"
+            : slotOccupant.current === PANEL_STAND_DOWN.CALENDAR
               ? connectHeight
               : slotHeight,
           feedbackHeight,
@@ -2407,14 +2419,14 @@ export function App(): React.JSX.Element {
           <KeySlot
             control={credentials}
             source={slotSource}
-            drawn={slotOpen && slotOccupant.current === "key"}
+            drawn={slotOpen && slotOccupant.current === PANEL_STAND_DOWN.KEY}
             measure={slotElement}
           />
           {/* The panel stood down while a calendar sign-in waits on the
               browser, on the key slot's exact terms. */}
           <CalendarConnectSlot
             entry={calendarConnect.entry}
-            drawn={slotOpen && slotOccupant.current === "calendar"}
+            drawn={slotOpen && slotOccupant.current === PANEL_STAND_DOWN.CALENDAR}
             onCancel={cancelCalendarSignIn}
             onReopen={() => window.sidecar.reopenGoogleCalendarSignIn()}
             measure={connectElement}

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -123,7 +123,6 @@ import {
   credentialSettingsPage,
   SETTING_PAGE,
   SETTINGS_VIEW,
-  type SettingsSubview,
   type SettingsView,
 } from "./settings-views";
 import { useSignInFaceCycle } from "./sign-in-gate";
@@ -345,7 +344,7 @@ export function App(): React.JSX.Element {
    * ends back on the page it began on. A ref rather than state: it is read
    * only when the panel is restored, by a callback that has to stay stable.
    */
-  const credentialPage = useRef<SettingsSubview>(SETTINGS_VIEW.CONNECTIONS);
+  const credentialPage = useRef<SettingsView>(SETTINGS_VIEW.CONNECTIONS);
   const feedbackHeld = useRef(false);
   /** Whether a calendar sign-in holds the slot, mirrored like the other two. */
   const calendarConnectHeld = useRef(false);

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -2120,9 +2120,13 @@ export function App(): React.JSX.Element {
   // answer can be seen.
   const [voiceService, setVoiceService] = useState<RealtimeDiagnostics | undefined>();
   const [hostedUsage, setHostedUsage] = useState<HostedUsageAnswer | undefined>();
+  // Asked as soon as the app knows itself and again on every settings change,
+  // not on the first Settings visit: the answer is one cheap read, and the
+  // meters must be standing when the tab opens rather than arriving a blink
+  // after it.
   // biome-ignore lint/correctness/useExhaustiveDependencies: the settings snapshot is not read here — its arrival is the signal the held answers went stale, because the key or the account may have moved with it.
   useEffect(() => {
-    if (tab !== PANEL_TAB.SETTINGS || !bootstrap) return;
+    if (!bootstrap) return;
     let stale = false;
     void window.sidecar
       .requestRealtimeDiagnostics()

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -40,6 +40,7 @@ import type {
   SettingsResetScope,
   SettingsUpdateResult,
   UpdateSnapshot,
+  VoiceSource,
 } from "../shared/contracts";
 import { ACCOUNT_STATUS, CREDENTIAL_SOURCE, SESSION_OPEN_RESULT_STATUS } from "../shared/contracts";
 import type { CredentialProviderId } from "../shared/credential-providers";
@@ -671,6 +672,11 @@ export function App(): React.JSX.Element {
 
   const changeDuckOtherMedia = useCallback(
     async (enabled: boolean) => applySettingsReply(await window.sidecar.setDuckOtherMedia(enabled)),
+    [applySettingsReply],
+  );
+
+  const changeVoiceSource = useCallback(
+    async (source: VoiceSource) => applySettingsReply(await window.sidecar.setVoiceSource(source)),
     [applySettingsReply],
   );
 
@@ -2267,6 +2273,7 @@ export function App(): React.JSX.Element {
   const preferences: PreferenceWrites = {
     onVoiceCaptionsChange: changeVoiceCaptions,
     onDuckOtherMediaChange: changeDuckOtherMedia,
+    onVoiceSourceChange: changeVoiceSource,
     onPreferBuiltInMicrophoneChange: changePreferBuiltInMicrophone,
     onQuietDuringMeetingsChange: changeQuietDuringMeetings,
     onVoiceChange: changeVoice,

--- a/apps/desktop/src/renderer/errand-queue.ts
+++ b/apps/desktop/src/renderer/errand-queue.ts
@@ -2,7 +2,7 @@ import type { AppSettings } from "../shared/contracts";
 import { ERRAND_WAIT, type ErrandTarget, type ErrandWait } from "./luke-errand";
 import type { PanelTab } from "./panel-tabs";
 import type { SessionView } from "./session-model";
-import type { SettingsSubview, SettingsView } from "./settings-views";
+import type { SettingsView } from "./settings-views";
 
 /**
  * The order Luke signs his own work in, when one reply asked for more than one
@@ -64,7 +64,7 @@ export interface PendingErrand {
   /** The tab its control is drawn on. */
   tab: PanelTab;
   /** The settings page it is drawn on, when it is drawn on one at all. */
-  page?: SettingsSubview;
+  page?: SettingsView;
   /** Whether this act is what stood the panel up. */
   opening: boolean;
   /**
@@ -215,7 +215,7 @@ export function errandBorrowedPanel(borrowed: boolean, launch: PendingErrand): b
 export function errandWait(input: {
   opening: boolean;
   tab: PanelTab;
-  page?: SettingsSubview;
+  page?: SettingsView;
   drawnTab: PanelTab;
   drawnPage: SettingsView;
 }): ErrandWait {

--- a/apps/desktop/src/renderer/feedback-panel.tsx
+++ b/apps/desktop/src/renderer/feedback-panel.tsx
@@ -31,11 +31,13 @@ function FeedbackOffer({
 }
 
 /**
- * The last section of the settings front page: the two ways to write to the
- * people who make Luke, side by side on one row. The section only offers —
- * pressing either button stands the panel down to the composer's own shape,
- * the way pressing Connect stands it down to the key slot — and the line under
- * the offers is where a landed send reports back.
+ * The two ways to write to the people who make Luke, side by side on one row,
+ * standing on the settings front page above the account and the way out. The
+ * section only offers — pressing either button stands the panel down to the
+ * composer's own shape, the way pressing Connect stands it down to the key
+ * slot — and the line under the offers is where a landed send reports back,
+ * which is why leaving the composer comes back to this page rather than to
+ * wherever it was last.
  */
 export function FeedbackSection({ control }: { control: FeedbackEntryControl }): React.JSX.Element {
   return (

--- a/apps/desktop/src/renderer/feedback-panel.tsx
+++ b/apps/desktop/src/renderer/feedback-panel.tsx
@@ -39,7 +39,7 @@ function FeedbackOffer({
  */
 export function FeedbackSection({ control }: { control: FeedbackEntryControl }): React.JSX.Element {
   return (
-    <section className="settings-section" style={{ "--row-index": 3 } as React.CSSProperties}>
+    <section className="settings-section" style={{ "--row-index": 4 } as React.CSSProperties}>
       <h2>
         <MegaphoneIcon />
         Feedback

--- a/apps/desktop/src/renderer/luke-face-art.ts
+++ b/apps/desktop/src/renderer/luke-face-art.ts
@@ -9,6 +9,11 @@
 export const FACE_ART = {
   /** A square window centred on the face. Loud motions leave it, and may. */
   VIEW_BOX: "48 51 146 146",
+  /**
+   * The face cropped to itself, the way the static mark SVGs are cut. Only for
+   * a mark that never moves: it is tight enough that any motion would leave it.
+   */
+  MARK_VIEW_BOX: "53.85 62.67 134.29 122.37",
   /** The head's resting tilt, about the point the motions pivot on. */
   TILT: "rotate(-8 120 124)",
   /** The capital-L nose, curling into the smile. */

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -97,6 +97,8 @@ const SETTINGS_TAB = "the panel's Settings tab";
 /* The tab's front page opens pages, and each setting is changed by hand on
    one of them — so every by-hand path names its page, worded once each. */
 const VOICE_PAGE = `${SETTINGS_TAB}, on its Voice page`;
+/** Where the account, the usage meters, and the OpenAI key row all live. */
+const ACCOUNT_SECTION = `the Account and usage section, at the top of ${SETTINGS_TAB}'s front page`;
 const APPEARANCE_PAGE = `${SETTINGS_TAB}, on its Appearance page`;
 const SHORTCUTS_PAGE = `${SETTINGS_TAB}, on its Keyboard shortcuts page`;
 const CONNECTIONS_PAGE = `${SETTINGS_TAB}, on its Connections page`;
@@ -541,17 +543,17 @@ function voiceKeyFact(settings: AppSettings, voiceAvailable: boolean): AppGuideF
   const source = settings.credentialSources[openai.id];
   const hosted = voiceAvailable && source === CREDENTIAL_SOURCE.NONE;
   return {
-    label: "OpenAI",
+    label: openai.displayName,
     detail:
       `${openai.displayName} (${connectionWord(source)}). ` +
       (hosted
-        ? `Voice and session review currently run on the signed-in Luke account, which includes ` +
-          `a daily allowance. Connecting a personal OpenAI key lifts the allowance and runs ` +
-          `voice on that key instead. `
-        : `Connecting OpenAI is what lets Luke speak, and review which sessions need a person; ` +
-          `a signed-in Luke account also includes both under a daily allowance without one. `) +
-      `The key is typed by hand into ${VOICE_PAGE}, at its top — never spoken, and never ` +
-      `repeated back.`,
+        ? `Voice and session review run on the signed-in Luke account's daily allowance; ` +
+          `connecting your own key lifts the limits and runs them on it instead. `
+        : source === CREDENTIAL_SOURCE.NONE
+          ? `Signing in — or connecting a key — is what lets Luke speak and review sessions. `
+          : `Voice and session review run on this key — no daily limits. `) +
+      `The key is typed by hand into ${ACCOUNT_SECTION} — never read from the environment, ` +
+      `never spoken, and never repeated back.`,
   };
 }
 
@@ -602,18 +604,18 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "chat is its own row: a workspace holding several draws them inside one tray named by " +
         "the workspace at its top, one holding a single chat stays one row titled by the " +
         "workspace, and every chat can be seen, opened, and messaged individually. Settings " +
-        "holds a front page led by the Account section — who is signed in, and what the " +
-        "account is buying right now: two small meters filling with the day's used voice " +
+        "holds a front page led by the Account and usage section — who is signed in, what " +
+        "the account is buying right now (small meters filling with the day's used voice " +
         "calls and session reviews while voice runs on its included allowance, or a note " +
-        "that it runs on the developer's own key — then rows that open its Voice, Appearance, Keyboard " +
+        "that it runs on the developer's own key), and the OpenAI BYOK row itself, typed by " +
+        "hand and never read from the environment — then rows that open its Voice, Appearance, Keyboard " +
         "shortcuts, and Connections pages — each led back out by its back button or Escape — " +
-        "and keeps the Feedback section and Quit on the front page itself; the Voice page reveals itself in " +
-        "stages — the OpenAI key section alone until voice is available at all (the signed-in " +
-        "account includes it, so for most people the page opens whole, with a note saying " +
-        "whose allowance voice runs on and how much of today's remains), then the microphone " +
-        "permission under it, and the voice settings only once both stand — and a small " +
-        "exclamation mark sits on whichever stage still needs a hand, on the front page's " +
-        "Voice row while either does, and on the Keyboard shortcuts rows while voice is off, " +
+        "and keeps the Feedback section and Quit on the front page itself; the Voice page " +
+        "holds the microphone permission and then the voice settings once voice is available, " +
+        "and only a pointer back to Account and usage while it is not — and a small " +
+        "exclamation mark sits on whatever still needs a hand: the Account and usage heading " +
+        "while voice has nothing to run on, the front page's Voice row and the microphone row " +
+        "while the permission is ungranted, and the Keyboard shortcuts rows while voice is off, " +
         "where each key's chord stays shown and changeable but answers nothing until voice is " +
         "available; the " +
         "menu bar item's Settings… opens the same tab, and Command-comma switches to it while " +
@@ -804,8 +806,8 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
           {
             label: "Voice",
             detail:
-              "Off: no OpenAI key is connected, so no conversation can be opened. " +
-              `The key is entered in ${VOICE_PAGE}, at its top.`,
+              "Off: nothing to run voice on, so no conversation can be opened. " +
+              `Signing in turns it on with the included allowance; a key entered in ${ACCOUNT_SECTION} also works.`,
           },
         ]),
     providersFact(input.settings),

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -603,9 +603,9 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "the workspace at its top, one holding a single chat stays one row titled by the " +
         "workspace, and every chat can be seen, opened, and messaged individually. Settings " +
         "holds a front page led by the Account section — who is signed in, and what the " +
-        "account is buying right now: the day's remaining voice calls and session reviews " +
-        "while voice runs on its included allowance, or a note that it runs on the " +
-        "developer's own key — then rows that open its Voice, Appearance, Keyboard " +
+        "account is buying right now: two small meters filling with the day's used voice " +
+        "calls and session reviews while voice runs on its included allowance, or a note " +
+        "that it runs on the developer's own key — then rows that open its Voice, Appearance, Keyboard " +
         "shortcuts, and Connections pages — each led back out by its back button or Escape — " +
         "and keeps the Feedback section and Quit on the front page itself; the Voice page reveals itself in " +
         "stages — the OpenAI key section alone until voice is available at all (the signed-in " +

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -44,6 +44,7 @@ import type {
   AppSettings,
   CredentialSource,
   MicrophoneStatus,
+  VoiceSource,
 } from "../shared/contracts";
 import {
   ACCOUNT_PROVIDER,
@@ -51,6 +52,7 @@ import {
   APP_SETTING_DEFAULTS,
   CREDENTIAL_SOURCE,
   SECRET_STORAGE,
+  VOICE_SOURCE,
 } from "../shared/contracts";
 import {
   CLOUD_AGENT_PROVIDER_LIST,
@@ -76,6 +78,7 @@ export const APP_SETTING_ID = {
   DEFAULT_WORKSPACE_PROVIDER: "default_workspace_provider",
   WORKSPACE_AGENT_MODEL: "workspace_agent_model",
   WORKSPACE_AGENT_EFFORT: "workspace_agent_effort",
+  VOICE_SOURCE: "voice_source",
 } as const;
 
 export type AppSettingId = (typeof APP_SETTING_ID)[keyof typeof APP_SETTING_ID];
@@ -97,8 +100,10 @@ const SETTINGS_TAB = "the panel's Settings tab";
 /* The tab's front page opens pages, and each setting is changed by hand on
    one of them — so every by-hand path names its page, worded once each. */
 const VOICE_PAGE = `${SETTINGS_TAB}, on its Voice page`;
-/** Where the account, the usage meters, and the OpenAI key row all live. */
-const ACCOUNT_SECTION = `the Account and usage section, at the top of ${SETTINGS_TAB}'s front page`;
+/** Where the allowance meters and the OpenAI key row both live. */
+const VOICE_SOURCE_SECTION = `${SETTINGS_TAB}, on its front page, in the What Luke runs on section at the top`;
+/** Where the signed-in identity and the two ways out of it live. */
+const ACCOUNT_SECTION = `the Account section, at the foot of ${SETTINGS_TAB}'s front page`;
 const APPEARANCE_PAGE = `${SETTINGS_TAB}, on its Appearance page`;
 const SHORTCUTS_PAGE = `${SETTINGS_TAB}, on its Keyboard shortcuts page`;
 const CONNECTIONS_PAGE = `${SETTINGS_TAB}, on its Connections page`;
@@ -120,6 +125,16 @@ const CONDUCTOR_DEFAULT_CHOICE = "Conductor's default";
  * offers: while nothing is chosen, Luke asks which provider each time.
  */
 const ASK_EACH_TIME_CHOICE = "ask each time";
+
+/**
+ * How the two sources are named in the guide — the toggle's own words, minus
+ * the price tag beside them, because a spoken value is read aloud and "(you
+ * pay)" is a label rather than a name.
+ */
+const VOICE_SOURCE_CHOICE: Record<VoiceSource, string> = {
+  [VOICE_SOURCE.ACCOUNT]: "your Luke account",
+  [VOICE_SOURCE.KEY]: "your OpenAI key",
+};
 
 /**
  * The words a pace is asked for in, slowest to fastest, each paired with the
@@ -392,6 +407,28 @@ const SETTING_GUIDE: Record<
   // Described in the stopping-a-reply fact instead, on the same terms as the
   // other two keys' stored choices.
   stopHotkey: () => undefined,
+  voiceSource: (settings) => ({
+    id: APP_SETTING_ID.VOICE_SOURCE,
+    label: "What Luke runs on",
+    description:
+      "Which credential Luke speaks and reviews sessions on: the signed-in Luke account, free " +
+      "and metered daily, or the developer's own OpenAI key, unmetered and billed to them by " +
+      "OpenAI. A key stays stored either way, so the free allowance can be used without " +
+      "deleting it.",
+    kind: APP_SETTING_KIND.CHOICE,
+    value: VOICE_SOURCE_CHOICE[settings.voiceSource],
+    // Every install begins on the account: the allowance is what a sign-in
+    // carries, and a key is something the developer goes and gets.
+    defaultValue: VOICE_SOURCE_CHOICE[VOICE_SOURCE.ACCOUNT],
+    choices: Object.values(VOICE_SOURCE_CHOICE),
+    // By hand only, and deliberately: this is the one switch that decides
+    // whose money is spent. It is not a credential, so the guide may describe
+    // it — but moving it is the developer's own act on their own bill, and a
+    // spoken ask that could start spending their key is exactly the shape of
+    // thing the refusal exists for.
+    adjustable: false,
+    manual: VOICE_SOURCE_SECTION,
+  }),
   // Not a switch but a set of keys, so it is described in the facts instead:
   // which providers are connected, and that a key is only ever typed by hand.
   credentialSources: () => undefined,
@@ -547,12 +584,14 @@ function voiceKeyFact(settings: AppSettings, voiceAvailable: boolean): AppGuideF
     detail:
       `${openai.displayName} (${connectionWord(source)}). ` +
       (hosted
-        ? `Voice and session review run on the signed-in Luke account's daily allowance; ` +
-          `connecting your own key lifts the limits and runs them on it instead. `
+        ? `Voice and session review run on the signed-in Luke account's daily allowance, free; ` +
+          `connecting your own key removes the daily limit and runs them on it instead, billed ` +
+          `by OpenAI. `
         : source === CREDENTIAL_SOURCE.NONE
           ? `Signing in — or connecting a key — is what lets Luke speak and review sessions. `
-          : `Voice and session review run on this key — no daily limits. `) +
-      `The key is typed by hand into ${ACCOUNT_SECTION} — never read from the environment, ` +
+          : `Voice and session review run on this key: no daily limit, nothing through Luke's ` +
+            `service, and OpenAI bills you for what you use. `) +
+      `The key is typed by hand into ${VOICE_SOURCE_SECTION} — never read from the environment, ` +
       `never spoken, and never repeated back.`,
   };
 }
@@ -604,16 +643,24 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "chat is its own row: a workspace holding several draws them inside one tray named by " +
         "the workspace at its top, one holding a single chat stays one row titled by the " +
         "workspace, and every chat can be seen, opened, and messaged individually. Settings " +
-        "holds a front page led by the Account and usage section — who is signed in, what " +
-        "the account is buying right now (small meters filling with the day's used voice " +
-        "calls and session reviews while voice runs on its included allowance, or a note " +
-        "that it runs on the developer's own key), and the OpenAI BYOK row itself, typed by " +
-        "hand and never read from the environment — then rows that open its Voice, Appearance, Keyboard " +
+        "holds a front page led by the What Luke runs on section — a two-way toggle naming the " +
+        "signed-in Luke account (free, a daily amount) against the developer's own OpenAI key " +
+        "(unmetered, billed by OpenAI), with the live one marked and the other pressable to " +
+        "switch: choosing the key with none stored asks for one, and choosing the account " +
+        "parks a stored key without deleting it. Under the toggle stands whichever half is " +
+        "live, and only that one: on the account, small meters filling with the day's talking " +
+        "and announcements and checks on your sessions — blue until the last fifth of either " +
+        "is left and amber from there on — when they reset, and a folded How this works " +
+        "saying what spends each; on the key, the OpenAI row itself, typed by hand and never " +
+        "read from the environment, and a folded How your key is used saying it pays for " +
+        "those same two things, straight from the Mac to OpenAI with no daily limit " +
+        "— then rows that open its Voice, Appearance, Keyboard " +
         "shortcuts, and Connections pages — each led back out by its back button or Escape — " +
-        "and keeps the Feedback section and Quit on the front page itself; the Voice page " +
+        "and keeps the Feedback section, the Account section, and Quit on the front page " +
+        "itself, the account last because signing out and deleting are done once or never; the Voice page " +
         "holds the microphone permission and then the voice settings once voice is available, " +
-        "and only a pointer back to Account and usage while it is not — and a small " +
-        "exclamation mark sits on whatever still needs a hand: the Account and usage heading " +
+        "and only a pointer back to What Luke runs on while it is not — and a small " +
+        "exclamation mark sits on whatever still needs a hand: the What Luke runs on heading " +
         "while voice has nothing to run on, the front page's Voice row and the microphone row " +
         "while the permission is ungranted, and the Keyboard shortcuts rows while voice is off, " +
         "where each key's chord stays shown and changeable but answers nothing until voice is " +
@@ -633,7 +680,7 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       label: "Account",
       detail:
         account.status === ACCOUNT_STATUS.SIGNED_IN
-          ? `Signed in as ${account.email} through ${account.provider === ACCOUNT_PROVIDER.GITHUB ? "GitHub" : "Google"}. Sign out by hand from Account, at the top of the Settings tab's front page — it asks before acting. The same section's Delete account row erases the account and everything Luke's service holds for it, cannot be undone, and is only ever done by hand — its button asks before acting, and no spoken ask can reach it.`
+          ? `Signed in as ${account.email} through ${account.provider === ACCOUNT_PROVIDER.GITHUB ? "GitHub" : "Google"}. Sign out by hand from ${ACCOUNT_SECTION} — it asks before acting. The same section's Delete account row erases the account and everything Luke's service holds for it, cannot be undone, and is only ever done by hand — its button asks before acting, and no spoken ask can reach it.`
           : "Not signed in. The sign-in screen greets the launch once with Google and GitHub, then closes like any panel. While signed out the strip beside the housing keeps Luke's face and a small Sign in label in place of the session count, and hovering or pressing it brings the sign-in screen back. Live sessions and Luke's controls stay off until sign-in finishes. Choosing a provider stands the panel down to a small waiting popup with a Cancel button while the browser finishes, and the panel opens itself once the sign-in lands.",
     },
     {
@@ -807,7 +854,7 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
             label: "Voice",
             detail:
               "Off: nothing to run voice on, so no conversation can be opened. " +
-              `Signing in turns it on with the included allowance; a key entered in ${ACCOUNT_SECTION} also works.`,
+              `Signing in turns it on with the included allowance; a key entered in ${VOICE_SOURCE_SECTION} also works.`,
           },
         ]),
     providersFact(input.settings),

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -602,9 +602,12 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "chat is its own row: a workspace holding several draws them inside one tray named by " +
         "the workspace at its top, one holding a single chat stays one row titled by the " +
         "workspace, and every chat can be seen, opened, and messaged individually. Settings " +
-        "holds a front page whose rows open its Voice, Appearance, Keyboard shortcuts, and " +
-        "Connections pages — each led back out by its back button or Escape — and keeps the " +
-        "Feedback section and Quit on the front page itself; the Voice page reveals itself in " +
+        "holds a front page led by the Account section — who is signed in, and what the " +
+        "account is buying right now: the day's remaining voice calls and session reviews " +
+        "while voice runs on its included allowance, or a note that it runs on the " +
+        "developer's own key — then rows that open its Voice, Appearance, Keyboard " +
+        "shortcuts, and Connections pages — each led back out by its back button or Escape — " +
+        "and keeps the Feedback section and Quit on the front page itself; the Voice page reveals itself in " +
         "stages — the OpenAI key section alone until voice is available at all (the signed-in " +
         "account includes it, so for most people the page opens whole, with a note saying " +
         "whose allowance voice runs on and how much of today's remains), then the microphone " +
@@ -628,13 +631,13 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       label: "Account",
       detail:
         account.status === ACCOUNT_STATUS.SIGNED_IN
-          ? `Signed in as ${account.email} through ${account.provider === ACCOUNT_PROVIDER.GITHUB ? "GitHub" : "Google"}. Sign out by hand from Account, at the foot of the Settings tab's front page just above Quit — it asks before acting. The same section's Delete account row erases the account and everything Luke's service holds for it, cannot be undone, and is only ever done by hand — its button asks before acting, and no spoken ask can reach it.`
+          ? `Signed in as ${account.email} through ${account.provider === ACCOUNT_PROVIDER.GITHUB ? "GitHub" : "Google"}. Sign out by hand from Account, at the top of the Settings tab's front page — it asks before acting. The same section's Delete account row erases the account and everything Luke's service holds for it, cannot be undone, and is only ever done by hand — its button asks before acting, and no spoken ask can reach it.`
           : "Not signed in. The sign-in screen greets the launch once with Google and GitHub, then closes like any panel. While signed out the strip beside the housing keeps Luke's face and a small Sign in label in place of the session count, and hovering or pressing it brings the sign-in screen back. Live sessions and Luke's controls stay off until sign-in finishes. Choosing a provider stands the panel down to a small waiting popup with a Cancel button while the browser finishes, and the panel opens itself once the sign-in lands.",
     },
     {
       label: "Feedback and prompts",
       detail:
-        "The Feedback section near the foot of the Settings tab, just above the Account section and Quit — or the menu bar item's Send " +
+        "The Feedback section near the foot of the Settings tab, just above Quit — or the menu bar item's Send " +
         "Feedback… and Submit a Prompt… — opens a composer under the notch. Send feedback is for " +
         "bugs and ideas; Submit a prompt sends a prompt to a coding agent, and one the founders " +
         "like ships in the next release. Either goes by email to the founders with an optional " +

--- a/apps/desktop/src/renderer/microphone-access.ts
+++ b/apps/desktop/src/renderer/microphone-access.ts
@@ -15,6 +15,21 @@ import type { MicrophoneStatus } from "../shared/contracts";
  */
 export const VOICE_KEYLESS_NOTE = "Voice is off: sign in, or connect an OpenAI key.";
 
+/** The one sentence a spent allowance is worded with, wherever it shows. */
+export const HOSTED_VOICE_SPENT_NOTE =
+  "Today's included voice is used up — it returns at midnight UTC.";
+
+/**
+ * The BYOK hint, worded once for every surface that carries it. Away from the
+ * key's own row, the hint says where that row lives; beside it, naming the
+ * page would send the reader to where they already are.
+ */
+export function hostedVoiceLift(options: { namesKeyRow?: boolean } = {}): string {
+  return options.namesKeyRow
+    ? "Connecting your own OpenAI key — on the Voice page — lifts the allowance and runs voice on it instead."
+    : "Connecting your own OpenAI key lifts the allowance and runs voice on it instead.";
+}
+
 /**
  * What the key section says while voice runs on the signed-in account: whose
  * allowance is speaking, how much of today's remains, and what connecting a
@@ -27,13 +42,12 @@ export const VOICE_KEYLESS_NOTE = "Voice is off: sign in, or connect an OpenAI k
 export function hostedVoiceNote(
   diagnostics: RealtimeDiagnostics | undefined,
   usage?: HostedUsageAnswer,
-  options: { namesKeyRow?: boolean } = {},
+  options: { namesKeyRow?: boolean; offersKey?: boolean } = {},
 ): string {
-  // Away from the key's own row, the hint says where that row lives; beside
-  // it, naming the page would send the reader to where they already are.
-  const lift = options.namesKeyRow
-    ? "Connecting your own OpenAI key — on the Voice page — lifts the allowance and runs voice on it instead."
-    : "Connecting your own OpenAI key lifts the allowance and runs voice on it instead.";
+  // A machine that cannot store a key is not sent to go connect one: the
+  // Voice page withholds that invitation while storage is unavailable, and a
+  // note pointing there from a page away must withhold it the same way.
+  const lift = options.offersKey === false ? "" : ` ${hostedVoiceLift(options)}`;
   // When a fresh read is in hand it alone decides spent-ness: the minter's
   // last outcome survives midnight, and yesterday's refusal must not outrank
   // today's full allowance.
@@ -41,20 +55,20 @@ export function hostedVoiceNote(
     ? usage.voice.remaining === 0
     : diagnostics?.lastOutcome === REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED;
   if (voiceSpent) {
-    return `Today's included voice is used up — it returns at midnight UTC. ${lift}`;
+    return `${HOSTED_VOICE_SPENT_NOTE}${lift}`;
   }
   if (usage) {
     return (
       `Voice is included with your Luke account — ${usage.voice.remaining} of ` +
       `${usage.voice.limit} calls and ${usage.attention.remaining} of ` +
-      `${usage.attention.limit} session reviews left today. ${lift}`
+      `${usage.attention.limit} session reviews left today.${lift}`
     );
   }
   const quota = diagnostics?.quota;
   if (quota) {
-    return `Voice is included with your Luke account — ${quota.remaining} of ${quota.limit} calls left today. ${lift}`;
+    return `Voice is included with your Luke account — ${quota.remaining} of ${quota.limit} calls left today.${lift}`;
   }
-  return `Voice is included with your Luke account, under a daily allowance. ${lift}`;
+  return `Voice is included with your Luke account, under a daily allowance.${lift}`;
 }
 
 /** Why Luke can speak but not listen: the system's grant is still missing. */

--- a/apps/desktop/src/renderer/microphone-access.ts
+++ b/apps/desktop/src/renderer/microphone-access.ts
@@ -52,6 +52,16 @@ export function fresherQuota(a?: HostedQuota, b?: HostedQuota): HostedQuota | un
 }
 
 /**
+ * A reading only while its day is still running. Past its own reset a quota
+ * describes an allowance that no longer exists — a spent yesterday must not
+ * be drawn as an almost-back today — so it reads as no reading at all, and
+ * the surface falls back to words that promise no numbers.
+ */
+export function currentQuota(quota: HostedQuota | undefined, now: number): HostedQuota | undefined {
+  return quota && quota.resetsAt > now ? quota : undefined;
+}
+
+/**
  * The BYOK hint, worded once. It names no page: the key row it means stands
  * directly below the one place this sentence is drawn.
  */
@@ -67,11 +77,17 @@ export function hostedVoiceLift(): string {
  */
 export function hostedVoiceNote(
   diagnostics: RealtimeDiagnostics | undefined,
-  options: { offersKey?: boolean } = {},
+  options: { offersKey?: boolean; now?: number } = {},
 ): string {
+  const now = options.now ?? Date.now();
   // A machine that cannot store a key is not offered one to connect.
   const lift = options.offersKey === false ? "" : ` ${hostedVoiceLift()}`;
-  if (diagnostics?.lastOutcome === REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED) {
+  // A spent outcome speaks only while its own day runs: past the reset it
+  // describes yesterday, and the fresh day has an allowance again.
+  const spentStands =
+    diagnostics?.lastOutcome === REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED &&
+    (diagnostics.quota === undefined || currentQuota(diagnostics.quota, now) !== undefined);
+  if (spentStands) {
     return `${hostedVoiceSpentNote()}${lift}`;
   }
   return `Voice and session review are included with your account.${lift}`;

--- a/apps/desktop/src/renderer/microphone-access.ts
+++ b/apps/desktop/src/renderer/microphone-access.ts
@@ -1,4 +1,8 @@
-import { REALTIME_MINT_OUTCOME, type RealtimeDiagnostics } from "@sidecar/core";
+import {
+  type HostedUsageAnswer,
+  REALTIME_MINT_OUTCOME,
+  type RealtimeDiagnostics,
+} from "@sidecar/core";
 import type { MicrophoneStatus } from "../shared/contracts";
 
 /**
@@ -13,15 +17,30 @@ export const VOICE_KEYLESS_NOTE = "Voice is off: sign in, or connect an OpenAI k
 
 /**
  * What the key section says while voice runs on the signed-in account: whose
- * allowance is speaking, how much of today's remains once a mint has said,
- * and what connecting a key of one's own changes. The refusal a spent
- * allowance answers with is a state here, not an error — nothing is broken,
- * and the sentence says when voice returns on its own.
+ * allowance is speaking, how much of today's remains, and what connecting a
+ * key of one's own changes. The numbers prefer the usage read — it answers
+ * before the first call of the day and counts the reviews the mint's own
+ * diagnostics never see — and fall back to the quota the last mint carried.
+ * The refusal a spent allowance answers with is a state here, not an error —
+ * nothing is broken, and the sentence says when voice returns on its own.
  */
-export function hostedVoiceNote(diagnostics: RealtimeDiagnostics | undefined): string {
+export function hostedVoiceNote(
+  diagnostics: RealtimeDiagnostics | undefined,
+  usage?: HostedUsageAnswer,
+): string {
   const lift = "Connecting your own OpenAI key lifts the allowance and runs voice on it instead.";
-  if (diagnostics?.lastOutcome === REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED) {
+  const voiceSpent =
+    diagnostics?.lastOutcome === REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED ||
+    usage?.voice.remaining === 0;
+  if (voiceSpent) {
     return `Today's included voice is used up — it returns at midnight UTC. ${lift}`;
+  }
+  if (usage) {
+    return (
+      `Voice is included with your Luke account — ${usage.voice.remaining} of ` +
+      `${usage.voice.limit} calls and ${usage.attention.remaining} of ` +
+      `${usage.attention.limit} session reviews left today. ${lift}`
+    );
   }
   const quota = diagnostics?.quota;
   if (quota) {

--- a/apps/desktop/src/renderer/microphone-access.ts
+++ b/apps/desktop/src/renderer/microphone-access.ts
@@ -29,9 +29,12 @@ export function hostedVoiceNote(
   usage?: HostedUsageAnswer,
 ): string {
   const lift = "Connecting your own OpenAI key lifts the allowance and runs voice on it instead.";
-  const voiceSpent =
-    diagnostics?.lastOutcome === REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED ||
-    usage?.voice.remaining === 0;
+  // When a fresh read is in hand it alone decides spent-ness: the minter's
+  // last outcome survives midnight, and yesterday's refusal must not outrank
+  // today's full allowance.
+  const voiceSpent = usage
+    ? usage.voice.remaining === 0
+    : diagnostics?.lastOutcome === REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED;
   if (voiceSpent) {
     return `Today's included voice is used up — it returns at midnight UTC. ${lift}`;
   }

--- a/apps/desktop/src/renderer/microphone-access.ts
+++ b/apps/desktop/src/renderer/microphone-access.ts
@@ -1,5 +1,5 @@
 import { type HostedQuota, REALTIME_MINT_OUTCOME, type RealtimeDiagnostics } from "@sidecar/core";
-import type { MicrophoneStatus } from "../shared/contracts";
+import { type MicrophoneStatus, VOICE_SOURCE, type VoiceSource } from "../shared/contracts";
 
 /**
  * Why voice as a whole is off: nothing it can run on stands — no signed-in
@@ -13,26 +13,30 @@ export const VOICE_KEYLESS_NOTE = "Voice is off: sign in, or connect an OpenAI k
 
 /**
  * When the day's counters return, in words a sentence can hold: the quota's
- * own `resetsAt` against the clock in hand. Rounded deliberately — a counter
- * nobody can spend by the minute earns no seconds precision.
+ * own `resetsAt` read on the wearer's own clock rather than as a subtraction
+ * they have to do. The counters turn over at midnight UTC, which is somebody
+ * else's clock and never the reader's — so the phrase names the hour their
+ * Mac would show, and says "tomorrow" whenever that hour falls on the next
+ * local day, because a bare time reads as today.
  */
-export function quotaResetsInWords(resetsAt: number, now: number): string {
-  const msLeft = resetsAt - now;
-  if (msLeft <= 60_000) return "in under a minute";
-  const minutes = Math.round(msLeft / 60_000);
-  if (minutes < 90) return `in about ${minutes < 60 ? `${minutes} minutes` : "an hour"}`;
-  return `in about ${Math.round(minutes / 60)} hours`;
+export function quotaResetsWhen(resetsAt: number, now: number): string {
+  const reset = new Date(resetsAt);
+  const clock = reset.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+  // A reset is always inside the next 24 hours — it is the end of the UTC day
+  // in hand — so a different local date can only ever be tomorrow's.
+  const sameDay = new Date(now).toDateString() === reset.toDateString();
+  return sameDay ? `at ${clock}` : `tomorrow at ${clock}`;
 }
 
 /**
- * The one sentence a spent allowance is worded with, wherever it shows: with
- * the reset in hand it says when voice returns, and without one it falls back
- * to the day boundary every counter shares.
+ * The one sentence a spent allowance is worded with, wherever it shows. It
+ * answers the question actually being asked — is Luke broken? — before it
+ * says when voice returns: observation is local and unmetered, so the rows
+ * keep moving whatever the day's talking has cost. With no reset in hand it
+ * falls back to the day boundary every counter shares.
  */
 export function hostedVoiceSpentNote(resetsIn?: string): string {
-  return resetsIn
-    ? `Voice is used up — back ${resetsIn}.`
-    : "Voice is used up — back at midnight UTC.";
+  return `You have used today's free voice — back ${resetsIn ?? "at midnight UTC"}. Luke keeps watching your sessions.`;
 }
 
 /**
@@ -62,11 +66,109 @@ export function currentQuota(quota: HostedQuota | undefined, now: number): Hoste
 }
 
 /**
- * The BYOK hint, worded once. It names no page: the key row it means stands
- * directly below the one place this sentence is drawn.
+ * How a meter reads at a glance: running, getting close, or gone. Three
+ * states rather than the two a spent flag carried, because a ceiling nobody
+ * saw coming is the one thing a meter exists to prevent — the warning has to
+ * arrive while there is still something left to spend differently.
  */
-export function hostedVoiceLift(): string {
-  return "Your own OpenAI key below lifts the limits.";
+export const QUOTA_LEVEL = {
+  RUNNING: "running",
+  LOW: "low",
+  SPENT: "spent",
+} as const;
+
+export type QuotaLevel = (typeof QUOTA_LEVEL)[keyof typeof QUOTA_LEVEL];
+
+/**
+ * What counts as close. One fraction serves both meters rather than a count
+ * each: their ceilings differ by an order of magnitude, and a threshold
+ * written as a number would have to be written twice and kept in step with a
+ * service free to move either. A fifth left is the last stretch of a day on
+ * either scale.
+ */
+const QUOTA_LOW_FRACTION = 0.2;
+
+export function quotaLevel(quota: HostedQuota): QuotaLevel {
+  if (quota.remaining === 0) return QUOTA_LEVEL.SPENT;
+  // A limit of nothing is not a meter with nothing left but a meter with
+  // nothing to say, so it reads as running rather than as a standing warning.
+  if (quota.limit <= 0) return QUOTA_LEVEL.RUNNING;
+  return quota.remaining <= quota.limit * QUOTA_LOW_FRACTION
+    ? QUOTA_LEVEL.LOW
+    : QUOTA_LEVEL.RUNNING;
+}
+
+/**
+ * The two sources as the toggle names them, and what each one costs. Held
+ * apart from the labels so the price reads as the tag it is drawn as, and
+ * together in one place so the toggle, its spoken name, and the disclosure
+ * beneath can never word the same choice three ways.
+ */
+export const VOICE_SOURCE_LABEL: Record<VoiceSource, string> = {
+  [VOICE_SOURCE.ACCOUNT]: "Your Luke account",
+  [VOICE_SOURCE.KEY]: "Your OpenAI key",
+};
+
+export const VOICE_SOURCE_PRICE: Record<VoiceSource, string> = {
+  [VOICE_SOURCE.ACCOUNT]: "Free",
+  [VOICE_SOURCE.KEY]: "You pay",
+};
+
+/** The one line under each name: what running on it is like, day to day. */
+export const VOICE_SOURCE_DETAIL: Record<VoiceSource, string> = {
+  [VOICE_SOURCE.ACCOUNT]: "A daily amount, included",
+  [VOICE_SOURCE.KEY]: "No daily limit, billed by OpenAI",
+};
+
+/** The toggle's name for a source, as a control says it aloud. */
+export function voiceSourceLabel(source: VoiceSource): string {
+  return `${VOICE_SOURCE_LABEL[source]} (${VOICE_SOURCE_PRICE[source].toLowerCase()})`;
+}
+
+/**
+ * The two things a hosted day meters, named for what the developer did rather
+ * than for what the service counted. "Voice calls" and "attention reviews"
+ * are the meters' own names; nobody spending them would recognise either.
+ */
+export const HOSTED_METER_LABEL = {
+  VOICE: "Talking and announcements",
+  REVIEWS: "Checks on your sessions",
+} as const;
+
+/**
+ * What each meter actually spends, for the disclosure that answers "what
+ * counts as one?" — folded away until asked, because the definitions are
+ * needed once and the numbers are needed daily.
+ */
+export const HOSTED_METER_MEANING = {
+  VOICE: "One conversation you open, or one thing Luke says on his own.",
+  REVIEWS:
+    "Each session update weighed in the background to decide whether it is worth telling you about.",
+} as const;
+
+/**
+ * What is true of both uses once a key is what pays for them, said once
+ * beneath the two the key disclosure lists. It is the only thing that half
+ * says which the allowance's half does not: Luke does the same two jobs
+ * either way, so they are worded identically in both, and what differs is
+ * where the work goes and who is billed for it — the half no meter could ever
+ * show.
+ *
+ * Not the place for the Realtime API's billing requirement: that matters
+ * while a key is being got rather than while one is being spent, and the
+ * entry's own hint says it there.
+ */
+export const KEY_USE_NOTE =
+  "Both go straight from your Mac to OpenAI on this key. Luke's service sees none of it, there is no daily limit, and OpenAI bills you at their rates.";
+
+/**
+ * A meter's ceiling as the disclosure says it, or nothing at all until a
+ * reading has arrived. The number is the service's to state — it is read off
+ * the quota in hand rather than written here, so the panel cannot drift from
+ * the ceiling actually being enforced.
+ */
+export function dailyLimitWords(limit?: number): string {
+  return limit === undefined ? "" : `${limit} a day. `;
 }
 
 /**
@@ -77,20 +179,19 @@ export function hostedVoiceLift(): string {
  */
 export function hostedVoiceNote(
   diagnostics: RealtimeDiagnostics | undefined,
-  options: { offersKey?: boolean; now?: number } = {},
+  options: { now?: number } = {},
 ): string {
   const now = options.now ?? Date.now();
-  // A machine that cannot store a key is not offered one to connect.
-  const lift = options.offersKey === false ? "" : ` ${hostedVoiceLift()}`;
   // A spent outcome speaks only while its own day runs: past the reset it
   // describes yesterday, and the fresh day has an allowance again.
   const spentStands =
     diagnostics?.lastOutcome === REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED &&
     (diagnostics.quota === undefined || currentQuota(diagnostics.quota, now) !== undefined);
-  if (spentStands) {
-    return `${hostedVoiceSpentNote()}${lift}`;
-  }
-  return `Voice and session review are included with your account.${lift}`;
+  if (spentStands) return hostedVoiceSpentNote();
+  // What a key of your own would change is not said here any more: the toggle
+  // above draws both sources side by side, with what each costs on its face,
+  // and a sentence repeating one of them would be selling the other.
+  return "Talking and session checks are included free with your account, up to a daily amount.";
 }
 
 /** Why Luke can speak but not listen: the system's grant is still missing. */

--- a/apps/desktop/src/renderer/microphone-access.ts
+++ b/apps/desktop/src/renderer/microphone-access.ts
@@ -1,8 +1,4 @@
-import {
-  type HostedUsageAnswer,
-  REALTIME_MINT_OUTCOME,
-  type RealtimeDiagnostics,
-} from "@sidecar/core";
+import { type HostedQuota, REALTIME_MINT_OUTCOME, type RealtimeDiagnostics } from "@sidecar/core";
 import type { MicrophoneStatus } from "../shared/contracts";
 
 /**
@@ -15,60 +11,70 @@ import type { MicrophoneStatus } from "../shared/contracts";
  */
 export const VOICE_KEYLESS_NOTE = "Voice is off: sign in, or connect an OpenAI key.";
 
-/** The one sentence a spent allowance is worded with, wherever it shows. */
-export const HOSTED_VOICE_SPENT_NOTE =
-  "Today's included voice is used up — it returns at midnight UTC.";
-
 /**
- * The BYOK hint, worded once for every surface that carries it. Away from the
- * key's own row, the hint says where that row lives; beside it, naming the
- * page would send the reader to where they already are.
+ * When the day's counters return, in words a sentence can hold: the quota's
+ * own `resetsAt` against the clock in hand. Rounded deliberately — a counter
+ * nobody can spend by the minute earns no seconds precision.
  */
-export function hostedVoiceLift(options: { namesKeyRow?: boolean } = {}): string {
-  return options.namesKeyRow
-    ? "Connecting your own OpenAI key — on the Voice page — lifts the allowance and runs voice on it instead."
-    : "Connecting your own OpenAI key lifts the allowance and runs voice on it instead.";
+export function quotaResetsInWords(resetsAt: number, now: number): string {
+  const msLeft = resetsAt - now;
+  if (msLeft <= 60_000) return "in under a minute";
+  const minutes = Math.round(msLeft / 60_000);
+  if (minutes < 90) return `in about ${minutes < 60 ? `${minutes} minutes` : "an hour"}`;
+  return `in about ${Math.round(minutes / 60)} hours`;
 }
 
 /**
- * What the key section says while voice runs on the signed-in account: whose
- * allowance is speaking, how much of today's remains, and what connecting a
- * key of one's own changes. The numbers prefer the usage read — it answers
- * before the first call of the day and counts the reviews the mint's own
- * diagnostics never see — and fall back to the quota the last mint carried.
- * The refusal a spent allowance answers with is a state here, not an error —
- * nothing is broken, and the sentence says when voice returns on its own.
+ * The one sentence a spent allowance is worded with, wherever it shows: with
+ * the reset in hand it says when voice returns, and without one it falls back
+ * to the day boundary every counter shares.
+ */
+export function hostedVoiceSpentNote(resetsIn?: string): string {
+  return resetsIn
+    ? `Voice is used up — back ${resetsIn}.`
+    : "Voice is used up — back at midnight UTC.";
+}
+
+/**
+ * The fresher of two readings of the same meter, decided from the readings
+ * themselves: `resetsAt` names the day, so a later one is a later day, and
+ * within one day `remaining` only ever falls — the usage read and the quota a
+ * mint carried have no timestamps of their own, but the smaller remainder is
+ * the newer fact. This is what lets a held usage read and a newer mint's
+ * quota disagree without the surface showing yesterday's allowance, or
+ * allowance a spent mint has already refused.
+ */
+export function fresherQuota(a?: HostedQuota, b?: HostedQuota): HostedQuota | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  if (a.resetsAt !== b.resetsAt) return a.resetsAt > b.resetsAt ? a : b;
+  return a.remaining <= b.remaining ? a : b;
+}
+
+/**
+ * The BYOK hint, worded once. It names no page: the key row it means stands
+ * directly below the one place this sentence is drawn.
+ */
+export function hostedVoiceLift(): string {
+  return "Your own OpenAI key below lifts the limits.";
+}
+
+/**
+ * The Account section's words while voice runs on the account but no numbers
+ * are in hand yet — every state with a quota draws the meters instead. Only
+ * the minter's last outcome can speak here, and a spent allowance is a state,
+ * not an error: the sentence says voice comes back on its own.
  */
 export function hostedVoiceNote(
   diagnostics: RealtimeDiagnostics | undefined,
-  usage?: HostedUsageAnswer,
-  options: { namesKeyRow?: boolean; offersKey?: boolean } = {},
+  options: { offersKey?: boolean } = {},
 ): string {
-  // A machine that cannot store a key is not sent to go connect one: the
-  // Voice page withholds that invitation while storage is unavailable, and a
-  // note pointing there from a page away must withhold it the same way.
-  const lift = options.offersKey === false ? "" : ` ${hostedVoiceLift(options)}`;
-  // When a fresh read is in hand it alone decides spent-ness: the minter's
-  // last outcome survives midnight, and yesterday's refusal must not outrank
-  // today's full allowance.
-  const voiceSpent = usage
-    ? usage.voice.remaining === 0
-    : diagnostics?.lastOutcome === REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED;
-  if (voiceSpent) {
-    return `${HOSTED_VOICE_SPENT_NOTE}${lift}`;
+  // A machine that cannot store a key is not offered one to connect.
+  const lift = options.offersKey === false ? "" : ` ${hostedVoiceLift()}`;
+  if (diagnostics?.lastOutcome === REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED) {
+    return `${hostedVoiceSpentNote()}${lift}`;
   }
-  if (usage) {
-    return (
-      `Voice is included with your Luke account — ${usage.voice.remaining} of ` +
-      `${usage.voice.limit} calls and ${usage.attention.remaining} of ` +
-      `${usage.attention.limit} session reviews left today.${lift}`
-    );
-  }
-  const quota = diagnostics?.quota;
-  if (quota) {
-    return `Voice is included with your Luke account — ${quota.remaining} of ${quota.limit} calls left today.${lift}`;
-  }
-  return `Voice is included with your Luke account, under a daily allowance.${lift}`;
+  return `Voice and session review are included with your account.${lift}`;
 }
 
 /** Why Luke can speak but not listen: the system's grant is still missing. */

--- a/apps/desktop/src/renderer/microphone-access.ts
+++ b/apps/desktop/src/renderer/microphone-access.ts
@@ -27,8 +27,13 @@ export const VOICE_KEYLESS_NOTE = "Voice is off: sign in, or connect an OpenAI k
 export function hostedVoiceNote(
   diagnostics: RealtimeDiagnostics | undefined,
   usage?: HostedUsageAnswer,
+  options: { namesKeyRow?: boolean } = {},
 ): string {
-  const lift = "Connecting your own OpenAI key lifts the allowance and runs voice on it instead.";
+  // Away from the key's own row, the hint says where that row lives; beside
+  // it, naming the page would send the reader to where they already are.
+  const lift = options.namesKeyRow
+    ? "Connecting your own OpenAI key — on the Voice page — lifts the allowance and runs voice on it instead."
+    : "Connecting your own OpenAI key lifts the allowance and runs voice on it instead.";
   // When a fresh read is in hand it alone decides spent-ness: the minter's
   // last outcome survives midnight, and yesterday's refusal must not outrank
   // today's full allowance.

--- a/apps/desktop/src/renderer/settings-icons.tsx
+++ b/apps/desktop/src/renderer/settings-icons.tsx
@@ -4,7 +4,12 @@
  * by the headings, labels, and controls they sit in. They are ours, not
  * anyone's brand mark, so they inherit `currentColor` like any other text — a
  * provider's own mark lives in `provider-marks.tsx` and keeps its brand colour.
+ * The one exception is Luke's own mark, which is ours in both senses: it is a
+ * brand mark, and it inherits `currentColor` like the rest.
  */
+
+import { FACE_ART } from "./luke-face-art";
+
 function Glyph({
   children,
   className = "settings-icon",
@@ -136,6 +141,51 @@ export function FolderIcon(): React.JSX.Element {
     <Glyph>
       <path d="M3.4 6.2a1.8 1.8 0 0 1 1.8-1.8h4l2 2.4h7.6a1.8 1.8 0 0 1 1.8 1.8v9.2a1.8 1.8 0 0 1-1.8 1.8H5.2a1.8 1.8 0 0 1-1.8-1.8Z" />
     </Glyph>
+  );
+}
+
+/**
+ * Luke himself, still: the same mark `design/brand/luke-mark-*.svg` is cut
+ * from, drawn here from the generated artwork rather than loaded, for the
+ * reason the face is — it inherits `currentColor`, so it reads as a letter in
+ * whatever line holds it. The only glyph in this file that is a brand mark;
+ * it earns that because what it stands for is Luke, not a thing Luke does.
+ *
+ * Cropped to the mark's own window rather than the face's, which is wider so
+ * the motions have room to leave it. Nothing here moves: none of the face's
+ * classes are worn, so no generated motion rule can reach it.
+ */
+export function LukeIcon(): React.JSX.Element {
+  return (
+    <svg
+      className="settings-icon"
+      viewBox={FACE_ART.MARK_VIEW_BOX}
+      fill="none"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <g transform={FACE_ART.TILT}>
+        <path
+          d={FACE_ART.SMILE}
+          stroke="currentColor"
+          strokeWidth={FACE_ART.STROKE_WIDTH}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <circle
+          cx={FACE_ART.EYE_X.LEFT}
+          cy={FACE_ART.EYE_Y}
+          r={FACE_ART.EYE_RADIUS}
+          fill="currentColor"
+        />
+        <circle
+          cx={FACE_ART.EYE_X.RIGHT}
+          cy={FACE_ART.EYE_Y}
+          r={FACE_ART.EYE_RADIUS}
+          fill="currentColor"
+        />
+      </g>
+    </svg>
   );
 }
 

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -75,6 +75,7 @@ import { Keycaps } from "./keycaps";
 import { type ErrandTarget, errandTargetProps } from "./luke-errand";
 import { APP_SETTING_ID } from "./luke-guide";
 import {
+  currentQuota,
   fresherQuota,
   hostedVoiceLift,
   hostedVoiceNote,
@@ -2477,11 +2478,25 @@ function AccountSection({
           {(() => {
             // The freshest reading of each meter, wherever it came from: the
             // usage read against the quota the last mint carried, day and
-            // remainder telling the two apart. Reviews only ride while the
-            // read shares the freshest day — an older read's reviews would be
-            // an older day's.
-            const voiceQuota = fresherQuota(hostedUsage?.voice, voiceService?.quota);
-            if (!voiceQuota) return null;
+            // remainder telling the two apart — and neither counted past its
+            // own reset, because a spent yesterday must not be drawn as an
+            // almost-back today. Reviews only ride while the read shares the
+            // freshest day — an older read's reviews would be an older day's.
+            const now = Date.now();
+            const voiceQuota = fresherQuota(
+              currentQuota(hostedUsage?.voice, now),
+              currentQuota(voiceService?.quota, now),
+            );
+            if (!voiceQuota) {
+              // Every reading in hand has outlived its day: fall back to the
+              // words that promise no numbers, exactly as before the first
+              // read of a day.
+              return (
+                <p className="settings-note">
+                  {hostedVoiceNote(voiceService, { offersKey: !storageLocked })}
+                </p>
+              );
+            }
             const reviews =
               hostedUsage && hostedUsage.attention.resetsAt === voiceQuota.resetsAt
                 ? hostedUsage.attention

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -1,5 +1,6 @@
 import {
   DEFAULT_PANEL_FORM_FACTOR,
+  type HostedUsageAnswer,
   isPanelFormFactor,
   isProviderId,
   isRealtimeVoice,
@@ -315,6 +316,11 @@ export interface SettingsPanelProps {
    * hosted note without it until then.
    */
   voiceService?: RealtimeDiagnostics;
+  /**
+   * Today's hosted allowance on both meters, read without spending either.
+   * Absent on a keyed or signed-out run, and until the first answer lands.
+   */
+  hostedUsage?: HostedUsageAnswer;
   preferences: PreferenceWrites;
   /** The one credential being entered anywhere, and everything that can be done to it. */
   credentials: CredentialEntryControl;
@@ -1644,6 +1650,7 @@ function VoiceSection({
   panelOpen,
   microphone,
   voiceService,
+  hostedUsage,
 }: {
   settings: AppSettings;
   preferences: PreferenceWrites;
@@ -1651,6 +1658,7 @@ function VoiceSection({
   panelOpen: boolean;
   microphone: MicrophoneControl;
   voiceService?: RealtimeDiagnostics;
+  hostedUsage?: HostedUsageAnswer;
 }): React.JSX.Element {
   const storageUnavailable = settings.secretStorage === SECRET_STORAGE.UNAVAILABLE;
   const microphoneRow = microphoneAccessRow({
@@ -1696,7 +1704,7 @@ function VoiceSection({
             sessions.
           </p>
         ) : settings.credentialSources[VOICE_CREDENTIAL_PROVIDER.id] === CREDENTIAL_SOURCE.NONE ? (
-          <p className="settings-note">{hostedVoiceNote(voiceService)}</p>
+          <p className="settings-note">{hostedVoiceNote(voiceService, hostedUsage)}</p>
         ) : null}
       </section>
       {/* Drawn only once there is a voice for the microphone to reach: until
@@ -2578,6 +2586,7 @@ export function SettingsPanel({
   updates,
   settings,
   voiceService,
+  hostedUsage,
   preferences,
   credentials,
   feedback,
@@ -2684,6 +2693,7 @@ export function SettingsPanel({
           panelOpen={panelOpen}
           microphone={microphone}
           {...(voiceService ? { voiceService } : {})}
+          {...(hostedUsage ? { hostedUsage } : {})}
         />
       ) : null}
 

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -2433,7 +2433,11 @@ function VoiceSourceToggle({
           return (
             <label
               key={candidate}
-              className="source-choice"
+              /* The Feedback section's own button, wearing its class rather
+                 than a copy of its measurements: the two sections offer the
+                 same kind of pair a few rows apart, and one that drifted from
+                 the other would be the drift nobody notices. */
+              className="quiet-button source-choice"
               data-live={String(live)}
               title={blocked ? STORAGE_UNAVAILABLE_NOTE : undefined}
             >

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -36,6 +36,8 @@ import {
   CREDENTIAL_SOURCE,
   SECRET_STORAGE,
   SETTINGS_RESET_SCOPE,
+  VOICE_SOURCE,
+  type VoiceSource,
 } from "../shared/contracts";
 import type { CredentialProvider } from "../shared/credential-providers";
 import {
@@ -76,15 +78,23 @@ import { type ErrandTarget, errandTargetProps } from "./luke-errand";
 import { APP_SETTING_ID } from "./luke-guide";
 import {
   currentQuota,
+  dailyLimitWords,
   fresherQuota,
-  hostedVoiceLift,
+  HOSTED_METER_LABEL,
+  HOSTED_METER_MEANING,
   hostedVoiceNote,
   hostedVoiceSpentNote,
+  KEY_USE_NOTE,
   MICROPHONE_UNGRANTED_NOTE,
   microphoneAccessRow,
-  quotaResetsInWords,
+  quotaLevel,
+  quotaResetsWhen,
   VOICE_KEYLESS_NOTE,
+  VOICE_SOURCE_DETAIL,
+  VOICE_SOURCE_LABEL,
+  VOICE_SOURCE_PRICE,
   voiceAttentionNote,
+  voiceSourceLabel,
 } from "./microphone-access";
 import { PANEL_TAB, panelPanelId, panelTabId } from "./panel-tabs";
 import { CloudBadge, ProviderMark } from "./provider-marks";
@@ -99,6 +109,7 @@ import {
   FolderIcon,
   KeyboardIcon,
   KeyIcon,
+  LukeIcon,
   PencilIcon,
   PlugIcon,
   PopUpIcon,
@@ -174,6 +185,12 @@ export interface PreferenceWrites {
   onVoiceCaptionsChange: (enabled: boolean) => Promise<string | undefined>;
   /** Turns the quieting of Music and Spotify during a spoken exchange on or off. */
   onDuckOtherMediaChange: (enabled: boolean) => Promise<string | undefined>;
+  /**
+   * Chooses which credential Luke speaks and reviews sessions on. The store
+   * answers with why when it refuses, and the toggle is where that answer
+   * belongs.
+   */
+  onVoiceSourceChange: (source: VoiceSource) => Promise<string | undefined>;
   /** Turns the Mac-microphone-over-Bluetooth-headset preference on or off. */
   onPreferBuiltInMicrophoneChange: (enabled: boolean) => Promise<string | undefined>;
   /**
@@ -2274,13 +2291,18 @@ type AccountAsk = (typeof ACCOUNT_ASK)[keyof typeof ACCOUNT_ASK];
  * One meter of today's allowance, drawn as a track the day fills. The native
  * `meter` rather than a progressbar, because nothing is underway: it reports
  * a level against a limit. Nothing about it animates — a changed value snaps
- * in place and only the section's arrival staggers — and a spent meter turns
- * to the attention color, so the bar and the sentence beside it agree.
+ * in place and only the section's arrival staggers.
+ *
+ * The fill is the working blue every live thing on the surface wears, and it
+ * turns to the attention orange while the day is running out — at the same
+ * level, and for the same reason, a session row wears it: something is about
+ * to need the developer. The bar and the sentence beside it therefore say the
+ * same thing at the same moment.
  */
 function UsageMeter({ label, quota }: { label: string; quota: HostedQuota }): React.JSX.Element {
   const capped = Math.min(quota.used, quota.limit);
   return (
-    <div className="usage-meter" data-spent={String(quota.remaining === 0)}>
+    <div className="usage-meter" data-level={quotaLevel(quota)}>
       <span className="usage-words" aria-hidden="true">
         <small>{label}</small>
         <small>
@@ -2298,37 +2320,309 @@ function UsageMeter({ label, quota }: { label: string; quota: HostedQuota }): Re
   );
 }
 
-function AccountSection({
-  account,
-  onSignOut,
-  onDeleteAccount,
+/**
+ * What counts as usage, folded away until asked, and only that: the two
+ * sources say what they are on their own faces, so repeating either here
+ * would make the one question the meters cannot answer — what spends them —
+ * the hardest thing in the dropdown to find.
+ *
+ * A `details` rather than a held-open state: the panel's own scroll takes the
+ * growth, the surface is not measured off this content, and nothing here
+ * animates.
+ */
+function UsageDisclosure({
+  voice,
+  reviews,
+}: {
+  /** Today's voice ceiling, where a reading has arrived to state it. */
+  voice?: number;
+  /** Today's review ceiling, on the same terms. */
+  reviews?: number;
+}): React.JSX.Element {
+  return (
+    <details className="settings-disclosure">
+      <summary>How this works</summary>
+      <dl className="settings-definitions">
+        <dt>{HOSTED_METER_LABEL.VOICE}</dt>
+        <dd>
+          {dailyLimitWords(voice)}
+          {HOSTED_METER_MEANING.VOICE}
+        </dd>
+        <dt>{HOSTED_METER_LABEL.REVIEWS}</dt>
+        <dd>
+          {dailyLimitWords(reviews)}
+          {HOSTED_METER_MEANING.REVIEWS}
+        </dd>
+      </dl>
+    </details>
+  );
+}
+
+/**
+ * The same question asked of a key instead: what is this being spent on? The
+ * two uses are the two the meters count, worded exactly as the allowance's
+ * disclosure words them — Luke does one job either way, and only whose
+ * credential does it changes — minus the counts a key has none of. The line
+ * beneath is the one thing that is different, and the one no meter could ever
+ * show: where the work goes, and who is billed for it.
+ */
+function KeyUseDisclosure(): React.JSX.Element {
+  return (
+    <details className="settings-disclosure">
+      <summary>How your key is used</summary>
+      <dl className="settings-definitions">
+        <dt>{HOSTED_METER_LABEL.VOICE}</dt>
+        <dd>{HOSTED_METER_MEANING.VOICE}</dd>
+        <dt>{HOSTED_METER_LABEL.REVIEWS}</dt>
+        <dd>{HOSTED_METER_MEANING.REVIEWS}</dd>
+      </dl>
+      {/* Set apart from the list rather than trailing it: it speaks for both
+          entries above, so it must not read as a third one. */}
+      <p className="settings-note settings-disclosure-close">{KEY_USE_NOTE}</p>
+    </details>
+  );
+}
+
+/**
+ * The choice itself: two halves side by side, each carrying its own name and
+ * its own price, with the live one marked. A radio group rather than two
+ * buttons, because it is one value from a small fixed set — the same thing a
+ * pop-up would be, drawn open because there are only two and the whole point
+ * is seeing them together.
+ *
+ * Pressing the half that is already live does nothing. Pressing the other
+ * either switches to a key already stored, or — with none — begins the entry
+ * that would store one, which is the same act the row's Connect was: a source
+ * you have not supplied yet has to be supplied before it can be chosen.
+ */
+function VoiceSourceToggle({
+  source,
+  keyStored,
+  storageLocked,
+  onChoose,
+  onConnect,
+}: {
+  /** Which source is actually running, as the store resolved it. */
+  source: VoiceSource;
+  /** Whether a key is stored at all, which decides what its half does. */
+  keyStored: boolean;
+  /** Whether this system can hold a key, which decides whether it can at all. */
+  storageLocked: boolean;
+  onChoose: (source: VoiceSource) => Promise<string | undefined>;
+  /** Begins the entry, which stands the panel down to the slot. */
+  onConnect: () => void;
+}): React.JSX.Element {
+  const { busy, rejection, run } = useSettingWrite(onChoose);
+  return (
+    <>
+      {/* Real radios under the drawing, the way the calendar's choices are
+          real checkboxes: one value from a set of two is exactly what a radio
+          group is, and taking the native one means the arrow keys, the
+          grouping, and the announcement all come with it. */}
+      <div className="source-toggle">
+        {[VOICE_SOURCE.ACCOUNT, VOICE_SOURCE.KEY].map((candidate) => {
+          const live = candidate === source;
+          // The key's half is the one that can be unavailable: a machine with
+          // no encrypted storage has nowhere to put one, so it can neither be
+          // supplied nor chosen. The account's half is always there — this
+          // section is only drawn for a signed-in account.
+          const blocked = candidate === VOICE_SOURCE.KEY && storageLocked;
+          // A key not yet supplied cannot be chosen, so its half says what
+          // pressing it will actually do.
+          const asksForKey = candidate === VOICE_SOURCE.KEY && !keyStored;
+          return (
+            <label
+              key={candidate}
+              className="source-choice"
+              data-live={String(live)}
+              title={blocked ? STORAGE_UNAVAILABLE_NOTE : undefined}
+            >
+              <input
+                type="radio"
+                className="visually-hidden"
+                name="voice-source"
+                value={candidate}
+                checked={live}
+                disabled={busy || blocked}
+                aria-label={voiceSourceLabel(candidate)}
+                onChange={() => {
+                  // With no key stored there is nothing to switch to yet, so
+                  // the press asks for one instead of storing a choice that
+                  // would resolve straight back to where it started.
+                  if (asksForKey) onConnect();
+                  else run(candidate);
+                }}
+              />
+              <span className="source-name">
+                {VOICE_SOURCE_LABEL[candidate]}
+                {/* Hidden from the reading because the radio's own name
+                    already carries the price; drawn because it is the fact
+                    worth seeing before choosing. */}
+                <span className="source-price" aria-hidden="true">
+                  {VOICE_SOURCE_PRICE[candidate]}
+                </span>
+                {/* The check rides beside the price rather than at the end of
+                    the line: the two facts a glance wants — what this costs,
+                    and that it is the one running — read as one mark. The
+                    radio already says it to a reader, so this is the drawing
+                    alone. */}
+                {live ? <CheckIcon /> : null}
+              </span>
+              <small>
+                {asksForKey ? "Connect a key to use it" : VOICE_SOURCE_DETAIL[candidate]}
+              </small>
+            </label>
+          );
+        })}
+      </div>
+      {rejection ? <p className="error-message">{rejection}</p> : null}
+    </>
+  );
+}
+
+/**
+ * The one question this section settles: which credential Luke speaks and
+ * reviews sessions on. Both answers stand here, side by side and switchable,
+ * because a choice split across two places — an allowance here, a key row
+ * there — is a choice nobody knows they have. It leads the front page: what
+ * Luke is running on, and what is left of it today, is the first thing worth
+ * knowing.
+ *
+ * The account itself is not here. Signing out and deleting are rare acts that
+ * cannot be taken back, and they sit at the foot of the page with the other
+ * ways out; this section is only ever read and switched.
+ */
+function WhatLukeRunsOnSection({
   panelOpen,
-  hosted,
-  keyed,
   storageLocked,
   settings,
   credentials,
+  preferences,
   voiceService,
   hostedUsage,
 }: {
-  account: Extract<AccountSnapshot, { status: typeof ACCOUNT_STATUS.SIGNED_IN }>;
-  onSignOut: () => Promise<void>;
-  onDeleteAccount: () => Promise<string | undefined>;
   panelOpen: boolean;
-  /** Whether voice currently runs on this account's included allowance. */
-  hosted: boolean;
-  /** Whether voice runs on the developer's own key instead. */
-  keyed: boolean;
   /**
-   * Whether this system cannot store a key at all. The key row's connect
-   * invitation is withheld then, and so is every hint pointing at it.
+   * Whether this system cannot store a key at all. The key half cannot be
+   * chosen or supplied then, and it says why rather than going quiet.
    */
   storageLocked: boolean;
   settings: AppSettings;
   /** The one credential being entered anywhere; the key row here uses it. */
   credentials: CredentialEntryControl;
+  preferences: PreferenceWrites;
   voiceService?: RealtimeDiagnostics;
   hostedUsage?: HostedUsageAnswer;
+}): React.JSX.Element {
+  const keySource = settings.credentialSources[VOICE_CREDENTIAL_PROVIDER.id];
+  const keyStored = keySource !== CREDENTIAL_SOURCE.NONE;
+  const entering = entryForProvider(credentials, VOICE_CREDENTIAL_PROVIDER.id) !== undefined;
+  const hosted = settings.voiceSource === VOICE_SOURCE.ACCOUNT;
+  // Which half's contents stand below. The live one, except while a key is
+  // being entered: an entry in flight is that half being supplied, and the
+  // panel brought back around it has to find the field still drawn — the
+  // source itself does not move until the key lands.
+  const keyBody = !hosted || entering;
+  // The freshest reading of each meter, wherever it came from: the usage read
+  // against the quota the last mint carried, day and remainder telling the two
+  // apart — and neither counted past its own reset, because a spent yesterday
+  // must not be drawn as an almost-back today.
+  const now = Date.now();
+  const voiceQuota = hosted
+    ? fresherQuota(currentQuota(hostedUsage?.voice, now), currentQuota(voiceService?.quota, now))
+    : undefined;
+  // Decided, not missed: a same-day reviews reading may trail a fresher voice
+  // mint, because mints say nothing about reviews — dropping it would delete
+  // the only reviews count for no accuracy gained. The skew is bounded by the
+  // refresh riding every settings change and tab turn, and a different day
+  // still discards it.
+  const reviewQuota =
+    voiceQuota && hostedUsage && hostedUsage.attention.resetsAt === voiceQuota.resetsAt
+      ? hostedUsage.attention
+      : undefined;
+  return (
+    <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
+      <h2>
+        <LukeIcon />
+        What Luke runs on
+        {/* The mark for voice having nothing to run on sits where both ways
+            in are drawn: the two halves of the toggle below. */}
+        {settings.voiceAvailable ? null : <AttentionMark note={VOICE_KEYLESS_NOTE} />}
+      </h2>
+      <VoiceSourceToggle
+        source={settings.voiceSource}
+        keyStored={keyStored}
+        storageLocked={storageLocked}
+        onChoose={preferences.onVoiceSourceChange}
+        onConnect={() => credentials.begin(VOICE_CREDENTIAL_PROVIDER.id)}
+      />
+      {/* Each half's own contents, drawn under the toggle for whichever is
+          live. They answer the same two questions in the two ways the sources
+          differ: the allowance is a quantity, so it draws bars and says when
+          they return; a key is a connection, so it draws the connection and
+          says what runs on it. Neither half explains the other — the toggle
+          above is where they are compared. */}
+      {keyBody ? (
+        <>
+          <ProviderCredential
+            provider={VOICE_CREDENTIAL_PROVIDER}
+            source={keySource}
+            storageUnavailable={storageLocked}
+            control={credentials}
+            panelOpen={panelOpen}
+          />
+          <KeyUseDisclosure />
+        </>
+      ) : (
+        <>
+          {/* The day's allowance from the usage read, or the voice meter alone
+              from the quota the last mint carried while no read has answered.
+              Every reading in hand having outlived its day reads as no reading
+              at all, and falls back to the words that promise no numbers. */}
+          {voiceQuota ? (
+            <>
+              <UsageMeter label={HOSTED_METER_LABEL.VOICE} quota={voiceQuota} />
+              {reviewQuota ? (
+                <UsageMeter label={HOSTED_METER_LABEL.REVIEWS} quota={reviewQuota} />
+              ) : null}
+              <p className="settings-note">
+                {voiceQuota.remaining === 0
+                  ? hostedVoiceSpentNote(quotaResetsWhen(voiceQuota.resetsAt, now))
+                  : `Resets ${quotaResetsWhen(voiceQuota.resetsAt, now)}.`}
+              </p>
+            </>
+          ) : (
+            <p className="settings-note">{hostedVoiceNote(voiceService)}</p>
+          )}
+          {/* The numbers come off whichever reading is in hand, so the
+              dropdown can never name a ceiling the service is not enforcing. */}
+          <UsageDisclosure
+            {...(voiceQuota ? { voice: voiceQuota.limit } : {})}
+            {...(reviewQuota ? { reviews: reviewQuota.limit } : {})}
+          />
+        </>
+      )}
+      {storageLocked ? <p className="settings-note">{STORAGE_UNAVAILABLE_NOTE}</p> : null}
+    </section>
+  );
+}
+
+/**
+ * Who is signed in, and the two ways out of that. It sits at the foot of the
+ * front page rather than at its head: what an account is spending is checked
+ * daily and belongs up top, where What Luke runs on now draws it, while signing
+ * out and deleting are done once or never. Both ways out ask before they act.
+ */
+function AccountSection({
+  account,
+  onSignOut,
+  onDeleteAccount,
+  panelOpen,
+}: {
+  account: Extract<AccountSnapshot, { status: typeof ACCOUNT_STATUS.SIGNED_IN }>;
+  onSignOut: () => Promise<void>;
+  onDeleteAccount: () => Promise<string | undefined>;
+  panelOpen: boolean;
 }): React.JSX.Element {
   // Signing out asks first, the way deleting a key does: getting back in costs
   // a whole trip through the browser, so the button asks and only the answer
@@ -2380,13 +2674,10 @@ function AccountSection({
   };
 
   return (
-    <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
+    <section className="settings-section" style={{ "--row-index": 5 } as React.CSSProperties}>
       <h2>
         <UserIcon />
-        Account and usage
-        {/* The mark for voice having nothing to run on sits where both ways
-            in now live: the sign-in above and the key row below. */}
-        {settings.voiceAvailable ? null : <AttentionMark note={VOICE_KEYLESS_NOTE} />}
+        Account
       </h2>
       <div className="settings-row">
         <span className="settings-copy account-identity">
@@ -2466,81 +2757,6 @@ function AccountSection({
           </fieldset>
         </span>
       </div>
-      {/* What the account is buying right now, said where the account is: the
-          day's allowance drawn as meters while voice runs on it — both from
-          the usage read, or the voice meter alone from the quota the last
-          mint carried while no read has answered — with the note beneath
-          keeping only what the bars cannot say. A key of the developer's own
-          is named instead. The wording is the Voice page's own, worded once,
-          with the key row named because it is a page away from here. */}
-      {hosted && (hostedUsage || voiceService?.quota) ? (
-        <>
-          {(() => {
-            // The freshest reading of each meter, wherever it came from: the
-            // usage read against the quota the last mint carried, day and
-            // remainder telling the two apart — and neither counted past its
-            // own reset, because a spent yesterday must not be drawn as an
-            // almost-back today. Reviews only ride while the read shares the
-            // freshest day — an older read's reviews would be an older day's.
-            const now = Date.now();
-            const voiceQuota = fresherQuota(
-              currentQuota(hostedUsage?.voice, now),
-              currentQuota(voiceService?.quota, now),
-            );
-            if (!voiceQuota) {
-              // Every reading in hand has outlived its day: fall back to the
-              // words that promise no numbers, exactly as before the first
-              // read of a day.
-              return (
-                <p className="settings-note">
-                  {hostedVoiceNote(voiceService, { offersKey: !storageLocked })}
-                </p>
-              );
-            }
-            // Decided, not missed: a same-day reviews reading may trail a
-            // fresher voice mint, because mints say nothing about reviews —
-            // dropping it would delete the only reviews count for no accuracy
-            // gained. The skew is bounded by the refresh riding every settings
-            // change and tab turn, and a different day still discards it.
-            const reviews =
-              hostedUsage && hostedUsage.attention.resetsAt === voiceQuota.resetsAt
-                ? hostedUsage.attention
-                : undefined;
-            const resetsIn = quotaResetsInWords(voiceQuota.resetsAt, Date.now());
-            const parts = [
-              voiceQuota.remaining === 0 ? hostedVoiceSpentNote(resetsIn) : `Resets ${resetsIn}.`,
-              ...(storageLocked ? [] : [hostedVoiceLift()]),
-            ];
-            return (
-              <>
-                <UsageMeter label="Voice calls" quota={voiceQuota} />
-                {reviews ? <UsageMeter label="Session reviews" quota={reviews} /> : null}
-                {parts.length > 0 ? <p className="settings-note">{parts.join(" ")}</p> : null}
-              </>
-            );
-          })()}
-        </>
-      ) : hosted ? (
-        <p className="settings-note">
-          {hostedVoiceNote(voiceService, { offersKey: !storageLocked })}
-        </p>
-      ) : keyed ? (
-        <p className="settings-note">Voice runs on your OpenAI key — no daily limits.</p>
-      ) : null}
-      {/* The key row lives with the account because they are the two ways
-          voice can run, and the meters above are what the key changes. The
-          same storage refusal every key section shows replaces the entry
-          while this system cannot store one; the keyless state needs no note
-          of its own here — the heading's mark and the sign-in above already
-          say both ways in. */}
-      <ProviderCredential
-        provider={VOICE_CREDENTIAL_PROVIDER}
-        source={settings.credentialSources[VOICE_CREDENTIAL_PROVIDER.id]}
-        storageUnavailable={storageLocked}
-        control={credentials}
-        panelOpen={panelOpen}
-      />
-      {storageLocked ? <p className="settings-note">{STORAGE_UNAVAILABLE_NOTE}</p> : null}
       <div className="settings-row">
         <span className="settings-copy">
           <strong>Delete account</strong>
@@ -2769,29 +2985,20 @@ export function SettingsPanel({
       ) : null}
 
       {drawnView === SETTINGS_VIEW.ROOT ? (
-        /* The front page: whose account this is and what it is buying right
-           now, then one row per page, then the sections that answer at a
-           glance — what Luke is allowed, the way to the founders, and the way
-           out. The account leads because the allowance it carries is the first
-           thing worth knowing about a hosted run, and its sign-out asks before
-           it acts, so leading with it costs no accidental exits. */
+        /* The front page: what voice runs on and what is left of it today,
+           then one row per page, then the sections that answer at a glance —
+           what Luke is allowed, the way to the founders, whose account this
+           is, and the way out. The allowance leads because it is the one
+           thing here worth checking daily; the account itself follows the
+           page down to the ways out, which are done once or never. */
         <>
           {account.status === ACCOUNT_STATUS.SIGNED_IN && settings ? (
-            <AccountSection
-              account={account}
-              onSignOut={onSignOut}
-              onDeleteAccount={onDeleteAccount}
+            <WhatLukeRunsOnSection
               panelOpen={panelOpen}
-              hosted={
-                settings.voiceAvailable &&
-                settings.credentialSources[VOICE_CREDENTIAL_PROVIDER.id] === CREDENTIAL_SOURCE.NONE
-              }
-              keyed={
-                settings.credentialSources[VOICE_CREDENTIAL_PROVIDER.id] !== CREDENTIAL_SOURCE.NONE
-              }
               storageLocked={settings.secretStorage === SECRET_STORAGE.UNAVAILABLE}
               settings={settings}
               credentials={credentials}
+              preferences={preferences}
               {...(voiceService ? { voiceService } : {})}
               {...(hostedUsage ? { hostedUsage } : {})}
             />
@@ -2857,10 +3064,22 @@ export function SettingsPanel({
 
           <FeedbackSection control={feedback} />
 
+          {/* The account and the two ways out of it, last of the sections:
+              signing out and deleting are rare, cannot be taken back, and
+              have nothing to do with the allowance the page opens on. */}
+          {account.status === ACCOUNT_STATUS.SIGNED_IN ? (
+            <AccountSection
+              account={account}
+              onSignOut={onSignOut}
+              onDeleteAccount={onDeleteAccount}
+              panelOpen={panelOpen}
+            />
+          ) : null}
+
           <button
             type="button"
             className="quit-button"
-            style={{ "--row-index": 5 } as React.CSSProperties}
+            style={{ "--row-index": 6 } as React.CSSProperties}
             onClick={onQuit}
           >
             <PowerIcon />

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -2488,20 +2488,30 @@ function AccountSection({
         </span>
       </div>
       {/* What the account is buying right now, said where the account is: the
-          day's allowance drawn as two meters while voice runs on it — the
-          note beneath them keeps only what the bars cannot say — or whose key
-          it runs on instead. The wording is the Voice page's own, worded
-          once, with the key row named because it is a page away from here. */}
-      {hosted && hostedUsage ? (
+          day's allowance drawn as meters while voice runs on it — both from
+          the usage read, or the voice meter alone from the quota the last
+          mint carried while no read has answered — with the note beneath
+          keeping only what the bars cannot say. A key of the developer's own
+          is named instead. The wording is the Voice page's own, worded once,
+          with the key row named because it is a page away from here. */}
+      {hosted && (hostedUsage || voiceService?.quota) ? (
         <>
-          <UsageMeter label="Voice calls" quota={hostedUsage.voice} />
-          <UsageMeter label="Session reviews" quota={hostedUsage.attention} />
           {(() => {
+            const voiceQuota = hostedUsage?.voice ?? voiceService?.quota;
+            if (!voiceQuota) return null;
             const parts = [
-              ...(hostedUsage.voice.remaining === 0 ? [HOSTED_VOICE_SPENT_NOTE] : []),
+              ...(voiceQuota.remaining === 0 ? [HOSTED_VOICE_SPENT_NOTE] : []),
               ...(storageLocked ? [] : [hostedVoiceLift({ namesKeyRow: true })]),
             ];
-            return parts.length > 0 ? <p className="settings-note">{parts.join(" ")}</p> : null;
+            return (
+              <>
+                <UsageMeter label="Voice calls" quota={voiceQuota} />
+                {hostedUsage ? (
+                  <UsageMeter label="Session reviews" quota={hostedUsage.attention} />
+                ) : null}
+                {parts.length > 0 ? <p className="settings-note">{parts.join(" ")}</p> : null}
+              </>
+            );
           })()}
         </>
       ) : hosted ? (

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -1,5 +1,6 @@
 import {
   DEFAULT_PANEL_FORM_FACTOR,
+  type HostedQuota,
   type HostedUsageAnswer,
   isPanelFormFactor,
   isProviderId,
@@ -74,6 +75,8 @@ import { Keycaps } from "./keycaps";
 import { type ErrandTarget, errandTargetProps } from "./luke-errand";
 import { APP_SETTING_ID } from "./luke-guide";
 import {
+  HOSTED_VOICE_SPENT_NOTE,
+  hostedVoiceLift,
   hostedVoiceNote,
   MICROPHONE_UNGRANTED_NOTE,
   microphoneAccessRow,
@@ -2296,6 +2299,34 @@ const ACCOUNT_ASK = {
 
 type AccountAsk = (typeof ACCOUNT_ASK)[keyof typeof ACCOUNT_ASK];
 
+/**
+ * One meter of today's allowance, drawn as a track the day fills. The native
+ * `meter` rather than a progressbar, because nothing is underway: it reports
+ * a level against a limit. Nothing about it animates — a changed value snaps
+ * in place and only the section's arrival staggers — and a spent meter turns
+ * to the attention color, so the bar and the sentence beside it agree.
+ */
+function UsageMeter({ label, quota }: { label: string; quota: HostedQuota }): React.JSX.Element {
+  const capped = Math.min(quota.used, quota.limit);
+  return (
+    <div className="usage-meter" data-spent={String(quota.remaining === 0)}>
+      <span className="usage-words" aria-hidden="true">
+        <small>{label}</small>
+        <small>
+          {quota.remaining} of {quota.limit} left
+        </small>
+      </span>
+      <meter
+        className="usage-track"
+        min={0}
+        max={quota.limit > 0 ? quota.limit : 1}
+        value={quota.limit > 0 ? capped : 1}
+        aria-label={`${label}: ${quota.remaining} of ${quota.limit} left today`}
+      />
+    </div>
+  );
+}
+
 function AccountSection({
   account,
   onSignOut,
@@ -2303,6 +2334,7 @@ function AccountSection({
   panelOpen,
   hosted,
   keyed,
+  storageLocked,
   voiceService,
   hostedUsage,
 }: {
@@ -2314,6 +2346,11 @@ function AccountSection({
   hosted: boolean;
   /** Whether voice runs on the developer's own key instead. */
   keyed: boolean;
+  /**
+   * Whether this system cannot store a key at all. The Voice page withholds
+   * its connect invitation then, so the hint pointing there must too.
+   */
+  storageLocked: boolean;
   voiceService?: RealtimeDiagnostics;
   hostedUsage?: HostedUsageAnswer;
 }): React.JSX.Element {
@@ -2451,12 +2488,28 @@ function AccountSection({
         </span>
       </div>
       {/* What the account is buying right now, said where the account is: the
-          day's remaining allowance while voice runs on it, or whose key it
-          runs on instead. The wording is the Voice page's own note, worded
+          day's allowance drawn as two meters while voice runs on it — the
+          note beneath them keeps only what the bars cannot say — or whose key
+          it runs on instead. The wording is the Voice page's own, worded
           once, with the key row named because it is a page away from here. */}
-      {hosted ? (
+      {hosted && hostedUsage ? (
+        <>
+          <UsageMeter label="Voice calls" quota={hostedUsage.voice} />
+          <UsageMeter label="Session reviews" quota={hostedUsage.attention} />
+          {(() => {
+            const parts = [
+              ...(hostedUsage.voice.remaining === 0 ? [HOSTED_VOICE_SPENT_NOTE] : []),
+              ...(storageLocked ? [] : [hostedVoiceLift({ namesKeyRow: true })]),
+            ];
+            return parts.length > 0 ? <p className="settings-note">{parts.join(" ")}</p> : null;
+          })()}
+        </>
+      ) : hosted ? (
         <p className="settings-note">
-          {hostedVoiceNote(voiceService, hostedUsage, { namesKeyRow: true })}
+          {hostedVoiceNote(voiceService, hostedUsage, {
+            namesKeyRow: true,
+            offersKey: !storageLocked,
+          })}
         </p>
       ) : keyed ? (
         <p className="settings-note">
@@ -2710,6 +2763,7 @@ export function SettingsPanel({
               keyed={
                 settings.credentialSources[VOICE_CREDENTIAL_PROVIDER.id] !== CREDENTIAL_SOURCE.NONE
               }
+              storageLocked={settings.secretStorage === SECRET_STORAGE.UNAVAILABLE}
               {...(voiceService ? { voiceService } : {})}
               {...(hostedUsage ? { hostedUsage } : {})}
             />

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -2497,6 +2497,11 @@ function AccountSection({
                 </p>
               );
             }
+            // Decided, not missed: a same-day reviews reading may trail a
+            // fresher voice mint, because mints say nothing about reviews —
+            // dropping it would delete the only reviews count for no accuracy
+            // gained. The skew is bounded by the refresh riding every settings
+            // change and tab turn, and a different day still discards it.
             const reviews =
               hostedUsage && hostedUsage.attention.resetsAt === voiceQuota.resetsAt
                 ? hostedUsage.attention

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -75,11 +75,13 @@ import { Keycaps } from "./keycaps";
 import { type ErrandTarget, errandTargetProps } from "./luke-errand";
 import { APP_SETTING_ID } from "./luke-guide";
 import {
-  HOSTED_VOICE_SPENT_NOTE,
+  fresherQuota,
   hostedVoiceLift,
   hostedVoiceNote,
+  hostedVoiceSpentNote,
   MICROPHONE_UNGRANTED_NOTE,
   microphoneAccessRow,
+  quotaResetsInWords,
   VOICE_KEYLESS_NOTE,
   voiceAttentionNote,
 } from "./microphone-access";
@@ -1649,73 +1651,41 @@ function SettingsPageHeader({
 function VoiceSection({
   settings,
   preferences,
-  credentials,
-  panelOpen,
   microphone,
-  voiceService,
-  hostedUsage,
 }: {
   settings: AppSettings;
   preferences: PreferenceWrites;
-  credentials: CredentialEntryControl;
-  panelOpen: boolean;
   microphone: MicrophoneControl;
-  voiceService?: RealtimeDiagnostics;
-  hostedUsage?: HostedUsageAnswer;
 }): React.JSX.Element {
-  const storageUnavailable = settings.secretStorage === SECRET_STORAGE.UNAVAILABLE;
   const microphoneRow = microphoneAccessRow({
     voiceAvailable: microphone.voiceAvailable,
     status: microphone.status,
   });
   return (
     <>
-      <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
-        <h2>
-          <KeyIcon />
-          OpenAI API key
-          {/* The same mark, for the same missing key, as the front page's
-              Voice row wears: the row someone pressed a mark to reach is the
-              row that has to carry it. */}
-          {settings.voiceAvailable ? null : <AttentionMark note={VOICE_KEYLESS_NOTE} />}
-        </h2>
-        <ProviderCredential
-          provider={VOICE_CREDENTIAL_PROVIDER}
-          source={settings.credentialSources[VOICE_CREDENTIAL_PROVIDER.id]}
-          storageUnavailable={storageUnavailable}
-          control={credentials}
-          panelOpen={panelOpen}
-        />
-        {/* Said only while it is true, and as a state rather than an error:
-            nothing is broken, the page is waiting on the one thing that turns
-            it on. `voiceAvailable` rather than the credential source, because
-            availability is the store's own answer — a fixture run or a key
-            that failed to resolve leaves voice off however the row reads.
-            While voice runs on the account instead, the note says whose
-            allowance is speaking and what a key of one's own changes, so an
-            unconnected row above a working feature does not read as a step
-            still owed. While this system cannot store a key at all, the
-            storage refusal replaces the invitation: a Connect stilled by
-            missing storage needs its why here exactly as it does in the other
-            key sections, and a note urging a key the panel will not store
-            would only send someone to a disabled control. */}
-        {storageUnavailable ? (
-          <p className="settings-note">{STORAGE_UNAVAILABLE_NOTE}</p>
-        ) : !settings.voiceAvailable ? (
+      {/* The key row lives with the account on the front page now — voice's
+          two ways in stand together there. This page holds what voice does
+          once it runs; while it cannot run, the one section says where to
+          turn it on rather than drawing settings for a feature two steps
+          from working. */}
+      {settings.voiceAvailable ? null : (
+        <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
+          <h2>
+            <KeyIcon />
+            Voice
+            <AttentionMark note={VOICE_KEYLESS_NOTE} />
+          </h2>
           <p className="settings-note">
-            Voice is off until you sign in or connect a key — Luke cannot talk, listen, or announce
-            sessions.
+            Voice is off until you sign in or connect an OpenAI key — both live under Account and
+            usage, at the top of Settings. Luke cannot talk, listen, or announce sessions.
           </p>
-        ) : settings.credentialSources[VOICE_CREDENTIAL_PROVIDER.id] === CREDENTIAL_SOURCE.NONE ? (
-          <p className="settings-note">{hostedVoiceNote(voiceService, hostedUsage)}</p>
-        ) : null}
-      </section>
+        </section>
+      )}
       {/* Drawn only once there is a voice for the microphone to reach: until
-          the key connects, the permission guards a feature that cannot run,
-          and the page holds the one thing to do next rather than a queue of
-          them. */}
+          then, the permission guards a feature that cannot run, and the page
+          holds the one thing to do next rather than a queue of them. */}
       {settings.voiceAvailable ? (
-        <section className="settings-section" style={{ "--row-index": 2 } as React.CSSProperties}>
+        <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
           <h2>
             <ShieldIcon />
             Permissions
@@ -1773,7 +1743,7 @@ function VoiceSection({
   );
 }
 
-/** The voice controls themselves, below the key that powers them. */
+/** The voice controls themselves, below the permission that lets Luke listen. */
 function VoiceControlsSection({
   settings,
   preferences,
@@ -1784,7 +1754,7 @@ function VoiceControlsSection({
   return (
     <section
       className="settings-section settings-plain"
-      style={{ "--row-index": 3 } as React.CSSProperties}
+      style={{ "--row-index": 2 } as React.CSSProperties}
     >
       <SelectRow
         label="Voice"
@@ -2335,6 +2305,8 @@ function AccountSection({
   hosted,
   keyed,
   storageLocked,
+  settings,
+  credentials,
   voiceService,
   hostedUsage,
 }: {
@@ -2347,10 +2319,13 @@ function AccountSection({
   /** Whether voice runs on the developer's own key instead. */
   keyed: boolean;
   /**
-   * Whether this system cannot store a key at all. The Voice page withholds
-   * its connect invitation then, so the hint pointing there must too.
+   * Whether this system cannot store a key at all. The key row's connect
+   * invitation is withheld then, and so is every hint pointing at it.
    */
   storageLocked: boolean;
+  settings: AppSettings;
+  /** The one credential being entered anywhere; the key row here uses it. */
+  credentials: CredentialEntryControl;
   voiceService?: RealtimeDiagnostics;
   hostedUsage?: HostedUsageAnswer;
 }): React.JSX.Element {
@@ -2407,7 +2382,10 @@ function AccountSection({
     <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
       <h2>
         <UserIcon />
-        Account
+        Account and usage
+        {/* The mark for voice having nothing to run on sits where both ways
+            in now live: the sign-in above and the key row below. */}
+        {settings.voiceAvailable ? null : <AttentionMark note={VOICE_KEYLESS_NOTE} />}
       </h2>
       <div className="settings-row">
         <span className="settings-copy account-identity">
@@ -2497,18 +2475,26 @@ function AccountSection({
       {hosted && (hostedUsage || voiceService?.quota) ? (
         <>
           {(() => {
-            const voiceQuota = hostedUsage?.voice ?? voiceService?.quota;
+            // The freshest reading of each meter, wherever it came from: the
+            // usage read against the quota the last mint carried, day and
+            // remainder telling the two apart. Reviews only ride while the
+            // read shares the freshest day — an older read's reviews would be
+            // an older day's.
+            const voiceQuota = fresherQuota(hostedUsage?.voice, voiceService?.quota);
             if (!voiceQuota) return null;
+            const reviews =
+              hostedUsage && hostedUsage.attention.resetsAt === voiceQuota.resetsAt
+                ? hostedUsage.attention
+                : undefined;
+            const resetsIn = quotaResetsInWords(voiceQuota.resetsAt, Date.now());
             const parts = [
-              ...(voiceQuota.remaining === 0 ? [HOSTED_VOICE_SPENT_NOTE] : []),
-              ...(storageLocked ? [] : [hostedVoiceLift({ namesKeyRow: true })]),
+              voiceQuota.remaining === 0 ? hostedVoiceSpentNote(resetsIn) : `Resets ${resetsIn}.`,
+              ...(storageLocked ? [] : [hostedVoiceLift()]),
             ];
             return (
               <>
                 <UsageMeter label="Voice calls" quota={voiceQuota} />
-                {hostedUsage ? (
-                  <UsageMeter label="Session reviews" quota={hostedUsage.attention} />
-                ) : null}
+                {reviews ? <UsageMeter label="Session reviews" quota={reviews} /> : null}
                 {parts.length > 0 ? <p className="settings-note">{parts.join(" ")}</p> : null}
               </>
             );
@@ -2516,16 +2502,25 @@ function AccountSection({
         </>
       ) : hosted ? (
         <p className="settings-note">
-          {hostedVoiceNote(voiceService, hostedUsage, {
-            namesKeyRow: true,
-            offersKey: !storageLocked,
-          })}
+          {hostedVoiceNote(voiceService, { offersKey: !storageLocked })}
         </p>
       ) : keyed ? (
-        <p className="settings-note">
-          Voice and session review run on your own OpenAI key, unmetered.
-        </p>
+        <p className="settings-note">Voice runs on your OpenAI key — no daily limits.</p>
       ) : null}
+      {/* The key row lives with the account because they are the two ways
+          voice can run, and the meters above are what the key changes. The
+          same storage refusal every key section shows replaces the entry
+          while this system cannot store one; the keyless state needs no note
+          of its own here — the heading's mark and the sign-in above already
+          say both ways in. */}
+      <ProviderCredential
+        provider={VOICE_CREDENTIAL_PROVIDER}
+        source={settings.credentialSources[VOICE_CREDENTIAL_PROVIDER.id]}
+        storageUnavailable={storageLocked}
+        control={credentials}
+        panelOpen={panelOpen}
+      />
+      {storageLocked ? <p className="settings-note">{STORAGE_UNAVAILABLE_NOTE}</p> : null}
       <div className="settings-row">
         <span className="settings-copy">
           <strong>Delete account</strong>
@@ -2685,11 +2680,12 @@ export function SettingsPanel({
   // Why the front page's Voice row wears its mark, or nothing while voice is
   // fully set up. Judged here rather than on the Voice page because the mark
   // has to stand while that page is not drawn: it is the front page saying a
-  // page one press away still needs a hand.
-  const voiceNote = voiceAttentionNote({
-    voiceAvailable: microphone.voiceAvailable,
-    status: microphone.status,
-  });
+  // page one press away still needs a hand. The keyless half moved to the
+  // Account and usage heading with the ways in, so the row marks only a
+  // microphone still ungranted for a voice that can run.
+  const voiceNote = microphone.voiceAvailable
+    ? voiceAttentionNote({ voiceAvailable: true, status: microphone.status })
+    : undefined;
   // The page as drawn, trailing the page as asked: turning one is a leave and
   // then an arrival, and the leaving page must be held mounted through its own
   // exit — the surface never resizes out from under something still drawn.
@@ -2774,6 +2770,8 @@ export function SettingsPanel({
                 settings.credentialSources[VOICE_CREDENTIAL_PROVIDER.id] !== CREDENTIAL_SOURCE.NONE
               }
               storageLocked={settings.secretStorage === SECRET_STORAGE.UNAVAILABLE}
+              settings={settings}
+              credentials={credentials}
               {...(voiceService ? { voiceService } : {})}
               {...(hostedUsage ? { hostedUsage } : {})}
             />
@@ -2795,15 +2793,7 @@ export function SettingsPanel({
       ) : null}
 
       {drawnView === SETTINGS_VIEW.VOICE && settings ? (
-        <VoiceSection
-          settings={settings}
-          preferences={preferences}
-          credentials={credentials}
-          panelOpen={panelOpen}
-          microphone={microphone}
-          {...(voiceService ? { voiceService } : {})}
-          {...(hostedUsage ? { hostedUsage } : {})}
-        />
+        <VoiceSection settings={settings} preferences={preferences} microphone={microphone} />
       ) : null}
 
       {drawnView === SETTINGS_VIEW.APPEARANCE && settings ? (

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -2301,11 +2301,21 @@ function AccountSection({
   onSignOut,
   onDeleteAccount,
   panelOpen,
+  hosted,
+  keyed,
+  voiceService,
+  hostedUsage,
 }: {
   account: Extract<AccountSnapshot, { status: typeof ACCOUNT_STATUS.SIGNED_IN }>;
   onSignOut: () => Promise<void>;
   onDeleteAccount: () => Promise<string | undefined>;
   panelOpen: boolean;
+  /** Whether voice currently runs on this account's included allowance. */
+  hosted: boolean;
+  /** Whether voice runs on the developer's own key instead. */
+  keyed: boolean;
+  voiceService?: RealtimeDiagnostics;
+  hostedUsage?: HostedUsageAnswer;
 }): React.JSX.Element {
   // Signing out asks first, the way deleting a key does: getting back in costs
   // a whole trip through the browser, so the button asks and only the answer
@@ -2357,7 +2367,7 @@ function AccountSection({
   };
 
   return (
-    <section className="settings-section" style={{ "--row-index": 4 } as React.CSSProperties}>
+    <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
       <h2>
         <UserIcon />
         Account
@@ -2440,6 +2450,19 @@ function AccountSection({
           </fieldset>
         </span>
       </div>
+      {/* What the account is buying right now, said where the account is: the
+          day's remaining allowance while voice runs on it, or whose key it
+          runs on instead. The wording is the Voice page's own note, worded
+          once, with the key row named because it is a page away from here. */}
+      {hosted ? (
+        <p className="settings-note">
+          {hostedVoiceNote(voiceService, hostedUsage, { namesKeyRow: true })}
+        </p>
+      ) : keyed ? (
+        <p className="settings-note">
+          Voice and session review run on your own OpenAI key, unmetered.
+        </p>
+      ) : null}
       <div className="settings-row">
         <span className="settings-copy">
           <strong>Delete account</strong>
@@ -2544,7 +2567,7 @@ function pageResetControl(
 function UpdatesSection({ control }: { control: UpdateControl }): React.JSX.Element {
   const row = updateRow(control.update);
   return (
-    <section className="settings-section" style={{ "--row-index": 2 } as React.CSSProperties}>
+    <section className="settings-section" style={{ "--row-index": 3 } as React.CSSProperties}>
       <h2>
         <DownloadIcon />
         Updates
@@ -2667,22 +2690,44 @@ export function SettingsPanel({
       ) : null}
 
       {drawnView === SETTINGS_VIEW.ROOT ? (
-        /* The front page: one row per page, then the sections that answer at
-           a glance — what Luke is allowed, the way to the founders, and the
-           way out. */
-        <section
-          className="settings-section settings-index"
-          style={{ "--row-index": 1 } as React.CSSProperties}
-        >
-          {SETTINGS_SUBVIEW_LIST.map((subview) => (
-            <SettingsNavRow
-              key={subview}
-              view={subview}
-              onOpen={onViewChange}
-              {...(subview === SETTINGS_VIEW.VOICE && voiceNote ? { attention: voiceNote } : {})}
+        /* The front page: whose account this is and what it is buying right
+           now, then one row per page, then the sections that answer at a
+           glance — what Luke is allowed, the way to the founders, and the way
+           out. The account leads because the allowance it carries is the first
+           thing worth knowing about a hosted run, and its sign-out asks before
+           it acts, so leading with it costs no accidental exits. */
+        <>
+          {account.status === ACCOUNT_STATUS.SIGNED_IN && settings ? (
+            <AccountSection
+              account={account}
+              onSignOut={onSignOut}
+              onDeleteAccount={onDeleteAccount}
+              panelOpen={panelOpen}
+              hosted={
+                settings.voiceAvailable &&
+                settings.credentialSources[VOICE_CREDENTIAL_PROVIDER.id] === CREDENTIAL_SOURCE.NONE
+              }
+              keyed={
+                settings.credentialSources[VOICE_CREDENTIAL_PROVIDER.id] !== CREDENTIAL_SOURCE.NONE
+              }
+              {...(voiceService ? { voiceService } : {})}
+              {...(hostedUsage ? { hostedUsage } : {})}
             />
-          ))}
-        </section>
+          ) : null}
+          <section
+            className="settings-section settings-index"
+            style={{ "--row-index": 2 } as React.CSSProperties}
+          >
+            {SETTINGS_SUBVIEW_LIST.map((subview) => (
+              <SettingsNavRow
+                key={subview}
+                view={subview}
+                onOpen={onViewChange}
+                {...(subview === SETTINGS_VIEW.VOICE && voiceNote ? { attention: voiceNote } : {})}
+              />
+            ))}
+          </section>
+        </>
       ) : null}
 
       {drawnView === SETTINGS_VIEW.VOICE && settings ? (
@@ -2737,18 +2782,6 @@ export function SettingsPanel({
           <UpdatesSection control={updates} />
 
           <FeedbackSection control={feedback} />
-
-          {/* The account stands last before the way out: signing out and
-              quitting are the two acts that end the session, so they live
-              together at the foot rather than above the sections still in use. */}
-          {account.status === ACCOUNT_STATUS.SIGNED_IN ? (
-            <AccountSection
-              account={account}
-              onSignOut={onSignOut}
-              onDeleteAccount={onDeleteAccount}
-              panelOpen={panelOpen}
-            />
-          ) : null}
 
           <button
             type="button"

--- a/apps/desktop/src/renderer/settings-views.ts
+++ b/apps/desktop/src/renderer/settings-views.ts
@@ -72,7 +72,7 @@ export function pageExitMs(element: Element | null): number {
  * each setting. That the two agree is a test rather than a type, because one
  * is a sentence and the other is a page.
  */
-export const SETTING_PAGE: Record<AppSettingId, SettingsSubview> = {
+export const SETTING_PAGE: Record<AppSettingId, SettingsView> = {
   [APP_SETTING_ID.VOICE]: SETTINGS_VIEW.VOICE,
   [APP_SETTING_ID.VOICE_SPEED]: SETTINGS_VIEW.VOICE,
   [APP_SETTING_ID.VOICE_CAPTIONS]: SETTINGS_VIEW.VOICE,
@@ -92,13 +92,18 @@ export const SETTING_PAGE: Record<AppSettingId, SettingsSubview> = {
   [APP_SETTING_ID.DEFAULT_WORKSPACE_PROVIDER]: SETTINGS_VIEW.CONNECTIONS,
   [APP_SETTING_ID.WORKSPACE_AGENT_MODEL]: SETTINGS_VIEW.CONNECTIONS,
   [APP_SETTING_ID.WORKSPACE_AGENT_EFFORT]: SETTINGS_VIEW.CONNECTIONS,
+  // The front page itself, which is why the value type is a view rather than
+  // a subview: the choice of what Luke runs on leads the page rather than
+  // living on one the page opens. By-hand-only like the three above, so
+  // nothing ever flies to it — but where it is drawn is a fact either way.
+  [APP_SETTING_ID.VOICE_SOURCE]: SETTINGS_VIEW.ROOT,
 };
 
 /**
  * Which page draws a provider's credential row. Every key lives under
- * Connections except the one voice runs on: the OpenAI BYOK row stands in the
- * Account and usage section on the Settings front page, beside the allowance
- * it lifts. This is what brings a credential entry back from the key slot to
+ * Connections except the one voice runs on: the OpenAI row stands in the
+ * What Luke runs on section on the Settings front page, beside the allowance it
+ * replaces. This is what brings a credential entry back from the key slot to
  * the page it began on — restoring Connections around an entry begun on the
  * front page would land the answer on a page nobody was looking at.
  */
@@ -108,8 +113,58 @@ export function credentialSettingsPage(providerId: CredentialProviderId): Settin
     : SETTINGS_VIEW.CONNECTIONS;
 }
 
+/**
+ * The three things that can stand the panel down and take its place: a key
+ * being entered, a calendar sign-in waiting on the browser, and a note being
+ * written. Each is begun from a row on one of Settings' pages, and each has to
+ * come back to that row.
+ */
+export const PANEL_STAND_DOWN = {
+  KEY: "key",
+  CALENDAR: "calendar",
+  FEEDBACK: "feedback",
+} as const;
+
+export type PanelStandDown = (typeof PANEL_STAND_DOWN)[keyof typeof PANEL_STAND_DOWN];
+
+/**
+ * The two of those three the slot shape is drawn around, never both at once.
+ * A note is not one of them: the composer is its own shape, at its own size.
+ */
+export type SlotOccupant = typeof PANEL_STAND_DOWN.KEY | typeof PANEL_STAND_DOWN.CALENDAR;
+
+/** What stood the panel down, and — for a key — whose row it was begun from. */
+export type StoodDown =
+  | { kind: typeof PANEL_STAND_DOWN.KEY; providerId: CredentialProviderId }
+  | { kind: typeof PANEL_STAND_DOWN.CALENDAR }
+  | { kind: typeof PANEL_STAND_DOWN.FEEDBACK };
+
+/**
+ * Which page a stand-down comes back to: the page its own row is drawn on.
+ * Returning is a fact about what was begun, not about what was begun last —
+ * one remembered page shared by all three lands a cancelled note on whichever
+ * page the last key entry happened to belong to.
+ *
+ * A key's row is its provider's; the calendar's block stands under
+ * Integrations on Connections; the feedback composer's section is on the front
+ * page itself, which is also where a return that knows nothing else belongs.
+ */
+export function standDownReturnPage(stood: StoodDown): SettingsView {
+  switch (stood.kind) {
+    case PANEL_STAND_DOWN.KEY:
+      return credentialSettingsPage(stood.providerId);
+    case PANEL_STAND_DOWN.CALENDAR:
+      return SETTINGS_VIEW.CONNECTIONS;
+    case PANEL_STAND_DOWN.FEEDBACK:
+      return SETTINGS_VIEW.ROOT;
+  }
+}
+
 /** How each page names itself, which is how the guide's by-hand paths word it. */
-export const SETTINGS_PAGE_LABEL: Record<SettingsSubview, string> = {
+export const SETTINGS_PAGE_LABEL: Record<SettingsView, string> = {
+  // Not a page a row opens, but a place a setting can be drawn — and the
+  // words the guide's by-hand paths use for it.
+  [SETTINGS_VIEW.ROOT]: "front page",
   [SETTINGS_VIEW.VOICE]: "Voice",
   [SETTINGS_VIEW.APPEARANCE]: "Appearance",
   [SETTINGS_VIEW.SHORTCUTS]: "Keyboard shortcuts",

--- a/apps/desktop/src/renderer/settings-views.ts
+++ b/apps/desktop/src/renderer/settings-views.ts
@@ -96,15 +96,15 @@ export const SETTING_PAGE: Record<AppSettingId, SettingsSubview> = {
 
 /**
  * Which page draws a provider's credential row. Every key lives under
- * Connections except the one voice runs on: the OpenAI row stands at the top
- * of the Voice page, beside the feature it turns on. This is what brings a
- * credential entry back from the key slot to the page it began on — restoring
- * Connections around an entry begun on Voice would land the answer on a page
- * nobody was looking at.
+ * Connections except the one voice runs on: the OpenAI BYOK row stands in the
+ * Account and usage section on the Settings front page, beside the allowance
+ * it lifts. This is what brings a credential entry back from the key slot to
+ * the page it began on — restoring Connections around an entry begun on the
+ * front page would land the answer on a page nobody was looking at.
  */
-export function credentialSettingsPage(providerId: CredentialProviderId): SettingsSubview {
+export function credentialSettingsPage(providerId: CredentialProviderId): SettingsView {
   return providerId === VOICE_CREDENTIAL_PROVIDER_ID
-    ? SETTINGS_VIEW.VOICE
+    ? SETTINGS_VIEW.ROOT
     : SETTINGS_VIEW.CONNECTIONS;
 }
 

--- a/apps/desktop/src/renderer/styles/settings.css
+++ b/apps/desktop/src/renderer/styles/settings.css
@@ -362,11 +362,203 @@
 
 .usage-track::-webkit-meter-optimum-value {
   border-radius: 999px;
-  background: color-mix(in srgb, var(--state-complete) 62%, transparent);
+  background: color-mix(in srgb, var(--state-working) 62%, transparent);
 }
 
-.usage-meter[data-spent="true"] .usage-track::-webkit-meter-optimum-value {
+/* Getting close, and gone: the same attention orange a session row wears when
+   it is about to need the developer, at the same weight — the warning arrives
+   while there is still something left to spend differently, rather than only
+   once there is not. */
+.usage-meter[data-level="low"] .usage-track::-webkit-meter-optimum-value,
+.usage-meter[data-level="spent"] .usage-track::-webkit-meter-optimum-value {
   background: color-mix(in srgb, var(--state-attention) 72%, transparent);
+}
+
+/* The two credentials Luke can run on, side by side: one value from a set of
+   two, drawn open rather than as a pop-up because seeing both at once — with
+   what each costs on its face — is the entire point of the control.
+
+   Two buttons rather than a segmented control in a well of its own: they are
+   the same pair of offers the Feedback section makes a few rows down, so they
+   are drawn in the same vocabulary — the quiet button's ground and radius at
+   rest, lifting to the ground and edge a chosen filter chip takes for the one
+   that is live. Chosen is a state, not an act: the accent belongs to the
+   meters below, which say what the choice is costing, and a button wearing it
+   too would read as the thing to press rather than the thing already true. */
+.source-toggle {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: 1fr 1fr;
+}
+
+.source-choice {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  /* The quiet button's box, opened up for a second line. The edge is carried
+     transparent at rest so taking one on the live half re-shapes nothing. */
+  padding: 8px 11px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: var(--raised);
+  color: var(--text-secondary);
+  font-family: inherit;
+  gap: 2px;
+  text-align: left;
+  cursor: pointer;
+  /* Ground, edge and colour only — the box never re-shapes as the choice
+     moves, so the words inside it are laid out once. */
+  transition:
+    background-color var(--duration-hover) ease,
+    border-color var(--duration-hover) ease,
+    color var(--duration-hover) ease;
+}
+
+.source-choice:hover:not([data-live="true"]):not(:has(input:disabled)) {
+  background: var(--raised-strong);
+  color: var(--text-primary);
+}
+
+.source-choice[data-live="true"] {
+  border-color: var(--selected-edge);
+  background: var(--selected);
+  color: var(--text-primary);
+}
+
+.source-choice:has(input:disabled) {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.source-choice small {
+  overflow: hidden;
+  color: var(--text-tertiary);
+  font-size: 9.5px;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The live half's second line comes up with the rest of it, a step behind the
+   name so the two lines keep their order. */
+.source-choice[data-live="true"] small {
+  color: var(--text-secondary);
+}
+
+.source-name {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 5px;
+  /* The button's own weight, at the size a two-line button's first line
+     wants. */
+  font-size: 10.5px;
+  font-weight: 640;
+}
+
+/* What the half costs, as a tag rather than a sentence: two words that have
+   to be read before the name is chosen, not after. Free wears the same green
+   the meters and the switches wear for a state that is simply on. */
+.source-price {
+  flex: 0 0 auto;
+  padding: 1px 5px;
+  border-radius: 999px;
+  background: var(--raised-strong);
+  color: var(--text-tertiary);
+  font-size: 8.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.source-choice:first-child .source-price {
+  background: color-mix(in srgb, var(--state-complete) 20%, transparent);
+  color: color-mix(in srgb, var(--state-complete) 85%, white);
+}
+
+/* The check sits beside the price, not at the end of the line: what this half
+   costs and that it is the one running are the two things a glance is after,
+   and they read fastest as one mark. Sized to the words rather than to the
+   12px a credential row's check takes, because here it is a letter in a
+   label — and it keeps that row's green, which is the one accent on a button
+   that is otherwise the surface's own grays. */
+.source-choice .credential-check {
+  width: 10px;
+  height: 10px;
+  margin-left: -1px;
+}
+
+/* What a meter counts, folded away until asked. The panel's own scroll takes
+   the growth — the surface in panel mode is a fixed height and is not
+   measured off this content — so opening one costs no resize and nothing here
+   animates. The marker is drawn rather than the system's, because Chromium's
+   own triangle cannot be coloured with the rest of the line. */
+.settings-disclosure > summary {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--text-secondary);
+  font-size: 10px;
+  list-style: none;
+  /* Pressable, like every other control in the panel that answers a press. */
+  cursor: pointer;
+  transition: color var(--duration-hover) ease;
+}
+
+.settings-disclosure > summary::-webkit-details-marker {
+  display: none;
+}
+
+.settings-disclosure > summary::before {
+  color: var(--text-tertiary);
+  content: "›";
+  font-size: 11px;
+  /* Rotation only: the glyph turns in place, so the words beside it never
+     re-shape. */
+  transition: transform var(--duration-quick) var(--spring-fast);
+}
+
+.settings-disclosure[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.settings-disclosure > summary:hover {
+  color: var(--text-primary);
+}
+
+/* One term per line with its meaning beneath. Flush with the summary rather
+   than indented under its marker: the disclosure is already the indent, and a
+   second one inside it pushed the answer away from the section's own column
+   for no reading it bought. */
+.settings-definitions {
+  display: flex;
+  flex-direction: column;
+  margin: 6px 0 2px;
+  gap: 2px;
+}
+
+.settings-definitions dt {
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 620;
+}
+
+.settings-definitions dt:not(:first-of-type) {
+  margin-top: 7px;
+}
+
+.settings-definitions dd {
+  margin: 0;
+  color: var(--text-tertiary);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+/* A line that speaks for every entry above it rather than being another one:
+   it takes a gap wider than the ones between the terms, so the list closes
+   before it starts. */
+.settings-disclosure-close {
+  margin-top: 10px;
 }
 
 /* The panel's switches. On is the palette connected and complete

--- a/apps/desktop/src/renderer/styles/settings.css
+++ b/apps/desktop/src/renderer/styles/settings.css
@@ -320,6 +320,55 @@
   line-height: 1.4;
 }
 
+/* Today's allowance, drawn as the day filling a track: the native meter,
+   redrawn through Chromium's meter parts. Nothing about it animates — a
+   changed value snaps, and only the section's own arrival staggers. The fill
+   wears the same complete green the switches wear for on, and turns to the
+   attention color once the meter is spent, so the bar and the sentence
+   beneath it agree. */
+.usage-meter {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.usage-words {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--text-tertiary);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.usage-track {
+  display: block;
+  width: 100%;
+  height: 4px;
+  appearance: none;
+}
+
+.usage-track::-webkit-meter-inner-element {
+  display: block;
+  height: 4px;
+}
+
+.usage-track::-webkit-meter-bar {
+  height: 4px;
+  border: none;
+  border-radius: 999px;
+  background: var(--raised-strong);
+}
+
+.usage-track::-webkit-meter-optimum-value {
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--state-complete) 62%, transparent);
+}
+
+.usage-meter[data-spent="true"] .usage-track::-webkit-meter-optimum-value {
+  background: color-mix(in srgb, var(--state-attention) 72%, transparent);
+}
+
 /* The panel's switches. On is the palette connected and complete
    already use, so an item that is drawn reads the same way a provider that is
    reachable does. Only the thumb moves, only by transform, and on

--- a/apps/desktop/src/renderer/styles/settings.css
+++ b/apps/desktop/src/renderer/styles/settings.css
@@ -378,34 +378,29 @@
    two, drawn open rather than as a pop-up because seeing both at once — with
    what each costs on its face — is the entire point of the control.
 
-   Two buttons rather than a segmented control in a well of its own: they are
-   the same pair of offers the Feedback section makes a few rows down, so they
-   are drawn in the same vocabulary — the quiet button's ground and radius at
-   rest, lifting to the ground and edge a chosen filter chip takes for the one
-   that is live. Chosen is a state, not an act: the accent belongs to the
+   The Feedback section offers its own pair a few rows down, and these are
+   drawn as that pair: the same flexed row at the same gap, each half wearing
+   `quiet-button` itself rather than a copy of its padding, radius, ground and
+   type. What is added here is only what a choice needs and an offer does not —
+   a second line, and the ground and edge a chosen filter chip takes for the
+   half that is live. Chosen is a state, not an act: the accent belongs to the
    meters below, which say what the choice is costing, and a button wearing it
    too would read as the thing to press rather than the thing already true. */
 .source-toggle {
-  display: grid;
-  gap: 8px;
-  grid-template-columns: 1fr 1fr;
+  display: flex;
+  gap: 7px;
 }
 
 .source-choice {
   display: flex;
   min-width: 0;
+  flex: 1 1 0;
   flex-direction: column;
-  /* The quiet button's box, opened up for a second line. The edge is carried
-     transparent at rest so taking one on the live half re-shapes nothing. */
-  padding: 8px 11px;
+  /* The edge is carried transparent at rest so taking one on the live half
+     re-shapes nothing. */
   border: 1px solid transparent;
-  border-radius: 10px;
-  background: var(--raised);
-  color: var(--text-secondary);
-  font-family: inherit;
   gap: 2px;
   text-align: left;
-  cursor: pointer;
   /* Ground, edge and colour only — the box never re-shapes as the choice
      moves, so the words inside it are laid out once. */
   transition:
@@ -414,26 +409,26 @@
     color var(--duration-hover) ease;
 }
 
-.source-choice:hover:not([data-live="true"]):not(:has(input:disabled)) {
-  background: var(--raised-strong);
-  color: var(--text-primary);
-}
-
-.source-choice[data-live="true"] {
-  border-color: var(--selected-edge);
-  background: var(--selected);
-  color: var(--text-primary);
-}
-
 .source-choice:has(input:disabled) {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+/* Both states hold their own ground under the pointer: the offer lifts the
+   way its Feedback twin does, and the live half stays exactly where it is,
+   because pressing it does nothing. */
+.source-choice[data-live="true"],
+.source-choice[data-live="true"]:hover {
+  border-color: var(--selected-edge);
+  background: var(--selected);
+  color: var(--text-primary);
 }
 
 .source-choice small {
   overflow: hidden;
   color: var(--text-tertiary);
   font-size: 9.5px;
+  font-weight: 500;
   line-height: 1.35;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -450,10 +445,6 @@
   min-width: 0;
   align-items: center;
   gap: 5px;
-  /* The button's own weight, at the size a two-line button's first line
-     wants. */
-  font-size: 10.5px;
-  font-weight: 640;
 }
 
 /* What the half costs, as a tag rather than a sentence: two words that have

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -1134,7 +1134,19 @@ export class SettingsStore {
       const ciphertext = normalized
         ? this.#cipher.encrypt(normalized).toString("base64")
         : undefined;
-      if (persisted.apiKeys[providerId] === ciphertext) return;
+      // Connecting the key voice runs on is choosing it: someone who parked on
+      // the free allowance and later pastes a key means to use that key, and a
+      // stored preference quietly ignoring it would look like the key failed
+      // to save. Deleting one leaves the choice alone — there is nothing left
+      // for it to hold back, and it says where to land if another key arrives.
+      const chooses =
+        providerId === VOICE_CREDENTIAL_PROVIDER_ID &&
+        ciphertext !== undefined &&
+        persisted.voiceSource !== VOICE_SOURCE.KEY;
+      // A key that is already stored is not a write — unless it is also the
+      // act of choosing it, which pasting the same key back while parked on
+      // the allowance is.
+      if (persisted.apiKeys[providerId] === ciphertext && !chooses) return;
       // Every other provider's ciphertext is carried over, so saving one key
       // never disturbs another.
       const apiKeys = { ...persisted.apiKeys };
@@ -1145,15 +1157,7 @@ export class SettingsStore {
         version: SETTINGS_FILE_VERSION,
         apiKeys,
       };
-      // Connecting the key voice runs on is choosing it: someone who parked on
-      // the free allowance and later pastes a fresh key means to use that key,
-      // and a stored preference quietly ignoring it would look like the key
-      // failed to save. Deleting one leaves the choice alone — there is
-      // nothing left for it to hold back, and it says where to land if another
-      // key ever arrives.
-      if (providerId === VOICE_CREDENTIAL_PROVIDER_ID && ciphertext) {
-        next.voiceSource = VOICE_SOURCE.KEY;
-      }
+      if (chooses) next.voiceSource = VOICE_SOURCE.KEY;
       await this.#write(next);
       this.#loading = Promise.resolve(next);
       this.#resolved.delete(providerId);

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -27,11 +27,14 @@ import {
   type AppSettings,
   CREDENTIAL_SOURCE,
   type CredentialSource,
+  isVoiceSource,
   SECRET_STORAGE,
   SETTINGS_RESET_SCOPE,
   type SecretStorage,
   type SettingsResetScope,
   type SettingsUpdateResult,
+  VOICE_SOURCE,
+  type VoiceSource,
 } from "./shared/contracts";
 import {
   CREDENTIAL_PROVIDER_ID,
@@ -68,6 +71,7 @@ const SETTINGS_FIELD = {
   VERSION: "version",
   VOICE: "voice",
   VOICE_CAPTIONS: "voiceCaptions",
+  VOICE_SOURCE: "voiceSource",
   VOICE_SPEED: "voiceSpeed",
   VOICE_HOTKEY: "voiceHotkey",
   WORKSPACE_AGENT_DEFAULTS: "workspaceAgentDefaults",
@@ -185,6 +189,14 @@ interface PersistedSettings {
    * and a corrupt value both land on doing it.
    */
   duckOtherMedia: boolean;
+  /**
+   * Which credential the user chose to speak and review on, absent until they
+   * choose. Absent means "whichever is there, the key first", which is what
+   * connecting a key meant before the choice existed — so an install that
+   * never touches the toggle behaves exactly as it always did, and only an
+   * explicit choice of the account holds a stored key back.
+   */
+  voiceSource?: VoiceSource;
   preferBuiltInMicrophone: boolean;
   /**
    * Whether announcements wait out calendar meetings. On unless the file says
@@ -458,6 +470,7 @@ function parsePersistedSettings(source: string): PersistedSettings {
   const version = record[SETTINGS_FIELD.VERSION];
   const calendarAccounts = storedCalendarAccounts(record);
   const voice = record[SETTINGS_FIELD.VOICE];
+  const voiceSource = record[SETTINGS_FIELD.VOICE_SOURCE];
   const voiceSpeed = record[SETTINGS_FIELD.VOICE_SPEED];
   const formFactor = record[SETTINGS_FIELD.FORM_FACTOR];
   const defaultWorkspaceProvider = record[SETTINGS_FIELD.DEFAULT_WORKSPACE_PROVIDER];
@@ -503,6 +516,11 @@ function parsePersistedSettings(source: string): PersistedSettings {
       record[SETTINGS_FIELD.DUCK_OTHER_MEDIA],
       APP_SETTING_DEFAULTS.duckOtherMedia,
     ),
+    // A source this build does not offer is dropped rather than carried, the
+    // way an unknown voice is: absent is a meaning of its own here — take
+    // whichever credential is there — so there is always somewhere safe to
+    // land.
+    ...(isVoiceSource(voiceSource) ? { voiceSource } : {}),
     preferBuiltInMicrophone: booleanSetting(
       record[SETTINGS_FIELD.PREFER_BUILT_IN_MICROPHONE],
       APP_SETTING_DEFAULTS.preferBuiltInMicrophone,
@@ -575,6 +593,9 @@ export class SettingsStore {
       // actually happen — and it travels with every settings reply, so storing a
       // key is what turns voice on and deleting one is what turns it off.
       voiceAvailable: await this.#voiceAvailable(),
+      // Resolved, not stored: the panel's toggle marks what a press of the
+      // talk key would actually spend, which is not always what was chosen.
+      voiceSource: await this.#resolveVoiceSource(),
       // Whether this build can offer the Google Calendar sign-in at all: a
       // registered OAuth client resolved, and this run would use what it
       // grants. Without one the integration is not drawn at all.
@@ -1036,6 +1057,48 @@ export class SettingsStore {
   }
 
   /**
+   * Which credential Luke actually runs on, from what is stored and what the
+   * user chose. The choice can only ever withhold a key that is there in
+   * favour of an account that can serve — never the other way round: falling
+   * back from an absent account onto a stored key would start spending the
+   * developer's money because something they did not touch went missing, and
+   * a fallback that costs money is not a fallback.
+   *
+   * Which leaves one rule, in one place, read by the panel and by the minter:
+   * the account serves when it was chosen and is signed in, or when there is
+   * no key to run on; otherwise the key does.
+   */
+  async #resolveVoiceSource(): Promise<VoiceSource> {
+    if (!this.#credentialsUsable) return VOICE_SOURCE.ACCOUNT;
+    const keyed = (await this.readApiKey(VOICE_CREDENTIAL_PROVIDER_ID)) !== undefined;
+    if (!keyed) return VOICE_SOURCE.ACCOUNT;
+    const chosen = (await this.#load()).voiceSource;
+    if (chosen !== VOICE_SOURCE.ACCOUNT) return VOICE_SOURCE.KEY;
+    // Chosen, but only honoured while the allowance it names can actually
+    // answer. Signed out, the stored key is what is left, and voice keeps
+    // working the way it did before the choice existed.
+    return (await this.readAccount()) !== undefined ? VOICE_SOURCE.ACCOUNT : VOICE_SOURCE.KEY;
+  }
+
+  /** Main-process only: the source the minter and the reviewer are built for. */
+  async readVoiceSource(): Promise<VoiceSource> {
+    return this.#resolveVoiceSource();
+  }
+
+  /**
+   * Chooses which credential Luke runs on. Stored as asked even where it
+   * cannot be honoured yet — choosing the account before signing in is a
+   * standing preference, not a refusal — because the resolution above is what
+   * decides what actually runs, every time it is asked.
+   */
+  async setVoiceSource(source: VoiceSource): Promise<SettingsUpdateResult> {
+    return this.#setField((persisted) => {
+      if (persisted.voiceSource === source) return;
+      return { ...persisted, voiceSource: source };
+    });
+  }
+
+  /**
    * Main-process only: the resolved key used to authenticate that provider's
    * reads. A provider with no key resolves to nothing, so its adapter observes
    * nothing and issues no request.
@@ -1082,6 +1145,15 @@ export class SettingsStore {
         version: SETTINGS_FILE_VERSION,
         apiKeys,
       };
+      // Connecting the key voice runs on is choosing it: someone who parked on
+      // the free allowance and later pastes a fresh key means to use that key,
+      // and a stored preference quietly ignoring it would look like the key
+      // failed to save. Deleting one leaves the choice alone — there is
+      // nothing left for it to hold back, and it says where to land if another
+      // key ever arrives.
+      if (providerId === VOICE_CREDENTIAL_PROVIDER_ID && ciphertext) {
+        next.voiceSource = VOICE_SOURCE.KEY;
+      }
       await this.#write(next);
       this.#loading = Promise.resolve(next);
       this.#resolved.delete(providerId);

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -2,6 +2,7 @@ import type {
   AttentionRequestResult,
   AttentionSpeech,
   FixtureSnapshot,
+  HostedUsageAnswer,
   IssueToolAction,
   NormalizedSession,
   ObservedWorkspaceProject,
@@ -814,6 +815,12 @@ export interface AppBridge {
    * It carries no credential material, which is what lets it cross at all.
    */
   requestRealtimeDiagnostics(): Promise<RealtimeDiagnostics>;
+  /**
+   * Where today's hosted allowance stands on both meters, read from the
+   * service without spending either. Nothing on a keyed or signed-out run,
+   * where no allowance is in play.
+   */
+  requestHostedUsage(): Promise<HostedUsageAnswer | undefined>;
   notifyReady(): void;
   quit(): void;
   onLifecycle(callback: (eventName: string) => void): () => void;
@@ -940,6 +947,7 @@ export const channels = {
   focusPanel: "app:focus-panel",
   requestRealtimeCredential: "app:request-realtime-credential",
   requestRealtimeDiagnostics: "app:request-realtime-diagnostics",
+  requestHostedUsage: "app:request-hosted-usage",
   attentionSpeech: "app:attention-speech",
   voiceHotkeyPress: "app:voice-hotkey-press",
   voiceHotkeyRelease: "app:voice-hotkey-release",

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -118,6 +118,29 @@ export interface ObservedAccountCalendars {
  * form factor keep their defaults beside their own types in `@sidecar/core`,
  * and the three keys' defaults live with the registrar that owns them.
  */
+/**
+ * The two credentials Luke can speak and review sessions on. Both paths reach
+ * OpenAI in the end; what differs is whose account pays and whether anything
+ * passes through Luke's service on the way.
+ *
+ * The account is free and metered daily; the key is the developer's own,
+ * unmetered, billed to them by OpenAI, and never touches Luke's service. A
+ * stored choice is what lets a key stay stored while the free allowance is
+ * being spent — without one, connecting a key would be the choice, and the
+ * only way back would be deleting it.
+ */
+export const VOICE_SOURCE = {
+  ACCOUNT: "account",
+  KEY: "key",
+} as const;
+
+export type VoiceSource = (typeof VOICE_SOURCE)[keyof typeof VOICE_SOURCE];
+
+/** Guards the source an IPC message carries, which the renderer chooses. */
+export function isVoiceSource(value: unknown): value is VoiceSource {
+  return value === VOICE_SOURCE.ACCOUNT || value === VOICE_SOURCE.KEY;
+}
+
 export const APP_SETTING_DEFAULTS = {
   showInDock: false,
   showInMenuBar: true,
@@ -203,6 +226,14 @@ export interface AppSettings {
    * they learn a deleted key turned it back off.
    */
   voiceAvailable: boolean;
+  /**
+   * Which credential Luke actually speaks and reviews sessions on right now,
+   * resolved rather than stored: the choice the user made where it can be
+   * honoured, and what is available where it cannot. The panel draws its
+   * toggle from this, so what is marked in use is always what a press of the
+   * talk key would really spend.
+   */
+  voiceSource: VoiceSource;
   /**
    * Whether this build can offer the Google Calendar sign-in: an OAuth client
    * registered and usable this run. Without one the integration is not drawn
@@ -615,6 +646,13 @@ export interface AppBridge {
   resetSettings(scope: SettingsResetScope): Promise<SettingsUpdateResult>;
   /** Turns the quieting of Music and Spotify during a spoken exchange on or off. */
   setDuckOtherMedia(enabled: boolean): Promise<SettingsUpdateResult>;
+  /**
+   * Chooses which credential Luke speaks and reviews sessions on. A choice
+   * only ever withholds a stored key while the account can serve instead — it
+   * can turn spending off, never on, so nothing here can start spending a key
+   * that is not there or an allowance that is not signed in.
+   */
+  setVoiceSource(source: VoiceSource): Promise<SettingsUpdateResult>;
   /** Turns the Mac-microphone-over-Bluetooth-headset preference on or off. */
   setPreferBuiltInMicrophone(enabled: boolean): Promise<SettingsUpdateResult>;
   /**
@@ -910,6 +948,7 @@ export const channels = {
   setAskHotkey: "app:set-ask-hotkey",
   setStopHotkey: "app:set-stop-hotkey",
   setDuckOtherMedia: "app:set-duck-other-media",
+  setVoiceSource: "app:set-voice-source",
   setPreferBuiltInMicrophone: "app:set-prefer-built-in-microphone",
   setQuietDuringMeetings: "app:set-quiet-during-meetings",
   connectGoogleCalendar: "app:connect-google-calendar",

--- a/apps/desktop/src/shared/credential-providers.ts
+++ b/apps/desktop/src/shared/credential-providers.ts
@@ -178,13 +178,16 @@ export const CREDENTIAL_PROVIDERS: Readonly<Record<CredentialProviderId, Credent
   },
   [CREDENTIAL_PROVIDER_ID.OPENAI]: {
     id: CREDENTIAL_PROVIDER_ID.OPENAI,
-    // "BYOK" — bring your own key — because the row's whole meaning is the
-    // choice it offers against the account's included allowance beside it.
-    displayName: "OpenAI BYOK",
-    // The panel writes apostrophes as `&rsquo;` in JSX and this string is read
-    // as text, so the apostrophe here is the typographic one rather than a
-    // straight quote.
-    description: "The API key for Luke’s voice capabilities.",
+    // The service, plainly. The row stands inside the section that already
+    // says what it is for — the other way voice can run — so the name has no
+    // acronym to carry: "BYOK" named the choice for anyone who already knew
+    // the word, and named nothing for everyone else.
+    displayName: "OpenAI",
+    // No description, alone among the providers, because its section says
+    // everything one could: the toggle above the row names both sources and
+    // what each costs, and the disclosure below it says what the key is spent
+    // on and who bills for it. A sentence between them could only repeat one
+    // of the two.
     // Realtime is what a spoken turn runs on, and an account that cannot reach
     // it fails at the first word rather than at the paste — so the line says so
     // before the key is entered rather than after.

--- a/apps/desktop/src/shared/credential-providers.ts
+++ b/apps/desktop/src/shared/credential-providers.ts
@@ -57,10 +57,6 @@ const LINEAR_ENVIRONMENT = {
   API_KEY: "LINEAR_API_KEY",
 } as const;
 
-const OPENAI_ENVIRONMENT = {
-  API_KEY: "OPENAI_API_KEY",
-} as const;
-
 /**
  * The only kind of credential Luke will hold for a provider that issues more
  * than one. Only a provider that publishes a format declares this; the rest
@@ -182,7 +178,9 @@ export const CREDENTIAL_PROVIDERS: Readonly<Record<CredentialProviderId, Credent
   },
   [CREDENTIAL_PROVIDER_ID.OPENAI]: {
     id: CREDENTIAL_PROVIDER_ID.OPENAI,
-    displayName: "OpenAI",
+    // "BYOK" — bring your own key — because the row's whole meaning is the
+    // choice it offers against the account's included allowance beside it.
+    displayName: "OpenAI BYOK",
     // The panel writes apostrophes as `&rsquo;` in JSX and this string is read
     // as text, so the apostrophe here is the typographic one rather than a
     // straight quote.
@@ -192,7 +190,12 @@ export const CREDENTIAL_PROVIDERS: Readonly<Record<CredentialProviderId, Credent
     // before the key is entered rather than after.
     hint: "Create a key on the OpenAI platform under API keys. Talking uses the Realtime API, which needs billing enabled.",
     apiKeysUrl: "https://platform.openai.com/api-keys",
-    environmentVariables: [OPENAI_ENVIRONMENT.API_KEY],
+    // Deliberately no environment fallback, alone among the providers: an
+    // `OPENAI_API_KEY` exported for some other tool would silently start
+    // spending itself on voice and move review off the hosted path — a key
+    // that costs money and changes where session fields travel is connected
+    // by hand or not at all.
+    environmentVariables: [],
     // No key format. Every kind OpenAI issues carries `sk-`, so a prefix would
     // refuse nothing, and which of them can reach Realtime is something only
     // OpenAI can answer — it answers it on the first mint.

--- a/apps/desktop/tests/credential-providers.test.ts
+++ b/apps/desktop/tests/credential-providers.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { HOSTED_METER_LABEL, KEY_USE_NOTE } from "../src/renderer/microphone-access";
 import {
   CLOUD_AGENT_PROVIDER_LIST,
   CREDENTIAL_PROVIDER_ID,
@@ -63,9 +64,13 @@ test("splits the settings sections without losing a provider", () => {
     INTEGRATION_PROVIDER_LIST.map((provider) => provider.id),
     [CREDENTIAL_PROVIDER_ID.LINEAR],
   );
-  // A row outside the agents' section carries its own answer to what
-  // connecting it buys.
-  for (const provider of [...INTEGRATION_PROVIDER_LIST, VOICE_CREDENTIAL_PROVIDER]) {
+  // An integration's row carries its own answer to what connecting it buys,
+  // because its section holds several and cannot say it once. The voice key is
+  // the exception: its section is the whole answer — a toggle naming both
+  // sources with their prices, and a disclosure saying what the key is spent
+  // on — so a sentence on the row could only repeat one of the two.
+  assert.equal(VOICE_CREDENTIAL_PROVIDER.description, undefined);
+  for (const provider of INTEGRATION_PROVIDER_LIST) {
     assert.ok(provider.description, `${provider.id} says what connecting it allows`);
   }
 });
@@ -141,8 +146,9 @@ test("holds the key Luke speaks through, apart from the agents he observes", () 
   // environment, because an OPENAI_API_KEY exported for some other tool must
   // not silently start being spent on voice or move the review path.
   assert.equal(isCredentialProviderId(CREDENTIAL_PROVIDER_ID.OPENAI), true);
-  // Named for the choice the row offers against the included allowance beside it.
-  assert.equal(openai.displayName, "OpenAI BYOK");
+  // The service, plainly: the row stands inside the section that already says
+  // what it is for, so it carries no acronym of its own.
+  assert.equal(openai.displayName, "OpenAI");
   assert.deepEqual(openai.environmentVariables, []);
   // Realtime is what a spoken turn runs on, and an account that cannot reach it
   // fails at the first word rather than at the paste.
@@ -159,8 +165,12 @@ test("holds the key Luke speaks through, apart from the agents he observes", () 
   assert.equal(VOICE_CREDENTIAL_PROVIDER, openai);
   assert.equal(INTEGRATION_PROVIDER_LIST.includes(openai), false);
   assert.equal(CLOUD_AGENT_PROVIDER_LIST.includes(openai), false);
-  // The row that holds the key says what it is for, because a credential that
-  // quietly enables an outbound request should not have to be learned from a
-  // README.
-  assert.match(openai.description ?? "", /voice/i);
+  // What the key is for is still on screen, because a credential that quietly
+  // enables an outbound request should not have to be learned from a README —
+  // it is just no longer on the row. The section around it carries it: the
+  // toggle names the two sources, and the disclosure beneath the row says the
+  // two things the key is spent on.
+  assert.match(HOSTED_METER_LABEL.VOICE, /talking/i);
+  assert.match(HOSTED_METER_LABEL.REVIEWS, /sessions/i);
+  assert.match(KEY_USE_NOTE, /OpenAI bills you/);
 });

--- a/apps/desktop/tests/credential-providers.test.ts
+++ b/apps/desktop/tests/credential-providers.test.ts
@@ -31,8 +31,14 @@ test("describes every provider it lists", () => {
     assert.equal(CREDENTIAL_PROVIDERS[provider.id], provider, "a provider is filed under its id");
     assert.ok(provider.displayName.length > 0);
     assert.ok(provider.hint.length > 0);
-    // The environment fallback every provider offers is `<PROVIDER>_API_KEY`.
-    assert.ok(provider.environmentVariables[0]?.endsWith("_API_KEY"), provider.id);
+    // The environment fallback is `<PROVIDER>_API_KEY` — except OpenAI, which
+    // deliberately offers none: a key that costs money and moves the review
+    // path is connected by hand or not at all.
+    if (provider.id === CREDENTIAL_PROVIDER_ID.OPENAI) {
+      assert.deepEqual(provider.environmentVariables, [], provider.id);
+    } else {
+      assert.ok(provider.environmentVariables[0]?.endsWith("_API_KEY"), provider.id);
+    }
     // A declared format has to say what it wants as well as refuse, because
     // the reason is the only thing the user has to act on.
     if (!provider.keyFormat) continue;
@@ -130,12 +136,14 @@ test("takes only the Linear key kind a person holds", () => {
 test("holds the key Luke speaks through, apart from the agents he observes", () => {
   const openai = CREDENTIAL_PROVIDERS[VOICE_CREDENTIAL_PROVIDER_ID];
 
-  // Voice is a credential like any other now: it can be pasted in, replaced and
-  // deleted, rather than reaching the app only through the environment it was
-  // launched with — which an app opened from Finder never has.
+  // Voice is a credential like any other in the panel — pasted in, replaced,
+  // deleted — and stricter than the rest outside it: never read from the
+  // environment, because an OPENAI_API_KEY exported for some other tool must
+  // not silently start being spent on voice or move the review path.
   assert.equal(isCredentialProviderId(CREDENTIAL_PROVIDER_ID.OPENAI), true);
-  assert.equal(openai.displayName, "OpenAI");
-  assert.deepEqual(openai.environmentVariables, ["OPENAI_API_KEY"]);
+  // Named for the choice the row offers against the included allowance beside it.
+  assert.equal(openai.displayName, "OpenAI BYOK");
+  assert.deepEqual(openai.environmentVariables, []);
   // Realtime is what a spoken turn runs on, and an account that cannot reach it
   // fails at the first word rather than at the paste.
   assert.match(openai.hint, /Realtime/);

--- a/apps/desktop/tests/hosted-usage.test.ts
+++ b/apps/desktop/tests/hosted-usage.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { HostedUsageReader } from "../src/hosted-usage";
+
+const ANSWER = {
+  voice: { used: 3, limit: 50, remaining: 47, resetsAt: 1_800_003_600_000 },
+  attention: { used: 41, limit: 500, remaining: 459, resetsAt: 1_800_003_600_000 },
+};
+
+interface RecordedRequest {
+  url: string;
+  init: RequestInit;
+}
+
+function service(answers: Array<() => Response>) {
+  const requests: RecordedRequest[] = [];
+  let call = 0;
+  const fetchLike = async (url: string, init: RequestInit): Promise<Response> => {
+    requests.push({ url, init });
+    const answer = answers[Math.min(call, answers.length - 1)];
+    call += 1;
+    if (!answer) throw new Error("no scripted answer");
+    return answer();
+  };
+  return { requests, fetchLike };
+}
+
+function reader(options: Partial<ConstructorParameters<typeof HostedUsageReader>[0]> = {}) {
+  return new HostedUsageReader({
+    serviceBaseUrl: "https://tryluke.dev",
+    readAccessToken: async () => "token-1",
+    refreshAccount: async () => undefined,
+    ...options,
+  });
+}
+
+test("reads both meters on the account's bearer token without spending either", async () => {
+  const { requests, fetchLike } = service([
+    () => new Response(JSON.stringify(ANSWER), { status: 200 }),
+  ]);
+
+  const usage = await reader({ fetch: fetchLike }).read();
+  assert.deepEqual(usage, ANSWER);
+
+  const [request] = requests;
+  assert.equal(request?.url, "https://tryluke.dev/api/usage");
+  assert.equal(request?.init.method, "GET");
+  assert.equal(new Headers(request?.init.headers).get("authorization"), "Bearer token-1");
+});
+
+test("a 401 refreshes the account and retries once", async () => {
+  const tokens = ["stale-token", "fresh-token"];
+  let refreshes = 0;
+  const { requests, fetchLike } = service([
+    () => new Response(JSON.stringify({ error: "invalid-token" }), { status: 401 }),
+    () => new Response(JSON.stringify(ANSWER), { status: 200 }),
+  ]);
+
+  const usage = await reader({
+    fetch: fetchLike,
+    readAccessToken: async () => tokens[Math.min(refreshes, tokens.length - 1)],
+    refreshAccount: async () => {
+      refreshes += 1;
+    },
+  }).read();
+
+  assert.deepEqual(usage, ANSWER);
+  assert.equal(refreshes, 1);
+  assert.equal(new Headers(requests[1]?.init.headers).get("authorization"), "Bearer fresh-token");
+});
+
+test("failures, malformed answers, and a missing account all read as no answer", async () => {
+  const failing = reader({
+    fetch: service([() => new Response("oops", { status: 500 })]).fetchLike,
+  });
+  assert.equal(await failing.read(), undefined);
+
+  const malformed = reader({
+    fetch: service([() => new Response(JSON.stringify({ voice: { used: 1 } }), { status: 200 })])
+      .fetchLike,
+  });
+  assert.equal(await malformed.read(), undefined);
+
+  const { requests, fetchLike } = service([]);
+  const signedOut = reader({ fetch: fetchLike, readAccessToken: async () => undefined });
+  assert.equal(await signedOut.read(), undefined);
+  assert.equal(requests.length, 0);
+});

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -219,18 +219,19 @@ test("the facts say what is connected, never what connects it", () => {
   );
   assert.match(connected, /Google Calendar \(2 accounts connected\)/);
   assert.match(connected, /checkboxes under each account/);
-  // The voice key stands in a fact of its own, named for the choice it offers
-  // — BYOK against the account's included allowance — and placed where its
-  // row actually lives: the Account and usage section, not the Voice page or
-  // the Integrations section it once shared with Linear. With voice available
-  // and no key connected, the fact says whose allowance voice runs on; with
-  // voice unavailable, it says both ways in.
-  assert.match(rendered, /OpenAI BYOK \(not connected\)/);
+  // The voice key stands in a fact of its own, placed where its row actually
+  // lives: the What Luke runs on section, not the Voice page or the Integrations
+  // section it once shared with Linear. With voice available and no key
+  // connected, the fact says whose allowance voice runs on — and what a key
+  // of your own would cost instead; with voice unavailable, it says both ways
+  // in.
+  assert.match(rendered, /OpenAI \(not connected\)/);
   assert.match(rendered, /signed-in Luke account's daily allowance/);
-  assert.match(rendered, /Account and usage section, at the top/);
+  assert.match(rendered, /billed by OpenAI/);
+  assert.match(rendered, /What Luke runs on section at the top/);
   const voiceless = JSON.stringify(buildLukeGuide(guideInput({ voiceAvailable: false })).facts);
   assert.match(voiceless, /Signing in — or connecting a key — is what lets Luke speak/);
-  assert.doesNotMatch(rendered, /OpenAI BYOK[^"]*under Integrations/);
+  assert.doesNotMatch(rendered, /OpenAI[^"]*under Integrations/);
   // The guide leaves the machine, so no key, prefix, or environment variable
   // value has any business in it.
   assert.doesNotMatch(rendered, /API key:/);
@@ -535,9 +536,9 @@ test("the facts follow the talk key, the microphone, and the storage the system 
 
   const voiceless = buildLukeGuide(guideInput({ voiceAvailable: false }));
   assert.match(JSON.stringify(voiceless.facts), /nothing to run voice on/);
-  // The refusal carries the way out: both ways in live under Account and
-  // usage, and a fact that stopped at "off" would leave the ask unanswerable.
-  assert.match(JSON.stringify(voiceless.facts), /Account and usage section, at the top/);
+  // The refusal carries the way out: both ways in live under What Luke runs on,
+  // and a fact that stopped at "off" would leave the ask unanswerable.
+  assert.match(JSON.stringify(voiceless.facts), /What Luke runs on section at the top/);
   // The muted-output behavior belongs to speech, so it is described exactly
   // where speech exists: with a voice it is a fact, without one it would
   // describe captions no reply will ever draw.

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -219,18 +219,18 @@ test("the facts say what is connected, never what connects it", () => {
   );
   assert.match(connected, /Google Calendar \(2 accounts connected\)/);
   assert.match(connected, /checkboxes under each account/);
-  // The voice key stands in a fact of its own, saying what connecting it buys
-  // and naming the page its row actually lives on — the Voice page, not the
-  // Integrations section it once shared with Linear. With voice available and
-  // no key connected, the fact says whose account voice is running on; with
-  // voice unavailable, it says what connecting a key would turn on.
-  assert.match(rendered, /OpenAI \(not connected\)/);
-  assert.match(rendered, /run on the signed-in Luke account/);
-  assert.match(rendered, /daily allowance/);
-  assert.match(rendered, /Voice page, at its top/);
+  // The voice key stands in a fact of its own, named for the choice it offers
+  // — BYOK against the account's included allowance — and placed where its
+  // row actually lives: the Account and usage section, not the Voice page or
+  // the Integrations section it once shared with Linear. With voice available
+  // and no key connected, the fact says whose allowance voice runs on; with
+  // voice unavailable, it says both ways in.
+  assert.match(rendered, /OpenAI BYOK \(not connected\)/);
+  assert.match(rendered, /signed-in Luke account's daily allowance/);
+  assert.match(rendered, /Account and usage section, at the top/);
   const voiceless = JSON.stringify(buildLukeGuide(guideInput({ voiceAvailable: false })).facts);
-  assert.match(voiceless, /Connecting OpenAI is what lets Luke speak/);
-  assert.doesNotMatch(rendered, /OpenAI[^"]*under Integrations/);
+  assert.match(voiceless, /Signing in — or connecting a key — is what lets Luke speak/);
+  assert.doesNotMatch(rendered, /OpenAI BYOK[^"]*under Integrations/);
   // The guide leaves the machine, so no key, prefix, or environment variable
   // value has any business in it.
   assert.doesNotMatch(rendered, /API key:/);
@@ -534,10 +534,10 @@ test("the facts follow the talk key, the microphone, and the storage the system 
   assert.match(denied, /Privacy & Security/);
 
   const voiceless = buildLukeGuide(guideInput({ voiceAvailable: false }));
-  assert.match(JSON.stringify(voiceless.facts), /no OpenAI key is connected/);
-  // The refusal carries the way out: the key's row is at the top of the Voice
-  // page, and a fact that stopped at "off" would leave the ask unanswerable.
-  assert.match(JSON.stringify(voiceless.facts), /Voice page, at its top/);
+  assert.match(JSON.stringify(voiceless.facts), /nothing to run voice on/);
+  // The refusal carries the way out: both ways in live under Account and
+  // usage, and a fact that stopped at "off" would leave the ask unanswerable.
+  assert.match(JSON.stringify(voiceless.facts), /Account and usage section, at the top/);
   // The muted-output behavior belongs to speech, so it is described exactly
   // where speech exists: with a voice it is a fact, without one it would
   // describe captions no reply will ever draw.

--- a/apps/desktop/tests/microphone-access.test.ts
+++ b/apps/desktop/tests/microphone-access.test.ts
@@ -164,6 +164,11 @@ test("the usage read words both meters, and a spent voice reads the same from ei
   );
   assert.match(rolledOver, /47 of 50 calls/);
   assert.doesNotMatch(rolledOver, /used up/);
+
+  // A machine that cannot store a key is not sent to go connect one.
+  const locked = hostedVoiceNote(undefined, usage, { offersKey: false });
+  assert.doesNotMatch(locked, /OpenAI key/);
+  assert.match(locked, /left today\.$/);
 });
 
 test("the hosted note says whose allowance voice runs on, and what remains once known", () => {

--- a/apps/desktop/tests/microphone-access.test.ts
+++ b/apps/desktop/tests/microphone-access.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { REALTIME_DEFAULTS, REALTIME_MINT_OUTCOME, type RealtimeDiagnostics } from "@sidecar/core";
 import {
+  currentQuota,
   fresherQuota,
   hostedVoiceNote,
   hostedVoiceSpentNote,
@@ -186,4 +187,30 @@ test("the numberless note stays short, and withholds the key from a machine that
 
   const locked = hostedVoiceNote(undefined, { offersKey: false });
   assert.doesNotMatch(locked, /OpenAI key/);
+});
+
+test("a reading past its own reset is no reading, and a stale spent outcome goes quiet", () => {
+  const now = 1_800_000_000_000;
+  const running = { used: 50, limit: 50, remaining: 0, resetsAt: now + 3_600_000 };
+  const expired = { used: 50, limit: 50, remaining: 0, resetsAt: now - 1 };
+
+  assert.equal(currentQuota(running, now), running);
+  assert.equal(currentQuota(expired, now), undefined);
+  assert.equal(currentQuota(undefined, now), undefined);
+
+  // Yesterday's refusal, dated by its own expired quota, describes an
+  // allowance that no longer exists — the fresh day promises numbers again.
+  const rolled = hostedVoiceNote(
+    diagnostics({ lastOutcome: REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED, quota: expired }),
+    { now },
+  );
+  assert.doesNotMatch(rolled, /used up/);
+  assert.match(rolled, /included with your account/);
+
+  // Still inside its day, the refusal stands.
+  const standing = hostedVoiceNote(
+    diagnostics({ lastOutcome: REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED, quota: running }),
+    { now },
+  );
+  assert.match(standing, /used up/);
 });

--- a/apps/desktop/tests/microphone-access.test.ts
+++ b/apps/desktop/tests/microphone-access.test.ts
@@ -134,6 +134,29 @@ test("the mark and the row agree on what ready means", () => {
   }
 });
 
+test("the usage read words both meters, and a spent voice reads the same from either source", () => {
+  const usage = {
+    voice: { used: 3, limit: 50, remaining: 47, resetsAt: 1_800_003_600_000 },
+    attention: { used: 37, limit: 500, remaining: 463, resetsAt: 1_800_003_600_000 },
+  };
+  const counted = hostedVoiceNote(undefined, usage);
+  assert.match(counted, /47 of 50 calls and 463 of 500 session reviews left today/);
+
+  // The usage read outranks the quota a mint carried: it is fresher and it
+  // counts the reviews the mint's own diagnostics never see.
+  const both = hostedVoiceNote(
+    diagnostics({ quota: { used: 10, limit: 50, remaining: 40, resetsAt: 1_800_003_600_000 } }),
+    usage,
+  );
+  assert.match(both, /47 of 50 calls/);
+
+  const spentByUsage = hostedVoiceNote(undefined, {
+    ...usage,
+    voice: { used: 50, limit: 50, remaining: 0, resetsAt: 1_800_003_600_000 },
+  });
+  assert.match(spentByUsage, /used up — it returns at midnight UTC/);
+});
+
 test("the hosted note says whose allowance voice runs on, and what remains once known", () => {
   // Before any mint has answered, the note promises only the allowance.
   assert.match(

--- a/apps/desktop/tests/microphone-access.test.ts
+++ b/apps/desktop/tests/microphone-access.test.ts
@@ -155,6 +155,15 @@ test("the usage read words both meters, and a spent voice reads the same from ei
     voice: { used: 50, limit: 50, remaining: 0, resetsAt: 1_800_003_600_000 },
   });
   assert.match(spentByUsage, /used up — it returns at midnight UTC/);
+
+  // Yesterday's refusal must not outrank today's full allowance: the minter's
+  // last outcome survives midnight, the fresh read decides.
+  const rolledOver = hostedVoiceNote(
+    diagnostics({ lastOutcome: REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED }),
+    usage,
+  );
+  assert.match(rolledOver, /47 of 50 calls/);
+  assert.doesNotMatch(rolledOver, /used up/);
 });
 
 test("the hosted note says whose allowance voice runs on, and what remains once known", () => {

--- a/apps/desktop/tests/microphone-access.test.ts
+++ b/apps/desktop/tests/microphone-access.test.ts
@@ -2,8 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { REALTIME_DEFAULTS, REALTIME_MINT_OUTCOME, type RealtimeDiagnostics } from "@sidecar/core";
 import {
+  fresherQuota,
   hostedVoiceNote,
+  hostedVoiceSpentNote,
   microphoneAccessRow,
+  quotaResetsInWords,
   voiceAttentionNote,
 } from "../src/renderer/microphone-access";
 
@@ -134,66 +137,53 @@ test("the mark and the row agree on what ready means", () => {
   }
 });
 
-test("the usage read words both meters, and a spent voice reads the same from either source", () => {
-  const usage = {
-    voice: { used: 3, limit: 50, remaining: 47, resetsAt: 1_800_003_600_000 },
-    attention: { used: 37, limit: 500, remaining: 463, resetsAt: 1_800_003_600_000 },
-  };
-  const counted = hostedVoiceNote(undefined, usage);
-  assert.match(counted, /47 of 50 calls and 463 of 500 session reviews left today/);
+test("the fresher of two quota readings is decided from the readings themselves", () => {
+  const DAY_END = 1_800_003_600_000;
+  const older = { used: 3, limit: 50, remaining: 47, resetsAt: DAY_END };
+  const newerSameDay = { used: 10, limit: 50, remaining: 40, resetsAt: DAY_END };
+  const nextDay = { used: 0, limit: 50, remaining: 50, resetsAt: DAY_END + 86_400_000 };
 
-  // The usage read outranks the quota a mint carried: it is fresher and it
-  // counts the reviews the mint's own diagnostics never see.
-  const both = hostedVoiceNote(
-    diagnostics({ quota: { used: 10, limit: 50, remaining: 40, resetsAt: 1_800_003_600_000 } }),
-    usage,
-  );
-  assert.match(both, /47 of 50 calls/);
-
-  const spentByUsage = hostedVoiceNote(undefined, {
-    ...usage,
-    voice: { used: 50, limit: 50, remaining: 0, resetsAt: 1_800_003_600_000 },
-  });
-  assert.match(spentByUsage, /used up — it returns at midnight UTC/);
-
-  // Yesterday's refusal must not outrank today's full allowance: the minter's
-  // last outcome survives midnight, the fresh read decides.
-  const rolledOver = hostedVoiceNote(
-    diagnostics({ lastOutcome: REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED }),
-    usage,
-  );
-  assert.match(rolledOver, /47 of 50 calls/);
-  assert.doesNotMatch(rolledOver, /used up/);
-
-  // A machine that cannot store a key is not sent to go connect one.
-  const locked = hostedVoiceNote(undefined, usage, { offersKey: false });
-  assert.doesNotMatch(locked, /OpenAI key/);
-  assert.match(locked, /left today\.$/);
+  // Within one day the smaller remainder is the newer fact; across days the
+  // later reset wins — yesterday's spent counter must not outrank a fresh day.
+  assert.equal(fresherQuota(older, newerSameDay), newerSameDay);
+  assert.equal(fresherQuota(newerSameDay, older), newerSameDay);
+  assert.equal(fresherQuota(newerSameDay, nextDay), nextDay);
+  assert.equal(fresherQuota(undefined, older), older);
+  assert.equal(fresherQuota(older, undefined), older);
+  assert.equal(fresherQuota(undefined, undefined), undefined);
 });
 
-test("the hosted note says whose allowance voice runs on, and what remains once known", () => {
-  // Before any mint has answered, the note promises only the allowance.
-  assert.match(
+test("the reset is worded at the coarseness a daily counter earns", () => {
+  const now = 1_800_000_000_000;
+  assert.equal(quotaResetsInWords(now + 30_000, now), "in under a minute");
+  assert.equal(quotaResetsInWords(now + 25 * 60_000, now), "in about 25 minutes");
+  assert.equal(quotaResetsInWords(now + 70 * 60_000, now), "in about an hour");
+  assert.equal(quotaResetsInWords(now + 7 * 3_600_000, now), "in about 7 hours");
+});
+
+test("the spent sentence says when voice returns, at whatever precision is in hand", () => {
+  assert.equal(
+    hostedVoiceSpentNote("in about 7 hours"),
+    "Voice is used up — back in about 7 hours.",
+  );
+  assert.equal(hostedVoiceSpentNote(), "Voice is used up — back at midnight UTC.");
+});
+
+test("the numberless note stays short, and withholds the key from a machine that cannot store one", () => {
+  // Before any numbers are in hand, the note promises the allowance and
+  // offers the key row directly below it.
+  assert.equal(
     hostedVoiceNote(undefined),
-    /included with your Luke account, under a daily allowance/,
+    "Voice and session review are included with your account. Your own OpenAI key below lifts the limits.",
   );
-  assert.match(hostedVoiceNote(undefined), /your own OpenAI key lifts the allowance/i);
 
-  const counted = hostedVoiceNote(
-    diagnostics({
-      lastOutcome: REALTIME_MINT_OUTCOME.SUCCEEDED,
-      quota: { used: 3, limit: 50, remaining: 47, resetsAt: 1_800_003_600_000 },
-    }),
-  );
-  assert.match(counted, /47 of 50 calls left today/);
-
-  // A spent allowance is a state with its own return time, not an error.
+  // Only the minter's last outcome can speak here — a spent allowance is a
+  // state with its own return, not an error.
   const spent = hostedVoiceNote(
-    diagnostics({
-      lastOutcome: REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED,
-      quota: { used: 51, limit: 50, remaining: 0, resetsAt: 1_800_003_600_000 },
-    }),
+    diagnostics({ lastOutcome: REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED }),
   );
-  assert.match(spent, /used up — it returns at midnight UTC/);
-  assert.doesNotMatch(spent, /left today/);
+  assert.match(spent, /used up — back at midnight UTC/);
+
+  const locked = hostedVoiceNote(undefined, { offersKey: false });
+  assert.doesNotMatch(locked, /OpenAI key/);
 });

--- a/apps/desktop/tests/microphone-access.test.ts
+++ b/apps/desktop/tests/microphone-access.test.ts
@@ -7,9 +7,16 @@ import {
   hostedVoiceNote,
   hostedVoiceSpentNote,
   microphoneAccessRow,
-  quotaResetsInWords,
+  QUOTA_LEVEL,
+  quotaLevel,
+  quotaResetsWhen,
+  VOICE_SOURCE_DETAIL,
+  VOICE_SOURCE_LABEL,
+  VOICE_SOURCE_PRICE,
   voiceAttentionNote,
+  voiceSourceLabel,
 } from "../src/renderer/microphone-access";
+import { VOICE_SOURCE } from "../src/shared/contracts";
 
 /** A hosted diagnostics report with only what a test wants to vary. */
 function diagnostics(overrides: Partial<RealtimeDiagnostics>): RealtimeDiagnostics {
@@ -154,39 +161,100 @@ test("the fresher of two quota readings is decided from the readings themselves"
   assert.equal(fresherQuota(undefined, undefined), undefined);
 });
 
-test("the reset is worded at the coarseness a daily counter earns", () => {
+test("the reset is worded on the reader's own clock, and says tomorrow when it is", () => {
   const now = 1_800_000_000_000;
-  assert.equal(quotaResetsInWords(now + 30_000, now), "in under a minute");
-  assert.equal(quotaResetsInWords(now + 25 * 60_000, now), "in about 25 minutes");
-  assert.equal(quotaResetsInWords(now + 70 * 60_000, now), "in about an hour");
-  assert.equal(quotaResetsInWords(now + 7 * 3_600_000, now), "in about 7 hours");
+  const clock = (at: number) =>
+    new Date(at).toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+
+  // Inside the same local day, the hour alone is unambiguous.
+  const soon = now + 60_000;
+  assert.equal(quotaResetsWhen(soon, now), `at ${clock(soon)}`);
+
+  // A reset landing on the next local date has to say so: a bare time reads
+  // as today, and the counters turn over at midnight UTC — somebody else's
+  // clock, and never the reader's.
+  const nextDay = new Date(now);
+  nextDay.setDate(nextDay.getDate() + 1);
+  assert.equal(quotaResetsWhen(nextDay.getTime(), now), `tomorrow at ${clock(nextDay.getTime())}`);
 });
 
-test("the spent sentence says when voice returns, at whatever precision is in hand", () => {
-  assert.equal(
-    hostedVoiceSpentNote("in about 7 hours"),
-    "Voice is used up — back in about 7 hours.",
-  );
-  assert.equal(hostedVoiceSpentNote(), "Voice is used up — back at midnight UTC.");
+test("the spent sentence answers whether Luke is broken before it says when voice returns", () => {
+  const spent = hostedVoiceSpentNote("at 5:00 PM");
+  // The return, on the reader's own clock…
+  assert.match(spent, /back at 5:00 PM/);
+  // …and the reassurance the question is actually about: observation is local
+  // and unmetered, so the rows keep moving whatever the talking has cost.
+  assert.match(spent, /keeps watching your sessions/);
+  // With no reading in hand, the day boundary every counter shares.
+  assert.match(hostedVoiceSpentNote(), /back at midnight UTC/);
 });
 
 test("the numberless note stays short, and withholds the key from a machine that cannot store one", () => {
-  // Before any numbers are in hand, the note promises the allowance and
-  // offers the key row directly below it.
+  // Before any numbers are in hand, the note promises the allowance — free,
+  // and daily — and nothing else.
   assert.equal(
     hostedVoiceNote(undefined),
-    "Voice and session review are included with your account. Your own OpenAI key below lifts the limits.",
+    "Talking and session checks are included free with your account, up to a daily amount.",
   );
+
+  // What a key of the developer's own would change is the toggle's to say,
+  // drawn directly above with the price on its face. A sentence here repeating
+  // it would be the panel selling one half of a choice it is already showing
+  // whole — and it was worded for a key row that no longer stands alone.
+  assert.doesNotMatch(hostedVoiceNote(undefined), /OpenAI/);
 
   // Only the minter's last outcome can speak here — a spent allowance is a
   // state with its own return, not an error.
   const spent = hostedVoiceNote(
     diagnostics({ lastOutcome: REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED }),
   );
-  assert.match(spent, /used up — back at midnight UTC/);
+  assert.match(spent, /used today's free voice — back at midnight UTC/);
+});
 
-  const locked = hostedVoiceNote(undefined, { offersKey: false });
-  assert.doesNotMatch(locked, /OpenAI key/);
+test("the toggle names both sources and what each one costs", () => {
+  // Each half carries its own name, its own price, and one line saying what
+  // running on it is like. A half missing any of the three is a choice made
+  // blind — and the dropdown beneath does not repeat them, so the toggle is
+  // where the whole comparison has to live.
+  for (const source of [VOICE_SOURCE.ACCOUNT, VOICE_SOURCE.KEY]) {
+    assert.ok(VOICE_SOURCE_LABEL[source].length > 0, source);
+    assert.ok(VOICE_SOURCE_PRICE[source].length > 0, source);
+    assert.ok(VOICE_SOURCE_DETAIL[source].length > 0, source);
+    // The spoken name folds the price in, because a control read aloud as
+    // "your OpenAI key" alone withholds the one fact worth knowing first.
+    assert.match(voiceSourceLabel(source), /\(free\)|\(you pay\)/);
+  }
+
+  // Free is free and the key is not: the two prices must never read the same.
+  assert.notEqual(VOICE_SOURCE_PRICE[VOICE_SOURCE.ACCOUNT], VOICE_SOURCE_PRICE[VOICE_SOURCE.KEY]);
+});
+
+test("a meter warns while there is still something left to spend differently", () => {
+  const day = { limit: 50, resetsAt: 1_800_003_600_000 };
+  const at = (remaining: number) => ({ ...day, remaining, used: day.limit - remaining });
+
+  // Running, most of the day.
+  assert.equal(quotaLevel(at(50)), QUOTA_LEVEL.RUNNING);
+  assert.equal(quotaLevel(at(11)), QUOTA_LEVEL.RUNNING);
+  // The last fifth is the warning, and it arrives with ten calls still in
+  // hand — a ceiling nobody saw coming is the thing a meter exists to stop.
+  assert.equal(quotaLevel(at(10)), QUOTA_LEVEL.LOW);
+  assert.equal(quotaLevel(at(1)), QUOTA_LEVEL.LOW);
+  assert.equal(quotaLevel(at(0)), QUOTA_LEVEL.SPENT);
+
+  // One fraction, both meters: the review ceiling is ten times the voice one,
+  // and warns at the same stretch of its own day rather than at a count
+  // copied from the other.
+  const reviews = { limit: 500, resetsAt: day.resetsAt };
+  assert.equal(quotaLevel({ ...reviews, remaining: 101, used: 399 }), QUOTA_LEVEL.RUNNING);
+  assert.equal(quotaLevel({ ...reviews, remaining: 100, used: 400 }), QUOTA_LEVEL.LOW);
+
+  // A meter with no ceiling has nothing to say, which is not the same as
+  // having nothing left: it must not sit there warning about nothing.
+  assert.equal(
+    quotaLevel({ limit: 0, remaining: 3, used: 0, resetsAt: day.resetsAt }),
+    QUOTA_LEVEL.RUNNING,
+  );
 });
 
 test("a reading past its own reset is no reading, and a stale spent outcome goes quiet", () => {
@@ -204,13 +272,13 @@ test("a reading past its own reset is no reading, and a stale spent outcome goes
     diagnostics({ lastOutcome: REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED, quota: expired }),
     { now },
   );
-  assert.doesNotMatch(rolled, /used up/);
-  assert.match(rolled, /included with your account/);
+  assert.doesNotMatch(rolled, /used today's free voice/);
+  assert.match(rolled, /included free with your account/);
 
   // Still inside its day, the refusal stands.
   const standing = hostedVoiceNote(
     diagnostics({ lastOutcome: REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED, quota: running }),
     { now },
   );
-  assert.match(standing, /used up/);
+  assert.match(standing, /used today's free voice/);
 });

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -16,6 +16,7 @@ import {
   CREDENTIAL_SOURCE,
   SECRET_STORAGE,
   SETTINGS_RESET_SCOPE,
+  VOICE_SOURCE,
 } from "../src/shared/contracts";
 import {
   CREDENTIAL_PROVIDER_ID,
@@ -1625,4 +1626,91 @@ test("a reset leaves a stored key standing", async (t) => {
   assert.deepEqual(contents.apiKeys, { [CONDUCTOR]: sealed(TEST_API_KEY) });
   assert.equal(contents.voiceCaptions, false);
   assert.equal(await store.readApiKey(CONDUCTOR), TEST_API_KEY);
+});
+
+/** A signed-in account, which is what makes the free allowance answerable. */
+const TEST_ACCOUNT = {
+  accessToken: "access-token-secret",
+  refreshToken: "refresh-token-secret",
+  email: "developer@example.com",
+  name: "Developer",
+  provider: "github" as const,
+};
+
+test("with no key stored there is only one source to run on", async (t) => {
+  const store = storeIn(await temporaryDirectory(t));
+  await store.setAccount(TEST_ACCOUNT);
+
+  assert.equal(await store.readVoiceSource(), VOICE_SOURCE.ACCOUNT);
+  assert.equal((await store.snapshot()).voiceSource, VOICE_SOURCE.ACCOUNT);
+
+  // Choosing the key with none stored changes nothing about what runs: there
+  // is nothing there to spend, and a resolution that answered otherwise would
+  // send the minter to a credential that does not exist.
+  await store.setVoiceSource(VOICE_SOURCE.KEY);
+  assert.equal(await store.readVoiceSource(), VOICE_SOURCE.ACCOUNT);
+});
+
+test("connecting the voice key chooses it, and the allowance can take it back", async (t) => {
+  const store = storeIn(await temporaryDirectory(t));
+  await store.setAccount(TEST_ACCOUNT);
+  await store.setApiKey(CREDENTIAL_PROVIDER_ID.OPENAI, "sk-developers-own");
+
+  // Connecting is choosing: someone who pastes a key means to use it, and a
+  // stored preference quietly ignoring it would look like the save failed.
+  assert.equal(await store.readVoiceSource(), VOICE_SOURCE.KEY);
+
+  // And back again, with the key still stored — the whole point of the
+  // choice. Before it existed, the only way back was deleting the key.
+  await store.setVoiceSource(VOICE_SOURCE.ACCOUNT);
+  assert.equal(await store.readVoiceSource(), VOICE_SOURCE.ACCOUNT);
+  assert.equal(
+    (await store.snapshot()).credentialSources[CREDENTIAL_PROVIDER_ID.OPENAI],
+    CREDENTIAL_SOURCE.ENCRYPTED_FILE,
+    "parking on the allowance keeps the key",
+  );
+  // Voice is still on: what changed is whose credential answers, not whether
+  // one does.
+  assert.equal((await store.snapshot()).voiceAvailable, true);
+});
+
+test("a choice that would start spending a key is never made by fallback", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+  await store.setAccount(TEST_ACCOUNT);
+  await store.setApiKey(CREDENTIAL_PROVIDER_ID.OPENAI, "sk-developers-own");
+  await store.setVoiceSource(VOICE_SOURCE.ACCOUNT);
+  assert.equal(await store.readVoiceSource(), VOICE_SOURCE.ACCOUNT);
+
+  // Signed out, the allowance they chose cannot answer. The stored key is
+  // what is left, so voice keeps working exactly as it did before the choice
+  // existed — the fallback that costs nothing is the account's, and this one
+  // only runs when the free half has gone.
+  await store.clearAccount();
+  assert.equal(await store.readVoiceSource(), VOICE_SOURCE.KEY);
+
+  // Signing back in returns them to what they chose: the preference was
+  // stored, not spent.
+  await store.setAccount(TEST_ACCOUNT);
+  assert.equal(await store.readVoiceSource(), VOICE_SOURCE.ACCOUNT);
+});
+
+test("the chosen source survives a reopen, and a corrupt one reads as no choice", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+  await store.setAccount(TEST_ACCOUNT);
+  await store.setApiKey(CREDENTIAL_PROVIDER_ID.OPENAI, "sk-developers-own");
+  await store.setVoiceSource(VOICE_SOURCE.ACCOUNT);
+  assert.equal(await storeIn(directory).readVoiceSource(), VOICE_SOURCE.ACCOUNT);
+
+  // A source this build does not offer is dropped rather than carried, and
+  // dropping it lands on the behaviour that existed before the field did:
+  // whichever credential is there, the key first.
+  const contents = JSON.parse(await readSettingsFile(directory));
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({ ...contents, voiceSource: "someone-elses-account" }),
+    "utf8",
+  );
+  assert.equal(await storeIn(directory).readVoiceSource(), VOICE_SOURCE.KEY);
 });

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -1714,3 +1714,17 @@ test("the chosen source survives a reopen, and a corrupt one reads as no choice"
   );
   assert.equal(await storeIn(directory).readVoiceSource(), VOICE_SOURCE.KEY);
 });
+
+test("pasting a key back while parked on the allowance is still choosing it", async (t) => {
+  const store = storeIn(await temporaryDirectory(t));
+  await store.setAccount(TEST_ACCOUNT);
+  await store.setApiKey(CREDENTIAL_PROVIDER_ID.OPENAI, "sk-developers-own");
+  await store.setVoiceSource(VOICE_SOURCE.ACCOUNT);
+  assert.equal(await store.readVoiceSource(), VOICE_SOURCE.ACCOUNT);
+
+  // The same key again is no change to what is stored, but it is still the
+  // act of connecting one — and a save that quietly changed nothing would
+  // read as a key that failed to take.
+  await store.setApiKey(CREDENTIAL_PROVIDER_ID.OPENAI, "sk-developers-own");
+  assert.equal(await store.readVoiceSource(), VOICE_SOURCE.KEY);
+});

--- a/apps/desktop/tests/settings-views.test.ts
+++ b/apps/desktop/tests/settings-views.test.ts
@@ -32,15 +32,14 @@ test("a token that cannot be read falls back to the resting exit, not to none", 
 
 test("a credential entry returns to the page its row is drawn on", () => {
   // The OpenAI row lives at the top of the Voice page — it is what turns
-  // voice on — and every other key lives under Connections. An entry's trip
-  // to the key slot has to end back on the page it began on, or the check
-  // beside the provider lands on a page nobody is looking at.
+  // voice on — its OpenAI BYOK row lives in Account and usage on the front
+  // page — and every other key lives under Connections. An entry's trip to
+  // the key slot has to end back on the page it began on, or the check beside
+  // the provider lands on a page nobody is looking at.
   for (const provider of CREDENTIAL_PROVIDER_LIST) {
     assert.equal(
       credentialSettingsPage(provider.id),
-      provider.id === VOICE_CREDENTIAL_PROVIDER_ID
-        ? SETTINGS_VIEW.VOICE
-        : SETTINGS_VIEW.CONNECTIONS,
+      provider.id === VOICE_CREDENTIAL_PROVIDER_ID ? SETTINGS_VIEW.ROOT : SETTINGS_VIEW.CONNECTIONS,
       provider.id,
     );
   }

--- a/apps/desktop/tests/settings-views.test.ts
+++ b/apps/desktop/tests/settings-views.test.ts
@@ -3,8 +3,10 @@ import { test } from "node:test";
 import {
   credentialSettingsPage,
   PAGE_EXIT_MS,
+  PANEL_STAND_DOWN,
   pageExitFromToken,
   SETTINGS_VIEW,
+  standDownReturnPage,
 } from "../src/renderer/settings-views";
 import {
   CREDENTIAL_PROVIDER_LIST,
@@ -31,9 +33,9 @@ test("a token that cannot be read falls back to the resting exit, not to none", 
 });
 
 test("a credential entry returns to the page its row is drawn on", () => {
-  // The OpenAI row lives at the top of the Voice page — it is what turns
-  // voice on — its OpenAI BYOK row lives in Account and usage on the front
-  // page — and every other key lives under Connections. An entry's trip to
+  // The OpenAI row lives in the What Luke runs on section at the top of the front
+  // page — beside the allowance it replaces — and every other key lives under
+  // Connections. An entry's trip to
   // the key slot has to end back on the page it began on, or the check beside
   // the provider lands on a page nobody is looking at.
   for (const provider of CREDENTIAL_PROVIDER_LIST) {
@@ -43,4 +45,38 @@ test("a credential entry returns to the page its row is drawn on", () => {
       provider.id,
     );
   }
+});
+
+test("every stand-down comes back to the page its own row is drawn on", () => {
+  // A note is written from the Feedback section on the front page, so leaving
+  // the composer — or the thank-you a send lands in — belongs there. It went
+  // to Connections for as long as all three shapes shared one remembered
+  // page, which only ever held whichever key row was last opened.
+  assert.equal(
+    standDownReturnPage({ kind: PANEL_STAND_DOWN.FEEDBACK }),
+    SETTINGS_VIEW.ROOT,
+    "a note is begun and answered on the front page",
+  );
+
+  // The Google Calendar block stands under Integrations, so a cancelled or
+  // refused sign-in returns to the row that can try it again.
+  assert.equal(standDownReturnPage({ kind: PANEL_STAND_DOWN.CALENDAR }), SETTINGS_VIEW.CONNECTIONS);
+
+  // A key follows its own provider's row, wherever that is drawn — which is
+  // the one stand-down whose answer is not fixed.
+  for (const provider of CREDENTIAL_PROVIDER_LIST) {
+    assert.equal(
+      standDownReturnPage({ kind: PANEL_STAND_DOWN.KEY, providerId: provider.id }),
+      credentialSettingsPage(provider.id),
+      provider.id,
+    );
+  }
+
+  // No two of them can be the same rule read from the same place: the whole
+  // bug was one page standing in for three.
+  const pages = new Set([
+    standDownReturnPage({ kind: PANEL_STAND_DOWN.FEEDBACK }),
+    standDownReturnPage({ kind: PANEL_STAND_DOWN.CALENDAR }),
+  ]);
+  assert.equal(pages.size, 2, "a note and a calendar sign-in do not share a page");
 });

--- a/apps/web/api/usage.ts
+++ b/apps/web/api/usage.ts
@@ -1,0 +1,21 @@
+import { auth } from "../server/auth.js";
+import { getDatabase } from "../server/db/index.js";
+import { hostedUserId } from "../server/hosted/bearer.js";
+import { readHostedUsage } from "../server/hosted/quota.js";
+import { handleUsage } from "../server/hosted/usage.js";
+
+/**
+ * Reads today's allowance standing for the signed-in desktop. The logic lives
+ * in `server/hosted/usage.ts`; this file only hands it the deployment's real
+ * seams.
+ */
+export default {
+  fetch(request: Request): Promise<Response> {
+    return handleUsage({
+      request,
+      resolveUserId: (incoming) =>
+        hostedUserId(incoming, (input) => auth.api.oauth2UserInfo(input)),
+      readUsage: (userId) => readHostedUsage(getDatabase(), { userId, now: Date.now() }),
+    });
+  },
+};

--- a/apps/web/server/hosted/quota.ts
+++ b/apps/web/server/hosted/quota.ts
@@ -1,4 +1,5 @@
-import { sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
+import type { HostedQuota, HostedUsageAnswer } from "../core.js";
 import type { createDatabase } from "../db/index.js";
 import { hostedUsage } from "../db/usage-schema.js";
 
@@ -21,17 +22,19 @@ export const HOSTED_DAILY_LIMIT: Record<HostedMeter, number> = {
   [HOSTED_METER.ATTENTION_REVIEW]: 500,
 };
 
-export interface HostedQuota {
-  used: number;
-  limit: number;
-  remaining: number;
-  /** When the day's counters reset, as epoch milliseconds. */
-  resetsAt: number;
-}
+/* The quota shape is the wire contract's, imported rather than restated, so
+   the endpoint and the desktop reading it cannot drift. */
+export type { HostedQuota } from "../core.js";
 
 export interface HostedSpend {
   allowed: boolean;
   quota: HostedQuota;
+}
+
+/** Where one meter stands on one day, worded once for the spend and the read. */
+function meterStanding(used: number, meter: HostedMeter, day: string): HostedQuota {
+  const limit = HOSTED_DAILY_LIMIT[meter];
+  return { used, limit, remaining: Math.max(0, limit - used), resetsAt: utcDayEnd(day) };
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -79,14 +82,30 @@ export async function spendHostedMeter(
   if (!row) throw new Error("The usage upsert returned no row.");
 
   const used = spendsVoice ? row.voiceCalls : row.attentionReviews;
-  const limit = HOSTED_DAILY_LIMIT[input.meter];
   return {
-    allowed: used <= limit,
-    quota: {
-      used,
-      limit,
-      remaining: Math.max(0, limit - used),
-      resetsAt: utcDayEnd(day),
-    },
+    allowed: used <= HOSTED_DAILY_LIMIT[input.meter],
+    quota: meterStanding(used, input.meter, day),
+  };
+}
+
+type UsageReadDatabase = Pick<ReturnType<typeof createDatabase>, "select">;
+
+/**
+ * Reads where today's allowance stands on both meters without spending
+ * either. A day with no row yet has spent nothing, which is an answer, not
+ * an absence — the panel asks this before the first call of the day.
+ */
+export async function readHostedUsage(
+  database: UsageReadDatabase,
+  input: { userId: string; now: number },
+): Promise<HostedUsageAnswer> {
+  const day = utcDayKey(input.now);
+  const [row] = await database
+    .select()
+    .from(hostedUsage)
+    .where(and(eq(hostedUsage.userId, input.userId), eq(hostedUsage.day, day)));
+  return {
+    voice: meterStanding(row?.voiceCalls ?? 0, HOSTED_METER.VOICE_CALL, day),
+    attention: meterStanding(row?.attentionReviews ?? 0, HOSTED_METER.ATTENTION_REVIEW, day),
   };
 }

--- a/apps/web/server/hosted/usage.ts
+++ b/apps/web/server/hosted/usage.ts
@@ -1,0 +1,32 @@
+import type { HostedUsageAnswer } from "../core.js";
+import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
+
+/**
+ * Answers where today's allowance stands, spending nothing. This is the one
+ * hosted endpoint that involves no OpenAI key: it reads Luke's own counters
+ * for the signed-in account, so the panel can show what remains before the
+ * first call of the day rather than only after one has answered.
+ */
+
+export interface UsageOptions {
+  request: Request;
+  resolveUserId: (request: Request) => Promise<string | undefined>;
+  readUsage: (userId: string) => Promise<HostedUsageAnswer>;
+}
+
+export async function handleUsage(options: UsageOptions): Promise<Response> {
+  const { request } = options;
+  if (request.method !== "GET") {
+    return errorResponse(
+      HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
+      HOSTED_API_ERROR.METHOD_NOT_ALLOWED,
+    );
+  }
+
+  const userId = await options.resolveUserId(request);
+  if (!userId) {
+    return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
+  }
+
+  return jsonResponse(HOSTED_HTTP_STATUS.OK, await options.readUsage(userId));
+}

--- a/apps/web/tests/hosted-usage.test.ts
+++ b/apps/web/tests/hosted-usage.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { hostedUsage } from "../server/db/usage-schema";
+import {
+  HOSTED_DAILY_LIMIT,
+  HOSTED_METER,
+  readHostedUsage,
+  utcDayEnd,
+} from "../server/hosted/quota";
+import { handleUsage } from "../server/hosted/usage";
+
+const NOON_UTC = Date.parse("2026-08-17T12:00:00.000Z");
+
+/** A database that answers the one select the read makes. */
+function usageDatabase(rows: Array<{ voiceCalls: number; attentionReviews: number }>) {
+  return {
+    select() {
+      return {
+        from(table: unknown) {
+          assert.equal(table, hostedUsage);
+          return { where: async () => rows };
+        },
+      };
+    },
+  } as unknown as Parameters<typeof readHostedUsage>[0];
+}
+
+test("a day with spending reads back both meters without touching either", async () => {
+  const usage = await readHostedUsage(usageDatabase([{ voiceCalls: 3, attentionReviews: 41 }]), {
+    userId: "user-1",
+    now: NOON_UTC,
+  });
+
+  assert.deepEqual(usage.voice, {
+    used: 3,
+    limit: HOSTED_DAILY_LIMIT[HOSTED_METER.VOICE_CALL],
+    remaining: HOSTED_DAILY_LIMIT[HOSTED_METER.VOICE_CALL] - 3,
+    resetsAt: utcDayEnd("2026-08-17"),
+  });
+  assert.deepEqual(usage.attention, {
+    used: 41,
+    limit: HOSTED_DAILY_LIMIT[HOSTED_METER.ATTENTION_REVIEW],
+    remaining: HOSTED_DAILY_LIMIT[HOSTED_METER.ATTENTION_REVIEW] - 41,
+    resetsAt: utcDayEnd("2026-08-17"),
+  });
+});
+
+test("a day with no row yet has spent nothing, which is an answer", async () => {
+  const usage = await readHostedUsage(usageDatabase([]), { userId: "user-1", now: NOON_UTC });
+  assert.equal(usage.voice.used, 0);
+  assert.equal(usage.voice.remaining, usage.voice.limit);
+  assert.equal(usage.attention.used, 0);
+});
+
+test("the endpoint answers GET for the signed-in account and nobody else", async () => {
+  const answer = {
+    voice: { used: 1, limit: 50, remaining: 49, resetsAt: NOON_UTC + 43_200_000 },
+    attention: { used: 2, limit: 500, remaining: 498, resetsAt: NOON_UTC + 43_200_000 },
+  };
+  const options = {
+    resolveUserId: async () => "user-1" as string | undefined,
+    readUsage: async () => answer,
+  };
+
+  const ok = await handleUsage({
+    ...options,
+    request: new Request("https://luke.test/api/usage"),
+  });
+  assert.equal(ok.status, 200);
+  assert.deepEqual(await ok.json(), answer);
+
+  const wrongMethod = await handleUsage({
+    ...options,
+    request: new Request("https://luke.test/api/usage", { method: "POST" }),
+  });
+  assert.equal(wrongMethod.status, 405);
+
+  const anonymous = await handleUsage({
+    ...options,
+    resolveUserId: async () => undefined,
+    request: new Request("https://luke.test/api/usage"),
+  });
+  assert.equal(anonymous.status, 401);
+  assert.equal((await anonymous.json()).error, "invalid-token");
+});

--- a/design/generate-brand-assets.mjs
+++ b/design/generate-brand-assets.mjs
@@ -885,6 +885,11 @@ function faceArtModule() {
 export const FACE_ART = {
   /** A square window centred on the face. Loud motions leave it, and may. */
   VIEW_BOX: "${box.map(fmt).join(" ")}",
+  /**
+   * The face cropped to itself, the way the static mark SVGs are cut. Only for
+   * a mark that never moves: it is tight enough that any motion would leave it.
+   */
+  MARK_VIEW_BOX: "${markBox().map(fmt).join(" ")}",
   /** The head's resting tilt, about the point the motions pivot on. */
   TILT: "rotate(${FACE.tilt} 120 124)",
   /** The capital-L nose, curling into the smile. */
@@ -998,9 +1003,20 @@ const svgOpenAt = (x, y, w, h) =>
 const svgOpen = (w, h) => svgOpenAt(0, 0, w, h);
 // Motion marks keep the full animation canvas; static artwork is cropped tight.
 const markSvg = (body) => `${svgOpen(240, 240)}${body}</svg>`;
-function tightMarkSvg(body, pad = 6) {
+/**
+ * The static mark's own window: the face's bounding box with a little air.
+ * Shared by the cut SVGs and by the app, which draws the same mark itself.
+ */
+const MARK_PAD = 6;
+
+function markBox(pad = MARK_PAD) {
   const b = faceBBox();
-  return `${svgOpenAt(b.x - pad, b.y - pad, b.w + 2 * pad, b.h + 2 * pad)}${body}</svg>`;
+  return [b.x - pad, b.y - pad, b.w + 2 * pad, b.h + 2 * pad];
+}
+
+function tightMarkSvg(body, pad = MARK_PAD) {
+  const [x, y, w, h] = markBox(pad);
+  return `${svgOpenAt(x, y, w, h)}${body}</svg>`;
 }
 // Words are trimmed vertically to the taller of the face and the letters.
 function wordSvg({ body, width }, pad = 6) {

--- a/packages/sidecar-core/src/hosted-service.ts
+++ b/packages/sidecar-core/src/hosted-service.ts
@@ -19,6 +19,7 @@ export const HOSTED_SERVICE_PATH = {
   VOICE_MINT: "/api/voice/mint",
   ATTENTION_REVIEW: "/api/attention/review",
   ACCOUNT_DELETE: "/api/account/delete",
+  USAGE: "/api/usage",
 } as const;
 
 /** Every refusal a hosted endpoint answers with, by its reason. */
@@ -132,6 +133,23 @@ export function hostedReviewAnswerFromWire(
   if (!decision) return undefined;
   const quota = hostedQuotaFromWire(value.quota);
   return { decision, ...(quota ? { quota } : {}) };
+}
+
+/**
+ * Where today's allowance stands on both meters, read without spending
+ * either: what the usage endpoint answers, and what the panel shows.
+ */
+export interface HostedUsageAnswer {
+  voice: HostedQuota;
+  attention: HostedQuota;
+}
+
+/** Validates a usage answer; a malformed one reads as no answer at all. */
+export function hostedUsageAnswerFromWire(value: unknown): HostedUsageAnswer | undefined {
+  if (!isRecord(value)) return undefined;
+  const voice = hostedQuotaFromWire(value.voice);
+  const attention = hostedQuotaFromWire(value.attention);
+  return voice && attention ? { voice, attention } : undefined;
 }
 
 /** Reads the error reason out of a refused hosted answer, or nothing. */

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -215,10 +215,12 @@ export {
   type HostedMintAnswer,
   type HostedQuota,
   type HostedReviewAnswer,
+  type HostedUsageAnswer,
   hostedErrorFromWire,
   hostedMintAnswerFromWire,
   hostedQuotaFromWire,
   hostedReviewAnswerFromWire,
+  hostedUsageAnswerFromWire,
 } from "./hosted-service.js";
 export {
   REALTIME_CALLS_PATH,

--- a/packages/sidecar-core/src/realtime-credentials.ts
+++ b/packages/sidecar-core/src/realtime-credentials.ts
@@ -197,7 +197,7 @@ const REALTIME_MINT_EXPLANATIONS: Record<RealtimeMintOutcome, string> = {
   [REALTIME_MINT_OUTCOME.NOT_ATTEMPTED]: "No credential has been requested yet.",
   [REALTIME_MINT_OUTCOME.SUCCEEDED]: "A short-lived credential was minted.",
   [REALTIME_MINT_OUTCOME.NO_API_KEY]:
-    "Voice has nothing to run on: no signed-in Luke account, and no OpenAI key. Signing in turns voice on with its included allowance; a key connected under Account and usage, at the top of the Settings tab, also works.",
+    "Voice has nothing to run on: no signed-in Luke account, and no OpenAI key. Signing in turns voice on with its included allowance; a key connected under What Luke runs on, at the top of the Settings tab, also works.",
   [REALTIME_MINT_OUTCOME.DISABLED_BY_FIXTURE]:
     "This is a fixture or evidence run, which never uses credentials.",
   [REALTIME_MINT_OUTCOME.HTTP_ERROR]: "The API rejected the mint request.",

--- a/packages/sidecar-core/src/realtime-credentials.ts
+++ b/packages/sidecar-core/src/realtime-credentials.ts
@@ -197,7 +197,7 @@ const REALTIME_MINT_EXPLANATIONS: Record<RealtimeMintOutcome, string> = {
   [REALTIME_MINT_OUTCOME.NOT_ATTEMPTED]: "No credential has been requested yet.",
   [REALTIME_MINT_OUTCOME.SUCCEEDED]: "A short-lived credential was minted.",
   [REALTIME_MINT_OUTCOME.NO_API_KEY]:
-    "Voice has nothing to run on: no signed-in Luke account, and no OpenAI key. Signing in turns voice on with its included allowance; a key connected in Settings, at the top of the Voice page, also works. Exporting OPENAI_API_KEY in a shell works too, but does not reach an app opened from Finder.",
+    "Voice has nothing to run on: no signed-in Luke account, and no OpenAI key. Signing in turns voice on with its included allowance; a key connected under Account and usage, at the top of the Settings tab, also works.",
   [REALTIME_MINT_OUTCOME.DISABLED_BY_FIXTURE]:
     "This is a fixture or evidence run, which never uses credentials.",
   [REALTIME_MINT_OUTCOME.HTTP_ERROR]: "The API rejected the mint request.",


### PR DESCRIPTION
## What

Usage was nearly invisible: numbers appeared on the Voice page only after a mint had answered, counted only voice calls, and said nothing before the first press of the day. Now the page tells the whole standing the moment it opens.

- **`GET /api/usage`** (web): read-only, authenticated by the same bearer validation as the other hosted endpoints, spending nothing and involving no OpenAI key. Answers both meters for today — a day with no row yet has spent nothing, which is an answer, not an absence. The quota shape moved fully onto the shared wire contract (`HostedUsageAnswer` + validator in `sidecar-core/hosted-service.ts`), so the endpoint and the desktop reading it cannot drift; the web quota module now imports the shape instead of restating it.
- **`HostedUsageReader`** (desktop): same seams as the other hosted clients — token read fresh per ask, 401 → single-flighted refresh → one retry — behind a new `requestHostedUsage` bridge ask. Built exactly while the hosted minter exists; a keyed or signed-out run answers nothing and the page words itself without numbers.
- **Voice page**: the hosted note now reads "Voice is included with your Luke account — 47 of 50 calls and 463 of 500 session reviews left today," refreshed when the Settings tab shows and on every settings change; the fresh read outranks the quota the last mint carried, and a spent allowance still reads as a state with its own return time. The guide's existing description ("how much of today's remains") stays true without change.

## Testing

- `./scripts/check.sh` passes (exit 0).
- New tests: web (read-both-meters, empty-day-is-an-answer, endpoint gate order) and desktop (bearer GET shape, 401 refresh-retry, failure/malformed/signed-out all read as no answer, note wording from usage vs mint-quota vs neither).
- UI change is one text node in the existing hosted note — no layout or motion touched; the note only draws signed-in and keyless, which fixture evidence (signed-out) does not capture. No physical-notch check performed (cloud workspace); the live check is the Voice page showing both counts on next `run.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/343d02ab-bf79-4850-a697-40e44a08ac75)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32095674011/artifacts/9309855583) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32095674011)

- Commit: `a9ea26c2a010c498586be8a11b99be2367da1361`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->


## Front-page prominence (second commit)

The Account section moves from the foot of the Settings front page to its head, and says what the account is buying right now: *"Voice is included with your Luke account — 47 of 50 calls and 463 of 500 session reviews left today. Connecting your own OpenAI key — on the Voice page — lifts the allowance and runs voice on it instead."* With a key connected it says voice runs on your own key, unmetered. The Voice page's note stays (same wording function, worded once); the sign-out the section carries asks before acting, so leading with it costs no accidental exits. Stagger indices renumbered (Account 1 → nav 2 → Updates 3 → Feedback 4 → Quit 5) and the guide's front-page description follows the furniture.


## Meters (third commit)

The Account section now draws the allowance as two small meters — the native `meter` element restyled through Chromium's meter parts, filling with the day's used voice calls and session reviews, in the switches' own complete green and turning to the attention color once spent. Nothing animates (a changed value snaps; only the section's arrival staggers), so no motion rules are engaged. The note beneath keeps only what the bars cannot say — the spent sentence and the BYOK hint — and per Bugbot's catch, that hint is withheld on a system that cannot store a key, matching the Voice page's own withheld invitation.


## Account and usage (fourth commit)

- The **OpenAI key row moves into the Account section**, renamed **"Account and usage"**, with the key row itself renamed **"OpenAI BYOK"** — identity, meters, one short line, and the key together as the two ways voice runs. The Voice page keeps the microphone permission and voice controls, and points back while voice is off.
- **`OPENAI_API_KEY` is no longer read from the environment** — alone among Luke's credentials — so a key exported for another tool can't silently start being spent on voice or move the review path. PRIVACY.md, the guide, and the mint explanation all follow.
- **Subtext is now one short line**: "Resets in about 7 hours. Your own OpenAI key below lifts the limits." — or "Voice is used up — back in about 7 hours." when spent; "Voice runs on your OpenAI key — no daily limits." when keyed. The reset countdown answers the quota's own `resetsAt`.
- **Both of Bugbot's staleness directions resolved with one rule**: `fresherQuota` picks by day (`resetsAt`) then by remainder (which only falls within a day), so a held usage read and a newer mint's quota can disagree without the surface showing yesterday's numbers or wiping on a dropped refresh.

## What Luke runs on (this round)

The panel *described* the two ways voice can run but never *drew* them as a choice, so nothing on screen said which one was live, what the other would give you, or how to move between them. Rebased onto `origin/main`.

### The choice, made real

**What Luke runs on** now leads the front page as a two-way toggle — *Your Luke account (free)* against *Your OpenAI key (you pay)* — with the live one marked and the other pressable. Choosing the key with none stored asks for one; choosing the account **parks a stored key without deleting it**.

That last part is a behaviour change, not a redraw: before this, connecting a key *was* the choice and the only way back was deleting it. A stored `voiceSource` now gates the Keychain read in `applyVoiceCredential()`, bounded so it can only ever move spending **off** a key, never onto one:

- A key that is stored but not chosen is never decrypted.
- Connecting a key chooses it — otherwise a fresh paste would be silently ignored and look like a failed save.
- The one fallback runs toward the free half. Sign out while parked on the account and the stored key returns to service (voice keeps working as it always did); there is deliberately no fallback the other way, because falling onto your key because something you didn't touch went missing would start spending your money.

### Two bodies, one per half

- **Account:** the day's meters, when they reset, and a folded **How this works** saying what spends them (limits read off the quota in hand, never hard-coded).
- **Key:** the OpenAI row and a folded **How your key is used** — the same two uses, worded identically, minus the counts — closing with where the work goes and who bills for it. The row's own description is gone; the section says it better.

Neither half explains the other. The toggle is where they are compared.

### Wording, meters, furniture

| Was | Now |
|---|---|
| Voice calls / Session reviews | Talking and announcements / Checks on your sessions |
| OpenAI BYOK | OpenAI |
| Resets in about 5 hours. | Resets at 5:00 PM. (local wall clock; "tomorrow at" when it crosses) |
| Voice is used up — back in about 5 hours. | You have used today's free voice — back at 5:00 PM. Luke keeps watching your sessions. |
| Meter fills green with what you *used* | Meter takes the working blue, and turns attention-orange with a fifth left |

The old meter filled with `used` in the "complete" green while the words beside it said "38 of 50 **left**" — bar and words describing opposite quantities. The warning now arrives at 20% (10 voice calls, 100 checks) rather than only at zero: one fraction for both, since their ceilings differ by 10×.

The **Account** section (identity, sign out, delete account) moved to the foot of the page beside the other ways out — the top is what you check daily, the foot is what you change forever. The heading wears **Luke's own mark**, drawn from the generated artwork; `MARK_VIEW_BOX` now comes out of `design/generate-brand-assets.mjs` at the same crop the mark SVGs are cut with, so the app and the assets cannot disagree (all 63 SVGs unchanged; `--check` passes).

### Also fixed here

Cancelling **or sending** a feedback note landed you on Connections instead of the front page. All three shapes that stand the panel down shared one remembered page that only a credential entry ever wrote, so the landing depended on the last unrelated thing you'd touched. Sending was worse: the thank-you line is drawn in the Feedback section, so a landed send navigated away from the only page that could report it. Now `standDownReturnPage` answers per occupant. The calendar was right before only by accident.

## Testing

- `./scripts/check.sh` passes (exit 0) — 1302 tests.
- New tests: the source resolution end to end (no key ⇒ one source; connecting chooses; the allowance takes it back with the key intact; signed out falls to the key and back; a corrupt stored value reads as no choice), the meter's three levels including a zero limit, the toggle's names and prices, and every stand-down's return page.
- **`verify.sh` not run** — macOS-only and this is a Linux cloud workspace, so the completion invariant for a UI change is outstanding and no physical-notch check was performed. Verified instead by rendering the real markup against the real stylesheets headlessly in each state (fresh / low / spent / keyed, both bodies).

### One thing to decide

Content follows the live half strictly, so a key parked behind the free allowance can't be deleted from the account half — you press the key half first (which does switch spending), delete, and it resolves back on its own. One extra press. Keeping the connector drawn under both halves is a one-line change if you'd rather.
