### PR TITLE
feat(voice): make Luke the agents' engineering manager

### DIFF
--- a/packages/sidecar-core/src/realtime-protocol.ts
+++ b/packages/sidecar-core/src/realtime-protocol.ts
@@ -129,9 +129,11 @@ export interface AttentionSpeech extends SessionIdentity {
 }
 
 const REALTIME_INSTRUCTION_HEAD: readonly string[] = [
-  "You are Luke, a spoken companion for a developer who is running coding agents.",
-  "You watch their sessions from the side, and you can carry out exactly what the developer asks of one.",
-  "The developer speaks to you or types to you; either way it is them asking, and you answer out loud.",
+  "You are Luke, the engineering manager for the developer's coding agents.",
+  "The developer is your CTO. Keep them oriented across the team: what is moving, what needs attention, and what decision is theirs.",
+  "Talk to them like an engineering manager talking to their CTO: direct, candid, calm, and familiar with the work.",
+  "You watch the agents' sessions from the side, and you can carry out exactly what the developer asks of one.",
+  "The developer speaks to you or types to you; either way it is your CTO asking, and you answer out loud.",
   "",
   "How to speak:",
   "- The developer is working, not reading: be extremely brief. One short sentence by default, two at most, under twenty-five words.",

--- a/packages/sidecar-core/tests/realtime.test.ts
+++ b/packages/sidecar-core/tests/realtime.test.ts
@@ -212,6 +212,14 @@ test("the standing instructions count the tools from the table", () => {
   assert.match(instructions, new RegExp(`You have ${spokenRealtimeToolCount()} tools:`));
 });
 
+test("the standing instructions make Luke the coding agents' engineering manager", () => {
+  const instructions = realtimeInstructions();
+
+  assert.match(instructions, /engineering manager for the developer's coding agents/i);
+  assert.match(instructions, /developer is your CTO/i);
+  assert.match(instructions, /direct, candid, calm, and familiar with the work/i);
+});
+
 test("the spoken instructions state what Luke cannot see, and when he may act", () => {
   const instructions = realtimeInstructions();
 


### PR DESCRIPTION
## Summary
- frame Luke as the engineering manager for the developer's coding agents
- treat the developer as Luke's CTO
- guide Luke toward direct, candid, calm status and decision communication
- lock the role and tone into regression coverage

## Verification
- `./scripts/check.sh`
- 32 existing Biome warnings; no check failures

## Visual evidence
- Not applicable: prompt-only change; no UI or macOS surface changed
- Physical-notch check not performed

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32199373933/artifacts/9346960600) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32199373933)

- Commit: `70d5a8b37440a49ef7cc6341d68a5d373931ca28`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
