### PR TITLE
fix(updates): ship the app-update.yml electron-updater reads before every download

### DIFF
--- a/apps/desktop/scripts/package-config.mjs
+++ b/apps/desktop/scripts/package-config.mjs
@@ -92,12 +92,35 @@ export function signingModeDefine(env) {
   };
 }
 
+/**
+ * The updater config electron-updater reads from the bundle's own Resources.
+ * Setting the feed at runtime does not spare the file: before every download
+ * the updater reads `updaterCacheDirName` from it (AppUpdater's
+ * downloadUpdate path), so a bundle without one fails with ENOENT the moment
+ * a newer build is found. electron-builder writes this file automatically;
+ * a packager build must write it itself. The URL must equal
+ * `UPDATE_ENDPOINT.UPDATE_FEED_URL` in src/update-service.ts — a packaging
+ * test holds the two together.
+ */
+export const APP_UPDATE_CONFIG_FILE_NAME = "app-update.yml";
+export const APP_UPDATE_FEED_URL = "https://github.com/ReviewStage/luke/releases/latest/download/";
+
+export function appUpdateConfig() {
+  return [
+    "provider: generic",
+    `url: ${APP_UPDATE_FEED_URL}`,
+    "updaterCacheDirName: luke-updater",
+    "",
+  ].join("\n");
+}
+
 export function createPackagerOptions({
   appRoot,
   outputRoot,
   helperPaths,
   iconPath,
   licensePath,
+  appUpdateConfigPath,
   entitlementsPath,
   signing,
   version,
@@ -116,7 +139,7 @@ export function createPackagerOptions({
     overwrite: true,
     prune: false,
     icon: iconPath,
-    extraResource: [...helperPaths, licensePath],
+    extraResource: [...helperPaths, licensePath, appUpdateConfigPath],
     extendInfo: {
       CFBundleDisplayName: "Luke",
       LSMinimumSystemVersion: MACOS_DEPLOYMENT_TARGET,

--- a/apps/desktop/scripts/package.mjs
+++ b/apps/desktop/scripts/package.mjs
@@ -4,6 +4,8 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { packager } from "@electron/packager";
 import {
+  APP_UPDATE_CONFIG_FILE_NAME,
+  appUpdateConfig,
   createPackagerOptions,
   ICONSET_SOURCES,
   iconutilArguments,
@@ -27,6 +29,7 @@ const helperPaths = NATIVE_HELPERS.map((helper) =>
 const iconsetPath = path.join(appRoot, ".build", "luke.iconset");
 const iconPath = path.join(appRoot, ".build", "Luke.icns");
 const licensePath = path.join(appRoot, ".build", LICENSE_RESOURCE_NAME);
+const appUpdateConfigPath = path.join(appRoot, ".build", APP_UPDATE_CONFIG_FILE_NAME);
 const entitlementsPath = path.join(appRoot, "native", "macos", "entitlements.plist");
 const desktopPackage = JSON.parse(fs.readFileSync(path.join(appRoot, "package.json"), "utf8"));
 const signing = resolveSigningMode(process.env);
@@ -41,6 +44,7 @@ for (const helperPath of helperPaths) {
 
 fs.mkdirSync(path.dirname(licensePath), { recursive: true });
 fs.copyFileSync(path.join(repoRoot, "LICENSE"), licensePath);
+fs.writeFileSync(appUpdateConfigPath, appUpdateConfig());
 const brandIconDirectory = path.join(repoRoot, "design", "brand", "icon");
 fs.rmSync(iconsetPath, { recursive: true, force: true });
 fs.mkdirSync(iconsetPath, { recursive: true });
@@ -62,6 +66,7 @@ const appPaths = await packager(
     helperPaths,
     iconPath,
     licensePath,
+    appUpdateConfigPath,
     entitlementsPath,
     signing,
     version: desktopPackage.version,
@@ -75,6 +80,17 @@ if (!fs.existsSync(appPath)) throw new Error(`Packaged app was not found: ${appP
 const packagedLicensePath = path.join(appPath, "Contents", "Resources", LICENSE_RESOURCE_NAME);
 if (!fs.existsSync(packagedLicensePath)) {
   throw new Error(`Packaged app is missing the Luke license: ${packagedLicensePath}`);
+}
+// A bundle without this file updates itself to nothing: the failure surfaces
+// only on a packaged build finding a newer release, which no test run does.
+const packagedUpdateConfigPath = path.join(
+  appPath,
+  "Contents",
+  "Resources",
+  APP_UPDATE_CONFIG_FILE_NAME,
+);
+if (!fs.existsSync(packagedUpdateConfigPath)) {
+  throw new Error(`Packaged app is missing its updater config: ${packagedUpdateConfigPath}`);
 }
 const infoPlistPath = path.join(appPath, "Contents", "Info.plist");
 const bundleIconFile = execFileSync(

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -4,8 +4,11 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
+  APP_UPDATE_CONFIG_FILE_NAME,
+  APP_UPDATE_FEED_URL,
   APPLE_EVENTS_USAGE_DESCRIPTION,
   addonCompilerArguments,
+  appUpdateConfig,
   createPackagerOptions,
   ICONSET_SOURCES,
   iconutilArguments,
@@ -47,11 +50,38 @@ function packagerOptions(signing = resolveSigningMode({})) {
     ],
     iconPath,
     licensePath: `/repo/apps/desktop/.build/${LICENSE_RESOURCE_NAME}`,
+    appUpdateConfigPath: `/repo/apps/desktop/.build/${APP_UPDATE_CONFIG_FILE_NAME}`,
     entitlementsPath,
     signing,
     version: "0.3.1",
   });
 }
+
+test("the bundle carries the updater config electron-updater reads before every download", () => {
+  // Setting the feed at runtime does not spare app-update.yml: the download
+  // step reads updaterCacheDirName from the bundle's own Resources, so a
+  // package without it finds an update and then fails with ENOENT.
+  assert.ok(
+    packagerOptions().extraResource.some((resourcePath) =>
+      resourcePath.endsWith(APP_UPDATE_CONFIG_FILE_NAME),
+    ),
+  );
+  const config = appUpdateConfig();
+  assert.ok(config.includes("provider: generic"));
+  assert.ok(config.includes(`url: ${APP_UPDATE_FEED_URL}`));
+  assert.ok(config.includes("updaterCacheDirName: luke-updater"));
+
+  // The bundled config and the runtime feed must name the same address, or a
+  // packaged build would read one feed and cache under another's rules.
+  const updateService = fs.readFileSync(
+    path.join(repoRoot, "apps", "desktop", "src", "update-service.ts"),
+    "utf8",
+  );
+  assert.ok(
+    updateService.includes(`UPDATE_FEED_URL: "${APP_UPDATE_FEED_URL}"`),
+    "src/update-service.ts UPDATE_ENDPOINT.UPDATE_FEED_URL must equal APP_UPDATE_FEED_URL",
+  );
+});
 
 test("workspace package versions agree on v0.3.1", () => {
   const packagePaths = [


### PR DESCRIPTION
## Summary

- First real-world auto-update (0.3.0 → 0.3.1) failed with `ENOENT: .../Contents/Resources/app-update.yml`. Diagnosis confirmed against electron-updater's source (`AppUpdater.js:545`): even with `setFeedURL` at runtime, the **download** step reads `updaterCacheDirName` from `app-update.yml` in the bundle's Resources. electron-builder writes that file automatically — which is why Superset never sees this — but Luke's `@electron/packager` pipeline never did. The published 0.3.1 artifacts were verified good from the outside (manifest sha512/size match the zip byte-for-byte), so this was the last broken link.
- `package.mjs` now writes `app-update.yml` (`provider: generic`, the fixed feed URL, `updaterCacheDirName: luke-updater`) into `.build/` and ships it as an extra resource — inside the signature, like the license — and packaging fails if the packaged bundle lacks it.
- A packaging test locks the bundled feed address to `UPDATE_ENDPOINT.UPDATE_FEED_URL` in `src/update-service.ts` so the two cannot drift.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (exit 0; desktop 1248/1248, web 53/53, scripts green)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — authored in a Linux cloud workspace; needs a macOS run

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32329807277/artifacts/9392662793) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32329807277)

- Commit: `2f3e02292b2fe6fbc8b6cca63d827258960d1d38`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Builds already installed (0.3.0, 0.3.1) lack the file, so they cannot self-update even to the release that carries this fix — one more manual hop through the row's releases-page fallback is expected. The first release cut after this merges (e.g. 0.3.2) is the first build whose *next* update installs in place; proving it needs the release after that.
- The electron-builder packaging migration (in flight in a separate workspace) generates this file natively and supersedes the hand-written step; `updaterCacheDirName` must stay `luke-updater` across that migration so a cached download isn't orphaned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b9e9e9d4-5416-4bc4-9efc-9e6517c5f571)
