### PR TITLE
feat(settings): offer signing in again on the connected Superset row

### DIFF
--- a/PROVIDERS.md
+++ b/PROVIDERS.md
@@ -246,8 +246,10 @@ legacy JSON storage), skipping subagent and archived rows.
 it manages are observed by their own providers' adapters, and Superset's
 local state groups them into its workspaces and labels them with its project,
 branch, and pull-request context. Connecting is the CLI's own `auth login`,
-run at the developer's press on the Superset row, and the CLI owns the
-credential throughout; disconnecting is its `auth logout`. While connected,
+run at the developer's press on the Superset row — the Connect a disconnected
+row offers, or the pencil a connected row keeps for signing in again, which
+is how the CLI switches organizations — and the CLI owns the credential
+throughout; disconnecting is its `auth logout`. While connected,
 Superset-managed rows take acts through the CLI's documented commands, each
 invoked directly without a shell, each only as the direct product of a
 developer-opened turn, and each carrying only observed identifiers beside the

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -232,8 +232,9 @@ function integrationsFact(settings: AppSettings): AppGuideFact {
     "Settings, finish Superset's own sign-in flow in the browser, and paste its one-time code " +
     "into Luke. Superset's CLI exchanges that code, stores the login, and switches organizations; " +
     "Luke never reads its token or clipboard. Superset's row sits under Providers on the " +
-    "Connections page, and disconnecting from it runs the CLI's own sign-out, clearing the " +
-    "login the CLI stored. The default agent for a creation ask that names " +
+    "Connections page; while connected it keeps a pencil that runs the same sign-in again — " +
+    "the CLI's way of switching organizations — and disconnecting from it runs the CLI's own " +
+    "sign-out, clearing the login the CLI stored. The default agent for a creation ask that names " +
     "none is chosen under Superset in Settings; until one is chosen, Luke asks.";
   return {
     label: "Integrations",

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -1714,6 +1714,24 @@ function SupersetIntegration({
               >
                 <TrashIcon />
               </button>
+              {/* The pencil is the credential rows' word for editing a
+                  connection that already stands. Here the connection is the
+                  CLI's own login, so editing it is signing in again — the
+                  same act the Connect button runs, which is how the CLI
+                  switches organizations. */}
+              <button
+                type="button"
+                className="icon-button"
+                disabled={busy || control.held || control.connecting}
+                aria-label="Sign in to Superset again"
+                title={control.held ? HELD_TITLE : "Sign in again"}
+                onClick={() => {
+                  setRejection(undefined);
+                  control.onConnect();
+                }}
+              >
+                <PencilIcon />
+              </button>
             </span>
             <fieldset
               className="settings-actions credential-confirm"


### PR DESCRIPTION
## What

The connected Superset row in Settings now exposes the same edit affordance the key-based provider rows have: a pencil icon-button beside the trash. Superset's connection is the CLI's own login rather than a stored key, so editing it is signing in again — the pencil runs the existing `beginSupersetSignIn` flow through `SupersetControl.onConnect`, the same `auth login` the Connect button runs, which is also how the CLI switches organizations.

## Why this shape

- Same vocabulary as `ProviderCredential`: trash-then-pencil order inside the same `credential-controls` span, so the disconnect confirm still swaps in over both without re-shaping the line.
- No new write path: still the CLI's own `auth login` at the developer's press on the Superset row, inside the existing trust boundary.
- Guards: disabled while another entry holds the slot (with the shared held title), while a sign-in already waits on the browser, or while a disconnect is in flight; pressing it clears any prior rejection, matching `beginEntry` on the credential rows.

## Docs, same change

- `luke-guide.ts`: Luke now knows the connected row keeps a pencil that runs the sign-in again, so he describes it rather than denies it.
- `PROVIDERS.md`: names both `auth login` entry points — Connect on a disconnected row, the pencil on a connected one.
- `PRIVACY.md` and the README need no change: no data flow changed, and PRIVACY.md's "You can start that login from Luke's Settings" already covers the pencil.

## Verification

`./scripts/check.sh` exits 0: repository contract checks pass, lint and typecheck clean, 1238 desktop + 53 web tests pass, builds succeed. This is a UI change, but this cloud workspace is Linux, so `./scripts/verify.sh` (macOS packaging + visual evidence) could not run here and no physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/813bd003-c8ad-4c8f-a933-6b49216e76da)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32326030010/artifacts/9391402912) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32326030010)

- Commit: `70973ea1c7d5248bf782b002dbdb3a7f7f4134d3`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
