### PR TITLE
fix(desktop): isolate ad-hoc Keychain storage

### DIFF
--- a/apps/desktop/src/app-identity.ts
+++ b/apps/desktop/src/app-identity.ts
@@ -1,8 +1,8 @@
 /**
- * Which Luke a process is: the released app, or a development run standing in
- * for it. The two carry different code signatures — a release is signed with
- * the Developer ID identity, while `electron .` runs under the Electron dev
- * binary's own signature and a locally packaged app is signed ad-hoc — and
+ * Which Luke a process is: the released app, an unpackaged development run, or
+ * a locally packaged test build. Each carries a different code signature — a
+ * release is signed with the Developer ID identity, `electron .` runs under
+ * the Electron dev binary's own signature, and a local package is ad-hoc — and
  * macOS binds a Keychain item to the signature of the program that created
  * it. A differently signed program reading the same item is treated as an
  * intruder: the login-keychain password dialog appears, twice for a plain
@@ -13,9 +13,9 @@
  *
  * The name decides both: Electron derives the state directory and the
  * `<name> Safe Storage` Keychain entry from the app's name, so answering to
- * a different name is the whole separation. Only a build packaged and signed
- * for release answers to the product name; every other run — unpackaged, or
- * packaged without the release identity — answers to the development name.
+ * a different name is the whole separation. A build packaged and signed for
+ * release answers to the product name, `electron .` answers to the development
+ * name, and an ad-hoc package answers to the test name.
  */
 
 export const RELEASE_APP_NAME = "Luke";
@@ -26,6 +26,7 @@ export const RELEASE_APP_NAME = "Luke";
  * instance's single-instance lock; the app-identity test holds them together.
  */
 export const DEVELOPMENT_APP_NAME = `${RELEASE_APP_NAME} Dev`;
