### PR TITLE
fix(desktop): register second-instance handler only once the app is ready

### DIFF
--- a/apps/desktop/src/desktop-app.ts
+++ b/apps/desktop/src/desktop-app.ts
@@ -1238,21 +1238,6 @@ export function startDesktopApp(): void {
     );
     app.quit();
   } else {
-    // A repeat launch is usually someone checking the notch capsule, so re-assert
-    // the panel where it already is. Expanding hides the compact capsule, which is
-    // the one thing the relaunch was meant to show. An explicit `--expanded` is a
-    // stated intent rather than a side effect, so it is still honoured.
-    app.on("second-instance", (_event, argv) => {
-      panels.refreshGeometry();
-      if (argv.includes("--expanded")) {
-        const host = panels.voiceHost();
-        const displayId = host ? panels.displayIdFor(host.webContents) : undefined;
-        if (displayId !== undefined) panels.setMode(displayId, "expanded", true);
-        return;
-      }
-      panels.reconcile();
-      panels.showInactiveAll();
-    });
     void app.whenReady().then(async () => {
       if (process.platform === "darwin") app.setActivationPolicy("accessory");
       Menu.setApplicationMenu(null);
@@ -1352,6 +1337,27 @@ export function startDesktopApp(): void {
       // Reconcile in the background. Only an explicit invalid_grant removes the
       // stored account; network failures and service outages leave it active.
       void accountSession.refreshOnce();
+
+      // A repeat launch is usually someone checking the notch capsule, so re-assert
+      // the panel where it already is. Expanding hides the compact capsule, which is
+      // the one thing the relaunch was meant to show. An explicit `--expanded` is a
+      // stated intent rather than a side effect, so it is still honoured.
+      // Registered only now, once the launch has built what a relaunch re-asserts:
+      // the ping can arrive while this instance is still starting, where the screen
+      // module cannot be read yet — the crash — and where a reconcile would raise
+      // windows before the bootstrap handler exists to answer them. A ping that
+      // early is dropped, because startup is about to assert the panel anyway.
+      app.on("second-instance", (_event, argv) => {
+        panels.refreshGeometry();
+        if (argv.includes("--expanded")) {
+          const host = panels.voiceHost();
+          const displayId = host ? panels.displayIdFor(host.webContents) : undefined;
+          if (displayId !== undefined) panels.setMode(displayId, "expanded", true);
+          return;
+        }
+        panels.reconcile();
+        panels.showInactiveAll();
+      });
 
       screen.on("display-added", handleDisplayChange);
       screen.on("display-removed", handleDisplayChange);


### PR DESCRIPTION
## Crash

Launching Luke while a previous launch was still starting killed the main process:

```
Uncaught Exception:
Error: The 'screen' module can't be used before the app 'ready' event
at PanelManager.refreshGeometry (...)
at EventEmitter.<anonymous> (...)
```

The `second-instance` handler was registered at the top of `startDesktopApp()`, outside `app.whenReady()`. Electron fires that event on the running instance the moment another launch requests the single-instance lock — which can happen before this instance reaches `ready`, where the handler's `refreshGeometry()`/`reconcile()` reads of the `screen` module throw. `./scripts/run.sh` makes the race easy to hit: the relaunch's lock request is exactly the ping that re-asserts the running panel.

## Fix

Register the handler at the end of the `whenReady` callback, once startup has built everything a relaunch re-asserts. A ping that arrives earlier is dropped — startup is about to assert the panel anyway. This also keeps a mid-startup `reconcile()` from raising windows before the bootstrap IPC handler exists to answer them, which would have left a blank panel.

## Validation

`./scripts/check.sh` passes (repository contracts, lint, typecheck, tests, build). Main-process lifecycle only — no UI or motion change, so no visual evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a0aadd63-ef0e-45c8-84a8-cae35e8475a4)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32202677352/artifacts/9348081087) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32202677352)

- Commit: `e649fa12c62ae482012383089c729ba1a731f2ff`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
