### PR TITLE
fix(desktop): dress the calendar sign-in wait like the account sign-in's

### DIFF
--- a/apps/desktop/src/renderer/calendar-connect-slot.tsx
+++ b/apps/desktop/src/renderer/calendar-connect-slot.tsx
@@ -1,5 +1,5 @@
 import { useRef } from "react";
-import { GOOGLE_CALENDAR_ID, GOOGLE_CALENDAR_NAME } from "../shared/google-calendar";
+import { GOOGLE_CALENDAR_ID } from "../shared/google-calendar";
 import { HIT_REGION } from "./panel-state";
 import { ProviderMark } from "./provider-marks";
 import { ExternalIcon } from "./settings-icons";
@@ -45,20 +45,19 @@ export function CalendarConnectSlot({
 
   return (
     <div className="slot-stage" aria-hidden={!live} inert={!live}>
-      <div className="key-slot" ref={measure} data-hit-region={HIT_REGION.SLOT}>
-        <span className="settings-label key-slot-label">{GOOGLE_CALENDAR_NAME}</span>
-        {/* One line: the mark, what is being waited for, and the one way to
-            stop waiting — a second row would grow the slot for nothing. */}
+      <div className="key-slot sign-in-slot" ref={measure} data-hit-region={HIT_REGION.SLOT}>
+        {/* One line, worded and dressed like the account sign-in's wait: the
+            mark, what is being waited for, and the one way to stop waiting —
+            only the calendar mark and the way back to a lost tab tell the two
+            popups apart. */}
         <div className="key-slot-row">
           <span className="key-slot-mark">
             <ProviderMark providerId={GOOGLE_CALENDAR_ID} />
           </span>
-          <span className="settings-copy calendar-connect-copy">
-            <span className="settings-name">
-              {held.rejection ? "Not connected" : "Waiting for Google…"}
-            </span>
+          <span className="sign-in-slot-copy" role="status">
+            <strong>{held.rejection ? "Not connected" : "Waiting for Google…"}</strong>
             <small>
-              {held.rejection ?? "Finish signing in with Google in your browser."}{" "}
+              {held.rejection ?? "Finish signing in in your browser."}{" "}
               {/* The lost-tab way back in, on the key slot's own terms: a
                   button, not an anchor — the main process reopens the page
                   the waiting flow built, and no address crosses from here.

--- a/apps/desktop/src/renderer/calendar-connect-slot.tsx
+++ b/apps/desktop/src/renderer/calendar-connect-slot.tsx
@@ -44,7 +44,7 @@ export function CalendarConnectSlot({
   if (!held) return null;
 
   return (
-    <div className="slot-stage" aria-hidden={!live} inert={!live}>
+    <div className="slot-stage" data-drawn={String(drawn)} aria-hidden={!live} inert={!live}>
       <div className="key-slot sign-in-slot" ref={measure} data-hit-region={HIT_REGION.SLOT}>
         {/* One line, worded and dressed like the account sign-in's wait: the
             mark, what is being waited for, and the one way to stop waiting —

--- a/apps/desktop/src/renderer/key-slot.tsx
+++ b/apps/desktop/src/renderer/key-slot.tsx
@@ -91,7 +91,7 @@ export function KeySlot({
   const ready = isSubmittable(entry);
 
   return (
-    <div className="slot-stage" aria-hidden={!live} inert={!live}>
+    <div className="slot-stage" data-drawn={String(drawn)} aria-hidden={!live} inert={!live}>
       {/* No grouping role: the field names the provider itself, and everything
           beside it acts on that one field. */}
       <div className="key-slot" ref={measure} data-hit-region={HIT_REGION.SLOT}>

--- a/apps/desktop/src/renderer/sign-in-slot.tsx
+++ b/apps/desktop/src/renderer/sign-in-slot.tsx
@@ -41,7 +41,7 @@ export function SignInSlot({
 
   const name = shown === ACCOUNT_PROVIDER.GITHUB ? "GitHub" : "Google";
   return (
-    <div className="slot-stage" aria-hidden={!live} inert={!live}>
+    <div className="slot-stage" data-drawn={String(drawn)} aria-hidden={!live} inert={!live}>
       <div className="key-slot sign-in-slot" ref={measure} data-hit-region={HIT_REGION.SLOT}>
         <div className="key-slot-row">
           <span className="key-slot-mark sign-in-slot-mark">

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1071,7 +1071,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   transform: translateX(-50%) translateY(calc(var(--shape-top) - 6px));
 }
 
-.app-stage[data-notch="false"][data-presentation="slot"] .slot-stage {
+.app-stage[data-notch="false"][data-presentation="slot"] .slot-stage[data-drawn="true"] {
   transform: translateX(-50%) translateY(var(--shape-top));
 }
 
@@ -2357,7 +2357,11 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   will-change: opacity, transform;
 }
 
-.app-stage[data-presentation="slot"] .slot-stage {
+/* Only the stage whose entry holds the slot comes forward: the others keep
+   whatever pill they last held — that is what lets an exit finish saying what
+   it was saying — so without the drawn gate a stale pill would resurface
+   under another occupant's wait. */
+.app-stage[data-presentation="slot"] .slot-stage[data-drawn="true"] {
   opacity: 1;
   visibility: visible;
   transform: translateX(-50%) translateY(0);
@@ -2379,7 +2383,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   border-radius: 0 0 var(--slot-radius) var(--slot-radius);
 }
 
-.app-stage[data-presentation="slot"] .key-slot {
+.app-stage[data-presentation="slot"] .slot-stage[data-drawn="true"] .key-slot {
   pointer-events: auto;
 }
 

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -2396,13 +2396,6 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   padding-left: calc(var(--slot-mark-size) + var(--slot-gutter-gap));
 }
 
-/* The connect slot's words take the room between the mark and the Cancel
-   beside them, so the one line holds all three. */
-.calendar-connect-copy {
-  flex: 1;
-  min-width: 0;
-}
-
 /* Larger than the mark on a settings line: here it is the only thing naming the
    provider, rather than a glyph beside its name. The badge grows with it. */
 .key-slot-mark {


### PR DESCRIPTION
## Summary

Two fixes to the slot pills under the housing.

**The calendar sign-in wait now dresses like the account sign-in's.** The Google Calendar connect slot drew a settings-style pill of its own: a "Google Calendar" header above the row, an unbolded title, and tertiary detail text with a wider gap, making it taller and visibly different from the account sign-in wait. It now takes the account sign-in slot's exact markup and classes (`sign-in-slot-copy`, `<strong>`/`<small>`, `role="status"`) and wording, keeping only what the calendar alone needs: the lost-tab "Open the page again" link, the rejection state, and its own provider mark — now the visual cue telling the two popups apart.

**Only the pill whose entry holds the slot is painted.** Every slot stage keeps drawing the pill it last held so an exit can finish saying what it was saying — but the slot presentation showed every stage at once, so a stale key pill resurfaced under the calendar sign-in's wait, and the calendar's stale wait under the next key entry (both overlapping, as reported with Linear → Calendar → Conductor). The stage now carries `data-drawn`, the presentation's visible rule (and the notchless variant, and the pointer-events grant) only brings forward the stage whose entry holds the slot, and keying the gate on `drawn` rather than the live entry keeps the held pill through the collapse exactly as before.

## Testing

- `./scripts/check.sh` passes (repository contract checks, lint, typecheck, tests, builds).
- `./scripts/verify.sh` was not run: this change was made in a Linux cloud workspace and the script requires macOS. The popups appear only mid-sign-in/mid-entry, so the fixture evidence would not show them; no physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32090252471/artifacts/9308105042) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32090252471)

- Commit: `1c5352b2098a69b6ac0807bfca45da1f0c38fb6a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
