### PR TITLE
fix(codex): hold announcements while a realtime voice conversation is live

### DIFF
--- a/PROVIDERS.md
+++ b/PROVIDERS.md
@@ -117,6 +117,24 @@ as a read-only row.
   itself, and the one thing read from the answer is the created task's id.
 - No message path and no controls: Codex documents no way to message or steer
   a task already running, so the honest absence stands.
+- Realtime voice: the rollout tail also says whether a Codex realtime voice
+  conversation is live over a local thread — the world-state snapshots Codex
+  persists carry a `realtime` section, and a delegated turn's
+  `<realtime_delegation>` marker says the same when the snapshot has scrolled
+  past the bounded tail. A thread the developer is speaking with produces no
+  spoken announcements and is left out of attention evaluation while the
+  conversation holds; announcements resume with the first edge after it
+  closes, and nothing from inside it is replayed. A chat born from a realtime
+  delegation is never announced at all, and a chat another conversation
+  delegated — linked back to its source by the delegation marker in the first
+  user message it was born with, so the link survives Codex naming the chat —
+  holds its announcements the same way for as long as the source's voice is
+  live.
+- Delegated chats are labelled by a name Codex actually keeps, never the raw
+  marker: the chat's own newest entry in Codex's `session_index.jsonl` — read
+  as a bounded tail, only on a pass that saw a marker, honoring entries that
+  clear a name — then the source conversation's title or indexed name, then
+  the workspace.
 - Transcript readout: yes for local sessions
   (`apps/desktop/src/codex-transcript.ts`); a cloud task's conversation lives
   with its provider and is never fetched.

