### PR TITLE
feat(desktop): silence announcements the moment the meeting quiet begins

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1742,6 +1742,7 @@ export function App(): React.JSX.Element {
     voiceCaptions: settings?.voiceCaptions === true,
     voiceAvailable: settings?.voiceAvailable,
     outputSilent: outputSilent(outputAudio),
+    meetingQuiet,
     fixtureSpeaking,
     capturingShortcut: () => shortcutCapture.current,
     openSession: openSessionAloud,

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -469,7 +469,9 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
               (input.settings.calendarSignInAvailable
                 ? " With a Google Calendar account connected and Quiet during meetings on, " +
                   "announcements decided during a meeting wait and are read out together once " +
-                  "it ends — and Luke's face sleeps beside the housing for as long as the " +
+                  "it ends. The quiet beginning — a meeting starting, or the setting switched " +
+                  "on mid-meeting — silences Luke at once, an announcement mid-sentence " +
+                  "included — and Luke's face sleeps beside the housing for as long as the " +
                   "quiet holds, which is how the hold is seen."
                 : ""),
           },

--- a/apps/desktop/src/renderer/spoken-notices.ts
+++ b/apps/desktop/src/renderer/spoken-notices.ts
@@ -48,6 +48,7 @@ export interface AnnouncerSession {
   readonly microphoneCall: boolean;
   connect(options: { microphone: false }): Promise<boolean>;
   speak(speech: AttentionSpeech): boolean;
+  stopSpeaking(): boolean;
   close(): Promise<void>;
 }
 
