### PR TITLE
fix(voice): stop trimming a stopped reply past its audio's end

### DIFF
--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -2390,7 +2390,7 @@ test("a stop after the reply's audio ran out leaves nothing to trim", async () =
   // turn holds and a stop can still land on it. Every word already reached the
   // room: there is nothing to correct, and a trim measured on the wall clock
   // would ask past the audio's end and be refused.
-  context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED });
+  context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED, response_id: "resp-1" });
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
   const before = context.sent.length;
 
@@ -2402,6 +2402,59 @@ test("a stop after the reply's audio ran out leaves nothing to trim", async () =
       .some((event) => event.type === REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_TRUNCATE),
   );
   assert.equal(context.session.status, REALTIME_STATUS.READY);
+});
+
+test("a stale drain from the spoken half does not skip the follow-up's trim", async () => {
+  let clock = 1_000;
+  const context = harness({ now: () => clock, carryAction: async () => ({ status: "sent" }) });
+  await context.session.connect();
+  context.deliverRemoteTrack();
+  context.session.updateSessions([observedSession("session-a", { canReceiveMessage: true })]);
+  await armDeveloperTurn(context);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-1" } });
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED, item: { id: "spoken" } });
+  context.session.reportRemoteAudioActive();
+
+  // The reply calls a tool, its follow-up is asked for, and only then does the
+  // spoken half's buffer report itself empty: the drain is the old reply's,
+  // arriving after the follow-up already owns the turn.
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: {
+      id: "resp-1",
+      output: [
+        {
+          type: "function_call",
+          name: "send_session_message",
+          call_id: "call-1",
+          arguments:
+            '{"provider_id":"claude-code","provider_session_id":"session-a","text":"run the tests"}',
+        },
+      ],
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED, response_id: "resp-1" });
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-2" } });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
+    item: { id: "follow_up" },
+  });
+  clock = 2_000;
+  context.session.reportRemoteAudioActive();
+  clock = 2_800;
+  const before = context.sent.length;
+
+  // A stop mid-follow-up still owes the record a trim: the words cut off were
+  // the follow-up's own, and the stale drain spoke for audio it never played.
+  assert.equal(context.session.stopSpeaking(), true);
+
+  const truncate = context.sent
+    .slice(before)
+    .find((event) => event.type === REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_TRUNCATE);
+  assert.ok(truncate, "the follow-up's record is corrected despite the spoken half's drain");
+  assert.equal(truncate?.item_id, "follow_up");
+  assert.equal(truncate?.audio_end_ms, 800);
 });
 
 test("a stop after response.done clears playback without cancelling finished generation", async () => {

--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -2308,6 +2308,102 @@ test("a stop does not surface the server refusing its already-finished cancellat
   assert.equal(context.session.status, REALTIME_STATUS.READY);
 });
 
+test("a stop does not surface the server refusing a trim past the audio's end", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.deliverRemoteTrack();
+  await holdTurn(context);
+  context.session.endTurn(true);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-1" } });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
+    item: { id: "item_reply" },
+  });
+  context.session.reportRemoteAudioActive();
+
+  assert.equal(context.session.stopSpeaking(), true);
+  const truncate = context.sent.findLast(
+    (event) => event.type === REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_TRUNCATE,
+  );
+  assert.ok(truncate);
+
+  // The audible clock runs on the wall, so a stop landing at the reply's very
+  // end can measure past the audio itself. The refusal means every word was
+  // heard and the record is already right — nothing the developer can or
+  // should act on.
+  context.emit({
+    type: REALTIME_SERVER_EVENT.ERROR,
+    error: {
+      type: "invalid_request_error",
+      message: "Audio content of 1500ms is already shorter than 2000ms",
+      event_id: truncate?.event_id,
+    },
+  });
+
+  assert.deepEqual(reportedErrors(context), []);
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+});
+
+test("a real error answering the stop's trim is still surfaced", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.deliverRemoteTrack();
+  await holdTurn(context);
+  context.session.endTurn(true);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-1" } });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
+    item: { id: "item_reply" },
+  });
+  context.session.reportRemoteAudioActive();
+
+  assert.equal(context.session.stopSpeaking(), true);
+  const truncate = context.sent.findLast(
+    (event) => event.type === REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_TRUNCATE,
+  );
+  context.emit({
+    type: REALTIME_SERVER_EVENT.ERROR,
+    error: {
+      type: "server_error",
+      message: "Truncation could not be processed.",
+      event_id: truncate?.event_id,
+    },
+  });
+
+  assert.deepEqual(reportedErrors(context), ["Truncation could not be processed."]);
+});
+
+test("a stop after the reply's audio ran out leaves nothing to trim", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.deliverRemoteTrack();
+  await holdTurn(context);
+  context.session.endTurn(true);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-1" } });
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_ITEM_ADDED,
+    item: { id: "item_reply" },
+  });
+  context.session.reportRemoteAudioActive();
+
+  // The audio runs out while the server still owes the reply its done, so the
+  // turn holds and a stop can still land on it. Every word already reached the
+  // room: there is nothing to correct, and a trim measured on the wall clock
+  // would ask past the audio's end and be refused.
+  context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED });
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+  const before = context.sent.length;
+
+  assert.equal(context.session.stopSpeaking(), true);
+
+  assert.ok(
+    !context.sent
+      .slice(before)
+      .some((event) => event.type === REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_TRUNCATE),
+  );
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+});
+
 test("a stop after response.done clears playback without cancelling finished generation", async () => {
   const context = harness();
   await context.session.connect();

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -125,11 +125,21 @@ const MAXIMUM_PENDING_INTERRUPTIONS = 24;
 const INTERRUPTION_EVENT_KIND = {
   CANCELLATION: "cancellation",
   AUDIO_CLEAR: "audio-clear",
+  TRUNCATION: "truncation",
 } as const;
 
 type InterruptionEventKind = (typeof INTERRUPTION_EVENT_KIND)[keyof typeof INTERRUPTION_EVENT_KIND];
 
 const NO_ACTIVE_RESPONSE_CANCELLATION = /^Cancellation failed:\s*no active response\b/i;
+
+/**
+ * The server refusing to trim a reply past its own end. The trim measures how
+ * long the reply was audible on a wall clock, which outruns the audio itself
+ * when a stop lands at the reply's very end — the words all played, the clock
+ * kept counting. A reply refused this way was heard whole, so the record the
+ * trim would have corrected is already right.
+ */
+const TRUNCATION_PAST_AUDIO_END = /^Audio content of \d+ms is already shorter than\b/i;
 
 /**
  * One kind of context as it is waiting to be said: the words, for telling an
@@ -458,10 +468,11 @@ export class RealtimeVoiceSession {
    */
   #pendingSupersedes = new Map<string, string>();
   /**
-   * Cancel and clear requests not yet answered with an error, by their stamped
-   * names. Their errors belong to the reply that was interrupted, so they must
-   * never finish a newer turn; only the documented redundant-cancel race stays
-   * quiet, while every genuine refusal is still reported.
+   * Cancel, clear, and trim requests not yet answered with an error, by their
+   * stamped names. Their errors belong to the reply that was interrupted, so
+   * they must never finish a newer turn; only the redundant-cancel race and a
+   * trim refused for asking past the audio's end stay quiet, while every
+   * genuine refusal is still reported.
    */
   #pendingInterruptions = new Map<string, InterruptionEventKind>();
   #interruptionSequence = 0;
@@ -1431,8 +1442,10 @@ export class RealtimeVoiceSession {
     this.#interruptionSequence += 1;
     const cancellationEventId = `response_cancel_${this.#interruptionSequence}`;
     const clearEventId = `output_audio_clear_${this.#interruptionSequence}`;
+    const truncationEventId = `item_truncate_${this.#interruptionSequence}`;
+    const truncateEvents = this.#truncateEvents(truncationEventId);
     const cancelGeneration = this.#responseOutstanding;
-    const interruptionCount = cancelGeneration ? 2 : 1;
+    const interruptionCount = (cancelGeneration ? 2 : 1) + (truncateEvents.length > 0 ? 1 : 0);
     while (this.#pendingInterruptions.size + interruptionCount > MAXIMUM_PENDING_INTERRUPTIONS) {
       const [oldest] = this.#pendingInterruptions.keys();
       if (oldest === undefined) break;
@@ -1448,7 +1461,10 @@ export class RealtimeVoiceSession {
     }
     // Then correct what Luke believes he said, or the next answer is free to
     // refer back to a sentence that never reached the room.
-    this.#send(this.#truncateEvents());
+    if (truncateEvents.length > 0) {
+      this.#pendingInterruptions.set(truncationEventId, INTERRUPTION_EVENT_KIND.TRUNCATION);
+      this.#send(truncateEvents);
+    }
     // The trim was this reply's last word: forgetting its item here is what
     // stops the transcript still trailing in — the server had produced it
     // before the cancel landed — from ever matching the caption again.
@@ -1712,13 +1728,21 @@ export class RealtimeVoiceSession {
   /**
    * What to trim the cut-off reply to, if there is anything to trim. Nothing
    * heard means nothing to correct — a reply interrupted in the gap before its
-   * first word left no impression to undo.
+   * first word left no impression to undo — and a reply whose audio already
+   * ran out was heard whole: the record needs no correction, and the wall
+   * clock has been counting past the audio's end for as long as the turn has
+   * held for its `done`, so a trim measured from it would ask past the end
+   * and be refused.
    */
-  #truncateEvents(): readonly WireRecord[] {
+  #truncateEvents(truncationEventId: string): readonly WireRecord[] {
     const itemId = this.#responseItemId;
     const audibleSince = this.#audibleSince;
-    if (!itemId || audibleSince === undefined) return [];
-    return truncateResponseEvents({ itemId, audioEndMs: this.#now() - audibleSince });
+    if (!itemId || audibleSince === undefined || this.#audioDrained) return [];
+    return truncateResponseEvents({
+      itemId,
+      audioEndMs: this.#now() - audibleSince,
+      truncationEventId,
+    });
   }
 
   #now(): number {
@@ -2120,9 +2144,11 @@ export class RealtimeVoiceSession {
 
   /**
    * Handles an error answering one interruption without letting an old reply's
-   * failure finish the new turn that interrupted it. Only the documented
-   * no-active-response race is quiet; every other refusal still reaches the
-   * developer as a real voice error.
+   * failure finish the new turn that interrupted it. Two refusals are quiet —
+   * the documented no-active-response race, and a trim refused for asking past
+   * the audio's end, which means the reply was heard whole and the record is
+   * already right; every other refusal still reaches the developer as a real
+   * voice error.
    */
   #interruptionError(event: { message: string; eventId?: string; errorType?: string }): boolean {
     if (event.eventId === undefined) return false;
@@ -2133,7 +2159,11 @@ export class RealtimeVoiceSession {
       kind === INTERRUPTION_EVENT_KIND.CANCELLATION &&
       event.errorType === "invalid_request_error" &&
       NO_ACTIVE_RESPONSE_CANCELLATION.test(event.message);
-    if (!benignCancellation) this.#options.onError(event.message);
+    const benignTruncation =
+      kind === INTERRUPTION_EVENT_KIND.TRUNCATION &&
+      event.errorType === "invalid_request_error" &&
+      TRUNCATION_PAST_AUDIO_END.test(event.message);
+    if (!benignCancellation && !benignTruncation) this.#options.onError(event.message);
     return true;
   }
 

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -513,12 +513,18 @@ export class RealtimeVoiceSession {
    */
   #responseOutstanding = false;
   /**
-   * Whether the reply's audio ran out while the server still owed its
-   * `done`. The ending the drain would have made is remembered here and
-   * lands when the `done` arrives, so the turn still closes on the second of
-   * the two events whichever order they come in.
+   * The reply whose audio ran out while the server still owed the turn its
+   * `done`, or false while audio is still owed. The ending the drain would
+   * have made is remembered here and lands when the `done` arrives, so the
+   * turn still closes on the second of the two events whichever order they
+   * come in. The drain keeps the name of the response the server said
+   * drained, because it can be an old reply's arriving late — a tool turn's
+   * spoken half empties after its follow-up was already asked for — and a
+   * stale drain read as the current reply's would end the follow-up under
+   * Luke's own voice, or skip the trim a stop mid-follow-up still owes the
+   * record.
    */
-  #audioDrained = false;
+  #audioDrained: { responseId: string | undefined } | false = false;
   /**
    * Whether an armed reply's calls are being answered and the follow-up
    * voicing their outcomes is still owed. The turn holds through the writes
@@ -1737,12 +1743,26 @@ export class RealtimeVoiceSession {
   #truncateEvents(truncationEventId: string): readonly WireRecord[] {
     const itemId = this.#responseItemId;
     const audibleSince = this.#audibleSince;
-    if (!itemId || audibleSince === undefined || this.#audioDrained) return [];
+    if (!itemId || audibleSince === undefined || this.#currentReplyDrained()) return [];
     return truncateResponseEvents({
       itemId,
       audioEndMs: this.#now() - audibleSince,
       truncationEventId,
     });
+  }
+
+  /**
+   * Whether the reply now under way has played out every word it generated.
+   * Only a drain that is attributably this reply's own says so: an old
+   * reply's late drain speaks for audio the current reply never played. A
+   * drain that named no reply keeps the old reading — it is nearly always
+   * the current one's, and reading it as another's would hold the turn to
+   * the settle backstop.
+   */
+  #currentReplyDrained(): boolean {
+    if (this.#audioDrained === false) return false;
+    const { responseId } = this.#audioDrained;
+    return responseId === undefined || responseId === this.#activeResponseId;
   }
 
   #now(): number {
@@ -2254,7 +2274,7 @@ export class RealtimeVoiceSession {
         // way, the READY an ending would offer is the same edge, and the
         // `done` already gave the hold a clock of its own.
         if (this.#responseOutstanding || this.#followUpPending) {
-          this.#audioDrained = true;
+          this.#audioDrained = { responseId: event.responseId };
           this.#armSettleTimer();
           return;
         }
@@ -2300,7 +2320,7 @@ export class RealtimeVoiceSession {
           // The spoken half's audio already drained — its ending deferred to
           // this `done`, and a reply owing no follow-up ends here, exactly
           // as the drain would have ended it.
-          if (fresh && this.#audioDrained) this.#finishResponse();
+          if (fresh && this.#currentReplyDrained()) this.#finishResponse();
           return;
         }
         if (!fresh) return;
@@ -2322,7 +2342,7 @@ export class RealtimeVoiceSession {
         // The server said the audio ran out before it said the reply was
         // over. That ending waited for this `done` — the conversation held
         // an active response until it — and lands now.
-        if (this.#audioDrained) {
+        if (this.#currentReplyDrained()) {
           this.#finishResponse();
           return;
         }

--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -204,20 +204,31 @@ export function cancelResponseEvents(input: {
  * said every word it generated, and will happily refer back to a sentence that
  * never reached the room.
  *
- * `audioEndMs` is how long the reply was audible, which cannot exceed what was
- * generated — the audio was heard because it had already been produced. That is
- * what keeps this from being refused for trimming past the end.
+ * `audioEndMs` is how long the reply was audible, measured on a wall clock —
+ * which can outrun the audio itself when playback stalls, or when the stop
+ * lands at the reply's very end. The server refuses a trim past the end, so
+ * the event carries a name for the session to recognize that refusal as its
+ * own: a reply refused this way was heard whole, and the record it would have
+ * corrected is already right.
  */
 export function truncateResponseEvents(input: {
   itemId: string;
   audioEndMs: number;
+  truncationEventId: string;
 }): readonly WireRecord[] {
-  if (!trimmedText(input.itemId) || !Number.isFinite(input.audioEndMs) || input.audioEndMs <= 0) {
+  const truncationEventId = trimmedText(input.truncationEventId);
+  if (
+    !trimmedText(input.itemId) ||
+    !truncationEventId ||
+    !Number.isFinite(input.audioEndMs) ||
+    input.audioEndMs <= 0
+  ) {
     return [];
   }
   return [
     {
       type: REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_TRUNCATE,
+      event_id: truncationEventId,
       item_id: input.itemId,
       // One audio part per assistant message, so the first is the reply.
       content_index: 0,

--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -492,7 +492,7 @@ export type ParsedRealtimeServerEvent =
       itemId?: string;
       transcript: string;
     }
-  | { type: typeof REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED }
+  | { type: typeof REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED; responseId?: string }
   | {
       type: typeof REALTIME_SERVER_EVENT.RESPONSE_DONE;
       responseId?: string;
@@ -626,8 +626,17 @@ export function parseRealtimeServerEvent(
       if (itemId) parsed.itemId = itemId;
       return parsed;
     }
-    case REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED:
-      return { type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED };
+    case REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED: {
+      // The drain names the response it drained. An old reply's buffer can
+      // empty after its follow-up was already asked for, and a drain read as
+      // the current reply's would end a turn under audio it never played.
+      const responseId = optionalString(event.response_id);
+      const parsed: ParsedRealtimeServerEvent = {
+        type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED,
+      };
+      if (responseId) parsed.responseId = responseId;
+      return parsed;
+    }
     case REALTIME_SERVER_EVENT.RESPONSE_DONE: {
       const responseId = optionalString(recordField(event, "response")?.id);
       const hasAudio = audioFromDone(event);

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -1200,6 +1200,13 @@ test("inbound events the conversation acts on are parsed, and nothing else is", 
     parseRealtimeServerEvent({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED }),
     { type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED },
   );
+  assert.deepEqual(
+    parseRealtimeServerEvent({
+      type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED,
+      response_id: "resp-1",
+    }),
+    { type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED, responseId: "resp-1" },
+  );
   assert.deepEqual(parseRealtimeServerEvent({ type: REALTIME_SERVER_EVENT.RESPONSE_DONE }), {
     type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
     calls: [],

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -346,10 +346,15 @@ test("a reply can be stopped by the developer taking the turn", () => {
 });
 
 test("a cut-off reply is trimmed to what was heard of it", () => {
-  const events = truncateResponseEvents({ itemId: "item_abc", audioEndMs: 1240.7 });
+  const events = truncateResponseEvents({
+    itemId: "item_abc",
+    audioEndMs: 1240.7,
+    truncationEventId: "item_truncate_1",
+  });
 
   assert.equal(events.length, 1);
   assert.equal(events[0]?.type, REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_TRUNCATE);
+  assert.equal(events[0]?.event_id, "item_truncate_1");
   assert.equal(events[0]?.item_id, "item_abc");
   assert.equal(events[0]?.content_index, 0);
   assert.equal(events[0]?.audio_end_ms, 1240);
@@ -358,13 +363,16 @@ test("a cut-off reply is trimmed to what was heard of it", () => {
 test("nothing heard is nothing to correct", () => {
   // Cut off in the gap before the first word: the model has said nothing to the
   // room, and asking to trim a reply to zero — or trimming a message that was
-  // never named — is a request the server refuses rather than a correction.
+  // never named — is a request the server refuses rather than a correction. An
+  // unnamed trim is refused too: the name is what lets the session recognize
+  // the server refusing it as the stop's own answer.
   for (const input of [
-    { itemId: "item_abc", audioEndMs: 0 },
-    { itemId: "item_abc", audioEndMs: -50 },
-    { itemId: "item_abc", audioEndMs: Number.NaN },
-    { itemId: "", audioEndMs: 900 },
-    { itemId: "   ", audioEndMs: 900 },
+    { itemId: "item_abc", audioEndMs: 0, truncationEventId: "item_truncate_1" },
+    { itemId: "item_abc", audioEndMs: -50, truncationEventId: "item_truncate_1" },
+    { itemId: "item_abc", audioEndMs: Number.NaN, truncationEventId: "item_truncate_1" },
+    { itemId: "", audioEndMs: 900, truncationEventId: "item_truncate_1" },
+    { itemId: "   ", audioEndMs: 900, truncationEventId: "item_truncate_1" },
+    { itemId: "item_abc", audioEndMs: 900, truncationEventId: " " },
   ]) {
     assert.deepEqual(truncateResponseEvents(input), []);
   }


### PR DESCRIPTION
## Problem

Stopping Luke mid-reply (Option S) could surface a voice error: **"Audio content of Xms is already shorter than Xms"**.

The stop trims the interrupted reply to what was actually heard, measuring `audio_end_ms` as wall-clock time since the reply first became audible. But a turn can outlive its own audio — the buffer drains while the server still owes its `response.done` (or a tool follow-up), and the wall clock keeps counting past the audio's end. A stop in that window — exactly what stopping near the natural end of a reply hits — asked the server to trim past the end. The truncate carried no `event_id`, so the refusal could not be recognized as the stop's own answer and reached the developer as an error.

## Fix

- A stop after the reply's audio has drained sends no truncate at all: every word reached the room, so the record needs no correction.
- For the stop that races the drain event, the truncate now carries a stamped `event_id` and is tracked with the cancel and clear interruptions; the past-the-end refusal is recognized as benign — the reply was heard whole — while every other truncate error still surfaces.

## Verification

- New session tests: the benign refusal stays quiet, a real truncate error still surfaces, and a stop after the drain sends no trim.
- Protocol tests updated for the stamped event id, including the blank-id refusal.
- `./scripts/check.sh` passes end to end. No visual surface changed, so no evidence run applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c617015d-9151-4a6c-a01a-d6c41cbbd965)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32404401192/artifacts/9419765199) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32404401192)

- Commit: `9f62169a3216e3bff584ab2143a29faac613ff05`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
