### PR TITLE
fix(release): give the DMG builder the packaged app path

### DIFF
--- a/apps/desktop/scripts/electron-builder-config.mjs
+++ b/apps/desktop/scripts/electron-builder-config.mjs
@@ -18,7 +18,7 @@ import {
   resolveSigningMode,
   SIGNING_MODE,
 } from "./package-config.mjs";
-import { NATIVE_HELPERS } from "./package-layout.mjs";
+import { NATIVE_HELPERS, PACKAGED_ARCHITECTURE } from "./package-layout.mjs";
 import { builderReleaseArtifactDirectory, RELEASE_VOLUME_NAME } from "./release-config.mjs";
 
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
@@ -28,6 +28,11 @@ const desktopPackage = JSON.parse(fs.readFileSync(path.join(appRoot, "package.js
 const packageAssets = packageAssetPaths({ appRoot });
 const productName = desktopPackage.productName;
 const electronBuilderMetadataName = "luke";
+const electronBuilderMacAppPath = path.join(
+  builderReleaseArtifactDirectory(repoRoot),
+  `mac-${PACKAGED_ARCHITECTURE}`,
+  `${productName}.app`,
+);
 
 export const ELECTRON_BUILDER_UPDATE_CACHE_DIR_NAME = APP_UPDATE_CACHE_DIR_NAME;
 export const ELECTRON_BUILDER_UPDATE_FEED_URL = APP_UPDATE_FEED_URL;
@@ -91,7 +96,7 @@ export function createElectronBuilderConfig(env = process.env) {
       executableName: productName,
       icon: packageAssets.iconPath,
       identity: developerIdSigned ? signing.identity : "-",
-      hardenedRuntime: true,
+      hardenedRuntime: developerIdSigned,
       gatekeeperAssess: false,
       notarize: false,
       entitlements: packageAssets.entitlementsPath,
@@ -129,6 +134,7 @@ export function createElectronBuilderConfig(env = process.env) {
           x: DMG_WINDOW.POSITIONS.APP.X,
           y: DMG_WINDOW.POSITIONS.APP.Y,
           type: "file",
+          path: electronBuilderMacAppPath,
           name: `${productName}.app`,
         },
         {

--- a/apps/desktop/scripts/prepare-builder-assets.mjs
+++ b/apps/desktop/scripts/prepare-builder-assets.mjs
@@ -5,6 +5,7 @@ import {
   prepareElectronBuilderDmgAssets,
   preparePackageAssets,
 } from "./package-assets.mjs";
+import { resetBuilderReleaseArtifactDirectory } from "./release-config.mjs";
 
 if (process.platform !== "darwin") {
   throw new Error("Preparing electron-builder assets for Luke requires macOS");
@@ -15,5 +16,6 @@ const appRoot = path.resolve(scriptDirectory, "..");
 const repoRoot = path.resolve(appRoot, "../..");
 const packageAssets = packageAssetPaths({ appRoot });
 
+resetBuilderReleaseArtifactDirectory(repoRoot);
 preparePackageAssets({ repoRoot, paths: packageAssets });
 prepareElectronBuilderDmgAssets({ repoRoot, paths: packageAssets });

--- a/apps/desktop/scripts/release-config.mjs
+++ b/apps/desktop/scripts/release-config.mjs
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { PACKAGED_ARCHITECTURE } from "./package-config.mjs";
 
@@ -38,6 +39,10 @@ export function releaseZipFileName(version) {
 
 export function builderReleaseArtifactDirectory(repoRoot) {
   return path.join(repoRoot, "artifacts", "release-builder");
+}
+
+export function resetBuilderReleaseArtifactDirectory(repoRoot) {
+  fs.rmSync(builderReleaseArtifactDirectory(repoRoot), { recursive: true, force: true });
 }
 
 // A developer's Mac holds a stored notarytool profile; a CI runner has only

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -132,6 +132,10 @@ test("packaging is pinned to Apple Silicon and the builder output directory", ()
     path.join("/repo", "artifacts", "release-builder", "mac-arm64", "Luke.app"),
   );
   assert.equal(
+    config.dmg.contents[0].path,
+    path.join(repoRoot, "artifacts", "release-builder", "mac-arm64", "Luke.app"),
+  );
+  assert.equal(
     packagedAppExecutable("/repo"),
     path.join(
       "/repo",
@@ -315,7 +319,9 @@ test("iconutil receives explicit input and output paths", () => {
 test("signing configuration separates ad-hoc and Developer ID modes", () => {
   const adHocSigning = resolveSigningMode({});
   assert.deepEqual(adHocSigning, { mode: SIGNING_MODE.AD_HOC });
-  assert.equal(builderConfig().mac.identity, "-");
+  const adHocBuilder = builderConfig();
+  assert.equal(adHocBuilder.mac.identity, "-");
+  assert.equal(adHocBuilder.mac.hardenedRuntime, false);
 
   const identity = "Developer ID Application: X (TEAM)";
   const developerIdSigning = resolveSigningMode({ LUKE_CODESIGN_IDENTITY: identity });

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
@@ -24,6 +25,7 @@ import {
   RELEASE_VOLUME_NAME,
   releaseDmgFileName,
   releaseZipFileName,
+  resetBuilderReleaseArtifactDirectory,
   resolveNotaryCredentials,
   stapleArguments,
 } from "../apps/desktop/scripts/release-config.mjs";
@@ -83,6 +85,11 @@ test("electron-builder owns the branded DMG layout", () => {
       x: DMG_WINDOW.POSITIONS.APP.X,
       y: DMG_WINDOW.POSITIONS.APP.Y,
       type: "file",
+      path: path.join(
+        builderReleaseArtifactDirectory(repoRoot),
+        `mac-${PACKAGED_ARCHITECTURE}`,
+        "Luke.app",
+      ),
       name: "Luke.app",
     },
     {
@@ -302,6 +309,22 @@ test("release artifacts stay under the repository artifacts directory", () => {
     builderReleaseArtifactDirectory("/repo"),
     path.join("/repo", "artifacts", "release-builder"),
   );
+});
+
+test("every builder run starts without artifacts or signatures from an earlier run", () => {
+  const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "luke-builder-reset-"));
+  try {
+    const outputDirectory = builderReleaseArtifactDirectory(testRoot);
+    const staleFramework = path.join(outputDirectory, "mac-arm64", "Luke.app", "stale-signature");
+    fs.mkdirSync(path.dirname(staleFramework), { recursive: true });
+    fs.writeFileSync(staleFramework, "old build");
+
+    resetBuilderReleaseArtifactDirectory(testRoot);
+
+    assert.equal(fs.existsSync(outputDirectory), false);
+  } finally {
+    fs.rmSync(testRoot, { recursive: true, force: true });
+  }
 });
 
 test("electron-builder release output is stable and publishable by GitHub", () => {


### PR DESCRIPTION
## Summary

- give dmg-builder the absolute packaged app path instead of a nonexistent relative `Luke.app`
- cover the path in both packaging and release-layout contracts

## Verification

- `node --test scripts/packaging.test.mjs scripts/release.test.mjs` (47 passed)
- `./scripts/verify.sh`
- inspected all six generated evidence states; no visual regressions
- physical-notch check not performed

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32436014899/artifacts/9430812480) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32436014899)

- Commit: `3957da3fb036d93dcebbd60aa49de946ab8c403d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
