### PR TITLE
feat(voice): give the mention band and captions the panel's full width

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -208,17 +208,19 @@ function captionBlockSize(textHeight: number, volumeHint: boolean, padding: numb
 /**
  * Sizes the notice band's growth to the chips it currently holds — the
  * caption block's own pattern. The chips size to their names and wrap where
- * they wrap, so only a measurement can say how many rows they made. The
- * band's own max-height already clamps the measurement to the rows the
- * window reserved — past it the chips scroll instead of growing the shape —
- * and the clamp here only restates that bound against a measurement landing
- * mid-layout. The 6px around the measured chips is the band's 3px stand-off
- * from the strip, top and bottom, which one reserved row already accounts
- * for. Unmeasured falls back to `--notice-size`, one row, in the stylesheet.
+ * they wrap, so only a measurement can say how many rows they made. Measured
+ * off the rows inside the band rather than the band itself: the band's box
+ * holds every reserved row so the growth can be revealed by its clip, which
+ * means only the inner stack's height says how many rows the chips actually
+ * made. The clamp is the rows the window reserved — past it the chips scroll
+ * inside the band instead of growing the shape. The 6px around the measured
+ * chips is the band's 3px stand-off from the strip, top and bottom, which
+ * one reserved row already accounts for. Unmeasured falls back to
+ * `--notice-size`, one row, in the stylesheet.
  */
-function noticeGrowthStyle(bandHeight: number | undefined): CSSProperties {
-  if (!bandHeight) return {};
-  const growth = Math.min(SESSION_NOTICE_HEIGHT * SESSION_NOTICE_MAX_ROWS, bandHeight + 6);
+function noticeGrowthStyle(rowsHeight: number | undefined): CSSProperties {
+  if (!rowsHeight) return {};
+  const growth = Math.min(SESSION_NOTICE_HEIGHT * SESSION_NOTICE_MAX_ROWS, rowsHeight + 6);
   return { "--notice-growth": `${growth}px` } as CSSProperties;
 }
 
@@ -1902,19 +1904,17 @@ export function App(): React.JSX.Element {
    * with no edge to say so hides its lower rows silently — the fades these
    * drive are what tell the developer there is more to see. Measured, not
    * derived from the count: the scroll position is the band's own, and only
-   * the element can say where it stands. The band's height is measured
+   * the element can say where it stands. The rows' height is measured
    * beside it, because naturally wrapped chips make however many rows their
    * names need and the shape has to grow to the rows actually made.
    */
   const noticeBand = useRef<HTMLSpanElement | null>(null);
-  const [noticeBandElement, noticeBandHeight] = useShapeHeight();
-  const attachNoticeBand = useCallback(
-    (element: HTMLSpanElement | null) => {
-      noticeBand.current = element;
-      noticeBandElement(element);
-    },
-    [noticeBandElement],
-  );
+  // The growth is measured off the rows stack inside the band, not the band:
+  // the band's box holds every reserved row in every state so its clip can
+  // reveal the growth on the shape's own spring, which leaves the inner
+  // stack's wrapped height as the only box that says how many rows the chips
+  // made.
+  const [noticeRowsElement, noticeBandHeight] = useShapeHeight();
   const [noticeFold, setNoticeFold] = useState({ above: false, below: false });
   const measureNoticeFold = useCallback(() => {
     const band = noticeBand.current;
@@ -2861,7 +2861,7 @@ export function App(): React.JSX.Element {
           shape. */}
       <span
         className="session-notices"
-        ref={attachNoticeBand}
+        ref={noticeBand}
         inert={!noticeShown}
         // The folds: which edges have chips beyond them, driving the fades
         // that say the band scrolls. Both settle to false while everything
@@ -2870,31 +2870,33 @@ export function App(): React.JSX.Element {
         data-fold-below={String(noticeFold.below)}
         onScroll={measureNoticeFold}
       >
-        {lastMentioned.current.map((mention) => (
-          <button
-            key={mention.id}
-            type="button"
-            className="session-notice"
-            data-hit-region={HIT_REGION.CAPSULE}
-            aria-label={`Open "${mention.title}"`}
-            // Keeps the press from moving focus here, like the capsule strip's
-            // own button, so a focused settings field keeps the caret.
-            onMouseDown={(event) => event.preventDefault()}
-            // An issue chip is the same press one roster over: the identity
-            // goes to the main process, which reads the tracker's own address
-            // back out of its observation and hands it to the system — and an
-            // issue that reported none is taken nowhere, because no panel
-            // surface holds a row to fall back to.
-            onClick={() =>
-              mention.kind === MENTION_CHIP_KIND.SESSION
-                ? openMentionedSession(mention.identity)
-                : void window.sidecar.openIssue(mention.identity)
-            }
-          >
-            <ProviderMark providerId={mention.markId} />
-            <span className="session-notice-name">{mention.title}</span>
-          </button>
-        ))}
+        <span className="session-notice-rows" ref={noticeRowsElement}>
+          {lastMentioned.current.map((mention) => (
+            <button
+              key={mention.id}
+              type="button"
+              className="session-notice"
+              data-hit-region={HIT_REGION.CAPSULE}
+              aria-label={`Open "${mention.title}"`}
+              // Keeps the press from moving focus here, like the capsule strip's
+              // own button, so a focused settings field keeps the caret.
+              onMouseDown={(event) => event.preventDefault()}
+              // An issue chip is the same press one roster over: the identity
+              // goes to the main process, which reads the tracker's own address
+              // back out of its observation and hands it to the system — and an
+              // issue that reported none is taken nowhere, because no panel
+              // surface holds a row to fall back to.
+              onClick={() =>
+                mention.kind === MENTION_CHIP_KIND.SESSION
+                  ? openMentionedSession(mention.identity)
+                  : void window.sidecar.openIssue(mention.identity)
+              }
+            >
+              <ProviderMark providerId={mention.markId} />
+              <span className="session-notice-name">{mention.title}</span>
+            </button>
+          ))}
+        </span>
       </span>
 
       <div className="compact-stage">

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -103,8 +103,8 @@ import { applySpokenSetting, buildLukeGuide, isAppSettingId } from "./luke-guide
 import { NotchWings } from "./notch-wings";
 import { PanelBody, type SessionWriteHandlers } from "./panel-body";
 import {
+  collapseMarkAfter,
   HIT_REGION,
-  leavesPanelForCompact,
   PANEL_PRESENTATION,
   type PanelPresentation,
 } from "./panel-state";
@@ -330,7 +330,7 @@ function useLeavingPanel(presentation: PanelPresentation): boolean {
   const [previous, setPrevious] = useState(presentation);
   if (previous !== presentation) {
     setPrevious(presentation);
-    setLeaving(leavesPanelForCompact(previous, presentation));
+    setLeaving(collapseMarkAfter(previous, presentation, leaving));
   }
   useEffect(() => {
     if (!leaving) return;

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -7,6 +7,7 @@ import {
   type HostedUsageAnswer,
   type IssueIdentity,
   isProviderId,
+  MOTION_DURATION_MS,
   type NormalizedSession,
   type ObservedWorkspaceProject,
   type PanelFormFactor,
@@ -101,7 +102,12 @@ import { usePrefersReducedMotion } from "./luke-face-mood";
 import { applySpokenSetting, buildLukeGuide, isAppSettingId } from "./luke-guide";
 import { NotchWings } from "./notch-wings";
 import { PanelBody, type SessionWriteHandlers } from "./panel-body";
-import { HIT_REGION, PANEL_PRESENTATION } from "./panel-state";
+import {
+  HIT_REGION,
+  leavesPanelForCompact,
+  PANEL_PRESENTATION,
+  type PanelPresentation,
+} from "./panel-state";
 import { PANEL_TAB, type PanelTab } from "./panel-tabs";
 import { ProviderMark } from "./provider-marks";
 import type { AppActionCarrier } from "./realtime-session";
@@ -305,6 +311,33 @@ function useShapeHeight(): [(element: HTMLElement | null) => void, number | unde
   useEffect(() => () => observer.current?.disconnect(), []);
 
   return [measured, height];
+}
+
+const COLLAPSE_ANIMATION_MS = MOTION_DURATION_MS.EXIT + MOTION_DURATION_MS.SHAPE;
+
+/**
+ * True from the render that leaves the panel for a compact shape until the
+ * collapse has settled — the window's own collapse clock, exit plus shape.
+ * The stylesheet spends it to hold the surface behind the content it is
+ * still carrying: the panel's rows fading out, and a caption block or
+ * notice band riding down from the panel's foot. Derived during render
+ * rather than in an effect, because the surface's transition reads its
+ * delay on the same style change that retargets it — an attribute landing
+ * one commit later finds the shape already moving.
+ */
+function useLeavingPanel(presentation: PanelPresentation): boolean {
+  const [leaving, setLeaving] = useState(false);
+  const [previous, setPrevious] = useState(presentation);
+  if (previous !== presentation) {
+    setPrevious(presentation);
+    setLeaving(leavesPanelForCompact(previous, presentation));
+  }
+  useEffect(() => {
+    if (!leaving) return;
+    const timer = window.setTimeout(() => setLeaving(false), COLLAPSE_ANIMATION_MS);
+    return () => window.clearTimeout(timer);
+  }, [leaving]);
+  return leaving;
 }
 
 export function App(): React.JSX.Element {
@@ -621,6 +654,8 @@ export function App(): React.JSX.Element {
     },
     onCapsuleTab: () => changeTab(PANEL_TAB.SESSIONS),
   });
+
+  const leavingPanel = useLeavingPanel(presentation);
 
   /**
    * Sends Luke to sign the next act waiting on him, and puts the panel where
@@ -1915,6 +1950,22 @@ export function App(): React.JSX.Element {
   // stack's wrapped height as the only box that says how many rows the chips
   // made.
   const [noticeRowsElement, noticeBandHeight] = useShapeHeight();
+  /**
+   * The measured caption and band heights the shape spends, held through a
+   * collapse out of the panel. The compact width lands at the flip and
+   * re-wraps the words and the chips while they are still riding down at the
+   * panel's foot, and a re-measure landing mid-ride would open the clips and
+   * retarget the surface past room nothing has made yet. The collapse
+   * travels on the panel's numbers; the compact re-measure lands when the
+   * shape has settled, and grows it there the way words arriving at rest do.
+   */
+  const heldShapeSizes = useRef<{ caption?: number; band?: number }>({});
+  useEffect(() => {
+    if (leavingPanel) return;
+    heldShapeSizes.current = { caption: captionTextHeight, band: noticeBandHeight };
+  });
+  const shownCaptionHeight = leavingPanel ? heldShapeSizes.current.caption : captionTextHeight;
+  const shownBandHeight = leavingPanel ? heldShapeSizes.current.band : noticeBandHeight;
   const [noticeFold, setNoticeFold] = useState({ above: false, below: false });
   const measureNoticeFold = useCallback(() => {
     const band = noticeBand.current;
@@ -2596,6 +2647,9 @@ export function App(): React.JSX.Element {
       // them; with captions off the band stands alone.
       data-notice={String(noticeShown)}
       data-presentation={presentation}
+      // Whether the shape is still on its way down from the panel, so the
+      // surface waits for the content it is carrying instead of leading it.
+      data-leaving-panel={String(leavingPanel)}
       data-notch={String(display.notch.hasNotch)}
       data-capture={String(bootstrap.captureMode)}
       style={{
@@ -2611,8 +2665,8 @@ export function App(): React.JSX.Element {
               : slotHeight,
           feedbackHeight,
         ),
-        ...captionSizeStyle(captionTextHeight, volumeHint, captionPadding),
-        ...noticeGrowthStyle(noticeBandHeight),
+        ...captionSizeStyle(shownCaptionHeight, volumeHint, captionPadding),
+        ...noticeGrowthStyle(shownBandHeight),
       }}
     >
       {/* Capsule, peek, slot and panel are all this one shape at different

--- a/apps/desktop/src/renderer/panel-state.ts
+++ b/apps/desktop/src/renderer/panel-state.ts
@@ -56,3 +56,21 @@ export const SETTLE_DELAY_MS = 1_700;
 export function presentationForMode(mode: WindowMode): PanelPresentation {
   return mode === "expanded" ? PANEL_PRESENTATION.PANEL : PANEL_PRESENTATION.CAPSULE;
 }
+
+/**
+ * Whether a presentation change is the panel standing down to a compact
+ * shape. This is the one shrink that lands in states whose surface rules let
+ * growth lead, so the renderer marks it and the stylesheet holds the shape
+ * back behind the content it is still carrying. The slot and the composer
+ * are not it: they keep the expanded window, and the base surface timing
+ * already serves their shrink.
+ */
+export function leavesPanelForCompact(
+  previous: PanelPresentation,
+  next: PanelPresentation,
+): boolean {
+  return (
+    previous === PANEL_PRESENTATION.PANEL &&
+    (next === PANEL_PRESENTATION.CAPSULE || next === PANEL_PRESENTATION.PEEK)
+  );
+}

--- a/apps/desktop/src/renderer/panel-state.ts
+++ b/apps/desktop/src/renderer/panel-state.ts
@@ -74,3 +74,21 @@ export function leavesPanelForCompact(
     (next === PANEL_PRESENTATION.CAPSULE || next === PANEL_PRESENTATION.PEEK)
   );
 }
+
+/**
+ * Whether the collapse mark stands after a presentation change. Leaving the
+ * panel for a compact shape raises it; a move between the compact shapes
+ * keeps it, because a peek answering a hover mid-collapse is a width
+ * retarget on the same journey down from the panel, and dropping the mark
+ * there releases the surface from behind the content still riding. Any
+ * other shape ends the journey — the panel leads its own growth, and the
+ * slot and the composer run on the base timing.
+ */
+export function collapseMarkAfter(
+  previous: PanelPresentation,
+  next: PanelPresentation,
+  marked: boolean,
+): boolean {
+  if (leavesPanelForCompact(previous, next)) return true;
+  return marked && (next === PANEL_PRESENTATION.CAPSULE || next === PANEL_PRESENTATION.PEEK);
+}

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1520,6 +1520,27 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   transition-delay: 0s;
 }
 
+/* Leaving the panel is the one way into the compact states by a shrink, and
+   the grow-leads rules above would let the shape abandon its content: the
+   panel's rows are still fading over `--duration-exit`, and the caption
+   block and the notice band wait out the same delay before riding down from
+   the panel's foot — a surface moving at once shrinks out from under all of
+   them. The renderer marks the collapse for the window's own collapse clock,
+   exit plus shape, so the shape waits here and nowhere else: a caption or a
+   band growing at rest keeps leading. */
+.app-stage[data-leaving-panel="true"][data-presentation="capsule"] .panel-surface,
+.app-stage[data-leaving-panel="true"][data-presentation="peek"] .panel-surface {
+  transition-delay: var(--duration-exit);
+}
+
+/* The hint rides undelayed everywhere else — expanding, it leads with the
+   panel — so the collapse holds it back with the caption block it explains,
+   or it would leave the block behind and arrive at the housing alone. The
+   opacity keeps the arrival crossing it rides in every state. */
+.app-stage[data-leaving-panel="true"][data-volume-hint="true"][data-caption="true"] .volume-hint {
+  transition-delay: calc(var(--duration-shape) - var(--duration-quick)), var(--duration-exit);
+}
+
 .app-stage[data-presentation="capsule"][data-notice="true"] .compact-hover-target {
   width: var(--peek-width);
   transform: translateX(-50%);

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -207,23 +207,11 @@
   /* The one width the caption block, the volume hint, and the notice band all
      lay out at: the peek less one convex corner a side, so their last row ends
      inside the shape's bottom curve. The open panel overrides it with its own
-     usable width, where these three stand at its foot. `--voice-band-widen`
-     is the half-side step between the two — restated against the compact
-     formula rather than `--voice-band-width`, which the panel's override
-     would zero it through — and the widen keyframes spend it as a clip
-     released on the surface's own duration and spring, so the wider layout
-     is uncovered by the shape's travel instead of being drawn past an edge
-     still springing toward it. */
-  --voice-band-width: calc(var(--peek-width) - var(--notch-convex-radius) * 2);
-  --voice-band-widen: calc(
-    (
-      var(--panel-width) -
-      var(--panel-inset) *
-      2 -
-      (var(--peek-width) - var(--notch-convex-radius) * 2)
-    ) /
-    2
-  );
+     usable width, where these three stand at its foot; the compact value
+     keeps a name of its own because the panel measures its widen step
+     against it. */
+  --voice-band-width-compact: calc(var(--peek-width) - var(--notch-convex-radius) * 2);
+  --voice-band-width: var(--voice-band-width-compact);
   /* Wide enough for a key, a way out, and a way on, and no wider — the page the
      key was copied from is behind this and has to stay readable. The floor is
      what those three need on a display with no housing to grow from. */
@@ -267,9 +255,11 @@
      its usable width — the content column between the panel's insets, which
      also clears the bottom corners' curve beside the band's last row. The
      width itself snaps, because animating a width re-wraps text on every
-     frame; the widen keyframes are what carry the change on the shape's
-     spring. */
+     frame; `--voice-band-widen`, the half-side step up from the compact
+     width, is what the widen keyframe spends as a clip so the change rides
+     the shape's spring instead. */
   --voice-band-width: calc(var(--panel-width) - var(--panel-inset) * 2);
+  --voice-band-widen: calc((var(--voice-band-width) - var(--voice-band-width-compact)) / 2);
 }
 
 /* The wings keep the capsule's quiet form while the slot is drawn — one mark and
@@ -1291,6 +1281,9 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
    under it is what answers, so hovering the words holds the peek like
    hovering the shape does. */
 .voice-caption {
+  /* Named so the widen keyframe can hold it while animating the sides: an
+     animation owns the whole clip-path while it runs. */
+  --voice-band-clip-bottom: calc(var(--caption-max) - var(--caption-size, 28px));
   position: absolute;
   z-index: 3;
   top: var(--capsule-height);
@@ -1299,7 +1292,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   width: var(--voice-band-width);
   height: var(--caption-max);
   padding: 5px 0 9px;
-  clip-path: inset(0 0 calc(var(--caption-max) - var(--caption-size, 28px)) 0);
+  clip-path: inset(0 0 var(--voice-band-clip-bottom));
   opacity: 0;
   pointer-events: none;
   transform: translate(-50%, calc(var(--caption-rest, 0px) - var(--shape-top, 0px)));
@@ -1565,6 +1558,13 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
    would be drawn on the desktop. Above the hover strip (z-index 4) because
    the presses have to open the sessions. */
 .session-notices {
+  /* Named so the widen keyframe can hold it while animating the sides: an
+     animation owns the whole clip-path while it runs. */
+  --voice-band-clip-bottom: calc(
+    var(--notice-size) *
+    var(--notice-max-rows) -
+    var(--notice-growth, var(--notice-size))
+  );
   position: absolute;
   z-index: 5;
   top: var(--capsule-height);
@@ -1580,10 +1580,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
      gives the width back. */
   width: var(--voice-band-width);
   height: calc(var(--notice-size) * var(--notice-max-rows) - 6px);
-  clip-path: inset(
-    0 0 calc(var(--notice-size) * var(--notice-max-rows) - var(--notice-growth, var(--notice-size)))
-      0
-  );
+  clip-path: inset(0 0 var(--voice-band-clip-bottom));
   opacity: 0;
   pointer-events: none;
   transform: translate(-50%, calc(3px - var(--shape-top, 0px) + var(--notice-rest, 0px)));
@@ -1733,59 +1730,26 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
    elements are always mounted, so the animation fires only at the flip and
    never mid-panel, where the surface is already wide and the caption's and
    the band's arriving content needs its clip transition live rather than
-   owned by a finished animation. Those two carry their bottom clips in their
-   keyframes alongside the sides, because an animation owns the whole
-   property while it runs. Leaving the panel needs no twin: the compact width
-   snaps back on the flip, already inside every edge the collapse will
+   owned by a finished animation. One keyframe serves all three because each
+   element's `--voice-band-clip-bottom` — 0 for the hint's bare row — rides
+   through both frames unchanged, so the animation ends exactly on the clip
+   the element's own rule draws. Leaving the panel needs no twin: the compact
+   width snaps back on the flip, already inside every edge the collapse will
    pass. */
 @keyframes voice-band-widen {
   from {
-    clip-path: inset(0 var(--voice-band-widen));
+    clip-path: inset(0 var(--voice-band-widen) var(--voice-band-clip-bottom, 0px));
   }
 
   to {
-    clip-path: inset(0 0);
+    clip-path: inset(0 0 var(--voice-band-clip-bottom, 0px));
   }
 }
 
-@keyframes voice-caption-widen {
-  from {
-    clip-path: inset(
-      0 var(--voice-band-widen) calc(var(--caption-max) - var(--caption-size, 28px))
-    );
-  }
-
-  to {
-    clip-path: inset(0 0 calc(var(--caption-max) - var(--caption-size, 28px)));
-  }
-}
-
-@keyframes notice-band-widen {
-  from {
-    clip-path: inset(
-      0 var(--voice-band-widen)
-        calc(var(--notice-size) * var(--notice-max-rows) - var(--notice-growth, var(--notice-size)))
-    );
-  }
-
-  to {
-    clip-path: inset(
-      0 0
-        calc(var(--notice-size) * var(--notice-max-rows) - var(--notice-growth, var(--notice-size)))
-    );
-  }
-}
-
-.app-stage[data-presentation="panel"] .voice-caption {
-  animation: voice-caption-widen var(--duration-shape) var(--spring);
-}
-
-.app-stage[data-presentation="panel"] .volume-hint {
-  animation: voice-band-widen var(--duration-shape) var(--spring);
-}
-
+.app-stage[data-presentation="panel"] .voice-caption,
+.app-stage[data-presentation="panel"] .volume-hint,
 .app-stage[data-presentation="panel"] .session-notices {
-  animation: notice-band-widen var(--duration-shape) var(--spring);
+  animation: voice-band-widen var(--duration-shape) var(--spring);
 }
 
 /* The chips are drawn on the shape, not in the panel's flow, so the body

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -204,6 +204,26 @@
      from the shared surface tokens, because the compact window reserves its
      room on top of the caption's: the chips stand directly under the housing,
      and captioned words drop below their band. */
+  /* The one width the caption block, the volume hint, and the notice band all
+     lay out at: the peek less one convex corner a side, so their last row ends
+     inside the shape's bottom curve. The open panel overrides it with its own
+     usable width, where these three stand at its foot. `--voice-band-widen`
+     is the half-side step between the two — restated against the compact
+     formula rather than `--voice-band-width`, which the panel's override
+     would zero it through — and the widen keyframes spend it as a clip
+     released on the surface's own duration and spring, so the wider layout
+     is uncovered by the shape's travel instead of being drawn past an edge
+     still springing toward it. */
+  --voice-band-width: calc(var(--peek-width) - var(--notch-convex-radius) * 2);
+  --voice-band-widen: calc(
+    (
+      var(--panel-width) -
+      var(--panel-inset) *
+      2 -
+      (var(--peek-width) - var(--notch-convex-radius) * 2)
+    ) /
+    2
+  );
   /* Wide enough for a key, a way out, and a way on, and no wider — the page the
      key was copied from is behind this and has to stay readable. The floor is
      what those three need on a display with no housing to grow from. */
@@ -243,6 +263,13 @@
 .app-stage[data-presentation="panel"] {
   --notch-concave-radius: calc(var(--panel-radius) * 0.489);
   --wing-bound: var(--panel-width);
+  /* The panel hands the caption block, the volume hint, and the notice band
+     its usable width — the content column between the panel's insets, which
+     also clears the bottom corners' curve beside the band's last row. The
+     width itself snaps, because animating a width re-wraps text on every
+     frame; the widen keyframes are what carry the change on the shape's
+     spring. */
+  --voice-band-width: calc(var(--panel-width) - var(--panel-inset) * 2);
 }
 
 /* The wings keep the capsule's quiet form while the slot is drawn — one mark and
@@ -1269,7 +1296,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   top: var(--capsule-height);
   left: 50%;
   overflow: hidden;
-  width: calc(var(--peek-width) - var(--notch-convex-radius) * 2);
+  width: var(--voice-band-width);
   height: var(--caption-max);
   padding: 5px 0 9px;
   clip-path: inset(0 0 calc(var(--caption-max) - var(--caption-size, 28px)) 0);
@@ -1399,7 +1426,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   align-items: center;
   justify-content: center;
   gap: 9px;
-  width: calc(var(--peek-width) - var(--notch-convex-radius) * 2);
+  width: var(--voice-band-width);
   height: 22px;
   opacity: 0;
   pointer-events: none;
@@ -1521,49 +1548,68 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 
 /* The band the chips share: centred wrapped rows. In the compact states it
    stands directly under the housing and the words are what move — the band
-   wants a fade crossing the last of the shape's travel, not a clip or a
-   journey of its own. `--notice-rest` is its one journey — the ride to the
-   open panel's foot, the caption's own travel — and the transform waits out
+   wants a fade crossing the last of the shape's travel, not a journey of its
+   own. `--notice-rest` is its one journey — the ride to the open panel's
+   foot, the caption's own travel — and the transform waits out
    `--duration-exit` like the caption's does, so leaving a state the band
    travels with the shape rather than ahead of it. It fades as one, however
    many sessions the reply names, so a chip can never linger after the words
-   that earned it. Past `--notice-max-rows` the chips scroll inside the band
-   rather than the shape growing further, because the window reserved exactly
-   that many rows and anything taller would be drawn on the desktop. Above
-   the hover strip (z-index 4) because the presses have to open the
-   sessions. */
+   that earned it. The box is always every row the window reserved and the
+   clip is what tracks the chips — the caption block's own geometry: the rows
+   the chips wrapped into land in layout at once, and the clip springs to
+   `--notice-growth` on the surface's own clock, so a row the chips just
+   wrapped into is uncovered by the shape's travel instead of the box
+   snapping past an edge still springing toward it. Past `--notice-max-rows`
+   the chips scroll inside the band rather than the shape growing further,
+   because the window reserved exactly that many rows and anything taller
+   would be drawn on the desktop. Above the hover strip (z-index 4) because
+   the presses have to open the sessions. */
 .session-notices {
   position: absolute;
   z-index: 5;
   top: var(--capsule-height);
   left: 50%;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  /* The full peek less one corner radius a side: the band's last row ends
-     3px above the shape's edge, where the bottom corners curve in by this
-     much, and a chip any wider would poke past the curve onto the desktop.
-     A definite width, not a cap: `left: 50%` leaves an absolutely positioned
-     box only the right half of the stage as available space, so a
-     shrink-to-fit band resolves to half its intended width and stacks one
-     chip to a row — the translate recentres the box but never gives the
-     width back. */
-  width: calc(var(--peek-width) - var(--notch-convex-radius) * 2);
-  max-height: calc(var(--notice-size) * var(--notice-max-rows) - 6px);
   overflow-y: auto;
+  /* The state's own band width, shared with the caption block: the band's
+     last row ends 3px above the shape's edge, where the bottom corners curve
+     in, and a chip wider than the state's width would poke past the curve
+     onto the desktop. A definite width, not a cap: `left: 50%` leaves an
+     absolutely positioned box only the right half of the stage as available
+     space, so a shrink-to-fit band resolves to half its intended width and
+     stacks one chip to a row — the translate recentres the box but never
+     gives the width back. */
+  width: var(--voice-band-width);
+  height: calc(var(--notice-size) * var(--notice-max-rows) - 6px);
+  clip-path: inset(
+    0 0 calc(var(--notice-size) * var(--notice-max-rows) - var(--notice-growth, var(--notice-size)))
+      0
+  );
   opacity: 0;
   pointer-events: none;
   transform: translate(-50%, calc(3px - var(--shape-top, 0px) + var(--notice-rest, 0px)));
   transition:
     opacity var(--duration-exit) var(--motion-exit),
-    transform var(--duration-shape) var(--spring) var(--duration-exit);
+    transform var(--duration-shape) var(--spring) var(--duration-exit),
+    clip-path var(--duration-shape) var(--spring) var(--duration-exit);
+}
+
+/* The rows inside the box: the chips wrap here, so this stack's natural
+   height — never the clipped box's — is what the renderer measures into
+   `--notice-growth`. */
+.session-notice-rows {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
 }
 
 /* Arrives the way the caption's first words do — the fade crossing the last
-   of the shape's travel. Takes the pointer only while it is drawn, because
-   everything a hidden button covers is desktop. */
+   of the shape's travel, and the clip alone taking no delay while the band
+   is up: it is the shape's twin, not content following it. Takes the pointer
+   only while it is drawn, because everything a hidden button covers is
+   desktop. */
 .app-stage[data-presentation="capsule"][data-notice="true"] .session-notices,
 .app-stage[data-presentation="peek"][data-notice="true"] .session-notices {
   opacity: 1;
@@ -1571,7 +1617,8 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   transition:
     opacity var(--duration-quick) var(--motion-exit)
     calc(var(--duration-shape) - var(--duration-quick)),
-    transform var(--duration-shape) var(--spring) var(--duration-exit);
+    transform var(--duration-shape) var(--spring) var(--duration-exit),
+    clip-path var(--duration-shape) var(--spring);
 }
 
 /* The folds: a band with chips beyond an edge fades the chips into that
@@ -1672,7 +1719,73 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   transition:
     opacity var(--duration-quick) var(--motion-exit)
     calc(var(--duration-shape) - var(--duration-quick)),
-    transform var(--duration-shape) var(--spring);
+    transform var(--duration-shape) var(--spring),
+    clip-path var(--duration-shape) var(--spring);
+}
+
+/* Opening the panel is the one move that changes `--voice-band-width`, and
+   the new width lands at once — a width that animated would re-wrap the words
+   and re-flow the chips on every frame. What must not land at once is the
+   reveal: on the flip the surface is still the peek's width, so the extra
+   width waits behind a side clip released on the surface's own duration and
+   spring — the shape's edge is what uncovers the wider rows, exactly as it
+   uncovers arriving content. Keyed to the presentation alone: all three
+   elements are always mounted, so the animation fires only at the flip and
+   never mid-panel, where the surface is already wide and the caption's and
+   the band's arriving content needs its clip transition live rather than
+   owned by a finished animation. Those two carry their bottom clips in their
+   keyframes alongside the sides, because an animation owns the whole
+   property while it runs. Leaving the panel needs no twin: the compact width
+   snaps back on the flip, already inside every edge the collapse will
+   pass. */
+@keyframes voice-band-widen {
+  from {
+    clip-path: inset(0 var(--voice-band-widen));
+  }
+
+  to {
+    clip-path: inset(0 0);
+  }
+}
+
+@keyframes voice-caption-widen {
+  from {
+    clip-path: inset(
+      0 var(--voice-band-widen) calc(var(--caption-max) - var(--caption-size, 28px))
+    );
+  }
+
+  to {
+    clip-path: inset(0 0 calc(var(--caption-max) - var(--caption-size, 28px)));
+  }
+}
+
+@keyframes notice-band-widen {
+  from {
+    clip-path: inset(
+      0 var(--voice-band-widen)
+        calc(var(--notice-size) * var(--notice-max-rows) - var(--notice-growth, var(--notice-size)))
+    );
+  }
+
+  to {
+    clip-path: inset(
+      0 0
+        calc(var(--notice-size) * var(--notice-max-rows) - var(--notice-growth, var(--notice-size)))
+    );
+  }
+}
+
+.app-stage[data-presentation="panel"] .voice-caption {
+  animation: voice-caption-widen var(--duration-shape) var(--spring);
+}
+
+.app-stage[data-presentation="panel"] .volume-hint {
+  animation: voice-band-widen var(--duration-shape) var(--spring);
+}
+
+.app-stage[data-presentation="panel"] .session-notices {
+  animation: notice-band-widen var(--duration-shape) var(--spring);
 }
 
 /* The chips are drawn on the shape, not in the panel's flow, so the body

--- a/apps/desktop/tests/panel-state.test.ts
+++ b/apps/desktop/tests/panel-state.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { leavesPanelForCompact, PANEL_PRESENTATION } from "../src/renderer/panel-state";
+
+test("only the panel standing down to a compact shape marks a collapse", () => {
+  assert.equal(leavesPanelForCompact(PANEL_PRESENTATION.PANEL, PANEL_PRESENTATION.CAPSULE), true);
+  assert.equal(leavesPanelForCompact(PANEL_PRESENTATION.PANEL, PANEL_PRESENTATION.PEEK), true);
+});
+
+test("standing down to the slot or the composer keeps the base surface timing", () => {
+  assert.equal(leavesPanelForCompact(PANEL_PRESENTATION.PANEL, PANEL_PRESENTATION.SLOT), false);
+  assert.equal(leavesPanelForCompact(PANEL_PRESENTATION.PANEL, PANEL_PRESENTATION.FEEDBACK), false);
+});
+
+test("moves between compact shapes are not a collapse, and neither is expanding", () => {
+  assert.equal(leavesPanelForCompact(PANEL_PRESENTATION.CAPSULE, PANEL_PRESENTATION.PEEK), false);
+  assert.equal(leavesPanelForCompact(PANEL_PRESENTATION.PEEK, PANEL_PRESENTATION.CAPSULE), false);
+  assert.equal(leavesPanelForCompact(PANEL_PRESENTATION.CAPSULE, PANEL_PRESENTATION.PANEL), false);
+  assert.equal(leavesPanelForCompact(PANEL_PRESENTATION.SLOT, PANEL_PRESENTATION.CAPSULE), false);
+});

--- a/apps/desktop/tests/panel-state.test.ts
+++ b/apps/desktop/tests/panel-state.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { leavesPanelForCompact, PANEL_PRESENTATION } from "../src/renderer/panel-state";
+import {
+  collapseMarkAfter,
+  leavesPanelForCompact,
+  PANEL_PRESENTATION,
+} from "../src/renderer/panel-state";
 
 test("only the panel standing down to a compact shape marks a collapse", () => {
   assert.equal(leavesPanelForCompact(PANEL_PRESENTATION.PANEL, PANEL_PRESENTATION.CAPSULE), true);
@@ -17,4 +21,37 @@ test("moves between compact shapes are not a collapse, and neither is expanding"
   assert.equal(leavesPanelForCompact(PANEL_PRESENTATION.PEEK, PANEL_PRESENTATION.CAPSULE), false);
   assert.equal(leavesPanelForCompact(PANEL_PRESENTATION.CAPSULE, PANEL_PRESENTATION.PANEL), false);
   assert.equal(leavesPanelForCompact(PANEL_PRESENTATION.SLOT, PANEL_PRESENTATION.CAPSULE), false);
+});
+
+test("the mark survives a hover peeking mid-collapse", () => {
+  assert.equal(collapseMarkAfter(PANEL_PRESENTATION.CAPSULE, PANEL_PRESENTATION.PEEK, true), true);
+  assert.equal(collapseMarkAfter(PANEL_PRESENTATION.PEEK, PANEL_PRESENTATION.CAPSULE, true), true);
+});
+
+test("compact moves with no collapse under way raise no mark", () => {
+  assert.equal(
+    collapseMarkAfter(PANEL_PRESENTATION.CAPSULE, PANEL_PRESENTATION.PEEK, false),
+    false,
+  );
+  assert.equal(
+    collapseMarkAfter(PANEL_PRESENTATION.PEEK, PANEL_PRESENTATION.CAPSULE, false),
+    false,
+  );
+});
+
+test("leaving the panel raises the mark; any non-compact shape ends it", () => {
+  assert.equal(
+    collapseMarkAfter(PANEL_PRESENTATION.PANEL, PANEL_PRESENTATION.CAPSULE, false),
+    true,
+  );
+  assert.equal(collapseMarkAfter(PANEL_PRESENTATION.PANEL, PANEL_PRESENTATION.PEEK, false), true);
+  assert.equal(
+    collapseMarkAfter(PANEL_PRESENTATION.CAPSULE, PANEL_PRESENTATION.PANEL, true),
+    false,
+  );
+  assert.equal(collapseMarkAfter(PANEL_PRESENTATION.PANEL, PANEL_PRESENTATION.SLOT, true), false);
+  assert.equal(
+    collapseMarkAfter(PANEL_PRESENTATION.PANEL, PANEL_PRESENTATION.FEEDBACK, true),
+    false,
+  );
 });


### PR DESCRIPTION
## What

In the expanded panel, the voice caption block, the volume hint, and the mention-chip band now lay out at the panel's usable width (the 580px column between its insets) instead of staying at the peek-tied width they keep in capsule and peek. Three commits:

1. **feat**: one shared `--voice-band-width` per state; the width snaps at the presentation flip (an animated width re-wraps text every frame) and a widen keyframe releases the extra width behind a side clip on the surface's own duration and spring, so the shape's edge is what uncovers the wider rows. The band adopts the caption block's proven geometry — a fixed box for every reserved row with a clip springing to the measured `--notice-growth` — measured off a new rows stack inside it.
2. **refactor**: the three per-element widen keyframes fold into one via an element-scoped `--voice-band-clip-bottom`, and the compact width formula is stated once (`--voice-band-width-compact`). Verified behavior-identical by computed-style comparison.
3. **fix**: collapsing out of the panel mid-announcement left the caption and chips drawn outside the shrinking surface — the captioned/noticed compact surface rules force `transition-delay: 0s` for the grow direction, so the shape led the content it was carrying (a pre-existing bug the full width made conspicuous). The renderer now marks the collapse (`data-leaving-panel`) for the window's own collapse clock; the stylesheet holds the surface back by `--duration-exit` while the mark stands, and the measured caption/band heights are held through the collapse so the compact re-wrap cannot open the clips past room nothing has made yet.

## Verification

- `./scripts/check.sh`: exit 0, zero `not ok`, after rebasing onto main (including #269's whole-caption change — the widen and collapse rules compose with the new 210px caption box unchanged).
- Per-frame headless CDP sampling (DESIGN.md's off-Mac proof): the unfixed stylesheet leaves the caption over 100px outside the surface mid-collapse; with the fix, caption, hint, and band stay inside the shape's edges through collapse, the settled re-measure, and the expand back — 0 violation frames of 295.
- Widen keyframe poses sampled at progress 0 and 1 match the resting clips exactly, at full and partial band growth.
- **No physical-notch check was performed** — worth one hardware eyeball of an expand/collapse mid-announcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/8a6d64a1-af56-41d0-af37-5e3e0cd0ba47)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32206844039/artifacts/9349426408) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32206844039)

- Commit: `54161155c95ed57470040e65c687504a4dd9a3a1`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
