### PR TITLE
fix(desktop): hold the meeting quiet through calendar misreads, with punctual edges

### DIFF
--- a/apps/desktop/src/desktop-app.ts
+++ b/apps/desktop/src/desktop-app.ts
@@ -273,8 +273,9 @@ const heldNotices = new SessionNoticeHold();
  * The other kind of announcement, held on the same terms: speech an answered
  * standing ask produced, already worded. It waits out a meeting exactly as a
  * status edge does — both break silence, and the quiet holds everything that
- * does. Unbidden evaluator summaries are never held: they only ever ride a
- * conversation the developer already has open, which is not silence to break.
+ * does. Unbidden evaluator summaries are never held: during the quiet they
+ * are dropped outright, because the evaluator supersedes its own decisions
+ * and speaks from a fresh review once the meeting ends.
  */
 const heldRequestSpeech = new SessionNoticeHold<AttentionSpeech>();
 /**
@@ -881,16 +882,21 @@ async function reviewSessionAttention(generation: number): Promise<void> {
     // `outcome` says whether to voice it now, which only these reviews do.
     const speech = attentionSpeechFromReviews(reviews);
     if (speech.length > 0) {
-      // An answered standing ask opens Luke's own call the way a status edge
-      // does, so the meeting quiet holds it the same way; the summaries that
-      // only ride an open conversation pass, because a developer mid-call is
-      // already talking to Luke, meeting or not. The pressable notice
-      // anchors to the spoken announcement, so it waits out the quiet with it.
+      // The quiet holds everything Luke would say unbidden. An answered
+      // standing ask waits out the meeting the way a status edge does; an
+      // unbidden evaluator summary is dropped rather than held — the
+      // evaluator supersedes its own decisions, so after the meeting it
+      // speaks from a fresh review, not a backlog. Neither rides even an
+      // open conversation: a call lingering idle after a question is not a
+      // conversation to interject into, and a reply to a turn the developer
+      // opened is not an announcement and passes untouched elsewhere. The
+      // pressable notice anchors to the spoken announcement, so it waits out
+      // the quiet with it.
       let sendable: readonly AttentionSpeech[] = speech;
       if (await announcementsQuietNow(Date.now())) {
         const held = speech.filter((item) => item.source !== ATTENTION_SPEECH_SOURCE.EVALUATOR);
         heldRequestSpeech.hold(held);
-        sendable = speech.filter((item) => item.source === ATTENTION_SPEECH_SOURCE.EVALUATOR);
+        sendable = [];
       }
       if (sendable.length > 0) {
         // Spoken once, by the one window that holds the voice: every display

--- a/apps/desktop/src/desktop-app.ts
+++ b/apps/desktop/src/desktop-app.ts
@@ -14,6 +14,7 @@ import {
   isProviderId,
   type MeetingInterval,
   type NormalizedSession,
+  nextMeetingBoundary,
   normalizeObservedWorkspaceProjects,
   normalizeTrackedIssue,
   type ObservedWorkspaceProject,
@@ -237,7 +238,9 @@ const CALENDAR_REFRESH_INTERVAL_MS = 5 * 60_000;
 /**
  * How often held notices ask whether the meeting holding them has ended. The
  * question is answered from meetings already in memory, so asking often costs
- * nothing — and half a minute is how late after a meeting the backlog speaks.
+ * nothing. The boundary timer is what answers on time — this tick is the net
+ * behind it, for the clocks a timer cannot promise to keep: a laptop asleep
+ * through the boundary, or a system clock moved by hand.
  */
 const HELD_NOTICE_RELEASE_INTERVAL_MS = 30_000;
 /**
@@ -246,6 +249,14 @@ const HELD_NOTICE_RELEASE_INTERVAL_MS = 30_000;
  * calendar that cannot answer is not an empty diary.
  */
 let calendarMeetings: readonly MeetingInterval[] | undefined;
