### PR TITLE
fix(desktop): space every band under the strip by one inset

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -7,10 +7,9 @@ import {
 } from "@sidecar/credentials";
 import type { FeedbackImage, FeedbackKind } from "@sidecar/feedback";
 import { FEEDBACK_KIND, FEEDBACK_LIMITS, feedbackKindForLifecycleEvent } from "@sidecar/feedback";
-import { FIXTURE_EPOCH_MS } from "@sidecar/fixtures";
+import { FIXTURE_EPOCH_MS, FIXTURE_SPEAKING_CAPTION } from "@sidecar/fixtures";
 import { FEEDBACK_COMPOSER_KIND } from "@sidecar/guide";
 import type { HostedUsageAnswer } from "@sidecar/hosted";
-import type { IssueIdentity } from "@sidecar/issues";
 import {
   APP_TOOL_KIND,
   dispatchByKind,
@@ -132,6 +131,9 @@ import {
   DEFAULT_SESSION_VIEW,
   type DisplaySession,
   displaySessions,
+  fixtureMentionChips,
+  MENTION_CHIP_KIND,
+  type MentionChip,
   type SessionFilter,
   type SessionView,
   sameSessionFilters,
@@ -303,47 +305,6 @@ function notchStyle(display: DisplayDiagnostic): CSSProperties {
     "--notch-housing-width": `${display.notch.housingWidth}px`,
   });
 }
