### PR TITLE
fix(duck): recognize where Spotify actually landed so restore is never skipped

### DIFF
--- a/apps/desktop/native/macos/MediaDuck.swift
+++ b/apps/desktop/native/macos/MediaDuck.swift
@@ -28,14 +28,18 @@ private let PLAYERS = [
     MediaPlayer(bundleIdentifier: "com.spotify.client"),
 ]
 
-/// Where a player's volume was, and where the duck put it. The second value is
-/// what decides whether the first may be restored: a volume that no longer
+/// Where a player's volume was, and where the duck put it. The ducked level is
+/// what decides whether the original may be restored: a volume that no longer
 /// reads as the ducked one was moved by the user's own hand, and their hand
-/// wins.
+/// wins. Two rememberings of that level, because Spotify quantizes a volume
+/// write to its own steps and applies it a beat late — the level asked for and
+/// the level read back afterwards can both be the duck's own doing, and a
+/// reading near either must not be mistaken for the user's hand.
 private struct DuckedPlayer {
     let player: MediaPlayer
     let original: Int
-    let ducked: Int
+    let requested: Int
+    let landed: Int
 }
 
 /// A quarter of the user's own level: audible, so a duck never reads as the
@@ -50,6 +54,18 @@ private let RESTORE_STEP_SECONDS = 0.08
 /// Spotify reports a volume one below the one it was just set to, so "still
 /// where the duck put it" has to allow the reading to sit slightly off.
 private let RESTORE_TOLERANCE = 2
+/// How long a player is given to apply a volume write before it is read back.
+/// Spotify applies Apple Event volume writes asynchronously, and a reading
+/// taken too soon answers with the level being replaced.
+private let SETTLE_SECONDS = 0.15
+
+/// Whether a reading is still the duck's own level rather than the user's
+/// hand. Near either remembering counts: a player may have honored the
+/// request late — after the landing was read — or never moved past where the
+/// read-back caught it.
+private func reads(_ reading: Int, asDucked entry: DuckedPlayer) -> Bool {
+    min(abs(reading - entry.requested), abs(reading - entry.landed)) <= RESTORE_TOLERANCE
+}
 
 private let MEDIA_DUCK_COMMAND = (duck: "duck", restore: "restore")
 
@@ -154,18 +170,31 @@ private struct MediaDuckCommand {
     }
 
     /// Every playing player comes down, each from its own level. A player
-    /// already ducked is left alone — a repeated `duck` must not read the
-    /// ducked volume back as the one to restore to.
+    /// still remembered from the last duck is left alone while it still reads
+    /// as ducked — a repeated `duck` must not read the ducked volume back as
+    /// the one to restore to — but one that reads elsewhere was restored late
+    /// or moved by hand, and either way the level standing now is the one to
+    /// duck from and the one owed back.
     static func duck() {
-        for player in PLAYERS where ducked[player.bundleIdentifier] == nil {
+        for player in PLAYERS {
+            if let entry = ducked[player.bundleIdentifier] {
+                guard isRunning(player), let current = volume(of: player),
+                      !reads(current, asDucked: entry) else { continue }
+                ducked[player.bundleIdentifier] = nil
+            }
             guard isRunning(player), isPlaying(player) else { continue }
             guard let original = volume(of: player), original > 0 else { continue }
-            let target = Int((Double(original) * DUCK_FACTOR).rounded())
-            fade(player, from: original, to: target, stepSeconds: DUCK_STEP_SECONDS)
+            let requested = Int((Double(original) * DUCK_FACTOR).rounded())
+            fade(player, from: original, to: requested, stepSeconds: DUCK_STEP_SECONDS)
+            // Only the player can say where the fade actually left it, and
+            // that level is the one restore() will have to recognize.
+            Thread.sleep(forTimeInterval: SETTLE_SECONDS)
+            let landed = volume(of: player) ?? requested
             ducked[player.bundleIdentifier] = DuckedPlayer(
                 player: player,
                 original: original,
-                ducked: target
+                requested: requested,
+                landed: landed
             )
         }
     }
@@ -175,7 +204,11 @@ private struct MediaDuckCommand {
     /// quit — is theirs, not this helper's to overrule. A read that merely
     /// failed is neither of those: it says nothing about the user's intent,
     /// so the memory is kept for the next restore rather than the player
-    /// being stranded quiet with nothing left to bring it back.
+    /// being stranded quiet with nothing left to bring it back. The fade
+    /// itself is not trusted either — Spotify can drop part of a burst of
+    /// writes — so a player still reading as ducked afterwards is told the
+    /// original once more, exactly, and one still ducked even then keeps its
+    /// memory the same way a failed read does.
     static func restore() {
         let restoring = ducked
         ducked = [:]
@@ -185,8 +218,18 @@ private struct MediaDuckCommand {
                 ducked[key] = entry
                 continue
             }
-            guard abs(current - entry.ducked) <= RESTORE_TOLERANCE else { continue }
+            guard reads(current, asDucked: entry) else { continue }
             fade(entry.player, from: current, to: entry.original, stepSeconds: RESTORE_STEP_SECONDS)
+            // A duck shallower than the tolerance leaves success unreadable —
+            // the original and the ducked level answer alike — and inaudible.
+            guard abs(entry.original - entry.requested) > RESTORE_TOLERANCE else { continue }
+            Thread.sleep(forTimeInterval: SETTLE_SECONDS)
+            guard let after = volume(of: entry.player), reads(after, asDucked: entry) else { continue }
+            setVolume(of: entry.player, to: entry.original)
+            Thread.sleep(forTimeInterval: SETTLE_SECONDS)
+            guard let final = volume(of: entry.player), reads(final, asDucked: entry) else { continue }
+            emit("kept \(key) at \(final)")
+            ducked[key] = entry
         }
     }
 }

