### PR TITLE
feat(desktop): announce a waiting update from the Settings tab

### DIFF
--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -535,9 +535,10 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         `The Updates section on ${FRONT_PAGE} says which version this is and whether a newer ` +
         "release exists. Its button checks GitHub on the spot, and Luke also checks on his own " +
         "a few times a day — always on; nothing about the developer or their sessions is sent, " +
-        "and only the release's version name is read back. A newer release is fetched by hand " +
-        "in the browser, from the fixed releases page: Luke never changes the running build " +
-        "himself.",
+        "and only the release's version name is read back. While a newer release is waiting, " +
+        "the Settings tab wears a dot, the section stands at the top of that page, and its " +
+        "button becomes Download. A newer release is fetched by hand in the browser, from the " +
+        "fixed releases page: Luke never changes the running build himself.",
     },
     {
       label: "Quitting",

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -57,6 +57,7 @@ import {
 import { SendIcon, StopIcon } from "./settings-icons";
 import { SettingsPanel, type SettingsPanelProps } from "./settings-panel";
 import { SignInGate } from "./sign-in-gate";
+import { updateAvailable, updateRow } from "./update-row";
 
 /** Handed up rather than performed here: the row knows sessions, not IPC. */
 export interface SessionWriteHandlers {
@@ -722,13 +723,18 @@ export function PanelBody({
   const highlight = list.search?.tokens;
   const runs = sessionListRuns(rows.map((row) => row.item));
   const runKeys = sessionRunKeys(runs, rows);
+  // The tab wears the update row's own words, so the dot's hover and the row
+  // it leads to can never tell two different stories about the same release.
+  const settingsNote = updateAvailable(settings.updates.update)
+    ? updateRow(settings.updates.update).detail
+    : undefined;
   return (
     <div className="body">
       {/* The tab bar says what you are looking at; the buttons beside it say
           how it is being shown. One line, because the second is only ever a
           qualifier on the first. */}
       <div className="panel-header">
-        <TabBar tab={tab} onTabChange={onTabChange} />
+        <TabBar tab={tab} onTabChange={onTabChange} {...(settingsNote ? { settingsNote } : {})} />
         {offerSearch || offerOptions ? (
           <span className="header-controls">
             {offerSearch ? (

--- a/apps/desktop/src/renderer/panel-tabs.tsx
+++ b/apps/desktop/src/renderer/panel-tabs.tsx
@@ -31,9 +31,16 @@ export function panelPanelId(tab: PanelTab): string {
 export function TabBar({
   tab,
   onTabChange,
+  settingsNote,
 }: {
   tab: PanelTab;
   onTabChange: (tab: PanelTab) => void;
+  /**
+   * News the Settings tab wears as a dot while it stands — a newer release
+   * waiting to be fetched. The words are the hover's and the screen
+   * reader's; the dot alone is the mark.
+   */
+  settingsNote?: string;
 }): React.JSX.Element {
   const activeIndex = PANEL_TABS.findIndex((candidate) => candidate.id === tab);
 
@@ -66,6 +73,11 @@ export function TabBar({
           onClick={() => onTabChange(candidate.id)}
         >
           {candidate.label}
+          {candidate.id === PANEL_TAB.SETTINGS && settingsNote ? (
+            <span className="tab-note" title={settingsNote}>
+              <span className="visually-hidden">({settingsNote})</span>
+            </span>
+          ) : null}
         </button>
       ))}
     </div>

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -131,7 +131,7 @@ import {
   type SettingsView,
   settingsNavRowId,
 } from "./settings-views";
-import { UPDATE_ROW_ACTION, updateRow } from "./update-row";
+import { UPDATE_ROW_ACTION, updateAvailable, updateRow } from "./update-row";
 
 /** One provider the default-workspace rows can offer, by id and display name. */
 export interface WorkspaceProviderOption {
@@ -2622,8 +2622,11 @@ function WhatLukeRunsOnSection({
   preferences,
   voiceService,
   hostedUsage,
+  rowIndex,
 }: {
   panelOpen: boolean;
+  /** Where the section stands in the page's arrival stagger, counted by the caller. */
+  rowIndex: number;
   /**
    * Whether this system cannot store a key at all. The key half cannot be
    * chosen or supplied then, and it says why rather than going quiet.
@@ -2663,7 +2666,10 @@ function WhatLukeRunsOnSection({
       ? hostedUsage.attention
       : undefined;
   return (
-    <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
+    <section
+      className="settings-section"
+      style={{ "--row-index": rowIndex } as React.CSSProperties}
+    >
       <h2>
         <LukeIcon />
         What Luke runs on
@@ -2991,10 +2997,26 @@ function pageResetControl(
   return undefined;
 }
 
-function UpdatesSection({ control }: { control: UpdateControl }): React.JSX.Element {
+/**
+ * Where the build stands against the latest release. It sits below the pages
+ * until a newer release is positively known, and leads the front page while
+ * one is — the place in the stack is itself the answer to "is there news",
+ * the same answer the Settings tab's dot gives from outside. The caller says
+ * where it stands, because the arrival stagger is counted by the page.
+ */
+function UpdatesSection({
+  control,
+  rowIndex,
+}: {
+  control: UpdateControl;
+  rowIndex: number;
+}): React.JSX.Element {
   const row = updateRow(control.update);
   return (
-    <section className="settings-section" style={{ "--row-index": 3 } as React.CSSProperties}>
+    <section
+      className="settings-section"
+      style={{ "--row-index": rowIndex } as React.CSSProperties}
+    >
       <h2>
         <DownloadIcon />
         Updates
@@ -3008,7 +3030,10 @@ function UpdatesSection({ control }: { control: UpdateControl }): React.JSX.Elem
           <small>{row.detail}</small>
         </span>
         {row.action === UPDATE_ROW_ACTION.GET ? (
-          <button type="button" className="quiet-button" onClick={control.onOpenLatest}>
+          /* The one button on the page with somewhere new to go, in the same
+             accent the tab's dot announced it with; every other state of this
+             row keeps the quiet button, because checking is maintenance. */
+          <button type="button" className="action-button" onClick={control.onOpenLatest}>
             Download
           </button>
         ) : (
@@ -3078,6 +3103,10 @@ export function SettingsPanel({
   }, [view, panelOpen]);
   // The drawn page's reset, absent while that page stands at its defaults.
   const pageReset = pageResetControl(view, settings, preferences);
+  // Whether the Updates section leads the front page instead of sitting below
+  // the pages: a newer release waiting is the one piece of news this page can
+  // hold, and news is not filed under maintenance.
+  const updateLeads = updateAvailable(updates.update);
   return (
     <div
       className="settings"
@@ -3100,10 +3129,16 @@ export function SettingsPanel({
            what Luke is allowed, the way to the founders, whose account this
            is, and the way out. The allowance leads because it is the one
            thing here worth checking daily; the account itself follows the
-           page down to the ways out, which are done once or never. */
+           page down to the ways out, which are done once or never. A newer
+           release waiting takes the head of the page for as long as it
+           stands, because it is the one thing here that is news rather than
+           state, and the row indexes below count past it so the arrival
+           stagger keeps one order with the sections. */
         <>
+          {updateLeads ? <UpdatesSection control={updates} rowIndex={1} /> : null}
           {account.status === ACCOUNT_STATUS.SIGNED_IN && settings ? (
             <WhatLukeRunsOnSection
+              rowIndex={updateLeads ? 2 : 1}
               panelOpen={panelOpen}
               storageLocked={settings.secretStorage === SECRET_STORAGE.UNAVAILABLE}
               settings={settings}
@@ -3115,7 +3150,7 @@ export function SettingsPanel({
           ) : null}
           <section
             className="settings-section settings-index"
-            style={{ "--row-index": 2 } as React.CSSProperties}
+            style={{ "--row-index": updateLeads ? 3 : 2 } as React.CSSProperties}
           >
             {SETTINGS_SUBVIEW_LIST.map((subview) => (
               <SettingsNavRow
@@ -3169,7 +3204,7 @@ export function SettingsPanel({
 
       {view !== SETTINGS_VIEW.ROOT ? null : (
         <>
-          <UpdatesSection control={updates} />
+          {updateLeads ? null : <UpdatesSection control={updates} rowIndex={3} />}
 
           <FeedbackSection control={feedback} />
 

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -2024,6 +2024,20 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   color: var(--text-primary);
 }
 
+/* The dot the Settings tab wears while a newer release is waiting. News, not
+   urgency, so it takes the working blue the Download button answers in rather
+   than the attention orange. Absolutely positioned with auto insets: it holds
+   its inline spot just past the label without re-centring the word under a
+   pointer the moment the news lands. */
+.tab-note {
+  position: absolute;
+  width: 4px;
+  height: 4px;
+  margin: 1px 0 0 3px;
+  border-radius: 50%;
+  background: var(--state-working);
+}
+
 /* Session primitives ----------------------------------------------------- */
 
 /* Read by assistive tech and drawn nowhere: the rows carry state in colour and

--- a/apps/desktop/src/renderer/update-row.ts
+++ b/apps/desktop/src/renderer/update-row.ts
@@ -21,6 +21,16 @@ export interface UpdateRow {
 }
 
 /**
+ * Whether a newer release is positively known to exist. This is what marks
+ * the Settings tab and moves the Updates section to the head of the front
+ * page — one judgment, so the dot, the section's place, and the Download
+ * button can never disagree about whether there is news.
+ */
+export function updateAvailable(update: UpdateSnapshot): boolean {
+  return update.status === UPDATE_STATUS.UPDATE_AVAILABLE;
+}
+
+/**
  * Reads the row from the last learned answer. Fetching an update is the
  * user's own act in the browser — the row only ever says where the build
  * stands and offers the next honest step: check again, wait for the check

--- a/apps/desktop/tests/update-row.test.ts
+++ b/apps/desktop/tests/update-row.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { UPDATE_ROW_ACTION, updateRow } from "../src/renderer/update-row";
+import { UPDATE_ROW_ACTION, updateAvailable, updateRow } from "../src/renderer/update-row";
 import { UPDATE_STATUS } from "../src/shared/contracts";
 
 test("an unasked question is an offer to ask, never an answer", () => {
@@ -36,4 +36,23 @@ test("an unreachable check says so and offers to try again", () => {
   const row = updateRow({ status: UPDATE_STATUS.UNREACHABLE, currentVersion: "0.1.0" });
   assert.equal(row.action, UPDATE_ROW_ACTION.CHECK);
   assert.equal(row.current, false);
+});
+
+test("only a positively known newer release counts as news", () => {
+  assert.equal(
+    updateAvailable({
+      status: UPDATE_STATUS.UPDATE_AVAILABLE,
+      currentVersion: "0.1.0",
+      latestVersion: "0.2.0",
+    }),
+    true,
+  );
+  for (const status of [
+    UPDATE_STATUS.UNKNOWN,
+    UPDATE_STATUS.CHECKING,
+    UPDATE_STATUS.UP_TO_DATE,
+    UPDATE_STATUS.UNREACHABLE,
+  ] as const) {
+    assert.equal(updateAvailable({ status, currentVersion: "0.1.0" }), false);
+  }
 });


### PR DESCRIPTION
## Summary

While a newer release is positively known to exist:

- The **Settings tab wears a dot** in the working blue — news, not urgency, so it takes `--state-working` rather than the attention orange. The dot is absolutely positioned with auto insets, so the label never re-centres under a pointer the moment the news lands; its hover and hidden text carry the update row's own words.
- The **Updates section leads the front page** instead of sitting under the pages, and the row indexes count past it so the arrival stagger keeps one order with the sections. While no release is waiting, the page keeps its existing order.
- The **Download button takes the blue accent** (`action-button`); every other state of the row keeps the quiet button, because checking is maintenance.

One judgment — `updateAvailable` in `update-row.ts` — feeds the dot, the section's place, and the button, so the three can never disagree. The guide's Updates fact learned the new surface in the same change.

## Testing

- `./scripts/check.sh` passes (1149 tests, 0 failures).
- New unit test: `updateAvailable` answers true only for `UPDATE_AVAILABLE`.
- Tab-bar markup rendered against the real CSS in headless Chrome to confirm the dot's placement and that the label holds its position with and without it. No physical-notch check was performed (developed in a cloud Linux workspace); `./scripts/verify.sh` runs in CI's macOS job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/4538ce77-fe6b-4ac9-ac19-df5c5306d4eb)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32268094814/artifacts/9371072108) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32268094814)

- Commit: `4fd844e887f20f79675b9478a1098829efc1193e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
