### PR TITLE
feat(web): add a hide-admins toggle to the admin dashboard

### DIFF
--- a/apps/web/api/admin/metrics.ts
+++ b/apps/web/api/admin/metrics.ts
@@ -49,8 +49,11 @@ export default {
     return handleAdminMetrics({
       request,
       resolveViewer,
-      readMetrics: async (now) =>
-        buildAdminMetrics(await readAdminMetricsSource(getDatabase(), { now, integrations }), now),
+      readMetrics: async (now, scope) =>
+        buildAdminMetrics(
+          await readAdminMetricsSource(getDatabase(), { now, integrations, scope }),
+          now,
+        ),
     });
   },
 };

--- a/apps/web/server/admin/admin-metrics.ts
+++ b/apps/web/server/admin/admin-metrics.ts
@@ -1,6 +1,13 @@
 import { HOSTED_DAILY_LIMIT, HOSTED_METER, utcDayKey } from "../hosted/quota.js";
 import { type AdminViewer, isAdminRole } from "./admin-access.js";
-import { ADMIN_ERROR, ADMIN_HTTP_STATUS, errorResponse, jsonResponse } from "./http.js";
+import {
+  ADMIN_ERROR,
+  ADMIN_HTTP_STATUS,
+  type AdminMetricsScope,
+  adminMetricsScope,
+  errorResponse,
+  jsonResponse,
+} from "./http.js";
 
 /**
  * What the admin dashboard reads about the service, and only what the service's
@@ -248,7 +255,7 @@ export interface AdminMetricsOptions {
    * `viewer.role` is the account's own `role`, read from the session.
    */
   resolveViewer: (request: Request) => Promise<AdminViewer | undefined>;
-  readMetrics: (now: number) => Promise<AdminMetrics>;
+  readMetrics: (now: number, scope: AdminMetricsScope) => Promise<AdminMetrics>;
   now?: () => number;
 }
 
@@ -281,7 +288,10 @@ export async function handleAdminMetrics(options: AdminMetricsOptions): Promise<
 
   const now = (options.now ?? Date.now)();
   try {
-    return jsonResponse(ADMIN_HTTP_STATUS.OK, await options.readMetrics(now));
+    return jsonResponse(
+      ADMIN_HTTP_STATUS.OK,
+      await options.readMetrics(now, adminMetricsScope(request.url)),
+    );
   } catch {
     return errorResponse(ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE, ADMIN_ERROR.UNAVAILABLE);
   }

--- a/apps/web/server/admin/admin-queries.ts
+++ b/apps/web/server/admin/admin-queries.ts
@@ -1,8 +1,9 @@
-import { and, count, desc, eq, gt, gte, or, type SQL, sql, sum } from "drizzle-orm";
+import { and, count, desc, eq, gt, gte, isNull, ne, or, type SQL, sql, sum } from "drizzle-orm";
 import type { createDatabase } from "../db/index.js";
 import { account, session, user } from "../db/schema.js";
 import { hostedUsage } from "../db/usage-schema.js";
 import { HOSTED_DAILY_LIMIT, HOSTED_METER, utcDayKey } from "../hosted/quota.js";
