### PR TITLE
feat(sessions): narrow the list to the sessions Superset manages

### DIFF
--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -287,8 +287,10 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       detail:
         "Lists every session that still matters: one working or waiting stays at any age, a " +
         "failure for three days, a finished or quiet one for two. Narrowable to all, local, " +
-        "cloud, or one provider, and orderable by urgency or recency — by its options button, " +
-        "or by the same ask that shows the tab. A row can be opened, messaged, or controlled " +
+        "cloud, voice chats, the sessions whose workspaces Superset manages, or one provider, " +
+        "and orderable " +
+        "by urgency or recency — by its options button, or by the same ask that shows the tab. " +
+        "A row can be opened, messaged, or controlled " +
         "where its provider allows. A session whose provider reported a pull request grows a " +
         "chip that opens it in the browser. A row the developer asked Luke to listen for wears " +
         "a listening mark beside its age. Luke's own composer at the foot takes a typed ask.",

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -19,23 +19,29 @@ import {
   urgencyLabel,
 } from "@sidecar/core";
 import type { AppBootstrap } from "../shared/contracts";
+import { SUPERSET_WORKSPACE_PROVIDER_ID } from "../shared/superset";
 
 /**
  * Which sessions the list draws: everything, everything running in one place,
- * or everything belonging to one agent. The coarse values are session
- * locations plus the realtime voice kind, and the rest are provider ids, so
- * narrowing the list is a comparison against something a row already carries
- * rather than a second vocabulary mapped onto it. The values cannot collide —
- * no provider is called `local`, `cloud`, or `voice`.
+ * every realtime voice chat, everything Superset manages, or everything
+ * belonging to one agent. The coarse values are the session locations, the
+ * realtime voice kind, and the Superset workspace scope itself, and the rest
+ * are provider ids, so narrowing the list is a comparison against something a
+ * row already carries rather than a second vocabulary mapped onto it. The
+ * values cannot collide — no provider is called `local`, `cloud`, `voice`, or
+ * `superset`.
  *
  * Location belongs to the session rather than to the agent, so an agent with
- * work in both places is one chip that answers `Local` and `Cloud` both.
+ * work in both places is one chip that answers `Local` and `Cloud` both — and
+ * Superset belongs to the workspace rather than to the agent, so the same
+ * agent answers its own chip and the Superset chip when Superset manages it.
  */
 export const SESSION_FILTER = {
   ALL: "all",
   LOCAL: SESSION_LOCATION.LOCAL,
   CLOUD: SESSION_LOCATION.CLOUD,
   VOICE: "voice",
+  SUPERSET: SUPERSET_WORKSPACE_PROVIDER_ID,
 } as const;
 
 export type SessionFilter = (typeof SESSION_FILTER)[keyof typeof SESSION_FILTER] | ProviderId;
@@ -46,6 +52,9 @@ function matchesFilter(session: DisplaySession, filter: SessionFilter): boolean 
     return session.location === filter;
   }
   if (filter === SESSION_FILTER.VOICE) return session.realtimeVoice === true;
+  if (filter === SESSION_FILTER.SUPERSET) {
+    return session.workspace?.scopeId === SESSION_FILTER.SUPERSET;
+  }
   return session.providerId === filter;
 }
 
@@ -60,7 +69,8 @@ export function sessionFilterFromSpoken(value: string): SessionFilter | undefine
     value === SESSION_FILTER.ALL ||
     value === SESSION_FILTER.LOCAL ||
     value === SESSION_FILTER.CLOUD ||
-    value === SESSION_FILTER.VOICE
+    value === SESSION_FILTER.VOICE ||
+    value === SESSION_FILTER.SUPERSET
   ) {
     return value;
   }
@@ -196,8 +206,9 @@ export interface SessionFilterOption {
   label: string;
   count: number;
   /**
-   * Set when the chip stands for one agent, so the row can draw that agent's
-   * own mark where the coarser chips carry a word.
+   * Set when the chip stands for one brand — an agent, or the Superset
+   * workspace manager — so the row can draw that brand's own mark where the
+   * coarser chips carry a word.
    */
   providerId?: string;
 }
