### PR TITLE
fix(voice): handle stop cancellation races

### DIFF
--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -11,6 +11,7 @@ import {
   type ContextItemKind,
   cancelResponseEvents,
   clearInputAudioEvents,
+  clearOutputAudioEvents,
   contextItemId,
   contextSupersedeEventId,
   contextSupersedeEvents,
@@ -118,6 +119,18 @@ const CONTEXT_FLUSH_ORDER: readonly ContextItemKind[] = [
  * two turns' worth of room for something that ordinarily clears immediately.
  */
 const MAXIMUM_PENDING_SUPERSEDES = CONTEXT_FLUSH_ORDER.length * 2;
+
+/** Bounds interruption events whose successful requests receive no matching acknowledgement. */
+const MAXIMUM_PENDING_INTERRUPTIONS = 24;
+
+const INTERRUPTION_EVENT_KIND = {
+  CANCELLATION: "cancellation",
+  AUDIO_CLEAR: "audio-clear",
+} as const;
+
+type InterruptionEventKind = (typeof INTERRUPTION_EVENT_KIND)[keyof typeof INTERRUPTION_EVENT_KIND];
+
+const NO_ACTIVE_RESPONSE_CANCELLATION = /^Cancellation failed:\s*no active response\b/i;
 
 /**
  // SAFETY: The preceding check establishes the asserted contract.
@@ -429,6 +442,14 @@ export class RealtimeVoiceSession {
    * rather than a fault to report to the developer.
    */
   #pendingSupersedes = new Map<string, string>();
+  /**
+   * Cancel and clear requests not yet answered with an error, by their stamped
+   * names. Their errors belong to the reply that was interrupted, so they must
+   * never finish a newer turn; only the documented redundant-cancel race stays
+   * quiet, while every genuine refusal is still reported.
+   */
+  #pendingInterruptions = new Map<string, InterruptionEventKind>();
+  #interruptionSequence = 0;
   /**
    * Luke's own audio track. Cancelling stops the model producing more, but what
    * it already produced is on its way down the connection and keeps playing —
@@ -1389,7 +1410,24 @@ export class RealtimeVoiceSession {
     // never heard — the text runs ahead of the speech — and leaving them up
     // would show Luke finishing a sentence he was just stopped from saying.
     this.#clearCaption();
-    this.#send(cancelResponseEvents());
+    this.#interruptionSequence += 1;
+    const cancellationEventId = `response_cancel_${this.#interruptionSequence}`;
+    const clearEventId = `output_audio_clear_${this.#interruptionSequence}`;
+    const cancelGeneration = this.#responseOutstanding;
+    const interruptionCount = cancelGeneration ? 2 : 1;
+    while (this.#pendingInterruptions.size + interruptionCount > MAXIMUM_PENDING_INTERRUPTIONS) {
+      const [oldest] = this.#pendingInterruptions.keys();
+      if (oldest === undefined) break;
+      this.#pendingInterruptions.delete(oldest);
+    }
+    if (cancelGeneration) {
+      this.#pendingInterruptions.set(cancellationEventId, INTERRUPTION_EVENT_KIND.CANCELLATION);
+      this.#pendingInterruptions.set(clearEventId, INTERRUPTION_EVENT_KIND.AUDIO_CLEAR);
+      this.#send(cancelResponseEvents({ cancellationEventId, clearEventId }));
+    } else {
+      this.#pendingInterruptions.set(clearEventId, INTERRUPTION_EVENT_KIND.AUDIO_CLEAR);
+      this.#send(clearOutputAudioEvents(clearEventId));
+    }
     // Then correct what Luke believes he said, or the next answer is free to
     // refer back to a sentence that never reached the room.
     this.#send(this.#truncateEvents());
@@ -1521,6 +1559,7 @@ export class RealtimeVoiceSession {
     this.#contextPending.clear();
     this.#contextLive.clear();
     this.#pendingSupersedes.clear();
+    this.#pendingInterruptions.clear();
     this.#conversationBegan = false;
     this.#clearIdleTimer();
     this.#responseOutstanding = false;
@@ -2066,6 +2105,25 @@ export class RealtimeVoiceSession {
   }
 
   /**
+   * Handles an error answering one interruption without letting an old reply's
+   * failure finish the new turn that interrupted it. Only the documented
+   * no-active-response race is quiet; every other refusal still reaches the
+   * developer as a real voice error.
+   */
+  #interruptionError(event: { message: string; eventId?: string; errorType?: string }): boolean {
+    if (event.eventId === undefined) return false;
+    const kind = this.#pendingInterruptions.get(event.eventId);
+    if (kind === undefined) return false;
+    this.#pendingInterruptions.delete(event.eventId);
+    const benignCancellation =
+      kind === INTERRUPTION_EVENT_KIND.CANCELLATION &&
+      event.errorType === "invalid_request_error" &&
+      NO_ACTIVE_RESPONSE_CANCELLATION.test(event.message);
+    if (!benignCancellation) this.#options.onError(event.message);
+    return true;
+  }
+
+  /**
    * The context items this call currently holds, by kind — what the
    * conversation would be answered from if a turn opened now. Exposed for the
    * tests that hold this class to its one-item-per-kind promise.
@@ -2245,6 +2303,7 @@ export class RealtimeVoiceSession {
         // nothing they can act on, and reporting it would both put a fault on
         // screen and, below, end a reply that is still being spoken.
         if (this.#supersedeError(event)) return;
+        if (this.#interruptionError(event)) return;
         this.#options.onError(event.message);
         // An error can arrive *instead of* `response.done` — an empty push-to-talk
         // commit is the common case — which would otherwise leave the session

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -2274,6 +2274,81 @@ test("a stop cuts the reply where it stands and opens nothing in its place", asy
   assert.equal(context.lukeAudible(), true);
 });
 
+test("a stop does not surface the server refusing its already-finished cancellation", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.deliverRemoteTrack();
+  await holdTurn(context);
+  context.session.endTurn(true);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-1" } });
+
+  assert.equal(context.session.stopSpeaking(), true);
+  const cancellation = context.sent.findLast(
+    (event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CANCEL,
+  );
+
+  // Generation can finish at the service while its buffered audio is still
+  // playing here. The local stop still succeeded, so the refusal of its now
+  // redundant cancel is not a failure the developer can or should act on.
+  context.emit({
+    type: REALTIME_SERVER_EVENT.ERROR,
+    error: {
+      type: "invalid_request_error",
+      message: "Cancellation failed: no active response found",
+      event_id: cancellation?.event_id,
+    },
+  });
+
+  assert.deepEqual(reportedErrors(context), []);
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+});
+
+test("a stop after response.done clears playback without cancelling finished generation", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.deliverRemoteTrack();
+  await holdTurn(context);
+  context.session.endTurn(true);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-1" } });
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_DONE, response: { id: "resp-1" } });
+  const before = context.sent.length;
+
+  assert.equal(context.session.stopSpeaking(), true);
+
+  const events = context.sent.slice(before);
+  assert.equal(
+    events.some((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CANCEL),
+    false,
+  );
+  const clear = events.find(
+    (event) => event.type === REALTIME_CLIENT_EVENT.OUTPUT_AUDIO_BUFFER_CLEAR,
+  );
+  assert.match(String(clear?.event_id), /^output_audio_clear_/);
+});
+
+test("a real error answering the stop's cancellation is still surfaced", async () => {
+  const context = harness();
+  await context.session.connect();
+  await holdTurn(context);
+  context.session.endTurn(true);
+
+  assert.equal(context.session.stopSpeaking(), true);
+  const cancellation = context.sent.findLast(
+    (event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CANCEL,
+  );
+  context.emit({
+    type: REALTIME_SERVER_EVENT.ERROR,
+    error: {
+      type: "server_error",
+      code: "realtime_unavailable",
+      message: "Cancellation could not be processed.",
+      event_id: cancellation?.event_id,
+    },
+  });
+
+  assert.deepEqual(reportedErrors(context), ["Cancellation could not be processed."]);
+});
+
 test("a stop with nothing being spoken reports so and sends nothing", async () => {
   const context = harness();
   await context.session.connect();

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -217,6 +217,7 @@ export {
   type AttentionSpeech,
   attentionSpeechFromReviews,
   cancelResponseEvents,
+  clearOutputAudioEvents,
   clearInputAudioEvents,
   functionCallFollowUpEvents,
   functionCallOutputEvents,

--- a/packages/sidecar-core/src/realtime-protocol.ts
+++ b/packages/sidecar-core/src/realtime-protocol.ts
@@ -154,6 +154,13 @@ export function realtimeInstructions(): string {
   return REALTIME_INSTRUCTION_HEAD.join("\n");
 }
 
+/** Clears audio already queued for playback, naming the request for error correlation. */
+export function clearOutputAudioEvents(eventId: string): readonly WireRecord[] {
+  const clearEventId = trimmedText(eventId);
+  if (!clearEventId) return [];
+  return [{ type: REALTIME_CLIENT_EVENT.OUTPUT_AUDIO_BUFFER_CLEAR, event_id: clearEventId }];
+}
+
 /**
  * Builds the events that stop a reply the developer is talking over.
  *
@@ -163,10 +170,16 @@ export function realtimeInstructions(): string {
  * output buffer is what drops that, and doing it second means the server is not
  * still filling the buffer as it empties it.
  */
-export function cancelResponseEvents(): readonly WireRecord[] {
+export function cancelResponseEvents(input: {
+  cancellationEventId: string;
+  clearEventId: string;
+}): readonly WireRecord[] {
+  const cancellationEventId = trimmedText(input.cancellationEventId);
+  const clearEvents = clearOutputAudioEvents(input.clearEventId);
+  if (!cancellationEventId || clearEvents.length === 0) return [];
   return [
-    { type: REALTIME_CLIENT_EVENT.RESPONSE_CANCEL },
-    { type: REALTIME_CLIENT_EVENT.OUTPUT_AUDIO_BUFFER_CLEAR },
+    { type: REALTIME_CLIENT_EVENT.RESPONSE_CANCEL, event_id: cancellationEventId },
+    ...clearEvents,
   ];
 }
 
@@ -474,7 +487,13 @@ export type ParsedRealtimeServerEvent =
    * says. It is what lets a caller tell an error meant for the developer from
    * the answer to something it asked for itself.
    */
-  | { type: typeof REALTIME_SERVER_EVENT.ERROR; message: string; eventId?: string };
+  | {
+      type: typeof REALTIME_SERVER_EVENT.ERROR;
+      message: string;
+      eventId?: string;
+      errorType?: string;
+      errorCode?: string;
+    };
 
 function optionalString(value: UnparsedWireValue): string | undefined {
   return text(value);
@@ -608,11 +627,15 @@ export function parseRealtimeServerEvent(
       const error = recordField(event, "error");
       const message = optionalString(error?.message);
       const eventId = optionalString(error?.event_id);
+      const errorType = optionalString(error?.type);
+      const errorCode = optionalString(error?.code);
       const parsed: ParsedRealtimeServerEvent = {
         type: REALTIME_SERVER_EVENT.ERROR,
         message: message ?? "The voice service reported an error.",
       };
       if (eventId) parsed.eventId = eventId;
+      if (errorType) parsed.errorType = errorType;
+      if (errorCode) parsed.errorCode = errorCode;
       return parsed;
     }
     default:

--- a/packages/sidecar-core/tests/realtime.test.ts
+++ b/packages/sidecar-core/tests/realtime.test.ts
@@ -214,6 +214,7 @@ test("a refused delete is read back with the event it names", () => {
     type: REALTIME_SERVER_EVENT.ERROR,
     error: {
       type: "invalid_request_error",
+      code: "item_not_found",
       message: "Item with id 'luke_ctx_sessions_1' not found.",
       event_id: "luke_supersede_2",
     },
@@ -221,6 +222,8 @@ test("a refused delete is read back with the event it names", () => {
 
   assert.equal(parsed?.type, REALTIME_SERVER_EVENT.ERROR);
   assert.equal(parsed?.eventId, "luke_supersede_2");
+  assert.equal(parsed?.errorType, "invalid_request_error");
+  assert.equal(parsed?.errorCode, "item_not_found");
   assert.match(parsed?.message ?? "", /not found/);
 
   const deleted = parseRealtimeServerEvent({
@@ -325,9 +328,19 @@ test("a reply can be stopped by the developer taking the turn", () => {
   // Cancelling is only half of it. The model generates faster than it speaks,
   // so the rest of the sentence has already been sent by the time anyone talks
   // over it, and only emptying the output buffer stops that being heard.
+  const events = cancelResponseEvents({
+    cancellationEventId: "response_cancel_1",
+    clearEventId: "output_audio_clear_1",
+  });
   assert.deepEqual(
-    cancelResponseEvents().map((event) => event.type),
+    events.map((event) => event.type),
     [REALTIME_CLIENT_EVENT.RESPONSE_CANCEL, REALTIME_CLIENT_EVENT.OUTPUT_AUDIO_BUFFER_CLEAR],
+  );
+  assert.equal(events[0]?.event_id, "response_cancel_1");
+  assert.equal(events[1]?.event_id, "output_audio_clear_1");
+  assert.deepEqual(
+    cancelResponseEvents({ cancellationEventId: " ", clearEventId: "output_audio_clear_2" }),
+    [],
   );
 });
 


### PR DESCRIPTION
## Summary

- Stop Option-S from surfacing the harmless Realtime race where generation has already finished before `response.cancel` arrives.
- Skip redundant cancellation after `response.done` while still clearing buffered audio and truncating unheard transcript text.
- Correlate interruption errors by client event ID, preserve Realtime error type/code, and continue surfacing genuine cancellation or audio-clear failures.
- Add regression coverage for the benign race, post-completion stop, genuine correlated failures, event IDs, and error parsing.

## Test Coverage

Coverage audit: 82%. Covered paths include event IDs, parsing, the benign cancellation race, genuine cancellation failures, and post-`response.done` clear-only behavior.

## Pre-Landing Review

No issues found after correcting the original broad error suppression. Two independent reviews confirmed the final implementation suppresses only the documented benign race and preserves real failures.

## Scope Drift

Scope Check: CLEAN. Five files change only the Realtime stop/cancellation behavior and its tests.

## Plan Completion

No relevant plan artifact exists; the diff matches the conversation's implementation checklist.

## Verification

- [x] `./scripts/verify.sh`
- [x] 47 harness tests
- [x] 288 sidecar-core tests
- [x] 1,241 desktop tests
- [x] Typecheck and production builds
- [x] macOS packaging
- [x] Six generated visual evidence captures inspected with no regression

Physical-notch check was not performed; this change does not alter layout, motion, or rendering.

Existing non-blocking warnings remain unchanged: Biome warnings, Node 24 vs expected Node 22, and the packaging icon-format warning.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32325784141/artifacts/9391320374) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32325784141)

- Commit: `df5e3ba010cdb52429294fe52cdcf5b2fff817b6`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
