### PR TITLE
chore(release): prepare 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,33 @@
 Notable changes to Luke, newest first. Each heading is a released version and
 the date its release was published.
 
+## 0.3.5 — 2026-08-20
+
+### Improvements
+
+- Luke keeps your voice conversation history across calls so you can continue
+  where you left off
+  ([#354](https://github.com/ReviewStage/luke/pull/354))
+- Luke records your spoken turns alongside his replies in the conversation
+  history
+  ([#355](https://github.com/ReviewStage/luke/pull/355))
+- Luke can search the session list when you ask out loud
+  ([#364](https://github.com/ReviewStage/luke/pull/364))
+- Luke shows Superset workspaces without chats as standing rows you can delete
+  ([#365](https://github.com/ReviewStage/luke/pull/365))
+
+### Fixes
+
+- Fixed the session count appearing before the roster finished loading
+  ([#361](https://github.com/ReviewStage/luke/pull/361))
+- Fixed idle voice calls lingering after their conversation history took over
+  ([#356](https://github.com/ReviewStage/luke/pull/356))
+
+### Miscellaneous
+
+- Updated every declared Node.js version to match the repository version
+  ([#366](https://github.com/ReviewStage/luke/pull/366))
+
 ## 0.3.4 — 2026-08-20
 
 ### Improvements

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@luke/desktop",
   "productName": "Luke",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "description": "Luke desktop application",
   "main": "dist/main.js",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luke/web",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "description": "Luke landing page",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luke",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "description": "A notch-attached desktop sidecar for coding-agent sessions",
   "packageManager": "pnpm@9.15.0",

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/account",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/analytics",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/attention/package.json
+++ b/packages/attention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/attention",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/calendar",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/credentials",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/feedback",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/fixtures/package.json
+++ b/packages/fixtures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/fixtures",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/guide/package.json
+++ b/packages/guide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/guide",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hosted/package.json
+++ b/packages/hosted/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/hosted",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/issues/package.json
+++ b/packages/issues/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/issues",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/oauth",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/observation/package.json
+++ b/packages/observation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/observation",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/providers",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/realtime",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/session",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/settings",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/superset/package.json
+++ b/packages/superset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/superset",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/surface/package.json
+++ b/packages/surface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/surface",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/trackers/package.json
+++ b/packages/trackers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/trackers",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/voice",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/wire/package.json
+++ b/packages/wire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/wire",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -64,7 +64,7 @@ function packagerOptions(signing = resolveSigningMode({})) {
     appUpdateConfigPath: `/repo/apps/desktop/.build/${APP_UPDATE_CONFIG_FILE_NAME}`,
     entitlementsPath,
     signing,
-    version: "0.3.4",
+    version: "0.3.5",
   });
 }
 
@@ -98,7 +98,7 @@ test("the bundle carries the updater config electron-updater reads before every 
   );
 });
 
-test("workspace package versions agree on v0.3.4", () => {
+test("workspace package versions agree on v0.3.5", () => {
   // Enumerated rather than listed, so a package added to the workspace is held
   // to the release version without anyone remembering to name it here.
   const packagePaths = [
@@ -122,7 +122,7 @@ test("workspace package versions agree on v0.3.4", () => {
 
   assert.deepEqual(
     versions.map(({ version }) => version),
-    packagePaths.map(() => "0.3.4"),
+    packagePaths.map(() => "0.3.5"),
   );
 });
 


### PR DESCRIPTION
## Summary

- bump every workspace package to 0.3.5
- add the 0.3.5 changelog entry for changes since v0.3.4
- update packaging version assertions

## Verification

- `./scripts/verify.sh`
- inspected expanded, compact, peek, key-slot, speaking, and muted fixture evidence
- physical-notch check not performed

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32431337422/artifacts/9429187718) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32431337422)

- Commit: `80eace9cd68d388034a3ad7e290d7b4b59893940`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
