### PR TITLE
fix(desktop): offer a workspace-level archive on the tray header, not each chat row

### DIFF
--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -681,10 +681,13 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       label: "Archiving",
       detail:
         "Where a provider documents an archive endpoint — a Conductor workspace, a Cursor " +
-        "cloud agent, and a Devin session today — a row offers Archive as a control once the " +
-        "work there was positively seen to settle: pressed on the row, or asked of Luke in " +
+        "cloud agent, and a Devin session today — Archive is offered as a control once the " +
+        "work there was positively seen to settle: pressed, or asked of Luke in " +
         "conversation, it files the work away through the provider's own endpoint. Archiving a " +
-        "Conductor workspace files away every chat in it at once; an archived Cursor agent " +
+        "Conductor workspace files away every chat in it at once, so when several of its chats " +
+        "are drawn together the control sits once on the group's own header rather than on " +
+        "each row; a lone chat, or any other provider's session, carries it on the row. An " +
+        "archived Cursor agent " +
         "stays readable but takes no new runs; an archived Devin session can be viewed but not " +
         "resumed. A row mid-turn — or one whose state could not be read — offers no archive, a " +
         "session whose roster entry lists no archive control takes no such ask, and local " +

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -18,6 +18,7 @@ import { PANEL_TAB, type PanelTab, TabBar } from "./panel-tabs";
 import { CloudBadge, ProviderMark } from "./provider-marks";
 import {
   type ArrangedSessions,
+  actsOnWorkspace,
   type DisplaySession,
   observedAgoLabel,
   type SessionAction,
@@ -25,9 +26,12 @@ import {
   type SessionView,
   sessionListRuns,
   sessionRunKeys,
+  type WorkspaceTrayAction,
+  workspaceTrayActions,
 } from "./session-model";
 import {
   LEAVING_ATTRIBUTE,
+  type RosterRow,
   SESSION_ROW_ID_ATTRIBUTE,
   useRoster,
   useSessionReorderMotion,
@@ -139,9 +143,13 @@ function RowActionButton({
  */
 function SessionRowActions({
   session,
+  actions,
   writes,
 }: {
   session: DisplaySession;
+  /** The actions this row draws itself: inside a tray, the workspace-level
+   * ones have moved to the tray's own header. */
+  actions: readonly SessionAction[];
   writes: SessionWriteHandlers;
 }): React.JSX.Element {
   const [sending, setSending] = useState(false);
@@ -274,7 +282,7 @@ function SessionRowActions({
           </button>
         </form>
       ) : null}
-      {session.actions.map((action) => (
+      {actions.map((action) => (
         <RowActionButton
           key={action.id}
           action={action}
@@ -301,6 +309,68 @@ function SessionRowActions({
       ) : null}
       {feedback ? <small className="row-feedback">{feedback}</small> : null}
     </div>
+  );
+}
+
+/**
+ * The tray header's own acts: every workspace-level action the tray's chats
+ * advertise, drawn once where the workspace is named once. Archiving files
+ * away every chat in the tray, so the same chip repeated on each row read as
+ * several different acts when any press did the whole thing. The press still
+ * travels as a session write — through the first chat that advertised the act
+ * — so it is validated against the same roster row that promised it, and its
+ * outcome answers on the header's own line the way a row's writes do.
+ */
+function WorkspaceTrayActs({
+  acts,
+  writes,
+}: {
+  acts: readonly WorkspaceTrayAction[];
+  writes: SessionWriteHandlers;
+}): React.JSX.Element {
+  const [pendingAction, setPendingAction] = useState<string | undefined>(undefined);
+  const [feedback, setFeedback] = useState<string | undefined>(undefined);
+  /** One write at a time for the header, in a ref for the same same-tick
+   * reason a row keeps one: disabling only lands with the next render. */
+  const writeInFlight = useRef(false);
+
+  const run = useCallback(
+    async (act: WorkspaceTrayAction) => {
+      if (writeInFlight.current) return;
+      writeInFlight.current = true;
+      setPendingAction(act.action.id);
+      setFeedback(undefined);
+      try {
+        const result = await writes.runAction(act.session, act.action.id);
+        // An accepted act answers too: the tray will not look different until
+        // its provider is observed again, and a control that seems to have
+        // done nothing would be pressed a second time.
+        setFeedback(
+          result.status === PROVIDER_ACT_RESULT_STATUS.ACCEPTED
+            ? `${act.session.provider} accepted`
+            : feedbackFor(result),
+        );
+      } finally {
+        writeInFlight.current = false;
+        setPendingAction(undefined);
+      }
+    },
+    [writes],
+  );
+
+  return (
+    <>
+      {acts.map((act) => (
+        <RowActionButton
+          key={act.action.id}
+          action={act.action}
+          pendingAction={pendingAction}
+          busy={pendingAction !== undefined}
+          onRun={() => void run(act)}
+        />
+      ))}
+      {feedback ? <small className="row-feedback">{feedback}</small> : null}
+    </>
   );
 }
 
@@ -350,7 +420,15 @@ function SessionRow({
   onOpen: (session: DisplaySession) => void;
   writes: SessionWriteHandlers;
 }): React.JSX.Element {
-  const withActions = session.canMessage || session.actions.length > 0 || session.hasChange;
+  // Inside a tray, an action aimed at the whole workspace is the tray
+  // header's to offer — drawn beside every chat it would file away, it read
+  // as several different acts — so the row keeps only the actions that are
+  // its own. A lone chat is its workspace here too: with no tray to carry the
+  // act, the row does.
+  const actions = inWorkspaceTray
+    ? session.actions.filter((action) => !actsOnWorkspace(session, action))
+    : session.actions;
+  const withActions = session.canMessage || actions.length > 0 || session.hasChange;
   const shared = {
     className: "session-row",
     "data-state": session.urgency,
@@ -456,7 +534,7 @@ function SessionRow({
       ) : (
         <div className="row-main">{content}</div>
       )}
-      <SessionRowActions session={session} writes={writes} />
+      <SessionRowActions session={session} actions={actions} writes={writes} />
     </article>
   );
 }
@@ -479,24 +557,35 @@ export function runDrawsTray(run: SessionListRun): boolean {
  * follow-up someone was typing into it. The chrome is a class, never a
  * different tree.
  *
- * The header is furniture rather than a session — it opens nothing and takes
- * nothing — and it names the tray in the reading order the same way it does
- * on screen: the workspace once, then its chats. A tray is a member of the
+ * The header opens nothing — the rows are what press through to a provider's
+ * window — but it does carry the acts that belong to the workspace rather
+ * than to any one chat: an archive files away every chat in the tray, so its
+ * chip sits where the workspace is named once instead of on each row it
+ * would empty. The header names the tray in the reading order the same way
+ * it does on screen: the workspace once, then its chats. A tray is a member of the
  * arrival stack in its rows' stead: it fans in at its lead row's turn, and
  * the rows ride it rather than fanning a second time inside it. A wrapper
  * that draws as nothing leaves its row in the stack exactly as before.
  */
 function SessionRun({
   run,
+  sessions,
   highlight,
+  writes,
   children,
 }: {
   run: SessionListRun;
+  /** The tray's living chats, in drawn order — what the header's acts are
+   * read from and carried through. A leaving row's session is already gone
+   * from the model, so it can neither offer an act nor carry one. */
+  sessions: readonly DisplaySession[];
   /** The search's words, marked on the tray's own header lines too. */
   highlight?: readonly string[] | undefined;
+  writes: SessionWriteHandlers;
   children: React.ReactNode;
 }): React.JSX.Element {
   const tray = runDrawsTray(run);
+  const acts = tray ? workspaceTrayActions(sessions) : [];
   return (
     <section
       className={tray ? "workspace-tray" : "session-run"}
@@ -525,6 +614,7 @@ function SessionRun({
               </span>
             ) : null}
           </span>
+          {acts.length > 0 ? <WorkspaceTrayActs acts={acts} writes={writes} /> : null}
         </header>
       ) : null}
       {children}
@@ -678,8 +768,20 @@ export function PanelBody({
               // the other runs of its workspace.
               runs.map((run, at) => {
                 const tray = runDrawsTray(run);
+                const living = run.indexes
+                  .map((index) => rows[index])
+                  .filter(
+                    (row): row is RosterRow<DisplaySession> => row !== undefined && !row.leaving,
+                  )
+                  .map((row) => row.item);
                 return (
-                  <SessionRun key={runKeys[at]} run={run} highlight={highlight}>
+                  <SessionRun
+                    key={runKeys[at]}
+                    run={run}
+                    sessions={living}
+                    highlight={highlight}
+                    writes={writes}
+                  >
                     {run.indexes.map((index) => {
                       const row = rows[index];
                       return row ? (

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -97,6 +97,13 @@ export interface SessionAction {
   label: string;
   /** A stop is drawn as the stop glyph; anything else is drawn by its label. */
   kind?: SessionControlKind;
+  /**
+   * The provider-owned identifier of the thing the action acts on, when that
+   * is not the session itself — carried through from the advertisement because
+   * an action aimed at the row's whole workspace is drawn on the tray, not on
+   * every chat inside it.
+   */
+  target?: string;
 }
 
 /**
@@ -574,6 +581,44 @@ export function sessionRunKeys(
     const lead = run.indexes[0];
     return (lead !== undefined ? rows[lead]?.item.id : undefined) ?? "";
   });
+}
+
+/**
+ * Whether an advertised action acts on the row's whole workspace rather than
+ * on the chat itself — a Conductor archive, whose target is the workspace id
+ * riding the advertisement. Only the target can say so: the label is the
+ * provider's own words, and words are not a contract.
+ */
+export function actsOnWorkspace(session: DisplaySession, action: SessionAction): boolean {
+  return session.workspace !== undefined && action.target === session.workspace.id;
+}
+
+/** One workspace-level act, and the chat whose advertisement carries it. */
+export interface WorkspaceTrayAction {
+  action: SessionAction;
+  session: DisplaySession;
+}
+
+/**
+ * The acts a tray's header offers: every workspace-level action its chats
+ * advertise, each once. A provider advertises the same archive on every chat
+ * of a settled workspace, and a tray drawing one chip per chat reads as
+ * several different acts when pressing any of them files the whole workspace
+ * away — so the tray says it once, where the workspace is named once. The
+ * first chat advertising an act is the one the press travels through, which
+ * keeps the write validated against the same roster row that advertised it.
+ */
+export function workspaceTrayActions(
+  sessions: readonly DisplaySession[],
+): readonly WorkspaceTrayAction[] {
+  const acts = new Map<string, WorkspaceTrayAction>();
+  for (const session of sessions) {
+    for (const action of session.actions) {
+      if (!actsOnWorkspace(session, action) || acts.has(action.id)) continue;
+      acts.set(action.id, { action, session });
+    }
+  }
+  return [...acts.values()];
 }
 
 export function sessionListRuns(sessions: readonly DisplaySession[]): readonly SessionListRun[] {

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -561,11 +561,15 @@ html[data-keyboard="true"] button.session-row:focus-visible {
 }
 
 /* The tray's name line: the workspace's name on the left, and at the far end
-   the glyph leading the checkout. Everything here is in the panel's own face —
-   the line is what the user calls the work, not an identifier to be
-   consulted. */
+   the glyph leading the checkout — then, past those, any act that belongs to
+   the workspace rather than to one chat, drawn as the same chip a row's
+   actions use. Everything else here is in the panel's own face — the line is
+   what the user calls the work, not an identifier to be consulted. The wrap
+   is for the outcome line a pressed act answers on, which takes the full
+   width below the header's own line. */
 .workspace-tray-header {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 7px;
   padding: 9px 14px 8px;
@@ -579,8 +583,12 @@ html[data-keyboard="true"] button.session-row:focus-visible {
   color: var(--text-tertiary);
 }
 
+/* The name grows from a zero basis so it soaks up the line's free space and
+   ellipsizes when long, rather than letting the wrap above break the meta or
+   an act onto a line of its own. */
 .workspace-tray-name {
   overflow: hidden;
+  flex: 1 1 0;
   color: var(--text-secondary);
   font-size: 11px;
   font-weight: 560;

--- a/apps/desktop/tests/session-model.test.ts
+++ b/apps/desktop/tests/session-model.test.ts
@@ -6,11 +6,14 @@ import {
   normalizeSession,
   PROVIDER_ID,
   PROVIDER_ID_LIST,
+  SESSION_CONTROL_KIND,
   SESSION_LOCATION,
   SESSION_STATUS,
   SESSION_URGENCY,
+  type SessionControl,
 } from "@sidecar/core";
 import {
+  actsOnWorkspace,
   arrangeSessions,
   DEFAULT_SESSION_VIEW,
   displaySessions,
@@ -23,6 +26,7 @@ import {
   sessionTally,
   tallyCaption,
   tallySummary,
+  workspaceTrayActions,
 } from "../src/renderer/session-model";
 import type { AppBootstrap } from "../src/shared/contracts";
 
@@ -614,6 +618,65 @@ test("a lone chat is a run of one, and namesake workspaces never join", () => {
       { workspaceId: "workspace-two", indexes: [1] },
     ],
   );
+});
+
+test("an act aimed at the workspace is the tray's, said once", () => {
+  // Every settled chat advertises the same workspace archive; the tray offers
+  // it once, carried by the first chat that advertised it, while a chat's own
+  // acts — the stop, aimed at its run — stay on the row that owns them.
+  const archive = { id: "archive-workspace", label: "Archive", target: "workspace-lisbon" };
+  const stop = {
+    id: "cancel-run",
+    label: "Stop this run",
+    kind: SESSION_CONTROL_KIND.STOP,
+    target: "run-1",
+  };
+  const chatOf = (id: string, controls: readonly SessionControl[]) =>
+    normalizeSession(CONDUCTOR_PROVIDER, {
+      providerSessionId: id,
+      title: `Chat ${id}`,
+      status: SESSION_STATUS.COMPLETE,
+      observedAt: 1_000,
+      controls,
+      workspace: { providerWorkspaceId: "workspace-lisbon", name: "lisbon-v2" },
+    });
+
+  const rows = displaySessions(bootstrap(false), [
+    chatOf("chat-one", [stop, archive]),
+    chatOf("chat-two", [archive]),
+  ]);
+
+  const acts = workspaceTrayActions(rows);
+  assert.deepEqual(
+    acts.map((act) => ({ actionId: act.action.id, sessionId: act.session.id })),
+    [{ actionId: "archive-workspace", sessionId: "chat-one" }],
+  );
+
+  const [first] = rows;
+  assert.ok(first);
+  const [firstStop, firstArchive] = first.actions;
+  assert.ok(firstStop && firstArchive);
+  assert.equal(actsOnWorkspace(first, firstStop), false);
+  assert.equal(actsOnWorkspace(first, firstArchive), true);
+});
+
+test("an ungrouped session's acts never read as a workspace's", () => {
+  // A target can only say "the workspace" beside a workspace to say it of: a
+  // session no provider grouped keeps every act its own, whatever the target.
+  const [row] = displaySessions(bootstrap(false), [
+    normalizeSession(CONDUCTOR_PROVIDER, {
+      providerSessionId: "chat-alone",
+      title: "Chat alone",
+      status: SESSION_STATUS.COMPLETE,
+      observedAt: 1_000,
+      controls: [{ id: "archive-workspace", label: "Archive", target: "workspace-lisbon" }],
+    }),
+  ]);
+  assert.ok(row);
+  const [action] = row.actions;
+  assert.ok(action);
+  assert.equal(actsOnWorkspace(row, action), false);
+  assert.deepEqual(workspaceTrayActions([row]), []);
 });
 
 test("a row carries its workspace by name, falling back to the id", () => {


### PR DESCRIPTION
## What

Archiving a Conductor workspace files away every chat in it at once, yet a multi-chat workspace tray drew one Archive chip on each chat's row — the same act repeated, reading as several different ones. An advertised action whose target is the row's own workspace now moves to the tray's header, said once where the workspace is named once.

## How

- `session-model.ts`: `SessionAction` carries the advertisement's `target` through; `actsOnWorkspace` says whether an action acts on the row's whole workspace (its target is the workspace id), and `workspaceTrayActions` collects each such act once, paired with the first chat that advertised it so the press still travels as a session write validated against the same roster row.
- `panel-body.tsx`: a row inside a tray keeps only its own actions (a Conductor chat's stop, say); the tray header draws the workspace-level acts with the same chip, the same one-write-at-a-time hold, and the same outcome line a row's writes answer on.
- A lone chat — whose workspace earns no tray — keeps the archive on its row, and ungrouped sessions (Cursor cloud agents, Devin) are untouched: with no workspace, no action of theirs can read as a workspace's.
- The guide's Archiving fact now says where the control sits, so Luke describes the surface he actually draws.

## Checks

- `./scripts/check.sh` passes (975 desktop tests, 0 failures), including new `session-model` tests for `actsOnWorkspace` and `workspaceTrayActions`.
- CI's macOS job runs `./scripts/verify.sh` for the packaged-app validation and visual evidence. The committed fixture does not advertise an archive (its Conductor workspace holds a working chat, which a live pass would never advertise archiving beside), so the fixture evidence is unchanged by design.
- No physical-notch check was performed; the change adds a chip inside the panel's tray header and touches nothing at the housing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/9387c500-bace-4dd9-bec1-44b67d3a55d7)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32081969546/artifacts/9305434761) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32081969546)

- Commit: `1d3490882af276d8c62bd295feb55391e0ff145e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
