### PR TITLE
feat(voice): let a spoken ask search the session list

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -136,6 +136,7 @@ import {
   sameSessionFilters,
   sessionFiltersFromSpoken,
   sessionTally,
+  spokenSearchOutcome,
   tallySummary,
 } from "./session-model";
 import { parsePixels } from "./session-motion";
@@ -596,6 +597,10 @@ export function App(): React.JSX.Element {
       // when one empties, and a snapshot taken at the ask would undo that.
       const view = hold.view;
       if (view !== undefined) setSessionView((current) => ({ ...current, ...view }));
+      // A query landing opens the field it fills, on the rule the field's own
+      // closing keeps: a narrowing in force behind no visible control would
+      // hide sessions with nothing on screen admitting it.
+      if (view?.query) setSearchOpen(true);
     },
     [applySettings],
   );
@@ -1946,11 +1951,23 @@ export function App(): React.JSX.Element {
           // a list that has already re-sorted itself by the time he gets there
           // makes the flight a report rather than the act.
           const view =
-            filters || action.sort
+            filters || action.sort || action.query !== undefined
               ? {
                   ...(filters ? { filters } : undefined),
                   ...(action.sort ? { sort: action.sort } : undefined),
+                  ...(action.query !== undefined ? { query: action.query } : undefined),
                 }
+              : undefined;
+          // What the query will leave, read now against the roster and the
+          // view the hold is about to land: the reply voices this outcome, and
+          // it must not claim rows the list will not draw. Only the drawing
+          // waits for the flight, never the report.
+          const searched =
+            action.query !== undefined && bootstrap !== undefined
+              ? spokenSearchOutcome(displaySessions(bootstrap, sessions, noticeAsks), {
+                  ...sessionView,
+                  ...view,
+                })
               : undefined;
           await changeMode(true);
           // The tab bar and the options button are drawn outside the settings
@@ -1966,14 +1983,22 @@ export function App(): React.JSX.Element {
             borrowsPanel: false,
             hold: view === undefined ? NOTHING_HELD : { view },
           });
+          // One note line, because an unmappable narrowing and an emptied
+          // search can arrive in the same ask and each has its own sentence.
+          const notes = [
+            action.filters && spoken === undefined
+              ? "That narrowing has no filter of its own here, so every session is shown."
+              : undefined,
+            searched?.note,
+          ].filter((line): line is string => line !== undefined);
           return {
             status: "shown",
             tab: action.tab,
             ...(spoken !== undefined ? { filters: action.filters } : undefined),
-            ...(action.filters && spoken === undefined
-              ? { note: "That narrowing has no filter of its own here, so every session is shown." }
-              : undefined),
             ...(action.sort ? { sort: action.sort } : undefined),
+            ...(action.query !== undefined ? { query: action.query } : undefined),
+            ...(searched !== undefined ? { matches: searched.matches } : undefined),
+            ...(notes.length > 0 ? { note: notes.join(" ") } : undefined),
           };
         },
       }),
@@ -1986,6 +2011,9 @@ export function App(): React.JSX.Element {
       drawErrandHold,
       feedbackEntry.latest,
       presentationOf,
+      sessions,
+      noticeAsks,
+      sessionView,
     ],
   );
 

--- a/apps/desktop/src/renderer/luke-errand.test.ts
+++ b/apps/desktop/src/renderer/luke-errand.test.ts
@@ -140,6 +140,25 @@ test("a narrowing or a re-ordering is signed on the control that carries it", ()
   );
 });
 
