### PR TITLE
feat(voice): preview tracked issues as chips on the mention band

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,7 +252,20 @@ What Luke may show:
   long as the spoken reply, so it can never stand for news nobody is
   telling. The notice's press is a row press at one remove: the session's
   reported address goes to the operating system, or Luke's own panel opens
-  for a session that reported none.
+  for a session that reported none. The same band previews tracked issues
+  while a spoken reply names them: the reply's own words are matched against
+  the identifiers and whole titles the latest tracker observation listed —
+  arithmetic against observed state, under the session mentions' own
+  minimum-length and ambiguity rules, so nothing a model said can conjure an
+  issue the tracker does not track — and each named issue draws a chip
+  beside the session chips, its identifier and title read on this machine
+  from that roster, living exactly as long as the words, with an
+  announcement's one session subject still the whole answer. An issue chip's
+  press hands the issue's tracker-reported address to the operating system
+  exactly as a session's would, validated against the observed roster again
+  in the main process; it reaches none of the tracker's write paths, and an
+  issue that reported none is taken nowhere, because no panel surface holds
+  a row to fall back to.
 
 Before handoff, run `./scripts/check.sh` for portable-only changes. For any
 macOS or UI change, `./scripts/verify.sh` is the completion invariant. Report

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -17,6 +17,7 @@ import {
   HOSTED_SERVICE_PATH,
   InMemorySessionRegistry,
   ISSUE_ACTION_KIND,
+  type IssueIdentity,
   isControllableAdapter,
   isMessageCapableAdapter,
   isPanelFormFactor,
@@ -836,6 +837,22 @@ function isSessionIdentity(value: unknown): value is SessionIdentity {
     providerId.trim().length > 0 &&
     typeof providerSessionId === "string" &&
     providerSessionId.trim().length > 0
+  );
+}
+
+/**
+ * Whether a renderer message names an issue, on the session identity's own
+ * terms: both halves present, and everything it names re-resolved against the
+ * latest observation before anything is done with it.
+ */
+function isIssueIdentity(value: unknown): value is IssueIdentity {
+  if (value === null || typeof value !== "object") return false;
+  const { trackerId, identifier } = value as Partial<IssueIdentity>;
+  return (
+    typeof trackerId === "string" &&
+    trackerId.trim().length > 0 &&
+    typeof identifier === "string" &&
+    identifier.trim().length > 0
   );
 }
 
@@ -2186,6 +2203,36 @@ function registerIpc(): void {
         void refreshTrackedIssues();
       }
       return result;
