### PR TITLE
feat(cursor): name the tool call an open local turn is running

### DIFF
--- a/packages/providers/src/cursor/local-adapter.test.ts
+++ b/packages/providers/src/cursor/local-adapter.test.ts
@@ -308,6 +308,119 @@ test("tells a turn that finished from one that failed", async (t) => {
   assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);
 });
 
+test("names the tool call an open turn is running", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "session-working",
+    [
+      messageRecord(TEST_ROLE.USER, TEST_CONTENT_TYPE.TEXT),
+      {
+        role: TEST_ROLE.ASSISTANT,
+        message: {
+          content: [
+            { type: TEST_CONTENT_TYPE.TEXT, text: SECRET_TRANSCRIPT_TEXT },
+            { type: TEST_CONTENT_TYPE.TOOL_USE, name: "Grep", input: { pattern: "statusFrom" } },
+            { type: TEST_CONTENT_TYPE.TOOL_USE, name: "Read", input: { file_path: "a/b.ts" } },
+          ],
+        },
+      },
+    ],
+    TEST_TIME - 5_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
+  // The newest call is what the turn is doing right now, named by the input
+  // that says what it is for; the message text beside it never surfaces.
+  assert.equal(observations[0]?.detail?.activity, "Read: a/b.ts");
+  assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);
+});
+
+test("a turn that ended is no longer running its last tool call", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  const toolCall = {
+    role: TEST_ROLE.ASSISTANT,
+    message: {
+      content: [{ type: TEST_CONTENT_TYPE.TOOL_USE, name: "Shell", input: { command: "ls" } }],
+    },
+  };
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "session-settled",
+    [toolCall, turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 5_000,
+  );
+  // A new prompt opens a turn that is not running the previous turn's call.
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "session-reprompted",
+    [toolCall, messageRecord(TEST_ROLE.USER, TEST_CONTENT_TYPE.TEXT)],
+    TEST_TIME - 10_000,
+  );
+  // A block with no tool name says nothing about what the turn is doing.
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "session-unnamed-call",
+    [messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TOOL_USE)],
+    TEST_TIME - 15_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => [
+      observation.providerSessionId,
+      observation.detail?.activity,
+    ]),
+    [
+      ["session-settled", undefined],
+      ["session-reprompted", undefined],
+      ["session-unnamed-call", undefined],
+    ],
+  );
+  assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);
+});
+
+test("bounds the phrase a tool call is named by", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "session-long-call",
+    [
+      {
+        role: TEST_ROLE.ASSISTANT,
+        message: {
+          content: [
+            {
+              type: TEST_CONTENT_TYPE.TOOL_USE,
+              name: "Shell",
+              input: { command: `run ${"x".repeat(200)}` },
+            },
+          ],
+        },
+      },
+    ],
+    TEST_TIME - 5_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  const activity = observations[0]?.detail?.activity;
+  assert.ok(activity?.startsWith("Shell: run x"));
+  assert.ok(activity !== undefined && activity.length <= "Shell: ".length + 80);
+  assert.ok(activity?.endsWith("…"));
+});
+
 test("offers the app's address only for the chats the app itself holds", async (t) => {
   const state = await temporaryCursorState(t);
   await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");

--- a/packages/providers/src/cursor/local-adapter.ts
+++ b/packages/providers/src/cursor/local-adapter.ts
@@ -9,8 +9,11 @@ import {
   UNKNOWN_WORKSPACE_LABEL,
 } from "@sidecar/session";
 import {
+  isRecord,
   isWireString,
+  oneLine,
   resolveOptions,
+  text,
   unparsedWire,
   type WireBoundaryInput,
   type WireRecord,
@@ -36,9 +39,10 @@ import {
   type SqliteDatabase,
   type SqliteModuleLoader,
 } from "../shared/local-sqlite.js";
+import { transcriptContentBlocks } from "../shared/local-transcript.js";
 import { CURSOR_PROVIDER } from "./adapter.js";
 import { cursorApplication, cursorChatLink } from "./app-links.js";
-import { readCursorSessionTranscript } from "./transcript.js";
+import { CURSOR_TOOL_INPUT_KEY, readCursorSessionTranscript } from "./transcript.js";
 
 /** A turn Cursor failed records its own reason, which is transcript content. */
 const CURSOR_TURN_FAILED_MESSAGE = "The turn failed";
@@ -113,14 +117,20 @@ const CURSOR_TURN_STATUS = {
   ERROR: "error",
 } as const;
 
-/** Who a message record belongs to. Its content is never read. */
+/** Who a message record belongs to. The conversation's words are never read. */
 const CURSOR_ROLE = {
   ASSISTANT: "assistant",
   USER: "user",
 } as const;
 
+/** The one content block observation reads: the tool call a turn is running. */
+const CURSOR_CONTENT_TYPE = {
+  TOOL_USE: "tool_use",
+} as const;
+
 const CURSOR_LOCAL_ADAPTER_DEFAULTS = {
   MAXIMUM_PROJECT_DIRECTORIES: 200,
+  MAXIMUM_ACTIVITY_LENGTH: 80,
 } as const;
 
 export interface CursorLocalAdapterOptions {
@@ -278,21 +288,57 @@ function isMessageRecord(record: WireRecord): boolean {
   return Object.values(CURSOR_ROLE).some((knownRole) => knownRole === role);
 }
 
-/**
- * How the newest turn ended, or nothing while one is still open. Cursor marks
- * the end of a turn explicitly, so an open turn is read from the absence of
- * that mark rather than inferred from what the assistant last said — which is
- * transcript content, and is not read here at all. A record this build does not
- * know is passed over rather than taken for either.
- */
-function closedTurn(tail: string): { failed: boolean } | undefined {
-  for (const record of tailRecords(tail).toReversed()) {
-    if (record[CURSOR_RECORD_FIELD.TYPE] === CURSOR_RECORD_TYPE.TURN_ENDED) {
-      return { failed: record[CURSOR_RECORD_FIELD.STATUS] === CURSOR_TURN_STATUS.ERROR };
-    }
-    if (isMessageRecord(record)) return undefined;
+/** What the bounded tail says about the newest turn. */
+interface ParsedCursorTail {
+  /** How the newest turn ended, or nothing while one is still open. */
+  turn?: { failed: boolean };
+  /** The tool call the open turn is running, named the way Codex's rows name theirs. */
+  activity?: string;
+}
+
+/** Names the tool a turn called, preferring whichever input says what it is for. */
+function activityFromToolUse(block: WireRecord): string | undefined {
+  const name = text(block.name);
+  if (!name) return undefined;
+  const input = isRecord(block.input) ? block.input : {};
+  for (const key of CURSOR_TOOL_INPUT_KEY) {
+    const detail = oneLine(text(input[key]), CURSOR_LOCAL_ADAPTER_DEFAULTS.MAXIMUM_ACTIVITY_LENGTH);
+    if (detail) return `${name}: ${detail}`;
   }
-  return undefined;
+  return name;
+}
+
+/**
+ * Reads the turn boundary and the current tool call out of a transcript tail.
+ * Cursor marks the end of a turn explicitly, so an open turn is read from the
+ * absence of that mark rather than inferred from what the assistant last said
+ * — the conversation's words are not read here at all, only the tool-call
+ * blocks that say what the turn is doing right now. A record this build does
+ * not know is passed over rather than taken for either.
+ */
+function parseCursorTail(tail: string): ParsedCursorTail {
+  const parsed: ParsedCursorTail = {};
+  for (const record of tailRecords(tail)) {
+    if (record[CURSOR_RECORD_FIELD.TYPE] === CURSOR_RECORD_TYPE.TURN_ENDED) {
+      parsed.turn = { failed: record[CURSOR_RECORD_FIELD.STATUS] === CURSOR_TURN_STATUS.ERROR };
+      // A turn that ended is not running its last call, and holding it would
+      // keep a stale line on the row until some other tool runs.
+      parsed.activity = undefined;
+      continue;
+    }
+    if (!isMessageRecord(record)) continue;
+    parsed.turn = undefined;
+    if (record[CURSOR_RECORD_FIELD.ROLE] === CURSOR_ROLE.USER) {
+      // A new turn is not running the previous turn's call either.
+      parsed.activity = undefined;
+      continue;
+    }
+    for (const block of transcriptContentBlocks(record, false)) {
+      if (block.type !== CURSOR_CONTENT_TYPE.TOOL_USE) continue;
+      parsed.activity = activityFromToolUse(block) ?? parsed.activity;
+    }
+  }
+  return parsed;
 }
 
 /**
@@ -400,14 +446,21 @@ function matchingChats(
 }
 
 /**
- * What Cursor knows about a local session beyond its state: the folder, that
- * a turn failed, and — for a chat the app holds — the chat's own address.
- * Cursor records why a turn failed, but that reason is written from the turn
- * itself, so the fact of the failure is reported and its wording is not —
- * the same fixed line the cloud half reports for a failed run.
+ * What Cursor knows about a local session beyond its state: the folder, the
+ * tool call an open turn is running, that a turn failed, and — for a chat the
+ * app holds — the chat's own address. Cursor records why a turn failed, but
+ * that reason is written from the turn itself, so the fact of the failure is
+ * reported and its wording is not — the same fixed line the cloud half
+ * reports for a failed run.
  */
-function detailFor(label: string, status: SessionStatus, link: string | undefined): SessionDetail {
+function detailFor(
+  label: string,
+  status: SessionStatus,
+  link: string | undefined,
+  activity: string | undefined,
+): SessionDetail {
   return {
+    ...(activity ? { activity } : undefined),
     repository: label,
     ...(link ? { link } : undefined),
     ...(status === SESSION_STATUS.ERROR ? { error: CURSOR_TURN_FAILED_MESSAGE } : undefined),
@@ -428,12 +481,13 @@ function defaultGlobalStorageStatePath(): string {
 
 /**
  * Observes the Cursor sessions that run on this machine, from the transcripts
- * Cursor already writes for itself. It reads no message content, needs no
- * credential, and reports nothing that Cursor has not written down.
+ * Cursor already writes for itself. It reads the turn markers and the open
+ * turn's tool calls — never the conversation's words — needs no credential,
+ * and reports nothing that Cursor has not written down.
  */
 export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
   CursorTranscriptCandidate,
-  { failed: boolean } | undefined
+  ParsedCursorTail
 > {
   readonly provider = CURSOR_PROVIDER;
 
@@ -506,10 +560,8 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
     });
   }
 
-  protected async parse(
-    candidate: CursorTranscriptCandidate,
-  ): Promise<{ failed: boolean } | undefined> {
-    return closedTurn(await readTail(candidate.filePath, this.#readTailBytes));
+  protected async parse(candidate: CursorTranscriptCandidate): Promise<ParsedCursorTail> {
+    return parseCursorTail(await readTail(candidate.filePath, this.#readTailBytes));
   }
 
   /**
@@ -520,12 +572,12 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
    */
   protected observation(
     candidate: CursorTranscriptCandidate,
-    turn: { failed: boolean } | undefined,
+    parsed: ParsedCursorTail,
     now: number,
     activeSessionFreshnessMs: number,
   ): ProviderSessionObservation {
     const label = this.#workspaceLabels.label(candidate.projectDirectoryName);
-    const status = statusFromTurn(turn, candidate.mtimeMs, now, activeSessionFreshnessMs);
+    const status = statusFromTurn(parsed.turn, candidate.mtimeMs, now, activeSessionFreshnessMs);
     const link = this.#appChats.has(candidate.providerSessionId)
       ? cursorChatLink(candidate.providerSessionId)
       : undefined;
@@ -537,7 +589,7 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
       // written is the only account Cursor keeps of when this session last did
       // anything.
       observedAt: candidate.mtimeMs,
-      detail: detailFor(label, status, link),
+      detail: detailFor(label, status, link, parsed.activity),
       ...(link ? { applications: [cursorApplication(link)] } : undefined),
     };
   }

--- a/packages/providers/src/cursor/transcript.ts
+++ b/packages/providers/src/cursor/transcript.ts
@@ -63,7 +63,7 @@ const CURSOR_CONTENT_TYPE = {
 } as const;
 
 /** Tool inputs whose value names the work, in the order they read best. */
-const CURSOR_TOOL_INPUT_KEY = [
+export const CURSOR_TOOL_INPUT_KEY = [
   "description",
   "file_path",
   "pattern",


### PR DESCRIPTION
## What

A local Cursor row now reports **current tool activity**: the open turn's newest `tool_use` block, named by the tool and the bounded input phrase that says what it is for (`Shell: Commit fix in worktree`, `Read: a/b.ts`) — the same line Codex local rows already carry, with the same 80-character bound.

The tail parser was restructured from `closedTurn` (boundary only) into `parseCursorTail`, walking the bounded tail forward the way Codex's rollout parser does: a `turn_ended` marker or a new user prompt clears the line, so only a turn that is actually running shows one. The conversation's words are still never read into an observation — only tool names and the one input value that names the work, the same fields the transcript readout already renders — and message text stays out, asserted by the existing `SECRET_TRANSCRIPT_TEXT` tests.

## Docs

`PRIVACY.md`'s launch rewrite already names "current tool" among the fields Luke uses ("On your Mac"), so this widening needs no policy change; per `packages/providers/AGENTS.md`, the README's agent table is unchanged because no provider was added.

## Verification

- `./scripts/check.sh` passed (portable change; no renderer code touched), re-run after rebasing onto the archived-chats change (#385).
- `packages/providers` Cursor tests pass, including three new ones (activity named and bounded, cleared at turn end / new prompt / unnamed block).
- Live adapter run against this machine's real `~/.cursor/projects` sessions shows activity lines on working-turn transcripts (`ApplyPatch`, `ReadFile`, `Shell: …`) and none on settled ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)