### PR TITLE
feat(desktop): create Codex cloud tasks through the documented CLI command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,15 +39,24 @@ Trust constraints:
   no token is read, stored, or forwarded — and the CLI answers exactly as it
   would in the user's own terminal. No shell stands between Luke and the
   binary, nothing enters an invocation's arguments beyond values the build
-  fixed, and a machine whose CLI is absent or signed out is observed as having
-  nothing, the same answer a key-observed provider gives with no key. The
+  fixed — or, for a paged read, the bounded page cursor the same read's
+  previous page handed back, as a single token — and a machine whose CLI is
+  absent or signed out is observed as having nothing, the same answer a
+  key-observed provider gives with no key. The
   login is the consent, given by the user's own hands to the provider itself,
-  and signing the CLI out withdraws it on the next pass. Writes stay bound to
-  what the CLI documents: Codex documents no way to message or steer a running
-  task, so its cloud sessions advertise none, and the honest absence stands
-  rather than an improvised control. Widening the invocation set, adding a
-  write, or observing another provider this way is a product decision, not an
-  implementation detail.
+  and signing the CLI out withdraws it on the next pass. Writes keep the shape
+  every provider write has, at one remove: the one write Luke makes through a
+  provider CLI is a new Codex cloud task the user just asked for, through the
+  CLI's own documented creation command, in an environment the latest
+  observation pass reported. The ask carries the developer's own task text as
+  a single argument behind an end-of-options separator — never through a
+  shell — under the same login, probed again at the moment of the act, and
+  the one thing read out of the answer is the created task's id, for the next
+  pass to report on its own. Codex documents no way to message or steer a
+  task already running, so its cloud sessions advertise none, and the honest
+  absence stands rather than an improvised control. Widening the invocation
+  set further, or observing another provider this way, is a product decision,
+  not an implementation detail.
 - One registration is the exception the previous rule's word "require" leaves
   room for, and it is bounded on every side: Luke may merge an observation
   hook into a provider's own user-level hook configuration — today Claude

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -221,9 +221,12 @@ login you gave that CLI for its own sake, never a credential of Luke's own.
 Luke reads no token and stores none: it first asks `codex login status`
 whether a login exists at all — an answer read from the exit code alone — and
 only then runs the CLI's documented read, `codex cloud list --json`, exactly
-as your own terminal would. Without the CLI installed, or with it signed out,
-Luke runs nothing further and reports no cloud tasks; the Codex sessions
-running on this machine are read from disk and are unaffected.
+as your own terminal would. Every few minutes that read also walks a bounded
+few pages further into your recent task history, following the CLI's own page
+cursor, so every environment in recent use can be offered when you ask Luke
+to start a task. Without the CLI installed, or with it signed out, Luke runs
+nothing further and reports no cloud tasks; the Codex sessions running on
+this machine are read from disk and are unaffected.
 
 What that read returns is what Luke processes: task identifiers, status,
 timestamps, the environment's repository label, and each task's own link. The
@@ -232,10 +235,15 @@ it and labels the row by repository instead, the same boundary every cloud
 provider's prompt-derived names get. Returned metadata is held in memory for
 display; command output is not persisted.
 
-Observation never invokes a command that could change anything: the CLI's
-write commands are never run, and Codex documents no way to message or steer
-a running cloud task, so its rows offer none. Signing the CLI out stops the
-reads on the next pass.
+Observation never invokes a command that could change anything. Luke runs
+exactly one Codex write command, and only to carry out something you just
+asked for: creating a new cloud task — spoken or typed in a turn you opened —
+runs the CLI's documented `codex cloud exec`, in an environment the latest
+observation listed, with your task text as a single argument. The command's
+answer is read only for the created task's id, so the next observation can
+show the task you asked for. Codex documents no way to message or steer a
+task already running, so its rows offer none. Signing the CLI out stops the
+reads, and refuses the write, on the next pass.
 
 ## Optional issue-tracker reads and spoken acts
 

--- a/PROVIDERS.md
+++ b/PROVIDERS.md
@@ -36,7 +36,7 @@ What each provider's sessions report:
 | Provider | Id | Sessions | Credential | Lifecycle hook | Recap | Opens at |
 | --- | --- | --- | --- | --- | --- | --- |
 | Claude Code | `claude-code` | Local | None | `settings.json` merge | Designated away summary | — |
-| Codex | `codex` | Local | None | `hooks.json` merge, behind Codex's trust gate | Last agent message | `codex:` thread link |
+| Codex | `codex` | Local and cloud | None; cloud via the Codex CLI login | `hooks.json` merge, behind Codex's trust gate | Last agent message (local) | `codex:` thread link (local), task URL (cloud) |
 | Conductor | `conductor` | Cloud | API key | — | Final assistant message, only while idle | `conductor:` deep link |
 | Cursor | `cursor` | Local and cloud | Cloud only | — | Run result (cloud) | Agent URL (cloud) |
 | Devin | `devin` | Local and cloud | Cloud only | — | — | Session URL (cloud) |
@@ -51,7 +51,7 @@ developer opened:
 | Provider | Message | Controls | New workspace | Add agent | Transcript readout |
 | --- | --- | --- | --- | --- | --- |
 | Claude Code | — | — | — | — | Yes |
