### PR TITLE
feat(cursor): merge the observation hook into Cursor's hooks.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,8 +99,8 @@ Trust constraints:
 - One registration is the exception the previous rule's word "require" leaves
   room for, and it is bounded on every side: Luke may merge an observation
   hook into a provider's own user-level hook configuration (today Claude
-  Code's `settings.json` and Codex's `hooks.json`, and nothing else of either
-  provider's) so local rows can tell a turn that just ended from a session
+  Code's `settings.json` and the `hooks.json` of Codex and Cursor, and nothing
+  else of any provider's) so local rows can tell a turn that just ended from a session
   walked away from, and can see a tool call holding for permission at all. The
   hook itself writes one fixed status token into a spool under Luke's own
   application data, named by the session's id; the envelope the provider hands

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -235,6 +235,7 @@ const providerRegistry = providerRegistrations({
   readApiKey: (providerId) => settingsStore.readApiKey(providerId),
   claudeHookInstallation: () => observationHooks.claudeInstallation(),
   codexHookInstallation: () => observationHooks.codexInstallation(),
+  cursorHookInstallation: () => observationHooks.cursorInstallation(),
   codexCloudAdapter,
 });
 // The record enforces completeness; the shared list preserves provider order.

--- a/packages/providers/src/claude-code/hooks.ts
+++ b/packages/providers/src/claude-code/hooks.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 import path from "node:path";
 import {
+  HOOK_ENTRY_NESTING,
   HOOK_SPOOL_MAXIMUM_AGE_MS,
   type ObservationHookSpec,
   type ObservedHookEvent,
@@ -81,6 +82,7 @@ const CLAUDE_HOOK_SPEC: ObservationHookSpec<ClaudeHookEvent> = {
   // The shape Claude Code mints: hex and hyphens.
   sessionIdPattern: "[0-9a-fA-F-]{8,64}",
   subagentField: "agent_id",
+  entryNesting: HOOK_ENTRY_NESTING.NESTED,
 };
 
 /** Where Claude Code keeps its transcripts and its user-level settings. */

--- a/packages/providers/src/codex/hooks.ts
+++ b/packages/providers/src/codex/hooks.ts
@@ -1,4 +1,5 @@
 import {
+  HOOK_ENTRY_NESTING,
   HOOK_SPOOL_MAXIMUM_AGE_MS,
   type ObservationHookSpec,
   type ObservedHookEvent,
@@ -76,6 +77,7 @@ const CODEX_HOOK_SPEC: ObservationHookSpec<CodexHookEvent> = {
   // Codex thread ids are UUIDs: hex and hyphens, like Claude Code's.
   sessionIdPattern: "[0-9a-fA-F-]{8,64}",
   subagentField: "agent_id",
+  entryNesting: HOOK_ENTRY_NESTING.NESTED,
 };
 
 export interface CodexHookInstallation {

--- a/packages/providers/src/cursor/hooks.test.ts
+++ b/packages/providers/src/cursor/hooks.test.ts
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test, { type TestContext } from "node:test";
+import { promisify } from "node:util";
+import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import {
+  CURSOR_HOOK_EVENT,
+  CURSOR_HOOK_SCRIPT_NAME,
+  type CursorHookInstallation,
+  installCursorObservationHooks,
+  readCursorHookEvent,
+  removeCursorObservationHooks,
+} from "./hooks.js";
+
+const execFileAsync = promisify(execFile);
+
+const TEST_TIME = Date.parse("2026-08-20T20:15:00.000Z");
+const TEST_SESSION_ID = "1a08731e-7e25-4ff8-acf3-000000000000";
+const SECRET_ENVELOPE_TEXT = "SECRET_ENVELOPE_TEXT";
+const CURSOR_HOOKS_FILE_NAME = "hooks.json";
+
+// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+/** Every lifecycle event the build registers, as Cursor's hooks.json names them. */
+const REGISTERED_EVENT_NAMES = [
+  "sessionStart",
+  "beforeSubmitPrompt",
+  "stop",
+  "sessionEnd",
+] as const;
+
+async function temporaryInstallation(t: TestContext): Promise<CursorHookInstallation> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-cursor-hooks-"));
+  t.after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  const cursorHome = path.join(directory, "cursor-home");
+  await fs.mkdir(cursorHome, { recursive: true });
+  return {
+    cursorHome,
+    hookScriptPath: path.join(directory, "luke-data", CURSOR_HOOK_SCRIPT_NAME),
+    spoolDirectory: path.join(directory, "luke-data", "events"),
+  };
+}
+
+function hooksPath(installation: CursorHookInstallation): string {
+  return path.join(installation.cursorHome, CURSOR_HOOKS_FILE_NAME);
+}
+
+async function readHooksFile(installation: CursorHookInstallation): Promise<ParsedJsonObject> {
+  return JSON.parse(await fs.readFile(hooksPath(installation), "utf8"));
+}
+
+function hookEntries(configuration: ParsedJsonObject, eventName: string): unknown[] {
+  // SAFETY: Parsed JSON matches the event object shape this harness exercises.
+  const events = configuration.hooks as ParsedJsonObject;
+  const entries = events[eventName];
+  return Array.isArray(entries) ? entries : [];
+}
+
+/** Cursor's entries are the command records themselves, with no nesting. */
+function entryCommands(entries: unknown[]): string[] {
+  // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+  return entries
+    .map((entry) => (entry as { command?: unknown }).command)
+    .filter(
+      (command): command is string => Object.prototype.toString.call(command) === "[object String]",
+    );
+}
+
+/**
+ * Runs the installed script the way Cursor would: the event as its one
+ * argument, the envelope as JSON on stdin, and stdout read back as the hook's
+ * JSON answer.
+ */
+async function pipeToHookScript(
+  installation: CursorHookInstallation,
+  eventArgument: string,
+  envelope: string,
+): Promise<string> {
+  const envelopeFile = path.join(path.dirname(installation.hookScriptPath), "envelope.json");
+  await fs.writeFile(envelopeFile, envelope, "utf8");
+  const { stdout } = await execFileAsync("sh", [
+    "-c",
+    `"${installation.hookScriptPath}" "${eventArgument}" < "${envelopeFile}"`,
+  ]);
+  await fs.rm(envelopeFile, { force: true });
+  return stdout;
+}
+
+test("registers every lifecycle event beside the user's own flat entries", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.writeFile(
+    hooksPath(installation),
+    JSON.stringify({
+      version: 1,
+      hooks: {
+        stop: [{ command: "afplay /System/done.aiff" }],
+      },
+    }),
+  );
+
+  await installCursorObservationHooks(installation);
+
+  const configuration = await readHooksFile(installation);
+  // The user's own hook survives the merge untouched, ahead of Luke's.
+  const stopCommands = entryCommands(hookEntries(configuration, "stop"));
+  assert.equal(stopCommands[0], "afplay /System/done.aiff");
+  assert.equal(configuration.version, 1);
+  for (const eventName of REGISTERED_EVENT_NAMES) {
+    const commands = entryCommands(hookEntries(configuration, eventName)).filter((command) =>
+      command.includes(CURSOR_HOOK_SCRIPT_NAME),
+    );
+    assert.equal(commands.length, 1, `${eventName} carries exactly one Luke entry`);
+    // Guarded on the script's own presence, and the fallback drains the piped
+    // envelope and answers the empty decision, because Cursor reads stdout as
+    // the hook's JSON answer.
+    assert.ok(commands[0]?.startsWith(`[ -x "${installation.hookScriptPath}" ]`));
+    assert.ok(commands[0]?.endsWith(`|| { cat >/dev/null 2>&1; printf '{}'; }`));
+  }
+
+  const script = await fs.readFile(installation.hookScriptPath, "utf8");
+  assert.ok(script.includes(installation.spoolDirectory));
+  const mode = (await fs.stat(installation.hookScriptPath)).mode & 0o777;
+  assert.equal(mode, 0o755);
+});
+
+test("a file being created gets the documented version beside the hooks", async (t) => {
+  const installation = await temporaryInstallation(t);
+
+  await installCursorObservationHooks(installation);
+
+  const configuration = await readHooksFile(installation);
+  assert.equal(configuration.version, 1);
+});
+
+test("the user's own schema version is never rewritten", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.writeFile(hooksPath(installation), JSON.stringify({ version: 2, hooks: {} }));
+
+  await installCursorObservationHooks(installation);
+
+  assert.equal((await readHooksFile(installation)).version, 2);
+});
+
+test("touches nothing on a machine with no Cursor home at all", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.rm(installation.cursorHome, { recursive: true, force: true });
+
+  await installCursorObservationHooks(installation);
+
+  await assert.rejects(fs.stat(installation.cursorHome));
+  await assert.rejects(fs.stat(installation.hookScriptPath));
+  await assert.rejects(fs.stat(installation.spoolDirectory));
+});
+
+test("leaves a hooks file it cannot parse exactly as it was", async (t) => {
+  const installation = await temporaryInstallation(t);
+  const corrupt = "{ this is not json";
+  await fs.writeFile(hooksPath(installation), corrupt);
+
+  await installCursorObservationHooks(installation);
+
+  assert.equal(await fs.readFile(hooksPath(installation), "utf8"), corrupt);
+});
+
+test("converges rather than accumulates: reinstalling changes nothing", async (t) => {
+  const installation = await temporaryInstallation(t);
+
+  await installCursorObservationHooks(installation);
+  const first = await fs.readFile(hooksPath(installation), "utf8");
+  await installCursorObservationHooks(installation);
+
+  assert.equal(await fs.readFile(hooksPath(installation), "utf8"), first);
+});
+
+test("removal strips Luke's flat entries and leaves the user's standing", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.writeFile(
+    hooksPath(installation),
+    JSON.stringify({
+      version: 1,
+      hooks: {
+        stop: [{ command: "afplay /System/done.aiff" }],
+      },
+    }),
+  );
+  await installCursorObservationHooks(installation);
+
+  await removeCursorObservationHooks(installation);
+
+  const configuration = await readHooksFile(installation);
+  assert.deepEqual(entryCommands(hookEntries(configuration, "stop")), ["afplay /System/done.aiff"]);
+  for (const eventName of REGISTERED_EVENT_NAMES) {
+    const lukeCommands = entryCommands(hookEntries(configuration, eventName)).filter((command) =>
+      command.includes(CURSOR_HOOK_SCRIPT_NAME),
+    );
+    assert.equal(lukeCommands.length, 0, `${eventName} carries no Luke entry after removal`);
+  }
+  await assert.rejects(fs.stat(installation.hookScriptPath));
+  await assert.rejects(fs.stat(installation.spoolDirectory));
+});
+
+test("the script writes one fixed token and answers the empty decision", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await installCursorObservationHooks(installation);
+  const envelope = JSON.stringify({
+    hook_event_name: "stop",
+    conversation_id: TEST_SESSION_ID,
+    status: "completed",
+    prompt: SECRET_ENVELOPE_TEXT,
+  });
+
+  const answer = await pipeToHookScript(installation, CURSOR_HOOK_EVENT.STOP, envelope);
+
+  // Cursor reads stdout as the hook's JSON answer; observing decides nothing.
+  assert.equal(answer, "{}");
+  const spooled = await fs.readFile(
+    path.join(installation.spoolDirectory, `${TEST_SESSION_ID}.json`),
+    "utf8",
+  );
+  // The whole file is the fixed token: the envelope's text never reaches disk.
+  assert.equal(spooled, '{"event":"stop"}');
+  for (const entry of await fs.readdir(installation.spoolDirectory)) {
+    const content = await fs.readFile(path.join(installation.spoolDirectory, entry), "utf8");
+    assert.ok(!content.includes(SECRET_ENVELOPE_TEXT));
+  }
+});
+
+test("the script answers the empty decision even when it records nothing", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await installCursorObservationHooks(installation);
+
+  // A token the build never registered — Claude Code's failure token — and a
+  // session id outside the shape Cursor mints each leave the spool empty, and
+  // each still answers, so Cursor never reads silence where it expects JSON.
+  const refusedToken = await pipeToHookScript(
+    installation,
+    "stop-failure",
+    JSON.stringify({ conversation_id: TEST_SESSION_ID }),
+  );
+  const refusedId = await pipeToHookScript(
+    installation,
+    CURSOR_HOOK_EVENT.STOP,
+    JSON.stringify({ conversation_id: "../../../etc/passwd" }),
+  );
+
+  assert.equal(refusedToken, "{}");
+  assert.equal(refusedId, "{}");
+  assert.deepEqual(await fs.readdir(installation.spoolDirectory), []);
+});
+
+test("reads the spooled event back with the file's own clock", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.mkdir(installation.spoolDirectory, { recursive: true });
+  const filePath = path.join(installation.spoolDirectory, `${TEST_SESSION_ID}.json`);
+  await fs.writeFile(filePath, '{"event":"session-end"}');
+  await fs.utimes(filePath, TEST_TIME / 1000, TEST_TIME / 1000);
+
+  const event = await readCursorHookEvent(installation.spoolDirectory, TEST_SESSION_ID);
+
+  assert.equal(event?.event, CURSOR_HOOK_EVENT.SESSION_END);
+  assert.equal(event?.atMs, TEST_TIME);
+});
+
+test("reads nothing from a token outside Cursor's own vocabulary", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.mkdir(installation.spoolDirectory, { recursive: true });
+  await fs.writeFile(
+    path.join(installation.spoolDirectory, `${TEST_SESSION_ID}.json`),
+    '{"event":"notification"}',
+  );
+
+  assert.equal(await readCursorHookEvent(installation.spoolDirectory, TEST_SESSION_ID), undefined);
+});

