### PR TITLE
fix(voice): pace unbidden speech around the developer's conversation

### DIFF
--- a/apps/desktop/src/renderer/spoken-notices.test.ts
+++ b/apps/desktop/src/renderer/spoken-notices.test.ts
@@ -4,6 +4,7 @@ import type { RealtimeStatus, ScheduledTimer } from "@sidecar/realtime";
 import { ATTENTION_SPEECH_SOURCE, type AttentionSpeech, REALTIME_STATUS } from "@sidecar/realtime";
 import { ATTENTION_DISPOSITION } from "@sidecar/session";
 import {
+  ANNOUNCER_GRACE_MS,
   ANNOUNCER_LINGER_MS,
   ANNOUNCER_RETRY_DELAY_MS,
   type AnnouncerSession,
@@ -590,4 +591,123 @@ test("a summary that went stale in the wait is dropped, not read as news", () =>
   session.setStatus(REALTIME_STATUS.READY);
   subject.onStatus(REALTIME_STATUS.READY);
   assert.deepEqual<AttentionSpeech[]>(session.spoken, []);
+});
+
+test("an announcement waits out the developer's floor after Luke answers them", () => {
+  const session = fakeSession();
+  session.microphone = true;
+  const timers = fakeTimers();
+  let now = 1_000;
+  const subject = announcer(session, timers, () => now);
+
+  // A full exchange: the developer asks, Luke answers, the reply ends.
+  session.setStatus(REALTIME_STATUS.LISTENING);
+  subject.onStatus(REALTIME_STATUS.LISTENING);
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  subject.onStatus(REALTIME_STATUS.RESPONDING);
+
+  // News arrives mid-reply and again right after: the pause belongs to the
+  // developer's next ask, not to the backlog.
+  subject.enqueue([speech("a")]);
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.deepEqual<AttentionSpeech[]>(session.spoken, []);
+
+  // Half the window passes in silence; a straggler still may not speak.
+  now = 1_000 + ANNOUNCER_GRACE_MS / 2;
+  subject.enqueue([speech("b")]);
+  assert.deepEqual<AttentionSpeech[]>(session.spoken, []);
+
+  // The developer left the pause empty; the backlog takes it.
+  now = 1_000 + ANNOUNCER_GRACE_MS;
+  timers.fire();
+  assert.deepEqual(
+    session.spoken.map((item) => item.providerSessionId),
+    ["a"],
+  );
+
+  // And chains without a second window: the readout is already Luke's turn.
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.deepEqual(
+    session.spoken.map((item) => item.providerSessionId),
+    ["a", "b"],
+  );
+});
+
+test("the developer speaking inside the window keeps the floor theirs", () => {
+  const session = fakeSession();
+  session.microphone = true;
+  const timers = fakeTimers();
+  let now = 1_000;
+  const subject = announcer(session, timers, () => now);
+
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  subject.onStatus(REALTIME_STATUS.RESPONDING);
+  subject.enqueueRide([summarySpeech("s")]);
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.deepEqual<AttentionSpeech[]>(session.spoken, []);
+
+  // The developer takes the turn inside the window — the grace did its job —
+  // and Luke's answer to them ends with a fresh window, not a spent one.
+  now = 1_000 + ANNOUNCER_GRACE_MS / 2;
+  session.setStatus(REALTIME_STATUS.LISTENING);
+  subject.onStatus(REALTIME_STATUS.LISTENING);
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  subject.onStatus(REALTIME_STATUS.RESPONDING);
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  timers.fire();
+  assert.deepEqual<AttentionSpeech[]>(session.spoken, []);
+
+  // Only the pause after the second answer, left empty, is spoken into.
+  now = 1_000 + ANNOUNCER_GRACE_MS / 2 + ANNOUNCER_GRACE_MS;
+  timers.fire();
+  assert.deepEqual(
+    session.spoken.map((item) => item.providerSessionId),
+    ["s"],
+  );
+});
+
+test("the retry clock respects the developer's floor", () => {
+  const session = fakeSession();
+  session.microphone = true;
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  const timers = fakeTimers();
+  let now = 1_000;
+  const subject = announcer(session, timers, () => now);
+
+  subject.onStatus(REALTIME_STATUS.RESPONDING);
+  subject.enqueue([speech("a")]);
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+
+  // Every armed clock firing inside the window still finds the floor held.
+  now = 1_000 + ANNOUNCER_GRACE_MS - 1;
+  timers.fire();
+  assert.deepEqual<AttentionSpeech[]>(session.spoken, []);
+
+  now = 1_000 + ANNOUNCER_GRACE_MS;
+  timers.fire();
+  assert.deepEqual(
+    session.spoken.map((item) => item.providerSessionId),
+    ["a"],
+  );
+});
+
+test("a notice on Luke's own call speaks without the developer's window", async () => {
+  const session = fakeSession();
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  // Nobody is conversing: the window guards the developer's next ask, and
+  // on Luke's own call there is no ask to guard.
+  subject.enqueue([speech("a")]);
+  await Promise.resolve();
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.deepEqual(
+    session.spoken.map((item) => item.providerSessionId),
+    ["a"],
+  );
 });

