### PR TITLE
fix(web): keep the mock's rows on the black and its marks at the far edge

### DIFF
--- a/apps/web/src/NotchMock.tsx
+++ b/apps/web/src/NotchMock.tsx
@@ -81,9 +81,11 @@ const WING_PROVIDERS = MOCK_SESSIONS.map((session) => session.providerId).filter
 /**
  * `wingMarkCapacity` and its constants in the renderer's notch-wings.tsx: what
  * one wing costs to fill, so the peek counts its remainder and the panel does
- * not have to.
+ * not have to. The insets are `--panel-inset` on the far side, where the marks
+ * start level with the tab bar and the rows, plus `--wing-inset` beside the
+ * housing.
  */
-const WING_INSETS = 18;
+const WING_INSETS = 29;
 const FACE_AND_GAP = 26;
 const MARK_WIDTH = 14;
 const MARK_AND_GAP = 21;
@@ -387,8 +389,9 @@ export function NotchMock(): React.JSX.Element {
             </section>
           </div>
 
-          {/* The wings: Luke nearest the housing, what he is watching unfolding
-              outward on one side, the count and its caption on the other. */}
+          {/* The wings: Luke nearest the housing, what he is watching resting
+              against the shape's far edge, the count and its caption on the
+              other side. */}
           <div className="wing wing-left">
             <div className="wing-inner">
               <span className="wing-marks">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -315,7 +315,9 @@
   --surface-shadow: 0 10px 26px rgba(0, 0, 0, 0.46), 0 2px 7px rgba(0, 0, 0, 0.3);
 
   --panel-radius: 30px;
+  --panel-inset: 20px;
   --wing-inset: 9px;
+  --scroll-fade: 26px;
 
   --capsule-width: calc(var(--notch-housing-width) + 72px);
   --capsule-height: max(var(--notch-top-inset), 32px);
@@ -492,6 +494,20 @@
   right: calc(50% + var(--notch-housing-width) / 2);
   left: calc(50% - var(--wing-bound) / 2);
   justify-content: flex-end;
+  /* The marks rest against this edge, and this edge is the one a morph moves.
+     In the product session-motion glides them along it on the surface's own
+     spring; here the edge itself takes the surface's exact timing — both
+     travel 50% minus half a springing width — so the marks track the black
+     without a frame of being drawn past it. The handful of fixed-size glyphs
+     inside re-lay out for pennies, and no text is re-shaped. */
+  transition: left var(--duration-shape) var(--spring) var(--duration-exit);
+}
+
+/* Growing, the far edge leads with the surface; shrinking, the base rule's
+   delay holds both back together — the two edges never part. */
+.mock[data-mode="peek"] .wing-left,
+.mock[data-mode="panel"] .wing-left {
+  transition-delay: 0s;
 }
 
 .mock .wing-right {
@@ -507,16 +523,28 @@
   padding: 0 var(--wing-inset);
 }
 
-/* Reversed so the first agent — the one that needs a person soonest — is the
-   mark nearest the face, and therefore the first to come out from behind it.
-   Every mark holds its place and only fades, so none of them moves during the
-   morph. */
+/* The left wing's inner spans the whole strip rather than shrinking to its
+   contents: the face keeps the notch's edge it always had, and the marks' own
+   auto margin is what holds them against the shape's far edge instead of
+   beside the face. */
+.mock .wing-left .wing-inner {
+  flex: 1;
+  justify-content: flex-end;
+}
+
+/* Anchored to the shape's far edge — the auto margin holds it there — and
+   starting at `--panel-inset` from it, so the first mark lines up with the tab
+   bar and the rows below. The wing already pads `--wing-inset`; the margin
+   makes up the difference. Read the way a list is: the first provider — the
+   one that needs a person soonest — holds the leftmost slot, and the overflow
+   count trails the rest. */
 .mock .wing-marks {
   display: flex;
   height: 22px;
-  flex-direction: row-reverse;
   align-items: center;
   gap: 7px;
+  margin-right: auto;
+  margin-left: calc(var(--panel-inset) - var(--wing-inset));
 }
 
 .mock .wing-mark {
@@ -715,7 +743,7 @@
   display: flex;
   max-height: 520px;
   flex-direction: column;
-  padding: calc(max(var(--notch-top-inset), 32px) + 14px) 20px 18px;
+  padding: calc(max(var(--notch-top-inset), 32px) + 14px) var(--panel-inset) 18px;
   border-radius: 0 0 var(--panel-radius) var(--panel-radius);
   /* The hero centers its own copy; the panel is a recreation of a real
      left-aligned product surface and must not inherit that. */
@@ -794,12 +822,36 @@
   flex: 0 0 auto;
 }
 
