### PR TITLE
fix(panel): carry still-hidden wing marks on a bound-moved travel

### DIFF
--- a/apps/desktop/src/renderer/session-motion.ts
+++ b/apps/desktop/src/renderer/session-motion.ts
@@ -237,6 +237,19 @@ function elementVisible(element: HTMLElement): boolean {
 }
 
 /**
+ * Whether a planned travel animates for an element in this visibility. A slot
+ * hop leaves a hidden element to take its place unseen — nothing a reader
+ * watches moved. A travel the bound caused is the shape's own motion and
+ * carries every element it displaced, seen or not: a mark can be
+ * mid-entrance, transparent on the frame of the morph and visible before the
+ * spring settles, and one left untravelled fades in at its new seat ahead of
+ * the surface's edge, drawn on the desktop.
+ */
+export function travelApplies(input: { boundMoved: boolean; visible: boolean }): boolean {
+  return input.boundMoved || input.visible;
+}
+
+/**
  * Watches one list across commits and turns every reorder into motion.
  * Returns the ref the list container must carry; a commit that unmounts the
  * container (the settings tab, the slot, the wing yielding to the meter) drops
@@ -435,7 +448,8 @@ function useReorderMotion<T extends HTMLElement>(list: ReorderList): RefObject<T
       };
       for (const [id, from] of plan.travels) {
         const element = elements.get(id);
-        if (element === undefined || !elementVisible(element)) continue;
+        if (element === undefined) continue;
+        if (!travelApplies({ boundMoved, visible: elementVisible(element) })) continue;
         const within = from - groupTravelOf(element);
         if (Math.abs(within) > TRAVEL_EPSILON) travel(element, within, 0);
       }

--- a/apps/desktop/tests/session-motion.test.ts
+++ b/apps/desktop/tests/session-motion.test.ts
@@ -6,6 +6,7 @@ import {
   parsePixels,
   planReorder,
   rosterRows,
+  travelApplies,
   withoutDeparture,
 } from "../src/renderer/session-motion";
 
@@ -18,6 +19,23 @@ test("a row found somewhere new travels back by exactly the distance it moved", 
   // `a` moved down 75px, so it starts 75px up — where it was — and vice versa.
   assert.equal(plan.travels.get("a"), -75);
   assert.equal(plan.travels.get("b"), 75);
+});
+
+test("a slot hop leaves a hidden element to take its place", () => {
+  assert.equal(travelApplies({ boundMoved: false, visible: false }), false);
+});
+
+test("a bound-moved travel carries an element still transparent mid-entrance", () => {
+  // The wing's marks enter behind the shape's travel, so a panel opened
+  // before their fade begins finds them at opacity zero — and they will be
+  // visible before the spring settles. Skipped, they would fade in at their
+  // new seat while the surface's edge is still on its way there.
+  assert.equal(travelApplies({ boundMoved: true, visible: false }), true);
+});
+
+test("a visible element travels whichever gesture moved it", () => {
+  assert.equal(travelApplies({ boundMoved: false, visible: true }), true);
+  assert.equal(travelApplies({ boundMoved: true, visible: true }), true);
 });
 
 test("a row that kept its place is left alone", () => {


### PR DESCRIPTION
## What

Expanding the panel quickly — before the wing's provider marks have begun their delayed entrance fade — left the icons ahead of the growing bubble: the reorder motion skips invisible elements, so a mark at opacity zero took its panel seat in one frame and then faded in there while the surface's edge was still travelling toward it, drawn on the desktop at the bubble's top left.

A travel the bound caused is the shape's own motion, so it now carries every element it displaced, seen or not — a mark transparent on the frame of the morph is visible before the spring settles, and it must already be riding the edge when it appears. A plain slot hop keeps the old rule: a hidden element just takes its place unseen.

This is the remaining piece of the "icons jump ahead of the bubble" report, after #281 (one window width across modes) and #278 (the pill's corner interpolation) addressed the other two causes.

## How

`travelApplies` is extracted as a pure predicate — bound-moved travels apply regardless of visibility, slot hops only to visible elements — and the travel loop consumes it. Unit tests pin all three cases.

## Verification

- `./scripts/check.sh` passes end to end (1,184 desktop tests, 3 new).
- Verified per DESIGN.md's "Proving it": drove the real app headless with CDP and sampled the mark's edge against the surface's drawn edge every frame through capsule→panel and peek→panel in the bubble form; the mark now stays ≥14px inside the shape on every visible frame at every click timing, where before it faded in up to ~9px outside while the edge was still arriving.
- Physical check: exercised on a notched MacBook in the bubble form during development of this fix series; `./scripts/verify.sh` was not run for this change (portable-only diff — renderer TypeScript and unit tests, no packaging or geometry change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/7d9cd83e-ad5d-4bb3-a25e-7bcf919184d3)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32300488192/artifacts/9382844652) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32300488192)

- Commit: `af55629c0bc8eb4475b481e5df8cae4e8727eacd`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
