### PR TITLE
fix(codex): hide archived local Codex threads from the session roster

### DIFF
--- a/PROVIDERS.md
+++ b/PROVIDERS.md
@@ -87,8 +87,9 @@ end — into a spool under Luke's own application data.
 ## Codex
 
 Local sessions need no credential. Luke reads the read-only session index in
-`state_5.sqlite` under `~/.codex` (honoring `CODEX_HOME`), then bounded tails
-of each thread's rollout file. The observation hook merges into `hooks.json`
+`state_5.sqlite` under `~/.codex` (honoring `CODEX_HOME`), skipping archived
+threads — a chat filed away in Codex's own UI is not a row — then bounded
+tails of each thread's rollout file. The observation hook merges into `hooks.json`
 and runs only after Codex's own review gate shows it to the user and they
 trust it; its events match Claude Code's minus stop failure.
 

--- a/apps/desktop/src/codex-adapter.ts
+++ b/apps/desktop/src/codex-adapter.ts
@@ -11,7 +11,6 @@ import {
   type ProviderSessionObservation,
   recordFromJsonLine,
   SESSION_COMPLETION_CAUSE,
-  SESSION_ROSTER_RETENTION_MS,
   SESSION_STATUS,
   type SessionDetail,
   type SessionProvider,
@@ -76,7 +75,6 @@ const CODEX_THREAD_LINK_PREFIX = "codex://threads/";
 const CODEX_THREAD_COLUMN = {
   ID: "id",
   CWD: "cwd",
-  ARCHIVED: "archived",
   CREATED_AT: "created_at",
   UPDATED_AT: "updated_at",
   CREATED_AT_MS: "created_at_ms",
@@ -152,6 +150,10 @@ const CODEX_ADAPTER_DEFAULTS = {
 // Every column is read defensively from the row, so the projection stays `*`:
 // Codex adds columns by migration, and naming one this build expects but an
 // older install lacks would fail the whole query rather than one field.
+// An archived thread is one the user filed away in Codex's own UI, so it is
+// no row at all rather than a completed one — the same reading OpenCode's
+// archived sessions get — and archiving touches the row's clock, so anything
+// short of excluding it outright would resurface it as fresh.
 const CODEX_THREAD_QUERY = `
   WITH observed_threads AS (
     SELECT
@@ -169,7 +171,7 @@ const CODEX_THREAD_QUERY = `
   FROM observed_threads
   WHERE id <> ''
     AND cwd <> ''
-    AND (archived = 0 OR luke_observed_at_ms >= ?)
+    AND archived = 0
   ORDER BY luke_observed_at_ms DESC,
     id DESC
 `;
@@ -417,15 +419,11 @@ function modelFromRow(row: CodexThreadRow): string | undefined {
 }
 
 function statusFromRow(
-  row: CodexThreadRow,
   rollout: ParsedCodexRollout | undefined,
   observedAt: number,
   now: number,
   activeSessionFreshnessMs: number,
 ): ProviderSessionObservation["status"] {
-  if ((numberFromRow(row, CODEX_THREAD_COLUMN.ARCHIVED) ?? 0) !== 0) {
-    return SESSION_STATUS.COMPLETE;
-  }
   // A turn that failed is stuck until someone comes back to it, so the error
   // outranks freshness: going stale is exactly what a session waiting on a
   // rescue looks like, and decaying it to unknown would hide the one row
@@ -520,15 +518,15 @@ function observationFromThreadRow(
       : CODEX_ADAPTER_DEFAULTS.HOOK_EVENT_TOLERANCE_MS;
   const eventStands = hookEvent !== undefined && hookEvent.atMs + toleranceMs >= rowAt;
   const observedAt = eventStands ? Math.max(rowAt, hookEvent.atMs) : rowAt;
-  let status = statusFromRow(row, rollout, observedAt, now, activeSessionFreshnessMs);
+  let status = statusFromRow(rollout, observedAt, now, activeSessionFreshnessMs);
   if (eventStands) {
     const isFresh = now - observedAt <= activeSessionFreshnessMs;
     status = statusWithHookEvent(status, hookEvent.event, isFresh);
   }
-  const archived = (numberFromRow(row, CODEX_THREAD_COLUMN.ARCHIVED) ?? 0) !== 0;
   const completionCause =
     status === SESSION_STATUS.COMPLETE &&
-    (archived || (eventStands && hookEvent.event === CODEX_HOOK_EVENT.SESSION_END))
+    eventStands &&
+    hookEvent.event === CODEX_HOOK_EVENT.SESSION_END
       ? SESSION_COMPLETION_CAUSE.SESSION_CLOSED
       : undefined;
   return {
@@ -575,7 +573,7 @@ export class CodexSessionAdapter extends LocalSessionAdapter {
         now = this.observationTime();
         rows = database
           .prepare(CODEX_THREAD_QUERY)
-          .all(now - SESSION_ROSTER_RETENTION_MS.SETTLED_MS)
+          .all()
           .filter((row): row is CodexThreadRow => isRecord(row));
       } catch (error) {
         if (error instanceof Error && canIgnoreSqliteError(error)) continue;
@@ -617,13 +615,12 @@ export class CodexSessionAdapter extends LocalSessionAdapter {
   }
 
   /**
-   * Reads the turn boundary for the threads that can still change. An archived
-   * thread has already settled, and the cap keeps a crowded day from turning
-   * one observation pass into dozens of file reads.
+   * Reads the turn boundary for each observed thread, newest first. The cap
+   * keeps a crowded day from turning one observation pass into dozens of file
+   * reads.
    */
   async #rollouts(rows: readonly CodexThreadRow[]): Promise<Map<string, ParsedCodexRollout>> {
     const candidates = rows
-      .filter((row) => (numberFromRow(row, CODEX_THREAD_COLUMN.ARCHIVED) ?? 0) === 0)
       .slice(0, CODEX_ADAPTER_DEFAULTS.MAXIMUM_ROLLOUT_READS)
       .map((row) => ({
         id: textFromRow(row, CODEX_THREAD_COLUMN.ID),
@@ -658,14 +655,12 @@ export class CodexSessionAdapter extends LocalSessionAdapter {
     const hookEventsDirectory = this.#hookEventsDirectory?.();
     if (!hookEventsDirectory) return events;
     await Promise.all(
-      rows
-        .filter((row) => (numberFromRow(row, CODEX_THREAD_COLUMN.ARCHIVED) ?? 0) === 0)
-        .map(async (row) => {
-          const id = textFromRow(row, CODEX_THREAD_COLUMN.ID);
-          if (!id) return;
-          const event = await readCodexHookEvent(hookEventsDirectory, id).catch(() => undefined);
-          if (event) events.set(id, event);
-        }),
+      rows.map(async (row) => {
+        const id = textFromRow(row, CODEX_THREAD_COLUMN.ID);
+        if (!id) return;
+        const event = await readCodexHookEvent(hookEventsDirectory, id).catch(() => undefined);
+        if (event) events.set(id, event);
+      }),
     );
     return events;
   }

--- a/apps/desktop/tests/codex-adapter.test.ts
+++ b/apps/desktop/tests/codex-adapter.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import test, { type TestContext } from "node:test";
-import { SESSION_COMPLETION_CAUSE, SESSION_STATUS } from "@sidecar/core";
+import { InMemorySessionRegistry, SESSION_COMPLETION_CAUSE, SESSION_STATUS } from "@sidecar/core";
 import { CODEX_PROVIDER, CodexSessionAdapter } from "../src/codex-adapter";
 import type { ParsedJsonObject } from "./support/json";
 
@@ -708,9 +708,11 @@ test("keeps stale unarchived Codex sessions unknown instead of inventing activit
   assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
 });
 
-// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-test("keeps archived Codex threads as closed completed rows", async (t) => {
+test("hides archived Codex threads however recently they were touched", async (t) => {
   const codexHome = await temporaryCodexHome(t);
+  // Archiving touches the row's clock, so the freshly-touched archived thread
+  // is the one that would resurface if anything short of the archive flag
+  // itself decided the roster.
   await writeCodexState(codexHome, [
     {
       id: "old-session",
@@ -718,7 +720,7 @@ test("keeps archived Codex threads as closed completed rows", async (t) => {
       observedAt: TEST_TIME - 90_000,
     },
     {
-      id: "archived-session",
+      id: "just-archived-session",
       cwd: "/Users/test/archived",
       observedAt: TEST_TIME - 3 * 24 * 60 * 60 * 1000,
       recencyAt: TEST_TIME - 3 * 24 * 60 * 60 * 1000,
@@ -726,8 +728,8 @@ test("keeps archived Codex threads as closed completed rows", async (t) => {
       archived: 1,
     },
     {
-      id: "expired-archived-session",
-      cwd: "/Users/test/expired-archived",
+      id: "long-archived-session",
+      cwd: "/Users/test/long-archived",
       observedAt: TEST_TIME - 3 * 24 * 60 * 60 * 1000,
       archived: 1,
     },
@@ -748,30 +750,54 @@ test("keeps archived Codex threads as closed completed rows", async (t) => {
     observations.map((observation) => ({
       providerSessionId: observation.providerSessionId,
       status: observation.status,
-      completionCause: observation.completionCause,
       title: observation.title,
     })),
     [
       {
-        providerSessionId: "archived-session",
-        status: SESSION_STATUS.COMPLETE,
-        completionCause: SESSION_COMPLETION_CAUSE.SESSION_CLOSED,
-        title: "archived",
-      },
-      {
         providerSessionId: "new-session",
         status: SESSION_STATUS.WORKING,
-        completionCause: undefined,
         title: "new",
       },
       {
         providerSessionId: "old-session",
         status: SESSION_STATUS.WORKING,
-        completionCause: undefined,
         title: "old",
       },
     ],
   );
+});
+
+test("a thread archived between passes leaves the roster and stays gone", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeCodexState(codexHome, [
+    {
+      id: "codex-live",
+      cwd: "/Users/test/luke",
+      observedAt: TEST_TIME - 10_000,
+    },
+  ]);
+  const adapter = new CodexSessionAdapter({ codexHome, now: () => TEST_TIME });
+  const registry = new InMemorySessionRegistry();
+
+  await registry.refresh(adapter);
+  assert.deepEqual(
+    registry.list().map((session) => session.providerSessionId),
+    ["codex-live"],
+  );
+
+  const database = new DatabaseSync(path.join(codexHome, CODEX_STATE_DATABASE), {});
+  try {
+    // Codex touches the row's clock as it archives — exactly the touch that
+    // must not read as fresh news.
+    database
+      .prepare("UPDATE threads SET archived = 1, updated_at_ms = ?, recency_at_ms = ? WHERE id = ?")
+      .run(TEST_TIME, TEST_TIME, "codex-live");
+  } finally {
+    database.close();
+  }
+
+  await registry.refresh(adapter);
+  assert.deepEqual(registry.list(), []);
 });
 
 test("returns an empty snapshot when Codex has no local state database", async (t) => {


### PR DESCRIPTION
## Summary

- Exclude archived threads from the Codex thread query outright (`AND archived = 0`), the same reading OpenCode's archived sessions get: a chat filed away in Codex's own UI is not a row. The old clause admitted an archived row for the whole settled-retention window, and archiving touches the row's clock, so filing a chat away is exactly what resurfaced it as a fresh completed row.
- Remove the now-unreachable archived handling in the adapter: the archived → complete status branch, the archived arm of the session-closed completion cause (the hook's `SessionEnd` path remains), the per-row archived filters in the rollout and hook-spool reads, and the unused `ARCHIVED` column constant and retention import.
- Replace the test that pinned the old behavior with one asserting archived threads stay hidden however recently they were touched, and add a two-pass registry test: a live thread archived between observation passes leaves the roster and stays gone.
- Note the skipped archived threads in `PROVIDERS.md`'s Codex section.

Nothing downstream re-surfaces a vanished session: the registry replaces a provider's sessions wholesale, the notice tracker forgets sessions absent from a pass, and transcript readout is roster-validated.

## Verification

- `./scripts/check.sh` exits 0 (repository checks, types, all workspace tests, builds); portable-only change, no UI or macOS surface touched.
- Codex adapter suite: 33/33, including the two new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a8739daa-26a0-48c9-8ccd-77bf485861f8)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32308890426/artifacts/9385744293) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32308890426)

- Commit: `84d10d9d317025497e397b72f25ad393a1e4a347`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
