### PR TITLE
fix(voice): let a typed ask connect without the microphone permission

### DIFF
--- a/apps/desktop/src/renderer/ask-luke.tsx
+++ b/apps/desktop/src/renderer/ask-luke.tsx
@@ -1,6 +1,5 @@
 import { REALTIME_STATUS, type RealtimeStatus } from "@sidecar/core";
 import { useCallback, useRef, useState } from "react";
-import type { MicrophoneStatus } from "../shared/contracts";
 import { FOCUS_FRAME_LIMIT } from "./credential-entry";
 import { cssCustomProperties } from "./css-custom-properties";
 import { Keycaps } from "./keycaps";
@@ -57,13 +56,15 @@ export type AskHandler = (text: string) => Promise<string | undefined>;
 /**
  * Why an ask could not be opened, said in one sentence the field can show.
  *
- * The refusal is diagnosed from the same two facts the settings rows draw —
- * how far the voice loop got, and what the system said about the microphone —
- * so the sentence under the field and the rows in settings can never tell two
- * different stories. A failure's own message is not repeated here: it lands
- * on the caption strip directly below, where the reply would have.
+ * The refusal is diagnosed from the same fact the settings rows draw — how
+ * far the voice loop got — so the sentence under the field and the rows in
+ * settings can never tell two different stories. The microphone permission
+ * has no say here: typing opens no capture device, and the reply arrives on
+ * the call's receiving half, so a typed ask goes whether or not the system
+ * would let a press capture. A failure's own message is not repeated here:
+ * it lands on the caption strip directly below, where the reply would have.
  */
