### PR TITLE
feat(desktop): keep the spoken notice up over the open panel

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1634,9 +1634,11 @@ export function App(): React.JSX.Element {
   // derived, not queued — the subject arrives with the caption and dies with
   // the reply, so it can never lag the words or stand for news Luke is not
   // saying — and it draws only for a session the roster still titles, because
-  // a press is a row press at one remove and needs a row to stand for. Only
-  // the resting shapes draw it: an open panel already shows the row, and the
-  // slot and the composer are shapes someone asked for.
+  // a press is a row press at one remove and needs a row to stand for. The
+  // resting shapes draw it under the housing, and the open panel keeps it at
+  // its foot: the row is up in the list, but the chip is what says which row
+  // Luke is talking about. Only the slot and the composer go without — those
+  // are shapes someone asked for.
   const announced = announcedSession
     ? sessions.find(
         (candidate) =>
@@ -1646,7 +1648,9 @@ export function App(): React.JSX.Element {
     : undefined;
   const noticeShown =
     announced !== undefined &&
-    (presentation === PANEL_PRESENTATION.CAPSULE || presentation === PANEL_PRESENTATION.PEEK);
+    (presentation === PANEL_PRESENTATION.CAPSULE ||
+      presentation === PANEL_PRESENTATION.PEEK ||
+      presentation === PANEL_PRESENTATION.PANEL);
   // The last announced fields, held so the notice fades out still worded
   // rather than emptying on the frame the reply ends.
   const lastAnnounced = useRef<{ title: string; providerId: string }>(undefined);

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -823,9 +823,10 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
               "stops on an error, or finishes — in his own words, naming the session and saying " +
               "what it needs, from the agent's parting words or the provider's error line when " +
               "one was reported. No conversation needs to be open, and the microphone stays " +
-              "off. While he says it, a pressable notice under the housing names the session " +
-              "he is talking about: pressing it opens the session where its provider keeps it, " +
-              "or opens the panel for a local session with no page of its own. " +
+              "off. While he says it, a pressable notice names the session he is talking " +
+              "about — under the housing, or at the open panel's foot: pressing it opens the " +
+              "session where its provider keeps it, or opens the panel for a local session " +
+              "with no page of its own. " +
               "Always on while voice is available; the panel and the capsule count show the " +
               "same states either way." +
               // Only a build that offers the calendar may describe the quiet:

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1477,12 +1477,15 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   height: calc(var(--capsule-height) - var(--shape-top) * 2 + var(--caption-growth));
 }
 
-/* The chip itself: the one raised, pressable pill on the compact shape, named
-   like the session's row — its provider's mark and its title. It stands
-   still, directly under the housing, and the words are what move: a single
-   row wants a fade crossing the last of the shape's travel, not a clip or a
-   journey of its own. Above the hover strip (z-index 4) because the press
-   has to open the session. */
+/* The chip itself: the one raised, pressable pill on the shape, named like
+   the session's row — its provider's mark and its title. In the compact
+   states it stands directly under the housing and the words are what move: a
+   single row wants a fade crossing the last of the shape's travel, not a
+   clip or a journey of its own. `--notice-rest` is its one journey — the
+   ride to the open panel's foot, the caption's own travel — and the
+   transform waits out `--duration-exit` like the caption's does, so leaving
+   a state the chip travels with the shape rather than ahead of it. Above the
+   hover strip (z-index 4) because the press has to open the session. */
 .session-notice {
   position: absolute;
   z-index: 5;
@@ -1501,9 +1504,10 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   font-weight: 640;
   opacity: 0;
   pointer-events: none;
-  transform: translate(-50%, calc(3px - var(--shape-top, 0px)));
+  transform: translate(-50%, calc(3px - var(--shape-top, 0px) + var(--notice-rest, 0px)));
   transition:
     opacity var(--duration-exit) var(--motion-exit),
+    transform var(--duration-shape) var(--spring) var(--duration-exit),
     background-color var(--duration-hover) ease;
 }
 
@@ -1517,7 +1521,53 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   transition:
     opacity var(--duration-quick) var(--motion-exit)
     calc(var(--duration-shape) - var(--duration-quick)),
+    transform var(--duration-shape) var(--spring) var(--duration-exit),
     background-color var(--duration-hover) ease;
+}
+
+/* The open panel keeps the chip at its foot, the way it keeps the caption's
+   words: the announced session's row is up in the list, but the chip is what
+   says which row Luke is talking about, and its press stays one press either
+   way. It stands above the caption's block when one is drawn — the compact
+   order, chip first and words below. `--notice-rest` is the travel from
+   under the housing to the foot the panel's measured height puts there.
+   Expanding, the chip leads with the surface — no delay, the panel's own
+   timing — and collapsing, the compact rule above holds it back by
+   `--duration-exit` so it leaves with the shape. */
+.app-stage[data-presentation="panel"][data-notice="true"] {
+  --notice-rest: calc(var(--panel-height, 520px) - var(--capsule-height) - var(--notice-size));
+}
+
+.app-stage[data-presentation="panel"][data-caption="true"][data-notice="true"] {
+  --notice-rest: calc(
+    var(--panel-height, 520px) -
+    var(--capsule-height) -
+    var(--caption-size, 28px) -
+    var(--notice-size)
+  );
+}
+
+.app-stage[data-presentation="panel"][data-notice="true"] .session-notice {
+  opacity: 1;
+  pointer-events: auto;
+  transition:
+    opacity var(--duration-quick) var(--motion-exit)
+    calc(var(--duration-shape) - var(--duration-quick)),
+    transform var(--duration-shape) var(--spring),
+    background-color var(--duration-hover) ease;
+}
+
+/* The chip is drawn on the shape, not in the panel's flow, so the body
+   reserves its band under the same padding the caption block takes — and
+   both at once stack, the caption's room under the chip's. Reserved whenever
+   the notice stands rather than only while the panel is up, so the height
+   the panel reports is already right when an expand begins mid-announcement. */
+.app-stage[data-notice="true"] .expanded-panel {
+  padding-bottom: calc(18px + var(--notice-size));
+}
+
+.app-stage[data-caption="true"][data-notice="true"] .expanded-panel {
+  padding-bottom: calc(18px + var(--caption-size, 28px) + var(--notice-size));
 }
 
 .session-notice:hover {


### PR DESCRIPTION
## Summary

- The pressable session notice — the chip naming the session Luke is announcing — drew only on the resting shapes (capsule and peek), so an announcement spoken while the panel was open had no chip saying which session Luke meant. Now the open panel draws it too.
- In the panel it rides at the panel's foot, the voice caption's own travel and timing: expanding, it leads with the surface on `--spring`; collapsing, it waits out `--duration-exit` so it leaves with the shape. When a caption is drawn it stands above the caption's block, keeping the compact order — chip first, words below.
- The panel body reserves the chip's band in its bottom padding (stacking with the caption's reserved room), keyed on the notice standing rather than on the panel being up, so a mid-announcement expand measures the right height from the first frame. The slot and the composer still go without: those are shapes someone asked for.
- The guide's Announcements fact now says the notice appears under the housing or at the open panel's foot, so Luke describes the behavior he has.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (lint, typecheck, tests, build)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — authored in a Linux cloud workspace

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32109125297/artifacts/9314230815) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32109125297)

- Commit: `4ad7c4e402acf16140ffb4b2ddac9291b61f1fae`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: the announcement-over-open-panel motion (chip riding to the panel's foot, and the collapse back under the housing) should be eyeballed on a physical notch when convenient; the choreography mirrors the caption's exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/4ff3efda-7857-419f-8dca-a94230e192da)
