### PR TITLE
fix(desktop): drop the Updates row's always-on subtext

### DIFF
--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -2455,11 +2455,6 @@ function UpdatesSection({ control }: { control: UpdateControl }): React.JSX.Elem
           </button>
         )}
       </div>
-      {/* Always on, like the announcements — stated rather than switched, so
-          the disclosure the retired switch carried is still on the row. */}
-      <p className="settings-note">
-        Luke checks on his own a few times a day. Nothing about you or your sessions is sent.
-      </p>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
Removes the "Luke checks on his own a few times a day. Nothing about you or your sessions is sent." note under the Updates row in the settings panel, along with the comment that motivated it. The update check's behavior is unchanged; only the copy is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a9f2389c-077c-467f-a6b2-6e6f4d8cd0d2)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32081208374/artifacts/9305195512) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32081208374)

- Commit: `6092c5df419d6f3dd7ebe5683298fc4fdf7989cd`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