-
-/** The two rosters a mention chip can stand for, deciding what its press does. */
-const MENTION_CHIP_KIND = {
-  SESSION: "session",
-  ISSUE: "issue",
-} as const;
-
-/**
- * One app mark trailing a session chip's name: the same associations the
- * session's own row wears, answering where the chat is also held. Copied onto
- * the chip rather than looked up at draw time, so the band held through its
- * fade-out keeps wearing them after the roster moves on.
- */
-type MentionChipApplication = {
-  id: string;
-  name: string;
-};
-
-/**
- * One pressable chip of the notice band: the mark and words it draws, and the
- * identity its press hands to the main process — where it is validated
- * against the observed roster again before any address reaches the system.
- * Resolved onto the chip when its mention is, so the band held through its
- * fade-out keeps saying what it said.
- */
-type MentionChip =
-  | {
-      kind: typeof MENTION_CHIP_KIND.SESSION;
-      id: string;
-      markId: string;
-      title: string;
-      identity: SessionIdentity;
-      applications: readonly MentionChipApplication[];
-    }
-  | {
-      kind: typeof MENTION_CHIP_KIND.ISSUE;
-      id: string;
-      markId: string;
-      title: string;
-      identity: IssueIdentity;
-    };
 
 function surfaceHeightStyle(
   panelHeight: number | undefined,
@@ -2151,7 +2112,14 @@ export function App(): React.JSX.Element {
   // it at its foot: the rows are up in the list, but the chips are what say
   // which of them Luke is talking about. Only the slot and the composer go
   // without — those are shapes someone asked for.
+  //
+  // A fixture run's own sentence is matched against the rows the fixture
+  // draws, because it observes no provider and both halves below resolve
+  // against a roster it never fills.
   const spokenOf: readonly MentionChip[] = [
+    ...(fixtureSpeaking && bootstrap.fixtureMode
+      ? fixtureMentionChips(FIXTURE_SPEAKING_CAPTION, bootstrap.fixture.sessions)
+      : []),
     ...mentionedSessions.flatMap((mention): readonly MentionChip[] => {
       const session = sessions.find(
         (candidate) =>

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -35,6 +35,7 @@ import {
   type PanelFormFactor,
   SESSION_NOTICE_HEIGHT,
   SESSION_NOTICE_MAX_ROWS,
+  VOICE_BAND_INSET,
   VOICE_CAPTION_MAX_HEIGHT,
 } from "@sidecar/surface";
 import { cssCustomProperties } from "@sidecar/surface/react-css";
@@ -246,8 +247,8 @@ const FEEDBACK_KIND_FOR_COMPOSER = {
  * for more height than the window holds.
  * Padding is the caption's own computed padding, not a restated number, so a
  * retune in the stylesheet grows the surface by exactly what the text is
- * inset — including the bottom inset the stylesheet hands to the band while
- * the hint stands.
+ * inset — the one inset above the words, with whatever stands below the block
+ * carrying the gap on that side.
  */
 function captionSizeStyle(
   textHeight: number | undefined,
@@ -279,14 +280,20 @@ function captionBlockSize(textHeight: number, volumeHint: boolean, padding: numb
  * holds every reserved row so the growth can be revealed by its clip, which
  * means only the inner stack's height says how many rows the chips actually
  * made. The clamp is the rows the window reserved — past it the chips scroll
- * inside the band instead of growing the shape. The 6px around the measured
- * chips is the band's 3px stand-off from the strip, top and bottom, which
- * one reserved row already accounts for. Unmeasured falls back to
- * `--notice-size`, one row, in the stylesheet.
+ * inside the band instead of growing the shape. The inset added to the
+ * measured chips is the band's own stand-off from the strip above it, the
+ * same one every band under the strip carries; the gap below the last row is
+ * the next band's, or the shape's. Because the chips wrap at that inset too,
+ * the sum lands on an exact multiple of `--notice-size` — the reserved row —
+ * however many rows they made. Unmeasured falls back to `--notice-size`, one
+ * row, in the stylesheet.
  */
 function noticeGrowthStyle(rowsHeight: number | undefined): CSSProperties {
   if (!rowsHeight) return {};
-  const growth = Math.min(SESSION_NOTICE_HEIGHT * SESSION_NOTICE_MAX_ROWS, rowsHeight + 6);
+  const growth = Math.min(
+    SESSION_NOTICE_HEIGHT * SESSION_NOTICE_MAX_ROWS,
+    rowsHeight + VOICE_BAND_INSET,
+  );
   return cssCustomProperties({ "--notice-growth": `${growth}px` });
 }
 

--- a/apps/desktop/src/renderer/luke-errand.tsx
+++ b/apps/desktop/src/renderer/luke-errand.tsx
@@ -486,6 +486,7 @@ const MOTION_TOKEN = {
   CAPTION_SIZE: "--caption-size",
   CAPTION_MAX: "--caption-max",
   VOLUME_HINT_SIZE: "--volume-hint-size",
+  BAND_INSET: "--voice-band-inset",
 } as const;
 
 type MotionToken = (typeof MOTION_TOKEN)[keyof typeof MOTION_TOKEN];
@@ -701,11 +702,13 @@ export function LukeErrand({ errand, onLanded, onReturned }: LukeErrandProps): R
       // An already-visible control with room to spare is left exactly where it
       // is, which is the usual case.
       // The room the reply takes off the panel's foot is the caption block
-      // plus the volume hint's band below it — two stacked elements, summed
-      // here the same way the shape's growth sums them.
+      // plus the volume hint's band below it and the inset that closes the
+      // stack against the shape's edge — summed here the same way the shape's
+      // growth sums them.
       const captionSize =
         parsePixels(token(MOTION_TOKEN.CAPTION_SIZE)) +
-        parsePixels(token(MOTION_TOKEN.VOLUME_HINT_SIZE));
+        parsePixels(token(MOTION_TOKEN.VOLUME_HINT_SIZE)) +
+        parsePixels(token(MOTION_TOKEN.BAND_INSET));
       keepInView(
         stage,
         target,

--- a/apps/desktop/src/renderer/session-model.test.ts
+++ b/apps/desktop/src/renderer/session-model.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { fixtureSnapshot } from "@sidecar/fixtures";
+import { FIXTURE_SPEAKING_CAPTION, fixtureSnapshot } from "@sidecar/fixtures";
 import {
   ATTENTION_DISPOSITION,
   normalizeSession,
@@ -21,6 +21,8 @@ import {
   arrangeSessions,
   DEFAULT_SESSION_VIEW,
   displaySessions,
+  fixtureMentionChips,
+  MENTION_CHIP_KIND,
   matchRanges,
   observedAgoLabel,
   SESSION_FILTER,
@@ -1476,5 +1478,34 @@ test("a hosted chat carries its agent for the mark, the chips, and the search", 
   assert.deepEqual(
     tally.providers.map((provider) => provider.providerId),
     [PROVIDER_ID.CLAUDE_CODE, PROVIDER_ID.CODEX],
+  );
+});
+
+test("the fixture's own sentence earns chips for the rows it names", () => {
+  const fixture = fixtureSnapshot("smoke");
+  const chips = fixtureMentionChips(FIXTURE_SPEAKING_CAPTION, fixture.sessions);
+
+  // Named whole, in the order the sentence says them: two chats by title, the
+  // Conductor workspace by name, two more chats. The Codex row is named by a
+  // fragment of its long title rather than the whole of it, so it earns
+  // nothing — the same refusal a live reply would meet.
+  assert.deepEqual(
+    chips.map((chip) => chip.title),
+    ["Review trust constraints", "lisbon-v2", "Follow a cloud agent", "Watch a cloud session"],
+  );
+  // Every chip stands for a row the surface is drawing, and wears the mark of
+  // the agent having the conversation.
+  for (const chip of chips) {
+    assert.equal(chip.kind, MENTION_CHIP_KIND.SESSION);
+    const row = fixture.sessions.find((session) => session.id === chip.id);
+    assert.ok(row);
+    assert.equal(chip.markId, row.agentId ?? row.providerId);
+  }
+});
+
+test("a fixture sentence naming nothing on the roster earns no chips", () => {
+  assert.deepEqual(
+    fixtureMentionChips("Nothing here names a session.", fixtureSnapshot("smoke").sessions),
+    [],
   );
 });

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -1,10 +1,13 @@
 import type { SessionNoticeAsk } from "@sidecar/attention";
+import type { SessionSnapshot } from "@sidecar/fixtures";
 import { SESSION_LIST_SORT, type SessionListSort } from "@sidecar/guide";
+import type { IssueIdentity } from "@sidecar/issues";
 import {
   ATTENTION_DISPOSITION,
   isProviderId,
   isSessionApplicationId,
   matchesFilterSelection,
+  mentionedSessions,
   type NormalizedSession,
   PROVIDER_ID_LIST,
   type ProviderId,
@@ -12,6 +15,7 @@ import {
   SESSION_FILTER,
   SESSION_FILTER_AXIS,
   SESSION_LOCATION,
+  SESSION_MENTION_KIND,
   SESSION_STATUS,
   type SessionApplicationId,
   type SessionApplicationScope,
@@ -19,6 +23,7 @@ import {
   type SessionDiffSummary,
   type SessionFilter,
   type SessionFilterAxis,
+  type SessionIdentity,
   type SessionLocation,
   sessionChangeNumber,
   sessionFilterAxis,
@@ -315,6 +320,101 @@ export interface DisplaySession {
 }
 
 /** One filter someone can choose, and how many sessions it alone would leave. */
+/** The two rosters a mention chip can stand for, deciding what its press does. */
+export const MENTION_CHIP_KIND = {
+  SESSION: "session",
+  ISSUE: "issue",
+} as const;
+
+/**
+ * One app mark trailing a session chip's name: the same associations the
+ * session's own row wears, answering where the chat is also held. Copied onto
+ * the chip rather than looked up at draw time, so the band held through its
+ * fade-out keeps wearing them after the roster moves on.
+ */
+export type MentionChipApplication = {
+  id: string;
+  name: string;
+};
+
+/**
+ * One pressable chip of the notice band: the mark and words it draws, and the
+ * identity its press hands to the main process — where it is validated
+ * against the observed roster again before any address reaches the system.
+ * Resolved onto the chip when its mention is, so the band held through its
+ * fade-out keeps saying what it said.
+ */
+export type MentionChip =
+  | {
+      kind: typeof MENTION_CHIP_KIND.SESSION;
+      id: string;
+      markId: string;
+      title: string;
+      identity: SessionIdentity;
+      applications: readonly MentionChipApplication[];
+    }
+  | {
+      kind: typeof MENTION_CHIP_KIND.ISSUE;
+      id: string;
+      markId: string;
+      title: string;
+      identity: IssueIdentity;
+    };
+
+/**
+ * The chips a fixture run's own sentence earns. A fixture run observes no
+ * provider, so the roster a reply's mentions resolve against is empty and the
+ * band would stand at no rows at all — while the sentence the profile speaks
+ * was written to name four of the fixture's sessions and one of its
+ * workspaces precisely so the evidence photographs it. The rows the surface
+ * is already drawing answer for the roster here, matched by the same rules a
+ * live reply is matched by, so what the PNG shows is the band a live reply
+ * naming the same things would draw.
+ */
+export function fixtureMentionChips(
+  caption: string,
+  sessions: readonly SessionSnapshot[],
+): readonly MentionChip[] {
+  const rows = sessions.map((session) => ({
+    providerId: session.providerId,
+    providerSessionId: session.id,
+    title: session.title,
+    observedAt: session.observedAt,
+    ...(session.workspace
+      ? {
+          workspace: {
+            providerWorkspaceId: session.workspace.id,
+            ...(session.workspace.scopeId ? { scopeId: session.workspace.scopeId } : undefined),
+            name: session.workspace.name,
+          },
+        }
+      : undefined),
+  }));
+  return mentionedSessions(caption, rows).flatMap((mention): readonly MentionChip[] => {
+    const session = sessions.find(
+      (candidate) =>
+        candidate.providerId === mention.providerId && candidate.id === mention.providerSessionId,
+    );
+    if (!session) return [];
+    const markId = session.agentId ?? session.providerId;
+    return [
+      {
+        kind: MENTION_CHIP_KIND.SESSION,
+        id: session.id,
+        markId,
+        title:
+          mention.kind === SESSION_MENTION_KIND.WORKSPACE && session.workspace !== undefined
+            ? session.workspace.name
+            : session.title,
+        identity: { providerId: session.providerId, providerSessionId: session.id },
+        applications: (session.applications ?? []).flatMap((application) =>
+          application.id === markId ? [] : [{ id: application.id, name: application.name }],
+        ),
+      },
+    ];
+  });
+}
+
 export interface SessionFilterOption {
   filter: SessionFilter;
   label: string;

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -197,10 +197,17 @@
      whole. `--caption-max` arrives from the shared surface tokens, the
      same number the compact window already holds below the capsule, so growing
      into it costs no IPC. `--caption-size` is the block's height right now —
-     measured off the wrapped text by the renderer, padding included, never
-     past the max less the volume hint's band while one stands. How much of
-     that room the shape is currently using: the caption states below raise
-     it, and every other state leaves the capsule's own height. */
+     the words as measured by the renderer plus the one inset above them,
+     never past the max less the volume hint's band while one stands. How
+     much of that room the shape is currently using: the caption states below
+     raise it, and every other state leaves the capsule's own height.
+
+     Every band grown below the strip is sized this way — its own inset plus
+     its content — so a stack of them is evenly spaced by construction and
+     the shape closes the column with one more inset below the last. That
+     final inset is what `--caption-growth` adds on top of the bands it
+     sums; `--voice-band-inset` itself arrives from the shared surface
+     tokens, because the compact window has to reserve it too. */
   --caption-growth: 0px;
   /* The volume hint's band below the caption block, 0 until the hint stands.
      The hint's own rule raises it, and every place that spends
@@ -209,10 +216,10 @@
      height. */
   --volume-hint-size: 0px;
   /* The notice band under the housing — one row for the chips naming the
-     sessions the reply being spoken is about — arrives as `--notice-size`
-     from the shared surface tokens, because the compact window reserves its
-     room on top of the caption's: the chips stand directly under the housing,
-     and captioned words drop below their band. */
+     sessions the reply being spoken is about, the inset above them included —
+     arrives as `--notice-size` from the shared surface tokens, because the
+     compact window reserves its room on top of the caption's: the chips stand
+     directly under the housing, and captioned words drop below their band. */
   /* The one width the caption block, the volume hint, and the notice band all
      lay out at: the peek less one convex corner a side, so their last row ends
      inside the shape's bottom curve. The open panel overrides it with its own
@@ -221,6 +228,13 @@
      against it. */
   --voice-band-width-compact: calc(var(--peek-width) - var(--notch-convex-radius) * 2);
   --voice-band-width: var(--voice-band-width-compact);
+  /* Where the three of them measure their travel from. Each is positioned at
+     the strip's full height and then moved by this, because a bubble's shape
+     is the strip inset by `--shape-top` on both edges: the strip a band hangs
+     off ends that much higher than the element's own top, and the shape's
+     bottom edge that much lower than its growth. Beside a housing the shape
+     starts at the display's edge, the lift is zero, and this is nothing. */
+  --voice-band-origin: calc(0px - var(--shape-top, 0px));
   /* Wide enough for a key, a way out, and a way on, and no wider — the page the
      key was copied from is behind this and has to stay readable. The floor is
      what those three need on a display with no housing to grow from. */
@@ -260,6 +274,12 @@
 .app-stage[data-presentation="panel"] {
   --notch-concave-radius: calc(var(--panel-radius) * 0.489);
   --wing-bound: var(--panel-width);
+  /* The open panel is the one shape drawn downward from the lift rather than
+     inward from both edges of the strip: its height is its own measured
+     height, and the bands ride at its foot. So the same edge they hang off is
+     that much below the element's top here, not above it — without the sign
+     change a bubble's panel closed on a gap twice the lift too wide. */
+  --voice-band-origin: var(--shape-top, 0px);
   /* The panel hands the caption block, the volume hint, and the notice band
      its usable width — the content column between the panel's insets, which
      also clears the bottom corners' curve beside the band's last row. The
@@ -525,10 +545,16 @@ button:disabled {
 /* Luke's words follow him onto the shape: the compact states grow a caption
    block below the housing while there are words to draw. Gated on the words
    rather than on the turn, because the first of them arrives a beat after the
-   reply starts and a shape grown around nothing reads as a twitch. */
+   reply starts and a shape grown around nothing reads as a twitch. The bands
+   carry the inset above themselves, so the growth adds the one below the
+   last of them. */
 .app-stage[data-presentation="capsule"][data-caption="true"],
 .app-stage[data-presentation="peek"][data-caption="true"] {
-  --caption-growth: calc(var(--caption-size, 28px) + var(--volume-hint-size));
+  --caption-growth: calc(
+    var(--caption-size, 20px) +
+    var(--volume-hint-size) +
+    var(--voice-band-inset)
+  );
 }
 
 /* While there are words, the capsule holds the peek's width whatever the
@@ -1365,7 +1391,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 .voice-caption {
   /* Named so the widen keyframe can hold it while animating the sides: an
      animation owns the whole clip-path while it runs. */
-  --voice-band-clip-bottom: calc(var(--caption-max) - var(--caption-size, 28px));
+  --voice-band-clip-bottom: calc(var(--caption-max) - var(--caption-size, 20px));
   position: absolute;
   z-index: 3;
   top: var(--capsule-height);
@@ -1373,11 +1399,15 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   overflow: hidden;
   width: var(--voice-band-width);
   height: var(--caption-max);
-  padding: 5px 0 9px;
+  /* The block's own inset, above the words and nowhere else: whatever stands
+     below it — the volume hint's band, or the shape's bottom edge — carries
+     the gap on that side, so the words are the same distance from the thing
+     above them as from the thing below however the stack is composed. */
+  padding: var(--voice-band-inset) 0 0;
   clip-path: inset(0 0 var(--voice-band-clip-bottom));
   opacity: 0;
   pointer-events: none;
-  transform: translate(-50%, calc(var(--caption-rest, 0px) - var(--shape-top, 0px)));
+  transform: translate(-50%, calc(var(--caption-rest, 0px) + var(--voice-band-origin)));
   /* The transform and the clip wait out `--duration-exit` like the surface
      does: leaving a state, the words travel with the shape rather than ahead
      of it. */
@@ -1410,8 +1440,9 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   --caption-rest: calc(
     var(--panel-height, var(--panel-height-max)) -
     var(--capsule-height) -
-    var(--caption-size, 28px) -
-    var(--volume-hint-size)
+    var(--caption-size, 20px) -
+    var(--volume-hint-size) -
+    var(--voice-band-inset)
   );
 }
 
@@ -1430,7 +1461,12 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
    the panel is up, so the height the panel reports is already right when a
    captioned expand begins. */
 .app-stage[data-caption="true"] .expanded-panel {
-  padding-bottom: calc(18px + var(--caption-size, 28px) + var(--volume-hint-size));
+  padding-bottom: calc(
+    18px +
+    var(--caption-size, 20px) +
+    var(--volume-hint-size) +
+    var(--voice-band-inset)
+  );
 }
 
 /* The stack holds one block per response, so two responses spoken
@@ -1475,30 +1511,22 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 /* Why the words above are the only part of Luke arriving: the Mac's output is
    muted or at zero. It stands in a band of its own directly below the caption
    block: `--volume-hint-size` mirrors VOLUME_HINT_BAND_HEIGHT in
-   volume-hint.ts — the 22px row this element draws plus the caption's 9px
-   bottom inset, which the rule below moves under the row — and the renderer
-   takes the band off the block's maximum. The block and the band partition
-   the reserved room rather than layering in it: the caption's clip ends
-   where the band begins, so no line can be revealed over the hint. The
-   travel is the caption's own transform plus
-   the block's current size, so the row springs down the shape's edge exactly
-   as the shape grows for new lines. Above the hover strip (z-index 4) because
-   it holds the one button on the compact shape that is not the strip: Got it
-   has to answer the press. */
+   volume-hint.ts — the inset every band carries above itself plus the 20px
+   row this element draws — and the renderer takes the band off the block's
+   maximum. The block and the band partition the reserved room rather than
+   layering in it: the caption's clip ends where the band begins, so no line
+   can be revealed over the hint. The travel is the caption's own transform
+   plus the block's current size and that inset, so the row springs down the
+   shape's edge exactly as the shape grows for new lines. Above the hover
+   strip (z-index 4) because it holds the one button on the compact shape
+   that is not the strip: Got it has to answer the press. */
 .app-stage[data-volume-hint="true"] {
-  --volume-hint-size: 31px;
-}
-
-/* While the hint stands, the block's bottom inset belongs below the hint —
-   the hint is what meets the shape's bottom edge then. The renderer measures
-   the caption's padding off the computed style, so the words' budget follows
-   this move by measurement rather than by a restated number. */
-.app-stage[data-volume-hint="true"] .voice-caption {
-  padding-bottom: 0;
+  --volume-hint-size: calc(var(--voice-band-inset) + 20px);
 }
 
 /* The row's height mirrors VOLUME_HINT_HEIGHT in volume-hint.ts — the two
-   must agree. */
+   must agree — and is exactly what it draws: the pill a chip is, with the
+   sentence beside it. */
 .volume-hint {
   position: absolute;
   z-index: 5;
@@ -1509,12 +1537,17 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   justify-content: center;
   gap: 9px;
   width: var(--voice-band-width);
-  height: 22px;
+  height: 20px;
   opacity: 0;
   pointer-events: none;
   transform: translate(
     -50%,
-    calc(var(--caption-rest, 0px) - var(--shape-top, 0px) + var(--caption-size, 28px))
+    calc(
+      var(--caption-rest, 0px) +
+      var(--voice-band-origin) +
+      var(--caption-size, 20px) +
+      var(--voice-band-inset)
+    )
   );
   /* The transform waits out `--duration-exit` like the caption's does, so
      leaving a state the row travels with the shape rather than ahead of it. */
@@ -1549,11 +1582,17 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   white-space: nowrap;
 }
 
-/* Shaped like the quiet buttons, scaled to a 22px row. */
+/* The notice chip's pill exactly — same height, padding, and radius — because
+   the two are the pressable things that appear under the housing and a row of
+   one standing a pixel taller than a row of the other is a difference nobody
+   meant. */
 .volume-hint-dismiss {
+  display: flex;
   flex: 0 0 auto;
-  padding: 3px 8px;
-  border-radius: 7px;
+  align-items: center;
+  height: 20px;
+  padding: 0 9px;
+  border-radius: 10px;
   background: var(--raised);
   color: var(--text-primary);
   font-size: 9.5px;
@@ -1580,10 +1619,12 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
    stands alone, so the mentions are pressable either way. `--caption-rest`
    is the caption block's own lift, the same variable the panel's foot
    spends, so the words and the volume hint inside their block both take the
-   drop from one assignment. */
+   drop from one assignment — and it is the band's growth exactly, because
+   the growth ends where the chips do and the block below carries its own
+   inset. */
 .app-stage[data-presentation="capsule"][data-notice="true"],
 .app-stage[data-presentation="peek"][data-notice="true"] {
-  --caption-growth: var(--notice-growth, var(--notice-size));
+  --caption-growth: calc(var(--notice-growth, var(--notice-size)) + var(--voice-band-inset));
   --caption-rest: var(--notice-growth, var(--notice-size));
 }
 
@@ -1592,9 +1633,10 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 .app-stage[data-presentation="capsule"][data-caption="true"][data-notice="true"],
 .app-stage[data-presentation="peek"][data-caption="true"][data-notice="true"] {
   --caption-growth: calc(
-    var(--caption-size, 28px) +
+    var(--caption-size, 20px) +
     var(--volume-hint-size) +
-    var(--notice-growth, var(--notice-size))
+    var(--notice-growth, var(--notice-size)) +
+    var(--voice-band-inset)
   );
 }
 
@@ -1681,19 +1723,26 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   left: 50%;
   overflow-y: auto;
   /* The state's own band width, shared with the caption block: the band's
-     last row ends 3px above the shape's edge, where the bottom corners curve
-     in, and a chip wider than the state's width would poke past the curve
-     onto the desktop. A definite width, not a cap: `left: 50%` leaves an
-     absolutely positioned box only the right half of the stage as available
-     space, so a shrink-to-fit band resolves to half its intended width and
-     stacks one chip to a row — the translate recentres the box but never
-     gives the width back. */
+     last row ends one inset above the shape's edge, where the bottom corners
+     curve in, and a chip wider than the state's width would poke past the
+     curve onto the desktop. A definite width, not a cap: `left: 50%` leaves
+     an absolutely positioned box only the right half of the stage as
+     available space, so a shrink-to-fit band resolves to half its intended
+     width and stacks one chip to a row — the translate recentres the box but
+     never gives the width back. */
   width: var(--voice-band-width);
-  height: calc(var(--notice-size) * var(--notice-max-rows) - 6px);
+  /* Every reserved row of chips and nothing else: each `--notice-size` is a
+     chip row plus the inset above it, and the band's own inset rides in the
+     transform below, so taking one off leaves exactly the rows. That is what
+     lets the clip measure rows rather than rows-plus-a-gap. */
+  height: calc(var(--notice-size) * var(--notice-max-rows) - var(--voice-band-inset));
   clip-path: inset(0 0 var(--voice-band-clip-bottom));
   opacity: 0;
   pointer-events: none;
-  transform: translate(-50%, calc(3px - var(--shape-top, 0px) + var(--notice-rest, 0px)));
+  transform: translate(
+    -50%,
+    calc(var(--voice-band-inset) + var(--voice-band-origin) + var(--notice-rest, 0px))
+  );
   transition:
     opacity var(--duration-exit) var(--motion-exit),
     transform var(--duration-shape) var(--spring) var(--duration-exit),
@@ -1702,13 +1751,16 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 
 /* The rows inside the box: the chips wrap here, so this stack's natural
    height — never the clipped box's — is what the renderer measures into
-   `--notice-growth`. */
+   `--notice-growth`. They wrap at the band's own inset, which is what makes a
+   two-row band as evenly spaced inside as it is against the strip above and
+   the shape's edge below — and what makes each measured row land on an exact
+   `--notice-size`, the row the window reserved. */
 .session-notice-rows {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: var(--voice-band-inset);
   width: 100%;
 }
 
@@ -1806,7 +1858,8 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   --notice-rest: calc(
     var(--panel-height, var(--panel-height-max)) -
     var(--capsule-height) -
-    var(--notice-growth, var(--notice-size))
+    var(--notice-growth, var(--notice-size)) -
+    var(--voice-band-inset)
   );
 }
 
@@ -1814,9 +1867,10 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   --notice-rest: calc(
     var(--panel-height, var(--panel-height-max)) -
     var(--capsule-height) -
-    var(--caption-size, 28px) -
+    var(--caption-size, 20px) -
     var(--volume-hint-size) -
-    var(--notice-growth, var(--notice-size))
+    var(--notice-growth, var(--notice-size)) -
+    var(--voice-band-inset)
   );
 }
 
@@ -1868,15 +1922,16 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
    the notice stands rather than only while the panel is up, so the height
    the panel reports is already right when an expand begins mid-announcement. */
 .app-stage[data-notice="true"] .expanded-panel {
-  padding-bottom: calc(18px + var(--notice-growth, var(--notice-size)));
+  padding-bottom: calc(18px + var(--notice-growth, var(--notice-size)) + var(--voice-band-inset));
 }
 
 .app-stage[data-caption="true"][data-notice="true"] .expanded-panel {
   padding-bottom: calc(
     18px +
-    var(--caption-size, 28px) +
+    var(--caption-size, 20px) +
     var(--volume-hint-size) +
-    var(--notice-growth, var(--notice-size))
+    var(--notice-growth, var(--notice-size)) +
+    var(--voice-band-inset)
   );
 }
 

--- a/apps/desktop/src/renderer/use-voice-conversation.test.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { FIXTURE_SPEAKING_CAPTION } from "@sidecar/fixtures";
 import { ISSUE_TRACKER_ID, normalizeTrackedIssue, type TrackedIssue } from "@sidecar/issues";
 import {
   ATTENTION_SPEECH_SOURCE,
@@ -20,7 +21,6 @@ import {
   activeVoiceStream,
   announcerNotices,
   evaluatorSummaries,
-  FIXTURE_SPEAKING_CAPTION,
   liveSpeedApplies,
   lukeCaptionsToShow,
   replyIssueMentions,

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -1,4 +1,5 @@
 import type { SessionNoticeAsk } from "@sidecar/attention";
+import { FIXTURE_SPEAKING_CAPTION } from "@sidecar/fixtures";
 import { type AppGuideSnapshot, EMPTY_APP_GUIDE } from "@sidecar/guide";
 import { mentionedIssues, type TrackedIssue } from "@sidecar/issues";
 import {
@@ -42,19 +43,6 @@ import { type AppActionCarrier, RealtimeVoiceSession } from "./realtime-session"
 import { SpokenNoticeAnnouncer } from "./spoken-notices";
 import { useStateWithRef } from "./use-state-with-ref";
 import { WAVEFORM_VOICE, type WaveformVoice } from "./waveform";
-
-/**
- * What the speaking evidence run captions the reply with. A capture run never
- * opens a call, so there are no words to draw unless the fixture supplies
- * them — and it must, or the caption strip ships unphotographed. Synthetic,
- * like every fixture, and long enough to wrap: a one-line fixture would leave
- * the wrapped form of the strip unphotographed too. It names four of the
- * fixture roster's own sessions and one of its workspaces, so the photograph
- * holds both kinds of mention chip and the band at every row it can grow to,
- * exactly as they would stand over a live reply walking the roster.
- */
-export const FIXTURE_SPEAKING_CAPTION =
-  "Bootstrap the desktop shell and Review trust constraints are finished, lisbon-v2 is packaging the macOS build, and Follow a cloud agent and Watch a cloud session are waiting on you.";
 
 /**
  * What a changed voice on a live call should do. The API locks a session's

--- a/apps/desktop/src/renderer/volume-hint.ts
+++ b/apps/desktop/src/renderer/volume-hint.ts
@@ -1,3 +1,4 @@
+import { VOICE_BAND_INSET } from "@sidecar/surface";
 import type { OutputAudioState } from "#shared/contracts";
 
 /**
@@ -29,22 +30,22 @@ export const VOLUME_HINT_REARM_MS = 15 * 60_000;
 
 /**
  * The hint row's height, mirrored by `.volume-hint` in the stylesheet — the
- * two must agree.
+ * two must agree. The row is exactly its content: the same pill a notice chip
+ * is, with the sentence beside it, so the inset above and below the row is
+ * the inset around what is actually drawn.
  */
-export const VOLUME_HINT_HEIGHT = 22;
+export const VOLUME_HINT_HEIGHT = 20;
 
 /**
- * The band the shape grows for the hint: the row plus the caption block's own
- * 9px bottom inset, which moves below the row while the hint stands — the
- * hint is what meets the shape's bottom edge then, so the breathing room
- * belongs under it. Mirrored by `--volume-hint-size` and the zeroed caption
- * padding in the stylesheet — the three must agree. The band is a stacked
- * element of its own, never part of the caption block: it is taken off the
- * block's maximum, so the words above scroll a row sooner and the clip that
- * reveals them ends where the band begins — no pace of scroll can draw a
- * line over the hint.
+ * The band the shape grows for the hint: the row plus the one inset every
+ * band under the strip carries above itself. Mirrored by `--volume-hint-size`
+ * in the stylesheet — the two must agree. The band is a stacked element of
+ * its own, never part of the caption block: it is taken off the block's
+ * maximum, so the words above scroll a row sooner and the clip that reveals
+ * them ends where the band begins — no pace of scroll can draw a line over
+ * the hint.
  */
-export const VOLUME_HINT_BAND_HEIGHT = VOLUME_HINT_HEIGHT + 9;
+export const VOLUME_HINT_BAND_HEIGHT = VOICE_BAND_INSET + VOLUME_HINT_HEIGHT;
 
 /** A "Got it", remembered against the stretch of silence it was given in. */
 export interface VolumeHintDismissal {

--- a/design/generate-surface-shared.mjs
+++ b/design/generate-surface-shared.mjs
@@ -72,13 +72,24 @@ const SURFACE_GEOMETRY_PX = {
   // cannot resize for speech, so this bound is physical: a reply taller
   // still clips at the block's edge rather than growing the window.
   VOICE_CAPTION_MAX_HEIGHT: 210,
-  // The notice band under the housing: one row of the pressable chips naming
-  // the sessions the reply being spoken is about. The chips size to their
-  // names and wrap naturally, so the renderer measures the rows they made
-  // and grows the shape by that, the caption block's own pattern. The
-  // compact window reserves `SESSION_NOTICE_MAX_ROWS` of these on top of
-  // the caption room, because captioned speech drops below the chips' band
-  // and a reply may name more sessions than one row holds.
+  // The one gap between anything the surface grows below the strip. The
+  // chips, the words, and the volume hint stack under the housing in the
+  // compact states and at the panel's foot when it opens, and each of them
+  // is this far from the strip above it, from the band before it, and from
+  // the shape's bottom edge below it — so a reply that draws all three reads
+  // as one evenly spaced column rather than three bands that each chose
+  // their own breathing room. It is also the gap the chips wrap at, which is
+  // what makes a two-row band as evenly spaced inside as it is at its edges.
+  VOICE_BAND_INSET: 6,
+  // One row of the notice band under the housing: a pressable chip naming a
+  // session the reply being spoken is about, plus the inset above it. The
+  // chips size to their names and wrap naturally, so the renderer measures
+  // the rows they made and grows the shape by that, the caption block's own
+  // pattern — and because the chips wrap at the inset too, that measurement
+  // lands on an exact multiple of this row. The compact window reserves
+  // `SESSION_NOTICE_MAX_ROWS` of them on top of the caption room, because
+  // captioned speech drops below the chips' band and a reply may name more
+  // sessions than one row holds.
   SESSION_NOTICE_HEIGHT: 26,
   PANEL_WIDTH: 620,
   PANEL_MAX_HEIGHT: 520,
@@ -373,6 +384,7 @@ function motionTokensCss() {
   --slot-delay: calc(var(--duration-exit) + var(--peek-delay));
   --bubble-lift: ${px(SURFACE_GEOMETRY_PX.BUBBLE_LIFT)};
   --caption-max: ${px(SURFACE_GEOMETRY_PX.VOICE_CAPTION_MAX_HEIGHT)};
+  --voice-band-inset: ${px(SURFACE_GEOMETRY_PX.VOICE_BAND_INSET)};
   --notice-size: ${px(SURFACE_GEOMETRY_PX.SESSION_NOTICE_HEIGHT)};
   --notice-max-rows: ${SESSION_NOTICE_MAX_ROWS};
   --panel-width: ${px(SURFACE_GEOMETRY_PX.PANEL_WIDTH)};
@@ -410,7 +422,12 @@ export const BUBBLE_LIFT = ${SURFACE_GEOMETRY_PX.BUBBLE_LIFT};
  * because the block grows to the words and nothing scrolls. CSS: \`--caption-max\`. */
 export const VOICE_CAPTION_MAX_HEIGHT = ${SURFACE_GEOMETRY_PX.VOICE_CAPTION_MAX_HEIGHT};
 
-/** One chip row of the session notice band. CSS: \`--notice-size\`. */
+/** The one gap between the strip, each band grown below it, and the shape's
+ * bottom edge. CSS: \`--voice-band-inset\`. */
+export const VOICE_BAND_INSET = ${SURFACE_GEOMETRY_PX.VOICE_BAND_INSET};
+
+/** One chip row of the session notice band, the inset above it included.
+ * CSS: \`--notice-size\`. */
 export const SESSION_NOTICE_HEIGHT = ${SURFACE_GEOMETRY_PX.SESSION_NOTICE_HEIGHT};
 
 /** Chip rows the band may grow to before scrolling. CSS: \`--notice-max-rows\`. */

--- a/packages/fixtures/src/fixtures.test.ts
+++ b/packages/fixtures/src/fixtures.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { fixtureSnapshot } from "@sidecar/fixtures";
+import { FIXTURE_SPEAKING_CAPTION, fixtureSnapshot } from "@sidecar/fixtures";
+import { mentionedSessions, SESSION_MENTION_KIND } from "@sidecar/session";
 import { attentionCount } from "./fixtures.js";
 
 test("the smoke fixture is stable and contains no duplicate identities", () => {
@@ -10,6 +11,31 @@ test("the smoke fixture is stable and contains no duplicate identities", () => {
   assert.equal(snapshot.scenario, "smoke");
   assert.equal(new Set(identities).size, identities.length);
   assert.equal(attentionCount(snapshot), 1);
+});
+
+test("the spoken sentence names rows of the roster it is captured beside", () => {
+  const snapshot = fixtureSnapshot("smoke");
+  const mentions = mentionedSessions(
+    FIXTURE_SPEAKING_CAPTION,
+    snapshot.sessions.map((session) => ({
+      providerId: session.providerId,
+      providerSessionId: session.id,
+      title: session.title,
+      observedAt: session.observedAt,
+      ...(session.workspace
+        ? { workspace: { providerWorkspaceId: session.workspace.id, name: session.workspace.name } }
+        : undefined),
+    })),
+  );
+
+  // Both kinds, so the photographed band holds a chat chip and a workspace
+  // one, and enough of them to wrap: a sentence that stopped naming these
+  // would ship the band unphotographed without failing anything else.
+  assert.deepEqual(
+    mentions.map((mention) => mention.providerSessionId),
+    ["claude-review", "conductor-chat-tidy", "cursor-agent", "devin-session"],
+  );
+  assert.ok(mentions.some((mention) => mention.kind === SESSION_MENTION_KIND.WORKSPACE));
 });
 
 test("unknown fixtures remain explicit", () => {

--- a/packages/fixtures/src/fixtures.ts
+++ b/packages/fixtures/src/fixtures.ts
@@ -78,6 +78,23 @@ export interface FixtureSnapshot {
 }
 
 /**
+ * What the speaking evidence run captions the reply with. A capture run never
+ * opens a call, so there are no words to draw unless the fixture supplies
+ * them — and it must, or the caption strip ships unphotographed. Synthetic,
+ * like every fixture, and long enough to wrap: a one-line fixture would leave
+ * the wrapped form of the strip unphotographed too.
+ *
+ * It lives here, beside the roster it talks about, because it names that
+ * roster's own rows — three chats by title and one workspace by name — and a
+ * reply's mentions are what the notice band draws chips for. Reworded apart
+ * from the fixture, it would quietly stop naming anything and the band would
+ * go unphotographed; the test beside this file is what holds the two
+ * together.
+ */
+export const FIXTURE_SPEAKING_CAPTION =
+  "Bootstrap the desktop shell and Review trust constraints are finished, lisbon-v2 is packaging the macOS build, and Follow a cloud agent and Watch a cloud session are waiting on you.";
+
+/**
  * A fixed instant the fixture's observation times are measured back from. A
  * clock read at load would make the ordering depend on when the fixture was
  * read, and the evidence screenshots are only reproducible while it does not.

--- a/packages/fixtures/src/index.ts
+++ b/packages/fixtures/src/index.ts
@@ -1,5 +1,7 @@
 export {
   FIXTURE_EPOCH_MS,
+  FIXTURE_SPEAKING_CAPTION,
   type FixtureSnapshot,
   fixtureSnapshot,
+  type SessionSnapshot,
 } from "./fixtures.js";

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -91,6 +91,7 @@ export {
 export {
   firstWholeNameIndex,
   MAXIMUM_MENTIONED_SESSIONS,
+  type MentionableSession,
   MINIMUM_MENTION_TITLE_LENGTH,
   mentionedSessions,
   SESSION_MENTION_KIND,

--- a/packages/session/src/session-mentions.ts
+++ b/packages/session/src/session-mentions.ts
@@ -1,4 +1,4 @@
-import type { NormalizedSession, SessionIdentity } from "./session.js";
+import type { SessionIdentity } from "./session.js";
 
 /**
  * The most sessions one reply's mentions may put on the notice band. The band
@@ -31,6 +31,25 @@ export const SESSION_MENTION_KIND = {
 } as const;
 
 export type SessionMentionKind = (typeof SESSION_MENTION_KIND)[keyof typeof SESSION_MENTION_KIND];
+
+/**
+ * What a row has to offer to be named by a reply: its identity, the two names
+ * a mention may be made by, and when it was last seen — the tiebreak when one
+ * workspace name fronts several chats. Stated as its own shape rather than as
+ * `NormalizedSession`, which every observed row already satisfies, because a
+ * row the surface draws without having observed it — the fixture roster an
+ * evidence run photographs — has to earn its chips by the same matching, and
+ * these are the only fields the matching reads.
+ */
+export interface MentionableSession extends SessionIdentity {
+  title: string;
+  observedAt: number;
+  workspace?: {
+    providerWorkspaceId: string;
+    scopeId?: string;
+    name?: string;
+  };
+}
 
 /**
  * One thing a spoken reply named, resolved to a session the roster observes.
@@ -72,7 +91,7 @@ export function firstWholeNameIndex(caption: string, name: string): number | und
 /** One name the caption may be searched for, and the session it stands for. */
 interface MentionCandidate {
   kind: SessionMentionKind;
-  session: NormalizedSession;
+  session: MentionableSession;
   /** Whether the name stopped being attributable to one thing and is dead. */
   ambiguous: boolean;
 }
@@ -89,7 +108,7 @@ interface MentionCandidate {
  *   mention cannot say which was meant, and a chip that might open the wrong
  *   one is worse than no chip.
  */
-function mentionCandidates(sessions: readonly NormalizedSession[]): Map<string, MentionCandidate> {
+function mentionCandidates(sessions: readonly MentionableSession[]): Map<string, MentionCandidate> {
   const candidates = new Map<string, MentionCandidate>();
   for (const session of sessions) {
     const title = session.title.trim().toLowerCase();
@@ -161,11 +180,11 @@ function mentionCandidates(sessions: readonly NormalizedSession[]): Map<string, 
  */
 export function mentionedSessions(
   caption: string | undefined,
-  sessions: readonly NormalizedSession[],
+  sessions: readonly MentionableSession[],
 ): readonly SessionMention[] {
   if (!caption) return [];
   const spoken = caption.toLowerCase();
-  const mentions: { at: number; kind: SessionMentionKind; session: NormalizedSession }[] = [];
+  const mentions: { at: number; kind: SessionMentionKind; session: MentionableSession }[] = [];
   for (const [name, candidate] of mentionCandidates(sessions)) {
     if (candidate.ambiguous) continue;
     const at = firstWholeNameIndex(spoken, name);

--- a/packages/surface/src/generated/motion-tokens.css
+++ b/packages/surface/src/generated/motion-tokens.css
@@ -78,6 +78,7 @@
   --slot-delay: calc(var(--duration-exit) + var(--peek-delay));
   --bubble-lift: 4px;
   --caption-max: 210px;
+  --voice-band-inset: 6px;
   --notice-size: 26px;
   --notice-max-rows: 3;
   --panel-width: 620px;

--- a/packages/surface/src/generated/motion-tokens.ts
+++ b/packages/surface/src/generated/motion-tokens.ts
@@ -28,7 +28,12 @@ export const BUBBLE_LIFT = 4;
  * because the block grows to the words and nothing scrolls. CSS: `--caption-max`. */
 export const VOICE_CAPTION_MAX_HEIGHT = 210;
 
-/** One chip row of the session notice band. CSS: `--notice-size`. */
+/** The one gap between the strip, each band grown below it, and the shape's
+ * bottom edge. CSS: `--voice-band-inset`. */
+export const VOICE_BAND_INSET = 6;
+
+/** One chip row of the session notice band, the inset above it included.
+ * CSS: `--notice-size`. */
 export const SESSION_NOTICE_HEIGHT = 26;
 
 /** Chip rows the band may grow to before scrolling. CSS: `--notice-max-rows`. */

--- a/packages/surface/src/geometry.test.ts
+++ b/packages/surface/src/geometry.test.ts
@@ -10,6 +10,7 @@ import {
   positionNotchWindow,
   SESSION_NOTICE_HEIGHT,
   SESSION_NOTICE_MAX_ROWS,
+  VOICE_BAND_INSET,
   VOICE_CAPTION_MAX_HEIGHT,
 } from "@sidecar/surface";
 import { BUBBLE_LIFT } from "./generated/motion-tokens.js";
@@ -39,9 +40,10 @@ test("anchors the compact window to the physical top edge", () => {
     y: 0,
     width: PANEL_WIDTH + SURFACE_MARGIN * 2,
     // The top inset, the caption block Luke's words wrap into below it, every
-    // chip row the notice band can grow to under those words, and the margin
-    // the overshoot and the shadow fall in: 38 + 210 + 26 × 3 + 40.
-    height: 366,
+    // chip row the notice band can grow to under those words, the inset that
+    // closes the stack against the shape's bottom edge, and the margin the
+    // overshoot and the shadow fall in: 38 + 210 + 26 × 3 + 6 + 40.
+    height: 372,
     notch: {
       topInset: 38,
       housingWidth: 210,
@@ -94,6 +96,7 @@ test("uses a top-center fallback without inventing a notch", () => {
     32 +
       VOICE_CAPTION_MAX_HEIGHT +
       SESSION_NOTICE_HEIGHT * SESSION_NOTICE_MAX_ROWS +
+      VOICE_BAND_INSET +
       SURFACE_MARGIN,
   );
   assert.equal(result.notch.hasNotch, false);
@@ -128,6 +131,7 @@ test("the notch form gives a display without a housing the simulated one", () =>
     32 +
       VOICE_CAPTION_MAX_HEIGHT +
       SESSION_NOTICE_HEIGHT * SESSION_NOTICE_MAX_ROWS +
+      VOICE_BAND_INSET +
       SURFACE_MARGIN,
   );
 });
@@ -258,6 +262,7 @@ test("uses the painted menu bar when it is deeper than the safe area", () => {
     34 +
       VOICE_CAPTION_MAX_HEIGHT +
       SESSION_NOTICE_HEIGHT * SESSION_NOTICE_MAX_ROWS +
+      VOICE_BAND_INSET +
       SURFACE_MARGIN,
   );
   assert.equal(macBookPro14.notch.topInset, 37);
@@ -297,6 +302,7 @@ test("snaps fractional depths to device pixels and ceils the window height", () 
     34 +
       VOICE_CAPTION_MAX_HEIGHT +
       SESSION_NOTICE_HEIGHT * SESSION_NOTICE_MAX_ROWS +
+      VOICE_BAND_INSET +
       SURFACE_MARGIN,
   );
 });

--- a/packages/surface/src/geometry.ts
+++ b/packages/surface/src/geometry.ts
@@ -5,6 +5,7 @@ import {
   PANEL_WIDTH,
   SESSION_NOTICE_HEIGHT,
   SESSION_NOTICE_MAX_ROWS,
+  VOICE_BAND_INSET,
   VOICE_CAPTION_MAX_HEIGHT,
 } from "./generated/motion-tokens.js";
 
@@ -93,15 +94,18 @@ export interface NotchWindowLayout extends Rectangle {
 export const CAPSULE_SIDE_WIDTH = 36;
 export const PEEK_SIDE_GROWTH = 88;
 export const SURFACE_MARGIN = 40;
-// BUBBLE_LIFT, VOICE_CAPTION_MAX_HEIGHT, SESSION_NOTICE_HEIGHT,
-// SESSION_NOTICE_MAX_ROWS, PANEL_WIDTH, and PANEL_MAX_HEIGHT come from the shared surface
+// BUBBLE_LIFT, VOICE_CAPTION_MAX_HEIGHT, VOICE_BAND_INSET,
+// SESSION_NOTICE_HEIGHT, SESSION_NOTICE_MAX_ROWS, PANEL_WIDTH, and
+// PANEL_MAX_HEIGHT come from the shared surface
 // tokens, so the window the main process sizes and the shape the renderer
 // draws cannot drift. The bubble's lift is derived: the pill matches the 24pt
 // menu bar it floats beside — the 32px compact strip minus the lift on each
 // side. The compact window holds the caption block for the same reason it
 // holds the peek's width — speech must never cost an IPC resize — and every
 // row the notice band can grow to below it, because a reply may name several
-// sessions under captioned speech.
+// sessions under captioned speech. One inset closes the stack: every band
+// carries the gap above itself, so the last one still needs its own gap
+// before the shape's bottom edge.
 const peekSideWidth = CAPSULE_SIDE_WIDTH + PEEK_SIDE_GROWTH;
 
 /**
@@ -190,6 +194,7 @@ export function positionNotchWindow(
           Math.ceil(Math.max(32, notch.topInset)) +
             VOICE_CAPTION_MAX_HEIGHT +
             SESSION_NOTICE_HEIGHT * SESSION_NOTICE_MAX_ROWS +
+            VOICE_BAND_INSET +
             SURFACE_MARGIN,
           display.bounds.height,
         );

--- a/packages/surface/src/index.ts
+++ b/packages/surface/src/index.ts
@@ -12,6 +12,7 @@ export {
   PANEL_WIDTH,
   SESSION_NOTICE_HEIGHT,
   SESSION_NOTICE_MAX_ROWS,
+  VOICE_BAND_INSET,
   VOICE_CAPTION_MAX_HEIGHT,
 } from "./generated/motion-tokens.js";
 export {

--- a/scripts/evidence.sh
+++ b/scripts/evidence.sh
@@ -85,16 +85,17 @@ validate_evidence() {
 # The window is a stage, not the shape: every window holds the panel's width,
 # so a mode change never moves it, and a compact one still holds the peek the
 # capsule grows into, the caption block a whole reply is shown in, every chip
-# row the notice band can wrap into, and room for a spring to overshoot —
-# 38 + 210 + 26 × 3 + 40 tall on the pinned housing.
+# row the notice band can wrap into, the inset that closes the stack against
+# the shape's bottom edge, and room for a spring to overshoot —
+# 38 + 210 + 26 × 3 + 6 + 40 tall on the pinned housing.
 validate_evidence "$SIDECAR_EXPANDED_EVIDENCE_PATH" 700 560
-validate_evidence "$SIDECAR_COMPACT_EVIDENCE_PATH" 700 366
-validate_evidence "$SIDECAR_PEEK_EVIDENCE_PATH" 700 366
+validate_evidence "$SIDECAR_COMPACT_EVIDENCE_PATH" 700 372
+validate_evidence "$SIDECAR_PEEK_EVIDENCE_PATH" 700 372
 # The slot is drawn in the expanded window, which is why stepping aside for a
 # browser costs no resize at all.
 validate_evidence "$SIDECAR_SLOT_EVIDENCE_PATH" 700 560
-validate_evidence "$SIDECAR_SPEAKING_EVIDENCE_PATH" 700 366
-validate_evidence "$SIDECAR_MUTED_EVIDENCE_PATH" 700 366
+validate_evidence "$SIDECAR_SPEAKING_EVIDENCE_PATH" 700 372
+validate_evidence "$SIDECAR_MUTED_EVIDENCE_PATH" 700 372
 
 printf 'Expanded visual evidence: %s\n' "$SIDECAR_EXPANDED_EVIDENCE_PATH"
 printf 'Compact visual evidence: %s\n' "$SIDECAR_COMPACT_EVIDENCE_PATH"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Everything the surface grows below the strip — the mention chips, Luke's words, the volume hint — chose its own breathing room, so a reply that drew all three read as three bands rather than one column. The chips stood 3px under the strip and 3px off the shape's edge, the caption block put 5px above its words and 9px below them, and the hint's row met the words with nothing between them while the caption's inset moved underneath it. A bubble's open panel closed on twice its lift more room again, because the bands measure their travel from the strip while a bubble's shape is inset from both of the strip's own edges.
- One number now: `VOICE_BAND_INSET`, emitted beside the layout sizes the window and the drawing already share. Each band carries that inset above itself and nothing below, the shape adds one more under the last of them, and `--voice-band-origin` gives the compact strip and the open panel the same edge to hang off. The chips already wrapped at that gap, so a measured band still lands on an exact reserved row; the compact window reserves the closing inset; and Got it takes the notice chip's pill exactly, so the two pressable things under the housing stand the same height.
- The chip band had never been photographed. The speaking and muted evidence profiles caption the shape with a sentence written to name the fixture roster's own rows, but a fixture run observes no provider and mentions resolve against the roster an observation pass fills — empty there. `mentionedSessions` now takes the fields it actually reads rather than a whole observed session, so a drawn-only fixture row is named by exactly the matching a live one is, and the band the fixture sentence earns is in every capture. The sentence moved next to the roster it talks about, where a test holds the two together.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — passed (1687 package tests plus 54 harness tests, 0 failures, exit 0)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — this agent runs on Linux, so the macOS packaging half is unavailable. The Electron app itself was built and run headless under Xvfb instead, and the repository's own capture path (`--fixture smoke --profile muted|speaking --capture-evidence`) produced the PNGs below.

Every band's drawn box was read out of the running renderer over the DevTools protocol, in each state that grows one, in both form factors — each gap is exactly the inset:

![The peek before and after: the same shape with chips, words, and the volume hint, evenly spaced after](https://cursor.com/artifacts/c/art-0c738298-c847-4d9e-a5a8-17d913f8e2b5)

![The open panel](https://cursor.com/artifacts/c/art-c3804249-0830-4f4e-bad4-96604f8cdd4d)

An announcement spoken with captions off draws the band alone, and it takes the same rule — the shape grows one row of chips plus an inset on each side:

![The chips-only band before and after: 3px above and below becomes 6px](https://cursor.com/artifacts/c/art-45055173-d210-4efa-95f5-afb49298664d)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32435616482/artifacts/9430670095) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32435616482)

- Commit: `c58eb6e9e5c2deb2061c82c7be175da37f1996a5`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded` — captured under Xvfb at 2000×1400, once with the simulated-housing form factor and once as a bubble

## Notes

- Blockers or follow-up verification: `./scripts/verify.sh` and a physical-notch look are still owed on a Mac. `scripts/evidence.sh` was updated to expect the compact window's new height (372 rather than 366), since the window now reserves the inset that closes the stack.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1df66b90-72b8-4362-8a1f-c225b3713e7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1df66b90-72b8-4362-8a1f-c225b3713e7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

