### PR TITLE
feat(analytics): set up PostHog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,11 @@ Trust constraints:
   a recap, a prompt, an error line — may reach a property, and no property may
   take free text; counts travel as buckets and versions as release versions.
   The desktop posts to Luke's own service and never to an analytics provider,
-  and the account is the bearer token's, so no identity travels with an event.
+  and the account is the bearer token's, so no identity travels from the
+  desktop at all. The service attaches the account's own name and address to
+  the analytics person record, read from its own user row — never from the
+  request, and never onto an event, because an event property is what the
+  allowlist governs and a person property is not.
   Nothing is sent in a fixture or evidence run, or while the developer has
   switched sharing off — a switch that is on by default, sits on the settings
   front page, and belongs to no reset scope, because a reset that turned

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,21 @@ Trust constraints:
   outputs out of its transcripts, so a Cursor reading carries none — and a
   provider whose stored shape this build cannot render faithfully keeps the
   honest refusal instead.
+- Analytics may name only what the build already fixed. An event is a name from
+  `packages/sidecar-core/src/product-events.ts` and properties whose values
+  come from `as const` sets in that same file, validated by one reader both the
+  desktop and the service run and which builds its output from the allowlist
+  rather than from what arrived. No observed value — a title, a branch, a path,
+  a recap, a prompt, an error line — may reach a property, and no property may
+  take free text; counts travel as buckets and versions as release versions.
+  The desktop posts to Luke's own service and never to an analytics provider,
+  and the account is the bearer token's, so no identity travels with an event.
+  Nothing is sent in a fixture or evidence run, or while the developer has
+  switched sharing off — a switch that is on by default, sits on the settings
+  front page, and belongs to no reset scope, because a reset that turned
+  counting back on would be a consent nobody gave. Widening the event list or a
+  property's value set is a product decision, not an implementation detail, and
+  moves `PRIVACY.md` in the same change.
 - The issue tracker follows the same rule at one remove, and is connected the
   way the calendar is rather than the way a cloud provider is. Luke reads the
   issues a tracker lists for the user under a grant the tracker's own consent
@@ -518,7 +533,10 @@ no longer keeps — has no lever, so the rule is stated here: a capability the
 document does not describe is one a reader will not know Luke has, and a stale
 entry describes a Luke that does not exist. `PRIVACY.md` and the README's
 integration table cover the same connections at different altitudes; a change
-that touches one usually touches all three.
+that touches one usually touches all three. `PRIVACY.md`'s product-analytics
+section is bound the same way and by nothing but this rule: it names every
+event and every property by name, so an event added, renamed, or given a wider
+value set leaves that document describing a Luke that no longer exists.
 
 ## Code comments
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,8 @@ Linear issues show as chips under the notch.
 ### Usage data
 
 Luke now counts how his own features are used — a launch, a provider connected,
