### PR TITLE
fix(voice): name a session's app associations in the roster

### DIFF
--- a/packages/realtime/src/realtime-context.ts
+++ b/packages/realtime/src/realtime-context.ts
@@ -130,7 +130,8 @@ function sessionSpokenName(session: NormalizedSession): string {
  * These are the same bounded, redacted fields the attention layer already
  * sends — provider, title, status, when last seen, repository or branch,
  * current tool, reported error, and the provider's own recap — plus the
- * workspace a chat belongs to when its provider groups them, the developer's
+ * workspace a chat belongs to when its provider groups them, the apps that
+ * independently associate themselves with it, the developer's
  * standing ask where one stands, what each session can be asked to do, and the
  * identity a tool call names it by. No transcript, file path, or command output
  * is ever included.
@@ -165,6 +166,17 @@ export function sessionContextText(
         ...(session.workspace?.name
           ? [
               `a chat in workspace ${session.workspace.name}${session.workspace.managerName ? ` managed by ${session.workspace.managerName}` : ""}`,
+            ]
+          : []),
+        // An app that independently claims the session is how "my cmux Cursor
+        // session" reads apart from the agent's other rows, so each
+        // association rides by name — and only by name: the pane address
+        // behind it stays on the machine, like every other link.
+        ...(session.applications.length > 0
+          ? [
+              `associated with ${session.applications
+                .map((application) => application.displayName)
+                .join(" and ")}`,
             ]
           : []),
         session.status,

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -66,6 +66,7 @@ import {
   normalizeSession,
   type ObservedWorkspaceProject,
   SESSION_APPLICATION_ID,
+  SESSION_APPLICATION_SCOPE,
   SESSION_LOCATION,
   SESSION_STATUS,
   WORKSPACE_TASK_SUPPORT,
@@ -705,6 +706,44 @@ test("the roster identifies sessions managed by Superset", () => {
   );
 
   assert.match(sessionContextText([chat]), /managed by Superset/);
+});
+
+test("the roster names a session's app associations, so 'my cmux Cursor session' resolves", () => {
+  const annotated = normalizeSession(
+    { id: "cursor", displayName: "Cursor" },
+    {
+      providerSessionId: "cursor-1",
+      title: "Refit the settings drawer",
+      status: SESSION_STATUS.WORKING,
+      observedAt: DECIDED_AT,
+      applications: [
+        {
+          id: SESSION_APPLICATION_ID.CMUX,
+          displayName: "cmux",
+          scope: SESSION_APPLICATION_SCOPE.SESSION,
+          link: "cmux://workspace/workspace-1/surface/surface-1",
+        },
+      ],
+    },
+  );
+
+  const text = sessionContextText([annotated]);
+
+  assert.match(text, /associated with cmux/);
+  // The association travels by name alone; the pane address stays on the machine.
+  assert.doesNotMatch(text, /cmux:\/\//);
+
+  // A session no app claimed says nothing about associations at all.
+  const unclaimed = normalizeSession(
+    { id: "cursor", displayName: "Cursor" },
+    {
+      providerSessionId: "cursor-2",
+      title: "Chase the flaky test",
+      status: SESSION_STATUS.WORKING,
+      observedAt: DECIDED_AT,
+    },
+  );
+  assert.doesNotMatch(sessionContextText([unclaimed]), /associated with/);
 });
 
 test("the roster names a hosted chat by its agent, with the host beside it", () => {


### PR DESCRIPTION
## Problem

Asking Luke to "open my cmux Cursor session" couldn't pinpoint the session. `show_panel`'s filter vocabulary already teaches the app ids, and the panel filter matches them — but the session roster lines the voice conversation actually reads never said which apps claim a session, so among several Cursor rows the cmux one was indistinguishable.

## Fix

Each roster line in `sessionContextText` now carries the session's app associations by display name ("associated with cmux"), beside the workspace segment. Only the name travels: the `cmux://` pane address behind an association stays on the machine, like every other link the roster redacts.

## Tests

- New test: an annotated session's roster line names the association and never leaks the pane address; an unclaimed session says nothing about associations.
- `./scripts/check.sh` passes (exit 0). Portable-only change — no macOS/UI surface touched, so no visual evidence run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/8e6889bb-dd17-41f3-b575-96f5bbf7c0e5)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32425958463/artifacts/9427448958) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32425958463)

- Commit: `93ca4020a868e611c9ae49df0d632fc0dcec1397`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
