### PR TITLE
fix(desktop): keep the fold fades off a notice band that cannot scroll

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1702,8 +1702,14 @@ export function App(): React.JSX.Element {
   const measureNoticeFold = useCallback(() => {
     const band = noticeBand.current;
     if (!band) return;
-    const above = band.scrollTop > 1;
-    const below = band.scrollTop + band.clientHeight < band.scrollHeight - 1;
+    // Folds only on a band that genuinely scrolls. Subpixel rounding can
+    // leave scrollHeight a pixel or two past clientHeight on a band whose
+    // chips all fit, and a fold drawn for that fades a chip nobody can
+    // scroll to. Real overflow is at least a row of chips; half of one
+    // tells the two apart at any display scale.
+    const scrollable = band.scrollHeight - band.clientHeight > SESSION_NOTICE_HEIGHT / 2;
+    const above = scrollable && band.scrollTop > 1;
+    const below = scrollable && band.scrollTop + band.clientHeight < band.scrollHeight - 1;
     setNoticeFold((held) =>
       held.above === above && held.below === below ? held : { above, below },
     );


### PR DESCRIPTION
## What

Follow-up to #250. The notice band's fold gradient was appearing over a band holding a single chip — a fade suggesting more chips below when there was nothing to scroll to.

## Why

The fold measure compared `scrollTop + clientHeight < scrollHeight − 1`, and subpixel rounding between `clientHeight` and `scrollHeight` can disagree by more than a pixel even when every chip fits. A fold is now drawn only when the band genuinely overflows — by more than half a chip row (13px) — which rounding can never fake and a real fourth row (26px) always clears, at any display scale.

## Testing

- `./scripts/check.sh` passes (sidecar-core 236, desktop 1034, web 40, hosted 40).
- Same caveat as #250: authored in a Linux sandbox, so the macOS visual pass is CI's evidence run; the state to eyeball is a lone announcement chip wearing no gradient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/7ea64775-b5df-4ac7-91e9-2786b6c48f5e)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32189859235/artifacts/9343838077) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32189859235)

- Commit: `4f342b35a85d9ef7159d8be21f07d462839d77ec`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
