### PR TITLE
fix(notch): leave the session count blank while the roster loads

### DIFF
--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -394,14 +394,17 @@ export function NotchWings({
             }
           >
             <span className="count-value" aria-hidden="true" ref={countValueElement}>
-              {accountGated ? "Sign in" : rosterLoading ? "…" : tallyValue(tally)}
+              {/* Blank while checking: the accessible label already says so,
+                  and a drawn placeholder poses as a count that is not there
+                  yet. */}
+              {accountGated ? "Sign in" : rosterLoading ? null : tallyValue(tally)}
             </span>
             <span className="count-caption" aria-hidden="true" ref={countCaptionElement}>
               {/* No caption while signed out: the two words are the label
                   entire, and with nothing beside them the fit keeps their
                   natural size inside the peek's side. Nor while checking —
-                  the ellipsis is the whole report until there is a count to
-                  put words beside. */}
+                  the badge stays blank until there is a count to put words
+                  beside. */}
               {accountGated || rosterLoading ? null : tallyCaption(tally)}
             </span>
           </span>


### PR DESCRIPTION
## Summary

- The count badge drew an ellipsis at startup until the first roster reading landed. It now draws nothing: the accessible label still announces "Checking for sessions", and a blank side reads cleaner than a placeholder posing as a count.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (lint, typecheck, tests, build)
- macOS Electron verification (`./scripts/verify.sh`): `not run` (Linux sandbox; CI covers macOS validation)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32427331586/artifacts/9427898623) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32427331586)

- Commit: `f0f94f122a5ab7ae1ac7ccba638289eb55112abd`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b69f3598-c955-4048-91c9-0cfea72e683e)
