### PR TITLE
feat(desktop): carry a session's diff summary onto its row

### DIFF
--- a/PROVIDERS.md
+++ b/PROVIDERS.md
@@ -63,8 +63,10 @@ Transcript readout is Luke reading a local session's conversation aloud — or
 into his composer — when asked about that session; a cloud session's
 conversation lives with its provider and is never fetched. Every provider's
 rows also carry the shared observation fields where the provider writes them:
-title, status, repository, branch, model, current tool activity, error, and a
-change link such as a pull request.
+title, status, repository, branch, model, current tool activity, error, a
+change link such as a pull request, and the size of the change as its
+provider counts it — files touched, lines added and removed — drawn beside
+the checkout. Codex cloud tasks are the one source of those counts today.
 
 ## Claude Code
 

--- a/apps/desktop/src/codex-cloud-adapter.ts
+++ b/apps/desktop/src/codex-cloud-adapter.ts
@@ -1,9 +1,11 @@
 import {
+  isRecord,
   PROVIDER_ACT_RESULT_STATUS,
   type ProviderSessionObservation,
   type ProviderWorkspaceRequest,
   type ProviderWorkspaceResult,
   SESSION_STATUS,
+  type SessionDiffSummary,
   type SessionStatus,
   sessionMessageText,
   WORKSPACE_TASK_SUPPORT,
@@ -51,6 +53,7 @@ const CODEX_TASK_FIELD = {
   ENVIRONMENT_LABEL: "environment_label",
   ID: "id",
   STATUS: "status",
+  SUMMARY: "summary",
   TASKS: "tasks",
   UPDATED_AT: "updated_at",
   URL: "url",
@@ -72,6 +75,13 @@ const CODEX_ADAPTER_DEFAULTS = {
   ENVIRONMENT_SWEEP_MAXIMUM_PAGES: 5,
   /** A cursor is an opaque token, not a document; longer is a report to distrust. */
   MAXIMUM_CURSOR_LENGTH: 400,
+} as const;
+
+/** The CLI's own names for the three counts inside a task's `summary`. */
+const CODEX_SUMMARY_FIELD = {
+  FILES_CHANGED: "files_changed",
+  LINES_ADDED: "lines_added",
+  LINES_REMOVED: "lines_removed",
 } as const;
 
 /** The CLI's documented task states, kebab-case as its JSON serializes them. */
@@ -111,6 +121,27 @@ interface CodexCloudTask {
   link?: string;
   environmentId?: string;
   environmentLabel?: string;
+  diff?: SessionDiffSummary;
+}
+
+/**
+ * The three counts the CLI reports for a task's change, or nothing: a summary
+ * missing any count is not half-reported, and the all-zero summary of a task
+ * still working is left to the normalizer to drop.
+ */
+function diffFromRecord(value: unknown): SessionDiffSummary | undefined {
+  if (!isRecord(value)) return undefined;
+  const filesChanged = value[CODEX_SUMMARY_FIELD.FILES_CHANGED];
+  const linesAdded = value[CODEX_SUMMARY_FIELD.LINES_ADDED];
+  const linesRemoved = value[CODEX_SUMMARY_FIELD.LINES_REMOVED];
+  if (
+    typeof filesChanged !== "number" ||
+    typeof linesAdded !== "number" ||
+    typeof linesRemoved !== "number"
+  ) {
+    return undefined;
+  }
+  return { filesChanged, linesAdded, linesRemoved };
 }
 
 function taskFromRecord(record: Record<string, unknown>): CodexCloudTask | undefined {
@@ -122,6 +153,7 @@ function taskFromRecord(record: Record<string, unknown>): CodexCloudTask | undef
   const link = textFromRecord(record, CODEX_TASK_FIELD.URL);
   const environmentId = textFromRecord(record, CODEX_TASK_FIELD.ENVIRONMENT_ID);
   const environmentLabel = textFromRecord(record, CODEX_TASK_FIELD.ENVIRONMENT_LABEL);
+  const diff = diffFromRecord(record[CODEX_TASK_FIELD.SUMMARY]);
 
   return {
     id,
@@ -135,6 +167,7 @@ function taskFromRecord(record: Record<string, unknown>): CodexCloudTask | undef
     ...(link ? { link } : {}),
     ...(environmentId ? { environmentId } : {}),
     ...(environmentLabel ? { environmentLabel } : {}),
+    ...(diff ? { diff } : {}),
   };
 }
 
@@ -354,6 +387,7 @@ function observationFor(task: CodexCloudTask): ProviderSessionObservation {
     detail: {
       repository: task.repositoryLabel,
       ...(task.link ? { link: task.link } : {}),
+      ...(task.diff ? { diff: task.diff } : {}),
     },
   };
 }

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -482,12 +482,17 @@ function SessionRow({
             <Highlighted text={session.detail} tokens={highlight} />
           </span>
         </small>
-        {place ? (
-          <small className="row-place" title={place}>
+        {place || session.diff ? (
+          <small className="row-place" title={place ?? session.diff}>
             {session.branch ? <BranchGlyph /> : null}
-            <span>
-              <Highlighted text={place} tokens={highlight} />
-            </span>
+            {place ? (
+              <span>
+                <Highlighted text={place} tokens={highlight} />
+              </span>
+            ) : null}
+            {/* The change's size rides the place line: both say what the work
+                touched, and a session with neither spends no line on it. */}
+            {session.diff ? <span className="row-diff">{session.diff}</span> : null}
           </small>
         ) : null}
       </span>

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -10,6 +10,7 @@ import {
   SESSION_STATUS,
   SESSION_URGENCY,
   type SessionControlKind,
+  type SessionDiffSummary,
   type SessionListSort,
   type SessionLocation,
   type SessionNoticeAsk,
@@ -134,6 +135,12 @@ export interface DisplaySession {
   branch?: string;
   /** Read on the provider mark's hover, never spent on a line of the row. */
   model?: string;
+  /**
+   * The size of the session's change, already worded for the row — the counts
+   * are the provider's, the words are the surface's. Beside the checkout on
+   * the place line, because both say what the work touched.
+   */
+  diff?: string;
   urgency: SessionUrgency;
   label: string;
   location: SessionLocation;
@@ -273,6 +280,16 @@ function sessionDetail(session: NormalizedSession, urgency: SessionUrgency): str
     session.recap ??
     urgencyLabel(urgency)
   );
+}
+
+/**
+ * The size of a change in the words a row spends on it. The counts are the
+ * provider's own; only the wording is the surface's, and the minus is the
+ * real minus sign so the two figures read as a diff rather than arithmetic.
+ */
+export function sessionDiffLabel(diff: SessionDiffSummary): string {
+  const files = `${diff.filesChanged} ${diff.filesChanged === 1 ? "file" : "files"}`;
+  return `${files} +${diff.linesAdded} −${diff.linesRemoved}`;
 }
 
 /**
@@ -422,6 +439,7 @@ export function displaySessions(
           repository: session.detail.repository,
           branch: session.detail.branch,
           model: session.detail.model,
+          ...(session.detail.diff ? { diff: sessionDiffLabel(session.detail.diff) } : {}),
           urgency,
           label: urgencyLabel(urgency),
           location: session.location,

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -738,6 +738,12 @@ html[data-keyboard="true"] button.session-row:focus-visible {
   white-space: nowrap;
 }
 
+/* The change's size never truncates: it is short by construction, and the
+   checkout beside it is the field that can afford an ellipsis. */
+.row-place .row-diff {
+  flex: 0 0 auto;
+}
+
 .row-branch-glyph {
   width: 10px;
   height: 10px;

--- a/apps/desktop/tests/codex-cloud-adapter.test.ts
+++ b/apps/desktop/tests/codex-cloud-adapter.test.ts
@@ -30,6 +30,7 @@ interface TestTask {
   environmentLabel?: string;
   omitEnvironmentLabel?: boolean;
   updatedAt: number;
+  summary?: { files_changed: number; lines_added: number; lines_removed: number };
 }
 
 function taskPayload(task: TestTask): Record<string, unknown> {
@@ -46,7 +47,7 @@ function taskPayload(task: TestTask): Record<string, unknown> {
     ...(task.omitEnvironmentLabel
       ? {}
       : { environment_label: task.environmentLabel ?? "reviewstage/luke" }),
-    summary: { files_changed: 3, lines_added: 12, lines_removed: 4 },
+    summary: task.summary ?? { files_changed: 3, lines_added: 12, lines_removed: 4 },
     is_review: false,
     attempt_total: 1,
   };
@@ -497,4 +498,33 @@ test("a sweep stops at its page bound however deep the history goes", async () =
   await adapterFor(run).observe();
 
   assert.equal(invocations.filter((invocation) => invocation.argv[1] === "list").length, 5);
+});
+
+test("carries the CLI's diff counts and leaves a zero summary unreported", async () => {
+  const { run } = fakeCodexCli({
+    tasks: [
+      { id: "task-ready", status: TEST_STATUS.READY, updatedAt: TEST_TIME },
+      {
+        id: "task-pending",
+        status: TEST_STATUS.PENDING,
+        updatedAt: TEST_TIME - 1,
+        summary: { files_changed: 0, lines_added: 0, lines_removed: 0 },
+      },
+    ],
+  });
+
+  const observations = await adapterFor(run).observe();
+
+  assert.deepEqual(observations[0]?.detail?.diff, {
+    filesChanged: 3,
+    linesAdded: 12,
+    linesRemoved: 4,
+  });
+  // The zero summary of a task still working rides to the normalizer, which
+  // drops it — the adapter reports the provider's counts, nothing more.
+  assert.deepEqual(observations[1]?.detail?.diff, {
+    filesChanged: 0,
+    linesAdded: 0,
+    linesRemoved: 0,
+  });
 });

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -44,6 +44,7 @@ export {
   type SessionControlKind,
   type SessionCompletionCause,
   type SessionDetail,
+  type SessionDiffSummary,
   type SessionIdentity,
   type SessionLocation,
   type SessionProvider,

--- a/packages/sidecar-core/src/session-registry.ts
+++ b/packages/sidecar-core/src/session-registry.ts
@@ -27,7 +27,13 @@ function copySession(session: NormalizedSession): NormalizedSession {
   return {
     ...session,
     provider: { ...session.provider },
-    detail: { ...session.detail },
+    // The one nested object inside a detail gets its own copy, like every
+    // other nested field here: a snapshot a caller holds must not share
+    // structure with the store.
+    detail: {
+      ...session.detail,
+      ...(session.detail.diff ? { diff: { ...session.detail.diff } } : {}),
+    },
     controls: session.controls.map((control) => ({ ...control })),
     spawnableAgents: [...session.spawnableAgents],
     ...(session.workspace ? { workspace: { ...session.workspace } } : {}),
@@ -93,6 +99,15 @@ const sameDetail = exhaustiveSame<SessionDetail>({
   error: (first, second) => first.error === second.error,
   link: (first, second) => first.link === second.link,
   change: (first, second) => first.change === second.change,
+  diff: (first, second) =>
+    sameOptional(
+      first.diff,
+      second.diff,
+      (a, b) =>
+        a.filesChanged === b.filesChanged &&
+        a.linesAdded === b.linesAdded &&
+        a.linesRemoved === b.linesRemoved,
+    ),
 });
 
 const sameControl = exhaustiveSame<SessionControl>({

--- a/packages/sidecar-core/src/session.ts
+++ b/packages/sidecar-core/src/session.ts
@@ -240,6 +240,20 @@ export interface SessionDetail {
   link?: string;
   /** The work the session has published, such as a pull request. */
   change?: string;
+  /** The size of the change the session holds, as its provider counts it. */
+  diff?: SessionDiffSummary;
+}
+
+/**
+ * A provider's own counts for a session's change: files touched, lines added,
+ * lines removed. Counts rather than words, because the surface words them —
+ * an adapter reports the numbers its provider actually returned and composes
+ * nothing.
+ */
+export interface SessionDiffSummary {
+  filesChanged: number;
+  linesAdded: number;
+  linesRemoved: number;
 }
 
 /**
@@ -414,6 +428,28 @@ export function sessionChangeNumber(change: string): number | undefined {
   return tail !== undefined && /^\d+$/.test(tail) ? Number(tail) : undefined;
 }
 
+/** A count a row can draw; anything past it is a report to distrust whole. */
+export const maximumSessionDiffCount = 999_999;
+
+/**
+ * A provider's diff counts, or nothing. Dropped whole rather than partially:
+ * one count outside sense makes the others' claim on the row suspect, and a
+ * summary of all zeroes says nothing a row should spend words on.
+ */
+function sessionDiff(diff: SessionDiffSummary | undefined): SessionDiffSummary | undefined {
+  if (!diff) return undefined;
+  const counts = [diff.filesChanged, diff.linesAdded, diff.linesRemoved];
+  const sound = counts.every(
+    (count) => Number.isSafeInteger(count) && count >= 0 && count <= maximumSessionDiffCount,
+  );
+  if (!sound || counts.every((count) => count === 0)) return undefined;
+  return {
+    filesChanged: diff.filesChanged,
+    linesAdded: diff.linesAdded,
+    linesRemoved: diff.linesRemoved,
+  };
+}
+
 function timestamp(value: number, field: string): number {
   if (!Number.isFinite(value) || value < 0) {
     throw new Error(`${field} must be a non-negative finite timestamp`);
@@ -489,6 +525,7 @@ export function normalizeSessionDetail(detail: SessionDetail | undefined): Sessi
   const error = boundedText(detail.error, maximumSessionDetailLength);
   const link = sessionLink(detail.link);
   const change = sessionChange(detail.change);
+  const diff = sessionDiff(detail.diff);
 
   return {
     ...(activity ? { activity } : {}),
@@ -498,6 +535,7 @@ export function normalizeSessionDetail(detail: SessionDetail | undefined): Sessi
     ...(error ? { error } : {}),
     ...(link ? { link } : {}),
     ...(change ? { change } : {}),
+    ...(diff ? { diff } : {}),
   };
 }
 

--- a/packages/sidecar-core/tests/session-registry.test.ts
+++ b/packages/sidecar-core/tests/session-registry.test.ts
@@ -377,3 +377,19 @@ test("a malformed provider snapshot leaves the previous registry state intact", 
     /provider id must not be empty/,
   );
 });
+
+test("a snapshot's diff summary is the caller's copy, never the store's", () => {
+  const registry = new InMemorySessionRegistry();
+  registry.replaceProvider(codex, [
+    observation("task-1", 1, {
+      detail: { diff: { filesChanged: 3, linesAdded: 12, linesRemoved: 4 } },
+    }),
+  ]);
+
+  const identity = { providerId: "codex", providerSessionId: "task-1" };
+  const held = registry.get(identity);
+  assert.ok(held?.detail.diff);
+  held.detail.diff.linesAdded = 999;
+
+  assert.equal(registry.get(identity)?.detail.diff?.linesAdded, 12);
+});

--- a/packages/sidecar-core/tests/session.test.ts
+++ b/packages/sidecar-core/tests/session.test.ts
@@ -88,3 +88,38 @@ test("an address whose tail names no number yields none rather than a guess", ()
   );
   assert.equal(sessionChangeNumber("not an address"), undefined);
 });
+
+test("keeps a sound diff summary and drops a suspect or empty one whole", () => {
+  const withDiff = (diff: Parameters<typeof normalizeSession>[1]["detail"]) =>
+    normalizeSession(
+      { id: "codex", displayName: "Codex" },
+      {
+        providerSessionId: "task-1",
+        title: "workspace",
+        status: SESSION_STATUS.COMPLETE,
+        observedAt: TEST_NOW,
+        detail: diff,
+      },
+    ).detail.diff;
+
+  assert.deepEqual(withDiff({ diff: { filesChanged: 3, linesAdded: 12, linesRemoved: 4 } }), {
+    filesChanged: 3,
+    linesAdded: 12,
+    linesRemoved: 4,
+  });
+  // A summary of nothing says nothing a row should spend words on.
+  assert.equal(withDiff({ diff: { filesChanged: 0, linesAdded: 0, linesRemoved: 0 } }), undefined);
+  // One count outside sense makes the others suspect, so the summary drops whole.
+  assert.equal(
+    withDiff({ diff: { filesChanged: -1, linesAdded: 12, linesRemoved: 4 } }),
+    undefined,
+  );
+  assert.equal(
+    withDiff({ diff: { filesChanged: 3, linesAdded: 12.5, linesRemoved: 4 } }),
+    undefined,
+  );
+  assert.equal(
+    withDiff({ diff: { filesChanged: 3, linesAdded: 12, linesRemoved: 1_000_000 } }),
+    undefined,
+  );
+});


### PR DESCRIPTION
## Summary

- Stacked on #258 (which stacks on #256). Add `SessionDetail.diff` — a provider's own counts for a session's change (files changed, lines added, lines removed). The normalizer drops a summary whole when any count is outside sense and drops the all-zero summary; the registry's exhaustive field comparison learns the new field, so a task whose diff grew redraws.
- Codex cloud tasks report the counts the CLI's `cloud list --json` already returns.
- The row draws the stat beside the checkout on the place line — "3 files +12 −4", worded by the surface, never composed in an adapter — never truncated (the checkout beside it is what ellipsizes).

## Evidence

- Platform-independent checks: `./scripts/check.sh` passes (exit 0); new normalizer, adapter, and registry coverage
- macOS Electron verification (`./scripts/verify.sh`): `not run locally` (Linux cloud workspace) — CI runs it on macos-15

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32204821286/artifacts/9348774569) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32204821286)

- Commit: `e7a6213a61965e03f3026c078736e95797996776`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- The smoke fixture is unchanged, so the automated evidence will not show the stat; the drawing is covered by unit tests and worth an eyeball on a Mac with a live ready task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/86e861fc-6154-48b6-a443-e74a159868b7)
