### PR TITLE
fix(desktop): keep the tray header one height whether or not it offers an act

### DIFF
--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -608,6 +608,16 @@ html[data-keyboard="true"] button.session-row:focus-visible {
   white-space: nowrap;
 }
 
+/* A workspace act keeps the chip a row's actions wear, but the chip is pulled
+   toward the name's own line with negative margins — the way a settings
+   heading holds its reset — so a header with an act to offer stays the height
+   of one without. The chip still draws its full size; it spends the header's
+   padding instead of growing it. */
+.workspace-tray-header .row-action {
+  margin-top: -6px;
+  margin-bottom: -6px;
+}
+
 /* Rows inside the tray hand their box to it: no border, no radius, no fill of
    their own, a hairline seam between neighbours. The attention tint keeps its
    ground — a chat that needs a person says so inside a tray exactly as loudly


### PR DESCRIPTION
## What

A Conductor workspace tray with an Archive act to offer wore a visibly taller header than one without: the chip is the same `.row-action` a row's actions use, and its padded box stood ~11px above the header's own name line. The chip is now pulled toward the name's line with negative block margins — the same bargain `.settings-heading .settings-reset` keeps — so it keeps its full pressable size and spends the header's padding instead of growing it.

## Verification

- `./scripts/check.sh` passed (exit 0).
- Measured against the real stylesheet in headless Chrome: the tray header is **30px with the chip and 30px without** after the fix; before, it was **41px against 30px**. The 23px chip stays inside the header's box, so nothing clips under the tray's `overflow: clip`.
- The committed fixture draws no tray-header act (its Conductor workspace holds a working chat, and a live Conductor only advertises Archive once every chat has settled), so the CI evidence shows the unchanged no-act header; the with-act height was proven by the measurement above.
- No physical-notch check was performed; this change touches only the tray header's interior geometry, nothing at the notch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a6cbdd28-dd2d-4e3f-9a60-8283cf44ac60)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32087207256/artifacts/9307123533) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32087207256)

- Commit: `cb1d5d83524de940970370221e9e5bd4c487ef1b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