+test("a search is signed on the magnifier, ahead of whatever else the ask changed", () => {
+  assert.deepEqual(errandTargets({ kind: "panel", tab: APP_PANEL_TAB.SESSIONS, query: "parser" }), [
+    ERRAND_TARGET.LIST_SEARCH,
+    ERRAND_TARGET.SESSIONS_TAB,
+  ]);
+  // One ask can search and narrow at once; one flight signs it, on the control
+  // whose change is loudest, with the others standing behind in case the
+  // magnifier is not drawn.
+  assert.deepEqual(
+    errandTargets({
+      kind: "panel",
+      tab: APP_PANEL_TAB.SESSIONS,
+      filters: ["cloud"],
+      query: "parser",
+    }),
+    [ERRAND_TARGET.LIST_SEARCH, ERRAND_TARGET.LIST_OPTIONS, ERRAND_TARGET.SESSIONS_TAB],
+  );
+});
+
 test("a refused act is signed nowhere", () => {
   assert.deepEqual(errandTargets({ kind: "refused", reason: "No such tool exists." }), []);
 });

--- a/apps/desktop/src/renderer/luke-errand.tsx
+++ b/apps/desktop/src/renderer/luke-errand.tsx
@@ -81,6 +81,7 @@ export const ERRAND_TARGET = {
   SESSIONS_TAB: "tab-sessions",
   SETTINGS_TAB: "tab-settings",
   LIST_OPTIONS: "list-options",
+  LIST_SEARCH: "list-search",
 } as const;
 
 export type ErrandTarget = AppSettingId | (typeof ERRAND_TARGET)[keyof typeof ERRAND_TARGET];
