### PR TITLE
chore(voice): retire idle calls sooner now that the history holds the thread

### DIFF
--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -600,13 +600,14 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
             detail:
               "One conversation outlives the calls that carry it. A call opens on the first " +
               "press of the talk key or the first typed ask, stays open across as many turns as " +
-              "the developer takes, and is put away after ten minutes with nothing said on it — " +
-              "which releases the microphone rather than holding it all day. The voice service " +
+              "the developer takes, and is put away after three minutes with nothing said on " +
+              "it — which releases the microphone rather than holding it all day, and costs " +
+              "only the next handshake. The voice service " +
               "also ends any call at an hour. Either way the next press picks the conversation " +
               "back up: a bounded history of the recent exchange — what was asked, answered, " +
               "announced, and done — is kept in memory and re-fed to the new call, so Luke " +
               "remembers what was just said without writing anything to disk. A call that ends " +
-              "underneath a conversation says so, and nothing said is lost with it.",
+              "underneath a conversation ends quietly, because nothing said is lost with it.",
           },
           {
             label: "When a call fails",

--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -5194,32 +5194,18 @@ test("a device that vanishes mid-conversation fails the call at the press", asyn
   assert.ok(reportedErrors(context).some((message) => /microphone went away/i.test(message)));
 });
 
-test("a call that drops mid-conversation says so, and how to start again", async () => {
+test("a call that drops goes quietly, because the history lost nothing", async () => {
   const context = harness();
   await context.session.connect();
   context.session.updateSessions([observedSession("session-a")]);
   await armDeveloperTurn(context);
 
   // The service ends every session at an hour, so this is how a long
-  // conversation ordinarily ends rather than an exotic failure.
+  // conversation ordinarily ends rather than an exotic failure — and the
+  // conversation lives in the history, which the next press re-feeds, so a
+  // warning here would report a loss that no longer happens.
   context.closeChannel();
 
-  assert.equal(context.session.status, REALTIME_STATUS.IDLE);
-  const reported = reportedErrors(context).at(-1) ?? "";
-  assert.match(reported, /call ended/i);
-  // Silence here is what made Luke seem to have forgotten on purpose, so the
-  // line carries the way back into a conversation.
-  assert.match(reported, /talk key/i);
-});
-
-test("a call that drops before anything was said goes quietly", async () => {
-  const context = harness();
-  await context.session.connect();
-
-  context.closeChannel();
-
-  // Nothing was lost, so there is nothing to report: a notice here would be a
-  // fault shown for a conversation that never happened.
   assert.equal(context.session.status, REALTIME_STATUS.IDLE);
   assert.deepEqual(reportedErrors(context), []);
 });

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -83,16 +83,18 @@ export const REALTIME_SETTLE_TIMEOUT_MS = 20_000;
  * How long the developer's call stays open with nothing being said on it.
  *
  * The capture device never rides this clock — it opens with a press and
- * closes with the turn — so what ten minutes buys is the conversation itself:
- * the thread Luke would otherwise lose. The service ends the session at an
- * hour regardless, so the choice was never between keeping this conversation
- * and losing it — only between letting go of it deliberately and being cut
- * off mid-sentence.
+ * closes with the turn — and neither does the conversation: the history holds
+ * the thread on this side of the wire and re-feeds whichever call opens
+ * next, so retiring a call forgets nothing. What the hold buys is only the
+ * reconnect handshake, which makes this a cost knob rather than Luke's
+ * memory: an open call is a held connection and a session the service is
+ * keeping warm, paid for by the minute.
  *
- * Ten minutes is longer than any pause inside a conversation and shorter than
- * the walk to get a coffee. Coming back costs one handshake.
+ * Three minutes is longer than any pause inside a conversation — the gap
+ * that means the developer walked away, not the gap between two questions —
+ * and coming back costs one handshake.
  */
-export const VOICE_IDLE_TIMEOUT_MS = 10 * 60_000;
+export const VOICE_IDLE_TIMEOUT_MS = 3 * 60_000;
 
 /**
  * The order context is flushed in, so a turn's items land the same way every
@@ -646,13 +648,6 @@ export class RealtimeVoiceSession {
    * cancelled the moment anything is being said on it.
    */
   #idleTimer: unknown;
-  /**
-   * Whether the developer has taken a turn on this call. It is what makes a
-   * dropped connection worth mentioning: a call that carried a conversation
-   * takes the conversation with it, and Luke would otherwise answer the next
-   * question having quietly forgotten the last one.
-   */
-  #conversationBegan = false;
 
   constructor(options: RealtimeVoiceSessionOptions) {
     this.#options = options;
@@ -786,22 +781,16 @@ export class RealtimeVoiceSession {
       channel.onmessage = (event) => this.#handleServerEvent(event.data);
       channel.onclose = () => {
         if (this.#closed) return;
-        // What the call was holding has to be read before the teardown empties
-        // it. A call that carried a conversation takes the conversation with
-        // it, and the service ends every session at an hour whether or not
-        // anyone is finished talking — so this is the ordinary end of a long
-        // one, not an exotic failure.
-        const lost = this.#conversationBegan;
+        // The service ends every session at an hour whether or not anyone is
+        // finished talking, so this is the ordinary end of a long call, not
+        // an exotic failure — and it costs nothing said: the history holds
+        // the conversation on this side of the wire, and the next press
+        // re-feeds it, so quiet is the honest report rather than a warning
+        // about a thread nobody lost.
         // A channel that closes on its own still leaves the capture running,
         // so this has to release the device as thoroughly as an explicit stop.
         this.#teardown();
         this.#setStatus(REALTIME_STATUS.IDLE);
-        // Silence here is what made Luke seem to have forgotten on purpose:
-        // the next question was answered by someone who had never heard the
-        // last one, and nothing said so.
-        if (lost) {
-          this.#options.onError("The call ended. Press the talk key to start again.");
-        }
       };
 
       // One deadline covers the SDP exchange and the channel opening together.
@@ -1617,7 +1606,6 @@ export class RealtimeVoiceSession {
     this.#contextLive.clear();
     this.#pendingSupersedes.clear();
     this.#pendingInterruptions.clear();
-    this.#conversationBegan = false;
     this.#clearIdleTimer();
     this.#responseOutstanding = false;
     this.#audioDrained = false;
@@ -1657,7 +1645,6 @@ export class RealtimeVoiceSession {
     // himself get none: a readout has a sentence to say and nothing to look up,
     // and a tool follow-up is answering from what this same flush already sent.
     if (toolsArmed) {
-      this.#conversationBegan = true;
       this.#flushContext();
     }
     // The track is deliberately left as it is. A reply that was cut off left it


### PR DESCRIPTION
## What

Stacked on #355. With the conversation history (#354) held on this side of the wire, two pieces of call-lifecycle machinery stopped earning their keep:

- **`VOICE_IDLE_TIMEOUT_MS` drops from 10 minutes to 3.** The ten-minute hold existed to keep "the thread Luke would otherwise lose" — it was Luke's memory, not a cost decision. Retiring a call now forgets nothing, so the hold buys only the reconnect handshake, and the timeout becomes the cost knob it always looked like: an open call is a held connection and a session the service keeps warm by the minute.
- **The dropped-call warning ("The call ended. Press the talk key to start again.") is removed, along with `#conversationBegan`,** which existed only to decide whether to show it. The warning was the honest report when losing the channel silently lost the conversation; nothing is lost now, so quiet is the honest report — a warning would announce a loss that no longer happens.

## Verification

- `./scripts/check.sh` passes (exit 0).
- `./scripts/verify.sh` not run locally (Linux cloud workspace); the macOS CI job stands in. No visual surface changed.
- Worth a hands-on QA pass on a Mac alongside the stack: let a call idle out, press the talk key again, and confirm Luke picks the thread back up from the history with no error strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32428781670/artifacts/9428383254) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32428781670)

- Commit: `d9dcdfcdbf155c3c75531548da4dc8b96bda73f9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
