### PR TITLE
feat(sessions): open Conductor's local chats where its notifications point

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -256,13 +256,17 @@ is said back to you under the field you typed in.
 - For the Conductor workspaces on this Mac, Luke opens Conductor's own session
   index (`~/Library/Application Support/com.conductor.app/conductor.db`) in
   read-only defensive mode and reads one fixed query's worth of rows: each
-  session's agent kind, the agent's own session identifier, and the identifier
-  and name of the workspace holding it. That identifier is joined exactly to a
-  session Luke already observed on this machine — never inferred from a title
-  or a path — and the matched row gains the Conductor mark and groups under
-  its Conductor workspace. No message, transcript, or terminal content is
-  read through this database, an absent app or unknown schema means no
-  annotation, and nothing is ever sent to Conductor. A local Codex chat's row
+  session's agent kind, the agent's own session identifier, Conductor's own
+  identifier for the chat, and the identifier and name of the workspace
+  holding it. That identifier is joined exactly to a session Luke already
+  observed on this machine — never inferred from a title or a path — and the
+  matched row gains the Conductor mark and groups under its Conductor
+  workspace. A matched row also carries the chat's `conductor://` address,
+  composed on this machine from the observed workspace and chat identifiers;
+  opening it hands that address to macOS like any row press. No message,
+  transcript, or terminal content is read through this database, an absent
+  app or unknown schema means no annotation, and nothing is ever sent to
+  Conductor. A local Codex chat's row
   also carries a ChatGPT mark whose press opens the same `codex://` thread
   address the row itself opens, composed on this machine; nothing is sent to
   OpenAI by drawing or pressing it.

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -139,7 +139,7 @@ unreadable file, or a schema this build does not know means no annotation.
 | --- | --- | --- | --- |
 | ChatGPT | Nothing | A mark opening the exact Codex thread | None |
 | cmux | Hook-session stores under `~/.cmuxterm` | Mark, exact `cmux:` pane address | None |
-| Conductor | Local session index (`conductor.db`) | Mark, workspace grouping | None |
+| Conductor | Local session index (`conductor.db`) | Mark, workspace grouping, `conductor:` chat address | None |
 | Orca | Hook-status cache and worktree names | Mark, worktree grouping | None |
 | Superset | Host state (`host.db`) | Mark, grouping, `superset:` workspace address | Message, open workspace, close terminal, add agent, new workspace, rename, delete workspace — through its CLI, while logged in |
 
@@ -157,9 +157,15 @@ unreadable file, or a schema this build does not know means no annotation.
   cmux names its workspaces only by identifier; no writes, because cmux's
   control socket is password-guarded and undocumented for outside callers.
 - **Conductor** — the index is never used to open an agent transcript, and a
-  schema that predates workspaces annotates without grouping. Conductor
-  documents no exact address or message endpoint for a local chat, so the
-  association adds no open or send control.
+  schema that predates workspaces annotates without grouping. The address,
+  `conductor://workspace?id=<workspace>&session=<chat>`, is composed on this
+  machine from the observed workspace and chat ids — the same deep link
+  Conductor's own notifications fire — and stands in as the row's own link
+  where the chat's agent gave it none; a sub-agent's address is its ancestor
+  chat's, where its conversation lives in Conductor's window, and a
+  pre-workspace schema has no workspace id to address, so its rows keep none.
+  Conductor documents no message endpoint for a local chat, so the
+  association adds no send control.
 - **Orca** — the hook-status cache also carries conversational fields — the
   last prompt, a message preview, a tool's input — and none of them are ever
   read. A sub-agent

--- a/packages/providers/src/conductor/session-applications.test.ts
+++ b/packages/providers/src/conductor/session-applications.test.ts
@@ -298,9 +298,47 @@ test("groups a matched chat under its Conductor workspace like a manager", async
       id: SESSION_APPLICATION_ID.CONDUCTOR,
       displayName: "Conductor",
       scope: SESSION_APPLICATION_SCOPE.WORKSPACE,
+      link: "conductor://workspace?id=workspace-named&session=chat-named",
     },
   ]);
+  // The composed address is also the row's own press, because the chat's
+  // provider — a local one — reported none of its own.
+  assert.equal(
+    observations[0]?.detail?.link,
+    "conductor://workspace?id=workspace-named&session=chat-named",
+  );
   assert.equal(observations[1]?.workspace?.name, "kingstown");
