### PR TITLE
fix(realtime): route session-list asks to the panel filter

### DIFF
--- a/packages/realtime/src/realtime-tools.ts
+++ b/packages/realtime/src/realtime-tools.ts
@@ -950,7 +950,11 @@ export const REALTIME_TOOLS = {
     name: "open_session",
     family: REALTIME_TOOL_FAMILY.SESSION,
     schema: {
-      description: "Open an observed session.",
+      description:
+        "Open one observed session where its provider keeps it — only when the developer asks " +
+        "to open, go to, or jump into that specific session. An ask to show, see, or list " +
+        'sessions or agents — "show me the cloud agents" — filters the panel through ' +
+        "show_panel instead, never this.",
       parameters: {
         type: "object",
         properties: { ...SESSION_IDENTITY_PARAMETERS },
@@ -1198,7 +1202,9 @@ export const REALTIME_TOOLS = {
     family: REALTIME_TOOL_FAMILY.APP,
     schema: {
       description:
-        "Show Luke's panel on a tab — and, on the sessions tab, narrow or reorder the list.",
+        "Show Luke's panel on a tab — and, on the sessions tab, narrow or reorder the list. " +
+        'An ask to show, see, or list sessions or agents of some kind — "show me the Codex ' +
+        'agents", "show me my local sessions" — is this tool with a filter, not open_session.',
       parameters: {
         type: "object",
         properties: {


### PR DESCRIPTION
A spoken or typed "show me X agents/sessions" sometimes routed to `open_session`, opening one chat in its app, when the developer meant to filter the session list. The spoken tool descriptions were terse enough to invite it: `open_session` said only "Open an observed session." and `show_panel` only "Show Luke's panel."

Each description now names the other tool at the boundary — `open_session` is only for an ask to open, go to, or jump into one specific session, and an ask to show, see, or list sessions of a kind is `show_panel` with a filter — and the `filter` parameter now says its vocabulary ("all", "local", "cloud", "voice", or an observed provider, agent, workspace, or app id).

No behavior or validation changes; the strings are the prompt the voice model chooses tools by. `./scripts/check.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/e013815a-5fb1-4a50-b0ec-420124679381)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32425425918/artifacts/9427273329) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32425425918)

- Commit: `463c2938988f31cd50b97751fc9f0f7937909d51`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
