### PR TITLE
fix(release): poll notarization instead of asking notarytool to wait

### DIFF
--- a/apps/desktop/scripts/release-config.mjs
+++ b/apps/desktop/scripts/release-config.mjs
@@ -10,6 +10,14 @@ export const NOTARY_CREDENTIAL_SOURCE = {
   KEYCHAIN_PROFILE: "keychain-profile",
   KEY_FILE: "key-file",
 };
+export const NOTARY_SUBMISSION_STATUS = {
+  ACCEPTED: "Accepted",
+  IN_PROGRESS: "In Progress",
+  INVALID: "Invalid",
+  REJECTED: "Rejected",
+};
+export const NOTARY_POLL_INTERVAL_MS = 30_000;
+export const NOTARY_POLL_TIMEOUT_MS = 20 * 60_000;
 export const RELEASE_VOLUME_NAME = "Luke";
 export const DMG_MOUNT_POINT = `/Volumes/${RELEASE_VOLUME_NAME}`;
 export const DMG_STAGING_ENTRIES = [
@@ -216,15 +224,26 @@ function notaryCredentialArguments(credentials) {
   return ["--keychain-profile", NOTARY_KEYCHAIN_PROFILE];
 }
 
+// notarytool's own --wait crashes with SIGBUS on most runs, and the upload has
+// already reached Apple by the time it does, so resubmitting would only
+// duplicate a submission that is already queued: submit once, then poll.
 export function notarySubmitArguments(dmgPath, credentials) {
   return [
     "notarytool",
     "submit",
     dmgPath,
     ...notaryCredentialArguments(credentials),
-    "--wait",
-    "--timeout",
-    "20m",
+    "--output-format",
+    "json",
+  ];
+}
+
+export function notaryInfoArguments(submissionId, credentials) {
+  return [
+    "notarytool",
+    "info",
+    submissionId,
+    ...notaryCredentialArguments(credentials),
     "--output-format",
     "json",
   ];
@@ -232,6 +251,35 @@ export function notarySubmitArguments(dmgPath, credentials) {
 
 export function notaryLogArguments(submissionId, credentials) {
   return ["notarytool", "log", submissionId, ...notaryCredentialArguments(credentials)];
+}
+
+// A status Apple has not documented here is treated as still running rather
+// than as a failure, so an unfamiliar name costs the release a wait instead of
+// the whole build.
+export async function awaitNotarizationDecision({
+  readStatus,
+  wait,
+  intervalMs = NOTARY_POLL_INTERVAL_MS,
+  timeoutMs = NOTARY_POLL_TIMEOUT_MS,
+}) {
+  for (let waited = 0; ; waited += intervalMs) {
+    const status = readStatus();
+    if (status === NOTARY_SUBMISSION_STATUS.ACCEPTED) {
+      return status;
+    }
+    if (
+      status === NOTARY_SUBMISSION_STATUS.INVALID ||
+      status === NOTARY_SUBMISSION_STATUS.REJECTED
+    ) {
+      throw new Error(`Notarization failed with status: ${status}`);
+    }
+    if (waited + intervalMs >= timeoutMs) {
+      throw new Error(
+        `Apple did not finish notarization within ${timeoutMs / 60_000} minutes; last status: ${status ?? "unknown"}`,
+      );
+    }
+    await wait(intervalMs);
+  }
 }
 
 export function stapleArguments(dmgPath) {

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { DMG_WINDOW } from "../../../design/dmg-window.mjs";
 import { packagedAppExecutable } from "./package-layout.mjs";
 import {
+  awaitNotarizationDecision,
   codesignDisplayArguments,
   DMG_MOUNT_POINT,
   DMG_STAGING_ENTRIES,
@@ -17,6 +18,7 @@ import {
   hdiutilConvertArguments,
   hdiutilCreateArguments,
   hdiutilDetachArguments,
+  notaryInfoArguments,
   notaryLogArguments,
   notarySubmitArguments,
   releaseArtifactDirectory,
@@ -225,14 +227,28 @@ try {
       );
     }
 
-    if (submission.status !== "Accepted") {
-      process.stderr.write(`Notarization failed with status: ${submission.status ?? "unknown"}\n`);
-      if (submission.id) {
-        execFileSync("xcrun", notaryLogArguments(submission.id, notaryCredentials), {
-          stdio: "inherit",
-        });
-      }
-      throw new Error("Apple did not accept the DMG for notarization");
+    if (!submission.id) {
+      process.stderr.write(notaryOutput);
+      throw new Error("Apple did not return a notarization submission ID");
+    }
+
+    try {
+      await awaitNotarizationDecision({
+        readStatus: () =>
+          JSON.parse(
+            execFileSync("xcrun", notaryInfoArguments(submission.id, notaryCredentials), {
+              encoding: "utf8",
+              stdio: ["ignore", "pipe", "inherit"],
+            }),
+          ).status,
+        wait: sleep,
+      });
+    } catch (error) {
+      process.stderr.write(`${error.message}\n`);
+      execFileSync("xcrun", notaryLogArguments(submission.id, notaryCredentials), {
+        stdio: "inherit",
+      });
+      throw new Error("Apple did not accept the DMG for notarization", { cause: error });
     }
 
     execFileSync("xcrun", stapleArguments(dmgPath), { stdio: "inherit" });

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -232,17 +232,24 @@ try {
       throw new Error("Apple did not return a notarization submission ID");
     }
 
+    // A lookup that fails or answers unreadably is a blip in the poll, not a
+    // verdict on a submission Apple already holds: reporting no status leaves
+    // the loop waiting, and notarytool's own complaint has reached stderr.
+    const readNotarizationStatus = () => {
+      try {
+        return JSON.parse(
+          execFileSync("xcrun", notaryInfoArguments(submission.id, notaryCredentials), {
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "inherit"],
+          }),
+        ).status;
+      } catch {
+        return undefined;
+      }
+    };
+
     try {
-      await awaitNotarizationDecision({
-        readStatus: () =>
-          JSON.parse(
-            execFileSync("xcrun", notaryInfoArguments(submission.id, notaryCredentials), {
-              encoding: "utf8",
-              stdio: ["ignore", "pipe", "inherit"],
-            }),
-          ).status,
-        wait: sleep,
-      });
+      await awaitNotarizationDecision({ readStatus: readNotarizationStatus, wait: sleep });
     } catch (error) {
       process.stderr.write(`${error.message}\n`);
       execFileSync("xcrun", notaryLogArguments(submission.id, notaryCredentials), {

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -5,6 +5,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { PACKAGED_ARCHITECTURE } from "../apps/desktop/scripts/package-layout.mjs";
 import {
+  awaitNotarizationDecision,
   codesignDisplayArguments,
   DMG_MOUNT_POINT,
   DMG_STAGING_ENTRIES,
@@ -16,6 +17,10 @@ import {
   hdiutilCreateArguments,
   hdiutilDetachArguments,
   NOTARY_CREDENTIAL_SOURCE,
+  NOTARY_POLL_INTERVAL_MS,
+  NOTARY_POLL_TIMEOUT_MS,
+  NOTARY_SUBMISSION_STATUS,
+  notaryInfoArguments,
   notaryLogArguments,
   notarySubmitArguments,
   parseHdiutilAttachPlist,
@@ -343,9 +348,19 @@ test("release notarization commands carry key-file credentials", () => {
     "KEYID",
     "--issuer",
     "issuer-id",
-    "--wait",
-    "--timeout",
-    "20m",
+    "--output-format",
+    "json",
+  ]);
+  assert.deepEqual(notaryInfoArguments("submission-id", credentials), [
+    "notarytool",
+    "info",
+    "submission-id",
+    "--key",
+    "/tmp/AuthKey_KEYID.p8",
+    "--key-id",
+    "KEYID",
+    "--issuer",
+    "issuer-id",
     "--output-format",
     "json",
   ]);
@@ -370,9 +385,15 @@ test("release notarization commands use the local keychain profile", () => {
     "/tmp/Luke.dmg",
     "--keychain-profile",
     "luke-notary",
-    "--wait",
-    "--timeout",
-    "20m",
+    "--output-format",
+    "json",
+  ]);
+  assert.deepEqual(notaryInfoArguments("submission-id", credentials), [
+    "notarytool",
+    "info",
+    "submission-id",
+    "--keychain-profile",
+    "luke-notary",
     "--output-format",
     "json",
   ]);
@@ -390,6 +411,88 @@ test("release notarization commands use the local keychain profile", () => {
     "--timestamp",
     "/tmp/Luke.dmg",
   ]);
+});
+
+test("neither notarization path asks notarytool to wait", () => {
+  const credentials = { source: NOTARY_CREDENTIAL_SOURCE.KEYCHAIN_PROFILE };
+  assert.ok(!notarySubmitArguments("/tmp/Luke.dmg", credentials).includes("--wait"));
+  assert.ok(!notarySubmitArguments("/tmp/Luke.dmg", credentials).includes("--timeout"));
+
+  const notarizeScript = fs.readFileSync(
+    path.join(repoRoot, "scripts", "release", "notarize.sh"),
+    "utf8",
+  );
+  // The rationale comment names the flag it removed, so only uncommented lines count.
+  assert.ok(!/^[^#\n]*--wait\b/m.test(notarizeScript));
+  assert.ok(!/^[^#\n]*--timeout\b/m.test(notarizeScript));
+  assert.ok(notarizeScript.includes("notarytool info"));
+});
+
+test("notarization polling settles on each status Apple reports", async () => {
+  const acceptedAfter = async (statuses) => {
+    const waits = [];
+    const remaining = [...statuses];
+    const settled = await awaitNotarizationDecision({
+      readStatus: () => remaining.shift(),
+      wait: (milliseconds) => waits.push(milliseconds),
+    });
+    return { settled, waits };
+  };
+
+  assert.deepEqual(await acceptedAfter([NOTARY_SUBMISSION_STATUS.ACCEPTED]), {
+    settled: NOTARY_SUBMISSION_STATUS.ACCEPTED,
+    waits: [],
+  });
+  assert.deepEqual(
+    await acceptedAfter([
+      NOTARY_SUBMISSION_STATUS.IN_PROGRESS,
+      NOTARY_SUBMISSION_STATUS.IN_PROGRESS,
+      NOTARY_SUBMISSION_STATUS.ACCEPTED,
+    ]),
+    {
+      settled: NOTARY_SUBMISSION_STATUS.ACCEPTED,
+      waits: [NOTARY_POLL_INTERVAL_MS, NOTARY_POLL_INTERVAL_MS],
+    },
+  );
+
+  for (const status of [NOTARY_SUBMISSION_STATUS.INVALID, NOTARY_SUBMISSION_STATUS.REJECTED]) {
+    await assert.rejects(
+      awaitNotarizationDecision({
+        readStatus: () => status,
+        wait: () => assert.fail(`${status} is terminal and must not be polled again`),
+      }),
+      new RegExp(`Notarization failed with status: ${status}`),
+    );
+  }
+});
+
+test("an unrecognised notarization status is polled to the bound, never failed early", async () => {
+  let polls = 0;
+
+  await assert.rejects(
+    awaitNotarizationDecision({
+      readStatus: () => {
+        polls += 1;
+        return "Bewildered";
+      },
+      wait: () => {},
+    }),
+    /Apple did not finish notarization within 20 minutes; last status: Bewildered/,
+  );
+
+  assert.equal(polls, NOTARY_POLL_TIMEOUT_MS / NOTARY_POLL_INTERVAL_MS);
+});
+
+test("a notarization status Apple never returns is bounded like any other", async () => {
+  await assert.rejects(
+    awaitNotarizationDecision({
+      readStatus: () => undefined,
+      wait: () => {},
+      intervalMs: 1,
+      timeoutMs: 3,
+    }),
+    /last status: unknown/,
+  );
 });
 
 test("release artifacts stay under the repository artifacts directory", () => {

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -428,6 +428,18 @@ test("neither notarization path asks notarytool to wait", () => {
   assert.ok(notarizeScript.includes("notarytool info"));
 });
 
+test("the CI notarization path polls the submission id, not the submit exit status", () => {
+  const notarizeScript = fs.readFileSync(
+    path.join(repoRoot, "scripts", "release", "notarize.sh"),
+    "utf8",
+  );
+
+  // notarytool can fail after the upload lands, so only a missing id may end
+  // the run before the poll — the JS path continues from that stdout the same way.
+  assert.ok(notarizeScript.includes('if [[ -z "$submission_id" ]]; then'));
+  assert.ok(!/\$submit_exit"?\s+-ne\s+0\s*\|\|/.test(notarizeScript));
+});
+
 test("notarization polling settles on each status Apple reports", async () => {
   const acceptedAfter = async (statuses) => {
     const waits = [];

--- a/scripts/release/notarize.sh
+++ b/scripts/release/notarize.sh
@@ -36,29 +36,54 @@ trap cleanup_key EXIT
 printf '%s' "$APPLE_API_KEY_P8_BASE64" | /usr/bin/base64 -D > "$key_path"
 chmod 600 "$key_path"
 
+notary_credentials=(
+    --key "$key_path"
+    --key-id "$APPLE_API_KEY_ID"
+    --issuer "$APPLE_API_ISSUER_ID"
+)
+
+# notarytool's own --wait crashes with SIGBUS on most runs, and the upload has
+# already reached Apple by the time it does, so resubmitting would only
+# duplicate a submission that is already queued: submit once, then poll.
 submit_exit=0
 xcrun notarytool submit "$submission_path" \
-    --key "$key_path" \
-    --key-id "$APPLE_API_KEY_ID" \
-    --issuer "$APPLE_API_ISSUER_ID" \
-    --wait \
-    --timeout 20m \
+    "${notary_credentials[@]}" \
     --output-format json > "$result_path" || submit_exit=$?
 
 cat "$result_path"
 submission_id=$(jq -r '.id // empty' "$result_path")
-status=$(jq -r '.status // empty' "$result_path")
 
-if [[ "$submit_exit" -ne 0 || "$status" != "Accepted" ]]; then
-    if [[ -n "$submission_id" ]]; then
-        printf 'Notarization failed; fetching Apple log for submission %s.\n' "$submission_id" >&2
-        xcrun notarytool log "$submission_id" \
-            --key "$key_path" \
-            --key-id "$APPLE_API_KEY_ID" \
-            --issuer "$APPLE_API_ISSUER_ID" || true
-    else
-        printf 'error: notarization failed before Apple returned a submission ID\n' >&2
+if [[ "$submit_exit" -ne 0 || -z "$submission_id" ]]; then
+    printf 'error: notarization failed before Apple returned a submission ID\n' >&2
+    exit 1
+fi
+
+poll_interval_seconds=30
+poll_attempts=40
+status=""
+
+for ((attempt = 1; attempt <= poll_attempts; attempt++)); do
+    if xcrun notarytool info "$submission_id" \
+        "${notary_credentials[@]}" \
+        --output-format json > "$result_path"; then
+        status=$(jq -r '.status // empty' "$result_path")
     fi
+    # An undocumented status is treated as still running, so an unfamiliar name
+    # costs the release a wait rather than the whole build.
+    case "$status" in
+        Accepted | Invalid | Rejected) break ;;
+    esac
+    if [[ "$attempt" -lt "$poll_attempts" ]]; then
+        sleep "$poll_interval_seconds"
+    fi
+done
+
+cat "$result_path"
+
+if [[ "$status" != "Accepted" ]]; then
+    printf 'Notarization failed with status: %s; fetching Apple log for submission %s.\n' \
+        "${status:-unknown}" "$submission_id" >&2
+    xcrun notarytool log "$submission_id" "${notary_credentials[@]}" || true
     exit 1
 fi
 

--- a/scripts/release/notarize.sh
+++ b/scripts/release/notarize.sh
@@ -53,8 +53,11 @@ xcrun notarytool submit "$submission_path" \
 cat "$result_path"
 submission_id=$(jq -r '.id // empty' "$result_path")
 
-if [[ "$submit_exit" -ne 0 || -z "$submission_id" ]]; then
-    printf 'error: notarization failed before Apple returned a submission ID\n' >&2
+# notarytool can fail after the upload has already landed, so the id it wrote
+# decides whether there is a submission to poll — never the exit status.
+if [[ -z "$submission_id" ]]; then
+    printf 'error: notarization failed before Apple returned a submission ID (exit %d)\n' \
+        "$submit_exit" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## What

`xcrun notarytool submit --wait` crashes with `Bus error: 10` on most releases: twice on v0.2.0, once on v0.1.1 (2026-08-17), and twice on 2026-08-16. Each crash aborts the release script.

The crash reports (`~/Library/Logs/DiagnosticReports/notarytool-*.ips`) show `EXC_BAD_ACCESS` / `KERN_PROTECTION_FAILURE` in a Stack Guard region — a stack overflow at only ~84 frames, inside `String(format:)` on SwiftNIO's `nio.nioTransportServices.connectionchannel` event-loop thread. Not recursion, not memory pressure. Apple DTS has confirmed notarytool must never crash and that `--wait` is the trigger ([thread 758646](https://developer.apple.com/forums/thread/758646), [thread 750044](https://developer.apple.com/forums/thread/750044)); dropping `--wait` is the documented workaround.

The upload always succeeds before the crash, so the submission is already registered with Apple. Resubmitting re-runs the crashing path and creates duplicate submissions — it is the wrong recovery.

## How

Both notarization paths now **submit once, then poll** the submission they already made:

- `release-config.mjs` — `notarySubmitArguments` drops `--wait` and `--timeout` (a `--timeout` without `--wait` is meaningless) and keeps `--output-format json`. New `notaryInfoArguments(submissionId, credentials)` sits beside `notaryLogArguments` and reuses `notaryCredentialArguments`.
- `awaitNotarizationDecision({ readStatus, wait })` holds the loop, bounded at 20 minutes (40 polls at 30s) to preserve today's behaviour. It takes its dependencies by injection, the way `withMountedDmg` does, so it is testable without `xcrun`.
- `release.mjs` — parses the submit response for its `id`, polls `notarytool info`, and keeps the existing contract exactly: any non-`Accepted` outcome prints Apple's log via `notaryLogArguments` and throws; `Accepted` staples and continues.
- `scripts/release/notarize.sh` — the same change for the CI app-zip path, polling with `notarytool info` in a bounded loop around the id it already captures with `jq`.

An unrecognised status is treated as non-terminal and polled to the bound, rather than failing a release on a status name Apple has not documented. `--skip-notarization` is untouched, as are the asset names and `RELEASE_LATEST_DMG_FILE_NAME`.

## Tests

`scripts/release.test.mjs`: the four argument-vector assertions no longer pin `--wait`/`--timeout`, and `notaryInfoArguments` is covered in both the keychain-profile and key-file credential shapes. New coverage for the poll loop using injected fakes — accepts on `Accepted`, keeps polling through `In Progress` (asserting the wait intervals), throws on `Invalid` and `Rejected` without polling again, and polls an unrecognised status all the way to the bound. A further test pins that neither path passes `--wait` or `--timeout`, including the shell script, which has no other unit seam. No test shells out to a real `xcrun`.

## Verification

Portable-only change with no UI surface, so `./scripts/check.sh` is the completion invariant.

`./scripts/check.sh` — **exit 0**. Repository contract checks passed (65 + 4 generated files up to date); lint, typecheck, and build clean. Tests: root 46/46, `packages/sidecar-core` 265/265, `apps/desktop` 1144/1144, `apps/web` 40/40 — 0 failures.

The notarization path itself cannot be exercised without a real signed release, since it requires Apple credentials and a live submission. The next release is what confirms the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32217302488/artifacts/9352779358) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32217302488)

- Commit: `179426121da2a31a25baae4afdbce9cd05261601`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
