### PR TITLE
fix(desktop): flip a coin between the shockwave and boop send landings

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -2272,13 +2272,7 @@ function registerIpc(): void {
       if (!runMode.sendsNetwork) {
         return { delivered: false, reason: "A fixture run sends nothing." };
       }
-      const result = await feedbackDelivery.deliver(parsed);
-      if (!result.delivered) return result;
-      // The count picks which celebration this landing gets, never whether it
-      // landed: a store that cannot write still answers, with the first
-      // send's scene.
-      const sequence = await settingsStore.countFeedbackSend().catch(() => 0);
-      return { ...result, sequence };
+      return feedbackDelivery.deliver(parsed);
     },
   );
 

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -354,8 +354,12 @@ export function App(): React.JSX.Element {
    */
   const slotOccupant = useRef<"key" | "calendar">("key");
   const feedbackNoticeTimer = useRef<number | undefined>(undefined);
-  /** How many sends landed before the one just delivered, from its reply. */
-  const feedbackSequence = useRef(0);
+  /**
+   * The landing the latest send drew, held so the confirmation's hold waits
+   * out the same gesture the slot is playing. The initial flip is fixed
+   * because it is never played: a landing is always drawn again on delivery.
+   */
+  const feedbackLanding = useRef(feedbackConfirmation(() => 0));
   /** Counts confirmations so each landing's swoop is replayed, not reused. */
   const feedbackConfirmPlays = useRef(0);
   const feedbackConfirmTimer = useRef<number | undefined>(undefined);
@@ -1032,7 +1036,6 @@ export function App(): React.JSX.Element {
         if (!result.delivered) {
           return { rejection: result.reason ?? "Could not send that. Try again." };
         }
-        feedbackSequence.current = result.sequence ?? 0;
         return {};
       } catch {
         return { rejection: "Could not send that. Try again." };
@@ -1041,16 +1044,19 @@ export function App(): React.JSX.Element {
     onDelivered: () => {
       showFeedbackNotice("Sent — thank you.");
       // The landing plays in the shape the note left from: Luke swoops down
-      // beside the thank-you and plays this send's gesture from the ring.
+      // beside the thank-you and plays this send's flip of the coin. The pick
+      // is held on a ref so the hold below waits out the same gesture.
+      const confirmation = feedbackConfirmation();
+      feedbackLanding.current = confirmation;
       feedbackConfirmPlays.current += 1;
       setFeedbackConfirming({
-        confirmation: feedbackConfirmation(feedbackSequence.current),
+        confirmation,
         play: feedbackConfirmPlays.current,
       });
     },
     afterDelivery: (finish) => {
       feedbackFinish.current = finish;
-      const { motion } = feedbackConfirmation(feedbackSequence.current);
+      const { motion } = feedbackLanding.current;
       if (feedbackConfirmTimer.current !== undefined) {
         window.clearTimeout(feedbackConfirmTimer.current);
       }

--- a/apps/desktop/src/renderer/feedback-confirmation.ts
+++ b/apps/desktop/src/renderer/feedback-confirmation.ts
@@ -3,21 +3,17 @@ import { FACE_MOTION, FACE_MOTION_CYCLE_MS, type FaceMotion } from "./luke-face-
 
 /**
  * The moment after a send lands: Luke swoops down into the composer's shape,
- * lands beside "Sent — thank you!", and plays one gesture from the artwork's
- * own vocabulary before the panel returns. Which gesture is a function of how
- * many sends have landed from this machine — the very first gets the loud
- * one, and every send after walks a fixed ring — so the confirmation is warm
- * without ever being the same twice in a row.
+ * lands beside "Sent — thank you!", and plays one of two dressed landings
+ * before the panel returns. Which one is a coin flip per send, so the
+ * confirmation is warm without being the same every time.
  */
 
 /** How the confirmation dresses the landing: what the text does alongside. */
 export const CONFIRMATION_SCENE = {
-  /** The first landing: a stomp whose impact ducks the text lines under him. */
+  /** A stomp whose impact ducks the text lines under him. */
   SHOCKWAVE: "shockwave",
   /** A puff at the exclamation mark, which tips over and springs back up. */
   BOOP: "boop",
-  /** The plain landing: Luke arrives, plays his gesture, and that is all. */
-  LANDING: "landing",
 } as const;
 
 export type ConfirmationScene = (typeof CONFIRMATION_SCENE)[keyof typeof CONFIRMATION_SCENE];
@@ -27,39 +23,30 @@ export interface FeedbackConfirmation {
   scene: ConfirmationScene;
 }
 
-/** The first-ever landing gets the loud one: the squash-and-stretch stomp. */
-const FIRST_CONFIRMATION: FeedbackConfirmation = {
+const SHOCKWAVE_CONFIRMATION: FeedbackConfirmation = {
   motion: FACE_MOTION.SUCCESS,
   scene: CONFIRMATION_SCENE.SHOCKWAVE,
 };
 
-/**
- * Every send after the first walks this ring in order and wraps. Each entry is
- * a motion the artwork already defines; the two dressed scenes lead so the
- * text tricks are seen early, and the quieter face-only gestures follow.
- */
-export const CONFIRMATION_CYCLE: readonly FeedbackConfirmation[] = [
-  { motion: FACE_MOTION.BOOP, scene: CONFIRMATION_SCENE.BOOP },
-  { motion: FACE_MOTION.REVIEWING, scene: CONFIRMATION_SCENE.LANDING },
-  { motion: FACE_MOTION.DIZZY, scene: CONFIRMATION_SCENE.LANDING },
-  { motion: FACE_MOTION.FLOATING, scene: CONFIRMATION_SCENE.LANDING },
-  { motion: FACE_MOTION.WINK, scene: CONFIRMATION_SCENE.LANDING },
-  { motion: FACE_MOTION.IDLE, scene: CONFIRMATION_SCENE.LANDING },
-  { motion: FACE_MOTION.YES, scene: CONFIRMATION_SCENE.LANDING },
-  { motion: FACE_MOTION.REFRESH, scene: CONFIRMATION_SCENE.LANDING },
-  { motion: FACE_MOTION.SHIMMY, scene: CONFIRMATION_SCENE.LANDING },
-  { motion: FACE_MOTION.GLANCE, scene: CONFIRMATION_SCENE.LANDING },
+const BOOP_CONFIRMATION: FeedbackConfirmation = {
+  motion: FACE_MOTION.BOOP,
+  scene: CONFIRMATION_SCENE.BOOP,
+};
+
+/** The two landings a send may draw. Each motion is one the artwork defines. */
+export const CONFIRMATIONS: readonly FeedbackConfirmation[] = [
+  SHOCKWAVE_CONFIRMATION,
+  BOOP_CONFIRMATION,
 ];
 
 /**
- * The confirmation a landed send plays, from how many landed before it. A
- * sequence the store could not supply reads as the first send, because the
- * worst that costs is replaying the welcome.
+ * The confirmation a landed send plays: a coin flip between the two
+ * landings. The flip is injectable so a test can watch both faces of the
+ * coin, and a fixture run never reaches here at all — a send is refused
+ * before it lands.
  */
-export function feedbackConfirmation(sequence: number): FeedbackConfirmation {
-  if (!Number.isSafeInteger(sequence) || sequence <= 0) return FIRST_CONFIRMATION;
-  const step = CONFIRMATION_CYCLE[(sequence - 1) % CONFIRMATION_CYCLE.length];
-  return step ?? FIRST_CONFIRMATION;
+export function feedbackConfirmation(random: () => number = Math.random): FeedbackConfirmation {
+  return random() < 0.5 ? SHOCKWAVE_CONFIRMATION : BOOP_CONFIRMATION;
 }
 
 /**

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -2282,9 +2282,9 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   }
 }
 
-/* The first landing's shockwave: the success motion lands its squash at 65%
-   of its 2s cycle, and the two text lines duck on that landing, the sub a
-   beat behind the headline. The delays and durations inside this block are
+/* The shockwave landing: the success motion lands its squash at 65% of its
+   2s cycle, and the two text lines duck on that landing, the sub a beat
+   behind the headline. The delays and durations inside this block are
    literal because they are the artwork's own timing — a face motion carries
    literal seconds for the same reason — and they answer `--face-motion`
    exactly as the gesture they follow does, so a capture run and reduced

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -58,7 +58,6 @@ const SETTINGS_FIELD = {
   DEFAULT_WORKSPACE_PROVIDER: "defaultWorkspaceProvider",
   DUCK_OTHER_MEDIA: "duckOtherMedia",
   PREFER_BUILT_IN_MICROPHONE: "preferBuiltInMicrophone",
-  FEEDBACK_SENDS: "feedbackSends",
   FORM_FACTOR: "formFactor",
   LEGACY_CONDUCTOR_API_KEY: "conductorApiKey",
   QUIET_DURING_MEETINGS: "quietDuringMeetings",
@@ -187,14 +186,6 @@ interface PersistedSettings {
    */
   duckOtherMedia: boolean;
   preferBuiltInMicrophone: boolean;
-  /**
-   * How many feedback sends have landed from this machine, so the composer's
-   * confirmation can pick which little celebration each delivery gets.
-   * Bookkeeping rather than a preference: it has no row, no reset scope
-   * forgets it, and it never reaches the renderer's settings snapshot. A
-   * missing field and a corrupt value both read as none yet.
-   */
-  feedbackSends?: number;
   /**
    * Whether announcements wait out calendar meetings. On unless the file says
    * `false` outright, on the media duck's own reasoning: this is what Luke
@@ -482,13 +473,6 @@ function parsePersistedSettings(source: string): PersistedSettings {
   const storedStopHotkey = record[SETTINGS_FIELD.STOP_HOTKEY];
   const stopHotkey =
     typeof storedStopHotkey === "string" ? parseVoiceHotkey(storedStopHotkey) : undefined;
-  const storedFeedbackSends = record[SETTINGS_FIELD.FEEDBACK_SENDS];
-  const feedbackSends =
-    typeof storedFeedbackSends === "number" &&
-    Number.isSafeInteger(storedFeedbackSends) &&
-    storedFeedbackSends > 0
-      ? storedFeedbackSends
-      : undefined;
   return {
     version: typeof version === "number" ? version : SETTINGS_FILE_VERSION,
     apiKeys: storedApiKeys(record),
@@ -523,9 +507,6 @@ function parsePersistedSettings(source: string): PersistedSettings {
       record[SETTINGS_FIELD.PREFER_BUILT_IN_MICROPHONE],
       APP_SETTING_DEFAULTS.preferBuiltInMicrophone,
     ),
-    // A count that is not a whole non-negative number reads as none yet: the
-    // worst a corrupt value can cost is replaying the first send's scene.
-    ...(feedbackSends !== undefined ? { feedbackSends } : {}),
     quietDuringMeetings: booleanSetting(
       record[SETTINGS_FIELD.QUIET_DURING_MEETINGS],
       APP_SETTING_DEFAULTS.quietDuringMeetings,
@@ -884,29 +865,6 @@ export class SettingsStore {
       if (persisted.duckOtherMedia === enabled) return;
       return { ...persisted, duckOtherMedia: enabled };
     });
-  }
-
-  /**
-   * Counts a landed send and answers how many landed before it, so the
-   * composer's confirmation can pick which celebration this delivery gets.
-   * Not `#setField`, because the caller needs the count the write was based
-   * on, not the settings snapshot — and the snapshot must never carry this:
-   * it is bookkeeping about the machine, not a preference with a row.
-   */
-  async countFeedbackSend(): Promise<number> {
-    let before = 0;
-    await this.#serialize(async () => {
-      const persisted = await this.#load();
-      before = persisted.feedbackSends ?? 0;
-      const next: PersistedSettings = {
-        ...persisted,
-        feedbackSends: before + 1,
-        version: SETTINGS_FILE_VERSION,
-      };
-      await this.#write(next);
-      this.#loading = Promise.resolve(next);
-    });
-    return before;
   }
 
   /**

--- a/apps/desktop/src/shared/feedback.ts
+++ b/apps/desktop/src/shared/feedback.ts
@@ -98,13 +98,6 @@ export interface FeedbackSubmission {
 export interface FeedbackResult {
   delivered: boolean;
   reason?: string;
-  /**
-   * How many sends landed before this one, so the composer can pick which
-   * little celebration this delivery gets. Bookkeeping about the machine's own
-   * history, never about the note: absent on a refusal, and `0` when the count
-   * cannot be read, which lands on the first send's scene.
-   */
-  sequence?: number;
 }
 
 /** Standard base64: whole quartets of the alphabet, padded or not at the end. */

--- a/apps/desktop/tests/feedback-confirmation.test.ts
+++ b/apps/desktop/tests/feedback-confirmation.test.ts
@@ -1,89 +1,52 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
-  CONFIRMATION_CYCLE,
   CONFIRMATION_ENTRANCE_MS,
   CONFIRMATION_REST_MS,
   CONFIRMATION_SCENE,
+  CONFIRMATIONS,
   confirmationHoldMs,
   feedbackConfirmation,
   STILL_CONFIRMATION_MS,
 } from "../src/renderer/feedback-confirmation";
 import { FACE_MOTION, FACE_MOTION_CYCLE_MS } from "../src/renderer/luke-face-art";
 
-test("the first landed send gets the shockwave, and only the first", () => {
-  const first = feedbackConfirmation(0);
+test("the coin lands on the shockwave or the boop, and nothing else", () => {
+  const low = feedbackConfirmation(() => 0);
+  const high = feedbackConfirmation(() => 0.999);
 
-  assert.equal(first.motion, FACE_MOTION.SUCCESS);
-  assert.equal(first.scene, CONFIRMATION_SCENE.SHOCKWAVE);
-  // Nothing in the ring repeats the welcome.
-  for (const step of CONFIRMATION_CYCLE) {
-    assert.notEqual(step.scene, CONFIRMATION_SCENE.SHOCKWAVE);
-  }
+  assert.equal(low.motion, FACE_MOTION.SUCCESS);
+  assert.equal(low.scene, CONFIRMATION_SCENE.SHOCKWAVE);
+  assert.equal(high.motion, FACE_MOTION.BOOP);
+  assert.equal(high.scene, CONFIRMATION_SCENE.BOOP);
+  assert.equal(CONFIRMATIONS.length, 2);
 });
 
-test("a count the store could not supply lands on the first send's scene", () => {
-  // The worst a lost or corrupt count can cost is replaying the welcome.
-  assert.equal(feedbackConfirmation(-3).scene, CONFIRMATION_SCENE.SHOCKWAVE);
-  assert.equal(feedbackConfirmation(Number.NaN).scene, CONFIRMATION_SCENE.SHOCKWAVE);
-  assert.equal(feedbackConfirmation(0.5).scene, CONFIRMATION_SCENE.SHOCKWAVE);
-});
-
-test("every send after the first walks the ring in order and wraps", () => {
-  const ring = [
-    FACE_MOTION.BOOP,
-    FACE_MOTION.REVIEWING,
-    FACE_MOTION.DIZZY,
-    FACE_MOTION.FLOATING,
-    FACE_MOTION.WINK,
-    FACE_MOTION.IDLE,
-    FACE_MOTION.YES,
-    FACE_MOTION.REFRESH,
-    FACE_MOTION.SHIMMY,
-    FACE_MOTION.GLANCE,
-  ];
-
-  ring.forEach((motion, index) => {
-    assert.equal(feedbackConfirmation(index + 1).motion, motion);
-  });
-  // The eleventh send after the first is the boop again: the ring wraps
-  // rather than running out of celebrations.
-  assert.equal(feedbackConfirmation(ring.length + 1).motion, FACE_MOTION.BOOP);
-  assert.equal(feedbackConfirmation(2 * ring.length).motion, FACE_MOTION.GLANCE);
-});
-
-test("only the boop landing dresses the exclamation mark", () => {
-  const dressed = CONFIRMATION_CYCLE.filter((step) => step.scene === CONFIRMATION_SCENE.BOOP);
-
-  assert.equal(dressed.length, 1);
-  assert.equal(dressed[0]?.motion, FACE_MOTION.BOOP);
-});
-
-test("every motion in the ring is one the artwork describes", () => {
-  for (const step of CONFIRMATION_CYCLE) {
-    const cycle = FACE_MOTION_CYCLE_MS[step.motion];
-    assert.ok(cycle > 0, `${step.motion} has no cycle`);
+test("every landing the coin can draw is one the artwork describes", () => {
+  for (const landing of CONFIRMATIONS) {
+    const cycle = FACE_MOTION_CYCLE_MS[landing.motion];
+    assert.ok(cycle > 0, `${landing.motion} has no cycle`);
   }
 });
 
 test("the hold spans the swoop, the gesture, and a beat of rest", () => {
-  const hold = confirmationHoldMs({ motion: FACE_MOTION.SUCCESS, still: false });
-
-  assert.equal(
-    hold,
-    CONFIRMATION_ENTRANCE_MS + FACE_MOTION_CYCLE_MS[FACE_MOTION.SUCCESS] + CONFIRMATION_REST_MS,
-  );
+  for (const landing of CONFIRMATIONS) {
+    assert.equal(
+      confirmationHoldMs({ motion: landing.motion, still: false }),
+      CONFIRMATION_ENTRANCE_MS + FACE_MOTION_CYCLE_MS[landing.motion] + CONFIRMATION_REST_MS,
+    );
+  }
 });
 
 test("with motion asked away the hold is only long enough to read", () => {
-  // No gesture plays, so there is no gesture to wait out — whichever motion
+  // No gesture plays, so there is no gesture to wait out — whichever landing
   // this send would have drawn.
   assert.equal(
-    confirmationHoldMs({ motion: FACE_MOTION.REFRESH, still: true }),
+    confirmationHoldMs({ motion: FACE_MOTION.SUCCESS, still: true }),
     STILL_CONFIRMATION_MS,
   );
   assert.equal(
-    confirmationHoldMs({ motion: FACE_MOTION.IDLE, still: true }),
+    confirmationHoldMs({ motion: FACE_MOTION.BOOP, still: true }),
     STILL_CONFIRMATION_MS,
   );
 });

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -347,45 +347,6 @@ test("a corrupt microphone preference reads as the default rather than as off", 
   assert.equal((await storeIn(directory).snapshot()).preferBuiltInMicrophone, true);
 });
 
-test("counts feedback sends from none, and the count survives a reopen", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-
-  // Each landing answers how many landed before it, so the first is zero.
-  assert.equal(await store.countFeedbackSend(), 0);
-  assert.equal(await store.countFeedbackSend(), 1);
-  assert.equal(await storeIn(directory).countFeedbackSend(), 2);
-});
-
-test("a corrupt send count reads as none yet and never reaches the snapshot", async (t) => {
-  const directory = await temporaryDirectory(t);
-  await fs.writeFile(
-    path.join(directory, SETTINGS_FILE_NAME),
-    JSON.stringify({ version: 2, apiKeys: {}, feedbackSends: "many" }),
-    "utf8",
-  );
-  const store = storeIn(directory);
-
-  // The worst a corrupt count can cost is replaying the first send's scene —
-  // and bookkeeping about the machine is not a setting, so the snapshot the
-  // renderer sees carries no trace of it.
-  assert.equal(await store.countFeedbackSend(), 0);
-  assert.equal("feedbackSends" in (await store.snapshot()), false);
-});
-
-test("a settings reset never forgets how many sends have landed", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const store = storeIn(directory);
-  await store.countFeedbackSend();
-  await store.countFeedbackSend();
-
-  await store.resetSettings(SETTINGS_RESET_SCOPE.VOICE);
-
-  // The count is history, not a preference: there is no default to return
-  // it to, so no scope may touch it.
-  assert.equal(await store.countFeedbackSend(), 2);
-});
-
 test("a calendar account stores its grant encrypted and survives a reopen", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);


### PR DESCRIPTION
## Summary

- After a feedback note or a prompt is delivered, the composer's confirmation now flips a coin between the two dressed landings — the shockwave stomp that ducks the text lines, and the boop that tips the exclamation mark over — instead of giving the first-ever send the shockwave and walking every later send through a ten-gesture ring.
- The persisted send counter existed only to pick a step on that ring, so it goes with it: `FeedbackResult` loses its `sequence` field, the send handler no longer counts, and the settings store drops `countFeedbackSend`/`feedbackSends`. An old `feedbackSends` key in a settings file is ignored and dropped on the next write.
- Fixture and capture runs are untouched: a fixture send is refused before it lands, so the coin flip never runs deterministically-observed code paths.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (lint, typecheck, 1000 desktop + 37 web tests, builds)
- macOS Electron verification (`./scripts/verify.sh`): `not run` (change authored in a Linux cloud workspace)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32088067230/artifacts/9307394037) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32088067230)

- Commit: `d242554ba35badc52b3445b1307ed9e744457c77`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: The confirmation only draws after a real delivered send, which fixture runs refuse, so the deterministic capture surface is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/9cadc3ce-f25f-4928-9184-983e645570e8)
