### PR TITLE
feat(voice): let an open ask name the app it lands in

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1700,6 +1700,29 @@ export function App(): React.JSX.Element {
   );
 
   /**
+   * The same spoken press aimed at one app mark, for an open ask that named
+   * the app: the same bridge call the mark's own button makes, standing the
+   * panel down on the same terms as {@link openSessionAloud}.
+   */
+  const openSessionApplicationAloud = useCallback(
+    async (
+      identity: SessionIdentity,
+      applicationId: SessionApplicationId,
+    ): Promise<SessionOpenResult> => {
+      const result = await window.sidecar.openSessionApplication(identity, applicationId);
+      if (
+        result.status === SESSION_OPEN_RESULT_STATUS.OPENED &&
+        presentationOf() === PANEL_PRESENTATION.PANEL
+      ) {
+        cancelHover();
+        void changeMode(false);
+      }
+      return result;
+    },
+    [cancelHover, changeMode, presentationOf],
+  );
+
+  /**
    * The ask key, pressed anywhere on the system. The main process has already
    * stood the panel up focused; what is left is the caret — or the dismissal,
    * because a summons repeated over its own open field is someone asking the
@@ -2063,6 +2086,7 @@ export function App(): React.JSX.Element {
     fixtureSpeaking,
     capturingShortcut: () => shortcutCapture.current,
     openSession: openSessionAloud,
+    openSessionApplication: openSessionApplicationAloud,
     carryAppAction,
   });
 

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -349,7 +349,11 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "preferred exact destination. A local Conductor chat or an Orca worktree exposes no " +
         "documented exact address or message endpoint, so each of those marks identifies the " +
         "association but adds no open or send control; a cmux chat takes no message or " +
-        "control through cmux either — its mark opens the pane, nothing more.",
+        "control through cmux either — its mark opens the pane, nothing more. An ask in " +
+        "conversation, spoken or typed, opens the same destinations the row offers: the row's " +
+        "own preferred address by default, or — when the chat appears in more than one app and " +
+        "the ask names one whose mark is a button — that app's exact address instead, so the " +
+        "developer picks where a chat held by several apps comes forward.",
     },
     {
       label: "Searching sessions",

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -23,6 +23,7 @@ import {
   type NormalizedSession,
   type ObservedWorkspaceProject,
   SESSION_MENTION_KIND,
+  type SessionApplicationId,
   type SessionIdentity,
   type SessionMention,
 } from "@sidecar/session";
@@ -408,6 +409,14 @@ export interface VoiceConversationOptions {
    */
   openSession: (identity: SessionIdentity) => Promise<SessionOpenResult>;
   /**
+   * The spoken form of pressing one app mark on a row, for an open that named
+   * the app. Passed in on the same terms as {@link openSession}.
+   */
+  openSessionApplication: (
+    identity: SessionIdentity,
+    applicationId: SessionApplicationId,
+  ) => Promise<SessionOpenResult>;
+  /**
    * The spoken asks about Luke himself. Passed in on the same terms as
    * {@link openSession}.
    */
@@ -663,7 +672,10 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
             window.sidecar.renameSessionWorkspace(act.identity, act.name),
           [SESSION_TOOL_KIND.RENAME_SESSION]: (act) =>
             window.sidecar.renameSession(act.identity, act.name),
-          [SESSION_TOOL_KIND.OPEN]: (act) => optionsRef.current.openSession(act.identity),
+          [SESSION_TOOL_KIND.OPEN]: (act) =>
+            act.applicationId
+              ? optionsRef.current.openSessionApplication(act.identity, act.applicationId)
+              : optionsRef.current.openSession(act.identity),
           [SESSION_TOOL_KIND.READ_TRANSCRIPT]: (act) =>
             window.sidecar.readSessionTranscript(act.identity),
         });

