### PR TITLE
feat(voice): manage coding agents as people

### DIFF
--- a/packages/attention/src/attention-openai.test.ts
+++ b/packages/attention/src/attention-openai.test.ts
@@ -37,6 +37,7 @@ test("the responses request is the shared construction with only the update vary
 
   assert.equal(request.model, "gpt-test");
   assert.equal(request.instructions, attentionInstructions());
+  assert.match(request.instructions, /refer to the coding agent as an agent, never as a session/i);
   assert.equal(request.input, attentionUpdateInput(UPDATE));
   assert.equal(request.max_output_tokens, 64);
   assert.equal(request.store, false);

--- a/packages/attention/src/attention-prompt.ts
+++ b/packages/attention/src/attention-prompt.ts
@@ -18,6 +18,7 @@ const NONE_LABEL = "none";
 
 const ATTENTION_INSTRUCTION_LINES: readonly string[] = [
   "Decide whether Luke should speak about a coding-agent session update.",
+  "- If speaking, refer to the coding agent as an agent, never as a session.",
   "- Default to silence when the update is routine, ambiguous, or merely continues work already underway.",
   "- A session waiting on automation it set in motion — CI, a merge queue, a watcher it left running — is not waiting on the developer: nothing they reply can move it, so stay silent and let the automation's outcome be the development.",
   "- When a user's standing ask is answered, speak and set answers_ask to true; otherwise set it to false.",

--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -144,11 +144,11 @@ export interface AttentionSpeech extends SessionIdentity {
 }
 
 const REALTIME_INSTRUCTION_HEAD: readonly string[] = [
-  "You are Luke, the engineering manager for the developer's coding agents.",
+  "You are Luke, a human engineering manager responsible for the developer's coding agents.",
   "",
   "How to speak:",
   '- Speak as Luke in first person and address the user directly as "you".',
-  "- Refer to sessions as agents and speak about them as if they were humans.",
+  "- Refer to them as agents, never sessions, and speak about them as real people you manage.",
   "- Be concise. Prefer short answers unless the user asks for more detail.",
   "- Start with the answer; do not repeat the user's request.",
   "- When the user asks about overall progress, summarize across the observed agents.",
@@ -403,6 +403,7 @@ const PROACTIVE_SPEECH_INSTRUCTIONS = [
 
 const STATUS_EDGE_INSTRUCTIONS = [
   "Summarize the status update in the last message in one or two short sentences, then stop.",
+  "Refer to its subject as an agent, never a session.",
 ].join("\n");
 
 export const maximumNoticeContextLength = 1_400;
@@ -449,7 +450,7 @@ export function proactiveSpeechEvents(speech: AttentionSpeech): readonly WireRec
         content: [
           {
             type: "input_text",
-            text: `${isStatusEdge ? "[session update]" : "[announcement to read out]"}\n${payload}`,
+            text: `${isStatusEdge ? "[agent update]" : "[announcement to read out]"}\n${payload}`,
           },
         ],
       },

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -235,10 +235,15 @@ test("a refused delete is read back with the event it names", () => {
   assert.equal(deleted?.itemId, "luke_ctx_sessions_1");
 });
 
-test("the standing instructions make Luke the coding agents' engineering manager", () => {
+test("the standing instructions make Luke the agents' human manager", () => {
   const instructions = realtimeInstructions();
 
-  assert.match(instructions, /engineering manager for the developer's coding agents/i);
+  assert.match(
+    instructions,
+    /human engineering manager responsible for the developer's coding agents/i,
+  );
+  assert.match(instructions, /agents, never sessions/i);
+  assert.match(instructions, /real people you manage/i);
   assert.match(instructions, /start with the answer; do not repeat the user's request/i);
 });
 
@@ -513,6 +518,20 @@ test("a proactive update is voiced as the sentence attention already approved", 
   assert.equal(request?.type, REALTIME_CLIENT_EVENT.RESPONSE_CREATE);
   assert.ok(noticeText(notice).includes(SPOKEN_SUMMARY));
   assert.match(instructionsOf(request), /verbatim/);
+});
+
+test("a status update is presented and summarized as news about an agent", () => {
+  const events = proactiveSpeechEvents({
+    providerId: "codex",
+    providerSessionId: "session-a",
+    disposition: ATTENTION_DISPOSITION.SPEAK_AT_TURN_END,
+    source: ATTENTION_SPEECH_SOURCE.STATUS_EDGE,
+    summary: 'provider: "Codex"; agent: "checkout"; event: finished',
+    decidedAt: DECIDED_AT,
+  });
+
+  assert.match(noticeText(events[0]), /^\[agent update\]/);
+  assert.match(instructionsOf(events[1]), /agent, never a session/i);
 });
 
 test("a summary is carried as words to say, never as words to obey", () => {

--- a/packages/voice/src/session-notifications.test.ts
+++ b/packages/voice/src/session-notifications.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { SESSION_NOTICE_STATUS, SESSION_STATUS, type SessionNotice } from "@sidecar/session";
+import { sessionNoticeSpeech } from "./session-notifications.js";
+
+test("a status announcement presents its subject as an agent", () => {
+  const notice: SessionNotice = {
+    providerId: "codex",
+    providerSessionId: "session-a",
+    providerName: "Codex",
+    title: "checkout",
+    status: SESSION_NOTICE_STATUS.COMPLETE,
+    previousStatus: SESSION_STATUS.WORKING,
+    canReceiveMessage: false,
+    observedAt: 1_000,
+  };
+
+  const speech = sessionNoticeSpeech(notice, 1_000);
+
+  assert.match(speech.summary, /agent: "checkout"/);
+  assert.doesNotMatch(speech.summary, /session: "checkout"/);
+});

--- a/packages/voice/src/session-notifications.ts
+++ b/packages/voice/src/session-notifications.ts
@@ -53,7 +53,7 @@ function noticeUpdateContext(notice: SessionNotice): string {
       : undefined;
   const fields: readonly (readonly [string, string] | undefined)[] = [
     ["provider", quoted(notice.providerName)],
-    ["session", quoted(notice.title)],
+    ["agent", quoted(notice.title)],
     workspace ? ["workspace", quoted(workspace)] : undefined,
     notice.repository ? ["repository", quoted(notice.repository)] : undefined,
     notice.branch ? ["branch", quoted(notice.branch)] : undefined,


### PR DESCRIPTION
## Summary

- Frame Luke as a human engineering manager responsible for coding agents
- Require conversations and evaluator announcements to call them agents, not sessions
- Keep status announcements on the same terminology even when response-specific instructions override the standing realtime prompt

## Test Coverage

Prompt behavior is covered at the attention evaluator, realtime response, and deterministic status-payload boundaries.

## Pre-Landing Review

No issues found. Independent review confirmed proactive turns remain tool-disabled and trust boundaries are unchanged.

## Design Review

No frontend files changed — design review skipped.

## Eval Results

No dedicated eval framework covers these prompt sources; focused contract tests cover every changed instruction path.

## Plan Completion

No relevant plan file detected.

## Test plan

- [x] `pnpm --filter @sidecar/attention test` — 50 passed
- [x] `pnpm --filter @sidecar/realtime test` — 96 passed
- [x] `pnpm --filter @sidecar/voice test` — 35 passed
- [x] `./scripts/check.sh`

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32415278904/artifacts/9423690349) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32415278904)

- Commit: `608e52e5efe94703fd70523c8c0e515200632109`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
