### PR TITLE
fix(web): restore the .js extensions the function sources need to load

### DIFF
--- a/apps/web/api/account/delete.ts
+++ b/apps/web/api/account/delete.ts
@@ -1,14 +1,17 @@
 import { eq } from "drizzle-orm";
-import { auth } from "../../server/auth";
-import { getDatabase } from "../../server/db/index";
-import { user } from "../../server/db/schema";
-import { type AccountDeleteOptions, handleAccountDelete } from "../../server/hosted/account-delete";
-import { hostedUserId, oauthUserInfoFromAuthAnswer } from "../../server/hosted/bearer";
+import { auth } from "../../server/auth.js";
+import { getDatabase } from "../../server/db/index.js";
+import { user } from "../../server/db/schema.js";
+import {
+  type AccountDeleteOptions,
+  handleAccountDelete,
+} from "../../server/hosted/account-delete.js";
+import { hostedUserId, oauthUserInfoFromAuthAnswer } from "../../server/hosted/bearer.js";
 import {
   forgetPosthogPerson,
   POSTHOG_ENVIRONMENT,
   type PosthogForgetOptions,
-} from "../../server/hosted/posthog";
+} from "../../server/hosted/posthog.js";
 
 /**
  * Erases the signed-in desktop's account. The logic lives in

--- a/apps/web/api/attention/review.ts
+++ b/apps/web/api/attention/review.ts
@@ -1,9 +1,9 @@
-import { auth } from "../../server/auth";
-import { getDatabase } from "../../server/db/index";
-import { handleAttentionReview } from "../../server/hosted/attention-review";
-import { hostedUserId, oauthUserInfoFromAuthAnswer } from "../../server/hosted/bearer";
-import { HOSTED_OPENAI_ENVIRONMENT } from "../../server/hosted/openai";
-import { HOSTED_METER, spendHostedMeter } from "../../server/hosted/quota";
+import { auth } from "../../server/auth.js";
+import { getDatabase } from "../../server/db/index.js";
+import { handleAttentionReview } from "../../server/hosted/attention-review.js";
+import { hostedUserId, oauthUserInfoFromAuthAnswer } from "../../server/hosted/bearer.js";
+import { HOSTED_OPENAI_ENVIRONMENT } from "../../server/hosted/openai.js";
+import { HOSTED_METER, spendHostedMeter } from "../../server/hosted/quota.js";
 
 /**
  * Reviews one bounded session update for the signed-in desktop, on the key

--- a/apps/web/api/auth/[...all].ts
+++ b/apps/web/api/auth/[...all].ts
@@ -1,4 +1,4 @@
-import { auth } from "../../server/auth";
+import { auth } from "../../server/auth.js";
 
 export default {
   fetch(request: Request): Promise<Response> {

--- a/apps/web/api/events.ts
+++ b/apps/web/api/events.ts
@@ -1,10 +1,10 @@
 import { eq } from "drizzle-orm";
-import { auth } from "../server/auth";
-import { getDatabase } from "../server/db/index";
-import { user } from "../server/db/schema";
-import { hostedUserId } from "../server/hosted/bearer";
-import { type EventsOptions, handleEvents } from "../server/hosted/events";
-import { POSTHOG_ENVIRONMENT } from "../server/hosted/posthog";
+import { auth } from "../server/auth.js";
+import { getDatabase } from "../server/db/index.js";
+import { user } from "../server/db/schema.js";
+import { hostedUserId } from "../server/hosted/bearer.js";
+import { type EventsOptions, handleEvents } from "../server/hosted/events.js";
+import { POSTHOG_ENVIRONMENT } from "../server/hosted/posthog.js";
 
 /**
  * Records what the signed-in desktop counted about its own use. The logic

--- a/apps/web/api/usage.ts
+++ b/apps/web/api/usage.ts
@@ -1,8 +1,8 @@
-import { auth } from "../server/auth";
-import { getDatabase } from "../server/db/index";
-import { hostedUserId, oauthUserInfoFromAuthAnswer } from "../server/hosted/bearer";
-import { readHostedUsage } from "../server/hosted/quota";
-import { handleUsage } from "../server/hosted/usage";
+import { auth } from "../server/auth.js";
+import { getDatabase } from "../server/db/index.js";
+import { hostedUserId, oauthUserInfoFromAuthAnswer } from "../server/hosted/bearer.js";
+import { readHostedUsage } from "../server/hosted/quota.js";
+import { handleUsage } from "../server/hosted/usage.js";
 
 /**
  * Reads today's allowance standing for the signed-in desktop. The logic lives

--- a/apps/web/api/voice/mint.ts
+++ b/apps/web/api/voice/mint.ts
@@ -1,9 +1,9 @@
-import { auth } from "../../server/auth";
-import { getDatabase } from "../../server/db/index";
-import { hostedUserId, oauthUserInfoFromAuthAnswer } from "../../server/hosted/bearer";
-import { HOSTED_OPENAI_ENVIRONMENT } from "../../server/hosted/openai";
-import { HOSTED_METER, spendHostedMeter } from "../../server/hosted/quota";
-import { handleVoiceMint } from "../../server/hosted/voice-mint";
+import { auth } from "../../server/auth.js";
+import { getDatabase } from "../../server/db/index.js";
+import { hostedUserId, oauthUserInfoFromAuthAnswer } from "../../server/hosted/bearer.js";
+import { HOSTED_OPENAI_ENVIRONMENT } from "../../server/hosted/openai.js";
+import { HOSTED_METER, spendHostedMeter } from "../../server/hosted/quota.js";
+import { handleVoiceMint } from "../../server/hosted/voice-mint.js";
 
 /**
  * Mints one ephemeral Realtime credential for the signed-in desktop, on the

--- a/apps/web/server/auth.ts
+++ b/apps/web/server/auth.ts
@@ -2,10 +2,14 @@ import { drizzleAdapter } from "@better-auth/drizzle-adapter";
 import { oauthProvider } from "@better-auth/oauth-provider";
 import { betterAuth } from "better-auth";
 import { jwt, lastLoginMethod } from "better-auth/plugins";
-import { ACCOUNT_TOKEN_STORAGE, denyOAuthClientPrivileges, JWT_KEY_STORAGE } from "./auth-policy";
-import { getDatabase } from "./db/index";
-import * as schema from "./db/schema";
-import { DESKTOP_OAUTH_CLIENT } from "./desktop-oauth-client";
+import {
+  ACCOUNT_TOKEN_STORAGE,
+  denyOAuthClientPrivileges,
+  JWT_KEY_STORAGE,
+} from "./auth-policy.js";
+import { getDatabase } from "./db/index.js";
+import * as schema from "./db/schema.js";
+import { DESKTOP_OAUTH_CLIENT } from "./desktop-oauth-client.js";
 
 export const DESKTOP_OAUTH_CLIENT_ID = DESKTOP_OAUTH_CLIENT.id;
 

--- a/apps/web/server/db/index.ts
+++ b/apps/web/server/db/index.ts
@@ -1,6 +1,6 @@
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
-import * as schema from "./schema";
+import * as schema from "./schema.js";
 
 /** Bounded so one warm function instance cannot monopolize Neon's pooler. */
 export const POOL_LIMITS = {

--- a/apps/web/server/db/schema.ts
+++ b/apps/web/server/db/schema.ts
@@ -1,4 +1,4 @@
 // Better Auth owns its generated schema; Luke-owned tables can join this
 // aggregate from their own schema modules without being overwritten by it.
-export * from "./auth-schema";
-export * from "./usage-schema";
+export * from "./auth-schema.js";
+export * from "./usage-schema.js";

--- a/apps/web/server/db/usage-schema.ts
+++ b/apps/web/server/db/usage-schema.ts
@@ -1,5 +1,5 @@
 import { integer, pgTable, primaryKey, text } from "drizzle-orm/pg-core";
-import { user } from "./auth-schema";
+import { user } from "./auth-schema.js";
 
 /**
  * What one signed-in user spent of the hosted allowance on one UTC day. The

--- a/apps/web/server/hosted/account-delete.ts
+++ b/apps/web/server/hosted/account-delete.ts
@@ -1,4 +1,4 @@
-import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http";
+import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
 
 /**
  * Deletes the signed-in user's account. The bearer token is the whole

--- a/apps/web/server/hosted/attention-review.ts
+++ b/apps/web/server/hosted/attention-review.ts
@@ -7,16 +7,16 @@ import {
   attentionResponsesRequest,
   text as trimmedText,
   type UnparsedWireValue,
-} from "../core";
+} from "../core.js";
 import {
   errorResponse,
   HOSTED_API_ERROR,
   HOSTED_HTTP_STATUS,
   type HostedErrorFields,
   jsonResponse,
-} from "./http";
-import { type FetchLike, postOpenAi } from "./openai";
-import type { HostedSpend } from "./quota";
+} from "./http.js";
+import { type FetchLike, postOpenAi } from "./openai.js";
+import type { HostedSpend } from "./quota.js";
 
 /**
  * Reviews one bounded session update on Luke's own key for a signed-in user.

--- a/apps/web/server/hosted/bearer.ts
+++ b/apps/web/server/hosted/bearer.ts
@@ -1,4 +1,4 @@
-import { isRecord, text, type UnparsedWireValue } from "../core";
+import { isRecord, text, type UnparsedWireValue } from "../core.js";
 
 /** The subject a signed-in OAuth userinfo answer names. */
 export interface OAuthUserInfo {

--- a/apps/web/server/hosted/events.ts
+++ b/apps/web/server/hosted/events.ts
@@ -3,8 +3,8 @@ import {
   productEventBatchFromWire,
   text as trimmedText,
   type UnparsedWireValue,
-} from "../core";
-import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http";
+} from "../core.js";
+import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
 import {
   type FetchLike,
   type PosthogBatch,
@@ -12,7 +12,7 @@ import {
   type PosthogPerson,
   type PosthogUpstreamOptions,
   postPosthogBatch,
-} from "./posthog";
+} from "./posthog.js";
 
 /**
  * Records what the signed-in desktop counted about its own use. The desktop

--- a/apps/web/server/hosted/http.ts
+++ b/apps/web/server/hosted/http.ts
@@ -1,4 +1,4 @@
-import type { HostedApiError, HostedQuota } from "../core";
+import type { HostedApiError, HostedQuota } from "../core.js";
 
 /**
  * The response vocabulary the hosted endpoints share. Every answer is JSON,
@@ -7,7 +7,7 @@ import type { HostedApiError, HostedQuota } from "../core";
  * clients validate against, so an error slug cannot drift between the two.
  */
 
-export { HOSTED_API_ERROR, type HostedApiError } from "../core";
+export { HOSTED_API_ERROR, type HostedApiError } from "../core.js";
 
 export const HOSTED_HTTP_STATUS = {
   OK: 200,

--- a/apps/web/server/hosted/openai.ts
+++ b/apps/web/server/hosted/openai.ts
@@ -5,7 +5,7 @@
  * off, the same kill switch the feedback endpoint uses.
  */
 
-import type { attentionResponsesRequest, realtimeClientSecretRequest } from "../core";
+import type { attentionResponsesRequest, realtimeClientSecretRequest } from "../core.js";
 
 export const HOSTED_OPENAI_ENVIRONMENT = {
   API_KEY: "OPENAI_API_KEY",

--- a/apps/web/server/hosted/quota.ts
+++ b/apps/web/server/hosted/quota.ts
@@ -1,7 +1,7 @@
 import { and, eq, sql } from "drizzle-orm";
-import type { HostedQuota, HostedUsageAnswer } from "../core";
-import type { createDatabase } from "../db/index";
-import { hostedUsage } from "../db/usage-schema";
+import type { HostedQuota, HostedUsageAnswer } from "../core.js";
+import type { createDatabase } from "../db/index.js";
+import { hostedUsage } from "../db/usage-schema.js";
 
 /** The two things the hosted tier spends, each metered on its own ceiling. */
 export const HOSTED_METER = {
@@ -24,7 +24,7 @@ export const HOSTED_DAILY_LIMIT = {
 
 /* The quota shape is the wire contract's, imported rather than restated, so
    the endpoint and the desktop reading it cannot drift. */
-export type { HostedQuota } from "../core";
+export type { HostedQuota } from "../core.js";
 
 export interface HostedSpend {
   allowed: boolean;

--- a/apps/web/server/hosted/usage.ts
+++ b/apps/web/server/hosted/usage.ts
@@ -1,5 +1,5 @@
-import type { HostedUsageAnswer } from "../core";
-import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http";
+import type { HostedUsageAnswer } from "../core.js";
+import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
 
 /**
  * Answers where today's allowance stands, spending nothing. This is the one

--- a/apps/web/server/hosted/voice-mint.ts
+++ b/apps/web/server/hosted/voice-mint.ts
@@ -12,10 +12,10 @@ import {
   realtimeCredentialIsUsable,
   text as trimmedText,
   type UnparsedWireValue,
-} from "../core";
-import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http";
-import { type FetchLike, HOSTED_OPENAI_DEFAULTS, postOpenAi } from "./openai";
-import type { HostedSpend } from "./quota";
+} from "../core.js";
+import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
+import { type FetchLike, HOSTED_OPENAI_DEFAULTS, postOpenAi } from "./openai.js";
+import type { HostedSpend } from "./quota.js";
 
 /**
  * Mints one ephemeral Realtime credential on Luke's own key for a signed-in

--- a/apps/web/server/seed-desktop-client.ts
+++ b/apps/web/server/seed-desktop-client.ts
@@ -1,7 +1,7 @@
 import { pathToFileURL } from "node:url";
-import { oauthClient } from "./db/auth-schema";
-import { getDatabase } from "./db/index";
-import { desktopOAuthClientRecord } from "./desktop-oauth-client";
+import { oauthClient } from "./db/auth-schema.js";
+import { getDatabase } from "./db/index.js";
+import { desktopOAuthClientRecord } from "./desktop-oauth-client.js";
 
 type SeedDatabase = Pick<ReturnType<typeof getDatabase>, "insert">;
 

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -99,18 +99,27 @@ if [[ -n "$generic_safety" ]]; then
     exit 1
 fi
 
-# Every relative import inside a package must carry its .js extension.
-# Vercel's builder compiles the packages' TypeScript into the web functions but
+# Every relative import the Vercel builder compiles must carry its .js
+# extension. The builder compiles this TypeScript into the web functions but
 # leaves the specifiers alone, and Node's ESM loader refuses an extensionless
 # one at run time — a break the build cannot see and production reports only as
 # FUNCTION_INVOCATION_FAILED. The desktop's esbuild and the web's Vite both
 # accept the .js form, so the stricter spelling costs the other consumers
-# nothing. Checked across every package rather than one, so a new package
-# cannot silently opt out of the rule that keeps the functions loadable.
-extensionless_imports=$(grep -rEn 'from "\.\.?/[^"]*"' "$SIDECAR_REPO_ROOT"/packages/*/src |
+# nothing.
+#
+# The function sources are checked alongside the packages because the builder
+# treats them identically: `apps/web/api` and `apps/web/server` are the entry
+# points of the very graph the doors in `server/core.ts` exist to pull in, so a
+# rule enforced on the packages alone leaves the two directories nearest the
+# failure uncovered. Side-effect imports count — a door is spelled `import "…"`
+# with no names, and an extensionless one fails exactly the same way.
+extensionless_imports=$(grep -rEn '(from|import) "\.\.?/[^"]*"' \
+    "$SIDECAR_REPO_ROOT"/packages/*/src \
+    "$SIDECAR_REPO_ROOT"/apps/web/api \
+    "$SIDECAR_REPO_ROOT"/apps/web/server |
     grep -vE '\.(js|css)"' || true)
 if [[ -n "$extensionless_imports" ]]; then
-    printf 'error: relative imports inside packages/ must end in .js (Node ESM cannot load them compiled otherwise):\n%s\n' \
+    printf 'error: relative imports in packages/ and the web function sources must end in .js (Node ESM cannot load them compiled otherwise):\n%s\n' \
         "$extensionless_imports" >&2
     exit 1
 fi


### PR DESCRIPTION
## What broke

Every serverless function on `tryluke.dev` was crashing at module load. Static pages were fine, so the site looked half-up: sign-in failed and the usage bars never rendered, because `/api/auth/*` and `/api/usage` both answered `500 FUNCTION_INVOCATION_FAILED`.

Production logs name it exactly:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/var/task/apps/web/server/auth'
  imported from /var/task/apps/web/api/events.js
```

`apps/web` is `"type": "module"`, so Vercel's builder compiles each function's TypeScript to ESM and leaves the import specifiers alone — and Node's ESM loader refuses an extensionless relative one.

## Root cause

#321 stripped `.js` off all 63 relative imports in `apps/web/api` and `apps/web/server`:

```diff
-import { auth } from "../../server/auth.js";
+import { auth } from "../../server/auth";
```

Every route imports `server/auth`, so every route died. `api/feedback.mjs` imports nothing and kept answering `405` rather than `500` — that asymmetry is what located the break.

The rule was already written down, and `repository-checks.sh` already enforced it — but only across `packages/*/src`, so the two directories nearest the failure were the ones left uncovered.

## The fix

- Restored `.js` on all 63 relative imports, each resolved against a real file rather than blind-patched. `api/usage.ts`'s specifier set now diffs identical to its pre-#321 state.
- Widened the `repository-checks.sh` guard to check the function sources beside the packages, and to recognize the side-effect `import "…"` form the doors in `core.ts` are spelled with — the previous pattern matched `from "…"` alone.

## Verification

- **Causal proof:** compiled the tree to ESM the way the builder does and loaded the route under Node — it loads. Stripping the extension back out of the *compiled* output reproduces `ERR_MODULE_NOT_FOUND` with production's exact shape, so the fix is confirmed against the real failure rather than a proxy for it.
- **Guard negative test:** reintroducing one extensionless import fails the check, naming the file and line.
- `./scripts/check.sh` → exit 0 (24 suites clean, `apps/web` 53/53), before and after rebasing onto `main`.

Portable-only change — no macOS or UI surface is touched, so `check.sh` is the completion invariant here and no visual evidence applies.

Nothing local reported any of this: `moduleResolution: "Bundler"` accepts the extensionless spelling, so typecheck, `check.sh`, CI, and local dev all pass either way. The guard is the part that keeps it from happening a third time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32419432951/artifacts/9425169657) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32419432951)

- Commit: `3eba2cbd7d77a07e17c72fdc3bc36ccac2f3a45a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
