### PR TITLE
fix(providers): drop Conductor chats the user filed away locally

### DIFF
--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -145,15 +145,16 @@ The bounds the tables cannot carry:
 ## Apps
 
 An app's chats are observed by their own agents' adapters; the app's own state
-is read solely for where those sessions live. Matching is by exact provider
-session id — never by title or filesystem path — and an absent app, an
-unreadable file, or a schema this build does not know means no annotation.
+is read solely for where those sessions live — and, for Conductor, whether the
+user filed them away there. Matching is by exact provider session id — never
+by title or filesystem path — and an absent app, an unreadable file, or a
+schema this build does not know means no annotation.
 
 | App | Reads | Adds to matched rows | Writes |
 | --- | --- | --- | --- |
 | ChatGPT | Nothing | A mark opening the exact Codex thread | None |
 | cmux | Hook-session stores under `~/.cmuxterm` | Mark, exact `cmux:` pane address | None |
-| Conductor | Local session index (`conductor.db`) | Mark, workspace grouping, `conductor:` chat address | None |
+| Conductor | Local session index (`conductor.db`) | Mark, workspace grouping, `conductor:` chat address, filed-away filtering | None |
 | Orca | Hook-status cache and worktree names | Mark, worktree grouping | None |
 | Superset | Host state (`host.db`) | Mark, grouping, `superset:` workspace address | Message, open workspace, close terminal, add agent, new workspace, rename, delete workspace — through its CLI, while logged in |
 
@@ -178,8 +179,14 @@ unreadable file, or a schema this build does not know means no annotation.
   where the chat's agent gave it none; a sub-agent's address is its ancestor
   chat's, where its conversation lives in Conductor's window, and a
   pre-workspace schema has no workspace id to address, so its rows keep none.
-  Conductor documents no message endpoint for a local chat, so the
-  association adds no send control.
+  A chat the user filed away on Conductor's own surface — the chat hidden on
+  its own, or its whole workspace archived — is dropped from the roster with
+  its sub-agents, the same way the cloud adapter drops an archived
+  workspace's chats: the agent's transcript outlives the chat the user
+  already said goodbye to. Only Conductor's positive record drops a row; an
+  absent app, an unreadable index, or a schema too old to say leaves every
+  observation standing. Conductor documents no message endpoint for a local
+  chat, so the association adds no send control.
 - **Orca** — the hook-status cache also carries conversational fields — the
   last prompt, a message preview, a tool's input — and none of them are ever
   read. A sub-agent