--- a/apps/desktop/src/codex-adapter.ts
+++ b/apps/desktop/src/codex-adapter.ts
@@ -2,6 +2,7 @@ import os from "node:os";
 import path from "node:path";
 import {
   isRecord,
+  isWireBoolean,
   isWireNumber,
   isWireString,
   maximumSessionRecapLength,
@@ -102,7 +103,23 @@ const CODEX_THREAD_COLUMN = {
 const CODEX_ROLLOUT_TYPE = {
   EVENT_MSG: "event_msg",
   RESPONSE_ITEM: "response_item",
+  WORLD_STATE: "world_state",
 } as const;
+
+/**
+ * The realtime section of Codex's persisted world state: `{ active: boolean }`,
+ * written into every turn's snapshot. This is the durable record of whether a
+ * realtime voice conversation was open over the thread when its last turn ran —
+ * the voice lifecycle events themselves are transient and never reach the
+ * rollout. A `full` snapshot carries every section, so one without this key is
+ * a build with no realtime at all; a patch reports the section only when it
+ * changed.
+ */
+const CODEX_WORLD_STATE_SECTION = {
+  REALTIME: "realtime",
+} as const;
+
+const CODEX_REALTIME_ACTIVE_KEY = "active";
 
 /**
  * The turn boundary. `threads` carries no status column at all, so without the
@@ -123,6 +140,11 @@ const CODEX_EVENT_PAYLOAD = {
 
 const CODEX_RESPONSE_PAYLOAD = {
   FUNCTION_CALL: "function_call",
+  MESSAGE: "message",
+} as const;
+
+const CODEX_MESSAGE_ROLE = {
+  USER: "user",
 } as const;
 
 /**
@@ -145,6 +167,14 @@ const CODEX_ADAPTER_DEFAULTS = {
   READ_ROLLOUT_TAIL_BYTES: 64 * 1024,
   /** Only the threads that can still change are worth a second file read. */
   MAXIMUM_ROLLOUT_READS: 12,
+  /**
+   * How far back into Codex's append-only name index one pass reads. The
+   * newest entry per thread wins and a delegated chat is created moments
+   * before its title needs resolving, so the names worth having live at the
+   * end; a bounded tail keeps a file that only ever grows from becoming an
+   * unbounded read on every pass.
+   */
+  READ_SESSION_INDEX_TAIL_BYTES: 128 * 1024,
   MAXIMUM_ACTIVITY_LENGTH: 80,
   /**
    * How much older than the thread row's clock a hook event may run and still
@@ -258,6 +288,33 @@ interface ParsedCodexRollout {
   error?: string;
   lastAgentMessage?: string;
   turnComplete?: boolean;
+  /** Whether a realtime voice conversation is live over this thread, when the tail says. */
+  realtimeVoiceLive?: boolean;
+}
+
+/**
+ * Reads whether the realtime voice conversation is open out of one world-state
+ * snapshot, or nothing when the snapshot does not say. A patch that omits the
+ * realtime section left it unchanged; a full snapshot omitting it comes from a
+ * build with no realtime to be in.
+ */
+function realtimeActiveFromWorldState(payload: WireRecord): boolean | undefined {
+  const state = isRecord(payload.state) ? payload.state : undefined;
+  if (!state) return undefined;
+  const realtime = state[CODEX_WORLD_STATE_SECTION.REALTIME];
+  if (isRecord(realtime)) {
+    const active = realtime[CODEX_REALTIME_ACTIVE_KEY];
+    return isWireBoolean(active) ? active : undefined;
+  }
+  return payload.full === true ? false : undefined;
+}
+
+/** Whether a message is the realtime conversation delegating its turn to the thread. */
+function isRealtimeDelegationMessage(payload: WireRecord): boolean {
+  if (payload.role !== CODEX_MESSAGE_ROLE.USER || !Array.isArray(payload.content)) return false;
+  return payload.content.some(
+    (block) => isRecord(block) && isCodexRealtimeDelegationText(text(block.text)),
+  );
 }
 
 /**
@@ -314,11 +371,21 @@ function parseCodexRolloutTail(tail: string): ParsedCodexRollout {
       }
       continue;
     }
-    if (
-      record.type === CODEX_ROLLOUT_TYPE.RESPONSE_ITEM &&
-      payload.type === CODEX_RESPONSE_PAYLOAD.FUNCTION_CALL
-    ) {
-      parsed.activity = activityFromCall(payload) ?? parsed.activity;
+    if (record.type === CODEX_ROLLOUT_TYPE.WORLD_STATE) {
+      parsed.realtimeVoiceLive = realtimeActiveFromWorldState(payload) ?? parsed.realtimeVoiceLive;
+      continue;
+    }
+    if (record.type === CODEX_ROLLOUT_TYPE.RESPONSE_ITEM) {
+      if (payload.type === CODEX_RESPONSE_PAYLOAD.FUNCTION_CALL) {
+        parsed.activity = activityFromCall(payload) ?? parsed.activity;
+      }
+      // A delegation is written only while the conversation is open, so one is
+      // proof of the conversation even when the world-state snapshot that
+      // opened it has scrolled past the bounded tail. The snapshot that closes
+      // it always lands after the last delegation, so last-in-file-order wins.
+      if (payload.type === CODEX_RESPONSE_PAYLOAD.MESSAGE && isRealtimeDelegationMessage(payload)) {
+        parsed.realtimeVoiceLive = true;
+      }
     }
   }
   return parsed;
@@ -413,35 +480,65 @@ export async function stateDatabasePaths(
   );
 }
 
-/**
- * Codex names its own threads, and that name is what a developer is looking
- * for. The workspace is the fallback for a thread too new to have been named.
- */
-function titleFromRow(row: CodexThreadRow, sessionTitles: ReadonlyMap<string, string>): string {
-  const title = oneLine(textFromRow(row, CODEX_THREAD_COLUMN.TITLE), maximumSessionTitleLength);
-  if (title) {
-    const sourceThreadId = CODEX_DELEGATION_TITLE.exec(title)?.[1];
-    if (sourceThreadId) {
-      return (
-        sessionTitles.get(textFromRow(row, CODEX_THREAD_COLUMN.ID) ?? "") ??
-        sessionTitles.get(sourceThreadId) ??
-        workspaceLabel(textFromRow(row, CODEX_THREAD_COLUMN.CWD))
-      );
-    }
-    return title;
-  }
-  return workspaceLabel(textFromRow(row, CODEX_THREAD_COLUMN.CWD));
+interface CodexThreadNameSources {
+  /**
+   * The newest name per thread from Codex's own index, read only on a pass
+   * where a marker title actually needs resolving.
+   */
+  indexNames: ReadonlyMap<string, string>;
+  /** Each observed thread's own titled name, for resolving a delegation's source in the same pass. */
+  rowTitles: ReadonlyMap<string, string>;
 }
 
+/**
+ * Codex names its own threads, and that name is what a developer is looking
+ * for. A delegated chat's derived title is the delegation marker itself, so it
+ * resolves through names Codex actually keeps — the chat's own newest indexed
+ * name first, for one renamed since it was spawned, then the source
+ * conversation's title or indexed name, because the delegated chat is that
+ * conversation's work. The workspace is the fallback for a thread too new to
+ * have been named — or one whose only title is the realtime delegation
+ * scaffolding, which names no source to borrow from.
+ */
+function titleFromRow(row: CodexThreadRow, names: CodexThreadNameSources): string {
+  const title = oneLine(textFromRow(row, CODEX_THREAD_COLUMN.TITLE), maximumSessionTitleLength);
+  const workspace = workspaceLabel(textFromRow(row, CODEX_THREAD_COLUMN.CWD));
+  if (!title) return workspace;
+  const ownName = names.indexNames.get(textFromRow(row, CODEX_THREAD_COLUMN.ID) ?? "");
+  const sourceThreadId = CODEX_DELEGATION_TITLE.exec(title)?.[1];
+  if (sourceThreadId) {
+    return (
+      ownName ??
+      names.rowTitles.get(sourceThreadId) ??
+      names.indexNames.get(sourceThreadId) ??
+      workspace
+    );
+  }
+  if (isCodexRealtimeDelegationText(title)) return ownName ?? workspace;
+  return title;
+}
+
+/**
+ * The newest name Codex's own index holds for each thread. Entries are
+ * append-only and a later line wins; a line with an empty name is the name
+ * being removed, and unmakes what an earlier line said rather than being
+ * skipped past it. The read is a bounded tail: the file only ever grows, and
+ * the names worth having — a delegated chat's, its source's — are recent by
+ * construction.
+ */
 async function readCodexSessionTitles(codexHome: string): Promise<Map<string, string>> {
   const titles = new Map<string, string>();
-  const contents = await readTextFile(path.join(codexHome, CODEX_SESSION_INDEX_FILE));
-  if (!contents) return titles;
-  for (const line of contents.split(/\r?\n/u)) {
+  const tail = await readTail(
+    path.join(codexHome, CODEX_SESSION_INDEX_FILE),
+    CODEX_ADAPTER_DEFAULTS.READ_SESSION_INDEX_TAIL_BYTES,
+  );
+  for (const line of tail.split(/\r?\n/u)) {
     const record = recordFromJsonLine(line);
     const id = text(record?.id);
+    if (!id) continue;
     const title = oneLine(text(record?.thread_name), maximumSessionTitleLength);
-    if (id && title) titles.set(id, title);
+    if (title) titles.set(id, title);
+    else titles.delete(id);
   }
   return titles;
 }
@@ -461,6 +558,44 @@ function isCodexRealtimeDelegationThread(row: CodexThreadRow): boolean {
     isCodexRealtimeDelegationText(textFromRow(row, CODEX_THREAD_COLUMN.FIRST_USER_MESSAGE)) ||
     isCodexRealtimeDelegationText(textFromRow(row, CODEX_THREAD_COLUMN.TITLE))
   );
+}
+
+/**
+ * The source conversation a delegated chat was born from, wherever the marker
+ * survives. The derived title is replaced once Codex names the chat, but the
+ * row keeps the first user message for its whole life, so the link back to the
+ * source outlives the rename; the title stands in for older rows whose column
+ * carries nothing.
+ */
+function delegationSourceFromRow(row: CodexThreadRow): string | undefined {
+  for (const column of [CODEX_THREAD_COLUMN.FIRST_USER_MESSAGE, CODEX_THREAD_COLUMN.TITLE]) {
+    const sourceId = CODEX_DELEGATION_TITLE.exec(textFromRow(row, column) ?? "")?.[1];
+    if (sourceId) return sourceId;
+  }
+  return undefined;
+}
+
+/**
+ * A chat another conversation delegated is a limb of that conversation: while
+ * the source thread's rollout says its realtime voice conversation is open,
+ * the delegated chat's turn boundaries belong to the same spoken exchange and
+ * hold their announcements the same way. The link is the marker Codex itself
+ * wrote the chat's first message with, and the source's state is the same
+ * pass's rollout read — arithmetic against observed state, nothing decided.
+ */
+function linkDelegatedVoiceConversations(
+  rows: readonly CodexThreadRow[],
+  rollouts: Map<string, ParsedCodexRollout>,
+): void {
+  for (const row of rows) {
+    const sourceId = delegationSourceFromRow(row);
+    if (!sourceId || rollouts.get(sourceId)?.realtimeVoiceLive !== true) continue;
+    const id = textFromRow(row, CODEX_THREAD_COLUMN.ID);
+    if (!id) continue;
+    const parsed = rollouts.get(id);
+    if (parsed) parsed.realtimeVoiceLive = true;
+    else rollouts.set(id, { realtimeVoiceLive: true });
+  }
 }
 
 function modelFromRow(row: CodexThreadRow): string | undefined {
@@ -549,7 +684,7 @@ function detailFromRow(
 function observationFromThreadRow(
   row: CodexThreadRow,
   rollout: ParsedCodexRollout | undefined,
-  sessionTitles: ReadonlyMap<string, string>,
+  names: CodexThreadNameSources,
   now: number,
   activeSessionFreshnessMs: number,
   hookEvent?: ObservedCodexHookEvent,
@@ -584,7 +719,7 @@ function observationFromThreadRow(
       : undefined;
   const observation: ProviderSessionObservation = {
     providerSessionId,
-    title: titleFromRow(row, sessionTitles),
+    title: titleFromRow(row, names),
     status,
     ...(completionCause ? { completionCause } : undefined),
     observedAt,
@@ -592,6 +727,7 @@ function observationFromThreadRow(
     detail: detailFromRow(row, rollout),
   };
   if (isCodexRealtimeDelegationThread(row)) observation.realtimeVoice = true;
+  if (rollout?.realtimeVoiceLive === true) observation.realtimeVoiceLive = true;
   return observation;
 }
 
@@ -642,13 +778,14 @@ export class CodexSessionAdapter extends LocalSessionAdapter {
       // writing.
       const rollouts = await this.#rollouts(rows);
       const hookEvents = await this.#hookEvents(rows);
-      const sessionTitles = await readCodexSessionTitles(this.#codexHome);
+      const names = await this.#threadNames(rows);
+      linkDelegatedVoiceConversations(rows, rollouts);
       return rows
         .map((row) =>
           observationFromThreadRow(
             row,
             rollouts.get(textFromRow(row, CODEX_THREAD_COLUMN.ID) ?? ""),
-            sessionTitles,
+            names,
             now,
             this.activeSessionFreshnessMs,
             hookEvents.get(textFromRow(row, CODEX_THREAD_COLUMN.ID) ?? ""),
@@ -698,6 +835,31 @@ export class CodexSessionAdapter extends LocalSessionAdapter {
       }),
     );
     return new Map(parsed);
+  }
+
+  /**
+   * Gathers the names a delegated chat's marker title can resolve through. The
+   * pass's own rows already carry every titled thread; the name index is a
+   * second file read, so it is opened only when some row actually shows a
+   * marker in need of a name.
+   */
+  async #threadNames(rows: readonly CodexThreadRow[]): Promise<CodexThreadNameSources> {
+    const rowTitles = new Map<string, string>();
+    let hasMarkerTitle = false;
+    for (const row of rows) {
+      const id = textFromRow(row, CODEX_THREAD_COLUMN.ID);
+      const title = oneLine(textFromRow(row, CODEX_THREAD_COLUMN.TITLE), maximumSessionTitleLength);
+      if (!id || !title) continue;
+      if (CODEX_DELEGATION_TITLE.test(title) || isCodexRealtimeDelegationText(title)) {
+        hasMarkerTitle = true;
+        continue;
+      }
+      rowTitles.set(id, title);
+    }
+    const indexNames = hasMarkerTitle
+      ? await readCodexSessionTitles(this.#codexHome)
+      : new Map<string, string>();
+    return { indexNames, rowTitles };
   }
 
   /**

--- a/apps/desktop/src/codex-adapter.ts
+++ b/apps/desktop/src/codex-adapter.ts
@@ -504,18 +504,33 @@ function titleFromRow(row: CodexThreadRow, names: CodexThreadNameSources): strin
   const title = oneLine(textFromRow(row, CODEX_THREAD_COLUMN.TITLE), maximumSessionTitleLength);
   const workspace = workspaceLabel(textFromRow(row, CODEX_THREAD_COLUMN.CWD));
   if (!title) return workspace;
-  const ownName = names.indexNames.get(textFromRow(row, CODEX_THREAD_COLUMN.ID) ?? "");
+  const ownName = indexedName(names, textFromRow(row, CODEX_THREAD_COLUMN.ID));
   const sourceThreadId = CODEX_DELEGATION_TITLE.exec(title)?.[1];
   if (sourceThreadId) {
     return (
       ownName ??
       names.rowTitles.get(sourceThreadId) ??
-      names.indexNames.get(sourceThreadId) ??
+      indexedName(names, sourceThreadId) ??
       workspace
     );
   }
   if (isCodexRealtimeDelegationText(title)) return ownName ?? workspace;
   return title;
+}
+
+/**
+ * The newest indexed name for a thread, unless that name is itself delegation
+ * scaffolding: the marker leaking into the index is still not a name, so every
+ * candidate passes the same test the title failed.
+ */
+function indexedName(
+  names: CodexThreadNameSources,
+  threadId: string | undefined,
+): string | undefined {
+  const name = names.indexNames.get(threadId ?? "");
+  if (name === undefined) return undefined;
+  if (CODEX_DELEGATION_TITLE.test(name) || isCodexRealtimeDelegationText(name)) return undefined;
+  return name;
 }
 
 /**

--- a/apps/desktop/src/desktop-app.ts
+++ b/apps/desktop/src/desktop-app.ts
@@ -1080,9 +1080,13 @@ async function reviewSessionAttention(generation: number): Promise<void> {
     // holds every conversation ever observed — reviewing all of it would send
     // an update about each one to OpenAI on every launch, hundreds of requests
     // rate-limiting the same key the voice opens calls with.
+    // A session inside a live realtime voice conversation sends the evaluator
+    // nothing while it holds: its updates would only ever decide to speak over
+    // the very exchange the developer is already in, and the conversation
+    // closing puts the session back under review with the next pass.
     const reviews = await attentionReviewer.review(
       rosterRelevantSessions(sessionRegistry.list(), Date.now()).filter(
-        (session) => session.realtimeVoice !== true,
+        (session) => session.realtimeVoice !== true && session.realtimeVoiceLive !== true,
       ),
     );
     if (!attentionObservationLoop.isCurrent(generation)) return;

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -488,7 +488,12 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
               "chips and the captioned words leave when the reply ends, but never out from " +
               "under the pointer: resting on them holds them until it moves away. " +
               "Always on while voice is available; the panel and the capsule count show the " +
-              "same states either way." +
+              "same states either way. A session the developer is speaking with through its " +
+              "provider's own realtime voice — a Codex thread in a live voice conversation, " +
+              "and any chat that conversation delegated — announces nothing while the " +
+              "conversation holds, because its turn boundaries are already being heard " +
+              "first-hand; the first change after the conversation closes is announced as " +
+              "usual, and nothing from inside it is replayed." +
               // Only a build that offers the calendar may describe the quiet:
               // a hold Luke claims without a calendar row to connect is a
               // capability he does not have.

--- a/apps/desktop/tests/codex-adapter.test.ts
+++ b/apps/desktop/tests/codex-adapter.test.ts
@@ -318,6 +318,292 @@ test("keeps realtime delegation sessions suppressed after Codex names the chat",
   assert.equal(observation?.realtimeVoice, true);
 });
 
+const TEST_SOURCE_THREAD_ID = "01a01c04-31e2-7be1-a478-0f321abcdef0";
+const TEST_DELEGATION_TITLE =
+  `<codex_delegation>\n<source_thread_id>${TEST_SOURCE_THREAD_ID}</source_thread_id>\n` +
+  "<input>delegated work</input>\n</codex_delegation>";
+
+test("labels a delegated chat by its source conversation's own title", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeCodexState(codexHome, [
+    {
+      id: TEST_SOURCE_THREAD_ID,
+      cwd: "/Users/test/luke",
+      observedAt: TEST_TIME - 2_000,
+      title: "Fix Luke voice announcements",
+    },
+    {
+      id: "codex-delegated",
+      cwd: "/Users/test/luke",
+      observedAt: TEST_TIME - 1_000,
+      title: TEST_DELEGATION_TITLE,
+    },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  const delegated = observations.find((o) => o.providerSessionId === "codex-delegated");
+  assert.equal(delegated?.title, "Fix Luke voice announcements");
+});
+
+test("a name the index has since cleared no longer resolves a delegation", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeCodexSessionIndex(codexHome, [
+    { id: TEST_SOURCE_THREAD_ID, threadName: "Fix Luke voice announcements" },
+    { id: TEST_SOURCE_THREAD_ID, threadName: "" },
+  ]);
+  await writeCodexState(codexHome, [
+    {
+      id: "codex-delegated",
+      cwd: "/Users/test/delegated-repository",
+      observedAt: TEST_TIME - 1_000,
+      title: TEST_DELEGATION_TITLE,
+    },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations[0]?.title, "delegated-repository");
+});
+
+test("a realtime delegation title with no source resolves to the workspace", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeCodexState(codexHome, [
+    {
+      id: "codex-voice-born",
+      cwd: "/Users/test/delegated-repository",
+      observedAt: TEST_TIME - 1_000,
+      title: "<realtime_delegation>\n<input>run the tests</input>\n</realtime_delegation>",
+    },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations[0]?.title, "delegated-repository");
+  assert.equal(observations[0]?.realtimeVoice, true);
+});
+
+// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+test("observes a live realtime voice conversation over a Codex thread", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const rolloutPath = path.join(codexHome, "rollout-realtime-open.jsonl");
+  await writeCodexState(codexHome, [
+    { id: "codex-voice", cwd: "/Users/test/luke", observedAt: TEST_TIME - 1_000, rolloutPath },
+  ]);
+  await writeRollout(rolloutPath, [
+    { type: "world_state", payload: { full: true, state: { realtime: { active: true } } } },
+    { type: "event_msg", payload: { type: "task_started" } },
+    {
+      type: "event_msg",
+      payload: { type: "task_complete", last_agent_message: "Ran the tests; all green." },
+    },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const [observation] = await adapter.observe();
+
+  // The settled delegated turn still reads as waiting — the conversation is
+  // what the notice layer holds its tongue about, not the row.
+  assert.equal(observation?.status, SESSION_STATUS.WAITING);
+  assert.equal(observation?.realtimeVoiceLive, true);
+});
+
+// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+test("observes the realtime voice conversation closing on a later turn", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const rolloutPath = path.join(codexHome, "rollout-realtime-closed.jsonl");
+  await writeCodexState(codexHome, [
+    { id: "codex-voice-done", cwd: "/Users/test/luke", observedAt: TEST_TIME - 1_000, rolloutPath },
+  ]);
+  await writeRollout(rolloutPath, [
+    { type: "world_state", payload: { full: true, state: { realtime: { active: true } } } },
+    { type: "event_msg", payload: { type: "task_started" } },
+    { type: "event_msg", payload: { type: "task_complete", last_agent_message: "Done." } },
+    // The first turn after the conversation ends patches the section closed.
+    { type: "world_state", payload: { full: false, state: { realtime: { active: false } } } },
+    { type: "event_msg", payload: { type: "task_started" } },
+    { type: "event_msg", payload: { type: "task_complete", last_agent_message: "Follow-up." } },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.realtimeVoiceLive, undefined);
+});
+
+// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+test("reads a delegation as the conversation being live when its snapshot left the tail", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const rolloutPath = path.join(codexHome, "rollout-realtime-delegation.jsonl");
+  await writeCodexState(codexHome, [
+    { id: "codex-delegated", cwd: "/Users/test/luke", observedAt: TEST_TIME - 1_000, rolloutPath },
+  ]);
+  await writeRollout(rolloutPath, [
+    { type: "event_msg", payload: { type: "task_started" } },
+    {
+      type: "response_item",
+      payload: {
+        type: "message",
+        role: "user",
+        content: [
+          {
+            type: "input_text",
+            text: "<realtime_delegation>\n  <input>run the release script</input>\n</realtime_delegation>",
+          },
+        ],
+      },
+    },
+    { type: "event_msg", payload: { type: "task_complete", last_agent_message: "Released." } },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.realtimeVoiceLive, true);
+});
+
+// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+test("a typed user message never reads as a live voice conversation", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const rolloutPath = path.join(codexHome, "rollout-typed-turn.jsonl");
+  await writeCodexState(codexHome, [
+    { id: "codex-typed", cwd: "/Users/test/luke", observedAt: TEST_TIME - 1_000, rolloutPath },
+  ]);
+  await writeRollout(rolloutPath, [
+    { type: "event_msg", payload: { type: "task_started" } },
+    {
+      type: "response_item",
+      payload: {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "please run the release script" }],
+      },
+    },
+    { type: "event_msg", payload: { type: "task_complete", last_agent_message: "Released." } },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.realtimeVoiceLive, undefined);
+});
+
+test("a delegated chat holds announcements while its source conversation's voice is live", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const sourceRollout = path.join(codexHome, "rollout-voice-source.jsonl");
+  const delegatedRollout = path.join(codexHome, "rollout-voice-delegated.jsonl");
+  await writeCodexState(codexHome, [
+    {
+      id: TEST_SOURCE_THREAD_ID,
+      cwd: "/Users/test/luke",
+      observedAt: TEST_TIME - 2_000,
+      title: "Fix Luke voice announcements",
+      rolloutPath: sourceRollout,
+    },
+    {
+      id: "codex-delegated",
+      cwd: "/Users/test/luke",
+      observedAt: TEST_TIME - 1_000,
+      title: TEST_DELEGATION_TITLE,
+      rolloutPath: delegatedRollout,
+    },
+  ]);
+  await writeRollout(sourceRollout, [
+    { type: "world_state", payload: { full: true, state: { realtime: { active: true } } } },
+    { type: "event_msg", payload: { type: "task_started" } },
+    { type: "event_msg", payload: { type: "task_complete", last_agent_message: "Delegated." } },
+  ]);
+  // The delegated chat's own rollout says nothing about the conversation that
+  // spawned it; the link through the marker is what must carry the hold.
+  await writeRollout(delegatedRollout, [
+    { type: "event_msg", payload: { type: "task_started" } },
+    { type: "event_msg", payload: { type: "task_complete", last_agent_message: "Done." } },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  const source = observations.find((o) => o.providerSessionId === TEST_SOURCE_THREAD_ID);
+  const delegated = observations.find((o) => o.providerSessionId === "codex-delegated");
+  assert.equal(source?.realtimeVoiceLive, true);
+  assert.equal(delegated?.realtimeVoiceLive, true);
+  assert.equal(delegated?.title, "Fix Luke voice announcements");
+});
+
+test("the voice hold outlives Codex naming the delegated chat", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  const sourceRollout = path.join(codexHome, "rollout-voice-renamed-source.jsonl");
+  await writeCodexState(codexHome, [
+    {
+      id: TEST_SOURCE_THREAD_ID,
+      cwd: "/Users/test/luke",
+      observedAt: TEST_TIME - 2_000,
+      title: "Fix Luke voice announcements",
+      rolloutPath: sourceRollout,
+    },
+    {
+      // Codex has named the chat, so the title no longer carries the marker;
+      // the first user message is where the link has to survive.
+      id: "codex-delegated-named",
+      cwd: "/Users/test/luke",
+      observedAt: TEST_TIME - 1_000,
+      title: "What sessions are open?",
+      firstUserMessage: TEST_DELEGATION_TITLE,
+    },
+  ]);
+  await writeRollout(sourceRollout, [
+    { type: "world_state", payload: { full: true, state: { realtime: { active: true } } } },
+    { type: "event_msg", payload: { type: "task_started" } },
+    { type: "event_msg", payload: { type: "task_complete", last_agent_message: "Delegated." } },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  const delegated = observations.find((o) => o.providerSessionId === "codex-delegated-named");
+  assert.equal(delegated?.realtimeVoiceLive, true);
+  assert.equal(delegated?.title, "What sessions are open?");
+});
+
 test("addresses a Codex thread by the id Codex files it under", async (t) => {
   const codexHome = await temporaryCodexHome(t);
   await writeCodexState(codexHome, [

--- a/apps/desktop/tests/codex-adapter.test.ts
+++ b/apps/desktop/tests/codex-adapter.test.ts
@@ -376,6 +376,33 @@ test("a name the index has since cleared no longer resolves a delegation", async
   assert.equal(observations[0]?.title, "delegated-repository");
 });
 
+test("a marker that leaked into the name index is still not a name", async (t) => {
+  const codexHome = await temporaryCodexHome(t);
+  await writeCodexSessionIndex(codexHome, [
+    { id: TEST_SOURCE_THREAD_ID, threadName: "Fix Luke voice announcements" },
+    // Codex indexed the delegated chat's own synthetic title; preferring it
+    // would put the raw marker back on the row the resolution exists to name.
+    { id: "codex-delegated", threadName: TEST_DELEGATION_TITLE },
+  ]);
+  await writeCodexState(codexHome, [
+    {
+      id: "codex-delegated",
+      cwd: "/Users/test/luke",
+      observedAt: TEST_TIME - 1_000,
+      title: TEST_DELEGATION_TITLE,
+    },
+  ]);
+
+  const adapter = new CodexSessionAdapter({
+    codexHome,
+    now: () => TEST_TIME,
+    maximumSessionAgeMs: 60_000,
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations[0]?.title, "Fix Luke voice announcements");
+});
+
 test("a realtime delegation title with no source resolves to the workspace", async (t) => {
   const codexHome = await temporaryCodexHome(t);
   await writeCodexState(codexHome, [

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -9,6 +9,7 @@
 // JSON — defensive readers for untrusted payloads.
 export {
   isRecord,
+  isWireBoolean,
   isWireNumber,
   isWireString,
   nonNegativeNumber,

--- a/packages/sidecar-core/src/json.ts
+++ b/packages/sidecar-core/src/json.ts
@@ -33,6 +33,11 @@ export function isWireNumber(value: UnparsedWireValue): value is number {
   return runtimeTag(value) === "[object Number]";
 }
 
+/** Narrows a wire value to boolean without trusting a runtime typeof check. */
+export function isWireBoolean(value: UnparsedWireValue): value is boolean {
+  return runtimeTag(value) === "[object Boolean]";
+}
+
 export function isRecord(value: UnparsedWireValue): value is WireRecord {
   if (value === null || value === undefined) return false;
   if (runtimeTag(value) !== "[object Object]") return false;

--- a/packages/sidecar-core/src/session-notices.ts
+++ b/packages/sidecar-core/src/session-notices.ts
@@ -158,6 +158,12 @@ export class SessionNoticeTracker {
       }
       provider.set(session.providerSessionId, state);
 
+      // A session the developer is speaking with announces nothing: its turn
+      // boundaries are the rhythm of a conversation being heard first-hand,
+      // and a voice reading them out would talk over the very exchange it is
+      // reporting. The edge is still tracked, so the conversation ending never
+      // replays what happened inside it — only a fresh edge after it speaks.
+      if (session.realtimeVoiceLive === true) continue;
       // First sight seeds silently; an unchanged status is not an edge.
       if (!previous || previous.status === session.status) continue;
       if (session.completionCause === SESSION_COMPLETION_CAUSE.SESSION_CLOSED) continue;

--- a/packages/sidecar-core/src/session-registry.ts
+++ b/packages/sidecar-core/src/session-registry.ts
@@ -148,6 +148,7 @@ const sameSession = exhaustiveSame<NormalizedSession>({
   completionCause: (first, second) => first.completionCause === second.completionCause,
   observedAt: (first, second) => first.observedAt === second.observedAt,
   realtimeVoice: (first, second) => first.realtimeVoice === second.realtimeVoice,
+  realtimeVoiceLive: (first, second) => first.realtimeVoiceLive === second.realtimeVoiceLive,
   location: (first, second) => first.location === second.location,
   recap: (first, second) => first.recap === second.recap,
   detail: (first, second) => sameDetail(first.detail, second.detail),

--- a/packages/sidecar-core/src/session.ts
+++ b/packages/sidecar-core/src/session.ts
@@ -299,6 +299,13 @@ export interface ProviderSessionObservation {
   observedAt: number;
   /** Whether this session is a realtime voice/delegation chat. */
   realtimeVoice?: boolean;
+  /**
+   * Whether a realtime voice conversation is live over this session right now,
+   * read from the provider's own persisted state. Where `realtimeVoice` names
+   * what the chat is, this names what is happening to it, and it ends when the
+   * conversation does. Absent means none observed.
+   */
+  realtimeVoiceLive?: boolean;
   /** Omitted by an adapter that reads sessions off this machine. */
   location?: SessionLocation;
   /**
@@ -347,6 +354,8 @@ export interface NormalizedSession extends SessionIdentity {
   observedAt: number;
   /** Whether this session is a realtime voice/delegation chat. */
   realtimeVoice?: boolean;
+  /** Whether a realtime voice conversation is live over this session right now. */
+  realtimeVoiceLive?: boolean;
   location: SessionLocation;
   recap?: string;
   detail: SessionDetail;
@@ -668,6 +677,7 @@ export function normalizeSession(
     attention: normalizeAttention(attention),
   };
   if (observation.realtimeVoice === true) session.realtimeVoice = true;
+  if (observation.realtimeVoiceLive === true) session.realtimeVoiceLive = true;
   if (completionCause) session.completionCause = completionCause;
   if (recap) session.recap = recap;
   if (spawnTarget) session.spawnTarget = spawnTarget;

--- a/packages/sidecar-core/tests/session-notices.test.ts
+++ b/packages/sidecar-core/tests/session-notices.test.ts
@@ -32,6 +32,7 @@ function session(
     recap?: string;
     workspace?: string;
     canReceiveMessage?: boolean;
+    realtimeVoiceLive?: boolean;
     completionCause?: (typeof SESSION_COMPLETION_CAUSE)[keyof typeof SESSION_COMPLETION_CAUSE];
   } = {},
 ): NormalizedSession {
@@ -50,6 +51,9 @@ function session(
   if (overrides.canReceiveMessage !== undefined) {
     observation.canReceiveMessage = overrides.canReceiveMessage;
   }
+  if (overrides.realtimeVoiceLive !== undefined) {
+    observation.realtimeVoiceLive = overrides.realtimeVoiceLive;
+  }
   if (overrides.error || overrides.repository || overrides.branch) {
     const detail = observation.detail ?? {};
     if (overrides.error) detail.error = overrides.error;
@@ -59,6 +63,60 @@ function session(
   }
   return normalizeSession(provider, observation);
 }
+
+test("a session under a live voice conversation announces nothing while it holds", () => {
+  const tracker = new SessionNoticeTracker();
+  tracker.notices(
+    [session(claude, "spoken", SESSION_STATUS.WORKING, { realtimeVoiceLive: true })],
+    1_000,
+  );
+
+  // Each delegated turn settling would otherwise be a waiting banner, and a
+  // failed one an error banner, spoken over the very conversation they belong to.
+  assert.deepEqual(
+    tracker.notices(
+      [session(claude, "spoken", SESSION_STATUS.WAITING, { realtimeVoiceLive: true })],
+      2_000,
+    ),
+    [],
+  );
+  assert.deepEqual(
+    tracker.notices(
+      [
+        session(claude, "spoken", SESSION_STATUS.ERROR, {
+          realtimeVoiceLive: true,
+          error: "sandbox denied",
+        }),
+      ],
+      3_000,
+    ),
+    [],
+  );
+});
+
+test("the voice conversation ending never replays the edges it covered", () => {
+  const tracker = new SessionNoticeTracker();
+  tracker.notices(
+    [session(claude, "spoken", SESSION_STATUS.WORKING, { realtimeVoiceLive: true })],
+    1_000,
+  );
+  tracker.notices(
+    [session(claude, "spoken", SESSION_STATUS.WAITING, { realtimeVoiceLive: true })],
+    2_000,
+  );
+
+  // The conversation closed with the session still waiting: nothing moved, so
+  // there is no news to read out after the fact.
+  assert.deepEqual(tracker.notices([session(claude, "spoken", SESSION_STATUS.WAITING)], 3_000), []);
+
+  // A fresh edge after the conversation speaks like any other session's.
+  tracker.notices([session(claude, "spoken", SESSION_STATUS.WORKING)], 4_000);
+  const notices = tracker.notices([session(claude, "spoken", SESSION_STATUS.COMPLETE)], 5_000);
+  assert.deepEqual(
+    notices.map((notice) => [notice.providerSessionId, notice.status]),
+    [["spoken", SESSION_NOTICE_STATUS.COMPLETE]],
+  );
+});
 
 test("first sight seeds silently, and only a change of status is news", () => {
   const tracker = new SessionNoticeTracker();


### PR DESCRIPTION
## Summary

Codex realtime voice delegates its turns to observed threads, so every spoken exchange produced turn edges Luke announced *over the very conversation being held*. Main's merged suppression (#304) covers chats *born* from a realtime delegation; this PR adds the live-conversation state, which is what covers the common case — voice opened over an **existing** thread, which no delegation marker identifies — and bounds every hold to exactly as long as the conversation is live.

- **Live detection, grounded in what Codex persists.** The realtime lifecycle events are transient and never reach the rollout, but two durable signals do: the `realtime: { active }` section of the `world_state` snapshots Codex writes with every turn, and the `<realtime_delegation>` fragments wrapping each delegated turn (the fallback when the opening snapshot has scrolled past the bounded 64 KiB tail read). Last signal in file order wins, so the patch closing the section ends the hold. Reported as `realtimeVoiceLive` — the state beside `realtimeVoice`'s kind — flowing observation → `NormalizedSession` with the registry comparator compile-enforced.
- **Suppression inside the tracker, not input filtering.** `SessionNoticeTracker` still tracks every edge of a live-conversation session but produces no notice, keeping the tracker's fed-every-pass invariant — the conversation ending never replays what happened inside it, and the first fresh edge afterwards announces as usual. A session under a live hold is also left out of attention evaluation until the conversation closes.
- **Delegated chats hold while their source's voice is live, through a rename.** A chat another conversation delegated is linked back to its source by the delegation marker in the first user message it was born with (title fallback for older rows), and holds for as long as the source conversation's voice is live — deterministic arithmetic against the same pass's rollout reads.
- **Hardened delegated-title resolution** (over merged #303): the name index is read as a bounded 128 KiB tail, only on a pass that actually saw a marker title; an index entry with an empty `thread_name` removes the name (Codex's clearing semantics) instead of resurrecting its predecessor; the source conversation's own title from the same pass stands in when the index has nothing; and a `<realtime_delegation>` title — which names no source — resolves to the workspace instead of standing raw on the row. Titles that merely resemble a marker are kept, exactly as the merged tests pin.
- `PROVIDERS.md` documents the combined Codex realtime/delegation behavior (the merged PRs had left it undescribed), and the app guide's Announcements fact teaches Luke the hold so he describes himself correctly.

## Validation

- `./scripts/check.sh` exits 0: 284 sidecar-core, 1226 desktop, 53 web, 47 harness tests pass, plus Biome, oxlint, typecheck, and build. All tests merged with #303/#304 pass unchanged.
- New tests: world-state open/close parsing, delegation-fragment fallback, typed messages never misread, tracker suppression with no replay, the delegated-chat hold, the hold surviving a rename, cleared index names, source-row title fallback, and realtime-delegation titles resolving to the workspace.
- No visual surface changed, so no macOS `verify.sh` run or physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32319496536/artifacts/9389288305) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32319496536)

- Commit: `31d0689317f6bf141fc5c3b8f513329048117707`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
