### PR TITLE
docs(providers): record why Orca rows open nowhere

### DIFF
--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -185,7 +185,11 @@ unreadable file, or a schema this build does not know means no annotation.
   read. A sub-agent
   inherits through its provider's own parent record, and a chat another
   manager already groups keeps that workspace with the Orca mark on the row
-  alone.
+  alone. No address, because Orca registers no URL scheme at all — even its
+  own notification clicks focus a pane over internal process messaging, so
+  there is no link to hand the operating system; and no writes, because its
+  control paths are a daemon socket undocumented for outside callers. The
+  honest absence stands rather than an improvised control.
 - **Superset** — every act runs the CLI's documented command, invoked directly
   without a shell, in a developer-opened turn, carrying only observed
   identifiers beside the developer's own words; the login serves one


### PR DESCRIPTION
## What

Restores — and strengthens — the rationale the Apps restructure compressed out
of the Orca note: why a matched Orca row carries no address and no writes.

## Why now

After #349 gave local Conductor rows the same composed address Superset rows
carry, Orca became the one app whose matched rows open nowhere, so the
absence was investigated the same way Conductor's address was found:

- Orca's Info.plist (and its bundled helper app's) registers no
  `CFBundleURLTypes`, its bundle contains no `setAsDefaultProtocolClient`
  call, and LaunchServices holds no `orca:` scheme binding — while `cmux:`
  and `conductor:` are both bound. The only `orca://` string in the build,
  `orca://pair?code=`, is a pairing-code paste format, not navigation.
- Orca's own notification clicks do not travel through URLs either: the
  Electron main process sends internal IPC (`ui:focusTerminal` with
  tab/worktree/leaf ids) straight to its own window. There is nothing an
  outside app can hand the operating system.

So there is no address to compose, and the repository rule — keep unsupported
capabilities explicit; do not invent fallback controls — asks for exactly
this sentence instead.

## Validation

`./scripts/check.sh` passes (exit 0) under Node 24. Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32426153848/artifacts/9427514976) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32426153848)

- Commit: `ec500aa8a72de757108933c0ab99338fb8b9752c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