--- a/apps/desktop/src/renderer/spoken-notices.test.ts
+++ b/apps/desktop/src/renderer/spoken-notices.test.ts
@@ -435,3 +435,159 @@ test("a sentence that went stale in the queue is dropped, not read as news", () 
   subject.onStatus(REALTIME_STATUS.READY);
   assert.deepEqual<AttentionSpeech[]>(session.spoken, []);
 });
+
+/** An unbidden evaluator summary, which may only ride the developer's call. */
+function summarySpeech(id: string, decidedAt = 1_000): AttentionSpeech {
+  return {
+    providerId: "claude-code",
+    providerSessionId: id,
+    disposition: ATTENTION_DISPOSITION.SPEAK_AT_TURN_END,
+    source: ATTENTION_SPEECH_SOURCE.EVALUATOR,
+    summary: `The agent on "${id}" is still at it.`,
+    decidedAt,
+  };
+}
+
+test("a batch of summaries rides the developer's call one READY edge at a time", () => {
+  const session = fakeSession();
+  session.microphone = true;
+  session.setStatus(REALTIME_STATUS.READY);
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  // One review pass decided two summaries at once. The first takes the turn;
+  // the second used to be refused against it and lost.
+  subject.enqueueRide([summarySpeech("a"), summarySpeech("b")]);
+  assert.deepEqual(
+    session.spoken.map((item) => item.providerSessionId),
+    ["a"],
+  );
+
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.deepEqual(
+    session.spoken.map((item) => item.providerSessionId),
+    ["a", "b"],
+  );
+  assert.equal(session.connects, 0, "the developer's call was ridden, never replaced");
+});
+
+test("a summary arriving mid-reply waits for the turn to end", () => {
+  const session = fakeSession();
+  session.microphone = true;
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  subject.enqueueRide([summarySpeech("a")]);
+  assert.deepEqual<AttentionSpeech[]>(session.spoken, []);
+
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.deepEqual(
+    session.spoken.map((item) => item.providerSessionId),
+    ["a"],
+  );
+});
+
+test("a summary never opens a call of Luke's own", async () => {
+  const session = fakeSession();
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  // No call is up, so there is nothing for a summary to ride: it is dropped
+  // rather than held for a call it must not open.
+  subject.enqueueRide([summarySpeech("a")]);
+  await Promise.resolve();
+  assert.equal(session.connects, 0);
+  timers.fire();
+  await Promise.resolve();
+  assert.equal(session.connects, 0);
+  assert.deepEqual<AttentionSpeech[]>(session.spoken, []);
+});
+
+test("a waiting summary dies with the call it was riding", async () => {
+  const session = fakeSession();
+  session.microphone = true;
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  subject.enqueueRide([summarySpeech("a")]);
+  assert.deepEqual<AttentionSpeech[]>(session.spoken, []);
+
+  // The developer hangs up before the reply's end ever frees an edge.
+  session.microphone = false;
+  session.setStatus(REALTIME_STATUS.IDLE);
+  subject.onStatus(REALTIME_STATUS.IDLE);
+
+  // A notice later opens Luke's own call, and the orphaned summary must not
+  // ride it: that call is not the one the developer opened.
+  subject.enqueue([speech("n")]);
+  await Promise.resolve();
+  timers.fire();
+  await Promise.resolve();
+  assert.deepEqual(
+    session.spoken.map((item) => item.providerSessionId),
+    ["n"],
+  );
+});
+
+test("notices outrank summaries on the same READY edge", () => {
+  const session = fakeSession();
+  session.microphone = true;
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  // Both wait out the same reply: the notice the developer asked to hear
+  // and a summary nobody asked about.
+  subject.enqueueRide([summarySpeech("s")]);
+  subject.enqueue([speech("n")]);
+
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.deepEqual(
+    session.spoken.map((item) => item.providerSessionId),
+    ["n"],
+  );
+
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.deepEqual(
+    session.spoken.map((item) => item.providerSessionId),
+    ["n", "s"],
+  );
+});
+
+test("quiet beginning drops the summaries waiting for an edge", () => {
+  const session = fakeSession();
+  session.microphone = true;
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  const timers = fakeTimers();
+  const subject = announcer(session, timers);
+
+  subject.enqueueRide([summarySpeech("a")]);
+  subject.setMeetingQuiet(true);
+  subject.setMeetingQuiet(false);
+
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.deepEqual<AttentionSpeech[]>(session.spoken, []);
+});
+
+test("a summary that went stale in the wait is dropped, not read as news", () => {
+  const session = fakeSession();
+  session.microphone = true;
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  const timers = fakeTimers();
+  let now = 10_000;
+  const subject = announcer(session, timers, () => now);
+
+  subject.enqueueRide([summarySpeech("a", 10_000)]);
+
+  now = 10_000 + SPOKEN_NOTICE_MAX_AGE_MS + 1;
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  assert.deepEqual<AttentionSpeech[]>(session.spoken, []);
+});

