### PR TITLE
fix(codex): resolve delegated chat titles

### DIFF
--- a/apps/desktop/src/codex-adapter.ts
+++ b/apps/desktop/src/codex-adapter.ts
@@ -55,6 +55,8 @@ const CODEX_DATABASE_FILE = {
   STATE: "state_5.sqlite",
 } as const;
 
+const CODEX_SESSION_INDEX_FILE = "session_index.jsonl";
+
 const CODEX_CONFIG_FILE = {
   USER: "config.toml",
 } as const;
@@ -71,6 +73,14 @@ const CODEX_CONFIG_KEY = {
  * the row and the address it opens name one thread rather than two.
  */
 const CODEX_THREAD_LINK_PREFIX = "codex://threads/";
+
+/**
+ * Codex uses this synthetic title for locally-created delegation sessions.
+ * It identifies the source chat for Codex itself, but is not a user-facing
+ * title and can be misleading when shown in Luke's session list.
+ */
+const CODEX_DELEGATION_TITLE =
+  /<codex_delegation>\s*<source_thread_id>\s*([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\s*<\/source_thread_id>/i;
 
 const CODEX_THREAD_COLUMN = {
   ID: "id",
@@ -404,11 +414,33 @@ export async function stateDatabasePaths(
  * Codex names its own threads, and that name is what a developer is looking
  * for. The workspace is the fallback for a thread too new to have been named.
  */
-function titleFromRow(row: CodexThreadRow): string {
-  return (
-    oneLine(textFromRow(row, CODEX_THREAD_COLUMN.TITLE), maximumSessionTitleLength) ??
-    workspaceLabel(textFromRow(row, CODEX_THREAD_COLUMN.CWD))
-  );
+function titleFromRow(row: CodexThreadRow, sessionTitles: ReadonlyMap<string, string>): string {
+  const title = oneLine(textFromRow(row, CODEX_THREAD_COLUMN.TITLE), maximumSessionTitleLength);
+  if (title) {
+    const sourceThreadId = CODEX_DELEGATION_TITLE.exec(title)?.[1];
+    if (sourceThreadId) {
+      return (
+        sessionTitles.get(textFromRow(row, CODEX_THREAD_COLUMN.ID) ?? "") ??
+        sessionTitles.get(sourceThreadId) ??
+        workspaceLabel(textFromRow(row, CODEX_THREAD_COLUMN.CWD))
+      );
+    }
+    return title;
+  }
+  return workspaceLabel(textFromRow(row, CODEX_THREAD_COLUMN.CWD));
+}
+
+async function readCodexSessionTitles(codexHome: string): Promise<Map<string, string>> {
+  const titles = new Map<string, string>();
+  const contents = await readTextFile(path.join(codexHome, CODEX_SESSION_INDEX_FILE));
+  if (!contents) return titles;
+  for (const line of contents.split(/\r?\n/u)) {
+    const record = recordFromJsonLine(line);
+    const id = text(record?.id);
+    const title = oneLine(text(record?.thread_name), maximumSessionTitleLength);
+    if (id && title) titles.set(id, title);
+  }
+  return titles;
 }
 
 function modelFromRow(row: CodexThreadRow): string | undefined {
@@ -497,6 +529,7 @@ function detailFromRow(
 function observationFromThreadRow(
   row: CodexThreadRow,
   rollout: ParsedCodexRollout | undefined,
+  sessionTitles: ReadonlyMap<string, string>,
   now: number,
   activeSessionFreshnessMs: number,
   hookEvent?: ObservedCodexHookEvent,
@@ -531,7 +564,7 @@ function observationFromThreadRow(
       : undefined;
   return {
     providerSessionId,
-    title: titleFromRow(row),
+    title: titleFromRow(row, sessionTitles),
     status,
     ...(completionCause ? { completionCause } : undefined),
     observedAt,
@@ -587,11 +620,13 @@ export class CodexSessionAdapter extends LocalSessionAdapter {
       // writing.
       const rollouts = await this.#rollouts(rows);
       const hookEvents = await this.#hookEvents(rows);
+      const sessionTitles = await readCodexSessionTitles(this.#codexHome);
       return rows
         .map((row) =>
           observationFromThreadRow(
             row,
             rollouts.get(textFromRow(row, CODEX_THREAD_COLUMN.ID) ?? ""),
+            sessionTitles,
             now,
             this.activeSessionFreshnessMs,
             hookEvents.get(textFromRow(row, CODEX_THREAD_COLUMN.ID) ?? ""),

--- a/apps/desktop/tests/codex-adapter.test.ts
+++ b/apps/desktop/tests/codex-adapter.test.ts
@@ -137,6 +137,16 @@ async function writeCodexConfig(codexHome: string, source: string): Promise<void
   await fs.writeFile(path.join(codexHome, "config.toml"), source);
 }
 
+async function writeCodexSessionIndex(
+  codexHome: string,
+  entries: readonly { id: string; threadName: string }[],
+): Promise<void> {
+  await fs.writeFile(
+    path.join(codexHome, "session_index.jsonl"),
+    `${entries.map((entry) => JSON.stringify({ id: entry.id, thread_name: entry.threadName })).join("\n")}\n`,
+  );
+}
+
 async function writeMalformedCodexState(codexHome: string): Promise<void> {
   await fs.mkdir(codexHome, { recursive: true });
   const database = new DatabaseSync(path.join(codexHome, CODEX_STATE_DATABASE), {});
@@ -180,6 +190,104 @@ test("observes a Codex thread under the name Codex gave it", async (t) => {
     model: "gpt-5.6-luna · medium",
     link: "codex://threads/codex-active",
   });
+});
+
+test("falls back to the workspace for Codex delegation marker titles", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeCodexState(codexHome, [
+    {
+      id: "codex-delegated",
+      cwd: "/Users/test/delegated-repository",
+      observedAt: TEST_TIME - 1_000,
+      title:
+        "<codex_delegation>\n<source_thread_id>01a01c04-31e2-7be1-a478-0f321abcdef0</source_thread_id>\n</codex_delegation>",
+    },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+
+  const observations = await adapter.observe();
+
+  assert.equal(observations[0]?.title, "delegated-repository");
+});
+
+test("resolves a Codex delegation marker through the source chat title index", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeCodexSessionIndex(codexHome, [
+    { id: "01a01c04-31e2-7be1-a478-0f321abcdef0", threadName: "Fix Luke Voice Announcements" },
+  ]);
+  await writeCodexState(codexHome, [
+    {
+      id: "codex-delegated",
+      cwd: "/Users/test/luke",
+      observedAt: TEST_TIME - 1_000,
+      title:
+        "<codex_delegation>\n<source_thread_id>01a01c04-31e2-7be1-a478-0f321abcdef0</source_thread_id>\n<input>delegated work</input>\n</codex_delegation>",
+    },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+
+  const observations = await adapter.observe();
+
+  assert.equal(observations[0]?.title, "Fix Luke Voice Announcements");
+});
+
+test("prefers a delegated session's own indexed title over its source chat", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeCodexSessionIndex(codexHome, [
+    { id: "01a01c04-31e2-7be1-a478-0f321abcdef0", threadName: "Parent chat" },
+    { id: "codex-delegated", threadName: "Add Claude Code archive status" },
+  ]);
+  await writeCodexState(codexHome, [
+    {
+      id: "codex-delegated",
+      cwd: "/Users/test/luke",
+      observedAt: TEST_TIME - 1_000,
+      title:
+        "<codex_delegation> <source_thread_id>01a01c04-31e2-7be1-a478-0f321abcdef0</source_thread_id> <input>delegated work</input> </codex_delegation>",
+    },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+
+  const observations = await adapter.observe();
+
+  assert.equal(observations[0]?.title, "Add Claude Code archive status");
+});
+
+test("keeps a legitimate title that resembles a delegation marker", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeCodexState(codexHome, [
+    {
+      id: "codex-named",
+      cwd: "/Users/test/luke",
+      observedAt: TEST_TIME - 1_000,
+      title: "<codex_delegation> <source_thread_id>not-a-uuid",
+    },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+
+  const observations = await adapter.observe();
+
+  assert.equal(observations[0]?.title, "<codex_delegation> <source_thread_id>not-a-uuid");
 });
 
 test("addresses a Codex thread by the id Codex files it under", async (t) => {


### PR DESCRIPTION
## Summary
- resolve Codex delegation markers through the local session title index
- prefer each delegated session's own title over its parent title
- fall back to the source title or workspace when needed

## Validation
- Biome check passes for the changed files
- all 37 Codex adapter tests pass

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32314839407/artifacts/9387713054) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32314839407)

- Commit: `7c4ba6e68b5fa300577466f27e567bfbca9d95c3`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
