### PR TITLE
fix(desktop): move the app marks below the timestamp on session rows

### DIFF
--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -498,57 +498,23 @@ function SessionRow({
         {session.realtimeVoice ? <AudioBadge /> : null}
       </span>
       <span className="row-copy">
-        <span className="row-title-line">
-          <strong>
-            {session.openable && hasOpenableApplication ? (
-              <button
-                type="button"
-                className="row-title-open"
-                title={`Open in ${openLabel}`}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onOpen(session);
-                }}
-              >
-                <Highlighted text={title} tokens={highlight} />
-              </button>
-            ) : (
+        <strong>
+          {session.openable && hasOpenableApplication ? (
+            <button
+              type="button"
+              className="row-title-open"
+              title={`Open in ${openLabel}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                onOpen(session);
+              }}
+            >
               <Highlighted text={title} tokens={highlight} />
-            )}
-          </strong>
-          {applications.length > 0 ? (
-            <span className="row-applications">
-              {applications.map((application) => {
-                const applicationId = application.id;
-                return application.openable && isSessionApplicationId(applicationId) ? (
-                  <button
-                    type="button"
-                    className="row-application row-application-button"
-                    title={`Open in ${application.name}`}
-                    aria-label={`Open in ${application.name}`}
-                    key={applicationId}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onOpenApplication(session, applicationId);
-                    }}
-                  >
-                    <ProviderMark providerId={applicationId} />
-                  </button>
-                ) : (
-                  <span
-                    className="row-application"
-                    role="img"
-                    aria-label={`Also in ${application.name}`}
-                    title={application.name}
-                    key={applicationId}
-                  >
-                    <ProviderMark providerId={applicationId} />
-                  </span>
-                );
-              })}
-            </span>
-          ) : null}
-        </span>
+            </button>
+          ) : (
+            <Highlighted text={title} tokens={highlight} />
+          )}
+        </strong>
         <small className="row-doing">
           {session.urgency === SESSION_URGENCY.WORKING ? (
             <span className="row-spinner" aria-hidden="true" />
@@ -577,10 +543,44 @@ function SessionRow({
           </small>
         ) : null}
       </span>
-      <small className="row-when">
-        {session.noticeAsk ? <ListeningGlyph ask={session.noticeAsk} /> : null}
-        {observedAgoLabel(session.observedAt, now)}
-      </small>
+      <span className="row-side">
+        <small className="row-when">
+          {session.noticeAsk ? <ListeningGlyph ask={session.noticeAsk} /> : null}
+          {observedAgoLabel(session.observedAt, now)}
+        </small>
+        {applications.length > 0 ? (
+          <span className="row-applications">
+            {applications.map((application) => {
+              const applicationId = application.id;
+              return application.openable && isSessionApplicationId(applicationId) ? (
+                <button
+                  type="button"
+                  className="row-application row-application-button"
+                  title={`Open in ${application.name}`}
+                  aria-label={`Open in ${application.name}`}
+                  key={applicationId}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onOpenApplication(session, applicationId);
+                  }}
+                >
+                  <ProviderMark providerId={applicationId} />
+                </button>
+              ) : (
+                <span
+                  className="row-application"
+                  role="img"
+                  aria-label={`Also in ${application.name}`}
+                  title={application.name}
+                  key={applicationId}
+                >
+                  <ProviderMark providerId={applicationId} />
+                </span>
+              );
+            })}
+          </span>
+        ) : null}
+      </span>
     </>
   );
 

--- a/apps/desktop/src/renderer/styles/sessions-row-side.test.ts
+++ b/apps/desktop/src/renderer/styles/sessions-row-side.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+/**
+ * The session row's trailing column stacks the age over the app marks. These
+ * read the stylesheet and the row's markup as text, the way the settings
+ * header tests do, and guard the facts "the marks sit under the age" stands
+ * on: the column that stacks them, the markup order that puts the age first,
+ * and the width rules that let a long title ellipsize instead of pushing the
+ * column off the row.
+ */
+const css = readFileSync(new URL("./sessions.css", import.meta.url), "utf8");
+const markup = readFileSync(new URL("../panel-body.tsx", import.meta.url), "utf8");
+
+const rule = (selector: string): string => {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`${escaped} \\{([^}]*)\\}`).exec(css)?.[1] ?? "";
+};
+
+test("the trailing column stacks and pins against the title's line", () => {
+  const side = rule(".row-side");
+  assert.match(side, /flex-direction: column;/);
+  // Pinned top-right whatever the copy column's line count, the seat the age
+  // held when it stood alone.
+  assert.match(side, /align-self: flex-start;/);
+  // The marks right-align under the age, flush with the row's right edge.
+  assert.match(side, /align-items: flex-end;/);
+});
+
+test("the age leads the trailing column and the app marks follow", () => {
+  const side = markup.indexOf('className="row-side"');
+  assert.notEqual(side, -1);
+  const when = markup.indexOf('className="row-when"', side);
+  const applications = markup.indexOf('className="row-applications"', side);
+  assert.notEqual(when, -1);
+  assert.notEqual(applications, -1);
+  assert.ok(when < applications, "the app marks belong under the age, not above it");
+});
+
+test("a narrowing row spends the title, never the trailing column", () => {
+  const copy = rule(".row-copy");
+  assert.match(copy, /flex: 1;/);
+  assert.match(copy, /min-width: 0;/);
+  assert.match(rule(".row-side"), /flex: 0 0 auto;/);
+});

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -585,18 +585,6 @@ html[data-keyboard="true"] button.session-row:focus-visible {
   white-space: nowrap;
 }
 
-.row-title-line {
-  display: flex;
-  min-width: 0;
-  align-items: center;
-  gap: 6px;
-}
-
-.row-title-line strong {
-  min-width: 0;
-  flex: 1 1 auto;
-}
-
 /* When an exact app mark is independently pressable, the title carries the
    row's preferred open action. It remains typographically indistinguishable
    from the strong text it replaces; only hover and keyboard focus reveal the
@@ -613,57 +601,6 @@ html[data-keyboard="true"] button.session-row:focus-visible {
   text-align: left;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-/* App associations follow the title as bare marks: the leading mark already
-   says which agent this is, while these answer where the same local chat also
-   appears. Their fixed trailing seat keeps them visible when a long provider
-   title ellipsizes. */
-.row-applications {
-  display: flex;
-  flex: 0 0 auto;
-  align-items: center;
-  gap: 5px;
-  color: var(--text-secondary);
-}
-
-.row-application {
-  display: grid;
-  place-items: center;
-}
-
-/* An exact destination earns a real button, but no resting container: its app
-   mark stays the same bare mark as an informative association. The small hover
-   ground is feedback for the pointer, not a badge drawn around the identity. */
-.row-application-button {
-  width: 19px;
-  height: 19px;
-  margin: -4px;
-  padding: 0;
-  border-radius: 5px;
-  background: transparent;
-  color: inherit;
-  transition:
-    background-color var(--duration-hover) ease,
-    color var(--duration-hover) ease;
-}
-
-.row-application-button:hover {
-  background: rgba(255, 255, 255, 0.09);
-  color: var(--text-primary);
-}
-
-.row-application .provider-mark {
-  width: 11px;
-  height: 11px;
-}
-
-.row-application .provider-mark[data-mark="superset"] {
-  width: 19px;
-}
-
-.row-application-button:has(.provider-mark[data-mark="superset"]) {
-  width: 27px;
 }
 
 /* A workspace's chats sit in a tray: one card that visibly contains them,
@@ -905,16 +842,25 @@ html[data-keyboard="true"] button.session-row:focus-visible {
   flex: 0 0 auto;
 }
 
-/* When the session was last seen, where every Apple surface puts it. Top-right
-   against the title's line rather than centred on the row, so two-line and
-   three-line rows hold it at the same height. */
-.row-when {
+/* The row's trailing column: the age on top, the app marks under it. Pinned
+   top-right against the title's line rather than centred on the row, so
+   two-line and three-line rows hold the age at the same height — where every
+   Apple surface puts it. */
+.row-side {
   display: flex;
   flex: 0 0 auto;
+  flex-direction: column;
   align-self: flex-start;
+  align-items: flex-end;
+  gap: 5px;
+  padding-top: 2px;
+}
+
+/* When the session was last seen. */
+.row-when {
+  display: flex;
   align-items: center;
   gap: 4px;
-  padding-top: 2px;
   color: var(--text-tertiary);
   font-size: 10px;
   font-variant-numeric: tabular-nums;
@@ -928,6 +874,56 @@ html[data-keyboard="true"] button.session-row:focus-visible {
   width: 11px;
   height: 11px;
   flex: 0 0 auto;
+}
+
+/* App associations sit under the age as bare marks: the leading mark already
+   says which agent this is, while these answer where the same local chat also
+   appears. Their seat in the trailing column keeps them clear of the title,
+   which can ellipsize without ever pushing them off the row. */
+.row-applications {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--text-secondary);
+}
+
+.row-application {
+  display: grid;
+  place-items: center;
+}
+
+/* An exact destination earns a real button, but no resting container: its app
+   mark stays the same bare mark as an informative association. The small hover
+   ground is feedback for the pointer, not a badge drawn around the identity. */
+.row-application-button {
+  width: 19px;
+  height: 19px;
+  margin: -4px;
+  padding: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: inherit;
+  transition:
+    background-color var(--duration-hover) ease,
+    color var(--duration-hover) ease;
+}
+
+.row-application-button:hover {
+  background: rgba(255, 255, 255, 0.09);
+  color: var(--text-primary);
+}
+
+.row-application .provider-mark {
+  width: 11px;
+  height: 11px;
+}
+
+.row-application .provider-mark[data-mark="superset"] {
+  width: 19px;
+}
+
+.row-application-button:has(.provider-mark[data-mark="superset"]) {
+  width: 27px;
 }
 
 /* A row with a second line stacks, and hands its box's padding down: the first


### PR DESCRIPTION
## What

Moves the session row's app-association marks out of the title line and into a trailing column that stacks them under the age, right-aligned against the row's edge.

- `panel-body.tsx`: `.row-applications` moves from `.row-title-line` into a new `span.row-side` that wraps `.row-when` first and the marks beneath it; the now-empty `.row-title-line` wrapper is gone and the title's `<strong>` is a direct child of `.row-copy` again. The mark markup itself (pressable button vs. static mark, labels, handlers) is unchanged.
- `sessions.css`: new `.row-side` column carries the pinning the age used to hold itself (`align-self: flex-start`, `padding-top: 2px`), so the age keeps its top-right seat on two- and three-line rows and the marks right-align flush beneath it. `.row-copy` keeps `flex: 1; min-width: 0` and `.row-side` is `flex: 0 0 auto`, so a narrowing row spends the title, never the trailing column.
- New `sessions-row-side.test.ts` guards the layout the way the settings header tests do: the column's stacking and pinning declarations, the markup order that puts the age first, and the width rules that keep the title the ellipsizing party.

The web mock needed no change: it never drew app marks, and its `.row-when` carries its own alignment in `apps/web/src/styles.css`.

## Verification

- `./scripts/check.sh` passes; the three new tests run and pass.
- Authored in a Linux sandbox, so `./scripts/verify.sh` could not run here; the layout was inspected against the built stylesheet in a browser harness at 360px and 260px (marks under the age, wide Superset mark included, rows without marks unchanged, long titles ellipsizing cleanly). No physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/fde238bc-7ce6-4948-869e-5e316cee56f7)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32437128362/artifacts/9431191555) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32437128362)

- Commit: `7ad52268cbf16cd84310edc32ca08662c947a337`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
