### PR TITLE
chore(release): bump version to 0.2.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@luke/desktop",
   "productName": "Luke",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "description": "Luke desktop application",
   "main": "dist/main.js",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luke/web",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "description": "Luke landing page",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luke",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "description": "A notch-attached desktop sidecar for coding-agent sessions",
   "packageManager": "pnpm@9.15.0",

--- a/packages/sidecar-core/package.json
+++ b/packages/sidecar-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/core",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -49,11 +49,11 @@ function packagerOptions(signing = resolveSigningMode({})) {
     licensePath: `/repo/apps/desktop/.build/${LICENSE_RESOURCE_NAME}`,
     entitlementsPath,
     signing,
-    version: "0.1.1",
+    version: "0.2.0",
   });
 }
 
-test("workspace package versions agree on v0.1.1", () => {
+test("workspace package versions agree on v0.2.0", () => {
   const packagePaths = [
     "package.json",
     "apps/desktop/package.json",
@@ -66,7 +66,7 @@ test("workspace package versions agree on v0.1.1", () => {
 
   assert.deepEqual(
     versions.map(({ version }) => version),
-    packagePaths.map(() => "0.1.1"),
+    packagePaths.map(() => "0.2.0"),
   );
 });
 


### PR DESCRIPTION
Prepares the next tagged release. The tag push and the manual release path
both require every workspace `package.json` to agree on the version, and
`publish-github.sh` refuses a tag that disagrees with the desktop one.

The minor bump reports what the release carries over v0.1.1: Codex cloud
sessions observed and created through the provider's own CLI, local Devin
agents, Linear connected by OAuth, and diff summaries on the rows.

`./scripts/check.sh` passes; no macOS or UI surface changes, so this is a
portable-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32215527340/artifacts/9352225995) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32215527340)

- Commit: `1e5e70dae5e3139e81f1d75b8d572046d12cc994`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
