### PR TITLE
feat(desktop): keep the build current with electron-updater

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -4,7 +4,10 @@ The release workflow builds, signs, notarizes, staples, and validates an arm64 m
 then creates `Luke-X.Y.Z-macos-arm64.zip` with a matching `.sha256` file, and a notarized
 `Luke-X.Y.Z-arm64.dmg` with its own `.sha256` plus a version-free copy named `Luke.dmg` —
 the asset the website's download button reaches through
-`releases/latest/download/Luke.dmg`, which is why its name must never change.
+`releases/latest/download/Luke.dmg`, which is why its name must never change. Beside them
+it writes a version-free `latest-mac.yml`, the electron-updater manifest the app updates
+from through `releases/latest/download/latest-mac.yml` — the manifest names the zip beside
+it and carries its sha512, so its name must never change either.
 
 Pushing a `vX.Y.Z` tag publishes or updates a GitHub Release. A manual
 `workflow_dispatch` run performs the same release rehearsal without publishing; its zip,
@@ -116,16 +119,18 @@ client under **APIs & Services → Credentials**.
 
 The builder writes both distribution artifacts under `artifacts/release/`, and the
 publish script is what knows the asset set: the versioned DMG and zip with their
-checksums, plus the version-free `Luke.dmg` the website's download link depends on. It
+checksums, plus the version-free `Luke.dmg` the website's download link depends on and
+the version-free `latest-mac.yml` the app updates from. It
 refuses to publish when the tag does not match `apps/desktop/package.json`, and it
 creates a published, non-draft release — the `releases/latest` link and the app's own
 update check both ignore drafts and prereleases, so a draft is a release nobody can
 reach. Re-running it is safe: assets are replaced with `--clobber`.
 
-Afterwards, confirm the two consumers see the build:
+Afterwards, confirm the three consumers see the build:
 
 ```sh
 curl -sI -o /dev/null -w '%{http_code}\n' \
   https://github.com/ReviewStage/luke/releases/latest/download/Luke.dmg
 curl -s https://api.github.com/repos/ReviewStage/luke/releases/latest | grep tag_name
+curl -sL https://github.com/ReviewStage/luke/releases/latest/download/latest-mac.yml
 ```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,7 @@ jobs:
           ASSET_NAME=$(node -e "import('./apps/desktop/scripts/release-config.mjs').then((config) => process.stdout.write(config.releaseZipFileName(process.argv[1])))" "$VERSION")
           DMG_ASSET_NAME=$(node -e "import('./apps/desktop/scripts/release-config.mjs').then((config) => process.stdout.write(config.releaseDmgFileName(process.argv[1])))" "$VERSION")
           LATEST_DMG_ASSET_NAME=$(node -e "import('./apps/desktop/scripts/release-config.mjs').then((config) => process.stdout.write(config.RELEASE_LATEST_DMG_FILE_NAME))")
+          UPDATE_FEED_ASSET_NAME=$(node -e "import('./apps/desktop/scripts/release-config.mjs').then((config) => process.stdout.write(config.RELEASE_UPDATE_FEED_FILE_NAME))")
           {
             echo "VERSION=$VERSION"
             echo "DIST_DIR=$DIST_DIR"
@@ -95,6 +96,7 @@ jobs:
             echo "DMG_ASSET_NAME=$DMG_ASSET_NAME"
             echo "DMG_CHECKSUM_NAME=$DMG_ASSET_NAME.sha256"
             echo "LATEST_DMG_ASSET_NAME=$LATEST_DMG_ASSET_NAME"
+            echo "UPDATE_FEED_ASSET_NAME=$UPDATE_FEED_ASSET_NAME"
             echo "APP_PATH=$GITHUB_WORKSPACE/apps/desktop/out/Luke-darwin-arm64/Luke.app"
             echo "SUBMISSION_ZIP=$RUNNER_TEMP/Luke-$VERSION-notarization.zip"
           } >> "$GITHUB_ENV"
@@ -179,6 +181,7 @@ jobs:
           cp "artifacts/release/$ASSET_NAME" "$DIST_DIR/$ASSET_NAME"
           cp "artifacts/release/$DMG_ASSET_NAME" "$DIST_DIR/$DMG_ASSET_NAME"
           cp "artifacts/release/$DMG_ASSET_NAME" "$DIST_DIR/$LATEST_DMG_ASSET_NAME"
+          node apps/desktop/scripts/write-update-feed.mjs "$DIST_DIR/$UPDATE_FEED_ASSET_NAME"
           (
             cd "$DIST_DIR"
             shasum -a 256 "$ASSET_NAME" > "$CHECKSUM_NAME"
@@ -203,6 +206,7 @@ jobs:
             "$DIST_DIR/$DMG_ASSET_NAME" \
             "$DIST_DIR/$DMG_CHECKSUM_NAME" \
             "$DIST_DIR/$LATEST_DMG_ASSET_NAME" \
+            "$DIST_DIR/$UPDATE_FEED_ASSET_NAME" \
             --clobber
 
       - name: Preserve rehearsal artifacts
@@ -216,6 +220,7 @@ jobs:
             ${{ env.DIST_DIR }}/${{ env.DMG_ASSET_NAME }}
             ${{ env.DIST_DIR }}/${{ env.DMG_CHECKSUM_NAME }}
             ${{ env.DIST_DIR }}/${{ env.LATEST_DMG_ASSET_NAME }}
+            ${{ env.DIST_DIR }}/${{ env.UPDATE_FEED_ASSET_NAME }}
           if-no-files-found: error
           retention-days: 14
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,17 +266,26 @@ Trust constraints:
   the press opened — opened by the press, closed when the exchange settles —
   and never outlives it; typed asks never open one at all. An unreadable
   route means the browser's default device, never a refusal to listen.
-- The update check is the one request Luke makes with no user-supplied key at
-  all: an unauthenticated read of this repository's latest release name from
-  GitHub's public API, on a timer of its own — always on, like the
-  announcements, answering only to the run mode — and at the press of the
-  Updates row's button; never in a fixture or capture run.
-  It carries nothing about the user, their sessions, or their keys; only the
-  release's version name is read back, and what a check learns changes only
-  what the row says. The way to a newer build is the browser, at the releases
-  page fixed by the build — nothing read from the network chooses that
-  address — and Luke never modifies the running app. Widening what the check
-  sends, reads, or does is a product decision, not an implementation detail.
+- Updating is the one thing Luke does on the network with no user-supplied
+  key at all, and it follows the same shape Superset's production updater
+  keeps: electron-updater reads this repository's release manifest from a
+  feed address fixed by the build — an unauthenticated fetch carrying
+  nothing about the user, their sessions, or their keys — on a timer of its
+  own and at the press of the Updates row's button; never in a fixture or
+  capture run, and never in an unpackaged build. A newer build found by any
+  check downloads at once, so the row can offer a restart instead of a wait,
+  but what is fetched is only ever what this repository's own release
+  pipeline published: the manifest carries the archive's sha512, the archive
+  must sit on the same release as the manifest, and Squirrel.Mac refuses one
+  whose code signature does not match the running app's. The running build
+  is replaced only at a quit — the row's restart press, or whenever the user
+  next quits — and an install is asked for at most once, because repeat asks
+  race the binary swap. A transient network failure is silence for the next
+  timed check; any other failure is an answer on the row whose way forward
+  is the browser, at the releases page fixed by the build — the same page
+  that serves a build which cannot install in place at all. Widening what
+  the updater sends, reads, or does is a product decision, not an
+  implementation detail.
 - Keep unsupported capabilities explicit; do not invent fallback controls.
 - Keep Electron renderers sandboxed with context isolation and narrow IPC.
 - Commit only synthetic fixtures and repository-relative paths. This binds

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -158,20 +158,28 @@ condition of it. A deployment holding no analytics configuration has no such
 request to make. Turning the switch off stops further collection but erases
 nothing already collected; ask us and we will run the erasure again.
 
-## Update check
+## Updates
 
-Luke asks GitHub's public API for the name of this repository's latest
-published release, so the Settings tab's Updates row can say whether a newer
-build exists. The request is unauthenticated and carries no account, session,
-transcript, or key material — GitHub sees what any HTTPS request shows it,
-such as the network address it came from, under GitHub's own policies. Only
-the release's version name is read from the answer.
+Luke keeps itself current with electron-updater, the same updater most
+Electron apps ship. It reads this repository's release manifest from GitHub
+(`releases/latest/download/latest-mac.yml`, an address fixed by the build) so
+the Settings tab's Updates row can say where the build stands. The requests
+are unauthenticated and carry no account, session, transcript, or key
+material — GitHub sees what any HTTPS request shows it, such as the network
+address it came from, under GitHub's own policies.
 
-Luke asks at launch and a few times a day while running, and at the press of
-the Updates row's Check for Updates button. Fixture and evidence runs never
-check. What a check learns changes only what the row says: fetching an update
-is your own download in the browser, from the repository's releases page, and
-Luke never modifies the running app.
+Luke checks at launch and a few times a day while running, and at the press
+of the Updates row's Check for updates button. Fixture and evidence runs
+never check, and an unpackaged build never checks. When a check finds a newer
+build, Luke downloads it right away from the same release the manifest came
+from — the manifest carries the archive's checksum, and macOS's own update
+machinery (Squirrel.Mac) refuses an archive whose code signature does not
+match the running app's. The downloaded build replaces the running one only
+when the app quits: at your press on Restart to update, or whenever you next
+quit. If a download or install fails, the row says so and offers the
+repository's releases page in the browser instead — the same fallback an
+unpackaged build offers, since only a signed, packaged build can install in
+place.
 
 ## Sending feedback
 

--- a/PROVIDERS.md
+++ b/PROVIDERS.md
@@ -311,10 +311,13 @@ review. They are credential-only — nothing of theirs is ever observed as a
 session — and the hosted account's daily allowance runs both until a
 user-supplied OpenAI key takes over.
 
-**The update check** is the one request made with no user key: an
-unauthenticated read of this repository's latest release name from GitHub's
-public API. Only the version name is read back, and it changes only what the
-Updates row says.
+**The updater** is the one thing on the network with no user key:
+electron-updater reads this repository's release manifest from a feed address
+fixed by the build, unauthenticated and carrying nothing about the user. A
+newer build found by any check downloads at once from the same release,
+checksum-verified against the manifest and signature-verified against the
+running app, and installs only at a quit — the Updates row's restart press,
+or the next quit. A failure falls back to the releases page in the browser.
 
 ## Keeping this document current
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -25,5 +25,8 @@
     "react-dom": "19.2.8",
     "tsx": "4.23.12",
     "typescript": "7.0.2"
+  },
+  "dependencies": {
+    "electron-updater": "6.8.9"
   }
 }

--- a/apps/desktop/scripts/release-config.mjs
+++ b/apps/desktop/scripts/release-config.mjs
@@ -6,6 +6,10 @@ export const NOTARY_KEYCHAIN_PROFILE = "luke-notary";
 // The version-free asset name every release carries beside the versioned DMG,
 // so the download link on the website can point at the latest release forever.
 export const RELEASE_LATEST_DMG_FILE_NAME = "Luke.dmg";
