### PR TITLE
fix(desktop): simplify voice source labels

### DIFF
--- a/apps/desktop/src/renderer/microphone-access.ts
+++ b/apps/desktop/src/renderer/microphone-access.ts
@@ -98,20 +98,10 @@ export function quotaLevel(quota: HostedQuota): QuotaLevel {
     : QUOTA_LEVEL.RUNNING;
 }
 
-/**
- * The two sources as the toggle names them, and what each one costs. Held
- * apart from the labels so the price reads as the tag it is drawn as, and
- * together in one place so the toggle, its spoken name, and the disclosure
- * beneath can never word the same choice three ways.
- */
+/** The two sources as the toggle names them. */
 export const VOICE_SOURCE_LABEL: Record<VoiceSource, string> = {
   [VOICE_SOURCE.ACCOUNT]: "Your Luke account",
   [VOICE_SOURCE.KEY]: "Your OpenAI key",
-};
-
-export const VOICE_SOURCE_PRICE: Record<VoiceSource, string> = {
-  [VOICE_SOURCE.ACCOUNT]: "Free",
-  [VOICE_SOURCE.KEY]: "You pay",
 };
 
 /** The one line under each name: what running on it is like, day to day. */
@@ -122,7 +112,7 @@ export const VOICE_SOURCE_DETAIL: Record<VoiceSource, string> = {
 
 /** The toggle's name for a source, as a control says it aloud. */
 export function voiceSourceLabel(source: VoiceSource): string {
-  return `${VOICE_SOURCE_LABEL[source]} (${VOICE_SOURCE_PRICE[source].toLowerCase()})`;
+  return VOICE_SOURCE_LABEL[source];
 }
 
 /**
@@ -188,9 +178,9 @@ export function hostedVoiceNote(
     diagnostics?.lastOutcome === REALTIME_MINT_OUTCOME.QUOTA_EXHAUSTED &&
     (diagnostics.quota === undefined || currentQuota(diagnostics.quota, now) !== undefined);
   if (spentStands) return hostedVoiceSpentNote();
-  // What a key of your own would change is not said here: the toggle
-  // above draws both sources side by side, with what each costs on its face,
-  // and a sentence repeating one of them would be selling the other.
+  // What a key of your own would change is not said here: the toggle above
+  // draws both sources side by side, and a sentence repeating one of them
+  // would be selling the other.
   return "Talking and session checks are included free with your account, up to a daily amount.";
 }
 

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -92,7 +92,6 @@ import {
   VOICE_KEYLESS_NOTE,
   VOICE_SOURCE_DETAIL,
   VOICE_SOURCE_LABEL,
-  VOICE_SOURCE_PRICE,
   voiceAttentionNote,
   voiceSourceLabel,
 } from "./microphone-access";
@@ -2388,9 +2387,9 @@ function KeyUseDisclosure(): React.JSX.Element {
 }
 
 /**
- * The choice itself: two halves side by side, each carrying its own name and
- * its own price, with the live one marked. A radio group rather than two
- * buttons, because it is one value from a small fixed set — the same thing a
+ * The choice itself: two halves side by side, each carrying its own name, with
+ * the live one marked. A radio group rather than two buttons, because it is
+ * one value from a small fixed set — the same thing a
  * pop-up would be, drawn open because there are only two and the whole point
  * is seeing them together.
  *
@@ -2463,17 +2462,6 @@ function VoiceSourceToggle({
               />
               <span className="source-name">
                 {VOICE_SOURCE_LABEL[candidate]}
-                {/* Hidden from the reading because the radio's own name
-                    already carries the price; drawn because it is the fact
-                    worth seeing before choosing. */}
-                <span className="source-price" aria-hidden="true">
-                  {VOICE_SOURCE_PRICE[candidate]}
-                </span>
-                {/* The check rides beside the price rather than at the end of
-                    the line: the two facts a glance wants — what this costs,
-                    and that it is the one running — read as one mark. The
-                    radio already says it to a reader, so this is the drawing
-                    alone. */}
                 {live ? <CheckIcon /> : null}
               </span>
               <small>

--- a/apps/desktop/src/renderer/styles/settings.css
+++ b/apps/desktop/src/renderer/styles/settings.css
@@ -446,33 +446,6 @@
   align-items: center;
   gap: 5px;
 }
