### PR TITLE
feat(cursor): recap a settled local turn by its parting words

### DIFF
--- a/packages/providers/src/cursor/local-adapter.test.ts
+++ b/packages/providers/src/cursor/local-adapter.test.ts
@@ -269,12 +269,13 @@ test("tells a turn that finished from one that failed", async (t) => {
   const state = await temporaryCursorState(t);
   await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
   await registerAppChats(state, ["session-finished", "session-failed"]);
+  const partingWords = "All checks are green and the branch is pushed.";
   await writeTranscript(
     state,
     "Users-test-luke",
     "session-finished",
     [
-      messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TEXT),
+      { role: TEST_ROLE.ASSISTANT, message: { content: [{ type: "text", text: partingWords }] } },
       turnEndedRecord(TEST_TURN_STATUS.SUCCESS),
     ],
     TEST_TIME - 5_000,
@@ -284,7 +285,7 @@ test("tells a turn that finished from one that failed", async (t) => {
     "Users-test-luke",
     "session-failed",
     [
-      messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TOOL_USE),
+      messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TEXT),
       turnEndedRecord(TEST_TURN_STATUS.ERROR),
     ],
     TEST_TIME - 10_000,
@@ -299,12 +300,55 @@ test("tells a turn that finished from one that failed", async (t) => {
       ["session-failed", SESSION_STATUS.ERROR],
     ],
   );
-  // The failure is reported; the reason Cursor recorded for it is not.
+  // A cleanly settled turn's parting words are the recap, the one bounded
+  // read of the conversation's words an observation makes.
+  assert.equal(observations[0]?.recap, partingWords);
+  // A failed turn keeps none: the agent's parting words predate what went
+  // wrong. The failure is reported; the reason Cursor recorded for it is not.
+  assert.equal(observations[1]?.recap, undefined);
   assert.deepEqual(observations[1]?.detail, {
     repository: "luke",
     link: "cursor://anysphere.cursor-deeplink/agent?id=session-failed",
     error: "The turn failed",
   });
+  assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);
+});
+
+test("a recap stands only while its turn is the newest word", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  const settledTurn = [
+    { role: TEST_ROLE.ASSISTANT, message: { content: [{ type: "text", text: "Done." }] } },
+    turnEndedRecord(TEST_TURN_STATUS.SUCCESS),
+  ];
+  // A new prompt opens a turn the old parting words no longer sum up.
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "session-reprompted",
+    [...settledTurn, messageRecord(TEST_ROLE.USER, TEST_CONTENT_TYPE.TEXT)],
+    TEST_TIME - 5_000,
+  );
+  // Parting words longer than a recap may carry are cut, not refused.
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "session-longhand",
+    [
+      {
+        role: TEST_ROLE.ASSISTANT,
+        message: { content: [{ type: "text", text: "y".repeat(700) }] },
+      },
+      turnEndedRecord(TEST_TURN_STATUS.SUCCESS),
+    ],
+    TEST_TIME - 10_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.equal(observations[0]?.recap, undefined);
+  assert.equal(observations[1]?.recap?.length, 500);
+  assert.ok(observations[1]?.recap?.endsWith("…"));
   assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);
 });
 

--- a/packages/providers/src/cursor/local-adapter.ts
+++ b/packages/providers/src/cursor/local-adapter.ts
@@ -2,6 +2,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  maximumSessionRecapLength,
   type ProviderSessionObservation,
   SESSION_STATUS,
   type SessionDetail,
@@ -39,7 +40,7 @@ import {
   type SqliteDatabase,
   type SqliteModuleLoader,
 } from "../shared/local-sqlite.js";
-import { transcriptContentBlocks } from "../shared/local-transcript.js";
+import { transcriptContentBlocks, transcriptMessageText } from "../shared/local-transcript.js";
 import { CURSOR_PROVIDER } from "./adapter.js";
 import { cursorApplication, cursorChatLink } from "./app-links.js";
 import { CURSOR_TOOL_INPUT_KEY, readCursorSessionTranscript } from "./transcript.js";
@@ -294,6 +295,8 @@ interface ParsedCursorTail {
   turn?: { failed: boolean };
   /** The tool call the open turn is running, named the way Codex's rows name theirs. */
   activity?: string;
+  /** A cleanly settled turn's parting words, the same standing as Codex's recap. */
+  recap?: string;
 }
 
 /** Names the tool a turn called, preferring whichever input says what it is for. */
