### PR TITLE
fix(desktop): keep caption popup open while hovered

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -2603,6 +2603,7 @@ export function App(): React.JSX.Element {
       <span
         className="voice-caption"
         ref={captionElement}
+        data-hit-region={HIT_REGION.CAPSULE}
         data-error={String(captionIsError)}
         {...(captionIsError ? { role: "status" } : { "aria-hidden": true })}
       >

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1291,6 +1291,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 .app-stage[data-presentation="capsule"][data-caption="true"] .voice-caption,
 .app-stage[data-presentation="peek"][data-caption="true"] .voice-caption {
   opacity: 1;
+  pointer-events: auto;
   transition:
     opacity var(--duration-quick) var(--motion-exit)
     calc(var(--duration-shape) - var(--duration-quick)),
@@ -1314,6 +1315,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 
 .app-stage[data-presentation="panel"][data-caption="true"] .voice-caption {
   opacity: 1;
+  pointer-events: auto;
   transition:
     opacity var(--duration-quick) var(--motion-exit)
     calc(var(--duration-shape) - var(--duration-quick)),


### PR DESCRIPTION
### Motivation
- Hovering the caption popup or preview chips was not preventing the panel from auto-dismissing, making it hard for users to read the popup without it disappearing.

### Description
- Mark the caption popup element as a capsule hit region by adding `data-hit-region={HIT_REGION.CAPSULE}` to the `.voice-caption` element in `apps/desktop/src/renderer/app.tsx` so pointer tracking recognizes hovering over the caption itself.
- Allow pointer interaction for visible caption popups by setting `pointer-events: auto;` in `apps/desktop/src/renderer/styles/base.css` for the caption when shown in capsule, peek, and panel presentations while preserving `pointer-events: none` when hidden.
- Changes keep the hidden state non-interactive and only enable pointer events when the caption is drawn, preserving existing behaviour except for hover retention.

### Testing
- Ran `git diff --check` with no new errors reported. (passed)
- Ran `pnpm exec biome check apps/desktop/src/renderer/app.tsx apps/desktop/src/renderer/styles/base.css`, which completed successfully but reported existing stylesheet specificity warnings that were pre-existing and not introduced by this change. (completed)
- Commit-time staged-file Biome checks (Husky pre-commit) ran and passed when committing this change. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a84d56d07c083268ff1b17874815278)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32192538057/artifacts/9344743411) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32192538057)

- Commit: `2719eec34cf94d654d5dbec197f3dc104924e2ce`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