+/**
+ * The timer standing at the next meeting edge — the instant the quiet can
+ * begin or end. The interval ticks bound how *stale* the quiet's answer can
+ * get; this is what makes its edges *punctual*, so a meeting's first second
+ * is already held and its last is already released, rather than either
+ * waiting on the next half-minute tick.
+ */
+let quietBoundaryTimer: NodeJS.Timeout | undefined;
 /**
  * Each connected account's calendars as last observed — what the settings
  * rows draw their choices from, and what a spoken-of or clicked selection is
@@ -963,23 +974,62 @@ function openCreatedWorkspaces(sessions: readonly NormalizedSession[]): void {
  * are consulted before the store so the common case — no calendar — costs no
  * read at all; the store's answer comes from its cached file either way,
  * never the keychain.
+ *
+ * Consulting it is also what keeps every window honest: the answer is
+ * reconciled with the broadcast state on the way out, so speech can never be
+ * decided against a fresher quiet than the one the face and the renderer's
+ * own gate are holding. Without that, an edge landing just after a meeting's
+ * end would speak over a face still drawn asleep until the next tick.
  */
 async function announcementsQuietNow(now: number): Promise<boolean> {
-  if (!calendarMeetings || activeMeetingEnd(calendarMeetings, now) === undefined) return false;
-  return settingsStore.get(APP_SETTING_SCHEMA.quietDuringMeetings.field);
+  const inMeeting =
+    calendarMeetings !== undefined && activeMeetingEnd(calendarMeetings, now) !== undefined;
+  const holding =
+    inMeeting && (await settingsStore.get(APP_SETTING_SCHEMA.quietDuringMeetings.field));
+  if (holding !== meetingQuietActive) {
+    meetingQuietActive = holding;
+    panels.broadcast(channels.meetingQuietChanged, holding);
+  }
+  return holding;
 }
 
 /**
- * Recomputes whether the quiet is holding and tells the renderer on change —
- * the face sleeps beside the housing for exactly as long as this is true.
- * Ridden by the same ticks that read the calendar and release the backlog,
- * and by the setting's own toggle, so the face never says a quiet that ended.
+ * Recomputes whether the quiet is holding — the face sleeps beside the
+ * housing for exactly as long as it is. The recompute itself broadcasts any
+ * change; this name is for the callers with nothing to say and only the face
+ * to keep current: the boundary timer, the ticks, and the setting's toggle.
  */
 async function refreshMeetingQuiet(): Promise<void> {
-  const active = await announcementsQuietNow(Date.now());
-  if (active === meetingQuietActive) return;
-  meetingQuietActive = active;
-  panels.broadcast(channels.meetingQuietChanged, active);
+  await announcementsQuietNow(Date.now());
+}
+
+/**
+ * Stands the boundary timer at the next meeting edge, from the intervals
+ * already in memory. On fire the quiet is recomputed and the backlog asked
+ * after — the same pair every tick runs — and the timer re-arms for the edge
+ * after that. Re-armed whole from every calendar pass because the pass may
+ * have moved any edge; cleared with the meetings at sign-out. `unref`ed like
+ * the ticks, so no meeting tomorrow holds the process open tonight.
+ */
+function armQuietBoundaryTimer(): void {
+  if (quietBoundaryTimer) clearTimeout(quietBoundaryTimer);
+  quietBoundaryTimer = undefined;
+  if (!calendarMeetings) return;
+  const now = Date.now();
+  const boundary = nextMeetingBoundary(calendarMeetings, now);
+  if (boundary === undefined) return;
+  // The extra millisecond puts the firing strictly past the edge, so the
+  // recompute reads the side of it the timer was armed for.
+  quietBoundaryTimer = setTimeout(
+    () => {
+      quietBoundaryTimer = undefined;
+      void refreshMeetingQuiet();
+      void releaseHeldNotices();
+      armQuietBoundaryTimer();
+    },
+    boundary - now + 1,
+  );
+  quietBoundaryTimer.unref();
 }
 
 /**
@@ -1061,6 +1111,7 @@ async function refreshCalendarMeetings(generation: number): Promise<void> {
   if (!calendarObservationLoop.isCurrent(generation)) return;
   void refreshMeetingQuiet();
   void releaseHeldNotices();
+  armQuietBoundaryTimer();
 }
 
 const observationGate = () => runMode.observesProviders && accountCapabilitiesActive();
@@ -1100,9 +1151,8 @@ const observationSupervisor = new ObservationSupervisor([
 function startCalendarObservation(): void {
   if (heldNoticeReleaseTimer) return;
   heldNoticeReleaseTimer = setInterval(() => {
-    // The quiet's edges move with the clock between calendar reads — a
-    // meeting starts, a meeting ends — so the face's answer refreshes on the
-    // release tick, not only when the feed is re-read.
+    // The boundary timer answers the meeting edges on time; this tick is the
+    // net under it, re-asking on a cadence no missed timer can silence.
     void refreshMeetingQuiet();
     void releaseHeldNotices();
   }, HELD_NOTICE_RELEASE_INTERVAL_MS);
@@ -1118,6 +1168,8 @@ function startCalendarObservation(): void {
 function stopCalendarObservation(): void {
   if (heldNoticeReleaseTimer) clearInterval(heldNoticeReleaseTimer);
   heldNoticeReleaseTimer = undefined;
+  if (quietBoundaryTimer) clearTimeout(quietBoundaryTimer);
+  quietBoundaryTimer = undefined;
   calendarMeetings = undefined;
   observedCalendars = [];
   // The reader forgets what it held for failing accounts too: a pass after

--- a/apps/desktop/src/google-calendar.ts
+++ b/apps/desktop/src/google-calendar.ts
@@ -247,9 +247,20 @@ export class GoogleCalendarReader {
     const calendars = isRecord(payload) && isRecord(payload.calendars) ? payload.calendars : {};
     // Every asked-for calendar's busy blocks, together: which calendar a
     // meeting sits on does not matter to a hold, only that the user is in it.
+    // Every asked-for calendar must also have answered: Google reports a
+    // calendar it could not read just then as an `errors` entry inside a 200,
+    // not as a failing request, and a calendar that cannot answer is not an
+    // empty diary. Read as free, one such entry would end a quiet mid-meeting
+    // and dump the held announcements aloud — so the pass fails instead, and
+    // the account stands what it last showed.
     const busy: unknown[] = [];
-    for (const entry of Object.values(calendars)) {
-      if (isRecord(entry) && Array.isArray(entry.busy)) busy.push(...entry.busy);
+    for (const id of calendarIds) {
+      const entry = calendars[id];
+      const errored = isRecord(entry) && Array.isArray(entry.errors) && entry.errors.length > 0;
+      if (!isRecord(entry) || errored || !Array.isArray(entry.busy)) {
+        throw new Error(`Google Calendar could not read free/busy for "${id}"`);
+      }
+      busy.push(...entry.busy);
     }
     return meetingsFromBusyIntervals(busy, now);
   }

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -471,8 +471,10 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
                   "announcements decided during a meeting wait and are read out together once " +
                   "it ends. The quiet beginning — a meeting starting, or the setting switched " +
                   "on mid-meeting — silences Luke at once, an announcement mid-sentence " +
-                  "included — and Luke's face sleeps beside the housing for as long as the " +
-                  "quiet holds, which is how the hold is seen."
+                  "included, and holds everything he would say unbidden, even on an open " +
+                  "conversation; questions asked of him still get their replies. Luke's face " +
+                  "sleeps beside the housing for as long as the quiet holds, which is how the " +
+                  "hold is seen."
                 : ""),
           },
           {

--- a/apps/desktop/tests/google-calendar.test.ts
+++ b/apps/desktop/tests/google-calendar.test.ts
@@ -232,6 +232,58 @@ test("one bad account never blinds the others, and keeps what it last showed", a
   assert.equal(second?.[1]?.failure, undefined);
 });
 
+test("a calendar unread inside an OK answer is a failure, not a quieter calendar", async () => {
+  // Google reports a calendar it could not read just then as an `errors`
+  // entry inside a 200 answer, not as a failing request. Read as free, the
+  // ongoing meeting would vanish for one pass — ending the quiet mid-meeting
+  // and dumping the held announcements aloud — so the pass fails and the
+  // account stands what it last showed.
+  let broken = false;
+  const { reader } = readerWith(
+    (request) => {
+      if (request.url === FREEBUSY_URL && broken) {
+        return jsonOk({
+          calendars: {
+            "work@example.com": { busy: [] },
+            "team-calendar": { errors: [{ domain: "global", reason: "internalError" }] },
+          },
+        });
+      }
+      return routes(request);
+    },
+    [WORK_ACCOUNT],
+  );
+
+  const first = await reader.observe();
+  assert.equal(first?.[0]?.failure, undefined);
+  broken = true;
+  const second = await reader.observe();
+
+  assert.match(second?.[0]?.failure ?? "", /team-calendar/);
+  assert.deepEqual(second?.[0]?.meetings, first?.[0]?.meetings);
+});
+
+test("an asked-for calendar missing from the answer fails the pass the same way", async () => {
+  const { reader } = readerWith(
+    (request) =>
+      request.url === FREEBUSY_URL
+        ? jsonOk({
+            calendars: {
+              "work@example.com": {
+                busy: [{ start: "2026-08-17T13:00:00Z", end: "2026-08-17T14:00:00Z" }],
+              },
+            },
+          })
+        : routes(request),
+    [WORK_ACCOUNT],
+  );
+
+  const observed = await reader.observe();
+
+  assert.match(observed?.[0]?.failure ?? "", /team-calendar/);
+  assert.deepEqual(observed?.[0]?.meetings, []);
+});
+
 test("forgetting ends an era: a failing pass after it holds nothing up", async () => {
   let broken = false;
   const { reader } = readerWith(

--- a/packages/sidecar-core/src/calendar.ts
+++ b/packages/sidecar-core/src/calendar.ts
@@ -74,3 +74,24 @@ export function activeMeetingEnd(
   }
   return latest;
 }
+
+/**
+ * The next instant at which {@link activeMeetingEnd}'s answer can change: the
+ * earliest meeting edge — a start or an end — still ahead of `now`, or nothing
+ * with no edge ahead. Not every edge changes the answer (a meeting ending
+ * inside a longer one changes nothing), but every change happens at an edge,
+ * so a caller re-asking at each is never late — and with the list bounded,
+ * never asked often enough to cost anything.
+ */
+export function nextMeetingBoundary(
+  meetings: readonly MeetingInterval[],
+  now: number,
+): number | undefined {
+  let next: number | undefined;
+  for (const meeting of meetings) {
+    for (const edge of [meeting.startsAt, meeting.endsAt]) {
+      if (edge > now && (next === undefined || edge < next)) next = edge;
+    }
+  }
+  return next;
+}

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -83,6 +83,7 @@ export {
   MAXIMUM_MEETING_LENGTH_MS,
   type MeetingInterval,
   meetingsFromBusyIntervals,
+  nextMeetingBoundary,
 } from "./calendar.js";
 
 // Providers — adapters and the acts they advertise.