--- a/packages/providers/src/cursor/hooks.ts
+++ b/packages/providers/src/cursor/hooks.ts
@@ -1,0 +1,96 @@
+import {
+  HOOK_ENTRY_NESTING,
+  HOOK_SPOOL_MAXIMUM_AGE_MS,
+  type ObservationHookSpec,
+  type ObservedHookEvent,
+  observationHooksFor,
+} from "../shared/hook-merge.js";
+
+/**
+ * Cursor's observation hooks, described for the shared machinery in
+ * `hook-merge.ts`. Cursor keeps user-level hooks in `~/.cursor/hooks.json`,
+ * honored by the app's own composer and the `agents` CLI alike, with entries
+ * that are the command records themselves rather than Claude Code's nested
+ * lists, and it pipes a registered command its envelope as JSON on stdin. The
+ * envelope's `conversation_id` is the same id the adapter reads transcripts
+ * under, so the spool token lands under the name the roster already knows —
+ * and Cursor reads the hook's stdout as its JSON answer, so the script
+ * replies with the empty decision on every path out.
+ *
+ * Cursor documents no event that fires only while a tool call holds for
+ * approval — `beforeShellExecution` fires before every run, held or not — so
+ * no permission token is registered and a held call stays invisible here,
+ * the honest absence, rather than every shell call reading as a wait.
+ */
+
+/**
+ * The script's name is also the marker a managed entry is recognized by, so
+ * renaming it is a migration: an entry naming the old script would stop being
+ * recognized as ours and would be left behind.
+ */
+export const CURSOR_HOOK_SCRIPT_NAME = "luke-cursor-observation-hook.sh";
+
+/** How long Cursor lets the spool write run before giving up on it. */
+const CURSOR_HOOK_TIMEOUT_SECONDS = 10;
+
+export const CURSOR_HOOK_SPOOL_MAXIMUM_AGE_MS = HOOK_SPOOL_MAXIMUM_AGE_MS;
+
+/**
+ * The tokens the script may write, fixed at registration: each hook entry
+ * passes its own token as the script's one argument, so nothing in the
+ * envelope Cursor pipes in can choose what lands in the spool. The same
+ * vocabulary Codex's spool speaks, minus the permission token — see above —
+ * and minus a failure token, because the transcript's own `turn_ended`
+ * marker keeps that verdict.
+ */
+export const CURSOR_HOOK_EVENT = {
+  SESSION_START: "session-start",
+  PROMPT: "prompt",
+  STOP: "stop",
+  SESSION_END: "session-end",
+} as const;
+
+export type CursorHookEvent = (typeof CURSOR_HOOK_EVENT)[keyof typeof CURSOR_HOOK_EVENT];
+
+/** The latest thing the hook reported about one session, dated by the spool. */
+export type ObservedCursorHookEvent = ObservedHookEvent<CursorHookEvent>;
+
+const CURSOR_HOOK_SPEC: ObservationHookSpec<CursorHookEvent> = {
+  scriptName: CURSOR_HOOK_SCRIPT_NAME,
+  configurationFileName: "hooks.json",
+  scriptTitle: "Luke Cursor observation hook v1",
+  registration: {
+    sessionStart: { event: CURSOR_HOOK_EVENT.SESSION_START },
+    beforeSubmitPrompt: { event: CURSOR_HOOK_EVENT.PROMPT },
+    stop: { event: CURSOR_HOOK_EVENT.STOP },
+    sessionEnd: { event: CURSOR_HOOK_EVENT.SESSION_END },
+  },
+  timeoutSeconds: CURSOR_HOOK_TIMEOUT_SECONDS,
+  sessionIdField: "conversation_id",
+  // Cursor chat ids are UUIDs: hex and hyphens, like Claude Code's.
+  sessionIdPattern: "[0-9a-fA-F-]{8,64}",
+  entryNesting: HOOK_ENTRY_NESTING.FLAT,
+  repliesWithJson: true,
+  // Cursor documents a schema version beside the hooks; a file being created
+  // gets it, and a user's own value is never rewritten.
+  rootDefaults: { version: 1 },
+};
+
+export interface CursorHookInstallation {
+  /** Cursor's own home, holding the `hooks.json` entries merge into. */
+  cursorHome: string;
+  /** Where Luke keeps the script, under Luke's own application data. */
+  hookScriptPath: string;
+  /** Where the script writes its event files, under Luke's own data too. */
+  spoolDirectory: string;
+}
+
+const cursorHooks = observationHooksFor(
+  CURSOR_HOOK_SPEC,
+  (installation: CursorHookInstallation) => installation.cursorHome,
+);
+
+export const installCursorObservationHooks = cursorHooks.install;
+export const removeCursorObservationHooks = cursorHooks.remove;
+export const readCursorHookEvent = cursorHooks.read;
+export const pruneCursorHookSpool = cursorHooks.prune;

