### PR TITLE
feat(desktop): add support for local Devin agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,8 @@ Trust constraints:
   on this machine, and rendered into a bounded reply that is kept nowhere —
   the read performs nothing, reaches no provider, and is offered only for a
   local session whose provider's transcript this build documents reading
-  (Claude Code, Codex, OpenCode, and Cursor's local agents today); a cloud
+  (Claude Code, Codex, OpenCode, and the Devin and Cursor agents running on
+  this machine today); a cloud
   session's conversation lives with its provider and is never fetched. The
   read renders only what the provider actually wrote down — Cursor keeps tool
   outputs out of its transcripts, so a Cursor reading carries none — and a

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -90,6 +90,15 @@ Luke never modifies the running app.
   errors — not the message text, which observation never opens. Installs from
   before OpenCode moved its sessions into that database are read from its
   session and message JSON files with the same boundary.
+- For the Devin sessions running on this machine, Luke opens the Devin CLI's
+  local session database in read-only mode and reads session records plus the
+  bookkeeping of a session's newest turn — the roles along the conversation's
+  chain, whether the newest reply opened tool calls, and the stored name of a
+  tool call still running. The chain's message records are inspected in memory
+  for that bookkeeping alone and their words are never reported, and the
+  column holding a tool call's output is never read. Observation reports no
+  failure for a Devin session, because its database records none this build
+  reads.
 - For the Cursor agents running on this machine, Luke finds recent transcripts,
   opens bounded tails read-only, and reads only the markers around a turn — its
   end and how it ended. Observation does not read message content, and reports
@@ -129,8 +138,9 @@ trust it there; declining costs the same sharper status and nothing else.
 Cursor, "observation never opens message content" — have one bounded,
 on-demand counterpart: in a conversation you are holding with Luke, you can
 ask what a local session did, said, or is stuck on, and Luke reads that
-session's own transcript — Claude Code, Codex, OpenCode, and Cursor's local
-agents today — from the provider's own file or database on this machine. The
+session's own transcript — Claude Code, Codex, OpenCode, and the Devin and
+Cursor agents running on this machine today — from the provider's own file or
+database on this machine. The
 read happens when you ask, is validated against the observed roster, renders a
 bounded excerpt into that conversation's reply, and keeps nothing: no history
 is stored, watched, or indexed, and nothing is fetched from any provider.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Visit [tryluke.dev](https://tryluke.dev) to see Luke in action.
 | Conductor | Cloud sessions | Yes |
 | GitHub Copilot | Cloud agent tasks | Yes |
 | Cursor | Local and cloud sessions | Cloud only |
-| Devin | Cloud sessions | Yes |
+| Devin | Local and cloud sessions | Cloud only |
 | Jules | Cloud sessions | Yes |
 | OpenCode | Local sessions | No |
 | Linear | Assigned issues | Yes |

--- a/apps/desktop/src/devin-adapter.ts
+++ b/apps/desktop/src/devin-adapter.ts
@@ -224,7 +224,10 @@ interface DevinSession {
   observedAt: number;
 }
 
-function millisecondsFromRecord(record: Record<string, unknown>, key: string): number | undefined {
+export function millisecondsFromRecord(
+  record: Record<string, unknown>,
+  key: string,
+): number | undefined {
   const value = record[key];
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return undefined;
   return value < EARLIEST_MILLISECOND_TIMESTAMP ? value * 1000 : value;

--- a/apps/desktop/src/devin-local-adapter.ts
+++ b/apps/desktop/src/devin-local-adapter.ts
@@ -1,0 +1,463 @@
+import os from "node:os";
+import path from "node:path";
+import {
+  agedStatus,
+  isRecord,
+  maximumSessionTitleLength,
+  OBSERVATION_WINDOW,
+  oneLine,
+  type ProviderSessionObservation,
+  recordFromJsonLine,
+  resolveOptions,
+  SESSION_STATUS,
+  type SessionDetail,
+  type SessionProviderAdapter,
+  type SessionStatus,
+  text,
+} from "@sidecar/core";
+import { DEVIN_PROVIDER, millisecondsFromRecord } from "./devin-adapter";
+import { uniquePaths, workspaceLabel } from "./local-session-adapter";
+import {
+  canIgnoreSqliteError,
+  defaultSqliteModule,
+  openReadOnlyDatabase,
+  type SqliteDatabase,
+  type SqliteModuleLoader,
+} from "./local-sqlite";
+
+/**
+ * Observes the Devin sessions running on this machine — the ones its CLI
+ * starts in a terminal — from the state the CLI already writes for itself:
+ * the SQLite database it keeps every session's conversation in. It runs no
+ * server, needs no credential, and opens everything read-only. Sessions
+ * handed to Devin's cloud live with the Devin API and are the cloud
+ * adapter's to observe; the two halves share one provider through the
+ * composite, exactly like Cursor's.
+ */
+
+const DEVIN_ENVIRONMENT = {
+  DATA_HOME: "XDG_DATA_HOME",
+  /** The CLI's own override, so a relocated database is observed where it is. */
+  DATABASE_FILE: "CHISEL_SESSION_DB",
+} as const;
+
+/** The Devin CLI keeps XDG data paths on every platform, macOS included. */
+const DEVIN_DATA_HOME_SEGMENTS = [".local", "share"] as const;
+const DEVIN_DATA_DIRECTORY_SEGMENTS = ["devin", "cli"] as const;
+const DEVIN_DATABASE_FILE = "sessions.db";
+
+const DEVIN_SESSION_COLUMN = {
+  ID: "id",
+  WORKING_DIRECTORY: "working_directory",
+  MODEL: "model",
+  TITLE: "title",
+  MAIN_CHAIN_ID: "main_chain_id",
+  HIDDEN: "hidden",
+  CREATED_AT: "created_at",
+  LAST_ACTIVITY_AT: "last_activity_at",
+} as const;
+
+const DEVIN_NODE_COLUMN = {
+  CHAT_MESSAGE: "chat_message",
+} as const;
+
+const DEVIN_TOOL_CALL_COLUMN = {
+  CALL: "tool_call_json",
+  UPDATE: "tool_call_update_json",
+} as const;
+
+/**
+ * The roles a chat message may carry. The CLI interleaves system context into
+ * the same chain — prompts, skill listings, workspace notes — and those say
+ * nothing about whose move it is, so only the conversation's own three roles
+ * decide the turn.
+ */
+export const DEVIN_ROLE = {
+  SYSTEM: "system",
+  USER: "user",
+  ASSISTANT: "assistant",
+  TOOL: "tool",
+} as const;
+
+/**
+ * The states of a tool call that is still someone's live work. The CLI stores
+ * each call as an ACP `ToolCall` record whose final update lands in a second
+ * column, so a call is open while that update is missing — unless the call's
+ * own status already says it settled, which an interrupted session can leave
+ * behind without ever committing the update.
+ */
+const DEVIN_TOOL_CALL_SETTLED_STATUS = {
+  COMPLETED: "completed",
+  FAILED: "failed",
+} as const;
+
+const DEVIN_ADAPTER_DEFAULTS = {
+  /**
+   * How far up the main chain the turn may be. System context arrives in
+   * runs of a handful of nodes between conversation turns, so the newest
+   * user, assistant, or tool node is well inside this.
+   */
+  MAXIMUM_CHAIN_WALK: 24,
+  MAXIMUM_ACTIVITY_LENGTH: 80,
+} as const;
+
+// Every column is read defensively from the row, so the projection stays `*`:
+// the CLI adds columns by migration, and naming one this build expects but an
+// older install lacks would fail the whole query rather than one field.
+const DEVIN_SESSION_QUERY = `
+  SELECT *
+  FROM sessions
+  WHERE hidden = 0
+  ORDER BY last_activity_at DESC, id DESC
+`;
+
+// The WHERE clause above is the one thing that can name a column an old schema
+// lacks, so a database it fails on is asked again with the filter moved into
+// code, where an absent column is one missing field rather than no sessions.
+const DEVIN_SESSION_QUERY_MINIMAL = `
+  SELECT *
+  FROM sessions
+  ORDER BY last_activity_at DESC, id DESC
+`;
+
+/**
+ * The main chain's newest nodes, tip first. The chain is walked by parent
+ * pointers from the tip the session row names rather than taken from the top
+ * of the table, because a rewound session leaves its abandoned branch as the
+ * newest nodes while the tip points where the conversation actually stands.
+ */
+const DEVIN_CHAIN_QUERY = `
+  WITH RECURSIVE chain (node_id, parent_node_id, chat_message, depth) AS (
+    SELECT node_id, parent_node_id, chat_message, 0
+    FROM message_nodes
+    WHERE session_id = ?1 AND node_id = ?2
+    UNION ALL
+    SELECT nodes.node_id, nodes.parent_node_id, nodes.chat_message, chain.depth + 1
+    FROM message_nodes AS nodes
+    JOIN chain ON nodes.node_id = chain.parent_node_id
+    WHERE nodes.session_id = ?1 AND chain.depth < ?3
+  )
+  SELECT chat_message FROM chain ORDER BY depth
+`;
+
+/** For a session row from before the tip pointer: newest nodes stand in. */
+const DEVIN_NEWEST_NODES_QUERY = `
+  SELECT chat_message
+  FROM message_nodes
+  WHERE session_id = ?1
+  ORDER BY node_id DESC
+  LIMIT ?2
+`;
+
+const DEVIN_TOOL_CALL_QUERY = `
+  SELECT *
+  FROM tool_call_state
+  WHERE session_id = ?1
+`;
+
+type DevinRow = Record<string, unknown>;
+
+export interface DevinLocalAdapterOptions {
+  cliDirectory?: string;
+  now?: () => number;
+  activeSessionFreshnessMs?: number;
+  sqlite?: SqliteModuleLoader;
+}
+
+/**
+ * Whose move the conversation's newest turn says it is. Only the message's
+ * role and whether it opened tool calls are read — the words of the message
+ * stay in the record they were parsed from and go no further.
+ */
+interface DevinTurn {
+  role?: string;
+  toolCallsOpen?: boolean;
+}
+
+interface DevinLocalSessionSnapshot {
+  providerSessionId: string;
+  workingDirectory?: string;
+  title?: string;
+  model?: string;
+  mainChainId?: number;
+  observedAt: number;
+  turn?: DevinTurn;
+  activity?: string;
+}
+
+export function defaultDevinCliDirectory(): string {
+  const dataHome = process.env[DEVIN_ENVIRONMENT.DATA_HOME]?.trim();
+  const base = dataHome || path.join(os.homedir(), ...DEVIN_DATA_HOME_SEGMENTS);
+  return path.join(base, ...DEVIN_DATA_DIRECTORY_SEGMENTS);
+}
+
+/**
+ * Where the database may be, most authoritative first: wherever the CLI's own
+ * `CHISEL_SESSION_DB` points, then the file every install writes.
+ */
+export function devinDatabasePaths(cliDirectory: string): string[] {
+  const configured = process.env[DEVIN_ENVIRONMENT.DATABASE_FILE]?.trim();
+  const configuredPath = configured
+    ? path.isAbsolute(configured)
+      ? configured
+      : path.join(cliDirectory, configured)
+    : undefined;
+  return uniquePaths(
+    [configuredPath, path.join(cliDirectory, DEVIN_DATABASE_FILE)].filter(
+      (candidate): candidate is string => candidate !== undefined,
+    ),
+  );
+}
+
+function textFromRow(row: DevinRow, key: string): string | undefined {
+  return text(row[key]);
+}
+
+/**
+ * Devin names a session after its first prompt and lets the developer rename
+ * it, and that name is what they are looking for. The workspace stands in for
+ * a session that has not been prompted yet, whose title is still empty.
+ */
+function sessionTitle(title: string | undefined, workingDirectory: string | undefined): string {
+  return oneLine(title, maximumSessionTitleLength) ?? workspaceLabel(workingDirectory);
+}
+
+/**
+ * Reads the turn out of the chain's newest conversation node, passing over the
+ * system context the CLI interleaves. Only the role and the presence of open
+ * tool calls are taken; content is never reported anywhere.
+ */
+function turnFromChainRecords(records: readonly Record<string, unknown>[]): DevinTurn | undefined {
+  for (const record of records) {
+    const role = text(record.role);
+    if (role === DEVIN_ROLE.SYSTEM || role === undefined) continue;
+    return {
+      role,
+      toolCallsOpen: Array.isArray(record.tool_calls) && record.tool_calls.length > 0,
+    };
+  }
+  return undefined;
+}
+
+/**
+ * A settled turn is an assistant message that opened no tool calls — the CLI
+ * commits a message when its turn resolves, so an assistant reply on the tip
+ * is holding for the developer, while their own prompt or a tool still in
+ * flight is work under way. The database records no failure this build can
+ * read, so a local Devin session never reports an error. A killed process
+ * leaves an open turn on disk forever, so an open turn gone quiet is unknown
+ * rather than still working.
+ */
+function statusFromTurn(
+  turn: DevinTurn | undefined,
+  observedAt: number,
+  now: number,
+  freshnessMs: number,
+): SessionStatus {
+  const settled = turn?.role === DEVIN_ROLE.ASSISTANT && turn.toolCallsOpen !== true;
+  const status = settled ? SESSION_STATUS.WAITING : SESSION_STATUS.WORKING;
+  if (status === SESSION_STATUS.WORKING && now - observedAt > freshnessMs) {
+    return SESSION_STATUS.UNKNOWN;
+  }
+  return agedStatus(status, observedAt, now, freshnessMs);
+}
+
+/**
+ * Names the work a still-open tool call is doing, from the call's own ACP
+ * record: the title the CLI wrote for it, or failing that its kind. The
+ * call's output lands in the update column, which is never read here.
+ */
+function activityFromToolCallRows(rows: readonly DevinRow[]): string | undefined {
+  for (const row of rows.toReversed()) {
+    if (textFromRow(row, DEVIN_TOOL_CALL_COLUMN.UPDATE)) continue;
+    const call = recordFromJsonLine(textFromRow(row, DEVIN_TOOL_CALL_COLUMN.CALL) ?? "");
+    if (!call) continue;
+    const status = text(call.status);
+    if (
+      status === DEVIN_TOOL_CALL_SETTLED_STATUS.COMPLETED ||
+      status === DEVIN_TOOL_CALL_SETTLED_STATUS.FAILED
+    ) {
+      continue;
+    }
+    const activity =
+      oneLine(text(call.title), DEVIN_ADAPTER_DEFAULTS.MAXIMUM_ACTIVITY_LENGTH) ?? text(call.kind);
+    if (activity) return activity;
+  }
+  return undefined;
+}
+
+function detailFromSnapshot(snapshot: DevinLocalSessionSnapshot): SessionDetail {
+  return {
+    ...(snapshot.activity ? { activity: snapshot.activity } : {}),
+    repository: workspaceLabel(snapshot.workingDirectory),
+    ...(snapshot.model ? { model: snapshot.model } : {}),
+  };
+}
+
+function observationFromSnapshot(
+  snapshot: DevinLocalSessionSnapshot,
+  now: number,
+  activeSessionFreshnessMs: number,
+): ProviderSessionObservation {
+  return {
+    providerSessionId: snapshot.providerSessionId,
+    title: sessionTitle(snapshot.title, snapshot.workingDirectory),
+    status: statusFromTurn(snapshot.turn, snapshot.observedAt, now, activeSessionFreshnessMs),
+    observedAt: snapshot.observedAt,
+    detail: detailFromSnapshot(snapshot),
+  };
+}
+
+function snapshotFromSessionRow(row: DevinRow): DevinLocalSessionSnapshot | undefined {
+  const providerSessionId = textFromRow(row, DEVIN_SESSION_COLUMN.ID);
+  if (!providerSessionId) return undefined;
+  const mainChainId = row[DEVIN_SESSION_COLUMN.MAIN_CHAIN_ID];
+  return {
+    providerSessionId,
+    workingDirectory: textFromRow(row, DEVIN_SESSION_COLUMN.WORKING_DIRECTORY),
+    title: textFromRow(row, DEVIN_SESSION_COLUMN.TITLE),
+    model: textFromRow(row, DEVIN_SESSION_COLUMN.MODEL),
+    ...(typeof mainChainId === "number" && Number.isInteger(mainChainId) ? { mainChainId } : {}),
+    observedAt: Math.max(
+      millisecondsFromRecord(row, DEVIN_SESSION_COLUMN.LAST_ACTIVITY_AT) ?? 0,
+      millisecondsFromRecord(row, DEVIN_SESSION_COLUMN.CREATED_AT) ?? 0,
+    ),
+  };
+}
+
+/**
+ * A hidden session is one the CLI itself keeps off its own listing; it is not
+ * a row here either. Also named in the primary query's WHERE clause — this is
+ * the same reading applied to rows the minimal query let through.
+ */
+function isObservableSessionRow(row: DevinRow): boolean {
+  return row[DEVIN_SESSION_COLUMN.HIDDEN] !== 1;
+}
+
+export class DevinLocalSessionAdapter implements SessionProviderAdapter {
+  readonly provider = DEVIN_PROVIDER;
+
+  readonly #cliDirectory: string;
+  readonly #now: () => number;
+  readonly #activeSessionFreshnessMs: number;
+  readonly #sqlite: SqliteModuleLoader;
+
+  constructor(options: DevinLocalAdapterOptions = {}) {
+    this.#cliDirectory = options.cliDirectory ?? defaultDevinCliDirectory();
+    this.#now = options.now ?? Date.now;
+    const resolved = resolveOptions(
+      options,
+      {
+        activeSessionFreshnessMs: OBSERVATION_WINDOW.ACTIVE_SESSION_FRESHNESS_MS,
+      },
+      {
+        nonNegative: ["activeSessionFreshnessMs"],
+      },
+    );
+    this.#activeSessionFreshnessMs = resolved.activeSessionFreshnessMs;
+    this.#sqlite = options.sqlite ?? defaultSqliteModule;
+  }
+
+  async observe(): Promise<readonly ProviderSessionObservation[]> {
+    for (const databasePath of devinDatabasePaths(this.#cliDirectory)) {
+      const database = await openReadOnlyDatabase(this.#sqlite, databasePath);
+      if (!database) continue;
+      let snapshots: DevinLocalSessionSnapshot[] | undefined;
+      let now = 0;
+      try {
+        now = this.#now();
+        snapshots = this.#databaseSnapshots(database, now);
+      } finally {
+        database.close();
+      }
+      // A database whose schema was unusable answers nothing; the next
+      // candidate may still answer.
+      if (snapshots === undefined) continue;
+      return snapshots.map((snapshot) =>
+        observationFromSnapshot(snapshot, now, this.#activeSessionFreshnessMs),
+      );
+    }
+    return [];
+  }
+
+  /** The session rows, or nothing when neither query fits this database. */
+  #sessionRows(database: SqliteDatabase): DevinRow[] | undefined {
+    for (const query of [DEVIN_SESSION_QUERY, DEVIN_SESSION_QUERY_MINIMAL]) {
+      try {
+        return database
+          .prepare(query)
+          .all()
+          .filter((row): row is DevinRow => isRecord(row));
+      } catch (error) {
+        if (!canIgnoreSqliteError(error)) throw error;
+      }
+    }
+    return undefined;
+  }
+
+  #databaseSnapshots(
+    database: SqliteDatabase,
+    now: number,
+  ): DevinLocalSessionSnapshot[] | undefined {
+    const rows = this.#sessionRows(database);
+    if (rows === undefined) return undefined;
+
+    const snapshots = rows
+      .filter(isObservableSessionRow)
+      .map(snapshotFromSessionRow)
+      .filter((snapshot): snapshot is DevinLocalSessionSnapshot => snapshot !== undefined);
+
+    // Every reported session gets its turn read, because a session without one
+    // would default to working on freshness alone — inventing live work for a
+    // row whose turn actually settled. Each read is an indexed walk from one
+    // session's tip, so the pass costs one cheap query per row.
+    for (const snapshot of snapshots) {
+      snapshot.turn = this.#turnFor(database, snapshot);
+      if (
+        statusFromTurn(snapshot.turn, snapshot.observedAt, now, this.#activeSessionFreshnessMs) ===
+        SESSION_STATUS.WORKING
+      ) {
+        snapshot.activity = this.#activityFor(database, snapshot.providerSessionId);
+      }
+    }
+    return snapshots;
+  }
+
+  #turnFor(database: SqliteDatabase, snapshot: DevinLocalSessionSnapshot): DevinTurn | undefined {
+    const rows =
+      snapshot.mainChainId !== undefined
+        ? this.#rowsFor(database, DEVIN_CHAIN_QUERY, [
+            snapshot.providerSessionId,
+            snapshot.mainChainId,
+            DEVIN_ADAPTER_DEFAULTS.MAXIMUM_CHAIN_WALK,
+          ])
+        : this.#rowsFor(database, DEVIN_NEWEST_NODES_QUERY, [
+            snapshot.providerSessionId,
+            DEVIN_ADAPTER_DEFAULTS.MAXIMUM_CHAIN_WALK,
+          ]);
+    return turnFromChainRecords(
+      rows
+        .map((row) => recordFromJsonLine(textFromRow(row, DEVIN_NODE_COLUMN.CHAT_MESSAGE) ?? ""))
+        .filter((record): record is Record<string, unknown> => record !== undefined),
+    );
+  }
+
+  #activityFor(database: SqliteDatabase, providerSessionId: string): string | undefined {
+    return activityFromToolCallRows(
+      this.#rowsFor(database, DEVIN_TOOL_CALL_QUERY, [providerSessionId]),
+    );
+  }
+
+  /** A node or tool table this build cannot read costs a field, not the pass. */
+  #rowsFor(database: SqliteDatabase, query: string, parameters: readonly unknown[]): DevinRow[] {
+    try {
+      return database
+        .prepare(query)
+        .all(...parameters)
+        .filter((row): row is DevinRow => isRecord(row));
+    } catch (error) {
+      if (canIgnoreSqliteError(error)) return [];
+      throw error;
+    }
+  }
+}

