### PR TITLE
feat(voice): show pressable previews for every session a reply mentions

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -14,6 +14,9 @@ import {
   type RealtimeDiagnostics,
   type RealtimeVoice,
   type RealtimeVoiceSpeed,
+  SESSION_MENTION_KIND,
+  SESSION_NOTICE_HEIGHT,
+  SESSION_NOTICE_MAX_ROWS,
   type SessionIdentity,
   type SessionNoticeAsk,
   VOICE_CAPTION_MAX_HEIGHT,
@@ -194,6 +197,23 @@ function captionSizeStyle(
     "--caption-size": `${Math.min(VOICE_CAPTION_MAX_HEIGHT - hintBand, textHeight + padding)}px`,
     "--caption-scroll": `${scroll}px`,
   } as CSSProperties;
+}
+
+/**
+ * Sizes the notice band's growth to the chips it currently holds — the
+ * caption block's own pattern. The chips size to their names and wrap where
+ * they wrap, so only a measurement can say how many rows they made. The
+ * band's own max-height already clamps the measurement to the rows the
+ * window reserved — past it the chips scroll instead of growing the shape —
+ * and the clamp here only restates that bound against a measurement landing
+ * mid-layout. The 6px around the measured chips is the band's 3px stand-off
+ * from the strip, top and bottom, which one reserved row already accounts
+ * for. Unmeasured falls back to `--notice-size`, one row, in the stylesheet.
+ */
+function noticeGrowthStyle(bandHeight: number | undefined): CSSProperties {
+  if (!bandHeight) return {};
+  const growth = Math.min(SESSION_NOTICE_HEIGHT * SESSION_NOTICE_MAX_ROWS, bandHeight + 6);
+  return { "--notice-growth": `${growth}px` } as CSSProperties;
 }
 
 function notchStyle(display: DisplayDiagnostic): CSSProperties {
@@ -1596,7 +1616,7 @@ export function App(): React.JSX.Element {
     voiceTurn,
     lukeCaptions,
     captionShownAt,
-    announcedSession,
+    mentionedSessions,
     remoteAudio,
     discardListening,
     stopSpeaking,
@@ -1620,53 +1640,110 @@ export function App(): React.JSX.Element {
     carryAppAction,
   });
 
-  // The notice: the pressable face of the announcement being spoken. It is
-  // derived, not queued — the subject arrives with the caption and dies with
-  // the reply, so it can never lag the words or stand for news Luke is not
-  // saying — and it draws only for a session the roster still titles, because
-  // a press is a row press at one remove and needs a row to stand for. The
-  // resting shapes draw it under the housing, and the open panel keeps it at
-  // its foot: the row is up in the list, but the chip is what says which row
-  // Luke is talking about. Only the slot and the composer go without — those
-  // are shapes someone asked for.
-  const announced = announcedSession
-    ? sessions.find(
-        (candidate) =>
-          candidate.providerId === announcedSession.providerId &&
-          candidate.providerSessionId === announcedSession.providerSessionId,
-      )
-    : undefined;
+  // The notices: the pressable faces of the sessions the reply being spoken
+  // is about — an announcement's one subject, or the several a conversation
+  // reply names when "what are we working on?" is answered with a walk
+  // through the roster: a chat by its title, or a whole workspace by name,
+  // fronted by its freshest chat. Derived, not queued — the subjects arrive
+  // with the captions and die with the reply, so a chip can never lag the
+  // words or stand for news Luke is not saying — and each draws only for a
+  // session the roster still titles, because a press is a row press at one
+  // remove and needs a row to stand for. A workspace chip wears the
+  // workspace's name, read off the same roster row, so the chip says what
+  // the words said. The resting shapes draw the band under the housing, and
+  // the open panel keeps it at its foot: the rows are up in the list, but
+  // the chips are what say which of them Luke is talking about. Only the
+  // slot and the composer go without — those are shapes someone asked for.
+  const spokenOf = mentionedSessions.flatMap((mention) => {
+    const session = sessions.find(
+      (candidate) =>
+        candidate.providerId === mention.providerId &&
+        candidate.providerSessionId === mention.providerSessionId,
+    );
+    if (!session) return [];
+    const title =
+      mention.kind === SESSION_MENTION_KIND.WORKSPACE && session.workspace?.name !== undefined
+        ? session.workspace.name
+        : session.title;
+    return [{ title, providerId: session.providerId, id: session.providerSessionId }];
+  });
   const noticeShown =
-    announced !== undefined &&
+    spokenOf.length > 0 &&
     (presentation === PANEL_PRESENTATION.CAPSULE ||
       presentation === PANEL_PRESENTATION.PEEK ||
       presentation === PANEL_PRESENTATION.PANEL);
-  // The last announced fields, held so the notice fades out still worded
+  // The last mentioned fields, held so the notices fade out still worded
   // rather than emptying on the frame the reply ends.
-  const lastAnnounced = useRef<{ title: string; providerId: string }>(undefined);
-  if (announced) {
-    lastAnnounced.current = { title: announced.title, providerId: announced.providerId };
+  const lastMentioned = useRef<readonly { title: string; providerId: string; id: string }[]>([]);
+  if (spokenOf.length > 0) {
+    lastMentioned.current = spokenOf;
   }
+  const noticeChipCount = lastMentioned.current.length;
 
   /**
-   * The notice's press: a row press at one remove. A session its provider
+   * Which of the band's folds have chips beyond them. A band that scrolls
+   * with no edge to say so hides its lower rows silently — the fades these
+   * drive are what tell the developer there is more to see. Measured, not
+   * derived from the count: the scroll position is the band's own, and only
+   * the element can say where it stands. The band's height is measured
+   * beside it, because naturally wrapped chips make however many rows their
+   * names need and the shape has to grow to the rows actually made.
+   */
+  const noticeBand = useRef<HTMLSpanElement | null>(null);
+  const [noticeBandElement, noticeBandHeight] = useShapeHeight();
+  const attachNoticeBand = useCallback(
+    (element: HTMLSpanElement | null) => {
+      noticeBand.current = element;
+      noticeBandElement(element);
+    },
+    [noticeBandElement],
+  );
+  const [noticeFold, setNoticeFold] = useState({ above: false, below: false });
+  const measureNoticeFold = useCallback(() => {
+    const band = noticeBand.current;
+    if (!band) return;
+    const above = band.scrollTop > 1;
+    const below = band.scrollTop + band.clientHeight < band.scrollHeight - 1;
+    setNoticeFold((held) =>
+      held.above === above && held.below === below ? held : { above, below },
+    );
+  }, []);
+  // Re-measured when the chips change, when their wrapped height moves, and
+  // when the band comes or goes — a scroll left behind by one reply must not
+  // start the next mid-list, so a band standing down rewinds to its first
+  // row.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the chip count and band height are not read here — either changing is the signal the fold moved, because content grows without any scroll event firing.
+  useEffect(() => {
+    const band = noticeBand.current;
+    if (band && !noticeShown) band.scrollTop = 0;
+    measureNoticeFold();
+  }, [noticeShown, noticeChipCount, noticeBandHeight, measureNoticeFold]);
+
+  /**
+   * A notice's press: a row press at one remove. A session its provider
    * gave an address goes to the system, exactly as pressing the row would;
    * one with no address — a local session — has the panel opened instead,
-   * where its row is already sorted to the top. Luke keeps talking: the
-   * press acts on the session, not on the sentence.
+   * where its row is already sorted near the top. Luke keeps talking: the
+   * press acts on the session, not on the sentence. Resolved against the
+   * roster at the press, because the chip may be one of several and only a
+   * session still observed has anywhere to go.
    */
-  const openAnnouncedSession = useCallback(() => {
-    if (!announced) return;
-    const identity: SessionIdentity = {
-      providerId: announced.providerId,
-      providerSessionId: announced.providerSessionId,
-    };
-    if (announced.detail.link !== undefined) {
-      void window.sidecar.openSession(identity);
-      return;
-    }
-    expand();
-  }, [announced, expand]);
+  const openMentionedSession = useCallback(
+    (identity: SessionIdentity) => {
+      const session = sessions.find(
+        (candidate) =>
+          candidate.providerId === identity.providerId &&
+          candidate.providerSessionId === identity.providerSessionId,
+      );
+      if (!session) return;
+      if (session.detail.link !== undefined) {
+        void window.sidecar.openSession(identity);
+        return;
+      }
+      expand();
+    },
+    [sessions, expand],
+  );
 
   /**
    * A live push beats a bootstrap snapshot still in flight. The main process
@@ -2314,9 +2391,9 @@ export function App(): React.JSX.Element {
       // Whether those words need the volume hint under them, which stands in
       // a band of its own below the caption block.
       data-volume-hint={String(volumeHint)}
-      // Whether the announcement being spoken has its pressable notice under
-      // the housing. Captioned words drop below it; with captions off it
-      // stands alone in a band of its own.
+      // Whether the reply being spoken has its pressable notices under the
+      // housing, and how many chip rows they need. Captioned words drop below
+      // them; with captions off the band stands alone.
       data-notice={String(noticeShown)}
       data-presentation={presentation}
       data-notch={String(display.notch.hasNotch)}
@@ -2335,6 +2412,7 @@ export function App(): React.JSX.Element {
           feedbackHeight,
         ),
         ...captionSizeStyle(captionTextHeight, volumeHint, captionPadding, captionReadingElapsed),
+        ...noticeGrowthStyle(noticeBandHeight),
       }}
     >
       {/* Capsule, peek, slot and panel are all this one shape at different
@@ -2552,30 +2630,50 @@ export function App(): React.JSX.Element {
         </button>
       </span>
 
-      {/* The session Luke is talking about, pressable while he says it. One
+      {/* The sessions Luke is talking about, pressable while he says them: an
+          announcement names one, and a conversation reply walking the roster
+          names several, each with a chip of its own on the same band. One
           press, and it is a row press at one remove — the session opens where
           its provider keeps it, or the panel comes forward for one with no
-          page of its own. Always mounted, like the caption, so both edges of
-          its fade can run, and holding the last announced fields through its
-          exit so the name leaves in place. Inert while away so nothing hidden
-          can be pressed or tabbed to; its own hit region keeps the pointer
-          resting on it from reading as leaving the shape. */}
-      <button
-        type="button"
-        className="session-notice"
-        data-hit-region={HIT_REGION.CAPSULE}
+          page of its own. The band is always mounted, like the caption, so
+          both edges of its fade can run, and holds the last mentioned fields
+          through its exit so the names leave in place. Inert while away so
+          nothing hidden can be pressed or tabbed to; each chip's own hit
+          region keeps the pointer resting on it from reading as leaving the
+          shape. */}
+      <span
+        className="session-notices"
+        ref={attachNoticeBand}
         inert={!noticeShown}
