### PR TITLE
docs(changelog): correct release dates and refine 0.2.0 wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 Notable changes to Luke, newest first. Each heading is a released version and
 the date its release was published.
 
-## 0.2.0 — 2026-08-19
+## 0.2.0 — 2026-08-18
 
 ### Codex cloud tasks
 
@@ -99,7 +99,7 @@ to jump straight there.
 - Removed excessive panel animations
   ([#243](https://github.com/ReviewStage/luke/pull/243))
 
-## 0.1.1 — 2026-08-18
+## 0.1.1 — 2026-08-17
 
 ### Free daily allowance
 
@@ -163,7 +163,7 @@ meeting is over.
 - Updated the landing page download button to always fetch the latest build
   ([#183](https://github.com/ReviewStage/luke/pull/183))
 
-## 0.1.0 — 2026-08-17
+## 0.1.0 — 2026-08-16
 
 Introducing Luke: a voice agent that lives in the MacBook notch and
 watches every local and cloud coding agent session.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,30 +36,26 @@ the date its release was published.
 
 ### Codex cloud tasks
 
-Luke observes your Codex cloud tasks through the login you already gave the
-Codex CLI — no key to paste, and a signed-out CLI simply reads as empty. Ask
-him for a new cloud task and he starts it the same way.
+Luke observes your Codex cloud tasks through the Codex CLI.
 ([#256](https://github.com/ReviewStage/luke/pull/256),
 [#258](https://github.com/ReviewStage/luke/pull/258))
 
 ### Previews you can press
 
-When a spoken reply names your sessions or tracked Linear issues, chips
-naming each appear under the notch for as long as the words last — press one
-to jump straight there.
+Linear issues show as chips under the notch.
 ([#250](https://github.com/ReviewStage/luke/pull/250),
 [#257](https://github.com/ReviewStage/luke/pull/257),
 [#271](https://github.com/ReviewStage/luke/pull/271))
 
 ### Improvements
 
-- Luke speaks as your agents' engineering manager — direct, candid, and calm
+- Luke's role is an engineering manager
   ([#265](https://github.com/ReviewStage/luke/pull/265))
-- Session rows carry each agent's diff: files touched, lines added and
-  removed ([#260](https://github.com/ReviewStage/luke/pull/260))
-- Luke observes Devin sessions running on your Mac
+- Session rows show number of files touched and lines changed when available
+  ([#260](https://github.com/ReviewStage/luke/pull/260))
+- Luke observes local Devin CLI sessions
   ([#255](https://github.com/ReviewStage/luke/pull/255))
-- Linear now connects through its own consent page instead of an API key
+- Linear now connects via a Luke Linear app instead of an API key
   ([#261](https://github.com/ReviewStage/luke/pull/261))
 - Luke hears what you say while the call is still connecting, even on the
   first press after launch
@@ -70,7 +66,7 @@ to jump straight there.
   [#272](https://github.com/ReviewStage/luke/pull/272))
 - A bare "new agent" ask opens a new workspace
   ([#230](https://github.com/ReviewStage/luke/pull/230))
-- The pull-request chip is titled by the request's own number
+- An agent's pull request button uses the PR number
   ([#249](https://github.com/ReviewStage/luke/pull/249))
 
 ### Fixes
@@ -91,7 +87,7 @@ to jump straight there.
 
 - Updated the landing page with a direct download button
   ([#221](https://github.com/ReviewStage/luke/pull/221))
-- Added the link card shared pages preview everywhere
+- Added the link card previews everywhere
   ([#244](https://github.com/ReviewStage/luke/pull/244),
   [#273](https://github.com/ReviewStage/luke/pull/273))
 - Removed the menu bar item


### PR DESCRIPTION
## Summary

- <!-- What changed and why? --> Every release heading was dated a day late: the entries used the GitHub release timestamps' UTC calendar day, while the releases shipped the evening before in local time. 0.1.0 → 2026-08-16, 0.1.1 → 2026-08-17, 0.2.0 → 2026-08-18.
- A wording pass over the 0.2.0 entry lands on this branch before merge — it was drafted from the git history in #277 and hasn't had the same review the earlier entries got.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passes (exit 0)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — content-only change to CHANGELOG.md

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32219246427/artifacts/9353391002) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32219246427)

- Commit: `9e4aeadb74140f643304c791bff482d2f7993b05`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` — not applicable, no surface changed
- Physical-notch check: `not performed` — not applicable
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: awaiting the 0.2.0 wording pass before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/e3661708-3e42-4bf4-80d5-17c7fa1e4ee1)
