### PR TITLE
feat(voice): record the developer's spoken turns in the conversation history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,7 +359,8 @@ What Luke may show:
   issues, or a transcript rendering, which travel only on conversations the
   developer opens, and the rendering only in the turn that asked for it. A
   developer-opened conversation also carries a bounded history of the recent
-  exchange itself — the developer's typed asks, the words Luke already spoke
+  exchange itself — the developer's own asks, typed or spoken and handed back
+  as text by the same service that heard them, the words Luke already spoke
   or announced, and the acts he carried at the developer's ask — so the one
   conversation survives the calls that transport it: an announcement read out
   on Luke's own call, or a call retired idle, is still remembered by the next

--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -97,6 +97,8 @@ interface Harness {
   captionSubjects: (string | undefined)[];
   /** The words each ended reply left behind, with its announced subject. */
   replyEndings: { texts: readonly string[]; about: string | undefined }[];
+  /** The developer's spoken turns, as the service handed them back. */
+  spokenAsks: string[];
   microphoneEnabled: () => boolean;
   microphoneStopped: () => boolean;
   emit: (event: JsonValue) => void;
@@ -199,6 +201,7 @@ function harness(
   const captions: (readonly string[] | undefined)[] = [];
   const captionSubjects: (string | undefined)[] = [];
   const replyEndings: { texts: readonly string[]; about: string | undefined }[] = [];
+  const spokenAsks: string[] = [];
   const requests: { url: string; init: RequestInit }[] = [];
   const calls: string[] = [];
   let enabled = false;
@@ -336,6 +339,9 @@ function harness(
         );
       }
     },
