### PR TITLE
chore(release): bump version to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@
 Notable changes to Luke, newest first. Each heading is a released version and
 the date its release was published.
 
+## 0.3.1 — 2026-08-19
+
+### Fixes
+
+- Fixed Luke falling asleep at launch before the first session roster arrived
+  ([#319](https://github.com/ReviewStage/luke/pull/319))
+
 ## 0.3.0 — 2026-08-19
 
 ### Superset workspaces

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@luke/desktop",
   "productName": "Luke",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "description": "Luke desktop application",
   "main": "dist/main.js",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luke/web",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "description": "Luke landing page",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luke",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "description": "A notch-attached desktop sidecar for coding-agent sessions",
   "packageManager": "pnpm@9.15.0",

--- a/packages/sidecar-core/package.json
+++ b/packages/sidecar-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -49,11 +49,11 @@ function packagerOptions(signing = resolveSigningMode({})) {
     licensePath: `/repo/apps/desktop/.build/${LICENSE_RESOURCE_NAME}`,
     entitlementsPath,
     signing,
-    version: "0.3.0",
+    version: "0.3.1",
   });
 }
 
-test("workspace package versions agree on v0.3.0", () => {
+test("workspace package versions agree on v0.3.1", () => {
   const packagePaths = [
     "package.json",
     "apps/desktop/package.json",
@@ -66,7 +66,7 @@ test("workspace package versions agree on v0.3.0", () => {
 
   assert.deepEqual(
     versions.map(({ version }) => version),
-    packagePaths.map(() => "0.3.0"),
+    packagePaths.map(() => "0.3.1"),
   );
 });
 


### PR DESCRIPTION
## Summary

- bump every workspace package version to `0.3.1`
- add the `0.3.1` changelog entry for the launch roster fix from #319
- update the packaging version contract

## Validation

- `./scripts/verify.sh`
- generated macOS fixture evidence inspected; no visual regressions found
- physical-notch check: not performed

## Release

After this lands, tag the resulting `main` commit as `v0.3.1`. The tag-triggered release workflow will build, sign, notarize, staple, validate, and publish the release assets.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32328133300/artifacts/9392105664) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32328133300)

- Commit: `1d50c27b424f6b981edc97adf3cee543838d5bef`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