@@ -131,10 +132,15 @@ export function errandTargets(action: AppToolAction): readonly ErrandTarget[] {
   const tab = tabErrandTarget(action.tab);
   // A narrowing or a re-ordering is the news; the tab is only where it
   // happened, and it may not have changed at all.
-  if (action.filters !== undefined || action.sort !== undefined) {
-    return [ERRAND_TARGET.LIST_OPTIONS, tab];
-  }
-  return [tab];
+  const narrowed =
+    action.filters !== undefined || action.sort !== undefined
+      ? [ERRAND_TARGET.LIST_OPTIONS, tab]
+      : [tab];
+  // A search is signed on the magnifier that opens its field, ahead of
+  // whatever else the same ask changed: the field appearing is the loudest
+  // thing the act does, so the magnifier is where the tap reads as its cause.
+  if (action.query !== undefined) return [ERRAND_TARGET.LIST_SEARCH, ...narrowed];
+  return narrowed;
 }
 
 /**

--- a/apps/desktop/src/renderer/luke-guide.test.ts
+++ b/apps/desktop/src/renderer/luke-guide.test.ts
@@ -748,23 +748,23 @@ test("the panel fact says the tabs answer an ask as well as a press", () => {
   assert.ok(guide.facts.some((candidate) => candidate.label === "The Settings tab"));
 });
 
-test("the guide describes the search, and says it is by hand alone", () => {
+test("the guide describes the search, its three ways in, and their shared bound", () => {
   const fact = buildLukeGuide(guideInput()).facts.find(
     (candidate) => candidate.label === "Searching sessions",
   );
 
   assert.ok(fact);
   // A capability the guide does not describe is one Luke will deny having —
-  // and a search Luke claimed he could run himself would be a capability the
-  // spoken tools deliberately do not have.
-  assert.match(fact.detail, /searchable by hand alone/);
+  // and the spoken way in must be described with its bound, because the
+  // refusal Luke voices beside a one-session list is itself the guidance.
   assert.match(fact.detail, /magnifier/);
   assert.match(fact.detail, /Command-F/);
+  assert.match(fact.detail, /asking Luke to search out loud/);
+  assert.match(fact.detail, /reaches no further than the magnifier/);
   assert.match(
     fact.detail,
-    /title, status line, branch, repository, workspace, agent, associated app, or model/,
+    /title, status word or status line, branch, repository, workspace, agent, associated app, or model/,
   );
-  assert.match(fact.detail, /no spoken ask can search/);
   assert.match(fact.detail, /no search survives the panel closing/);
 });
 

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -348,12 +348,14 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
     {
       label: "Searching sessions",
       detail:
-        "The list is searchable by hand alone: the magnifier beside the options button, or " +
-        "Command-F while the panel has the keyboard. It keeps rows saying every typed word in " +
-        "their title, status line, branch, repository, workspace, agent, associated app, or model, and counts " +
+        "The list is searchable three ways: the magnifier beside the options button, Command-F " +
+        "while the panel has the keyboard, or asking Luke to search out loud — a spoken search " +
+        "fills the same field and reaches no further than the magnifier, which is only offered " +
+        "beside a list of more than one session. It keeps rows saying every typed word in " +
+        "their title, status word or status line, branch, repository, workspace, agent, associated app, or model, and counts " +
         "what it left. A search matching nothing offers the matches a filter is hiding rather " +
         "than pretending there are none. Escape clears the query and then closes the field; " +
-        "no spoken ask can search, and no search survives the panel closing. Command-F answers " +
+        "no search survives the panel closing. Command-F answers " +
         "for whichever tab is showing: the sessions list here, the settings search on Settings.",
     },
     {

--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -4503,6 +4503,56 @@ test("a spoken panel ask is validated against the roster and carried", async () 
   assert.equal(carried.length, combinedBefore);
 });
 
+test("a spoken search is bounded by the list the magnifier is offered beside", async () => {
+  const carried: unknown[] = [];
+  const context = harness({
+    carryAppAction: async (action) => {
+      carried.push(action);
+      return { status: "shown" };
+    },
+  });
+  await context.session.connect();
+  context.session.updateGuide(CAPTIONS_GUIDE);
+  context.session.updateSessions([observedSession("session-a")]);
+  await armDeveloperTurn(context);
+
+  // One session offers no magnifier, so the ask is refused rather than
+  // carried into a field the panel will not draw.
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: {
+      output: [
+        {
+          type: "function_call",
+          name: "show_panel",
+          call_id: "call-search-1",
+          arguments: '{"query":"parser"}',
+        },
+      ],
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(carried, []);
+
+  context.session.updateSessions([observedSession("session-a"), observedSession("session-b")]);
+  await armDeveloperTurn(context);
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: {
+      output: [
+        {
+          type: "function_call",
+          name: "show_panel",
+          call_id: "call-search-2",
+          arguments: '{"query":" parser "}',
+        },
+      ],
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(carried, [{ kind: "panel", tab: "sessions", query: "parser" }]);
+});
+
 test("a spoken composer open is validated against the fixed kinds and carried, never sent", async () => {
   const carried: unknown[] = [];
   const context = harness({

--- a/apps/desktop/src/renderer/session-model.test.ts
+++ b/apps/desktop/src/renderer/session-model.test.ts
@@ -30,6 +30,7 @@ import {
   sessionListRuns,
   sessionRunKeys,
   sessionTally,
+  spokenSearchOutcome,
   tallyCaption,
   tallySummary,
   tallyValue,
@@ -1198,6 +1199,79 @@ test("a query is read against everything the row can say", () => {
       `query: ${query}`,
     );
   }
+});
+
+test("a query finds a session by its status word, even under a busy detail line", () => {
+  const rows = displaySessions(bootstrap(false), [
+    normalizeSession(CLAUDE_PROVIDER, {
+      providerSessionId: "busy",
+      title: "Rework the parser",
+      status: SESSION_STATUS.WORKING,
+      observedAt: 1_000,
+      detail: { activity: "Running the tests" },
+    }),
+    normalizeSession(CODEX_PROVIDER, {
+      providerSessionId: "stuck",
+      title: "Fix the login flow",
+      status: SESSION_STATUS.WAITING,
+      observedAt: 2_000,
+      detail: { activity: "Holding for an approval" },
+    }),
+  ]);
+
+  // Both detail lines are spent on the provider's own words, so the status
+  // word appears nowhere the row draws — the query still answers for the
+  // state, and answers for it alone: "working" leaves the waiting row out.
+  const working = arrangeSessions(rows, { ...DEFAULT_SESSION_VIEW, query: "working" });
+  assert.deepEqual(
+    working.sessions.map((session) => session.id),
+    ["busy"],
+  );
+
+  const waiting = arrangeSessions(rows, { ...DEFAULT_SESSION_VIEW, query: "needs you" });
+  assert.deepEqual(
+    waiting.sessions.map((session) => session.id),
+    ["stuck"],
+  );
+});
+
+test("a spoken search is told exactly what the list will show", () => {
+  const rows = displaySessions(bootstrap(false), [
+    normalizeSession(CLAUDE_PROVIDER, {
+      providerSessionId: "parser",
+      title: "Rework the parser",
+      status: SESSION_STATUS.WORKING,
+      observedAt: 1_000,
+    }),
+    normalizeSession(CODEX_PROVIDER, {
+      providerSessionId: "login",
+      title: "Fix the login flow",
+      status: SESSION_STATUS.WORKING,
+      observedAt: 2_000,
+    }),
+  ]);
+
+  assert.deepEqual(spokenSearchOutcome(rows, { ...DEFAULT_SESSION_VIEW, query: "parser" }), {
+    matches: 1,
+  });
+  // An emptied search answers with its honest zero rather than a refusal —
+  // and when the filter in force is what hides the matches, the note says so
+  // the way the list's own empty state does.
+  assert.deepEqual(spokenSearchOutcome(rows, { ...DEFAULT_SESSION_VIEW, query: "zanzibar" }), {
+    matches: 0,
+    note: "No sessions match those words.",
+  });
+  assert.deepEqual(
+    spokenSearchOutcome(rows, {
+      ...DEFAULT_SESSION_VIEW,
+      filters: [PROVIDER_ID.CODEX],
+      query: "parser",
+    }),
+    {
+      matches: 0,
+      note: "No shown sessions match, but the filter in force hides 1 session that would.",
+    },
+  );
 });
 
 test("a blank query is no search at all", () => {

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -138,6 +138,38 @@ export function sessionFiltersFromSpoken(
   return selection;
 }
 
+/** What a spoken search is told it did: the count, and the honest word for a zero. */
+export interface SpokenSearchOutcome {
+  matches: number;
+  note?: string;
+}
+
+/**
+ * What a spoken search is told it did, read against the same arrangement the
+ * panel is about to draw. A spoken filter that would show nothing is refused
+ * before it is carried, but an emptied search is the list's honest answer
+ * rather than a stale choice — so the outcome carries the count instead of a
+ * refusal, and names the matches a filter is hiding the way the list's own
+ * empty state does, so the sentence Luke says can never claim rows the list
+ * will not draw.
+ */
+export function spokenSearchOutcome(
+  sessions: readonly DisplaySession[],
+  view: SessionView,
+): SpokenSearchOutcome {
+  const list = arrangeSessions(sessions, view);
+  const matches = list.sessions.length;
+  if (matches > 0) return { matches };
+  const beyond = list.search?.beyondFilter ?? 0;
+  if (beyond === 0) return { matches, note: "No sessions match those words." };
+  return {
+    matches,
+    note: `No shown sessions match, but the filter in force hides ${beyond} ${
+      beyond === 1 ? "session" : "sessions"
+    } that would.`,
+  };
+}
+
 /**
  * The two questions a list of agent sessions is read to answer. The set is
  * core's, because a spoken ask names an order in the same words this control
@@ -446,12 +478,15 @@ export function searchTokens(query: string): readonly string[] {
  * which a lone chat cedes its title line to its workspace for. Those still
  * find the session — each is a name the provider's own surface knows it by —
  * so a row can match without a mark to show for it; the marks only ever land
- * on the lines the row draws.
+ * on the lines the row draws. The status word is its own line because the
+ * detail sentence only falls back to it: a row busy saying what it is doing
+ * must still answer for the state it is in.
  */
 function searchableLines(session: DisplaySession): readonly string[] {
   const lines = [
     session.title,
     session.detail,
+    session.label,
     session.branch,
     session.repository,
     session.workspace?.name,

--- a/apps/desktop/src/renderer/session-search.tsx
+++ b/apps/desktop/src/renderer/session-search.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react";
 import { FOCUS_FRAME_LIMIT } from "./credential-entry";
+import { ERRAND_TARGET, errandTargetProps } from "./luke-errand";
 import { type ArrangedSessions, matchRanges, type SessionView } from "./session-model";
 import { CloseIcon, SearchIcon } from "./settings-icons";
 
@@ -57,6 +58,9 @@ export function SessionSearchButton({
     <button
       type="button"
       className="search-button"
+      // The magnifier is what opens the field, so it is where a search Luke
+      // ran himself is signed.
+      {...errandTargetProps(ERRAND_TARGET.LIST_SEARCH)}
       data-active={String(open)}
       aria-expanded={open}
       aria-label="Search sessions"

--- a/packages/realtime/src/guide.test.ts
+++ b/packages/realtime/src/guide.test.ts
@@ -370,6 +370,49 @@ test("a spoken panel ask can combine filters, on the axes the chips combine on",
   });
 });
 
+test("a spoken panel ask can search, only where the list offers a search at all", () => {
+  const pair = [
+    observedConductorSession(),
+    normalizeSession(
+      { id: "codex", displayName: "Codex" },
+      {
+        providerSessionId: "local-1",
+        title: "Rework the parser",
+        status: SESSION_STATUS.WORKING,
+        observedAt: 1_800_000_000_000,
+      },
+    ),
+  ];
+  const show = (argumentsJson: string, sessions = pair) =>
+    appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, sessions);
+
+  assert.deepEqual(show('{"query":" parser build "}'), {
+    kind: "panel",
+    tab: APP_PANEL_TAB.SESSIONS,
+    query: "parser build",
+  });
+  // A search rides the same ask as a narrowing and an ordering, and the words
+  // are not judged here: a query matching nothing is the list's own honest
+  // answer, where a filter showing nothing would be a stale choice.
+  assert.deepEqual(show('{"filters":["conductor"],"sort":"recency","query":"zanzibar"}'), {
+    kind: "panel",
+    tab: APP_PANEL_TAB.SESSIONS,
+    filters: ["conductor"],
+    sort: SESSION_LIST_SORT.RECENCY,
+    query: "zanzibar",
+  });
+  // A blank query is no search, the way a blank draft is no draft.
+  assert.deepEqual(show('{"query":"   "}'), { kind: "panel", tab: APP_PANEL_TAB.SESSIONS });
+
+  // The magnifier is only offered beside a list with more than one session,
+  // and a spoken search reaches no further than the hand's own control.
+  assert.deepEqual(show('{"query":"parser"}', [observedConductorSession()]), {
+    kind: "refused",
+    reason: "The list offers a search only when more than one session is observed.",
+  });
+  assert.equal(show('{"query":"parser"}', []).kind, "refused");
+});
+
 test("a spoken panel ask can reorder the list in the panel's own two words", () => {
   const sessions = [observedConductorSession()];
   const show = (argumentsJson: string) =>

--- a/packages/realtime/src/realtime-tools.ts
+++ b/packages/realtime/src/realtime-tools.ts
@@ -221,6 +221,8 @@ export type AppToolAction =
       /** The validated narrowing, combined like the chips: OR within an axis, AND across. */
       filters?: readonly string[];
       sort?: SessionListSort;
+      /** Words to search the list for, exactly as the developer asked them. */
+      query?: string;
     }
   | { kind: typeof APP_TOOL_KIND.FEEDBACK; composer: FeedbackComposerKind; draft?: string }
   | { kind: "refused"; reason: string };
@@ -948,11 +950,26 @@ function validateShowPanel(parsed: WireRecord, context: AppToolContext): AppTool
   if (sort !== undefined && !isSessionListSort(sort)) {
     return { kind: "refused", reason: "The list orders by urgency or by recency." };
   }
+  // A search is bounded by the hand's own control: the magnifier is only
+  // offered beside a list with more than one session, and a spoken ask
+  // reaches no further than it. The words themselves are not validated
+  // against the rows the way a filter is — a query is read against the lines
+  // as the surface words them, which only the renderer knows, and a search
+  // matching nothing is the list's own honest answer rather than a stale
+  // narrowing to refuse.
+  const query = textArgument(parsed, "query");
+  if (query !== undefined && context.sessions.length < 2) {
+    return {
+      kind: "refused",
+      reason: "The list offers a search only when more than one session is observed.",
+    };
+  }
   const asked = spokenFilterValues(parsed.filters);
   if ("reason" in asked) return { kind: "refused", reason: asked.reason };
   if (asked.values === undefined) {
     const action: AppToolAction = { kind: APP_TOOL_KIND.PANEL, tab };
     if (sort !== undefined) action.sort = sort;
+    if (query !== undefined) action.query = query;
     return action;
   }
   const outcome = panelFiltersAction(asked.values, context.sessions);
@@ -963,6 +980,7 @@ function validateShowPanel(parsed: WireRecord, context: AppToolContext): AppTool
     filters: outcome.filters,
   };
   if (sort !== undefined) action.sort = sort;