--- a/apps/desktop/src/devin-local-adapter.ts
+++ b/apps/desktop/src/devin-local-adapter.ts
@@ -63,7 +63,6 @@ const DEVIN_NODE_COLUMN = {
 
 const DEVIN_TOOL_CALL_COLUMN = {
   CALL: "tool_call_json",
-  UPDATE: "tool_call_update_json",
 } as const;
 
 /**
@@ -149,10 +148,18 @@ const DEVIN_NEWEST_NODES_QUERY = `
   LIMIT ?2
 `;
 
+// The open tool calls, newest first. Openness is asked of the database — the
+// update column a settled call's output lands in is named only in the WHERE
+// clause, so its contents are never selected — and the projection carries the
+// call record alone. This is also the one query that must name its columns
+// rather than read them defensively, because leaving the output column out of
+// the projection is the point; a schema it does not fit costs the activity
+// field, never the pass.
 const DEVIN_TOOL_CALL_QUERY = `
-  SELECT *
+  SELECT tool_call_json
   FROM tool_call_state
-  WHERE session_id = ?1
+  WHERE session_id = ?1 AND tool_call_update_json IS NULL
+  ORDER BY rowid DESC
 `;
 
 type DevinRow = Record<string, unknown>;
@@ -263,13 +270,14 @@ function statusFromTurn(
 }
 
 /**
- * Names the work a still-open tool call is doing, from the call's own ACP
- * record: the title the CLI wrote for it, or failing that its kind. The
- * call's output lands in the update column, which is never read here.
+ * Names the work the newest still-open tool call is doing, from the call's
+ * own ACP record: the title the CLI wrote for it, or failing that its kind.
+ * The rows arrive newest first and already hold only open calls, so the one
+ * check left to code is the settled status an interrupted session can leave
+ * inside a call whose update never landed.
  */
 function activityFromToolCallRows(rows: readonly DevinRow[]): string | undefined {
-  for (const row of rows.toReversed()) {
-    if (textFromRow(row, DEVIN_TOOL_CALL_COLUMN.UPDATE)) continue;
+  for (const row of rows) {
     const call = recordFromJsonLine(textFromRow(row, DEVIN_TOOL_CALL_COLUMN.CALL) ?? "");
     if (!call) continue;
     const status = text(call.status);

--- a/apps/desktop/src/devin-transcript.ts
+++ b/apps/desktop/src/devin-transcript.ts
@@ -1,0 +1,230 @@
+import { isRecord, oneLine, recordFromJsonLine, text } from "@sidecar/core";
+import { DEVIN_ROLE, defaultDevinCliDirectory, devinDatabasePaths } from "./devin-local-adapter";
+import {
+  canIgnoreSqliteError,
+  defaultSqliteModule,
+  openReadOnlyDatabase,
+  type SqliteDatabase,
+  type SqliteModuleLoader,
+} from "./local-sqlite";
+import { boundedTranscript, TRANSCRIPT_BOUNDS } from "./local-transcript";
+
+/**
+ * On-demand reading of one local Devin session's transcript, for a question
+ * the developer just asked. The message nodes in the CLI's own database are
+ * the transcript — the same table the adapter reads bookkeeping from, here
+ * opened for its words: the main chain's newest nodes, read through
+ * parameterized point queries against the read-only handle, rendered into a
+ * bounded conversation, and discarded. Nothing here is retained, watched, or
+ * written; a session is re-read the next time it is asked about.
+ */
+
+const DEVIN_SPEAKER_NAME = "Devin";
+
+const DEVIN_SESSION_QUERY = `
+  SELECT *
+  FROM sessions
+  WHERE id = ?1
+`;
+
+// The chain is walked by parent pointers from the tip the session row names,
+// exactly as the adapter walks it: a rewound session leaves its abandoned
+// branch as the newest nodes, and compaction re-inserts older messages, so
+// the tip pointer is the one true reading of where the conversation stands.
+const DEVIN_CHAIN_QUERY = `
+  WITH RECURSIVE chain (node_id, parent_node_id, chat_message, depth) AS (
+    SELECT node_id, parent_node_id, chat_message, 0
+    FROM message_nodes
+    WHERE session_id = ?1 AND node_id = ?2
+    UNION ALL
+    SELECT nodes.node_id, nodes.parent_node_id, nodes.chat_message, chain.depth + 1
+    FROM message_nodes AS nodes
+    JOIN chain ON nodes.node_id = chain.parent_node_id
+    WHERE nodes.session_id = ?1 AND chain.depth < ?3
+  )
+  SELECT chat_message FROM chain ORDER BY depth
+`;
+
+/** For a session row from before the tip pointer: newest nodes stand in. */
+const DEVIN_NEWEST_NODES_QUERY = `
+  SELECT chat_message
+  FROM message_nodes
+  WHERE session_id = ?1
+  ORDER BY node_id DESC
+  LIMIT ?2
+`;
+
+const DEVIN_TRANSCRIPT_BOUNDS = {
+  /** How many of the chain's newest nodes one read may walk. */
+  MAXIMUM_CHAIN_WALK: 96,
+} as const;
+
+/**
+ * Tool inputs whose value names the work, in the order they read best. The
+ * set matches what the other transcript renderers already show — a URL is
+ * deliberately not in it, because a signed URL is a credential.
+ */
+const DEVIN_TOOL_INPUT_KEY = [
+  "description",
+  "command",
+  "filePath",
+  "file_path",
+  "pattern",
+  "query",
+] as const;
+
+type DevinRow = Record<string, unknown>;
+
+export interface DevinTranscriptRequest {
+  cliDirectory?: string;
+  providerSessionId: string;
+  sqlite?: SqliteModuleLoader;
+  maximumRenderedLength?: number;
+}
+
+/**
+ * One assistant tool call, in whichever of the shapes the CLI has written it.
+ * A call this build cannot name takes no line rather than a guessed one.
+ */
+function toolLine(call: Record<string, unknown>): string | undefined {
+  const name =
+    text(call.name) ??
+    text(call.tool_name) ??
+    (isRecord(call.function) ? text(call.function.name) : undefined);
+  if (!name) return undefined;
+  const rawArguments = isRecord(call.arguments)
+    ? call.arguments
+    : (recordFromJsonLine(text(call.arguments) ?? "") ??
+      (isRecord(call.function)
+        ? recordFromJsonLine(text(call.function.arguments) ?? "")
+        : undefined));
+  for (const key of DEVIN_TOOL_INPUT_KEY) {
+    const detail = oneLine(text(rawArguments?.[key]), TRANSCRIPT_BOUNDS.MAXIMUM_TOOL_LENGTH);
+    if (detail) return `→ ${name}: ${detail}`;
+  }
+  return `→ ${name}`;
+}
+
+/**
+ * Renders one chat message into the lines a conversation can carry. System
+ * nodes are the CLI's own scaffolding, not something anyone said; a tool
+ * node's content is the answer a call came back with.
+ */
+function linesFromChatMessage(record: Record<string, unknown>): string[] {
+  const role = text(record.role);
+  if (role === DEVIN_ROLE.USER || role === DEVIN_ROLE.ASSISTANT) {
+    const lines: string[] = [];
+    const speaker = role === DEVIN_ROLE.USER ? "Developer" : DEVIN_SPEAKER_NAME;
+    const said = oneLine(text(record.content), TRANSCRIPT_BOUNDS.MAXIMUM_MESSAGE_LENGTH);
+    if (said) lines.push(`${speaker}: ${said}`);
+    if (role === DEVIN_ROLE.ASSISTANT && Array.isArray(record.tool_calls)) {
+      for (const call of record.tool_calls) {
+        if (!isRecord(call)) continue;
+        const line = toolLine(call);
+        if (line) lines.push(line);
+      }
+    }
+    return lines;
+  }
+  if (role === DEVIN_ROLE.TOOL) {
+    const answer = oneLine(text(record.content), TRANSCRIPT_BOUNDS.MAXIMUM_TOOL_LENGTH);
+    return answer ? [`← ${answer}`] : [];
+  }
+  return [];
+}
+
+function readRows(
+  database: SqliteDatabase,
+  query: string,
+  parameters: readonly unknown[],
+): DevinRow[] {
+  try {
+    return database
+      .prepare(query)
+      .all(...parameters)
+      .filter((row): row is DevinRow => isRecord(row));
+  } catch (error) {
+    if (canIgnoreSqliteError(error)) return [];
+    throw error;
+  }
+}
+
+function chainRecords(
+  database: SqliteDatabase,
+  providerSessionId: string,
+  mainChainId: number | undefined,
+): Record<string, unknown>[] {
+  const rows =
+    mainChainId !== undefined
+      ? readRows(database, DEVIN_CHAIN_QUERY, [
+          providerSessionId,
+          mainChainId,
+          DEVIN_TRANSCRIPT_BOUNDS.MAXIMUM_CHAIN_WALK,
+        ])
+      : readRows(database, DEVIN_NEWEST_NODES_QUERY, [
+          providerSessionId,
+          DEVIN_TRANSCRIPT_BOUNDS.MAXIMUM_CHAIN_WALK,
+        ]);
+  const records: Record<string, unknown>[] = [];
+  // Compaction re-inserts a message under a fresh node, so the tip-first walk
+  // keeps each message's newest copy and drops the rest — a no-op on a chain,
+  // which holds one copy, but what keeps the no-tip fallback from repeating
+  // every compacted turn.
+  const seenMessageIds = new Set<string>();
+  for (const row of rows) {
+    const record = recordFromJsonLine(text(row.chat_message) ?? "");
+    if (!record) continue;
+    const messageId = text(record.message_id);
+    if (messageId) {
+      if (seenMessageIds.has(messageId)) continue;
+      seenMessageIds.add(messageId);
+    }
+    records.push(record);
+  }
+  return records.toReversed();
+}
+
+function renderedFromDatabase(
+  database: SqliteDatabase,
+  providerSessionId: string,
+  maximumLength: number,
+): string | undefined {
+  const session = readRows(database, DEVIN_SESSION_QUERY, [providerSessionId])[0];
+  if (!session) return undefined;
+  const mainChainId = session.main_chain_id;
+  const records = chainRecords(
+    database,
+    providerSessionId,
+    typeof mainChainId === "number" && Number.isInteger(mainChainId) ? mainChainId : undefined,
+  );
+  return boundedTranscript(
+    records.flatMap((record) => linesFromChatMessage(record)),
+    maximumLength,
+  );
+}
+
+/**
+ * Reads one session's recent transcript into a bounded rendering, or nothing
+ * when no database holds messages for that id.
+ */
+export async function readDevinSessionTranscript(
+  request: DevinTranscriptRequest,
+): Promise<string | undefined> {
+  const cliDirectory = request.cliDirectory ?? defaultDevinCliDirectory();
+  const sqlite = request.sqlite ?? defaultSqliteModule;
+  for (const databasePath of devinDatabasePaths(cliDirectory)) {
+    const database = await openReadOnlyDatabase(sqlite, databasePath);
+    if (!database) continue;
+    try {
+      const rendered = renderedFromDatabase(
+        database,
+        request.providerSessionId,
+        request.maximumRenderedLength ?? TRANSCRIPT_BOUNDS.MAXIMUM_RENDERED_LENGTH,
+      );
+      if (rendered) return rendered;
+    } finally {
+      database.close();
+    }
+  }
+  return undefined;
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -106,7 +106,9 @@ import { CopilotSessionAdapter } from "./copilot-adapter";
 import { CURSOR_PROVIDER, CursorSessionAdapter } from "./cursor-adapter";
 import { CursorLocalSessionAdapter } from "./cursor-local-adapter";
 import { readCursorSessionTranscript } from "./cursor-transcript";
-import { DevinSessionAdapter } from "./devin-adapter";
+import { DEVIN_PROVIDER, DevinSessionAdapter } from "./devin-adapter";
+import { DevinLocalSessionAdapter } from "./devin-local-adapter";
+import { readDevinSessionTranscript } from "./devin-transcript";
 import { DockPresence } from "./dock-presence";
 import { feedbackDeliveryFromEnvironment } from "./feedback-delivery";
 import { GoogleCalendarReader } from "./google-calendar";
@@ -260,8 +262,17 @@ const cursorAdapter = new CompositeSessionProviderAdapter({
     }),
   ],
 });
-const devinAdapter = new DevinSessionAdapter({
-  readApiKey: () => settingsStore.readApiKey(CREDENTIAL_PROVIDER_ID.DEVIN),
+// Devin runs sessions in two places the same way Cursor does: in a terminal
+// on this machine, observed from the session database its CLI writes for
+// itself, and in its cloud, which needs a key. One provider, one commit.
+const devinAdapter = new CompositeSessionProviderAdapter({
+  provider: DEVIN_PROVIDER,
+  adapters: [
+    new DevinLocalSessionAdapter(),
+    new DevinSessionAdapter({
+      readApiKey: () => settingsStore.readApiKey(CREDENTIAL_PROVIDER_ID.DEVIN),
+    }),
+  ],
 });
 const julesAdapter = new JulesSessionAdapter({
   readApiKey: () => settingsStore.readApiKey(CREDENTIAL_PROVIDER_ID.JULES),
@@ -1825,6 +1836,10 @@ function registerIpc(): void {
     [
       PROVIDER_ID.CURSOR,
       (providerSessionId: string) => readCursorSessionTranscript({ providerSessionId }),
+    ],
+    [
+      PROVIDER_ID.DEVIN,
+      (providerSessionId: string) => readDevinSessionTranscript({ providerSessionId }),
     ],
     [
       PROVIDER_ID.OPENCODE,

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -708,8 +708,8 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       label: "Reading a session's transcript",
       detail:
         "Asked what a local session did, said, or is stuck on, Luke can read that session's own " +
-        "recent transcript — Claude Code, Codex, OpenCode, and the Cursor agents running on " +
-        "this machine today — and answer from it. Cursor keeps tool outputs out of its own " +
+        "recent transcript — Claude Code, Codex, OpenCode, and the Devin and Cursor agents " +
+        "running on this machine today — and answer from it. Cursor keeps tool outputs out of its own " +
         "transcripts, so those readings carry the words and the calls but no results. " +
         "The reading happens when asked and is kept nowhere; cloud sessions keep their " +
         "conversations with their provider, so Luke answers about those from their roster " +
@@ -758,7 +758,7 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       label: "Archiving",
       detail:
         "Where a provider documents an archive endpoint — a Conductor workspace, a Cursor " +
-        "cloud agent, and a Devin session today — Archive is offered as a control once the " +
+        "cloud agent, and a Devin cloud session today — Archive is offered as a control once the " +
         "work there was positively seen to settle: pressed, or asked of Luke in " +
         "conversation, it files the work away through the provider's own endpoint. Archiving a " +
         "Conductor workspace files away every chat in it at once, so when several of its chats " +

--- a/apps/desktop/tests/devin-local-adapter.test.ts
+++ b/apps/desktop/tests/devin-local-adapter.test.ts
@@ -498,6 +498,18 @@ test("names the open tool call a working session is running", async (t) => {
             rawInput: { command: `./scripts/check.sh ${SECRET_TRANSCRIPT_TEXT}` },
           },
         },
+        // Newer than the running call, but an interrupted session left it
+        // settled without its update — passed over rather than reported.
+        {
+          sessionId: "swift-gorge",
+          toolCallId: "call-2",
+          call: {
+            toolCallId: "call-2",
+            title: "Read the interrupted file",
+            kind: "read",
+            status: "completed",
+          },
+        },
       ],
     },
   );

--- a/apps/desktop/tests/devin-local-adapter.test.ts
+++ b/apps/desktop/tests/devin-local-adapter.test.ts
@@ -1,0 +1,659 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import test, { type TestContext } from "node:test";
+import { SESSION_STATUS } from "@sidecar/core";
+import { DEVIN_PROVIDER } from "../src/devin-adapter";
+import { DevinLocalSessionAdapter } from "../src/devin-local-adapter";
+
+const TEST_TIME = Date.parse("2026-08-18T21:30:00.000Z");
+const DEVIN_DATABASE = "sessions.db";
+const TEST_SQLITE_ERROR = {
+  UNKNOWN_BUILTIN_MODULE: "ERR_UNKNOWN_BUILTIN_MODULE",
+} as const;
+const TEST_DEVIN_ENVIRONMENT = {
+  DATABASE_FILE: "CHISEL_SESSION_DB",
+} as const;
+
+/** Words that must never leave the records they are parsed from. */
+const SECRET_TRANSCRIPT_TEXT = "SECRET_ROTATION_TOKEN_ABC123";
+
+/** The CLI stores every clock in seconds; the adapter must not read them as ms. */
+function seconds(timeMs: number): number {
+  return Math.floor(timeMs / 1000);
+}
+
+interface TestSession {
+  id: string;
+  workingDirectory: string;
+  observedAt: number;
+  title?: string;
+  model?: string;
+  mainChainId?: number;
+  hidden?: boolean;
+}
+
+interface TestNode {
+  sessionId: string;
+  nodeId: number;
+  parentNodeId?: number;
+  time: number;
+  message: Record<string, unknown>;
+}
+
+interface TestToolCall {
+  sessionId: string;
+  toolCallId: string;
+  call?: Record<string, unknown>;
+  update?: Record<string, unknown>;
+}
+
+function chatMessage(
+  role: string,
+  content: string,
+  options: { messageId?: string; toolCalls?: readonly Record<string, unknown>[] } = {},
+): Record<string, unknown> {
+  return {
+    message_id: options.messageId ?? `msg-${role}-${content.length}`,
+    role,
+    content,
+    metadata: { is_user_input: role === "user" ? true : null, finish_reason: null },
+    ...(options.toolCalls ? { tool_calls: options.toolCalls } : {}),
+  };
+}
+
+async function temporaryCliDirectory(t: TestContext): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-devin-"));
+  t.after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  return directory;
+}
+
+function writeSession(database: DatabaseSync, session: TestSession): void {
+  database
+    .prepare(`
+      INSERT INTO sessions (
+        id,
+        working_directory,
+        backend_type,
+        model,
+        agent_mode,
+        created_at,
+        last_activity_at,
+        title,
+        main_chain_id,
+        shell_last_seen_index,
+        cogs_json,
+        workspace_dirs,
+        hidden,
+        metadata
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `)
+    .run(
+      session.id,
+      session.workingDirectory,
+      "windsurf",
+      session.model ?? "",
+      "accept-edits",
+      seconds(session.observedAt),
+      seconds(session.observedAt),
+      session.title ?? null,
+      session.mainChainId ?? null,
+      0,
+      null,
+      "[]",
+      session.hidden ? 1 : 0,
+      null,
+    );
+}
+
+function writeNode(database: DatabaseSync, node: TestNode): void {
+  database
+    .prepare(`
+      INSERT INTO message_nodes (session_id, node_id, parent_node_id, chat_message, created_at)
+      VALUES (?, ?, ?, ?, ?)
+    `)
+    .run(
+      node.sessionId,
+      node.nodeId,
+      node.parentNodeId ?? null,
+      JSON.stringify(node.message),
+      seconds(node.time),
+    );
+}
+
+function writeToolCall(database: DatabaseSync, toolCall: TestToolCall): void {
+  database
+    .prepare(`
+      INSERT INTO tool_call_state (session_id, tool_call_id, tool_call_json, tool_call_update_json)
+      VALUES (?, ?, ?, ?)
+    `)
+    .run(
+      toolCall.sessionId,
+      toolCall.toolCallId,
+      toolCall.call ? JSON.stringify(toolCall.call) : null,
+      toolCall.update ? JSON.stringify(toolCall.update) : null,
+    );
+}
+
+async function writeDevinState(
+  cliDirectory: string,
+  sessions: readonly TestSession[],
+  options: {
+    databaseFile?: string;
+    nodes?: readonly TestNode[];
+    toolCalls?: readonly TestToolCall[];
+  } = {},
+): Promise<void> {
+  await fs.mkdir(cliDirectory, { recursive: true });
+  const database = new DatabaseSync(
+    path.join(cliDirectory, options.databaseFile ?? DEVIN_DATABASE),
+    {},
+  );
+  try {
+    database.exec(`
+      CREATE TABLE sessions (
+        id TEXT PRIMARY KEY,
+        working_directory TEXT NOT NULL,
+        backend_type TEXT NOT NULL,
+        model TEXT NOT NULL,
+        agent_mode TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        last_activity_at INTEGER NOT NULL,
+        title TEXT,
+        main_chain_id INTEGER,
+        shell_last_seen_index INTEGER DEFAULT 0,
+        cogs_json TEXT,
+        workspace_dirs TEXT,
+        hidden INTEGER NOT NULL DEFAULT 0,
+        metadata TEXT
+      );
+      CREATE TABLE message_nodes (
+        row_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        node_id INTEGER NOT NULL,
+        parent_node_id INTEGER,
+        chat_message TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        metadata TEXT,
+        UNIQUE(session_id, node_id)
+      );
+      CREATE TABLE tool_call_state (
+        session_id TEXT NOT NULL,
+        tool_call_id TEXT NOT NULL,
+        tool_call_json TEXT,
+        tool_call_update_json TEXT,
+        PRIMARY KEY (session_id, tool_call_id)
+      );
+    `);
+    for (const session of sessions) writeSession(database, session);
+    for (const node of options.nodes ?? []) writeNode(database, node);
+    for (const toolCall of options.toolCalls ?? []) writeToolCall(database, toolCall);
+  } finally {
+    database.close();
+  }
+}
+
+async function writeMalformedDevinState(cliDirectory: string): Promise<void> {
+  await fs.mkdir(cliDirectory, { recursive: true });
+  const database = new DatabaseSync(path.join(cliDirectory, DEVIN_DATABASE), {});
+  try {
+    database.exec("CREATE TABLE unrelated (id TEXT PRIMARY KEY)");
+  } finally {
+    database.close();
+  }
+}
+
+/** A database from before the title, chain-tip, and hidden migrations. */
+async function writeEarlyDevinState(
+  cliDirectory: string,
+  sessions: readonly { id: string; workingDirectory: string; observedAt: number }[],
+): Promise<void> {
+  await fs.mkdir(cliDirectory, { recursive: true });
+  const database = new DatabaseSync(path.join(cliDirectory, DEVIN_DATABASE), {});
+  try {
+    database.exec(`
+      CREATE TABLE sessions (
+        id TEXT PRIMARY KEY,
+        working_directory TEXT NOT NULL,
+        backend_type TEXT NOT NULL,
+        model TEXT NOT NULL,
+        agent_mode TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        last_activity_at INTEGER NOT NULL
+      )
+    `);
+    for (const session of sessions) {
+      database
+        .prepare("INSERT INTO sessions VALUES (?, ?, ?, ?, ?, ?, ?)")
+        .run(
+          session.id,
+          session.workingDirectory,
+          "windsurf",
+          "",
+          "auto",
+          seconds(session.observedAt),
+          seconds(session.observedAt),
+        );
+    }
+  } finally {
+    database.close();
+  }
+}
+
+test("observes a Devin session under the name Devin gave it", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  await writeDevinState(
+    cliDirectory,
+    [
+      {
+        id: "leaf-flax",
+        workingDirectory: "/Users/test/luke",
+        observedAt: TEST_TIME - 60_000,
+        title: "Wire the notch geometry to the housing",
+        model: "swe-1-6-fast",
+        mainChainId: 3,
+      },
+    ],
+    {
+      nodes: [
+        {
+          sessionId: "leaf-flax",
+          nodeId: 0,
+          time: TEST_TIME - 60_000,
+          message: chatMessage("system", `Prompt holding ${SECRET_TRANSCRIPT_TEXT}`),
+        },
+        {
+          sessionId: "leaf-flax",
+          nodeId: 1,
+          parentNodeId: 0,
+          time: TEST_TIME - 60_000,
+          message: chatMessage("user", "Wire the notch geometry to the housing"),
+        },
+        {
+          sessionId: "leaf-flax",
+          nodeId: 2,
+          parentNodeId: 1,
+          time: TEST_TIME - 60_000,
+          message: chatMessage("system", "<available_skills>plumbing</available_skills>"),
+        },
+        {
+          sessionId: "leaf-flax",
+          nodeId: 3,
+          parentNodeId: 2,
+          time: TEST_TIME - 60_000,
+          message: chatMessage("system", "<system_info>workspace context</system_info>"),
+        },
+      ],
+    },
+  );
+
+  const adapter = new DevinLocalSessionAdapter({ cliDirectory, now: () => TEST_TIME });
+  const observations = await adapter.observe();
+
+  assert.deepEqual(adapter.provider, DEVIN_PROVIDER);
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "leaf-flax");
+  assert.equal(observations[0]?.title, "Wire the notch geometry to the housing");
+  // The tip walks past the interleaved system context to the developer's own
+  // prompt, which is a turn Devin still owes an answer to.
+  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
+  // The database stores seconds; the observation must report milliseconds.
+  assert.equal(observations[0]?.observedAt, TEST_TIME - 60_000);
+  assert.deepEqual(observations[0]?.detail, {
+    repository: "luke",
+    model: "swe-1-6-fast",
+  });
+  assert.ok(!JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT));
+});
+
+test("falls back to the workspace while Devin has not named the session", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  await writeDevinState(cliDirectory, [
+    {
+      id: "brisk-otter",
+      workingDirectory: "/Users/test/luke",
+      observedAt: TEST_TIME - 1_000,
+    },
+  ]);
+
+  const adapter = new DevinLocalSessionAdapter({ cliDirectory, now: () => TEST_TIME });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.title, "luke");
+  // A session with no messages yet has just been started.
+  assert.equal(observation?.status, SESSION_STATUS.WORKING);
+});
+
+test("reports a settled Devin turn as waiting for its developer", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  await writeDevinState(
+    cliDirectory,
+    [
+      {
+        id: "calm-harbor",
+        workingDirectory: "/Users/test/luke",
+        observedAt: TEST_TIME - 60_000,
+        title: "Explain the panel motion",
+        mainChainId: 2,
+      },
+    ],
+    {
+      nodes: [
+        {
+          sessionId: "calm-harbor",
+          nodeId: 0,
+          time: TEST_TIME - 120_000,
+          message: chatMessage("user", "Explain the panel motion"),
+        },
+        {
+          sessionId: "calm-harbor",
+          nodeId: 1,
+          parentNodeId: 0,
+          time: TEST_TIME - 60_000,
+          message: chatMessage("assistant", `The spring ${SECRET_TRANSCRIPT_TEXT}`),
+        },
+        {
+          sessionId: "calm-harbor",
+          nodeId: 2,
+          parentNodeId: 1,
+          time: TEST_TIME - 60_000,
+          message: chatMessage("system", "<system_info>context refresh</system_info>"),
+        },
+      ],
+    },
+  );
+
+  const adapter = new DevinLocalSessionAdapter({ cliDirectory, now: () => TEST_TIME });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WAITING);
+  assert.ok(!JSON.stringify(await adapter.observe()).includes(SECRET_TRANSCRIPT_TEXT));
+});
+
+test("ages a settled turn nobody has come back to into unknown", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  const staleTime = TEST_TIME - 16 * 60_000;
+  await writeDevinState(
+    cliDirectory,
+    [
+      {
+        id: "quiet-brook",
+        workingDirectory: "/Users/test/luke",
+        observedAt: staleTime,
+        mainChainId: 1,
+      },
+    ],
+    {
+      nodes: [
+        {
+          sessionId: "quiet-brook",
+          nodeId: 0,
+          time: staleTime,
+          message: chatMessage("user", "hello"),
+        },
+        {
+          sessionId: "quiet-brook",
+          nodeId: 1,
+          parentNodeId: 0,
+          time: staleTime,
+          message: chatMessage("assistant", "Hi!"),
+        },
+      ],
+    },
+  );
+
+  const adapter = new DevinLocalSessionAdapter({ cliDirectory, now: () => TEST_TIME });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.UNKNOWN);
+});
+
+test("ages an open turn a killed process left behind into unknown", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  const staleTime = TEST_TIME - 16 * 60_000;
+  await writeDevinState(
+    cliDirectory,
+    [
+      {
+        id: "left-behind",
+        workingDirectory: "/Users/test/luke",
+        observedAt: staleTime,
+        mainChainId: 0,
+      },
+    ],
+    {
+      nodes: [
+        {
+          sessionId: "left-behind",
+          nodeId: 0,
+          time: staleTime,
+          message: chatMessage("user", "run the suite"),
+        },
+      ],
+    },
+  );
+
+  const adapter = new DevinLocalSessionAdapter({ cliDirectory, now: () => TEST_TIME });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.UNKNOWN);
+});
+
+test("names the open tool call a working session is running", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  await writeDevinState(
+    cliDirectory,
+    [
+      {
+        id: "swift-gorge",
+        workingDirectory: "/Users/test/luke",
+        observedAt: TEST_TIME - 1_000,
+        title: "Run the checks",
+        mainChainId: 1,
+      },
+    ],
+    {
+      nodes: [
+        {
+          sessionId: "swift-gorge",
+          nodeId: 0,
+          time: TEST_TIME - 2_000,
+          message: chatMessage("user", "Run the checks"),
+        },
+        {
+          sessionId: "swift-gorge",
+          nodeId: 1,
+          parentNodeId: 0,
+          time: TEST_TIME - 1_000,
+          message: chatMessage("assistant", "Running them now.", {
+            toolCalls: [{ id: "call-1", name: "exec" }],
+          }),
+        },
+      ],
+      toolCalls: [
+        {
+          sessionId: "swift-gorge",
+          toolCallId: "call-0",
+          call: {
+            toolCallId: "call-0",
+            title: "Read package.json",
+            kind: "read",
+            status: "completed",
+            content: [{ type: "content", content: SECRET_TRANSCRIPT_TEXT }],
+          },
+          update: { toolCallId: "call-0", status: "completed" },
+        },
+        {
+          sessionId: "swift-gorge",
+          toolCallId: "call-1",
+          call: {
+            toolCallId: "call-1",
+            title: "Run ./scripts/check.sh",
+            kind: "execute",
+            status: "in_progress",
+            rawInput: { command: `./scripts/check.sh ${SECRET_TRANSCRIPT_TEXT}` },
+          },
+        },
+      ],
+    },
+  );
+
+  const adapter = new DevinLocalSessionAdapter({ cliDirectory, now: () => TEST_TIME });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WORKING);
+  assert.equal(observation?.detail?.activity, "Run ./scripts/check.sh");
+  assert.ok(!JSON.stringify(await adapter.observe()).includes(SECRET_TRANSCRIPT_TEXT));
+});
+
+test("follows the main chain rather than a rewound session's abandoned branch", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  await writeDevinState(
+    cliDirectory,
+    [
+      {
+        id: "second-try",
+        workingDirectory: "/Users/test/luke",
+        observedAt: TEST_TIME - 1_000,
+        title: "Try again",
+        mainChainId: 2,
+      },
+    ],
+    {
+      nodes: [
+        {
+          sessionId: "second-try",
+          nodeId: 0,
+          time: TEST_TIME - 4_000,
+          message: chatMessage("user", "First attempt"),
+        },
+        // The abandoned branch: an answer the developer rewound away from. It
+        // holds the newest node id, so top-of-table reading would call this
+        // session settled.
+        {
+          sessionId: "second-try",
+          nodeId: 3,
+          parentNodeId: 0,
+          time: TEST_TIME - 3_000,
+          message: chatMessage("assistant", "A settled answer"),
+        },
+        {
+          sessionId: "second-try",
+          nodeId: 2,
+          parentNodeId: 0,
+          time: TEST_TIME - 1_000,
+          message: chatMessage("user", "Second attempt"),
+        },
+      ],
+    },
+  );
+
+  const adapter = new DevinLocalSessionAdapter({ cliDirectory, now: () => TEST_TIME });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WORKING);
+});
+
+test("leaves hidden sessions off the roster", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  await writeDevinState(cliDirectory, [
+    {
+      id: "shown-session",
+      workingDirectory: "/Users/test/luke",
+      observedAt: TEST_TIME - 1_000,
+    },
+    {
+      id: "hidden-session",
+      workingDirectory: "/Users/test/luke",
+      observedAt: TEST_TIME - 1_000,
+      hidden: true,
+    },
+  ]);
+
+  const adapter = new DevinLocalSessionAdapter({ cliDirectory, now: () => TEST_TIME });
+  const observations = await adapter.observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.providerSessionId),
+    ["shown-session"],
+  );
+});
+
+test("reads a database from before the title and hidden migrations", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  await writeEarlyDevinState(cliDirectory, [
+    {
+      id: "early-install",
+      workingDirectory: "/Users/test/luke",
+      observedAt: TEST_TIME - 1_000,
+    },
+  ]);
+
+  const adapter = new DevinLocalSessionAdapter({ cliDirectory, now: () => TEST_TIME });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.providerSessionId, "early-install");
+  assert.equal(observation?.title, "luke");
+});
+
+test("observes nothing where the Devin CLI has never run", async (t) => {
+  const cliDirectory = path.join(await temporaryCliDirectory(t), "missing");
+  const adapter = new DevinLocalSessionAdapter({ cliDirectory, now: () => TEST_TIME });
+  assert.deepEqual(await adapter.observe(), []);
+});
+
+test("observes nothing from a database this build cannot read", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  await writeMalformedDevinState(cliDirectory);
+  const adapter = new DevinLocalSessionAdapter({ cliDirectory, now: () => TEST_TIME });
+  assert.deepEqual(await adapter.observe(), []);
+});
+
+test("observes nothing where the runtime has no sqlite module", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  await writeDevinState(cliDirectory, [
+    { id: "unreadable", workingDirectory: "/Users/test/luke", observedAt: TEST_TIME - 1_000 },
+  ]);
+
+  const adapter = new DevinLocalSessionAdapter({
+    cliDirectory,
+    now: () => TEST_TIME,
+    sqlite: async () => {
+      const error: NodeJS.ErrnoException = new Error("No such built-in module: node:sqlite");
+      error.code = TEST_SQLITE_ERROR.UNKNOWN_BUILTIN_MODULE;
+      throw error;
+    },
+  });
+  assert.deepEqual(await adapter.observe(), []);
+});
+
+test("honors the CLI's own database override", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  const relocatedDirectory = await temporaryCliDirectory(t);
+  await writeDevinState(relocatedDirectory, [
+    {
+      id: "relocated",
+      workingDirectory: "/Users/test/luke",
+      observedAt: TEST_TIME - 1_000,
+    },
+  ]);
+
+  const previous = process.env[TEST_DEVIN_ENVIRONMENT.DATABASE_FILE];
+  process.env[TEST_DEVIN_ENVIRONMENT.DATABASE_FILE] = path.join(relocatedDirectory, DEVIN_DATABASE);
+  t.after(() => {
+    if (previous === undefined) {
+      delete process.env[TEST_DEVIN_ENVIRONMENT.DATABASE_FILE];
+    } else {
+      process.env[TEST_DEVIN_ENVIRONMENT.DATABASE_FILE] = previous;
+    }
+  });
+
+  const adapter = new DevinLocalSessionAdapter({ cliDirectory, now: () => TEST_TIME });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.providerSessionId, "relocated");
+});

