### PR TITLE
feat(release): dress the DMG volume in the app's own icon

### DIFF
--- a/apps/desktop/scripts/release-config.mjs
+++ b/apps/desktop/scripts/release-config.mjs
@@ -28,6 +28,11 @@ export const DMG_STAGING_ENTRIES = [
   { name: "Luke.app", kind: "application" },
   { name: "Applications", kind: "symlink", target: "/Applications" },
 ];
+// The name Finder reads a volume's icon from, at the volume root. The file
+// alone is not enough: Finder only looks for it once the root directory's
+// custom-icon bit is set, which can only happen on a mounted volume — see
+// volumeCustomIconArguments.
+export const DMG_VOLUME_ICON_FILE_NAME = ".VolumeIcon.icns";
 
 export function releaseDmgFileName(version) {
   return `Luke-${version}-${PACKAGED_ARCHITECTURE}.dmg`;
@@ -213,6 +218,14 @@ export function dmgStoreLayout(mountPoint) {
       },
     ],
   };
+}
+
+// Sets the custom-icon Finder bit on the mounted volume's root, which is what
+// makes Finder read DMG_VOLUME_ICON_FILE_NAME beside it. Run through xcrun:
+// SetFile ships with the developer tools rather than on the system path. Both
+// the bit and the icon file survive the UDZO conversion.
+export function volumeCustomIconArguments(mountPoint) {
+  return ["SetFile", "-a", "C", mountPoint];
 }
 
 export function dmgCodesignArguments(identity, dmgPath) {

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -11,6 +11,7 @@ import {
   codesignDisplayArguments,
   DMG_MOUNT_POINT,
   DMG_STAGING_ENTRIES,
+  DMG_VOLUME_ICON_FILE_NAME,
   dmgCodesignArguments,
   dmgStoreLayout,
   dmgVerificationCommands,
@@ -29,6 +30,7 @@ import {
   resolveReleaseSigning,
   stapleArguments,
   tiffutilHiDpiArguments,
+  volumeCustomIconArguments,
   withMountedDmg,
 } from "./release-config.mjs";
 
@@ -146,6 +148,25 @@ try {
     }
   }
 
+  // The volume wears the packaged app's own icon — read from the bundle it is
+  // shipping rather than from .build, so the two can never disagree.
+  const bundleIconFile = execFileSync(
+    "plutil",
+    [
+      "-extract",
+      "CFBundleIconFile",
+      "raw",
+      "-o",
+      "-",
+      path.join(appPath, "Contents", "Info.plist"),
+    ],
+    { encoding: "utf8" },
+  ).trim();
+  fs.copyFileSync(
+    path.join(appPath, "Contents", "Resources", bundleIconFile),
+    path.join(stagingDirectory, DMG_VOLUME_ICON_FILE_NAME),
+  );
+
   const stagingBackgroundDirectory = path.join(stagingDirectory, DMG_WINDOW.BACKGROUND.DIRECTORY);
   fs.mkdirSync(stagingBackgroundDirectory);
   execFileSync(
@@ -187,6 +208,7 @@ try {
         const storePath = path.join(mountPoint, ".DS_Store");
         fs.rmSync(storePath, { force: true });
         await writeDmgStore(storePath, dmgStoreLayout(mountPoint));
+        execFileSync("xcrun", volumeCustomIconArguments(mountPoint), { stdio: "inherit" });
         execFileSync("sync", [], { stdio: "inherit" });
       },
     });

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -9,6 +9,7 @@ import {
   codesignDisplayArguments,
   DMG_MOUNT_POINT,
   DMG_STAGING_ENTRIES,
+  DMG_VOLUME_ICON_FILE_NAME,
   dmgCodesignArguments,
   dmgStoreLayout,
   dmgVerificationCommands,
@@ -35,6 +36,7 @@ import {
   resolveReleaseSigning,
   stapleArguments,
   tiffutilHiDpiArguments,
+  volumeCustomIconArguments,
   withMountedDmg,
 } from "../apps/desktop/scripts/release-config.mjs";
 import { DMG_WINDOW } from "../design/dmg-window.mjs";
@@ -291,6 +293,29 @@ test("release DMG store layout is branded and bounded", () => {
   assert.equal(DMG_WINDOW.BOUNDS.WIDTH, DMG_WINDOW.BACKGROUND.PNG.WIDTH);
   assert.equal(DMG_WINDOW.BOUNDS.HEIGHT, DMG_WINDOW.BACKGROUND.PNG.HEIGHT);
   assert.ok(DMG_WINDOW.BACKGROUND.DIRECTORY.startsWith("."));
+});
+
+test("the DMG volume wears the app's own icon", () => {
+  // Finder reads a volume icon from this exact hidden name at the root, and
+  // only once the root's custom-icon bit is set — so staging the file without
+  // setting the bit, or the reverse, is a generic disk icon with no other sign.
+  assert.equal(DMG_VOLUME_ICON_FILE_NAME, ".VolumeIcon.icns");
+  assert.deepEqual(volumeCustomIconArguments("/Volumes/Luke"), [
+    "SetFile",
+    "-a",
+    "C",
+    "/Volumes/Luke",
+  ]);
+
+  const releaseScript = fs.readFileSync(
+    path.join(repoRoot, "apps", "desktop", "scripts", "release.mjs"),
+    "utf8",
+  );
+  assert.ok(releaseScript.includes("DMG_VOLUME_ICON_FILE_NAME"));
+  assert.ok(releaseScript.includes("volumeCustomIconArguments(mountPoint)"));
+  // The staged icon comes from the packaged bundle itself, not the .build
+  // intermediate, so the volume can never wear an icon the app does not.
+  assert.ok(releaseScript.includes("CFBundleIconFile"));
 });
 
 test("release zip names include the desktop version and packaged architecture", () => {


### PR DESCRIPTION
## Summary

- The release DMG mounted with macOS's generic removable-disk icon because the pipeline never staged a volume icon; the Luke icon now shows everywhere Finder draws the mounted volume — the desktop, the sidebar, and the installer window's title bar.
- `release.mjs` stages the packaged bundle's own icns (read through `CFBundleIconFile`, so the volume can never wear an icon the app does not) as `.VolumeIcon.icns` at the image root, then sets the mounted root's custom-icon Finder bit (`xcrun SetFile -a C`), which is what makes Finder read the file at all.
- `release-config.mjs` carries the new `DMG_VOLUME_ICON_FILE_NAME` constant and `volumeCustomIconArguments()` in the existing xcrun-arguments shape; `release.test.mjs` pins both and asserts the release script stages the icon and sets the bit, since either half alone is a generic icon with no other sign.
- The `.dmg` file itself in Downloads keeps the system disk-image icon: a custom file icon rides an extended attribute no HTTP download preserves, so that half is not possible for any distributed DMG.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (exit 0), including all 26 release tests
- macOS Electron verification (`./scripts/verify.sh`): `not run` — the change is confined to the release DMG path, which `verify.sh` does not exercise; the mechanism (`.VolumeIcon.icns` + custom-icon bit surviving UDZO conversion, `xcrun SetFile` availability) was verified end-to-end on a physical Mac with the same hdiutil invocations the release script uses

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32329002564/artifacts/9392399275) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32329002564)

- Commit: `9973f646fe24f09c161c204ceeba18e1025188a2`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` — no app UI change; the surface touched exists only inside a signed release DMG
- Physical-notch check: `not performed` — no on-screen change
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: the next real `pnpm release:macos` run is the full-pipeline confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/4893dad8-4de8-42db-8b38-41e3f541b06d)
