### PR TITLE
refactor(desktop): remove excessive panel animations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -320,11 +320,13 @@ nothing.
 
 One spring for everything that moves. `--spring` drives the surface;
 `--spring-fast` is the same damping ratio at a higher frequency for small
-elements like the tab thumb, so the bounce profile is identical and only the
-scale differs. Panel content arrives as one stack: the tab bar is index 0 and
-each row below it starts further up, so the gaps spring open rather than the
-rows sliding in as a block. The fan and the stagger stop accumulating past
-`--row-fan-limit`, because only about five rows are ever on screen.
+elements like switch thumbs, so the bounce profile is identical and only the
+scale differs. Settings pages and the tab selection indicator change at once;
+task navigation does not travel. Panel content arrives as one stack: the tab
+bar is index 0 and each row below it starts further up, so the gaps spring open
+rather than the rows sliding in as a block. The fan and the stagger stop
+accumulating past `--row-fan-limit`, because only about five rows are ever on
+screen.
 
 In either direction the shape and its content must not cross, or content is
 left drawn on the desktop: growing, the surface leads and content follows;

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -8,10 +8,11 @@ that review is to build from them.
 
 ## The vocabulary
 
-One spring drives everything: `--spring` for the surface and anything that
-travels with it, `--spring-fast` — the same damping ratio at a higher
-frequency — for small elements like the tab thumb and switch thumbs. Durations
-and delays come only from the tokens in
+One spring drives everything that needs to travel: `--spring` for the surface
+and anything that travels with it, `--spring-fast` — the same damping ratio at
+a higher frequency — for small elements like switch thumbs. Settings pages and
+the tab selection indicator change at once; task navigation does not travel.
+Durations and delays come only from the tokens in
 `packages/sidecar-core/src/motion-tokens.css` (`--duration-shape`,
 `--duration-exit`, `--duration-quick`, `--duration-fast`, `--expand-delay`,
 `--peek-delay`, `--slot-delay`, `--row-stagger`). Never write a literal

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -260,7 +260,9 @@ export function App(): React.JSX.Element {
   );
   const [display, setDisplay] = useState<DisplayDiagnostic>();
   const [tab, setTab, tabNow] = useStateWithRef<PanelTab>(PANEL_TAB.SESSIONS);
-  const [settingsView, setSettingsView] = useState<SettingsView>(SETTINGS_VIEW.ROOT);
+  const [settingsView, setSettingsView, settingsViewNow] = useStateWithRef<SettingsView>(
+    SETTINGS_VIEW.ROOT,
+  );
   const [sessionView, setSessionView] = useState<SessionView>(DEFAULT_SESSION_VIEW);
   const [optionsOpen, setOptionsOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
@@ -491,7 +493,7 @@ export function App(): React.JSX.Element {
       // starts in it — set their page right after this reset.
       setSettingsView(SETTINGS_VIEW.ROOT);
     },
-    [setTab],
+    [setSettingsView, setTab],
   );
 
   // A choice made in the sheet puts the sheet away. It is drawn over the list
