### PR TITLE
fix(sessions): report an unanswered cloud write as indeterminate

### DIFF
--- a/apps/desktop/src/main/ipc/session-acts.ts
+++ b/apps/desktop/src/main/ipc/session-acts.ts
@@ -150,7 +150,12 @@ export function registerSessionActsIpc(dependencies: SessionActsIpcDependencies)
     const adapter = adapterFor(identity.providerId);
     if (!adapter) return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
     const result = await act(adapter, session);
-    if (result.status === PROVIDER_ACT_RESULT_STATUS.ACCEPTED) {
+    // A rejection refreshes like an acceptance: a write whose answer never
+    // arrived may still have landed, so the roster must catch up with the
+    // provider rather than keep advertising what it may have already taken. A
+    // rejection that never reached the network is answered from the adapter's
+    // cache anyway.
+    if (result.status !== PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED) {
       void sessionRegistry.refresh(adapter);
     }
     return countSessionAct(adapter.provider.id, counted, result);
@@ -753,7 +758,7 @@ export function registerSessionActsIpc(dependencies: SessionActsIpcDependencies)
         const fallback = stored?.agent === advertised ? stored : undefined;
         const model = namedModel ?? fallback?.model;
         const effort = namedModel !== undefined ? namedEffort : fallback?.effort;
-        const result = await adapter.spawnWorkspaceAgent({
+        return adapter.spawnWorkspaceAgent({
           providerSessionId: identity.providerSessionId,
           agent: advertised,
           ...(sessionName.value ? { name: sessionName.value } : undefined),
@@ -761,10 +766,6 @@ export function registerSessionActsIpc(dependencies: SessionActsIpcDependencies)
           ...(model ? { model } : undefined),
           ...(effort ? { effort } : undefined),
         });
-        if (result.status === PROVIDER_ACT_RESULT_STATUS.REJECTED) {
-          void sessionRegistry.refresh(adapter);
-        }
-        return result;
       });
     },
   );

--- a/packages/providers/src/shared/cloud-session-adapter.test.ts
+++ b/packages/providers/src/shared/cloud-session-adapter.test.ts
@@ -570,18 +570,28 @@ test("reports what became of a send the provider refused", async () => {
   assert.match(failed.status === "rejected" ? failed.reason : "", /500/);
 });
 
-// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-test("reports a send that never reached the provider as rejected, not thrown", async () => {
-  const adapter = adapterFor(async () => {
-    throw new Error("connection reset");
+test("reports an unanswered send as indeterminate and makes the next refresh ask", async () => {
+  let failWrites = false;
+  const { fetch } = recordingFetch((request) => {
+    if (failWrites && request.method === "POST") throw new Error("connection reset");
+    return jsonResponse({});
   });
+  const adapter = adapterFor(fetch, { minimumRefreshIntervalMs: 60_000 });
   adapter.collected = [observation("session-one", { canReceiveMessage: true })];
-  await adapter.observe().catch(() => {});
-  // Observation failed too, so the session was never observed; re-prime the
-  // adapter with a working pass before the network goes away.
+  await adapter.observe();
+
+  failWrites = true;
   const result = await adapter.sendMessage({ providerSessionId: "session-one", text: "go on" });
 
-  assert.equal(result.status, "unsupported");
+  // A thrown fetch cannot say whether the request landed — the provider may
+  // have taken it and only the answer was lost — so the refusal must hedge
+  // rather than claim nothing was sent.
+  assert.equal(result.status, "rejected");
+  assert.match(result.status === "rejected" ? result.reason : "", /may not have landed/);
+  // And because it may have landed, the next refresh asks the provider
+  // instead of serving the cache for the rest of the interval.
+  await adapter.observe();
+  assert.equal(adapter.passes, 2);
 });
 
 test("runs an advertised control through its documented route, sending no body", async () => {

--- a/packages/providers/src/shared/cloud-session-adapter.ts
+++ b/packages/providers/src/shared/cloud-session-adapter.ts
@@ -900,10 +900,17 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
         signal: AbortSignal.timeout(CLOUD_ADAPTER_DEFAULTS.REQUEST_TIMEOUT_MS),
       });
     } catch {
+      // A thrown fetch cannot say which side of the wire failed: a connection
+      // that never opened sent nothing, but a timeout or a reset while the
+      // answer was coming back leaves a request the provider may have already
+      // acted on. So the refusal hedges rather than claims, and the refresh
+      // that follows must actually ask, so a write that did land is reconciled
+      // against the provider instead of the cache still advertising it.
+      this.#lastAttemptAt = Number.NEGATIVE_INFINITY;
       return {
         outcome: {
           status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
-          reason: `${name} could not be reached, so nothing was sent.`,
+          reason: `${name} did not answer, so the request may not have landed.`,
         },
       };
     }


### PR DESCRIPTION
## What happened

A Conductor workspace archive succeeded, but Luke reported it as "Conductor could not be reached, so nothing was sent." The archive POST was delivered and acted on; only the answer never made it back (a reset or abort while awaiting the response), and the write path's bare `catch` words every thrown fetch as a connect-phase failure — the strongest claim, and in this case a false one. Commit f762d907 (#126) fixed this bug class on the read path; the write catch kept it.

## The fix, kept minimal

- **`cloud-session-adapter.ts`** — the thrown-write refusal now hedges ("did not answer, so the request may not have landed") instead of claiming nothing was sent, and resets the refresh throttle so the next observation pass actually asks the provider rather than serving the cache that still advertises the control.
- **`session-acts.ts`** — `performSessionAct` refreshes the roster on rejections as well as acceptances, mirroring the rationale `createSessionWorkspace` already states: an unanswered write may have landed, and a rejection that never reached the network is answered from the adapter's cache anyway. The now-redundant inner rejected-refresh in `addWorkspaceAgent` is removed.
- **`cloud-session-adapter.test.ts`** — replaces the misleading thrown-fetch test (its observation failed too, so it only exercised the unsupported guard) with one that observes successfully, fails the write, and asserts both the hedged wording and that the next `observe()` collects despite the refresh interval.

Deliberately not done: classifying undici error causes to split connect-phase from post-send failures, per-route write timeouts, or a write-side diagnostic hook — the hedged wording is honest for every case, and the roster reconciliation against the provider's lifecycle read is what actually corrects the row.

## Validation

`./scripts/check.sh` passes (repository contracts, typecheck, all package tests, web and desktop builds). Portable-only change — no macOS or UI surface touched, so no `verify.sh` evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/03d8389f-2229-485c-8402-c0c1b2f8ed9a)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32421463761/artifacts/9425889153) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32421463761)

- Commit: `2dd764da29e47fb9ebbfa8a4ff13e7b77c2b90e2`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