+  if (query !== undefined) action.query = query;
   return action;
 }
 
@@ -1303,6 +1321,11 @@ export const REALTIME_TOOLS = {
             description:
               `Reorders the session list: ${SESSION_LIST_SORT.URGENCY} puts what needs the ` +
               `developer first, ${SESSION_LIST_SORT.RECENCY} puts what moved last first.`,
+          },
+          query: {
+            type: "string",
+            description:
+              "Optional words to search the session list for; only rows saying every word stay.",
           },
         },
         required: [],


### PR DESCRIPTION
## Summary

- Luke can now search the session list when asked — out loud or in his composer — the way he can already filter and sort it: a new optional `query` argument on the existing `show_panel` tool, so no new tool or write path is added and the ask still runs only in a developer-opened turn.
- Validation follows the spoken filter's shape at one remove: a spoken search reaches no further than the hand's own control, so it is refused beside a list of zero or one session (where the magnifier is not offered), and a blank query is no search at all. The words themselves are not judged in the tool layer — an emptied search is the list's honest answer, not a stale narrowing.
- The carried query rides the errand hold: Luke flies to the magnifier, taps it, and the field opens filled — the field opening with the query keeps the rule that a narrowing in force is never hidden behind no visible control.
- The tool result reports the match count computed against the exact view the panel will draw, with the empty state's own note ("No sessions match those words." / "No shown sessions match, but the filter in force hides N that would."), so the sentence Luke voices can never claim rows the list will not show.
- The row's status word (Working / Needs you / Complete / Idle) joins the lines a query is read against, since the detail sentence only falls back to it.
- The guide now describes the three ways into search — magnifier, ⌘F, and asking Luke — replacing "by hand alone"; the settings search stays by hand alone and keeps saying so.

## Evidence

- Platform-independent checks: `./scripts/check.sh` exit 0 (repository checks, typecheck, all package and app tests, builds)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — implemented in a Linux cloud workspace; the errand flight to the magnifier deserves one look on a real Mac

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32428059535/artifacts/9428279438) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32428059535)

- Commit: `c4d1b6e78a99834356b5bc84d037f4bf90d200cc`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: none known; new tests cover the tool grammar (accepted, trimmed, combined with filter+sort, refused beside ≤1 session), the end-to-end carry through the realtime session, the spoken outcome's counts and notes, and the errand's landing place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/6999ca18-daea-4988-9b5b-d50b57372898)
