### PR TITLE
feat(cursor): message a settled local chat through the agents CLI resume

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,29 @@ Trust constraints:
   absence stands rather than an improvised control. Widening the invocation
   set further, or observing another provider this way, is a product decision,
   not an implementation detail.
+- A message to a local Cursor chat is the same bounded CLI exception at one
+  remove: Cursor's own `cursor-agent` CLI documents resuming a chat by id and
+  taking one prompt non-interactively, so the one write Luke makes through it
+  is the message the developer just asked to send to a chat the latest
+  observation advertised for one. The advertisement itself is bounded on
+  every side — the turn is settled, because a resume into an open turn would
+  race it; the folder is the one Cursor's own workspace record names, because
+  the resume must be pinned there with `--workspace` or the CLI forks the
+  chat's transcript under the invoking directory's project; the CLI is
+  installed; and the Cursor app does not hold the chat, because Cursor does
+  not document whether an app window shows a turn landed behind it, and a
+  message the developer cannot see land is worse than none. The invocation is
+  direct without a shell, its arguments fixed by the build beside the
+  observed chat id, the observed folder, and the developer's own words as a
+  single argument behind an end-of-options separator. The moment of the act
+  re-checks what the advertisement rested on: the login is probed again by
+  exit code alone, and the chat's transcript must still stand, because the
+  CLI silently starts a fresh chat under an id it does not know, so a stale
+  id must refuse rather than fork. Nothing is read out of the launched turn —
+  the transcript observation already reads is the report — and a turn that
+  outlives the short refusal window is a delivered message, never a process
+  to kill. This authorizes no other `cursor-agent` command; widening it is a
+  product decision, not an implementation detail.
 - One registration is the exception the previous rule's word "require" leaves
   room for, and it is bounded on every side: Luke may merge an observation
   hook into a provider's own user-level hook configuration (today Claude

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -36,9 +36,11 @@ and email you signed it with, and any screenshots you attached.
   memory so it carries across calls, and sends it again when you open the next
   one. It is never written to disk and is discarded when you quit Luke.
 - Coding agent providers you connect (Conductor, Cursor, Devin, GitHub Copilot,
-  Jules) and Linear, using the key or account access you supply. Luke reads your
-  sessions or issues, and sends something back only when you ask it to, such as
-  a message you wrote or an issue you moved.
+  Jules) and Linear, using the key or account access you supply — for Codex
+  cloud tasks and for messaging local Cursor chats, that access is the sign-in
+  you already gave the provider's own command-line tool, which Luke runs and
+  never reads. Luke reads your sessions or issues, and sends something back
+  only when you ask it to, such as a message you wrote or an issue you moved.
 - Google, if you connect Google Calendar. We request your calendar list and your
   availability. Google returns busy times only, so event titles and attendees
   are never available to Luke.

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -496,6 +496,20 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "fields alone.",
     },
     {
+      label: "Messaging local Cursor chats",
+      detail:
+        "A local Cursor chat whose turn has settled can take the developer's own message, " +
+        "typed on its row or asked of Luke in conversation: Luke runs Cursor's own agents " +
+        "CLI, resuming exactly that chat in its own folder with the message as its one " +
+        "prompt, and the reply lands in the same transcript the row already reads. It is " +
+        "offered only where that is honest — the CLI installed and signed in, the chat's " +
+        "folder named by Cursor's own records, the turn not still running — and not for " +
+        "chats the Cursor app's own windows hold, whose rows open the exact chat in the " +
+        "app instead, because Cursor does not document whether an app window would show a " +
+        "turn landed behind it. A Superset-managed Cursor chat still messages through " +
+        "Superset's own terminal, which shows the message where the agent actually runs.",
+    },
+    {
       label: "Creating workspaces",
       detail:
         "Where a connected provider documents a creation endpoint — Conductor, Cursor, and " +

--- a/packages/providers/src/cursor/local-adapter.test.ts
+++ b/packages/providers/src/cursor/local-adapter.test.ts
@@ -466,6 +466,203 @@ test("bounds the phrase a tool call is named by", async (t) => {
   assert.ok(activity?.endsWith("…"));
 });
 
+test("advertises a message only where the CLI's resume can honestly land one", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  await registerAppChats(state, ["app-chat"]);
+  const settled = [
+    messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TEXT),
+    turnEndedRecord(TEST_TURN_STATUS.SUCCESS),
+  ];
+  const open = [messageRecord(TEST_ROLE.USER, TEST_CONTENT_TYPE.TEXT)];
+  await writeTranscript(state, "Users-test-luke", "cli-chat-settled", settled, TEST_TIME - 5_000);
+  await writeTranscript(state, "Users-test-luke", "cli-chat-working", open, TEST_TIME - 6_000);
+  await writeTranscript(state, "Users-test-luke", "app-chat", settled, TEST_TIME - 7_000);
+  // A folder no workspace record names offers nowhere to pin the resume.
+  await writeTranscript(
+    state,
+    "Users-test-mystery",
+    "cli-chat-unplaced",
+    settled,
+    TEST_TIME - 8_000,
+  );
+
+  const adapter = new CursorLocalSessionAdapter({
+    ...state,
+    now: () => TEST_TIME,
+    cursorAgent: {
+      locate: async () => "/opt/test/cursor-agent",
+      probeLogin: async () => true,
+      launch: async () => "running" as const,
+    },
+  });
+  const observations = await adapter.observe();
+
+  assert.deepEqual(
+    observations.map((observation) => [
+      observation.providerSessionId,
+      observation.canReceiveMessage,
+    ]),
+    [
+      ["cli-chat-settled", true],
+      ["cli-chat-working", undefined],
+      ["app-chat", undefined],
+      ["cli-chat-unplaced", undefined],
+    ],
+  );
+});
+
+test("a machine without the CLI advertises no message at all", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "cli-chat-settled",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 5_000,
+  );
+
+  const adapter = new CursorLocalSessionAdapter({
+    ...state,
+    now: () => TEST_TIME,
+    cursorAgent: {
+      locate: async () => undefined,
+      probeLogin: async () => true,
+      launch: async () => "running" as const,
+    },
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations[0]?.canReceiveMessage, undefined);
+  const result = await adapter.sendMessage({
+    providerSessionId: "cli-chat-settled",
+    text: "carry on",
+  });
+  assert.equal(result.status, "unsupported");
+});
+
+test("a send runs the documented resume with the developer's words behind the separator", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "cli-chat-settled",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 5_000,
+  );
+  const launches: { binaryPath: string; argv: readonly string[] }[] = [];
+  const adapter = new CursorLocalSessionAdapter({
+    ...state,
+    now: () => TEST_TIME,
+    cursorAgent: {
+      locate: async () => "/opt/test/cursor-agent",
+      probeLogin: async () => true,
+      launch: async (binaryPath, argv) => {
+        launches.push({ binaryPath, argv });
+        return "running" as const;
+      },
+    },
+  });
+  await adapter.observe();
+
+  const result = await adapter.sendMessage({
+    providerSessionId: "cli-chat-settled",
+    text: "--continue where you left off",
+  });
+
+  assert.equal(result.status, "accepted");
+  assert.equal(launches[0]?.binaryPath, "/opt/test/cursor-agent");
+  // The message rides behind the end-of-options separator, so words that look
+  // like flags never read as flags, and the workspace pin is the folder
+  // Cursor's own record names for the chat's project.
+  assert.deepEqual(launches[0]?.argv, [
+    "--resume",
+    "cli-chat-settled",
+    "--workspace",
+    "/Users/test/luke",
+    "--print",
+    "--output-format",
+    "json",
+    "--",
+    "--continue where you left off",
+  ]);
+});
+
+test("a send refuses what the moment of the act no longer supports", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "cli-chat-settled",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 5_000,
+  );
+  const launches: string[] = [];
+  let loggedIn = false;
+  let earlyExitCode = 1;
+  const adapter = new CursorLocalSessionAdapter({
+    ...state,
+    now: () => TEST_TIME,
+    cursorAgent: {
+      locate: async () => "/opt/test/cursor-agent",
+      probeLogin: async () => loggedIn,
+      launch: async (_binaryPath, argv) => {
+        launches.push(argv.join(" "));
+        return { exitCode: earlyExitCode };
+      },
+    },
+  });
+  await adapter.observe();
+
+  // A chat that never advertised taking a message is refused before anything
+  // runs — the roster is the outer bound.
+  const unadvertised = await adapter.sendMessage({ providerSessionId: "ghost", text: "hello" });
+  assert.equal(unadvertised.status, "unsupported");
+  // A CLI signed out since the pass refuses before anything runs.
+  const signedOut = await adapter.sendMessage({
+    providerSessionId: "cli-chat-settled",
+    text: "hello",
+  });
+  assert.equal(signedOut.status, "rejected");
+  assert.equal(launches.length, 0);
+  // An early refusal — a folder the CLI does not trust — is an answer.
+  loggedIn = true;
+  const refused = await adapter.sendMessage({
+    providerSessionId: "cli-chat-settled",
+    text: "hello",
+  });
+  assert.equal(refused.status, "rejected");
+  assert.equal(launches.length, 1);
+  // A launch that outlives the refusal window is a delivered message: the
+  // transcript the adapter already observes is the report from here.
+  earlyExitCode = 0;
+  const delivered = await adapter.sendMessage({
+    providerSessionId: "cli-chat-settled",
+    text: "hello",
+  });
+  assert.equal(delivered.status, "accepted");
+  // A transcript gone since the pass refuses rather than letting the CLI
+  // silently start a fresh chat under the stale id.
+  await fs.rm(
+    path.join(
+      state.cursorHome,
+      CURSOR_PROJECTS_DIRECTORY,
+      "Users-test-luke",
+      CURSOR_TRANSCRIPTS_DIRECTORY,
+      "cli-chat-settled",
+    ),
+    { recursive: true, force: true },
+  );
+  const gone = await adapter.sendMessage({
+    providerSessionId: "cli-chat-settled",
+    text: "hello",
+  });
+  assert.equal(gone.status, "rejected");
+});
+
 test("the observation hook sharpens what the transcript alone cannot say", async (t) => {
   const state = await temporaryCursorState(t);
   await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");

--- a/packages/providers/src/cursor/local-adapter.test.ts
+++ b/packages/providers/src/cursor/local-adapter.test.ts
@@ -512,6 +512,40 @@ test("advertises a message only where the CLI's resume can honestly land one", a
   );
 });
 