--- a/packages/sidecar-core/tests/calendar.test.ts
+++ b/packages/sidecar-core/tests/calendar.test.ts
@@ -5,6 +5,7 @@ import {
   CALENDAR_LOOKAHEAD_MS,
   MAXIMUM_CALENDAR_MEETINGS,
   meetingsFromBusyIntervals,
+  nextMeetingBoundary,
 } from "../src";
 
 /** Noon UTC on a fixed Monday, so every expectation is a plain number. */
@@ -67,4 +68,25 @@ test("activeMeetingEnd answers only inside a meeting", () => {
   // An end is an end, not a last covered instant.
   assert.equal(activeMeetingEnd(meetings, 6_000), undefined);
   assert.equal(activeMeetingEnd([], 1_000), undefined);
+});
+
+test("nextMeetingBoundary names the earliest edge still ahead", () => {
+  const meetings = [
+    { startsAt: 1_000, endsAt: 2_000 },
+    { startsAt: 1_500, endsAt: 3_000 },
+    { startsAt: 5_000, endsAt: 6_000 },
+  ];
+
+  // Before anything: the first start is the next edge.
+  assert.equal(nextMeetingBoundary(meetings, 500), 1_000);
+  // Inside the overlap, the inner end is still an edge — not every edge
+  // changes the answer, but every change happens at one.
+  assert.equal(nextMeetingBoundary(meetings, 1_600), 2_000);
+  assert.equal(nextMeetingBoundary(meetings, 2_500), 3_000);
+  // The gap looks ahead to the next start; an instant is never its own edge.
+  assert.equal(nextMeetingBoundary(meetings, 3_000), 5_000);
+  assert.equal(nextMeetingBoundary(meetings, 5_500), 6_000);
+  // Past the last end there is nothing left to wait for.
+  assert.equal(nextMeetingBoundary(meetings, 6_000), undefined);
+  assert.equal(nextMeetingBoundary([], 1_000), undefined);
 });


