### PR TITLE
fix(providers): drop archived Cursor chats from the roster

### DIFF
--- a/packages/providers/src/cursor/adapter.test.ts
+++ b/packages/providers/src/cursor/adapter.test.ts
@@ -413,7 +413,7 @@ test("keeps reporting a long run as working", async () => {
 });
 
 // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-test("reports an archived agent as complete without reading its run", async () => {
+test("draws no row for an archived agent, and spends no request on it", async () => {
   const api = fakeCursorApi([
     {
       id: "agent-archived",
@@ -427,9 +427,9 @@ test("reports an archived agent as complete without reading its run", async () =
 
   const observations = await adapterFor(api.fetch).observe();
 
-  assert.equal(observations.length, 1);
-  assert.equal(observations[0]?.status, SESSION_STATUS.COMPLETE);
-  assert.equal(observations[0]?.observedAt, TEST_TIME - 20_000);
+  // Filing away is Cursor's own way of saying a task is done being looked at,
+  // so an archived agent leaves the roster rather than lingering as complete.
+  assert.deepEqual(observations, []);
   assert.deepEqual(
     api.requests.map((request) => request.pathname),
     ["/v1/repositories", "/v1/agents"],
@@ -538,7 +538,7 @@ test("falls back to a neutral label for an agent with no name at all", async () 
   assert.equal(observations[0]?.title, "Cloud agent");
 });
 
-test("reports every agent the page holds, the ones that can still change first", async () => {
+test("reports every unarchived agent the page holds, newest first", async () => {
   const api = fakeCursorApi([
     {
       id: "agent-archived-moments-ago",
@@ -555,7 +555,7 @@ test("reports every agent the page holds, the ones that can still change first",
 
   assert.deepEqual(
     observations.map((observation) => observation.providerSessionId),
-    ["agent-running-newer", "agent-running-older", "agent-archived-moments-ago"],
+    ["agent-running-newer", "agent-running-older"],
   );
 });
 
@@ -635,9 +635,8 @@ test("advertises a follow-up only for an agent whose run has finished", async ()
   // does after a failure is documented nowhere; neither is promised one.
   assert.equal(byId.get("agent-running")?.canReceiveMessage, false);
   assert.equal(byId.get("agent-errored")?.canReceiveMessage, false);
-  assert.equal(byId.get("agent-filed")?.canReceiveMessage, false);
   // The stoppable one is the one still running; every settled agent offers to
-  // be filed away instead, and one already filed offers nothing.
+  // be filed away instead, and one already filed draws no row at all.
   assert.deepEqual(byId.get("agent-running")?.controls, [
     { id: "cancel-run", label: "Stop this run", kind: "stop", target: "run-agent-running" },
   ]);
@@ -647,7 +646,7 @@ test("advertises a follow-up only for an agent whose run has finished", async ()
   assert.deepEqual(byId.get("agent-errored")?.controls, [
     { id: "archive-agent", label: "Archive" },
   ]);
-  assert.equal(byId.get("agent-filed")?.controls, undefined);
+  assert.equal(byId.get("agent-filed"), undefined);
 });
 
 test("hands a follow-up to Cursor's documented run endpoint", async () => {

--- a/packages/providers/src/cursor/adapter.ts
+++ b/packages/providers/src/cursor/adapter.ts
@@ -116,7 +116,8 @@ function cursorCancelRunControl(runId: string): SessionControl {
  * readable but takes no new runs — and the agent is the whole unit of a
  * Cursor cloud workspace, so filing it away is this provider's workspace
  * archive. It is advertised only once the latest run has settled: an agent
- * mid-run has a stop to offer, not a filing away.
+ * mid-run has a stop to offer, not a filing away. A press files the agent
+ * off the roster too, because an archived agent draws no row.
  */
 const CURSOR_ARCHIVE_AGENT_CONTROL = {
   id: "archive-agent",
@@ -331,20 +332,17 @@ export class CursorSessionAdapter extends CloudSessionAdapter {
 
     // Agents are never capped: one page of the documented maximum is the
     // request's only bound, and Cursor lists newest-first, so the `cursor`
-    // page after it could only reach further into the settled past.
+    // page after it could only reach further into the settled past. An
+    // archived agent draws no row at all: filing away is Cursor's own way of
+    // saying a task is done being looked at, and its own surfaces list one
+    // only behind an archive filter.
     const agents = recordsFromPage(body, CURSOR_FIELD.ITEMS)
       .map(agentFromRecord)
       .filter(isDefined)
-      .sort(
-        (first, second) =>
-          Number(first.archived) - Number(second.archived) ||
-          second.lastActivityAt - first.lastActivityAt,
-      );
+      .filter((agent) => !agent.archived)
+      .sort((first, second) => second.lastActivityAt - first.lastActivityAt);
 
-    // The only fan-out in a pass, bounded by the page above — and an archived
-    // agent spends no request at all: an agent record reports whether it was
-    // filed away, never what it is doing, so the status Luke shows exists
-    // only on the run.
+    // The only fan-out in a pass, bounded by the page above.
     const observations = await Promise.all(
       agents.map((agent) => this.#observationFor(request, agent, now)),
     );
@@ -353,13 +351,12 @@ export class CursorSessionAdapter extends CloudSessionAdapter {
 
   /**
    * Cursor documents a follow-up only against an agent whose latest run has
-   * finished: an archived agent cannot take new runs, a running one answers
-   * conflict until its run ends, and what a follow-up does to a failed or
-   * expired run is documented nowhere. Only the case Cursor has promised is
-   * advertised.
+   * finished: a running one answers conflict until its run ends, and what a
+   * follow-up does to a failed or expired run is documented nowhere. Only the
+   * case Cursor has promised is advertised.
    */
-  #agentTakesMessages(agent: CursorAgent, run: CursorRun | undefined): boolean {
-    return !agent.archived && run?.status === CURSOR_RUN_STATUS.FINISHED;
+  #agentTakesMessages(run: CursorRun | undefined): boolean {
+    return run?.status === CURSOR_RUN_STATUS.FINISHED;
   }
 
   /**
@@ -367,11 +364,8 @@ export class CursorSessionAdapter extends CloudSessionAdapter {
    * conflict for one that has already settled. An active run is the only state
    * the control is advertised in.
    */
-  #agentTakesCancel(agent: CursorAgent, run: CursorRun | undefined): boolean {
-    return (
-      !agent.archived &&
-      (run?.status === CURSOR_RUN_STATUS.RUNNING || run?.status === CURSOR_RUN_STATUS.CREATING)
-    );
+  #agentTakesCancel(run: CursorRun | undefined): boolean {
+    return run?.status === CURSOR_RUN_STATUS.RUNNING || run?.status === CURSOR_RUN_STATUS.CREATING;
   }
 
   /**
@@ -381,11 +375,9 @@ export class CursorSessionAdapter extends CloudSessionAdapter {
    * that ends a run on purpose. An agent that has never run has no run to
    * take; one whose run could not be read, or reports a state this build does
    * not know, is not known to have stopped, so it is offered nothing rather
-   * than a filing away that could land on a live turn. An agent already
-   * archived has nothing left to archive.
+   * than a filing away that could land on a live turn.
    */
   #agentTakesArchive(agent: CursorAgent, run: CursorRun | undefined): boolean {
-    if (agent.archived) return false;
     if (!agent.latestRunId) return true;
     return run?.status !== undefined && CURSOR_SETTLED_RUN_STATUSES.has(run.status);
   }
@@ -515,16 +507,16 @@ export class CursorSessionAdapter extends CloudSessionAdapter {
     agent: CursorAgent,
     now: number,
   ): Promise<ProviderSessionObservation | undefined> {
-    // An archived agent is already settled, and one that has never run has no
-    // run to ask about, so neither spends a request.
-    const latestRunId = agent.archived ? undefined : agent.latestRunId;
+    // An agent that has never run has no run to ask about, so it spends no
+    // request.
+    const latestRunId = agent.latestRunId;
     const run = latestRunId
       ? await this.tolerateItemFailure(() => this.#latestRun(request, agent.id, latestRunId))
       : undefined;
     // The run's timestamp is the moment its state was entered; the agent's is
     // only the last resort, because it also moves for edits that are not work.
     const observedAt = run?.updatedAt ?? agent.lastActivityAt;
-    const status = this.#statusFor(agent, run, observedAt, now);
+    const status = this.#statusFor(run, observedAt, now);
     // A run names the repository it pushed to, so a list item that carries no
     // `repos` still resolves to something better than "workspace".
     const repository = agent.repositoryLabel ?? run?.repositoryLabel;
@@ -539,11 +531,10 @@ export class CursorSessionAdapter extends CloudSessionAdapter {
       // share the thread's. The agent page URL Cursor also reports stays
       // reachable inside the app; the pull request keeps its own chip.
       applications: [cursorApplication(cursorCloudAgentLink(agent.id))],
-      canReceiveMessage: this.#agentTakesMessages(agent, run),
+      canReceiveMessage: this.#agentTakesMessages(run),
       // The two controls are exclusive by construction: an active run offers
-      // its stop, a settled agent offers to be filed away, and an archived one
-      // offers nothing.
-      ...(latestRunId && this.#agentTakesCancel(agent, run)
+      // its stop, and a settled agent offers to be filed away.
+      ...(latestRunId && this.#agentTakesCancel(run)
         ? { controls: [cursorCancelRunControl(latestRunId)] }
         : this.#agentTakesArchive(agent, run)
           ? { controls: [CURSOR_ARCHIVE_AGENT_CONTROL] }
@@ -561,13 +552,7 @@ export class CursorSessionAdapter extends CloudSessionAdapter {
     };
   }
 
-  #statusFor(
-    agent: CursorAgent,
-    run: CursorRun | undefined,
-    observedAt: number,
-    now: number,
-  ): SessionStatus {
-    if (agent.archived) return SESSION_STATUS.COMPLETE;
+  #statusFor(run: CursorRun | undefined, observedAt: number, now: number): SessionStatus {
     // A run state this build does not know is not guessed at.
     if (!run?.status) return SESSION_STATUS.UNKNOWN;
     return agedStatus(

--- a/packages/providers/src/cursor/local-adapter.test.ts
+++ b/packages/providers/src/cursor/local-adapter.test.ts
@@ -95,6 +95,38 @@ async function registerAppChats(state: CursorState, sessionIds: readonly string[
   }
 }
 
+/**
+ * The app's per-chat header rows, where Cursor records that a chat was filed
+ * away. A header's value column carries the chat's name, which Cursor writes
+ * from the opening prompt, so the fixture plants transcript text there and
+ * the tests assert it never surfaces.
+ */
+async function writeChatHeaders(
+  state: CursorState,
+  chats: readonly { sessionId: string; archived: boolean }[],
+): Promise<void> {
+  const { DatabaseSync } = await import("node:sqlite");
+  const database = new DatabaseSync(state.globalStorageStatePath, {});
+  try {
+    database.exec(
+      "CREATE TABLE IF NOT EXISTS composerHeaders (composerId TEXT PRIMARY KEY, workspaceId TEXT, createdAt INTEGER, lastUpdatedAt INTEGER, isArchived INTEGER, isSubagent INTEGER, recency INTEGER, checkpointAt INTEGER, value TEXT)",
+    );
+    for (const chat of chats) {
+      database
+        .prepare(
+          "INSERT OR REPLACE INTO composerHeaders (composerId, isArchived, value) VALUES (?, ?, ?)",
+        )
+        .run(
+          chat.sessionId,
+          chat.archived ? 1 : 0,
+          JSON.stringify({ name: SECRET_TRANSCRIPT_TEXT }),
+        );
+    }
+  } finally {
+    database.close();
+  }
+}
+
 async function writeTranscript(
   state: CursorState,
   projectDirectoryName: string,
@@ -301,6 +333,54 @@ test("offers the app's address only for the chats the app itself holds", async (
   assert.equal(observations[0]?.applications?.[0]?.id, SESSION_APPLICATION_ID.CURSOR);
   assert.equal(observations[1]?.applications, undefined);
   assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);
+});
+
+test("leaves a chat the app filed away off the roster", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  await registerAppChats(state, ["chat-active", "chat-archived"]);
+  await writeChatHeaders(state, [
+    { sessionId: "chat-active", archived: false },
+    { sessionId: "chat-archived", archived: true },
+  ]);
+  const records = [messageRecord(TEST_ROLE.USER, TEST_CONTENT_TYPE.TEXT)];
+  await writeTranscript(state, "Users-test-luke", "chat-active", records, TEST_TIME - 5_000);
+  await writeTranscript(state, "Users-test-luke", "chat-archived", records, TEST_TIME - 1_000);
+
+  const observations = await adapterFor(state).observe();
+
+  // Archiving is the app's own way of saying a chat is done being looked at,
+  // so the filed chat draws no row while its transcript stays on disk.
+  assert.deepEqual(
+    observations.map((observation) => observation.providerSessionId),
+    ["chat-active"],
+  );
+  assert.equal(JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT), false);
+});
+
+test("keeps a row the index cannot positively call archived", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  // A Cursor build too old to keep header rows: the chat index exists and the
+  // header table does not, so nothing can vouch for a filing away.
+  await registerAppChats(state, ["chat-headerless"]);
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "chat-headerless",
+    [messageRecord(TEST_ROLE.USER, TEST_CONTENT_TYPE.TEXT)],
+    TEST_TIME - 5_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.providerSessionId, "chat-headerless");
+  // The chat index still answers, so the row keeps its address.
+  assert.equal(
+    observations[0]?.detail?.link,
+    "cursor://anysphere.cursor-deeplink/agent?id=chat-headerless",
+  );
 });
 
 test("a malformed app index never costs the rows themselves", async (t) => {

--- a/packages/providers/src/cursor/local-adapter.ts
+++ b/packages/providers/src/cursor/local-adapter.ts
@@ -77,6 +77,15 @@ const CURSOR_GLOBAL_STORAGE_STATE_SEGMENTS = [
 const CURSOR_APP_CHAT_KEY_PREFIX = "composerData:";
 const CURSOR_APP_CHAT_QUERY = "SELECT 1 FROM cursorDiskKV WHERE key = ?";
 
+/**
+ * The app's per-chat header row, which is where Cursor records that the user
+ * filed a chat away. Only the presence of a positively archived row is ever
+ * read — the header's own value column is the chat's name and standing, which
+ * Cursor writes from the conversation, and observation never opens it.
+ */
+const CURSOR_APP_ARCHIVED_CHAT_QUERY =
+  "SELECT 1 FROM composerHeaders WHERE composerId = ? AND isArchived = 1";
+
 const CURSOR_TRANSCRIPT_FILE_EXTENSION = ".jsonl";
 const CURSOR_WORKSPACE_FILE = "workspace.json";
 
@@ -304,13 +313,25 @@ function statusFromTurn(
   return localSessionStatus(status, observedAt, now, freshnessMs);
 }
 
+/** What the app's own index says about the observed chats. */
+interface CursorAppChatIndex {
+  /** The chats the app holds a window record for, which can carry an address. */
+  held: ReadonlySet<string>;
+  /** The chats the user positively filed away, which draw no row. */
+  archived: ReadonlySet<string>;
+}
+
+const EMPTY_APP_CHAT_INDEX: CursorAppChatIndex = { held: new Set(), archived: new Set() };
+
 /**
- * Reads which of the observed chats Cursor's app holds, as the presence of
- * each chat's key in the app's own index — a point lookup per chat, never a
- * value, because the values are the conversations themselves. An absent app,
- * an unreadable or mid-write database, or a schema this build does not know
- * holds nothing, which withholds addresses rather than inventing ones the
- * app cannot resolve — and never fails the pass the rows come from.
+ * Reads which of the observed chats Cursor's app holds, and which of them the
+ * user has archived — each as the presence of a row in the app's own index, a
+ * point lookup per chat, never a value, because the values are the
+ * conversations themselves. An absent app, an unreadable or mid-write
+ * database, or a schema this build does not know holds nothing, which
+ * withholds addresses and keeps every row rather than inventing an address
+ * the app cannot resolve or a filing away nobody performed — and never fails
+ * the pass the rows come from.
  */
 class CursorAppChatRegistry {
   readonly #statePath: string;
@@ -324,29 +345,57 @@ class CursorAppChatRegistry {
   // The index read is auxiliary to observing at all: a database Cursor holds
   // mid-write, or one this build cannot parse, answers nothing — never a
   // failed pass, because losing the app addresses must not cost the rows.
-  async heldChats(providerSessionIds: readonly string[]): Promise<ReadonlySet<string>> {
-    if (providerSessionIds.length === 0) return new Set();
+  async index(providerSessionIds: readonly string[]): Promise<CursorAppChatIndex> {
+    if (providerSessionIds.length === 0) return EMPTY_APP_CHAT_INDEX;
     let database: SqliteDatabase | undefined;
     try {
       database = await openReadOnlyDatabase(this.#sqlite, this.#statePath);
     } catch {
-      return new Set();
+      return EMPTY_APP_CHAT_INDEX;
     }
-    if (!database) return new Set();
+    if (!database) return EMPTY_APP_CHAT_INDEX;
     try {
-      const statement = database.prepare(CURSOR_APP_CHAT_QUERY);
-      const held = new Set<string>();
-      for (const providerSessionId of providerSessionIds) {
-        if (statement.all(`${CURSOR_APP_CHAT_KEY_PREFIX}${providerSessionId}`).length > 0) {
-          held.add(providerSessionId);
-        }
-      }
-      return held;
-    } catch {
-      return new Set();
+      // Each lookup stands its own failure alone: a Cursor build too old to
+      // keep header rows still addresses the chats it holds, and one whose
+      // chat index this build cannot read still honours what the user filed
+      // away.
+      return {
+        held: matchingChats(
+          database,
+          CURSOR_APP_CHAT_QUERY,
+          providerSessionIds,
+          (id) => `${CURSOR_APP_CHAT_KEY_PREFIX}${id}`,
+        ),
+        archived: matchingChats(
+          database,
+          CURSOR_APP_ARCHIVED_CHAT_QUERY,
+          providerSessionIds,
+          (id) => id,
+        ),
+      };
     } finally {
       database.close();
     }
+  }
+}
+
+function matchingChats(
+  database: SqliteDatabase,
+  query: string,
+  providerSessionIds: readonly string[],
+  parameter: (providerSessionId: string) => string,
+): ReadonlySet<string> {
+  try {
+    const statement = database.prepare(query);
+    const matched = new Set<string>();
+    for (const providerSessionId of providerSessionIds) {
+      if (statement.all(parameter(providerSessionId)).length > 0) {
+        matched.add(providerSessionId);
+      }
+    }
+    return matched;
+  } catch {
+    return new Set();
   }
 }
 
@@ -423,23 +472,29 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
     this.#transcriptMaximumRenderedLength = options.transcriptMaximumRenderedLength;
   }
 
-  protected discover(): Promise<CursorTranscriptCandidate[]> {
-    return discoverSessionFiles({
+  protected async discover(): Promise<CursorTranscriptCandidate[]> {
+    const candidates = await discoverSessionFiles({
       projectsDirectory: path.join(this.#cursorHome, CURSOR_DIRECTORY.PROJECTS),
       sessionsDirectoryName: CURSOR_DIRECTORY.TRANSCRIPTS,
       maximumProjectDirectories: this.#maximumProjectDirectories,
       sessionFilesIn: transcriptsIn,
     });
+    const index = await this.#appChatRegistry.index(
+      candidates.map((candidate) => candidate.providerSessionId),
+    );
+    this.#appChats = index.held;
+    // A chat the user filed away in the app draws no row, the same answer an
+    // archived cloud agent gives. The transcript Cursor keeps for it is left
+    // unread; a chat the index cannot vouch for either way stays.
+    return candidates.filter((candidate) => !index.archived.has(candidate.providerSessionId));
   }
 
   protected override async prepare(
     candidates: readonly CursorTranscriptCandidate[],
   ): Promise<void> {
-    const [appChats] = await Promise.all([
-      this.#appChatRegistry.heldChats(candidates.map((candidate) => candidate.providerSessionId)),
-      this.#workspaceLabels.resolve(candidates.map((candidate) => candidate.projectDirectoryName)),
-    ]);
-    this.#appChats = appChats;
+    await this.#workspaceLabels.resolve(
+      candidates.map((candidate) => candidate.projectDirectoryName),
+    );
   }
 
   override readTranscript(providerSessionId: string): Promise<string | undefined> {


### PR DESCRIPTION
## Summary

Archived Cursor chats were still appearing on the roster, on both surfaces. An archived agent or chat is one the user filed away — Cursor's own surfaces list it only behind an archive filter — so it now draws no row.

- **Cloud**: `collect()` filters agents whose status is `ARCHIVED` before any row is built, and the now-unreachable archived special-casing (the COMPLETE status branch, the archived guards on message/cancel/archive advertisement) comes out. Pressing the Archive control now also files the agent off the roster on the next pass.
- **Local**: Cursor records a chat's archived state in the `composerHeaders` table of the app's own `state.vscdb` index, keyed by the chat's id (which is also the transcript directory's name). The adapter reads it as a point lookup per chat — `SELECT 1 … WHERE composerId = ? AND isArchived = 1`, presence only, never the value column, which holds the chat's prompt-derived name — and drops positively archived chats at discovery, before their transcripts are parsed. Failure stays open in the safe direction: an older Cursor without the table, a mid-write database, or a missing header row keeps the row, and each of the two index lookups (address, archived) survives the other's failure independently.

Nothing new leaves the machine and no provider row changes, so the README table and `PRIVACY.md` stand as they are.

## Testing

- `./scripts/check.sh` passes (portable-only change; no UI code touched).
- Cloud tests: an archived agent draws no row and spends no run request; the settled/running control exclusivity tests updated accordingly.
- Local tests: an archived chat draws no row while its transcript stays on disk (header value planted with secret text and asserted never to surface); an index without header rows keeps the row and its address.
- Read-only smoke test against the real Cursor state on this machine: the chat `composerHeaders` marks archived disappears from `observe()`, active chats stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32437385175/artifacts/9431267409) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32437385175)

- Commit: `5334ddaf4daa8564a2d67be8396231c5313e1868`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
