### PR TITLE
fix(face): wait awake for the first roster instead of sleeping at launch

### DIFF
--- a/apps/desktop/src/desktop-app.ts
+++ b/apps/desktop/src/desktop-app.ts
@@ -762,6 +762,12 @@ function registerIpc(): void {
         runMode.observesProviders && accountCapabilitiesActive()
           ? rosterRelevantSessions(sessionRegistry.snapshot().sessions, Date.now())
           : [],
+      // A live run's roster has settled once it has been broadcast at all —
+      // the first pass publishes even an empty reading — so before that, the
+      // empty list above means "not looked yet" and the face must not sleep
+      // on it. A fixture run never broadcasts and its sessions travel in the
+      // fixture itself, so it is settled from the start.
+      sessionsSettled: !runMode.observesProviders || lastRosterRevision !== -1,
       // Asks are about observed sessions, so they ride the same gate the
       // roster does: a panel shown no sessions is shown no asks about them.
       noticeAsks:

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -375,6 +375,11 @@ export function App(): React.JSX.Element {
   // lifecycle subscription to every sign-in change.
   const [account, setAccount, accountNow] = useStateWithRef<AccountSnapshot | undefined>(undefined);
   const [sessions, setSessions] = useState<readonly NormalizedSession[]>([]);
+  // Whether the roster above has been read at all yet. It only ever settles —
+  // the bootstrap can say a reading already happened, and any push is one —
+  // so a bootstrap replying "not yet" after a push raced past it clobbers
+  // nothing, and the wing stops saying "loading" the moment either arrives.
+  const [sessionsSettled, setSessionsSettled] = useState(false);
   const [noticeAsks, setNoticeAsks] = useState<readonly SessionNoticeAsk[]>([]);
   const [workspaceProjects, setWorkspaceProjects] = useState<readonly ObservedWorkspaceProject[]>(
     [],
@@ -2308,6 +2313,7 @@ export function App(): React.JSX.Element {
     void window.sidecar.getBootstrap().then((value) => {
       setBootstrap(value);
       setSessions(value.sessions);
+      if (value.sessionsSettled) setSessionsSettled(true);
       setNoticeAsks(value.noticeAsks);
       // Only fill in what no push has said yet: the bootstrap snapshot is
       // older than any change that raced past it, and the main process will
@@ -2369,7 +2375,12 @@ export function App(): React.JSX.Element {
       }
     });
     const removeDisplay = window.sidecar.onDisplayChanged(setDisplay);
-    const removeSessions = window.sidecar.onSessionsChanged(setSessions);
+    const removeSessions = window.sidecar.onSessionsChanged((next) => {
+      setSessions(next);
+      // Any publish is a reading: the main process broadcasts even an empty
+      // first pass, so hearing one at all means Luke has looked.
+      setSessionsSettled(true);
+    });
     const removeNoticeAsks = window.sidecar.onNoticeAsksChanged(setNoticeAsks);
     const removeSupersetSignIn = window.sidecar.onSupersetSignInChanged((next) => {
       setSupersetConnected(next.stage === SUPERSET_SIGN_IN_STAGE.CONNECTED);
@@ -3152,6 +3163,7 @@ export function App(): React.JSX.Element {
         voiceOpening={talkOpening}
         meetingQuiet={meetingQuiet}
         voiceSpent={voiceSpentNote !== undefined}
+        sessionsSettled={sessionsSettled}
         presentation={presentation}
         housingWidth={display.notch.housingWidth}
         accountGated={accountGated}

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -2201,6 +2201,19 @@ export function App(): React.JSX.Element {
     (onChange) => window.sidecar.onWorkspaceProjectsChanged(onChange),
     setWorkspaceProjects,
   );
+  // The roster itself rides the same rule, and settling rides with it: any
+  // push is a reading — the main process broadcasts even an empty first
+  // pass — so an older bootstrap snapshot can neither clobber a roster that
+  // raced past it nor leave the settled flag standing over a blank it
+  // reintroduced.
+  const acceptSessionsBootstrap = useBootstrapRacedChannel(
+    (onChange) =>
+      window.sidecar.onSessionsChanged((pushed) => {
+        setSessionsSettled(true);
+        onChange(pushed);
+      }),
+    setSessions,
+  );
   // Straight to the conversation rather than through state: no panel
   // surface draws the issue roster, so a re-render would be work for nobody.
   const acceptIssuesBootstrap = useBootstrapRacedChannel(
@@ -2312,7 +2325,7 @@ export function App(): React.JSX.Element {
     const bootstrapGeneration = modeGenerationOf();
     void window.sidecar.getBootstrap().then((value) => {
       setBootstrap(value);
-      setSessions(value.sessions);
+      acceptSessionsBootstrap(value.sessions);
       if (value.sessionsSettled) setSessionsSettled(true);
       setNoticeAsks(value.noticeAsks);
       // Only fill in what no push has said yet: the bootstrap snapshot is
@@ -2375,12 +2388,6 @@ export function App(): React.JSX.Element {
       }
     });
     const removeDisplay = window.sidecar.onDisplayChanged(setDisplay);
-    const removeSessions = window.sidecar.onSessionsChanged((next) => {
-      setSessions(next);
-      // Any publish is a reading: the main process broadcasts even an empty
-      // first pass, so hearing one at all means Luke has looked.
-      setSessionsSettled(true);
-    });
     const removeNoticeAsks = window.sidecar.onNoticeAsksChanged(setNoticeAsks);
     const removeSupersetSignIn = window.sidecar.onSupersetSignInChanged((next) => {
       setSupersetConnected(next.stage === SUPERSET_SIGN_IN_STAGE.CONNECTED);
@@ -2395,7 +2402,6 @@ export function App(): React.JSX.Element {
       cancelHover();
       removeLifecycle();
       removeDisplay();
-      removeSessions();
       removeNoticeAsks();
       removeSupersetSignIn();
       void stopMicrophone();
@@ -2407,6 +2413,7 @@ export function App(): React.JSX.Element {
     acceptMeetingQuietBootstrap,
     acceptOutputAudioBootstrap,
     acceptProjectsBootstrap,
+    acceptSessionsBootstrap,
     acceptSettingsBootstrap,
     acceptUpdateBootstrap,
     applyAuthoritativeMode,
@@ -2798,6 +2805,13 @@ export function App(): React.JSX.Element {
   // Luke is watching, not what the panel is currently showing — but it reads
   // in the list's own sort, so the wing's marks sit in the order the rows do.
   const tally = sessionTally(visibleSessions, sessionView.sort);
+  // The capsule button announces the same fact the badge draws: until the
+  // first roster reading lands, an unread zero is "checking", never "none
+  // tracked" — assistive tech must not hear a claim the wing is not making.
+  const tallyAnnouncement =
+    !accountGated && !sessionsSettled && tally.total === 0
+      ? "Checking for sessions"
+      : tallySummary(tally);
   const list = arrangeSessions(visibleSessions, sessionView);
   // Dropping an emptied filter is a change of view, not a way of drawing one.
   // Left in state it would lie dormant behind an All that only looks chosen,
@@ -3309,7 +3323,7 @@ export function App(): React.JSX.Element {
           className="compact-hover-target"
           data-hit-region={HIT_REGION.CAPSULE}
           aria-expanded={panelOpen}
-          aria-label={`${tallySummary(tally)}. ${panelOpen ? "Close" : "Open"} the panel`}
+          aria-label={`${tallyAnnouncement}. ${panelOpen ? "Close" : "Open"} the panel`}
           // Keeps the press from moving focus here at all, so nothing is drawn
           // around the notch strip and a focused settings field keeps the caret.
           onMouseDown={(event) => event.preventDefault()}

--- a/apps/desktop/src/renderer/luke-face-mood.ts
+++ b/apps/desktop/src/renderer/luke-face-mood.ts
@@ -29,6 +29,12 @@ export interface FaceContext {
    * anything a model decided.
    */
   voiceSpent: boolean;
+  /**
+   * Whether the roster has been read at all yet. Until the first reading
+   * lands, an empty total means "not looked yet" rather than "nothing to
+   * watch", and the two must not wear the same face.
+   */
+  settled: boolean;
   attention: readonly string[];
   working: number;
   complete: number;
@@ -110,8 +116,12 @@ export function restingMotion(context: FaceContext): FaceMotion | undefined {
   // what a rest must do. Speech still outranks it: a developer who opens a
   // turn mid-meeting is talking to a face, not to a pillow.
   if (context.meetingQuiet) return FACE_MOTION.SLEEPING;
-  // Nothing to watch at all, which is a different thing from nothing happening.
-  if (context.total === 0) return FACE_MOTION.SLEEPING;
+  // Nothing to watch at all, which is a different thing from nothing
+  // happening — and different again from not having looked yet. Until the
+  // first roster reading lands, the zero is the reading's absence, and Luke
+  // waits for it awake and still: falling asleep at launch would report an
+  // empty desk he has not actually seen.
+  if (context.total === 0 && context.settled) return FACE_MOTION.SLEEPING;
   // The day's voice is spent. Ranked below both sleeps: a meeting's hold and
   // an empty roster each say more about this moment than the meter does. It
   // stays true until the quota's own reset, which is what a rest must do —
@@ -402,7 +412,7 @@ export function useFaceMotion(context: FaceContext, still: boolean, hovered = fa
   const [gesture, setGesture] = useState<PlayingGesture>();
   const plays = useRef(0);
   const observed = useRef(observedFace(context));
-  const { total, complete, attention, working } = context;
+  const { total, complete, attention, working, settled } = context;
 
   // Which pool the next moment is drawn from, held in a ref rather than read in
   // the waiting effect below: work starting and stopping is exactly the churn
@@ -421,16 +431,24 @@ export function useFaceMotion(context: FaceContext, still: boolean, hovered = fa
   // often than anything actually changes; what makes that free is that the
   // comparison is against the sessions seen last time rather than against the
   // last render.
+  // The first reading to settle is a baseline, not news: its sessions were
+  // already running before Luke looked, so greeting them would announce
+  // arrivals that never happened — the same reason the very first render
+  // seeds silently. Tracked against the settling seen last time, like the
+  // observations, so nothing else changing can replay the exemption.
+  const settledBefore = useRef(settled);
   useEffect(() => {
     const previous = observed.current;
     const current = observedFace({ attention, complete, total });
     observed.current = current;
-    if (still) return;
+    const firstReading = settled && !settledBefore.current;
+    settledBefore.current = settled;
+    if (still || firstReading) return;
     const noticed = noticedMotion(previous, current);
     if (noticed === undefined) return;
     plays.current += 1;
     setGesture({ motion: noticed, play: plays.current });
-  }, [attention, complete, total, still]);
+  }, [attention, complete, total, still, settled]);
 
   // The artwork plays each motion once and leaves the face at the pose it
   // started from, so this is only the bookkeeping that catches up with it: the

--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -48,6 +48,13 @@ interface NotchWingsProps {
   meetingQuiet: boolean;
   /** Whether today's voice allowance is spent with no call open — the face hushes on it. */
   voiceSpent: boolean;
+  /**
+   * Whether the roster has been read at all yet. Until it has, the wing is
+   * loading rather than empty: the face waits awake instead of sleeping on a
+   * zero that only means "not looked yet", and the badge says it is checking
+   * rather than counting nothing.
+   */
+  sessionsSettled: boolean;
   presentation: PanelPresentation;
   housingWidth: number;
   /**
@@ -201,6 +208,7 @@ export function NotchWings({
   voiceOpening,
   meetingQuiet,
   voiceSpent,
+  sessionsSettled,
   presentation,
   housingWidth,
   accountGated,
@@ -240,6 +248,7 @@ export function NotchWings({
       }),
       meetingQuiet,
       voiceSpent,
+      settled: sessionsSettled,
       attention: tally.attentionIds,
       working: tally.working,
       complete: tally.complete,
@@ -290,6 +299,11 @@ export function NotchWings({
     countWidths.caption,
     accountGated,
   );
+  // The badge must not count a roster nobody has read: until the first
+  // reading lands it says it is checking, because "0 none tracked" is a
+  // claim about the desk and "still looking" is not. The sign-in label
+  // outranks it — a gated Luke is not checking anything.
+  const rosterLoading = !accountGated && !sessionsSettled && tally.total === 0;
 
   return (
     <>
@@ -378,16 +392,24 @@ export function NotchWings({
             data-sign-in={String(accountGated)}
             role="status"
             aria-live="polite"
-            aria-label={accountGated ? "Sign in" : tallySummary(tally)}
+            aria-label={
+              accountGated
+                ? "Sign in"
+                : rosterLoading
+                  ? "Checking for sessions"
+                  : tallySummary(tally)
+            }
           >
             <span className="count-value" aria-hidden="true" ref={countValueElement}>
-              {accountGated ? "Sign in" : tallyValue(tally)}
+              {accountGated ? "Sign in" : rosterLoading ? "…" : tallyValue(tally)}
             </span>
             <span className="count-caption" aria-hidden="true" ref={countCaptionElement}>
               {/* No caption while signed out: the two words are the label
                   entire, and with nothing beside them the fit keeps their
-                  natural size inside the peek's side. */}
-              {accountGated ? null : tallyCaption(tally)}
+                  natural size inside the peek's side. Nor while checking —
+                  the ellipsis is the whole report until there is a count to
+                  put words beside. */}
+              {accountGated || rosterLoading ? null : tallyCaption(tally)}
             </span>
           </span>
         </div>

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -566,6 +566,14 @@ export interface AppBootstrap {
   update: UpdateSnapshot;
   sessions: readonly NormalizedSession[];
   /**
+   * Whether `sessions` reflects a roster Luke has actually read. False only
+   * while a live run's first observation pass is still on its way, so an
+   * empty list can say "not looked yet" rather than "nothing to watch"; every
+   * later reading arrives over `onSessionsChanged`, whose first delivery is
+   * itself the settling signal.
+   */
+  sessionsSettled: boolean;
+  /**
    * The standing asks the developer has made about sessions, so a panel that
    * opens late still marks the rows Luke is listening for. The words are the
    * developer's own and never a provider's.

--- a/apps/desktop/tests/luke-face-mood.test.ts
+++ b/apps/desktop/tests/luke-face-mood.test.ts
@@ -26,6 +26,7 @@ function context(overrides: Partial<FaceContext> = {}): FaceContext {
     microphoneLive: false,
     meetingQuiet: false,
     voiceSpent: false,
+    settled: true,
     attention: [],
     working: 0,
     complete: 0,
@@ -100,6 +101,23 @@ test("a meeting the calendar is holding through puts the face to sleep", () => {
     restingMotion(context({ meetingQuiet: true, microphoneLive: true })),
     FACE_MOTION.LISTENING,
   );
+});
+
+test("a roster not yet read holds the face awake rather than asleep", () => {
+  // At launch the zero is the reading's absence, not an empty desk: the face
+  // waits still until the first roster lands, and only a settled zero sleeps.
+  assert.equal(restingMotion(context({ settled: false })), undefined);
+  assert.equal(restingMotion(context()), FACE_MOTION.SLEEPING);
+  // The meeting's sleep reports the calendar's hold, not the roster, so it
+  // does not wait for one; and speech is speech whatever has been read.
+  assert.equal(
+    restingMotion(context({ settled: false, meetingQuiet: true })),
+    FACE_MOTION.SLEEPING,
+  );
+  assert.equal(restingMotion(context({ settled: false, speaking: true })), FACE_MOTION.TALKING);
+  // A spent meter is about the voice, not the roster: hushed says it honestly
+  // while the first reading is still on its way.
+  assert.equal(restingMotion(context({ settled: false, voiceSpent: true })), FACE_MOTION.HUSHED);
 });
 
 test("a spent voice hushes an awake face, and everything else outranks it", () => {


### PR DESCRIPTION
## Summary

- At launch, before the first observation pass published a roster, the renderer's empty session list read as "nothing to watch" and the face slept the moment it was drawn — an odd look while chats were still loading. The zero before the first reading means "not looked yet", and the two no longer wear the same face.
- `AppBootstrap` gains `sessionsSettled`: true once the roster has been broadcast at all (the first pass publishes even an empty reading), and true from the start in fixture/capture runs, whose sessions travel in the fixture itself and never see a broadcast. In the renderer the flag only ever settles — the bootstrap can say a reading already happened, and any `onSessionsChanged` push is one — so a bootstrap reply racing a push clobbers nothing.
- While the roster is unread, the face waits awake and still instead of sleeping, and the count badge shows a dim ellipsis ("Checking for sessions") instead of "0 none tracked". The meeting-quiet sleep, speech, the open microphone, and the hushed spent-voice face are unaffected — each reports something other than the roster.
- The first reading to land is a baseline, not news: the face no longer plays arrival/attention gestures for sessions that were already running before Luke looked, the same reason the very first render seeds silently.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (repository checks, types, tests, builds; exit 0)
- macOS Electron verification (`./scripts/verify.sh`): `not run locally (Linux cloud workspace) — covered by CI's macOS job`

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32327547965/artifacts/9391915725) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32327547965)

- Commit: `90b101d7dc5abe9987a0e180d95b8e30d2247c33`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed (no physical Mac in this workspace)`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: A re-sign-in after a mid-run sign-out can still show the sleeping face for one pass (~5s) before its first post-sign-in reading lands, because the sign-out's empty broadcast is itself a reading; that window predates this change at one remove and is left as is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/71edc2ce-7254-4e2e-b2ad-c96827a48dc8)
