### PR TITLE
fix(settings): draw the Superset mark whole and drop the local host annotation

### DIFF
--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -380,7 +380,8 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "workspace or session the agent should join adds one beside it instead. Only reported " +
         "projects can be named, a project that needs a task cannot be created " +
         "without one, and a provider that reports none takes no ask. Superset asks for more than " +
-        "the others: every Superset project is listed against the host that runs it, and a new " +
+        "the others: every Superset project carries the host that runs it — named for a remote " +
+        "host, unannotated on this Mac — and a new " +
         "Superset workspace needs that host, an agent Superset currently lists for it, and an " +
         "opening task — so a task-less ask for one is refused rather than created idle. An ask that names no " +
         "provider goes to the default workspace provider; until one is chosen Luke asks when " +

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -871,13 +871,12 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   transform: scale(0.94);
 }
 
-/* Superset's bracket mark is two and a half times as wide as it is tall, so
-   fitted to the box's width it carries far less ink than the square marks; it
-   is scaled up until its weight sits beside theirs, and the overhang past the
-   box is empty margin in every place a mark is drawn. */
-.provider-mark[data-mark="superset"] {
-  transform: scale(1.3);
-}
+/* Superset's bracket mark is two and a half times as wide as it is tall, and
+   it takes no scale at all: a credential row pulls its mark box left until a
+   mark fitted to the box's width sits flush with the identity's clip
+   boundary, so any overhang past the box is cut, not empty margin. Fitted to
+   the width, the glyph carries less ink than the square marks — that is the
+   published proportion, shown whole rather than enlarged and clipped. */
 
 /* The work is happening somewhere the user cannot see. The badge overhangs the
    mark's box rather than sitting inside it, so it reads as attached to the mark

--- a/apps/desktop/src/superset-cli.ts
+++ b/apps/desktop/src/superset-cli.ts
@@ -219,12 +219,15 @@ export class SupersetCli {
   async workspaceProjects(defaultAgent?: string): Promise<readonly WorkspaceProject[]> {
     if (!(await this.connected())) return [];
     const remoteHosts = await this.#records(["hosts", "list", "--json"]);
-    const targets = [
-      { id: LOCAL_TARGET_ID, name: "This Mac", arguments_: ["--local"] as const },
+    // Only a remote host names itself on a project: the local target is the
+    // machine the user is sitting at, which the rows already say by wearing
+    // no cloud badge, so annotating it would state the default.
+    const targets: readonly { id: string; name?: string; arguments_: readonly string[] }[] = [
+      { id: LOCAL_TARGET_ID, arguments_: ["--local"] },
       ...remoteHosts.slice(0, SUPERSET_TARGET_LIMIT).flatMap((host) => {
         const id = text(host.machineId) ?? text(host.id);
         const name = text(host.name) ?? text(host.displayName) ?? text(host.hostname) ?? id;
-        return id && name ? [{ id, name, arguments_: ["--host", id] as const }] : [];
+        return id && name ? [{ id, name, arguments_: ["--host", id] }] : [];
       }),
     ];
     const projects = await Promise.all(
@@ -252,9 +255,11 @@ export class SupersetCli {
             repository: name,
             taskSupport: WORKSPACE_TASK_SUPPORT.REQUIRED,
             providerTargetId: target.id,
-            targetName: target.name,
             spawnableAgents: agents,
           };
+          if (target.name) {
+            project.targetName = target.name;
+          }
           if (selectedDefault) {
             project.defaultAgent = selectedDefault;
           }

--- a/apps/desktop/tests/superset-cli.test.ts
+++ b/apps/desktop/tests/superset-cli.test.ts
@@ -269,7 +269,6 @@ test("discovers host-scoped projects and creates a workspace with a generated br
       repository: "Luke",
       taskSupport: "required",
       providerTargetId: "local",
-      targetName: "This Mac",
       spawnableAgents: ["codex", "claude"],
       defaultAgent: "codex",
     },


### PR DESCRIPTION
Follow-up to #299. The credential row pulls its mark box left until a mark fitted to the box's width sits flush with the identity's clip boundary (`.credential-identity { overflow: hidden }` + `.credential-mark { margin: 0 -3.5px }`), so the `scale(1.3)` that bought the wide bracket glyph its optical weight pushed its outer brackets past the clip and cut them off on the Providers row.

The mark now renders at its box's width — the published 2.5:1 proportion, shown whole — and the CSS comment records why this one mark must not be scaled past its box.

Reproduced and verified in a headless-Chrome render of the row geometry: at `scale(1.3)` the left bracket clips exactly as in the report; unscaled, the glyph draws whole.

This branch currently includes #299's commits; it will be rebased onto main the moment #299 leaves the merge queue, leaving only the two Superset row fixes: the unscaled mark, and the dropped "on This Mac" annotation (Luke's own string — the Superset CLI names only remote hosts, which keep their names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/7af9d073-ca4f-46cd-b680-69aec2384e1c)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32315831348/artifacts/9388032903) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32315831348)

- Commit: `4f174e05afb0d6f7261c70df9f9ef76823ae200b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

