### PR TITLE
refactor(desktop): declare settings in one schema

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1352,6 +1352,11 @@ function registerIpc(): void {
   registerSettingHandler(channels.updateSetting, {
     async validate(field: unknown, value: unknown) {
       if (!isAppSettingField(field)) throw new Error("Unknown setting");
+      // A map-valued setting is written one entry at a time. Its own guard drops
+      // entries it cannot hold rather than refusing them — right for reading a
+      // stored file, wrong for a write, where a whole map of unholdable entries
+      // would read as valid and silently clear what is stored.
+      if (isKeyedAppSettingField(field)) throw new Error("Setting takes one entry at a time");
       const parsed = APP_SETTING_SCHEMA[field].guard(value);
       if (!parsed.valid) throw new Error("Invalid setting value");
       if (field === APP_SETTING_SCHEMA.askHotkey.field && typeof parsed.value === "string") {
@@ -1369,13 +1374,6 @@ function registerIpc(): void {
             settings: await settingsStore.snapshot(),
             reason: `That chord is reserved for the ${owner === HOTKEY_RANK.TALK ? "talk" : "ask"} key.`,
           });
-        }
-      }
-      if (field === APP_SETTING_SCHEMA.workspaceProjectDefaults.field && parsed.value) {
-        for (const [providerId, providerProjectId] of Object.entries(parsed.value)) {
-          if (!workspaceProjectOffered(providerId, providerProjectId)) {
-            throw new Error("Unknown workspace project");
-          }
         }
       }
       return { field, value: parsed.value };

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -140,6 +140,7 @@ import {
   type AccountSnapshot,
   APP_SETTING_DEFAULTS,
   type AppBootstrap,
+  type AppSettings,
   channels,
   isSettingsResetScope,
   type MicrophoneRoute,
@@ -148,7 +149,6 @@ import {
   type OutputAudioState,
   SESSION_OPEN_RESULT_STATUS,
   SESSION_TRANSCRIPT_RESULT_STATUS,
-  SETTINGS_RESET_SCOPE,
   type SessionOpenResult,
   type SessionTranscriptResult,
   VOICE_SOURCE,
@@ -167,7 +167,10 @@ import {
   isFeedbackKind,
 } from "./shared/feedback";
 import {
+  APP_SETTING_FIELDS,
   APP_SETTING_SCHEMA,
+  type AppSettingField,
+  type AppSettingValue,
   isAppSettingField,
   SETTING_SIDE_EFFECT,
 } from "./shared/settings-schema";
@@ -1278,6 +1281,60 @@ function registerIpc(): void {
     refusal: "Could not save that API key on this system.",
   });
 
+  async function applySettingSideEffect(
+    field: AppSettingField,
+    value: AppSettingValue<AppSettingField>,
+    settings: AppSettings,
+    event: IpcMainInvokeEvent,
+    waitForDeferredEffects = false,
+  ): Promise<void> {
+    switch (APP_SETTING_SCHEMA[field].mainProcessSideEffect) {
+      case SETTING_SIDE_EFFECT.DOCK:
+        dock.apply(settings.showInDock, panels.displayIdFor(event.sender));
+        break;
+      case SETTING_SIDE_EFFECT.DISPLAYS:
+        panels.setShowOnAllDisplays(settings.showOnAllDisplays);
+        panels.reconcile();
+        break;
+      case SETTING_SIDE_EFFECT.FORM_FACTOR:
+        panels.setFormFactor(settings.formFactor);
+        panels.positionAll();
+        break;
+      case SETTING_SIDE_EFFECT.VOICE:
+        realtimeCredentials?.setVoice(settings.voice);
+        break;
+      case SETTING_SIDE_EFFECT.VOICE_SPEED:
+        realtimeCredentials?.setSpeed(settings.voiceSpeed);
+        break;
+      case SETTING_SIDE_EFFECT.TALK_HOTKEY:
+        hotkeys.setChosen(HOTKEY_RANK.TALK, value as string | undefined);
+        await hotkeys.reapply(HOTKEY_RANK.TALK);
+        break;
+      case SETTING_SIDE_EFFECT.ASK_HOTKEY:
+        hotkeys.setChosen(HOTKEY_RANK.ASK, value as string | undefined);
+        if (waitForDeferredEffects) await hotkeys.reapply(HOTKEY_RANK.ASK);
+        else void hotkeys.reapply(HOTKEY_RANK.ASK);
+        break;
+      case SETTING_SIDE_EFFECT.STOP_HOTKEY:
+        hotkeys.setChosen(HOTKEY_RANK.STOP, value as string | undefined);
+        if (waitForDeferredEffects) await hotkeys.reapply(HOTKEY_RANK.STOP);
+        else void hotkeys.reapply(HOTKEY_RANK.STOP);
+        break;
+      case SETTING_SIDE_EFFECT.MEDIA_DUCK:
+        mediaDuck.setEnabled(settings.duckOtherMedia);
+        break;
+      case SETTING_SIDE_EFFECT.VOICE_SOURCE:
+        void applyVoiceCredential();
+        break;
+      case SETTING_SIDE_EFFECT.MEETING_QUIET:
+        void refreshMeetingQuiet();
+        void releaseHeldNotices();
+        break;
+      case SETTING_SIDE_EFFECT.NONE:
+        break;
+    }
+  }
+
   registerSettingHandler(channels.updateSetting, {
     async validate(field: unknown, value: unknown) {
       if (!isAppSettingField(field)) throw new Error("Unknown setting");
@@ -1317,49 +1374,7 @@ function registerIpc(): void {
     save: ({ field, value }) => settingsStore.set(field, value),
     async apply(result, { field, value }, event) {
       if (result.reason) return;
-      switch (APP_SETTING_SCHEMA[field].mainProcessSideEffect) {
-        case SETTING_SIDE_EFFECT.DOCK:
-          dock.apply(result.settings.showInDock, panels.displayIdFor(event.sender));
-          break;
-        case SETTING_SIDE_EFFECT.DISPLAYS:
-          panels.setShowOnAllDisplays(result.settings.showOnAllDisplays);
-          panels.reconcile();
-          break;
-        case SETTING_SIDE_EFFECT.FORM_FACTOR:
-          panels.setFormFactor(result.settings.formFactor);
-          panels.positionAll();
-          break;
-        case SETTING_SIDE_EFFECT.VOICE:
-          realtimeCredentials?.setVoice(result.settings.voice);
-          break;
-        case SETTING_SIDE_EFFECT.VOICE_SPEED:
-          realtimeCredentials?.setSpeed(result.settings.voiceSpeed);
-          break;
-        case SETTING_SIDE_EFFECT.TALK_HOTKEY:
-          hotkeys.setChosen(HOTKEY_RANK.TALK, value as string | undefined);
-          await hotkeys.reapply(HOTKEY_RANK.TALK);
-          break;
-        case SETTING_SIDE_EFFECT.ASK_HOTKEY:
-          hotkeys.setChosen(HOTKEY_RANK.ASK, value as string | undefined);
-          void hotkeys.reapply(HOTKEY_RANK.ASK);
-          break;
-        case SETTING_SIDE_EFFECT.STOP_HOTKEY:
-          hotkeys.setChosen(HOTKEY_RANK.STOP, value as string | undefined);
-          void hotkeys.reapply(HOTKEY_RANK.STOP);
-          break;
-        case SETTING_SIDE_EFFECT.MEDIA_DUCK:
-          mediaDuck.setEnabled(result.settings.duckOtherMedia);
-          break;
-        case SETTING_SIDE_EFFECT.VOICE_SOURCE:
-          void applyVoiceCredential();
-          break;
-        case SETTING_SIDE_EFFECT.MEETING_QUIET:
-          void refreshMeetingQuiet();
-          void releaseHeldNotices();
-          break;
-        case SETTING_SIDE_EFFECT.NONE:
-          break;
-      }
+      await applySettingSideEffect(field, value, result.settings, event);
     },
     refusal: "Could not save that setting on this system.",
   });
@@ -1379,37 +1394,10 @@ function registerIpc(): void {
     save: (scope) => settingsStore.resetSettings(scope),
     async apply(result, scope, event) {
       if (result.reason) return;
-      switch (scope) {
-        case SETTINGS_RESET_SCOPE.VOICE:
-          // The next credential is minted for the default voice and pace; the
-          // renderer carries the change onto a conversation already open the
-          // same way it does for the rows' own saves.
-          realtimeCredentials?.setVoice(result.settings.voice);
-          realtimeCredentials?.setSpeed(result.settings.voiceSpeed);
-          mediaDuck.setEnabled(result.settings.duckOtherMedia);
-          break;
-        case SETTINGS_RESET_SCOPE.APPEARANCE:
-          dock.apply(result.settings.showInDock, panels.displayIdFor(event.sender));
-          panels.setShowOnAllDisplays(result.settings.showOnAllDisplays);
-          panels.reconcile();
-          panels.setFormFactor(result.settings.formFactor);
-          panels.positionAll();
-          break;
-        case SETTINGS_RESET_SCOPE.SHORTCUTS:
-          // All three keys back to their defaults, re-registered in rank
-          // order and awaited, so the renderer's controls stay at rest until
-          // the keys the rows are about to show have actually answered.
-          hotkeys.setChosen(HOTKEY_RANK.TALK, undefined);
-          hotkeys.setChosen(HOTKEY_RANK.ASK, undefined);
-          hotkeys.setChosen(HOTKEY_RANK.STOP, undefined);
-          await hotkeys.reapply(HOTKEY_RANK.TALK);
-          await hotkeys.reapply(HOTKEY_RANK.ASK);
-          await hotkeys.reapply(HOTKEY_RANK.STOP);
-          break;
-        case SETTINGS_RESET_SCOPE.WORKSPACES:
-          // Nothing to re-run: the workspace defaults only steer the next
-          // creation ask, which reads the store when it happens.
-          break;
+      for (const field of APP_SETTING_FIELDS) {
+        const definition = APP_SETTING_SCHEMA[field];
+        if (!("resetScope" in definition) || definition.resetScope !== scope) continue;
+        await applySettingSideEffect(field, result.settings[field], result.settings, event, true);
       }
     },
     refusal: "Could not reset those settings on this system.",

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -20,10 +20,7 @@ import {
   type IssueIdentity,
   isControllableAdapter,
   isMessageCapableAdapter,
-  isPanelFormFactor,
   isProviderId,
-  isRealtimeVoice,
-  isRealtimeVoiceSpeed,
   issueCommentText,
   isWorkspaceAgentCapableAdapter,
   isWorkspaceCapableAdapter,
@@ -145,7 +142,6 @@ import {
   type AppBootstrap,
   channels,
   isSettingsResetScope,
-  isVoiceSource,
   type MicrophoneRoute,
   type MicrophoneStatus,
   type ObservedAccountCalendars,
@@ -170,7 +166,11 @@ import {
   feedbackSubmission,
   isFeedbackKind,
 } from "./shared/feedback";
-import { parseVoiceHotkey } from "./shared/voice-hotkey";
+import {
+  APP_SETTING_SCHEMA,
+  isAppSettingField,
+  SETTING_SIDE_EFFECT,
+} from "./shared/settings-schema";
 import { isWorkspaceAgentSelection } from "./shared/workspace-agents";
 import { UPDATE_ENDPOINT, UpdateService } from "./update-service";
 
@@ -1000,8 +1000,8 @@ async function applyVoiceCredential(): Promise<void> {
   // cannot be read means no choice was kept, and the environment or the defaults
   // answer inside the factory.
   const [voice, speed] = await Promise.all([
-    settingsStore.readVoice().catch(() => undefined),
-    settingsStore.readVoiceSpeed().catch(() => undefined),
+    settingsStore.get(APP_SETTING_SCHEMA.voice.field).catch(() => undefined),
+    settingsStore.get(APP_SETTING_SCHEMA.voiceSpeed.field).catch(() => undefined),
   ]);
   realtimeCredentials = apiKey
     ? openAiRealtimeCredentials(apiKey, {
@@ -1023,21 +1023,6 @@ async function applyVoiceCredential(): Promise<void> {
   // Warm only when the next press would actually mint through the service.
   if (hosted) warmHostedVoice();
   reportVoiceAvailability(apiKey !== undefined);
-}
-
-/**
- * The renderer records chords through the same reader, so one that does
- * not parse is a malformed request rather than a choice to answer.
- */
-function parsedVoiceHotkey(accelerator: unknown): string | undefined {
-  if (accelerator !== undefined && typeof accelerator !== "string") {
-    throw new Error("Invalid shortcut request");
-  }
-  const chosen = accelerator === undefined ? undefined : parseVoiceHotkey(accelerator);
-  if (accelerator !== undefined && chosen === undefined) {
-    throw new Error("Invalid shortcut request");
-  }
-  return chosen;
 }
 
 function adapterFor(providerId: string) {
@@ -1072,8 +1057,13 @@ async function rememberWorkspaceDefaults(
   if (!isProviderId(adapter.provider.id)) return;
   const providerId = adapter.provider.id;
   try {
-    if ((await settingsStore.readDefaultWorkspaceProvider()) === undefined) {
-      const saved = await settingsStore.setDefaultWorkspaceProvider(providerId);
+    if (
+      (await settingsStore.get(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field)) === undefined
+    ) {
+      const saved = await settingsStore.set(
+        APP_SETTING_SCHEMA.defaultWorkspaceProvider.field,
+        providerId,
+      );
       panels.broadcast(channels.settingsChanged, saved.settings);
     }
     // The project the workspace landed in becomes that provider's default on
@@ -1081,8 +1071,14 @@ async function rememberWorkspaceDefaults(
     // the model below. The id was validated against the adapter's offered
     // projects before the creation ran, so what is remembered is one the
     // provider itself listed.
-    if ((await settingsStore.readWorkspaceProjectDefault(providerId)) === undefined) {
-      const saved = await settingsStore.setWorkspaceProjectDefault(providerId, providerProjectId);
+    const workspaceProjectDefaults = await settingsStore.get(
+      APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
+    );
+    if (workspaceProjectDefaults?.[providerId] === undefined) {
+      const saved = await settingsStore.set(APP_SETTING_SCHEMA.workspaceProjectDefaults.field, {
+        ...workspaceProjectDefaults,
+        [providerId]: providerProjectId,
+      });
       panels.broadcast(channels.settingsChanged, saved.settings);
     }
     // A model named for this creation becomes the default on the same
@@ -1094,9 +1090,13 @@ async function rememberWorkspaceDefaults(
     // held, and must not lose to the request it overlapped.
     if (
       namedSelection !== undefined &&
-      (await settingsStore.readWorkspaceAgentDefault(providerId)) === undefined
+      (await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field))?.[providerId] ===
+        undefined
     ) {
-      const saved = await settingsStore.setWorkspaceAgentDefault(providerId, namedSelection);
+      const saved = await settingsStore.set(APP_SETTING_SCHEMA.workspaceAgentDefaults.field, {
+        ...(await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field)),
+        [providerId]: namedSelection,
+      });
       panels.broadcast(channels.settingsChanged, saved.settings);
     }
   } catch {
@@ -1278,278 +1278,89 @@ function registerIpc(): void {
     refusal: "Could not save that API key on this system.",
   });
 
-  // The Dock icon follows the stored answer at once: a
-  // setting that only took effect on the next launch would read as a toggle
-  // that does nothing.
-  registerSettingHandler(channels.setShowInDock, {
-    validate(show: unknown) {
-      if (typeof show !== "boolean") throw new Error("Invalid Dock request");
-      return show;
-    },
-    save: (show) => settingsStore.setShowInDock(show),
-    apply: (result, _show, event) =>
-      dock.apply(result.settings.showInDock, panels.displayIdFor(event.sender)),
-    refusal: "Could not save that setting on this system.",
-  });
-
-  // The windows follow the stored answer at once: on
-  // raises a panel on every connected display, off brings Luke back to the
-  // main one alone.
-  registerSettingHandler(channels.setShowOnAllDisplays, {
-    validate(show: unknown) {
-      if (typeof show !== "boolean") throw new Error("Invalid display request");
-      return show;
-    },
-    save: (show) => settingsStore.setShowOnAllDisplays(show),
-    apply(result) {
-      panels.setShowOnAllDisplays(result.settings.showOnAllDisplays);
-      panels.reconcile();
-    },
-    refusal: "Could not save that setting on this system.",
-  });
-
-  // The form follows the stored answer at once, for the same reason: every
-  // window resizes around the housing the shape is about to draw or drop.
-  registerSettingHandler(channels.setFormFactor, {
-    validate(formFactor: unknown) {
-      if (!isPanelFormFactor(formFactor)) throw new Error("Invalid form factor request");
-      return formFactor;
-    },
-    save: (formFactor) => settingsStore.setFormFactor(formFactor),
-    apply(result) {
-      panels.setFormFactor(result.settings.formFactor);
-      panels.positionAll();
-    },
-    refusal: "Could not save that setting on this system.",
-  });
-
-  // The default workspace provider is a preference about where a nameless
-  // creation ask goes, never a wider write path: it steers which project list
-  // the conversation is told to prefer, and every creation is still validated
-  // against what the adapters actually offer.
-  registerSettingHandler(channels.setDefaultWorkspaceProvider, {
-    validate(providerId: unknown) {
-      if (
-        providerId !== undefined &&
-        (typeof providerId !== "string" || !isProviderId(providerId))
-      ) {
-        throw new Error("Unknown workspace provider");
+  registerSettingHandler(channels.updateSetting, {
+    async validate(field: unknown, value: unknown) {
+      if (!isAppSettingField(field)) throw new Error("Unknown setting");
+      const parsed = APP_SETTING_SCHEMA[field].guard(value);
+      if (!parsed.valid) throw new Error("Invalid setting value");
+      if (field === APP_SETTING_SCHEMA.askHotkey.field && typeof parsed.value === "string") {
+        if (hotkeys.reserve(parsed.value, HOTKEY_RANK.ASK) === HOTKEY_RANK.TALK) {
+          return new SettingsRefusal({
+            settings: await settingsStore.snapshot(),
+            reason: "That chord is reserved for the talk key.",
+          });
+        }
       }
-      return typeof providerId === "string" ? providerId : undefined;
-    },
-    save: (providerId) => settingsStore.setDefaultWorkspaceProvider(providerId),
-    refusal: "Could not save that setting on this system.",
-  });
-
-  // The agent and model new workspaces start with, per provider. The pairing
-  // travels the form factor's road — a value from a set fixed by this build —
-  // it is just a documented table per provider rather than one enum: anything
-  // outside the table is refused here, so the store never holds a value no
-  // endpoint takes.
-  registerSettingHandler(channels.setWorkspaceAgentDefault, {
-    validate(providerId: unknown, selection: unknown) {
-      if (typeof providerId !== "string" || !isProviderId(providerId)) {
-        throw new Error("Unknown workspace provider");
+      if (field === APP_SETTING_SCHEMA.stopHotkey.field && typeof parsed.value === "string") {
+        const owner = hotkeys.reserve(parsed.value, HOTKEY_RANK.STOP);
+        if (owner === HOTKEY_RANK.TALK || owner === HOTKEY_RANK.ASK) {
+          return new SettingsRefusal({
+            settings: await settingsStore.snapshot(),
+            reason: `That chord is reserved for the ${owner === HOTKEY_RANK.TALK ? "talk" : "ask"} key.`,
+          });
+        }
       }
-      if (selection !== undefined && !isWorkspaceAgentSelection(providerId, selection)) {
-        throw new Error("Unknown workspace agent");
+      if (field === APP_SETTING_SCHEMA.workspaceProjectDefaults.field && parsed.value) {
+        for (const [providerId, providerProjectId] of Object.entries(parsed.value)) {
+          const adapter = adapterFor(providerId);
+          const offered =
+            adapter && isWorkspaceCapableAdapter(adapter)
+              ? adapter
+                  .workspaceProjects()
+                  .some((project) => project.providerProjectId === providerProjectId)
+              : false;
+          if (!offered) throw new Error("Unknown workspace project");
+        }
       }
-      return { providerId, selection };
+      return { field, value: parsed.value };
     },
-    save: ({ providerId, selection }) =>
-      settingsStore.setWorkspaceAgentDefault(providerId, selection),
-    refusal: "Could not save that setting on this system.",
-  });
-
-  // The project one provider creates nameless-ask workspaces in. Projects are
-  // observed rather than build-fixed, so the value is held to the list the
-  // provider's adapter currently offers — the same list every creation act is
-  // validated against — and clearing needs no list at all.
-  registerSettingHandler(channels.setWorkspaceProjectDefault, {
-    validate(providerId: unknown, providerProjectId: unknown) {
-      if (typeof providerId !== "string" || !isProviderId(providerId)) {
-        throw new Error("Unknown workspace provider");
-      }
-      if (providerProjectId === undefined) {
-        return { providerId, providerProjectId: undefined };
-      }
-      if (typeof providerProjectId !== "string" || !providerProjectId.trim()) {
-        throw new Error("Invalid workspace project");
-      }
-      const adapter = adapterFor(providerId);
-      const offered =
-        adapter && isWorkspaceCapableAdapter(adapter)
-          ? adapter
-              .workspaceProjects()
-              .some((project) => project.providerProjectId === providerProjectId)
-          : false;
-      if (!offered) throw new Error("Unknown workspace project");
-      return { providerId, providerProjectId };
-    },
-    save: ({ providerId, providerProjectId }) =>
-      settingsStore.setWorkspaceProjectDefault(providerId, providerProjectId),
-    refusal: "Could not save that setting on this system.",
-  });
-
-  // The voice is a preference rather than a credential, but it travels the
-  // same road: the renderer names a value from a set fixed by this build and
-  // hears back the settings as they now stand.
-  registerSettingHandler(channels.setVoice, {
-    validate(voice: unknown) {
-      if (!isRealtimeVoice(voice)) throw new Error("Unknown voice");
-      return voice;
-    },
-    save: (voice) => settingsStore.setVoice(voice),
-    apply(result, voice) {
-      // The next credential is minted for the new voice; the renderer makes
-      // the change heard now by reopening any conversation already up.
-      if (!result.reason) realtimeCredentials?.setVoice(voice);
-    },
-    refusal: "Could not save that voice on this system.",
-  });
-  // The pace travels the voice's road: a value from the set fixed by this
-  // build, stored, and handed to the minter for the next conversation.
-  registerSettingHandler(channels.setVoiceSpeed, {
-    validate(speed: unknown) {
-      if (!isRealtimeVoiceSpeed(speed)) throw new Error("Unknown voice speed");
-      return speed;
-    },
-    save: (speed) => settingsStore.setVoiceSpeed(speed),
-    apply(result, speed) {
-      // The next credential is minted for the new pace; the renderer
-      // carries the change onto a conversation already open itself.
-      if (!result.reason) realtimeCredentials?.setSpeed(speed);
-    },
-    refusal: "Could not save that speed on this system.",
-  });
-  // A plain preference, validated to a boolean the way every renderer value
-  // is validated at this boundary. The reply reports what was actually
-  // stored, so the switch redraws from the settings rather than the press.
-  registerSettingHandler(channels.setVoiceCaptions, {
-    validate(enabled: unknown) {
-      if (typeof enabled !== "boolean") throw new Error("Invalid caption request");
-      return enabled;
-    },
-    save: (enabled) => settingsStore.setVoiceCaptions(enabled),
-    refusal: "Could not save that setting on this system.",
-  });
-
-  // The talk key is the user's to move — a chord another tool already holds,
-  // or a hand that does not reach ⌥Space. What arrives is read through the
-  // same gate the stored value passes, so only a chord the registrars can
-  // actually take is ever stored; omitting one returns the defaults, making
-  // reset the absence of a choice rather than a second stored value. The new
-  // chord is registered at once — a shortcut that only moved on the next
-  // launch would read as a control that does nothing.
-  registerSettingHandler(channels.setVoiceHotkey, {
-    validate: parsedVoiceHotkey,
-    save: (chosen) => settingsStore.setVoiceHotkey(chosen),
-    async apply(result, chosen) {
-      if (!result.reason) {
-        hotkeys.setChosen(HOTKEY_RANK.TALK, chosen);
-        // Awaited so the renderer's controls stay at rest until the swap has
-        // finished and the helper's own registration line can say the truth.
-        await hotkeys.reapply(HOTKEY_RANK.TALK);
+    save: ({ field, value }) => settingsStore.set(field, value),
+    async apply(result, { field, value }, event) {
+      if (result.reason) return;
+      switch (APP_SETTING_SCHEMA[field].mainProcessSideEffect) {
+        case SETTING_SIDE_EFFECT.DOCK:
+          dock.apply(result.settings.showInDock, panels.displayIdFor(event.sender));
+          break;
+        case SETTING_SIDE_EFFECT.DISPLAYS:
+          panels.setShowOnAllDisplays(result.settings.showOnAllDisplays);
+          panels.reconcile();
+          break;
+        case SETTING_SIDE_EFFECT.FORM_FACTOR:
+          panels.setFormFactor(result.settings.formFactor);
+          panels.positionAll();
+          break;
+        case SETTING_SIDE_EFFECT.VOICE:
+          realtimeCredentials?.setVoice(result.settings.voice);
+          break;
+        case SETTING_SIDE_EFFECT.VOICE_SPEED:
+          realtimeCredentials?.setSpeed(result.settings.voiceSpeed);
+          break;
+        case SETTING_SIDE_EFFECT.TALK_HOTKEY:
+          hotkeys.setChosen(HOTKEY_RANK.TALK, value as string | undefined);
+          await hotkeys.reapply(HOTKEY_RANK.TALK);
+          break;
+        case SETTING_SIDE_EFFECT.ASK_HOTKEY:
+          hotkeys.setChosen(HOTKEY_RANK.ASK, value as string | undefined);
+          void hotkeys.reapply(HOTKEY_RANK.ASK);
+          break;
+        case SETTING_SIDE_EFFECT.STOP_HOTKEY:
+          hotkeys.setChosen(HOTKEY_RANK.STOP, value as string | undefined);
+          void hotkeys.reapply(HOTKEY_RANK.STOP);
+          break;
+        case SETTING_SIDE_EFFECT.MEDIA_DUCK:
+          mediaDuck.setEnabled(result.settings.duckOtherMedia);
+          break;
+        case SETTING_SIDE_EFFECT.VOICE_SOURCE:
+          void applyVoiceCredential();
+          break;
+        case SETTING_SIDE_EFFECT.MEETING_QUIET:
+          void refreshMeetingQuiet();
+          void releaseHeldNotices();
+          break;
+        case SETTING_SIDE_EFFECT.NONE:
+          break;
       }
     },
-    refusal: "Could not save that shortcut on this system.",
-  });
-
-  // The ask key is the user's to move on the talk key's exact terms, read
-  // through the same gate and registered at once. The one extra rule is the
-  // standing one — the two Luke keys must never compete for a chord — so a
-  // chord the talk key sits on is refused with words rather than stored and
-  // silently outbid.
-  registerSettingHandler<string | undefined>(channels.setAskHotkey, {
-    async validate(accelerator: unknown) {
-      const chosen = parsedVoiceHotkey(accelerator);
-      // The talk key's whole candidate list is refused, not just the chord it
-      // holds now: its helper may fall back to any of them on a later launch,
-      // and an ask key stored on one would race it there.
-      if (chosen && hotkeys.reserve(chosen, HOTKEY_RANK.ASK) === HOTKEY_RANK.TALK) {
-        return new SettingsRefusal({
-          settings: await settingsStore.snapshot(),
-          reason: "That chord is reserved for the talk key.",
-        });
-      }
-      return chosen;
-    },
-    save: (chosen) => settingsStore.setAskHotkey(chosen),
-    apply(result, chosen) {
-      if (!result.reason) {
-        hotkeys.setChosen(HOTKEY_RANK.ASK, chosen);
-        void hotkeys.reapply(HOTKEY_RANK.ASK);
-      }
-    },
-    refusal: "Could not save that shortcut on this system.",
-  });
-
-  // The stop key is the user's to move on the other two keys' exact terms,
-  // read through the same gate and registered at once. It sits at the bottom
-  // of the pecking order, so both standing rules point up: a chord the talk
-  // key or the ask key sits on — or could fall back to — is refused with
-  // words rather than stored and silently outbid.
-  registerSettingHandler<string | undefined>(channels.setStopHotkey, {
-    async validate(accelerator: unknown) {
-      const chosen = parsedVoiceHotkey(accelerator);
-      const owner = chosen ? hotkeys.reserve(chosen, HOTKEY_RANK.STOP) : undefined;
-      if (owner === HOTKEY_RANK.TALK) {
-        return new SettingsRefusal({
-          settings: await settingsStore.snapshot(),
-          reason: "That chord is reserved for the talk key.",
-        });
-      }
-      if (owner === HOTKEY_RANK.ASK) {
-        return new SettingsRefusal({
-          settings: await settingsStore.snapshot(),
-          reason: "That chord is reserved for the ask key.",
-        });
-      }
-      return chosen;
-    },
-    save: (chosen) => settingsStore.setStopHotkey(chosen),
-    apply(result, chosen) {
-      if (!result.reason) {
-        hotkeys.setChosen(HOTKEY_RANK.STOP, chosen);
-        void hotkeys.reapply(HOTKEY_RANK.STOP);
-      }
-    },
-    refusal: "Could not save that shortcut on this system.",
-  });
-
-  // The duck follows the stored answer at once: off
-  // must let a duck currently held go rather than waiting for the next launch.
-  registerSettingHandler(channels.setPreferBuiltInMicrophone, {
-    validate(enabled: unknown) {
-      if (typeof enabled !== "boolean") throw new Error("Invalid microphone preference request");
-      return enabled;
-    },
-    save: (enabled) => settingsStore.setPreferBuiltInMicrophone(enabled),
-    refusal: "Could not save that setting on this system.",
-  });
-
-  registerSettingHandler(channels.setDuckOtherMedia, {
-    validate(enabled: unknown) {
-      if (typeof enabled !== "boolean") throw new Error("Invalid media duck request");
-      return enabled;
-    },
-    save: (enabled) => settingsStore.setDuckOtherMedia(enabled),
-    apply: (result) => mediaDuck.setEnabled(result.settings.duckOtherMedia),
-    refusal: "Could not save that setting on this system.",
-  });
-
-  // Which credential Luke runs on, rebuilt at once rather than at the next
-  // launch: the whole point of the choice is that the next thing said runs on
-  // what was just chosen. The rebuild is the same one a key being saved or
-  // deleted triggers, so the minter, the reviewer, and the usage reader can
-  // never be left built for the source that was just switched away from.
-  registerSettingHandler(channels.setVoiceSource, {
-    validate(source: unknown) {
-      if (!isVoiceSource(source)) throw new Error("Invalid voice source request");
-      return source;
-    },
-    save: (source) => settingsStore.setVoiceSource(source),
-    apply: () => void applyVoiceCredential(),
     refusal: "Could not save that setting on this system.",
   });
 
@@ -1704,23 +1515,6 @@ function registerIpc(): void {
       if (!result.reason) void refreshCalendarMeetings();
     },
     refusal: "Could not save that calendar choice on this system.",
-  });
-
-  // Switching the quiet off mid-meeting is the meeting ending, as far as the
-  // backlog is concerned: the face wakes and anything held is said now, not
-  // on the next release tick — the user just asked to hear it.
-  registerSettingHandler(channels.setQuietDuringMeetings, {
-    validate(enabled: unknown) {
-      if (typeof enabled !== "boolean") throw new Error("Invalid meeting quiet request");
-      return enabled;
-    },
-    save: (enabled) => settingsStore.setQuietDuringMeetings(enabled),
-    apply(result) {
-      if (result.reason) return;
-      void refreshMeetingQuiet();
-      void releaseHeldNotices();
-    },
-    refusal: "Could not save that setting on this system.",
   });
 
   // The row's button. Answered rather than fire-and-forget so the row that
@@ -2109,7 +1903,7 @@ function registerIpc(): void {
       // the stored one when it was written — and the adapter holds whichever
       // rides to its own table again before anything reaches the network.
       const stored = isProviderId(providerId)
-        ? await settingsStore.readWorkspaceAgentDefault(providerId)
+        ? (await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field))?.[providerId]
         : undefined;
       const agentSelection = namedSelection ?? stored;
       const result = await adapter.createWorkspace({
@@ -2321,7 +2115,9 @@ function registerIpc(): void {
       // preference, so "add a codex agent" is never quietly re-modelled by a
       // choice made about claude.
       const stored: WorkspaceAgentSelection | undefined = isProviderId(identity.providerId)
-        ? await settingsStore.readWorkspaceAgentDefault(identity.providerId)
+        ? (await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field))?.[
+            identity.providerId
+          ]
         : undefined;
       const fallback = stored?.agent === advertised ? stored : undefined;
       const model = namedModel ?? fallback?.model;
@@ -2654,7 +2450,7 @@ function openCreatedWorkspaces(sessions: readonly NormalizedSession[]): void {
  */
 async function announcementsQuietNow(now: number): Promise<boolean> {
   if (!calendarMeetings || activeMeetingEnd(calendarMeetings, now) === undefined) return false;
-  return settingsStore.quietDuringMeetings();
+  return settingsStore.get(APP_SETTING_SCHEMA.quietDuringMeetings.field);
 }
 
 /**
@@ -3008,7 +2804,7 @@ if (!app.requestSingleInstanceLock()) {
     // The Dock icon reads the same file under the opposite default: it is
     // opt-in, so a file that cannot be read leaves Luke out of the Dock — the
     // accessory app the launch just asserted. Nothing to do until it says so.
-    void settingsStore.showInDock().then(
+    void settingsStore.get(APP_SETTING_SCHEMA.showInDock.field).then(
       (show) => {
         if (show) dock.apply(true);
       },
@@ -3017,7 +2813,7 @@ if (!app.requestSingleInstanceLock()) {
     // Armed from the settings file alone, like the status item, and for the
     // same reason. A file that cannot be read leaves the duck on, the same
     // answer a file that has never said gives.
-    void settingsStore.duckOtherMedia().then(
+    void settingsStore.get(APP_SETTING_SCHEMA.duckOtherMedia.field).then(
       (enabled) => mediaDuck.setEnabled(enabled),
       () => mediaDuck.setEnabled(APP_SETTING_DEFAULTS.duckOtherMedia),
     );
@@ -3045,11 +2841,12 @@ if (!app.requestSingleInstanceLock()) {
     // the default form — and must not keep the panels from starting.
     panels.setShowOnAllDisplays(
       await settingsStore
-        .readShowOnAllDisplays()
+        .get(APP_SETTING_SCHEMA.showOnAllDisplays.field)
         .catch(() => APP_SETTING_DEFAULTS.showOnAllDisplays),
     );
     panels.setFormFactor(
-      (await settingsStore.readFormFactor().catch(() => undefined)) ?? DEFAULT_PANEL_FORM_FACTOR,
+      (await settingsStore.get(APP_SETTING_SCHEMA.formFactor.field).catch(() => undefined)) ??
+        DEFAULT_PANEL_FORM_FACTOR,
     );
     // Awaited for the same reason the voice is: the chosen chord has to be in
     // hand before the key is registered, or the first registration would take
@@ -3057,12 +2854,15 @@ if (!app.requestSingleInstanceLock()) {
     // read means no choice was kept, and the defaults answer.
     hotkeys.setChosen(
       HOTKEY_RANK.TALK,
-      await settingsStore.readVoiceHotkey().catch(() => undefined),
+      await settingsStore.get(APP_SETTING_SCHEMA.voiceHotkey.field).catch(() => undefined),
     );
-    hotkeys.setChosen(HOTKEY_RANK.ASK, await settingsStore.readAskHotkey().catch(() => undefined));
+    hotkeys.setChosen(
+      HOTKEY_RANK.ASK,
+      await settingsStore.get(APP_SETTING_SCHEMA.askHotkey.field).catch(() => undefined),
+    );
     hotkeys.setChosen(
       HOTKEY_RANK.STOP,
-      await settingsStore.readStopHotkey().catch(() => undefined),
+      await settingsStore.get(APP_SETTING_SCHEMA.stopHotkey.field).catch(() => undefined),
     );
     // The report is not made here: the helper answers over its own stdout a
     // moment later, and a line printed now would state an absence that only

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -172,7 +172,10 @@ import {
   type AppSettingField,
   type AppSettingValue,
   isAppSettingField,
+  isKeyedAppSettingField,
+  isSettingEntryKey,
   SETTING_SIDE_EFFECT,
+  settingEntryGuard,
 } from "./shared/settings-schema";
 import { isWorkspaceAgentSelection } from "./shared/workspace-agents";
 import { UPDATE_ENDPOINT, UpdateService } from "./update-service";
@@ -1045,6 +1048,15 @@ function boundedField(
   return value === undefined ? { ok: false } : { ok: true, value };
 }
 
+/** Whether a provider is currently offering the project a default would name. */
+function workspaceProjectOffered(providerId: string, providerProjectId: string): boolean {
+  const adapter = adapterFor(providerId);
+  if (!adapter || !isWorkspaceCapableAdapter(adapter)) return false;
+  return adapter
+    .workspaceProjects()
+    .some((project) => project.providerProjectId === providerProjectId);
+}
+
 /**
  * The first workspace that lands chooses the default provider — and its
  * project, and a model named for that creation, the default agent — only
@@ -1074,14 +1086,15 @@ async function rememberWorkspaceDefaults(
     // the model below. The id was validated against the adapter's offered
     // projects before the creation ran, so what is remembered is one the
     // provider itself listed.
-    const workspaceProjectDefaults = await settingsStore.get(
-      APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
-    );
-    if (workspaceProjectDefaults?.[providerId] === undefined) {
-      const saved = await settingsStore.set(APP_SETTING_SCHEMA.workspaceProjectDefaults.field, {
-        ...workspaceProjectDefaults,
-        [providerId]: providerProjectId,
-      });
+    if (
+      (await settingsStore.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field))?.[providerId] ===
+      undefined
+    ) {
+      const saved = await settingsStore.setEntry(
+        APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
+        providerId,
+        providerProjectId,
+      );
       panels.broadcast(channels.settingsChanged, saved.settings);
     }
     // A model named for this creation becomes the default on the same
@@ -1096,10 +1109,11 @@ async function rememberWorkspaceDefaults(
       (await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field))?.[providerId] ===
         undefined
     ) {
-      const saved = await settingsStore.set(APP_SETTING_SCHEMA.workspaceAgentDefaults.field, {
-        ...(await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field)),
-        [providerId]: namedSelection,
-      });
+      const saved = await settingsStore.setEntry(
+        APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
+        providerId,
+        namedSelection,
+      );
       panels.broadcast(channels.settingsChanged, saved.settings);
     }
   } catch {
@@ -1359,14 +1373,9 @@ function registerIpc(): void {
       }
       if (field === APP_SETTING_SCHEMA.workspaceProjectDefaults.field && parsed.value) {
         for (const [providerId, providerProjectId] of Object.entries(parsed.value)) {
-          const adapter = adapterFor(providerId);
-          const offered =
-            adapter && isWorkspaceCapableAdapter(adapter)
-              ? adapter
-                  .workspaceProjects()
-                  .some((project) => project.providerProjectId === providerProjectId)
-              : false;
-          if (!offered) throw new Error("Unknown workspace project");
+          if (!workspaceProjectOffered(providerId, providerProjectId)) {
+            throw new Error("Unknown workspace project");
+          }
         }
       }
       return { field, value: parsed.value };
@@ -1375,6 +1384,32 @@ function registerIpc(): void {
     async apply(result, { field, value }, event) {
       if (result.reason) return;
       await applySettingSideEffect(field, value, result.settings, event);
+    },
+    refusal: "Could not save that setting on this system.",
+  });
+
+  // One key of a map-valued preference. The merge belongs to the store, so what
+  // arrives here is the single entry and the renderer never sends back a map it
+  // read before an overlapping write landed.
+  registerSettingHandler(channels.updateSettingEntry, {
+    async validate(field: unknown, key: unknown, value: unknown) {
+      if (!isKeyedAppSettingField(field)) throw new Error("Unknown setting");
+      if (!isSettingEntryKey(field, key)) throw new Error("Unknown setting entry");
+      const parsed = settingEntryGuard(field, key, value);
+      if (!parsed.valid) throw new Error("Invalid setting value");
+      if (
+        field === APP_SETTING_SCHEMA.workspaceProjectDefaults.field &&
+        typeof parsed.value === "string" &&
+        !workspaceProjectOffered(key, parsed.value)
+      ) {
+        throw new Error("Unknown workspace project");
+      }
+      return { field, key, value: parsed.value };
+    },
+    save: ({ field, key, value }) => settingsStore.setEntry(field, key, value),
+    async apply(result, { field }, event) {
+      if (result.reason) return;
+      await applySettingSideEffect(field, result.settings[field], result.settings, event);
     },
     refusal: "Could not save that setting on this system.",
   });

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -27,26 +27,11 @@ const bridge: AppBridge = {
   getMicrophoneRoute: invoke(channels.microphoneRoute),
   openMicrophoneSettings: () => ipcRenderer.send(channels.openMicrophoneSettings),
   setProviderApiKey: invoke(channels.setProviderApiKey),
-  setVoice: invoke(channels.setVoice),
-  setVoiceSpeed: invoke(channels.setVoiceSpeed),
+  updateSetting: invoke(channels.updateSetting),
   openProviderApiKeys: (providerId) => {
     ipcRenderer.send(channels.openProviderApiKeys, providerId);
   },
-  setShowInDock: invoke(channels.setShowInDock),
-  setShowOnAllDisplays: invoke(channels.setShowOnAllDisplays),
-  setFormFactor: invoke(channels.setFormFactor),
-  setDefaultWorkspaceProvider: invoke(channels.setDefaultWorkspaceProvider),
-  setWorkspaceAgentDefault: invoke(channels.setWorkspaceAgentDefault),
-  setWorkspaceProjectDefault: invoke(channels.setWorkspaceProjectDefault),
-  setVoiceCaptions: invoke(channels.setVoiceCaptions),
   resetSettings: invoke(channels.resetSettings),
-  setVoiceHotkey: invoke(channels.setVoiceHotkey),
-  setAskHotkey: invoke(channels.setAskHotkey),
-  setStopHotkey: invoke(channels.setStopHotkey),
-  setDuckOtherMedia: invoke(channels.setDuckOtherMedia),
-  setVoiceSource: invoke(channels.setVoiceSource),
-  setPreferBuiltInMicrophone: invoke(channels.setPreferBuiltInMicrophone),
-  setQuietDuringMeetings: invoke(channels.setQuietDuringMeetings),
   connectGoogleCalendar: invoke(channels.connectGoogleCalendar),
   cancelGoogleCalendarSignIn: () => {
     ipcRenderer.send(channels.cancelGoogleCalendarSignIn);

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -28,6 +28,7 @@ const bridge: AppBridge = {
   openMicrophoneSettings: () => ipcRenderer.send(channels.openMicrophoneSettings),
   setProviderApiKey: invoke(channels.setProviderApiKey),
   updateSetting: invoke(channels.updateSetting),
+  updateSettingEntry: invoke(channels.updateSettingEntry),
   openProviderApiKeys: (providerId) => {
     ipcRenderer.send(channels.openProviderApiKeys, providerId);
   },

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -999,18 +999,15 @@ export function App(): React.JSX.Element {
   );
 
   const changeWorkspaceAgentDefault = useCallback(
-    async (providerId: ProviderId, selection: WorkspaceAgentSelection | undefined) => {
-      const defaults = { ...settings?.workspaceAgentDefaults };
-      if (selection) defaults[providerId] = selection;
-      else delete defaults[providerId];
-      return applySettingsReply(
-        await window.sidecar.updateSetting(
+    async (providerId: ProviderId, selection: WorkspaceAgentSelection | undefined) =>
+      applySettingsReply(
+        await window.sidecar.updateSettingEntry(
           APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
-          Object.keys(defaults).length > 0 ? defaults : undefined,
+          providerId,
+          selection,
         ),
-      );
-    },
-    [applySettingsReply, settings?.workspaceAgentDefaults],
+      ),
+    [applySettingsReply],
   );
 
   // One group of settings back to its defaults — the same store forgetting
@@ -1026,18 +1023,15 @@ export function App(): React.JSX.Element {
   // write the first creation there makes on its own, offered by hand so the
   // choice can be changed or returned to the first creation.
   const changeWorkspaceProjectDefault = useCallback(
-    async (providerId: ProviderId, providerProjectId: string | undefined) => {
-      const defaults = { ...settings?.workspaceProjectDefaults };
-      if (providerProjectId) defaults[providerId] = providerProjectId;
-      else delete defaults[providerId];
-      return applySettingsReply(
-        await window.sidecar.updateSetting(
+    async (providerId: ProviderId, providerProjectId: string | undefined) =>
+      applySettingsReply(
+        await window.sidecar.updateSettingEntry(
           APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
-          Object.keys(defaults).length > 0 ? defaults : undefined,
+          providerId,
+          providerProjectId,
         ),
-      );
-    },
-    [applySettingsReply, settings?.workspaceProjectDefaults],
+      ),
+    [applySettingsReply],
   );
 
   /**

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1005,7 +1005,7 @@ export function App(): React.JSX.Element {
       else delete defaults[providerId];
       return applySettingsReply(
         await window.sidecar.updateSetting(
-          "workspaceAgentDefaults",
+          APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
           Object.keys(defaults).length > 0 ? defaults : undefined,
         ),
       );
@@ -1032,7 +1032,7 @@ export function App(): React.JSX.Element {
       else delete defaults[providerId];
       return applySettingsReply(
         await window.sidecar.updateSetting(
-          "workspaceProjectDefaults",
+          APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
           Object.keys(defaults).length > 0 ? defaults : undefined,
         ),
       );

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -56,6 +56,7 @@ import {
 } from "../shared/credential-providers";
 import type { FeedbackImage, FeedbackKind } from "../shared/feedback";
 import { FEEDBACK_KIND, FEEDBACK_LIMITS, feedbackKindForLifecycleEvent } from "../shared/feedback";
+import { APP_SETTING_SCHEMA } from "../shared/settings-schema";
 import { voiceHotkeyLabel, voiceHotkeyToShow } from "../shared/voice-hotkey";
 import { ASK_LUKE_INPUT_ID, focusAskField } from "./ask-luke";
 import { type CalendarConnectEntry, CalendarConnectSlot } from "./calendar-connect-slot";
@@ -712,29 +713,45 @@ export function App(): React.JSX.Element {
   );
 
   const changeVoiceCaptions = useCallback(
-    async (enabled: boolean) => applySettingsReply(await window.sidecar.setVoiceCaptions(enabled)),
+    async (enabled: boolean) =>
+      applySettingsReply(
+        await window.sidecar.updateSetting(APP_SETTING_SCHEMA.voiceCaptions.field, enabled),
+      ),
     [applySettingsReply],
   );
 
   const changeDuckOtherMedia = useCallback(
-    async (enabled: boolean) => applySettingsReply(await window.sidecar.setDuckOtherMedia(enabled)),
+    async (enabled: boolean) =>
+      applySettingsReply(
+        await window.sidecar.updateSetting(APP_SETTING_SCHEMA.duckOtherMedia.field, enabled),
+      ),
     [applySettingsReply],
   );
 
   const changeVoiceSource = useCallback(
-    async (source: VoiceSource) => applySettingsReply(await window.sidecar.setVoiceSource(source)),
+    async (source: VoiceSource) =>
+      applySettingsReply(
+        await window.sidecar.updateSetting(APP_SETTING_SCHEMA.voiceSource.field, source),
+      ),
     [applySettingsReply],
   );
 
   const changePreferBuiltInMicrophone = useCallback(
     async (enabled: boolean) =>
-      applySettingsReply(await window.sidecar.setPreferBuiltInMicrophone(enabled)),
+      applySettingsReply(
+        await window.sidecar.updateSetting(
+          APP_SETTING_SCHEMA.preferBuiltInMicrophone.field,
+          enabled,
+        ),
+      ),
     [applySettingsReply],
   );
 
   const changeQuietDuringMeetings = useCallback(
     async (enabled: boolean) =>
-      applySettingsReply(await window.sidecar.setQuietDuringMeetings(enabled)),
+      applySettingsReply(
+        await window.sidecar.updateSetting(APP_SETTING_SCHEMA.quietDuringMeetings.field, enabled),
+      ),
     [applySettingsReply],
   );
 
@@ -944,18 +961,26 @@ export function App(): React.JSX.Element {
   }, [expand, presentationOf, setSignInWait, signInWaitNow]);
 
   const changeShowInDock = useCallback(
-    async (show: boolean) => applySettingsReply(await window.sidecar.setShowInDock(show)),
+    async (show: boolean) =>
+      applySettingsReply(
+        await window.sidecar.updateSetting(APP_SETTING_SCHEMA.showInDock.field, show),
+      ),
     [applySettingsReply],
   );
 
   const changeShowOnAllDisplays = useCallback(
-    async (show: boolean) => applySettingsReply(await window.sidecar.setShowOnAllDisplays(show)),
+    async (show: boolean) =>
+      applySettingsReply(
+        await window.sidecar.updateSetting(APP_SETTING_SCHEMA.showOnAllDisplays.field, show),
+      ),
     [applySettingsReply],
   );
 
   const changeFormFactor = useCallback(
     async (formFactor: PanelFormFactor) =>
-      applySettingsReply(await window.sidecar.setFormFactor(formFactor)),
+      applySettingsReply(
+        await window.sidecar.updateSetting(APP_SETTING_SCHEMA.formFactor.field, formFactor),
+      ),
     [applySettingsReply],
   );
 
@@ -964,14 +989,28 @@ export function App(): React.JSX.Element {
   // or returned to asking each time.
   const changeDefaultWorkspaceProvider = useCallback(
     async (providerId: ProviderId | undefined) =>
-      applySettingsReply(await window.sidecar.setDefaultWorkspaceProvider(providerId)),
+      applySettingsReply(
+        await window.sidecar.updateSetting(
+          APP_SETTING_SCHEMA.defaultWorkspaceProvider.field,
+          providerId,
+        ),
+      ),
     [applySettingsReply],
   );
 
   const changeWorkspaceAgentDefault = useCallback(
-    async (providerId: ProviderId, selection: WorkspaceAgentSelection | undefined) =>
-      applySettingsReply(await window.sidecar.setWorkspaceAgentDefault(providerId, selection)),
-    [applySettingsReply],
+    async (providerId: ProviderId, selection: WorkspaceAgentSelection | undefined) => {
+      const defaults = { ...settings?.workspaceAgentDefaults };
+      if (selection) defaults[providerId] = selection;
+      else delete defaults[providerId];
+      return applySettingsReply(
+        await window.sidecar.updateSetting(
+          "workspaceAgentDefaults",
+          Object.keys(defaults).length > 0 ? defaults : undefined,
+        ),
+      );
+    },
+    [applySettingsReply, settings?.workspaceAgentDefaults],
   );
 
   // One group of settings back to its defaults — the same store forgetting
@@ -987,11 +1026,18 @@ export function App(): React.JSX.Element {
   // write the first creation there makes on its own, offered by hand so the
   // choice can be changed or returned to the first creation.
   const changeWorkspaceProjectDefault = useCallback(
-    async (providerId: ProviderId, providerProjectId: string | undefined) =>
-      applySettingsReply(
-        await window.sidecar.setWorkspaceProjectDefault(providerId, providerProjectId),
-      ),
-    [applySettingsReply],
+    async (providerId: ProviderId, providerProjectId: string | undefined) => {
+      const defaults = { ...settings?.workspaceProjectDefaults };
+      if (providerProjectId) defaults[providerId] = providerProjectId;
+      else delete defaults[providerId];
+      return applySettingsReply(
+        await window.sidecar.updateSetting(
+          "workspaceProjectDefaults",
+          Object.keys(defaults).length > 0 ? defaults : undefined,
+        ),
+      );
+    },
+    [applySettingsReply, settings?.workspaceProjectDefaults],
   );
 
   /**
@@ -1263,7 +1309,9 @@ export function App(): React.JSX.Element {
   // pressed, so what is shown as chosen is always what was actually saved.
   const changeVoice = useCallback(
     (voice: RealtimeVoice) => {
-      void window.sidecar.setVoice(voice).then(applySettingsReply);
+      void window.sidecar
+        .updateSetting(APP_SETTING_SCHEMA.voice.field, voice)
+        .then(applySettingsReply);
     },
     [applySettingsReply],
   );
@@ -1271,7 +1319,9 @@ export function App(): React.JSX.Element {
   // The pace, under the same rule as the voice above.
   const changeVoiceSpeed = useCallback(
     (speed: RealtimeVoiceSpeed) => {
-      void window.sidecar.setVoiceSpeed(speed).then(applySettingsReply);
+      void window.sidecar
+        .updateSetting(APP_SETTING_SCHEMA.voiceSpeed.field, speed)
+        .then(applySettingsReply);
     },
     [applySettingsReply],
   );
@@ -1284,7 +1334,9 @@ export function App(): React.JSX.Element {
    */
   const changeVoiceHotkey = useCallback(
     async (accelerator: string | undefined) =>
-      applySettingsReply(await window.sidecar.setVoiceHotkey(accelerator)),
+      applySettingsReply(
+        await window.sidecar.updateSetting(APP_SETTING_SCHEMA.voiceHotkey.field, accelerator),
+      ),
     [applySettingsReply],
   );
 
@@ -1292,14 +1344,18 @@ export function App(): React.JSX.Element {
   // process's own announcement of what actually registered.
   const changeAskHotkey = useCallback(
     async (accelerator: string | undefined) =>
-      applySettingsReply(await window.sidecar.setAskHotkey(accelerator)),
+      applySettingsReply(
+        await window.sidecar.updateSetting(APP_SETTING_SCHEMA.askHotkey.field, accelerator),
+      ),
     [applySettingsReply],
   );
 
   // The stop key, under the same rule again.
   const changeStopHotkey = useCallback(
     async (accelerator: string | undefined) =>
-      applySettingsReply(await window.sidecar.setStopHotkey(accelerator)),
+      applySettingsReply(
+        await window.sidecar.updateSetting(APP_SETTING_SCHEMA.stopHotkey.field, accelerator),
+      ),
     [applySettingsReply],
   );
 

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -9,30 +9,20 @@
  * spoken ask can touch, so adding either to the app means adding it here in
  * the same change.
  *
- * The settings half is compile-enforced: `SETTING_GUIDE` is a `Record` over
- * every key of `AppSettings`, so a new settings field does not build until a
- * decision is written down — a spoken entry, or `undefined` with a comment
- * saying how the guide covers it instead. The facts have no such lever, which
- * is why the agent guide states the rule in words.
+ * The settings half is built from the exhaustive schema in
+ * `shared/settings-schema.ts`, so a new stored setting does not build until its
+ * guide entry is declared there. The facts have no such lever, which is why
+ * the agent guide states the rule in words.
  *
  * Nothing here may carry a credential, a key's shape, or any part of one:
  * the guide says whether a provider is connected, and no more.
  */
 
 import {
-  APP_SETTING_KIND,
   type AppGuideFact,
   type AppGuideSetting,
   type AppGuideSnapshot,
-  appToggleText,
-  DEFAULT_PANEL_FORM_FACTOR,
-  PANEL_FORM_FACTOR_LIST,
   PROVIDER_ID,
-  type ProviderId,
-  REALTIME_DEFAULTS,
-  REALTIME_VOICE_LIST,
-  REALTIME_VOICE_SPEED,
-  type RealtimeVoiceSpeed,
   type WorkspaceAgentSelection,
 } from "@sidecar/core";
 import type {
@@ -42,30 +32,28 @@ import type {
   CredentialSource,
   MicrophoneStatus,
   SettingsUpdateResult,
-  VoiceSource,
 } from "../shared/contracts";
 import {
   ACCOUNT_PROVIDER,
   ACCOUNT_STATUS,
-  APP_SETTING_DEFAULTS,
   CREDENTIAL_SOURCE,
   SECRET_STORAGE,
-  VOICE_SOURCE,
 } from "../shared/contracts";
 import {
   CLOUD_AGENT_PROVIDER_LIST,
   CREDENTIAL_PROVIDERS,
   INTEGRATION_PROVIDER_LIST,
-  isCredentialProviderId,
   VOICE_CREDENTIAL_PROVIDER_ID,
 } from "../shared/credential-providers";
 import {
   APP_SETTING_ID,
+  APP_SETTING_SCHEMA,
   type AppSettingId,
   settingFieldForGuideId,
+  settingGuideEntries,
   spokenSettingValue,
 } from "../shared/settings-schema";
-import { workspaceAgentModelLabel, workspaceAgentModels } from "../shared/workspace-agents";
+import { workspaceAgentModels } from "../shared/workspace-agents";
 
 export type { AppSettingId } from "../shared/settings-schema";
 /** The ids a spoken change names Luke's settings by. */
@@ -74,21 +62,14 @@ export { APP_SETTING_ID, isAppSettingId } from "../shared/settings-schema";
 /** Where the switches live, said once so every entry words it the same way. */
 const SETTINGS_TAB = "the panel's Settings tab";
 
-/* The tab's front page opens pages, and each setting is changed by hand on
-   one of them — so every by-hand path names its page, worded once each. */
-const VOICE_PAGE = `${SETTINGS_TAB}, on its Voice page`;
 /** Where the allowance meters and the OpenAI key row both live. */
 const VOICE_SOURCE_SECTION = `${SETTINGS_TAB}, on its front page, in the What Luke runs on section at the top`;
 /** Where the signed-in identity and the two ways out of it live. */
 const ACCOUNT_SECTION = `the Account section, at the foot of ${SETTINGS_TAB}'s front page`;
-const APPEARANCE_PAGE = `${SETTINGS_TAB}, on its Appearance page`;
 const SHORTCUTS_PAGE = `${SETTINGS_TAB}, on its Keyboard shortcuts page`;
 const CONNECTIONS_PAGE = `${SETTINGS_TAB}, on its Connections page`;
 /* Where the Updates section stands, for the fact that describes it. */
 const FRONT_PAGE = `${SETTINGS_TAB}, on its front page`;
-
-/** Where the Conductor agent choices live, said once for both their entries. */
-const CONDUCTOR_ROW_PATH = `the Conductor row under Cloud Agent API keys, in ${CONNECTIONS_PAGE} — drawn once Conductor is connected`;
 
 /**
  * The word both Conductor agent entries use for no choice at all. It is a
@@ -98,335 +79,6 @@ const CONDUCTOR_ROW_PATH = `the Conductor row under Cloud Agent API keys, in ${C
 const CONDUCTOR_DEFAULT_CHOICE = "Conductor's default";
 
 /**
- * The provider entry's word for no default at all, the same words its row
- * offers: while nothing is chosen, Luke asks which provider each time.
- */
-const ASK_EACH_TIME_CHOICE = "ask each time";
-
-/**
- * How the two sources are named in the guide — the toggle's own words, minus
- * the price tag beside them, because a spoken value is read aloud and "(you
- * pay)" is a label rather than a name.
- */
-const VOICE_SOURCE_CHOICE: Record<VoiceSource, string> = {
-  [VOICE_SOURCE.ACCOUNT]: "your Luke account",
-  [VOICE_SOURCE.KEY]: "your OpenAI key",
-};
-
-/**
- * The words a pace is asked for in, slowest to fastest, each paired with the
- * multiple it means. A conversation offers both spellings: the word because
- * "quick" survives speech where "1.25×" does not, and the multiple because it
- * is the label the settings row shows, so it is the name a reader of the row
- * will ask by.
- */
-const VOICE_SPEED_WORDS: readonly { word: string; speed: RealtimeVoiceSpeed }[] = [
-  { word: "slow", speed: REALTIME_VOICE_SPEED.SLOW },
-  { word: "normal", speed: REALTIME_VOICE_SPEED.NORMAL },
-  { word: "quick", speed: REALTIME_VOICE_SPEED.QUICK },
-  { word: "fast", speed: REALTIME_VOICE_SPEED.FAST },
-];
-
-/** A pace spelt the way its settings row labels it. */
-function voiceSpeedMultiple(speed: RealtimeVoiceSpeed): string {
-  return `${speed}×`;
-}
-
-function voiceSpeedWord(speed: RealtimeVoiceSpeed): string {
-  return VOICE_SPEED_WORDS.find((candidate) => candidate.speed === speed)?.word ?? "normal";
-}
-
-/** The name a provider is known by on its rows, falling back to its id. */
-function workspaceProviderName(providerId: ProviderId): string {
-  return isCredentialProviderId(providerId)
-    ? CREDENTIAL_PROVIDERS[providerId].displayName
-    : providerId;
-}
-
-/**
- * One guide entry per settings field — or several, where one stored value is
- * spoken of as more than one choice — or an explicit nothing. Exhaustive over
- * `AppSettings` on purpose: this `Record` failing to compile is how a new
- * setting is prevented from shipping unknown to Luke.
- */
-const SETTING_GUIDE: Record<
-  keyof AppSettings,
-  (settings: AppSettings) => AppGuideSetting | readonly AppGuideSetting[] | undefined
-> = {
-  voice: (settings) => ({
-    id: APP_SETTING_ID.VOICE,
-    label: "Voice",
-    description:
-      "Which voice Luke speaks with; a change is heard right away — a conversation under way starts afresh in the new voice.",
-    kind: APP_SETTING_KIND.CHOICE,
-    value: settings.voice,
-    defaultValue: REALTIME_DEFAULTS.VOICE,
-    choices: REALTIME_VOICE_LIST,
-    adjustable: true,
-    manual: VOICE_PAGE,
-  }),
-  voiceSpeed: (settings) => ({
-    id: APP_SETTING_ID.VOICE_SPEED,
-    label: "Speed",
-    description:
-      "How fast Luke talks — slow is 0.75×, normal 1×, quick 1.25×, fast 1.5× the voice's natural rate, and an ask may use the word or the multiple; a change is heard from the next reply on.",
-    kind: APP_SETTING_KIND.CHOICE,
-    value: voiceSpeedWord(settings.voiceSpeed),
-    defaultValue: voiceSpeedWord(REALTIME_DEFAULTS.SPEED),
-    choices: VOICE_SPEED_WORDS.flatMap((candidate) => [
-      candidate.word,
-      voiceSpeedMultiple(candidate.speed),
-    ]),
-    adjustable: true,
-    manual: VOICE_PAGE,
-  }),
-  voiceCaptions: (settings) => ({
-    id: APP_SETTING_ID.VOICE_CAPTIONS,
-    label: "Captions",
-    description:
-      "Luke's words on screen while he speaks; nothing is kept. They also appear on their own, " +
-      "whatever this says, for a reply answering a typed ask and while the Mac's output is " +
-      "muted or at zero.",
-    kind: APP_SETTING_KIND.TOGGLE,
-    value: appToggleText(settings.voiceCaptions),
-    defaultValue: appToggleText(APP_SETTING_DEFAULTS.voiceCaptions),
-    adjustable: true,
-    manual: VOICE_PAGE,
-  }),
-  duckOtherMedia: (settings) => ({
-    id: APP_SETTING_ID.DUCK_OTHER_MEDIA,
-    label: "Quiet Music and Spotify",
-    description:
-      "Whether Music and Spotify are turned down while a spoken exchange is live, and back up after.",
-    kind: APP_SETTING_KIND.TOGGLE,
-    value: appToggleText(settings.duckOtherMedia),
-    defaultValue: appToggleText(APP_SETTING_DEFAULTS.duckOtherMedia),
-    adjustable: true,
-    manual: VOICE_PAGE,
-  }),
-  preferBuiltInMicrophone: (settings) => ({
-    id: APP_SETTING_ID.PREFER_BUILT_IN_MICROPHONE,
-    label: "Prefer the Mac's microphone",
-    description:
-      "Whether Luke listens through the Mac's own microphone when the system input is a " +
-      "Bluetooth headset, so the headset keeps its full music quality. A shut lid keeps the " +
-      "headset's microphone either way.",
-    kind: APP_SETTING_KIND.TOGGLE,
-    value: appToggleText(settings.preferBuiltInMicrophone),
-    defaultValue: appToggleText(APP_SETTING_DEFAULTS.preferBuiltInMicrophone),
-    adjustable: true,
-    manual: VOICE_PAGE,
-  }),
-  quietDuringMeetings: (settings) => ({
-    id: APP_SETTING_ID.QUIET_DURING_MEETINGS,
-    label: "Quiet during meetings",
-    description:
-      "Whether spoken announcements wait while a connected calendar shows a meeting on, and are read out together once it ends. It changes nothing until a Google Calendar account is connected.",
-    kind: APP_SETTING_KIND.TOGGLE,
-    value: appToggleText(settings.quietDuringMeetings),
-    defaultValue: appToggleText(APP_SETTING_DEFAULTS.quietDuringMeetings),
-    adjustable: true,
-    manual: `${CONNECTIONS_PAGE} — drawn once a calendar account is connected`,
-  }),
-  showInDock: (settings) => ({
-    id: APP_SETTING_ID.SHOW_IN_DOCK,
-    label: "Show Luke in the Dock",
-    description: "Whether Luke also stands in the Dock as an app icon.",
-    kind: APP_SETTING_KIND.TOGGLE,
-    value: appToggleText(settings.showInDock),
-    defaultValue: appToggleText(APP_SETTING_DEFAULTS.showInDock),
-    adjustable: true,
-    manual: APPEARANCE_PAGE,
-  }),
-  showOnAllDisplays: (settings) => ({
-    id: APP_SETTING_ID.SHOW_ON_ALL_DISPLAYS,
-    label: "Show Luke on all displays",
-    description:
-      "Whether Luke stands on every connected display at once; off keeps him to the main display alone.",
-    kind: APP_SETTING_KIND.TOGGLE,
-    value: appToggleText(settings.showOnAllDisplays),
-    defaultValue: appToggleText(APP_SETTING_DEFAULTS.showOnAllDisplays),
-    adjustable: true,
-    manual: APPEARANCE_PAGE,
-  }),
-  // One stored value, spoken of as two choices: the model, and — only while a
-  // model whose agent documents levels is chosen — its effort, because a
-  // level with no model to ride has nowhere documented to go. The model entry
-  // also lists the levels each choice takes, so a model and its effort named
-  // in one breath are one change riding one call — the only way to set both
-  // while nothing is chosen yet, since the effort entry does not exist to be
-  // named. Both are changeable by voice, but only at the developer's own
-  // naming: the standing instructions forbid asking or suggesting either, so
-  // the ask is always theirs to bring up. Conductor is the one provider the
-  // build documents a table for; a second provider growing one is the moment
-  // this generalizes.
-  workspaceAgentDefaults: (settings) => {
-    const chosen = settings.workspaceAgentDefaults?.[PROVIDER_ID.CONDUCTOR];
-    const chosenAgent = chosen
-      ? workspaceAgentModels(PROVIDER_ID.CONDUCTOR).find((entry) => entry.agent === chosen.agent)
-      : undefined;
-    return [
-      {
-        id: APP_SETTING_ID.WORKSPACE_AGENT_MODEL,
-        label: "New Conductor agents run",
-        description:
-          "Which model a Conductor workspace or agent created through Luke starts with. Unset, " +
-          "Conductor's own defaults decide. An effort the model's agent documents may be named " +
-          "in the same change.",
-        kind: APP_SETTING_KIND.CHOICE,
-        // Said by the name people know the model by, the way its row draws
-        // it; the id stays on the wire where only endpoints read it.
-        value: chosen
-          ? workspaceAgentModelLabel(PROVIDER_ID.CONDUCTOR, chosen)
-          : CONDUCTOR_DEFAULT_CHOICE,
-        choices: [
-          CONDUCTOR_DEFAULT_CHOICE,
-          ...workspaceAgentModels(PROVIDER_ID.CONDUCTOR).flatMap((entry) =>
-            entry.models.map((model) => model.label),
-          ),
-        ],
-        // Each model's documented levels, keyed by the label the choice is
-        // said by, so an effort can ride the model's own change — the guide
-        // never lists a level nowhere documented, and a model whose agent
-        // takes none is simply absent.
-        efforts: Object.fromEntries(
-          workspaceAgentModels(PROVIDER_ID.CONDUCTOR).flatMap((entry) =>
-            entry.efforts.length > 0
-              ? entry.models.map((model) => [model.label, entry.efforts] as const)
-              : [],
-          ),
-        ),
-        // The default is itself one of the choices, so an ask to restore it
-        // is an ordinary change to the value listed.
-        defaultValue: CONDUCTOR_DEFAULT_CHOICE,
-        adjustable: true,
-        manual: CONDUCTOR_ROW_PATH,
-      },
-      ...(chosen && chosenAgent && chosenAgent.efforts.length > 0
-        ? [
-            {
-              id: APP_SETTING_ID.WORKSPACE_AGENT_EFFORT,
-              label: "New Conductor agents' effort",
-              description:
-                "How hard the chosen model thinks. Unset, Conductor's own default decides.",
-              kind: APP_SETTING_KIND.CHOICE,
-              value: chosen.effort ?? CONDUCTOR_DEFAULT_CHOICE,
-              choices: [CONDUCTOR_DEFAULT_CHOICE, ...chosenAgent.efforts],
-              defaultValue: CONDUCTOR_DEFAULT_CHOICE,
-              adjustable: true,
-              manual: CONDUCTOR_ROW_PATH,
-            },
-          ]
-        : []),
-    ];
-  },
-  // Described but kept by hand: the value's own story is conversational — the
-  // first workspace created saves its provider — so a spoken "change it"
-  // would shadow the same act the setting exists to record, and the refusal
-  // Luke voices carries the by-hand path. The projects context, not this
-  // entry, is what steers a live creation ask.
-  defaultWorkspaceProvider: (settings) => ({
-    id: APP_SETTING_ID.DEFAULT_WORKSPACE_PROVIDER,
-    label: "Default workspace provider",
-    description:
-      "Which provider a conversational ask creates a new workspace in when the ask names none. " +
-      "Until one is chosen Luke asks when more than one provider could take it, and the first " +
-      "workspace created saves its provider as the default.",
-    kind: APP_SETTING_KIND.CHOICE,
-    value: settings.defaultWorkspaceProvider
-      ? workspaceProviderName(settings.defaultWorkspaceProvider)
-      : ASK_EACH_TIME_CHOICE,
-    // Descriptive, never a spoken vocabulary — the entry is by-hand-only.
-    // The two named providers are the two that document a creation endpoint,
-    // the same two the "Creating workspaces" fact names; a third gaining one
-    // updates both.
-    choices: [
-      ASK_EACH_TIME_CHOICE,
-      workspaceProviderName(PROVIDER_ID.CONDUCTOR),
-      workspaceProviderName(PROVIDER_ID.CURSOR),
-    ],
-    // Every install starts with no provider chosen: asking each time is the
-    // default, and the first creation is what ends it.
-    defaultValue: ASK_EACH_TIME_CHOICE,
-    adjustable: false,
-    manual: `${CONNECTIONS_PAGE}, under Workspaces`,
-  }),
-  // Described in the workspace projects context instead, for a reason the
-  // provider entry does not have: projects are observed rather than
-  // build-fixed, so the guide's settings half holds only their ids, while the
-  // projects context names each provider's default by the repository a person
-  // knows it as. Kept by hand for the provider default's own reason — the
-  // first creation in a provider saves its project — and the Creating
-  // workspaces fact carries the by-hand path.
-  workspaceProjectDefaults: () => undefined,
-  formFactor: (settings) => ({
-    id: APP_SETTING_ID.FORM_FACTOR,
-    label: "Form factor",
-    description:
-      "How Luke stands on a display without a camera housing — notch draws him one pressed into the top edge, bubble floats him just under it. A display with a real notch ignores this.",
-    kind: APP_SETTING_KIND.CHOICE,
-    value: settings.formFactor,
-    defaultValue: DEFAULT_PANEL_FORM_FACTOR,
-    choices: PANEL_FORM_FACTOR_LIST,
-    adjustable: true,
-    manual: APPEARANCE_PAGE,
-  }),
-  // Described in the talk-key fact instead, which carries the key that
-  // actually registered — this field is only the stored choice, absent on the
-  // defaults and silently outbid when another app owns the chord. Not spoken-
-  // changeable either way: a chord is recorded by typing it, so the fact says
-  // where.
-  voiceHotkey: () => undefined,
-  // Described in the ask-key fact instead, for exactly the talk key's
-  // reasons: the fact carries the key that registered, and a chord is
-  // recorded by typing it rather than saying it.
-  askHotkey: () => undefined,
-  // Described in the stopping-a-reply fact instead, on the same terms as the
-  // other two keys' stored choices.
-  stopHotkey: () => undefined,
-  voiceSource: (settings) => ({
-    id: APP_SETTING_ID.VOICE_SOURCE,
-    label: "What Luke runs on",
-    description:
-      "Which credential Luke speaks and reviews sessions on: the signed-in Luke account, free " +
-      "and metered daily, or the developer's own OpenAI key, unmetered and billed to them by " +
-      "OpenAI. A key stays stored either way, so the free allowance can be used without " +
-      "deleting it.",
-    kind: APP_SETTING_KIND.CHOICE,
-    value: VOICE_SOURCE_CHOICE[settings.voiceSource],
-    // Every install begins on the account: the allowance is what a sign-in
-    // carries, and a key is something the developer goes and gets.
-    defaultValue: VOICE_SOURCE_CHOICE[VOICE_SOURCE.ACCOUNT],
-    choices: Object.values(VOICE_SOURCE_CHOICE),
-    // By hand only, and deliberately: this is the one switch that decides
-    // whose money is spent. It is not a credential, so the guide may describe
-    // it — but moving it is the developer's own act on their own bill, and a
-    // spoken ask that could start spending their key is exactly the shape of
-    // thing the refusal exists for.
-    adjustable: false,
-    manual: VOICE_SOURCE_SECTION,
-  }),
-  // Not a switch but a set of keys, so it is described in the facts instead:
-  // which providers are connected, and that a key is only ever typed by hand.
-  credentialSources: () => undefined,
-  // Only worth a word when it has refused a key, which the facts carry.
-  secretStorage: () => undefined,
-  /* Not a setting: it is whether the OpenAI key resolved, which the credential
-     row is where anyone changes. Luke is told whether he can speak at all by
-     the voice facts built from `LukeGuideInput.voiceAvailable`, so a spoken
-     ask about it is already answered without a settings entry to adjust. */
-  voiceAvailable: () => undefined,
-  /* Not a setting either: whether this build carries the OAuth client the
-     Google Calendar sign-in runs on. The integrations fact says whether the
-     calendar is connected, which is the question anyone actually asks. */
-  calendarSignInAvailable: () => undefined,
-  /* Connections rather than settings: accounts are signed into and
-     disconnected on their own rows, and which calendars count is chosen
-     there too. The integrations fact carries the counts; nothing here is a
-     value a spoken change could set. */
-  calendarAccounts: () => undefined,
-};
-
 /** What the guide needs from the app to describe the current state of it. */
 export interface LukeGuideInput {
   /** Optional only for pure callers that predate accounts; the app always supplies it. */
@@ -873,11 +525,7 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
     },
   ];
 
-  const settings = Object.values(SETTING_GUIDE).flatMap((entry) => {
-    const setting = entry(input.settings);
-    if (setting === undefined) return [];
-    return Array.isArray(setting) ? setting : [setting as AppGuideSetting];
-  });
+  const settings = settingGuideEntries(input.settings);
 
   return { facts, settings };
 }
@@ -977,7 +625,7 @@ export async function applySpokenSetting(
     if (composed.selection) defaults[PROVIDER_ID.CONDUCTOR] = composed.selection;
     else delete defaults[PROVIDER_ID.CONDUCTOR];
     result = await bridge.updateSetting(
-      "workspaceAgentDefaults",
+      APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
       Object.keys(defaults).length > 0 ? defaults : undefined,
     );
   } else {

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -21,14 +21,11 @@
 
 import {
   APP_SETTING_KIND,
-  APP_TOGGLE_VALUE,
   type AppGuideFact,
   type AppGuideSetting,
   type AppGuideSnapshot,
   appToggleText,
   DEFAULT_PANEL_FORM_FACTOR,
-  isPanelFormFactor,
-  isRealtimeVoice,
   PANEL_FORM_FACTOR_LIST,
   PROVIDER_ID,
   type ProviderId,
@@ -44,6 +41,7 @@ import type {
   AppSettings,
   CredentialSource,
   MicrophoneStatus,
+  SettingsUpdateResult,
   VoiceSource,
 } from "../shared/contracts";
 import {
@@ -61,37 +59,17 @@ import {
   isCredentialProviderId,
   VOICE_CREDENTIAL_PROVIDER_ID,
 } from "../shared/credential-providers";
+import {
+  APP_SETTING_ID,
+  type AppSettingId,
+  settingFieldForGuideId,
+  spokenSettingValue,
+} from "../shared/settings-schema";
 import { workspaceAgentModelLabel, workspaceAgentModels } from "../shared/workspace-agents";
 
+export type { AppSettingId } from "../shared/settings-schema";
 /** The ids a spoken change names Luke's settings by. */
-export const APP_SETTING_ID = {
-  VOICE: "voice",
-  VOICE_SPEED: "voice_speed",
-  VOICE_CAPTIONS: "voice_captions",
-  DUCK_OTHER_MEDIA: "duck_other_media",
-  PREFER_BUILT_IN_MICROPHONE: "prefer_built_in_microphone",
-  QUIET_DURING_MEETINGS: "quiet_during_meetings",
-  SHOW_IN_DOCK: "show_in_dock",
-  SHOW_ON_ALL_DISPLAYS: "show_on_all_displays",
-  FORM_FACTOR: "form_factor",
-  DEFAULT_WORKSPACE_PROVIDER: "default_workspace_provider",
-  WORKSPACE_AGENT_MODEL: "workspace_agent_model",
-  WORKSPACE_AGENT_EFFORT: "workspace_agent_effort",
-  VOICE_SOURCE: "voice_source",
-} as const;
-
-export type AppSettingId = (typeof APP_SETTING_ID)[keyof typeof APP_SETTING_ID];
-
-const APP_SETTING_ID_LIST: readonly AppSettingId[] = Object.values(APP_SETTING_ID);
-
-/**
- * Whether an id read back off a guide entry is one of Luke's own settings. A
- * guide entry carries its id as plain text — the snapshot is data on its way
- * out to a conversation — so anything reading one back has to ask.
- */
-export function isAppSettingId(value: string): value is AppSettingId {
-  return APP_SETTING_ID_LIST.includes(value as AppSettingId);
-}
+export { APP_SETTING_ID, isAppSettingId } from "../shared/settings-schema";
 
 /** Where the switches live, said once so every entry words it the same way. */
 const SETTINGS_TAB = "the panel's Settings tab";
@@ -156,12 +134,6 @@ function voiceSpeedMultiple(speed: RealtimeVoiceSpeed): string {
 
 function voiceSpeedWord(speed: RealtimeVoiceSpeed): string {
   return VOICE_SPEED_WORDS.find((candidate) => candidate.speed === speed)?.word ?? "normal";
-}
-
-function voiceSpeedFromWord(word: string): RealtimeVoiceSpeed | undefined {
-  return VOICE_SPEED_WORDS.find(
-    (candidate) => candidate.word === word || voiceSpeedMultiple(candidate.speed) === word,
-  )?.speed;
 }
 
 /** The name a provider is known by on its rows, falling back to its id. */
@@ -984,23 +956,12 @@ function spokenWorkspaceAgentSelection(
  * so a model or effort change composes against the selection actually stored.
  */
 export async function applySpokenSetting(
-  bridge: Pick<
-    AppBridge,
-    | "setVoice"
-    | "setVoiceSpeed"
-    | "setVoiceCaptions"
-    | "setDuckOtherMedia"
-    | "setPreferBuiltInMicrophone"
-    | "setQuietDuringMeetings"
-    | "setShowInDock"
-    | "setShowOnAllDisplays"
-    | "setFormFactor"
-    | "setWorkspaceAgentDefault"
-  >,
+  bridge: Pick<AppBridge, "updateSetting">,
   action: { setting: AppGuideSetting; value: string; effort?: string },
   onSettings: (settings: AppSettings) => void,
   current?: AppSettings,
 ): Promise<Record<string, unknown>> {
+  let result: SettingsUpdateResult;
   if (
     action.setting.id === APP_SETTING_ID.WORKSPACE_AGENT_MODEL ||
     action.setting.id === APP_SETTING_ID.WORKSPACE_AGENT_EFFORT
@@ -1012,46 +973,23 @@ export async function applySpokenSetting(
       current?.workspaceAgentDefaults?.[PROVIDER_ID.CONDUCTOR],
     );
     if ("refused" in composed) return { status: "refused", reason: composed.refused };
-    const answered = await bridge.setWorkspaceAgentDefault(
-      PROVIDER_ID.CONDUCTOR,
-      composed.selection,
+    const defaults = { ...current?.workspaceAgentDefaults };
+    if (composed.selection) defaults[PROVIDER_ID.CONDUCTOR] = composed.selection;
+    else delete defaults[PROVIDER_ID.CONDUCTOR];
+    result = await bridge.updateSetting(
+      "workspaceAgentDefaults",
+      Object.keys(defaults).length > 0 ? defaults : undefined,
     );
-    onSettings(answered.settings);
-    if (answered.reason) return { status: "refused", reason: answered.reason };
-    return {
-      status: "changed",
-      setting: action.setting.label,
-      value: action.value,
-      ...(action.effort !== undefined ? { effort: action.effort } : {}),
-    };
-  }
-  const enabled = action.value === APP_TOGGLE_VALUE.ON;
-  const speed = voiceSpeedFromWord(action.value);
-  const result =
-    action.setting.id === APP_SETTING_ID.VOICE_CAPTIONS
-      ? await bridge.setVoiceCaptions(enabled)
-      : action.setting.id === APP_SETTING_ID.DUCK_OTHER_MEDIA
-        ? await bridge.setDuckOtherMedia(enabled)
-        : action.setting.id === APP_SETTING_ID.PREFER_BUILT_IN_MICROPHONE
-          ? await bridge.setPreferBuiltInMicrophone(enabled)
-          : action.setting.id === APP_SETTING_ID.QUIET_DURING_MEETINGS
-            ? await bridge.setQuietDuringMeetings(enabled)
-            : action.setting.id === APP_SETTING_ID.SHOW_IN_DOCK
-              ? await bridge.setShowInDock(enabled)
-              : action.setting.id === APP_SETTING_ID.SHOW_ON_ALL_DISPLAYS
-                ? await bridge.setShowOnAllDisplays(enabled)
-                : action.setting.id === APP_SETTING_ID.VOICE_SPEED && speed !== undefined
-                  ? await bridge.setVoiceSpeed(speed)
-                  : action.setting.id === APP_SETTING_ID.VOICE && isRealtimeVoice(action.value)
-                    ? await bridge.setVoice(action.value)
-                    : action.setting.id === APP_SETTING_ID.FORM_FACTOR &&
-                        isPanelFormFactor(action.value)
-                      ? await bridge.setFormFactor(action.value)
-                      : undefined;
-  if (!result) {
-    // An adjustable entry with no carrier is a guide ahead of its wiring;
-    // refuse honestly rather than claim a change that never happened.
-    return { status: "refused", reason: "That setting cannot be changed from here." };
+  } else {
+    const field = settingFieldForGuideId(action.setting.id as AppSettingId);
+    if (!field) {
+      return { status: "refused", reason: "That setting cannot be changed from here." };
+    }
+    const value = spokenSettingValue(field, action.value);
+    if (value === undefined) {
+      return { status: "refused", reason: "That setting cannot be changed from here." };
+    }
+    result = await bridge.updateSetting(field, value);
   }
   onSettings(result.settings);
   if (result.reason) return { status: "refused", reason: result.reason };
@@ -1059,10 +997,7 @@ export async function applySpokenSetting(
     status: "changed",
     setting: action.setting.label,
     value: action.value,
-    // What each change means for the call now open, so the outcome Luke
-    // voices matches what actually happens. The API locks a session's voice
-    // once the model has spoken, so a changed voice is heard by starting the
-    // conversation afresh; a pace rides a session update and needs no restart.
+    ...(action.effort !== undefined ? { effort: action.effort } : {}),
     ...(action.setting.id === APP_SETTING_ID.VOICE
       ? {
           note: "The new voice takes over as soon as this reply ends, and the conversation starts afresh in it.",

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -604,7 +604,7 @@ function spokenWorkspaceAgentSelection(
  * so a model or effort change composes against the selection actually stored.
  */
 export async function applySpokenSetting(
-  bridge: Pick<AppBridge, "updateSetting">,
+  bridge: Pick<AppBridge, "updateSetting" | "updateSettingEntry">,
   action: { setting: AppGuideSetting; value: string; effort?: string },
   onSettings: (settings: AppSettings) => void,
   current?: AppSettings,
@@ -621,12 +621,10 @@ export async function applySpokenSetting(
       current?.workspaceAgentDefaults?.[PROVIDER_ID.CONDUCTOR],
     );
     if ("refused" in composed) return { status: "refused", reason: composed.refused };
-    const defaults = { ...current?.workspaceAgentDefaults };
-    if (composed.selection) defaults[PROVIDER_ID.CONDUCTOR] = composed.selection;
-    else delete defaults[PROVIDER_ID.CONDUCTOR];
-    result = await bridge.updateSetting(
+    result = await bridge.updateSettingEntry(
       APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
-      Object.keys(defaults).length > 0 ? defaults : undefined,
+      PROVIDER_ID.CONDUCTOR,
+      composed.selection,
     );
   } else {
     const field = settingFieldForGuideId(action.setting.id as AppSettingId);

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -78,7 +78,6 @@ const FRONT_PAGE = `${SETTINGS_TAB}, on its front page`;
  */
 const CONDUCTOR_DEFAULT_CHOICE = "Conductor's default";
 
-/**
 /** What the guide needs from the app to describe the current state of it. */
 export interface LukeGuideInput {
   /** Optional only for pure callers that predate accounts; the app always supplies it. */

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -47,6 +47,7 @@ import {
   VOICE_CREDENTIAL_PROVIDER,
 } from "../shared/credential-providers";
 import { GOOGLE_CALENDAR_ID, GOOGLE_CALENDAR_NAME } from "../shared/google-calendar";
+import { settingsScopeChanged } from "../shared/settings-schema";
 import {
   capturedVoiceHotkey,
   DEFAULT_ASK_HOTKEYS,
@@ -807,40 +808,6 @@ function AttentionMark({ note }: { note: string }): React.JSX.Element {
    always agree on what is standing. The voice and pace compare against the
    shipped defaults the way their menus label them; a launch-environment
    override reads as changed, which is what the row shows too. */
-function voiceSettingsChanged(settings: AppSettings): boolean {
-  return (
-    settings.voice !== REALTIME_DEFAULTS.VOICE ||
-    settings.voiceSpeed !== REALTIME_DEFAULTS.SPEED ||
-    settings.voiceCaptions !== APP_SETTING_DEFAULTS.voiceCaptions ||
-    settings.duckOtherMedia !== APP_SETTING_DEFAULTS.duckOtherMedia ||
-    settings.preferBuiltInMicrophone !== APP_SETTING_DEFAULTS.preferBuiltInMicrophone
-  );
-}
-
-function appearanceSettingsChanged(settings: AppSettings): boolean {
-  return (
-    settings.showInDock !== APP_SETTING_DEFAULTS.showInDock ||
-    settings.showOnAllDisplays !== APP_SETTING_DEFAULTS.showOnAllDisplays ||
-    settings.formFactor !== DEFAULT_PANEL_FORM_FACTOR
-  );
-}
-
-/* The keys' terms are the rows' own: a chord is changed while one is stored,
-   whatever key the row is showing for it. */
-function shortcutSettingsChanged(shortcuts: ShortcutControl): boolean {
-  return shortcuts.voiceChosen || shortcuts.askChosen || shortcuts.stopChosen;
-}
-
-/* Only the choices the Workspaces group itself draws: the Conductor agent
-   pairing lives on the Conductor row, whose own menu already offers the
-   provider's default, so no reset here may reach it. */
-function workspaceSettingsChanged(settings: AppSettings): boolean {
-  return (
-    settings.defaultWorkspaceProvider !== undefined ||
-    Object.keys(settings.workspaceProjectDefaults ?? {}).length > 0
-  );
-}
-
 /**
  * The one control that returns a whole group to its defaults, drawn only
  * while the group holds something to return — until then it could only offer
@@ -1922,7 +1889,7 @@ function WorkspacesSection({
           <FolderIcon />
           Workspaces
         </h2>
-        {workspaceSettingsChanged(settings) ? (
+        {settingsScopeChanged(settings, SETTINGS_RESET_SCOPE.WORKSPACES) ? (
           <ResetGroupButton
             scope={SETTINGS_RESET_SCOPE.WORKSPACES}
             label="the workspace defaults"
@@ -2806,10 +2773,13 @@ function AccountSection({
 function pageResetControl(
   view: SettingsView,
   settings: AppSettings | undefined,
-  shortcuts: ShortcutControl,
   preferences: PreferenceWrites,
 ): React.JSX.Element | undefined {
-  if (view === SETTINGS_VIEW.VOICE && settings && voiceSettingsChanged(settings)) {
+  if (
+    view === SETTINGS_VIEW.VOICE &&
+    settings &&
+    settingsScopeChanged(settings, SETTINGS_RESET_SCOPE.VOICE)
+  ) {
     return (
       <ResetGroupButton
         scope={SETTINGS_RESET_SCOPE.VOICE}
@@ -2818,7 +2788,11 @@ function pageResetControl(
       />
     );
   }
-  if (view === SETTINGS_VIEW.APPEARANCE && settings && appearanceSettingsChanged(settings)) {
+  if (
+    view === SETTINGS_VIEW.APPEARANCE &&
+    settings &&
+    settingsScopeChanged(settings, SETTINGS_RESET_SCOPE.APPEARANCE)
+  ) {
     return (
       <ResetGroupButton
         scope={SETTINGS_RESET_SCOPE.APPEARANCE}
@@ -2827,7 +2801,11 @@ function pageResetControl(
       />
     );
   }
-  if (view === SETTINGS_VIEW.SHORTCUTS && shortcutSettingsChanged(shortcuts)) {
+  if (
+    view === SETTINGS_VIEW.SHORTCUTS &&
+    settings &&
+    settingsScopeChanged(settings, SETTINGS_RESET_SCOPE.SHORTCUTS)
+  ) {
     return (
       <ResetGroupButton
         scope={SETTINGS_RESET_SCOPE.SHORTCUTS}
@@ -2924,7 +2902,7 @@ export function SettingsPanel({
     backControl.current?.focus();
   }, [view, panelOpen]);
   // The drawn page's reset, absent while that page stands at its defaults.
-  const pageReset = pageResetControl(view, settings, shortcuts, preferences);
+  const pageReset = pageResetControl(view, settings, preferences);
   return (
     <div
       className="settings"

--- a/apps/desktop/src/renderer/settings-views.ts
+++ b/apps/desktop/src/renderer/settings-views.ts
@@ -2,8 +2,13 @@ import {
   type CredentialProviderId,
   VOICE_CREDENTIAL_PROVIDER_ID,
 } from "../shared/credential-providers";
-import { APP_SETTING_ID, type AppSettingId } from "./luke-guide";
+import {
+  SETTING_PAGE,
+  SETTINGS_PAGE as SETTINGS_VIEW,
+  type SettingsPage as SettingsView,
+} from "../shared/settings-schema";
 
+export type { SettingsView };
 /**
  * Where inside the Settings tab the panel currently is: its front page, or one
  * of the pages a front-page row opens. App state rather than panel state for
@@ -11,15 +16,7 @@ import { APP_SETTING_ID, type AppSettingId } from "./luke-guide";
  * app's own key handler, and a credential entry begun on a settings page has
  * to bring the panel back to that page after its trip to the key slot.
  */
-export const SETTINGS_VIEW = {
-  ROOT: "root",
-  VOICE: "voice",
-  APPEARANCE: "appearance",
-  SHORTCUTS: "shortcuts",
-  CONNECTIONS: "connections",
-} as const;
-
-export type SettingsView = (typeof SETTINGS_VIEW)[keyof typeof SETTINGS_VIEW];
+export { SETTINGS_VIEW };
 
 /** The pages the front page opens, in the order its rows offer them. */
 export const SETTINGS_SUBVIEW_LIST = [
@@ -44,31 +41,7 @@ export type SettingsSubview = (typeof SETTINGS_SUBVIEW_LIST)[number];
  * each setting. That the two agree is a test rather than a type, because one
  * is a sentence and the other is a page.
  */
-export const SETTING_PAGE: Record<AppSettingId, SettingsView> = {
-  [APP_SETTING_ID.VOICE]: SETTINGS_VIEW.VOICE,
-  [APP_SETTING_ID.VOICE_SPEED]: SETTINGS_VIEW.VOICE,
-  [APP_SETTING_ID.VOICE_CAPTIONS]: SETTINGS_VIEW.VOICE,
-  [APP_SETTING_ID.DUCK_OTHER_MEDIA]: SETTINGS_VIEW.VOICE,
-  [APP_SETTING_ID.PREFER_BUILT_IN_MICROPHONE]: SETTINGS_VIEW.VOICE,
-  // Beside the calendar row whose connection gives it meaning, not with the
-  // voice switches: the quiet is a fact about the calendar integration.
-  [APP_SETTING_ID.QUIET_DURING_MEETINGS]: SETTINGS_VIEW.CONNECTIONS,
-  [APP_SETTING_ID.SHOW_IN_DOCK]: SETTINGS_VIEW.APPEARANCE,
-  [APP_SETTING_ID.SHOW_ON_ALL_DISPLAYS]: SETTINGS_VIEW.APPEARANCE,
-  [APP_SETTING_ID.FORM_FACTOR]: SETTINGS_VIEW.APPEARANCE,
-  // The three the guide describes but marks by-hand-only. Nothing flies to
-  // them — a spoken ask is refused before it reaches a page — but where they
-  // are drawn is a fact about the settings either way, and answering it here
-  // is what keeps the answer right if one of them is ever opened up.
-  [APP_SETTING_ID.DEFAULT_WORKSPACE_PROVIDER]: SETTINGS_VIEW.CONNECTIONS,
-  [APP_SETTING_ID.WORKSPACE_AGENT_MODEL]: SETTINGS_VIEW.CONNECTIONS,
-  [APP_SETTING_ID.WORKSPACE_AGENT_EFFORT]: SETTINGS_VIEW.CONNECTIONS,
-  // The front page itself, which is why the value type is a view rather than
-  // a subview: the choice of what Luke runs on leads the page rather than
-  // living on one the page opens. By-hand-only like the three above, so
-  // nothing ever flies to it — but where it is drawn is a fact either way.
-  [APP_SETTING_ID.VOICE_SOURCE]: SETTINGS_VIEW.ROOT,
-};
+export { SETTING_PAGE };
 
 /**
  * Which page draws a provider's credential row. Every key lives under

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -34,7 +34,10 @@ import {
   APP_SETTING_SCHEMA,
   type AppSettingField,
   type AppSettingValue,
+  type KeyedAppSettingField,
+  type SettingEntryValue,
   type StoredAppSettings,
+  sameSettingEntry,
 } from "./shared/settings-schema";
 
 const SETTINGS_FILE_NAME = "settings.json";
@@ -326,6 +329,42 @@ export class SettingsStore {
       const next: PersistedSettings = { ...persisted };
       if (value === undefined) delete next[field];
       else Object.assign(next, { [field]: value });
+      return next;
+    });
+  }
+
+  /**
+   * Writes one entry of a map-valued setting, or forgets it when the value is
+   * omitted. The merge happens inside the mutation rather than in the caller so
+   * one key's write cannot drop another's: a caller holding the map it read
+   * before an overlapping write landed would put the stale copy back. A map
+   * left with no entries is deleted, so an emptied setting reads as unset
+   * rather than as an empty object.
+   */
+  async setEntry<Field extends KeyedAppSettingField>(
+    field: Field,
+    key: string,
+    value: SettingEntryValue<Field> | undefined,
+  ): Promise<SettingsUpdateResult>;
+  async setEntry(
+    field: KeyedAppSettingField,
+    key: string,
+    value: unknown,
+  ): Promise<SettingsUpdateResult>;
+  async setEntry(
+    field: KeyedAppSettingField,
+    key: string,
+    value: unknown,
+  ): Promise<SettingsUpdateResult> {
+    return this.#setField((persisted) => {
+      const current = persisted[field] as Record<string, unknown> | undefined;
+      if (sameSettingEntry(field, current?.[key], value)) return;
+      const entries = { ...current };
+      if (value === undefined) delete entries[key];
+      else entries[key] = value;
+      const next: PersistedSettings = { ...persisted };
+      if (Object.keys(entries).length > 0) Object.assign(next, { [field]: entries });
+      else delete next[field];
       return next;
     });
   }

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -1,18 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import {
-  DEFAULT_PANEL_FORM_FACTOR,
-  isPanelFormFactor,
-  isProviderId,
-  isRealtimeVoice,
-  isRealtimeVoiceSpeed,
-  type PanelFormFactor,
-  type ProviderId,
-  REALTIME_DEFAULTS,
-  type RealtimeVoice,
-  type RealtimeVoiceSpeed,
-  type WorkspaceAgentSelection,
-} from "@sidecar/core";
+import { DEFAULT_PANEL_FORM_FACTOR, REALTIME_DEFAULTS } from "@sidecar/core";
 // The reader owns the shape it is fed: what this store resolves a stored
 // account into is exactly what `readAccounts` promises it.
 import type { CalendarAccountCredential } from "./google-calendar";
@@ -23,13 +11,10 @@ import {
   ACCOUNT_STATUS,
   type AccountProvider,
   type AccountSnapshot,
-  APP_SETTING_DEFAULTS,
   type AppSettings,
   CREDENTIAL_SOURCE,
   type CredentialSource,
-  isVoiceSource,
   SECRET_STORAGE,
-  SETTINGS_RESET_SCOPE,
   type SecretStorage,
   type SettingsResetScope,
   type SettingsUpdateResult,
@@ -44,8 +29,13 @@ import {
   type CredentialProviderId,
   VOICE_CREDENTIAL_PROVIDER_ID,
 } from "./shared/credential-providers";
-import { parseVoiceHotkey } from "./shared/voice-hotkey";
-import { isWorkspaceAgentSelection } from "./shared/workspace-agents";
+import {
+  APP_SETTING_FIELDS,
+  APP_SETTING_SCHEMA,
+  type AppSettingField,
+  type AppSettingValue,
+  type StoredAppSettings,
+} from "./shared/settings-schema";
 
 const SETTINGS_FILE_NAME = "settings.json";
 const SETTINGS_TEMPORARY_FILE_NAME = "settings.json.tmp";
@@ -57,24 +47,8 @@ const SETTINGS_FIELD = {
   ACCOUNT: "account",
   API_KEYS: "apiKeys",
   CALENDAR_ACCOUNTS: "calendarAccounts",
-  ASK_HOTKEY: "askHotkey",
-  DEFAULT_WORKSPACE_PROVIDER: "defaultWorkspaceProvider",
-  DUCK_OTHER_MEDIA: "duckOtherMedia",
-  PREFER_BUILT_IN_MICROPHONE: "preferBuiltInMicrophone",
-  FORM_FACTOR: "formFactor",
   LEGACY_CONDUCTOR_API_KEY: "conductorApiKey",
-  QUIET_DURING_MEETINGS: "quietDuringMeetings",
-  SHOW_IN_DOCK: "showInDock",
-  SHOW_ON_ALL_DISPLAYS: "showOnAllDisplays",
-  STOP_HOTKEY: "stopHotkey",
   VERSION: "version",
-  VOICE: "voice",
-  VOICE_CAPTIONS: "voiceCaptions",
-  VOICE_SOURCE: "voiceSource",
-  VOICE_SPEED: "voiceSpeed",
-  VOICE_HOTKEY: "voiceHotkey",
-  WORKSPACE_AGENT_DEFAULTS: "workspaceAgentDefaults",
-  WORKSPACE_PROJECT_DEFAULTS: "workspaceProjectDefaults",
 } as const;
 
 const API_KEY_LENGTH = {
@@ -114,7 +88,7 @@ export interface SettingsStoreOptions {
   credentialsUsable?: boolean;
 }
 
-interface PersistedSettings {
+interface PersistedSettings extends StoredAppSettings {
   version: number;
   /**
    * Ciphertext by provider id. A provider this build does not know is carried
@@ -135,105 +109,6 @@ interface PersistedSettings {
    * Absent from the file while none are connected.
    */
   calendarAccounts?: readonly PersistedCalendarAccount[];
-  /**
-   * Whether Luke stands in the Dock. Off unless the file says `true` outright,
-   * so a missing field, an older file, and a corrupt value all land on the
-   * accessory app Luke ships as rather than putting an icon somewhere new.
-   */
-  showInDock: boolean;
-  /**
-   * The voice the user chose, absent until one has been. A preference rather
-   * than a credential, so it is stored plainly and never touches the cipher.
-   */
-  voice?: RealtimeVoice;
-  /**
-   * The pace the user chose for Luke's speech, absent until one has been.
-   * Stored plainly like the voice, and held to the same offered set.
-   */
-  voiceSpeed?: RealtimeVoiceSpeed;
-  /**
-   * Whether Luke's speech is captioned on screen. Off unless the file says
-   * `true` outright, so a missing field, an older file, and a corrupt value
-   * all land on the default rather than switching something on.
-   */
-  voiceCaptions: boolean;
-  /**
-   * The talk-key chord the user chose, absent while the defaults stand. A
-   * preference like the voice, stored plainly — and like the voice, a value
-   * this build cannot register is dropped rather than carried, because
-   * honouring it would claim a system key nothing was ever told about.
-   */
-  voiceHotkey?: string;
-  /**
-   * The ask-key chord the user chose, held to everything the talk key's is:
-   * stored plainly, absent while the defaults stand, and dropped rather than
-   * carried when this build cannot register it.
-   */
-  askHotkey?: string;
-  /**
-   * The stop-key chord the user chose, held to the same terms as the other
-   * two keys' choices.
-   */
-  stopHotkey?: string;
-  /**
-   * Whether Music and Spotify are turned down while a spoken exchange is
-   * live. On unless the file says `false` outright: this is what Luke does
-   * until the user asks otherwise, so a missing field
-   * and a corrupt value both land on doing it.
-   */
-  duckOtherMedia: boolean;
-  /**
-   * Which credential the user chose to speak and review on, absent until they
-   * choose. Absent means "whichever is there, the key first", which is what
-   * connecting a key meant before the choice existed — so an install that
-   * never touches the toggle behaves exactly as it always did, and only an
-   * explicit choice of the account holds a stored key back.
-   */
-  voiceSource?: VoiceSource;
-  preferBuiltInMicrophone: boolean;
-  /**
-   * Whether announcements wait out calendar meetings. On unless the file says
-   * `false` outright, on the media duck's own reasoning: this is what Luke
-   * does with a connected calendar until the user asks otherwise, so a
-   * missing field and a corrupt value both land on doing it.
-   */
-  quietDuringMeetings: boolean;
-  /**
-   * Whether Luke stands on every connected display. Off unless the file says
-   * `true` outright, like the Dock: a missing field, an older file, and a
-   * corrupt value all land on the main display alone rather than raising
-   * windows somewhere new.
-   */
-  showOnAllDisplays: boolean;
-  /**
-   * How Luke stands on a display without a housing, absent until the user has
-   * chosen. Held to the offered set like the voice: a value this build does
-   * not draw is dropped rather than honoured.
-   */
-  formFactor?: PanelFormFactor;
-  /**
-   * The provider a conversational ask creates a workspace in when it names
-   * none, absent until the user's first creation chooses it. Held to the
-   * providers this build knows: an unknown id is dropped rather than steered
-   * by, because it names nowhere an ask could actually go.
-   */
-  defaultWorkspaceProvider?: ProviderId;
-  /**
-   * The agent kind and model new workspaces start with, per provider, each
-   * entry absent while that provider's own defaults stand. Held to the
-   * build's documented table twice over: an unknown provider and an unlisted
-   * pairing are both dropped, because each names something no endpoint takes.
-   */
-  workspaceAgentDefaults?: Readonly<Partial<Record<ProviderId, WorkspaceAgentSelection>>>;
-  /**
-   * The project a nameless creation ask lands in, per provider, each entry
-   * absent until the user's first creation there chooses it. Projects are
-   * observed rather than build-fixed, so only the value's shape can be held
-   * here — an unknown provider or a malformed id is dropped, and whether the
-   * project is still offered is answered where the list lives: the id only
-   * ever steers, and every creation is validated against the observed list.
-   */
-  workspaceProjectDefaults?: Readonly<Partial<Record<ProviderId, string>>>;
 }
 
 interface ResolvedApiKey {
@@ -326,15 +201,6 @@ function storedCalendarAccounts(
   return accounts;
 }
 
-/**
- * Reads a stored switch: a boolean is honoured, and anything else — a missing
- * field, an older file, a corrupt value — lands on the stated default rather
- * than switching anything on or off by accident.
- */
-function booleanSetting(value: unknown, fallback: boolean): boolean {
-  return typeof value === "boolean" ? value : fallback;
-}
-
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error;
 }
@@ -399,61 +265,6 @@ function storedApiKeys(record: Record<string, unknown>): Record<string, string> 
  * with a model this one does not know; honouring it would send a value no
  * documented endpoint takes, so it is dropped the way an unknown voice is.
  */
-function storedWorkspaceAgentDefaults(
-  record: Record<string, unknown>,
-): Partial<Record<ProviderId, WorkspaceAgentSelection>> | undefined {
-  const persisted = record[SETTINGS_FIELD.WORKSPACE_AGENT_DEFAULTS];
-  if (persisted === null || typeof persisted !== "object" || Array.isArray(persisted)) {
-    return undefined;
-  }
-  const defaults: Partial<Record<ProviderId, WorkspaceAgentSelection>> = {};
-  for (const [providerId, value] of Object.entries(persisted)) {
-    if (!isProviderId(providerId)) continue;
-    if (!isWorkspaceAgentSelection(providerId, value)) continue;
-    defaults[providerId] = {
-      agent: value.agent,
-      model: value.model,
-      ...(value.effort !== undefined ? { effort: value.effort } : {}),
-    };
-  }
-  return Object.keys(defaults).length > 0 ? defaults : undefined;
-}
-
-/** A stored project id reads like one wire value; anything longer is not an id. */
-const MAXIMUM_WORKSPACE_PROJECT_ID_LENGTH = 200;
-
-/** A provider's project id as this store will keep it, or nothing. */
-function workspaceProjectIdText(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
-  const normalized = value.trim();
-  if (!normalized || normalized.length > MAXIMUM_WORKSPACE_PROJECT_ID_LENGTH) return undefined;
-  return normalized;
-}
-
-/**
- * Reads the stored per-provider project choices, keeping only entries whose
- * provider this build knows and whose value has an id's shape. Whether the
- * project is still offered cannot be answered here — the list is observed at
- * run time — so a stale id is carried and simply steers nothing until its
- * provider offers that project again.
- */
-function storedWorkspaceProjectDefaults(
-  record: Record<string, unknown>,
-): Partial<Record<ProviderId, string>> | undefined {
-  const persisted = record[SETTINGS_FIELD.WORKSPACE_PROJECT_DEFAULTS];
-  if (persisted === null || typeof persisted !== "object" || Array.isArray(persisted)) {
-    return undefined;
-  }
-  const defaults: Partial<Record<ProviderId, string>> = {};
-  for (const [providerId, value] of Object.entries(persisted)) {
-    if (!isProviderId(providerId)) continue;
-    const providerProjectId = workspaceProjectIdText(value);
-    if (!providerProjectId) continue;
-    defaults[providerId] = providerProjectId;
-  }
-  return Object.keys(defaults).length > 0 ? defaults : undefined;
-}
-
 function parsePersistedSettings(source: string): PersistedSettings {
   const parsed: unknown = JSON.parse(source);
   if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
@@ -462,75 +273,18 @@ function parsePersistedSettings(source: string): PersistedSettings {
   const record = parsed as Record<string, unknown>;
   const version = record[SETTINGS_FIELD.VERSION];
   const calendarAccounts = storedCalendarAccounts(record);
-  const voice = record[SETTINGS_FIELD.VOICE];
-  const voiceSource = record[SETTINGS_FIELD.VOICE_SOURCE];
-  const voiceSpeed = record[SETTINGS_FIELD.VOICE_SPEED];
-  const formFactor = record[SETTINGS_FIELD.FORM_FACTOR];
-  const defaultWorkspaceProvider = record[SETTINGS_FIELD.DEFAULT_WORKSPACE_PROVIDER];
-  const workspaceAgentDefaults = storedWorkspaceAgentDefaults(record);
-  const workspaceProjectDefaults = storedWorkspaceProjectDefaults(record);
-  const storedHotkey = record[SETTINGS_FIELD.VOICE_HOTKEY];
-  // Read through the same gate a submitted chord passes, so a hand-edited
-  // value is either the one spelling the rest of the app uses or nothing.
-  const voiceHotkey = typeof storedHotkey === "string" ? parseVoiceHotkey(storedHotkey) : undefined;
-  const storedAskHotkey = record[SETTINGS_FIELD.ASK_HOTKEY];
-  const askHotkey =
-    typeof storedAskHotkey === "string" ? parseVoiceHotkey(storedAskHotkey) : undefined;
-  const storedStopHotkey = record[SETTINGS_FIELD.STOP_HOTKEY];
-  const stopHotkey =
-    typeof storedStopHotkey === "string" ? parseVoiceHotkey(storedStopHotkey) : undefined;
+  const settings = Object.fromEntries(
+    APP_SETTING_FIELDS.map((field) => [
+      field,
+      APP_SETTING_SCHEMA[field].guard(record[field]).value,
+    ]),
+  ) as unknown as StoredAppSettings;
   return {
+    ...settings,
     version: typeof version === "number" ? version : SETTINGS_FILE_VERSION,
     apiKeys: storedApiKeys(record),
     ...(storedAccount(record) ? { account: storedAccount(record) } : {}),
     ...(calendarAccounts.length > 0 ? { calendarAccounts } : {}),
-    showInDock: booleanSetting(
-      record[SETTINGS_FIELD.SHOW_IN_DOCK],
-      APP_SETTING_DEFAULTS.showInDock,
-    ),
-    // A voice this build does not offer is dropped rather than carried: unlike
-    // a credential it has a default to fall back to, and honouring an unknown
-    // one would mint sessions the API refuses.
-    ...(isRealtimeVoice(voice) ? { voice } : {}),
-    // A pace outside the offered set is dropped for the same reason.
-    ...(isRealtimeVoiceSpeed(voiceSpeed) ? { voiceSpeed } : {}),
-    voiceCaptions: booleanSetting(
-      record[SETTINGS_FIELD.VOICE_CAPTIONS],
-      APP_SETTING_DEFAULTS.voiceCaptions,
-    ),
-    ...(voiceHotkey ? { voiceHotkey } : {}),
-    ...(askHotkey ? { askHotkey } : {}),
-    ...(stopHotkey ? { stopHotkey } : {}),
-    duckOtherMedia: booleanSetting(
-      record[SETTINGS_FIELD.DUCK_OTHER_MEDIA],
-      APP_SETTING_DEFAULTS.duckOtherMedia,
-    ),
-    // A source this build does not offer is dropped rather than carried, the
-    // way an unknown voice is: absent is a meaning of its own here — take
-    // whichever credential is there — so there is always somewhere safe to
-    // land.
-    ...(isVoiceSource(voiceSource) ? { voiceSource } : {}),
-    preferBuiltInMicrophone: booleanSetting(
-      record[SETTINGS_FIELD.PREFER_BUILT_IN_MICROPHONE],
-      APP_SETTING_DEFAULTS.preferBuiltInMicrophone,
-    ),
-    quietDuringMeetings: booleanSetting(
-      record[SETTINGS_FIELD.QUIET_DURING_MEETINGS],
-      APP_SETTING_DEFAULTS.quietDuringMeetings,
-    ),
-    showOnAllDisplays: booleanSetting(
-      record[SETTINGS_FIELD.SHOW_ON_ALL_DISPLAYS],
-      APP_SETTING_DEFAULTS.showOnAllDisplays,
-    ),
-    // A form this build does not draw is dropped like an unknown voice.
-    ...(isPanelFormFactor(formFactor) ? { formFactor } : {}),
-    // A provider this build does not know is dropped the same way: it names
-    // nowhere a creation ask could go, so honouring it would steer nothing.
-    ...(typeof defaultWorkspaceProvider === "string" && isProviderId(defaultWorkspaceProvider)
-      ? { defaultWorkspaceProvider }
-      : {}),
-    ...(workspaceAgentDefaults ? { workspaceAgentDefaults } : {}),
-    ...(workspaceProjectDefaults ? { workspaceProjectDefaults } : {}),
   };
 }
 
@@ -550,6 +304,31 @@ export class SettingsStore {
   /** Decrypted accounts, cached like the keys so timers never drum the Keychain. */
   #resolvedCalendarAccounts: readonly CalendarAccountCredential[] | undefined;
   #mutations: Promise<void> = Promise.resolve();
+
+  async get<Field extends AppSettingField>(field: Field): Promise<AppSettingValue<Field>> {
+    return (await this.#load())[field];
+  }
+
+  async set<Field extends AppSettingField>(
+    field: Field,
+    value: AppSettingValue<Field>,
+  ): Promise<SettingsUpdateResult>;
+  async set(
+    field: AppSettingField,
+    value: StoredAppSettings[AppSettingField],
+  ): Promise<SettingsUpdateResult>;
+  async set(
+    field: AppSettingField,
+    value: StoredAppSettings[AppSettingField],
+  ): Promise<SettingsUpdateResult> {
+    return this.#setField((persisted) => {
+      if (persisted[field] === value) return;
+      const next: PersistedSettings = { ...persisted };
+      if (value === undefined) delete next[field];
+      else Object.assign(next, { [field]: value });
+      return next;
+    });
+  }
   #secretStorage: SecretStorage = SECRET_STORAGE.UNKNOWN;
 
   constructor(options: SettingsStoreOptions) {
@@ -708,318 +487,6 @@ export class SettingsStore {
   }
 
   /**
-   * The Dock icon is decided
-   * at launch from the settings file alone, never the keychain behind the
-   * stored keys.
-   */
-  async showInDock(): Promise<boolean> {
-    return (await this.#load()).showInDock;
-  }
-
-  /**
-   * Shallow so the media duck arms at
-   * startup, and arming it must never be what wakes the OS keychain.
-   */
-  async duckOtherMedia(): Promise<boolean> {
-    return (await this.#load()).duckOtherMedia;
-  }
-
-  /**
-   * Main-process only, like the resolved keys: the voice the user chose, for
-   * the minter at startup. Nothing chosen resolves to nothing — the minter
-   * already carries the environment's voice and the default.
-   */
-  async readVoice(): Promise<RealtimeVoice | undefined> {
-    return (await this.#load()).voice;
-  }
-
-  /** Stores the chosen voice, or returns to the default when omitted. */
-  async setVoice(voice: RealtimeVoice | undefined): Promise<SettingsUpdateResult> {
-    return this.#setField((persisted) => {
-      if (persisted.voice === voice) return;
-      const next: PersistedSettings = { ...persisted };
-      if (voice) next.voice = voice;
-      else delete next.voice;
-      return next;
-    });
-  }
-
-  /**
-   * Main-process only, like the voice: the pace the user chose, for the minter
-   * at startup. Nothing chosen resolves to nothing — the minter already
-   * carries the environment's pace and the default.
-   */
-  async readVoiceSpeed(): Promise<RealtimeVoiceSpeed | undefined> {
-    return (await this.#load()).voiceSpeed;
-  }
-
-  /** Stores the chosen pace, or returns to the default when omitted. */
-  async setVoiceSpeed(speed: RealtimeVoiceSpeed | undefined): Promise<SettingsUpdateResult> {
-    return this.#setField((persisted) => {
-      if (persisted.voiceSpeed === speed) return;
-      const next: PersistedSettings = { ...persisted };
-      if (speed) next.voiceSpeed = speed;
-      else delete next.voiceSpeed;
-      return next;
-    });
-  }
-
-  /**
-   * Turns the on-screen caption of Luke's speech on or off. Nothing here needs
-   * the cipher, and there is no way to enter an invalid value, so the write
-   * either lands or throws.
-   */
-  async setVoiceCaptions(enabled: boolean): Promise<SettingsUpdateResult> {
-    return this.#setField((persisted) => {
-      if (persisted.voiceCaptions === enabled) return;
-      return { ...persisted, voiceCaptions: enabled };
-    });
-  }
-
-  /**
-   * Main-process only, for registration at startup: the talk-key chord the
-   * user chose, or nothing while the defaults stand — the registrar already
-   * carries those.
-   */
-  async readVoiceHotkey(): Promise<string | undefined> {
-    return (await this.#load()).voiceHotkey;
-  }
-
-  /**
-   * Stores the chosen talk-key chord, or returns to the defaults when
-   * omitted. The caller hands in a chord already read into its one canonical
-   * spelling; what arrives here is written as given, so resetting is the
-   * absence of a choice rather than a second stored value.
-   */
-  async setVoiceHotkey(accelerator: string | undefined): Promise<SettingsUpdateResult> {
-    return this.#setField((persisted) => {
-      if (persisted.voiceHotkey === accelerator) return;
-      const next: PersistedSettings = { ...persisted };
-      if (accelerator) next.voiceHotkey = accelerator;
-      else delete next.voiceHotkey;
-      return next;
-    });
-  }
-
-  /**
-   * Main-process only, like the talk key's: the ask-key chord the user chose,
-   * for registration at startup, or nothing while the defaults stand.
-   */
-  async readAskHotkey(): Promise<string | undefined> {
-    return (await this.#load()).askHotkey;
-  }
-
-  /**
-   * Stores the chosen ask-key chord, or returns to the defaults when omitted,
-   * on the talk key's exact terms: the chord arrives already read into its one
-   * canonical spelling, and resetting is the absence of a choice.
-   */
-  async setAskHotkey(accelerator: string | undefined): Promise<SettingsUpdateResult> {
-    return this.#setField((persisted) => {
-      if (persisted.askHotkey === accelerator) return;
-      const next: PersistedSettings = { ...persisted };
-      if (accelerator) next.askHotkey = accelerator;
-      else delete next.askHotkey;
-      return next;
-    });
-  }
-
-  /**
-   * Main-process only, like the other two keys': the stop-key chord the user
-   * chose, for registration at startup, or nothing while the default stands.
-   */
-  async readStopHotkey(): Promise<string | undefined> {
-    return (await this.#load()).stopHotkey;
-  }
-
-  /**
-   * Stores the chosen stop-key chord, or returns to the default when omitted,
-   * on the other two keys' exact terms: the chord arrives already read into
-   * its one canonical spelling, and resetting is the absence of a choice.
-   */
-  async setStopHotkey(accelerator: string | undefined): Promise<SettingsUpdateResult> {
-    return this.#setField((persisted) => {
-      if (persisted.stopHotkey === accelerator) return;
-      const next: PersistedSettings = { ...persisted };
-      if (accelerator) next.stopHotkey = accelerator;
-      else delete next.stopHotkey;
-      return next;
-    });
-  }
-
-  /**
-   * Turns the quieting of Music and Spotify during a spoken exchange on or
-   * off. A plain preference like the caption's: no cipher, no invalid value,
-   * so the write either lands or throws.
-   */
-  async setPreferBuiltInMicrophone(enabled: boolean): Promise<SettingsUpdateResult> {
-    return this.#setField((persisted) => {
-      if (persisted.preferBuiltInMicrophone === enabled) return;
-      return { ...persisted, preferBuiltInMicrophone: enabled };
-    });
-  }
-
-  async setDuckOtherMedia(enabled: boolean): Promise<SettingsUpdateResult> {
-    return this.#setField((persisted) => {
-      if (persisted.duckOtherMedia === enabled) return;
-      return { ...persisted, duckOtherMedia: enabled };
-    });
-  }
-
-  /**
-   * Shallow like `duckOtherMedia()`: every announcement pass asks whether to
-   * hold, and asking must never be what wakes the OS keychain.
-   */
-  async quietDuringMeetings(): Promise<boolean> {
-    return (await this.#load()).quietDuringMeetings;
-  }
-
-  /**
-   * Turns the holding of announcements during meetings on or off. A plain
-   * preference like the media duck's: no cipher, no invalid value, so the
-   * write either lands or throws.
-   */
-  async setQuietDuringMeetings(enabled: boolean): Promise<SettingsUpdateResult> {
-    return this.#setField((persisted) => {
-      if (persisted.quietDuringMeetings === enabled) return;
-      return { ...persisted, quietDuringMeetings: enabled };
-    });
-  }
-
-  /**
-   * Shallow like `showInDock()`: the displays Luke stands on are decided at
-   * launch from the settings file alone, never the keychain.
-   */
-  async readShowOnAllDisplays(): Promise<boolean> {
-    return (await this.#load()).showOnAllDisplays;
-  }
-
-  /**
-   * Remembers whether Luke stands on every display or the main one alone. A
-   * preference like the Dock's, and held to the same rule: nothing here
-   * touches the cipher.
-   */
-  async setShowOnAllDisplays(show: boolean): Promise<SettingsUpdateResult> {
-    return this.#setField((persisted) => {
-      if (persisted.showOnAllDisplays === show) return;
-      return { ...persisted, showOnAllDisplays: show };
-    });
-  }
-
-  /**
-   * Shallow for the same reason as `readShowOnAllDisplays()`: the windows are
-   * placed at launch from the settings file alone, never the keychain.
-   */
-  async readFormFactor(): Promise<PanelFormFactor | undefined> {
-    return (await this.#load()).formFactor;
-  }
-
-  /** Stores the chosen form, or returns to the default when omitted. */
-  async setFormFactor(formFactor: PanelFormFactor | undefined): Promise<SettingsUpdateResult> {
-    return this.#setField((persisted) => {
-      if (persisted.formFactor === formFactor) return;
-      const next: PersistedSettings = { ...persisted };
-      if (formFactor) next.formFactor = formFactor;
-      else delete next.formFactor;
-      return next;
-    });
-  }
-
-  /**
-   * Shallow like `readFormFactor()`: whether a default provider has been
-   * chosen decides only whether a creation saves one, and that answer must
-   * never wake the keychain behind the stored keys.
-   */
-  async readDefaultWorkspaceProvider(): Promise<ProviderId | undefined> {
-    return (await this.#load()).defaultWorkspaceProvider;
-  }
-
-  /**
-   * Stores the provider a nameless creation ask goes to, or returns to asking
-   * each time when omitted. A preference like the form factor's: no cipher,
-   * and the absence of a choice is itself the stored state.
-   */
-  async setDefaultWorkspaceProvider(
-    providerId: ProviderId | undefined,
-  ): Promise<SettingsUpdateResult> {
-    return this.#setField((persisted) => {
-      if (persisted.defaultWorkspaceProvider === providerId) return;
-      const next: PersistedSettings = { ...persisted };
-      if (providerId) next.defaultWorkspaceProvider = providerId;
-      else delete next.defaultWorkspaceProvider;
-      return next;
-    });
-  }
-
-  /**
-   * Shallow like the default provider's read, and read at the same moment: a
-   * creation ask must not wake the keychain to learn which model it carries.
-   */
-  async readWorkspaceAgentDefault(
-    providerId: ProviderId,
-  ): Promise<WorkspaceAgentSelection | undefined> {
-    return (await this.#load()).workspaceAgentDefaults?.[providerId];
-  }
-
-  /**
-   * Stores the agent kind and model one provider starts new workspaces with,
-   * or returns to that provider's own defaults when omitted. One provider's
-   * choice never disturbs another's, the way one provider's key never
-   * disturbs another's ciphertext.
-   */
-  async setWorkspaceAgentDefault(
-    providerId: ProviderId,
-    selection: WorkspaceAgentSelection | undefined,
-  ): Promise<SettingsUpdateResult> {
-    return this.#setField((persisted) => {
-      const current = persisted.workspaceAgentDefaults?.[providerId];
-      if (
-        current?.agent === selection?.agent &&
-        current?.model === selection?.model &&
-        current?.effort === selection?.effort
-      ) {
-        return;
-      }
-      const defaults = { ...persisted.workspaceAgentDefaults };
-      if (selection) defaults[providerId] = selection;
-      else delete defaults[providerId];
-      const next: PersistedSettings = { ...persisted };
-      if (Object.keys(defaults).length > 0) next.workspaceAgentDefaults = defaults;
-      else delete next.workspaceAgentDefaults;
-      return next;
-    });
-  }
-
-  /**
-   * Shallow like the agent default's read, and read at the same moment: a
-   * creation ask must not wake the keychain to learn which project it prefers.
-   */
-  async readWorkspaceProjectDefault(providerId: ProviderId): Promise<string | undefined> {
-    return (await this.#load()).workspaceProjectDefaults?.[providerId];
-  }
-
-  /**
-   * Stores the project one provider creates nameless-ask workspaces in, or
-   * returns to letting the first creation choose when omitted. One provider's
-   * choice never disturbs another's, the way the agent defaults keep apart.
-   */
-  async setWorkspaceProjectDefault(
-    providerId: ProviderId,
-    providerProjectId: string | undefined,
-  ): Promise<SettingsUpdateResult> {
-    return this.#setField((persisted) => {
-      if (persisted.workspaceProjectDefaults?.[providerId] === providerProjectId) return;
-      const defaults = { ...persisted.workspaceProjectDefaults };
-      if (providerProjectId) defaults[providerId] = providerProjectId;
-      else delete defaults[providerId];
-      const next: PersistedSettings = { ...persisted };
-      if (Object.keys(defaults).length > 0) next.workspaceProjectDefaults = defaults;
-      else delete next.workspaceProjectDefaults;
-      return next;
-    });
-  }
-
-  /**
    * Whether the credential Luke speaks through resolved to something this run
    * would use. A run that refuses its credentials does not ask for the key at
    * all: reading a stored one means a Keychain decrypt, which a run that would
@@ -1061,19 +528,6 @@ export class SettingsStore {
   /** Main-process only: the source the minter and the reviewer are built for. */
   async readVoiceSource(): Promise<VoiceSource> {
     return this.#resolveVoiceSource();
-  }
-
-  /**
-   * Chooses which credential Luke runs on. Stored as asked even where it
-   * cannot be honoured yet — choosing the account before signing in is a
-   * standing preference, not a refusal — because the resolution above is what
-   * decides what actually runs, every time it is asked.
-   */
-  async setVoiceSource(source: VoiceSource): Promise<SettingsUpdateResult> {
-    return this.#setField((persisted) => {
-      if (persisted.voiceSource === source) return;
-      return { ...persisted, voiceSource: source };
-    });
   }
 
   /**
@@ -1283,17 +737,6 @@ export class SettingsStore {
   }
 
   /**
-   * Remembers whether Luke stands in the Dock. A preference that never touches
-   * the cipher.
-   */
-  async setShowInDock(show: boolean): Promise<SettingsUpdateResult> {
-    return this.#setField((persisted) => {
-      if (persisted.showInDock === show) return;
-      return { ...persisted, showInDock: show };
-    });
-  }
-
-  /**
    * Returns one group of preferences to its defaults in a single write, by
    * forgetting the choices rather than storing copies of the defaults: an
    * optional field is deleted the way its own clear deletes it, and a plain
@@ -1307,28 +750,11 @@ export class SettingsStore {
   async resetSettings(scope: SettingsResetScope): Promise<SettingsUpdateResult> {
     return this.#setField((persisted) => {
       const next: PersistedSettings = { ...persisted };
-      switch (scope) {
-        case SETTINGS_RESET_SCOPE.VOICE:
-          delete next.voice;
-          delete next.voiceSpeed;
-          next.voiceCaptions = APP_SETTING_DEFAULTS.voiceCaptions;
-          next.duckOtherMedia = APP_SETTING_DEFAULTS.duckOtherMedia;
-          next.preferBuiltInMicrophone = APP_SETTING_DEFAULTS.preferBuiltInMicrophone;
-          break;
-        case SETTINGS_RESET_SCOPE.APPEARANCE:
-          next.showInDock = APP_SETTING_DEFAULTS.showInDock;
-          next.showOnAllDisplays = APP_SETTING_DEFAULTS.showOnAllDisplays;
-          delete next.formFactor;
-          break;
-        case SETTINGS_RESET_SCOPE.SHORTCUTS:
-          delete next.voiceHotkey;
-          delete next.askHotkey;
-          delete next.stopHotkey;
-          break;
-        case SETTINGS_RESET_SCOPE.WORKSPACES:
-          delete next.defaultWorkspaceProvider;
-          delete next.workspaceProjectDefaults;
-          break;
+      for (const field of APP_SETTING_FIELDS) {
+        const definition = APP_SETTING_SCHEMA[field];
+        if (!("resetScope" in definition) || definition.resetScope !== scope) continue;
+        if (definition.guard(undefined).valid) delete next[field];
+        else Object.assign(next, { [field]: definition.default });
       }
       const changed = (Object.keys(persisted) as (keyof PersistedSettings)[]).some(
         (field) => next[field] !== persisted[field],
@@ -1448,7 +874,12 @@ export class SettingsStore {
     let persisted: PersistedSettings = {
       version: SETTINGS_FILE_VERSION,
       apiKeys: {},
-      ...APP_SETTING_DEFAULTS,
+      ...(Object.fromEntries(
+        APP_SETTING_FIELDS.map((field) => [
+          field,
+          APP_SETTING_SCHEMA[field].guard(undefined).value,
+        ]),
+      ) as unknown as StoredAppSettings),
     };
     if (source) {
       try {

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -27,8 +27,27 @@ import type {
 } from "@sidecar/core";
 import type { CredentialProviderId } from "./credential-providers";
 import type { FeedbackKind, FeedbackResult, FeedbackSubmission } from "./feedback";
+import type {
+  AppSettingField,
+  AppSettingValue,
+  SettingsResetScope,
+  VoiceSource,
+} from "./settings-schema";
 
 export type { WindowMode } from "@sidecar/core";
+export type {
+  AppSettingField,
+  AppSettingValue,
+  SettingsResetScope,
+  VoiceSource,
+} from "./settings-schema";
+export {
+  APP_SETTING_DEFAULTS,
+  isSettingsResetScope,
+  isVoiceSource,
+  SETTINGS_RESET_SCOPE,
+  VOICE_SOURCE,
+} from "./settings-schema";
 
 export const ACCOUNT_PROVIDER = {
   GOOGLE: "google",
@@ -130,51 +149,6 @@ export interface ObservedAccountCalendars {
  * being spent — without one, connecting a key would be the choice, and the
  * only way back would be deleting it.
  */
-export const VOICE_SOURCE = {
-  ACCOUNT: "account",
-  KEY: "key",
-} as const;
-
-export type VoiceSource = (typeof VOICE_SOURCE)[keyof typeof VOICE_SOURCE];
-
-/** Guards the source an IPC message carries, which the renderer chooses. */
-export function isVoiceSource(value: unknown): value is VoiceSource {
-  return value === VOICE_SOURCE.ACCOUNT || value === VOICE_SOURCE.KEY;
-}
-
-export const APP_SETTING_DEFAULTS = {
-  showInDock: false,
-  voiceCaptions: false,
-  duckOtherMedia: true,
-  preferBuiltInMicrophone: true,
-  quietDuringMeetings: true,
-  showOnAllDisplays: false,
-} as const satisfies Partial<Record<keyof AppSettings, boolean>>;
-
-/**
- * The groups of preferences a reset control returns to their defaults, each
- * scoped to exactly the rows the control stands over: a settings page, or the
- * Workspaces group on the Connections page. A fixed vocabulary rather than a
- * field list on the wire, so a renderer can only ever name a grouping this
- * build documents — and no scope reaches a credential, an account, or the
- * Conductor agent pairing, whose own row already offers its default.
- */
-export const SETTINGS_RESET_SCOPE = {
-  VOICE: "voice",
-  APPEARANCE: "appearance",
-  SHORTCUTS: "shortcuts",
-  WORKSPACES: "workspaces",
-} as const;
-
-export type SettingsResetScope = (typeof SETTINGS_RESET_SCOPE)[keyof typeof SETTINGS_RESET_SCOPE];
-
-const SETTINGS_RESET_SCOPE_LIST: readonly SettingsResetScope[] =
-  Object.values(SETTINGS_RESET_SCOPE);
-
-export function isSettingsResetScope(value: unknown): value is SettingsResetScope {
-  return SETTINGS_RESET_SCOPE_LIST.includes(value as SettingsResetScope);
-}
-
 /**
  * Where the app stands against the latest published release, as last learned.
  * `UNKNOWN` is the state before any check has answered — at launch, and
@@ -571,63 +545,17 @@ export interface AppBridge {
     providerId: CredentialProviderId,
     apiKey: string | undefined,
   ): Promise<SettingsUpdateResult>;
-  /**
-   * Chooses the voice Luke speaks with, from the set fixed by this build. It
-   * reaches the next conversation to connect; the renderer makes it heard now
-   * by reopening a call already up, because the API locks a session's voice
-   * once the model has spoken.
-   */
-  setVoice(voice: RealtimeVoice): Promise<SettingsUpdateResult>;
-  /**
-   * Chooses the pace Luke speaks at, from the set fixed by this build. It
-   * reaches the next conversation the way the voice does, and the renderer
-   * carries it onto a call already open as a session update.
-   */
-  setVoiceSpeed(speed: RealtimeVoiceSpeed): Promise<SettingsUpdateResult>;
+  /** Updates one declared preference; main validates its field and value again. */
+  updateSetting<Field extends AppSettingField>(
+    field: Field,
+    value: AppSettingValue<Field>,
+  ): Promise<SettingsUpdateResult>;
   /**
    * Opens a provider's own API-key page in the default browser. The renderer
    * names the provider, not the address, so the set of pages Luke can open is
    * fixed by this build.
    */
   openProviderApiKeys(providerId: CredentialProviderId): void;
-  /** Shows or hides the Dock icon, and remembers the choice. */
-  setShowInDock(show: boolean): Promise<SettingsUpdateResult>;
-  /**
-   * Stands Luke on every connected display, or brings him back to the main
-   * one alone, and remembers the choice.
-   */
-  setShowOnAllDisplays(show: boolean): Promise<SettingsUpdateResult>;
-  /** Chooses how Luke stands on a display without a housing, and remembers it. */
-  setFormFactor(formFactor: PanelFormFactor): Promise<SettingsUpdateResult>;
-  /**
-   * Chooses the provider a conversational ask creates a workspace in when the
-   * ask names none, or returns to asking each time when omitted. The same
-   * store write the main process makes on the first creation, offered to the
-   * settings row so the choice can be changed or cleared by hand.
-   */
-  setDefaultWorkspaceProvider(providerId: ProviderId | undefined): Promise<SettingsUpdateResult>;
-  /**
-   * Chooses the agent kind and model one provider starts new workspaces with,
-   * or returns to that provider's own defaults when omitted. The pairing must
-   * be one the build's documented table lists for the provider; the main
-   * process validates it again before the store keeps it.
-   */
-  setWorkspaceAgentDefault(
-    providerId: ProviderId,
-    selection: WorkspaceAgentSelection | undefined,
-  ): Promise<SettingsUpdateResult>;
-  /**
-   * Chooses the project one provider creates nameless-ask workspaces in, or
-   * returns to letting the first creation choose when omitted. The project
-   * must be one the provider's adapter currently offers; the main process
-   * validates that again before the store keeps it.
-   */
-  setWorkspaceProjectDefault(
-    providerId: ProviderId,
-    providerProjectId: string | undefined,
-  ): Promise<SettingsUpdateResult>;
-  /** Turns the on-screen caption of Luke's speech on or off. */
-  setVoiceCaptions(enabled: boolean): Promise<SettingsUpdateResult>;
   /**
    * Returns one group of preferences to its defaults in a single stored write:
    * the choices behind the named scope are forgotten, the way each row's own
@@ -636,17 +564,6 @@ export interface AppBridge {
    * fixed by this build, never a field list, and no scope reaches a credential.
    */
   resetSettings(scope: SettingsResetScope): Promise<SettingsUpdateResult>;
-  /** Turns the quieting of Music and Spotify during a spoken exchange on or off. */
-  setDuckOtherMedia(enabled: boolean): Promise<SettingsUpdateResult>;
-  /**
-   * Chooses which credential Luke speaks and reviews sessions on. A choice
-   * only ever withholds a stored key while the account can serve instead — it
-   * can turn spending off, never on, so nothing here can start spending a key
-   * that is not there or an allowance that is not signed in.
-   */
-  setVoiceSource(source: VoiceSource): Promise<SettingsUpdateResult>;
-  /** Turns the Mac-microphone-over-Bluetooth-headset preference on or off. */
-  setPreferBuiltInMicrophone(enabled: boolean): Promise<SettingsUpdateResult>;
   /**
    * Asks GitHub for the latest release name, right now, because the row's
    * button was pressed. The answer is the same snapshot the broadcast
@@ -659,11 +576,6 @@ export interface AppBridge {
    * process, so nothing an update check read can steer where this goes.
    */
   openLatestRelease(): void;
-  /**
-   * Turns the holding of announcements during calendar meetings on or off.
-   * The hold itself lives in the main process, beside the calendar it reads.
-   */
-  setQuietDuringMeetings(enabled: boolean): Promise<SettingsUpdateResult>;
   /**
    * Runs the Google Calendar sign-in: the browser opens Google's own consent
    * page, the grant comes back over a loopback redirect that never leaves the
@@ -704,26 +616,6 @@ export interface AppBridge {
    * because the exchange must never wait on the players.
    */
   setVoiceExchangeActive(active: boolean): void;
-  /**
-   * Moves the talk key to a chord of the user's own, or back to the defaults
-   * when omitted. The change is registered with the system at once, and the
-   * key the panel shows follows the same announcement it always has.
-   */
-  setVoiceHotkey(accelerator: string | undefined): Promise<SettingsUpdateResult>;
-  /**
-   * Moves the ask key the same way, or back to its defaults when omitted. The
-   * one extra rule is the standing one: a chord the talk key holds — or could
-   * fall back to on a later launch — is refused with a reason rather than
-   * stored and left to race it.
-   */
-  setAskHotkey(accelerator: string | undefined): Promise<SettingsUpdateResult>;
-  /**
-   * Moves the stop key the same way, or back to its default when omitted,
-   * under the same standing rule one rung further down: a chord either other
-   * Luke key holds — or could fall back to — is refused with a reason rather
-   * than stored and left to race it.
-   */
-  setStopHotkey(accelerator: string | undefined): Promise<SettingsUpdateResult>;
   /**
    * Opens an observed session where its provider keeps it. The renderer names
    * the session rather than its address, for the same reason it names a
@@ -942,16 +834,7 @@ export const channels = {
   microphoneRoute: "app:microphone-route",
   openMicrophoneSettings: "app:open-microphone-settings",
   setProviderApiKey: "app:set-provider-api-key",
-  setVoice: "app:set-voice",
-  setVoiceSpeed: "app:set-voice-speed",
-  setVoiceCaptions: "app:set-voice-captions",
-  setVoiceHotkey: "app:set-voice-hotkey",
-  setAskHotkey: "app:set-ask-hotkey",
-  setStopHotkey: "app:set-stop-hotkey",
-  setDuckOtherMedia: "app:set-duck-other-media",
-  setVoiceSource: "app:set-voice-source",
-  setPreferBuiltInMicrophone: "app:set-prefer-built-in-microphone",
-  setQuietDuringMeetings: "app:set-quiet-during-meetings",
+  updateSetting: "app:update-setting",
   connectGoogleCalendar: "app:connect-google-calendar",
   cancelGoogleCalendarSignIn: "app:cancel-google-calendar-sign-in",
   reopenGoogleCalendarSignIn: "app:reopen-google-calendar-sign-in",
@@ -964,12 +847,6 @@ export const channels = {
   updateChanged: "app:update-changed",
   setVoiceExchange: "app:set-voice-exchange",
   openProviderApiKeys: "app:open-provider-api-keys",
-  setShowInDock: "app:set-show-in-dock",
-  setShowOnAllDisplays: "app:set-show-on-all-displays",
-  setFormFactor: "app:set-form-factor",
-  setDefaultWorkspaceProvider: "app:set-default-workspace-provider",
-  setWorkspaceAgentDefault: "app:set-workspace-agent-default",
-  setWorkspaceProjectDefault: "app:set-workspace-project-default",
   resetSettings: "app:reset-settings",
   openSession: "app:open-session",
   openSessionChange: "app:open-session-change",

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -30,6 +30,8 @@ import type { FeedbackKind, FeedbackResult, FeedbackSubmission } from "./feedbac
 import type {
   AppSettingField,
   AppSettingValue,
+  KeyedAppSettingField,
+  SettingEntryValue,
   SettingsResetScope,
   VoiceSource,
 } from "./settings-schema";
@@ -38,6 +40,8 @@ export type { WindowMode } from "@sidecar/core";
 export type {
   AppSettingField,
   AppSettingValue,
+  KeyedAppSettingField,
+  SettingEntryValue,
   SettingsResetScope,
   VoiceSource,
 } from "./settings-schema";
@@ -551,6 +555,17 @@ export interface AppBridge {
     value: AppSettingValue<Field>,
   ): Promise<SettingsUpdateResult>;
   /**
+   * Updates one key of a map-valued preference, or forgets it when the value is
+   * omitted. Named rather than merged here because the renderer cannot hold the
+   * store's lock across the bridge: a map merged from a snapshot this side would
+   * put back whatever a write it overlapped had already stored.
+   */
+  updateSettingEntry<Field extends KeyedAppSettingField>(
+    field: Field,
+    key: string,
+    value: SettingEntryValue<Field> | undefined,
+  ): Promise<SettingsUpdateResult>;
+  /**
    * Opens a provider's own API-key page in the default browser. The renderer
    * names the provider, not the address, so the set of pages Luke can open is
    * fixed by this build.
@@ -835,6 +850,7 @@ export const channels = {
   openMicrophoneSettings: "app:open-microphone-settings",
   setProviderApiKey: "app:set-provider-api-key",
   updateSetting: "app:update-setting",
+  updateSettingEntry: "app:update-setting-entry",
   connectGoogleCalendar: "app:connect-google-calendar",
   cancelGoogleCalendarSignIn: "app:cancel-google-calendar-sign-in",
   reopenGoogleCalendarSignIn: "app:reopen-google-calendar-sign-in",

--- a/apps/desktop/src/shared/settings-schema.ts
+++ b/apps/desktop/src/shared/settings-schema.ts
@@ -1,0 +1,419 @@
+import {
+  APP_TOGGLE_VALUE,
+  DEFAULT_PANEL_FORM_FACTOR,
+  isPanelFormFactor,
+  isProviderId,
+  isRealtimeVoice,
+  isRealtimeVoiceSpeed,
+  type PanelFormFactor,
+  type ProviderId,
+  REALTIME_DEFAULTS,
+  type RealtimeVoice,
+  type RealtimeVoiceSpeed,
+  type WorkspaceAgentSelection,
+} from "@sidecar/core";
+import { parseVoiceHotkey } from "./voice-hotkey";
+import { isWorkspaceAgentSelection } from "./workspace-agents";
+
+export const APP_SETTING_ID = {
+  VOICE: "voice",
+  VOICE_SPEED: "voice_speed",
+  VOICE_CAPTIONS: "voice_captions",
+  DUCK_OTHER_MEDIA: "duck_other_media",
+  PREFER_BUILT_IN_MICROPHONE: "prefer_built_in_microphone",
+  QUIET_DURING_MEETINGS: "quiet_during_meetings",
+  SHOW_IN_DOCK: "show_in_dock",
+  SHOW_ON_ALL_DISPLAYS: "show_on_all_displays",
+  FORM_FACTOR: "form_factor",
+  DEFAULT_WORKSPACE_PROVIDER: "default_workspace_provider",
+  WORKSPACE_AGENT_MODEL: "workspace_agent_model",
+  WORKSPACE_AGENT_EFFORT: "workspace_agent_effort",
+  VOICE_SOURCE: "voice_source",
+} as const;
+
+export type AppSettingId = (typeof APP_SETTING_ID)[keyof typeof APP_SETTING_ID];
+
+export const VOICE_SOURCE = {
+  ACCOUNT: "account",
+  KEY: "key",
+} as const;
+
+export type VoiceSource = (typeof VOICE_SOURCE)[keyof typeof VOICE_SOURCE];
+
+export function isVoiceSource(value: unknown): value is VoiceSource {
+  return value === VOICE_SOURCE.ACCOUNT || value === VOICE_SOURCE.KEY;
+}
+
+export const SETTINGS_PAGE = {
+  ROOT: "root",
+  VOICE: "voice",
+  APPEARANCE: "appearance",
+  SHORTCUTS: "shortcuts",
+  CONNECTIONS: "connections",
+} as const;
+
+export type SettingsPage = (typeof SETTINGS_PAGE)[keyof typeof SETTINGS_PAGE];
+
+export const SETTINGS_RESET_SCOPE = {
+  VOICE: "voice",
+  APPEARANCE: "appearance",
+  SHORTCUTS: "shortcuts",
+  WORKSPACES: "workspaces",
+} as const;
+
+export type SettingsResetScope = (typeof SETTINGS_RESET_SCOPE)[keyof typeof SETTINGS_RESET_SCOPE];
+
+export const SETTING_SIDE_EFFECT = {
+  NONE: "none",
+  DOCK: "dock",
+  DISPLAYS: "displays",
+  FORM_FACTOR: "form-factor",
+  VOICE: "voice",
+  VOICE_SPEED: "voice-speed",
+  TALK_HOTKEY: "talk-hotkey",
+  ASK_HOTKEY: "ask-hotkey",
+  STOP_HOTKEY: "stop-hotkey",
+  MEDIA_DUCK: "media-duck",
+  VOICE_SOURCE: "voice-source",
+  MEETING_QUIET: "meeting-quiet",
+} as const;
+
+export type SettingSideEffect = (typeof SETTING_SIDE_EFFECT)[keyof typeof SETTING_SIDE_EFFECT];
+
+export interface StoredAppSettings {
+  showInDock: boolean;
+  voice?: RealtimeVoice;
+  voiceSpeed?: RealtimeVoiceSpeed;
+  voiceCaptions: boolean;
+  voiceHotkey?: string;
+  askHotkey?: string;
+  stopHotkey?: string;
+  duckOtherMedia: boolean;
+  voiceSource?: VoiceSource;
+  preferBuiltInMicrophone: boolean;
+  quietDuringMeetings: boolean;
+  showOnAllDisplays: boolean;
+  formFactor?: PanelFormFactor;
+  defaultWorkspaceProvider?: ProviderId;
+  workspaceAgentDefaults?: Readonly<Partial<Record<ProviderId, WorkspaceAgentSelection>>>;
+  workspaceProjectDefaults?: Readonly<Partial<Record<ProviderId, string>>>;
+}
+
+export type AppSettingField = keyof StoredAppSettings;
+export type AppSettingValue<Field extends AppSettingField> = StoredAppSettings[Field];
+
+export interface SettingGuardResult<Value> {
+  valid: boolean;
+  value: Value;
+}
+
+interface SettingDefinition<Field extends AppSettingField> {
+  field: Field;
+  default: AppSettingValue<Field>;
+  guard(value: unknown): SettingGuardResult<AppSettingValue<Field>>;
+  settingsPage: SettingsPage;
+  resetScope?: SettingsResetScope;
+  guideEntry: AppSettingId | readonly AppSettingId[] | undefined;
+  mainProcessSideEffect: SettingSideEffect;
+  spokenValue?: (value: string) => AppSettingValue<Field> | undefined;
+}
+
+const valid = <Value>(value: Value): SettingGuardResult<Value> => ({ valid: true, value });
+const invalid = <Value>(value: Value): SettingGuardResult<Value> => ({ valid: false, value });
+
+function optional<Value>(
+  value: unknown,
+  guard: (candidate: unknown) => candidate is Value,
+): SettingGuardResult<Value | undefined> {
+  if (value === undefined) return valid(undefined);
+  return guard(value) ? valid(value) : invalid(undefined);
+}
+
+function boolean(defaultValue: boolean) {
+  return (value: unknown): SettingGuardResult<boolean> =>
+    typeof value === "boolean" ? valid(value) : invalid(defaultValue);
+}
+
+function hotkey(value: unknown): SettingGuardResult<string | undefined> {
+  if (value === undefined) return valid(undefined);
+  if (typeof value !== "string") return invalid(undefined);
+  const parsed = parseVoiceHotkey(value);
+  return parsed ? valid(parsed) : invalid(undefined);
+}
+
+function workspaceAgentDefaults(
+  value: unknown,
+): SettingGuardResult<StoredAppSettings["workspaceAgentDefaults"]> {
+  if (value === undefined) return valid(undefined);
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return invalid(undefined);
+  }
+  const defaults: Partial<Record<ProviderId, WorkspaceAgentSelection>> = {};
+  for (const [providerId, selection] of Object.entries(value)) {
+    if (!isProviderId(providerId) || !isWorkspaceAgentSelection(providerId, selection)) continue;
+    defaults[providerId] = selection;
+  }
+  return valid(Object.keys(defaults).length > 0 ? defaults : undefined);
+}
+
+const MAXIMUM_WORKSPACE_PROJECT_ID_LENGTH = 200;
+
+function workspaceProjectDefaults(
+  value: unknown,
+): SettingGuardResult<StoredAppSettings["workspaceProjectDefaults"]> {
+  if (value === undefined) return valid(undefined);
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return invalid(undefined);
+  }
+  const defaults: Partial<Record<ProviderId, string>> = {};
+  for (const [providerId, candidate] of Object.entries(value)) {
+    if (!isProviderId(providerId) || typeof candidate !== "string") continue;
+    const providerProjectId = candidate.trim();
+    if (!providerProjectId || providerProjectId.length > MAXIMUM_WORKSPACE_PROJECT_ID_LENGTH) {
+      continue;
+    }
+    defaults[providerId] = providerProjectId;
+  }
+  return valid(Object.keys(defaults).length > 0 ? defaults : undefined);
+}
+
+export const APP_SETTING_SCHEMA = {
+  showInDock: {
+    field: "showInDock",
+    default: false,
+    guard: boolean(false),
+    settingsPage: SETTINGS_PAGE.APPEARANCE,
+    resetScope: SETTINGS_RESET_SCOPE.APPEARANCE,
+    guideEntry: APP_SETTING_ID.SHOW_IN_DOCK,
+    mainProcessSideEffect: SETTING_SIDE_EFFECT.DOCK,
+    spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
+  },
+  voice: {
+    field: "voice",
+    default: REALTIME_DEFAULTS.VOICE,
+    guard: (value: unknown) => optional(value, isRealtimeVoice),
+    settingsPage: SETTINGS_PAGE.VOICE,
+    resetScope: SETTINGS_RESET_SCOPE.VOICE,
+    guideEntry: APP_SETTING_ID.VOICE,
+    mainProcessSideEffect: SETTING_SIDE_EFFECT.VOICE,
+    spokenValue: (value: string) => (isRealtimeVoice(value) ? value : undefined),
+  },
+  voiceSpeed: {
+    field: "voiceSpeed",
+    default: REALTIME_DEFAULTS.SPEED,
+    guard: (value: unknown) => optional(value, isRealtimeVoiceSpeed),
+    settingsPage: SETTINGS_PAGE.VOICE,
+    resetScope: SETTINGS_RESET_SCOPE.VOICE,
+    guideEntry: APP_SETTING_ID.VOICE_SPEED,
+    mainProcessSideEffect: SETTING_SIDE_EFFECT.VOICE_SPEED,
+    spokenValue: (value: string) => {
+      const words: Record<string, RealtimeVoiceSpeed> = {
+        slow: 0.75,
+        normal: 1,
+        quick: 1.25,
+        fast: 1.5,
+        "0.75×": 0.75,
+        "1×": 1,
+        "1.25×": 1.25,
+        "1.5×": 1.5,
+      };
+      return words[value];
+    },
+  },
+  voiceCaptions: {
+    field: "voiceCaptions",
+    default: false,
+    guard: boolean(false),
+    settingsPage: SETTINGS_PAGE.VOICE,
+    resetScope: SETTINGS_RESET_SCOPE.VOICE,
+    guideEntry: APP_SETTING_ID.VOICE_CAPTIONS,
+    mainProcessSideEffect: SETTING_SIDE_EFFECT.NONE,
+    spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
+  },
+  voiceHotkey: {
+    field: "voiceHotkey",
+    default: undefined,
+    guard: hotkey,
+    settingsPage: SETTINGS_PAGE.SHORTCUTS,
+    resetScope: SETTINGS_RESET_SCOPE.SHORTCUTS,
+    guideEntry: undefined,
+    mainProcessSideEffect: SETTING_SIDE_EFFECT.TALK_HOTKEY,
+  },
+  askHotkey: {
+    field: "askHotkey",
+    default: undefined,
+    guard: hotkey,
+    settingsPage: SETTINGS_PAGE.SHORTCUTS,
+    resetScope: SETTINGS_RESET_SCOPE.SHORTCUTS,
+    guideEntry: undefined,
+    mainProcessSideEffect: SETTING_SIDE_EFFECT.ASK_HOTKEY,
+  },
+  stopHotkey: {
+    field: "stopHotkey",
+    default: undefined,
+    guard: hotkey,
+    settingsPage: SETTINGS_PAGE.SHORTCUTS,
+    resetScope: SETTINGS_RESET_SCOPE.SHORTCUTS,
+    guideEntry: undefined,
+    mainProcessSideEffect: SETTING_SIDE_EFFECT.STOP_HOTKEY,
+  },
+  duckOtherMedia: {
+    field: "duckOtherMedia",
+    default: true,
+    guard: boolean(true),
+    settingsPage: SETTINGS_PAGE.VOICE,
+    resetScope: SETTINGS_RESET_SCOPE.VOICE,
+    guideEntry: APP_SETTING_ID.DUCK_OTHER_MEDIA,
+    mainProcessSideEffect: SETTING_SIDE_EFFECT.MEDIA_DUCK,
+    spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
+  },
+  voiceSource: {
+    field: "voiceSource",
+    default: undefined,
+    guard: (value: unknown) => optional(value, isVoiceSource),
+    settingsPage: SETTINGS_PAGE.ROOT,
+    guideEntry: APP_SETTING_ID.VOICE_SOURCE,
+    mainProcessSideEffect: SETTING_SIDE_EFFECT.VOICE_SOURCE,
+  },
+  preferBuiltInMicrophone: {
+    field: "preferBuiltInMicrophone",
+    default: true,
+    guard: boolean(true),
+    settingsPage: SETTINGS_PAGE.VOICE,
+    resetScope: SETTINGS_RESET_SCOPE.VOICE,
+    guideEntry: APP_SETTING_ID.PREFER_BUILT_IN_MICROPHONE,
+    mainProcessSideEffect: SETTING_SIDE_EFFECT.NONE,
+    spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
+  },
+  quietDuringMeetings: {
+    field: "quietDuringMeetings",
+    default: true,
+    guard: boolean(true),
+    settingsPage: SETTINGS_PAGE.CONNECTIONS,
+    guideEntry: APP_SETTING_ID.QUIET_DURING_MEETINGS,
+    mainProcessSideEffect: SETTING_SIDE_EFFECT.MEETING_QUIET,
+    spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
+  },
+  showOnAllDisplays: {
+    field: "showOnAllDisplays",
+    default: false,
+    guard: boolean(false),
+    settingsPage: SETTINGS_PAGE.APPEARANCE,
+    resetScope: SETTINGS_RESET_SCOPE.APPEARANCE,
+    guideEntry: APP_SETTING_ID.SHOW_ON_ALL_DISPLAYS,
+    mainProcessSideEffect: SETTING_SIDE_EFFECT.DISPLAYS,
+    spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
+  },
+  formFactor: {
+    field: "formFactor",
+    default: DEFAULT_PANEL_FORM_FACTOR,
+    guard: (value: unknown) => optional(value, isPanelFormFactor),
+    settingsPage: SETTINGS_PAGE.APPEARANCE,
+    resetScope: SETTINGS_RESET_SCOPE.APPEARANCE,
+    guideEntry: APP_SETTING_ID.FORM_FACTOR,
+    mainProcessSideEffect: SETTING_SIDE_EFFECT.FORM_FACTOR,
+    spokenValue: (value: string) => (isPanelFormFactor(value) ? value : undefined),
+  },
+  defaultWorkspaceProvider: {
+    field: "defaultWorkspaceProvider",
+    default: undefined,
+    guard: (value: unknown) =>
+      optional(
+        value,
+        (candidate): candidate is ProviderId =>
+          typeof candidate === "string" && isProviderId(candidate),
+      ),
+    settingsPage: SETTINGS_PAGE.CONNECTIONS,
+    resetScope: SETTINGS_RESET_SCOPE.WORKSPACES,
+    guideEntry: APP_SETTING_ID.DEFAULT_WORKSPACE_PROVIDER,
+    mainProcessSideEffect: SETTING_SIDE_EFFECT.NONE,
+  },
+  workspaceAgentDefaults: {
+    field: "workspaceAgentDefaults",
+    default: undefined,
+    guard: workspaceAgentDefaults,
+    settingsPage: SETTINGS_PAGE.CONNECTIONS,
+    guideEntry: [APP_SETTING_ID.WORKSPACE_AGENT_MODEL, APP_SETTING_ID.WORKSPACE_AGENT_EFFORT],
+    mainProcessSideEffect: SETTING_SIDE_EFFECT.NONE,
+  },
+  workspaceProjectDefaults: {
+    field: "workspaceProjectDefaults",
+    default: undefined,
+    guard: workspaceProjectDefaults,
+    settingsPage: SETTINGS_PAGE.CONNECTIONS,
+    resetScope: SETTINGS_RESET_SCOPE.WORKSPACES,
+    guideEntry: undefined,
+    mainProcessSideEffect: SETTING_SIDE_EFFECT.NONE,
+  },
+} as const satisfies {
+  [Field in AppSettingField]: SettingDefinition<Field>;
+};
+
+export const APP_SETTING_FIELDS = Object.keys(APP_SETTING_SCHEMA) as AppSettingField[];
+
+export function isAppSettingField(value: unknown): value is AppSettingField {
+  return typeof value === "string" && value in APP_SETTING_SCHEMA;
+}
+
+export function isSettingsResetScope(value: unknown): value is SettingsResetScope {
+  return Object.values(SETTINGS_RESET_SCOPE).includes(value as SettingsResetScope);
+}
+
+export function isAppSettingId(value: string): value is AppSettingId {
+  return Object.values(APP_SETTING_ID).includes(value as AppSettingId);
+}
+
+export function settingFieldForGuideId(id: AppSettingId): AppSettingField | undefined {
+  return APP_SETTING_FIELDS.find((field) => {
+    const entry = APP_SETTING_SCHEMA[field].guideEntry;
+    return Array.isArray(entry) ? entry.includes(id) : entry === id;
+  });
+}
+
+export function spokenSettingValue(
+  field: AppSettingField,
+  value: string,
+): StoredAppSettings[AppSettingField] {
+  const definition = APP_SETTING_SCHEMA[field];
+  const convert = ("spokenValue" in definition ? definition.spokenValue : undefined) as
+    | ((candidate: string) => StoredAppSettings[AppSettingField])
+    | undefined;
+  return convert?.(value);
+}
+
+export const APP_SETTING_DEFAULTS = {
+  showInDock: APP_SETTING_SCHEMA.showInDock.default,
+  voice: REALTIME_DEFAULTS.VOICE,
+  voiceSpeed: REALTIME_DEFAULTS.SPEED,
+  voiceCaptions: APP_SETTING_SCHEMA.voiceCaptions.default,
+  duckOtherMedia: APP_SETTING_SCHEMA.duckOtherMedia.default,
+  preferBuiltInMicrophone: APP_SETTING_SCHEMA.preferBuiltInMicrophone.default,
+  quietDuringMeetings: APP_SETTING_SCHEMA.quietDuringMeetings.default,
+  showOnAllDisplays: APP_SETTING_SCHEMA.showOnAllDisplays.default,
+  formFactor: DEFAULT_PANEL_FORM_FACTOR,
+} as const;
+
+export const SETTING_PAGE = Object.fromEntries(
+  Object.values(APP_SETTING_SCHEMA).flatMap((definition) => {
+    const entries = definition.guideEntry;
+    if (entries === undefined) return [];
+    return (Array.isArray(entries) ? entries : [entries]).map((id) => [
+      id,
+      definition.settingsPage,
+    ]);
+  }),
+) as Record<AppSettingId, SettingsPage>;
+
+export function settingsScopeChanged(
+  settings: Pick<StoredAppSettings, AppSettingField>,
+  scope: SettingsResetScope,
+): boolean {
+  return APP_SETTING_FIELDS.some((field) => {
+    const definition = APP_SETTING_SCHEMA[field];
+    if (!("resetScope" in definition) || definition.resetScope !== scope) return false;
+    const current = settings[field];
+    const defaultValue = definition.default;
+    if (current === undefined || defaultValue === undefined) return current !== defaultValue;
+    return current !== defaultValue;
+  });
+}

--- a/apps/desktop/src/shared/settings-schema.ts
+++ b/apps/desktop/src/shared/settings-schema.ts
@@ -1,19 +1,31 @@
 import {
+  APP_SETTING_KIND,
   APP_TOGGLE_VALUE,
+  type AppGuideSetting,
+  appToggleText,
   DEFAULT_PANEL_FORM_FACTOR,
   isPanelFormFactor,
   isProviderId,
   isRealtimeVoice,
   isRealtimeVoiceSpeed,
+  PANEL_FORM_FACTOR_LIST,
   type PanelFormFactor,
+  PROVIDER_ID,
   type ProviderId,
   REALTIME_DEFAULTS,
+  REALTIME_VOICE_LIST,
+  REALTIME_VOICE_SPEED,
   type RealtimeVoice,
   type RealtimeVoiceSpeed,
   type WorkspaceAgentSelection,
 } from "@sidecar/core";
+import { CREDENTIAL_PROVIDERS, isCredentialProviderId } from "./credential-providers";
 import { parseVoiceHotkey } from "./voice-hotkey";
-import { isWorkspaceAgentSelection } from "./workspace-agents";
+import {
+  isWorkspaceAgentSelection,
+  workspaceAgentModelLabel,
+  workspaceAgentModels,
+} from "./workspace-agents";
 
 export const APP_SETTING_ID = {
   VOICE: "voice",
@@ -113,9 +125,85 @@ interface SettingDefinition<Field extends AppSettingField> {
   guard(value: unknown): SettingGuardResult<AppSettingValue<Field>>;
   settingsPage: SettingsPage;
   resetScope?: SettingsResetScope;
-  guideEntry: AppSettingId | readonly AppSettingId[] | undefined;
+  guideEntry: {
+    ids: readonly AppSettingId[];
+    build(
+      settings: AppSettingGuideSettings,
+      defaultValue: AppSettingValue<Field>,
+    ): AppGuideSetting | readonly AppGuideSetting[] | undefined;
+  };
   mainProcessSideEffect: SettingSideEffect;
   spokenValue?: (value: string) => AppSettingValue<Field> | undefined;
+}
+
+export type AppSettingGuideSettings = Omit<
+  StoredAppSettings,
+  "voice" | "voiceSpeed" | "voiceSource" | "formFactor"
+> & {
+  voice: RealtimeVoice;
+  voiceSpeed: RealtimeVoiceSpeed;
+  voiceSource: VoiceSource;
+  formFactor: PanelFormFactor;
+};
+
+const SETTINGS_TAB = "the panel's Settings tab";
+const VOICE_PAGE = `${SETTINGS_TAB}, on its Voice page`;
+const VOICE_SOURCE_SECTION = `${SETTINGS_TAB}, on its front page, in the What Luke runs on section at the top`;
+const APPEARANCE_PAGE = `${SETTINGS_TAB}, on its Appearance page`;
+const CONNECTIONS_PAGE = `${SETTINGS_TAB}, on its Connections page`;
+const CONDUCTOR_ROW_PATH = `the Conductor row under Cloud Agent API keys, in ${CONNECTIONS_PAGE} — drawn once Conductor is connected`;
+const CONDUCTOR_DEFAULT_CHOICE = "Conductor's default";
+const ASK_EACH_TIME_CHOICE = "ask each time";
+
+const VOICE_SOURCE_CHOICE: Record<VoiceSource, string> = {
+  [VOICE_SOURCE.ACCOUNT]: "your Luke account",
+  [VOICE_SOURCE.KEY]: "your OpenAI key",
+};
+
+const VOICE_SPEED_WORD = {
+  SLOW: "slow",
+  NORMAL: "normal",
+  QUICK: "quick",
+  FAST: "fast",
+} as const;
+
+const VOICE_SPEED_WORDS = [
+  { word: VOICE_SPEED_WORD.SLOW, speed: REALTIME_VOICE_SPEED.SLOW },
+  { word: VOICE_SPEED_WORD.NORMAL, speed: REALTIME_VOICE_SPEED.NORMAL },
+  { word: VOICE_SPEED_WORD.QUICK, speed: REALTIME_VOICE_SPEED.QUICK },
+  { word: VOICE_SPEED_WORD.FAST, speed: REALTIME_VOICE_SPEED.FAST },
+] as const;
+
+const VOICE_SPEED_BY_SPOKEN_VALUE: Readonly<Record<string, RealtimeVoiceSpeed>> =
+  Object.fromEntries(
+    VOICE_SPEED_WORDS.flatMap(({ word, speed }) => [
+      [word, speed],
+      [`${speed}×`, speed],
+    ]),
+  );
+
+function voiceSpeedMultiple(speed: RealtimeVoiceSpeed): string {
+  return `${speed}×`;
+}
+
+function voiceSpeedWord(speed: RealtimeVoiceSpeed): string {
+  return (
+    VOICE_SPEED_WORDS.find((candidate) => candidate.speed === speed)?.word ??
+    VOICE_SPEED_WORD.NORMAL
+  );
+}
+
+function workspaceProviderName(providerId: ProviderId): string {
+  return isCredentialProviderId(providerId)
+    ? CREDENTIAL_PROVIDERS[providerId].displayName
+    : providerId;
+}
+
+function settingGuideEntry(
+  ids: readonly AppSettingId[],
+  build: SettingDefinition<AppSettingField>["guideEntry"]["build"],
+): SettingDefinition<AppSettingField>["guideEntry"] {
+  return { ids, build };
 }
 
 const valid = <Value>(value: Value): SettingGuardResult<Value> => ({ valid: true, value });
@@ -184,7 +272,16 @@ export const APP_SETTING_SCHEMA = {
     guard: boolean(false),
     settingsPage: SETTINGS_PAGE.APPEARANCE,
     resetScope: SETTINGS_RESET_SCOPE.APPEARANCE,
-    guideEntry: APP_SETTING_ID.SHOW_IN_DOCK,
+    guideEntry: settingGuideEntry([APP_SETTING_ID.SHOW_IN_DOCK], (settings, defaultValue) => ({
+      id: APP_SETTING_ID.SHOW_IN_DOCK,
+      label: "Show Luke in the Dock",
+      description: "Whether Luke also stands in the Dock as an app icon.",
+      kind: APP_SETTING_KIND.TOGGLE,
+      value: appToggleText(settings.showInDock),
+      defaultValue: appToggleText(defaultValue as boolean),
+      adjustable: true,
+      manual: APPEARANCE_PAGE,
+    })),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.DOCK,
     spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
   },
@@ -194,7 +291,18 @@ export const APP_SETTING_SCHEMA = {
     guard: (value: unknown) => optional(value, isRealtimeVoice),
     settingsPage: SETTINGS_PAGE.VOICE,
     resetScope: SETTINGS_RESET_SCOPE.VOICE,
-    guideEntry: APP_SETTING_ID.VOICE,
+    guideEntry: settingGuideEntry([APP_SETTING_ID.VOICE], (settings, defaultValue) => ({
+      id: APP_SETTING_ID.VOICE,
+      label: "Voice",
+      description:
+        "Which voice Luke speaks with; a change is heard right away — a conversation under way starts afresh in the new voice.",
+      kind: APP_SETTING_KIND.CHOICE,
+      value: settings.voice,
+      defaultValue: defaultValue as RealtimeVoice,
+      choices: REALTIME_VOICE_LIST,
+      adjustable: true,
+      manual: VOICE_PAGE,
+    })),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.VOICE,
     spokenValue: (value: string) => (isRealtimeVoice(value) ? value : undefined),
   },
@@ -204,20 +312,24 @@ export const APP_SETTING_SCHEMA = {
     guard: (value: unknown) => optional(value, isRealtimeVoiceSpeed),
     settingsPage: SETTINGS_PAGE.VOICE,
     resetScope: SETTINGS_RESET_SCOPE.VOICE,
-    guideEntry: APP_SETTING_ID.VOICE_SPEED,
+    guideEntry: settingGuideEntry([APP_SETTING_ID.VOICE_SPEED], (settings, defaultValue) => ({
+      id: APP_SETTING_ID.VOICE_SPEED,
+      label: "Speed",
+      description:
+        "How fast Luke talks — slow is 0.75×, normal 1×, quick 1.25×, fast 1.5× the voice's natural rate, and an ask may use the word or the multiple; a change is heard from the next reply on.",
+      kind: APP_SETTING_KIND.CHOICE,
+      value: voiceSpeedWord(settings.voiceSpeed),
+      defaultValue: voiceSpeedWord(defaultValue as RealtimeVoiceSpeed),
+      choices: VOICE_SPEED_WORDS.flatMap((candidate) => [
+        candidate.word,
+        voiceSpeedMultiple(candidate.speed),
+      ]),
+      adjustable: true,
+      manual: VOICE_PAGE,
+    })),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.VOICE_SPEED,
     spokenValue: (value: string) => {
-      const words: Record<string, RealtimeVoiceSpeed> = {
-        slow: 0.75,
-        normal: 1,
-        quick: 1.25,
-        fast: 1.5,
-        "0.75×": 0.75,
-        "1×": 1,
-        "1.25×": 1.25,
-        "1.5×": 1.5,
-      };
-      return words[value];
+      return VOICE_SPEED_BY_SPOKEN_VALUE[value];
     },
   },
   voiceCaptions: {
@@ -226,7 +338,19 @@ export const APP_SETTING_SCHEMA = {
     guard: boolean(false),
     settingsPage: SETTINGS_PAGE.VOICE,
     resetScope: SETTINGS_RESET_SCOPE.VOICE,
-    guideEntry: APP_SETTING_ID.VOICE_CAPTIONS,
+    guideEntry: settingGuideEntry([APP_SETTING_ID.VOICE_CAPTIONS], (settings, defaultValue) => ({
+      id: APP_SETTING_ID.VOICE_CAPTIONS,
+      label: "Captions",
+      description:
+        "Luke's words on screen while he speaks; nothing is kept. They also appear on their own, " +
+        "whatever this says, for a reply answering a typed ask and while the Mac's output is " +
+        "muted or at zero.",
+      kind: APP_SETTING_KIND.TOGGLE,
+      value: appToggleText(settings.voiceCaptions),
+      defaultValue: appToggleText(defaultValue as boolean),
+      adjustable: true,
+      manual: VOICE_PAGE,
+    })),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.NONE,
     spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
   },
@@ -236,7 +360,8 @@ export const APP_SETTING_SCHEMA = {
     guard: hotkey,
     settingsPage: SETTINGS_PAGE.SHORTCUTS,
     resetScope: SETTINGS_RESET_SCOPE.SHORTCUTS,
-    guideEntry: undefined,
+    // The talk-key fact reports the registered chord and its manual path.
+    guideEntry: settingGuideEntry([], () => undefined),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.TALK_HOTKEY,
   },
   askHotkey: {
@@ -245,7 +370,8 @@ export const APP_SETTING_SCHEMA = {
     guard: hotkey,
     settingsPage: SETTINGS_PAGE.SHORTCUTS,
     resetScope: SETTINGS_RESET_SCOPE.SHORTCUTS,
-    guideEntry: undefined,
+    // The ask-key fact reports the registered chord and its manual path.
+    guideEntry: settingGuideEntry([], () => undefined),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.ASK_HOTKEY,
   },
   stopHotkey: {
@@ -254,7 +380,8 @@ export const APP_SETTING_SCHEMA = {
     guard: hotkey,
     settingsPage: SETTINGS_PAGE.SHORTCUTS,
     resetScope: SETTINGS_RESET_SCOPE.SHORTCUTS,
-    guideEntry: undefined,
+    // The stop-key fact reports the registered chord and its manual path.
+    guideEntry: settingGuideEntry([], () => undefined),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.STOP_HOTKEY,
   },
   duckOtherMedia: {
@@ -263,7 +390,17 @@ export const APP_SETTING_SCHEMA = {
     guard: boolean(true),
     settingsPage: SETTINGS_PAGE.VOICE,
     resetScope: SETTINGS_RESET_SCOPE.VOICE,
-    guideEntry: APP_SETTING_ID.DUCK_OTHER_MEDIA,
+    guideEntry: settingGuideEntry([APP_SETTING_ID.DUCK_OTHER_MEDIA], (settings, defaultValue) => ({
+      id: APP_SETTING_ID.DUCK_OTHER_MEDIA,
+      label: "Quiet Music and Spotify",
+      description:
+        "Whether Music and Spotify are turned down while a spoken exchange is live, and back up after.",
+      kind: APP_SETTING_KIND.TOGGLE,
+      value: appToggleText(settings.duckOtherMedia),
+      defaultValue: appToggleText(defaultValue as boolean),
+      adjustable: true,
+      manual: VOICE_PAGE,
+    })),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.MEDIA_DUCK,
     spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
   },
@@ -272,7 +409,21 @@ export const APP_SETTING_SCHEMA = {
     default: undefined,
     guard: (value: unknown) => optional(value, isVoiceSource),
     settingsPage: SETTINGS_PAGE.ROOT,
-    guideEntry: APP_SETTING_ID.VOICE_SOURCE,
+    guideEntry: settingGuideEntry([APP_SETTING_ID.VOICE_SOURCE], (settings) => ({
+      id: APP_SETTING_ID.VOICE_SOURCE,
+      label: "What Luke runs on",
+      description:
+        "Which credential Luke speaks and reviews sessions on: the signed-in Luke account, free " +
+        "and metered daily, or the developer's own OpenAI key, unmetered and billed to them by " +
+        "OpenAI. A key stays stored either way, so the free allowance can be used without " +
+        "deleting it.",
+      kind: APP_SETTING_KIND.CHOICE,
+      value: VOICE_SOURCE_CHOICE[settings.voiceSource],
+      defaultValue: VOICE_SOURCE_CHOICE[VOICE_SOURCE.ACCOUNT],
+      choices: Object.values(VOICE_SOURCE_CHOICE),
+      adjustable: false,
+      manual: VOICE_SOURCE_SECTION,
+    })),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.VOICE_SOURCE,
   },
   preferBuiltInMicrophone: {
@@ -281,7 +432,22 @@ export const APP_SETTING_SCHEMA = {
     guard: boolean(true),
     settingsPage: SETTINGS_PAGE.VOICE,
     resetScope: SETTINGS_RESET_SCOPE.VOICE,
-    guideEntry: APP_SETTING_ID.PREFER_BUILT_IN_MICROPHONE,
+    guideEntry: settingGuideEntry(
+      [APP_SETTING_ID.PREFER_BUILT_IN_MICROPHONE],
+      (settings, defaultValue) => ({
+        id: APP_SETTING_ID.PREFER_BUILT_IN_MICROPHONE,
+        label: "Prefer the Mac's microphone",
+        description:
+          "Whether Luke listens through the Mac's own microphone when the system input is a " +
+          "Bluetooth headset, so the headset keeps its full music quality. A shut lid keeps the " +
+          "headset's microphone either way.",
+        kind: APP_SETTING_KIND.TOGGLE,
+        value: appToggleText(settings.preferBuiltInMicrophone),
+        defaultValue: appToggleText(defaultValue as boolean),
+        adjustable: true,
+        manual: VOICE_PAGE,
+      }),
+    ),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.NONE,
     spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
   },
@@ -290,7 +456,20 @@ export const APP_SETTING_SCHEMA = {
     default: true,
     guard: boolean(true),
     settingsPage: SETTINGS_PAGE.CONNECTIONS,
-    guideEntry: APP_SETTING_ID.QUIET_DURING_MEETINGS,
+    guideEntry: settingGuideEntry(
+      [APP_SETTING_ID.QUIET_DURING_MEETINGS],
+      (settings, defaultValue) => ({
+        id: APP_SETTING_ID.QUIET_DURING_MEETINGS,
+        label: "Quiet during meetings",
+        description:
+          "Whether spoken announcements wait while a connected calendar shows a meeting on, and are read out together once it ends. It changes nothing until a Google Calendar account is connected.",
+        kind: APP_SETTING_KIND.TOGGLE,
+        value: appToggleText(settings.quietDuringMeetings),
+        defaultValue: appToggleText(defaultValue as boolean),
+        adjustable: true,
+        manual: `${CONNECTIONS_PAGE} — drawn once a calendar account is connected`,
+      }),
+    ),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.MEETING_QUIET,
     spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
   },
@@ -300,7 +479,20 @@ export const APP_SETTING_SCHEMA = {
     guard: boolean(false),
     settingsPage: SETTINGS_PAGE.APPEARANCE,
     resetScope: SETTINGS_RESET_SCOPE.APPEARANCE,
-    guideEntry: APP_SETTING_ID.SHOW_ON_ALL_DISPLAYS,
+    guideEntry: settingGuideEntry(
+      [APP_SETTING_ID.SHOW_ON_ALL_DISPLAYS],
+      (settings, defaultValue) => ({
+        id: APP_SETTING_ID.SHOW_ON_ALL_DISPLAYS,
+        label: "Show Luke on all displays",
+        description:
+          "Whether Luke stands on every connected display at once; off keeps him to the main display alone.",
+        kind: APP_SETTING_KIND.TOGGLE,
+        value: appToggleText(settings.showOnAllDisplays),
+        defaultValue: appToggleText(defaultValue as boolean),
+        adjustable: true,
+        manual: APPEARANCE_PAGE,
+      }),
+    ),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.DISPLAYS,
     spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
   },
@@ -310,7 +502,18 @@ export const APP_SETTING_SCHEMA = {
     guard: (value: unknown) => optional(value, isPanelFormFactor),
     settingsPage: SETTINGS_PAGE.APPEARANCE,
     resetScope: SETTINGS_RESET_SCOPE.APPEARANCE,
-    guideEntry: APP_SETTING_ID.FORM_FACTOR,
+    guideEntry: settingGuideEntry([APP_SETTING_ID.FORM_FACTOR], (settings, defaultValue) => ({
+      id: APP_SETTING_ID.FORM_FACTOR,
+      label: "Form factor",
+      description:
+        "How Luke stands on a display without a camera housing — notch draws him one pressed into the top edge, bubble floats him just under it. A display with a real notch ignores this.",
+      kind: APP_SETTING_KIND.CHOICE,
+      value: settings.formFactor,
+      defaultValue: defaultValue as PanelFormFactor,
+      choices: PANEL_FORM_FACTOR_LIST,
+      adjustable: true,
+      manual: APPEARANCE_PAGE,
+    })),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.FORM_FACTOR,
     spokenValue: (value: string) => (isPanelFormFactor(value) ? value : undefined),
   },
@@ -325,7 +528,26 @@ export const APP_SETTING_SCHEMA = {
       ),
     settingsPage: SETTINGS_PAGE.CONNECTIONS,
     resetScope: SETTINGS_RESET_SCOPE.WORKSPACES,
-    guideEntry: APP_SETTING_ID.DEFAULT_WORKSPACE_PROVIDER,
+    guideEntry: settingGuideEntry([APP_SETTING_ID.DEFAULT_WORKSPACE_PROVIDER], (settings) => ({
+      id: APP_SETTING_ID.DEFAULT_WORKSPACE_PROVIDER,
+      label: "Default workspace provider",
+      description:
+        "Which provider a conversational ask creates a new workspace in when the ask names none. " +
+        "Until one is chosen Luke asks when more than one provider could take it, and the first " +
+        "workspace created saves its provider as the default.",
+      kind: APP_SETTING_KIND.CHOICE,
+      value: settings.defaultWorkspaceProvider
+        ? workspaceProviderName(settings.defaultWorkspaceProvider)
+        : ASK_EACH_TIME_CHOICE,
+      choices: [
+        ASK_EACH_TIME_CHOICE,
+        workspaceProviderName(PROVIDER_ID.CONDUCTOR),
+        workspaceProviderName(PROVIDER_ID.CURSOR),
+      ],
+      defaultValue: ASK_EACH_TIME_CHOICE,
+      adjustable: false,
+      manual: `${CONNECTIONS_PAGE}, under Workspaces`,
+    })),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.NONE,
   },
   workspaceAgentDefaults: {
@@ -333,7 +555,63 @@ export const APP_SETTING_SCHEMA = {
     default: undefined,
     guard: workspaceAgentDefaults,
     settingsPage: SETTINGS_PAGE.CONNECTIONS,
-    guideEntry: [APP_SETTING_ID.WORKSPACE_AGENT_MODEL, APP_SETTING_ID.WORKSPACE_AGENT_EFFORT],
+    guideEntry: settingGuideEntry(
+      [APP_SETTING_ID.WORKSPACE_AGENT_MODEL, APP_SETTING_ID.WORKSPACE_AGENT_EFFORT],
+      (settings) => {
+        const chosen = settings.workspaceAgentDefaults?.[PROVIDER_ID.CONDUCTOR];
+        const chosenAgent = chosen
+          ? workspaceAgentModels(PROVIDER_ID.CONDUCTOR).find(
+              (entry) => entry.agent === chosen.agent,
+            )
+          : undefined;
+        return [
+          {
+            id: APP_SETTING_ID.WORKSPACE_AGENT_MODEL,
+            label: "New Conductor agents run",
+            description:
+              "Which model a Conductor workspace or agent created through Luke starts with. Unset, " +
+              "Conductor's own defaults decide. An effort the model's agent documents may be named " +
+              "in the same change.",
+            kind: APP_SETTING_KIND.CHOICE,
+            value: chosen
+              ? workspaceAgentModelLabel(PROVIDER_ID.CONDUCTOR, chosen)
+              : CONDUCTOR_DEFAULT_CHOICE,
+            choices: [
+              CONDUCTOR_DEFAULT_CHOICE,
+              ...workspaceAgentModels(PROVIDER_ID.CONDUCTOR).flatMap((entry) =>
+                entry.models.map((model) => model.label),
+              ),
+            ],
+            efforts: Object.fromEntries(
+              workspaceAgentModels(PROVIDER_ID.CONDUCTOR).flatMap((entry) =>
+                entry.efforts.length > 0
+                  ? entry.models.map((model) => [model.label, entry.efforts] as const)
+                  : [],
+              ),
+            ),
+            defaultValue: CONDUCTOR_DEFAULT_CHOICE,
+            adjustable: true,
+            manual: CONDUCTOR_ROW_PATH,
+          },
+          ...(chosen && chosenAgent && chosenAgent.efforts.length > 0
+            ? [
+                {
+                  id: APP_SETTING_ID.WORKSPACE_AGENT_EFFORT,
+                  label: "New Conductor agents' effort",
+                  description:
+                    "How hard the chosen model thinks. Unset, Conductor's own default decides.",
+                  kind: APP_SETTING_KIND.CHOICE,
+                  value: chosen.effort ?? CONDUCTOR_DEFAULT_CHOICE,
+                  choices: [CONDUCTOR_DEFAULT_CHOICE, ...chosenAgent.efforts],
+                  defaultValue: CONDUCTOR_DEFAULT_CHOICE,
+                  adjustable: true,
+                  manual: CONDUCTOR_ROW_PATH,
+                },
+              ]
+            : []),
+        ];
+      },
+    ),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.NONE,
   },
   workspaceProjectDefaults: {
@@ -342,7 +620,8 @@ export const APP_SETTING_SCHEMA = {
     guard: workspaceProjectDefaults,
     settingsPage: SETTINGS_PAGE.CONNECTIONS,
     resetScope: SETTINGS_RESET_SCOPE.WORKSPACES,
-    guideEntry: undefined,
+    // Observed project names and defaults travel in the workspace-project context.
+    guideEntry: settingGuideEntry([], () => undefined),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.NONE,
   },
 } as const satisfies {
@@ -364,9 +643,15 @@ export function isAppSettingId(value: string): value is AppSettingId {
 }
 
 export function settingFieldForGuideId(id: AppSettingId): AppSettingField | undefined {
-  return APP_SETTING_FIELDS.find((field) => {
-    const entry = APP_SETTING_SCHEMA[field].guideEntry;
-    return Array.isArray(entry) ? entry.includes(id) : entry === id;
+  return APP_SETTING_FIELDS.find((field) => APP_SETTING_SCHEMA[field].guideEntry.ids.includes(id));
+}
+
+export function settingGuideEntries(settings: AppSettingGuideSettings): AppGuideSetting[] {
+  return APP_SETTING_FIELDS.flatMap((field) => {
+    const definition = APP_SETTING_SCHEMA[field];
+    const entry = definition.guideEntry.build(settings, definition.default);
+    if (entry === undefined) return [];
+    return Array.isArray(entry) ? entry : [entry as AppGuideSetting];
   });
 }
 
@@ -381,26 +666,15 @@ export function spokenSettingValue(
   return convert?.(value);
 }
 
-export const APP_SETTING_DEFAULTS = {
-  showInDock: APP_SETTING_SCHEMA.showInDock.default,
-  voice: REALTIME_DEFAULTS.VOICE,
-  voiceSpeed: REALTIME_DEFAULTS.SPEED,
-  voiceCaptions: APP_SETTING_SCHEMA.voiceCaptions.default,
-  duckOtherMedia: APP_SETTING_SCHEMA.duckOtherMedia.default,
-  preferBuiltInMicrophone: APP_SETTING_SCHEMA.preferBuiltInMicrophone.default,
-  quietDuringMeetings: APP_SETTING_SCHEMA.quietDuringMeetings.default,
-  showOnAllDisplays: APP_SETTING_SCHEMA.showOnAllDisplays.default,
-  formFactor: DEFAULT_PANEL_FORM_FACTOR,
-} as const;
+export const APP_SETTING_DEFAULTS = Object.fromEntries(
+  APP_SETTING_FIELDS.map((field) => [field, APP_SETTING_SCHEMA[field].default]),
+) as {
+  readonly [Field in AppSettingField]: (typeof APP_SETTING_SCHEMA)[Field]["default"];
+};
 
 export const SETTING_PAGE = Object.fromEntries(
   Object.values(APP_SETTING_SCHEMA).flatMap((definition) => {
-    const entries = definition.guideEntry;
-    if (entries === undefined) return [];
-    return (Array.isArray(entries) ? entries : [entries]).map((id) => [
-      id,
-      definition.settingsPage,
-    ]);
+    return definition.guideEntry.ids.map((id) => [id, definition.settingsPage]);
   }),
 ) as Record<AppSettingId, SettingsPage>;
 

--- a/apps/desktop/src/shared/settings-schema.ts
+++ b/apps/desktop/src/shared/settings-schema.ts
@@ -119,10 +119,28 @@ export interface SettingGuardResult<Value> {
   value: Value;
 }
 
+/** What one key of a map-valued setting holds. */
+export type SettingEntryValue<Field extends AppSettingField> = NonNullable<
+  NonNullable<AppSettingValue<Field>>[keyof NonNullable<AppSettingValue<Field>>]
+>;
+
+/**
+ * Declares a setting whose value is a map of per-key entries, so one entry can
+ * be written under the store's own lock. A caller that read the map, merged an
+ * entry, and wrote the whole thing back would drop any entry saved while its
+ * write was in flight — the lost update `#serialize` exists to prevent.
+ */
+interface SettingEntryDefinition<Value> {
+  isKey(value: unknown): boolean;
+  /** Whether the stored entry already says what a write would say. */
+  same(current: Value | undefined, next: Value | undefined): boolean;
+}
+
 interface SettingDefinition<Field extends AppSettingField> {
   field: Field;
   default: AppSettingValue<Field>;
   guard(value: unknown): SettingGuardResult<AppSettingValue<Field>>;
+  entry?: SettingEntryDefinition<SettingEntryValue<Field>>;
   settingsPage: SettingsPage;
   resetScope?: SettingsResetScope;
   guideEntry: {
@@ -554,6 +572,13 @@ export const APP_SETTING_SCHEMA = {
     field: "workspaceAgentDefaults",
     default: undefined,
     guard: workspaceAgentDefaults,
+    entry: {
+      isKey: isProviderId,
+      same: (current, next) =>
+        current?.agent === next?.agent &&
+        current?.model === next?.model &&
+        current?.effort === next?.effort,
+    },
     settingsPage: SETTINGS_PAGE.CONNECTIONS,
     guideEntry: settingGuideEntry(
       [APP_SETTING_ID.WORKSPACE_AGENT_MODEL, APP_SETTING_ID.WORKSPACE_AGENT_EFFORT],
@@ -618,6 +643,10 @@ export const APP_SETTING_SCHEMA = {
     field: "workspaceProjectDefaults",
     default: undefined,
     guard: workspaceProjectDefaults,
+    entry: {
+      isKey: isProviderId,
+      same: (current, next) => current === next,
+    },
     settingsPage: SETTINGS_PAGE.CONNECTIONS,
     resetScope: SETTINGS_RESET_SCOPE.WORKSPACES,
     // Observed project names and defaults travel in the workspace-project context.
@@ -632,6 +661,52 @@ export const APP_SETTING_FIELDS = Object.keys(APP_SETTING_SCHEMA) as AppSettingF
 
 export function isAppSettingField(value: unknown): value is AppSettingField {
   return typeof value === "string" && value in APP_SETTING_SCHEMA;
+}
+
+/** The settings whose value is a map, and so can be written one entry at a time. */
+export type KeyedAppSettingField = {
+  [Field in AppSettingField]: "entry" extends keyof (typeof APP_SETTING_SCHEMA)[Field]
+    ? Field
+    : never;
+}[AppSettingField];
+
+export function isKeyedAppSettingField(value: unknown): value is KeyedAppSettingField {
+  return isAppSettingField(value) && "entry" in APP_SETTING_SCHEMA[value];
+}
+
+function settingEntry(field: KeyedAppSettingField): SettingEntryDefinition<never> {
+  return (APP_SETTING_SCHEMA[field] as { entry: SettingEntryDefinition<never> }).entry;
+}
+
+export function isSettingEntryKey(field: KeyedAppSettingField, key: unknown): key is string {
+  return settingEntry(field).isKey(key);
+}
+
+export function sameSettingEntry(
+  field: KeyedAppSettingField,
+  current: unknown,
+  next: unknown,
+): boolean {
+  return settingEntry(field).same(current as never, next as never);
+}
+
+/**
+ * Validates one entry by running the field's own whole-map guard over a map
+ * holding only that entry: an entry the guard drops is one the map would have
+ * dropped, so the two readings of what is valid cannot drift apart. Clearing an
+ * entry carries no value to check.
+ */
+export function settingEntryGuard(
+  field: KeyedAppSettingField,
+  key: string,
+  value: unknown,
+): SettingGuardResult<unknown> {
+  if (value === undefined) return { valid: true, value: undefined };
+  const parsed = APP_SETTING_SCHEMA[field].guard({ [key]: value });
+  const kept = parsed.valid
+    ? (parsed.value as Record<string, unknown> | undefined)?.[key]
+    : undefined;
+  return kept === undefined ? { valid: false, value: undefined } : { valid: true, value: kept };
 }
 
 export function isSettingsResetScope(value: unknown): value is SettingsResetScope {

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -366,10 +366,9 @@ test("the guide offers what a new Conductor agent runs, by the names people know
 test("a spoken model or effort change composes the one stored selection", async () => {
   const carried: (WorkspaceAgentSelection | undefined)[] = [];
   const bridge = {
-    setWorkspaceAgentDefault: async (
-      _providerId: string,
-      selection: WorkspaceAgentSelection | undefined,
-    ) => {
+    updateSetting: async (_field: string, value: unknown) => {
+      const defaults = value as Partial<Record<string, WorkspaceAgentSelection>> | undefined;
+      const selection = defaults?.[PROVIDER_ID.CONDUCTOR];
       carried.push(selection);
       return { settings: settings() };
     },
@@ -438,11 +437,9 @@ test("a spoken model or effort change composes the one stored selection", async 
 test("a model and its effort named in one change land as one stored pairing", async () => {
   const carried: (WorkspaceAgentSelection | undefined)[] = [];
   const bridge = {
-    setWorkspaceAgentDefault: async (
-      _providerId: string,
-      selection: WorkspaceAgentSelection | undefined,
-    ) => {
-      carried.push(selection);
+    updateSetting: async (_field: string, value: unknown) => {
+      const defaults = value as Partial<Record<string, WorkspaceAgentSelection>> | undefined;
+      carried.push(defaults?.[PROVIDER_ID.CONDUCTOR]);
       return { settings: settings() };
     },
   } as unknown as Parameters<typeof applySpokenSetting>[0];
@@ -501,10 +498,9 @@ test("a model and its effort named in one change land as one stored pairing", as
 test("a model and its effort asked in one breath compose through the held answer", async () => {
   const carried: (WorkspaceAgentSelection | undefined)[] = [];
   const bridge = {
-    setWorkspaceAgentDefault: async (
-      _providerId: string,
-      selection: WorkspaceAgentSelection | undefined,
-    ) => {
+    updateSetting: async (_field: string, value: unknown) => {
+      const defaults = value as Partial<Record<string, WorkspaceAgentSelection>> | undefined;
+      const selection = defaults?.[PROVIDER_ID.CONDUCTOR];
       carried.push(selection);
       return {
         settings: settings(
@@ -687,47 +683,14 @@ test("every adjustable setting is carried to the bridge call its row uses", asyn
   const calls: string[] = [];
   const answered: SettingsUpdateResult = { settings: settings() };
   const bridge = {
-    setVoice: async () => {
-      calls.push("setVoice");
-      return answered;
-    },
-    setVoiceSpeed: async (speed: number) => {
-      calls.push(`setVoiceSpeed:${speed}`);
-      return answered;
-    },
-    setVoiceCaptions: async (enabled: boolean) => {
-      calls.push(`setVoiceCaptions:${enabled}`);
-      return answered;
-    },
-    setDuckOtherMedia: async (enabled: boolean) => {
-      calls.push(`setDuckOtherMedia:${enabled}`);
-      return answered;
-    },
-    setPreferBuiltInMicrophone: async (enabled: boolean) => {
-      calls.push(`setPreferBuiltInMicrophone:${enabled}`);
-      return answered;
-    },
-    setQuietDuringMeetings: async (enabled: boolean) => {
-      calls.push(`setQuietDuringMeetings:${enabled}`);
-      return answered;
-    },
-    setShowInDock: async (show: boolean) => {
-      calls.push(`setShowInDock:${show}`);
-      return answered;
-    },
-    setShowOnAllDisplays: async (show: boolean) => {
-      calls.push(`setShowOnAllDisplays:${show}`);
-      return answered;
-    },
-    setFormFactor: async (formFactor: string) => {
-      calls.push(`setFormFactor:${formFactor}`);
-      return answered;
-    },
-    setWorkspaceAgentDefault: async (
-      _providerId: string,
-      selection: WorkspaceAgentSelection | undefined,
-    ) => {
-      calls.push(`setWorkspaceAgentDefault:${selection ? selection.model : "default"}`);
+    updateSetting: async (field: string, value: unknown) => {
+      const rendered =
+        field === "workspaceAgentDefaults"
+          ? ((value as Partial<Record<string, WorkspaceAgentSelection>> | undefined)?.[
+              PROVIDER_ID.CONDUCTOR
+            ]?.model ?? "default")
+          : String(value);
+      calls.push(`${field}:${rendered}`);
       return answered;
     },
   };
@@ -743,18 +706,18 @@ test("every adjustable setting is carried to the bridge call its row uses", asyn
   }
 
   assert.deepEqual(calls.sort(), [
-    "setDuckOtherMedia:true",
-    "setFormFactor:notch",
-    "setPreferBuiltInMicrophone:true",
-    "setQuietDuringMeetings:true",
-    "setShowInDock:true",
-    "setShowOnAllDisplays:true",
-    "setVoice",
-    "setVoiceCaptions:true",
+    "duckOtherMedia:true",
+    "formFactor:notch",
+    "preferBuiltInMicrophone:true",
+    "quietDuringMeetings:true",
+    "showInDock:true",
+    "showOnAllDisplays:true",
+    "voice:alloy",
+    "voiceCaptions:true",
     // The first choice offered is "slow", which is the 0.75 multiple.
-    "setVoiceSpeed:0.75",
+    "voiceSpeed:0.75",
     // The first choice offered is "Conductor's default", which clears.
-    "setWorkspaceAgentDefault:default",
+    "workspaceAgentDefaults:default",
   ]);
   // The snapshot the store answered with is handed back either way, so the
   // panel's switches redraw from what was actually stored.
@@ -764,8 +727,8 @@ test("every adjustable setting is carried to the bridge call its row uses", asyn
 test("a pace asked for by its multiple carries the same as its word", async () => {
   const calls: string[] = [];
   const bridge = {
-    setVoiceSpeed: async (speed: number) => {
-      calls.push(`setVoiceSpeed:${speed}`);
+    updateSetting: async (field: string, value: unknown) => {
+      calls.push(`${field}:${value}`);
       return { settings: settings() };
     },
   };
@@ -779,13 +742,12 @@ test("a pace asked for by its multiple carries the same as its word", async () =
     assert.equal(outcome.status, "changed");
   }
 
-  assert.deepEqual(calls, ["setVoiceSpeed:1.25", "setVoiceSpeed:1.25"]);
+  assert.deepEqual(calls, ["voiceSpeed:1.25", "voiceSpeed:1.25"]);
 });
 
 test("the store's refusal comes back as the spoken outcome", async () => {
   const bridge = {
-    setVoice: async () => ({ settings: settings() }),
-    setVoiceCaptions: async () => ({
+    updateSetting: async () => ({
       settings: settings(),
       reason: "The settings file could not be written.",
     }),

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -366,10 +366,9 @@ test("the guide offers what a new Conductor agent runs, by the names people know
 test("a spoken model or effort change composes the one stored selection", async () => {
   const carried: (WorkspaceAgentSelection | undefined)[] = [];
   const bridge = {
-    updateSetting: async (_field: string, value: unknown) => {
-      const defaults = value as Partial<Record<string, WorkspaceAgentSelection>> | undefined;
-      const selection = defaults?.[PROVIDER_ID.CONDUCTOR];
-      carried.push(selection);
+    updateSettingEntry: async (_field: string, key: string, value: unknown) => {
+      assert.equal(key, PROVIDER_ID.CONDUCTOR);
+      carried.push(value as WorkspaceAgentSelection | undefined);
       return { settings: settings() };
     },
   } as unknown as Parameters<typeof applySpokenSetting>[0];
@@ -437,9 +436,9 @@ test("a spoken model or effort change composes the one stored selection", async 
 test("a model and its effort named in one change land as one stored pairing", async () => {
   const carried: (WorkspaceAgentSelection | undefined)[] = [];
   const bridge = {
-    updateSetting: async (_field: string, value: unknown) => {
-      const defaults = value as Partial<Record<string, WorkspaceAgentSelection>> | undefined;
-      carried.push(defaults?.[PROVIDER_ID.CONDUCTOR]);
+    updateSettingEntry: async (_field: string, key: string, value: unknown) => {
+      assert.equal(key, PROVIDER_ID.CONDUCTOR);
+      carried.push(value as WorkspaceAgentSelection | undefined);
       return { settings: settings() };
     },
   } as unknown as Parameters<typeof applySpokenSetting>[0];
@@ -498,9 +497,9 @@ test("a model and its effort named in one change land as one stored pairing", as
 test("a model and its effort asked in one breath compose through the held answer", async () => {
   const carried: (WorkspaceAgentSelection | undefined)[] = [];
   const bridge = {
-    updateSetting: async (_field: string, value: unknown) => {
-      const defaults = value as Partial<Record<string, WorkspaceAgentSelection>> | undefined;
-      const selection = defaults?.[PROVIDER_ID.CONDUCTOR];
+    updateSettingEntry: async (_field: string, key: string, value: unknown) => {
+      assert.equal(key, PROVIDER_ID.CONDUCTOR);
+      const selection = value as WorkspaceAgentSelection | undefined;
       carried.push(selection);
       return {
         settings: settings(
@@ -684,13 +683,12 @@ test("every adjustable setting is carried to the bridge call its row uses", asyn
   const answered: SettingsUpdateResult = { settings: settings() };
   const bridge = {
     updateSetting: async (field: string, value: unknown) => {
-      const rendered =
-        field === "workspaceAgentDefaults"
-          ? ((value as Partial<Record<string, WorkspaceAgentSelection>> | undefined)?.[
-              PROVIDER_ID.CONDUCTOR
-            ]?.model ?? "default")
-          : String(value);
-      calls.push(`${field}:${rendered}`);
+      calls.push(`${field}:${String(value)}`);
+      return answered;
+    },
+    updateSettingEntry: async (field: string, _key: string, value: unknown) => {
+      const selection = value as WorkspaceAgentSelection | undefined;
+      calls.push(`${field}:${selection?.model ?? "default"}`);
       return answered;
     },
   };

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -25,7 +25,12 @@ import {
   type CredentialProvider,
   type CredentialProviderId,
 } from "../src/shared/credential-providers";
-import { APP_SETTING_SCHEMA } from "../src/shared/settings-schema";
+import {
+  APP_SETTING_FIELDS,
+  APP_SETTING_SCHEMA,
+  isKeyedAppSettingField,
+  settingEntryGuard,
+} from "../src/shared/settings-schema";
 
 const TEST_API_KEY = "conductor-live-key";
 const SETTINGS_FILE_NAME = "settings.json";
@@ -1408,6 +1413,56 @@ test("keeps one provider's default project apart from another's", async (t) => {
   assert.deepEqual(cleared.settings.workspaceProjectDefaults, {
     [PROVIDER_ID.CURSOR]: "proj-2",
   });
+});
+
+test("an entry the field cannot hold is refused rather than quietly dropped", () => {
+  // The map guards drop what they cannot hold, which is right when reading a
+  // stored file and wrong for a write: a whole map of unholdable entries would
+  // read as valid and clear what is stored. Every write goes one entry at a
+  // time so the refusal is the guard's own answer.
+  assert.equal(
+    settingEntryGuard(
+      APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
+      PROVIDER_ID.CONDUCTOR,
+      "   ",
+    ).valid,
+    false,
+  );
+  assert.equal(
+    settingEntryGuard(APP_SETTING_SCHEMA.workspaceAgentDefaults.field, PROVIDER_ID.CONDUCTOR, {
+      agent: "codex",
+      model: "no-such-model",
+    }).valid,
+    false,
+  );
+
+  // Clearing carries no value to check, and a holdable entry comes back whole.
+  assert.equal(
+    settingEntryGuard(
+      APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
+      PROVIDER_ID.CONDUCTOR,
+      undefined,
+    ).valid,
+    true,
+  );
+  assert.deepEqual(
+    settingEntryGuard(APP_SETTING_SCHEMA.workspaceAgentDefaults.field, PROVIDER_ID.CONDUCTOR, {
+      agent: "codex",
+      model: "gpt-5.6-sol",
+    }),
+    { valid: true, value: { agent: "codex", model: "gpt-5.6-sol" } },
+  );
+});
+
+test("every map-valued setting is written one entry at a time", () => {
+  // The keyed set is what the whole-map write path refuses, so a new map field
+  // that forgot its entry declaration would be writable as a whole map again.
+  for (const field of APP_SETTING_FIELDS) {
+    const holdsMap =
+      field === APP_SETTING_SCHEMA.workspaceAgentDefaults.field ||
+      field === APP_SETTING_SCHEMA.workspaceProjectDefaults.field;
+    assert.equal(isKeyedAppSettingField(field), holdsMap, field);
+  }
 });
 
 test("overlapping default projects each survive the other's write", async (t) => {

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -6,9 +6,11 @@ import test, { type TestContext } from "node:test";
 import {
   PANEL_FORM_FACTOR,
   PROVIDER_ID,
+  type ProviderId,
   REALTIME_DEFAULTS,
   REALTIME_VOICE,
   REALTIME_VOICE_SPEED,
+  type WorkspaceAgentSelection,
 } from "@sidecar/core";
 import { type SecretCipher, SettingsStore } from "../src/settings-store";
 import {
@@ -23,6 +25,7 @@ import {
   type CredentialProvider,
   type CredentialProviderId,
 } from "../src/shared/credential-providers";
+import { APP_SETTING_SCHEMA } from "../src/shared/settings-schema";
 
 const TEST_API_KEY = "conductor-live-key";
 const SETTINGS_FILE_NAME = "settings.json";
@@ -144,6 +147,42 @@ function storeIn(
   });
 }
 
+async function readWorkspaceAgentDefault(store: SettingsStore, providerId: ProviderId) {
+  return (await store.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field))?.[providerId];
+}
+
+async function setWorkspaceAgentDefault(
+  store: SettingsStore,
+  providerId: ProviderId,
+  selection: WorkspaceAgentSelection | undefined,
+) {
+  const defaults = { ...(await store.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field)) };
+  if (selection) defaults[providerId] = selection;
+  else delete defaults[providerId];
+  return store.set(
+    "workspaceAgentDefaults",
+    Object.keys(defaults).length > 0 ? defaults : undefined,
+  );
+}
+
+async function readWorkspaceProjectDefault(store: SettingsStore, providerId: ProviderId) {
+  return (await store.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field))?.[providerId];
+}
+
+async function setWorkspaceProjectDefault(
+  store: SettingsStore,
+  providerId: ProviderId,
+  providerProjectId: string | undefined,
+) {
+  const defaults = { ...(await store.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field)) };
+  if (providerProjectId) defaults[providerId] = providerProjectId;
+  else delete defaults[providerId];
+  return store.set(
+    "workspaceProjectDefaults",
+    Object.keys(defaults).length > 0 ? defaults : undefined,
+  );
+}
+
 async function readSettingsFile(directory: string): Promise<string> {
   return fs.readFile(path.join(directory, SETTINGS_FILE_NAME), "utf8");
 }
@@ -254,7 +293,7 @@ test("captions are off until switched on, and the choice survives a reopen", asy
   const store = storeIn(directory, { cipher });
 
   assert.equal((await store.snapshot()).voiceCaptions, false);
-  const enabled = await store.setVoiceCaptions(true);
+  const enabled = await store.set(APP_SETTING_SCHEMA.voiceCaptions.field, true);
 
   assert.equal(enabled.settings.voiceCaptions, true);
   assert.equal((await storeIn(directory).snapshot()).voiceCaptions, true);
@@ -267,8 +306,8 @@ test("switching captions never disturbs a stored key", async (t) => {
   const store = storeIn(directory);
   await store.setApiKey(CONDUCTOR, TEST_API_KEY);
 
-  await store.setVoiceCaptions(true);
-  const off = await store.setVoiceCaptions(false);
+  await store.set(APP_SETTING_SCHEMA.voiceCaptions.field, true);
+  const off = await store.set(APP_SETTING_SCHEMA.voiceCaptions.field, false);
 
   assert.equal(off.settings.voiceCaptions, false);
   assert.equal(await storeIn(directory).readApiKey(CONDUCTOR), TEST_API_KEY);
@@ -293,7 +332,7 @@ test("other media is quieted until asked otherwise, and the choice survives a re
   const store = storeIn(directory, { cipher });
 
   assert.equal((await store.snapshot()).duckOtherMedia, true);
-  const disabled = await store.setDuckOtherMedia(false);
+  const disabled = await store.set(APP_SETTING_SCHEMA.duckOtherMedia.field, false);
 
   assert.equal(disabled.settings.duckOtherMedia, false);
   assert.equal((await storeIn(directory).snapshot()).duckOtherMedia, false);
@@ -306,8 +345,8 @@ test("switching the media duck never disturbs a stored key", async (t) => {
   const store = storeIn(directory);
   await store.setApiKey(CONDUCTOR, TEST_API_KEY);
 
-  await store.setDuckOtherMedia(false);
-  const on = await store.setDuckOtherMedia(true);
+  await store.set(APP_SETTING_SCHEMA.duckOtherMedia.field, false);
+  const on = await store.set(APP_SETTING_SCHEMA.duckOtherMedia.field, true);
 
   assert.equal(on.settings.duckOtherMedia, true);
   assert.equal(await storeIn(directory).readApiKey(CONDUCTOR), TEST_API_KEY);
@@ -331,7 +370,7 @@ test("the microphone preference persists, defaults on, and shrugs off corruption
   const store = storeIn(directory);
 
   assert.equal((await store.snapshot()).preferBuiltInMicrophone, true);
-  const disabled = await store.setPreferBuiltInMicrophone(false);
+  const disabled = await store.set(APP_SETTING_SCHEMA.preferBuiltInMicrophone.field, false);
 
   assert.equal(disabled.settings.preferBuiltInMicrophone, false);
   assert.equal((await storeIn(directory).snapshot()).preferBuiltInMicrophone, false);
@@ -441,11 +480,11 @@ test("announcements wait out meetings until asked otherwise, and the choice surv
   const store = storeIn(directory, { cipher });
 
   assert.equal((await store.snapshot()).quietDuringMeetings, true);
-  assert.equal(await store.quietDuringMeetings(), true);
-  const disabled = await store.setQuietDuringMeetings(false);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.quietDuringMeetings.field), true);
+  const disabled = await store.set(APP_SETTING_SCHEMA.quietDuringMeetings.field, false);
 
   assert.equal(disabled.settings.quietDuringMeetings, false);
-  assert.equal(await storeIn(directory).quietDuringMeetings(), false);
+  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.quietDuringMeetings.field), false);
   assert.equal((await storeIn(directory).snapshot()).quietDuringMeetings, false);
   assert.equal(cipher.calls.isAvailable, 0);
   assert.equal(cipher.calls.encrypt, 0);
@@ -456,8 +495,8 @@ test("switching the meeting quiet never disturbs a stored key", async (t) => {
   const store = storeIn(directory);
   await store.setApiKey(CONDUCTOR, TEST_API_KEY);
 
-  await store.setQuietDuringMeetings(false);
-  const on = await store.setQuietDuringMeetings(true);
+  await store.set(APP_SETTING_SCHEMA.quietDuringMeetings.field, false);
+  const on = await store.set(APP_SETTING_SCHEMA.quietDuringMeetings.field, true);
 
   assert.equal(on.settings.quietDuringMeetings, true);
   assert.equal(await storeIn(directory).readApiKey(CONDUCTOR), TEST_API_KEY);
@@ -767,7 +806,7 @@ test("drops the retired menu bar preference on the next settings write", async (
   );
   const store = storeIn(directory);
 
-  await store.setShowInDock(true);
+  await store.set(APP_SETTING_SCHEMA.showInDock.field, true);
 
   const persisted = JSON.parse(await readSettingsFile(directory));
   assert.equal(persisted.showInMenuBar, undefined);
@@ -780,7 +819,7 @@ test("keeps Luke out of the Dock until asked, and remembers the answer", async (
 
   assert.equal((await store.snapshot()).showInDock, false);
 
-  const { settings, reason } = await store.setShowInDock(true);
+  const { settings, reason } = await store.set(APP_SETTING_SCHEMA.showInDock.field, true);
 
   assert.equal(reason, undefined);
   assert.equal(settings.showInDock, true);
@@ -805,7 +844,7 @@ test("changes the Dock preference without touching the cipher", async (t) => {
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
 
-  const { settings } = await store.setShowInDock(true);
+  const { settings } = await store.set(APP_SETTING_SCHEMA.showInDock.field, true);
 
   assert.equal(settings.showInDock, true);
   assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
@@ -828,7 +867,7 @@ test("decides the Dock icon from the file alone, never the keychain", async (t) 
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
 
-  assert.equal(await store.showInDock(), true);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.showInDock.field), true);
   assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
 });
 
@@ -847,7 +886,7 @@ test("reports the default voice until one is chosen", async (t) => {
   const store = storeIn(directory);
 
   assert.equal((await store.snapshot()).voice, REALTIME_DEFAULTS.VOICE);
-  assert.equal(await store.readVoice(), undefined);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.voice.field), undefined);
 });
 
 test("stores the chosen voice plainly and reads it back from a new store instance", async (t) => {
@@ -855,14 +894,17 @@ test("stores the chosen voice plainly and reads it back from a new store instanc
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
 
-  const { settings, reason } = await store.setVoice(REALTIME_VOICE.MARIN);
+  const { settings, reason } = await store.set(
+    APP_SETTING_SCHEMA.voice.field,
+    REALTIME_VOICE.MARIN,
+  );
 
   assert.equal(reason, undefined);
   assert.equal(settings.voice, REALTIME_VOICE.MARIN);
   // A preference is not a credential, so choosing one never reaches the
   // Keychain — and never raises its permission dialog.
   assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
-  assert.equal(await storeIn(directory).readVoice(), REALTIME_VOICE.MARIN);
+  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.voice.field), REALTIME_VOICE.MARIN);
 });
 
 test("prefers the chosen voice over the environment, and the environment over the default", async (t) => {
@@ -874,12 +916,12 @@ test("prefers the chosen voice over the environment, and the environment over th
   assert.equal((await store.snapshot()).voice, REALTIME_VOICE.SAGE);
   // The environment names the voice only until the user does, so it is
   // reported in the snapshot but never as something the user stored.
-  assert.equal(await store.readVoice(), undefined);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.voice.field), undefined);
 
-  await store.setVoice(REALTIME_VOICE.MARIN);
+  await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.MARIN);
   assert.equal((await store.snapshot()).voice, REALTIME_VOICE.MARIN);
 
-  await store.setVoice(undefined);
+  await store.set(APP_SETTING_SCHEMA.voice.field, undefined);
   assert.equal((await store.snapshot()).voice, REALTIME_VOICE.SAGE);
 });
 
@@ -891,7 +933,7 @@ test("ignores a stored or environment voice this build does not offer", async (t
   );
   const store = storeIn(directory, { environment: { LUKE_REALTIME_VOICE: "baritone" } });
 
-  assert.equal(await store.readVoice(), undefined);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.voice.field), undefined);
   assert.equal((await store.snapshot()).voice, REALTIME_DEFAULTS.VOICE);
 });
 
@@ -900,7 +942,7 @@ test("reports the natural pace until one is chosen", async (t) => {
   const store = storeIn(directory);
 
   assert.equal((await store.snapshot()).voiceSpeed, REALTIME_DEFAULTS.SPEED);
-  assert.equal(await store.readVoiceSpeed(), undefined);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.voiceSpeed.field), undefined);
 });
 
 test("stores the chosen pace plainly and reads it back from a new store instance", async (t) => {
@@ -908,14 +950,20 @@ test("stores the chosen pace plainly and reads it back from a new store instance
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
 
-  const { settings, reason } = await store.setVoiceSpeed(REALTIME_VOICE_SPEED.QUICK);
+  const { settings, reason } = await store.set(
+    APP_SETTING_SCHEMA.voiceSpeed.field,
+    REALTIME_VOICE_SPEED.QUICK,
+  );
 
   assert.equal(reason, undefined);
   assert.equal(settings.voiceSpeed, REALTIME_VOICE_SPEED.QUICK);
   // A preference is not a credential, so choosing one never reaches the
   // Keychain — and never raises its permission dialog.
   assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
-  assert.equal(await storeIn(directory).readVoiceSpeed(), REALTIME_VOICE_SPEED.QUICK);
+  assert.equal(
+    await storeIn(directory).get(APP_SETTING_SCHEMA.voiceSpeed.field),
+    REALTIME_VOICE_SPEED.QUICK,
+  );
 });
 
 test("prefers the chosen pace over the environment, and the environment over the default", async (t) => {
@@ -925,12 +973,12 @@ test("prefers the chosen pace over the environment, and the environment over the
   });
 
   assert.equal((await store.snapshot()).voiceSpeed, REALTIME_VOICE_SPEED.SLOW);
-  assert.equal(await store.readVoiceSpeed(), undefined);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.voiceSpeed.field), undefined);
 
-  await store.setVoiceSpeed(REALTIME_VOICE_SPEED.FAST);
+  await store.set(APP_SETTING_SCHEMA.voiceSpeed.field, REALTIME_VOICE_SPEED.FAST);
   assert.equal((await store.snapshot()).voiceSpeed, REALTIME_VOICE_SPEED.FAST);
 
-  await store.setVoiceSpeed(undefined);
+  await store.set(APP_SETTING_SCHEMA.voiceSpeed.field, undefined);
   assert.equal((await store.snapshot()).voiceSpeed, REALTIME_VOICE_SPEED.SLOW);
 });
 
@@ -942,7 +990,7 @@ test("ignores a stored or environment pace this build does not offer", async (t)
   );
   const store = storeIn(directory, { environment: { LUKE_REALTIME_SPEED: "0.1" } });
 
-  assert.equal(await store.readVoiceSpeed(), undefined);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.voiceSpeed.field), undefined);
   assert.equal((await store.snapshot()).voiceSpeed, REALTIME_DEFAULTS.SPEED);
 });
 
@@ -950,7 +998,7 @@ test("reports no talk-key chord until one is chosen", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);
 
-  assert.equal(await store.readVoiceHotkey(), undefined);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.voiceHotkey.field), undefined);
   assert.equal((await store.snapshot()).voiceHotkey, undefined);
 });
 
@@ -959,27 +1007,33 @@ test("stores the chosen talk-key chord plainly and reads it back from a new stor
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
 
-  const { settings, reason } = await store.setVoiceHotkey("Shift+Command+L");
+  const { settings, reason } = await store.set(
+    APP_SETTING_SCHEMA.voiceHotkey.field,
+    "Shift+Command+L",
+  );
 
   assert.equal(reason, undefined);
   assert.equal(settings.voiceHotkey, "Shift+Command+L");
   // A preference is not a credential, so choosing one never reaches the
   // Keychain — and never raises its permission dialog.
   assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
-  assert.equal(await storeIn(directory).readVoiceHotkey(), "Shift+Command+L");
+  assert.equal(
+    await storeIn(directory).get(APP_SETTING_SCHEMA.voiceHotkey.field),
+    "Shift+Command+L",
+  );
 });
 
 test("clearing the talk-key chord returns to no choice at all", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);
 
-  await store.setVoiceHotkey("Shift+Command+L");
-  const { settings } = await store.setVoiceHotkey(undefined);
+  await store.set(APP_SETTING_SCHEMA.voiceHotkey.field, "Shift+Command+L");
+  const { settings } = await store.set(APP_SETTING_SCHEMA.voiceHotkey.field, undefined);
 
   assert.equal(settings.voiceHotkey, undefined);
   // Absent from the file rather than stored as an empty value: reset is the
   // absence of a choice, and a reopened store must read it the same way.
-  assert.equal(await storeIn(directory).readVoiceHotkey(), undefined);
+  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.voiceHotkey.field), undefined);
 });
 
 test("ignores a stored talk-key chord this build cannot register", async (t) => {
@@ -992,7 +1046,7 @@ test("ignores a stored talk-key chord this build cannot register", async (t) => 
 
   // A hand-edited chord the registrars would refuse is dropped rather than
   // carried: honouring it would claim a key nothing was ever told about.
-  assert.equal(await store.readVoiceHotkey(), undefined);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.voiceHotkey.field), undefined);
   assert.equal((await store.snapshot()).voiceHotkey, undefined);
 });
 
@@ -1001,30 +1055,30 @@ test("stores the chosen ask-key chord on the talk key's terms and reads it back"
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
 
-  assert.equal(await store.readAskHotkey(), undefined);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.askHotkey.field), undefined);
   assert.equal((await store.snapshot()).askHotkey, undefined);
 
-  const { settings, reason } = await store.setAskHotkey("Control+Alt+K");
+  const { settings, reason } = await store.set(APP_SETTING_SCHEMA.askHotkey.field, "Control+Alt+K");
 
   assert.equal(reason, undefined);
   assert.equal(settings.askHotkey, "Control+Alt+K");
   // A preference is not a credential, so choosing one never reaches the
   // Keychain — and never raises its permission dialog.
   assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
-  assert.equal(await storeIn(directory).readAskHotkey(), "Control+Alt+K");
+  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.askHotkey.field), "Control+Alt+K");
 });
 
 test("clearing the ask-key chord returns to no choice at all", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);
 
-  await store.setAskHotkey("Control+Alt+K");
-  const { settings } = await store.setAskHotkey(undefined);
+  await store.set(APP_SETTING_SCHEMA.askHotkey.field, "Control+Alt+K");
+  const { settings } = await store.set(APP_SETTING_SCHEMA.askHotkey.field, undefined);
 
   assert.equal(settings.askHotkey, undefined);
   // Absent from the file rather than stored as an empty value: reset is the
   // absence of a choice, and a reopened store must read it the same way.
-  assert.equal(await storeIn(directory).readAskHotkey(), undefined);
+  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.askHotkey.field), undefined);
 });
 
 test("ignores a stored ask-key chord this build cannot register", async (t) => {
@@ -1037,7 +1091,7 @@ test("ignores a stored ask-key chord this build cannot register", async (t) => {
 
   // A hand-edited chord the registrar would refuse is dropped rather than
   // carried: honouring it would claim a key nothing was ever told about.
-  assert.equal(await store.readAskHotkey(), undefined);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.askHotkey.field), undefined);
   assert.equal((await store.snapshot()).askHotkey, undefined);
 });
 
@@ -1046,30 +1100,33 @@ test("stores the chosen stop-key chord on the other keys' terms and reads it bac
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
 
-  assert.equal(await store.readStopHotkey(), undefined);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.stopHotkey.field), undefined);
   assert.equal((await store.snapshot()).stopHotkey, undefined);
 
-  const { settings, reason } = await store.setStopHotkey("Control+Alt+X");
+  const { settings, reason } = await store.set(
+    APP_SETTING_SCHEMA.stopHotkey.field,
+    "Control+Alt+X",
+  );
 
   assert.equal(reason, undefined);
   assert.equal(settings.stopHotkey, "Control+Alt+X");
   // A preference is not a credential, so choosing one never reaches the
   // Keychain — and never raises its permission dialog.
   assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
-  assert.equal(await storeIn(directory).readStopHotkey(), "Control+Alt+X");
+  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.stopHotkey.field), "Control+Alt+X");
 });
 
 test("clearing the stop-key chord returns to no choice at all", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);
 
-  await store.setStopHotkey("Control+Alt+X");
-  const { settings } = await store.setStopHotkey(undefined);
+  await store.set(APP_SETTING_SCHEMA.stopHotkey.field, "Control+Alt+X");
+  const { settings } = await store.set(APP_SETTING_SCHEMA.stopHotkey.field, undefined);
 
   assert.equal(settings.stopHotkey, undefined);
   // Absent from the file rather than stored as an empty value: reset is the
   // absence of a choice, and a reopened store must read it the same way.
-  assert.equal(await storeIn(directory).readStopHotkey(), undefined);
+  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.stopHotkey.field), undefined);
 });
 
 test("ignores a stored stop-key chord this build cannot register", async (t) => {
@@ -1082,7 +1139,7 @@ test("ignores a stored stop-key chord this build cannot register", async (t) => 
 
   // A hand-edited chord the registrar would refuse is dropped rather than
   // carried: honouring it would claim a key nothing was ever told about.
-  assert.equal(await store.readStopHotkey(), undefined);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.stopHotkey.field), undefined);
   assert.equal((await store.snapshot()).stopHotkey, undefined);
 });
 
@@ -1090,14 +1147,14 @@ test("the three Luke keys survive each other's writes", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);
 
-  await store.setVoiceHotkey("Control+Alt+Space");
-  await store.setAskHotkey("Control+Alt+K");
-  await store.setStopHotkey("Control+Alt+X");
+  await store.set(APP_SETTING_SCHEMA.voiceHotkey.field, "Control+Alt+Space");
+  await store.set(APP_SETTING_SCHEMA.askHotkey.field, "Control+Alt+K");
+  await store.set(APP_SETTING_SCHEMA.stopHotkey.field, "Control+Alt+X");
 
   const reopened = storeIn(directory);
-  assert.equal(await reopened.readVoiceHotkey(), "Control+Alt+Space");
-  assert.equal(await reopened.readAskHotkey(), "Control+Alt+K");
-  assert.equal(await reopened.readStopHotkey(), "Control+Alt+X");
+  assert.equal(await reopened.get(APP_SETTING_SCHEMA.voiceHotkey.field), "Control+Alt+Space");
+  assert.equal(await reopened.get(APP_SETTING_SCHEMA.askHotkey.field), "Control+Alt+K");
+  assert.equal(await reopened.get(APP_SETTING_SCHEMA.stopHotkey.field), "Control+Alt+X");
 });
 
 test("the talk-key chord and a stored key survive each other's writes", async (t) => {
@@ -1105,12 +1162,12 @@ test("the talk-key chord and a stored key survive each other's writes", async (t
   const store = storeIn(directory);
 
   await store.setApiKey(CONDUCTOR, TEST_API_KEY);
-  await store.setVoiceHotkey("Control+Alt+Space");
+  await store.set(APP_SETTING_SCHEMA.voiceHotkey.field, "Control+Alt+Space");
   await store.setApiKey(CONDUCTOR, "conductor-replacement-key");
 
   const reopened = storeIn(directory);
   assert.equal(await reopened.readApiKey(CONDUCTOR), "conductor-replacement-key");
-  assert.equal(await reopened.readVoiceHotkey(), "Control+Alt+Space");
+  assert.equal(await reopened.get(APP_SETTING_SCHEMA.voiceHotkey.field), "Control+Alt+Space");
 });
 
 test("keeps Luke to the main display until asked, and remembers the answer", async (t) => {
@@ -1118,14 +1175,14 @@ test("keeps Luke to the main display until asked, and remembers the answer", asy
   const store = storeIn(directory);
 
   assert.equal((await store.snapshot()).showOnAllDisplays, false);
-  assert.equal(await store.readShowOnAllDisplays(), false);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.showOnAllDisplays.field), false);
 
-  const { settings, reason } = await store.setShowOnAllDisplays(true);
+  const { settings, reason } = await store.set(APP_SETTING_SCHEMA.showOnAllDisplays.field, true);
 
   assert.equal(reason, undefined);
   assert.equal(settings.showOnAllDisplays, true);
   // The choice outlives the run that heard it.
-  assert.equal(await storeIn(directory).readShowOnAllDisplays(), true);
+  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.showOnAllDisplays.field), true);
 });
 
 test("changes the displays preference without touching the cipher", async (t) => {
@@ -1135,7 +1192,7 @@ test("changes the displays preference without touching the cipher", async (t) =>
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
 
-  const { settings } = await store.setShowOnAllDisplays(true);
+  const { settings } = await store.set(APP_SETTING_SCHEMA.showOnAllDisplays.field, true);
 
   assert.equal(settings.showOnAllDisplays, true);
   assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
@@ -1148,7 +1205,7 @@ test("keeps Luke to the main display when the file says something a boolean is n
     JSON.stringify({ version: 2, apiKeys: {}, showOnAllDisplays: "every one of them" }),
   );
 
-  assert.equal(await storeIn(directory).readShowOnAllDisplays(), false);
+  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.showOnAllDisplays.field), false);
 });
 
 test("draws the bubble until a form is chosen, and remembers the choice", async (t) => {
@@ -1156,14 +1213,20 @@ test("draws the bubble until a form is chosen, and remembers the choice", async 
   const store = storeIn(directory);
 
   assert.equal((await store.snapshot()).formFactor, PANEL_FORM_FACTOR.BUBBLE);
-  assert.equal(await store.readFormFactor(), undefined);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.formFactor.field), undefined);
 
-  const { settings, reason } = await store.setFormFactor(PANEL_FORM_FACTOR.NOTCH);
+  const { settings, reason } = await store.set(
+    APP_SETTING_SCHEMA.formFactor.field,
+    PANEL_FORM_FACTOR.NOTCH,
+  );
 
   assert.equal(reason, undefined);
   assert.equal(settings.formFactor, PANEL_FORM_FACTOR.NOTCH);
   // The choice outlives the run that heard it.
-  assert.equal(await storeIn(directory).readFormFactor(), PANEL_FORM_FACTOR.NOTCH);
+  assert.equal(
+    await storeIn(directory).get(APP_SETTING_SCHEMA.formFactor.field),
+    PANEL_FORM_FACTOR.NOTCH,
+  );
 });
 
 test("changes the form without touching the cipher", async (t) => {
@@ -1171,7 +1234,10 @@ test("changes the form without touching the cipher", async (t) => {
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
 
-  const { settings } = await store.setFormFactor(PANEL_FORM_FACTOR.NOTCH);
+  const { settings } = await store.set(
+    APP_SETTING_SCHEMA.formFactor.field,
+    PANEL_FORM_FACTOR.NOTCH,
+  );
 
   assert.equal(settings.formFactor, PANEL_FORM_FACTOR.NOTCH);
   assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
@@ -1184,7 +1250,7 @@ test("ignores a stored form this build does not draw", async (t) => {
     JSON.stringify({ version: 2, apiKeys: {}, formFactor: "hexagon" }),
   );
 
-  assert.equal(await storeIn(directory).readFormFactor(), undefined);
+  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.formFactor.field), undefined);
   assert.equal((await storeIn(directory).snapshot()).formFactor, PANEL_FORM_FACTOR.BUBBLE);
 });
 
@@ -1195,19 +1261,28 @@ test("asks each time until a default workspace provider is chosen, and remembers
   // Unset on purpose: the default is always a choice the user made — by hand
   // or by their first creation — never one made for them.
   assert.equal((await store.snapshot()).defaultWorkspaceProvider, undefined);
-  assert.equal(await store.readDefaultWorkspaceProvider(), undefined);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field), undefined);
 
-  const { settings, reason } = await store.setDefaultWorkspaceProvider(PROVIDER_ID.CONDUCTOR);
+  const { settings, reason } = await store.set(
+    APP_SETTING_SCHEMA.defaultWorkspaceProvider.field,
+    PROVIDER_ID.CONDUCTOR,
+  );
 
   assert.equal(reason, undefined);
   assert.equal(settings.defaultWorkspaceProvider, PROVIDER_ID.CONDUCTOR);
   // The choice outlives the run that heard it.
-  assert.equal(await storeIn(directory).readDefaultWorkspaceProvider(), PROVIDER_ID.CONDUCTOR);
+  assert.equal(
+    await storeIn(directory).get(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field),
+    PROVIDER_ID.CONDUCTOR,
+  );
 
   // Clearing is returning to asking each time, not storing an answer.
-  const cleared = await store.setDefaultWorkspaceProvider(undefined);
+  const cleared = await store.set(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field, undefined);
   assert.equal(cleared.settings.defaultWorkspaceProvider, undefined);
-  assert.equal(await storeIn(directory).readDefaultWorkspaceProvider(), undefined);
+  assert.equal(
+    await storeIn(directory).get(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field),
+    undefined,
+  );
 });
 
 test("changes the default workspace provider without touching the cipher", async (t) => {
@@ -1215,7 +1290,10 @@ test("changes the default workspace provider without touching the cipher", async
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
 
-  const { settings } = await store.setDefaultWorkspaceProvider(PROVIDER_ID.CURSOR);
+  const { settings } = await store.set(
+    APP_SETTING_SCHEMA.defaultWorkspaceProvider.field,
+    PROVIDER_ID.CURSOR,
+  );
 
   assert.equal(settings.defaultWorkspaceProvider, PROVIDER_ID.CURSOR);
   assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
@@ -1228,7 +1306,10 @@ test("ignores a stored default provider this build does not know", async (t) => 
     JSON.stringify({ version: 2, apiKeys: {}, defaultWorkspaceProvider: "someone-else" }),
   );
 
-  assert.equal(await storeIn(directory).readDefaultWorkspaceProvider(), undefined);
+  assert.equal(
+    await storeIn(directory).get(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field),
+    undefined,
+  );
   assert.equal((await storeIn(directory).snapshot()).defaultWorkspaceProvider, undefined);
 });
 
@@ -1237,24 +1318,24 @@ test("starts new workspaces on the provider's defaults until a pairing is chosen
   const store = storeIn(directory);
 
   assert.equal((await store.snapshot()).workspaceAgentDefaults, undefined);
-  assert.equal(await store.readWorkspaceAgentDefault(PROVIDER_ID.CONDUCTOR), undefined);
+  assert.equal(await readWorkspaceAgentDefault(store, PROVIDER_ID.CONDUCTOR), undefined);
 
   const chosen = { agent: "claude", model: "sonnet", effort: "max" };
-  const { settings, reason } = await store.setWorkspaceAgentDefault(PROVIDER_ID.CONDUCTOR, chosen);
+  const { settings, reason } = await setWorkspaceAgentDefault(store, PROVIDER_ID.CONDUCTOR, chosen);
 
   assert.equal(reason, undefined);
   assert.deepEqual(settings.workspaceAgentDefaults, { [PROVIDER_ID.CONDUCTOR]: chosen });
   // The choice outlives the run that heard it.
   assert.deepEqual(
-    await storeIn(directory).readWorkspaceAgentDefault(PROVIDER_ID.CONDUCTOR),
+    await readWorkspaceAgentDefault(storeIn(directory), PROVIDER_ID.CONDUCTOR),
     chosen,
   );
 
   // Clearing returns that one provider to its own defaults.
-  const cleared = await store.setWorkspaceAgentDefault(PROVIDER_ID.CONDUCTOR, undefined);
+  const cleared = await setWorkspaceAgentDefault(store, PROVIDER_ID.CONDUCTOR, undefined);
   assert.equal(cleared.settings.workspaceAgentDefaults, undefined);
   assert.equal(
-    await storeIn(directory).readWorkspaceAgentDefault(PROVIDER_ID.CONDUCTOR),
+    await readWorkspaceAgentDefault(storeIn(directory), PROVIDER_ID.CONDUCTOR),
     undefined,
   );
 });
@@ -1264,7 +1345,7 @@ test("changes a workspace agent pairing without touching the cipher", async (t) 
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
 
-  const { settings } = await store.setWorkspaceAgentDefault(PROVIDER_ID.CONDUCTOR, {
+  const { settings } = await setWorkspaceAgentDefault(store, PROVIDER_ID.CONDUCTOR, {
     agent: "codex",
     model: "gpt-5.6-sol",
   });
@@ -1283,9 +1364,10 @@ test("lets the first creation choose each provider's project until one is chosen
   // Unset on purpose, the provider default's own terms: the default is always
   // a choice the user made — by hand or by their first creation there.
   assert.equal((await store.snapshot()).workspaceProjectDefaults, undefined);
-  assert.equal(await store.readWorkspaceProjectDefault(PROVIDER_ID.CONDUCTOR), undefined);
+  assert.equal(await readWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR), undefined);
 
-  const { settings, reason } = await store.setWorkspaceProjectDefault(
+  const { settings, reason } = await setWorkspaceProjectDefault(
+    store,
     PROVIDER_ID.CONDUCTOR,
     "proj-1",
   );
@@ -1294,15 +1376,15 @@ test("lets the first creation choose each provider's project until one is chosen
   assert.deepEqual(settings.workspaceProjectDefaults, { [PROVIDER_ID.CONDUCTOR]: "proj-1" });
   // The choice outlives the run that heard it.
   assert.equal(
-    await storeIn(directory).readWorkspaceProjectDefault(PROVIDER_ID.CONDUCTOR),
+    await readWorkspaceProjectDefault(storeIn(directory), PROVIDER_ID.CONDUCTOR),
     "proj-1",
   );
 
   // Clearing returns that one provider to its first creation choosing.
-  const cleared = await store.setWorkspaceProjectDefault(PROVIDER_ID.CONDUCTOR, undefined);
+  const cleared = await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, undefined);
   assert.equal(cleared.settings.workspaceProjectDefaults, undefined);
   assert.equal(
-    await storeIn(directory).readWorkspaceProjectDefault(PROVIDER_ID.CONDUCTOR),
+    await readWorkspaceProjectDefault(storeIn(directory), PROVIDER_ID.CONDUCTOR),
     undefined,
   );
 });
@@ -1312,7 +1394,7 @@ test("changes a default project without touching the cipher", async (t) => {
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
 
-  const { settings } = await store.setWorkspaceProjectDefault(PROVIDER_ID.CURSOR, "proj-2");
+  const { settings } = await setWorkspaceProjectDefault(store, PROVIDER_ID.CURSOR, "proj-2");
 
   assert.deepEqual(settings.workspaceProjectDefaults, { [PROVIDER_ID.CURSOR]: "proj-2" });
   assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
@@ -1322,15 +1404,15 @@ test("keeps one provider's default project apart from another's", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);
 
-  await store.setWorkspaceProjectDefault(PROVIDER_ID.CONDUCTOR, "proj-1");
-  const { settings } = await store.setWorkspaceProjectDefault(PROVIDER_ID.CURSOR, "proj-2");
+  await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "proj-1");
+  const { settings } = await setWorkspaceProjectDefault(store, PROVIDER_ID.CURSOR, "proj-2");
 
   assert.deepEqual(settings.workspaceProjectDefaults, {
     [PROVIDER_ID.CONDUCTOR]: "proj-1",
     [PROVIDER_ID.CURSOR]: "proj-2",
   });
 
-  const cleared = await store.setWorkspaceProjectDefault(PROVIDER_ID.CONDUCTOR, undefined);
+  const cleared = await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, undefined);
   assert.deepEqual(cleared.settings.workspaceProjectDefaults, {
     [PROVIDER_ID.CURSOR]: "proj-2",
   });
@@ -1356,7 +1438,7 @@ test("ignores stored default projects this store cannot hold", async (t) => {
   );
 
   const store = storeIn(directory);
-  assert.equal(await store.readWorkspaceProjectDefault(PROVIDER_ID.CONDUCTOR), undefined);
+  assert.equal(await readWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR), undefined);
   assert.equal((await store.snapshot()).workspaceProjectDefaults, undefined);
 });
 
@@ -1379,7 +1461,7 @@ test("ignores a stored pairing this build's table does not list", async (t) => {
   );
 
   const store = storeIn(directory);
-  assert.equal(await store.readWorkspaceAgentDefault(PROVIDER_ID.CONDUCTOR), undefined);
+  assert.equal(await readWorkspaceAgentDefault(store, PROVIDER_ID.CONDUCTOR), undefined);
   assert.equal((await store.snapshot()).workspaceAgentDefaults, undefined);
 });
 
@@ -1388,12 +1470,12 @@ test("the voice and a stored key survive each other's writes", async (t) => {
   const store = storeIn(directory);
 
   await store.setApiKey(CONDUCTOR, TEST_API_KEY);
-  await store.setVoice(REALTIME_VOICE.MARIN);
+  await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.MARIN);
   await store.setApiKey(CONDUCTOR, "conductor-replacement-key");
 
   const reopened = storeIn(directory);
   assert.equal(await reopened.readApiKey(CONDUCTOR), "conductor-replacement-key");
-  assert.equal(await reopened.readVoice(), REALTIME_VOICE.MARIN);
+  assert.equal(await reopened.get(APP_SETTING_SCHEMA.voice.field), REALTIME_VOICE.MARIN);
 });
 
 test("recovers from a corrupt settings file", async (t) => {
@@ -1410,10 +1492,10 @@ test("recovers from a corrupt settings file", async (t) => {
 test("a voice reset forgets the voice, pace, captions, and duck in one act", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);
-  await store.setVoice(REALTIME_VOICE.MARIN);
-  await store.setVoiceSpeed(REALTIME_VOICE_SPEED.QUICK);
-  await store.setVoiceCaptions(true);
-  await store.setDuckOtherMedia(false);
+  await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.MARIN);
+  await store.set(APP_SETTING_SCHEMA.voiceSpeed.field, REALTIME_VOICE_SPEED.QUICK);
+  await store.set(APP_SETTING_SCHEMA.voiceCaptions.field, true);
+  await store.set(APP_SETTING_SCHEMA.duckOtherMedia.field, false);
 
   const { settings, reason } = await store.resetSettings(SETTINGS_RESET_SCOPE.VOICE);
 
@@ -1424,8 +1506,8 @@ test("a voice reset forgets the voice, pace, captions, and duck in one act", asy
   assert.equal(settings.duckOtherMedia, true);
   // The choices are forgotten rather than restated, so a default that moves
   // in a later build moves these settings with it.
-  assert.equal(await storeIn(directory).readVoice(), undefined);
-  assert.equal(await storeIn(directory).readVoiceSpeed(), undefined);
+  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.voice.field), undefined);
+  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.voiceSpeed.field), undefined);
 });
 
 test("a voice reset returns to the environment's voice where one stands behind the choice", async (t) => {
@@ -1433,23 +1515,23 @@ test("a voice reset returns to the environment's voice where one stands behind t
   const store = storeIn(directory, {
     environment: { LUKE_REALTIME_VOICE: REALTIME_VOICE.SAGE },
   });
-  await store.setVoice(REALTIME_VOICE.MARIN);
+  await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.MARIN);
 
   const { settings } = await store.resetSettings(SETTINGS_RESET_SCOPE.VOICE);
 
   // Forgetting the choice is the reset's whole meaning: what stands afterwards
   // is whatever would have stood had none been made.
   assert.equal(settings.voice, REALTIME_VOICE.SAGE);
-  assert.equal(await store.readVoice(), undefined);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.voice.field), undefined);
 });
 
 test("an appearance reset returns Luke's stances without touching the voice page", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);
-  await store.setShowInDock(true);
-  await store.setShowOnAllDisplays(true);
-  await store.setFormFactor(PANEL_FORM_FACTOR.NOTCH);
-  await store.setVoice(REALTIME_VOICE.MARIN);
+  await store.set(APP_SETTING_SCHEMA.showInDock.field, true);
+  await store.set(APP_SETTING_SCHEMA.showOnAllDisplays.field, true);
+  await store.set(APP_SETTING_SCHEMA.formFactor.field, PANEL_FORM_FACTOR.NOTCH);
+  await store.set(APP_SETTING_SCHEMA.voice.field, REALTIME_VOICE.MARIN);
 
   const { settings, reason } = await store.resetSettings(SETTINGS_RESET_SCOPE.APPEARANCE);
 
@@ -1457,7 +1539,7 @@ test("an appearance reset returns Luke's stances without touching the voice page
   assert.equal(settings.showInDock, false);
   assert.equal(settings.showOnAllDisplays, false);
   assert.equal(settings.formFactor, PANEL_FORM_FACTOR.BUBBLE);
-  assert.equal(await storeIn(directory).readFormFactor(), undefined);
+  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.formFactor.field), undefined);
   // One scope's reset is that scope's alone.
   assert.equal(settings.voice, REALTIME_VOICE.MARIN);
 });
@@ -1465,9 +1547,9 @@ test("an appearance reset returns Luke's stances without touching the voice page
 test("a shortcuts reset forgets all three chords at once", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);
-  await store.setVoiceHotkey("Shift+Command+L");
-  await store.setAskHotkey("Control+Alt+K");
-  await store.setStopHotkey("Control+Alt+X");
+  await store.set(APP_SETTING_SCHEMA.voiceHotkey.field, "Shift+Command+L");
+  await store.set(APP_SETTING_SCHEMA.askHotkey.field, "Control+Alt+K");
+  await store.set(APP_SETTING_SCHEMA.stopHotkey.field, "Control+Alt+X");
 
   const { settings, reason } = await store.resetSettings(SETTINGS_RESET_SCOPE.SHORTCUTS);
 
@@ -1475,18 +1557,18 @@ test("a shortcuts reset forgets all three chords at once", async (t) => {
   assert.equal(settings.voiceHotkey, undefined);
   assert.equal(settings.askHotkey, undefined);
   assert.equal(settings.stopHotkey, undefined);
-  assert.equal(await storeIn(directory).readVoiceHotkey(), undefined);
-  assert.equal(await storeIn(directory).readAskHotkey(), undefined);
-  assert.equal(await storeIn(directory).readStopHotkey(), undefined);
+  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.voiceHotkey.field), undefined);
+  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.askHotkey.field), undefined);
+  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.stopHotkey.field), undefined);
 });
 
 test("a workspaces reset forgets the provider and project defaults but never the agent pairing", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);
   const pairing = { agent: "claude", model: "sonnet" };
-  await store.setDefaultWorkspaceProvider(PROVIDER_ID.CONDUCTOR);
-  await store.setWorkspaceProjectDefault(PROVIDER_ID.CONDUCTOR, "proj-1");
-  await store.setWorkspaceAgentDefault(PROVIDER_ID.CONDUCTOR, pairing);
+  await store.set(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field, PROVIDER_ID.CONDUCTOR);
+  await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "proj-1");
+  await setWorkspaceAgentDefault(store, PROVIDER_ID.CONDUCTOR, pairing);
 
   const { settings, reason } = await store.resetSettings(SETTINGS_RESET_SCOPE.WORKSPACES);
 
@@ -1515,7 +1597,7 @@ test("a reset never touches the cipher", async (t) => {
   const directory = await temporaryDirectory(t);
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
-  await store.setVoiceCaptions(true);
+  await store.set(APP_SETTING_SCHEMA.voiceCaptions.field, true);
 
   await store.resetSettings(SETTINGS_RESET_SCOPE.VOICE);
 
@@ -1571,7 +1653,7 @@ test("with no key stored there is only one source to run on", async (t) => {
   // Choosing the key with none stored changes nothing about what runs: there
   // is nothing there to spend, and a resolution that answered otherwise would
   // send the minter to a credential that does not exist.
-  await store.setVoiceSource(VOICE_SOURCE.KEY);
+  await store.set(APP_SETTING_SCHEMA.voiceSource.field, VOICE_SOURCE.KEY);
   assert.equal(await store.readVoiceSource(), VOICE_SOURCE.ACCOUNT);
 });
 
@@ -1586,7 +1668,7 @@ test("connecting the voice key chooses it, and the allowance can take it back", 
 
   // And back again, with the key still stored — the whole point of the
   // choice: changing sources never costs a credential.
-  await store.setVoiceSource(VOICE_SOURCE.ACCOUNT);
+  await store.set(APP_SETTING_SCHEMA.voiceSource.field, VOICE_SOURCE.ACCOUNT);
   assert.equal(await store.readVoiceSource(), VOICE_SOURCE.ACCOUNT);
   assert.equal(
     (await store.snapshot()).credentialSources[CREDENTIAL_PROVIDER_ID.OPENAI],
@@ -1603,7 +1685,7 @@ test("a choice that would start spending a key is never made by fallback", async
   const store = storeIn(directory);
   await store.setAccount(TEST_ACCOUNT);
   await store.setApiKey(CREDENTIAL_PROVIDER_ID.OPENAI, "sk-developers-own");
-  await store.setVoiceSource(VOICE_SOURCE.ACCOUNT);
+  await store.set(APP_SETTING_SCHEMA.voiceSource.field, VOICE_SOURCE.ACCOUNT);
   assert.equal(await store.readVoiceSource(), VOICE_SOURCE.ACCOUNT);
 
   // Signed out, the allowance they chose cannot answer. The stored key is
@@ -1623,7 +1705,7 @@ test("the chosen source survives a reopen, and a corrupt one reads as no choice"
   const store = storeIn(directory);
   await store.setAccount(TEST_ACCOUNT);
   await store.setApiKey(CREDENTIAL_PROVIDER_ID.OPENAI, "sk-developers-own");
-  await store.setVoiceSource(VOICE_SOURCE.ACCOUNT);
+  await store.set(APP_SETTING_SCHEMA.voiceSource.field, VOICE_SOURCE.ACCOUNT);
   assert.equal(await storeIn(directory).readVoiceSource(), VOICE_SOURCE.ACCOUNT);
 
   // A source this build does not offer is dropped rather than carried, and
@@ -1642,7 +1724,7 @@ test("pasting a key back while parked on the allowance is still choosing it", as
   const store = storeIn(await temporaryDirectory(t));
   await store.setAccount(TEST_ACCOUNT);
   await store.setApiKey(CREDENTIAL_PROVIDER_ID.OPENAI, "sk-developers-own");
-  await store.setVoiceSource(VOICE_SOURCE.ACCOUNT);
+  await store.set(APP_SETTING_SCHEMA.voiceSource.field, VOICE_SOURCE.ACCOUNT);
   assert.equal(await store.readVoiceSource(), VOICE_SOURCE.ACCOUNT);
 
   // The same key again is no change to what is stored, but it is still the

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -156,13 +156,7 @@ async function setWorkspaceAgentDefault(
   providerId: ProviderId,
   selection: WorkspaceAgentSelection | undefined,
 ) {
-  const defaults = { ...(await store.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field)) };
-  if (selection) defaults[providerId] = selection;
-  else delete defaults[providerId];
-  return store.set(
-    "workspaceAgentDefaults",
-    Object.keys(defaults).length > 0 ? defaults : undefined,
-  );
+  return store.setEntry(APP_SETTING_SCHEMA.workspaceAgentDefaults.field, providerId, selection);
 }
 
 async function readWorkspaceProjectDefault(store: SettingsStore, providerId: ProviderId) {
@@ -174,12 +168,10 @@ async function setWorkspaceProjectDefault(
   providerId: ProviderId,
   providerProjectId: string | undefined,
 ) {
-  const defaults = { ...(await store.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field)) };
-  if (providerProjectId) defaults[providerId] = providerProjectId;
-  else delete defaults[providerId];
-  return store.set(
-    "workspaceProjectDefaults",
-    Object.keys(defaults).length > 0 ? defaults : undefined,
+  return store.setEntry(
+    APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
+    providerId,
+    providerProjectId,
   );
 }
 
@@ -1414,6 +1406,42 @@ test("keeps one provider's default project apart from another's", async (t) => {
 
   const cleared = await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, undefined);
   assert.deepEqual(cleared.settings.workspaceProjectDefaults, {
+    [PROVIDER_ID.CURSOR]: "proj-2",
+  });
+});
+
+test("overlapping default projects each survive the other's write", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+
+  // Both start before either lands, the way two provider rows saved in quick
+  // succession do. The merge belongs to the store for exactly this reason: a
+  // caller holding the map it read before the first write would put that stale
+  // copy back, and the later write would drop the other provider's choice.
+  await Promise.all([
+    setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "proj-1"),
+    setWorkspaceProjectDefault(store, PROVIDER_ID.CURSOR, "proj-2"),
+  ]);
+
+  assert.deepEqual((await storeIn(directory).snapshot()).workspaceProjectDefaults, {
+    [PROVIDER_ID.CONDUCTOR]: "proj-1",
+    [PROVIDER_ID.CURSOR]: "proj-2",
+  });
+});
+
+test("an overlapping clear forgets its own entry and no other", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+  await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "proj-1");
+
+  // A row cleared while another row is being saved forgets one entry, never
+  // the map the clear was composed against.
+  await Promise.all([
+    setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, undefined),
+    setWorkspaceProjectDefault(store, PROVIDER_ID.CURSOR, "proj-2"),
+  ]);
+
+  assert.deepEqual((await storeIn(directory).snapshot()).workspaceProjectDefaults, {
     [PROVIDER_ID.CURSOR]: "proj-2",
   });
 });


### PR DESCRIPTION
## Summary

- Declare persisted settings once in a compile-enforced schema, including defaults, guards, settings pages, guide entries, reset scopes, spoken conversions, and main-process effect tags.
- Replace per-setting bridge channels and store accessors with typed `updateSetting(field, value)` and generic `get`/`set` paths while keeping credentials, accounts, and calendar grants separate.
- Derive persistence parsing, page reset state, guide dispatch, and reset effects from the schema while preserving API-key voice-source behavior.
- Declare the two workspace-defaults maps as keyed settings so one entry is merged inside the store's serialized mutation, rather than read, merged, and written back whole by each caller.
- Refuse a whole-map write to a keyed setting, so a map whose entries this build cannot hold can no longer read back as valid and silently clear the stored choice.

## Test plan

- [x] `./scripts/check.sh` — exit 0; 1,348 tests passed, 0 failed (desktop 1,059, sidecar-core 249, web 40); typechecks and desktop/web builds passed.
- [x] `./scripts/verify.sh` — exit 0; packaged the macOS app and captured all six fixture evidence images. The earlier timeout was another worktree holding Luke's single-instance lock, not this branch.
- [x] Visual evidence inspected: expanded, compact, peek, key slot, speaking, and muted all render as before this branch; the settings write path this PR changes is not drawn in the smoke fixture.
- [x] All three Bugbot findings addressed: the lost update (High), whole-map writes clearing stored maps (Medium), and a `/**` left open above `LukeGuideInput` (Low).
- [x] Lost-update regression covered by two new tests that write overlapping default-project entries. Both were confirmed to fail against the previous read-merge-write helper and pass against the store's `setEntry`.
- [ ] Physical-notch check not performed — no notch display available in this environment.

## Notes

- The repository lint run reports 32 existing warnings and no errors, unchanged from before this branch.
- No generated evidence or private state is committed.
- Rebased onto `origin/main` (`7de5f11`) and force-pushed; checks above were re-run on the rebased tree.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32194640321/artifacts/9345444778) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32194640321)

- Commit: `ddc351c7690f81ee0a009ef60413b4284f061e1a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->