-
-/* What the half costs, as a tag rather than a sentence: two words that have
-   to be read before the name is chosen, not after. Free wears the same green
-   the meters and the switches wear for a state that is simply on. */
-.source-price {
-  flex: 0 0 auto;
-  padding: 1px 5px;
-  border-radius: 999px;
-  background: var(--raised-strong);
-  color: var(--text-tertiary);
-  font-size: 8.5px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.source-choice:first-child .source-price {
-  background: color-mix(in srgb, var(--state-complete) 20%, transparent);
-  color: color-mix(in srgb, var(--state-complete) 85%, white);
-}
-
-/* The check sits beside the price, not at the end of the line: what this half
-   costs and that it is the one running are the two things a glance is after,
-   and they read fastest as one mark. Sized to the words rather than to the
-   12px a credential row's check takes, because here it is a letter in a
-   label — and it keeps that row's green, which is the one accent on a button
-   that is otherwise the surface's own grays. */
 .source-choice .credential-check {
   width: 10px;
   height: 10px;

--- a/apps/desktop/tests/microphone-access.test.ts
+++ b/apps/desktop/tests/microphone-access.test.ts
@@ -12,7 +12,6 @@ import {
   quotaResetsWhen,
   VOICE_SOURCE_DETAIL,
   VOICE_SOURCE_LABEL,
-  VOICE_SOURCE_PRICE,
   voiceAttentionNote,
   voiceSourceLabel,
 } from "../src/renderer/microphone-access";
@@ -197,10 +196,9 @@ test("the numberless note stays short, and withholds the key from a machine that
     "Talking and session checks are included free with your account, up to a daily amount.",
   );
 
-  // What a key of the developer's own would change is the toggle's to say,
-  // drawn directly above with the price on its face. A sentence here repeating
-  // it would be the panel selling one half of a choice it is already showing
-  // whole.
+  // What a key of the developer's own would change is the toggle's to say. A
+  // sentence here repeating it would be the panel selling one half of a choice
+  // it is already showing whole.
   assert.doesNotMatch(hostedVoiceNote(undefined), /OpenAI/);
 
   // Only the minter's last outcome can speak here — a spent allowance is a
@@ -211,22 +209,12 @@ test("the numberless note stays short, and withholds the key from a machine that
   assert.match(spent, /used today's free voice — back at midnight UTC/);
 });
 
-test("the toggle names both sources and what each one costs", () => {
-  // Each half carries its own name, its own price, and one line saying what
-  // running on it is like. A half missing any of the three is a choice made
-  // blind — and the dropdown beneath does not repeat them, so the toggle is
-  // where the whole comparison has to live.
+test("the toggle names both sources and explains each one", () => {
   for (const source of [VOICE_SOURCE.ACCOUNT, VOICE_SOURCE.KEY]) {
     assert.ok(VOICE_SOURCE_LABEL[source].length > 0, source);
-    assert.ok(VOICE_SOURCE_PRICE[source].length > 0, source);
     assert.ok(VOICE_SOURCE_DETAIL[source].length > 0, source);
-    // The spoken name folds the price in, because a control read aloud as
-    // "your OpenAI key" alone withholds the one fact worth knowing first.
-    assert.match(voiceSourceLabel(source), /\(free\)|\(you pay\)/);
+    assert.equal(voiceSourceLabel(source), VOICE_SOURCE_LABEL[source]);
   }
-
-  // Free is free and the key is not: the two prices must never read the same.
-  assert.notEqual(VOICE_SOURCE_PRICE[VOICE_SOURCE.ACCOUNT], VOICE_SOURCE_PRICE[VOICE_SOURCE.KEY]);
 });
 
 test("a meter warns while there is still something left to spend differently", () => {


### PR DESCRIPTION
## Summary

- Remove the `Free` and `You pay` badges from the voice-source toggle.
- Keep visible and accessible source names aligned, with the existing explanatory detail underneath.
- Update coverage and stale comments for the simplified labels.

## Test coverage

- Coverage audit: 100% (2/2 changed label paths; 0 gaps).
- Targeted microphone-access tests: 13 passed, 0 failed.

## Pre-landing review

- No functional, security, or data-safety issues found.
- Removed stale comments that still described the deleted price badges.

## Verification

- `./scripts/verify.sh` passed: repository checks, lint, typecheck, 1,288 tests, builds, macOS packaging, and fixture evidence generation.
- Inspected the generated expanded-state visual evidence; no rendering regression observed.
- Physical-notch check was not performed.

## Test plan

- [x] Voice-source labels no longer include price suffixes.
- [x] Existing source details remain present.
- [x] Full macOS verification passes.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32172629554/artifacts/9337862564) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32172629554)

- Commit: `86e68051deab5eb22cfd7fecff51a970ccef5279`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
