### PR TITLE
chore(release): bump version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,61 @@
 Notable changes to Luke, newest first. Each heading is a released version and
 the date its release was published.
 
+## 0.3.0 — 2026-08-19
+
+### Superset workspaces
+
+Luke connects to Superset and puts its managed workspaces alongside every
+other coding-agent session. You can create, open, rename, message, and delete
+settled workspaces without leaving Luke.
+([#274](https://github.com/ReviewStage/luke/pull/274),
+[#299](https://github.com/ReviewStage/luke/pull/299),
+[#309](https://github.com/ReviewStage/luke/pull/309),
+[#310](https://github.com/ReviewStage/luke/pull/310),
+[#312](https://github.com/ReviewStage/luke/pull/312),
+[#316](https://github.com/ReviewStage/luke/pull/316))
+
+### Improvements
+
+- You can search Settings
+  ([#305](https://github.com/ReviewStage/luke/pull/305))
+- Luke keeps himself current from the Updates row
+  ([#284](https://github.com/ReviewStage/luke/pull/284))
+- Luke stays silent for sessions waiting on automation
+  ([#298](https://github.com/ReviewStage/luke/pull/298))
+- Luke hides archived Claude Code and local Codex sessions
+  ([#295](https://github.com/ReviewStage/luke/pull/295),
+  [#297](https://github.com/ReviewStage/luke/pull/297))
+- Luke's voice and interface speak more directly about agents and their work
+  ([#290](https://github.com/ReviewStage/luke/pull/290),
+  [#296](https://github.com/ReviewStage/luke/pull/296),
+  [#307](https://github.com/ReviewStage/luke/pull/307),
+  [#313](https://github.com/ReviewStage/luke/pull/313))
+- Settings makes a spent free voice allowance clear everywhere
+  ([#308](https://github.com/ReviewStage/luke/pull/308))
+
+### Fixes
+
+- Fixed a typed ask requesting microphone permission
+  ([#294](https://github.com/ReviewStage/luke/pull/294))
+- Fixed the panel closing when its shape receded past the pointer
+  ([#293](https://github.com/ReviewStage/luke/pull/293))
+- Fixed delegated Codex chat titles and announcements
+  ([#303](https://github.com/ReviewStage/luke/pull/303),
+  [#304](https://github.com/ReviewStage/luke/pull/304),
+  [#306](https://github.com/ReviewStage/luke/pull/306))
+- Fixed voice stop cancellation races
+  ([#315](https://github.com/ReviewStage/luke/pull/315))
+- Fixed the Superset sign-in code field looking unlike the other key slots
+  ([#317](https://github.com/ReviewStage/luke/pull/317))
+
+### Miscellaneous
+
+- Added PostHog analytics setup
+  ([#289](https://github.com/ReviewStage/luke/pull/289))
+- Added anti-slop Oxlint rules across the repository
+  ([#286](https://github.com/ReviewStage/luke/pull/286))
+
 ## 0.2.0 — 2026-08-18
 
 ### Codex cloud tasks

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@luke/desktop",
   "productName": "Luke",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Luke desktop application",
   "main": "dist/main.js",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luke/web",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "description": "Luke landing page",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luke",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "A notch-attached desktop sidecar for coding-agent sessions",
   "packageManager": "pnpm@9.15.0",

--- a/packages/sidecar-core/package.json
+++ b/packages/sidecar-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -49,11 +49,11 @@ function packagerOptions(signing = resolveSigningMode({})) {
     licensePath: `/repo/apps/desktop/.build/${LICENSE_RESOURCE_NAME}`,
     entitlementsPath,
     signing,
-    version: "0.2.0",
+    version: "0.3.0",
   });
 }
 
-test("workspace package versions agree on v0.2.0", () => {
+test("workspace package versions agree on v0.3.0", () => {
   const packagePaths = [
     "package.json",
     "apps/desktop/package.json",
@@ -66,7 +66,7 @@ test("workspace package versions agree on v0.2.0", () => {
 
   assert.deepEqual(
     versions.map(({ version }) => version),
-    packagePaths.map(() => "0.2.0"),
+    packagePaths.map(() => "0.3.0"),
   );
 });
 


### PR DESCRIPTION
## Summary

- bump every workspace package version to `0.3.0`
- add the `0.3.0` changelog entry for Superset workspace management, Settings search, automatic updates, and the fixes landed since `v0.2.0`
- update the packaging version contract

## Validation

- `./scripts/bootstrap.sh && ./scripts/check.sh`

## Release

After this lands, tag the resulting `main` commit as `v0.3.0`, build the signed and notarized artifacts locally, and publish them through the repository release script.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32327131560/artifacts/9391769970) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32327131560)

- Commit: `bfe4525d7b36cdb614c9b00956783e3ea5414991`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
