### PR TITLE
chore(release): prepare 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,51 @@
 Notable changes to Luke, newest first. Each heading is a released version and
 the date its release was published.
 
+## 0.3.4 — 2026-08-20
+
+### Improvements
+
+- Luke reads this Mac's own calendars to stay quiet while you are in a meeting
+  ([#311](https://github.com/ReviewStage/luke/pull/311))
+- Luke observes local Gemini CLI sessions alongside your other coding agents
+  ([#347](https://github.com/ReviewStage/luke/pull/347))
+- Luke opens local Conductor chats at the exact place their notifications point
+  ([#349](https://github.com/ReviewStage/luke/pull/349))
+- Luke shows each session's app marks on spoken announcement notices
+  ([#340](https://github.com/ReviewStage/luke/pull/340))
+- Luke combines session filters in spoken asks just like the panel chips do
+  ([#348](https://github.com/ReviewStage/luke/pull/348))
+
+### Fixes
+
+- Fixed voice replies ending early when audio resumes after draining
+  ([#342](https://github.com/ReviewStage/luke/pull/342))
+- Fixed the web service failing to load its function sources
+  ([#343](https://github.com/ReviewStage/luke/pull/343))
+- Fixed unanswered cloud writes appearing to have failed
+  ([#345](https://github.com/ReviewStage/luke/pull/345))
+- Fixed spoken announcements interrupting the developer's active conversation
+  ([#344](https://github.com/ReviewStage/luke/pull/344))
+- Fixed spoken panel asks misunderstanding session filters and sort order
+  ([#346](https://github.com/ReviewStage/luke/pull/346))
+- Fixed status-edge announcements omitting the session name
+  ([#350](https://github.com/ReviewStage/luke/pull/350))
+- Fixed session-list asks bypassing the panel's session filter
+  ([#351](https://github.com/ReviewStage/luke/pull/351))
+- Fixed spoken session answers omitting the apps that hold each session
+  ([#352](https://github.com/ReviewStage/luke/pull/352))
+- Fixed media volume restoration being skipped when Luke quits
+  ([#353](https://github.com/ReviewStage/luke/pull/353))
+
+### Miscellaneous
+
+- Added the electron-builder release path
+  ([#324](https://github.com/ReviewStage/luke/pull/324))
+- Updated the installer volume name to Luke Installer
+  ([#339](https://github.com/ReviewStage/luke/pull/339))
+- Updated the provider documentation around agents, apps, and read/write surfaces
+  ([#341](https://github.com/ReviewStage/luke/pull/341))
+
 ## 0.3.3 — 2026-08-20
 
 ### Improvements

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@luke/desktop",
   "productName": "Luke",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "description": "Luke desktop application",
   "main": "dist/main.js",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luke/web",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "description": "Luke landing page",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luke",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "description": "A notch-attached desktop sidecar for coding-agent sessions",
   "packageManager": "pnpm@9.15.0",

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/account",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/analytics",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/attention/package.json
+++ b/packages/attention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/attention",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/calendar",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/credentials",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/feedback",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/fixtures/package.json
+++ b/packages/fixtures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/fixtures",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/guide/package.json
+++ b/packages/guide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/guide",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hosted/package.json
+++ b/packages/hosted/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/hosted",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/issues/package.json
+++ b/packages/issues/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/issues",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/oauth",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/observation/package.json
+++ b/packages/observation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/observation",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/providers",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/realtime",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/session",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/settings",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/superset/package.json
+++ b/packages/superset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/superset",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/surface/package.json
+++ b/packages/surface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/surface",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/trackers/package.json
+++ b/packages/trackers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/trackers",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/voice",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/wire/package.json
+++ b/packages/wire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/wire",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -64,7 +64,7 @@ function packagerOptions(signing = resolveSigningMode({})) {
     appUpdateConfigPath: `/repo/apps/desktop/.build/${APP_UPDATE_CONFIG_FILE_NAME}`,
     entitlementsPath,
     signing,
-    version: "0.3.3",
+    version: "0.3.4",
   });
 }
 
@@ -98,7 +98,7 @@ test("the bundle carries the updater config electron-updater reads before every 
   );
 });
 
-test("workspace package versions agree on v0.3.3", () => {
+test("workspace package versions agree on v0.3.4", () => {
   // Enumerated rather than listed, so a package added to the workspace is held
   // to the release version without anyone remembering to name it here.
   const packagePaths = [
@@ -122,7 +122,7 @@ test("workspace package versions agree on v0.3.3", () => {
 
   assert.deepEqual(
     versions.map(({ version }) => version),
-    packagePaths.map(() => "0.3.3"),
+    packagePaths.map(() => "0.3.4"),
   );
 });
 


### PR DESCRIPTION
## Summary

- prepare Luke 0.3.4 across every workspace package
- publish release notes for the 16 changes merged since 0.3.3
- update the packaging version contract

## Verification

- `./scripts/verify.sh` passed on current head
- repository and design contracts passed
- lint and type checks passed with 24 existing Biome warnings and existing Oxlint warnings
- 54 harness tests passed; all recursive package tests passed, including 699 desktop tests
- web and desktop builds passed
- native macOS helpers and the arm64 Electron app packaged successfully
- generated expanded, compact, peek, key-slot, speaking, and muted evidence was inspected with no visual regression found
- physical-notch verification was not performed

## Test plan

- [x] Full macOS verification
- [x] Generated visual evidence inspection
- [ ] Physical-notch hardware check (not required for this metadata-only release PR)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32426729483/artifacts/9427708567) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32426729483)

- Commit: `125b4675f79697148e50a415614ce819099d32b2`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
