### PR TITLE
feat(desktop): count the badge by the state its colour names

### DIFF
--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -238,7 +238,7 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "pressing count among the sessions the panel lists — the ones still live or recently " +
         "settled, not every conversation on disk: how many need the developer, else how many " +
         "are working, else how many settled — wearing that state's colour, and the peek's " +
-        "caption names the state and any work still running behind it; hovering it peeks, " +
+        "caption names the state in words; hovering it peeks, " +
         "pressing it opens the panel, and Escape closes what is open. " +
         "Resting the pointer on the face itself earns one trick — most often flying off the strip " +
         "and swooping back — and another only after the pointer leaves and returns; asking the " +

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -234,10 +234,12 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
     {
       label: "What Luke is",
       detail:
-        "A macOS sidecar living beside the notch. The capsule beside the housing counts the " +
-        "sessions the panel lists — the ones still live or recently settled, not every " +
-        "conversation on disk; hovering it peeks, pressing it opens the panel, and Escape " +
-        "closes what is open. " +
+        "A macOS sidecar living beside the notch. The number beside the housing is the most " +
+        "pressing count among the sessions the panel lists — the ones still live or recently " +
+        "settled, not every conversation on disk: how many need the developer, else how many " +
+        "are working, else how many settled — wearing that state's colour, and the peek's " +
+        "caption names the state and any work still running behind it; hovering it peeks, " +
+        "pressing it opens the panel, and Escape closes what is open. " +
         "Resting the pointer on the face itself earns one trick — most often flying off the strip " +
         "and swooping back — and another only after the pointer leaves and returns; asking the " +
         "system for reduced motion stills the tricks.",

--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -11,7 +11,13 @@ import {
 } from "./luke-face-mood";
 import { PANEL_PRESENTATION, type PanelPresentation } from "./panel-state";
 import { ProviderMark } from "./provider-marks";
-import { type ProviderTally, type SessionTally, tallyCaption, tallySummary } from "./session-model";
+import {
+  type ProviderTally,
+  type SessionTally,
+  tallyCaption,
+  tallySummary,
+  tallyValue,
+} from "./session-model";
 import {
   LEAVING_ATTRIBUTE,
   useRoster,
@@ -363,7 +369,7 @@ export function NotchWings({
             aria-label={accountGated ? "Sign in" : tallySummary(tally)}
           >
             <span className="count-value" aria-hidden="true" ref={countValueElement}>
-              {accountGated ? "Sign in" : tally.total}
+              {accountGated ? "Sign in" : tallyValue(tally)}
             </span>
             <span className="count-caption" aria-hidden="true" ref={countCaptionElement}>
               {/* No caption while signed out: the two words are the label

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -799,10 +799,7 @@ export function tallyValue(tally: SessionTally): number {
 export function tallySummary(tally: SessionTally): string {
   if (tally.total === 0) return "No sessions tracked";
   if (tally.attention > 0) {
-    const needing = `${tally.attention} ${
-      tally.attention === 1 ? "session needs" : "sessions need"
-    } you`;
-    return tally.working > 0 ? `${needing}, ${tally.working} working` : needing;
+    return `${tally.attention} ${tally.attention === 1 ? "session needs" : "sessions need"} you`;
   }
   if (tally.working > 0) {
     return `${tally.working} ${tally.working === 1 ? "session" : "sessions"} working`;
@@ -835,18 +832,13 @@ export function observedAgoLabel(observedAt: number, now: number): string {
 
 /**
  * The caption beside the count once the panel has room for it. The badge's
- * number is the count of the state its colour names, so the caption's first
- * words say which state that is — never a number of their own, which would
- * stand two numerals with different denominators side by side. Only the
- * second fact behind the separator names its number, because it is a second
- * count: "2 need you · 3 working" reads as two counts because it is two.
+ * number is the count of the state its colour names, so the caption is only
+ * that state's words — never a number of its own, which would stand two
+ * numerals with different denominators side by side.
  */
 export function tallyCaption(tally: SessionTally): string {
   if (tally.total === 0) return "none tracked";
-  if (tally.attention > 0) {
-    const needing = tally.attention === 1 ? "needs you" : "need you";
-    return tally.working > 0 ? `${needing} · ${tally.working} working` : needing;
-  }
+  if (tally.attention > 0) return tally.attention === 1 ? "needs you" : "need you";
   if (tally.working > 0) return "working";
   if (tally.complete > 0) return "complete";
   return "tracked";

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -773,15 +773,44 @@ function dominantUrgency(counts: {
   return SESSION_URGENCY.UNKNOWN;
 }
 
+/**
+ * The number the badge draws: the count of the state its colour names, so the
+ * numeral and the tint state one fact. A "12" that meant "12 tracked" while
+ * its colour meant "something needs you" made the reader hold two channels
+ * apart; here an attention-coloured 2 is 2 sessions needing you. The total
+ * only stands in when nothing is live enough to colour, because "how many
+ * need me" and "how many are working" are the questions the badge exists to
+ * answer, and the total answers neither.
+ */
+export function tallyValue(tally: SessionTally): number {
+  switch (tally.urgency) {
+    case SESSION_URGENCY.ATTENTION:
+      return tally.attention;
+    case SESSION_URGENCY.WORKING:
+      return tally.working;
+    case SESSION_URGENCY.COMPLETE:
+      return tally.complete;
+    default:
+      return tally.total;
+  }
+}
+
 /** One sentence that reads correctly for a screen reader in either mode. */
 export function tallySummary(tally: SessionTally): string {
   if (tally.total === 0) return "No sessions tracked";
-  const sessionWord = tally.total === 1 ? "session" : "sessions";
   if (tally.attention > 0) {
-    return `${tally.total} ${sessionWord} tracked, ${tally.attention} needing you`;
+    const needing = `${tally.attention} ${
+      tally.attention === 1 ? "session needs" : "sessions need"
+    } you`;
+    return tally.working > 0 ? `${needing}, ${tally.working} working` : needing;
   }
-  if (tally.working > 0) return `${tally.total} ${sessionWord} tracked, ${tally.working} working`;
-  return `${tally.total} ${sessionWord} tracked`;
+  if (tally.working > 0) {
+    return `${tally.working} ${tally.working === 1 ? "session" : "sessions"} working`;
+  }
+  if (tally.complete > 0) {
+    return `${tally.complete} ${tally.complete === 1 ? "session" : "sessions"} complete`;
+  }
+  return `${tally.total} ${tally.total === 1 ? "session" : "sessions"} tracked`;
 }
 
 /**
@@ -805,16 +834,20 @@ export function observedAgoLabel(observedAt: number, now: number): string {
 }
 
 /**
- * The caption beside the count once the panel has room for it. The badge shows
- * how many sessions are tracked, so the caption has to name its own number:
- * "4 · 1 needs you" rather than "4 · needs you".
+ * The caption beside the count once the panel has room for it. The badge's
+ * number is the count of the state its colour names, so the caption's first
+ * words say which state that is — never a number of their own, which would
+ * stand two numerals with different denominators side by side. Only the
+ * second fact behind the separator names its number, because it is a second
+ * count: "2 need you · 3 working" reads as two counts because it is two.
  */
 export function tallyCaption(tally: SessionTally): string {
   if (tally.total === 0) return "none tracked";
   if (tally.attention > 0) {
-    return `${tally.attention} ${tally.attention === 1 ? "needs" : "need"} you`;
+    const needing = tally.attention === 1 ? "needs you" : "need you";
+    return tally.working > 0 ? `${needing} · ${tally.working} working` : needing;
   }
-  if (tally.working > 0) return `${tally.working} working`;
-  if (tally.complete > 0) return `${tally.complete} complete`;
+  if (tally.working > 0) return "working";
+  if (tally.complete > 0) return "complete";
   return "tracked";
 }

--- a/apps/desktop/tests/session-model.test.ts
+++ b/apps/desktop/tests/session-model.test.ts
@@ -26,6 +26,7 @@ import {
   sessionTally,
   tallyCaption,
   tallySummary,
+  tallyValue,
   workspaceTrayActions,
 } from "../src/renderer/session-model";
 import type { AppBootstrap } from "../src/shared/contracts";
@@ -312,15 +313,42 @@ test("the badge urgency follows the most urgent session", () => {
   assert.equal(empty.urgency, SESSION_URGENCY.UNKNOWN);
 });
 
-test("the caption names its own number so the count is never misread", () => {
+test("the badge number counts the state its colour names", () => {
+  // The fixture holds 1 attention, 3 working, 1 complete, and 1 idle session:
+  // the badge says 1 in the attention colour, never a 6 posing as urgent.
+  const attention = sessionTally(displaySessions(bootstrap(true), []));
+  const working = sessionTally(
+    displaySessions(bootstrap(false), [
+      liveSession(CODEX_PROVIDER, "a", SESSION_STATUS.WORKING),
+      liveSession(CODEX_PROVIDER, "b", SESSION_STATUS.WORKING),
+    ]),
+  );
+  const complete = sessionTally(
+    displaySessions(bootstrap(false), [liveSession(CODEX_PROVIDER, "a", SESSION_STATUS.COMPLETE)]),
+  );
+
+  assert.equal(tallyValue(attention), 1);
+  assert.equal(tallyValue(working), 2);
+  assert.equal(tallyValue(complete), 1);
+  assert.equal(tallyValue(sessionTally([])), 0);
+});
+
+test("the caption names the badge's state and counts the work behind it", () => {
   const tally = sessionTally(displaySessions(bootstrap(true), []));
 
-  assert.equal(tallyCaption(tally), "1 needs you");
-  assert.equal(tallySummary(tally), "6 sessions tracked, 1 needing you");
-  assert.equal(tallyCaption({ ...tally, attention: 2 }), "2 need you");
-  assert.equal(tallyCaption({ ...tally, attention: 0, working: 3 }), "3 working");
-  assert.equal(tallyCaption({ ...tally, attention: 0, working: 0 }), "1 complete");
+  assert.equal(tallyCaption(tally), "needs you · 3 working");
+  assert.equal(tallySummary(tally), "1 session needs you, 3 working");
+  assert.equal(tallyCaption({ ...tally, attention: 2 }), "need you · 3 working");
+  assert.equal(tallyCaption({ ...tally, working: 0 }), "needs you");
+  assert.equal(tallyCaption({ ...tally, attention: 0, working: 3 }), "working");
+  assert.equal(tallySummary({ ...tally, attention: 0, working: 3 }), "3 sessions working");
+  assert.equal(tallyCaption({ ...tally, attention: 0, working: 0 }), "complete");
+  assert.equal(tallySummary({ ...tally, attention: 0, working: 0 }), "1 session complete");
   assert.equal(tallyCaption({ ...tally, attention: 0, working: 0, complete: 0 }), "tracked");
+  assert.equal(
+    tallySummary({ ...tally, attention: 0, working: 0, complete: 0 }),
+    "6 sessions tracked",
+  );
   assert.equal(tallyCaption(sessionTally([])), "none tracked");
   assert.equal(tallySummary(sessionTally([])), "No sessions tracked");
 });

--- a/apps/desktop/tests/session-model.test.ts
+++ b/apps/desktop/tests/session-model.test.ts
@@ -333,13 +333,12 @@ test("the badge number counts the state its colour names", () => {
   assert.equal(tallyValue(sessionTally([])), 0);
 });
 
-test("the caption names the badge's state and counts the work behind it", () => {
+test("the caption is the badge state's own words, never a second number", () => {
   const tally = sessionTally(displaySessions(bootstrap(true), []));
 
-  assert.equal(tallyCaption(tally), "needs you · 3 working");
-  assert.equal(tallySummary(tally), "1 session needs you, 3 working");
-  assert.equal(tallyCaption({ ...tally, attention: 2 }), "need you · 3 working");
-  assert.equal(tallyCaption({ ...tally, working: 0 }), "needs you");
+  assert.equal(tallyCaption(tally), "needs you");
+  assert.equal(tallySummary(tally), "1 session needs you");
+  assert.equal(tallyCaption({ ...tally, attention: 2 }), "need you");
   assert.equal(tallyCaption({ ...tally, attention: 0, working: 3 }), "working");
   assert.equal(tallySummary({ ...tally, attention: 0, working: 3 }), "3 sessions working");
   assert.equal(tallyCaption({ ...tally, attention: 0, working: 0 }), "complete");


### PR DESCRIPTION
## What

The notch badge no longer draws the total tracked sessions. Its number is now the count of the state its colour names — an attention-orange **1** is 1 session needing you, a working-blue **3** is 3 sessions working — and the peek's caption is that state's own words: **1 NEEDS YOU**. The total only stands in when nothing is live enough to colour. The screen-reader summary follows the same shape, and the guide's "What Luke is" fact teaches the new meaning.

## Why

User feedback: the numbers in the top right were confusing, and the original question — how many sessions are working, how many need me — went unanswered. The prominent number was the total, which mostly counts dormant rows, and the numeral said inventory while the tint said urgency — two channels the reader had to hold apart. Making the number mean what its colour says collapses the channels into one fact, and the caption carries no second numeral, so nothing on the badge competes with it.

## Testing

- `./scripts/verify.sh` passes (check.sh all green; evidence PNGs written).
- Visual evidence inspected: the peek and expanded shots read "1 NEEDS YOU" with the 1 in attention orange, and the compact capsule shows the orange 1 alone.
- Physical-notch check: not performed (authored in an agent session; CI's evidence run is linked below and the fixture screenshots were eyeballed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32202361726/artifacts/9347975509) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32202361726)

- Commit: `7483f8cef88909f358a2b032c9fca40e72a1f3f9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
