### PR TITLE
feat(voice): let a spoken ask combine session filters like the chips do

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1933,12 +1933,14 @@ export function App(): React.JSX.Element {
           // errand into a shape still growing has to trail the whole opening,
           // and one into a panel already up does not.
           const opening = presentationOf() !== PANEL_PRESENTATION.PANEL;
-          const spoken = action.filter ? sessionFiltersFromSpoken(action.filter) : undefined;
-          // An agent this build never registered cannot narrow the list, and Luke
-          // must not claim it did. The list still has to match the sentence that
-          // says every session is shown, so an unmappable ask widens the view to
-          // everything rather than leaving whatever narrowing was already in force.
-          const filters = action.filter ? (spoken ?? []) : undefined;
+          const spoken = action.filters ? sessionFiltersFromSpoken(action.filters) : undefined;
+          // An identity this build holds no chip for cannot narrow the list, and
+          // Luke must not claim it did. The list still has to match the sentence
+          // that says every session is shown, so an unmappable ask widens the view
+          // to everything rather than leaving whatever narrowing was already in
+          // force — the whole ask, because a combination quietly missing one of
+          // its values would show more than the sentence names.
+          const filters = action.filters ? (spoken ?? []) : undefined;
           // Caught rather than applied, on the settings switch's terms: the
           // narrowing is what Luke is on his way to the options button to do, and
           // a list that has already re-sorted itself by the time he gets there
@@ -1967,9 +1969,9 @@ export function App(): React.JSX.Element {
           return {
             status: "shown",
             tab: action.tab,
-            ...(spoken !== undefined ? { filter: action.filter } : undefined),
-            ...(action.filter && spoken === undefined
-              ? { note: "That agent has no filter of its own here, so every session is shown." }
+            ...(spoken !== undefined ? { filters: action.filters } : undefined),
+            ...(action.filters && spoken === undefined
+              ? { note: "That narrowing has no filter of its own here, so every session is shown." }
               : undefined),
             ...(action.sort ? { sort: action.sort } : undefined),
           };

--- a/apps/desktop/src/renderer/luke-errand.test.ts
+++ b/apps/desktop/src/renderer/luke-errand.test.ts
@@ -126,10 +126,10 @@ test("a narrowing or a re-ordering is signed on the control that carries it", ()
   // The options button says how the list is being shown, so it comes first —
   // and it is only drawn beside a list with something to choose between, which
   // is why the tab stands behind it rather than instead of it.
-  assert.deepEqual(errandTargets({ kind: "panel", tab: APP_PANEL_TAB.SESSIONS, filter: "cloud" }), [
-    ERRAND_TARGET.LIST_OPTIONS,
-    ERRAND_TARGET.SESSIONS_TAB,
-  ]);
+  assert.deepEqual(
+    errandTargets({ kind: "panel", tab: APP_PANEL_TAB.SESSIONS, filters: ["cloud"] }),
+    [ERRAND_TARGET.LIST_OPTIONS, ERRAND_TARGET.SESSIONS_TAB],
+  );
   assert.deepEqual(
     errandTargets({
       kind: "panel",

--- a/apps/desktop/src/renderer/luke-errand.tsx
+++ b/apps/desktop/src/renderer/luke-errand.tsx
@@ -131,7 +131,7 @@ export function errandTargets(action: AppToolAction): readonly ErrandTarget[] {
   const tab = tabErrandTarget(action.tab);
   // A narrowing or a re-ordering is the news; the tab is only where it
   // happened, and it may not have changed at all.
-  if (action.filter !== undefined || action.sort !== undefined) {
+  if (action.filters !== undefined || action.sort !== undefined) {
     return [ERRAND_TARGET.LIST_OPTIONS, tab];
   }
   return [tab];

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -309,7 +309,8 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "chips toggle, and the options button wears the narrowing while the sheet is closed. " +
         "Chosen chips are un-pressed the same way they were pressed, a spoken ask can narrow " +
         "to one or several values combined the same way — local Codex voice chats is one ask " +
-        "— or back to all, replacing what was picked by hand, and the list is " +
+        "— naming an agent or app by its everyday name, or back to all, replacing what was " +
+        "picked by hand, and the list is " +
         "orderable by urgency or recency by the same button or ask. " +
         "A row can be opened, messaged, or controlled " +
         "where its provider allows. A session whose provider reported a pull request grows a " +

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -308,7 +308,8 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "Conductor means Codex chats associated with Conductor. The sheet stays open while " +
         "chips toggle, and the options button wears the narrowing while the sheet is closed. " +
         "Chosen chips are un-pressed the same way they were pressed, a spoken ask can narrow " +
-        "to one value or back to all, replacing what was picked by hand, and the list is " +
+        "to one or several values combined the same way — local Codex voice chats is one ask " +
+        "— or back to all, replacing what was picked by hand, and the list is " +
         "orderable by urgency or recency by the same button or ask. " +
         "A row can be opened, messaged, or controlled " +
         "where its provider allows. A session whose provider reported a pull request grows a " +

--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -4337,7 +4337,7 @@ test("a spoken panel ask is validated against the roster and carried", async () 
           type: "function_call",
           name: "show_panel",
           call_id: "call-guide-3",
-          arguments: '{"filter":"claude-code","sort":"recency"}',
+          arguments: '{"filters":["claude-code"],"sort":"recency"}',
         },
       ],
     },
@@ -4345,7 +4345,7 @@ test("a spoken panel ask is validated against the roster and carried", async () 
   await new Promise((resolve) => setTimeout(resolve, 0));
 
   assert.deepEqual(carried, [
-    { kind: "panel", tab: "sessions", filter: "claude-code", sort: "recency" },
+    { kind: "panel", tab: "sessions", filters: ["claude-code"], sort: "recency" },
   ]);
 
   // Switching to the settings tab is the same ask carried with a tab, not a
@@ -4381,7 +4381,7 @@ test("a spoken panel ask is validated against the roster and carried", async () 
           type: "function_call",
           name: "show_panel",
           call_id: "call-guide-5",
-          arguments: '{"filter":"superset"}',
+          arguments: '{"filters":["superset"]}',
         },
       ],
     },
@@ -4407,14 +4407,14 @@ test("a spoken panel ask is validated against the roster and carried", async () 
           type: "function_call",
           name: "show_panel",
           call_id: "call-guide-6",
-          arguments: '{"filter":"superset"}',
+          arguments: '{"filters":["superset"]}',
         },
       ],
     },
   });
   await new Promise((resolve) => setTimeout(resolve, 0));
 
-  assert.deepEqual(carried.at(-1), { kind: "panel", tab: "sessions", filter: "superset" });
+  assert.deepEqual(carried.at(-1), { kind: "panel", tab: "sessions", filters: ["superset"] });
 
   // A hosted chat answers its agent's filter and its apps' filters the way
   // its chips do: the agent behind the chat and an associated app are
@@ -4435,13 +4435,13 @@ test("a spoken panel ask is validated against the roster and carried", async () 
           type: "function_call",
           name: "show_panel",
           call_id: "call-guide-7",
-          arguments: '{"filter":"codex"}',
+          arguments: '{"filters":["codex"]}',
         },
       ],
     },
   });
   await new Promise((resolve) => setTimeout(resolve, 0));