+    onSpokenAsk: (transcript) => {
+      spokenAsks.push(transcript);
+    },
   };
   if (options.connectTimeoutMs !== undefined) {
     sessionOptions.connectTimeoutMs = options.connectTimeoutMs;
@@ -364,6 +370,7 @@ function harness(
     captions,
     captionSubjects,
     replyEndings,
+    spokenAsks,
     microphoneEnabled: () => enabled,
     microphoneStopped: () => stopped,
     lukeAudible: () => remoteTrack.enabled,
@@ -1914,6 +1921,35 @@ test("a reply ending at teardown writes nothing back into the retired call", asy
   await armDeveloperTurn(context);
 
   assert.deepEqual(contextItems(context, "[recent conversation", sentBefore), []);
+});
+
+test("the developer's spoken words come back only from their own call", async () => {
+  const context = harness();
+  await context.session.connect();
+
+  context.emit({
+    type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED,
+    item_id: "item-1",
+    transcript: "how is the checkout agent doing?",
+  });
+
+  assert.deepEqual(context.spokenAsks, ["how is the checkout agent doing?"]);
+});
+
+test("a speak-only call has no spoken turns to hand back", async () => {
+  const context = harness();
+  await context.session.connect({ microphone: false });
+
+  // The speak-only shape offers no microphone, so a transcription arriving on
+  // it speaks for nobody: the guard keeps a stray event from ever writing a
+  // developer line into the history.
+  context.emit({
+    type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED,
+    item_id: "item-1",
+    transcript: "how is the checkout agent doing?",
+  });
+
+  assert.deepEqual(context.spokenAsks, []);
 });
 
 test("a reply hands its words back as it ends, whole and once", async () => {

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -233,6 +233,14 @@ export interface RealtimeVoiceSessionCallbacks {
    * heard); the caller records them so the thread survives the call.
    */
   onReplyEnded?(texts: readonly string[], about: SessionIdentity | undefined): void;
+  /**
+   * The developer's own spoken turn, as the voice service transcribed it. It
+   * arrives on the transcription's clock — often after the reply to it has
+   * already begun — and only from the developer's own call: a speak-only call
+   * offers no microphone, so it has no spoken turns to hand back. The caller
+   * records the words so the thread holds both halves of the exchange.
+   */
+  onSpokenAsk?(transcript: string): void;
 }
 
 /**
@@ -2249,6 +2257,12 @@ export class RealtimeVoiceSession {
           this.#clearSettleTimer();
           this.#armSettleTimer();
         }
+        return;
+      case REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED:
+        // Only the developer's own call has spoken turns to hand back; the
+        // guard is belt to the speak-only shape's suspenders, so a stray
+        // event on Luke's own call can never write a developer line.
+        if (this.#withMicrophone) this.#options.onSpokenAsk?.(event.transcript);
         return;
       case REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED:
         this.#audioEndingsReported = true;

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -657,6 +657,11 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
         if (about || spokeTranscript) return;
         rememberConversationEntry({ kind: CONVERSATION_ENTRY_KIND.REPLY, words: texts.join(" ") });
       },
+      // The developer's spoken words, back from the service that heard them:
+      // recorded like a typed ask, so the thread holds both halves of the
+      // exchange whichever way the developer asked.
+      onSpokenAsk: (transcript) =>
+        rememberConversationEntry({ kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK, words: transcript }),
     });
     return voiceSession.current;
   }, [rememberConversationEntry, setVoiceStatus]);

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -10,6 +10,7 @@ import {
   CONVERSATION_ENTRY_KIND,
   type ConversationEntry,
   dispatchByKind,
+  insertSpokenAskEntry,
   REALTIME_STATUS,
   type RealtimeStatus,
   type RealtimeVoice,
@@ -567,6 +568,39 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     voiceSession.current?.updateConversation(conversationRef.current);
   }, []);
 
+  /**
+   * Where the spoken turn now owed a transcription belongs in the history:
+   * the entry the history ended with at the moment the turn committed —
+   * everything recorded after that mark is the turn's own produce. Marked at
+   * the commit edge, consumed by the transcription, and overwritten by the
+   * next commit, so a transcription that never arrives leaves nothing stale
+   * standing.
+   */
+  const spokenTurnMarkRef = useRef<{ after: ConversationEntry | undefined } | undefined>(undefined);
+  /** The status an edge is read against, for the commit mark above. */
+  const previousVoiceStatus = useRef<RealtimeStatus>(REALTIME_STATUS.IDLE);
+
+  /**
+   * Records a spoken ask where its turn happened rather than where its
+   * transcription landed: the words come back on the service's own clock,
+   * sometimes after the reply they asked for has ended, and an exchange
+   * stored in reverse would be re-fed in reverse to every later call. A
+   * transcription with no mark to land on — a turn delivered without a
+   * listening edge — appends plainly, which is the order said in the common
+   * case of the words beating the reply.
+   */
+  const rememberSpokenAsk = useCallback((transcript: string) => {
+    const mark = spokenTurnMarkRef.current;
+    spokenTurnMarkRef.current = undefined;
+    conversationRef.current = mark
+      ? insertSpokenAskEntry(conversationRef.current, transcript, mark.after)
+      : appendConversationEntry(conversationRef.current, {
+          kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK,
+          words: transcript,
+        });
+    voiceSession.current?.updateConversation(conversationRef.current);
+  }, []);
+
   const ensureVoiceSession = useCallback((): RealtimeVoiceSession => {
     voiceSession.current ??= new RealtimeVoiceSession({
       requestConnection: () => window.sidecar.requestRealtimeCredential(),
@@ -657,14 +691,13 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
         if (about || spokeTranscript) return;
         rememberConversationEntry({ kind: CONVERSATION_ENTRY_KIND.REPLY, words: texts.join(" ") });
       },
-      // The developer's spoken words, back from the service that heard them:
-      // recorded like a typed ask, so the thread holds both halves of the
-      // exchange whichever way the developer asked.
-      onSpokenAsk: (transcript) =>
-        rememberConversationEntry({ kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK, words: transcript }),
+      // The developer's spoken words, back from the service that heard them,
+      // placed where their turn happened: the thread holds both halves of
+      // the exchange, in the order they were said.
+      onSpokenAsk: rememberSpokenAsk,
     });
     return voiceSession.current;
-  }, [rememberConversationEntry, setVoiceStatus]);
+  }, [rememberConversationEntry, rememberSpokenAsk, setVoiceStatus]);
 
   /**
    * The announcer that lets Luke speak into silence: it queues the notices the
@@ -1056,6 +1089,17 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     if (voiceStatus === REALTIME_STATUS.LISTENING) {
       transcriptSpokenRef.current = false;
     }
+    // A spoken turn committing — the microphone closing into a reply — is the
+    // moment its ask belongs at: the words come back later, on the
+    // transcription's own clock, and this mark is what lets them land where
+    // the turn actually was rather than behind a reply that outran them.
+    if (
+      previousVoiceStatus.current === REALTIME_STATUS.LISTENING &&
+      voiceStatus === REALTIME_STATUS.RESPONDING
+    ) {
+      spokenTurnMarkRef.current = { after: conversationRef.current.at(-1) };
+    }
+    previousVoiceStatus.current = voiceStatus;
     // Any settled status ends the wait the press started, however it ended:
     // listening takes the meter live, ready means the turn was dropped
     // mid-handshake, and a failure has its own message to show. Unless the

--- a/packages/realtime/src/conversation-history.test.ts
+++ b/packages/realtime/src/conversation-history.test.ts
@@ -166,6 +166,18 @@ test("the rendering reads oldest first and says who each line speaks for", () =>
   assert.match(lines[4] ?? "", /\[provider_id=claude-code provider_session_id=session-a\]$/);
 });
 
+test("a spoken ask reads as the developer's own words, said rather than typed", () => {
+  const entries = appendConversationEntry([], {
+    kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK,
+    words: "how is the checkout agent doing?",
+  });
+
+  const text = conversationHistoryText(entries, []);
+
+  assert.ok(text);
+  assert.match(text, /^- the developer said: "how is the checkout agent doing\?"$/m);
+});
+
 test("a line whose session left the roster keeps its words and drops the identity", () => {
   const entries = appendConversationEntry([], {
     kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,

--- a/packages/realtime/src/conversation-history.test.ts
+++ b/packages/realtime/src/conversation-history.test.ts
@@ -12,6 +12,7 @@ import {
   CONVERSATION_ENTRY_KIND,
   type ConversationEntry,
   conversationHistoryText,
+  insertSpokenAskEntry,
   maximumConversationEntries,
   maximumConversationEntryLength,
   sessionActConversationEntry,
@@ -167,15 +168,75 @@ test("the rendering reads oldest first and says who each line speaks for", () =>
 });
 
 test("a spoken ask reads as the developer's own words, said rather than typed", () => {
-  const entries = appendConversationEntry([], {
-    kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK,
-    words: "how is the checkout agent doing?",
-  });
+  const entries = insertSpokenAskEntry([], "how is the checkout agent doing?", undefined);
 
   const text = conversationHistoryText(entries, []);
 
   assert.ok(text);
   assert.match(text, /^- the developer said: "how is the checkout agent doing\?"$/m);
+});
+
+test("a spoken ask lands at its turn's own mark, not where its transcription did", () => {
+  // A completed exchange already stands, and its last entry is the mark the
+  // next spoken turn commits over. The turn's reply outruns the
+  // transcription; the ask still lands between the old exchange and the new
+  // reply — where the turn actually was.
+  const priorReply: ConversationEntry = {
+    kind: CONVERSATION_ENTRY_KIND.REPLY,
+    words: "The checkout work is done.",
+  };
+  const exchange: readonly ConversationEntry[] = [
+    { kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK, words: "how is checkout going?" },
+    priorReply,
+    { kind: CONVERSATION_ENTRY_KIND.ACT, words: 'sent a message to "checkout-service": "go"' },
+    { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "Sent it over." },
+  ];
+
+  const placed = insertSpokenAskEntry(exchange, "ask that chat to ship it", priorReply);
+
+  assert.deepEqual(
+    placed.map((entry) => entry.words),
+    [
+      "how is checkout going?",
+      "The checkout work is done.",
+      "ask that chat to ship it",
+      'sent a message to "checkout-service": "go"',
+      "Sent it over.",
+    ],
+  );
+
+  // A transcription that beats the reply finds nothing behind its mark and
+  // lands at the end — the order everything was said in.
+  const onTime = insertSpokenAskEntry(exchange.slice(0, 2), "and what broke?", priorReply);
+  assert.deepEqual(
+    onTime.map((entry) => entry.words),
+    ["how is checkout going?", "The checkout work is done.", "and what broke?"],
+  );
+
+  // A turn committed against an empty history belongs at the very front, and
+  // so does one whose mark the bounds have already retired: both are older
+  // than everything recorded since.
+  const first = insertSpokenAskEntry(exchange, "the very first ask", undefined);
+  assert.equal(first[0]?.words, "the very first ask");
+  const retired = insertSpokenAskEntry(exchange, "an ancient ask", {
+    kind: CONVERSATION_ENTRY_KIND.REPLY,
+    words: "long evicted",
+  });
+  assert.equal(retired[0]?.words, "an ancient ask");
+
+  // The same flattening and bounds as an append: nothing left, nothing placed.
+  assert.deepEqual(insertSpokenAskEntry(exchange, "   ", priorReply), exchange);
+  let full: readonly ConversationEntry[] = [];
+  for (let index = 0; index < maximumConversationEntries; index += 1) {
+    full = appendConversationEntry(full, {
+      kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
+      words: `line ${index}`,
+    });
+  }
+  assert.equal(
+    insertSpokenAskEntry(full, "one more", full.at(-1)).length,
+    maximumConversationEntries,
+  );
 });
 
 test("a line whose session left the roster keeps its words and drops the identity", () => {

--- a/packages/realtime/src/conversation-history.ts
+++ b/packages/realtime/src/conversation-history.ts
@@ -71,11 +71,43 @@ export function appendConversationEntry(
   entries: readonly ConversationEntry[],
   entry: ConversationEntry,
 ): readonly ConversationEntry[] {
-  const words = entry.words.replace(/\s+/g, " ").trim().slice(0, maximumConversationEntryLength);
+  const words = boundedEntryWords(entry.words);
   if (!words) return entries;
   const appended: ConversationEntry = { kind: entry.kind, words };
   if (entry.identity) appended.identity = entry.identity;
   return [...entries, appended].slice(-maximumConversationEntries);
+}
+
+/** One flattening and one bound for every line, however it enters. */
+function boundedEntryWords(words: string): string {
+  return words.replace(/\s+/g, " ").trim().slice(0, maximumConversationEntryLength);
+}
+
+/**
+ * Places a spoken ask where its turn actually happened. The transcription
+ * arrives on the service's own clock — usually while the reply is still being
+ * spoken, sometimes after it has ended — and a plain append would then store
+ * Luke's answer ahead of the developer's question, re-feeding a reversed
+ * exchange to the next call. The place is the caller's mark, not a guess
+ * against the entries: `after` is the entry the history ended with at the
+ * moment the spoken turn committed — everything behind it is that turn's own
+ * produce — or nothing for a turn committed against an empty history, which
+ * belongs at the very front. A mark the bounds have already retired lands
+ * there too: an ask older than everything left comes before all of it.
+ */
+export function insertSpokenAskEntry(
+  entries: readonly ConversationEntry[],
+  words: string,
+  after: ConversationEntry | undefined,
+): readonly ConversationEntry[] {
+  const bounded = boundedEntryWords(words);
+  if (!bounded) return entries;
+  // indexOf answers -1 for a retired mark, so the ask lands at the front —
+  // exactly where an entry older than the whole history belongs.
+  const at = after ? entries.indexOf(after) + 1 : 0;
+  const placed = [...entries];
+  placed.splice(at, 0, { kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK, words: bounded });
+  return placed.slice(-maximumConversationEntries);
 }
 
 /**

--- a/packages/realtime/src/conversation-history.ts
+++ b/packages/realtime/src/conversation-history.ts
@@ -7,7 +7,8 @@
  * and re-fed to whichever call the developer opens next.
  *
  * Every line already traveled to the voice service once, on the call that
- * said it: the developer's own typed asks, the words Luke spoke or announced,
+ * said it: the developer's own asks — typed, or spoken and handed back as
+ * text by the service that heard them — the words Luke spoke or announced,
  * and the acts he carried at the developer's ask. Nothing else may enter —
  * not a roster, not a transcript rendering, not an outcome a provider
  * answered with — and the record lives in memory alone, dying with the app.
@@ -21,6 +22,8 @@ import { type CarriedSessionAction, dispatchByKind, SESSION_TOOL_KIND } from "./
 export const CONVERSATION_ENTRY_KIND = {
   /** The developer's own words, typed into Luke's composer. */
   TYPED_ASK: "typed-ask",
