### PR TITLE
fix(conductor): title local chats by the names Conductor gave them

### DIFF
--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -459,11 +459,12 @@ function SessionRow({
   // inside a tray leaves a bare repository unsaid: the tray's own header has
   // already named it, once, for every chat it holds.
   const place = session.branch ?? (inWorkspaceTray ? undefined : session.repository);
-  // A lone chat is its workspace: with no tray to name it, the row takes the
-  // workspace's name — the name the user knows the work by — because the
-  // chat's own generated name only earns a line once there is a sibling to
-  // tell it from.
-  const title = !inWorkspaceTray && session.workspace ? session.workspace.name : session.title;
+  // The chat's own name titles the row even where no tray names the
+  // workspace: it is the most specific fact the row has, and a provider whose
+  // chat has no name of its own already falls the title back to something
+  // workspace-shaped. The workspace's name still matches a search, and the
+  // acts aimed at the whole workspace still collapse onto this row.
+  const title = session.title;
   const applications = session.applications.filter(
     (application) =>
       !inWorkspaceTray ||
@@ -650,9 +651,9 @@ export function runDrawsTray(run: SessionListRun): boolean {
  * the tray: a single card that visibly contains them, named once at its top —
  * the workspace's name on the left, and at the far end the glyph leading the
  * repository — with the chats divided by hairlines inside.
- * A workspace holding one chat earns no tray — its row already says
- * everything the tray would — and an ungrouped session never does; either
- * way the wrapper stays, drawing as nothing. It has to: a workspace crosses
+ * A workspace holding one chat earns no tray — its one row carries the
+ * workspace's acts and mark itself — and an ungrouped session never does;
+ * either way the wrapper stays, drawing as nothing. It has to: a workspace crosses
  * between one chat and several as siblings come and go, and if that crossing
  * changed the row's parent element, React would remount the row and wipe a
  * follow-up someone was typing into it. The chrome is a class, never a

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -474,13 +474,13 @@ export function searchTokens(query: string): readonly string[] {
  * The lines a query is read against: everything the row itself can say — its
  * title, the sentence under it, the branch and repository, the workspace it is
  * a chat of — plus identifiers the row does not always spend a line on: the
- * agent's name and its model, kept on the mark's hover, and a chat's own name,
- * which a lone chat cedes its title line to its workspace for. Those still
- * find the session — each is a name the provider's own surface knows it by —
- * so a row can match without a mark to show for it; the marks only ever land
- * on the lines the row draws. The status word is its own line because the
- * detail sentence only falls back to it: a row busy saying what it is doing
- * must still answer for the state it is in.
+ * agent's name and its model, kept on the mark's hover, and the workspace of
+ * a lone chat, which earns no tray to name it. Those still find the session —
+ * each is a name the provider's own surface knows it by — so a row can match
+ * without a mark to show for it; the marks only ever land on the lines the
+ * row draws. The status word is its own line because the detail sentence only
+ * falls back to it: a row busy saying what it is doing must still answer for
+ * the state it is in.
  */
 function searchableLines(session: DisplaySession): readonly string[] {
   const lines = [

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -162,12 +162,16 @@ is read solely for where those sessions live — and, for Conductor, whether the
 user filed them away there. Matching is by exact provider session id — never
 by title or filesystem path — and an absent app, an unreadable file, or a
 schema this build does not know means no annotation.
+A row's marks are led by the app whose workspace groups the chat, and the
+row's own press follows its first linked mark: a grouped chat opens where its
+manager holds it — ahead of the agent's own app — while every mark keeps its
+own exact route.
 
 | App | Reads | Adds to matched rows | Writes |
 | --- | --- | --- | --- |
 | ChatGPT | Nothing | A mark opening the exact Codex thread | None |
 | cmux | Hook-session stores under `~/.cmuxterm` | Mark, exact `cmux:` pane address | None |
-| Conductor | Local session index (`conductor.db`) | Mark, workspace grouping, `conductor:` chat address, filed-away filtering | None |
+| Conductor | Local session index (`conductor.db`) | Mark on each chat, chat name as the row's title, workspace grouping, `conductor:` chat address as the row's press, filed-away filtering | None |
 | Cursor | Chat-key presence in the app's own index | Mark and `cursor:` address opening the exact chat, on app-held local chats and every cloud agent | None |
 | Orca | Hook-status cache and worktree names | Mark, worktree grouping | None |
 | Superset | Host state (`host.db`) | Mark, grouping, `superset:` workspace address; a standing row for each unarchived worktree with no agent terminal | Message, open workspace, close terminal, add agent, new workspace, rename, delete workspace — through its CLI, while logged in |
@@ -185,14 +189,24 @@ schema this build does not know means no annotation.
   the row's own link where no other manager gave it one; no grouping, because
   cmux names its workspaces only by identifier; no writes, because cmux's
   control socket is password-guarded and undocumented for outside callers.
-- **Conductor** — the index is never used to open an agent transcript, and a
-  schema that predates workspaces annotates without grouping. The address,
+- **Conductor** — the index is never used to open an agent transcript. The
+  name Conductor gave a chat — the one its own sidebar shows — titles the
+  matched row the way it titles a cloud-observed chat's; the schema's
+  `Untitled` default is no name at all, a sub-agent keeps its own title, and
+  a schema that predates chat titles keeps the titles the providers derived,
+  as one that predates workspaces annotates without grouping. The workspace
+  grouping is named the way Conductor's own sidebar names it: the chosen
+  workspace name, then the pull request's title where only a PR names the
+  work, then the directory name. The address,
   `conductor://workspace?id=<workspace>&session=<chat>`, is composed on this
   machine from the observed workspace and chat ids — the same deep link
-  Conductor's own notifications fire — and stands in as the row's own link
-  where the chat's agent gave it none; a sub-agent's address is its ancestor
-  chat's, where its conversation lives in Conductor's window, and a
-  pre-workspace schema has no workspace id to address, so its rows keep none.
+  Conductor's own notifications fire. It names the exact chat, so the mark
+  carrying it rides each matched row, inside a workspace tray too, and a
+  chat Conductor grouped is led by that mark — so the row's press follows
+  it, under the one ordering rule above; a sub-agent's address is its
+  ancestor chat's, where its conversation lives in Conductor's window, and
+  a pre-workspace schema has no workspace id to address, so its rows keep
+  none.
   A chat the user filed away on Conductor's own surface — the chat hidden on
   its own, or its whole workspace archived — is dropped from the roster with
   its sub-agents, the same way the cloud adapter drops an archived

--- a/packages/fixtures/src/fixtures.ts
+++ b/packages/fixtures/src/fixtures.ts
@@ -141,8 +141,9 @@ const smokeFixture: FixtureSnapshot = {
     // grouped under the workspace's — the name the user knows the work by,
     // which never was a branch. The pair is what proves a run of chats joins
     // into one card in the one screenshot the evidence is reviewed from —
-    // each row led by the agent's own mark, with the Conductor mark carried
-    // once on the tray header the way a Superset workspace carries its own.
+    // each row led by the agent's own mark and trailed by the Conductor mark
+    // that opens its exact chat, with the tray header carrying the manager's
+    // mark once the way a Superset workspace carries its own.
     {
       id: "conductor-chat-package",
       title: "amber-shoal",
@@ -154,7 +155,7 @@ const smokeFixture: FixtureSnapshot = {
         {
           id: SESSION_APPLICATION_ID.CONDUCTOR,
           name: "Conductor",
-          scope: SESSION_APPLICATION_SCOPE.WORKSPACE,
+          scope: SESSION_APPLICATION_SCOPE.SESSION,
         },
       ],
       detail: "Packaging the macOS build.",
@@ -186,7 +187,7 @@ const smokeFixture: FixtureSnapshot = {
         {
           id: SESSION_APPLICATION_ID.CONDUCTOR,
           name: "Conductor",
-          scope: SESSION_APPLICATION_SCOPE.WORKSPACE,
+          scope: SESSION_APPLICATION_SCOPE.SESSION,
         },
       ],
       detail: "",

--- a/packages/providers/src/conductor/adapter.test.ts
+++ b/packages/providers/src/conductor/adapter.test.ts
@@ -882,12 +882,13 @@ test("reports every chat in a workspace, each grouped under it", async () => {
     });
     // The Conductor mark rides each chat as an app association carrying the
     // chat's own exact address, so the trailing mark opens the same place the
-    // row does.
+    // row does — and the address names the exact chat, so the association is
+    // the session's own and its mark rides the row even inside the tray.
     assert.deepEqual(observation.applications, [
       {
         id: "conductor",
         displayName: "Conductor",
-        scope: "workspace",
+        scope: "session",
         link: observation.detail?.link,
       },
     ]);

--- a/packages/providers/src/conductor/adapter.ts
+++ b/packages/providers/src/conductor/adapter.ts
@@ -912,11 +912,14 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
       // The Conductor mark rides as an app association like every other app
       // holding a chat, carrying the same exact address the row opens with,
       // so the one glyph means the same thing on a cloud row and a local one.
+      // The address names the exact chat, so the association is the
+      // session's own and rides the row even inside the workspace's tray;
+      // the tray header's manager mark comes from the workspace above.
       applications: [
         {
           id: SESSION_APPLICATION_ID.CONDUCTOR,
           displayName: CONDUCTOR_PROVIDER_NAME,
-          scope: SESSION_APPLICATION_SCOPE.WORKSPACE,
+          scope: SESSION_APPLICATION_SCOPE.SESSION,
           ...(session.deepLink ? { link: session.deepLink } : undefined),
         },
       ],

--- a/packages/providers/src/conductor/session-applications.test.ts
+++ b/packages/providers/src/conductor/session-applications.test.ts
@@ -36,11 +36,35 @@ function createConductorDatabase(databasePath: string): DatabaseSync {
       claude_session_id TEXT,
       agent_type TEXT,
       workspace_id TEXT,
+      title TEXT DEFAULT 'Untitled',
       is_hidden INTEGER DEFAULT 0
     );
     CREATE TABLE workspaces (
       id TEXT PRIMARY KEY,
       workspace_name TEXT,
+      pr_title TEXT,
+      directory_name TEXT,
+      state TEXT DEFAULT 'active'
+    );
+  `);
+  return database;
+}
+
+/** The schema from before Conductor titled chats, for the middle fallback read. */
+function createConductorDatabaseWithoutTitles(databasePath: string): DatabaseSync {
+  const database = new DatabaseSync(databasePath, {});
+  database.exec(`
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      claude_session_id TEXT,
+      agent_type TEXT,
+      workspace_id TEXT,
+      is_hidden INTEGER DEFAULT 0
+    );
+    CREATE TABLE workspaces (
+      id TEXT PRIMARY KEY,
+      workspace_name TEXT,
+      pr_title TEXT,
       directory_name TEXT,
       state TEXT DEFAULT 'active'
     );
@@ -67,13 +91,20 @@ function writeSession(
   providerSessionId: string,
   agentType: string,
   workspaceId?: string,
-  hidden?: boolean,
+  options?: { title?: string; hidden?: boolean },
 ): void {
   database
     .prepare(
-      "INSERT INTO sessions (id, claude_session_id, agent_type, workspace_id, is_hidden) VALUES (?, ?, ?, ?, ?)",
+      "INSERT INTO sessions (id, claude_session_id, agent_type, workspace_id, title, is_hidden) VALUES (?, ?, ?, ?, ?, ?)",
     )
-    .run(id, providerSessionId, agentType, workspaceId ?? null, hidden ? 1 : 0);
+    .run(
+      id,
+      providerSessionId,
+      agentType,
+      workspaceId ?? null,
+      options?.title ?? "Untitled",
+      options?.hidden ? 1 : 0,
+    );
 }
 
 function writeWorkspace(
@@ -81,13 +112,19 @@ function writeWorkspace(
   id: string,
   workspaceName: string | undefined,
   directoryName: string,
-  state?: string,
+  options?: { prTitle?: string; state?: string },
 ): void {
   database
     .prepare(
-      "INSERT INTO workspaces (id, workspace_name, directory_name, state) VALUES (?, ?, ?, ?)",
+      "INSERT INTO workspaces (id, workspace_name, pr_title, directory_name, state) VALUES (?, ?, ?, ?, ?)",
     )
-    .run(id, workspaceName ?? null, directoryName, state ?? "active");
+    .run(
+      id,
+      workspaceName ?? null,
+      options?.prTitle ?? null,
+      directoryName,
+      options?.state ?? "active",
+    );
 }
 
 test("indexes supported provider session ids from Conductor records", async (t) => {
@@ -291,8 +328,10 @@ test("groups a matched chat under its Conductor workspace like a manager", async
     { ...OBSERVED_CHAT, providerSessionId: "sibling", title: "Sibling" },
   ]);
 
-  // The workspace carries the mark, so the association's scope follows it —
-  // and the name falls back to the directory Conductor itself falls back to.
+  // The workspace claim carries the manager's mark on the tray header, and
+  // the name falls back to the directory Conductor itself falls back to. The
+  // association stays the session's own — its address names the exact chat —
+  // so its mark rides the row even inside the tray.
   assert.deepEqual(observations[0]?.workspace, {
     providerWorkspaceId: "workspace-named",
     name: "lisbon-v2",
@@ -303,7 +342,7 @@ test("groups a matched chat under its Conductor workspace like a manager", async
     {
       id: SESSION_APPLICATION_ID.CONDUCTOR,
       displayName: "Conductor",
-      scope: SESSION_APPLICATION_SCOPE.WORKSPACE,
+      scope: SESSION_APPLICATION_SCOPE.SESSION,
       link: "conductor://workspace?id=workspace-named&session=chat-named",
     },
   ]);
@@ -320,7 +359,65 @@ test("groups a matched chat under its Conductor workspace like a manager", async
   );
 });
 
-test("a provider-reported address keeps the row press; the mark keeps its own", async (t) => {
+test("a nameless workspace groups under its PR title before its directory", async (t) => {
+  const databasePath = await temporaryDatabasePath(t);
+  const database = createConductorDatabase(databasePath);
+  try {
+    writeWorkspace(database, "workspace-pr", undefined, "kingstown", {
+      prTitle: "fix(panel): keep the tray label honest",
+    });
+    writeWorkspace(database, "workspace-chosen", "lisbon-v2", "kingstown", {
+      prTitle: "feat(panel): the PR a chosen name outranks",
+    });
+    writeSession(database, "chat-pr", "local", TEST_CONDUCTOR_AGENT_TYPE.CLAUDE, "workspace-pr");
+    writeSession(
+      database,
+      "chat-chosen",
+      "sibling",
+      TEST_CONDUCTOR_AGENT_TYPE.CLAUDE,
+      "workspace-chosen",
+    );
+  } finally {
+    database.close();
+  }
+  const snapshot = await new ConductorSessionApplicationReader({ databasePath }).read();
+  const observations = snapshot.enrich(PROVIDER_ID.CLAUDE_CODE, [
+    OBSERVED_CHAT,
+    { ...OBSERVED_CHAT, providerSessionId: "sibling", title: "Sibling" },
+  ]);
+
+  // The ladder is Conductor's own sidebar's: the PR title names work nobody
+  // named directly, and a chosen workspace name still outranks it.
+  assert.equal(observations[0]?.workspace?.name, "fix(panel): keep the tray label honest");
+  assert.equal(observations[1]?.workspace?.name, "lisbon-v2");
+});
+
+test("titles a matched chat by the name Conductor gave it", async (t) => {
+  const databasePath = await temporaryDatabasePath(t);
+  const database = createConductorDatabase(databasePath);
+  try {
+    writeSession(database, "chat-named", "local", TEST_CONDUCTOR_AGENT_TYPE.CLAUDE, undefined, {
+      title: "Fix the transcript parser",
+    });
+    writeSession(database, "chat-unnamed", "sibling", TEST_CONDUCTOR_AGENT_TYPE.CLAUDE);
+  } finally {
+    database.close();
+  }
+  const snapshot = await new ConductorSessionApplicationReader({ databasePath }).read();
+  const observations = snapshot.enrich(PROVIDER_ID.CLAUDE_CODE, [
+    OBSERVED_CHAT,
+    { ...OBSERVED_CHAT, providerSessionId: "sibling", title: "Sibling" },
+  ]);
+
+  // The name the user reads in Conductor's own sidebar titles the row, the
+  // way it titles a cloud-observed chat's.
+  assert.equal(observations[0]?.title, "Fix the transcript parser");
+  // The schema's default is the absence of a name rather than one anybody
+  // chose, so the provider's own title keeps the row.
+  assert.equal(observations[1]?.title, "Sibling");
+});
+
+test("the annotation fills only an absent row link; precedence is not its call", async (t) => {
   const databasePath = await temporaryDatabasePath(t);
   const database = createConductorDatabase(databasePath);
   try {
@@ -337,12 +434,29 @@ test("a provider-reported address keeps the row press; the mark keeps its own", 
   }
   const snapshot = await new ConductorSessionApplicationReader({ databasePath }).read();
   const observations = snapshot.enrich(PROVIDER_ID.CLAUDE_CODE, [
-    { ...OBSERVED_CHAT, detail: { link: "https://example.com/session/local" } },
+    {
+      ...OBSERVED_CHAT,
+      detail: { link: "codex://threads/local" },
+      applications: [
+        {
+          id: SESSION_APPLICATION_ID.CHATGPT,
+          displayName: "ChatGPT",
+          scope: SESSION_APPLICATION_SCOPE.SESSION,
+          link: "codex://threads/local",
+        },
+      ],
+    },
   ]);
 
-  assert.equal(observations[0]?.detail?.link, "https://example.com/session/local");
+  // The annotation itself never rewrites a press another hand gave the row:
+  // Conductor's precedence over the agent's own app is the session
+  // normalization's call, made from the grouping — the manager's mark leads
+  // and the press follows the first linked mark — so each association here
+  // only carries its own exact route.
+  assert.equal(observations[0]?.detail?.link, "codex://threads/local");
+  assert.equal(observations[0]?.applications?.[0]?.link, "codex://threads/local");
   assert.equal(
-    observations[0]?.applications?.[0]?.link,
+    observations[0]?.applications?.[1]?.link,
     "conductor://workspace?id=workspace-named&session=chat-named",
   );
 });
@@ -358,6 +472,7 @@ test("a spawned descendant inherits its ancestor's Conductor workspace", async (
       "local",
       TEST_CONDUCTOR_AGENT_TYPE.CODEX,
       "workspace-parent",
+      { title: "Rework the pipeline" },
     );
   } finally {
     database.close();
@@ -380,6 +495,34 @@ test("a spawned descendant inherits its ancestor's Conductor workspace", async (
   assert.equal(
     observations[1]?.detail?.link,
     "conductor://workspace?id=workspace-parent&session=chat-parent",
+  );
+  // The chat's Conductor name is the chat's alone: the sub-agent keeps its
+  // own title rather than reading as the same conversation twice.
+  assert.equal(observations[0]?.title, "Rework the pipeline");
+  assert.equal(observations[1]?.title, "Child");
+});
+
+test("a schema from before chat titles still annotates and groups", async (t) => {
+  const databasePath = await temporaryDatabasePath(t);
+  const database = createConductorDatabaseWithoutTitles(databasePath);
+  try {
+    writeWorkspace(database, "workspace-named", "lisbon-v2", "kingstown");
+    database
+      .prepare(
+        "INSERT INTO sessions (id, claude_session_id, agent_type, workspace_id) VALUES (?, ?, ?, ?)",
+      )
+      .run("chat-untitled", "local", TEST_CONDUCTOR_AGENT_TYPE.CLAUDE, "workspace-named");
+  } finally {
+    database.close();
+  }
+  const snapshot = await new ConductorSessionApplicationReader({ databasePath }).read();
+  const observations = snapshot.enrich(PROVIDER_ID.CLAUDE_CODE, [OBSERVED_CHAT]);
+
+  assert.equal(observations[0]?.title, "Local");
+  assert.equal(observations[0]?.workspace?.name, "lisbon-v2");
+  assert.equal(
+    observations[0]?.applications?.[0]?.link,
+    "conductor://workspace?id=workspace-named&session=chat-untitled",
   );
 });
 
@@ -406,13 +549,19 @@ test("keeps another manager's workspace and stays on the row instead", async (t)
   };
   const snapshot = await new ConductorSessionApplicationReader({ databasePath }).read();
   const observations = snapshot.enrich(PROVIDER_ID.CLAUDE_CODE, [
-    { ...OBSERVED_CHAT, workspace: supersetWorkspace },
+    {
+      ...OBSERVED_CHAT,
+      workspace: supersetWorkspace,
+      detail: { link: "superset://workspace/workspace-superset" },
+    },
   ]);
 
-  // The first manager to group the chat keeps it; Conductor still identifies
-  // itself, on the row, where no tray header would carry its mark — and the
-  // mark keeps the chat's own Conductor address either way.
+  // The first manager to group the chat keeps it — its press included:
+  // Conductor outranks only the chat's agent's own app, never another
+  // manager. Conductor still identifies itself, on the row, and the mark
+  // keeps the chat's own Conductor address either way.
   assert.deepEqual(observations[0]?.workspace, supersetWorkspace);
+  assert.equal(observations[0]?.detail?.link, "superset://workspace/workspace-superset");
   assert.deepEqual(observations[0]?.applications, [
     {
       id: SESSION_APPLICATION_ID.CONDUCTOR,
@@ -427,8 +576,10 @@ test("drops chats filed away in Conductor: hidden chats and archived workspaces"
   const databasePath = await temporaryDatabasePath(t);
   const database = createConductorDatabase(databasePath);
   try {
-    writeWorkspace(database, "workspace-open", "lisbon-v2", "kingstown", "ready");
-    writeWorkspace(database, "workspace-filed", "adana-v1", "kingstown", "archived");
+    writeWorkspace(database, "workspace-open", "lisbon-v2", "kingstown", { state: "ready" });
+    writeWorkspace(database, "workspace-filed", "adana-v1", "kingstown", {
+      state: "archived",
+    });
     writeSession(database, "chat-open", "open", TEST_CONDUCTOR_AGENT_TYPE.CLAUDE, "workspace-open");
     writeSession(
       database,
@@ -436,7 +587,7 @@ test("drops chats filed away in Conductor: hidden chats and archived workspaces"
       "hidden",
       TEST_CONDUCTOR_AGENT_TYPE.CLAUDE,
       "workspace-open",
-      true,
+      { hidden: true },
     );
     writeSession(
       database,

--- a/packages/providers/src/conductor/session-applications.ts
+++ b/packages/providers/src/conductor/session-applications.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 import path from "node:path";
 import {
+  maximumSessionTitleLength,
   PROVIDER_ID,
   type ProviderSessionObservation,
   SESSION_APPLICATION_ID,
@@ -53,6 +54,7 @@ export function conductorAgent(value: string | undefined): SessionProvider | und
 
 const CONDUCTOR_SESSION_FIELD = {
   AGENT_TYPE: "agent_type",
+  CHAT_TITLE: "chat_title",
   CONDUCTOR_SESSION_ID: "conductor_session_id",
   HIDDEN: "hidden",
   PROVIDER_SESSION_ID: "provider_session_id",
@@ -60,6 +62,14 @@ const CONDUCTOR_SESSION_FIELD = {
   WORKSPACE_NAME: "workspace_name",
   WORKSPACE_STATE: "workspace_state",
 } as const;
+
+/**
+ * The schema's default for a chat nobody has named yet. It is the absence of
+ * a name rather than one anybody chose — Conductor replaces it the moment it
+ * generates a real title — so it reads as no name at all, and the provider's
+ * own title keeps the row.
+ */
+const CONDUCTOR_UNNAMED_CHAT_TITLE = "Untitled";
 
 /**
  * The address of one chat in Conductor's own app — the same deep link
@@ -86,8 +96,11 @@ const CONDUCTOR_ARCHIVED_WORKSPACE_STATE = "archived";
 /**
  * Conductor's provider-session column kept its original Claude-specific name
  * as more agents were added. The alias is the meaning Luke reads from it. The
- * workspace join carries the name the user knows the work by — the chosen
- * workspace name, or the directory name Conductor fell back to itself — and
+ * chat's title is the name the user reads in Conductor's own sidebar, and the
+ * workspace join carries the name the user knows the work by, laddered the
+ * way Conductor's own sidebar labels a workspace — the chosen workspace name,
+ * then the pull request's title where only a PR names the work, then the
+ * directory name Conductor fell back to itself — and
  * the workspace's lifecycle state, because an archived state is the one place
  * Conductor records that the user filed the workspace away. A chat filed away
  * on its own is Conductor's hidden flag, which its schema has carried since
@@ -99,9 +112,33 @@ const CONDUCTOR_SESSION_QUERY = `
     sessions.claude_session_id AS ${CONDUCTOR_SESSION_FIELD.PROVIDER_SESSION_ID},
     sessions.agent_type AS ${CONDUCTOR_SESSION_FIELD.AGENT_TYPE},
     sessions.id AS ${CONDUCTOR_SESSION_FIELD.CONDUCTOR_SESSION_ID},
+    sessions.title AS ${CONDUCTOR_SESSION_FIELD.CHAT_TITLE},
     sessions.is_hidden AS ${CONDUCTOR_SESSION_FIELD.HIDDEN},
     workspaces.id AS ${CONDUCTOR_SESSION_FIELD.WORKSPACE_ID},
-    COALESCE(workspaces.workspace_name, workspaces.directory_name)
+    COALESCE(workspaces.workspace_name, workspaces.pr_title, workspaces.directory_name)
+      AS ${CONDUCTOR_SESSION_FIELD.WORKSPACE_NAME},
+    workspaces.state AS ${CONDUCTOR_SESSION_FIELD.WORKSPACE_STATE}
+  FROM sessions
+  LEFT JOIN workspaces ON workspaces.id = sessions.workspace_id
+  WHERE sessions.claude_session_id IS NOT NULL
+    AND sessions.agent_type IS NOT NULL
+`;
+
+/**
+ * The same read against a database from before Conductor titled its chats.
+ * The sessions still annotate, group, and file away; their rows simply keep
+ * the titles their own providers derived. Conductor stored a workspace's PR
+ * title, its lifecycle state, and the hidden flag all before its chosen
+ * name, so any schema this tier can read holds everything else it asks for.
+ */
+const CONDUCTOR_SESSION_QUERY_WITHOUT_TITLES = `
+  SELECT
+    sessions.claude_session_id AS ${CONDUCTOR_SESSION_FIELD.PROVIDER_SESSION_ID},
+    sessions.agent_type AS ${CONDUCTOR_SESSION_FIELD.AGENT_TYPE},
+    sessions.id AS ${CONDUCTOR_SESSION_FIELD.CONDUCTOR_SESSION_ID},
+    sessions.is_hidden AS ${CONDUCTOR_SESSION_FIELD.HIDDEN},
+    workspaces.id AS ${CONDUCTOR_SESSION_FIELD.WORKSPACE_ID},
+    COALESCE(workspaces.workspace_name, workspaces.pr_title, workspaces.directory_name)
       AS ${CONDUCTOR_SESSION_FIELD.WORKSPACE_NAME},
     workspaces.state AS ${CONDUCTOR_SESSION_FIELD.WORKSPACE_STATE}
   FROM sessions
@@ -128,6 +165,8 @@ const CONDUCTOR_SESSION_QUERY_WITHOUT_WORKSPACES = `
 interface ConductorSessionContext {
   /** Conductor's own id for the chat, which its deep link takes as the focus. */
   conductorSessionId?: string;
+  /** The name Conductor gave the chat, absent while it is still unnamed. */
+  chatTitle?: string;
   workspaceId?: string;
   workspaceName?: string;
   /**
@@ -162,6 +201,12 @@ function agentType(value: UnparsedWireValue): ConductorAgentType | undefined {
   return Object.values(CONDUCTOR_AGENT_TYPE).find((candidate) => candidate === parsed);
 }
 
+function chatTitle(value: UnparsedWireValue): string | undefined {
+  const parsed = text(value);
+  if (!parsed || parsed === CONDUCTOR_UNNAMED_CHAT_TITLE) return undefined;
+  return parsed.slice(0, maximumSessionTitleLength);
+}
+
 /**
  * Reads Conductor's own session-to-provider mapping without opening any agent
  * transcript. An absent app, an older schema, or a failed auxiliary read means
@@ -183,15 +228,15 @@ export class ConductorSessionApplicationSnapshot {
 
   /**
    * Adds Conductor beside any app associations the provider already reported,
-   * and groups the chat under the Conductor workspace it belongs to, the way
-   * a Superset-managed chat groups under its Superset workspace. Only local
-   * observations can match a local Conductor database; a cloud row with a
-   * coincidentally equal provider id is never annotated. A sub-agent inherits
-   * its nearest Conductor-known ancestor's association and workspace: the
-   * child is Conductor's work even though only the parent is in its index —
-   * and a chat the user filed away in Conductor is dropped from the roster
-   * with its sub-agents, because the agent's transcript outlives the chat the
-   * user already said goodbye to.
+   * titles the chat by the name Conductor gave it, and groups it under the
+   * Conductor workspace it belongs to, the way a Superset-managed chat groups
+   * under its Superset workspace. Only local observations can match a local
+   * Conductor database; a cloud row with a coincidentally equal provider id
+   * is never annotated. A sub-agent inherits its nearest Conductor-known
+   * ancestor's association and workspace: the child is Conductor's work even
+   * though only the parent is in its index — and a chat the user filed away
+   * in Conductor is dropped from the roster with its sub-agents, because the
+   * agent's transcript outlives the chat the user already said goodbye to.
    */
   enrich(
     providerId: string,
@@ -236,9 +281,8 @@ export class ConductorSessionApplicationSnapshot {
         return [observation];
       }
       // The workspace is claimed only where no other manager already grouped
-      // the chat, and the association's scope follows it: carried by the
-      // workspace, the mark sits once on the tray header; carried by the
-      // session alone, it stays on the row.
+      // the chat; the claim is what carries the manager's mark on the tray
+      // header, once, above the chats it holds.
       const workspace =
         context.workspaceId && !observation.workspace
           ? {
@@ -252,22 +296,38 @@ export class ConductorSessionApplicationSnapshot {
       // link without one — and a sub-agent's inherited context addresses the
       // ancestor chat, which is where its conversation lives. The app that
       // wrote the index is the scheme's handler, so the address stands with
-      // no credential at all. A native provider address still wins as the
-      // row's primary press; the Conductor association keeps its own.
+      // no credential at all.
       const link = context.workspaceId
         ? conductorWorkspaceLink(context.workspaceId, context.conductorSessionId)
         : undefined;
+      // The association names the exact chat — its address does, when it has
+      // one — so it is the session's own and rides the row even inside the
+      // workspace's tray, where the tray header's manager mark comes from
+      // the workspace claim above rather than from this.
       const application: SessionApplication = {
         id: SESSION_APPLICATION_ID.CONDUCTOR,
         displayName: CONDUCTOR_APPLICATION_NAME,
-        scope: workspace ? SESSION_APPLICATION_SCOPE.WORKSPACE : SESSION_APPLICATION_SCOPE.SESSION,
+        scope: SESSION_APPLICATION_SCOPE.SESSION,
         ...(link ? { link } : undefined),
       };
+      // The address fills the row's link only where nothing else gave one.
+      // Which app a grouped row's press follows is not decided here: the
+      // session normalization orders every row's marks with its workspace's
+      // manager in the lead and points the press at the first linked mark,
+      // so Conductor's precedence over an agent's own app falls out of the
+      // grouping rather than out of any Conductor-specific write.
       const detail =
         link && !observation.detail?.link ? { ...observation.detail, link } : observation.detail;
+      // The name Conductor gave the chat is what the user reads in Conductor's
+      // own sidebar, so it titles the row here the way it titles a
+      // cloud-observed chat's — but only on the chat itself, never inherited:
+      // a sub-agent labelled with its parent's name would read as the same
+      // conversation twice while saying nothing about its own work.
+      const title = conductorSessions.get(observation.providerSessionId)?.chatTitle;
       return [
         {
           ...observation,
+          ...(title ? { title } : undefined),
           ...(detail ? { detail } : undefined),
           applications: [...(observation.applications ?? []), application],
           ...(workspace ? { workspace } : undefined),
@@ -316,6 +376,7 @@ export class ConductorSessionApplicationReader {
       const providerSessionId = text(record[CONDUCTOR_SESSION_FIELD.PROVIDER_SESSION_ID]);
       if (!type || !providerSessionId) continue;
       const conductorSessionId = text(record[CONDUCTOR_SESSION_FIELD.CONDUCTOR_SESSION_ID]);
+      const title = chatTitle(record[CONDUCTOR_SESSION_FIELD.CHAT_TITLE]);
       const workspaceId = text(record[CONDUCTOR_SESSION_FIELD.WORKSPACE_ID]);
       const workspaceName = text(record[CONDUCTOR_SESSION_FIELD.WORKSPACE_NAME]);
       // Filed away only on a positive record: a hidden flag or workspace
@@ -328,6 +389,7 @@ export class ConductorSessionApplicationReader {
       const sessions = sessionsByProvider.get(providerId) ?? new Map();
       sessions.set(providerSessionId, {
         ...(conductorSessionId ? { conductorSessionId } : undefined),
+        ...(title ? { chatTitle: title } : undefined),
         ...(workspaceId ? { workspaceId } : undefined),
         ...(workspaceName ? { workspaceName } : undefined),
         ...(filedAway ? { filedAway } : undefined),
@@ -338,17 +400,18 @@ export class ConductorSessionApplicationReader {
   }
 
   /**
-   * The joined read first, then the plain one where the schema predates
-   * workspaces: losing the grouping must not cost the annotation itself.
+   * The fullest read first, then progressively older schemas: losing the
+   * chat titles must not cost the grouping, and losing the grouping must not
+   * cost the annotation itself.
    */
   #queryRows(database: SqliteDatabase): UnparsedWireValue[] {
-    try {
-      return database.prepare(CONDUCTOR_SESSION_QUERY).all();
-    } catch (error) {
-      if (error instanceof Error && canIgnoreSqliteError(error)) {
-        return database.prepare(CONDUCTOR_SESSION_QUERY_WITHOUT_WORKSPACES).all();
+    for (const query of [CONDUCTOR_SESSION_QUERY, CONDUCTOR_SESSION_QUERY_WITHOUT_TITLES]) {
+      try {
+        return database.prepare(query).all();
+      } catch (error) {
+        if (!(error instanceof Error && canIgnoreSqliteError(error))) throw error;
       }
-      throw error;
     }
+    return database.prepare(CONDUCTOR_SESSION_QUERY_WITHOUT_WORKSPACES).all();
   }
 }

--- a/packages/session/src/session.test.ts
+++ b/packages/session/src/session.test.ts
@@ -89,6 +89,114 @@ test("filters a roster to the sessions still worth a row, keeping their order", 
   );
 });
 
+test("the grouping manager's mark leads the row and the press follows it", () => {
+  const normalized = normalizeSession(
+    { id: "codex", displayName: "Codex" },
+    {
+      providerSessionId: "run:grouped",
+      title: "Implement the shared session core",
+      status: SESSION_STATUS.WORKING,
+      observedAt: TEST_NOW,
+      detail: { link: "codex://threads/run-grouped" },
+      applications: [
+        {
+          id: "chatgpt",
+          displayName: "ChatGPT",
+          scope: "session",
+          link: "codex://threads/run-grouped",
+        },
+        {
+          id: "conductor",
+          displayName: "Conductor",
+          scope: "session",
+          link: "conductor://workspace?id=ws&session=chat",
+        },
+      ],
+      workspace: {
+        providerWorkspaceId: "ws",
+        name: "lisbon-v2",
+        scopeId: "conductor",
+        managerName: "Conductor",
+      },
+    },
+  );
+
+  // The manager that grouped the chat leads its marks ahead of the fixed
+  // order, and the row's press follows the first linked mark — so the chat
+  // opens where its manager holds it, with the agent's own route kept on its
+  // own mark.
+  assert.deepEqual(
+    normalized.applications.map((application) => application.id),
+    ["conductor", "chatgpt"],
+  );
+  assert.equal(normalized.detail.link, "conductor://workspace?id=ws&session=chat");
+  assert.equal(normalized.applications[1]?.link, "codex://threads/run-grouped");
+});
+
+test("a manager without a linked mark cedes the press down the marks", () => {
+  const normalized = normalizeSession(
+    { id: "codex", displayName: "Codex" },
+    {
+      providerSessionId: "run:orca",
+      title: "Implement the shared session core",
+      status: SESSION_STATUS.WORKING,
+      observedAt: TEST_NOW,
+      detail: { link: "codex://threads/run-orca" },
+      applications: [
+        { id: "orca", displayName: "Orca", scope: "workspace" },
+        {
+          id: "chatgpt",
+          displayName: "ChatGPT",
+          scope: "session",
+          link: "codex://threads/run-orca",
+        },
+      ],
+      workspace: { providerWorkspaceId: "worktree", scopeId: "orca", managerName: "Orca" },
+    },
+  );
+
+  assert.deepEqual(
+    normalized.applications.map((application) => application.id),
+    ["orca", "chatgpt"],
+  );
+  assert.equal(normalized.detail.link, "codex://threads/run-orca");
+});
+
+test("an ungrouped row keeps the fixed mark order and its provider's press", () => {
+  const normalized = normalizeSession(
+    { id: "codex", displayName: "Codex" },
+    {
+      providerSessionId: "run:plain",
+      title: "Implement the shared session core",
+      status: SESSION_STATUS.WORKING,
+      observedAt: TEST_NOW,
+      detail: { link: "https://example.com/run-plain" },
+      applications: [
+        {
+          id: "conductor",
+          displayName: "Conductor",
+          scope: "session",
+          link: "conductor://workspace?id=ws&session=chat",
+        },
+        {
+          id: "chatgpt",
+          displayName: "ChatGPT",
+          scope: "session",
+          link: "codex://threads/run-plain",
+        },
+      ],
+    },
+  );
+
+  // With no grouping there is no lead: the fixed order stands, and the press
+  // follows the first linked mark it yields.
+  assert.deepEqual(
+    normalized.applications.map((application) => application.id),
+    ["chatgpt", "conductor"],
+  );
+  assert.equal(normalized.detail.link, "codex://threads/run-plain");
+});
+
 test("reads the pull request's number off every host's address shape", () => {
   assert.equal(sessionChangeNumber("https://github.com/reviewstage/luke/pull/245"), 245);
   assert.equal(

--- a/packages/session/src/session.ts
+++ b/packages/session/src/session.ts
@@ -683,6 +683,23 @@ function normalizeApplications(
 }
 
 /**
+ * The app whose workspace groups the chat leads the row's marks: a grouped
+ * chat is worked in its manager's window before anywhere else, so the
+ * manager's mark comes first and the fixed order carries the rest. The row's
+ * own press follows the first linked mark below, which is what makes this
+ * ordering the one place a press's precedence is decided.
+ */
+function applicationsLedByManager(
+  applications: readonly SessionApplication[],
+  managerScopeId: string | undefined,
+): readonly SessionApplication[] {
+  if (!managerScopeId) return applications;
+  const lead = applications.find((application) => application.id === managerScopeId);
+  if (!lead) return applications;
+  return [lead, ...applications.filter((application) => application !== lead)];
+}
+
+/**
  * Bounds every field a provider reported and drops the ones it left empty, so
  * a renderer can treat any present field as worth drawing.
  */
@@ -819,6 +836,18 @@ export function normalizeSession(
   const renameTarget = boundedText(observation.renameTarget, maximumSessionDetailLength);
   const workspace = normalizeWorkspace(observation.workspace);
   const agent = normalizeAgent(observation.agent, providerId);
+  const applications = applicationsLedByManager(
+    normalizeApplications(observation.applications),
+    workspace?.scopeId,
+  );
+  const detail = normalizeSessionDetail(observation.detail);
+  // The row opens where its first linked mark leads. The marks are ordered by
+  // who owns the chat — its workspace's manager ahead of the fixed order — so
+  // the press's precedence is decided by that one ordering rather than by
+  // whichever enricher wrote the row's link last, and a row with no linked
+  // mark keeps the address its provider reported.
+  const pressLink = applications.find((application) => application.link)?.link;
+  if (pressLink) detail.link = pressLink;
 
   const session: NormalizedSession = {
     providerId,
@@ -831,8 +860,8 @@ export function normalizeSession(
     status,
     observedAt,
     location: normalizeLocation(observation.location),
-    detail: normalizeSessionDetail(observation.detail),
-    applications: normalizeApplications(observation.applications),
+    detail,
+    applications,
     controls: normalizeControls(observation.controls),
     // Anything but an explicit yes is a no, so an adapter that has not thought
     // about messaging reports a session that cannot be messaged.

--- a/packages/superset/src/workspaces.ts
+++ b/packages/superset/src/workspaces.ts
@@ -273,9 +273,12 @@ export class SupersetWorkspaceSnapshot {
         ? supersetTerminalLink(context.workspaceId, context.terminalId)
         : supersetWorkspaceLink(context.workspaceId);
       // The app that wrote the host state is the scheme's handler, so the
-      // address stands without the CLI login the acts below wait for. A native
-      // provider address still wins as the row's primary press; the Superset
-      // association keeps its own exact terminal address independently.
+      // address stands without the CLI login the acts below wait for. The
+      // association carries the exact terminal address; which mark a grouped
+      // row's press follows is the session normalization's call — the
+      // workspace's manager leads the marks and the press follows the first
+      // linked one — so the fill here only covers a row nothing else
+      // addressed.
       if (!detail.link) detail.link = applicationLink;
       const applications = observation.applications?.some(
         (application) => application.id === SESSION_APPLICATION_ID.SUPERSET,


### PR DESCRIPTION
## Problem

Local Conductor sessions weren't reading like Conductor's own: rows ignored the names Conductor gave chats and workspaces, chats inside a multi-chat workspace showed no Conductor indicator at all, and a local Codex row's press opened ChatGPT instead of Conductor.

## Fix

- **Chat names** (`c57a725`): the `conductor.db` index read carries `sessions.title`; the name Conductor gave a chat titles the matched row, the same standing it has on a cloud-observed row. The schema's `'Untitled'` default reads as no name, a sub-agent keeps its own title while inheriting the workspace/mark/address, and the query ladder degrades one schema tier at a time (titles → grouping → annotation).
- **Workspace names** (`dc4543c`): the workspace join ladders the way Conductor's sidebar labels a workspace — chosen name, then PR title, then directory name.
- **Lone chats** (`d387716`): a lone chat's row is titled by the chat's own name everywhere; the workspace's name stays searchable and its acts/mark stay on the row.
- **Mark on every chat** (`084f14a`): the Conductor association's address names the exact chat, so it is SESSION-scoped — local and cloud alike — and its mark rides each matched row inside a tray too, while the tray header's manager mark keeps coming from the workspace claim.
- **Generic press precedence** (`c3f37b3`): which app a row's press follows is decided once, in `normalizeSession`, not per enricher. The app whose workspace groups the chat leads the row's marks ahead of the fixed order, and the press follows the first linked mark, falling back to the provider's reported address when no mark carries one. A Conductor-grouped Codex chat opens Conductor (ChatGPT's exact thread keeps its own mark), a Superset-grouped chat opens its Superset terminal the same way, and Orca — whose mark carries no link — cedes the press down the marks unchanged.

`docs/PROVIDERS.md` updated alongside, per the providers-package obligation.

## Testing

- `./scripts/check.sh` and `./scripts/verify.sh` — passed (exit 0) after each change; visual evidence inspected: tray rows trail the Conductor mark with the header naming the manager once, lone rows titled by their own chat names, the ungrouped Codex row keeping ChatGPT's lead. No physical-notch check was performed (fixture evidence only).
- Package tests green across `session` (manager-led ordering, first-linked-mark press, linkless-manager cession, ungrouped fixed order), `providers` (title override, `'Untitled'` handling, sub-agent title independence, PR-title workspace fallback, schema ladders, fill-only-absent link), and `superset`.
- Enrichment verified read-only against the live `conductor.db` on this machine: rows titled by their Conductor chat names, trays named by PR title, the row press resolving to the exact `conductor://` chat address with ChatGPT's route kept on its own mark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32434476964/artifacts/9430279950) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32434476964)

- Commit: `96985e4517a806c3e0bd352f4832fd8bcf22ae6c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