-| Codex | — | — | — | — | Yes |
+| Codex | — | — | Yes, task required (cloud) | — | Yes, local sessions |
 | Conductor | While idle or working | `cancel-turn`, `archive-workspace` | Yes, task optional | Yes | — |
 | Cursor | After a finished run | `cancel-run`, `archive-agent` | Yes, task required | — | Yes, local sessions |
 | Devin | While running or suspended | `archive-session` | — | — | Yes, local sessions |
@@ -84,17 +84,39 @@ end — into a spool under Luke's own application data.
 
 ## Codex
 
-Local sessions, no credential. Luke reads the read-only session index in
+Local sessions need no credential. Luke reads the read-only session index in
 `state_5.sqlite` under `~/.codex` (honoring `CODEX_HOME`), then bounded tails
 of each thread's rollout file. The observation hook merges into `hooks.json`
 and runs only after Codex's own review gate shows it to the user and they
 trust it; its events match Claude Code's minus stop failure.
 
-- Recap: the last agent message from the rollout tail; a failed turn reports
-  its error instead.
-- Opens at `codex://threads/<id>`.
-- No message path, no controls, no workspace acts.
-- Transcript readout: yes (`apps/desktop/src/codex-transcript.ts`).
+Cloud tasks are the one CLI-observed surface: Codex documents no key-scoped
+API, so observation runs the user's own Codex CLI — `codex login status` by
+exit code alone, then `codex cloud list --json` — under the ChatGPT login the
+user already gave that CLI. No token is read, stored, or forwarded, and a
+machine whose CLI is absent or signed out is observed as having nothing. The
+newest page is the roster; every few minutes a bounded walk of further pages,
+following the CLI's own cursor, gathers the environments in recent use so
+they can be offered for creation. The Connections page draws the login state
+as a read-only row.
+
+- Recap (local): the last agent message from the rollout tail; a failed turn
+  reports its error instead. Cloud tasks carry none.
+- Cloud rows are labelled by the environment's repository — the prompt-derived
+  task title is discarded as transcript content — and map `pending` to
+  working, `ready` and `applied` to complete, and `error` to a failure.
+- Opens at `codex://threads/<id>` locally; a cloud task opens its
+  `chatgpt.com` page.
+- New workspace (cloud): a task started with `codex cloud exec --env`, in an
+  environment the latest observation reported, by id where the list reports
+  one and by label otherwise. The opening task is required — the prompt is
+  the whole creation — a chosen name is refused because Codex names tasks
+  itself, and the one thing read from the answer is the created task's id.
+- No message path and no controls: Codex documents no way to message or steer
+  a task already running, so the honest absence stands.
+- Transcript readout: yes for local sessions
+  (`apps/desktop/src/codex-transcript.ts`); a cloud task's conversation lives
+  with its provider and is never fetched.
 
 ## Conductor
 