-sessions observed, a call opened — and sends those counts to Luke's own service
-so we can see what is worth building next. This is on by default, and the
+sessions observed, a call opened — and sends those counts to Luke's own service,
+tied to your account, so we can see what is worth building next. This is on by default, and the
 switch is Share usage data in the new Usage data section on the Settings tab's
 front page; turning it off stops it at once. Every event name and every value
 is fixed by the build, so nothing about a session — no title, branch, path,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,22 @@ Linear issues show as chips under the notch.
 [#257](https://github.com/ReviewStage/luke/pull/257),
 [#271](https://github.com/ReviewStage/luke/pull/271))
 
+### Usage data
+
+Luke now counts how his own features are used — a launch, a provider connected,
+sessions observed, a call opened — and sends those counts to Luke's own service
+so we can see what is worth building next. This is on by default, and the
+switch is Share usage data in the new Usage data section on the Settings tab's
+front page; turning it off stops it at once. Every event name and every value
+is fixed by the build, so nothing about a session — no title, branch, path,
+recap, or transcript — and nothing you type or say can travel in one, and
+nothing is sent while you are signed out. [Privacy](PRIVACY.md) lists every
+event and property by name.
+
 ### Improvements
 
+- Luke counts how his own features are used, on by default and switched off
+  under Share usage data on the Settings tab's front page
 - Luke's role is an engineering manager
   ([#265](https://github.com/ReviewStage/luke/pull/265))
 - Session rows show number of files touched and lines changed when available

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -63,6 +63,89 @@ a status alone. What OpenAI receives on these paths is the same as on the
 keyed paths below, under Luke's key rather than yours, and OpenAI's policies
 govern it the same way.
 
+## Product analytics
+
+Luke counts how his own features are used, so that whether anyone launches him
+twice, which providers people actually connect, and where install-to-first-
+session loses them are answerable at all. **This is on by default.** The switch
+is **Share usage data**, in the Usage data section on Luke's Settings tab,
+front page — the same page as Updates. Turning it off stops it at once and
+sends one final `usage:sharing_stop` event so that opting out is itself
+countable; nothing is sent afterwards.
+
+The desktop never talks to an analytics provider. It posts a batch of events to
+Luke's own service, on the same origin and the same short-lived access token
+the voice and review endpoints use, and that service forwards them to PostHog
+(PostHog Cloud, US region) under a key that exists only in the deployment.
+**Because the account is resolved from the bearer token, the desktop transmits
+no identity at all** — there is no field in what it sends that could name a
+person, and a `distinct_id` written into the request body is discarded rather
+than honoured. Each forwarded event carries `$geoip_disable`, so PostHog never
+resolves your Mac's network address or location; the address it would otherwise
+see is the data centre's, not yours.
+
+**There is no free-text field on the wire.** An event is one name from a fixed
+list, and each of its properties is one value from a fixed set, a version
+number, or a bucket — enforced by a single validator in
+`packages/sidecar-core/src/product-events.ts` that both the desktop and the
+service run, and that builds each event from the allowlist rather than copying
+what arrived. A session title, branch, repository path, recap, prompt, tool
+output, error line, file name, or anything typed or spoken has no shape it
+could travel in.
+
+The events are, in full:
+
+| Event | When |
+| --- | --- |
+| `app:launch` | Luke started |
+| `app:day_active` | first activity of a UTC day, because one launch can run for a week |
+| `account:sign_in` | the desktop moved into signed-in |
+| `provider:connect`, `provider:disconnect` | a credential was saved or cleared |
+| `tracker:connect` | Linear was connected |
+| `calendar:connect` | a Google Calendar account was connected |
+| `session:observe` | once per provider per UTC day, that observation is happening |
+| `session:act_send` | a message, control, open, transcript read, workspace creation, or added agent was accepted |
+| `issue:act_send` | an issue state move or comment was accepted |
+| `voice:call_start` | a Realtime credential was minted for a call |
+| `voice:announcement_speak` | a session announcement was spoken |
+| `setting:update` | a setting was changed |
+| `usage:sharing_stop`, `usage:sharing_resume` | this switch moved |
+
+The properties are, in full: `app_version` (a `x.y.z` release version and
+nothing else); `provider_id`, `connection_id`, and `tracker_id` (ids from the
+build's own provider, credential, and tracker lists); `session_count` (never a
+count — one rung of the fixed ladder 0, 1, 2, 5, 10, 25, because "137 sessions"
+identifies a machine where "a crowd" does not); `session_status` (waiting,
+error, or complete); `credential_source` (account or key); `session_act` and
+`issue_act` (which kind of act, never what it carried); `setting_id` (which
+setting); and `setting_value` — on, off, set, or cleared, never the value
+itself, because some settings hold a project name or a keyboard chord you
+chose. No event carries more than two of these.
+
+Nothing is sent while sharing is off, while the desktop is signed out, or in a
+fixture or evidence run. Delivery is best-effort and held in memory only:
+a failed send drops those counts rather than retrying, and quitting drops
+whatever had not been sent. Nothing is written to disk.
+
+**The website is a separate matter and a weaker guarantee.** tryluke.dev counts
+page views and two sign-in steps (started, completed) through PostHog's browser
+library, with autocapture and session recording both switched off, so the text
+and attributes of what you click and the contents of the page are not
+collected. But the browser talks to PostHog directly, which means **PostHog
+sees your network address and user agent on the website**, as it would for any
+third-party script. Visitors are not given a person record until they sign in;
+at that point the account's opaque database id — and only that id, never an
+email, name, or sign-in provider — is what links the visit to the account, so
+the website half and the desktop half of the funnel join.
+
+Deleting your Luke account also asks PostHog to erase the person and the events
+recorded against them. That erasure is **asynchronous on PostHog's side and
+best-effort**: it is requested before the account row is deleted, but if PostHog
+refuses or is unreachable the account is still deleted and the request is not
+retried, because a third party's availability is not a condition of erasing
+your account. Turning the switch off stops future collection but does not by
+itself erase what was already collected.
+
 ## Update check
 
 Luke asks GitHub's public API for the name of this repository's latest

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -79,12 +79,17 @@ the voice and review endpoints use, and that service forwards them to PostHog
 (PostHog Cloud, US region) under a key that exists only in the deployment.
 **Because the account is resolved from the bearer token, the desktop transmits
 no identity at all** — there is no field in what it sends that could name a
-person, and a `distinct_id` written into the request body is discarded rather
-than honoured. Each forwarded event carries `$geoip_disable`, so PostHog never
+person, and a `distinct_id` or `$set` written into the request body is discarded
+rather than honoured. The service itself attaches your account's name and email
+address to the PostHog person record, read from its own user row, so that the
+counts can be read as belonging to an account rather than to an anonymous id.
+Those two fields sit on the person, never in an event.
+
+Each forwarded event carries `$geoip_disable`, so PostHog never
 resolves your Mac's network address or location; the address it would otherwise
 see is the data centre's, not yours.
 
-**There is no free-text field on the wire.** An event is one name from a fixed
+**No free text reaches the event stream.** An event is one name from a fixed
 list, and each of its properties is one value from a fixed set, a version
 number, or a bucket — enforced by a single validator in
 `packages/sidecar-core/src/product-events.ts` that both the desktop and the
@@ -134,17 +139,16 @@ and attributes of what you click and the contents of the page are not
 collected. But the browser talks to PostHog directly, which means **PostHog
 sees your network address and user agent on the website**, as it would for any
 third-party script. Visitors are not given a person record until they sign in;
-at that point the account's opaque database id — and only that id, never an
-email, name, or sign-in provider — is what links the visit to the account, so
-the website half and the desktop half of the funnel join.
+at that point the account's database id is what links the visit to the account, so the website
+half and the desktop half of the funnel join, and the same name and email
+address the account holds are set on the person record. The sign-in provider
+does not travel.
 
-Deleting your Luke account also asks PostHog to erase the person and the events
-recorded against them. That erasure is **asynchronous on PostHog's side and
-best-effort**: it is requested before the account row is deleted, but if PostHog
-refuses or is unreachable the account is still deleted and the request is not
-retried, because a third party's availability is not a condition of erasing
-your account. Turning the switch off stops future collection but does not by
-itself erase what was already collected.
+Deleting your Luke account removes it from Luke's own service, but does not by
+itself erase counts already sent to PostHog: those remain against the person
+record, which afterwards names an account that no longer exists. Turning the
+switch off stops further collection and likewise erases nothing already
+collected. Ask us and we will delete the person record and its events.
 
 ## Update check
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ key in Settings.
 Voice is the one feature that sends audio off your Mac. Refer to
 [PRIVACY.md](PRIVACY.md).
 
+Luke also counts how his own features are used, on by default — switch it off
+under **Share usage data** in Settings.
+
 ## Supported providers
 
 | Provider | Local | Cloud |

--- a/apps/desktop/src/desktop-app.ts
+++ b/apps/desktop/src/desktop-app.ts
@@ -19,7 +19,10 @@ import {
   normalizeObservedWorkspaceProjects,
   normalizeTrackedIssue,
   type ObservedWorkspaceProject,
+  PRODUCT_EVENT,
   PROVIDER_ID_LIST,
+  productSessionCountBucket,
+  type RecordProductEvent,
   rosterRelevantSessions,
   SessionNoticeHold,
   SessionNoticeTracker,
@@ -71,6 +74,7 @@ import { ObservationHookRegistry } from "./observation-hook-registry";
 import { ObservationLoop, ObservationSupervisor } from "./observation-loop";
 import { OutputVolumeWatcher } from "./output-volume";
 import { PanelManager } from "./panel-manager";
+import { ProductEventSender } from "./product-event-sender";
 import { type ProviderRegistration, providerRegistrations } from "./provider-registrations";
 import { runModeFor } from "./run-mode";
 import { sessionNoticeSpeech } from "./session-notifications";
@@ -183,9 +187,14 @@ const accountSession = new AccountSessionManager({
   startCapabilities: () => startAccountCapabilities(),
   stopCapabilities: stopAccountCapabilities,
   onChange: (next) => {
+    const signedIn = next.status === ACCOUNT_STATUS.SIGNED_IN;
+    const wasSignedIn = account.status === ACCOUNT_STATUS.SIGNED_IN;
     account = next;
     broadcastAccount();
     void broadcastVoiceAvailability();
+    // The transition alone: which provider signed in is already on the person
+    // from the browser's own sign-in, so nothing about it needs to travel again.
+    if (signedIn && !wasSignedIn) productEvents.record(PRODUCT_EVENT.ACCOUNT_SIGN_IN, {});
   },
 });
 const observationHooks = new ObservationHookRegistry(() => app.getPath("userData"));
@@ -343,6 +352,21 @@ const updateService = new UpdateService({
   currentVersion: app.getVersion(),
   onChange: (update) => panels.broadcast(channels.updateChanged, update),
 });
+// Counts how Luke's own features are used. It lives here rather than in a
+// renderer because every emit site is already in this process and the timer
+// must survive every window; what it may say is fixed by the vocabulary in
+// core, and a fixture or evidence run switches it off entirely.
+const productEvents = new ProductEventSender({
+  serviceBaseUrl: HOSTED_SERVICE_BASE_URL,
+  appVersion: app.getVersion(),
+  sends: runMode.sendsNetwork,
+  readAccessToken: async () => (await settingsStore.readAccount())?.accessToken,
+  refreshAccount: accountSession.refreshOnce,
+});
+// One narrow function rather than the service itself, so an IPC module can
+// count an act without being handed anything it could flush, stop, or read.
+const recordProductEvent: RecordProductEvent = (name, properties) =>
+  productEvents.record(name, properties);
 /**
  // SAFETY: The preceding check establishes the asserted contract.
  * The output's switches as last read, and the helper that reads them. The
@@ -806,6 +830,8 @@ function registerIpc(): void {
     workspaceProjectOffered,
     refreshMeetingQuiet: () => void refreshMeetingQuiet(),
     releaseHeldNotices: () => void releaseHeldNotices(),
+    setUsageSharing: (enabled) => productEvents.setSharing(enabled),
+    recordProductEvent,
   });
 
   registerCalendarConnectionIpc({
@@ -817,6 +843,7 @@ function registerIpc(): void {
     signIn: googleCalendarSignIn,
     observedCalendars: () => observedCalendars,
     refresh: () => void calendarObservationLoop.refresh(),
+    recordProductEvent,
   });
 
   registerTrackerConnectionIpc({
@@ -827,6 +854,7 @@ function registerIpc(): void {
     credentials: linearCredentials,
     signIn: linearSignIn,
     refresh: () => void issueObservationLoop.refresh(),
+    recordProductEvent,
   });
 
   // The row's button. Answered rather than fire-and-forget so the row that
@@ -854,6 +882,8 @@ function registerIpc(): void {
     realtimeCredentials: () => voiceCapabilities.realtimeCredentials,
     unavailableDiagnostics: () => voiceCapabilities.unavailableDiagnostics,
     hostedUsageReader: () => voiceCapabilities.hostedUsageReader,
+    voiceSource: () => voiceCapabilities.voiceSource,
+    recordProductEvent,
   });
 
   registerSessionActsIpc({
@@ -878,6 +908,7 @@ function registerIpc(): void {
         ? observedSupersetWorkspaces.context(identity.providerId, identity.providerSessionId)
         : undefined,
     supersetCli,
+    recordProductEvent,
   });
 
   // A note to the founders travels one road: typed in the composer, validated
@@ -1118,6 +1149,13 @@ async function announceSessionNotices(sessions: readonly NormalizedSession[]): P
     return;
   }
   const speech = notices.map((notice) => sessionNoticeSpeech(notice, now));
+  for (const notice of notices) {
+    if (!isProviderId(notice.providerId)) continue;
+    productEvents.record(PRODUCT_EVENT.VOICE_ANNOUNCEMENT_SPEAK, {
+      provider_id: notice.providerId,
+      session_status: notice.status,
+    });
+  }
   panels.voiceHost()?.webContents.send(channels.attentionSpeech, speech);
 }
 
@@ -1414,7 +1452,29 @@ function startSessionObservation(): void {
     // A commit is the earliest a write-triggered refresh can have changed the
     // offer, so the announcement rides it rather than waiting for the timer.
     void broadcastWorkspaceProjects();
+    countObservedSessions(snapshot.sessions);
   });
+}
+
+/**
+ * Counts what each provider is observing, once per provider per day. The
+ * registry commits on every effective change, so counting each commit would
+ * measure registry churn rather than use; and the count itself is a rung of
+ * the shared ladder rather than a number, because "137 sessions" identifies a
+ * machine where "a crowd" does not.
+ */
+function countObservedSessions(sessions: readonly NormalizedSession[]): void {
+  const counts = new Map<string, number>();
+  for (const session of sessions) {
+    counts.set(session.providerId, (counts.get(session.providerId) ?? 0) + 1);
+  }
+  for (const [providerId, count] of counts) {
+    if (!isProviderId(providerId)) continue;
+    productEvents.recordOncePerDay(PRODUCT_EVENT.SESSION_OBSERVE, providerId, {
+      provider_id: providerId,
+      session_count: productSessionCountBucket(count),
+    });
+  }
 }
 
 function stopSessionObservation(): void {
@@ -1539,10 +1599,28 @@ export function startDesktopApp(): void {
         (enabled) => mediaDuck.setEnabled(enabled === true),
         () => mediaDuck.setEnabled(APP_SETTING_DEFAULTS.duckOtherMedia),
       );
+      // Armed from the settings file alone, like the duck above, and on the
+      // same terms: a file that cannot be read leaves counting on, the answer
+      // a file that has never said gives.
+      void settingsStore
+        .get(APP_SETTING_SCHEMA.shareUsageData.field)
+        .catch(() => APP_SETTING_DEFAULTS.shareUsageData)
+        .then((share) => {
+          productEvents.setSharing(share);
+          // Recorded behind the read, because nothing may be counted before
+          // the file has said whether counting is wanted at all.
+          productEvents.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: app.getVersion() });
+          // Luke can run for a week on one launch, so launches alone would
+          // undercount the days he was actually used.
+          productEvents.markDayActive();
+        });
       // Always on, like the announcements: the timed check answers to no
       // setting, only to the run — a fixture or capture run sends no network,
       // so it never asks GitHub anything.
-      if (runMode.sendsNetwork) updateService.start();
+      if (runMode.sendsNetwork) {
+        updateService.start();
+        productEvents.start();
+      }
       // The hook registrations converge at every launch. Each provider's
       // failure is logged under its own name and absorbed inside — a launch
       // must never hang on another app's configuration file — so this catch is
@@ -1662,6 +1740,10 @@ export function startDesktopApp(): void {
   app.on("before-quit", () => {
     observationSupervisor.setEnabled(false);
     stopCalendarObservation();
+    // Deliberately not a flush: a request here either delays the quit or is
+    // killed mid-flight, and an instant quit is worth the last minute of
+    // counts.
+    productEvents.stop();
     panels.clearCollapseTimers();
   });
 

--- a/apps/desktop/src/desktop-app.ts
+++ b/apps/desktop/src/desktop-app.ts
@@ -24,6 +24,7 @@ import {
   productSessionCountBucket,
   type RecordProductEvent,
   rosterRelevantSessions,
+  type SessionNotice,
   SessionNoticeHold,
   SessionNoticeTracker,
   type SessionProviderAdapter,
@@ -1149,6 +1150,17 @@ async function announceSessionNotices(sessions: readonly NormalizedSession[]): P
     return;
   }
   const speech = notices.map((notice) => sessionNoticeSpeech(notice, now));
+  countSpokenAnnouncements(notices);
+  panels.voiceHost()?.webContents.send(channels.attentionSpeech, speech);
+}
+
+/**
+ * Counts the announcements about to be spoken. It sits beside the send rather
+ * than inside the notice tracker because a notice held through a meeting is
+ * spoken later or not at all, and only the two paths that actually hand
+ * speech to the voice host know which happened.
+ */
+function countSpokenAnnouncements(notices: readonly SessionNotice[]): void {
   for (const notice of notices) {
     if (!isProviderId(notice.providerId)) continue;
     productEvents.record(PRODUCT_EVENT.VOICE_ANNOUNCEMENT_SPEAK, {
@@ -1156,7 +1168,6 @@ async function announceSessionNotices(sessions: readonly NormalizedSession[]): P
       session_status: notice.status,
     });
   }
-  panels.voiceHost()?.webContents.send(channels.attentionSpeech, speech);
 }
 
 /**
@@ -1287,6 +1298,7 @@ async function releaseHeldNotices(): Promise<void> {
   const releasedAsks = heldRequestSpeech.release().map((item) => ({ ...item, decidedAt: now }));
   const speech = [...releasedAsks, ...released.map((notice) => sessionNoticeSpeech(notice, now))];
   if (speech.length === 0) return;
+  countSpokenAnnouncements(released);
   panels.voiceHost()?.webContents.send(channels.attentionSpeech, speech);
 }
 

--- a/apps/desktop/src/ipc/calendar-connection.ts
+++ b/apps/desktop/src/ipc/calendar-connection.ts
@@ -1,4 +1,9 @@
-import { isWireString, type UnparsedWireValue } from "@sidecar/core";
+import {
+  isWireString,
+  PRODUCT_EVENT,
+  type RecordProductEvent,
+  type UnparsedWireValue,
+} from "@sidecar/core";
 import type { IpcMain, IpcMainEvent, IpcMainInvokeEvent } from "electron";
 import type { GoogleCalendarReader } from "../google-calendar";
 import type { GoogleCalendarSignIn } from "../google-calendar-oauth";
@@ -15,13 +20,22 @@ export interface CalendarConnectionIpcDependencies {
   signIn: GoogleCalendarSignIn;
   observedCalendars: () => readonly ObservedAccountCalendars[];
   refresh: () => void;
+  recordProductEvent: RecordProductEvent;
 }
 
 export function registerCalendarConnectionIpc(
   dependencies: CalendarConnectionIpcDependencies,
 ): void {
-  const { ipcMain, trustedSender, registerSetting, settingsStore, calendar, signIn, refresh } =
-    dependencies;
+  const {
+    ipcMain,
+    trustedSender,
+    registerSetting,
+    settingsStore,
+    calendar,
+    signIn,
+    refresh,
+    recordProductEvent,
+  } = dependencies;
   registerSetting(channels.connectGoogleCalendar, {
     validate: () => undefined,
     async save() {
@@ -45,7 +59,10 @@ export function registerCalendarConnectionIpc(
       return settingsStore.addCalendarAccount(primaryId, outcome.refreshToken, [primaryId]);
     },
     apply(result) {
-      if (!result.reason) refresh();
+      if (!result.reason) {
+        refresh();
+        recordProductEvent(PRODUCT_EVENT.CALENDAR_CONNECT, {});
+      }
     },
     refusal: "Could not connect Google Calendar on this system.",
   });

--- a/apps/desktop/src/ipc/session-acts.ts
+++ b/apps/desktop/src/ipc/session-acts.ts
@@ -6,16 +6,22 @@ import {
   type InMemorySessionRegistry,
   ISSUE_ACTION_KIND,
   type IssueIdentity,
+  isIssueTrackerId,
   isProviderId,
   isRecord,
   issueCommentText,
   isWireString,
   type NormalizedSession,
+  PRODUCT_EVENT,
+  PRODUCT_ISSUE_ACT,
+  PRODUCT_SESSION_ACT,
   PROVIDER_ACT_RESULT_STATUS,
+  type ProductSessionAct,
   type ProviderActResult,
   type ProviderControlResult,
   type ProviderMessageResult,
   type ProviderWorkspaceResult,
+  type RecordProductEvent,
   SESSION_LOCATION,
   type SessionAttentionReviewer,
   type SessionIdentity,
@@ -73,6 +79,7 @@ export interface SessionActsIpcDependencies {
   refreshIssues: () => void;
   supersetContext: (identity: SessionIdentity) => SupersetSessionContext | undefined;
   supersetCli: SupersetCli;
+  recordProductEvent: RecordProductEvent;
 }
 
 export function registerSessionActsIpc(dependencies: SessionActsIpcDependencies): void {
@@ -95,14 +102,38 @@ export function registerSessionActsIpc(dependencies: SessionActsIpcDependencies)
     refreshIssues,
     supersetContext,
     supersetCli,
+    recordProductEvent,
   } = dependencies;
   const registerAction = createActionHandler({
     trustedSender,
     handle: (channel, handler) => ipcMain.handle(channel, handler),
   });
+  /**
+   * Counts an act that actually landed. It takes the result rather than
+   * sitting inside `performSessionAct`, because a Superset-managed session
+   * takes the same acts through the CLI without passing through there — an act
+   * counted in only one of the two paths would read as a provider nobody sends
+   * messages to.
+   */
+  function countSessionAct<Result extends ProviderActResult>(
+    providerId: string,
+    counted: ProductSessionAct,
+    result: Result,
+  ): Result {
+    // An adapter reports its provider id as a string; only one this build's
+    // own vocabulary names has anything to be counted under.
+    if (result.status === PROVIDER_ACT_RESULT_STATUS.ACCEPTED && isProviderId(providerId)) {
+      recordProductEvent(PRODUCT_EVENT.SESSION_ACT_SEND, {
+        provider_id: providerId,
+        session_act: counted,
+      });
+    }
+    return result;
+  }
   // Capability checks stay in their handlers so no act can inherit another act's authority.
   async function performSessionAct<Result extends ProviderActResult>(
     identity: SessionIdentity,
+    counted: ProductSessionAct,
     act: (adapter: SessionProviderAdapter, session: NormalizedSession) => Promise<Result>,
   ): Promise<Result | { status: typeof PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED }> {
     const session = sessionRegistry.get(identity);
@@ -113,7 +144,7 @@ export function registerSessionActsIpc(dependencies: SessionActsIpcDependencies)
     if (result.status === PROVIDER_ACT_RESULT_STATUS.ACCEPTED) {
       void sessionRegistry.refresh(adapter);
     }
-    return result;
+    return countSessionAct(adapter.provider.id, counted, result);
   }
   const registerOpenAction = (
     channel: string,
@@ -134,6 +165,12 @@ export function registerSessionActsIpc(dependencies: SessionActsIpcDependencies)
         const url = address(identity);
         if (!url) return { status: SESSION_OPEN_RESULT_STATUS.UNSUPPORTED };
         await openExternal(url);
+        if (isProviderId(identity.providerId)) {
+          recordProductEvent(PRODUCT_EVENT.SESSION_ACT_SEND, {
+            provider_id: identity.providerId,
+            session_act: PRODUCT_SESSION_ACT.SESSION_OPEN,
+          });
+        }
         return { status: SESSION_OPEN_RESULT_STATUS.OPENED };
       },
       failure: () => ({ status: SESSION_OPEN_RESULT_STATUS.REJECTED, reason: failureReason }),
@@ -230,6 +267,12 @@ export function registerSessionActsIpc(dependencies: SessionActsIpcDependencies)
             reason: "That session's transcript could not be found.",
           };
         }
+        if (isProviderId(identity.providerId)) {
+          recordProductEvent(PRODUCT_EVENT.SESSION_ACT_SEND, {
+            provider_id: identity.providerId,
+            session_act: PRODUCT_SESSION_ACT.TRANSCRIPT_READ,
+          });
+        }
         return { status: SESSION_TRANSCRIPT_RESULT_STATUS.READ, transcript };
       } catch {
         return {
@@ -269,8 +312,14 @@ export function registerSessionActsIpc(dependencies: SessionActsIpcDependencies)
         return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
       }
       const managed = supersetContext(identity);
-      if (managed) return supersetCli.sendMessage(managed, messageText);
-      return performSessionAct(identity, (adapter) => {
+      if (managed) {
+        return countSessionAct(
+          identity.providerId,
+          PRODUCT_SESSION_ACT.MESSAGE_SEND,
+          await supersetCli.sendMessage(managed, messageText),
+        );
+      }
+      return performSessionAct(identity, PRODUCT_SESSION_ACT.MESSAGE_SEND, (adapter) => {
         return adapter.sendMessage({
           providerSessionId: identity.providerSessionId,
           text: messageText,
@@ -300,9 +349,13 @@ export function registerSessionActsIpc(dependencies: SessionActsIpcDependencies)
       if (!control) return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
       const managed = supersetContext(identity);
       if (managed && isSupersetControlId(control.id)) {
-        return supersetCli.executeControl(managed, control.id);
+        return countSessionAct(
+          identity.providerId,
+          PRODUCT_SESSION_ACT.CONTROL_RUN,
+          await supersetCli.executeControl(managed, control.id),
+        );
       }
-      return performSessionAct(identity, (adapter) => {
+      return performSessionAct(identity, PRODUCT_SESSION_ACT.CONTROL_RUN, (adapter) => {
         return adapter.executeControl({
           providerSessionId: identity.providerSessionId,
           control,
@@ -506,6 +559,7 @@ export function registerSessionActsIpc(dependencies: SessionActsIpcDependencies)
           parsedSelection,
           isWireString(agent) ? agent.trim() : undefined,
         );
+        countSessionAct(adapter.provider.id, PRODUCT_SESSION_ACT.WORKSPACE_CREATE, result);
         // The named session was consumed above; the renderer's answer stays
         // what became of the ask, so nothing rides this boundary that the
         // roster will not report on its own.
@@ -569,6 +623,15 @@ export function registerSessionActsIpc(dependencies: SessionActsIpcDependencies)
       // as soon as Linear will say.
       if (result.status === TRACKER_ACTION_RESULT_STATUS.ACCEPTED) {
         refreshIssues();
+        if (isIssueTrackerId(issue.trackerId)) {
+          recordProductEvent(PRODUCT_EVENT.ISSUE_ACT_SEND, {
+            tracker_id: issue.trackerId,
+            issue_act:
+              action.kind === "issue-state"
+                ? PRODUCT_ISSUE_ACT.STATE_MOVE
+                : PRODUCT_ISSUE_ACT.COMMENT_ADD,
+          });
+        }
       }
       return result;
     },
@@ -631,8 +694,14 @@ export function registerSessionActsIpc(dependencies: SessionActsIpcDependencies)
         };
       }
       const managed = supersetContext(identity);
-      if (managed) return supersetCli.createAgent(managed, advertised, openingTask.value);
-      return performSessionAct(identity, async (adapter) => {
+      if (managed) {
+        return countSessionAct(
+          identity.providerId,
+          PRODUCT_SESSION_ACT.AGENT_ADD,
+          await supersetCli.createAgent(managed, advertised, openingTask.value),
+        );
+      }
+      return performSessionAct(identity, PRODUCT_SESSION_ACT.AGENT_ADD, async (adapter) => {
         const stored: WorkspaceAgentSelection | undefined = isProviderId(identity.providerId)
           ? (await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field))?.[
               identity.providerId

--- a/apps/desktop/src/ipc/settings-rows.ts
+++ b/apps/desktop/src/ipc/settings-rows.ts
@@ -1,5 +1,10 @@
-import type { SessionProviderAdapter } from "@sidecar/core";
-import { isWireString, type UnparsedWireValue } from "@sidecar/core";
+import {
+  isWireString,
+  PRODUCT_EVENT,
+  type RecordProductEvent,
+  type SessionProviderAdapter,
+  type UnparsedWireValue,
+} from "@sidecar/core";
 import type { IpcMainInvokeEvent } from "electron";
 import type { DockPresence } from "../dock-presence";
 import { HOTKEY_RANK, type HotkeyRegistrar } from "../hotkey-registrar";
@@ -15,6 +20,7 @@ import {
   isCredentialProviderId,
   VOICE_CREDENTIAL_PROVIDER_ID,
 } from "../shared/credential-providers";
+import { CONNECTION_COUNTED_AS } from "../shared/product-vocabulary";
 import {
   APP_SETTING_FIELDS,
   APP_SETTING_SCHEMA,
@@ -24,6 +30,7 @@ import {
   isKeyedAppSettingField,
   isSettingEntryKey,
   SETTING_SIDE_EFFECT,
+  settingAnalytics,
   settingEntryGuard,
 } from "../shared/settings-schema";
 
@@ -42,6 +49,9 @@ export interface SettingsRowsIpcDependencies {
   workspaceProjectOffered: (providerId: string, providerProjectId: string) => boolean;
   refreshMeetingQuiet: () => void;
   releaseHeldNotices: () => void;
+  /** Moves the counting switch, which is also what records the move itself. */
+  setUsageSharing: (enabled: boolean) => void;
+  recordProductEvent: RecordProductEvent;
 }
 
 export function registerSettingsRowsIpc(dependencies: SettingsRowsIpcDependencies): void {
@@ -60,6 +70,8 @@ export function registerSettingsRowsIpc(dependencies: SettingsRowsIpcDependencie
     workspaceProjectOffered,
     refreshMeetingQuiet,
     releaseHeldNotices,
+    setUsageSharing,
+    recordProductEvent,
   } = dependencies;
   // The renderer can replace or clear a provider's credential but never reads
   // it back; the reply reports only where each key now comes from.
@@ -74,7 +86,7 @@ export function registerSettingsRowsIpc(dependencies: SettingsRowsIpcDependencie
       return { providerId, apiKey };
     },
     save: ({ providerId, apiKey }) => settingsStore.setApiKey(providerId, apiKey),
-    async apply(result, { providerId }) {
+    async apply(result, { providerId, apiKey }) {
       // Only the provider whose key changed is affected, so the local
       // observers are left alone rather than re-crawling the filesystem on
       // every save.
@@ -94,9 +106,32 @@ export function registerSettingsRowsIpc(dependencies: SettingsRowsIpcDependencie
         await applyVoiceCredential();
         await hotkeys.reapply(HOTKEY_RANK.TALK);
       }
+      // The store reads a blank key as a clearing, so the count reads it the
+      // same way rather than reporting a connection that did not happen.
+      if (!result.reason) {
+        recordProductEvent(
+          apiKey?.trim() ? PRODUCT_EVENT.PROVIDER_CONNECT : PRODUCT_EVENT.PROVIDER_DISCONNECT,
+          { connection_id: CONNECTION_COUNTED_AS[providerId] },
+        );
+      }
     },
     refusal: "Could not save that API key on this system.",
   });
+
+  /**
+   * Counts a setting that just moved, for a setting the schema says to count.
+   * The id travels and the shape of the new value does; the value itself never
+   * does, because several of these hold a project name or a chord the
+   * developer typed.
+   */
+  function recordSettingUpdate(field: AppSettingField, settings: AppSettings): void {
+    const analytics = settingAnalytics(field, settings);
+    if (!analytics) return;
+    recordProductEvent(PRODUCT_EVENT.SETTING_UPDATE, {
+      setting_id: analytics.id,
+      setting_value: analytics.value,
+    });
+  }
 
   async function applySettingSideEffect(
     field: AppSettingField,
@@ -150,6 +185,9 @@ export function registerSettingsRowsIpc(dependencies: SettingsRowsIpcDependencie
         refreshMeetingQuiet();
         releaseHeldNotices();
         break;
+      case SETTING_SIDE_EFFECT.USAGE_SHARING:
+        setUsageSharing(settings.shareUsageData);
+        break;
       case SETTING_SIDE_EFFECT.NONE:
         break;
     }
@@ -187,6 +225,7 @@ export function registerSettingsRowsIpc(dependencies: SettingsRowsIpcDependencie
     save: ({ field, value }) => settingsStore.set(field, value),
     async apply(result, { field, value }, event) {
       if (result.reason) return;
+      recordSettingUpdate(field, result.settings);
       await applySettingSideEffect(field, value, result.settings, event);
     },
     refusal: "Could not save that setting on this system.",
@@ -223,6 +262,7 @@ export function registerSettingsRowsIpc(dependencies: SettingsRowsIpcDependencie
       ),
     async apply(result, { field }, event) {
       if (result.reason) return;
+      recordSettingUpdate(field, result.settings);
       await applySettingSideEffect(field, result.settings[field], result.settings, event);
     },
     refusal: "Could not save that setting on this system.",

--- a/apps/desktop/src/ipc/tracker-connection.ts
+++ b/apps/desktop/src/ipc/tracker-connection.ts
@@ -1,3 +1,4 @@
+import { ISSUE_TRACKER_ID, PRODUCT_EVENT, type RecordProductEvent } from "@sidecar/core";
 import type { IpcMain, IpcMainEvent, IpcMainInvokeEvent } from "electron";
 import type { LinearCredentials } from "../linear-credentials";
 import type { LinearSignIn } from "../linear-oauth";
@@ -14,11 +15,20 @@ export interface TrackerConnectionIpcDependencies {
   credentials: LinearCredentials;
   signIn: LinearSignIn;
   refresh: () => void;
+  recordProductEvent: RecordProductEvent;
 }
 
 export function registerTrackerConnectionIpc(dependencies: TrackerConnectionIpcDependencies): void {
-  const { ipcMain, trustedSender, registerSetting, settingsStore, credentials, signIn, refresh } =
-    dependencies;
+  const {
+    ipcMain,
+    trustedSender,
+    registerSetting,
+    settingsStore,
+    credentials,
+    signIn,
+    refresh,
+    recordProductEvent,
+  } = dependencies;
   // The Linear sign-in runs whole inside `save`, exactly as the calendar's
   // does: the browser trip, the loopback redirect and the exchange all happen
   // in the main process, and the renderer's reply is the settings snapshot
@@ -38,7 +48,12 @@ export function registerTrackerConnectionIpc(dependencies: TrackerConnectionIpcD
     apply(result) {
       // The board is a minute stale at worst, but a row that just connected
       // and shows nothing reads as a connection that failed.
-      if (!result.reason) refresh();
+      if (!result.reason) {
+        refresh();
+        recordProductEvent(PRODUCT_EVENT.TRACKER_CONNECT, {
+          tracker_id: ISSUE_TRACKER_ID.LINEAR,
+        });
+      }
     },
     refusal: "Could not connect Linear on this system.",
   });

--- a/apps/desktop/src/ipc/voice-runtime.ts
+++ b/apps/desktop/src/ipc/voice-runtime.ts
@@ -1,4 +1,4 @@
-import type { UnparsedWireValue } from "@sidecar/core";
+import { PRODUCT_EVENT, type RecordProductEvent, type UnparsedWireValue } from "@sidecar/core";
 import type { IpcMain, IpcMainEvent, IpcMainInvokeEvent } from "electron";
 import type { HostedUsageReader } from "../hosted-usage";
 import type { PanelManager } from "../panel-manager";
@@ -9,6 +9,8 @@ import {
   CREDENTIAL_PROVIDERS,
   isCredentialProviderId,
 } from "../shared/credential-providers";
+import { VOICE_SOURCE_COUNTED_AS } from "../shared/product-vocabulary";
+import type { VoiceSource } from "../shared/settings-schema";
 
 export interface VoiceRuntimeIpcDependencies {
   ipcMain: Pick<IpcMain, "handle" | "on">;
@@ -18,6 +20,9 @@ export interface VoiceRuntimeIpcDependencies {
   realtimeCredentials: () => RealtimeCredentialMinter | undefined;
   unavailableDiagnostics: () => ReturnType<RealtimeCredentialMinter["diagnostics"]>;
   hostedUsageReader: () => HostedUsageReader | undefined;
+  /** Which credential the voice would run on, as the last applied policy decided. */
+  voiceSource: () => VoiceSource;
+  recordProductEvent: RecordProductEvent;
 }
 
 export function registerVoiceRuntimeIpc(dependencies: VoiceRuntimeIpcDependencies): void {
@@ -48,7 +53,14 @@ export function registerVoiceRuntimeIpc(dependencies: VoiceRuntimeIpcDependencie
   });
   ipcMain.handle(channels.requestRealtimeCredential, async (event) => {
     if (!trustedSender(event)) throw new Error("Untrusted renderer");
-    return dependencies.realtimeCredentials()?.mint();
+    const credential = await dependencies.realtimeCredentials()?.mint();
+    // A credential in hand is a call about to open; a refused mint is not one.
+    if (credential) {
+      dependencies.recordProductEvent(PRODUCT_EVENT.VOICE_CALL_START, {
+        credential_source: VOICE_SOURCE_COUNTED_AS[dependencies.voiceSource()],
+      });
+    }
+    return credential;
   });
   ipcMain.handle(channels.requestRealtimeDiagnostics, (event) => {
     if (!trustedSender(event)) throw new Error("Untrusted renderer");

--- a/apps/desktop/src/product-event-sender.ts
+++ b/apps/desktop/src/product-event-sender.ts
@@ -196,7 +196,14 @@ export class ProductEventSender {
     // Unlike the update check there is no flush here: letting the launch
     // events ride the first tick is what makes the first batch carry more
     // than one event.
-    this.#timer = setInterval(() => void this.flush(), this.#flushIntervalMs);
+    this.#timer = setInterval(() => {
+      // The day is marked on the tick rather than at launch alone, because a
+      // Luke left running crosses midnight without relaunching — which is the
+      // whole case this event exists for, and marking it only at launch would
+      // make it a second, worse copy of `app:launch`.
+      this.markDayActive();
+      void this.flush();
+    }, this.#flushIntervalMs);
     this.#timer.unref();
   }
 

--- a/apps/desktop/src/product-event-sender.ts
+++ b/apps/desktop/src/product-event-sender.ts
@@ -1,0 +1,264 @@
+import {
+  HOSTED_SERVICE_PATH,
+  PRODUCT_EVENT,
+  PRODUCT_EVENT_BATCH_LIMIT,
+  type ProductEvent,
+  type ProductEventName,
+  type ProductEventPropertiesFor,
+  positiveInteger,
+  productEventFromWire,
+  text,
+} from "@sidecar/core";
+
+const PRODUCT_EVENT_DEFAULTS = {
+  REQUEST_TIMEOUT_MS: 10_000,
+  /**
+   * A minute between flushes. Long enough that a launch, a sign-in, and a
+   * first observation ride one request rather than three; short enough that a
+   * quit loses at most a minute of counts.
+   */
+  FLUSH_INTERVAL_MS: 60_000,
+  /**
+   * How many events wait for a network at most. Past this the oldest go: a
+   * long stretch offline should keep recent behaviour, and the one event that
+   * would hurt to lose — the day marker — is recorded again the next day
+   * anyway.
+   */
+  QUEUE_LIMIT: 200,
+} as const;
+
+const UNAUTHORIZED_STATUS = 401;
+
+/** The one discriminator the day marker dedups on; the day itself is the key. */
+const DAY_ACTIVE_KEY = "day";
+
+type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
+
+export interface ProductEventSenderOptions {
+  /** The hosted service origin, without a trailing slash. */
+  serviceBaseUrl: string;
+  /** The running build's version, as the packaged app reports it. */
+  appVersion: string;
+  /** `runMode.sendsNetwork`. False makes every record a no-op. */
+  sends: boolean;
+  readAccessToken: () => Promise<string | undefined>;
+  refreshAccount: () => Promise<void>;
+  fetch?: FetchLike;
+  now?: () => number;
+  requestTimeoutMs?: number;
+  flushIntervalMs?: number;
+  queueLimit?: number;
+}
+
+function withoutTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+/**
+ * Counts how Luke's own features are used, and sends nothing else. The
+ * vocabulary is core's: every event is run through the same reader the service
+ * runs before it is even queued, so a bad emitter is dropped on this machine
+ * rather than becoming a refusal over the wire, and nothing observed can reach
+ * a property in the first place.
+ *
+ * The pipeline is lossy on purpose. Any outcome — accepted, refused,
+ * unreachable — drops the batch, and nothing is ever retried: counts undercount
+ * on a flaky network in exchange for never retry-storming Luke's own service
+ * and never double-counting a day. `stop()` drops the queue rather than
+ * flushing, because a request in `will-quit` either delays the quit or is
+ * killed mid-flight, and an instant quit is worth a minute of counts.
+ *
+ * No identity travels with an event. The service resolves the account from the
+ * bearer token this sender already holds for the voice and review endpoints,
+ * so there is nothing here to name a person with.
+ */
+export class ProductEventSender {
+  readonly #endpoint: string;
+  readonly #appVersion: string;
+  readonly #sends: boolean;
+  readonly #readAccessToken: () => Promise<string | undefined>;
+  readonly #refreshAccount: () => Promise<void>;
+  readonly #fetch: FetchLike;
+  readonly #now: () => number;
+  readonly #requestTimeoutMs: number;
+  readonly #flushIntervalMs: number;
+  readonly #queueLimit: number;
+  readonly #queue: ProductEvent[] = [];
+  /** Nested rather than an interpolated key: the name and the discriminator stay apart. */
+  readonly #recordedDays = new Map<ProductEventName, Map<string, string>>();
+  #sharing = false;
+  #sharingKnown = false;
+  #timer: NodeJS.Timeout | undefined;
+  #inFlight: Promise<void> | undefined;
+
+  constructor(options: ProductEventSenderOptions) {
+    const baseUrl = text(options.serviceBaseUrl);
+    if (!baseUrl) throw new Error("Hosted service base URL must not be empty");
+    this.#endpoint = `${withoutTrailingSlash(baseUrl)}${HOSTED_SERVICE_PATH.EVENTS}`;
+    this.#appVersion = options.appVersion;
+    this.#sends = options.sends;
+    this.#readAccessToken = options.readAccessToken;
+    this.#refreshAccount = options.refreshAccount;
+    this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
+    this.#now = options.now ?? Date.now;
+    this.#requestTimeoutMs = positiveInteger(
+      options.requestTimeoutMs,
+      PRODUCT_EVENT_DEFAULTS.REQUEST_TIMEOUT_MS,
+    );
+    this.#flushIntervalMs = positiveInteger(
+      options.flushIntervalMs,
+      PRODUCT_EVENT_DEFAULTS.FLUSH_INTERVAL_MS,
+    );
+    this.#queueLimit = positiveInteger(options.queueLimit, PRODUCT_EVENT_DEFAULTS.QUEUE_LIMIT);
+  }
+
+  /** The build's version, so an emitter never has to hold it to report it. */
+  get appVersion(): string {
+    return this.#appVersion;
+  }
+
+  /**
+   * Queues one event. Synchronous and never throws, so an emit site can sit
+   * on any path without ordering itself around it.
+   */
+  record<Name extends ProductEventName>(
+    name: Name,
+    properties: ProductEventPropertiesFor<Name>,
+  ): void {
+    if (!this.#allowed()) return;
+    const event = productEventFromWire({ name, at: this.#now(), properties });
+    if (!event) return;
+    this.#queue.push(event);
+    if (this.#queue.length > this.#queueLimit) {
+      this.#queue.splice(0, this.#queue.length - this.#queueLimit);
+    }
+  }
+
+  /**
+   * Marks today active, at most once per UTC day. Luke can run for a week on
+   * one launch, so launches alone would undercount the days he was used.
+   */
+  markDayActive(): void {
+    this.recordOncePerDay(PRODUCT_EVENT.APP_DAY_ACTIVE, DAY_ACTIVE_KEY, {
+      app_version: this.#appVersion,
+    });
+  }
+
+  /**
+   * Queues one event per discriminator per UTC day. Observation commits on
+   * every registry change, which would be a count of registry churn rather
+   * than of use; one per provider per day is the fact worth having.
+   */
+  recordOncePerDay<Name extends ProductEventName>(
+    name: Name,
+    discriminator: string,
+    properties: ProductEventPropertiesFor<Name>,
+  ): void {
+    if (!this.#allowed()) return;
+    const today = new Date(this.#now()).toISOString().slice(0, 10);
+    let recorded = this.#recordedDays.get(name);
+    if (!recorded) {
+      recorded = new Map();
+      this.#recordedDays.set(name, recorded);
+    }
+    if (recorded.get(discriminator) === today) return;
+    recorded.set(discriminator, today);
+    this.record(name, properties);
+  }
+
+  /**
+   * Arms or moves the switch. The first call is the settings file answering
+   * and records no transition — there is no change yet to count. A later turn
+   * to off records the stop *while sharing still stands* and flushes it: a
+   * stop recorded after the switch moved could never be sent, and the opt-out
+   * rate would be unmeasurable, visible only as people who stayed.
+   */
+  setSharing(enabled: boolean): void {
+    if (!this.#sharingKnown) {
+      this.#sharingKnown = true;
+      this.#sharing = enabled;
+      return;
+    }
+    if (this.#sharing === enabled) return;
+    if (enabled) {
+      this.#sharing = true;
+      this.record(PRODUCT_EVENT.USAGE_SHARING_RESUME, {});
+      return;
+    }
+    this.record(PRODUCT_EVENT.USAGE_SHARING_STOP, {});
+    this.#sharing = false;
+    void this.flush();
+  }
+
+  /** Starts the timed flush. The timer never holds the process open. */
+  start(): void {
+    if (this.#timer) return;
+    // Unlike the update check there is no flush here: letting the launch
+    // events ride the first tick is what makes the first batch carry more
+    // than one event.
+    this.#timer = setInterval(() => void this.flush(), this.#flushIntervalMs);
+    this.#timer.unref();
+  }
+
+  stop(): void {
+    if (this.#timer) clearInterval(this.#timer);
+    this.#timer = undefined;
+    this.#queue.length = 0;
+  }
+
+  /**
+   * Sends what is queued, at most one request at a time. Never throws: a
+   * failure is a count nobody has, which is the trade this whole pipeline
+   * makes.
+   */
+  flush(): Promise<void> {
+    this.#inFlight ??= this.#send().then(
+      () => {
+        this.#inFlight = undefined;
+      },
+      () => {
+        this.#inFlight = undefined;
+      },
+    );
+    return this.#inFlight;
+  }
+
+  #allowed(): boolean {
+    return this.#sends && this.#sharing;
+  }
+
+  async #send(): Promise<void> {
+    if (this.#queue.length === 0) return;
+    const token = await this.#readAccessToken();
+    // Signed out is temporary and nobody's fault, so the queue waits rather
+    // than being spent against a request that cannot authenticate.
+    if (!token) return;
+    // Taken only once a request will actually be made, and gone whatever
+    // becomes of it.
+    const events = this.#queue.splice(0, PRODUCT_EVENT_BATCH_LIMIT);
+    let response = await this.#post(token, events);
+    if (response?.status === UNAUTHORIZED_STATUS) {
+      await this.#refreshAccount().catch(() => undefined);
+      const refreshed = await this.#readAccessToken();
+      if (refreshed && refreshed !== token) {
+        response = await this.#post(refreshed, events);
+      }
+    }
+  }
+
+  async #post(token: string, events: readonly ProductEvent[]): Promise<Response | undefined> {
+    try {
+      return await this.#fetch(this.#endpoint, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ events }),
+        signal: AbortSignal.timeout(this.#requestTimeoutMs),
+      });
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -814,6 +814,14 @@ export function App(): React.JSX.Element {
     [applySettingsReply],
   );
 
+  const changeShareUsageData = useCallback(
+    async (enabled: boolean) =>
+      applySettingsReply(
+        await window.sidecar.updateSetting(APP_SETTING_SCHEMA.shareUsageData.field, enabled),
+      ),
+    [applySettingsReply],
+  );
+
   const changeVoiceSource = useCallback(
     async (source: VoiceSource) =>
       applySettingsReply(
@@ -2703,6 +2711,7 @@ export function App(): React.JSX.Element {
   const preferences: PreferenceWrites = {
     onVoiceCaptionsChange: changeVoiceCaptions,
     onDuckOtherMediaChange: changeDuckOtherMedia,
+    onShareUsageDataChange: changeShareUsageData,
     onVoiceSourceChange: changeVoiceSource,
     onPreferBuiltInMicrophoneChange: changePreferBuiltInMicrophone,
     onQuietDuringMeetingsChange: changeQuietDuringMeetings,

--- a/apps/desktop/src/renderer/feedback-panel.tsx
+++ b/apps/desktop/src/renderer/feedback-panel.tsx
@@ -42,7 +42,7 @@ function FeedbackOffer({
  */
 export function FeedbackSection({ control }: { control: FeedbackEntryControl }): React.JSX.Element {
   return (
-    <section className="settings-section" style={cssCustomProperties({ "--row-index": 4 })}>
+    <section className="settings-section" style={cssCustomProperties({ "--row-index": 5 })}>
       <h2>
         <MegaphoneIcon />
         Feedback

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -569,12 +569,11 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       detail:
         "Luke counts how his own features are used — a launch, a provider connected, sessions " +
         "observed, a call opened, an announcement spoken — and sends those counts to Luke's own " +
-        "service, tied to the signed-in account by name and email. Every event and every value " +
-        "is fixed by this build: nothing about a session — " +
-        "no title, branch, path, recap, or transcript — and nothing typed or spoken can travel " +
-        `in one, and nothing is sent while signed out. The switch is Share usage data, in the ` +
-        `Usage data section on ${FRONT_PAGE}; it is on to begin with, and turning it off stops ` +
-        "it at once.",
+        "service, tied to the signed-in account by name and email. Every event and value is " +
+        "fixed by this build, so nothing about a session — no title, branch, path, recap, or " +
+        "transcript — and nothing typed or spoken can travel in one. Nothing is sent while " +
+        `signed out. The switch is Share usage data, in the Usage data section on ${FRONT_PAGE}; ` +
+        "it is on to begin with, and turning it off stops it at once.",
     },
     {
       label: "Quitting",

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -70,7 +70,7 @@ const VOICE_SOURCE_SECTION = `${SETTINGS_TAB}, on its front page, in the What Lu
 const ACCOUNT_SECTION = `the Account section, at the foot of ${SETTINGS_TAB}'s front page`;
 const SHORTCUTS_PAGE = `${SETTINGS_TAB}, on its Keyboard shortcuts page`;
 const CONNECTIONS_PAGE = `${SETTINGS_TAB}, on its Connections page`;
-/* Where the Updates section stands, for the fact that describes it. */
+/* Where the Updates and Usage data sections stand, for the facts about them. */
 const FRONT_PAGE = `${SETTINGS_TAB}, on its front page`;
 
 /**
@@ -560,6 +560,20 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "the Settings tab wears a dot, the section stands at the top of that page, and its " +
         "button becomes Download. A newer release is fetched by hand in the browser, from the " +
         "fixed releases page: Luke never changes the running build himself.",
+    },
+    {
+      label: "Usage data",
+      // The behaviour rather than the switch: the setting entry describes the
+      // switch, and a Luke who could describe only that would be one who could
+      // not say what it governs.
+      detail:
+        "Luke counts how his own features are used — a launch, a provider connected, sessions " +
+        "observed, a call opened, an announcement spoken — and sends those counts to Luke's own " +
+        "service. Every event and every value is fixed by this build: nothing about a session — " +
+        "no title, branch, path, recap, or transcript — and nothing typed or spoken can travel " +
+        `in one, and nothing is sent while signed out. The switch is Share usage data, in the ` +
+        `Usage data section on ${FRONT_PAGE}; it is on to begin with, and turning it off stops ` +
+        "it at once.",
     },
     {
       label: "Quitting",

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -569,7 +569,8 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       detail:
         "Luke counts how his own features are used — a launch, a provider connected, sessions " +
         "observed, a call opened, an announcement spoken — and sends those counts to Luke's own " +
-        "service. Every event and every value is fixed by this build: nothing about a session — " +
+        "service, tied to the signed-in account by name and email. Every event and every value " +
+        "is fixed by this build: nothing about a session — " +
         "no title, branch, path, recap, or transcript — and nothing typed or spoken can travel " +
         `in one, and nothing is sent while signed out. The switch is Share usage data, in the ` +
         `Usage data section on ${FRONT_PAGE}; it is on to begin with, and turning it off stops ` +

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -3152,8 +3152,8 @@ function UsageDataSection({
              account, and the honest claim is the narrow one — a fixed list of
              events whose values this build chose, so nothing a session or a
              conversation contains has a shape to travel in. */
-          "Counts of Luke's own features — a launch, a provider connected, a call opened. " +
-          "Nothing about a session, and nothing you type or say."
+          "Counts of Luke's own features — a launch, a provider connected, a call opened — tied " +
+          "to your account. Nothing about a session, and nothing you type or say."
         }
         changed={settings.shareUsageData !== APP_SETTING_DEFAULTS.shareUsageData}
         checked={settings.shareUsageData}

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -3147,14 +3147,9 @@ function UsageDataSection({
         label="Share usage data"
         ariaLabel="Share counts of how Luke's own features are used"
         errand={APP_SETTING_ID.SHARE_USAGE_DATA}
-        detail={
-          /* What travels, not that it is anonymous: the counts are tied to the
-             account, and the honest claim is the narrow one — a fixed list of
-             events whose values this build chose, so nothing a session or a
-             conversation contains has a shape to travel in. */
-          "Counts of Luke's own features — a launch, a provider connected, a call opened — tied " +
-          "to your account. Nothing about a session, and nothing you type or say."
-        }
+        // Tied to the account rather than anonymous, because that is the
+        // honest claim and the narrow one is what the allowlist buys.
+        detail="Counts of feature use, tied to your account. Never session contents."
         changed={settings.shareUsageData !== APP_SETTING_DEFAULTS.shareUsageData}
         checked={settings.shareUsageData}
         onChange={preferences.onShareUsageDataChange}

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -190,6 +190,8 @@ export interface PreferenceWrites {
   onVoiceCaptionsChange: (enabled: boolean) => Promise<string | undefined>;
   /** Turns the quieting of Music and Spotify during a spoken exchange on or off. */
   onDuckOtherMediaChange: (enabled: boolean) => Promise<string | undefined>;
+  /** Turns the counting of Luke's own feature use on or off. */
+  onShareUsageDataChange: (enabled: boolean) => Promise<string | undefined>;
   /**
    * Chooses which credential Luke speaks and reviews sessions on. The store
    * answers with why when it refuses, and the toggle is where that answer
@@ -2870,8 +2872,7 @@ function AccountSection({
   };
 
   return (
-    // SAFETY: The preceding check establishes the asserted contract.
-    <section className="settings-section" style={{ "--row-index": 5 } as React.CSSProperties}>
+    <section className="settings-section" style={cssCustomProperties({ "--row-index": 6 })}>
       <h2>
         <UserIcon />
         Account
@@ -3122,6 +3123,46 @@ function UpdatesSection({
   );
 }
 
+/**
+ * The one thing Luke sends without being asked, and the switch for it. It sits
+ * beside Updates because both are always-on background behaviours rather than
+ * features with a page: the section is where the developer learns the counting
+ * happens at all, so the detail says what travels rather than only naming the
+ * switch.
+ */
+function UsageDataSection({
+  settings,
+  preferences,
+}: {
+  settings: AppSettings;
+  preferences: PreferenceWrites;
+}): React.JSX.Element {
+  return (
+    <section className="settings-section" style={cssCustomProperties({ "--row-index": 4 })}>
+      <h2>
+        <ShieldIcon />
+        Usage data
+      </h2>
+      <SwitchRow
+        label="Share usage data"
+        ariaLabel="Share counts of how Luke's own features are used"
+        errand={APP_SETTING_ID.SHARE_USAGE_DATA}
+        detail={
+          /* What travels, not that it is anonymous: the counts are tied to the
+             account, and the honest claim is the narrow one — a fixed list of
+             events whose values this build chose, so nothing a session or a
+             conversation contains has a shape to travel in. */
+          "Counts of Luke's own features — a launch, a provider connected, a call opened. " +
+          "Nothing about a session, and nothing you type or say."
+        }
+        changed={settings.shareUsageData !== APP_SETTING_DEFAULTS.shareUsageData}
+        checked={settings.shareUsageData}
+        onChange={preferences.onShareUsageDataChange}
+      />
+    </section>
+  );
+}
+
 export function SettingsPanel({
   account,
   onSignOut,
@@ -3198,8 +3239,8 @@ export function SettingsPanel({
       {view === SETTINGS_VIEW.ROOT ? (
         /* The front page: what voice runs on and what is left of it today,
            then one row per page, then the sections that answer at a glance —
-           what Luke is allowed, the way to the founders, whose account this
-           is, and the way out. The allowance leads because it is the one
+           what Luke is allowed, what he counts about his own use, the way to
+           the founders, whose account this is, and the way out. The allowance leads because it is the one
            thing here worth checking daily; the account itself follows the
            page down to the ways out, which are done once or never. A newer
            // SAFETY: The preceding check establishes the asserted contract.
@@ -3285,6 +3326,8 @@ export function SettingsPanel({
         <>
           {updateLeads ? null : <UpdatesSection control={updates} rowIndex={3} />}
 
+          {settings ? <UsageDataSection settings={settings} preferences={preferences} /> : null}
+
           <FeedbackSection control={feedback} />
 
           {/* The account and the two ways out of it, last of the sections:
@@ -3302,8 +3345,7 @@ export function SettingsPanel({
           <button
             type="button"
             className="quit-button"
-            // SAFETY: The preceding check establishes the asserted contract.
-            style={{ "--row-index": 6 } as React.CSSProperties}
+            style={cssCustomProperties({ "--row-index": 7 })}
             onClick={onQuit}
           >
             <PowerIcon />

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -572,6 +572,7 @@ export class SettingsStore {
       preferBuiltInMicrophone: persisted.preferBuiltInMicrophone,
       quietDuringMeetings: persisted.quietDuringMeetings,
       showOnAllDisplays: persisted.showOnAllDisplays,
+      shareUsageData: persisted.shareUsageData,
       formFactor: persisted.formFactor ?? DEFAULT_PANEL_FORM_FACTOR,
       ...(persisted.defaultWorkspaceProvider
         ? { defaultWorkspaceProvider: persisted.defaultWorkspaceProvider }

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -350,6 +350,15 @@ export interface AppSettings {
    */
   showOnAllDisplays: boolean;
   /**
+   * Whether Luke counts how his own features are used and sends those counts
+   * to his own service. On by default, and the only thing that ever leaves
+   * unbidden: every event name and every property value is fixed by the build,
+   * so nothing observed and nothing typed or spoken can travel in one. It is
+   * excluded from every reset scope, because a reset that turned it back on
+   * would be a consent nobody gave.
+   */
+  shareUsageData: boolean;
+  /**
    * How Luke stands on a display without a camera housing: a drawn notch
    * pressed into the top edge, or the free-floating bubble every such display
    * gets by default. A display with a real notch answers to neither.

--- a/apps/desktop/src/shared/product-vocabulary.ts
+++ b/apps/desktop/src/shared/product-vocabulary.ts
@@ -1,0 +1,31 @@
+import {
+  PRODUCT_CONNECTION_ID,
+  PRODUCT_CREDENTIAL_SOURCE,
+  type ProductConnectionId,
+  type ProductCredentialSource,
+} from "@sidecar/core";
+import { CREDENTIAL_PROVIDER_ID, type CredentialProviderId } from "./credential-providers";
+import { VOICE_SOURCE, type VoiceSource } from "./settings-schema";
+
+/**
+ * How the desktop's own value sets are said in the counting vocabulary. Each
+ * bridge is a total `Record`, which is the whole point: a new credential
+ * provider or a third voice source does not build until the analytics
+ * vocabulary in `@sidecar/core` has answered for it, rather than quietly
+ * arriving on the wire under a name nothing documents.
+ */
+
+export const CONNECTION_COUNTED_AS = {
+  [CREDENTIAL_PROVIDER_ID.CONDUCTOR]: PRODUCT_CONNECTION_ID.CONDUCTOR,
+  [CREDENTIAL_PROVIDER_ID.COPILOT]: PRODUCT_CONNECTION_ID.COPILOT,
+  [CREDENTIAL_PROVIDER_ID.CURSOR]: PRODUCT_CONNECTION_ID.CURSOR,
+  [CREDENTIAL_PROVIDER_ID.DEVIN]: PRODUCT_CONNECTION_ID.DEVIN,
+  [CREDENTIAL_PROVIDER_ID.JULES]: PRODUCT_CONNECTION_ID.JULES,
+  [CREDENTIAL_PROVIDER_ID.LINEAR]: PRODUCT_CONNECTION_ID.LINEAR,
+  [CREDENTIAL_PROVIDER_ID.OPENAI]: PRODUCT_CONNECTION_ID.OPENAI,
+} satisfies Record<CredentialProviderId, ProductConnectionId>;
+
+export const VOICE_SOURCE_COUNTED_AS = {
+  [VOICE_SOURCE.ACCOUNT]: PRODUCT_CREDENTIAL_SOURCE.ACCOUNT,
+  [VOICE_SOURCE.KEY]: PRODUCT_CREDENTIAL_SOURCE.KEY,
+} satisfies Record<VoiceSource, ProductCredentialSource>;

--- a/apps/desktop/src/shared/settings-schema.ts
+++ b/apps/desktop/src/shared/settings-schema.ts
@@ -570,10 +570,9 @@ export const APP_SETTING_SCHEMA = {
       label: "Share usage data",
       description:
         "Whether Luke counts how his own features are used — a launch, a provider connected, " +
-        "sessions observed, a call opened — and sends those counts to Luke's own service, tied " +
-        "to the signed-in account by name and email. Every event and every value is fixed by " +
-        "this build: nothing about a session, and nothing typed or spoken, can travel in one. " +
-        "On to begin with; off stops it at once.",
+        "a call opened — and sends those counts to Luke's own service, tied to the signed-in " +
+        "account by name and email. Every event and value is fixed by this build, so nothing " +
+        "about a session and nothing typed or spoken can travel in one. On to begin with.",
       kind: APP_SETTING_KIND.TOGGLE,
       value: appToggleText(settings.shareUsageData),
       // SAFETY: The preceding check establishes the asserted contract.

--- a/apps/desktop/src/shared/settings-schema.ts
+++ b/apps/desktop/src/shared/settings-schema.ts
@@ -570,9 +570,10 @@ export const APP_SETTING_SCHEMA = {
       label: "Share usage data",
       description:
         "Whether Luke counts how his own features are used — a launch, a provider connected, " +
-        "sessions observed, a call opened — and sends those counts to Luke's own service. " +
-        "Every event and every value is fixed by this build: nothing about a session, and " +
-        "nothing typed or spoken, can travel in one. On to begin with; off stops it at once.",
+        "sessions observed, a call opened — and sends those counts to Luke's own service, tied " +
+        "to the signed-in account by name and email. Every event and every value is fixed by " +
+        "this build: nothing about a session, and nothing typed or spoken, can travel in one. " +
+        "On to begin with; off stops it at once.",
       kind: APP_SETTING_KIND.TOGGLE,
       value: appToggleText(settings.shareUsageData),
       // SAFETY: The preceding check establishes the asserted contract.

--- a/apps/desktop/src/shared/settings-schema.ts
+++ b/apps/desktop/src/shared/settings-schema.ts
@@ -1,9 +1,12 @@
 import {
+  APP_SETTING_ID,
   APP_SETTING_KIND,
   APP_TOGGLE_VALUE,
   type AppGuideSetting,
+  type AppSettingId,
   appToggleText,
   DEFAULT_PANEL_FORM_FACTOR,
+  isAppSettingId,
   isPanelFormFactor,
   isProviderId,
   isRealtimeVoice,
@@ -12,7 +15,9 @@ import {
   isWireString,
   PANEL_FORM_FACTOR_LIST,
   type PanelFormFactor,
+  PRODUCT_SETTING_VALUE,
   PROVIDER_ID,
+  type ProductSettingValue,
   type ProviderId,
   REALTIME_DEFAULTS,
   REALTIME_VOICE_LIST,
@@ -36,24 +41,9 @@ import {
   workspaceAgentModels,
 } from "./workspace-agents";
 
-export const APP_SETTING_ID = {
-  VOICE: "voice",
-  VOICE_SPEED: "voice_speed",
-  VOICE_CAPTIONS: "voice_captions",
-  DUCK_OTHER_MEDIA: "duck_other_media",
-  PREFER_BUILT_IN_MICROPHONE: "prefer_built_in_microphone",
-  QUIET_DURING_MEETINGS: "quiet_during_meetings",
-  SHOW_IN_DOCK: "show_in_dock",
-  SHOW_ON_ALL_DISPLAYS: "show_on_all_displays",
-  FORM_FACTOR: "form_factor",
-  DEFAULT_WORKSPACE_PROVIDER: "default_workspace_provider",
-  WORKSPACE_AGENT_MODEL: "workspace_agent_model",
-  WORKSPACE_AGENT_EFFORT: "workspace_agent_effort",
-  SUPERSET_AGENT: "superset_agent",
-  VOICE_SOURCE: "voice_source",
-} as const;
-
-export type AppSettingId = (typeof APP_SETTING_ID)[keyof typeof APP_SETTING_ID];
+// The ids themselves live in core, because the product-event vocabulary names
+// the same set and may not depend on anything here.
+export { APP_SETTING_ID, type AppSettingId, isAppSettingId };
 
 export const VOICE_SOURCE = {
   ACCOUNT: "account",
@@ -98,6 +88,7 @@ export const SETTING_SIDE_EFFECT = {
   MEDIA_DUCK: "media-duck",
   VOICE_SOURCE: "voice-source",
   MEETING_QUIET: "meeting-quiet",
+  USAGE_SHARING: "usage-sharing",
 } as const;
 
 export type SettingSideEffect = (typeof SETTING_SIDE_EFFECT)[keyof typeof SETTING_SIDE_EFFECT];
@@ -115,6 +106,7 @@ export interface StoredAppSettings {
   preferBuiltInMicrophone: boolean;
   quietDuringMeetings: boolean;
   showOnAllDisplays: boolean;
+  shareUsageData: boolean;
   formFactor?: PanelFormFactor;
   defaultWorkspaceProvider?: WorkspaceProviderId;
   workspaceAgentDefaults?: Readonly<Partial<Record<ProviderId, WorkspaceAgentSelection>>>;
@@ -163,6 +155,16 @@ interface SettingDefinition<Field extends AppSettingField> {
   };
   mainProcessSideEffect: SettingSideEffect;
   spokenValue?: (value: string) => AppSettingValue<Field> | undefined;
+  /**
+   * How a change to this setting is counted, for a setting worth counting.
+   * The id travels; the value never does — only whether a switch went on or
+   * off, or whether a choice was made or returned to nothing, because several
+   * choices here hold a project name or a chord the developer typed.
+   */
+  analytics?: {
+    id: AppSettingId;
+    value(value: AppSettingValue<Field>): ProductSettingValue;
+  };
 }
 
 export type AppSettingGuideSettings = Omit<
@@ -178,6 +180,7 @@ export type AppSettingGuideSettings = Omit<
 const SETTINGS_TAB = "the panel's Settings tab";
 const VOICE_PAGE = `${SETTINGS_TAB}, on its Voice page`;
 const VOICE_SOURCE_SECTION = `${SETTINGS_TAB}, on its front page, in the What Luke runs on section at the top`;
+const USAGE_DATA_SECTION = `${SETTINGS_TAB}, on its front page, in the Usage data section`;
 const APPEARANCE_PAGE = `${SETTINGS_TAB}, on its Appearance page`;
 const CONNECTIONS_PAGE = `${SETTINGS_TAB}, on its Connections page`;
 const CONDUCTOR_ROW_PATH = `the Conductor row under Cloud Agent API keys, in ${CONNECTIONS_PAGE} — drawn once Conductor is connected`;
@@ -249,6 +252,15 @@ function optional<Value extends UnparsedWireValue>(
   return guard(value) ? valid(value) : invalid(undefined);
 }
 
+/** Any stored setting's value, which is what a counter is handed. */
+type StoredSettingValue = AppSettingValue<AppSettingField>;
+
+const toggleAnalytics = (value: StoredSettingValue): ProductSettingValue =>
+  value ? PRODUCT_SETTING_VALUE.ON : PRODUCT_SETTING_VALUE.OFF;
+
+const choiceAnalytics = (value: StoredSettingValue): ProductSettingValue =>
+  value === undefined ? PRODUCT_SETTING_VALUE.CLEARED : PRODUCT_SETTING_VALUE.SET;
+
 function boolean(defaultValue: boolean) {
   return (value: UnparsedWireValue): SettingGuardResult<boolean> =>
     value === true || value === false ? valid(value) : invalid(defaultValue);
@@ -319,6 +331,7 @@ export const APP_SETTING_SCHEMA = {
     })),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.DOCK,
     spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
+    analytics: { id: APP_SETTING_ID.SHOW_IN_DOCK, value: toggleAnalytics },
   },
   voice: {
     field: "voice",
@@ -341,6 +354,7 @@ export const APP_SETTING_SCHEMA = {
     })),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.VOICE,
     spokenValue: (value: string) => (isRealtimeVoice(value) ? value : undefined),
+    analytics: { id: APP_SETTING_ID.VOICE, value: choiceAnalytics },
   },
   voiceSpeed: {
     field: "voiceSpeed",
@@ -368,6 +382,7 @@ export const APP_SETTING_SCHEMA = {
     spokenValue: (value: string) => {
       return VOICE_SPEED_BY_SPOKEN_VALUE[value];
     },
+    analytics: { id: APP_SETTING_ID.VOICE_SPEED, value: choiceAnalytics },
   },
   voiceCaptions: {
     field: "voiceCaptions",
@@ -391,6 +406,7 @@ export const APP_SETTING_SCHEMA = {
     })),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.NONE,
     spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
+    analytics: { id: APP_SETTING_ID.VOICE_CAPTIONS, value: toggleAnalytics },
   },
   voiceHotkey: {
     field: "voiceHotkey",
@@ -442,6 +458,7 @@ export const APP_SETTING_SCHEMA = {
     })),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.MEDIA_DUCK,
     spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
+    analytics: { id: APP_SETTING_ID.DUCK_OTHER_MEDIA, value: toggleAnalytics },
   },
   voiceSource: {
     field: "voiceSource",
@@ -463,6 +480,7 @@ export const APP_SETTING_SCHEMA = {
       manual: VOICE_SOURCE_SECTION,
     })),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.VOICE_SOURCE,
+    analytics: { id: APP_SETTING_ID.VOICE_SOURCE, value: choiceAnalytics },
   },
   preferBuiltInMicrophone: {
     field: "preferBuiltInMicrophone",
@@ -489,6 +507,7 @@ export const APP_SETTING_SCHEMA = {
     ),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.NONE,
     spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
+    analytics: { id: APP_SETTING_ID.PREFER_BUILT_IN_MICROPHONE, value: toggleAnalytics },
   },
   quietDuringMeetings: {
     field: "quietDuringMeetings",
@@ -512,6 +531,7 @@ export const APP_SETTING_SCHEMA = {
     ),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.MEETING_QUIET,
     spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
+    analytics: { id: APP_SETTING_ID.QUIET_DURING_MEETINGS, value: toggleAnalytics },
   },
   showOnAllDisplays: {
     field: "showOnAllDisplays",
@@ -536,6 +556,33 @@ export const APP_SETTING_SCHEMA = {
     ),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.DISPLAYS,
     spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
+    analytics: { id: APP_SETTING_ID.SHOW_ON_ALL_DISPLAYS, value: toggleAnalytics },
+  },
+  shareUsageData: {
+    field: "shareUsageData",
+    default: true,
+    guard: boolean(true),
+    settingsPage: SETTINGS_PAGE.ROOT,
+    // No reset scope on purpose: a "reset appearance" that quietly turned
+    // sharing back on would be a consent the developer never gave.
+    guideEntry: settingGuideEntry([APP_SETTING_ID.SHARE_USAGE_DATA], (settings, defaultValue) => ({
+      id: APP_SETTING_ID.SHARE_USAGE_DATA,
+      label: "Share usage data",
+      description:
+        "Whether Luke counts how his own features are used — a launch, a provider connected, " +
+        "sessions observed, a call opened — and sends those counts to Luke's own service. " +
+        "Every event and every value is fixed by this build: nothing about a session, and " +
+        "nothing typed or spoken, can travel in one. On to begin with; off stops it at once.",
+      kind: APP_SETTING_KIND.TOGGLE,
+      value: appToggleText(settings.shareUsageData),
+      // SAFETY: The preceding check establishes the asserted contract.
+      defaultValue: appToggleText(defaultValue as boolean),
+      adjustable: true,
+      manual: USAGE_DATA_SECTION,
+    })),
+    mainProcessSideEffect: SETTING_SIDE_EFFECT.USAGE_SHARING,
+    spokenValue: (value: string) => value === APP_TOGGLE_VALUE.ON,
+    analytics: { id: APP_SETTING_ID.SHARE_USAGE_DATA, value: toggleAnalytics },
   },
   formFactor: {
     field: "formFactor",
@@ -558,6 +605,7 @@ export const APP_SETTING_SCHEMA = {
     })),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.FORM_FACTOR,
     spokenValue: (value: string) => (isPanelFormFactor(value) ? value : undefined),
+    analytics: { id: APP_SETTING_ID.FORM_FACTOR, value: choiceAnalytics },
   },
   defaultWorkspaceProvider: {
     field: "defaultWorkspaceProvider",
@@ -594,6 +642,7 @@ export const APP_SETTING_SCHEMA = {
       manual: `${CONNECTIONS_PAGE}, under Workspaces`,
     })),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.NONE,
+    analytics: { id: APP_SETTING_ID.DEFAULT_WORKSPACE_PROVIDER, value: choiceAnalytics },
   },
   workspaceAgentDefaults: {
     field: "workspaceAgentDefaults",
@@ -778,11 +827,6 @@ export function isSettingsResetScope(value: UnparsedWireValue): value is Setting
   return Object.values(SETTINGS_RESET_SCOPE).includes(value as SettingsResetScope);
 }
 
-export function isAppSettingId(value: string): value is AppSettingId {
-  // SAFETY: The preceding check establishes the asserted contract.
-  return Object.values(APP_SETTING_ID).includes(value as AppSettingId);
-}
-
 export function settingFieldForGuideId(id: AppSettingId): AppSettingField | undefined {
   return APP_SETTING_FIELDS.find((field) => APP_SETTING_SCHEMA[field].guideEntry.ids.includes(id));
 }
@@ -807,6 +851,31 @@ export function spokenSettingValue(
     | ((candidate: string) => StoredAppSettings[AppSettingField])
     | undefined;
   return convert?.(value);
+}
+
+/** What a counted setting change reports: which setting, and the shape of its new value. */
+export interface SettingAnalytics {
+  id: AppSettingId;
+  value: ProductSettingValue;
+}
+
+/**
+ * How a change to this field is counted, or nothing for a field the schema
+ * does not count. The value itself never travels — only whether a switch went
+ * on or off, or whether a choice was made or returned to nothing.
+ */
+export function settingAnalytics(
+  field: AppSettingField,
+  settings: Pick<StoredAppSettings, AppSettingField>,
+): SettingAnalytics | undefined {
+  const definition = APP_SETTING_SCHEMA[field];
+  if (!("analytics" in definition)) return undefined;
+  // SAFETY: analytics exists only on fields that declare it; the branch narrows the union.
+  const analytics = definition.analytics as {
+    id: AppSettingId;
+    value: (value: StoredSettingValue) => ProductSettingValue;
+  };
+  return { id: analytics.id, value: analytics.value(settings[field]) };
 }
 
 export const APP_SETTING_DEFAULTS = APP_SETTING_FIELDS.reduce(

--- a/apps/desktop/src/voice-capability-assembler.ts
+++ b/apps/desktop/src/voice-capability-assembler.ts
@@ -78,6 +78,7 @@ export class VoiceCapabilityAssembler {
   #realtimeCredentials: RealtimeCredentialMinter | undefined;
   #unavailableDiagnostics: RealtimeDiagnostics;
   #hostedUsageReader: HostedUsageReader | undefined;
+  #voiceSource: VoiceSource = VOICE_SOURCE.ACCOUNT;
 
   constructor(options: VoiceCapabilityAssemblerOptions) {
     this.#options = options;
@@ -101,6 +102,11 @@ export class VoiceCapabilityAssembler {
 
   get hostedUsageReader(): HostedUsageReader | undefined {
     return this.#hostedUsageReader;
+  }
+
+  /** Which credential the last applied policy settled on, for a count to name. */
+  get voiceSource(): VoiceSource {
+    return this.#voiceSource;
   }
 
   async apply(): Promise<void> {
@@ -152,6 +158,7 @@ export class VoiceCapabilityAssembler {
       apiKeyConfigured: apiKey !== undefined,
     });
     this.#hostedUsageReader = policy.useHosted ? new HostedUsageReader(seams) : undefined;
+    this.#voiceSource = policy.source;
     if (policy.useHosted) this.#warmHostedVoice();
     this.#report(apiKey !== undefined);
   }

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -732,7 +732,7 @@ test("the usage-data fact describes the counting, and names no session field", (
   // the switch lives is the only useful thing to say next.
   assert.match(fact.detail, /on to begin with/);
   assert.match(fact.detail, /Usage data section on the panel's Settings tab, on its front page/);
-  assert.match(fact.detail, /nothing is sent while signed out/);
+  assert.match(fact.detail, /[Nn]othing is sent while signed out/);
   // The guide leaves the machine, so a fact that claimed a session field
   // travelled would be describing a Luke that must not exist.
   assert.match(fact.detail, /no title, branch, path, recap, or transcript/);

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   APP_SETTING_KIND,
+  APP_TOGGLE_VALUE,
   type AppGuideSetting,
   PANEL_FORM_FACTOR,
   PROVIDER_ID,
@@ -721,6 +722,33 @@ test("the feedback fact says what a spoken open may do, and that sending stays b
   assert.match(fact.detail, /no spoken ask can send one/);
 });
 
+test("the usage-data fact describes the counting, and names no session field", () => {
+  const fact = buildLukeGuide(guideInput()).facts.find(
+    (candidate) => candidate.label === "Usage data",
+  );
+
+  assert.ok(fact);
+  // On by default is the fact a developer is owed without asking, and where
+  // the switch lives is the only useful thing to say next.
+  assert.match(fact.detail, /on to begin with/);
+  assert.match(fact.detail, /Usage data section on the panel's Settings tab, on its front page/);
+  assert.match(fact.detail, /nothing is sent while signed out/);
+  // The guide leaves the machine, so a fact that claimed a session field
+  // travelled would be describing a Luke that must not exist.
+  assert.match(fact.detail, /no title, branch, path, recap, or transcript/);
+});
+
+test("the usage-data switch is described where it is turned, and is spoken", () => {
+  const setting = buildLukeGuide(guideInput()).settings.find(
+    (candidate) => candidate.id === APP_SETTING_ID.SHARE_USAGE_DATA,
+  );
+
+  assert.ok(setting);
+  assert.equal(setting.adjustable, true);
+  assert.equal(setting.defaultValue, APP_TOGGLE_VALUE.ON);
+  assert.match(setting.manual, /front page, in the Usage data section/);
+});
+
 test("every adjustable setting is carried to the bridge call its row uses", async () => {
   const calls: string[] = [];
   const answered: SettingsUpdateResult = { settings: settings() };
@@ -754,6 +782,7 @@ test("every adjustable setting is carried to the bridge call its row uses", asyn
     "formFactor:notch",
     "preferBuiltInMicrophone:true",
     "quietDuringMeetings:true",
+    "shareUsageData:true",
     "showInDock:true",
     "showOnAllDisplays:true",
     "voice:alloy",

--- a/apps/desktop/tests/product-event-sender.test.ts
+++ b/apps/desktop/tests/product-event-sender.test.ts
@@ -1,0 +1,292 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  HOSTED_SERVICE_PATH,
+  PRODUCT_EVENT,
+  PRODUCT_SESSION_COUNT_BUCKET,
+  type ProductEvent,
+} from "@sidecar/core";
+import { ProductEventSender, type ProductEventSenderOptions } from "../src/product-event-sender";
+import { HTTP_STATUS, type RecordedRequest, recordingFetch } from "./support/http-fake";
+
+const BASE_URL = "https://luke.test";
+const ENDPOINT = `${BASE_URL}${HOSTED_SERVICE_PATH.EVENTS}`;
+const APP_VERSION = "0.2.0";
+const NOON = Date.parse("2026-08-19T12:00:00.000Z");
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function sentEvents(request: RecordedRequest): ProductEvent[] {
+  return JSON.parse(request.body ?? "{}").events;
+}
+
+function senderWith(
+  overrides: Partial<ProductEventSenderOptions> = {},
+  respond: (request: RecordedRequest) => Response = () => new Response("{}"),
+) {
+  const { fetch, requests } = recordingFetch(respond);
+  const sender = new ProductEventSender({
+    serviceBaseUrl: BASE_URL,
+    appVersion: APP_VERSION,
+    sends: true,
+    readAccessToken: async () => "token-1",
+    refreshAccount: async () => {},
+    fetch,
+    now: () => NOON,
+    ...overrides,
+  });
+  return { sender, requests };
+}
+
+/** The armed sender every test that is not about arming starts from. */
+function sharingSender(
+  overrides: Partial<ProductEventSenderOptions> = {},
+  respond?: (request: RecordedRequest) => Response,
+) {
+  const built = senderWith(overrides, respond);
+  built.sender.setSharing(true);
+  return built;
+}
+
+test("a run that sends no network queues nothing and asks for nothing", async () => {
+  const { sender, requests } = sharingSender({ sends: false });
+  sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
+  sender.markDayActive();
+  sender.record(PRODUCT_EVENT.ACCOUNT_SIGN_IN, {});
+  await sender.flush();
+  assert.deepEqual(requests, []);
+});
+
+test("nothing is queued before the settings file has answered", async () => {
+  const { sender, requests } = senderWith();
+  sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
+  await sender.flush();
+  assert.deepEqual(requests, []);
+});
+
+test("a flush posts one bearer-authenticated batch and empties the queue", async () => {
+  const { sender, requests } = sharingSender();
+  sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
+  sender.record(PRODUCT_EVENT.ACCOUNT_SIGN_IN, {});
+  await sender.flush();
+
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].url, ENDPOINT);
+  assert.equal(requests[0].method, "POST");
+  assert.equal(requests[0].authorization, "Bearer token-1");
+  assert.deepEqual(sentEvents(requests[0]), [
+    { name: PRODUCT_EVENT.APP_LAUNCH, at: NOON, properties: { app_version: APP_VERSION } },
+    { name: PRODUCT_EVENT.ACCOUNT_SIGN_IN, at: NOON, properties: {} },
+  ]);
+
+  await sender.flush();
+  assert.equal(requests.length, 1);
+});
+
+test("arming records no transition; turning it off records one stop and then goes quiet", async () => {
+  const { sender, requests } = senderWith();
+  sender.setSharing(true);
+  sender.setSharing(true);
+  await sender.flush();
+  assert.deepEqual(requests, []);
+
+  sender.setSharing(false);
+  await sender.flush();
+  assert.equal(requests.length, 1);
+  assert.deepEqual(sentEvents(requests[0]), [
+    { name: PRODUCT_EVENT.USAGE_SHARING_STOP, at: NOON, properties: {} },
+  ]);
+
+  sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
+  sender.markDayActive();
+  await sender.flush();
+  assert.equal(requests.length, 1);
+
+  sender.setSharing(true);
+  await sender.flush();
+  assert.equal(requests.length, 2);
+  assert.deepEqual(sentEvents(requests[1]), [
+    { name: PRODUCT_EVENT.USAGE_SHARING_RESUME, at: NOON, properties: {} },
+  ]);
+});
+
+test("a 401 refreshes and retries once, and the same token twice does not", async () => {
+  let token = "stale";
+  const { fetch, requests } = recordingFetch((request) =>
+    request.authorization === "Bearer fresh"
+      ? new Response("{}")
+      : new Response("{}", { status: HTTP_STATUS.UNAUTHORIZED }),
+  );
+  let refreshes = 0;
+  const sender = new ProductEventSender({
+    serviceBaseUrl: BASE_URL,
+    appVersion: APP_VERSION,
+    sends: true,
+    readAccessToken: async () => token,
+    refreshAccount: async () => {
+      refreshes += 1;
+      token = "fresh";
+    },
+    fetch,
+    now: () => NOON,
+  });
+  sender.setSharing(true);
+  sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
+  await sender.flush();
+
+  assert.equal(refreshes, 1);
+  assert.deepEqual(
+    requests.map((request) => request.authorization),
+    ["Bearer stale", "Bearer fresh"],
+  );
+
+  const stuck = senderWith(
+    { readAccessToken: async () => "same" },
+    () => new Response("{}", { status: HTTP_STATUS.UNAUTHORIZED }),
+  );
+  stuck.sender.setSharing(true);
+  stuck.sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
+  await stuck.sender.flush();
+  assert.equal(stuck.requests.length, 1);
+});
+
+test("a failed send drops its batch rather than retrying it behind the next one", async () => {
+  const { fetch, requests } = recordingFetch(() => {
+    throw new Error("network down");
+  });
+  const sender = new ProductEventSender({
+    serviceBaseUrl: BASE_URL,
+    appVersion: APP_VERSION,
+    sends: true,
+    readAccessToken: async () => "token-1",
+    refreshAccount: async () => {},
+    fetch,
+    now: () => NOON,
+  });
+  sender.setSharing(true);
+  sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
+  await sender.flush();
+  assert.equal(requests.length, 1);
+
+  sender.record(PRODUCT_EVENT.ACCOUNT_SIGN_IN, {});
+  await sender.flush().catch(() => assert.fail("a flush must never throw"));
+  assert.equal(requests.length, 2);
+  assert.deepEqual(sentEvents(requests[1]), [
+    { name: PRODUCT_EVENT.ACCOUNT_SIGN_IN, at: NOON, properties: {} },
+  ]);
+});
+
+test("signed out the queue waits rather than being spent", async () => {
+  let token: string | undefined;
+  const { fetch, requests } = recordingFetch(() => new Response("{}"));
+  const sender = new ProductEventSender({
+    serviceBaseUrl: BASE_URL,
+    appVersion: APP_VERSION,
+    sends: true,
+    readAccessToken: async () => token,
+    refreshAccount: async () => {},
+    fetch,
+    now: () => NOON,
+  });
+  sender.setSharing(true);
+  sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
+  await sender.flush();
+  assert.deepEqual(requests, []);
+
+  token = "token-1";
+  await sender.flush();
+  assert.equal(requests.length, 1);
+  assert.equal(sentEvents(requests[0]).length, 1);
+});
+
+test("past the queue limit the oldest go and the newest stay", async () => {
+  const { sender, requests } = sharingSender({ queueLimit: 3 });
+  for (const providerId of ["claude-code", "codex", "conductor", "cursor"] as const) {
+    sender.record(PRODUCT_EVENT.SESSION_ACT_SEND, {
+      provider_id: providerId,
+      session_act: "message_send",
+    });
+  }
+  await sender.flush();
+
+  assert.deepEqual(
+    sentEvents(requests[0]).map((event) => event.properties.provider_id),
+    ["codex", "conductor", "cursor"],
+  );
+});
+
+test("a batch past the wire limit is left for the next flush rather than refused", async () => {
+  const { sender, requests } = sharingSender();
+  for (let index = 0; index < 60; index += 1) {
+    sender.record(PRODUCT_EVENT.ACCOUNT_SIGN_IN, {});
+  }
+  await sender.flush();
+  assert.equal(sentEvents(requests[0]).length, 50);
+  await sender.flush();
+  assert.equal(sentEvents(requests[1]).length, 10);
+});
+
+test("the day marker records once a day, and again once the day has turned", async () => {
+  let now = NOON;
+  const { sender, requests } = sharingSender({ now: () => now });
+  sender.markDayActive();
+  sender.markDayActive();
+  now = NOON + 6 * 60 * 60 * 1000;
+  sender.markDayActive();
+  await sender.flush();
+  assert.equal(sentEvents(requests[0]).length, 1);
+
+  now = NOON + DAY_MS;
+  sender.markDayActive();
+  await sender.flush();
+  assert.deepEqual(sentEvents(requests[1]), [
+    {
+      name: PRODUCT_EVENT.APP_DAY_ACTIVE,
+      at: now,
+      properties: { app_version: APP_VERSION },
+    },
+  ]);
+});
+
+test("an observation is counted once per provider per day, in buckets", async () => {
+  const { sender, requests } = sharingSender();
+  for (const providerId of ["codex", "codex", "claude-code"] as const) {
+    sender.recordOncePerDay(PRODUCT_EVENT.SESSION_OBSERVE, providerId, {
+      provider_id: providerId,
+      session_count: PRODUCT_SESSION_COUNT_BUCKET.FEW,
+    });
+  }
+  await sender.flush();
+
+  assert.deepEqual(
+    sentEvents(requests[0]).map((event) => event.properties),
+    [
+      { provider_id: "codex", session_count: PRODUCT_SESSION_COUNT_BUCKET.FEW },
+      { provider_id: "claude-code", session_count: PRODUCT_SESSION_COUNT_BUCKET.FEW },
+    ],
+  );
+});
+
+test("a call site handing a value outside the allowlist queues nothing", async () => {
+  const { sender, requests } = sharingSender();
+  // SAFETY: the point of the test is the runtime guard, so the compile-time
+  // one is stepped around exactly as a mis-typed emitter would step around it.
+  const smuggler = sender as unknown as {
+    record(name: string, properties: Readonly<Record<string, string | number>>): void;
+  };
+  smuggler.record(PRODUCT_EVENT.SESSION_OBSERVE, {
+    provider_id: "codex — /Users/me/luke on feature/x",
+    session_count: 137,
+  });
+  smuggler.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: "/Users/me/luke" });
+  await sender.flush();
+  assert.deepEqual(requests, []);
+});
+
+test("stopping drops what was queued rather than holding the quit open", async () => {
+  const { sender, requests } = sharingSender();
+  sender.start();
+  sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
+  sender.stop();
+  await sender.flush();
+  assert.deepEqual(requests, []);
+});

--- a/apps/desktop/tests/product-event-sender.test.ts
+++ b/apps/desktop/tests/product-event-sender.test.ts
@@ -282,6 +282,33 @@ test("a call site handing a value outside the allowlist queues nothing", async (
   assert.deepEqual(requests, []);
 });
 
+test("a run left open marks each day it crosses, not only its launch day", async () => {
+  let now = NOON;
+  const { sender, requests } = sharingSender({ now: () => now, flushIntervalMs: 10 });
+  sender.markDayActive();
+  sender.start();
+
+  // Two ticks inside the launch day add nothing: the day is already marked.
+  await new Promise((resolve) => setTimeout(resolve, 35));
+  assert.equal(requests.length, 1);
+  assert.deepEqual(sentEvents(requests[0]).length, 1);
+
+  // The day turns while the app stays open, which is the case the marker
+  // exists for — without a tick it would be a second copy of app:launch.
+  now = NOON + DAY_MS;
+  await new Promise((resolve) => setTimeout(resolve, 35));
+  sender.stop();
+
+  const marked = requests.flatMap((request) =>
+    sentEvents(request).filter((event) => event.name === PRODUCT_EVENT.APP_DAY_ACTIVE),
+  );
+  assert.equal(marked.length, 2);
+  assert.deepEqual(
+    marked.map((event) => event.at),
+    [NOON, NOON + DAY_MS],
+  );
+});
+
 test("stopping drops what was queued rather than holding the quit open", async () => {
   const { sender, requests } = sharingSender();
   sender.start();

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -541,6 +541,40 @@ test("a corrupt meeting quiet value reads as the default rather than as off", as
   assert.equal((await storeIn(directory).snapshot()).quietDuringMeetings, true);
 });
 
+test("usage sharing is on in a file that never mentions it, and survives a round trip", async (t) => {
+  const directory = await temporaryDirectory(t);
+  // The one setting on by default that sends something, so a file written
+  // before it existed must read as on rather than as an absence.
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({ version: 2, apiKeys: {} }),
+    "utf8",
+  );
+
+  const store = storeIn(directory);
+  assert.equal((await store.snapshot()).shareUsageData, true);
+  assert.equal(await store.get(APP_SETTING_SCHEMA.shareUsageData.field), true);
+
+  const stopped = await store.set(APP_SETTING_SCHEMA.shareUsageData.field, false);
+  assert.equal(stopped.settings.shareUsageData, false);
+  assert.equal(await storeIn(directory).get(APP_SETTING_SCHEMA.shareUsageData.field), false);
+});
+
+test("no reset scope reaches usage sharing", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+  await store.set(APP_SETTING_SCHEMA.shareUsageData.field, false);
+
+  for (const scope of Object.values(SETTINGS_RESET_SCOPE)) {
+    await store.resetSettings(scope);
+    assert.equal(
+      (await store.snapshot()).shareUsageData,
+      false,
+      `${scope} must not restore data sharing`,
+    );
+  }
+});
+
 test("keeps each provider's key, environment fallback, and reported source separate", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory, {
@@ -596,6 +630,7 @@ test("keeps both keys when two providers are saved at once", async (t) => {
     duckOtherMedia: true,
     preferBuiltInMicrophone: true,
     quietDuringMeetings: true,
+    shareUsageData: true,
     showOnAllDisplays: false,
   });
   const reopened = storeIn(directory, { providers: TEST_PROVIDERS });
@@ -799,6 +834,7 @@ test("keeps a Conductor key stored by an earlier version working", async (t) => 
     duckOtherMedia: true,
     preferBuiltInMicrophone: true,
     quietDuringMeetings: true,
+    shareUsageData: true,
     showOnAllDisplays: false,
   });
   assert.equal(await storeIn(directory).readApiKey(CONDUCTOR), "conductor-replacement-key");
@@ -823,6 +859,7 @@ test("carries a key belonging to a provider this build does not know", async (t)
     duckOtherMedia: true,
     preferBuiltInMicrophone: true,
     quietDuringMeetings: true,
+    shareUsageData: true,
     showOnAllDisplays: false,
   });
 });
@@ -860,6 +897,7 @@ test("keeps Luke out of the Dock until asked, and remembers the answer", async (
     duckOtherMedia: true,
     preferBuiltInMicrophone: true,
     quietDuringMeetings: true,
+    shareUsageData: true,
     showOnAllDisplays: false,
   });
   // The choice outlives the run that heard it.

--- a/apps/web/api/account/delete.ts
+++ b/apps/web/api/account/delete.ts
@@ -2,18 +2,28 @@ import { eq } from "drizzle-orm";
 import { auth } from "../../server/auth.js";
 import { getDatabase } from "../../server/db/index.js";
 import { user } from "../../server/db/schema.js";
-import { handleAccountDelete } from "../../server/hosted/account-delete.js";
+import {
+  type AccountDeleteOptions,
+  handleAccountDelete,
+} from "../../server/hosted/account-delete.js";
 import { hostedUserId, oauthUserInfoFromAuthAnswer } from "../../server/hosted/bearer.js";
+import {
+  forgetPosthogPerson,
+  POSTHOG_ENVIRONMENT,
+  type PosthogForgetOptions,
+} from "../../server/hosted/posthog.js";
 
 /**
  * Erases the signed-in desktop's account. The logic lives in
  * `server/hosted/account-delete.ts`; this file only hands it the deployment's
  * real seams. Deleting the user row is the whole act — sessions, provider
- * accounts, OAuth grants, and usage counters all cascade with it.
+ * accounts, OAuth grants, and usage counters all cascade with it. A
+ * deployment configured to record product analytics also asks the processor to
+ * erase the person; one that is not simply has no such seam to run.
  */
 export default {
   fetch(request: Request): Promise<Response> {
-    return handleAccountDelete({
+    const options: AccountDeleteOptions = {
       request,
       resolveUserId: (incoming) =>
         hostedUserId(incoming, async (input) =>
@@ -22,6 +32,19 @@ export default {
       deleteUser: async (userId) => {
         await getDatabase().delete(user).where(eq(user.id, userId));
       },
-    });
+    };
+    // Without both halves of the analytics configuration there is no person to
+    // erase and nothing to erase it with, so the seam is simply absent.
+    const personalApiKey = process.env[POSTHOG_ENVIRONMENT.PERSONAL_API_KEY];
+    const projectId = process.env[POSTHOG_ENVIRONMENT.PROJECT_ID];
+    if (personalApiKey && projectId) {
+      const host = process.env[POSTHOG_ENVIRONMENT.API_HOST];
+      options.forgetAnalytics = (userId: string) => {
+        const forget: PosthogForgetOptions = { personalApiKey, projectId };
+        if (host) forget.host = host;
+        return forgetPosthogPerson(userId, forget);
+      };
+    }
+    return handleAccountDelete(options);
   },
 };

--- a/apps/web/api/events.ts
+++ b/apps/web/api/events.ts
@@ -1,0 +1,24 @@
+import { auth } from "../server/auth.js";
+import { hostedUserId } from "../server/hosted/bearer.js";
+import { type EventsOptions, handleEvents } from "../server/hosted/events.js";
+import { POSTHOG_ENVIRONMENT } from "../server/hosted/posthog.js";
+
+/**
+ * Records what the signed-in desktop counted about its own use. The logic
+ * lives in `server/hosted/events.ts`; this file only hands it the deployment's
+ * real seams — the project token the desktop never holds, and the same
+ * in-process token resolution every other hosted endpoint trusts.
+ */
+export default {
+  fetch(request: Request): Promise<Response> {
+    const options: EventsOptions = {
+      request,
+      projectApiKey: process.env[POSTHOG_ENVIRONMENT.PROJECT_API_KEY],
+      resolveUserId: (incoming) =>
+        hostedUserId(incoming, (input) => auth.api.oauth2UserInfo(input)),
+    };
+    const host = process.env[POSTHOG_ENVIRONMENT.HOST];
+    if (host) options.host = host;
+    return handleEvents(options);
+  },
+};

--- a/apps/web/api/events.ts
+++ b/apps/web/api/events.ts
@@ -1,4 +1,7 @@
+import { eq } from "drizzle-orm";
 import { auth } from "../server/auth.js";
+import { getDatabase } from "../server/db/index.js";
+import { user } from "../server/db/schema.js";
 import { hostedUserId } from "../server/hosted/bearer.js";
 import { type EventsOptions, handleEvents } from "../server/hosted/events.js";
 import { POSTHOG_ENVIRONMENT } from "../server/hosted/posthog.js";
@@ -16,6 +19,16 @@ export default {
       projectApiKey: process.env[POSTHOG_ENVIRONMENT.PROJECT_API_KEY],
       resolveUserId: (incoming) =>
         hostedUserId(incoming, (input) => auth.api.oauth2UserInfo(input)),
+      // Read from the service's own user row rather than from the request, so
+      // the desktop still sends nothing that names anybody.
+      readPerson: async (userId) => {
+        const rows = await getDatabase()
+          .select({ name: user.name, email: user.email })
+          .from(user)
+          .where(eq(user.id, userId))
+          .limit(1);
+        return rows[0];
+      },
     };
     const host = process.env[POSTHOG_ENVIRONMENT.HOST];
     if (host) options.host = host;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,6 +31,7 @@
     "drizzle-orm": "0.45.2",
     "marked": "18.0.9",
     "pg": "8.23.0",
+    "posthog-js": "1.418.3",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "tailwindcss": "4.3.3"

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -77,6 +77,32 @@ the `user` row is the entire act — sessions, provider accounts, OAuth grants,
 and usage counters all reference it with `onDelete: "cascade"`, so nothing of
 the account outlives the request.
 
+`api/events.ts` records what a signed-in desktop counted about its own use, on
+the same bearer resolution. The desktop never talks to the analytics processor:
+it posts an allowlisted batch here, and this is the one place a `distinct_id`
+is attached — from the resolved account, never from the body, which has no
+place to name one. `productEventBatchFromWire` in `@sidecar/core` is the whole
+admission policy, and it builds each event from that event's property
+allowlist, so nothing outside the vocabulary survives the read.
+
+It needs `POSTHOG_PROJECT_API_KEY`; without it the endpoint answers 503 and
+product analytics is simply off, which is the intended state for Preview
+deployments. `POSTHOG_HOST` optionally overrides the ingestion host.
+`POSTHOG_PERSONAL_API_KEY` and `POSTHOG_PROJECT_ID` are what let
+`api/account/delete.ts` ask PostHog to erase the person before the account row
+goes — a private endpoint, so it takes a personal key rather than the project
+token, and `POSTHOG_API_HOST` overrides *its* host, which is not the ingestion
+host. Without that pair the delete simply has no erasure seam to run. Every
+forwarded event carries `$geoip_disable`, without which an event arriving with
+no address resolves to the data centre's own location and the privacy claim in
+`PRIVACY.md` becomes false; the project's IP-capture setting should be set to
+discard as well, so the guarantee does not rest on one property in one file.
+
+The browser half of the funnel is separate and weaker: `VITE_POSTHOG_PROJECT_API_KEY`
+is a build-time variable that lets the site's own pages talk to PostHog
+directly, so PostHog sees a visitor's address there. A build without it never
+loads the library at all.
+
 Use is metered per user per UTC day in the Luke-owned `hosted_usage` table —
 one atomic upsert before each upstream call, checked against the ceilings in
 `server/hosted/quota.ts`. The ceilings bound how often calls open, not how

--- a/apps/web/server/hosted/account-delete.ts
+++ b/apps/web/server/hosted/account-delete.ts
@@ -7,6 +7,8 @@ import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } fro
  * caller sends can choose a different account. The delete itself is one seam —
  * the user row goes, and every dependent row (sessions, provider accounts,
  * OAuth grants, usage counters) cascades with it in the database's own schema.
+ * Where the deployment can, the analytics person is asked to be erased first,
+ * because nothing after the delete would still name it.
  */
 
 export interface AccountDeleteOptions {
@@ -14,6 +16,12 @@ export interface AccountDeleteOptions {
   resolveUserId: (request: Request) => Promise<string | undefined>;
   /** Deletes the user row; every dependent row cascades with it. */
   deleteUser: (userId: string) => Promise<void>;
+  /**
+   * Erases the analytics person for this account, where a deployment can.
+   * Omitted entirely without the environment for it, the same posture the
+   * recording endpoint takes when the deployment holds no key.
+   */
+  forgetAnalytics?: (userId: string) => Promise<void>;
 }
 
 export async function handleAccountDelete(options: AccountDeleteOptions): Promise<Response> {
@@ -28,6 +36,21 @@ export async function handleAccountDelete(options: AccountDeleteOptions): Promis
   const userId = await options.resolveUserId(request);
   if (!userId) {
     return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
+  }
+
+  // Asked before the row goes: once the user is deleted nothing names the
+  // person to retry with. A refusal or an outage there must not hold up the
+  // delete — the account is the user's to erase, and a third party's
+  // availability is not a condition of that — so it is logged as a status and
+  // the delete proceeds.
+  if (options.forgetAnalytics) {
+    try {
+      await options.forgetAnalytics(userId);
+    } catch (error) {
+      process.stderr.write(
+        `Analytics erasure did not complete: ${error instanceof Error ? error.message : "unknown error"}\n`,
+      );
+    }
   }
 
   await options.deleteUser(userId);

--- a/apps/web/server/hosted/events.ts
+++ b/apps/web/server/hosted/events.ts
@@ -1,0 +1,178 @@
+import {
+  type ProductEventBatch,
+  productEventBatchFromWire,
+  text as trimmedText,
+  type UnparsedWireValue,
+} from "../core.js";
+import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
+import {
+  type FetchLike,
+  type PosthogBatch,
+  type PosthogUpstreamOptions,
+  postPosthogBatch,
+} from "./posthog.js";
+
+/**
+ * Records what the signed-in desktop counted about its own use. The desktop
+ * never talks to the analytics processor: it posts an allowlisted batch here,
+ * and this endpoint is the one place an identity is attached to it — resolved
+ * from the same bearer token the voice and review endpoints trust, so the
+ * request body has no place to name an account and no way to name a different
+ * one.
+ *
+ * What the reader admits is the whole vocabulary: `productEventBatchFromWire`
+ * builds each event from the event's own property allowlist rather than from
+ * what arrived, so a `distinct_id`, an `$ip`, or a `$set` on the way in is not
+ * copied forward, and no property can hold free text.
+ */
+
+/** Bigger than a full batch of allowlisted events can be, and refused before parsing. */
+const MAXIMUM_BODY_BYTES = 16_384;
+
+/**
+ * A best-effort brake, keyed on the resolved account rather than the address:
+ * the token already names who is asking, so an account cannot rotate past it
+ * by changing networks. The counter lives in the function instance, which
+ * makes it a per-instance brake rather than a guarantee — platform-level rules
+ * are the real backstop — but it turns a looping desktop bug into a trickle.
+ */
+const RATE_LIMIT = {
+  WINDOW_MS: 60_000,
+  MAX_EVENTS_PER_WINDOW: 120,
+  /** The counter map is bounded; past this it forgets rather than grows. */
+  MAX_TRACKED_USERS: 10_000,
+} as const;
+
+/**
+ * How far back a desktop's own clock may place an event. A Mac set to the
+ * wrong year must not scatter counts across the timeline, so what arrives is
+ * clamped into this window ending at the reader's own clock — the same
+ * principle the review answer follows by stamping `decidedAt` here rather than
+ * trusting the sender.
+ */
+const MAXIMUM_EVENT_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+const recentUsers = new Map<string, { windowStart: number; count: number }>();
+
+function rateLimited(userId: string, events: number, now: number): boolean {
+  const held = recentUsers.get(userId);
+  if (!held || now - held.windowStart >= RATE_LIMIT.WINDOW_MS) {
+    if (recentUsers.size >= RATE_LIMIT.MAX_TRACKED_USERS) recentUsers.clear();
+    recentUsers.set(userId, { windowStart: now, count: events });
+    return events > RATE_LIMIT.MAX_EVENTS_PER_WINDOW;
+  }
+  held.count += events;
+  return held.count > RATE_LIMIT.MAX_EVENTS_PER_WINDOW;
+}
+
+export interface EventsOptions {
+  request: Request;
+  /** The analytics project token, from the deployment environment; absent means recording is off. */
+  projectApiKey: string | undefined;
+  /** A deployment-configured ingestion host; the shared default otherwise. */
+  host?: string;
+  resolveUserId: (request: Request) => Promise<string | undefined>;
+  fetch?: FetchLike;
+  now?: () => number;
+  timeoutMs?: number;
+}
+
+/**
+ * Builds the documented batch document. Three of its fields are the whole
+ * privacy posture, and each fails silently if got wrong: `distinct_id` sits
+ * inside an item's properties, where a top-level one is accepted and dropped;
+ * `$geoip_disable` is what keeps the processor from resolving an event with no
+ * address to the data centre's own location; and `historical_migration` stays
+ * false because this is live traffic rather than a backfill.
+ */
+function batchDocument(
+  events: ProductEventBatch,
+  projectApiKey: string,
+  userId: string,
+  now: number,
+): PosthogBatch {
+  return {
+    api_key: projectApiKey,
+    historical_migration: false,
+    batch: events.map((event) => ({
+      event: event.name,
+      timestamp: new Date(
+        Math.min(now, Math.max(event.at, now - MAXIMUM_EVENT_AGE_MS)),
+      ).toISOString(),
+      properties: {
+        ...event.properties,
+        distinct_id: userId,
+        $geoip_disable: true,
+        $lib: "luke-desktop",
+      },
+    })),
+  };
+}
+
+export async function handleEvents(options: EventsOptions): Promise<Response> {
+  const { request } = options;
+  if (request.method !== "POST") {
+    return errorResponse(
+      HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
+      HOSTED_API_ERROR.METHOD_NOT_ALLOWED,
+    );
+  }
+  // Trimmed like every other deployment key read: a whitespace token is the
+  // kill switch, not a key, and an unconfigured deployment is simply not
+  // measured — nothing else depends on this endpoint answering.
+  const projectApiKey = trimmedText(options.projectApiKey);
+  if (!projectApiKey) {
+    return errorResponse(HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE, HOSTED_API_ERROR.UNAVAILABLE);
+  }
+
+  const userId = await options.resolveUserId(request);
+  if (!userId) {
+    return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
+  }
+
+  const raw = await request.text().catch(() => undefined);
+  // Measured before parsing: an oversized body is refused rather than read.
+  if (raw === undefined || new TextEncoder().encode(raw).byteLength > MAXIMUM_BODY_BYTES) {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+  // SAFETY: JSON.parse returns a runtime value; the batch reader is the parser.
+  const wire = payload as UnparsedWireValue;
+  // The reader owns the batch limit as well as the vocabulary, and refuses an
+  // oversized batch whole rather than trimming it.
+  const events = productEventBatchFromWire(wire);
+  if (!events) {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
+  }
+
+  const now = (options.now ?? Date.now)();
+  if (rateLimited(userId, events.length, now)) {
+    return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
+  }
+
+  const upstream: PosthogUpstreamOptions = {};
+  if (options.host !== undefined) upstream.host = options.host;
+  if (options.fetch) upstream.fetch = options.fetch;
+  if (options.timeoutMs !== undefined) upstream.timeoutMs = options.timeoutMs;
+  const response = await postPosthogBatch(
+    batchDocument(events, projectApiKey, userId, now),
+    upstream,
+  );
+  if (!response) {
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_GATEWAY, HOSTED_API_ERROR.UPSTREAM_ERROR);
+  }
+  if (!response.ok) {
+    // Status alone diagnoses the upstream without carrying its body onward.
+    return errorResponse(HOSTED_HTTP_STATUS.BAD_GATEWAY, HOSTED_API_ERROR.UPSTREAM_ERROR, {
+      upstreamStatus: response.status,
+    });
+  }
+  // The desktop drops the batch whichever way this lands; the distinction is
+  // for the tests and alerts that watch this endpoint.
+  return jsonResponse(HOSTED_HTTP_STATUS.ACCEPTED, { accepted: events.length });
+}

--- a/apps/web/server/hosted/events.ts
+++ b/apps/web/server/hosted/events.ts
@@ -8,6 +8,8 @@ import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } fro
 import {
   type FetchLike,
   type PosthogBatch,
+  type PosthogBatchItem,
+  type PosthogPerson,
   type PosthogUpstreamOptions,
   postPosthogBatch,
 } from "./posthog.js";
@@ -72,6 +74,11 @@ export interface EventsOptions {
   /** A deployment-configured ingestion host; the shared default otherwise. */
   host?: string;
   resolveUserId: (request: Request) => Promise<string | undefined>;
+  /**
+   * The account's own name and address, for the person record. Omitted by a
+   * deployment that would rather PostHog held neither; the counts still land.
+   */
+  readPerson?: (userId: string) => Promise<PosthogPerson | undefined>;
   fetch?: FetchLike;
   now?: () => number;
   timeoutMs?: number;
@@ -84,28 +91,39 @@ export interface EventsOptions {
  * `$geoip_disable` is what keeps the processor from resolving an event with no
  * address to the data centre's own location; and `historical_migration` stays
  * false because this is live traffic rather than a backfill.
+ *
+ * The account's name and address ride as person properties rather than event
+ * properties, and only on the first item of a batch — `$set` names the person
+ * the events belong to, where an event property would put free text in the
+ * event stream the allowlist exists to keep it out of. They are read from the
+ * service's own user row: nothing identifying arrives from the desktop, and
+ * nothing a caller sends can name a different person.
  */
 function batchDocument(
   events: ProductEventBatch,
   projectApiKey: string,
   userId: string,
   now: number,
+  person: PosthogPerson | undefined,
 ): PosthogBatch {
   return {
     api_key: projectApiKey,
     historical_migration: false,
-    batch: events.map((event) => ({
-      event: event.name,
-      timestamp: new Date(
-        Math.min(now, Math.max(event.at, now - MAXIMUM_EVENT_AGE_MS)),
-      ).toISOString(),
-      properties: {
+    batch: events.map((event, index) => {
+      const properties = {
         ...event.properties,
         distinct_id: userId,
         $geoip_disable: true,
         $lib: "luke-desktop",
-      },
-    })),
+      };
+      return {
+        event: event.name,
+        timestamp: new Date(
+          Math.min(now, Math.max(event.at, now - MAXIMUM_EVENT_AGE_MS)),
+        ).toISOString(),
+        properties: index === 0 && person ? { ...properties, $set: person } : properties,
+      } satisfies PosthogBatchItem;
+    }),
   };
 }
 
@@ -159,8 +177,10 @@ export async function handleEvents(options: EventsOptions): Promise<Response> {
   if (options.host !== undefined) upstream.host = options.host;
   if (options.fetch) upstream.fetch = options.fetch;
   if (options.timeoutMs !== undefined) upstream.timeoutMs = options.timeoutMs;
+  // A failed read costs the person's name, never the counts.
+  const person = await options.readPerson?.(userId).catch(() => undefined);
   const response = await postPosthogBatch(
-    batchDocument(events, projectApiKey, userId, now),
+    batchDocument(events, projectApiKey, userId, now, person),
     upstream,
   );
   if (!response) {

--- a/apps/web/server/hosted/http.ts
+++ b/apps/web/server/hosted/http.ts
@@ -11,6 +11,7 @@ export { HOSTED_API_ERROR, type HostedApiError } from "../core.js";
 
 export const HOSTED_HTTP_STATUS = {
   OK: 200,
+  ACCEPTED: 202,
   BAD_REQUEST: 400,
   UNAUTHORIZED: 401,
   METHOD_NOT_ALLOWED: 405,

--- a/apps/web/server/hosted/posthog.ts
+++ b/apps/web/server/hosted/posthog.ts
@@ -34,11 +34,25 @@ export const POSTHOG_DEFAULTS = {
 
 export type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
 
+/**
+ * Who the account behind a batch is, as the person record should read. The
+ * service reads this from its own user row rather than taking it from the
+ * request, so the desktop still names nobody: these are the same fields the
+ * account itself already holds.
+ */
+export interface PosthogPerson {
+  name?: string;
+  email?: string;
+}
+
+/** Every kind of value one of this build's event properties may hold. */
+export type PosthogPropertyValue = string | number | boolean | PosthogPerson;
+
 /** One item of the documented batch document, as this build builds it. */
 export interface PosthogBatchItem {
   event: string;
   timestamp: string;
-  properties: Readonly<Record<string, string | number | boolean>>;
+  properties: Readonly<Record<string, PosthogPropertyValue>>;
 }
 
 /** The whole batch document, exactly as the capture endpoint documents it. */

--- a/apps/web/server/hosted/posthog.ts
+++ b/apps/web/server/hosted/posthog.ts
@@ -1,0 +1,113 @@
+/**
+ * How the recording endpoint reaches the analytics processor. The project key
+ * comes from the deployment's environment and never appears in a response, a
+ * log line, or an error; without one the endpoint answers 503 and product
+ * analytics is simply off, the same kill switch the voice endpoint uses for
+ * its OpenAI key.
+ *
+ * `fetch` rather than the vendor SDK on purpose. The SDK's value is queueing,
+ * retry, and a background flush, all built for a long-lived process; a
+ * serverless instance may freeze the moment it returns, so a background flush
+ * can be lost silently, and shutting the SDK down per request produces the
+ * same single POST minus a dependency to track. What is given up is automatic
+ * retry, which this pipeline does not want — the desktop never retries either.
+ */
+
+export const POSTHOG_ENVIRONMENT = {
+  PROJECT_API_KEY: "POSTHOG_PROJECT_API_KEY",
+  /** The ingestion host a batch is posted to. */
+  HOST: "POSTHOG_HOST",
+  /** The private API host deletion is asked of, which is not the ingestion host. */
+  API_HOST: "POSTHOG_API_HOST",
+  /** Deletion is a private endpoint, so it takes a personal key rather than the project token. */
+  PERSONAL_API_KEY: "POSTHOG_PERSONAL_API_KEY",
+  PROJECT_ID: "POSTHOG_PROJECT_ID",
+} as const;
+
+export const POSTHOG_DEFAULTS = {
+  HOST: "https://us.i.posthog.com",
+  /** The private API lives on the app host, not the ingestion host. */
+  API_HOST: "https://us.posthog.com",
+  BATCH_PATH: "/batch/",
+  REQUEST_TIMEOUT_MS: 5_000,
+} as const;
+
+export type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
+
+/** One item of the documented batch document, as this build builds it. */
+export interface PosthogBatchItem {
+  event: string;
+  timestamp: string;
+  properties: Readonly<Record<string, string | number | boolean>>;
+}
+
+/** The whole batch document, exactly as the capture endpoint documents it. */
+export interface PosthogBatch {
+  api_key: string;
+  historical_migration: boolean;
+  batch: readonly PosthogBatchItem[];
+}
+
+export interface PosthogUpstreamOptions {
+  host?: string;
+  fetch?: FetchLike;
+  timeoutMs?: number;
+}
+
+function withoutTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+/**
+ * Posts one batch document, resolving to nothing on a network fault so the
+ * caller answers 502 without ever holding an error that could name the key.
+ */
+export async function postPosthogBatch(
+  body: PosthogBatch,
+  options: PosthogUpstreamOptions = {},
+): Promise<Response | undefined> {
+  const send = options.fetch ?? ((input: string, init: RequestInit) => fetch(input, init));
+  const host = withoutTrailingSlash(options.host?.trim() || POSTHOG_DEFAULTS.HOST);
+  try {
+    return await send(`${host}${POSTHOG_DEFAULTS.BATCH_PATH}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(options.timeoutMs ?? POSTHOG_DEFAULTS.REQUEST_TIMEOUT_MS),
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+export interface PosthogForgetOptions extends PosthogUpstreamOptions {
+  personalApiKey: string;
+  projectId: string;
+}
+
+/**
+ * Asks the processor to erase the person behind one distinct id, and the
+ * events recorded against them. The documented bulk-delete endpoint takes the
+ * distinct ids in its body and `delete_events` in its query, and queues the
+ * event deletion rather than performing it — so a resolved promise means the
+ * erasure was accepted, never that it has already happened.
+ */
+export async function forgetPosthogPerson(
+  distinctId: string,
+  options: PosthogForgetOptions,
+): Promise<void> {
+  const send = options.fetch ?? ((input: string, init: RequestInit) => fetch(input, init));
+  const host = withoutTrailingSlash(options.host?.trim() || POSTHOG_DEFAULTS.API_HOST);
+  const url = `${host}/api/projects/${encodeURIComponent(options.projectId)}/persons/bulk_delete/?delete_events=true`;
+  const response = await send(url, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${options.personalApiKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ distinct_ids: [distinctId] }),
+    signal: AbortSignal.timeout(options.timeoutMs ?? POSTHOG_DEFAULTS.REQUEST_TIMEOUT_MS),
+  });
+  // The status alone diagnoses the refusal; the body could name the key.
+  if (!response.ok) throw new Error(`Analytics erasure refused with status ${response.status}`);
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,3 +1,4 @@
+import { captureSiteEvent, SITE_EVENT } from "./analytics";
 import { NotchMock } from "./NotchMock";
 import { DMG_URL, GitHubMark, REPOSITORY_URL, SiteFooter, SiteHeader } from "./SiteChrome";
 
@@ -25,6 +26,7 @@ export function App(): React.JSX.Element {
             <a
               className="inline-flex items-center gap-2 rounded-md bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground no-underline transition-[filter,transform] duration-150 hover:brightness-95 active:translate-y-px motion-reduce:transition-none"
               href={DMG_URL}
+              onClick={() => captureSiteEvent(SITE_EVENT.DOWNLOAD_PRESS)}
             >
               Download for macOS
             </a>

--- a/apps/web/src/analytics.ts
+++ b/apps/web/src/analytics.ts
@@ -1,0 +1,92 @@
+import type { PostHog } from "posthog-js";
+
+/**
+ * What tryluke.dev counts about itself. It exists to close the funnel the
+ * desktop opens: without the landing page and the sign-in, install-to-first-
+ * session drop-off is only visible from the point someone already has an
+ * account.
+ *
+ * This half has a weaker privacy posture than the app's and must be described
+ * as such. The browser talks to the analytics processor directly, so the
+ * processor sees the visitor's address and user agent — where the desktop's
+ * events reach it through Luke's own service with location resolution
+ * switched off. Do not let the app's stronger claim bleed onto the site.
+ *
+ * The options below are the posture in configuration form rather than
+ * defaults worth reading past: autocapture would collect the text and
+ * attributes of whatever was clicked, and recording would collect the page
+ * itself.
+ */
+
+const PROJECT_API_KEY = import.meta.env.VITE_POSTHOG_PROJECT_API_KEY;
+const HOST = import.meta.env.VITE_POSTHOG_HOST ?? "https://us.i.posthog.com";
+
+export const SITE_EVENT = {
+  DOWNLOAD_PRESS: "site:download_press",
+  SIGN_IN_START: "site:sign_in_start",
+  SIGN_IN_COMPLETE: "site:sign_in_complete",
+} as const;
+
+export type SiteEvent = (typeof SITE_EVENT)[keyof typeof SITE_EVENT];
+
+/**
+ * The client, once it has loaded. It is imported dynamically rather than at
+ * the top of this module because the library is larger than everything else
+ * the site ships put together: a static import would land it in the shared
+ * chunk, so every page — the privacy document included — would block on it.
+ * Deferring also makes the kill switch literal, since a build with no key
+ * never fetches the chunk at all.
+ */
+let client: Promise<PostHog | undefined> | undefined;
+
+/**
+ * Starts counting, or does nothing at all. A build carrying no project key is
+ * inert rather than broken — the same kill switch the recording endpoint has,
+ * so a preview deployment or a local run measures nothing without being
+ * configured to.
+ */
+export function startSiteAnalytics(): void {
+  const projectApiKey = PROJECT_API_KEY;
+  if (client || !projectApiKey) return;
+  client = import("posthog-js").then(({ default: posthog }) => {
+    posthog.init(projectApiKey, {
+      api_host: HOST,
+      // The DOM text and attributes of whatever was clicked; never collected.
+      autocapture: false,
+      disable_session_recording: true,
+      capture_pageview: true,
+      capture_pageleave: false,
+      // Visitors stay personless until they sign in, which is both cheaper
+      // and the honest shape: an anonymous visitor is not a person Luke
+      // knows. The identify at consent is what links their earlier page views
+      // to the account, so no aliasing is needed.
+      person_profiles: "identified_only",
+      mask_all_text: true,
+      mask_all_element_attributes: true,
+    });
+    return posthog;
+  });
+}
+
+/**
+ * Runs one call against the client, whenever it arrives. A press landing
+ * before the chunk does still counts, because it queues behind the load; a
+ * chunk that never arrives costs nothing but the count.
+ */
+function withClient(use: (posthog: PostHog) => void): void {
+  void client?.then((posthog) => posthog && use(posthog)).catch(() => undefined);
+}
+
+/**
+ * Names the visitor by the account they just created, and nothing else. The id
+ * is the same opaque database id the desktop's events resolve to, so the two
+ * halves of the funnel join; no email, name, or provider travels with it,
+ * because a person record should be an id and not an identity.
+ */
+export function identifySiteVisitor(userId: string): void {
+  withClient((posthog) => posthog.identify(userId));
+}
+
+export function captureSiteEvent(event: SiteEvent): void {
+  withClient((posthog) => posthog.capture(event));
+}

--- a/apps/web/src/analytics.ts
+++ b/apps/web/src/analytics.ts
@@ -77,14 +77,21 @@ function withClient(use: (posthog: PostHog) => void): void {
   void client?.then((posthog) => posthog && use(posthog)).catch(() => undefined);
 }
 
+/** What the person record holds beyond the id it is keyed by. */
+export interface SiteVisitor {
+  name?: string;
+  email?: string;
+}
+
 /**
- * Names the visitor by the account they just created, and nothing else. The id
- * is the same opaque database id the desktop's events resolve to, so the two
- * halves of the funnel join; no email, name, or provider travels with it,
- * because a person record should be an id and not an identity.
+ * Names the visitor by the account they just created. The id is the same
+ * opaque database id the desktop's events resolve to, which is what joins the
+ * two halves of the funnel; the name and address ride as person properties,
+ * the same two fields the account itself holds and the service attaches to
+ * desktop events.
  */
-export function identifySiteVisitor(userId: string): void {
-  withClient((posthog) => posthog.identify(userId));
+export function identifySiteVisitor(userId: string, visitor: SiteVisitor = {}): void {
+  withClient((posthog) => posthog.identify(userId, visitor));
 }
 
 export function captureSiteEvent(event: SiteEvent): void {

--- a/apps/web/src/changelog.tsx
+++ b/apps/web/src/changelog.tsx
@@ -1,7 +1,12 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { startSiteAnalytics } from "./analytics";
 import { ChangelogPage } from "./ChangelogPage";
 import "./styles.css";
+
+// Every page the site builds, not only the landing one: a funnel that saw
+// the landing page alone would undercount everyone who arrived by a link.
+startSiteAnalytics();
 
 const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Root element is missing");

--- a/apps/web/src/consent.tsx
+++ b/apps/web/src/consent.tsx
@@ -20,10 +20,11 @@ function Consent(): React.JSX.Element {
       // Where the two halves of the funnel join. The desktop's counts resolve
       // to the same account id from the bearer token, so naming the visitor by
       // it here links the page views they arrived through to the account they
-      // just made. The id alone travels: no email, no name, no provider.
-      const session = await authClient.getSession();
-      const userId = session.data?.user.id;
-      if (userId) identifySiteVisitor(userId);
+      // just made.
+      const account = (await authClient.getSession()).data?.user;
+      if (account) {
+        identifySiteVisitor(account.id, { name: account.name, email: account.email });
+      }
       captureSiteEvent(SITE_EVENT.SIGN_IN_COMPLETE);
     });
   }, []);

--- a/apps/web/src/consent.tsx
+++ b/apps/web/src/consent.tsx
@@ -2,6 +2,7 @@ import { oauthProviderClient } from "@better-auth/oauth-provider/client";
 import { createAuthClient } from "better-auth/react";
 import { StrictMode, useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
+import { captureSiteEvent, identifySiteVisitor, SITE_EVENT, startSiteAnalytics } from "./analytics";
 import { AUTH_CARD, AUTH_PILL, AUTH_SHELL, AUTH_TITLE } from "./auth-surface";
 import { LukeMark } from "./SiteChrome";
 import "./styles.css";
@@ -11,8 +12,19 @@ const authClient = createAuthClient({ plugins: [oauthProviderClient()] });
 function Consent(): React.JSX.Element {
   const [failure, setFailure] = useState(false);
   useEffect(() => {
-    void authClient.oauth2.consent({ accept: true }).then((result) => {
-      if (result.error) setFailure(true);
+    void authClient.oauth2.consent({ accept: true }).then(async (result) => {
+      if (result.error) {
+        setFailure(true);
+        return;
+      }
+      // Where the two halves of the funnel join. The desktop's counts resolve
+      // to the same account id from the bearer token, so naming the visitor by
+      // it here links the page views they arrived through to the account they
+      // just made. The id alone travels: no email, no name, no provider.
+      const session = await authClient.getSession();
+      const userId = session.data?.user.id;
+      if (userId) identifySiteVisitor(userId);
+      captureSiteEvent(SITE_EVENT.SIGN_IN_COMPLETE);
     });
   }, []);
   return (
@@ -41,6 +53,8 @@ function Consent(): React.JSX.Element {
     </main>
   );
 }
+
+startSiteAnalytics();
 
 const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Root element is missing");

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,7 +1,12 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import { startSiteAnalytics } from "./analytics";
 import "./styles.css";
+
+// Every page the site builds, not only the landing one: a funnel that saw
+// the landing page alone would undercount everyone who arrived by a link.
+startSiteAnalytics();
 
 const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Root element is missing");

--- a/apps/web/src/privacy.tsx
+++ b/apps/web/src/privacy.tsx
@@ -1,7 +1,12 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { startSiteAnalytics } from "./analytics";
 import { PrivacyPage } from "./PrivacyPage";
 import "./styles.css";
+
+// Every page the site builds, not only the landing one: a funnel that saw
+// the landing page alone would undercount everyone who arrived by a link.
+startSiteAnalytics();
 
 const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Root element is missing");

--- a/apps/web/src/sign-in.tsx
+++ b/apps/web/src/sign-in.tsx
@@ -2,6 +2,7 @@ import { oauthProviderClient } from "@better-auth/oauth-provider/client";
 import { createAuthClient } from "better-auth/react";
 import { StrictMode, useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
+import { captureSiteEvent, SITE_EVENT, startSiteAnalytics } from "./analytics";
 import { AUTH_BUTTON, AUTH_CARD, AUTH_SHELL, AUTH_TITLE } from "./auth-surface";
 import { LukeMark } from "./SiteChrome";
 import {
@@ -30,6 +31,7 @@ function SignIn(): React.JSX.Element {
     if (!provider || startedFromHint.current) return;
     startedFromHint.current = true;
     setPending(provider);
+    captureSiteEvent(SITE_EVENT.SIGN_IN_START);
     void authClient.signIn.social({ provider }).then((result) => {
       if (!result.error) return;
       setPending(undefined);
@@ -41,6 +43,7 @@ function SignIn(): React.JSX.Element {
     if (!provider || pending) return;
     setPending(provider);
     setFailure(undefined);
+    captureSiteEvent(SITE_EVENT.SIGN_IN_START);
     const result = await authClient.signIn.social({ provider });
     if (result.error) {
       setPending(undefined);
@@ -87,6 +90,8 @@ function SignIn(): React.JSX.Element {
     </main>
   );
 }
+
+startSiteAnalytics();
 
 const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Root element is missing");

--- a/apps/web/tests/hosted-account-delete.test.ts
+++ b/apps/web/tests/hosted-account-delete.test.ts
@@ -64,3 +64,38 @@ test("only POST reaches the resolver, and no token deletes nothing", async () =>
   assert.equal((await anonymous.json()).error, HOSTED_API_ERROR.INVALID_TOKEN);
   assert.equal(deleted, 0);
 });
+
+test("the analytics person is erased before the row that names them goes", async () => {
+  const order: string[] = [];
+  const response = await handleAccountDelete(
+    options({
+      forgetAnalytics: async (userId) => {
+        order.push(`forget:${userId}`);
+      },
+      deleteUser: async (userId) => {
+        order.push(`delete:${userId}`);
+      },
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(order, ["forget:user-1", "delete:user-1"]);
+});
+
+test("a processor that refuses erasure still deletes the account and answers 200", async () => {
+  let deleted = 0;
+  const response = await handleAccountDelete(
+    options({
+      forgetAnalytics: async () => {
+        throw new Error("processor unreachable");
+      },
+      deleteUser: async () => {
+        deleted += 1;
+      },
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { deleted: true });
+  assert.equal(deleted, 1);
+});

--- a/apps/web/tests/hosted-events.test.ts
+++ b/apps/web/tests/hosted-events.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 import { PRODUCT_EVENT, PRODUCT_EVENT_BATCH_LIMIT, type WireValue } from "../server/core.js";
 import { type EventsOptions, handleEvents } from "../server/hosted/events";
 import { HOSTED_API_ERROR } from "../server/hosted/http";
-import type { PosthogBatch } from "../server/hosted/posthog";
+import type { PosthogBatch, PosthogBatchItem } from "../server/hosted/posthog";
 
 const NOW = Date.parse("2026-08-19T12:00:00.000Z");
 const PROJECT_KEY = "phc_project";
@@ -14,13 +14,7 @@ const LAUNCH = {
   properties: { app_version: "0.2.0" },
 };
 
-type PropertyValue = string | number | boolean | undefined;
-
-interface BatchItem {
-  event: string;
-  timestamp: string;
-  properties: Readonly<Record<string, PropertyValue>>;
-}
+type BatchItem = PosthogBatchItem;
 
 interface Forwarded {
   url: string;
@@ -238,6 +232,69 @@ test("the forwarded document matches the processor's documented batch shape", as
   assert.equal(item.properties.$geoip_disable, true);
   assert.equal(item.timestamp, new Date(LAUNCH.at).toISOString());
   assert.match(item.timestamp, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+});
+
+test("the account's name and address ride as person properties, once per batch", async () => {
+  const posthog = upstream();
+  await handleEvents(
+    options({
+      request: eventsRequest({ events: [LAUNCH, LAUNCH] }),
+      readPerson: async () => ({ name: "Ada", email: "ada@example.test" }),
+      fetch: posthog.fetch,
+      resolveUserId: freshUser(),
+    }),
+  );
+
+  const { items } = onlyBatch(posthog.forwarded);
+  // `$set` names the person; a second copy on every item would say the same
+  // thing again for nothing.
+  assert.deepEqual(itemAt(items, 0).properties.$set, {
+    name: "Ada",
+    email: "ada@example.test",
+  });
+  assert.equal(itemAt(items, 1).properties.$set, undefined);
+  // Never an event property: the event stream is what the allowlist guards.
+  assert.equal(itemAt(items, 0).properties.name, undefined);
+  assert.equal(itemAt(items, 0).properties.email, undefined);
+});
+
+test("a deployment that reads no person, or fails to, still records the counts", async () => {
+  const withoutSeam = upstream();
+  const anonymous = await handleEvents(
+    options({ fetch: withoutSeam.fetch, resolveUserId: freshUser() }),
+  );
+  assert.equal(anonymous.status, 202);
+  assert.equal(itemAt(onlyBatch(withoutSeam.forwarded).items, 0).properties.$set, undefined);
+
+  const failing = upstream();
+  const survived = await handleEvents(
+    options({
+      readPerson: async () => {
+        throw new Error("database unreachable");
+      },
+      fetch: failing.fetch,
+      resolveUserId: freshUser(),
+    }),
+  );
+  assert.equal(survived.status, 202);
+  assert.equal(itemAt(onlyBatch(failing.forwarded).items, 0).properties.$set, undefined);
+});
+
+test("nothing the request body says can name the person", async () => {
+  const posthog = upstream();
+  await handleEvents(
+    options({
+      request: eventsRequest({
+        events: [{ ...LAUNCH, properties: { app_version: "0.2.0", $set: { email: "them@evil" } } }],
+      }),
+      readPerson: async () => ({ name: "Ada", email: "ada@example.test" }),
+      fetch: posthog.fetch,
+      resolveUserId: freshUser(),
+    }),
+  );
+
+  const item = itemAt(onlyBatch(posthog.forwarded).items, 0);
+  assert.deepEqual(item.properties.$set, { name: "Ada", email: "ada@example.test" });
 });
 
 test("a wrong desktop clock is clamped to the reader's own window", async () => {

--- a/apps/web/tests/hosted-events.test.ts
+++ b/apps/web/tests/hosted-events.test.ts
@@ -1,0 +1,315 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { PRODUCT_EVENT, PRODUCT_EVENT_BATCH_LIMIT, type WireValue } from "../server/core.js";
+import { type EventsOptions, handleEvents } from "../server/hosted/events";
+import { HOSTED_API_ERROR } from "../server/hosted/http";
+import type { PosthogBatch } from "../server/hosted/posthog";
+
+const NOW = Date.parse("2026-08-19T12:00:00.000Z");
+const PROJECT_KEY = "phc_project";
+
+const LAUNCH = {
+  name: PRODUCT_EVENT.APP_LAUNCH,
+  at: NOW - 30_000,
+  properties: { app_version: "0.2.0" },
+};
+
+type PropertyValue = string | number | boolean | undefined;
+
+interface BatchItem {
+  event: string;
+  timestamp: string;
+  properties: Readonly<Record<string, PropertyValue>>;
+}
+
+interface Forwarded {
+  url: string;
+  body: PosthogBatch;
+}
+
+interface OnlyBatch {
+  request: Forwarded;
+  items: readonly BatchItem[];
+}
+
+/** The one forwarded request, with its batch already narrowed. */
+function onlyBatch(forwarded: readonly Forwarded[]): OnlyBatch {
+  assert.equal(forwarded.length, 1);
+  const request = forwarded[0];
+  assert.ok(request);
+  return { request, items: request.body.batch };
+}
+
+function itemAt(items: readonly BatchItem[], index: number): BatchItem {
+  const item = items[index];
+  assert.ok(item, `batch item ${index} is missing`);
+  return item;
+}
+
+function upstream(status = 200) {
+  const forwarded: Forwarded[] = [];
+  const fetch = async (url: string, init: RequestInit) => {
+    // SAFETY: the body is the batch document this endpoint just serialized.
+    const body = JSON.parse(String(init.body)) as PosthogBatch;
+    forwarded.push({ url, body });
+    return new Response("{}", { status });
+  };
+  return { fetch, forwarded };
+}
+
+/** A request carrying an already-serialized body, for the malformed cases. */
+function rawEventsRequest(body: string): Request {
+  return new Request("https://luke.test/api/events", {
+    method: "POST",
+    headers: { authorization: "Bearer token-1" },
+    body,
+  });
+}
+
+function eventsRequest(body: WireValue): Request {
+  return rawEventsRequest(JSON.stringify(body));
+}
+
+function options(overrides: Partial<EventsOptions> = {}): EventsOptions {
+  const resolveUserId: EventsOptions["resolveUserId"] = async () => "user-1";
+  return {
+    request: eventsRequest({ events: [LAUNCH] }),
+    projectApiKey: PROJECT_KEY,
+    resolveUserId,
+    now: () => NOW,
+    ...overrides,
+  };
+}
+
+/** Each test gets its own account, because the rate-limit map outlives one. */
+let accounts = 0;
+function freshUser(): () => Promise<string | undefined> {
+  accounts += 1;
+  const userId = `user-${accounts}`;
+  return async () => userId;
+}
+
+test("only POST is answered, and nothing is forwarded without a key or a token", async () => {
+  const wrongMethod = upstream();
+  const rejectedMethod = await handleEvents(
+    options({
+      request: new Request("https://luke.test/api/events"),
+      fetch: wrongMethod.fetch,
+    }),
+  );
+  assert.equal(rejectedMethod.status, 405);
+  assert.equal((await rejectedMethod.json()).error, HOSTED_API_ERROR.METHOD_NOT_ALLOWED);
+  assert.equal(wrongMethod.forwarded.length, 0);
+
+  const keyless = upstream();
+  let resolved = 0;
+  const unconfigured = await handleEvents(
+    options({
+      projectApiKey: "   ",
+      fetch: keyless.fetch,
+      resolveUserId: async () => {
+        resolved += 1;
+        return "user-1";
+      },
+    }),
+  );
+  assert.equal(unconfigured.status, 503);
+  assert.equal((await unconfigured.json()).error, HOSTED_API_ERROR.UNAVAILABLE);
+  assert.equal(keyless.forwarded.length, 0);
+  // The kill switch is read before the token, so an unconfigured deployment
+  // does no work at all.
+  assert.equal(resolved, 0);
+
+  const anonymous = upstream();
+  const refused = await handleEvents(
+    options({ resolveUserId: async () => undefined, fetch: anonymous.fetch }),
+  );
+  assert.equal(refused.status, 401);
+  assert.equal((await refused.json()).error, HOSTED_API_ERROR.INVALID_TOKEN);
+  assert.equal(anonymous.forwarded.length, 0);
+});
+
+test("a malformed or oversized body is refused, the oversized one before parsing", async () => {
+  const malformed = upstream();
+  const unreadable = await handleEvents(
+    options({
+      request: rawEventsRequest("{not json"),
+      fetch: malformed.fetch,
+      resolveUserId: freshUser(),
+    }),
+  );
+  assert.equal(unreadable.status, 400);
+  assert.equal((await unreadable.json()).error, HOSTED_API_ERROR.INVALID_REQUEST);
+
+  const strange = await handleEvents(
+    options({
+      request: eventsRequest({ events: [{ name: "app:sneak", at: NOW, properties: {} }] }),
+      fetch: malformed.fetch,
+      resolveUserId: freshUser(),
+    }),
+  );
+  assert.equal(strange.status, 400);
+
+  const overLimit = await handleEvents(
+    options({
+      request: eventsRequest({
+        events: Array.from({ length: PRODUCT_EVENT_BATCH_LIMIT + 1 }, () => LAUNCH),
+      }),
+      fetch: malformed.fetch,
+      resolveUserId: freshUser(),
+    }),
+  );
+  assert.equal(overLimit.status, 400);
+
+  // Valid JSON, but past the byte ceiling: refused without being parsed at all.
+  const huge = await handleEvents(
+    options({
+      request: rawEventsRequest(`{"events":[],"pad":"${"x".repeat(20_000)}"}`),
+      fetch: malformed.fetch,
+      resolveUserId: freshUser(),
+    }),
+  );
+  assert.equal(huge.status, 400);
+  assert.equal(malformed.forwarded.length, 0);
+});
+
+test("the resolved account is the distinct id, whatever the body tried to say", async () => {
+  const posthog = upstream();
+  const response = await handleEvents(
+    options({
+      request: eventsRequest({
+        distinct_id: "someone-else",
+        events: [
+          { ...LAUNCH, distinct_id: "someone-else" },
+          {
+            name: PRODUCT_EVENT.SESSION_OBSERVE,
+            at: NOW,
+            properties: {
+              provider_id: "codex",
+              session_count: 2,
+              $ip: "203.0.113.7",
+              distinct_id: "someone-else",
+            },
+          },
+        ],
+      }),
+      fetch: posthog.fetch,
+      resolveUserId: freshUser(),
+    }),
+  );
+
+  assert.equal(response.status, 202);
+  assert.deepEqual(await response.json(), { accepted: 2 });
+  const { request: forwarded, items } = onlyBatch(posthog.forwarded);
+  assert.match(forwarded.url, /\/batch\/$/);
+  assert.equal(items.length, 2);
+  for (const item of items) {
+    assert.equal(item.properties.distinct_id, `user-${accounts}`);
+    assert.equal(item.properties.$ip, undefined);
+  }
+  assert.deepEqual(itemAt(items, 1).properties, {
+    provider_id: "codex",
+    session_count: 2,
+    distinct_id: `user-${accounts}`,
+    $geoip_disable: true,
+    $lib: "luke-desktop",
+  });
+});
+
+/**
+ * The four conventions that fail silently if got wrong: a top-level
+ * `distinct_id` is accepted and dropped, an event with no address geo-resolves
+ * to the data centre without `$geoip_disable`, `historical_migration` skips
+ * spike detection, and a non-ISO timestamp is not read as one.
+ */
+test("the forwarded document matches the processor's documented batch shape", async () => {
+  const posthog = upstream();
+  await handleEvents(options({ fetch: posthog.fetch, resolveUserId: freshUser() }));
+
+  const { request: forwarded, items } = onlyBatch(posthog.forwarded);
+  assert.equal(forwarded.body.api_key, PROJECT_KEY);
+  assert.equal(forwarded.body.historical_migration, false);
+  const item = itemAt(items, 0);
+  assert.equal(item.event, PRODUCT_EVENT.APP_LAUNCH);
+  // The documented shape puts it inside properties; a top-level one is
+  // accepted by the processor and then silently dropped.
+  assert.ok(!Object.hasOwn(item, "distinct_id"));
+  assert.equal(item.properties.distinct_id, `user-${accounts}`);
+  assert.equal(item.properties.$geoip_disable, true);
+  assert.equal(item.timestamp, new Date(LAUNCH.at).toISOString());
+  assert.match(item.timestamp, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+});
+
+test("a wrong desktop clock is clamped to the reader's own window", async () => {
+  const posthog = upstream();
+  await handleEvents(
+    options({
+      request: eventsRequest({
+        events: [
+          { ...LAUNCH, at: NOW + 400 * 24 * 60 * 60 * 1000 },
+          { ...LAUNCH, at: NOW - 400 * 24 * 60 * 60 * 1000 },
+        ],
+      }),
+      fetch: posthog.fetch,
+      resolveUserId: freshUser(),
+    }),
+  );
+
+  const { items } = onlyBatch(posthog.forwarded);
+  assert.equal(itemAt(items, 0).timestamp, new Date(NOW).toISOString());
+  assert.equal(itemAt(items, 1).timestamp, new Date(NOW - 7 * 24 * 60 * 60 * 1000).toISOString());
+});
+
+test("past the per-account brake the batch is refused rather than forwarded", async () => {
+  const posthog = upstream();
+  const resolveUserId = freshUser();
+  const send = () =>
+    handleEvents(
+      options({
+        request: eventsRequest({ events: Array.from({ length: 50 }, () => LAUNCH) }),
+        fetch: posthog.fetch,
+        resolveUserId,
+      }),
+    );
+
+  assert.equal((await send()).status, 202);
+  assert.equal((await send()).status, 202);
+  const braked = await send();
+  assert.equal(braked.status, 429);
+  assert.equal((await braked.json()).error, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
+  assert.equal(posthog.forwarded.length, 2);
+
+  // The window turning frees the account again.
+  const later = await handleEvents(
+    options({
+      request: eventsRequest({ events: [LAUNCH] }),
+      fetch: posthog.fetch,
+      resolveUserId,
+      now: () => NOW + 61_000,
+    }),
+  );
+  assert.equal(later.status, 202);
+});
+
+test("an upstream refusal answers 502 carrying its status and nothing else", async () => {
+  const refusing = upstream(400);
+  const response = await handleEvents(
+    options({ fetch: refusing.fetch, resolveUserId: freshUser() }),
+  );
+  assert.equal(response.status, 502);
+  assert.deepEqual(await response.json(), {
+    error: HOSTED_API_ERROR.UPSTREAM_ERROR,
+    upstreamStatus: 400,
+  });
+
+  const unreachable = await handleEvents(
+    options({
+      fetch: async () => {
+        throw new Error("network down");
+      },
+      resolveUserId: freshUser(),
+    }),
+  );
+  assert.equal(unreachable.status, 502);
+  assert.deepEqual(await unreachable.json(), { error: HOSTED_API_ERROR.UPSTREAM_ERROR });
+});

--- a/packages/sidecar-core/src/app-settings.ts
+++ b/packages/sidecar-core/src/app-settings.ts
@@ -1,0 +1,34 @@
+/**
+ * The ids the app's own user-facing settings are named by. They live here
+ * rather than beside the desktop's settings schema because two things outside
+ * that schema have to name the same set: the guide a spoken change is
+ * validated against, and the product-event vocabulary, which may carry a
+ * setting's id but never its value.
+ */
+export const APP_SETTING_ID = {
+  VOICE: "voice",
+  VOICE_SPEED: "voice_speed",
+  VOICE_CAPTIONS: "voice_captions",
+  DUCK_OTHER_MEDIA: "duck_other_media",
+  PREFER_BUILT_IN_MICROPHONE: "prefer_built_in_microphone",
+  QUIET_DURING_MEETINGS: "quiet_during_meetings",
+  SHOW_IN_DOCK: "show_in_dock",
+  SHOW_ON_ALL_DISPLAYS: "show_on_all_displays",
+  FORM_FACTOR: "form_factor",
+  DEFAULT_WORKSPACE_PROVIDER: "default_workspace_provider",
+  WORKSPACE_AGENT_MODEL: "workspace_agent_model",
+  WORKSPACE_AGENT_EFFORT: "workspace_agent_effort",
+  SUPERSET_AGENT: "superset_agent",
+  VOICE_SOURCE: "voice_source",
+  SHARE_USAGE_DATA: "share_usage_data",
+} as const;
+
+export type AppSettingId = (typeof APP_SETTING_ID)[keyof typeof APP_SETTING_ID];
+
+export const APP_SETTING_ID_LIST: readonly AppSettingId[] = Object.values(APP_SETTING_ID);
+
+const APP_SETTING_IDS: ReadonlySet<string> = new Set(APP_SETTING_ID_LIST);
+
+export function isAppSettingId(value: string): value is AppSettingId {
+  return APP_SETTING_IDS.has(value);
+}

--- a/packages/sidecar-core/src/hosted-service.ts
+++ b/packages/sidecar-core/src/hosted-service.ts
@@ -20,6 +20,7 @@ export const HOSTED_SERVICE_PATH = {
   ATTENTION_REVIEW: "/api/attention/review",
   ACCOUNT_DELETE: "/api/account/delete",
   USAGE: "/api/usage",
+  EVENTS: "/api/events",
 } as const;
 
 /** Every refusal a hosted endpoint answers with, by its reason. */
@@ -28,11 +29,18 @@ export const HOSTED_API_ERROR = {
   INVALID_TOKEN: "invalid-token",
   /** The request body is not what this endpoint takes. */
   INVALID_REQUEST: "invalid-request",
-  /** Today's free allowance for this meter is spent. */
+  /**
+   * Today's free allowance for this meter is spent, or — on the recording
+   * endpoint, which meters nothing — this account has sent more counts this
+   * minute than the brake allows.
+   */
   QUOTA_EXHAUSTED: "quota-exhausted",
-  /** The deployment holds no OpenAI key: the hosted tier is switched off. */
+  /**
+   * The deployment holds no key for what was asked — OpenAI's for the hosted
+   * tier, the analytics processor's for recording — so that endpoint is off.
+   */
   UNAVAILABLE: "unavailable",
-  /** OpenAI refused or failed; the status travels, the bodies never do. */
+  /** The upstream refused or failed; the status travels, the bodies never do. */
   UPSTREAM_ERROR: "upstream-error",
   METHOD_NOT_ALLOWED: "method-not-allowed",
 } as const;

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -131,6 +131,7 @@ export {
   type IssueTrackerAdapter,
   type IssueTrackerId,
   type IssueTransition,
+  isIssueTrackerId,
   issueCommentText,
   maximumIssueTransitions,
   normalizeTrackedIssue,
@@ -172,6 +173,12 @@ export {
 } from "./attention-prompt.js";
 
 // Guide — what the app knows about itself.
+export {
+  APP_SETTING_ID,
+  APP_SETTING_ID_LIST,
+  type AppSettingId,
+  isAppSettingId,
+} from "./app-settings.js";
 export {
   APP_PANEL_TAB,
   APP_SETTING_KIND,
@@ -246,6 +253,36 @@ export {
   hostedReviewAnswerFromWire,
   hostedUsageAnswerFromWire,
 } from "./hosted-service.js";
+// Product events — what the desktop may count about its own use.
+export {
+  PRODUCT_CONNECTION_ID,
+  PRODUCT_CREDENTIAL_SOURCE,
+  PRODUCT_EVENT,
+  PRODUCT_EVENT_BATCH_LIMIT,
+  PRODUCT_EVENT_PROPERTIES,
+  PRODUCT_EVENT_PROPERTY,
+  PRODUCT_EVENT_PROPERTY_VALUES,
+  PRODUCT_ISSUE_ACT,
+  PRODUCT_SESSION_ACT,
+  PRODUCT_SESSION_COUNT_BUCKET,
+  PRODUCT_SETTING_VALUE,
+  type ProductConnectionId,
+  type ProductCredentialSource,
+  type ProductEvent,
+  type ProductEventBatch,
+  type ProductEventName,
+  type ProductEventProperties,
+  type ProductEventPropertiesFor,
+  type ProductEventProperty,
+  type ProductIssueAct,
+  type ProductSessionAct,
+  type ProductSessionCountBucket,
+  type ProductSettingValue,
+  productEventBatchFromWire,
+  productEventFromWire,
+  productSessionCountBucket,
+  type RecordProductEvent,
+} from "./product-events.js";
 export {
   REALTIME_CALLS_PATH,
   REALTIME_CLIENT_SECRETS_PATH,

--- a/packages/sidecar-core/src/issues.ts
+++ b/packages/sidecar-core/src/issues.ts
@@ -18,6 +18,13 @@ export const ISSUE_TRACKER_ID = {
 
 export type IssueTrackerId = (typeof ISSUE_TRACKER_ID)[keyof typeof ISSUE_TRACKER_ID];
 
+const ISSUE_TRACKER_IDS: ReadonlySet<string> = new Set(Object.values(ISSUE_TRACKER_ID));
+
+/** Whether this build knows the tracker an observation or an act names. */
+export function isIssueTrackerId(value: string): value is IssueTrackerId {
+  return ISSUE_TRACKER_IDS.has(value);
+}
+
 /** A stable tracker identity and the label that can be shown or spoken. */
 export interface IssueTracker {
   id: string;

--- a/packages/sidecar-core/src/product-events.ts
+++ b/packages/sidecar-core/src/product-events.ts
@@ -1,0 +1,382 @@
+import { APP_SETTING_ID, type AppSettingId } from "./app-settings.js";
+import { parseReleaseVersion } from "./app-update.js";
+import { ISSUE_TRACKER_ID, type IssueTrackerId } from "./issues.js";
+import { isRecord, isWireNumber, isWireString, type UnparsedWireValue } from "./json.js";
+import { PROVIDER_ID, PROVIDER_ID_LIST, type ProviderId } from "./providers.js";
+import { SESSION_STATUS, type SessionStatus } from "./session.js";
+
+/**
+ * What the desktop may count about its own use, and the one reader both sides
+ * run over it. `hosted-service.ts` holds the contracts for what Luke's service
+ * *answers*; this holds the contract for what the desktop *asks* it to record.
+ *
+ * The vocabulary is the privacy boundary, not a convention on top of one. An
+ * event is a name from this file, and every property value is a member of an
+ * `as const` set here, a rung on the session-count ladder, or a release
+ * version — so a session title, a branch, a path, a recap, a prompt, or an
+ * error line has no shape it could travel in. Nothing observed and nothing
+ * typed or spoken can be expressed, and the reader below builds its output
+ * from the allowlist rather than from the envelope, so a field cannot be
+ * smuggled through by naming it.
+ */
+
+export const PRODUCT_EVENT = {
+  APP_LAUNCH: "app:launch",
+  APP_DAY_ACTIVE: "app:day_active",
+  ACCOUNT_SIGN_IN: "account:sign_in",
+  PROVIDER_CONNECT: "provider:connect",
+  PROVIDER_DISCONNECT: "provider:disconnect",
+  TRACKER_CONNECT: "tracker:connect",
+  CALENDAR_CONNECT: "calendar:connect",
+  SESSION_OBSERVE: "session:observe",
+  SESSION_ACT_SEND: "session:act_send",
+  ISSUE_ACT_SEND: "issue:act_send",
+  VOICE_CALL_START: "voice:call_start",
+  VOICE_ANNOUNCEMENT_SPEAK: "voice:announcement_speak",
+  SETTING_UPDATE: "setting:update",
+  USAGE_SHARING_STOP: "usage:sharing_stop",
+  USAGE_SHARING_RESUME: "usage:sharing_resume",
+} as const;
+
+export type ProductEventName = (typeof PRODUCT_EVENT)[keyof typeof PRODUCT_EVENT];
+
+export const PRODUCT_EVENT_PROPERTY = {
+  APP_VERSION: "app_version",
+  CONNECTION_ID: "connection_id",
+  PROVIDER_ID: "provider_id",
+  TRACKER_ID: "tracker_id",
+  SESSION_COUNT: "session_count",
+  SESSION_STATUS: "session_status",
+  CREDENTIAL_SOURCE: "credential_source",
+  SESSION_ACT: "session_act",
+  ISSUE_ACT: "issue_act",
+  SETTING_ID: "setting_id",
+  SETTING_VALUE: "setting_value",
+} as const;
+
+export type ProductEventProperty =
+  (typeof PRODUCT_EVENT_PROPERTY)[keyof typeof PRODUCT_EVENT_PROPERTY];
+
+/**
+ * Every service a credential row connects, as a count names it. It repeats
+ * the desktop's own credential-provider set rather than importing it, because
+ * that set knows about Electron and this file may not; the desktop closes the
+ * gap with a total `Record` bridge, so a new credential provider does not
+ * build until this vocabulary answers for it.
+ */
+export const PRODUCT_CONNECTION_ID = {
+  CONDUCTOR: PROVIDER_ID.CONDUCTOR,
+  COPILOT: PROVIDER_ID.COPILOT,
+  CURSOR: PROVIDER_ID.CURSOR,
+  DEVIN: PROVIDER_ID.DEVIN,
+  JULES: PROVIDER_ID.JULES,
+  LINEAR: ISSUE_TRACKER_ID.LINEAR,
+  OPENAI: "openai",
+} as const;
+
+export type ProductConnectionId =
+  (typeof PRODUCT_CONNECTION_ID)[keyof typeof PRODUCT_CONNECTION_ID];
+
+/** Which credential a spoken call ran on, never which credential it was. */
+export const PRODUCT_CREDENTIAL_SOURCE = {
+  ACCOUNT: "account",
+  KEY: "key",
+} as const;
+
+export type ProductCredentialSource =
+  (typeof PRODUCT_CREDENTIAL_SOURCE)[keyof typeof PRODUCT_CREDENTIAL_SOURCE];
+
+/** Which act a session took, never what it carried. */
+export const PRODUCT_SESSION_ACT = {
+  MESSAGE_SEND: "message_send",
+  CONTROL_RUN: "control_run",
+  SESSION_OPEN: "session_open",
+  TRANSCRIPT_READ: "transcript_read",
+  WORKSPACE_CREATE: "workspace_create",
+  AGENT_ADD: "agent_add",
+} as const;
+
+export type ProductSessionAct = (typeof PRODUCT_SESSION_ACT)[keyof typeof PRODUCT_SESSION_ACT];
+
+/** Which act a tracker took, never the state moved to or the comment written. */
+export const PRODUCT_ISSUE_ACT = {
+  STATE_MOVE: "state_move",
+  COMMENT_ADD: "comment_add",
+} as const;
+
+export type ProductIssueAct = (typeof PRODUCT_ISSUE_ACT)[keyof typeof PRODUCT_ISSUE_ACT];
+
+/**
+ * The shape a setting's new value is counted in, never the value itself: a
+ * chosen workspace project is a project name, and a hotkey is a chord the
+ * developer chose. Whether a switch went on or off, and whether a choice was
+ * made or returned to nothing, is the whole of what travels.
+ */
+export const PRODUCT_SETTING_VALUE = {
+  ON: "on",
+  OFF: "off",
+  SET: "set",
+  CLEARED: "cleared",
+} as const;
+
+export type ProductSettingValue =
+  (typeof PRODUCT_SETTING_VALUE)[keyof typeof PRODUCT_SETTING_VALUE];
+
+/**
+ * The rungs a session count travels on. A raw count is a weak fingerprint —
+ * "137 Codex sessions" identifies a machine across days — where a rung says
+ * the same thing about adoption and says it about a crowd rather than a
+ * person. Each rung is the smallest count that reaches it.
+ */
+export const PRODUCT_SESSION_COUNT_BUCKET = {
+  NONE: 0,
+  ONE: 1,
+  FEW: 2,
+  SEVERAL: 5,
+  MANY: 10,
+  CROWD: 25,
+} as const;
+
+export type ProductSessionCountBucket =
+  (typeof PRODUCT_SESSION_COUNT_BUCKET)[keyof typeof PRODUCT_SESSION_COUNT_BUCKET];
+
+const PRODUCT_SESSION_COUNT_LADDER: readonly ProductSessionCountBucket[] = Object.values(
+  PRODUCT_SESSION_COUNT_BUCKET,
+).sort((left, right) => right - left);
+
+/** The highest rung a count reaches; anything below the first rung is none. */
+export function productSessionCountBucket(count: number): ProductSessionCountBucket {
+  if (!Number.isFinite(count)) return PRODUCT_SESSION_COUNT_BUCKET.NONE;
+  return (
+    PRODUCT_SESSION_COUNT_LADDER.find((rung) => count >= rung) ?? PRODUCT_SESSION_COUNT_BUCKET.NONE
+  );
+}
+
+/** What each property's value is, once it has been read. */
+interface ProductEventPropertyValue {
+  [PRODUCT_EVENT_PROPERTY.APP_VERSION]: string;
+  [PRODUCT_EVENT_PROPERTY.CONNECTION_ID]: ProductConnectionId;
+  [PRODUCT_EVENT_PROPERTY.PROVIDER_ID]: ProviderId;
+  [PRODUCT_EVENT_PROPERTY.TRACKER_ID]: IssueTrackerId;
+  [PRODUCT_EVENT_PROPERTY.SESSION_COUNT]: ProductSessionCountBucket;
+  [PRODUCT_EVENT_PROPERTY.SESSION_STATUS]: SessionStatus;
+  [PRODUCT_EVENT_PROPERTY.CREDENTIAL_SOURCE]: ProductCredentialSource;
+  [PRODUCT_EVENT_PROPERTY.SESSION_ACT]: ProductSessionAct;
+  [PRODUCT_EVENT_PROPERTY.ISSUE_ACT]: ProductIssueAct;
+  [PRODUCT_EVENT_PROPERTY.SETTING_ID]: AppSettingId;
+  [PRODUCT_EVENT_PROPERTY.SETTING_VALUE]: ProductSettingValue;
+}
+
+/**
+ * The two properties no set can enumerate. Each gets a named reader instead,
+ * and both are narrower than free text by construction: a version parses as
+ * `x.y.z` or not at all, and a count must be a rung of the ladder above.
+ */
+export type EnumeratedProductEventProperty = Exclude<
+  ProductEventProperty,
+  typeof PRODUCT_EVENT_PROPERTY.APP_VERSION | typeof PRODUCT_EVENT_PROPERTY.SESSION_COUNT
+>;
+
+/** Every value each enumerable property may ever hold. */
+export const PRODUCT_EVENT_PROPERTY_VALUES = {
+  [PRODUCT_EVENT_PROPERTY.CONNECTION_ID]: Object.values(PRODUCT_CONNECTION_ID),
+  [PRODUCT_EVENT_PROPERTY.PROVIDER_ID]: PROVIDER_ID_LIST,
+  [PRODUCT_EVENT_PROPERTY.TRACKER_ID]: Object.values(ISSUE_TRACKER_ID),
+  [PRODUCT_EVENT_PROPERTY.SESSION_STATUS]: Object.values(SESSION_STATUS),
+  [PRODUCT_EVENT_PROPERTY.CREDENTIAL_SOURCE]: Object.values(PRODUCT_CREDENTIAL_SOURCE),
+  [PRODUCT_EVENT_PROPERTY.SESSION_ACT]: Object.values(PRODUCT_SESSION_ACT),
+  [PRODUCT_EVENT_PROPERTY.ISSUE_ACT]: Object.values(PRODUCT_ISSUE_ACT),
+  [PRODUCT_EVENT_PROPERTY.SETTING_ID]: Object.values(APP_SETTING_ID),
+  [PRODUCT_EVENT_PROPERTY.SETTING_VALUE]: Object.values(PRODUCT_SETTING_VALUE),
+} as const satisfies Record<EnumeratedProductEventProperty, readonly string[]>;
+
+/**
+ * Which properties each event may carry. A name without an entry here does
+ * not build, the same lever the settings schema uses — so widening the
+ * vocabulary is a deliberate edit to this table rather than a call site that
+ * quietly started sending more.
+ */
+export const PRODUCT_EVENT_PROPERTIES = {
+  [PRODUCT_EVENT.APP_LAUNCH]: [PRODUCT_EVENT_PROPERTY.APP_VERSION],
+  [PRODUCT_EVENT.APP_DAY_ACTIVE]: [PRODUCT_EVENT_PROPERTY.APP_VERSION],
+  [PRODUCT_EVENT.ACCOUNT_SIGN_IN]: [],
+  [PRODUCT_EVENT.PROVIDER_CONNECT]: [PRODUCT_EVENT_PROPERTY.CONNECTION_ID],
+  [PRODUCT_EVENT.PROVIDER_DISCONNECT]: [PRODUCT_EVENT_PROPERTY.CONNECTION_ID],
+  [PRODUCT_EVENT.TRACKER_CONNECT]: [PRODUCT_EVENT_PROPERTY.TRACKER_ID],
+  [PRODUCT_EVENT.CALENDAR_CONNECT]: [],
+  [PRODUCT_EVENT.SESSION_OBSERVE]: [
+    PRODUCT_EVENT_PROPERTY.PROVIDER_ID,
+    PRODUCT_EVENT_PROPERTY.SESSION_COUNT,
+  ],
+  [PRODUCT_EVENT.SESSION_ACT_SEND]: [
+    PRODUCT_EVENT_PROPERTY.PROVIDER_ID,
+    PRODUCT_EVENT_PROPERTY.SESSION_ACT,
+  ],
+  [PRODUCT_EVENT.ISSUE_ACT_SEND]: [
+    PRODUCT_EVENT_PROPERTY.TRACKER_ID,
+    PRODUCT_EVENT_PROPERTY.ISSUE_ACT,
+  ],
+  [PRODUCT_EVENT.VOICE_CALL_START]: [PRODUCT_EVENT_PROPERTY.CREDENTIAL_SOURCE],
+  [PRODUCT_EVENT.VOICE_ANNOUNCEMENT_SPEAK]: [
+    PRODUCT_EVENT_PROPERTY.PROVIDER_ID,
+    PRODUCT_EVENT_PROPERTY.SESSION_STATUS,
+  ],
+  [PRODUCT_EVENT.SETTING_UPDATE]: [
+    PRODUCT_EVENT_PROPERTY.SETTING_ID,
+    PRODUCT_EVENT_PROPERTY.SETTING_VALUE,
+  ],
+  [PRODUCT_EVENT.USAGE_SHARING_STOP]: [],
+  [PRODUCT_EVENT.USAGE_SHARING_RESUME]: [],
+} as const satisfies { [Name in ProductEventName]: readonly ProductEventProperty[] };
+
+/** Exactly the properties one event carries, each with its own value type. */
+export type ProductEventPropertiesFor<Name extends ProductEventName> = {
+  readonly [Property in (typeof PRODUCT_EVENT_PROPERTIES)[Name][number]]: ProductEventPropertyValue[Property];
+};
+
+/** Any event's properties, as a validated event holds them. */
+export type ProductEventProperties = {
+  readonly [Property in ProductEventProperty]?: ProductEventPropertyValue[Property];
+};
+
+/** One counted event: what happened, when, and the properties it may carry. */
+export interface ProductEvent {
+  name: ProductEventName;
+  /** When it happened on the desktop's clock, as epoch milliseconds. */
+  at: number;
+  properties: ProductEventProperties;
+}
+
+export type ProductEventBatch = readonly ProductEvent[];
+
+/**
+ * How many events one request may carry. A flush past this is a desktop bug
+ * rather than a busy day, so the endpoint refuses the batch whole.
+ */
+export const PRODUCT_EVENT_BATCH_LIMIT = 50;
+
+/** The one shape a recording request has: events and nothing else. */
+export interface ProductEventBatchRequest {
+  events: readonly unknown[];
+}
+
+type PropertyReader = {
+  [Property in ProductEventProperty]: (
+    value: UnparsedWireValue,
+  ) => ProductEventPropertyValue[Property] | undefined;
+};
+
+function memberReader<Value extends string>(
+  values: readonly string[],
+): (value: UnparsedWireValue) => Value | undefined {
+  const members: ReadonlySet<string> = new Set(values);
+  return (value: UnparsedWireValue) => {
+    if (!isWireString(value) || !members.has(value)) return undefined;
+    // SAFETY: the value is a member of this property's own declared set.
+    return value as Value;
+  };
+}
+
+const SESSION_COUNT_BUCKETS: ReadonlySet<number> = new Set(
+  Object.values(PRODUCT_SESSION_COUNT_BUCKET),
+);
+
+/**
+ * How each property's value is read. The two unenumerable ones are named
+ * here, which is what makes "no free text" a property of the type rather than
+ * a promise about call sites: a version that is not `x.y.z` and a count that
+ * is not a rung are both discarded.
+ */
+const PRODUCT_EVENT_PROPERTY_READER: PropertyReader = {
+  [PRODUCT_EVENT_PROPERTY.APP_VERSION]: (value) =>
+    isWireString(value) && parseReleaseVersion(value) ? value.trim() : undefined,
+  [PRODUCT_EVENT_PROPERTY.SESSION_COUNT]: (value) => {
+    if (!isWireNumber(value) || !SESSION_COUNT_BUCKETS.has(value)) return undefined;
+    // SAFETY: the value is a member of the bucket ladder declared above.
+    return value as ProductSessionCountBucket;
+  },
+  [PRODUCT_EVENT_PROPERTY.CONNECTION_ID]: memberReader(
+    PRODUCT_EVENT_PROPERTY_VALUES[PRODUCT_EVENT_PROPERTY.CONNECTION_ID],
+  ),
+  [PRODUCT_EVENT_PROPERTY.PROVIDER_ID]: memberReader(
+    PRODUCT_EVENT_PROPERTY_VALUES[PRODUCT_EVENT_PROPERTY.PROVIDER_ID],
+  ),
+  [PRODUCT_EVENT_PROPERTY.TRACKER_ID]: memberReader(
+    PRODUCT_EVENT_PROPERTY_VALUES[PRODUCT_EVENT_PROPERTY.TRACKER_ID],
+  ),
+  [PRODUCT_EVENT_PROPERTY.SESSION_STATUS]: memberReader(
+    PRODUCT_EVENT_PROPERTY_VALUES[PRODUCT_EVENT_PROPERTY.SESSION_STATUS],
+  ),
+  [PRODUCT_EVENT_PROPERTY.CREDENTIAL_SOURCE]: memberReader(
+    PRODUCT_EVENT_PROPERTY_VALUES[PRODUCT_EVENT_PROPERTY.CREDENTIAL_SOURCE],
+  ),
+  [PRODUCT_EVENT_PROPERTY.SESSION_ACT]: memberReader(
+    PRODUCT_EVENT_PROPERTY_VALUES[PRODUCT_EVENT_PROPERTY.SESSION_ACT],
+  ),
+  [PRODUCT_EVENT_PROPERTY.ISSUE_ACT]: memberReader(
+    PRODUCT_EVENT_PROPERTY_VALUES[PRODUCT_EVENT_PROPERTY.ISSUE_ACT],
+  ),
+  [PRODUCT_EVENT_PROPERTY.SETTING_ID]: memberReader(
+    PRODUCT_EVENT_PROPERTY_VALUES[PRODUCT_EVENT_PROPERTY.SETTING_ID],
+  ),
+  [PRODUCT_EVENT_PROPERTY.SETTING_VALUE]: memberReader(
+    PRODUCT_EVENT_PROPERTY_VALUES[PRODUCT_EVENT_PROPERTY.SETTING_VALUE],
+  ),
+};
+
+const PRODUCT_EVENT_NAMES: ReadonlySet<string> = new Set(Object.values(PRODUCT_EVENT));
+
+function isProductEventName(value: UnparsedWireValue): value is ProductEventName {
+  return isWireString(value) && PRODUCT_EVENT_NAMES.has(value);
+}
+
+/**
+ * Reads one event out of an untrusted envelope, or nothing. The result is
+ * assembled from the event's own allowlist rather than copied from what
+ * arrived, so a `distinct_id`, an `$ip`, an `email`, or a `$set` on the way in
+ * has nowhere to land — naming a field is not a way to send one. A missing or
+ * unreadable property discards the whole event rather than being repaired: the
+ * desktop only sends what it built from this same table, so anything else is a
+ * bug that should be loud.
+ */
+export function productEventFromWire(value: UnparsedWireValue): ProductEvent | undefined {
+  if (!isRecord(value) || !isProductEventName(value.name)) return undefined;
+  const at = value.at;
+  if (!isWireNumber(at) || !Number.isFinite(at) || at < 0) return undefined;
+  const source = isRecord(value.properties) ? value.properties : undefined;
+  const allowed: readonly ProductEventProperty[] = PRODUCT_EVENT_PROPERTIES[value.name];
+  const properties: Record<string, string | number> = {};
+  for (const property of allowed) {
+    const read = PRODUCT_EVENT_PROPERTY_READER[property](source?.[property]);
+    if (read === undefined) return undefined;
+    properties[property] = read;
+  }
+  // SAFETY: every key came from this event's allowlist and every value from
+  // that property's own reader, which is exactly the declared shape.
+  return { name: value.name, at, properties: properties as ProductEventProperties };
+}
+
+/**
+ * Reads a whole batch, or nothing. One unreadable event refuses the batch
+ * rather than trimming it: a partial acceptance would let a desktop bug show
+ * up as a quiet gap in the counts instead of a refusal somebody notices.
+ */
+export function productEventBatchFromWire(value: UnparsedWireValue): ProductEventBatch | undefined {
+  if (!isRecord(value) || !Array.isArray(value.events)) return undefined;
+  if (value.events.length === 0 || value.events.length > PRODUCT_EVENT_BATCH_LIMIT) {
+    return undefined;
+  }
+  const events: ProductEvent[] = [];
+  for (const candidate of value.events) {
+    const event = productEventFromWire(candidate);
+    if (!event) return undefined;
+    events.push(event);
+  }
+  return events;
+}
+
+/** What every emitter is handed: a name, and exactly that name's properties. */
+export type RecordProductEvent = <Name extends ProductEventName>(
+  name: Name,
+  properties: ProductEventPropertiesFor<Name>,
+) => void;

--- a/packages/sidecar-core/tests/product-events.test.ts
+++ b/packages/sidecar-core/tests/product-events.test.ts
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  PRODUCT_EVENT,
+  PRODUCT_EVENT_BATCH_LIMIT,
+  PRODUCT_EVENT_PROPERTIES,
+  PRODUCT_EVENT_PROPERTY,
+  PRODUCT_EVENT_PROPERTY_VALUES,
+  PRODUCT_SESSION_COUNT_BUCKET,
+  type ProductEventName,
+  type ProductEventProperty,
+  productEventBatchFromWire,
+  productEventFromWire,
+  productSessionCountBucket,
+  type WireRecord,
+} from "../src/index.js";
+
+const AT = Date.parse("2026-08-19T12:00:00.000Z");
+
+const EVENT_NAMES = Object.values(PRODUCT_EVENT);
+
+/** A value every property will accept, for building a legal event of any name. */
+const SAMPLE_VALUE = {
+  [PRODUCT_EVENT_PROPERTY.APP_VERSION]: "0.2.0",
+  [PRODUCT_EVENT_PROPERTY.SESSION_COUNT]: PRODUCT_SESSION_COUNT_BUCKET.FEW,
+  [PRODUCT_EVENT_PROPERTY.CONNECTION_ID]: "conductor",
+  [PRODUCT_EVENT_PROPERTY.PROVIDER_ID]: "codex",
+  [PRODUCT_EVENT_PROPERTY.TRACKER_ID]: "linear",
+  [PRODUCT_EVENT_PROPERTY.SESSION_STATUS]: "waiting",
+  [PRODUCT_EVENT_PROPERTY.CREDENTIAL_SOURCE]: "account",
+  [PRODUCT_EVENT_PROPERTY.SESSION_ACT]: "message_send",
+  [PRODUCT_EVENT_PROPERTY.ISSUE_ACT]: "comment_add",
+  [PRODUCT_EVENT_PROPERTY.SETTING_ID]: "voice_captions",
+  [PRODUCT_EVENT_PROPERTY.SETTING_VALUE]: "on",
+} satisfies Record<ProductEventProperty, string | number>;
+
+function legalEvent(name: ProductEventName): WireRecord {
+  const properties: Record<string, string | number> = {};
+  for (const property of PRODUCT_EVENT_PROPERTIES[name]) {
+    properties[property] = SAMPLE_VALUE[property];
+  }
+  return { name, at: AT, properties };
+}
+
+test("every event name has an allowlist, and every listed property has a value set", () => {
+  for (const name of EVENT_NAMES) {
+    assert.ok(
+      Object.hasOwn(PRODUCT_EVENT_PROPERTIES, name),
+      `${name} carries no property allowlist`,
+    );
+    for (const property of PRODUCT_EVENT_PROPERTIES[name]) {
+      assert.ok(
+        Object.values(PRODUCT_EVENT_PROPERTY).includes(property),
+        `${name} lists an unknown property ${property}`,
+      );
+    }
+  }
+});
+
+test("every event round-trips through the reader unchanged", () => {
+  for (const name of EVENT_NAMES) {
+    const wire = legalEvent(name);
+    assert.deepEqual(productEventFromWire(wire), {
+      name,
+      at: AT,
+      properties: wire.properties,
+    });
+  }
+});
+
+test("a property valid for another event is dropped from this one", () => {
+  const event = productEventFromWire({
+    name: PRODUCT_EVENT.ACCOUNT_SIGN_IN,
+    at: AT,
+    properties: { [PRODUCT_EVENT_PROPERTY.PROVIDER_ID]: "codex" },
+  });
+  assert.deepEqual(event, {
+    name: PRODUCT_EVENT.ACCOUNT_SIGN_IN,
+    at: AT,
+    properties: {},
+  });
+});
+
+test("a value outside its own set discards the event", () => {
+  assert.equal(
+    productEventFromWire({
+      name: PRODUCT_EVENT.PROVIDER_CONNECT,
+      at: AT,
+      properties: { [PRODUCT_EVENT_PROPERTY.CONNECTION_ID]: "not-a-provider" },
+    }),
+    undefined,
+  );
+  assert.equal(productEventFromWire({ name: "app:sneak", at: AT, properties: {} }), undefined);
+  assert.equal(productEventFromWire({ name: PRODUCT_EVENT.APP_LAUNCH, at: AT }), undefined);
+});
+
+test("prose cannot pass as a property value", () => {
+  const prose = "codex — /Users/me/luke on feature/x";
+  assert.equal(
+    productEventFromWire({
+      name: PRODUCT_EVENT.SESSION_OBSERVE,
+      at: AT,
+      properties: {
+        [PRODUCT_EVENT_PROPERTY.PROVIDER_ID]: prose,
+        [PRODUCT_EVENT_PROPERTY.SESSION_COUNT]: 1,
+      },
+    }),
+    undefined,
+  );
+  // A version reader is not a string reader: a path is not `x.y.z`.
+  assert.equal(
+    productEventFromWire({
+      name: PRODUCT_EVENT.APP_LAUNCH,
+      at: AT,
+      properties: { [PRODUCT_EVENT_PROPERTY.APP_VERSION]: "/Users/me/luke" },
+    }),
+    undefined,
+  );
+});
+
+test("a raw count is refused; only a rung of the ladder travels", () => {
+  assert.equal(
+    productEventFromWire({
+      name: PRODUCT_EVENT.SESSION_OBSERVE,
+      at: AT,
+      properties: {
+        [PRODUCT_EVENT_PROPERTY.PROVIDER_ID]: "codex",
+        [PRODUCT_EVENT_PROPERTY.SESSION_COUNT]: 137,
+      },
+    }),
+    undefined,
+  );
+  assert.equal(productSessionCountBucket(137), PRODUCT_SESSION_COUNT_BUCKET.CROWD);
+  assert.equal(productSessionCountBucket(0), PRODUCT_SESSION_COUNT_BUCKET.NONE);
+  assert.equal(productSessionCountBucket(1), PRODUCT_SESSION_COUNT_BUCKET.ONE);
+  assert.equal(productSessionCountBucket(4), PRODUCT_SESSION_COUNT_BUCKET.FEW);
+  assert.equal(productSessionCountBucket(5), PRODUCT_SESSION_COUNT_BUCKET.SEVERAL);
+  assert.equal(productSessionCountBucket(24), PRODUCT_SESSION_COUNT_BUCKET.MANY);
+  assert.equal(productSessionCountBucket(-3), PRODUCT_SESSION_COUNT_BUCKET.NONE);
+  assert.equal(productSessionCountBucket(Number.NaN), PRODUCT_SESSION_COUNT_BUCKET.NONE);
+});
+
+test("nothing on the envelope survives except what the allowlist names", () => {
+  const event = productEventFromWire({
+    name: PRODUCT_EVENT.APP_LAUNCH,
+    at: AT,
+    distinct_id: "someone-else",
+    $ip: "203.0.113.7",
+    email: "someone@example.test",
+    properties: {
+      [PRODUCT_EVENT_PROPERTY.APP_VERSION]: "0.2.0",
+      distinct_id: "someone-else",
+      $set: { email: "someone@example.test" },
+      $ip: "203.0.113.7",
+    },
+  });
+  assert.deepEqual(event, {
+    name: PRODUCT_EVENT.APP_LAUNCH,
+    at: AT,
+    properties: { [PRODUCT_EVENT_PROPERTY.APP_VERSION]: "0.2.0" },
+  });
+});
+
+test("one bad event refuses the whole batch, and so does an oversized one", () => {
+  const good = legalEvent(PRODUCT_EVENT.APP_LAUNCH);
+  assert.equal(productEventBatchFromWire({ events: [good, good] })?.length, 2);
+  assert.equal(
+    productEventBatchFromWire({ events: [good, { name: "app:sneak", at: AT, properties: {} }] }),
+    undefined,
+  );
+  assert.equal(
+    productEventBatchFromWire({
+      events: Array.from({ length: PRODUCT_EVENT_BATCH_LIMIT + 1 }, () => good),
+    }),
+    undefined,
+  );
+  assert.equal(productEventBatchFromWire({ events: [] }), undefined);
+  assert.equal(productEventBatchFromWire({ events: "many" }), undefined);
+  assert.equal(productEventBatchFromWire([good]), undefined);
+});
+
+/**
+ * The structural half of the promise: walk the whole vocabulary and assert
+ * every value it can ever hold is a token rather than prose. A property that
+ * could carry a title, a path, or a sentence fails here.
+ */
+test("no value the vocabulary can express is free text", () => {
+  const token = /^[a-z0-9_.:-]+$/;
+  for (const name of EVENT_NAMES) {
+    assert.match(name, token, `event name ${name} is not a token`);
+    for (const property of PRODUCT_EVENT_PROPERTIES[name]) {
+      assert.match(property, token, `property ${property} is not a token`);
+      if (property === PRODUCT_EVENT_PROPERTY.SESSION_COUNT) {
+        // A rung is a number rather than a token, which is the one exception
+        // the pattern below cannot express.
+        for (const rung of Object.values(PRODUCT_SESSION_COUNT_BUCKET)) {
+          assert.ok(Number.isInteger(rung), `${rung} is not a bucket rung`);
+        }
+        continue;
+      }
+      if (property === PRODUCT_EVENT_PROPERTY.APP_VERSION) {
+        assert.match("0.2.0", /^\d+\.\d+\.\d+$/);
+        continue;
+      }
+      for (const value of PRODUCT_EVENT_PROPERTY_VALUES[property]) {
+        assert.match(value, token, `${property} may hold non-token ${value}`);
+      }
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       pg:
         specifier: 8.23.0
         version: 8.23.0
+      posthog-js:
+        specifier: 1.418.3
+        version: 1.418.3
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -1390,6 +1393,15 @@ packages:
     resolution: {integrity: sha512-S0uyoxakDINJ4DPgqxGlEEvrdSMeQb7Z2lKVjxoY2gwsbZbfg2Xr8Klfeo5ZeraHmmdBCELFUHkSe6KEmBpMvg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@posthog/browser-common@0.5.0':
+    resolution: {integrity: sha512-8DaxVZS1bQPbA514RePurLNbYjei3P4jhnC206DwVv5XThmZM3QdlsXenI2ujE3pLbgQ79hYn9o1Kda8I3WK/Q==}
+
+  '@posthog/core@1.48.4':
+    resolution: {integrity: sha512-Bff4EVy6x1FrJIdhrEZYGJuyarwZkKC0fOncRobpPgJWMQc83W2U/6ChYPQYcA1Vp3wzAOVCOSigs6fMqojM5Q==}
+
+  '@posthog/types@1.405.0':
+    resolution: {integrity: sha512-4rZ/taVXKQxs9Jrf7ZjlCRgrOSL69oKAgIWJQa5kRNJ6wll1UANbrJTSY+Su1e88LIG4zZVjKKKjyQHCkHdHcw==}
+
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
 
@@ -1649,6 +1661,9 @@ packages:
   '@types/react@19.2.18':
     resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
     engines: {node: '>=16.20.0'}
@@ -1890,6 +1905,9 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  core-js@3.50.0:
+    resolution: {integrity: sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1912,6 +1930,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dompurify@3.4.14:
+    resolution: {integrity: sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==}
 
   drizzle-kit@0.31.10:
     resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
@@ -2063,6 +2084,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.4.9:
+    resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
 
   filename-reserved-regex@3.0.0:
     resolution: {integrity: sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==}
@@ -2375,10 +2399,21 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  posthog-js@1.418.3:
+    resolution: {integrity: sha512-EoYOsc89ThquZUTasbozerMOAjWea8u1LD6LuHvvKnNmQKMf5SiT7DGahGMzInTlrMep+IkWMexq4wU9hbz/5A==}
+
   postject@1.0.0-alpha.6:
     resolution: {integrity: sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  preact@10.29.8:
+    resolution: {integrity: sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
 
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
@@ -2387,6 +2422,9 @@ packages:
   promise-retry@2.0.1:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
@@ -2591,6 +2629,12 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
+
+  web-vitals@6.0.0:
+    resolution: {integrity: sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -3458,6 +3502,17 @@ snapshots:
 
   '@oxlint/plugins@1.79.0': {}
 
+  '@posthog/browser-common@0.5.0':
+    dependencies:
+      '@posthog/core': 1.48.4
+      '@posthog/types': 1.405.0
+
+  '@posthog/core@1.48.4':
+    dependencies:
+      '@posthog/types': 1.405.0
+
+  '@posthog/types@1.405.0': {}
+
   '@rolldown/pluginutils@1.0.0-beta.53': {}
 
   '@rollup/rollup-android-arm-eabi@4.62.4':
@@ -3659,6 +3714,9 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
 
@@ -3806,6 +3864,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  core-js@3.50.0: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -3821,6 +3881,10 @@ snapshots:
   defu@6.1.7: {}
 
   detect-libc@2.1.2: {}
+
+  dompurify@3.4.14:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   drizzle-kit@0.31.10:
     dependencies:
@@ -3978,6 +4042,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
+
+  fflate@0.4.9: {}
 
   filename-reserved-regex@3.0.0: {}
 
@@ -4251,9 +4317,26 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  posthog-js@1.418.3:
+    dependencies:
+      '@posthog/browser-common': 0.5.0
+      '@posthog/core': 1.48.4
+      '@posthog/types': 1.405.0
+      core-js: 3.50.0
+      dompurify: 3.4.14
+      fflate: 0.4.9
+      preact: 10.29.8
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+      web-vitals-soft-navs: web-vitals@6.0.0
+    transitivePeerDependencies:
+      - preact-render-to-string
+
   postject@1.0.0-alpha.6:
     dependencies:
       commander: 9.5.0
+
+  preact@10.29.8: {}
 
   progress@2.0.3: {}
 
@@ -4261,6 +4344,8 @@ snapshots:
     dependencies:
       err-code: 2.0.3
       retry: 0.12.0
+
+  query-selector-shadow-dom@1.0.1: {}
 
   react-dom@19.2.8(react@19.2.8):
     dependencies:
@@ -4474,6 +4559,10 @@ snapshots:
       lightningcss: 1.32.0
       tsx: 4.23.12
       yaml: 2.9.0
+
+  web-vitals@5.3.0: {}
+
+  web-vitals@6.0.0: {}
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
Luke shipped with no usage signal at all, so whether anyone launches him twice,
which providers people actually connect, and where install → first session
loses them were unanswerable. This adds PostHog behind Luke's own service.

**Counting is on by default.** That is the first thing Luke sends that the
developer did not start, so three properties of the design carry the weight.

## The vocabulary is the privacy boundary

An event is a name from `packages/sidecar-core/src/product-events.ts`, and each
property is a value from an `as const` set in that same file, an `x.y.z`
version, or a rung of a bucket ladder. A title, branch, path, recap, prompt,
tool output, or error line has no shape it could travel in — structural, rather
than a promise about call sites.

One reader validates both sides, and it **builds its output from the
allowlist** rather than copying what arrived, so a `distinct_id`, `$ip`, or
`$set` on an envelope has nowhere to land. A test walks the whole vocabulary
and asserts every expressible value is a token or a bucket.

Session counts travel as rungs (0, 1, 2, 5, 10, 25) — "137 sessions" identifies
a machine across days; "a crowd" does not.

## The desktop transmits no identity

It posts to `/api/events` on the same short-lived token the voice and review
endpoints already use. The service resolves the account from that token, sets
`distinct_id` there, and attaches the account's own name and email to the
**person** record from its own user row — never onto an event, because an event
property is what the allowlist governs and a person property is not.

Every forwarded event carries `$geoip_disable`, so PostHog never resolves the
Mac's address or location.

## The switch is on the front settings page

Beside Updates, excluded from every reset scope, because a "reset appearance"
that quietly turned counting back on would be a consent nobody gave. Turning it
off records one final `usage:sharing_stop` **while sharing still stands** —
record it after the flag moves and the opt-out rate is unmeasurable, visible
only as the people who stayed.

## Notes for review

- **`posthog-js` is dynamically imported.** A static import more than doubled
  the shared web chunk (196 → 451 kB raw) and landed on every page including
  `/privacy`. Now its own lazy chunk; a build without the key never fetches it.
- **`connection_id` is distinct from `provider_id`**, because credential rows
  span providers *plus* Linear *plus* OpenAI. The total `Record` bridge in
  `shared/product-vocabulary.ts` means a new credential provider fails
  typecheck until the vocabulary answers for it.
- **Superset-managed sessions count too.** Those acts bypass
  `performSessionAct` through the CLI, so counting lives in a helper both paths
  call — otherwise Superset would have reported zero acts.
- **`POSTHOG_API_HOST` is separate from `POSTHOG_HOST`** — deletion targets the
  private API host, not the ingestion host.
- **Account deletion does not erase the PostHog person.** The personal API key
  is deliberately not configured, so `PRIVACY.md` says plainly that deleting an
  account leaves the counts and that erasure happens on request. The seam stays,
  so configuring the key later switches it on with no code change.
- **The site half is a weaker guarantee and is documented as such**: PostHog
  sees a visitor's address in the browser. `PRIVACY.md` keeps that in its own
  paragraph.

Docs moved together: `PRIVACY.md` (new section naming every event and property
by name), `README.md`, `AGENTS.md` (new trust constraint), `CHANGELOG.md`,
`luke-guide.ts`, `apps/web/server/README.md`. `PROVIDERS.md` untouched — no
provider capability changed.

## Verification

`./scripts/check.sh` passes: lint, oxlint anti-slop, typecheck, 1584 tests,
builds. `apps/desktop/package.json` still has no `dependencies` key.

Rebased onto `main` after #287 condensed the README and #290 trimmed interface
prose; the usage-data copy was tightened to match the new house style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32309224609/artifacts/9385857562) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32309224609)

- Commit: `fc6bda42fc52c677e0520a7ce53ff6f486cd59b9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