+  /** The developer's own spoken turn, as the voice service transcribed it. */
+  SPOKEN_ASK: "spoken-ask",
   /** The words Luke spoke as a conversation reply. */
   REPLY: "reply",
   /** The bounded announcement payload Luke put in front of the developer. */
@@ -149,6 +152,7 @@ export function sessionActConversationEntry(
  */
 const CONVERSATION_ENTRY_LEAD = {
   [CONVERSATION_ENTRY_KIND.TYPED_ASK]: "the developer typed",
+  [CONVERSATION_ENTRY_KIND.SPOKEN_ASK]: "the developer said",
   [CONVERSATION_ENTRY_KIND.REPLY]: "Luke said",
   [CONVERSATION_ENTRY_KIND.ANNOUNCEMENT]: "Luke announced",
   [CONVERSATION_ENTRY_KIND.ACT]: "at the developer's ask, Luke",

--- a/packages/realtime/src/index.ts
+++ b/packages/realtime/src/index.ts
@@ -5,6 +5,7 @@ export {
   type ConversationEntry,
   type ConversationEntryKind,
   conversationHistoryText,
+  insertSpokenAskEntry,
   maximumConversationEntries,
   maximumConversationEntryLength,
   sessionActConversationEntry,

--- a/packages/realtime/src/realtime-credentials.ts
+++ b/packages/realtime/src/realtime-credentials.ts
@@ -99,6 +99,10 @@ export function realtimeSessionConfig(options: RealtimeSessionOptions = {}) {
         // call and never reads this.
         format: { type: "audio/pcm", rate: PRESS_AUDIO_SAMPLE_RATE },
         turn_detection: null,
+        // The developer's spoken turns come back as text, so their own words
+        // can enter the conversation history beside Luke's. The audio already
+        // travels to this same service to be heard at all.
+        transcription: { model: REALTIME_DEFAULTS.TRANSCRIPTION_MODEL },
       },
       output: {
         voice: trimmedText(options.voice) ?? REALTIME_DEFAULTS.VOICE,
@@ -113,7 +117,12 @@ export function realtimeSessionConfig(options: RealtimeSessionOptions = {}) {
   };
 }
 
-/** Reasserts the local build's instructions and tools after any credential source opens a call. */
+/**
+ * Reasserts the local build's instructions and tools after any credential
+ * source opens a call. The transcription rides along for the same reason: the
+ * hosted mint composes its session on the service, so the one place every
+ * call can be asked to hand the developer's words back is the call itself.
+ */
 export function realtimeSessionSyncEvents(): readonly WireRecord[] {
   const built = [
     {
@@ -123,6 +132,7 @@ export function realtimeSessionSyncEvents(): readonly WireRecord[] {
         instructions: realtimeInstructions(),
         tools: realtimeToolDefinitions(),
         tool_choice: "auto",
+        audio: { input: { transcription: { model: REALTIME_DEFAULTS.TRANSCRIPTION_MODEL } } },
       },
     },
   ];

--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -119,6 +119,13 @@ export const REALTIME_SERVER_EVENT = {
   RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA: "response.output_audio_transcript.delta",
   /** The reply's complete text, which supersedes whatever the deltas built. */
   RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DONE: "response.output_audio_transcript.done",
+  /**
+   * The developer's own spoken turn, as the service transcribed it. It
+   * arrives on its own clock — transcription runs beside the reply, not ahead
+   * of it — and it is the one way their spoken words come back as text at
+   * all, so the conversation history can hold both halves of the exchange.
+   */
+  INPUT_AUDIO_TRANSCRIPTION_COMPLETED: "conversation.item.input_audio_transcription.completed",
   RESPONSE_DONE: "response.done",
   ERROR: "error",
 } as const;
@@ -510,6 +517,10 @@ export type ParsedRealtimeServerEvent =
       itemId?: string;
       transcript: string;
     }
+  | {
+      type: typeof REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED;
+      transcript: string;
+    }
   | { type: typeof REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED; responseId?: string }
   | { type: typeof REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STARTED; responseId?: string }
   | {
@@ -644,6 +655,16 @@ export function parseRealtimeServerEvent(
       };
       if (itemId) parsed.itemId = itemId;
       return parsed;
+    }
+    case REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED: {
+      // A transcription that came back empty said nothing worth a history
+      // line, and a failed one arrives as its own event this parser ignores.
+      const transcript = text(event.transcript);
+      if (!transcript) return undefined;
+      return {
+        type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED,
+        transcript,
+      };
     }
     case REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED: {
       // The drain names the response it drained. An old reply's buffer can

--- a/packages/realtime/src/realtime-voice-settings.ts
+++ b/packages/realtime/src/realtime-voice-settings.ts
@@ -60,4 +60,11 @@ export const REALTIME_DEFAULTS = {
   MODEL: "gpt-realtime-2.1",
   VOICE: REALTIME_VOICE.CEDAR,
   SPEED: REALTIME_VOICE_SPEED.NORMAL,
+  /**
+   * What transcribes the developer's spoken turns, so their own words can
+   * enter the conversation history beside Luke's. The audio already travels
+   * to the same service to be heard at all; this only asks it to hand the
+   * text back.
+   */
+  TRANSCRIPTION_MODEL: "gpt-4o-mini-transcribe",
 } as const;

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -45,6 +45,7 @@ import {
   realtimeClientSecretRequest,
   realtimeCredentialFromResponse,
   realtimeCredentialIsUsable,
+  realtimeSessionSyncEvents,
   sessionContextEvents,
   sessionContextText,
   sessionToolAction,
@@ -141,6 +142,15 @@ test("the minted session closes the microphone until push-to-talk opens it", () 
   // An always-open microphone is the one thing a desk-side sidecar must not have.
   assert.equal(config.audio.input.turn_detection, null);
   assert.equal(realtimeClientSecretRequest().session.type, REALTIME_SESSION_TYPE);
+});
+
+test("the minted session asks for the developer's spoken words back as text", () => {
+  // The audio already travels to this same service to be heard at all; the
+  // transcription only hands the text back, so the history can hold both
+  // halves of the exchange.
+  assert.deepEqual(realtimeSessionConfig().audio.input.transcription, {
+    model: REALTIME_DEFAULTS.TRANSCRIPTION_MODEL,
+  });
 });
 
 test("the minted session chooses how it gives way at the edge of the window", () => {
@@ -313,12 +323,6 @@ test("every offered pace is recognized and anything else is refused", () => {
   }
 });
 
-test("nothing asks the API for a transcript it will not show", () => {
-  const config = realtimeSessionConfig();
-
-  assert.equal("transcription" in config.audio.input, false);
-});
-
 test("a reply can be stopped by the developer taking the turn", () => {
   // Cancelling is only half of it. The model generates faster than it speaks,
   // so the rest of the sentence has already been sent by the time anyone talks
@@ -393,6 +397,18 @@ test("the keyed mint pins the same input format the appends travel as", () => {
   assert.deepEqual(config.audio.input.format, {
     type: "audio/pcm",
     rate: PRESS_AUDIO_SAMPLE_RATE,
+  });
+});
+
+test("the session sync asks every call for the developer's words back", () => {
+  // The hosted mint composes its session on the service, so the sync the
+  // channel opens with is the one place every call — hosted or keyed — can be
+  // asked to transcribe the developer's spoken turns.
+  const [sync] = realtimeSessionSyncEvents();
+
+  assert.ok(sync && isRecord(sync.session));
+  assert.deepEqual(sync.session.audio, {
+    input: { transcription: { model: REALTIME_DEFAULTS.TRANSCRIPTION_MODEL } },
   });
 });
 
@@ -1101,6 +1117,17 @@ test("inbound events the conversation acts on are parsed, and nothing else is", 
     }),
     { type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STARTED, responseId: "resp-1" },
   );
+  assert.deepEqual(
+    parseRealtimeServerEvent({
+      type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED,
+      item_id: "item-2",
+      transcript: "how is the checkout agent doing?",
+    }),
+    {
+      type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED,
+      transcript: "how is the checkout agent doing?",
+    },
+  );
   assert.deepEqual(parseRealtimeServerEvent({ type: REALTIME_SERVER_EVENT.RESPONSE_DONE }), {
     type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
     calls: [],
@@ -1139,6 +1166,8 @@ test("inbound events the conversation acts on are parsed, and nothing else is", 
     {},
     { type: REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_CLEARED },
     { type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA, item_id: "item-1" },
+    // A transcription that came back empty said nothing worth acting on.
+    { type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED, transcript: "  " },
     { type: "session.updated" },
   ];
   for (const payload of payloads) {


### PR DESCRIPTION
## What

Stacked on #354. The conversation history held only one half of a spoken exchange: Luke's replies entered it as they ended, but the developer's spoken words never came back as text — so a reconnected call remembered every answer and none of the questions (typed asks were already recorded; spoken ones were not).

- `realtimeSessionConfig` now asks for input transcription (`gpt-4o-mini-transcribe`, a new `REALTIME_DEFAULTS.TRANSCRIPTION_MODEL`), and `realtimeSessionSyncEvents` re-asserts it per call — the hosted mint composes its session on the service, so the channel's own sync is the one place every call, hosted or keyed, can be asked.
- The protocol parses `conversation.item.input_audio_transcription.completed`; an empty transcript parses to nothing.
- The session hands the transcript to a new `onSpokenAsk` callback — only on the developer's own call: a speak-only call offers no microphone, and the `#withMicrophone` guard is belt to that shape's suspenders.
- The hook records it as a new `SPOKEN_ASK` entry kind, rendered "the developer said: …" beside the typed asks.

## Trust boundaries

- The audio already travels to this same service to be heard at all; transcription only hands the text back, into the same bounded, in-memory, never-on-disk history.
- One deliberate policy change: the old test "nothing asks the API for a transcript it will not show" pinned a config that requested no transcription because nothing used it. The history now uses it, so that test is superseded by one pinning the new ask. `AGENTS.md` trust prose moves in the same change.

## Verification

- `./scripts/check.sh` passes (exit 0).
- `./scripts/verify.sh` not run locally (Linux cloud workspace); the macOS CI job stands in. No visual surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32428782572/artifacts/9428381332) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32428782572)

- Commit: `c81b171f6a1094aba905d822f8eef8305fe26bf1`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
