### PR TITLE
chore(release): bump version to 0.1.1

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@luke/desktop",
   "productName": "Luke",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Luke desktop application",
   "main": "dist/main.js",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luke/web",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "description": "Luke landing page",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luke",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "A notch-attached desktop sidecar for coding-agent sessions",
   "packageManager": "pnpm@9.15.0",

--- a/packages/sidecar-core/package.json
+++ b/packages/sidecar-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -48,11 +48,11 @@ function packagerOptions(signing = resolveSigningMode({})) {
     licensePath: `/repo/apps/desktop/.build/${LICENSE_RESOURCE_NAME}`,
     entitlementsPath,
     signing,
-    version: "0.1.0",
+    version: "0.1.1",
   });
 }
 
-test("workspace package versions agree on v0.1.0", () => {
+test("workspace package versions agree on v0.1.1", () => {
   const packagePaths = [
     "package.json",
     "apps/desktop/package.json",
@@ -65,7 +65,7 @@ test("workspace package versions agree on v0.1.0", () => {
 
   assert.deepEqual(
     versions.map(({ version }) => version),
-    packagePaths.map(() => "0.1.0"),
+    packagePaths.map(() => "0.1.1"),
   );
 });
 


### PR DESCRIPTION
## Summary
- Bump every workspace package.json (root, `apps/desktop`, `apps/web`, `packages/sidecar-core`) from `0.1.0` to `0.1.1`
- Update `scripts/packaging.test.mjs`'s hardcoded version assertions to match

## Why
Preparing to cut the next release. The release scripts (`pnpm release:macos`, `scripts/release/publish-github.sh`) and CI's tag-triggered workflow require the tag to exactly match `apps/desktop/package.json`, and `scripts/packaging.test.mjs` asserts every workspace package agrees on the same version.

## Test plan
- [x] `./scripts/check.sh` — repository checks, typecheck, 1016 tests, build all pass
- [ ] After merge: `git tag v0.1.1 && git push origin v0.1.1`, then either let CI's Apple-secrets gate run it or cut manually with `pnpm release:macos` + `scripts/release/publish-github.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32099268600/artifacts/9311013219) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32099268600)

- Commit: `e3848b27ab297afff971b83c4fe44133d42c1403`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
