### PR TITLE
feat(web): ask the admin dashboard's first visit to sign in explicitly

### DIFF
--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -1,5 +1,5 @@
 import { createAuthClient } from "better-auth/react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import type {
   AdminDailySignups,
   AdminDailyUsage,
@@ -8,12 +8,49 @@ import type {
   AdminTopUser,
 } from "../server/admin/admin-metrics";
 import { ADMIN_METRICS_SCOPE, ADMIN_METRICS_SCOPE_PARAM } from "../server/admin/http";
+import { GitHubMark, GoogleMark } from "./account-marks";
+import { AUTH_BUTTON } from "./auth-surface";
 import { LukeMark } from "./SiteChrome";
 import { SOCIAL_PROVIDER, SOCIAL_PROVIDER_LABEL, type SocialProvider } from "./sign-in-provider";
 
 const authClient = createAuthClient();
 
 const METRICS_PATH = "/api/admin/metrics";
+
+/**
+ * The site's session cookie is shared with the sign-in flow the desktop app
+ * opens in this browser, so the first visit to this page would otherwise land
+ * already signed in — on a session the maintainer never chose to spend here.
+ * The dashboard opens only after a sign-in pressed on this page once; the
+ * press is remembered locally, and from then on an existing session resumes
+ * the way it does on any signed-in page.
+ */
+const SIGN_IN_CHOSEN_STORAGE_KEY = "luke-admin-sign-in-chosen";
+
+function signInChosenHere(): boolean {
+  try {
+    return window.localStorage.getItem(SIGN_IN_CHOSEN_STORAGE_KEY) !== null;
+  } catch {
+    return false;
+  }
+}
+
+function rememberSignInChosen(): void {
+  try {
+    window.localStorage.setItem(SIGN_IN_CHOSEN_STORAGE_KEY, "true");
+  } catch {
+    // Storage refused: the card simply asks again on the next visit.
+  }
+}
+
+/** The signed-in account the header names; read from the session, shown as-is. */
+interface ViewerAccount {
+  name: string;
+  email: string;
+}
+
+const SIGN_OUT_BUTTON =
+  "cursor-pointer rounded-md border border-border bg-card px-3 py-1.5 text-sm font-medium transition-colors duration-150 hover:bg-muted";
 
 /** What the fetch resolved to: the gate's refusals stay distinct here. */
 type DashboardState =