--- a/apps/desktop/src/cli-session-adapter.ts
+++ b/apps/desktop/src/cli-session-adapter.ts
@@ -2,6 +2,8 @@ import { execFile } from "node:child_process";
 import path from "node:path";
 import {
   isRecord,
+  PROVIDER_ACT_RESULT_STATUS,
+  type ProviderActResult,
   type ProviderSessionObservation,
   resolveOptions,
   SESSION_LOCATION,
@@ -37,6 +39,12 @@ export class CliCommandError extends Error {
 export const CLI_ADAPTER_DEFAULTS = {
   MINIMUM_REFRESH_INTERVAL_MS: 15 * 1000,
   COMMAND_TIMEOUT_MS: 8 * 1000,
+  /**
+   * A write command does more than a read answers for — Codex's creation
+   * resolves the environment and stands the task up before it prints — so it
+   * gets a wider deadline than the read's, and still a hard one.
+   */
+  WRITE_TIMEOUT_MS: 20 * 1000,
   /** A read that answers with more than this is not the bounded list it claims to be. */
   MAXIMUM_OUTPUT_BYTES: 4 * 1024 * 1024,
 } as const;
@@ -236,6 +244,84 @@ export abstract class CliSessionAdapter extends SessionProviderAdapterBase {
     return this.#connection;
   }
 
+  /**
+   * Clears anything a subclass cached across passes — projects offered for
+   * creation, above all. It runs whenever the login goes away, so nothing
+   * observed under one login can be offered or acted on under another.
+   */
+  protected forgetCachedIdentity(): void {}
+
+  /**
+   * The one authenticated write: a single invocation of the provider's own
+   * CLI, for something the user just asked for against what the latest pass
+   * observed — a subclass validates before it builds the argv, exactly as the
+   * cloud base does. The login is probed at act time rather than held from
+   * the observation pass, so a CLI signed out since then refuses before
+   * anything runs, and the refusal wording is fixed here rather than echoing
+   * whatever the CLI printed. What the command wrote to stdout rides an
+   * acceptance for the subclass that needs the id a creation named — it
+   * travels no further than that subclass.
+   */
+  protected async performWrite(
+    argv: readonly string[],
+  ): Promise<{ outcome: ProviderActResult; stdout?: string }> {
+    const name = this.provider.displayName;
+    let connection: CliConnection;
+    try {
+      connection = await this.#probeLogin();
+    } catch {
+      return {
+        outcome: {
+          status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
+          reason: `${name}'s CLI could not answer, so nothing was sent.`,
+        },
+      };
+    }
+    this.#connection = connection;
+    if (connection !== CLI_CONNECTION.CONNECTED) {
+      // The act just learned what the next pass would have: the login is
+      // gone. Observed state clears now rather than a tick later, and a pass
+      // still in flight is superseded so its answer cannot land what was read
+      // under the login that no longer stands.
+      this.#forgetLogin();
+      return {
+        outcome: {
+          status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
+          reason:
+            connection === CLI_CONNECTION.CLI_MISSING
+              ? `${name}'s CLI is not installed, so nothing was sent.`
+              : `${name}'s CLI is signed out, so nothing was sent.`,
+        },
+      };
+    }
+    let result: CliRunResult;
+    try {
+      result = await this.#run(this.#binary, argv, {
+        timeoutMs: CLI_ADAPTER_DEFAULTS.WRITE_TIMEOUT_MS,
+        maximumOutputBytes: CLI_ADAPTER_DEFAULTS.MAXIMUM_OUTPUT_BYTES,
+      });
+    } catch {
+      return {
+        outcome: {
+          status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
+          reason: `${name}'s CLI could not answer, so the request may not have landed.`,
+        },
+      };
+    }
+    if (result.exitCode !== 0) {
+      return {
+        outcome: {
+          status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
+          reason: `${name}'s CLI refused the request.`,
+        },
+      };
+    }
+    // A write that landed changes what the provider holds, so the refresh
+    // that follows must actually ask rather than serve the cached snapshot.
+    this.#lastAttemptAt = Number.NEGATIVE_INFINITY;
+    return { outcome: { status: PROVIDER_ACT_RESULT_STATUS.ACCEPTED }, stdout: result.stdout };
+  }
+
   async #probeLogin(): Promise<CliConnection> {
     try {
       const probe = await this.#run(this.#binary, this.#loginProbeArgv, {
@@ -295,6 +381,16 @@ export abstract class CliSessionAdapter extends SessionProviderAdapterBase {
 
   #forgetObservedState(pass: number): void {
     if (pass !== this.#collectPass) return;
+    this.#forgetLogin();
+  }
+
+  /**
+   * Clears observed state and supersedes any pass still in flight, so nothing
+   * read under a login that no longer stands can land back over the clear.
+   */
+  #forgetLogin(): void {
+    this.#collectPass += 1;
+    this.forgetCachedIdentity();
     this.#observations = [];
   }
 }