--- a/apps/desktop/tests/devin-transcript.test.ts
+++ b/apps/desktop/tests/devin-transcript.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import test, { type TestContext } from "node:test";
+import { readDevinSessionTranscript } from "../src/devin-transcript";
+import { OMISSION_MARKER } from "../src/local-transcript";
+
+const TEST_TIME_S = Math.floor(Date.parse("2026-08-18T21:30:00.000Z") / 1000);
+const DEVIN_DATABASE = "sessions.db";
+
+interface TestNode {
+  nodeId: number;
+  parentNodeId?: number;
+  message: Record<string, unknown>;
+}
+
+async function temporaryCliDirectory(t: TestContext): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-devin-transcript-"));
+  t.after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  return directory;
+}
+
+async function writeDevinSession(
+  cliDirectory: string,
+  sessionId: string,
+  mainChainId: number | undefined,
+  nodes: readonly TestNode[],
+): Promise<void> {
+  await fs.mkdir(cliDirectory, { recursive: true });
+  const database = new DatabaseSync(path.join(cliDirectory, DEVIN_DATABASE), {});
+  try {
+    database.exec(`
+      CREATE TABLE sessions (
+        id TEXT PRIMARY KEY,
+        working_directory TEXT NOT NULL,
+        backend_type TEXT NOT NULL,
+        model TEXT NOT NULL,
+        agent_mode TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        last_activity_at INTEGER NOT NULL,
+        title TEXT,
+        main_chain_id INTEGER,
+        hidden INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE TABLE message_nodes (
+        row_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        node_id INTEGER NOT NULL,
+        parent_node_id INTEGER,
+        chat_message TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        UNIQUE(session_id, node_id)
+      );
+    `);
+    database
+      .prepare(
+        "INSERT INTO sessions VALUES (?, '/Users/test/luke', 'windsurf', '', 'auto', ?, ?, ?, ?, 0)",
+      )
+      .run(sessionId, TEST_TIME_S, TEST_TIME_S, "A test session", mainChainId ?? null);
+    for (const node of nodes) {
+      database
+        .prepare("INSERT INTO message_nodes VALUES (NULL, ?, ?, ?, ?, ?)")
+        .run(
+          sessionId,
+          node.nodeId,
+          node.parentNodeId ?? null,
+          JSON.stringify(node.message),
+          TEST_TIME_S,
+        );
+    }
+  } finally {
+    database.close();
+  }
+}
+
+function message(
+  role: string,
+  content: string,
+  options: { messageId?: string; toolCalls?: readonly Record<string, unknown>[] } = {},
+): Record<string, unknown> {
+  return {
+    message_id: options.messageId ?? `msg-${role}-${content.length}`,
+    role,
+    content,
+    ...(options.toolCalls ? { tool_calls: options.toolCalls } : {}),
+  };
+}
+
+test("renders the main chain as a conversation with tool calls and answers", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  await writeDevinSession(cliDirectory, "leaf-flax", 4, [
+    { nodeId: 0, message: message("system", "You are Devin, a command line agent.") },
+    { nodeId: 1, parentNodeId: 0, message: message("user", "Fix the flaky panel test") },
+    {
+      nodeId: 2,
+      parentNodeId: 1,
+      message: message("assistant", "Let me run it first.", {
+        toolCalls: [
+          { id: "call-1", name: "exec", arguments: JSON.stringify({ command: "pnpm test" }) },
+        ],
+      }),
+    },
+    { nodeId: 3, parentNodeId: 2, message: message("tool", "1 test failed: panel motion") },
+    { nodeId: 4, parentNodeId: 3, message: message("assistant", "Fixed the spring token.") },
+  ]);
+
+  const transcript = await readDevinSessionTranscript({
+    cliDirectory,
+    providerSessionId: "leaf-flax",
+  });
+
+  assert.equal(
+    transcript,
+    [
+      "Developer: Fix the flaky panel test",
+      "Devin: Let me run it first.",
+      "→ exec: pnpm test",
+      "← 1 test failed: panel motion",
+      "Devin: Fixed the spring token.",
+    ].join("\n"),
+  );
+  assert.ok(!transcript?.includes("You are Devin"));
+});
+
+test("keeps each message's newest copy when an old session has no chain tip", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  // Compaction re-inserted the same messages under fresh nodes.
+  await writeDevinSession(cliDirectory, "compacted", undefined, [
+    { nodeId: 0, message: message("user", "hello", { messageId: "m-1" }) },
+    {
+      nodeId: 1,
+      parentNodeId: 0,
+      message: message("assistant", "Hi there!", { messageId: "m-2" }),
+    },
+    { nodeId: 2, message: message("user", "hello", { messageId: "m-1" }) },
+    {
+      nodeId: 3,
+      parentNodeId: 2,
+      message: message("assistant", "Hi there!", { messageId: "m-2" }),
+    },
+  ]);
+
+  const transcript = await readDevinSessionTranscript({
+    cliDirectory,
+    providerSessionId: "compacted",
+  });
+
+  assert.equal(transcript, ["Developer: hello", "Devin: Hi there!"].join("\n"));
+});
+
+test("cuts a long conversation from the front and says so", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  await writeDevinSession(cliDirectory, "long-run", 2, [
+    { nodeId: 0, message: message("user", "First question about the panel and its motion") },
+    { nodeId: 1, parentNodeId: 0, message: message("assistant", "A first considered answer") },
+    { nodeId: 2, parentNodeId: 1, message: message("assistant", "The final answer") },
+  ]);
+
+  const transcript = await readDevinSessionTranscript({
+    cliDirectory,
+    providerSessionId: "long-run",
+    maximumRenderedLength: 60,
+  });
+
+  assert.ok(transcript?.startsWith(OMISSION_MARKER));
+  assert.ok(transcript?.includes("The final answer"));
+});
+
+test("answers nothing for a session the database does not hold", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  await writeDevinSession(cliDirectory, "leaf-flax", undefined, [
+    { nodeId: 0, message: message("user", "hello") },
+  ]);
+
+  assert.equal(
+    await readDevinSessionTranscript({ cliDirectory, providerSessionId: "unknown-session" }),
+    undefined,
+  );
+});
+
+test("answers nothing where the Devin CLI has never run", async (t) => {
+  const cliDirectory = path.join(await temporaryCliDirectory(t), "missing");
+  assert.equal(
+    await readDevinSessionTranscript({ cliDirectory, providerSessionId: "leaf-flax" }),
+    undefined,
+  );
+});


