### PR TITLE
fix(voice): keep the turn open when a reply's audio resumes after a drain

### DIFF
--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -1087,6 +1087,53 @@ test("audio draining before response.done does not free the turn early", async (
   assert.deepEqual(reportedErrors(context), []);
 });
 
+test("audio resuming after a mid-reply drain keeps the turn for the second half", async () => {
+  const context = harness();
+  await context.session.connect();
+  await holdTurn(context);
+  context.session.endTurn(true);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-1" } });
+
+  // A reply with two things to say can drain the buffer between them. The
+  // stop is remembered as a deferred ending, and the audio starting again is
+  // what says it was a pause instead.
+  context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED });
+  context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STARTED });
+
+  // Generation concludes while the second half is still audible. A stale
+  // drain here ended the turn under it — the face and the duck released
+  // while Luke was still speaking.
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_DONE, response: { id: "resp-1" } });
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+
+  // The second half's own drain is the ending that lands.
+  context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED });
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+  assert.deepEqual(reportedErrors(context), []);
+});
+
+test("a drain's backstop restarts when the audio resumes", async (t) => {
+  const context = harness();
+  await context.session.connect();
+  await holdTurn(context);
+  context.session.endTurn(true);
+  context.emit({ type: REALTIME_SERVER_EVENT.RESPONSE_CREATED, response: { id: "resp-1" } });
+
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED });
+  t.mock.timers.tick(REALTIME_SETTLE_TIMEOUT_MS - 1_000);
+
+  // The resume is when Luke was last heard, so the backstop measures from
+  // it: the pause's nearly spent clock must not cut the second half short.
+  context.emit({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STARTED });
+  t.mock.timers.tick(1_000);
+  assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+
+  // A done that never comes still meets the restarted backstop.
+  t.mock.timers.tick(REALTIME_SETTLE_TIMEOUT_MS);
+  assert.equal(context.session.status, REALTIME_STATUS.READY);
+});
+
 test("an announcement queued mid-reply waits out the server's own ending", async () => {
   // The reported shape of the fault, whole: Luke is reading one announcement
   // out on his own call when another agent finishes. The second announcement

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -2257,6 +2257,26 @@ export class RealtimeVoiceSession {
           this.#settleCaptionTranscript(event.itemId, event.transcript);
         }
         return;
+      case REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STARTED:
+        // Audio flowing again says the drain the turn remembered was the
+        // pause between two things the reply had to say, not its ending.
+        // Left standing, the stale drain lets the `done` end the turn under
+        // the second half — the face and the duck released while Luke is
+        // still speaking. Only a resume that is attributably the current
+        // reply's own — or unnamed, the same reading the drain gets — may
+        // un-remember it. The backstop a drain armed is restarted rather
+        // than kept or cleared: kept, its clock ran from the pause and cuts
+        // a resumed half that outlives it; cleared, a `done` that never
+        // comes would hold the turn open with nothing left to end it.
+        if (event.responseId !== undefined && event.responseId !== this.#activeResponseId) {
+          return;
+        }
+        this.#audioDrained = false;
+        if (this.#settleTimer !== undefined) {
+          this.#clearSettleTimer();
+          this.#armSettleTimer();
+        }
+        return;
       case REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED:
         this.#audioEndingsReported = true;
         // The audio can run out while the server still owes the reply its

--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -104,6 +104,14 @@ export const REALTIME_SERVER_EVENT = {
    */
   OUTPUT_AUDIO_BUFFER_STOPPED: "output_audio_buffer.stopped",
   /**
+   * Luke is audible again — the server streaming into a buffer that had
+   * drained. WebRTC only, like its stop, and what makes a mid-reply stop
+   * readable at all: a reply with more than one thing to say can drain the
+   * buffer between them, and only this event says that drain was a pause
+   * rather than the ending.
+   */
+  OUTPUT_AUDIO_BUFFER_STARTED: "output_audio_buffer.started",
+  /**
    * The words of the reply, arriving as they are generated. They run ahead of
    * the audio — the model produces text faster than it speaks it — so they
    * caption the reply in progress rather than subtitling word by word.
@@ -493,6 +501,7 @@ export type ParsedRealtimeServerEvent =
       transcript: string;
     }
   | { type: typeof REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED; responseId?: string }
+  | { type: typeof REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STARTED; responseId?: string }
   | {
       type: typeof REALTIME_SERVER_EVENT.RESPONSE_DONE;
       responseId?: string;
@@ -633,6 +642,16 @@ export function parseRealtimeServerEvent(
       const responseId = optionalString(event.response_id);
       const parsed: ParsedRealtimeServerEvent = {
         type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED,
+      };
+      if (responseId) parsed.responseId = responseId;
+      return parsed;
+    }
+    case REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STARTED: {
+      // The resume names its response the same way, so a stale start cannot
+      // un-remember a drain that was really the current reply's ending.
+      const responseId = optionalString(event.response_id);
+      const parsed: ParsedRealtimeServerEvent = {
+        type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STARTED,
       };
       if (responseId) parsed.responseId = responseId;
       return parsed;

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -1207,6 +1207,17 @@ test("inbound events the conversation acts on are parsed, and nothing else is", 
     }),
     { type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED, responseId: "resp-1" },
   );
+  assert.deepEqual(
+    parseRealtimeServerEvent({ type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STARTED }),
+    { type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STARTED },
+  );
+  assert.deepEqual(
+    parseRealtimeServerEvent({
+      type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STARTED,
+      response_id: "resp-1",
+    }),
+    { type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STARTED, responseId: "resp-1" },
+  );
   assert.deepEqual(parseRealtimeServerEvent({ type: REALTIME_SERVER_EVENT.RESPONSE_DONE }), {
     type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
     calls: [],


### PR DESCRIPTION
## What

Sometimes Luke's talking animation stopped early — and the media duck brought Spotify back to full volume — while he was still audibly speaking. It happened when one reply had multiple things to say back to back.

## Why

When a reply's audio drains the server's output buffer between two stretches of speech, `output_audio_buffer.stopped` arrives while the server still owes the reply its `response.done`. The session correctly remembers that drain as a deferred ending — but `output_audio_buffer.started`, the one event saying the drain was a pause rather than the reply's end, was never parsed at all. The stale drain then let `response.done` (which lands mid-playback, since generation runs ahead of speech) end the turn under the second half. The talking face is cut the instant the RESPONDING status drops, and the duck's release timer fires one second after the exchange goes inactive, so both failed together, exactly as reported.

## How

- `packages/realtime/src/realtime-protocol.ts` — parse `output_audio_buffer.started` (constant, union member, parser case).
- `apps/desktop/src/renderer/realtime-session.ts` — on `started`, forget the remembered drain and restart the settle backstop from the resume rather than keeping the pause's nearly spent clock (which would cut a resumed half that outlives it) or clearing it (which would leave a `done` that never comes with nothing to end the turn).

## Verification

- `./scripts/check.sh` passes (exit 0).
- New tests: protocol parse of `output_audio_buffer.started`; session holds the turn across drain → resume → `done` until the second half's own drain ends it; the settle backstop restarts at the resume.
- No visual or macOS-specific change; `./scripts/verify.sh` was not run (Linux environment), and no physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b42379d9-cd0d-4e42-b178-5199851cb6d6)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32418921637/artifacts/9424983803) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32418921637)

- Commit: `0d7ba391717982bd2b026395e413207026110ba7`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