+    },
+  );
+
+  // Pressing an issue — the notice under the housing while Luke names it —
+  // hands its tracker's own address to the system, exactly as pressing a
+  // session's row does. The renderer names an issue rather than an address,
+  // so the pages Luke can send you to are the issues currently observed: the
+  // URL is read back out of the roster, where normalization admitted nothing
+  // but a bounded https address, and nothing reaches the tracker. A fixture
+  // run observes no tracker and so opens nothing.
+  ipcMain.handle(
+    channels.openIssue,
+    async (event, identity: unknown): Promise<SessionOpenResult> => {
+      if (!trustedSender(event)) throw new Error("Untrusted renderer");
+      if (!isIssueIdentity(identity)) throw new Error("Invalid issue open request");
+      const url = trackedIssues?.find(
+        (candidate) =>
+          candidate.trackerId === identity.trackerId &&
+          candidate.identifier === identity.identifier,
+      )?.url;
+      if (!url) return { status: SESSION_OPEN_RESULT_STATUS.UNSUPPORTED };
+      try {
+        await shell.openExternal(url);
+        return { status: SESSION_OPEN_RESULT_STATUS.OPENED };
+      } catch {
+        return {
+          status: SESSION_OPEN_RESULT_STATUS.REJECTED,
+          reason: "The system could not open that issue.",
+        };
+      }
     },
   );
 

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -71,6 +71,7 @@ const bridge: AppBridge = {
   createSessionWorkspace: invoke(channels.createSessionWorkspace),
   addWorkspaceAgent: invoke(channels.addWorkspaceAgent),
   executeIssueAction: invoke(channels.executeIssueAction),
+  openIssue: invoke(channels.openIssue),
   sendFeedback: invoke(channels.sendFeedback),
   summonFeedback: invoke(channels.summonFeedback),
   focusPanel: () => ipcRenderer.send(channels.focusPanel),

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -5,6 +5,7 @@ import {
   type FeedbackComposerKind,
   FIXTURE_EPOCH_MS,
   type HostedUsageAnswer,
+  type IssueIdentity,
   isProviderId,
   type NormalizedSession,
   type ObservedWorkspaceProject,
@@ -222,6 +223,35 @@ function notchStyle(display: DisplayDiagnostic): CSSProperties {
     "--notch-housing-width": `${display.notch.housingWidth}px`,
   } as CSSProperties;
 }
+
+/** The two rosters a mention chip can stand for, deciding what its press does. */
+const MENTION_CHIP_KIND = {
+  SESSION: "session",
+  ISSUE: "issue",
+} as const;
+
+/**
+ * One pressable chip of the notice band: the mark and words it draws, and the
+ * identity its press hands to the main process — where it is validated
+ * against the observed roster again before any address reaches the system.
+ * Resolved onto the chip when its mention is, so the band held through its
+ * fade-out keeps saying what it said.
+ */
+type MentionChip =
+  | {
+      kind: typeof MENTION_CHIP_KIND.SESSION;
+      id: string;
+      markId: string;
+      title: string;
+      identity: SessionIdentity;
+    }
+  | {
+      kind: typeof MENTION_CHIP_KIND.ISSUE;
+      id: string;
+      markId: string;
+      title: string;
+      identity: IssueIdentity;
+    };
 
 function shapeHeightStyle(
   panelHeight: number | undefined,
@@ -1617,6 +1647,7 @@ export function App(): React.JSX.Element {
     lukeCaptions,
     captionShownAt,
     mentionedSessions,
+    mentionedIssues,
     remoteAudio,
     discardListening,
     stopSpeaking,
@@ -1640,33 +1671,60 @@ export function App(): React.JSX.Element {
     carryAppAction,
   });
 
-  // The notices: the pressable faces of the sessions the reply being spoken
-  // is about — an announcement's one subject, or the several a conversation
-  // reply names when "what are we working on?" is answered with a walk
-  // through the roster: a chat by its title, or a whole workspace by name,
-  // fronted by its freshest chat. Derived, not queued — the subjects arrive
-  // with the captions and die with the reply, so a chip can never lag the
-  // words or stand for news Luke is not saying — and each draws only for a
-  // session the roster still titles, because a press is a row press at one
-  // remove and needs a row to stand for. A workspace chip wears the
-  // workspace's name, read off the same roster row, so the chip says what
-  // the words said. The resting shapes draw the band under the housing, and
-  // the open panel keeps it at its foot: the rows are up in the list, but
-  // the chips are what say which of them Luke is talking about. Only the
-  // slot and the composer go without — those are shapes someone asked for.
-  const spokenOf = mentionedSessions.flatMap((mention) => {
-    const session = sessions.find(
-      (candidate) =>
-        candidate.providerId === mention.providerId &&
-        candidate.providerSessionId === mention.providerSessionId,
-    );
-    if (!session) return [];
-    const title =
-      mention.kind === SESSION_MENTION_KIND.WORKSPACE && session.workspace?.name !== undefined
-        ? session.workspace.name
-        : session.title;
-    return [{ title, providerId: session.providerId, id: session.providerSessionId }];
-  });
+  // The notices: the pressable faces of what the reply being spoken is about
+  // — an announcement's one subject, or the several a conversation reply
+  // names when "what are we working on?" is answered with a walk through the
+  // roster: a chat by its title, a whole workspace by name fronted by its
+  // freshest chat, or a tracked issue by identifier or title. Derived, not
+  // queued — the subjects arrive with the captions and die with the reply,
+  // so a chip can never lag the words or stand for news Luke is not saying —
+  // and each draws only for a session the roster still titles or an issue
+  // the tracker still lists, because a press is a row press at one remove
+  // and needs a row to stand for. A workspace chip wears the workspace's
+  // name, read off the same roster row, so the chip says what the words
+  // said; an issue chip wears its identifier and title, because the
+  // identifier is what was mentioned. The issues follow the sessions rather
+  // than interleaving, because each half keeps its own first-heard order and
+  // one band cannot honestly claim an order across the two rosters. The
+  // resting shapes draw the band under the housing, and the open panel keeps
+  // it at its foot: the rows are up in the list, but the chips are what say
+  // which of them Luke is talking about. Only the slot and the composer go
+  // without — those are shapes someone asked for.
+  const spokenOf: readonly MentionChip[] = [
+    ...mentionedSessions.flatMap((mention): readonly MentionChip[] => {
+      const session = sessions.find(
+        (candidate) =>
+          candidate.providerId === mention.providerId &&
+          candidate.providerSessionId === mention.providerSessionId,
+      );
+      if (!session) return [];
+      const title =
+        mention.kind === SESSION_MENTION_KIND.WORKSPACE && session.workspace?.name !== undefined
+          ? session.workspace.name
+          : session.title;
+      return [
+        {
+          kind: MENTION_CHIP_KIND.SESSION,
+          id: session.providerSessionId,
+          markId: session.providerId,
+          title,
+          identity: {
+            providerId: session.providerId,
+            providerSessionId: session.providerSessionId,
+          },
+        },
+      ];
+    }),
+    ...mentionedIssues.map(
+      (issue): MentionChip => ({
+        kind: MENTION_CHIP_KIND.ISSUE,
+        id: issue.identifier,
+        markId: issue.trackerId,
+        title: `${issue.identifier} — ${issue.title}`,
+        identity: { trackerId: issue.trackerId, identifier: issue.identifier },
+      }),
+    ),
+  ];
   const noticeShown =
     spokenOf.length > 0 &&
     (presentation === PANEL_PRESENTATION.CAPSULE ||
@@ -1674,7 +1732,7 @@ export function App(): React.JSX.Element {
       presentation === PANEL_PRESENTATION.PANEL);
   // The last mentioned fields, held so the notices fade out still worded
   // rather than emptying on the frame the reply ends.
-  const lastMentioned = useRef<readonly { title: string; providerId: string; id: string }[]>([]);
+  const lastMentioned = useRef<readonly MentionChip[]>([]);
   if (spokenOf.length > 0) {
     lastMentioned.current = spokenOf;
   }
@@ -2668,14 +2726,18 @@ export function App(): React.JSX.Element {
             // Keeps the press from moving focus here, like the capsule strip's
             // own button, so a focused settings field keeps the caret.
             onMouseDown={(event) => event.preventDefault()}
+            // An issue chip is the same press one roster over: the identity
+            // goes to the main process, which reads the tracker's own address
+            // back out of its observation and hands it to the system — and an
+            // issue that reported none is taken nowhere, because no panel
+            // surface holds a row to fall back to.
             onClick={() =>
-              openMentionedSession({
-                providerId: mention.providerId,
-                providerSessionId: mention.id,
-              })
+              mention.kind === MENTION_CHIP_KIND.SESSION
+                ? openMentionedSession(mention.identity)
+                : void window.sidecar.openIssue(mention.identity)
             }
           >
-            <ProviderMark providerId={mention.providerId} />
+            <ProviderMark providerId={mention.markId} />
             <span className="session-notice-name">{mention.title}</span>
           </button>
         ))}

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -817,8 +817,10 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
               "with no page of its own. The same chips appear while a conversation reply " +
               "names observed sessions by title, or a workspace of grouped chats by its " +
               "name — asking what is being worked on draws one chip per thing named, up to " +
-              "a dozen, a workspace's opening its most recent chat. Past three rows the " +
-              "chips scroll in place, and each presses the same way. " +
+              "a dozen, a workspace's opening its most recent chat. A reply naming tracked " +
+              "issues — by identifier like LUKE-123, or by whole title — draws their chips " +
+              "on the same band, each opening its issue where the tracker keeps it. Past " +
+              "three rows the chips scroll in place, and each presses the same way. " +
               "Always on while voice is available; the panel and the capsule count show the " +
               "same states either way." +
               // Only a build that offers the calendar may describe the quiet:

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -5,6 +5,7 @@ import {
   type CarriedSessionAction,
   dispatchByKind,
   EMPTY_APP_GUIDE,
+  mentionedIssues,
   mentionedSessions,
   type NormalizedSession,
   type ObservedWorkspaceProject,
@@ -312,6 +313,27 @@ export function replyMentions(input: {
 }
 
 /**
+ * The issue half of {@link replyMentions}, on its rules exactly: the tracked
+ * issues the replies being spoken name — by identifier like LUKE-123, or by
+ * whole title — each resolved against the observed issue roster and never
+ * from the model's words alone. An announcement's one validated subject is a
+ * session, and it stays the whole answer: identifiers riding along in its
+ * sentence earn nothing, because the update was about the session. The
+ * fixture sentence names no issues and a capture run observes no tracker, so
+ * a capture run draws none.
+ */
+export function replyIssueMentions(input: {
+  fixtureSpeaking: boolean;
+  about: SessionIdentity | undefined;
+  captions: readonly string[] | undefined;
+  issues: readonly TrackedIssue[] | undefined;
+}): readonly TrackedIssue[] {
+  if (input.about) return [];
+  const spoken = input.fixtureSpeaking ? FIXTURE_SPEAKING_CAPTION : input.captions?.join("\n");
+  return mentionedIssues(spoken, input.issues);
+}
+
+/**
  * The other half of {@link announcerNotices}: an unbidden evaluator summary is
  * a model's words on a session nobody asked about, so it keeps its original
  * bound — spoken only on a call the developer opened themselves.
@@ -409,6 +431,15 @@ export interface VoiceConversation {
    * preference, which only governs whether the words are drawn.
    */
   mentionedSessions: readonly SessionMention[];
+  /**
+   * The tracked issues the reply being spoken names — by identifier or by
+   * whole title — on the session mentions' own terms: resolved against the
+   * observed issue roster, present exactly as long as the reply, and empty
+   * for an announcement, whose one validated subject is a session. The rows
+   * are the roster's own, because no panel surface holds the issue roster
+   * for the chips to resolve against.
+   */
+  mentionedIssues: readonly TrackedIssue[];
   remoteAudio: RefObject<HTMLAudioElement | null>;
   /** Escape out of an open turn: forget the press and the latch, and stop listening. */
   discardListening: () => void;
@@ -482,6 +513,11 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   const workspaceProjectDefaultsRef = useRef(options.workspaceProjectDefaults);
   const guideRef = useRef<AppGuideSnapshot>(EMPTY_APP_GUIDE);
   const issuesRef = useRef<readonly TrackedIssue[] | undefined>(undefined);
+  // The same roster as state, because the issue chips are derived from it and
+  // a derivation only reruns on what React can see change.
+  const [trackedIssues, setTrackedIssues] = useState<readonly TrackedIssue[] | undefined>(
+    undefined,
+  );
   /**
    * The session under discussion, surviving here across calls: an announcement
    * is often read out on Luke's own speak-only call, which the talk-key press
@@ -802,6 +838,10 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
 
   const syncIssues = useCallback((issues: readonly TrackedIssue[] | undefined) => {
     issuesRef.current = issues;
+    // Held as state beside the ref, because the issue chips derive from it:
+    // the ref feeds a call being opened, the state re-renders the band when
+    // an observation pass moves the board under a reply already speaking.
+    setTrackedIssues(issues);
     voiceSession.current?.updateIssues(issues);
   }, []);
 
@@ -1008,6 +1048,18 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       }),
     [options.fixtureSpeaking, options.sessions, voiceCaption],
   );
+  // The issue half of the same derivation, against the tracker's roster
+  // instead of the sessions'.
+  const mentionedIssueRows = useMemo(
+    () =>
+      replyIssueMentions({
+        fixtureSpeaking: options.fixtureSpeaking,
+        about: voiceCaption.about,
+        captions: voiceCaption.texts,
+        issues: trackedIssues,
+      }),
+    [options.fixtureSpeaking, trackedIssues, voiceCaption],
+  );
 
   const voiceTurn = waveformVoice(voiceStatus);
   const lukeCaptions = lukeCaptionsToShow({
@@ -1046,6 +1098,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     lukeCaptions,
     captionShownAt,
     mentionedSessions: mentioned,
+    mentionedIssues: mentionedIssueRows,
     remoteAudio,
     discardListening,
     stopSpeaking,

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -3,6 +3,7 @@ import type {
   AttentionSpeech,
   FixtureSnapshot,
   HostedUsageAnswer,
+  IssueIdentity,
   IssueToolAction,
   NormalizedSession,
   ObservedWorkspaceProject,
@@ -739,6 +740,15 @@ export interface AppBridge {
    */
   openSessionChange(identity: SessionIdentity): Promise<SessionOpenResult>;
   /**
+   * Opens an observed issue where its tracker keeps it, on the session
+   * press's own terms: the renderer names an issue the latest observation
+   * listed, never an address, and the main process reads the tracker-reported
+   * URL back out of its own roster — an address that never passed
+   * normalization never reached it. The answer shares the open vocabulary,
+   * because the act is the same act one roster over.
+   */
+  openIssue(identity: IssueIdentity): Promise<SessionOpenResult>;
+  /**
    * Reads the recent transcript of one observed local session into a bounded
    * rendering, for a conversation the developer is holding. The renderer
    * names a session it was shown; the main process validates it against its
@@ -971,6 +981,7 @@ export const channels = {
   createSessionWorkspace: "app:create-session-workspace",
   addWorkspaceAgent: "app:add-workspace-agent",
   executeIssueAction: "app:execute-issue-action",
+  openIssue: "app:open-issue",
   sendFeedback: "app:send-feedback",
   summonFeedback: "app:summon-feedback",
   focusPanel: "app:focus-panel",

--- a/apps/desktop/tests/use-voice-conversation.test.ts
+++ b/apps/desktop/tests/use-voice-conversation.test.ts
@@ -4,14 +4,17 @@ import {
   ATTENTION_DISPOSITION,
   ATTENTION_SPEECH_SOURCE,
   type AttentionSpeech,
+  ISSUE_TRACKER_ID,
   type NormalizedSession,
   normalizeSession,
+  normalizeTrackedIssue,
   REALTIME_STATUS,
   REALTIME_VOICE,
   REALTIME_VOICE_SPEED,
   SESSION_MENTION_KIND,
   SESSION_STATUS,
   SESSION_TOOL_KIND,
+  type TrackedIssue,
 } from "@sidecar/core";
 import {
   activeVoiceStream,
@@ -23,6 +26,7 @@ import {
   latestSpeechReference,
   liveSpeedApplies,
   lukeCaptionsToShow,
+  replyIssueMentions,
   replyMentions,
   talkKeyPress,
   talkOpeningHolds,
@@ -414,6 +418,70 @@ test("a capture run's chips are earned by the fixture's own words", () => {
         providerSessionId: "chat",
       },
     ],
+  );
+});
+
+function trackedIssue(identifier: string, title: string): TrackedIssue {
+  const issue = normalizeTrackedIssue(
+    { id: ISSUE_TRACKER_ID.LINEAR, displayName: "Linear" },
+    {
+      trackerIssueId: `issue-uuid-${identifier}`,
+      identifier,
+      title,
+      stateName: "Todo",
+      observedAt: 1_800_000_000_000,
+    },
+  );
+  assert.ok(issue);
+  return issue;
+}
+
+test("a conversation reply's issue previews are what its words name off the tracker", () => {
+  const board = [trackedIssue("LUKE-1", "Fix login"), trackedIssue("LUKE-2", "Ship captions")];
+  // Back-to-back replies stack their captions, exactly as the session
+  // mentions read them: everything still on screen feeds the chips.
+  assert.deepEqual(
+    replyIssueMentions({
+      fixtureSpeaking: false,
+      about: undefined,
+      captions: ["LUKE-2 is nearly done.", "And Fix login is still waiting."],
+      issues: board,
+    }),
+    [board[1], board[0]],
+  );
+  assert.deepEqual(
+    replyIssueMentions({
+      fixtureSpeaking: false,
+      about: undefined,
+      captions: undefined,
+      issues: board,
+    }),
+    [],
+  );
+});
+
+test("an announcement's session subject leaves issue identifiers unclaimed", () => {
+  const board = [trackedIssue("LUKE-1", "Fix login")];
+  assert.deepEqual(
+    replyIssueMentions({
+      fixtureSpeaking: false,
+      about: { providerId: "conductor", providerSessionId: "b" },
+      captions: ["Checkout service finished LUKE-1."],
+      issues: board,
+    }),
+    [],
+  );
+});
+
+test("a capture run observes no tracker, so its fixture words draw no issue chips", () => {
+  assert.deepEqual(
+    replyIssueMentions({
+      fixtureSpeaking: true,
+      about: undefined,
+      captions: undefined,
+      issues: undefined,
+    }),
+    [],
   );
 });
 

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -72,6 +72,7 @@ export {
   type SessionMention,
   type SessionMentionKind,
 } from "./session-mentions.js";
+export { MAXIMUM_MENTIONED_ISSUES, mentionedIssues } from "./issue-mentions.js";
 
 // Calendar — when meetings start and end, and nothing else about them.
 export {
@@ -122,6 +123,7 @@ export { CompositeSessionProviderAdapter } from "./composite-provider-adapter.js
 export {
   ISSUE_ACTION_KIND,
   ISSUE_TRACKER_ID,
+  type IssueIdentity,
   type IssueTracker,
   type IssueTrackerAdapter,
   type IssueTransition,

--- a/packages/sidecar-core/src/issue-mentions.ts
+++ b/packages/sidecar-core/src/issue-mentions.ts
@@ -1,0 +1,113 @@
+import type { TrackedIssue } from "./issues.js";
+import { firstWholeNameIndex, MINIMUM_MENTION_TITLE_LENGTH } from "./session-mentions.js";
+
+/**
+ * The most issues one reply's mentions may put on the notice band, the session
+ * cap's own number for the session cap's own reasons: deep enough for any
+ * reply worth hearing out, shallow enough that the band's scroll stays a
+ * glance. A reply that reads the whole board has the tracker for a record.
+ */
+export const MAXIMUM_MENTIONED_ISSUES = 12;
+
+/**
+ * How one issue's identifier is looked for in spoken words. Case falls away
+ * because a transcript is a rendering of speech, and a hyphen may come back
+ * as a space or a pause on the same grounds — but the boundaries stay strict:
+ * an identifier inside a longer token is a different identifier, so LUKE-1
+ * never claims a mention of LUKE-12. An identifier is precise the way a title
+ * is not, so it earns a mention at any length.
+ */
+function identifierMentionPattern(identifier: string): RegExp {
+  const escaped = identifier.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(
+    `(?<![\\p{L}\\p{N}])${escaped.replace(/-/g, "[-\\s]")}(?![\\p{L}\\p{N}])`,
+    "iu",
+  );
+}
+
+/** Where an identifier is first mentioned in the words, or nowhere. */
+function firstIdentifierIndex(caption: string, identifier: string): number | undefined {
+  const at = caption.search(identifierMentionPattern(identifier));
+  return at === -1 ? undefined : at;
+}
+
+/** One name the caption may be searched for, and the issue it stands for. */
+interface IssueMentionCandidate {
+  issue: TrackedIssue;
+  /** Whether the name stopped being attributable to one issue and is dead. */
+  ambiguous: boolean;
+}
+
+/**
+ * The searchable names one issue roster offers, each mapped to the one issue
+ * it attributably stands for — the session candidates' own discipline, one
+ * roster over. Identifiers and titles are collected into the same map, so a
+ * title that reads exactly like another issue's identifier dies with the
+ * collision instead of pointing two chips at one phrase.
+ */
+function issueMentionCandidates(
+  issues: readonly TrackedIssue[],
+): Map<string, IssueMentionCandidate> {
+  const candidates = new Map<string, IssueMentionCandidate>();
+  const offer = (name: string, issue: TrackedIssue) => {
+    const existing = candidates.get(name);
+    if (!existing) {
+      candidates.set(name, { issue, ambiguous: false });
+      return;
+    }
+    // The same issue offering the same words twice — an identifier equal to
+    // its own title — is still one attributable name, not a collision.
+    if (existing.issue !== issue) existing.ambiguous = true;
+  };
+  for (const issue of issues) {
+    offer(issue.identifier.toLowerCase(), issue);
+    const title = issue.title.trim().toLowerCase();
+    if (title.length >= MINIMUM_MENTION_TITLE_LENGTH) offer(title, issue);
+  }
+  return candidates;
+}
+
+/**
+ * The tracked issues a spoken reply names, in the order they are first heard,
+ * for the surface to draw pressable previews of beside the sessions the same
+ * words name. A reply may name an issue by its tracker identifier — LUKE-123,
+ * however the transcript renders it — or by its whole title under the session
+ * mentions' own minimum-length rule.
+ *
+ * Deterministic on the side that matters, exactly like the session mentions:
+ * the issues come only from the observed roster, and one is included only
+ * when its own identifier or title appears whole in the words being spoken —
+ * so the model's words can select among what the tracker actually lists but
+ * can never point a chip at anything else. A name two issues share earns
+ * nothing, because a chip that might open the wrong issue is worse than no
+ * chip; an issue named by identifier and title at once counts once, at its
+ * first hearing; and the result is capped at {@link MAXIMUM_MENTIONED_ISSUES}.
+ * The rows returned are the roster's own, resolved here so every caller draws
+ * the same observed fields.
+ */
+export function mentionedIssues(
+  caption: string | undefined,
+  issues: readonly TrackedIssue[] | undefined,
+): readonly TrackedIssue[] {
+  if (!caption || !issues || issues.length === 0) return [];
+  const spoken = caption.toLowerCase();
+  const heard = new Map<TrackedIssue, number>();
+  for (const [name, candidate] of issueMentionCandidates(issues)) {
+    if (candidate.ambiguous) continue;
+    // The identifier's tolerance (a hyphen spoken as a space) is harmless on
+    // a title too, so one matcher serves both kinds of name — except that a
+    // title may carry regex-meaningful punctuation, which the pattern
+    // escapes, and the plain whole-name walk is cheaper where it suffices.
+    const at =
+      name === candidate.issue.identifier.toLowerCase()
+        ? firstIdentifierIndex(spoken, name)
+        : firstWholeNameIndex(spoken, name);
+    if (at === undefined) continue;
+    const earliest = heard.get(candidate.issue);
+    if (earliest === undefined || at < earliest) heard.set(candidate.issue, at);
+  }
+  return [...heard.entries()]
+    .sort((a, b) => a[1] - b[1])
+    .slice(0, MAXIMUM_MENTIONED_ISSUES)
+    .map(([issue]) => issue);
+}

--- a/packages/sidecar-core/src/issue-mentions.ts
+++ b/packages/sidecar-core/src/issue-mentions.ts
@@ -10,12 +10,25 @@ import { firstWholeNameIndex, MINIMUM_MENTION_TITLE_LENGTH } from "./session-men
 export const MAXIMUM_MENTIONED_ISSUES = 12;
 
 /**
- * How one issue's identifier is looked for in spoken words. Case falls away
- * because a transcript is a rendering of speech, and a hyphen may come back
- * as a space or a pause on the same grounds — but the boundaries stay strict:
- * an identifier inside a longer token is a different identifier, so LUKE-1
- * never claims a mention of LUKE-12. An identifier is precise the way a title
- * is not, so it earns a mention at any length.
+ * Whether an identifier's hyphens may come back from the transcript as
+ * spaces. The tolerance exists because a transcript is a rendering of speech
+ * — LUKE-123 is often written down as "LUKE 123" — but the spaced form of a
+ * short key is ordinary language: IT-1 must not claim every "it 1" a sentence
+ * produces. So the spaced form is what a short name is, and it is held to the
+ * titles' own minimum: only a key whose first segment could stand as a title
+ * earns the tolerance. The literal hyphenated form stays precise at any
+ * length — "it-1" is not a phrase speech produces by accident.
+ */
+function spacedFormTolerated(identifier: string): boolean {
+  const prefix = identifier.split("-")[0] ?? "";
+  return prefix.length >= MINIMUM_MENTION_TITLE_LENGTH;
+}
+
+/**
+ * How a tolerant identifier is looked for in spoken words. Case falls away
+ * because the caller lowercases both sides; the boundaries stay strict, so an
+ * identifier inside a longer token is a different identifier and LUKE-1 never
+ * claims a mention of LUKE-12.
  */
 function identifierMentionPattern(identifier: string): RegExp {
   const escaped = identifier.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -25,7 +38,7 @@ function identifierMentionPattern(identifier: string): RegExp {
   );
 }
 
-/** Where an identifier is first mentioned in the words, or nowhere. */
+/** Where a tolerant identifier is first mentioned in the words, or nowhere. */
 function firstIdentifierIndex(caption: string, identifier: string): number | undefined {
   const at = caption.search(identifierMentionPattern(identifier));
   return at === -1 ? undefined : at;
@@ -34,35 +47,52 @@ function firstIdentifierIndex(caption: string, identifier: string): number | und
 /** One name the caption may be searched for, and the issue it stands for. */
 interface IssueMentionCandidate {
   issue: TrackedIssue;
+  /** The literal lowercased name the caption is searched for. */
+  name: string;
+  /** Whether the name is an identifier whose hyphens may match spaces. */
+  tolerant: boolean;
   /** Whether the name stopped being attributable to one issue and is dead. */
   ambiguous: boolean;
 }
 
 /**
+ * How a name reads to a listener: hyphens and runs of whitespace as one
+ * space. Ambiguity is keyed on this rather than on the literal spelling,
+ * because the identifier tolerance makes LUKE-1 and a title "luke 1" the
+ * same spoken phrase — two candidates whose literal names differ but whose
+ * sound collides must die together, or one phrase lights two chips.
+ */
+function spokenForm(name: string): string {
+  return name.replace(/[-\s]+/g, " ");
+}
+
+/**
  * The searchable names one issue roster offers, each mapped to the one issue
  * it attributably stands for — the session candidates' own discipline, one
- * roster over. Identifiers and titles are collected into the same map, so a
- * title that reads exactly like another issue's identifier dies with the
- * collision instead of pointing two chips at one phrase.
+ * roster over. Identifiers and titles are collected into the same map, keyed
+ * by how they sound, so a title that reads like another issue's identifier —
+ * spaced or hyphenated — dies with the collision instead of pointing two
+ * chips at one phrase.
  */
 function issueMentionCandidates(
   issues: readonly TrackedIssue[],
 ): Map<string, IssueMentionCandidate> {
   const candidates = new Map<string, IssueMentionCandidate>();
-  const offer = (name: string, issue: TrackedIssue) => {
-    const existing = candidates.get(name);
+  const offer = (name: string, tolerant: boolean, issue: TrackedIssue) => {
+    const existing = candidates.get(spokenForm(name));
     if (!existing) {
-      candidates.set(name, { issue, ambiguous: false });
+      candidates.set(spokenForm(name), { issue, name, tolerant, ambiguous: false });
       return;
     }
-    // The same issue offering the same words twice — an identifier equal to
+    // The same issue offering the same sound twice — an identifier equal to
     // its own title — is still one attributable name, not a collision.
     if (existing.issue !== issue) existing.ambiguous = true;
   };
   for (const issue of issues) {
-    offer(issue.identifier.toLowerCase(), issue);
+    const identifier = issue.identifier.toLowerCase();
+    offer(identifier, spacedFormTolerated(identifier), issue);
     const title = issue.title.trim().toLowerCase();
-    if (title.length >= MINIMUM_MENTION_TITLE_LENGTH) offer(title, issue);
+    if (title.length >= MINIMUM_MENTION_TITLE_LENGTH) offer(title, false, issue);
   }
   return candidates;
 }
@@ -71,19 +101,19 @@ function issueMentionCandidates(
  * The tracked issues a spoken reply names, in the order they are first heard,
  * for the surface to draw pressable previews of beside the sessions the same
  * words name. A reply may name an issue by its tracker identifier — LUKE-123,
- * however the transcript renders it — or by its whole title under the session
- * mentions' own minimum-length rule.
+ * however the transcript renders its hyphen — or by its whole title under the
+ * session mentions' own minimum-length rule.
  *
  * Deterministic on the side that matters, exactly like the session mentions:
  * the issues come only from the observed roster, and one is included only
  * when its own identifier or title appears whole in the words being spoken —
  * so the model's words can select among what the tracker actually lists but
- * can never point a chip at anything else. A name two issues share earns
- * nothing, because a chip that might open the wrong issue is worse than no
- * chip; an issue named by identifier and title at once counts once, at its
- * first hearing; and the result is capped at {@link MAXIMUM_MENTIONED_ISSUES}.
- * The rows returned are the roster's own, resolved here so every caller draws
- * the same observed fields.
+ * can never point a chip at anything else. Names that sound alike and stand
+ * for different issues earn nothing, because a chip that might open the
+ * wrong issue is worse than no chip; an issue named by identifier and title
+ * at once counts once, at its first hearing; and the result is capped at
+ * {@link MAXIMUM_MENTIONED_ISSUES}. The rows returned are the roster's own,
+ * resolved here so every caller draws the same observed fields.
  */
 export function mentionedIssues(
   caption: string | undefined,
@@ -92,16 +122,14 @@ export function mentionedIssues(
   if (!caption || !issues || issues.length === 0) return [];
   const spoken = caption.toLowerCase();
   const heard = new Map<TrackedIssue, number>();
-  for (const [name, candidate] of issueMentionCandidates(issues)) {
+  for (const candidate of issueMentionCandidates(issues).values()) {
     if (candidate.ambiguous) continue;
-    // The identifier's tolerance (a hyphen spoken as a space) is harmless on
-    // a title too, so one matcher serves both kinds of name — except that a
-    // title may carry regex-meaningful punctuation, which the pattern
-    // escapes, and the plain whole-name walk is cheaper where it suffices.
-    const at =
-      name === candidate.issue.identifier.toLowerCase()
-        ? firstIdentifierIndex(spoken, name)
-        : firstWholeNameIndex(spoken, name);
+    // A tolerant identifier needs the pattern's hyphen-or-space; everything
+    // else — titles, and identifiers too short to earn the tolerance — is a
+    // literal whole name, which the plain walk finds cheaper.
+    const at = candidate.tolerant
+      ? firstIdentifierIndex(spoken, candidate.name)
+      : firstWholeNameIndex(spoken, candidate.name);
     if (at === undefined) continue;
     const earliest = heard.get(candidate.issue);
     if (earliest === undefined || at < earliest) heard.set(candidate.issue, at);

--- a/packages/sidecar-core/src/session-mentions.ts
+++ b/packages/sidecar-core/src/session-mentions.ts
@@ -55,8 +55,10 @@ function boundaryAt(text: string, index: number): boolean {
  * Where a name is first mentioned whole in the caption, or nowhere. Whole
  * means bounded on both sides by something other than a letter or digit, so a
  * short name cannot ride inside a longer word that merely contains it.
+ * Exported for the issue mentions, which hold titles to exactly this rule —
+ * one definition of "named whole", however many rosters offer names.
  */
-function firstMentionIndex(caption: string, name: string): number | undefined {
+export function firstWholeNameIndex(caption: string, name: string): number | undefined {
   let from = 0;
   while (from + name.length <= caption.length) {
     const at = caption.indexOf(name, from);
@@ -165,7 +167,7 @@ export function mentionedSessions(
   const mentions: { at: number; kind: SessionMentionKind; session: NormalizedSession }[] = [];
   for (const [name, candidate] of mentionCandidates(sessions)) {
     if (candidate.ambiguous) continue;
-    const at = firstMentionIndex(spoken, name);
+    const at = firstWholeNameIndex(spoken, name);
     if (at === undefined) continue;
     mentions.push({ at, kind: candidate.kind, session: candidate.session });
   }

--- a/packages/sidecar-core/tests/issue-mentions.test.ts
+++ b/packages/sidecar-core/tests/issue-mentions.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ISSUE_TRACKER_ID,
+  MAXIMUM_MENTIONED_ISSUES,
+  mentionedIssues,
+  normalizeTrackedIssue,
+  type TrackedIssue,
+} from "../src";
+
+const LINEAR = { id: ISSUE_TRACKER_ID.LINEAR, displayName: "Linear" } as const;
+
+function issue(identifier: string, title: string): TrackedIssue {
+  const normalized = normalizeTrackedIssue(LINEAR, {
+    trackerIssueId: `issue-uuid-${identifier}`,
+    identifier,
+    title,
+    stateName: "Todo",
+    observedAt: 1_800_000_000_000,
+  });
+  assert.ok(normalized);
+  return normalized;
+}
+
+function identifiers(issues: readonly TrackedIssue[]): readonly string[] {
+  return issues.map((mention) => mention.identifier);
+}
+
+test("names the issues the reply mentions, in the order they are heard", () => {
+  const board = [issue("LUKE-1", "Fix login"), issue("LUKE-2", "Ship captions")];
+  assert.deepEqual(identifiers(mentionedIssues("LUKE-2 is blocked on LUKE-1, remember.", board)), [
+    "LUKE-2",
+    "LUKE-1",
+  ]);
+});
+
+test("an identifier matches case aside, and a hyphen may return as a space", () => {
+  const board = [issue("LUKE-12", "Fix login")];
+  assert.deepEqual(identifiers(mentionedIssues("luke-12 looks stuck.", board)), ["LUKE-12"]);
+  assert.deepEqual(identifiers(mentionedIssues("Luke 12 looks stuck.", board)), ["LUKE-12"]);
+});
+
+test("an identifier inside a longer token is a different identifier", () => {
+  const board = [issue("LUKE-1", "Fix login")];
+  assert.deepEqual(mentionedIssues("LUKE-12 is not this issue.", board), []);
+  assert.deepEqual(mentionedIssues("XLUKE-1 is not this issue either.", board), []);
+  assert.deepEqual(identifiers(mentionedIssues("(LUKE-1) is, punctuation and all.", board)), [
+    "LUKE-1",
+  ]);
+});
+
+test("a whole title names its issue on the session mentions' own terms", () => {
+  const board = [issue("LUKE-7", "Checkout flaking")];
+  assert.deepEqual(identifiers(mentionedIssues('I looked at "checkout flaking".', board)), [
+    "LUKE-7",
+  ]);
+  // Inside a longer word is not a mention of this issue.
+  assert.deepEqual(mentionedIssues("The precheckout flakingest queue.", board), []);
+});
+
+test("a title too short to be attributable earns no chip; its identifier still does", () => {
+  const board = [issue("LUKE-9", "Fix")];
+  assert.deepEqual(mentionedIssues("I can fix that for you.", board), []);
+  assert.deepEqual(identifiers(mentionedIssues("Fix is LUKE-9 on the board.", board)), ["LUKE-9"]);
+});
+
+test("a title two issues share names neither; their identifiers still do", () => {
+  const board = [issue("LUKE-1", "Untitled issue"), issue("LUKE-2", "untitled issue")];
+  assert.deepEqual(mentionedIssues("The untitled issue is waiting.", board), []);
+  assert.deepEqual(identifiers(mentionedIssues("Untitled issue LUKE-2 is waiting.", board)), [
+    "LUKE-2",
+  ]);
+});
+
+test("a title reading exactly like another issue's identifier stands for neither", () => {
+  const board = [issue("LUKE-1", "Fix login"), issue("LUKE-2", "luke-1")];
+  assert.deepEqual(mentionedIssues("Have a look at LUKE-1 today.", board), []);
+});
+
+test("an issue named by identifier and title at once counts once, at its first hearing", () => {
+  const board = [issue("LUKE-1", "Fix login"), issue("LUKE-2", "Ship captions")];
+  assert.deepEqual(
+    identifiers(mentionedIssues("Ship captions waits on Fix login, that is LUKE-1.", board)),
+    ["LUKE-2", "LUKE-1"],
+  );
+});
+
+test("mentions past the cap are dropped from the tail of the reply", () => {
+  const board = Array.from({ length: MAXIMUM_MENTIONED_ISSUES + 1 }, (_, index) =>
+    issue(`LUKE-${index + 1}`, `Errand number ${index + 1}`),
+  );
+  const spoken = mentionedIssues(
+    `${board.map((entry) => entry.identifier).join(", then ")}.`,
+    board,
+  );
+  assert.equal(spoken.length, MAXIMUM_MENTIONED_ISSUES);
+  assert.deepEqual(
+    identifiers(spoken),
+    board.slice(0, MAXIMUM_MENTIONED_ISSUES).map((entry) => entry.identifier),
+  );
+});
+
+test("only the observed roster can be pointed at, whatever the words claim", () => {
+  assert.deepEqual(mentionedIssues("Move LUKE-999 to Done right now.", []), []);
+  assert.deepEqual(mentionedIssues("Move LUKE-999 to Done right now.", undefined), []);
+  assert.deepEqual(mentionedIssues("Move LUKE-999 to Done.", [issue("LUKE-1", "Fix login")]), []);
+});
+
+test("an empty or absent caption mentions nothing", () => {
+  const board = [issue("LUKE-1", "Fix login")];
+  assert.deepEqual(mentionedIssues(undefined, board), []);
+  assert.deepEqual(mentionedIssues("", board), []);
+});

--- a/packages/sidecar-core/tests/issue-mentions.test.ts
+++ b/packages/sidecar-core/tests/issue-mentions.test.ts
@@ -77,6 +77,29 @@ test("a title reading exactly like another issue's identifier stands for neither
   assert.deepEqual(mentionedIssues("Have a look at LUKE-1 today.", board), []);
 });
 
+test("names that sound alike across the hyphen die together, spelt either way", () => {
+  // The identifier's spaced form and another issue's title are one spoken
+  // phrase; a chip that might open the wrong issue is worse than no chip.
+  const spacedTitle = [issue("LUKE-1", "Fix login"), issue("LUKE-2", "luke 1")];
+  assert.deepEqual(mentionedIssues("Have a look at luke 1 today.", spacedTitle), []);
+  assert.deepEqual(mentionedIssues("Have a look at LUKE-1 today.", spacedTitle), []);
+  // A title merely containing another issue's identifier is not a collision:
+  // the phrase names the identifier whole and the title whole, and both are
+  // attributable — the session mentions' own containment behavior.
+  const hyphenTitle = [issue("LUKE-1", "Fix login"), issue("LUKE-2", "luke-1 fallout")];
+  assert.deepEqual(identifiers(mentionedIssues("luke-1 fallout again.", hyphenTitle)), [
+    "LUKE-1",
+    "LUKE-2",
+  ]);
+});
+
+test("a short key never claims the ordinary speech its spaced form reads as", () => {
+  const board = [issue("IT-1", "Fix login"), issue("A-1", "Ship captions")];
+  assert.deepEqual(mentionedIssues("Give it 1 more try, then a 1 line fix.", board), []);
+  // The literal hyphenated form stays precise at any length.
+  assert.deepEqual(identifiers(mentionedIssues("IT-1 is waiting on A-1.", board)), ["IT-1", "A-1"]);
+});
+
 test("an issue named by identifier and title at once counts once, at its first hearing", () => {
   const board = [issue("LUKE-1", "Fix login"), issue("LUKE-2", "Ship captions")];
   assert.deepEqual(


### PR DESCRIPTION
## Summary

A spoken reply that names tracked issues — by identifier like `LUKE-123`, however the transcript renders its hyphen, or by whole title — now draws a pressable chip for each on the same notice band the session mentions stand on (#250). Each chip wears the issue's identifier and title with the tracker's mark, and pressing one hands the issue's tracker-reported https address to the operating system through a new `openIssue` bridge call, validated against the observed issue roster in the main process.

## How it holds the rules

- The matcher (`packages/sidecar-core/src/issue-mentions.ts`) is the session mentions' discipline one roster over: whole names only, case aside, first-heard order, dedup at first hearing, capped at 12. A name two issues share earns nothing — including a title that reads exactly like another issue's identifier — and titles are held to the same minimum length as session titles. It reuses `firstWholeNameIndex`, now exported from `session-mentions.ts`, so "named whole" has one definition.
- Identities come only from the observed roster: the model's words can select among what the tracker actually lists, never point a chip at anything else.
- An announcement's one validated session subject stays the whole answer; issue identifiers riding along in its sentence earn nothing.
- Chips are display only. A press reaches none of the tracker's write paths — the main process re-validates the identity and opens only the normalization-admitted https address; an issue that reported none is taken nowhere.
- No new band, no new geometry: the chips inherit #250's wrap, three-row growth, scroll, and fold fades (#253) untouched.
- The guide's Announcements fact and AGENTS.md describe the issue chips in the same change.

## Testing

- `./scripts/check.sh` exits 0: 247 core + 1037 desktop + 40 web tests, lint, typecheck, builds, generator drift check.
- 11 new matcher tests extend the session-mentions patterns (`issue-mentions.test.ts`); 3 new `replyIssueMentions` tests cover the announcement, stacked-caption, and capture-run bounds.
- Not verified on macOS: this change was built in a Linux cloud workspace, so `./scripts/verify.sh` and a physical-notch check were not run — the mixed band (issue chips wrapping among session chips) deserves an eyeball on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d5e823c3-7319-407c-8cef-982d56c2c483)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32192925151/artifacts/9344880076) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32192925151)

- Commit: `e951f5c0d002163696dd44e9fb635b806a96e07f`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