+// The version-free manifest name every release carries, so the app's update
+// feed URL — releases/latest/download/latest-mac.yml — never moves either.
+// The name is electron-updater's own convention for a macOS generic feed.
+export const RELEASE_UPDATE_FEED_FILE_NAME = "latest-mac.yml";
 export const NOTARY_CREDENTIAL_SOURCE = {
   KEYCHAIN_PROFILE: "keychain-profile",
   KEY_FILE: "key-file",
@@ -29,11 +33,35 @@ export function releaseDmgFileName(version) {
   return `Luke-${version}-${PACKAGED_ARCHITECTURE}.dmg`;
 }
 
-// The zip is the future auto-update path's food — Squirrel.Mac updates from
-// an archive of the app, never a DMG — so every release carries it beside the
+// The zip is the auto-update path's food — Squirrel.Mac updates from an
+// archive of the app, never a DMG — so every release carries it beside the
 // DMG people actually open.
 export function releaseZipFileName(version) {
   return `Luke-${version}-macos-${PACKAGED_ARCHITECTURE}.zip`;
+}
+
+/**
+ * The update manifest a release publishes beside its archive, in the
+ * `latest-mac.yml` shape electron-builder writes and electron-updater reads.
+ * The archive URL is the bare file name on purpose: the generic provider
+ * resolves it against the feed's own address, `releases/latest/download/`,
+ * so the manifest and the archive can only ever be read from the same
+ * release. The sha512 is what makes a truncated or substituted download a
+ * refusal rather than an install.
+ */
+export function releaseUpdateManifest({ version, sha512, size, releaseDate }) {
+  const zipFileName = releaseZipFileName(version);
+  return [
+    `version: ${version}`,
+    "files:",
+    `  - url: ${zipFileName}`,
+    `    sha512: ${sha512}`,
+    `    size: ${size}`,
+    `path: ${zipFileName}`,
+    `sha512: ${sha512}`,
+    `releaseDate: '${releaseDate}'`,
+    "",
+  ].join("\n");
 }
 
 export function releaseArtifactDirectory(repoRoot) {

--- a/apps/desktop/scripts/write-update-feed.mjs
+++ b/apps/desktop/scripts/write-update-feed.mjs
@@ -1,0 +1,45 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  releaseArtifactDirectory,
+  releaseUpdateManifest,
+  releaseZipFileName,
+} from "./release-config.mjs";
+
+// Writes the electron-updater manifest for the version about to be published,
+// hashed from the very archive the release uploads, so both publish paths —
+// the manual script and the tag-push workflow — upload the same document they
+// could never hand-compose consistently.
+
+const outputPath = process.argv[2];
+if (!outputPath) {
+  process.stderr.write("usage: node write-update-feed.mjs <output-path>\n");
+  process.exit(1);
+}
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDirectory, "..", "..", "..");
+const require = createRequire(import.meta.url);
+const desktopPackage = require(path.join(scriptDirectory, "..", "package.json"));
+
+const zipPath = path.join(
+  releaseArtifactDirectory(repoRoot),
+  releaseZipFileName(desktopPackage.version),
+);
+if (!fs.existsSync(zipPath)) {
+  process.stderr.write(`error: ${zipPath} does not exist. Build the release archive first.\n`);
+  process.exit(1);
+}
+
+const archive = fs.readFileSync(zipPath);
+const manifest = releaseUpdateManifest({
+  version: desktopPackage.version,
+  sha512: crypto.createHash("sha512").update(archive).digest("base64"),
+  size: archive.byteLength,
+  releaseDate: new Date().toISOString(),
+});
+fs.writeFileSync(outputPath, manifest);
+process.stdout.write(`Wrote update manifest for ${desktopPackage.version}: ${outputPath}\n`);

