### PR TITLE
fix(release): sign nested helpers once

### DIFF
--- a/apps/desktop/scripts/electron-builder-config.mjs
+++ b/apps/desktop/scripts/electron-builder-config.mjs
@@ -94,7 +94,7 @@ export function createElectronBuilderConfig(env = process.env) {
       entitlements: packageAssets.entitlementsPath,
       entitlementsInherit: packageAssets.entitlementsPath,
       minimumSystemVersion: MACOS_DEPLOYMENT_TARGET,
-      binaries: NATIVE_HELPERS.map(macBinaryPath),
+      binaries: NATIVE_HELPERS.filter((helper) => !helper.bundle).map(macBinaryPath),
       extendInfo: {
         CFBundleName: productName,
         CFBundleDisplayName: productName,

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -248,12 +248,15 @@ test("every native helper is built and shipped, or neither happens", () => {
       builderShipped.some((resourcePath) => resourcePath.endsWith(helper.bundle ?? helper.binary)),
       `${helper.binary} reaches the electron-builder bundle`,
     );
-    const signedPath = helper.bundle
-      ? path.join(helper.bundle, "Contents", "MacOS", helper.binary)
-      : helper.binary;
-    assert.ok(
-      builderBinaries.some((resourcePath) => resourcePath.endsWith(signedPath)),
-      `${helper.binary} is signed by electron-builder`,
+    const explicitlySigned = builderBinaries.some((resourcePath) =>
+      resourcePath.endsWith(helper.binary),
+    );
+    assert.equal(
+      explicitlySigned,
+      helper.bundle === undefined,
+      helper.bundle
+        ? `${helper.bundle} is signed as a nested app bundle, not again as a loose binary`
+        : `${helper.binary} is signed explicitly by electron-builder`,
     );
     // A spawned helper is a Swift executable; an in-process addon is
     // Objective-C, loaded through Node-API, and named so the loader can tell.


### PR DESCRIPTION
## Summary

- keep bundled native helpers out of electron-builder’s loose-binary signing list
- preserve explicit signing for standalone native helpers
- lock the nested-app signing boundary into the packaging regression test

## Root cause

The builder listed the Calendar helper’s nested `Luke.app` executable in `mac.binaries`, even though electron-builder already discovers and signs nested app bundles. A real Developer ID build later attempted the explicit path after processing the bundle and failed with `No such file or directory`.

## Verification

- `node --test scripts/packaging.test.mjs`
- `./scripts/verify.sh`
- inspected expanded, compact, peek, key-slot, speaking, and muted fixture evidence
- physical-notch check not performed

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32432542705/artifacts/9429618189) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32432542705)

- Commit: `4668e2a4a112f1a1191312a4173e336739ea3dc1`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