@@ -587,7 +589,12 @@ export function App(): React.JSX.Element {
       const { run, launch } = nextErrand(errandRun.current);
       errandRun.current = run;
       if (launch === undefined) return;
-      const wait = errandWait(launch.opening);
+      const wait = errandWait({
+        opening: launch.opening,
+        surfaceChanging:
+          launch.page !== undefined &&
+          (tabNow() !== launch.tab || settingsViewNow() !== launch.page),
+      });
       // The control has to be drawn to be flown to, and a settings page that is
       // not open is not drawn at all — so the tab comes forward and then the
       // page the setting lives on, in that order, because arriving at the tab
@@ -612,7 +619,7 @@ export function App(): React.JSX.Element {
       errandRun.current = finished.run;
       drawErrandHold(finished.hold);
     }
-  }, [changeTab, drawErrandHold, presentationOf]);
+  }, [changeTab, drawErrandHold, presentationOf, setSettingsView, settingsViewNow, tabNow]);
 
   /** Adds an act to the run, and sends Luke off if he is not already out. */
   const armErrandFlight = useCallback(
@@ -636,7 +643,7 @@ export function App(): React.JSX.Element {
     // note was written — would land on a page nobody is looking at.
     setSettingsView(standDownPage.current);
     expand();
-  }, [changeTab, expand]);
+  }, [changeTab, expand, setSettingsView]);
 
   /**
    * Applies a settings write's reply: the snapshot the store actually holds,
@@ -1866,6 +1873,7 @@ export function App(): React.JSX.Element {
     cancelHover,
     changeTab,
     setMicrophoneStatus,
+    setSettingsView,
     startMicrophone,
     stopMicrophone,
     summonAsk,
@@ -2051,6 +2059,7 @@ export function App(): React.JSX.Element {
     optionsOpen,
     presentation,
     searchOpen,
+    setSettingsView,
     settingsView,
     signInWaitNow,
     stopSpeaking,

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -260,12 +260,7 @@ export function App(): React.JSX.Element {
   );
   const [display, setDisplay] = useState<DisplayDiagnostic>();
   const [tab, setTab, tabNow] = useStateWithRef<PanelTab>(PANEL_TAB.SESSIONS);
-  // The drawn page has to be readable from a callback as well as rendered: an
-  // errand coming up for its turn reads it to decide whether a page still has
-  // to be turned before the mark can be measured against anything.
-  const [settingsView, setSettingsView, settingsViewNow] = useStateWithRef<SettingsView>(
-    SETTINGS_VIEW.ROOT,
-  );
+  const [settingsView, setSettingsView] = useState<SettingsView>(SETTINGS_VIEW.ROOT);
   const [sessionView, setSessionView] = useState<SessionView>(DEFAULT_SESSION_VIEW);
   const [optionsOpen, setOptionsOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
@@ -496,7 +491,7 @@ export function App(): React.JSX.Element {
       // starts in it — set their page right after this reset.
       setSettingsView(SETTINGS_VIEW.ROOT);
     },
-    [setSettingsView, setTab],
+    [setTab],
   );
 
   // A choice made in the sheet puts the sheet away. It is drawn over the list
@@ -592,16 +587,7 @@ export function App(): React.JSX.Element {
       const { run, launch } = nextErrand(errandRun.current);
       errandRun.current = run;
       if (launch === undefined) return;
-      // What the flight has to wait out, read off the panel as it is drawn
-      // this moment — which is the last moment it is true, because turning the
-      // tab and the page below is the very thing being waited for.
-      const wait = errandWait({
-        opening: launch.opening,
-        tab: launch.tab,
-        ...(launch.page === undefined ? {} : { page: launch.page }),
-        drawnTab: tabNow(),
-        drawnPage: settingsViewNow(),
-      });
+      const wait = errandWait(launch.opening);
       // The control has to be drawn to be flown to, and a settings page that is
       // not open is not drawn at all — so the tab comes forward and then the
       // page the setting lives on, in that order, because arriving at the tab
@@ -626,7 +612,7 @@ export function App(): React.JSX.Element {
       errandRun.current = finished.run;
       drawErrandHold(finished.hold);
     }
-  }, [changeTab, drawErrandHold, presentationOf, setSettingsView, settingsViewNow, tabNow]);
+  }, [changeTab, drawErrandHold, presentationOf]);
 
   /** Adds an act to the run, and sends Luke off if he is not already out. */
   const armErrandFlight = useCallback(
@@ -650,7 +636,7 @@ export function App(): React.JSX.Element {
     // note was written — would land on a page nobody is looking at.
     setSettingsView(standDownPage.current);
     expand();
-  }, [changeTab, expand, setSettingsView]);
+  }, [changeTab, expand]);
 
   /**
    * Applies a settings write's reply: the snapshot the store actually holds,
@@ -1880,7 +1866,6 @@ export function App(): React.JSX.Element {
     cancelHover,
     changeTab,
     setMicrophoneStatus,
-    setSettingsView,
     startMicrophone,
     stopMicrophone,
     summonAsk,
@@ -2066,7 +2051,6 @@ export function App(): React.JSX.Element {
     optionsOpen,
     presentation,
     searchOpen,
-    setSettingsView,
     settingsView,
     signInWaitNow,
     stopSpeaking,

--- a/apps/desktop/src/renderer/errand-queue.ts
+++ b/apps/desktop/src/renderer/errand-queue.ts
@@ -200,29 +200,10 @@ export function errandBorrowedPanel(borrowed: boolean, launch: PendingErrand): b
 }
 
 /**
- * What a flight has to wait out before it can measure anything, read off what
- * the panel is drawing at the moment the act comes up rather than at the
- * moment it was asked for. In a run of several, the page drawn when the second
- * act was spoken is the first act's page, and by the time the second flies it
- * may be a third — only the reading taken as it launches says what the mark
- * will actually land on.
- *
- * A panel that had to open is a whole page of content arriving. A control
- * already drawn owes nothing but a beat. Anything else is a page being turned:
- * the leaving one goes first and the arriving one lands on the panel's own
- * fan, which is the longest trail of the three.
+ * A panel that had to open is a whole page of content arriving. Once the panel
+ * is open, settings pages swap without motion, so every control owes nothing
+ * but the beat that lets its newly mounted row enter the layout.
  */