--- a/packages/providers/src/cursor/local-adapter.test.ts
+++ b/packages/providers/src/cursor/local-adapter.test.ts
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 import {
   SESSION_APPLICATION_ID,
   SESSION_APPLICATION_SCOPE,
+  SESSION_COMPLETION_CAUSE,
   SESSION_STATUS,
 } from "@sidecar/session";
 import type { MutableWireRecord, ParsedJsonObject } from "@sidecar/wire/testing";
@@ -463,6 +464,50 @@ test("bounds the phrase a tool call is named by", async (t) => {
   assert.ok(activity?.startsWith("Shell: run x"));
   assert.ok(activity !== undefined && activity.length <= "Shell: ".length + 80);
   assert.ok(activity?.endsWith("…"));
+});
+
+test("the observation hook sharpens what the transcript alone cannot say", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  const settled = [
+    messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TEXT),
+    turnEndedRecord(TEST_TURN_STATUS.SUCCESS),
+  ];
+  // A chat whose window or CLI closed looks exactly like one holding for its
+  // developer; the hook's session-end token is the one thing that tells them
+  // apart.
+  await writeTranscript(state, "Users-test-luke", "session-closed", settled, TEST_TIME - 60_000);
+  // A stale event — one the transcript has already moved past — is ignored.
+  await writeTranscript(state, "Users-test-luke", "session-moved-on", settled, TEST_TIME - 5_000);
+  const spoolDirectory = path.join(state.cursorHome, "luke-spool");
+  await fs.mkdir(spoolDirectory, { recursive: true });
+  const closedEvent = path.join(spoolDirectory, "session-closed.json");
+  await fs.writeFile(closedEvent, '{"event":"session-end"}');
+  await fs.utimes(closedEvent, (TEST_TIME - 30_000) / 1000, (TEST_TIME - 30_000) / 1000);
+  const staleEvent = path.join(spoolDirectory, "session-moved-on.json");
+  await fs.writeFile(staleEvent, '{"event":"session-end"}');
+  await fs.utimes(staleEvent, (TEST_TIME - 60_000) / 1000, (TEST_TIME - 60_000) / 1000);
+
+  const adapter = new CursorLocalSessionAdapter({
+    ...state,
+    now: () => TEST_TIME,
+    hookEventsDirectory: () => spoolDirectory,
+  });
+  const observations = await adapter.observe();
+
+  assert.deepEqual(
+    observations.map((observation) => [
+      observation.providerSessionId,
+      observation.status,
+      observation.completionCause,
+    ]),
+    [
+      ["session-moved-on", SESSION_STATUS.WAITING, undefined],
+      ["session-closed", SESSION_STATUS.COMPLETE, SESSION_COMPLETION_CAUSE.SESSION_CLOSED],
+    ],
+  );
+  // The event that stands dates the session as well.
+  assert.equal(observations[1]?.observedAt, TEST_TIME - 30_000);
 });
 
 test("offers the app's address only for the chats the app itself holds", async (t) => {

--- a/packages/providers/src/cursor/local-adapter.ts
+++ b/packages/providers/src/cursor/local-adapter.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import {
   maximumSessionRecapLength,
   type ProviderSessionObservation,
+  SESSION_COMPLETION_CAUSE,
   SESSION_STATUS,
   type SessionDetail,
   type SessionStatus,
@@ -24,12 +25,14 @@ import {
   type DirectoryEntry,
   discoverSessionFiles,
   fileStats,
+  type HookStatusRefinement,
   LOCAL_ADAPTER_DEFAULTS,
   LocalFileSessionAdapter,
   localSessionStatus,
   readDirectory,
   readTail,
   readTextFile,
+  refineStatusWithHookEvent,
   type SessionFileCandidate,
   tailRecords,
   workspaceLabel,
@@ -43,6 +46,12 @@ import {
 import { transcriptContentBlocks, transcriptMessageText } from "../shared/local-transcript.js";
 import { CURSOR_PROVIDER } from "./adapter.js";
 import { cursorApplication, cursorChatLink } from "./app-links.js";
+import {
+  CURSOR_HOOK_EVENT,
+  type CursorHookEvent,
+  type ObservedCursorHookEvent,
+  readCursorHookEvent,
+} from "./hooks.js";
 import { CURSOR_TOOL_INPUT_KEY, readCursorSessionTranscript } from "./transcript.js";
 
 /** A turn Cursor failed records its own reason, which is transcript content. */
@@ -132,6 +141,7 @@ const CURSOR_CONTENT_TYPE = {
 const CURSOR_LOCAL_ADAPTER_DEFAULTS = {
   MAXIMUM_PROJECT_DIRECTORIES: 200,
   MAXIMUM_ACTIVITY_LENGTH: 80,
+  HOOK_EVENT_TOLERANCE_MS: 5_000,
 } as const;
 
 export interface CursorLocalAdapterOptions {
@@ -145,6 +155,14 @@ export interface CursorLocalAdapterOptions {
   transcriptReadTailBytes?: number;
   transcriptMaximumRenderedLength?: number;
   readTailBytes?: number;
+  /**
+   * Where the observation hook spools its events, when hooks are on at all.
+   * Read lazily like the cloud adapters' credentials, because the app decides
+   * the path after this adapter is declared. Absent — or answering nothing —
+   * the adapter reads the transcripts alone, exactly as it always has: the
+   * hooks only ever sharpen what those already showed.
+   */
+  hookEventsDirectory?: () => string | undefined;
 }
 
 interface CursorTranscriptCandidate extends SessionFileCandidate {
@@ -384,6 +402,33 @@ interface CursorAppChatIndex {
 const EMPTY_APP_CHAT_INDEX: CursorAppChatIndex = { held: new Set(), archived: new Set() };
 
 /**
+ * Sharpens the transcript's verdict with what the observation hook last said,
+ * in the order the meanings bind. A closed session is definite: the hook
+ * saying so outranks the transcript, and a transcript that says error is
+ * never talked out of it by a softer event. Past that, the events refine only
+ * a fresh session — the decay to `UNKNOWN` exists because a hook can go
+ * silent (a killed process fires no `sessionEnd`), so an old "waiting" must
+ * age the same way an old transcript does. What the refinement actually buys
+ * is the state the transcript cannot show at all: a chat whose window or CLI
+ * closed looks exactly like one holding for its developer.
+ */
+const CURSOR_HOOK_STATUS_REFINEMENT = {
+  definitive: [{ event: CURSOR_HOOK_EVENT.SESSION_END, fresh: SESSION_STATUS.COMPLETE }],
+  fresh: [
+    { event: CURSOR_HOOK_EVENT.PROMPT, fresh: SESSION_STATUS.WORKING },
+    { event: CURSOR_HOOK_EVENT.STOP, fresh: SESSION_STATUS.WAITING },
+  ],
+} as const satisfies HookStatusRefinement<CursorHookEvent>;
+
+function statusWithHookEvent(
+  status: SessionStatus,
+  event: CursorHookEvent,
+  isFresh: boolean,
+): SessionStatus {
+  return refineStatusWithHookEvent(status, event, isFresh, CURSOR_HOOK_STATUS_REFINEMENT);
+}
+
+/**
  * Reads which of the observed chats Cursor's app holds, and which of them the
  * user has archived — each as the presence of a row in the app's own index, a
  * point lookup per chat, never a value, because the values are the
@@ -481,7 +526,7 @@ function detailFor(
   };
 }
 
-function defaultCursorHome(): string {
+export function defaultCursorHome(): string {
   return path.join(os.homedir(), ".cursor");
 }
 
@@ -514,9 +559,11 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
   readonly #readTailBytes: number;
   readonly #transcriptReadTailBytes: number | undefined;
   readonly #transcriptMaximumRenderedLength: number | undefined;
+  readonly #hookEventsDirectory: (() => string | undefined) | undefined;
 
   constructor(options: CursorLocalAdapterOptions = {}) {
     super(options);
+    this.#hookEventsDirectory = options.hookEventsDirectory;
     this.#cursorHome = options.cursorHome ?? defaultCursorHome();
     this.#workspaceLabels = new CursorWorkspaceLabels(
       options.workspaceStorageDirectory ?? defaultWorkspaceStorageDirectory(),
@@ -585,14 +632,35 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
    * reaches an observation — and the location is left unsaid, which is how an
    * adapter reading this machine reports one that runs on it.
    */
-  protected observation(
+  protected async observation(
     candidate: CursorTranscriptCandidate,
     parsed: ParsedCursorTail,
     now: number,
     activeSessionFreshnessMs: number,
-  ): ProviderSessionObservation {
+  ): Promise<ProviderSessionObservation> {
     const label = this.#workspaceLabels.label(candidate.projectDirectoryName);
-    const status = statusFromTurn(parsed.turn, candidate.mtimeMs, now, activeSessionFreshnessMs);
+    const hookEventsDirectory = this.#hookEventsDirectory?.();
+    const hookEvent: ObservedCursorHookEvent | undefined = hookEventsDirectory
+      ? await readCursorHookEvent(hookEventsDirectory, candidate.providerSessionId).catch(
+          () => undefined,
+        )
+      : undefined;
+    // A transcript carries no timestamps of its own, so when it was last
+    // written is Cursor's only account of when this session last did anything.
+    // A hook event trailing that clock by more than the tolerance describes a
+    // turn the transcript already moved past, so it is ignored whole; one that
+    // stands is proof the session moved — only Luke's own script writes the
+    // spool — and dates the session for the freshness decay as well.
+    const transcriptAt = candidate.mtimeMs;
+    const eventStands =
+      hookEvent !== undefined &&
+      hookEvent.atMs + CURSOR_LOCAL_ADAPTER_DEFAULTS.HOOK_EVENT_TOLERANCE_MS >= transcriptAt;
+    const observedAt = eventStands ? Math.max(transcriptAt, hookEvent.atMs) : transcriptAt;
+    let status = statusFromTurn(parsed.turn, observedAt, now, activeSessionFreshnessMs);
+    if (eventStands) {
+      const isFresh = now - observedAt <= activeSessionFreshnessMs;
+      status = statusWithHookEvent(status, hookEvent.event, isFresh);
+    }
     const link = this.#appChats.has(candidate.providerSessionId)
       ? cursorChatLink(candidate.providerSessionId)
       : undefined;
@@ -600,12 +668,12 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
       providerSessionId: candidate.providerSessionId,
       title: label,
       status,
-      // A transcript carries no timestamps of its own, so when it was last
-      // written is the only account Cursor keeps of when this session last did
-      // anything.
-      observedAt: candidate.mtimeMs,
+      observedAt,
       detail: detailFor(label, status, link, parsed.activity),
       ...(parsed.recap ? { recap: parsed.recap } : undefined),
+      ...(status === SESSION_STATUS.COMPLETE
+        ? { completionCause: SESSION_COMPLETION_CAUSE.SESSION_CLOSED }
+        : undefined),
       ...(link ? { applications: [cursorApplication(link)] } : undefined),
     };
   }

--- a/packages/providers/src/hook-registry.ts
+++ b/packages/providers/src/hook-registry.ts
@@ -6,10 +6,13 @@ import {
 } from "./claude-code/hooks.js";
 import { defaultCodexHome } from "./codex/adapter.js";
 import { CODEX_HOOK_SCRIPT_NAME, type CodexHookInstallation } from "./codex/hooks.js";
+import { CURSOR_HOOK_SCRIPT_NAME, type CursorHookInstallation } from "./cursor/hooks.js";
+import { defaultCursorHome } from "./cursor/local-adapter.js";
 
 const HOOK_DIRECTORY = {
   CLAUDE_CODE: "claude-code-hooks",
   CODEX: "codex-hooks",
+  CURSOR: "cursor-hooks",
 } as const;
 const SPOOL_DIRECTORY = "events";
 
@@ -38,6 +41,13 @@ export class ObservationHookRegistry {
     return {
       codexHome: defaultCodexHome(),
       ...this.#paths(HOOK_DIRECTORY.CODEX, CODEX_HOOK_SCRIPT_NAME),
+    };
+  }
+
+  cursorInstallation(): CursorHookInstallation {
+    return {
+      cursorHome: defaultCursorHome(),
+      ...this.#paths(HOOK_DIRECTORY.CURSOR, CURSOR_HOOK_SCRIPT_NAME),
     };
   }
 

--- a/packages/providers/src/registrations.test.ts
+++ b/packages/providers/src/registrations.test.ts
@@ -21,6 +21,11 @@ const registrations = providerRegistrations({
     hookScriptPath: "/missing/codex-hook",
     spoolDirectory: "/missing/codex-spool",
   }),
+  cursorHookInstallation: () => ({
+    cursorHome: "/missing/cursor",
+    hookScriptPath: "/missing/cursor-hook",
+    spoolDirectory: "/missing/cursor-spool",
+  }),
 });
 
 test("registers every provider exactly once", () => {
@@ -37,6 +42,7 @@ test("declares credentials and observation hooks beside their adapters", () => {
   assert.equal(registrations[PROVIDER_ID.CURSOR].credential?.id, CREDENTIAL_PROVIDER_ID.CURSOR);
   assert.ok(registrations[PROVIDER_ID.CLAUDE_CODE].registerObservationHook instanceof Function);
   assert.ok(registrations[PROVIDER_ID.CODEX].registerObservationHook instanceof Function);
+  assert.ok(registrations[PROVIDER_ID.CURSOR].registerObservationHook instanceof Function);
   assert.equal("credential" in registrations[PROVIDER_ID.OPENCODE], false);
   assert.equal("credential" in registrations[PROVIDER_ID.GEMINI_CLI], false);
   assert.equal("registerObservationHook" in registrations[PROVIDER_ID.GEMINI_CLI], false);

--- a/packages/providers/src/registrations.ts
+++ b/packages/providers/src/registrations.ts
@@ -28,6 +28,12 @@ import {
 import { ConductorSessionAdapter } from "./conductor/adapter.js";
 import { CopilotSessionAdapter } from "./copilot/adapter.js";
 import { CURSOR_PROVIDER, CursorSessionAdapter } from "./cursor/adapter.js";
+import {
+  CURSOR_HOOK_SPOOL_MAXIMUM_AGE_MS,
+  type CursorHookInstallation,
+  installCursorObservationHooks,
+  pruneCursorHookSpool,
+} from "./cursor/hooks.js";
 import { CursorLocalSessionAdapter } from "./cursor/local-adapter.js";
 import { DEVIN_PROVIDER, DevinSessionAdapter } from "./devin/adapter.js";
 import { DevinLocalSessionAdapter } from "./devin/local-adapter.js";
@@ -45,6 +51,7 @@ export interface ProviderRegistrationOptions {
   readApiKey: (providerId: CredentialProviderId) => Promise<string | undefined>;
   claudeHookInstallation: () => ClaudeCodeHookInstallation;
   codexHookInstallation: () => CodexHookInstallation;
+  cursorHookInstallation: () => CursorHookInstallation;
   /**
    * Constructed by the caller rather than here, because the app also asks it
    * what the latest pass learned about the Codex CLI login — the settings
@@ -75,7 +82,9 @@ export function providerRegistrations(options: ProviderRegistrationOptions) {
   const cursor = new CompositeSessionProviderAdapter({
     provider: CURSOR_PROVIDER,
     adapters: [
-      new CursorLocalSessionAdapter(),
+      new CursorLocalSessionAdapter({
+        hookEventsDirectory: () => options.cursorHookInstallation().spoolDirectory,
+      }),
       new CursorSessionAdapter({
         readApiKey: () => options.readApiKey(CREDENTIAL_PROVIDER_ID.CURSOR),
       }),
@@ -131,6 +140,15 @@ export function providerRegistrations(options: ProviderRegistrationOptions) {
     [PROVIDER_ID.CURSOR]: {
       adapter: cursor,
       credential: CREDENTIAL_PROVIDERS[CREDENTIAL_PROVIDER_ID.CURSOR],
+      registerObservationHook: async () => {
+        const installation = options.cursorHookInstallation();
+        await installCursorObservationHooks(installation);
+        await pruneCursorHookSpool(
+          installation.spoolDirectory,
+          CURSOR_HOOK_SPOOL_MAXIMUM_AGE_MS,
+          now(),
+        );
+      },
     },
     [PROVIDER_ID.DEVIN]: {
       adapter: devin,

--- a/packages/providers/src/shared/hook-merge.ts
+++ b/packages/providers/src/shared/hook-merge.ts
@@ -57,6 +57,18 @@ export interface ObservationHookRegistration<Event extends string> {
 }
 
 /**
+ * How a provider's configuration file shapes one registered entry. Claude Code
+ * and Codex nest commands inside a `hooks` list per entry; Cursor's entries
+ * are the command records themselves.
+ */
+export const HOOK_ENTRY_NESTING = {
+  NESTED: "nested",
+  FLAT: "flat",
+} as const;
+
+export type HookEntryNesting = (typeof HOOK_ENTRY_NESTING)[keyof typeof HOOK_ENTRY_NESTING];
+
+/**
  * Everything one provider decides about its observation hooks. The guarantees
  * — merge beside the user's entries, refuse an unparseable file, converge at
  * every launch, no envelope text on disk — are the module's; the spec only
@@ -96,6 +108,20 @@ export interface ObservationHookSpec<Event extends string> {
    * recording them would flap the row.
    */
   subagentField?: string;
+  /** How the provider's configuration file shapes one registered entry. */
+  entryNesting: HookEntryNesting;
+  /**
+   * Whether the provider reads the hook's stdout as its JSON answer. The
+   * script then prints the empty decision on every path out, so an observer
+   * that decides nothing is never mistaken for a hook that failed to answer.
+   */
+  repliesWithJson?: boolean;
+  /**
+   * Root fields the provider's configuration documents beside `hooks`, filled
+   * in only where the file does not already carry them — a file being created
+   * gets the documented shape, and the user's own values are never rewritten.
+   */
+  rootDefaults?: Readonly<Record<string, WireValue>>;
 }
 
 /** Where one installed arrangement lives: the provider's home, and Luke's own. */
@@ -134,6 +160,16 @@ function observationHookScript<Event extends string>(
   spec: ObservationHookSpec<Event>,
   spoolDirectory: string,
 ): string {
+  // A provider that reads stdout as the hook's JSON answer is handed the
+  // empty decision on every path out; every other provider gets a plain exit.
+  const leave = spec.repliesWithJson ? "reply_and_leave" : "exit 0";
+  const replyFunction = spec.repliesWithJson
+    ? `
+# The provider reads stdout as the hook's JSON answer, so every path out
+# replies with the empty decision — observing decides nothing.
+reply_and_leave() { printf '{}'; exit 0; }
+`
+    : "";
   const subagentSkip = spec.subagentField
     ? `
 # A subagent's turns are not the session's: they start and stop while the
@@ -143,7 +179,7 @@ function observationHookScript<Event extends string>(
 # that turn.
 if printf '%s' "$ENVELOPE" \\
   | grep -qE '"${spec.subagentField}"[[:space:]]*:[[:space:]]*"[^"]+"'; then
-  exit 0
+  ${leave}
 fi
 `
     : "";
@@ -154,18 +190,18 @@ fi
 # status token into Luke's own spool — never into any provider file — naming
 # the file by the session's own id. The envelope handed in is read only for
 # that id; its text never reaches disk. Luke installs and removes this file.
-
+${replyFunction}
 SPOOL_DIRECTORY="${spoolDirectory}"
 
 # The token is fixed at registration, one per hook entry, so nothing handed in
 # can choose what is written.
 case "$1" in
   ${eventTokens(spec).join("|")}) EVENT_TOKEN="$1" ;;
-  *) exit 0 ;;
+  *) ${leave} ;;
 esac
 
 # No spool means observation hooks are off or Luke is gone; leave quietly.
-[ -d "$SPOOL_DIRECTORY" ] || exit 0
+[ -d "$SPOOL_DIRECTORY" ] || ${leave}
 
 # The envelope rides in as the argument after the token where the provider
 # passes one, and on stdin where it pipes instead.
@@ -176,15 +212,15 @@ ${subagentSkip}
 SESSION_ID=$(printf '%s' "$ENVELOPE" \\
   | grep -oE '"${spec.sessionIdField}"[[:space:]]*:[[:space:]]*"${spec.sessionIdPattern}"' \\
   | head -n 1 | grep -oE '${spec.sessionIdPattern}')
-[ -n "$SESSION_ID" ] || exit 0
+[ -n "$SESSION_ID" ] || ${leave}
 
 # One tiny file per session, replaced on every event: only the newest event
 # matters, and replacement is what bounds the spool. Writing beside the spool
 # file and moving over it keeps a concurrent reader off half a write.
 TEMPORARY_FILE="$SPOOL_DIRECTORY/.$SESSION_ID.$$.tmp"
-printf '{"event":"%s"}' "$EVENT_TOKEN" > "$TEMPORARY_FILE" || exit 0
+printf '{"event":"%s"}' "$EVENT_TOKEN" > "$TEMPORARY_FILE" || ${leave}
 mv -f "$TEMPORARY_FILE" "$SPOOL_DIRECTORY/$SESSION_ID${HOOK_EVENT_FILE_EXTENSION}"
-`;
+${spec.repliesWithJson ? "reply_and_leave\n" : ""}`;
 }
 
 /**
@@ -192,13 +228,17 @@ mv -f "$TEMPORARY_FILE" "$SPOOL_DIRECTORY/$SESSION_ID${HOOK_EVENT_FILE_EXTENSION
  * script being present and executable, so an entry outliving an uninstalled
  * Luke is an instant no-op rather than a "not found" in every session on the
  * machine — and always exiting zero, so no provider can read a missing spool
- * as a decision.
+ * as a decision. Where the provider reads stdout as the hook's JSON answer,
+ * the guard's own fallback drains the piped envelope and replies with the
+ * empty decision, exactly as the script itself would have.
  */
 function observationHookCommand<Event extends string>(
   hookScriptPath: string,
   event: Event,
+  repliesWithJson: boolean,
 ): string {
-  return `[ -x "${hookScriptPath}" ] && "${hookScriptPath}" ${event} || true`;
+  const fallback = repliesWithJson ? `{ cat >/dev/null 2>&1; printf '{}'; }` : "true";
+  return `[ -x "${hookScriptPath}" ] && "${hookScriptPath}" ${event} || ${fallback}`;
 }
 
 /**
@@ -248,13 +288,23 @@ function mutableHooks(root: MutableWireRecord): MutableWireRecord {
   return hooks ? { ...hooks } : createMutableWireRecord();
 }
 
-function stripLukeEntries(events: MutableWireRecord, scriptName: string): boolean {
+function stripLukeEntries(
+  events: MutableWireRecord,
+  scriptName: string,
+  entryNesting: HookEntryNesting,
+): boolean {
   let stripped = false;
   for (const [eventName, entries] of Object.entries(events)) {
     if (!Array.isArray(entries)) continue;
     let strippedHere = false;
     const kept = entries.flatMap((entry) => {
       if (!isRecord(entry)) return [entry];
+      if (entryNesting === HOOK_ENTRY_NESTING.FLAT) {
+        // A flat entry is the command record itself, so ours is dropped whole.
+        if (!isLukeHookCommand(entry.command, scriptName)) return [entry];
+        strippedHere = true;
+        return [];
+      }
       const cleaned = withoutLukeHooks(entry, scriptName);
       if (cleaned !== entry) strippedHere = true;
       return cleaned === undefined ? [] : [cleaned];
@@ -265,6 +315,26 @@ function stripLukeEntries(events: MutableWireRecord, scriptName: string): boolea
     else events[eventName] = kept;
   }
   return stripped;
+}
+
+/** One registered entry, in the shape the provider's configuration documents. */
+function registrationEntry<Event extends string>(
+  spec: ObservationHookSpec<Event>,
+  registration: ObservationHookRegistration<Event>,
+  hookScriptPath: string,
+): WireValue {
+  const matcher =
+    registration.matcher !== undefined ? { matcher: registration.matcher } : undefined;
+  const command = observationHookCommand(
+    hookScriptPath,
+    registration.event,
+    spec.repliesWithJson === true,
+  );
+  const timeout = spec.timeoutSeconds !== undefined ? { timeout: spec.timeoutSeconds } : undefined;
+  if (spec.entryNesting === HOOK_ENTRY_NESTING.FLAT) {
+    return { ...matcher, command, ...timeout };
+  }
+  return { ...matcher, hooks: [{ type: "command", command, ...timeout }] };
 }
 
 /**
@@ -292,26 +362,19 @@ export function configurationWithObservationHooks<Event extends string>(
     root = { ...record };
   }
 
+  if (spec.rootDefaults) {
+    for (const [key, value] of Object.entries(spec.rootDefaults)) {
+      if (!(key in root)) root[key] = value;
+    }
+  }
   const events = mutableHooks(root);
   root.hooks = events;
-  stripLukeEntries(events, spec.scriptName);
+  stripLukeEntries(events, spec.scriptName, spec.entryNesting);
 
   for (const [eventName, registration] of Object.entries(spec.registration)) {
     const existing = events[eventName];
     const kept = Array.isArray(existing) ? existing : [];
-    events[eventName] = [
-      ...kept,
-      {
-        ...(registration.matcher !== undefined ? { matcher: registration.matcher } : undefined),
-        hooks: [
-          {
-            type: "command",
-            command: observationHookCommand(hookScriptPath, registration.event),
-            ...(spec.timeoutSeconds !== undefined ? { timeout: spec.timeoutSeconds } : undefined),
-          },
-        ],
-      },
-    ];
+    events[eventName] = [...kept, registrationEntry(spec, registration, hookScriptPath)];
   }
 
   return `${JSON.stringify(root, undefined, 2)}\n`;
@@ -338,7 +401,7 @@ export function configurationWithoutObservationHooks<Event extends string>(
   const root = { ...parsedRecord };
   const events = mutableHooks(root);
   if (!readWireRecord(unparsedWire(root.hooks))) return undefined;
-  if (!stripLukeEntries(events, spec.scriptName)) return undefined;
+  if (!stripLukeEntries(events, spec.scriptName, spec.entryNesting)) return undefined;
   if (Object.keys(events).length === 0) delete root.hooks;
   else root.hooks = events;
 


### PR DESCRIPTION
> Stacked on #383 (`feat/cursor-local-recap`); this PR's own change is the last commit. It will be rebased as the stack lands.

## What

Cursor becomes the third provider whose user-level hook configuration Luke merges an observation hook into — the product decision CLAUDE.md's registration exception reserves, made deliberately here, with the exception's wording updated in the same change.

Cursor's hooks system is documented at cursor.com/docs/agent/hooks: user-level `~/.cursor/hooks.json`, honored by the IDE composer and the `agents` CLI alike, every envelope carrying `conversation_id` — verified empirically on this machine to be exactly the transcript id the roster already observes. The shared `hook-merge` machinery gains the per-provider facts Cursor decides differently, all spec-driven so Claude Code's and Codex's installed bytes do not change:

- **`entryNesting`**: Cursor's entries are flat command records (`{command, timeout}`), not Claude Code's nested `hooks` lists. Strip and merge both understand the flat form.
- **`repliesWithJson`**: Cursor reads a hook's stdout as its JSON answer, so the script — and the guarded fallback in the registered command, which also drains the piped envelope — replies `{}` on every path out. Observing decides nothing.
- **`rootDefaults`**: a `hooks.json` being created gets the documented `version: 1`; a user's own value is never rewritten.

Registered events → spool tokens: `sessionStart`, `beforeSubmitPrompt` → `prompt`, `stop` → `stop`, `sessionEnd` → `session-end`. Two honest absences, both stated in the spec's rationale:

- **No permission token**: Cursor documents no event that fires only while a tool call holds for approval — `beforeShellExecution` fires before *every* run — so registering it would read every shell call as a wait.
- **No failure token**: the transcript's own `turn_ended` error marker already keeps that verdict.

The local adapter reads the spool exactly as Claude Code's and Codex's do (same tolerance, same refinement order): `session-end` → the row completes as session-closed — the one state a transcript can never show, a chat whose window or CLI closed looking otherwise identical to one holding for its developer.

## Docs

- `CLAUDE.md`: the registration exception now names "the `hooks.json` of Codex and Cursor, and nothing else of any provider's".
- `PRIVACY.md` is unchanged on purpose: the hook merge moves no data off the machine, which is the altitude the launch policy documents at — the same standing the Claude Code and Codex merges already have there.

## Verification

- `./scripts/check.sh` passed; re-run after rebasing onto #385 and the launch-docs rewrite (#379).
- New `cursor/hooks.test.ts` (11 tests): flat-entry merge beside user entries, version defaulting and preservation, unparseable-file refusal, convergence, removal restoring the user's file, the script's fixed-token write, `{}` answers on the record path and on both refusal paths, spool read-back.
- New adapter test: `session-end` completes a settled row as session-closed; a stale hook event is ignored whole.
- Live roundtrip against a **copy** of this machine's real `~/.cursor/hooks.json` (which carries Superset, cmux, and Orca entries): all eleven user event lists preserved verbatim under the merge, `version` preserved, and removal restored the user's hooks byte-identically.
- Hook envelope verified live: a project-scoped capture hook in a disposable workspace received `conversation_id` equal to the observed transcript id on `sessionEnd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32441463571/artifacts/9432611182) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32441463571)

- Commit: `8c156692016e7c01e51f9021c08790920a1fabc1`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
