### PR TITLE
docs(release): include waiting announcement fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ the date its release was published.
 
 ### Fixes
 
+- Fixed Luke announcing that a chat is waiting when it does not need a reply
+  ([#374](https://github.com/ReviewStage/luke/pull/374))
 - Fixed the ready-to-install update status using unnecessary extra copy
   ([#373](https://github.com/ReviewStage/luke/pull/373))
 - Fixed Developer ID releases omitting native helpers from the packaged app


### PR DESCRIPTION
## Summary

- include #374 in the 0.3.7 release notes after it landed immediately ahead of the version PR

## Verification

- `./scripts/check.sh`

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32434840569/artifacts/9430401212) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32434840569)

- Commit: `0e1b0578e3d4215dbeb25a8ac4538717bbe1a4d6`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