-  assert.deepEqual(carried.at(-1), { kind: "panel", tab: "sessions", filter: "codex" });
+  assert.deepEqual(carried.at(-1), { kind: "panel", tab: "sessions", filters: ["codex"] });
 
   await armDeveloperTurn(context);
   context.emit({
@@ -4452,13 +4452,55 @@ test("a spoken panel ask is validated against the roster and carried", async () 
           type: "function_call",
           name: "show_panel",
           call_id: "call-guide-8",
-          arguments: '{"filter":"conductor"}',
+          arguments: '{"filters":["conductor"]}',
         },
       ],
     },
   });
   await new Promise((resolve) => setTimeout(resolve, 0));
-  assert.deepEqual(carried.at(-1), { kind: "panel", tab: "sessions", filter: "conductor" });
+  assert.deepEqual(carried.at(-1), { kind: "panel", tab: "sessions", filters: ["conductor"] });
+
+  // Several values combine like the chips: the observed session is a local
+  // Codex chat associated with Conductor, so the combination is carried
+  // whole — and one nothing occupies is refused rather than carried.
+  await armDeveloperTurn(context);
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: {
+      output: [
+        {
+          type: "function_call",
+          name: "show_panel",
+          call_id: "call-guide-9",
+          arguments: '{"filters":["codex","conductor","local"]}',
+        },
+      ],
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(carried.at(-1), {
+    kind: "panel",
+    tab: "sessions",
+    filters: ["codex", "conductor", "local"],
+  });
+
+  await armDeveloperTurn(context);
+  const combinedBefore = carried.length;
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: {
+      output: [
+        {
+          type: "function_call",
+          name: "show_panel",
+          call_id: "call-guide-10",
+          arguments: '{"filters":["codex","cloud"]}',
+        },
+      ],
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(carried.length, combinedBefore);
 });
 
 test("a spoken composer open is validated against the fixed kinds and carried, never sent", async () => {

--- a/apps/desktop/src/renderer/session-model.test.ts
+++ b/apps/desktop/src/renderer/session-model.test.ts
@@ -459,7 +459,24 @@ test("the voice filter narrows to realtime voice chats and has a spoken name", (
     }).sessions.map((session) => session.id),
     ["codex-voice"],
   );
-  assert.deepEqual(sessionFiltersFromSpoken(SESSION_FILTER.VOICE), [SESSION_FILTER.VOICE]);
+  assert.deepEqual(sessionFiltersFromSpoken([SESSION_FILTER.VOICE]), [SESSION_FILTER.VOICE]);
+});
+
+test("a spoken narrowing of several values reads as the matching chips combined", () => {
+  assert.deepEqual(
+    sessionFiltersFromSpoken([SESSION_FILTER.LOCAL, PROVIDER_ID.CODEX, SESSION_FILTER.VOICE]),
+    [SESSION_FILTER.LOCAL, PROVIDER_ID.CODEX, SESSION_FILTER.VOICE],
+  );
+  // A repeated value is one chip, not a tighter ask.
+  assert.deepEqual(sessionFiltersFromSpoken([SESSION_FILTER.CLOUD, SESSION_FILTER.CLOUD]), [
+    SESSION_FILTER.CLOUD,
+  ]);
+  // The whole list is the empty selection.
+  assert.deepEqual(sessionFiltersFromSpoken(["all"]), []);
+  // A value no chip of this build holds makes the whole ask nothing rather
+  // than a guess: a selection quietly missing one of its values would show
+  // more than the ask named.
+  assert.equal(sessionFiltersFromSpoken([SESSION_FILTER.LOCAL, "not-an-agent"]), undefined);
 });
 
 // The fixture above covers the agents it happens to contain. Every agent the