@@ -75,6 +76,10 @@ export interface SpokenNoticeAnnouncerOptions {
  * per backlog, and every queued sentence ages out of being news regardless.
  * A backlog that outlives its attempts is dropped, because every notice is
  * still standing in the panel.
+ *
+ * The meeting quiet reaches it through {@link setMeetingQuiet}: quiet
+ * beginning silences it at once — the announcement mid-sentence on Luke's
+ * own call included — and holds it silent until the quiet ends.
  */
 export class SpokenNoticeAnnouncer {
   readonly #options: SpokenNoticeAnnouncerOptions;
@@ -85,14 +90,43 @@ export class SpokenNoticeAnnouncer {
   /** How many times the backlog now queued has tried to open Luke's own call. */
   #connectAttempts = 0;
   #retryTimer: unknown;
+  /** Whether the meeting quiet is holding, which silences this announcer. */
+  #quiet = false;
 
   constructor(options: SpokenNoticeAnnouncerOptions) {
     this.#options = options;
   }
 
+  /**
+   * Follows the meeting quiet the main process decided. Quiet beginning —
+   * the setting switched on mid-meeting, or a meeting starting under it — is
+   * asked-for silence right now: the announcement mid-sentence on Luke's own
+   * call is cut off and the call closed rather than left lingering into the
+   * meeting, and the backlog is dropped rather than played — every notice in
+   * it is still standing in the panel, and anything decided from here waits
+   * in the main process for the release. The developer's own call is never
+   * touched: a conversation they are holding passes, meeting or not. Quiet
+   * ending needs no act here — the main process re-sends what the meeting
+   * held, and that arrives as a fresh backlog.
+   */
+  setMeetingQuiet(active: boolean): void {
+    this.#quiet = active;
+    if (!active) return;
+    this.#queue = [];
+    this.#connectAttempts = 0;
+    this.#cancelRetry();
+    this.#cancelLinger();
+    if (!this.#ownsCall) return;
+    this.#ownsCall = false;
+    const session = this.#options.session();
+    if (session.microphoneCall) return;
+    session.stopSpeaking();
+    void session.close();
+  }
+
   /** Takes notices the main process decided to voice, and starts saying them. */
   enqueue(notices: readonly AttentionSpeech[]): void {
-    if (notices.length === 0) return;
+    if (this.#quiet || notices.length === 0) return;
     this.#queue.push(...notices);
     // The oldest waiting sentence is the least newsworthy one; a bounded queue
     // sheds from the front.
@@ -135,6 +169,9 @@ export class SpokenNoticeAnnouncer {
   }
 
   #flush(): void {
+    // Quiet holds everything: nothing may speak, and an empty queue must not
+    // start the linger toward closing a call the quiet already closed.
+    if (this.#quiet) return;
     const now = this.#options.now?.() ?? Date.now();
     this.#queue = this.#queue.filter((item) => now - item.decidedAt <= SPOKEN_NOTICE_MAX_AGE_MS);
     const session = this.#options.session();
@@ -206,6 +243,12 @@ export class SpokenNoticeAnnouncer {
       this.#retryTimer = undefined;
       this.#flush();
     }, ANNOUNCER_RETRY_DELAY_MS);
+  }
+
+  #cancelRetry(): void {
+    if (this.#retryTimer === undefined) return;
+    (this.#options.cancel ?? clearTimeout)(this.#retryTimer as Parameters<typeof clearTimeout>[0]);
+    this.#retryTimer = undefined;
   }
 
   #armLinger(): void {

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -369,6 +369,12 @@ export interface VoiceConversationOptions {
    */
   voiceAvailable: boolean | undefined;
   outputSilent: boolean;
+  /**
+   * Whether the meeting quiet is holding — a meeting on the connected
+   * calendar covers now and the setting is on. True silences the announcer at
+   * once, the announcement mid-sentence on Luke's own call included.
+   */
+  meetingQuiet: boolean;
   fixtureSpeaking: boolean;
   /**
    * True while a settings row is recording a chord. Both Luke keys stay
@@ -984,6 +990,15 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   useEffect(() => {
     announcer.current?.onStatus(voiceStatus);
   }, [voiceStatus]);
+
+  // The meeting quiet reaching the announcer. Quiet beginning is built
+  // through ensure, so it stands even before the first notice would have
+  // built the announcer; quiet ending has no announcer to wake, because the
+  // main process re-sends what the meeting held as a fresh backlog.
+  useEffect(() => {
+    if (options.meetingQuiet) ensureAnnouncer().setMeetingQuiet(true);
+    else announcer.current?.setMeetingQuiet(false);
+  }, [ensureAnnouncer, options.meetingQuiet]);
 
   // The talk key is registered by the main process so it answers from any app,
   // which is the whole point: no window to find, nothing to focus first. Both

--- a/apps/desktop/src/shared/settings-schema.ts
+++ b/apps/desktop/src/shared/settings-schema.ts
@@ -482,7 +482,7 @@ export const APP_SETTING_SCHEMA = {
         id: APP_SETTING_ID.QUIET_DURING_MEETINGS,
         label: "Quiet during meetings",
         description:
-          "Whether spoken announcements wait while a connected calendar shows a meeting on, and are read out together once it ends. It changes nothing until a Google Calendar account is connected.",
+          "Whether spoken announcements wait while a connected calendar shows a meeting on, and are read out together once it ends. Switched on during a meeting it takes hold at once, cutting off an announcement mid-sentence. It changes nothing until a Google Calendar account is connected.",
         kind: APP_SETTING_KIND.TOGGLE,
         value: appToggleText(settings.quietDuringMeetings),
         defaultValue: appToggleText(defaultValue as boolean),

--- a/apps/desktop/tests/spoken-notices.test.ts
+++ b/apps/desktop/tests/spoken-notices.test.ts
@@ -31,6 +31,7 @@ interface FakeSession extends AnnouncerSession {
   spoken: AttentionSpeech[];
   connects: number;
   closes: number;
+  stops: number;
   /** What the next connect resolves to; the call opens when it does. */
   connectOpens: boolean;
   setStatus(status: RealtimeStatus): void;
@@ -42,6 +43,7 @@ function fakeSession(): FakeSession {
     spoken: [],
     connects: 0,
     closes: 0,
+    stops: 0,
     connectOpens: true,
     microphone: false,
     status: REALTIME_STATUS.IDLE,
@@ -66,6 +68,12 @@ function fakeSession(): FakeSession {
       if (!this.isConnected || this.status === REALTIME_STATUS.RESPONDING) return false;
       this.spoken.push(item);
       this.setStatus(REALTIME_STATUS.RESPONDING);
+      return true;
+    },
+    stopSpeaking() {
+      if (this.status !== REALTIME_STATUS.RESPONDING) return false;
+      this.stops += 1;
+      this.setStatus(REALTIME_STATUS.READY);
       return true;
     },
     async close() {
@@ -338,6 +346,76 @@ test("a notice refused mid-reply keeps a clock of its own beside the READY edge"
     session.spoken.map((item) => item.providerSessionId),
     ["a"],
   );
+});
+
+test("quiet beginning cuts the announcement mid-sentence and closes Luke's own call", async () => {
+  const session = fakeSession();
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  // Mid-announcement on Luke's own call, with another sentence waiting.
+  subject.enqueue([speech("a"), speech("b")]);
+  await Promise.resolve();
+  assert.equal(session.status, REALTIME_STATUS.RESPONDING);
+
+  subject.setMeetingQuiet(true);
+  assert.equal(session.stops, 1, "the reply under way is cut off");
+  assert.equal(session.closes, 1, "the call Luke opened is closed");
+
+  // The backlog was dropped with the reply: quiet ending finds nothing to
+  // say, and no clock is left ticking toward saying it.
+  subject.onStatus(REALTIME_STATUS.IDLE);
+  subject.setMeetingQuiet(false);
+  assert.equal(timers.armed(), 0);
+  assert.equal(session.connects, 1);
+  assert.deepEqual(
+    session.spoken.map((item) => item.providerSessionId),
+    ["a"],
+  );
+
+  // Quiet over, fresh news speaks again — the release arrives exactly here.
+  subject.enqueue([speech("c")]);
+  await Promise.resolve();
+  assert.deepEqual(
+    session.spoken.map((item) => item.providerSessionId),
+    ["a", "c"],
+  );
+});
+
+test("a notice arriving under the quiet never opens a call", async () => {
+  const session = fakeSession();
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  subject.setMeetingQuiet(true);
+  subject.enqueue([speech("a")]);
+  await Promise.resolve();
+
+  assert.equal(session.connects, 0);
+  assert.deepEqual(session.spoken, []);
+  assert.equal(timers.armed(), 0);
+});
+
+test("quiet beginning never touches the developer's own call", () => {
+  const session = fakeSession();
+  session.microphone = true;
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  // Waiting out the developer's reply when the quiet lands.
+  subject.enqueue([speech("a")]);
+  assert.deepEqual(session.spoken, []);
+
+  subject.setMeetingQuiet(true);
+  assert.equal(session.stops, 0, "the developer's reply is theirs to finish");
+  assert.equal(session.closes, 0);
+
+  // But the waiting announcement is dropped rather than read after the reply.
+  assert.equal(timers.armed(), 0);
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.deepEqual(session.spoken, []);
 });
 
 test("a sentence that went stale in the queue is dropped, not read as news", () => {


### PR DESCRIPTION
## What

Toggling **Quiet during meetings** on during a meeting now takes hold immediately: Luke stops speaking mid-sentence, and queued announcements are prevented from playing. The same applies when a meeting starts while the setting is already on — the quiet beginning is the trigger, and it is still a deterministic edge the main process decided, never anything a model said.

## How

The main process already held notices decided during the quiet and broadcast `meetingQuietChanged` on the setting's side effect; the gap was in the renderer, where the `SpokenNoticeAnnouncer` kept reading an in-flight announcement and kept its backlog.

- `SpokenNoticeAnnouncer.setMeetingQuiet(active)`: quiet beginning cuts off the reply mid-sentence on Luke's own call (`stopSpeaking`), closes that call rather than leaving it lingering into the meeting, drops the queued backlog (every notice in it is still standing in the panel; anything decided from here waits in the main process for the release), and cancels the retry/linger clocks. While quiet holds, `enqueue` and `#flush` are gated, so nothing can open a call or speak. The developer's own call is never touched — a conversation they are holding passes, meeting or not, so a spoken "turn quiet on" ask still gets its confirmation.
- `useVoiceConversation` takes a `meetingQuiet` option and feeds it to the announcer; `app.tsx` passes the `meetingQuiet` state it already tracked from `onMeetingQuietChanged`.
- Guide updated in the same change: the Announcements fact and the setting's description now say the quiet takes hold at once, cutting an announcement mid-sentence.

## Tests

- quiet beginning cuts the announcement mid-sentence, closes Luke's own call, and drops the backlog; fresh news after the quiet speaks again
- a notice arriving under the quiet never opens a call
- quiet beginning never touches the developer's own call, and the announcement waiting on it is dropped rather than read after the reply

## Verification

`./scripts/check.sh` passes: repository contract checks, lint, typecheck, 1124 tests (0 fail), build. Portable-only change (renderer logic + guide text, no visual or macOS surface change), so no `verify.sh` evidence run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/f3711486-aca9-4389-964e-d3c6c88d005a)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32205935314/artifacts/9349147936) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32205935314)

- Commit: `d636a12c22ce771939ad43c6a62c6d7aaef1458d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
