### PR TITLE
fix(desktop): keep the panel open when its shape recedes past the pointer

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -657,6 +657,7 @@ export function App(): React.JSX.Element {
     changeMode,
     cancelHover,
     onHitRegionLeave,
+    panelReceded,
     changeAskEngagement,
     settle,
     leave,
@@ -684,6 +685,22 @@ export function App(): React.JSX.Element {
   });
 
   const leavingPanel = useLeavingPanel(presentation);
+
+  /**
+   * The panel following its content down is the one move that can take the
+   * shape out from under a resting pointer — a settings page opening shorter
+   * than the page it replaces. The mark lands here, on the measure that
+   * retargets the surface, so it is standing before the spring can pass the
+   * pointer and manufacture a leave nobody performed.
+   */
+  const previousPanelHeight = useRef<number | undefined>(undefined);
+  useEffect(() => {
+    const previous = previousPanelHeight.current;
+    previousPanelHeight.current = panelHeight;
+    if (previous !== undefined && panelHeight !== undefined && panelHeight < previous) {
+      panelReceded();
+    }
+  }, [panelHeight, panelReceded]);
 
   /**
    * Sends Luke to sign the next act waiting on him, and puts the panel where

--- a/apps/desktop/src/renderer/panel-state.ts
+++ b/apps/desktop/src/renderer/panel-state.ts
@@ -39,8 +39,8 @@ export const PEEK_ENTER_DELAY_MS = 60;
 /**
  * Short, and the same whichever state is being left: a panel that lingered
  * after the pointer had gone felt like a different object from a peek that
- * did not. The settings tab opts out of pointer-driven closing entirely,
- * which is what protects someone reaching for the keyboard.
+ * did not. A key or ask being typed opts the panel out of pointer-driven
+ * closing entirely, which is what protects someone reaching for the keyboard.
  */
 export const LEAVE_DELAY_MS = 110;
 /**

--- a/apps/desktop/src/renderer/use-panel-presentation.ts
+++ b/apps/desktop/src/renderer/use-panel-presentation.ts
@@ -1,3 +1,4 @@
+import { MOTION_DURATION_MS } from "@sidecar/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { WindowMode } from "../shared/contracts";
 import {
@@ -14,17 +15,58 @@ import {
 /**
  * Whether a pointer leave should schedule a close. The slot and the composer
  * stay put — someone is in the middle of writing, often in a browser — and a
- * key or ask being typed holds the panel the same way.
+ * key or ask being typed holds the panel the same way. A panel whose shape
+ * has just receded out from under the pointer stays too: entering a settings
+ * page shorter than the one it replaces shrinks the shape past a resting
+ * hand, and that is the shape leaving the pointer, not the pointer leaving
+ * the shape.
  */
 export function pointerLeaveSchedules(input: {
   presentation: PanelPresentation;
   hold: boolean;
+  receded: boolean;
 }): boolean {
   if (input.presentation === PANEL_PRESENTATION.CAPSULE) return false;
   if (input.presentation === PANEL_PRESENTATION.SLOT) return false;
   if (input.presentation === PANEL_PRESENTATION.FEEDBACK) return false;
-  if (input.presentation === PANEL_PRESENTATION.PANEL && input.hold) return false;
+  if (input.presentation === PANEL_PRESENTATION.PANEL && (input.hold || input.receded)) {
+    return false;
+  }
   return true;
+}
+
+/**
+ * How long a marked recede is still travelling: exit plus shape, the same
+ * clock the collapse spends. Until it has passed, the vacated footprint still
+ * answers hit tests — the surface and the panel's clip spring down behind the
+ * content — so what the pointer is confirmed over inside this window may be
+ * ground the shape is about to leave.
+ */
+export const RECEDE_SETTLE_MS = MOTION_DURATION_MS.EXIT + MOTION_DURATION_MS.SURFACE;
+
+/**
+ * Whether the shape shrinking marks the pointer as left behind. Only the
+ * panel follows its content down under a resting pointer — the slot and the
+ * composer never close by leaving anyway — and only a pointer actually on
+ * the shape can be left by it: a shrink with the pointer already away has
+ * nobody to protect, and marking it would swallow a later, genuine leave.
+ */
+export function recedeArms(input: {
+  presentation: PanelPresentation;
+  pointerInside: boolean;
+}): boolean {
+  return input.presentation === PANEL_PRESENTATION.PANEL && input.pointerInside;
+}
+
+/**
+ * Whether a pointer confirmed over the panel's content releases the recede
+ * mark. Only once the recede has settled: while the spring is still
+ * travelling, the vacated footprint itself answers as content, so a twitch
+ * during the shrink would spend the protection one frame before the leave it
+ * exists for.
+ */
+export function recedeReleases(input: { recededAt: number; now: number }): boolean {
+  return input.now - input.recededAt >= RECEDE_SETTLE_MS;
 }
 
 // SAFETY: The preceding check establishes the asserted contract.
