### PR TITLE
fix(voice): stack back-to-back replies as two captions

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1604,7 +1604,7 @@ export function App(): React.JSX.Element {
     stopMicrophone,
     askLuke,
     voiceTurn,
-    lukeCaption,
+    lukeCaptions,
     captionShownAt,
     announcedSession,
     remoteAudio,
@@ -2229,8 +2229,14 @@ export function App(): React.JSX.Element {
     voice: voiceTurn,
     error: voiceError,
   });
-  const captionText = lukeCaption ?? voiceErrorNotice;
-  const captionIsError = lukeCaption === undefined && voiceErrorNotice !== undefined;
+  const captionTexts =
+    lukeCaptions ?? (voiceErrorNotice === undefined ? undefined : [voiceErrorNotice]);
+  const captionIsError = lukeCaptions === undefined && voiceErrorNotice !== undefined;
+  // Two responses spoken back-to-back stack as two captions: the settled one
+  // above, the one still arriving below, in the always-mounted slot the lone
+  // caption also uses.
+  const settledCaption = captionTexts && captionTexts.length > 1 ? captionTexts.at(-2) : undefined;
+  const liveCaption = captionTexts?.at(-1);
   // How long the words on screen have been readable, or nothing while the
   // output is audible: the reading clock only paces words nobody can hear.
   const captionReadingElapsed =
