### PR TITLE
fix(panel): keep one window width across modes so a close cannot flash off-centre

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,13 +341,18 @@ move — the spring vocabulary, how content joins and leaves a resizing shape,
 and how a motion change is proven. Read it before adding or altering any
 animation; this section covers only the window and the surface themselves.
 
-The window is a stage; the drawn surface is the shape. A window therefore holds
-the largest shape its mode can draw — a compact window holds the peek and an
-expanded one holds the slot as well as the panel, so neither hovering nor
-stepping aside for a browser costs any IPC — plus `SURFACE_MARGIN` on every
-side, which is what the spring overshoots into and the shadow falls in. Anything the shape does not cover is
-transparent and must stay click-through, so hit regions track the shape rather
-than the window.
+The window is a stage; the drawn surface is the shape. Every window holds the
+width of the widest shape any mode can draw — the panel, and the peek where a
+housing outgrows it — so hovering and the slot cost no IPC and a mode change
+never moves the window: macOS lands a window's move and its content's relayout
+on different frames, so a mode change that also recentred a narrower window
+flashed the capsule against the old origin before the move caught up. Only the
+height changes between modes, anchored to the top edge, where everything a
+shorter frame crops is margin below a shape that has already closed. The stage
+carries `SURFACE_MARGIN` on every side, which is what the spring overshoots
+into and the shadow falls in. Anything the shape does not cover is transparent
+and must stay click-through, so hit regions track the shape rather than the
+window.
 
 The shape's depth is the menu bar's painted depth, not the safe-area inset. The
 inset is the region apps must avoid; macOS may paint the bar deeper than it, and

