### PR TITLE
docs: drop workflow prose the agent guide already binds

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -8,22 +8,19 @@
    would have caught a behavior bug; use visual evidence for appearance-only
    changes.
 3. Run `./scripts/check.sh` for portable-only work. For a macOS, Electron-window,
-   native-adapter, microphone, or desktop UI change, run `./scripts/verify.sh`;
-   it packages the desktop app and generates visual evidence. Inspect all PNGs.
-   For a web UI change, run `pnpm --filter @luke/web dev` and inspect the page in
-   a browser. For desktop motion changes, run `pnpm evidence:record`
-   on a physical Mac and inspect the generated MP4 or GIF before publishing it.
+   native-adapter, microphone, or desktop UI change, run `./scripts/verify.sh`
+   and inspect all PNGs. For a web UI change, run `pnpm --filter @luke/web dev`
+   and inspect the page in a browser. For desktop motion changes, run
+   `pnpm evidence:record` on a physical Mac and inspect the generated MP4 or GIF
+   before publishing it.
 4. Review the complete diff for secrets, machine-specific paths, generated
    files, unsafe IPC, unsupported provider behavior, and accidental scope
    expansion.
-5. Open a focused PR. Record commands and results in the template's Evidence
-   section. For every UI change, upload an inspected verification screenshot to
-   the PR description's Evidence section through GitHub's PR editor. For desktop
-   UI, use a PNG from `./scripts/verify.sh` in `artifacts/evidence/`; for web UI,
-   capture the page after running `pnpm --filter @luke/web dev`. CI
-   maintains the automated-evidence link there. Attach physical-device
-   screenshots or recordings through GitHub's PR editor and call out
-   physical-notch checks that remain.
+5. Open a focused PR and record commands and results in the template's Evidence
+   section. Every UI change needs an inspected verification screenshot there,
+   uploaded through GitHub's PR editor: for desktop UI, a PNG `./scripts/verify.sh`
+   wrote to `artifacts/evidence/`; for web UI, a capture of the page served by
+   `pnpm --filter @luke/web dev`.
 6. When pushing follow-up commits to an open PR, re-read the PR description and
    update it if the change made it inaccurate or incomplete. Keep the summary,
    scope, and Evidence section matching the commands and results for the current


### PR DESCRIPTION
## Summary

- `WORKFLOW.md` steps 3 and 5 restated rules that the agent guide's handoff paragraph (`AGENTS.md:341-348`) already binds, so the two files could drift apart on the same rule.
- Step 3 described what `verify.sh` does; the canonical command list in the agent guide already says it.
- Step 5 restated the CI evidence link and the physical-notch note, said "through GitHub's PR editor" twice in one step, and re-listed bullets `.github/pull_request_template.md` already prints.
- What survives is the guidance that lives nowhere else: which changes trigger `verify.sh`, the web UI inspection path, and which artifact belongs to which surface.

Steps 1, 2, 4, 6, and 7 are unchanged. Step 4 was left alone deliberately: its items overlap the agent guide's constraints, but a checklist of what to look for in a diff does a different job from a rule you follow while writing.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — pass (exit 0). 1,550 tests across four packages, 0 failed, 0 cancelled, 0 skipped, on Node v24.19.0 per `.nvmrc`.
- macOS Electron verification (`./scripts/verify.sh`): `not run` — documentation-only change, no macOS, Electron-window, native-adapter, microphone, or UI surface touched.

Rebased onto `origin/main` after `feat(voice): speak directly as Luke (#296)` and the other five commits landed; the handoff paragraph this change defers to survived that rebase intact and the diff is still `WORKFLOW.md` alone.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32312762803/artifacts/9387074237) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32312762803)

- Commit: `68edf01dfc510e53257251ed124b96a1d2c358a0`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not applicable` — no UI change.
- Physical-notch check: `not performed` — no UI change.
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: None for this change. Unrelated observation while validating: `scripts/oxlint.sh:15` runs `nvm install`, which resolves `.nvmrc` (`24`) to the newest 24.x rather than any already-installed 24.x. On a machine missing that exact patch it tries to build Node from source, which is a long detour inside `check.sh`. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)