### PR TITLE
feat(sessions): open local Cursor chats through Cursor's own agent route

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -250,10 +250,13 @@ is said back to you under the field you typed in.
   end and how it ended. Observation does not read message content, and reports
   the fact of a failed turn rather than the reason Cursor recorded for it. A
   session is labelled by the folder it runs in, which Luke reads from Cursor's
-  own record of that folder, not from the chat's generated name. Each row
-  carries the chat's `cursor://` address, composed on this machine from the
-  chat's own observed identifier; opening it hands that address to macOS like
-  any row press, and nothing is sent to Cursor.
+  own record of that folder, not from the chat's generated name. A chat the
+  Cursor app itself holds carries the chat's `cursor://` address, composed on
+  this machine from the chat's own observed identifier; whether the app holds
+  a chat is read from Cursor's own index, opened read-only, as the presence
+  of the chat's key alone — never the value, which is the conversation
+  itself. Opening the address hands it to macOS like any row press, and
+  nothing is sent to Cursor.
 - For Superset, Luke discovers each `host/<organization-id>/host.db`, opens it
   in read-only defensive mode, and reads three fixed queries' worth of rows:
   from the terminal-to-agent bindings, each workspace's name, identifier,

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -250,7 +250,10 @@ is said back to you under the field you typed in.
   end and how it ended. Observation does not read message content, and reports
   the fact of a failed turn rather than the reason Cursor recorded for it. A
   session is labelled by the folder it runs in, which Luke reads from Cursor's
-  own record of that folder, not from the chat's generated name.
+  own record of that folder, not from the chat's generated name. Each row
+  carries the chat's `cursor://` address, composed on this machine from the
+  chat's own observed identifier; opening it hands that address to macOS like
+  any row press, and nothing is sent to Cursor.
 - For Superset, Luke discovers each `host/<organization-id>/host.db`, opens it
   in read-only defensive mode, and reads three fixed queries' worth of rows:
   from the terminal-to-agent bindings, each workspace's name, identifier,

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -455,7 +455,10 @@ boundary the Linear section below describes.
   of repositories the key may launch agents in. It processes identifiers, agent
   names and links, repository URLs, starting refs and run branches, timestamps,
   archive and run status, provider-designated run results, and pull-request
-  links.
+  links. Each agent's row also carries a `cursor://` address for the Cursor
+  app mark, composed on this machine from the observed agent identifier;
+  opening it hands the address to macOS like any row press, and nothing is
+  sent to Cursor by drawing or pressing it.
 - For Devin, Luke reads who the token authenticates as — the identity route
   answers a user id, an organization id, and which kind of credential it is,
   and a token that is not a person's own personal access token is observed as

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -251,12 +251,12 @@ is said back to you under the field you typed in.
   the fact of a failed turn rather than the reason Cursor recorded for it. A
   session is labelled by the folder it runs in, which Luke reads from Cursor's
   own record of that folder, not from the chat's generated name. A chat the
-  Cursor app itself holds carries the chat's `cursor://` address, composed on
-  this machine from the chat's own observed identifier; whether the app holds
-  a chat is read from Cursor's own index, opened read-only, as the presence
-  of the chat's key alone — never the value, which is the conversation
-  itself. Opening the address hands it to macOS like any row press, and
-  nothing is sent to Cursor.
+  Cursor app itself holds carries the chat's `cursor://` address and the
+  Cursor app mark, composed on this machine from the chat's own observed
+  identifier; whether the app holds a chat is read from Cursor's own index,
+  opened read-only, as the presence of the chat's key alone — never the
+  value, which is the conversation itself. Opening the address hands it to
+  macOS like any row press, and nothing is sent to Cursor.
 - For Superset, Luke discovers each `host/<organization-id>/host.db`, opens it
   in read-only defensive mode, and reads three fixed queries' worth of rows:
   from the terminal-to-agent bindings, each workspace's name, identifier,

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -455,10 +455,11 @@ boundary the Linear section below describes.
   of repositories the key may launch agents in. It processes identifiers, agent
   names and links, repository URLs, starting refs and run branches, timestamps,
   archive and run status, provider-designated run results, and pull-request
-  links. Each agent's row also carries a `cursor://` address for the Cursor
-  app mark, composed on this machine from the observed agent identifier;
-  opening it hands the address to macOS like any row press, and nothing is
-  sent to Cursor by drawing or pressing it.
+  links. Each agent's row opens through a `cursor://` address into the Cursor
+  app — carried by the row's own press and its Cursor app mark alike,
+  composed on this machine from the observed agent identifier; opening it
+  hands the address to macOS like any row press, and nothing is sent to
+  Cursor by drawing or pressing it.
 - For Devin, Luke reads who the token authenticates as — the identity route
   answers a user id, an organization id, and which kind of credential it is,
   and a token that is not a person's own personal access token is observed as

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -453,7 +453,7 @@ boundary the Linear section below describes.
 - For Cursor, Luke reads agents owned by the supplied key and their latest runs,
   and — on a much slower cadence, within Cursor's documented limits — the list
   of repositories the key may launch agents in. It processes identifiers, agent
-  names and links, repository URLs, starting refs and run branches, timestamps,
+  names, repository URLs, starting refs and run branches, timestamps,
   archive and run status, provider-designated run results, and pull-request
   links. Each agent's row opens through a `cursor://` address into the Cursor
   app — carried by the row's own press and its Cursor app mark alike,

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -311,7 +311,9 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "filter rows by axis — location (local, cloud), kind (voice chats), app (Conductor, " +
         "ChatGPT, Cursor, Orca, Superset, cmux), and agent — where several chips can be pressed at once: choices " +
         "on one row widen each other and choices across rows narrow, so Codex beside " +
-        "Conductor means Codex chats associated with Conductor. The sheet stays open while " +
+        "Conductor means Codex chats associated with Conductor. Cursor sits on both rows: " +
+        "its app chip narrows to the chats the Cursor app can open, its agent chip to every " +
+        "Cursor chat. The sheet stays open while " +
         "chips toggle, and the options button wears the narrowing while the sheet is closed. " +
         "Chosen chips are un-pressed the same way they were pressed, a spoken ask can narrow " +
         "to one or several values combined the same way — local Codex voice chats is one ask " +
@@ -340,9 +342,10 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "Cursor, Gemini CLI, and OpenCode only after cmux's `cmux hooks setup`, so a session cmux never " +
         "recorded carries no cmux mark. A local Codex chat also names " +
         "ChatGPT because OpenAI's desktop app documents the exact Codex thread address Luke " +
-        "already opens. A local Cursor chat held by the Cursor app names Cursor itself the " +
-        "same way — the app's own index says which chats its windows hold, read as key " +
-        "presence alone — where a chat Cursor's agents CLI started in a plain terminal " +
+        "already opens. A Cursor chat the Cursor app can open names Cursor itself the same " +
+        "way — a local chat the app's own index holds, read as key presence alone, or any " +
+        "Cursor cloud agent, which the app opens by id like its own dashboard does — where " +
+        "a chat Cursor's agents CLI started in a plain terminal " +
         "carries no Cursor app mark and opens nowhere unless cmux, Superset, or Conductor " +
         "hosts its terminal. More than one app mark may appear on one row; none replaces the agent " +
         "or changes local versus cloud. An app mark with an exact address is a button: " +

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -309,7 +309,7 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "Lists every session that still matters: one working or waiting stays at any age, a " +
         "failure for three days, a finished or quiet one for two. The options button opens " +
         "filter rows by axis — location (local, cloud), kind (voice chats), app (Conductor, " +
-        "ChatGPT, Orca, Superset, cmux), and agent — where several chips can be pressed at once: choices " +
+        "ChatGPT, Cursor, Orca, Superset, cmux), and agent — where several chips can be pressed at once: choices " +
         "on one row widen each other and choices across rows narrow, so Codex beside " +
         "Conductor means Codex chats associated with Conductor. The sheet stays open while " +
         "chips toggle, and the options button wears the narrowing while the sheet is closed. " +
@@ -340,9 +340,14 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "Cursor, Gemini CLI, and OpenCode only after cmux's `cmux hooks setup`, so a session cmux never " +
         "recorded carries no cmux mark. A local Codex chat also names " +
         "ChatGPT because OpenAI's desktop app documents the exact Codex thread address Luke " +
-        "already opens. More than one app mark may appear on one row; none replaces the agent " +
+        "already opens. A local Cursor chat held by the Cursor app names Cursor itself the " +
+        "same way — the app's own index says which chats its windows hold, read as key " +
+        "presence alone — where a chat Cursor's agents CLI started in a plain terminal " +
+        "carries no Cursor app mark and opens nowhere unless cmux, Superset, or Conductor " +
+        "hosts its terminal. More than one app mark may appear on one row; none replaces the agent " +
         "or changes local versus cloud. An app mark with an exact address is a button: " +
-        "ChatGPT opens that Codex thread, Superset opens its bound terminal, cmux opens the " +
+        "ChatGPT opens that Codex thread, Cursor opens the exact chat in its own window, " +
+        "Superset opens its bound terminal, cmux opens the " +
         "exact terminal pane the agent runs in — and stands in as the row's own destination " +
         "when no other app gave it one — and a Conductor " +
         "cloud chat's Conductor mark opens that exact chat. The row body still opens its " +

