### PR TITLE
fix: skip waiting announcements when a chat does not need a reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ the date its release was published.
 
 - Fixed Developer ID releases failing while signing the nested Calendar helper
   ([#370](https://github.com/ReviewStage/luke/pull/370))
+- Fixed spoken announcements calling a settled chat "waiting on you" when it
+  did not need a reply
 
 ## 0.3.5 — 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ the date its release was published.
   ([#370](https://github.com/ReviewStage/luke/pull/370))
 - Fixed spoken announcements calling a settled chat "waiting on you" when it
   did not need a reply
+  ([#374](https://github.com/ReviewStage/luke/pull/374))
 
 ## 0.3.5 — 2026-08-20
 

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -568,8 +568,9 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
             // denies announcing nor offers to turn it off.
             label: "Announcements",
             detail:
-              "Luke says it out loud when an observed session starts waiting on the developer, " +
-              "stops on an error, or finishes — in his own words, naming the session and saying " +
+              "Luke says it out loud when an observed session is holding for you, stops on an " +
+              "error, or finishes — a hold is a question, a permission, or an approval, not a " +
+              "turn that merely ended — in his own words, naming the session and saying " +
               "what it needs, from the agent's parting words or the provider's error line when " +
               "one was reported. No conversation needs to be open, and the microphone stays " +
               "off. While he says it, a pressable notice names the session he is talking " +

--- a/packages/attention/src/attention-prompt.ts
+++ b/packages/attention/src/attention-prompt.ts
@@ -20,6 +20,7 @@ const ATTENTION_INSTRUCTION_LINES: readonly string[] = [
   "Decide whether Luke should speak about a coding-agent session update.",
   "- Default to silence when the update is routine, ambiguous, or merely continues work already underway.",
   "- A session waiting on automation it set in motion — CI, a merge queue, a watcher it left running — is not waiting on the developer: nothing they reply can move it, so stay silent and let the automation's outcome be the development.",
+  "- A waiting status means the turn has stopped, not that the developer must reply. Speak only when the recap or context shows the session cannot continue without them — a question, a permission, or an approval. A settled turn that merely leaves the next prompt to them is silence.",
   "- When a user's standing ask is answered, speak and set answers_ask to true; otherwise set it to false.",
 ];
 

--- a/packages/providers/src/claude-code/adapter.test.ts
+++ b/packages/providers/src/claude-code/adapter.test.ts
@@ -77,6 +77,7 @@ test("observes a Claude Code session file and labels it by its workspace", async
   assert.equal(observations[0]?.providerSessionId, "session-waiting");
   assert.equal(observations[0]?.title, "luke");
   assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
+  assert.equal(observations[0]?.holdingForDeveloper, undefined);
   assert.equal(observations[0]?.controls, undefined);
   assert.equal(observations[0]?.detail?.repository, "luke");
 });
@@ -1065,6 +1066,7 @@ test("a permission prompt the transcript cannot show turns the row to waiting", 
   const [observation] = await adapter.observe();
 
   assert.equal(observation?.status, SESSION_STATUS.WAITING);
+  assert.equal(observation?.holdingForDeveloper, true);
   // The event also dates the session: the spool is written only by Luke's own
   // script, so its clock cannot suffer the transcripts' bulk-touch problem.
   assert.equal(observation?.observedAt, TEST_TIME - 60_000);

--- a/packages/providers/src/claude-code/adapter.ts
+++ b/packages/providers/src/claude-code/adapter.ts
@@ -537,6 +537,11 @@ function observationFromSessionFile(
     observedAt,
     ...(parsed.awaySummary ? { recap: parsed.awaySummary } : undefined),
     detail: detailFromTail(parsed),
+    ...(status === SESSION_STATUS.WAITING &&
+    eventStands &&
+    hookEvent?.event === CLAUDE_HOOK_EVENT.NOTIFICATION
+      ? { holdingForDeveloper: true }
+      : undefined),
   };
 }
 

--- a/packages/providers/src/codex/adapter.test.ts
+++ b/packages/providers/src/codex/adapter.test.ts
@@ -1343,6 +1343,7 @@ test("a permission request the database cannot show turns the row to waiting", a
   const [observation] = await adapter.observe();
 
   assert.equal(observation?.status, SESSION_STATUS.WAITING);
+  assert.equal(observation?.holdingForDeveloper, true);
   // The event also dates the session: the spool is written only by Luke's own
   // script, so its clock is the moment the session actually moved.
   assert.equal(observation?.observedAt, TEST_TIME - 60_000);

--- a/packages/providers/src/codex/adapter.ts
+++ b/packages/providers/src/codex/adapter.ts
@@ -767,6 +767,11 @@ function observationFromThreadRow(
     ...(rollout?.lastAgentMessage ? { recap: rollout.lastAgentMessage } : undefined),
     detail,
     ...(detail.link ? { applications: [chatGptApplication(detail.link)] } : undefined),
+    ...(status === SESSION_STATUS.WAITING &&
+    eventStands &&
+    hookEvent?.event === CODEX_HOOK_EVENT.NOTIFICATION
+      ? { holdingForDeveloper: true }
+      : undefined),
   };
   if (isCodexRealtimeDelegationThread(row)) observation.realtimeVoice = true;
   if (rollout?.realtimeVoiceLive === true) observation.realtimeVoiceLive = true;

--- a/packages/providers/src/conductor/adapter.ts
+++ b/packages/providers/src/conductor/adapter.ts
@@ -267,9 +267,11 @@ type ConductorSessionStatus =
 
 /**
  * An idle Conductor session has finished its turn and is holding for the user,
- * which is what Luke reports as waiting. A session the provider reports as
- * errored stopped on something the user has to deal with, and it carries the
- * message that says what.
+ * which is what Luke reports as waiting on the row. That is not itself an
+ * ask: a waiting notice still needs the recap to ask, because a settled turn
+ * that merely leaves the next prompt to them is silence. A session the
+ * provider reports as errored stopped on something the user has to deal with,
+ * and it carries the message that says what.
  */
 const SESSION_STATUS_BY_CONDUCTOR_STATUS = {
   [CONDUCTOR_SESSION_STATUS.IDLE]: SESSION_STATUS.WAITING,

--- a/packages/providers/src/copilot/adapter.test.ts
+++ b/packages/providers/src/copilot/adapter.test.ts
@@ -245,6 +245,12 @@ test("maps every state GitHub reports onto a state Luke can show", async () => {
       ["task-later-state", SESSION_STATUS.UNKNOWN],
     ],
   );
+  assert.deepEqual(
+    observations
+      .filter((observation) => observation.holdingForDeveloper === true)
+      .map((observation) => observation.providerSessionId),
+    ["task-waiting"],
+  );
 });
 
 // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.

--- a/packages/providers/src/copilot/adapter.ts
+++ b/packages/providers/src/copilot/adapter.ts
@@ -257,13 +257,15 @@ export class CopilotSessionAdapter extends CloudSessionAdapter {
   }
 
   #observationFor(task: CopilotTask, now: number): ProviderSessionObservation {
+    const status = this.#statusFor(task, now);
     return {
       providerSessionId: task.id,
       // The provider is already on the row as its mark and in the context line,
       // so the title carries only what tells one Copilot task from another.
       title: task.repositoryLabel,
-      status: this.#statusFor(task, now),
+      status,
       observedAt: task.observedAt,
+      ...(status === SESSION_STATUS.WAITING ? { holdingForDeveloper: true } : undefined),
       detail: {
         repository: task.repositoryLabel,
         ...(task.branch ? { branch: task.branch } : undefined),

--- a/packages/providers/src/devin/adapter.test.ts
+++ b/packages/providers/src/devin/adapter.test.ts
@@ -435,6 +435,12 @@ test("maps the states Devin reports onto states Luke can show", async () => {
       ["devin-later-state", SESSION_STATUS.UNKNOWN],
     ],
   );
+  assert.deepEqual(
+    observations
+      .filter((observation) => observation.holdingForDeveloper === true)
+      .map((observation) => observation.providerSessionId),
+    ["devin-waiting-user", "devin-waiting-approval"],
+  );
 });
 
 // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.

--- a/packages/providers/src/devin/adapter.ts
+++ b/packages/providers/src/devin/adapter.ts
@@ -446,6 +446,10 @@ export class DevinSessionAdapter extends CloudSessionAdapter {
 
   #observationFor(session: DevinSession, now: number): ProviderSessionObservation {
     const status = this.#statusFor(session, now);
+    const holdingForDeveloper =
+      status === SESSION_STATUS.WAITING &&
+      (session.detail === DEVIN_RUNNING_DETAIL.WAITING_FOR_USER ||
+        session.detail === DEVIN_RUNNING_DETAIL.WAITING_FOR_APPROVAL);
     return {
       providerSessionId: session.id,
       // What Devin named it, then where the work landed. The adapter reports
@@ -453,6 +457,7 @@ export class DevinSessionAdapter extends CloudSessionAdapter {
       title: session.name ?? session.repository ?? UNKNOWN_SESSION_LABEL,
       status,
       observedAt: session.observedAt,
+      ...(holdingForDeveloper ? { holdingForDeveloper: true } : undefined),
       canReceiveMessage: this.#sessionTakesMessages(session),
       ...(this.#sessionTakesArchive(session)
         ? { controls: [DEVIN_ARCHIVE_SESSION_CONTROL] }

--- a/packages/providers/src/gemini-cli/adapter.test.ts
+++ b/packages/providers/src/gemini-cli/adapter.test.ts
@@ -236,6 +236,7 @@ test("reports a tool call holding for approval as waiting", async (t) => {
   const observations = await adapter.observe();
 
   assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
+  assert.equal(observations[0]?.holdingForDeveloper, true);
 });
 
 test("reports the error that stopped a session", async (t) => {

--- a/packages/providers/src/gemini-cli/adapter.ts
+++ b/packages/providers/src/gemini-cli/adapter.ts
@@ -360,13 +360,17 @@ export class GeminiCliSessionAdapter extends LocalFileSessionAdapter<
     // mtimes the way any bulk touch would. The file's date remains the
     // fallback for a slice holding no conversation stamp at all.
     const observedAt = parsed.timestampMs ?? candidate.mtimeMs;
+    const status = statusFromTail(parsed, observedAt, now, activeSessionFreshnessMs);
     return {
       providerSessionId: candidate.providerSessionId,
       title: titleFromTail(parsed, workspace),
-      status: statusFromTail(parsed, observedAt, now, activeSessionFreshnessMs),
+      status,
       observedAt,
       ...(parsed.recap ? { recap: parsed.recap } : undefined),
       detail: detailFromTail(parsed, workspace),
+      ...(status === SESSION_STATUS.WAITING && parsed.holdingForApproval === true
+        ? { holdingForDeveloper: true }
+        : undefined),
     };
   }
 

--- a/packages/providers/src/jules/adapter.test.ts
+++ b/packages/providers/src/jules/adapter.test.ts
@@ -260,6 +260,12 @@ test("maps every state Jules reports onto a state Luke can show", async () => {
       ["session-later-state", SESSION_STATUS.UNKNOWN],
     ],
   );
+  assert.deepEqual(
+    observations
+      .filter((observation) => observation.holdingForDeveloper === true)
+      .map((observation) => observation.providerSessionId),
+    ["session-awaiting-plan", "session-awaiting-feedback", "session-paused"],
+  );
 });
 
 // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.

--- a/packages/providers/src/jules/adapter.ts
+++ b/packages/providers/src/jules/adapter.ts
@@ -264,6 +264,7 @@ export class JulesSessionAdapter extends CloudSessionAdapter {
       status,
       observedAt: session.observedAt,
       canReceiveMessage: session.state !== undefined && JULES_MESSAGEABLE_STATES.has(session.state),
+      ...(status === SESSION_STATUS.WAITING ? { holdingForDeveloper: true } : undefined),
       ...(session.state === JULES_STATE.AWAITING_PLAN_APPROVAL
         ? { controls: [JULES_APPROVE_PLAN_CONTROL] }
         : undefined),

--- a/packages/session/src/session-notices.test.ts
+++ b/packages/session/src/session-notices.test.ts
@@ -296,6 +296,23 @@ test("a waiting recap that only has a URL query string is not an ask", () => {
   );
 });
 
+test("a question that ends on a URL is still an ask", () => {
+  const tracker = new SessionNoticeTracker();
+  tracker.notices([session(conductor, "ask", SESSION_STATUS.WORKING)], 1_000);
+
+  const notices = tracker.notices(
+    [
+      session(conductor, "ask", SESSION_STATUS.WAITING, {
+        recap: "Should I open https://github.com/review/luke/pull/12?",
+      }),
+    ],
+    2_000,
+  );
+
+  assert.equal(notices.length, 1);
+  assert.equal(notices[0]?.status, SESSION_NOTICE_STATUS.WAITING);
+});
+
 test("a permission hold is a waiting notice even without a question in the recap", () => {
   const tracker = new SessionNoticeTracker();
   tracker.notices([session(claude, "held", SESSION_STATUS.WORKING)], 1_000);

--- a/packages/session/src/session-notices.test.ts
+++ b/packages/session/src/session-notices.test.ts
@@ -32,6 +32,7 @@ function session(
     recap?: string;
     workspace?: string;
     canReceiveMessage?: boolean;
+    holdingForDeveloper?: boolean;
     realtimeVoiceLive?: boolean;
     completionCause?: (typeof SESSION_COMPLETION_CAUSE)[keyof typeof SESSION_COMPLETION_CAUSE];
   } = {},
@@ -50,6 +51,9 @@ function session(
   }
   if (overrides.canReceiveMessage !== undefined) {
     observation.canReceiveMessage = overrides.canReceiveMessage;
+  }
+  if (overrides.holdingForDeveloper !== undefined) {
+    observation.holdingForDeveloper = overrides.holdingForDeveloper;
   }
   if (overrides.realtimeVoiceLive !== undefined) {
     observation.realtimeVoiceLive = overrides.realtimeVoiceLive;
@@ -154,7 +158,7 @@ test("every notice-worthy arrival is one, and the quiet statuses are not", () =>
 
   const notices = tracker.notices(
     [
-      session(claude, "waits", SESSION_STATUS.WAITING),
+      session(claude, "waits", SESSION_STATUS.WAITING, { holdingForDeveloper: true }),
       session(claude, "stops", SESSION_STATUS.ERROR, { error: "API rate limit" }),
       session(claude, "finishes", SESSION_STATUS.COMPLETE),
       // An adapter losing sight of a session is not the session asking for a hand.
@@ -254,14 +258,82 @@ test("the recap, workspace, and reply-ability ride a waiting notice", () => {
   assert.equal(notices[0]?.canReceiveMessage, true);
 });
 
+test("a waiting turn that does not need the developer produces no notice", () => {
+  const tracker = new SessionNoticeTracker();
+  tracker.notices([session(conductor, "idle", SESSION_STATUS.WORKING)], 1_000);
+
+  // Conductor idle is waiting on the row — the turn ended — but the parting
+  // words do not ask anything, so reading them out as "waiting on you" would
+  // be a false ask.
+  assert.deepEqual(
+    tracker.notices(
+      [
+        session(conductor, "idle", SESSION_STATUS.WAITING, {
+          recap: "The notch panel now follows the menu bar depth.",
+          canReceiveMessage: true,
+        }),
+      ],
+      2_000,
+    ),
+    [],
+  );
+});
+
+test("a waiting recap that only has a URL query string is not an ask", () => {
+  const tracker = new SessionNoticeTracker();
+  tracker.notices([session(conductor, "link", SESSION_STATUS.WORKING)], 1_000);
+
+  assert.deepEqual(
+    tracker.notices(
+      [
+        session(conductor, "link", SESSION_STATUS.WAITING, {
+          recap: "Opened https://github.com/review/luke/pull/12?w=1 for the panel follow.",
+        }),
+      ],
+      2_000,
+    ),
+    [],
+  );
+});
+
+test("a permission hold is a waiting notice even without a question in the recap", () => {
+  const tracker = new SessionNoticeTracker();
+  tracker.notices([session(claude, "held", SESSION_STATUS.WORKING)], 1_000);
+
+  const notices = tracker.notices(
+    [
+      session(claude, "held", SESSION_STATUS.WAITING, {
+        recap: "Editing the shared session core.",
+        holdingForDeveloper: true,
+      }),
+    ],
+    2_000,
+  );
+
+  assert.equal(notices.length, 1);
+  assert.equal(notices[0]?.status, SESSION_NOTICE_STATUS.WAITING);
+});
+
 test("a flapping status is noticed once per repeat window, then again after it", () => {
   const tracker = new SessionNoticeTracker();
   tracker.notices([session(claude, "flap", SESSION_STATUS.WORKING)], 0);
 
-  assert.equal(tracker.notices([session(claude, "flap", SESSION_STATUS.WAITING)], 1_000).length, 1);
+  assert.equal(
+    tracker.notices(
+      [session(claude, "flap", SESSION_STATUS.WAITING, { holdingForDeveloper: true })],
+      1_000,
+    ).length,
+    1,
+  );
   tracker.notices([session(claude, "flap", SESSION_STATUS.WORKING)], 2_000);
   // The same edge inside the window stays quiet.
-  assert.equal(tracker.notices([session(claude, "flap", SESSION_STATUS.WAITING)], 3_000).length, 0);
+  assert.equal(
+    tracker.notices(
+      [session(claude, "flap", SESSION_STATUS.WAITING, { holdingForDeveloper: true })],
+      3_000,
+    ).length,
+    0,
+  );
   tracker.notices([session(claude, "flap", SESSION_STATUS.WORKING)], 4_000);
   // A different status is its own ledger entry.
   assert.equal(tracker.notices([session(claude, "flap", SESSION_STATUS.ERROR)], 5_000).length, 1);
@@ -272,6 +344,7 @@ test("a flapping status is noticed once per repeat window, then again after it",
     tracker.notices(
       [
         session(claude, "flap", SESSION_STATUS.WAITING, {
+          holdingForDeveloper: true,
           observedAt: 1_000 + SESSION_NOTICE_REPEAT_WINDOW_MS,
         }),
       ],

--- a/packages/session/src/session-notices.ts
+++ b/packages/session/src/session-notices.ts
@@ -89,13 +89,17 @@ export interface SessionNotice {
  * without the developer. A provider that saw a permission, an approval, or
  * an open question says so on the observation; a recap that itself asks is
  * the same evidence when the adapter could not tell. A query string inside
- * a URL is not a question.
+ * a URL is not a question. A `?` that ends a sentence after a link still
+ * is: a query string has characters after the mark, and a trailing ask
+ * does not.
  */
 function waitingHoldsForDeveloper(session: NormalizedSession): boolean {
   if (session.status !== SESSION_STATUS.WAITING) return false;
   if (session.holdingForDeveloper === true) return true;
   if (!session.recap) return false;
-  return session.recap.replace(/\bhttps?:\/\/\S+/gi, "").includes("?");
+  return session.recap
+    .replace(/\bhttps?:\/\/[^\s?]+(?:\?[^\s#]+)?(?:#[^\s]+)?/gi, "")
+    .includes("?");
 }
 
 interface TrackedSessionState {

--- a/packages/session/src/session-notices.ts
+++ b/packages/session/src/session-notices.ts
@@ -84,6 +84,20 @@ export interface SessionNotice {
   observedAt: number;
 }
 
+/**
+ * A waiting banner is only worth hearing when the session cannot continue
+ * without the developer. A provider that saw a permission, an approval, or
+ * an open question says so on the observation; a recap that itself asks is
+ * the same evidence when the adapter could not tell. A query string inside
+ * a URL is not a question.
+ */
+function waitingHoldsForDeveloper(session: NormalizedSession): boolean {
+  if (session.status !== SESSION_STATUS.WAITING) return false;
+  if (session.holdingForDeveloper === true) return true;
+  if (!session.recap) return false;
+  return session.recap.replace(/\bhttps?:\/\/\S+/gi, "").includes("?");
+}
+
 interface TrackedSessionState {
   status: SessionStatus;
   /** When each notice-worthy status was last noticed, for the repeat window. */
@@ -122,7 +136,9 @@ function sessionNotice(session: NormalizedSession, previousStatus: SessionStatus
  * A watched edge speaks only while its event is fresh — the status's own
  * timestamp within `SESSION_NOTICE_FRESH_AGE_MS` of now — so a wake from
  * sleep or a provider back from an outage never reads out the afternoon's
- * history as though it just happened.
+ * history as though it just happened. A waiting edge is quieter still: the
+ * turn ending is not an ask, so it announces only when the session is
+ * holding for the developer.
  * Deterministic by construction — nothing a model wrote can reach it — and
  * purely derived from the roster, so it can never act on a session, only
  * describe one.
@@ -169,6 +185,10 @@ export class SessionNoticeTracker {
       if (session.completionCause === SESSION_COMPLETION_CAUSE.SESSION_CLOSED) continue;
       const status = noticeStatus(session.status);
       if (!status) continue;
+      // Idle-after-a-turn is waiting on the row and still not an ask.
+      if (status === SESSION_NOTICE_STATUS.WAITING && !waitingHoldsForDeveloper(session)) {
+        continue;
+      }
       // The edge is still tracked above — it just is not news any more.
       if (now - session.observedAt > SESSION_NOTICE_FRESH_AGE_MS) continue;
       const lastNoticed = state.noticedAt.get(status);

--- a/packages/session/src/session-registry.ts
+++ b/packages/session/src/session-registry.ts
@@ -170,6 +170,7 @@ const sameSession = exhaustiveSame<NormalizedSession>({
     sameItems(first.applications, second.applications, sameApplication),
   controls: (first, second) => sameItems(first.controls, second.controls, sameControl),
   canReceiveMessage: (first, second) => first.canReceiveMessage === second.canReceiveMessage,
+  holdingForDeveloper: (first, second) => first.holdingForDeveloper === second.holdingForDeveloper,
   canRename: (first, second) => first.canRename === second.canRename,
   spawnableAgents: (first, second) =>
     sameItems(first.spawnableAgents, second.spawnableAgents, Object.is),

--- a/packages/session/src/session.test.ts
+++ b/packages/session/src/session.test.ts
@@ -172,3 +172,29 @@ test("keeps the agent behind a hosted session, and drops one saying nothing", ()
   assert.equal(withAgent({ id: "   ", displayName: "Claude Code" }), undefined);
   assert.equal(withAgent(undefined), undefined);
 });
+
+test("a developer hold rides a waiting session and is dropped on any other status", () => {
+  const waiting = normalizeSession(
+    { id: "claude-code", displayName: "Claude Code" },
+    {
+      providerSessionId: "held",
+      title: "Held for permission",
+      status: SESSION_STATUS.WAITING,
+      observedAt: TEST_NOW,
+      holdingForDeveloper: true,
+    },
+  );
+  assert.equal(waiting.holdingForDeveloper, true);
+
+  const working = normalizeSession(
+    { id: "claude-code", displayName: "Claude Code" },
+    {
+      providerSessionId: "held",
+      title: "Held for permission",
+      status: SESSION_STATUS.WORKING,
+      observedAt: TEST_NOW,
+      holdingForDeveloper: true,
+    },
+  );
+  assert.equal(working.holdingForDeveloper, undefined);
+});

--- a/packages/session/src/session.ts
+++ b/packages/session/src/session.ts
@@ -405,6 +405,14 @@ export interface ProviderSessionObservation {
    */
   canReceiveMessage?: boolean;
   /**
+   * Whether a waiting session is holding for the developer to act — a
+   * permission, an approval, or a question the provider itself reported.
+   * Absent means the adapter could not tell: a waiting notice then speaks
+   * only when the recap itself asks, because idle-after-a-turn is the
+   * panel's to show, not a banner's to read as an ask.
+   */
+  holdingForDeveloper?: boolean;
+  /**
    * Set only by an adapter whose provider documents renaming this session
    * itself, through the provider's own API, under the same absent-means-no
    * rule. The chat's own name is what this renames; the workspace around it
@@ -467,6 +475,11 @@ export interface NormalizedSession extends SessionIdentity {
   controls: readonly SessionControl[];
   /** Whether this session's provider will take a message for it right now. */
   canReceiveMessage: boolean;
+  /**
+   * Whether a waiting session is holding for the developer to act. Absent
+   * means the adapter could not tell.
+   */
+  holdingForDeveloper?: boolean;
   /** Whether this session's provider documents renaming the chat itself. */
   canRename: boolean;
   /** The agents that can be started alongside this session, or none. */
@@ -844,6 +857,9 @@ export function normalizeSession(
   if (observation.realtimeVoice === true) session.realtimeVoice = true;
   if (observation.realtimeVoiceLive === true) session.realtimeVoiceLive = true;
   if (observation.standing === true) session.standing = true;
+  if (status === SESSION_STATUS.WAITING && observation.holdingForDeveloper === true) {
+    session.holdingForDeveloper = true;
+  }
   if (parentProviderSessionId && parentProviderSessionId !== providerSessionId) {
     session.parentProviderSessionId = parentProviderSessionId;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Idle-after-a-turn was reported as `waiting` and spoken as an ask, so Conductor and other settled chats announced that a session was "waiting on you" when nothing the developer said could move them
- Waiting notices now require a provider-reported hold (permission, approval, or a native waiting-for-user state) or a recap that itself asks
- The attention evaluator and Luke's guide use the same rule: a waiting status means the turn stopped, not that the developer must reply

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (`pnpm lint && pnpm typecheck && pnpm test && pnpm build`)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — portable announcement-gating change, no UI or packaging change

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32434292666/artifacts/9430229214) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32434292666)

- Commit: `1049c73d2c3ba9023693af42647d8818d11a8d2f`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Portable announcement-gating change; `./scripts/check.sh` is the completion invariant
- Blockers or follow-up verification: None
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5cddd4c2-669b-4117-bb4e-9da969676c63?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5cddd4c2-669b-4117-bb4e-9da969676c63&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

