### PR TITLE
feat(desktop): connect Linear with OAuth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,16 +115,27 @@ Trust constraints:
   outputs out of its transcripts, so a Cursor reading carries none — and a
   provider whose stored shape this build cannot render faithfully keeps the
   honest refusal instead.
-- The issue tracker follows the same rule at one remove. Luke reads the issues
-  a tracker lists for the user under a user-supplied key and observes nothing
-  without one, exactly like a cloud session provider. The two acts a tracker
-  takes — moving an issue to a state its latest observation listed, adding a
-  comment — happen only as the direct product of a turn the developer opened
-  themselves, through the tracker's own documented endpoint under the same
-  key, validated against the observed issue roster in the renderer and again
-  in the main process before the tracker client sees anything. Observation
-  sends only the read document; the write documents are fixed by the build and
-  issued only for a validated act.
+- The issue tracker follows the same rule at one remove, and is connected the
+  way the calendar is rather than the way a cloud provider is. Luke reads the
+  issues a tracker lists for the user under a grant the tracker's own consent
+  page issued, and observes nothing without one. The integration exists only
+  in a build carrying a registered OAuth client — without one it is not drawn
+  — and connecting is the tracker's own flow for a public client: PKCE over a
+  loopback redirect that never leaves the machine, carrying no client secret,
+  asking for the narrowest scopes the acts need. No key is ever typed, and
+  none is read from the environment: a tracker connected by consent has no
+  environment variable at all. The grant is stored encrypted like a key, is
+  renewed before it lapses — the renewal written before it is used, because a
+  consumed refresh token is spent — and is deleted only when the tracker
+  itself refuses the renewal, never when the network merely could not carry
+  it. Disconnecting revokes the grant with the tracker as well as deleting it
+  here. The two acts a tracker takes — moving an issue to a state its latest
+  observation listed, adding a comment — happen only as the direct product of
+  a turn the developer opened themselves, through the tracker's own documented
+  endpoint under the same grant, validated against the observed issue roster
+  in the renderer and again in the main process before the tracker client sees
+  anything. Observation sends only the read document; the write documents are
+  fixed by the build and issued only for a validated act.
 - The calendar is the same rule with no write path at all. Luke reads when
   the user's meetings start and end, under accounts the user signed in, and
   observes nothing without one. The integration exists only in a build

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -215,14 +215,29 @@ response data.
 
 ## Optional issue-tracker reads and spoken acts
 
-Linear is read the way the cloud providers are: without a key, Luke sends
-Linear no request and knows nothing about your board. With a key — from Luke's
-Settings or `LINEAR_API_KEY` — Luke sends it in the `Authorization` header of
-GraphQL `POST` requests to Linear's API and reads the issues assigned to the
-authenticated user: identifiers, titles, current state, issue links, and the
-team's workflow states. Completed and cancelled issues are not requested, and
-issue descriptions and comment threads are never read. Returned metadata is
-held in memory; response bodies are not persisted.
+Linear is read the way the cloud providers are, but connected the way the
+calendar is: without a connection, Luke sends Linear no request and knows
+nothing about your board. Connecting runs Linear's own OAuth flow for a public
+client — Linear's consent page opens in your browser, the authorization code
+comes back over a loopback redirect that never leaves the machine, and the
+exchange is verified with PKCE. No API key is ever typed, read from your
+environment, or held by Luke. The integration exists only in builds carrying a
+registered OAuth client; without one it is not offered at all.
+
+The grant is stored encrypted at rest and read only in the main process.
+Linear's access tokens last a day, so Luke renews the grant with the refresh
+token Linear issued alongside it; Linear consumes a refresh token when it is
+spent, so each renewal is written before it is used. Only Linear refusing a
+renewal disconnects the integration — a network that could not carry the
+request leaves the grant untouched. Disconnecting revokes the grant with
+Linear as well as deleting it here.
+
+Under that grant, Luke sends `Bearer` GraphQL `POST` requests to Linear's API
+and reads the issues assigned to the authenticated user: identifiers, titles,
+current state, issue links, and the team's workflow states. Completed and
+cancelled issues are not requested, and issue descriptions and comment threads
+are never read. Returned metadata is held in memory; response bodies are not
+persisted.
 
 Reading and acting are separate GraphQL documents, and observation only ever
 sends the read. Luke calls Linear's two write mutations — moving an issue to
@@ -230,6 +245,12 @@ another of its team's states, and adding a comment — only to carry out
 something you just asked for in a turn you opened — spoken or typed — and only
 against an issue and a state the latest read actually listed. Nothing Luke
 decides on its own reaches either mutation.
+
+The consent page asks for Linear's `read` and `write` scopes, which are the
+narrowest pair carrying both acts: Linear publishes no scope for moving an
+issue between states. What bounds the acts is not the scope but the validation
+above it — only an issue and a state the latest read listed, and only in a turn
+you opened.
 
 Changing `LINEAR_API_URL` sends the credential to that configured endpoint,
 whose policies then govern the request and response data.
@@ -347,7 +368,7 @@ a spoken question about Luke can be answered and a spoken ask can change a
 setting. The guide never includes an API key, any part of one, or any value
 read from your environment beyond whether one exists.
 
-With a Linear key saved, the conversation also carries the issue roster — each
+With Linear connected, the conversation also carries the issue roster — each
 assigned issue's identifier, title, state, and the states its team's workflow
 allows — so a question about your board can be answered and an ask validated
 against what Linear actually listed. No issue description or comment thread is