### PR DESCRIPTION
## Summary

Devin's CLI ("Devin for Terminal") runs sessions on this machine, and Luke now observes them the way it observes every other local provider: from the state the provider already writes for itself, read-only, with no credential.

- **`DevinLocalSessionAdapter`** reads the CLI's session database at `~/.local/share/devin/cli/sessions.db` (XDG paths on every platform; `XDG_DATA_HOME` and the CLI's own `CHISEL_SESSION_DB` override honored). A row reports the session's own title (the first prompt, or a `/title` rename, with the workspace as fallback), repository label, and model; status comes from whose move the newest turn on the **main chain** says it is — the chain is walked by parent pointers from the tip the session row names, so a `/revert`-abandoned branch is never mistaken for the conversation — and a working session names the tool call still open from the CLI's own ACP record of it. Hidden sessions stay off the roster, pre-migration schemas fall back to a minimal query, seconds-typed clocks are normalized the same way the cloud adapter already normalizes Devin's API clocks, and a missing directory, locked database, or absent `node:sqlite` observes nothing rather than failing the pass.
- **One provider, one commit**: the local half joins the existing cloud adapter through `CompositeSessionProviderAdapter`, exactly the Cursor pattern, so the two halves cannot retire each other's rows. Local rows stay entirely read-only — message, archive, and every other capability remain the cloud half's alone.
- **Transcript reading in conversation**: asked what a local Devin session did, said, or is stuck on, Luke renders the main chain's newest nodes into the shared bounded line vocabulary (`Developer:` / `Devin:` / `→` / `←`), skipping the system context the CLI interleaves and deduping compaction copies by message id. Read on demand, kept nowhere.
- **Observation stays content-blind**: message records are inspected in memory for role and turn bookkeeping alone, the tool-output column is never read, and the tests plant secret text in message bodies and tool payloads and assert it never reaches an observation.
- Guide, README, PRIVACY.md, and AGENTS.md are taught in the same change (the Archive fact now says "Devin *cloud* session", since a Devin session can now be local).

## Ground truth

Devin's on-disk format is undocumented, so the schema was verified against a real install (devin v3000.4.25): the `sessions` / `message_nodes` / `tool_call_state` tables from the binary's embedded migrations, and a live session row produced by driving `devin acp` — word-pair ids, unix-second clocks, `main_chain_id` tip semantics, `hidden` flag, and the ACP `ToolCall` shape in `tool_call_state`.

## Testing

- 18 new tests: `apps/desktop/tests/devin-local-adapter.test.ts` (13) and `devin-transcript.test.ts` (5), following the OpenCode temp-database pattern with content-blindness assertions.
- `./scripts/check.sh` passes end to end after rebasing onto main (lint, types, all workspace tests, desktop + web builds).
- Not a UI change: nothing drawn changes — local Devin rows render through the existing session row and the already-shipped Devin mark, so no visual evidence or physical-notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/5dc1581e-baf2-4005-9748-0f68ab4b2312)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32191945433/artifacts/9344547259) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32191945433)

- Commit: `34d620690b865b8b76f0715eb6b9761903e28a72`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
