### PR TITLE
feat(voice): trail notice chips with their session's app marks

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -2032,22 +2032,27 @@ export function App(): React.JSX.Element {
         mention.kind === SESSION_MENTION_KIND.WORKSPACE && session.workspace?.name !== undefined
           ? session.workspace.name
           : session.title;
+      // The chip's mark is the agent having the conversation, the same
+      // identity the session's own row leads with.
+      const markId = session.agent?.id ?? session.providerId;
       return [
         {
           kind: MENTION_CHIP_KIND.SESSION,
           id: session.providerSessionId,
-          // The chip's mark is the agent having the conversation, the same
-          // identity the session's own row leads with.
-          markId: session.agent?.id ?? session.providerId,
+          markId,
           title,
           identity: {
             providerId: session.providerId,
             providerSessionId: session.providerSessionId,
           },
-          applications: session.applications.map((application) => ({
-            id: application.id,
-            name: application.displayName,
-          })),
+          applications: session.applications.flatMap((application) =>
+            // An app the leading mark already stands for — a provider that is
+            // itself the app, standing in where no agent was reported — would
+            // draw the same mark twice on one chip.
+            application.id === markId
+              ? []
+              : [{ id: application.id, name: application.displayName }],
+          ),
         },
       ];
     }),

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -273,6 +273,17 @@ const MENTION_CHIP_KIND = {
 } as const;
 
 /**
+ * One app mark trailing a session chip's name: the same associations the
+ * session's own row wears, answering where the chat is also held. Copied onto
+ * the chip rather than looked up at draw time, so the band held through its
+ * fade-out keeps wearing them after the roster moves on.
+ */
+type MentionChipApplication = {
+  id: string;
+  name: string;
+};
+
+/**
  * One pressable chip of the notice band: the mark and words it draws, and the
  * identity its press hands to the main process — where it is validated
  * against the observed roster again before any address reaches the system.
@@ -286,6 +297,7 @@ type MentionChip =
       markId: string;
       title: string;
       identity: SessionIdentity;
+      applications: readonly MentionChipApplication[];
     }
   | {
       kind: typeof MENTION_CHIP_KIND.ISSUE;
@@ -2032,6 +2044,10 @@ export function App(): React.JSX.Element {
             providerId: session.providerId,
             providerSessionId: session.providerSessionId,
           },
+          applications: session.applications.map((application) => ({
+            id: application.id,
+            name: application.displayName,
+          })),
         },
       ];
     }),
@@ -3345,6 +3361,24 @@ export function App(): React.JSX.Element {
             >
               <ProviderMark providerId={mention.markId} />
               <span className="session-notice-name">{mention.title}</span>
+              {/* The app marks the session's row already wears, saying where
+                  the chat is also held. Bare marks, never presses of their
+                  own: the chip is one press, and it stays the row press. */}
+              {mention.kind === MENTION_CHIP_KIND.SESSION && mention.applications.length > 0 ? (
+                <span className="session-notice-applications">
+                  {mention.applications.map((application) => (
+                    <span
+                      key={application.id}
+                      className="session-notice-application"
+                      role="img"
+                      aria-label={`Also in ${application.name}`}
+                      title={application.name}
+                    >
+                      <ProviderMark providerId={application.id} />
+                    </span>
+                  ))}
+                </span>
+              ) : null}
             </button>
           ))}
         </span>

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -542,7 +542,9 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
               "off. While he says it, a pressable notice names the session he is talking " +
               "about — under the housing, or at the open panel's foot: pressing it opens the " +
               "session where its provider keeps it, or opens the panel for a local session " +
-              "with no page of its own. The same chips appear while a conversation reply " +
+              "with no page of its own. A session's chip wears the same marks its row " +
+              "does: the agent's own in front, and the apps holding the chat — Conductor, " +
+              "Orca, and kin — trailing the name. The same chips appear while a conversation reply " +
               "names observed sessions by title, or a workspace of grouped chats by its " +
               "name — asking what is being worked on draws one chip per thing named, up to " +
               "a dozen, a workspace's opening its most recent chat. A reply naming tracked " +

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1876,6 +1876,27 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   height: 11px;
 }
 
+/* App associations trail the name as bare marks, the way they trail the
+   title on the session's own row: the leading mark says which agent this
+   is, these say where the same chat is also held. Secondary ink keeps them
+   subordinate to the name inside a chip this small. */
+.session-notice-applications {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 4px;
+  color: var(--text-secondary);
+}
+
+.session-notice-application {
+  display: grid;
+  place-items: center;
+}
+
+.session-notice .provider-mark[data-mark="superset"] {
+  width: 19px;
+}
+
 .session-notice-name {
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## What

The notice band's pressable session chips — the popup under the housing naming what a spoken announcement or reply is about — led with the agent's mark alone. Each now also trails the app marks its session's own row wears (Conductor, Orca, cmux, ChatGPT, Superset), so the chip says not just which chat Luke means but where it is held.

## How

- `MentionChip`'s session variant carries the session's app associations (`id` + display name), copied onto the chip when its mention resolves — like every other chip field, so the band held through its fade-out keeps wearing them after the roster moves on. Issue chips are unchanged.
- The marks render inside the one chip button as bare `role="img"` spans, mirroring the row's non-openable `.row-application` branch — never presses of their own, because the chip is one press and nested buttons aren't a thing. Aria label and title name the app (`Also in Conductor`).
- CSS mirrors `.row-applications`: a fixed trailing seat after the ellipsizing name, secondary ink to stay subordinate to the name, the same 11px mark sizing the chip's leading mark takes, and the Superset wide-mark special case.
- The guide's Announcements fact learns the same detail in the same change, per the renderer rule.

## Testing

- `./scripts/check.sh` passes (exit 0; every suite `fail 0`).
- `./scripts/verify.sh` passes (exit 0). The generated evidence is **byte-identical to main** — including `app-smoke-speaking.png` — which exposed a pre-existing gap rather than proving this change: in a fixture run `bootstrap.sessions` is deliberately empty (`desktop-app.ts` gates it on `runMode.observesProviders`), and the mention chips resolve against that observed roster, so the capture pipeline has never actually photographed the chip band despite `FIXTURE_SPEAKING_CAPTION`'s comment saying the photograph holds both kinds of chip. Left as-is here; worth a follow-up if the evidence should honor that comment again.
- To still see the change working, the packaged fixture app was launched on this Mac and a synthetic roster was injected into the renderer's sessions state over CDP: both session chips drew their trailing app marks (Orca on "Review trust constraints", Conductor on "lisbon-v2"), correctly dimmed, with the leading agent mark and ellipsizing title unchanged.
- No physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32418140675/artifacts/9424709491) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32418140675)

- Commit: `4ac56a647390fc7fbcd133646ec8cdab131bdf40`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
