### PR TITLE
fix(release): copy builder helpers explicitly

### DIFF
--- a/apps/desktop/scripts/electron-builder-config.mjs
+++ b/apps/desktop/scripts/electron-builder-config.mjs
@@ -73,7 +73,10 @@ export function createElectronBuilderConfig(env = process.env) {
     npmRebuild: false,
     files: ["dist/**/*", "package.json", "!dist/**/*.map"],
     extraResources: [
-      ...packageAssets.helperPaths,
+      ...packageAssets.helperPaths.map((helperPath) => ({
+        from: helperPath,
+        to: path.basename(helperPath),
+      })),
       {
         from: packageAssets.licensePath,
         to: path.basename(packageAssets.licensePath),

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -244,9 +244,13 @@ test("every native helper is built and shipped, or neither happens", () => {
       // and is simply absent from the app someone downloads.
       `${helper.binary} reaches the bundle`,
     );
+    const builderResource = builderShipped.find(
+      (resource) => resource.to === (helper.bundle ?? helper.binary),
+    );
+    assert.ok(builderResource, `${helper.binary} reaches the electron-builder bundle`);
     assert.ok(
-      builderShipped.some((resourcePath) => resourcePath.endsWith(helper.bundle ?? helper.binary)),
-      `${helper.binary} reaches the electron-builder bundle`,
+      builderResource.from.endsWith(helper.bundle ?? helper.binary),
+      `${helper.binary} is copied from its built output`,
     );
     const explicitlySigned = builderBinaries.some((resourcePath) =>
       resourcePath.endsWith(helper.binary),


### PR DESCRIPTION
## Summary

- map each built native helper explicitly into the electron-builder resources directory
- verify both source and destination in the packaging contract test

## Verification

- `node --test scripts/packaging.test.mjs`
- `./scripts/verify.sh`
- inspected all six generated evidence states; no visual regressions
- physical-notch check not performed (packaging-only change)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32434144167/artifacts/9430169136) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32434144167)

- Commit: `535ff64a196bc3cf84775635f799286784f7b08c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