--- a/apps/desktop/src/renderer/spoken-notices.test.ts
+++ b/apps/desktop/src/renderer/spoken-notices.test.ts
@@ -711,3 +711,43 @@ test("a notice on Luke's own call speaks without the developer's window", async 
     ["a"],
   );
 });
+
+test("the developer taking the turn stands the grace clock down", () => {
+  const session = fakeSession();
+  session.microphone = true;
+  const timers = fakeTimers();
+  let now = 1_000;
+  const subject = announcer(session, timers, () => now);
+
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  subject.onStatus(REALTIME_STATUS.RESPONDING);
+  subject.enqueue([speech("a")]);
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  const armedDuringWindow = timers.armed();
+
+  // The press is what the window waited for: the clock aimed at the pause
+  // stands down rather than firing into the developer's own turn.
+  session.setStatus(REALTIME_STATUS.LISTENING);
+  subject.onStatus(REALTIME_STATUS.LISTENING);
+  assert.ok(timers.armed() < armedDuringWindow);
+
+  // Every clock still standing fires into the busy turn and speaks nothing.
+  session.setStatus(REALTIME_STATUS.RESPONDING);
+  subject.onStatus(REALTIME_STATUS.RESPONDING);
+  now = 1_000 + ANNOUNCER_GRACE_MS * 2;
+  timers.fire();
+  assert.deepEqual<AttentionSpeech[]>(session.spoken, []);
+
+  // The answer's own end opens the next window, on a clock of its own.
+  session.setStatus(REALTIME_STATUS.READY);
+  subject.onStatus(REALTIME_STATUS.READY);
+  timers.fire();
+  assert.deepEqual<AttentionSpeech[]>(session.spoken, []);
+  now = 1_000 + ANNOUNCER_GRACE_MS * 3;
+  timers.fire();
+  assert.deepEqual(
+    session.spoken.map((item) => item.providerSessionId),
+    ["a"],
+  );
+});

--- a/apps/desktop/src/renderer/spoken-notices.ts
+++ b/apps/desktop/src/renderer/spoken-notices.ts
@@ -209,10 +209,13 @@ export class SpokenNoticeAnnouncer {
       this.#ownsCall = false;
       this.#cancelLinger();
     }