--- a/apps/desktop/src/renderer/provider-marks.tsx
+++ b/apps/desktop/src/renderer/provider-marks.tsx
@@ -468,6 +468,9 @@ const PROVIDER_MARKS = {
   [PROVIDER_ID.CONDUCTOR]: ConductorMark,
   [PROVIDER_ID.COPILOT]: CopilotMark,
   [PROVIDER_ID.CURSOR]: CursorMark,
+  // Cursor the app draws Cursor's own mark: the id differs from the agent's
+  // only so the two filter chips can answer different questions.
+  [SESSION_APPLICATION_ID.CURSOR]: CursorMark,
   [PROVIDER_ID.DEVIN]: DevinMark,
   [PROVIDER_ID.GEMINI_CLI]: GeminiCliMark,
   [GOOGLE_CALENDAR_ID]: GoogleCalendarMark,

--- a/apps/desktop/src/renderer/session-model.test.ts
+++ b/apps/desktop/src/renderer/session-model.test.ts
@@ -411,6 +411,15 @@ test("the filters offered are grouped by axis, coarse to fine, counted", () => {
           count: 3,
           markId: SESSION_APPLICATION_ID.CONDUCTOR,
         },
+        {
+          // Cursor occupies both vocabularies the way Conductor does, so its
+          // chip is seated by its own axis — the app row — even when only
+          // native Cursor chats put it on offer.
+          filter: SESSION_APPLICATION_ID.CURSOR,
+          label: "Cursor",
+          count: 1,
+          markId: SESSION_APPLICATION_ID.CURSOR,
+        },
       ],
     },
     {
@@ -426,7 +435,6 @@ test("the filters offered are grouped by axis, coarse to fine, counted", () => {
           markId: PROVIDER_ID.CLAUDE_CODE,
         },
         { filter: PROVIDER_ID.CODEX, label: "Codex", count: 1, markId: PROVIDER_ID.CODEX },
-        { filter: PROVIDER_ID.CURSOR, label: "Cursor", count: 1, markId: PROVIDER_ID.CURSOR },
         { filter: PROVIDER_ID.DEVIN, label: "Devin", count: 1, markId: PROVIDER_ID.DEVIN },
       ],
     },
