### PR TITLE
fix(superset): act on observed sessions without a host id

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -105,8 +105,8 @@ Luke never modifies the running app.
   the fact of a failed turn rather than the reason Cursor recorded for it. A
   session is labelled by the folder it runs in, which Luke reads from Cursor's
   own record of that folder, not from the chat's generated name.
-- For Superset, Luke discovers each `host/<host-id>/host.db`, opens it in
-  read-only defensive mode, and reads project and workspace names, branches,
+- For Superset, Luke discovers each `host/<organization-id>/host.db`, opens it
+  in read-only defensive mode, and reads project and workspace names, branches,
   pull-request links, terminal identifiers, configured agent kinds, lifecycle
   events, and the agent's own session identifier. That identifier is joined
   exactly to a session Luke already observed; Luke does not infer membership
@@ -141,13 +141,15 @@ waiting three minutes ends the login process.
 
 Luke asks macOS's property-list utility whether the CLI config names an active
 organization and receives only that identifier; Luke never opens the config or
-receives its credential fields. A message or control runs only from the developer's press or a turn
-the developer opened, invokes the CLI executable directly without a shell, and
-passes only the observed host, workspace and terminal identifiers plus the
-developer's own message. Luke never reads, copies, or stores the CLI token. The
-CLI is Superset's cloud client and its own telemetry and privacy terms apply to
-commands it runs. Without its login, these actions do not appear and local
-observation continues unchanged.
+receives its credential fields. Actions are offered only on the workspaces that
+organization's own host database recorded. A message or control runs only from
+the developer's press or a turn the developer opened, invokes the CLI executable
+directly without a shell, and passes only the observed workspace and terminal
+identifiers plus the developer's own message. It names no host: those workspaces
+are on this machine, which is the CLI's own default target. Luke never reads,
+copies, or stores the CLI token. The CLI is Superset's cloud client and its own
+telemetry and privacy terms apply to commands it runs. Without its login, these
+actions do not appear and local observation continues unchanged.
 
 A developer-opened conversation may also ask Luke to create a Superset
 workspace. Luke first asks the CLI for accessible hosts, their projects, and