+/* Rows dissolve into the panel rather than being cut off at its edge — the
+   renderer's own treatment for a fixture taller than the shape. A scroll
+   timeline is exactly the right tool: with nothing to scroll it never becomes
+   active, so content that fits is left alone without asking JavaScript
+   whether it overflows. */
+@keyframes scroll-edge-fade {
+  from {
+    mask-image: linear-gradient(to bottom, #000 calc(100% - var(--scroll-fade)), transparent 100%);
+  }
+
+  to {
+    mask-image: linear-gradient(to bottom, #000 100%, transparent 100%);
+  }
+}
+
+/* `min-height: 0` is what actually permits the clip: a flex child defaults to
+   its content size, which would push the list past the panel instead of
+   containing it. The renderer shows a thin scrollbar here; the mock is an
+   illustration nobody can scroll, so it draws none. */
 .mock .session-list {
   display: flex;
   min-height: 0;
   flex: 1;
   flex-direction: column;
   gap: 9px;
+  overflow-x: clip;
+  overflow-y: auto;
+  animation: scroll-edge-fade linear both;
+  animation-timeline: scroll(self block);
+  scrollbar-width: none;
 }
 
 /* Content arrives behind the surface on the same spring the surface is
@@ -1142,6 +1194,7 @@
 
   .mock .panel-surface,
   .mock .expanded-stage,
+  .mock .wing-left,
   .mock .wing-mark,
   .mock .wing-more,
   .mock .count-badge,


### PR DESCRIPTION
## Summary

The landing page's hero mock drifted from the renderer it ports, in two visible ways:

- **The last session row was drawn past the black.** The smoke fixture grew a sixth session, and the mock's session list had no overflow rule, so "Watch a cloud session" spilled off the panel surface onto the display frame. The list now takes the renderer's own treatment — `overflow` clipped with the `scroll-edge-fade` scroll-timeline mask — so a row that does not fit dissolves into the panel's bottom edge, and content that fits is left alone.
- **The provider marks sat beside the face instead of at the shape's far edge.** The renderer rests them against the far edge, level with the tab bar and the rows, first provider leftmost with the overflow count trailing; the mock still kept the old reversed arrangement bunched against the housing. The left wing's inner now spans the strip and the marks' auto margin holds them at the far edge, exactly as `base.css` does — and the wing-inset math in `NotchMock.tsx` takes the renderer's current `--panel-inset + --wing-inset` figure, so the peek counts its remainder the same way (two marks and a "+3").

The far edge is the one the peek→panel morph moves, and the mock has no session-motion to glide the marks along it, so the wing's own `left` takes the surface's exact spring timing instead: both edges travel 50% minus half the same springing width, so the marks track the black without a frame of being drawn past it.

## Validation

- `./scripts/check.sh` — passed (repository, type, test, and build checks; `fail 0`).
- Headless-Chrome captures of the dev server at the panel and peek steps confirm the sixth row now fades at the panel's edge and the marks rest level with the tab bar; no physical-notch check was performed (web-only change, no desktop surface touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/f0061461-e435-4323-ae44-cbcf36bb5b88)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32154867312/artifacts/9331305874) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32154867312)

- Commit: `9cb382c75ed4213693469b301252aa54a87a3a7d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