@@ -76,6 +118,7 @@ export function askDisengageLeaves(input: {
 function usePointerPassthrough(
   onHitRegionEnter: () => void,
   onHitRegionLeave: () => void,
+  onPointerOverPanel: () => void,
   presentation: PanelPresentation,
 ): void {
   const lastValue = useRef<boolean | undefined>(undefined);
@@ -104,6 +147,11 @@ function usePointerPassthrough(
         .elementFromPoint(point.x, point.y)
         ?.closest(`[${HIT_REGION_ATTRIBUTE}]`);
       const kind = region?.getAttribute(HIT_REGION_ATTRIBUTE);
+      const overPanel = kind === HIT_REGION.PANEL && drawn === PANEL_PRESENTATION.PANEL;
+      // Reported on every move rather than on the transition, because it is
+      // what releases a recede mark: a pointer resting on the panel as it now
+      // stands is not one the shape left behind.
+      if (overPanel) onPointerOverPanel();
       // The shape takes the pointer wherever it is drawn, which is the whole
       // rule: the capsule strip and the panel's body are what sit on top of it
       // and answer first. The surface is what answers in between — the panel's
@@ -114,12 +162,12 @@ function usePointerPassthrough(
       update(
         kind === HIT_REGION.SURFACE ||
           kind === HIT_REGION.CAPSULE ||
-          (kind === HIT_REGION.PANEL && drawn === PANEL_PRESENTATION.PANEL) ||
+          overPanel ||
           (kind === HIT_REGION.SLOT && drawn === PANEL_PRESENTATION.SLOT) ||
           (kind === HIT_REGION.FEEDBACK && drawn === PANEL_PRESENTATION.FEEDBACK),
       );
     },
-    [update],
+    [onPointerOverPanel, update],
   );
 
   useEffect(() => {
@@ -175,6 +223,8 @@ export interface PanelPresentationApi {
   changeMode: (expanded: boolean) => Promise<void>;
   cancelHover: () => void;
   onHitRegionLeave: () => void;
+  /** The drawn panel followed its content down and may have left the pointer. */
+  panelReceded: () => void;
   changeAskEngagement: (engaged: boolean) => void;
   settle: () => void;
   leave: () => void;
@@ -196,6 +246,14 @@ export function usePanelPresentation(options: PanelPresentationOptions): PanelPr
   const pointerInside = useRef(false);
   const modeGeneration = useRef(0);
   const askEngaged = useRef(false);
+  /**
+   * When the shape last receded out from under the pointer, undefined once
+   * spent. Spent by the one leave it explains, by the pointer settling on the
+   * panel as it now stands, or by the panel closing some other way — a mark
+   * that survived into the next opening would swallow that panel's first,
+   * genuine leave.
+   */
+  const recededAt = useRef<number | undefined>(undefined);
 
   const heldAgainstPointer = useCallback(
     () => optionsRef.current.entryDrawn() || askEngaged.current,
@@ -211,6 +269,7 @@ export function usePanelPresentation(options: PanelPresentationOptions): PanelPr
   const applyPresentation = useCallback((next: PanelPresentation) => {
     presentationRef.current = next;
     setPresentation(next);
+    if (next !== PANEL_PRESENTATION.PANEL) recededAt.current = undefined;
     const host = optionsRef.current;
     // The sheet is only ever drawn inside the panel, so any other shape puts
     // it away. Left set behind a shape that cannot draw it, it would be over
@@ -284,10 +343,15 @@ export function usePanelPresentation(options: PanelPresentationOptions): PanelPr
   const onHitRegionLeave = useCallback(() => {
     cancelHover();
     pointerInside.current = false;
+    // Read and spent in the same breath: the mark explains exactly one leave,
+    // and the next one is the pointer's own act again.
+    const receded = recededAt.current !== undefined;
+    recededAt.current = undefined;
     if (
       !pointerLeaveSchedules({
         presentation: presentationRef.current,
         hold: heldAgainstPointer(),
+        receded,
       })
     ) {
       return;
@@ -331,11 +395,27 @@ export function usePanelPresentation(options: PanelPresentationOptions): PanelPr
     void changeMode(true);
   }, [changeMode]);
 
+  const panelReceded = useCallback(() => {
+    const arms = recedeArms({
+      presentation: presentationRef.current,
+      pointerInside: pointerInside.current,
+    });
+    if (arms) recededAt.current = performance.now();
+  }, []);
+
+  const onPointerOverPanel = useCallback(() => {
+    const marked = recededAt.current;
+    if (marked === undefined) return;
+    if (recedeReleases({ recededAt: marked, now: performance.now() })) {
+      recededAt.current = undefined;
+    }
+  }, []);
+
   const presentationOf = useCallback(() => presentationRef.current, []);
   const modeGenerationOf = useCallback(() => modeGeneration.current, []);
   const pointerIsInside = useCallback(() => pointerInside.current, []);
 
-  usePointerPassthrough(onHitRegionEnter, onHitRegionLeave, presentation);
+  usePointerPassthrough(onHitRegionEnter, onHitRegionLeave, onPointerOverPanel, presentation);
 
   useEffect(() => () => cancelHover(), [cancelHover]);
 
@@ -350,6 +430,7 @@ export function usePanelPresentation(options: PanelPresentationOptions): PanelPr
     changeMode,
     cancelHover,
     onHitRegionLeave,
+    panelReceded,
     changeAskEngagement,
     settle,
     leave,

--- a/apps/desktop/src/renderer/use-panel-presentation.ts
+++ b/apps/desktop/src/renderer/use-panel-presentation.ts
@@ -249,9 +249,9 @@ export function usePanelPresentation(options: PanelPresentationOptions): PanelPr
   /**
    * When the shape last receded out from under the pointer, undefined once
    * spent. Spent by the one leave it explains, by the pointer settling on the
-   * panel as it now stands, or by the panel closing some other way — a mark
-   * that survived into the next opening would swallow that panel's first,
-   * genuine leave.
+   * panel as it now stands, by the pointer arriving back from outside, or by
+   * the panel closing any way at all — a mark that survived into the next
+   * opening would swallow that panel's first, genuine leave.
    */
   const recededAt = useRef<number | undefined>(undefined);
 
@@ -314,6 +314,11 @@ export function usePanelPresentation(options: PanelPresentationOptions): PanelPr
       const generation = modeGeneration.current + 1;
       modeGeneration.current = generation;
       presentationRef.current = expanded ? PANEL_PRESENTATION.PANEL : PANEL_PRESENTATION.CAPSULE;
+      // Spent here as well as on the confirmed presentation, because a newer
+      // generation can win the race and leave this call's applyPresentation
+      // unmade — a mark surviving that into a reopened panel would swallow
+      // its first genuine leave.
+      if (!expanded) recededAt.current = undefined;
       try {
         // Asking for focus is what makes Escape reach the panel someone opened.
         const confirmedMode = await window.sidecar.setExpanded(expanded, expanded);
@@ -331,6 +336,11 @@ export function usePanelPresentation(options: PanelPresentationOptions): PanelPr
   const onHitRegionEnter = useCallback(() => {
     cancelHover();
     pointerInside.current = true;
+    // A pointer arriving from outside ends whatever story a mark was telling:
+    // it is back on the shape, so its next leave is its own act. The arrival
+    // cannot land between a recede and the leave it explains — the surface
+    // covers the pointer for that whole stretch, so no enter fires there.
+    recededAt.current = undefined;
     if (!pointerEnterPeeks(presentationRef.current)) return;
     hoverTimer.current = window.setTimeout(() => {
       hoverTimer.current = undefined;

--- a/apps/desktop/tests/use-panel-presentation.test.ts
+++ b/apps/desktop/tests/use-panel-presentation.test.ts
@@ -8,6 +8,9 @@ import {
   pointerEnterPeeks,
   pointerLeaveFires,
   pointerLeaveSchedules,
+  RECEDE_SETTLE_MS,
+  recedeArms,
+  recedeReleases,
 } from "../src/renderer/use-panel-presentation";
 
 test("hovering the capsule peeks; any other shape is already answering", () => {
@@ -18,31 +21,82 @@ test("hovering the capsule peeks; any other shape is already answering", () => {
 
 test("the slot and the composer stay put when the pointer leaves", () => {
   assert.equal(
-    pointerLeaveSchedules({ presentation: PANEL_PRESENTATION.SLOT, hold: false }),
+    pointerLeaveSchedules({ presentation: PANEL_PRESENTATION.SLOT, hold: false, receded: false }),
     false,
     "someone fetching a key is in a browser; the pointer being away is the normal case",
   );
   assert.equal(
-    pointerLeaveSchedules({ presentation: PANEL_PRESENTATION.FEEDBACK, hold: false }),
+    pointerLeaveSchedules({
+      presentation: PANEL_PRESENTATION.FEEDBACK,
+      hold: false,
+      receded: false,
+    }),
     false,
     "a note being written must not be discarded by the pointer wandering off",
   );
   assert.equal(
-    pointerLeaveSchedules({ presentation: PANEL_PRESENTATION.CAPSULE, hold: false }),
+    pointerLeaveSchedules({
+      presentation: PANEL_PRESENTATION.CAPSULE,
+      hold: false,
+      receded: false,
+    }),
     false,
   );
 });
 
 test("a key or ask being typed holds the panel against the pointer", () => {
   assert.equal(
-    pointerLeaveSchedules({ presentation: PANEL_PRESENTATION.PANEL, hold: true }),
+    pointerLeaveSchedules({ presentation: PANEL_PRESENTATION.PANEL, hold: true, receded: false }),
     false,
   );
   assert.equal(
-    pointerLeaveSchedules({ presentation: PANEL_PRESENTATION.PANEL, hold: false }),
+    pointerLeaveSchedules({
+      presentation: PANEL_PRESENTATION.PANEL,
+      hold: false,
+      receded: false,
+    }),
     true,
   );
-  assert.equal(pointerLeaveSchedules({ presentation: PANEL_PRESENTATION.PEEK, hold: false }), true);
+  assert.equal(
+    pointerLeaveSchedules({ presentation: PANEL_PRESENTATION.PEEK, hold: false, receded: false }),
+    true,
+  );
+});
+
+test("a shape that receded out from under the pointer does not close by leaving", () => {
+  assert.equal(
+    pointerLeaveSchedules({ presentation: PANEL_PRESENTATION.PANEL, hold: false, receded: true }),
+    false,
+    "a settings page opening shorter than the last shrinks the shape past a resting hand",
+  );
+  assert.equal(
+    pointerLeaveSchedules({ presentation: PANEL_PRESENTATION.PEEK, hold: false, receded: true }),
+    true,
+    "the peek never follows the panel's content, so a mark there explains nothing",
+  );
+});
+
+test("only a pointer actually on the panel can be left behind by a shrink", () => {
+  assert.equal(recedeArms({ presentation: PANEL_PRESENTATION.PANEL, pointerInside: true }), true);
+  assert.equal(
+    recedeArms({ presentation: PANEL_PRESENTATION.PANEL, pointerInside: false }),
+    false,
+    "a shrink with the pointer already away has nobody to protect",
+  );
+  assert.equal(
+    recedeArms({ presentation: PANEL_PRESENTATION.CAPSULE, pointerInside: true }),
+    false,
+    "the hidden panel's content can resize behind the capsule without moving the shape",
+  );
+});
+
+test("the recede mark releases only once the spring has settled", () => {
+  assert.equal(
+    recedeReleases({ recededAt: 1_000, now: 1_000 + RECEDE_SETTLE_MS - 1 }),
+    false,
+    "mid-spring the vacated footprint still answers as content",
+  );
+  assert.equal(recedeReleases({ recededAt: 1_000, now: 1_000 + RECEDE_SETTLE_MS }), true);
 });
 
 test("the leave timer peeks back to the capsule, or collapses a panel that is not held", () => {


### PR DESCRIPTION
## Summary

- Entering a nested Settings page shorter than the page it replaces springs the surface down past a pointer resting on the old footprint; the next mouse move read as the pointer leaving and collapsed the panel 110ms after someone pressed a row.
- Mark the recede when the panel's measured content height shrinks under a pointer that is on it (`panelReceded`, armed from the same measure that retargets the surface, so the mark stands before the spring can pass the pointer).
- Spend the mark on the one leave it explains — `pointerLeaveSchedules` gains a `receded` input and schedules no collapse for it — so the panel stays open while pointer interception still drops and clicks below pass through. The next enter/leave cycle closes the panel as before.
- Release the mark when a move confirms the pointer on the panel as it now stands, but only after `RECEDE_SETTLE_MS` (exit + shape): mid-spring the vacated footprint itself still answers hit tests as content, and a twitch during the shrink must not spend the protection one frame before the leave it exists for.
- The protection is generic to any content-driven shrink of the drawn panel (a session row leaving does the same physical thing), and the mark is cleared whenever the panel closes another way so it can never swallow a reopened panel's first genuine leave. Also corrects the stale `LEAVE_DELAY_MS` comment claiming the settings tab opts out of pointer-driven closing — a key or ask being typed is what holds.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passes (exit 0), including new unit tests for the arm, spend, and release rules in `apps/desktop/tests/use-panel-presentation.test.ts`
- macOS Electron verification (`./scripts/verify.sh`): `not run` (authored in a Linux cloud workspace; behavior is pointer-driven and not visible in still evidence)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32306165721/artifacts/9384803798) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32306165721)

- Commit: `4b0d1093da955fbe3bda0bdbb743f1e5ba1c24d1`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: A hands-on pass on a physical Mac is worth doing: open Settings, enter a short nested page (e.g. Shortcuts) with the mouse low in the panel, and confirm the panel holds; then confirm a normal hover-in/hover-out still collapses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/eb7d8ee8-7904-4544-a002-cc0afe31b318)
