### PR TITLE
chore: align every declared Node major on .nvmrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ per agent and app, and [PRIVACY.md](PRIVACY.md) for the data's point of view.
 
 ## Build from source
 
-Requires an Apple Silicon Mac on macOS 14 or newer, Node.js 22.12 or newer,
+Requires an Apple Silicon Mac on macOS 14 or newer, Node.js 24 or newer,
 pnpm 9.15.0, and the Xcode Command Line Tools.
 
 ```sh

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Luke landing page",
   "engines": {
-    "node": "22.x"
+    "node": "24.x"
   },
   "scripts": {
     "auth:generate": "DATABASE_URL=${DATABASE_URL:-postgresql://schema:generate@127.0.0.1:5432/luke} pnpm dlx @better-auth/cli@1.4.21 generate --config server/auth.ts --output server/db/auth-schema.ts --yes && pnpm exec biome check --write server/db/auth-schema.ts",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A notch-attached desktop sidecar for coding-agent sessions",
   "packageManager": "pnpm@9.15.0",
   "engines": {
-    "node": ">=22.12.0"
+    "node": ">=24.0.0"
   },
   "scripts": {
     "build": "pnpm --recursive --if-present run build",

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -69,6 +69,35 @@ find "$SIDECAR_REPO_ROOT/scripts" -type f -name '*.sh' -print0 |
 
 git -C "$SIDECAR_REPO_ROOT" diff --check
 
+# The Node major is stated in more than one place because different readers look
+# in different files, so they have to agree. `.nvmrc` is what local shells and
+# CI read — the workflows name it as `node-version-file` — and Vercel reads
+# neither it nor the root manifest: it takes `engines.node` from the deployed
+# app and overrides its own dashboard setting with it. A stale `engines`
+# therefore fails nothing and announces nothing local, and quietly ships
+# production on a major no test ever ran on, which is how `22.x` outlived the
+# move to 24. `.nvmrc` is the source; every declared major is checked against it.
+nvmrc_major=$(sed -E 's/^v?([0-9]+).*$/\1/' "$SIDECAR_REPO_ROOT/.nvmrc" | head -1)
+engines_drift=""
+for manifest in "$SIDECAR_REPO_ROOT/package.json" \
+    "$SIDECAR_REPO_ROOT"/apps/*/package.json \
+    "$SIDECAR_REPO_ROOT"/packages/*/package.json; do
+    declared=$(node -e 'const n = require(process.argv[1]).engines?.node; if (n) process.stdout.write(n)' \
+        "$manifest")
+    if [[ -z "$declared" ]]; then
+        continue
+    fi
+    declared_major=$(printf '%s' "$declared" | grep -oE '[0-9]+' | head -1)
+    if [[ "$declared_major" != "$nvmrc_major" ]]; then
+        engines_drift+="${manifest#"$SIDECAR_REPO_ROOT/"}: engines.node \"$declared\" is not Node $nvmrc_major"$'\n'
+    fi
+done
+if [[ -n "$engines_drift" ]]; then
+    printf 'error: every engines.node must name the Node major .nvmrc pins (%s):\n%s' \
+        "$nvmrc_major" "$engines_drift" >&2
+    exit 1
+fi
+
 # The brand artwork has one source and three sets of committed outputs cut from
 # it: the SVGs, the face the renderer draws, and the motions it plays. If the
 # copies no longer match the source, one of them is telling a story the artwork


### PR DESCRIPTION
## The drift

`.nvmrc` moved to 24; the two `engines.node` fields never followed. The repository was stating three different Node majors at once:

| Where | Was | Read by |
|---|---|---|
| `.nvmrc` | `24` | local shells, and CI via `node-version-file` |
| `package.json` | `>=22.12.0` | local tooling |
| `apps/web/package.json` | `22.x` | **Vercel — selects the production runtime** |
| Vercel Project Settings | `24.x` | nothing, while `engines` disagreed |

Nothing reported it, because each reader looks in a different file and each was internally consistent. Vercel reads neither `.nvmrc` nor the root manifest — it takes `engines.node` from the deployed app and overrides its own dashboard setting with it. It said so on every build step of every deploy:

```
Warning: Due to "engines": { "node": "22.x" } in your `package.json` file, the
Node.js Version defined in your Project Settings ("24.x") will not apply,
Node.js Version "22.x" will be used instead.
```

**So every test ran on Node 24 and production ran on Node 22.** That skew was harmless in the end, but it is the kind only ever found by the bug it causes.

## The shape this settles on

`.nvmrc` stays the single source of truth, which is what the CI workflows already read.

- `apps/web` spells its major `24.x` — the form [Vercel documents](https://vercel.com/docs/functions/runtimes/node-js/node-js-versions), and the only kind it resolves to a runtime. Keeping it in the manifest rather than the dashboard is also what Vercel recommends, since the manifest is versioned.
- The root keeps its floor and moves it to `>=24.0.0`.
- The dashboard setting is already `24.x`, so the two now agree and the warning goes away.

24 is what CI has validated all along and what Vercel now defaults to, so this is **production catching up to its own tests** rather than a change of target.

## The guard

`repository-checks.sh` now checks each declared major against `.nvmrc` rather than against a literal, so the next bump stays a one-line edit to `.nvmrc` and a failing check names whatever did not follow. Verified in both directions: reverting `apps/web` to `22.x` fails, and bumping `.nvmrc` alone fails and names both manifests.

## Verification

`./scripts/check.sh` → exit 0, 24 suites clean. Portable-only change; no macOS or UI surface is touched, so no visual evidence applies.

Production runtime moves 22 → 24 on the next deploy, which I'll confirm against the live endpoints after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32430191270/artifacts/9428835159) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32430191270)

- Commit: `4c0cfa567598838c55740b22c95d7f38a1c26159`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