--- a/packages/realtime/src/conversation-history.test.ts
+++ b/packages/realtime/src/conversation-history.test.ts
@@ -3,6 +3,8 @@ import test from "node:test";
 import {
   ATTENTION_DISPOSITION,
   normalizeSession,
+  SESSION_APPLICATION_ID,
+  SESSION_APPLICATION_SCOPE,
   SESSION_STATUS,
   type SessionControl,
 } from "@sidecar/session";
@@ -118,6 +120,36 @@ test("an act's line records the ask in words, with the identity it named", () =>
     sessionActConversationEntry({ kind: SESSION_TOOL_KIND.OPEN, identity }, []).words,
     "opened a session",
   );
+
+  // An open that picked an app records where it landed, under the display
+  // name the roster listed — or the bare id when the roster has let it go.
+  const heldByApp = normalizeSession(
+    { id: "claude-code", displayName: "Claude Code" },
+    {
+      providerSessionId: "session-a",
+      title: "checkout-service",
+      status: SESSION_STATUS.WORKING,
+      observedAt: OBSERVED_AT,
+      applications: [
+        {
+          id: SESSION_APPLICATION_ID.SUPERSET,
+          displayName: "Superset",
+          scope: SESSION_APPLICATION_SCOPE.SESSION,
+          link: "superset://v2-workspace/workspace-1",
+        },
+      ],
+    },
+  );
+  const openedInApp = {
+    kind: SESSION_TOOL_KIND.OPEN,
+    identity,
+    applicationId: SESSION_APPLICATION_ID.SUPERSET,
+  } as const;
+  assert.equal(
+    sessionActConversationEntry(openedInApp, [heldByApp]).words,
+    'opened "checkout-service" in Superset',
+  );
+  assert.equal(sessionActConversationEntry(openedInApp, []).words, "opened a session in superset");
 
   // A workspace creation aims at no session, so its line carries no identity.
   const created = sessionActConversationEntry(

--- a/packages/realtime/src/conversation-history.ts
+++ b/packages/realtime/src/conversation-history.ts
@@ -14,7 +14,7 @@
  * answered with — and the record lives in memory alone, dying with the app.
  */
 
-import type { NormalizedSession, SessionIdentity } from "@sidecar/session";
+import type { NormalizedSession, SessionApplicationId, SessionIdentity } from "@sidecar/session";
 import { type AttentionSpeech, announcementSummaryText } from "./realtime-protocol.js";
 import { type CarriedSessionAction, dispatchByKind, SESSION_TOOL_KIND } from "./realtime-tools.js";
 
@@ -142,6 +142,28 @@ function sessionName(identity: SessionIdentity, sessions: readonly NormalizedSes
 }
 
 /**
+ * How the app an open landed in is named inside a history line: the display
+ * name the roster listed it under. The id stands in only for a session the
+ * roster no longer reports — the line is written at the act, so that is a
+ * session retired between the ask and the record.
+ */
+function applicationName(
+  identity: SessionIdentity,
+  applicationId: SessionApplicationId,
+  sessions: readonly NormalizedSession[],
+): string {
+  const session = sessions.find(
+    (candidate) =>
+      candidate.providerId === identity.providerId &&
+      candidate.providerSessionId === identity.providerSessionId,
+  );
+  return (
+    session?.applications.find((application) => application.id === applicationId)?.displayName ??
+    applicationId
+  );
+}
+
+/**
  * The history line one carried act leaves behind: the ask, in the words of
  * what was asked — never the outcome, which the reply voicing it records as
  * its own line. A transcript reading is deliberately only the fact that one
@@ -156,7 +178,10 @@ export function sessionActConversationEntry(
   const describe = {
     [SESSION_TOOL_KIND.MESSAGE]: (act) => `sent a message to ${name}: "${act.text}"`,
     [SESSION_TOOL_KIND.CONTROL]: (act) => `ran "${act.control.label}" on ${name}`,
-    [SESSION_TOOL_KIND.OPEN]: () => `opened ${name}`,
+    [SESSION_TOOL_KIND.OPEN]: (act) =>
+      act.applicationId
+        ? `opened ${name} in ${applicationName(act.identity, act.applicationId, sessions)}`
+        : `opened ${name}`,
     [SESSION_TOOL_KIND.NOTICE_REQUEST]: (act) =>
       `remembered a standing ask about ${name}: "${act.request}"`,
     [SESSION_TOOL_KIND.NOTICE_WITHDRAW]: () => `withdrew the standing ask about ${name}`,

--- a/packages/realtime/src/realtime-context.ts
+++ b/packages/realtime/src/realtime-context.ts
@@ -30,13 +30,25 @@ export const maximumVoiceContextSessions = 25;
 /**
  * What one session can be asked to do, said in the roster so Luke offers only
  * what its provider promised: the identity a tool call must name, whether it
- * takes a message, and each advertised control with the id a call names it by.
+ * takes a message, each advertised control with the id a call names it by,
+ * and each app whose exact address an open ask may pick — by name alone,
+ * because the address behind it stays on the machine.
  */
 function sessionCapabilityText(session: NormalizedSession): string {
+  const openableApplications = session.applications.filter(
+    (application) => application.link !== undefined,
+  );
   const capabilities = [
     `provider_id=${session.providerId} provider_session_id=${session.providerSessionId}`,
     `messages=${session.canReceiveMessage}`,
     `open=${Boolean(session.detail.link)}`,
+    ...(openableApplications.length > 0
+      ? [
+          `opens_in=${openableApplications
+            .map((application) => application.displayName)
+            .join(", ")}`,
+        ]
+      : []),
     `transcript=${session.location === SESSION_LOCATION.LOCAL}`,
     ...(session.detail.change ? ["pull_request=true"] : []),
     ...(session.controls.length > 0

--- a/packages/realtime/src/realtime-tools.ts
+++ b/packages/realtime/src/realtime-tools.ts
@@ -42,6 +42,7 @@ import {
   type TrackedIssue,
 } from "@sidecar/issues";
 import {
+  isSessionApplicationId,
   matchesFilterSelection,
   maximumSessionMessageLength,
   maximumWorkspaceNameLength,
@@ -50,6 +51,7 @@ import {
   PROVIDER_ID_LIST,
   SESSION_APPLICATION_ID,
   SESSION_LOCATION,
+  type SessionApplicationId,
   type SessionControl,
   type SessionIdentity,
   sessionMessageText,
@@ -145,7 +147,12 @@ const SESSION_LIST_FILTER_DESCRIPTION =
 export type SessionToolAction =
   | { kind: typeof SESSION_TOOL_KIND.MESSAGE; identity: SessionIdentity; text: string }
   | { kind: typeof SESSION_TOOL_KIND.CONTROL; identity: SessionIdentity; control: SessionControl }
-  | { kind: typeof SESSION_TOOL_KIND.OPEN; identity: SessionIdentity }
+  | {
+      kind: typeof SESSION_TOOL_KIND.OPEN;
+      identity: SessionIdentity;
+      /** The one app the developer named to open it in, resolved to its id. */
+      applicationId?: SessionApplicationId;
+    }
   | { kind: typeof SESSION_TOOL_KIND.NOTICE_REQUEST; identity: SessionIdentity; request: string }
   | { kind: typeof SESSION_TOOL_KIND.NOTICE_WITHDRAW; identity: SessionIdentity }
   | { kind: typeof SESSION_TOOL_KIND.READ_TRANSCRIPT; identity: SessionIdentity }
@@ -486,8 +493,36 @@ function validateOpenSession(parsed: WireRecord, context: SessionToolContext): S
   const found = sessionFromArguments(parsed, context.sessions);
   if ("kind" in found) return found;
   const { session, identity } = found;
-  // The action carries the identity, never the address: the main process
-  // reads the link back out of its own registry, the same as a pressed row.
+  // The action carries the identity — and, when the developer named an app,
+  // that app's id — never the address: the main process reads the link back
+  // out of its own registry, the same as a pressed row or a pressed app mark.
+  const applicationWord = textArgument(parsed, "application");
+  if (applicationWord !== undefined) {
+    const normalized = applicationWord.trim().toLowerCase();
+    const application = session.applications.find(
+      (candidate) =>
+        candidate.displayName.toLowerCase() === normalized || candidate.id === normalized,
+    );
+    // An association without an exact address identifies the app but opens
+    // nothing, so it refuses like an app the roster never listed — and the
+    // refusal names the apps that can open, which the roster already carries.
+    // The id must be one the build fixed: the bridge takes no other, and the
+    // main process would refuse it again.
+    const applicationId = application?.link ? application.id : undefined;
+    if (applicationId === undefined || !isSessionApplicationId(applicationId)) {
+      const openable = session.applications.filter((candidate) => candidate.link);
+      return {
+        kind: "refused",
+        reason:
+          openable.length > 0
+            ? `That session opens in ${openable
+                .map((candidate) => candidate.displayName)
+                .join(" or ")}, not there.`
+            : "No app carries an exact address for that session.",
+      };
+    }
+    return { kind: SESSION_TOOL_KIND.OPEN, identity, applicationId };
+  }
   if (!session.detail.link) {
     return { kind: "refused", reason: "That session has no address to open." };
   }
@@ -1054,7 +1089,15 @@ export const REALTIME_TOOLS = {
         "show_panel instead, never this.",
       parameters: {
         type: "object",
-        properties: { ...SESSION_IDENTITY_PARAMETERS },
+        properties: {
+          ...SESSION_IDENTITY_PARAMETERS,
+          application: {
+            type: "string",
+            description:
+              "The app to open the session in, as its roster line's opens_in lists it — only " +
+              "when the developer named one. Omitted, the session opens at its own address.",
+          },
+        },
         required: ["provider_id", "provider_session_id"],
       },
     },

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -743,6 +743,9 @@ test("the roster names a session's app associations, so 'my cmux Cursor session'
   assert.match(text, /associated with cmux/);
   // The association travels by name alone; the pane address stays on the machine.
   assert.doesNotMatch(text, /cmux:\/\//);
+  // An association with an exact address is one an open ask may name, so the
+  // capability line lists it — by the same name, and never the address.
+  assert.match(text, /opens_in=cmux/);
 
   // A session no app claimed says nothing about associations at all.
   const unclaimed = normalizeSession(
@@ -755,6 +758,29 @@ test("the roster names a session's app associations, so 'my cmux Cursor session'
     },
   );
   assert.doesNotMatch(sessionContextText([unclaimed]), /associated with/);
+  assert.doesNotMatch(sessionContextText([unclaimed]), /opens_in/);
+
+  // An association without an address identifies the app but opens nothing,
+  // so it rides the association line and stays off the capability line.
+  const identifiedOnly = normalizeSession(
+    { id: "claude-code", displayName: "Claude Code" },
+    {
+      providerSessionId: "session-3",
+      title: "Rework the roster",
+      status: SESSION_STATUS.WORKING,
+      observedAt: DECIDED_AT,
+      applications: [
+        {
+          id: SESSION_APPLICATION_ID.ORCA,
+          displayName: "Orca",
+          scope: SESSION_APPLICATION_SCOPE.WORKSPACE,
+        },
+      ],
+    },
+  );
+  const identifiedText = sessionContextText([identifiedOnly]);
+  assert.match(identifiedText, /associated with Orca/);
+  assert.doesNotMatch(identifiedText, /opens_in/);
 });
 
 test("the roster names a hosted chat by its agent, with the host beside it", () => {
@@ -1363,6 +1389,65 @@ test("a tool call can act only on a session Luke was shown, doing what it advert
     [cloudSession],
   );
   assert.equal(nothingToRead.kind, "refused");
+});
+
+test("an open ask can pick the app, held to the roster's own associations", () => {
+  const held = normalizeSession(
+    { id: "codex", displayName: "Codex" },
+    {
+      providerSessionId: "thread-2",
+      title: "Codex: luke",
+      status: SESSION_STATUS.WAITING,
+      observedAt: DECIDED_AT,
+      detail: { link: "codex://thread/thread-2" },
+      applications: [
+        {
+          id: SESSION_APPLICATION_ID.SUPERSET,
+          displayName: "Superset",
+          scope: SESSION_APPLICATION_SCOPE.SESSION,
+          link: "superset://v2-workspace/workspace-1?terminalId=terminal-1",
+        },
+        {
+          id: SESSION_APPLICATION_ID.ORCA,
+          displayName: "Orca",
+          scope: SESSION_APPLICATION_SCOPE.WORKSPACE,
+        },
+      ],
+    },
+  );
+  const identity = '"provider_id":"codex","provider_session_id":"thread-2"';
+
+  // The developer's word for the app resolves to the build's id — by display
+  // name in any case, or by the id itself — and the action carries that id,
+  // never the address behind it.
+  assert.deepEqual(
+    sessionToolAction(
+      messageCall(`{${identity},"application":"superset"}`, REALTIME_TOOL.OPEN_SESSION),
+      [held],
+    ),
+    {
+      kind: "open",
+      identity: { providerId: "codex", providerSessionId: "thread-2" },
+      applicationId: SESSION_APPLICATION_ID.SUPERSET,
+    },
+  );
+
+  // An ask that names no app keeps the row's own destination.
+  assert.deepEqual(
+    sessionToolAction(messageCall(`{${identity}}`, REALTIME_TOOL.OPEN_SESSION), [held]),
+    { kind: "open", identity: { providerId: "codex", providerSessionId: "thread-2" } },
+  );
+
+  // An association without an address opens nothing, and an app the roster
+  // never listed opens nothing; each refusal says where the session does open.
+  for (const application of ["Orca", "TextEdit"]) {
+    const refusal = sessionToolAction(
+      messageCall(`{${identity},"application":"${application}"}`, REALTIME_TOOL.OPEN_SESSION),
+      [held],
+    );
+    assert.equal(refusal.kind, "refused");
+    assert.match("reason" in refusal ? refusal.reason : "", /opens in Superset/);
+  }
 });
 
 const OFFERED_PROJECT: ObservedWorkspaceProject = {


### PR DESCRIPTION
## What

A chat held by several apps — a Codex thread appearing in ChatGPT, Superset, and cmux at once — could only be opened at its row's own preferred address when asked of Luke in conversation: the per-app routes existed solely as the row's mark buttons, and #352 had put the app names into the spoken roster with no way to open a named one. Now the developer can pick where a chat comes forward.

- `open_session` takes an optional `application` word, resolved case-insensitively against the session's observed app associations by display name or id. An association without an exact address, an id outside the build's set, or an app the roster never listed refuses — naming the apps that *can* open, which the roster already carries.
- The validated action carries the app's id, never the address: the renderer dispatches it over the same `openSessionApplication` bridge the row's mark buttons press, and the main process reads the normalized route back out of its own registry, exactly as before.
- The roster's capability line lists each openable app by name (`opens_in=ChatGPT, Superset`) — names alone; the addresses stay on the machine, as the association line already keeps them.
- The conversation history records where an open landed (`opened "…" in Superset`), and the guide's "Apps beside a session" entry teaches the new ask.

## Trust boundaries

No new write path and no widening: opening remains a read of an observed address handed to the operating system, only in a developer-opened turn, validated against the observed roster in the renderer and again in the main process. The one change is which of a session's *already-observed* addresses the ask selects — the same choice a pressed app mark has always made by hand.

## Verification

- `./scripts/check.sh` passes (exit 0).
- `./scripts/verify.sh` not run locally (Linux cloud workspace); the macOS CI job stands in. No visual surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/e58d0df0-3343-45ad-ab0d-03996b4cfb23)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32432166375/artifacts/9429487968) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32432166375)

- Commit: `96c89d7b6d6ac77a4a842b999852acfc89421968`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