@@ -602,9 +610,11 @@ test("filters on one axis widen each other and across axes narrow", () => {
 // and the list correcting itself must not choose — so the selection falls
 // back whole.
 test("a combination no session answers falls back whole to everything", () => {
+  // Devin rather than Cursor: Cursor now shares the app axis with Conductor,
+  // where two values widen each other instead of contradicting.
   const emptied = arrangeSessions(FIXTURE_SESSIONS, {
     ...DEFAULT_SESSION_VIEW,
-    filters: [SESSION_FILTER.LOCAL, SESSION_APPLICATION_ID.CONDUCTOR, PROVIDER_ID.CURSOR],
+    filters: [SESSION_FILTER.LOCAL, SESSION_APPLICATION_ID.CONDUCTOR, PROVIDER_ID.DEVIN],
   });
 
   assert.deepEqual(emptied.filters, []);

--- a/apps/desktop/src/renderer/session-model.test.ts
+++ b/apps/desktop/src/renderer/session-model.test.ts
@@ -412,9 +412,9 @@ test("the filters offered are grouped by axis, coarse to fine, counted", () => {
           markId: SESSION_APPLICATION_ID.CONDUCTOR,
         },
         {
-          // Cursor occupies both vocabularies the way Conductor does, so its
-          // chip is seated by its own axis — the app row — even when only
-          // native Cursor chats put it on offer.
+          // The app chip counts the chats the Cursor app can open; the agent
+          // chip below counts every Cursor chat. Separate ids keep the two
+          // questions on their own axes.
           filter: SESSION_APPLICATION_ID.CURSOR,
           label: "Cursor",
           count: 1,
@@ -435,6 +435,7 @@ test("the filters offered are grouped by axis, coarse to fine, counted", () => {
           markId: PROVIDER_ID.CLAUDE_CODE,
         },
         { filter: PROVIDER_ID.CODEX, label: "Codex", count: 1, markId: PROVIDER_ID.CODEX },
+        { filter: PROVIDER_ID.CURSOR, label: "Cursor", count: 1, markId: PROVIDER_ID.CURSOR },
         { filter: PROVIDER_ID.DEVIN, label: "Devin", count: 1, markId: PROVIDER_ID.DEVIN },
       ],
     },
@@ -610,11 +611,9 @@ test("filters on one axis widen each other and across axes narrow", () => {
 // and the list correcting itself must not choose — so the selection falls
 // back whole.
 test("a combination no session answers falls back whole to everything", () => {
-  // Devin rather than Cursor: Cursor now shares the app axis with Conductor,
-  // where two values widen each other instead of contradicting.
   const emptied = arrangeSessions(FIXTURE_SESSIONS, {
     ...DEFAULT_SESSION_VIEW,
-    filters: [SESSION_FILTER.LOCAL, SESSION_APPLICATION_ID.CONDUCTOR, PROVIDER_ID.DEVIN],
+    filters: [SESSION_FILTER.LOCAL, SESSION_APPLICATION_ID.CONDUCTOR, PROVIDER_ID.CURSOR],
   });
 
   assert.deepEqual(emptied.filters, []);

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -118,18 +118,16 @@ The bounds the tables cannot carry:
   the build's table. Conductor on this Mac is an app — see [Apps](#apps).
 - **Cursor, local** — rows report turn state and failure without Cursor's
   reason, which is not stored, and the readout renders what Cursor wrote down,
-  which excludes tool outputs. A chat the app itself holds carries its own
+  which excludes tool outputs. A chat the Cursor app holds carries its own
   address, `cursor://anysphere.cursor-deeplink/agent?id=<chat>`, composed on
   this machine from the chat's observed id — the same route Cursor's
-  deep-link handler resolves — and it opens the exact chat whether Cursor is
-  running or not. Whether the app holds a chat is read from Cursor's own
-  index as the presence of the chat's key alone, because the values are the
-  conversations. Cursor's `agents` CLI writes transcripts beside the app's
-  without registering them in any window, so a CLI chat keeps no provider
-  address — an app that manages its terminal stands its own in, the way
-  cmux, Superset, and Conductor rows already do, and a CLI chat in an
-  unmanaged terminal honestly opens nowhere, like every other
-  terminal-only agent.
+  deep-link handler resolves, opening the exact chat whether Cursor is
+  running or not — and wears the app's own mark: Cursor on this Mac is an
+  app as well as an agent — see [Apps](#apps). A chat the `agents` CLI
+  started keeps no provider address — an app that manages its terminal
+  stands its own in, the way cmux, Superset, and Conductor rows already do,
+  and a CLI chat in an unmanaged terminal honestly opens nowhere, like every
+  other terminal-only agent.
 - **Cursor, cloud** — cancel and archive are never offered at once; a message
   is a follow-up run, only after the latest run finished on an unarchived
   agent; the new agent's task is required because Cursor cannot make an idle
@@ -166,6 +164,7 @@ schema this build does not know means no annotation.
 | ChatGPT | Nothing | A mark opening the exact Codex thread | None |
 | cmux | Hook-session stores under `~/.cmuxterm` | Mark, exact `cmux:` pane address | None |
 | Conductor | Local session index (`conductor.db`) | Mark, workspace grouping, `conductor:` chat address, filed-away filtering | None |
+| Cursor | Chat-key presence in the app's own index | Mark and `cursor:` address opening the exact chat | None |
 | Orca | Hook-status cache and worktree names | Mark, worktree grouping | None |
 | Superset | Host state (`host.db`) | Mark, grouping, `superset:` workspace address; a standing row for each unarchived worktree with no agent terminal | Message, open workspace, close terminal, add agent, new workspace, rename, delete workspace — through its CLI, while logged in |
 
@@ -198,6 +197,14 @@ schema this build does not know means no annotation.
   absent app, an unreadable index, or a schema too old to say leaves every
   observation standing. Conductor documents no message endpoint for a local
   chat, so the association adds no send control.
+- **Cursor** — the agent's own app, riding the local rows it holds the way
+  ChatGPT rides a Codex chat: the agent stays the row's identity, the Cursor
+  mark and the row's own press open the same exact chat, and the Cursor
+  filter takes the union of agent and app the way Conductor's does. Whether
+  the app holds a chat is read from the app's own index as the presence of
+  the chat's key alone — the values are the conversations, and observation
+  never opens message content. A chat the `agents` CLI started registers in
+  no window, so it carries no Cursor app mark and none of the app's address.
 - **Orca** — the hook-status cache also carries conversational fields — the
   last prompt, a message preview, a tool's input — and none of them are ever
   read. A sub-agent

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -131,7 +131,9 @@ The bounds the tables cannot carry:
 - **Cursor, cloud** — cancel and archive are never offered at once; a message
   is a follow-up run, only after the latest run finished on an unarchived
   agent; the new agent's task is required because Cursor cannot make an idle
-  workspace.
+  workspace. The row's press keeps the agent page Cursor reported, and the
+  Cursor app mark carries the in-app address the same agent answers to — see
+  [Apps](#apps).
 - **Devin** — the local database has no address, no recap, and no error
   detail; the cloud archive is offered only once the turn positively settled.
 - **Gemini CLI** — bounded tails only (honoring `GEMINI_CLI_HOME`), never
@@ -164,7 +166,7 @@ schema this build does not know means no annotation.
 | ChatGPT | Nothing | A mark opening the exact Codex thread | None |
 | cmux | Hook-session stores under `~/.cmuxterm` | Mark, exact `cmux:` pane address | None |
 | Conductor | Local session index (`conductor.db`) | Mark, workspace grouping, `conductor:` chat address, filed-away filtering | None |
-| Cursor | Chat-key presence in the app's own index | Mark and `cursor:` address opening the exact chat | None |
+| Cursor | Chat-key presence in the app's own index | Mark and `cursor:` address opening the exact chat, on app-held local chats and every cloud agent | None |
 | Orca | Hook-status cache and worktree names | Mark, worktree grouping | None |
 | Superset | Host state (`host.db`) | Mark, grouping, `superset:` workspace address; a standing row for each unarchived worktree with no agent terminal | Message, open workspace, close terminal, add agent, new workspace, rename, delete workspace — through its CLI, while logged in |
 
@@ -197,14 +199,19 @@ schema this build does not know means no annotation.
   absent app, an unreadable index, or a schema too old to say leaves every
   observation standing. Conductor documents no message endpoint for a local
   chat, so the association adds no send control.
-- **Cursor** — the agent's own app, riding the local rows it holds the way
-  ChatGPT rides a Codex chat: the agent stays the row's identity, the Cursor
-  mark and the row's own press open the same exact chat, and the Cursor
-  filter takes the union of agent and app the way Conductor's does. Whether
-  the app holds a chat is read from the app's own index as the presence of
-  the chat's key alone — the values are the conversations, and observation
-  never opens message content. A chat the `agents` CLI started registers in
-  no window, so it carries no Cursor app mark and none of the app's address.
+- **Cursor** — the agent's own app, riding the rows it can open the way
+  ChatGPT rides a Codex chat: the agent stays the row's identity, and the
+  mark's press opens the exact chat in the app. A local chat qualifies when
+  the app's own index holds it — read as the presence of the chat's key
+  alone, because the values are the conversations, and observation never
+  opens message content — through the handler's `/agent` route; every cloud
+  agent qualifies through its `/background-agent` route, the same address
+  Cursor's own dashboard fires, composed here from the observed agent id. The
+  app deliberately keeps its own filter id rather than the agent's: the app
+  chip counts the chats the Cursor app can open, the agent chip every Cursor
+  chat, and the two chips narrow each other across their axes. A chat the
+  `agents` CLI started registers in no window, so it carries no Cursor app
+  mark and none of the app's address.
 - **Orca** — the hook-status cache also carries conversational fields — the
   last prompt, a message preview, a tool's input — and none of them are ever
   read. A sub-agent

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -44,7 +44,7 @@ What Luke reads:
 | Codex | Cloud | The user's own Codex CLI, under its ChatGPT login | — | — | `chatgpt.com` task page |
 | Conductor | Cloud | `api.conductor.build`, under an API key | Final assistant message, while idle | — | `conductor:` deep link |
 | Cursor | Local | Agent transcripts under `~/.cursor/projects/` | — | Yes | `cursor:` chat deep link, for the app's own chats |
-| Cursor | Cloud | `api.cursor.com`, under `CURSOR_API_KEY` | Run result | — | Agent URL |
+| Cursor | Cloud | `api.cursor.com`, under `CURSOR_API_KEY` | Run result | — | `cursor:` deep link into the app |
 | Devin | Local | The Devin CLI's session database | — | Yes | — |
 | Devin | Cloud | `api.devin.ai`, under a `cog_` access token | — | — | Session URL |
 | Gemini CLI | Local | Session recordings under `~/.gemini/tmp/<project>/chats/` | Last agent message | Yes | — |
@@ -131,9 +131,11 @@ The bounds the tables cannot carry:
 - **Cursor, cloud** — cancel and archive are never offered at once; a message
   is a follow-up run, only after the latest run finished on an unarchived
   agent; the new agent's task is required because Cursor cannot make an idle
-  workspace. The row's press keeps the agent page Cursor reported, and the
-  Cursor app mark carries the in-app address the same agent answers to — see
-  [Apps](#apps).
+  workspace. A row opens in the Cursor app — its press and its Cursor app
+  mark share the one `/background-agent` address the app's own dashboard
+  fires, composed from the observed agent id — and the agent page URL Cursor
+  also reports is not offered, because two presses should not answer one row
+  differently — see [Apps](#apps).
 - **Devin** — the local database has no address, no recap, and no error
   detail; the cloud archive is offered only once the turn positively settled.
 - **Gemini CLI** — bounded tails only (honoring `GEMINI_CLI_HOME`), never

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -43,7 +43,7 @@ What Luke reads:
 | Codex | Local | Session index and rollout files under `~/.codex` | Last agent message, or the turn's error | Yes | `codex:` thread |
 | Codex | Cloud | The user's own Codex CLI, under its ChatGPT login | — | — | `chatgpt.com` task page |
 | Conductor | Cloud | `api.conductor.build`, under an API key | Final assistant message, while idle | — | `conductor:` deep link |
-| Cursor | Local | Agent transcripts under `~/.cursor/projects/` | — | Yes | `cursor:` chat deep link |
+| Cursor | Local | Agent transcripts under `~/.cursor/projects/` | — | Yes | `cursor:` chat deep link, for the app's own chats |
 | Cursor | Cloud | `api.cursor.com`, under `CURSOR_API_KEY` | Run result | — | Agent URL |
 | Devin | Local | The Devin CLI's session database | — | Yes | — |
 | Devin | Cloud | `api.devin.ai`, under a `cog_` access token | — | — | Session URL |
@@ -118,12 +118,18 @@ The bounds the tables cannot carry:
   the build's table. Conductor on this Mac is an app — see [Apps](#apps).
 - **Cursor, local** — rows report turn state and failure without Cursor's
   reason, which is not stored, and the readout renders what Cursor wrote down,
-  which excludes tool outputs. Each row's address,
-  `cursor://anysphere.cursor-deeplink/agent?id=<chat>`, is composed on this
-  machine from the chat's own observed id — the same route Cursor's deep-link
-  handler resolves — and opens the exact chat whether Cursor is running or
-  not; a chat Cursor cannot resolve draws Cursor's own not-found notice
-  rather than acting on anything.
+  which excludes tool outputs. A chat the app itself holds carries its own
+  address, `cursor://anysphere.cursor-deeplink/agent?id=<chat>`, composed on
+  this machine from the chat's observed id — the same route Cursor's
+  deep-link handler resolves — and it opens the exact chat whether Cursor is
+  running or not. Whether the app holds a chat is read from Cursor's own
+  index as the presence of the chat's key alone, because the values are the
+  conversations. Cursor's `agents` CLI writes transcripts beside the app's
+  without registering them in any window, so a CLI chat keeps no provider
+  address — an app that manages its terminal stands its own in, the way
+  cmux, Superset, and Conductor rows already do, and a CLI chat in an
+  unmanaged terminal honestly opens nowhere, like every other
+  terminal-only agent.
 - **Cursor, cloud** — cancel and archive are never offered at once; a message
   is a follow-up run, only after the latest run finished on an unarchived
   agent; the new agent's task is required because Cursor cannot make an idle

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -43,7 +43,7 @@ What Luke reads:
 | Codex | Local | Session index and rollout files under `~/.codex` | Last agent message, or the turn's error | Yes | `codex:` thread |
 | Codex | Cloud | The user's own Codex CLI, under its ChatGPT login | — | — | `chatgpt.com` task page |
 | Conductor | Cloud | `api.conductor.build`, under an API key | Final assistant message, while idle | — | `conductor:` deep link |
-| Cursor | Local | Agent transcripts under `~/.cursor/projects/` | — | Yes | — |
+| Cursor | Local | Agent transcripts under `~/.cursor/projects/` | — | Yes | `cursor:` chat deep link |
 | Cursor | Cloud | `api.cursor.com`, under `CURSOR_API_KEY` | Run result | — | Agent URL |
 | Devin | Local | The Devin CLI's session database | — | Yes | — |
 | Devin | Cloud | `api.devin.ai`, under a `cog_` access token | — | — | Session URL |
@@ -118,7 +118,12 @@ The bounds the tables cannot carry:
   the build's table. Conductor on this Mac is an app — see [Apps](#apps).
 - **Cursor, local** — rows report turn state and failure without Cursor's
   reason, which is not stored, and the readout renders what Cursor wrote down,
-  which excludes tool outputs.
+  which excludes tool outputs. Each row's address,
+  `cursor://anysphere.cursor-deeplink/agent?id=<chat>`, is composed on this
+  machine from the chat's own observed id — the same route Cursor's deep-link
+  handler resolves — and opens the exact chat whether Cursor is running or
+  not; a chat Cursor cannot resolve draws Cursor's own not-found notice
+  rather than acting on anything.
 - **Cursor, cloud** — cancel and archive are never offered at once; a message
   is a follow-up run, only after the latest run finished on an unarchived
   agent; the new agent's task is required because Cursor cannot make an idle

--- a/packages/fixtures/src/fixtures.ts
+++ b/packages/fixtures/src/fixtures.ts
@@ -207,6 +207,17 @@ const smokeFixture: FixtureSnapshot = {
       title: "Follow a cloud agent",
       providerId: PROVIDER_ID.CURSOR,
       provider: "Cursor",
+      // The Cursor app opens any cloud agent by id, so the row wears the app
+      // mark beside the agent identity — which also keeps both Cursor filter
+      // chips, app and agent, in the one screenshot the evidence is reviewed
+      // from.
+      applications: [
+        {
+          id: SESSION_APPLICATION_ID.CURSOR,
+          name: "Cursor",
+          scope: SESSION_APPLICATION_SCOPE.SESSION,
+        },
+      ],
       detail: "Opened a pull request against sidecar.",
       repository: "sidecar",
       branch: "cursor/follow-agent-a1b2",

--- a/packages/providers/src/cursor/adapter.test.ts
+++ b/packages/providers/src/cursor/adapter.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { SESSION_CONTROL_KIND, SESSION_STATUS, type SessionControl } from "@sidecar/session";
+import {
+  SESSION_APPLICATION_ID,
+  SESSION_APPLICATION_SCOPE,
+  SESSION_CONTROL_KIND,
+  SESSION_STATUS,
+  type SessionControl,
+} from "@sidecar/session";
 import type { JsonObject } from "@sidecar/wire/testing";
 import { HTTP_STATUS, jsonResponse, recordingFetch } from "@sidecar/wire/testing";
 import type { CloudFetch } from "../shared/cloud-session-adapter.js";
@@ -285,6 +291,16 @@ test("observes a running agent under the name Cursor gave it", async () => {
     link: "https://cursor.com/agents/agent-running",
     change: TEST_PULL_REQUEST_URL,
   });
+  // The row's own press keeps the agent page Cursor reported; the app mark
+  // carries the in-app address the same agent answers to.
+  assert.deepEqual(observations[0]?.applications, [
+    {
+      id: SESSION_APPLICATION_ID.CURSOR,
+      displayName: "Cursor",
+      scope: SESSION_APPLICATION_SCOPE.SESSION,
+      link: "cursor://anysphere.cursor-deeplink/background-agent?bcId=agent-running",
+    },
+  ]);
   // The repository offer, one list call, then one read of the run that list
   // named. Nothing else.
   assert.deepEqual(

--- a/packages/providers/src/cursor/adapter.test.ts
+++ b/packages/providers/src/cursor/adapter.test.ts
@@ -288,11 +288,11 @@ test("observes a running agent under the name Cursor gave it", async () => {
   assert.deepEqual(observations[0]?.detail, {
     repository: "luke",
     branch: TEST_RUN_BRANCH,
-    link: "https://cursor.com/agents/agent-running",
+    link: "cursor://anysphere.cursor-deeplink/background-agent?bcId=agent-running",
     change: TEST_PULL_REQUEST_URL,
   });
-  // The row's own press keeps the agent page Cursor reported; the app mark
-  // carries the in-app address the same agent answers to.
+  // The row's own press and the app mark share the one in-app address, the
+  // way a local Codex row and its ChatGPT mark share the thread's.
   assert.deepEqual(observations[0]?.applications, [
     {
       id: SESSION_APPLICATION_ID.CURSOR,

--- a/packages/providers/src/cursor/adapter.ts
+++ b/packages/providers/src/cursor/adapter.ts
@@ -28,6 +28,7 @@ import {
   textFromRecord,
   timestampFromRecord,
 } from "../shared/cloud-session-adapter.js";
+import { cursorApplication, cursorCloudAgentLink } from "./app-links.js";
 
 // Shared with the credential registry so the key the user saves and the
 // provider Luke observes with it can never name different things.
@@ -535,6 +536,10 @@ export class CursorSessionAdapter extends CloudSessionAdapter {
       title: agent.name ?? repository ?? UNKNOWN_AGENT_LABEL,
       status,
       observedAt,
+      // The Cursor app opens any cloud agent by id — the same address its own
+      // dashboard fires — so every cloud row wears the app's mark; the row's
+      // own press keeps the agent page Cursor reported.
+      applications: [cursorApplication(cursorCloudAgentLink(agent.id))],
       canReceiveMessage: this.#agentTakesMessages(agent, run),
       // The two controls are exclusive by construction: an active run offers
       // its stop, a settled agent offers to be filed away, and an archived one

--- a/packages/providers/src/cursor/adapter.ts
+++ b/packages/providers/src/cursor/adapter.ts
@@ -537,8 +537,10 @@ export class CursorSessionAdapter extends CloudSessionAdapter {
       status,
       observedAt,
       // The Cursor app opens any cloud agent by id — the same address its own
-      // dashboard fires — so every cloud row wears the app's mark; the row's
-      // own press keeps the agent page Cursor reported.
+      // dashboard fires — so the row's own press and the app's mark carry
+      // that one address, the way a local Codex row and its ChatGPT mark
+      // share the thread's. The agent page URL Cursor also reports stays
+      // reachable inside the app; the pull request keeps its own chip.
       applications: [cursorApplication(cursorCloudAgentLink(agent.id))],
       canReceiveMessage: this.#agentTakesMessages(agent, run),
       // The two controls are exclusive by construction: an active run offers
@@ -556,7 +558,7 @@ export class CursorSessionAdapter extends CloudSessionAdapter {
         // a run that has pushed nothing still has a starting point worth naming.
         ...(run?.branch ? { branch: run.branch } : agent.ref ? { branch: agent.ref } : undefined),
         ...(status === SESSION_STATUS.ERROR ? { error: CURSOR_RUN_FAILED_MESSAGE } : undefined),
-        ...(agent.url ? { link: agent.url } : undefined),
+        link: cursorCloudAgentLink(agent.id),
         ...(run?.pullRequestUrl ? { change: run.pullRequestUrl } : undefined),
       },
     };

--- a/packages/providers/src/cursor/adapter.ts
+++ b/packages/providers/src/cursor/adapter.ts
@@ -217,7 +217,6 @@ interface CursorAgent {
   lastActivityAt: number;
   latestRunId?: string;
   ref?: string;
-  url?: string;
 }
 
 interface CursorRun {
@@ -264,7 +263,6 @@ function agentFromRecord(record: WireRecord): CursorAgent | undefined {
   );
   const latestRunId = textFromRecord(record, CURSOR_FIELD.LATEST_RUN_ID);
   const name = textFromRecord(record, CURSOR_FIELD.NAME)?.slice(0, maximumSessionTitleLength);
-  const url = textFromRecord(record, CURSOR_FIELD.URL);
   return {
     id,
     lastActivityAt,
@@ -273,7 +271,6 @@ function agentFromRecord(record: WireRecord): CursorAgent | undefined {
     archived: textFromRecord(record, CURSOR_FIELD.STATUS) === CURSOR_AGENT_STATUS.ARCHIVED,
     ...(latestRunId ? { latestRunId } : undefined),
     ...(ref ? { ref } : undefined),
-    ...(url ? { url } : undefined),
   };
 }
 

--- a/packages/providers/src/cursor/app-links.ts
+++ b/packages/providers/src/cursor/app-links.ts
@@ -1,0 +1,40 @@
+import {
+  SESSION_APPLICATION_ID,
+  SESSION_APPLICATION_SCOPE,
+  type SessionApplication,
+} from "@sidecar/session";
+
+/**
+ * The two routes Cursor's own deep-link handler resolves to an exact chat,
+ * each composed on this machine from an observed id and handed to the
+ * operating system, reaching Cursor's write paths never. A local chat the
+ * app holds answers `/agent` by its chat id; a cloud agent answers
+ * `/background-agent` by its agent id — the same address Cursor's own
+ * dashboard fires from its Open in Cursor buttons. Either opens the exact
+ * chat whether Cursor is running or not, and an id Cursor cannot resolve
+ * draws its own not-found notice rather than acting on anything.
+ */
+export function cursorChatLink(providerSessionId: string): string {
+  return `cursor://anysphere.cursor-deeplink/agent?id=${encodeURIComponent(providerSessionId)}`;
+}
+
+export function cursorCloudAgentLink(agentId: string): string {
+  return `cursor://anysphere.cursor-deeplink/background-agent?bcId=${encodeURIComponent(agentId)}`;
+}
+
+/**
+ * The Cursor app riding a chat it can open as an app association, the way
+ * ChatGPT rides a local Codex chat: the agent stays the row's identity, and
+ * the mark's press opens the exact chat in the app. The application id is
+ * deliberately not the provider's — the app chip counts the chats the Cursor
+ * app can open, where the agent chip counts every Cursor chat — so a local
+ * CLI chat, which the app cannot open, wears the agent identity alone.
+ */
+export function cursorApplication(link: string): SessionApplication {
+  return {
+    id: SESSION_APPLICATION_ID.CURSOR,
+    displayName: "Cursor",
+    scope: SESSION_APPLICATION_SCOPE.SESSION,
+    link,
+  };
+}

--- a/packages/providers/src/cursor/local-adapter.test.ts
+++ b/packages/providers/src/cursor/local-adapter.test.ts
@@ -38,6 +38,7 @@ const TEST_CONTENT_TYPE = {
 interface CursorState {
   cursorHome: string;
   workspaceStorageDirectory: string;
+  globalStorageStatePath: string;
 }
 
 function messageRecord(role: string, contentType: string): ParsedJsonObject {
@@ -66,7 +67,28 @@ async function temporaryCursorState(t: TestContext): Promise<CursorState> {
   return {
     cursorHome: path.join(directory, "cursor-home"),
     workspaceStorageDirectory: path.join(directory, "workspace-storage"),
+    globalStorageStatePath: path.join(directory, "global-storage-state.vscdb"),
   };
+}
+
+/**
+ * The app's own index of the chats its windows hold. The values are the
+ * conversations themselves, which observation must never read, so the fixture
+ * plants transcript text there and the tests assert it never surfaces.
+ */
+async function registerAppChats(state: CursorState, sessionIds: readonly string[]): Promise<void> {
+  const { DatabaseSync } = await import("node:sqlite");
+  const database = new DatabaseSync(state.globalStorageStatePath, {});
+  try {
+    database.exec("CREATE TABLE IF NOT EXISTS cursorDiskKV (key TEXT PRIMARY KEY, value BLOB)");
+    for (const sessionId of sessionIds) {
+      database
+        .prepare("INSERT OR REPLACE INTO cursorDiskKV (key, value) VALUES (?, ?)")
+        .run(`composerData:${sessionId}`, JSON.stringify({ conversation: SECRET_TRANSCRIPT_TEXT }));
+    }
+  } finally {
+    database.close();
+  }
 }
 
 async function writeTranscript(
@@ -162,6 +184,7 @@ function adapterFor(
 test("observes an open turn as work, labelled by its folder and free of transcript text", async (t) => {
   const state = await temporaryCursorState(t);
   await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  await registerAppChats(state, ["0b1f4b0e-2c5a-4d1e-9a3c-6d5f7e8a9b0c"]);
   await writeTranscript(
     state,
     "Users-test-luke",
@@ -185,7 +208,8 @@ test("observes an open turn as work, labelled by its folder and free of transcri
   assert.equal(observations[0]?.controls, undefined);
   assert.equal(observations[0]?.recap, undefined);
   // The address is the same /agent route Cursor's own deep-link handler
-  // resolves, composed from the observed composer id alone.
+  // resolves, composed from the observed chat id alone — offered because the
+  // app's own index holds this chat.
   assert.deepEqual(observations[0]?.detail, {
     repository: "luke",
     link: "cursor://anysphere.cursor-deeplink/agent?id=0b1f4b0e-2c5a-4d1e-9a3c-6d5f7e8a9b0c",
@@ -199,6 +223,7 @@ test("observes an open turn as work, labelled by its folder and free of transcri
 test("tells a turn that finished from one that failed", async (t) => {
   const state = await temporaryCursorState(t);
   await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  await registerAppChats(state, ["session-finished", "session-failed"]);
   await writeTranscript(
     state,
     "Users-test-luke",
@@ -236,6 +261,51 @@ test("tells a turn that finished from one that failed", async (t) => {
     error: "The turn failed",
   });
   assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);
+});
+
+test("offers the app's address only for the chats the app itself holds", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  await registerAppChats(state, ["app-chat"]);
+  const records = [messageRecord(TEST_ROLE.USER, TEST_CONTENT_TYPE.TEXT)];
+  await writeTranscript(state, "Users-test-luke", "app-chat", records, TEST_TIME - 5_000);
+  // A chat Cursor's `agents` CLI started writes its transcript beside the
+  // app's without registering in any window; its row keeps no provider
+  // address, which is what lets a manager's own address stand in — or an
+  // unmanaged terminal's row honestly open nowhere.
+  await writeTranscript(state, "Users-test-luke", "cli-chat", records, TEST_TIME - 10_000);
+
+  const observations = await adapterFor(state).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => [observation.providerSessionId, observation.detail?.link]),
+    [
+      ["app-chat", "cursor://anysphere.cursor-deeplink/agent?id=app-chat"],
+      ["cli-chat", undefined],
+    ],
+  );
+  assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);
+});
+
+test("an app index this build cannot read withholds addresses rather than guessing", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  const { DatabaseSync } = await import("node:sqlite");
+  const database = new DatabaseSync(state.globalStorageStatePath, {});
+  database.exec("CREATE TABLE unrelated (id TEXT PRIMARY KEY)");
+  database.close();
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "app-chat",
+    [messageRecord(TEST_ROLE.USER, TEST_CONTENT_TYPE.TEXT)],
+    TEST_TIME - 5_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.detail?.link, undefined);
 });
 
 test("passes over trailing records this build does not know", async (t) => {

--- a/packages/providers/src/cursor/local-adapter.test.ts
+++ b/packages/providers/src/cursor/local-adapter.test.ts
@@ -184,7 +184,12 @@ test("observes an open turn as work, labelled by its folder and free of transcri
   assert.equal(observations[0]?.observedAt, TEST_TIME - 5_000);
   assert.equal(observations[0]?.controls, undefined);
   assert.equal(observations[0]?.recap, undefined);
-  assert.deepEqual(observations[0]?.detail, { repository: "luke" });
+  // The address is the same /agent route Cursor's own deep-link handler
+  // resolves, composed from the observed composer id alone.
+  assert.deepEqual(observations[0]?.detail, {
+    repository: "luke",
+    link: "cursor://anysphere.cursor-deeplink/agent?id=0b1f4b0e-2c5a-4d1e-9a3c-6d5f7e8a9b0c",
+  });
   // Nothing says this session runs anywhere but here, which is what leaves it
   // local once the registry normalizes it.
   assert.equal(observations[0]?.location, undefined);
@@ -227,6 +232,7 @@ test("tells a turn that finished from one that failed", async (t) => {
   // The failure is reported; the reason Cursor recorded for it is not.
   assert.deepEqual(observations[1]?.detail, {
     repository: "luke",
+    link: "cursor://anysphere.cursor-deeplink/agent?id=session-failed",
     error: "The turn failed",
   });
   assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);

--- a/packages/providers/src/cursor/local-adapter.test.ts
+++ b/packages/providers/src/cursor/local-adapter.test.ts
@@ -303,6 +303,26 @@ test("offers the app's address only for the chats the app itself holds", async (
   assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);
 });
 
+test("a malformed app index never costs the rows themselves", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  // Not a database at all — the shape a torn write or a foreign file leaves.
+  await fs.writeFile(state.globalStorageStatePath, "not a sqlite database");
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "app-chat",
+    [messageRecord(TEST_ROLE.USER, TEST_CONTENT_TYPE.TEXT)],
+    TEST_TIME - 5_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.detail?.link, undefined);
+  assert.equal(observations[0]?.applications, undefined);
+});
+
 test("an app index this build cannot read withholds addresses rather than guessing", async (t) => {
   const state = await temporaryCursorState(t);
   await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");

--- a/packages/providers/src/cursor/local-adapter.test.ts
+++ b/packages/providers/src/cursor/local-adapter.test.ts
@@ -4,7 +4,11 @@ import os from "node:os";
 import path from "node:path";
 import test, { type TestContext } from "node:test";
 import { pathToFileURL } from "node:url";
-import { SESSION_STATUS } from "@sidecar/session";
+import {
+  SESSION_APPLICATION_ID,
+  SESSION_APPLICATION_SCOPE,
+  SESSION_STATUS,
+} from "@sidecar/session";
 import type { MutableWireRecord, ParsedJsonObject } from "@sidecar/wire/testing";
 import { CURSOR_PROVIDER } from "./adapter.js";
 import { CursorLocalSessionAdapter } from "./local-adapter.js";
@@ -209,11 +213,20 @@ test("observes an open turn as work, labelled by its folder and free of transcri
   assert.equal(observations[0]?.recap, undefined);
   // The address is the same /agent route Cursor's own deep-link handler
   // resolves, composed from the observed chat id alone — offered because the
-  // app's own index holds this chat.
+  // app's own index holds this chat, which is also what seats the Cursor app
+  // mark beside the agent identity, the way ChatGPT rides a Codex chat.
   assert.deepEqual(observations[0]?.detail, {
     repository: "luke",
     link: "cursor://anysphere.cursor-deeplink/agent?id=0b1f4b0e-2c5a-4d1e-9a3c-6d5f7e8a9b0c",
   });
+  assert.deepEqual(observations[0]?.applications, [
+    {
+      id: SESSION_APPLICATION_ID.CURSOR,
+      displayName: "Cursor",
+      scope: SESSION_APPLICATION_SCOPE.SESSION,
+      link: "cursor://anysphere.cursor-deeplink/agent?id=0b1f4b0e-2c5a-4d1e-9a3c-6d5f7e8a9b0c",
+    },
+  ]);
   // Nothing says this session runs anywhere but here, which is what leaves it
   // local once the registry normalizes it.
   assert.equal(observations[0]?.location, undefined);
@@ -284,6 +297,9 @@ test("offers the app's address only for the chats the app itself holds", async (
       ["cli-chat", undefined],
     ],
   );
+  // The app association follows the same gate: the app rides only its own.
+  assert.equal(observations[0]?.applications?.[0]?.id, SESSION_APPLICATION_ID.CURSOR);
+  assert.equal(observations[1]?.applications, undefined);
   assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);
 });
 

--- a/packages/providers/src/cursor/local-adapter.ts
+++ b/packages/providers/src/cursor/local-adapter.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   type ProviderSessionObservation,
+  SESSION_APPLICATION_ID,
+  SESSION_APPLICATION_SCOPE,
   SESSION_STATUS,
   type SessionDetail,
   type SessionStatus,
@@ -358,6 +360,21 @@ class CursorAppChatRegistry {
 }
 
 /**
+ * The Cursor app riding a chat it holds as an app association, the way
+ * ChatGPT rides a local Codex chat: the agent stays the row's identity, and
+ * the mark's press opens the same exact chat the row itself opens. A CLI
+ * chat gets none, because the app does not hold it.
+ */
+function cursorApplication(link: string) {
+  return {
+    id: SESSION_APPLICATION_ID.CURSOR,
+    displayName: "Cursor",
+    scope: SESSION_APPLICATION_SCOPE.SESSION,
+    link,
+  } as const;
+}
+
+/**
  * What Cursor knows about a local session beyond its state: the folder, that
  * a turn failed, and — for a chat the app holds — the chat's own address.
  * Cursor records why a turn failed, but that reason is written from the turn
@@ -490,6 +507,7 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
       // anything.
       observedAt: candidate.mtimeMs,
       detail: detailFor(label, status, link),
+      ...(link ? { applications: [cursorApplication(link)] } : undefined),
     };
   }
 }

--- a/packages/providers/src/cursor/local-adapter.ts
+++ b/packages/providers/src/cursor/local-adapter.ts
@@ -278,20 +278,30 @@ function statusFromTurn(
 }
 
 /**
- * What Cursor knows about a local session beyond its state: the folder, and
- * that a turn failed. Cursor records why it failed, but that reason is written
- * from the turn itself, so the fact of the failure is reported and its wording
- * is not — the same fixed line the cloud half reports for a failed run.
- *
- * No address, unlike the cloud half, which reports the agent's own page. Cursor
- * registers `cursor://` for its windows but publishes no route to a chat: its
- * handler answers a prompt, a command, a rule, and a background agent, and none
- * of them is a chat that already exists. The folder the chat was held in is not
- * the chat, so it is not offered as one.
+ * The address of one chat in Cursor's own app — the same `/agent` route
+ * Cursor's deep-link handler resolves for its cloud agents, which also
+ * resolves a local chat by its composer id: the id Cursor names the
+ * transcript directory after, so the address is composed on this machine
+ * from the observed id and handed to the operating system, reaching Cursor's
+ * write paths never. The route opens the exact chat whether Cursor is
+ * running or not; a link Cursor cannot resolve draws Cursor's own
+ * not-found notice rather than acting on anything.
  */
-function detailFor(label: string, status: SessionStatus): SessionDetail {
+export function cursorChatLink(providerSessionId: string): string {
+  return `cursor://anysphere.cursor-deeplink/agent?id=${encodeURIComponent(providerSessionId)}`;
+}
+
+/**
+ * What Cursor knows about a local session beyond its state: the folder, that
+ * a turn failed, and the chat's own address. Cursor records why a turn
+ * failed, but that reason is written from the turn itself, so the fact of the
+ * failure is reported and its wording is not — the same fixed line the cloud
+ * half reports for a failed run.
+ */
+function detailFor(label: string, status: SessionStatus, providerSessionId: string): SessionDetail {
   return {
     repository: label,
+    link: cursorChatLink(providerSessionId),
     ...(status === SESSION_STATUS.ERROR ? { error: CURSOR_TURN_FAILED_MESSAGE } : undefined),
   };
 }
@@ -396,7 +406,7 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
       // written is the only account Cursor keeps of when this session last did
       // anything.
       observedAt: candidate.mtimeMs,
-      detail: detailFor(label, status),
+      detail: detailFor(label, status, candidate.providerSessionId),
     };
   }
 }

--- a/packages/providers/src/cursor/local-adapter.ts
+++ b/packages/providers/src/cursor/local-adapter.ts
@@ -3,8 +3,6 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   type ProviderSessionObservation,
-  SESSION_APPLICATION_ID,
-  SESSION_APPLICATION_SCOPE,
   SESSION_STATUS,
   type SessionDetail,
   type SessionStatus,
@@ -39,6 +37,7 @@ import {
   type SqliteModuleLoader,
 } from "../shared/local-sqlite.js";
 import { CURSOR_PROVIDER } from "./adapter.js";
+import { cursorApplication, cursorChatLink } from "./app-links.js";
 import { readCursorSessionTranscript } from "./transcript.js";
 
 /** A turn Cursor failed records its own reason, which is transcript content. */
@@ -306,22 +305,6 @@ function statusFromTurn(
 }
 
 /**
- * The address of one chat in Cursor's own app — the same `/agent` route
- * Cursor's deep-link handler resolves, composed on this machine from the
- * observed chat id and handed to the operating system, reaching Cursor's
- * write paths never. The route opens the exact chat whether Cursor is
- * running or not — but only a chat the app itself holds: Cursor's `agents`
- * CLI writes its transcripts beside the app's without registering them in
- * any window, and a link Cursor cannot resolve draws its not-found notice.
- * So the address is offered exactly where the app's own index says the chat
- * is one of its own, and a CLI chat keeps no provider address — leaving the
- * row's press to whatever manager hosts its terminal, or honestly to no one.
- */
-export function cursorChatLink(providerSessionId: string): string {
-  return `cursor://anysphere.cursor-deeplink/agent?id=${encodeURIComponent(providerSessionId)}`;
-}
-
-/**
  * Reads which of the observed chats Cursor's app holds, as the presence of
  * each chat's key in the app's own index — a point lookup per chat, never a
  * value, because the values are the conversations themselves. An absent app,
@@ -357,21 +340,6 @@ class CursorAppChatRegistry {
       database.close();
     }
   }
-}
-
-/**
- * The Cursor app riding a chat it holds as an app association, the way
- * ChatGPT rides a local Codex chat: the agent stays the row's identity, and
- * the mark's press opens the same exact chat the row itself opens. A CLI
- * chat gets none, because the app does not hold it.
- */
-function cursorApplication(link: string) {
-  return {
-    id: SESSION_APPLICATION_ID.CURSOR,
-    displayName: "Cursor",
-    scope: SESSION_APPLICATION_SCOPE.SESSION,
-    link,
-  } as const;
 }
 
 /**

--- a/packages/providers/src/cursor/local-adapter.ts
+++ b/packages/providers/src/cursor/local-adapter.ts
@@ -30,6 +30,12 @@ import {
   tailRecords,
   workspaceLabel,
 } from "../shared/local-session-adapter.js";
+import {
+  canIgnoreSqliteError,
+  defaultSqliteModule,
+  openReadOnlyDatabase,
+  type SqliteModuleLoader,
+} from "../shared/local-sqlite.js";
 import { CURSOR_PROVIDER } from "./adapter.js";
 import { readCursorSessionTranscript } from "./transcript.js";
 
@@ -51,6 +57,24 @@ const CURSOR_WORKSPACE_STORAGE_SEGMENTS = [
   "User",
   "workspaceStorage",
 ] as const;
+
+/** Where the app indexes the chats its own windows hold, one record per chat. */
+const CURSOR_GLOBAL_STORAGE_STATE_SEGMENTS = [
+  "Library",
+  "Application Support",
+  "Cursor",
+  "User",
+  "globalStorage",
+  "state.vscdb",
+] as const;
+
+/**
+ * The app's record of one chat it holds, keyed by the chat's id. Only the
+ * key's presence is ever read — the value is the conversation itself, and
+ * observation never opens message content.
+ */
+const CURSOR_APP_CHAT_KEY_PREFIX = "composerData:";
+const CURSOR_APP_CHAT_QUERY = "SELECT 1 FROM cursorDiskKV WHERE key = ?";
 
 const CURSOR_TRANSCRIPT_FILE_EXTENSION = ".jsonl";
 const CURSOR_WORKSPACE_FILE = "workspace.json";
@@ -92,6 +116,8 @@ const CURSOR_LOCAL_ADAPTER_DEFAULTS = {
 export interface CursorLocalAdapterOptions {
   cursorHome?: string;
   workspaceStorageDirectory?: string;
+  globalStorageStatePath?: string;
+  sqlite?: SqliteModuleLoader;
   now?: () => number;
   maximumProjectDirectories?: number;
   activeSessionFreshnessMs?: number;
@@ -279,29 +305,69 @@ function statusFromTurn(
 
 /**
  * The address of one chat in Cursor's own app — the same `/agent` route
- * Cursor's deep-link handler resolves for its cloud agents, which also
- * resolves a local chat by its composer id: the id Cursor names the
- * transcript directory after, so the address is composed on this machine
- * from the observed id and handed to the operating system, reaching Cursor's
+ * Cursor's deep-link handler resolves, composed on this machine from the
+ * observed chat id and handed to the operating system, reaching Cursor's
  * write paths never. The route opens the exact chat whether Cursor is
- * running or not; a link Cursor cannot resolve draws Cursor's own
- * not-found notice rather than acting on anything.
+ * running or not — but only a chat the app itself holds: Cursor's `agents`
+ * CLI writes its transcripts beside the app's without registering them in
+ * any window, and a link Cursor cannot resolve draws its not-found notice.
+ * So the address is offered exactly where the app's own index says the chat
+ * is one of its own, and a CLI chat keeps no provider address — leaving the
+ * row's press to whatever manager hosts its terminal, or honestly to no one.
  */
 export function cursorChatLink(providerSessionId: string): string {
   return `cursor://anysphere.cursor-deeplink/agent?id=${encodeURIComponent(providerSessionId)}`;
 }
 
 /**
- * What Cursor knows about a local session beyond its state: the folder, that
- * a turn failed, and the chat's own address. Cursor records why a turn
- * failed, but that reason is written from the turn itself, so the fact of the
- * failure is reported and its wording is not — the same fixed line the cloud
- * half reports for a failed run.
+ * Reads which of the observed chats Cursor's app holds, as the presence of
+ * each chat's key in the app's own index — a point lookup per chat, never a
+ * value, because the values are the conversations themselves. An absent app,
+ * an unreadable database, or a schema this build does not know holds nothing,
+ * which withholds addresses rather than inventing ones the app cannot resolve.
  */
-function detailFor(label: string, status: SessionStatus, providerSessionId: string): SessionDetail {
+class CursorAppChatRegistry {
+  readonly #statePath: string;
+  readonly #sqlite: SqliteModuleLoader;
+
+  constructor(statePath: string, sqlite: SqliteModuleLoader) {
+    this.#statePath = statePath;
+    this.#sqlite = sqlite;
+  }
+
+  async heldChats(providerSessionIds: readonly string[]): Promise<ReadonlySet<string>> {
+    if (providerSessionIds.length === 0) return new Set();
+    const database = await openReadOnlyDatabase(this.#sqlite, this.#statePath);
+    if (!database) return new Set();
+    try {
+      const statement = database.prepare(CURSOR_APP_CHAT_QUERY);
+      const held = new Set<string>();
+      for (const providerSessionId of providerSessionIds) {
+        if (statement.all(`${CURSOR_APP_CHAT_KEY_PREFIX}${providerSessionId}`).length > 0) {
+          held.add(providerSessionId);
+        }
+      }
+      return held;
+    } catch (error) {
+      if (error instanceof Error && canIgnoreSqliteError(error)) return new Set();
+      throw error;
+    } finally {
+      database.close();
+    }
+  }
+}
+
+/**
+ * What Cursor knows about a local session beyond its state: the folder, that
+ * a turn failed, and — for a chat the app holds — the chat's own address.
+ * Cursor records why a turn failed, but that reason is written from the turn
+ * itself, so the fact of the failure is reported and its wording is not —
+ * the same fixed line the cloud half reports for a failed run.
+ */
+function detailFor(label: string, status: SessionStatus, link: string | undefined): SessionDetail {
   return {
     repository: label,
-    link: cursorChatLink(providerSessionId),
+    ...(link ? { link } : undefined),
     ...(status === SESSION_STATUS.ERROR ? { error: CURSOR_TURN_FAILED_MESSAGE } : undefined),
   };
 }
@@ -312,6 +378,10 @@ function defaultCursorHome(): string {
 
 function defaultWorkspaceStorageDirectory(): string {
   return path.join(os.homedir(), ...CURSOR_WORKSPACE_STORAGE_SEGMENTS);
+}
+
+function defaultGlobalStorageStatePath(): string {
+  return path.join(os.homedir(), ...CURSOR_GLOBAL_STORAGE_STATE_SEGMENTS);
 }
 
 /**
@@ -327,6 +397,8 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
 
   readonly #cursorHome: string;
   readonly #workspaceLabels: CursorWorkspaceLabels;
+  readonly #appChatRegistry: CursorAppChatRegistry;
+  #appChats: ReadonlySet<string> = new Set();
   readonly #maximumProjectDirectories: number;
   readonly #readTailBytes: number;
   readonly #transcriptReadTailBytes: number | undefined;
@@ -337,6 +409,10 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
     this.#cursorHome = options.cursorHome ?? defaultCursorHome();
     this.#workspaceLabels = new CursorWorkspaceLabels(
       options.workspaceStorageDirectory ?? defaultWorkspaceStorageDirectory(),
+    );
+    this.#appChatRegistry = new CursorAppChatRegistry(
+      options.globalStorageStatePath ?? defaultGlobalStorageStatePath(),
+      options.sqlite ?? defaultSqliteModule,
     );
     const resolved = resolveOptions(
       options,
@@ -363,10 +439,14 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
     });
   }
 
-  protected override prepare(candidates: readonly CursorTranscriptCandidate[]): Promise<void> {
-    return this.#workspaceLabels.resolve(
-      candidates.map((candidate) => candidate.projectDirectoryName),
-    );
+  protected override async prepare(
+    candidates: readonly CursorTranscriptCandidate[],
+  ): Promise<void> {
+    const [appChats] = await Promise.all([
+      this.#appChatRegistry.heldChats(candidates.map((candidate) => candidate.providerSessionId)),
+      this.#workspaceLabels.resolve(candidates.map((candidate) => candidate.projectDirectoryName)),
+    ]);
+    this.#appChats = appChats;
   }
 
   override readTranscript(providerSessionId: string): Promise<string | undefined> {
@@ -398,6 +478,9 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
   ): ProviderSessionObservation {
     const label = this.#workspaceLabels.label(candidate.projectDirectoryName);
     const status = statusFromTurn(turn, candidate.mtimeMs, now, activeSessionFreshnessMs);
+    const link = this.#appChats.has(candidate.providerSessionId)
+      ? cursorChatLink(candidate.providerSessionId)
+      : undefined;
     return {
       providerSessionId: candidate.providerSessionId,
       title: label,
@@ -406,7 +489,7 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
       // written is the only account Cursor keeps of when this session last did
       // anything.
       observedAt: candidate.mtimeMs,
-      detail: detailFor(label, status, candidate.providerSessionId),
+      detail: detailFor(label, status, link),
     };
   }
 }

--- a/packages/providers/src/cursor/local-adapter.ts
+++ b/packages/providers/src/cursor/local-adapter.ts
@@ -31,9 +31,9 @@ import {
   workspaceLabel,
 } from "../shared/local-session-adapter.js";
 import {
-  canIgnoreSqliteError,
   defaultSqliteModule,
   openReadOnlyDatabase,
+  type SqliteDatabase,
   type SqliteModuleLoader,
 } from "../shared/local-sqlite.js";
 import { CURSOR_PROVIDER } from "./adapter.js";
@@ -308,8 +308,9 @@ function statusFromTurn(
  * Reads which of the observed chats Cursor's app holds, as the presence of
  * each chat's key in the app's own index — a point lookup per chat, never a
  * value, because the values are the conversations themselves. An absent app,
- * an unreadable database, or a schema this build does not know holds nothing,
- * which withholds addresses rather than inventing ones the app cannot resolve.
+ * an unreadable or mid-write database, or a schema this build does not know
+ * holds nothing, which withholds addresses rather than inventing ones the
+ * app cannot resolve — and never fails the pass the rows come from.
  */
 class CursorAppChatRegistry {
   readonly #statePath: string;
@@ -320,9 +321,17 @@ class CursorAppChatRegistry {
     this.#sqlite = sqlite;
   }
 
+  // The index read is auxiliary to observing at all: a database Cursor holds
+  // mid-write, or one this build cannot parse, answers nothing — never a
+  // failed pass, because losing the app addresses must not cost the rows.
   async heldChats(providerSessionIds: readonly string[]): Promise<ReadonlySet<string>> {
     if (providerSessionIds.length === 0) return new Set();
-    const database = await openReadOnlyDatabase(this.#sqlite, this.#statePath);
+    let database: SqliteDatabase | undefined;
+    try {
+      database = await openReadOnlyDatabase(this.#sqlite, this.#statePath);
+    } catch {
+      return new Set();
+    }
     if (!database) return new Set();
     try {
       const statement = database.prepare(CURSOR_APP_CHAT_QUERY);
@@ -333,9 +342,8 @@ class CursorAppChatRegistry {
         }
       }
       return held;
-    } catch (error) {
-      if (error instanceof Error && canIgnoreSqliteError(error)) return new Set();
-      throw error;
+    } catch {
+      return new Set();
     } finally {
       database.close();
     }

--- a/packages/session/src/session-filter.ts
+++ b/packages/session/src/session-filter.ts
@@ -61,15 +61,16 @@ export const SESSION_FILTER_AXIS = {
 export type SessionFilterAxis = (typeof SESSION_FILTER_AXIS)[keyof typeof SESSION_FILTER_AXIS];
 
 /**
- * Conductor, Cursor, and Superset land on the app axis even where a namesake
- * provider exists, because "associated with that app" is the question their
- * chips answer — a native cloud Conductor chat and a local Codex chat
- * annotated by Conductor answer the same chip, a Cursor chat answers Cursor's
- * whichever way it met the app, and an agent chip beside it stays a further
- * narrowing rather than a widening. The parameter is wider than
- * {@link SessionFilter} because a spoken ask may name an identity only the
- * roster knows — a hosted agent's own id — and it lands on the agent axis
- * like the provider ids do.
+ * Conductor and Superset land on the app axis even where a namesake provider
+ * exists, because "associated with that app" is the question their chips
+ * answer — a native cloud Conductor chat and a local Codex chat annotated by
+ * Conductor answer the same chip, and an agent chip beside it stays a further
+ * narrowing rather than a widening. Cursor deliberately does not share one
+ * id: its app chip counts the chats the Cursor app can open and its agent
+ * chip every Cursor chat, so each axis holds its own Cursor value. The
+ * parameter is wider than {@link SessionFilter} because a spoken ask may
+ * name an identity only the roster knows — a hosted agent's own id — and it
+ * lands on the agent axis like the provider ids do.
  */
 export function sessionFilterAxis(filter: string): SessionFilterAxis {
   if (filter === SESSION_FILTER.LOCAL || filter === SESSION_FILTER.CLOUD) {

--- a/packages/session/src/session-filter.ts
+++ b/packages/session/src/session-filter.ts
@@ -61,10 +61,11 @@ export const SESSION_FILTER_AXIS = {
 export type SessionFilterAxis = (typeof SESSION_FILTER_AXIS)[keyof typeof SESSION_FILTER_AXIS];
 
 /**
- * Conductor and Superset land on the app axis even where a namesake provider
- * exists, because "associated with that app" is the question their chips
- * answer — a native cloud Conductor chat and a local Codex chat annotated by
- * Conductor answer the same chip, and an agent chip beside it stays a further
+ * Conductor, Cursor, and Superset land on the app axis even where a namesake
+ * provider exists, because "associated with that app" is the question their
+ * chips answer — a native cloud Conductor chat and a local Codex chat
+ * annotated by Conductor answer the same chip, a Cursor chat answers Cursor's
+ * whichever way it met the app, and an agent chip beside it stays a further
  * narrowing rather than a widening. The parameter is wider than
  * {@link SessionFilter} because a spoken ask may name an identity only the
  * roster knows — a hosted agent's own id — and it lands on the agent axis

--- a/packages/session/src/session.ts
+++ b/packages/session/src/session.ts
@@ -200,6 +200,10 @@ export const SESSION_APPLICATION_ID = {
   CHATGPT: "chatgpt",
   CMUX: "cmux",
   CONDUCTOR: "conductor",
+  // Cursor is an agent whose own app also holds chats, so like Conductor it
+  // deliberately occupies both vocabularies under one id: the mark and the
+  // filter are the same identity whichever way a chat met Cursor.
+  CURSOR: "cursor",
   ORCA: "orca",
   SUPERSET: "superset",
 } as const;

--- a/packages/session/src/session.ts
+++ b/packages/session/src/session.ts
@@ -200,10 +200,11 @@ export const SESSION_APPLICATION_ID = {
   CHATGPT: "chatgpt",
   CMUX: "cmux",
   CONDUCTOR: "conductor",
-  // Cursor is an agent whose own app also holds chats, so like Conductor it
-  // deliberately occupies both vocabularies under one id: the mark and the
-  // filter are the same identity whichever way a chat met Cursor.
-  CURSOR: "cursor",
+  // Cursor the app is deliberately not Cursor the agent: the app chip counts
+  // the chats the Cursor app can open — app-held local chats and cloud
+  // agents — where the agent chip counts every Cursor chat, CLI ones
+  // included, so the two ride separate axes under separate ids.
+  CURSOR: "cursor-app",
   ORCA: "orca",
   SUPERSET: "superset",
 } as const;

--- a/packages/session/src/session.ts
+++ b/packages/session/src/session.ts
@@ -257,6 +257,7 @@ export const SESSION_LINK_SCHEME = {
   CMUX: "cmux:",
   CODEX: "codex:",
   CONDUCTOR: "conductor:",
+  CURSOR: "cursor:",
   SUPERSET: "superset:",
 } as const;
 

--- a/packages/superset/src/workspaces.test.ts
+++ b/packages/superset/src/workspaces.test.ts
@@ -141,6 +141,38 @@ test("reads live host databases and enriches an exact provider session", async (
   );
 });
 
+test("binds Cursor's agents CLI under Superset's own name for it", async (t) => {
+  const home = await temporarySupersetHome(t);
+  const database = await writeHostDatabase(home, "host-local");
+  createSchema(database);
+  // Superset records the app's agents as `cursor` and the `agents` CLI as
+  // `cursor-agent`; both are Cursor sessions to Luke.
+  database.exec(`
+    INSERT INTO workspaces VALUES (
+      'workspace-1', NULL, NULL, 'square-geometry', 'main', 200
+    );
+    INSERT INTO terminal_agent_bindings VALUES (
+      'terminal-1', 'workspace-1', 'cursor-agent', 'cli-session', 'Start'
+    );
+  `);
+  database.close();
+
+  const snapshot = await new SupersetWorkspaceReader({ homeDirectory: home }).read();
+  const context = snapshot.context(PROVIDER_ID.CURSOR, "cli-session");
+  assert.equal(context?.workspaceId, "workspace-1");
+  assert.equal(
+    snapshot.enrich(PROVIDER_ID.CURSOR, [
+      {
+        providerSessionId: "cli-session",
+        title: "square-geometry",
+        status: SESSION_STATUS.WORKING,
+        observedAt: 100,
+      },
+    ])[0]?.detail?.link,
+    "superset://v2-workspace/workspace-1?terminalId=terminal-1",
+  );
+});
+
 test("keeps the newest duplicate binding across host databases", async (t) => {
   const home = await temporarySupersetHome(t);
   for (const [organizationId, updatedAt] of [

--- a/packages/superset/src/workspaces.test.ts
+++ b/packages/superset/src/workspaces.test.ts
@@ -148,7 +148,7 @@ test("binds Cursor's agents CLI under Superset's own name for it", async (t) => 
   // Superset records the app's agents as `cursor` and the `agents` CLI as
   // `cursor-agent`; both are Cursor sessions to Luke.
   database.exec(`
-    INSERT INTO workspaces VALUES (
+    INSERT INTO workspaces (id, project_id, pull_request_id, name, branch, updated_at) VALUES (
       'workspace-1', NULL, NULL, 'square-geometry', 'main', 200
     );
     INSERT INTO terminal_agent_bindings VALUES (

--- a/packages/superset/src/workspaces.ts
+++ b/packages/superset/src/workspaces.ts
@@ -25,6 +25,9 @@ const SUPERSET_AGENT_PROVIDER = {
   codex: PROVIDER_ID.CODEX,
   copilot: PROVIDER_ID.COPILOT,
   cursor: PROVIDER_ID.CURSOR,
+  // Superset binds Cursor's `agents` CLI under its own name, beside the id
+  // it uses for the app's agents; both are Cursor sessions to Luke.
+  "cursor-agent": PROVIDER_ID.CURSOR,
   gemini: PROVIDER_ID.GEMINI_CLI,
   opencode: PROVIDER_ID.OPENCODE,
 } as const satisfies Readonly<Record<string, string>>;


### PR DESCRIPTION
## What

Local Cursor agents open where they actually live, Cursor cloud agents open
in the Cursor app, and Cursor holds both vocabularies — app and agent — as
separate identities with separate filter chips.

### The rows

- **Started in the Cursor app** — the row's own press is
  `cursor://anysphere.cursor-deeplink/agent?id=<chat>` and the row wears the
  Cursor app mark opening the same chat. Verified live on Cursor 3.16.29,
  warm and cold-start.
- **Cloud agent** — the row's own press keeps the `cursor.com` agent page
  the API reports; the Cursor app mark carries
  `cursor://anysphere.cursor-deeplink/background-agent?bcId=<id>` — the same
  address Cursor's own dashboard fires — verified live against a real cloud
  agent.
- **Started by the `agents` CLI inside cmux, Superset, or Conductor** — no
  provider address or app mark, so the hosting manager's own address stands
  in. Superset records the CLI as `cursor-agent`, which Luke's map now knows
  is a Cursor session (previously undetected).
- **Started by the `agents` CLI in an unmanaged terminal** — no address,
  honestly.

### The filters

`SESSION_APPLICATION_ID.CURSOR` is `cursor-app`, deliberately not the
provider's `cursor`: the App-axis chip counts the chats the Cursor app can
open (app-held local chats and cloud agents), the Agent-axis chip counts
every Cursor chat (CLI ones included), and pressing both narrows across axes
like any pair. Conductor keeps its deliberate one-id union; Cursor's two
questions get two values.

## How app-held is told

Cursor's app indexes the chats its windows hold (`composerData:<chat>` in
its global storage); the `agents` CLI registers nothing there. Luke reads
**key presence alone — never a value, which is the conversation itself** (a
point lookup per observed chat, read-only). Absent app, unreadable index, or
unknown schema holds nothing, which withholds rather than invents. Cloud
agents need no gate: the app opens any of them by id, as its dashboard does.

## Validation

- Live: the app chat, Warp/cmux/Superset CLI chats, and a real cloud agent
  (`bc-a03deba2…`) all behave per spec on this machine.
- `./scripts/check.sh` exit 0; `./scripts/verify.sh` exit 0 with visual
  evidence inspected — the fixture cloud agent now wears the Cursor app mark
  in the evidence screenshot, and panel, trays, and chips render correctly.
  No physical-notch check was performed.
- Tests: Cursor adapters 50/50 (cloud rows assert mark + in-app address),
  session-model 49/49 (App-axis chip beside the restored Agent-axis chip),
  Superset 7/7.
- `docs/PROVIDERS.md`, `PRIVACY.md`, and Luke's guide move in the same
  change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32433227620/artifacts/9429851962) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32433227620)

- Commit: `f09ff9d215b1d8e73ce1fece2bc9269f3426a2e6`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
