### PR TITLE
fix(voice): stop announcements colliding with a reply the server still owns

### DIFF
--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -65,10 +65,11 @@ const CONNECT_TIMEOUT_MS = 15_000;
 
 /**
  * How long a finished generation may go on playing before the turn is ended
- * anyway. It is a backstop for a reply that produced no audio at all, not the
+ * anyway. It is a backstop for a reply that produced no audio at all — or one
+ * whose audio drained while its `response.done` never arrived — not the
  * normal path: a spoken reply ends when it goes quiet.
  */
-const REALTIME_SETTLE_TIMEOUT_MS = 20_000;
+export const REALTIME_SETTLE_TIMEOUT_MS = 20_000;
 
 /**
  * How long the developer's call stays open with nothing being said on it.
@@ -356,6 +357,25 @@ export class RealtimeVoiceSession {
    * be.
    */
   #remoteQuiet = false;
+  /**
+   * Whether the server still owes this turn a `response.done`: raised when a
+   * reply is asked for, lowered when the server concludes it — its own
+   * `done`, the error that refused it outright, or the cancel an interrupt
+   * sends ahead of anything newer. The client's side of the turn can settle
+   * first — the audio drains before the `done` arrives — and in that window
+   * the conversation still holds an active response: a `response.create`
+   * sent into it is refused as a conversation already in progress, with the
+   * refusal read out to the developer as a voice error and the reply it was
+   * meant to open lost. Nothing may end the turn while this stands.
+   */
+  #responseOutstanding = false;
+  /**
+   * Whether the reply's audio ran out while the server still owed its
+   * `done`. The ending the drain would have made is remembered here and
+   * lands when the `done` arrives, so the turn still closes on the second of
+   * the two events whichever order they come in.
+   */
+  #audioDrained = false;
   /**
    * Whether Luke has actually been heard during this reply. Committing a turn
    * swaps the meter from the microphone to Luke, and the meter reports quiet as
@@ -1022,6 +1042,12 @@ export class RealtimeVoiceSession {
     // that opens a new developer turn arms it afresh in #startResponse; left
     // true here, the cancelled reply's late calls would find it still standing.
     this.#toolTurnArmed = false;
+    // The cancel concludes the reply at the server before anything sent after
+    // it is read — the channel is ordered — so nothing is outstanding from
+    // here, and whatever `done` the cancelled reply still sends matches no
+    // active response above.
+    this.#responseOutstanding = false;
+    this.#audioDrained = false;
     this.#generationDone = false;
     this.#remoteQuiet = false;
     this.#heardLuke = false;
@@ -1124,6 +1150,8 @@ export class RealtimeVoiceSession {
     this.#pendingSupersedes.clear();
     this.#conversationBegan = false;
     this.#clearIdleTimer();
+    this.#responseOutstanding = false;
+    this.#audioDrained = false;
     this.#generationDone = false;
     this.#remoteQuiet = false;
     this.#heardLuke = false;
@@ -1167,6 +1195,10 @@ export class RealtimeVoiceSession {
     this.#generationDone = false;
     this.#remoteQuiet = false;
     this.#heardLuke = false;
+    // The reply now being asked for is the server's until it concludes it:
+    // nothing else may ask for one over it.
+    this.#responseOutstanding = true;
+    this.#audioDrained = false;
     this.#clearQuietTimer();
     this.#responseItemId = undefined;
     // Nothing has been confirmed for this turn yet: whatever `response.done`
@@ -1266,6 +1298,14 @@ export class RealtimeVoiceSession {
     if (this.#remoteTrack) this.#remoteTrack.enabled = true;
   }
 
+  /** Starts the backstop for a reply whose proper ending never arrives. */
+  #armSettleTimer(): void {
+    this.#settleTimer ??= setTimeout(() => {
+      this.#settleTimer = undefined;
+      this.#finishResponse();
+    }, REALTIME_SETTLE_TIMEOUT_MS);
+  }
+
   #clearSettleTimer(): void {
     if (this.#settleTimer === undefined) return;
     clearTimeout(this.#settleTimer);
@@ -1291,6 +1331,11 @@ export class RealtimeVoiceSession {
   /** Ends the turn once the reply is done, so the next one can start. */
   #finishResponse(): void {
     this.#generationDone = false;
+    // However the turn ended — the settle backstop included — whatever the
+    // server still owed it is treated as concluded, so a `done` that never
+    // comes cannot leave every later reply refused against it.
+    this.#responseOutstanding = false;
+    this.#audioDrained = false;
     // The caption is of speech, and the speech is over. Whatever ended the
     // reply — the audio draining, an error, the settle timer — the words leave
     // with the meter and the face rather than lingering under a quiet capsule.
@@ -1651,6 +1696,21 @@ export class RealtimeVoiceSession {
         return;
       case REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED:
         this.#audioEndingsReported = true;
+        // The audio can run out while the server still owes the reply its
+        // `done` — generation finishing and playback finishing have no fixed
+        // order — and until that `done` the conversation holds an active
+        // response. A turn ended here would offer READY to a caller with a
+        // reply to ask for — the announcer reading out a notice that queued
+        // behind this reply is the one that takes it — and the create it
+        // sends would be refused as a conversation already in progress, the
+        // refusal read out as a voice error and the notice lost. So the
+        // drain is remembered and the `done` ends the turn, with the settle
+        // backstop for a `done` that never comes.
+        if (this.#responseOutstanding) {
+          this.#audioDrained = true;
+          this.#armSettleTimer();
+          return;
+        }
         // The reply is over because the server says the audio ran out, not
         // because this end guessed from a stretch of quiet. A pause between two
         // sentences is quiet too, and guessing ended the turn in the middle of
@@ -1666,11 +1726,18 @@ export class RealtimeVoiceSession {
         // end that turn early: its calls are answered refused so the model is
         // not left waiting, and everything else about it is ignored.
         const fresh = event.responseId === this.#activeResponseId;
+        // Whatever this reply turns out to be below, the server has concluded
+        // it: from here the conversation can take a new `response.create`.
+        if (fresh) this.#responseOutstanding = false;
         // A reply that asked for tools has not finished talking: the calls are
         // answered and the reply resumes over their outcomes, so the turn stays
         // open rather than ending on a reply that was only half made.
         if (event.calls.length > 0) {
           void this.#answerToolCalls(event.calls, fresh && this.#toolTurnArmed);
+          // The spoken half's audio already drained — its ending deferred to
+          // this `done` — so the ending lands now, exactly as the drain would
+          // have made it; an armed follow-up re-opens the turn on its own.
+          if (fresh && this.#audioDrained) this.#finishResponse();
           return;
         }
         if (!fresh) return;
@@ -1689,6 +1756,13 @@ export class RealtimeVoiceSession {
         // being audible, which the caller reports from the audio itself rather
         // than from an event — the one that would say so is undocumented.
         this.#generationDone = true;
+        // The server said the audio ran out before it said the reply was
+        // over. That ending waited for this `done` — the conversation held
+        // an active response until it — and lands now.
+        if (this.#audioDrained) {
+          this.#finishResponse();
+          return;
+        }
         // The audio can run out before the event that says generation is over.
         // The meter has already reported its quiet and will not report it twice,
         // so waiting for another would hold the turn open until the settle
@@ -1697,10 +1771,7 @@ export class RealtimeVoiceSession {
           this.#finishResponse();
           return;
         }
-        this.#settleTimer ??= setTimeout(() => {
-          this.#settleTimer = undefined;
-          this.#finishResponse();
-        }, REALTIME_SETTLE_TIMEOUT_MS);
+        this.#armSettleTimer();
         return;
       }
       case REALTIME_SERVER_EVENT.CONVERSATION_ITEM_DELETED:
@@ -1716,7 +1787,16 @@ export class RealtimeVoiceSession {
         this.#options.onError(event.message);
         // An error can arrive *instead of* `response.done` — an empty push-to-talk
         // commit is the common case — which would otherwise leave the session
-        // stuck in `responding` and unable to take another turn.
+        // stuck in `responding` and unable to take another turn. But only a
+        // reply the server never confirmed ends this way: behind a confirmed
+        // one an error is an aside — the reply is still the server's, its own
+        // `done` still ends the turn, and ending it here would offer READY
+        // while the conversation still holds an active response. The settle
+        // backstop covers a `done` that never comes.
+        if (this.#activeResponseId !== undefined) {
+          this.#armSettleTimer();
+          return;
+        }
         this.#finishResponse();
     }
   }

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -460,11 +460,13 @@ export class RealtimeVoiceSession {
    */
   #toolTurnArmed = false;
   /**
-   * A monotonic id for the turn now under way, bumped whenever a new one
-   * begins. A tool follow-up captures it before awaiting the write and refuses
-   * to open if it has changed — the developer has taken the turn, or started
-   * another — so Luke never speaks the outcome over a live microphone or over
-   * a reply the developer is already hearing.
+   * A monotonic id for the turn now under way, bumped at every boundary a
+   * turn crosses — a new one beginning, or the old one declared over. A tool
+   * follow-up captures it before awaiting the write and refuses to open if it
+   * has changed — the developer has taken the turn, started another, or the
+   * turn ended without it, the settle backstop giving up on a hung write —
+   * so Luke never speaks the outcome over a live microphone, over a reply the
+   * developer is already hearing, or out of a silence already declared.
    */
   #turnEpoch = 0;
   /**
@@ -1351,6 +1353,10 @@ export class RealtimeVoiceSession {
     this.#responseOutstanding = false;
     this.#audioDrained = false;
     this.#followUpPending = false;
+    // The turn is over, and everything of it is spent — a write still in
+    // flight from it finds this boundary and stands down, rather than opening
+    // its follow-up out of a silence already declared.
+    this.#turnEpoch += 1;
     // No reply is current once the turn is over, and the arming went with the
     // turn: a `done` that outlives the settle backstop reads as a stranger's,
     // its calls answered refused rather than run as writes out of a turn the

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -377,6 +377,16 @@ export class RealtimeVoiceSession {
    */
   #audioDrained = false;
   /**
+   * Whether an armed reply's calls are being answered and the follow-up
+   * voicing their outcomes is still owed. The turn holds through the writes
+   * — a READY offered mid-write is the edge the announcer rides, and a reply
+   * taken there bumps the epoch and abandons the follow-up — so the audio
+   * draining then is remembered rather than an ending. Lowered by whatever
+   * reply comes next, the finish that ends the hold, or the interrupt of a
+   * developer moving on.
+   */
+  #followUpPending = false;
+  /**
    * Whether Luke has actually been heard during this reply. Committing a turn
    * swaps the meter from the microphone to Luke, and the meter reports quiet as
    * it lets go of the old stream — a silence that belongs to the developer, not
@@ -1048,6 +1058,7 @@ export class RealtimeVoiceSession {
     // active response above.
     this.#responseOutstanding = false;
     this.#audioDrained = false;
+    this.#followUpPending = false;
     this.#generationDone = false;
     this.#remoteQuiet = false;
     this.#heardLuke = false;
@@ -1152,6 +1163,7 @@ export class RealtimeVoiceSession {
     this.#clearIdleTimer();
     this.#responseOutstanding = false;
     this.#audioDrained = false;
+    this.#followUpPending = false;
     this.#generationDone = false;
     this.#remoteQuiet = false;
     this.#heardLuke = false;
@@ -1196,9 +1208,11 @@ export class RealtimeVoiceSession {
     this.#remoteQuiet = false;
     this.#heardLuke = false;
     // The reply now being asked for is the server's until it concludes it:
-    // nothing else may ask for one over it.
+    // nothing else may ask for one over it — and whatever follow-up was being
+    // waited on, this is the reply that answers or supersedes the wait.
     this.#responseOutstanding = true;
     this.#audioDrained = false;
+    this.#followUpPending = false;
     this.#clearQuietTimer();
     this.#responseItemId = undefined;
     // Nothing has been confirmed for this turn yet: whatever `response.done`
@@ -1336,6 +1350,7 @@ export class RealtimeVoiceSession {
     // comes cannot leave every later reply refused against it.
     this.#responseOutstanding = false;
     this.#audioDrained = false;
+    this.#followUpPending = false;
     // No reply is current once the turn is over, and the arming went with the
     // turn: a `done` that outlives the settle backstop reads as a stranger's,
     // its calls answered refused rather than run as writes out of a turn the
@@ -1712,7 +1727,11 @@ export class RealtimeVoiceSession {
         // refusal read out as a voice error and the notice lost. So the
         // drain is remembered and the `done` ends the turn, with the settle
         // backstop for a `done` that never comes.
-        if (this.#responseOutstanding) {
+        // An armed reply whose `done` has landed but whose follow-up is still
+        // owed holds the same way, in the mirror order: the write is under
+        // way, the READY an ending would offer is the same edge, and the
+        // `done` already gave the hold a clock of its own.
+        if (this.#responseOutstanding || this.#followUpPending) {
           this.#audioDrained = true;
           this.#armSettleTimer();
           return;
@@ -1740,14 +1759,26 @@ export class RealtimeVoiceSession {
         // open rather than ending on a reply that was only half made.
         if (event.calls.length > 0) {
           void this.#answerToolCalls(event.calls, fresh && this.#toolTurnArmed);
+          if (fresh && this.#toolTurnArmed) {
+            this.#followUpPending = true;
+            // The turn now holds for the follow-up, because the READY an
+            // ending here would offer while the writes run is the edge the
+            // announcer rides — a reply taken there bumps the epoch, and the
+            // follow-up voicing the outcome stands down against it, the
+            // developer's answer abandoned for a notice. The hold is the
+            // write's, so it gets a clock of its own: whatever backstop the
+            // drain or an aside armed was watching for this `done` and may
+            // have seconds left on it, while a write that hangs past a whole
+            // window still meets a backstop — a turn that never ends is
+            // worse than one that ends early.
+            this.#clearSettleTimer();
+            this.#armSettleTimer();
+            return;
+          }
           // The spoken half's audio already drained — its ending deferred to
-          // this `done`. A reply owing no follow-up ends here, exactly as the
-          // drain would have ended it; one that owes a follow-up keeps the
-          // turn, because the READY an ending would offer while the writes
-          // run is the edge the announcer rides — a reply taken there bumps
-          // the epoch, and the follow-up voicing the outcome stands down
-          // against it, the developer's answer abandoned for a notice.
-          if (fresh && this.#audioDrained && !this.#toolTurnArmed) this.#finishResponse();
+          // this `done`, and a reply owing no follow-up ends here, exactly
+          // as the drain would have ended it.
+          if (fresh && this.#audioDrained) this.#finishResponse();
           return;
         }
         if (!fresh) return;

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -1336,6 +1336,12 @@ export class RealtimeVoiceSession {
     // comes cannot leave every later reply refused against it.
     this.#responseOutstanding = false;
     this.#audioDrained = false;
+    // No reply is current once the turn is over, and the arming went with the
+    // turn: a `done` that outlives the settle backstop reads as a stranger's,
+    // its calls answered refused rather than run as writes out of a turn the
+    // developer was already told had ended.
+    this.#activeResponseId = undefined;
+    this.#toolTurnArmed = false;
     // The caption is of speech, and the speech is over. Whatever ended the
     // reply — the audio draining, an error, the settle timer — the words leave
     // with the meter and the face rather than lingering under a quiet capsule.
@@ -1735,9 +1741,13 @@ export class RealtimeVoiceSession {
         if (event.calls.length > 0) {
           void this.#answerToolCalls(event.calls, fresh && this.#toolTurnArmed);
           // The spoken half's audio already drained — its ending deferred to
-          // this `done` — so the ending lands now, exactly as the drain would
-          // have made it; an armed follow-up re-opens the turn on its own.
-          if (fresh && this.#audioDrained) this.#finishResponse();
+          // this `done`. A reply owing no follow-up ends here, exactly as the
+          // drain would have ended it; one that owes a follow-up keeps the
+          // turn, because the READY an ending would offer while the writes
+          // run is the edge the announcer rides — a reply taken there bumps
+          // the epoch, and the follow-up voicing the outcome stands down
+          // against it, the developer's answer abandoned for a notice.
+          if (fresh && this.#audioDrained && !this.#toolTurnArmed) this.#finishResponse();
           return;
         }
         if (!fresh) return;

--- a/apps/desktop/src/renderer/spoken-notices.ts
+++ b/apps/desktop/src/renderer/spoken-notices.ts
@@ -149,6 +149,12 @@ export class SpokenNoticeAnnouncer {
       while (this.#queue.length > 0 && session.speak(this.#queue[0] as AttentionSpeech)) {
         this.#queue.shift();
       }
+      // A backlog waiting on a refused speak is normally resumed by the READY
+      // edge, but that edge is the session's promise, not this class's: the
+      // retry clock keeps the backlog from depending on it. Redundant on the
+      // ordinary path — the edge lands first and says everything — and what
+      // stands between an announcement and permanent silence when it does not.
+      this.#armRetry();
       return;
     }
     if (session.isConnecting) return;

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -2660,6 +2660,113 @@ test("a tool outcome is not spoken over a turn the developer has taken", async (
   assert.equal(context.session.status, REALTIME_STATUS.LISTENING);
 });
 
+test("a drained tool reply holds the turn for the follow-up it owes", async () => {
+  let resolveWrite: ((output: Record<string, unknown>) => void) | undefined;
+  const context = harness({
+    carryAction: () =>
+      new Promise<Record<string, unknown>>((resolve) => {
+        resolveWrite = resolve;
+      }),
+  });
+  await context.session.connect();
+  context.session.updateSessions([observedSession("session-a", { canReceiveMessage: true })]);
+  await armDeveloperTurn(context);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-1" } });
+
+  // The spoken half's audio drains before the done that carries the calls.
+  context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: {
+      id: "resp-1",
+      output: [
+        {
+          type: "function_call",
+          name: "send_session_message",
+          call_id: "call-1",
+          arguments:
+            '{"provider_id":"claude-code","provider_session_id":"session-a","text":"add tests"}',
+        },
+      ],
+    },
+  });
+  await Promise.resolve();
+
+  // The turn holds through the write: the READY an ending here would offer is
+  // the edge the announcer rides, and a reply taken there would abandon the
+  // follow-up that is the outcome's only voice.
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+  assert.equal(context.session.speak(announcedFinish("session-b")), false);
+
+  resolveWrite?.({ status: "accepted" });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  // The follow-up opened: the outcome is voiced rather than abandoned.
+  assert.equal(
+    context.sent.filter((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE).length,
+    2,
+  );
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+});
+
+test("a done that outlives the settle backstop cannot act with the spent turn's arming", async (t) => {
+  const carried: unknown[] = [];
+  const context = harness({
+    carryAction: async (action) => {
+      carried.push(action);
+      return { status: "accepted" };
+    },
+  });
+  await context.session.connect();
+  context.session.updateSessions([observedSession("session-a", { canReceiveMessage: true })]);
+  await armDeveloperTurn(context);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-1" } });
+
+  // The audio drains, the done never follows, and the backstop ends the turn.
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED });
+  t.mock.timers.tick(REALTIME_SETTLE_TIMEOUT_MS);
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+  t.mock.timers.reset();
+
+  const sentBefore = context.sent.length;
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: {
+      id: "resp-1",
+      output: [
+        {
+          type: "function_call",
+          name: "send_session_message",
+          call_id: "call-1",
+          arguments:
+            '{"provider_id":"claude-code","provider_session_id":"session-a","text":"add tests"}',
+        },
+      ],
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  // The turn ended with the backstop and its arming went with it: the late
+  // calls are answered refused rather than run as writes out of a turn the
+  // developer was already told had ended, and no reply opens over the quiet.
+  assert.deepEqual(carried, []);
+  const events = context.sent.slice(sentBefore);
+  const output = events.find(
+    (event) => (event.item as { type?: string } | undefined)?.type === "function_call_output",
+  );
+  assert.equal(
+    (
+      JSON.parse((output?.item as { output?: string } | undefined)?.output ?? "{}") as {
+        status?: string;
+      }
+    ).status,
+    "refused",
+  );
+  assert.ok(!events.some((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE));
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+});
+
 test("the caption grows with the deltas and the final text supersedes them", async () => {
   const context = harness();
   await context.session.connect();

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -2801,6 +2801,59 @@ test("audio draining mid-write holds the turn the same way", async () => {
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
 });
 
+test("a write that outlives the backstop cannot speak out of the spent turn", async (t) => {
+  let resolveWrite: ((output: Record<string, unknown>) => void) | undefined;
+  const context = harness({
+    carryAction: () =>
+      new Promise<Record<string, unknown>>((resolve) => {
+        resolveWrite = resolve;
+      }),
+  });
+  await context.session.connect();
+  context.session.updateSessions([observedSession("session-a", { canReceiveMessage: true })]);
+  await armDeveloperTurn(context);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-1" } });
+
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: {
+      id: "resp-1",
+      output: [
+        {
+          type: "function_call",
+          name: "send_session_message",
+          call_id: "call-1",
+          arguments:
+            '{"provider_id":"claude-code","provider_session_id":"session-a","text":"add tests"}',
+        },
+      ],
+    },
+  });
+  await Promise.resolve();
+
+  // The write hangs past the whole window; the backstop declares the turn
+  // over, and the developer has been shown the silence.
+  t.mock.timers.tick(REALTIME_SETTLE_TIMEOUT_MS);
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+  t.mock.timers.reset();
+
+  const sentBefore = context.sent.length;
+  resolveWrite?.({ status: "accepted" });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  // The outcome is still delivered as an item, so the next turn has it...
+  const events = context.sent.slice(sentBefore);
+  assert.ok(
+    events.some(
+      (event) => (event.item as { type?: string } | undefined)?.type === "function_call_output",
+    ),
+  );
+  // ...but no reply opens out of a silence already declared.
+  assert.ok(!events.some((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE));
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+});
+
 test("a done that outlives the settle backstop cannot act with the spent turn's arming", async (t) => {
   const carried: unknown[] = [];
   const context = harness({

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -6,6 +6,7 @@ import {
   type AppGuideSnapshot,
   ATTENTION_DISPOSITION,
   ATTENTION_SPEECH_SOURCE,
+  type AttentionSpeech,
   CONTEXT_ITEM_KIND,
   ISSUE_TRACKER_ID,
   type NormalizedSession,
@@ -16,6 +17,7 @@ import {
   REALTIME_SERVER_EVENT,
   REALTIME_STATUS,
   type RealtimeConnection,
+  type RealtimeStatus,
   SESSION_STATUS,
   type TrackedIssue,
   WORKSPACE_TASK_SUPPORT,
@@ -24,11 +26,13 @@ import {
   type AppActionCarrier,
   type IssueActionCarrier,
   quietIsLukesOwn,
+  REALTIME_SETTLE_TIMEOUT_MS,
   REMOTE_QUIET_MS,
   RealtimeVoiceSession,
   type SessionActionCarrier,
   VOICE_IDLE_TIMEOUT_MS,
 } from "../src/renderer/realtime-session";
+import { SpokenNoticeAnnouncer } from "../src/renderer/spoken-notices";
 
 const CONNECTION: RealtimeConnection = {
   value: "ek_test_secret",
@@ -112,6 +116,8 @@ function harness(
     carryAppAction?: AppActionCarrier;
     carryIssueAction?: IssueActionCarrier;
     idleTimeoutMs?: number;
+    /** Lets a test ride the status edges, the way the announcer does. */
+    onStatus?: (status: RealtimeStatus) => void;
   } = {},
 ): Harness {
   const timers: HeldTimer[] = [];
@@ -239,7 +245,7 @@ function harness(
     ...(options.carryAction ? { carryAction: options.carryAction } : {}),
     ...(options.carryAppAction ? { carryAppAction: options.carryAppAction } : {}),
     ...(options.carryIssueAction ? { carryIssueAction: options.carryIssueAction } : {}),
-    onStatus: () => undefined,
+    onStatus: (status) => options.onStatus?.(status),
     onLocalStream: () => undefined,
     onRemoteStream: () => undefined,
     onError: (message) => errors.push(message),
@@ -626,6 +632,146 @@ test("the reply ends when the server says the audio ran out", async () => {
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
 
   context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED });
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+});
+
+/** A proactive update on the announcer's terms, decided a moment ago. */
+function announcedFinish(id: string): AttentionSpeech {
+  return {
+    providerId: "claude-code",
+    providerSessionId: id,
+    disposition: ATTENTION_DISPOSITION.SPEAK_AT_TURN_END,
+    source: ATTENTION_SPEECH_SOURCE.STATUS_EDGE,
+    summary: `session: '${id}'; event: finished`,
+    decidedAt: Date.now(),
+  };
+}
+
+test("audio draining before response.done does not free the turn early", async () => {
+  const context = harness();
+  await context.session.connect();
+  await holdTurn(context);
+  context.session.endTurn(true);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-1" } });
+
+  // The audio runs out while the server still owes the reply its done —
+  // generation finishing and playback finishing have no fixed order. Until
+  // that done the conversation holds an active response, and a turn ended
+  // here offers READY to callers with a reply of their own to ask for.
+  context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED });
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+
+  // The announcement that queued behind the reply is refused rather than
+  // sent: the create it would open is the one the service refuses as a
+  // conversation already in progress, surfacing the refusal as a voice error
+  // with the notice lost behind it.
+  assert.equal(context.session.speak(announcedFinish("session-a")), false);
+  assert.equal(
+    context.sent.filter((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE).length,
+    1,
+  );
+
+  // The server concluding the reply is what ends the turn — the drain's
+  // deferred ending lands with the done — and only then is the next reply
+  // welcome.
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_DONE, response: { id: "resp-1" } });
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+  assert.equal(context.session.speak(announcedFinish("session-a")), true);
+  assert.deepEqual(reportedErrors(context), []);
+});
+
+test("an announcement queued mid-reply waits out the server's own ending", async () => {
+  // The reported shape of the fault, whole: Luke is reading one announcement
+  // out on his own call when another agent finishes. The second announcement
+  // must wait for the server to conclude the first reply — not for the audio
+  // alone — or its create collides with the active response.
+  let announcer: SpokenNoticeAnnouncer | undefined;
+  const context = harness({ onStatus: (status) => announcer?.onStatus(status) });
+  const timers: (() => void)[] = [];
+  announcer = new SpokenNoticeAnnouncer({
+    session: () => context.session,
+    schedule: (callback) => {
+      timers.push(callback);
+      return timers.length - 1;
+    },
+    cancel: () => undefined,
+  });
+
+  announcer.enqueue([announcedFinish("session-a")]);
+  // The call the announcer opens for itself is a handshake away.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-1" } });
+
+  // The second agent finishes mid-reply, and then the first reply's audio
+  // drains before its done arrives.
+  announcer.enqueue([announcedFinish("session-b")]);
+  context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED });
+
+  // One reply asked for so far: the drain freed nothing, so the READY edge
+  // the announcer rides has not fired into the server's open response.
+  assert.equal(
+    context.sent.filter((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE).length,
+    1,
+  );
+
+  // The server concludes the first reply, and the second speaks on that edge.
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_DONE, response: { id: "resp-1" } });
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+  assert.equal(
+    context.sent.filter((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE).length,
+    2,
+  );
+  assert.deepEqual(reportedErrors(context), []);
+});
+
+test("a done that never follows the drained audio still ends the turn", async (t) => {
+  const context = harness();
+  await context.session.connect();
+  await holdTurn(context);
+  context.session.endTurn(true);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-1" } });
+
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED });
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+
+  // A turn that never ends is worse than one that ends early: the settle
+  // backstop closes what the missing done left open.
+  t.mock.timers.tick(REALTIME_SETTLE_TIMEOUT_MS);
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+});
+
+test("an error behind a confirmed reply does not end the turn under it", async () => {
+  const context = harness();
+  await context.session.connect();
+  await holdTurn(context);
+  context.session.endTurn(true);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-1" } });
+
+  // An aside mid-reply — a refused truncate, a warning — is surfaced, but the
+  // reply is still the server's: ending the turn on it is what offered READY
+  // while the conversation still held an active response.
+  context.emit({ type: REALTIME_SERVER_EVENT.ERROR, error: { message: "An aside" } });
+  assert.ok(context.errors.includes("An aside"));
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+
+  // The reply's own ending still ends it.
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_DONE, response: { id: "resp-1" } });
+  context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED });
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+});
+
+test("a reply the server refused outright still frees the turn at its error", async () => {
+  const context = harness();
+  await context.session.connect();
+  const spoken = context.session.speak(announcedFinish("session-a"));
+  assert.equal(spoken, true);
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+
+  // No response.created ever came: the error is the create's own refusal,
+  // and it is all the ending this reply will get.
+  context.emit({ type: REALTIME_SERVER_EVENT.ERROR, error: { message: "Rate limited" } });
   assert.equal(context.session.status, REALTIME_STATUS.READY);
 });
 

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -2709,6 +2709,98 @@ test("a drained tool reply holds the turn for the follow-up it owes", async () =
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
 });
 
