### PR TITLE
feat(superset): observe chatless workspaces as standing, deletable rows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,14 @@ Trust constraints:
   the control's own press or a developer-opened turn, and advertised only on
   a row positively seen settled — never one still working or unreadable,
   because the delete is unrecoverable and takes every sibling chat's terminal
-  with it. This does not authorize any other Superset CLI command, deletion
+  with it. A managed row here is also the standing row an idle workspace
+  earns for itself: a worktree with no agent terminal at all, read from the
+  same observed host state, is settled by construction — there is no agent
+  whose turn could be cut, and a workspace whose only terminal Luke cannot
+  map draws no row rather than a gamble — while the main checkout and
+  anything Superset already archived stand behind no row and can never be
+  offered the delete. This does not authorize any other Superset CLI command,
+  deletion
   of anything else, tasks, automations, account changes, or settings changes.
 - Product behavior must not require provider MCP, plugins, hooks, wrappers,
   credentials, or live sessions. A provider whose sessions exist only in a cloud

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -252,15 +252,20 @@ is said back to you under the field you typed in.
   session is labelled by the folder it runs in, which Luke reads from Cursor's
   own record of that folder, not from the chat's generated name.
 - For Superset, Luke discovers each `host/<organization-id>/host.db`, opens it
-  in read-only defensive mode, and reads two fixed queries' worth of rows: from
-  the terminal-to-agent bindings, each workspace's name, identifier, branch,
-  last-updated timestamp, pull-request link, project name, terminal identifier,
-  and the agent's own session identifier; and from the host's agent
-  configuration, the identifiers of the agent presets it has. That identifier
+  in read-only defensive mode, and reads three fixed queries' worth of rows:
+  from the terminal-to-agent bindings, each workspace's name, identifier,
+  branch, last-updated timestamp, pull-request link, project name, terminal
+  identifier, and the agent's own session identifier; from the host's agent
+  configuration, the identifiers of the agent presets it has; and from the
+  workspaces themselves, the same workspace fields for each unarchived
+  worktree with no agent terminal at all, which the panel shows as its own
+  idle row — the main checkout and anything Superset archived are never read
+  out. A binding's identifier
   is joined exactly to a session Luke already observed; Luke does not infer
   membership from a filesystem path. Missing files and unknown schemas mean no
   Superset context, never an on-screen failure. The stale legacy `local.db` is
-  not read. A managed session's row carries its workspace's `superset://`
+  not read. A managed session's or idle workspace's row carries its
+  workspace's `superset://`
   address, composed on this machine from the observed workspace identifier;
   opening it hands that address to macOS like any row press, and nothing is
   sent to Superset.
@@ -356,7 +361,9 @@ passes only the observed workspace and terminal identifiers plus the
 developer's own message — the terminal lives on this machine, which is the
 CLI's own default, so no host identifier travels at all. The one control
 offered today is Delete workspace, on a row whose work was positively seen
-settled: it runs Superset's own `workspaces delete` with the observed workspace
+settled — a chat's row once its turn ended, or the standing row of a
+workspace with no agent terminal at all, which is settled by construction:
+it runs Superset's own `workspaces delete` with the observed workspace
 id as its single argument, and Superset documents no archive or restore, so it
 permanently removes that workspace and every terminal in it. Luke never reads,
 copies, or stores the CLI token. The CLI is Superset's cloud client and its own

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ Every row leads with its agent — the provider the session belongs to:
 Luke also marks the apps holding a session on your Mac — ChatGPT, cmux,
 Conductor, Orca, and Superset — grouping rows under their workspaces and
 opening the exact window an app documents. Superset-managed rows can
-additionally take messages and workspace acts through Superset's own CLI.
+additionally take messages and workspace acts through Superset's own CLI,
+and a Superset worktree with no agent chat stands as its own idle row, so a
+stale workspace can be found, renamed, given an agent, or deleted.
 
 See [docs/PROVIDERS.md](docs/PROVIDERS.md) for what Luke can read and write
 per agent and app, and [PRIVACY.md](PRIVACY.md) for the data's point of view.

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -1116,14 +1116,23 @@ async function refreshProviderSessions(generation: number): Promise<void> {
   });
   let supersetSnapshot = new SupersetWorkspaceSnapshot([]);
   let supersetOrganization: string | undefined;
