### PR TITLE
fix(desktop): keep a development build's Keychain grant across rebuilds

### DIFF
--- a/apps/desktop/scripts/package-config.mjs
+++ b/apps/desktop/scripts/package-config.mjs
@@ -34,6 +34,9 @@ export const SIGNING_MODE = {
   DEVELOPER_ID: "developer-id",
 };
 
+/** `codesign`'s own name for signing without an identity. */
+export const AD_HOC_IDENTITY = "-";
+
 export function addonCompilerArguments(source, output, frameworks = ["AppKit"]) {
   return [
     "clang",
@@ -73,6 +76,25 @@ export function resolveSigningMode(env) {
   const identity =
     typeof env.LUKE_CODESIGN_IDENTITY === "string" ? env.LUKE_CODESIGN_IDENTITY.trim() : "";
   return identity ? { mode: SIGNING_MODE.DEVELOPER_ID, identity } : { mode: SIGNING_MODE.AD_HOC };
+}
+
+/**
+ * The identity a development package is signed with, ad-hoc unless one is
+ * named. An ad-hoc signature carries no identity, so macOS derives the
+ * designated requirement from the bytes themselves — a bare `cdhash`, new on
+ * every build. The Keychain binds an item's trust to that requirement, so each
+ * rebuild is a program it has never seen and the login-password dialog returns,
+ * however many times "Always Allow" was pressed before. An identity moves the
+ * requirement onto the certificate, which every later build satisfies.
+ *
+ * This decides nothing else: `resolveSigningMode` still reads ad-hoc, so the
+ * build is still not a release, still answers to the development name, and
+ * still keeps the development Keychain entry apart from the released app's.
+ */
+export function developmentSigningIdentity(env) {
+  const identity =
+    typeof env.LUKE_DEV_CODESIGN_IDENTITY === "string" ? env.LUKE_DEV_CODESIGN_IDENTITY.trim() : "";
+  return identity || AD_HOC_IDENTITY;
 }
 
 /**

--- a/apps/desktop/scripts/package.mjs
+++ b/apps/desktop/scripts/package.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { packager } from "@electron/packager";
 import {
   createPackagerOptions,
+  developmentSigningIdentity,
   ICONSET_SOURCES,
   iconutilArguments,
   LICENSE_RESOURCE_NAME,
@@ -91,9 +92,11 @@ if (!fs.readFileSync(packagedIconPath).equals(fs.readFileSync(iconPath))) {
 }
 
 if (signing.mode === SIGNING_MODE.AD_HOC) {
-  execFileSync("codesign", ["--force", "--deep", "--sign", "-", appPath], {
-    stdio: "inherit",
-  });
+  execFileSync(
+    "codesign",
+    ["--force", "--deep", "--sign", developmentSigningIdentity(process.env), appPath],
+    { stdio: "inherit" },
+  );
 }
 execFileSync("codesign", ["--verify", "--deep", "--strict", appPath], {
   stdio: "inherit",

--- a/scripts/lib/workspace.sh
+++ b/scripts/lib/workspace.sh
@@ -160,7 +160,11 @@ sidecar_require_node() {
 # with, the prompt is the cost of a development run and the bundle is left as
 # Electron shipped it.
 sidecar_sign_development_electron() {
-    local identity=${LUKE_DEV_CODESIGN_IDENTITY:-}
+    # Trimmed the way `developmentSigningIdentity` trims it, so a padded value
+    # reads as unset here too rather than reaching codesign as a name wrapped in
+    # spaces — which would fail the lookup and take the whole launch down.
+    local identity
+    read -r identity <<<"${LUKE_DEV_CODESIGN_IDENTITY:-}"
     if [[ -z $identity ]]; then
         return 0
     fi
@@ -174,8 +178,11 @@ sidecar_sign_development_electron() {
 
     # Electron's postinstall re-extracts the ad-hoc bundle, so the signature on
     # disk rather than a marker decides whether this run has anything to do.
+    # The signature line comes from `-dvv`; `--display` alone reports only the
+    # executable path, which would leave the ad-hoc half of this test matching
+    # nothing and a bundle that verifies while still ad-hoc unsigned.
     if codesign --verify "$electron_app" >/dev/null 2>&1 &&
-        ! codesign --display "$electron_app" 2>&1 | grep -qx 'Signature=adhoc'; then
+        ! codesign -dvv "$electron_app" 2>&1 | grep -qx 'Signature=adhoc'; then
         return 0
     fi
 

--- a/scripts/lib/workspace.sh
+++ b/scripts/lib/workspace.sh
@@ -149,6 +149,40 @@ sidecar_require_node() {
     fi
 }
 
+# Electron ships its prebuilt bundle linker-signed ad-hoc: the executable
+# carries a signature, but the bundle seals no resources, so `codesign --verify`
+# rejects it. macOS binds a Keychain item's trust to the program's designated
+# requirement, and a requirement it cannot verify never matches — so an
+# `electron .` run asks for the login password on every launch and "Always
+# Allow" can never take. Signing the bundle with a stable identity is what makes
+# the grant hold: the requirement then names the certificate, so it survives
+# both a reinstall and a move to another worktree. Without an identity to sign
+# with, the prompt is the cost of a development run and the bundle is left as
+# Electron shipped it.
+sidecar_sign_development_electron() {
+    local identity=${LUKE_DEV_CODESIGN_IDENTITY:-}
+    if [[ -z $identity ]]; then
+        return 0
+    fi
+
+    local electron_app
+    electron_app=$(cd "$SIDECAR_DESKTOP_APP_ROOT" &&
+        node -p 'require("node:path").resolve(require("electron"), "../../..")' 2>/dev/null) || return 0
+    if [[ ! -d $electron_app ]]; then
+        return 0
+    fi
+
+    # Electron's postinstall re-extracts the ad-hoc bundle, so the signature on
+    # disk rather than a marker decides whether this run has anything to do.
+    if codesign --verify "$electron_app" >/dev/null 2>&1 &&
+        ! codesign --display "$electron_app" 2>&1 | grep -qx 'Signature=adhoc'; then
+        return 0
+    fi
+
+    printf 'Signing the development Electron bundle so its Keychain grant holds\n'
+    codesign --force --deep --sign "$identity" "$electron_app"
+}
+
 # A script that launches Electron is not useful until the workspace has been
 # bootstrapped; running bootstrap here keeps `run.sh` and `evidence.sh` from
 # each restating that guard.
@@ -156,4 +190,5 @@ sidecar_ensure_dependencies() {
     if [[ ! -x "$SIDECAR_ELECTRON_BIN" ]]; then
         "$SIDECAR_REPO_ROOT/scripts/bootstrap.sh"
     fi
+    sidecar_sign_development_electron
 }

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -4,9 +4,11 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
+  AD_HOC_IDENTITY,
   APPLE_EVENTS_USAGE_DESCRIPTION,
   addonCompilerArguments,
   createPackagerOptions,
+  developmentSigningIdentity,
   ICONSET_SOURCES,
   iconutilArguments,
   LICENSE_RESOURCE_NAME,
@@ -268,6 +270,30 @@ test("signing configuration separates ad-hoc and Developer ID modes", () => {
     hardenedRuntime: true,
     entitlements: entitlementsPath,
   });
+});
+
+test("a development signing identity signs the package without making it a release", () => {
+  assert.equal(developmentSigningIdentity({}), AD_HOC_IDENTITY);
+  assert.equal(developmentSigningIdentity({ LUKE_DEV_CODESIGN_IDENTITY: "   " }), AD_HOC_IDENTITY);
+
+  const identity = "Luke Development Signing";
+  const environment = { LUKE_DEV_CODESIGN_IDENTITY: ` ${identity} ` };
+  assert.equal(developmentSigningIdentity(environment), identity);
+  // The whole point of the split: a stable signature for the development build,
+  // and none of the release's identity — so it keeps the development name, the
+  // development state directory, and the development Keychain entry.
+  assert.deepEqual(resolveSigningMode(environment), { mode: SIGNING_MODE.AD_HOC });
+  assert.deepEqual(signingModeDefine(environment), {
+    PACKAGED_WITH_DEVELOPER_ID_SIGNING: "false",
+  });
+});
+
+test("the release identity is not read as a development one", () => {
+  // Both are signing identities, but only `LUKE_CODESIGN_IDENTITY` may reach a
+  // release: reading it here would sign a development package with it and hand
+  // that package the released app's Keychain entry.
+  const environment = { LUKE_CODESIGN_IDENTITY: "Developer ID Application: X (TEAM)" };
+  assert.equal(developmentSigningIdentity(environment), AD_HOC_IDENTITY);
 });
 
 test("the baked signing define mirrors the signing mode and carries no identity", () => {


### PR DESCRIPTION
## Problem

A development build is signed ad-hoc, which carries no identity — so macOS derives the designated requirement from the bytes themselves, a bare `cdhash` that is new on every build. Both the Keychain and TCC bind a grant to that requirement, so every rebuild is a program neither has seen before.

Two symptoms, one cause:

- The `Luke Dev Safe Storage` login-password dialog returns on every launch, however many times "Always Allow" was pressed. The item's ACL accumulates one dead entry per build path (`-67068 cannot find code object on disk`), all pinned by `cdhash`, while the released app's single entry is pinned by identity and survives every update.
- `./scripts/evidence.sh` hangs indefinitely with no error. The capture app launches, loads ScreenCaptureKit, and never writes a PNG, because Screen Recording was never granted to that hash. Apple states the rule directly: TCC uses the code signature to decide that version N+1 is the same code as version N, and an ad-hoc signed app has no stable identity to remember.

`electron .` runs are worse: Electron's prebuilt bundle is linker-signed ad-hoc with no sealed resources, so it fails `codesign --verify` outright ("code has no resources but signature indicates they must be present") and the Keychain can never hold a durable entry for it at all.

## Change

`LUKE_DEV_CODESIGN_IDENTITY` names an identity to sign development builds with, moving the requirement onto the certificate. `sidecar_sign_development_electron` gives Electron's bundle the same treatment after install.

It decides nothing else — `resolveSigningMode` still reads ad-hoc, so the build is still not a release, still answers to the development name, and still keeps its Keychain entry apart from the released app's. `LUKE_CODESIGN_IDENTITY` stays release-only, with a test pinning that.

**Without an identity named, nothing changes**: the packager signs ad-hoc exactly as before, and the Electron bundle is left as Electron shipped it. The release path is untouched.

## For review

This adds a third state to a boundary the project guards deliberately — signed, but still not a release. `app-identity.ts` and `resolveSigningMode` were built around a two-way split. The tests pin the new state so it cannot drift, but it is a widening worth deciding rather than assuming.

Also worth a look: `sidecar_ensure_dependencies` now signs as well as bootstraps, so its name no longer covers what it does. Calling `sidecar_sign_development_electron` from `run.sh` and `evidence.sh` directly would keep each function to one job.

## Verification

- `./scripts/check.sh` — passes
- `./scripts/evidence.sh` — passes, six PNGs, expanded frame inspected and unchanged. **This only completes with `LUKE_DEV_CODESIGN_IDENTITY` set**; without it the capture hangs on this machine, which is the second symptom above.
- The resulting development package's requirement is identity-based, and `buildCarriesDeveloperIdSigning()` still compiles to `false`, so it keeps the development name, state directory, and Keychain entry.
- Physical-notch check: not performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32183943494/artifacts/9341793782) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32183943494)

- Commit: `4c926586c310c1738bbb72cad23ba0d747e74dd1`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
