### PR TITLE
fix(web): run the sign-in and consent pages on the flow's dark card

### DIFF
--- a/apps/desktop/src/account-loopback-page.ts
+++ b/apps/desktop/src/account-loopback-page.ts
@@ -3,10 +3,11 @@ import { FACE_ART } from "./renderer/luke-face-art";
 /**
  * The page the browser is left on after the OAuth redirect lands on the
  * loopback. It is the last thing the sign-in shows, so it dresses like the
- * landing page — one dark card, the mark, a status pill, and a line saying
- * where things stand — rather than a line of bare text. Self-contained on
- * purpose: the ephemeral 127.0.0.1 server serves exactly one document, so
- * nothing here may fetch a font, a script, or an image from anywhere.
+ * sign-in and consent pages before it — one dark card, the mark, a status
+ * pill, and a line saying where things stand — rather than a line of bare
+ * text. Self-contained on purpose: the ephemeral 127.0.0.1 server serves
+ * exactly one document, so nothing here may fetch a font, a script, or an
+ * image from anywhere.
  *
  * Every string on the page is fixed by the build. Nothing the redirect
  * carried — code, state, error — is ever interpolated into the document.

--- a/apps/web/consent.html
+++ b/apps/web/consent.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/web/sign-in.html
+++ b/apps/web/sign-in.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/web/src/auth-surface.ts
+++ b/apps/web/src/auth-surface.ts
@@ -11,8 +11,14 @@
 /** A single card, centered in the window, with nothing else on the page. */
 export const AUTH_SHELL = "grid min-h-screen place-items-center p-6";
 
+/**
+ * The shadow is the loopback page's, not the landing page's: both pages here
+ * run dark (`class="dark"` on their HTML roots), where a light-page shadow at
+ * a few percent black disappears, and the flow should end on the same card it
+ * ran on.
+ */
 export const AUTH_CARD =
-  "w-full max-w-[390px] rounded-lg border border-border bg-card px-8 py-12 text-center shadow-[0_1px_2px_rgba(0,0,0,0.04),0_8px_24px_rgba(0,0,0,0.06)]";
+  "w-full max-w-[390px] rounded-lg border border-border bg-card px-8 py-12 text-center shadow-[0_24px_80px_rgba(0,0,0,0.42)]";
 
 export const AUTH_TITLE = "mt-4 mb-2 text-[1.75rem] leading-[1.15] font-semibold";
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -132,6 +132,31 @@
   font-synthesis: none;
 }
 
+/* The sign-in and consent pages opt in with `class="dark"` on their root
+   element: they are the browser moments of the desktop sign-in, and the flow
+   ends on the loopback's dark card, so the theme holds from the first card to
+   the last instead of flashing light in the middle. The values are the
+   loopback page's own (`apps/desktop/src/account-loopback-page.ts`), restated
+   only for the tokens those two pages actually read — everything else stays
+   the light page's, unread here and drift waiting to happen if copied. */
+.dark {
+  color-scheme: dark;
+
+  --background: #08090b;
+  --foreground: rgba(255, 255, 255, 0.92);
+  --card: #000;
+  --muted: rgba(255, 255, 255, 0.05);
+  --muted-foreground: rgba(255, 255, 255, 0.56);
+  --border: rgba(255, 255, 255, 0.08);
+
+  /* The product's state palette needs no pastel restatement on its own dark
+     ground: ink and tint are the loopback pill's values verbatim. */
+  --attention: #ffa049;
+  --attention-tint: rgba(255, 160, 73, 0.14);
+  --complete: #6fdca4;
+  --complete-tint: rgba(111, 220, 164, 0.14);
+}
+
 @layer base {
   html {
     font-family: var(--font-page);


### PR DESCRIPTION
## What

The desktop sign-in flow ends on the loopback's dark "Signed in to Luke" card, but the hosted sign-in and consent pages in the middle of that flow inherited the landing page's light theme when the site went light — even though both entry points still declared `<meta name="color-scheme" content="dark">`.

- `apps/web/src/styles.css`: a `.dark` token scope for the two auth pages, using the loopback page's own palette (`#08090b` ground, `#000` card, 8% white hairline, `#6fdca4`/`#ffa049` state ink-and-tint), restating only the tokens those pages read. The landing and privacy pages stay light and untouched.
- `apps/web/sign-in.html`, `apps/web/consent.html`: opt in with `class="dark"`, making the existing dark color-scheme meta true.
- `apps/web/src/auth-surface.ts`: the shared card carries the loopback's shadow — a few-percent-black light shadow disappears on a dark ground.
- `apps/desktop/src/account-loopback-page.ts`: comment-only truth-up — the loopback card's design anchor is the sign-in and consent pages, not the now-light landing page.

## Verification

- `./scripts/check.sh` passes (exit 0).
- Rendered `sign-in.html`, `consent.html`, and the loopback success page in headless Chrome before and after: the three cards share one structure (mark, pill, title, one body line) and now one dark theme end to end. Web-page change only; no macOS packaging or notch surface touched, so no physical-notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/39959d57-9b3b-4218-9c6b-21b60c535b98)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32109039898/artifacts/9314214028) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32109039898)

- Commit: `e4531cca68970101f9d0b3fb79077933a66fe210`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