+import { USER_ROLE } from "./admin-access.js";
 import {
   ADMIN_METRICS_WINDOW_DAYS,
   type AdminIntegration,
@@ -12,6 +13,7 @@ import {
   type AdminUsageDay,
   lastNDayKeys,
 } from "./admin-metrics.js";
+import { ADMIN_METRICS_SCOPE, type AdminMetricsScope } from "./http.js";
 
 /** How many of the heaviest hosted-tier users the dashboard names. */
 export const ADMIN_TOP_USERS_LIMIT = 5;
@@ -19,6 +21,17 @@ export const ADMIN_TOP_USERS_LIMIT = 5;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 type Database = ReturnType<typeof createDatabase>;
+
+/**
+ * The accounts a scope keeps. The default keeps every account whose role is not
+ * admin — a null role predates the column's default and is an ordinary user, so
+ * it stays — and `all` filters nothing. Every query below joins the user row it
+ * counts through, so this one condition is the whole filter.
+ */
+function scopeCondition(scope: AdminMetricsScope): SQL<unknown> | undefined {
+  if (scope === ADMIN_METRICS_SCOPE.ALL) return undefined;
+  return or(ne(user.role, USER_ROLE.ADMIN), isNull(user.role));
+}
 
 /** Postgres returns a `count` as a number and a bigint `sum` as a string or null. */
 function toNumber(value: number | string | null | undefined): number {
@@ -42,6 +55,7 @@ async function readUserMetrics(
   database: Database,
   now: number,
   windowStart: Date,
+  scope: AdminMetricsScope,
 ): Promise<AdminMetricsSource["users"]> {
   const dayExpression = sql<string>`to_char(${user.createdAt} at time zone 'UTC', 'YYYY-MM-DD')`;
   const [
@@ -53,31 +67,35 @@ async function readUserMetrics(
     providerRows,
     signupRows,
   ] = await Promise.all([
-    database.select({ value: count() }).from(user),
+    database.select({ value: count() }).from(user).where(scopeCondition(scope)),
     database
       .select({ value: count() })
       .from(user)
-      .where(gte(user.createdAt, new Date(now - 7 * DAY_MS))),
+      .where(and(gte(user.createdAt, new Date(now - 7 * DAY_MS)), scopeCondition(scope))),
     database
       .select({ value: count() })
       .from(user)
-      .where(gte(user.createdAt, new Date(now - 30 * DAY_MS))),
+      .where(and(gte(user.createdAt, new Date(now - 30 * DAY_MS)), scopeCondition(scope))),
     database
       .select({ value: count() })
       .from(session)
-      .where(gt(session.expiresAt, new Date(now))),
+      .innerJoin(user, eq(session.userId, user.id))
+      .where(and(gt(session.expiresAt, new Date(now)), scopeCondition(scope))),
     database
       .select({ value: sql<number>`count(distinct ${session.userId})` })
       .from(session)
-      .where(gt(session.expiresAt, new Date(now))),
+      .innerJoin(user, eq(session.userId, user.id))
+      .where(and(gt(session.expiresAt, new Date(now)), scopeCondition(scope))),
     database
       .select({ providerId: account.providerId, value: count() })
       .from(account)
+      .innerJoin(user, eq(account.userId, user.id))
+      .where(scopeCondition(scope))
       .groupBy(account.providerId),
     database
       .select({ day: dayExpression, value: count() })
       .from(user)
-      .where(gte(user.createdAt, windowStart))
+      .where(and(gte(user.createdAt, windowStart), scopeCondition(scope)))
       .groupBy(dayExpression),
   ]);
 
@@ -107,6 +125,7 @@ async function readUsageMetrics(
   database: Database,
   todayKey: string,
   windowStartDay: string,
+  scope: AdminMetricsScope,
 ): Promise<AdminMetricsSource["usage"]> {
   const [usageRows, [activeTodayRow], topUserRows] = await Promise.all([
     database
@@ -116,9 +135,14 @@ async function readUsageMetrics(
         attentionReviews: sum(hostedUsage.attentionReviews),
       })
       .from(hostedUsage)
-      .where(gte(hostedUsage.day, windowStartDay))
+      .innerJoin(user, eq(hostedUsage.userId, user.id))
+      .where(and(gte(hostedUsage.day, windowStartDay), scopeCondition(scope)))
       .groupBy(hostedUsage.day),
-    database.select({ value: count() }).from(hostedUsage).where(eq(hostedUsage.day, todayKey)),
+    database
+      .select({ value: count() })
+      .from(hostedUsage)
+      .innerJoin(user, eq(hostedUsage.userId, user.id))
+      .where(and(eq(hostedUsage.day, todayKey), scopeCondition(scope))),
     database
       .select({
         name: user.name,
@@ -128,7 +152,7 @@ async function readUsageMetrics(
       })
       .from(hostedUsage)
       .innerJoin(user, eq(hostedUsage.userId, user.id))
-      .where(gte(hostedUsage.day, windowStartDay))
+      .where(and(gte(hostedUsage.day, windowStartDay), scopeCondition(scope)))
       .groupBy(user.id, user.name, user.email)
       .orderBy(desc(sql`sum(${hostedUsage.voiceCalls}) + sum(${hostedUsage.attentionReviews})`))
       .limit(ADMIN_TOP_USERS_LIMIT),
@@ -174,16 +198,19 @@ async function readReliabilityMetrics(
   database: Database,
   todayKey: string,
   windowStartDay: string,
+  scope: AdminMetricsScope,
 ): Promise<AdminMetricsSource["reliability"]> {
   const [[todayRow], [windowRow]] = await Promise.all([
     database
       .select({ value: count() })
       .from(hostedUsage)
-      .where(and(eq(hostedUsage.day, todayKey), ceilingReached())),
+      .innerJoin(user, eq(hostedUsage.userId, user.id))
+      .where(and(eq(hostedUsage.day, todayKey), ceilingReached(), scopeCondition(scope))),
     database
       .select({ value: count() })
       .from(hostedUsage)
-      .where(and(gte(hostedUsage.day, windowStartDay), ceilingReached())),
+      .innerJoin(user, eq(hostedUsage.userId, user.id))
+      .where(and(gte(hostedUsage.day, windowStartDay), ceilingReached(), scopeCondition(scope))),
   ]);
 
   return {
@@ -221,7 +248,11 @@ function emptySource(
  */
 export async function readAdminMetricsSource(
   database: Database,
-  input: { now: number; integrations: readonly AdminIntegration[] },
+  input: {
+    now: number;
+    integrations: readonly AdminIntegration[];
+    scope: AdminMetricsScope;
+  },
 ): Promise<AdminMetricsSource> {
   const health = await probeDatabase(database);
   if (!health.reachable) return emptySource(input.integrations, health);
@@ -232,9 +263,9 @@ export async function readAdminMetricsSource(
   const windowStart = new Date(`${windowStartDay}T00:00:00.000Z`);
 
   const [users, usage, reliability] = await Promise.all([
-    readUserMetrics(database, input.now, windowStart),
-    readUsageMetrics(database, todayKey, windowStartDay),
-    readReliabilityMetrics(database, todayKey, windowStartDay),
+    readUserMetrics(database, input.now, windowStart, input.scope),
+    readUsageMetrics(database, todayKey, windowStartDay, input.scope),
+    readReliabilityMetrics(database, todayKey, windowStartDay, input.scope),
   ]);
 
   return {

--- a/apps/web/server/admin/http.ts
+++ b/apps/web/server/admin/http.ts
@@ -28,6 +28,35 @@ export const ADMIN_ERROR = {
 
 export type AdminError = (typeof ADMIN_ERROR)[keyof typeof ADMIN_ERROR];
 
+/**
+ * How much of the user population a metrics read covers. Admin accounts are the
+ * maintainers' own, and their traffic reads as noise in a dashboard asking how
+ * the product is doing, so the default scope leaves them out; `all` is the
+ * explicit ask to count every account. The set lives here, with the rest of the
+ * wire vocabulary, because both sides of the request speak it: the page asks
+ * with the query parameter and the endpoint reads its answer from it.
+ */
+export const ADMIN_METRICS_SCOPE = {
+  NON_ADMINS: "non-admins",
+  ALL: "all",
+} as const;
+
+export type AdminMetricsScope = (typeof ADMIN_METRICS_SCOPE)[keyof typeof ADMIN_METRICS_SCOPE];
+
+export const ADMIN_METRICS_SCOPE_PARAM = "scope";
+
+/**
+ * The scope a request asked for. Anything but the explicit `all` — absent,
+ * misspelled, or unknown — falls to the default, because the narrower answer is
+ * the safe one to give a request that did not clearly ask for more.
+ */
+export function adminMetricsScope(url: string): AdminMetricsScope {
+  const value = new URL(url).searchParams.get(ADMIN_METRICS_SCOPE_PARAM);
+  return value === ADMIN_METRICS_SCOPE.ALL
+    ? ADMIN_METRICS_SCOPE.ALL
+    : ADMIN_METRICS_SCOPE.NON_ADMINS;
+}
+
 export function jsonResponse<Body extends object>(status: number, body: Body): Response {
   return new Response(JSON.stringify(body), {
     status,

--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -7,6 +7,7 @@ import type {
   AdminMetrics,
   AdminTopUser,
 } from "../server/admin/admin-metrics";
+import { ADMIN_METRICS_SCOPE, ADMIN_METRICS_SCOPE_PARAM } from "../server/admin/http";
 import { LukeMark } from "./SiteChrome";
 import { SOCIAL_PROVIDER, SOCIAL_PROVIDER_LABEL, type SocialProvider } from "./sign-in-provider";
 
@@ -251,7 +252,15 @@ function IntegrationRow({ integration }: { integration: AdminIntegration }): Rea
   );
 }
 
-function Dashboard({ metrics }: { metrics: AdminMetrics }): React.JSX.Element {
+function Dashboard({
+  metrics,
+  hideAdmins,
+  onHideAdminsChange,
+}: {
+  metrics: AdminMetrics;
+  hideAdmins: boolean;
+  onHideAdminsChange: (hide: boolean) => void;
+}): React.JSX.Element {
   const providerTotal =
     metrics.users.signInMethods.google +
     metrics.users.signInMethods.github +
@@ -267,9 +276,20 @@ function Dashboard({ metrics }: { metrics: AdminMetrics }): React.JSX.Element {
           </span>
           <span className="font-brand text-base font-bold tracking-[-0.01em]">Luke admin</span>
         </div>
-        <span className="font-mono text-xs text-muted-foreground">
-          {metrics.windowDays}-day window · generated {formatTimestamp(metrics.generatedAt)} UTC
-        </span>
+        <div className="flex items-center gap-4">
+          <label className="inline-flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground select-none">
+            <input
+              type="checkbox"
+              className="size-3.5 cursor-pointer accent-primary"
+              checked={hideAdmins}
+              onChange={(event) => onHideAdminsChange(event.target.checked)}
+            />
+            Hide admins
+          </label>
+          <span className="font-mono text-xs text-muted-foreground">
+            {metrics.windowDays}-day window · generated {formatTimestamp(metrics.generatedAt)} UTC
+          </span>
+        </div>
       </header>
 
       <SectionHeading>User activity</SectionHeading>
@@ -482,12 +502,21 @@ function Centered({
 
 export function AdminDashboard(): React.JSX.Element {
   const [state, setState] = useState<DashboardState>({ status: "loading" });
+  // Admin accounts are the maintainers' own; their traffic reads as noise in
+  // every count, so the dashboard opens with them hidden and the toggle is the
+  // explicit ask to include them. The scope is the server's filter — aggregates
+  // cannot be unpicked client-side — so flipping it refetches.
+  const [hideAdmins, setHideAdmins] = useState(true);
 
   useEffect(() => {
     let live = true;
+    setState({ status: "loading" });
+    const path = hideAdmins
+      ? METRICS_PATH
+      : `${METRICS_PATH}?${ADMIN_METRICS_SCOPE_PARAM}=${ADMIN_METRICS_SCOPE.ALL}`;
     void (async () => {
       try {
-        const response = await fetch(METRICS_PATH, { headers: { accept: "application/json" } });
+        const response = await fetch(path, { headers: { accept: "application/json" } });
         if (!live) return;
         // A followed cross-origin redirect means something sat in front of the
         // API — a preview's deployment protection is the usual culprit — so the
@@ -522,7 +551,7 @@ export function AdminDashboard(): React.JSX.Element {
     return () => {
       live = false;
     };
-  }, []);
+  }, [hideAdmins]);
 
   const body = useMemo(() => {
     switch (state.status) {
@@ -541,9 +570,15 @@ export function AdminDashboard(): React.JSX.Element {
       case "error":
         return <Centered title="Could not load">{state.detail}</Centered>;
       case "ready":
-        return <Dashboard metrics={state.metrics} />;
+        return (
+          <Dashboard
+            metrics={state.metrics}
+            hideAdmins={hideAdmins}
+            onHideAdminsChange={setHideAdmins}
+          />
+        );
     }
-  }, [state]);
+  }, [state, hideAdmins]);
 
   return body;
 }

--- a/apps/web/tests/admin-metrics.test.ts
+++ b/apps/web/tests/admin-metrics.test.ts
@@ -11,7 +11,13 @@ import {
   handleAdminMetrics,
   lastNDayKeys,
 } from "../server/admin/admin-metrics";
-import { ADMIN_ERROR } from "../server/admin/http";
+import {
+  ADMIN_ERROR,
+  ADMIN_METRICS_SCOPE,
+  ADMIN_METRICS_SCOPE_PARAM,
+  type AdminMetricsScope,
+  adminMetricsScope,
+} from "../server/admin/http";
 import { HOSTED_DAILY_LIMIT, HOSTED_METER } from "../server/hosted/quota";
 
 const NOON_UTC = Date.parse("2026-08-17T12:00:00.000Z");
@@ -166,6 +172,38 @@ test("the gate answers 405, 401, 403, and 200 as distinct outcomes", async () =>
   const body = (await ok.json()) as AdminMetrics;
   assert.equal(body.generatedAt, NOON_UTC);
   assert.equal(body.windowDays, ADMIN_METRICS_WINDOW_DAYS);
+});
+
+test("the scope defaults to hiding admins; only the explicit `all` widens it", () => {
+  assert.equal(
+    adminMetricsScope("https://luke.test/api/admin/metrics"),
+    ADMIN_METRICS_SCOPE.NON_ADMINS,
+  );
+  assert.equal(
+    adminMetricsScope("https://luke.test/api/admin/metrics?scope=all"),
+    ADMIN_METRICS_SCOPE.ALL,
+  );
+  assert.equal(
+    adminMetricsScope("https://luke.test/api/admin/metrics?scope=everyone"),
+    ADMIN_METRICS_SCOPE.NON_ADMINS,
+  );
+});
+
+test("the handler reads metrics at the scope the request asked for", async () => {
+  const scopes: AdminMetricsScope[] = [];
+  const readMetrics = async (now: number, scope: AdminMetricsScope): Promise<AdminMetrics> => {
+    scopes.push(scope);
+    return emptyMetrics(now);
+  };
+  const respond = (request: Request) =>
+    handleAdminMetrics({ request, resolveViewer: async () => ADMIN_VIEWER, readMetrics });
+
+  assert.equal((await respond(metricsRequest())).status, 200);
+  const widened = new Request(
+    `https://luke.test/api/admin/metrics?${ADMIN_METRICS_SCOPE_PARAM}=${ADMIN_METRICS_SCOPE.ALL}`,
+  );
+  assert.equal((await respond(widened)).status, 200);
+  assert.deepEqual(scopes, [ADMIN_METRICS_SCOPE.NON_ADMINS, ADMIN_METRICS_SCOPE.ALL]);
 });
 
 test("metrics are not read for a request that fails the gate", async () => {


### PR DESCRIPTION
## What

Adds a **Hide admins** toggle to the admin dashboard header, on by default.

The maintainers' own accounts carry the admin role, and their traffic reads as noise in a dashboard asking how the product is doing. Since every number on the page is a server-side aggregate, the filter has to live in the queries: the metrics endpoint now takes a `scope` query parameter, part of the wire vocabulary in `server/admin/http.ts`.

- **`scope` absent or unrecognized (the default):** every user-scoped aggregate — account totals, signups, active sessions, sign-in methods, hosted usage, top users, throttled account-days — counts only accounts whose role is not admin (a null role is an ordinary user and stays). The narrower answer is the safe default for a request that did not clearly ask for more.
- **`scope=all`:** the previous behavior, counting every account.

The dashboard opens hidden and the checkbox refetches at the chosen scope. System-health and ceiling numbers are not user-scoped and are unchanged.

## Tests

- `adminMetricsScope` defaults to hiding admins and widens only on the explicit `all`.
- `handleAdminMetrics` reads metrics at the scope the request asked for.

## Verification

`./scripts/check.sh` passes (all 64 `apps/web` tests green, full workspace lint/typecheck/test/build clean). This change touches only the web dashboard, so the macOS `verify.sh` pipeline is not implicated; the built `admin.html` was served against fixture metrics and inspected — the toggle renders checked in the header and the page draws correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/5838e902-7197-4a49-bc17-76ffea5f684f)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32444000543/artifacts/9433467271) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32444000543)

- Commit: `051e2e9046073c7e0ce2d285ac1e17f37b60dc26`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
