### PR TITLE
feat(attention): stay silent for sessions waiting on automation

### DIFF
--- a/packages/sidecar-core/src/attention-examples.ts
+++ b/packages/sidecar-core/src/attention-examples.ts
@@ -88,6 +88,29 @@ export const ATTENTION_TUNING_EXAMPLES: readonly AttentionTuningExample[] = [
       "The session reached a resting point and nothing is blocked, so it waits for a natural pause rather than interrupting.",
   },
   {
+    name: "A turn ends waiting on automation, not the developer",
+    update: {
+      providerId: "codex",
+      providerSessionId: "example-automation",
+      trigger: ATTENTION_TRIGGER.STATUS_CHANGED,
+      providerName: "Codex",
+      title: "Rename the quickstart headings",
+      status: SESSION_STATUS.WAITING,
+      previousStatus: SESSION_STATUS.WORKING,
+      recap:
+        "Pushed the heading rename to the pull request. CI is running, and a watcher will add it to the merge queue when the checks pass.",
+      context: { repository: "docs-site", branch: "codex/quickstart-headings" },
+      observedAt: 1_760_000_240_000,
+    },
+    expected: {
+      disposition: ATTENTION_DISPOSITION.SILENT,
+      summary: null,
+      answers_ask: false,
+    },
+    rationale:
+      "The session waits on CI and the merge queue, not on the developer; nothing they could reply would move it, and the merge itself is the development worth hearing about.",
+  },
+  {
     name: "A session stops on a failure it cannot pass",
     update: {
       providerId: "claude-code",

--- a/packages/sidecar-core/src/attention-prompt.ts
+++ b/packages/sidecar-core/src/attention-prompt.ts
@@ -31,6 +31,7 @@ const ATTENTION_INSTRUCTION_LINES: readonly string[] = [
   "",
   "Rules:",
   "- Default to silence when the update is routine, ambiguous, or merely continues work already underway.",
+  "- A session waiting on automation it set in motion — CI, a merge queue, a watcher it left running — is not waiting on the developer: nothing they reply can move it, so stay silent and let the automation's outcome be the development.",
   `- A speaking summary is one short spoken sentence under ${maximumAttentionSummaryLength} characters. Say what the session needs, not merely that it changed.`,
   "- Prefer the session's own recap and title over its status when deciding what to say; the status alone is rarely worth an interruption.",
   "- When the update names a workspace, the session is one chat of it.",


### PR DESCRIPTION
## Summary

A turn that ends waiting on CI or a merge queue is not blocked on the developer, but the attention evaluator's only `waiting` tuning example was a turn blocked on a decision, so sessions parked on automation were announced as needing a developer reply.

- Add an instruction line to the evaluator prompt: a session waiting on automation it set in motion — CI, a merge queue, a watcher it left running — is not waiting on the developer, so stay silent and let the automation's outcome be the development.
- Add a synthetic tuning example deciding `silent` for a turn that ends `working → waiting` with a recap saying CI is running and a watcher will enqueue the merge.

The eventual merge still gets announced: the recap/status change it produces is a fresh development the evaluator reviews on its own.

## Testing

- `./scripts/check.sh` passes (exit 0): repository contract checks, lint, typecheck, all tests, builds. Portable-only change — no UI or macOS surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/e32e7ed3-d904-4be6-98af-da58f04561f7)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32308953744/artifacts/9385754806) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32308953744)

- Commit: `74fb833c7766152bb95772de275dc0480ee4e906`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