-    // The developer taking the turn is the very act the floor was theirs for,
-    // and whatever reply follows is an answer to them, not a readout.
+    // The developer taking the turn is the very act the floor was theirs for:
+    // whatever reply follows is an answer to them, not a readout, and the
+    // clock waiting to speak into their pause has nothing left to wait for —
+    // the reply's own end starts the next window.
     if (status === REALTIME_STATUS.LISTENING) {
       this.#ownReply = false;
+      this.#cancelHold();
       return;
     }
     if (status === REALTIME_STATUS.READY) {
@@ -229,6 +232,9 @@ export class SpokenNoticeAnnouncer {
         this.#options.session().microphoneCall
       ) {
         this.#holdUntil = (this.#options.now?.() ?? Date.now()) + ANNOUNCER_GRACE_MS;
+        // A fresh window gets a fresh clock: one still armed for an older
+        // window would come back early and find the floor still held.
+        this.#cancelHold();
       }
       this.#flush();
       return;

--- a/apps/desktop/src/renderer/spoken-notices.ts
+++ b/apps/desktop/src/renderer/spoken-notices.ts
@@ -77,6 +77,15 @@ export interface SpokenNoticeAnnouncerOptions {
  * A backlog that outlives its attempts is dropped, because every notice is
  * still standing in the panel.
  *
+ * An evaluator summary is a narrower passenger. It may only ride the
+ * developer's own call — never open one — so it waits here for that call's
+ * next READY edge instead of being refused against a busy turn and lost:
+ * one review pass can decide several summaries at once, and the first
+ * taking the turn left the rest nowhere to go. The wait is the call's own:
+ * a summary is dropped the moment the developer's call ends, ages out like
+ * a notice does, and yields every edge to the notices the developer asked
+ * to hear.
+ *
  * The meeting quiet reaches it through {@link setMeetingQuiet}: quiet
  * beginning silences it at once — the announcement mid-sentence on Luke's
  * own call included — and holds it silent until the quiet ends.
@@ -84,6 +93,12 @@ export interface SpokenNoticeAnnouncerOptions {
 export class SpokenNoticeAnnouncer {
   readonly #options: SpokenNoticeAnnouncerOptions;
   #queue: AttentionSpeech[] = [];
+  /**
+   * Evaluator summaries waiting for the developer's own call to pause. They
+   * may only ride that call: nothing here opens one for them, and they are
+   * dropped the moment the call they were waiting on ends.
+   */
+  #rideQueue: AttentionSpeech[] = [];
   /** Whether the call now up is one this announcer opened, and so must close. */
   #ownsCall = false;
   #lingerTimer: unknown;
@@ -113,6 +128,7 @@ export class SpokenNoticeAnnouncer {
     this.#quiet = active;
     if (!active) return;
     this.#queue = [];
+    this.#rideQueue = [];
     this.#connectAttempts = 0;
     this.#cancelRetry();
     this.#cancelLinger();
@@ -134,6 +150,24 @@ export class SpokenNoticeAnnouncer {
       this.#queue = this.#queue.slice(this.#queue.length - MAXIMUM_QUEUED_NOTICES);
     }
     this.#cancelLinger();
+    this.#flush();
+  }
+
+  /**
+   * Takes evaluator summaries, which may only ride the developer's open call.
+   * A summary arriving while Luke is mid-reply — or several deciding at once,
+   * which one review pass can produce — waits for the READY edge the queue
+   * already paces itself by, instead of being refused against the busy turn
+   * and lost. Nothing here may open a call: a summary with no developer's
+   * call to ride is dropped, still standing in the panel.
+   */
+  enqueueRide(summaries: readonly AttentionSpeech[]): void {
+    if (this.#quiet || summaries.length === 0) return;
+    if (!this.#options.session().microphoneCall) return;
+    this.#rideQueue.push(...summaries);
+    if (this.#rideQueue.length > MAXIMUM_QUEUED_NOTICES) {
+      this.#rideQueue = this.#rideQueue.slice(this.#rideQueue.length - MAXIMUM_QUEUED_NOTICES);
+    }
     this.#flush();
   }
 
@@ -160,6 +194,9 @@ export class SpokenNoticeAnnouncer {
     ) {
       this.#cancelLinger();
       this.#ownsCall = false;
+      // The call a summary was riding is gone, and it may ride no other:
+      // what it said is still standing in the panel.
+      this.#rideQueue = [];
       // The backlog survives the call it was waiting on — a developer's call
       // that ended mid-queue, or Luke's own that dropped — and the retry clock
       // is what picks it back up. The connect path arms the same clock when an
@@ -175,18 +212,30 @@ export class SpokenNoticeAnnouncer {
     const now = this.#options.now?.() ?? Date.now();
     this.#queue = this.#queue.filter((item) => now - item.decidedAt <= SPOKEN_NOTICE_MAX_AGE_MS);
     const session = this.#options.session();
-    if (this.#queue.length === 0) {
+    // A summary may only ride the developer's own call, so the call no longer
+    // being theirs takes the wait with it, and age fells the rest.
+    this.#rideQueue = session.microphoneCall
+      ? this.#rideQueue.filter((item) => now - item.decidedAt <= SPOKEN_NOTICE_MAX_AGE_MS)
+      : [];
+    if (this.#queue.length === 0 && this.#rideQueue.length === 0) {
       this.#connectAttempts = 0;
       this.#armLinger();
       return;
     }
     if (session.isConnected) {
       // One reply at a time: the first speak takes the turn and the second is
-      // refused, so the loop stops itself and READY resumes it.
+      // refused, so the loop stops itself and READY resumes it. Notices go
+      // first — the developer asked to hear them — and a summary rides only
+      // the edges the notices leave.
       while (this.#queue.length > 0) {
         const next = this.#queue[0];
         if (!next || !session.speak(next)) break;
         this.#queue.shift();
+      }
+      while (this.#queue.length === 0 && this.#rideQueue.length > 0) {
+        const next = this.#rideQueue[0];
+        if (!next || !session.speak(next)) break;
+        this.#rideQueue.shift();
       }
       // A backlog waiting on a refused speak is normally resumed by the READY
       // edge, but that edge is the session's promise, not this class's: the
@@ -197,6 +246,10 @@ export class SpokenNoticeAnnouncer {
       return;
     }
     if (session.isConnecting) return;
+    // Only a notice may open a call of Luke's own: a summary with nothing to
+    // ride was already dropped above, and opening for one would turn a
+    // passenger into a driver.
+    if (this.#queue.length === 0) return;
     // Silence, and something to say into it: open a call of Luke's own.
     this.#connectAttempts += 1;
     this.#ownsCall = true;
@@ -240,7 +293,7 @@ export class SpokenNoticeAnnouncer {
    * in {@link #retreatOrRetry} are what keep the clock from ticking forever.
    */
   #armRetry(): void {
-    if (this.#queue.length === 0) return;
+    if (this.#queue.length === 0 && this.#rideQueue.length === 0) return;
     this.#retryTimer ??= (this.#options.schedule ?? setTimeout)(() => {
       this.#retryTimer = undefined;
       this.#flush();

--- a/apps/desktop/src/renderer/spoken-notices.ts
+++ b/apps/desktop/src/renderer/spoken-notices.ts
@@ -37,6 +37,16 @@ export const ANNOUNCER_RETRY_DELAY_MS = 20_000;
 export const MAXIMUM_CONNECT_ATTEMPTS = 3;
 
 /**
+ * How long the developer keeps the floor once Luke has answered them. A reply
+ * invites the next ask, and an announcement speaking into that pause takes
+ * the very turn the developer was about to open — so the queue waits, and
+ * only a pause the developer leaves empty is announced into. Luke's own
+ * announcements chain without waiting: the readout is already his turn, and
+ * a backlog read one sentence per window would outlive its own news.
+ */
+export const ANNOUNCER_GRACE_MS = 10_000;
+
+/**
  * The slice of the voice session the announcer drives. `microphoneCall` is the
  * ownership question: true means the call up or coming is the developer's own,
  * which the announcer may speak on but must never close.
@@ -89,6 +99,12 @@ export interface SpokenNoticeAnnouncerOptions {
  * The meeting quiet reaches it through {@link setMeetingQuiet}: quiet
  * beginning silences it at once — the announcement mid-sentence on Luke's
  * own call included — and holds it silent until the quiet ends.
+ *
+ * On the developer's own call, a reply Luke just gave them holds the whole
+ * backlog for {@link ANNOUNCER_GRACE_MS}: the pause after an answer is where
+ * the developer's next ask lives, and an announcement speaking into it takes
+ * that turn from them. Luke's own announcements chain without the wait — the
+ * readout is already his turn.
  */
 export class SpokenNoticeAnnouncer {
   readonly #options: SpokenNoticeAnnouncerOptions;
@@ -101,6 +117,13 @@ export class SpokenNoticeAnnouncer {
   #rideQueue: AttentionSpeech[] = [];
   /** Whether the call now up is one this announcer opened, and so must close. */
   #ownsCall = false;
+  /** The last status seen, which tells a reply's READY from a connect's. */
+  #lastStatus: RealtimeStatus | undefined;
+  /** Whether the reply now under way — or just ended — is one this announcer spoke. */
+  #ownReply = false;
+  /** Until when the developer keeps the floor, as the injected clock reads it. */
+  #holdUntil = 0;
+  #holdTimer: unknown;
   #lingerTimer: unknown;
   /** How many times the backlog now queued has tried to open Luke's own call. */
   #connectAttempts = 0;
@@ -131,6 +154,7 @@ export class SpokenNoticeAnnouncer {
     this.#rideQueue = [];
     this.#connectAttempts = 0;
     this.#cancelRetry();
+    this.#cancelHold();
     this.#cancelLinger();
     if (!this.#ownsCall) return;
     this.#ownsCall = false;
@@ -177,13 +201,35 @@ export class SpokenNoticeAnnouncer {
    * linger toward closing Luke's own call.
    */
   onStatus(status: RealtimeStatus): void {
+    const previous = this.#lastStatus;
+    this.#lastStatus = status;
     // The developer's call replaced or absorbed Luke's; nothing here may
     // close it, however it ends.
     if (this.#options.session().microphoneCall) {
       this.#ownsCall = false;
       this.#cancelLinger();
     }
+    // The developer taking the turn is the very act the floor was theirs for,
+    // and whatever reply follows is an answer to them, not a readout.
+    if (status === REALTIME_STATUS.LISTENING) {
+      this.#ownReply = false;
+      return;
+    }
     if (status === REALTIME_STATUS.READY) {
+      const own = this.#ownReply;
+      this.#ownReply = false;
+      // A reply to the developer invites their next ask, and an announcement
+      // speaking into that pause takes the very turn they were about to
+      // open: the floor stays the developer's for the grace window, and only
+      // a pause they leave empty is announced into. Only a READY that ends a
+      // reply holds the floor — one that opens the call has answered nothing.
+      if (
+        !own &&
+        previous === REALTIME_STATUS.RESPONDING &&
+        this.#options.session().microphoneCall
+      ) {
+        this.#holdUntil = (this.#options.now?.() ?? Date.now()) + ANNOUNCER_GRACE_MS;
+      }
       this.#flush();
       return;
     }
@@ -193,6 +239,10 @@ export class SpokenNoticeAnnouncer {
       status === REALTIME_STATUS.UNAVAILABLE
     ) {
       this.#cancelLinger();
+      // The conversation the floor was being held for is gone with the call.
+      this.#cancelHold();
+      this.#holdUntil = 0;
+      this.#ownReply = false;
       this.#ownsCall = false;
       // The call a summary was riding is gone, and it may ride no other:
       // what it said is still standing in the panel.
@@ -223,6 +273,13 @@ export class SpokenNoticeAnnouncer {
       return;
     }
     if (session.isConnected) {
+      // The developer keeps the floor for the grace window after Luke answers
+      // them; the backlog comes back when the window closes.
+      const floorHeld = this.#holdUntil - now;
+      if (floorHeld > 0 && session.microphoneCall) {
+        this.#armHold(floorHeld);
+        return;
+      }
       // One reply at a time: the first speak takes the turn and the second is
       // refused, so the loop stops itself and READY resumes it. Notices go
       // first — the developer asked to hear them — and a summary rides only
@@ -230,11 +287,13 @@ export class SpokenNoticeAnnouncer {
       while (this.#queue.length > 0) {
         const next = this.#queue[0];
         if (!next || !session.speak(next)) break;
+        this.#ownReply = true;
         this.#queue.shift();
       }
       while (this.#queue.length === 0 && this.#rideQueue.length > 0) {
         const next = this.#rideQueue[0];
         if (!next || !session.speak(next)) break;
+        this.#ownReply = true;
         this.#rideQueue.shift();
       }
       // A backlog waiting on a refused speak is normally resumed by the READY
@@ -298,6 +357,24 @@ export class SpokenNoticeAnnouncer {
       this.#retryTimer = undefined;
       this.#flush();
     }, ANNOUNCER_RETRY_DELAY_MS);
+  }
+
+  /** Comes back for the backlog once the developer's floor window closes. */
+  #armHold(delayMs: number): void {
+    this.#holdTimer ??= (this.#options.schedule ?? setTimeout)(() => {
+      this.#holdTimer = undefined;
+      this.#flush();
+    }, delayMs);
+  }
+
+  #cancelHold(): void {
+    if (this.#holdTimer === undefined) return;
+    // SAFETY: The handle is whatever `schedule ?? setTimeout` returned, and the
+    // fallbacks are paired — a handle from `setTimeout` can only reach
+    // `clearTimeout`. The cast satisfies that signature; nothing reads it as a
+    // number.
+    (this.#options.cancel ?? clearTimeout)(this.#holdTimer as number);
+    this.#holdTimer = undefined;
   }
 
   #cancelRetry(): void {

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -1148,9 +1148,13 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       rememberLastAnnouncement(latestSpeech(speech));
       const notices = announcerNotices(speech);
       if (notices.length > 0) ensureAnnouncer().enqueue(notices);
-      const session = voiceSession.current;
-      if (!session?.microphoneCall) return;
-      for (const item of evaluatorSummaries(speech)) session.speak(item);
+      // Evaluator summaries may only ride the developer's own call. The
+      // announcer paces them by the READY edge like everything else it says,
+      // so a batch of several — or one arriving while Luke is mid-reply — is
+      // spoken as the turns free up instead of being refused and lost.
+      if (!voiceSession.current?.microphoneCall) return;
+      const summaries = evaluatorSummaries(speech);
+      if (summaries.length > 0) ensureAnnouncer().enqueueRide(summaries);
     });
   }, [ensureAnnouncer, rememberLastAnnouncement, rememberSessionReference]);
 

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -1160,10 +1160,12 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
 
   // The announcer paces itself by the session's status: READY is when a queued
   // sentence can speak and when an empty queue starts the walk toward closing
-  // the call Luke opened for himself.
+  // the call Luke opened for himself. Built through ensure so the status
+  // history is already standing when the first notice arrives — the grace
+  // window after a reply needs to know one just ended.
   useEffect(() => {
-    announcer.current?.onStatus(voiceStatus);
-  }, [voiceStatus]);
+    ensureAnnouncer().onStatus(voiceStatus);
+  }, [ensureAnnouncer, voiceStatus]);
 
   // The meeting quiet reaching the announcer. Quiet beginning is built
   // through ensure, so it stands even before the first notice would have


### PR DESCRIPTION
Two changes to how the announcer paces what Luke says unbidden, one commit each.

## 1. Evaluator summaries wait for the turn instead of being lost

When Luke had several evaluator summaries to say back to back, only the first was ever spoken. A batch of up to four can arrive from one attention review pass, and a summary can land while Luke is mid-reply — in both cases everything but the first was silently dropped, and the attention ledger had already counted the dropped sentence as spoken, suppressing it for ten minutes. The renderer spoke them in a plain loop that ignored `speak()`'s refusal, so the `SPEAK_AT_TURN_END` disposition the evaluator decides was never actually honored.

The `SpokenNoticeAnnouncer` now carries summaries in a ride-only queue paced by the same READY edge that paces its notices, holding the boundaries a summary has always had:

- It may only ride the developer's own call — the queue never opens a call of Luke's own for one, and a summary with no call to ride is dropped, still standing in the panel.
- It dies with the call it was waiting on: a hangup clears the queue, and a notice later opening Luke's own call cannot carry an orphaned summary.
- Notices — which the developer asked to hear — outrank summaries on every edge.
- It ages out on the same clock as a notice and is dropped by the meeting quiet.

## 2. The developer keeps the floor for ten seconds after Luke answers them

A reply to the developer invites their next ask, and an announcement speaking into that pause takes the very turn they were about to open. The announcer now holds its whole backlog — notices and summaries alike — for `ANNOUNCER_GRACE_MS` (10 s) after a reply to the developer ends, and speaks only into a pause they left empty. The developer taking the turn inside the window is the window doing its job; the answer they get ends with a fresh window.

The floor is only ever the developer's conversation's: Luke's own announcements chain without waiting (the readout is already his turn), a READY that merely opened a call answered nothing and holds nothing, Luke's own call has no ask to guard, and the window dies with the call. The retry clock respects the hold, so no side timer can speak through it.

No new write path and nothing new leaves the machine: the same items travel to the same call, only paced instead of raced.

## Verification

- `./scripts/check.sh` passes (exit 0) on both commits.
- Eleven new announcer tests: batch pacing by READY, mid-reply waiting, never opening Luke's own call, dying with the developer's call, notice priority, meeting-quiet drop, staleness aging, the floor window end to end, the developer retaking the floor, the retry clock respecting the hold, and Luke's own call staying exempt.
- No visual or macOS-specific change; `./scripts/verify.sh` was not run (Linux environment), and no physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32424066998/artifacts/9426785210) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32424066998)

- Commit: `7b511b1e8e0da27678f60204e1b596a2d87f0fcd`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
