### PR TITLE
fix(web): repeat the link card under the twitter: names X reads

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -21,11 +21,11 @@
     <meta property="og:url" content="https://tryluke.dev/" />
     <!-- The 1200x630 card every unfurler reads — Facebook, LinkedIn, Slack,
          Discord, iMessage, WhatsApp, and Telegram all take these Open Graph
-         tags, and X falls back to them under twitter:card. The URL is
-         absolute because scrapers resolve nothing, the dimensions let a
-         first share render before the image is fetched, and the alt is what
-         screen readers get on platforms that honor it. The PNG is cut from
-         design/brand/social/luke-og-card.svg — see design/brand/README.md. -->
+         tags. The URL is absolute because scrapers resolve nothing, the
+         dimensions let a first share render before the image is fetched, and
+         the alt is what screen readers get on platforms that honor it. The
+         PNG is cut from design/brand/social/luke-og-card.svg — see
+         design/brand/README.md. -->
     <meta property="og:image" content="https://tryluke.dev/luke-og-card.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -35,8 +35,20 @@
       content="The LUKE wordmark — a smiling L-face followed by U, K, E — on space black."
     />
     <!-- summary_large_image is what makes X and Discord show the card full
-         width instead of as a thumbnail. -->
+         width instead of as a thumbnail. X documents falling back to the
+         Open Graph tags, but its crawler renders no image on that fallback,
+         so the card is repeated under the twitter: names it reads. -->
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Luke — your AI engineering manager" />
+    <meta
+      name="twitter:description"
+      content="Luke is an open-source macOS app that watches your coding agent sessions and shows you which ones need you."
+    />
+    <meta name="twitter:image" content="https://tryluke.dev/luke-og-card.png" />
+    <meta
+      name="twitter:image:alt"
+      content="The LUKE wordmark — a smiling L-face followed by U, K, E — on space black."
+    />
 
     <!-- Luke's app icon: the L-face on its space-black tile, traced from the
          generated design/brand/icon/luke-icon-dark.svg — the dark set serves

--- a/apps/web/privacy.html
+++ b/apps/web/privacy.html
@@ -24,6 +24,13 @@
       content="The LUKE wordmark — a smiling L-face followed by U, K, E — on space black."
     />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Privacy — Luke" />
+    <meta name="twitter:description" content="What Luke reads, when, and where it sends it." />
+    <meta name="twitter:image" content="https://tryluke.dev/luke-og-card.png" />
+    <meta
+      name="twitter:image:alt"
+      content="The LUKE wordmark — a smiling L-face followed by U, K, E — on space black."
+    />
 
     <!-- The compact state as a mark: display frame, black notch capsule, cyan
          status dot. Inline so the page ships no binary asset. -->


### PR DESCRIPTION
## Summary

Shared links to tryluke.dev showed no preview image on X, while Slack, Discord, iMessage, and the other unfurlers drew the Open Graph card fine. The card itself was never the problem: `https://tryluke.dev/luke-og-card.png` serves correctly, and no robots rule blocks Twitterbot. The pages relied on X's documented fallback from `og:image` under `twitter:card`, and X's crawler renders no image on that fallback in practice.

- `apps/web/index.html`: add explicit `twitter:image`, `twitter:image:alt`, `twitter:title`, and `twitter:description` pointing at the same card, and rewrite the head comment that claimed the og fallback was sufficient.
- `apps/web/privacy.html`: the same four tags, since it shares the identical fallback bug.

No change to the card artwork — the face already lives in the wordmark's L.

## Validation

- `./scripts/check.sh` passes (exit 0).
- Web-only change; `./scripts/verify.sh` does not apply, and no visual evidence or physical-notch check is relevant.
- X caches unfurls, so after deploy the card validator (or a fresh query string on a test post) is the way to confirm the render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/4378ad2f-f271-4aa6-9377-04121bb0b852)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32207697087/artifacts/9349689874) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32207697087)

- Commit: `6244d635e1144dcab84795275db69436e9a940f0`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
