### PR TITLE
fix(release): bootstrap dependencies before checks

### DIFF
--- a/scripts/release-macos.sh
+++ b/scripts/release-macos.sh
@@ -17,6 +17,7 @@ if [[ -z "${GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET:-}" ]]; then
     exit 1
 fi
 
+"$SCRIPT_DIRECTORY/bootstrap.sh"
 "$SCRIPT_DIRECTORY/check.sh"
 
 cd "$SIDECAR_REPO_ROOT"

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -34,6 +34,15 @@ import { DMG_WINDOW } from "../design/dmg-window.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
+test("manual releases install the locked dependencies before checking the workspace", () => {
+  const releaseScript = fs.readFileSync(path.join(repoRoot, "scripts", "release-macos.sh"), "utf8");
+  const bootstrapCall = releaseScript.indexOf('"$SCRIPT_DIRECTORY/bootstrap.sh"');
+  const checkCall = releaseScript.indexOf('"$SCRIPT_DIRECTORY/check.sh"');
+
+  assert.notEqual(bootstrapCall, -1);
+  assert.ok(bootstrapCall < checkCall);
+});
+
 test("release DMG names include the desktop version and packaged architecture", () => {
   const desktopPackage = JSON.parse(
     fs.readFileSync(path.join(repoRoot, "apps", "desktop", "package.json"), "utf8"),


### PR DESCRIPTION
## Summary

- install the exact locked workspace dependencies before manual release checks
- cover the bootstrap-before-check ordering with a release regression test

## Evidence

- Platform-independent checks: `./scripts/bootstrap.sh && ./scripts/check.sh` passed
- macOS Electron verification (`./scripts/verify.sh`): `not required (release orchestration only; no macOS app or UI behavior changed)`

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32100140203/artifacts/9311284394) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32100140203)

- Commit: `363de99e53c0fee728add10f91f7e9040fa86ee8`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed; no UI change`
- Device/display configuration: `not applicable`

## Notes

- Fixes manual releases that run after pulling a lockfile with newly added packages while retaining stale `node_modules`.
- The local full check emitted existing Biome warnings and the Node 24 warning for `apps/web`, but completed successfully.