### PR TITLE
fix(desktop): offer feedback and prompts as one row of half-width buttons

### DIFF
--- a/apps/desktop/src/renderer/feedback-entry.ts
+++ b/apps/desktop/src/renderer/feedback-entry.ts
@@ -144,24 +144,22 @@ export function openedFeedbackEntry(
 }
 
 /**
- * Each kind in its own words: the line that offers it in settings, and the
+ * Each kind in its own words: the button that offers it in settings, and the
  * label, hint, and field the shape opens with. Two kinds rather than one form
  * with a switch, because they are read differently on arrival — feedback is
  * about Luke, and a prompt is a candidate for the product itself.
  */
 export const FEEDBACK_COPY: Record<
   FeedbackKind,
-  { title: string; opener: string; label: string; placeholder: string; detail?: string }
+  { title: string; label: string; placeholder: string; detail?: string }
 > = {
   [FEEDBACK_KIND.FEEDBACK]: {
     title: "Send feedback",
-    opener: "Write feedback",
     label: "Feedback",
     placeholder: "What happened, and what did you expect?",
   },
   [FEEDBACK_KIND.PROMPT]: {
     title: "Submit a prompt",
-    opener: "Share a prompt",
     label: "The prompt",
     placeholder: "Describe a feature…",
     detail:

--- a/apps/desktop/src/renderer/feedback-panel.tsx
+++ b/apps/desktop/src/renderer/feedback-panel.tsx
@@ -4,10 +4,11 @@ import { FEEDBACK_COPY, type FeedbackEntryControl } from "./feedback-entry";
 import { CheckIcon, MegaphoneIcon } from "./settings-icons";
 
 /**
- * One line that offers a kind: its name and the button that opens the
- * composer on it. No sentence under it — the composer's own shape is where
- * each kind explains itself. The button says "keep writing" when a draft of
- * this kind is waiting, because pressing it then continues rather than opens.
+ * One button that offers a kind: its name is the whole line, and pressing it
+ * opens the composer on it. No sentence under it — the composer's own shape is
+ * where each kind explains itself. The button says "keep writing" when a draft
+ * of this kind is waiting, because pressing it then continues rather than
+ * opens.
  */
 function FeedbackOffer({
   kind,
@@ -19,25 +20,22 @@ function FeedbackOffer({
   const copy = FEEDBACK_COPY[kind];
   const holdsDraft = control.entry?.kind === kind;
   return (
-    <div className="settings-row">
-      <span className="settings-copy">
-        <strong>{copy.title}</strong>
-      </span>
-      <span className="settings-actions">
-        <button type="button" className="quiet-button" onClick={() => control.begin(kind)}>
-          {holdsDraft ? "Keep writing" : copy.opener}
-        </button>
-      </span>
-    </div>
+    <button
+      type="button"
+      className="quiet-button feedback-offer"
+      onClick={() => control.begin(kind)}
+    >
+      {holdsDraft ? "Keep writing" : copy.title}
+    </button>
   );
 }
 
 /**
  * The last section of the settings front page: the two ways to write to the
- * people who make Luke. The section only offers — pressing either button stands the
- * panel down to the composer's own shape, the way pressing Connect stands it
- * down to the key slot — and the line under the offers is where a landed send
- * reports back.
+ * people who make Luke, side by side on one row. The section only offers —
+ * pressing either button stands the panel down to the composer's own shape,
+ * the way pressing Connect stands it down to the key slot — and the line under
+ * the offers is where a landed send reports back.
  */
 export function FeedbackSection({ control }: { control: FeedbackEntryControl }): React.JSX.Element {
   return (
@@ -46,8 +44,10 @@ export function FeedbackSection({ control }: { control: FeedbackEntryControl }):
         <MegaphoneIcon />
         Feedback
       </h2>
-      <FeedbackOffer kind={FEEDBACK_KIND.FEEDBACK} control={control} />
-      <FeedbackOffer kind={FEEDBACK_KIND.PROMPT} control={control} />
+      <div className="feedback-offers">
+        <FeedbackOffer kind={FEEDBACK_KIND.FEEDBACK} control={control} />
+        <FeedbackOffer kind={FEEDBACK_KIND.PROMPT} control={control} />
+      </div>
       {control.notice ? (
         <p className="feedback-sent">
           <CheckIcon />

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -2194,6 +2194,16 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   height: 12px;
 }
 
+/* The settings section's two offers share one row, half the width each. */
+.feedback-offers {
+  display: flex;
+  gap: 7px;
+}
+
+.feedback-offer {
+  flex: 1 1 0;
+}
+
 /* A send that landed, said in the palette every settled answer uses. */
 .feedback-sent {
   display: flex;


### PR DESCRIPTION
## What

The settings Feedback section drew each kind as a settings row — a title beside a small opener button ("Send feedback" / "Write feedback", "Submit a prompt" / "Share a prompt"). Now each kind is one button carrying its title, and the two sit side by side on one row at half the width each:

- `feedback-panel.tsx` — `FeedbackOffer` is the button itself; `FeedbackSection` lays the pair out in a `feedback-offers` row. A button whose kind holds a draft still says "Keep writing", because pressing it continues rather than opens.
- `feedback-entry.ts` — dropped the now-unused `opener` field from `FEEDBACK_COPY`; the composer only ever read `label`, `placeholder`, and `detail`.
- `styles/base.css` — `.feedback-offers` (flex row, 7px gap) and `.feedback-offer` (`flex: 1 1 0`), beside the other feedback styles. The buttons keep the `quiet-button` look.

## Verification

- `./scripts/check.sh` passes (repository contracts, lint, typecheck, tests, build).
- Visual: launched the built app with the smoke fixture under xvfb (Linux sandbox), opened the Settings tab, and inspected the screenshot — the two buttons split the section's row evenly (270.5px each in the 548px section, 7px gap).
- `./scripts/verify.sh` was not run (authored in a Linux sandbox); no physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/3e1cef83-f38b-4029-83ac-f1da0556a121)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32093681683/artifacts/9309220188) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32093681683)

- Commit: `1213760a6631ff7b46b56c984facdf70dd9b502d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
