### PR TITLE
fix(web): take the feedback inbox from the deployment and true up the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Luke v0.1 is an Apple Silicon developer preview for macOS 14 and newer.
 Download the latest build from
 [GitHub Releases](https://github.com/ReviewStage/luke/releases).
 
+Luke asks for an identity-only Google or GitHub sign-in when it first opens —
+see [Privacy](PRIVACY.md) for exactly what the account does and does not
+carry.
+
 Visit [tryluke.dev](https://tryluke.dev) to see Luke in action.
 
 ## Features
@@ -51,7 +55,9 @@ Visit [tryluke.dev](https://tryluke.dev) to see Luke in action.
 | Google Calendar | Meeting busy times | Yes (sign-in) |
 
 Cloud integrations remain inactive until you add their credentials in Luke's
-Settings. Voice and optional attention review require an OpenAI API key.
+Settings. Voice and the optional attention review are included with the
+signed-in account under a daily allowance; connecting your own OpenAI API key
+lifts the allowance and runs both on that key instead.
 
 ## Calendar support
 
@@ -107,19 +113,21 @@ panel keeps showing every session state throughout either way.
 - An optional spoken conversation, described below, lets you ask Luke about your
   sessions and hear the answer.
 
-Luke does not send commands to agents, inject terminal input, or expose agent
-controls.
+Luke never injects terminal input or simulates keystrokes. A message or a
+provider-advertised control reaches a session only when you explicitly ask —
+typed on its row, or requested of Luke in a conversation you opened.
 
 ## Talking to Luke
 
-Voice is off until you give Luke an OpenAI key. It is a real voice session: your
-microphone audio goes to OpenAI, and Luke answers out loud. Read
-[Privacy](PRIVACY.md) first — this is the one feature that sends audio off your
-Mac.
+Voice works as soon as you sign in — the account includes a daily allowance —
+and runs on your own OpenAI key once you connect one. Either way it is a real
+voice session: your microphone audio goes to OpenAI, and Luke answers out
+loud. Read [Privacy](PRIVACY.md) first — this is the one feature that sends
+audio off your Mac.
 
-Connect the key in Settings, under **Integrations**: press **Connect** beside
-OpenAI, paste the key, and Luke takes it from there — no relaunch, and no
-terminal. It is stored encrypted through the macOS Keychain, and the panel never
+Connect a key of your own in Settings, at the top of the **Voice** page: paste
+the key and Luke takes it from there — no relaunch, and no terminal. It is
+stored encrypted through the macOS Keychain, and the panel never
 reads it back. Setting `OPENAI_API_KEY` in the environment still works and is
 used when nothing is stored, but a shell export does not reach an app opened from
 Finder, which is why the panel is the way in.
@@ -181,7 +189,6 @@ hint under the words asks for volume. Its **Got it** button rests the hint for
 that stretch of silence (the captions stay); once sound has been back for a
 while, a fresh mute earns the hint again. Luke only reads the output's mute
 switch and volume, and never changes either.
->>>>>>> Stashed changes
 
 ## Privacy
 

--- a/apps/web/api/feedback.mjs
+++ b/apps/web/api/feedback.mjs
@@ -10,14 +10,16 @@
  * function is compiled by Vercel's builder, and handing it JavaScript leaves
  * that builder nothing to resolve, transpile, or fail on.
  *
- * Deployment needs one secret: `RESEND_API_KEY`, a Resend key for a domain
- * verified to send as the `from` address. `FEEDBACK_FROM` may override that
- * sender. Without the key the endpoint answers 503 and the composer reports
- * the service unavailable; nothing else about the app depends on it.
+ * Deployment needs two values: `RESEND_API_KEY`, a Resend key for a domain
+ * verified to send as the `from` address, and `FEEDBACK_TO`, the inbox
+ * submissions are forwarded to — held in the deployment rather than this
+ * public repository, so the address cannot be scraped from source.
+ * `FEEDBACK_FROM` may override the sender. Without either required value the
+ * endpoint answers 503 and the composer reports the service unavailable;
+ * nothing else about the app depends on it.
  */
 
 const RESEND_URL = "https://api.resend.com/emails";
-const DESTINATION = "founders@stagereview.app";
 const DEFAULT_FROM = "Luke <feedback@tryluke.dev>";
 
 /**
@@ -247,7 +249,10 @@ function json(status, body) {
 /** @param {Request} request */
 export async function POST(request) {
   const apiKey = process.env.RESEND_API_KEY?.trim();
-  if (!apiKey) return json(503, { reason: "The feedback service is not configured." });
+  const destination = process.env.FEEDBACK_TO?.trim();
+  if (!apiKey || !destination) {
+    return json(503, { reason: "The feedback service is not configured." });
+  }
   if (rateLimited(senderAddress(request), Date.now())) {
     return json(429, { reason: "Too many submissions from this address. Try again later." });
   }
@@ -276,7 +281,7 @@ export async function POST(request) {
       },
       body: JSON.stringify({
         from: process.env.FEEDBACK_FROM?.trim() || DEFAULT_FROM,
-        to: [DESTINATION],
+        to: [destination],
         subject,
         text: emailBody(submission),
         // Replying to the email answers the person who wrote it, when they


### PR DESCRIPTION
## Summary

- `apps/web/api/feedback.mjs` no longer hardcodes the founders' inbox in a public file: the destination now comes from a `FEEDBACK_TO` deployment variable, and the endpoint answers the same 503 as a missing `RESEND_API_KEY` until it is set. The header comment documents both required values. **`FEEDBACK_TO` must be set in the Vercel deployment before this ships**, or the composer reports the service unavailable.
- README fixes ahead of the v0.1.1 launch:
  - Removed a committed `>>>>>>> Stashed changes` conflict marker that rendered on the repository front page.
  - Replaced the stale claim that Luke "does not send commands to agents … or expose agent controls" with the accurate trust boundary: no injected input ever, and messages/controls only on an explicit ask.
  - Updated the two "voice requires an OpenAI key" claims to the hosted tier from #204: the signed-in account includes voice and attention review under a daily allowance, and a personal key lifts it.
  - Corrected where the key connects (top of the Voice page, not Integrations).
  - Noted in Download that first open asks for the identity-only Google/GitHub sign-in.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (exit 0)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — docs and a serverless function only; no desktop or UI change

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32081307474/artifacts/9305222644) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32081307474)

- Commit: `3d36eb7949b6125311cf907151cf51602b2b2c17`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed` — no UI change
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: set `FEEDBACK_TO` in the Vercel project before the next deploy. The old address remains in git history; pointing `FEEDBACK_TO` at a forwarding alias is worth considering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/96babd60-401e-46e8-a55e-489b1d27837d)