@@ -309,30 +312,41 @@ function activityFromToolUse(block: WireRecord): string | undefined {
 }
 
 /**
- * Reads the turn boundary and the current tool call out of a transcript tail.
- * Cursor marks the end of a turn explicitly, so an open turn is read from the
- * absence of that mark rather than inferred from what the assistant last said
- * — the conversation's words are not read here at all, only the tool-call
- * blocks that say what the turn is doing right now. A record this build does
- * not know is passed over rather than taken for either.
+ * Reads the turn boundary, the current tool call, and a settled turn's recap
+ * out of a transcript tail. Cursor marks the end of a turn explicitly, so an
+ * open turn is read from the absence of that mark rather than inferred from
+ * what the assistant last said. The conversation's words stay in the records
+ * they were parsed from, with one bounded exception: a cleanly settled turn's
+ * parting words become the session's recap, the same standing as the recap
+ * Codex writes — a failed turn keeps none, because the agent's parting words
+ * predate what went wrong. A record this build does not know is passed over
+ * rather than taken for anything.
  */
 function parseCursorTail(tail: string): ParsedCursorTail {
   const parsed: ParsedCursorTail = {};
+  let partingWords: string | undefined;
   for (const record of tailRecords(tail)) {
     if (record[CURSOR_RECORD_FIELD.TYPE] === CURSOR_RECORD_TYPE.TURN_ENDED) {
-      parsed.turn = { failed: record[CURSOR_RECORD_FIELD.STATUS] === CURSOR_TURN_STATUS.ERROR };
+      const failed = record[CURSOR_RECORD_FIELD.STATUS] === CURSOR_TURN_STATUS.ERROR;
+      parsed.turn = { failed };
       // A turn that ended is not running its last call, and holding it would
       // keep a stale line on the row until some other tool runs.
       parsed.activity = undefined;
+      parsed.recap = failed ? undefined : oneLine(partingWords, maximumSessionRecapLength);
+      partingWords = undefined;
       continue;
     }
     if (!isMessageRecord(record)) continue;
     parsed.turn = undefined;
     if (record[CURSOR_RECORD_FIELD.ROLE] === CURSOR_ROLE.USER) {
-      // A new turn is not running the previous turn's call either.
+      // A new turn is not running the previous turn's call, and its work is
+      // not summed up by the previous turn's parting words.
       parsed.activity = undefined;
+      parsed.recap = undefined;
+      partingWords = undefined;
       continue;
     }
+    partingWords = transcriptMessageText(record, false) ?? partingWords;
     for (const block of transcriptContentBlocks(record, false)) {
       if (block.type !== CURSOR_CONTENT_TYPE.TOOL_USE) continue;
       parsed.activity = activityFromToolUse(block) ?? parsed.activity;
@@ -481,9 +495,10 @@ function defaultGlobalStorageStatePath(): string {
 
 /**
  * Observes the Cursor sessions that run on this machine, from the transcripts
- * Cursor already writes for itself. It reads the turn markers and the open
- * turn's tool calls — never the conversation's words — needs no credential,
- * and reports nothing that Cursor has not written down.
+ * Cursor already writes for itself. It reads the turn markers, the open
+ * turn's tool calls, and a settled turn's parting words as the recap — nothing
+ * else of the conversation — needs no credential, and reports nothing that
+ * Cursor has not written down.
  */
 export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
   CursorTranscriptCandidate,
@@ -590,6 +605,7 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
       // anything.
       observedAt: candidate.mtimeMs,
       detail: detailFor(label, status, link, parsed.activity),
+      ...(parsed.recap ? { recap: parsed.recap } : undefined),
       ...(link ? { applications: [cursorApplication(link)] } : undefined),
     };
   }


### PR DESCRIPTION
> Stacked on #382 (`feat/cursor-local-activity`); this PR's own change is the last commit. It will be rebased as the stack lands.

## What

A local Cursor row now reports a **recap**: the settled turn's last agent message, read from the transcript tail the adapter already parses, mirroring the two precedents:

- **Codex local** reports `last_agent_message` as the recap; **Gemini CLI** reports a cleanly settled turn's parting words. Cursor local now has exactly the Gemini shape: parting words only once the turn settled cleanly, nothing mid-turn.
- A **failed turn keeps no recap** — the parting words predate what went wrong, and the failure (without Cursor's withheld reason) is what the row has to say.
- A **new prompt clears it**: an open turn is not summed up by the previous turn's words.
- Bounded by `maximumSessionRecapLength` (500), cut with an ellipsis, never refused.

## Docs

`PRIVACY.md`'s launch rewrite already names "the summary the agent wrote" among the fields Luke uses, the same standing Codex's and Gemini CLI's recaps travel under, so this widening needs no policy change.

## Verification

- `./scripts/check.sh` passed; re-run after rebasing onto #385.
- Cursor adapter tests pass, including the reworked settled/failed pair (recap present on settled, absent on failed) and a new test covering the cleared-by-new-prompt and 500-character bound behaviors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32439696486/artifacts/9432001304) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32439696486)

- Commit: `0288be295b7100fa19a69e01083624a7a1cc5a4d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
