### PR TITLE
feat(web): refresh landing page with direct download

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,13 +23,17 @@
     "@better-auth/drizzle-adapter": "1.6.29",
     "@better-auth/oauth-provider": "1.6.29",
     "@fontsource-variable/bricolage-grotesque": "5.3.0",
+    "@fontsource-variable/geist": "5.3.0",
+    "@fontsource-variable/jetbrains-mono": "5.3.0",
     "@sidecar/core": "workspace:*",
+    "@tailwindcss/vite": "4.3.3",
     "better-auth": "1.6.29",
     "drizzle-orm": "0.45.2",
     "marked": "18.0.9",
     "pg": "8.23.0",
     "react": "19.2.8",
-    "react-dom": "19.2.8"
+    "react-dom": "19.2.8",
+    "tailwindcss": "4.3.3"
   },
   "devDependencies": {
     "@types/node": "22.20.1",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,15 +1,5 @@
-import { PROVIDER_ID } from "@sidecar/core";
 import { NotchMock } from "./NotchMock";
-import { ProviderMark } from "./provider-marks";
 import { DMG_URL, GitHubMark, REPOSITORY_URL, SiteFooter, SiteHeader } from "./SiteChrome";
-
-const OBSERVED_PROVIDERS = [
-  { id: PROVIDER_ID.CLAUDE_CODE, label: "Claude Code" },
-  { id: PROVIDER_ID.CODEX, label: "Codex" },
-  { id: PROVIDER_ID.CONDUCTOR, label: "Conductor" },
-  { id: PROVIDER_ID.CURSOR, label: "Cursor" },
-  { id: PROVIDER_ID.DEVIN, label: "Devin" },
-] as const;
 
 export function App(): React.JSX.Element {
   return (
@@ -54,23 +44,6 @@ export function App(): React.JSX.Element {
           </p>
 
           <NotchMock />
-
-          <section className="hairline mt-12 pt-6" aria-labelledby="providers-title">
-            <h2 id="providers-title" className="m-0 text-lg leading-tight font-semibold">
-              Your agents, one place.
-            </h2>
-            <p className="mt-2 mb-0 text-sm text-muted-foreground">
-              Luke observes the tools you already use.
-            </p>
-            <ul className="mt-8 flex list-none flex-wrap gap-x-6 gap-y-4 p-0 text-muted-foreground">
-              {OBSERVED_PROVIDERS.map((provider) => (
-                <li key={provider.id} className="flex min-w-0 items-center gap-2 font-mono text-xs">
-                  <ProviderMark providerId={provider.id} className="size-5 shrink-0" />
-                  <span>{provider.label}</span>
-                </li>
-              ))}
-            </ul>
-          </section>
         </section>
       </main>
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -13,38 +13,59 @@ const OBSERVED_PROVIDERS = [
 
 export function App(): React.JSX.Element {
   return (
-    <div className="landing-page">
-      <div className="rules" aria-hidden="true">
-        <div className="rules-column" />
-      </div>
+    <div className="min-h-screen">
       <SiteHeader />
 
       <main className="shell">
-        <section className="hero">
-          <h1>Your AI Engineering Manager.</h1>
-          <p className="hero-subhead">
+        {/* The copy runs left, the way a page of prose does. The mock does not:
+            a notch belongs at the horizontal center of a display, so the art
+            centers itself inside the column the copy is aligned against. */}
+        <section className="pt-12 pb-16 max-[520px]:pt-8 max-[520px]:pb-0">
+          {/* Fixed rather than fluid, with one step down: at 2.25rem the line
+              needs about 490px, so it steps before the column can squeeze it
+              rather than at the column's own padding breakpoint. */}
+          <h1 className="m-0 text-[2.25rem] leading-[1.1] font-semibold tracking-[-0.02em] text-pretty max-[576px]:text-[1.75rem]">
+            Your AI Engineering Manager.
+          </h1>
+          <p className="mt-6 mb-0 max-w-[34rem] text-lg text-pretty text-muted-foreground">
             Luke watches your coding agent sessions and notifies you when they need your attention.
           </p>
-          <div className="cta-row">
-            <a className="cta-primary" href={DMG_URL}>
+
+          <div className="mt-8 flex flex-wrap items-center gap-3">
+            <a
+              className="inline-flex items-center gap-2 rounded-md bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground no-underline transition-[filter,transform] duration-150 hover:brightness-95 active:translate-y-px motion-reduce:transition-none"
+              href={DMG_URL}
+            >
               Download for macOS
             </a>
-            <a className="cta-secondary" href={REPOSITORY_URL}>
+            <a
+              className="inline-flex items-center gap-2 rounded-md border border-border px-[23px] py-[11px] text-sm font-semibold text-muted-foreground no-underline transition-colors duration-150 hover:border-muted-foreground hover:text-foreground motion-reduce:transition-none"
+              href={REPOSITORY_URL}
+            >
               <GitHubMark />
               View on GitHub
             </a>
           </div>
-          <p className="cta-caption">macOS 14+ · Apple silicon</p>
+
+          {/* A requirement, not a sentence: mono is what the page reserves for
+              technical tokens. */}
+          <p className="mt-3 mb-0 font-mono text-xs text-muted-foreground">
+            macOS 14+ · Apple silicon
+          </p>
 
           <NotchMock />
 
-          <section className="providers hairline" aria-labelledby="providers-title">
-            <h2 id="providers-title">Your agents, one place.</h2>
-            <p>Luke observes the tools you already use.</p>
-            <ul className="provider-list">
+          <section className="hairline mt-12 pt-6" aria-labelledby="providers-title">
+            <h2 id="providers-title" className="m-0 text-lg leading-tight font-semibold">
+              Your agents, one place.
+            </h2>
+            <p className="mt-2 mb-0 text-sm text-muted-foreground">
+              Luke observes the tools you already use.
+            </p>
+            <ul className="mt-8 flex list-none flex-wrap gap-x-6 gap-y-4 p-0 text-muted-foreground">
               {OBSERVED_PROVIDERS.map((provider) => (
-                <li key={provider.id}>
-                  <ProviderMark providerId={provider.id} />
+                <li key={provider.id} className="flex min-w-0 items-center gap-2 font-mono text-xs">
+                  <ProviderMark providerId={provider.id} className="size-5 shrink-0" />
                   <span>{provider.label}</span>
                 </li>
               ))}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,9 +1,22 @@
+import { PROVIDER_ID } from "@sidecar/core";
 import { NotchMock } from "./NotchMock";
-import { GitHubMark, REPOSITORY_URL, SiteFooter, SiteHeader } from "./SiteChrome";
+import { ProviderMark } from "./provider-marks";
+import { DMG_URL, GitHubMark, REPOSITORY_URL, SiteFooter, SiteHeader } from "./SiteChrome";
+
+const OBSERVED_PROVIDERS = [
+  { id: PROVIDER_ID.CLAUDE_CODE, label: "Claude Code" },
+  { id: PROVIDER_ID.CODEX, label: "Codex" },
+  { id: PROVIDER_ID.CONDUCTOR, label: "Conductor" },
+  { id: PROVIDER_ID.CURSOR, label: "Cursor" },
+  { id: PROVIDER_ID.DEVIN, label: "Devin" },
+] as const;
 
 export function App(): React.JSX.Element {
   return (
-    <>
+    <div className="landing-page">
+      <div className="rules" aria-hidden="true">
+        <div className="rules-column" />
+      </div>
       <SiteHeader />
 
       <main className="shell">
@@ -13,17 +26,34 @@ export function App(): React.JSX.Element {
             Luke watches your coding agent sessions and notifies you when they need your attention.
           </p>
           <div className="cta-row">
-            <a className="cta-primary" href={REPOSITORY_URL}>
+            <a className="cta-primary" href={DMG_URL}>
+              Download for macOS
+            </a>
+            <a className="cta-secondary" href={REPOSITORY_URL}>
               <GitHubMark />
               View on GitHub
             </a>
           </div>
+          <p className="cta-caption">macOS 14+ · Apple silicon</p>
 
           <NotchMock />
+
+          <section className="providers hairline" aria-labelledby="providers-title">
+            <h2 id="providers-title">Your agents, one place.</h2>
+            <p>Luke observes the tools you already use.</p>
+            <ul className="provider-list">
+              {OBSERVED_PROVIDERS.map((provider) => (
+                <li key={provider.id}>
+                  <ProviderMark providerId={provider.id} />
+                  <span>{provider.label}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
         </section>
       </main>
 
       <SiteFooter />
-    </>
+    </div>
   );
 }

--- a/apps/web/src/SiteChrome.tsx
+++ b/apps/web/src/SiteChrome.tsx
@@ -1,4 +1,5 @@
 export const REPOSITORY_URL = "https://github.com/ReviewStage/luke";
+export const DMG_URL = `${REPOSITORY_URL}/releases/latest/download/Luke.dmg`;
 
 /**
  * GitHub's mark, drawn in `currentColor` so the stylesheet holds the color in
@@ -66,7 +67,7 @@ export function SiteHeader(): React.JSX.Element {
 /** Shared between every page so the legal and license links never drift apart. */
 export function SiteFooter(): React.JSX.Element {
   return (
-    <footer className="site-footer shell">
+    <footer className="site-footer shell hairline">
       <div className="footer-meta">
         <span>Apache-2.0</span>
         <span>macOS 14+</span>

--- a/apps/web/src/SiteChrome.tsx
+++ b/apps/web/src/SiteChrome.tsx
@@ -10,13 +10,19 @@ const GITHUB_MARK_PATH =
   "M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.65 7.65 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z";
 
 /**
+ * Both marks size at their call site rather than through a stylesheet rule, so
+ * the one place a mark's box is decided is the place it is drawn.
+ */
+type MarkProps = { readonly className?: string };
+
+/**
  * Always decorative: every use either sits beside a visible label or hangs off
  * a link that carries its own `aria-label`, so announcing the mark as well
  * would only repeat what a reader already hears.
  */
-export function GitHubMark(): React.JSX.Element {
+export function GitHubMark({ className = "block size-4" }: MarkProps): React.JSX.Element {
   return (
-    <svg className="github-mark" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+    <svg className={className} viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
       <path d={GITHUB_MARK_PATH} />
     </svg>
   );
@@ -27,10 +33,13 @@ export function GitHubMark(): React.JSX.Element {
  * files differ only in a hard-coded stroke color, so drawing in `currentColor`
  * collapses them into one inline mark and keeps the page free of fetched
  * assets. Decorative: the wordmark beside it already says "Luke".
+ *
+ * Wider than tall, so a caller sizes both axes and lets the default
+ * `xMidYMid meet` letterbox the face inside that box rather than stretch it.
  */
-export function LukeMark(): React.JSX.Element {
+export function LukeMark({ className = "block h-[18px] w-5" }: MarkProps): React.JSX.Element {
   return (
-    <svg className="luke-mark" viewBox="53.85 62.67 134.29 122.37" fill="none" aria-hidden="true">
+    <svg className={className} viewBox="53.85 62.67 134.29 122.37" fill="none" aria-hidden="true">
       <g transform="rotate(-8 120 124)">
         <path
           d="M 104 84 V 150 Q 104 164 118 164 Q 140 164 168 142"
@@ -51,13 +60,24 @@ export function LukeMark(): React.JSX.Element {
 export function SiteHeader(): React.JSX.Element {
   return (
     <header className="shell">
-      <nav className="site-nav">
-        <a className="wordmark" href="/">
+      <nav className="flex h-16 items-center justify-between">
+        <a
+          className="inline-flex items-center gap-2 font-brand text-base font-bold tracking-[-0.01em] no-underline"
+          href="/"
+        >
           <LukeMark />
           Luke
         </a>
-        <a className="nav-link" href={REPOSITORY_URL} aria-label="Luke on GitHub">
-          <GitHubMark />
+        {/* Icon-only, so the padding buys a comfortable hit target and a focus
+            ring with room around the mark. The matching negative margin keeps
+            the mark optically aligned with the wordmark's edge rather than
+            inset from it. */}
+        <a
+          className="-mr-1.5 inline-flex items-center rounded-md p-1.5 text-muted-foreground transition-colors duration-150 hover:text-foreground motion-reduce:transition-none"
+          href={REPOSITORY_URL}
+          aria-label="Luke on GitHub"
+        >
+          <GitHubMark className="block size-[18px]" />
         </a>
       </nav>
     </header>
@@ -67,11 +87,16 @@ export function SiteHeader(): React.JSX.Element {
 /** Shared between every page so the legal and license links never drift apart. */
 export function SiteFooter(): React.JSX.Element {
   return (
-    <footer className="site-footer shell hairline">
-      <div className="footer-meta">
+    <footer className="shell hairline pt-12 pb-16 font-mono text-xs text-muted-foreground">
+      {/* The separator belongs to the gap between items rather than to any
+          item, so adding or reordering a link never leaves a stray dot. */}
+      <div className="flex flex-wrap gap-2 [&>*+*]:before:mr-2 [&>*+*]:before:content-['·']">
         <span>Apache-2.0</span>
         <span>macOS 14+</span>
-        <a className="footer-link" href="/privacy">
+        <a
+          className="no-underline transition-colors duration-150 hover:text-foreground motion-reduce:transition-none"
+          href="/privacy"
+        >
           Privacy
         </a>
       </div>

--- a/apps/web/src/auth-surface.ts
+++ b/apps/web/src/auth-surface.ts
@@ -1,0 +1,32 @@
+/**
+ * The card the sign-in and consent windows are drawn as. Both pages are the
+ * same object at two moments of one flow, so the surface is written once here
+ * rather than twice at two call sites that would drift.
+ *
+ * Deliberately not a component: the two pages differ in what the card holds,
+ * not in what it is, and a wrapper that took children would earn nothing but
+ * a level of nesting.
+ */
+
+/** A single card, centered in the window, with nothing else on the page. */
+export const AUTH_SHELL = "grid min-h-screen place-items-center p-6";
+
+export const AUTH_CARD =
+  "w-full max-w-[390px] rounded-lg border border-border bg-card px-8 py-12 text-center shadow-[0_1px_2px_rgba(0,0,0,0.04),0_8px_24px_rgba(0,0,0,0.06)]";
+
+export const AUTH_TITLE = "mt-4 mb-2 text-[1.75rem] leading-[1.15] font-semibold";
+
+/**
+ * `data-tone` carries the state rather than a computed class, so the pill
+ * says what it means in the markup and the palette stays in one string.
+ */
+export const AUTH_PILL =
+  "mt-4 inline-block rounded-full bg-complete-tint px-[11px] py-[3px] font-mono text-xs font-semibold tracking-[0.2px] text-complete data-[tone=attention]:bg-attention-tint data-[tone=attention]:text-attention";
+
+/**
+ * `cursor-pointer` is carried here rather than inherited: Tailwind's preflight
+ * leaves a button on the user agent's own arrow, where the sheet this replaced
+ * reset every button to a pointer.
+ */
+export const AUTH_BUTTON =
+  "min-h-[46px] cursor-pointer rounded-md border border-border bg-card font-semibold transition-[background-color,transform] duration-150 hover:not-disabled:-translate-y-px hover:not-disabled:bg-muted disabled:cursor-wait disabled:opacity-[0.56] motion-reduce:transition-none";

--- a/apps/web/src/consent.tsx
+++ b/apps/web/src/consent.tsx
@@ -1,8 +1,8 @@
-import "@fontsource-variable/bricolage-grotesque/wght.css";
 import { oauthProviderClient } from "@better-auth/oauth-provider/client";
 import { createAuthClient } from "better-auth/react";
 import { StrictMode, useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
+import { AUTH_CARD, AUTH_PILL, AUTH_SHELL, AUTH_TITLE } from "./auth-surface";
 import { LukeMark } from "./SiteChrome";
 import "./styles.css";
 
@@ -16,18 +16,25 @@ function Consent(): React.JSX.Element {
     });
   }, []);
   return (
-    <main className="auth-shell">
-      <section className="auth-card">
-        <div className="auth-mark" aria-hidden="true">
-          <LukeMark />
+    <main className={AUTH_SHELL}>
+      <section className={AUTH_CARD}>
+        {/* The full mark, not a pair of dots: the card is the one thing on the
+            page, so it carries the same face the product and the landing page
+            wear. */}
+        <div className="inline-flex w-13" aria-hidden="true">
+          <LukeMark className="h-auto w-full" />
         </div>
         <div>
-          <span className="auth-pill" data-tone={failure ? "attention" : "settled"}>
+          {/* One word saying where things stand, in the state palette the
+              product uses. */}
+          <span className={AUTH_PILL} data-tone={failure ? "attention" : "settled"}>
             {failure ? "Not completed" : "Confirming"}
           </span>
         </div>
-        <h1>{failure ? "Luke could not continue" : "Continuing to Luke…"}</h1>
-        <p>
+        <h1 className={AUTH_TITLE}>
+          {failure ? "Luke could not continue" : "Continuing to Luke…"}
+        </h1>
+        <p className="m-0 text-muted-foreground">
           {failure ? "Return to Luke and start sign-in again." : "This window will close soon."}
         </p>
       </section>

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,4 +1,3 @@
-import "@fontsource-variable/bricolage-grotesque/wght.css";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";

--- a/apps/web/src/privacy.tsx
+++ b/apps/web/src/privacy.tsx
@@ -1,4 +1,3 @@
-import "@fontsource-variable/bricolage-grotesque/wght.css";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { PrivacyPage } from "./PrivacyPage";

--- a/apps/web/src/sign-in.tsx
+++ b/apps/web/src/sign-in.tsx
@@ -1,8 +1,8 @@
-import "@fontsource-variable/bricolage-grotesque/wght.css";
 import { oauthProviderClient } from "@better-auth/oauth-provider/client";
 import { createAuthClient } from "better-auth/react";
 import { StrictMode, useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
+import { AUTH_BUTTON, AUTH_CARD, AUTH_SHELL, AUTH_TITLE } from "./auth-surface";
 import { LukeMark } from "./SiteChrome";
 import {
   SOCIAL_PROVIDER_LABEL,
@@ -49,26 +49,40 @@ function SignIn(): React.JSX.Element {
   };
 
   return (
-    <main className="auth-shell">
-      <section className="auth-card" aria-labelledby="auth-title">
-        <div className="auth-mark" aria-hidden="true">
-          <LukeMark />
+    <main className={AUTH_SHELL}>
+      <section className={AUTH_CARD} aria-labelledby="auth-title">
+        {/* The full mark, not a pair of dots: the card is the one thing on the
+            page, so it carries the same face the product and the landing page
+            wear. */}
+        <div className="inline-flex w-13" aria-hidden="true">
+          <LukeMark className="h-auto w-full" />
         </div>
-        <h1 id="auth-title">Sign in to Luke</h1>
-        <p>
+        <h1 id="auth-title" className={AUTH_TITLE}>
+          Sign in to Luke
+        </h1>
+        <p className="m-0 text-muted-foreground">
           {provider
             ? `Continue with the ${SOCIAL_PROVIDER_LABEL[provider]} account you want Luke to know you by.`
             : "Luke could not verify which provider you chose. Return to Luke and try again."}
         </p>
         {provider ? (
-          <div className="auth-actions">
-            <button type="button" disabled={pending !== undefined} onClick={() => void begin()}>
+          <div className="mt-8 mb-4 grid gap-3">
+            <button
+              type="button"
+              className={AUTH_BUTTON}
+              disabled={pending !== undefined}
+              onClick={() => void begin()}
+            >
               {pending ? "Opening…" : `Continue with ${SOCIAL_PROVIDER_LABEL[provider]}`}
             </button>
           </div>
         ) : null}
-        {failure ? <p className="auth-error">{failure}</p> : null}
-        <small>You can close this window after Luke confirms the sign-in.</small>
+        {failure ? <p className="m-0 text-attention">{failure}</p> : null}
+        {/* Its own line rather than a run-on: with no provider to continue
+            with there is no action block between it and the copy above. */}
+        <small className="mt-4 block text-muted-foreground">
+          You can close this window after Luke confirms the sign-in.
+        </small>
       </section>
     </main>
   );

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -13,10 +13,11 @@
  * it is the one part of the page that has to stay diffable against
  * `apps/desktop/src/renderer/styles/base.css` and `styles/sessions.css`.
  *
- * Deliberately not ported from the renderer: `overflow: clip` on the root,
- * `user-select: none`, and the transparent body. Those exist so an Electron
- * notch window can never scroll its capsule off screen, and a scrolling web
- * page needs the opposite of all three.
+ * Deliberately not ported from the renderer: the root's `overflow: clip` on
+ * both axes, `user-select: none`, and the transparent body. Those exist so an
+ * Electron notch window can never scroll its capsule off screen, and a
+ * scrolling web page needs the opposite of all three. The root clips `x`
+ * alone here for a reason of the page's own, written where it is set.
  */
 
 @import "tailwindcss";
@@ -138,6 +139,26 @@
 @layer base {
   html {
     font-family: var(--font-page);
+  }
+
+  /* Two places deliberately draw wider than the measure — the full-bleed
+     hairline and the mock's stage — and both size themselves in `vw`, which
+     counts a classic scrollbar's gutter that `100%` does not. Left alone that
+     gutter is a horizontal scrollbar on every page anywhere scrollbars take
+     space, which is everywhere the visitor is not on a Mac.
+
+     It has to be `clip` and not `hidden`, for the reason `.mock-pin` gives
+     below: `hidden` makes a scroll container, and a scroll container ancestor
+     is exactly what stops the pin from sticking. `overflow-y` is left alone,
+     which a `clip` on the other axis permits, so the page still scrolls down.
+
+     And it has to name both elements. The root's overflow propagates to the
+     viewport and the root itself is then drawn as `visible`, so `html` alone
+     clips nothing; `body` alone is likewise skipped while the root carries a
+     value. Only the pair actually holds. */
+  html,
+  body {
+    overflow-x: clip;
   }
 
   body {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -211,6 +211,10 @@
   top: max(72px, 14svh);
   display: flex;
   justify-content: center;
+  /* The stage is wider than the shell's content box, whose padding belongs to
+     the prose. Give the display the viewport width at every breakpoint so the
+     clip keeps its rounded corners instead of shaving them to the measure. */
+  margin-inline: calc(50% - 50vw);
   /* `transform: scale()` leaves the layout box at full size, so the pin
      tracks the scale itself or a phone reserves 560px for a 300px visual.
      `clip` keeps the untransformed art width from opening a horizontal
@@ -247,7 +251,7 @@
   --raised: rgba(255, 255, 255, 0.05);
   --raised-strong: rgba(255, 255, 255, 0.09);
   --frame-top: #14171c;
-  --frame-bottom: #0a0b0e;
+  --frame-bottom: #101318;
 
   /* Provider brand colours, used only by the marks and ported with them:
      Claude Code's published coral, the vertical gradient Codex draws its mark
@@ -315,44 +319,16 @@
   --accent: var(--state-idle);
 }
 
-/* The display the capsule is cut into, kept as its own layer so it can end
-   well before the mock's bottom edge: the capsule reads as the top of a
-   screen rather than as a container with nothing in it, and the flares at its
-   corners have a surface to turn into.
-
-   A strip rather than the full box, because the page is light. Fading a black
-   rectangle out over the mock's whole height means fading it through every
-   grey on the way, which on a dark page was invisible and on this one is a
-   bank of fog behind the art. Short enough to read as an edge, and opaque for
-   most of its own height so it reads as an object with a bottom rather than
-   as a gradient. */
+/* The persistent display the capsule is cut into. It stays in place while the
+   surface grows, so the panel remains inside the same rounded stage instead
+   of exposing the square ends of a narrower strip. */
 .mock-frame {
   position: absolute;
   z-index: 0;
-  top: 0;
-  right: 0;
-  left: 0;
-  height: 104px;
+  inset: 0;
   border: 1px solid var(--hairline-strong);
-  border-bottom: 0;
-  border-radius: 18px 18px 0 0;
+  border-radius: 18px;
   background: linear-gradient(180deg, var(--frame-top) 0%, var(--frame-bottom) 100%);
-  -webkit-mask-image: linear-gradient(180deg, #000 0%, #000 74%, transparent 100%);
-  mask-image: linear-gradient(180deg, #000 0%, #000 74%, transparent 100%);
-  /* Returning: held back until the shape has shrunk, or the display is drawn
-     beside a panel that has not closed yet — the very artifact below. */
-  transition: opacity var(--duration-quick) ease var(--duration-shape);
-}
-
-/* The display is what the capsule is cut into, and only the capsule. Once the
-   surface has grown past the housing it is its own object, with its own shadow
-   and its own edge; the display is 700px wide against a 620px panel, so left
-   drawn it puts a square slab either side of the panel's rounded corners.
-   Leaving leads the growing edge — immediately, over the exit duration — so
-   the display is gone before the surface reaches where it was. */
-.mock:not([data-mode="capsule"]) .mock-frame {
-  opacity: 0;
-  transition: opacity var(--duration-exit) ease;
 }
 
 /* The black surface is the whole animation: one leaf element with no children
@@ -1068,13 +1044,6 @@
     --mock-scale: 0.75;
   }
 
-  /* A notch lives on an edge-to-edge display, and a phone has one: the pin
-     escapes the shell's column so the art is sized by the screen rather than
-     by the text measure. The copy above keeps the shell's padding. */
-  .mock-pin {
-    margin-inline: calc(50% - 50vw);
-  }
-
   /* The 700px box exists for the desktop shadow's room, and a phone spends
      that room on nothing but feeding the frame's own corners to the pin's
      clip. 660 still holds the 620px panel with margin for its shadow, and is
@@ -1130,7 +1099,6 @@
   }
 
   .mock .panel-surface,
-  .mock .mock-frame,
   .mock .expanded-stage,
   .mock .wing-mark,
   .mock .wing-more,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6,56 +6,108 @@
  * paths, and state labels are generated into `@sidecar/core` and imported
  * here, so they cannot drift from the product they advertise.
  *
+ * The page chrome around the mock is Tailwind, written at its call sites.
+ * What stays in this file is what utilities cannot hold: the theme, the
+ * privacy document's generated HTML, and the mock. The mock stays
+ * hand-written CSS deliberately — its class names are the renderer's own and
+ * it is the one part of the page that has to stay diffable against
+ * `apps/desktop/src/renderer/styles/base.css` and `styles/sessions.css`.
+ *
  * Deliberately not ported from the renderer: `overflow: clip` on the root,
  * `user-select: none`, and the transparent body. Those exist so an Electron
  * notch window can never scroll its capsule off screen, and a scrolling web
  * page needs the opposite of all three.
  */
 
+@import "tailwindcss";
 @import "@sidecar/core/motion-tokens.css";
 
+/* The three faces the page loads, declared beside the stack that names them
+   rather than at each of the four HTML entry points. */
+@import "@fontsource-variable/geist/wght.css";
+@import "@fontsource-variable/jetbrains-mono/wght.css";
+@import "@fontsource-variable/bricolage-grotesque/wght.css";
+
+/* Only the tokens the page actually draws with. shadcn/ui's contract is a
+   superset — popover, secondary, destructive, sidebar, chart — and a token
+   nothing reads is drift waiting to happen. Every value is declared in
+   `:root` below and merely aliased here, so the plain-CSS blocks further down
+   read the same vocabulary the utilities do. */
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-accent-ink: var(--accent-ink);
+  --color-attention: var(--attention);
+  --color-attention-tint: var(--attention-tint);
+  --color-complete: var(--complete);
+  --color-complete-tint: var(--complete-tint);
+  --color-border: var(--border);
+  --color-ring: var(--ring);
+
+  --radius-sm: calc(var(--radius) - 2px);
+  --radius-md: var(--radius);
+  --radius-lg: calc(var(--radius) + 4px);
+
+  --font-sans: var(--font-page);
+  --font-mono: var(--font-code);
+  --font-brand: var(--font-wordmark);
+}
+
 :root {
-  color-scheme: dark;
+  color-scheme: light;
 
-  /* Product surfaces are pure black. The page sits a shade off it so the notch
-     housing and the session panel read as objects instead of holes. */
-  --page: #08090b;
-  --surface: #000;
-  --frame-top: #14171c;
-  --frame-bottom: #0a0b0e;
+  /* shadcn/ui's stock light theme, with one deliberate change: the ground is
+     warmed off pure white. It cannot be warmed further without darkening
+     `--muted-foreground` with it — shadcn's stock `oklch(0.556 0 0)` is
+     4.58:1 here and 4.43:1 on #f7f7f7, which is under AA for body text. */
+  --background: #fbfbfa;
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --border: oklch(0.922 0 0);
 
-  --accent: #5cd5ff;
-  --accent-strong: #72dcff;
-  --attention: #ffa049;
-  --complete: #6fdca4;
-  /* `unknown` is the product's idle accent: a session Luke can still see but
-     has no current activity for. Matches `--state-idle` in the renderer. */
-  --idle: rgba(255, 255, 255, 0.44);
+  /* Luke's accent carries the one filled control on the page. #04121a on
+     #5cd5ff is 11.2:1, so the pairing the dark page used survives the
+     inversion untouched: a filled button owns its own ground. */
+  --primary: #5cd5ff;
+  --primary-foreground: #04121a;
 
-  --text: rgba(255, 255, 255, 0.92);
-  --text-secondary: rgba(255, 255, 255, 0.56);
-  --text-muted: rgba(255, 255, 255, 0.4);
-  --text-faint: rgba(255, 255, 255, 0.32);
+  /* The same accent at text weight. #5cd5ff is 1.4:1 on this ground — fine
+     behind near-black, unreadable as ink — so links and inline accents get a
+     darkened member of the same hue family at 5.7:1. */
+  --accent-ink: #0d6e80;
 
-  --hairline: rgba(255, 255, 255, 0.08);
-  --hairline-strong: rgba(255, 255, 255, 0.09);
-  --raised: rgba(255, 255, 255, 0.05);
-  --raised-strong: rgba(255, 255, 255, 0.09);
+  /* The focus ring is a non-text indicator and owes 3:1 against the ground
+     (WCAG 2.2, 1.4.11), which the accent cannot pay on a light page. */
+  --ring: var(--foreground);
 
-  --radius-card: 17px;
-  --radius-control: 10px;
-  --radius-panel: 30px;
-  --radius-pill: 999px;
+  /* The product's state palette, restated for a light ground: the dark-page
+     values are pastels here. Ink passes AA against the page, tint carries it
+     as a pill. */
+  --attention: #9a5300;
+  --attention-tint: #fdf0e2;
+  --complete: #0f7a4e;
+  --complete-tint: #e6f5ed;
 
-  /* Type scale. The hero is the only fluid step; everything below it is fixed
-     so the rhythm does not shift with the viewport. */
-  --text-xs: 0.75rem;
-  --text-sm: 0.875rem;
-  --text-base: 1rem;
-  --text-lg: 1.125rem;
-  --text-hero: clamp(1rem, 4.4vw, 2.5rem);
+  --radius: 0.5rem;
 
-  /* Space scale, 4px grid. */
+  /* Prose and headings are the sans; mono is reserved for code, commands, and
+     the small technical labels that read as tokens rather than as sentences.
+     The wordmark keeps its own face, and the mock keeps the product's. */
+  --font-page: "Geist Variable", -apple-system, blinkmacsystemfont, "Segoe UI", sans-serif;
+  --font-code: "JetBrains Mono Variable", ui-monospace, "SF Mono", SFMono-Regular, Menlo, monospace;
+  --font-wordmark: "Bricolage Grotesque Variable", "Arial Narrow", sans-serif;
+  --font-product: -apple-system, blinkmacsystemfont, "SF Pro Display", "Segoe UI", sans-serif;
+
+  /* Space scale, 4px grid. Read by the two blocks that stay plain CSS — the
+     mock and the privacy document — and mirrored by Tailwind's own scale for
+     everything written at a call site. */
   --space-1: 4px;
   --space-2: 8px;
   --space-3: 12px;
@@ -70,9 +122,6 @@
      page and the product feel like the same software. */
   --swift: cubic-bezier(0.2, 0.8, 0.2, 1);
 
-  --font-brand: "Bricolage Grotesque Variable", "Arial Narrow", sans-serif;
-  --font-mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, monospace;
-  --font-product: -apple-system, blinkmacsystemfont, "SF Pro Display", "Segoe UI", sans-serif;
   /* The mock renders at true product geometry and scales as a unit. Stepped
      rather than fluid so the interior never lands on a half pixel. The height
      is the 520px expanded panel plus the product's own SURFACE_MARGIN for the
@@ -82,340 +131,57 @@
   --mock-scale: 1;
   --mock-height: 560px;
 
-  font-family: var(--font-mono);
   font-optical-sizing: auto;
   font-synthesis: none;
 }
 
-* {
-  box-sizing: border-box;
+@layer base {
+  html {
+    font-family: var(--font-page);
+  }
+
+  body {
+    background: var(--background);
+    color: var(--foreground);
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  :focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 3px;
+  }
 }
 
-body {
-  margin: 0;
-  background: var(--page);
-  color: var(--text);
-  font-size: var(--text-base);
-  line-height: 1.6;
-  -webkit-font-smoothing: antialiased;
-}
-
-a {
-  color: inherit;
-}
-
-button {
-  border: 0;
-  color: inherit;
-  cursor: pointer;
-  font: inherit;
-}
-
-.auth-shell {
-  min-height: 100vh;
-  display: grid;
-  place-items: center;
-  padding: var(--space-5);
-}
-
-.auth-card {
-  width: min(100%, 390px);
-  padding: var(--space-7) var(--space-6);
-  border: 1px solid var(--hairline);
-  border-radius: var(--radius-card);
-  background: var(--surface);
-  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.42);
-  text-align: center;
-}
-
-.auth-card h1 {
-  margin: var(--space-4) 0 var(--space-2);
-  font-size: 1.75rem;
-  line-height: 1.15;
-}
-
-.auth-card p {
-  margin: 0;
-  color: var(--text-secondary);
-}
-
-/* The full mark, not a pair of dots: the card is the one thing on the page,
-   so it carries the same face the product and the landing page wear. */
-.auth-mark {
-  display: inline-flex;
-  width: 52px;
-  color: var(--text);
-}
-
-.auth-mark svg {
+/* The column every page shares. Narrow and left-aligned: the references this
+   page is drawn against run 625–720px, and a measure that wide reads as a
+   document rather than as a poster. */
+@utility shell {
   width: 100%;
-  height: auto;
+  max-width: 700px;
+  margin-inline: auto;
+  padding-inline: var(--space-5);
+
+  @media (width < 520px) {
+    padding-inline: var(--space-4);
+  }
 }
 
-/* One word saying where things stand, in the state palette the product uses. */
-.auth-pill {
-  display: inline-block;
-  margin-top: var(--space-4);
-  padding: 3px 11px;
-  border-radius: var(--radius-pill);
-  background: rgba(111, 220, 164, 0.14);
-  color: var(--complete);
-  font-size: var(--text-xs);
-  font-weight: 650;
-  letter-spacing: 0.2px;
-}
-
-.auth-pill[data-tone="attention"] {
-  background: rgba(255, 160, 73, 0.14);
-  color: var(--attention);
-}
-
-.auth-actions {
-  display: grid;
-  gap: var(--space-3);
-  margin: var(--space-6) 0 var(--space-4);
-}
-
-.auth-actions button {
-  min-height: 46px;
-  border: 1px solid var(--hairline-strong);
-  border-radius: var(--radius-control);
-  background: var(--raised);
-  font-weight: 650;
-  transition:
-    background 140ms ease,
-    transform 140ms ease;
-}
-
-.auth-actions button:hover:not(:disabled) {
-  background: var(--raised-strong);
-  transform: translateY(-1px);
-}
-
-.auth-actions button:disabled {
-  cursor: wait;
-  opacity: 0.56;
-}
-
-.auth-card .auth-error {
-  color: var(--attention);
-}
-
-.auth-card small {
-  color: var(--text-muted);
-}
-
-:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 3px;
-}
-
-/* Page shell
-   ------------------------------------------------------------------------- */
-
-.landing-page {
+/* A full-bleed rule that escapes the column it is written in, so a section
+   break reads across the whole page rather than stopping at the measure. */
+@utility hairline {
   position: relative;
-  min-height: 100vh;
-  isolation: isolate;
-}
 
-.shell {
-  position: relative;
-  z-index: 1;
-  width: 100%;
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 0 var(--space-5);
-}
-
-.rules {
-  position: absolute;
-  z-index: 0;
-  inset: 0;
-  pointer-events: none;
-}
-
-.rules-column {
-  position: relative;
-  width: 100%;
-  max-width: 960px;
-  height: 100%;
-  margin: 0 auto;
-  padding: 0 var(--space-5);
-}
-
-.rules-column::before,
-.rules-column::after {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 1px;
-  background: var(--hairline);
-  content: "";
-}
-
-.rules-column::before {
-  left: 0;
-}
-
-.rules-column::after {
-  right: 0;
-}
-
-.hairline {
-  position: relative;
-}
-
-.hairline::before {
-  position: absolute;
-  top: calc(var(--space-5) * -1);
-  left: 50%;
-  width: 100vw;
-  height: 1px;
-  background: var(--hairline);
-  content: "";
-  transform: translateX(-50%);
-}
-
-/* Navigation
-   ------------------------------------------------------------------------- */
-
-.site-nav {
-  display: flex;
-  height: var(--space-8);
-  align-items: center;
-  justify-content: space-between;
-}
-
-.wordmark {
-  display: inline-flex;
-  align-items: center;
-  font-family: var(--font-brand);
-  font-size: var(--text-base);
-  font-weight: 700;
-  gap: var(--space-2);
-  letter-spacing: -0.01em;
-  text-decoration: none;
-}
-
-/* Wider than tall, and the default `xMidYMid meet` letterboxes it inside the
-   box rather than stretching the face. */
-.luke-mark {
-  display: block;
-  width: 20px;
-  height: 18px;
-}
-
-/* Icon-only, so the padding buys a comfortable hit target and a focus ring
-   with room around the mark. The matching negative margin keeps the mark
-   optically aligned with the wordmark's edge rather than inset from it. */
-.nav-link {
-  display: inline-flex;
-  align-items: center;
-  padding: 6px;
-  margin-right: -6px;
-  border-radius: 8px;
-  color: var(--text-secondary);
-  transition: color 140ms ease;
-}
-
-.nav-link:hover {
-  color: var(--text);
-}
-
-.github-mark {
-  display: block;
-  width: 16px;
-  height: 16px;
-}
-
-.nav-link .github-mark {
-  width: 18px;
-  height: 18px;
-}
-
-/* Hero
-   ------------------------------------------------------------------------- */
-
-.hero {
-  /* A notch belongs at the horizontal center of a display, so the art and the
-     copy that introduces it intentionally share the same centered axis. */
-  padding: var(--space-7) 0 var(--space-8);
-  text-align: center;
-}
-
-.hero h1 {
-  margin: 0 auto var(--space-5);
-  font-size: var(--text-hero);
-  font-weight: 600;
-  letter-spacing: 0;
-  line-height: 1.05;
-  white-space: nowrap;
-}
-
-.hero-subhead {
-  max-width: 620px;
-  margin: 0 auto;
-  color: var(--text-secondary);
-  font-size: var(--text-lg);
-  text-wrap: pretty;
-}
-
-.cta-row {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  margin-top: var(--space-6);
-  gap: var(--space-3);
-}
-
-.cta-primary {
-  display: inline-flex;
-  align-items: center;
-  padding: var(--space-3) var(--space-5);
-  border-radius: var(--radius-control);
-  background: var(--accent);
-  color: #04121a;
-  font-size: var(--text-sm);
-  font-weight: 650;
-  gap: var(--space-2);
-  text-decoration: none;
-  transition:
-    background 140ms ease,
-    transform 180ms var(--swift);
-}
-
-.cta-primary:hover {
-  background: var(--accent-strong);
-}
-
-.cta-primary:active {
-  transform: translateY(1px);
-}
-
-.cta-secondary {
-  display: inline-flex;
-  align-items: center;
-  padding: calc(var(--space-3) - 1px) calc(var(--space-5) - 1px);
-  border: 1px solid var(--hairline);
-  border-radius: var(--radius-control);
-  color: var(--text-secondary);
-  font-size: var(--text-sm);
-  font-weight: 650;
-  gap: var(--space-2);
-  text-decoration: none;
-}
-
-.cta-secondary:hover {
-  border-color: var(--hairline-strong);
-  color: var(--text);
-}
-
-.cta-caption {
-  margin: var(--space-3) 0 0;
-  color: var(--text-secondary);
-  font-size: var(--text-xs);
+  &::before {
+    position: absolute;
+    top: calc(var(--space-5) * -1);
+    left: 50%;
+    width: 100vw;
+    height: 1px;
+    background: var(--border);
+    content: "";
+    transform: translateX(-50%);
+  }
 }
 
 /* Notch mock
@@ -468,6 +234,20 @@ button {
   --state-idle: rgba(255, 255, 255, 0.44);
   --text-primary: rgba(255, 255, 255, 0.95);
   --text-tertiary: rgba(255, 255, 255, 0.34);
+
+  /* Luke's surface is pure black and the page around it is not, so the mock is
+     the one dark object on a light page and every token it draws with has to
+     be declared here. These were the page's until the page went light:
+     inherited now, white-on-white becomes black-on-black and the interior
+     disappears. The frame is the display the capsule is cut into, which is why
+     it alone is allowed to end on the page's own ground. */
+  --text-secondary: rgba(255, 255, 255, 0.56);
+  --hairline: rgba(255, 255, 255, 0.08);
+  --hairline-strong: rgba(255, 255, 255, 0.09);
+  --raised: rgba(255, 255, 255, 0.05);
+  --raised-strong: rgba(255, 255, 255, 0.09);
+  --frame-top: #14171c;
+  --frame-bottom: #0a0b0e;
 
   /* Provider brand colours, used only by the marks and ported with them:
      Claude Code's published coral, the vertical gradient Codex draws its mark
@@ -535,24 +315,44 @@ button {
   --accent: var(--state-idle);
 }
 
-/* The display the capsule is cut into, kept as its own layer so it can fade
-   out well before the mock's bottom edge: the capsule reads as the top of a
-   screen rather than as a container with nothing in it. */
+/* The display the capsule is cut into, kept as its own layer so it can end
+   well before the mock's bottom edge: the capsule reads as the top of a
+   screen rather than as a container with nothing in it, and the flares at its
+   corners have a surface to turn into.
+
+   A strip rather than the full box, because the page is light. Fading a black
+   rectangle out over the mock's whole height means fading it through every
+   grey on the way, which on a dark page was invisible and on this one is a
+   bank of fog behind the art. Short enough to read as an edge, and opaque for
+   most of its own height so it reads as an object with a bottom rather than
+   as a gradient. */
 .mock-frame {
   position: absolute;
   z-index: 0;
-  inset: 0;
+  top: 0;
+  right: 0;
+  left: 0;
+  height: 104px;
   border: 1px solid var(--hairline-strong);
   border-bottom: 0;
   border-radius: 18px 18px 0 0;
-  background: linear-gradient(
-    180deg,
-    var(--frame-top) 0%,
-    var(--frame-bottom) 55%,
-    var(--page) 100%
-  );
-  -webkit-mask-image: linear-gradient(180deg, #000 0%, #000 18%, transparent 62%);
-  mask-image: linear-gradient(180deg, #000 0%, #000 18%, transparent 62%);
+  background: linear-gradient(180deg, var(--frame-top) 0%, var(--frame-bottom) 100%);
+  -webkit-mask-image: linear-gradient(180deg, #000 0%, #000 74%, transparent 100%);
+  mask-image: linear-gradient(180deg, #000 0%, #000 74%, transparent 100%);
+  /* Returning: held back until the shape has shrunk, or the display is drawn
+     beside a panel that has not closed yet — the very artifact below. */
+  transition: opacity var(--duration-quick) ease var(--duration-shape);
+}
+
+/* The display is what the capsule is cut into, and only the capsule. Once the
+   surface has grown past the housing it is its own object, with its own shadow
+   and its own edge; the display is 700px wide against a 620px panel, so left
+   drawn it puts a square slab either side of the panel's rounded corners.
+   Leaving leads the growing edge — immediately, over the exit duration — so
+   the display is gone before the surface reaches where it was. */
+.mock:not([data-mode="capsule"]) .mock-frame {
+  opacity: 0;
+  transition: opacity var(--duration-exit) ease;
 }
 
 /* The black surface is the whole animation: one leaf element with no children
@@ -1181,89 +981,14 @@ button {
   white-space: nowrap;
 }
 
-/* Providers
-   ------------------------------------------------------------------------- */
-
-.providers {
-  margin-top: var(--space-7);
-  padding-top: var(--space-5);
-}
-
-.providers h2 {
-  margin: 0;
-  font-size: var(--text-lg);
-  font-weight: 600;
-  line-height: 1.3;
-}
-
-.providers > p {
-  margin: var(--space-2) 0 0;
-  color: var(--text-secondary);
-  font-size: var(--text-sm);
-}
-
-.provider-list {
-  display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  max-width: 680px;
-  margin: var(--space-6) auto 0;
-  padding: 0;
-  color: var(--text-secondary);
-  list-style: none;
-}
-
-.provider-list li {
-  display: flex;
-  min-width: 0;
-  flex-direction: column;
-  align-items: center;
-  font-size: var(--text-xs);
-  gap: var(--space-3);
-}
-
-.provider-list .provider-mark {
-  width: 24px;
-  height: 24px;
-}
-
-/* Footer
-   ------------------------------------------------------------------------- */
-
-.site-footer {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: var(--space-7) 0 var(--space-8);
-  color: var(--text-secondary);
-  font-size: var(--text-xs);
-  text-align: center;
-}
-
-.footer-meta {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: var(--space-2);
-}
-
-.footer-meta > * + *::before {
-  margin-right: var(--space-2);
-  content: "·";
-}
-
-.footer-link {
-  text-decoration: none;
-  transition: color 140ms ease;
-}
-
-.footer-link:hover {
-  color: var(--text);
-}
-
 /* Privacy
    A legal document read start to finish, so it gets a narrower measure and
    more vertical rhythm than the marketing copy above: constrained width,
    a clear step between h1/h2, and generous paragraph spacing.
+
+   Plain CSS rather than utilities because the markup is generated: the page
+   parses PRIVACY.md at build time and hands the result to
+   `dangerouslySetInnerHTML`, so there is no call site to write a class on.
    ------------------------------------------------------------------------- */
 
 .privacy {
@@ -1282,20 +1007,23 @@ button {
 
 .privacy h2 {
   margin: var(--space-8) 0 var(--space-4);
-  font-size: var(--text-lg);
+  font-size: 1.125rem;
   font-weight: 650;
   letter-spacing: -0.01em;
 }
 
 .privacy p {
   margin: 0 0 var(--space-4);
-  color: var(--text-secondary);
+  color: var(--muted-foreground);
 }
 
+/* Tailwind's preflight strips list markers from every `ul`. The generated
+   document has real lists in it, so they come back here. */
 .privacy ul {
   margin: 0 0 var(--space-4);
   padding-left: var(--space-5);
-  color: var(--text-secondary);
+  color: var(--muted-foreground);
+  list-style: disc;
 }
 
 .privacy li {
@@ -1307,32 +1035,35 @@ button {
 }
 
 .privacy strong {
-  color: var(--text);
+  color: var(--foreground);
 }
 
 .privacy a {
-  color: var(--accent);
+  color: var(--accent-ink);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
 .privacy code {
   padding: 0.15em 0.4em;
-  border-radius: 4px;
-  background: var(--raised);
+  border-radius: var(--radius-sm);
+  background: var(--muted);
+  font-family: var(--font-code);
   font-size: 0.9em;
 }
 
 /* Responsive
+   The mock's scale steps. Everything else the page draws answers to Tailwind
+   variants at its own call site.
    ------------------------------------------------------------------------- */
 
-@media (max-width: 900px) {
+@media (width < 900px) {
   :root {
     --mock-scale: 0.8;
   }
 }
 
-@media (max-width: 700px) {
+@media (width < 700px) {
   :root {
     --mock-scale: 0.75;
   }
@@ -1356,21 +1087,9 @@ button {
 /* Each step is the largest scale whose 660px art still clears the screen at
    the step's floor, so the mock fills a phone instead of floating in it and
    the pin's clip never eats the frame's edges. */
-@media (max-width: 520px) {
+@media (width < 520px) {
   :root {
     --mock-scale: 0.58;
-  }
-
-  .shell {
-    padding: 0 var(--space-4);
-  }
-
-  .site-footer {
-    padding: var(--space-7) var(--space-4) var(--space-8);
-  }
-
-  .hero {
-    padding: var(--space-6) 0 0;
   }
 
   .mock-scroll {
@@ -1378,13 +1097,13 @@ button {
   }
 }
 
-@media (max-width: 384px) {
+@media (width < 384px) {
   :root {
     --mock-scale: 0.54;
   }
 }
 
-@media (max-width: 356px) {
+@media (width < 356px) {
   :root {
     --mock-scale: 0.5;
   }
@@ -1411,6 +1130,7 @@ button {
   }
 
   .mock .panel-surface,
+  .mock .mock-frame,
   .mock .expanded-stage,
   .mock .wing-mark,
   .mock .wing-more,
@@ -1418,9 +1138,7 @@ button {
   .mock .count-caption,
   .mock .tab-thumb,
   .mock .session-row,
-  .mock .panel-header,
-  .cta-primary,
-  .nav-link {
+  .mock .panel-header {
     transition-duration: 1ms;
     transition-delay: 0ms;
   }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -119,10 +119,6 @@
   --space-8: 64px;
   --space-9: 96px;
 
-  /* The renderer's expansion easing. Reused for every page transition so the
-     page and the product feel like the same software. */
-  --swift: cubic-bezier(0.2, 0.8, 0.2, 1);
-
   /* The mock renders at true product geometry and scales as a unit. Stepped
      rather than fluid so the interior never lands on a half pixel. The height
      is the 520px expanded panel plus the product's own SURFACE_MARGIN for the

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -53,7 +53,7 @@
   --text-sm: 0.875rem;
   --text-base: 1rem;
   --text-lg: 1.125rem;
-  --text-hero: clamp(1rem, 5.5vw, 3.5rem);
+  --text-hero: clamp(1rem, 4.4vw, 2.5rem);
 
   /* Space scale, 4px grid. */
   --space-1: 4px;
@@ -71,6 +71,7 @@
   --swift: cubic-bezier(0.2, 0.8, 0.2, 1);
 
   --font-brand: "Bricolage Grotesque Variable", "Arial Narrow", sans-serif;
+  --font-mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, monospace;
   --font-product: -apple-system, blinkmacsystemfont, "SF Pro Display", "Segoe UI", sans-serif;
   /* The mock renders at true product geometry and scales as a unit. Stepped
      rather than fluid so the interior never lands on a half pixel. The height
@@ -81,7 +82,7 @@
   --mock-scale: 1;
   --mock-height: 560px;
 
-  font-family: var(--font-brand);
+  font-family: var(--font-mono);
   font-optical-sizing: auto;
   font-synthesis: none;
 }
@@ -212,11 +213,68 @@ button {
 /* Page shell
    ------------------------------------------------------------------------- */
 
+.landing-page {
+  position: relative;
+  min-height: 100vh;
+  isolation: isolate;
+}
+
 .shell {
+  position: relative;
+  z-index: 1;
   width: 100%;
   max-width: 960px;
   margin: 0 auto;
   padding: 0 var(--space-5);
+}
+
+.rules {
+  position: absolute;
+  z-index: 0;
+  inset: 0;
+  pointer-events: none;
+}
+
+.rules-column {
+  position: relative;
+  width: 100%;
+  max-width: 960px;
+  height: 100%;
+  margin: 0 auto;
+  padding: 0 var(--space-5);
+}
+
+.rules-column::before,
+.rules-column::after {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--hairline);
+  content: "";
+}
+
+.rules-column::before {
+  left: 0;
+}
+
+.rules-column::after {
+  right: 0;
+}
+
+.hairline {
+  position: relative;
+}
+
+.hairline::before {
+  position: absolute;
+  top: calc(var(--space-5) * -1);
+  left: 50%;
+  width: 100vw;
+  height: 1px;
+  background: var(--hairline);
+  content: "";
+  transform: translateX(-50%);
 }
 
 /* Navigation
@@ -232,6 +290,7 @@ button {
 .wordmark {
   display: inline-flex;
   align-items: center;
+  font-family: var(--font-brand);
   font-size: var(--text-base);
   font-weight: 700;
   gap: var(--space-2);
@@ -288,8 +347,8 @@ button {
 .hero h1 {
   margin: 0 auto var(--space-5);
   font-size: var(--text-hero);
-  font-weight: 650;
-  letter-spacing: -0.02em;
+  font-weight: 600;
+  letter-spacing: 0;
   line-height: 1.05;
   white-space: nowrap;
 }
@@ -333,6 +392,30 @@ button {
 
 .cta-primary:active {
   transform: translateY(1px);
+}
+
+.cta-secondary {
+  display: inline-flex;
+  align-items: center;
+  padding: calc(var(--space-3) - 1px) calc(var(--space-5) - 1px);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-control);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 650;
+  gap: var(--space-2);
+  text-decoration: none;
+}
+
+.cta-secondary:hover {
+  border-color: var(--hairline-strong);
+  color: var(--text);
+}
+
+.cta-caption {
+  margin: var(--space-3) 0 0;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
 }
 
 /* Notch mock
@@ -1098,6 +1181,51 @@ button {
   white-space: nowrap;
 }
 
+/* Providers
+   ------------------------------------------------------------------------- */
+
+.providers {
+  margin-top: var(--space-7);
+  padding-top: var(--space-5);
+}
+
+.providers h2 {
+  margin: 0;
+  font-size: var(--text-lg);
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.providers > p {
+  margin: var(--space-2) 0 0;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+
+.provider-list {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  max-width: 680px;
+  margin: var(--space-6) auto 0;
+  padding: 0;
+  color: var(--text-secondary);
+  list-style: none;
+}
+
+.provider-list li {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  align-items: center;
+  font-size: var(--text-xs);
+  gap: var(--space-3);
+}
+
+.provider-list .provider-mark {
+  width: 24px;
+  height: 24px;
+}
+
 /* Footer
    ------------------------------------------------------------------------- */
 
@@ -1106,7 +1234,6 @@ button {
   flex-direction: column;
   align-items: center;
   padding: var(--space-7) 0 var(--space-8);
-  border-top: 1px solid var(--hairline-strong);
   color: var(--text-secondary);
   font-size: var(--text-xs);
   text-align: center;
@@ -1236,6 +1363,10 @@ button {
 
   .shell {
     padding: 0 var(--space-4);
+  }
+
+  .site-footer {
+    padding: var(--space-7) var(--space-4) var(--space-8);
   }
 
   .hero {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,11 +1,12 @@
 import { fileURLToPath } from "node:url";
+import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 const resolveEntry = (path: string) => fileURLToPath(new URL(path, import.meta.url));
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
   build: {
     rollupOptions: {
       input: {

--- a/biome.json
+++ b/biome.json
@@ -52,6 +52,11 @@
       "indentWidth": 2
     }
   },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
+    }
+  },
   "assist": {
     "enabled": true,
     "actions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,16 +65,25 @@ importers:
         version: 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))
       '@better-auth/oauth-provider':
         specifier: 1.6.29
-        version: 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.29(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(better-call@1.4.0(zod@4.4.3))
+        version: 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.29(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(better-call@1.4.0(zod@4.4.3))
       '@fontsource-variable/bricolage-grotesque':
+        specifier: 5.3.0
+        version: 5.3.0
+      '@fontsource-variable/geist':
+        specifier: 5.3.0
+        version: 5.3.0
+      '@fontsource-variable/jetbrains-mono':
         specifier: 5.3.0
         version: 5.3.0
       '@sidecar/core':
         specifier: workspace:*
         version: link:../../packages/sidecar-core
+      '@tailwindcss/vite':
+        specifier: 4.3.3
+        version: 4.3.3(vite@7.3.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
       better-auth:
         specifier: 1.6.29
-        version: 1.6.29(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 1.6.29(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       drizzle-orm:
         specifier: 0.45.2
         version: 0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0)
@@ -90,6 +99,9 @@ importers:
       react-dom:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
+      tailwindcss:
+        specifier: 4.3.3
+        version: 4.3.3
     devDependencies:
       '@types/node':
         specifier: 22.20.1
@@ -105,7 +117,7 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       '@vitejs/plugin-react':
         specifier: 5.1.2
-        version: 5.1.2(vite@7.3.1(@types/node@22.20.1)(tsx@4.23.12)(yaml@2.9.0))
+        version: 5.1.2(vite@7.3.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
       drizzle-kit:
         specifier: 0.31.10
         version: 0.31.10
@@ -117,7 +129,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@22.20.1)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.3.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
 
   packages/sidecar-core:
     devDependencies:
@@ -398,6 +410,9 @@ packages:
     resolution: {integrity: sha512-ESWgNkFsXFH06I5EB2uHv3hmZA3yF4j9GTB77W74x3b5KZNItxggNzuADw41HUy6mhnC2K+E2mT0Xgc4YKu3IQ==}
     engines: {node: '>=22.12.0'}
     hasBin: true
+
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
@@ -1010,6 +1025,158 @@ packages:
   '@fontsource-variable/bricolage-grotesque@5.3.0':
     resolution: {integrity: sha512-TLi9Q4hJjS2UvoTMRSS2nHu6c4R56lAw60NR9QYtVRCHn0XtsFpiEhNffZ8Glsoxu6wEEwLKBP8lb94J52PNBA==}
 
+  '@fontsource-variable/geist@5.3.0':
+    resolution: {integrity: sha512-j0m+vLQuG5XAYoHtGCVu0spvlGreR3EzpECUVzkFmI1mTVnAO38l/NEPDCFgZ177JxzYJCLSmTQibIiYPilGrA==}
+
+  '@fontsource-variable/jetbrains-mono@5.3.0':
+    resolution: {integrity: sha512-F32xpS2NsGYoQi2ADSkKTgpJj7ozajsGgDJ8woTnqjmIB+dxDIqImjl4pXZVEExu8UFZ2ndhmX18EBS/hdz3Lw==}
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.35.3':
+    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.35.3':
+    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.35.3':
+    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.35.3':
+    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.35.3':
+    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.35.3':
+    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.35.3':
+    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.35.3':
+    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.35.3':
+    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
+    engines: {node: '>=20.9.0'}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.35.3':
+    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.35.3':
+    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.3':
+    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1035,6 +1202,57 @@ packages:
     engines: {node: ^22.20 || ^24.12 || >=25}
     cpu: [x64]
     os: [linux]
+
+  '@next/env@16.3.1':
+    resolution: {integrity: sha512-35G3xwkQUb2oETSDjFXGrVugknoayLFBh7vSE+yAcl9IP2zT9wyGwq7297AYHR11kJld807t5f8AJBs6WBzXsQ==}
+
+  '@next/swc-darwin-arm64@16.3.1':
+    resolution: {integrity: sha512-ABMIu2zQ7cnNIHm5ivKGwZwUrm0pAai3yiJ/gK/rF1c1VP9UOnj7XECbMKFdVKp9I9eMYq9NoDs1WXOoowxzJw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@16.3.1':
+    resolution: {integrity: sha512-gNG21e/UnrroeScbY/QndUEdl0mF1FRibW7BBeYUz/5ABCepjqDdEdgr592vpzMtCn/m7FTjYq3TN4TpyDnutw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@16.3.1':
+    resolution: {integrity: sha512-6B6Lw016iwNUQuaJoraMMTLh6TwHzFUtxipSScD1F3YyymcrRWkobodRS2ftIOkF5vrs4zNlyUrTC5YZQ9Lz5w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-arm64-musl@16.3.1':
+    resolution: {integrity: sha512-JUiPXZKK9wOhjf4MgDiH29GZLxfqOesbLtHq2pDxwH/WwscTRV2ToymnOTh1egzaZf0ueUf8T2+CeYTGHjW0Iw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-x64-gnu@16.3.1':
+    resolution: {integrity: sha512-Uog9jsrmIRIL/lfvIp9htmskSNC7JcQsMVucXL2V2YY1y/D9IUN3LPEafqy0zRJ2cIU1SQ0V6F6TlffQ+pLAGg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-linux-x64-musl@16.3.1':
+    resolution: {integrity: sha512-6yy3FT13KgUFOj5H8bl8w/6nKiJwHIvbtwh1V+1acsu+7y4tJjnemSa6mhsh53BeoVrlozE+fMgZhXH46WmjMA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-win32-arm64-msvc@16.3.1':
+    resolution: {integrity: sha512-iOoN1QecUoGNZik536U/vtK43YwgyrCsGIkth52yIkl612n+0C9MjSnJbQAikISpb+WYRooBVhaDlUW7iZoKog==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@16.3.1':
+    resolution: {integrity: sha512-d/k+PpAriUPaeMJJOG7HUSdqfEX46FEPWU1p3/nm2ACmXhj9hFEWdFODUBIpkuijXYkfL90qZzTqVPRp4BW/hw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
 
   '@noble/ciphers@2.3.0':
     resolution: {integrity: sha512-Clu/xdfgVTf9o7ngLOURaxePwR0j8sjclKEtVij10/jGulwFsPWCvvRgG/XjUVf8Nei+jLG6uwyXzUTGY1DQrw==}
@@ -1178,6 +1396,99 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
+
+  '@tailwindcss/node@4.3.3':
+    resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    resolution: {integrity: sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    resolution: {integrity: sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    resolution: {integrity: sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    resolution: {integrity: sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    resolution: {integrity: sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    resolution: {integrity: sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    resolution: {integrity: sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    resolution: {integrity: sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.3':
+    resolution: {integrity: sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.3.3':
+    resolution: {integrity: sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1445,6 +1756,9 @@ packages:
   caniuse-lite@1.0.30001809:
     resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
 
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
   commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
@@ -1470,6 +1784,10 @@ packages:
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   drizzle-kit@0.31.10:
     resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
@@ -1578,6 +1896,10 @@ packages:
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
+  enhanced-resolve@5.24.5:
+    resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
+    engines: {node: '>=10.13.0'}
+
   env-paths@3.0.0:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1665,6 +1987,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
   jose@6.2.9:
     resolution: {integrity: sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==}
 
@@ -1689,6 +2015,76 @@ packages:
     resolution: {integrity: sha512-ooa+eSbBNPTo3MycPEuW5jdrxQdQwdtB3LC3h43FiXQbIry5tR0C5lDG7eealK0E4D7XjrnOP5DIUg/LyjRMYQ==}
     engines: {node: '>=22.0.0'}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   lint-staged@17.3.0:
     resolution: {integrity: sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw==}
     engines: {node: '>=22.22.1'}
@@ -1704,6 +2100,9 @@ packages:
   macos-alias@0.2.12:
     resolution: {integrity: sha512-yiLHa7cfJcGRFq4FrR4tMlpNHb4Vy4mWnpajlSSIFM5k4Lv8/7BbbDLzCAVogWNl0LlLhizRp1drXv0hK9h0Yw==}
     os: [darwin]
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   marked@18.0.9:
     resolution: {integrity: sha512-/Sa4qiiHZxf0/FQdBBowr9q4r10krCwMvpK48FUBdXdUXScDxiQGR9zCPrFgRVR5LU3iySOiIjy09ZQvADir1w==}
@@ -1732,6 +2131,27 @@ packages:
   nanostores@1.5.0:
     resolution: {integrity: sha512-E0SrU7uLV/k4E6YbBIpQNDnRj00vgE5wlutM1sYVSAXDtHQosiRCGS9eKMKyiGg4ChXfDiJmTB+NCR3yXr6UAw==}
     engines: {node: ^20.0.0 || >=22.0.0}
+
+  next@16.3.1:
+    resolution: {integrity: sha512-hsAp0i7Rh+/dhe7DGIeN2YlpLM1DP4MNxti9EtDMtqcO612X81MvvEj388/oTce9U1EcEIOWDlGq0zRwrBKvuA==}
+    engines: {node: '>=20.9.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
 
   node-releases@2.0.53:
     resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
@@ -1793,6 +2213,10 @@ packages:
   plist@3.1.1:
     resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
     engines: {node: '>=10.4.0'}
+
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
@@ -1874,6 +2298,15 @@ packages:
   set-cookie-parser@3.1.2:
     resolution: {integrity: sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==}
 
+  sharp@0.35.3:
+    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -1905,9 +2338,29 @@ packages:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
 
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
+
+  tailwindcss@4.3.3:
+    resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
 
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
@@ -1920,6 +2373,9 @@ packages:
   tn1150@0.1.0:
     resolution: {integrity: sha512-DbplOfQFkqG5IHcDyyrs/lkvSr3mPUVsFf/RbDppOshs22yTPnSJWEe6FkYd1txAwU/zcnR905ar2fi4kwF29w==}
     engines: {node: '>=0.12'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.23.12:
     resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
@@ -2177,12 +2633,12 @@ snapshots:
       '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/oauth-provider@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.29(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(better-call@1.4.0(zod@4.4.3))':
+  '@better-auth/oauth-provider@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.29(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(better-call@1.4.0(zod@4.4.3))':
     dependencies:
       '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
-      better-auth: 1.6.29(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      better-auth: 1.6.29(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       better-call: 1.4.0(zod@4.4.3)
       jose: 6.2.9
       zod: 4.4.3
@@ -2318,6 +2774,11 @@ snapshots:
       postject: 1.0.0-alpha.6
     transitivePeerDependencies:
       - supports-color
+
+  '@emnapi/runtime@1.11.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
@@ -2631,6 +3092,117 @@ snapshots:
 
   '@fontsource-variable/bricolage-grotesque@5.3.0': {}
 
+  '@fontsource-variable/geist@5.3.0': {}
+
+  '@fontsource-variable/jetbrains-mono@5.3.0': {}
+
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-darwin-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-s390x@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-wasm32@0.35.3':
+    dependencies:
+      '@emnapi/runtime': 1.11.3
+    optional: true
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.3':
+    optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2655,6 +3227,33 @@ snapshots:
       cross-spawn: 7.0.6
 
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
+  '@next/env@16.3.1':
+    optional: true
+
+  '@next/swc-darwin-arm64@16.3.1':
+    optional: true
+
+  '@next/swc-darwin-x64@16.3.1':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@16.3.1':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@16.3.1':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@16.3.1':
+    optional: true
+
+  '@next/swc-linux-x64-musl@16.3.1':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@16.3.1':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@16.3.1':
     optional: true
 
   '@noble/ciphers@2.3.0': {}
@@ -2741,6 +3340,79 @@ snapshots:
     optional: true
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@tailwindcss/node@4.3.3':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.24.5
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.3
+
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.3':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-x64': 4.3.3
+      '@tailwindcss/oxide-freebsd-x64': 4.3.3
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.3
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.3
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.3
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
+
+  '@tailwindcss/vite@4.3.3(vite@7.3.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.3
+      '@tailwindcss/oxide': 4.3.3
+      tailwindcss: 4.3.3
+      vite: 7.3.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -2851,7 +3523,7 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
-  '@vitejs/plugin-react@5.1.2(vite@7.3.1(@types/node@22.20.1)(tsx@4.23.12)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.1.2(vite@7.3.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -2859,7 +3531,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.53
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.1(@types/node@22.20.1)(tsx@4.23.12)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2871,7 +3543,7 @@ snapshots:
 
   baseline-browser-mapping@2.11.13: {}
 
-  better-auth@1.6.29(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  better-auth@1.6.29(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/drizzle-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))
@@ -2893,6 +3565,7 @@ snapshots:
     optionalDependencies:
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0)
+      next: 16.3.1(@babel/core@7.29.7)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       pg: 8.23.0
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -2930,6 +3603,9 @@ snapshots:
 
   caniuse-lite@1.0.30001809: {}
 
+  client-only@0.0.1:
+    optional: true
+
   commander@9.5.0: {}
 
   convert-source-map@2.0.0: {}
@@ -2947,6 +3623,8 @@ snapshots:
       ms: 2.1.3
 
   defu@6.1.7: {}
+
+  detect-libc@2.1.2: {}
 
   drizzle-kit@0.31.10:
     dependencies:
@@ -2977,6 +3655,11 @@ snapshots:
       '@types/node': 24.13.3
     transitivePeerDependencies:
       - supports-color
+
+  enhanced-resolve@5.24.5:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
 
   env-paths@3.0.0: {}
 
@@ -3142,6 +3825,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  jiti@2.7.0: {}
+
   jose@6.2.9: {}
 
   js-tokens@4.0.0: {}
@@ -3153,6 +3838,55 @@ snapshots:
   junk@4.0.1: {}
 
   kysely@0.29.5: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lint-staged@17.3.0:
     dependencies:
@@ -3173,6 +3907,10 @@ snapshots:
       nan: 2.28.0
     optional: true
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   marked@18.0.9: {}
 
   minimatch@10.2.6:
@@ -3189,6 +3927,32 @@ snapshots:
   nanoid@3.3.18: {}
 
   nanostores@1.5.0: {}
+
+  next@16.3.1(@babel/core@7.29.7)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      '@next/env': 16.3.1
+      '@swc/helpers': 0.5.23
+      baseline-browser-mapping: 2.11.13
+      caniuse-lite: 1.0.30001809
+      postcss: 8.5.23
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.8)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.3.1
+      '@next/swc-darwin-x64': 16.3.1
+      '@next/swc-linux-arm64-gnu': 16.3.1
+      '@next/swc-linux-arm64-musl': 16.3.1
+      '@next/swc-linux-x64-gnu': 16.3.1
+      '@next/swc-linux-x64-musl': 16.3.1
+      '@next/swc-win32-arm64-msvc': 16.3.1
+      '@next/swc-win32-x64-msvc': 16.3.1
+      sharp: 0.35.3(@types/node@22.20.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/node'
+      - babel-plugin-macros
+    optional: true
 
   node-releases@2.0.53: {}
 
@@ -3245,6 +4009,13 @@ snapshots:
       '@xmldom/xmldom': 0.9.10
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
+
+  postcss@8.5.23:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+    optional: true
 
   postcss@8.5.26:
     dependencies:
@@ -3332,6 +4103,40 @@ snapshots:
 
   set-cookie-parser@3.1.2: {}
 
+  sharp@0.35.3(@types/node@22.20.1):
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.3
+      '@img/sharp-darwin-x64': 0.35.3
+      '@img/sharp-freebsd-wasm32': 0.35.3
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-linux-arm': 0.35.3
+      '@img/sharp-linux-arm64': 0.35.3
+      '@img/sharp-linux-ppc64': 0.35.3
+      '@img/sharp-linux-riscv64': 0.35.3
+      '@img/sharp-linux-s390x': 0.35.3
+      '@img/sharp-linux-x64': 0.35.3
+      '@img/sharp-linuxmusl-arm64': 0.35.3
+      '@img/sharp-linuxmusl-x64': 0.35.3
+      '@img/sharp-webcontainers-wasm32': 0.35.3
+      '@img/sharp-win32-arm64': 0.35.3
+      '@img/sharp-win32-ia32': 0.35.3
+      '@img/sharp-win32-x64': 0.35.3
+      '@types/node': 22.20.1
+    optional: true
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -3354,11 +4159,23 @@ snapshots:
 
   string-argv@0.3.2: {}
 
+  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.8):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.8
+    optionalDependencies:
+      '@babel/core': 7.29.7
+    optional: true
+
   sumchecker@3.0.1:
     dependencies:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  tailwindcss@4.3.3: {}
+
+  tapable@2.3.3: {}
 
   tinyexec@1.3.0: {}
 
@@ -3370,6 +4187,9 @@ snapshots:
   tn1150@0.1.0:
     dependencies:
       unorm: 1.6.0
+    optional: true
+
+  tslib@2.8.1:
     optional: true
 
   tsx@4.23.12:
@@ -3421,7 +4241,7 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  vite@7.3.1(@types/node@22.20.1)(tsx@4.23.12)(yaml@2.9.0):
+  vite@7.3.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.5)
@@ -3432,6 +4252,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.20.1
       fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
       tsx: 4.23.12
       yaml: 2.9.0
 


### PR DESCRIPTION
## Summary

- Give the landing page a monospace editorial treatment with drawn column rules, full-bleed dividers, and a row naming the five observed agent providers.
- Make the stable Apple-silicon DMG download the primary CTA while keeping GitHub available as a secondary action.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (975 desktop tests, repository checks, typechecks, tests, and builds)
- macOS Electron verification (`./scripts/verify.sh`): passed; all six deterministic captures inspected

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32099464734/artifacts/9311079101) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32099464734)

- Commit: `292cefdf7f6a6fe82e89303d4714a8a1d5f24052`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed` (web-only change)
- Device/display configuration: `not recorded`

## Notes

- The download permalink resolves to the current `Luke.dmg`; responsive browser QA passed at 1440, 900, 700, 520, and 384 px.
- The full-bleed hairline and the mock's stage both size themselves in `vw`, which counts a classic scrollbar's gutter that `100%` does not — a horizontal scrollbar on every page anywhere scrollbars take space. Both are now clipped on the x axis at `html, body`. It has to be `clip` (a `hidden` scroll-container ancestor would stop the mock's pin from sticking) and it has to name both elements (the root's overflow propagates to the viewport, leaving the root itself drawn as `visible`, so either alone clips nothing). Verified in a browser by forcing the over-wide condition macOS's overlay scrollbars hide: `html` alone and `body` alone each still scrolled 20px, the pair scrolled 0, `overflow-y` stayed `visible`, and the pin held its 114px offset across the runway.

