### PR TITLE
fix(claude): hide archived sessions

### DIFF
--- a/PROVIDERS.md
+++ b/PROVIDERS.md
@@ -35,7 +35,7 @@ What each provider's sessions report:
 
 | Provider | Id | Sessions | Credential | Lifecycle hook | Recap | Opens at |
 | --- | --- | --- | --- | --- | --- | --- |
-| Claude Code | `claude-code` | Local | None | `settings.json` merge | Designated away summary | — |
+| Claude Code | `claude-code` | Local | None | `settings.json` merge | Designated away summary; archived sessions omitted when local `sessions-index.json` says so | — |
 | Codex | `codex` | Local and cloud | None; cloud via the Codex CLI login | `hooks.json` merge, behind Codex's trust gate | Last agent message (local) | `codex:` thread link (local), task URL (cloud) |
 | Conductor | `conductor` | Cloud | API key | — | Final assistant message, only while idle | `conductor:` deep link |
 | Cursor | `cursor` | Local and cloud | Cloud only | — | Run result (cloud) | Agent URL (cloud) |

--- a/apps/desktop/src/claude-code-adapter.ts
+++ b/apps/desktop/src/claude-code-adapter.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import {
   isRecord,
@@ -156,13 +157,40 @@ interface ParsedClaudeSessionTail {
   usedTool?: boolean;
 }
 
+async function archivedSessionsIn(projectDirectory: string): Promise<ReadonlyMap<string, boolean>> {
+  try {
+    const raw = JSON.parse(
+      await fs.readFile(path.join(projectDirectory, "sessions-index.json"), "utf8"),
+    );
+    if (!isRecord(raw) || !Array.isArray(raw.entries)) return new Map();
+    const archived = new Map<string, boolean>();
+    for (const entry of raw.entries) {
+      if (!isRecord(entry)) continue;
+      const sessionId = text(entry.sessionId);
+      const isArchived = entry.isArchived;
+      if (!sessionId || (isArchived !== true && isArchived !== false)) continue;
+      archived.set(sessionId, isArchived);
+    }
+    return archived;
+  } catch {
+    // Metadata is a best-effort provider signal. A missing or unreadable index
+    // leaves archive state unknown rather than treating every session as open.
+    return new Map();
+  }
+}
+
 /** Claude Code keeps a session's transcript directly in its project directory. */
 async function sessionFilesIn(projectDirectory: string): Promise<SessionFileCandidate[]> {
   const entries = await readDirectory(projectDirectory);
+  const archived = await archivedSessionsIn(projectDirectory);
   const candidates = await Promise.all(
     entries.map(async (entry) => {
       const providerSessionId = sessionIdFromFileName(entry.name, CLAUDE_SESSION_FILE_EXTENSION);
       if (!providerSessionId) return undefined;
+      // Claude's index is authoritative when it explicitly marks a session
+      // archived. Missing, invalid, or false metadata leaves the transcript
+      // visible; archive state is never inferred from CLI resume membership.
+      if (archived.get(providerSessionId) === true) return undefined;
       const candidate = await statDirectoryEntry(projectDirectory, entry.name);
       if (!candidate?.stats.isFile()) return undefined;
       return {


### PR DESCRIPTION
## Summary
- Read Claude Code project `sessions-index.json` metadata.
- Omit only sessions explicitly marked `isArchived: true`.
- Keep sessions visible when metadata is missing, invalid, unreadable, or false.
- Document the provider behavior.

## Validation
- Targeted Biome check: passed.
- `pnpm --filter @luke/desktop typecheck`: passed.
- `pnpm test:harness`: 42 passed.
- Desktop tests: 963 passed; 44 failed/cancelled because Electron could not install under the host disk-full condition.
- `git diff --check`: passed.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32308067005/artifacts/9385446388) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32308067005)

- Commit: `df0bdb274e294d76ada1e8dda3debd10214dfdf7`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
