### PR TITLE
feat(voice): carry the words spoken while the call is still connecting

### DIFF
--- a/apps/desktop/src/renderer/press-audio-capture.ts
+++ b/apps/desktop/src/renderer/press-audio-capture.ts
@@ -1,0 +1,62 @@
+import { PRESS_AUDIO_SAMPLE_RATE } from "@sidecar/core";
+
+/**
+ * Reads PCM off the microphone stream the connect attempt already opened, so
+ * the words spoken while the call is still connecting can be appended to the
+ * turn once the data channel opens. It captures nothing the WebRTC track
+ * would not carry a moment later, holds nothing itself — every chunk goes to
+ * the callback — and it runs only while a press holds a turn: the session
+ * that creates it stops it at release, at the seam, and at every teardown.
+ */
+export interface PressCaptureSource {
+  stop(): void;
+}
+
+export type PressCaptureFactory = (
+  stream: MediaStream,
+  onChunk: (chunk: Int16Array) => void,
+) => PressCaptureSource;
+
+/**
+ * How many samples one captured chunk holds — about 85ms at the capture rate.
+ * The processor hands audio over a quantum at a time, and its last partial
+ * quantum is lost when capture stops, so the size is a floor under how close
+ * to the release the captured audio can end: small enough that letting go of
+ * the key costs less than a syllable, large enough not to flood the channel.
+ */
+export const PRESS_CAPTURE_CHUNK_SAMPLES = 2_048;
+
+/**
+ * Captures the stream at the rate the appends need. The context is created at
+ * `PRESS_AUDIO_SAMPLE_RATE`, so the engine resamples the device's own rate on
+ * the way in and the chunks need no conversion of this module's own.
+ */
+export const createPressCaptureSource: PressCaptureFactory = (stream, onChunk) => {
+  const context = new AudioContext({ sampleRate: PRESS_AUDIO_SAMPLE_RATE });
+  // The talk key is a system shortcut, so no user gesture in this window has
+  // vouched for the context — the analyser's own reason, and the same answer.
+  if (context.state === "suspended") void context.resume();
+  const source = context.createMediaStreamSource(stream);
+  const processor = context.createScriptProcessor(PRESS_CAPTURE_CHUNK_SAMPLES, 1, 1);
+  processor.onaudioprocess = (event) => {
+    const input = event.inputBuffer.getChannelData(0);
+    const chunk = new Int16Array(input.length);
+    for (let index = 0; index < input.length; index += 1) {
+      const sample = input[index] ?? 0;
+      chunk[index] = Math.max(-32_768, Math.min(32_767, Math.round(sample * 32_767)));
+    }
+    onChunk(chunk);
+  };
+  source.connect(processor);
+  // The processor only runs while it reaches the destination. Its output
+  // buffer is left at zeros, so nothing of the microphone reaches the speakers.
+  processor.connect(context.destination);
+  return {
+    stop: () => {
+      processor.onaudioprocess = null;
+      source.disconnect();
+      processor.disconnect();
+      void context.close().catch(() => undefined);
+    },
+  };
+};

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -18,6 +18,8 @@ import {
   functionCallFollowUpEvents,
   functionCallOutputEvents,
   ISSUE_TRACKER_DISCONNECTED_TEXT,
+  inputAudioAppendEvents,
+  inputAudioFormatUpdateEvents,
   issueContextEvents,
   issueContextText,
   issueToolAction,
@@ -27,6 +29,7 @@ import {
   type NormalizedSession,
   type ObservedWorkspaceProject,
   outputSpeedUpdateEvents,
+  PressAudioBuffer,
   parseRealtimeServerEvent,
   positiveInteger,
   proactiveSpeechEvents,
@@ -57,6 +60,11 @@ import {
 } from "@sidecar/core";
 import { workspaceAgentModels } from "../shared/workspace-agents";
 import { MICROPHONE_PROCESSING } from "./microphone-choice";
+import {
+  createPressCaptureSource,
+  type PressCaptureFactory,
+  type PressCaptureSource,
+} from "./press-audio-capture";
 
 const SDP_CONTENT_TYPE = "application/sdp";
 
@@ -122,6 +130,16 @@ interface PendingContext {
 interface LiveContext {
   itemId: string;
   text: string;
+}
+
+/**
+ * One press's words on their way through a handshake: the capture reading the
+ * device — absent once the press was released — and the buffer holding what
+ * it has heard until the data channel can carry it.
+ */
+interface PressCaptureState {
+  source: PressCaptureSource | undefined;
+  buffer: PressAudioBuffer;
 }
 
 /**
@@ -204,6 +222,12 @@ export interface RealtimeVoiceSessionOptions extends RealtimeVoiceSessionCallbac
    */
   createPeerConnection?: () => RTCPeerConnection;
   requestMicrophoneStream?: () => Promise<MediaStream>;
+  /**
+   * The local PCM capture a press runs while its call is still connecting.
+   * Injectable on the browser pieces' own terms: the cold-press seam is a
+   * state machine worth testing without a real audio graph.
+   */
+  createPressCapture?: PressCaptureFactory;
   exchangeDescription?: (url: string, init: RequestInit) => Promise<Response>;
   connectTimeoutMs?: number;
   /**
@@ -271,6 +295,44 @@ export class RealtimeVoiceSession {
   #microphoneSender: RTCRtpSender | undefined;
   /** The device being reopened, held so two presses cannot open it twice. */
   #acquiring: Promise<void> | undefined;
+  /**
+   * The connect attempt the state below belongs to, as an identity: refreshed
+   * by every teardown, captured by a device open before its wait, and what a
+   * device arriving late is checked against — a call closed or replaced while
+   * the device was opening keeps a fresh token, so the stale open releases
+   * what it holds instead of adopting it. Mid-connect there is no sender yet
+   * to stand for the call, so the token is what does.
+   */
+  #attempt: object = {};
+  /**
+   * The words the press has spoken while its call is still connecting: a local
+   * PCM capture off the press's own device, buffered until the data channel
+   * can carry them as appends. It belongs to exactly one connect attempt —
+   * created only while a press holds a turn, discarded on every path that ends
+   * the attempt — so no press can leave audio behind for a later connection.
+   *
+   * The seam between the captured words and the live WebRTC track is decided
+   * deliberately: the whole of the turn the press opened travels as appends,
+   * and the track joins the sender only when that turn is over. Appends ride
+   * the ordered data channel while the track rides RTP, and the server writes
+   * one input buffer in arrival order — so any turn that mixed the two would
+   * have an unorderable seam where a late append lands after the first live
+   * frames and words swap, double, or drop. On one channel every chunk lands
+   * exactly once, in capture order, with the commit behind the last of them.
+   * Handing over between turns is safe because every turn opens by clearing
+   * the buffer: there is nothing across that seam to double.
+   */
+  #pressCapture: PressCaptureState | undefined;
+  /**
+   * A press released while the call was still connecting, with words already
+   * captured. The turn it held is over — the capture stops reading and the
+   * device closes at the release — but what it heard is owed a delivery:
+   * flushed and committed once this attempt's channel opens, and discarded
+   * with the attempt if it never does.
+   */
+  #pressCommitPending = false;
+  /** Whether the turn now under way travels as appends rather than the track. */
+  #listeningOnAppends = false;
   /**
    * Whether the current connect attempt — and the call it opens — includes the
    * microphone. A developer's call does; one Luke opens for himself, to read a
@@ -557,8 +619,14 @@ export class RealtimeVoiceSession {
         // A press does not outlive the attempt it started. Every way a connect
         // ends without a call passes through here — no credential, a refused
         // call, a timeout — so none of them can leave an intention behind for
-        // some later connection to open a turn nobody asked for.
-        if (!opened) this.#pendingTurn = false;
+        // some later connection to open a turn nobody asked for. The words a
+        // press captured are under the same rule: the teardown each of those
+        // paths runs has already discarded them, and this clears the delivery
+        // they were owed.
+        if (!opened) {
+          this.#pendingTurn = false;
+          this.#pressCommitPending = false;
+        }
         return opened;
       })
       .finally(() => {
@@ -572,9 +640,11 @@ export class RealtimeVoiceSession {
     this.#setStatus(REALTIME_STATUS.CONNECTING);
     this.#options.onError(undefined);
 
-    // Connecting opens no capture device: the microphone is the developer's,
-    // not the call's, and it opens only when a press takes a turn. All the
-    // wait before the handshake is the credential being minted.
+    // Connecting opens no capture device of its own: the microphone is the
+    // developer's, not the call's, and it opens only when a press takes a
+    // turn. A press that started this connect has already asked for it, and
+    // its capture rides beside the mint — but that is the press's doing,
+    // never the connect's.
     let connection: RealtimeConnection | undefined;
     try {
       connection = await this.#options.requestConnection();
@@ -668,11 +738,28 @@ export class RealtimeVoiceSession {
       // credential this call answered may have been minted before the change.
       this.#flushPendingSpeed();
       // Whoever pressed the talk key to get here has been waiting through the
-      // handshake for their turn to open, and the device opens now, for that
-      // press. A speak-only call leaves the press pending instead — it has no
-      // sending half to open a turn with, and the developer's own call is
-      // already replacing it.
-      if (this.#pendingTurn && this.#withMicrophone) this.#acquireMicrophone();
+      // handshake for their turn to open. The press already opened the device
+      // and has been captured since it answered, so the turn opens on those
+      // words — as appends, with the track joining the sender only when the
+      // turn is over. A press whose device is still opening falls back to the
+      // acquire, and its turn opens when the device arrives. A speak-only
+      // call leaves the press pending instead — it has no sending half to
+      // open a turn with, and the developer's own call is already replacing
+      // it.
+      if (this.#pendingTurn && this.#withMicrophone) {
+        if (this.#pressCapture && this.#microphone) {
+          this.#pendingTurn = false;
+          this.#beginAppendsTurn();
+        } else {
+          this.#acquireMicrophone();
+        }
+      } else if (this.#pressCommitPending) {
+        // The press was released mid-handshake. Its words go as the turn it
+        // held — one tick later, because the caller re-feeds the roster and
+        // the guide right after this connect resolves, and the reply to those
+        // words must be answered from that context rather than from none.
+        setTimeout(() => this.#deliverHeldTurn(), 0);
+      }
       return true;
     } catch (error) {
       if (this.#closed) return this.#abandonConnect();
@@ -786,6 +873,23 @@ export class RealtimeVoiceSession {
   endTurn(commit: boolean): void {
     if (!this.isConnected) {
       this.#pendingTurn = false;
+      const capture = this.#pressCapture;
+      if (commit && capture && !capture.buffer.isEmpty) {
+        // The press already spoke, so its words are owed a delivery once this
+        // attempt's channel opens. The press no longer holds a turn, though:
+        // the capture stops reading and the device closes this instant — the
+        // sealed words wait in memory, not on an open microphone.
+        capture.source?.stop();
+        capture.source = undefined;
+        this.#pressCommitPending = true;
+        this.#releaseMicrophone();
+        return;
+      }
+      // Nothing was captured toward this press — the device never arrived,
+      // or nothing was said into it — so the turn it was owed is dropped, as
+      // committing it would ask the server to answer an empty buffer.
+      this.#retirePressCapture();
+      this.#releaseMicrophone();
       return;
     }
     // A press let go of while its device was still opening held nothing to
@@ -814,6 +918,12 @@ export class RealtimeVoiceSession {
         // press, and the turn opens when the device arrives.
         this.stopSpeaking();
         this.#acquireMicrophone();
+      } else {
+        // The second press takes back the first: the words captured toward
+        // the cancelled turn go with it, and so does the device they were
+        // being read from.
+        this.#retirePressCapture();
+        if (this.#status !== REALTIME_STATUS.LISTENING) this.#releaseMicrophone();
       }
       return;
     }
@@ -834,9 +944,11 @@ export class RealtimeVoiceSession {
    * opening meter reads this: a takeover — the developer's call replacing
    * Luke's own — passes through a settled status on the way, and the meter
    * must not come down while the press that started it is still owed a turn.
+   * A press released mid-connect with words captured is owed one too — its
+   * delivery — so the meter rides until the reply to it begins.
    */
   get turnPending(): boolean {
-    return this.#pendingTurn;
+    return this.#pendingTurn || this.#pressCommitPending;
   }
 
   /**
@@ -846,6 +958,8 @@ export class RealtimeVoiceSession {
    */
   dropPendingTurn(): void {
     this.#pendingTurn = false;
+    // The words captured toward the dropped press go with it.
+    this.#retirePressCapture();
     // A device already opened for that press has no turn left to serve, and
     // nobody is talking into it: it closes now, not on any clock.
     if (this.#status !== REALTIME_STATUS.LISTENING) this.#releaseMicrophone();
@@ -853,10 +967,13 @@ export class RealtimeVoiceSession {
 
   /**
    * Opens the capture device for the press waiting on it. One request at a
-   * time: a second press mid-open joins the first rather than racing it.
+   * time: a second press mid-open joins the first rather than racing it. A
+   * press ahead of the call opens the device too — the capture beside the
+   * handshake is what carries the words spoken into it — so being connected
+   * is not required, only being a call that will take a microphone.
    */
   #acquireMicrophone(): void {
-    if (!this.isConnected || !this.#withMicrophone || this.#microphone) return;
+    if (!this.#withMicrophone || this.#microphone) return;
     if (this.#acquiring) return;
     this.#acquiring = this.#openMicrophone().finally(() => {
       this.#acquiring = undefined;
@@ -867,42 +984,48 @@ export class RealtimeVoiceSession {
   }
 
   async #openMicrophone(): Promise<void> {
-    // The sender names the call this open belongs to, captured before the
-    // wait: a call closed and replaced while the device was opening keeps its
-    // own fresh sender, which is how this open knows it has gone stale.
-    const sender = this.#microphoneSender;
+    // The attempt names the call — or the connect under way — this open
+    // belongs to, captured before the wait: one closed and replaced while the
+    // device was opening keeps a fresh token, which is how this open knows it
+    // has gone stale. The sender cannot stand for the call here, because a
+    // press ahead of the handshake opens the device before any sender exists.
+    const attempt = this.#attempt;
     let stream: MediaStream;
     try {
       stream = await this.#requestStream();
     } catch (error) {
-      // A refusal belongs to the call whose press asked for the device. If
-      // that call is gone — closed, or replaced mid-open — the refusal died
-      // with it, and the call now up must not be torn down for it. For the
-      // call still standing, it is failed rather than left looking able to
-      // listen, and `FAILED` offers "Start voice" again.
-      if (!this.#closed && this.isConnected && sender === this.#microphoneSender) {
+      // A refusal belongs to the attempt whose press asked for the device. If
+      // that attempt is gone — closed, or replaced mid-open — the refusal
+      // died with it, and the call now up must not be torn down for it. On a
+      // call already standing it is failed rather than left looking able to
+      // listen, and `FAILED` offers "Start voice" again; mid-connect the call
+      // the press is still waiting for goes on opening, the press is dropped —
+      // there is nothing to capture with — and the refusal is shown beside it.
+      if (this.#closed || attempt !== this.#attempt) return;
+      if (this.isConnected) {
         this.#fail(errorMessage(error));
+        return;
       }
+      this.#pendingTurn = false;
+      this.#options.onError(errorMessage(error));
       return;
     }
-    // The call may have gone away — or been replaced, bringing a fresh
-    // sender — while this one was opening. A device nobody adopts is
-    // released here, or it would hold the indicator lit with nothing left to
-    // close it.
-    if (
-      this.#closed ||
-      !this.isConnected ||
-      !sender ||
-      sender !== this.#microphoneSender ||
-      this.#microphone
-    ) {
+    // The attempt may have gone away while the device was opening. A device
+    // nobody adopts is released here, or it would hold the indicator lit with
+    // nothing left to close it.
+    if (this.#closed || attempt !== this.#attempt || this.#microphone) {
       for (const track of stream.getTracks()) track.stop();
       return;
     }
     const [microphone] = stream.getAudioTracks();
     if (!microphone) {
       for (const track of stream.getTracks()) track.stop();
-      this.#fail("No microphone track was available");
+      if (this.isConnected) {
+        this.#fail("No microphone track was available");
+      } else {
+        this.#pendingTurn = false;
+        this.#options.onError("No microphone track was available");
+      }
       return;
     }
     // Closed until the turn opens it, so nothing is sent before the state
@@ -911,6 +1034,24 @@ export class RealtimeVoiceSession {
     this.#stream = stream;
     this.#microphone = microphone;
     this.#options.onLocalStream(stream);
+    if (!this.isConnected) {
+      // The call is still connecting, and the press is waiting it out: the
+      // words start being captured now, and the turn they open travels as
+      // appends — the track joins the sender only when that turn is over. A
+      // press already let go of leaves nothing to capture for, and a connect
+      // that turned speak-only under the press takes no device at all: either
+      // way the device closes as fast as it arrived.
+      if (this.#pendingTurn && this.#withMicrophone) this.#beginPressCapture();
+      else this.#releaseMicrophone();
+      return;
+    }
+    const sender = this.#microphoneSender;
+    if (!sender) {
+      // A connected microphone call always negotiated a sender; without one
+      // there is nothing for a turn to ride, and the device has no taker.
+      this.#releaseMicrophone();
+      return;
+    }
     try {
       // Onto the sender the call has kept since its handshake: no
       // renegotiation, the same line, the same call.
@@ -918,7 +1059,7 @@ export class RealtimeVoiceSession {
     } catch (error) {
       // Guarded like the open's own refusal: a sender that rejected because
       // its call was torn down mid-replace is not the live call's fault.
-      if (!this.#closed && this.isConnected && sender === this.#microphoneSender) {
+      if (!this.#closed && attempt === this.#attempt && this.isConnected) {
         this.#fail(errorMessage(error));
       }
       return;
@@ -950,6 +1091,135 @@ export class RealtimeVoiceSession {
     });
     void this.#microphoneSender?.replaceTrack(null);
     this.#options.onLocalStream(undefined);
+  }
+
+  /**
+   * Starts capturing the press's words, when there is a press to capture for.
+   * Harmless to ask again: it runs only while a press is waiting on a
+   * connecting microphone call with the device already open and nothing
+   * already reading it — every other moment it does nothing.
+   */
+  #beginPressCapture(): void {
+    if (!this.#withMicrophone || !this.#pendingTurn || this.isConnected) return;
+    if (this.#pressCapture?.source || this.#closed) return;
+    const stream = this.#stream;
+    const microphone = this.#microphone;
+    if (!stream || !microphone) return;
+    // A press landing again over words a release already sealed re-opens the
+    // same turn: the delivery the release was owed is superseded — this
+    // press's own release decides afresh — and capture resumes into the same
+    // buffer, so neither press's words are lost.
+    this.#pressCommitPending = false;
+    const capture: PressCaptureState = this.#pressCapture ?? {
+      source: undefined,
+      buffer: new PressAudioBuffer(),
+    };
+    const buffer = capture.buffer;
+    this.#pressCapture = capture;
+    capture.source = (this.#options.createPressCapture ?? createPressCaptureSource)(
+      stream,
+      (chunk) => {
+        // A chunk from a capture this session has already let go of belongs
+        // to no turn and goes nowhere.
+        if (this.#pressCapture !== capture) return;
+        if (this.#listeningOnAppends) {
+          this.#send(inputAudioAppendEvents(chunk));
+          return;
+        }
+        buffer.push(chunk);
+      },
+    );
+    // The capture reads the track, and a disabled track reads as silence to
+    // every consumer — so the track is open exactly while the capture is. The
+    // sender carries no track yet, so nothing reaches the network.
+    microphone.enabled = true;
+  }
+
+  /**
+   * Ends the press capture, discarding whatever it still holds, and hands the
+   * device's track to the sender so the turns after the seam ride WebRTC as
+   * every turn did before it. Every path out of the captured-turn machinery
+   * ends here — the seam settling, a discarded press, a failed attempt — so
+   * none of them can leave the capture reading the device.
+   */
+  #retirePressCapture(): void {
+    const capture = this.#pressCapture;
+    this.#pressCapture = undefined;
+    this.#listeningOnAppends = false;
+    this.#pressCommitPending = false;
+    capture?.source?.stop();
+    // The track was open for the capture to read; nothing reads it now, so it
+    // closes until a turn opens it.
+    if (capture?.source && this.#microphone) this.#microphone.enabled = false;
+    if (capture && this.isConnected && this.#microphoneSender && this.#microphone) {
+      void this.#microphoneSender.replaceTrack(this.#microphone).catch(() => undefined);
+    }
+  }
+
+  /**
+   * Opens the turn a still-held press has been capturing: `startListening` in
+   * every respect but the transport. The words captured so far flush behind a
+   * clean buffer, and the capture keeps appending live from here — the track
+   * stays off the sender, because the whole of this turn travels on the one
+   * ordered channel.
+   */
+  #beginAppendsTurn(): void {
+    const capture = this.#pressCapture;
+    if (!capture || !this.#microphone) {
+      this.#acquireMicrophone();
+      return;
+    }
+    this.#flushHeldAudio(capture, "opened live");
+    this.#listeningOnAppends = true;
+    this.#turnEpoch += 1;
+    this.#setStatus(REALTIME_STATUS.LISTENING);
+  }
+
+  /**
+   * Sends one captured turn's opening: the format the appends must be read
+   * as, a clean buffer, then everything the capture has held — and one line
+   * of diagnostics, because whether the held words actually left this machine
+   * is exactly what a report of Luke not hearing them needs answered. How
+   * much audio and nothing else: the words themselves stay out of the log.
+   */
+  #flushHeldAudio(capture: PressCaptureState, how: string): void {
+    const heldMs = Math.round(capture.buffer.bufferedMs);
+    const droppedMs = Math.round(capture.buffer.droppedMs);
+    this.#send(inputAudioFormatUpdateEvents());
+    this.#send(clearInputAudioEvents());
+    let appends = 0;
+    for (const chunk of capture.buffer.drain()) {
+      this.#send(inputAudioAppendEvents(chunk));
+      appends += 1;
+    }
+    console.log(
+      `AI call: cold-press turn ${how} with ${heldMs}ms of held audio` +
+        ` (${appends} appends${droppedMs > 0 ? `, oldest ${droppedMs}ms dropped at the ceiling` : ""})`,
+    );
+  }
+
+  /**
+   * Delivers the turn a press held and released while the call was still
+   * connecting: the captured words flush as appends and commit as the turn
+   * the release already closed. It runs a tick after the channel opened so
+   * the caller's context re-feed lands first, and it yields to anything that
+   * moved in that tick — a new turn is the developer talking again, and words
+   * that yielded are discarded rather than queued behind it.
+   */
+  #deliverHeldTurn(): void {
+    const capture = this.#pressCapture;
+    if (!capture || !this.#pressCommitPending) return;
+    if (this.#closed || !this.isConnected || this.#turnBusy) {
+      this.#retirePressCapture();
+      return;
+    }
+    this.#pressCommitPending = false;
+    this.#flushHeldAudio(capture, "delivered sealed");
+    this.#retirePressCapture();
+    // A turn a tool may run in, exactly as a live commit is: the developer
+    // opened it by holding the key and spoke into it; only the delivery
+    // waited.
+    this.#startResponse(pushToTalkCommitEvents(), { toolsArmed: true });
   }
 
   /**
@@ -996,6 +1266,24 @@ export class RealtimeVoiceSession {
    */
   stopListening(commit: boolean): void {
     if (!this.#microphone || this.#status !== REALTIME_STATUS.LISTENING) return;
+    if (this.#listeningOnAppends) {
+      // The captured turn ends here whichever way, and the seam settles with
+      // it: the capture stops and the track joins the sender, so every turn
+      // after this one rides WebRTC as before. The device itself is kept
+      // exactly as a track turn keeps it — through the reply, released in
+      // the quiet after it — for the same shared-hardware reason.
+      this.#retirePressCapture();
+      this.#microphone.enabled = false;
+      if (!commit) {
+        this.#send(clearInputAudioEvents());
+        this.#setStatus(REALTIME_STATUS.READY);
+        return;
+      }
+      // The commit follows the last append on the same ordered channel, so it
+      // closes over every word the capture delivered.
+      this.#startResponse(pushToTalkCommitEvents(), { toolsArmed: true });
+      return;
+    }
     this.#microphone.enabled = false;
     if (!commit) {
       this.#send(clearInputAudioEvents());
@@ -1161,6 +1449,14 @@ export class RealtimeVoiceSession {
     }
     this.#peer = undefined;
     this.#remoteTrack = undefined;
+    // A fresh token before the capture retires: a device still opening for
+    // the attempt this teardown ends finds it stale and releases itself. The
+    // capture retires while the track is still known — so it can close it —
+    // and the channel is already down, so retirement hands no track to a
+    // sender: there is no call left to carry it, and the words the capture
+    // still held die with the attempt.
+    this.#attempt = {};
+    this.#retirePressCapture();
     this.#microphone = undefined;
     this.#microphoneSender = undefined;
     this.#stream?.getTracks().forEach((track) => {
@@ -1740,9 +2036,14 @@ export class RealtimeVoiceSession {
    * thing that can leave the machine in a conversation nobody opened by hand.
    * The stores above still update either way, so the developer's next call
    * starts current.
+   *
+   * Judged by whose call it is, not by whether a device is open this instant:
+   * the device is the press's and comes and goes with each turn, while the
+   * context belongs to the conversation — a typed ask between turns and a
+   * held press delivered after its release are both answered from it.
    */
   #carriesContext(): boolean {
-    return this.isConnected && this.#microphone !== undefined;
+    return this.isConnected && this.#withMicrophone;
   }
 
   #handleServerEvent(data: unknown): void {

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -892,12 +892,17 @@ export class RealtimeVoiceSession {
       this.#releaseMicrophone();
       return;
     }
-    // A press let go of while its device was still opening held nothing to
-    // send: the turn it was owed is dropped rather than opened under a key
-    // that is already up. A press against Luke's speak-only call is a
-    // different wait — for the developer's call — and keeps its meaning.
+    // A press let go of while its device was still opening held nothing of
+    // its own to send: the turn it was owed is dropped rather than opened
+    // under a key that is already up. But a re-press re-opens a sealed turn,
+    // and the words sealed toward it are still owed — a commit delivers them
+    // now, connected as we are, and a discard lets the whole turn go. A press
+    // against Luke's speak-only call is a different wait — for the
+    // developer's call — and keeps its meaning.
     if (!this.#microphone && this.#withMicrophone) {
       this.#pendingTurn = false;
+      if (commit && this.#pressCommitPending) this.#deliverHeldTurn();
+      else this.#retirePressCapture();
       return;
     }
     this.stopListening(commit);
@@ -1045,6 +1050,18 @@ export class RealtimeVoiceSession {
       else this.#releaseMicrophone();
       return;
     }
+    if (this.#pendingTurn && this.#pressCapture) {
+      // The device arrived connected, for a re-press over sealed words — the
+      // channel opened while it was still on its way. The turn it re-opened
+      // still owes those words, and a track turn would start by clearing
+      // them: so the turn opens as the captured turn it began as, resuming
+      // capture on the device that just arrived, and the track joins the
+      // sender at the seam as every captured turn's does.
+      this.#beginPressCapture();
+      this.#pendingTurn = false;
+      this.#beginAppendsTurn();
+      return;
+    }
     const sender = this.#microphoneSender;
     if (!sender) {
       // A connected microphone call always negotiated a sender; without one
@@ -1095,12 +1112,14 @@ export class RealtimeVoiceSession {
 
   /**
    * Starts capturing the press's words, when there is a press to capture for.
-   * Harmless to ask again: it runs only while a press is waiting on a
-   * connecting microphone call with the device already open and nothing
-   * already reading it — every other moment it does nothing.
+   * Harmless to ask again: it runs only while a press holds a turn on a
+   * microphone call with the device already open and nothing already reading
+   * it — every other moment it does nothing. Its two callers are the device
+   * arriving mid-connect, and the device arriving connected for a re-press
+   * over sealed words: either way the turn it feeds travels as appends.
    */
   #beginPressCapture(): void {
-    if (!this.#withMicrophone || !this.#pendingTurn || this.isConnected) return;
+    if (!this.#withMicrophone || !this.#pendingTurn) return;
     if (this.#pressCapture?.source || this.#closed) return;
     const stream = this.#stream;
     const microphone = this.#microphone;

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -789,10 +789,20 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       return;
     }
     talkLatched.current = false;
-    // A held press let go of before the call opened is dropped, not sent —
-    // nothing was captured to send — and the meter it put up leaves with it.
-    if (voiceSession.current && !voiceSession.current.isConnected) setTalkOpening(false);
     voiceSession.current?.endTurn(true);
+    // A held press let go of before the call opened is no longer always
+    // dropped: its words were captured beside the handshake, and a press that
+    // said something is still owed its turn — the session keeps it pending
+    // and delivers it when the channel opens, so the meter rides until the
+    // reply to it begins. One that said nothing leaves with its meter, as it
+    // always did.
+    if (
+      voiceSession.current &&
+      !voiceSession.current.isConnected &&
+      !voiceSession.current.turnPending
+    ) {
+      setTalkOpening(false);
+    }
   }, []);
 
   /**

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -9,6 +9,8 @@ import {
   type AttentionSpeech,
   CONTEXT_ITEM_KIND,
   ISSUE_TRACKER_ID,
+  inputAudioAppendEvents,
+  inputAudioFormatUpdateEvents,
   type NormalizedSession,
   normalizeSession,
   normalizeTrackedIssue,
@@ -73,6 +75,11 @@ interface Harness {
   fireIdle: () => void;
   /** Every track handed to the sender, `null` standing for the device let go. */
   replacedTracks: () => (object | null)[];
+  /**
+   * The press captures the session created, in order. `feed` plays samples
+   * into one as the audio graph would; `stopped` says the session let go.
+   */
+  pressCaptures: { stopped: boolean; feed: (samples: readonly number[]) => void }[];
   /** Makes the next device request refuse, as a vanished microphone would. */
   failMicrophone: () => void;
   /** Holds device opens in flight until `ungateMicrophone` lets them land. */
@@ -202,6 +209,7 @@ function harness(
   let connection = "connection" in options ? options.connection : CONNECTION;
   let microphoneError = options.microphoneError;
   let microphoneGate: (() => void)[] | undefined;
+  const pressCaptures: { stopped: boolean; feed: (samples: readonly number[]) => void }[] = [];
   const session = new RealtimeVoiceSession({
     requestConnection: async () => {
       calls.push("credential-requested");
@@ -221,6 +229,18 @@ function harness(
         });
       }
       return stream as unknown as MediaStream;
+    },
+    createPressCapture: (_stream, onChunk) => {
+      const record = {
+        stopped: false,
+        feed: (samples: readonly number[]) => onChunk(new Int16Array(samples)),
+      };
+      pressCaptures.push(record);
+      return {
+        stop: () => {
+          record.stopped = true;
+        },
+      };
     },
     createPeerConnection: () => peer as unknown as RTCPeerConnection,
     exchangeDescription: async (url, init) => {
@@ -310,6 +330,7 @@ function harness(
       for (const release of held) release();
     },
     transceivers,
+    pressCaptures,
   };
 }
 
@@ -560,13 +581,17 @@ test("a press during the handshake opens the turn it was asking for", async () =
   const context = harness({ connectionDelayMs: 5 });
 
   // The order a talk key produces: the press comes first, and the call is what
-  // it starts. Nothing is captured until the microphone opens at the far end.
+  // it starts. The press opens the device beside the mint and is captured
+  // from the moment it answers, so the turn opens on those words — as
+  // appends, with the track joining the sender only when the turn is over.
   context.session.toggleTurn();
   await context.session.connect();
-  await deviceArrives();
 
   assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
+  // Open for the capture to read — a disabled track reads as silence — while
+  // the sender stays empty, so nothing rides the network before the commit.
   assert.equal(context.microphoneEnabled(), true);
+  assert.deepEqual(context.replacedTracks(), []);
 });
 
 test("pressing twice during the handshake leaves no turn open", async () => {
@@ -586,6 +611,240 @@ test("pressing twice during the handshake leaves no turn open", async () => {
     context.sent.filter((event) => event.type === REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_COMMIT),
     [],
   );
+});
+
+test("words spoken into the handshake are carried into the turn it opens", async () => {
+  const context = harness({ connectionDelayMs: 5 });
+
+  context.session.beginTurn();
+  const opening = context.session.connect();
+  // The press asked for the device before the mint was even requested — the
+  // press is what opens it — and it answered while the mint was still out:
+  // the press's words are already being captured.
+  await deviceArrives();
+  assert.deepEqual(context.calls.slice(0, 2), ["microphone-requested", "credential-requested"]);
+  const capture = context.pressCaptures[0];
+  assert.ok(capture);
+  assert.equal(context.microphoneEnabled(), true);
+  capture.feed([1, 2, 3]);
+  capture.feed([4, 5]);
+  assert.equal(await opening, true);
+
+  // The turn opened on what was held: the format the appends must be read
+  // as, a clean buffer, then the captured chunks in capture order, all on
+  // the one ordered channel.
+  assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
+  assert.deepEqual(context.sent, [
+    ...inputAudioFormatUpdateEvents(),
+    { type: REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_CLEAR },
+    ...inputAudioAppendEvents(new Int16Array([1, 2, 3])),
+    ...inputAudioAppendEvents(new Int16Array([4, 5])),
+  ]);
+  // The whole turn travels as appends, so the sender carries no track yet:
+  // its silence must not land beside the words.
+  assert.deepEqual(context.replacedTracks(), []);
+
+  // Words said after the channel opened ride the same path, live.
+  capture.feed([6]);
+  assert.deepEqual(context.sent.at(-1), inputAudioAppendEvents(new Int16Array([6]))[0]);
+
+  // The release commits behind the last append: nothing can double or drop,
+  // because one channel carried every word and the commit follows them all.
+  context.session.endTurn(true);
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+  assert.deepEqual(
+    context.sent.slice(-2).map((event) => event.type),
+    [REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_COMMIT, REALTIME_CLIENT_EVENT.RESPONSE_CREATE],
+  );
+  // The seam settles with the turn: the capture ends, the track closes with
+  // it, and the sender takes the track for every turn after this one.
+  assert.equal(capture.stopped, true);
+  assert.equal(context.microphoneEnabled(), false);
+  assert.equal(context.replacedTracks().length, 1);
+  assert.notEqual(context.replacedTracks().at(-1), null);
+});
+
+test("a release during the handshake delivers the words once the channel opens", async () => {
+  const context = harness({ connectionDelayMs: 5 });
+
+  context.session.beginTurn();
+  const opening = context.session.connect();
+  await deviceArrives();
+  const capture = context.pressCaptures[0];
+  assert.ok(capture);
+  capture.feed([7, 8]);
+  // The key comes up while the call is still connecting: the capture stops
+  // reading and the device closes this instant — the sealed words wait in
+  // memory, not on an open microphone.
+  context.session.endTurn(true);
+  assert.equal(capture.stopped, true);
+  assert.equal(context.microphoneStopped(), true);
+  // The press is still owed its turn, so the opening meter keeps riding.
+  assert.equal(context.session.turnPending, true);
+
+  assert.equal(await opening, true);
+  // The delivery waits a beat for exactly this: the caller re-feeds the
+  // roster right after connect resolves, and the held words' reply must be
+  // answered from that context rather than from none.
+  context.session.updateSessions([observedSession("session-1")]);
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+  await deviceArrives();
+
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+  assert.equal(context.session.turnPending, false);
+  assert.deepEqual(
+    context.sent.map((event) => event.type),
+    [
+      REALTIME_CLIENT_EVENT.SESSION_UPDATE,
+      REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_CLEAR,
+      REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_APPEND,
+      REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE,
+      REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_COMMIT,
+      REALTIME_CLIENT_EVENT.RESPONSE_CREATE,
+    ],
+  );
+  assert.deepEqual(context.sent[0], inputAudioFormatUpdateEvents()[0]);
+  assert.deepEqual(context.sent[2], inputAudioAppendEvents(new Int16Array([7, 8]))[0]);
+});
+
+test("the words a failed attempt captured die with it", async () => {
+  const context = harness({ connection: undefined, connectionDelayMs: 5 });
+
+  context.session.beginTurn();
+  const opening = context.session.connect();
+  await deviceArrives();
+  context.pressCaptures[0]?.feed([9, 9]);
+  context.session.endTurn(true);
+  assert.equal(await opening, false);
+
+  assert.equal(context.session.status, REALTIME_STATUS.UNAVAILABLE);
+  assert.equal(context.pressCaptures[0]?.stopped, true);
+  assert.equal(context.session.turnPending, false);
+
+  // The key appears later and something opens a call. Nobody has pressed
+  // anything since, so nothing of those words may reach it: a press does not
+  // outlive the attempt it started, and now neither does what it said.
+  context.provideConnection();
+  assert.equal(await context.session.connect(), true);
+  await deviceArrives();
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+  assert.deepEqual(
+    context.sent.filter(
+      (event) =>
+        event.type === REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_APPEND ||
+        event.type === REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_COMMIT,
+    ),
+    [],
+  );
+});
+
+test("pressing twice during the handshake takes the words back with the press", async () => {
+  const context = harness({ connectionDelayMs: 5 });
+
+  context.session.toggleTurn();
+  const opening = context.session.connect();
+  await deviceArrives();
+  context.pressCaptures[0]?.feed([1]);
+  context.session.toggleTurn();
+  // The cancelled turn takes its words and its device with it.
+  assert.equal(context.pressCaptures[0]?.stopped, true);
+  assert.equal(context.microphoneStopped(), true);
+  await opening;
+
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+  assert.deepEqual(
+    context.sent.filter(
+      (event) =>
+        event.type === REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_APPEND ||
+        event.type === REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_COMMIT,
+    ),
+    [],
+  );
+});
+
+test("an abandoned captured turn clears the buffer and settles the seam", async () => {
+  const context = harness({ connectionDelayMs: 5 });
+
+  context.session.beginTurn();
+  const opening = context.session.connect();
+  await deviceArrives();
+  const capture = context.pressCaptures[0];
+  assert.ok(capture);
+  capture.feed([1, 2]);
+  await opening;
+  assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
+
+  context.session.endTurn(false);
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+  assert.equal(capture.stopped, true);
+  const types = context.sent.map((event) => event.type);
+  // One clear opened the turn, one abandoned it, and nothing was committed.
+  assert.equal(
+    types.filter((type) => type === REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_CLEAR).length,
+    2,
+  );
+  assert.equal(types.includes(REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_COMMIT), false);
+
+  // A chunk from the capture the session already let go of goes nowhere.
+  const sentBefore = context.sent.length;
+  capture.feed([5]);
+  assert.equal(context.sent.length, sentBefore);
+
+  // And the next turn rides the track, as every turn before the press did.
+  await holdTurn(context);
+  assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
+  assert.equal(context.microphoneEnabled(), true);
+  assert.notEqual(context.replacedTracks().at(-1), null);
+});
+
+test("a press landing again over sealed words re-opens the same turn", async () => {
+  const context = harness({ connectionDelayMs: 20 });
+
+  context.session.beginTurn();
+  const opening = context.session.connect();
+  await deviceArrives();
+  context.pressCaptures[0]?.feed([1]);
+  // Released mid-connect: the words seal for delivery and the device rests.
+  context.session.endTurn(true);
+  assert.equal(context.pressCaptures[0]?.stopped, true);
+
+  // Pressed again before the channel opened. The sealed delivery is
+  // superseded — this press's own release will decide afresh — and capture
+  // resumes into the same turn, so neither press's words are lost.
+  context.session.beginTurn();
+  await deviceArrives();
+  const resumed = context.pressCaptures[1];
+  assert.ok(resumed);
+  resumed.feed([2]);
+  await opening;
+
+  // Still held at the open, so the turn is live on both presses' words.
+  assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
+  assert.deepEqual(context.sent, [
+    ...inputAudioFormatUpdateEvents(),
+    { type: REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_CLEAR },
+    ...inputAudioAppendEvents(new Int16Array([1])),
+    ...inputAudioAppendEvents(new Int16Array([2])),
+  ]);
+
+  context.session.endTurn(true);
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+  assert.equal(resumed.stopped, true);
+});
+
+test("a speak-only call captures nothing, however long a press waits", async () => {
+  const context = harness();
+
+  context.session.beginTurn();
+  assert.equal(await context.session.connect({ microphone: false }), true);
+  await deviceArrives();
+
+  // Luke's own call takes no device: one the press opened ahead of it is
+  // released the moment it answers, nothing is captured, and the press stays
+  // pending for the developer's call.
+  assert.deepEqual(context.pressCaptures, []);
+  assert.equal(context.session.turnPending, true);
+  assert.equal(context.microphoneEnabled(), false);
 });
 
 test("a press does not outlive the call it failed to open", async () => {

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -832,6 +832,83 @@ test("a press landing again over sealed words re-opens the same turn", async () 
   assert.equal(resumed.stopped, true);
 });
 
+test("a re-press whose device trails the channel still carries the sealed words", async () => {
+  const context = harness({ connectionDelayMs: 10 });
+
+  context.session.beginTurn();
+  const opening = context.session.connect();
+  await deviceArrives();
+  context.pressCaptures[0]?.feed([1]);
+  // Released mid-connect: the words seal and the device rests.
+  context.session.endTurn(true);
+
+  // Pressed again — but this time the channel opens before the re-press's
+  // device has answered, so the turn's device arrives on a connected call.
+  context.gateMicrophone();
+  context.session.beginTurn();
+  assert.equal(await opening, true);
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+  context.ungateMicrophone();
+  await deviceArrives();
+
+  // The re-opened turn still owes the sealed words: it opens as the captured
+  // turn it began as, never as a track turn whose clear would wipe them.
+  assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
+  assert.deepEqual(context.sent, [
+    ...inputAudioFormatUpdateEvents(),
+    { type: REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_CLEAR },
+    ...inputAudioAppendEvents(new Int16Array([1])),
+  ]);
+  const resumed = context.pressCaptures[1];
+  assert.ok(resumed);
+  resumed.feed([2]);
+  assert.deepEqual(context.sent.at(-1), inputAudioAppendEvents(new Int16Array([2]))[0]);
+
+  context.session.endTurn(true);
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+  assert.equal(context.session.turnPending, false);
+  assert.notEqual(context.replacedTracks().at(-1), null);
+});
+
+test("a re-press released before its device arrives still delivers the sealed words", async () => {
+  const context = harness({ connectionDelayMs: 10 });
+
+  context.session.beginTurn();
+  const opening = context.session.connect();
+  await deviceArrives();
+  context.pressCaptures[0]?.feed([3]);
+  context.session.endTurn(true);
+
+  context.gateMicrophone();
+  context.session.beginTurn();
+  assert.equal(await opening, true);
+  // Let go again while the re-press's device is still opening: the re-press
+  // itself captured nothing, but the sealed words it re-opened are still
+  // owed, and the press is not left standing forever behind a delivery
+  // nothing would ever trigger.
+  context.session.endTurn(true);
+
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+  assert.equal(context.session.turnPending, false);
+  assert.deepEqual(
+    context.sent.map((event) => event.type),
+    [
+      REALTIME_CLIENT_EVENT.SESSION_UPDATE,
+      REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_CLEAR,
+      REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_APPEND,
+      REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_COMMIT,
+      REALTIME_CLIENT_EVENT.RESPONSE_CREATE,
+    ],
+  );
+  assert.deepEqual(context.sent[2], inputAudioAppendEvents(new Int16Array([3]))[0]);
+
+  // The device that was still opening arrives to a turn already delivered:
+  // nobody is talking into it, so it closes as fast as it arrived.
+  context.ungateMicrophone();
+  await deviceArrives();
+  assert.equal(context.microphoneStopped(), true);
+});
+
 test("a speak-only call captures nothing, however long a press waits", async () => {
   const context = harness();
 

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -199,6 +199,8 @@ export {
   clearInputAudioEvents,
   functionCallFollowUpEvents,
   functionCallOutputEvents,
+  inputAudioAppendEvents,
+  inputAudioFormatUpdateEvents,
   maximumNoticeContextLength,
   outputSpeedUpdateEvents,
   parseRealtimeServerEvent,
@@ -213,6 +215,11 @@ export {
   truncateResponseEvents,
   typedAskEvents,
 } from "./realtime-protocol.js";
+export {
+  MAXIMUM_PRESS_AUDIO_MS,
+  PRESS_AUDIO_SAMPLE_RATE,
+  PressAudioBuffer,
+} from "./press-audio.js";
 export {
   HOSTED_API_ERROR,
   HOSTED_CALLS_URL,

--- a/packages/sidecar-core/src/press-audio.ts
+++ b/packages/sidecar-core/src/press-audio.ts
@@ -1,0 +1,95 @@
+/**
+ * The audio a talk-key press captures while its call is still connecting.
+ *
+ * The microphone device opens at key-down, but on a WebRTC call nothing the
+ * developer says can reach the service until the data channel opens — so the
+ * words spoken into the handshake are captured locally, held here, and flushed
+ * as `input_audio_buffer.append` events the moment the channel is up. The
+ * buffer belongs to one connect attempt and dies with it: a failed attempt
+ * discards it, so no press can leave words behind for a later connection.
+ */
+
+/**
+ * The sample rate the held audio is captured at. It is the input format the
+ * session is minted with — the API's default of 16-bit PCM at 24kHz mono,
+ * which `realtimeSessionConfig` leaves in place — so an append needs no
+ * conversion the capture did not already do.
+ */
+export const PRESS_AUDIO_SAMPLE_RATE = 24_000;
+
+/**
+ * How much held audio a press may accumulate before the oldest of it goes.
+ *
+ * The bound exists because the wait it covers is not itself bounded: the SDP
+ * exchange and the channel opening share a deadline, but the credential mint
+ * ahead of them has none — on the hosted path it transits Luke's service — so
+ * a stuck mint under a held key would otherwise grow memory for as long as
+ * the key was down. Thirty seconds is twice the connect deadline and longer
+ * than anything worth saying into a call that has not opened.
+ */
+export const MAXIMUM_PRESS_AUDIO_MS = 30_000;
+
+/**
+ * Holds the chunks one press captured, in capture order, under a hard ceiling.
+ *
+ * Overflow drops the oldest audio first, trimming within a chunk when it must,
+ * so the ceiling is exact and what survives is one continuous stretch ending
+ * at the newest sample — the words that flow straight into the live turn. The
+ * beginning of a sentence spoken into a thirty-second stall is the least
+ * recoverable part of it, and a gap in the middle would garble more than the
+ * loss of either end.
+ */
+export class PressAudioBuffer {
+  readonly #maximumSamples: number;
+  readonly #sampleRate: number;
+  #chunks: Int16Array[] = [];
+  #bufferedSamples = 0;
+  #droppedSamples = 0;
+
+  constructor(options: { maximumMs?: number; sampleRate?: number } = {}) {
+    this.#sampleRate = options.sampleRate ?? PRESS_AUDIO_SAMPLE_RATE;
+    const maximumMs = options.maximumMs ?? MAXIMUM_PRESS_AUDIO_MS;
+    this.#maximumSamples = Math.max(1, Math.floor((maximumMs * this.#sampleRate) / 1_000));
+  }
+
+  push(chunk: Int16Array): void {
+    if (chunk.length === 0) return;
+    this.#chunks.push(chunk);
+    this.#bufferedSamples += chunk.length;
+    while (this.#bufferedSamples > this.#maximumSamples) {
+      const oldest = this.#chunks[0];
+      if (!oldest) break;
+      const excess = this.#bufferedSamples - this.#maximumSamples;
+      if (oldest.length <= excess) {
+        this.#chunks.shift();
+        this.#bufferedSamples -= oldest.length;
+        this.#droppedSamples += oldest.length;
+      } else {
+        this.#chunks[0] = oldest.subarray(excess);
+        this.#bufferedSamples -= excess;
+        this.#droppedSamples += excess;
+      }
+    }
+  }
+
+  /** The chunks in capture order. The buffer is empty afterwards. */
+  drain(): readonly Int16Array[] {
+    const chunks = this.#chunks;
+    this.#chunks = [];
+    this.#bufferedSamples = 0;
+    return chunks;
+  }
+
+  get isEmpty(): boolean {
+    return this.#bufferedSamples === 0;
+  }
+
+  get bufferedMs(): number {
+    return (this.#bufferedSamples * 1_000) / this.#sampleRate;
+  }
+
+  /** How much the ceiling has cost so far, oldest-first, across the press. */
+  get droppedMs(): number {
+    return (this.#droppedSamples * 1_000) / this.#sampleRate;
+  }
+}

--- a/packages/sidecar-core/src/realtime-credentials.ts
+++ b/packages/sidecar-core/src/realtime-credentials.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "./json.js";
+import { PRESS_AUDIO_SAMPLE_RATE } from "./press-audio.js";
 import { REALTIME_SESSION_TYPE, realtimeInstructions } from "./realtime-protocol.js";
 import { realtimeToolDefinitions } from "./realtime-tools.js";
 import { REALTIME_DEFAULTS } from "./realtime-voice-settings.js";
@@ -81,6 +82,12 @@ export function realtimeSessionConfig(options: RealtimeSessionOptions = {}) {
     },
     audio: {
       input: {
+        // What base64 audio over the data channel means, pinned rather than
+        // assumed: the words a press captures during the handshake travel as
+        // appends, and PCM read at any rate but its own is not heard wrong,
+        // it is not heard at all. The track's own Opus is negotiated by the
+        // call and never reads this.
+        format: { type: "audio/pcm", rate: PRESS_AUDIO_SAMPLE_RATE },
         turn_detection: null,
       },
       output: {

--- a/packages/sidecar-core/src/realtime-protocol.ts
+++ b/packages/sidecar-core/src/realtime-protocol.ts
@@ -4,6 +4,7 @@ import {
   maximumAttentionSummaryLength,
 } from "./attention.js";
 import { isRecord } from "./json.js";
+import { PRESS_AUDIO_SAMPLE_RATE } from "./press-audio.js";
 import { spokenRealtimeToolCount } from "./realtime-tools.js";
 import {
   ATTENTION_DISPOSITION,
@@ -41,6 +42,13 @@ export type RealtimeStatus = (typeof REALTIME_STATUS)[keyof typeof REALTIME_STAT
 
 export const REALTIME_CLIENT_EVENT = {
   SESSION_UPDATE: "session.update",
+  /**
+   * Adds audio to the input buffer over the data channel. On a WebRTC call the
+   * microphone track already feeds that buffer, so this exists for the audio
+   * the track cannot carry: the words spoken while the call was still
+   * connecting, captured locally and flushed once the channel opens.
+   */
+  INPUT_AUDIO_BUFFER_APPEND: "input_audio_buffer.append",
   INPUT_AUDIO_BUFFER_COMMIT: "input_audio_buffer.commit",
   INPUT_AUDIO_BUFFER_CLEAR: "input_audio_buffer.clear",
   CONVERSATION_ITEM_CREATE: "conversation.item.create",
@@ -288,6 +296,77 @@ export function typedAskEvents(text: string): readonly Record<string, unknown>[]
       },
     },
     { type: REALTIME_CLIENT_EVENT.RESPONSE_CREATE },
+  ];
+}
+
+const BASE64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/**
+ * Encodes bytes without reaching for an environment: `btoa` wants a binary
+ * string and Node's `Buffer` does not exist in a sandboxed renderer, and the
+ * audio event is this module's grammar, so its encoding lives here too.
+ */
+function base64FromBytes(bytes: Uint8Array): string {
+  let encoded = "";
+  for (let index = 0; index < bytes.length; index += 3) {
+    const first = bytes[index] ?? 0;
+    const second = bytes[index + 1];
+    const third = bytes[index + 2];
+    encoded += BASE64_ALPHABET[first >> 2];
+    encoded += BASE64_ALPHABET[((first & 0b11) << 4) | ((second ?? 0) >> 4)];
+    encoded +=
+      second === undefined ? "=" : BASE64_ALPHABET[((second & 0b1111) << 2) | ((third ?? 0) >> 6)];
+    encoded += third === undefined ? "=" : BASE64_ALPHABET[third & 0b111111];
+  }
+  return encoded;
+}
+
+/**
+ * Builds the event that declares what the appended audio is, ahead of
+ * appending any.
+ *
+ * On a WebRTC call the negotiated input is Opus at the codec's own rate, so
+ * nothing about the call itself says how base64 audio arriving over the data
+ * channel should be read — and 24kHz PCM read at any other rate is not heard
+ * wrong, it is not heard at all. The keyed mint pins the same format, but the
+ * hosted mint composes its session on the service, so the one place every
+ * call can be pinned from is the channel itself: this travels at the start of
+ * every captured turn, before the clear and the appends it speaks for.
+ */
+export function inputAudioFormatUpdateEvents(): readonly Record<string, unknown>[] {
+  return [
+    {
+      type: REALTIME_CLIENT_EVENT.SESSION_UPDATE,
+      session: {
+        type: REALTIME_SESSION_TYPE,
+        audio: { input: { format: { type: "audio/pcm", rate: PRESS_AUDIO_SAMPLE_RATE } } },
+      },
+    },
+  ];
+}
+
+/**
+ * Builds the event that adds one captured chunk to the input audio buffer.
+ *
+ * The samples travel as the format {@link inputAudioFormatUpdateEvents} pins —
+ * 16-bit PCM at the press capture's own rate, little-endian whatever this
+ * machine is, base64 over the data channel. An empty chunk builds nothing:
+ * there is no audio to add, and the API refuses an empty append rather than
+ * ignoring it.
+ */
+export function inputAudioAppendEvents(audio: Int16Array): readonly Record<string, unknown>[] {
+  if (audio.length === 0) return [];
+  const bytes = new Uint8Array(audio.length * 2);
+  for (let index = 0; index < audio.length; index += 1) {
+    const sample = audio[index] ?? 0;
+    bytes[index * 2] = sample & 0xff;
+    bytes[index * 2 + 1] = (sample >> 8) & 0xff;
+  }
+  return [
+    {
+      type: REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_APPEND,
+      audio: base64FromBytes(bytes),
+    },
   ];
 }
 

--- a/packages/sidecar-core/tests/press-audio.test.ts
+++ b/packages/sidecar-core/tests/press-audio.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { MAXIMUM_PRESS_AUDIO_MS, PRESS_AUDIO_SAMPLE_RATE, PressAudioBuffer } from "../src";
+
+/** A chunk whose samples are all one value, so provenance survives a trim. */
+function chunk(samples: number, value: number): Int16Array {
+  return new Int16Array(samples).fill(value);
+}
+
+test("chunks drain in capture order and draining empties the buffer", () => {
+  const buffer = new PressAudioBuffer();
+  buffer.push(chunk(3, 1));
+  buffer.push(chunk(2, 2));
+
+  const drained = buffer.drain();
+  assert.deepEqual(
+    drained.map((piece) => [...piece]),
+    [
+      [1, 1, 1],
+      [2, 2],
+    ],
+  );
+  assert.equal(buffer.isEmpty, true);
+  assert.deepEqual(buffer.drain(), []);
+});
+
+test("the buffered duration is counted at the capture rate", () => {
+  const buffer = new PressAudioBuffer();
+  buffer.push(chunk(PRESS_AUDIO_SAMPLE_RATE, 0));
+  assert.equal(buffer.bufferedMs, 1_000);
+
+  buffer.push(chunk(PRESS_AUDIO_SAMPLE_RATE / 2, 0));
+  assert.equal(buffer.bufferedMs, 1_500);
+});
+
+test("an empty chunk is not a chunk", () => {
+  const buffer = new PressAudioBuffer();
+  buffer.push(new Int16Array(0));
+  assert.equal(buffer.isEmpty, true);
+});
+
+test("overflow drops the oldest audio, so what survives ends at the newest word", () => {
+  // A press held into a stuck connect must not grow memory without bound —
+  // the mint ahead of the handshake has no deadline of its own — so the
+  // ceiling is hard, and it is the oldest audio that goes: what survives is
+  // one continuous stretch that flows into the live turn at the seam, and the
+  // opening of a sentence spoken into a thirty-second stall is the least
+  // recoverable part of it.
+  const buffer = new PressAudioBuffer({ maximumMs: 1_000 });
+  const second = PRESS_AUDIO_SAMPLE_RATE;
+  buffer.push(chunk(second / 2, 1));
+  buffer.push(chunk(second / 2, 2));
+  buffer.push(chunk(second / 2, 3));
+
+  assert.equal(buffer.bufferedMs, 1_000);
+  assert.equal(buffer.droppedMs, 500);
+  assert.deepEqual(
+    buffer.drain().map((piece) => piece[0]),
+    [2, 3],
+  );
+});
+
+test("the ceiling is exact even when it falls inside a chunk", () => {
+  const buffer = new PressAudioBuffer({ maximumMs: 1_000 });
+  const second = PRESS_AUDIO_SAMPLE_RATE;
+  const numbered = new Int16Array(second);
+  for (let index = 0; index < second; index += 1) numbered[index] = index % 32_000;
+  buffer.push(numbered);
+  buffer.push(chunk(second / 4, 9));
+
+  assert.equal(buffer.bufferedMs, 1_000);
+  assert.equal(buffer.droppedMs, 250);
+  const drained = buffer.drain();
+  // The oldest chunk lost exactly its first quarter — the trim is within the
+  // chunk, not of it — and the newer chunk is untouched.
+  assert.equal(drained[0]?.length, (second * 3) / 4);
+  assert.equal(drained[0]?.[0], (second / 4) % 32_000);
+  assert.equal(drained[1]?.length, second / 4);
+});
+
+test("a chunk larger than the whole ceiling keeps only its newest samples", () => {
+  const buffer = new PressAudioBuffer({ maximumMs: 100 });
+  const ceiling = (PRESS_AUDIO_SAMPLE_RATE * 100) / 1_000;
+  buffer.push(chunk(ceiling * 3, 7));
+
+  assert.equal(buffer.bufferedMs, 100);
+  assert.equal(buffer.droppedMs, 200);
+  assert.equal(buffer.drain()[0]?.length, ceiling);
+});
+
+test("the default ceiling outlasts the connect deadline it exists to survive", () => {
+  // Thirty seconds: twice the handshake's own deadline, because the mint
+  // ahead of the handshake answers to no deadline at all.
+  assert.equal(MAXIMUM_PRESS_AUDIO_MS, 30_000);
+  const buffer = new PressAudioBuffer();
+  buffer.push(chunk(PRESS_AUDIO_SAMPLE_RATE * 31, 0));
+  assert.equal(buffer.bufferedMs, 30_000);
+  assert.equal(buffer.droppedMs, 1_000);
+});

--- a/packages/sidecar-core/tests/realtime.test.ts
+++ b/packages/sidecar-core/tests/realtime.test.ts
@@ -17,6 +17,8 @@ import {
   functionCallFollowUpEvents,
   functionCallOutputEvents,
   ISSUE_TRACKER_ID,
+  inputAudioAppendEvents,
+  inputAudioFormatUpdateEvents,
   isIssueToolName,
   isRealtimeVoice,
   isRealtimeVoiceSpeed,
@@ -31,6 +33,7 @@ import {
   normalizeTrackedIssue,
   type ObservedWorkspaceProject,
   outputSpeedUpdateEvents,
+  PRESS_AUDIO_SAMPLE_RATE,
   parseRealtimeServerEvent,
   proactiveSpeechEvents,
   pushToTalkCommitEvents,
@@ -387,6 +390,58 @@ test("nothing heard is nothing to correct", () => {
   ]) {
     assert.deepEqual(truncateResponseEvents(input), []);
   }
+});
+
+test("a captured turn declares its audio's format before appending any", () => {
+  // On a WebRTC call nothing else says how base64 audio over the data channel
+  // should be read, and the hosted mint composes its session on the service —
+  // so the channel itself pins the format, at the capture's own rate.
+  assert.deepEqual(inputAudioFormatUpdateEvents(), [
+    {
+      type: REALTIME_CLIENT_EVENT.SESSION_UPDATE,
+      session: {
+        type: "realtime",
+        audio: { input: { format: { type: "audio/pcm", rate: PRESS_AUDIO_SAMPLE_RATE } } },
+      },
+    },
+  ]);
+});
+
+test("the keyed mint pins the same input format the appends travel as", () => {
+  const config = realtimeSessionConfig();
+
+  assert.deepEqual(config.audio.input.format, {
+    type: "audio/pcm",
+    rate: PRESS_AUDIO_SAMPLE_RATE,
+  });
+});
+
+test("captured audio travels as one append, little-endian PCM in base64", () => {
+  const events = inputAudioAppendEvents(new Int16Array([0, 1, -1, 32_767, -32_768]));
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0]?.type, REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_APPEND);
+  // The five samples byte for byte, as Node's own encoder writes them —
+  // including the padded tail a length that is not a multiple of three needs.
+  assert.equal(events[0]?.audio, "AAABAP///38AgA==");
+});
+
+test("the append encoder agrees with a reference encoder at every length", () => {
+  // Base64 groups three bytes at a time, so each length modulo three is its
+  // own code path; a hand-rolled encoder has to be held to all of them.
+  for (const length of [1, 2, 3, 4, 5, 6, 100]) {
+    const samples = new Int16Array(length);
+    for (let index = 0; index < length; index += 1) samples[index] = index * 257 - 30_000;
+    const bytes = Buffer.alloc(length * 2);
+    for (let index = 0; index < length; index += 1) {
+      bytes.writeInt16LE(samples[index] ?? 0, index * 2);
+    }
+    assert.equal(inputAudioAppendEvents(samples)[0]?.audio, bytes.toString("base64"));
+  }
+});
+
+test("an empty chunk builds no append rather than one the API refuses", () => {
+  assert.deepEqual(inputAudioAppendEvents(new Int16Array(0)), []);
 });
 
 test("push-to-talk commits a turn and cancelling discards it", () => {


### PR DESCRIPTION
## What

Words spoken while a Realtime call is still connecting were lost: the microphone device opens at key-down, in parallel with the credential mint, but nothing could reach the service until the data channel opened. It bit on the first press after launch and on any press after the ten-minute idle retirement — worse on the hosted path (#204), where the mint transits Luke's service, but true of the keyed path too.

Now the press's words are captured locally from the moment the device answers — while the mint is still out — held in a bounded buffer, and flushed into the session's `input_audio_buffer` as `append` events the moment the channel opens. Turn detection is already off and commits already manual, so the release commits behind the flush exactly as it commits behind the track today.

## The seam, decided deliberately

The hard part is the seam between the flushed buffer and the live WebRTC microphone track. **The whole of the turn the press opened travels as appends; the sender carries no track until that turn settles.** Reasoning, also written into `realtime-session.ts`:

- Appends ride the ordered data channel; the track rides RTP. The server writes one input buffer in arrival order, so any turn that mixes the two has an unorderable seam — a late append lands after the first live frames and words swap, double, or drop.
- A muted track is not silent-on-the-wire: it transmits silence, which would interleave the flushed words with real-time gaps. So the sender is emptied (`replaceTrack(null)`) for the captured turn and handed the track back at the seam.
- On one channel every chunk lands exactly once, in capture order, with the commit behind the last of them: doubling and dropping are structurally impossible for the turn where it matters.
- The track takes over from the next turn on, across a boundary every turn already clears (`input_audio_buffer.clear` opens each turn), so there is nothing across that seam to double.

## Bounds and rules kept

- **Bounded buffer**: 30s ceiling (`MAXIMUM_PRESS_AUDIO_MS`) — twice the connect deadline, because the mint ahead of the handshake answers to no deadline at all. Overflow drops the *oldest* audio, trimming within a chunk so the bound is exact: what survives is one continuous stretch ending at the newest word, flowing into the live turn.
- **"A press does not outlive the attempt it started"**: the capture belongs to one connect attempt and every failing path discards it. A release mid-connect seals the words for delivery *on that attempt's channel* — delivered one tick after the caller re-feeds the roster, so the reply is answered from real context — and dies with the attempt otherwise.
- **The macOS indicator stays honest**: the device is acquired exactly where it was before (key-down, with the mint); the local capture reads it only while a press holds a turn, and a mid-connect release stops the read that instant.
- **A speak-only announcement call still offers no microphone track and captures nothing.**
- Captions and the face indicate the connecting state exactly as before (the press-wait meter now also rides a mid-connect release that is still owed its delivery), so `luke-guide.ts` needed no new facts; the talk-key and microphone facts remain true as written.

Known bound: capture chunks are ~85ms, and the processor's last partial quantum is lost at release — letting go of the key costs less than a syllable, which the track path's own encoder latency also costs today.

## Verification

- `./scripts/check.sh` passes: lint, typecheck, tests (sidecar-core 220, desktop 981, web 35, harness 38 — all green), builds.
- New unit tests cover the buffering seam: append builder byte-for-byte against a reference encoder; the bounded buffer's ceiling, oldest-first drop, and within-chunk trim; the appends turn end-to-end (clear → buffered appends → live appends → commit); release-mid-connect delivery after the context re-feed; a re-press over sealed words; discard, takeover, failed-attempt, and speak-only paths; the sender's withhold/hand-back at every seam.
- **Completion evidence is a physical-Mac spoken exchange**: first press after launch must carry the whole first sentence (and a press after the 10-minute idle retirement likewise). Not performable in this cloud workspace — no drawn change, so no visual evidence run; no physical-notch check applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/9ac96143-880a-433e-b5ef-c37be2e0cdda)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32207962989/artifacts/9349754825) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32207962989)

- Commit: `32d42d45c07ae1c42b76b68b8cf13e9ad4930c8a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