@@ -497,11 +508,13 @@ const LOCATION_ORDER: readonly SessionLocation[] = [SESSION_LOCATION.LOCAL, SESS
 const VOICE_FILTER_OPTION = { filter: SESSION_FILTER.VOICE, label: "Voice" } as const;
 
 /**
- * All, then where a session runs, then whether it is voice, then which agent is
- * running it — coarse to fine, left to right. Each level is offered only where
- * it is a real choice: a single location, voice kind, or agent says nothing
- * All has not already said. The counts make the row a breakdown of what is
- * tracked before it is a control, which is what earns it the line it costs.
+ * All, then where a session runs, then whether it is voice, then whether
+ * Superset manages it, then which agent is running it — coarse to fine, left
+ * to right. Each level is offered only where it is a real choice: a single
+ * location, voice kind, or agent says nothing All has not already said, and a
+ * Voice or Superset chip counting every session — or none — narrows nothing.
+ * The counts make the row a breakdown of what is tracked before it is a
+ * control, which is what earns it the line it costs.
  *
  * Agents are listed in the registry's own order rather than by how many
  * sessions they have, so a chip never moves out from under the pointer as
@@ -513,9 +526,11 @@ function filterOptions(sessions: readonly DisplaySession[]): readonly SessionFil
   const locations = new Map<SessionLocation, number>();
   const providers = new Map<ProviderId, { label: string; count: number }>();
   let voiceCount = 0;
+  let managed = 0;
   for (const session of sessions) {
     locations.set(session.location, (locations.get(session.location) ?? 0) + 1);
     if (session.realtimeVoice === true) voiceCount += 1;
+    if (session.workspace?.scopeId === SESSION_FILTER.SUPERSET) managed += 1;
     // An agent this build has no registry entry for has no mark to draw a chip
     // with, so it is counted under All and offered under nothing else.
     if (!isProviderId(session.providerId)) continue;
@@ -533,6 +548,17 @@ function filterOptions(sessions: readonly DisplaySession[]): readonly SessionFil
           label: LOCATION_LABEL[location],
           count: locations.get(location) ?? 0,
         }))
+      : [];
+  const managedOptions =
+    managed > 0 && managed < sessions.length
+      ? [
+          {
+            filter: SESSION_FILTER.SUPERSET,
+            label: "Superset",
+            count: managed,
+            providerId: SUPERSET_WORKSPACE_PROVIDER_ID,
+          },
+        ]
       : [];
   const providerOptions =
     providers.size > 1
@@ -552,6 +578,7 @@ function filterOptions(sessions: readonly DisplaySession[]): readonly SessionFil
     { filter: SESSION_FILTER.ALL, label: "All", count: sessions.length },
     ...locationOptions,
     ...voiceOptions,
+    ...managedOptions,
     ...providerOptions,
   ];
 }

--- a/apps/desktop/src/renderer/session-parts.tsx
+++ b/apps/desktop/src/renderer/session-parts.tsx
@@ -156,7 +156,7 @@ function FilterIcon({ filter }: { filter: SessionFilter }): React.JSX.Element | 
   return null;
 }
 
-/** The mark for an agent, the glyph for a place, nothing for everything. */
+/** The mark for a brand — agent or Superset — the glyph for a place, nothing for everything. */
 function FilterMark({ option }: { option: SessionFilterOption }): React.JSX.Element | null {
   if (option.providerId) {
     return <ProviderMark providerId={option.providerId} className="filter-mark" />;

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -239,6 +239,14 @@
   height: 13px;
 }
 
+/* Superset's bracket mark is two and a half times as wide as it is tall.
+   Fitted whole into the square box the agent marks fill it would draw five
+   pixels tall, so its box takes the mark's own proportion instead and the
+   chip reads at the same optical weight as its neighbours. */
+.filter-mark[data-mark="superset"] {
+  width: 24px;
+}
+
 /* The number is what the row is worth reading before anything is pressed: the
    chips are a breakdown of what is tracked first and a control second. */
 .filter-count {

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -4093,6 +4093,54 @@ test("a spoken panel ask is validated against the roster and carried", async () 
   await new Promise((resolve) => setTimeout(resolve, 0));
 
   assert.deepEqual(carried.at(-1), { kind: "panel", tab: "settings" });
+
+  // A workspace manager's scope is validated against the same roster: with no
+  // observed session under Superset the narrowing is refused rather than
+  // carried, and Luke never reports a narrowing that never happened.
+  await armDeveloperTurn(context);
+  const askedBefore = carried.length;
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: {
+      output: [
+        {
+          type: "function_call",
+          name: "show_panel",
+          call_id: "call-guide-5",
+          arguments: '{"filter":"superset"}',
+        },
+      ],
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(carried.length, askedBefore);
+
+  context.session.updateSessions([
+    observedSession("session-a", {
+      workspace: {
+        providerWorkspaceId: "workspace-1",
+        scopeId: "superset",
+        name: "power-vacation",
+      },
+    }),
+  ]);
+  await armDeveloperTurn(context);
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: {
+      output: [
+        {
+          type: "function_call",
+          name: "show_panel",
+          call_id: "call-guide-6",
+          arguments: '{"filter":"superset"}',
+        },
+      ],
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.deepEqual(carried.at(-1), { kind: "panel", tab: "sessions", filter: "superset" });
 });
 
 test("a spoken composer open is validated against the fixed kinds and carried, never sent", async () => {

--- a/apps/desktop/tests/session-model.test.ts
+++ b/apps/desktop/tests/session-model.test.ts
@@ -716,6 +716,81 @@ test("an orchestrator workspace groups sessions from different providers", () =>
   );
 });
 
+// Superset is a level of its own between where a session runs and which agent
+// runs it: the same agent answers its own chip and the Superset chip when
+// Superset manages its workspace.
+test("sessions Superset manages earn a chip and can be narrowed to", () => {
+  const workspace = {
+    providerWorkspaceId: "workspace-superset",
+    scopeId: "superset",
+    name: "power-vacation",
+  };
+  const rows = displaySessions(bootstrap(false), [
+    normalizeSession(CLAUDE_PROVIDER, {
+      providerSessionId: "claude-managed",
+      title: "Claude",
+      status: SESSION_STATUS.WORKING,
+      observedAt: 2_000,
+      workspace,
+    }),
+    liveSession(CODEX_PROVIDER, "codex-loose", SESSION_STATUS.WORKING, 1_000),
+  ]);
+  const list = arrangeSessions(rows, DEFAULT_SESSION_VIEW);
+
+  assert.deepEqual(list.options, [
+    { filter: SESSION_FILTER.ALL, label: "All", count: 2 },
+    {
+      filter: SESSION_FILTER.SUPERSET,
+      label: "Superset",
+      count: 1,
+      providerId: SESSION_FILTER.SUPERSET,
+    },
+    {
+      filter: PROVIDER_ID.CLAUDE_CODE,
+      label: "Claude Code",
+      count: 1,
+      providerId: PROVIDER_ID.CLAUDE_CODE,
+    },
+    { filter: PROVIDER_ID.CODEX, label: "Codex", count: 1, providerId: PROVIDER_ID.CODEX },
+  ]);
+
+  const narrowed = arrangeSessions(rows, {
+    ...DEFAULT_SESSION_VIEW,
+    filter: SESSION_FILTER.SUPERSET,
+  });
+  assert.equal(narrowed.filter, SESSION_FILTER.SUPERSET);
+  assert.deepEqual(
+    narrowed.sessions.map((session) => session.id),
+    ["claude-managed"],
+  );
+  assert.equal(narrowed.total, 2);
+
+  // The spoken vocabulary is the chips' own, so the same word narrows by voice.
+  assert.equal(sessionFilterFromSpoken("superset"), SESSION_FILTER.SUPERSET);
+});
+
+// A Superset chip counting every session narrows nothing, like a lone
+// location or a lone agent — the agents below it are still a real choice.
+test("a Superset chip counting every session is not offered", () => {
+  const managed = (provider: typeof CLAUDE_PROVIDER, id: string) =>
+    normalizeSession(provider, {
+      providerSessionId: id,
+      title: `Session ${id}`,
+      status: SESSION_STATUS.WORKING,
+      observedAt: 1_000,
+      workspace: { providerWorkspaceId: "workspace-superset", scopeId: "superset" },
+    });
+  const rows = displaySessions(bootstrap(false), [
+    managed(CLAUDE_PROVIDER, "claude-managed"),
+    managed(CODEX_PROVIDER, "codex-managed"),
+  ]);
+
+  assert.deepEqual(
+    arrangeSessions(rows, DEFAULT_SESSION_VIEW).options.map((option) => option.filter),
+    [SESSION_FILTER.ALL, PROVIDER_ID.CLAUDE_CODE, PROVIDER_ID.CODEX],
+  );
+});
+
 test("a lone chat is a run of one, and namesake workspaces never join", () => {
   // Two workspaces wearing one name: the id is what groups, so each stays a
   // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.

--- a/packages/sidecar-core/src/realtime-tools.ts
+++ b/packages/sidecar-core/src/realtime-tools.ts
@@ -722,7 +722,9 @@ function appSettingValue(setting: AppGuideSetting, value: UnparsedWireValue): st
  * Validates a spoken session-list filter against the sessions actually being
  * observed. A filter that would show nothing is refused rather than applied:
  * the panel would quietly fall back to showing everything, and Luke would have
- * reported a narrowing that never happened.
+ * reported a narrowing that never happened. A workspace manager's scope id —
+ * the one a session's workspace carries when an orchestrator owns it — is a
+ * filter on the same terms as a provider id: the two share no namespace.
  */
 function panelFilterAction(
   filter: string,
@@ -737,8 +739,14 @@ function panelFilterAction(
     if (sessions.some((session) => session.realtimeVoice === true)) return { filter };
     return { reason: "No voice sessions are observed right now." };
   }
-  if (sessions.some((session) => session.providerId === filter)) return { filter };
-  return { reason: "No observed session belongs to that provider." };
+  if (
+    sessions.some(
+      (session) => session.providerId === filter || session.workspace?.scopeId === filter,
+    )
+  ) {
+    return { filter };
+  }
+  return { reason: "No observed session belongs to that provider or workspace manager." };
 }
 
 function validateChangeAppSetting(parsed: WireRecord, context: AppToolContext): AppToolAction {
@@ -1142,7 +1150,9 @@ export const REALTIME_TOOLS = {
           filter: {
             type: "string",
             description:
-              "Narrows the session list: all, local, cloud, or the provider_id of one observed provider. Only meaningful on the sessions tab.",
+              "Narrows the session list: all, local, cloud, voice for realtime voice chats, " +
+              "the provider_id of one observed provider, or superset for the sessions whose " +
+              "workspaces Superset manages. Only meaningful on the sessions tab.",
           },
           sort: {
             type: "string",


### PR DESCRIPTION
## What

Adds a Superset filter to the Sessions tab. The options sheet now offers a Superset chip between the location chips and the agent chips — drawn by Superset's own bracket mark at its published proportion, counted like every other level, and offered only while it narrows (some, but not all, sessions managed). Choosing it keeps only the sessions whose workspaces Superset manages.

## Why it is its own level

A managed session's `providerId` is still the underlying agent's (claude-code, codex, …); Superset identity rides the workspace's `scopeId`. So the filter is a new coarse value in the chips' vocabulary rather than a provider id, matched against what the row already carries — the same agent answers its own chip and the Superset chip when Superset manages it.

## The spoken path keeps the same vocabulary

`show_panel`'s filter now accepts a workspace manager's scope on the same terms as a provider id: validated in core against the observed roster (refused while nothing is managed, so Luke never reports a narrowing that never happened), and mapped in the renderer by the same words the chips use. The core check stays brand-neutral — any observed workspace scope — while the renderer's vocabulary names Superset at the app boundary. The guide's sessions-list fact teaches the new narrowing in the same change.

## Checks

- `./scripts/check.sh` — pass (exit 0, 0 failures across all workspaces)
- `./scripts/verify.sh` — **not run**: this change was made in a Linux cloud workspace with no macOS host. No physical-notch check was performed. The shared fixture carries no Superset workspace, so the chip does not appear in fixture evidence; behavior is covered by unit tests (chip offered/withheld, narrowing, spoken validation and refusal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d8878800-f84c-41fc-ab5b-eb9eff19b964)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32317598379/artifacts/9388661061) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32317598379)

- Commit: `9b4bc1c59634641489d892e7a5a3e7ca05dd4a76`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