-export function errandWait(input: {
-  opening: boolean;
-  tab: PanelTab;
-  page?: SettingsView;
-  drawnTab: PanelTab;
-  drawnPage: SettingsView;
-}): ErrandWait {
-  if (input.opening) return ERRAND_WAIT.CONTENT;
-  // The tab bar and the list's own options button are drawn outside the
-  // settings pages, so there is no page to turn to for them.
-  if (input.page === undefined) return ERRAND_WAIT.AT_ONCE;
-  if (input.drawnTab === input.tab && input.drawnPage === input.page) return ERRAND_WAIT.AT_ONCE;
-  return ERRAND_WAIT.PAGE;
+export function errandWait(opening: boolean): ErrandWait {
+  return opening ? ERRAND_WAIT.CONTENT : ERRAND_WAIT.AT_ONCE;
 }

--- a/apps/desktop/src/renderer/errand-queue.ts
+++ b/apps/desktop/src/renderer/errand-queue.ts
@@ -200,10 +200,11 @@ export function errandBorrowedPanel(borrowed: boolean, launch: PendingErrand): b
 }
 
 /**
- * A panel that had to open is a whole page of content arriving. Once the panel
- * is open, settings pages swap without motion, so every control owes nothing
- * but the beat that lets its newly mounted row enter the layout.
+ * A panel that had to open is a whole page of content arriving. Settings pages
+ * swap without motion, but a page whose height changes still has to wait for
+ * the black surface to reach its newly mounted control.
  */