--- a/apps/desktop/src/codex-cloud-adapter.ts
+++ b/apps/desktop/src/codex-cloud-adapter.ts
@@ -1,4 +1,14 @@
-import { type ProviderSessionObservation, SESSION_STATUS, type SessionStatus } from "@sidecar/core";
+import {
+  PROVIDER_ACT_RESULT_STATUS,
+  type ProviderSessionObservation,
+  type ProviderWorkspaceRequest,
+  type ProviderWorkspaceResult,
+  SESSION_STATUS,
+  type SessionStatus,
+  sessionMessageText,
+  WORKSPACE_TASK_SUPPORT,
+  type WorkspaceProject,
+} from "@sidecar/core";
 import {
   type CliAdapterOptions,
   type CliReadRequest,
@@ -15,26 +25,53 @@ import {
 import { CODEX_PROVIDER } from "./codex-adapter";
 
 /**
- * The two invocations this adapter is allowed to make, fixed by the build the
- * way a cloud adapter's routes are. `login status` answers by exit code alone
- * whether the CLI holds the user's ChatGPT login, and `cloud list --json` is
- * the CLI's documented machine-readable read of the account's cloud tasks —
- * the documented maximum page, newest tasks first, so one call per pass is
- * the whole read.
+ * The invocations this adapter is allowed to make, fixed by the build the way
+ * a cloud adapter's routes are. `login status` answers by exit code alone
+ * whether the CLI holds the user's ChatGPT login; `cloud list --json` is the
+ * CLI's documented machine-readable read of the account's cloud tasks — the
+ * newest page is the roster, and a bounded walk of further pages on a slower
+ * cadence gathers the environments in recent use; and `cloud exec --env` is
+ * its documented way to start a task, the one write this adapter makes. The
+ * `--` before the task text ends option parsing, so the developer's own words
+ * can never read as a flag, and a page cursor rides as one `--cursor=` token
+ * for the same reason.
  */
 const CODEX_CLI = {
   BINARY: "codex",
   LOGIN_PROBE_ARGV: ["login", "status"],
   LIST_TASKS_ARGV: ["cloud", "list", "--json", "--limit", "20"],
+  CURSOR_FLAG: "--cursor=",
+  CREATE_TASK_ARGV: ["cloud", "exec", "--env"],
+  ARGUMENT_SEPARATOR: "--",
 } as const;
 
 const CODEX_TASK_FIELD = {
+  CURSOR: "cursor",
+  ENVIRONMENT_ID: "environment_id",
   ENVIRONMENT_LABEL: "environment_label",
   ID: "id",
   STATUS: "status",
   TASKS: "tasks",
   UPDATED_AT: "updated_at",
   URL: "url",
+} as const;
+
+const CODEX_ADAPTER_DEFAULTS = {
+  /**
+   * How often the environment sweep walks deeper into the task history. The
+   * roster refreshes every pass; the set of environments changes at the pace
+   * of hands, so its deeper read spends its invocations far more slowly.
+   */
+  ENVIRONMENT_SWEEP_INTERVAL_MS: 5 * 60 * 1000,
+  /**
+   * Pages per sweep, the first included: the newest hundred tasks. Bounded
+   * because the walk is per-invocation work under a login that answers for
+   * it, not because the history ends there — an environment older than the
+   * sweep is offered again the next time a task runs in it.
+   */
+  ENVIRONMENT_SWEEP_MAXIMUM_PAGES: 5,
+  /** A cursor is an opaque token, not a document; longer is a report to distrust. */
+  MAXIMUM_CURSOR_LENGTH: 400,
 } as const;
 
 /** The CLI's documented task states, kebab-case as its JSON serializes them. */
@@ -61,6 +98,9 @@ const SESSION_STATUS_BY_CODEX_TASK_STATUS: Readonly<Record<CodexTaskStatus, Sess
   [CODEX_TASK_STATUS.ERROR]: SESSION_STATUS.ERROR,
 } as const;
 
+/** A created task's id reads back from the URL the CLI prints, and is only an id. */
+const MAXIMUM_CREATED_TASK_ID_LENGTH = 120;
+
 export type CodexCloudAdapterOptions = CliAdapterOptions;
 
 interface CodexCloudTask {
@@ -69,6 +109,8 @@ interface CodexCloudTask {
   status: SessionStatus;
   observedAt: number;
   link?: string;
+  environmentId?: string;
+  environmentLabel?: string;
 }
 
 function taskFromRecord(record: Record<string, unknown>): CodexCloudTask | undefined {
@@ -78,6 +120,8 @@ function taskFromRecord(record: Record<string, unknown>): CodexCloudTask | undef
 
   const status = knownValue(CODEX_TASK_STATUS, textFromRecord(record, CODEX_TASK_FIELD.STATUS));
   const link = textFromRecord(record, CODEX_TASK_FIELD.URL);
+  const environmentId = textFromRecord(record, CODEX_TASK_FIELD.ENVIRONMENT_ID);
+  const environmentLabel = textFromRecord(record, CODEX_TASK_FIELD.ENVIRONMENT_LABEL);
 
   return {
     id,
@@ -85,25 +129,52 @@ function taskFromRecord(record: Record<string, unknown>): CodexCloudTask | undef
     // A task's `title` is generated from the prompt the user typed, so it is
     // transcript content that no observation may carry. The environment label
     // — the repository the environment was made for — is the label available.
-    repositoryLabel: repositoryLabel(
-      textFromRecord(record, CODEX_TASK_FIELD.ENVIRONMENT_LABEL),
-      undefined,
-    ),
+    repositoryLabel: repositoryLabel(environmentLabel, undefined),
     // A state this build does not know is not guessed at.
     status: status ? SESSION_STATUS_BY_CODEX_TASK_STATUS[status] : SESSION_STATUS.UNKNOWN,
     ...(link ? { link } : {}),
+    ...(environmentId ? { environmentId } : {}),
+    ...(environmentLabel ? { environmentLabel } : {}),
   };
+}
+
+/**
+ * The id of the task a creation printed. The CLI's documented output is the
+ * new task's URL on one line; the id is its last path segment, and the id is
+ * all that is read — an identifier for the next pass to report on its own,
+ * never an address to act on.
+ */
+function createdTaskId(stdout: string): string | undefined {
+  const line = stdout
+    .split("\n")
+    .map((candidate) => candidate.trim())
+    .find((candidate) => candidate.length > 0);
+  if (!line) return undefined;
+  let url: URL;
+  try {
+    url = new URL(line);
+  } catch {
+    return undefined;
+  }
+  const id = url.pathname.split("/").filter(Boolean).pop();
+  if (!id || id.length > MAXIMUM_CREATED_TASK_ID_LENGTH) return undefined;
+  return id;
 }
 
 /**
  * Observes Codex cloud tasks through the Codex CLI's own documented read,
  * under the ChatGPT login the user already gave that CLI — Luke reads no
  * token and stores none, and a machine whose CLI is absent or signed out is
- * observed as having nothing. Codex documents no way to message or control a
- * running task, so these sessions advertise no writes at all: rows say where
+ * observed as having nothing. The one write is the one the user asks for: a
+ * new task, through the CLI's documented `cloud exec`, in an environment the
+ * latest pass reported. Codex documents no way to message or steer a task
+ * already running, so its sessions advertise no writes at all: rows say where
  * cloud tasks stand, and their address opens them where they live.
  */
 export class CodexCloudSessionAdapter extends CliSessionAdapter {
+  #projects: readonly WorkspaceProject[] = [];
+  #lastEnvironmentSweepAt = Number.NEGATIVE_INFINITY;
+
   constructor(options: CodexCloudAdapterOptions = {}) {
     super(
       {
@@ -115,16 +186,160 @@ export class CodexCloudSessionAdapter extends CliSessionAdapter {
     );
   }
 
+  /**
+   * The environments the latest pass's tasks ran in, which is the only place
+   * the CLI reports environments at all: an account whose recent tasks are
+   * empty is offered nowhere to create, honestly, until it runs one by hand.
+   */
+  override workspaceProjects(): readonly WorkspaceProject[] {
+    return this.#projects;
+  }
+
+  override async createWorkspace(
+    request: ProviderWorkspaceRequest,
+  ): Promise<ProviderWorkspaceResult> {
+    const project = this.#projects.find(
+      (candidate) => candidate.providerProjectId === request.providerProjectId,
+    );
+    if (!project) return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
+
+    // Codex names tasks itself from the prompt; a name the user typed has
+    // nowhere to go, and dropping it silently would honour half the ask.
+    if (request.name !== undefined) {
+      return {
+        status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
+        reason: "Codex names cloud tasks itself, so a chosen name has nowhere to go.",
+      };
+    }
+
+    // The task is the whole creation — `cloud exec` starts nothing without a
+    // prompt — and it is held to the same bound as a message.
+    const task = request.task === undefined ? undefined : sessionMessageText(request.task);
+    if (!task) {
+      return {
+        status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
+        reason: "A Codex cloud task needs an opening task shorter than a document.",
+      };
+    }
+
+    const written = await this.performWrite([
+      ...CODEX_CLI.CREATE_TASK_ARGV,
+      project.providerProjectId,
+      CODEX_CLI.ARGUMENT_SEPARATOR,
+      task,
+    ]);
+    if (written.outcome.status !== PROVIDER_ACT_RESULT_STATUS.ACCEPTED) {
+      return written.outcome;
+    }
+    const providerSessionId = createdTaskId(written.stdout ?? "");
+    return {
+      status: PROVIDER_ACT_RESULT_STATUS.ACCEPTED,
+      ...(providerSessionId ? { providerSessionId } : {}),
+    };
+  }
+
   protected async collect(
     request: CliReadRequest,
-    _now: number,
+    now: number,
   ): Promise<readonly ProviderSessionObservation[]> {
     const body = await request(CODEX_CLI.LIST_TASKS_ARGV);
-    return recordsFromPage(body, CODEX_TASK_FIELD.TASKS)
+    const tasks = recordsFromPage(body, CODEX_TASK_FIELD.TASKS)
       .map(taskFromRecord)
       .filter(isDefined)
-      .sort((first, second) => second.observedAt - first.observedAt)
-      .map((task) => observationFor(task));
+      .sort((first, second) => second.observedAt - first.observedAt);
+
+    if (
+      now - this.#lastEnvironmentSweepAt >=
+      CODEX_ADAPTER_DEFAULTS.ENVIRONMENT_SWEEP_INTERVAL_MS
+    ) {
+      this.#projects = await this.#sweepEnvironments(request, body, tasks);
+      this.#lastEnvironmentSweepAt = now;
+    } else {
+      // Between sweeps the newest page still joins the offer, so an
+      // environment first used moments ago is offered without waiting for
+      // one; only a sweep, or the login going away, removes an environment.
+      const environments = new Map(
+        this.#projects.map((project) => [project.providerProjectId, project]),
+      );
+      collectEnvironments(environments, tasks);
+      this.#projects = [...environments.values()];
+    }
+    return tasks.map((task) => observationFor(task));
+  }
+
+  /**
+   * Walks a bounded few pages further into the task history for the
+   * environments in recent use, so one older than the newest page is still
+   * offered for creation. The cursor is the one value a read hands back into
+   * an invocation: bounded, and passed as a single `--cursor=` token so it can
+   * never read as a flag of its own. A page that fails mid-sweep keeps what
+   * the sweep has — the offer grows by what was actually read, and the pages
+   * beyond it wait for the next sweep rather than costing the whole pass.
+   */
+  async #sweepEnvironments(
+    request: CliReadRequest,
+    firstPage: Record<string, unknown>,
+    firstTasks: readonly CodexCloudTask[],
+  ): Promise<readonly WorkspaceProject[]> {
+    const environments = new Map<string, WorkspaceProject>();
+    collectEnvironments(environments, firstTasks);
+    let cursor = sweepCursor(firstPage);
+    try {
+      for (
+        let page = 1;
+        page < CODEX_ADAPTER_DEFAULTS.ENVIRONMENT_SWEEP_MAXIMUM_PAGES && cursor;
+        page += 1
+      ) {
+        const body = await request([
+          ...CODEX_CLI.LIST_TASKS_ARGV,
+          `${CODEX_CLI.CURSOR_FLAG}${cursor}`,
+        ]);
+        collectEnvironments(
+          environments,
+          recordsFromPage(body, CODEX_TASK_FIELD.TASKS).map(taskFromRecord).filter(isDefined),
+        );
+        cursor = sweepCursor(body);
+      }
+    } catch {
+      // Deliberately swallowed: the roster page already succeeded, and a
+      // shallower environment offer is better than losing the pass whole.
+    }
+    return [...environments.values()];
+  }
+
+  protected override forgetCachedIdentity(): void {
+    this.#projects = [];
+    this.#lastEnvironmentSweepAt = Number.NEGATIVE_INFINITY;
+  }
+}
+
+/** The next page's cursor, or nothing where the history ends. */
+function sweepCursor(body: Record<string, unknown>): string | undefined {
+  const cursor = textFromRecord(body, CODEX_TASK_FIELD.CURSOR);
+  if (!cursor || cursor.length > CODEX_ADAPTER_DEFAULTS.MAXIMUM_CURSOR_LENGTH) return undefined;
+  return cursor;
+}
+
+/**
+ * One creation target per environment, newest task first — the same recency
+ * the roster reads in, so the environments offered are the ones the account
+ * actually uses. The identifier a creation names the environment by is the id
+ * when the list reported one and the label otherwise: the CLI's creation
+ * command documents taking either, and real accounts routinely carry only the
+ * label — keyed on the id alone, they would be offered nowhere.
+ */
+function collectEnvironments(
+  environments: Map<string, WorkspaceProject>,
+  tasks: readonly CodexCloudTask[],
+): void {
+  for (const task of tasks) {
+    const target = task.environmentId ?? task.environmentLabel;
+    if (!target || environments.has(target)) continue;
+    environments.set(target, {
+      providerProjectId: target,
+      repository: task.repositoryLabel,
+      taskSupport: WORKSPACE_TASK_SUPPORT.REQUIRED,
+    });
   }
 }
 

--- a/apps/desktop/src/shared/settings-schema.ts
+++ b/apps/desktop/src/shared/settings-schema.ts
@@ -212,9 +212,11 @@ function voiceSpeedWord(speed: RealtimeVoiceSpeed): string {
 }
 
 function workspaceProviderName(providerId: ProviderId): string {
-  return isCredentialProviderId(providerId)
-    ? CREDENTIAL_PROVIDERS[providerId].displayName
-    : providerId;
+  if (isCredentialProviderId(providerId)) return CREDENTIAL_PROVIDERS[providerId].displayName;
+  // The one workspace-capable provider with no credential row to take a
+  // display name from.
+  if (providerId === PROVIDER_ID.CODEX) return "Codex";
+  return providerId;
 }
 
 function settingGuideEntry(
@@ -559,6 +561,7 @@ export const APP_SETTING_SCHEMA = {
         : ASK_EACH_TIME_CHOICE,
       choices: [
         ASK_EACH_TIME_CHOICE,
+        workspaceProviderName(PROVIDER_ID.CODEX),
         workspaceProviderName(PROVIDER_ID.CONDUCTOR),
         workspaceProviderName(PROVIDER_ID.CURSOR),
       ],

--- a/apps/desktop/tests/codex-cloud-adapter.test.ts
+++ b/apps/desktop/tests/codex-cloud-adapter.test.ts
@@ -26,6 +26,7 @@ const TEST_STATUS = {
 interface TestTask {
   id: string;
   status?: string;
+  environmentId?: string;
   environmentLabel?: string;
   omitEnvironmentLabel?: boolean;
   updatedAt: number;
@@ -40,7 +41,8 @@ function taskPayload(task: TestTask): Record<string, unknown> {
     title: `${SECRET_PROMPT_TEXT} title`,
     status: task.status ?? TEST_STATUS.PENDING,
     updated_at: new Date(task.updatedAt).toISOString(),
-    environment_id: "env-1",
+    // Real accounts routinely carry no environment id — only the label.
+    environment_id: task.environmentId ?? null,
     ...(task.omitEnvironmentLabel
       ? {}
       : { environment_label: task.environmentLabel ?? "reviewstage/luke" }),
@@ -55,12 +57,21 @@ interface RecordedInvocation {
   argv: readonly string[];
 }
 
+interface TestPage {
+  tasks: readonly TestTask[];
+  cursor?: string;
+}
+
 interface FakeCliBehavior {
   loggedIn?: boolean;
   binaryMissing?: boolean;
   listExitCode?: number;
   listStdout?: string;
   tasks?: readonly TestTask[];
+  /** Cursor-addressed pages, for the environment sweep; cursors are "page-N". */
+  pages?: readonly TestPage[];
+  execExitCode?: number;
+  createdTaskId?: string;
 }
 
 /** Serves the two invocations the adapter is allowed to make, recording each. */
@@ -74,9 +85,21 @@ function fakeCodexCli(behavior: FakeCliBehavior) {
     if (argv.join(" ") === LOGIN_PROBE_ARGV.join(" ")) {
       return { exitCode: (behavior.loggedIn ?? true) ? 0 : 1, stdout: "" };
     }
-    if (argv.join(" ") === LIST_TASKS_ARGV.join(" ")) {
+    if (argv.slice(0, LIST_TASKS_ARGV.length).join(" ") === LIST_TASKS_ARGV.join(" ")) {
       if (behavior.listExitCode !== undefined && behavior.listExitCode !== 0) {
         return { exitCode: behavior.listExitCode, stdout: "" };
+      }
+      if (behavior.pages) {
+        const cursorToken = argv.find((argument) => argument.startsWith("--cursor="));
+        const index = cursorToken ? Number(cursorToken.slice("--cursor=page-".length)) : 0;
+        const page = behavior.pages[index] ?? { tasks: [] };
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            tasks: page.tasks.map(taskPayload),
+            cursor: page.cursor ?? null,
+          }),
+        };
       }
       return {
         exitCode: 0,
@@ -86,6 +109,16 @@ function fakeCodexCli(behavior: FakeCliBehavior) {
             tasks: (behavior.tasks ?? []).map(taskPayload),
             cursor: null,
           }),
+      };
+    }
+    if (argv.slice(0, 3).join(" ") === "cloud exec --env") {
+      if (behavior.execExitCode !== undefined && behavior.execExitCode !== 0) {
+        return { exitCode: behavior.execExitCode, stdout: "" };
+      }
+      // The CLI's documented creation output: the new task's URL, one line.
+      return {
+        exitCode: 0,
+        stdout: `https://chatgpt.com/codex/tasks/${behavior.createdTaskId ?? "task-created"}\n`,
       };
     }
     throw new Error(`Unexpected invocation: ${binary} ${argv.join(" ")}`);
@@ -273,7 +306,7 @@ test("reports what each pass learned about the CLI login, and only that", async 
   assert.equal(adapter.connection(), CLI_CONNECTION.CONNECTED);
 });
 
-test("answers unsupported for every act its provider does not document", async () => {
+test("answers unsupported for every act but the creation its provider documents", async () => {
   const { run } = fakeCodexCli({ tasks: [{ id: "task-1", updatedAt: TEST_TIME }] });
   const adapter = adapterFor(run);
   await adapter.observe();
@@ -288,13 +321,180 @@ test("answers unsupported for every act its provider does not document", async (
     }),
     { status: "unsupported" },
   );
-  assert.deepEqual(await adapter.createWorkspace({ providerProjectId: "env-1", task: "Fix it" }), {
-    status: "unsupported",
-  });
   assert.deepEqual(await adapter.spawnWorkspaceAgent({ providerSessionId: "task-1", agent: "x" }), {
     status: "unsupported",
   });
-  assert.deepEqual(adapter.workspaceProjects(), []);
   // A cloud task's conversation lives with its provider and is never fetched.
   assert.equal(await adapter.readTranscript("task-1"), undefined);
+});
+
+test("offers one creation target per observed environment, and none signed out", async () => {
+  const behavior: FakeCliBehavior = {
+    tasks: [
+      { id: "task-1", updatedAt: TEST_TIME },
+      { id: "task-2", updatedAt: TEST_TIME - 1 },
+      {
+        id: "task-3",
+        updatedAt: TEST_TIME - 2,
+        environmentLabel: "reviewstage/site",
+        environmentId: "env-2",
+      },
+    ],
+  };
+  const { run } = fakeCodexCli(behavior);
+  const adapter = adapterFor(run);
+
+  // The label stands in where the list reported no id — which is what real
+  // accounts return — and the id is preferred where one exists.
+  await adapter.observe();
+  assert.deepEqual(adapter.workspaceProjects(), [
+    { providerProjectId: "reviewstage/luke", repository: "luke", taskSupport: "required" },
+    { providerProjectId: "env-2", repository: "site", taskSupport: "required" },
+  ]);
+
+  behavior.loggedIn = false;
+  await adapter.observe();
+  assert.deepEqual(adapter.workspaceProjects(), []);
+});
+
+test("creates a task in an observed environment through the documented command", async () => {
+  const { run, invocations } = fakeCodexCli({
+    tasks: [{ id: "task-1", updatedAt: TEST_TIME }],
+    createdTaskId: "task-created-9",
+  });
+  const adapter = adapterFor(run);
+  await adapter.observe();
+
+  const result = await adapter.createWorkspace({
+    providerProjectId: "reviewstage/luke",
+    task: "Fix the flaky login test",
+  });
+
+  assert.deepEqual(result, { status: "accepted", providerSessionId: "task-created-9" });
+  const exec = invocations.at(-1);
+  assert.deepEqual(exec?.argv, [
+    "cloud",
+    "exec",
+    "--env",
+    "reviewstage/luke",
+    "--",
+    "Fix the flaky login test",
+  ]);
+});
+
+test("refuses a creation the latest pass did not offer or cannot honour", async () => {
+  const behavior: FakeCliBehavior = { tasks: [{ id: "task-1", updatedAt: TEST_TIME }] };
+  const { run, invocations } = fakeCodexCli(behavior);
+  const adapter = adapterFor(run);
+  await adapter.observe();
+  const invocationsAfterObserve = invocations.length;
+
+  // An environment the pass never reported names nowhere a creation could go.
+  assert.deepEqual(await adapter.createWorkspace({ providerProjectId: "env-9", task: "Fix it" }), {
+    status: "unsupported",
+  });
+  // Codex names tasks itself, so a chosen name is refused rather than dropped.
+  const named = await adapter.createWorkspace({
+    providerProjectId: "reviewstage/luke",
+    name: "My workspace",
+    task: "Fix it",
+  });
+  assert.equal(named.status, "rejected");
+  // The task is the whole creation; without one there is nothing to start.
+  const taskless = await adapter.createWorkspace({ providerProjectId: "reviewstage/luke" });
+  assert.equal(taskless.status, "rejected");
+  // Every refusal above answered without running anything.
+  assert.equal(invocations.length, invocationsAfterObserve);
+
+  // A CLI that refuses the request is reported as a rejection, not a success.
+  behavior.execExitCode = 2;
+  const refused = await adapter.createWorkspace({
+    providerProjectId: "reviewstage/luke",
+    task: "Fix it",
+  });
+  assert.equal(refused.status, "rejected");
+
+  // A login gone since the pass refuses at the moment of the act.
+  behavior.execExitCode = 0;
+  behavior.loggedIn = false;
+  const signedOut = await adapter.createWorkspace({
+    providerProjectId: "reviewstage/luke",
+    task: "Fix it",
+  });
+  assert.equal(signedOut.status, "rejected");
+});
+
+test("a login lost at the moment of an act clears observed state immediately", async () => {
+  const behavior: FakeCliBehavior = { tasks: [{ id: "task-1", updatedAt: TEST_TIME }] };
+  const { run } = fakeCodexCli(behavior);
+  const adapter = adapterFor(run);
+  await adapter.observe();
+  assert.equal(adapter.workspaceProjects().length, 1);
+
+  behavior.loggedIn = false;
+  const rejected = await adapter.createWorkspace({
+    providerProjectId: "reviewstage/luke",
+    task: "Fix it",
+  });
+
+  assert.equal(rejected.status, "rejected");
+  assert.equal(adapter.connection(), CLI_CONNECTION.SIGNED_OUT);
+  // The write's probe already said the login is gone; the projects offered
+  // under it must not outlive it by even a pass.
+  assert.deepEqual(adapter.workspaceProjects(), []);
+});
+
+test("sweeps a bounded few pages for environments, on its own slower cadence", async () => {
+  const { run, invocations } = fakeCodexCli({
+    pages: [
+      { tasks: [{ id: "t1", updatedAt: TEST_TIME }], cursor: "page-1" },
+      {
+        tasks: [{ id: "t2", updatedAt: TEST_TIME - 1, environmentLabel: "reviewstage/site" }],
+        cursor: "page-2",
+      },
+      { tasks: [{ id: "t3", updatedAt: TEST_TIME - 2, environmentLabel: "reviewstage/docs" }] },
+    ],
+  });
+  const adapter = adapterFor(run);
+
+  await adapter.observe();
+
+  // Environments from every swept page are offered, newest first, and the
+  // sweep followed exactly the cursors the CLI handed back — each one token.
+  assert.deepEqual(
+    adapter.workspaceProjects().map((project) => project.providerProjectId),
+    ["reviewstage/luke", "reviewstage/site", "reviewstage/docs"],
+  );
+  const listArgv = invocations.filter((invocation) => invocation.argv[1] === "list");
+  assert.deepEqual(
+    listArgv.map((invocation) => invocation.argv.at(-1)),
+    ["20", "--cursor=page-1", "--cursor=page-2"],
+  );
+
+  // A pass inside the sweep interval reads the newest page alone and keeps
+  // the sweep's offer standing.
+  await adapter.observe();
+  assert.equal(
+    invocations.filter((invocation) => invocation.argv[1] === "list").length,
+    listArgv.length + 1,
+  );
+  assert.equal(adapter.workspaceProjects().length, 3);
+});
+
+test("a sweep stops at its page bound however deep the history goes", async () => {
+  const endlessPages = Array.from({ length: 9 }, (_, index) => ({
+    tasks: [
+      {
+        id: `task-${index}`,
+        updatedAt: TEST_TIME - index,
+        environmentLabel: `reviewstage/repo-${index}`,
+      },
+    ],
+    cursor: `page-${index + 1}`,
+  }));
+  const { run, invocations } = fakeCodexCli({ pages: endlessPages });
+
+  await adapterFor(run).observe();
+
+  assert.equal(invocations.filter((invocation) => invocation.argv[1] === "list").length, 5);
 });


### PR DESCRIPTION
## Summary

- Stacked on #256. Add the one write the CLI-observed class makes: creating a Codex cloud task via the CLI's documented `codex cloud exec --env <id> -- <task>`, validated like every provider write — the environment must be one the latest observation pass reported, the task text is bounded like a message, a user-chosen name is refused (Codex names tasks itself) rather than dropped, and the login is probed again at the moment of the act.
- Offer one creation target per environment observed on the latest pass (an account with no recent tasks is honestly offered nowhere), cleared when the login goes away.
- Read exactly one thing from the command's answer — the created task's id from the URL the CLI prints — so the next pass reports the new task and the existing created-workspace-opens-itself flow applies unchanged.
- Amend the trust constraints and PRIVACY.md for the write; teach the guide Codex's display name where a default workspace provider is spoken.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passes (exit 0); adapter suite now 14 tests
- macOS Electron verification (`./scripts/verify.sh`): `not run locally` (Linux cloud workspace) — CI runs it on macos-15

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32204314608/artifacts/9348603563) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32204314608)

- Commit: `3cb1c253c488feeb5bae4d3ab7e2d898af7b51ae`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- No new drawn UI: the creation flow rides the existing workspace-creation machinery, which keys off observed projects.
- `codex cloud exec` without `--branch` targets the CLI's own fallback (literal `main` outside a git repo); if an environment's default branch differs, the provider's own refusal surfaces as the rejection. A branch choice is deliberately not invented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/86e861fc-6154-48b6-a443-e74a159868b7)