+export const AD_HOC_APP_NAME = `${RELEASE_APP_NAME} Test`;
 
 export interface AppIdentityContext {
   /** Whether this process runs from a packaged bundle rather than `electron .`. */
@@ -41,7 +42,8 @@ export interface AppIdentityContext {
  * prevent.
  */
 export function resolveAppName({ packaged, developerIdSigned }: AppIdentityContext): string {
-  return packaged && developerIdSigned ? RELEASE_APP_NAME : DEVELOPMENT_APP_NAME;
+  if (!packaged) return DEVELOPMENT_APP_NAME;
+  return developerIdSigned ? RELEASE_APP_NAME : AD_HOC_APP_NAME;
 }
 
 /**

--- a/apps/desktop/tests/app-identity.test.ts
+++ b/apps/desktop/tests/app-identity.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
 import test from "node:test";
 import {
+  AD_HOC_APP_NAME,
   buildCarriesDeveloperIdSigning,
   DEVELOPMENT_APP_NAME,
   RELEASE_APP_NAME,
@@ -12,10 +14,8 @@ test("only a packaged Developer ID build answers to the product name", () => {
   assert.equal(resolveAppName({ packaged: true, developerIdSigned: true }), RELEASE_APP_NAME);
 });
 
-test("a packaged build without the release identity answers to the development name", () => {
-  // An ad-hoc signature changes with every build, so sharing the release's
-  // Keychain entry would poison it for the released app.
-  assert.equal(resolveAppName({ packaged: true, developerIdSigned: false }), DEVELOPMENT_APP_NAME);
+test("an ad-hoc package is isolated from unpackaged development credentials", () => {
+  assert.equal(resolveAppName({ packaged: true, developerIdSigned: false }), AD_HOC_APP_NAME);
 });
 
 test("an unpackaged run answers to the development name whatever it was built for", () => {
@@ -43,6 +43,17 @@ test("the names hold to the manifest and to the shell derivation", async () => {
   // scripts/lib/workspace.sh derives the development instance's lock directory
   // as "<product name> Dev"; this is the pin that keeps the two together.
   assert.equal(DEVELOPMENT_APP_NAME, `${productName} Dev`);
+  assert.equal(AD_HOC_APP_NAME, `${productName} Test`);
+  const shellNames = execFileSync(
+    "bash",
+    ["-c", "source scripts/lib/workspace.sh; sidecar_app_names"],
+    { cwd: new URL("../../..", import.meta.url), encoding: "utf8" },
+  );
+  assert.deepEqual(shellNames.trim().split("\n"), [
+    DEVELOPMENT_APP_NAME,
+    AD_HOC_APP_NAME,
+    RELEASE_APP_NAME,
+  ]);
 });
 
 test("main.ts applies the identity before the lock that lives under it", async () => {

--- a/scripts/lib/workspace.sh
+++ b/scripts/lib/workspace.sh
@@ -56,11 +56,12 @@ sidecar_wait_for_exit() {
 # worktree: the lock is keyed on the app name, which every checkout shares.
 #
 # The app chooses its own name at launch — the product name for a Developer ID
-# release, and "<product name> Dev" for every development run, so the two never
-# share a Keychain entry (see apps/desktop/src/app-identity.ts). Each name keeps
-# a lock of its own, so a caller replacing "the running instance" asks about
-# both. The product name is still derived the way Electron derives its default,
-# from the manifest: `productName` when it sets one, the package name otherwise.
+# release, "<product name> Dev" for an unpackaged run, and "<product name> Test"
+# for an ad-hoc package, so differently signed builds never share a Keychain
+# entry (see apps/desktop/src/app-identity.ts). Each name keeps a lock of its own,
+# so a caller replacing "the running instance" asks about all three. The product
+# name is still derived the way Electron derives its default, from the manifest:
+# `productName` when it sets one, the package name otherwise.
 sidecar_app_names() {
     local app_name
     if ! app_name=$(cd "$SIDECAR_DESKTOP_APP_ROOT" &&
@@ -68,7 +69,7 @@ sidecar_app_names() {
         printf 'error: could not read the desktop app name\n' >&2
         return 1
     fi
-    printf '%s Dev\n%s\n' "$app_name" "$app_name"
+    printf '%s Dev\n%s Test\n%s\n' "$app_name" "$app_name" "$app_name"
 }
 
 sidecar_app_lock_holder_pid() {
@@ -99,8 +100,8 @@ sidecar_app_lock_holder_pid() {
 }
 
 # Stopping a holder has to wait for it to exit, because the lock is released
-# as that process goes away rather than when it is signalled. Development and
-# release instances hold separate locks, so both are stopped: a launch means
+# as that process goes away rather than when it is signalled. Development, test,
+# and release instances hold separate locks, so all are stopped: a launch means
 # "this build owns the screen now", whichever build was there before.
 sidecar_stop_running_app() {
     local app_names


### PR DESCRIPTION
## Summary

- Give unpackaged development, ad-hoc packaged tests, and Developer ID releases separate Electron identities and Keychain storage.
- Keep cross-worktree launch replacement aware of all three identities.
- Cover the full packaged/signing truth table and assert the shell launcher derives the same ordered names.

## Test coverage

- `resolveAppName` covers all four packaged/signing combinations.
- The regression test executes `sidecar_app_names` and asserts `Luke Dev`, `Luke Test`, then `Luke`.
- Coverage audit found no remaining gaps for the changed behavior.

## Pre-landing review

No issues found. Scope audit found the change complete and limited to app identity, its regression test, and launcher lock discovery.

## Verification

- `./scripts/verify.sh`
- 1,055 desktop tests passed.
- macOS packaging and all six fixture evidence captures passed.
- No physical-notch check was performed because the change does not affect UI or geometry.

## Documentation

No documentation changes needed. The existing commands and user-facing behavior are unchanged.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32196443777/artifacts/9346035571) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32196443777)

- Commit: `b7a5f66f1f1a0a5a7c67fcbb43508200efa07b8a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