### PR DESCRIPTION
## Investigation

Follow-up to #270. Reported symptom (refined twice): a meeting an hour in with ninety minutes still to run, Luke's face showing the sleeping icon **the entire time**, and Luke still speaking up sometimes. Explicit questions the developer asks must — and do — still get replies; only Luke-driven announcements are held. This PR closes three distinct holes found along the way, in the order the evidence narrowed them.

### 1. The one that matches the sleeping face: unbidden evaluator summaries rode any open call, quiet or not

`microphoneCall` is true for the whole life of a conversation call — including the ~10 idle minutes it lingers after the developer's last question. During the quiet, `reviewSessionAttention` deliberately passed unbidden evaluator summaries through, and the renderer speaks them on any open developer call. So: ask Luke a question mid-meeting (answered, as it should be), the call lingers idle, and an unbidden summary speaks aloud minutes later — face asleep before and after, the quiet honestly holding throughout. Matches every observation: mid-meeting at any point, intermittent, sleeping icon the whole time, and precisely Luke-driven speech rather than a reply.

**Fix:** the quiet now holds everything Luke would say unbidden. An answered standing ask waits out the meeting as a status edge does; an unbidden evaluator summary is dropped rather than held — the evaluator supersedes its own decisions, so after the meeting it speaks from a fresh review, not a backlog. Replies to developer-opened turns are untouched. The guide's Announcements fact states the rule so Luke describes himself correctly.

