### PR TITLE
fix(duck): ignore quit signals so the helper lives to restore

### DIFF
--- a/apps/desktop/native/macos/MediaDuck.swift
+++ b/apps/desktop/native/macos/MediaDuck.swift
@@ -71,7 +71,9 @@ private let MEDIA_DUCK_COMMAND = (duck: "duck", restore: "restore")
 
 private func emit(_ line: String) {
     guard let payload = "\(line)\n".data(using: .utf8) else { return }
-    FileHandle.standardOutput.write(payload)
+    // A diagnostic that cannot be delivered — the parent and its pipe already
+    // gone — must not take the restore down with it.
+    try? FileHandle.standardOutput.write(contentsOf: payload)
 }
 
 /// One Apple Event, or nothing. A player that refuses — consent denied, the
@@ -135,6 +137,16 @@ private struct MediaDuckCommand {
     static var ducked: [String: DuckedPlayer] = [:]
 
     static func main() {
+        // The signals that quit the app must not quit the helper: Luke and
+        // this process share a group, so the Ctrl+C or teardown that ends a
+        // terminal run reaches both, and a helper killed mid-duck restores
+        // nothing. Stdin closing stays the one exit, and it always restores;
+        // SIGPIPE joins the list so a restore whose diagnostic has no pipe
+        // left to land in still runs to the end.
+        signal(SIGINT, SIG_IGN)
+        signal(SIGTERM, SIG_IGN)
+        signal(SIGHUP, SIG_IGN)
+        signal(SIGPIPE, SIG_IGN)
         FileHandle.standardInput.readabilityHandler = { handle in
             let data = handle.availableData
             DispatchQueue.main.async {


### PR DESCRIPTION
## Summary

- Quitting Luke mid-sentence through a terminal Ctrl+C or a process-group teardown stranded the ducked players quiet: the media-duck helper shares Luke's process group, so the same signal that quit the app killed the helper before the stdin EOF that asks it to restore could arrive. The helper now ignores SIGINT, SIGTERM, SIGHUP, and SIGPIPE — stdin closing stays its one exit, and that exit always restores. The pre-`main()` window is benign: a helper killed before it can ignore signals has not yet processed a `duck`, so there is nothing to restore.
- `emit` now uses the throwing `FileHandle.write(contentsOf:)` behind `try?`, so a refusal diagnostic met during the final restore cannot take the restore down with it when the parent's stdout pipe is already gone.
- Verified on a physical Mac against the rebuilt helper in the exact production spawn shape: it survives SIGINT/SIGTERM/SIGHUP, still exits 0 on stdin EOF, and leaves no orphan on abrupt parent death. The pre-fix binary died instantly on SIGINT with no restore.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (exit 0)
- macOS Electron verification (`./scripts/verify.sh`): passed on a physical Mac — zero test failures, six fixture evidence PNGs generated under `artifacts/evidence/`

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32426099093/artifacts/9427503556) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32426099093)

- Commit: `a666583e2087bec014eb6e261225a3e4d37387fb`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` (no UI change; behavioral fix verified by the lifecycle experiments above)
- Physical-notch check: `not performed` (not a UI change)
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: If a stranded duck is ever reproduced on a packaged build quit via Cmd+Q (no signal involved), that would point at a second cause — Apple Events refused for the orphaned helper once its responsible app is gone — needing a restore-and-wait before quit instead of restore-after-EOF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)