--- a/packages/providers/src/conductor/session-applications.test.ts
+++ b/packages/providers/src/conductor/session-applications.test.ts
@@ -35,12 +35,14 @@ function createConductorDatabase(databasePath: string): DatabaseSync {
       id TEXT PRIMARY KEY,
       claude_session_id TEXT,
       agent_type TEXT,
-      workspace_id TEXT
+      workspace_id TEXT,
+      is_hidden INTEGER DEFAULT 0
     );
     CREATE TABLE workspaces (
       id TEXT PRIMARY KEY,
       workspace_name TEXT,
-      directory_name TEXT
+      directory_name TEXT,
+      state TEXT DEFAULT 'active'
     );
   `);
   return database;
@@ -65,12 +67,13 @@ function writeSession(
   providerSessionId: string,
   agentType: string,
   workspaceId?: string,
+  hidden?: boolean,
 ): void {
   database
     .prepare(
-      "INSERT INTO sessions (id, claude_session_id, agent_type, workspace_id) VALUES (?, ?, ?, ?)",
+      "INSERT INTO sessions (id, claude_session_id, agent_type, workspace_id, is_hidden) VALUES (?, ?, ?, ?, ?)",
     )
-    .run(id, providerSessionId, agentType, workspaceId ?? null);
+    .run(id, providerSessionId, agentType, workspaceId ?? null, hidden ? 1 : 0);
 }
 
 function writeWorkspace(
@@ -78,10 +81,13 @@ function writeWorkspace(
   id: string,
   workspaceName: string | undefined,
   directoryName: string,
+  state?: string,
 ): void {
   database
-    .prepare("INSERT INTO workspaces (id, workspace_name, directory_name) VALUES (?, ?, ?)")
-    .run(id, workspaceName ?? null, directoryName);
+    .prepare(
+      "INSERT INTO workspaces (id, workspace_name, directory_name, state) VALUES (?, ?, ?, ?)",
+    )
+    .run(id, workspaceName ?? null, directoryName, state ?? "active");
 }
 
 test("indexes supported provider session ids from Conductor records", async (t) => {
@@ -415,6 +421,64 @@ test("keeps another manager's workspace and stays on the row instead", async (t)
       link: "conductor://workspace?id=workspace-conductor&session=chat-managed",
     },
   ]);
+});
+
+test("drops chats filed away in Conductor: hidden chats and archived workspaces", async (t) => {
+  const databasePath = await temporaryDatabasePath(t);
+  const database = createConductorDatabase(databasePath);
+  try {
+    writeWorkspace(database, "workspace-open", "lisbon-v2", "kingstown", "ready");
+    writeWorkspace(database, "workspace-filed", "adana-v1", "kingstown", "archived");
+    writeSession(database, "chat-open", "open", TEST_CONDUCTOR_AGENT_TYPE.CLAUDE, "workspace-open");
+    writeSession(
+      database,
+      "chat-hidden",
+      "hidden",
+      TEST_CONDUCTOR_AGENT_TYPE.CLAUDE,
+      "workspace-open",
+      true,
+    );
+    writeSession(
+      database,
+      "chat-archived",
+      "archived",
+      TEST_CONDUCTOR_AGENT_TYPE.CLAUDE,
+      "workspace-filed",
+    );
+  } finally {
+    database.close();
+  }
+  const snapshot = await new ConductorSessionApplicationReader({ databasePath }).read();
+  const observations = snapshot.enrich(PROVIDER_ID.CLAUDE_CODE, [
+    { ...OBSERVED_CHAT, providerSessionId: "open", title: "Open" },
+    { ...OBSERVED_CHAT, providerSessionId: "hidden", title: "Hidden" },
+    { ...OBSERVED_CHAT, providerSessionId: "archived", title: "Archived" },
+    // A sub-agent of a filed-away chat was filed away with its parent.
+    {
+      ...OBSERVED_CHAT,
+      providerSessionId: "archived-child",
+      parentProviderSessionId: "archived",
+      title: "Archived child",
+    },
+    // A cloud row with a coincidentally equal provider id is never Conductor's.
+    {
+      ...OBSERVED_CHAT,
+      providerSessionId: "archived",
+      title: "Cloud twin",
+      location: SESSION_LOCATION.CLOUD,
+    },
+  ]);
+
+  assert.deepEqual(
+    observations.map((observation) => observation.title),
+    ["Open", "Cloud twin"],
+  );
+  assert.deepEqual(observations[0]?.workspace, {
+    providerWorkspaceId: "workspace-open",
+    name: "lisbon-v2",
+    scopeId: SESSION_APPLICATION_ID.CONDUCTOR,
+    managerName: "Conductor",
+  });
 });
 
 test("a schema from before workspaces still annotates, without grouping", async (t) => {

--- a/packages/providers/src/conductor/session-applications.ts
+++ b/packages/providers/src/conductor/session-applications.ts
@@ -9,7 +9,7 @@ import {
   type SessionApplication,
   type SessionProvider,
 } from "@sidecar/session";
-import { text, type UnparsedWireValue, wireRecord } from "@sidecar/wire";
+import { text, type UnparsedWireValue, wholeNumber, wireRecord } from "@sidecar/wire";
 import {
   canIgnoreSqliteError,
   defaultSqliteModule,
@@ -54,9 +54,11 @@ export function conductorAgent(value: string | undefined): SessionProvider | und
 const CONDUCTOR_SESSION_FIELD = {
   AGENT_TYPE: "agent_type",
   CONDUCTOR_SESSION_ID: "conductor_session_id",
+  HIDDEN: "hidden",
   PROVIDER_SESSION_ID: "provider_session_id",
   WORKSPACE_ID: "workspace_id",
   WORKSPACE_NAME: "workspace_name",
+  WORKSPACE_STATE: "workspace_state",
 } as const;
 
 /**
@@ -75,19 +77,33 @@ export function conductorWorkspaceLink(workspaceId: string, conductorChatId?: st
 }
 
 /**
+ * The one workspace state that means the user filed the whole workspace away
+ * on Conductor's own surface. Its other states — active, ready, sleeping —
+ * are all still-open workspaces.
+ */
+const CONDUCTOR_ARCHIVED_WORKSPACE_STATE = "archived";
+
+/**
  * Conductor's provider-session column kept its original Claude-specific name
  * as more agents were added. The alias is the meaning Luke reads from it. The
  * workspace join carries the name the user knows the work by — the chosen
- * workspace name, or the directory name Conductor fell back to itself.
+ * workspace name, or the directory name Conductor fell back to itself — and
+ * the workspace's lifecycle state, because an archived state is the one place
+ * Conductor records that the user filed the workspace away. A chat filed away
+ * on its own is Conductor's hidden flag, which its schema has carried since
+ * before it named agents, so any database this query can read at all says
+ * both.
  */
 const CONDUCTOR_SESSION_QUERY = `
   SELECT
     sessions.claude_session_id AS ${CONDUCTOR_SESSION_FIELD.PROVIDER_SESSION_ID},
     sessions.agent_type AS ${CONDUCTOR_SESSION_FIELD.AGENT_TYPE},
     sessions.id AS ${CONDUCTOR_SESSION_FIELD.CONDUCTOR_SESSION_ID},
