### PR TITLE
docs: adopt Stage's code-comment guidance and clean comments to match

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -425,6 +425,28 @@ Rules the guide must keep:
   whether a provider is connected. The guide leaves the machine, so nothing in
   it may carry a key, a key's shape, or an environment variable's value.
 
+## Code comments
+
+No unnecessary comments. Make the code obvious and immediately understandable
+on its own — prefer explicit over clever — and let a comment carry only what
+the code cannot: a constraint, a boundary, or the reason the obvious
+alternative is wrong. The rationale prose already throughout this repository is
+the bar; a comment that meets it earns its line, and one that does not is
+noise.
+
+- Never narrate. A comment that restates the adjacent code — what the next
+  line does, what a function is named, what a parameter takes — repeats what
+  the reader can already see. Delete it, or make the code say what it was
+  trying to say.
+- Describe the code as it stands, never the edit that produced it. A comment
+  about what moved, what it replaced, or why the change is correct is
+  addressed to a reviewer and goes stale the moment it lands; that story
+  belongs in the commit message.
+- No commented-out code. Delete it; history keeps it.
+- A comment the toolchain demands must still explain: a `biome-ignore` states
+  why the rule is wrong at that line, and a `SETTING_GUIDE` entry returning
+  `undefined` states how the guide covers the setting instead.
+
 ## TypeScript value sets and keys
 
 - Do not use stringly typed fixed value sets. Define `as const`

--- a/apps/desktop/src/conductor-adapter.ts
+++ b/apps/desktop/src/conductor-adapter.ts
@@ -621,12 +621,10 @@ export class ConductorSessionAdapter
       if (!settled) settledWorkspaceIds.delete(session.workspace.id);
     });
 
-    // One row per chat, each grouped under its workspace. Two chats used to
-    // collapse into one row because their generated names drew as identical
-    // lines — but the workspace grouping now names the group once, which
-    // leaves each chat free to say what it alone is doing, be opened where it
-    // alone lives, and take the message meant for it rather than for whichever
-    // sibling most needed a person.
+    // One row per chat, each grouped under its workspace. The grouping names
+    // the workspace once, which leaves each chat free to say what it alone is
+    // doing, be opened where it alone lives, and take the message meant for it
+    // rather than for whichever sibling most needed a person.
     return sessions
       .map((session, index) =>
         this.#observationFor(
@@ -733,8 +731,8 @@ export class ConductorSessionAdapter
         }
         const model = modelLabel(record);
         const deepLink = textFromRecord(record, CONDUCTOR_FIELD.DEEP_LINK);
-        // The chat's own name tells it from its siblings now that every chat
-        // is a row of its own; the workspace's name moved to the group.
+        // The chat's own name tells it from its siblings; the workspace's
+        // name belongs to the group.
         const name = textFromRecord(record, CONDUCTOR_FIELD.NAME)?.slice(
           0,
           maximumSessionTitleLength,
@@ -935,8 +933,7 @@ export class ConductorSessionAdapter
       sessionId,
       CONDUCTOR_ROUTE_SEGMENT.STATUS,
     ]);
-    // A session that failed says why, and dropping that left the panel showing
-    // a failed chat as though nothing had happened to it. `lastError` is the
+    // A session that failed says why. `lastError` is the
     // last failure this session ever had rather than its current state, so both
     // are read only while the session is actually reporting an error: otherwise
     // a chat that recovered hours ago would keep showing the failure it