-export function askRefusal(status: RealtimeStatus, microphone: MicrophoneStatus): string {
+export function askRefusal(status: RealtimeStatus): string {
   if (status === REALTIME_STATUS.LISTENING) {
     return "The microphone is open. Finish saying it.";
   }
@@ -74,9 +75,6 @@ export function askRefusal(status: RealtimeStatus, microphone: MicrophoneStatus)
   }
   if (status === REALTIME_STATUS.CONNECTING) {
     return "Still connecting. Ask again in a moment.";
-  }
-  if (microphone !== "granted") {
-    return "Luke answers out loud. Allow the microphone in Settings.";
   }
   if (status === REALTIME_STATUS.FAILED) {
     return "The conversation could not be opened.";

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -143,10 +143,16 @@ const MICROPHONE_DETAIL = {
     "the key comes up, and closes once the exchange settles. Typing to Luke never opens it. " +
     "Which device it opens is the Prefer the Mac's microphone setting's to say.",
   denied:
-    "Denied. It can only be granted back in System Settings, under Privacy & Security, Microphone.",
-  restricted: "Restricted by a system policy, which only the system's manager can change.",
+    "Denied, so the talk key cannot capture. Typing to Luke still works: a typed ask opens no " +
+    "capture device, and the reply is spoken either way. It can only be granted back in " +
+    "System Settings, under Privacy & Security, Microphone.",
+  restricted:
+    "Restricted by a system policy, which only the system's manager can change. Typing to " +
+    "Luke still works: a typed ask opens no capture device.",
   "not-determined":
-    "Not asked yet. The Permissions section on the Settings tab's Voice page can ask while voice is available — a signed-in account includes it, and an OpenAI key also provides it.",
+    "Not asked yet — typing to Luke needs no permission, and only the talk key's capture " +
+    "does. The Permissions section on the Settings tab's Voice page can ask while voice is " +
+    "available — a signed-in account includes it, and an OpenAI key also provides it.",
   unknown: "Unknown. The Permissions section on the Settings tab's Voice page shows its state.",
 };
 

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -808,6 +808,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     // request could fail a standing call that was carrying the typed
     // conversation fine.
     if (microphoneStatus !== "granted") {
+      const pressedAt = talkPressedAt.current;
       const permission = await window.sidecar.requestMicrophone();
       setMicrophoneStatus(permission);
       if (permission !== "granted") {
@@ -818,6 +819,11 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
         );
         return;
       }
+      // The system's prompt can outlive the press that raised it. A key
+      // released — or pressed again — while it stood has no turn left to
+      // open here: opening one would put a live microphone under a key
+      // that is already up.
+      if (talkPressedAt.current !== pressedAt) return;
     }
     session.beginTurn();
     const press = talkKeyPress({ latched: false, microphoneCall: session.microphoneCall });

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -711,9 +711,43 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   }, [options.voiceAvailable, setVoiceStatus, stopMicrophone, voiceStatusNow]);
 
   /**
-   * Opens the call, answering with what the system said about the microphone —
-   * the one fact a caller that could not send anything needs in order to say
-   * why.
+   * Opens the developer's call and feeds it everything a turn is validated
+   * against. Nothing is asked of the system on the way: connecting declares a
+   * bare transceiver, no capture device opens, and the microphone permission
+   * has no part in it — the device stays the press's own act.
+   */
+  const startConversation = useCallback(async (): Promise<boolean> => {
+    setVoiceError(undefined);
+    const session = ensureVoiceSession();
+    if (!(await session.connect())) return false;
+    session.updateSessions(sessionsRef.current, noticeAsksRef.current);
+    // After the roster, which it is rendered against. The reference outlives
+    // the calls themselves on purpose: the announcement it points back at
+    // may have been read out on the speak-only call this one just replaced.
+    session.updateSessionReference(sessionReferenceRef.current);
+    // The announcement's own words re-feed on the same terms, so "what did
+    // you just say?" can be answered on the call that replaced the one that
+    // said it.
+    if (lastAnnouncementRef.current) {
+      session.updateLastAnnouncement(lastAnnouncementRef.current);
+    }
+    session.updateWorkspaceProjects(
+      workspaceProjectsRef.current,
+      defaultWorkspaceProviderRef.current,
+      workspaceProjectDefaultsRef.current,
+    );
+    session.updateGuide(guideRef.current);
+    session.updateIssues(issuesRef.current);
+    return true;
+  }, [ensureVoiceSession]);
+
+  /**
+   * The press's way in: asks the system about the microphone, then opens the
+   * call, answering with what the system said — the one fact a caller that
+   * could not send anything needs in order to say why. The gate belongs here
+   * and not on the call itself, because the press is what opens a capture
+   * device; a call opened for a typed ask goes through {@link startConversation}
+   * and never asks.
    */
   const startMicrophone = useCallback(async (): Promise<MicrophoneStatus> => {
     setVoiceError(undefined);
@@ -728,28 +762,9 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       setTalkOpening(false);
       return permission;
     }
-    if (await session.connect()) {
-      session.updateSessions(sessionsRef.current, noticeAsksRef.current);
-      // After the roster, which it is rendered against. The reference outlives
-      // the calls themselves on purpose: the announcement it points back at
-      // may have been read out on the speak-only call this one just replaced.
-      session.updateSessionReference(sessionReferenceRef.current);
-      // The announcement's own words re-feed on the same terms, so "what did
-      // you just say?" can be answered on the call that replaced the one that
-      // said it.
-      if (lastAnnouncementRef.current) {
-        session.updateLastAnnouncement(lastAnnouncementRef.current);
-      }
-      session.updateWorkspaceProjects(
-        workspaceProjectsRef.current,
-        defaultWorkspaceProviderRef.current,
-        workspaceProjectDefaultsRef.current,
-      );
-      session.updateGuide(guideRef.current);
-      session.updateIssues(issuesRef.current);
-    }
+    await startConversation();
     return permission;
-  }, [ensureVoiceSession]);
+  }, [ensureVoiceSession, startConversation]);
 
   /**
    * Luke's reply is over when it stops being audible, not when the model stops
@@ -837,32 +852,33 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   }, []);
 
   /**
-   * A typed ask to Luke himself. It rides the same call the talk key opens —
-   * permission, connect, then the turn — and opens the same kind of turn:
-   * typing is the developer asking in their own words, so the turn may carry
-   * a tool the way a spoken one may, behind the same roster gauntlet. Answers
-   * with why the ask could not go, or nothing when it did — the reply is
-   // SAFETY: The preceding check establishes the asserted contract.
-   * spoken, and its words land under the panel as the answer.
+   * A typed ask to Luke himself. It rides the same call the talk key opens
+   * and opens the same kind of turn: typing is the developer asking in their
+   * own words, so the turn may carry a tool the way a spoken one may, behind
+   * the same roster gauntlet. But it asks the system for nothing on the way:
+   * typing opens no capture device, and the reply arrives on the call's
+   * receiving half, so a typed ask goes whether or not the system would let
+   * a press capture. Answers with why the ask could not go, or nothing when
+   * it did — the reply is spoken, and its words land under the panel as the
+   * answer.
    */
   const askLuke = useCallback(
     async (text: string): Promise<string | undefined> => {
       const session = ensureVoiceSession();
-      let microphone: MicrophoneStatus = "granted";
       // Luke's own speak-only call cannot carry a typed ask — it was sent no
       // roster to validate one against — so it counts as no call here, and
       // `connect` inside stands it down for the developer's own. A microphone
       // call still connecting is awaited, not doubled.
       if (!session.isConnected || !session.microphoneCall) {
-        microphone = await startMicrophone();
+        await startConversation();
       }
       if (session.sendText(text)) {
         setTypedAsk(true);
         return undefined;
       }
-      return askRefusal(session.status, microphone);
+      return askRefusal(session.status);
     },
-    [ensureVoiceSession, startMicrophone],
+    [ensureVoiceSession, startConversation],
   );
 
   const discardListening = useCallback(() => {
@@ -911,11 +927,13 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     if (options.voice !== undefined) heardVoice.current = options.voice;
     voiceRestartDue.current = decided.due;
     if (decided.action !== VOICE_RESTART.RESTART) return;
+    // Reconnecting is the call's act, not a press: the device the old call
+    // held went with its close, and the next press asks for its own.
     void (async () => {
       await voiceSession.current?.close();
-      await startMicrophone();
+      await startConversation();
     })();
-  }, [options.voice, startMicrophone, voiceStatus]);
+  }, [options.voice, startConversation, voiceStatus]);
 
   const activeStream = activeVoiceStream({
     status: voiceStatus,
@@ -978,8 +996,8 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
 
   // An exchange going live outranks the clock: the conversation has moved on,
   // and a fault the turn hid must not come back once the words finish.
-  // `startMicrophone` clears the calls that have to reconnect; this clears the
-  // one that carried a mid-call error and never dropped.
+  // `startConversation` clears the calls that have to reconnect; this clears
+  // the one that carried a mid-call error and never dropped.
   useEffect(() => {
     if (voiceExchangeActive(voiceStatus)) setVoiceError(undefined);
   }, [voiceStatus]);

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -856,7 +856,17 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       latched: talkLatched.current,
     });
     if (release === TALK_KEY_RELEASE.LATCH) {
-      talkLatched.current = true;
+      // A latch keeps a turn open past the release, so it needs a turn to
+      // keep: pending counts — the tap-to-open flow latches while its call is
+      // still on the way — but a press that opened none, because the
+      // permission prompt or a failed device swallowed it, must not latch, or
+      // the next press would read as the end of a turn nobody is holding.
+      if (
+        voiceSession.current?.turnPending === true ||
+        voiceStatusNow() === REALTIME_STATUS.LISTENING
+      ) {
+        talkLatched.current = true;
+      }
       return;
     }
     talkLatched.current = false;
