### PR TITLE
fix(desktop): keep the captions and the volume hint from overlapping

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -138,7 +138,7 @@ import { useStateWithRef } from "./use-state-with-ref";
 import { useVoiceConversation, voiceErrorToShow } from "./use-voice-conversation";
 import {
   outputSilent,
-  VOLUME_HINT_HEIGHT,
+  VOLUME_HINT_BAND_HEIGHT,
   type VolumeHintDismissal,
   volumeHintDismissed,
   volumeHintText,
@@ -167,11 +167,14 @@ const FEEDBACK_KIND_FOR_COMPOSER: Record<FeedbackComposerKind, FeedbackKind> = {
  * only a measurement can say how tall it is; the size drives the surface's
  * growth and the clip that reveals the text, and past the reserved maximum
  * the remainder becomes scroll, rolling the oldest lines up under the shape.
- * The volume hint shares the block's reserved room: while it is drawn, its
- * row is added to the size and taken from the words' budget, so the block
- * never asks for more height than the window holds. Padding is the caption's
- * own computed padding, not a restated number, so a retune in the stylesheet
- * grows the surface by exactly what the text is inset.
+ * The volume hint stands in a band of its own below the block: while it is
+ * drawn, the band comes off the block's maximum — and off the words' budget
+ * with it — so the block and the band partition the reserved room instead of
+ * sharing it, and the stack never asks for more height than the window holds.
+ * Padding is the caption's own computed padding, not a restated number, so a
+ * retune in the stylesheet grows the surface by exactly what the text is
+ * inset — including the bottom inset the stylesheet hands to the band while
+ * the hint stands.
  */
 function captionSizeStyle(
   textHeight: number | undefined,
@@ -180,15 +183,15 @@ function captionSizeStyle(
   readingElapsedMs: number | undefined,
 ): CSSProperties {
   if (!textHeight) return {};
-  const hintHeight = volumeHint ? VOLUME_HINT_HEIGHT : 0;
-  const overflow = Math.max(0, textHeight - (VOICE_CAPTION_MAX_HEIGHT - padding - hintHeight));
+  const hintBand = volumeHint ? VOLUME_HINT_BAND_HEIGHT : 0;
+  const overflow = Math.max(0, textHeight - (VOICE_CAPTION_MAX_HEIGHT - padding - hintBand));
   // Heard words keep the newest line on screen — the half of the reply the
   // voice has not reached yet. Words landing on a silent output are read, not
   // heard, so the oldest unread line holds instead, leaving at reading pace.
   const scroll =
     readingElapsedMs === undefined ? overflow : pacedCaptionScroll(overflow, readingElapsedMs);
   return {
-    "--caption-size": `${Math.min(VOICE_CAPTION_MAX_HEIGHT, textHeight + hintHeight + padding)}px`,
+    "--caption-size": `${Math.min(VOICE_CAPTION_MAX_HEIGHT - hintBand, textHeight + padding)}px`,
     "--caption-scroll": `${scroll}px`,
   } as CSSProperties;
 }
@@ -2308,8 +2311,8 @@ export function App(): React.JSX.Element {
       // failure borrowing its strip — so the surface can grow the room they
       // are drawn in.
       data-caption={String(Boolean(captionTexts))}
-      // Whether those words need the volume hint under them, which shares the
-      // caption block's room.
+      // Whether those words need the volume hint under them, which stands in
+      // a band of its own below the caption block.
       data-volume-hint={String(volumeHint)}
       // Whether the announcement being spoken has its pressable notice under
       // the housing. Captioned words drop below it; with captions off it
@@ -2528,9 +2531,11 @@ export function App(): React.JSX.Element {
       </span>
 
       {/* The one reason the words above might be the only part of Luke
-          arriving: the Mac's own output is off. It sits on the caption
-          block's bottom edge, inside the same reserved room, and is drawn
-          only while Luke speaks into a silence the helper reported. Always
+          arriving: the Mac's own output is off. It stands in a band of its
+          own directly below the caption block — the block's clip ends where
+          the band begins, so the words above can never be drawn over it —
+          and is drawn only while Luke speaks into a silence the helper
+          reported. Always
           mounted, like the caption, so both edges of its fade can run, and
           inert while hidden so its button cannot be tabbed to. It carries a
           hit region of its own and sits above the hover strip, so Got it

--- a/apps/desktop/src/renderer/caption-reading.ts
+++ b/apps/desktop/src/renderer/caption-reading.ts
@@ -36,9 +36,10 @@ export const CAPTION_LINE_READ_MS = 3_000;
  * instead of shoving the unread ones off the screen.
  *
  * The clock paces lines, so only whole lines wait on it. The volume hint's
- * row is not a whole number of lines, so a block it shares can overflow by
- * less than one — a remainder that is spacing, not words: it tucks the text
- * up into the block's own top padding and hides nothing. It settles at once,
+ * band is not a whole number of lines, so a block that has ceded it room can
+ * overflow by less than one — a remainder that is spacing, not words: it
+ * tucks the text up into the block's own top padding and hides nothing. It
+ * settles at once,
  * because words that shift after they were readable read as a stutter, not
  * as a line leaving.
  */

--- a/apps/desktop/src/renderer/luke-errand.tsx
+++ b/apps/desktop/src/renderer/luke-errand.tsx
@@ -478,6 +478,7 @@ const MOTION_TOKEN = {
   ROW_FAN_LIMIT: "--row-fan-limit",
   CAPTION_SIZE: "--caption-size",
   CAPTION_MAX: "--caption-max",
+  VOLUME_HINT_SIZE: "--volume-hint-size",
 } as const;
 
 type MotionToken = (typeof MOTION_TOKEN)[keyof typeof MOTION_TOKEN];
@@ -669,7 +670,12 @@ export function LukeErrand({ errand, onLanded, onReturned }: LukeErrandProps): R
       // the foot that the captions still to come cannot take the view back.
       // An already-visible control with room to spare is left exactly where it
       // is, which is the usual case.
-      const captionSize = parsePixels(token(MOTION_TOKEN.CAPTION_SIZE));
+      // The room the reply takes off the panel's foot is the caption block
+      // plus the volume hint's band below it — two stacked elements, summed
+      // here the same way the shape's growth sums them.
+      const captionSize =
+        parsePixels(token(MOTION_TOKEN.CAPTION_SIZE)) +
+        parsePixels(token(MOTION_TOKEN.VOLUME_HINT_SIZE));
       keepInView(
         stage,
         target,

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -188,10 +188,16 @@
      same number the compact window already holds below the capsule, so growing
      into it costs no IPC. `--caption-size` is the block's height right now —
      measured off the wrapped text by the renderer, padding included, never
-     past the max. How much of that room the shape is currently using: the
-     caption states below raise it, and every other state leaves the capsule's
-     own height. */
+     past the max less the volume hint's band while one stands. How much of
+     that room the shape is currently using: the caption states below raise
+     it, and every other state leaves the capsule's own height. */
   --caption-growth: 0px;
+  /* The volume hint's band below the caption block, 0 until the hint stands.
+     The hint's own rule raises it, and every place that spends
+     `--caption-size` adds this beside it — the block and the band are two
+     stacked elements partitioning the reserved room, never one shared
+     height. */
+  --volume-hint-size: 0px;
   /* The notice band under the housing — one row for the chip naming the
      session Luke is announcing — arrives as `--notice-size` from the shared
      surface tokens, because the compact window reserves its room on top of the
@@ -486,7 +492,7 @@ button:disabled {
    reply starts and a shape grown around nothing reads as a twitch. */
 .app-stage[data-presentation="capsule"][data-caption="true"],
 .app-stage[data-presentation="peek"][data-caption="true"] {
-  --caption-growth: var(--caption-size, 28px);
+  --caption-growth: calc(var(--caption-size, 28px) + var(--volume-hint-size));
 }
 
 /* While there are words, the capsule holds the peek's width whatever the
@@ -1247,9 +1253,10 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
    compact states, riding down to the panel's foot when the shape opens.
 
    The box is always the full block the window reserves; what tracks the text
-   is the clip. It springs to the same edge the surface's height does, from
-   the same `--caption-size`, so a line that wraps into existence is revealed
-   by the black arriving under it rather than being drawn on the desktop. The
+   is the clip. It springs on the same `--caption-size` the surface's height
+   does — meeting the surface's edge, or the volume hint's band when one
+   stands between them — so a line that wraps into existence is revealed by
+   the black arriving under it rather than being drawn on the desktop. The
    lift off the top edge rides in the transform rather than in `top` for the
    same reason the surface carries it there: it changes between states, and
    only a transform travels on the spring. It takes no pointer — the surface
@@ -1300,7 +1307,8 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   --caption-rest: calc(
     var(--panel-height, 520px) -
     var(--capsule-height) -
-    var(--caption-size, 28px)
+    var(--caption-size, 28px) -
+    var(--volume-hint-size)
   );
 }
 
@@ -1319,7 +1327,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
    the panel is up, so the height the panel reports is already right when a
    captioned expand begins. */
 .app-stage[data-caption="true"] .expanded-panel {
-  padding-bottom: calc(18px + var(--caption-size, 28px));
+  padding-bottom: calc(18px + var(--caption-size, 28px) + var(--volume-hint-size));
 }
 
 /* The stack holds one block per response, so two responses spoken
@@ -1364,14 +1372,32 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 /* Volume hint ------------------------------------------------------------- */
 
 /* Why the words above are the only part of Luke arriving: the Mac's output is
-   muted or at zero. It sits on the caption block's bottom edge — the height
-   here mirrors VOLUME_HINT_HEIGHT in app.tsx, and the renderer adds that row
-   to `--caption-size` while the hint is drawn, so it rides inside the same
-   reserved room the caption does and the words scroll a row sooner. The
-   travel is the caption's own transform plus the block's current size, so the
-   row springs down the shape's edge exactly as the shape grows for new lines.
-   Above the hover strip (z-index 4) because it holds the one button on the
-   compact shape that is not the strip: Got it has to answer the press. */
+   muted or at zero. It stands in a band of its own directly below the caption
+   block: `--volume-hint-size` mirrors VOLUME_HINT_BAND_HEIGHT in
+   volume-hint.ts — the 22px row this element draws plus the caption's 9px
+   bottom inset, which the rule below moves under the row — and the renderer
+   takes the band off the block's maximum, so the words scroll a row sooner.
+   The block and the band partition the reserved room rather than layering in
+   it: the caption's clip ends where the band begins, so no pace of scroll can
+   reveal a line over the hint. The travel is the caption's own transform plus
+   the block's current size, so the row springs down the shape's edge exactly
+   as the shape grows for new lines. Above the hover strip (z-index 4) because
+   it holds the one button on the compact shape that is not the strip: Got it
+   has to answer the press. */
+.app-stage[data-volume-hint="true"] {
+  --volume-hint-size: 31px;
+}
+
+/* While the hint stands, the block's bottom inset belongs below the hint —
+   the hint is what meets the shape's bottom edge then. The renderer measures
+   the caption's padding off the computed style, so the words' budget follows
+   this move by measurement rather than by a restated number. */
+.app-stage[data-volume-hint="true"] .voice-caption {
+  padding-bottom: 0;
+}
+
+/* The row's height mirrors VOLUME_HINT_HEIGHT in volume-hint.ts — the two
+   must agree. */
 .volume-hint {
   position: absolute;
   z-index: 5;
@@ -1387,7 +1413,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   pointer-events: none;
   transform: translate(
     -50%,
-    calc(var(--caption-rest, 0px) - var(--shape-top, 0px) + var(--caption-size, 28px) - 31px)
+    calc(var(--caption-rest, 0px) - var(--shape-top, 0px) + var(--caption-size, 28px))
   );
   /* The transform waits out `--duration-exit` like the caption's does, so
      leaving a state the row travels with the shape rather than ahead of it. */
@@ -1459,7 +1485,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
    its own below. Stated after the single-band rules so it wins their tie. */
 .app-stage[data-presentation="capsule"][data-caption="true"][data-notice="true"],
 .app-stage[data-presentation="peek"][data-caption="true"][data-notice="true"] {
-  --caption-growth: calc(var(--caption-size, 28px) + var(--notice-size));
+  --caption-growth: calc(var(--caption-size, 28px) + var(--volume-hint-size) + var(--notice-size));
 }
 
 /* While a notice stands, the capsule holds the peek's width, exactly as the
@@ -1558,6 +1584,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
     var(--panel-height, 520px) -
     var(--capsule-height) -
     var(--caption-size, 28px) -
+    var(--volume-hint-size) -
     var(--notice-size)
   );
 }
@@ -1582,7 +1609,12 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 }
 
 .app-stage[data-caption="true"][data-notice="true"] .expanded-panel {
-  padding-bottom: calc(18px + var(--caption-size, 28px) + var(--notice-size));
+  padding-bottom: calc(
+    18px +
+    var(--caption-size, 28px) +
+    var(--volume-hint-size) +
+    var(--notice-size)
+  );
 }
 
 .session-notice:hover {

--- a/apps/desktop/src/renderer/volume-hint.ts
+++ b/apps/desktop/src/renderer/volume-hint.ts
@@ -29,10 +29,22 @@ export const VOLUME_HINT_REARM_MS = 15 * 60_000;
 
 /**
  * The hint row's height, mirrored by `.volume-hint` in the stylesheet — the
- * two must agree. It shares the caption block's reserved room, so while the
- * hint is drawn the words above it get this much less before they scroll.
+ * two must agree.
  */
 export const VOLUME_HINT_HEIGHT = 22;
+
+/**
+ * The band the shape grows for the hint: the row plus the caption block's own
+ * 9px bottom inset, which moves below the row while the hint stands — the
+ * hint is what meets the shape's bottom edge then, so the breathing room
+ * belongs under it. Mirrored by `--volume-hint-size` and the zeroed caption
+ * padding in the stylesheet — the three must agree. The band is a stacked
+ * element of its own, never part of the caption block: it is taken off the
+ * block's maximum, so the words above scroll a row sooner and the clip that
+ * reveals them ends where the band begins — no pace of scroll can draw a
+ * line over the hint.
+ */
+export const VOLUME_HINT_BAND_HEIGHT = VOLUME_HINT_HEIGHT + 9;
 
 /** A "Got it", remembered against the stretch of silence it was given in. */
 export interface VolumeHintDismissal {

--- a/scripts/evidence.sh
+++ b/scripts/evidence.sh
@@ -42,8 +42,8 @@ capture_evidence slot --expanded --slot --capture-evidence "$SIDECAR_SLOT_EVIDEN
 # peek is the narrowest state that shows both, which is what has to be checked.
 capture_evidence speaking --profile speaking --compact --peek --capture-evidence "$SIDECAR_SPEAKING_EVIDENCE_PATH"
 # The speaking run with the Mac's output off: the captions are forced on and
-# the volume hint sits on the caption block's bottom edge with its Got it
-# button. The state is the profile's own — a capture run reads no system
+# the volume hint stands in its own band below the caption block with its Got
+# it button. The state is the profile's own — a capture run reads no system
 # volume — so the frame is deterministic like every other.
 capture_evidence muted --profile muted --compact --peek --capture-evidence "$SIDECAR_MUTED_EVIDENCE_PATH"
 


### PR DESCRIPTION
## Summary

- The "Unmute your Mac" hint rode inside the caption block's revealed room, and words paced for reading into a silent output stayed revealed straight through its row — the captions drew over the hint exactly when the hint exists.
- The caption block and the hint now partition the reserved room as two stacked bands: a new `--volume-hint-size` band below the block, taken off the block's maximum. The caption's clip ends where the band begins, so no pace of scroll can draw a line over the hint. Settled geometry is pixel-identical to before; the words' budget is unchanged.
- The panel's foot, the notice-band combinations, and the errand's caption-room arithmetic all sum the band the same way the shape's growth does.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — pass on the rebased head (1284 tests, 0 failures; repository contract checks pass, lint/typecheck/build clean)
- macOS Electron verification (`./scripts/verify.sh`): split across environments — `check.sh` half ran in the Linux workspace (pass, above); `./scripts/evidence.sh` half ran on a physical MacBook Pro (notched built-in display, macOS 26.3) — all six fixture captures produced and validated

Muted — captions above, the hint in its own band below, no overlap:

![Muted state: captions and the volume hint in separate bands](https://raw.githubusercontent.com/ReviewStage/luke/pr-assets/pr-248/app-smoke-muted.png)

Speaking — captions alone, unchanged by the band restructure:

![Speaking state: captions alone, no regression](https://raw.githubusercontent.com/ReviewStage/luke/pr-assets/pr-248/app-smoke-speaking.png)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32186774742/artifacts/9342765492) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32186774742)

- Commit: `1db228be0ef0e638da6ad453439a888cce80c313`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: the two PNGs above, captured by `./scripts/evidence.sh` on the physical Mac and inspected
- Physical-notch check: `not performed` — the captures ran on the notched MacBook, but nobody was at the physical display to eyeball it
- Device/display configuration: MacBook Pro built-in Liquid Retina XDR, 3456×2234, notched, macOS 26.3

## Notes

- Blockers or follow-up verification: a physical-notch eyeball check on the muted state remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
