### PR TITLE
fix(voice): stop a reply the server already concluded without a cancel

### DIFF
--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -11,6 +11,7 @@ import {
   type ContextItemKind,
   cancelResponseEvents,
   clearInputAudioEvents,
+  clearOutputAudioEvents,
   contextItemId,
   contextSupersedeEventId,
   contextSupersedeEvents,
@@ -44,6 +45,7 @@ import {
   type RealtimeToolFamily,
   realtimeSessionSyncEvents,
   realtimeToolFamily,
+  responseCancelEventId,
   SESSION_REFERENCE_WITHDRAWN_TEXT,
   type SessionIdentity,
   type SessionNoticeAsk,
@@ -118,6 +120,15 @@ const CONTEXT_FLUSH_ORDER: readonly ContextItemKind[] = [
  * two turns' worth of room for something that ordinarily clears immediately.
  */
 const MAXIMUM_PENDING_SUPERSEDES = CONTEXT_FLUSH_ORDER.length * 2;
+
+/**
+ * How many named cancels are worth remembering. Only a refused cancel is ever
+ * answered by name — one that landed in time is concluded by the reply's own
+ * `done`, and nothing ever clears its entry — so the set is evicted oldest
+ * first, with room for far more unanswered cancels than one round trip can
+ * hold.
+ */
+const MAXIMUM_PENDING_CANCELS = 8;
 
 /**
  // SAFETY: The preceding check establishes the asserted contract.
@@ -429,6 +440,16 @@ export class RealtimeVoiceSession {
    * rather than a fault to report to the developer.
    */
   #pendingSupersedes = new Map<string, string>();
+  /** Rises for every cancel named, so no two ever share a name on one call. */
+  #cancelSequence = 0;
+  /**
+   * The cancels issued that could still be answered, by the name stamped on
+   * each. A cancel is answered with an error when the response is already over
+   * — its `done` was on the wire when the developer pressed stop — and that
+   * refusal means the quiet asked for already holds: this call's own business
+   * rather than a fault to report to the developer.
+   */
+  #pendingCancels = new Set<string>();
   /**
    * Luke's own audio track. Cancelling stops the model producing more, but what
    * it already produced is on its way down the connection and keeps playing —
@@ -1389,7 +1410,24 @@ export class RealtimeVoiceSession {
     // never heard — the text runs ahead of the speech — and leaving them up
     // would show Luke finishing a sentence he was just stopped from saying.
     this.#clearCaption();
-    this.#send(cancelResponseEvents());
+    // A cancel is for a reply the server still holds. Generation runs ahead
+    // of speech, so most stops land after the reply's `done` has already
+    // arrived — nothing is left to cancel, only queued audio to drop, and a
+    // cancel sent then is refused as having no active response, the refusal
+    // read out to the developer as a fault in a stop that worked.
+    if (this.#responseOutstanding) {
+      const eventId = responseCancelEventId(this.#cancelSequence);
+      this.#cancelSequence += 1;
+      while (this.#pendingCancels.size >= MAXIMUM_PENDING_CANCELS) {
+        const [oldest] = this.#pendingCancels;
+        if (oldest === undefined) break;
+        this.#pendingCancels.delete(oldest);
+      }
+      this.#pendingCancels.add(eventId);
+      this.#send(cancelResponseEvents({ eventId }));
+    } else {
+      this.#send(clearOutputAudioEvents());
+    }
     // Then correct what Luke believes he said, or the next answer is free to
     // refer back to a sentence that never reached the room.
     this.#send(this.#truncateEvents());
@@ -1406,10 +1444,11 @@ export class RealtimeVoiceSession {
     // that opens a new developer turn arms it afresh in #startResponse; left
     // true here, the cancelled reply's late calls would find it still standing.
     this.#toolTurnArmed = false;
-    // The cancel concludes the reply at the server before anything sent after
-    // it is read — the channel is ordered — so nothing is outstanding from
-    // here, and whatever `done` the cancelled reply still sends matches no
-    // active response above.
+    // The reply is concluded at the server from here — by the cancel, read
+    // before anything sent after it on an ordered channel, or by the `done`
+    // that already arrived or beat the cancel across the wire — so nothing is
+    // outstanding, and whatever `done` the stopped reply still sends matches
+    // no active response above.
     this.#responseOutstanding = false;
     this.#audioDrained = false;
     this.#followUpPending = false;
@@ -1521,6 +1560,7 @@ export class RealtimeVoiceSession {
     this.#contextPending.clear();
     this.#contextLive.clear();
     this.#pendingSupersedes.clear();
+    this.#pendingCancels.clear();
     this.#conversationBegan = false;
     this.#clearIdleTimer();
     this.#responseOutstanding = false;
@@ -2066,6 +2106,21 @@ export class RealtimeVoiceSession {
   }
 
   /**
+   * Whether an error is one of this call's own cancels coming back refused.
+   *
+   * A stop can race the reply's own conclusion: its `done` was already on the
+   * wire when the cancel was sent, so the server finds no active response to
+   * act on and says so. The refusal means the quiet the developer asked for
+   * already held — nothing they did and nothing they can act on — and the
+   * `done` that won the race concluded the turn on its own.
+   */
+  #cancelError(event: { eventId?: string }): boolean {
+    if (event.eventId === undefined || !this.#pendingCancels.has(event.eventId)) return false;
+    this.#pendingCancels.delete(event.eventId);
+    return true;
+  }
+
+  /**
    * The context items this call currently holds, by kind — what the
    * conversation would be answered from if a turn opened now. Exposed for the
    * tests that hold this class to its one-item-per-kind promise.
@@ -2245,6 +2300,11 @@ export class RealtimeVoiceSession {
         // nothing they can act on, and reporting it would both put a fault on
         // screen and, below, end a reply that is still being spoken.
         if (this.#supersedeError(event)) return;
+        // So can a cancel that lost its race: the reply it was stopping was
+        // already over, the interrupt already settled the turn, and the turn
+        // now under way — if any — is a newer one this answer says nothing
+        // about.
+        if (this.#cancelError(event)) return;
         this.#options.onError(event.message);
         // An error can arrive *instead of* `response.done` — an empty push-to-talk
         // commit is the common case — which would otherwise leave the session

--- a/apps/desktop/tests/realtime-session.test.ts
+++ b/apps/desktop/tests/realtime-session.test.ts
@@ -2292,6 +2292,80 @@ test("a stop with nothing being spoken reports so and sends nothing", async () =
   );
 });
 
+test("a stop after the reply finished generating sends no cancel", async () => {
+  // Generation runs ahead of speech, so most stops land after the reply's
+  // `done` has already arrived and the server holds no active response. A
+  // cancel sent then is refused as "no active response found" — an error read
+  // out to the developer as a fault in a stop that worked — when the only
+  // thing left to do is drop the queued audio and trim the record.
+  let clock = 1_000;
+  const context = harness({ now: () => clock });
+  await context.session.connect();
+  context.deliverRemoteTrack();
+  await holdTurn(context);
+  context.session.endTurn(true);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-a" } });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
+    item: { id: "item_reply" },
+  });
+  context.session.reportRemoteAudioActive();
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: {
+      id: "resp-a",
+      output: [{ type: "message", content: [{ type: "output_audio" }] }],
+    },
+  });
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+  clock = 2_500;
+  const before = context.sent.length;
+
+  assert.equal(context.session.stopSpeaking(), true);
+
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+  assert.equal(context.lukeAudible(), false);
+  assert.deepEqual(
+    context.sent.slice(before).map((event) => event.type),
+    [
+      REALTIME_CLIENT_EVENT.OUTPUT_AUDIO_BUFFER_CLEAR,
+      REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_TRUNCATE,
+    ],
+  );
+  assert.deepEqual(reportedErrors(context), []);
+});
+
+test("a cancel refused because the reply was already over is not a fault", async () => {
+  // The stop can also lose the race it cannot see: the reply's `done` was on
+  // the wire when the cancel went out, so the server refuses it for want of an
+  // active response. The refusal is the quiet already holding — nothing the
+  // developer did and nothing they can act on.
+  const context = harness();
+  await context.session.connect();
+  context.deliverRemoteTrack();
+  await holdTurn(context);
+  context.session.endTurn(true);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-a" } });
+  const before = context.sent.length;
+  assert.equal(context.session.stopSpeaking(), true);
+  const cancel = context.sent
+    .slice(before)
+    .find((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CANCEL);
+  assert.ok(cancel?.event_id, "a reply the server still holds is cancelled by name");
+
+  context.emit({
+    type: REALTIME_SERVER_EVENT.ERROR,
+    error: {
+      type: "invalid_request_error",
+      event_id: cancel?.event_id,
+      message: "Cancellation failed: no active response found",
+    },
+  });
+
+  assert.deepEqual(reportedErrors(context), []);
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+});
+
 test("a stop that races the reply's confirmation still holds", async () => {
   const carried: unknown[] = [];
   const context = harness({

--- a/packages/sidecar-core/src/index.ts
+++ b/packages/sidecar-core/src/index.ts
@@ -218,6 +218,7 @@ export {
   attentionSpeechFromReviews,
   cancelResponseEvents,
   clearInputAudioEvents,
+  clearOutputAudioEvents,
   functionCallFollowUpEvents,
   functionCallOutputEvents,
   inputAudioAppendEvents,
@@ -232,6 +233,7 @@ export {
   REALTIME_STATUS,
   type RealtimeFunctionCall,
   type RealtimeStatus,
+  responseCancelEventId,
   truncateResponseEvents,
   typedAskEvents,
 } from "./realtime-protocol.js";

--- a/packages/sidecar-core/src/realtime-protocol.ts
+++ b/packages/sidecar-core/src/realtime-protocol.ts
@@ -154,20 +154,44 @@ export function realtimeInstructions(): string {
   return REALTIME_INSTRUCTION_HEAD.join("\n");
 }
 
+/** Names the cancel itself, so the error a refused one answers with is known as ours. */
+export function responseCancelEventId(sequence: number): string {
+  return `luke_cancel_${sequence}`;
+}
+
 /**
- * Builds the events that stop a reply the developer is talking over.
+ * Builds the events that stop a reply the server has not yet concluded.
  *
  * Both are needed and in this order. Cancelling stops the model producing more
  * of the reply; it says nothing about the audio it already produced, which the
  * server has sent ahead because it generates faster than speech. Clearing the
  * output buffer is what drops that, and doing it second means the server is not
  * still filling the buffer as it empties it.
+ *
+ * A stop can race the reply's own `response.done` across the wire, and a
+ * cancel that loses finds no active response left: it is answered with an
+ * error rather than silence, which is why the event is named. The caller
+ * keeps the name and knows that answer for its own, rather than reporting it
+ * to the developer as a fault in a stop that worked.
  */
-export function cancelResponseEvents(): readonly WireRecord[] {
+export function cancelResponseEvents(input: { eventId: string }): readonly WireRecord[] {
+  if (!trimmedText(input.eventId)) return [];
   return [
-    { type: REALTIME_CLIENT_EVENT.RESPONSE_CANCEL },
+    { type: REALTIME_CLIENT_EVENT.RESPONSE_CANCEL, event_id: input.eventId },
     { type: REALTIME_CLIENT_EVENT.OUTPUT_AUDIO_BUFFER_CLEAR },
   ];
+}
+
+/**
+ * Builds the event that stops a reply the server has already concluded from
+ * being heard any further. Generation runs ahead of speech, so a reply is
+ * routinely finished at the server — its `response.done` delivered — while its
+ * audio is still playing out: by then there is nothing left to cancel, only
+ * queued audio to drop, and a cancel sent anyway is refused as having no
+ * active response to act on.
+ */
+export function clearOutputAudioEvents(): readonly WireRecord[] {
+  return [{ type: REALTIME_CLIENT_EVENT.OUTPUT_AUDIO_BUFFER_CLEAR }];
 }
 
 /**

--- a/packages/sidecar-core/tests/realtime.test.ts
+++ b/packages/sidecar-core/tests/realtime.test.ts
@@ -10,6 +10,7 @@ import {
   CONTEXT_ITEM_KIND,
   cancelResponseEvents,
   clearInputAudioEvents,
+  clearOutputAudioEvents,
   contextItemId,
   contextSupersedeEventId,
   contextSupersedeEvents,
@@ -45,6 +46,7 @@ import {
   realtimeClientSecretRequest,
   realtimeCredentialFromResponse,
   realtimeCredentialIsUsable,
+  responseCancelEventId,
   SESSION_LOCATION,
   SESSION_REFERENCE_WITHDRAWN_TEXT,
   SESSION_STATUS,
@@ -325,9 +327,24 @@ test("a reply can be stopped by the developer taking the turn", () => {
   // Cancelling is only half of it. The model generates faster than it speaks,
   // so the rest of the sentence has already been sent by the time anyone talks
   // over it, and only emptying the output buffer stops that being heard.
+  const events = cancelResponseEvents({ eventId: responseCancelEventId(3) });
   assert.deepEqual(
-    cancelResponseEvents().map((event) => event.type),
+    events.map((event) => event.type),
     [REALTIME_CLIENT_EVENT.RESPONSE_CANCEL, REALTIME_CLIENT_EVENT.OUTPUT_AUDIO_BUFFER_CLEAR],
+  );
+  // The cancel carries its name, so the error a losing race answers with is
+  // known as ours rather than reported as a fault.
+  assert.equal(events[0]?.event_id, "luke_cancel_3");
+  assert.deepEqual(cancelResponseEvents({ eventId: "   " }), []);
+});
+
+test("a reply already concluded is stopped without a cancel", () => {
+  // Generation runs ahead of speech, so a reply is routinely finished at the
+  // server while its audio still plays: there is nothing left to cancel, and
+  // asking anyway is answered with an error about a stop that worked.
+  assert.deepEqual(
+    clearOutputAudioEvents().map((event) => event.type),
+    [REALTIME_CLIENT_EVENT.OUTPUT_AUDIO_BUFFER_CLEAR],
   );
 });
 


### PR DESCRIPTION
## Problem

Pressing the stop key (Option-S) while Luke talks frequently surfaces **"Cancellation failed: no active response found"** even though the stop itself works.

The model generates a reply faster than it speaks it, so the server routinely delivers the reply's `response.done` while its audio is still playing out. The session correctly stays in `responding` until the audio drains — but `#interruptReply` sent `response.cancel` unconditionally, so a stop pressed after the `done` (the common case: generation finishes seconds before speech does) asked the server to cancel a response it no longer holds. The refusal came back as an `error` event and was reported to the developer as a fault. The same doomed cancel went out from every interrupt path: the stop key, talking over Luke, and typing over him.

## Fix

- `#interruptReply` sends `response.cancel` only while the server still owes the reply its `response.done` (`#responseOutstanding`); once the reply is concluded, only `output_audio_buffer.clear` (and the usual truncate) goes out — dropping the queued audio is all that is left to do.
- The cancel that remains can still lose a race against a `done` already on the wire, so it now carries a build-composed `event_id` — the same shape as a context supersede's named delete — and the error answering a named cancel is recognized as the session's own business instead of being read out: the quiet the developer asked for already held.

## Tests

- sidecar-core: `cancelResponseEvents` carries its name (and refuses a blank one); `clearOutputAudioEvents` sends the clear alone.
- desktop: a stop after `response.done` sends no cancel and reports no error; a refused cancel answered by name is swallowed and leaves the session `ready`. The existing stop/race suite is unchanged and still green.

`./scripts/check.sh` passes (exit 0; 278 core + 1240 desktop tests). Portable-only change — no UI or macOS surface touched, so no visual evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/652eaa16-2fc4-4874-9301-e09de85ed8a1)
