### PR TITLE
fix(desktop): keep development builds out of the release's Keychain entry

### DIFF
--- a/apps/desktop/scripts/build.mjs
+++ b/apps/desktop/scripts/build.mjs
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
+import { signingModeDefine } from "./package-config.mjs";
 
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const appRoot = path.resolve(scriptDirectory, "..");
@@ -41,6 +42,10 @@ await Promise.all([
       PACKAGED_GOOGLE_CALENDAR_CLIENT_SECRET: JSON.stringify(
         process.env.GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET ?? "",
       ),
+      // Whether this bundle rides in a Developer ID release, which is what
+      // decides the name — and so the state directory and Keychain entry —
+      // the run answers to; see app-identity.ts.
+      ...signingModeDefine(process.env),
     },
     sourcemap: true,
     logLevel: "info",

--- a/apps/desktop/scripts/package-config.mjs
+++ b/apps/desktop/scripts/package-config.mjs
@@ -75,6 +75,22 @@ export function resolveSigningMode(env) {
   return identity ? { mode: SIGNING_MODE.DEVELOPER_ID, identity } : { mode: SIGNING_MODE.AD_HOC };
 }
 
+/**
+ * The esbuild define telling the bundle whether it was built alongside
+ * Developer ID packaging, read by app-identity.ts to decide which name — and
+ * so which state directory and Keychain entry — the run answers to. Derived
+ * from the same environment `resolveSigningMode` reads so the flag and the
+ * signature it stands for come from one place; only the fact travels, never
+ * the identity's name.
+ */
+export function signingModeDefine(env) {
+  return {
+    PACKAGED_WITH_DEVELOPER_ID_SIGNING: JSON.stringify(
+      resolveSigningMode(env).mode === SIGNING_MODE.DEVELOPER_ID,
+    ),
+  };
+}
+
 export function createPackagerOptions({
   appRoot,
   outputRoot,

--- a/apps/desktop/src/app-identity.ts
+++ b/apps/desktop/src/app-identity.ts
@@ -1,0 +1,60 @@
+/**
+ * Which Luke a process is: the released app, or a development run standing in
+ * for it. The two carry different code signatures — a release is signed with
+ * the Developer ID identity, while `electron .` runs under the Electron dev
+ * binary's own signature and a locally packaged app is signed ad-hoc — and
+ * macOS binds a Keychain item to the signature of the program that created
+ * it. A differently signed program reading the same item is treated as an
+ * intruder: the login-keychain password dialog appears, twice for a plain
+ * "Allow". So a development run must never share the release's Keychain
+ * entry, and the state directory holding the ciphertexts moves with it —
+ * a settings file one identity wrote names credentials only that identity's
+ * Keychain entry can open.
+ *
+ * The name decides both: Electron derives the state directory and the
+ * `<name> Safe Storage` Keychain entry from the app's name, so answering to
+ * a different name is the whole separation. Only a build packaged and signed
+ * for release answers to the product name; every other run — unpackaged, or
+ * packaged without the release identity — answers to the development name.
+ */
+
+export const RELEASE_APP_NAME = "Luke";
+
+/**
+ * Derived from the release name rather than freestanding, because
+ * `scripts/lib/workspace.sh` derives it the same way to find a development
+ * instance's single-instance lock; the app-identity test holds them together.
+ */
+export const DEVELOPMENT_APP_NAME = `${RELEASE_APP_NAME} Dev`;
+
+export interface AppIdentityContext {
+  /** Whether this process runs from a packaged bundle rather than `electron .`. */
+  packaged: boolean;
+  /** Whether the bundle was built alongside Developer ID packaging. */
+  developerIdSigned: boolean;
+}
+
+/**
+ * The name this run answers to. Both facts must hold for the product name:
+ * a bundle built for release but launched unpackaged runs under the Electron
+ * dev binary's signature, which is exactly the mismatch the split exists to
+ * prevent.
+ */
+export function resolveAppName({ packaged, developerIdSigned }: AppIdentityContext): string {
+  return packaged && developerIdSigned ? RELEASE_APP_NAME : DEVELOPMENT_APP_NAME;
+}
+
+/**
+ * Baked by `build.mjs` from the same environment `resolveSigningMode` reads,
+ * in the same `pnpm package` run, so the flag and the signature it stands for
+ * cannot come apart. Absent under tsx — tests and tooling run the sources
+ * directly — which reads as a development build, like every other unsigned run.
+ */
+declare const PACKAGED_WITH_DEVELOPER_ID_SIGNING: boolean | undefined;
+
+/** Whether this bundle was built alongside Developer ID packaging. */
+export function buildCarriesDeveloperIdSigning(): boolean {
+  return (
+    typeof PACKAGED_WITH_DEVELOPER_ID_SIGNING === "boolean" && PACKAGED_WITH_DEVELOPER_ID_SIGNING
+  );
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -83,6 +83,7 @@ import {
   startAccountLoopback,
 } from "./account-loopback";
 import { singleFlight, withIssuedAccountTokens } from "./account-token-lifecycle";
+import { buildCarriesDeveloperIdSigning, resolveAppName } from "./app-identity";
 import { CLAUDE_CODE_PROVIDER, ClaudeCodeSessionAdapter } from "./claude-code-adapter";
 import {
   CLAUDE_HOOK_SCRIPT_NAME,
@@ -172,6 +173,23 @@ import {
 import { parseVoiceHotkey } from "./shared/voice-hotkey";
 import { isWorkspaceAgentSelection } from "./shared/workspace-agents";
 import { UPDATE_ENDPOINT, UpdateService } from "./update-service";
+
+// Which Luke this process is decides where its state lives and which Keychain
+// entry protects its credentials; see app-identity.ts for why a development
+// run must never share the release's. Applied before anything derives a path:
+// the single-instance lock, the settings store, and the hook spools all live
+// under this name.
+const appName = resolveAppName({
+  packaged: app.isPackaged,
+  developerIdSigned: buildCarriesDeveloperIdSigning(),
+});
+app.setName(appName);
+// `setName` renames the app, not the paths Electron already derived from the
+// manifest name, so the state directory is pointed at the chosen name by
+// hand — and session data alongside it, since its default only follows a
+// `userData` that has not been resolved yet.
+app.setPath("userData", path.join(app.getPath("appData"), appName));
+app.setPath("sessionData", path.join(app.getPath("appData"), appName));
 
 const captureOutput = argumentValue("--capture-evidence");
 const profile = argumentValue("--profile") ?? "idle";

--- a/apps/desktop/tests/app-identity.test.ts
+++ b/apps/desktop/tests/app-identity.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import test from "node:test";
+import {
+  buildCarriesDeveloperIdSigning,
+  DEVELOPMENT_APP_NAME,
+  RELEASE_APP_NAME,
+  resolveAppName,
+} from "../src/app-identity";
+
+test("only a packaged Developer ID build answers to the product name", () => {
+  assert.equal(resolveAppName({ packaged: true, developerIdSigned: true }), RELEASE_APP_NAME);
+});
+
+test("a packaged build without the release identity answers to the development name", () => {
+  // An ad-hoc signature changes with every build, so sharing the release's
+  // Keychain entry would poison it for the released app.
+  assert.equal(resolveAppName({ packaged: true, developerIdSigned: false }), DEVELOPMENT_APP_NAME);
+});
+
+test("an unpackaged run answers to the development name whatever it was built for", () => {
+  // `electron .` runs under the Electron dev binary's signature even when the
+  // bundle itself was built alongside Developer ID packaging.
+  assert.equal(resolveAppName({ packaged: false, developerIdSigned: true }), DEVELOPMENT_APP_NAME);
+  assert.equal(resolveAppName({ packaged: false, developerIdSigned: false }), DEVELOPMENT_APP_NAME);
+});
+
+test("sources run directly read as a development build", () => {
+  // Under tsx the baked define does not exist, and that absence must land on
+  // the development identity rather than throwing or claiming the release's.
+  assert.equal(buildCarriesDeveloperIdSigning(), false);
+});
+
+test("the names hold to the manifest and to the shell derivation", async () => {
+  const manifest: unknown = JSON.parse(
+    await fs.readFile(new URL("../package.json", import.meta.url), "utf8"),
+  );
+  const { productName } = manifest as { productName?: string };
+  // The release name is Electron's own default — the manifest's product name —
+  // so a release build setting it changes nothing about where released state
+  // already lives.
+  assert.equal(RELEASE_APP_NAME, productName);
+  // scripts/lib/workspace.sh derives the development instance's lock directory
+  // as "<product name> Dev"; this is the pin that keeps the two together.
+  assert.equal(DEVELOPMENT_APP_NAME, `${productName} Dev`);
+});
+
+test("main.ts applies the identity before the lock that lives under it", async () => {
+  const main = await fs.readFile(new URL("../src/main.ts", import.meta.url), "utf8");
+  const named = main.indexOf("app.setName(appName)");
+  assert.notEqual(named, -1, "main.ts must set the resolved app name");
+  // `setName` alone leaves the state directory on the manifest name, so both
+  // paths that hold state must be pointed at the chosen name too.
+  assert.ok(main.includes('app.setPath("userData"'), "main.ts must repoint userData");
+  assert.ok(main.includes('app.setPath("sessionData"'), "main.ts must repoint sessionData");
+  // The single-instance lock is written into the state directory, so taking it
+  // before the identity is applied would guard the wrong instance.
+  const locked = main.indexOf("app.requestSingleInstanceLock()");
+  assert.notEqual(locked, -1, "main.ts must take the single-instance lock");
+  assert.ok(named < locked, "the identity must be applied before the lock is taken");
+});

--- a/scripts/lib/workspace.sh
+++ b/scripts/lib/workspace.sh
@@ -57,16 +57,24 @@ sidecar_wait_for_exit() {
 # itself. That is the process to replace even when it belongs to another
 # worktree: the lock is keyed on the app name, which every checkout shares.
 #
-# That name has to be derived the way Electron derives it, since Electron is what
-# chose the directory: `productName` when the manifest sets one, and the package
-# name only when it does not.
-sidecar_app_lock_holder_pid() {
+# The app chooses its own name at launch — the product name for a Developer ID
+# release, and "<product name> Dev" for every development run, so the two never
+# share a Keychain entry (see apps/desktop/src/app-identity.ts). Each name keeps
+# a lock of its own, so a caller replacing "the running instance" asks about
+# both. The product name is still derived the way Electron derives its default,
+# from the manifest: `productName` when it sets one, the package name otherwise.
+sidecar_app_names() {
     local app_name
     if ! app_name=$(cd "$SIDECAR_DESKTOP_APP_ROOT" &&
         node -p 'const manifest = require("./package.json"); manifest.productName ?? manifest.name'); then
         printf 'error: could not read the desktop app name\n' >&2
         return 1
     fi
+    printf '%s Dev\n%s\n' "$app_name" "$app_name"
+}
+
+sidecar_app_lock_holder_pid() {
+    local app_name=$1
 
     local lock_target
     lock_target=$(readlink "$HOME/Library/Application Support/$app_name/SingletonLock" 2>/dev/null || true)
@@ -86,35 +94,42 @@ sidecar_app_lock_holder_pid() {
         printf '%s\n' "$pid"
         ;;
     *)
-        printf 'error: pid %s holds the Luke lock but is not Luke: %s\n' "$pid" "$command_line" >&2
+        printf 'error: pid %s holds the "%s" lock but is not Luke: %s\n' "$pid" "$app_name" "$command_line" >&2
         return 1
         ;;
     esac
 }
 
-# Stopping the holder has to wait for it to exit, because the lock is released
-# as that process goes away rather than when it is signalled.
+# Stopping a holder has to wait for it to exit, because the lock is released
+# as that process goes away rather than when it is signalled. Development and
+# release instances hold separate locks, so both are stopped: a launch means
+# "this build owns the screen now", whichever build was there before.
 sidecar_stop_running_app() {
-    local pid
-    pid=$(sidecar_app_lock_holder_pid) || return 1
-    if [[ -z $pid ]]; then
-        return 0
-    fi
+    local app_names
+    app_names=$(sidecar_app_names) || return 1
 
-    # The path tells you which checkout the older instance came from.
-    printf 'Stopping the running Luke instance (pid %s: %s)\n' "$pid" "$(ps -o comm= -p "$pid")"
-    kill "$pid" 2>/dev/null || true
-    if sidecar_wait_for_exit 5 "$pid"; then
-        return 0
-    fi
+    local app_name pid
+    while IFS= read -r app_name; do
+        pid=$(sidecar_app_lock_holder_pid "$app_name") || return 1
+        if [[ -z $pid ]]; then
+            continue
+        fi
 
-    kill -KILL "$pid" 2>/dev/null || true
-    if sidecar_wait_for_exit 3 "$pid"; then
-        return 0
-    fi
+        # The path tells you which checkout the older instance came from.
+        printf 'Stopping the running %s instance (pid %s: %s)\n' "$app_name" "$pid" "$(ps -o comm= -p "$pid")"
+        kill "$pid" 2>/dev/null || true
+        if sidecar_wait_for_exit 5 "$pid"; then
+            continue
+        fi
 
-    printf 'error: the running Luke instance did not exit; quit it and retry\n' >&2
-    return 1
+        kill -KILL "$pid" 2>/dev/null || true
+        if sidecar_wait_for_exit 3 "$pid"; then
+            continue
+        fi
+
+        printf 'error: the running %s instance did not exit; quit it and retry\n' "$app_name" >&2
+        return 1
+    done <<<"$app_names"
 }
 
 sidecar_require_macos() {

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -16,6 +16,7 @@ import {
   resolveSigningMode,
   SIGNING_MODE,
   SWIFT_TARGET_TRIPLE,
+  signingModeDefine,
   swiftCompilerArguments,
 } from "../apps/desktop/scripts/package-config.mjs";
 import { NATIVE_HELPERS, packagedAppExecutable } from "../apps/desktop/scripts/package-layout.mjs";
@@ -267,6 +268,22 @@ test("signing configuration separates ad-hoc and Developer ID modes", () => {
     hardenedRuntime: true,
     entitlements: entitlementsPath,
   });
+});
+
+test("the baked signing define mirrors the signing mode and carries no identity", () => {
+  // app-identity.ts reads this define to decide which name — and so which
+  // state directory and Keychain entry — a run answers to, so it must say
+  // Developer ID exactly when the packager signs with one.
+  assert.deepEqual(signingModeDefine({}), { PACKAGED_WITH_DEVELOPER_ID_SIGNING: "false" });
+  const defined = signingModeDefine({
+    LUKE_CODESIGN_IDENTITY: "Developer ID Application: X (TEAM)",
+  });
+  assert.deepEqual(defined, { PACKAGED_WITH_DEVELOPER_ID_SIGNING: "true" });
+  // Only the fact travels into the bundle: a boolean literal, never the
+  // identity's own name.
+  for (const value of Object.values(defined)) {
+    assert.equal(value.includes("Developer ID"), false);
+  }
 });
 
 test("release entitlements allow required capabilities without unsigned executable memory", () => {


### PR DESCRIPTION
## What happened

First-time users of the released DMG were asked for their login-keychain password twice at first launch. The dialog is macOS protecting the `Luke Safe Storage` Keychain item: a development run — `electron .` under the Electron dev binary's signature, or an ad-hoc-signed package — answered to the released app's own name, so signing into one created that item bound to a signature the released app does not carry, and left account/key ciphertexts in the release's own settings file. The released, Developer-ID-signed app then decrypted the stored account at launch, and macOS treats a differently signed program reading another program's item as an intruder — prompting twice for a plain "Allow" ([Apple's documented double-prompt behavior](https://developer.apple.com/forums/thread/747190)). A machine with no dev history sees no prompt at all: with nothing stored the launch touches no Keychain, and the first sign-in creates the item silently.

## The fix

Only a build packaged and signed with the Developer ID identity answers to the product name. Every other run answers to **"Luke Dev"**, with its own state directory and its own `Luke Dev Safe Storage` entry, so neither build can ever poison the other's:

- `app-identity.ts` resolves the name from `app.isPackaged` and a boolean baked by `build.mjs` from the same environment the packager's signing mode reads (`LUKE_CODESIGN_IDENTITY`); only the fact travels, never the identity.
- `main.ts` applies the name and repoints `userData`/`sessionData` before anything derives a path — the settings store, the single-instance lock, and the hook spools all live under it.
- `scripts/lib/workspace.sh` stops a running instance under either name, since the two now hold separate single-instance locks.

## Consequences worth knowing

- Development sign-ins and keys move to "Luke Dev" and are entered again once — the same precedent as #50.
- A machine a pre-fix dev build signed into still holds the foreign item beside the release's settings file; one "Always Allow", or `security delete-generic-password -s "Luke Safe Storage"` plus removing `~/Library/Application Support/Luke`, settles it.
- On a machine running both builds, the observation-hook registration points at whichever build launched last; the other degrades to transcript-only observation until its next launch.

## Verification

- `./scripts/check.sh` passes: 1033 desktop tests including six new app-identity tests (identity truth table, tsx fallback, name pins against `productName` holding the shell derivation together, and a main.ts ordering pin), plus a packaging test that the baked define mirrors the signing mode and carries no identity.
- Built the bundle both ways: the flag folds to `false` in a plain build and `true` under `LUKE_CODESIGN_IDENTITY`.
- `./scripts/verify.sh` was not run — this change was produced in a cloud (Linux) workspace; no UI drawing changed and no physical-notch check was performed. Recommended macOS QA: fresh user → install DMG → sign in (expect zero prompts); dev build and release side by side (expect each to keep its own state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/2f9529d4-2a7c-480e-a48e-5aeca8aaf663)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32108683688/artifacts/9314091108) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32108683688)

- Commit: `7ddd287cffb1428851b0ff1490438944d1a22418`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