+test("a prompt the hook already knows about withdraws the advertisement", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  // The tail still shows a settled turn, but the hook heard a new prompt the
+  // transcript has not written yet: a resume now would race the open turn.
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "cli-chat-reprompted",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 60_000,
+  );
+  const spoolDirectory = path.join(state.cursorHome, "luke-spool");
+  await fs.mkdir(spoolDirectory, { recursive: true });
+  const promptEvent = path.join(spoolDirectory, "cli-chat-reprompted.json");
+  await fs.writeFile(promptEvent, '{"event":"prompt"}');
+  await fs.utimes(promptEvent, (TEST_TIME - 5_000) / 1000, (TEST_TIME - 5_000) / 1000);
+
+  const adapter = new CursorLocalSessionAdapter({
+    ...state,
+    now: () => TEST_TIME,
+    hookEventsDirectory: () => spoolDirectory,
+    cursorAgent: {
+      locate: async () => "/opt/test/cursor-agent",
+      probeLogin: async () => true,
+      launch: async () => "running" as const,
+    },
+  });
+  const observations = await adapter.observe();
+
+  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
+  assert.equal(observations[0]?.canReceiveMessage, undefined);
+});
+
 test("a machine without the CLI advertises no message at all", async (t) => {
   const state = await temporaryCursorState(t);
   await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");

--- a/packages/providers/src/cursor/local-adapter.ts
+++ b/packages/providers/src/cursor/local-adapter.ts
@@ -1,17 +1,24 @@
+import { execFile, spawn } from "node:child_process";
+import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   maximumSessionRecapLength,
+  PROVIDER_ACT_RESULT_STATUS,
+  type ProviderMessageResult,
+  type ProviderSessionMessage,
   type ProviderSessionObservation,
   SESSION_COMPLETION_CAUSE,
   SESSION_STATUS,
   type SessionDetail,
   type SessionStatus,
+  sessionMessageText,
   UNKNOWN_WORKSPACE_LABEL,
 } from "@sidecar/session";
 import {
   isRecord,
+  isWireNumber,
   isWireString,
   oneLine,
   resolveOptions,
@@ -103,6 +110,17 @@ const CURSOR_APP_ARCHIVED_CHAT_QUERY =
 const CURSOR_TRANSCRIPT_FILE_EXTENSION = ".jsonl";
 const CURSOR_WORKSPACE_FILE = "workspace.json";
 
+/**
+ * Cursor's own record, inside a project directory, of the folder the project
+ * runs in and the fact that its CLI trusts it. Where it exists it names the
+ * exact folder — no reduced-name matching — and a folder the CLI trusts is
+ * one a resume pinned there will not refuse.
+ */
+const CURSOR_WORKSPACE_TRUSTED_FILE = ".workspace-trusted";
+const CURSOR_WORKSPACE_TRUSTED_FIELD = {
+  WORKSPACE_PATH: "workspacePath",
+} as const;
+
 const CURSOR_WORKSPACE_FIELD = {
   /** A window opened on a single folder. Cursor omits it for every other window. */
   FOLDER: "folder",
@@ -163,6 +181,14 @@ export interface CursorLocalAdapterOptions {
    * hooks only ever sharpen what those already showed.
    */
   hookEventsDirectory?: () => string | undefined;
+  /** How the adapter reaches Cursor's own CLI; tests inject one that spawns nothing. */
+  cursorAgent?: CursorAgentRunner;
+}
+
+/** Everything a send must still know about one chat that advertised taking one. */
+interface CursorSendTarget {
+  folderPath: string;
+  transcriptFilePath: string;
 }
 
 interface CursorTranscriptCandidate extends SessionFileCandidate {
@@ -217,6 +243,7 @@ function folderPathFromWorkspaceRecord(source: string): string | undefined {
 class CursorWorkspaceLabels {
   readonly #directory: string;
   readonly #labelsByProjectName = new Map<string, string | undefined>();
+  readonly #foldersByProjectName = new Map<string, string | undefined>();
   readonly #readWorkspaceRecords = new Set<string>();
 
   constructor(directory: string) {
@@ -231,7 +258,7 @@ class CursorWorkspaceLabels {
   async resolve(projectDirectoryNames: readonly string[]): Promise<void> {
     if (
       projectDirectoryNames.every((name) =>
-        this.#labelsByProjectName.has(canonicalProjectName(name)),
+        this.#foldersByProjectName.has(canonicalProjectName(name)),
       )
     ) {
       return;
@@ -254,17 +281,32 @@ class CursorWorkspaceLabels {
     );
   }
 
+  /**
+   * The folder Cursor's own record names for a project, when exactly one does.
+   * Stricter than the label on purpose: two folders can reduce to one project
+   * name and still agree on what to call it, but a message pinned to the wrong
+   * folder would fork the chat it meant to continue, so any ambiguity names
+   * nowhere to send.
+   */
+  folder(projectDirectoryName: string): string | undefined {
+    return this.#foldersByProjectName.get(canonicalProjectName(projectDirectoryName));
+  }
+
   #record(folderPath: string): void {
     const projectName = canonicalProjectName(folderPath);
     const label = workspaceLabel(folderPath);
     if (!this.#labelsByProjectName.has(projectName)) {
       this.#labelsByProjectName.set(projectName, label);
+      this.#foldersByProjectName.set(projectName, folderPath);
       return;
     }
     // Two folders can reduce to one project name. When they disagree about
     // what to call it, Luke names neither.
     if (this.#labelsByProjectName.get(projectName) !== label) {
       this.#labelsByProjectName.set(projectName, undefined);
+    }
+    if (this.#foldersByProjectName.get(projectName) !== folderPath) {
+      this.#foldersByProjectName.set(projectName, undefined);
     }
   }
 }
@@ -526,6 +568,134 @@ function detailFor(
   };
 }
 
+/**
+ * The invocations this adapter may make of Cursor's own `cursor-agent` CLI,
+ * fixed by the build the way a cloud adapter's routes are. `status` answers by
+ * exit code alone whether the CLI holds the user's login. The send is the
+ * CLI's documented resume: `--resume` names the observed chat, `--workspace`
+ * pins the turn to the folder Cursor's own record names — a resume run
+ * anywhere else appends the turn under that other folder's project and forks
+ * the chat it meant to continue — `--print` keeps it non-interactive, and the
+ * `--` before the message ends option parsing, so the developer's own words
+ * can never read as a flag.
+ */
+const CURSOR_AGENT_CLI = {
+  BINARY: "cursor-agent",
+  LOGIN_PROBE_ARGV: ["status"],
+  RESUME_FLAG: "--resume",
+  WORKSPACE_FLAG: "--workspace",
+  SEND_ARGV: ["--print", "--output-format", "json"],
+  ARGUMENT_SEPARATOR: "--",
+} as const;
+
+const CURSOR_SEND_DEFAULTS = {
+  LOGIN_PROBE_TIMEOUT_MS: 8_000,
+  /**
+   * How long a launched resume is watched for an early refusal — a folder the
+   * CLI does not trust, a login gone since the probe — before the turn is let
+   * run. A resumed turn is a whole agent turn and can take minutes; holding
+   * the send open for it would be a deadline that kills the very turn it
+   * delivered, so past this window the send is delivered and the transcript
+   * the adapter already observes is the report.
+   */
+  EARLY_REFUSAL_WINDOW_MS: 8_000,
+} as const;
+
+/**
+ * Where `cursor-agent` actually lands on a Mac, beside whatever PATH an app
+ * launched from the Finder inherits: the CLI's own installer uses
+ * `~/.local/bin`, and package managers use the usual two.
+ */
+function wellKnownCursorAgentDirectories(): readonly string[] {
+  return [path.join(os.homedir(), ".local", "bin"), "/opt/homebrew/bin", "/usr/local/bin"];
+}
+
+/** The one launch result: an exit inside the refusal window, or a turn running. */
+export type CursorAgentLaunch = { exitCode: number } | "running";
+
+/**
+ * How the adapter reaches Cursor's own CLI, injectable so tests never spawn
+ * one. Every method runs the binary directly — no shell, so nothing in an
+ * argument can become a second command.
+ */
+export interface CursorAgentRunner {
+  /** The installed binary's path, or nothing on a machine without one. */
+  locate(): Promise<string | undefined>;
+  /** Whether the CLI holds a login, by exit code alone; stdout is never read. */
+  probeLogin(binaryPath: string): Promise<boolean>;
+  /** Starts the resume detached and watches only for an early refusal. */
+  launch(binaryPath: string, argv: readonly string[]): Promise<CursorAgentLaunch>;
+}
+
+async function locateCursorAgent(): Promise<string | undefined> {
+  const pathDirectories = (process.env.PATH ?? "").split(path.delimiter).filter(Boolean);
+  for (const directory of [...pathDirectories, ...wellKnownCursorAgentDirectories()]) {
+    const candidate = path.join(directory, CURSOR_AGENT_CLI.BINARY);
+    try {
+      await fs.access(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch {
+      // Not here; the next directory may hold it.
+    }
+  }
+  return undefined;
+}
+
+const defaultCursorAgentRunner: CursorAgentRunner = {
+  locate: locateCursorAgent,
+  probeLogin: (binaryPath) =>
+    new Promise((resolve, reject) => {
+      execFile(
+        binaryPath,
+        CURSOR_AGENT_CLI.LOGIN_PROBE_ARGV,
+        { timeout: CURSOR_SEND_DEFAULTS.LOGIN_PROBE_TIMEOUT_MS, windowsHide: true },
+        (error) => {
+          if (error === null) {
+            resolve(true);
+            return;
+          }
+          // SAFETY: Node's execFile callback reports command failures as ErrnoException objects.
+          const commandError = error as NodeJS.ErrnoException & { code?: unknown };
+          if (isWireNumber(commandError.code)) {
+            resolve(false);
+            return;
+          }
+          reject(new Error(`${CURSOR_AGENT_CLI.BINARY} could not be run`));
+        },
+      );
+    }),
+  launch: (binaryPath, argv) =>
+    new Promise((resolve) => {
+      // Detached with no pipes: the turn's output lives in the transcript the
+      // adapter already observes, and the send must not hold a handle open
+      // for however long the turn runs.
+      const child = spawn(binaryPath, [...argv], {
+        detached: true,
+        stdio: "ignore",
+        windowsHide: true,
+      });
+      let settled = false;
+      const settle = (result: CursorAgentLaunch) => {
+        if (settled) return;
+        settled = true;
+        resolve(result);
+      };
+      const window = setTimeout(() => {
+        child.unref();
+        settle("running");
+      }, CURSOR_SEND_DEFAULTS.EARLY_REFUSAL_WINDOW_MS);
+      window.unref();
+      child.once("exit", (code) => {
+        clearTimeout(window);
+        settle({ exitCode: code ?? 1 });
+      });
+      child.once("error", () => {
+        clearTimeout(window);
+        settle({ exitCode: 1 });
+      });
+    }),
+};
+
 export function defaultCursorHome(): string {
   return path.join(os.homedir(), ".cursor");
 }
@@ -560,10 +730,15 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
   readonly #transcriptReadTailBytes: number | undefined;
   readonly #transcriptMaximumRenderedLength: number | undefined;
   readonly #hookEventsDirectory: (() => string | undefined) | undefined;
+  readonly #cursorAgent: CursorAgentRunner;
+  #cursorAgentBinaryPath: string | undefined;
+  #trustedFoldersByProject: ReadonlyMap<string, string> = new Map();
+  readonly #sendTargets = new Map<string, CursorSendTarget>();
 
   constructor(options: CursorLocalAdapterOptions = {}) {
     super(options);
     this.#hookEventsDirectory = options.hookEventsDirectory;
+    this.#cursorAgent = options.cursorAgent ?? defaultCursorAgentRunner;
     this.#cursorHome = options.cursorHome ?? defaultCursorHome();
     this.#workspaceLabels = new CursorWorkspaceLabels(
       options.workspaceStorageDirectory ?? defaultWorkspaceStorageDirectory(),
@@ -608,9 +783,56 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
   protected override async prepare(
     candidates: readonly CursorTranscriptCandidate[],
   ): Promise<void> {
-    await this.#workspaceLabels.resolve(
-      candidates.map((candidate) => candidate.projectDirectoryName),
+    this.#sendTargets.clear();
+    const projectDirectoryNames = [
+      ...new Set(candidates.map((candidate) => candidate.projectDirectoryName)),
+    ];
+    const [binaryPath, trustedFolders] = await Promise.all([
+      // Located every pass, so an install or removal is honoured on the next
+      // one — the same cadence a signed-out CLI is honoured on.
+      this.#cursorAgent.locate().catch(() => undefined),
+      this.#trustedFolders(projectDirectoryNames),
+      this.#workspaceLabels.resolve(projectDirectoryNames),
+    ]);
+    this.#cursorAgentBinaryPath = binaryPath;
+    this.#trustedFoldersByProject = trustedFolders;
+  }
+
+  /**
+   * The folder each project's own `.workspace-trusted` record names, where one
+   * exists. It is the send path's preferred source: exact where the workspace
+   * records need reduced-name matching, and present exactly where the CLI
+   * already trusts the folder a resume would be pinned to.
+   */
+  async #trustedFolders(
+    projectDirectoryNames: readonly string[],
+  ): Promise<ReadonlyMap<string, string>> {
+    const folders = new Map<string, string>();
+    await Promise.all(
+      projectDirectoryNames.map(async (projectDirectoryName) => {
+        const record = await readTextFile(
+          path.join(
+            this.#cursorHome,
+            CURSOR_DIRECTORY.PROJECTS,
+            projectDirectoryName,
+            CURSOR_WORKSPACE_TRUSTED_FILE,
+          ),
+        );
+        if (!record) return;
+        let parsed: WireBoundaryInput;
+        try {
+          parsed = JSON.parse(record);
+        } catch {
+          return;
+        }
+        const wire = wireRecord(unparsedWire(parsed));
+        const workspacePath = wire?.[CURSOR_WORKSPACE_TRUSTED_FIELD.WORKSPACE_PATH];
+        if (isWireString(workspacePath) && path.isAbsolute(workspacePath)) {
+          folders.set(projectDirectoryName, workspacePath);
+        }
+      }),
     );
+    return folders;
   }
 
   override readTranscript(providerSessionId: string): Promise<string | undefined> {
@@ -661,9 +883,31 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
       const isFresh = now - observedAt <= activeSessionFreshnessMs;
       status = statusWithHookEvent(status, hookEvent.event, isFresh);
     }
-    const link = this.#appChats.has(candidate.providerSessionId)
-      ? cursorChatLink(candidate.providerSessionId)
-      : undefined;
+    const appHeld = this.#appChats.has(candidate.providerSessionId);
+    const link = appHeld ? cursorChatLink(candidate.providerSessionId) : undefined;
+    // A message is advertised only where the CLI's documented resume can
+    // honestly land one: the turn is settled — a resume into an open turn
+    // would race it — the folder to pin the resume to is named by Cursor's
+    // own record, the CLI is installed, and the app does not hold the chat,
+    // because Cursor does not document whether an app window shows a turn
+    // landed behind it, and a message the developer cannot see land is worse
+    // than none.
+    const folderPath =
+      this.#trustedFoldersByProject.get(candidate.projectDirectoryName) ??
+      this.#workspaceLabels.folder(candidate.projectDirectoryName);
+    const canReceiveMessage =
+      parsed.turn !== undefined &&
+      folderPath !== undefined &&
+      this.#cursorAgentBinaryPath !== undefined &&
+      !appHeld;
+    if (canReceiveMessage && folderPath !== undefined) {
+      this.#sendTargets.set(candidate.providerSessionId, {
+        folderPath,
+        transcriptFilePath: candidate.filePath,
+      });
+    } else {
+      this.#sendTargets.delete(candidate.providerSessionId);
+    }
     return {
       providerSessionId: candidate.providerSessionId,
       title: label,
@@ -671,10 +915,88 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
       observedAt,
       detail: detailFor(label, status, link, parsed.activity),
       ...(parsed.recap ? { recap: parsed.recap } : undefined),
+      ...(canReceiveMessage ? { canReceiveMessage: true } : undefined),
       ...(status === SESSION_STATUS.COMPLETE
         ? { completionCause: SESSION_COMPLETION_CAUSE.SESSION_CLOSED }
         : undefined),
       ...(link ? { applications: [cursorApplication(link)] } : undefined),
     };
+  }
+
+  /**
+   * Hands the developer's own message to one observed chat through Cursor's
+   * documented CLI resume — the bounded exception CLAUDE.md's trust
+   * constraints describe. The chat must have advertised taking one on the
+   * latest pass, and the moment of the act re-checks what the advertisement
+   * rested on: the transcript must still stand — the CLI silently starts a
+   * fresh chat under an id it does not know, so a stale id must refuse rather
+   * than fork — and the login is probed again, because a CLI signed out since
+   * the pass must refuse before anything runs. Nothing is read out of a
+   * launched turn: the transcript the adapter already observes is the report.
+   */
+  override async sendMessage(message: ProviderSessionMessage): Promise<ProviderMessageResult> {
+    const text = sessionMessageText(message.text);
+    if (!text) {
+      return {
+        status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
+        reason: "That message is empty or too long.",
+      };
+    }
+    const target = this.#sendTargets.get(message.providerSessionId);
+    if (!target) return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
+    const stats = await fileStats(target.transcriptFilePath);
+    if (!stats?.isFile()) {
+      return {
+        status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
+        reason: "That chat's transcript is gone, so nothing was sent.",
+      };
+    }
+    const binaryPath =
+      this.#cursorAgentBinaryPath ?? (await this.#cursorAgent.locate().catch(() => undefined));
+    if (!binaryPath) {
+      return {
+        status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
+        reason: "Cursor's agent CLI is not installed, so nothing was sent.",
+      };
+    }
+    let loggedIn: boolean;
+    try {
+      loggedIn = await this.#cursorAgent.probeLogin(binaryPath);
+    } catch {
+      return {
+        status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
+        reason: "Cursor's agent CLI could not answer, so nothing was sent.",
+      };
+    }
+    if (!loggedIn) {
+      return {
+        status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
+        reason: "Cursor's agent CLI is signed out, so nothing was sent.",
+      };
+    }
+    let launch: CursorAgentLaunch;
+    try {
+      launch = await this.#cursorAgent.launch(binaryPath, [
+        CURSOR_AGENT_CLI.RESUME_FLAG,
+        message.providerSessionId,
+        CURSOR_AGENT_CLI.WORKSPACE_FLAG,
+        target.folderPath,
+        ...CURSOR_AGENT_CLI.SEND_ARGV,
+        CURSOR_AGENT_CLI.ARGUMENT_SEPARATOR,
+        text,
+      ]);
+    } catch {
+      return {
+        status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
+        reason: "Cursor's agent CLI could not be started, so nothing was sent.",
+      };
+    }
+    if (launch !== "running" && launch.exitCode !== 0) {
+      return {
+        status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
+        reason: "Cursor's agent CLI refused the message.",
+      };
+    }
+    return { status: PROVIDER_ACT_RESULT_STATUS.ACCEPTED };
   }
 }

--- a/packages/providers/src/cursor/local-adapter.ts
+++ b/packages/providers/src/cursor/local-adapter.ts
@@ -783,7 +783,6 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
   protected override async prepare(
     candidates: readonly CursorTranscriptCandidate[],
   ): Promise<void> {
-    this.#sendTargets.clear();
     const projectDirectoryNames = [
       ...new Set(candidates.map((candidate) => candidate.projectDirectoryName)),
     ];
@@ -886,17 +885,21 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
     const appHeld = this.#appChats.has(candidate.providerSessionId);
     const link = appHeld ? cursorChatLink(candidate.providerSessionId) : undefined;
     // A message is advertised only where the CLI's documented resume can
-    // honestly land one: the turn is settled — a resume into an open turn
-    // would race it — the folder to pin the resume to is named by Cursor's
-    // own record, the CLI is installed, and the app does not hold the chat,
+    // honestly land one: the turn is settled and nothing newer says work is
+    // running — a prompt hook can know about a turn the transcript has not
+    // written yet — the folder to pin the resume to is named by Cursor's own
+    // record, the CLI is installed, and the app does not hold the chat,
     // because Cursor does not document whether an app window shows a turn
     // landed behind it, and a message the developer cannot see land is worse
-    // than none.
+    // than none. A target outlives the pass that advertised it — clearing at
+    // the pass's start would fail a send arriving mid-pass — and a session
+    // gone from the roster is caught by the act-time transcript re-check.
     const folderPath =
       this.#trustedFoldersByProject.get(candidate.projectDirectoryName) ??
       this.#workspaceLabels.folder(candidate.projectDirectoryName);
     const canReceiveMessage =
       parsed.turn !== undefined &&
+      status !== SESSION_STATUS.WORKING &&
       folderPath !== undefined &&
       this.#cursorAgentBinaryPath !== undefined &&
       !appHeld;


### PR DESCRIPTION
> Stacked on #386 (`feat/cursor-hook-merge`); this PR's own change is the last commit. It will be rebased as the stack lands.

## What

The first message path a local surface has, and a new bounded trust-constraint exception written into CLAUDE.md in the same change, worded the way the Superset `terminals send` and Codex-cloud `cloud exec` exceptions are.

Cursor's own `cursor-agent` CLI documents `--resume [chatId]` and non-interactive `--print` (cursor.com/docs/cli). Verified live on this machine before any code was written:

- `--resume <id> -p -- <text>` continues the **same session id** and appends to the **same transcript file** Luke observes, with the chat's history replayed.
- The resume **must be pinned with `--workspace <folder>`**: run from another directory it silently forks the transcript under that directory's project (verified — same id, two transcript files).
- An **unknown id silently starts a fresh chat** rather than erroring, so a stale id must refuse before the CLI runs.
- Print mode **auto-denies held tool calls** rather than hanging, and never takes `--force`/`--trust`/`--model` from Luke.

`sendMessage` on `CursorLocalSessionAdapter` follows exactly that shape: documented invocation, direct `spawn` without a shell, argv fixed by the build plus the observed chat id, the observed folder, and the developer's words as one argument behind `--`. The advertisement (`canReceiveMessage`) is bounded on every side — settled turn only (a resume would race an open one), folder named by Cursor's own records (the project's `.workspace-trusted` first, the workspace-storage record as fallback, any ambiguity names nowhere), CLI located, and **not app-held**: Cursor does not document whether an app window shows a turn landed behind it, so an app chat keeps its address and takes no message. The moment of the act re-probes the login (exit code alone) and the transcript's existence; nothing is read out of the launched turn — the transcript the adapter already observes is the report — and a turn outliving the 8-second refusal window is a delivered message, never a process to kill. Superset-managed chats keep routing through Superset (`session-acts.ts` checks the managed context first).

The app side is a verified honest absence, from full extraction of Cursor 3.16's bundles: `/prompt` only prefills a new composer behind Cursor's own confirmation dialog, `/createchat` is a BugBot-report ingest rather than a chat creator, and `cursor-app-control` is an internal MCP-style tool surface for Cursor's own agent with no send or create verb. The CLI resume is the one documented endpoint.

## Docs

- `CLAUDE.md`: the new exception paragraph, bounding the advertisement, the invocation, the act-time re-checks, and what it does not authorize.
- `PRIVACY.md`: the coding-agent bullet now says the access for Codex cloud tasks and local Cursor messages is the sign-in already given to the provider's own CLI, which Luke runs and never reads.
- `luke-guide.ts`: a "Messaging local Cursor chats" entry, including the app-held refusal and the Superset routing.

## Verification

- `./scripts/check.sh` passed on the rebased stack.
- New adapter tests: advertisement (settled ✓ / working ✗ / app-held ✗ / unplaced folder ✗ / CLI absent ✗), exact argv incl. separator and workspace pin, and act-time refusals (unadvertised id, signed-out CLI, early CLI refusal, transcript gone).
- **Live end-to-end** on this machine against a disposable chat: `sendMessage` accepted → the CLI resumed the exact chat pinned to its folder → the turn ran and the reply landed in the same observed transcript → the next observation pass showed the row waiting with the new reply as its recap. Disposable artifacts were removed afterwards.
- `./scripts/verify.sh`: packaging succeeded, but the evidence step failed launching the packaged app with a pre-existing code-signature Team-ID mismatch between the Luke binary and the bundled Electron Framework in this environment — unrelated to this diff (nothing here touches packaging); no visual evidence was produced and no physical-notch check was performed. The renderer change is one guide knowledge string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32443727875/artifacts/9433380914) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32443727875)

- Commit: `015d8f7b543b8ede8355f75ee7e171cfe5cb124b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
