### PR TITLE
fix(superset): dress the sign-in code field like every other key slot

### DIFF
--- a/apps/desktop/src/renderer/superset-sign-in-slot.tsx
+++ b/apps/desktop/src/renderer/superset-sign-in-slot.tsx
@@ -81,7 +81,7 @@ export function SupersetSignInSlot({
           >
             <input
               ref={input}
-              className="key-slot-input"
+              className="settings-input key-slot-input"
               aria-label="Superset sign-in code"
               placeholder="Paste Superset code"
               value={code}
@@ -109,6 +109,7 @@ export function SupersetSignInSlot({
             <button
               type="submit"
               className="action-button key-slot-confirm"
+              data-ready={String(code.length > 0)}
               disabled={!code || exchanging}
             >
               {exchanging ? "Connecting…" : "Continue"}


### PR DESCRIPTION
## Summary

- add `settings-input` to the Superset sign-in slot's code field, so it draws the same dark, hairline-bordered field every other API-key popup does instead of the native browser appearance
- give its confirm button the same `data-ready` quiet-until-filled treatment the key slot's confirm has

## Validation

- `./scripts/check.sh` — passed (Linux sandbox; `./scripts/verify.sh` runs in CI, no physical-notch check performed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/10a8a730-da7d-4006-873c-c02687a8a5cc)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32326234582/artifacts/9391476759) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32326234582)

- Commit: `0985252bee3be9ab1f3229ca6b5275fff3a41bc3`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