@@ -256,10 +293,14 @@ function Dashboard({
   metrics,
   hideAdmins,
   onHideAdminsChange,
+  account,
+  onSignOut,
 }: {
   metrics: AdminMetrics;
   hideAdmins: boolean;
   onHideAdminsChange: (hide: boolean) => void;
+  account: ViewerAccount | undefined;
+  onSignOut: () => void;
 }): React.JSX.Element {
   const providerTotal =
     metrics.users.signInMethods.google +
@@ -269,14 +310,14 @@ function Dashboard({
 
   return (
     <div className="mx-auto max-w-[1040px] px-6 py-10">
-      <header className="flex items-center justify-between gap-4">
+      <header className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
         <div className="inline-flex items-center gap-2">
           <span className="inline-flex w-6 text-foreground" aria-hidden="true">
             <LukeMark className="h-auto w-full" />
           </span>
           <span className="font-brand text-base font-bold tracking-[-0.01em]">Luke admin</span>
         </div>
-        <div className="flex items-center gap-4">
+        <div className="flex flex-wrap items-center gap-4">
           <label className="inline-flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground select-none">
             <input
               type="checkbox"
@@ -289,6 +330,18 @@ function Dashboard({
           <span className="font-mono text-xs text-muted-foreground">
             {metrics.windowDays}-day window · generated {formatTimestamp(metrics.generatedAt)} UTC
           </span>
+          {account ? (
+            <>
+              <span className="h-8 w-px bg-border" aria-hidden="true" />
+              <div className="text-right">
+                <div className="text-sm leading-tight font-medium">{account.name}</div>
+                <div className="text-xs text-muted-foreground">{account.email}</div>
+              </div>
+              <button type="button" className={SIGN_OUT_BUTTON} onClick={onSignOut}>
+                Sign out
+              </button>
+            </>
+          ) : null}
         </div>
       </header>
 
@@ -439,7 +492,9 @@ function SignInCard(): React.JSX.Element {
     if (result.error) {
       setPending(undefined);
       setFailed(true);
+      return;
     }
+    rememberSignInChosen();
   };
 
   return (
@@ -455,20 +510,22 @@ function SignInCard(): React.JSX.Element {
         <div className="mt-8 mb-4 grid gap-3">
           <button
             type="button"
-            className="min-h-[46px] cursor-pointer rounded-md border border-border bg-card font-semibold transition-[background-color,transform] duration-150 hover:not-disabled:-translate-y-px hover:not-disabled:bg-muted disabled:cursor-wait disabled:opacity-[0.56] motion-reduce:transition-none"
+            className={`${AUTH_BUTTON} inline-flex items-center justify-center gap-2.5`}
             disabled={pending !== undefined}
             onClick={() => void begin(SOCIAL_PROVIDER.GITHUB)}
           >
+            <GitHubMark className="size-[15px] shrink-0" />
             {pending === SOCIAL_PROVIDER.GITHUB
               ? "Opening…"
               : `Continue with ${SOCIAL_PROVIDER_LABEL[SOCIAL_PROVIDER.GITHUB]}`}
           </button>
           <button
             type="button"
-            className="min-h-[46px] cursor-pointer rounded-md border border-border bg-card font-semibold transition-[background-color,transform] duration-150 hover:not-disabled:-translate-y-px hover:not-disabled:bg-muted disabled:cursor-wait disabled:opacity-[0.56] motion-reduce:transition-none"
+            className={`${AUTH_BUTTON} inline-flex items-center justify-center gap-2.5`}
             disabled={pending !== undefined}
             onClick={() => void begin(SOCIAL_PROVIDER.GOOGLE)}
           >
+            <GoogleMark className="size-[15px] shrink-0" />
             {pending === SOCIAL_PROVIDER.GOOGLE
               ? "Opening…"
               : `Continue with ${SOCIAL_PROVIDER_LABEL[SOCIAL_PROVIDER.GOOGLE]}`}
@@ -507,8 +564,17 @@ export function AdminDashboard(): React.JSX.Element {
   // explicit ask to include them. The scope is the server's filter — aggregates
   // cannot be unpicked client-side — so flipping it refetches.
   const [hideAdmins, setHideAdmins] = useState(true);
+  const session = authClient.useSession();
+  const account = session.data?.user;
 
   useEffect(() => {
+    // A session earned elsewhere on the site does not open the dashboard by
+    // itself: until a sign-in has been pressed on this page once, the card is
+    // the answer, whatever cookie the browser holds.
+    if (!signInChosenHere()) {
+      setState({ status: "signed-out" });
+      return;
+    }
     let live = true;
     setState({ status: "loading" });
     const path = hideAdmins
@@ -553,32 +619,40 @@ export function AdminDashboard(): React.JSX.Element {
     };
   }, [hideAdmins]);
 
-  const body = useMemo(() => {
-    switch (state.status) {
-      case "loading":
-        return <Centered title="Loading…">Reading the service's own tables.</Centered>;
-      case "signed-out":
-        return <SignInCard />;
-      case "forbidden":
-        return (
-          <Centered title="Not authorized">
-            You are signed in, but this account does not have the admin role. Admin access is the{" "}
-            <code className="font-mono">admin</code> role on your account, set directly in the
-            database.
-          </Centered>
-        );
-      case "error":
-        return <Centered title="Could not load">{state.detail}</Centered>;
-      case "ready":
-        return (
-          <Dashboard
-            metrics={state.metrics}
-            hideAdmins={hideAdmins}
-            onHideAdminsChange={setHideAdmins}
-          />
-        );
-    }
-  }, [state, hideAdmins]);
+  const signOut = async () => {
+    await authClient.signOut();
+    setState({ status: "signed-out" });
+  };
 
-  return body;
+  switch (state.status) {
+    case "loading":
+      return <Centered title="Loading…">Reading the service's own tables.</Centered>;
+    case "signed-out":
+      return <SignInCard />;
+    case "forbidden":
+      return (
+        <Centered title="Not authorized">
+          You are signed in{account ? ` as ${account.email}` : ""}, but this account does not have
+          the admin role. Admin access is the <code className="font-mono">admin</code> role on your
+          account, set directly in the database.
+          <div className="mt-6">
+            <button type="button" className={SIGN_OUT_BUTTON} onClick={() => void signOut()}>
+              Sign out
+            </button>
+          </div>
+        </Centered>
+      );
+    case "error":
+      return <Centered title="Could not load">{state.detail}</Centered>;
+    case "ready":
+      return (
+        <Dashboard
+          metrics={state.metrics}
+          hideAdmins={hideAdmins}
+          onHideAdminsChange={setHideAdmins}
+          account={account ? { name: account.name, email: account.email } : undefined}
+          onSignOut={() => void signOut()}
+        />
+      );
+  }
 }

--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -558,7 +558,11 @@ function Centered({
 }
 
 export function AdminDashboard(): React.JSX.Element {
-  const [state, setState] = useState<DashboardState>({ status: "loading" });
+  // A first visit is signed-out from the very first frame: it never fetches,
+  // so a loading state would pose as a request that is not in flight.
+  const [state, setState] = useState<DashboardState>(() =>
+    signInChosenHere() ? { status: "loading" } : { status: "signed-out" },
+  );
   // Admin accounts are the maintainers' own; their traffic reads as noise in
   // every count, so the dashboard opens with them hidden and the toggle is the
   // explicit ask to include them. The scope is the server's filter — aggregates

--- a/apps/web/src/account-marks.tsx
+++ b/apps/web/src/account-marks.tsx
@@ -1,17 +1,20 @@
-import { ACCOUNT_PROVIDER, type AccountProvider } from "#shared/contracts";
-
 /**
- * The two identity providers' own marks, traced for the sign-in surface. They
- * are brand marks like a session provider's, not glyphs of ours: the Google G
- * keeps its four official colours, and the GitHub mark rides `currentColor`
- * the way GitHub's own guidance draws it on a dark ground. The web admin
- * sign-in traces its own copy in `apps/web/src/account-marks.tsx`, duplicated
- * on purpose the way `provider-marks.tsx` is: the React that traces a mark
- * stays in each app rather than entering the shared surface vocabulary.
+ * The two identity providers' own marks, traced for the admin sign-in card.
+ * They are brand marks, not glyphs of ours: the Google G keeps its four
+ * official colours, and the GitHub mark rides `currentColor` the way GitHub's
+ * own guidance draws it on a dark ground. They are the desktop sign-in gate's
+ * marks (`apps/desktop/src/renderer/account-marks.tsx`), duplicated on purpose
+ * the way `provider-marks.tsx` duplicates the session marks: the React that
+ * traces a mark stays in each app. Do not restyle the geometry or recolour
+ * them; change both copies if a provider publishes an updated mark.
  */
-export function GoogleMark(): React.JSX.Element {
+interface MarkProps {
+  className?: string;
+}
+
+export function GoogleMark({ className }: MarkProps): React.JSX.Element {
   return (
-    <svg className="account-mark" viewBox="0 0 18 18" aria-hidden="true" focusable="false">
+    <svg className={className} viewBox="0 0 18 18" aria-hidden="true" focusable="false">
       <path
         fill="#4285F4"
         d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z"
@@ -32,10 +35,10 @@ export function GoogleMark(): React.JSX.Element {
   );
 }
 
-export function GitHubMark(): React.JSX.Element {
+export function GitHubMark({ className }: MarkProps): React.JSX.Element {
   return (
     <svg
-      className="account-mark"
+      className={className}
       viewBox="0 0 16 16"
       fill="currentColor"
       aria-hidden="true"
@@ -44,13 +47,4 @@ export function GitHubMark(): React.JSX.Element {
       <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
     </svg>
   );
-}
-
-/** The pressed provider's own mark, for the surfaces that name one by id. */
-export function AccountProviderMark({
-  provider,
-}: {
-  provider: AccountProvider;
-}): React.JSX.Element {
-  return provider === ACCOUNT_PROVIDER.GITHUB ? <GitHubMark /> : <GoogleMark />;
 }


### PR DESCRIPTION
## What

Three changes to the admin dashboard's auth surface:

- **No automatic sign-in on the first visit.** The admin page shares the site's Better Auth session cookie with the sign-in flow the desktop app opens in the same browser, so a maintainer's first-ever visit landed already signed in on a session they never chose to spend there. The dashboard now opens only after a sign-in pressed on the page once; the press is remembered in `localStorage`, and from then on an existing session resumes the way it does on any signed-in page.
- **Official provider marks on the sign-in buttons.** The Google G in its four official colours and the GitHub mark on `currentColor`, traced exactly as the desktop sign-in gate draws them and duplicated into `apps/web/src/account-marks.tsx` on purpose, the way `provider-marks.tsx` already is (the React that traces a mark stays in each app). The desktop copy's rationale comment is updated to match.
- **The signed-in account is named, with a way out.** The dashboard header shows the session's name and email beside a Sign out button that returns to the sign-in card; the not-authorized screen names the account and gets the same sign-out, since a wrong account is exactly where signing out and back in matters.

## Verification

- `./scripts/check.sh` passes (portable checks; this is a web-only change, so `verify.sh`'s macOS packaging does not apply).
- Visual check of the sign-in card against the vite dev server (headless Chrome): the card renders with both marks, and the first visit shows the card without touching the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/301dd7ac-a779-410a-ae1a-6bd8126409f3)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32445603080/artifacts/9433977391) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32445603080)

- Commit: `83ead3e05d52d131a5f67b38bcc942fce9059dcf`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
