### PR TITLE
fix(superset): dress the sign-in popup exactly like the key popups

### DIFF
--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -2799,15 +2799,11 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   padding-left: calc(var(--slot-mark-size) + var(--slot-gutter-gap));
 }
 
-.superset-code-row,
-.superset-organization-list {
-  padding-left: calc(var(--slot-mark-size) + var(--slot-gutter-gap));
-}
-
 .superset-organization-list {
   display: flex;
   flex-wrap: wrap;
   gap: 7px;
+  padding-left: calc(var(--slot-mark-size) + var(--slot-gutter-gap));
 }
 
 /* Evidence capture screenshots a fixed moment after the renderer reports ready.

--- a/apps/desktop/src/renderer/superset-sign-in-slot.tsx
+++ b/apps/desktop/src/renderer/superset-sign-in-slot.tsx
@@ -15,8 +15,9 @@ import { ExternalIcon } from "./settings-icons";
  * Superset's own word for it, the provider's mark beside it, where the code
  * comes from on the line below, and the confirm quiet until there is
  * something to confirm. Only the stages a key never has — choosing an
- * organization, a sign-in that failed — keep the waiting popups' one-line
- * dress, worded the way the consent slot words them.
+ * organization, the switch that choice starts, a sign-in that failed — keep
+ * the waiting popups' one-line dress, worded the way the consent slot words
+ * them: an organization switch asks for no code, so it never wears the field.
  */
 export function SupersetSignInSlot({
   state,
@@ -47,6 +48,7 @@ export function SupersetSignInSlot({
   const exchanging = state.stage === SUPERSET_SIGN_IN_STAGE.EXCHANGING;
   const failed = state.stage === SUPERSET_SIGN_IN_STAGE.FAILURE;
   const choosing = state.stage === SUPERSET_SIGN_IN_STAGE.ORGANIZATION;
+  const switching = state.stage === SUPERSET_SIGN_IN_STAGE.SWITCHING;
   const filled = code.trim().length > 0;
   const ready = filled && waiting;
 
@@ -138,13 +140,19 @@ export function SupersetSignInSlot({
             </div>
           </>
         ) : null}
-        {choosing || failed ? (
+        {choosing || switching || failed ? (
           <div className="key-slot-row">
             <span className="key-slot-mark">
               <ProviderMark providerId={SUPERSET_WORKSPACE_PROVIDER_ID} />
             </span>
             <span className="sign-in-slot-copy" role="status">
-              <strong>{failed ? "Not connected" : "Choose a Superset organization"}</strong>
+              <strong>
+                {failed
+                  ? "Not connected"
+                  : switching
+                    ? "Connecting…"
+                    : "Choose a Superset organization"}
+              </strong>
               {failed ? (
                 <small>
                   {state.failure}{" "}

--- a/apps/desktop/src/renderer/superset-sign-in-slot.tsx
+++ b/apps/desktop/src/renderer/superset-sign-in-slot.tsx
@@ -1,10 +1,23 @@
 import { useEffect, useRef, useState } from "react";
-import { SUPERSET_SIGN_IN_STAGE, type SupersetSignInSnapshot } from "../shared/contracts";
+import type { SupersetSignInSnapshot } from "../shared/contracts";
+import { CREDENTIAL_SOURCE, SUPERSET_SIGN_IN_STAGE } from "../shared/contracts";
 import { SUPERSET_WORKSPACE_PROVIDER_ID } from "../shared/superset";
+import { CREDENTIAL_PLACEHOLDER, useStagedFocus } from "./credential-entry";
 import { HIT_REGION } from "./panel-state";
 import { ProviderMark } from "./provider-marks";
 import { ExternalIcon } from "./settings-icons";
 
+/**
+ * The panel stood down to Superset's sign-in code, on the key slot's exact
+ * terms: to anyone standing in front of Luke, a one-time code and an API key
+ * are the same errand with a different word on it, so the popup keeps the
+ * same shape and the same words — what to paste named above the field in
+ * Superset's own word for it, the provider's mark beside it, where the code
+ * comes from on the line below, and the confirm quiet until there is
+ * something to confirm. Only the stages a key never has — choosing an
+ * organization, a sign-in that failed — keep the waiting popups' one-line
+ * dress, worded the way the consent slot words them.
+ */
 export function SupersetSignInSlot({
   state,
   drawn,
@@ -26,95 +39,129 @@ export function SupersetSignInSlot({
 }): React.JSX.Element {
   const [code, setCode] = useState("");
   const input = useRef<HTMLInputElement>(null);
-  const pasteArmed = useRef(false);
   useEffect(() => {
-    if (drawn && state.stage === SUPERSET_SIGN_IN_STAGE.BROWSER_CODE) input.current?.focus();
     if (state.stage !== SUPERSET_SIGN_IN_STAGE.BROWSER_CODE) setCode("");
-  }, [drawn, state.stage]);
+  }, [state.stage]);
 
   const waiting = state.stage === SUPERSET_SIGN_IN_STAGE.BROWSER_CODE;
   const exchanging = state.stage === SUPERSET_SIGN_IN_STAGE.EXCHANGING;
   const failed = state.stage === SUPERSET_SIGN_IN_STAGE.FAILURE;
   const choosing = state.stage === SUPERSET_SIGN_IN_STAGE.ORGANIZATION;
+  const filled = code.trim().length > 0;
+  const ready = filled && waiting;
+
+  useStagedFocus(input, drawn && waiting);
+
+  useEffect(() => {
+    if (!(drawn && waiting)) return;
+    // Coming back from the browser with the code on the clipboard should cost
+    // one gesture, not two, exactly as it does for a key: however the window
+    // is raised, the caret is already where the code goes.
+    const takeCaret = () => input.current?.focus({ preventScroll: true });
+    window.addEventListener("focus", takeCaret);
+    return () => window.removeEventListener("focus", takeCaret);
+  }, [drawn, waiting]);
 
   return (
     <div className="slot-stage" data-drawn={String(drawn)} aria-hidden={!drawn} inert={!drawn}>
-      {/* Dressed like every other slot: the same shape, and Superset's own
-          mark naming whose sign-in this is, the way the key and consent slots
-          introduce their providers. */}
       <div className="key-slot sign-in-slot" ref={measure} data-hit-region={HIT_REGION.SLOT}>
-        <div className="key-slot-row">
-          <span className="key-slot-mark">
-            <ProviderMark providerId={SUPERSET_WORKSPACE_PROVIDER_ID} />
-          </span>
-          <span className="sign-in-slot-copy" role="status">
-            <strong>
-              {failed
-                ? "Not connected"
-                : choosing
-                  ? "Choose a Superset organization"
-                  : "Finish signing in with Superset"}
-            </strong>
-            {waiting ? (
-              <small>
-                Copy the code from the browser, then press ⌘V here.{" "}
-                <button type="button" className="link-button" onClick={onReopen}>
-                  Open the page again
+        {waiting || exchanging ? (
+          <>
+            {/* What to paste, in Superset's own word for it, where every key
+                popup names its credential. */}
+            <span className="settings-label key-slot-label">Sign-in code</span>
+            <div className="key-slot-row">
+              <span className="key-slot-mark">
+                <ProviderMark providerId={SUPERSET_WORKSPACE_PROVIDER_ID} />
+              </span>
+              <input
+                ref={input}
+                className="settings-input key-slot-input"
+                type="password"
+                aria-label="Superset sign-in code"
+                autoComplete="off"
+                spellCheck={false}
+                placeholder={CREDENTIAL_PLACEHOLDER[CREDENTIAL_SOURCE.NONE]}
+                value={code}
+                disabled={exchanging}
+                onChange={(event) => setCode(event.target.value)}
+                onFocus={() => {
+                  // The slot is shown without stealing focus, and a field that
+                  // cannot be typed into is worse than no field.
+                  window.sidecar.focusPanel();
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" && ready) onSubmit(code);
+                  // Escape belongs to the sign-in here: there is no panel
+                  // behind the slot to close.
+                  if (event.key === "Escape") {
+                    event.stopPropagation();
+                    onCancel();
+                  }
+                }}
+              />
+            </div>
+            <div className="settings-row key-slot-foot">
+              <small className="settings-note">
+                Superset shows a one-time code at the end of its sign-in page.{" "}
+                {/* A button, not an anchor, like the key slot's own: the main
+                    process reopens the page the waiting flow built, and no
+                    address crosses from here. */}
+                <button
+                  type="button"
+                  className="link-button"
+                  disabled={exchanging}
+                  onClick={onReopen}
+                >
+                  Where to get one
                   <ExternalIcon />
                 </button>
               </small>
-            ) : null}
-            {exchanging ? <small>Connecting…</small> : null}
-            {failed ? <small>{state.failure}</small> : null}
-          </span>
-          <button type="button" className="quiet-button" onClick={failed ? onRetry : onCancel}>
-            {failed ? "Retry" : "Cancel"}
-          </button>
-        </div>
-        {waiting || exchanging ? (
-          <form
-            className="key-slot-row superset-code-row"
-            onSubmit={(event) => {
-              event.preventDefault();
-              if (code) onSubmit(code);
-            }}
-          >
-            <input
-              ref={input}
-              className="settings-input key-slot-input"
-              aria-label="Superset sign-in code"
-              placeholder="Paste Superset code"
-              value={code}
-              disabled={exchanging}
-              onKeyDown={(event) => {
-                pasteArmed.current = event.metaKey && event.key.toLowerCase() === "v";
-                if (
-                  !pasteArmed.current &&
-                  (event.key.length === 1 || event.key === "Backspace" || event.key === "Delete")
-                ) {
-                  event.preventDefault();
-                }
-              }}
-              onKeyUp={() => {
-                pasteArmed.current = false;
-              }}
-              onPaste={(event) => {
-                event.preventDefault();
-                if (!pasteArmed.current) return;
-                pasteArmed.current = false;
-                setCode(event.clipboardData.getData("text"));
-              }}
-              onChange={() => undefined}
-            />
-            <button
-              type="submit"
-              className="action-button key-slot-confirm"
-              data-ready={String(code.length > 0)}
-              disabled={!code || exchanging}
-            >
-              {exchanging ? "Connecting…" : "Continue"}
+              <span className="settings-actions">
+                <button type="button" className="quiet-button" onClick={onCancel}>
+                  Cancel
+                </button>
+                {/* The settings row's own word for what this finishes. It is
+                    quiet and small until the code lands in the field, exactly
+                    as a key's confirm waits for its key, and stays up to size
+                    while the exchange it started runs. */}
+                <button
+                  type="button"
+                  className="action-button key-slot-confirm"
+                  data-ready={String(exchanging || filled)}
+                  disabled={!ready}
+                  onClick={() => onSubmit(code)}
+                >
+                  {exchanging ? "Connecting…" : "Connect"}
+                </button>
+              </span>
+            </div>
+          </>
+        ) : null}
+        {choosing || failed ? (
+          <div className="key-slot-row">
+            <span className="key-slot-mark">
+              <ProviderMark providerId={SUPERSET_WORKSPACE_PROVIDER_ID} />
+            </span>
+            <span className="sign-in-slot-copy" role="status">
+              <strong>{failed ? "Not connected" : "Choose a Superset organization"}</strong>
+              {failed ? (
+                <small>
+                  {state.failure}{" "}
+                  {/* The settings row's word for redoing the sign-in, dressed
+                      like the way back to a lost tab: retrying opens
+                      Superset's page again. */}
+                  <button type="button" className="link-button" onClick={onRetry}>
+                    Sign in again
+                    <ExternalIcon />
+                  </button>
+                </small>
+              ) : null}
+            </span>
+            <button type="button" className="quiet-button" onClick={onCancel}>
+              {failed ? "Close" : "Cancel"}
             </button>
-          </form>
+          </div>
         ) : null}
         {choosing ? (
           <div className="superset-organization-list">
@@ -128,13 +175,6 @@ export function SupersetSignInSlot({
                 {organization.name}
               </button>
             ))}
-          </div>
-        ) : null}
-        {failed ? (
-          <div className="key-slot-foot">
-            <button type="button" className="link-button" onClick={onCancel}>
-              Close
-            </button>
           </div>
         ) : null}
       </div>

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -639,6 +639,7 @@ export const SUPERSET_SIGN_IN_STAGE = {
   BROWSER_CODE: "browser-code",
   EXCHANGING: "exchanging",
   ORGANIZATION: "organization",
+  SWITCHING: "switching",
   FAILURE: "failure",
   CONNECTED: "connected",
 } as const;

--- a/apps/desktop/src/superset-sign-in.ts
+++ b/apps/desktop/src/superset-sign-in.ts
@@ -186,7 +186,9 @@ export class SupersetSignIn {
   async chooseOrganization(slug: string): Promise<SupersetSignInSnapshot> {
     if (this.#state.stage !== SUPERSET_SIGN_IN_STAGE.ORGANIZATION) return this.#state;
     const attempt = ++this.#attempt;
-    this.#set(snapshot(SUPERSET_SIGN_IN_STAGE.EXCHANGING));
+    // The CLI's own word for this act: an organization switch is not the code
+    // exchange, and drawing it as one would ask for a code nobody owes.
+    this.#set(snapshot(SUPERSET_SIGN_IN_STAGE.SWITCHING));
     const connected = await this.#cli.chooseOrganization(slug);
     if (attempt !== this.#attempt) return this.#state;
     if (connected) {

--- a/apps/desktop/tests/superset-sign-in-slot.test.ts
+++ b/apps/desktop/tests/superset-sign-in-slot.test.ts
@@ -20,12 +20,15 @@ function render(state: SupersetSignInSnapshot): string {
   );
 }
 
-test("the browser stage asks for an explicit paste and can reopen or cancel", () => {
+test("the browser stage speaks the key popups' own language", () => {
   const markup = render({ stage: SUPERSET_SIGN_IN_STAGE.BROWSER_CODE, organizations: [] });
-  assert.match(markup, /Finish signing in with Superset/);
-  assert.match(markup, /press ⌘V here/);
-  assert.match(markup, /Open the page again/);
+  assert.match(markup, /key-slot-label[^>]*>Sign-in code/);
+  assert.match(markup, /key-slot-foot/);
+  assert.match(markup, /type="password"/);
+  assert.match(markup, /Paste it here/);
+  assert.match(markup, /Where to get one/);
   assert.match(markup, /Cancel/);
+  assert.match(markup, /Connect</);
   assert.match(markup, /Superset sign-in code/);
 });
 
@@ -55,14 +58,14 @@ test("the organization stage draws only the returned identities", () => {
   assert.doesNotMatch(markup, /Superset sign-in code/);
 });
 
-test("a bounded failure offers both retry and close", () => {
+test("a bounded failure offers both another sign-in and close", () => {
   const markup = render({
     stage: SUPERSET_SIGN_IN_STAGE.FAILURE,
     failure: "Superset sign-in did not finish.",
     organizations: [],
   });
   assert.match(markup, /Not connected/);
-  assert.match(markup, /Retry/);
+  assert.match(markup, /Sign in again/);
   assert.match(markup, /Close/);
   assert.doesNotMatch(markup, /token=/);
 });

--- a/apps/desktop/tests/superset-sign-in-slot.test.ts
+++ b/apps/desktop/tests/superset-sign-in-slot.test.ts
@@ -58,6 +58,15 @@ test("the organization stage draws only the returned identities", () => {
   assert.doesNotMatch(markup, /Superset sign-in code/);
 });
 
+test("the organization switch keeps the one-line dress and asks for no code", () => {
+  const markup = render({ stage: SUPERSET_SIGN_IN_STAGE.SWITCHING, organizations: [] });
+  assert.match(markup, /Connecting…/);
+  assert.match(markup, /Cancel/);
+  assert.doesNotMatch(markup, /Sign-in code/);
+  assert.doesNotMatch(markup, /Paste it here/);
+  assert.doesNotMatch(markup, /Where to get one/);
+});
+
 test("a bounded failure offers both another sign-in and close", () => {
   const markup = render({
     stage: SUPERSET_SIGN_IN_STAGE.FAILURE,

--- a/apps/desktop/tests/superset-sign-in.test.ts
+++ b/apps/desktop/tests/superset-sign-in.test.ts
@@ -221,6 +221,29 @@ test("zero organizations fail; listed organizations are offered and revalidated"
   listed = [];
   assert.equal((await signIn.chooseOrganization("acme")).stage, SUPERSET_SIGN_IN_STAGE.FAILURE);
 
+  const chosen = new FakeChild();
+  listed = organizations;
+  const stages: string[] = [];
+  const switching = new SupersetSignIn({
+    cli,
+    openExternal: async () => undefined,
+    onChange: (state) => stages.push(state.stage),
+    spawnLogin: () => chosen,
+  });
+  await fs.rm(path.join(home, "config.json"), { force: true });
+  await switching.begin();
+  chosen.emit("close", 1);
+  await waitFor(() => switching.current().stage === SUPERSET_SIGN_IN_STAGE.ORGANIZATION);
+  assert.equal(
+    (await switching.chooseOrganization("acme")).stage,
+    SUPERSET_SIGN_IN_STAGE.CONNECTED,
+  );
+  // The switch is its own stage: drawn as the code exchange, the slot would
+  // ask for a second code nobody owes.
+  assert.ok(stages.includes(SUPERSET_SIGN_IN_STAGE.SWITCHING));
+  assert.equal(stages.includes(SUPERSET_SIGN_IN_STAGE.EXCHANGING), false);
+  await fs.rm(path.join(home, "config.json"), { force: true });
+
   const second = new FakeChild();
   listed = [];
   const empty = new SupersetSignIn({


### PR DESCRIPTION
## Summary

- restructure the Superset sign-in slot's code-entry stage onto the key slot's exact skeleton and language: the credential named above the field in Superset's own word for it (**Sign-in code**), the provider's mark beside the field, the shared "Paste it here" placeholder, a note line saying where the code comes from with the same "Where to get one" link back to the page, and Cancel beside a confirm that stays quiet until the field is filled — **Connect**, the settings row's own word
- drop the popup's one-off paste ceremony: the field takes typing and pasting like every other credential field (the CLI still validates the code's shape), is masked like a key, and no longer instructs "press ⌘V here"
- adopt the key slot's focus manners: staged focus instead of a focus call a still-hidden element ignores, the caret retaken when the window is raised on the way back from the browser, and Escape ending the entry
- word a failed sign-in the way the consent popup's failure reads — "Not connected", the reason, a quiet Close — with "Sign in again" offered as the link back to Superset's page

## Validation

- `./scripts/check.sh` — passed (48 harness + 277 sidecar-core + 53 web + 1246 desktop tests)
- side-by-side static render of the key slot and every Superset stage inspected in headless Chrome; the code-entry stage matches the key slot's layout exactly
- Linux sandbox: `./scripts/verify.sh` runs in CI, no physical-notch check performed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/621dfc4f-eb09-4411-b35f-d912db737a05)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32328872625/artifacts/9392457088) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32328872625)

- Commit: `d4aa2a3daf3644ad6c08f36d33073055ac1b3fe4`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
