### PR TITLE
fix(settings): place project defaults with providers

### DIFF
--- a/apps/desktop/src/desktop-app.ts
+++ b/apps/desktop/src/desktop-app.ts
@@ -24,6 +24,7 @@ import {
   SessionNoticeHold,
   SessionNoticeTracker,
   type SessionProviderAdapter,
+  staleWorkspaceProjectDefaults,
   type TrackedIssue,
   type UnparsedWireValue,
   type WorkspaceAgentSelection,
@@ -445,6 +446,8 @@ let unsubscribeSessions: (() => void) | undefined;
  * Undefined until the first announcement decides what there is to compare.
  */
 let lastWorkspaceProjects: string | undefined;
+/** Invalidates an older async broadcast whenever a newer pass or stop wins. */
+let workspaceProjectsBroadcastGeneration = 0;
 
 /**
  * Announces where a workspace can be created whenever the offer changes. This
@@ -456,12 +459,53 @@ let lastWorkspaceProjects: string | undefined;
  // SAFETY: The preceding check establishes the asserted contract.
  * runs on the observation cadence as well as on every commit.
  */
-function broadcastWorkspaceProjects(): void {
-  const projects = observedWorkspaceProjects();
+async function broadcastWorkspaceProjects(): Promise<void> {
+  const generation = ++workspaceProjectsBroadcastGeneration;
+  const offeredProjects = offeredWorkspaceProjects();
+  const defaults = await settingsStore.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field);
+  if (generation !== workspaceProjectsBroadcastGeneration) return;
+  await pruneWorkspaceProjectDefaults(
+    offeredProjects,
+    defaults,
+    () => generation === workspaceProjectsBroadcastGeneration,
+  );
+  if (generation !== workspaceProjectsBroadcastGeneration) return;
+  const projects = normalizeObservedWorkspaceProjects(offeredProjects, defaults);
   const serialized = JSON.stringify(projects);
   if (serialized === lastWorkspaceProjects) return;
   lastWorkspaceProjects = serialized;
   panels.broadcast(channels.workspaceProjectsChanged, projects);
+}
+
+/**
+ * Forgets a stored default project its provider has stopped offering. Every
+ * path that reads one matches it against the offered list, so an unmatched
+ * default steers nothing while the settings row still shows a choice; the
+ * write is what makes the row and the behaviour agree again. A failed write
+ * costs only the stale entry, which the next pass tries again.
+ */
+async function pruneWorkspaceProjectDefaults(
+  projects: readonly ObservedWorkspaceProject[],
+  defaults: Readonly<Partial<Record<string, string>>> | undefined,
+  isCurrent: () => boolean,
+): Promise<void> {
+  try {
+    for (const providerId of staleWorkspaceProjectDefaults(projects, defaults)) {
+      if (!isCurrent()) return;
+      const expected = defaults?.[providerId];
+      if (expected === undefined) continue;
+      const saved = await settingsStore.clearEntryIfUnchanged(
+        APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
+        providerId,
+        expected,
+      );
+      if (!saved.cleared) continue;
+      if (!isCurrent()) return;
+      panels.broadcast(channels.settingsChanged, saved.settings);
+    }
+  } catch {
+    return;
+  }
 }
 
 function argumentValue(name: string): string | undefined {
@@ -697,7 +741,12 @@ function registerIpc(): void {
       // roster does: a panel shown no sessions is shown no asks about them.
       noticeAsks:
         runMode.observesProviders && accountCapabilitiesActive() ? attentionRequests.list() : [],
-      workspaceProjects: accountCapabilitiesActive() ? observedWorkspaceProjects() : [],
+      workspaceProjects: accountCapabilitiesActive()
+        ? normalizeObservedWorkspaceProjects(
+            offeredWorkspaceProjects(),
+            await settingsStore.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field),
+          )
+        : [],
       ...(trackedIssues && runMode.observesProviders && accountCapabilitiesActive()
         ? { issues: trackedIssues }
         : undefined),
@@ -877,21 +926,20 @@ function registerIpc(): void {
 /**
  // SAFETY: The preceding check establishes the asserted contract.
  * Where a workspace can be created right now, as the adapters offer it: each
- * capable adapter's latest project list, stamped with its provider and bounded
- * once here so the panel and the conversation are handed the same list. A
+ * capable adapter's latest project list, stamped with its provider. This full
+ * list is the source of truth for validating and pruning saved choices; the
+ * renderer and conversation receive its separately bounded projection. A
  * fixture run offers nothing, for the same reason it observes nothing.
  */
-function observedWorkspaceProjects(): readonly ObservedWorkspaceProject[] {
+function offeredWorkspaceProjects(): readonly ObservedWorkspaceProject[] {
   if (!runMode.observesProviders) return [];
-  return normalizeObservedWorkspaceProjects(
-    [...orderedRegistrations.map(({ adapter }) => adapter), supersetWorkspaceAdapter].flatMap(
-      (adapter) =>
-        adapter.workspaceProjects().map((project) => ({
-          ...project,
-          providerId: adapter.provider.id,
-          providerName: adapter.provider.displayName,
-        })),
-    ),
+  return [...orderedRegistrations.map(({ adapter }) => adapter), supersetWorkspaceAdapter].flatMap(
+    (adapter) =>
+      adapter.workspaceProjects().map((project) => ({
+        ...project,
+        providerId: adapter.provider.id,
+        providerName: adapter.provider.displayName,
+      })),
   );
 }
 
@@ -976,7 +1024,7 @@ async function refreshProviderSessions(generation: number): Promise<void> {
   if (!sessionObservationLoop.isCurrent(generation)) return;
   // The registry only spoke if the sessions themselves changed, and a pass can
   // change the project list while leaving them exactly as they were.
-  broadcastWorkspaceProjects();
+  void broadcastWorkspaceProjects();
   // Attention review runs outside the observation guard so a slow model call
   // never delays the next provider snapshot.
   void attentionObservationLoop.refresh();
@@ -1365,11 +1413,12 @@ function startSessionObservation(): void {
     openCreatedWorkspaces(snapshot.sessions);
     // A commit is the earliest a write-triggered refresh can have changed the
     // offer, so the announcement rides it rather than waiting for the timer.
-    broadcastWorkspaceProjects();
+    void broadcastWorkspaceProjects();
   });
 }
 
 function stopSessionObservation(): void {
+  workspaceProjectsBroadcastGeneration += 1;
   unsubscribeSessions?.();
   unsubscribeSessions = undefined;
   for (const { adapter } of orderedRegistrations) {

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1160,10 +1160,14 @@ export function App(): React.JSX.Element {
   /**
    * The providers the default-workspace rows can offer: every provider
    * currently offering projects, named the way its adapter names itself, plus
-   * one holding a stored default — provider or project — that is not offering
-   * right now: the rows must show the choices they hold, or a choice could be
-   * neither seen nor cleared. Each option carries the projects its
-   * default-project row offers, on the same show-what-is-held terms.
+   * one holding a stored default provider that is not offering right now — a
+   * provider falls back to its own display name, so the row still shows a
+   * choice it can name. A project has no such name to fall back to: its label
+   * lived on the observed list that stopped listing it, and an option labelled
+   * with the stored identity would offer a raw id for a default that already
+   * steers nothing. So each option carries only the projects its provider is
+   * offering, and a default the provider stops offering is cleared by the main
+   * process rather than shown here.
    */
   const storedWorkspaceProvider = settings?.defaultWorkspaceProvider;
   const storedWorkspaceProjects = settings?.workspaceProjectDefaults;
@@ -1194,14 +1198,7 @@ export function App(): React.JSX.Element {
             ? `${project.repository} on ${project.targetName}`
             : project.repository,
         }));
-      const stored = storedWorkspaceProjects?.[id];
-      // A stored project the provider no longer offers is its own label: the
-      // repository name lived on the observed list that stopped listing it.
-      const projects =
-        stored && !offered.some((project) => project.id === stored)
-          ? [...offered, { id: stored, label: stored }]
-          : offered;
-      return { id, name, projects };
+      return { id, name, projects: offered };
     });
   }, [workspaceProjects, storedWorkspaceProvider, storedWorkspaceProjects]);
 

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -363,22 +363,27 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
     {
       label: "Creating workspaces",
       detail:
-        "Where a connected provider documents a creation endpoint — Conductor and Cursor today — " +
+        "Where a connected provider documents a creation endpoint — Conductor, Cursor, and " +
+        "Superset today — " +
         "an ask in conversation, spoken or typed, can create a new workspace in one of the " +
         "projects that provider reports, optionally under a name the developer chose, and can " +
         "hand the new agent an opening task in the developer's own words where the project takes " +
         "one. A bare ask for a new agent lands here: only an ask that itself names the existing " +
         "workspace or session the agent should join adds one beside it instead. Only reported " +
         "projects can be named, a project that needs a task cannot be created " +
-        "without one, and a provider that reports none takes no ask. An ask that names no " +
+        "without one, and a provider that reports none takes no ask. Superset asks for more than " +
+        "the others: every Superset project is listed against the host that runs it, and a new " +
+        "Superset workspace needs that host, an agent Superset currently lists for it, and an " +
+        "opening task — so a task-less ask for one is refused rather than created idle. An ask that names no " +
         "provider goes to the default workspace provider; until one is chosen Luke asks when " +
         "more than one provider could take it, and the first workspace created saves its " +
         // SAFETY: The preceding check establishes the asserted contract.
         "provider as the default — changed or cleared by hand in the Settings tab. An ask that " +
         "names no project goes the same way: each provider remembers a default project, filled " +
         "in by the first workspace created there and changed or cleared by hand on the " +
-        "Connections page, under Workspaces; until one is chosen Luke asks when the provider " +
-        "lists more than one project. What a new " +
+        "Connections page, on that provider's own row — under Cloud Agent API keys for a " +
+        "provider connected by key, and under Superset for Superset; until one is chosen Luke " +
+        "asks when the provider lists more than one project. What a new " +
         "Conductor agent runs — its model, and its effort where the model's agent takes one — " +
         "follows the choice on the Conductor row under Cloud Agent API keys, or Conductor's own " +
         "defaults while none is made. A model named in a creation ask rides that creation alone " +

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -40,6 +40,7 @@ import {
   CREDENTIAL_SOURCE,
   SECRET_STORAGE,
   SETTINGS_RESET_SCOPE,
+  SUPERSET_WORKSPACE_PROVIDER_ID,
   VOICE_SOURCE,
   type VoiceSource,
 } from "../shared/contracts";
@@ -138,8 +139,10 @@ export interface WorkspaceProviderOption {
   name: string;
   /**
    * The projects this provider's default-project row can offer: everything
-   * currently observed for it, plus a stored default it no longer offers — a
-   * choice the row cannot show is one that can be neither seen nor cleared.
+   * currently observed for it, and nothing else. A stored default the provider
+   * has stopped offering has no label of its own to be drawn under, and steers
+   * nothing until it is cleared, which the main process does on the same
+   * observation that stopped offering it.
    */
   projects: readonly { id: string; label: string }[];
 }
@@ -442,9 +445,9 @@ function ProviderCredential({
   control: CredentialEntryControl;
   panelOpen: boolean;
   /**
-   * The provider's own sub-rows — today, the agent defaults a connected
-   * Conductor offers. Drawn inside the credential block so the rule that
-   * separates providers falls under them, not between them and their line.
+   * The provider's own sub-rows — what a new agent runs, and where a nameless
+   * ask creates. Drawn inside the credential block so the rule that separates
+   * providers falls under them, not between them and their line.
    */
   children?: React.ReactNode;
 }): React.JSX.Element {
@@ -1207,7 +1210,22 @@ const CODEX_CLOUD_STATUS = {
  * signing that CLI out is what disconnects — so the words name that step
  * exactly when it is the missing one, and no control pretends otherwise.
  */
-function CodexCloudConnection({ connection }: { connection: CliConnection }): React.JSX.Element {
+function CodexCloudConnection({
+  connection,
+  settings,
+  preferences,
+  workspaceProvider,
+}: {
+  connection: CliConnection;
+  settings: AppSettings;
+  preferences: PreferenceWrites;
+  /**
+   * Codex's own projects, absent until an observation pass reports any. Codex
+   * connects by CLI login rather than by key, so it has no credential row to
+   * hang its creation defaults under and carries them here instead.
+   */
+  workspaceProvider?: WorkspaceProviderOption;
+}): React.JSX.Element {
   return (
     <div className="credential">
       <div className="credential-row">
@@ -1224,6 +1242,13 @@ function CodexCloudConnection({ connection }: { connection: CliConnection }): Re
         </span>
         <span className="credential-status">{CODEX_CLOUD_STATUS[connection]}</span>
       </div>
+      {connection === CLI_CONNECTION.CONNECTED && workspaceProvider ? (
+        <WorkspaceProjectRow
+          provider={workspaceProvider}
+          settings={settings}
+          preferences={preferences}
+        />
+      ) : null}
     </div>
   );
 }
@@ -1238,16 +1263,19 @@ function CredentialsSection({
   control,
   panelOpen,
   preferences,
+  workspaceProviders,
 }: {
   settings: AppSettings;
   control: CredentialEntryControl;
   panelOpen: boolean;
   preferences: PreferenceWrites;
+  workspaceProviders: readonly WorkspaceProviderOption[];
 }): React.JSX.Element {
   // Only a system Luke has actually asked, and been refused by, is reported as
   // one that cannot hold a key. Until then the rows stand as usual: a warning
   // about storage nobody has tried to use yet would be a guess.
   const storageUnavailable = settings.secretStorage === SECRET_STORAGE.UNAVAILABLE;
+  const codexWorkspace = workspaceProviders.find((option) => option.id === PROVIDER_ID.CODEX);
   return (
     // SAFETY: The preceding check establishes the asserted contract.
     <section className="settings-section" style={{ "--row-index": 1 } as React.CSSProperties}>
@@ -1256,7 +1284,12 @@ function CredentialsSection({
         Cloud Agent API keys
       </h2>
       {/* First because the list reads alphabetically, like the key rows below. */}
-      <CodexCloudConnection connection={settings.codexCloudConnection} />
+      <CodexCloudConnection
+        connection={settings.codexCloudConnection}
+        settings={settings}
+        preferences={preferences}
+        {...(codexWorkspace ? { workspaceProvider: codexWorkspace } : {})}
+      />
       {CLOUD_AGENT_PROVIDER_LIST.map((provider) => {
         // The agent row belongs to providers the build documents a table for,
         // and only while connected: disconnected, there is nothing the choice
@@ -1267,6 +1300,7 @@ function CredentialsSection({
           workspaceAgentModels(provider.id).length > 0
             ? provider.id
             : undefined;
+        const workspaceProvider = workspaceProviders.find((option) => option.id === provider.id);
         return (
           <ProviderCredential
             key={provider.id}
@@ -1284,6 +1318,13 @@ function CredentialsSection({
                   ? { selection: settings.workspaceAgentDefaults[agentRow] }
                   : undefined)}
                 onChange={preferences.onWorkspaceAgentDefaultChange}
+              />
+            ) : null}
+            {workspaceProvider ? (
+              <WorkspaceProjectRow
+                provider={workspaceProvider}
+                settings={settings}
+                preferences={preferences}
               />
             ) : null}
           </ProviderCredential>
@@ -1549,7 +1590,18 @@ export interface SupersetControl {
   onDefaultAgentChange: (agent: string | undefined) => Promise<string | undefined>;
 }
 
-function SupersetIntegration({ control }: { control: SupersetControl }): React.JSX.Element | null {
+function SupersetIntegration({
+  control,
+  settings,
+  preferences,
+  workspaceProvider,
+}: {
+  control: SupersetControl;
+  settings: AppSettings;
+  preferences: PreferenceWrites;
+  /** Superset's own projects, absent until an observation pass reports any. */
+  workspaceProvider?: WorkspaceProviderOption;
+}): React.JSX.Element | null {
   if (!control.installed) return null;
   return (
     <div className="credential">
@@ -1590,6 +1642,13 @@ function SupersetIntegration({ control }: { control: SupersetControl }): React.J
           onChange={(agent) =>
             control.onDefaultAgentChange(agent === PROVIDER_DEFAULT_VALUE ? undefined : agent)
           }
+        />
+      ) : null}
+      {control.connected && workspaceProvider ? (
+        <WorkspaceProjectRow
+          provider={workspaceProvider}
+          settings={settings}
+          preferences={preferences}
         />
       ) : null}
     </div>
@@ -1730,14 +1789,19 @@ function IntegrationsSection({
   calendar,
   linear,
   superset,
+  workspaceProviders,
 }: {
   settings: AppSettings;
   preferences: PreferenceWrites;
   calendar: CalendarControl;
   linear: LinearControl;
   superset: SupersetControl;
+  workspaceProviders: readonly WorkspaceProviderOption[];
 }): React.JSX.Element {
   const storageUnavailable = settings.secretStorage === SECRET_STORAGE.UNAVAILABLE;
+  const supersetWorkspace = workspaceProviders.find(
+    (option) => option.id === SUPERSET_WORKSPACE_PROVIDER_ID,
+  );
   return (
     // SAFETY: The preceding check establishes the asserted contract.
     <section className="settings-section" style={{ "--row-index": 2 } as React.CSSProperties}>
@@ -1746,7 +1810,12 @@ function IntegrationsSection({
         Integrations
       </h2>
       <LinearIntegration settings={settings} linear={linear} />
-      <SupersetIntegration control={superset} />
+      <SupersetIntegration
+        control={superset}
+        settings={settings}
+        preferences={preferences}
+        {...(supersetWorkspace ? { workspaceProvider: supersetWorkspace } : {})}
+      />
       <GoogleCalendarIntegration
         settings={settings}
         calendar={calendar}
@@ -2125,9 +2194,11 @@ function WorkspacesSection({
   return (
     // SAFETY: The preceding check establishes the asserted contract.
     <section className="settings-section" style={{ "--row-index": 3 } as React.CSSProperties}>
-      {/* The heading and the group's reset share a line: the reset stands
-          over exactly the rows below it, and nothing else on the Connections
-          page — the keys above are not settings and are never reset. */}
+      {/* The heading and the group's reset share a line. The reset groups by
+          meaning rather than by position: it covers every workspace-creation
+          default on this page, including the per-provider rows drawn beside
+          the providers they belong to. Only the keys are exempt — they are not
+          settings and are never reset. */}
       <div className="settings-heading">
         <h2>
           <FolderIcon />
@@ -2165,23 +2236,18 @@ function WorkspacesSection({
           if (provider) return preferences.onDefaultWorkspaceProviderChange(provider.id);
         }}
       />
-      {workspaceProviders.map((provider) => (
-        <WorkspaceProjectRow
-          key={provider.id}
-          provider={provider}
-          settings={settings}
-          preferences={preferences}
-        />
-      ))}
     </section>
   );
 }
 
 /**
- * Where one provider's nameless creation ask lands: a row per provider with
- * projects to choose between, filled in the way the provider default is — by
- * the first creation there — and this select is where that choice is seen,
- * changed, or returned to the first creation.
+ * Where one provider's nameless creation ask lands: filled in the way the
+ * provider default is — by the first creation there — and this select is where
+ * that choice is seen, changed, or returned to the first creation. Drawn under
+ * its own provider, beside what a new agent there runs, because both answer
+ * the same question about the same provider; the label leaves the provider to
+ * the heading above it and the aria-label carries it for a reader arriving
+ * without that context.
  */
 function WorkspaceProjectRow({
   provider,
@@ -2197,12 +2263,20 @@ function WorkspaceProjectRow({
   // to choose between, has nothing for the row to say.
   if (provider.projects.length === 0) return null;
   const stored = settings.workspaceProjectDefaults?.[providerId];
+  // A stored default the provider has stopped offering is on its way out: the
+  // main process clears it on the same observation, and until that write lands
+  // the row reads as the unchosen state it is about to become. Drawing the
+  // stored value instead would leave the select on an option it does not hold.
+  const shown =
+    stored !== undefined && provider.projects.some((project) => project.id === stored)
+      ? stored
+      : PROJECT_ASK_EACH_TIME;
   return (
     <SelectRow
-      label={`Default ${provider.name} project`}
+      label="Default project"
       ariaLabel={`The project a nameless ask creates ${provider.name} workspaces in`}
-      changed={stored !== undefined}
-      value={stored ?? PROJECT_ASK_EACH_TIME}
+      changed={shown !== PROJECT_ASK_EACH_TIME}
+      value={shown}
       options={[
         // The provider row's own words for the same state: until a default
         // exists, an ambiguous ask is asked about, and the two rows should
@@ -3189,6 +3263,7 @@ export function SettingsPanel({
             control={credentials}
             panelOpen={panelOpen}
             preferences={preferences}
+            workspaceProviders={workspaceProviders}
           />
           <IntegrationsSection
             settings={settings}
@@ -3196,6 +3271,7 @@ export function SettingsPanel({
             calendar={calendar}
             linear={linear}
             superset={superset}
+            workspaceProviders={workspaceProviders}
           />
           <WorkspacesSection
             settings={settings}

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -465,6 +465,30 @@ export class SettingsStore {
       return next;
     });
   }
+
+  /** Clears one map entry only if it still holds the value the caller read. */
+  async clearEntryIfUnchanged<Field extends KeyedAppSettingField>(
+    field: Field,
+    key: string,
+    expected: SettingEntryValue<Field>,
+  ): Promise<SettingsUpdateResult & { cleared: boolean }> {
+    let cleared = false;
+    await this.#serialize(async () => {
+      const persisted = await this.#load();
+      // SAFETY: KeyedAppSettingField identifies fields whose stored value is a wire record.
+      const current = persisted[field] as WireRecord | undefined;
+      if (!sameSettingEntry(field, current?.[key], expected)) return;
+      const entries = { ...current };
+      delete entries[key];
+      const next: PersistedSettings = { ...persisted, version: SETTINGS_FILE_VERSION };
+      if (Object.keys(entries).length > 0) Object.assign(next, { [field]: entries });
+      else delete next[field];
+      await this.#write(next);
+      this.#loading = Promise.resolve(next);
+      cleared = true;
+    });
+    return { settings: await this.snapshot(), cleared };
+  }
   #secretStorage: SecretStorage = SECRET_STORAGE.UNKNOWN;
 
   constructor(options: SettingsStoreOptions) {

--- a/apps/desktop/tests/luke-guide.test.ts
+++ b/apps/desktop/tests/luke-guide.test.ts
@@ -295,6 +295,12 @@ test("the facts describe creating a workspace, so Luke does not deny the capabil
   // a fresh workspace it did not ask for.
   assert.match(rendered, /names the existing workspace or session/);
   assert.match(rendered, /bare ask for a new agent creates a new workspace instead/);
+  // Superset creates workspaces too, and asks for more than the others do —
+  // a guide that named only Conductor and Cursor would have Luke deny a
+  // capability he has, then be surprised by the refusal a task-less ask earns.
+  assert.match(rendered, /Superset/);
+  assert.match(rendered, /new Superset workspace needs that host, an agent/);
+  assert.match(rendered, /opening task/);
 });
 
 test("the guide offers what a new Conductor agent runs, by the names people know", () => {

--- a/apps/desktop/tests/settings-store.test.ts
+++ b/apps/desktop/tests/settings-store.test.ts
@@ -1465,6 +1465,39 @@ test("keeps one provider's default project apart from another's", async (t) => {
   });
 });
 
+test("forgetting a default no provider offers survives the reload it was written for", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const cipher = countingCipher();
+  const store = storeIn(directory, { cipher });
+  await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "proj-gone");
+  await setWorkspaceProjectDefault(store, PROVIDER_ID.CURSOR, "proj-2");
+
+  // The write the observation pass makes when a provider stops offering the
+  // project a default names. It has to reach the file, not just the snapshot:
+  // the entry it forgets is one an earlier launch wrote.
+  await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, undefined);
+
+  assert.deepEqual((await storeIn(directory).snapshot()).workspaceProjectDefaults, {
+    [PROVIDER_ID.CURSOR]: "proj-2",
+  });
+  assert.deepEqual(cipher.calls, { isAvailable: 0, encrypt: 0, decrypt: 0 });
+});
+
+test("a stale cleanup cannot clear a newer project default", async (t) => {
+  const store = storeIn(await temporaryDirectory(t));
+  await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "proj-old");
+  await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "proj-new");
+
+  const stale = await store.clearEntryIfUnchanged(
+    APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
+    PROVIDER_ID.CONDUCTOR,
+    "proj-old",
+  );
+
+  assert.equal(stale.cleared, false);
+  assert.equal(stale.settings.workspaceProjectDefaults?.[PROVIDER_ID.CONDUCTOR], "proj-new");
+});
+
 test("an entry the field cannot hold is refused rather than quietly dropped", () => {
   // The map guards drop what they cannot hold, which is right when reading a
   // stored file and wrong for a write: a whole map of unholdable entries would

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -112,6 +112,7 @@ export {
   type ProviderWorkspaceResult,
   type SessionProviderAdapter,
   SessionProviderAdapterBase,
+  staleWorkspaceProjectDefaults,
   WORKSPACE_TASK_SUPPORT,
   type WorkspaceAgentModels,
   type WorkspaceAgentSelection,

--- a/packages/sidecar-core/src/providers.ts
+++ b/packages/sidecar-core/src/providers.ts
@@ -194,6 +194,32 @@ export function workspaceProjectSelectionId(
     : project.providerProjectId;
 }
 
+/**
+ * The providers whose stored default names no project they currently offer —
+ * a choice that steers nothing, because every path that reads it matches
+ * against the offered set. Only providers present in `projects` are judged: a
+ * provider offering nothing is observing nothing, and a default must not be
+ * discarded on that silence.
+ */
+export function staleWorkspaceProjectDefaults(
+  projects: readonly ObservedWorkspaceProject[],
+  defaults: Readonly<Partial<Record<string, string>>> | undefined,
+): readonly string[] {
+  if (!defaults) return [];
+  const offered = new Map<string, Set<string>>();
+  for (const project of projects) {
+    const selections = offered.get(project.providerId) ?? new Set<string>();
+    selections.add(workspaceProjectSelectionId(project));
+    offered.set(project.providerId, selections);
+  }
+  return [...offered.entries()]
+    .filter(([providerId, selections]) => {
+      const stored = defaults[providerId];
+      return stored !== undefined && !selections.has(stored);
+    })
+    .map(([providerId]) => providerId);
+}
+
 /** A workspace name reads in one breath; anything longer is a different ask. */
 export const maximumWorkspaceNameLength = 80;
 
@@ -220,6 +246,7 @@ export function workspaceNameText(value: UnparsedWireValue): string | undefined 
  */
 export function normalizeObservedWorkspaceProjects(
   projects: readonly ObservedWorkspaceProject[],
+  preferredSelections?: Readonly<Partial<Record<string, string>>>,
 ): readonly ObservedWorkspaceProject[] {
   const seen = new Map<string, Map<string, Set<string>>>();
   const normalized: ObservedWorkspaceProject[] = [];
@@ -262,16 +289,29 @@ export function normalizeObservedWorkspaceProjects(
     if (defaultAgent) normalizedProject.defaultAgent = defaultAgent;
     normalized.push(normalizedProject);
   }
-  return normalized
-    .sort(
-      (left, right) =>
-        compareRepositoryLabels(left.repository, right.repository) ||
-        // Two providers can offer one repository label; the provider and then
-        // the id keep the order deterministic rather than arrival-dependent.
-        left.providerName.localeCompare(right.providerName) ||
-        left.providerProjectId.localeCompare(right.providerProjectId),
-    )
-    .slice(0, maximumObservedWorkspaceProjects);
+  const sorted = normalized.sort(compareWorkspaceProjects);
+  const preferred = sorted.filter(
+    (project) => preferredSelections?.[project.providerId] === workspaceProjectSelectionId(project),
+  );
+  const ordinary = sorted.filter(
+    (project) => preferredSelections?.[project.providerId] !== workspaceProjectSelectionId(project),
+  );
+  return [...preferred, ...ordinary]
+    .slice(0, maximumObservedWorkspaceProjects)
+    .sort(compareWorkspaceProjects);
+}
+
+function compareWorkspaceProjects(
+  left: ObservedWorkspaceProject,
+  right: ObservedWorkspaceProject,
+): number {
+  return (
+    compareRepositoryLabels(left.repository, right.repository) ||
+    // Two providers can offer one repository label; the provider and then the
+    // id keep the order deterministic rather than arrival-dependent.
+    left.providerName.localeCompare(right.providerName) ||
+    left.providerProjectId.localeCompare(right.providerProjectId)
+  );
 }
 
 /** Alphabetical the way a person reads labels: case-blind, digits as numbers. */

--- a/packages/sidecar-core/tests/providers.test.ts
+++ b/packages/sidecar-core/tests/providers.test.ts
@@ -4,6 +4,7 @@ import {
   maximumObservedWorkspaceProjects,
   normalizeObservedWorkspaceProjects,
   type ObservedWorkspaceProject,
+  staleWorkspaceProjectDefaults,
   WORKSPACE_TASK_SUPPORT,
   workspaceProjectSelectionId,
 } from "../src";
@@ -107,5 +108,76 @@ test("normalizing still drops blanks and duplicates before it sorts", () => {
   assert.deepEqual(
     normalized.map((entry) => entry.repository),
     ["beta"],
+  );
+});
+
+test("a default naming no offered project is stale, host segment and all", () => {
+  const offeredProject = project({ providerProjectId: "proj-1", providerTargetId: "local" });
+  const offered = [offeredProject];
+
+  // What an earlier build stored: the project id alone, before the host that
+  // owns it joined the identity. It matches nothing offered, so it steers
+  // nothing — the whole reason the row must stop showing it.
+  assert.deepEqual(staleWorkspaceProjectDefaults(offered, { conductor: "proj-1" }), ["conductor"]);
+  assert.deepEqual(
+    staleWorkspaceProjectDefaults(offered, {
+      conductor: workspaceProjectSelectionId(offeredProject),
+    }),
+    [],
+  );
+});
+
+test("a provider offering nothing keeps the default it holds", () => {
+  // Offering nothing is observing nothing — a signed-out CLI, a cold cache at
+  // launch, a fixture run. A default must not be discarded on that silence.
+  assert.deepEqual(staleWorkspaceProjectDefaults([], { conductor: "proj-1" }), []);
+  assert.deepEqual(
+    staleWorkspaceProjectDefaults([project({ providerId: "cursor" })], { conductor: "proj-1" }),
+    [],
+  );
+});
+
+test("each provider's default is judged against its own offer alone", () => {
+  const stale = staleWorkspaceProjectDefaults(
+    [
+      project({ providerId: "conductor", providerProjectId: "proj-1" }),
+      project({ providerId: "cursor", providerProjectId: "proj-2" }),
+      project({ providerId: "superset", providerProjectId: "proj-3" }),
+    ],
+    { conductor: "proj-1", cursor: "gone", superset: undefined },
+  );
+
+  assert.deepEqual(stale, ["cursor"]);
+  assert.deepEqual(staleWorkspaceProjectDefaults([project({})], undefined), []);
+});
+
+test("a valid default beyond the bounded display roster is not stale", () => {
+  const hiddenProject = project({
+    providerProjectId: "proj-z",
+    repository: "repository-z",
+  });
+  const offered = [
+    ...Array.from({ length: maximumObservedWorkspaceProjects }, (_, index) =>
+      project({
+        providerProjectId: `proj-${String(index).padStart(2, "0")}`,
+        repository: `repository-${String(index).padStart(2, "0")}`,
+      }),
+    ),
+    hiddenProject,
+  ];
+  const stored = workspaceProjectSelectionId(hiddenProject);
+
+  assert.equal(
+    normalizeObservedWorkspaceProjects(offered).some(
+      (candidate) => workspaceProjectSelectionId(candidate) === stored,
+    ),
+    false,
+  );
+  assert.deepEqual(staleWorkspaceProjectDefaults(offered, { conductor: stored }), []);
+  assert.equal(
+    normalizeObservedWorkspaceProjects(offered, { conductor: stored }).some(
+      (candidate) => workspaceProjectSelectionId(candidate) === stored,
+    ),
+    true,
   );
 });


### PR DESCRIPTION
## Summary

- move each default-project control beside the provider it configures, including Superset and Codex cloud
- clear stored project defaults when an observed provider no longer offers that project, while preserving defaults during provider silence
- update Luke’s guide and coverage for Superset workspace requirements

## Verification

- `./scripts/verify.sh`
- inspected `artifacts/evidence/app-smoke-expanded.png` (no clipping or overlap)
- physical-notch check not performed

## Test plan

- verify connected providers show Default project on their own settings row
- verify stale observed project defaults return to Ask each time
- verify a provider with no observed projects retains its stored default

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32305257953/artifacts/9384497095) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32305257953)

- Commit: `9c88d4538d642b0ceeebf8dce09517865c84f789`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
