### PR TITLE
fix(desktop): drop the sent-to confirmation after an accepted follow-up

### DIFF
--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -137,9 +137,11 @@ function RowActionButton({
  * message field that is simply there, the way every chat surface keeps its
  * composer on screen, and each advertised action beside it — a stop as the
  * square glyph, anything else as a chip in the provider's own words.
- * Everything here answers back onto the same line — sending, sent, or the
- * provider's refusal — because a write is the user's own act and its outcome
- * may not vanish into a log.
+ * Every outcome that needs words answers back onto the same line — sending, an
+ * action's acceptance, or the provider's refusal — because a write is the
+ * user's own act and its outcome may not vanish into a log. An accepted
+ * message alone answers silently: the draft emptying is the confirmation, and
+ * a line saying so again only holds the row taller than it needs to be.
  */
 function SessionRowActions({
   session,
@@ -179,9 +181,9 @@ function SessionRowActions({
     try {
       const result = await writes.sendMessage(session, text);
       if (result.status === PROVIDER_ACT_RESULT_STATUS.ACCEPTED) {
-        // The draft has become the session's; the field empties for the next.
+        // The draft has become the session's; the field emptying for the next
+        // message is the whole confirmation, so no line repeats it.
         setDraft("");
-        setFeedback(`Sent to ${session.provider}`);
       } else {
         // The draft stays: a refused message is still the user's words.
         setFeedback(feedbackFor(result));


### PR DESCRIPTION
## What

After a follow-up sent from a session row was accepted, the row answered twice: the composer emptied, and a `Sent to <provider>` line appeared beneath it. The line only repeated what the cleared field already said and held the row taller than it needed to be, so an accepted message now answers silently — the draft emptying is the whole confirmation.

- `panel-body.tsx` — the accepted branch of `send` no longer sets feedback; the component's doc comment now states which outcomes still answer on the line (sending, an action's acceptance, and every refusal) and why an accepted message does not.

Refusals keep the line and keep the draft, and accepted actions keep their `<provider> accepted` answer, because those outcomes have nowhere else to show.

## Verification

- `./scripts/check.sh` passes (repository contracts, lint, typecheck, tests, build).
- `./scripts/verify.sh` was not run (authored in a Linux sandbox); no physical-notch check was performed. The removed line only ever drew after a live provider accepted a message, so a fixture run cannot capture the before/after; CI's deterministic macOS evidence covers the panel as drawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d03b120e-0869-4a53-87f9-7ee8b16c0bab)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32096499542/artifacts/9310135229) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32096499542)

- Commit: `a25b7f72f504c20a9e3aca5e507c09462b40c6f2`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