@@ -2243,7 +2249,7 @@ export function App(): React.JSX.Element {
   const volumeHint =
     fixtureMuted ||
     (outputIsSilent &&
-      lukeCaption !== undefined &&
+      lukeCaptions !== undefined &&
       !volumeHintDismissed(hintDismissal, silenceStretch, Date.now()));
   const panelOpen = presentation === PANEL_PRESENTATION.PANEL;
   const slotOpen = presentation === PANEL_PRESENTATION.SLOT;
@@ -2312,7 +2318,7 @@ export function App(): React.JSX.Element {
       // Whether there are words to draw under the shape — a caption or a
       // failure borrowing its strip — so the surface can grow the room they
       // are drawn in.
-      data-caption={String(Boolean(captionText))}
+      data-caption={String(Boolean(captionTexts))}
       // Whether those words need the volume hint under them, which shares the
       // caption block's room.
       data-volume-hint={String(volumeHint)}
@@ -2509,9 +2515,13 @@ export function App(): React.JSX.Element {
           foot when it opens, so the words travel with the morph instead of
           jumping between two copies. Not in a wing — the wings clip at the
           capsule's height — and always mounted, like the count's caption, so
-          both edges of its fade can run. The inner text is what is measured:
-          its wrapped height is the only honest answer to how much room the
-          words need. Hidden from readers while it captions speech — it
+          both edges of its fade can run. The inner stack is what is measured —
+          two responses spoken back-to-back are two blocks in it, the settled
+          words above the ones still arriving — and its wrapped height is the
+          only honest answer to how much room the words need. The newest block
+          is always mounted like the stack itself; the settled one mounts only
+          while it has words, so a lone reply pays no gap for a block that is
+          not there. Hidden from readers while it captions speech — it
           duplicates what is already audible — and announced as a status line
           when it carries a failure, which was never audible at all. */}
       <span
@@ -2520,8 +2530,11 @@ export function App(): React.JSX.Element {
         data-error={String(captionIsError)}
         {...(captionIsError ? { role: "status" } : { "aria-hidden": true })}
       >
-        <span className="voice-caption-text" ref={captionTextElement}>
-          {captionText}
+        <span className="voice-caption-stack" ref={captionTextElement}>
+          {settledCaption === undefined ? null : (
+            <span className="voice-caption-text">{settledCaption}</span>
+          )}
+          <span className="voice-caption-text">{liveCaption}</span>
         </span>
       </span>
 

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -138,6 +138,14 @@ interface LiveContext {
 export const REMOTE_QUIET_MS = 2_500;
 
 /**
+ * How many back-to-back responses the caption keeps on screen at once. Two is
+ * the shape the surface stacks — the words just settled and the words now
+ * arriving — and a third response starting simply retires the oldest, the way
+ * a long reply's oldest lines already roll up under the shape.
+ */
+export const CAPTION_SEGMENT_LIMIT = 2;
+
+/**
  * Carries one validated action to the process that can perform it, answering
  * with what became of it. The renderer validates a tool call against the
  * observed roster before this is called, and the main process validates it
@@ -166,15 +174,19 @@ export interface RealtimeVoiceSessionCallbacks {
   onRemoteStream(stream: MediaStream | undefined): void;
   onError(message: string | undefined): void;
   /**
-   * The text of the reply Luke is currently speaking, growing as it is
-   * generated, or undefined once there is nothing being spoken. The session
-   * owns the whole lifecycle — the caption clears when the reply ends, is cut
-   * off, or the call closes — so the caller only ever draws what it is handed.
-   * `about` is the session a proactive announcement names, carried from the
-   * roster-validated update `speak()` was handed and living exactly as long as
-   * that reply; a conversation reply carries none.
+   * The words Luke is currently speaking, growing as they are generated, or
+   * undefined once there is nothing being spoken. Each entry is one response's
+   * words: a turn that speaks twice — a sentence before a tool call and the
+   * outcome after it, or a reply the model split into two messages — hands
+   * over both, oldest first, so the surface can stack them apart instead of
+   * running two sentences together. The session owns the whole lifecycle —
+   * the captions clear when the reply ends, is cut off, or the call closes —
+   * so the caller only ever draws what it is handed. `about` is the session a
+   * proactive announcement names, carried from the roster-validated update
+   * `speak()` was handed and living exactly as long as that reply; a
+   * conversation reply carries none.
    */
-  onCaption(text: string | undefined, about: SessionIdentity | undefined): void;
+  onCaption(texts: readonly string[] | undefined, about: SessionIdentity | undefined): void;
 }
 
 export interface RealtimeVoiceSessionOptions extends RealtimeVoiceSessionCallbacks {
@@ -424,12 +436,17 @@ export class RealtimeVoiceSession {
   #activeResponseId: string | undefined;
   #audibleSince: number | undefined;
   /**
-   * The words of the reply being spoken, as far as they have arrived. Kept
-   * here rather than in the caller so every path that ends a reply — finishing,
+   * The words of the turn being spoken, as far as they have arrived — one
+   * segment per output item, oldest first, each remembering which item spoke
+   * it. A turn that speaks twice back-to-back — a second message item, or the
+   * follow-up after a tool call — starts a new segment rather than running
+   * its words onto the last one's, and an item's own final transcript can
+   * still land on its own segment after the turn has moved on. Kept here
+   * rather than in the caller so every path that ends a reply — finishing,
    * being talked over, the call dropping — clears the words with it, and a
    * caption can never outlive the speech it captions.
    */
-  #caption: string | undefined;
+  #captionSegments: { itemId: string | undefined; text: string }[] = [];
   /**
    * The session the reply under way is announcing, or nothing for a
    * conversation reply. Set only by `speak()` from the identity the attention
@@ -994,7 +1011,7 @@ export class RealtimeVoiceSession {
     // playback drops out for a beat — and this is the very moment Luke starts
     // to answer. The track is disabled, so nothing is sent; the device itself
     // is let go when the exchange settles, in the quiet after the reply.
-    this.#startResponse(pushToTalkCommitEvents(), true);
+    this.#startResponse(pushToTalkCommitEvents(), { toolsArmed: true });
   }
 
   /**
@@ -1020,7 +1037,7 @@ export class RealtimeVoiceSession {
     const events = typedAskEvents(text);
     if (events.length === 0) return false;
     if (this.#status === REALTIME_STATUS.RESPONDING) this.#interruptReply();
-    this.#startResponse(events, true);
+    this.#startResponse(events, { toolsArmed: true });
     return true;
   }
 
@@ -1036,7 +1053,7 @@ export class RealtimeVoiceSession {
     // The caption is cut with the audio. It already held words the room
     // never heard — the text runs ahead of the speech — and leaving them up
     // would show Luke finishing a sentence he was just stopped from saying.
-    this.#setCaption(undefined);
+    this.#clearCaption();
     this.#send(cancelResponseEvents());
     // Then correct what Luke believes he said, or the next answer is free to
     // refer back to a sentence that never reached the room.
@@ -1106,7 +1123,7 @@ export class RealtimeVoiceSession {
       providerId: speech.providerId,
       providerSessionId: speech.providerSessionId,
     };
-    this.#options.onCaption(this.#caption, this.#captionAbout);
+    this.#emitCaption();
     return true;
   }
 
@@ -1176,7 +1193,7 @@ export class RealtimeVoiceSession {
     this.#responseItemId = undefined;
     this.#activeResponseId = undefined;
     this.#audibleSince = undefined;
-    this.#setCaption(undefined);
+    this.#clearCaption();
     // Learned about this call, so it does not outlive it.
     this.#audioEndingsReported = false;
     this.#clearSettleTimer();
@@ -1184,7 +1201,13 @@ export class RealtimeVoiceSession {
     this.#options.onRemoteStream(undefined);
   }
 
-  #startResponse(events: readonly Record<string, unknown>[], toolsArmed = false): void {
+  #startResponse(
+    events: readonly Record<string, unknown>[],
+    {
+      toolsArmed = false,
+      keepCaption = false,
+    }: { toolsArmed?: boolean; keepCaption?: boolean } = {},
+  ): void {
     // A pace still waiting from the last reply lands here, ahead of the
     // request: the channel is ordered and no response is in progress — a
     // cancel for the reply being talked over was sent before this — so the
@@ -1226,7 +1249,9 @@ export class RealtimeVoiceSession {
     // follow-up still awaiting from the last turn will see this and stand down.
     this.#toolTurnArmed = toolsArmed;
     this.#turnEpoch += 1;
-    this.#setCaption(undefined);
+    // A new turn starts with a clean strip; a follow-up continuing the same
+    // exchange keeps the words just said, and its own words stack under them.
+    if (!keepCaption) this.#clearCaption();
     this.#clearSettleTimer();
     // Every reply request passes through here, so this one line logs each
     // voice-model turn. The turn's kind and nothing else: what was said stays
@@ -1334,14 +1359,55 @@ export class RealtimeVoiceSession {
     this.#quietTimer = undefined;
   }
 
-  #setCaption(text: string | undefined): void {
+  #clearCaption(): void {
     // The subject is of the reply, so the reply ending takes it too: every
     // path that ends one clears the caption through here.
-    const about = text === undefined ? undefined : this.#captionAbout;
-    if (this.#caption === text && this.#captionAbout === about) return;
-    this.#caption = text;
-    this.#captionAbout = about;
-    this.#options.onCaption(text, about);
+    if (this.#captionSegments.length === 0 && this.#captionAbout === undefined) return;
+    this.#captionSegments = [];
+    this.#captionAbout = undefined;
+    this.#options.onCaption(undefined, undefined);
+  }
+
+  /** What the caption currently says, or undefined with nothing to say. */
+  #captionTexts(): readonly string[] | undefined {
+    if (this.#captionSegments.length === 0) return undefined;
+    return this.#captionSegments.map((segment) => segment.text);
+  }
+
+  #emitCaption(): void {
+    this.#options.onCaption(this.#captionTexts(), this.#captionAbout);
+  }
+
+  /**
+   * Grows the caption with the words just generated. The current item's words
+   * grow its own segment; an item taking over from another — the reply's
+   * second message, or the follow-up after a tool call — starts a segment of
+   * its own, so two responses stack instead of running together. Only the
+   * newest {@link CAPTION_SEGMENT_LIMIT} stay up.
+   */
+  #appendCaptionDelta(itemId: string | undefined, delta: string): void {
+    const last = this.#captionSegments.at(-1);
+    if (last && last.itemId === itemId) {
+      last.text += delta;
+    } else {
+      this.#captionSegments.push({ itemId, text: delta });
+      this.#captionSegments = this.#captionSegments.slice(-CAPTION_SEGMENT_LIMIT);
+    }
+    this.#emitCaption();
+  }
+
+  /**
+   * Lands an item's final transcript on the segment its deltas built — even
+   * after a later item has taken the turn on, which is what keeps a settled
+   * response's words whole while the next one streams under them. A transcript
+   * whose item holds no segment is a cancelled reply's straggler, and writes
+   * nothing.
+   */
+  #settleCaptionTranscript(itemId: string | undefined, transcript: string): void {
+    const segment = this.#captionSegments.find((candidate) => candidate.itemId === itemId);
+    if (!segment || segment.text === transcript) return;
+    segment.text = transcript;
+    this.#emitCaption();
   }
 
   /** Ends the turn once the reply is done, so the next one can start. */
@@ -1366,7 +1432,7 @@ export class RealtimeVoiceSession {
     // The caption is of speech, and the speech is over. Whatever ended the
     // reply — the audio draining, an error, the settle timer — the words leave
     // with the meter and the face rather than lingering under a quiet capsule.
-    this.#setCaption(undefined);
+    this.#clearCaption();
     // Whatever ended the reply — an error, the settle timer, Luke simply
     // stopping — the next one has to be audible. Without this a reply that
     // failed before it started would leave Luke silenced with nothing to
@@ -1708,17 +1774,18 @@ export class RealtimeVoiceSession {
         // would draw the words Luke was just stopped from saying, or splice them
         // onto the next reply's.
         if (event.itemId === this.#responseItemId && event.delta) {
-          this.#setCaption((this.#caption ?? "") + event.delta);
+          this.#appendCaptionDelta(event.itemId, event.delta);
         }
         return;
       case REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DONE:
-        // The server's own rendering of the whole reply, which the deltas only
+        // The server's own rendering of the whole item, which the deltas only
         // approximate: a delta lost to the channel would otherwise leave a hole
-        // in the sentence for as long as it stayed up. Held to the same item as
-        // the deltas, because the cancelled reply's `done` is the likeliest
-        // straggler of all.
-        if (event.itemId === this.#responseItemId && event.transcript) {
-          this.#setCaption(event.transcript);
+        // in the sentence for as long as it stayed up. It lands on the segment
+        // the item's deltas built — even one the turn has already moved past —
+        // and a cancelled reply's `done`, the likeliest straggler of all, finds
+        // its segments cleared and writes nothing.
+        if (event.transcript) {
+          this.#settleCaptionTranscript(event.itemId, event.transcript);
         }
         return;
       case REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED:
@@ -1885,7 +1952,10 @@ export class RealtimeVoiceSession {
     // developer took the turn, started another, or the call is gone. The
     // outcomes were still delivered as items, so the next turn has them.
     if (!this.isConnected || this.#turnEpoch !== epoch) return;
-    this.#startResponse(functionCallFollowUpEvents());
+    // The follow-up continues the exchange the developer opened, so whatever
+    // the reply said before its tool call stays on the strip and the outcome
+    // stacks under it, rather than replacing words still being read.
+    this.#startResponse(functionCallFollowUpEvents(), { keepCaption: true });
   }
 
   async #toolCallOutput(

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1318,13 +1318,26 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   padding-bottom: calc(18px + var(--caption-size, 28px));
 }
 
-/* The translate is how a reply that outgrows the block rolls its oldest lines
-   up under the capsule band. The cut lands where black meets black, so lines
-   slide under the shape rather than being sliced in the open. Heard words
-   keep the newest line on screen — the half of the reply the voice has not
-   reached yet; words landing on a silent output scroll at reading pace
-   instead, oldest unread line first, because there the caption is the speech.
-   The line height is mirrored by CAPTION_LINE_HEIGHT in caption-reading.ts —
+/* The stack holds one block per response, so two responses spoken
+   back-to-back sit apart instead of running together. The gap between them is
+   one caption line — it mirrors CAPTION_LINE_HEIGHT in caption-reading.ts —
+   so the reading clock's whole-line scroll stays whole-line with two blocks
+   up. The translate is how words that outgrow the block roll their oldest
+   lines up under the capsule band. The cut lands where black meets black, so
+   lines slide under the shape rather than being sliced in the open. Heard
+   words keep the newest line on screen — the half of the reply the voice has
+   not reached yet; words landing on a silent output scroll at reading pace
+   instead, oldest unread line first, because there the caption is the speech. */
+.voice-caption-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  width: 100%;
+  transform: translateY(calc(var(--caption-scroll, 0px) * -1));
+  transition: transform var(--duration-fast) var(--spring-fast);
+}
+
+/* The line height is mirrored by CAPTION_LINE_HEIGHT in caption-reading.ts —
    the two must agree, or the reading clock releases part-lines. */
 .voice-caption-text {
   display: block;
@@ -1335,8 +1348,6 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   letter-spacing: 0.1px;
   line-height: 14px;
   text-align: center;
-  transform: translateY(calc(var(--caption-scroll, 0px) * -1));
-  transition: transform var(--duration-fast) var(--spring-fast);
 }
 
 /* A voice failure borrows the caption's strip — same box, same travel — in

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -118,26 +118,27 @@ export function voiceErrorToShow(input: {
 }
 
 /**
- * The words drawn under the shape. A capture run always draws the fixture's
- * words; otherwise Luke's caption is shown only when there is a reason to
- * read them and the reply they belong to is his turn: the captions preference,
- * a reply answering an ask the developer typed, or an output that would
- * swallow the speech.
+ * The words drawn under the shape, one entry per response so back-to-back
+ * responses stack apart instead of running together. A capture run always
+ * draws the fixture's words; otherwise Luke's captions are shown only when
+ * there is a reason to read them and the reply they belong to is his turn:
+ * the captions preference, a reply answering an ask the developer typed, or
+ * an output that would swallow the speech.
  */
-export function lukeCaptionToShow(input: {
+export function lukeCaptionsToShow(input: {
   fixtureSpeaking: boolean;
   captionsEnabled: boolean;
   typedAsk: boolean;
   outputSilent: boolean;
   voice: WaveformVoice | undefined;
-  caption: string | undefined;
-}): string | undefined {
-  if (input.fixtureSpeaking) return FIXTURE_SPEAKING_CAPTION;
+  captions: readonly string[] | undefined;
+}): readonly string[] | undefined {
+  if (input.fixtureSpeaking) return [FIXTURE_SPEAKING_CAPTION];
   if (
     (input.captionsEnabled || input.typedAsk || input.outputSilent) &&
     input.voice === WAVEFORM_VOICE.LUKE
   ) {
-    return input.caption;
+    return input.captions;
   }
   return undefined;
 }
@@ -353,7 +354,11 @@ export interface VoiceConversation {
   stopMicrophone: () => Promise<void>;
   askLuke: (text: string) => Promise<string | undefined>;
   voiceTurn: WaveformVoice | undefined;
-  lukeCaption: string | undefined;
+  /**
+   * The words being spoken, one entry per response: a turn that speaks twice
+   * back-to-back keeps both on screen, stacked oldest first.
+   */
+  lukeCaptions: readonly string[] | undefined;
   /**
    * When the words now on screen first appeared. It is the reading clock's
    * start: the surface paces a silent caption's scroll from it, so the words
@@ -407,9 +412,9 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   // the notice the surface anchors to the subject can never draw against a
   // caption from a different reply.
   const [voiceCaption, setVoiceCaption] = useState<{
-    text: string | undefined;
+    texts: readonly string[] | undefined;
     about: SessionIdentity | undefined;
-  }>({ text: undefined, about: undefined });
+  }>({ texts: undefined, about: undefined });
   /**
    * Whether the reply under way answers an ask the developer typed. A typed
    * ask is read, not only heard, so its reply draws the caption whatever the
@@ -547,7 +552,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       onLocalStream: setLocalStream,
       onRemoteStream: setRemoteStream,
       onError: setVoiceError,
-      onCaption: (text, about) => setVoiceCaption({ text, about }),
+      onCaption: (texts, about) => setVoiceCaption({ texts, about }),
     });
     return voiceSession.current;
   }, [rememberSessionReference, setVoiceStatus]);
@@ -955,19 +960,20 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   );
 
   const voiceTurn = waveformVoice(voiceStatus);
-  const lukeCaption = lukeCaptionToShow({
+  const lukeCaptions = lukeCaptionsToShow({
     fixtureSpeaking: options.fixtureSpeaking,
     captionsEnabled: options.voiceCaptions,
     typedAsk,
     outputSilent: options.outputSilent,
     voice: voiceTurn,
-    caption: voiceCaption.text,
+    captions: voiceCaption.texts,
   });
 
   // The reading clock starts when words appear and ends when they leave; the
   // text growing between those edges is the same block of words, still on its
-  // own clock, however fast the deltas behind it streamed in.
-  const captionDrawn = lukeCaption !== undefined;
+  // own clock, however fast the deltas behind it streamed in — a second
+  // response stacking under the first grows the block the same way.
+  const captionDrawn = lukeCaptions !== undefined;
   useEffect(() => {
     setCaptionShownAt(captionDrawn ? Date.now() : undefined);
   }, [captionDrawn]);
@@ -987,7 +993,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     stopMicrophone,
     askLuke,
     voiceTurn,
-    lukeCaption,
+    lukeCaptions,
     captionShownAt,
     announcedSession: voiceCaption.about,
     remoteAudio,

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -45,7 +45,8 @@ interface Harness {
   session: RealtimeVoiceSession;
   sent: Record<string, unknown>[];
   errors: (string | undefined)[];
-  captions: (string | undefined)[];
+  /** Each caption emission: one text per stacked response, or a clear. */
+  captions: (readonly string[] | undefined)[];
   /** The announced session each caption emission carried, by session id. */
   captionSubjects: (string | undefined)[];
   microphoneEnabled: () => boolean;
@@ -131,7 +132,7 @@ function harness(
   };
   const sent: Record<string, unknown>[] = [];
   const errors: (string | undefined)[] = [];
-  const captions: (string | undefined)[] = [];
+  const captions: (readonly string[] | undefined)[] = [];
   const captionSubjects: (string | undefined)[] = [];
   const requests: { url: string; init: RequestInit }[] = [];
   const calls: string[] = [];
@@ -249,8 +250,8 @@ function harness(
     onLocalStream: () => undefined,
     onRemoteStream: () => undefined,
     onError: (message) => errors.push(message),
-    onCaption: (text, about) => {
-      captions.push(text);
+    onCaption: (texts, about) => {
+      captions.push(texts);
       captionSubjects.push(about?.providerSessionId);
     },
   });
@@ -2934,10 +2935,118 @@ test("the caption grows with the deltas and the final text supersedes them", asy
   });
 
   assert.deepEqual(context.captions, [
-    "Two sessions ",
-    "Two sessions need review.",
-    "Two sessions need review, and one failed.",
+    ["Two sessions "],
+    ["Two sessions need review."],
+    ["Two sessions need review, and one failed."],
   ]);
+});
+
+test("back-to-back responses stack as two captions instead of running together", async () => {
+  const context = harness();
+  await context.session.connect();
+  await holdTurn(context);
+  context.session.endTurn(true);
+
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
+    item: { id: "item-one" },
+  });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
+    item_id: "item-one",
+    delta: "First response.",
+  });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
+    item: { id: "item-two" },
+  });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
+    item_id: "item-two",
+    delta: "Second response.",
+  });
+
+  // The second response's words start a caption of their own rather than
+  // being spliced onto the first's without so much as a space.
+  assert.deepEqual(context.captions.at(-1), ["First response.", "Second response."]);
+
+  // The first response's own final rendering lands on its own caption — even
+  // though the turn has moved on — instead of erasing the pair.
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DONE,
+    item_id: "item-one",
+    transcript: "First response, corrected.",
+  });
+  assert.deepEqual(context.captions.at(-1), ["First response, corrected.", "Second response."]);
+
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DONE,
+    item_id: "item-two",
+    transcript: "Second response, finished.",
+  });
+  assert.deepEqual(context.captions.at(-1), [
+    "First response, corrected.",
+    "Second response, finished.",
+  ]);
+
+  // A third response retires the oldest: only two ever stack.
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
+    item: { id: "item-three" },
+  });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
+    item_id: "item-three",
+    delta: "Third.",
+  });
+  assert.deepEqual(context.captions.at(-1), ["Second response, finished.", "Third."]);
+});
+
+test("a tool follow-up keeps the words said before the call and stacks the outcome", async () => {
+  const context = harness({ carryAction: async () => ({ status: "accepted" }) });
+  await context.session.connect();
+  context.session.updateSessions([observedSession("session-a", { canReceiveMessage: true })]);
+  await armDeveloperTurn(context);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-1" } });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
+    item: { id: "item-ask" },
+  });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
+    item_id: "item-ask",
+    delta: "Sending that now.",
+  });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: {
+      id: "resp-1",
+      output: [
+        {
+          type: "function_call",
+          name: "send_session_message",
+          call_id: "call-1",
+          arguments:
+            '{"provider_id":"claude-code","provider_session_id":"session-a","text":"add tests"}',
+        },
+      ],
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  // The follow-up continues the exchange, so the sentence spoken before the
+  // call stays on the strip and the outcome's words stack under it, instead
+  // of the outcome erasing words still being read.
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
+    item: { id: "item-outcome" },
+  });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
+    item_id: "item-outcome",
+    delta: "Sent.",
+  });
+  assert.deepEqual(context.captions.at(-1), ["Sending that now.", "Sent."]);
 });
 
 test("the caption leaves when the reply does", async () => {
@@ -2952,11 +3061,11 @@ test("the caption leaves when the reply does", async () => {
   context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_DONE });
   // Generation finishing is not speech finishing: the words stay up while
   // Luke is still saying them.
-  assert.deepEqual(context.captions, ["All quiet."]);
+  assert.deepEqual(context.captions, [["All quiet."]]);
 
   context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED });
 