--- a/apps/desktop/src/desktop-app.ts
+++ b/apps/desktop/src/desktop-app.ts
@@ -12,6 +12,7 @@ import {
   fixtureSnapshot,
   InMemorySessionRegistry,
   isProviderId,
+  isRecord,
   isWireString,
   type MeetingInterval,
   type NormalizedSession,
@@ -30,6 +31,7 @@ import {
   type SessionProviderAdapter,
   staleWorkspaceProjectDefaults,
   type TrackedIssue,
+  text,
   type UnparsedWireValue,
   type WorkspaceAgentSelection,
   workspaceProjectSelectionId,
@@ -100,6 +102,7 @@ import { APP_SETTING_SCHEMA } from "./shared/settings-schema";
 import { SupersetCli, SupersetWorkspaceAdapter } from "./superset-cli";
 import { SupersetSignIn } from "./superset-sign-in";
 import { SupersetWorkspaceReader, SupersetWorkspaceSnapshot } from "./superset-workspaces";
+import { createElectronUpdaterEngine } from "./update-installer";
 import { UPDATE_ENDPOINT, UpdateService } from "./update-service";
 import { VoiceCapabilityAssembler } from "./voice-capability-assembler";
 
@@ -346,12 +349,43 @@ const voiceCapabilities = new VoiceCapabilityAssembler({
 // anything the renderer does — and only this process may run a helper.
 const mediaDuck = new MediaDuckController();
 const feedbackDelivery = feedbackDeliveryFromEnvironment();
-// Learns whether a newer release exists, and nothing else. It lives here
-// rather than in a renderer because the timer must survive every window, and
-// what it learns reaches them all through the same broadcast settings use.
+// Keeps the running build current: a timed check reads the release manifest,
+// a newer build downloads at once, and the install lands at the quit the
+// user asks for. It lives here rather than in a renderer because the timer
+// must survive every window, only this process may run the updater, and what
+// it learns reaches them all through the same broadcast settings use.
+// Squirrel can only replace a signed, packaged build, and a fixture or
+// evidence run must not fetch, so every other run carries no engine and its
+// row offers the browser instead. The last-run version lives in its own file
+// so the first launch after an install can say what just happened.
+const lastRunVersionPath = () => path.join(app.getPath("userData"), "last-run-version.json");
 const updateService = new UpdateService({
   currentVersion: app.getVersion(),
   onChange: (update) => panels.broadcast(channels.updateChanged, update),
+  engine:
+    app.isPackaged && runMode.sendsNetwork && process.platform === "darwin"
+      ? createElectronUpdaterEngine()
+      : undefined,
+  lastRunVersion: {
+    read: () => {
+      try {
+        const stored: UnparsedWireValue = JSON.parse(fs.readFileSync(lastRunVersionPath(), "utf8"));
+        return isRecord(stored) ? text(stored.version) : undefined;
+      } catch {
+        // A missing or unreadable file is the first launch: nothing to confirm.
+        return undefined;
+      }
+    },
+    write: (version) => {
+      try {
+        fs.writeFileSync(lastRunVersionPath(), `${JSON.stringify({ version })}\n`);
+      } catch (error) {
+        process.stderr.write(
+          `Could not persist the last-run version: ${error instanceof Error ? error.message : String(error)}\n`,
+        );
+      }
+    },
+  },
 });
 // Counts how Luke's own features are used. It lives here rather than in a
 // renderer because every emit site is already in this process and the timer
@@ -868,17 +902,25 @@ function registerIpc(): void {
   });
 
   // The row's button. Answered rather than fire-and-forget so the row that
-  // asked and the broadcast never disagree; a run that sends no network
-  // answers with the standing snapshot rather than make a request it must not.
+  // asked and the broadcast never disagree; a run without an engine answers
+  // with the standing snapshot rather than make a request it must not.
   ipcMain.handle(channels.checkForUpdates, (event) => {
     if (!trustedSender(event)) throw new Error("Untrusted renderer");
-    if (!runMode.sendsNetwork) return updateService.snapshot();
     return updateService.check();
   });
 
-  // The newest release's page, in the browser. The address is fixed here like
-  // the microphone pane's, so nothing an update check read can steer where a
-  // press goes.
+  // The restart into a downloaded build. The service ignores the ask unless
+  // its own snapshot says one is ready — and ignores a repeat while Squirrel
+  // stages the swap — so a stray send installs nothing.
+  ipcMain.on(channels.installUpdate, (event) => {
+    if (!trustedSender(event)) return;
+    updateService.install();
+  });
+
+  // The newest release's page, in the browser — the way to a build where
+  // installing in place is impossible or has failed. The address is fixed
+  // here like the microphone pane's, so nothing an update check read can
+  // steer where a press goes.
   ipcMain.on(channels.openLatestRelease, (event) => {
     if (!trustedSender(event)) return;
     void shell.openExternal(UPDATE_ENDPOINT.LATEST_RELEASE_PAGE_URL);

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -70,6 +70,7 @@ const bridge: AppBridge = {
   },
   disconnectLinear: invokeMethod<"disconnectLinear">(channels.disconnectLinear),
   checkForUpdates: invokeMethod<"checkForUpdates">(channels.checkForUpdates),
+  installUpdate: () => ipcRenderer.send(channels.installUpdate),
   openLatestRelease: () => ipcRenderer.send(channels.openLatestRelease),
   beginSupersetSignIn: invokeMethod<"beginSupersetSignIn">(channels.beginSupersetSignIn),
   submitSupersetSignInCode: invokeMethod<"submitSupersetSignInCode">(

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -2872,6 +2872,7 @@ export function App(): React.JSX.Element {
     onCheck: async () => {
       setUpdate(await window.sidecar.checkForUpdates());
     },
+    onInstall: () => window.sidecar.installUpdate(),
     onOpenLatest: () => window.sidecar.openLatestRelease(),
   };
   const preferences: PreferenceWrites = {

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -610,13 +610,14 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       // A behavior rather than a setting, like the announcements: stated so
       // Luke neither denies checking nor offers a switch that does not exist.
       detail:
-        `The Updates section on ${FRONT_PAGE} says which version this is and whether a newer ` +
-        "release exists. Its button checks GitHub on the spot, and Luke also checks on his own " +
-        "a few times a day — always on; nothing about the developer or their sessions is sent, " +
-        "and only the release's version name is read back. While a newer release is waiting, " +
-        "the Settings tab wears a dot, the section stands at the top of that page, and its " +
-        "button becomes Download. A newer release is fetched by hand in the browser, from the " +
-        "fixed releases page: Luke never changes the running build himself.",
+        `The Updates section on ${FRONT_PAGE} says which version this is and where the build ` +
+        "stands. Its button checks the release manifest on the spot, and Luke also checks on " +
+        "his own a few times a day — always on; the fetch is unauthenticated and nothing about " +
+        "the developer or their sessions is sent. A newer release downloads itself when a check " +
+        "finds one — while it does, the Settings tab wears a dot and the section stands at the " +
+        "top of that page — and installs when Luke next quits: the row offers Restart to update, " +
+        "or it simply lands on the next quit. If a download or install fails, the row says so " +
+        "and offers the fixed releases page in the browser instead.",
     },
     {
       label: "Usage data",

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -142,7 +142,7 @@ import {
   type SettingsView,
   settingsNavRowId,
 } from "./settings-views";
-import { UPDATE_ROW_ACTION, updateAvailable, updateRow } from "./update-row";
+import { UPDATE_ROW_ACTION, type UpdateRowAction, updateAvailable, updateRow } from "./update-row";
 
 /** One provider the default-workspace rows can offer, by id and display name. */
 export interface WorkspaceProviderOption {
@@ -174,15 +174,18 @@ export interface MicrophoneControl {
 }
 
 /**
- * Where the app stands against the latest release, and the two things the row
- * can do about that: ask GitHub now, or open the newer release's page in the
- * browser. Fetching an update stays the user's own act there — the row never
- * changes the running build.
+ * Where the app stands against the latest release, and the acts the row can
+ * take about that: ask the release manifest now, restart into a build already
+ * downloaded, or — where installing in place is impossible or has failed —
+ * open the releases page in the browser. A newer build downloads itself when
+ * a check finds one; the running build is replaced only at a quit.
  */
 export interface UpdateControl {
   update: UpdateSnapshot;
-  /** Asks GitHub for the latest release name, right now. */
+  /** Asks the release manifest for the latest build, right now. */
   onCheck: () => Promise<void>;
+  /** Restarts into the downloaded release. */
+  onInstall: () => void;
   /** Opens the latest release's page, fixed by the build, in the browser. */
   onOpenLatest: () => void;
 }
@@ -3185,6 +3188,46 @@ function pageResetControl(
 }
 
 /**
+ * The buttons with somewhere new to go — fetch the release, restart into it,
+ * or reach its page in the browser — wear the same accent the tab's dot
+ * announced the news with; checking stays the quiet button, because checking
+ * is maintenance.
+ */
+function updateButton(action: UpdateRowAction, control: UpdateControl): React.JSX.Element {
+  switch (action) {
+    case UPDATE_ROW_ACTION.DOWNLOADING:
+      return (
+        <button type="button" className="quiet-button" disabled>
+          Downloading…
+        </button>
+      );
+    case UPDATE_ROW_ACTION.RESTART:
+      return (
+        <button type="button" className="action-button" onClick={control.onInstall}>
+          Restart to update
+        </button>
+      );
+    case UPDATE_ROW_ACTION.GET:
+      return (
+        <button type="button" className="action-button" onClick={control.onOpenLatest}>
+          Download
+        </button>
+      );
+    default:
+      return (
+        <button
+          type="button"
+          className="quiet-button"
+          disabled={action === UPDATE_ROW_ACTION.CHECKING}
+          onClick={() => void control.onCheck()}
+        >
+          {action === UPDATE_ROW_ACTION.CHECKING ? "Checking…" : "Check for updates"}
+        </button>
+      );
+  }
+}
+
+/**
  * Where the build stands against the latest release. It sits below the pages
  * until a newer release is positively known, and leads the front page while
  * one is — the place in the stack is itself the answer to "is there news",
@@ -3217,23 +3260,7 @@ function UpdatesSection({
           </span>
           <small>{row.detail}</small>
         </span>
-        {row.action === UPDATE_ROW_ACTION.GET ? (
-          /* The one button on the page with somewhere new to go, in the same
-             accent the tab's dot announced it with; every other state of this
-             row keeps the quiet button, because checking is maintenance. */
-          <button type="button" className="action-button" onClick={control.onOpenLatest}>
-            Download
-          </button>
-        ) : (
-          <button
-            type="button"
-            className="quiet-button"
-            disabled={row.action === UPDATE_ROW_ACTION.CHECKING}
-            onClick={() => void control.onCheck()}
-          >
-            {row.action === UPDATE_ROW_ACTION.CHECKING ? "Checking…" : "Check for updates"}
-          </button>
-        )}
+        {updateButton(row.action, control)}
       </div>
     </section>
   );

--- a/apps/desktop/src/renderer/update-row.ts
+++ b/apps/desktop/src/renderer/update-row.ts
@@ -2,10 +2,14 @@ import { UPDATE_STATUS, type UpdateSnapshot } from "../shared/contracts";
 
 /** The one act the row's button offers in each state. */
 export const UPDATE_ROW_ACTION = {
-  /** Ask GitHub for the latest release name. */
+  /** Ask the release manifest for the latest build. */
   CHECK: "check",
   /** Nothing to press: a check is already out. */
   CHECKING: "checking",
+  /** Nothing to press: a newer build is downloading itself. */
+  DOWNLOADING: "downloading",
+  /** Restart into the downloaded release. */
+  RESTART: "restart",
   /** Open the latest release's page in the browser. */
   GET: "get",
 } as const;
@@ -23,20 +27,40 @@ export interface UpdateRow {
 /**
  * Whether a newer release is positively known to exist. This is what marks
  * the Settings tab and moves the Updates section to the head of the front
- * page — one judgment, so the dot, the section's place, and the Download
- * button can never disagree about whether there is news.
+ * page — one judgment, so the dot, the section's place, and the row can
+ * never disagree about whether there is news. The news stands through the
+ * whole install: a release downloading, waiting on its restart, or failed
+ * mid-fetch is still one this build is not on.
  */
 export function updateAvailable(update: UpdateSnapshot): boolean {
-  return update.status === UPDATE_STATUS.UPDATE_AVAILABLE;
+  return (
+    update.status === UPDATE_STATUS.DOWNLOADING ||
+    update.status === UPDATE_STATUS.READY ||
+    (update.status === UPDATE_STATUS.ERROR && update.latestVersion !== undefined)
+  );
+}
+
+function downloadingDetail(update: UpdateSnapshot & { status: "downloading" }): string {
+  const percent = update.progress ? ` (${Math.round(update.progress.percent)}%)` : "";
+  return `Downloading version ${update.latestVersion}…${percent}`;
 }
 
 /**
- * Reads the row from the last learned answer. Fetching an update is the
- * user's own act in the browser — the row only ever says where the build
- * stands and offers the next honest step: check again, wait for the check
- * already out, or go get the newer release.
+ * Reads the row from the last learned answer. The row only ever says where
+ * the build stands and offers the next honest step: check again, wait for
+ * the check or download already out, restart into a build already fetched —
+ * or, where installing in place is impossible or has failed, go get it in
+ * the browser instead. A build that cannot install itself never offers a
+ * check it could do nothing with.
  */
 export function updateRow(update: UpdateSnapshot): UpdateRow {
+  if (!update.installSupported) {
+    return {
+      detail: "This build updates by hand: the releases page has the latest.",
+      action: UPDATE_ROW_ACTION.GET,
+      current: false,
+    };
+  }
   switch (update.status) {
     case UPDATE_STATUS.CHECKING:
       return {
@@ -44,31 +68,47 @@ export function updateRow(update: UpdateSnapshot): UpdateRow {
         action: UPDATE_ROW_ACTION.CHECKING,
         current: false,
       };
-    case UPDATE_STATUS.UP_TO_DATE:
+    case UPDATE_STATUS.DOWNLOADING:
       return {
-        detail: "This is the latest release.",
+        detail: downloadingDetail(update),
+        action: UPDATE_ROW_ACTION.DOWNLOADING,
+        current: false,
+      };
+    case UPDATE_STATUS.READY:
+      return {
+        detail:
+          `Version ${update.latestVersion} is downloaded. Restart Luke to finish ` +
+          "installing — or it installs on your next quit.",
+        action: UPDATE_ROW_ACTION.RESTART,
+        current: false,
+      };
+    case UPDATE_STATUS.UPDATED:
+      return {
+        detail: `Updated from version ${update.previousVersion}.`,
         action: UPDATE_ROW_ACTION.CHECK,
         current: true,
       };
-    case UPDATE_STATUS.UPDATE_AVAILABLE:
+    case UPDATE_STATUS.ERROR:
       return {
-        detail: `Version ${update.latestVersion} is available to download.`,
+        detail: update.latestVersion
+          ? `The update could not be installed. Get version ${update.latestVersion} from the releases page instead.`
+          : "The update check failed. The releases page has the latest build.",
         action: UPDATE_ROW_ACTION.GET,
         current: false,
       };
-    case UPDATE_STATUS.UNREACHABLE:
-      return {
-        detail: "Could not reach GitHub to check. Try again in a moment.",
-        action: UPDATE_ROW_ACTION.CHECK,
-        current: false,
-      };
     default:
-      return {
-        // Not an answer: nothing has been learned yet, so the row only offers
-        // to ask rather than posing an unknown as up to date.
-        detail: "Not checked yet.",
-        action: UPDATE_ROW_ACTION.CHECK,
-        current: false,
-      };
+      return update.status === UPDATE_STATUS.IDLE && update.upToDate
+        ? {
+            detail: "This is the latest release.",
+            action: UPDATE_ROW_ACTION.CHECK,
+            current: true,
+          }
+        : {
+            // Not an answer: nothing has been learned yet, so the row only
+            // offers to ask rather than posing an unknown as up to date.
+            detail: "The latest release has not been checked for yet.",
+            action: UPDATE_ROW_ACTION.CHECK,
+            current: false,
+          };
   }
 }

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -185,40 +185,82 @@ export interface ObservedAccountCalendars {
  * only way back would be deleting it.
  */
 /**
- // SAFETY: The preceding check establishes the asserted contract.
- * Where the app stands against the latest published release, as last learned.
- * `UNKNOWN` is the state before any check has answered — at launch, and
- // SAFETY: The preceding check establishes the asserted contract.
- * forever in a run that sends no network — and must be drawn as an offer to
- // SAFETY: The preceding check establishes the asserted contract.
- * check rather than as an answer.
+ * Where the updater stands, in the states electron-updater's own lifecycle
+ * moves through. `IDLE` is both "nothing learned yet" and "nothing newer" —
+ * `upToDate` on the snapshot says which, so the row never poses an unasked
+ * question as an answer. A check that finds a newer build downloads it at
+ * once, so there is no standing "available" state: the news arrives as
+ * `DOWNLOADING`. `UPDATED` is transient — the first launch after an install
+ * confirms what just happened. `ERROR` must be drawn as the way back to the
+ * browser, never as a dead end.
  */
 export const UPDATE_STATUS = {
-  UNKNOWN: "unknown",
+  IDLE: "idle",
   CHECKING: "checking",
-  UP_TO_DATE: "up-to-date",
-  UPDATE_AVAILABLE: "update-available",
-  UNREACHABLE: "unreachable",
+  DOWNLOADING: "downloading",
+  READY: "ready",
+  UPDATED: "updated",
+  ERROR: "error",
 } as const;
 
 export type UpdateStatus = (typeof UPDATE_STATUS)[keyof typeof UPDATE_STATUS];
 
+/** How far along a download is, as electron-updater reports it. */
+export interface UpdateProgress {
+  percent: number;
+  transferredBytes: number;
+  totalBytes: number;
+}
+
 /**
- * What the update row draws from. The latest version travels only on the one
- * state that learned it, and no address ever travels: the page an update is
- * fetched from is fixed in the main process, so nothing a check read can
- * steer where a press goes.
+ * What the update row draws from. The latest version travels only on the
+ * states that learned it, and no address ever travels: the manifest updates
+ * are fetched from and the page a failure falls back to are both fixed in
+ * the main process, so nothing a check read can steer where a press goes.
+ * `installSupported` says whether this build can replace itself in place —
+ * only a signed, packaged build running live can — so every other run's row
+ * offers the browser instead of an install that must fail. An error's text
+ * stays in the main process's log; the row words failures itself.
  */
 export type UpdateSnapshot =
-  | { status: typeof UPDATE_STATUS.UNKNOWN; currentVersion: string }
-  | { status: typeof UPDATE_STATUS.CHECKING; currentVersion: string }
-  | { status: typeof UPDATE_STATUS.UP_TO_DATE; currentVersion: string }
   | {
-      status: typeof UPDATE_STATUS.UPDATE_AVAILABLE;
+      status: typeof UPDATE_STATUS.IDLE;
       currentVersion: string;
+      installSupported: boolean;
+      /** True only after a check positively answered "nothing newer". */
+      upToDate: boolean;
+    }
+  | {
+      status: typeof UPDATE_STATUS.CHECKING;
+      currentVersion: string;
+      installSupported: boolean;
+    }
+  | {
+      status: typeof UPDATE_STATUS.DOWNLOADING;
+      currentVersion: string;
+      installSupported: boolean;
+      latestVersion: string;
+      progress?: UpdateProgress;
+    }
+  | {
+      status: typeof UPDATE_STATUS.READY;
+      currentVersion: string;
+      installSupported: boolean;
       latestVersion: string;
     }
-  | { status: typeof UPDATE_STATUS.UNREACHABLE; currentVersion: string };
+  | {
+      status: typeof UPDATE_STATUS.UPDATED;
+      currentVersion: string;
+      installSupported: boolean;
+      /** The version this build replaced, for the row to name the arrival. */
+      previousVersion: string;
+    }
+  | {
+      status: typeof UPDATE_STATUS.ERROR;
+      currentVersion: string;
+      installSupported: boolean;
+      latestVersion?: string;
+    };
 
 /** Renderer-safe settings. Credentials are never sent to a renderer. */
 export interface AppSettings {
@@ -687,15 +729,25 @@ export interface AppBridge {
    */
   resetSettings(scope: SettingsResetScope): Promise<SettingsUpdateResult>;
   /**
-   * Asks GitHub for the latest release name, right now, because the row's
-   * button was pressed. The answer is the same snapshot the broadcast
-   * carries, so the row that asked and every other window agree.
+   * Asks the release manifest for the latest build, right now, because the
+   * row's button was pressed. A newer build found by any check downloads at
+   * once, so the answer may already say `downloading`. The answer is the same
+   * snapshot the broadcast carries, so the row that asked and every other
+   * window agree; a build that cannot install answers with its standing
+   * snapshot and sends nothing.
    */
   checkForUpdates(): Promise<UpdateSnapshot>;
   /**
-   * Opens the latest release's page in the default browser. The renderer
-   * names an intent and never an address — the page is fixed in the main
-   * process, so nothing an update check read can steer where this goes.
+   * Restarts the app into the downloaded release. Meaningful only once the
+   * snapshot says `ready`; any other state — including an install already
+   * under way — ignores it.
+   */
+  installUpdate(): void;
+  /**
+   * Opens the latest release's page in the default browser — the way to a
+   * newer build where installing in place is impossible or has failed. The
+   * renderer names an intent and never an address — the page is fixed in the
+   * main process, so nothing an update check read can steer where this goes.
    */
   openLatestRelease(): void;
   /** Starts Superset's own OAuth login in one directly spawned CLI child. */
@@ -1028,6 +1080,7 @@ export const channels = {
   calendarsChanged: "app:calendars-changed",
   meetingQuietChanged: "app:meeting-quiet-changed",
   checkForUpdates: "app:check-for-updates",
+  installUpdate: "app:install-update",
   openLatestRelease: "app:open-latest-release",
   beginSupersetSignIn: "app:begin-superset-sign-in",
   submitSupersetSignInCode: "app:submit-superset-sign-in-code",

--- a/apps/desktop/src/update-installer.ts
+++ b/apps/desktop/src/update-installer.ts
@@ -1,0 +1,76 @@
+import { autoUpdater, type UpdateCheckResult } from "electron-updater";
+import { UPDATE_ENDPOINT, type UpdaterEngine, type UpdaterEngineEvents } from "./update-service";
+
+/** electron-updater emits progress per chunk; the broadcast needs far less. */
+const PROGRESS_EMIT_INTERVAL_MS = 500;
+
+/**
+ * electron-updater starts the auto-download inside checkForUpdates and hands
+ * back its promise unattached; every rejection has already gone through the
+ * `error` event, so the copy only needs to stop being unhandled.
+ */
+function releaseDownloadPromise(result: UpdateCheckResult | null): void {
+  result?.downloadPromise?.catch(() => undefined);
+}
+
+/**
+ * electron-updater's cache helper is not part of its public surface, but a
+ * corrupt cached download is only ever retried — the cache self-invalidates
+ * solely on a remote sha512 change — so errors must reach in and clear it.
+ */
+interface AppUpdaterInternals {
+  downloadedUpdateHelper: { clear(): Promise<void> } | null;
+}
+
+/**
+ * The updater Superset runs in production, bound the same way: electron
+ * updater's generic provider pointed at the feed fixed by the build, auto
+ * download on, install at quit on, differential download off (a known source
+ * of flaky downloads). Under it all is still Squirrel.Mac: the archive's code
+ * signature must match the running app's, and the swap happens in ShipIt at
+ * quit. It can only replace a signed, packaged build, which is why the caller
+ * constructs this at all only for one.
+ */
+export function createElectronUpdaterEngine(): UpdaterEngine {
+  return {
+    wire(events: UpdaterEngineEvents) {
+      autoUpdater.autoDownload = true;
+      autoUpdater.autoInstallOnAppQuit = true;
+      autoUpdater.disableDifferentialDownload = true;
+      autoUpdater.setFeedURL({ provider: "generic", url: UPDATE_ENDPOINT.UPDATE_FEED_URL });
+      autoUpdater.on("checking-for-update", () => events.onChecking());
+      autoUpdater.on("update-available", (info) => events.onAvailable(info.version));
+      autoUpdater.on("update-not-available", () => events.onNotAvailable());
+      let lastProgressAt = 0;
+      autoUpdater.on("download-progress", (progress) => {
+        const now = Date.now();
+        if (now - lastProgressAt < PROGRESS_EMIT_INTERVAL_MS) return;
+        lastProgressAt = now;
+        events.onProgress({
+          percent: progress.percent,
+          transferredBytes: progress.transferred,
+          totalBytes: progress.total,
+        });
+      });
+      autoUpdater.on("update-downloaded", (info) => events.onDownloaded(info.version));
+      autoUpdater.on("error", (error) => events.onError(error.message));
+    },
+    async checkForUpdates() {
+      releaseDownloadPromise(await autoUpdater.checkForUpdates());
+    },
+    quitAndInstall() {
+      autoUpdater.quitAndInstall(false, true);
+    },
+    async clearCachedUpdate() {
+      // electron-updater keeps the cache helper protected, so no typed access
+      // exists: Reflect is the narrowest way to a property the type will not
+      // name, and the annotation keeps every use of the answer checked.
+      // oxlint-disable-next-line anti-slop/no-reflect-get
+      const helper: AppUpdaterInternals["downloadedUpdateHelper"] = Reflect.get(
+        autoUpdater,
+        "downloadedUpdateHelper",
+      );
+      await helper?.clear();
+    },
+  };
+}

--- a/apps/desktop/src/update-service.ts
+++ b/apps/desktop/src/update-service.ts
@@ -1,77 +1,177 @@
-import { isNewerVersion, parseReleaseVersion, text } from "@sidecar/core";
-import { UPDATE_STATUS, type UpdateSnapshot } from "./shared/contracts";
-import { unparsedWire, type WireBoundaryInput, wireRecord } from "./wire-boundary";
+import {
+  UPDATE_STATUS,
+  type UpdateProgress,
+  type UpdateSnapshot,
+  type UpdateStatus,
+} from "./shared/contracts";
 
 /**
  * The two addresses updating ever touches, fixed here rather than passed in,
  * so the renderer names an intent and never an address — and nothing a check
- * read can steer where a press goes. The check is the one request Luke makes
- * with no user-supplied key at all: an unauthenticated read of the latest
- * published release's name, carrying nothing about the user or their
- * sessions.
+ * read can steer where a press goes. The feed is where electron-updater reads
+ * `latest-mac.yml` and the archive it names, both published by this
+ * repository's release pipeline; `releases/latest` is what keeps the address
+ * from ever moving.
  */
 export const UPDATE_ENDPOINT = {
-  LATEST_RELEASE_URL: "https://api.github.com/repos/ReviewStage/luke/releases/latest",
+  // The trailing slash keeps the last segment a directory under every URL
+  // resolver; electron-updater normalizes a slashless base itself, but the
+  // literal should not need that reading.
+  UPDATE_FEED_URL: "https://github.com/ReviewStage/luke/releases/latest/download/",
   LATEST_RELEASE_PAGE_URL: "https://github.com/ReviewStage/luke/releases/latest",
 } as const;
 
-// SAFETY: The preceding check establishes the asserted contract.
-/** GitHub's documented media type and version pin, as the Copilot adapter sends them. */
-const GITHUB_REQUEST_HEADERS = {
-  Accept: "application/vnd.github+json",
-  "X-GitHub-Api-Version": "2026-03-10",
-} as const satisfies Readonly<Record<string, string>>;
-
 const UPDATE_CHECK_DEFAULTS = {
-  REQUEST_TIMEOUT_MS: 10_000,
   /**
-   * Six hours between timed checks: a release lands at most every few days,
-   * and an unauthenticated GitHub read is rate-limited by address, so asking
-   * more often buys nothing but requests.
+   * Four hours between timed checks, matching the interval Superset settled
+   * on for the same feed shape: a release lands at most every few days, and
+   * an unauthenticated GitHub read is rate-limited by address.
    */
-  INTERVAL_MS: 6 * 60 * 60 * 1000,
+  INTERVAL_MS: 4 * 60 * 60 * 1000,
+  /**
+   * The first check after an install waits long enough for the "updated"
+   * confirmation to be seen before `checking` overwrites it.
+   */
+  JUST_UPDATED_FIRST_CHECK_DELAY_MS: 10_000,
 } as const;
 
-type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
+/**
+ * Failures that are the network's, not the release's: transient, expected,
+ * and resolved by the next timed check, so they must not be drawn as errors.
+ */
+const SILENT_NETWORK_ERROR_PATTERNS = [
+  "net::ERR_INTERNET_DISCONNECTED",
+  "net::ERR_NETWORK_CHANGED",
+  "net::ERR_CONNECTION_REFUSED",
+  "net::ERR_NAME_NOT_RESOLVED",
+  "net::ERR_CONNECTION_TIMED_OUT",
+  "net::ERR_CONNECTION_RESET",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+  "ECONNREFUSED",
+  "ECONNRESET",
+] as const;
+
+export function isNetworkErrorMessage(message: string): boolean {
+  return SILENT_NETWORK_ERROR_PATTERNS.some((pattern) => message.includes(pattern));
+}
+
+/** The updater lifecycle, as electron-updater announces it. */
+export interface UpdaterEngineEvents {
+  onChecking: () => void;
+  /** A newer build exists; with auto-download its fetch has already begun. */
+  onAvailable: (version: string) => void;
+  onNotAvailable: () => void;
+  onProgress: (progress: UpdateProgress) => void;
+  onDownloaded: (version: string) => void;
+  onError: (message: string) => void;
+}
+
+/**
+ * The one thing that can replace the running build: a wrapper over
+ * electron-updater, injected so the service's state can be exercised without
+ * it. Absent wherever installing in place is impossible — an unpackaged run,
+ * a run that sends no network — which the service reports as
+ * `installSupported: false` so the row offers the browser instead.
+ */
+export interface UpdaterEngine {
+  wire(events: UpdaterEngineEvents): void;
+  /** Resolves when the check has answered; a found download runs on behind it. */
+  checkForUpdates(): Promise<void>;
+  quitAndInstall(): void;
+  /**
+   * Drops electron-updater's cached download. Its cache only self-invalidates
+   * when the remote sha512 differs, so a corrupt cached download would be
+   * retried forever if an error left it standing.
+   */
+  clearCachedUpdate(): Promise<void>;
+}
+
+/** Where the last-run version is kept between launches, for the `updated` confirmation. */
+export interface LastRunVersionStore {
+  read(): string | undefined;
+  write(version: string): void;
+}
 
 export interface UpdateServiceOptions {
-  // SAFETY: The preceding check establishes the asserted contract.
   /** The running build's version, as the packaged app reports it. */
   currentVersion: string;
   /** Every state the service moves through, for the broadcast to carry. */
   onChange: (update: UpdateSnapshot) => void;
-  fetch?: FetchLike;
-  requestTimeoutMs?: number;
+  engine?: UpdaterEngine;
+  lastRunVersion?: LastRunVersionStore;
   intervalMs?: number;
+  justUpdatedFirstCheckDelayMs?: number;
+  report?: (line: string) => void;
 }
 
 /**
- * Learns whether a newer release than the running build has been published,
- * and nothing else. A failed check is an answer for the row — `unreachable`
- * — never a throw: status codes alone diagnose the path, and the response's
- // SAFETY: The preceding check establishes the asserted contract.
- * only read field is the release's tag name, validated as a version before
- * it is compared or kept. What the service learns changes only what the
- * settings row says; fetching the update stays the user's own press, on a
- * page fixed by the build.
+ * Luke's face on electron-updater, shaped after the updater Superset runs in
+ * production. A check reads the release manifest from the feed fixed by the
+ * build; a newer build downloads at once and installs at the quit the user
+ * asks for — the row's restart press, or whenever they next quit. Failures
+ * are answers for the row, never throws: a network failure is silence (the
+ * next timed check retries), anything else is `error`, drawn as the way back
+ * to the releases page. An install may only be asked for once — repeat
+ * presses racing Squirrel's binary swap is a failure Superset met in
+ * production — and a failed install falls out of `ready`, so the guard
+ * releases with it.
  */
 export class UpdateService {
   readonly #currentVersion: string;
   readonly #onChange: (update: UpdateSnapshot) => void;
-  readonly #fetch: FetchLike;
-  readonly #requestTimeoutMs: number;
+  readonly #engine: UpdaterEngine | undefined;
+  readonly #lastRunVersion: LastRunVersionStore | undefined;
   readonly #intervalMs: number;
+  readonly #justUpdatedFirstCheckDelayMs: number;
+  readonly #report: (line: string) => void;
   #snapshot: UpdateSnapshot;
-  #inFlight: Promise<UpdateSnapshot> | undefined;
+  #latestVersion: string | undefined;
+  #installing = false;
+  #started = false;
   #timer: NodeJS.Timeout | undefined;
+  #firstCheck: NodeJS.Timeout | undefined;
 
   constructor(options: UpdateServiceOptions) {
     this.#currentVersion = options.currentVersion;
     this.#onChange = options.onChange;
-    this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
-    this.#requestTimeoutMs = options.requestTimeoutMs ?? UPDATE_CHECK_DEFAULTS.REQUEST_TIMEOUT_MS;
+    this.#engine = options.engine;
+    this.#lastRunVersion = options.lastRunVersion;
     this.#intervalMs = options.intervalMs ?? UPDATE_CHECK_DEFAULTS.INTERVAL_MS;
-    this.#snapshot = { status: UPDATE_STATUS.UNKNOWN, currentVersion: this.#currentVersion };
+    this.#justUpdatedFirstCheckDelayMs =
+      options.justUpdatedFirstCheckDelayMs ??
+      UPDATE_CHECK_DEFAULTS.JUST_UPDATED_FIRST_CHECK_DELAY_MS;
+    this.#report = options.report ?? ((line) => process.stderr.write(`${line}\n`));
+    this.#snapshot = this.#idle(false);
+    this.#engine?.wire({
+      onChecking: () => this.#move({ ...this.#base(UPDATE_STATUS.CHECKING) }),
+      onAvailable: (version) => {
+        this.#latestVersion = version;
+        this.#move({ ...this.#base(UPDATE_STATUS.DOWNLOADING), latestVersion: version });
+      },
+      onNotAvailable: () => this.#move(this.#idle(true)),
+      onProgress: (progress) => {
+        if (this.#snapshot.status !== UPDATE_STATUS.DOWNLOADING) return;
+        this.#move({ ...this.#snapshot, progress });
+      },
+      onDownloaded: (version) => {
+        this.#latestVersion = version;
+        this.#move({ ...this.#base(UPDATE_STATUS.READY), latestVersion: version });
+      },
+      onError: (message) => {
+        // Squirrel surfacing an error instead of quitting must release the
+        // install guard, or the row's restart press dies with the attempt.
+        this.#installing = false;
+        if (isNetworkErrorMessage(message)) {
+          this.#report(`Update check could not reach the feed: ${message}`);
+          this.#move(this.#idle(false));
+          return;
+        }
+        this.#report(`Update failed: ${message}`);
+        void this.#engine?.clearCachedUpdate().catch(() => undefined);
+        this.#move({ ...this.#base(UPDATE_STATUS.ERROR), latestVersion: this.#latestVersion });
+      },
+    });
   }
 
   snapshot(): UpdateSnapshot {
@@ -79,87 +179,95 @@ export class UpdateService {
   }
 
   /**
-   * Asks for the latest release name once. A check already in flight answers
-   * the new asker too, rather than doubling the request — the timer and the
-   * row's button land on the same read.
+   * Asks the manifest for the latest build once, resolving with the state the
+   * answer moved to — `downloading` when a newer build was found, because the
+   * fetch begins inside the check. Without an engine there is nothing to ask
+   * and the standing snapshot is the whole answer.
    */
-  check(): Promise<UpdateSnapshot> {
-    this.#inFlight ??= this.#read()
-      .catch((error): UpdateSnapshot => {
-        // A throw anywhere in the read must not leave a dead check parked in
-        // flight, where every later ask would reuse the failure and the row
-        // would say "checking" forever. It lands on the same honest answer an
-        // unreachable service gives, and the next ask is a fresh read.
-        this.#report(
-          `Update check failed: ${error instanceof Error ? error.name : "unknown error"}`,
-        );
-        return { status: UPDATE_STATUS.UNREACHABLE, currentVersion: this.#currentVersion };
-      })
-      .then((snapshot) => {
-        this.#inFlight = undefined;
-        this.#move(snapshot);
-        return snapshot;
-      });
-    return this.#inFlight;
+  async check(): Promise<UpdateSnapshot> {
+    const engine = this.#engine;
+    if (!engine || this.#installing) return this.#snapshot;
+    // A download in flight or in hand holds the row — here Luke is stricter
+    // than the updater Superset runs: a timed tick that re-checked mid-flight
+    // would stomp the progress or the restart offer with `checking`, and a
+    // feed failure after a completed download would trade a build in hand
+    // for an error row and a cleared cache.
+    if (
+      this.#snapshot.status === UPDATE_STATUS.DOWNLOADING ||
+      this.#snapshot.status === UPDATE_STATUS.READY
+    ) {
+      return this.#snapshot;
+    }
+    this.#move({ ...this.#base(UPDATE_STATUS.CHECKING) });
+    try {
+      await engine.checkForUpdates();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (isNetworkErrorMessage(message)) {
+        this.#report(`Update check could not reach the feed: ${message}`);
+        this.#move(this.#idle(false));
+      } else {
+        this.#report(`Update check failed: ${message}`);
+        this.#move({ ...this.#base(UPDATE_STATUS.ERROR), latestVersion: this.#latestVersion });
+      }
+    }
+    return this.#snapshot;
   }
 
   /**
-   * Starts the timed check. It checks at once — a build that only ever
-   * checked hours after launch would spend its first day behind — and the
-   * timer never holds the process open.
+   * Restarts into the downloaded build. Only `ready` has one, and only one
+   * ask ever reaches the engine: repeat presses while Squirrel stages the
+   * swap fan out into parallel installs racing to replace the binary, which
+   * can leave the app on the old version.
+   */
+  install(): void {
+    if (!this.#engine || this.#installing) return;
+    if (this.#snapshot.status !== UPDATE_STATUS.READY) return;
+    this.#installing = true;
+    this.#engine.quitAndInstall();
+  }
+
+  /**
+   * Starts the timed check. The first check runs at once — except on the
+   * first launch after an install, where it waits long enough for the
+   * `updated` confirmation to be seen before `checking` overwrites it.
    */
   start(): void {
-    if (this.#timer) return;
-    void this.check();
+    if (this.#started || !this.#engine) return;
+    this.#started = true;
+    const previous = this.#lastRunVersion?.read();
+    const justUpdated = previous !== undefined && previous !== this.#currentVersion;
+    if (previous !== this.#currentVersion) this.#lastRunVersion?.write(this.#currentVersion);
+    if (justUpdated) {
+      this.#report(`Updated: ${previous} -> ${this.#currentVersion}`);
+      this.#move({ ...this.#base(UPDATE_STATUS.UPDATED), previousVersion: previous });
+    }
     this.#timer = setInterval(() => void this.check(), this.#intervalMs);
     this.#timer.unref();
+    this.#firstCheck = setTimeout(
+      () => void this.check(),
+      justUpdated ? this.#justUpdatedFirstCheckDelayMs : 0,
+    );
+    this.#firstCheck.unref();
   }
 
   stop(): void {
     if (this.#timer) clearInterval(this.#timer);
+    if (this.#firstCheck) clearTimeout(this.#firstCheck);
     this.#timer = undefined;
+    this.#firstCheck = undefined;
   }
 
-  async #read(): Promise<UpdateSnapshot> {
-    this.#move({ status: UPDATE_STATUS.CHECKING, currentVersion: this.#currentVersion });
-    let response: Response;
-    try {
-      response = await this.#fetch(UPDATE_ENDPOINT.LATEST_RELEASE_URL, {
-        headers: GITHUB_REQUEST_HEADERS,
-        signal: AbortSignal.timeout(this.#requestTimeoutMs),
-      });
-    } catch (error) {
-      this.#report(
-        `Update check did not complete: ${error instanceof Error ? error.name : "unknown error"}`,
-      );
-      return { status: UPDATE_STATUS.UNREACHABLE, currentVersion: this.#currentVersion };
-    }
-    if (!response.ok) {
-      this.#report(`Update check failed with status ${response.status}`);
-      return { status: UPDATE_STATUS.UNREACHABLE, currentVersion: this.#currentVersion };
-    }
-    let payload: WireBoundaryInput | undefined;
-    try {
-      payload = await response.json();
-    } catch {
-      this.#report("Update check answered with an unreadable body");
-      return { status: UPDATE_STATUS.UNREACHABLE, currentVersion: this.#currentVersion };
-    }
-    const release = wireRecord(unparsedWire(payload));
-    const tag = release ? text(release.tag_name) : undefined;
-    const latest = tag && parseReleaseVersion(tag) ? tag.trim().replace(/^v/, "") : undefined;
-    if (!latest) {
-      // A release this build cannot name is not an update it can offer.
-      this.#report("Update check answered without a readable release version");
-      return { status: UPDATE_STATUS.UNREACHABLE, currentVersion: this.#currentVersion };
-    }
-    return isNewerVersion(latest, this.#currentVersion)
-      ? {
-          status: UPDATE_STATUS.UPDATE_AVAILABLE,
-          currentVersion: this.#currentVersion,
-          latestVersion: latest,
-        }
-      : { status: UPDATE_STATUS.UP_TO_DATE, currentVersion: this.#currentVersion };
+  #base<Status extends UpdateStatus>(status: Status) {
+    return {
+      status,
+      currentVersion: this.#currentVersion,
+      installSupported: this.#engine !== undefined,
+    };
+  }
+
+  #idle(upToDate: boolean): UpdateSnapshot {
+    return { ...this.#base(UPDATE_STATUS.IDLE), upToDate };
   }
 
   #move(snapshot: UpdateSnapshot): void {
@@ -168,11 +276,7 @@ export class UpdateService {
       this.#onChange(snapshot);
     } catch {
       // A listener's failure is its own — a window torn down mid-broadcast
-      // must not fail the check whose snapshot has already moved.
+      // must not fail the transition that has already moved.
     }
-  }
-
-  #report(message: string): void {
-    process.stderr.write(`${message}\n`);
   }
 }

--- a/apps/desktop/tests/update-row.test.ts
+++ b/apps/desktop/tests/update-row.test.ts
@@ -1,59 +1,109 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { UPDATE_ROW_ACTION, updateAvailable, updateRow } from "../src/renderer/update-row";
-import { UPDATE_STATUS } from "../src/shared/contracts";
+import { UPDATE_STATUS, type UpdateSnapshot } from "../src/shared/contracts";
+
+function supported(update: Partial<UpdateSnapshot> & Pick<UpdateSnapshot, "status">) {
+  // SAFETY: every call site passes the fields its status's snapshot variant
+  // requires; the assertion only spares each test restating the two constants.
+  return { currentVersion: "0.1.0", installSupported: true, ...update } as UpdateSnapshot;
+}
 
 test("an unasked question is an offer to ask, never an answer", () => {
-  const row = updateRow({ status: UPDATE_STATUS.UNKNOWN, currentVersion: "0.1.0" });
+  const row = updateRow(supported({ status: UPDATE_STATUS.IDLE, upToDate: false }));
   assert.equal(row.action, UPDATE_ROW_ACTION.CHECK);
-  assert.equal(row.current, false);
-});
-
-test("a check under way offers nothing to press", () => {
-  const row = updateRow({ status: UPDATE_STATUS.CHECKING, currentVersion: "0.1.0" });
-  assert.equal(row.action, UPDATE_ROW_ACTION.CHECKING);
   assert.equal(row.current, false);
 });
 
 test("only a positively latest build earns the check mark", () => {
-  const row = updateRow({ status: UPDATE_STATUS.UP_TO_DATE, currentVersion: "0.1.0" });
+  const row = updateRow(supported({ status: UPDATE_STATUS.IDLE, upToDate: true }));
   assert.equal(row.action, UPDATE_ROW_ACTION.CHECK);
   assert.equal(row.current, true);
 });
 
-test("a newer release is named, and the button becomes the way to it", () => {
+test("a check under way offers nothing to press", () => {
+  const row = updateRow(supported({ status: UPDATE_STATUS.CHECKING }));
+  assert.equal(row.action, UPDATE_ROW_ACTION.CHECKING);
+  assert.equal(row.current, false);
+});
+
+test("a download under way names the version and how far along it is", () => {
+  const row = updateRow(
+    supported({
+      status: UPDATE_STATUS.DOWNLOADING,
+      latestVersion: "0.2.0",
+      progress: { percent: 41.7, transferredBytes: 41, totalBytes: 100 },
+    }),
+  );
+  assert.equal(row.action, UPDATE_ROW_ACTION.DOWNLOADING);
+  assert.ok(row.detail.includes("0.2.0"), "the version being fetched is said on the row");
+  assert.ok(row.detail.includes("42%"), "progress is said in whole percent");
+  assert.equal(row.current, false);
+
+  const silent = updateRow(
+    supported({ status: UPDATE_STATUS.DOWNLOADING, latestVersion: "0.2.0" }),
+  );
+  assert.ok(!silent.detail.includes("%"), "no invented progress before the first report");
+});
+
+test("a downloaded build offers the restart that installs it", () => {
+  const row = updateRow(supported({ status: UPDATE_STATUS.READY, latestVersion: "0.2.0" }));
+  assert.equal(row.action, UPDATE_ROW_ACTION.RESTART);
+  assert.ok(row.detail.includes("Restart"), "the row says a restart finishes the update");
+  assert.ok(row.detail.includes("quit"), "the row says quitting installs it too");
+  assert.equal(row.current, false);
+});
+
+test("the first launch after an install confirms what happened", () => {
+  const row = updateRow(supported({ status: UPDATE_STATUS.UPDATED, previousVersion: "0.1.0" }));
+  assert.equal(row.action, UPDATE_ROW_ACTION.CHECK);
+  assert.ok(row.detail.includes("0.1.0"), "the version left behind is named");
+  assert.equal(row.current, true);
+});
+
+test("a failed update says so and falls back to the releases page", () => {
+  const failed = updateRow(supported({ status: UPDATE_STATUS.ERROR, latestVersion: "0.2.0" }));
+  assert.equal(failed.action, UPDATE_ROW_ACTION.GET);
+  assert.ok(failed.detail.includes("could not be installed"), "the failure is said plainly");
+  assert.ok(failed.detail.includes("0.2.0"), "the version to fetch by hand is still named");
+
+  const unversioned = updateRow(supported({ status: UPDATE_STATUS.ERROR }));
+  assert.equal(unversioned.action, UPDATE_ROW_ACTION.GET);
+  assert.equal(unversioned.current, false);
+});
+
+test("a build that cannot install itself offers the browser in every state", () => {
   const row = updateRow({
-    status: UPDATE_STATUS.UPDATE_AVAILABLE,
+    status: UPDATE_STATUS.IDLE,
     currentVersion: "0.1.0",
-    latestVersion: "0.2.0",
+    installSupported: false,
+    upToDate: false,
   });
   assert.equal(row.action, UPDATE_ROW_ACTION.GET);
-  assert.ok(row.detail.includes("0.2.0"), "the newer version is said on the row");
   assert.equal(row.current, false);
 });
 
-test("an unreachable check says so and offers to try again", () => {
-  const row = updateRow({ status: UPDATE_STATUS.UNREACHABLE, currentVersion: "0.1.0" });
-  assert.equal(row.action, UPDATE_ROW_ACTION.CHECK);
-  assert.equal(row.current, false);
-});
-
-// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
 test("only a positively known newer release counts as news", () => {
+  // The news stands through the whole install: a release downloading,
+  // waiting on its restart, or failed mid-fetch is still one this build is
+  // not on — while a failure that never named a version has no news to mark.
   assert.equal(
-    updateAvailable({
-      status: UPDATE_STATUS.UPDATE_AVAILABLE,
-      currentVersion: "0.1.0",
-      latestVersion: "0.2.0",
-    }),
+    updateAvailable(supported({ status: UPDATE_STATUS.DOWNLOADING, latestVersion: "0.2.0" })),
     true,
   );
-  for (const status of [
-    UPDATE_STATUS.UNKNOWN,
-    UPDATE_STATUS.CHECKING,
-    UPDATE_STATUS.UP_TO_DATE,
-    UPDATE_STATUS.UNREACHABLE,
-  ] as const) {
-    assert.equal(updateAvailable({ status, currentVersion: "0.1.0" }), false);
-  }
+  assert.equal(
+    updateAvailable(supported({ status: UPDATE_STATUS.READY, latestVersion: "0.2.0" })),
+    true,
+  );
+  assert.equal(
+    updateAvailable(supported({ status: UPDATE_STATUS.ERROR, latestVersion: "0.2.0" })),
+    true,
+  );
+  assert.equal(updateAvailable(supported({ status: UPDATE_STATUS.ERROR })), false);
+  assert.equal(updateAvailable(supported({ status: UPDATE_STATUS.IDLE, upToDate: true })), false);
+  assert.equal(updateAvailable(supported({ status: UPDATE_STATUS.CHECKING })), false);
+  assert.equal(
+    updateAvailable(supported({ status: UPDATE_STATUS.UPDATED, previousVersion: "0.1.0" })),
+    false,
+  );
 });

--- a/apps/desktop/tests/update-service.test.ts
+++ b/apps/desktop/tests/update-service.test.ts
@@ -1,184 +1,264 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { UPDATE_STATUS, type UpdateSnapshot } from "../src/shared/contracts";
-import { UPDATE_ENDPOINT, UpdateService } from "../src/update-service";
-import type { JsonValue } from "./support/json";
-
-function releaseResponse(body: JsonValue): Response {
-  return new Response(JSON.stringify(body), {
-    status: 200,
-    headers: { "content-type": "application/json" },
-  });
-}
+import {
+  type UpdaterEngineEvents,
+  UpdateService,
+  type UpdateServiceOptions,
+} from "../src/update-service";
 
 function sleep(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
-test("a newer published release is offered by its version, without the tag's v", async () => {
-  const requests: { url: string; headers: Record<string, string> }[] = [];
-  const states: UpdateSnapshot[] = [];
-  const service = new UpdateService({
+/** An engine whose lifecycle fires only when the test says so. */
+function fakeEngine() {
+  const calls = { checks: 0, installs: 0, cacheClears: 0 };
+  let events: UpdaterEngineEvents | undefined;
+  let rejectNextCheck: string | undefined;
+  return {
+    calls,
+    fire: (): UpdaterEngineEvents => {
+      assert.ok(events, "the service wires the engine at construction");
+      return events;
+    },
+    rejectNextCheckWith: (message: string) => {
+      rejectNextCheck = message;
+    },
+    engine: {
+      wire: (next: UpdaterEngineEvents) => {
+        events = next;
+      },
+      checkForUpdates: async () => {
+        calls.checks += 1;
+        if (rejectNextCheck) {
+          const message = rejectNextCheck;
+          rejectNextCheck = undefined;
+          throw new Error(message);
+        }
+      },
+      quitAndInstall: () => {
+        calls.installs += 1;
+      },
+      clearCachedUpdate: async () => {
+        calls.cacheClears += 1;
+      },
+    },
+  };
+}
+
+function service(options: Partial<UpdateServiceOptions> & { states?: UpdateSnapshot[] }) {
+  const states = options.states ?? [];
+  return new UpdateService({
     currentVersion: "0.1.0",
     onChange: (update) => states.push(update),
-    fetch: async (url, init) => {
-      // SAFETY: Fixture headers map matches the string header shape the fake records.
-      requests.push({ url, headers: (init.headers ?? {}) as Record<string, string> });
-      return releaseResponse({ tag_name: "v0.2.0" });
-    },
+    report: () => undefined,
+    ...options,
   });
+}
 
-  const answered = await service.check();
+test("a found update downloads at once and installs only at the one restart press", async () => {
+  const { calls, fire, engine } = fakeEngine();
+  const states: UpdateSnapshot[] = [];
+  const updates = service({ engine, states });
 
-  assert.deepEqual(answered, {
-    status: UPDATE_STATUS.UPDATE_AVAILABLE,
+  // Installing before anything is downloaded is ignored, not a crash.
+  updates.install();
+  assert.equal(calls.installs, 0);
+
+  const checked = updates.check();
+  fire().onChecking();
+  fire().onAvailable("0.2.0");
+  assert.deepEqual(await checked, {
+    status: UPDATE_STATUS.DOWNLOADING,
     currentVersion: "0.1.0",
+    installSupported: true,
     latestVersion: "0.2.0",
   });
-  assert.deepEqual(service.snapshot(), answered);
-  // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-  // The row is told about the check under way as well as its answer.
+
+  fire().onProgress({ percent: 40, transferredBytes: 40, totalBytes: 100 });
+  assert.deepEqual(updates.snapshot().status === UPDATE_STATUS.DOWNLOADING && updates.snapshot(), {
+    status: UPDATE_STATUS.DOWNLOADING,
+    currentVersion: "0.1.0",
+    installSupported: true,
+    latestVersion: "0.2.0",
+    progress: { percent: 40, transferredBytes: 40, totalBytes: 100 },
+  });
+
+  fire().onDownloaded("0.2.0");
+  assert.equal(updates.snapshot().status, UPDATE_STATUS.READY);
+
+  // Only the first press reaches the engine: repeat presses while Squirrel
+  // stages the swap race to replace the binary and can lose the update.
+  updates.install();
+  updates.install();
+  assert.equal(calls.installs, 1);
   assert.deepEqual(
     states.map((state) => state.status),
-    [UPDATE_STATUS.CHECKING, UPDATE_STATUS.UPDATE_AVAILABLE],
+    [
+      UPDATE_STATUS.CHECKING,
+      UPDATE_STATUS.CHECKING,
+      UPDATE_STATUS.DOWNLOADING,
+      UPDATE_STATUS.DOWNLOADING,
+      UPDATE_STATUS.READY,
+    ],
   );
-  // One read, of the fixed address, spoken in GitHub's documented media type.
-  assert.equal(requests.length, 1);
-  assert.equal(requests[0]?.url, UPDATE_ENDPOINT.LATEST_RELEASE_URL);
-  assert.equal(requests[0]?.headers.Accept, "application/vnd.github+json");
 });
 
-// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-test("the running release reads as up to date", async () => {
-  const service = new UpdateService({
+test("nothing newer is idle with the up-to-date mark, never an error", async () => {
+  const { fire, engine } = fakeEngine();
+  const updates = service({ engine });
+
+  const checked = updates.check();
+  fire().onNotAvailable();
+  assert.deepEqual(await checked, {
+    status: UPDATE_STATUS.IDLE,
+    currentVersion: "0.1.0",
+    installSupported: true,
+    upToDate: true,
+  });
+});
+
+test("a network failure is silence for the next timed check; anything else is the error row", async () => {
+  const { calls, fire, engine, rejectNextCheckWith } = fakeEngine();
+  const updates = service({ engine });
+
+  // The engine's error event mid-download, transient: back to idle, unmarked.
+  fire().onAvailable("0.2.0");
+  fire().onError("net::ERR_INTERNET_DISCONNECTED");
+  assert.deepEqual(updates.snapshot(), {
+    status: UPDATE_STATUS.IDLE,
+    currentVersion: "0.1.0",
+    installSupported: true,
+    upToDate: false,
+  });
+  assert.equal(calls.cacheClears, 0);
+
+  // A real failure lands on the error row, still naming the newer build, and
+  // drops the cached download a corrupt archive would otherwise pin forever.
+  fire().onAvailable("0.2.0");
+  fire().onError("sha512 checksum mismatch");
+  assert.deepEqual(updates.snapshot(), {
+    status: UPDATE_STATUS.ERROR,
+    currentVersion: "0.1.0",
+    installSupported: true,
+    latestVersion: "0.2.0",
+  });
+  assert.equal(calls.cacheClears, 1);
+
+  // A check whose own promise rejects answers the same two ways.
+  rejectNextCheckWith("ENOTFOUND api.github.com");
+  assert.equal((await updates.check()).status, UPDATE_STATUS.IDLE);
+  rejectNextCheckWith("cannot parse update info");
+  assert.equal((await updates.check()).status, UPDATE_STATUS.ERROR);
+});
+
+test("an error mid-install releases the guard so the next ready build can install", async () => {
+  const { calls, fire, engine } = fakeEngine();
+  const updates = service({ engine });
+
+  fire().onDownloaded("0.2.0");
+  updates.install();
+  assert.equal(calls.installs, 1);
+
+  // Squirrel surfaced an error instead of quitting: the guard must release,
+  // or the row's restart press is dead for the rest of the run.
+  fire().onError("could not stage the update");
+  fire().onDownloaded("0.2.0");
+  updates.install();
+  assert.equal(calls.installs, 2);
+});
+
+test("no check moves the row while a download in flight or in hand holds it", async () => {
+  const { calls, fire, engine } = fakeEngine();
+  const updates = service({ engine });
+
+  fire().onAvailable("0.2.0");
+  const midDownload = calls.checks;
+  assert.equal((await updates.check()).status, UPDATE_STATUS.DOWNLOADING);
+  assert.equal(calls.checks, midDownload, "a timed tick mid-download never reaches the feed");
+
+  fire().onDownloaded("0.2.0");
+  assert.equal((await updates.check()).status, UPDATE_STATUS.READY);
+  assert.equal(calls.checks, midDownload, "a build in hand is never traded for a re-check");
+});
+
+test("without an engine nothing checks, downloads, or installs", async () => {
+  const { calls } = fakeEngine();
+  const updates = service({});
+
+  assert.deepEqual(await updates.check(), {
+    status: UPDATE_STATUS.IDLE,
+    currentVersion: "0.1.0",
+    installSupported: false,
+    upToDate: false,
+  });
+  updates.install();
+  updates.start();
+  await sleep(10);
+  assert.equal(calls.checks, 0);
+  assert.equal(calls.installs, 0);
+});
+
+test("the timed check starts at once and stops when asked", async () => {
+  const { calls, engine } = fakeEngine();
+  const updates = service({ engine, intervalMs: 10 });
+
+  updates.start();
+  await sleep(45);
+  assert.ok(calls.checks >= 2, `expected the timer to have checked again, saw ${calls.checks}`);
+
+  updates.stop();
+  const settled = calls.checks;
+  await sleep(30);
+  assert.equal(calls.checks, settled);
+});
+
+test("the first launch after an install says what happened before checking again", async () => {
+  const { calls, engine } = fakeEngine();
+  let stored: string | undefined = "0.1.0";
+  const states: UpdateSnapshot[] = [];
+  const updates = new UpdateService({
     currentVersion: "0.2.0",
-    onChange: () => undefined,
-    fetch: async () => releaseResponse({ tag_name: "v0.2.0" }),
+    onChange: (update) => states.push(update),
+    report: () => undefined,
+    engine,
+    lastRunVersion: {
+      read: () => stored,
+      write: (version) => {
+        stored = version;
+      },
+    },
+    justUpdatedFirstCheckDelayMs: 30,
+    intervalMs: 60_000,
   });
 
-  assert.deepEqual(await service.check(), {
-    status: UPDATE_STATUS.UP_TO_DATE,
+  updates.start();
+  assert.deepEqual(updates.snapshot(), {
+    status: UPDATE_STATUS.UPDATED,
     currentVersion: "0.2.0",
+    installSupported: true,
+    previousVersion: "0.1.0",
   });
+  assert.equal(stored, "0.2.0");
+  // The confirmation holds until the delayed first check overwrites it.
+  assert.equal(calls.checks, 0);
+  await sleep(60);
+  assert.ok(calls.checks >= 1);
+  updates.stop();
 });
 
-// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-test("a refusal, an unreachable service, and an unreadable answer all read as unreachable", async () => {
-  const refused = new UpdateService({
-    currentVersion: "0.1.0",
-    onChange: () => undefined,
-    fetch: async () => new Response("", { status: 503 }),
-  });
-  assert.equal((await refused.check()).status, UPDATE_STATUS.UNREACHABLE);
-
-  const unreachable = new UpdateService({
-    currentVersion: "0.1.0",
-    onChange: () => undefined,
-    fetch: async () => {
-      throw new Error("offline");
-    },
-  });
-  assert.equal((await unreachable.check()).status, UPDATE_STATUS.UNREACHABLE);
-
-  const unreadable = new UpdateService({
-    currentVersion: "0.1.0",
-    onChange: () => undefined,
-    fetch: async () => new Response("not json", { status: 200 }),
-  });
-  assert.equal((await unreadable.check()).status, UPDATE_STATUS.UNREACHABLE);
-});
-
-// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-test("a release this build cannot name is not offered as an update", async () => {
-  // A prerelease suffix and a missing tag both leave nothing to compare, and
-  // an unnamed update would send someone to fetch an unknown.
-  const prerelease = new UpdateService({
-    currentVersion: "0.1.0",
-    onChange: () => undefined,
-    fetch: async () => releaseResponse({ tag_name: "v0.2.0-beta.1" }),
-  });
-  assert.equal((await prerelease.check()).status, UPDATE_STATUS.UNREACHABLE);
-
-  const unnamed = new UpdateService({
-    currentVersion: "0.1.0",
-    onChange: () => undefined,
-    fetch: async () => releaseResponse({}),
-  });
-  assert.equal((await unnamed.check()).status, UPDATE_STATUS.UNREACHABLE);
-});
-
-test("the timer and the button share a check already in flight", async () => {
-  let requests = 0;
-  let release: ((response: Response) => void) | undefined;
-  const service = new UpdateService({
-    currentVersion: "0.1.0",
-    onChange: () => undefined,
-    fetch: () => {
-      requests += 1;
-      return new Promise((resolve) => {
-        release = resolve;
-      });
-    },
-  });
-
-  const first = service.check();
-  const second = service.check();
-  release?.(releaseResponse({ tag_name: "v0.1.1" }));
-
-  assert.equal((await first).status, UPDATE_STATUS.UPDATE_AVAILABLE);
-  assert.equal((await second).status, UPDATE_STATUS.UPDATE_AVAILABLE);
-  assert.equal(requests, 1);
-
-  // A finished check is let go of, so the next ask is a fresh read.
-  const third = service.check();
-  assert.equal(requests, 2);
-  release?.(releaseResponse({ tag_name: "v0.1.1" }));
-  await third;
-});
-
-test("a listener that throws neither fails the check nor jams the next one", async () => {
-  // The broadcast can outlive the window it reaches. A throw there must not
-  // park a dead check in flight — the row would say "checking" forever and
-  // every later ask would reuse the failure.
-  let requests = 0;
-  const service = new UpdateService({
+test("a listener that throws does not fail the transition", () => {
+  const { fire, engine } = fakeEngine();
+  const updates = new UpdateService({
     currentVersion: "0.1.0",
     onChange: () => {
       throw new Error("window already torn down");
     },
-    fetch: async () => {
-      requests += 1;
-      return releaseResponse({ tag_name: "v0.2.0" });
-    },
+    report: () => undefined,
+    engine,
   });
 
-  const first = await service.check();
-  assert.equal(first.status, UPDATE_STATUS.UPDATE_AVAILABLE);
-  assert.equal(service.snapshot().status, UPDATE_STATUS.UPDATE_AVAILABLE);
-
-  const second = await service.check();
-  assert.equal(second.status, UPDATE_STATUS.UPDATE_AVAILABLE);
-  assert.equal(requests, 2);
-});
-
-test("the timed check starts at once and stops when asked", async () => {
-  let requests = 0;
-  const service = new UpdateService({
-    currentVersion: "0.1.0",
-    onChange: () => undefined,
-    intervalMs: 10,
-    fetch: async () => {
-      requests += 1;
-      return releaseResponse({ tag_name: "v0.1.0" });
-    },
-  });
-
-  service.start();
-  await sleep(35);
-  assert.ok(requests >= 2, `expected the timer to have checked again, saw ${requests}`);
-
-  service.stop();
-  const settled = requests;
-  await sleep(30);
-  assert.equal(requests, settled);
+  fire().onAvailable("0.2.0");
+  assert.equal(updates.snapshot().status, UPDATE_STATUS.DOWNLOADING);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,10 @@ importers:
         version: 1.79.0
 
   apps/desktop:
+    dependencies:
+      electron-updater:
+        specifier: 6.8.9
+        version: 6.8.9
     devDependencies:
       '@electron/packager':
         specifier: 20.2.1
@@ -1795,6 +1799,9 @@ packages:
     engines: {node: '>=14.6'}
     deprecated: this version has critical issues, please update to the latest version
 
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1891,6 +1898,10 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  builder-util-runtime@9.7.0:
+    resolution: {integrity: sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==}
+    engines: {node: '>=12.0.0'}
 
   caniuse-lite@1.0.30001809:
     resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
@@ -2036,6 +2047,9 @@ packages:
   electron-to-chromium@1.5.404:
     resolution: {integrity: sha512-3WJtd7/lVq2Jnuz6wed1l9+1ZD2u2Tet1/1NBc4Iedkmgbu+I7YuAqdAQ8T+VZtnwysMsAf3IqSq9D1gyZjA2g==}
 
+  electron-updater@6.8.9:
+    resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==}
+
   electron@43.3.0:
     resolution: {integrity: sha512-nLlvu0WFjftWsSaTkV2B/c4NDuJBspTyXu8vKSQ6vLvFt8uG3NgN49LLKcXddwX0GqVvAQDhciWp+4xOdTdhew==}
     engines: {node: '>= 22.12.0'}
@@ -2100,6 +2114,10 @@ packages:
     resolution: {integrity: sha512-Jk78K/Tzt6saxQPGChlJw69xuFGpWyTSAS8EdU0h/FyXwD2K46yNOXmo6nRHcZ9ooekyBAzMkwmiGNt7wOC5zg==}
     engines: {node: '>=22.12.0'}
 
+  fs-extra@10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2145,6 +2163,10 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+    hasBin: true
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -2155,6 +2177,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
   junk@4.0.1:
     resolution: {integrity: sha512-Qush0uP+G8ZScpGMZvHUiRfI0YBWuB3gVBYlI0v0vvOJt5FLicco+IkP0a50LqTTQhmts/m6tP5SWE+USyIvcQ==}
     engines: {node: '>=12.20'}
@@ -2162,6 +2187,9 @@ packages:
   kysely@0.29.5:
     resolution: {integrity: sha512-ooa+eSbBNPTo3MycPEuW5jdrxQdQwdtB3LC3h43FiXQbIry5tR0C5lDG7eealK0E4D7XjrnOP5DIUg/LyjRMYQ==}
     engines: {node: '>=22.0.0'}
+
+  lazy-val@1.0.5:
+    resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -2237,6 +2265,13 @@ packages:
     resolution: {integrity: sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw==}
     engines: {node: '>=22.22.1'}
     hasBin: true
+
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
@@ -2458,11 +2493,20 @@ packages:
   rou3@0.9.2:
     resolution: {integrity: sha512-3SOzvaAg8rkHrXtRjpCvCvbyO5to9oOO27Z/XqHEYXfMRVSw/qMIVdmaOk9W2lcRLtR6dlqTjo9hDeJk70QBYQ==}
 
+  sax@1.6.1:
+    resolution: {integrity: sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==}
+    engines: {node: '>=11.0.0'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
     hasBin: true
 
   semver@7.8.5:
@@ -2537,6 +2581,9 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
+
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
@@ -2579,6 +2626,10 @@ packages:
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
 
   unorm@1.6.0:
     resolution: {integrity: sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==}
@@ -3791,6 +3842,8 @@ snapshots:
 
   '@xmldom/xmldom@0.9.10': {}
 
+  argparse@2.0.1: {}
+
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -3855,6 +3908,13 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  builder-util-runtime@9.7.0:
+    dependencies:
+      debug: 4.4.3
+      sax: 1.6.1
+    transitivePeerDependencies:
+      - supports-color
+
   caniuse-lite@1.0.30001809: {}
 
   client-only@0.0.1:
@@ -3907,6 +3967,19 @@ snapshots:
     optional: true
 
   electron-to-chromium@1.5.404: {}
+
+  electron-updater@6.8.9:
+    dependencies:
+      builder-util-runtime: 9.7.0
+      fs-extra: 10.1.0
+      js-yaml: 4.3.1
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   electron@43.3.0:
     dependencies:
@@ -4057,6 +4130,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fs-extra@10.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
   fsevents@2.3.3:
     optional: true
 
@@ -4093,13 +4172,25 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-yaml@4.3.1:
+    dependencies:
+      argparse: 2.0.1
+
   jsesc@3.1.0: {}
 
   json5@2.2.3: {}
 
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
   junk@4.0.1: {}
 
   kysely@0.29.5: {}
+
+  lazy-val@1.0.5: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -4157,6 +4248,10 @@ snapshots:
       tinyexec: 1.3.0
     optionalDependencies:
       yaml: 2.9.0
+
+  lodash.escaperegexp@4.1.2: {}
+
+  lodash.isequal@4.5.0: {}
 
   lru-cache@11.5.2: {}
 
@@ -4398,9 +4493,13 @@ snapshots:
 
   rou3@0.9.2: {}
 
+  sax@1.6.1: {}
+
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
+
+  semver@7.7.4: {}
 
   semver@7.8.5: {}
 
@@ -4480,6 +4579,8 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tiny-typed-emitter@2.1.0: {}
+
   tinyexec@1.3.0: {}
 
   tinyglobby@0.2.17:
@@ -4534,6 +4635,8 @@ snapshots:
 
   undici@7.29.0:
     optional: true
+
+  universalify@2.0.1: {}
 
   unorm@1.6.0:
     optional: true

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -25,9 +25,11 @@ import {
   notarySubmitArguments,
   parseHdiutilAttachPlist,
   RELEASE_LATEST_DMG_FILE_NAME,
+  RELEASE_UPDATE_FEED_FILE_NAME,
   releaseArtifactDirectory,
   releaseDmgFileName,
   releaseSignatureMatchesIdentity,
+  releaseUpdateManifest,
   releaseZipFileName,
   resolveNotaryCredentials,
   resolveReleaseSigning,
@@ -298,6 +300,35 @@ test("release zip names include the desktop version and packaged architecture", 
 test("the latest-DMG asset name carries no version, so its download URL never moves", () => {
   assert.equal(RELEASE_LATEST_DMG_FILE_NAME, "Luke.dmg");
   assert.ok(!RELEASE_LATEST_DMG_FILE_NAME.includes(PACKAGED_ARCHITECTURE));
+});
+
+test("the update manifest names the archive beside it, hashed whole", () => {
+  // The manifest name carries no version — the app reads it through
+  // releases/latest — and the archive URL inside is the bare file name, so
+  // electron-updater resolves it against the same release the manifest came
+  // from: yesterday's manifest can never hand it today's archive.
+  assert.equal(RELEASE_UPDATE_FEED_FILE_NAME, "latest-mac.yml");
+  const manifest = releaseUpdateManifest({
+    version: "0.3.0",
+    sha512: "c2hhLWZpdmUtdHdlbHZl",
+    size: 12345,
+    releaseDate: "2026-08-20T00:00:00.000Z",
+  });
+  const zipName = releaseZipFileName("0.3.0");
+  assert.equal(
+    manifest,
+    [
+      "version: 0.3.0",
+      "files:",
+      `  - url: ${zipName}`,
+      "    sha512: c2hhLWZpdmUtdHdlbHZl",
+      "    size: 12345",
+      `path: ${zipName}`,
+      "sha512: c2hhLWZpdmUtdHdlbHZl",
+      "releaseDate: '2026-08-20T00:00:00.000Z'",
+      "",
+    ].join("\n"),
+  );
 });
 
 test("notary credentials come from the keychain profile unless a key file is provided whole", () => {

--- a/scripts/release/publish-github.sh
+++ b/scripts/release/publish-github.sh
@@ -4,10 +4,10 @@ set -euo pipefail
 # Publishes a manual macOS release from what pnpm release:macos just built.
 # The asset set is load-bearing on both ends and encoded here so a by-hand
 # release cannot break either: the version-free Luke.dmg is what the website's
-# download link reaches through releases/latest, and the app's own update
-# check reads the latest release's tag name — so the release must be a
-# published, non-draft, non-prerelease one whose tag matches the desktop
-# version exactly.
+# download link reaches through releases/latest, and the version-free
+# latest-mac.yml is the electron-updater manifest the app updates from — so
+# the release must be a published, non-draft, non-prerelease one whose tag
+# matches the desktop version exactly.
 
 SCRIPT_DIRECTORY=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIRECTORY/../.." && pwd)
@@ -18,6 +18,7 @@ TAG="v$VERSION"
 DMG_ASSET_NAME=$(node -e "import('./apps/desktop/scripts/release-config.mjs').then((config) => process.stdout.write(config.releaseDmgFileName(process.argv[1])))" "$VERSION")
 ZIP_ASSET_NAME=$(node -e "import('./apps/desktop/scripts/release-config.mjs').then((config) => process.stdout.write(config.releaseZipFileName(process.argv[1])))" "$VERSION")
 LATEST_DMG_ASSET_NAME=$(node -e "import('./apps/desktop/scripts/release-config.mjs').then((config) => process.stdout.write(config.RELEASE_LATEST_DMG_FILE_NAME))")
+UPDATE_FEED_ASSET_NAME=$(node -e "import('./apps/desktop/scripts/release-config.mjs').then((config) => process.stdout.write(config.RELEASE_UPDATE_FEED_FILE_NAME))")
 ARTIFACT_DIRECTORY="artifacts/release"
 DMG_PATH="$ARTIFACT_DIRECTORY/$DMG_ASSET_NAME"
 ZIP_PATH="$ARTIFACT_DIRECTORY/$ZIP_ASSET_NAME"
@@ -41,6 +42,7 @@ trap 'rm -rf "$staging_directory"' EXIT
 cp "$DMG_PATH" "$staging_directory/$DMG_ASSET_NAME"
 cp "$DMG_PATH" "$staging_directory/$LATEST_DMG_ASSET_NAME"
 cp "$ZIP_PATH" "$staging_directory/$ZIP_ASSET_NAME"
+node apps/desktop/scripts/write-update-feed.mjs "$staging_directory/$UPDATE_FEED_ASSET_NAME"
 (
     cd "$staging_directory"
     shasum -a 256 "$DMG_ASSET_NAME" > "$DMG_ASSET_NAME.sha256"
@@ -59,6 +61,7 @@ gh release upload "$TAG" \
     "$staging_directory/$LATEST_DMG_ASSET_NAME" \
     "$staging_directory/$ZIP_ASSET_NAME" \
     "$staging_directory/$ZIP_ASSET_NAME.sha256" \
+    "$staging_directory/$UPDATE_FEED_ASSET_NAME" \
     --clobber
 
 printf 'Published %s. The website reaches this build at:\n' "$TAG"


### PR DESCRIPTION
## Summary

- Replaces the Updates flow's browser-only Download with in-place updating, replicating the updater [Superset runs in production](https://github.com/superset-sh/superset/blob/main/apps/desktop/src/main/lib/auto-updater.ts): `electron-updater`'s generic provider pointed at `releases/latest/download/`, reading a `latest-mac.yml` manifest the release pipeline now publishes beside the zip (hashed from that very archive). Auto-download is on — a newer build found by any check (4-hourly timer, or the row's button) downloads itself — and the install lands at quit: the row's "Restart to update" press, or whenever the user next quits (`autoInstallOnAppQuit`).
- Superset's production lessons are carried over: an install may be asked for only once (repeat presses race Squirrel's binary swap), transient network errors are silence rather than an error state, electron-updater's cached download is cleared on error (a corrupt cache is otherwise retried forever), differential downloads are disabled, download progress is throttled to the row, and the first launch after an install shows an "updated" confirmation via a persisted last-run version.
- The row walks `idle → checking → downloading (with %) → ready → updated`, with `error` falling back to the releases page in the browser — the same fallback an unpackaged or fixture build (which carries no updater) offers from the start. Trust prose updated for the policy change (AGENTS.md, PRIVACY.md, PROVIDERS.md, in-app guide): downloads now start on a check's finding, not a press; installs still land only at a quit.
- The previous approach on this branch (GitHub-API version check + raw Squirrel `updates.json` feed) is fully replaced; `app-update.ts` helpers stay in core for product-events version validation.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (exit 0; desktop 1223/1223, core 282/282, web 53/53, scripts 48/48)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — authored in a Linux cloud workspace; needs a macOS run

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32325244194/artifacts/9391141533) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32325244194)

- Commit: `216ae5b1212bcf9bbbd56e1e4125e3ba3dbc250a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- The first release cut after this merges is what makes `latest-mac.yml` exist; a build running this code before then lands on the tested error row with the browser fallback, never a hang.
- The full upgrade path (auto-download → restart → new version, and install-on-quit) can only be proven with two signed, notarized releases on a physical Mac. The failure drill: delete the `latest-mac.yml` or zip asset from the latest release and check for updates.
- Not replicated deliberately: Superset's Sentry error telemetry and disk-space classification (Luke sends nothing home), their canary channel (Luke has no prerelease builds), and their electron-builder packaging — the manifest is byte-compatible, produced by this repo's existing signed/notarized pipeline. Migrating packaging to electron-builder would be its own project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)