### PR TITLE
feat(desktop): observe Codex cloud tasks through the Codex CLI login

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,23 @@ Trust constraints:
   credentials, or live sessions. A provider whose sessions exist only in a cloud
   service may read a user-supplied API key, but it must observe nothing until
   the user supplies one and must leave every other provider working without it.
+- A cloud surface that documents no key-scoped API and answers only its own
+  CLI — Codex cloud today — is observed through that CLI instead, and the rule
+  keeps its shape at one remove. Observation runs the provider's own binary
+  with a read invocation fixed by the build, under the login the user already
+  gave that CLI for its own sake: the credential never passes through Luke —
+  no token is read, stored, or forwarded — and the CLI answers exactly as it
+  would in the user's own terminal. No shell stands between Luke and the
+  binary, nothing enters an invocation's arguments beyond values the build
+  fixed, and a machine whose CLI is absent or signed out is observed as having
+  nothing, the same answer a key-observed provider gives with no key. The
+  login is the consent, given by the user's own hands to the provider itself,
+  and signing the CLI out withdraws it on the next pass. Writes stay bound to
+  what the CLI documents: Codex documents no way to message or steer a running
+  task, so its cloud sessions advertise none, and the honest absence stands
+  rather than an improvised control. Widening the invocation set, adding a
+  write, or observing another provider this way is a product decision, not an
+  implementation detail.
 - One registration is the exception the previous rule's word "require" leaves
   room for, and it is bounded on every side: Luke may merge an observation
   hook into a provider's own user-level hook configuration — today Claude

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -213,6 +213,30 @@ By default, these requests go to the provider's own API. Changing
 to that configured endpoint, whose policies then govern the request and
 response data.
 