--- a/packages/sidecar-core/src/geometry.ts
+++ b/packages/sidecar-core/src/geometry.ts
@@ -73,13 +73,12 @@ export interface NotchWindowLayout extends Rectangle {
 
 /**
  * The window is a stage for a shape the renderer draws and animates; it is not
- * the shape itself. A compact window therefore has to hold the widest thing
- * that can be drawn without the window resizing — the peek the capsule grows
- * into under the pointer — plus a margin for what falls outside the shape: a
- * spring overshooting its target, and the shadow the peek and the panel cast.
- * A clipped shadow is a hard edge, so the margin runs along the bottom too.
- * Everything the shape does not cover is transparent and passes the pointer
- * through.
+ * the shape itself. Every window therefore holds the widest thing any mode can
+ * draw — the panel, and the peek where a housing outgrows it — plus a margin
+ * for what falls outside the shape: a spring overshooting its target, and the
+ * shadow the peek and the panel cast. A clipped shadow is a hard edge, so the
+ * margin runs along the bottom too. Everything the shape does not cover is
+ * transparent and passes the pointer through.
  *
  * The margin is measured against what actually falls outside the shape rather
  * than chosen: `--surface-shadow` still puts ink about 35px below the panel —
@@ -164,10 +163,17 @@ export function positionNotchWindow(
 ): NotchWindowLayout {
   const notch = resolveNotchGeometry(display, native, formFactor);
   const housingWidth = notch.hasNotch ? notch.housingWidth : 0;
-  const width =
-    mode === "expanded"
-      ? Math.min(PANEL_WIDTH + SURFACE_MARGIN * 2, display.bounds.width)
-      : Math.min(peekWidth(housingWidth) + SURFACE_MARGIN * 2, display.bounds.width);
+  // One width for both modes, so a mode change is a height-only resize and the
+  // window never moves. macOS lands a window's move and its content's relayout
+  // on different frames, so a mode change that also recentred a narrower
+  // window drew the capsule laid out for the new width against the old origin
+  // — flashed toward the panel's corner — before the move caught up. A height
+  // change has no such tear: the window stays put, and everything a shorter
+  // frame crops is transparent margin below a shape that has already closed.
+  const width = Math.min(
+    Math.max(PANEL_WIDTH, peekWidth(housingWidth)) + SURFACE_MARGIN * 2,
+    display.bounds.width,
+  );
   // A bubble panel floats `BUBBLE_LIFT` below the top edge, and the margin was
   // measured from a panel drawn at the edge, so the lift is added back or the
   // last of the shadow's tail meets the window edge as a faint line.

--- a/packages/sidecar-core/tests/geometry.test.ts
+++ b/packages/sidecar-core/tests/geometry.test.ts
@@ -34,9 +34,9 @@ test("anchors the compact window to the physical top edge", () => {
   });
 
   assert.deepEqual(result, {
-    x: 487,
+    x: 406,
     y: 0,
-    width: 538,
+    width: PANEL_WIDTH + SURFACE_MARGIN * 2,
     // The top inset, the caption block Luke's words wrap into below it, every
     // chip row the notice band can grow to under those words, and the margin
     // the overshoot and the shadow fall in: 38 + 210 + 26 × 3 + 40.
@@ -50,19 +50,28 @@ test("anchors the compact window to the physical top edge", () => {
   });
 });
 
-test("a compact window holds the peek, the overshoot, and the shadow", () => {
-  const result = positionNotchWindow(notchedDisplay, "compact", {
+test("both modes share one width and origin, so a mode change only resizes down", () => {
+  const native = {
     displayId: 1,
     safeAreaTop: 38,
     menuBarHeight: 38,
     notchWidth: 210,
     hasNotch: true,
-  });
+  };
+  const compact = positionNotchWindow(notchedDisplay, "compact", native);
+  const expanded = positionNotchWindow(notchedDisplay, "expanded", native);
 
-  assert.equal(result.width, peekWidth(210) + SURFACE_MARGIN * 2);
+  // A mode change that also moved the window flashed the capsule against the
+  // old origin, because macOS lands the move and the relayout on different
+  // frames. Equal widths keep the origin still in both directions.
+  assert.equal(compact.width, expanded.width);
+  assert.equal(compact.x, expanded.x);
+  assert.equal(compact.y, expanded.y);
+  // The stage still holds the peek, the overshoot, and the shadow.
+  assert.ok(compact.width >= peekWidth(210) + SURFACE_MARGIN * 2);
   // The capsule at rest stays centred on the housing inside that window.
   assert.equal(
-    (peekWidth(210) - result.notch.housingWidth) / 2,
+    (peekWidth(210) - compact.notch.housingWidth) / 2,
     CAPSULE_SIDE_WIDTH + PEEK_SIDE_GROWTH,
   );
 });
@@ -76,9 +85,9 @@ test("uses a top-center fallback without inventing a notch", () => {
     "compact",
   );
 
-  assert.equal(result.x, -1229);
+  assert.equal(result.x, -1310);
   assert.equal(result.y, -200);
-  assert.equal(result.width, peekWidth(0) + SURFACE_MARGIN * 2);
+  assert.equal(result.width, PANEL_WIDTH + SURFACE_MARGIN * 2);
   assert.equal(
     result.height,
     32 +
@@ -110,9 +119,9 @@ test("the notch form gives a display without a housing the simulated one", () =>
     hasNotch: true,
     source: "simulated",
   });
-  // The window grows to hold the peek around the simulated housing, exactly as
-  // it would around a real one of the same width.
-  assert.equal(result.width, peekWidth(SIMULATED_HOUSING_WIDTH) + SURFACE_MARGIN * 2);
+  // The window holds the peek around the simulated housing, exactly as it
+  // would around a real one of the same width.
+  assert.ok(result.width >= peekWidth(SIMULATED_HOUSING_WIDTH) + SURFACE_MARGIN * 2);
   assert.equal(
     result.height,
     32 +
@@ -154,9 +163,8 @@ test("a display without a housing keeps the peek's width beside the 14-inch one"
   // same floored peek the caption block's reservation was measured against —
   // never the 248px left when no housing grows it.
   assert.equal(PEEK_MIN_WIDTH, 210 + (CAPSULE_SIDE_WIDTH + PEEK_SIDE_GROWTH) * 2);
-  assert.equal(
-    positionNotchWindow(plainDisplay, "compact").width,
-    PEEK_MIN_WIDTH + SURFACE_MARGIN * 2,
+  assert.ok(
+    positionNotchWindow(plainDisplay, "compact").width >= PEEK_MIN_WIDTH + SURFACE_MARGIN * 2,
   );
 });
 

--- a/scripts/evidence.sh
+++ b/scripts/evidence.sh
@@ -82,18 +82,19 @@ validate_evidence() {
     fi
 }
 
-# The window is a stage, not the shape: a compact window holds the peek the
+# The window is a stage, not the shape: every window holds the panel's width,
+# so a mode change never moves it, and a compact one still holds the peek the
 # capsule grows into, the caption block a whole reply is shown in, every chip
 # row the notice band can wrap into, and room for a spring to overshoot —
 # 38 + 210 + 26 × 3 + 40 tall on the pinned housing.
 validate_evidence "$SIDECAR_EXPANDED_EVIDENCE_PATH" 700 560
-validate_evidence "$SIDECAR_COMPACT_EVIDENCE_PATH" 538 366
-validate_evidence "$SIDECAR_PEEK_EVIDENCE_PATH" 538 366
+validate_evidence "$SIDECAR_COMPACT_EVIDENCE_PATH" 700 366
+validate_evidence "$SIDECAR_PEEK_EVIDENCE_PATH" 700 366
 # The slot is drawn in the expanded window, which is why stepping aside for a
 # browser costs no resize at all.
 validate_evidence "$SIDECAR_SLOT_EVIDENCE_PATH" 700 560
-validate_evidence "$SIDECAR_SPEAKING_EVIDENCE_PATH" 538 366
-validate_evidence "$SIDECAR_MUTED_EVIDENCE_PATH" 538 366
+validate_evidence "$SIDECAR_SPEAKING_EVIDENCE_PATH" 700 366
+validate_evidence "$SIDECAR_MUTED_EVIDENCE_PATH" 700 366
 
 printf 'Expanded visual evidence: %s\n' "$SIDECAR_EXPANDED_EVIDENCE_PATH"
 printf 'Compact visual evidence: %s\n' "$SIDECAR_COMPACT_EVIDENCE_PATH"


### PR DESCRIPTION
## What

Closing the expanded panel could flash the capsule and its icons toward the top-left of where the panel had been, before they snapped back to the centre of the screen.

The collapse ends with the window snapping from the expanded stage to a narrower, re-centred compact one — a move and a resize in one `setBounds`. macOS lands the content's relayout and the window's move on different frames, so for a beat the compact layout (capsule centred in the new, narrower viewport) is drawn against the old window origin: shifted left by half the width difference, at the top — exactly the reported flash — until the move catches up and it recentres.

The window now holds the width of the widest shape any mode can draw — the panel, and the peek where a housing outgrows it — in **both** modes, so a mode change is a height-only resize anchored to the top edge and the window origin never moves. A height change has no visible tear: everything a shorter frame crops is transparent margin below a shape that has already closed. The compact window was already wider than its shape for exactly this no-IPC reason; this extends that rule across modes.

- `positionNotchWindow` computes one width for both modes (`max(panel, peek) + margins`, clamped to the display).
- `scripts/evidence.sh` validates the compact captures at the shared width.
- `AGENTS.md` panel-motion prose updated to state the invariant and why.

## How it was diagnosed and verified

Reproduced on a physical Mac by driving the packaged app (fixture scenario) over CDP while screen-recording the notch region, then frame-stepping the video:

- **Before:** the first post-collapse frame showed the compact strip displaced left by exactly `(700 − 538) / 2 = 81px` (compact layout against the expanded origin), recentring on a later frame. The renderer's own samples showed `innerWidth` flipping to the compact size before `screenX`/`outerWidth` moved.
- **After:** the window's `x` is identical in both modes, mode changes are height-only, and no frame in the re-recording shows the strip off-centre (centroid stays within ~2px throughout). The close spring also renders visibly smoother, since the snap no longer forces a full-width relayout.

## Checks

- `./scripts/check.sh` — passes (lint, typecheck, 265 core + all desktop tests, builds).
- `./scripts/evidence.sh` — passes on a physical Mac; all six captures validated at the new geometry, compact/peek inspected: capsule and wings centred in the wider stage.
- `./scripts/verify.sh` — its check stage fails on that Mac in `realtime-session.test.ts` (99 cancellations, "promise resolution still pending"), which reproduces identically on a clean `main` checkout there — a pre-existing local Node-environment issue unrelated to this change; the evidence stage was run and validated separately as above.
- Physical-notch check: **not performed** — the diagnosis and re-verification ran on a notchless display (bubble form and the fixture's pinned housing). The fix removes the window move for every form factor the same way, but a hover-and-close pass on a notched MacBook is worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b4d7e4ca-0265-41d0-a40a-81fd9f62a40a)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32218870999/artifacts/9353273848) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32218870999)

- Commit: `1d55673c57d3dc4bd897d89b0ff08c65e739841f`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