-  assert.deepEqual(context.captions, ["All quiet.", undefined]);
+  assert.deepEqual(context.captions, [["All quiet."], undefined]);
 });
 
 test("an announcement's caption names its session; a conversation's names none", async () => {
@@ -2978,7 +3087,7 @@ test("an announcement's caption names its session; a conversation's names none",
     type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
     delta: "Checkout just finished.",
   });
-  assert.deepEqual(context.captions, [undefined, "Checkout just finished."]);
+  assert.deepEqual(context.captions, [undefined, ["Checkout just finished."]]);
   assert.deepEqual(context.captionSubjects, ["session-a", "session-a"]);
 
   // The reply ending takes the subject with the words: the notice can never
@@ -2995,7 +3104,7 @@ test("an announcement's caption names its session; a conversation's names none",
     type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA,
     delta: "Two sessions need review.",
   });
-  assert.equal(context.captions.at(-1), "Two sessions need review.");
+  assert.deepEqual(context.captions.at(-1), ["Two sessions need review."]);
   assert.equal(context.captionSubjects.at(-1), undefined);
 });
 
@@ -3062,10 +3171,15 @@ test("a cancelled reply's late transcript cannot pollute the next caption", asyn
     delta: "The second reply",
   });
 
-  assert.equal(context.captions.at(-1), "The second reply");
-  assert.equal(context.captions.includes("The first reply, finished anyway."), false);
+  assert.deepEqual(context.captions.at(-1), ["The second reply"]);
   assert.equal(
-    context.captions.some((caption) => caption?.includes("still streaming in")),
+    context.captions.some((caption) => caption?.includes("The first reply, finished anyway.")),
+    false,
+  );
+  assert.equal(
+    context.captions.some((caption) =>
+      caption?.some((text) => text.includes("still streaming in")),
+    ),
     false,
   );
 });

