### PR TITLE
fix(voice): reteach show_panel the session-list filter and sort vocabulary

### DIFF
--- a/packages/realtime/src/realtime-tools.ts
+++ b/packages/realtime/src/realtime-tools.ts
@@ -46,6 +46,7 @@ import {
   maximumWorkspaceNameLength,
   type NormalizedSession,
   type ObservedWorkspaceProject,
+  SESSION_APPLICATION_ID,
   SESSION_LOCATION,
   type SessionControl,
   type SessionIdentity,
@@ -115,6 +116,19 @@ export type AppToolKind = (typeof APP_TOOL_KIND)[keyof typeof APP_TOOL_KIND];
  */
 export const SESSION_LIST_ALL = "all";
 export const SESSION_LIST_VOICE = "voice";
+
+/**
+ * The filter vocabulary, taught on the tool itself. The parameter cannot be
+ * an enum — an agent filter is whatever provider_id the roster currently
+ * lists — so this description is the only place the model learns what the
+ * validator will accept, and it is composed from the same value sets the
+ * validator reads so the two cannot drift.
+ */
+const SESSION_LIST_FILTER_DESCRIPTION =
+  `Narrows the session list: ${SESSION_LIST_ALL} for every session, ` +
+  `${SESSION_LOCATION.LOCAL} or ${SESSION_LOCATION.CLOUD} for where work runs, ` +
+  `${SESSION_LIST_VOICE} for voice chats, an observed session's provider_id for one agent, ` +
+  `or an associated app: ${Object.values(SESSION_APPLICATION_ID).join(", ")}.`;
 
 /** What one validated tool call asks for, ready for the bridge that carries it. */
 export type SessionToolAction =
@@ -1183,23 +1197,26 @@ export const REALTIME_TOOLS = {
     name: "show_panel",
     family: REALTIME_TOOL_FAMILY.APP,
     schema: {
-      description: "Show Luke's panel.",
+      description:
+        "Show Luke's panel on a tab — and, on the sessions tab, narrow or reorder the list.",
       parameters: {
         type: "object",
         properties: {
           tab: {
             type: "string",
             enum: Object.values(APP_PANEL_TAB),
-            description: "The tab to show.",
+            description: "The tab to show. Defaults to sessions.",
           },
           filter: {
             type: "string",
-            description: "An optional session-list filter.",
+            description: SESSION_LIST_FILTER_DESCRIPTION,
           },
           sort: {
             type: "string",
             enum: Object.values(SESSION_LIST_SORT),
-            description: "An optional session-list sort order.",
+            description:
+              `Reorders the session list: ${SESSION_LIST_SORT.URGENCY} puts what needs the ` +
+              `developer first, ${SESSION_LIST_SORT.RECENCY} puts what moved last first.`,
           },
         },
         required: [],

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -65,6 +65,7 @@ import {
   maximumWorkspaceNameLength,
   normalizeSession,
   type ObservedWorkspaceProject,
+  SESSION_APPLICATION_ID,
   SESSION_LOCATION,
   SESSION_STATUS,
   WORKSPACE_TASK_SUPPORT,
@@ -88,7 +89,13 @@ import {
   REALTIME_SESSION_TYPE,
   realtimeInstructions,
 } from "./realtime-protocol.js";
-import { REALTIME_TOOL, REALTIME_TOOL_FAMILY, REALTIME_TOOLS } from "./realtime-tools.js";
+import {
+  REALTIME_TOOL,
+  REALTIME_TOOL_FAMILY,
+  REALTIME_TOOLS,
+  SESSION_LIST_ALL,
+  SESSION_LIST_VOICE,
+} from "./realtime-tools.js";
 
 function conversationItem(event: WireRecord | undefined): WireRecord | undefined {
   if (!event) return undefined;
@@ -1075,6 +1082,29 @@ test("the session is minted with the fifteen acts and nothing wider", () => {
     ],
   );
   assert.equal(config.tool_choice, "auto");
+});
+
+test("show_panel teaches the whole filter vocabulary its validator accepts", () => {
+  const filter = REALTIME_TOOLS.SHOW_PANEL.schema.parameters.properties.filter.description;
+
+  // The filter parameter has no enum — an agent filter is whatever
+  // provider_id the roster currently lists — so its description is the only
+  // place the model learns the fixed half of the vocabulary. A value the
+  // validator accepts but the description never names is a narrowing no ask
+  // can reach.
+  assert.match(filter, /provider_id/);
+  const scopes = [
+    SESSION_LIST_ALL,
+    SESSION_LOCATION.LOCAL,
+    SESSION_LOCATION.CLOUD,
+    SESSION_LIST_VOICE,
+  ];
+  for (const value of scopes) {
+    assert.ok(filter.includes(value), `filter description never names "${value}"`);
+  }
+  for (const applicationId of Object.values(SESSION_APPLICATION_ID)) {
+    assert.ok(filter.includes(applicationId), `filter description never names "${applicationId}"`);
+  }
 });
 
 test("a proactive turn is opened with its tools withheld", () => {


### PR DESCRIPTION
## What broke

Asking Luke to filter or re-sort the sessions list stopped working. The plumbing is all intact — `show_panel`'s `filter`/`sort` arguments, `validateShowPanel`, `panelFilterAction`, `sessionFiltersFromSpoken`, and the errand hold that draws the narrowed view all still work (verified end to end). What broke was the teaching: the prompt-surface simplification (#313) reduced `show_panel`'s description to "Show Luke's panel." and the `filter` parameter's to "An optional session-list filter."

The `filter` parameter carries no enum — an agent filter is whatever `provider_id` the roster currently lists — so the old description was the **only** place the model ever learned which values the validator accepts (`all`, `local`, `cloud`, `voice`, a provider id, an app id), and the tool's own description was the only place it learned that `show_panel` narrows and reorders the list at all. With both gone, an ask to filter or re-sort either never became a tool call or arrived carrying words the validator rightly refused — and the capability read as missing.

## The fix

- Restore `show_panel`'s description to say it can narrow and reorder the sessions list, and the `tab` default.
- Restore the `filter` description, composed from the same value sets the validator reads — `SESSION_LIST_ALL`, `SESSION_LOCATION`, `SESSION_LIST_VOICE`, and `SESSION_APPLICATION_ID` — so the taught vocabulary and the accepted one cannot drift apart. (The set has also widened since the old prose was written — #331 added agent and app identities — so the restored text teaches the current vocabulary, not the old one.)
- Restore the `sort` description naming what each order means, from `SESSION_LIST_SORT`.
- Add a test that fails if any fixed value the validator accepts ever leaves the `filter` description again.

## Verification

`./scripts/check.sh` passes (exit 0): repository checks, typecheck, all workspace tests (including the new one), and build. Portable-only change — nothing drawn changes, so no visual evidence applies and no physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ef03be81-5ddd-4458-a538-80bf694896be)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32421837111/artifacts/9426002765) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32421837111)

- Commit: `ad811204ee1988dc7c5b7357930587910e85bb99`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
