### PR TITLE
feat(desktop): title the pull-request chip by the request's own number

### DIFF
--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -638,8 +638,9 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "than pretending there are none — Escape clears the query and then closes the field, " +
         "no spoken ask can search, and no search survives the panel closing. " +
         "A row can be opened, messaged, or controlled where its " +
-        "provider allows; a session whose provider reported a pull request grows a Pull request " +
-        "chip that opens it in the browser; and a row the developer asked Luke to listen for — " +
+        "provider allows; a session whose provider reported a pull request grows a chip that " +
+        "opens it in the browser, titled by the request's own number — #245 — or reading " +
+        "Pull request when its address names none; and a row the developer asked Luke to listen for — " +
         "“tell me when this finishes” — wears a small listening mark beside its age, whose hover " +
         "says the ask in the developer's own words. Luke's own composer at the foot of the list " +
         "takes a typed ask — Enter sends it, Shift-Enter breaks the line, and the field grows " +

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -306,7 +306,7 @@ function SessionRowActions({
             void openChange();
           }}
         >
-          Pull request
+          {session.changeNumber !== undefined ? `#${session.changeNumber}` : "Pull request"}
         </button>
       ) : null}
       {feedback ? <small className="row-feedback">{feedback}</small> : null}

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -14,6 +14,7 @@ import {
   type SessionLocation,
   type SessionNoticeAsk,
   type SessionUrgency,
+  sessionChangeNumber,
   urgencyLabel,
 } from "@sidecar/core";
 import type { AppBootstrap } from "../shared/contracts";
@@ -157,6 +158,12 @@ export interface DisplaySession {
    * process; the row only has to know the chip would open something.
    */
   hasChange: boolean;
+  /**
+   * The pull request's own number, when the address's shape names one, so the
+   * chip can say "#245" the way the host does. A number and never the address:
+   * absent, the chip keeps the generic words rather than guessing.
+   */
+  changeNumber?: number;
   /**
    * The developer's standing ask about this session, when one stands, so the
    * row can mark that Luke is listening for it. The words are the developer's
@@ -403,6 +410,9 @@ export function displaySessions(
     : sessions.map((session) => {
         const urgency = sessionUrgency(session);
         const noticeAsk = asks.get(session.providerId)?.get(session.providerSessionId);
+        const changeNumber = session.detail.change
+          ? sessionChangeNumber(session.detail.change)
+          : undefined;
         return {
           id: session.providerSessionId,
           title: session.title,
@@ -420,6 +430,7 @@ export function displaySessions(
           canMessage: session.canReceiveMessage,
           actions: session.controls,
           hasChange: session.detail.change !== undefined,
+          ...(changeNumber !== undefined ? { changeNumber } : {}),
           ...(noticeAsk ? { noticeAsk } : {}),
           // A workspace the provider left unnamed still groups its chats; the
           // id is at least stable, where a made-up name would claim knowledge

--- a/apps/desktop/tests/session-model.test.ts
+++ b/apps/desktop/tests/session-model.test.ts
@@ -153,6 +153,41 @@ test("the line under the title says the state when the provider said nothing", (
   assert.equal(conductor?.detail, "Complete");
 });
 
+test("a row carries the pull request's number when its address names one", () => {
+  const live = displaySessions(bootstrap(false), [
+    normalizeSession(CODEX_PROVIDER, {
+      providerSessionId: "codex-published",
+      title: "Session codex-published",
+      status: SESSION_STATUS.WORKING,
+      observedAt: 1_000,
+      detail: { change: "https://github.com/reviewstage/luke/pull/245" },
+    }),
+    normalizeSession(CLAUDE_PROVIDER, {
+      providerSessionId: "claude-unnumbered",
+      title: "Session claude-unnumbered",
+      status: SESSION_STATUS.WORKING,
+      observedAt: 1_000,
+      detail: { change: "https://github.com/reviewstage/luke/pulls" },
+    }),
+  ]);
+
+  const published = live.find((session) => session.id === "codex-published");
+  assert.equal(published?.hasChange, true);
+  assert.equal(published?.changeNumber, 245);
+
+  // An address naming no number still earns the chip — only its title falls
+  // back to the generic words.
+  const unnumbered = live.find((session) => session.id === "claude-unnumbered");
+  assert.equal(unnumbered?.hasChange, true);
+  assert.equal(unnumbered?.changeNumber, undefined);
+
+  // The fixture's chip carries a number too, so the visual evidence shows the
+  // label a live address would earn.
+  const cursor = FIXTURE_SESSIONS.find((session) => session.id === "cursor-agent");
+  assert.equal(cursor?.hasChange, true);
+  assert.equal(cursor?.changeNumber, 31);
+});
+
 test("a row carries the identifiers that tell it from its neighbours", () => {
   const [live] = displaySessions(bootstrap(false), [
     normalizeSession(CODEX_PROVIDER, {

--- a/packages/sidecar-core/src/fixtures.ts
+++ b/packages/sidecar-core/src/fixtures.ts
@@ -44,6 +44,8 @@ export interface SessionSnapshot {
   actions?: readonly SessionControl[];
   /** Drawn only: the pull-request chip a live session's published work earns. */
   hasChange?: boolean;
+  /** Drawn only: the number the chip is titled by when the address names one. */
+  changeNumber?: number;
   /** Drawn only: the standing ask a live row would be marked as listened for. */
   noticeAsk?: string;
   /** The workspace this row is one chat of, when its provider nests them. */
@@ -150,9 +152,11 @@ const smokeFixture: FixtureSnapshot = {
       observedAt: minutesBeforeEpoch(18),
       // What a working Cursor agent advertises live, so the one screenshot the
       // evidence is reviewed from also proves the stop control is drawn — and
-      // the pull-request chip beside it, on the row whose sentence names one.
+      // the pull-request chip beside it, on the row whose sentence names one,
+      // titled by a synthetic number the way a live address would title it.
       actions: [{ id: "cancel-run", label: "Stop this run", kind: SESSION_CONTROL_KIND.STOP }],
       hasChange: true,
+      changeNumber: 31,
     },
     // A fifth session keeps every state and every provider mark visible in the
     // one screenshot the visual evidence is reviewed from. It is also one more

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -48,6 +48,7 @@ export {
   type SessionLocation,
   type SessionProvider,
   type SessionStatus,
+  sessionChangeNumber,
   sessionMessageText,
   UNKNOWN_WORKSPACE_LABEL,
 } from "./session.js";

--- a/packages/sidecar-core/src/session.ts
+++ b/packages/sidecar-core/src/session.ts
@@ -394,6 +394,26 @@ function sessionChange(value: string | undefined): string | undefined {
   }
 }
 