@@ -884,7 +901,7 @@ test("sessions Superset manages earn a chip and can be narrowed to", () => {
   assert.equal(narrowed.total, 2);
 
   // The spoken vocabulary is the chips' own, so the same word narrows by voice.
-  assert.deepEqual(sessionFiltersFromSpoken("superset"), [SESSION_FILTER.SUPERSET]);
+  assert.deepEqual(sessionFiltersFromSpoken(["superset"]), [SESSION_FILTER.SUPERSET]);
 });
 
 test("an app filter matches annotations as well as a namesake provider", () => {
@@ -942,7 +959,7 @@ test("an app filter matches annotations as well as a namesake provider", () => {
     }).sessions.map((session) => session.id),
     ["codex-conductor"],
   );
-  assert.deepEqual(sessionFiltersFromSpoken(SESSION_APPLICATION_ID.CHATGPT), [
+  assert.deepEqual(sessionFiltersFromSpoken([SESSION_APPLICATION_ID.CHATGPT]), [
     SESSION_APPLICATION_ID.CHATGPT,
   ]);
 });

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -4,11 +4,13 @@ import {
   ATTENTION_DISPOSITION,
   isProviderId,
   isSessionApplicationId,
+  matchesFilterSelection,
   type NormalizedSession,
   PROVIDER_ID_LIST,
   type ProviderId,
   SESSION_APPLICATION_ID_LIST,
   SESSION_FILTER,
+  SESSION_FILTER_AXIS,
   SESSION_LOCATION,
   SESSION_STATUS,
   type SessionApplicationId,
@@ -16,8 +18,10 @@ import {
   type SessionControlKind,
   type SessionDiffSummary,
   type SessionFilter,
+  type SessionFilterAxis,
   type SessionLocation,
   sessionChangeNumber,
+  sessionFilterAxis,
 } from "@sidecar/session";
 import { SUPERSET_WORKSPACE_PROVIDER_ID } from "@sidecar/superset/vocabulary";
 import {
@@ -38,39 +42,18 @@ import type { AppBootstrap } from "#shared/contracts";
  * Superset manages it. A hosted chat carries its agent's identity beside its
  * provider's, so a Claude conversation in Conductor's cloud answers the
  * Claude Code chip and the Conductor chip at once.
+ *
+ * The axes the filters combine on live there too, because a spoken ask's
+ * combination is validated against the observed roster by the same rules the
+ * chips narrow the drawn list by, and the two readings must not drift apart.
  */
-export { SESSION_FILTER, type SessionFilter };
-
-/**
- * The independent questions the filters answer. Each filter value belongs to
- * exactly one axis, and the axis is what gives a combined selection its
- * meaning: values on one axis are alternatives (either place, either agent),
- * where values on different axes are each a further narrowing.
- */
-export const SESSION_FILTER_AXIS = {
-  LOCATION: "location",
-  KIND: "kind",
-  APP: "app",
-  AGENT: "agent",
-} as const;
-
-export type SessionFilterAxis = (typeof SESSION_FILTER_AXIS)[keyof typeof SESSION_FILTER_AXIS];
-
-/**
- * Conductor and Superset land on the app axis even where a namesake provider
- * exists, because "associated with that app" is the question their chips
- * answer — a native cloud Conductor chat and a local Codex chat annotated by
- * Conductor answer the same chip, and an agent chip beside it stays a further
- * narrowing rather than a widening.
- */
-export function sessionFilterAxis(filter: SessionFilter): SessionFilterAxis {
-  if (filter === SESSION_FILTER.LOCAL || filter === SESSION_FILTER.CLOUD) {
-    return SESSION_FILTER_AXIS.LOCATION;
-  }
-  if (filter === SESSION_FILTER.VOICE) return SESSION_FILTER_AXIS.KIND;
-  if (isSessionApplicationId(filter)) return SESSION_FILTER_AXIS.APP;
-  return SESSION_FILTER_AXIS.AGENT;
-}
+export {
+  SESSION_FILTER,
+  SESSION_FILTER_AXIS,
+  type SessionFilter,
+  type SessionFilterAxis,
+  sessionFilterAxis,
+};
 
 function matchesFilter(session: DisplaySession, filter: SessionFilter): boolean {
   if (filter === SESSION_FILTER.LOCAL || filter === SESSION_FILTER.CLOUD) {
@@ -85,28 +68,12 @@ function matchesFilter(session: DisplaySession, filter: SessionFilter): boolean 
   );
 }
 
-/**
- * Whether a row answers the whole selection. Within one axis the values are
- * ORed — Local and Cloud together is either place — and across axes they are
- * ANDed — Codex beside Conductor is Codex chats associated with Conductor.
- * An axis nothing is chosen on asks nothing, so an empty selection is the
- * unnarrowed list.
- */
+/** Whether a row answers the whole selection, on the axes' own combining rules. */
 export function matchesSessionFilters(
   session: DisplaySession,
   filters: readonly SessionFilter[],
 ): boolean {
-  const byAxis = new Map<SessionFilterAxis, SessionFilter[]>();
-  for (const filter of filters) {
-    const axis = sessionFilterAxis(filter);
-    const held = byAxis.get(axis) ?? [];
-    held.push(filter);
-    byAxis.set(axis, held);
-  }
-  for (const alternatives of byAxis.values()) {
-    if (!alternatives.some((filter) => matchesFilter(session, filter))) return false;
-  }
-  return true;
+  return matchesFilterSelection(filters, (filter) => matchesFilter(session, filter));
 }
 
 /**
@@ -134,26 +101,41 @@ export function sameSessionFilters(
 /** The spoken name for the unnarrowed list, shared with the voice tool's vocabulary. */
 const SPOKEN_ALL = "all";
 
-/**
- * Reads a spoken filter into the list's own selection. The values are the
- * same strings the chips use — the coarse scopes, voice kind, app ids, and
- * provider ids — so a validated spoken ask maps one-to-one. A spoken ask says
- * what the list should show, so it replaces a hand-picked combination rather
- * than joining it: `all` is the empty selection, one value is a selection of
- * one. Anything else is nothing rather than a guess, and the list is left as
- * it was.
- */
-export function sessionFiltersFromSpoken(value: string): readonly SessionFilter[] | undefined {
-  if (value === SPOKEN_ALL) return [];
+/** One spoken value read as the chip it names, or nothing when no chip holds it. */
+function sessionFilterFromSpoken(value: string): SessionFilter | undefined {
   if (
     value === SESSION_FILTER.LOCAL ||
     value === SESSION_FILTER.CLOUD ||
     value === SESSION_FILTER.VOICE
   ) {
-    return [value];
+    return value;
   }
-  if (isSessionApplicationId(value)) return [value];
-  return isProviderId(value) ? [value] : undefined;
+  if (isSessionApplicationId(value)) return value;
+  return isProviderId(value) ? value : undefined;
+}
+
+/**
+ * Reads a spoken narrowing into the list's own selection. The values are the
+ * same strings the chips use — the coarse scopes, voice kind, app ids, and
+ * provider ids — so a validated spoken ask maps one-to-one, and several
+ * values combine exactly as the matching chips would. A spoken ask says what
+ * the list should show, so it replaces a hand-picked combination rather than
+ * joining it: `all` is the empty selection. A value no chip of this build
+ * holds makes the whole ask nothing rather than a guess — a selection quietly
+ * missing one of its values would show more than the ask named while
+ * reporting the narrowing happened.
+ */
+export function sessionFiltersFromSpoken(
+  values: readonly string[],
+): readonly SessionFilter[] | undefined {
+  if (values.length === 1 && values[0] === SPOKEN_ALL) return [];
+  const selection: SessionFilter[] = [];
+  for (const value of values) {
+    const filter = sessionFilterFromSpoken(value);
+    if (filter === undefined) return undefined;
+    if (!selection.includes(filter)) selection.push(filter);
+  }
+  return selection;
 }
 
 /**

--- a/packages/realtime/src/guide.test.ts
+++ b/packages/realtime/src/guide.test.ts
@@ -262,23 +262,24 @@ test("a spoken panel ask opens a real tab and narrows only to what is observed",
 
   assert.deepEqual(show("{}"), { kind: "panel", tab: APP_PANEL_TAB.SESSIONS });
   assert.deepEqual(show('{"tab":"settings"}'), { kind: "panel", tab: APP_PANEL_TAB.SETTINGS });
-  assert.deepEqual(show('{"filter":"all"}'), {
+  assert.deepEqual(show('{"filters":["all"]}'), {
     kind: "panel",
     tab: APP_PANEL_TAB.SESSIONS,
-    filter: "all",
+    filters: ["all"],
   });
-  assert.deepEqual(show('{"filter":"conductor"}'), {
+  assert.deepEqual(show('{"filters":["conductor"]}'), {
     kind: "panel",
     tab: APP_PANEL_TAB.SESSIONS,
-    filter: "conductor",
+    filters: ["conductor"],
   });
-  assert.deepEqual(show('{"filter":"cloud"}'), {
+  // A narrowing of one may arrive as a lone string, read as a list of one.
+  assert.deepEqual(show('{"filters":"cloud"}'), {
     kind: "panel",
     tab: APP_PANEL_TAB.SESSIONS,
-    filter: "cloud",
+    filters: ["cloud"],
   });
 
-  assert.deepEqual(show('{"filter":"voice"}'), {
+  assert.deepEqual(show('{"filters":["voice"]}'), {
     kind: "refused",
     reason: "No voice sessions are observed right now.",
   });
@@ -286,18 +287,80 @@ test("a spoken panel ask opens a real tab and narrows only to what is observed",
   assert.equal(show('{"tab":"about"}').kind, "refused");
   // A narrowing that would show nothing is refused rather than applied: the
   // panel would fall back to everything, and the sentence would be wrong.
-  assert.equal(show('{"filter":"local"}').kind, "refused");
-  assert.equal(show('{"filter":"codex"}').kind, "refused");
+  assert.equal(show('{"filters":["local"]}').kind, "refused");
+  assert.equal(show('{"filters":["codex"]}').kind, "refused");
 
   const voiceShow = (argumentsJson: string) =>
     appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, [
       observedConductorSession(true),
     ]);
-  assert.deepEqual(voiceShow('{"filter":"voice"}'), {
+  assert.deepEqual(voiceShow('{"filters":["voice"]}'), {
     kind: "panel",
     tab: APP_PANEL_TAB.SESSIONS,
-    filter: SESSION_LIST_VOICE,
+    filters: [SESSION_LIST_VOICE],
   });
+});
+
+test("a spoken panel ask can combine filters, on the axes the chips combine on", () => {
+  const sessions = [observedConductorSession(), observedConductorSession(true)];
+  const show = (argumentsJson: string) =>
+    appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, sessions);
+
+  // Values on different axes narrow: a cloud Conductor voice chat is observed.
+  assert.deepEqual(show('{"filters":["cloud","conductor","voice"]}'), {
+    kind: "panel",
+    tab: APP_PANEL_TAB.SESSIONS,
+    filters: ["cloud", "conductor", "voice"],
+  });
+  // A repeated value is one value, not a tighter ask.
+  assert.deepEqual(show('{"filters":["cloud","cloud"]}'), {
+    kind: "panel",
+    tab: APP_PANEL_TAB.SESSIONS,
+    filters: ["cloud"],
+  });
+
+  // Each value answered by some session can still name an intersection
+  // nothing occupies: every observed session is cloud, so local matches
+  // nothing — and with a local session beside them, local Conductor exists
+  // but no local voice chat does.
+  assert.deepEqual(show('{"filters":["local","conductor"]}'), {
+    kind: "refused",
+    reason: "No local sessions are observed right now.",
+  });
+  const mixed = (argumentsJson: string) =>
+    appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, [
+      ...sessions,
+      normalizeSession(
+        { id: "conductor", displayName: "Conductor" },
+        {
+          providerSessionId: "workspace-2",
+          title: "Conductor: checkout-service",
+          status: SESSION_STATUS.WORKING,
+          observedAt: 1_800_000_000_000,
+          location: SESSION_LOCATION.LOCAL,
+        },
+      ),
+    ]);
+  assert.deepEqual(mixed('{"filters":["local","conductor"]}'), {
+    kind: "panel",
+    tab: APP_PANEL_TAB.SESSIONS,
+    filters: ["local", "conductor"],
+  });
+  assert.deepEqual(mixed('{"filters":["local","voice"]}'), {
+    kind: "refused",
+    reason: "No observed session matches that combination of filters.",
+  });
+
+  // The whole list is not a value to narrow by.
+  assert.deepEqual(show('{"filters":["all","cloud"]}'), {
+    kind: "refused",
+    reason: "all is the whole list, so it combines with nothing.",
+  });
+  // A narrowing has to be a list of words; anything else is unreadable.
+  assert.equal(show('{"filters":[3]}').kind, "refused");
+  assert.equal(show('{"filters":{"value":"cloud"}}').kind, "refused");
+  // A list of nothing is no narrowing at all.
+  assert.deepEqual(show('{"filters":[]}'), { kind: "panel", tab: APP_PANEL_TAB.SESSIONS });
 });
 
 test("a spoken panel ask can reorder the list in the panel's own two words", () => {
@@ -310,10 +373,10 @@ test("a spoken panel ask can reorder the list in the panel's own two words", () 
     tab: APP_PANEL_TAB.SESSIONS,
     sort: SESSION_LIST_SORT.RECENCY,
   });
-  assert.deepEqual(show('{"filter":"conductor","sort":"urgency"}'), {
+  assert.deepEqual(show('{"filters":["conductor"],"sort":"urgency"}'), {
     kind: "panel",
     tab: APP_PANEL_TAB.SESSIONS,
-    filter: "conductor",
+    filters: ["conductor"],
     sort: SESSION_LIST_SORT.URGENCY,
   });
   assert.equal(show('{"sort":"alphabetical"}').kind, "refused");

--- a/packages/realtime/src/guide.test.ts
+++ b/packages/realtime/src/guide.test.ts
@@ -361,6 +361,13 @@ test("a spoken panel ask can combine filters, on the axes the chips combine on",
   assert.equal(show('{"filters":{"value":"cloud"}}').kind, "refused");
   // A list of nothing is no narrowing at all.
   assert.deepEqual(show('{"filters":[]}'), { kind: "panel", tab: APP_PANEL_TAB.SESSIONS });
+
+  // The enum on the schema binds the model to real tokens — a developer's
+  // phrase arriving untranslated is refused by the backstop, never guessed at.
+  assert.deepEqual(show('{"filters":["Claude Code"]}'), {
+    kind: "refused",
+    reason: '"Claude Code" is not one of the filter values the tool lists.',
+  });
 });
 
 test("a spoken panel ask can reorder the list in the panel's own two words", () => {

--- a/packages/realtime/src/realtime-tools.ts
+++ b/packages/realtime/src/realtime-tools.ts
@@ -47,6 +47,7 @@ import {
   maximumWorkspaceNameLength,
   type NormalizedSession,
   type ObservedWorkspaceProject,
+  PROVIDER_ID_LIST,
   SESSION_APPLICATION_ID,
   SESSION_LOCATION,
   type SessionControl,
@@ -109,27 +110,34 @@ export const APP_TOOL_KIND = {
 
 export type AppToolKind = (typeof APP_TOOL_KIND)[keyof typeof APP_TOOL_KIND];
 
-/**
- * The whole-list scope a spoken panel ask may name. The rest of the filter
- * vocabulary is not this module's to define: a location is a session's own
- * `location`, and a provider is its `provider_id`, so a spoken filter is
- * validated against the observed roster rather than against a second list.
- */
+/** The two whole-list scopes of a spoken panel ask beyond the locations. */
 export const SESSION_LIST_ALL = "all";
 export const SESSION_LIST_VOICE = "voice";
 
 /**
- * The filter vocabulary, taught on the tool itself. The parameter cannot be
- * an enum — an agent filter is whatever provider_id the roster currently
- * lists — so this description is the only place the model learns what the
- * validator will accept, and it is composed from the same value sets the
- * validator reads so the two cannot drift.
+ * Every value a spoken narrowing may name, fixed by the build: the whole-list
+ * scopes, every agent this build knows, and every app that associates with
+ * sessions. The chips can hold no other value — a `SessionFilter` is drawn
+ * from these same sets — so this enum is the whole vocabulary rather than a
+ * convenience, and the model picks a token from it instead of echoing the
+ * developer's words for a matcher to guess at. Which of these values narrow
+ * to anything right now is the roster's question, answered by the validator.
  */
+const SESSION_LIST_FILTER_VALUES: readonly string[] = [
+  ...new Set<string>([
+    SESSION_LIST_ALL,
+    SESSION_LOCATION.LOCAL,
+    SESSION_LOCATION.CLOUD,
+    SESSION_LIST_VOICE,
+    ...PROVIDER_ID_LIST,
+    ...Object.values(SESSION_APPLICATION_ID),
+  ]),
+];
+
 const SESSION_LIST_FILTER_DESCRIPTION =
   `The values to narrow the session list to: ${SESSION_LIST_ALL} for every session, ` +
   `${SESSION_LOCATION.LOCAL} or ${SESSION_LOCATION.CLOUD} for where work runs, ` +
-  `${SESSION_LIST_VOICE} for voice chats, an observed session's provider_id for one agent, ` +
-  `or an associated app: ${Object.values(SESSION_APPLICATION_ID).join(", ")}. ` +
+  `${SESSION_LIST_VOICE} for voice chats, an agent's provider_id, or an associated app's id. ` +
   `Values combine — ${SESSION_LOCATION.LOCAL} with an agent keeps that agent's local ` +
   `sessions — and ${SESSION_LIST_ALL} stands alone.`;
 
@@ -836,6 +844,13 @@ function panelFiltersAction(
   filters: readonly string[],
   sessions: readonly NormalizedSession[],
 ): { filters: readonly string[] } | { reason: string } {
+  // The enum on the tool's own schema already binds a compliant model to
+  // these tokens; this is the backstop for a call composed past it.
+  for (const filter of filters) {
+    if (!SESSION_LIST_FILTER_VALUES.includes(filter)) {
+      return { reason: `"${filter}" is not one of the filter values the tool lists.` };
+    }
+  }
   const chosen = [...new Set(filters)];
   if (chosen.includes(SESSION_LIST_ALL)) {
     if (chosen.length > 1) {
@@ -1273,7 +1288,7 @@ export const REALTIME_TOOLS = {
           },
           filters: {
             type: "array",
-            items: { type: "string" },
+            items: { type: "string", enum: SESSION_LIST_FILTER_VALUES },
             description: SESSION_LIST_FILTER_DESCRIPTION,
           },
           sort: {

--- a/packages/realtime/src/realtime-tools.ts
+++ b/packages/realtime/src/realtime-tools.ts
@@ -42,6 +42,7 @@ import {
   type TrackedIssue,
 } from "@sidecar/issues";
 import {
+  matchesFilterSelection,
   maximumSessionMessageLength,
   maximumWorkspaceNameLength,
   type NormalizedSession,
@@ -125,10 +126,12 @@ export const SESSION_LIST_VOICE = "voice";
  * validator reads so the two cannot drift.
  */
 const SESSION_LIST_FILTER_DESCRIPTION =
-  `Narrows the session list: ${SESSION_LIST_ALL} for every session, ` +
+  `The values to narrow the session list to: ${SESSION_LIST_ALL} for every session, ` +
   `${SESSION_LOCATION.LOCAL} or ${SESSION_LOCATION.CLOUD} for where work runs, ` +
   `${SESSION_LIST_VOICE} for voice chats, an observed session's provider_id for one agent, ` +
-  `or an associated app: ${Object.values(SESSION_APPLICATION_ID).join(", ")}.`;
+  `or an associated app: ${Object.values(SESSION_APPLICATION_ID).join(", ")}. ` +
+  `Values combine — ${SESSION_LOCATION.LOCAL} with an agent keeps that agent's local ` +
+  `sessions — and ${SESSION_LIST_ALL} stands alone.`;
 
 /** What one validated tool call asks for, ready for the bridge that carries it. */
 export type SessionToolAction =
@@ -204,7 +207,13 @@ export type AppToolAction =
       /** The effort riding the new value, when the developer named both. */
       effort?: string;
     }
-  | { kind: typeof APP_TOOL_KIND.PANEL; tab: AppPanelTab; filter?: string; sort?: SessionListSort }
+  | {
+      kind: typeof APP_TOOL_KIND.PANEL;
+      tab: AppPanelTab;
+      /** The validated narrowing, combined like the chips: OR within an axis, AND across. */
+      filters?: readonly string[];
+      sort?: SessionListSort;
+    }
   | { kind: typeof APP_TOOL_KIND.FEEDBACK; composer: FeedbackComposerKind; draft?: string }
   | { kind: "refused"; reason: string };
 
@@ -240,7 +249,16 @@ type JsonSchemaObjectProperty = {
   additionalProperties?: boolean;
 };
 
-type JsonSchemaProperty = JsonSchemaStringProperty | JsonSchemaObjectProperty;
+type JsonSchemaArrayProperty = {
+  type: "array";
+  description?: string;
+  items: JsonSchemaStringProperty;
+};
+
+type JsonSchemaProperty =
+  | JsonSchemaStringProperty
+  | JsonSchemaObjectProperty
+  | JsonSchemaArrayProperty;
 
 type JsonSchemaPropertyMap = {
   readonly [key: string]: JsonSchemaProperty;
@@ -785,39 +803,67 @@ function appSettingValue(setting: AppGuideSetting, value: UnparsedWireValue): st
 }
 
 /**
- * Validates a spoken session-list filter against the sessions actually being
- * observed. A filter that would show nothing is refused rather than applied:
- * the panel would quietly fall back to showing everything, and Luke would have
- * reported a narrowing that never happened. Every identity a row carries is a
- * filter on the same terms as its provider id — the agent behind a hosted
- * chat, an app associated with it, and a workspace manager's scope id — so a
- * spoken ask reaches exactly the rows the matching chip would keep.
+ * Whether one observed session answers one spoken filter value. Every
+ * identity a row carries is a filter on the same terms as its provider id —
+ * the agent behind a hosted chat, an app associated with it, and a workspace
+ * manager's scope id — so a spoken ask reaches exactly the rows the matching
+ * chip would keep.
  */
-function panelFilterAction(
-  filter: string,
-  sessions: readonly NormalizedSession[],
-): { filter: string } | { reason: string } {
-  if (filter === SESSION_LIST_ALL) return { filter };
+function sessionAnswersFilter(session: NormalizedSession, filter: string): boolean {
   if (filter === SESSION_LOCATION.LOCAL || filter === SESSION_LOCATION.CLOUD) {
-    if (sessions.some((session) => session.location === filter)) return { filter };
-    return { reason: `No ${filter} sessions are observed right now.` };
+    return session.location === filter;
   }
-  if (filter === SESSION_LIST_VOICE) {
-    if (sessions.some((session) => session.realtimeVoice === true)) return { filter };
-    return { reason: "No voice sessions are observed right now." };
+  if (filter === SESSION_LIST_VOICE) return session.realtimeVoice === true;
+  return (
+    session.providerId === filter ||
+    session.agent?.id === filter ||
+    session.workspace?.scopeId === filter ||
+    session.applications.some((application) => application.id === filter)
+  );
+}
+
+/**
+ * Validates a spoken session-list narrowing against the sessions actually
+ * being observed. A narrowing that would show nothing is refused rather than
+ * applied: the panel would quietly fall back to showing everything, and Luke
+ * would have reported a narrowing that never happened. Each value is checked
+ * on its own first, so the refusal can name the value that is wrong rather
+ * than only the combination — and then the combination is checked whole, on
+ * the same axis terms the chips combine on, because two values a roster
+ * answers separately can still name an intersection nothing occupies.
+ */
+function panelFiltersAction(
+  filters: readonly string[],
+  sessions: readonly NormalizedSession[],
+): { filters: readonly string[] } | { reason: string } {
+  const chosen = [...new Set(filters)];
+  if (chosen.includes(SESSION_LIST_ALL)) {
+    if (chosen.length > 1) {
+      return { reason: `${SESSION_LIST_ALL} is the whole list, so it combines with nothing.` };
+    }
+    return { filters: chosen };
+  }
+  for (const filter of chosen) {
+    if (sessions.some((session) => sessionAnswersFilter(session, filter))) continue;
+    if (filter === SESSION_LOCATION.LOCAL || filter === SESSION_LOCATION.CLOUD) {
+      return { reason: `No ${filter} sessions are observed right now.` };
+    }
+    if (filter === SESSION_LIST_VOICE) {
+      return { reason: "No voice sessions are observed right now." };
+    }
+    return {
+      reason: `No observed session belongs to an agent, app, or workspace manager "${filter}".`,
+    };
   }
   if (
-    sessions.some(
-      (session) =>
-        session.providerId === filter ||
-        session.agent?.id === filter ||
-        session.workspace?.scopeId === filter ||
-        session.applications.some((application) => application.id === filter),
+    chosen.length > 1 &&
+    !sessions.some((session) =>
+      matchesFilterSelection(chosen, (filter) => sessionAnswersFilter(session, filter)),
     )
   ) {
-    return { filter };
+    return { reason: "No observed session matches that combination of filters." };
   }
-  return { reason: "No observed session belongs to that agent, app, or workspace manager." };
+  return { filters: chosen };
 }
 
 function validateChangeAppSetting(parsed: WireRecord, context: AppToolContext): AppToolAction {
@@ -861,6 +907,23 @@ function validateChangeAppSetting(parsed: WireRecord, context: AppToolContext): 
   return { kind: APP_TOOL_KIND.SETTING, setting, value, effort };
 }
 
+/**
+ * Reads the narrowing a panel ask carries: several values, or a lone string
+ * for a narrowing of one. Blank entries are dropped rather than validated,
+ * and an emptied list is no narrowing at all.
+ */
+function spokenFilterValues(
+  value: UnparsedWireValue,
+): { values: readonly string[] | undefined } | { reason: string } {
+  if (value === undefined) return { values: undefined };
+  const entries = isWireString(value) ? [value] : value;
+  if (!Array.isArray(entries) || !entries.every((entry) => isWireString(entry))) {
+    return { reason: "filters takes a list of filter values." };
+  }
+  const cleaned = entries.map((entry) => entry.trim()).filter((entry) => entry.length > 0);
+  return { values: cleaned.length > 0 ? cleaned : undefined };
+}
+
 function validateShowPanel(parsed: WireRecord, context: AppToolContext): AppToolAction {
   const tab = parsed.tab ?? APP_PANEL_TAB.SESSIONS;
   if (!isAppPanelTab(tab)) {
@@ -870,18 +933,19 @@ function validateShowPanel(parsed: WireRecord, context: AppToolContext): AppTool
   if (sort !== undefined && !isSessionListSort(sort)) {
     return { kind: "refused", reason: "The list orders by urgency or by recency." };
   }
-  const filter = textArgument(parsed, "filter");
-  if (filter === undefined) {
+  const asked = spokenFilterValues(parsed.filters);
+  if ("reason" in asked) return { kind: "refused", reason: asked.reason };
+  if (asked.values === undefined) {
     const action: AppToolAction = { kind: APP_TOOL_KIND.PANEL, tab };
     if (sort !== undefined) action.sort = sort;
     return action;
   }
-  const outcome = panelFilterAction(filter, context.sessions);
+  const outcome = panelFiltersAction(asked.values, context.sessions);
   if ("reason" in outcome) return { kind: "refused", reason: outcome.reason };
   const action: AppToolAction = {
     kind: APP_TOOL_KIND.PANEL,
     tab,
-    filter: outcome.filter,
+    filters: outcome.filters,
   };
   if (sort !== undefined) action.sort = sort;
   return action;
@@ -1207,8 +1271,9 @@ export const REALTIME_TOOLS = {
             enum: Object.values(APP_PANEL_TAB),
             description: "The tab to show. Defaults to sessions.",
           },
-          filter: {
-            type: "string",
+          filters: {
+            type: "array",
+            items: { type: "string" },
             description: SESSION_LIST_FILTER_DESCRIPTION,
           },
           sort: {

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -1085,7 +1085,7 @@ test("the session is minted with the fifteen acts and nothing wider", () => {
 });
 
 test("show_panel teaches the whole filter vocabulary its validator accepts", () => {
-  const filter = REALTIME_TOOLS.SHOW_PANEL.schema.parameters.properties.filter.description;
+  const filter = REALTIME_TOOLS.SHOW_PANEL.schema.parameters.properties.filters.description;
 
   // The filter parameter has no enum — an agent filter is whatever
   // provider_id the roster currently lists — so its description is the only

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -65,6 +65,7 @@ import {
   maximumWorkspaceNameLength,
   normalizeSession,
   type ObservedWorkspaceProject,
+  PROVIDER_ID_LIST,
   SESSION_APPLICATION_ID,
   SESSION_LOCATION,
   SESSION_STATUS,
@@ -1084,27 +1085,25 @@ test("the session is minted with the fifteen acts and nothing wider", () => {
   assert.equal(config.tool_choice, "auto");
 });
 
-test("show_panel teaches the whole filter vocabulary its validator accepts", () => {
-  const filter = REALTIME_TOOLS.SHOW_PANEL.schema.parameters.properties.filters.description;
+test("show_panel's filter enum carries the whole vocabulary its validator accepts", () => {
+  const filters = REALTIME_TOOLS.SHOW_PANEL.schema.parameters.properties.filters;
+  const values = filters.items.enum;
 
-  // The filter parameter has no enum — an agent filter is whatever
-  // provider_id the roster currently lists — so its description is the only
-  // place the model learns the fixed half of the vocabulary. A value the
-  // validator accepts but the description never names is a narrowing no ask
-  // can reach.
-  assert.match(filter, /provider_id/);
+  // The enum is what binds the model to real tokens instead of the
+  // developer's own words for them — a value the validator accepts but the
+  // enum never lists is a narrowing no ask can reach, and the sets must stay
+  // the ones the chips draw from so the two cannot drift.
   const scopes = [
     SESSION_LIST_ALL,
     SESSION_LOCATION.LOCAL,
     SESSION_LOCATION.CLOUD,
     SESSION_LIST_VOICE,
   ];
-  for (const value of scopes) {
-    assert.ok(filter.includes(value), `filter description never names "${value}"`);
+  for (const value of [...scopes, ...PROVIDER_ID_LIST, ...Object.values(SESSION_APPLICATION_ID)]) {
+    assert.ok(values.includes(value), `the filter enum never lists "${value}"`);
   }
-  for (const applicationId of Object.values(SESSION_APPLICATION_ID)) {
-    assert.ok(filter.includes(applicationId), `filter description never names "${applicationId}"`);
-  }
+  // One token is one value however many sets carry it.
+  assert.equal(new Set(values).size, values.length);
 });
 
 test("a proactive turn is opened with its tools withheld", () => {

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -81,8 +81,12 @@ export {
 } from "./session.js";
 export {
   isSessionFilter,
+  matchesFilterSelection,
   SESSION_FILTER,
+  SESSION_FILTER_AXIS,
   type SessionFilter,
+  type SessionFilterAxis,
+  sessionFilterAxis,
 } from "./session-filter.js";
 export {
   firstWholeNameIndex,

--- a/packages/session/src/session-filter.ts
+++ b/packages/session/src/session-filter.ts
@@ -41,3 +41,65 @@ export function isSessionFilter(value: string): value is SessionFilter {
     isSessionApplicationId(value)
   );
 }
+
+/**
+ * The independent questions the filters answer. Each filter value belongs to
+ * exactly one axis, and the axis is what gives a combined selection its
+ * meaning: values on one axis are alternatives (either place, either agent),
+ * where values on different axes are each a further narrowing. The axes live
+ * beside the vocabulary because a combination is read in two places — the
+ * chips narrowing the drawn list, and a spoken ask validated against the
+ * observed roster — and the two readings must not drift apart.
+ */
+export const SESSION_FILTER_AXIS = {
+  LOCATION: "location",
+  KIND: "kind",
+  APP: "app",
+  AGENT: "agent",
+} as const;
+
+export type SessionFilterAxis = (typeof SESSION_FILTER_AXIS)[keyof typeof SESSION_FILTER_AXIS];
+
+/**
+ * Conductor and Superset land on the app axis even where a namesake provider
+ * exists, because "associated with that app" is the question their chips
+ * answer — a native cloud Conductor chat and a local Codex chat annotated by
+ * Conductor answer the same chip, and an agent chip beside it stays a further
+ * narrowing rather than a widening. The parameter is wider than
+ * {@link SessionFilter} because a spoken ask may name an identity only the
+ * roster knows — a hosted agent's own id — and it lands on the agent axis
+ * like the provider ids do.
+ */
+export function sessionFilterAxis(filter: string): SessionFilterAxis {
+  if (filter === SESSION_FILTER.LOCAL || filter === SESSION_FILTER.CLOUD) {
+    return SESSION_FILTER_AXIS.LOCATION;
+  }
+  if (filter === SESSION_FILTER.VOICE) return SESSION_FILTER_AXIS.KIND;
+  if (isSessionApplicationId(filter)) return SESSION_FILTER_AXIS.APP;
+  return SESSION_FILTER_AXIS.AGENT;
+}
+
+/**
+ * Whether a candidate answers the whole selection. Within one axis the values
+ * are ORed — Local and Cloud together is either place — and across axes they
+ * are ANDed — Codex beside Conductor is Codex chats associated with Conductor.
+ * An axis nothing is chosen on asks nothing, so an empty selection is the
+ * unnarrowed list. The candidate stays behind the predicate because the two
+ * callers hold sessions of different shapes; only the combining is shared.
+ */
+export function matchesFilterSelection<T extends string>(
+  filters: readonly T[],
+  matches: (filter: T) => boolean,
+): boolean {
+  const byAxis = new Map<SessionFilterAxis, T[]>();
+  for (const filter of filters) {
+    const axis = sessionFilterAxis(filter);
+    const held = byAxis.get(axis) ?? [];
+    held.push(filter);
+    byAxis.set(axis, held);
+  }
+  for (const alternatives of byAxis.values()) {
+    if (!alternatives.some(matches)) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
Stacked on #346.

## What broke

The filter chips combine — alternatives within one axis (local + cloud is either place), a further narrowing across axes (Codex + Conductor is Codex chats associated with Conductor) — but the spoken path carried exactly **one** filter string end to end: `show_panel` took a single `filter`, the validator checked a single value, and the renderer mapped a single token. "Show Conductor cloud sessions" or "local Codex voice chats" was not an ask Luke could carry.

## The fix

- **`show_panel` takes `filters`, a list.** A lone string is still read as a list of one, so a narrowing of one keeps working however the model spells it.
- **The combination is validated whole against the observed roster.** Each value must be answered by some observed session (with the same per-value refusals as before, now naming the value that failed), and then the combination must keep at least one row — two values a roster answers separately can still name an intersection nothing occupies, and a narrowing that would show nothing is refused rather than applied. `all` stands alone; combined with anything it is refused rather than guessed at.
- **The axis rules now live in `@sidecar/session`** (`SESSION_FILTER_AXIS`, `sessionFilterAxis`, `matchesFilterSelection`), where the filter vocabulary already lives. The validator in `@sidecar/realtime` and the chips in the renderer both read the one definition, so the two readings of what a combination means cannot drift apart. The renderer's `matchesSessionFilters` delegates to it unchanged in behavior.
- **The renderer maps the validated list onto the chips one-to-one**, replacing a hand-picked selection the way a spoken narrowing always has. An ask naming a value no chip of this build holds widens to everything with the existing note — the whole ask, because a selection quietly missing one of its values would show more than the reported sentence names.
- **The guide fact and the tool description teach the combined ask** in the same change, per the guide's own rule that a capability it does not describe is one Luke will deny having.

## Verification

`./scripts/check.sh` passes (exit 0): repository checks, typecheck, all workspace tests, and build. New tests cover the combination validation (valid combinations carried, empty intersections refused, `all` alone, unreadable lists refused, lone-string tolerance), the renderer's list mapping (dedupe, `all`, all-or-nothing on unknown values), and an end-to-end carried multi-filter ask plus a refused empty combination in the realtime session tests. Portable-only change — nothing drawn changes shape, so no visual evidence applies and no physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ef03be81-5ddd-4458-a538-80bf694896be)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32425149500/artifacts/9427175583) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32425149500)

- Commit: `41eaa293bbc10419bde4e05af7b97ca2cbe4730c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