--- a/apps/desktop/src/hotkey-registrar.ts
+++ b/apps/desktop/src/hotkey-registrar.ts
@@ -55,9 +55,8 @@ export interface HotkeyRegistrarOptions {
 /**
  * Owns the talk, ask, and stop keys and the pecking order between them.
  *
- * Eight pieces of state that used to live beside each other in the main
- * process — the registered chord, the stored choice, and the talk-key helper —
- * are one reservation table here: `reserve` is the answer the settings
+ * The registered chord, the stored choice, and the talk-key helper are one
+ * reservation table here: `reserve` is the answer the settings
  * handlers ask instead of re-deriving who sits on a chord, and `reapply`
  * is the one operation that knows `unregisterAll` takes the lower keys down
  * and puts them back in rank order.
@@ -219,7 +218,7 @@ export class HotkeyRegistrar {
         this.#send(this.#voiceHostContents(), channels.voiceHotkeyPress);
         // A toggle has only the one edge, so it reports a release immediately and
         // one short enough to read as a tap. Every press then latches or ends a
-        // turn, which is the old behaviour exactly.
+        // turn.
         this.#send(this.#voiceHostContents(), channels.voiceHotkeyRelease);
       });
       if (!registered) continue;

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -573,7 +573,7 @@ function broadcastAccount(): void {
 
 /**
  * Tells every panel what an account transition just did to the settings.
- * `voiceAvailable` rides the settings snapshot and now moves with the account
+ * `voiceAvailable` rides the settings snapshot and moves with the account
  * — a sign-in carries the hosted allowance, a sign-out takes it — but the
  * transitions themselves only broadcast `accountChanged`, so without this the
  * renderer keeps drawing the voice state of the account it no longer has.
@@ -892,16 +892,6 @@ function warmHostedVoice(): void {
 }
 
 /**
- * Reads the OpenAI key and rebuilds everything that runs on it.
- *
- * This is the whole of turning voice on and off. It runs once at startup and
- * again on every change to that key, so a key pasted into the panel takes effect
- * where it was pasted rather than on the next launch — and a key deleted there
- * takes voice away just as immediately, ephemeral secret included. The talk key
- * is not moved here: only a change while the app is running needs that, and
- * `hotkeys.reapply` is what does it.
- */
-/**
  * The seams the hosted clients reach the account through. The token is read
  * fresh from the store on every use — the lifecycle owns rotation — and a 401
  * asks that same lifecycle for a refresh rather than growing a second one.
@@ -919,6 +909,16 @@ function hostedServiceSeams() {
   };
 }
 
+/**
+ * Reads the OpenAI key and rebuilds everything that runs on it.
+ *
+ * This is the whole of turning voice on and off. It runs once at startup and
+ * again on every change to that key, so a key pasted into the panel takes effect
+ * where it was pasted rather than on the next launch — and a key deleted there
+ * takes voice away just as immediately, ephemeral secret included. The talk key
+ * is not moved here: only a change while the app is running needs that, and
+ * `hotkeys.reapply` is what does it.
+ */
 async function applyVoiceCredential(): Promise<void> {
   // A fixture run does not ask for the key at all: reading a stored one means a
   // Keychain decrypt, which a run that would refuse to use it has no business
@@ -2480,9 +2480,9 @@ async function reviewSessionAttention(generation = observationGeneration): Promi
   try {
     // Only sessions still worth a row are worth a model call: an attention
     // decision about a session with no row surfaces nowhere, and the registry
-    // holds every conversation ever observed — reviewing all of it sent an
-    // update about each one to OpenAI on every launch, hundreds of requests
-    // that rate-limited the same key the voice opens calls with.
+    // holds every conversation ever observed — reviewing all of it would send
+    // an update about each one to OpenAI on every launch, hundreds of requests
+    // rate-limiting the same key the voice opens calls with.
     const reviews = await attentionReviewer.review(
       rosterRelevantSessions(sessionRegistry.list(), Date.now()),
     );
@@ -2497,7 +2497,7 @@ async function reviewSessionAttention(generation = observationGeneration): Promi
       // An answered standing ask opens Luke's own call the way a status edge
       // does, so the meeting quiet holds it the same way; the summaries that
       // only ride an open conversation pass, because a developer mid-call is
-      // already talking to Luke, meeting or not. The pressable notice now
+      // already talking to Luke, meeting or not. The pressable notice
       // anchors to the spoken announcement, so it waits out the quiet with it.
       let sendable: readonly AttentionSpeech[] = speech;
       if (await announcementsQuietNow(Date.now())) {
@@ -2747,13 +2747,6 @@ let lastRosterRevision = -1;
 let lastRosterIds = "";
 
 /**
- * Hands the renderer the sessions still worth a row. The registry keeps every
- * observation — announcements and attention read it whole — but the panel and
- * the voice roster it feeds see only what `isRosterRelevant` keeps: adapters
- * no longer age out or cap anything, so this one gate is where a session that
- * settled long ago stops being a row.
- */
-/**
  * Hands every panel the standing asks as they now stand, so the rows marking
  * them never describe an ask already withdrawn or let go. The words are the
  * developer's own; nothing here reaches a provider or leaves the machine.
@@ -2762,6 +2755,13 @@ function broadcastNoticeAsks(): void {
   panels.broadcast(channels.noticeAsksChanged, attentionRequests.list());
 }
 
+/**
+ * Hands the renderer the sessions still worth a row. The registry keeps every
+ * observation — announcements and attention read it whole — but the panel and
+ * the voice roster it feeds see only what `isRosterRelevant` keeps: adapters
+ * age out and cap nothing, so this one gate is where a session that settled
+ * long ago stops being a row.
+ */
 function broadcastRelevantSessions(): void {
   const snapshot = sessionRegistry.snapshot();
   const roster = rosterRelevantSessions(snapshot.sessions, Date.now());

--- a/apps/desktop/src/openai-realtime-credentials.ts
+++ b/apps/desktop/src/openai-realtime-credentials.ts
@@ -250,9 +250,8 @@ export class OpenAiRealtimeCredentialMinter {
  * Explains why no minter exists, which is the state the panel shows as "voice
  * unavailable". Distinguishing a missing key from a fixture run matters: they
  * look identical from the UI and have completely different fixes. Whether a key
- * resolved is passed in rather than read here, because it can now come from the
- * settings store as well as from the environment and only the caller knows
- * which.
+ * resolved is passed in rather than read here, because it comes from either the
+ * settings store or the environment and only the caller knows which.
  */
 export function unavailableRealtimeDiagnostics(input: {
   fixtureMode: boolean;

--- a/apps/desktop/src/panel-manager.ts
+++ b/apps/desktop/src/panel-manager.ts
@@ -344,7 +344,7 @@ export class PanelManager {
    * Resizes without AppKit's frame animation. An animated setBounds re-lays out
    * the renderer at a new viewport width on every frame — and its duration scales
    * with the distance moved, so a 482px growth ran far longer than the panel's
-   * own motion. The window now snaps to the size the mode needs and the renderer
+   * own motion. The window instead snaps to the size the mode needs and the renderer
    * animates the capsule into the panel inside it, where the viewport is constant
    * and the work stays on the compositor.
    */

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -548,7 +548,7 @@ export function App(): React.JSX.Element {
     expand,
   } = usePanelPresentation({
     // True while a field someone could be part-way through is actually on
-    // screen. An entry outlives the tab it was started on now, so holding the
+    // screen. An entry outlives the tab it was started on, so holding the
     // panel open for one that is not drawn would leave the pointer unable to
     // close a panel showing nothing but sessions.
     entryDrawn: () => credentialHeld.current && tabNow() === PANEL_TAB.SETTINGS,
@@ -1384,7 +1384,7 @@ export function App(): React.JSX.Element {
    * a flight whose shape goes out from under it is cut short where it stands.
    *
    * Every beat is acted on, with no test for whether the flight reporting it is
-   * still the current one. There is no such thing as a stale flight any more —
+   * still the current one. There is no such thing as a stale flight —
    * a second act waits its turn rather than overtaking the one in the air — and
    * a guard here would be worse than redundant: this is what advances the run,
    * so a beat it declined to act on would strand every act still waiting and

--- a/apps/desktop/src/renderer/ask-luke.tsx
+++ b/apps/desktop/src/renderer/ask-luke.tsx
@@ -202,9 +202,9 @@ export function AskLuke({
               event.currentTarget.blur();
               return;
             }
-            // Enter is the send a one-line field taught, kept now the field
+            // Enter is the send a one-line field taught, kept though the field
             // wraps; Shift-Enter is the line break, the way every chat
-            // composer splits the two. A textarea's Enter no longer submits
+            // composer splits the two. A textarea's Enter does not submit
             // the form on its own, so the send is asked for here — but not
             // mid-composition: an IME's Enter is choosing a character, not
             // taking a turn.

--- a/apps/desktop/src/renderer/luke-face-mood.ts
+++ b/apps/desktop/src/renderer/luke-face-mood.ts
@@ -195,8 +195,8 @@ const IDLE_ASIDES: readonly WeightedAside[] = [
 
 /**
  * The sway is the one gesture in the pool that means something, so it is in the
- * pool only while what it means is true. It is how work still reads on the face
- * now that nothing rocks for as long as work runs: often enough to notice that
+ * pool only while what it means is true. It is how work reads on a face that
+ * plays no continuous motion while work runs: often enough to notice that
  * something is happening, seldom enough that the face is mostly still.
  */
 const WORKING_ASIDE: WeightedAside = { motion: FACE_MOTION.MONITORING, weight: 18 };

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -814,9 +814,8 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
               `default restored, in ${SHORTCUTS_PAGE}.`,
           },
           {
-            // A behavior rather than a setting since the switch was retired:
-            // stated here so Luke neither denies announcing nor offers to
-            // turn it off.
+            // A behavior rather than a setting: stated here so Luke neither
+            // denies announcing nor offers to turn it off.
             label: "Announcements",
             detail:
               "Luke says it out loud when an observed session starts waiting on the developer, " +

--- a/apps/desktop/src/renderer/microphone-access.ts
+++ b/apps/desktop/src/renderer/microphone-access.ts
@@ -67,7 +67,7 @@ export function currentQuota(quota: HostedQuota | undefined, now: number): Hoste
 
 /**
  * How a meter reads at a glance: running, getting close, or gone. Three
- * states rather than the two a spent flag carried, because a ceiling nobody
+ * states rather than a spent-or-not flag's two, because a ceiling nobody
  * saw coming is the one thing a meter exists to prevent — the warning has to
  * arrive while there is still something left to spend differently.
  */
@@ -188,7 +188,7 @@ export function hostedVoiceNote(
     diagnostics?.lastOutcome === REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED &&
     (diagnostics.quota === undefined || currentQuota(diagnostics.quota, now) !== undefined);
   if (spentStands) return hostedVoiceSpentNote();
-  // What a key of your own would change is not said here any more: the toggle
+  // What a key of your own would change is not said here: the toggle
   // above draws both sources side by side, with what each costs on its face,
   // and a sentence repeating one of them would be selling the other.
   return "Talking and session checks are included free with your account, up to a daily amount.";

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -150,7 +150,7 @@ function SessionRowActions({
 }: {
   session: DisplaySession;
   /** The actions this row draws itself: inside a tray, the workspace-level
-   * ones have moved to the tray's own header. */
+   * ones live in the tray's own header. */
   actions: readonly SessionAction[];
   writes: SessionWriteHandlers;
 }): React.JSX.Element {

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -250,9 +250,9 @@ function sessionNeedsAttention(session: NormalizedSession): boolean {
  * outranks the recap of a turn that has already ended.
  *
  * When a provider reported none of them, the line says the state in so many
- * words. This sentence is the one place the row states it — there is no chip at
- * the other end any more — so a session whose provider said nothing still reads
- * as Working or Complete rather than as a row with a line missing.
+ * words. This sentence is the one place the row states it, so a session whose
+ * provider said nothing still reads as Working or Complete rather than as a
+ * row with a line missing.
  */
 function sessionDetail(session: NormalizedSession, urgency: SessionUrgency): string {
   const flaggedSummary =

--- a/apps/desktop/src/renderer/settings-icons.tsx
+++ b/apps/desktop/src/renderer/settings-icons.tsx
@@ -241,7 +241,6 @@ export function MicrophoneIcon(): React.JSX.Element {
   );
 }
 
-/** Drawn rather than typed: a ↗ character depends on a font having one. */
 /** Heads the Updates section: the arrival a newer release waits as. */
 export function DownloadIcon(): React.JSX.Element {
   return (
@@ -253,6 +252,7 @@ export function DownloadIcon(): React.JSX.Element {
   );
 }
 
+/** Drawn rather than typed: a ↗ character depends on a font having one. */
 export function ExternalIcon(): React.JSX.Element {
   return (
     <Glyph className="link-icon">

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -1682,7 +1682,7 @@ function VoiceSection({
   });
   return (
     <>
-      {/* The key row lives with the account on the front page now — voice's
+      {/* The key row lives with the account on the front page — voice's
           two ways in stand together there. This page holds what voice does
           once it runs; while it cannot run, the one section says where to
           turn it on rather than drawing settings for a feature two steps

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -484,8 +484,8 @@ html[data-keyboard="true"] button.session-row:focus-visible {
   outline-offset: -3px;
 }
 
-/* The mark stands bare. The tile it used to sit in was the one box on the row
-   that carried no information — a hairline square inside a hairline card — and
+/* The mark stands bare — no tile around it: a hairline square inside a
+   hairline card would be the one box on the row carrying no information, and
    the mark's own colour and silhouette are the identification. The slot keeps a
    fixed size so every title starts on the same column whatever shape the mark
    is, and so the cloud badge has a corner to hold whichever mark it rides. */
@@ -790,7 +790,7 @@ html[data-keyboard="true"] button.session-row:focus-visible {
   text-align: left;
 }
 
-/* The whole openable row is the press target now, controls excepted, so the
+/* The whole openable row is the press target, controls excepted, so the
    whole row takes the hand and the lift. The one place neither belongs is a
    pointer that is on a control: a press there is about the message or the
    action, and a lift under it would promise a window it will not open. */

--- a/apps/desktop/src/renderer/styles/settings.css
+++ b/apps/desktop/src/renderer/styles/settings.css
@@ -62,8 +62,8 @@
   color: var(--text-secondary);
   font-size: 11.5px;
   font-weight: 620;
-  /* Arrival on the stack's stagger, feedback with none. The order no longer
-     matters to anything outside this declaration. */
+  /* Arrival on the stack's stagger, feedback with none. The order matters to
+     nothing outside this declaration. */
   transition:
     opacity var(--duration-exit) var(--motion-exit) var(--row-delay),
     transform var(--duration-shape) var(--spring) var(--row-delay),

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -575,7 +575,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   }, []);
 
   // Voice arriving and voice going away. It is not read from bootstrap, because
-  // it is no longer only true of a launch: a key entered in the panel turns a
+  // it is not only true of a launch: a key entered in the panel turns a
   // session that reported itself unavailable into one that can connect, without a
   // relaunch — and deleting that key has to close whatever call is open rather
   // than leave a live microphone answering a talk key the main process has
@@ -733,7 +733,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       // Luke's own speak-only call cannot carry a typed ask — it was sent no
       // roster to validate one against — so it counts as no call here, and
       // `connect` inside stands it down for the developer's own. A microphone
-      // call still connecting is awaited exactly as before.
+      // call still connecting is awaited, not doubled.
       if (!session.isConnected || !session.microphoneCall) {
         microphone = await startMicrophone();
       }

--- a/apps/desktop/src/shared/voice-hotkey.ts
+++ b/apps/desktop/src/shared/voice-hotkey.ts
@@ -11,10 +11,9 @@
  *
  * Option-Space is where a macOS user reaches for a voice assistant —
  * Superwhisper, the ChatGPT desktop app and Alfred all sit there. It stands
- * alone: Option-S used to be its fallback, and was given to the stop key
- * instead — S is for stop, and a talk key that sometimes lands on the stop
- * key's chord would make which key does what depend on what else is
- * installed.
+ * alone, with no fallback chord: S is for stop, and a talk key that sometimes
+ * lands on the stop key's chord would make which key does what depend on what
+ * else is installed.
  */
 export const DEFAULT_VOICE_HOTKEYS: readonly string[] = ["Alt+Space"];
 

--- a/apps/desktop/tests/conductor-adapter.test.ts
+++ b/apps/desktop/tests/conductor-adapter.test.ts
@@ -1122,8 +1122,8 @@ test("lets a crowded workspace keep every chat beside its quiet neighbour", asyn
   const observations = await adapterFor(api.fetch).observe();
   const observedIds = observations.map((observation) => observation.providerSessionId);
 
-  // A crowded workspace no longer costs anyone anything: all of its chats are
-  // rows, and its quiet neighbour's chat is one too.
+  // A crowded workspace costs no one anything: all of its chats are rows, and
+  // its quiet neighbour's chat is one too.
   assert.equal(observedIds.filter((id) => id.startsWith("crowded-")).length, 8);
   assert.equal(observedIds.includes("quiet-session"), true);
   assert.equal(observations.length, 9);

--- a/apps/desktop/tests/errand-queue.test.ts
+++ b/apps/desktop/tests/errand-queue.test.ts
@@ -91,8 +91,8 @@ test("a second act waits its turn rather than taking the first out of the air", 
   assert.equal(armed.launch, first);
   assert.equal(armed.run.flying, first);
 
-  // The whole of the fix: while one is out, nothing else is handed to the
-  // flight. A second errand handed over here re-identifies the one in the air,
+  // While one is out, nothing else is handed to the flight. A second errand
+  // handed over here re-identifies the one in the air,
   // which ends it before it has left the strip.
   const overtaking = nextErrand(armed.run);
   assert.equal(overtaking.launch, undefined);

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -220,8 +220,8 @@ test("the facts say what is connected, never what connects it", () => {
   assert.match(connected, /Google Calendar \(2 accounts connected\)/);
   assert.match(connected, /checkboxes under each account/);
   // The voice key stands in a fact of its own, placed where its row actually
-  // lives: the What Luke runs on section, not the Voice page or the Integrations
-  // section it once shared with Linear. With voice available and no key
+  // lives: the What Luke runs on section, not the Voice page or the
+  // Integrations section. With voice available and no key
   // connected, the fact says whose allowance voice runs on — and what a key
   // of your own would cost instead; with voice unavailable, it says both ways
   // in.

--- a/apps/desktop/tests/microphone-access.test.ts
+++ b/apps/desktop/tests/microphone-access.test.ts
@@ -200,7 +200,7 @@ test("the numberless note stays short, and withholds the key from a machine that
   // What a key of the developer's own would change is the toggle's to say,
   // drawn directly above with the price on its face. A sentence here repeating
   // it would be the panel selling one half of a choice it is already showing
-  // whole — and it was worded for a key row that no longer stands alone.
+  // whole.
   assert.doesNotMatch(hostedVoiceNote(undefined), /OpenAI/);
 
   // Only the minter's last outcome can speak here — a spent allowance is a

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -1661,7 +1661,7 @@ test("connecting the voice key chooses it, and the allowance can take it back", 
   assert.equal(await store.readVoiceSource(), VOICE_SOURCE.KEY);
 
   // And back again, with the key still stored — the whole point of the
-  // choice. Before it existed, the only way back was deleting the key.
+  // choice: changing sources never costs a credential.
   await store.setVoiceSource(VOICE_SOURCE.ACCOUNT);
   assert.equal(await store.readVoiceSource(), VOICE_SOURCE.ACCOUNT);
   assert.equal(
@@ -1683,9 +1683,8 @@ test("a choice that would start spending a key is never made by fallback", async
   assert.equal(await store.readVoiceSource(), VOICE_SOURCE.ACCOUNT);
 
   // Signed out, the allowance they chose cannot answer. The stored key is
-  // what is left, so voice keeps working exactly as it did before the choice
-  // existed — the fallback that costs nothing is the account's, and this one
-  // only runs when the free half has gone.
+  // what is left, so voice keeps working — the fallback that costs nothing
+  // is the account's, and this one only runs when the free half has gone.
   await store.clearAccount();
   assert.equal(await store.readVoiceSource(), VOICE_SOURCE.KEY);
 
@@ -1704,8 +1703,8 @@ test("the chosen source survives a reopen, and a corrupt one reads as no choice"
   assert.equal(await storeIn(directory).readVoiceSource(), VOICE_SOURCE.ACCOUNT);
 
   // A source this build does not offer is dropped rather than carried, and
-  // dropping it lands on the behaviour that existed before the field did:
-  // whichever credential is there, the key first.
+  // dropping it lands where no choice lands: whichever credential is there,
+  // the key first.
   const contents = JSON.parse(await readSettingsFile(directory));
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),

--- a/apps/desktop/tests/settings-views.test.ts
+++ b/apps/desktop/tests/settings-views.test.ts
@@ -49,9 +49,7 @@ test("a credential entry returns to the page its row is drawn on", () => {
 
 test("every stand-down comes back to the page its own row is drawn on", () => {
   // A note is written from the Feedback section on the front page, so leaving
-  // the composer — or the thank-you a send lands in — belongs there. It went
-  // to Connections for as long as all three shapes shared one remembered
-  // page, which only ever held whichever key row was last opened.
+  // the composer — or the thank-you a send lands in — belongs there.
   assert.equal(
     standDownReturnPage({ kind: PANEL_STAND_DOWN.FEEDBACK }),
     SETTINGS_VIEW.ROOT,
@@ -72,8 +70,8 @@ test("every stand-down comes back to the page its own row is drawn on", () => {
     );
   }
 
-  // No two of them can be the same rule read from the same place: the whole
-  // bug was one page standing in for three.
+  // No two of them can be the same rule read from the same place: one
+  // remembered page cannot stand in for three.
   const pages = new Set([
     standDownReturnPage({ kind: PANEL_STAND_DOWN.FEEDBACK }),
     standDownReturnPage({ kind: PANEL_STAND_DOWN.CALENDAR }),

--- a/apps/desktop/tests/voice-hotkey.test.ts
+++ b/apps/desktop/tests/voice-hotkey.test.ts
@@ -20,7 +20,7 @@ import {
 
 test("the default is the chord a macOS voice assistant is reached for", () => {
   // Option-Space is where Superwhisper, the ChatGPT desktop app and Alfred
-  // sit. It stands alone: Option-S belongs to the stop key now, and a talk
+  // sit. It stands alone: Option-S belongs to the stop key, and a talk
   // key that sometimes fell back onto it would make which key does what
   // depend on what else is installed.
   assert.deepEqual(DEFAULT_VOICE_HOTKEYS, ["Alt+Space"]);

--- a/apps/web/src/NotchMock.tsx
+++ b/apps/web/src/NotchMock.tsx
@@ -337,7 +337,7 @@ export function NotchMock(): React.JSX.Element {
   return (
     <div className="mock-scroll" ref={scrollSection}>
       <div className="mock-pin" ref={pin}>
-        {/* One labelled image, like the old mock: nothing inside is a control,
+        {/* One labelled image: nothing inside is a control,
             so the whole recreation reads as a single illustration. The hidden
             stage stays inert so find-in-page cannot match invisible titles and
             a drag cannot select text nobody can see. */}

--- a/apps/web/src/auth-surface.ts
+++ b/apps/web/src/auth-surface.ts
@@ -25,8 +25,7 @@ export const AUTH_PILL =
 
 /**
  * `cursor-pointer` is carried here rather than inherited: Tailwind's preflight
- * leaves a button on the user agent's own arrow, where the sheet this replaced
- * reset every button to a pointer.
+ * leaves a button on the user agent's own arrow.
  */
 export const AUTH_BUTTON =
   "min-h-[46px] cursor-pointer rounded-md border border-border bg-card font-semibold transition-[background-color,transform] duration-150 hover:not-disabled:-translate-y-px hover:not-disabled:bg-muted disabled:cursor-wait disabled:opacity-[0.56] motion-reduce:transition-none";

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -258,9 +258,9 @@
 
   /* Luke's surface is pure black and the page around it is not, so the mock is
      the one dark object on a light page and every token it draws with has to
-     be declared here. These were the page's until the page went light:
-     inherited now, white-on-white becomes black-on-black and the interior
-     disappears. The frame is the display the capsule is cut into, which is why
+     be declared here: inherited from the light page, white-on-white becomes
+     black-on-black and the interior disappears. The frame is the display the
+     capsule is cut into, which is why
      it alone is allowed to end on the page's own ground. */
   --text-secondary: rgba(255, 255, 255, 0.56);
   --hairline: rgba(255, 255, 255, 0.08);

--- a/design/generate-brand-assets.mjs
+++ b/design/generate-brand-assets.mjs
@@ -1061,7 +1061,6 @@ function emitModes(baseName, svgWithCurrentColor, title) {
   }
 }
 
-// Static mark and wordmark, per mode.
 emitModes("luke-mark", tightMarkSvg(face()), "Luke");
 emitModes("luke-wordmark", wordSvg(wordmark()), "LUKE");
 
@@ -1152,7 +1151,6 @@ const dmg =
   `fill="none" stroke="#6e6e73" stroke-width="16" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
 emit("dmg/luke-dmg-background.svg", dmg, "Drag Luke to Applications");
 
-// Animated state marks, per mode.
 for (const name of MOTION_NAMES) {
   emitModes(`motion/luke-${name}`, markSvg(motionSvg(MOTIONS[name])), `Luke — ${name}`);
 }

--- a/packages/sidecar-core/src/attention.ts
+++ b/packages/sidecar-core/src/attention.ts
@@ -136,9 +136,9 @@ export interface AttentionUpdate extends SessionIdentity {
   title: string;
   /**
    * The workspace the session is one chat of, by name, when its provider
-   * groups them. A deliberate widening: this name used to leave the machine as
-   * the title itself when a workspace was one row, and a readout that cannot
-   * say which workspace a chat belongs to cannot identify the work out loud.
+   * groups them. A deliberate widening of what leaves the machine: a readout
+   * that cannot say which workspace a chat belongs to cannot identify the
+   * work out loud.
    */
   workspace?: string;
   status: SessionStatus;

--- a/packages/sidecar-core/src/fixtures.ts
+++ b/packages/sidecar-core/src/fixtures.ts
@@ -156,8 +156,8 @@ const smokeFixture: FixtureSnapshot = {
     },
     // A fifth session keeps every state and every provider mark visible in the
     // one screenshot the visual evidence is reviewed from. It is also one more
-    // provider than the wings hold now that the face has the place nearest the
-    // housing, so the same screenshot proves the remainder is counted rather
+    // provider than the wings hold — the face has the place nearest the
+    // housing — so the same screenshot proves the remainder is counted rather
     // than dropped. Reporting a repository and no branch, it is also the row
     // that shows the identifier line falling back.
     {

--- a/packages/sidecar-core/src/realtime-tools.ts
+++ b/packages/sidecar-core/src/realtime-tools.ts
@@ -757,10 +757,9 @@ function validateOpenFeedbackComposer(
   if (!isFeedbackComposerKind(composer)) {
     return { kind: "refused", reason: "The composer writes feedback or a prompt, nothing else." };
   }
-  // The draft is the developer's ask restated, so it is bounded like a typed
-  // one; a blank draft is no draft, and the composer simply opens empty.
-  // Same bound as maximumFeedbackDraftLength: the draft is the developer's
-  // ask restated in their words, not a document.
+  // The draft is the developer's ask restated in their words, not a document,
+  // so it is bounded like a typed one; a blank draft is no draft, and the
+  // composer simply opens empty.
   const draft = textArgument(parsed, "draft")?.slice(0, maximumSessionMessageLength);
   return { kind: APP_TOOL_KIND.FEEDBACK, composer, ...(draft ? { draft } : {}) };
 }

--- a/packages/sidecar-core/src/session-registry.ts
+++ b/packages/sidecar-core/src/session-registry.ts
@@ -40,9 +40,9 @@ function copySession(session: NormalizedSession): NormalizedSession {
  * over `T` on purpose: a new field does not compile until someone decides how
  * it compares.
  *
- * Comparators are collected once at module load, then walked with the same
- * short-circuit as the old `&&` chain, so `#commit` still does one field
- * compare per key rather than serializing the session on every observation.
+ * Comparators are collected once at module load, then walked with an `&&`
+ * chain's short-circuit, so `#commit` does one field compare per key rather
+ * than serializing the session on every observation.
  */
 function exhaustiveSame<T extends object>(
   equality: Record<keyof T, (first: T, second: T) => boolean>,

--- a/packages/sidecar-core/src/session.ts
+++ b/packages/sidecar-core/src/session.ts
@@ -54,7 +54,7 @@ export const OBSERVATION_WINDOW = {
 
 /**
  * How long a status keeps its session on the roster, measured from the moment
- * the status was entered. This is what bounds the roster now that no adapter
+ * the status was entered. This is the one bound on the roster — no adapter
  * ages out or caps its sessions: relevance follows what the status asks of the
  * user, never a blanket clock over every conversation. A failure does not heal
  * by going stale, but a rescue nobody made for days is a session the user has

--- a/packages/sidecar-core/tests/guide.test.ts
+++ b/packages/sidecar-core/tests/guide.test.ts
@@ -144,7 +144,7 @@ test("the standing instructions promise the guide the context actually delivers"
   const instructions = realtimeInstructions();
   assert.match(instructions, /\[app guide\]/);
   assert.match(instructions, /change_app_setting/);
-  // The guide now carries each setting's default, and the instructions must
+  // The guide carries each setting's default, and the instructions must
   // say what it is for: an ask for the default is a change to that value.
   assert.match(instructions, /its current value, its default/);
   assert.match(instructions, /a change to the default the guide lists/);

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -65,10 +65,10 @@ node "$SIDECAR_REPO_ROOT/design/generate-surface-shared.mjs" --check
 # Every relative import inside sidecar-core must carry its .js extension.
 # Vercel's builder compiles the package's TypeScript into the web functions
 # but leaves the specifiers alone, and Node's ESM loader refuses an
-# extensionless one at run time — a break the build cannot see, which has
-# twice reached production as FUNCTION_INVOCATION_FAILED (#202, and again
-# with app-update). The desktop's esbuild and the web's Vite both accept the
-# .js form, so the stricter spelling costs the other consumers nothing.
+# extensionless one at run time — a break the build cannot see and production
+# reports only as FUNCTION_INVOCATION_FAILED. The desktop's esbuild and the
+# web's Vite both accept the .js form, so the stricter spelling costs the
+# other consumers nothing.
 extensionless_imports=$(grep -rEn 'from "\.\.?/[^"]*"' "$SIDECAR_REPO_ROOT/packages/sidecar-core/src" |
     grep -vE '\.(js|css)"' || true)
 if [[ -n "$extensionless_imports" ]]; then


### PR DESCRIPTION
## What

Adapts the code-comment guidance from [ReviewStage/stage's AGENTS.md](https://github.com/ReviewStage/stage) — "no unnecessary comments," code obvious on its own, a comment carrying only what the code cannot show — into a **Code comments** section of our own AGENTS.md, written to this repository's existing rationale-prose style, and cleans the codebase's comments up to that bar.

## The new guidance

- A comment carries only what the code cannot show: a constraint, a boundary, or the reason the obvious alternative is wrong.
- Never narrate the adjacent code.
- Describe the code as it stands, never the edit that produced it — that story belongs in the commit message.
- No commented-out code.
- Toolchain-required comments (`biome-ignore`, `SETTING_GUIDE` `undefined` entries) must still explain.

## The cleanup

Four sweeps covered the desktop main process, the renderer, all tests, and packages/web/design/scripts (~310 files). The codebase's rationale style already held almost everywhere — no narration, no commented-out code, no stale TODOs. What the sweeps found, and this PR fixes:

- **~35 change-talk comments**: comments defining behavior by reference to a removed design ("the old `&&` chain", "the sheet this replaced", "Option-S used to be its fallback"), framing invariants as bug fixes ("the whole bug was", "the whole of the fix"), or carrying a stray "now"/"no longer"/"any more". Each was rewritten to state the standing rule, keeping the rationale and dropping the history.
- **4 misattached doc comments**: two JSDoc blocks in `main.ts` stranded above the wrong function (`applyVoiceCredential`, `broadcastRelevantSessions`) and the ↗-glyph comment in `settings-icons.tsx` sitting on `DownloadIcon` instead of `ExternalIcon` — moved onto their subjects.
- **2 narration comments** in `design/generate-brand-assets.mjs` restating the calls below them — deleted (generator body only; all generated outputs are unchanged, `--check` passes).
- One incident-history comment in `repository-checks.sh` trimmed to the standing constraint, keeping the searchable `FUNCTION_INVOCATION_FAILED` token.

Deliberately kept: section banners that serve as navigation in the long generators, and privacy-boundary notes like `attention.ts`'s "a deliberate widening" (reworded to stand without history).

## Verification

Portable-only change: `./scripts/check.sh` passes (exit 0 — repository checks including both generators' `--check`, types, tests, and builds). No UI or macOS behavior change; no visual evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/97edcd32-4aee-4360-aa50-e8f732f6f2ed)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32100950852/artifacts/9311537436) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32100950852)

- Commit: `e3815f842cbe8c6f67fbde9c53570a2f0966ec34`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
