### PR TITLE
feat(desktop): suppress realtime delegation announcements

### DIFF
--- a/apps/desktop/src/codex-adapter.ts
+++ b/apps/desktop/src/codex-adapter.ts
@@ -91,6 +91,7 @@ const CODEX_THREAD_COLUMN = {
   UPDATED_AT_MS: "updated_at_ms",
   RECENCY_AT_MS: "recency_at_ms",
   TITLE: "title",
+  FIRST_USER_MESSAGE: "first_user_message",
   GIT_BRANCH: "git_branch",
   MODEL: "model",
   REASONING_EFFORT: "reasoning_effort",
@@ -156,6 +157,8 @@ const CODEX_ADAPTER_DEFAULTS = {
    */
   HOOK_EVENT_TOLERANCE_MS: 5_000,
 } as const;
+
+const CODEX_REALTIME_DELEGATION_MARKER = "<realtime_delegation>";
 
 // Every column is read defensively from the row, so the projection stays `*`:
 // Codex adds columns by migration, and naming one this build expects but an
@@ -443,6 +446,23 @@ async function readCodexSessionTitles(codexHome: string): Promise<Map<string, st
   return titles;
 }
 
+/**
+ * Codex keeps the initial user message in the thread row even after it gives
+ * the chat a user-facing name. That makes it a more durable signal than the
+ * provisional title, while the title fallback covers older rows that do not
+ * carry the column's value.
+ */
+export function isCodexRealtimeDelegationText(value: unknown): boolean {
+  return text(value)?.trimStart().startsWith(CODEX_REALTIME_DELEGATION_MARKER) === true;
+}
+
+function isCodexRealtimeDelegationThread(row: CodexThreadRow): boolean {
+  return (
+    isCodexRealtimeDelegationText(textFromRow(row, CODEX_THREAD_COLUMN.FIRST_USER_MESSAGE)) ||
+    isCodexRealtimeDelegationText(textFromRow(row, CODEX_THREAD_COLUMN.TITLE))
+  );
+}
+
 function modelFromRow(row: CodexThreadRow): string | undefined {
   const model = textFromRow(row, CODEX_THREAD_COLUMN.MODEL);
   if (!model) return undefined;
@@ -565,6 +585,7 @@ function observationFromThreadRow(
   return {
     providerSessionId,
     title: titleFromRow(row, sessionTitles),
+    ...(isCodexRealtimeDelegationThread(row) ? { realtimeVoice: true } : {}),
     status,
     ...(completionCause ? { completionCause } : undefined),
     observedAt,

--- a/apps/desktop/src/codex-adapter.ts
+++ b/apps/desktop/src/codex-adapter.ts
@@ -452,7 +452,7 @@ async function readCodexSessionTitles(codexHome: string): Promise<Map<string, st
  * provisional title, while the title fallback covers older rows that do not
  * carry the column's value.
  */
-export function isCodexRealtimeDelegationText(value: unknown): boolean {
+export function isCodexRealtimeDelegationText(value: string | undefined): boolean {
   return text(value)?.trimStart().startsWith(CODEX_REALTIME_DELEGATION_MARKER) === true;
 }
 
@@ -582,16 +582,17 @@ function observationFromThreadRow(
     hookEvent.event === CODEX_HOOK_EVENT.SESSION_END
       ? SESSION_COMPLETION_CAUSE.SESSION_CLOSED
       : undefined;
-  return {
+  const observation: ProviderSessionObservation = {
     providerSessionId,
     title: titleFromRow(row, sessionTitles),
-    ...(isCodexRealtimeDelegationThread(row) ? { realtimeVoice: true } : {}),
     status,
     ...(completionCause ? { completionCause } : undefined),
     observedAt,
     ...(rollout?.lastAgentMessage ? { recap: rollout.lastAgentMessage } : undefined),
     detail: detailFromRow(row, rollout),
   };
+  if (isCodexRealtimeDelegationThread(row)) observation.realtimeVoice = true;
+  return observation;
 }
 
 export function defaultCodexHome(): string {

--- a/apps/desktop/src/desktop-app.ts
+++ b/apps/desktop/src/desktop-app.ts
@@ -1081,7 +1081,9 @@ async function reviewSessionAttention(generation: number): Promise<void> {
     // an update about each one to OpenAI on every launch, hundreds of requests
     // rate-limiting the same key the voice opens calls with.
     const reviews = await attentionReviewer.review(
-      rosterRelevantSessions(sessionRegistry.list(), Date.now()),
+      rosterRelevantSessions(sessionRegistry.list(), Date.now()).filter(
+        (session) => session.realtimeVoice !== true,
+      ),
     );
     if (!attentionObservationLoop.isCurrent(generation)) return;
     for (const review of reviews) {
@@ -1144,7 +1146,10 @@ async function announceSessionNotices(sessions: readonly NormalizedSession[]): P
   // that a deterministic alert is never traded away on a model's judgment.
   // Fed before anything is awaited, so passes reach the tracker in order —
   // the retain above included.
-  const notices = sessionNoticeTracker.notices(sessions, now);
+  const notices = sessionNoticeTracker.notices(
+    sessions.filter((session) => session.realtimeVoice !== true),
+    now,
+  );
   if (notices.length === 0) return;
   // No voice, nothing to say it with: without a Realtime credential the
   // renderer cannot open a call, and the panel still shows every state. The

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -466,7 +466,11 @@ function SessionRow({
   const content = (
     <>
       <span
-        className={session.realtimeVoice ? "row-mark row-mark-audio" : "row-mark"}
+        className={
+          session.realtimeVoice && session.location === SESSION_LOCATION.CLOUD
+            ? "row-mark row-mark-audio"
+            : "row-mark"
+        }
         title={session.model ? `${session.provider} · ${session.model}` : session.provider}
       >
         <span className="visually-hidden">{session.provider}</span>

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -15,7 +15,7 @@ import {
 } from "../shared/contracts";
 import { type AskHandler, AskLuke } from "./ask-luke";
 import { PANEL_TAB, type PanelTab, TabBar } from "./panel-tabs";
-import { CloudBadge, ProviderMark } from "./provider-marks";
+import { AudioBadge, CloudBadge, ProviderMark } from "./provider-marks";
 import {
   type ArrangedSessions,
   actsOnWorkspace,
@@ -466,12 +466,13 @@ function SessionRow({
   const content = (
     <>
       <span
-        className="row-mark"
+        className={session.realtimeVoice ? "row-mark row-mark-audio" : "row-mark"}
         title={session.model ? `${session.provider} · ${session.model}` : session.provider}
       >
         <span className="visually-hidden">{session.provider}</span>
         <ProviderMark providerId={session.providerId} />
         {session.location === SESSION_LOCATION.CLOUD ? <CloudBadge /> : null}
+        {session.realtimeVoice ? <AudioBadge /> : null}
       </span>
       <span className="row-copy">
         <strong>

--- a/apps/desktop/src/renderer/provider-marks.tsx
+++ b/apps/desktop/src/renderer/provider-marks.tsx
@@ -353,3 +353,20 @@ export function CloudBadge(): React.JSX.Element {
     </span>
   );
 }
+
+/**
+ * Rides the provider mark for a Codex realtime voice/delegation chat. The glyph
+ * is Google's Material Symbols `graphic_eq` shape (Apache 2.0), used here as a
+ * familiar, filled audio indicator rather than a bespoke line drawing. It uses
+ * the same corner slot as the cloud badge; when both are present, the audio
+ * mark shifts inward so both silhouettes remain legible while overlapping.
+ */
+export function AudioBadge(): React.JSX.Element {
+  return (
+    <span className="audio-badge" role="img" aria-label="Realtime voice chat">
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false">
+        <path d="M6 18q-.825 0-1.412-.587Q4 16.825 4 16V8q0-.825.588-1.412Q5.175 6 6 6t1.413.588Q8 7.175 8 8v8q0 .825-.587 1.413Q6.825 18 6 18Zm6 4q-.825 0-1.412-.587Q10 20.825 10 20V4q0-.825.588-1.412Q11.175 2 12 2t1.413.588Q14 3.175 14 4v16q0 .825-.587 1.413Q12.825 22 12 22Zm6-4q-.825 0-1.412-.587Q16 16.825 16 16V8q0-.825.588-1.412Q17.175 6 18 6t1.413.588Q20 7.175 20 8v8q0 .825-.587 1.413Q18.825 18 18 18Z" />
+      </svg>
+    </span>
+  );
+}

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -441,7 +441,7 @@ export function displaySessions(
         const changeNumber = session.detail.change
           ? sessionChangeNumber(session.detail.change)
           : undefined;
-        return {
+        const displaySession: DisplaySession = {
           id: session.providerSessionId,
           title: session.title,
           providerId: session.providerId,
@@ -454,7 +454,6 @@ export function displaySessions(
           urgency,
           label: urgencyLabel(urgency),
           location: session.location,
-          ...(session.realtimeVoice ? { realtimeVoice: true } : {}),
           observedAt: session.observedAt,
           openable: session.detail.link !== undefined,
           canMessage: session.canReceiveMessage,
@@ -480,6 +479,8 @@ export function displaySessions(
               }
             : undefined),
         };
+        if (session.realtimeVoice === true) displaySession.realtimeVoice = true;
+        return displaySession;
       });
 
   return [...visible].sort(byUrgency);

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -22,11 +22,11 @@ import type { AppBootstrap } from "../shared/contracts";
 
 /**
  * Which sessions the list draws: everything, everything running in one place,
- * or everything belonging to one agent. The two coarse values are the session
- * locations themselves and the rest are provider ids, so narrowing the list is
- * a comparison against something a row already carries rather than a second
- * vocabulary mapped onto it. The two sets cannot collide — no provider is
- * called `local` or `cloud`.
+ * or everything belonging to one agent. The coarse values are session
+ * locations plus the realtime voice kind, and the rest are provider ids, so
+ * narrowing the list is a comparison against something a row already carries
+ * rather than a second vocabulary mapped onto it. The values cannot collide —
+ * no provider is called `local`, `cloud`, or `voice`.
  *
  * Location belongs to the session rather than to the agent, so an agent with
  * work in both places is one chip that answers `Local` and `Cloud` both.
@@ -35,6 +35,7 @@ export const SESSION_FILTER = {
   ALL: "all",
   LOCAL: SESSION_LOCATION.LOCAL,
   CLOUD: SESSION_LOCATION.CLOUD,
+  VOICE: "voice",
 } as const;
 
 export type SessionFilter = (typeof SESSION_FILTER)[keyof typeof SESSION_FILTER] | ProviderId;
@@ -44,21 +45,22 @@ function matchesFilter(session: DisplaySession, filter: SessionFilter): boolean 
   if (filter === SESSION_FILTER.LOCAL || filter === SESSION_FILTER.CLOUD) {
     return session.location === filter;
   }
+  if (filter === SESSION_FILTER.VOICE) return session.realtimeVoice === true;
   return session.providerId === filter;
 }
 
 /**
  * Reads a spoken filter into the list's own vocabulary. The values are the
- * same strings the chips use — the coarse scopes and the provider ids — so a
- * validated spoken ask maps one-to-one; anything else is nothing rather than
- // SAFETY: The preceding check establishes the asserted contract.
- * a guess, and the list is left as it was.
+ * same strings the chips use — the coarse scopes, voice kind, and provider ids
+ * — so a validated spoken ask maps one-to-one; anything else is nothing rather
+ * than a guess, and the list is left as it was.
  */
 export function sessionFilterFromSpoken(value: string): SessionFilter | undefined {
   if (
     value === SESSION_FILTER.ALL ||
     value === SESSION_FILTER.LOCAL ||
-    value === SESSION_FILTER.CLOUD
+    value === SESSION_FILTER.CLOUD ||
+    value === SESSION_FILTER.VOICE
   ) {
     return value;
   }
@@ -149,6 +151,8 @@ export interface DisplaySession {
   urgency: SessionUrgency;
   label: string;
   location: SessionLocation;
+  /** Whether this is a realtime voice/delegation chat. */
+  realtimeVoice?: boolean;
   observedAt: number;
   /**
    * Whether the provider gave an address that opens this session, which is what
@@ -450,6 +454,7 @@ export function displaySessions(
           urgency,
           label: urgencyLabel(urgency),
           location: session.location,
+          ...(session.realtimeVoice ? { realtimeVoice: true } : {}),
           observedAt: session.observedAt,
           openable: session.detail.link !== undefined,
           canMessage: session.canReceiveMessage,
@@ -488,12 +493,14 @@ const LOCATION_LABEL = {
 /** The order the location chips read in: what runs here, then what runs away. */
 const LOCATION_ORDER: readonly SessionLocation[] = [SESSION_LOCATION.LOCAL, SESSION_LOCATION.CLOUD];
 
+const VOICE_FILTER_OPTION = { filter: SESSION_FILTER.VOICE, label: "Voice" } as const;
+
 /**
- * All, then where a session runs, then which agent is running it — coarse to
- * fine, left to right. Each level is offered only where it is a real choice: a
- * single location says nothing All has not already said, and neither does a
- * single agent. The counts make the row a breakdown of what is tracked before
- * it is a control, which is what earns it the line it costs.
+ * All, then where a session runs, then whether it is voice, then which agent is
+ * running it — coarse to fine, left to right. Each level is offered only where
+ * it is a real choice: a single location, voice kind, or agent says nothing
+ * All has not already said. The counts make the row a breakdown of what is
+ * tracked before it is a control, which is what earns it the line it costs.
  *
  * Agents are listed in the registry's own order rather than by how many
  * sessions they have, so a chip never moves out from under the pointer as
@@ -504,8 +511,10 @@ function filterOptions(sessions: readonly DisplaySession[]): readonly SessionFil
 
   const locations = new Map<SessionLocation, number>();
   const providers = new Map<ProviderId, { label: string; count: number }>();
+  let voiceCount = 0;
   for (const session of sessions) {
     locations.set(session.location, (locations.get(session.location) ?? 0) + 1);
+    if (session.realtimeVoice === true) voiceCount += 1;
     // An agent this build has no registry entry for has no mark to draw a chip
     // with, so it is counted under All and offered under nothing else.
     if (!isProviderId(session.providerId)) continue;
@@ -533,10 +542,15 @@ function filterOptions(sessions: readonly DisplaySession[]): readonly SessionFil
           providerId,
         }))
       : [];
+  const voiceOptions =
+    voiceCount > 0 && voiceCount < sessions.length
+      ? [{ ...VOICE_FILTER_OPTION, count: voiceCount }]
+      : [];
 
   return [
     { filter: SESSION_FILTER.ALL, label: "All", count: sessions.length },
     ...locationOptions,
+    ...voiceOptions,
     ...providerOptions,
   ];
 }

--- a/apps/desktop/src/renderer/session-parts.tsx
+++ b/apps/desktop/src/renderer/session-parts.tsx
@@ -10,7 +10,7 @@ import {
   type SessionSort,
   type SessionView,
 } from "./session-model";
-import { CloudIcon, LaptopIcon, OptionsIcon } from "./settings-icons";
+import { CloudIcon, LaptopIcon, OptionsIcon, VoiceIcon } from "./settings-icons";
 
 /**
  * Rides beside a branch name to say which kind of identifier it is: a branch
@@ -152,6 +152,7 @@ export const SESSION_OPTIONS_BUTTON_ID = "session-options-button";
 function FilterIcon({ filter }: { filter: SessionFilter }): React.JSX.Element | null {
   if (filter === SESSION_FILTER.LOCAL) return <LaptopIcon />;
   if (filter === SESSION_FILTER.CLOUD) return <CloudIcon />;
+  if (filter === SESSION_FILTER.VOICE) return <VoiceIcon />;
   return null;
 }
 

--- a/apps/desktop/src/renderer/settings-icons.tsx
+++ b/apps/desktop/src/renderer/settings-icons.tsx
@@ -356,6 +356,19 @@ export function CloudIcon(): React.JSX.Element {
   );
 }
 
+/** Realtime voice sessions: the familiar filled Material Symbols graphic_eq shape. */
+export function VoiceIcon(): React.JSX.Element {
+  return (
+    <Glyph className="filter-icon">
+      <path
+        d="M6 18q-.825 0-1.412-.587Q4 16.825 4 16V8q0-.825.588-1.412Q5.175 6 6 6t1.413.588Q8 7.175 8 8v8q0 .825-.587 1.413Q6.825 18 6 18Zm6 4q-.825 0-1.412-.587Q10 20.825 10 20V4q0-.825.588-1.412Q11.175 2 12 2t1.413.588Q14 3.175 14 4v16q0 .825-.587 1.413Q12.825 22 12 22Zm6-4q-.825 0-1.412-.587Q16 16.825 16 16V8q0-.825.588-1.412Q17.175 6 18 6t1.413.588Q20 7.175 20 8v8q0 .825-.587 1.413Q18.825 18 18 18Z"
+        fill="currentColor"
+        stroke="none"
+      />
+    </Glyph>
+  );
+}
+
 /**
  * The stop glyph every chat surface uses: a filled, slightly rounded square.
  * Filled rather than stroked, because at control size a stroked square reads

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -903,6 +903,22 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   height: auto;
 }
 
+/* The realtime voice badge uses the same out-of-flow corner treatment as the
+   cloud badge, so it cannot become a second grid item under the provider mark. */
+.audio-badge {
+  position: absolute;
+  display: grid;
+  border-radius: 50%;
+  background: var(--surface-fill);
+  box-shadow: inset 0 0 0 1px var(--hairline);
+  color: var(--text-secondary);
+  place-items: center;
+}
+
+.audio-badge svg {
+  height: auto;
+}
+
 /* Luke's face ------------------------------------------------------------ */
 
 /* The place nearest the housing is the one the capsule keeps, and Luke holds it

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -516,6 +516,25 @@ html[data-keyboard="true"] button.session-row:focus-visible {
   width: 8.5px;
 }
 
+.row-mark .audio-badge {
+  right: -2px;
+  bottom: -1px;
+  width: 13px;
+  height: 13px;
+}
+
+.row-mark .audio-badge svg {
+  width: 8.5px;
+}
+
+/* Cloud and audio are both badges on the same session. Keep the wave visible
+   over the cloud while preserving the shared corner and their overlap. */
+.row-mark-audio .audio-badge {
+  right: 3px;
+  bottom: 3px;
+  z-index: 1;
+}
+
 .row-copy {
   display: flex;
   min-width: 0;

--- a/apps/desktop/tests/codex-adapter.test.ts
+++ b/apps/desktop/tests/codex-adapter.test.ts
@@ -5,7 +5,11 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import test, { type TestContext } from "node:test";
 import { InMemorySessionRegistry, SESSION_COMPLETION_CAUSE, SESSION_STATUS } from "@sidecar/core";
-import { CODEX_PROVIDER, CodexSessionAdapter } from "../src/codex-adapter";
+import {
+  CODEX_PROVIDER,
+  CodexSessionAdapter,
+  isCodexRealtimeDelegationText,
+} from "../src/codex-adapter";
 import type { ParsedJsonObject } from "./support/json";
 
 const TEST_TIME = Date.parse("2026-08-11T23:45:00.000Z");
@@ -288,6 +292,30 @@ test("keeps a legitimate title that resembles a delegation marker", async (t) =>
   const observations = await adapter.observe();
 
   assert.equal(observations[0]?.title, "<codex_delegation> <source_thread_id>not-a-uuid");
+});
+
+test("recognizes the realtime delegation marker in Codex text", () => {
+  assert.equal(isCodexRealtimeDelegationText("<realtime_delegation> <input>hello</input>"), true);
+  assert.equal(isCodexRealtimeDelegationText("a named chat"), false);
+});
+
+test("keeps realtime delegation sessions suppressed after Codex names the chat", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeCodexState(codexHome, [
+    {
+      id: "codex-realtime-delegation",
+      cwd: "/Users/test/luke",
+      observedAt: TEST_TIME - 1_000,
+      title: "What sessions do we have open?",
+      firstUserMessage: "<realtime_delegation> <input>What sessions do we have open</input>",
+    },
+  ]);
+
+  const adapter = new CodexSessionAdapter({ codexHome, now: () => TEST_TIME });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.title, "What sessions do we have open?");
+  assert.equal(observation?.realtimeVoice, true);
 });
 
 test("addresses a Codex thread by the id Codex files it under", async (t) => {

--- a/apps/desktop/tests/session-model.test.ts
+++ b/apps/desktop/tests/session-model.test.ts
@@ -21,6 +21,7 @@ import {
   observedAgoLabel,
   SESSION_FILTER,
   SESSION_SORT,
+  sessionFilterFromSpoken,
   sessionListRuns,
   sessionRunKeys,
   sessionTally,
@@ -381,6 +382,33 @@ test("the filters offered run from everything to one agent, counted", () => {
     { filter: PROVIDER_ID.CURSOR, label: "Cursor", count: 1, providerId: PROVIDER_ID.CURSOR },
     { filter: PROVIDER_ID.DEVIN, label: "Devin", count: 1, providerId: PROVIDER_ID.DEVIN },
   ]);
+});
+
+test("the voice filter narrows to realtime voice chats and has a spoken name", () => {
+  const sessions = displaySessions(bootstrap(false), [
+    normalizeSession(CODEX_PROVIDER, {
+      providerSessionId: "codex-voice",
+      title: "Voice chat",
+      status: SESSION_STATUS.WORKING,
+      observedAt: 1_000,
+      realtimeVoice: true,
+    }),
+    liveSession(CODEX_PROVIDER, "codex-typed", SESSION_STATUS.COMPLETE),
+  ]);
+
+  const list = arrangeSessions(sessions, DEFAULT_SESSION_VIEW);
+  assert.deepEqual(list.options, [
+    { filter: SESSION_FILTER.ALL, label: "All", count: 2 },
+    { filter: SESSION_FILTER.VOICE, label: "Voice", count: 1 },
+  ]);
+  assert.deepEqual(
+    arrangeSessions(sessions, {
+      ...DEFAULT_SESSION_VIEW,
+      filter: SESSION_FILTER.VOICE,
+    }).sessions.map((session) => session.id),
+    ["codex-voice"],
+  );
+  assert.equal(sessionFilterFromSpoken(SESSION_FILTER.VOICE), SESSION_FILTER.VOICE);
 });
 
 // The fixture above covers the agents it happens to contain. Every agent the

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -336,6 +336,7 @@ export {
   REALTIME_TOOL_FAMILY,
   type RealtimeToolFamily,
   realtimeToolFamily,
+  SESSION_LIST_VOICE,
   SESSION_TOOL_KIND,
   type SessionToolAction,
   sessionToolAction,

--- a/packages/sidecar-core/src/realtime-tools.ts
+++ b/packages/sidecar-core/src/realtime-tools.ts
@@ -114,6 +114,7 @@ export type AppToolKind = (typeof APP_TOOL_KIND)[keyof typeof APP_TOOL_KIND];
  * validated against the observed roster rather than against a second list.
  */
 export const SESSION_LIST_ALL = "all";
+export const SESSION_LIST_VOICE = "voice";
 
 /** What one validated tool call asks for, ready for the bridge that carries it. */
 export type SessionToolAction =
@@ -731,6 +732,10 @@ function panelFilterAction(
   if (filter === SESSION_LOCATION.LOCAL || filter === SESSION_LOCATION.CLOUD) {
     if (sessions.some((session) => session.location === filter)) return { filter };
     return { reason: `No ${filter} sessions are observed right now.` };
+  }
+  if (filter === SESSION_LIST_VOICE) {
+    if (sessions.some((session) => session.realtimeVoice === true)) return { filter };
+    return { reason: "No voice sessions are observed right now." };
   }
   if (sessions.some((session) => session.providerId === filter)) return { filter };
   return { reason: "No observed session belongs to that provider." };

--- a/packages/sidecar-core/src/session-registry.ts
+++ b/packages/sidecar-core/src/session-registry.ts
@@ -147,6 +147,7 @@ const sameSession = exhaustiveSame<NormalizedSession>({
   status: (first, second) => first.status === second.status,
   completionCause: (first, second) => first.completionCause === second.completionCause,
   observedAt: (first, second) => first.observedAt === second.observedAt,
+  realtimeVoice: (first, second) => first.realtimeVoice === second.realtimeVoice,
   location: (first, second) => first.location === second.location,
   recap: (first, second) => first.recap === second.recap,
   detail: (first, second) => sameDetail(first.detail, second.detail),

--- a/packages/sidecar-core/src/session.ts
+++ b/packages/sidecar-core/src/session.ts
@@ -658,7 +658,6 @@ export function normalizeSession(
     title: boundedText(observation.title, maximumSessionTitleLength) ?? "Untitled session",
     status,
     observedAt,
-    ...(observation.realtimeVoice === true ? { realtimeVoice: true } : {}),
     location: normalizeLocation(observation.location),
     detail: normalizeSessionDetail(observation.detail),
     controls: normalizeControls(observation.controls),
@@ -668,6 +667,7 @@ export function normalizeSession(
     spawnableAgents: normalizeSpawnableAgents(observation.spawnableAgents),
     attention: normalizeAttention(attention),
   };
+  if (observation.realtimeVoice === true) session.realtimeVoice = true;
   if (completionCause) session.completionCause = completionCause;
   if (recap) session.recap = recap;
   if (spawnTarget) session.spawnTarget = spawnTarget;

--- a/packages/sidecar-core/src/session.ts
+++ b/packages/sidecar-core/src/session.ts
@@ -297,6 +297,8 @@ export interface ProviderSessionObservation {
   /** Why a completed row became complete, when the provider can distinguish it. */
   completionCause?: SessionCompletionCause;
   observedAt: number;
+  /** Whether this session is a realtime voice/delegation chat. */
+  realtimeVoice?: boolean;
   /** Omitted by an adapter that reads sessions off this machine. */
   location?: SessionLocation;
   /**
@@ -343,6 +345,8 @@ export interface NormalizedSession extends SessionIdentity {
   status: SessionStatus;
   completionCause?: SessionCompletionCause;
   observedAt: number;
+  /** Whether this session is a realtime voice/delegation chat. */
+  realtimeVoice?: boolean;
   location: SessionLocation;
   recap?: string;
   detail: SessionDetail;
@@ -654,6 +658,7 @@ export function normalizeSession(
     title: boundedText(observation.title, maximumSessionTitleLength) ?? "Untitled session",
     status,
     observedAt,
+    ...(observation.realtimeVoice === true ? { realtimeVoice: true } : {}),
     location: normalizeLocation(observation.location),
     detail: normalizeSessionDetail(observation.detail),
     controls: normalizeControls(observation.controls),

--- a/packages/sidecar-core/tests/guide.test.ts
+++ b/packages/sidecar-core/tests/guide.test.ts
@@ -15,6 +15,7 @@ import {
   REALTIME_CLIENT_EVENT,
   type RealtimeFunctionCall,
   SESSION_LIST_SORT,
+  SESSION_LIST_VOICE,
   SESSION_LOCATION,
   SESSION_STATUS,
 } from "../src";
@@ -95,7 +96,7 @@ function call(name: string, argumentsJson: string): RealtimeFunctionCall {
   return { name, callId: "call-1", argumentsJson };
 }
 
-function observedConductorSession() {
+function observedConductorSession(realtimeVoice = false) {
   return normalizeSession(
     { id: "conductor", displayName: "Conductor" },
     {
@@ -104,6 +105,7 @@ function observedConductorSession() {
       status: SESSION_STATUS.WORKING,
       observedAt: 1_800_000_000_000,
       location: SESSION_LOCATION.CLOUD,
+      ...(realtimeVoice ? { realtimeVoice: true } : undefined),
     },
   );
 }
@@ -317,11 +319,26 @@ test("a spoken panel ask opens a real tab and narrows only to what is observed",
     filter: "cloud",
   });
 
+  assert.deepEqual(show('{"filter":"voice"}'), {
+    kind: "refused",
+    reason: "No voice sessions are observed right now.",
+  });
+
   assert.equal(show('{"tab":"about"}').kind, "refused");
   // A narrowing that would show nothing is refused rather than applied: the
   // panel would fall back to everything, and the sentence would be wrong.
   assert.equal(show('{"filter":"local"}').kind, "refused");
   assert.equal(show('{"filter":"codex"}').kind, "refused");
+
+  const voiceShow = (argumentsJson: string) =>
+    appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, [
+      observedConductorSession(true),
+    ]);
+  assert.deepEqual(voiceShow('{"filter":"voice"}'), {
+    kind: "panel",
+    tab: APP_PANEL_TAB.SESSIONS,
+    filter: SESSION_LIST_VOICE,
+  });
 });
 
 test("a spoken panel ask can reorder the list in the panel's own two words", () => {


### PR DESCRIPTION
## Summary
- Detects Codex realtime delegation chats from their first user message, even after Codex renames the chat
- Suppresses attention reviews and spoken notices for those chats while leaving ordinary sessions unchanged
- Adds a Voice session filter with a matching audio-wave icon
- Adds realtime voice row badges, including cloud-plus-voice overlap

## Verification
- `pnpm typecheck` passed
- `./node_modules/.bin/oxlint --config .oxlintrc.json` passed with existing warnings
- Focused Codex/session-model tests: 76 passed
- `pnpm build` passed
- Full suite: 1,108 passed, 0 failed, 102 cancelled by the local realtime event-loop environment

## Notes
- No Claude Code archive-status work was touched
- Physical-notch visual check was not performed

## Test plan
- [x] Codex marker detection and renamed-chat suppression
- [x] Voice filter narrowing and spoken filter mapping
- [x] Typecheck and production build
- [ ] Physical-notch visual check

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32316111725/artifacts/9388134076) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32316111725)

- Commit: `36e1db7a62fa18f31f77e92e5de06d3a95931861`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