--- a/apps/desktop/src/desktop-app.ts
+++ b/apps/desktop/src/desktop-app.ts
@@ -157,7 +157,7 @@ const supersetWorkspaces = new SupersetWorkspaceReader({
 const supersetCli = new SupersetCli({ homeDirectory: supersetHomeDirectory });
 const supersetWorkspaceAdapter = new SupersetWorkspaceAdapter(supersetCli);
 let observedSupersetWorkspaces = new SupersetWorkspaceSnapshot([]);
-let observedSupersetActionsEnabled = false;
+let observedSupersetOrganization: string | undefined;
 // `directory` and the cipher are read lazily so the store can be declared before
 // the Electron app is ready.
 const settingsStore = new SettingsStore({
@@ -874,9 +874,11 @@ function registerIpc(): void {
     issueTrackers,
     refreshIssues: () => void issueObservationLoop.refresh(),
     supersetContext: (identity) =>
-      observedSupersetActionsEnabled
-        ? observedSupersetWorkspaces.context(identity.providerId, identity.providerSessionId)
-        : undefined,
+      observedSupersetWorkspaces.actableContext(
+        identity.providerId,
+        identity.providerSessionId,
+        observedSupersetOrganization,
+      ),
     supersetCli,
   });
 
@@ -975,24 +977,28 @@ async function applyLocalSessionHooks(): Promise<void> {
 }
 
 async function refreshProviderSessions(generation: number): Promise<void> {
-  const actionsWereEnabled = observedSupersetActionsEnabled;
+  const actionsWereEnabled = observedSupersetOrganization !== undefined;
   let supersetSnapshot = new SupersetWorkspaceSnapshot([]);
-  let supersetActionsEnabled = false;
+  let supersetOrganization: string | undefined;
   try {
     const supersetAgentDefault = await settingsStore.get(
       APP_SETTING_SCHEMA.supersetAgentDefault.field,
     );
-    [supersetSnapshot, supersetActionsEnabled] = await Promise.all([
+    [supersetSnapshot, supersetOrganization] = await Promise.all([
       supersetWorkspaces.read(),
-      supersetCli.connected(),
+      supersetCli.activeOrganization(),
     ]);
-    await supersetWorkspaceAdapter.refresh(supersetAgentDefault, supersetActionsEnabled);
+    await supersetWorkspaceAdapter.refresh(
+      supersetAgentDefault,
+      supersetOrganization !== undefined,
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     process.stderr.write(`Superset observation failed: ${message}\n`);
   }
   observedSupersetWorkspaces = supersetSnapshot;
-  observedSupersetActionsEnabled = supersetActionsEnabled;
+  observedSupersetOrganization = supersetOrganization;
+  const supersetActionsEnabled = supersetOrganization !== undefined;
   if (actionsWereEnabled !== supersetActionsEnabled) {
     if (supersetActionsEnabled) {
       panels.broadcast(channels.supersetSignInChanged, {
@@ -1013,7 +1019,7 @@ async function refreshProviderSessions(generation: number): Promise<void> {
     orderedRegistrations.map(async ({ adapter }) => {
       try {
         await sessionRegistry.refresh(adapter, (providerId, observations) =>
-          supersetSnapshot.enrich(providerId, observations, supersetActionsEnabled),
+          supersetSnapshot.enrich(providerId, observations, supersetOrganization),
         );
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/apps/desktop/src/superset-cli.ts
+++ b/apps/desktop/src/superset-cli.ts
@@ -142,11 +142,15 @@ export class SupersetCli {
   }
 
   async connected(): Promise<boolean> {
-    if (!(await this.installed())) return false;
+    return (await this.activeOrganization()) !== undefined;
+  }
+
+  async activeOrganization(): Promise<string | undefined> {
+    if (!(await this.installed())) return undefined;
     try {
-      return ((await this.#organizationId())?.trim().length ?? 0) > 0;
+      return (await this.#organizationId())?.trim() || undefined;
     } catch {
-      return false;
+      return undefined;
     }
   }
 
@@ -332,6 +336,13 @@ export class SupersetCli {
     }
   }
 
+  /**
+   * The acts on an observed session pass no `--host`, which is the CLI's own
+   * default: this machine, where every host database Luke reads lives. `--host`
+   * names a machine id, and the only identifier a session carries is the
+   * organization its `host/` directory is named by; a host Superset cannot
+   * place answers "Host is not online" rather than acting.
+   */
   async sendMessage(context: SupersetSessionContext, text: string): Promise<ProviderMessageResult> {
     return this.#act(
       [
@@ -339,8 +350,6 @@ export class SupersetCli {
         "send",
         "--workspace",
         context.workspaceId,
-        "--host",
-        context.hostId,
         "--terminal",
         context.terminalId,
         "--text",
@@ -357,7 +366,7 @@ export class SupersetCli {
   ): Promise<ProviderControlResult> {
     if (controlId === SUPERSET_CONTROL_ID.OPEN_WORKSPACE) {
       return this.#act(
-        ["workspaces", "open", context.workspaceId, "--host", context.hostId, "--json"],
+        ["workspaces", "open", context.workspaceId, "--json"],
         "Superset could not open that workspace.",
       );
     }
@@ -368,8 +377,6 @@ export class SupersetCli {
           "close",
           "--workspace",
           context.workspaceId,
-          "--host",
-          context.hostId,
           "--terminal",
           context.terminalId,
           "--json",
@@ -397,8 +404,6 @@ export class SupersetCli {
         "create",
         "--workspace",
         context.workspaceId,
-        "--host",
-        context.hostId,
         "--agent",
         agent,
         "--prompt",

--- a/apps/desktop/src/superset-workspaces.ts
+++ b/apps/desktop/src/superset-workspaces.ts
@@ -56,7 +56,13 @@ const SUPERSET_AGENT_QUERY = `
 export interface SupersetSessionContext {
   providerId: string;
   providerSessionId: string;
-  hostId: string;
+  /**
+   * The organization whose local host service recorded the session, which is
+   * what the directory under `host/` is named by. It is not a host id: the
+   * machine's own host id is written nowhere Luke reads, and every database
+   * under that directory belongs to this machine.
+   */
+  organizationId: string;
   workspaceId: string;
   workspaceName: string;
   terminalId: string;
@@ -68,7 +74,7 @@ export interface SupersetSessionContext {
 }
 
 function contextFromRow(
-  hostId: string,
+  organizationId: string,
   row: WireRecord,
   spawnableAgents: readonly string[],
 ): SupersetSessionContext | undefined {
@@ -96,7 +102,7 @@ function contextFromRow(
   const context: SupersetSessionContext = {
     providerId,
     providerSessionId,
-    hostId,
+    organizationId,
     workspaceId,
     workspaceName,
     terminalId,
@@ -107,6 +113,18 @@ function contextFromRow(
   if (branch) context.branch = branch;
   if (pullRequestUrl) context.pullRequestUrl = pullRequestUrl;
   return context;
+}
+
+/**
+ * An act reaches Superset through the CLI's own login, which serves one
+ * organization at a time, so only sessions the active organization's host
+ * service recorded can be acted on at all.
+ */
+function actableInOrganization(
+  context: SupersetSessionContext,
+  activeOrganizationId: string | undefined,
+): boolean {
+  return activeOrganizationId !== undefined && context.organizationId === activeOrganizationId;
 }
 
 export class SupersetWorkspaceSnapshot {
@@ -127,10 +145,19 @@ export class SupersetWorkspaceSnapshot {
     return this.#sessions.get(providerId)?.get(providerSessionId);
   }
 
+  actableContext(
+    providerId: string,
+    providerSessionId: string,
+    activeOrganizationId: string | undefined,
+  ): SupersetSessionContext | undefined {
+    const context = this.context(providerId, providerSessionId);
+    return context && actableInOrganization(context, activeOrganizationId) ? context : undefined;
+  }
+
   enrich(
     providerId: string,
     observations: readonly ProviderSessionObservation[],
-    actionsEnabled = false,
+    activeOrganizationId?: string,
   ): readonly ProviderSessionObservation[] {
     return observations.map((observation) => {
       const context = this.context(providerId, observation.providerSessionId);
@@ -145,7 +172,7 @@ export class SupersetWorkspaceSnapshot {
         scopeId: SUPERSET_WORKSPACE_PROVIDER_ID,
         managerName: "Superset",
       };
-      if (!actionsEnabled) {
+      if (!actableInOrganization(context, activeOrganizationId)) {
         return { ...observation, detail, workspace };
       }
       const controls = [
@@ -204,15 +231,15 @@ export class SupersetWorkspaceReader {
         entries
           .filter((entry) => entry.isDirectory())
           .map((entry) =>
-            this.#readHost(entry.name, path.join(hostDirectory, entry.name, "host.db")),
+            this.#readOrganization(entry.name, path.join(hostDirectory, entry.name, "host.db")),
           ),
       )
     ).flat();
     return new SupersetWorkspaceSnapshot(contexts);
   }
 
-  async #readHost(
-    hostId: string,
+  async #readOrganization(
+    organizationId: string,
     databasePath: string,
   ): Promise<readonly SupersetSessionContext[]> {
     const database = await openReadOnlyDatabase(this.#sqlite, databasePath);
@@ -233,7 +260,7 @@ export class SupersetWorkspaceReader {
         .flatMap((value) => {
           const row = wireRecord(value);
           if (!row) return [];
-          const context = contextFromRow(hostId, row, spawnableAgents);
+          const context = contextFromRow(organizationId, row, spawnableAgents);
           return context ? [context] : [];
         });
     } catch (error) {

--- a/apps/desktop/tests/superset-cli.test.ts
+++ b/apps/desktop/tests/superset-cli.test.ts
@@ -42,7 +42,7 @@ function testCliOptions(homeDirectory: string) {
 const CONTEXT: SupersetSessionContext = {
   providerId: PROVIDER_ID.CODEX,
   providerSessionId: "session-1",
-  hostId: "host-1",
+  organizationId: "org-1",
   workspaceId: "workspace-1",
   workspaceName: "power-vacation",
   terminalId: "terminal-1",
@@ -59,8 +59,10 @@ test("recognizes only controls owned by Superset", () => {
 test("login state uses only the injected organization-id answer", async (t) => {
   const home = await connectedHome(t);
   const cli = new SupersetCli(testCliOptions(home));
+  assert.equal(await cli.activeOrganization(), "org-1");
   assert.equal(await cli.connected(), true);
   await fs.writeFile(path.join(home, "config.json"), '{"organizationId":""}');
+  assert.equal(await cli.activeOrganization(), undefined);
   assert.equal(await cli.connected(), false);
   await fs.writeFile(path.join(home, "config.json"), "not json");
   assert.equal(await cli.connected(), false);
@@ -103,7 +105,7 @@ test("organization selection is refreshed and switched by exact slug", async (t)
   assert.equal(await cli.chooseOrganization("luke"), true);
 });
 
-test("message and controls use fixed arguments without a shell", async (t) => {
+test("message and controls target this machine with fixed arguments and no shell", async (t) => {
   const home = await connectedHome(t);
   const calls: Array<{ executable: string; arguments_: readonly string[] }> = [];
   const cli = new SupersetCli({
@@ -137,8 +139,6 @@ test("message and controls use fixed arguments without a shell", async (t) => {
         "send",
         "--workspace",
         "workspace-1",
-        "--host",
-        "host-1",
         "--terminal",
         "terminal-1",
         "--text",
@@ -148,7 +148,7 @@ test("message and controls use fixed arguments without a shell", async (t) => {
     },
     {
       executable: path.join(home, "bin", "superset"),
-      arguments_: ["workspaces", "open", "workspace-1", "--host", "host-1", "--json"],
+      arguments_: ["workspaces", "open", "workspace-1", "--json"],
     },
     {
       executable: path.join(home, "bin", "superset"),
@@ -157,8 +157,6 @@ test("message and controls use fixed arguments without a shell", async (t) => {
         "close",
         "--workspace",
         "workspace-1",
-        "--host",
-        "host-1",
         "--terminal",
         "terminal-1",
         "--json",
@@ -171,8 +169,6 @@ test("message and controls use fixed arguments without a shell", async (t) => {
         "create",
         "--workspace",
         "workspace-1",
-        "--host",
-        "host-1",
         "--agent",
         "claude",
         "--prompt",

--- a/apps/desktop/tests/superset-workspaces.test.ts
+++ b/apps/desktop/tests/superset-workspaces.test.ts
@@ -15,8 +15,8 @@ async function temporarySupersetHome(t: TestContext): Promise<string> {
   return directory;
 }
 
-async function writeHostDatabase(home: string, hostId: string): Promise<DatabaseSync> {
-  const directory = path.join(home, "host", hostId);
+async function writeHostDatabase(home: string, organizationId: string): Promise<DatabaseSync> {
+  const directory = path.join(home, "host", organizationId);
   await fs.mkdir(directory, { recursive: true });
   return new DatabaseSync(path.join(directory, "host.db"), {});
 }
@@ -49,7 +49,7 @@ function createSchema(database: DatabaseSync): void {
 
 test("reads live host databases and enriches an exact provider session", async (t) => {
   const home = await temporarySupersetHome(t);
-  const database = await writeHostDatabase(home, "host-local");
+  const database = await writeHostDatabase(home, "org-local");
   createSchema(database);
   database.exec(`
     INSERT INTO projects VALUES ('project-1', 'Luke');
@@ -67,7 +67,7 @@ test("reads live host databases and enriches an exact provider session", async (
   assert.deepEqual(snapshot.context(PROVIDER_ID.CODEX, "session-1"), {
     providerId: PROVIDER_ID.CODEX,
     providerSessionId: "session-1",
-    hostId: "host-local",
+    organizationId: "org-local",
     workspaceId: "workspace-1",
     workspaceName: "power-vacation",
     terminalId: "terminal-1",
@@ -110,32 +110,35 @@ test("reads live host databases and enriches an exact provider session", async (
   );
 });
 
-test("keeps the newest duplicate binding across host databases", async (t) => {
+test("keeps the newest duplicate binding across organization databases", async (t) => {
   const home = await temporarySupersetHome(t);
-  for (const [hostId, updatedAt] of [
-    ["host-old", 100],
-    ["host-new", 200],
+  for (const [organizationId, updatedAt] of [
+    ["org-old", 100],
+    ["org-new", 200],
   ] as const) {
-    const database = await writeHostDatabase(home, hostId);
+    const database = await writeHostDatabase(home, organizationId);
     createSchema(database);
     database.exec(`
       INSERT INTO workspaces VALUES (
-        'workspace-${hostId}', NULL, NULL, '${hostId}', 'main', ${updatedAt}
+        'workspace-${organizationId}', NULL, NULL, '${organizationId}', 'main', ${updatedAt}
       );
       INSERT INTO terminal_agent_bindings VALUES (
-        'terminal-${hostId}', 'workspace-${hostId}', 'claude', 'shared-session', 'Stop'
+        'terminal-${organizationId}', 'workspace-${organizationId}', 'claude', 'shared-session', 'Stop'
       );
     `);
     database.close();
   }
 
   const snapshot = await new SupersetWorkspaceReader({ homeDirectory: home }).read();
-  assert.equal(snapshot.context(PROVIDER_ID.CLAUDE_CODE, "shared-session")?.hostId, "host-new");
+  assert.equal(
+    snapshot.context(PROVIDER_ID.CLAUDE_CODE, "shared-session")?.organizationId,
+    "org-new",
+  );
 });
 
-test("advertises Superset actions only after the CLI is connected", async (t) => {
+test("advertises Superset actions only for the logged-in organization", async (t) => {
   const home = await temporarySupersetHome(t);
-  const database = await writeHostDatabase(home, "host-local");
+  const database = await writeHostDatabase(home, "org-local");
   createSchema(database);
   database.exec(`
     INSERT INTO workspaces VALUES ('workspace-1', NULL, NULL, 'power-vacation', 'main', 100);
@@ -154,7 +157,17 @@ test("advertises Superset actions only after the CLI is connected", async (t) =>
   };
 
   assert.equal(snapshot.enrich(PROVIDER_ID.CODEX, [observation])[0]?.canReceiveMessage, undefined);
-  const connected = snapshot.enrich(PROVIDER_ID.CODEX, [observation], true)[0];
+  assert.equal(
+    snapshot.enrich(PROVIDER_ID.CODEX, [observation], "org-elsewhere")[0]?.canReceiveMessage,
+    undefined,
+  );
+  assert.equal(snapshot.actableContext(PROVIDER_ID.CODEX, "session-1", undefined), undefined);
+  assert.equal(snapshot.actableContext(PROVIDER_ID.CODEX, "session-1", "org-elsewhere"), undefined);
+  assert.equal(
+    snapshot.actableContext(PROVIDER_ID.CODEX, "session-1", "org-local")?.workspaceId,
+    "workspace-1",
+  );
+  const connected = snapshot.enrich(PROVIDER_ID.CODEX, [observation], "org-local")[0];
   assert.equal(connected?.canReceiveMessage, true);
   assert.deepEqual(connected?.spawnableAgents, ["claude", "codex"]);
   assert.equal(connected?.spawnTarget, "workspace-1");
@@ -169,7 +182,7 @@ test("treats missing and drifted Superset state as no enrichment", async (t) => 
   const empty = await new SupersetWorkspaceReader({ homeDirectory: home }).read();
   assert.equal(empty.context(PROVIDER_ID.CODEX, "session-1"), undefined);
 
-  const database = await writeHostDatabase(home, "host-drifted");
+  const database = await writeHostDatabase(home, "org-drifted");
   database.exec("CREATE TABLE future_workspaces (id TEXT PRIMARY KEY)");
   database.close();
   const drifted = await new SupersetWorkspaceReader({ homeDirectory: home }).read();
@@ -178,7 +191,7 @@ test("treats missing and drifted Superset state as no enrichment", async (t) => 
 
 test("does not attach unknown Superset agent kinds to a Luke provider", async (t) => {
   const home = await temporarySupersetHome(t);
-  const database = await writeHostDatabase(home, "host-local");
+  const database = await writeHostDatabase(home, "org-local");
   createSchema(database);
   database.exec(`
     INSERT INTO workspaces VALUES ('workspace-1', NULL, NULL, 'power-vacation', 'main', 100);


### PR DESCRIPTION
## Summary

- Superset's per-session acts passed `--host <directory name>`, taking the directory a session was read from for a host id. `~/.superset/host/<id>/host.db` is named by the **organization** the local host service serves, not by a machine id, so the CLI could not place the host and answered `Error: Host is not online` — "Open in Superset", "Close terminal", sending a message, and spawning an agent all failed on every Superset row.
- Every session Luke observes lives in a host database on this machine, which is exactly what the CLI's own default target means, so the four acts (`workspaces open`, `terminals close`, `terminals send`, `agents create`) now name no host at all. Each documents `--host` as "default: this machine"; the machine's own host id is written nowhere Luke reads.
- `SupersetSessionContext` carries `organizationId` instead of the misnamed `hostId`, and acts are advertised only where that organization is the one the CLI is logged in to: the login serves one organization at a time, so a workspace another organization's host service recorded is not reachable through it and now advertises nothing rather than a control that cannot work.
- `PRIVACY.md` corrects the discovery path and the identifiers an act sends.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (exit 0; 1189 desktop tests, 0 failures)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — no renderer, window, or motion change; this is main-process provider logic and documentation

Verified against the real CLI (v1.23.0) on this machine, with the failing and fixed argument vectors side by side:

```
$ superset terminals close --workspace <ws> --host <organization id> --terminal <t> --json
Error: Host is not online            # exit 1, terminal still listed as active

$ superset terminals close --workspace <ws> --terminal <t> --json
{ "terminalId": "…", "status": "disposed" }    # exit 0, terminal gone from `terminals list`
```

```
$ superset workspaces open <ws> --host <organization id> --print --json
Error: Host is not online

$ superset workspaces open <ws> --print --json
{ "id": "…", "name": "…", "url": "superset://v2-workspace/…" }
```

The close round trip used a scratch terminal created for the check and disposed by it. `workspaces open` was exercised with `--print`, which resolves the workspace exactly as the act does without raising a window.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32312712271/artifacts/9387041357) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32312712271)

- Commit: `60d23cf741cc870935e0ecae5d3b9abe4c983a78`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` — nothing drawn changes
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)