### 2. A calendar unread inside a 200 answer erased the ongoing meeting

Google's freeBusy reports a calendar it could not read just then as an `errors` entry inside a 200 answer, not as a failing request; the reader pooled only entries carrying a `busy` array and silently skipped the rest. One transiently unreadable calendar made a successful-looking pass whose meetings lacked the ongoing meeting — quiet off mid-meeting, held backlog dumped aloud, restored by the next pass. (This one would have woken the face for up to five minutes, so it is not the sleeping-face symptom — but it is real.) **Fix:** every asked-for calendar must answer with its busy list; otherwise the account's pass fails and stands what it last showed, naming the calendar in the failure line.

### 3. The quiet's edges were up to 30 seconds late

The speech gates recomputed the quiet per decision while the face and the renderer's #270 gate followed `meetingQuietActive`, refreshed only by the 30-second tick and 5-minute calendar pass. **Fix:** `nextMeetingBoundary` (sidecar-core) names the earliest meeting edge ahead; a boundary timer recomputes the quiet and asks after the backlog the instant an edge passes, re-arming for the next — re-armed whole each calendar pass, cleared at sign-out, `unref`ed. `announcementsQuietNow` also reconciles the broadcast state on the way out, so speech is never decided against a fresher quiet than the face is holding; the tick remains as the net for clocks a timer cannot promise to keep.

Everything the timers and gates decide stays arithmetic against observed intervals — no model output can reach any of it.

## Tests

- Free/busy answers with an `errors` entry, or with an asked-for calendar missing entirely, are failures that stand the last observation — not quieter calendars.
- `nextMeetingBoundary` unit coverage: earliest edge ahead, overlapping meetings' inner edges, gaps, past-the-last-end, empty list.
- The renderer's mid-sentence cut-off is #270's, already covered in `spoken-notices.test.ts`.

## Verification

`./scripts/check.sh` passes: repository contract checks, lint, typecheck, 253 core + 1129 desktop + 40 web tests (0 fail), build. (One unrelated flaky loopback test, `linear-oauth.test.ts` "a claimed callback is allowed to finish after the waiting timeout", reset a socket on one run and passes in isolation and on rerun.) Portable-only change — main-process gating, reader, and timing plus one pure core function — no visual or macOS surface change, so no `verify.sh` evidence run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32209145211/artifacts/9350151189) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32209145211)

- Commit: `ac2cb4d5fefbe9d7e55aa5a6ad1c9d0cca1afee8`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
