### PR TITLE
feat(sessions): persist the filter chips across closings and restarts

### DIFF
--- a/apps/desktop/src/main/settings-store.test.ts
+++ b/apps/desktop/src/main/settings-store.test.ts
@@ -10,7 +10,12 @@ import {
   type CredentialProviderId,
 } from "@sidecar/credentials";
 import { REALTIME_DEFAULTS, REALTIME_VOICE, REALTIME_VOICE_SPEED } from "@sidecar/realtime";
-import { PROVIDER_ID, type ProviderId, type WorkspaceAgentSelection } from "@sidecar/session";
+import {
+  PROVIDER_ID,
+  type ProviderId,
+  SESSION_FILTER,
+  type WorkspaceAgentSelection,
+} from "@sidecar/session";
 import {
   APP_SETTING_FIELDS,
   APP_SETTING_SCHEMA,
@@ -406,6 +411,75 @@ test("a corrupt microphone preference reads as the default rather than as off", 
   );
 
   assert.equal((await storeIn(directory).snapshot()).preferBuiltInMicrophone, true);
+});
+
+test("the session filter selection starts unset and survives a reopen", async (t) => {
+  const directory = await temporaryDirectory(t);
+  // A view preference is not a credential, so storing it must reach the
+  // Keychain not at all.
+  const cipher = countingCipher();
+  const store = storeIn(directory, { cipher });
+
+  assert.equal((await store.snapshot()).sessionFilters, undefined);
+  const chosen = [SESSION_FILTER.LOCAL, PROVIDER_ID.CODEX];
+  const narrowed = await store.set(APP_SETTING_SCHEMA.sessionFilters.field, chosen);
+
+  assert.deepEqual(narrowed.settings.sessionFilters, chosen);
+  assert.deepEqual((await storeIn(directory).snapshot()).sessionFilters, chosen);
+  assert.equal(cipher.calls.isAvailable, 0);
+  assert.equal(cipher.calls.encrypt, 0);
+});
+
+test("clearing the session filter selection reads as unset after a reopen", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+  await store.set(APP_SETTING_SCHEMA.sessionFilters.field, [SESSION_FILTER.CLOUD]);
+
+  const cleared = await store.set(APP_SETTING_SCHEMA.sessionFilters.field, undefined);
+
+  assert.equal(cleared.settings.sessionFilters, undefined);
+  assert.equal((await storeIn(directory).snapshot()).sessionFilters, undefined);
+});
+
+test("storing the session filter selection never disturbs a stored key", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+  await store.setApiKey(CONDUCTOR, TEST_API_KEY);
+
+  await store.set(APP_SETTING_SCHEMA.sessionFilters.field, [SESSION_FILTER.VOICE]);
+
+  assert.equal(await storeIn(directory).readApiKey(CONDUCTOR), TEST_API_KEY);
+});
+
+// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+test("a stored selection keeps only the filters this build recognizes", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({
+      version: 2,
+      apiKeys: {},
+      sessionFilters: ["local", "a-future-builds-filter", 7, "local", PROVIDER_ID.CODEX],
+    }),
+    "utf8",
+  );
+
+  assert.deepEqual((await storeIn(directory).snapshot()).sessionFilters, [
+    SESSION_FILTER.LOCAL,
+    PROVIDER_ID.CODEX,
+  ]);
+});
+
+// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+test("a corrupt session filter value reads as unset rather than narrowing the list", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({ version: 2, apiKeys: {}, sessionFilters: "local" }),
+    "utf8",
+  );
+
+  assert.equal((await storeIn(directory).snapshot()).sessionFilters, undefined);
 });
 
 test("a calendar account stores its grant encrypted and survives a reopen", async (t) => {

--- a/apps/desktop/src/main/settings-store.ts
+++ b/apps/desktop/src/main/settings-store.ts
@@ -563,6 +563,7 @@ export class SettingsStore {
       showOnAllDisplays: persisted.showOnAllDisplays,
       shareUsageData: persisted.shareUsageData,
       formFactor: persisted.formFactor ?? DEFAULT_PANEL_FORM_FACTOR,
+      ...(persisted.sessionFilters ? { sessionFilters: persisted.sessionFilters } : undefined),
       ...(persisted.defaultWorkspaceProvider
         ? { defaultWorkspaceProvider: persisted.defaultWorkspaceProvider }
         : undefined),

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -2844,10 +2844,16 @@ export function App(): React.JSX.Element {
   // unnarrowed, and the next session to enter that state would narrow the list
   // back down to it with nothing having been pressed. Setting state here rather
   // than from an effect is what keeps that from being drawn first and corrected
-  // after. Only once the roster has actually been read, though: before the
-  // first reading an empty list says "not looked yet", and a selection
-  // restored from the store must not be judged stale against it.
-  if (sessionsSettled && !sameSessionFilters(list.filters, sessionView.filters)) {
+  // after. Only a roster actually read and holding sessions can prove a
+  // selection stale, though: before the first reading an empty list says "not
+  // looked yet", and an empty roster hides nothing behind a chip — either way
+  // a selection restored from the store is left to stand rather than wiped
+  // against a list that has nothing to show under any view.
+  if (
+    sessionsSettled &&
+    visibleSessions.length > 0 &&
+    !sameSessionFilters(list.filters, sessionView.filters)
+  ) {
     setSessionView({ ...sessionView, filters: list.filters });
   }
   // The sheet exists only while there is something for it to decide, and its

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -670,9 +670,13 @@ export function App(): React.JSX.Element {
     },
     onCapsuleList: () => {
       // A search is a question about the list as it was, so it closes with
-      // the panel on the same terms the filter does — a remembered query
-      // could hide the very session the capsule is reporting.
-      setSessionView(DEFAULT_SESSION_VIEW);
+      // the panel — a remembered query could hide the very session the
+      // capsule is reporting — and the order goes back with it, so the top
+      // row keeps matching the mark the capsule kept. The filter chips stay:
+      // a chosen narrowing is a standing way of viewing the list, and the
+      // capsule stays honest over it because its tally is taken before the
+      // list is narrowed.
+      setSessionView((current) => ({ ...DEFAULT_SESSION_VIEW, filters: current.filters }));
       setSearchOpen(false);
     },
     onCapsuleTab: () => changeTab(PANEL_TAB.SESSIONS),
@@ -791,6 +795,33 @@ export function App(): React.JSX.Element {
     },
     [applySettings],
   );
+
+  /**
+   * The selection as last stored, so only a change of selection writes.
+   * Seeded from bootstrap's snapshot rather than from nothing, because
+   * restoring the stored chips must not read as a fresh choice to store
+   * again. A ref rather than reading the settings state: a stored write's
+   * reply races the next chip press, and the last value this window sent is
+   * the only honest baseline either way.
+   */
+  const storedSessionFilters = useRef<readonly SessionFilter[] | undefined>(undefined);
+  // Every way the selection changes funnels through the view — a chip, a
+  // spoken ask, the widen button, the list correcting an emptied selection —
+  // so the store follows the view from one place. Never in a fixture or
+  // capture run, which must not write a developer's own settings file.
+  useEffect(() => {
+    if (!bootstrap || bootstrap.fixtureMode) return;
+    storedSessionFilters.current ??= bootstrap.settings.sessionFilters ?? [];
+    const filters = sessionView.filters;
+    if (sameSessionFilters(storedSessionFilters.current, filters)) return;
+    storedSessionFilters.current = filters;
+    void window.sidecar
+      .updateSetting(
+        APP_SETTING_SCHEMA.sessionFilters.field,
+        filters.length > 0 ? filters : undefined,
+      )
+      .then(applySettingsReply);
+  }, [bootstrap, sessionView.filters, applySettingsReply]);
 
   const changeVoiceCaptions = useCallback(
     async (enabled: boolean) =>
@@ -2323,6 +2354,15 @@ export function App(): React.JSX.Element {
       acceptCalendarsBootstrap(value.calendars);
       acceptMeetingQuietBootstrap(value.meetingQuiet);
       acceptSettingsBootstrap(value.settings);
+      // The stored filter chips come back with the panel: a chosen narrowing
+      // is a standing way of viewing the list, and this is the one moment it
+      // is read from the store — from here on the view leads and the store
+      // follows. Never in a fixture or capture run, whose evidence must not
+      // vary with what a developer last chose.
+      const storedFilters = value.settings.sessionFilters;
+      if (!value.fixtureMode && storedFilters !== undefined) {
+        setSessionView((current) => ({ ...current, filters: storedFilters }));
+      }
       acceptAccountBootstrap(value.account);
       acceptUpdateBootstrap(value.update);
       setDisplay(value.display);
@@ -2804,8 +2844,10 @@ export function App(): React.JSX.Element {
   // unnarrowed, and the next session to enter that state would narrow the list
   // back down to it with nothing having been pressed. Setting state here rather
   // than from an effect is what keeps that from being drawn first and corrected
-  // after.
-  if (!sameSessionFilters(list.filters, sessionView.filters)) {
+  // after. Only once the roster has actually been read, though: before the
+  // first reading an empty list says "not looked yet", and a selection
+  // restored from the store must not be judged stale against it.
+  if (sessionsSettled && !sameSessionFilters(list.filters, sessionView.filters)) {
     setSessionView({ ...sessionView, filters: list.filters });
   }
   // The sheet exists only while there is something for it to decide, and its

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -8,12 +8,14 @@ import {
   PROVIDER_ID_LIST,
   type ProviderId,
   SESSION_APPLICATION_ID_LIST,
+  SESSION_FILTER,
   SESSION_LOCATION,
   SESSION_STATUS,
   type SessionApplicationId,
   type SessionApplicationScope,
   type SessionControlKind,
   type SessionDiffSummary,
+  type SessionFilter,
   type SessionLocation,
   sessionChangeNumber,
 } from "@sidecar/session";
@@ -27,33 +29,17 @@ import {
 import type { AppBootstrap } from "#shared/contracts";
 
 /**
- * One narrowing the list can hold: a place work runs, the realtime voice kind,
- * one app that associates with sessions, or one agent. The values are
- * identities a row already carries: its location, voice kind, app associations
- * and provider. Conductor deliberately occupies both app and provider
- * vocabularies, so its filter takes the union — native Conductor chats and
- * local chats annotated as running in Conductor — while no identity collides
- * with `local`, `cloud`, or `voice`.
- *
- * Location belongs to the session rather than to the agent, so an agent with
- * work in both places is one chip that answers `Local` and `Cloud` both — and
- * Superset belongs to the workspace rather than to the agent, so the same
- * agent answers its own chip and the Superset chip when Superset manages it.
- * A hosted chat carries its agent's identity beside its provider's, so a
- * Claude conversation in Conductor's cloud answers the Claude Code chip and
- * the Conductor chip at once.
+ * The narrowings and their vocabulary live in core so the stored selection is
+ * validated by the same set the chips draw from. What a chip answers stays a
+ * surface fact: location belongs to the session rather than to the agent, so
+ * an agent with work in both places is one chip that answers `Local` and
+ * `Cloud` both — and Superset belongs to the workspace rather than to the
+ * agent, so the same agent answers its own chip and the Superset chip when
+ * Superset manages it. A hosted chat carries its agent's identity beside its
+ * provider's, so a Claude conversation in Conductor's cloud answers the
+ * Claude Code chip and the Conductor chip at once.
  */
-export const SESSION_FILTER = {
-  LOCAL: SESSION_LOCATION.LOCAL,
-  CLOUD: SESSION_LOCATION.CLOUD,
-  VOICE: "voice",
-  SUPERSET: SUPERSET_WORKSPACE_PROVIDER_ID,
-} as const;
-
-export type SessionFilter =
-  | (typeof SESSION_FILTER)[keyof typeof SESSION_FILTER]
-  | ProviderId
-  | SessionApplicationId;
+export { SESSION_FILTER, type SessionFilter };
 
 /**
  * The independent questions the filters answer. Each filter value belongs to
@@ -188,11 +174,14 @@ export interface SessionView {
 }
 
 /**
- * What the panel opens on, every time. A filter is not remembered across a
- * closing, because a remembered one could hide the very session the capsule is
- * reporting; the order is not remembered with it, so the top row keeps matching
- * the mark the capsule kept. A search is forgotten on the same terms — it is a
- * question about the list as it was, not a standing way of viewing it.
+ * What the panel opens on before any stored view arrives. The filters are the
+ * one part of the view that outlives a closing: a chosen narrowing is a
+ * standing way of viewing the list, restored from the stored settings at
+ * launch and kept across capsule closings — and the capsule stays honest over
+ * it because its tally is taken before the list is narrowed. The order is not
+ * remembered, so the top row keeps matching the mark the capsule kept, and a
+ * search is forgotten on the same terms — it is a question about the list as
+ * it was, not a standing way of viewing it.
  */
 export const DEFAULT_SESSION_VIEW: SessionView = {
   filters: [],

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -28,6 +28,7 @@ import type {
   ProviderMessageResult,
   ProviderWorkspaceResult,
   SessionApplicationId,
+  SessionFilter,
   SessionIdentity,
   WorkspaceAgentSelection,
 } from "@sidecar/session";
@@ -361,6 +362,15 @@ export interface AppSettings {
    * gets by default. A display with a real notch answers to neither.
    */
   formFactor: PanelFormFactor;
+  /**
+   * The session list's chosen filter chips, absent while nothing narrows it.
+   * A chosen narrowing is a standing way of viewing the list, so it survives
+   * the panel closing and the app restarting; the search query and the order
+   * deliberately do not travel with it. Fixture and capture runs leave it
+   * unread, because their evidence must not vary with what a developer last
+   * chose.
+   */
+  sessionFilters?: readonly SessionFilter[];
   /**
    * The provider a conversational ask creates a new workspace in when the ask
    * names none, absent until one has been chosen. It starts unset on purpose:

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -80,6 +80,11 @@ export {
   UNKNOWN_WORKSPACE_LABEL,
 } from "./session.js";
 export {
+  isSessionFilter,
+  SESSION_FILTER,
+  type SessionFilter,
+} from "./session-filter.js";
+export {
   firstWholeNameIndex,
   MAXIMUM_MENTIONED_SESSIONS,
   MINIMUM_MENTION_TITLE_LENGTH,

--- a/packages/session/src/session-filter.ts
+++ b/packages/session/src/session-filter.ts
@@ -1,0 +1,43 @@
+import { isProviderId, type ProviderId } from "./providers.js";
+import {
+  isSessionApplicationId,
+  SESSION_APPLICATION_ID,
+  SESSION_LOCATION,
+  type SessionApplicationId,
+} from "./session.js";
+
+/**
+ * One narrowing a session list can hold: a place work runs, the realtime voice
+ * kind, one app that associates with sessions, or one agent. The values are
+ * identities a row already carries: its location, voice kind, app associations
+ * and provider. Conductor deliberately occupies both app and provider
+ * vocabularies, so its filter takes the union — native Conductor chats and
+ * local chats annotated as running in Conductor — while no identity collides
+ * with `local`, `cloud`, or `voice`.
+ *
+ * The vocabulary lives here rather than with the surface that draws the chips
+ * because the stored view reads it too: a persisted selection is restored only
+ * as far as this set still recognizes it, and two readings of what a filter is
+ * must not drift apart.
+ */
+export const SESSION_FILTER = {
+  LOCAL: SESSION_LOCATION.LOCAL,
+  CLOUD: SESSION_LOCATION.CLOUD,
+  VOICE: "voice",
+  SUPERSET: SESSION_APPLICATION_ID.SUPERSET,
+} as const;
+
+export type SessionFilter =
+  | (typeof SESSION_FILTER)[keyof typeof SESSION_FILTER]
+  | ProviderId
+  | SessionApplicationId;
+
+export function isSessionFilter(value: string): value is SessionFilter {
+  return (
+    value === SESSION_FILTER.LOCAL ||
+    value === SESSION_FILTER.CLOUD ||
+    value === SESSION_FILTER.VOICE ||
+    isProviderId(value) ||
+    isSessionApplicationId(value)
+  );
+}

--- a/packages/settings/src/schema.ts
+++ b/packages/settings/src/schema.ts
@@ -20,9 +20,11 @@ import {
 } from "@sidecar/realtime";
 import {
   isProviderId,
+  isSessionFilter,
   PROVIDER_ID,
   type ProviderId,
   parseWorkspaceAgentSelection,
+  type SessionFilter,
   type WorkspaceAgentSelection,
   workspaceAgentModelLabel,
   workspaceAgentModels,
@@ -108,6 +110,8 @@ export interface StoredAppSettings {
   showOnAllDisplays: boolean;
   shareUsageData: boolean;
   formFactor?: PanelFormFactor;
+  /** The session list's chosen filter chips, absent while nothing narrows it. */
+  sessionFilters?: readonly SessionFilter[];
   defaultWorkspaceProvider?: WorkspaceProviderId;
   workspaceAgentDefaults?: Readonly<Partial<Record<ProviderId, WorkspaceAgentSelection>>>;
   workspaceProjectDefaults?: Readonly<Partial<Record<WorkspaceProviderId, string>>>;
@@ -288,6 +292,27 @@ function workspaceAgentDefaults(
     defaults[providerId] = parsed;
   }
   return valid(Object.keys(defaults).length > 0 ? defaults : undefined);
+}
+
+/**
+ * The stored chips come back only as far as this build still recognizes them:
+ * a value that names no place, kind, app, or agent here — another build's
+ * vocabulary, or a corrupted file — is dropped rather than held dormant, a
+ * repeated value narrows no further than its first, and a selection left with
+ * nothing reads as unset, which is the unnarrowed list.
+ */
+function sessionFilters(
+  value: UnparsedWireValue,
+): SettingGuardResult<StoredAppSettings["sessionFilters"]> {
+  if (value === undefined) return valid(undefined);
+  if (!Array.isArray(value)) return invalid(undefined);
+  const filters: SessionFilter[] = [];
+  for (const candidate of value) {
+    if (!isWireString(candidate) || !isSessionFilter(candidate)) continue;
+    if (filters.includes(candidate)) continue;
+    filters.push(candidate);
+  }
+  return valid(filters.length > 0 ? filters : undefined);
 }
 
 const MAXIMUM_WORKSPACE_PROJECT_ID_LENGTH = 500;
@@ -623,6 +648,21 @@ export const APP_SETTING_SCHEMA = {
     mainProcessSideEffect: SETTING_SIDE_EFFECT.FORM_FACTOR,
     spokenValue: (value: string) => (isPanelFormFactor(value) ? value : undefined),
     analytics: { id: APP_SETTING_ID.FORM_FACTOR, value: choiceAnalytics },
+  },
+  sessionFilters: {
+    field: "sessionFilters",
+    default: undefined,
+    guard: sessionFilters,
+    // The selection backs no settings row — it is the session list's own view
+    // state, stored so the chips survive the panel closing and the app
+    // restarting. With no guide ids the page below is inert; the root page is
+    // named only because a definition must name one.
+    settingsPage: SETTINGS_PAGE.ROOT,
+    // The guide covers narrowing the list through the session-filter facts and
+    // the spoken filter tool's own vocabulary; the stored selection is what
+    // those already changed, not a setting of its own to describe.
+    guideEntry: settingGuideEntry("sessionFilters", [], () => undefined),
+    mainProcessSideEffect: SETTING_SIDE_EFFECT.NONE,
   },
   defaultWorkspaceProvider: {
     field: "defaultWorkspaceProvider",

--- a/packages/settings/src/session-filters.test.ts
+++ b/packages/settings/src/session-filters.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { PROVIDER_ID, SESSION_APPLICATION_ID, SESSION_FILTER } from "@sidecar/session";
+import { APP_SETTING_SCHEMA } from "./schema.js";
+
+const guard = APP_SETTING_SCHEMA.sessionFilters.guard;
+
+test("an absent selection is valid and reads as the unnarrowed list", () => {
+  assert.deepEqual(guard(undefined), { valid: true, value: undefined });
+});
+
+test("keeps every filter this build recognizes, in the order chosen", () => {
+  const chosen = [
+    SESSION_FILTER.LOCAL,
+    SESSION_FILTER.CLOUD,
+    SESSION_FILTER.VOICE,
+    SESSION_FILTER.SUPERSET,
+    PROVIDER_ID.CODEX,
+    SESSION_APPLICATION_ID.CONDUCTOR,
+  ];
+
+  assert.deepEqual(guard(chosen), { valid: true, value: chosen });
+});
+
+test("drops a value that names no place, kind, app, or agent here", () => {
+  const held = guard([SESSION_FILTER.LOCAL, "a-future-builds-filter", 7, true, {}, null]);
+
+  assert.deepEqual(held, { valid: true, value: [SESSION_FILTER.LOCAL] });
+});
+
+test("a repeated value narrows no further than its first", () => {
+  const held = guard([SESSION_FILTER.LOCAL, PROVIDER_ID.CODEX, SESSION_FILTER.LOCAL]);
+
+  assert.deepEqual(held, { valid: true, value: [SESSION_FILTER.LOCAL, PROVIDER_ID.CODEX] });
+});
+
+test("a selection left with nothing reads as unset", () => {
+  assert.deepEqual(guard([]), { valid: true, value: undefined });
+  assert.deepEqual(guard(["a-future-builds-filter"]), { valid: true, value: undefined });
+});
+
+test("a selection that is not a list is invalid rather than guessed at", () => {
+  assert.deepEqual(guard(SESSION_FILTER.LOCAL), { valid: false, value: undefined });
+  assert.deepEqual(guard({ filters: [SESSION_FILTER.LOCAL] }), { valid: false, value: undefined });
+  assert.deepEqual(guard(7), { valid: false, value: undefined });
+});


### PR DESCRIPTION
## What

The sessions list's filter selection — the location, kind, app, and agent chips — now survives the panel closing, the pointer leaving the notch, and the app restarting. The search query deliberately stays transient, and the sort still resets with the panel.

## How

- **Vocabulary moved to core.** `SESSION_FILTER` / `SessionFilter` now live in `@sidecar/session` (`session-filter.ts`) with an `isSessionFilter` guard, so the stored selection is validated by the same set the chips draw from; the renderer's `session-model.ts` re-exports them.
- **A declared setting.** `sessionFilters` joins `StoredAppSettings` with a schema guard that keeps only filters this build recognizes (unknown values from another build are dropped rather than held dormant), deduplicates, and reads an emptied selection as unset — which is the migration/default behavior. No settings row, no guide entry, no analytics, no side effect; writes travel the existing `updateSetting` bridge and its main-process re-validation.
- **Restore once, then follow.** The renderer restores the stored chips at bootstrap — never in a fixture or capture run, whose evidence must not vary with what a developer last chose — and from then on a single effect persists every selection change, whatever path made it (chip press, spoken ask, widen button, the list correcting an emptied selection).
- **Capsule close keeps the chips.** `onCapsuleList` now resets only the sort and the query. The capsule stays honest over a remembered narrowing because its tally is taken before the list is narrowed, and an emptied search still offers the matches sitting behind the chips.
- **Correction waits for the roster.** The emptied-selection fallback now runs only once `sessionsSettled`, so a restored selection is not judged stale against an empty list nobody has read yet.

## Tests

- `packages/settings/src/session-filters.test.ts` — guard behavior: order kept, unknown values and non-strings dropped, duplicates collapsed, empty reads as unset, non-list invalid.
- `apps/desktop/src/main/settings-store.test.ts` — round trip across a store reopen, clearing reads as unset, a stored key is undisturbed, unknown stored values dropped at read, corrupt value reads as unset, and no Keychain traffic for a view preference.

## Results

- `./scripts/check.sh` passes (exit 0); desktop suite 665/665, settings package 22/22.
- `./scripts/verify.sh` was not run: this change was made in a Linux cloud workspace, so macOS packaging and visual evidence come from CI. No physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/91f23bf5-5629-4369-a4e0-5d871fb7bc80)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32406260463/artifacts/9420413916) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32406260463)

- Commit: `490285c49ab31076a20a82cde56424a273793484`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
