### PR TITLE
docs: catalogue provider capabilities in PROVIDERS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -452,6 +452,29 @@ Rules the guide must keep:
   whether a provider is connected. The guide leaves the machine, so nothing in
   it may carry a key, a key's shape, or an environment variable's value.
 
+## Provider capability documentation
+
+`PROVIDERS.md` is the one place the per-provider capability surface is written
+down for a reader: what each provider connection observes, what a session row
+can say, and which acts each provider takes. The code cannot state that in one
+place — an adapter has a capability exactly when it overrides the method, so
+the truth is spread across every adapter — which is why the document exists,
+and why it can drift.
+
+**When you change what a provider can do, update `PROVIDERS.md` in the same
+change.** That means adding or removing a provider or tracker, widening or
+narrowing what an adapter observes, adding or dropping a control, a message
+path, a workspace act, a recap source, or a hook, or changing how a credential
+connects. The levers that exist are narrow: `scripts/provider-docs.test.mjs`
+refuses a provider or tracker id the document does not name, and
+`scripts/repository-checks.sh` requires the file to exist. Everything subtler
+— a stale endpoint, a control the document still claims, a boundary the code
+no longer keeps — has no lever, so the rule is stated here: a capability the
+document does not describe is one a reader will not know Luke has, and a stale
+entry describes a Luke that does not exist. `PRIVACY.md` and the README's
+integration table cover the same connections at different altitudes; a change
+that touches one usually touches all three.
+
 ## Code comments
 
 No unnecessary comments. Make the code obvious and immediately understandable