--- a/apps/desktop/tests/use-voice-conversation.test.ts
+++ b/apps/desktop/tests/use-voice-conversation.test.ts
@@ -18,7 +18,7 @@ import {
   latestSpeech,
   latestSpeechReference,
   liveSpeedApplies,
-  lukeCaptionToShow,
+  lukeCaptionsToShow,
   talkKeyPress,
   talkOpeningHolds,
   typedAskHolds,
@@ -68,36 +68,39 @@ test("the media duck follows the exchange, not a settled call", () => {
 });
 
 test("a capture run always captions the fixture's words", () => {
-  assert.equal(
-    lukeCaptionToShow({
+  assert.deepEqual(
+    lukeCaptionsToShow({
       fixtureSpeaking: true,
       captionsEnabled: false,
       typedAsk: false,
       outputSilent: false,
       voice: WAVEFORM_VOICE.LUKE,
-      caption: "live words",
+      captions: ["live words"],
     }),
-    FIXTURE_SPEAKING_CAPTION,
+    [FIXTURE_SPEAKING_CAPTION],
   );
 });
 
-test("Luke's caption is drawn only on his turn, and only with a reason to read it", () => {
+test("Luke's captions are drawn only on his turn, and only with a reason to read them", () => {
   const shown = {
     fixtureSpeaking: false,
     captionsEnabled: true,
     typedAsk: false,
     outputSilent: false,
     voice: WAVEFORM_VOICE.LUKE,
-    caption: "two sessions are waiting on you.",
+    captions: ["two sessions are waiting on you.", "and the build just finished."],
   };
-  assert.equal(lukeCaptionToShow(shown), "two sessions are waiting on you.");
+  assert.deepEqual(lukeCaptionsToShow(shown), [
+    "two sessions are waiting on you.",
+    "and the build just finished.",
+  ]);
   assert.equal(
-    lukeCaptionToShow({ ...shown, voice: WAVEFORM_VOICE.DEVELOPER }),
+    lukeCaptionsToShow({ ...shown, voice: WAVEFORM_VOICE.DEVELOPER }),
     undefined,
     "a caption that raced a status change must not be drawn on the developer's turn",
   );
   assert.equal(
-    lukeCaptionToShow({ ...shown, captionsEnabled: false }),
+    lukeCaptionsToShow({ ...shown, captionsEnabled: false }),
     undefined,
     "the preference is about speech being duplicated, and with it off there is no reason to read",
   );
@@ -135,10 +138,10 @@ test("a typed ask, or an output that would swallow the reply, captions whatever 
     typedAsk: false,
     outputSilent: false,
     voice: WAVEFORM_VOICE.LUKE,
-    caption: "the words",
+    captions: ["the words"],
   };
-  assert.equal(lukeCaptionToShow({ ...hidden, typedAsk: true }), "the words");
-  assert.equal(lukeCaptionToShow({ ...hidden, outputSilent: true }), "the words");
+  assert.deepEqual(lukeCaptionsToShow({ ...hidden, typedAsk: true }), ["the words"]);
+  assert.deepEqual(lukeCaptionsToShow({ ...hidden, outputSilent: true }), ["the words"]);
 });
 
 test("a latched press is the release's to answer, and does not open a second call", () => {


### PR DESCRIPTION
## Problem

When Luke spoke two responses back-to-back — a reply whose model split its words across two output items, or a reply that spoke before and after a tool call — the caption strip misbehaved:

- The second response's transcript deltas were appended straight onto the first response's words, concatenating two sentences without a space.
- The second response's final transcript then replaced the whole caption, so the first response's words vanished while they were still being read.
- The first item's own final transcript (the server's lost-delta correction) was silently dropped once the turn had moved on to the next item.

## Fix

- `realtime-session.ts`: the caption is now one segment per output item, oldest first, capped at `CAPTION_SEGMENT_LIMIT = 2` (a third response retires the oldest). Deltas grow their own item's segment; a new item stacks a new segment; a final transcript lands on the segment its deltas built even after the turn moved past it, while a cancelled reply's straggler finds its segments cleared and writes nothing. The tool-call follow-up passes `keepCaption` through `#startResponse`, so the sentence spoken before the call stays up and the outcome stacks under it. Every path that ends, cuts, or replaces a turn still clears everything — a caption can never outlive the speech it captions.
- `use-voice-conversation.ts`: `onCaption` carries `readonly string[] | undefined`; `lukeCaptionToShow` became `lukeCaptionsToShow`; the hook exposes `lukeCaptions`.
- `app.tsx` / `base.css`: the strip renders a measured `.voice-caption-stack` with one `.voice-caption-text` block per response — settled words above, live words below, one caption line (14px, mirroring `CAPTION_LINE_HEIGHT`) apart so the silent-output reading clock still scrolls whole lines. The scroll transform moved from the text to the stack; error captions and the volume hint are unchanged.

## Verification

- `./scripts/check.sh` passes (exit 0, 1320 tests), including new tests: *back-to-back responses stack as two captions instead of running together* (concatenation, preserved first response, late final-transcript landing, two-segment cap) and *a tool follow-up keeps the words said before the call and stacks the outcome*.
- `./scripts/verify.sh` was not run: this change was made in a Linux cloud workspace with no macOS to package on. No physical-notch check was performed. The speaking fixture still draws a single caption, so existing visual evidence is unchanged; photographing the stacked form would need a second fixture caption and is left as a product call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/66335a38-da08-4133-bcdd-4b21b0ada130)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32109056394/artifacts/9314216246) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32109056394)

- Commit: `0e937cefddce450b4e5fa76f446f54073630ab9a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