+    sessions.is_hidden AS ${CONDUCTOR_SESSION_FIELD.HIDDEN},
     workspaces.id AS ${CONDUCTOR_SESSION_FIELD.WORKSPACE_ID},
     COALESCE(workspaces.workspace_name, workspaces.directory_name)
-      AS ${CONDUCTOR_SESSION_FIELD.WORKSPACE_NAME}
+      AS ${CONDUCTOR_SESSION_FIELD.WORKSPACE_NAME},
+    workspaces.state AS ${CONDUCTOR_SESSION_FIELD.WORKSPACE_STATE}
   FROM sessions
   LEFT JOIN workspaces ON workspaces.id = sessions.workspace_id
   WHERE sessions.claude_session_id IS NOT NULL
@@ -96,7 +112,8 @@ const CONDUCTOR_SESSION_QUERY = `
 
 /**
  * The same read against a database from before Conductor stored workspaces.
- * The sessions still annotate; they simply group under nothing.
+ * The sessions still annotate; they simply group under nothing, and a schema
+ * too old to say what was filed away files nothing away.
  */
 const CONDUCTOR_SESSION_QUERY_WITHOUT_WORKSPACES = `
   SELECT
@@ -113,6 +130,14 @@ interface ConductorSessionContext {
   conductorSessionId?: string;
   workspaceId?: string;
   workspaceName?: string;
+  /**
+   * The user filed this chat away on Conductor's own surface — the chat
+   * hidden on its own, or its whole workspace archived. Filing a chat away is
+   * how a user says it is done being watched, so it keeps the chat off the
+   * panel the same way an archived workspace keeps its chats out of the cloud
+   * adapter's roster.
+   */
+  filedAway?: boolean;
 }
 
 type SessionContextsByProvider = ReadonlyMap<string, ReadonlyMap<string, ConductorSessionContext>>;
