### PR TITLE
feat(desktop): pin the settings page header while its rows scroll

### DIFF
--- a/apps/desktop/src/renderer/luke-errand.tsx
+++ b/apps/desktop/src/renderer/luke-errand.tsx
@@ -497,6 +497,23 @@ const RING_BLOOM = 0.26;
 const RING_SPREAD = 1.16;
 
 /**
+ * Where a scroller's view really starts: a child pinned to its top — the
+ * settings pages' header — covers the first strip of it, so a landing brought
+ * flush with the scroller's own edge would arrive under the header rather
+ * than below it. Measured off the children rather than assumed, because
+ * which scroller pins what is the panel's business, not the errand's.
+ */
+function pinnedViewTop(scroller: HTMLElement, viewTop: number): number {
+  let top = viewTop;
+  for (const child of scroller.children) {
+    if (!(child instanceof HTMLElement)) continue;
+    if (getComputedStyle(child).position !== "sticky") continue;
+    top = Math.max(top, child.getBoundingClientRect().bottom);
+  }
+  return top;
+}
+
+/**
  * Scrolls the landing clear of the room the captions may still take. Reads the
  * scroller off the control rather than being told which one: the errand knows
  * what it is flying to, not what the panel happens to have wrapped it in.
@@ -513,7 +530,7 @@ function keepInView(stage: HTMLElement, target: HTMLElement, room: number): void
     const box = target.getBoundingClientRect();
     node.scrollTop = errandScrollTop({
       scrollTop: node.scrollTop,
-      view: { top: view.top, bottom: view.bottom },
+      view: { top: pinnedViewTop(node, view.top), bottom: view.bottom },
       target: { top: box.top, bottom: box.bottom },
       room,
     });

--- a/apps/desktop/src/renderer/luke-errand.tsx
+++ b/apps/desktop/src/renderer/luke-errand.tsx
@@ -501,16 +501,22 @@ const RING_SPREAD = 1.16;
  * settings pages' header — covers the first strip of it, so a landing brought
  * flush with the scroller's own edge would arrive under the header rather
  * than below it. Measured off the children rather than assumed, because
- * which scroller pins what is the panel's business, not the errand's.
+ * which scroller pins what is the panel's business, not the errand's. The
+ * strip one gap below a pinned child is covered too: that is the band where
+ * rows dissolve under it, so a landing there is a landing mid-fade — and the
+ * gap is what the scroller's own scroll padding already adds for the
+ * keyboard, so the errand and a tabbed-to control agree on what clear means.
  */
 function pinnedViewTop(scroller: HTMLElement, viewTop: number): number {
-  let top = viewTop;
+  let bottom = Number.NEGATIVE_INFINITY;
   for (const child of scroller.children) {
     if (!(child instanceof HTMLElement)) continue;
     if (getComputedStyle(child).position !== "sticky") continue;
-    top = Math.max(top, child.getBoundingClientRect().bottom);
+    bottom = Math.max(bottom, child.getBoundingClientRect().bottom);
   }
-  return top;
+  if (bottom === Number.NEGATIVE_INFINITY) return viewTop;
+  const gap = Number.parseFloat(getComputedStyle(scroller).rowGap);
+  return Math.max(viewTop, bottom + (Number.isNaN(gap) ? 0 : gap));
 }
 
 /**

--- a/apps/desktop/src/renderer/styles/settings.css
+++ b/apps/desktop/src/renderer/styles/settings.css
@@ -5,11 +5,15 @@
    at its foot through the same shared fade — a page taller than the panel must
    melt into the surface above Luke's caption, not be sliced off against it. */
 .settings {
+  /* Named because the pinned header's dissolve band below must span exactly
+     this: the two drifting apart is what would leave a passing row sliced
+     against the header's edge, or the resting page reading faded. */
+  --settings-gap: 14px;
   display: flex;
   min-height: 0;
   flex: 1;
   flex-direction: column;
-  gap: 14px;
+  gap: var(--settings-gap);
   overflow-x: clip;
   overflow-y: auto;
   overscroll-behavior: contain;
@@ -17,6 +21,18 @@
   scrollbar-width: thin;
   animation: scroll-edge-fade linear both;
   animation-timeline: scroll(self block);
+}
+
+/* Native focus scrolling knows nothing of the pinned header, so a control
+   tabbed to near the page's top would be brought flush with the scroller's
+   edge — under the header rather than below it. Scroll padding is what that
+   scrolling reads. `--settings-header-height` is the back button's own 26px,
+   the header's height whenever its line has not wrapped; scoped to a page
+   that pins one, so the front page keeps its plain edge. */
+.settings:has(> .settings-header) {
+  --settings-header-height: 26px;
+
+  scroll-padding-top: calc(var(--settings-header-height) + var(--settings-gap));
 }
 
 .settings-section {
@@ -95,14 +111,38 @@
 
 /* A page's head: the way back beside the page's own name, above the sections
    it holds. It wraps so the reset's refusal, when there is one, lands on a
-   line of its own under the controls rather than crowding the title. */
+   line of its own under the controls rather than crowding the title. Pinned
+   to the scroller's top edge, so the way back never has to be scrolled back
+   to, in the surface's own fill so the rows slide under it rather than
+   through it. Raised above the sections, whose arrival transforms make each
+   its own stacking context. */
 .settings-header {
+  position: sticky;
+  z-index: 1;
+  top: 0;
   display: flex;
   flex: 0 0 auto;
   flex-wrap: wrap;
   align-items: center;
   gap: 9px;
   padding: 0 2px;
+  background: var(--surface-fill);
+}
+
+/* The band below the pinned header, where a passing row dissolves into the
+   surface the way every scroller's foot already does. It spans exactly the
+   scroller's own gap: any taller and the first section would read faded while
+   the page rests at its top, any shorter and a row would be sliced against
+   the header's edge on its way under. */
+.settings-header::after {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  left: 0;
+  height: var(--settings-gap);
+  background: linear-gradient(to bottom, var(--surface-fill), transparent);
+  content: "";
+  pointer-events: none;
 }
 
 .settings-header strong {

--- a/apps/desktop/tests/settings-sticky-header.test.ts
+++ b/apps/desktop/tests/settings-sticky-header.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+/**
+ * The nested settings pages pin their header to the scroller's top edge.
+ * These read the stylesheet as text, the way face-motion's tests do, and
+ * guard the declarations the pinning stands on: the pin itself, the opacity
+ * that keeps rows from reading through the title, the dissolve band's tie to
+ * the scroller's gap, and the scroll padding that keeps keyboard focus from
+ * landing under the header.
+ */
+const css = readFileSync(new URL("../src/renderer/styles/settings.css", import.meta.url), "utf8");
+
+const rule = (selector: string): string => {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`${escaped} \\{([^}]*)\\}`).exec(css)?.[1] ?? "";
+};
+
+test("the page header is pinned to the scroller's top edge", () => {
+  const header = rule(".settings-header");
+  assert.match(header, /position: sticky;/);
+  assert.match(header, /top: 0;/);
+});
+
+test("the pinned header wears the surface's own fill", () => {
+  // Rows scroll beneath it; through a transparent header they would read
+  // over the title and the way back.
+  assert.match(rule(".settings-header"), /background: var\(--surface-fill\);/);
+});
+
+test("the dissolve band spans exactly the scroller's gap", () => {
+  // One custom property feeds both, so the band and the gap cannot drift:
+  // a band taller than the gap fades the resting page's first section, one
+  // shorter slices a passing row against the header's edge.
+  assert.match(rule(".settings"), /gap: var\(--settings-gap\);/);
+  const band = rule(".settings-header::after");
+  assert.match(band, /height: var\(--settings-gap\);/);
+  assert.match(band, /pointer-events: none;/);
+});
+
+test("focus scrolling is told what the pinned header covers", () => {
+  // Native focus scrolling reads scroll padding and nothing else, so this is
+  // the one declaration keeping a tabbed-to control below the header.
+  assert.match(
+    css,
+    /scroll-padding-top: calc\(var\(--settings-header-height\) \+ var\(--settings-gap\)\);/,
+  );
+});


### PR DESCRIPTION
## What

A nested settings page's header — the back button beside the page's own name, with its reset when one stands — scrolled away with the rows it stood above. It now pins to the `.settings` scroller's top edge:

- `position: sticky` in the surface's own fill (`--surface-fill`), raised above the sections whose arrival transforms make each its own stacking context, so rows slide under it rather than through it.
- A `::after` dissolve band below the header, spanning exactly the scroller's gap through a new `--settings-gap` custom property, so passing rows melt into the surface the way every scroller's foot already does — and the resting page reads unfaded.
- `scroll-padding-top` on `.settings:has(> .settings-header)`, so native keyboard-focus scrolling and `scrollIntoView` land controls below the pinned header instead of under it; the front page keeps its plain edge.
- The errand's `keepInView` raises the view's effective top past any sticky child's bottom edge — measured off the scroller's children rather than assumed — so a spoken setting's landing is scrolled clear of the header.

DOM order, the back-button focus choreography, and the arrival stagger are unchanged; the root page draws no header and is untouched.

## Tests

`apps/desktop/tests/settings-sticky-header.test.ts` reads the stylesheet as text, the way face-motion's tests do, and guards the pin, the opaque fill, the band's tie to the gap, and the scroll-padding declaration.

## Verification

- `./scripts/check.sh` passes: repository checks, lint, typecheck, all tests, builds.
- Form factors: notch vs bubble changes only `.expanded-panel`'s top padding and the shape's translation, both outside the scroller, so the pinning is geometrically identical. Proven with a headless-Chrome harness loading the real `base.css` + `settings.css` under `data-notch="true"` (38px inset, 180px housing) and `data-notch="false"`: in both, the header rests at the scroller's top, stays pinned at scrollTop 300 under the live scroll-edge mask, spans the scroller's width, reports 40px `scroll-padding-top`, and `scrollIntoView` lands a control clear of it; the root page keeps `scroll-padding: auto`. All 11 assertions passed; a screenshot confirmed a section card dissolving beneath the pinned header. Harness lived in `/tmp` — nothing generated is committed.
- `./scripts/verify.sh` and a physical-notch check were **not** performed: this change was made in a Linux cloud workspace with no macOS packaging or physical display. Please run both on a Mac before merge; the state to inspect is a nested settings page scrolled mid-list, in both form factors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/28210302-1522-47ef-a599-8e7ed8bce314)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32219486951/artifacts/9353469950) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32219486951)

- Commit: `cce534547e5a53d5ef89507efbe065481189b78f`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