+  let supersetAgentDefault: string | undefined;
   try {
-    const supersetAgentDefault = await settingsStore.get(
-      APP_SETTING_SCHEMA.supersetAgentDefault.field,
-    );
+    supersetAgentDefault = await settingsStore.get(APP_SETTING_SCHEMA.supersetAgentDefault.field);
     [supersetSnapshot, supersetOrganization] = await Promise.all([
       supersetWorkspaces.read(),
       supersetCli.activeOrganization(),
     ]);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Superset observation failed: ${message}\n`);
+  }
+  observedSupersetWorkspaces = supersetSnapshot;
+  observedSupersetOrganization = supersetOrganization;
+  // Refreshed outside the read's own try so a failed pass hands the adapter
+  // the same emptiness the act contexts just took: rows the router would
+  // refuse to act on must not keep standing on a snapshot that is gone.
+  try {
     await supersetWorkspaceAdapter.refresh(
       supersetAgentDefault,
       supersetOrganization !== undefined,
@@ -1133,8 +1142,6 @@ async function refreshProviderSessions(generation: number): Promise<void> {
     const message = error instanceof Error ? error.message : String(error);
     process.stderr.write(`Superset observation failed: ${message}\n`);
   }
-  observedSupersetWorkspaces = supersetSnapshot;
-  observedSupersetOrganization = supersetOrganization;
   const conductorSnapshot = await conductorSnapshotPromise;
   const orcaSnapshot = await orcaSnapshotPromise;
   const cmuxSnapshot = await cmuxSnapshotPromise;

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -1127,6 +1127,7 @@ async function refreshProviderSessions(generation: number): Promise<void> {
     await supersetWorkspaceAdapter.refresh(
       supersetAgentDefault,
       supersetOrganization !== undefined,
+      supersetSnapshot.workspaceRowObservations(supersetOrganization),
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -1154,8 +1155,8 @@ async function refreshProviderSessions(generation: number): Promise<void> {
   // registry commits each provider atomically, so one that is slow or failing
   // can neither delay nor cancel the others. A network provider would
   // otherwise hold up the local ones for as long as its requests take.
-  await Promise.all(
-    orderedRegistrations.map(async ({ adapter }) => {
+  await Promise.all([
+    ...orderedRegistrations.map(async ({ adapter }) => {
       try {
         // Superset claims its workspaces first and Conductor next — the
         // precedence that stood before Orca joined, so no existing tray moves
@@ -1182,7 +1183,20 @@ async function refreshProviderSessions(generation: number): Promise<void> {
         process.stderr.write(`Session observation failed (${adapter.provider.id}): ${message}\n`);
       }
     }),
-  );
+    // The chatless Superset workspaces, as rows of the workspace provider.
+    // No transform rides this refresh: the snapshot decorated them already,
+    // so an act path's plain refresh commits exactly this shape.
+    (async () => {
+      try {
+        await sessionRegistry.refresh(supersetWorkspaceAdapter);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        process.stderr.write(
+          `Session observation failed (${supersetWorkspaceAdapter.provider.id}): ${message}\n`,
+        );
+      }
+    })(),
+  ]);
   if (!sessionObservationLoop.isCurrent(generation)) return;
   // The registry only spoke if the sessions themselves changed, and a pass can
   // change the project list while leaving them exactly as they were.

--- a/apps/desktop/src/renderer/luke-guide.test.ts
+++ b/apps/desktop/src/renderer/luke-guide.test.ts
@@ -353,7 +353,12 @@ test("the facts describe creating a workspace, so Luke does not deny the capabil
   // closed on its own, so the refusal Luke voices is itself the guidance,
   // and that the developer's own word for tidying, archive, is taken as the
   // delete rather than refused over vocabulary.
-  assert.match(rendered, /Delete workspace once their work settled/);
+  assert.match(rendered, /Delete workspace once its work settled/);
+  // The idle workspaces are the ones a cleanup ask is usually about, so the
+  // guide teaches that they stand as rows at all — and which never do.
+  assert.match(rendered, /no agent chat at all stands as its own idle row/);
+  assert.match(rendered, /settled by construction/);
+  assert.match(rendered, /main checkout and workspaces Superset already archived draw no row/);
   assert.match(rendered, /deleting is permanent/);
   assert.match(rendered, /single chat cannot be closed or removed on its own/);
   assert.match(rendered, /ask to archive one means exactly this delete/);

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -222,13 +222,19 @@ function integrationsFact(settings: AppSettings): AppGuideFact {
     "read-only host state, so agents from different providers group under the project and " +
     "workspace that owns them. Every grouped chat carries its workspace's own Superset " +
     "and terminal identifiers, so a chat with no native address opens at its exact terminal " +
-    "in Superset — pressed, or asked of Luke — with no login needed. When Superset's CLI is " +
-    "logged in, those rows can also send the " +
-    "developer's own message, offer Delete workspace once their work settled — Superset " +
+    "in Superset — pressed, or asked of Luke — with no login needed. A worktree workspace " +
+    "with no agent chat at all stands as its own idle row — titled by the workspace, opening " +
+    "in Superset on press, staying however long it has sat idle, which is how a stale " +
+    "workspace is found and cleaned up; the main checkout and workspaces Superset already " +
+    "archived draw no row. When Superset's CLI is " +
+    "logged in, chat rows can also send the " +
+    "developer's own message, every Superset row offers Delete workspace once its work " +
+    "settled — an agentless workspace row counts as settled by construction — Superset " +
     "keeps no archive, so deleting is permanent and takes the whole workspace with every " +
     "chat in it, and a row still working is never offered it; a single chat cannot be " +
     "closed or removed on its own, so deleting the settled workspace is the one removal " +
-    "a Superset row takes, and an ask to archive one means exactly this delete — and " +
+    "a Superset row takes, and an ask to archive one means exactly this delete. Those rows " +
+    "also rename the workspace and start another agent in it, and a conversation ask can " +
     "create a new workspace " +
     "with an agent in a project and host Superset currently lists; connect from Luke's " +
     "Settings, finish Superset's own sign-in flow in the browser, and paste its one-time code " +

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -156,7 +156,7 @@ schema this build does not know means no annotation.
 | cmux | Hook-session stores under `~/.cmuxterm` | Mark, exact `cmux:` pane address | None |
 | Conductor | Local session index (`conductor.db`) | Mark, workspace grouping, `conductor:` chat address, filed-away filtering | None |
 | Orca | Hook-status cache and worktree names | Mark, worktree grouping | None |
-| Superset | Host state (`host.db`) | Mark, grouping, `superset:` workspace address | Message, open workspace, close terminal, add agent, new workspace, rename, delete workspace — through its CLI, while logged in |
+| Superset | Host state (`host.db`) | Mark, grouping, `superset:` workspace address; a standing row for each unarchived worktree with no agent terminal | Message, open workspace, close terminal, add agent, new workspace, rename, delete workspace — through its CLI, while logged in |
 
 ### App notes
 
@@ -202,7 +202,14 @@ schema this build does not know means no annotation.
   id its single argument) is permanent — Superset documents no archive — and
   takes every chat in the workspace, so it is offered only on a row positively
   seen settled, carried once on a grouped tray's header, and an archive-worded
-  ask is taken and reported as the delete it is. Connect and Disconnect are
+  ask is taken and reported as the delete it is. A worktree workspace with no
+  agent terminal at all is settled by construction, so it stands as its own
+  row — read from the same host state, titled by the workspace, opening at
+  its `superset:` address, taking the same rename, add-agent, and delete
+  while logged in, and never taking a message, because no terminal exists to
+  land one. The main checkout and workspaces Superset itself archived draw no
+  row: the one is the user's own working copy, the other already filed away.
+  Connect and Disconnect are
   the CLI's own `auth login` and `auth logout` at the developer's press on the
   Superset row; the CLI owns the credential throughout, and signing out
   withdraws every act while observation continues unchanged.

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -20,6 +20,7 @@ export {
   defaultSqliteModule,
   numberFromRow,
   openReadOnlyDatabase,
+  type SqliteDatabase,
   type SqliteModuleLoader,
   textFromRow,
 } from "./shared/local-sqlite.js";

--- a/packages/session/src/session-registry.ts
+++ b/packages/session/src/session-registry.ts
@@ -161,6 +161,7 @@ const sameSession = exhaustiveSame<NormalizedSession>({
   observedAt: (first, second) => first.observedAt === second.observedAt,
   realtimeVoice: (first, second) => first.realtimeVoice === second.realtimeVoice,
   realtimeVoiceLive: (first, second) => first.realtimeVoiceLive === second.realtimeVoiceLive,
+  standing: (first, second) => first.standing === second.standing,
   location: (first, second) => first.location === second.location,
   agent: (first, second) => sameOptional(first.agent, second.agent, sameProvider),
   recap: (first, second) => first.recap === second.recap,

--- a/packages/session/src/session.test.ts
+++ b/packages/session/src/session.test.ts
@@ -53,6 +53,27 @@ test("a settled or quiet session stays while its ending is news and then leaves"
   }
 });
 
+test("a standing row never ages out, however old its own timestamp", () => {
+  const standing = normalizeSession(
+    { id: "superset", displayName: "Superset" },
+    {
+      providerSessionId: "workspace-1",
+      title: "power-vacation",
+      status: SESSION_STATUS.COMPLETE,
+      observedAt: TEST_NOW - 100 * DAY_MS,
+      standing: true,
+    },
+  );
+  // Its provider re-reports it while it exists and drops it when it is gone,
+  // so retention has nothing to age out — unlike the settled chat beside it.
+  assert.equal(standing.standing, true);
+  assert.equal(isRosterRelevant(standing, TEST_NOW), true);
+  assert.equal(
+    isRosterRelevant(session("run:1", SESSION_STATUS.COMPLETE, TEST_NOW - 100 * DAY_MS), TEST_NOW),
+    false,
+  );
+});
+
 test("filters a roster to the sessions still worth a row, keeping their order", () => {
   const workedForever = session("run:working", SESSION_STATUS.WORKING, TEST_NOW - 100 * DAY_MS);
   const finishedToday = session("run:finished-today", SESSION_STATUS.COMPLETE, TEST_NOW - 1_000);

--- a/packages/session/src/session.ts
+++ b/packages/session/src/session.ts
@@ -94,9 +94,14 @@ export function sessionRosterRetentionMs(status: SessionStatus): number {
 
 /** Whether a session's status still earns it a place on the roster. */
 export function isRosterRelevant(
-  session: Pick<NormalizedSession, "status" | "observedAt">,
+  session: Pick<NormalizedSession, "status" | "observedAt" | "standing">,
   now: number,
 ): boolean {
+  // Retention ages out history — settled chats whose files linger after the
+  // work ended. A standing session is not history: its provider re-reports it
+  // while the thing it names still exists and stops the moment it is gone, so
+  // there is nothing here to age out, however old its own timestamp grows.
+  if (session.standing) return true;
   return now - session.observedAt <= sessionRosterRetentionMs(session.status);
 }
 
@@ -358,6 +363,15 @@ export interface ProviderSessionObservation {
    * conversation does. Absent means none observed.
    */
   realtimeVoiceLive?: boolean;
+  /**
+   * Whether this row reports a thing that currently stands rather than a
+   * conversation that happened: the adapter re-reports it on every pass for as
+   * long as it exists and drops it the pass after it is gone, so roster
+   * retention never ages it out. `observedAt` then carries the provider's own
+   * timestamp for the thing itself, however old, without costing the row its
+   * place. Absent means the row is history like any other.
+   */
+  standing?: boolean;
   /** Omitted by an adapter that reads sessions off this machine. */
   location?: SessionLocation;
   /**
@@ -435,6 +449,8 @@ export interface NormalizedSession extends SessionIdentity {
   realtimeVoice?: boolean;
   /** Whether a realtime voice conversation is live over this session right now. */
   realtimeVoiceLive?: boolean;
+  /** Whether this row reports a thing that currently stands, exempt from retention. */
+  standing?: boolean;
   location: SessionLocation;
   /** The agent behind this session, when its provider hosts rather than is it. */
   agent?: SessionProvider;
@@ -821,6 +837,7 @@ export function normalizeSession(
   };
   if (observation.realtimeVoice === true) session.realtimeVoice = true;
   if (observation.realtimeVoiceLive === true) session.realtimeVoiceLive = true;
+  if (observation.standing === true) session.standing = true;
   if (parentProviderSessionId && parentProviderSessionId !== providerSessionId) {
     session.parentProviderSessionId = parentProviderSessionId;
   }

--- a/packages/superset/src/cli.test.ts
+++ b/packages/superset/src/cli.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test, { type TestContext } from "node:test";
-import { PROVIDER_ACT_RESULT_STATUS, PROVIDER_ID } from "@sidecar/session";
+import { PROVIDER_ACT_RESULT_STATUS, PROVIDER_ID, SESSION_STATUS } from "@sidecar/session";
 import { isRecord, text, type UnparsedWireValue } from "@sidecar/wire";
 import {
   isSupersetControlId,
@@ -247,6 +247,56 @@ test("a refused rename answers with the CLI's own bounded error line", async (t)
   });
 });
 
+test("a chatless workspace context takes the delete but never a message", async (t) => {
+  const home = await connectedHome(t);
+  const calls: Array<readonly string[]> = [];
+  const cli = new SupersetCli({
+    ...testCliOptions(home),
+    run: async (_executable, arguments_) => {
+      calls.push(arguments_);
+    },
+  });
+  const { terminalId: _terminalId, ...chatless } = CONTEXT;
+
+  // No terminal exists for a message to land in, so no invocation may run.
+  assert.deepEqual(await cli.sendMessage(chatless, "hello"), {
+    status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED,
+  });
+  assert.equal(
+    (await cli.executeControl(chatless, SUPERSET_CONTROL_ID.DELETE_WORKSPACE)).status,
+    PROVIDER_ACT_RESULT_STATUS.ACCEPTED,
+  );
+  assert.equal(
+    (await cli.renameWorkspace(chatless, "Cleaned up")).status,
+    PROVIDER_ACT_RESULT_STATUS.ACCEPTED,
+  );
+  assert.deepEqual(calls, [
+    ["workspaces", "delete", "workspace-1", "--json"],
+    ["workspaces", "update", "workspace-1", "--name", "Cleaned up"],
+  ]);
+});
+
+test("the workspace adapter reports the rows it was refreshed with", async (t) => {
+  const home = await connectedHome(t);
+  const cli = new SupersetCli({ ...testCliOptions(home), query: async () => "[]" });
+  const adapter = new SupersetWorkspaceAdapter(cli);
+  const row = {
+    providerSessionId: "workspace-1",
+    title: "power-vacation",
+    status: SESSION_STATUS.COMPLETE,
+    observedAt: 100,
+    standing: true,
+  };
+
+  assert.deepEqual(await adapter.observe(), []);
+  // Observation reads host state, which needs no login, so the rows stand
+  // while the CLI is signed out — only their acts wait for the connection.
+  await adapter.refresh(undefined, false, [row]);
+  assert.deepEqual(await adapter.observe(), [row]);
+  await adapter.refresh(undefined, false, []);
+  assert.deepEqual(await adapter.observe(), []);
+});
+
 test("a CLI failure becomes a bounded rejection", async (t) => {
   const home = await connectedHome(t);
   const cli = new SupersetCli({
@@ -389,8 +439,8 @@ test("reuses recently discovered workspace projects", async (t) => {
   });
   const adapter = new SupersetWorkspaceAdapter(cli);
 
-  await adapter.refresh("codex", true);
-  await adapter.refresh("codex", true);
+  await adapter.refresh("codex", true, []);
+  await adapter.refresh("codex", true, []);
 
   assert.equal(projectQueries, 1);
   assert.equal(adapter.workspaceProjects()[0]?.defaultAgent, "codex");
@@ -412,8 +462,8 @@ test("retries workspace discovery after an empty result", async (t) => {
   });
   const adapter = new SupersetWorkspaceAdapter(cli);
 
-  await adapter.refresh("codex", true);
-  await adapter.refresh("codex", true);
+  await adapter.refresh("codex", true, []);
+  await adapter.refresh("codex", true, []);
 
   assert.equal(projectQueries, 2);
   assert.equal(adapter.workspaceProjects()[0]?.providerProjectId, "project-1");

--- a/packages/superset/src/cli.ts
+++ b/packages/superset/src/cli.ts
@@ -8,6 +8,7 @@ import {
   PROVIDER_ACT_RESULT_STATUS,
   type ProviderControlResult,
   type ProviderMessageResult,
+  type ProviderSessionObservation,
   type ProviderWorkspaceRequest,
   type ProviderWorkspaceResult,
   SessionProviderAdapterBase,
@@ -373,6 +374,10 @@ export class SupersetCli {
   // the flag takes a machineId the state does not carry — passing the state
   // directory's organization name there is what made every act fail.
   async sendMessage(context: SupersetSessionContext, text: string): Promise<ProviderMessageResult> {
+    // A chatless workspace row carries no terminal for a message to land in,
+    // and never advertises taking one; the adapter answers the same way
+    // rather than improvising a way in.
+    if (!context.terminalId) return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
     return this.#act(
       [
         "terminals",
@@ -519,17 +524,32 @@ export class SupersetWorkspaceAdapter extends SessionProviderAdapterBase {
   #projects: readonly WorkspaceProject[] = [];
   #projectsRefreshedAt: number | undefined;
   #defaultAgent: string | undefined;
+  #workspaceRows: readonly ProviderSessionObservation[] = [];
 
   constructor(cli: SupersetCli) {
     super();
     this.#cli = cli;
   }
 
-  async observe(): Promise<readonly never[]> {
-    return [];
+  /**
+   * The chatless workspaces the latest host-state read reported, exactly as
+   * the snapshot decorated them. They are handed in by `refresh` rather than
+   * read here so that this adapter observes the same pass everything else
+   * validated against — and so a plain registry refresh after an act commits
+   * the same decorated shape the observation loop does.
+   */
+  async observe(): Promise<readonly ProviderSessionObservation[]> {
+    return this.#workspaceRows;
   }
 
-  async refresh(defaultAgent: string | undefined, connected: boolean): Promise<void> {
+  async refresh(
+    defaultAgent: string | undefined,
+    connected: boolean,
+    workspaceRows: readonly ProviderSessionObservation[],
+  ): Promise<void> {
+    // The rows are observation, not an act: host state reads without a login,
+    // so they stand — undecorated with acts — however the connection looks.
+    this.#workspaceRows = workspaceRows;
     if (!connected) {
       this.#projects = [];
       this.#projectsRefreshedAt = undefined;

--- a/packages/superset/src/workspaces.test.ts
+++ b/packages/superset/src/workspaces.test.ts
@@ -36,7 +36,9 @@ function createSchema(database: DatabaseSync): void {
       pull_request_id TEXT,
       name TEXT NOT NULL,
       branch TEXT NOT NULL,
-      updated_at INTEGER NOT NULL
+      updated_at INTEGER NOT NULL,
+      type TEXT NOT NULL DEFAULT 'worktree',
+      archived_at INTEGER
     );
     CREATE TABLE terminal_agent_bindings (
       terminal_id TEXT PRIMARY KEY,
@@ -59,7 +61,7 @@ test("reads live host databases and enriches an exact provider session", async (
   database.exec(`
     INSERT INTO projects VALUES ('project-1', 'Luke');
     INSERT INTO pull_requests VALUES ('pr-1', 'https://github.com/example/luke/pull/42');
-    INSERT INTO workspaces VALUES (
+    INSERT INTO workspaces (id, project_id, pull_request_id, name, branch, updated_at) VALUES (
       'workspace-1', 'project-1', 'pr-1', 'power-vacation', 'feat/superset', 200
     );
     INSERT INTO terminal_agent_bindings VALUES (
@@ -148,7 +150,7 @@ test("keeps the newest duplicate binding across host databases", async (t) => {
     const database = await writeHostDatabase(home, organizationId);
     createSchema(database);
     database.exec(`
-      INSERT INTO workspaces VALUES (
+      INSERT INTO workspaces (id, project_id, pull_request_id, name, branch, updated_at) VALUES (
         'workspace-${organizationId}', NULL, NULL, '${organizationId}', 'main', ${updatedAt}
       );
       INSERT INTO terminal_agent_bindings VALUES (
@@ -170,7 +172,8 @@ test("advertises Superset actions only after the CLI is connected", async (t) =>
   const database = await writeHostDatabase(home, "host-local");
   createSchema(database);
   database.exec(`
-    INSERT INTO workspaces VALUES ('workspace-1', NULL, NULL, 'power-vacation', 'main', 100);
+    INSERT INTO workspaces (id, project_id, pull_request_id, name, branch, updated_at)
+      VALUES ('workspace-1', NULL, NULL, 'power-vacation', 'main', 100);
     INSERT INTO host_agent_configs VALUES ('claude', 0), ('codex', 1);
     INSERT INTO terminal_agent_bindings VALUES (
       'terminal-1', 'workspace-1', 'codex', 'session-1', 'Start'
@@ -247,7 +250,8 @@ test("does not attach unknown Superset agent kinds to a Luke provider", async (t
   const database = await writeHostDatabase(home, "host-local");
   createSchema(database);
   database.exec(`
-    INSERT INTO workspaces VALUES ('workspace-1', NULL, NULL, 'power-vacation', 'main', 100);
+    INSERT INTO workspaces (id, project_id, pull_request_id, name, branch, updated_at)
+      VALUES ('workspace-1', NULL, NULL, 'power-vacation', 'main', 100);
     INSERT INTO terminal_agent_bindings VALUES (
       'terminal-1', 'workspace-1', 'mystery-agent', 'session-1', 'Start'
     );
@@ -258,12 +262,148 @@ test("does not attach unknown Superset agent kinds to a Luke provider", async (t
   assert.equal(snapshot.context(PROVIDER_ID.CODEX, "session-1"), undefined);
 });
 
+test("reports a chatless workspace as its own standing, settled row", async (t) => {
+  const home = await temporarySupersetHome(t);
+  const database = await writeHostDatabase(home, "host-local");
+  createSchema(database);
+  database.exec(`
+    INSERT INTO projects VALUES ('project-1', 'Luke');
+    INSERT INTO pull_requests VALUES ('pr-1', 'https://github.com/example/luke/pull/42');
+    INSERT INTO workspaces (id, project_id, pull_request_id, name, branch, updated_at) VALUES
+      ('workspace-idle', 'project-1', 'pr-1', 'grok-bot-support', 'grok-bot', 300);
+    INSERT INTO host_agent_configs VALUES ('claude', 0), ('codex', 1);
+  `);
+  database.close();
+
+  const snapshot = await new SupersetWorkspaceReader({ homeDirectory: home }).read();
+  // Signed out, the row still observes — host state needs no login — but
+  // advertises no act, the same posture a bound chat's enrichment keeps.
+  assert.deepEqual(snapshot.workspaceRowObservations(undefined), [
+    {
+      providerSessionId: "workspace-idle",
+      title: "grok-bot-support",
+      status: SESSION_STATUS.COMPLETE,
+      observedAt: 300,
+      standing: true,
+      detail: {
+        link: "superset://v2-workspace/workspace-idle",
+        repository: "Luke",
+        branch: "grok-bot",
+        change: "https://github.com/example/luke/pull/42",
+      },
+      applications: [
+        {
+          id: SESSION_APPLICATION_ID.SUPERSET,
+          displayName: "Superset",
+          scope: SESSION_APPLICATION_SCOPE.WORKSPACE,
+          link: "superset://v2-workspace/workspace-idle",
+        },
+      ],
+      workspace: {
+        providerWorkspaceId: "workspace-idle",
+        name: "grok-bot-support",
+        scopeId: SUPERSET_WORKSPACE_PROVIDER_ID,
+        managerName: "Superset",
+      },
+    },
+  ]);
+
+  const connected = snapshot.workspaceRowObservations("host-local")[0];
+  assert.deepEqual(connected?.controls, [
+    {
+      id: SUPERSET_CONTROL_ID.DELETE_WORKSPACE,
+      label: "Delete workspace",
+      target: "workspace-idle",
+    },
+  ]);
+  assert.equal(connected?.renameTarget, "workspace-idle");
+  assert.deepEqual(connected?.spawnableAgents, ["claude", "codex"]);
+  assert.equal(connected?.spawnTarget, "workspace-idle");
+  assert.equal(connected?.canReceiveMessage, undefined);
+  assert.equal(snapshot.workspaceRowObservations("org-other")[0]?.controls, undefined);
+
+  // The act router resolves the row like any managed session, terminal-less.
+  const context = snapshot.actableContext(
+    SUPERSET_WORKSPACE_PROVIDER_ID,
+    "workspace-idle",
+    "host-local",
+  );
+  assert.equal(context?.workspaceId, "workspace-idle");
+  assert.equal(context?.terminalId, undefined);
+  assert.equal(
+    snapshot.actableContext(SUPERSET_WORKSPACE_PROVIDER_ID, "workspace-idle", "org-other"),
+    undefined,
+  );
+});
+
+test("keeps the main checkout, archived, and chat-bound workspaces off the workspace rows", async (t) => {
+  const home = await temporarySupersetHome(t);
+  const database = await writeHostDatabase(home, "host-local");
+  createSchema(database);
+  database.exec(`
+    INSERT INTO workspaces (id, project_id, pull_request_id, name, branch, updated_at, type, archived_at) VALUES
+      ('workspace-main', NULL, NULL, 'main', 'main', 500, 'main', NULL),
+      ('workspace-archived', NULL, NULL, 'filed-away', 'old-branch', 400, 'worktree', 350),
+      ('workspace-bound', NULL, NULL, 'has-a-chat', 'chat-branch', 300, 'worktree', NULL),
+      ('workspace-shadowed', NULL, NULL, 'unmapped-agent', 'shadow-branch', 200, 'worktree', NULL),
+      ('workspace-idle', NULL, NULL, 'truly-idle', 'idle-branch', 100, 'worktree', NULL);
+    INSERT INTO terminal_agent_bindings VALUES
+      ('terminal-1', 'workspace-bound', 'claude', 'session-1', 'Stop'),
+      ('terminal-2', 'workspace-shadowed', 'mystery-agent', NULL, 'Start');
+  `);
+  database.close();
+
+  const snapshot = await new SupersetWorkspaceReader({ homeDirectory: home }).read();
+  // Only the truly idle worktree earns a row: the main checkout is the user's
+  // own working copy, the archived one Superset already filed away, and any
+  // agent terminal — even one Luke cannot map, which could be mid-turn
+  // invisibly — means the workspace is not settled by construction.
+  assert.deepEqual(
+    snapshot.workspaceRowObservations("host-local").map((row) => row.providerSessionId),
+    ["workspace-idle"],
+  );
+});
+
+test("a host database without the workspace columns loses only the chatless rows", async (t) => {
+  const home = await temporarySupersetHome(t);
+  const database = await writeHostDatabase(home, "host-local");
+  database.exec(`
+    CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL);
+    CREATE TABLE pull_requests (id TEXT PRIMARY KEY, url TEXT NOT NULL);
+    CREATE TABLE workspaces (
+      id TEXT PRIMARY KEY,
+      project_id TEXT,
+      pull_request_id TEXT,
+      name TEXT NOT NULL,
+      branch TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE terminal_agent_bindings (
+      terminal_id TEXT PRIMARY KEY,
+      workspace_id TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      agent_session_id TEXT,
+      last_event_type TEXT NOT NULL
+    );
+    CREATE TABLE host_agent_configs (preset_id TEXT, display_order INTEGER NOT NULL);
+    INSERT INTO workspaces VALUES ('workspace-1', NULL, NULL, 'power-vacation', 'main', 100);
+    INSERT INTO terminal_agent_bindings VALUES
+      ('terminal-1', 'workspace-1', 'codex', 'session-1', 'Start');
+  `);
+  database.close();
+
+  const snapshot = await new SupersetWorkspaceReader({ homeDirectory: home }).read();
+  assert.equal(snapshot.context(PROVIDER_ID.CODEX, "session-1")?.workspaceId, "workspace-1");
+  assert.deepEqual(snapshot.workspaceRowObservations("host-local"), []);
+});
+
 test("attaches Superset's Gemini terminals to Gemini CLI rows", async (t) => {
   const home = await temporarySupersetHome(t);
   const database = await writeHostDatabase(home, "host-local");
   createSchema(database);
   database.exec(`
-    INSERT INTO workspaces VALUES ('workspace-1', NULL, NULL, 'power-vacation', 'main', 100);
+    INSERT INTO workspaces (id, project_id, pull_request_id, name, branch, updated_at)
+      VALUES ('workspace-1', NULL, NULL, 'power-vacation', 'main', 100);
     INSERT INTO terminal_agent_bindings VALUES (
       'terminal-1', 'workspace-1', 'gemini', 'session-1', 'Start'
     );

--- a/packages/superset/src/workspaces.ts
+++ b/packages/superset/src/workspaces.ts
@@ -5,6 +5,7 @@ import {
   numberFromRow,
   openReadOnlyDatabase,
   readDirectory,
+  type SqliteDatabase,
   type SqliteModuleLoader,
   textFromRow,
 } from "@sidecar/providers";
@@ -79,6 +80,36 @@ const SUPERSET_AGENT_QUERY = `
 `;
 
 /**
+ * The workspaces standing with no agent terminal at all, which no chat row
+ * will ever carry. Three exclusions bound it: the main checkout, whose
+ * deletion would take the user's own working copy rather than clean up after
+ * an agent — only the worktree shape Superset makes for agents qualifies; a
+ * workspace Superset already archived, which its own app has filed away; and
+ * any workspace with a terminal binding, mapped agent or not — its chat's own
+ * row carries the workspace where Luke can see one, and where Luke cannot,
+ * an unmappable agent could be mid-turn invisibly, so only a workspace with
+ * no agent terminal is settled by construction.
+ */
+const SUPERSET_CHATLESS_WORKSPACE_QUERY = `
+  SELECT
+    workspaces.id AS workspace_id,
+    workspaces.name AS workspace_name,
+    workspaces.branch,
+    workspaces.updated_at,
+    projects.name AS project_name,
+    pull_requests.url AS pull_request_url
+  FROM workspaces
+  LEFT JOIN projects ON projects.id = workspaces.project_id
+  LEFT JOIN pull_requests ON pull_requests.id = workspaces.pull_request_id
+  WHERE workspaces.type = 'worktree'
+    AND workspaces.archived_at IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM terminal_agent_bindings
+      WHERE terminal_agent_bindings.workspace_id = workspaces.id
+    )
+`;
+
+/**
  * What one binding row says about the session it manages. Deliberately no
  * host identifier: the host state read here is this machine's own — the
  * directories under `host/` are named by organization, not by machine — so
@@ -97,7 +128,12 @@ export interface SupersetSessionContext {
   organizationId: string;
   workspaceId: string;
   workspaceName: string;
-  terminalId: string;
+  /**
+   * The bound terminal a message lands in. A chatless workspace row has none
+   * — there is nothing there to message — so every act that needs one must
+   * check rather than assume.
+   */
+  terminalId?: string;
   updatedAt: number;
   projectName?: string;
   branch?: string;
@@ -159,6 +195,38 @@ function contextFromRow(
   return context;
 }
 
+/**
+ * A chatless workspace as its own row's context, keyed under the Superset
+ * workspace provider by the workspace's own id — the same shape a bound
+ * chat's context has, minus the terminal there is nothing to message through.
+ */
+function contextFromWorkspaceRow(
+  organizationId: string,
+  row: WireRecord,
+  spawnableAgents: readonly string[],
+): SupersetSessionContext | undefined {
+  const workspaceId = textFromRow(row, "workspace_id");
+  const workspaceName = textFromRow(row, "workspace_name");
+  const updatedAt = numberFromRow(row, "updated_at");
+  if (!workspaceId || !workspaceName || updatedAt === undefined) return undefined;
+  const projectName = textFromRow(row, "project_name");
+  const branch = textFromRow(row, "branch");
+  const pullRequestUrl = textFromRow(row, "pull_request_url");
+  const context: SupersetSessionContext = {
+    providerId: SUPERSET_WORKSPACE_PROVIDER_ID,
+    providerSessionId: workspaceId,
+    organizationId,
+    workspaceId,
+    workspaceName,
+    updatedAt,
+    spawnableAgents,
+  };
+  if (projectName) context.projectName = projectName;
+  if (branch) context.branch = branch;
+  if (pullRequestUrl) context.pullRequestUrl = pullRequestUrl;
+  return context;
+}
+
 export class SupersetWorkspaceSnapshot {
   readonly #sessions = new Map<string, Map<string, SupersetSessionContext>>();
 
@@ -198,7 +266,9 @@ export class SupersetWorkspaceSnapshot {
       if (context.projectName) detail.repository = context.projectName;
       if (context.branch) detail.branch = context.branch;
       if (context.pullRequestUrl) detail.change = context.pullRequestUrl;
-      const applicationLink = supersetTerminalLink(context.workspaceId, context.terminalId);
+      const applicationLink = context.terminalId
+        ? supersetTerminalLink(context.workspaceId, context.terminalId)
+        : supersetWorkspaceLink(context.workspaceId);
       // The app that wrote the host state is the scheme's handler, so the
       // address stands without the CLI login the acts below wait for. A native
       // provider address still wins as the row's primary press; the Superset
@@ -247,30 +317,87 @@ export class SupersetWorkspaceSnapshot {
             ]
           : []),
       ];
-      if (context.spawnableAgents.length > 0) {
-        return {
-          ...observation,
-          detail,
-          applications,
-          workspace,
-          canReceiveMessage: true,
-          spawnableAgents: context.spawnableAgents,
-          spawnTarget: context.workspaceId,
-          // Superset documents renaming any workspace it manages, so the
-          // target rides the advertisement the way the spawn target does.
-          renameTarget: context.workspaceId,
-          controls,
-        };
-      }
-      return {
+      const enriched: ProviderSessionObservation = {
         ...observation,
         detail,
         applications,
         workspace,
-        canReceiveMessage: true,
+        // Superset documents renaming any workspace it manages, so the
+        // target rides the advertisement the way the spawn target does.
         renameTarget: context.workspaceId,
         controls,
       };
+      // Only a bound terminal gives a message somewhere to land; a chatless
+      // workspace row stays unmessageable rather than improvising a way in.
+      if (context.terminalId) enriched.canReceiveMessage = true;
+      if (context.spawnableAgents.length > 0) {
+        enriched.spawnableAgents = context.spawnableAgents;
+        enriched.spawnTarget = context.workspaceId;
+      }
+      return enriched;
+    });
+  }
+
+  /**
+   * The chatless workspaces as rows of the Superset workspace provider,
+   * decorated here — beside `enrich`, from the same observed state — rather
+   * than by a registry transform, so an act path's plain refresh commits the
+   * same shape the observation loop does. Each row stands (`standing`): it is
+   * re-reported for as long as the workspace exists and dropped the pass
+   * after it is gone, so retention never ages it out however long the
+   * workspace has sat idle — sitting idle is exactly what earns it a row.
+   * Complete is the vocabulary's settled state, and a workspace with no agent
+   * terminal is settled by construction — the same gate the delete control's
+   * advertisement stands on — so the acts ride only while the CLI's login
+   * serves the recording organization, exactly as they do on a chat row.
+   */
+  workspaceRowObservations(activeOrganizationId?: string): readonly ProviderSessionObservation[] {
+    const contexts = [...(this.#sessions.get(SUPERSET_WORKSPACE_PROVIDER_ID)?.values() ?? [])].sort(
+      (first, second) =>
+        second.updatedAt - first.updatedAt || first.workspaceId.localeCompare(second.workspaceId),
+    );
+    return contexts.map((context) => {
+      const link = supersetWorkspaceLink(context.workspaceId);
+      const detail: ProviderSessionObservation["detail"] = { link };
+      if (context.projectName) detail.repository = context.projectName;
+      if (context.branch) detail.branch = context.branch;
+      if (context.pullRequestUrl) detail.change = context.pullRequestUrl;
+      const observation: ProviderSessionObservation = {
+        providerSessionId: context.workspaceId,
+        title: context.workspaceName,
+        status: SESSION_STATUS.COMPLETE,
+        observedAt: context.updatedAt,
+        standing: true,
+        detail,
+        applications: [
+          {
+            id: SESSION_APPLICATION_ID.SUPERSET,
+            displayName: "Superset",
+            scope: SESSION_APPLICATION_SCOPE.WORKSPACE,
+            link,
+          },
+        ],
+        workspace: {
+          providerWorkspaceId: context.workspaceId,
+          name: context.workspaceName,
+          scopeId: SUPERSET_WORKSPACE_PROVIDER_ID,
+          managerName: "Superset",
+        },
+      };
+      if (!actableInOrganization(context, activeOrganizationId)) return observation;
+      observation.controls = [
+        {
+          id: SUPERSET_CONTROL_ID.DELETE_WORKSPACE,
+          label: "Delete workspace",
+          target: context.workspaceId,
+        },
+      ];
+      observation.renameTarget = context.workspaceId;
+      if (context.spawnableAgents.length > 0) {
+        observation.spawnableAgents = context.spawnableAgents;
+        observation.spawnTarget = context.workspaceId;
+      }
+      return observation;
     });
   }
 }
@@ -320,7 +447,7 @@ export class SupersetWorkspaceReader {
           const presetId = textFromRow(row, "preset_id");
           return presetId ? [presetId] : [];
         });
-      return database
+      const bound = database
         .prepare(SUPERSET_WORKSPACE_QUERY)
         .all()
         .flatMap((value) => {
@@ -329,11 +456,38 @@ export class SupersetWorkspaceReader {
           const context = contextFromRow(organizationId, row, spawnableAgents);
           return context ? [context] : [];
         });
+      return [...bound, ...this.#chatlessWorkspaces(database, organizationId, spawnableAgents)];
     } catch (error) {
       if (error instanceof Error && canIgnoreSqliteError(error)) return [];
       throw error;
     } finally {
       database.close();
+    }
+  }
+
+  /**
+   * Read behind its own guard: a host database from a Superset without the
+   * workspace columns this query names loses only the chatless rows, never
+   * the bound chats read above it.
+   */
+  #chatlessWorkspaces(
+    database: SqliteDatabase,
+    organizationId: string,
+    spawnableAgents: readonly string[],
+  ): readonly SupersetSessionContext[] {
+    try {
+      return database
+        .prepare(SUPERSET_CHATLESS_WORKSPACE_QUERY)
+        .all()
+        .flatMap((value) => {
+          const row = wireRecord(value);
+          if (!row) return [];
+          const context = contextFromWorkspaceRow(organizationId, row, spawnableAgents);
+          return context ? [context] : [];
+        });
+    } catch (error) {
+      if (error instanceof Error && canIgnoreSqliteError(error)) return [];
+      throw error;
     }
   }
 }


### PR DESCRIPTION
## Why

Luke already carries the one authorized Superset deletion (#312), but it was advertised only on rows behind an observed agent chat. A worktree with no agent terminal at all — the stale workspace a cleanup ask is usually about — had no row, so it could not be seen, opened, renamed, spawned into, or deleted. On the reporting machine, 7 of 8 workspaces were invisible for exactly this reason. Superset's CLI documents no archive (`workspaces delete` is the only removal), so the delete stays the one removal, and an archive-worded ask keeps meaning it.

## What

- **Observation** — `SupersetWorkspaceReader` reads a third fixed query from the same read-only host state: every unarchived worktree with no agent terminal becomes its own standing row of the Superset workspace provider, titled by the workspace, opening at its `superset:` address. The main checkout and anything Superset already archived draw no row, and any terminal binding — mapped agent or not, which could be mid-turn invisibly — keeps a workspace off the rows: only a workspace with no agent terminal is settled by construction, the gate the delete already stood on.
- **Acts** — while the CLI's login serves the recording organization, the row offers Delete workspace, rename, and add-agent, from the row or asked of Luke, validated against the observed roster in both processes like every act. It never takes a message — no terminal exists to land one — and `sendMessage` refuses a terminal-less context by type.
- **Session vocabulary** — a new `standing` mark exempts these rows from roster retention: the provider re-reports them while the workspace exists and drops them the pass after it is gone, so sitting idle past the settled horizon — exactly what earns a workspace its row — never hides it.
- **Docs** — the agent guide's delete constraint, `PRIVACY.md`, `docs/PROVIDERS.md`, and the in-app guide move in the same change.

## Verification

- `./scripts/check.sh` exits 0 (repository checks, typechecks, all tests — 32 superset, 86 session, 698 desktop — and builds).
- New tests: workspace-row emission and its three exclusions, act advertisement gated on the active organization, terminal-less message refusal, adapter row reporting, schema-drift fallback (old host databases lose only the chatless rows), and `standing` retention.
- `./scripts/verify.sh` was **not** run locally (authored in a Linux sandbox; macOS-only) and no physical-notch check was performed — the new rows draw through the existing row machinery with no renderer changes, but macOS validation should come from CI before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/adab0a7e-cc26-4c16-ac2d-2fc91fc88956)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32429819981/artifacts/9428710355) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32429819981)

- Commit: `4a4c02f050fde327123440d150c4e788671a905c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