+  assert.equal(
+    observations[1]?.detail?.link,
+    "conductor://workspace?id=workspace-plain&session=chat-plain",
+  );
+});
+
+test("a provider-reported address keeps the row press; the mark keeps its own", async (t) => {
+  const databasePath = await temporaryDatabasePath(t);
+  const database = createConductorDatabase(databasePath);
+  try {
+    writeWorkspace(database, "workspace-named", "lisbon-v2", "kingstown");
+    writeSession(
+      database,
+      "chat-named",
+      "local",
+      TEST_CONDUCTOR_AGENT_TYPE.CLAUDE,
+      "workspace-named",
+    );
+  } finally {
+    database.close();
+  }
+  const snapshot = await new ConductorSessionApplicationReader({ databasePath }).read();
+  const observations = snapshot.enrich(PROVIDER_ID.CLAUDE_CODE, [
+    { ...OBSERVED_CHAT, detail: { link: "https://example.com/session/local" } },
+  ]);
+
+  assert.equal(observations[0]?.detail?.link, "https://example.com/session/local");
+  assert.equal(
+    observations[0]?.applications?.[0]?.link,
+    "conductor://workspace?id=workspace-named&session=chat-named",
+  );
 });
 
 test("a spawned descendant inherits its ancestor's Conductor workspace", async (t) => {
@@ -331,6 +369,12 @@ test("a spawned descendant inherits its ancestor's Conductor workspace", async (
 
   assert.deepEqual(observations[1]?.workspace, observations[0]?.workspace);
   assert.deepEqual(observations[1]?.applications, observations[0]?.applications);
+  // The inherited address is the ancestor chat's, where the sub-agent's
+  // conversation actually lives in Conductor's own window.
+  assert.equal(
+    observations[1]?.detail?.link,
+    "conductor://workspace?id=workspace-parent&session=chat-parent",
+  );
 });
 
 test("keeps another manager's workspace and stays on the row instead", async (t) => {
@@ -360,13 +404,15 @@ test("keeps another manager's workspace and stays on the row instead", async (t)
   ]);
 
   // The first manager to group the chat keeps it; Conductor still identifies
-  // itself, on the row, where no tray header would carry its mark.
+  // itself, on the row, where no tray header would carry its mark — and the
+  // mark keeps the chat's own Conductor address either way.
   assert.deepEqual(observations[0]?.workspace, supersetWorkspace);
   assert.deepEqual(observations[0]?.applications, [
     {
       id: SESSION_APPLICATION_ID.CONDUCTOR,
       displayName: "Conductor",
       scope: SESSION_APPLICATION_SCOPE.SESSION,
+      link: "conductor://workspace?id=workspace-conductor&session=chat-managed",
     },
   ]);
 });

--- a/packages/providers/src/conductor/session-applications.ts
+++ b/packages/providers/src/conductor/session-applications.ts
@@ -53,10 +53,26 @@ export function conductorAgent(value: string | undefined): SessionProvider | und
 
 const CONDUCTOR_SESSION_FIELD = {
   AGENT_TYPE: "agent_type",
+  CONDUCTOR_SESSION_ID: "conductor_session_id",
   PROVIDER_SESSION_ID: "provider_session_id",
   WORKSPACE_ID: "workspace_id",
   WORKSPACE_NAME: "workspace_name",
 } as const;
+
+/**
+ * The address of one chat in Conductor's own app — the same deep link
+ * Conductor's notifications fire, composed here from the observed workspace
+ * and chat ids, so opening stays what every open is: an address handed to
+ * the operating system, reaching no provider. Conductor's handler requires
+ * the workspace id and takes the chat id as the focus inside it, which is
+ * why a session without a workspace has no address at all.
+ */
+export function conductorWorkspaceLink(workspaceId: string, conductorChatId?: string): string {
+  const link = new URL("conductor://workspace");
+  link.searchParams.set("id", workspaceId);
+  if (conductorChatId !== undefined) link.searchParams.set("session", conductorChatId);
+  return link.toString();
+}
 
 /**
  * Conductor's provider-session column kept its original Claude-specific name
@@ -68,6 +84,7 @@ const CONDUCTOR_SESSION_QUERY = `
   SELECT
     sessions.claude_session_id AS ${CONDUCTOR_SESSION_FIELD.PROVIDER_SESSION_ID},
     sessions.agent_type AS ${CONDUCTOR_SESSION_FIELD.AGENT_TYPE},
+    sessions.id AS ${CONDUCTOR_SESSION_FIELD.CONDUCTOR_SESSION_ID},
     workspaces.id AS ${CONDUCTOR_SESSION_FIELD.WORKSPACE_ID},
     COALESCE(workspaces.workspace_name, workspaces.directory_name)
       AS ${CONDUCTOR_SESSION_FIELD.WORKSPACE_NAME}
@@ -92,6 +109,8 @@ const CONDUCTOR_SESSION_QUERY_WITHOUT_WORKSPACES = `
 
 /** What Conductor's own index says about one session it holds. */
 interface ConductorSessionContext {
+  /** Conductor's own id for the chat, which its deep link takes as the focus. */
+  conductorSessionId?: string;
   workspaceId?: string;
   workspaceName?: string;
 }
@@ -194,13 +213,26 @@ export class ConductorSessionApplicationSnapshot {
               managerName: CONDUCTOR_APPLICATION_NAME,
             }
           : undefined;
+      // The address needs the workspace id — Conductor's handler drops a
+      // link without one — and a sub-agent's inherited context addresses the
+      // ancestor chat, which is where its conversation lives. The app that
+      // wrote the index is the scheme's handler, so the address stands with
+      // no credential at all. A native provider address still wins as the
+      // row's primary press; the Conductor association keeps its own.
+      const link = context.workspaceId
+        ? conductorWorkspaceLink(context.workspaceId, context.conductorSessionId)
+        : undefined;
       const application: SessionApplication = {
         id: SESSION_APPLICATION_ID.CONDUCTOR,
         displayName: CONDUCTOR_APPLICATION_NAME,
         scope: workspace ? SESSION_APPLICATION_SCOPE.WORKSPACE : SESSION_APPLICATION_SCOPE.SESSION,
+        ...(link ? { link } : undefined),
       };
+      const detail =
+        link && !observation.detail?.link ? { ...observation.detail, link } : observation.detail;
       return {
         ...observation,
+        ...(detail ? { detail } : undefined),
         applications: [...(observation.applications ?? []), application],
         ...(workspace ? { workspace } : undefined),
       };
@@ -245,11 +277,13 @@ export class ConductorSessionApplicationReader {
       const type = agentType(record[CONDUCTOR_SESSION_FIELD.AGENT_TYPE]);
       const providerSessionId = text(record[CONDUCTOR_SESSION_FIELD.PROVIDER_SESSION_ID]);
       if (!type || !providerSessionId) continue;
+      const conductorSessionId = text(record[CONDUCTOR_SESSION_FIELD.CONDUCTOR_SESSION_ID]);
       const workspaceId = text(record[CONDUCTOR_SESSION_FIELD.WORKSPACE_ID]);
       const workspaceName = text(record[CONDUCTOR_SESSION_FIELD.WORKSPACE_NAME]);
       const providerId = CONDUCTOR_AGENT_BY_TYPE[type].id;
       const sessions = sessionsByProvider.get(providerId) ?? new Map();
       sessions.set(providerSessionId, {
+        ...(conductorSessionId ? { conductorSessionId } : undefined),
         ...(workspaceId ? { workspaceId } : undefined),
         ...(workspaceName ? { workspaceName } : undefined),
       });


### PR DESCRIPTION
## What

A local Conductor-annotated row gains its chat's own address,
`conductor://workspace?id=<workspace>&session=<chat>`, composed on this
machine from the workspace and chat ids already in the session index Luke
reads. The address rides the Conductor mark, and becomes the row's own press
where the chat's provider reported no address of its own — the exact shape
Superset's managed rows already keep.

## Why this address

Conductor's public deep-link docs cover only workspace creation
(`conductor://prompt=…`), which is why the local annotation previously added
no open control. But Conductor's own notifications deep link every session
status change: its frontend builds
`conductor://workspace?id=<workspaceId>&session=<sessionId>` and hands it to
a native notification, and its incoming-link parser resolves that host to an
open-workspace action (`id` required, `session` an optional focus). Both ids
are the same `workspaces.id` / `sessions.id` the annotation already reads
from `conductor.db`. The scheme matches the production app's registered
`conductor` handler, which is already in `SESSION_LINK_SCHEME`.

## Bounds kept

- A sub-agent's address is its ancestor chat's, where its conversation lives
  in Conductor's window.
- A schema from before workspaces has no workspace id to address, so its rows
  stay without one — Conductor's parser drops a link without `id`.
- Opening stays what every open is: an address handed to the operating
  system, reaching no provider and needing no credential.
- `docs/PROVIDERS.md` and `PRIVACY.md` move in the same change.

## Validation

- `./scripts/check.sh` passes (exit 0) under Node 24. Portable-only change:
  packages and docs, no renderer or Electron code, so no visual evidence run.
- `packages/providers` Conductor session-application tests: 9/9 pass,
  including new coverage for the composed address, a provider-reported
  address winning the row press, sub-agent inheritance, and the
  pre-workspace schema keeping no address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32424720893/artifacts/9427017775) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32424720893)

- Commit: `7c991bea938042aeda9d0ce6cb7418db7620c3bf`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