-        aria-label={announced ? `Open "${announced.title}"` : undefined}
-        // Keeps the press from moving focus here, like the capsule strip's
-        // own button, so a focused settings field keeps the caret.
-        onMouseDown={(event) => event.preventDefault()}
-        onClick={openAnnouncedSession}
+        // The folds: which edges have chips beyond them, driving the fades
+        // that say the band scrolls. Both settle to false while everything
+        // fits, so a band of few chips wears no mask at all.
+        data-fold-above={String(noticeFold.above)}
+        data-fold-below={String(noticeFold.below)}
+        onScroll={measureNoticeFold}
       >
-        {lastAnnounced.current ? (
-          <ProviderMark providerId={lastAnnounced.current.providerId} />
-        ) : null}
-        <span className="session-notice-name">{lastAnnounced.current?.title}</span>
-      </button>
+        {lastMentioned.current.map((mention) => (
+          <button
+            key={mention.id}
+            type="button"
+            className="session-notice"
+            data-hit-region={HIT_REGION.CAPSULE}
+            aria-label={`Open "${mention.title}"`}
+            // Keeps the press from moving focus here, like the capsule strip's
+            // own button, so a focused settings field keeps the caret.
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() =>
+              openMentionedSession({
+                providerId: mention.providerId,
+                providerSessionId: mention.id,
+              })
+            }
+          >
+            <ProviderMark providerId={mention.providerId} />
+            <span className="session-notice-name">{mention.title}</span>
+          </button>
+        ))}
+      </span>
 
       <div className="compact-stage">
         {/* A button, not a hover target: hovering only peeks, pressing commits.

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -814,7 +814,11 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
               "off. While he says it, a pressable notice names the session he is talking " +
               "about — under the housing, or at the open panel's foot: pressing it opens the " +
               "session where its provider keeps it, or opens the panel for a local session " +
-              "with no page of its own. " +
+              "with no page of its own. The same chips appear while a conversation reply " +
+              "names observed sessions by title, or a workspace of grouped chats by its " +
+              "name — asking what is being worked on draws one chip per thing named, up to " +
+              "a dozen, a workspace's opening its most recent chat. Past three rows the " +
+              "chips scroll in place, and each presses the same way. " +
               "Always on while voice is available; the panel and the capsule count show the " +
               "same states either way." +
               // Only a build that offers the calendar may describe the quiet:

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -198,11 +198,11 @@
      stacked elements partitioning the reserved room, never one shared
      height. */
   --volume-hint-size: 0px;
-  /* The notice band under the housing — one row for the chip naming the
-     session Luke is announcing — arrives as `--notice-size` from the shared
-     surface tokens, because the compact window reserves its room on top of the
-     caption's: the chip stands directly under the housing, and captioned
-     words drop below its band. */
+  /* The notice band under the housing — one row for the chips naming the
+     sessions the reply being spoken is about — arrives as `--notice-size`
+     from the shared surface tokens, because the compact window reserves its
+     room on top of the caption's: the chips stand directly under the housing,
+     and captioned words drop below their band. */
   /* Wide enough for a key, a way out, and a way on, and no wider — the page the
      key was copied from is behind this and has to stay readable. The floor is
      what those three need on a display with no housing to grow from. */
@@ -1467,25 +1467,34 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 
 /* Session notice ----------------------------------------------------------- */
 
-/* The session Luke is announcing, pressable while he says it: the surface
-   grows a one-row band for the chip naming it, directly under the housing.
-   Captioned words drop below the chip's band; with captions off it stands
-   alone, so the announcement is pressable either way. The compact window
-   reserves room for both bands, so drawing them together costs no IPC.
-   `--caption-rest` is the caption block's own lift, the same variable the
-   panel's foot spends, so the words and the volume hint inside their block
-   both take the drop from one assignment. */
+/* The sessions Luke is talking about, pressable while he says them: the
+   surface grows a band for the chips naming them — an announcement's one
+   subject, or the several a conversation reply mentions, wrapped into
+   centred rows — directly under the housing. `--notice-growth` arrives
+   measured, the caption block's own pattern: the chips size to their names
+   and wrap where they wrap, so only a measurement can say how tall the band
+   is, and the renderer clamps it to the `--notice-max-rows` rows the compact
+   window reserved on top of the caption room — drawing all of it costs no
+   IPC. Captioned words drop below the chips' band; with captions off it
+   stands alone, so the mentions are pressable either way. `--caption-rest`
+   is the caption block's own lift, the same variable the panel's foot
+   spends, so the words and the volume hint inside their block both take the
+   drop from one assignment. */
 .app-stage[data-presentation="capsule"][data-notice="true"],
 .app-stage[data-presentation="peek"][data-notice="true"] {
-  --caption-growth: var(--notice-size);
-  --caption-rest: var(--notice-size);
+  --caption-growth: var(--notice-growth, var(--notice-size));
+  --caption-rest: var(--notice-growth, var(--notice-size));
 }
 
 /* Both at once: the caption keeps its measured room and the notice band adds
    its own below. Stated after the single-band rules so it wins their tie. */
 .app-stage[data-presentation="capsule"][data-caption="true"][data-notice="true"],
 .app-stage[data-presentation="peek"][data-caption="true"][data-notice="true"] {
-  --caption-growth: calc(var(--caption-size, 28px) + var(--volume-hint-size) + var(--notice-size));
+  --caption-growth: calc(
+    var(--caption-size, 28px) +
+    var(--volume-hint-size) +
+    var(--notice-growth, var(--notice-size))
+  );
 }
 
 /* While a notice stands, the capsule holds the peek's width, exactly as the
@@ -1518,65 +1527,141 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   height: calc(var(--capsule-height) - var(--shape-top) * 2 + var(--caption-growth));
 }
 
-/* The chip itself: the one raised, pressable pill on the shape, named like
-   the session's row — its provider's mark and its title. In the compact
-   states it stands directly under the housing and the words are what move: a
-   single row wants a fade crossing the last of the shape's travel, not a
-   clip or a journey of its own. `--notice-rest` is its one journey — the
-   ride to the open panel's foot, the caption's own travel — and the
-   transform waits out `--duration-exit` like the caption's does, so leaving
-   a state the chip travels with the shape rather than ahead of it. Above the
-   hover strip (z-index 4) because the press has to open the session. */
-.session-notice {
+/* The band the chips share: centred wrapped rows. In the compact states it
+   stands directly under the housing and the words are what move — the band
+   wants a fade crossing the last of the shape's travel, not a clip or a
+   journey of its own. `--notice-rest` is its one journey — the ride to the
+   open panel's foot, the caption's own travel — and the transform waits out
+   `--duration-exit` like the caption's does, so leaving a state the band
+   travels with the shape rather than ahead of it. It fades as one, however
+   many sessions the reply names, so a chip can never linger after the words
+   that earned it. Past `--notice-max-rows` the chips scroll inside the band
+   rather than the shape growing further, because the window reserved exactly
+   that many rows and anything taller would be drawn on the desktop. Above
+   the hover strip (z-index 4) because the presses have to open the
+   sessions. */
+.session-notices {
   position: absolute;
   z-index: 5;
   top: var(--capsule-height);
   left: 50%;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 5px;
-  max-width: calc(var(--peek-width) - var(--notch-convex-radius) * 4);
-  height: 20px;
-  padding: 0 9px;
-  border-radius: 10px;
-  background: var(--raised);
-  color: var(--text-primary);
-  font-size: 10px;
-  font-weight: 640;
+  justify-content: center;
+  gap: 6px;
+  /* The full peek less one corner radius a side: the band's last row ends
+     3px above the shape's edge, where the bottom corners curve in by this
+     much, and a chip any wider would poke past the curve onto the desktop.
+     A definite width, not a cap: `left: 50%` leaves an absolutely positioned
+     box only the right half of the stage as available space, so a
+     shrink-to-fit band resolves to half its intended width and stacks one
+     chip to a row — the translate recentres the box but never gives the
+     width back. */
+  width: calc(var(--peek-width) - var(--notch-convex-radius) * 2);
+  max-height: calc(var(--notice-size) * var(--notice-max-rows) - 6px);
+  overflow-y: auto;
   opacity: 0;
   pointer-events: none;
   transform: translate(-50%, calc(3px - var(--shape-top, 0px) + var(--notice-rest, 0px)));
   transition:
     opacity var(--duration-exit) var(--motion-exit),
-    transform var(--duration-shape) var(--spring) var(--duration-exit),
-    background-color var(--duration-hover) ease;
+    transform var(--duration-shape) var(--spring) var(--duration-exit);
 }
 
 /* Arrives the way the caption's first words do — the fade crossing the last
    of the shape's travel. Takes the pointer only while it is drawn, because
    everything a hidden button covers is desktop. */
-.app-stage[data-presentation="capsule"][data-notice="true"] .session-notice,
-.app-stage[data-presentation="peek"][data-notice="true"] .session-notice {
+.app-stage[data-presentation="capsule"][data-notice="true"] .session-notices,
+.app-stage[data-presentation="peek"][data-notice="true"] .session-notices {
   opacity: 1;
   pointer-events: auto;
   transition:
     opacity var(--duration-quick) var(--motion-exit)
     calc(var(--duration-shape) - var(--duration-quick)),
-    transform var(--duration-shape) var(--spring) var(--duration-exit),
-    background-color var(--duration-hover) ease;
+    transform var(--duration-shape) var(--spring) var(--duration-exit);
 }
 
-/* The open panel keeps the chip at its foot, the way it keeps the caption's
-   words: the announced session's row is up in the list, but the chip is what
-   says which row Luke is talking about, and its press stays one press either
-   way. It stands above the caption's block when one is drawn — the compact
-   order, chip first and words below. `--notice-rest` is the travel from
-   under the housing to the foot the panel's measured height puts there.
-   Expanding, the chip leads with the surface — no delay, the panel's own
-   timing — and collapsing, the compact rule above holds it back by
-   `--duration-exit` so it leaves with the shape. */
+/* The folds: a band with chips beyond an edge fades the chips into that
+   edge, which is what says there is more to scroll to — a fold with no edge
+   hides its lower rows silently. Each mask covers only the edge that has
+   more; a band whose chips all fit wears none, so nothing readable is ever
+   dimmed for decoration. */
+.session-notices[data-fold-below="true"] {
+  mask-image: linear-gradient(to bottom, black calc(100% - 14px), transparent);
+}
+
+.session-notices[data-fold-above="true"] {
+  mask-image: linear-gradient(to bottom, transparent, black 14px);
+}
+
+.session-notices[data-fold-above="true"][data-fold-below="true"] {
+  mask-image: linear-gradient(
+    to bottom,
+    transparent,
+    black 14px,
+    black calc(100% - 14px),
+    transparent
+  );
+}
+
+/* Each chip: a raised, pressable pill named like the session's row — its
+   provider's mark and its title, sized to the name and nothing more. The
+   chips wrap where they wrap; only a name too long for the whole band
+   ellipsizes rather than widening the chip past it. A chip joins the way
+   the options popover does — a mount fade on the shared tokens, which a
+   capture run and reduced motion have already zeroed — because mentions
+   accumulate as the words are said, and a pill simply appearing mid-reply
+   reads as a redraw rather than an arrival. The band's own opacity governs
+   the first chips: their mount fade has settled long before the band's
+   delayed arrival reveals them. */
+.session-notice {
+  display: flex;
+  min-width: 0;
+  max-width: 100%;
+  flex: 0 1 auto;
+  align-items: center;
+  gap: 5px;
+  height: 20px;
+  padding: 0 9px;
+  border-radius: 10px;
+  animation: notice-chip-enter var(--duration-quick) var(--motion-exit) both;
+  background: var(--raised);
+  color: var(--text-primary);
+  font-size: 10px;
+  font-weight: 640;
+  transition: background-color var(--duration-hover) ease;
+}
+
+@keyframes notice-chip-enter {
+  from {
+    opacity: 0;
+    transform: translateY(2px) scale(0.97);
+  }
+
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* The open panel keeps the band at its foot, the way it keeps the caption's
+   words: the mentioned sessions' rows are up in the list, but the chips are
+   what say which of them Luke is talking about, and each press stays one
+   press either way. The band stands above the caption's block when one is
+   drawn — the compact order, chips first and words below. `--notice-rest` is
+   the travel from under the housing to the foot the panel's measured height
+   puts there, less the band's own measured growth, so however many rows the
+   chips wrapped into end just above the panel's edge. Expanding, the band
+   leads with the surface — no delay, the panel's own timing — and
+   collapsing, the compact rule above holds it back by `--duration-exit` so
+   it leaves with the shape. */
 .app-stage[data-presentation="panel"][data-notice="true"] {
-  --notice-rest: calc(var(--panel-height, 520px) - var(--capsule-height) - var(--notice-size));
+  --notice-rest: calc(
+    var(--panel-height, 520px) -
+    var(--capsule-height) -
+    var(--notice-growth, var(--notice-size))
+  );
 }
 
 .app-stage[data-presentation="panel"][data-caption="true"][data-notice="true"] {
@@ -1585,27 +1670,26 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
     var(--capsule-height) -
     var(--caption-size, 28px) -
     var(--volume-hint-size) -
-    var(--notice-size)
+    var(--notice-growth, var(--notice-size))
   );
 }
 
-.app-stage[data-presentation="panel"][data-notice="true"] .session-notice {
+.app-stage[data-presentation="panel"][data-notice="true"] .session-notices {
   opacity: 1;
   pointer-events: auto;
   transition:
     opacity var(--duration-quick) var(--motion-exit)
     calc(var(--duration-shape) - var(--duration-quick)),
-    transform var(--duration-shape) var(--spring),
-    background-color var(--duration-hover) ease;
+    transform var(--duration-shape) var(--spring);
 }
 
-/* The chip is drawn on the shape, not in the panel's flow, so the body
-   reserves its band under the same padding the caption block takes — and
-   both at once stack, the caption's room under the chip's. Reserved whenever
+/* The chips are drawn on the shape, not in the panel's flow, so the body
+   reserves their band under the same padding the caption block takes — and
+   both at once stack, the caption's room under the chips'. Reserved whenever
    the notice stands rather than only while the panel is up, so the height
    the panel reports is already right when an expand begins mid-announcement. */
 .app-stage[data-notice="true"] .expanded-panel {
-  padding-bottom: calc(18px + var(--notice-size));
+  padding-bottom: calc(18px + var(--notice-growth, var(--notice-size)));
 }
 
 .app-stage[data-caption="true"][data-notice="true"] .expanded-panel {
@@ -1613,7 +1697,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
     18px +
     var(--caption-size, 28px) +
     var(--volume-hint-size) +
-    var(--notice-size)
+    var(--notice-growth, var(--notice-size))
   );
 }
 

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -5,18 +5,21 @@ import {
   type CarriedSessionAction,
   dispatchByKind,
   EMPTY_APP_GUIDE,
+  mentionedSessions,
   type NormalizedSession,
   type ObservedWorkspaceProject,
   REALTIME_STATUS,
   type RealtimeStatus,
   type RealtimeVoice,
   type RealtimeVoiceSpeed,
+  SESSION_MENTION_KIND,
   SESSION_TOOL_KIND,
   type SessionIdentity,
+  type SessionMention,
   type SessionNoticeAsk,
   type TrackedIssue,
 } from "@sidecar/core";
-import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
+import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MicrophoneStatus, SessionOpenResult, VoiceHotkeyState } from "../shared/contracts";
 import { TALK_KEY_RELEASE, talkKeyRelease } from "../shared/voice-hotkey";
 import { askRefusal } from "./ask-luke";
@@ -31,10 +34,13 @@ import { WAVEFORM_VOICE, type WaveformVoice } from "./waveform";
  * opens a call, so there are no words to draw unless the fixture supplies
  * them — and it must, or the caption strip ships unphotographed. Synthetic,
  * like every fixture, and long enough to wrap: a one-line fixture would leave
- * the wrapped form of the strip unphotographed too.
+ * the wrapped form of the strip unphotographed too. It names four of the
+ * fixture roster's own sessions and one of its workspaces, so the photograph
+ * holds both kinds of mention chip and the band at every row it can grow to,
+ * exactly as they would stand over a live reply walking the roster.
  */
 export const FIXTURE_SPEAKING_CAPTION =
-  "Claude Code finished checkout-service, and Codex is still migrating the payments schema. Two sessions are waiting on you.";
+  "Bootstrap the desktop shell and Review trust constraints are finished, lisbon-v2 is packaging the macOS build, and Follow a cloud agent and Watch a cloud session are waiting on you.";
 
 /**
  * What a changed voice on a live call should do. The API locks a session's
@@ -278,6 +284,34 @@ export function carriedSessionIdentity(action: CarriedSessionAction): SessionIde
 }
 
 /**
+ * The sessions the replies being spoken are about, for the surface to draw
+ * pressable previews of. An announcement already carries its one
+ * roster-validated subject, and that stays the whole answer: the update was
+ * about one session, whatever else its sentence brushes past. A conversation
+ * reply carries no subject, so its previews are read from the words
+ * themselves — the roster sessions whose own titles appear whole in the
+ * captions, and the workspaces whose names do, each resolved to its freshest
+ * observed chat — which is how "what are we working on?" is answered with a
+ * chip per thing named. Back-to-back replies stack their captions, and the
+ * chips follow every caption still on screen, because all of it is what Luke
+ * is currently telling the developer. The words select only among observed
+ * sessions; the identities never come from the model. A capture run has no
+ * reply, so its fixture words stand in for the captions — the chips the
+ * fixture sentence earns are photographed like everything else the surface
+ * draws.
+ */
+export function replyMentions(input: {
+  fixtureSpeaking: boolean;
+  about: SessionIdentity | undefined;
+  captions: readonly string[] | undefined;
+  sessions: readonly NormalizedSession[];
+}): readonly SessionMention[] {
+  if (input.about) return [{ ...input.about, kind: SESSION_MENTION_KIND.SESSION }];
+  const spoken = input.fixtureSpeaking ? FIXTURE_SPEAKING_CAPTION : input.captions?.join("\n");
+  return mentionedSessions(spoken, input.sessions);
+}
+
+/**
  * The other half of {@link announcerNotices}: an unbidden evaluator summary is
  * a model's words on a session nobody asked about, so it keeps its original
  * bound — spoken only on a call the developer opened themselves.
@@ -367,12 +401,14 @@ export interface VoiceConversation {
    */
   captionShownAt: number | undefined;
   /**
-   * The session the reply being spoken is announcing, or nothing for a
-   * conversation reply. Present exactly as long as the announcement is — it is
-   * what the surface anchors the pressable notice to — and independent of the
-   * captions preference, which only governs whether the words are drawn.
+   * The sessions the reply being spoken is about: an announcement's one
+   * validated subject, or what a conversation reply names in its words — a
+   * chat by its title, or a workspace by name, resolved to its freshest
+   * chat. Present exactly as long as the reply is — it is what the surface
+   * anchors the pressable notices to — and independent of the captions
+   * preference, which only governs whether the words are drawn.
    */
-  announcedSession: SessionIdentity | undefined;
+  mentionedSessions: readonly SessionMention[];
   remoteAudio: RefObject<HTMLAudioElement | null>;
   /** Escape out of an open turn: forget the press and the latch, and stop listening. */
   discardListening: () => void;
@@ -959,6 +995,20 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     [],
   );
 
+  // Derived, not queued: the subjects arrive with the captions and die with
+  // the reply, so a chip can never lag the words or stand for a session the
+  // reply is not talking about.
+  const mentioned = useMemo(
+    () =>
+      replyMentions({
+        fixtureSpeaking: options.fixtureSpeaking,
+        about: voiceCaption.about,
+        captions: voiceCaption.texts,
+        sessions: options.sessions,
+      }),
+    [options.fixtureSpeaking, options.sessions, voiceCaption],
+  );
+
   const voiceTurn = waveformVoice(voiceStatus);
   const lukeCaptions = lukeCaptionsToShow({
     fixtureSpeaking: options.fixtureSpeaking,
@@ -995,7 +1045,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     voiceTurn,
     lukeCaptions,
     captionShownAt,
-    announcedSession: voiceCaption.about,
+    mentionedSessions: mentioned,
     remoteAudio,
     discardListening,
     stopSpeaking,

--- a/apps/desktop/tests/use-voice-conversation.test.ts
+++ b/apps/desktop/tests/use-voice-conversation.test.ts
@@ -4,9 +4,13 @@ import {
   ATTENTION_DISPOSITION,
   ATTENTION_SPEECH_SOURCE,
   type AttentionSpeech,
+  type NormalizedSession,
+  normalizeSession,
   REALTIME_STATUS,
   REALTIME_VOICE,
   REALTIME_VOICE_SPEED,
+  SESSION_MENTION_KIND,
+  SESSION_STATUS,
   SESSION_TOOL_KIND,
 } from "@sidecar/core";
 import {
@@ -19,6 +23,7 @@ import {
   latestSpeechReference,
   liveSpeedApplies,
   lukeCaptionsToShow,
+  replyMentions,
   talkKeyPress,
   talkOpeningHolds,
   typedAskHolds,
@@ -311,6 +316,105 @@ test("the newest announcement's words are what 'what did you just say?' points b
   assert.equal(latestSpeech([older, newest, newer]), newest);
   // An empty batch keeps whatever announcement already stands.
   assert.equal(latestSpeech([]), undefined);
+});
+
+function rosterSession(
+  providerSessionId: string,
+  title: string,
+  workspace?: { providerWorkspaceId: string; name?: string },
+): NormalizedSession {
+  return normalizeSession(
+    { id: "conductor", displayName: "Conductor" },
+    {
+      providerSessionId,
+      title,
+      status: SESSION_STATUS.WORKING,
+      observedAt: 100,
+      ...(workspace ? { workspace } : {}),
+      detail: {},
+    },
+  );
+}
+
+test("an announcement's one validated subject is the whole answer", () => {
+  const roster = [rosterSession("a", "Checkout service"), rosterSession("b", "Payments schema")];
+  assert.deepEqual(
+    replyMentions({
+      fixtureSpeaking: false,
+      about: { providerId: "conductor", providerSessionId: "b" },
+      // The sentence brushes past another roster title; the update was still
+      // about one session, and the chip must say so.
+      captions: ["Payments schema finished, right after Checkout service did."],
+      sessions: roster,
+    }),
+    [
+      {
+        kind: SESSION_MENTION_KIND.SESSION,
+        providerId: "conductor",
+        providerSessionId: "b",
+      },
+    ],
+  );
+});
+
+test("a conversation reply's previews are what its words name off the roster", () => {
+  const roster = [
+    rosterSession("a", "Checkout service"),
+    rosterSession("b", "Payments schema"),
+    rosterSession("c", "amber-shoal", { providerWorkspaceId: "ws-lisbon", name: "lisbon-v2" }),
+  ];
+  // Back-to-back replies stack their captions, and every caption still on
+  // screen feeds the chips: the first names one session, the second another.
+  assert.deepEqual(
+    replyMentions({
+      fixtureSpeaking: false,
+      about: undefined,
+      captions: ["Payments schema is migrating.", "And lisbon-v2 is waiting on you."],
+      sessions: roster,
+    }),
+    [
+      { kind: SESSION_MENTION_KIND.SESSION, providerId: "conductor", providerSessionId: "b" },
+      { kind: SESSION_MENTION_KIND.WORKSPACE, providerId: "conductor", providerSessionId: "c" },
+    ],
+  );
+  assert.deepEqual(
+    replyMentions({
+      fixtureSpeaking: false,
+      about: undefined,
+      captions: undefined,
+      sessions: roster,
+    }),
+    [],
+  );
+});
+
+test("a capture run's chips are earned by the fixture's own words", () => {
+  // The fixture sentence names this title and this workspace on purpose: the
+  // chips they earn are what the speaking evidence photographs.
+  const roster = [
+    rosterSession("fixture", "Bootstrap the desktop shell"),
+    rosterSession("chat", "gentle-cove", { providerWorkspaceId: "ws-lisbon", name: "lisbon-v2" }),
+  ];
+  assert.deepEqual(
+    replyMentions({
+      fixtureSpeaking: true,
+      about: undefined,
+      captions: undefined,
+      sessions: roster,
+    }),
+    [
+      {
+        kind: SESSION_MENTION_KIND.SESSION,
+        providerId: "conductor",
+        providerSessionId: "fixture",
+      },
+      {
+        kind: SESSION_MENTION_KIND.WORKSPACE,
+        providerId: "conductor",
+        providerSessionId: "chat",
+      },
+    ],
+  );
 });
 
 test("a carried act aims the reference at its session; a creation aims at none", () => {

--- a/design/generate-surface-shared.mjs
+++ b/design/generate-surface-shared.mjs
@@ -66,14 +66,21 @@ const ROW_FAN_LIMIT = 5;
 const SURFACE_GEOMETRY_PX = {
   BUBBLE_LIFT: 4,
   VOICE_CAPTION_MAX_HEIGHT: 70,
-  // The notice band under the housing: one row for the pressable chip naming
-  // the session Luke is announcing. Fixed rather than measured — the name
-  // truncates into it — so the surface springs to one destination. The
-  // compact window reserves this on top of the caption room, because
-  // captioned speech drops below the chip's band.
+  // The notice band under the housing: one row of the pressable chips naming
+  // the sessions the reply being spoken is about. The chips size to their
+  // names and wrap naturally, so the renderer measures the rows they made
+  // and grows the shape by that, the caption block's own pattern. The
+  // compact window reserves `SESSION_NOTICE_MAX_ROWS` of these on top of
+  // the caption room, because captioned speech drops below the chips' band
+  // and a reply may name more sessions than one row holds.
   SESSION_NOTICE_HEIGHT: 26,
   PANEL_WIDTH: 620,
 };
+
+// How many chip rows the notice band may grow to before the chips scroll
+// inside it instead. A count, not pixels: the window reserves this many
+// `SESSION_NOTICE_HEIGHT` rows, and the band clamps its own growth to it.
+const SESSION_NOTICE_MAX_ROWS = 3;
 
 // ---------- Session display ----------
 // How the surface ranks a row, not what the provider observed. Keys are the
@@ -238,6 +245,7 @@ function motionTokensCss() {
   --bubble-lift: ${px(SURFACE_GEOMETRY_PX.BUBBLE_LIFT)};
   --caption-max: ${px(SURFACE_GEOMETRY_PX.VOICE_CAPTION_MAX_HEIGHT)};
   --notice-size: ${px(SURFACE_GEOMETRY_PX.SESSION_NOTICE_HEIGHT)};
+  --notice-max-rows: ${SESSION_NOTICE_MAX_ROWS};
   --panel-width: ${px(SURFACE_GEOMETRY_PX.PANEL_WIDTH)};
 }
 `;
@@ -271,8 +279,11 @@ export const BUBBLE_LIFT = ${SURFACE_GEOMETRY_PX.BUBBLE_LIFT};
 /** Tallest compact caption block the window holds. CSS: \`--caption-max\`. */
 export const VOICE_CAPTION_MAX_HEIGHT = ${SURFACE_GEOMETRY_PX.VOICE_CAPTION_MAX_HEIGHT};
 
-/** The session notice's band, held beside the caption room. CSS: \`--notice-size\`. */
+/** One chip row of the session notice band. CSS: \`--notice-size\`. */
 export const SESSION_NOTICE_HEIGHT = ${SURFACE_GEOMETRY_PX.SESSION_NOTICE_HEIGHT};
+
+/** Chip rows the band may grow to before scrolling. CSS: \`--notice-max-rows\`. */
+export const SESSION_NOTICE_MAX_ROWS = ${SESSION_NOTICE_MAX_ROWS};
 
 /** Expanded panel width. CSS: \`--panel-width\`. */
 export const PANEL_WIDTH = ${SURFACE_GEOMETRY_PX.PANEL_WIDTH};

--- a/packages/sidecar-core/src/geometry.ts
+++ b/packages/sidecar-core/src/geometry.ts
@@ -2,6 +2,7 @@ import {
   BUBBLE_LIFT,
   PANEL_WIDTH,
   SESSION_NOTICE_HEIGHT,
+  SESSION_NOTICE_MAX_ROWS,
   VOICE_CAPTION_MAX_HEIGHT,
 } from "./motion-tokens.js";
 
@@ -89,14 +90,15 @@ export interface NotchWindowLayout extends Rectangle {
 export const CAPSULE_SIDE_WIDTH = 36;
 export const PEEK_SIDE_GROWTH = 88;
 export const SURFACE_MARGIN = 40;
-// BUBBLE_LIFT, VOICE_CAPTION_MAX_HEIGHT, SESSION_NOTICE_HEIGHT, and
-// PANEL_WIDTH come from the shared surface tokens, so the window the main
-// process sizes and the shape the renderer draws cannot drift. The bubble's
-// lift is derived: the pill matches the 24pt menu bar it floats beside — the
-// 32px compact strip minus the lift on each side. The compact window holds the
-// caption block for the same reason it holds the peek's width — speech must
-// never cost an IPC resize — and the notice band below it, because a session
-// announcement may stand under captioned speech.
+// BUBBLE_LIFT, VOICE_CAPTION_MAX_HEIGHT, SESSION_NOTICE_HEIGHT,
+// SESSION_NOTICE_MAX_ROWS, and PANEL_WIDTH come from the shared surface
+// tokens, so the window the main process sizes and the shape the renderer
+// draws cannot drift. The bubble's lift is derived: the pill matches the 24pt
+// menu bar it floats beside — the 32px compact strip minus the lift on each
+// side. The compact window holds the caption block for the same reason it
+// holds the peek's width — speech must never cost an IPC resize — and every
+// row the notice band can grow to below it, because a reply may name several
+// sessions under captioned speech.
 const peekSideWidth = CAPSULE_SIDE_WIDTH + PEEK_SIDE_GROWTH;
 const panelHeight = 520;
 
@@ -178,7 +180,7 @@ export function positionNotchWindow(
       : Math.min(
           Math.ceil(Math.max(32, notch.topInset)) +
             VOICE_CAPTION_MAX_HEIGHT +
-            SESSION_NOTICE_HEIGHT +
+            SESSION_NOTICE_HEIGHT * SESSION_NOTICE_MAX_ROWS +
             SURFACE_MARGIN,
           display.bounds.height,
         );

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -64,6 +64,14 @@ export {
   CreatedWorkspaceOpenTracker,
 } from "./workspace-opens.js";
 export { MAXIMUM_HELD_NOTICES, SessionNoticeHold } from "./session-notice-hold.js";
+export {
+  MAXIMUM_MENTIONED_SESSIONS,
+  MINIMUM_MENTION_TITLE_LENGTH,
+  mentionedSessions,
+  SESSION_MENTION_KIND,
+  type SessionMention,
+  type SessionMentionKind,
+} from "./session-mentions.js";
 
 // Calendar — when meetings start and end, and nothing else about them.
 export {
@@ -304,6 +312,7 @@ export {
   MOTION_DURATION_MS,
   PANEL_WIDTH,
   SESSION_NOTICE_HEIGHT,
+  SESSION_NOTICE_MAX_ROWS,
   VOICE_CAPTION_MAX_HEIGHT,
 } from "./motion-tokens.js";
 export {

--- a/packages/sidecar-core/src/motion-tokens.css
+++ b/packages/sidecar-core/src/motion-tokens.css
@@ -79,5 +79,6 @@
   --bubble-lift: 4px;
   --caption-max: 70px;
   --notice-size: 26px;
+  --notice-max-rows: 3;
   --panel-width: 620px;
 }

--- a/packages/sidecar-core/src/motion-tokens.ts
+++ b/packages/sidecar-core/src/motion-tokens.ts
@@ -27,8 +27,11 @@ export const BUBBLE_LIFT = 4;
 /** Tallest compact caption block the window holds. CSS: `--caption-max`. */
 export const VOICE_CAPTION_MAX_HEIGHT = 70;
 
-/** The session notice's band, held beside the caption room. CSS: `--notice-size`. */
+/** One chip row of the session notice band. CSS: `--notice-size`. */
 export const SESSION_NOTICE_HEIGHT = 26;
+
+/** Chip rows the band may grow to before scrolling. CSS: `--notice-max-rows`. */
+export const SESSION_NOTICE_MAX_ROWS = 3;
 
 /** Expanded panel width. CSS: `--panel-width`. */
 export const PANEL_WIDTH = 620;

--- a/packages/sidecar-core/src/session-mentions.ts
+++ b/packages/sidecar-core/src/session-mentions.ts
@@ -1,0 +1,209 @@
+import type { NormalizedSession, SessionIdentity } from "./session.js";
+
+/**
+ * The most sessions one reply's mentions may put on the notice band. The band
+ * under the housing wraps chips into rows, holds three rows on screen, and
+ * scrolls past that — this cap is about twice the visible band, deep enough
+ * for any reply worth hearing out and shallow enough that the scroll stays a
+ * glance. A reply that walks through more sessions than that has the panel
+ * for a record, the way a burst of notices does.
+ */
+export const MAXIMUM_MENTIONED_SESSIONS = 12;
+
+/**
+ * The shortest name a mention may be recognized by. A chip is a claim that
+ * the words on screen name this session or workspace, and a two-letter name
+ * matches too many sentences that were never about it. Anything named shorter
+ * than this simply earns no chip — its row in the panel is unchanged.
+ */
+export const MINIMUM_MENTION_TITLE_LENGTH = 4;
+
+/**
+ * What a reply named: a session by its own title, or a workspace by the name
+ * its provider groups chats under. The kind is what tells the surface which
+ * words the chip should carry — the fields stay on the roster row the
+ * identity resolves to, so a renamed session or workspace is worded as it is
+ * now.
+ */
+export const SESSION_MENTION_KIND = {
+  SESSION: "session",
+  WORKSPACE: "workspace",
+} as const;
+
+export type SessionMentionKind = (typeof SESSION_MENTION_KIND)[keyof typeof SESSION_MENTION_KIND];
+
+/**
+ * One thing a spoken reply named, resolved to a session the roster observes.
+ * A workspace mention resolves to its most recently observed chat, because a
+ * chip's press is a row press at one remove and only a session row has
+ * anywhere to go — the chat is the workspace's freshest way in.
+ */
+export interface SessionMention extends SessionIdentity {
+  kind: SessionMentionKind;
+}
+
+const WORDLIKE = /[\p{L}\p{N}]/u;
+
+/** Whether the character beside a match keeps it a whole mention of the name. */
+function boundaryAt(text: string, index: number): boolean {
+  if (index < 0 || index >= text.length) return true;
+  const character = text[index];
+  return character === undefined || !WORDLIKE.test(character);
+}
+
+/**
+ * Where a name is first mentioned whole in the caption, or nowhere. Whole
+ * means bounded on both sides by something other than a letter or digit, so a
+ * short name cannot ride inside a longer word that merely contains it.
+ */
+function firstMentionIndex(caption: string, name: string): number | undefined {
+  let from = 0;
+  while (from + name.length <= caption.length) {
+    const at = caption.indexOf(name, from);
+    if (at === -1) return undefined;
+    if (boundaryAt(caption, at - 1) && boundaryAt(caption, at + name.length)) return at;
+    from = at + 1;
+  }
+  return undefined;
+}
+
+/** One name the caption may be searched for, and the session it stands for. */
+interface MentionCandidate {
+  kind: SessionMentionKind;
+  session: NormalizedSession;
+  /** Whether the name stopped being attributable to one thing and is dead. */
+  ambiguous: boolean;
+}
+
+/**
+ * The searchable names one roster offers, each mapped to the one thing it
+ * attributably stands for. Built in one pass so every collision is seen:
+ *
+ * - A session's own title, unless two observed sessions share it.
+ * - A workspace's name, standing for its most recently observed chat — the
+ *   name repeats across the workspace's own chats without harm, but one
+ *   naming two distinct workspaces stands for neither.
+ * - A name that is both a title and a workspace's is skipped outright: the
+ *   mention cannot say which was meant, and a chip that might open the wrong
+ *   one is worse than no chip.
+ */
+function mentionCandidates(sessions: readonly NormalizedSession[]): Map<string, MentionCandidate> {
+  const candidates = new Map<string, MentionCandidate>();
+  for (const session of sessions) {
+    const title = session.title.trim().toLowerCase();
+    if (title.length >= MINIMUM_MENTION_TITLE_LENGTH) {
+      const existing = candidates.get(title);
+      if (existing) existing.ambiguous = true;
+      else candidates.set(title, { kind: SESSION_MENTION_KIND.SESSION, session, ambiguous: false });
+    }
+    const workspaceName = session.workspace?.name?.trim().toLowerCase();
+    if (workspaceName === undefined || workspaceName.length < MINIMUM_MENTION_TITLE_LENGTH) {
+      continue;
+    }
+    const existing = candidates.get(workspaceName);
+    if (!existing) {
+      candidates.set(workspaceName, {
+        kind: SESSION_MENTION_KIND.WORKSPACE,
+        session,
+        ambiguous: false,
+      });
+      continue;
+    }
+    if (existing.kind === SESSION_MENTION_KIND.SESSION) {
+      // The same name titles a session outright; neither reading survives.
+      existing.ambiguous = true;
+      continue;
+    }
+    // Another chat wearing the same workspace name: the same workspace keeps
+    // its freshest chat as the way in, and a different workspace — another
+    // provider's, or another id under this one — kills the name.
+    const sameWorkspace =
+      existing.session.providerId === session.providerId &&
+      existing.session.workspace?.providerWorkspaceId === session.workspace?.providerWorkspaceId;
+    if (!sameWorkspace) {
+      existing.ambiguous = true;
+      continue;
+    }
+    if (session.observedAt > existing.session.observedAt) existing.session = session;
+  }
+  return candidates;
+}
+
+/**
+ * The sessions a spoken reply names, for the surface to draw pressable
+ * previews of — "what are we working on?" is answered with a walk through
+ * several, and each deserves the same chip an announcement's one subject
+ * gets. A reply may name a chat by its title or a whole workspace by the
+ * name its provider groups chats under; a workspace mention resolves to its
+ * most recently observed chat.
+ *
+ * The specific beats the general: a workspace named beside one of its own
+ * chats is absorbed by the chat's mention, because the band is a row of
+ * destinations and the named chat is the precise way into that workspace —
+ * the freshest-chat fallback exists for a workspace named alone, and using
+ * it when the sentence itself picked a chat would open a chat nobody was
+ * talking about. A workspace named with no chat of its own keeps its chip.
+ *
+ * Deterministic on the side that matters: the identities come only from the
+ * observed roster, and something is included only when its own name appears
+ * whole in the words being spoken — case aside — so the model's words can
+ * select among what Luke was actually shown but can never point a chip at
+ * anything else. The result is ordered by first mention, because that is the
+ * order the developer hears them in, deduplicated by the session each
+ * mention resolves to, and capped at {@link MAXIMUM_MENTIONED_SESSIONS}.
+ * Every ambiguity — a title two sessions share, a name two workspaces
+ * share, a name that is both — earns nothing at all, because a chip that
+ * might open the wrong thing is worse than no chip. The panel still shows
+ * every row.
+ */
+export function mentionedSessions(
+  caption: string | undefined,
+  sessions: readonly NormalizedSession[],
+): readonly SessionMention[] {
+  if (!caption) return [];
+  const spoken = caption.toLowerCase();
+  const mentions: { at: number; kind: SessionMentionKind; session: NormalizedSession }[] = [];
+  for (const [name, candidate] of mentionCandidates(sessions)) {
+    if (candidate.ambiguous) continue;
+    const at = firstMentionIndex(spoken, name);
+    if (at === undefined) continue;
+    mentions.push({ at, kind: candidate.kind, session: candidate.session });
+  }
+  // The workspaces the reply named a chat of, by the original identifiers.
+  // Their own mentions are absorbed below — before the dedup and the cap, so
+  // an absorbed workspace frees its slot rather than spending it.
+  const chatNamedIn = new Map<string, Set<string>>();
+  for (const entry of mentions) {
+    if (entry.kind !== SESSION_MENTION_KIND.SESSION) continue;
+    const workspaceId = entry.session.workspace?.providerWorkspaceId;
+    if (workspaceId === undefined) continue;
+    let provider = chatNamedIn.get(entry.session.providerId);
+    if (!provider) {
+      provider = new Set();
+      chatNamedIn.set(entry.session.providerId, provider);
+    }
+    provider.add(workspaceId);
+  }
+  // One chip per session falls out of the absorption: every candidate name is
+  // distinct, a session-kind mention resolves only to its own title's session,
+  // and a workspace-kind mention that could share a chat with a named title is
+  // exactly the one absorbed above.
+  return mentions
+    .filter(
+      (entry) =>
+        entry.kind !== SESSION_MENTION_KIND.WORKSPACE ||
+        entry.session.workspace?.providerWorkspaceId === undefined ||
+        !chatNamedIn
+          .get(entry.session.providerId)
+          ?.has(entry.session.workspace.providerWorkspaceId),
+    )
+    .sort((a, b) => a.at - b.at)
+    .slice(0, MAXIMUM_MENTIONED_SESSIONS)
+    .map(
+      (entry): SessionMention => ({
+        kind: entry.kind,
+        providerId: entry.session.providerId,
+        providerSessionId: entry.session.providerSessionId,
+      }),
+    );
+}

--- a/packages/sidecar-core/tests/geometry.test.ts
+++ b/packages/sidecar-core/tests/geometry.test.ts
@@ -8,6 +8,7 @@ import {
   PEEK_SIDE_GROWTH,
   positionNotchWindow,
   SESSION_NOTICE_HEIGHT,
+  SESSION_NOTICE_MAX_ROWS,
   VOICE_CAPTION_MAX_HEIGHT,
 } from "../src";
 import { SIMULATED_HOUSING_WIDTH, SURFACE_MARGIN } from "../src/geometry";
@@ -36,10 +37,10 @@ test("anchors the compact window to the physical top edge", () => {
     x: 487,
     y: 0,
     width: 538,
-    // The top inset, the caption block Luke's words wrap into below it, the
-    // notice band the announced session's chip holds under those words, and
-    // the margin the overshoot and the shadow fall in.
-    height: 174,
+    // The top inset, the caption block Luke's words wrap into below it, every
+    // chip row the notice band can grow to under those words, and the margin
+    // the overshoot and the shadow fall in: 38 + 70 + 26 × 3 + 40.
+    height: 226,
     notch: {
       topInset: 38,
       housingWidth: 210,
@@ -80,7 +81,10 @@ test("uses a top-center fallback without inventing a notch", () => {
   assert.equal(result.width, peekWidth(0) + SURFACE_MARGIN * 2);
   assert.equal(
     result.height,
-    32 + VOICE_CAPTION_MAX_HEIGHT + SESSION_NOTICE_HEIGHT + SURFACE_MARGIN,
+    32 +
+      VOICE_CAPTION_MAX_HEIGHT +
+      SESSION_NOTICE_HEIGHT * SESSION_NOTICE_MAX_ROWS +
+      SURFACE_MARGIN,
   );
   assert.equal(result.notch.hasNotch, false);
   assert.equal(result.notch.topInset, 25);
@@ -111,7 +115,10 @@ test("the notch form gives a display without a housing the simulated one", () =>
   assert.equal(result.width, peekWidth(SIMULATED_HOUSING_WIDTH) + SURFACE_MARGIN * 2);
   assert.equal(
     result.height,
-    32 + VOICE_CAPTION_MAX_HEIGHT + SESSION_NOTICE_HEIGHT + SURFACE_MARGIN,
+    32 +
+      VOICE_CAPTION_MAX_HEIGHT +
+      SESSION_NOTICE_HEIGHT * SESSION_NOTICE_MAX_ROWS +
+      SURFACE_MARGIN,
   );
 });
 
@@ -239,7 +246,10 @@ test("uses the painted menu bar when it is deeper than the safe area", () => {
   assert.equal(reportingMachine.notch.topInset, 34);
   assert.equal(
     reportingMachine.height,
-    34 + VOICE_CAPTION_MAX_HEIGHT + SESSION_NOTICE_HEIGHT + SURFACE_MARGIN,
+    34 +
+      VOICE_CAPTION_MAX_HEIGHT +
+      SESSION_NOTICE_HEIGHT * SESSION_NOTICE_MAX_ROWS +
+      SURFACE_MARGIN,
   );
   assert.equal(macBookPro14.notch.topInset, 37);
 });
@@ -275,6 +285,9 @@ test("snaps fractional depths to device pixels and ceils the window height", () 
   assert.equal(result.notch.topInset, 33.5);
   assert.equal(
     result.height,
-    34 + VOICE_CAPTION_MAX_HEIGHT + SESSION_NOTICE_HEIGHT + SURFACE_MARGIN,
+    34 +
+      VOICE_CAPTION_MAX_HEIGHT +
+      SESSION_NOTICE_HEIGHT * SESSION_NOTICE_MAX_ROWS +
+      SURFACE_MARGIN,
   );
 });

--- a/packages/sidecar-core/tests/session-mentions.test.ts
+++ b/packages/sidecar-core/tests/session-mentions.test.ts
@@ -1,0 +1,244 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  MAXIMUM_MENTIONED_SESSIONS,
+  mentionedSessions,
+  type NormalizedSession,
+  normalizeSession,
+  SESSION_MENTION_KIND,
+  SESSION_STATUS,
+  type SessionProvider,
+} from "../src";
+
+const claude: SessionProvider = { id: "claude-code", displayName: "Claude Code" };
+const conductor: SessionProvider = { id: "conductor", displayName: "Conductor" };
+
+function session(
+  provider: SessionProvider,
+  providerSessionId: string,
+  title: string,
+  overrides: {
+    observedAt?: number;
+    workspace?: { providerWorkspaceId: string; name?: string };
+  } = {},
+): NormalizedSession {
+  return normalizeSession(provider, {
+    providerSessionId,
+    title,
+    status: SESSION_STATUS.WORKING,
+    observedAt: overrides.observedAt ?? 100,
+    ...(overrides.workspace ? { workspace: overrides.workspace } : {}),
+    detail: {},
+  });
+}
+
+test("names the sessions the reply mentions, in the order they are heard", () => {
+  const roster = [
+    session(claude, "a", "Checkout service"),
+    session(conductor, "b", "Payments schema"),
+    session(conductor, "c", "Docs sweep"),
+  ];
+  assert.deepEqual(
+    mentionedSessions(
+      "Payments schema is still migrating, and Checkout service just finished.",
+      roster,
+    ),
+    [
+      { kind: SESSION_MENTION_KIND.SESSION, providerId: "conductor", providerSessionId: "b" },
+      { kind: SESSION_MENTION_KIND.SESSION, providerId: "claude-code", providerSessionId: "a" },
+    ],
+  );
+});
+
+test("matches case aside, but only a whole title with its own edges", () => {
+  const roster = [session(claude, "a", "Checkout service")];
+  assert.deepEqual(mentionedSessions('I paused "checkout service" for you.', roster), [
+    { kind: SESSION_MENTION_KIND.SESSION, providerId: "claude-code", providerSessionId: "a" },
+  ]);
+  // Inside a longer word is not a mention of this session.
+  assert.deepEqual(mentionedSessions("The precheckout services queue is empty.", roster), []);
+});
+
+test("an empty or absent caption mentions nothing", () => {
+  const roster = [session(claude, "a", "Checkout service")];
+  assert.deepEqual(mentionedSessions(undefined, roster), []);
+  assert.deepEqual(mentionedSessions("", roster), []);
+});
+
+test("a name too short to be attributable earns no chip", () => {
+  const roster = [
+    session(claude, "a", "Fix"),
+    session(conductor, "b", "Long enough title", {
+      workspace: { providerWorkspaceId: "ws-1", name: "два" },
+    }),
+  ];
+  assert.deepEqual(mentionedSessions("I can fix that in два for you.", roster), []);
+});
+
+test("a title shared by two observed sessions names neither", () => {
+  const roster = [
+    session(claude, "a", "Untitled session"),
+    session(conductor, "b", "untitled session"),
+    session(conductor, "c", "Docs sweep"),
+  ];
+  assert.deepEqual(
+    mentionedSessions("The untitled session is waiting, and Docs sweep finished.", roster),
+    [{ kind: SESSION_MENTION_KIND.SESSION, providerId: "conductor", providerSessionId: "c" }],
+  );
+});
+
+test("a workspace named whole resolves to its most recently observed chat", () => {
+  const roster = [
+    session(conductor, "older-chat", "amber-shoal", {
+      observedAt: 100,
+      workspace: { providerWorkspaceId: "ws-lisbon", name: "lisbon-v2" },
+    }),
+    session(conductor, "fresher-chat", "gentle-cove", {
+      observedAt: 200,
+      workspace: { providerWorkspaceId: "ws-lisbon", name: "lisbon-v2" },
+    }),
+  ];
+  assert.deepEqual(mentionedSessions("lisbon-v2 is packaging the macOS build.", roster), [
+    {
+      kind: SESSION_MENTION_KIND.WORKSPACE,
+      providerId: "conductor",
+      providerSessionId: "fresher-chat",
+    },
+  ]);
+});
+
+test("a workspace named beside its own chat is absorbed by the chat's mention", () => {
+  const roster = [
+    session(conductor, "older-chat", "amber-shoal", {
+      observedAt: 100,
+      workspace: { providerWorkspaceId: "ws-lisbon", name: "lisbon-v2" },
+    }),
+    session(conductor, "fresher-chat", "gentle-cove", {
+      observedAt: 200,
+      workspace: { providerWorkspaceId: "ws-lisbon", name: "lisbon-v2" },
+    }),
+  ];
+  // The named chat is the precise way in, however the two are ordered — the
+  // freshest-chat fallback must not open gentle-cove out of a sentence that
+  // picked amber-shoal.
+  const chipForChat = [
+    {
+      kind: SESSION_MENTION_KIND.SESSION,
+      providerId: "conductor",
+      providerSessionId: "older-chat",
+    },
+  ];
+  assert.deepEqual(
+    mentionedSessions("amber-shoal, in lisbon-v2, is packaging.", roster),
+    chipForChat,
+  );
+  assert.deepEqual(
+    mentionedSessions("In lisbon-v2, amber-shoal is packaging.", roster),
+    chipForChat,
+  );
+});
+
+test("naming a workspace and two of its chats draws one chip per chat", () => {
+  const roster = [
+    session(conductor, "a", "amber-shoal", {
+      workspace: { providerWorkspaceId: "ws-lisbon", name: "lisbon-v2" },
+    }),
+    session(conductor, "b", "gentle-cove", {
+      workspace: { providerWorkspaceId: "ws-lisbon", name: "lisbon-v2" },
+    }),
+  ];
+  assert.deepEqual(
+    mentionedSessions("In lisbon-v2, amber-shoal is packaging and gentle-cove finished.", roster),
+    [
+      { kind: SESSION_MENTION_KIND.SESSION, providerId: "conductor", providerSessionId: "a" },
+      { kind: SESSION_MENTION_KIND.SESSION, providerId: "conductor", providerSessionId: "b" },
+    ],
+  );
+});
+
+test("an absorbed workspace frees its slot under the cap", () => {
+  // Exactly the cap's worth of titled sessions, plus a workspace mention that
+  // is absorbed by its own chat's: every titled session keeps its chip, so
+  // the absorbed workspace visibly spent no slot.
+  const others = Array.from({ length: MAXIMUM_MENTIONED_SESSIONS - 1 }, (_, index) =>
+    session(claude, `other-${index}`, `Errand number ${index}`),
+  );
+  const roster = [
+    session(conductor, "a", "Alpha task", {
+      workspace: { providerWorkspaceId: "ws-1", name: "lisbon-v2" },
+    }),
+    ...others,
+  ];
+  const spoken = mentionedSessions(
+    `lisbon-v2's Alpha task, then ${others.map((other) => other.title).join(", then ")}.`,
+    roster,
+  );
+  assert.deepEqual(
+    spoken.map((mention) => mention.providerSessionId),
+    ["a", ...others.map((other) => other.providerSessionId)],
+  );
+});
+
+test("a chat of another workspace absorbs nothing", () => {
+  const roster = [
+    session(conductor, "a", "amber-shoal", {
+      workspace: { providerWorkspaceId: "ws-lisbon", name: "lisbon-v2" },
+    }),
+    session(conductor, "b", "quiet-reef", {
+      workspace: { providerWorkspaceId: "ws-porto", name: "porto-novo" },
+    }),
+  ];
+  assert.deepEqual(mentionedSessions("amber-shoal is packaging; porto-novo is idle.", roster), [
+    { kind: SESSION_MENTION_KIND.SESSION, providerId: "conductor", providerSessionId: "a" },
+    { kind: SESSION_MENTION_KIND.WORKSPACE, providerId: "conductor", providerSessionId: "b" },
+  ]);
+});
+
+test("a workspace name shared by two distinct workspaces names neither", () => {
+  const roster = [
+    session(conductor, "a", "amber-shoal", {
+      workspace: { providerWorkspaceId: "ws-1", name: "lisbon-v2" },
+    }),
+    session(claude, "b", "gentle-cove", {
+      workspace: { providerWorkspaceId: "ws-1", name: "lisbon-v2" },
+    }),
+  ];
+  assert.deepEqual(mentionedSessions("lisbon-v2 is packaging.", roster), []);
+});
+
+test("a name that is both a title and a workspace's stands for neither", () => {
+  const roster = [
+    session(claude, "solo", "lisbon-v2"),
+    session(conductor, "chat", "amber-shoal", {
+      workspace: { providerWorkspaceId: "ws-1", name: "lisbon-v2" },
+    }),
+  ];
+  assert.deepEqual(mentionedSessions("lisbon-v2 is packaging.", roster), []);
+});
+
+test("mentions past the cap are dropped from the tail of the reply", () => {
+  const roster = Array.from({ length: MAXIMUM_MENTIONED_SESSIONS + 1 }, (_, index) =>
+    session(claude, `chat-${index}`, `Errand number ${index}`),
+  );
+  const spoken = mentionedSessions(`${roster.map((chat) => chat.title).join(", then ")}.`, roster);
+  assert.equal(spoken.length, MAXIMUM_MENTIONED_SESSIONS);
+  assert.deepEqual(
+    spoken.map((mention) => mention.providerSessionId),
+    roster.slice(0, MAXIMUM_MENTIONED_SESSIONS).map((chat) => chat.providerSessionId),
+  );
+});
+
+test("only the observed roster can be pointed at, whatever the words claim", () => {
+  assert.deepEqual(mentionedSessions("Open the secret admin console now.", []), []);
+});
+
+test("a repeated mention counts once, at its first hearing", () => {
+  const roster = [session(claude, "a", "Alpha task"), session(claude, "b", "Bravo task")];
+  assert.deepEqual(
+    mentionedSessions("Bravo task depends on Alpha task, so Bravo task waits.", roster),
+    [
+      { kind: SESSION_MENTION_KIND.SESSION, providerId: "claude-code", providerSessionId: "b" },
+      { kind: SESSION_MENTION_KIND.SESSION, providerId: "claude-code", providerSessionId: "a" },
+    ],
+  );
+});

--- a/scripts/evidence.sh
+++ b/scripts/evidence.sh
@@ -83,15 +83,16 @@ validate_evidence() {
 }
 
 # The window is a stage, not the shape: a compact window holds the peek the
-# capsule grows into, and both carry room for a spring to overshoot.
+# capsule grows into, every chip row the notice band can wrap into, and room
+# for a spring to overshoot — 38 + 70 + 26 × 3 + 40 tall on the pinned housing.
 validate_evidence "$SIDECAR_EXPANDED_EVIDENCE_PATH" 700 560
-validate_evidence "$SIDECAR_COMPACT_EVIDENCE_PATH" 538 174
-validate_evidence "$SIDECAR_PEEK_EVIDENCE_PATH" 538 174
+validate_evidence "$SIDECAR_COMPACT_EVIDENCE_PATH" 538 226
+validate_evidence "$SIDECAR_PEEK_EVIDENCE_PATH" 538 226
 # The slot is drawn in the expanded window, which is why stepping aside for a
 # browser costs no resize at all.
 validate_evidence "$SIDECAR_SLOT_EVIDENCE_PATH" 700 560
-validate_evidence "$SIDECAR_SPEAKING_EVIDENCE_PATH" 538 174
-validate_evidence "$SIDECAR_MUTED_EVIDENCE_PATH" 538 174
+validate_evidence "$SIDECAR_SPEAKING_EVIDENCE_PATH" 538 226
+validate_evidence "$SIDECAR_MUTED_EVIDENCE_PATH" 538 226
 
 printf 'Expanded visual evidence: %s\n' "$SIDECAR_EXPANDED_EVIDENCE_PATH"
 printf 'Compact visual evidence: %s\n' "$SIDECAR_COMPACT_EVIDENCE_PATH"


### PR DESCRIPTION
## What

A reply that names observed sessions by title — or a Conductor workspace by name — now draws a pressable chip for each under the housing, where an announcement's one notice already stood. Asking "what are we working on?" answers with a chip per thing named; each press is a row press at one remove, exactly as before.

## How

- **`session-mentions.ts` (new, sidecar-core):** deterministic matching of the words being spoken against the observed roster. A name must appear whole (case aside, bounded by non-word characters) and be at least four characters; every ambiguity — a title two sessions share, a name two workspaces share, a name that is both a title and a workspace's — earns nothing at all. A workspace mention resolves to its most recently observed chat, and is absorbed entirely when the reply also names one of that workspace's own chats: the specific beats the general. Ordered by first hearing, capped at twelve. The identities only ever come from the roster; the model's words select among what Luke was shown but can never point a chip at anything else.
- **Hook:** `announcedSession` became `mentionedSessions` — an announcement's one roster-validated subject stays the whole answer; a conversation reply derives its previews from the stacked captions. Independent of the captions preference, like the notice always was.
- **Surface:** the single notice became a band of content-sized chips that wrap naturally, centred, up to the three rows the compact window now reserves (`SESSION_NOTICE_MAX_ROWS`, new shared token) and scrolling past them, with fold fades saying more chips stand beyond an edge. The band's height is measured off the wrapped chips (the caption block's own pattern) and drives the shape's growth; new chips join with a mount fade on the shared tokens. The band rides `--notice-rest` to the open panel's foot as #238 introduced, with the rest and the panel's reserved padding sized by the measured growth.
- **Fixture:** the speaking caption now names four fixture sessions and the lisbon-v2 workspace, so the evidence photographs both chip kinds and the band at full height.
- The guide's Announcements fact teaches the chips, so Luke can describe them.

## Testing

- `./scripts/check.sh` passes: sidecar-core 234, desktop 1036, web 40, hosted 40 — including new matcher tests (ordering, whole-name boundaries, ambiguity, workspace resolution and absorption, cap) and hook tests (announcement subject wins; stacked captions feed the chips; fixture words earn the photographed chips).
- Developed in a Linux sandbox, so `./scripts/verify.sh` and a physical-notch check were **not** run here; CI's macOS evidence is the visual record. Worth an eye when it lands: natural wrap at mixed chip widths, the fold fades past three rows, and the multi-row band riding to the open panel's foot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/7ea64775-b5df-4ac7-91e9-2786b6c48f5e)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32188995463/artifacts/9343538400) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32188995463)

- Commit: `f57678208ff5ca4d3f1e2765db405c63a6281f7f`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