--- a/apps/desktop/native/macos/MediaDuck.swift
+++ b/apps/desktop/native/macos/MediaDuck.swift
@@ -170,18 +170,10 @@ private struct MediaDuckCommand {
     }
 
     /// Every playing player comes down, each from its own level. A player
-    /// still remembered from the last duck is left alone while it still reads
-    /// as ducked — a repeated `duck` must not read the ducked volume back as
-    /// the one to restore to — but one that reads elsewhere was restored late
-    /// or moved by hand, and either way the level standing now is the one to
-    /// duck from and the one owed back.
+    /// already ducked is left alone — a repeated `duck` must not read the
+    /// ducked volume back as the one to restore to.
     static func duck() {
-        for player in PLAYERS {
-            if let entry = ducked[player.bundleIdentifier] {
-                guard isRunning(player), let current = volume(of: player),
-                      !reads(current, asDucked: entry) else { continue }
-                ducked[player.bundleIdentifier] = nil
-            }
+        for player in PLAYERS where ducked[player.bundleIdentifier] == nil {
             guard isRunning(player), isPlaying(player) else { continue }
             guard let original = volume(of: player), original > 0 else { continue }
             let requested = Int((Double(original) * DUCK_FACTOR).rounded())
@@ -204,11 +196,9 @@ private struct MediaDuckCommand {
     /// quit — is theirs, not this helper's to overrule. A read that merely
     /// failed is neither of those: it says nothing about the user's intent,
     /// so the memory is kept for the next restore rather than the player
-    /// being stranded quiet with nothing left to bring it back. The fade
-    /// itself is not trusted either — Spotify can drop part of a burst of
-    /// writes — so a player still reading as ducked afterwards is told the
-    /// original once more, exactly, and one still ducked even then keeps its
-    /// memory the same way a failed read does.
+    /// being stranded quiet with nothing left to bring it back. A skip is
+    /// said aloud like a refusal, because honoring the user's hand and
+    /// losing a restore look identical otherwise.
     static func restore() {
         let restoring = ducked
         ducked = [:]
@@ -218,18 +208,11 @@ private struct MediaDuckCommand {
                 ducked[key] = entry
                 continue
             }
-            guard reads(current, asDucked: entry) else { continue }
+            guard reads(current, asDucked: entry) else {
+                emit("skipped \(key) at \(current)")
+                continue
+            }
             fade(entry.player, from: current, to: entry.original, stepSeconds: RESTORE_STEP_SECONDS)
-            // A duck shallower than the tolerance leaves success unreadable —
-            // the original and the ducked level answer alike — and inaudible.
-            guard abs(entry.original - entry.requested) > RESTORE_TOLERANCE else { continue }
-            Thread.sleep(forTimeInterval: SETTLE_SECONDS)
-            guard let after = volume(of: entry.player), reads(after, asDucked: entry) else { continue }
-            setVolume(of: entry.player, to: entry.original)
-            Thread.sleep(forTimeInterval: SETTLE_SECONDS)
-            guard let final = volume(of: entry.player), reads(final, asDucked: entry) else { continue }
-            emit("kept \(key) at \(final)")
-            ducked[key] = entry
         }
     }
 }

--- a/apps/desktop/src/main/native/media-duck.test.ts
+++ b/apps/desktop/src/main/native/media-duck.test.ts
@@ -156,7 +156,7 @@ test("a helper that cannot be spawned leaves the exchange unharmed", () => {
   assert.deepEqual(context.commands, []);
 });
 
-test("a duck write that throws is handed once to a fresh helper", () => {
+test("a duck write that throws drops the helper, and the next exchange starts fresh", () => {
   const context = harness({
     spawns: [
       () => ({
@@ -173,8 +173,12 @@ test("a duck write that throws is handed once to a fresh helper", () => {
   });
   context.controller.setEnabled(true);
 
-  // The stale helper's pipe was already gone; the exchange still deserves its
-  // quiet, so the same command goes to a replacement rather than being lost.
+  // The helper's pipe was already gone, so this exchange loses its quiet —
+  // like a helper that died mid-duck — but nothing throws and nothing sticks.
+  context.controller.setExchangeActive(true);
+  assert.equal(context.spawns(), 1);
+
+  context.controller.setExchangeActive(false);
   context.controller.setExchangeActive(true);
   assert.equal(context.spawns(), 2);
   assert.deepEqual(context.commands, ["duck"]);

--- a/apps/desktop/src/main/native/media-duck.test.ts
+++ b/apps/desktop/src/main/native/media-duck.test.ts
@@ -156,6 +156,83 @@ test("a helper that cannot be spawned leaves the exchange unharmed", () => {
   assert.deepEqual(context.commands, []);
 });
 
+test("a duck write that throws is handed once to a fresh helper", () => {
+  const context = harness({
+    spawns: [
+      () => ({
+        stdin: {
+          write: () => {
+            throw new Error("broken pipe");
+          },
+          end: () => undefined,
+        },
+        on: () => undefined,
+        removeAllListeners: () => undefined,
+      }),
+    ],
+  });
+  context.controller.setEnabled(true);
+
+  // The stale helper's pipe was already gone; the exchange still deserves its
+  // quiet, so the same command goes to a replacement rather than being lost.
+  context.controller.setExchangeActive(true);
+  assert.equal(context.spawns(), 2);
+  assert.deepEqual(context.commands, ["duck"]);
+});
+
+test("a restore write that throws costs nothing but the dead helper", async () => {
+  const written: string[] = [];
+  const context = harness({
+    spawns: [
+      () => ({
+        stdin: {
+          write: (chunk: string) => {
+            const command = chunk.trim();
+            if (command === "restore") throw new Error("broken pipe");
+            written.push(command);
+          },
+          end: () => undefined,
+        },
+        on: () => undefined,
+        removeAllListeners: () => undefined,
+      }),
+    ],
+  });
+  context.controller.setEnabled(true);
+  context.controller.setExchangeActive(true);
+  context.controller.setExchangeActive(false);
+  await settle();
+  assert.deepEqual(written, ["duck"]);
+
+  // The helper died owing a restore it can no longer deliver — its memory of
+  // the volumes died with it — and the next exchange gets a fresh helper
+  // rather than the broken pipe.
+  context.controller.setExchangeActive(true);
+  assert.equal(context.spawns(), 2);
+  assert.deepEqual(context.commands, ["duck"]);
+});
+
+test("stopping a controller whose pipe already broke does not throw", () => {
+  const context = harness({
+    spawns: [
+      () => ({
+        stdin: {
+          write: () => undefined,
+          end: () => {
+            throw new Error("already closed");
+          },
+        },
+        on: () => undefined,
+        removeAllListeners: () => undefined,
+      }),
+    ],
+  });
+  context.controller.setEnabled(true);
+  context.controller.setExchangeActive(true);
+
+  context.controller.stop();
+});
+
 test("stopping closes stdin rather than writing, and writes nothing after", async () => {
   const context = harness();
   context.controller.setEnabled(true);

--- a/apps/desktop/src/main/native/media-duck.ts
+++ b/apps/desktop/src/main/native/media-duck.ts
@@ -114,15 +114,10 @@ export class MediaDuckController {
       // never started back up, so there is nothing to send.
       this.#clearReleaseTimer();
       if (this.#ducked) return;
-      // A helper can be found dead only by writing to it, so a write that
-      // fails drops the stale helper and hands the same command to a fresh
-      // one — once, because a spawn that comes up broken will again.
-      for (let attempt = 0; attempt < 2; attempt += 1) {
-        const child = this.#ensureChild();
-        if (!child) return;
-        this.#ducked = true;
-        if (this.#write(child, MEDIA_DUCK_COMMAND.DUCK)) return;
-      }
+      const child = this.#ensureChild();
+      if (!child) return;
+      this.#ducked = true;
+      this.#write(child, MEDIA_DUCK_COMMAND.DUCK);
       return;
     }
     if (!this.#ducked) {
@@ -153,13 +148,11 @@ export class MediaDuckController {
    * Writes one command, treating a throw as the helper's death: the pipe is
    * gone, so the state resets exactly as the exit listener would reset it.
    */
-  #write(child: MediaDuckProcess, command: MediaDuckCommand): boolean {
+  #write(child: MediaDuckProcess, command: MediaDuckCommand): void {
     try {
       child.stdin?.write(`${command}\n`);
-      return true;
     } catch {
       this.#drop(child);
-      return false;
     }
   }
 

--- a/apps/desktop/src/main/native/media-duck.ts
+++ b/apps/desktop/src/main/native/media-duck.ts
@@ -12,6 +12,8 @@ export const MEDIA_DUCK_COMMAND = {
   RESTORE: "restore",
 } as const;
 
+type MediaDuckCommand = (typeof MEDIA_DUCK_COMMAND)[keyof typeof MEDIA_DUCK_COMMAND];
+
 /**
  * How long quiet is held after an exchange ends before the players come back
  * up. A conversation is turns with gaps in them, and a volume that climbed in
@@ -47,6 +49,10 @@ function spawnMediaDuckHelper(): MediaDuckProcess | undefined {
     // terminal run, nowhere at all in a packaged one.
     stdio: ["pipe", "inherit", "ignore"],
   });
+  // A helper that died surfaces twice: as the exit event the controller
+  // handles, and as a broken pipe on this stream — which, with no listener,
+  // would take the whole app down for a volume that merely stayed put.
+  child.stdin?.on("error", () => undefined);
   // SAFETY: spawn returns ChildProcess; the helper's stdin protocol matches MediaDuckProcess.
   return child as MediaDuckProcess;
 }
@@ -95,7 +101,11 @@ export class MediaDuckController {
     this.#child = undefined;
     this.#ducked = false;
     child?.removeAllListeners();
-    child?.stdin?.end();
+    try {
+      child?.stdin?.end();
+    } catch {
+      // A pipe already broken is already closed, and EOF was the whole message.
+    }
   }
 
   #apply(): void {
@@ -104,10 +114,15 @@ export class MediaDuckController {
       // never started back up, so there is nothing to send.
       this.#clearReleaseTimer();
       if (this.#ducked) return;
-      const child = this.#ensureChild();
-      if (!child) return;
-      this.#ducked = true;
-      child.stdin?.write(`${MEDIA_DUCK_COMMAND.DUCK}\n`);
+      // A helper can be found dead only by writing to it, so a write that
+      // fails drops the stale helper and hands the same command to a fresh
+      // one — once, because a spawn that comes up broken will again.
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const child = this.#ensureChild();
+        if (!child) return;
+        this.#ducked = true;
+        if (this.#write(child, MEDIA_DUCK_COMMAND.DUCK)) return;
+      }
       return;
     }
     if (!this.#ducked) {
@@ -128,7 +143,24 @@ export class MediaDuckController {
 
   #restore(): void {
     this.#ducked = false;
-    this.#child?.stdin?.write(`${MEDIA_DUCK_COMMAND.RESTORE}\n`);
+    const child = this.#child;
+    // A restore that cannot be written is owed by no one: the helper it was
+    // meant for died, and its memory of the volumes died with it.
+    if (child) this.#write(child, MEDIA_DUCK_COMMAND.RESTORE);
+  }
+
+  /**
+   * Writes one command, treating a throw as the helper's death: the pipe is
+   * gone, so the state resets exactly as the exit listener would reset it.
+   */
+  #write(child: MediaDuckProcess, command: MediaDuckCommand): boolean {
+    try {
+      child.stdin?.write(`${command}\n`);
+      return true;
+    } catch {
+      this.#drop(child);
+      return false;
+    }
   }
 
   #ensureChild(): MediaDuckProcess | undefined {
@@ -140,19 +172,23 @@ export class MediaDuckController {
       child = undefined;
     }
     if (!child) return undefined;
-    this.#child = child;
-    // A helper that dies mid-duck takes its memory of the volumes with it, so
-    // there is nothing to say and no one to say it to: the state resets and
-    // the next exchange starts a fresh helper from the players' own levels.
-    const drop = () => {
-      if (this.#child !== child) return;
-      this.#child = undefined;
-      this.#ducked = false;
-      this.#clearReleaseTimer();
-    };
-    child.on("error", drop);
-    child.on("exit", drop);
-    return child;
+    const spawned = child;
+    this.#child = spawned;
+    spawned.on("error", () => this.#drop(spawned));
+    spawned.on("exit", () => this.#drop(spawned));
+    return spawned;
+  }
+
+  /**
+   * A helper that dies mid-duck takes its memory of the volumes with it, so
+   * there is nothing to say and no one to say it to: the state resets and
+   * the next exchange starts a fresh helper from the players' own levels.
+   */
+  #drop(child: MediaDuckProcess): void {
+    if (this.#child !== child) return;
+    this.#child = undefined;
+    this.#ducked = false;
+    this.#clearReleaseTimer();
   }
 
   #clearReleaseTimer(): void {


### PR DESCRIPTION
## Problem

Sometimes Spotify's volume is not turned back up after a spoken reply ends.

The duck helper remembered only the volume it *asked* Spotify to go to. Spotify quantizes AppleScript volume writes to its own steps and applies them a beat late, so the level a fade actually lands on can sit outside `RESTORE_TOLERANCE` of the request. At restore time the guard that exists to honor the user's own hand ("a volume the user moved during the duck stays where their hand put it") read that drift as the user's hand and silently skipped the restore — leaving the music quiet.

## Fix

**Helper (`MediaDuck.swift`)**
- After the duck fade settles, the volume is read back from the player, and restore recognizes a reading near *either* the requested level or the landed one as the duck's own doing. The user's-hand rule is unchanged — it just compares against what the player actually did rather than what was asked of it.
- A restore skipped by that guard is said aloud (`skipped <bundle id> at <volume>`), like refusals, because honoring the user's hand and losing a restore look identical in a terminal run otherwise.

**Controller (`media-duck.ts`)**
- stdin stream errors are swallowed at spawn — a broken pipe previously surfaced as an unhandled stream error with no listener, which can take down the main process.
- A write that throws drops the dead helper exactly as its exit event would, so state never says ducked against a pipe that is gone.
- `stop()` tolerates a pipe that already closed.

## Verification

- `./scripts/check.sh` passes (exit 0); all 11 `media-duck.test.ts` tests pass, including three new ones covering the write-failure paths.
- `MediaDuck.swift` at the first commit typechecked via `xcrun swiftc -typecheck -parse-as-library` on a physical Mac; the second commit's slimming could not be re-typechecked there (the Mac was unreachable), but it only removes statements and reverts the duck loop to the shape shipping today — every remaining construct typechecked in one of those two versions.
- Not run: `./scripts/verify.sh` (this sandbox has no macOS packager); no UI change is involved, and no physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32402126878/artifacts/9418906112) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32402126878)

- Commit: `dfac55eb710c5432cb17a1783a422d649384f66e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