--- a/PROVIDERS.md
+++ b/PROVIDERS.md
@@ -1,0 +1,221 @@
+# Provider capabilities
+
+What Luke can see and do differs for every provider it connects to, and the
+code cannot state that surface in one place: an adapter has a capability
+exactly when it overrides the method, so the truth is spread across every
+adapter. This document is the one written-down capability surface — what each
+connection observes, what a session row can say, and which acts each provider
+takes — for anyone deciding what Luke can do before reading eight adapters.
+[AGENTS.md](AGENTS.md#provider-capability-documentation) states how it is kept
+current; [PRIVACY.md](PRIVACY.md) covers the same connections from the data's
+point of view and binds harder wherever the two could disagree.
+
+## Where a capability lives in code
+
+- `packages/sidecar-core/src/providers.ts` defines `SessionProviderAdapter`.
+  `SessionProviderAdapterBase` answers unsupported — or none — for every act,
+  so an adapter has a capability exactly when it overrides the method; there
+  is no separate flags object to drift from the behavior.
+- What a session can take right now is advertised per observation:
+  `ProviderSessionObservation` in `packages/sidecar-core/src/session.ts`
+  carries `canReceiveMessage`, `controls`, `spawnableAgents`, `workspace`,
+  `recap`, `location`, and the address a row press opens. Every act is
+  validated against the latest observation in the renderer and again in the
+  main process, so the observed roster is the outer bound of what any ask can
+  do.
+- The agent kinds and models offerable when creating a workspace or adding an
+  agent are the build-fixed table in
+  `apps/desktop/src/shared/workspace-agents.ts`; credential shapes and
+  connection kinds live in `apps/desktop/src/shared/credential-providers.ts`;
+  adapters wire in through `apps/desktop/src/provider-registrations.ts`.
+
+## Session providers at a glance
+
+What each provider's sessions report:
+
+| Provider | Id | Sessions | Credential | Lifecycle hook | Recap | Opens at |
+| --- | --- | --- | --- | --- | --- | --- |
+| Claude Code | `claude-code` | Local | None | `settings.json` merge | Designated away summary | — |
+| Codex | `codex` | Local | None | `hooks.json` merge, behind Codex's trust gate | Last agent message | `codex:` thread link |
+| Conductor | `conductor` | Cloud | API key | — | Final assistant message, only while idle | `conductor:` deep link |
+| Cursor | `cursor` | Local and cloud | Cloud only | — | Run result (cloud) | Agent URL (cloud) |
+| Devin | `devin` | Local and cloud | Cloud only | — | — | Session URL (cloud) |
+| GitHub Copilot | `copilot` | Cloud | Fine-grained PAT | — | — | Task page URL |
+| Jules | `jules` | Cloud | API key | — | — | Session URL |
+| OpenCode | `opencode` | Local | None | — | — | Share URL, once shared |
+
+What each provider's sessions can take — every act only when the latest
+observation advertised it, and only as the direct product of a turn the
+developer opened:
+
+| Provider | Message | Controls | New workspace | Add agent | Transcript readout |
+| --- | --- | --- | --- | --- | --- |
+| Claude Code | — | — | — | — | Yes |
+| Codex | — | — | — | — | Yes |
+| Conductor | While idle or working | `cancel-turn`, `archive-workspace` | Yes, task optional | Yes | — |
+| Cursor | After a finished run | `cancel-run`, `archive-agent` | Yes, task required | — | Yes, local sessions |
+| Devin | While running or suspended | `archive-session` | — | — | Yes, local sessions |
+| GitHub Copilot | — | — | — | — | — |
+| Jules | In four documented states | `approve-plan` | — | — | — |
+| OpenCode | — | — | — | — | Yes |
+
+Transcript readout is Luke reading a local session's conversation aloud — or
+into his composer — when asked about that session; a cloud session's
+conversation lives with its provider and is never fetched. Every provider's
+rows also carry the shared observation fields where the provider writes them:
+title, status, repository, branch, model, current tool activity, error, and a
+change link such as a pull request.
+
+## Claude Code
+
+Local sessions, no credential. Luke reads bounded tails of the session JSONL
+files under `~/.claude/projects/` (honoring `CLAUDE_CONFIG_DIR`), and never
+writes them. The one provider-side write is the observation hook merged into
+the user-level `settings.json`, which records a fixed status token per
+session — start, prompt, stop, stop failure, permission notification, session
+end — into a spool under Luke's own application data.
+
+- Recap: only the away summary the provider itself designated; Luke never
+  composes one from the assistant tail.
+- Rows carry activity from the current tool call, repository, branch, model,
+  API errors, and a pull-request change link.
+- No address to open, no message path, no controls, no workspace acts.
+- Transcript readout: yes (`apps/desktop/src/claude-code-transcript.ts`).
+
+## Codex
+
+Local sessions, no credential. Luke reads the read-only session index in
+`state_5.sqlite` under `~/.codex` (honoring `CODEX_HOME`), then bounded tails
+of each thread's rollout file. The observation hook merges into `hooks.json`
+and runs only after Codex's own review gate shows it to the user and they
+trust it; its events match Claude Code's minus stop failure.
+
+- Recap: the last agent message from the rollout tail; a failed turn reports
+  its error instead.
+- Opens at `codex://threads/<id>`.
+- No message path, no controls, no workspace acts.
+- Transcript readout: yes (`apps/desktop/src/codex-transcript.ts`).
+
+## Conductor
+
+Cloud sessions under a user-supplied API key; nothing is observed without one.
+Luke reads projects, workspaces, sessions, and their statuses from
+`api.conductor.build`, plus one fixed read-only SQL document over the
+transcripts view for each session's agent kind and recap tail. Conductor is
+the one provider that reports `workspace`, so its chats group into a tray
+named by the workspace, and the one provider whose sessions list
+`spawnableAgents`.
+
+- Message: while a session is idle or working.
+- Controls: `cancel-turn` mid-turn; `archive-workspace` once every open chat
+  in the workspace was seen settled.
+- New workspace: in any project the latest pass reported, with an optional
+  opening task delivered as the first message, and an agent, model, and
+  effort chosen from the build's table.
+- Add agent: another chat in an observed workspace, as one of the kinds its
+  row's latest observation listed.
+- Recap: the final assistant message's tail, only while the chat is idle.
+- Opens through its `conductor:` deep link. No transcript readout — the
+  conversation lives with the provider.
+
+## Cursor
+
+Two observers under one provider id. The local half reads bounded tails of
+`~/.cursor/projects/<project>/agent-transcripts/*.jsonl`, labeling workspaces
+from Cursor's own workspace storage; it reports turn state and failure —
+without Cursor's reason, which is not stored — and offers no address and no
+recap. Transcript readout renders what Cursor wrote down, which excludes tool
+outputs. The cloud half reads agents and their latest runs from
+`api.cursor.com` under `CURSOR_API_KEY`, with the repository list on its own
+slower cadence.
+
+- Message: a follow-up run, only after the latest run finished on an
+  unarchived agent.
+- Controls: `cancel-run` while a run is underway; `archive-agent` once the
+  latest run positively settled. Never both at once.
+- New workspace: a cloud agent in any repository the latest pass listed; the
+  opening task is required because Cursor cannot make an idle workspace.
+- Recap: the run result. Opens at the agent's URL; the run's pull request is
+  the change link.
+
+## Devin
+
+Two observers under one provider id. The local half reads the Devin CLI's
+read-only session database, reporting activity, repository, and model — no
+address, no recap, no error detail. Transcript readout: yes, from the same
+database. The cloud half reads the organization's sessions from
+`api.devin.ai` v3 under a `cog_`-prefixed personal access token.
+
+- Message: while a session is running or suspended and not archived.
+- Controls: `archive-session`, offered only once the turn positively settled.
+- Opens at the session URL; the pull request is the change link.
+- No workspace acts, no recap.
+
+## GitHub Copilot
+
+Cloud agent tasks under a fine-grained personal access token, read from
+`api.github.com`. The connection is fully read-only by design: no message
+path, no controls, no workspace acts, no recap, no transcript readout. Rows
+carry repository and branch, and open at the task's page URL.
+
+## Jules
+
+Cloud sessions under a user-supplied API key, read from
+`jules.googleapis.com` — the one provider authenticated by Google's API-key
+header rather than a bearer token.
+
+- Message: while a session is planning, in progress, awaiting plan approval,
+  or awaiting user feedback.
+- Controls: `approve-plan`, only while the plan awaits approval.
+- Opens at the session URL. No workspace acts, no recap, no transcript
+  readout. Titles fall back to the repository label.
+
+## OpenCode
+
+Local sessions, no credential. Luke reads the read-only OpenCode database
+(honoring `OPENCODE_DB`, falling back through the XDG data path and the
+legacy JSON storage), skipping subagent and archived rows.
+
+- No hook, no recap, no message path, no controls, no workspace acts.
+- Opens at the session's share URL, once the user has shared it.
+- Rows carry tool activity, repository, model, and turn failures.
+- Transcript readout: yes (`apps/desktop/src/opencode-transcript.ts`).
+
+## Integrations beyond sessions
+
+**Linear** (`linear`) is connected by the tracker's own consent page — OAuth
+with PKCE over a loopback redirect, never a typed key or an environment
+variable — and reads one fixed GraphQL document for the user's assigned
+issues. Each issue advertises its available state transitions and whether it
+takes a comment, and the two acts — moving an issue to an advertised state,
+adding a comment — run only as the direct product of a developer-opened turn,
+validated against the observed issue roster in the renderer and again in the
+main process. Disconnecting revokes the grant with Linear as well as deleting
+it locally.
+
+**Google Calendar** is the same consent shape with no write path at all:
+per-account grants read the calendar list and free/busy intervals — start and
+end instants only, so titles cannot even travel. The intervals drive exactly
+one behavior: while a meeting covers now and Quiet during meetings is on,
+spoken announcements hold and the face sleeps.
+
+**OpenAI and the hosted account** carry voice and the optional attention
+review. They are credential-only — nothing of theirs is ever observed as a
+session — and the hosted account's daily allowance runs both until a
+user-supplied OpenAI key takes over.
+
+**The update check** is the one request made with no user key: an
+unauthenticated read of this repository's latest release name from GitHub's
+public API. Only the version name is read back, and it changes only what the
+Updates row says.
+
+## Keeping this document current
+
+When a change adds a provider, widens or narrows what an adapter observes or
+may do, or changes how a credential connects, this document changes in the
+same commit. `scripts/provider-docs.test.mjs` refuses a provider or tracker
+id this file does not name, and `scripts/repository-checks.sh` requires the
+file to exist; everything subtler than an id's presence rests on the rule in
+[AGENTS.md](AGENTS.md#provider-capability-documentation). Widening any
+capability described here is a product decision, not an implementation
+detail.

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ See [WORKFLOW.md](WORKFLOW.md) for the issue-to-pull-request workflow.
 
 ## Documentation
 
+- [Provider capabilities](PROVIDERS.md)
 - [Privacy details](PRIVACY.md)
 - [Maintainer release guide](.github/RELEASE.md)
 

--- a/scripts/provider-docs.test.mjs
+++ b/scripts/provider-docs.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const documentation = fs.readFileSync(path.join(repositoryRoot, "PROVIDERS.md"), "utf8");
+
+// Harness tests run on plain Node and cannot import TypeScript, so the value
+// sets are read out of their sources by shape. The match is anchored to the
+// `as const` declaration these constants are required to use, so a set that
+// moves or changes form fails loudly here rather than passing on nothing.
+function valueSetValues(sourcePath, constantName) {
+  const source = fs.readFileSync(path.join(repositoryRoot, sourcePath), "utf8");
+  const declaration = source.match(
+    new RegExp(`export const ${constantName} = \\{([^}]*)\\} as const;`),
+  );
+  assert.ok(declaration, `${constantName} not found in ${sourcePath}`);
+  const values = [...declaration[1].matchAll(/:\s*"([^"]+)"/g)].map((entry) => entry[1]);
+  assert.ok(values.length > 0, `${constantName} in ${sourcePath} lists no values`);
+  return values;
+}
+
+test("PROVIDERS.md names every session provider id", () => {
+  for (const providerId of valueSetValues(
+    "packages/sidecar-core/src/providers.ts",
+    "PROVIDER_ID",
+  )) {
+    assert.ok(
+      documentation.includes(`\`${providerId}\``),
+      `PROVIDERS.md does not name provider \`${providerId}\` — document its capabilities`,
+    );
+  }
+});
+
+test("PROVIDERS.md names every issue tracker id", () => {
+  for (const trackerId of valueSetValues(
+    "packages/sidecar-core/src/issues.ts",
+    "ISSUE_TRACKER_ID",
+  )) {
+    assert.ok(
+      documentation.includes(`\`${trackerId}\``),
+      `PROVIDERS.md does not name tracker \`${trackerId}\` — document its capabilities`,
+    );
+  }
+});

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -10,6 +10,7 @@ required_files=(
     CLAUDE.md
     WORKFLOW.md
     README.md
+    PROVIDERS.md
     package.json
     pnpm-lock.yaml
     pnpm-workspace.yaml


### PR DESCRIPTION
## Summary

- Add `PROVIDERS.md`, the one written-down capability surface across every provider connection: what each observes, what a session row can say (recap source, open address, hook), and which acts each takes (messages, controls, workspace creation, added agents, transcript readout), plus the non-session integrations (Linear, Google Calendar, OpenAI/hosted, the update check).
- Add an AGENTS.md section stating the maintenance rule: a change to what a provider can do updates `PROVIDERS.md` in the same change.
- Add `scripts/provider-docs.test.mjs` (runs under `pnpm test:harness`), which refuses any `PROVIDER_ID` or `ISSUE_TRACKER_ID` value the document does not name, and list `PROVIDERS.md` in `repository-checks.sh`'s required files.
- Link the document from the README's Documentation section.

## Validation

- `./scripts/check.sh` passes (docs + portable scripts only; no macOS or UI change, so no `verify.sh` run or visual evidence applies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ebc23cc5-0953-4df2-87a9-c8c7a4407d8f)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32203670271/artifacts/9348394691) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32203670271)

- Commit: `d5bbb59ffbc1828b18f467a18892cfc684f44388`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
