### PR TITLE
fix(desktop): hold the caption and chips under a resting pointer

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1767,21 +1767,23 @@ export function App(): React.JSX.Element {
    * nothing, so nothing dismissed before the hover began is ever resurrected.
    */
   const [stripHovered, setStripHovered] = useState(false);
-  const [stripHold, setStripHold] = useState<SpokenStripContent>();
   /** When the words now held first appeared, surviving the reply for the hold. */
   const heldCaptionShownAt = useRef<number | undefined>(undefined);
-  useEffect(() => {
-    setStripHold((held) =>
-      stripHoldNext({
-        hovered: stripHovered,
-        drawn:
-          liveCaptionTexts === undefined && !chipsDrawn
-            ? undefined
-            : { texts: liveCaptionTexts, isError: captionLiveIsError, chips: chipsDrawn },
-        held,
-      }),
-    );
-  }, [stripHovered, liveCaptionTexts, captionLiveIsError, chipsDrawn]);
+  // Derived in the render, never advanced after paint: the frame that brings
+  // a new reply's content composes the hold against that same content, so a
+  // held snapshot can never paint one frame beside live words it should have
+  // yielded to. The ref carries the previous frame's answer, the way
+  // `lastMentioned` carries the band's.
+  const stripHoldRef = useRef<SpokenStripContent | undefined>(undefined);
+  const stripHold = stripHoldNext({
+    hovered: stripHovered,
+    drawn:
+      liveCaptionTexts === undefined && !chipsDrawn
+        ? undefined
+        : { texts: liveCaptionTexts, isError: captionLiveIsError, chips: chipsDrawn },
+    held: stripHoldRef.current,
+  });
+  stripHoldRef.current = stripHold;
 
   /**
    * The strip's hoverable boxes, kept current for the window's move listener:

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -135,6 +135,7 @@ import {
 } from "./settings-views";
 import { useSignInFaceCycle } from "./sign-in-gate";
 import { SignInSlot } from "./sign-in-slot";
+import { pointOverStrip, type SpokenStripContent, stripHoldNext } from "./strip-hold";
 import { useBootstrapRacedChannel } from "./use-bootstrap-raced-channel";
 import { panelEntryOpen, usePanelEntry } from "./use-panel-entry";
 import { usePanelPresentation } from "./use-panel-presentation";
@@ -195,9 +196,20 @@ function captionSizeStyle(
   const scroll =
     readingElapsedMs === undefined ? overflow : pacedCaptionScroll(overflow, readingElapsedMs);
   return {
-    "--caption-size": `${Math.min(VOICE_CAPTION_MAX_HEIGHT - hintBand, textHeight + padding)}px`,
+    "--caption-size": `${captionBlockSize(textHeight, volumeHint, padding)}px`,
     "--caption-scroll": `${scroll}px`,
   } as CSSProperties;
+}
+
+/**
+ * The caption block's visible height — the `--caption-size` the clip ends the
+ * element at. The strip's hover test reads it too: the element's own box runs
+ * to the reserved maximum, and only this much of it is words rather than
+ * desktop.
+ */
+function captionBlockSize(textHeight: number, volumeHint: boolean, padding: number): number {
+  const hintBand = volumeHint ? VOLUME_HINT_BAND_HEIGHT : 0;
+  return Math.min(VOICE_CAPTION_MAX_HEIGHT - hintBand, textHeight + padding);
 }
 
 /**
@@ -1630,6 +1642,10 @@ export function App(): React.JSX.Element {
 
   const defaultWorkspaceProvider = (settings ?? bootstrap?.settings)?.defaultWorkspaceProvider;
   const workspaceProjectDefaults = (settings ?? bootstrap?.settings)?.workspaceProjectDefaults;
+  // The muted evidence run is the speaking run with the hint drawn over it: a
+  // capture has no system output to read, so the state is asked for directly.
+  const fixtureMuted = bootstrap?.profile === "muted";
+  const fixtureSpeaking = bootstrap?.profile === "speaking" || fixtureMuted;
   const {
     analyser,
     microphoneStatus,
@@ -1665,11 +1681,25 @@ export function App(): React.JSX.Element {
     voiceCaptions: settings?.voiceCaptions === true,
     voiceAvailable: settings?.voiceAvailable,
     outputSilent: outputSilent(outputAudio),
-    fixtureSpeaking: bootstrap?.profile === "speaking" || bootstrap?.profile === "muted",
+    fixtureSpeaking,
     capturingShortcut: () => shortcutCapture.current,
     openSession: openSessionAloud,
     carryAppAction,
   });
+
+  // A failed call is reported where its reply would have landed: on the
+  // caption strip, under the field or the key press that asked. It yields to
+  // live words, so it can never be drawn over a reply being spoken.
+  const voiceErrorNotice = voiceErrorToShow({
+    fixtureSpeaking,
+    voice: voiceTurn,
+    error: voiceError,
+  });
+  // What the caption block is being handed live this frame: Luke's words, or
+  // a failure borrowing their strip.
+  const liveCaptionTexts =
+    lukeCaptions ?? (voiceErrorNotice === undefined ? undefined : [voiceErrorNotice]);
+  const captionLiveIsError = lukeCaptions === undefined && voiceErrorNotice !== undefined;
 
   // The notices: the pressable faces of what the reply being spoken is about
   // — an announcement's one subject, or the several a conversation reply
@@ -1677,7 +1707,8 @@ export function App(): React.JSX.Element {
   // roster: a chat by its title, a whole workspace by name fronted by its
   // freshest chat, or a tracked issue by identifier or title. Derived, not
   // queued — the subjects arrive with the captions and die with the reply,
-  // so a chip can never lag the words or stand for news Luke is not saying —
+  // outliving it only under the strip hold's pointer, so a chip can never
+  // lag the words or stand for news Luke is not saying —
   // and each draws only for a session the roster still titles or an issue
   // the tracker still lists, because a press is a row press at one remove
   // and needs a row to stand for. A workspace chip wears the workspace's
@@ -1725,8 +1756,75 @@ export function App(): React.JSX.Element {
       }),
     ),
   ];
+  const chipsDrawn = spokenOf.length > 0;
+
+  /**
+   * The pointer's hold on the strip. The words and the chips leave with the
+   * reply that earned them, and a failure leaves on its own clock — but never
+   * out from under a pointer resting on them, which is someone mid-read or
+   * mid-press on a chip. The hold snapshots exactly what the strip was
+   * showing and keeps it drawn until the pointer moves away; it can start
+   * nothing, so nothing dismissed before the hover began is ever resurrected.
+   */
+  const [stripHovered, setStripHovered] = useState(false);
+  const [stripHold, setStripHold] = useState<SpokenStripContent>();
+  /** When the words now held first appeared, surviving the reply for the hold. */
+  const heldCaptionShownAt = useRef<number | undefined>(undefined);
+  useEffect(() => {
+    setStripHold((held) =>
+      stripHoldNext({
+        hovered: stripHovered,
+        drawn:
+          liveCaptionTexts === undefined && !chipsDrawn
+            ? undefined
+            : { texts: liveCaptionTexts, isError: captionLiveIsError, chips: chipsDrawn },
+        held,
+      }),
+    );
+  }, [stripHovered, liveCaptionTexts, captionLiveIsError, chipsDrawn]);
+
+  /**
+   * The strip's hoverable boxes, kept current for the window's move listener:
+   * the caption block's visible height — zero while no words are drawn, so an
+   * invisible block holds nothing — and whether the chip band is drawn, on
+   * the same terms. Refs rather than state, because the listener reads them
+   * at each move and re-subscribing per frame would be work for nobody.
+   */
+  const captionHoverHeight = useRef(0);
+  const noticeHoverable = useRef(false);
+  useEffect(() => {
+    // Forwarded moves arrive even while the window is click-through, which is
+    // what lets a pointer resting on words that take no pointer be seen here
+    // at all.
+    const handleMove = (event: MouseEvent) => {
+      const caption = captionElement.current;
+      const band = noticeBand.current;
+      setStripHovered(
+        pointOverStrip({
+          x: event.clientX,
+          y: event.clientY,
+          caption:
+            caption && captionHoverHeight.current > 0
+              ? {
+                  box: caption.getBoundingClientRect(),
+                  visibleHeight: captionHoverHeight.current,
+                }
+              : undefined,
+          band: band && noticeHoverable.current ? band.getBoundingClientRect() : undefined,
+        }),
+      );
+    };
+    const handleLeave = () => setStripHovered(false);
+    window.addEventListener("mousemove", handleMove, { passive: true });
+    document.documentElement.addEventListener("mouseleave", handleLeave);
+    return () => {
+      window.removeEventListener("mousemove", handleMove);
+      document.documentElement.removeEventListener("mouseleave", handleLeave);
+    };
+  }, []);
+
   const noticeShown =
-    spokenOf.length > 0 &&
+    (chipsDrawn || stripHold?.chips === true) &&
     (presentation === PANEL_PRESENTATION.CAPSULE ||
       presentation === PANEL_PRESENTATION.PEEK ||
       presentation === PANEL_PRESENTATION.PANEL);
@@ -2349,23 +2447,14 @@ export function App(): React.JSX.Element {
   const shownHotkey = voiceHotkeyToShow(bootstrap, voiceHotkey);
   const shownAskHotkey = askHotkeyChange ? askHotkeyChange.accelerator : bootstrap.askHotkey;
   const shownStopHotkey = stopHotkeyChange ? stopHotkeyChange.accelerator : bootstrap.stopHotkey;
-  // The muted evidence run is the speaking run with the hint drawn over it: a
-  // capture has no system output to read, so the state is asked for directly.
-  const fixtureMuted = bootstrap.profile === "muted";
-  const fixtureSpeaking = bootstrap.profile === "speaking" || fixtureMuted;
   const hasAudioSignal = fixtureSpeaking || analyser !== undefined;
   const outputIsSilent = outputSilent(outputAudio);
-  // A failed call is reported where its reply would have landed: on the
-  // caption strip, under the field or the key press that asked. It yields to
-  // live words, so it can never be drawn over a reply being spoken.
-  const voiceErrorNotice = voiceErrorToShow({
-    fixtureSpeaking,
-    voice: voiceTurn,
-    error: voiceError,
-  });
-  const captionTexts =
-    lukeCaptions ?? (voiceErrorNotice === undefined ? undefined : [voiceErrorNotice]);
-  const captionIsError = lukeCaptions === undefined && voiceErrorNotice !== undefined;
+  // Live words win; the held snapshot only ever finishes being read. A held
+  // caption is drawn exactly as it was, failure red included.
+  const heldCaptionTexts = liveCaptionTexts === undefined ? stripHold?.texts : undefined;
+  const captionTexts = liveCaptionTexts ?? heldCaptionTexts;
+  const captionIsError =
+    liveCaptionTexts !== undefined ? captionLiveIsError : stripHold?.isError === true;
   // Two responses spoken back-to-back stack as two captions: the settled one
   // above, the one still arriving below, in the always-mounted slot the lone
   // caption also uses.
@@ -2373,9 +2462,15 @@ export function App(): React.JSX.Element {
   const liveCaption = captionTexts?.at(-1);
   // How long the words on screen have been readable, or nothing while the
   // output is audible: the reading clock only paces words nobody can hear.
+  // The clock's start survives the reply for the hold's sake: a held silent
+  // caption keeps the lines where the reader had them rather than snapping
+  // its unread ones away the moment the clock's own state clears.
+  if (captionShownAt !== undefined) heldCaptionShownAt.current = captionShownAt;
+  const captionClockStart =
+    captionShownAt ?? (heldCaptionTexts === undefined ? undefined : heldCaptionShownAt.current);
   const captionReadingElapsed =
-    outputIsSilent && captionShownAt !== undefined
-      ? Math.max(0, readingNow - captionShownAt)
+    outputIsSilent && captionClockStart !== undefined
+      ? Math.max(0, readingNow - captionClockStart)
       : undefined;
   // The hint rides the caption it explains, and only over a silence the
   // helper actually reported. "Got it" quiets it for this stretch of silence
@@ -2385,6 +2480,12 @@ export function App(): React.JSX.Element {
     (outputIsSilent &&
       lukeCaptions !== undefined &&
       !volumeHintDismissed(hintDismissal, silenceStretch, Date.now()));
+  // What the hover test may match this frame, now that both are known.
+  captionHoverHeight.current =
+    captionTexts === undefined || captionTextHeight === undefined
+      ? 0
+      : captionBlockSize(captionTextHeight, volumeHint, captionPadding);
+  noticeHoverable.current = noticeShown;
   const panelOpen = presentation === PANEL_PRESENTATION.PANEL;
   const slotOpen = presentation === PANEL_PRESENTATION.SLOT;
   const feedbackOpen = presentation === PANEL_PRESENTATION.FEEDBACK;

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -820,7 +820,9 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
               "a dozen, a workspace's opening its most recent chat. A reply naming tracked " +
               "issues — by identifier like LUKE-123, or by whole title — draws their chips " +
               "on the same band, each opening its issue where the tracker keeps it. Past " +
-              "three rows the chips scroll in place, and each presses the same way. " +
+              "three rows the chips scroll in place, and each presses the same way. The " +
+              "chips and the captioned words leave when the reply ends, but never out from " +
+              "under the pointer: resting on them holds them until it moves away. " +
               "Always on while voice is available; the panel and the capsule count show the " +
               "same states either way." +
               // Only a build that offers the calendar may describe the quiet:

--- a/apps/desktop/src/renderer/strip-hold.ts
+++ b/apps/desktop/src/renderer/strip-hold.ts
@@ -1,0 +1,98 @@
+/**
+ * The decisions behind a pointer resting on the spoken strip — the caption
+ * block and the chip band drawn under the housing while Luke speaks — kept
+ * pure so they can be tested.
+ *
+ * The words and the chips normally leave with the reply that earned them, and
+ * a voice failure leaves on its own clock. But a pointer already over them is
+ * someone mid-read, or mid-press on a chip, and content that vanishes under a
+ * hand is worse than content that lingers: the hold keeps exactly what the
+ * strip was showing until the pointer moves away. It can start nothing — a
+ * pointer arriving over an empty strip finds nothing to hold — so nothing
+ * dismissed before the hover began is ever resurrected.
+ */
+
+/**
+ * What the strip is showing, snapshotted whole. The hold keeps a snapshot
+ * rather than reading each part's own last-drawn value, because the parts
+ * outlive each other separately: a reply that drew only chips must not hold
+ * an older reply's words, and one that drew only words must not hold chips
+ * nobody was shown.
+ */
+export interface SpokenStripContent {
+  /** The caption block's words, absent while only chips are drawn. */
+  texts: readonly string[] | undefined;
+  /** Whether the words are a failure borrowing the caption's strip. */
+  isError: boolean;
+  /** Whether the chip band is drawn. */
+  chips: boolean;
+}
+
+/**
+ * What the hold should be after this frame. Live content always wins — a new
+ * reply's words replace whatever was held — and the hold survives only from
+ * one drawn frame to the next under an unbroken hover: the moment the pointer
+ * leaves, the strip goes back to saying only what is live. A hold that would
+ * say the same thing keeps its identity, because the caller stores it as
+ * state and the live content's own identity churns per render: words rebuilt
+ * around an unchanged sentence must not read as a change.
+ */
+export function stripHoldNext(input: {
+  hovered: boolean;
+  drawn: SpokenStripContent | undefined;
+  held: SpokenStripContent | undefined;
+}): SpokenStripContent | undefined {
+  if (!input.hovered) return undefined;
+  const next = input.drawn ?? input.held;
+  return next !== undefined && input.held !== undefined && stripContentEquals(next, input.held)
+    ? input.held
+    : next;
+}
+
+function stripContentEquals(a: SpokenStripContent, b: SpokenStripContent): boolean {
+  if (a.isError !== b.isError || a.chips !== b.chips) return false;
+  if (a.texts === undefined || b.texts === undefined) return a.texts === b.texts;
+  return (
+    a.texts.length === b.texts.length && a.texts.every((text, index) => text === b.texts?.[index])
+  );
+}
+
+/** An element's box as the hover test reads it. */
+export interface StripBox {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+/**
+ * Whether the pointer is over the strip. The caption element's own box runs
+ * to the reserved maximum and a clip is what ends it at the words, so
+ * containment stops at the visible height rather than the box's edge — the
+ * remainder is desktop, and a pointer resting there is not resting on the
+ * words. Either box is offered only while its content is drawn; an invisible
+ * element still has a box, and it must hold nothing.
+ */
+export function pointOverStrip(input: {
+  x: number;
+  y: number;
+  caption: { box: StripBox; visibleHeight: number } | undefined;
+  band: StripBox | undefined;
+}): boolean {
+  if (input.caption) {
+    const { box, visibleHeight } = input.caption;
+    if (
+      input.x >= box.left &&
+      input.x <= box.right &&
+      input.y >= box.top &&
+      input.y <= box.top + visibleHeight
+    ) {
+      return true;
+    }
+  }
+  if (input.band) {
+    const { left, top, right, bottom } = input.band;
+    if (input.x >= left && input.x <= right && input.y >= top && input.y <= bottom) return true;
+  }
+  return false;
+}

--- a/apps/desktop/src/renderer/strip-hold.ts
+++ b/apps/desktop/src/renderer/strip-hold.ts
@@ -33,9 +33,10 @@ export interface SpokenStripContent {
  * reply's words replace whatever was held — and the hold survives only from
  * one drawn frame to the next under an unbroken hover: the moment the pointer
  * leaves, the strip goes back to saying only what is live. A hold that would
- * say the same thing keeps its identity, because the caller stores it as
- * state and the live content's own identity churns per render: words rebuilt
- * around an unchanged sentence must not read as a change.
+ * say the same thing keeps its identity, because the caller re-derives it
+ * every render against the last frame's answer and the live content's own
+ * identity churns per render: words rebuilt around an unchanged sentence must
+ * not read as a change.
  */
 export function stripHoldNext(input: {
   hovered: boolean;

--- a/apps/desktop/tests/strip-hold.test.ts
+++ b/apps/desktop/tests/strip-hold.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { pointOverStrip, type SpokenStripContent, stripHoldNext } from "../src/renderer/strip-hold";
+
+const WORDS: SpokenStripContent = {
+  texts: ["Bootstrap the desktop shell is finished."],
+  isError: false,
+  chips: true,
+};
+
+test("content leaves on its own terms while nobody is over it", () => {
+  // The hold exists for a pointer already resting on the strip; without one,
+  // the words and chips keep dying with the reply exactly as they always did.
+  assert.equal(stripHoldNext({ hovered: false, drawn: WORDS, held: undefined }), undefined);
+  assert.equal(stripHoldNext({ hovered: false, drawn: undefined, held: WORDS }), undefined);
+});
+
+test("a hovered strip holds exactly what it was showing", () => {
+  // Live content refreshes the hold while it lasts...
+  assert.equal(stripHoldNext({ hovered: true, drawn: WORDS, held: undefined }), WORDS);
+  // ...and the reply ending under the pointer leaves the snapshot standing.
+  assert.equal(stripHoldNext({ hovered: true, drawn: undefined, held: WORDS }), WORDS);
+});
+
+test("a hover that began after the dismissal resurrects nothing", () => {
+  // The hold can only finish being read: a pointer arriving over an empty
+  // strip finds nothing, however recently something was there.
+  assert.equal(stripHoldNext({ hovered: true, drawn: undefined, held: undefined }), undefined);
+});
+
+test("a new reply's content replaces whatever was held", () => {
+  const older: SpokenStripContent = { texts: ["An older reply."], isError: false, chips: false };
+  assert.equal(stripHoldNext({ hovered: true, drawn: WORDS, held: older }), WORDS);
+});
+
+test("an unchanged sentence keeps the hold's identity", () => {
+  // The caller stores the hold as state and the live content's identity
+  // churns per render: a rebuilt-but-equal snapshot returning as a new object
+  // would re-render an unchanged strip every frame the pointer rests on it.
+  const rebuilt: SpokenStripContent = { ...WORDS, texts: [...(WORDS.texts ?? [])] };
+  assert.equal(stripHoldNext({ hovered: true, drawn: rebuilt, held: WORDS }), WORDS);
+  const chipless: SpokenStripContent = { texts: undefined, isError: false, chips: true };
+  assert.equal(stripHoldNext({ hovered: true, drawn: { ...chipless }, held: chipless }), chipless);
+});
+
+test("the caption counts only to its visible height", () => {
+  // The element's box runs to the reserved maximum and the clip ends it at
+  // the words, so the remainder is desktop: resting there holds nothing.
+  const caption = { box: { left: 0, top: 0, right: 100, bottom: 70 }, visibleHeight: 28 };
+  assert.equal(pointOverStrip({ x: 50, y: 20, caption, band: undefined }), true);
+  assert.equal(pointOverStrip({ x: 50, y: 40, caption, band: undefined }), false);
+});
+
+test("the band counts whole, and absent boxes never match", () => {
+  const band = { left: 0, top: 30, right: 100, bottom: 60 };
+  assert.equal(pointOverStrip({ x: 50, y: 45, caption: undefined, band }), true);
+  assert.equal(pointOverStrip({ x: 50, y: 65, caption: undefined, band }), false);
+  // An undrawn element still has a box; the caller withholds it, and a strip
+  // offering neither can never read as hovered.
+  assert.equal(pointOverStrip({ x: 50, y: 45, caption: undefined, band: undefined }), false);
+});


### PR DESCRIPTION
## What

While Luke speaks, his captioned words and the pressable session chips are drawn under the housing — and they left the moment the reply ended, including out from under a pointer that was mid-read on the words or mid-press on a chip. A voice failure borrowing the caption strip left the same way on its own 12-second clock. A pointer resting on the strip now holds exactly what it was showing until the pointer moves away.

## Why

Content that vanishes under a hand is worse than content that lingers: a chip disappearing between hover and click makes the press land on nothing, and a caption leaving mid-sentence makes the reader chase it. The hold is deliberately narrow — a new pure module (`strip-hold.ts`) snapshots what the strip is showing and keeps the snapshot only across an unbroken hover, so live words always win, a hover that began after the dismissal resurrects nothing, and a reply that drew only chips can never hold an older reply's words. Hover is read from the window's forwarded mouse moves (the caption takes no pointer by design), with the caption's box trimmed to its clip-visible height so desktop below the words holds nothing. The reading clock's start survives the reply on the same terms, so a held silent caption keeps its lines where the reader had them. The guide's Announcements fact now describes the hold, so Luke neither denies nor misdescribes it.

## Testing

- `./scripts/check.sh` passes (sidecar-core 236, desktop 1059, web 40, hosted 40) — 7 of the desktop tests are new, covering the hold's lifecycle and the hover geometry.
- Same caveat as #250/#253: authored in a Linux sandbox, so the macOS visual pass is CI's evidence run. The capture profiles drive no pointer, so the fixture evidence should be unchanged; a physical-notch check was not performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/e8fff4b5-2df1-43c6-981c-ca7feb46a071)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32195161941/artifacts/9345611129) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32195161941)

- Commit: `e619b2c6bf544ebb6b1f4bf62cf6a92dde81cb93`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