+## Optional Codex cloud reads through the Codex CLI
+
+Codex cloud tasks live in OpenAI's cloud and document no key-scoped API, so
+Luke observes them through the Codex CLI you already use — under the ChatGPT
+login you gave that CLI for its own sake, never a credential of Luke's own.
+Luke reads no token and stores none: it first asks `codex login status`
+whether a login exists at all — an answer read from the exit code alone — and
+only then runs the CLI's documented read, `codex cloud list --json`, exactly
+as your own terminal would. Without the CLI installed, or with it signed out,
+Luke runs nothing further and reports no cloud tasks; the Codex sessions
+running on this machine are read from disk and are unaffected.
+
+What that read returns is what Luke processes: task identifiers, status,
+timestamps, the environment's repository label, and each task's own link. The
+CLI also returns a title generated from the prompt you typed; Luke discards
+it and labels the row by repository instead, the same boundary every cloud
+provider's prompt-derived names get. Returned metadata is held in memory for
+display; command output is not persisted.
+
+Observation never invokes a command that could change anything: the CLI's
+write commands are never run, and Codex documents no way to message or steer
+a running cloud task, so its rows offer none. Signing the CLI out stops the
+reads on the next pass.
+
 ## Optional issue-tracker reads and spoken acts
 
 Linear is read the way the cloud providers are, but connected the way the

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Visit [tryluke.dev](https://tryluke.dev) to see Luke in action.
 | Integration | Support | Credential required |
 | --- | --- | --- |
 | Claude Code | Local sessions | No |
-| Codex | Local sessions | No |
+| Codex | Local and cloud sessions | Cloud via your Codex CLI login |
 | Conductor | Cloud sessions | Yes |
 | GitHub Copilot | Cloud agent tasks | Yes |
 | Cursor | Local and cloud sessions | Cloud only |
@@ -56,9 +56,12 @@ Visit [tryluke.dev](https://tryluke.dev) to see Luke in action.
 
 Cloud integrations remain inactive until you add their credentials in Luke's
 Settings. Linear and Google Calendar are connected by signing in on the
-provider's own consent page rather than by pasting a key. Voice and the optional attention review are included with the
-signed-in account under a daily allowance; connecting your own OpenAI API key
-lifts the allowance and runs both on that key instead.
+provider's own consent page rather than by pasting a key, and Codex cloud
+tasks take no credential in Luke at all: they are observed through the Codex
+CLI's own login — run `codex login` once and the rows follow; sign the CLI
+out and they stop. Voice and the optional attention review are included with
+the signed-in account under a daily allowance; connecting your own OpenAI API
+key lifts the allowance and runs both on that key instead.
 
 ## Calendar support
 

--- a/apps/desktop/src/cli-session-adapter.ts
+++ b/apps/desktop/src/cli-session-adapter.ts
@@ -1,0 +1,320 @@
+import { execFile } from "node:child_process";
+import path from "node:path";
+import {
+  isRecord,
+  type ProviderSessionObservation,
+  resolveOptions,
+  SESSION_LOCATION,
+  type SessionProvider,
+  SessionProviderAdapterBase,
+} from "@sidecar/core";
+import { CLI_CONNECTION, type CliConnection } from "./shared/contracts";
+
+/**
+ * How a CLI-observed provider fails. Unavailable means there is nothing to
+ * observe with — the binary is not installed, or its login probe answered no —
+ * which is the CLI analogue of a missing API key and clears observed state the
+ * same way. Transient covers a command that ran and failed, which keeps the
+ * last snapshot until the next attempt the way a network blip does.
+ */
+export const CLI_FAILURE = {
+  UNAVAILABLE: "unavailable",
+  TRANSIENT: "transient",
+} as const;
+
+export type CliFailure = (typeof CLI_FAILURE)[keyof typeof CLI_FAILURE];
+
+export class CliCommandError extends Error {
+  readonly failure: CliFailure;
+
+  constructor(failure: CliFailure, message: string) {
+    super(message);
+    this.name = "CliCommandError";
+    this.failure = failure;
+  }
+}
+
+export const CLI_ADAPTER_DEFAULTS = {
+  MINIMUM_REFRESH_INTERVAL_MS: 15 * 1000,
+  COMMAND_TIMEOUT_MS: 8 * 1000,
+  /** A read that answers with more than this is not the bounded list it claims to be. */
+  MAXIMUM_OUTPUT_BYTES: 4 * 1024 * 1024,
+} as const;
+
+/**
+ * Where provider CLIs actually land on a Mac. An app launched from the Finder
+ * inherits a PATH without the package-manager directories a terminal adds, so
+ * these are appended after the inherited PATH — never ahead of it, so a binary
+ * the user's own shell would resolve still wins.
+ */
+const WELL_KNOWN_BINARY_DIRECTORIES = ["/opt/homebrew/bin", "/usr/local/bin"] as const;
+
+export interface CliRunResult {
+  exitCode: number;
+  stdout: string;
+}
+
+export type CliRun = (
+  binary: string,
+  argv: readonly string[],
+  options: Readonly<{ timeoutMs: number; maximumOutputBytes: number }>,
+) => Promise<CliRunResult>;
+
+/**
+ * Runs the binary directly — no shell, so nothing in an argument can become a
+ * second command — and answers with the exit code rather than throwing on it:
+ * a probe's no is an answer, not a failure. Only a binary that cannot run at
+ * all is unavailable; a command that ran out of time or output is transient.
+ */
+const defaultRun: CliRun = (binary, argv, options) =>
+  new Promise((resolve, reject) => {
+    execFile(
+      binary,
+      argv,
+      {
+        timeout: options.timeoutMs,
+        maxBuffer: options.maximumOutputBytes,
+        windowsHide: true,
+        env: {
+          ...process.env,
+          PATH: [process.env.PATH, ...WELL_KNOWN_BINARY_DIRECTORIES]
+            .filter(Boolean)
+            .join(path.delimiter),
+        },
+      },
+      (error, stdout) => {
+        if (error === null) {
+          resolve({ exitCode: 0, stdout });
+          return;
+        }
+        const exitCode = (error as NodeJS.ErrnoException & { code?: unknown }).code;
+        if (typeof exitCode === "number") {
+          resolve({ exitCode, stdout });
+          return;
+        }
+        reject(
+          new CliCommandError(
+            (error as NodeJS.ErrnoException).code === "ENOENT"
+              ? CLI_FAILURE.UNAVAILABLE
+              : CLI_FAILURE.TRANSIENT,
+            `${binary} could not be run`,
+          ),
+        );
+      },
+    );
+  });
+
+export interface CliAdapterOptions {
+  run?: CliRun;
+  now?: () => number;
+  minimumRefreshIntervalMs?: number;
+  /**
+   * Called when an observation pass fails for a reason other than the CLI
+   * being unavailable or a command failing — a TypeError in a subclass's
+   * parsing, for example. Unavailable and transient failures never reach it.
+   */
+  onDiagnostic?: (error: unknown) => void;
+}
+
+/** The provider identity and the one binary a subclass observes with. */
+export interface CliAdapterProfile {
+  provider: SessionProvider;
+  /** The provider's own CLI, resolved the way the user's shell would resolve it. */
+  binary: string;
+  /**
+   * The read that answers whether the CLI holds a login, by exit code alone.
+   * Its stdout is never parsed: what the account is called is the CLI's
+   * business, and whether it exists is the only fact observation needs.
+   */
+  loginProbeArgv: readonly string[];
+}
+
+/**
+ * The only way a subclass reaches its provider while observing: one invocation
+ * of the profile's binary, bounded in time and output, parsed as JSON, and
+ * discarded past what the subclass reports. The argv a subclass passes must be
+ * fixed by the build — the same rule that fixes a POSTed read document — with
+ * nothing interpolated beyond bounded values the provider itself reported.
+ */
+export type CliReadRequest = (argv: readonly string[]) => Promise<Record<string, unknown>>;
+
+/**
+ * The shared half of every CLI-observed provider adapter: the login gate, its
+ * own refresh cadence, the failure rules that decide whether a snapshot
+ * survives, and bounded read-only invocations of the provider's own CLI.
+ *
+ * The credential never passes through Luke. The CLI holds the login the user
+ * gave it for its own sake, and observation runs under it exactly as the
+ * user's own terminal would — Luke reads no token, stores none, and passes
+ * none. A machine whose CLI is absent or signed out is observed as having
+ * nothing, the same answer a cloud provider gives with no key, so observation
+ * begins and ends with the user's own login and nothing else.
+ */
+export abstract class CliSessionAdapter extends SessionProviderAdapterBase {
+  readonly provider: SessionProvider;
+
+  readonly #binary: string;
+  readonly #loginProbeArgv: readonly string[];
+  readonly #run: CliRun;
+  readonly #now: () => number;
+  readonly #minimumRefreshIntervalMs: number;
+  readonly #onDiagnostic: ((error: unknown) => void) | undefined;
+
+  #observations: readonly ProviderSessionObservation[] = [];
+  #lastAttemptAt = Number.NEGATIVE_INFINITY;
+  #collectPass = 0;
+  #connection: CliConnection = CLI_CONNECTION.UNKNOWN;
+
+  constructor(profile: CliAdapterProfile, options: CliAdapterOptions = {}) {
+    super();
+    this.provider = profile.provider;
+    this.#binary = profile.binary;
+    this.#loginProbeArgv = profile.loginProbeArgv;
+    this.#run = options.run ?? defaultRun;
+    this.#now = options.now ?? Date.now;
+    const { minimumRefreshIntervalMs } = resolveOptions(
+      options,
+      { minimumRefreshIntervalMs: CLI_ADAPTER_DEFAULTS.MINIMUM_REFRESH_INTERVAL_MS },
+      { nonNegative: ["minimumRefreshIntervalMs"] },
+    );
+    this.#minimumRefreshIntervalMs = minimumRefreshIntervalMs;
+    this.#onDiagnostic = options.onDiagnostic;
+  }
+
+  async observe(): Promise<readonly ProviderSessionObservation[]> {
+    const now = this.#now();
+    // A CLI is spawned per read, so the cadence guard leads everything: the
+    // shared refresh timer ticks faster than a process-per-pass should run.
+    if (now - this.#lastAttemptAt < this.#minimumRefreshIntervalMs) return this.#observations;
+    this.#lastAttemptAt = now;
+
+    const pass = ++this.#collectPass;
+    try {
+      // The login is probed every pass rather than cached, so signing the CLI
+      // out is honoured on the next pass the way removing a key is: state read
+      // under a login that no longer stands must not keep being served.
+      const connection = await this.#probeLogin();
+      this.#connection = connection;
+      if (connection !== CLI_CONNECTION.CONNECTED) {
+        this.#forgetObservedState(pass);
+        return this.#observations;
+      }
+      const collected = await this.collect(this.#requestForPass(pass), now);
+      if (pass === this.#collectPass) this.#observations = cliObservations(collected);
+    } catch (error) {
+      // A superseded pass says nothing about the login that now stands.
+      if (pass !== this.#collectPass) return this.#observations;
+      if (error instanceof CliCommandError) {
+        // A binary gone mid-pass clears observed state; a command that ran and
+        // failed keeps the previous snapshot until the next attempt.
+        if (error.failure === CLI_FAILURE.UNAVAILABLE) {
+          this.#connection = CLI_CONNECTION.CLI_MISSING;
+          this.#forgetObservedState(pass);
+        }
+        return this.#observations;
+      }
+      // Anything else is a bug in this pass — a TypeError thrown by a
+      // subclass's parsing is not a flaky command, and must not keep serving
+      // the stale snapshot with no log, counter, or hook.
+      this.#onDiagnostic?.(error);
+      throw error;
+    }
+    return this.#observations;
+  }
+
+  /** Runs one login-gated pass. Duplicate session ids are dropped by the base. */
+  protected abstract collect(
+    request: CliReadRequest,
+    now: number,
+  ): Promise<readonly ProviderSessionObservation[]>;
+
+  /**
+   * What the latest pass learned about the login behind this provider, for a
+   * settings row to report — never the login itself, which stays the CLI's.
+   */
+  connection(): CliConnection {
+    return this.#connection;
+  }
+
+  async #probeLogin(): Promise<CliConnection> {
+    try {
+      const probe = await this.#run(this.#binary, this.#loginProbeArgv, {
+        timeoutMs: CLI_ADAPTER_DEFAULTS.COMMAND_TIMEOUT_MS,
+        maximumOutputBytes: CLI_ADAPTER_DEFAULTS.MAXIMUM_OUTPUT_BYTES,
+      });
+      return probe.exitCode === 0 ? CLI_CONNECTION.CONNECTED : CLI_CONNECTION.SIGNED_OUT;
+    } catch (error) {
+      // A probe that cannot run at all is a machine with nothing to observe;
+      // a probe that ran out of time says nothing about the login either way,
+      // so the pass keeps its snapshot and asks again next time.
+      if (error instanceof CliCommandError && error.failure === CLI_FAILURE.UNAVAILABLE) {
+        return CLI_CONNECTION.CLI_MISSING;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Binds one pass's invocations to its own currency, so a slow command from
+   * a pass that has been superseded fails instead of landing its answer over
+   * state that belongs to the newer pass.
+   */
+  #requestForPass(pass: number): CliReadRequest {
+    return async (argv) => {
+      this.#assertPassCurrent(pass);
+      const result = await this.#run(this.#binary, argv, {
+        timeoutMs: CLI_ADAPTER_DEFAULTS.COMMAND_TIMEOUT_MS,
+        maximumOutputBytes: CLI_ADAPTER_DEFAULTS.MAXIMUM_OUTPUT_BYTES,
+      });
+      this.#assertPassCurrent(pass);
+      const name = this.provider.displayName;
+      if (result.exitCode !== 0) {
+        throw new CliCommandError(CLI_FAILURE.TRANSIENT, `${name} CLI answered with a failure`);
+      }
+      let body: unknown;
+      try {
+        body = JSON.parse(result.stdout);
+      } catch {
+        throw new CliCommandError(CLI_FAILURE.TRANSIENT, `${name} CLI answered unreadably`);
+      }
+      if (!isRecord(body)) {
+        throw new CliCommandError(CLI_FAILURE.TRANSIENT, `${name} CLI answered unexpectedly`);
+      }
+      return body;
+    };
+  }
+
+  #assertPassCurrent(pass: number): void {
+    if (pass !== this.#collectPass) {
+      throw new CliCommandError(
+        CLI_FAILURE.TRANSIENT,
+        `${this.provider.displayName} pass was superseded`,
+      );
+    }
+  }
+
+  #forgetObservedState(pass: number): void {
+    if (pass !== this.#collectPass) return;
+    this.#observations = [];
+  }
+}
+
+/**
+ * Drops a session a subclass reported twice, and stamps the location the base
+ * already knows: nothing reaches this point except through the provider's own
+ * cloud CLI, so a subclass cannot forget to say its sessions run elsewhere.
+ */
+function cliObservations(
+  observations: readonly ProviderSessionObservation[],
+): readonly ProviderSessionObservation[] {
+  const unique = new Map<string, ProviderSessionObservation>();
+  for (const observation of observations) {
+    if (!unique.has(observation.providerSessionId)) {
+      unique.set(observation.providerSessionId, {
+        ...observation,
+        location: SESSION_LOCATION.CLOUD,
+      });
+    }
+  }
+  return [...unique.values()];
+}

--- a/apps/desktop/src/codex-cloud-adapter.ts
+++ b/apps/desktop/src/codex-cloud-adapter.ts
@@ -1,0 +1,144 @@
+import { type ProviderSessionObservation, SESSION_STATUS, type SessionStatus } from "@sidecar/core";
+import {
+  type CliAdapterOptions,
+  type CliReadRequest,
+  CliSessionAdapter,
+} from "./cli-session-adapter";
+import {
+  isDefined,
+  knownValue,
+  recordsFromPage,
+  repositoryLabel,
+  textFromRecord,
+  timestampFromRecord,
+} from "./cloud-session-adapter";
+import { CODEX_PROVIDER } from "./codex-adapter";
+
+/**
+ * The two invocations this adapter is allowed to make, fixed by the build the
+ * way a cloud adapter's routes are. `login status` answers by exit code alone
+ * whether the CLI holds the user's ChatGPT login, and `cloud list --json` is
+ * the CLI's documented machine-readable read of the account's cloud tasks —
+ * the documented maximum page, newest tasks first, so one call per pass is
+ * the whole read.
+ */
+const CODEX_CLI = {
+  BINARY: "codex",
+  LOGIN_PROBE_ARGV: ["login", "status"],
+  LIST_TASKS_ARGV: ["cloud", "list", "--json", "--limit", "20"],
+} as const;
+
+const CODEX_TASK_FIELD = {
+  ENVIRONMENT_LABEL: "environment_label",
+  ID: "id",
+  STATUS: "status",
+  TASKS: "tasks",
+  UPDATED_AT: "updated_at",
+  URL: "url",
+} as const;
+
+/** The CLI's documented task states, kebab-case as its JSON serializes them. */
+const CODEX_TASK_STATUS = {
+  PENDING: "pending",
+  READY: "ready",
+  APPLIED: "applied",
+  ERROR: "error",
+} as const;
+
+type CodexTaskStatus = (typeof CODEX_TASK_STATUS)[keyof typeof CODEX_TASK_STATUS];
+
+/**
+ * A pending task is queued or running; Codex documents no way to tell those
+ * apart, and neither asks anything of the user yet. Ready and applied are both
+ * a finished turn — ready holds a diff nobody has taken and applied one the
+ * user already pulled down — and a Codex task takes no follow-up, so neither
+ * is ever waiting. An errored task stopped on something it cannot get past.
+ */
+const SESSION_STATUS_BY_CODEX_TASK_STATUS: Readonly<Record<CodexTaskStatus, SessionStatus>> = {
+  [CODEX_TASK_STATUS.PENDING]: SESSION_STATUS.WORKING,
+  [CODEX_TASK_STATUS.READY]: SESSION_STATUS.COMPLETE,
+  [CODEX_TASK_STATUS.APPLIED]: SESSION_STATUS.COMPLETE,
+  [CODEX_TASK_STATUS.ERROR]: SESSION_STATUS.ERROR,
+} as const;
+
+export type CodexCloudAdapterOptions = CliAdapterOptions;
+
+interface CodexCloudTask {
+  id: string;
+  repositoryLabel: string;
+  status: SessionStatus;
+  observedAt: number;
+  link?: string;
+}
+
+function taskFromRecord(record: Record<string, unknown>): CodexCloudTask | undefined {
+  const id = textFromRecord(record, CODEX_TASK_FIELD.ID);
+  const observedAt = timestampFromRecord(record, CODEX_TASK_FIELD.UPDATED_AT);
+  if (!id || observedAt === undefined) return undefined;
+
+  const status = knownValue(CODEX_TASK_STATUS, textFromRecord(record, CODEX_TASK_FIELD.STATUS));
+  const link = textFromRecord(record, CODEX_TASK_FIELD.URL);
+
+  return {
+    id,
+    observedAt,
+    // A task's `title` is generated from the prompt the user typed, so it is
+    // transcript content that no observation may carry. The environment label
+    // — the repository the environment was made for — is the label available.
+    repositoryLabel: repositoryLabel(
+      textFromRecord(record, CODEX_TASK_FIELD.ENVIRONMENT_LABEL),
+      undefined,
+    ),
+    // A state this build does not know is not guessed at.
+    status: status ? SESSION_STATUS_BY_CODEX_TASK_STATUS[status] : SESSION_STATUS.UNKNOWN,
+    ...(link ? { link } : {}),
+  };
+}
+
+/**
+ * Observes Codex cloud tasks through the Codex CLI's own documented read,
+ * under the ChatGPT login the user already gave that CLI — Luke reads no
+ * token and stores none, and a machine whose CLI is absent or signed out is
+ * observed as having nothing. Codex documents no way to message or control a
+ * running task, so these sessions advertise no writes at all: rows say where
+ * cloud tasks stand, and their address opens them where they live.
+ */
+export class CodexCloudSessionAdapter extends CliSessionAdapter {
+  constructor(options: CodexCloudAdapterOptions = {}) {
+    super(
+      {
+        provider: CODEX_PROVIDER,
+        binary: CODEX_CLI.BINARY,
+        loginProbeArgv: CODEX_CLI.LOGIN_PROBE_ARGV,
+      },
+      options,
+    );
+  }
+
+  protected async collect(
+    request: CliReadRequest,
+    _now: number,
+  ): Promise<readonly ProviderSessionObservation[]> {
+    const body = await request(CODEX_CLI.LIST_TASKS_ARGV);
+    return recordsFromPage(body, CODEX_TASK_FIELD.TASKS)
+      .map(taskFromRecord)
+      .filter(isDefined)
+      .sort((first, second) => second.observedAt - first.observedAt)
+      .map((task) => observationFor(task));
+  }
+}
+
+function observationFor(task: CodexCloudTask): ProviderSessionObservation {
+  return {
+    providerSessionId: task.id,
+    // The provider is already on the row as its mark, so the title carries
+    // only what tells one Codex cloud task from another.
+    title: task.repositoryLabel,
+    status: task.status,
+    observedAt: task.observedAt,
+    detail: {
+      repository: task.repositoryLabel,
+      ...(task.link ? { link: task.link } : {}),
+    },
+  };
+}

--- a/apps/desktop/src/desktop-app.ts
+++ b/apps/desktop/src/desktop-app.ts
@@ -43,6 +43,7 @@ import { AccountClient } from "./account-client";
 import { accountGateOpen } from "./account-gate";
 import { AccountSessionManager } from "./account-session-manager";
 import { buildCarriesDeveloperIdSigning, resolveAppName } from "./app-identity";
+import { CodexCloudSessionAdapter } from "./codex-cloud-adapter";
 import { DockPresence } from "./dock-presence";
 import { feedbackDeliveryFromEnvironment } from "./feedback-delivery";
 import { GoogleCalendarReader } from "./google-calendar";
@@ -131,6 +132,12 @@ const HOSTED_SERVICE_BASE_URL = ACCOUNT_BASE_URL.replace(/\/api\/auth\/?$/, "");
 const ACCOUNT_CLIENT_ID = "luke-desktop";
 const SESSION_REFRESH_INTERVAL_MS = 5_000;
 const sessionRegistry = new InMemorySessionRegistry();
+// Declared before the settings store because the store's snapshot asks it
+// what the latest pass learned about the Codex CLI's login. It observes only
+// inside the codex composite the provider registrations build; a fixture or
+// evidence run never refreshes it, so there its answer stays the honest
+// "unknown".
+const codexCloudAdapter = new CodexCloudSessionAdapter();
 // `directory` and the cipher are read lazily so the store can be declared before
 // the Electron app is ready.
 const settingsStore = new SettingsStore({
@@ -143,6 +150,7 @@ const settingsStore = new SettingsStore({
     encrypt: (plainText) => safeStorage.encryptString(plainText),
     decrypt: (cipherText) => safeStorage.decryptString(cipherText),
   },
+  codexCloudConnection: () => codexCloudAdapter.connection(),
 });
 const accountClient = new AccountClient({ baseUrl: ACCOUNT_BASE_URL, clientId: ACCOUNT_CLIENT_ID });
 let account: AccountSnapshot = { status: ACCOUNT_STATUS.SIGNED_OUT };
@@ -168,6 +176,7 @@ const providerRegistry = providerRegistrations({
   readApiKey: (providerId) => settingsStore.readApiKey(providerId),
   claudeHookInstallation: () => observationHooks.claudeInstallation(),
   codexHookInstallation: () => observationHooks.codexInstallation(),
+  codexCloudAdapter,
 });
 // The issue tracker is not a session provider: its issues feed the voice
 // roster rather than the registry, so it stands beside the adapters rather
@@ -441,6 +450,22 @@ function broadcastAccount(): void {
  * renderer keeps drawing the voice state of the account it no longer has.
  */
 async function broadcastVoiceAvailability(): Promise<void> {
+  panels.broadcast(channels.settingsChanged, await settingsStore.snapshot());
+}
+
+/**
+ * What the settings last told the panels about the Codex CLI login. The
+ * connection is not a setting anyone writes, so no save ever announces it
+ * moving: the observation loop is where it changes — the user ran codex
+ * login or logout in their own terminal — and without this the panels keep
+ * drawing the words of whatever snapshot they loaded.
+ */
+let announcedCodexCloudConnection = codexCloudAdapter.connection();
+
+async function broadcastCodexCloudConnection(): Promise<void> {
+  const connection = codexCloudAdapter.connection();
+  if (connection === announcedCodexCloudConnection) return;
+  announcedCodexCloudConnection = connection;
   panels.broadcast(channels.settingsChanged, await settingsStore.snapshot());
 }
 
@@ -1040,7 +1065,12 @@ const sessionObservationLoop = new ObservationLoop({
   gate: observationGate,
   intervalMs: SESSION_REFRESH_INTERVAL_MS,
   run: refreshProviderSessions,
-  afterRun: broadcastRelevantSessions,
+  // A pass is also when the Codex CLI login can have changed hands, and no
+  // settings save stands behind that to announce it.
+  afterRun: () => {
+    broadcastRelevantSessions();
+    void broadcastCodexCloudConnection();
+  },
 });
 const attentionObservationLoop = new ObservationLoop({
   gate: () => observationGate() && voiceCapabilities.attentionReviewer !== undefined,

--- a/apps/desktop/src/provider-registrations.ts
+++ b/apps/desktop/src/provider-registrations.ts
@@ -6,7 +6,8 @@ import {
   installClaudeCodeObservationHooks,
   pruneClaudeHookSpool,
 } from "./claude-code-hooks";
-import { CodexSessionAdapter } from "./codex-adapter";
+import { CODEX_PROVIDER, CodexSessionAdapter } from "./codex-adapter";
+import type { CodexCloudSessionAdapter } from "./codex-cloud-adapter";
 import {
   CODEX_HOOK_SPOOL_MAXIMUM_AGE_MS,
   type CodexHookInstallation,
@@ -38,6 +39,13 @@ export interface ProviderRegistrationOptions {
   readApiKey: (providerId: CredentialProviderId) => Promise<string | undefined>;
   claudeHookInstallation: () => ClaudeCodeHookInstallation;
   codexHookInstallation: () => CodexHookInstallation;
+  /**
+   * Constructed by the caller rather than here, because the app also asks it
+   * what the latest pass learned about the Codex CLI login — the settings
+   * snapshot reports that beside the key sources — and the reference the
+   * settings read is the reference the composite observes with.
+   */
+  codexCloudAdapter: CodexCloudSessionAdapter;
   now?: () => number;
 }
 
@@ -48,8 +56,17 @@ export function providerRegistrations(
   const claude = new ClaudeCodeSessionAdapter({
     hookEventsDirectory: () => options.claudeHookInstallation().spoolDirectory,
   });
-  const codex = new CodexSessionAdapter({
-    hookEventsDirectory: () => options.codexHookInstallation().spoolDirectory,
+  // Codex runs sessions in two places: on this machine, observed from its own
+  // transcripts, and in Codex cloud, observed through the Codex CLI's
+  // documented read under the ChatGPT login the user already gave that CLI.
+  const codex = new CompositeSessionProviderAdapter({
+    provider: CODEX_PROVIDER,
+    adapters: [
+      new CodexSessionAdapter({
+        hookEventsDirectory: () => options.codexHookInstallation().spoolDirectory,
+      }),
+      options.codexCloudAdapter,
+    ],
   });
   const cursor = new CompositeSessionProviderAdapter({
     provider: CURSOR_PROVIDER,

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -29,6 +29,7 @@ import type {
   AccountSnapshot,
   AppBridge,
   AppSettings,
+  CliConnection,
   CredentialSource,
   MicrophoneStatus,
   SettingsUpdateResult,
@@ -36,6 +37,7 @@ import type {
 import {
   ACCOUNT_PROVIDER,
   ACCOUNT_STATUS,
+  CLI_CONNECTION,
   CREDENTIAL_SOURCE,
   SECRET_STORAGE,
 } from "../shared/contracts";
@@ -156,6 +158,14 @@ function connectionWord(source: CredentialSource): string {
       : "connected";
 }
 
+/** The row's answer about the Codex CLI login, in words a fact can carry. */
+const CODEX_CLOUD_CONNECTION_WORD: Readonly<Record<CliConnection, string>> = {
+  [CLI_CONNECTION.CONNECTED]: "connected",
+  [CLI_CONNECTION.SIGNED_OUT]: "not connected; the CLI is signed out",
+  [CLI_CONNECTION.CLI_MISSING]: "not connected; the CLI is not installed",
+  [CLI_CONNECTION.UNKNOWN]: "not checked yet",
+};
+
 function providersFact(settings: AppSettings): AppGuideFact {
   const roster = CLOUD_AGENT_PROVIDER_LIST.map(
     (provider) =>
@@ -166,7 +176,11 @@ function providersFact(settings: AppSettings): AppGuideFact {
     detail:
       `${roster.join(", ")}. Connecting one takes the key its row names, typed by hand into ` +
       `${CONNECTIONS_PAGE}, under Cloud Agent API keys — never spoken, and never repeated back. ` +
-      "Local providers such as Claude Code need no key and are observed on their own.",
+      "Local providers such as Claude Code need no key and are observed on their own. " +
+      `Codex cloud tasks (${CODEX_CLOUD_CONNECTION_WORD[settings.codexCloudConnection]}) take ` +
+      "no key in Luke at all: they are observed through the Codex CLI's own login, and the " +
+      "Codex row on the same page reports that login's state. Running codex login once in a " +
+      "terminal connects them, and signing that CLI out stops them.",
   };
 }
 

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -8,6 +8,7 @@ import {
   isRealtimeVoiceSpeed,
   PANEL_FORM_FACTOR_LIST,
   type PanelFormFactor,
+  PROVIDER_ID,
   type ProviderId,
   REALTIME_DEFAULTS,
   REALTIME_VOICE_LIST,
@@ -33,6 +34,8 @@ import {
   ACCOUNT_PROVIDER,
   ACCOUNT_STATUS,
   APP_SETTING_DEFAULTS,
+  CLI_CONNECTION,
+  type CliConnection,
   CREDENTIAL_SOURCE,
   SECRET_STORAGE,
   SETTINGS_RESET_SCOPE,
@@ -1159,6 +1162,52 @@ function WorkspaceAgentRow({
 }
 
 /**
+ * What each answer the Codex CLI can give reads as on its row. Every state
+ * has words — unlike a key row, whose check needs none — because the check
+ * alone could not say the connection is a CLI login rather than a key, and
+ * the disconnected states are exactly where the next step must be named.
+ * The step is a command, so it is drawn as one.
+ */
+const CODEX_CLOUD_STATUS: Readonly<Record<CliConnection, React.ReactNode>> = {
+  [CLI_CONNECTION.CONNECTED]: "Via the Codex CLI login",
+  [CLI_CONNECTION.SIGNED_OUT]: (
+    <>
+      Run <code>codex login</code> on your Mac
+    </>
+  ),
+  [CLI_CONNECTION.CLI_MISSING]: "Codex CLI not installed",
+  [CLI_CONNECTION.UNKNOWN]: "Not checked yet",
+};
+
+/**
+ * The one provider observed through its own CLI's login rather than a key.
+ * The row reports what the latest pass learned and offers nothing to enter
+ * or delete: connecting is `codex login` in the user's own terminal, and
+ * signing that CLI out is what disconnects — so the words name that step
+ * exactly when it is the missing one, and no control pretends otherwise.
+ */
+function CodexCloudConnection({ connection }: { connection: CliConnection }): React.JSX.Element {
+  return (
+    <div className="credential">
+      <div className="credential-row">
+        <span className="credential-identity">
+          {/* The same mark and cloud badge the codex session rows carry: the
+              login buys the observation of cloud tasks, and the same mark
+              cannot differ between the row and the sessions it stands for. */}
+          <span className="credential-mark">
+            <ProviderMark providerId={PROVIDER_ID.CODEX} />
+            <CloudBadge />
+          </span>
+          <span className="credential-name">Codex</span>
+          {connection === CLI_CONNECTION.CONNECTED ? <CheckIcon /> : null}
+        </span>
+        <span className="credential-status">{CODEX_CLOUD_STATUS[connection]}</span>
+      </div>
+    </div>
+  );
+}
+
+/**
  * Every agent provider that can hold a key, one line each. A provider is
  * listed whether or not it has one, because the list is how you learn which
  * services Luke can watch at all.
@@ -1188,6 +1237,8 @@ function CredentialsSection({
       <p className="settings-note">
         Luke reads only cloud workspaces you created, and never sends a prompt or any other change.
       </p>
+      {/* First because the list reads alphabetically, like the key rows below. */}
+      <CodexCloudConnection connection={settings.codexCloudConnection} />
       {CLOUD_AGENT_PROVIDER_LIST.map((provider) => {
         // The agent row belongs to providers the build documents a table for,
         // and only while connected: disconnected, there is nothing the choice

--- a/apps/desktop/src/renderer/styles/settings.css
+++ b/apps/desktop/src/renderer/styles/settings.css
@@ -642,6 +642,14 @@
   font-weight: 640;
 }
 
+/* The one command a status can name, in the system's own mono face — a shade
+   smaller than the caption around it, because mono runs wider at equal size. */
+.credential-status code {
+  font-family: ui-monospace, "SF Mono", SFMono-Regular, Menlo, monospace;
+  font-size: 9.5px;
+  font-weight: 560;
+}
+
 /* Square, quiet, and captioned only for a reader: a trash can and a pencil say
    what they do, and a label beside each would say it twice. */
 .icon-button {

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -15,6 +15,8 @@ import {
   type AccountProvider,
   type AccountSnapshot,
   type AppSettings,
+  CLI_CONNECTION,
+  type CliConnection,
   CREDENTIAL_SOURCE,
   type CredentialSource,
   SECRET_STORAGE,
@@ -95,6 +97,15 @@ export interface SettingsStoreOptions {
    * key is. Only the app knows which kind of run this is. True by default.
    */
   credentialsUsable?: boolean;
+  /**
+   * What the latest observation pass learned about the Codex CLI's login. It
+   * rides the settings snapshot beside `credentialSources` because it answers
+   * the same question for a provider whose connection is not a key — but the
+   * fact lives with the observer, so the app supplies it rather than the
+   * store resolving it. Absent, the snapshot says the question was never
+   * asked, which is what a store without an app around it can honestly say.
+   */
+  codexCloudConnection?: () => CliConnection;
 }
 
 interface PersistedSettings extends StoredAppSettings {
@@ -364,6 +375,7 @@ export class SettingsStore {
   readonly #environment: NodeJS.ProcessEnv;
   readonly #providers: readonly CredentialProvider[];
   readonly #credentialsUsable: boolean;
+  readonly #codexCloudConnection: () => CliConnection;
   #loading: Promise<PersistedSettings> | undefined;
   #resolved = new Map<CredentialProviderId, ResolvedApiKey>();
   /** Decrypted accounts, cached like the keys so timers never drum the Keychain. */
@@ -440,6 +452,7 @@ export class SettingsStore {
     this.#environment = options.environment ?? process.env;
     this.#providers = options.providers ?? CREDENTIAL_PROVIDER_LIST;
     this.#credentialsUsable = options.credentialsUsable ?? true;
+    this.#codexCloudConnection = options.codexCloudConnection ?? (() => CLI_CONNECTION.UNKNOWN);
   }
 
   async snapshot(): Promise<AppSettings> {
@@ -462,6 +475,11 @@ export class SettingsStore {
         CredentialProviderId,
         CredentialSource
       >,
+      // The same question `credentialSources` answers, for the one provider
+      // whose connection is a CLI login rather than a key: asked of the
+      // observer that actually holds the answer, at snapshot time like the
+      // key sources beside it.
+      codexCloudConnection: this.#codexCloudConnection(),
       // Reports what storing a key has already established, and asks nothing on
       // its own: a snapshot is taken on every launch, and most of them are for
       // a user with no key to protect.

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -98,6 +98,21 @@ export const CREDENTIAL_SOURCE = {
 export type CredentialSource = (typeof CREDENTIAL_SOURCE)[keyof typeof CREDENTIAL_SOURCE];
 
 /**
+ * Whether a CLI-observed provider can be observed right now, without ever
+ * exposing the login behind it — the CLI analogue of {@link CredentialSource}.
+ * Unknown is the state before the first pass has asked; the other three are
+ * what the latest pass learned from the provider's own CLI.
+ */
+export const CLI_CONNECTION = {
+  UNKNOWN: "unknown",
+  CONNECTED: "connected",
+  SIGNED_OUT: "signed-out",
+  CLI_MISSING: "cli-missing",
+} as const;
+
+export type CliConnection = (typeof CLI_CONNECTION)[keyof typeof CLI_CONNECTION];
+
+/**
  * Whether Luke can store a credential through OS-provided encryption. Asking is
  * not free: on macOS the answer comes from the Keychain, and reading it is what
  * raises the permission dialog. Nobody who has never stored a key has any
@@ -194,6 +209,12 @@ export type UpdateSnapshot =
 export interface AppSettings {
   /** Where each provider's key comes from, keyed by provider id. */
   credentialSources: Readonly<Record<CredentialProviderId, CredentialSource>>;
+  /**
+   * Whether Codex cloud tasks can be observed right now: through the Codex
+   * CLI's own login rather than a key of Luke's, so the row it draws reports
+   * a fact learned from that CLI instead of offering anything to enter.
+   */
+  codexCloudConnection: CliConnection;
   /**
    * Luke stores credentials only through OS-provided encryption. When that is
    * known to be unavailable the app says so rather than falling back to

--- a/apps/desktop/tests/codex-cloud-adapter.test.ts
+++ b/apps/desktop/tests/codex-cloud-adapter.test.ts
@@ -1,0 +1,300 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { SESSION_LOCATION, SESSION_STATUS } from "@sidecar/core";
+import {
+  CLI_ADAPTER_DEFAULTS,
+  CLI_FAILURE,
+  CliCommandError,
+  type CliRun,
+} from "../src/cli-session-adapter";
+import { CodexCloudSessionAdapter } from "../src/codex-cloud-adapter";
+import { CLI_CONNECTION } from "../src/shared/contracts";
+
+const TEST_TIME = Date.parse("2026-08-18T02:45:00.000Z");
+const SECRET_PROMPT_TEXT = "SECRET_PROMPT_TEXT";
+const LOGIN_PROBE_ARGV = ["login", "status"];
+const LIST_TASKS_ARGV = ["cloud", "list", "--json", "--limit", "20"];
+
+/** The CLI's documented task states, verified against the open-source serializer. */
+const TEST_STATUS = {
+  PENDING: "pending",
+  READY: "ready",
+  APPLIED: "applied",
+  ERROR: "error",
+} as const;
+
+interface TestTask {
+  id: string;
+  status?: string;
+  environmentLabel?: string;
+  omitEnvironmentLabel?: boolean;
+  updatedAt: number;
+}
+
+function taskPayload(task: TestTask): Record<string, unknown> {
+  return {
+    id: task.id,
+    url: `https://chatgpt.com/codex/tasks/${task.id}`,
+    // The CLI returns a title generated from the prompt the user typed, so it
+    // is transcript content that no observation may carry.
+    title: `${SECRET_PROMPT_TEXT} title`,
+    status: task.status ?? TEST_STATUS.PENDING,
+    updated_at: new Date(task.updatedAt).toISOString(),
+    environment_id: "env-1",
+    ...(task.omitEnvironmentLabel
+      ? {}
+      : { environment_label: task.environmentLabel ?? "reviewstage/luke" }),
+    summary: { files_changed: 3, lines_added: 12, lines_removed: 4 },
+    is_review: false,
+    attempt_total: 1,
+  };
+}
+
+interface RecordedInvocation {
+  binary: string;
+  argv: readonly string[];
+}
+
+interface FakeCliBehavior {
+  loggedIn?: boolean;
+  binaryMissing?: boolean;
+  listExitCode?: number;
+  listStdout?: string;
+  tasks?: readonly TestTask[];
+}
+
+/** Serves the two invocations the adapter is allowed to make, recording each. */
+function fakeCodexCli(behavior: FakeCliBehavior) {
+  const invocations: RecordedInvocation[] = [];
+  const run: CliRun = async (binary, argv) => {
+    invocations.push({ binary, argv });
+    if (behavior.binaryMissing) {
+      throw new CliCommandError(CLI_FAILURE.UNAVAILABLE, "codex could not be run");
+    }
+    if (argv.join(" ") === LOGIN_PROBE_ARGV.join(" ")) {
+      return { exitCode: (behavior.loggedIn ?? true) ? 0 : 1, stdout: "" };
+    }
+    if (argv.join(" ") === LIST_TASKS_ARGV.join(" ")) {
+      if (behavior.listExitCode !== undefined && behavior.listExitCode !== 0) {
+        return { exitCode: behavior.listExitCode, stdout: "" };
+      }
+      return {
+        exitCode: 0,
+        stdout:
+          behavior.listStdout ??
+          JSON.stringify({
+            tasks: (behavior.tasks ?? []).map(taskPayload),
+            cursor: null,
+          }),
+      };
+    }
+    throw new Error(`Unexpected invocation: ${binary} ${argv.join(" ")}`);
+  };
+  return { run, invocations };
+}
+
+function adapterFor(
+  run: CliRun,
+  overrides: { now?: () => number; minimumRefreshIntervalMs?: number } = {},
+): CodexCloudSessionAdapter {
+  return new CodexCloudSessionAdapter({
+    run,
+    now: overrides.now ?? (() => TEST_TIME),
+    minimumRefreshIntervalMs: overrides.minimumRefreshIntervalMs ?? 0,
+  });
+}
+
+test("observes cloud tasks as cloud sessions labelled by their environment's repository", async () => {
+  const { run, invocations } = fakeCodexCli({
+    tasks: [
+      { id: "task-old", status: TEST_STATUS.READY, updatedAt: TEST_TIME - 60_000 },
+      { id: "task-new", status: TEST_STATUS.PENDING, updatedAt: TEST_TIME - 5_000 },
+    ],
+  });
+  const adapter = adapterFor(run);
+
+  const observations = await adapter.observe();
+
+  assert.equal(observations.length, 2);
+  const [newest, oldest] = observations;
+  assert.ok(newest && oldest);
+  assert.equal(newest.providerSessionId, "task-new");
+  assert.equal(newest.title, "luke");
+  assert.equal(newest.status, SESSION_STATUS.WORKING);
+  assert.equal(newest.location, SESSION_LOCATION.CLOUD);
+  assert.equal(newest.observedAt, TEST_TIME - 5_000);
+  assert.equal(newest.detail?.repository, "luke");
+  assert.equal(newest.detail?.link, "https://chatgpt.com/codex/tasks/task-new");
+  assert.equal(newest.canReceiveMessage, undefined);
+  assert.equal(oldest.providerSessionId, "task-old");
+  assert.equal(oldest.status, SESSION_STATUS.COMPLETE);
+  // The pass is exactly the two build-fixed invocations, in order.
+  assert.deepEqual(
+    invocations.map((invocation) => [invocation.binary, ...invocation.argv]),
+    [
+      ["codex", ...LOGIN_PROBE_ARGV],
+      ["codex", ...LIST_TASKS_ARGV],
+    ],
+  );
+});
+
+test("never surfaces the prompt-derived task title", async () => {
+  const { run } = fakeCodexCli({ tasks: [{ id: "task-1", updatedAt: TEST_TIME }] });
+  const observations = await adapterFor(run).observe();
+
+  assert.equal(JSON.stringify(observations).includes(SECRET_PROMPT_TEXT), false);
+});
+
+test("maps every documented task state and refuses to guess at unknown ones", async () => {
+  const { run } = fakeCodexCli({
+    tasks: [
+      { id: "task-pending", status: TEST_STATUS.PENDING, updatedAt: TEST_TIME },
+      { id: "task-ready", status: TEST_STATUS.READY, updatedAt: TEST_TIME - 1 },
+      { id: "task-applied", status: TEST_STATUS.APPLIED, updatedAt: TEST_TIME - 2 },
+      { id: "task-error", status: TEST_STATUS.ERROR, updatedAt: TEST_TIME - 3 },
+      { id: "task-novel", status: "queued-for-review", updatedAt: TEST_TIME - 4 },
+    ],
+  });
+
+  const observations = await adapterFor(run).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.status),
+    [
+      SESSION_STATUS.WORKING,
+      SESSION_STATUS.COMPLETE,
+      SESSION_STATUS.COMPLETE,
+      SESSION_STATUS.ERROR,
+      SESSION_STATUS.UNKNOWN,
+    ],
+  );
+});
+
+test("labels a task with no environment label as an unnamed workspace", async () => {
+  const { run } = fakeCodexCli({
+    tasks: [{ id: "task-1", omitEnvironmentLabel: true, updatedAt: TEST_TIME }],
+  });
+
+  const observations = await adapterFor(run).observe();
+
+  assert.equal(observations[0]?.title, "workspace");
+});
+
+test("observes nothing while the CLI is signed out, and never asks for the list", async () => {
+  const { run, invocations } = fakeCodexCli({ loggedIn: false });
+
+  const observations = await adapterFor(run).observe();
+
+  assert.deepEqual(observations, []);
+  assert.deepEqual(
+    invocations.map((invocation) => invocation.argv),
+    [LOGIN_PROBE_ARGV],
+  );
+});
+
+test("observes nothing on a machine without the CLI", async () => {
+  const { run } = fakeCodexCli({ binaryMissing: true });
+
+  const observations = await adapterFor(run).observe();
+
+  assert.deepEqual(observations, []);
+});
+
+test("clears observed state when the login goes away", async () => {
+  const behavior: FakeCliBehavior = { tasks: [{ id: "task-1", updatedAt: TEST_TIME }] };
+  const { run } = fakeCodexCli(behavior);
+  const adapter = adapterFor(run);
+
+  assert.equal((await adapter.observe()).length, 1);
+  behavior.loggedIn = false;
+  assert.deepEqual(await adapter.observe(), []);
+});
+
+test("keeps the last snapshot across a failed or unreadable list", async () => {
+  const behavior: FakeCliBehavior = { tasks: [{ id: "task-1", updatedAt: TEST_TIME }] };
+  const { run } = fakeCodexCli(behavior);
+  const adapter = adapterFor(run);
+
+  const first = await adapter.observe();
+  assert.equal(first.length, 1);
+
+  behavior.listExitCode = 2;
+  assert.deepEqual(await adapter.observe(), first);
+
+  behavior.listExitCode = 0;
+  behavior.listStdout = "not json at all";
+  assert.deepEqual(await adapter.observe(), first);
+});
+
+test("refreshes on its own cadence rather than on every tick", async () => {
+  let now = TEST_TIME;
+  const { run, invocations } = fakeCodexCli({ tasks: [] });
+  const adapter = adapterFor(run, {
+    now: () => now,
+    minimumRefreshIntervalMs: CLI_ADAPTER_DEFAULTS.MINIMUM_REFRESH_INTERVAL_MS,
+  });
+
+  await adapter.observe();
+  await adapter.observe();
+  assert.equal(invocations.length, 2);
+
+  now += CLI_ADAPTER_DEFAULTS.MINIMUM_REFRESH_INTERVAL_MS;
+  await adapter.observe();
+  assert.equal(invocations.length, 4);
+});
+
+test("reports what each pass learned about the CLI login, and only that", async () => {
+  const behavior: FakeCliBehavior = { tasks: [] };
+  const { run } = fakeCodexCli(behavior);
+  const adapter = adapterFor(run);
+
+  // Before a pass has asked, the honest answer is that nothing was checked.
+  assert.equal(adapter.connection(), CLI_CONNECTION.UNKNOWN);
+
+  await adapter.observe();
+  assert.equal(adapter.connection(), CLI_CONNECTION.CONNECTED);
+
+  behavior.loggedIn = false;
+  await adapter.observe();
+  assert.equal(adapter.connection(), CLI_CONNECTION.SIGNED_OUT);
+
+  behavior.loggedIn = true;
+  behavior.binaryMissing = true;
+  await adapter.observe();
+  assert.equal(adapter.connection(), CLI_CONNECTION.CLI_MISSING);
+
+  behavior.binaryMissing = false;
+  await adapter.observe();
+  assert.equal(adapter.connection(), CLI_CONNECTION.CONNECTED);
+
+  // A list that ran and failed says nothing about the login behind it.
+  behavior.listExitCode = 2;
+  await adapter.observe();
+  assert.equal(adapter.connection(), CLI_CONNECTION.CONNECTED);
+});
+
+test("answers unsupported for every act its provider does not document", async () => {
+  const { run } = fakeCodexCli({ tasks: [{ id: "task-1", updatedAt: TEST_TIME }] });
+  const adapter = adapterFor(run);
+  await adapter.observe();
+
+  assert.deepEqual(await adapter.sendMessage({ providerSessionId: "task-1", text: "hello" }), {
+    status: "unsupported",
+  });
+  assert.deepEqual(
+    await adapter.executeControl({
+      providerSessionId: "task-1",
+      control: { id: "stop", label: "Stop" },
+    }),
+    { status: "unsupported" },
+  );
+  assert.deepEqual(await adapter.createWorkspace({ providerProjectId: "env-1", task: "Fix it" }), {
+    status: "unsupported",
+  });
+  assert.deepEqual(await adapter.spawnWorkspaceAgent({ providerSessionId: "task-1", agent: "x" }), {
+    status: "unsupported",
+  });
+  assert.deepEqual(adapter.workspaceProjects(), []);
+  // A cloud task's conversation lives with its provider and is never fetched.
+  assert.equal(await adapter.readTranscript("task-1"), undefined);
+});

--- a/apps/desktop/tests/errand-queue.test.ts
+++ b/apps/desktop/tests/errand-queue.test.ts
@@ -24,7 +24,7 @@ import { PANEL_TAB } from "../src/renderer/panel-tabs";
 import { SESSION_FILTER, SESSION_SORT } from "../src/renderer/session-model";
 import { SETTINGS_VIEW } from "../src/renderer/settings-views";
 import type { AppSettings } from "../src/shared/contracts";
-import { CREDENTIAL_SOURCE, SECRET_STORAGE } from "../src/shared/contracts";
+import { CLI_CONNECTION, CREDENTIAL_SOURCE, SECRET_STORAGE } from "../src/shared/contracts";
 import { CREDENTIAL_PROVIDER_ID } from "../src/shared/credential-providers";
 
 /** A settings snapshot, told apart from the next only by the switch that moved. */
@@ -40,6 +40,7 @@ function settings(captions: boolean): AppSettings {
       [CREDENTIAL_PROVIDER_ID.OPENAI]: CREDENTIAL_SOURCE.NONE,
     },
     secretStorage: SECRET_STORAGE.UNKNOWN,
+    codexCloudConnection: CLI_CONNECTION.UNKNOWN,
     showInDock: false,
     voice: REALTIME_VOICE.CEDAR,
     voiceSpeed: REALTIME_VOICE_SPEED.NORMAL,

--- a/apps/desktop/tests/luke-errand.test.ts
+++ b/apps/desktop/tests/luke-errand.test.ts
@@ -33,7 +33,7 @@ import {
 } from "../src/renderer/luke-guide";
 import { SETTING_PAGE, SETTINGS_PAGE_LABEL } from "../src/renderer/settings-views";
 import type { AppSettings } from "../src/shared/contracts";
-import { CREDENTIAL_SOURCE, SECRET_STORAGE } from "../src/shared/contracts";
+import { CLI_CONNECTION, CREDENTIAL_SOURCE, SECRET_STORAGE } from "../src/shared/contracts";
 import { CREDENTIAL_PROVIDER_ID } from "../src/shared/credential-providers";
 
 function settings(): AppSettings {
@@ -48,6 +48,7 @@ function settings(): AppSettings {
       [CREDENTIAL_PROVIDER_ID.OPENAI]: CREDENTIAL_SOURCE.NONE,
     },
     secretStorage: SECRET_STORAGE.UNKNOWN,
+    codexCloudConnection: CLI_CONNECTION.UNKNOWN,
     showInDock: false,
     voice: REALTIME_VOICE.CEDAR,
     voiceSpeed: REALTIME_VOICE_SPEED.NORMAL,

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -21,6 +21,7 @@ import type { AppSettings, SettingsUpdateResult } from "../src/shared/contracts"
 import {
   ACCOUNT_PROVIDER,
   ACCOUNT_STATUS,
+  CLI_CONNECTION,
   CREDENTIAL_SOURCE,
   SECRET_STORAGE,
 } from "../src/shared/contracts";
@@ -38,6 +39,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
       [CREDENTIAL_PROVIDER_ID.OPENAI]: CREDENTIAL_SOURCE.NONE,
     },
     secretStorage: SECRET_STORAGE.UNKNOWN,
+    codexCloudConnection: CLI_CONNECTION.UNKNOWN,
     showInDock: false,
     voice: REALTIME_VOICE.CEDAR,
     voiceSpeed: REALTIME_VOICE_SPEED.NORMAL,

--- a/apps/desktop/tests/provider-registrations.test.ts
+++ b/apps/desktop/tests/provider-registrations.test.ts
@@ -1,11 +1,16 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { PROVIDER_ID, PROVIDER_ID_LIST } from "@sidecar/core";
+import { CodexCloudSessionAdapter } from "../src/codex-cloud-adapter";
 import { providerRegistrations } from "../src/provider-registrations";
 import { CREDENTIAL_PROVIDER_ID } from "../src/shared/credential-providers";
 
 const registrations = providerRegistrations({
   readApiKey: async () => undefined,
+  // A runner that answers signed-out, so no test can spawn a real CLI.
+  codexCloudAdapter: new CodexCloudSessionAdapter({
+    run: async () => ({ exitCode: 1, stdout: "" }),
+  }),
   claudeHookInstallation: () => ({
     claudeHome: "/missing/claude",
     hookScriptPath: "/missing/claude-hook",


### PR DESCRIPTION
## Summary

- Add a CLI-observed provider class to the trust constraints: observation runs the provider's own CLI with build-fixed read invocations under the login the user already gave that CLI — no token is read, stored, or forwarded, and no shell stands between Luke and the binary. A machine whose CLI is absent or signed out is observed as having nothing.
- Observe Codex cloud tasks through `codex login status` (exit code only) and `codex cloud list --json`, joined with the local codex adapter as one composite provider. Rows are labelled by environment repository (the prompt-derived task title is discarded), carry the cloud badge and the task's chatgpt.com address, and advertise no writes because Codex documents none.
- Draw a read-only Codex row in Connections reporting the login state live — connected, signed out (with the `codex login` step in code face), CLI missing, or not yet checked — re-broadcast from the observation loop whenever it changes.
- Teach PRIVACY.md, README.md, and the spoken guide the new class.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passes (exit 0), including 11 new adapter tests with a faked CLI runner
- macOS Electron verification (`./scripts/verify.sh`): `not run locally` (implemented from a Linux cloud workspace) — CI runs it on macos-15

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32203208633/artifacts/9348244857) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32203208633)

- Commit: `4d201164086c53dfe85ec9572255ed7888a6db65`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- The drawn change is one settings row (plus a `.credential-status code` style); no motion or notch geometry is touched.
- Two stacked follow-ups are planned: task creation via `codex cloud exec`, and diff summaries on rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/86e861fc-6154-48b6-a443-e74a159868b7)