@@ -140,7 +165,10 @@ function agentType(value: UnparsedWireValue): ConductorAgentType | undefined {
 /**
  * Reads Conductor's own session-to-provider mapping without opening any agent
  * transcript. An absent app, an older schema, or a failed auxiliary read means
- * no annotation; it can never make the provider's own observation disappear.
+ * no annotation; failure can never make the provider's own observation
+ * disappear. Only Conductor's own positive record that the user filed a chat
+ * away — the chat hidden, or its workspace archived — drops a row, and drops
+ * it whole.
  */
 export class ConductorSessionApplicationSnapshot {
   readonly #sessionsByProvider: SessionContextsByProvider;
@@ -160,7 +188,10 @@ export class ConductorSessionApplicationSnapshot {
    * observations can match a local Conductor database; a cloud row with a
    * coincidentally equal provider id is never annotated. A sub-agent inherits
    * its nearest Conductor-known ancestor's association and workspace: the
-   * child is Conductor's work even though only the parent is in its index.
+   * child is Conductor's work even though only the parent is in its index —
+   * and a chat the user filed away in Conductor is dropped from the roster
+   * with its sub-agents, because the agent's transcript outlives the chat the
+   * user already said goodbye to.
    */
   enrich(
     providerId: string,
@@ -190,15 +221,19 @@ export class ConductorSessionApplicationSnapshot {
       return undefined;
     };
 
-    return observations.map((observation) => {
+    return observations.flatMap((observation) => {
       const context = conductorContextFor(observation);
+      // A filed-away chat is dropped rather than annotated: the user archived
+      // or hid it on Conductor's own surface, and a sub-agent inheriting that
+      // context was filed away with its parent.
+      if (context?.filedAway) return [];
       if (
         !context ||
         observation.applications?.some(
           (application) => application.id === SESSION_APPLICATION_ID.CONDUCTOR,
         )
       ) {
-        return observation;
+        return [observation];
       }
       // The workspace is claimed only where no other manager already grouped
       // the chat, and the association's scope follows it: carried by the
@@ -230,12 +265,14 @@ export class ConductorSessionApplicationSnapshot {
       };
       const detail =
         link && !observation.detail?.link ? { ...observation.detail, link } : observation.detail;
-      return {
-        ...observation,
-        ...(detail ? { detail } : undefined),
-        applications: [...(observation.applications ?? []), application],
-        ...(workspace ? { workspace } : undefined),
-      };
+      return [
+        {
+          ...observation,
+          ...(detail ? { detail } : undefined),
+          applications: [...(observation.applications ?? []), application],
+          ...(workspace ? { workspace } : undefined),
+        },
+      ];
     });
   }
 }
@@ -243,7 +280,8 @@ export class ConductorSessionApplicationSnapshot {
 /**
  * Reads Conductor's own session-to-provider mapping without opening any agent
  * transcript. An absent app, an older schema, or a failed auxiliary read means
- * an empty snapshot; it can never make the provider's observation disappear.
+ * an empty snapshot; failure can never make the provider's observation
+ * disappear.
  */
 export class ConductorSessionApplicationReader {
   readonly #databasePath: string;
@@ -280,12 +318,19 @@ export class ConductorSessionApplicationReader {
       const conductorSessionId = text(record[CONDUCTOR_SESSION_FIELD.CONDUCTOR_SESSION_ID]);
       const workspaceId = text(record[CONDUCTOR_SESSION_FIELD.WORKSPACE_ID]);
       const workspaceName = text(record[CONDUCTOR_SESSION_FIELD.WORKSPACE_NAME]);
+      // Filed away only on a positive record: a hidden flag or workspace
+      // state the fallback query never read leaves the chat standing.
+      const filedAway =
+        (wholeNumber(record[CONDUCTOR_SESSION_FIELD.HIDDEN]) ?? 0) !== 0 ||
+        text(record[CONDUCTOR_SESSION_FIELD.WORKSPACE_STATE]) ===
+          CONDUCTOR_ARCHIVED_WORKSPACE_STATE;
       const providerId = CONDUCTOR_AGENT_BY_TYPE[type].id;
       const sessions = sessionsByProvider.get(providerId) ?? new Map();
       sessions.set(providerSessionId, {
         ...(conductorSessionId ? { conductorSessionId } : undefined),
         ...(workspaceId ? { workspaceId } : undefined),
         ...(workspaceName ? { workspaceName } : undefined),
+        ...(filedAway ? { filedAway } : undefined),
       });
       sessionsByProvider.set(providerId, sessions);
     }


### PR DESCRIPTION
## Problem

Chats archived in the local Conductor app kept their rows in Luke's session panel. Local Conductor chats are observed by their own agents' adapters (Claude Code, Codex, Cursor, OpenCode) and annotated from Conductor's local index (`conductor.db`) — but the index was read only for the mark and workspace grouping, never for whether the user had filed the chat away. On this machine, Conductor's index holds ~3,840 Claude chats of which only 16 are still open and visible; the archived rest could keep surfacing.

## Fix

The index already records both ways a chat is filed away locally: `sessions.is_hidden` for a chat archived on its own, and `workspaces.state = 'archived'` for the whole workspace around it. The session-applications read now carries that record, and `enrich` drops a filed-away chat — and its sub-agents, which inherit the nearest Conductor-known ancestor's context — the same way the cloud adapter already drops an archived workspace's chats.

The failure posture is unchanged: only Conductor's positive record drops a row. An absent app, an unreadable index, or a schema too old to say (the pre-workspaces fallback query) annotates nothing and drops nothing. Cloud rows with a coincidentally equal provider session id are never matched, so they are never dropped.

## Validation

- `./scripts/check.sh` passes (portable-only change; no UI or macOS packaging touched).
- New test covers: hidden chat dropped, archived-workspace chat dropped, sub-agent of a filed-away chat dropped, open chat and cloud twin kept.
- Probed against the real local `conductor.db`: 3,840 indexed Claude chats → 16 kept, matching the chats actually open in Conductor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32426761341/artifacts/9427720366) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32426761341)

- Commit: `197983d534b8cbd5bc90439271da0ead30509ae7`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