+test("the write's hold gets a clock of its own, not the drain's leftovers", async (t) => {
+  const context = harness({
+    carryAction: () => new Promise<Record<string, unknown>>(() => undefined),
+  });
+  await context.session.connect();
+  context.session.updateSessions([observedSession("session-a", { canReceiveMessage: true })]);
+  await armDeveloperTurn(context);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-1" } });
+
+  // The drain arms a backstop for the missing done, and nearly spends it.
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED });
+  t.mock.timers.tick(REALTIME_SETTLE_TIMEOUT_MS - 1);
+
+  // The done it was watching for arrives, carrying calls: the hold that
+  // follows is the write's, not the tail of the drain's clock.
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: {
+      id: "resp-1",
+      output: [
+        {
+          type: "function_call",
+          name: "send_session_message",
+          call_id: "call-1",
+          arguments:
+            '{"provider_id":"claude-code","provider_session_id":"session-a","text":"add tests"}',
+        },
+      ],
+    },
+  });
+  await Promise.resolve();
+
+  // The drain's leftover second must not cut the hold mid-write...
+  t.mock.timers.tick(1);
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+
+  // ...while a write that hangs past a whole window still meets the backstop:
+  // a turn that never ends is worse than one that ends early.
+  t.mock.timers.tick(REALTIME_SETTLE_TIMEOUT_MS);
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+});
+
+test("audio draining mid-write holds the turn the same way", async () => {
+  let resolveWrite: ((output: Record<string, unknown>) => void) | undefined;
+  const context = harness({
+    carryAction: () =>
+      new Promise<Record<string, unknown>>((resolve) => {
+        resolveWrite = resolve;
+      }),
+  });
+  await context.session.connect();
+  context.session.updateSessions([observedSession("session-a", { canReceiveMessage: true })]);
+  await armDeveloperTurn(context);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-1" } });
+
+  // The ordinary order: the done carrying the calls lands while the spoken
+  // half is still audible, and the audio drains during the write.
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: {
+      id: "resp-1",
+      output: [
+        {
+          type: "function_call",
+          name: "send_session_message",
+          call_id: "call-1",
+          arguments:
+            '{"provider_id":"claude-code","provider_session_id":"session-a","text":"add tests"}',
+        },
+      ],
+    },
+  });
+  await Promise.resolve();
+  context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED });
+
+  // The same hold, in the mirror order: no READY edge mid-write for the
+  // announcer to take the turn on.
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+  assert.equal(context.session.speak(announcedFinish("session-b")), false);
+
+  resolveWrite?.({ status: "accepted" });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  // The follow-up opened: the outcome is voiced rather than abandoned.
+  assert.equal(
+    context.sent.filter((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE).length,
+    2,
+  );
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+});
+
 test("a done that outlives the settle backstop cannot act with the spent turn's arming", async (t) => {
   const carried: unknown[] = [];
   const context = harness({

--- a/apps/desktop/tests/spoken-notices.test.ts
+++ b/apps/desktop/tests/spoken-notices.test.ts
@@ -315,6 +315,31 @@ test("a backlog stranded by a call that ended is picked up by the retry clock", 
   );
 });
 
+test("a notice refused mid-reply keeps a clock of its own beside the READY edge", () => {
+  const session = fakeSession();
+  session.microphone = true;
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  // Arrives mid-reply and is refused the turn. The READY edge is the
+  // session's promise, not this class's, so the backlog arms its own retry
+  // rather than depending on that edge alone.
+  subject.enqueue([speech("a")]);
+  assert.deepEqual(session.spoken, []);
+  assert.equal(timers.armed(), 1);
+  assert.deepEqual(timers.delays, [ANNOUNCER_RETRY_DELAY_MS]);
+
+  // The edge never lands; the clock fires into a call that has since settled
+  // and the notice is spoken rather than stranded.
+  session.setStatus(REALTIME_STATUS.READY);
+  timers.fire();
+  assert.deepEqual(
+    session.spoken.map((item) => item.providerSessionId),
+    ["a"],
+  );
+});
+
 test("a sentence that went stale in the queue is dropped, not read as news", () => {
   const session = fakeSession();
   session.setStatus(REALTIME_STATUS.RESPONDING);


### PR DESCRIPTION
## The fault

With voice on, a session announcement could surface the raw service error **"Conversation is already in progress. Wait till that one is done to start a new one."** on the caption strip, and the announcement itself was never spoken. Reproduced when Luke is responding — reading one announcement out, most often — and another agent finishes, queueing a second announcement behind the reply.

## Root cause

The client's side of a turn could settle before the server's. `output_audio_buffer.stopped` ended the turn unconditionally, but generation finishing and playback finishing have no fixed order: when a reply's audio drained **before** its `response.done` arrived, the session went READY while the conversation still held an active response. The announcer rides exactly that READY edge (`SpokenNoticeAnnouncer.onStatus` → `flush` → `speak`), so the queued announcement's `response.create` was sent into the server's open response. The service refuses that with the quoted error, which reached the developer verbatim through `onError`, and the announcement was shifted off the queue as though spoken — read out never.

The mid-reply `error` handler had the same shape at one remove: any aside behind a confirmed reply called `#finishResponse()` and offered the same false READY.

## The fix

The turn now ends only once the server has concluded the reply:

- A drain that beats the `done` is remembered (`#audioDrained`) and its ending lands with the `done` — the turn still closes on the second of the two events, whichever order they arrive in. The settle backstop covers a `done` that never comes.
- `response.done` lowers a new `#responseOutstanding` flag wherever it ends up below (spoken reply, silent reply, tool calls), and only an unconfirmed reply's error — the empty push-to-talk commit — still substitutes for a missing `done`; an error behind a confirmed reply is surfaced without ending the turn under it.
- The announcer arms its own retry clock behind a refused `speak`, so a backlog no longer depends on the READY edge alone.

## Tests

New tests were written first and fail on the unfixed code (5 failures, including the whole reported shape: a real `SpokenNoticeAnnouncer` wired to the session's status edges sends a second `response.create` into the server's open response), and pass with the fix:

- `audio draining before response.done does not free the turn early`
- `an announcement queued mid-reply waits out the server's own ending`
- `a done that never follows the drained audio still ends the turn`
- `an error behind a confirmed reply does not end the turn under it`
- `a reply the server refused outright still frees the turn at its error` (pins the empty-commit unstick)
- `a notice refused mid-reply keeps a clock of its own beside the READY edge`

## Verification

- `./scripts/check.sh` — passed (repository contract checks, types, all 1022 desktop tests + core/web suites, builds).
- No UI, motion, or macOS-surface change — nothing drawn changes — so no visual evidence applies and no physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ae4d69d7-7947-4c5a-80b8-028ab5e4a235)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32099286287/artifacts/9311012252) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32099286287)

- Commit: `66dbca5f79aeab23928f9f564d61715f3b72edde`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