--- a/README.md
+++ b/README.md
@@ -51,11 +51,12 @@ Visit [tryluke.dev](https://tryluke.dev) to see Luke in action.
 | Devin | Local and cloud sessions | Cloud only |
 | Jules | Cloud sessions | Yes |
 | OpenCode | Local sessions | No |
-| Linear | Assigned issues | Yes |
+| Linear | Assigned issues | Yes (sign-in) |
 | Google Calendar | Meeting busy times | Yes (sign-in) |
 
 Cloud integrations remain inactive until you add their credentials in Luke's
-Settings. Voice and the optional attention review are included with the
+Settings. Linear and Google Calendar are connected by signing in on the
+provider's own consent page rather than by pasting a key. Voice and the optional attention review are included with the
 signed-in account under a daily allowance; connecting your own OpenAI API key
 lifts the allowance and runs both on that key instead.
 

--- a/apps/desktop/src/linear-credentials.ts
+++ b/apps/desktop/src/linear-credentials.ts
@@ -40,17 +40,25 @@ export class LinearCredentials {
   readonly #options: LinearCredentialsOptions;
   readonly #now: () => number;
   readonly #renew: () => Promise<void>;
+  #disconnecting = false;
   #generation = 0;
 
   constructor(options: LinearCredentialsOptions) {
     this.#options = options;
     this.#now = options.now ?? Date.now;
     this.#renew = singleFlight(async () => {
+      const generation = this.#generation;
+      if (this.#disconnecting) return;
       const grant = await this.#options.readGrant();
       // Another ask may have renewed it while this one waited for the flight,
       // in which case there is nothing left to spend a rotation on.
-      if (!grant?.refreshToken || this.#current(grant)) return;
-      const generation = this.#generation;
+      if (
+        generation !== this.#generation ||
+        this.#disconnecting ||
+        !grant?.refreshToken ||
+        this.#current(grant)
+      )
+        return;
       const outcome = await refreshLinearGrant(grant.refreshToken, {
         ...(this.#options.environment ? { environment: this.#options.environment } : {}),
         ...(this.#options.fetchImplementation
@@ -81,8 +89,9 @@ export class LinearCredentials {
    * same thing to a caller: no request may be sent.
    */
   async accessToken(): Promise<string | undefined> {
+    if (this.#disconnecting) return undefined;
     const grant = await this.#options.readGrant();
-    if (!grant) return undefined;
+    if (this.#disconnecting || !grant) return undefined;
     if (this.#current(grant)) return grant.accessToken;
     if (!grant.refreshToken) {
       // Linear issues some registrations a long-lived token and no way to
@@ -92,8 +101,11 @@ export class LinearCredentials {
       return undefined;
     }
     await this.#renew();
+    if (this.#disconnecting) return undefined;
     const renewed = await this.#options.readGrant();
-    return renewed && this.#current(renewed) ? renewed.accessToken : undefined;
+    return !this.#disconnecting && renewed && this.#unexpired(renewed)
+      ? renewed.accessToken
+      : undefined;
   }
 
   /**
@@ -103,19 +115,28 @@ export class LinearCredentials {
    * message is no reason to keep the grant on this machine.
    */
   async disconnect(): Promise<void> {
+    this.#disconnecting = true;
     this.#generation += 1;
-    const grant = await this.#options.readGrant();
-    if (grant) {
-      await revokeLinearGrant(
-        grant.refreshToken ?? grant.accessToken,
-        grant.refreshToken ? "refresh_token" : "access_token",
-        this.#options.fetchImplementation ?? fetch,
-      );
+    try {
+      const grant = await this.#options.readGrant();
+      await this.#options.forgetGrant();
+      if (grant) {
+        await revokeLinearGrant(
+          grant.refreshToken ?? grant.accessToken,
+          grant.refreshToken ? "refresh_token" : "access_token",
+          this.#options.fetchImplementation ?? fetch,
+        );
+      }
+    } finally {
+      this.#disconnecting = false;
     }
-    await this.#options.forgetGrant();
   }
 
   #current(grant: LinearGrant): boolean {
     return grant.expiresAt - ACCESS_TOKEN_EXPIRY_SLACK_MS > this.#now();
+  }
+
+  #unexpired(grant: LinearGrant): boolean {
+    return grant.expiresAt > this.#now();
   }
 }

--- a/apps/desktop/src/linear-credentials.ts
+++ b/apps/desktop/src/linear-credentials.ts
@@ -106,7 +106,11 @@ export class LinearCredentials {
     this.#generation += 1;
     const grant = await this.#options.readGrant();
     if (grant) {
-      await revokeLinearGrant(grant.accessToken, this.#options.fetchImplementation ?? fetch);
+      await revokeLinearGrant(
+        grant.refreshToken ?? grant.accessToken,
+        grant.refreshToken ? "refresh_token" : "access_token",
+        this.#options.fetchImplementation ?? fetch,
+      );
     }
     await this.#options.forgetGrant();
   }

--- a/apps/desktop/src/linear-credentials.ts
+++ b/apps/desktop/src/linear-credentials.ts
@@ -1,0 +1,112 @@
+// The same collapsing the account's refresh uses, and for the same reason:
+// Linear consumes a refresh token when it is spent, so two refreshes racing
+// would have the loser spend one Linear has already rotated away.
+import { singleFlight } from "./account-token-lifecycle";
+import {
+  LINEAR_REFRESH_STATUS,
+  type LinearGrant,
+  refreshLinearGrant,
+  revokeLinearGrant,
+} from "./linear-oauth";
+
+/** Refreshed a minute early, so a pass never rides a token mid-expiry. */
+const ACCESS_TOKEN_EXPIRY_SLACK_MS = 60_000;
+
+export interface LinearCredentialsOptions {
+  /**
+   * Resolved at each ask, so a grant connected or disconnected in settings
+   * takes effect on the next pass without this being rebuilt.
+   */
+  readGrant: () => Promise<LinearGrant | undefined>;
+  /** Stores a renewed grant. Always awaited before the grant is used. */
+  writeGrant: (grant: LinearGrant) => Promise<void>;
+  /** Deletes the stored grant, which is what a refusal from Linear settles. */
+  forgetGrant: () => Promise<void>;
+  environment?: NodeJS.ProcessEnv;
+  fetchImplementation?: typeof fetch;
+  now?: () => number;
+}
+
+/**
+ * Holds the one thing a Linear request needs: an access token that has not
+ * lapsed. Linear's access tokens last a day and its refresh tokens rotate
+ * when spent, so this is where the two rules that follow from that live —
+ * a renewed grant is written before it is used, and only Linear refusing the
+ * refresh deletes anything. A network that could not carry the refresh leaves
+ * the grant exactly where it was: the next pass is the whole remedy, and a
+ * developer must not be disconnected for having closed their laptop.
+ */
+export class LinearCredentials {
+  readonly #options: LinearCredentialsOptions;
+  readonly #now: () => number;
+  readonly #renew: () => Promise<void>;
+
+  constructor(options: LinearCredentialsOptions) {
+    this.#options = options;
+    this.#now = options.now ?? Date.now;
+    this.#renew = singleFlight(async () => {
+      const grant = await this.#options.readGrant();
+      // Another ask may have renewed it while this one waited for the flight,
+      // in which case there is nothing left to spend a rotation on.
+      if (!grant?.refreshToken || this.#current(grant)) return;
+      const outcome = await refreshLinearGrant(grant.refreshToken, {
+        ...(this.#options.environment ? { environment: this.#options.environment } : {}),
+        ...(this.#options.fetchImplementation
+          ? { fetchImplementation: this.#options.fetchImplementation }
+          : {}),
+        now: this.#now,
+      });
+      if (outcome.status === LINEAR_REFRESH_STATUS.RENEWED) {
+        await this.#options.writeGrant(outcome.grant);
+        return;
+      }
+      // Linear said no: the grant is spent, withdrawn, or expired, and no
+      // number of further passes will change that. Forgetting it is what
+      // turns the row back into an offer to connect, which is the only thing
+      // that helps.
+      if (outcome.status === LINEAR_REFRESH_STATUS.REFUSED) {
+        await this.#options.forgetGrant();
+      }
+    });
+  }
+
+  /**
+   * A token that will still be honoured, renewing first when the stored one
+   * is spent. Nothing connected, nothing renewable, or a renewal Linear
+   * refused all answer the same way — with nothing — because each means the
+   * same thing to a caller: no request may be sent.
+   */
+  async accessToken(): Promise<string | undefined> {
+    const grant = await this.#options.readGrant();
+    if (!grant) return undefined;
+    if (this.#current(grant)) return grant.accessToken;
+    if (!grant.refreshToken) {
+      // Linear issues some registrations a long-lived token and no way to
+      // renew it. Once that one lapses there is nothing to hold, and the row
+      // should say connect rather than sit there failing every pass.
+      await this.#options.forgetGrant();
+      return undefined;
+    }
+    await this.#renew();
+    const renewed = await this.#options.readGrant();
+    return renewed && this.#current(renewed) ? renewed.accessToken : undefined;
+  }
+
+  /**
+   * Ends the connection: the grant is revoked at Linear so the access stops
+   * there too, and forgotten here either way. The revocation is best effort —
+   * the developer asked to disconnect, and a network that cannot carry the
+   * message is no reason to keep the grant on this machine.
+   */
+  async disconnect(): Promise<void> {
+    const grant = await this.#options.readGrant();
+    if (grant) {
+      await revokeLinearGrant(grant.accessToken, this.#options.fetchImplementation ?? fetch);
+    }
+    await this.#options.forgetGrant();
+  }
+
+  #current(grant: LinearGrant): boolean {
+    return grant.expiresAt - ACCESS_TOKEN_EXPIRY_SLACK_MS > this.#now();
+  }
+}

--- a/apps/desktop/src/linear-credentials.ts
+++ b/apps/desktop/src/linear-credentials.ts
@@ -40,6 +40,7 @@ export class LinearCredentials {
   readonly #options: LinearCredentialsOptions;
   readonly #now: () => number;
   readonly #renew: () => Promise<void>;
+  #generation = 0;
 
   constructor(options: LinearCredentialsOptions) {
     this.#options = options;
@@ -49,6 +50,7 @@ export class LinearCredentials {
       // Another ask may have renewed it while this one waited for the flight,
       // in which case there is nothing left to spend a rotation on.
       if (!grant?.refreshToken || this.#current(grant)) return;
+      const generation = this.#generation;
       const outcome = await refreshLinearGrant(grant.refreshToken, {
         ...(this.#options.environment ? { environment: this.#options.environment } : {}),
         ...(this.#options.fetchImplementation
@@ -57,6 +59,7 @@ export class LinearCredentials {
         now: this.#now,
       });
       if (outcome.status === LINEAR_REFRESH_STATUS.RENEWED) {
+        if (generation !== this.#generation) return;
         await this.#options.writeGrant(outcome.grant);
         return;
       }
@@ -65,6 +68,7 @@ export class LinearCredentials {
       // turns the row back into an offer to connect, which is the only thing
       // that helps.
       if (outcome.status === LINEAR_REFRESH_STATUS.REFUSED) {
+        if (generation !== this.#generation) return;
         await this.#options.forgetGrant();
       }
     });
@@ -99,6 +103,7 @@ export class LinearCredentials {
    * message is no reason to keep the grant on this machine.
    */
   async disconnect(): Promise<void> {
+    this.#generation += 1;
     const grant = await this.#options.readGrant();
     if (grant) {
       await revokeLinearGrant(grant.accessToken, this.#options.fetchImplementation ?? fetch);

--- a/apps/desktop/src/linear-oauth.ts
+++ b/apps/desktop/src/linear-oauth.ts
@@ -1,0 +1,475 @@
+import { randomUUID } from "node:crypto";
+import http from "node:http";
+// The same landing page the Luke account sign-in leaves the browser on, so no
+// two of Luke's consent trips dress their tabs differently.
+import { accountLoopbackPage, LOOPBACK_PAGE_TONE } from "./account-loopback-page";
+// The same RFC 7636 arithmetic every other flow here uses: one PKCE, three
+// flows, so none can drift into a weaker verifier than the others.
+import { codeChallenge, createCodeVerifier } from "./account-pkce";
+
+/**
+ * The sign-in behind the Linear row: Linear's own OAuth flow for a public
+ * client, run the way it documents one — an authorization page opened in the
+ * user's browser, a code handed back on a loopback redirect that never leaves
+ * this machine, and a PKCE-verified exchange at Linear's token endpoint. No
+ * client secret is involved at all: Linear makes it optional under PKCE, and
+ * a secret every installed copy carries protects nothing that the verifier
+ * does not already protect.
+ *
+ * The flow exists only in a run holding the registration — the client id
+ * standing in source below, or the environment variable that stands in for it
+ * during development. A build with neither offers the integration not at all,
+ * which is why `linearSignInConfig` returning nothing hides the row rather
+ * than drawing one whose button cannot work.
+ */
+
+export interface LinearSignInConfig {
+  clientId: string;
+}
+
+const SIGN_IN_ENVIRONMENT = {
+  CLIENT_ID: "LINEAR_OAUTH_CLIENT_ID",
+} as const;
+
+/**
+ * The Linear OAuth application this project registered — created under
+ * Settings · API · OAuth applications in the workspace that owns Luke. A
+ * client id is published in every authorization URL, so it stands in source
+ * the way the calendar's does; the environment variable above overrides it
+ * for development against another registration.
+ *
+ * Every redirect URL in `LINEAR_REDIRECT_URIS` must be registered on it, or
+ * Linear refuses the callback rather than the exchange, and the browser stops
+ * at Linear's own error page.
+ */
+const REGISTERED_LINEAR_CLIENT_ID = "781b6356943d0c71c4dc618b782e0ab0";
+
+/** The sign-in this run can offer, or nothing — which hides the row. */
+export function linearSignInConfig(
+  environment: NodeJS.ProcessEnv = process.env,
+): LinearSignInConfig | undefined {
+  const clientId =
+    environment[SIGN_IN_ENVIRONMENT.CLIENT_ID]?.trim() || REGISTERED_LINEAR_CLIENT_ID;
+  if (!clientId) return undefined;
+  return { clientId };
+}
+
+/** Linear's documented OAuth endpoints, fixed by this build. */
+export const LINEAR_AUTHORIZATION_URL = "https://linear.app/oauth/authorize";
+export const LINEAR_TOKEN_URL = "https://api.linear.app/oauth/token";
+export const LINEAR_REVOKE_URL = "https://api.linear.app/oauth/revoke";
+
+/**
+ * The scopes the consent page asks for. `read` is the roster; `write` is the
+ * two acts a developer can ask for on a row — moving an issue to another of
+ * its team's states, and commenting. Linear publishes narrower scopes only
+ * for creating issues and comments, and moving an issue is neither, so
+ * `write` is the narrowest grant that carries both acts rather than a wide
+ * one chosen for convenience. What bounds the acts is not the scope but the
+ * validation above it: an act is issued only for an issue and a state the
+ * latest read actually listed, and only in a turn the developer opened.
+ *
+ * Linear separates scopes with commas, where most providers use spaces.
+ */
+export const LINEAR_SCOPES = ["read", "write"].join(",");
+
+/**
+ * Where Linear is asked to send the code back. Unlike Google, Linear does not
+ * document loopback redirects as exempt from exact matching, so the port
+ * cannot be the ephemeral one the other flows take: every address here is
+ * registered on the OAuth application, and the flow takes the first that will
+ * bind. Three, so a port held by another app — or by a second copy of Luke —
+ * is an inconvenience rather than a dead row. Linear's own desktop app probes
+ * 44450, 18450 and 33234, so those are left alone.
+ */
+const LOOPBACK_PORTS = [47821, 47822, 47823] as const;
+const LOOPBACK_HOST = "127.0.0.1";
+const CALLBACK_PATH = "/linear/callback";
+
+/** Every redirect URL this build can use, which is what the app must register. */
+export const LINEAR_REDIRECT_URIS: readonly string[] = LOOPBACK_PORTS.map(
+  (port) => `http://${LOOPBACK_HOST}:${port}${CALLBACK_PATH}`,
+);
+
+/** Long enough to find the right workspace; not an open door all afternoon. */
+const SIGN_IN_TIMEOUT_MS = 180_000;
+
+const TOKEN_REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * What the browser tab shows once the flow is over, drawn as the same card
+ * every other loopback landing draws. Every string is fixed by the build, and
+ * nothing the redirect carried is ever interpolated.
+ */
+function signInPage(granted: boolean): string {
+  return granted
+    ? accountLoopbackPage({
+        tone: LOOPBACK_PAGE_TONE.SETTLED,
+        badge: "Connected",
+        title: "Connected to Linear",
+        body: "You can close this tab and return to Luke.",
+      })
+    : accountLoopbackPage({
+        tone: LOOPBACK_PAGE_TONE.ATTENTION,
+        badge: "Not connected",
+        title: "Sign-in didn’t complete",
+        body: "You can close this tab and try again from Luke.",
+      });
+}
+
+/**
+ * One connected Linear workspace's credentials. The refresh token is absent
+ * where Linear issued none — it grants long-lived access tokens to some
+ * registrations — and a grant without one is simply reconnected when its
+ * access token finally expires.
+ */
+export interface LinearGrant {
+  accessToken: string;
+  refreshToken?: string;
+  /** When the access token stops being honoured, as epoch milliseconds. */
+  expiresAt: number;
+}
+
+export type LinearSignInOutcome = LinearGrant | { reason: string };
+
+export interface LinearSignInOptions {
+  /**
+   * Opens the authorization page in the user's own browser. Injected so the
+   * one caller hands in the shell and tests hand in a recorder — this module
+   * never reaches for Electron itself.
+   */
+  openExternal: (url: string) => void;
+  environment?: NodeJS.ProcessEnv;
+  /** Injectable so tests exercise the exchange without a network. */
+  fetchImplementation?: typeof fetch;
+  now?: () => number;
+  timeoutMs?: number;
+}
+
+/**
+ * Reads the grant Linear answered an exchange or a refresh with, trusting no
+ * shape. An access token is the whole requirement: without one there is
+ * nothing to read Linear with, and the caller says so rather than storing a
+ * grant that cannot work.
+ */
+export function grantFrom(payload: unknown, now: number): LinearGrant | undefined {
+  if (payload === null || typeof payload !== "object") return undefined;
+  const record = payload as Record<string, unknown>;
+  const accessToken = record.access_token;
+  if (typeof accessToken !== "string" || !accessToken) return undefined;
+  const refreshToken = record.refresh_token;
+  // Linear states the lifetime in seconds. A response without one is treated
+  // as already expired rather than as eternal, so a refresh proves the grant
+  // before a pass rides it.
+  const expiresIn = typeof record.expires_in === "number" ? record.expires_in : 0;
+  return {
+    accessToken,
+    ...(typeof refreshToken === "string" && refreshToken ? { refreshToken } : {}),
+    expiresAt: now + expiresIn * 1_000,
+  };
+}
+
+/**
+ * Runs one sign-in from button press to grant. One at a time: a second press
+ * while the browser tab is open is answered with why, rather than a second tab
+ * racing the first for the loopback port.
+ */
+export class LinearSignIn {
+  readonly #options: LinearSignInOptions;
+  #running = false;
+  /** Ends the flow now waiting, when there is one — the cancel button's way in. */
+  #abandon: (() => void) | undefined;
+  /** Reopens the waiting flow's own consent page — the lost-tab way back in. */
+  #reopen: (() => void) | undefined;
+
+  constructor(options: LinearSignInOptions) {
+    this.#options = options;
+  }
+
+  async signIn(): Promise<LinearSignInOutcome> {
+    const config = linearSignInConfig(this.#options.environment);
+    if (!config) return { reason: "Sign-in is not configured in this build." };
+    if (this.#running) return { reason: "A sign-in is already waiting in your browser." };
+    this.#running = true;
+    try {
+      return await this.#run(config);
+    } finally {
+      this.#running = false;
+      this.#abandon = undefined;
+      this.#reopen = undefined;
+    }
+  }
+
+  /**
+   * Ends the flow now waiting, if any. The browser tab is left where it is —
+   * closing another app's window is not Luke's to do — but the loopback stops
+   * listening, so a grant given after this lands nowhere.
+   */
+  cancel(): void {
+    this.#abandon?.();
+  }
+
+  /**
+   * Opens the waiting flow's consent page again — the very URL, state and
+   * challenge included, the flow is already listening for — for a tab lost
+   * behind other windows or closed by mistake. With no flow waiting there is
+   * no page to reopen, and nothing happens.
+   */
+  reopen(): void {
+    this.#reopen?.();
+  }
+
+  async #run(config: LinearSignInConfig): Promise<LinearSignInOutcome> {
+    const verifier = createCodeVerifier();
+    const challenge = codeChallenge(verifier);
+    const state = randomUUID();
+
+    let finish: (outcome: LinearSignInOutcome) => void = () => undefined;
+    const outcome = new Promise<LinearSignInOutcome>((resolve) => {
+      finish = resolve;
+    });
+    // Assigned once a registered port has bound, before the browser is opened
+    // — no request can arrive ahead of it.
+    let redirectUri = "";
+
+    const server = http.createServer((request, response) => {
+      const url = new URL(request.url ?? "/", `http://${LOOPBACK_HOST}`);
+      // Anything that is not this flow's own redirect — another path, a stray
+      // request, a state this run never issued — is refused without ending
+      // the wait: the real redirect may still be on its way.
+      if (url.pathname !== CALLBACK_PATH || url.searchParams.get("state") !== state) {
+        response.writeHead(404, { "content-type": "text/plain" }).end("Not found");
+        return;
+      }
+      const refused = url.searchParams.get("error");
+      const code = url.searchParams.get("code");
+      if (refused || !code) {
+        response
+          .writeHead(200, { "content-type": "text/html; charset=utf-8" })
+          .end(signInPage(false));
+        finish({ reason: "Linear did not grant access." });
+        return;
+      }
+      void this.#exchange(config, code, verifier, redirectUri).then((exchanged) => {
+        response
+          .writeHead(200, { "content-type": "text/html; charset=utf-8" })
+          .end(signInPage(!("reason" in exchanged)));
+        finish(exchanged);
+      });
+    });
+
+    const port = await this.#bind(server);
+    if (port === undefined) {
+      return { reason: "Luke could not open a sign-in callback on this machine." };
+    }
+    redirectUri = `http://${LOOPBACK_HOST}:${port}${CALLBACK_PATH}`;
+
+    const authorization = new URL(LINEAR_AUTHORIZATION_URL);
+    authorization.searchParams.set("client_id", config.clientId);
+    authorization.searchParams.set("redirect_uri", redirectUri);
+    authorization.searchParams.set("response_type", "code");
+    authorization.searchParams.set("scope", LINEAR_SCOPES);
+    authorization.searchParams.set("code_challenge", challenge);
+    authorization.searchParams.set("code_challenge_method", "S256");
+    // Everything Luke does on a board, he does as the developer who asked:
+    // an issue moves under their name and a comment carries it. `user` is
+    // Linear's default, and saying so keeps a changed default from quietly
+    // turning Luke into an actor of his own.
+    authorization.searchParams.set("actor", "user");
+    // Consent every time, so reconnecting after withdrawing the grant in
+    // Linear actually asks again rather than silently reissuing.
+    authorization.searchParams.set("prompt", "consent");
+    authorization.searchParams.set("state", state);
+
+    const timeout = setTimeout(() => {
+      finish({ reason: "Sign-in timed out. Try again from the Linear row." });
+    }, this.#options.timeoutMs ?? SIGN_IN_TIMEOUT_MS);
+    timeout.unref();
+    this.#abandon = () => finish({ reason: "Sign-in was cancelled." });
+    this.#reopen = () => this.#options.openExternal(authorization.toString());
+
+    try {
+      this.#options.openExternal(authorization.toString());
+      return await outcome;
+    } finally {
+      clearTimeout(timeout);
+      server.close();
+      // The browser keeps its connection alive after the redirect, and a
+      // socket it holds open would keep this port bound — which, on a
+      // registered port rather than an ephemeral one, is the next sign-in's
+      // port. Ending those connections is what makes the flow repeatable.
+      server.closeAllConnections();
+      // The server holds the process open only while the flow is live; a
+      // browser tab left forever must not be what keeps Luke running.
+      server.unref();
+    }
+  }
+
+  /**
+   * Binds the first registered port that is free. A port already held is the
+   * ordinary case — another copy of Luke, or another app — and not a failure
+   * until every registered address has been tried, because a port Linear was
+   * never told about would fail at the redirect instead.
+   */
+  async #bind(server: http.Server): Promise<number | undefined> {
+    for (const port of LOOPBACK_PORTS) {
+      const bound = await new Promise<boolean>((resolve) => {
+        const failed = (): void => {
+          server.removeListener("error", failed);
+          // A server that failed to bind is closed before the next address is
+          // tried, so no attempt inherits the last one's half-open state.
+          server.close(() => resolve(false));
+        };
+        server.once("error", failed);
+        // The loopback answers this machine alone: Linear's redirect lands in
+        // the user's own browser, which hands the code straight back across
+        // localhost.
+        server.listen(port, LOOPBACK_HOST, () => {
+          server.removeListener("error", failed);
+          resolve(true);
+        });
+      });
+      if (bound) return port;
+    }
+    return undefined;
+  }
+
+  async #exchange(
+    config: LinearSignInConfig,
+    code: string,
+    verifier: string,
+    redirectUri: string,
+  ): Promise<LinearSignInOutcome> {
+    const body = new URLSearchParams({
+      code,
+      client_id: config.clientId,
+      redirect_uri: redirectUri,
+      grant_type: "authorization_code",
+      code_verifier: verifier,
+    });
+    try {
+      const fetchImplementation = this.#options.fetchImplementation ?? fetch;
+      const response = await fetchImplementation(LINEAR_TOKEN_URL, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: body.toString(),
+        signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
+      });
+      if (!response.ok) return { reason: "Linear refused the sign-in exchange." };
+      const grant = grantFrom(await response.json(), (this.#options.now ?? Date.now)());
+      if (!grant) return { reason: "Linear answered the sign-in without a token." };
+      return grant;
+    } catch {
+      return { reason: "The sign-in exchange with Linear did not complete." };
+    }
+  }
+}
+
+/**
+ * Tells Linear the grant is finished with, so disconnecting ends the access
+ * at Linear rather than only forgetting it here. Best effort by design: the
+ * user asked to disconnect, and a network that cannot carry the revocation is
+ * not a reason to keep the grant on this machine — the caller deletes it
+ * either way, and Linear's own settings remain the certain way to withdraw.
+ */
+export async function revokeLinearGrant(
+  accessToken: string,
+  fetchImplementation: typeof fetch = fetch,
+): Promise<boolean> {
+  try {
+    const response = await fetchImplementation(LINEAR_REVOKE_URL, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({ token: accessToken }).toString(),
+      signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * What a refresh settled, which is two different answers a caller must not
+ * confuse. `REFUSED` is Linear itself saying no — the grant was withdrawn,
+ * expired, or spent — and the only cure is connecting again, so the stored
+ * grant is finished with. `UNREACHABLE` is nothing having come back at all,
+ * where the grant is untouched and the next pass is the whole remedy.
+ * Deleting a grant over a dropped connection would disconnect a developer
+ * for closing their laptop lid.
+ */
+export const LINEAR_REFRESH_STATUS = {
+  RENEWED: "renewed",
+  REFUSED: "refused",
+  UNREACHABLE: "unreachable",
+} as const;
+
+export type LinearRefreshStatus =
+  (typeof LINEAR_REFRESH_STATUS)[keyof typeof LINEAR_REFRESH_STATUS];
+
+export type LinearRefreshOutcome =
+  | { status: typeof LINEAR_REFRESH_STATUS.RENEWED; grant: LinearGrant }
+  | { status: typeof LINEAR_REFRESH_STATUS.REFUSED }
+  | { status: typeof LINEAR_REFRESH_STATUS.UNREACHABLE };
+
+/**
+ * Trades a refresh token for a fresh grant. Linear consumes the refresh token
+ * it is given and answers with another, so what comes back must be stored
+ * before it is used — a grant refreshed and then lost is a grant the user has
+ * to make again.
+ */
+export async function refreshLinearGrant(
+  refreshToken: string,
+  options: {
+    environment?: NodeJS.ProcessEnv;
+    fetchImplementation?: typeof fetch;
+    now?: () => number;
+  } = {},
+): Promise<LinearRefreshOutcome> {
+  const config = linearSignInConfig(options.environment);
+  // A build that lost its registration cannot refresh anything, and has not
+  // been told the grant is bad either.
+  if (!config) return { status: LINEAR_REFRESH_STATUS.UNREACHABLE };
+  const body = new URLSearchParams({
+    refresh_token: refreshToken,
+    client_id: config.clientId,
+    grant_type: "refresh_token",
+  });
+  const fetchImplementation = options.fetchImplementation ?? fetch;
+  let response: Response;
+  try {
+    response = await fetchImplementation(LINEAR_TOKEN_URL, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+      signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
+    });
+  } catch {
+    return { status: LINEAR_REFRESH_STATUS.UNREACHABLE };
+  }
+  // Linear answering at all, but not with a grant, is Linear saying no. A
+  // fault on its own side is the exception: a 500 is not a withdrawn grant,
+  // and a developer should not be disconnected by someone else's outage.
+  if (!response.ok) {
+    return response.status >= 500
+      ? { status: LINEAR_REFRESH_STATUS.UNREACHABLE }
+      : { status: LINEAR_REFRESH_STATUS.REFUSED };
+  }
+  let grant: LinearGrant | undefined;
+  try {
+    grant = grantFrom(await response.json(), (options.now ?? Date.now)());
+  } catch {
+    return { status: LINEAR_REFRESH_STATUS.UNREACHABLE };
+  }
+  if (!grant) return { status: LINEAR_REFRESH_STATUS.REFUSED };
+  // Linear may answer a refresh without repeating the refresh token. The one
+  // just spent is the only one there is, so it carries forward rather than
+  // leaving a grant that can never be refreshed again.
+  return {
+    status: LINEAR_REFRESH_STATUS.RENEWED,
+    grant: grant.refreshToken ? grant : { ...grant, refreshToken },
+  };
+}

--- a/apps/desktop/src/linear-oauth.ts
+++ b/apps/desktop/src/linear-oauth.ts
@@ -231,6 +231,7 @@ export class LinearSignIn {
     // Assigned once a registered port has bound, before the browser is opened
     // — no request can arrive ahead of it.
     let redirectUri = "";
+    let callbackClaimed = false;
 
     const server = http.createServer((request, response) => {
       const url = new URL(request.url ?? "/", `http://${LOOPBACK_HOST}`);
@@ -241,6 +242,11 @@ export class LinearSignIn {
         response.writeHead(404, { "content-type": "text/plain" }).end("Not found");
         return;
       }
+      if (callbackClaimed) {
+        response.writeHead(404, { "content-type": "text/plain" }).end("Not found");
+        return;
+      }
+      callbackClaimed = true;
       const refused = url.searchParams.get("error");
       const code = url.searchParams.get("code");
       if (refused || !code) {
@@ -450,13 +456,20 @@ export async function refreshLinearGrant(
   } catch {
     return { status: LINEAR_REFRESH_STATUS.UNREACHABLE };
   }
-  // Linear answering at all, but not with a grant, is Linear saying no. A
-  // fault on its own side is the exception: a 500 is not a withdrawn grant,
-  // and a developer should not be disconnected by someone else's outage.
   if (!response.ok) {
-    return response.status >= 500
-      ? { status: LINEAR_REFRESH_STATUS.UNREACHABLE }
-      : { status: LINEAR_REFRESH_STATUS.REFUSED };
+    try {
+      const payload: unknown = await response.json();
+      if (
+        payload !== null &&
+        typeof payload === "object" &&
+        (payload as Record<string, unknown>).error === "invalid_grant"
+      ) {
+        return { status: LINEAR_REFRESH_STATUS.REFUSED };
+      }
+    } catch {
+      // An unreadable refusal proves nothing about the grant.
+    }
+    return { status: LINEAR_REFRESH_STATUS.UNREACHABLE };
   }
   let grant: LinearGrant | undefined;
   try {
@@ -464,12 +477,6 @@ export async function refreshLinearGrant(
   } catch {
     return { status: LINEAR_REFRESH_STATUS.UNREACHABLE };
   }
-  if (!grant) return { status: LINEAR_REFRESH_STATUS.REFUSED };
-  // Linear may answer a refresh without repeating the refresh token. The one
-  // just spent is the only one there is, so it carries forward rather than
-  // leaving a grant that can never be refreshed again.
-  return {
-    status: LINEAR_REFRESH_STATUS.RENEWED,
-    grant: grant.refreshToken ? grant : { ...grant, refreshToken },
-  };
+  if (!grant?.refreshToken) return { status: LINEAR_REFRESH_STATUS.UNREACHABLE };
+  return { status: LINEAR_REFRESH_STATUS.RENEWED, grant };
 }

--- a/apps/desktop/src/linear-oauth.ts
+++ b/apps/desktop/src/linear-oauth.ts
@@ -232,6 +232,7 @@ export class LinearSignIn {
     // — no request can arrive ahead of it.
     let redirectUri = "";
     let callbackClaimed = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
 
     const server = http.createServer((request, response) => {
       const url = new URL(request.url ?? "/", `http://${LOOPBACK_HOST}`);
@@ -247,6 +248,8 @@ export class LinearSignIn {
         return;
       }
       callbackClaimed = true;
+      if (timeout) clearTimeout(timeout);
+      this.#abandon = undefined;
       const refused = url.searchParams.get("error");
       const code = url.searchParams.get("code");
       if (refused || !code) {
@@ -287,7 +290,7 @@ export class LinearSignIn {
     authorization.searchParams.set("prompt", "consent");
     authorization.searchParams.set("state", state);
 
-    const timeout = setTimeout(() => {
+    timeout = setTimeout(() => {
       finish({ reason: "Sign-in timed out. Try again from the Linear row." });
     }, this.#options.timeoutMs ?? SIGN_IN_TIMEOUT_MS);
     timeout.unref();
@@ -379,17 +382,17 @@ export class LinearSignIn {
  * either way, and Linear's own settings remain the certain way to withdraw.
  */
 export async function revokeLinearGrant(
-  accessToken: string,
+  token: string,
+  tokenType: "access_token" | "refresh_token",
   fetchImplementation: typeof fetch = fetch,
 ): Promise<boolean> {
   try {
     const response = await fetchImplementation(LINEAR_REVOKE_URL, {
       method: "POST",
       headers: {
-        authorization: `Bearer ${accessToken}`,
         "content-type": "application/x-www-form-urlencoded",
       },
-      body: new URLSearchParams({ token: accessToken }).toString(),
+      body: new URLSearchParams({ token, token_type_hint: tokenType }).toString(),
       signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
     });
     return response.ok;

--- a/apps/desktop/src/linear-tracker.ts
+++ b/apps/desktop/src/linear-tracker.ts
@@ -72,10 +72,12 @@ const LINEAR_WRITE = {
 
 export interface LinearTrackerOptions {
   /**
-   * Resolved at observation time, so a key saved or cleared in settings takes
-   * effect on the next pass without the tracker being rebuilt.
+   * Resolved at observation time, so a connection made or ended in settings
+   * takes effect on the next pass without the tracker being rebuilt. Nothing
+   * here knows how the token was come by or when it lapses: it arrives
+   * already renewed, or it does not arrive.
    */
-  readApiKey: () => Promise<string | undefined>;
+  readAccessToken: () => Promise<string | undefined>;
   /** Injectable so tests exercise the client without a network. */
   fetchImplementation?: typeof fetch;
   now?: () => number;
@@ -124,25 +126,25 @@ export class LinearIssueTracker implements IssueTrackerAdapter {
     displayName: LINEAR_TRACKER_NAME,
   };
 
-  readonly #readApiKey: () => Promise<string | undefined>;
+  readonly #readAccessToken: () => Promise<string | undefined>;
   readonly #fetch: typeof fetch;
   readonly #now: () => number;
   readonly #endpoint: string;
 
   constructor(options: LinearTrackerOptions) {
-    this.#readApiKey = options.readApiKey;
+    this.#readAccessToken = options.readAccessToken;
     this.#fetch = options.fetchImplementation ?? fetch;
     this.#now = options.now ?? Date.now;
     this.#endpoint = process.env[LINEAR_ENVIRONMENT.API_URL]?.trim() || LINEAR_DEFAULT_API_URL;
   }
 
   async observe(): Promise<readonly TrackerIssueObservation[] | undefined> {
-    const apiKey = await this.#readApiKey();
-    // No key, no request: the tracker is not connected, which is a different
+    const accessToken = await this.#readAccessToken();
+    // No token, no request: the tracker is not connected, which is a different
     // answer from a connected tracker listing nothing.
-    if (!apiKey) return undefined;
+    if (!accessToken) return undefined;
 
-    const payload = await this.#post(apiKey, LINEAR_READ_ASSIGNED_ISSUES, {
+    const payload = await this.#post(accessToken, LINEAR_READ_ASSIGNED_ISSUES, {
       first: ISSUE_PAGE_SIZE,
     });
     if (payload.errors) throw new Error("Linear answered the read with errors");
@@ -178,8 +180,8 @@ export class LinearIssueTracker implements IssueTrackerAdapter {
   }
 
   async execute(action: TrackerIssueAction): Promise<TrackerActionResult> {
-    const apiKey = await this.#readApiKey();
-    if (!apiKey) return { status: TRACKER_ACTION_RESULT_STATUS.UNSUPPORTED };
+    const accessToken = await this.#readAccessToken();
+    if (!accessToken) return { status: TRACKER_ACTION_RESULT_STATUS.UNSUPPORTED };
 
     const [document, variables, resultField] =
       action.kind === ISSUE_ACTION_KIND.SET_STATE
@@ -198,7 +200,7 @@ export class LinearIssueTracker implements IssueTrackerAdapter {
     // throw: the developer asked for something, and the reply has to say.
     let payload: GraphQlPayload;
     try {
-      payload = await this.#post(apiKey, document, variables);
+      payload = await this.#post(accessToken, document, variables);
     } catch {
       return {
         status: TRACKER_ACTION_RESULT_STATUS.REJECTED,
@@ -222,16 +224,16 @@ export class LinearIssueTracker implements IssueTrackerAdapter {
   }
 
   async #post(
-    apiKey: string,
+    accessToken: string,
     document: string,
     variables: Record<string, unknown>,
   ): Promise<GraphQlPayload> {
     const response = await this.#fetch(this.#endpoint, {
       method: "POST",
       headers: {
-        // A personal API key is its own authorization; only an OAuth token
-        // takes a Bearer prefix, and the credential registry refuses those.
-        authorization: apiKey,
+        // What the consent page granted is an OAuth access token, which
+        // Linear reads under the scheme every OAuth token is sent with.
+        authorization: `Bearer ${accessToken}`,
         "content-type": "application/json",
       },
       body: JSON.stringify({ query: document, variables }),

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -116,6 +116,8 @@ import { HostedRealtimeCredentialMinter } from "./hosted-realtime-credentials";
 import { HostedUsageReader } from "./hosted-usage";
 import { HOTKEY_RANK, HotkeyRegistrar } from "./hotkey-registrar";
 import { JulesSessionAdapter } from "./jules-adapter";
+import { LinearCredentials } from "./linear-credentials";
+import { LinearSignIn } from "./linear-oauth";
 import { LinearIssueTracker } from "./linear-tracker";
 import { MediaDuckController } from "./media-duck";
 import { MicrophoneRouteWatcher } from "./microphone-route";
@@ -334,8 +336,30 @@ const sessionAdapters = [
 // The issue tracker is not a session provider: its issues feed the voice
 // roster rather than the registry, so it stands beside the adapters rather
 // than among them.
+// What authorizes a read is minted rather than stored ready to send: Linear's
+// access tokens last a day, so the grant behind the row is renewed here, and
+// only Linear refusing that renewal disconnects anything.
+const linearCredentials = new LinearCredentials({
+  readGrant: () => settingsStore.readGrant(CREDENTIAL_PROVIDER_ID.LINEAR),
+  writeGrant: async (grant) => {
+    await settingsStore.setGrant(CREDENTIAL_PROVIDER_ID.LINEAR, grant);
+  },
+  forgetGrant: async () => {
+    const cleared = await settingsStore.clearGrant(CREDENTIAL_PROVIDER_ID.LINEAR);
+    // Nobody pressed anything to end this connection — Linear refused the
+    // renewal — so no settings reply is on its way to say so. A row left
+    // saying connected would be a row about a grant that no longer exists.
+    panels.broadcast(channels.settingsChanged, cleared.settings);
+  },
+});
 const linearTracker = new LinearIssueTracker({
-  readApiKey: () => settingsStore.readApiKey(CREDENTIAL_PROVIDER_ID.LINEAR),
+  readAccessToken: () => linearCredentials.accessToken(),
+});
+// The sign-in behind the Linear row: it opens Linear's own consent page in the
+// user's browser and hands back one grant, which the connect handler stores.
+// Offered only when this build carries an OAuth client.
+const linearSignIn = new LinearSignIn({
+  openExternal: (url) => void shell.openExternal(url),
 });
 const issueTrackers = [linearTracker] as const;
 /** A board changes at the pace of hands, not of models; a minute is current. */
@@ -1489,6 +1513,58 @@ function registerIpc(): void {
     googleCalendarSignIn.reopen();
   });
 
+  // The Linear sign-in runs whole inside `save`, exactly as the calendar's
+  // does: the browser trip, the loopback redirect and the exchange all happen
+  // in the main process, and the renderer's reply is the settings snapshot
+  // alone. A refusal or a closed browser tab comes back as the reason the row
+  // shows.
+  registerSettingHandler(channels.connectLinear, {
+    validate() {
+      return undefined;
+    },
+    async save() {
+      const outcome = await linearSignIn.signIn();
+      if ("reason" in outcome) {
+        return { settings: await settingsStore.snapshot(), reason: outcome.reason };
+      }
+      return settingsStore.setGrant(CREDENTIAL_PROVIDER_ID.LINEAR, outcome);
+    },
+    apply(result) {
+      // The board is a minute stale at worst, but a row that just connected
+      // and shows nothing reads as a connection that failed.
+      if (!result.reason) void refreshTrackedIssues();
+    },
+    refusal: "Could not connect Linear on this system.",
+  });
+
+  ipcMain.on(channels.cancelLinearSignIn, (event) => {
+    if (!trustedSender(event)) return;
+    linearSignIn.cancel();
+  });
+
+  ipcMain.on(channels.reopenLinearSignIn, (event) => {
+    if (!trustedSender(event)) return;
+    linearSignIn.reopen();
+  });
+
+  registerSettingHandler(channels.disconnectLinear, {
+    validate() {
+      return undefined;
+    },
+    async save() {
+      // Revoked with Linear as well as forgotten here, so disconnecting ends
+      // the access rather than only losing sight of it.
+      await linearCredentials.disconnect();
+      return { settings: await settingsStore.snapshot() };
+    },
+    apply(result) {
+      // The roster is about a board Luke can no longer read, so it goes with
+      // the grant rather than sitting there until the next pass.
+      if (!result.reason) void refreshTrackedIssues();
+    },
+    refusal: "Could not disconnect Linear on this system.",
+  });
+
   registerSettingHandler(channels.removeCalendarAccount, {
     validate(accountId: unknown) {
       if (typeof accountId !== "string" || !accountId) {
@@ -1584,7 +1660,10 @@ function registerIpc(): void {
   // registry, and no URL crosses this boundary.
   ipcMain.on(channels.openProviderApiKeys, (event, providerId: unknown) => {
     if (!trustedSender(event) || !isCredentialProviderId(providerId)) return;
-    void shell.openExternal(CREDENTIAL_PROVIDERS[providerId].apiKeysUrl);
+    // A provider connected by consent issues no key and publishes no page to
+    // fetch one from, so there is nowhere to send anyone.
+    const apiKeysUrl = CREDENTIAL_PROVIDERS[providerId].apiKeysUrl;
+    if (apiKeysUrl) void shell.openExternal(apiKeysUrl);
   });
 
   // Pressing a session — on its row, or out loud — hands its provider's own

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -42,6 +42,14 @@ const bridge: AppBridge = {
   },
   removeCalendarAccount: invoke(channels.removeCalendarAccount),
   setCalendarSelected: invoke(channels.setCalendarSelected),
+  connectLinear: invoke(channels.connectLinear),
+  cancelLinearSignIn: () => {
+    ipcRenderer.send(channels.cancelLinearSignIn);
+  },
+  reopenLinearSignIn: () => {
+    ipcRenderer.send(channels.reopenLinearSignIn);
+  },
+  disconnectLinear: invoke(channels.disconnectLinear),
   checkForUpdates: invoke(channels.checkForUpdates),
   openLatestRelease: () => ipcRenderer.send(channels.openLatestRelease),
   setVoiceExchangeActive: (active) => {

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -32,6 +32,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { CONSENT_SERVICE_ID, type ConsentServiceId } from "../shared/consent-services";
 import type {
   AccountProvider,
   AccountSnapshot,
@@ -59,8 +60,8 @@ import { FEEDBACK_KIND, FEEDBACK_LIMITS, feedbackKindForLifecycleEvent } from ".
 import { APP_SETTING_SCHEMA } from "../shared/settings-schema";
 import { voiceHotkeyLabel, voiceHotkeyToShow } from "../shared/voice-hotkey";
 import { ASK_LUKE_INPUT_ID, focusAskField } from "./ask-luke";
-import { type CalendarConnectEntry, CalendarConnectSlot } from "./calendar-connect-slot";
 import { CAPTION_LINE_READ_MS, pacedCaptionScroll } from "./caption-reading";
+import { type ConsentConnectEntry, ConsentConnectSlot } from "./consent-connect-slot";
 import type { CredentialEntry, CredentialEntryControl } from "./credential-entry";
 import { isSubmittable, removalEndsEntry } from "./credential-entry";
 import {
@@ -418,7 +419,7 @@ export function App(): React.JSX.Element {
   const standDownPage = useRef<SettingsView>(SETTINGS_VIEW.ROOT);
   const feedbackHeld = useRef(false);
   /** Whether a calendar sign-in holds the slot, mirrored like the other two. */
-  const calendarConnectHeld = useRef(false);
+  const consentConnectHeld = useRef(false);
   /**
    * Which entry the slot shape is drawn around — a key being pasted, or a
    * sign-in being waited out. One shape, two occupants, never both: beginning
@@ -616,7 +617,7 @@ export function App(): React.JSX.Element {
     // close a panel showing nothing but sessions.
     entryDrawn: () => credentialHeld.current && tabNow() === PANEL_TAB.SETTINGS,
     composerHeld: () =>
-      credentialHeld.current || feedbackHeld.current || calendarConnectHeld.current,
+      credentialHeld.current || feedbackHeld.current || consentConnectHeld.current,
     onNotPanel: () => setOptionsOpen(false),
     onCapsuleList: () => {
       // A search is a question about the list as it was, so it closes with
@@ -779,22 +780,34 @@ export function App(): React.JSX.Element {
     [applySettingsReply],
   );
 
+  const disconnectLinear = useCallback(
+    async () => applySettingsReply(await window.sidecar.disconnectLinear()),
+    [applySettingsReply],
+  );
+
   /**
-   * The calendar sign-in is asking for one thing too, so the panel gets out
-   * of the way of it the same way it does for a key: the shape goes down to a
+   * A consent sign-in is asking for one thing too, so the panel gets out of
+   * the way of it the same way it does for a key: the shape goes down to a
    * slot that says what it is waiting for. The flow itself runs in the
    * browser and the main process; when the grant lands, the panel comes back
-   * around the newly connected account.
+   * around the newly connected service. One entry serves every such sign-in,
+   * because only one consent page can be open at a time and there is only one
+   * slot for it to stand in.
    */
-  const calendarConnect = usePanelEntry<CalendarConnectEntry>({
+  const consentConnect = usePanelEntry<ConsentConnectEntry>({
     aside: PANEL_PRESENTATION.SLOT,
     // Giving up mid-wait leaves — the consent page is where the user is — but
     // a sign-in that failed is read in the slot, so its Close restores the
     // panel to try again from the row.
     restoresPanel: (held) => held.rejection !== undefined,
-    isSendable: (entry): entry is CalendarConnectEntry => entry !== undefined && !entry.busy,
-    send: async () => {
-      const result = await window.sidecar.connectGoogleCalendar();
+    isSendable: (entry): entry is ConsentConnectEntry => entry !== undefined && !entry.busy,
+    send: async (sending) => {
+      // Which service is being connected decides which documented act runs,
+      // and nothing else does: the entry names one of the two the build knows.
+      const result =
+        sending.serviceId === CONSENT_SERVICE_ID.LINEAR
+          ? await window.sidecar.connectLinear()
+          : await window.sidecar.connectGoogleCalendar();
       applySettings(result.settings);
       return result.reason ? { rejection: result.reason } : {};
     },
@@ -806,27 +819,35 @@ export function App(): React.JSX.Element {
     restorePanel,
     leave,
     settle,
-    heldRef: calendarConnectHeld,
+    heldRef: consentConnectHeld,
   });
 
   /** One press: stand down to the waiting slot and open the consent page. */
-  const beginCalendarSignIn = useCallback(() => {
-    // One slot, one occupant: a key mid-paste is not disturbed by a sign-in.
-    if (credentialHeld.current || calendarConnectHeld.current) return;
-    slotOccupant.current = PANEL_STAND_DOWN.CALENDAR;
-    // The calendar's block stands under Integrations, so that is where a
-    // cancelled or refused sign-in comes back to.
-    standDownPage.current = standDownReturnPage({ kind: PANEL_STAND_DOWN.CALENDAR });
-    calendarConnect.begin({ busy: false });
-    calendarConnect.commit();
-  }, [calendarConnect.begin, calendarConnect.commit]);
+  const beginConsentSignIn = useCallback(
+    (serviceId: ConsentServiceId) => {
+      // One slot, one occupant: a key mid-paste is not disturbed by a
+      // sign-in, and neither is another sign-in already waiting.
+      if (credentialHeld.current || consentConnectHeld.current) return;
+      slotOccupant.current = PANEL_STAND_DOWN.CONSENT;
+      // Every consent block stands under Integrations, so that is where a
+      // cancelled or refused sign-in comes back to.
+      standDownPage.current = standDownReturnPage({ kind: PANEL_STAND_DOWN.CONSENT });
+      consentConnect.begin({ serviceId, busy: false });
+      consentConnect.commit();
+    },
+    [consentConnect.begin, consentConnect.commit],
+  );
 
-  const cancelCalendarSignIn = useCallback(() => {
+  const cancelConsentSignIn = useCallback(() => {
     // Mid-wait, the loopback must stop listening too; after a failure there
     // is nothing left to stop.
-    if (calendarConnect.latest()?.busy) window.sidecar.cancelGoogleCalendarSignIn();
-    calendarConnect.cancel();
-  }, [calendarConnect.cancel, calendarConnect.latest]);
+    const waiting = consentConnect.latest();
+    if (waiting?.busy) {
+      if (waiting.serviceId === CONSENT_SERVICE_ID.LINEAR) window.sidecar.cancelLinearSignIn();
+      else window.sidecar.cancelGoogleCalendarSignIn();
+    }
+    consentConnect.cancel();
+  }, [consentConnect.cancel, consentConnect.latest]);
 
   /**
    * Asking to write a key is asking for one thing, so the panel gets out of the
@@ -2308,11 +2329,11 @@ export function App(): React.JSX.Element {
       if (stopSpeaking()) return;
       // Escape out of the slot is the entry's own way out, wherever the caret
       // happens to be: the slot is the only thing on screen, so there is nothing
-      // else it could mean. The sign-in wait and the calendar connect borrow
+      // else it could mean. The sign-in wait and the consent connect borrow
       // the same shape, so the same key withdraws whichever is holding it.
       if (presentation === PANEL_PRESENTATION.SLOT) {
         if (signInWaitNow() !== undefined) cancelSignIn();
-        else if (calendarConnect.latest()) cancelCalendarSignIn();
+        else if (consentConnect.latest()) cancelConsentSignIn();
         else credentialsEntry.cancel();
         return;
       }
@@ -2341,8 +2362,8 @@ export function App(): React.JSX.Element {
     return () => window.removeEventListener("keydown", handleKey);
   }, [
     cancelSignIn,
-    calendarConnect.latest,
-    cancelCalendarSignIn,
+    consentConnect.latest,
+    cancelConsentSignIn,
     credentialsEntry.cancel,
     changeMode,
     changeTab,
@@ -2623,7 +2644,7 @@ export function App(): React.JSX.Element {
           panelHeight,
           signInWait !== undefined
             ? signInSlotHeight
-            : slotOccupant.current === PANEL_STAND_DOWN.CALENDAR
+            : slotOccupant.current === PANEL_STAND_DOWN.CONSENT
               ? connectHeight
               : slotHeight,
           feedbackHeight,
@@ -2693,11 +2714,21 @@ export function App(): React.JSX.Element {
               workspaceProviders: workspaceProviderOptions,
               calendar: {
                 choices: calendars,
-                held: credentialsEntry.entry !== undefined,
-                connecting: calendarConnect.entry !== undefined,
-                onSignIn: beginCalendarSignIn,
+                held:
+                  credentialsEntry.entry !== undefined ||
+                  consentConnect.entry?.serviceId === CONSENT_SERVICE_ID.LINEAR,
+                connecting: consentConnect.entry?.serviceId === CONSENT_SERVICE_ID.GOOGLE_CALENDAR,
+                onSignIn: () => beginConsentSignIn(CONSENT_SERVICE_ID.GOOGLE_CALENDAR),
                 onRemoveAccount: removeCalendarAccount,
                 onToggleCalendar: toggleCalendarSelected,
+              },
+              linear: {
+                held:
+                  credentialsEntry.entry !== undefined ||
+                  consentConnect.entry?.serviceId === CONSENT_SERVICE_ID.GOOGLE_CALENDAR,
+                connecting: consentConnect.entry?.serviceId === CONSENT_SERVICE_ID.LINEAR,
+                onSignIn: () => beginConsentSignIn(CONSENT_SERVICE_ID.LINEAR),
+                onDisconnect: disconnectLinear,
               },
               onQuit: () => window.sidecar.quit(),
               shortcuts,
@@ -2711,7 +2742,7 @@ export function App(): React.JSX.Element {
       {/* The three shapes that borrow the slot never draw together: the
           gate's sign-in wait suppresses the settings tab's two entries
           outright — the two are never on screen at once — and the key and
-          calendar-connect pills split the remaining case by which entry
+          consent-connect pills split the remaining case by which entry
           holds the slot. A pill held through an old exit must not resurface
           under another's wait. */}
       {signInWait === undefined ? (
@@ -2722,18 +2753,26 @@ export function App(): React.JSX.Element {
             drawn={slotOpen && slotOccupant.current === PANEL_STAND_DOWN.KEY}
             measure={slotElement}
           />
-          {/* The panel stood down while a calendar sign-in waits on the
+          {/* The panel stood down while a consent sign-in waits on the
               browser, on the key slot's exact terms. */}
-          <CalendarConnectSlot
-            entry={calendarConnect.entry}
-            drawn={slotOpen && slotOccupant.current === PANEL_STAND_DOWN.CALENDAR}
-            onCancel={cancelCalendarSignIn}
-            onReopen={() => window.sidecar.reopenGoogleCalendarSignIn()}
+          <ConsentConnectSlot
+            entry={consentConnect.entry}
+            drawn={slotOpen && slotOccupant.current === PANEL_STAND_DOWN.CONSENT}
+            onCancel={cancelConsentSignIn}
+            onReopen={() => {
+              // The page reopened is the one the waiting flow built, named by
+              // the service the entry says is waiting — no address from here.
+              if (consentConnect.latest()?.serviceId === CONSENT_SERVICE_ID.LINEAR) {
+                window.sidecar.reopenLinearSignIn();
+              } else {
+                window.sidecar.reopenGoogleCalendarSignIn();
+              }
+            }}
             measure={connectElement}
           />
         </>
       ) : null}
-      {credentialsEntry.entry === undefined && calendarConnect.entry === undefined ? (
+      {credentialsEntry.entry === undefined && consentConnect.entry === undefined ? (
         /* The panel stood down to the account sign-in it is waiting on. */
         <SignInSlot
           {...(signInWait ? { provider: signInWait } : {})}

--- a/apps/desktop/src/renderer/consent-connect-slot.tsx
+++ b/apps/desktop/src/renderer/consent-connect-slot.tsx
@@ -1,31 +1,38 @@
 import { useRef } from "react";
-import { GOOGLE_CALENDAR_ID } from "../shared/google-calendar";
+import { CONSENT_SERVICE_NAME, type ConsentServiceId } from "../shared/consent-services";
 import { HIT_REGION } from "./panel-state";
 import { ProviderMark } from "./provider-marks";
 import { ExternalIcon } from "./settings-icons";
 
-/** What the connect entry holds: nothing to type, only the wait and its end. */
-export interface CalendarConnectEntry {
+/**
+ * What the connect entry holds: nothing to type, only which service's page is
+ * open, the wait, and its end.
+ */
+export interface ConsentConnectEntry {
+  serviceId: ConsentServiceId;
   busy: boolean;
   rejection?: string;
 }
 
 /**
- * The panel stood down while a sign-in waits on the browser — the same
- * courtesy the key slot pays: Luke floats above every window, including
- * Google's consent page, so the shape shrinks to a line that says what it is
- * waiting for and the one way to stop waiting. The flow finishes in the
+ * The panel stood down while a consent sign-in waits on the browser — the
+ * same courtesy the key slot pays: Luke floats above every window, including
+ * the provider's consent page, so the shape shrinks to a line that says what
+ * it is waiting for and the one way to stop waiting. The flow finishes in the
  * browser and the main process; when it does, the panel comes back on its own
- * around the newly connected account.
+ * around the newly connected service.
+ *
+ * One slot serves every consent flow, so no two of them can introduce
+ * themselves differently: only the mark and the service's name change.
  */
-export function CalendarConnectSlot({
+export function ConsentConnectSlot({
   entry,
   drawn,
   onCancel,
   onReopen,
   measure,
 }: {
-  entry: CalendarConnectEntry | undefined;
+  entry: ConsentConnectEntry | undefined;
   /** True while this slot is the shape the surface is drawn as. */
   drawn: boolean;
   onCancel: () => void;
@@ -48,14 +55,18 @@ export function CalendarConnectSlot({
       <div className="key-slot sign-in-slot" ref={measure} data-hit-region={HIT_REGION.SLOT}>
         {/* One line, worded and dressed like the account sign-in's wait: the
             mark, what is being waited for, and the one way to stop waiting —
-            only the calendar mark and the way back to a lost tab tell the two
+            only the service's mark and the way back to a lost tab tell the
             popups apart. */}
         <div className="key-slot-row">
           <span className="key-slot-mark">
-            <ProviderMark providerId={GOOGLE_CALENDAR_ID} />
+            <ProviderMark providerId={held.serviceId} />
           </span>
           <span className="sign-in-slot-copy" role="status">
-            <strong>{held.rejection ? "Not connected" : "Waiting for Google…"}</strong>
+            <strong>
+              {held.rejection
+                ? "Not connected"
+                : `Waiting for ${CONSENT_SERVICE_NAME[held.serviceId]}…`}
+            </strong>
             <small>
               {held.rejection ?? "Finish signing in in your browser."}{" "}
               {/* The lost-tab way back in, on the key slot's own terms: a

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -41,8 +41,8 @@ import {
 } from "../shared/contracts";
 import {
   CLOUD_AGENT_PROVIDER_LIST,
+  CREDENTIAL_PROVIDER_ID,
   CREDENTIAL_PROVIDERS,
-  INTEGRATION_PROVIDER_LIST,
   VOICE_CREDENTIAL_PROVIDER_ID,
 } from "../shared/credential-providers";
 import {
@@ -171,13 +171,16 @@ function providersFact(settings: AppSettings): AppGuideFact {
 }
 
 function integrationsFact(settings: AppSettings): AppGuideFact {
-  const roster = INTEGRATION_PROVIDER_LIST.map(
-    (provider) =>
-      `${provider.displayName} (${connectionWord(settings.credentialSources[provider.id])})`,
-  );
-  // The calendar is an integration too, connected by sign-in rather than by a
-  // key — and only a build carrying the sign-in offers it at all, so a build
-  // without one says nothing rather than describing a row that is not drawn.
+  const linearProvider = CREDENTIAL_PROVIDERS[CREDENTIAL_PROVIDER_ID.LINEAR];
+  const linear = !settings.linearSignInAvailable
+    ? ""
+    : `${linearProvider.displayName} ` +
+      `(${connectionWord(settings.credentialSources[linearProvider.id])}) connects by signing ` +
+      `in with Linear from its row in ${CONNECTIONS_PAGE}, under Integrations — Linear's own ` +
+      `consent page opens in the browser, and no key is ever typed or spoken. Connecting it ` +
+      `lets Luke read the developer's assigned issues and, only when asked in a turn the ` +
+      `developer opened, move one to another state or comment on it. Disconnecting from the ` +
+      `same row ends the access at Linear as well as here.`;
   const accounts = settings.calendarAccounts.length;
   const calendar = !settings.calendarSignInAvailable
     ? ""
@@ -191,11 +194,7 @@ function integrationsFact(settings: AppSettings): AppGuideFact {
         "can be added from the same row.";
   return {
     label: "Integrations",
-    detail:
-      `${roster.join(", ")}. Connecting Linear lets Luke read the developer's issues and, only ` +
-      `when asked in a turn the developer opened, move or comment on one. Its key is typed by ` +
-      `hand into ${CONNECTIONS_PAGE}, under Integrations — never spoken, and never repeated ` +
-      `back.${calendar}`,
+    detail: `${linear}${calendar}`.trim() || "No integrations are available in this build.",
   };
 }
 

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -42,7 +42,8 @@ import {
 import type { CredentialProvider } from "../shared/credential-providers";
 import {
   CLOUD_AGENT_PROVIDER_LIST,
-  INTEGRATION_PROVIDER_LIST,
+  CREDENTIAL_PROVIDER_ID,
+  CREDENTIAL_PROVIDERS,
   providerRunsSessionsInCloud,
   VOICE_CREDENTIAL_PROVIDER,
 } from "../shared/credential-providers";
@@ -357,6 +358,8 @@ export interface SettingsPanelProps {
   workspaceProviders: readonly WorkspaceProviderOption[];
   /** Everything the Google Calendar block can do. */
   calendar: CalendarControl;
+  /** Everything the Linear block can do. */
+  linear: LinearControl;
   onQuit: () => void;
   shortcuts: ShortcutControl;
 }
@@ -1455,25 +1458,154 @@ function GoogleCalendarIntegration({
   );
 }
 
+/** What the Linear row can be asked for, which is connecting and ending it. */
+export interface LinearControl {
+  /** True while another entry holds the slot, which refuses a second act. */
+  held: boolean;
+  /** True while a sign-in is waiting on the browser. */
+  connecting: boolean;
+  /** Stands the panel down and opens Linear's consent page. */
+  onSignIn: () => void;
+  onDisconnect: () => Promise<string | undefined>;
+}
+
+/**
+ * The issue tracker: connected by signing in with Linear, never by a pasted
+ * credential, and drawn at all only in a build that carries the OAuth client
+ * the sign-in runs on — a row whose one act cannot run is not a row.
+ */
+function LinearIntegration({
+  settings,
+  linear,
+}: {
+  settings: AppSettings;
+  linear: LinearControl;
+}): React.JSX.Element | null {
+  const provider = CREDENTIAL_PROVIDERS[CREDENTIAL_PROVIDER_ID.LINEAR];
+  // Disconnecting asks first, exactly like deleting a key: nothing here can
+  // hand the grant back, so a disconnect taken on the first press would cost
+  // a trip through Linear's consent to undo.
+  const [asking, setAsking] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [rejection, setRejection] = useState<string>();
+
+  if (!settings.linearSignInAvailable) return null;
+  const connected = settings.credentialSources[provider.id] !== CREDENTIAL_SOURCE.NONE;
+
+  const disconnect = async () => {
+    setBusy(true);
+    setRejection(await linear.onDisconnect());
+    setBusy(false);
+    setAsking(false);
+  };
+
+  return (
+    <div className="credential">
+      <div className="credential-row">
+        <span className="credential-identity">
+          <span className="credential-mark">
+            <ProviderMark providerId={provider.id} />
+          </span>
+          <span className="credential-name">{provider.displayName}</span>
+          {connected ? <CheckIcon /> : null}
+        </span>
+        {connected ? (
+          /* The trash and the confirm that stands in for it share one grid
+             cell, exactly as the credential rows' do: the cell is as wide and
+             as tall as the larger of the two whichever is showing, so asking
+             the question never re-shapes the line. */
+          <span className="credential-actions">
+            <span
+              className="settings-actions credential-controls"
+              data-drawn={String(!asking)}
+              aria-hidden={asking}
+              inert={asking}
+            >
+              <button
+                type="button"
+                className="icon-button credential-remove"
+                disabled={busy}
+                aria-label={`Disconnect ${provider.displayName}`}
+                /* The ellipsis is the promise that it asks first. */
+                title="Disconnect…"
+                onClick={() => {
+                  setRejection(undefined);
+                  setAsking(true);
+                }}
+              >
+                <TrashIcon />
+              </button>
+            </span>
+            <fieldset
+              className="settings-actions credential-confirm"
+              aria-label={`Disconnect ${provider.displayName}?`}
+              data-drawn={String(asking)}
+              aria-hidden={!asking}
+              inert={!asking}
+              onKeyDown={(event) => {
+                if (event.key !== "Escape" || busy) return;
+                event.stopPropagation();
+                setAsking(false);
+              }}
+            >
+              <button
+                type="button"
+                className="quiet-button"
+                disabled={busy}
+                onClick={() => setAsking(false)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="danger-button"
+                disabled={busy}
+                onClick={() => void disconnect()}
+              >
+                {busy ? "Disconnecting…" : "Disconnect"}
+              </button>
+            </fieldset>
+          </span>
+        ) : (
+          <span className="settings-actions">
+            {/* The consent page does the connecting: the same word every
+                other integration's row uses. */}
+            <button
+              type="button"
+              className="quiet-button"
+              disabled={linear.held || linear.connecting}
+              aria-label={`Connect ${provider.displayName} by signing in`}
+              title={linear.held ? HELD_TITLE : undefined}
+              onClick={linear.onSignIn}
+            >
+              {linear.connecting ? "Waiting for Linear…" : "Connect"}
+            </button>
+          </span>
+        )}
+      </div>
+      <p className="settings-note">{provider.description}</p>
+      {rejection ? <p className="error-message">{rejection}</p> : null}
+    </div>
+  );
+}
+
 /**
  * The services Luke connects to that are not agents: the issue tracker and
- * the calendar. Each row is the same credential line an agent provider gets —
- * same entry, same trash, same environment fallback — with its own one-line
- * answer to what connecting it buys. The OpenAI key is not here: it lives at
- * the top of the Voice page, beside the feature it turns on.
+ * the calendar. Both are signed into rather than pasted into, so each is a
+ * mark, a name and one button, with its own one-line answer to what
+ * connecting it buys. The OpenAI key is not here: it lives at the top of the
+ * Voice page, beside the feature it turns on.
  */
 function IntegrationsSection({
   settings,
-  control,
-  panelOpen,
   preferences,
   calendar,
+  linear,
 }: {
   settings: AppSettings;
-  control: CredentialEntryControl;
-  panelOpen: boolean;
   preferences: PreferenceWrites;
   calendar: CalendarControl;
+  linear: LinearControl;
 }): React.JSX.Element {
   const storageUnavailable = settings.secretStorage === SECRET_STORAGE.UNAVAILABLE;
   return (
@@ -1482,16 +1614,7 @@ function IntegrationsSection({
         <PlugIcon />
         Integrations
       </h2>
-      {INTEGRATION_PROVIDER_LIST.map((provider) => (
-        <ProviderCredential
-          key={provider.id}
-          provider={provider}
-          source={settings.credentialSources[provider.id]}
-          storageUnavailable={storageUnavailable}
-          control={control}
-          panelOpen={panelOpen}
-        />
-      ))}
+      <LinearIntegration settings={settings} linear={linear} />
       <GoogleCalendarIntegration
         settings={settings}
         calendar={calendar}
@@ -2869,6 +2992,7 @@ export function SettingsPanel({
   panelOpen,
   workspaceProviders,
   calendar,
+  linear,
   onQuit,
   shortcuts,
 }: SettingsPanelProps): React.JSX.Element {
@@ -2980,10 +3104,9 @@ export function SettingsPanel({
           />
           <IntegrationsSection
             settings={settings}
-            control={credentials}
-            panelOpen={panelOpen}
             preferences={preferences}
             calendar={calendar}
+            linear={linear}
           />
           <WorkspacesSection
             settings={settings}

--- a/apps/desktop/src/renderer/settings-views.ts
+++ b/apps/desktop/src/renderer/settings-views.ts
@@ -65,7 +65,7 @@ export function credentialSettingsPage(providerId: CredentialProviderId): Settin
  */
 export const PANEL_STAND_DOWN = {
   KEY: "key",
-  CALENDAR: "calendar",
+  CONSENT: "consent",
   FEEDBACK: "feedback",
 } as const;
 
@@ -75,12 +75,12 @@ export type PanelStandDown = (typeof PANEL_STAND_DOWN)[keyof typeof PANEL_STAND_
  * The two of those three the slot shape is drawn around, never both at once.
  * A note is not one of them: the composer is its own shape, at its own size.
  */
-export type SlotOccupant = typeof PANEL_STAND_DOWN.KEY | typeof PANEL_STAND_DOWN.CALENDAR;
+export type SlotOccupant = typeof PANEL_STAND_DOWN.KEY | typeof PANEL_STAND_DOWN.CONSENT;
 
 /** What stood the panel down, and — for a key — whose row it was begun from. */
 export type StoodDown =
   | { kind: typeof PANEL_STAND_DOWN.KEY; providerId: CredentialProviderId }
-  | { kind: typeof PANEL_STAND_DOWN.CALENDAR }
+  | { kind: typeof PANEL_STAND_DOWN.CONSENT }
   | { kind: typeof PANEL_STAND_DOWN.FEEDBACK };
 
 /**
@@ -89,7 +89,7 @@ export type StoodDown =
  * one remembered page shared by all three lands a cancelled note on whichever
  * page the last key entry happened to belong to.
  *
- * A key's row is its provider's; the calendar's block stands under
+ * A key's row is its provider's; every consent sign-in's block stands under
  * Integrations on Connections; the feedback composer's section is on the front
  * page itself, which is also where a return that knows nothing else belongs.
  */
@@ -97,7 +97,7 @@ export function standDownReturnPage(stood: StoodDown): SettingsView {
   switch (stood.kind) {
     case PANEL_STAND_DOWN.KEY:
       return credentialSettingsPage(stood.providerId);
-    case PANEL_STAND_DOWN.CALENDAR:
+    case PANEL_STAND_DOWN.CONSENT:
       return SETTINGS_VIEW.CONNECTIONS;
     case PANEL_STAND_DOWN.FEEDBACK:
       return SETTINGS_VIEW.ROOT;

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -5,6 +5,9 @@ import { DEFAULT_PANEL_FORM_FACTOR, REALTIME_DEFAULTS } from "@sidecar/core";
 // account into is exactly what `readAccounts` promises it.
 import type { CalendarAccountCredential } from "./google-calendar";
 import { googleCalendarSignInConfig } from "./google-calendar-oauth";
+// The same ownership the calendar reader has over its credential shape: what
+// this store resolves a stored grant into is what the sign-in produced.
+import { type LinearGrant, linearSignInConfig } from "./linear-oauth";
 import { environmentRealtimeSpeed, environmentRealtimeVoice } from "./openai-realtime-credentials";
 import {
   ACCOUNT_PROVIDER,
@@ -22,6 +25,7 @@ import {
   type VoiceSource,
 } from "./shared/contracts";
 import {
+  CREDENTIAL_CONNECTION,
   CREDENTIAL_PROVIDER_ID,
   CREDENTIAL_PROVIDER_LIST,
   type CredentialFormat,
@@ -50,6 +54,7 @@ const SETTINGS_FIELD = {
   ACCOUNT: "account",
   API_KEYS: "apiKeys",
   CALENDAR_ACCOUNTS: "calendarAccounts",
+  GRANTS: "grants",
   LEGACY_CONDUCTOR_API_KEY: "conductorApiKey",
   VERSION: "version",
 } as const;
@@ -98,6 +103,13 @@ interface PersistedSettings extends StoredAppSettings {
    * through untouched so an older build cannot discard a newer one's key.
    */
   apiKeys: Readonly<Record<string, string>>;
+  /**
+   * The consent grants, by provider id, kept apart from the pasted keys
+   * because what is inside is not a credential the user could type back in:
+   * two tokens and the moment the shorter-lived one lapses. Carried through
+   * untouched for a provider this build does not know, exactly as a key is.
+   */
+  grants?: Readonly<Record<string, PersistedGrant>>;
   /** Account tokens encrypted together; only display identity stays plaintext. */
   account?: {
     tokenCipher: string;
@@ -204,6 +216,38 @@ function storedCalendarAccounts(
   return accounts;
 }
 
+/**
+ * One provider's consent grant at rest. The tokens travel together under one
+ * ciphertext, the way the account's do — they are useless apart, and a single
+ * decryption is a single trip to the Keychain. The expiry stays in plaintext
+ * beside it: when a token lapses is not a secret, and knowing it without
+ * decrypting is what lets a pass skip the refresh it does not need.
+ */
+interface PersistedGrant {
+  tokenCipher: string;
+  expiresAt: number;
+}
+
+/** Reads the stored grants, keeping only well-formed entries. */
+function storedGrants(record: Record<string, unknown>): Record<string, PersistedGrant> {
+  const grants: Record<string, PersistedGrant> = {};
+  const persisted = record[SETTINGS_FIELD.GRANTS];
+  if (persisted === null || typeof persisted !== "object" || Array.isArray(persisted)) {
+    return grants;
+  }
+  for (const [providerId, entry] of Object.entries(persisted)) {
+    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) continue;
+    const { tokenCipher, expiresAt } = entry as Record<string, unknown>;
+    if (typeof tokenCipher !== "string" || !tokenCipher) continue;
+    // A grant whose expiry did not survive the file is treated as lapsed
+    // rather than as eternal, so the next pass refreshes it before riding it.
+    grants[providerId] = {
+      tokenCipher,
+      expiresAt: typeof expiresAt === "number" ? expiresAt : 0,
+    };
+  }
+  return grants;
+}
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error;
 }
@@ -245,12 +289,24 @@ function environmentApiKey(
   return undefined;
 }
 
-function storedApiKeys(record: Record<string, unknown>): Record<string, string> {
+function storedApiKeys(
+  record: Record<string, unknown>,
+  providers: readonly CredentialProvider[],
+): Record<string, string> {
   const apiKeys: Record<string, string> = {};
   const persisted = record[SETTINGS_FIELD.API_KEYS];
   if (persisted !== null && typeof persisted === "object" && !Array.isArray(persisted)) {
     for (const [providerId, ciphertext] of Object.entries(persisted)) {
-      if (typeof ciphertext === "string" && ciphertext) apiKeys[providerId] = ciphertext;
+      if (typeof ciphertext !== "string" || !ciphertext) continue;
+      // A provider this build connects by consent takes no key, so a key left
+      // by a build that asked for one is dropped rather than carried: it can
+      // never authorize anything again, and a credential Luke will not use is
+      // not a credential Luke should keep. A provider this build does not
+      // know is still carried through untouched — that is an older build
+      // meeting a newer one's key, which is the opposite case.
+      const provider = providers.find((candidate) => candidate.id === providerId);
+      if (provider?.connection === CREDENTIAL_CONNECTION.CONSENT) continue;
+      apiKeys[providerId] = ciphertext;
     }
   }
   // An installation upgraded from version 1 keeps its Conductor key: the
@@ -268,7 +324,10 @@ function storedApiKeys(record: Record<string, unknown>): Record<string, string> 
  * with a model this one does not know; honouring it would send a value no
  * documented endpoint takes, so it is dropped the way an unknown voice is.
  */
-function parsePersistedSettings(source: string): PersistedSettings {
+function parsePersistedSettings(
+  source: string,
+  providers: readonly CredentialProvider[],
+): PersistedSettings {
   const parsed: unknown = JSON.parse(source);
   if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error("Settings file is not an object");
@@ -276,6 +335,7 @@ function parsePersistedSettings(source: string): PersistedSettings {
   const record = parsed as Record<string, unknown>;
   const version = record[SETTINGS_FIELD.VERSION];
   const calendarAccounts = storedCalendarAccounts(record);
+  const grants = storedGrants(record);
   const settings = Object.fromEntries(
     APP_SETTING_FIELDS.map((field) => [
       field,
@@ -285,7 +345,8 @@ function parsePersistedSettings(source: string): PersistedSettings {
   return {
     ...settings,
     version: typeof version === "number" ? version : SETTINGS_FILE_VERSION,
-    apiKeys: storedApiKeys(record),
+    apiKeys: storedApiKeys(record, providers),
+    ...(Object.keys(grants).length > 0 ? { grants } : {}),
     ...(storedAccount(record) ? { account: storedAccount(record) } : {}),
     ...(calendarAccounts.length > 0 ? { calendarAccounts } : {}),
   };
@@ -306,6 +367,8 @@ export class SettingsStore {
   #resolved = new Map<CredentialProviderId, ResolvedApiKey>();
   /** Decrypted accounts, cached like the keys so timers never drum the Keychain. */
   #resolvedCalendarAccounts: readonly CalendarAccountCredential[] | undefined;
+  /** Decrypted grants, cached for the same reason and cleared by the same writes. */
+  #resolvedGrants = new Map<CredentialProviderId, LinearGrant | undefined>();
   #mutations: Promise<void> = Promise.resolve();
 
   async get<Field extends AppSettingField>(field: Field): Promise<AppSettingValue<Field>> {
@@ -408,6 +471,11 @@ export class SettingsStore {
       // grants. Without one the integration is not drawn at all.
       calendarSignInAvailable:
         this.#credentialsUsable && googleCalendarSignInConfig(this.#environment) !== undefined,
+      // The same question for Linear, answered the same way: without a
+      // registered OAuth client there is no consent page to open, so the row
+      // is not drawn rather than drawn refusing.
+      linearSignInAvailable:
+        this.#credentialsUsable && linearSignInConfig(this.#environment) !== undefined,
       // The accounts without their grants: which are connected and which
       // calendars count is the renderer's to draw; the tokens never travel.
       calendarAccounts: (persisted.calendarAccounts ?? []).map((account) => ({
@@ -634,6 +702,109 @@ export class SettingsStore {
       this.#resolved.delete(providerId);
     });
     return { settings: await this.snapshot() };
+  }
+
+  /**
+   * Main-process only, like the resolved keys: one provider's grant with its
+   * tokens decrypted, for the reader that mints requests from it. A grant
+   * that no longer decrypts — another OS account, a rotated Keychain — reads
+   * as absent, and the row it draws says to connect again.
+   */
+  async readGrant(providerId: CredentialProviderId): Promise<LinearGrant | undefined> {
+    if (this.#resolvedGrants.has(providerId)) return this.#resolvedGrants.get(providerId);
+    const held = (await this.#load()).grants?.[providerId];
+    const grant = held ? this.#decryptGrant(held) : undefined;
+    this.#resolvedGrants.set(providerId, grant);
+    return grant;
+  }
+
+  /**
+   * Stores one provider's grant encrypted at rest. Every refresh comes back
+   * through here as well as every connection, because Linear consumes the
+   * refresh token it is given: a grant refreshed and not written is a grant
+   * the user has to make again.
+   */
+  async setGrant(
+    providerId: CredentialProviderId,
+    grant: LinearGrant,
+  ): Promise<SettingsUpdateResult> {
+    const accessToken = grant.accessToken.trim();
+    const rejection = !this.#secretStorageUsable()
+      ? "Encrypted credential storage is unavailable on this system."
+      : // The shape rules a pasted key answers to. What is inside is the
+        // provider's to shape, so only sendability is checked.
+        apiKeyRejection(accessToken);
+    if (rejection) return { settings: await this.snapshot(), reason: rejection };
+
+    await this.#serialize(async () => {
+      const persisted = await this.#load();
+      const tokenCipher = this.#cipher
+        .encrypt(
+          JSON.stringify({
+            accessToken,
+            ...(grant.refreshToken ? { refreshToken: grant.refreshToken } : {}),
+          }),
+        )
+        .toString("base64");
+      // Every other provider's grant is carried over, so connecting one never
+      // disturbs another.
+      const grants = { ...(persisted.grants ?? {}) };
+      grants[providerId] = { tokenCipher, expiresAt: grant.expiresAt };
+      await this.#writeGrants(persisted, grants, providerId);
+    });
+    return { settings: await this.snapshot() };
+  }
+
+  /** Disconnects one provider, deleting its stored grant with it. */
+  async clearGrant(providerId: CredentialProviderId): Promise<SettingsUpdateResult> {
+    await this.#serialize(async () => {
+      const persisted = await this.#load();
+      if (!persisted.grants?.[providerId]) return;
+      const grants = { ...persisted.grants };
+      delete grants[providerId];
+      await this.#writeGrants(persisted, grants, providerId);
+    });
+    return { settings: await this.snapshot() };
+  }
+
+  /** One place writes the grants, so neither cache can outlive the file. */
+  async #writeGrants(
+    persisted: PersistedSettings,
+    grants: Readonly<Record<string, PersistedGrant>>,
+    providerId: CredentialProviderId,
+  ): Promise<void> {
+    const next: PersistedSettings = {
+      ...persisted,
+      version: SETTINGS_FILE_VERSION,
+    };
+    if (Object.keys(grants).length > 0) next.grants = grants;
+    else delete next.grants;
+    await this.#write(next);
+    this.#loading = Promise.resolve(next);
+    this.#resolvedGrants.delete(providerId);
+    // The row's own source is resolved from the same file, so it is stale now
+    // for exactly the same reason.
+    this.#resolved.delete(providerId);
+  }
+
+  /** Recovers one stored grant's tokens, or nothing if they cannot be read. */
+  #decryptGrant(held: PersistedGrant): LinearGrant | undefined {
+    try {
+      const tokens: unknown = JSON.parse(
+        this.#cipher.decrypt(Buffer.from(held.tokenCipher, "base64")),
+      );
+      if (tokens === null || typeof tokens !== "object" || Array.isArray(tokens)) return undefined;
+      const { accessToken, refreshToken } = tokens as Record<string, unknown>;
+      if (typeof accessToken !== "string" || !accessToken) return undefined;
+      return {
+        accessToken,
+        ...(typeof refreshToken === "string" && refreshToken ? { refreshToken } : {}),
+        expiresAt: held.expiresAt,
+      };
+    } catch {
+      // Unrecoverable; the user connects that provider again.
+      return undefined;
+    }
   }
 
   /**
@@ -869,6 +1040,19 @@ export class SettingsStore {
   async #resolveApiKey(provider: CredentialProvider): Promise<ResolvedApiKey> {
     const cached = this.#resolved.get(provider.id);
     if (cached) return cached;
+    // A consent grant is not a key and is never handed out as one: what
+    // authorizes a request is minted from it, by the reader that holds it.
+    // Only whether one is stored belongs here, because that is what the
+    // provider's row draws — and a grant can only ever have come from this
+    // file, never from a launch environment.
+    if (provider.connection === CREDENTIAL_CONNECTION.CONSENT) {
+      const held = (await this.#load()).grants?.[provider.id];
+      const resolved: ResolvedApiKey = {
+        source: held ? CREDENTIAL_SOURCE.ENCRYPTED_FILE : CREDENTIAL_SOURCE.NONE,
+      };
+      this.#resolved.set(provider.id, resolved);
+      return resolved;
+    }
     const stored = await this.#storedApiKey(provider);
     const fromEnvironment = stored ? undefined : environmentApiKey(provider, this.#environment);
     const resolved: ResolvedApiKey = stored
@@ -922,7 +1106,7 @@ export class SettingsStore {
     };
     if (source) {
       try {
-        persisted = parsePersistedSettings(source);
+        persisted = parsePersistedSettings(source, this.#providers);
       } catch {
         // A corrupt settings file is replaced by the next write rather than
         // failing app start.

--- a/apps/desktop/src/shared/consent-services.ts
+++ b/apps/desktop/src/shared/consent-services.ts
@@ -1,0 +1,29 @@
+import { CREDENTIAL_PROVIDER_ID } from "./credential-providers";
+import { GOOGLE_CALENDAR_ID, GOOGLE_CALENDAR_NAME } from "./google-calendar";
+
+/**
+ * The services connected by consent rather than by a pasted key: the panel
+ * stands down for each of them the same way, and the slot it stands down to
+ * has to say which one the browser is waiting on. Named together here because
+ * they answer to one wait — only one consent page can be open at a time, one
+ * slot holds it, and a slot that cannot say whose page it is would be the
+ * same pill for both.
+ *
+ * Linear's id is the credential registry's, because Linear is a service Luke
+ * holds one credential for. The calendar's is its own: it holds several
+ * accounts at once, which the per-provider registry does not model.
+ */
+export const CONSENT_SERVICE_ID = {
+  GOOGLE_CALENDAR: GOOGLE_CALENDAR_ID,
+  LINEAR: CREDENTIAL_PROVIDER_ID.LINEAR,
+} as const;
+
+export type ConsentServiceId = (typeof CONSENT_SERVICE_ID)[keyof typeof CONSENT_SERVICE_ID];
+
+/** What the wait calls each service, which is the provider's own name for itself. */
+export const CONSENT_SERVICE_NAME: Readonly<Record<ConsentServiceId, string>> = {
+  [CONSENT_SERVICE_ID.GOOGLE_CALENDAR]: GOOGLE_CALENDAR_NAME,
+  // Not the registry's `displayName` by lookup: the wait says "Waiting for
+  // Linear…", and the two must be the same word.
+  [CONSENT_SERVICE_ID.LINEAR]: "Linear",
+};

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -219,6 +219,13 @@ export interface AppSettings {
    */
   calendarSignInAvailable: boolean;
   /**
+   * The same for Linear, whose row is a sign-in rather than a field: the
+   * issues are read under a grant Linear's own consent page issues, so a
+   * build carrying no registration draws no Linear row at all. Whether one is
+   * connected is `credentialSources`, as it is for every other service.
+   */
+  linearSignInAvailable: boolean;
+  /**
    * The connected Google Calendar accounts, each with the calendars the user
    * chose to count. Empty until a sign-in lands one.
    */
@@ -615,6 +622,23 @@ export interface AppBridge {
   /** Disconnects one calendar account, deleting its stored grant. */
   removeCalendarAccount(accountId: string): Promise<SettingsUpdateResult>;
   /**
+   * Runs the Linear sign-in, on exactly the terms the calendar's runs on:
+   * Linear's own consent page in the user's browser, the code back over a
+   * loopback that never leaves the machine, and the grant stored encrypted by
+   * the main process. The renderer asks for the act and receives only the
+   * settings snapshot — no token, code, or address ever crosses this bridge.
+   */
+  connectLinear(): Promise<SettingsUpdateResult>;
+  /** Ends a Linear sign-in still waiting on the browser, like the calendar's. */
+  cancelLinearSignIn(): void;
+  /** Opens the waiting Linear sign-in's consent page again, for a lost tab. */
+  reopenLinearSignIn(): void;
+  /**
+   * Disconnects Linear: the grant is revoked with Linear so the access ends
+   * there too, and deleted here either way.
+   */
+  disconnectLinear(): Promise<SettingsUpdateResult>;
+  /**
    * Chooses whether one of an account's calendars counts toward meetings. A
    * calendar being switched on must be one the account's latest observation
    * listed; the main process validates that again before the store keeps it.
@@ -855,6 +879,10 @@ export const channels = {
   cancelGoogleCalendarSignIn: "app:cancel-google-calendar-sign-in",
   reopenGoogleCalendarSignIn: "app:reopen-google-calendar-sign-in",
   removeCalendarAccount: "app:remove-calendar-account",
+  connectLinear: "app:connect-linear",
+  cancelLinearSignIn: "app:cancel-linear-sign-in",
+  reopenLinearSignIn: "app:reopen-linear-sign-in",
+  disconnectLinear: "app:disconnect-linear",
   setCalendarSelected: "app:set-calendar-selected",
   calendarsChanged: "app:calendars-changed",
   meetingQuietChanged: "app:meeting-quiet-changed",

--- a/apps/desktop/src/shared/credential-providers.ts
+++ b/apps/desktop/src/shared/credential-providers.ts
@@ -4,7 +4,8 @@ import { ISSUE_TRACKER_ID, PROVIDER_ID } from "@sidecar/core";
  * The services Luke can hold a credential for: the subset of the observed
  * providers whose sessions live in a cloud service with no local state to
  * read, plus the issue tracker Luke reads the same way — each of which must
- * observe nothing at all until the user supplies a key. Most ids are core's,
+ * observe nothing at all until the user connects it, by pasting a key or by
+ * granting one on the provider's own consent page. Most ids are core's,
  * so a credential row names the same service a session row or the issue
  * roster does — that is what lets one mark registry serve them all.
  *
@@ -27,6 +28,23 @@ export const CREDENTIAL_PROVIDER_ID = {
 
 export type CredentialProviderId =
   (typeof CREDENTIAL_PROVIDER_ID)[keyof typeof CREDENTIAL_PROVIDER_ID];
+
+/**
+ * How a service's credential is come by, which is the whole difference between
+ * the two rows Settings draws for one. A key is the user's to fetch and paste,
+ * so its row is a field and a page to go and get one from. A consent grant is
+ * the provider's to issue over its own page in the user's browser, so its row
+ * is a button and nothing to type. What is stored is the same either way —
+ * encrypted at rest, read only in the main process — because a credential is a
+ * credential however it arrived.
+ */
+export const CREDENTIAL_CONNECTION = {
+  KEY: "key",
+  CONSENT: "consent",
+} as const;
+
+export type CredentialConnection =
+  (typeof CREDENTIAL_CONNECTION)[keyof typeof CREDENTIAL_CONNECTION];
 
 /**
  * `<PROVIDER>_API_KEY` is the convention every provider follows. A provider may
@@ -53,10 +71,6 @@ const JULES_ENVIRONMENT = {
   API_KEY: "JULES_API_KEY",
 } as const;
 
-const LINEAR_ENVIRONMENT = {
-  API_KEY: "LINEAR_API_KEY",
-} as const;
-
 /**
  * The only kind of credential Luke will hold for a provider that issues more
  * than one. Only a provider that publishes a format declares this; the rest
@@ -78,15 +92,23 @@ export interface CredentialFormat {
 export interface CredentialProvider {
   id: CredentialProviderId;
   displayName: string;
-  /** Where the user creates a key, shown beside that provider's field. */
-  hint: string;
+  /** How this provider's credential is come by, which decides what its row is. */
+  connection: CredentialConnection;
+  /**
+   * Where the user creates a key, shown in the editor its row opens. Absent
+   * for a provider connected by consent: there is no editor to say it in, and
+   * nothing for the user to go and fetch — what such a row says under itself
+   * is `description`, the same line every integration carries.
+   */
+  hint?: string;
   /**
    * The page that issues this provider's keys. It is opened by provider id
    * rather than by a URL the renderer supplies, so the only addresses Luke can
-   * ever open are the ones in this file.
+   * ever open are the ones in this file. Absent for a provider whose credential
+   * is granted rather than pasted: there is no key page to send anyone to.
    */
-  apiKeysUrl: string;
-  /** Read in order when nothing is stored for this provider. */
+  apiKeysUrl?: string;
+  /** Read in order when nothing is stored for this provider. Empty for a grant. */
   environmentVariables: readonly string[];
   /** Present only for a provider that publishes more than one kind of key. */
   keyFormat?: CredentialFormat;
@@ -102,6 +124,7 @@ export interface CredentialProvider {
 export const CREDENTIAL_PROVIDERS: Readonly<Record<CredentialProviderId, CredentialProvider>> = {
   [CREDENTIAL_PROVIDER_ID.CONDUCTOR]: {
     id: CREDENTIAL_PROVIDER_ID.CONDUCTOR,
+    connection: CREDENTIAL_CONNECTION.KEY,
     displayName: "Conductor",
     hint: "Create a key in Conductor under Settings · API keys.",
     apiKeysUrl: "https://app.conductor.build/users/api-keys",
@@ -109,6 +132,7 @@ export const CREDENTIAL_PROVIDERS: Readonly<Record<CredentialProviderId, Credent
   },
   [CREDENTIAL_PROVIDER_ID.COPILOT]: {
     id: CREDENTIAL_PROVIDER_ID.COPILOT,
+    connection: CREDENTIAL_CONNECTION.KEY,
     displayName: "Copilot",
     // GitHub's agent-tasks endpoints answer only user tokens. The copy names
     // the kind to create because the wrong kinds also come from GitHub: a
@@ -123,6 +147,7 @@ export const CREDENTIAL_PROVIDERS: Readonly<Record<CredentialProviderId, Credent
   },
   [CREDENTIAL_PROVIDER_ID.CURSOR]: {
     id: CREDENTIAL_PROVIDER_ID.CURSOR,
+    connection: CREDENTIAL_CONNECTION.KEY,
     displayName: "Cursor",
     hint: "Create a key in the Cursor dashboard under Integrations · API keys.",
     apiKeysUrl: "https://cursor.com/dashboard/api",
@@ -130,6 +155,7 @@ export const CREDENTIAL_PROVIDERS: Readonly<Record<CredentialProviderId, Credent
   },
   [CREDENTIAL_PROVIDER_ID.DEVIN]: {
     id: CREDENTIAL_PROVIDER_ID.DEVIN,
+    connection: CREDENTIAL_CONNECTION.KEY,
     displayName: "Devin",
     hint: "Create one on the Devin API settings page, under PATs.",
     // Not the Settings · API keys page, which issues the deprecated `apk_`
@@ -153,6 +179,7 @@ export const CREDENTIAL_PROVIDERS: Readonly<Record<CredentialProviderId, Credent
   },
   [CREDENTIAL_PROVIDER_ID.JULES]: {
     id: CREDENTIAL_PROVIDER_ID.JULES,
+    connection: CREDENTIAL_CONNECTION.KEY,
     displayName: "Jules",
     // Jules shows a key once, on creation, and allows at most three at a time.
     hint: "Create a key in Jules under Settings · API key. It is shown only once.",
@@ -161,23 +188,19 @@ export const CREDENTIAL_PROVIDERS: Readonly<Record<CredentialProviderId, Credent
   },
   [CREDENTIAL_PROVIDER_ID.LINEAR]: {
     id: CREDENTIAL_PROVIDER_ID.LINEAR,
+    connection: CREDENTIAL_CONNECTION.CONSENT,
     displayName: "Linear",
     description: "Luke reads your issues and can move or comment on them when you ask.",
-    hint: "Create a personal API key in Linear under Settings · Security & access.",
-    apiKeysUrl: "https://linear.app/settings/account/security",
-    environmentVariables: [LINEAR_ENVIRONMENT.API_KEY],
-    // Linear issues its personal API keys under one prefix; an OAuth access
-    // token belongs to an application acting for a workspace, which is not
-    // what Luke is, so a credential without the prefix would only mislead.
-    keyFormat: {
-      label: "Personal API key",
-      prefix: "lin_api_",
-      rejection:
-        "Linear's personal API keys start with lin_api_. OAuth tokens belong to an application rather than to Luke.",
-    },
+    // No key page and no environment variable, alone among the providers:
+    // nothing is pasted here, so there is nowhere to send anyone to fetch a
+    // credential and nothing for a launch environment to supply. What the
+    // consent page hands back is Linear's to shape, and it is withdrawn in
+    // Linear's own settings as well as by disconnecting the row.
+    environmentVariables: [],
   },
   [CREDENTIAL_PROVIDER_ID.OPENAI]: {
     id: CREDENTIAL_PROVIDER_ID.OPENAI,
+    connection: CREDENTIAL_CONNECTION.KEY,
     // The service, plainly. The row stands inside the section that already
     // says what it is for — the other way voice can run — so the name has no
     // acronym to carry: "BYOK" named the choice for anyone who already knew
@@ -233,7 +256,12 @@ export const CLOUD_AGENT_PROVIDER_LIST: readonly CredentialProvider[] =
     (provider) => !INTEGRATION_IDS.has(provider.id) && provider.id !== VOICE_CREDENTIAL_PROVIDER_ID,
   );
 
-/** The services beyond the agents, in the order the Integrations section lists them. */
+/**
+ * The services beyond the agents. The Integrations section draws each as its
+ * own block rather than from this list — a consent row and a key row are not
+ * the same line — so this stands for what belongs in that section, which is
+ * what keeps the three lists together covering the whole registry.
+ */
 export const INTEGRATION_PROVIDER_LIST: readonly CredentialProvider[] =
   CREDENTIAL_PROVIDER_LIST.filter((provider) => INTEGRATION_IDS.has(provider.id));
 

--- a/apps/desktop/tests/credential-providers.test.ts
+++ b/apps/desktop/tests/credential-providers.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { HOSTED_METER_LABEL, KEY_USE_NOTE } from "../src/renderer/microphone-access";
 import {
   CLOUD_AGENT_PROVIDER_LIST,
+  CREDENTIAL_CONNECTION,
   CREDENTIAL_PROVIDER_ID,
   CREDENTIAL_PROVIDER_LIST,
   CREDENTIAL_PROVIDERS,
@@ -31,14 +32,30 @@ test("describes every provider it lists", () => {
   for (const provider of CREDENTIAL_PROVIDER_LIST) {
     assert.equal(CREDENTIAL_PROVIDERS[provider.id], provider, "a provider is filed under its id");
     assert.ok(provider.displayName.length > 0);
-    assert.ok(provider.hint.length > 0);
+    // A pasted key has an editor to say where to fetch one, and a page to
+    // fetch it from. A consent grant has neither: nothing is fetched by hand.
+    if (provider.connection === CREDENTIAL_CONNECTION.KEY) {
+      assert.ok(provider.hint, provider.id);
+      assert.ok(provider.apiKeysUrl, provider.id);
+    } else {
+      assert.equal(provider.hint, undefined, provider.id);
+      assert.equal(provider.apiKeysUrl, undefined, provider.id);
+    }
     // The environment fallback is `<PROVIDER>_API_KEY` — except OpenAI, which
-    // deliberately offers none: a key that costs money and moves the review
-    // path is connected by hand or not at all.
-    if (provider.id === CREDENTIAL_PROVIDER_ID.OPENAI) {
+    // deliberately offers none (a key that costs money and moves the review
+    // path is connected by hand or not at all), and except a provider
+    // connected by consent, where there is no key for an environment to hold.
+    if (
+      provider.id === CREDENTIAL_PROVIDER_ID.OPENAI ||
+      provider.connection === CREDENTIAL_CONNECTION.CONSENT
+    ) {
       assert.deepEqual(provider.environmentVariables, [], provider.id);
     } else {
       assert.ok(provider.environmentVariables[0]?.endsWith("_API_KEY"), provider.id);
+    }
+    // A consent grant is never typed, so no format could refuse one.
+    if (provider.connection === CREDENTIAL_CONNECTION.CONSENT) {
+      assert.equal(provider.keyFormat, undefined, provider.id);
     }
     // A declared format has to say what it wants as well as refuse, because
     // the reason is the only thing the user has to act on.
@@ -125,17 +142,19 @@ test("takes only the Devin credentials its API version issues", () => {
   }
 });
 
-test("takes only the Linear key kind a person holds", () => {
+test("connects Linear by consent rather than by a key", () => {
   const linear = CREDENTIAL_PROVIDERS[CREDENTIAL_PROVIDER_ID.LINEAR];
 
   assert.equal(linear.displayName, "Linear");
-  assert.deepEqual(linear.environmentVariables, ["LINEAR_API_KEY"]);
-  // Luke reads the tracker as the user, with the key kind Linear issues to a
-  // person. An OAuth token names an application acting for a workspace, which
-  // is a different actor and would be refused where it matters least.
-  assert.equal(linear.keyFormat?.prefix, "lin_api_");
-  assert.equal(linear.keyFormat?.label, "Personal API key");
-  assert.match(linear.apiKeysUrl, /^https:\/\/linear\.app\/settings\//);
+  assert.equal(linear.connection, CREDENTIAL_CONNECTION.CONSENT);
+  // Nothing is pasted for Linear, so there is nothing for a launch
+  // environment to supply, no page to send anyone to, and no shape to refuse:
+  // what authorizes a read is granted on Linear's own consent page and
+  // withdrawn there or from the row.
+  assert.deepEqual(linear.environmentVariables, []);
+  assert.equal(linear.hint, undefined);
+  assert.equal(linear.apiKeysUrl, undefined);
+  assert.equal(linear.keyFormat, undefined);
 });
 
 test("holds the key Luke speaks through, apart from the agents he observes", () => {

--- a/apps/desktop/tests/linear-credentials.test.ts
+++ b/apps/desktop/tests/linear-credentials.test.ts
@@ -144,6 +144,18 @@ test("Linear refusing the renewal disconnects; a network that cannot answer does
   assert.equal(offline.state.grant?.refreshToken, "good-refresh");
 });
 
+test("a transient renewal failure can still use an access token until it lapses", async () => {
+  const store = grantStore({
+    accessToken: "nearly-lapsed-access",
+    refreshToken: "good-refresh",
+    expiresAt: NOW + 30_000,
+  });
+  const { credentials } = credentialsFor(store, () => jsonResponse({}, HTTP_STATUS.SERVER_ERROR));
+
+  assert.equal(await credentials.accessToken(), "nearly-lapsed-access");
+  assert.equal(store.state.forgets, 0);
+});
+
 test("a lapsed grant with nothing to renew it is let go", async () => {
   const store = grantStore({ accessToken: "stale-access", expiresAt: NOW - HOUR_MS });
   const { credentials, requests } = credentialsFor(store, () => renewed());
@@ -218,6 +230,44 @@ test("disconnecting while a refresh is in flight cannot restore the grant", asyn
 
   await disconnect;
   assert.equal(await access, undefined);
+  assert.equal(store.state.grant, undefined);
+  assert.equal(store.state.writes, 0);
+});
+
+test("a refresh cannot start while disconnect is revoking the grant", async () => {
+  const store = grantStore({
+    accessToken: "stale-access",
+    refreshToken: "current-refresh",
+    expiresAt: NOW - HOUR_MS,
+  });
+  let finishRevocation: ((response: Response) => void) | undefined;
+  const revocationResponse = new Promise<Response>((resolve) => {
+    finishRevocation = resolve;
+  });
+  const requests: RecordedRequest[] = [];
+  const credentials = new LinearCredentials({
+    readGrant: store.readGrant,
+    writeGrant: store.writeGrant,
+    forgetGrant: store.forgetGrant,
+    environment: ENVIRONMENT,
+    fetchImplementation: (async (input, init) => {
+      requests.push({
+        url: String(input),
+        authorization: new Headers(init?.headers).get("authorization"),
+        body: typeof init?.body === "string" ? init.body : undefined,
+      });
+      return revocationResponse;
+    }) as typeof globalThis.fetch,
+    now: () => NOW,
+  });
+
+  const disconnect = credentials.disconnect();
+  while (requests.length === 0) await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(await credentials.accessToken(), undefined);
+  assert.equal(requests.length, 1);
+  finishRevocation?.(jsonResponse({}, HTTP_STATUS.OK));
+  await disconnect;
   assert.equal(store.state.grant, undefined);
   assert.equal(store.state.writes, 0);
 });

--- a/apps/desktop/tests/linear-credentials.test.ts
+++ b/apps/desktop/tests/linear-credentials.test.ts
@@ -164,7 +164,9 @@ test("disconnecting revokes at Linear and forgets here either way", async () => 
   const { credentials, requests } = credentialsFor(store, () => jsonResponse({}, HTTP_STATUS.OK));
 
   await credentials.disconnect();
-  assert.equal(requests[0]?.authorization, "Bearer current-access");
+  const revokeBody = new URLSearchParams(requests[0]?.body ?? "");
+  assert.equal(revokeBody.get("token"), "current-refresh");
+  assert.equal(revokeBody.get("token_type_hint"), "refresh_token");
   assert.equal(store.state.grant, undefined);
 
   const stubborn = grantStore({

--- a/apps/desktop/tests/linear-credentials.test.ts
+++ b/apps/desktop/tests/linear-credentials.test.ts
@@ -180,3 +180,42 @@ test("disconnecting revokes at Linear and forgets here either way", async () => 
   // revocation is no reason to keep the grant on this machine.
   assert.equal(stubborn.state.grant, undefined);
 });
+
+test("disconnecting while a refresh is in flight cannot restore the grant", async () => {
+  const store = grantStore({
+    accessToken: "stale-access",
+    refreshToken: "current-refresh",
+    expiresAt: NOW - HOUR_MS,
+  });
+  let finishRefresh: ((response: Response) => void) | undefined;
+  const refreshResponse = new Promise<Response>((resolve) => {
+    finishRefresh = resolve;
+  });
+  const requests: RecordedRequest[] = [];
+  const credentials = new LinearCredentials({
+    readGrant: store.readGrant,
+    writeGrant: store.writeGrant,
+    forgetGrant: store.forgetGrant,
+    environment: ENVIRONMENT,
+    fetchImplementation: (async (input, init) => {
+      requests.push({
+        url: String(input),
+        authorization: new Headers(init?.headers).get("authorization"),
+        body: typeof init?.body === "string" ? init.body : undefined,
+      });
+      return requests.length === 1 ? refreshResponse : jsonResponse({}, HTTP_STATUS.OK);
+    }) as typeof globalThis.fetch,
+    now: () => NOW,
+  });
+
+  const access = credentials.accessToken();
+  while (requests.length === 0) await new Promise((resolve) => setImmediate(resolve));
+  const disconnect = credentials.disconnect();
+  while (requests.length < 2) await new Promise((resolve) => setImmediate(resolve));
+  finishRefresh?.(renewed());
+
+  await disconnect;
+  assert.equal(await access, undefined);
+  assert.equal(store.state.grant, undefined);
+  assert.equal(store.state.writes, 0);
+});

--- a/apps/desktop/tests/linear-credentials.test.ts
+++ b/apps/desktop/tests/linear-credentials.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { LinearCredentials } from "../src/linear-credentials";
+import type { LinearGrant } from "../src/linear-oauth";
+import {
+  HTTP_STATUS,
+  jsonResponse,
+  type RecordedRequest,
+  recordingFetch,
+} from "./support/http-fake";
+
+const NOW = 1_760_000_000_000;
+const HOUR_MS = 3_600_000;
+
+const ENVIRONMENT: NodeJS.ProcessEnv = { LINEAR_OAUTH_CLIENT_ID: "6f0a2c1e9b3d4f5a" };
+
+/** A store of one grant, standing in for the settings store's own. */
+function grantStore(initial: LinearGrant | undefined) {
+  const state = { grant: initial, writes: 0, forgets: 0 };
+  return {
+    state,
+    readGrant: async () => state.grant,
+    writeGrant: async (grant: LinearGrant) => {
+      state.grant = grant;
+      state.writes += 1;
+    },
+    forgetGrant: async () => {
+      state.grant = undefined;
+      state.forgets += 1;
+    },
+  };
+}
+
+function credentialsFor(
+  store: ReturnType<typeof grantStore>,
+  respond: (request: RecordedRequest) => Response,
+): { credentials: LinearCredentials; requests: RecordedRequest[] } {
+  const { fetch: fakeFetch, requests } = recordingFetch(respond);
+  const credentials = new LinearCredentials({
+    readGrant: store.readGrant,
+    writeGrant: store.writeGrant,
+    forgetGrant: store.forgetGrant,
+    environment: ENVIRONMENT,
+    fetchImplementation: fakeFetch as typeof globalThis.fetch,
+    now: () => NOW,
+  });
+  return { credentials, requests };
+}
+
+function renewed(): Response {
+  return jsonResponse({
+    access_token: "renewed-access",
+    refresh_token: "renewed-refresh",
+    expires_in: 86_400,
+  });
+}
+
+test("nothing connected sends nothing", async () => {
+  const store = grantStore(undefined);
+  const { credentials, requests } = credentialsFor(store, () => renewed());
+
+  assert.equal(await credentials.accessToken(), undefined);
+  assert.deepEqual(requests, []);
+});
+
+test("a token still good is spent rather than renewed", async () => {
+  const store = grantStore({
+    accessToken: "current-access",
+    refreshToken: "current-refresh",
+    expiresAt: NOW + HOUR_MS,
+  });
+  const { credentials, requests } = credentialsFor(store, () => renewed());
+
+  assert.equal(await credentials.accessToken(), "current-access");
+  // A rotation is a cost: spending one for a token that had an hour left
+  // would burn the grant's only refresh token for nothing.
+  assert.deepEqual(requests, []);
+});
+
+test("a lapsed token is renewed, and the renewal is stored before it is used", async () => {
+  const store = grantStore({
+    accessToken: "stale-access",
+    refreshToken: "current-refresh",
+    expiresAt: NOW - HOUR_MS,
+  });
+  const { credentials, requests } = credentialsFor(store, () => renewed());
+
+  assert.equal(await credentials.accessToken(), "renewed-access");
+  assert.equal(requests.length, 1);
+  assert.equal(new URLSearchParams(requests[0]?.body ?? "").get("grant_type"), "refresh_token");
+  // Linear consumed the old refresh token, so a renewal that reached nobody's
+  // disk would be a grant the developer has to make again.
+  assert.equal(store.state.writes, 1);
+  assert.deepEqual(store.state.grant, {
+    accessToken: "renewed-access",
+    refreshToken: "renewed-refresh",
+    expiresAt: NOW + 86_400_000,
+  });
+});
+
+test("two asks at once spend one rotation between them", async () => {
+  const store = grantStore({
+    accessToken: "stale-access",
+    refreshToken: "current-refresh",
+    expiresAt: NOW - HOUR_MS,
+  });
+  const { credentials, requests } = credentialsFor(store, () => renewed());
+
+  // An observation pass and a spoken act can both find the token lapsed. The
+  // loser of a race would spend a refresh token Linear had already rotated
+  // away, and Linear reads that as a withdrawn grant.
+  const [first, second] = await Promise.all([credentials.accessToken(), credentials.accessToken()]);
+  assert.equal(first, "renewed-access");
+  assert.equal(second, "renewed-access");
+  assert.equal(requests.length, 1);
+});
+
+test("Linear refusing the renewal disconnects; a network that cannot answer does not", async () => {
+  const refused = grantStore({
+    accessToken: "stale-access",
+    refreshToken: "dead-refresh",
+    expiresAt: NOW - HOUR_MS,
+  });
+  const { credentials: refusedCredentials } = credentialsFor(refused, () =>
+    jsonResponse({ error: "invalid_grant" }, HTTP_STATUS.UNAUTHORIZED),
+  );
+  assert.equal(await refusedCredentials.accessToken(), undefined);
+  // The row goes back to offering a connection, which is the only thing that
+  // helps: no number of further passes will revive a withdrawn grant.
+  assert.equal(refused.state.forgets, 1);
+  assert.equal(refused.state.grant, undefined);
+
+  const offline = grantStore({
+    accessToken: "stale-access",
+    refreshToken: "good-refresh",
+    expiresAt: NOW - HOUR_MS,
+  });
+  const { credentials: offlineCredentials } = credentialsFor(offline, () =>
+    jsonResponse({}, HTTP_STATUS.SERVER_ERROR),
+  );
+  assert.equal(await offlineCredentials.accessToken(), undefined);
+  // The grant is exactly where it was: a closed laptop is not a disconnection.
+  assert.equal(offline.state.forgets, 0);
+  assert.equal(offline.state.grant?.refreshToken, "good-refresh");
+});
+
+test("a lapsed grant with nothing to renew it is let go", async () => {
+  const store = grantStore({ accessToken: "stale-access", expiresAt: NOW - HOUR_MS });
+  const { credentials, requests } = credentialsFor(store, () => renewed());
+
+  assert.equal(await credentials.accessToken(), undefined);
+  // Nothing to send, so nothing is sent; the row says connect rather than
+  // sitting there failing every pass.
+  assert.deepEqual(requests, []);
+  assert.equal(store.state.forgets, 1);
+});
+
+test("disconnecting revokes at Linear and forgets here either way", async () => {
+  const store = grantStore({
+    accessToken: "current-access",
+    refreshToken: "current-refresh",
+    expiresAt: NOW + HOUR_MS,
+  });
+  const { credentials, requests } = credentialsFor(store, () => jsonResponse({}, HTTP_STATUS.OK));
+
+  await credentials.disconnect();
+  assert.equal(requests[0]?.authorization, "Bearer current-access");
+  assert.equal(store.state.grant, undefined);
+
+  const stubborn = grantStore({
+    accessToken: "current-access",
+    refreshToken: "current-refresh",
+    expiresAt: NOW + HOUR_MS,
+  });
+  const { credentials: stubbornCredentials } = credentialsFor(stubborn, () => {
+    throw new Error("offline");
+  });
+  await stubbornCredentials.disconnect();
+  // The developer asked to disconnect. A network that cannot carry the
+  // revocation is no reason to keep the grant on this machine.
+  assert.equal(stubborn.state.grant, undefined);
+});

--- a/apps/desktop/tests/linear-oauth.test.ts
+++ b/apps/desktop/tests/linear-oauth.test.ts
@@ -1,0 +1,286 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import http from "node:http";
+import test from "node:test";
+import {
+  LINEAR_AUTHORIZATION_URL,
+  LINEAR_REDIRECT_URIS,
+  LINEAR_REFRESH_STATUS,
+  LINEAR_REVOKE_URL,
+  LINEAR_SCOPES,
+  LINEAR_TOKEN_URL,
+  LinearSignIn,
+  linearSignInConfig,
+  refreshLinearGrant,
+  revokeLinearGrant,
+} from "../src/linear-oauth";
+import {
+  HTTP_STATUS,
+  jsonResponse,
+  type RecordedRequest,
+  recordingFetch,
+} from "./support/http-fake";
+
+const CLIENT_ID = "6f0a2c1e9b3d4f5a";
+const NOW = 1_760_000_000_000;
+
+function environment(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return { LINEAR_OAUTH_CLIENT_ID: CLIENT_ID, ...overrides };
+}
+
+/**
+ * Follows the redirect the browser would make, code and all. On its own
+ * connection every time: the loopback binds one of a few registered ports
+ * rather than an ephemeral one, so a pooled socket left over from an earlier
+ * flow would be reused against a server that has since closed.
+ */
+async function answerCallback(
+  authorizationUrl: string,
+  parameters: Record<string, string>,
+): Promise<{ status: number; body: string }> {
+  const redirectUri = new URL(authorizationUrl).searchParams.get("redirect_uri");
+  assert.ok(redirectUri, "the authorization URL names the loopback redirect");
+  const callback = new URL(redirectUri);
+  for (const [name, value] of Object.entries(parameters)) {
+    callback.searchParams.set(name, value);
+  }
+  return new Promise((resolve, reject) => {
+    const request = http.get({ ...urlParts(callback), agent: false }, (response) => {
+      let body = "";
+      response.setEncoding("utf8");
+      response.on("data", (chunk: string) => {
+        body += chunk;
+      });
+      response.on("end", () => resolve({ status: response.statusCode ?? 0, body }));
+    });
+    request.on("error", reject);
+  });
+}
+
+function urlParts(url: URL): { host: string; port: string; path: string } {
+  return { host: url.hostname, port: url.port, path: `${url.pathname}${url.search}` };
+}
+
+function grantResponse(overrides: Record<string, unknown> = {}): Response {
+  return jsonResponse({
+    access_token: "lin_oauth_access",
+    refresh_token: "lin_oauth_refresh",
+    expires_in: 86_400,
+    token_type: "Bearer",
+    scope: LINEAR_SCOPES,
+    ...overrides,
+  });
+}
+
+function signInWith(respond: (request: RecordedRequest) => Response): {
+  signIn: LinearSignIn;
+  opened: string[];
+  requests: RecordedRequest[];
+} {
+  const opened: string[] = [];
+  const { fetch: fakeFetch, requests } = recordingFetch(respond);
+  const signIn = new LinearSignIn({
+    openExternal: (url) => opened.push(url),
+    environment: environment(),
+    fetchImplementation: fakeFetch as typeof globalThis.fetch,
+    now: () => NOW,
+  });
+  return { signIn, opened, requests };
+}
+
+/** The browser is opened synchronously with the flow; wait for the loopback. */
+async function openedUrl(opened: readonly string[]): Promise<URL> {
+  while (opened.length === 0) await new Promise((resolve) => setImmediate(resolve));
+  return new URL(opened[0] as string);
+}
+
+test("the sign-in carries its registration, and the environment may replace it", () => {
+  // Linear needs no secret under PKCE, so the registered client id is the
+  // whole registration and it stands in source: a bare checkout offers the
+  // sign-in rather than hiding a row it could not open.
+  const registered = linearSignInConfig({});
+  assert.match(registered?.clientId ?? "", /^[0-9a-f]{32}$/);
+
+  // The variable stands in for development against another registration.
+  assert.deepEqual(linearSignInConfig(environment()), { clientId: CLIENT_ID });
+
+  // A build whose registration was stripped offers nothing, which is what
+  // keeps the row from being drawn refusing.
+  assert.equal(
+    linearSignInConfig({ LINEAR_OAUTH_CLIENT_ID: "   " })?.clientId,
+    registered?.clientId,
+  );
+});
+
+test("runs Linear's documented public-client flow end to end", async () => {
+  const { signIn, opened, requests } = signInWith(() => grantResponse());
+
+  const pending = signIn.signIn();
+  const authorization = await openedUrl(opened);
+
+  // The page is Linear's own, asking for the two scopes the two acts need,
+  // with PKCE and as the developer rather than as an app of Luke's own.
+  assert.equal(authorization.origin + authorization.pathname, LINEAR_AUTHORIZATION_URL);
+  assert.equal(authorization.searchParams.get("client_id"), CLIENT_ID);
+  assert.equal(authorization.searchParams.get("scope"), LINEAR_SCOPES);
+  assert.equal(authorization.searchParams.get("response_type"), "code");
+  assert.equal(authorization.searchParams.get("code_challenge_method"), "S256");
+  assert.equal(authorization.searchParams.get("actor"), "user");
+  assert.equal(authorization.searchParams.get("prompt"), "consent");
+  // Linear matches the redirect against what the application registered, so
+  // the flow may only ever use an address that registration carries.
+  const redirectUri = authorization.searchParams.get("redirect_uri") ?? "";
+  assert.ok(
+    LINEAR_REDIRECT_URIS.includes(redirectUri),
+    `${redirectUri} is one of the registered redirects`,
+  );
+
+  const state = authorization.searchParams.get("state") ?? "";
+  const answered = await answerCallback(opened[0] as string, { state, code: "auth-code" });
+  assert.equal(answered.status, 200);
+  assert.match(answered.body, /connected/i);
+
+  assert.deepEqual(await pending, {
+    accessToken: "lin_oauth_access",
+    refreshToken: "lin_oauth_refresh",
+    expiresAt: NOW + 86_400_000,
+  });
+
+  // The exchange went to Linear's token endpoint carrying the verifier whose
+  // hash the authorization page was shown — the PKCE contract, checkable here.
+  assert.equal(requests.length, 1);
+  const exchange = requests[0] as RecordedRequest;
+  assert.equal(exchange.url, LINEAR_TOKEN_URL);
+  const body = new URLSearchParams(exchange.body ?? "");
+  assert.equal(body.get("grant_type"), "authorization_code");
+  assert.equal(body.get("code"), "auth-code");
+  assert.equal(body.get("redirect_uri"), redirectUri);
+  // No secret travels: PKCE is what protects a public client, and a secret
+  // every installed copy carried would protect nothing the verifier does not.
+  assert.equal(body.get("client_secret"), null);
+  const verifier = body.get("code_verifier") ?? "";
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  assert.equal(authorization.searchParams.get("code_challenge"), challenge);
+});
+
+test("a redirect with the wrong state is refused without ending the wait", async () => {
+  const { signIn, opened } = signInWith(() => grantResponse());
+
+  const pending = signIn.signIn();
+  const authorization = await openedUrl(opened);
+  const state = authorization.searchParams.get("state") ?? "";
+
+  // A stray or forged request is answered 404 and the flow keeps waiting.
+  const forged = await answerCallback(opened[0] as string, { state: "not-it", code: "stolen" });
+  assert.equal(forged.status, 404);
+
+  const genuine = await answerCallback(opened[0] as string, { state, code: "auth-code" });
+  assert.equal(genuine.status, 200);
+  assert.equal("accessToken" in (await pending), true);
+});
+
+test("a refusal from Linear is an answer, not an exchange", async () => {
+  const { signIn, opened, requests } = signInWith(() => grantResponse());
+
+  const pending = signIn.signIn();
+  const authorization = await openedUrl(opened);
+  const state = authorization.searchParams.get("state") ?? "";
+
+  const answered = await answerCallback(opened[0] as string, { state, error: "access_denied" });
+  assert.equal(answered.status, 200);
+  assert.match(answered.body, /didn’t complete/i);
+  assert.deepEqual(await pending, { reason: "Linear did not grant access." });
+  assert.deepEqual(requests, []);
+});
+
+test("an abandoned sign-in times out instead of listening forever", async () => {
+  const signIn = new LinearSignIn({
+    openExternal: () => undefined,
+    environment: environment(),
+    timeoutMs: 20,
+  });
+
+  const outcome = await signIn.signIn();
+  assert.ok("reason" in outcome && /timed out/i.test(outcome.reason));
+});
+
+test("one sign-in at a time", async () => {
+  const { signIn, opened } = signInWith(() => grantResponse());
+
+  const first = signIn.signIn();
+  await openedUrl(opened);
+  const second = await signIn.signIn();
+  assert.deepEqual(second, { reason: "A sign-in is already waiting in your browser." });
+
+  signIn.cancel();
+  assert.deepEqual(await first, { reason: "Sign-in was cancelled." });
+});
+
+test("a renewed grant carries forward the refresh token Linear left out", async () => {
+  // Linear rotates the refresh token when it is spent, but does not always
+  // repeat it. The one just spent is then the only one there is, so dropping
+  // it would leave a grant that could never be renewed again.
+  const { fetch: fakeFetch } = recordingFetch(() =>
+    grantResponse({ refresh_token: undefined, expires_in: 3_600 }),
+  );
+  const outcome = await refreshLinearGrant("spent-refresh", {
+    environment: environment(),
+    fetchImplementation: fakeFetch as typeof globalThis.fetch,
+    now: () => NOW,
+  });
+
+  assert.deepEqual(outcome, {
+    status: LINEAR_REFRESH_STATUS.RENEWED,
+    grant: {
+      accessToken: "lin_oauth_access",
+      refreshToken: "spent-refresh",
+      expiresAt: NOW + 3_600_000,
+    },
+  });
+});
+
+test("Linear saying no and Linear saying nothing are different answers", async () => {
+  const refused = await refreshLinearGrant("dead-refresh", {
+    environment: environment(),
+    fetchImplementation: recordingFetch(() =>
+      jsonResponse({ error: "invalid_grant" }, HTTP_STATUS.UNAUTHORIZED),
+    ).fetch as typeof globalThis.fetch,
+  });
+  assert.deepEqual(refused, { status: LINEAR_REFRESH_STATUS.REFUSED });
+
+  // Someone else's outage is not a withdrawn grant, and neither is a network
+  // that never answered: a developer must not be disconnected by either.
+  const faulted = await refreshLinearGrant("good-refresh", {
+    environment: environment(),
+    fetchImplementation: recordingFetch(() => jsonResponse({}, HTTP_STATUS.SERVER_ERROR))
+      .fetch as typeof globalThis.fetch,
+  });
+  assert.deepEqual(faulted, { status: LINEAR_REFRESH_STATUS.UNREACHABLE });
+
+  const unreachable = await refreshLinearGrant("good-refresh", {
+    environment: environment(),
+    fetchImplementation: (() => Promise.reject(new Error("offline"))) as typeof globalThis.fetch,
+  });
+  assert.deepEqual(unreachable, { status: LINEAR_REFRESH_STATUS.UNREACHABLE });
+});
+
+test("revoking posts the grant to Linear and never throws", async () => {
+  const { fetch: fakeFetch, requests } = recordingFetch(() => jsonResponse({}, HTTP_STATUS.OK));
+  assert.equal(
+    await revokeLinearGrant("lin_oauth_access", fakeFetch as typeof globalThis.fetch),
+    true,
+  );
+
+  const revoke = requests[0] as RecordedRequest;
+  assert.equal(revoke.url, LINEAR_REVOKE_URL);
+  assert.equal(revoke.authorization, "Bearer lin_oauth_access");
+  assert.equal(new URLSearchParams(revoke.body ?? "").get("token"), "lin_oauth_access");
+
+  // Best effort by design: the developer asked to disconnect, and a network
+  // that cannot carry the message is no reason to keep the grant here.
+  assert.equal(
+    await revokeLinearGrant("lin_oauth_access", (() =>
+      Promise.reject(new Error("offline"))) as typeof globalThis.fetch),
+    false,
+  );
+});

--- a/apps/desktop/tests/linear-oauth.test.ts
+++ b/apps/desktop/tests/linear-oauth.test.ts
@@ -179,6 +179,41 @@ test("a redirect with the wrong state is refused without ending the wait", async
   assert.equal("accessToken" in (await pending), true);
 });
 
+test("the first valid callback exclusively claims the one-time code exchange", async () => {
+  let finishExchange: ((response: Response) => void) | undefined;
+  const exchangeResponse = new Promise<Response>((resolve) => {
+    finishExchange = resolve;
+  });
+  const opened: string[] = [];
+  const requests: RecordedRequest[] = [];
+  const signIn = new LinearSignIn({
+    openExternal: (url) => opened.push(url),
+    environment: environment(),
+    fetchImplementation: (async (input, init) => {
+      requests.push({
+        url: String(input),
+        authorization: new Headers(init?.headers).get("authorization"),
+        body: typeof init?.body === "string" ? init.body : undefined,
+      });
+      return exchangeResponse;
+    }) as typeof globalThis.fetch,
+    now: () => NOW,
+  });
+
+  const pending = signIn.signIn();
+  const authorization = await openedUrl(opened);
+  const state = authorization.searchParams.get("state") ?? "";
+  const first = answerCallback(opened[0] as string, { state, code: "auth-code" });
+  while (requests.length === 0) await new Promise((resolve) => setImmediate(resolve));
+  const duplicate = await answerCallback(opened[0] as string, { state, code: "auth-code" });
+  assert.equal(duplicate.status, 404);
+  assert.equal(requests.length, 1);
+
+  finishExchange?.(grantResponse());
+  assert.equal((await first).status, 200);
+  assert.equal("accessToken" in (await pending), true);
+});
+
 test("a refusal from Linear is an answer, not an exchange", async () => {
   const { signIn, opened, requests } = signInWith(() => grantResponse());
 
@@ -216,10 +251,7 @@ test("one sign-in at a time", async () => {
   assert.deepEqual(await first, { reason: "Sign-in was cancelled." });
 });
 
-test("a renewed grant carries forward the refresh token Linear left out", async () => {
-  // Linear rotates the refresh token when it is spent, but does not always
-  // repeat it. The one just spent is then the only one there is, so dropping
-  // it would leave a grant that could never be renewed again.
+test("a refresh answer without its rotated refresh token is not persisted", async () => {
   const { fetch: fakeFetch } = recordingFetch(() =>
     grantResponse({ refresh_token: undefined, expires_in: 3_600 }),
   );
@@ -229,14 +261,7 @@ test("a renewed grant carries forward the refresh token Linear left out", async 
     now: () => NOW,
   });
 
-  assert.deepEqual(outcome, {
-    status: LINEAR_REFRESH_STATUS.RENEWED,
-    grant: {
-      accessToken: "lin_oauth_access",
-      refreshToken: "spent-refresh",
-      expiresAt: NOW + 3_600_000,
-    },
-  });
+  assert.deepEqual(outcome, { status: LINEAR_REFRESH_STATUS.UNREACHABLE });
 });
 
 test("Linear saying no and Linear saying nothing are different answers", async () => {
@@ -262,6 +287,22 @@ test("Linear saying no and Linear saying nothing are different answers", async (
     fetchImplementation: (() => Promise.reject(new Error("offline"))) as typeof globalThis.fetch,
   });
   assert.deepEqual(unreachable, { status: LINEAR_REFRESH_STATUS.UNREACHABLE });
+
+  for (const status of [408, HTTP_STATUS.TOO_MANY_REQUESTS]) {
+    const transient = await refreshLinearGrant("good-refresh", {
+      environment: environment(),
+      fetchImplementation: recordingFetch(() => jsonResponse({ error: "try_again" }, status))
+        .fetch as typeof globalThis.fetch,
+    });
+    assert.deepEqual(transient, { status: LINEAR_REFRESH_STATUS.UNREACHABLE });
+  }
+
+  const malformed = await refreshLinearGrant("good-refresh", {
+    environment: environment(),
+    fetchImplementation: recordingFetch(() => jsonResponse({ expires_in: 86_400 }))
+      .fetch as typeof globalThis.fetch,
+  });
+  assert.deepEqual(malformed, { status: LINEAR_REFRESH_STATUS.UNREACHABLE });
 });
 
 test("revoking posts the grant to Linear and never throws", async () => {

--- a/apps/desktop/tests/linear-oauth.test.ts
+++ b/apps/desktop/tests/linear-oauth.test.ts
@@ -239,6 +239,32 @@ test("an abandoned sign-in times out instead of listening forever", async () => 
   assert.ok("reason" in outcome && /timed out/i.test(outcome.reason));
 });
 
+test("a claimed callback is allowed to finish after the waiting timeout", async () => {
+  let finishExchange: ((response: Response) => void) | undefined;
+  const exchangeResponse = new Promise<Response>((resolve) => {
+    finishExchange = resolve;
+  });
+  const opened: string[] = [];
+  const signIn = new LinearSignIn({
+    openExternal: (url) => opened.push(url),
+    environment: environment(),
+    fetchImplementation: (() => exchangeResponse) as typeof globalThis.fetch,
+    now: () => NOW,
+    timeoutMs: 20,
+  });
+
+  const pending = signIn.signIn();
+  const authorization = await openedUrl(opened);
+  const state = authorization.searchParams.get("state") ?? "";
+  const callback = answerCallback(opened[0] as string, { state, code: "auth-code" });
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  signIn.cancel();
+  finishExchange?.(grantResponse());
+
+  assert.equal((await callback).status, 200);
+  assert.equal("accessToken" in (await pending), true);
+});
+
 test("one sign-in at a time", async () => {
   const { signIn, opened } = signInWith(() => grantResponse());
 
@@ -308,19 +334,25 @@ test("Linear saying no and Linear saying nothing are different answers", async (
 test("revoking posts the grant to Linear and never throws", async () => {
   const { fetch: fakeFetch, requests } = recordingFetch(() => jsonResponse({}, HTTP_STATUS.OK));
   assert.equal(
-    await revokeLinearGrant("lin_oauth_access", fakeFetch as typeof globalThis.fetch),
+    await revokeLinearGrant(
+      "lin_oauth_refresh",
+      "refresh_token",
+      fakeFetch as typeof globalThis.fetch,
+    ),
     true,
   );
 
   const revoke = requests[0] as RecordedRequest;
   assert.equal(revoke.url, LINEAR_REVOKE_URL);
-  assert.equal(revoke.authorization, "Bearer lin_oauth_access");
-  assert.equal(new URLSearchParams(revoke.body ?? "").get("token"), "lin_oauth_access");
+  assert.equal(revoke.authorization, undefined);
+  const revokeBody = new URLSearchParams(revoke.body ?? "");
+  assert.equal(revokeBody.get("token"), "lin_oauth_refresh");
+  assert.equal(revokeBody.get("token_type_hint"), "refresh_token");
 
   // Best effort by design: the developer asked to disconnect, and a network
   // that cannot carry the message is no reason to keep the grant here.
   assert.equal(
-    await revokeLinearGrant("lin_oauth_access", (() =>
+    await revokeLinearGrant("lin_oauth_refresh", "refresh_token", (() =>
       Promise.reject(new Error("offline"))) as typeof globalThis.fetch),
     false,
   );

--- a/apps/desktop/tests/linear-tracker.test.ts
+++ b/apps/desktop/tests/linear-tracker.test.ts
@@ -23,7 +23,7 @@ function graphqlDocument(request: RecordedRequest | undefined): {
 
 function trackerWith(
   payloads: readonly unknown[],
-  options: { apiKey?: string; status?: number } = {},
+  options: { accessToken?: string; status?: number } = {},
 ): { tracker: LinearIssueTracker; requests: RecordedRequest[] } {
   let call = 0;
   const { fetch, requests } = recordingFetch(() => {
@@ -32,7 +32,7 @@ function trackerWith(
     return jsonResponse(payload, options.status ?? HTTP_STATUS.OK);
   });
   const tracker = new LinearIssueTracker({
-    readApiKey: async () => options.apiKey,
+    readAccessToken: async () => options.accessToken,
     now: () => OBSERVED_AT,
     fetchImplementation: fetch as typeof fetch,
   });
@@ -71,7 +71,7 @@ function assignedIssuesPayload() {
   };
 }
 
-test("no key means no request and a tracker that is not connected", async () => {
+test("no token means no request and a tracker that is not connected", async () => {
   const { tracker, requests } = trackerWith([assignedIssuesPayload()]);
 
   assert.equal(await tracker.observe(), undefined);
@@ -89,7 +89,7 @@ test("no key means no request and a tracker that is not connected", async () => 
 
 test("observing reads the assigned issues and advertises the rest of the workflow", async () => {
   const { tracker, requests } = trackerWith([assignedIssuesPayload()], {
-    apiKey: "lin_api_test",
+    accessToken: "linear-access-token",
   });
 
   const observations = await tracker.observe();
@@ -111,8 +111,9 @@ test("observing reads the assigned issues and advertises the rest of the workflo
     canComment: true,
   });
 
-  // The key authorizes as itself: a personal API key takes no Bearer prefix.
-  assert.equal(requests[0]?.authorization, "lin_api_test");
+  // What the consent page granted is an OAuth access token, sent under the
+  // scheme every OAuth token is sent with.
+  assert.equal(requests[0]?.authorization, "Bearer linear-access-token");
   // An observation pass sends the one read document and nothing else.
   assert.equal(requests.length, 1);
   assert.match(graphqlDocument(requests[0]).query, /^query AssignedIssues/);
@@ -120,18 +121,21 @@ test("observing reads the assigned issues and advertises the rest of the workflo
 });
 
 test("a failed or malformed read is an error, never a quieter roster", async () => {
-  const failed = trackerWith([{}], { apiKey: "lin_api_test", status: HTTP_STATUS.SERVER_ERROR });
+  const failed = trackerWith([{}], {
+    accessToken: "linear-access-token",
+    status: HTTP_STATUS.SERVER_ERROR,
+  });
   await assert.rejects(() => failed.tracker.observe());
 
   const errored = trackerWith([{ errors: [{ message: "rate limited" }] }], {
-    apiKey: "lin_api_test",
+    accessToken: "linear-access-token",
   });
   await assert.rejects(() => errored.tracker.observe());
 });
 
 test("moving an issue posts the one documented write and reads its answer", async () => {
   const { tracker, requests } = trackerWith([{ data: { issueUpdate: { success: true } } }], {
-    apiKey: "lin_api_test",
+    accessToken: "linear-access-token",
   });
 
   const result = await tracker.execute({
@@ -151,7 +155,7 @@ test("moving an issue posts the one documented write and reads its answer", asyn
 
 test("a comment posts the other documented write", async () => {
   const { tracker, requests } = trackerWith([{ data: { commentCreate: { success: true } } }], {
-    apiKey: "lin_api_test",
+    accessToken: "linear-access-token",
   });
 
   const result = await tracker.execute({
@@ -180,13 +184,13 @@ test("a write Linear turns down is a rejection with a reason, never a throw", as
     { data: { issueUpdate: { success: false } } },
     { data: {} },
   ]) {
-    const { tracker } = trackerWith([payload], { apiKey: "lin_api_test" });
+    const { tracker } = trackerWith([payload], { accessToken: "linear-access-token" });
     const result = await tracker.execute(setState);
     assert.equal(result.status, TRACKER_ACTION_RESULT_STATUS.REJECTED);
     assert.ok("reason" in result && result.reason.length > 0);
   }
 
-  const failed = trackerWith([{}], { apiKey: "lin_api_test", status: 401 });
+  const failed = trackerWith([{}], { accessToken: "linear-access-token", status: 401 });
   const result = await failed.tracker.execute(setState);
   assert.equal(result.status, TRACKER_ACTION_RESULT_STATUS.REJECTED);
 });

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -45,6 +45,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     duckOtherMedia: true,
     quietDuringMeetings: true,
     calendarSignInAvailable: false,
+    linearSignInAvailable: false,
     calendarAccounts: [],
     showOnAllDisplays: false,
     formFactor: PANEL_FORM_FACTOR.BUBBLE,
@@ -182,13 +183,24 @@ test("the facts say what is connected, never what connects it", () => {
   assert.match(rendered, /Conductor \(connected\)/);
   assert.match(rendered, /Copilot \(not connected\)/);
   assert.match(rendered, /Devin \(connected from the environment\)/);
-  // The tracker stands in its own fact, the way it stands in its own section.
-  assert.match(rendered, /Linear \(not connected\)/);
   assert.match(rendered, /Integrations/);
-  // A build without the calendar sign-in draws no calendar row, so the guide
-  // says nothing about one — a capability the guide describes is one Luke
-  // will claim to have.
+  // A build carrying neither registration draws neither integration row, so
+  // the guide says nothing about either — a capability the guide describes is
+  // one Luke will claim to have.
   assert.doesNotMatch(rendered, /Google Calendar/);
+  assert.doesNotMatch(rendered, /Linear/);
+
+  // A build carrying the Linear registration describes the tracker: that it
+  // is signed into rather than typed into, and what connecting it allows.
+  const tracker = JSON.stringify(
+    buildLukeGuide(guideInput({ settings: settings({ linearSignInAvailable: true }) })).facts,
+  );
+  assert.match(tracker, /Linear \(not connected\)/);
+  assert.match(tracker, /signing in with Linear/);
+  assert.match(tracker, /move one to another state or comment on it/);
+  // Nothing in the guide may send anyone to a key page for Linear: there is
+  // no key, and describing one would be describing a row that is not drawn.
+  assert.doesNotMatch(tracker, /Linear[^"]*API key/);
 
   // A build carrying the sign-in describes the calendar: what it reads —
   // times, never titles — and how it connects.

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -21,6 +21,7 @@ import {
   VOICE_SOURCE,
 } from "../src/shared/contracts";
 import {
+  CREDENTIAL_CONNECTION,
   CREDENTIAL_PROVIDER_ID,
   type CredentialProvider,
   type CredentialProviderId,
@@ -52,6 +53,7 @@ const TEST_ENVIRONMENT_VARIABLE = {
 const FIRST_CLOUD_PROVIDER: CredentialProvider = {
   id: "first-cloud" as CredentialProviderId,
   displayName: "First Cloud",
+  connection: CREDENTIAL_CONNECTION.KEY,
   hint: "Create a key in First Cloud.",
   environmentVariables: [TEST_ENVIRONMENT_VARIABLE.FIRST_CLOUD_API_KEY],
 };
@@ -59,6 +61,7 @@ const FIRST_CLOUD_PROVIDER: CredentialProvider = {
 const SECOND_CLOUD_PROVIDER: CredentialProvider = {
   id: "second-cloud" as CredentialProviderId,
   displayName: "Second Cloud",
+  connection: CREDENTIAL_CONNECTION.KEY,
   hint: "Create a key in Second Cloud.",
   environmentVariables: [TEST_ENVIRONMENT_VARIABLE.SECOND_CLOUD_API_KEY],
 };
@@ -67,6 +70,7 @@ const SECOND_CLOUD_PROVIDER: CredentialProvider = {
 const THIRD_CLOUD_PROVIDER: CredentialProvider = {
   id: "third-cloud" as CredentialProviderId,
   displayName: "Third Cloud",
+  connection: CREDENTIAL_CONNECTION.KEY,
   hint: "Create a key in Third Cloud.",
   environmentVariables: [TEST_ENVIRONMENT_VARIABLE.THIRD_CLOUD_API_KEY],
   keyFormat: {
@@ -75,7 +79,21 @@ const THIRD_CLOUD_PROVIDER: CredentialProvider = {
   },
 };
 
-const TEST_PROVIDERS = [FIRST_CLOUD_PROVIDER, SECOND_CLOUD_PROVIDER, THIRD_CLOUD_PROVIDER];
+/** Connected on the provider's own consent page rather than by a pasted key. */
+const CONSENT_PROVIDER: CredentialProvider = {
+  id: "consent-service" as CredentialProviderId,
+  displayName: "Consent Service",
+  connection: CREDENTIAL_CONNECTION.CONSENT,
+  environmentVariables: [],
+};
+
+const TEST_PROVIDERS = [
+  FIRST_CLOUD_PROVIDER,
+  SECOND_CLOUD_PROVIDER,
+  THIRD_CLOUD_PROVIDER,
+  CONSENT_PROVIDER,
+];
+const CONSENT_SERVICE = CONSENT_PROVIDER.id;
 const FIRST_CLOUD = FIRST_CLOUD_PROVIDER.id;
 const SECOND_CLOUD = SECOND_CLOUD_PROVIDER.id;
 const THIRD_CLOUD = THIRD_CLOUD_PROVIDER.id;
@@ -1815,4 +1833,81 @@ test("pasting a key back while parked on the allowance is still choosing it", as
   // read as a key that failed to take.
   await store.setApiKey(CREDENTIAL_PROVIDER_ID.OPENAI, "sk-developers-own");
   assert.equal(await store.readVoiceSource(), VOICE_SOURCE.KEY);
+});
+
+test("a grant is stored encrypted, and read back only in the main process", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory, { providers: TEST_PROVIDERS });
+
+  const { settings } = await store.setGrant(CONSENT_SERVICE, {
+    accessToken: "granted-access",
+    refreshToken: "granted-refresh",
+    expiresAt: 1_760_000_000_000,
+  });
+
+  // The row says connected the way every other credential's row does.
+  assert.equal(settings.credentialSources[CONSENT_SERVICE], CREDENTIAL_SOURCE.ENCRYPTED_FILE);
+  // Neither token is anywhere in what a renderer receives.
+  const rendered = JSON.stringify(settings);
+  assert.doesNotMatch(rendered, /granted-access/);
+  assert.doesNotMatch(rendered, /granted-refresh/);
+
+  // Both tokens travel under one ciphertext; only the expiry stays readable,
+  // which is what lets a pass skip a refresh it does not need.
+  const file = JSON.parse(await readSettingsFile(directory));
+  assert.equal(file.grants[CONSENT_SERVICE].expiresAt, 1_760_000_000_000);
+  assert.doesNotMatch(file.grants[CONSENT_SERVICE].tokenCipher, /granted-access/);
+
+  assert.deepEqual(await store.readGrant(CONSENT_SERVICE), {
+    accessToken: "granted-access",
+    refreshToken: "granted-refresh",
+    expiresAt: 1_760_000_000_000,
+  });
+
+  // A stored grant outlives the process that made it.
+  const reopened = storeIn(directory, { providers: TEST_PROVIDERS });
+  assert.equal((await reopened.readGrant(CONSENT_SERVICE))?.accessToken, "granted-access");
+});
+
+test("clearing a grant leaves nothing behind, and keys alone", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory, { providers: TEST_PROVIDERS });
+  await store.setApiKey(FIRST_CLOUD, "first-cloud-key");
+  await store.setGrant(CONSENT_SERVICE, { accessToken: "granted-access", expiresAt: 1 });
+
+  const { settings } = await store.clearGrant(CONSENT_SERVICE);
+  assert.equal(settings.credentialSources[CONSENT_SERVICE], CREDENTIAL_SOURCE.NONE);
+  assert.equal(await store.readGrant(CONSENT_SERVICE), undefined);
+  // Disconnecting one service never disturbs another's credential.
+  assert.equal(await store.readApiKey(FIRST_CLOUD), "first-cloud-key");
+  assert.doesNotMatch(await readSettingsFile(directory), /granted-access/);
+});
+
+test("a key left by a build that asked for one is dropped, never carried", async (t) => {
+  const directory = await temporaryDirectory(t);
+  // What an installation upgraded from a build that pasted this service's key
+  // would hold: a credential this build can never send anywhere.
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({
+      version: 2,
+      apiKeys: {
+        [CONSENT_SERVICE]: sealed("stale-pasted-key"),
+        [FIRST_CLOUD]: sealed("first-cloud-key"),
+      },
+    }),
+    "utf8",
+  );
+  const store = storeIn(directory, { providers: TEST_PROVIDERS });
+
+  const settings = await store.snapshot();
+  assert.equal(settings.credentialSources[CONSENT_SERVICE], CREDENTIAL_SOURCE.NONE);
+  assert.equal(await store.readApiKey(CONSENT_SERVICE), undefined);
+
+  // A provider this build does know, and knows takes no key, has its key let
+  // go on the next write — a credential Luke will not use is not one to keep.
+  await store.setApiKey(FIRST_CLOUD, "replaced-key");
+  const file = JSON.parse(await readSettingsFile(directory));
+  assert.equal(file.apiKeys[CONSENT_SERVICE], undefined);
+  assert.ok(file.apiKeys[FIRST_CLOUD]);
 });

--- a/apps/desktop/tests/settings-views.test.ts
+++ b/apps/desktop/tests/settings-views.test.ts
@@ -37,7 +37,7 @@ test("every stand-down comes back to the page its own row is drawn on", () => {
 
   // The Google Calendar block stands under Integrations, so a cancelled or
   // refused sign-in returns to the row that can try it again.
-  assert.equal(standDownReturnPage({ kind: PANEL_STAND_DOWN.CALENDAR }), SETTINGS_VIEW.CONNECTIONS);
+  assert.equal(standDownReturnPage({ kind: PANEL_STAND_DOWN.CONSENT }), SETTINGS_VIEW.CONNECTIONS);
 
   // A key follows its own provider's row, wherever that is drawn — which is
   // the one stand-down whose answer is not fixed.
@@ -53,7 +53,7 @@ test("every stand-down comes back to the page its own row is drawn on", () => {
   // remembered page cannot stand in for three.
   const pages = new Set([
     standDownReturnPage({ kind: PANEL_STAND_DOWN.FEEDBACK }),
-    standDownReturnPage({ kind: PANEL_STAND_DOWN.CALENDAR }),
+    standDownReturnPage({ kind: PANEL_STAND_DOWN.CONSENT }),
   ]);
   assert.equal(pages.size, 2, "a note and a calendar sign-in do not share a page");
 });


### PR DESCRIPTION
## Problem

Linear currently uses a pasted personal API key. That makes the issue tracker behave unlike the other consent-based integrations, asks developers to handle a credential manually, and cannot renew or revoke access as a grant.

## Fix

- Replace the Linear API-key field with Linear's public-client OAuth flow: PKCE, a registered loopback callback, no client secret, and `read,write` scopes.
- Store access and refresh tokens encrypted in the existing settings store, renew rotated grants before use, and revoke the grant when the developer disconnects.
- Keep transient refresh failures from disconnecting the user, serialize concurrent refreshes, prevent an in-flight refresh from restoring a disconnected grant, and let only the first valid loopback callback spend the authorization code.
- Keep the renderer sandboxed: codes, tokens, and authorization URLs remain in the main process; the renderer receives settings snapshots only.
- Update Luke's settings surface, self-guide, privacy disclosure, README, and tests for consent-based Linear connections.

## Verification

- `./scripts/verify.sh` passes after the final lifecycle fixes.
- 40 harness tests, 236 sidecar-core tests, 1,073 desktop tests, and 40 web tests pass with zero failures.
- Typecheck, desktop/web builds, native helper builds, macOS packaging, repository contract checks, and generated-artifact checks pass.
- Inspected the expanded deterministic visual evidence; the surface is clean with no clipping or transparency leaks. All six evidence states were generated.
- Live Linear OAuth completion was not performed; it requires approving the registered OAuth application in a real Linear workspace.
- Physical-notch check: not performed.

## Review fixes

- A disconnect generation guard prevents a late refresh from writing the grant back.
- Only an explicit `invalid_grant` response deletes stored credentials; rate limits, timeouts, malformed responses, and service failures preserve them.
- A valid callback atomically claims the one-time code before its exchange begins.
- A refresh response missing Linear's required rotated refresh token is not persisted.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32197079743/artifacts/9346239636) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32197079743)

- Commit: `368f295ea7b0a916a3830a9c01e209bedaf07caf`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
