### PR TITLE
fix(voice): name the session in status-edge announcements

### DIFF
--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -411,6 +411,7 @@ const PROACTIVE_SPEECH_INSTRUCTIONS = [
 
 const STATUS_EDGE_INSTRUCTIONS = [
   "Summarize the status update in the last message in one or two short sentences, then stop.",
+  'Name the session by its title — never a bare "the session", which leaves the developer guessing which one.',
 ].join("\n");
 
 export const maximumNoticeContextLength = 1_400;


### PR DESCRIPTION
## Summary

Luke's status-edge announcements could say "the session is ready" without naming which session, leaving the developer guessing among their open agents. The payload handed to the voice already carries the session's title (`session: "..."` from `sessionNoticeSpeech`), but `STATUS_EDGE_INSTRUCTIONS` only asked for a summary, so the model was free to drop the name.

This adds a second instruction line telling the voice to name the session by its title and never say a bare "the session".

## Testing

- `./scripts/check.sh` passes (lint, typecheck, tests, build) — portable-only change, no UI or macOS surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c4dac86c-a4a9-48de-b449-1109aa4930a3)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32425058344/artifacts/9427137588) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32425058344)

- Commit: `66c4bd00a08ade1c778e95da5b3f9755dd2afd57`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