+/**
+ * The pull request's own number, read from the published work's address so a
+ * surface can name the work the way its host does — "#245" — instead of the
+ * generic words. Every host this build has seen a change from ends the
+ * address with the number (GitHub's `/pull/245`, GitLab's
+ * `/-/merge_requests/3`, Bitbucket's `/pull-requests/9`), so the final path
+ * segment is the number or the address names none. Nothing but the number
+ * ever leaves this read: an address whose tail is not one yields nothing,
+ * and the surface keeps the generic words rather than guessing.
+ */
+export function sessionChangeNumber(change: string): number | undefined {
+  let tail: string | undefined;
+  try {
+    tail = new URL(change).pathname.split("/").filter(Boolean).at(-1);
+  } catch {
+    return undefined;
+  }
+  return tail !== undefined && /^\d+$/.test(tail) ? Number(tail) : undefined;
+}
+
 function timestamp(value: number, field: string): number {
   if (!Number.isFinite(value) || value < 0) {
     throw new Error(`${field} must be a non-negative finite timestamp`);

--- a/packages/sidecar-core/tests/session.test.ts
+++ b/packages/sidecar-core/tests/session.test.ts
@@ -7,6 +7,7 @@ import {
   rosterRelevantSessions,
   SESSION_STATUS,
   type SessionStatus,
+  sessionChangeNumber,
   sessionRosterRetentionMs,
 } from "../src";
 
@@ -65,4 +66,25 @@ test("filters a roster to the sessions still worth a row, keeping their order", 
     rosterRelevantSessions([workedForever, finishedLongAgo, finishedToday], TEST_NOW),
     [workedForever, finishedToday],
   );
+});
+
+test("reads the pull request's number off every host's address shape", () => {
+  assert.equal(sessionChangeNumber("https://github.com/reviewstage/luke/pull/245"), 245);
+  assert.equal(
+    sessionChangeNumber("https://gitlab.com/reviewstage/group/sidecar-web/-/merge_requests/3"),
+    3,
+  );
+  assert.equal(
+    sessionChangeNumber("https://bitbucket.org/reviewstage/sidecar-native/pull-requests/9"),
+    9,
+  );
+});
+
+test("an address whose tail names no number yields none rather than a guess", () => {
+  assert.equal(sessionChangeNumber("https://github.com/reviewstage/luke/pulls"), undefined);
+  assert.equal(
+    sessionChangeNumber("https://github.com/reviewstage/luke/pull/245/files"),
+    undefined,
+  );
+  assert.equal(sessionChangeNumber("not an address"), undefined);
 });


### PR DESCRIPTION
## Summary

- The session row's pull-request chip now reads "#245"-style — the request's own number — instead of the words "Pull request".
- Every host a change arrives from ends its address with the number (GitHub's `/pull/245`, GitLab's `/-/merge_requests/3`, Bitbucket's `/pull-requests/9`), so a new `sessionChangeNumber` reads the final path segment. Only the number reaches the display model, never the address; an address whose tail names no number keeps the generic words rather than a guess.
- The smoke fixture's Cursor row carries a synthetic `#31` so the visual evidence shows the numbered label, and the guide now describes the chip the way it reads.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (216 core, 1034 desktop, 40 web tests)
- macOS Electron verification (`./scripts/verify.sh`): `not run` (developed in a Linux cloud workspace); verified by hand on a physical Mac

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32187065310/artifacts/9342871888) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32187065310)

- Commit: `ca81fad74499a8ba730e53ab6f92a5d0824c25ac`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `performed` (chip inspected on a physical Mac)
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/93130517-50a2-4476-a35b-99837593ae49)
