### PR TITLE
fix(updates): shorten ready-to-install status copy

### DIFF
--- a/apps/desktop/src/renderer/update-row.test.ts
+++ b/apps/desktop/src/renderer/update-row.test.ts
@@ -49,8 +49,7 @@ test("a download under way names the version and how far along it is", () => {
 test("a downloaded build offers the restart that installs it", () => {
   const row = updateRow(supported({ status: UPDATE_STATUS.READY, latestVersion: "0.2.0" }));
   assert.equal(row.action, UPDATE_ROW_ACTION.RESTART);
-  assert.ok(row.detail.includes("Restart"), "the row says a restart finishes the update");
-  assert.ok(row.detail.includes("quit"), "the row says quitting installs it too");
+  assert.equal(row.detail, "Version 0.2.0 is downloaded.");
   assert.equal(row.current, false);
 });
 

--- a/apps/desktop/src/renderer/update-row.ts
+++ b/apps/desktop/src/renderer/update-row.ts
@@ -76,9 +76,7 @@ export function updateRow(update: UpdateSnapshot): UpdateRow {
       };
     case UPDATE_STATUS.READY:
       return {
-        detail:
-          `Version ${update.latestVersion} is downloaded. Restart Luke to finish ` +
-          "installing — or it installs on your next quit.",
+        detail: `Version ${update.latestVersion} is downloaded.`,
         action: UPDATE_ROW_ACTION.RESTART,
         current: false,
       };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Shorten the Ready-to-install Updates row from “Version {latestVersion} is downloaded. Restart Luke to finish installing — or it installs on your next quit.” to **“Version {latestVersion} is downloaded.”**
- The button remains **Restart to update**; the status line no longer repeats the restart/quit instructions.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (lint, typecheck, tests, build)
- macOS Electron verification (`./scripts/verify.sh`): `not run` (Linux cloud agent; no macOS)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32433840524/artifacts/9430061477) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32433840524)

- Commit: `57e27a1e84a2cdb4d0be4051ae7793eb27b34711`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Copy-only change. Physical-notch check was not performed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f253682d-8f15-4e44-a365-b01238d41743?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f253682d-8f15-4e44-a365-b01238d41743&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

