### PR TITLE
fix(desktop): grow the bubble with the corners its pill rests at

### DIFF
--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1063,7 +1063,14 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 .app-stage[data-notch="false"] .panel-surface {
   height: calc(var(--capsule-height) - var(--shape-top) * 2 + var(--caption-growth));
   min-height: calc(var(--capsule-height) - var(--shape-top) * 2);
-  border-radius: 999px;
+  /* Half the resting strip, stated as that number rather than an overlarge
+     one: at rest the two draw the same pill, but an overlarge radius scales
+     with whatever box it is given, so a shape grown for captions or chips
+     curved its sides to half its new height — under bands laid out for the
+     resting corner, whose first line ran past the curve onto the desktop.
+     Stated once here, the growth extends the pill downward with the corners
+     it had, the same way the notch capsule keeps its convex radius. */
+  border-radius: calc((var(--capsule-height) - var(--shape-top) * 2) / 2);
 }
 
 /* The panel and the slot keep the pill's lift rather than gluing themselves to
@@ -1124,7 +1131,10 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 .app-stage[data-notch="false"] .compact-hover-target {
   top: var(--shape-top);
   height: calc(var(--capsule-height) - var(--shape-top) * 2);
-  border-radius: 999px;
+  /* The surface's own radius above, for the surface's reason: the captioned
+     target grows with the shape, and an overlarge radius would round its hit
+     region past the corners the shape actually draws. */
+  border-radius: calc((var(--capsule-height) - var(--shape-top) * 2) / 2);
 }
 
 /* Inside an open panel the strip is surrounded by the shape rather than


### PR DESCRIPTION
## Summary

- In bubble mode, a spoken reply's captions, the volume hint's band, and the mention chips were laid out for the resting pill's corner but drawn on a shape whose corners ballooned with it: the surface stated its radius as `999px`, which CSS resolves to half of whatever box it is given. At rest that is the intended 24px pill — but grown for a caption block (up to 210px), the hint's band, or the chip rows, half the new height is a deep stadium whose sides curve in far under the bands. The first caption line's ends and the chips' top row were drawn past the curve onto the desktop.
- The radius is now stated as what it actually is — half the resting strip's lifted height, `calc((var(--capsule-height) - var(--shape-top) * 2) / 2)` — so the resting pill is unchanged pixel for pixel, and a shape grown for captions or chips extends downward with the corners it had, the same way the notch capsule keeps its convex radius. The compact hover target takes the same radius so its hit region follows the drawn shape.
- Verified while here, unchanged and correct in bubble: the caption block shows the whole reply (the #269 reservation is sized against the peek's wrap width, which #245 already floored for the bubble), the caption's clip ends exactly where the "Unmute your Mac" hint band begins even at the reserved maximum (the #248 partition is form-factor-agnostic), and the session/Linear-issue mention chips band (#250/#257) lays out and presses identically — its only bubble defect was the corner spill fixed here.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — pass (repository contract checks, Biome, typecheck, all workspace tests, desktop and web builds; exit 0)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — authored in a Linux cloud workspace; needs a macOS pass before merge

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32217180598/artifacts/9352749101) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32217180598)

- Commit: `200a59960bf37cc7c7557b9e69324a1a7b32e2c2`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` — verified instead with an untracked headless-Chromium harness rendering the real renderer stylesheets (`motion-tokens.css` + `base.css`) with the app's exact DOM and attribute states, mirroring `captionSizeStyle`/`noticeGrowthStyle` measurement. Before/after screenshots inspected for: bubble captioned (short/long), captioned + volume hint, captioned + mention chips, all three at once, peek presentation, clamped extra-long caption, resting pill, and the same states in notch form (unchanged).
- Physical-notch check: `not performed` — the changed rules match only `data-notch="false"`, which a display with a real notch never draws; notch states were screenshotted in the harness and are byte-identical rules.
- Device/display configuration: headless Chromium 560×400 stage, `--notch-top-inset: 24px`, `--notch-housing-width: 0px` (bubble) and `32px`/`210px` (notch comparison)

## Notes

- Blockers or follow-up verification: run `./scripts/verify.sh` on a physical Mac (ideally with an external, notch-less display) and eyeball a long spoken reply with the Mac muted in bubble mode: whole reply readable, hint row on the black below the words, chips pressable on the shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ba65fcc4-7b51-402c-8611-c1c061e9f17e)