@@ -874,7 +884,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     ) {
       setTalkOpening(false);
     }
-  }, []);
+  }, [voiceStatusNow]);
 
   /**
    * A typed ask to Luke himself. It rides the same call the talk key opens

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -790,9 +790,10 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
    * the call before it can open a turn, which is what lets the key work without
    * the panel ever being visited.
    *
-   * The talk key going down. Every press goes to the session, including the one
-   * that has no call to press against yet: the microphone opens for the press,
-   * so one that beats the call is remembered and applied when it comes up.
+   * The talk key going down. Every press the system lets capture goes to the
+   * session, including the one that has no call to press against yet: the
+   * microphone opens for the press, so one that beats the call is remembered
+   * and applied when it comes up.
    */
   const beginTalk = useCallback(async () => {
     talkPressedAt.current = performance.now();
@@ -800,6 +801,24 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     // done, which is the release's to answer.
     if (talkLatched.current) return;
     const session = ensureVoiceSession();
+    // The press is what opens a capture device, and the call under it may
+    // have been opened by a typed ask, which asked the system for nothing.
+    // So a press against anything but a granted microphone asks before the
+    // turn opens: refused, the press is dropped here — before its device
+    // request could fail a standing call that was carrying the typed
+    // conversation fine.
+    if (microphoneStatus !== "granted") {
+      const permission = await window.sidecar.requestMicrophone();
+      setMicrophoneStatus(permission);
+      if (permission !== "granted") {
+        // Said where the device failure used to land it: the caption strip.
+        setVoiceError(
+          "The talk key needs the microphone. Allow it in System Settings, " +
+            "under Privacy & Security, Microphone — or type to Luke instead.",
+        );
+        return;
+      }
+    }
     session.beginTurn();
     const press = talkKeyPress({ latched: false, microphoneCall: session.microphoneCall });
     // A press against no call — or against Luke's own speak-only call, which
@@ -811,7 +830,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     // `connect` inside stands Luke's own call down if one is open: the
     // developer pressing the key always gets the developer's call.
     await startMicrophone();
-  }, [ensureVoiceSession, startMicrophone]);
+  }, [ensureVoiceSession, microphoneStatus, startMicrophone]);
 
   /**
    * The talk key coming up. How long it was held is the whole of the decision:

--- a/apps/desktop/tests/ask-luke.test.ts
+++ b/apps/desktop/tests/ask-luke.test.ts
@@ -7,27 +7,29 @@ test("a refused ask is diagnosed from how far the voice loop got", () => {
   // Voice off is the one refusal with a fix the developer can go and do, so
   // it names where the fix lives — and both ways in, because naming only the
   // key would send a signed-in developer to buy one they do not need.
-  assert.match(askRefusal(REALTIME_STATUS.UNAVAILABLE, "granted"), /Sign in/);
-  assert.match(askRefusal(REALTIME_STATUS.UNAVAILABLE, "granted"), /OpenAI key/);
-  assert.match(askRefusal(REALTIME_STATUS.UNAVAILABLE, "granted"), /Settings/);
+  assert.match(askRefusal(REALTIME_STATUS.UNAVAILABLE), /Sign in/);
+  assert.match(askRefusal(REALTIME_STATUS.UNAVAILABLE), /OpenAI key/);
+  assert.match(askRefusal(REALTIME_STATUS.UNAVAILABLE), /Settings/);
   // An open microphone is the developer's own turn, not a fault.
-  assert.match(askRefusal(REALTIME_STATUS.LISTENING, "granted"), /microphone is open/i);
-  assert.match(askRefusal(REALTIME_STATUS.CONNECTING, "granted"), /connecting/i);
+  assert.match(askRefusal(REALTIME_STATUS.LISTENING), /microphone is open/i);
+  assert.match(askRefusal(REALTIME_STATUS.CONNECTING), /connecting/i);
   // The failure's own message lands on the caption strip directly below the
   // field, so this one sends nobody to a settings page.
-  assert.doesNotMatch(askRefusal(REALTIME_STATUS.FAILED, "granted"), /Settings/);
+  assert.doesNotMatch(askRefusal(REALTIME_STATUS.FAILED), /Settings/);
 });
 
-test("a missing microphone explains the conversation, not the keystroke", () => {
-  // The reply is spoken, so the call needs the device even though typing does
-  // not — the sentence has to say why a text field wants a microphone.
-  for (const microphone of ["denied", "restricted", "not-determined", "unknown"] as const) {
-    const refusal = askRefusal(REALTIME_STATUS.IDLE, microphone);
-    assert.match(refusal, /microphone/i);
-    assert.match(refusal, /out loud/i);
+test("no refusal sends a typed ask after the microphone permission", () => {
+  // Typing opens no capture device and the reply arrives on the call's
+  // receiving half, so a typed ask goes whether or not the system would let
+  // a press capture. The one microphone sentence left is the developer's own
+  // open turn, which is a turn under way, not a permission.
+  for (const status of Object.values(REALTIME_STATUS)) {
+    if (status === REALTIME_STATUS.LISTENING) continue;
+    assert.doesNotMatch(askRefusal(status), /microphone/i);
+    assert.doesNotMatch(askRefusal(status), /allow/i);
   }
 });
 
 test("a failure the loop cannot name still answers with something to do", () => {
-  assert.ok(askRefusal(REALTIME_STATUS.READY, "granted").length > 0);
+  assert.ok(askRefusal(REALTIME_STATUS.READY).length > 0);
 });


### PR DESCRIPTION
## Why

Typing to Luke was refused whenever macOS microphone permission was anything but granted: every typed ask ran through `startMicrophone`, whose permission gate returned before `connect()`, so the composer answered "Luke answers out loud. Allow the microphone in Settings." and the ask never went.

The gate was protecting nothing on this path:

- A typed ask never opens a capture device. The developer's call declares a bare `sendrecv` transceiver — no track, no `getUserMedia`, no consent involved — until a talk-key press takes a turn.
- The spoken reply needs no permission either: it arrives on the call's receiving half, which Luke's own speak-only announcement calls (`spoken-notices.ts`, `connect({ microphone: false })`) already open with no permission check at all.

So the keyboard was gated on a grant the path never uses.

## What

- `use-voice-conversation.ts`: split `startConversation` (connect + feed roster/reference/announcement/projects/guide/issues, asks nothing of the system) out of `startMicrophone`, which keeps the permission gate — the press is what opens a device — and delegates to it when granted. The typed ask and the voice-change reconnect now call `startConversation` directly, so neither asks for (or pops) a permission prompt.
- `ask-luke.tsx`: `askRefusal` loses its now-unreachable microphone branch and parameter; refusals diagnose from the voice loop's status alone.
- `luke-guide.ts`: the microphone facts for denied / restricted / not-determined now say typing still works, so Luke describes himself truthfully.
- `ask-luke.test.ts`: the old test's premise ("the reply is spoken, so the call needs the device") was false; replaced with a pin that no refusal sends a typed ask after the microphone permission.

The talk key's behavior is unchanged: a press still runs the permission gate before opening a call, and the capture device still opens only for a press.

## Verification

`./scripts/check.sh` passes (repository checks, types, tests, builds). Renderer-logic-only change — no motion, layout, or macOS packaging touched, so no visual evidence run; no physical-notch check performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b4f40dca-85c4-4b11-86e8-572c8bd9e9a3)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32309177511/artifacts/9385833728) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32309177511)

- Commit: `7adce0f05a13784ccede865d9fd325f01b28c2c3`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