-export function errandWait(opening: boolean): ErrandWait {
-  return opening ? ERRAND_WAIT.CONTENT : ERRAND_WAIT.AT_ONCE;
+export function errandWait(input: { opening: boolean; surfaceChanging: boolean }): ErrandWait {
+  if (input.opening) return ERRAND_WAIT.CONTENT;
+  return input.surfaceChanging ? ERRAND_WAIT.SURFACE : ERRAND_WAIT.AT_ONCE;
 }

--- a/apps/desktop/src/renderer/luke-errand.tsx
+++ b/apps/desktop/src/renderer/luke-errand.tsx
@@ -150,6 +150,8 @@ export const ERRAND_WAIT = {
   AT_ONCE: "at-once",
   /** The panel opened for this, so a whole page of content is arriving. */
   CONTENT: "content",
+  /** An instant page swap changed the black surface's height. */
+  SURFACE: "surface",
 } as const;
 
 export type ErrandWait = (typeof ERRAND_WAIT)[keyof typeof ERRAND_WAIT];
@@ -258,16 +260,21 @@ export function errandFlies(tokens: ErrandTokens): boolean {
  *
  * The wait before setting off is the whole of what the act it signs has set in
  * motion. A panel that had to open costs the shape's travel plus the delay and
- * stagger its content arrives on. An errand that set off inside it would be
- * crossing a surface still growing and landing where a row had not finished
- * arriving.
+ * stagger its content arrives on. An instant page swap has no content motion,
+ * but its flight still waits for the surface's edge when the destination page
+ * changes its height.
  */
 export function errandBeats(tokens: ErrandTokens, wait: ErrandWait): ErrandBeats {
   const duration = tokens.shape * 2 + tokens.quick;
   const arrival = tokens.shape / duration;
   const arriving = tokens.expand + tokens.stagger * tokens.fanLimit + tokens.shape;
   return {
-    delay: wait === ERRAND_WAIT.AT_ONCE ? tokens.quick : arriving,
+    delay:
+      wait === ERRAND_WAIT.AT_ONCE
+        ? tokens.quick
+        : wait === ERRAND_WAIT.SURFACE
+          ? tokens.shape
+          : arriving,
     duration,
     arrival,
     departure: (tokens.shape + tokens.quick) / duration,

--- a/apps/desktop/src/renderer/luke-errand.tsx
+++ b/apps/desktop/src/renderer/luke-errand.tsx
@@ -150,8 +150,6 @@ export const ERRAND_WAIT = {
   AT_ONCE: "at-once",
   /** The panel opened for this, so a whole page of content is arriving. */
   CONTENT: "content",
-  /** A settings page is being turned too, and one leaves before the next arrives. */
-  PAGE: "page",
 } as const;
 
 export type ErrandWait = (typeof ERRAND_WAIT)[keyof typeof ERRAND_WAIT];
@@ -260,22 +258,16 @@ export function errandFlies(tokens: ErrandTokens): boolean {
  *
  * The wait before setting off is the whole of what the act it signs has set in
  * motion. A panel that had to open costs the shape's travel plus the delay and
- * stagger its content arrives on; a settings page turned as well costs that
- * again — the pages arrive on the very same fan — behind the exit the leaving
- * page takes first. An errand that set off inside either would be crossing a
- * surface still growing and landing where a row had not finished arriving.
+ * stagger its content arrives on. An errand that set off inside it would be
+ * crossing a surface still growing and landing where a row had not finished
+ * arriving.
  */
 export function errandBeats(tokens: ErrandTokens, wait: ErrandWait): ErrandBeats {
   const duration = tokens.shape * 2 + tokens.quick;
   const arrival = tokens.shape / duration;
   const arriving = tokens.expand + tokens.stagger * tokens.fanLimit + tokens.shape;
   return {
-    delay:
-      wait === ERRAND_WAIT.AT_ONCE
-        ? tokens.quick
-        : wait === ERRAND_WAIT.PAGE
-          ? tokens.exit + arriving
-          : arriving,
+    delay: wait === ERRAND_WAIT.AT_ONCE ? tokens.quick : arriving,
     duration,
     arrival,
     departure: (tokens.shape + tokens.quick) / duration,

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -120,7 +120,6 @@ import {
   UserIcon,
 } from "./settings-icons";
 import {
-  pageExitMs,
   SETTINGS_SUBVIEW_LIST,
   SETTINGS_VIEW,
   type SettingsSubview,
@@ -2904,69 +2903,45 @@ export function SettingsPanel({
   const voiceNote = microphone.voiceAvailable
     ? voiceAttentionNote({ voiceAvailable: true, status: microphone.status })
     : undefined;
-  // The page as drawn, trailing the page as asked: turning one is a leave and
-  // then an arrival, and the leaving page must be held mounted through its own
-  // exit — the surface never resizes out from under something still drawn.
-  // The swap is timed off the token the stylesheet fades with, read live off
-  // the element: a capture run and reduced motion zero it, and the drawn page
-  // has to swap as fast as the fade they stilled.
-  const box = useRef<HTMLDivElement | null>(null);
-  const [drawnView, setDrawnView] = useState(view);
-  // Whether a page has turned since this panel mounted, which is what scopes
-  // the arrival animation: the tab's first draw belongs to the panel-arrival
-  // transition alone.
-  const [turned, setTurned] = useState(false);
-  const leaving = drawnView !== view;
-  useEffect(() => {
-    if (!leaving) return;
-    const timer = window.setTimeout(() => {
-      setDrawnView(view);
-      setTurned(true);
-    }, pageExitMs(box.current));
-    return () => window.clearTimeout(timer);
-  }, [leaving, view]);
   // Moving between pages moves the keyboard with it: into a page, onto its
   // back button; back out, onto the row that opened the page just left. Keyed
-  // to the drawn page, because the control being reached for only exists once
-  // the new page is mounted. Only while the panel is the shape on screen — a
+  // to the page, because the control being reached for only exists once the
+  // new page is mounted. Only while the panel is the shape on screen — a
   // view reset behind a closed panel is housekeeping, and reaching into an
   // inert stage would find nothing focusable anyway.
   const backControl = useRef<HTMLButtonElement | null>(null);
-  const heldView = useRef(drawnView);
+  const heldView = useRef(view);
   useEffect(() => {
     const previous = heldView.current;
-    heldView.current = drawnView;
-    if (previous === drawnView || !panelOpen) return;
-    if (drawnView === SETTINGS_VIEW.ROOT) {
+    heldView.current = view;
+    if (previous === view || !panelOpen) return;
+    if (view === SETTINGS_VIEW.ROOT) {
       if (previous !== SETTINGS_VIEW.ROOT) {
         document.getElementById(settingsNavRowId(previous))?.focus();
       }
       return;
     }
     backControl.current?.focus();
-  }, [drawnView, panelOpen]);
+  }, [view, panelOpen]);
   // The drawn page's reset, absent while that page stands at its defaults.
-  const pageReset = pageResetControl(drawnView, settings, shortcuts, preferences);
+  const pageReset = pageResetControl(view, settings, shortcuts, preferences);
   return (
     <div
-      ref={box}
       className="settings"
       role="tabpanel"
       id={panelPanelId(PANEL_TAB.SETTINGS)}
       aria-labelledby={panelTabId(PANEL_TAB.SETTINGS)}
-      data-page-leaving={String(leaving)}
-      data-page-turned={String(turned)}
     >
-      {drawnView !== SETTINGS_VIEW.ROOT ? (
+      {view !== SETTINGS_VIEW.ROOT ? (
         <SettingsPageHeader
-          view={drawnView}
+          view={view}
           onBack={() => onViewChange(SETTINGS_VIEW.ROOT)}
           backControl={backControl}
           {...(pageReset ? { reset: pageReset } : {})}
         />
       ) : null}
 
-      {drawnView === SETTINGS_VIEW.ROOT ? (
+      {view === SETTINGS_VIEW.ROOT ? (
         /* The front page: what voice runs on and what is left of it today,
            then one row per page, then the sections that answer at a glance —
            what Luke is allowed, the way to the founders, whose account this
@@ -3001,15 +2976,15 @@ export function SettingsPanel({
         </>
       ) : null}
 
-      {drawnView === SETTINGS_VIEW.VOICE && settings ? (
+      {view === SETTINGS_VIEW.VOICE && settings ? (
         <VoiceSection settings={settings} preferences={preferences} microphone={microphone} />
       ) : null}
 
-      {drawnView === SETTINGS_VIEW.APPEARANCE && settings ? (
+      {view === SETTINGS_VIEW.APPEARANCE && settings ? (
         <AppearanceSection settings={settings} preferences={preferences} />
       ) : null}
 
-      {drawnView === SETTINGS_VIEW.SHORTCUTS ? (
+      {view === SETTINGS_VIEW.SHORTCUTS ? (
         <ShortcutSection
           shortcuts={shortcuts}
           {...(settings ? { settings } : {})}
@@ -3017,7 +2992,7 @@ export function SettingsPanel({
         />
       ) : null}
 
-      {drawnView === SETTINGS_VIEW.CONNECTIONS && settings ? (
+      {view === SETTINGS_VIEW.CONNECTIONS && settings ? (
         <>
           <CredentialsSection
             settings={settings}
@@ -3040,7 +3015,7 @@ export function SettingsPanel({
         </>
       ) : null}
 
-      {drawnView !== SETTINGS_VIEW.ROOT ? null : (
+      {view !== SETTINGS_VIEW.ROOT ? null : (
         <>
           <UpdatesSection control={updates} />
 

--- a/apps/desktop/src/renderer/settings-views.ts
+++ b/apps/desktop/src/renderer/settings-views.ts
@@ -32,34 +32,6 @@ export const SETTINGS_SUBVIEW_LIST = [
 export type SettingsSubview = (typeof SETTINGS_SUBVIEW_LIST)[number];
 
 /**
- * How long a leaving page's content takes to go when the token cannot be
- * read, in milliseconds — a mirror of the stylesheet's resting
- * `--duration-exit`, which is what fades it. The live value comes off the
- * element instead wherever possible, because a capture run and reduced
- * motion both zero the token, and the drawn page must swap as fast as the
- * fade they stilled.
- */
-export const PAGE_EXIT_MS = 90;
-
-/**
- * The stylesheet's `--duration-exit` as milliseconds. A computed time keeps
- * its authored unit, so both spellings are read; anything unreadable falls
- * back to the token's resting value rather than to no exit at all.
- */
-export function pageExitFromToken(token: string): number {
-  const trimmed = token.trim();
-  const scale = trimmed.endsWith("ms") ? 1 : trimmed.endsWith("s") ? 1000 : undefined;
-  const parsed = Number.parseFloat(trimmed);
-  return scale === undefined || Number.isNaN(parsed) ? PAGE_EXIT_MS : parsed * scale;
-}
-
-/** Reads the exit duration off the element the fade actually runs on. */
-export function pageExitMs(element: Element | null): number {
-  if (!element) return PAGE_EXIT_MS;
-  return pageExitFromToken(getComputedStyle(element).getPropertyValue("--duration-exit"));
-}
-
-/**
  * Which page each setting is drawn on.
  *
  * A page that is not open is not rendered at all, so this is what anything

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1777,7 +1777,6 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   border-radius: 8px;
   background: var(--raised-strong);
   transform: translateX(calc(var(--tab-index) * 100%));
-  transition: transform var(--duration-fast) var(--spring-fast);
 }
 
 /* The radius is the thumb's, not a shape of its own: the tab draws no
@@ -2603,7 +2602,6 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   .wing-meter,
   .count-badge,
   .count-caption,
-  .tab-thumb,
   .session-row {
     transition-duration: 1ms;
     transition-delay: 0ms;

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1745,7 +1745,9 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   /* A page lands in layout at once, while the black surface takes one spring
      to its new height. The panel follows that same edge so newly mounted rows
      cannot paint onto the transparent window below it. */
-  clip-path: inset(0 0 calc(100% - var(--panel-height, 520px)) 0);
+  clip-path: inset(
+    0 0 calc(100% - var(--panel-height, 520px)) 0 round 0 0 var(--panel-radius) var(--panel-radius)
+  );
   transition: clip-path var(--duration-shape) var(--spring);
 }
 

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1742,6 +1742,11 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   flex-direction: column;
   padding: calc(max(var(--notch-top-inset), 32px) + 14px) var(--panel-inset) 18px;
   border-radius: 0 0 var(--panel-radius) var(--panel-radius);
+  /* A page lands in layout at once, while the black surface takes one spring
+     to its new height. The panel follows that same edge so newly mounted rows
+     cannot paint onto the transparent window below it. */
+  clip-path: inset(0 0 calc(100% - var(--panel-height, 520px)) 0);
+  transition: clip-path var(--duration-shape) var(--spring);
 }
 
 .app-stage[data-presentation="panel"] .expanded-panel {

--- a/apps/desktop/src/renderer/styles/settings.css
+++ b/apps/desktop/src/renderer/styles/settings.css
@@ -162,50 +162,6 @@
   background: none;
 }
 
-/* Turning a settings page follows the shape contract. Leaving: the old page's
-   content goes first, over `--duration-exit` and with no delay — the state
-   being entered declares its own `--row-delay` — and only its end releases
-   the room, so the surface never resizes out from under something still
-   drawn. The swap is timed off this same token, read live off the element
-   (`pageExitMs`), so a capture run or reduced motion — which zero it — swap
-   as fast as they stilled the fade. */
-.settings[data-page-leaving="true"] .settings-header,
-.settings[data-page-leaving="true"] .settings-section,
-.settings[data-page-leaving="true"] .quit-button {
-  --row-delay: 0s;
-
-  opacity: 0;
-}
-
-/* Arriving: the new page's room lands at once — the surface takes one clean
-   spring — and its content becomes visible only over black, riding the pair
-   every arriving element rides on the same `--row-delay` the panel's own
-   arrival fans out with. A mount animation with `backwards` fill rather than
-   a transition, because an element cannot transition from a style it never
-   held. Scoped to a panel that has actually turned a page, so the tab's
-   first draw stays the panel-arrival transition's alone. */
-@keyframes settings-page-fade {
-  from {
-    opacity: 0;
-  }
-}
-
-@keyframes settings-page-travel {
-  from {
-    transform: translateY(
-      calc((min(var(--row-index, 0), var(--row-fan-limit)) + 1) * var(--row-fan) * -1)
-    );
-  }
-}
-
-.settings[data-page-turned="true"] .settings-header,
-.settings[data-page-turned="true"] .settings-section,
-.settings[data-page-turned="true"] .quit-button {
-  animation:
-    settings-page-fade var(--duration-quick) var(--motion-exit) var(--row-delay) backwards,
-    settings-page-travel var(--duration-shape) var(--spring) var(--row-delay) backwards;
-}
-
 /* A front-page row that opens a page rather than holding a control: glyph,
    name, what the page holds, and the chevron that promises somewhere to go.
    The hover bleeds to the section's padding so the pill reads as the row. */

--- a/apps/desktop/tests/errand-queue.test.ts
+++ b/apps/desktop/tests/errand-queue.test.ts
@@ -252,7 +252,8 @@ test("a panel asked for out loud is nobody's to take away afterwards", () => {
   assert.equal(errandBorrowedPanel(false, shows(true)), false);
 });
 
-test("a flight waits only when it had to open the panel", () => {
-  assert.equal(errandWait(true), ERRAND_WAIT.CONTENT);
-  assert.equal(errandWait(false), ERRAND_WAIT.AT_ONCE);
+test("a flight waits for every surface edge its act moves", () => {
+  assert.equal(errandWait({ opening: true, surfaceChanging: true }), ERRAND_WAIT.CONTENT);
+  assert.equal(errandWait({ opening: false, surfaceChanging: true }), ERRAND_WAIT.SURFACE);
+  assert.equal(errandWait({ opening: false, surfaceChanging: false }), ERRAND_WAIT.AT_ONCE);
 });

--- a/apps/desktop/tests/errand-queue.test.ts
+++ b/apps/desktop/tests/errand-queue.test.ts
@@ -252,47 +252,7 @@ test("a panel asked for out loud is nobody's to take away afterwards", () => {
   assert.equal(errandBorrowedPanel(false, shows(true)), false);
 });
 
-test("a flight waits out whatever the act it signs has set in motion", () => {
-  const drawn = { drawnTab: PANEL_TAB.SETTINGS, drawnPage: SETTINGS_VIEW.VOICE };
-
-  // A panel that had to open is a whole page of content arriving, whatever
-  // else is true.
-  assert.equal(
-    errandWait({ ...drawn, opening: true, tab: PANEL_TAB.SETTINGS, page: SETTINGS_VIEW.VOICE }),
-    ERRAND_WAIT.CONTENT,
-  );
-  // The page the control is on is already the drawn one: a beat, and go.
-  assert.equal(
-    errandWait({ ...drawn, opening: false, tab: PANEL_TAB.SETTINGS, page: SETTINGS_VIEW.VOICE }),
-    ERRAND_WAIT.AT_ONCE,
-  );
-  // The second of two settings, on a page the first was not on: the leaving
-  // page goes before the arriving one is drawn at all.
-  assert.equal(
-    errandWait({
-      ...drawn,
-      opening: false,
-      tab: PANEL_TAB.SETTINGS,
-      page: SETTINGS_VIEW.APPEARANCE,
-    }),
-    ERRAND_WAIT.PAGE,
-  );
-  // Same page, but the panel is showing the sessions: the tab has to come
-  // forward, and it arrives on its own front page first.
-  assert.equal(
-    errandWait({
-      drawnTab: PANEL_TAB.SESSIONS,
-      drawnPage: SETTINGS_VIEW.ROOT,
-      opening: false,
-      tab: PANEL_TAB.SETTINGS,
-      page: SETTINGS_VIEW.VOICE,
-    }),
-    ERRAND_WAIT.PAGE,
-  );
-  // The tab bar and the list's options button are drawn outside the settings
-  // pages, so an act landing on one waits for no page at all.
-  assert.equal(
-    errandWait({ ...drawn, opening: false, tab: PANEL_TAB.SESSIONS }),
-    ERRAND_WAIT.AT_ONCE,
-  );
+test("a flight waits only when it had to open the panel", () => {
+  assert.equal(errandWait(true), ERRAND_WAIT.CONTENT);
+  assert.equal(errandWait(false), ERRAND_WAIT.AT_ONCE);
 });

--- a/apps/desktop/tests/luke-errand.test.ts
+++ b/apps/desktop/tests/luke-errand.test.ts
@@ -198,23 +198,6 @@ test("an errand that opened the panel trails the whole opening", () => {
   assert.equal(errandBeats(TOKENS, ERRAND_WAIT.CONTENT).delay, 200 + 32 * 5 + 460);
 });
 
-test("an errand that turned a settings page waits for the page it turned to", () => {
-  // A settings page is not drawn until the page it replaced has finished
-  // leaving, and then it arrives on the very fan the panel's own content
-  // does — so the wait is that arrival with the leaving page's exit in front
-  // of it. Measured any sooner, the mark lands where a row was passing.
-  assert.equal(
-    errandBeats(TOKENS, ERRAND_WAIT.PAGE).delay,
-    90 + errandBeats(TOKENS, ERRAND_WAIT.CONTENT).delay,
-  );
-  // Only the wait changes: the flight itself is one flight however it started.
-  const page = errandBeats(TOKENS, ERRAND_WAIT.PAGE);
-  const content = errandBeats(TOKENS, ERRAND_WAIT.CONTENT);
-  assert.equal(page.duration, content.duration);
-  assert.equal(page.arrival, content.arrival);
-  assert.equal(page.home, content.home);
-});
-
 /** The window, and the black drawn in the middle of it: a 620-wide open panel. */
 const STAGE = { left: 0, top: 0, width: 1512, height: 600 };
 const SURFACE = { left: 446, top: 0, width: 620, height: 520 };

--- a/apps/desktop/tests/luke-errand.test.ts
+++ b/apps/desktop/tests/luke-errand.test.ts
@@ -198,6 +198,10 @@ test("an errand that opened the panel trails the whole opening", () => {
   assert.equal(errandBeats(TOKENS, ERRAND_WAIT.CONTENT).delay, 200 + 32 * 5 + 460);
 });
 
+test("an errand crossing an instant page swap waits for the black surface", () => {
+  assert.equal(errandBeats(TOKENS, ERRAND_WAIT.SURFACE).delay, TOKENS.shape);
+});
+
 /** The window, and the black drawn in the middle of it: a 620-wide open panel. */
 const STAGE = { left: 0, top: 0, width: 1512, height: 600 };
 const SURFACE = { left: 446, top: 0, width: 620, height: 520 };

--- a/apps/desktop/tests/settings-views.test.ts
+++ b/apps/desktop/tests/settings-views.test.ts
@@ -2,9 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
   credentialSettingsPage,
-  PAGE_EXIT_MS,
   PANEL_STAND_DOWN,
-  pageExitFromToken,
   SETTINGS_VIEW,
   standDownReturnPage,
 } from "../src/renderer/settings-views";
@@ -12,25 +10,6 @@ import {
   CREDENTIAL_PROVIDER_LIST,
   VOICE_CREDENTIAL_PROVIDER_ID,
 } from "../src/shared/credential-providers";
-
-test("the page swap reads the exit token in either unit", () => {
-  assert.equal(pageExitFromToken("90ms"), 90);
-  assert.equal(pageExitFromToken(" 90ms "), 90);
-  assert.equal(pageExitFromToken("0.09s"), 90);
-});
-
-test("a zeroed token swaps at once, the way capture and reduced motion still the fade", () => {
-  // Capture zeroes the token as a length of seconds; reduced motion leaves a
-  // millisecond so transitions still fire. Either way the swap must not wait
-  // out an exit that is not running.
-  assert.equal(pageExitFromToken("0s"), 0);
-  assert.equal(pageExitFromToken("1ms"), 1);
-});
-
-test("a token that cannot be read falls back to the resting exit, not to none", () => {
-  assert.equal(pageExitFromToken(""), PAGE_EXIT_MS);
-  assert.equal(pageExitFromToken("fast"), PAGE_EXIT_MS);
-});
 
 test("a credential entry returns to the page its row is drawn on", () => {
   // The OpenAI row lives in the What Luke runs on section at the top of the front


### PR DESCRIPTION
## Summary
- make settings pages and the panel tab indicator change immediately instead of traveling or fading
- simplify errand timing now that settings-page transitions no longer need to settle
- update the binding motion contract and remove obsolete transition tests and helpers

## Verification
- `./scripts/verify.sh`
  - repository contract checks passed
  - typecheck passed
  - 40 harness tests, 213 sidecar-core tests, 40 web tests, and 1,027 desktop tests passed
  - desktop and web builds passed
  - macOS native helpers and app packaging passed
  - six fixture evidence captures generated
- visual inspection: expanded, compact, peek, key-entry, speaking, and muted captures show no clipping, transparent gaps, or spacing regressions
- physical-notch check: not performed

## Test plan
- [x] Settings-page state changes remain covered by the desktop test suite
- [x] Errand waits cover panel-opening and already-open cases
- [x] Full macOS packaging and fixture evidence completed

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32183640558/artifacts/9341682592) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32183640558)

- Commit: `8025000af991113dc026a9d5229008ce2f620dbb`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
