### PR TITLE
feat(conductor): create local workspaces, distinguished from cloud

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,18 @@ Trust constraints:
   conversation, lands only in a project its provider reported on the latest
   observation pass and documents a creation endpoint for; the ask names a
   reported project, never a repository URL or path of its own, and a provider
-  that documents no such endpoint offers nowhere to create. The ask may carry
+  that documents no such endpoint offers nowhere to create. A local manager's
+  documented creation endpoint may be its own deep link rather than a network
+  call: for a workspace on this machine (Conductor today) the ask is honored
+  by handing that link to the operating system the way an open is, except that
+  where an open reaches no provider this one asks the manager to make exactly
+  what the developer asked. The project it names is still a reported one — a
+  repository that manager's own index listed on the latest pass — and the path
+  the create lands on is the one that report carried, read back from the
+  offered project rather than composed by the ask; a manager that lists no
+  repository offers nowhere to create, and the link carries the opening task
+  alone, since Conductor's creation link documents no agent, model, or name.
+  The ask may carry
   the new agent's opening task, the developer's own words, bounded and
   delivered like a message to an existing session, through the provider's
   documented endpoints, and each project says whether it takes one, needs

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -723,7 +723,13 @@ async function rememberWorkspaceDefaults(
   agent: string | undefined,
 ): Promise<void> {
   const providerId = adapter.provider.id;
-  if (!isProviderId(providerId) && providerId !== SUPERSET_WORKSPACE_PROVIDER_ID) return;
+  if (
+    !isProviderId(providerId) &&
+    providerId !== SUPERSET_WORKSPACE_PROVIDER_ID &&
+    providerId !== CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID
+  ) {
+    return;
+  }
   try {
     if (
       (await settingsStore.get(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field)) === undefined

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -29,6 +29,7 @@ import {
   CmuxSessionApplicationReader,
   CmuxSessionApplicationSnapshot,
   CodexCloudSessionAdapter,
+  ConductorLocalWorkspaceAdapter,
   ConductorSessionApplicationReader,
   ConductorSessionApplicationSnapshot,
   defaultOrcaDataDirectory,
@@ -44,6 +45,7 @@ import {
   attentionSpeechFromReviews,
 } from "@sidecar/realtime";
 import {
+  CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
   CreatedWorkspaceOpenTracker,
   InMemorySessionRegistry,
   isProviderId,
@@ -173,6 +175,14 @@ const sessionRegistry = new InMemorySessionRegistry();
 // "unknown".
 const codexCloudAdapter = new CodexCloudSessionAdapter();
 const conductorSessionApplications = new ConductorSessionApplicationReader();
+// The local counterpart of the cloud Conductor adapter's creation path: it
+// reads the repositories Conductor holds and creates a workspace in one by
+// handing Conductor's own creation deep link to the operating system. It
+// observes no sessions of its own, so it joins the workspace-project offer and
+// the act router rather than the observation registry.
+const conductorLocalWorkspaceAdapter = new ConductorLocalWorkspaceAdapter({
+  openExternal: (url) => shell.openExternal(url),
+});
 const orcaWorkspaces = new OrcaWorkspaceReader({
   dataDirectory: process.env.ORCA_USER_DATA_PATH ?? defaultOrcaDataDirectory(),
 });
@@ -684,6 +694,7 @@ async function applyVoiceCredential(): Promise<void> {
 
 function adapterFor(providerId: string) {
   if (providerId === SUPERSET_WORKSPACE_PROVIDER_ID) return supersetWorkspaceAdapter;
+  if (providerId === CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID) return conductorLocalWorkspaceAdapter;
   return isProviderId(providerId) ? providerRegistry[providerId].adapter : undefined;
 }
 
@@ -1056,13 +1067,16 @@ function registerIpc(): void {
  */
 function offeredWorkspaceProjects(): readonly ObservedWorkspaceProject[] {
   if (!runMode.observesProviders) return [];
-  return [...orderedRegistrations.map(({ adapter }) => adapter), supersetWorkspaceAdapter].flatMap(
-    (adapter) =>
-      adapter.workspaceProjects().map((project) => ({
-        ...project,
-        providerId: adapter.provider.id,
-        providerName: adapter.provider.displayName,
-      })),
+  return [
+    ...orderedRegistrations.map(({ adapter }) => adapter),
+    supersetWorkspaceAdapter,
+    conductorLocalWorkspaceAdapter,
+  ].flatMap((adapter) =>
+    adapter.workspaceProjects().map((project) => ({
+      ...project,
+      providerId: adapter.provider.id,
+      providerName: adapter.provider.displayName,
+    })),
   );
 }
 
@@ -1114,6 +1128,13 @@ async function refreshProviderSessions(generation: number): Promise<void> {
     process.stderr.write(`cmux application observation failed: ${message}\n`);
     return new CmuxSessionApplicationSnapshot();
   });
+  // Re-reads the repositories Conductor holds so the local create offer tracks
+  // its index. A failed read empties the offer inside the adapter, so a create
+  // is never validated against repositories a later read could no longer see.
+  const conductorRepositoriesPromise = conductorLocalWorkspaceAdapter.refresh().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Conductor repository observation failed: ${message}\n`);
+  });
   let supersetSnapshot = new SupersetWorkspaceSnapshot([]);
   let supersetOrganization: string | undefined;
   let supersetAgentDefault: string | undefined;
@@ -1145,6 +1166,7 @@ async function refreshProviderSessions(generation: number): Promise<void> {
   const conductorSnapshot = await conductorSnapshotPromise;
   const orcaSnapshot = await orcaSnapshotPromise;
   const cmuxSnapshot = await cmuxSnapshotPromise;
+  await conductorRepositoriesPromise;
   const supersetActionsEnabled = supersetOrganization !== undefined;
   if (actionsWereEnabled !== supersetActionsEnabled) {
     if (supersetActionsEnabled) {

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -244,9 +244,21 @@ function integrationsFact(settings: AppSettings): AppGuideFact {
     "the CLI's way of switching organizations — and disconnecting from it runs the CLI's own " +
     "sign-out, clearing the login the CLI stored. The default agent for a creation ask that names " +
     "none is chosen under Superset in Settings; until one is chosen, Luke asks.";
+  const conductor =
+    " Conductor comes two ways, told apart by where the work lands. Conductor cloud connects " +
+    "with a key under Providers and creates workspaces in the cloud projects that key " +
+    "lists. Conductor on this Mac needs no key: it is recognized read-only from Conductor's own " +
+    "index, and a conversation ask can create a new workspace in any repository Conductor holds " +
+    "locally — shown as “Conductor (local)” in the create picker and its own block under " +
+    "Providers. A local creation opens the new workspace in Conductor itself and may carry an " +
+    "opening task, but no agent, model, or name choice, so it runs the repository's own default " +
+    "agent and wears the name Conductor gives it; the default repository a nameless ask lands in " +
+    "is chosen under Conductor (local) in Settings, and until one is chosen Luke asks. Local " +
+    "Conductor chats stay read-only otherwise: Luke cannot message, archive, or add an agent to " +
+    "one, because Conductor documents no local way in for those.";
   return {
     label: "Integrations",
-    detail: `${linear}${apple}${calendar}${superset}`.trim(),
+    detail: `${linear}${apple}${calendar}${superset}${conductor}`.trim(),
   };
 }
 

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -251,8 +251,11 @@ function integrationsFact(settings: AppSettings): AppGuideFact {
     "index, and a conversation ask can create a new workspace in any repository Conductor holds " +
     "locally — shown as “Conductor (local)” in the create picker and its own block under " +
     "Providers. A local creation opens the new workspace in Conductor itself and may carry an " +
-    "opening task, but no agent, model, or name choice, so it runs the repository's own default " +
-    "agent and wears the name Conductor gives it; the default repository a nameless ask lands in " +
+    "opening task, which Conductor pre-fills in the new workspace's composer but does not send — " +
+    "its link cannot, so Luke says the prompt is ready and the developer presses Return in " +
+    "Conductor to start it. It carries no agent, model, or name choice, so it runs the " +
+    "repository's own default agent and wears the name Conductor gives it; the default repository " +
+    "a nameless ask lands in " +
     "is chosen under Conductor (local) in Settings, and until one is chosen Luke asks. Local " +
     "Conductor chats stay read-only otherwise: Luke cannot message, archive, or add an agent to " +
     "one, because Conductor documents no local way in for those.";

--- a/apps/desktop/src/renderer/provider-marks.tsx
+++ b/apps/desktop/src/renderer/provider-marks.tsx
@@ -2,6 +2,7 @@ import { GOOGLE_CALENDAR_ID } from "@sidecar/calendar/vocabulary";
 import { CREDENTIAL_PROVIDER_ID } from "@sidecar/credentials";
 import { ISSUE_TRACKER_ID, type IssueTrackerId } from "@sidecar/issues";
 import {
+  CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
   PROVIDER_ID,
   type ProviderId,
   SESSION_APPLICATION_ID,
@@ -457,7 +458,8 @@ export type MarkId =
   | typeof APPLE_CALENDAR_ID
   | typeof GOOGLE_CALENDAR_ID
   | typeof CREDENTIAL_PROVIDER_ID.OPENAI
-  | typeof SUPERSET_WORKSPACE_PROVIDER_ID;
+  | typeof SUPERSET_WORKSPACE_PROVIDER_ID
+  | typeof CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID;
 
 const PROVIDER_MARKS = {
   [APPLE_CALENDAR_ID]: AppleCalendarMark,
@@ -466,6 +468,9 @@ const PROVIDER_MARKS = {
   [SESSION_APPLICATION_ID.CMUX]: CmuxMark,
   [PROVIDER_ID.CODEX]: CodexMark,
   [PROVIDER_ID.CONDUCTOR]: ConductorMark,
+  // Local Conductor creation wears the same mark as the cloud provider: both
+  // are Conductor making a workspace, told apart only by where it lands.
+  [CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID]: ConductorMark,
   [PROVIDER_ID.COPILOT]: CopilotMark,
   [PROVIDER_ID.CURSOR]: CursorMark,
   // Cursor the app draws Cursor's own mark: the id differs from the agent's

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -20,6 +20,7 @@ import {
   type RealtimeVoiceSpeed,
 } from "@sidecar/realtime";
 import {
+  CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
   isProviderId,
   PROVIDER_ID,
   type ProviderId,
@@ -1327,6 +1328,9 @@ function CredentialsSection({
   const supersetWorkspace = workspaceProviders.find(
     (option) => option.id === SUPERSET_WORKSPACE_PROVIDER_ID,
   );
+  const conductorLocalWorkspace = workspaceProviders.find(
+    (option) => option.id === CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
+  );
   return (
     <section className="settings-section" style={cssCustomProperties({ "--row-index": 2 })}>
       <h2>
@@ -1352,32 +1356,44 @@ function CredentialsSection({
             : undefined;
         const workspaceProvider = workspaceProviders.find((option) => option.id === provider.id);
         return (
-          <ProviderCredential
-            key={provider.id}
-            provider={provider}
-            source={settings.credentialSources[provider.id]}
-            storageUnavailable={storageUnavailable}
-            control={control}
-            panelOpen={panelOpen}
-          >
-            {agentRow ? (
-              <WorkspaceAgentRow
-                provider={provider}
-                providerId={agentRow}
-                {...(settings.workspaceAgentDefaults?.[agentRow]
-                  ? { selection: settings.workspaceAgentDefaults[agentRow] }
-                  : undefined)}
-                onChange={preferences.onWorkspaceAgentDefaultChange}
-              />
-            ) : null}
-            {workspaceProvider ? (
-              <WorkspaceProjectRow
-                provider={workspaceProvider}
+          <Fragment key={provider.id}>
+            <ProviderCredential
+              provider={provider}
+              source={settings.credentialSources[provider.id]}
+              storageUnavailable={storageUnavailable}
+              control={control}
+              panelOpen={panelOpen}
+            >
+              {agentRow ? (
+                <WorkspaceAgentRow
+                  provider={provider}
+                  providerId={agentRow}
+                  {...(settings.workspaceAgentDefaults?.[agentRow]
+                    ? { selection: settings.workspaceAgentDefaults[agentRow] }
+                    : undefined)}
+                  onChange={preferences.onWorkspaceAgentDefaultChange}
+                />
+              ) : null}
+              {workspaceProvider ? (
+                <WorkspaceProjectRow
+                  provider={workspaceProvider}
+                  settings={settings}
+                  preferences={preferences}
+                />
+              ) : null}
+            </ProviderCredential>
+            {/* Right below the cloud Conductor key row: the local app on this
+                Mac, recognized with no key. Its own block so the two Conductors
+                read as the different places they are — a repository here versus
+                a cloud project behind a key — rather than one name twice. */}
+            {provider.id === PROVIDER_ID.CONDUCTOR && conductorLocalWorkspace ? (
+              <ConductorLocalIntegration
+                workspaceProvider={conductorLocalWorkspace}
                 settings={settings}
                 preferences={preferences}
               />
             ) : null}
-          </ProviderCredential>
+          </Fragment>
         );
       })}
       {/* Last because the list reads alphabetically. Superset is the other
@@ -1870,6 +1886,44 @@ export interface SupersetControl {
   agents: readonly string[];
   defaultAgent?: string;
   onDefaultAgentChange: (agent: string | undefined) => Promise<string | undefined>;
+}
+
+/**
+ * Local Conductor: the app on this Mac, recognized read-only from its own
+ * index with no key and nothing to connect, so the block has no Connect and no
+ * disconnect — it stands only while repositories are actually detected, and its
+ * whole control is the default-project row every workspace creator draws. It
+ * is deliberately its own block beside the cloud Conductor key row, so the two
+ * Conductors are told apart by where they are rather than sharing one name.
+ */
+function ConductorLocalIntegration({
+  workspaceProvider,
+  settings,
+  preferences,
+}: {
+  /** Local Conductor's repositories, present only once a read reported any. */
+  workspaceProvider: WorkspaceProviderOption;
+  settings: AppSettings;
+  preferences: PreferenceWrites;
+}): React.JSX.Element {
+  return (
+    <div className="credential" {...searchAnchorProps(CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID)}>
+      <div className="credential-row">
+        <span className="credential-identity">
+          <span className="credential-mark">
+            <ProviderMark providerId={CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID} />
+          </span>
+          <span className="credential-name">{workspaceProvider.name}</span>
+          <CheckIcon />
+        </span>
+      </div>
+      <WorkspaceProjectRow
+        provider={workspaceProvider}
+        settings={settings}
+        preferences={preferences}
+      />
+    </div>
+  );
 }
 
 function SupersetIntegration({

--- a/apps/desktop/src/renderer/settings-search.tsx
+++ b/apps/desktop/src/renderer/settings-search.tsx
@@ -4,7 +4,11 @@ import {
   CREDENTIAL_PROVIDER_ID,
   VOICE_CREDENTIAL_PROVIDER,
 } from "@sidecar/credentials";
-import { PROVIDER_ID, workspaceAgentModels } from "@sidecar/session";
+import {
+  CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
+  PROVIDER_ID,
+  workspaceAgentModels,
+} from "@sidecar/session";
 import {
   APP_SETTING_ID,
   type AppSettingId,
@@ -120,6 +124,7 @@ export const SETTINGS_SEARCH_ROW = {
  */
 const DEFAULT_PROJECT_ROW_ID = {
   [PROVIDER_ID.CONDUCTOR]: "default-project-conductor",
+  [CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID]: "default-project-conductor-local",
   [PROVIDER_ID.CODEX]: "default-project-codex",
   [PROVIDER_ID.CURSOR]: "default-project-cursor",
   [SUPERSET_WORKSPACE_PROVIDER_ID]: "default-project-superset",
@@ -371,6 +376,20 @@ function fixedEntries(input: SettingsSearchInput): readonly SettingsSearchEntry[
           page: SETTINGS_VIEW.CONNECTIONS,
           icon: <PlugIcon />,
           haystack: ["Superset", "workspaces sign in connect integration"],
+        }
+      : undefined,
+    // Drawn only while local Conductor is actually detected — the block stands
+    // on the same repositories its row offers, so it is searchable exactly when
+    // it is on screen.
+    input.workspaceProjects.some(
+      (provider) => provider.id === CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
+    )
+      ? {
+          id: CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
+          label: "Conductor (local)",
+          page: SETTINGS_VIEW.CONNECTIONS,
+          icon: <ProviderMark providerId={CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID} />,
+          haystack: ["Conductor local", "workspaces create this Mac no key integration"],
         }
       : undefined,
     input.settings.appleCalendarAvailable

--- a/packages/providers/src/conductor/local-workspace-adapter.test.ts
+++ b/packages/providers/src/conductor/local-workspace-adapter.test.ts
@@ -224,6 +224,41 @@ test("creating a workspace fires Conductor's create link for the offered reposit
   );
 });
 
+test("a failed refresh empties the offer rather than keeping a stale one", async (t) => {
+  const databasePath = await temporaryDatabasePath(t);
+  // The file must exist for the read-only open to be attempted; the mock below
+  // stands in for its contents, succeeding once and then failing.
+  createReposDatabase(databasePath).close();
+  let calls = 0;
+  const sqlite = async () => ({
+    DatabaseSync: class {
+      enableDefensive(): void {}
+      close(): void {}
+      prepare() {
+        return {
+          all: () => {
+            calls += 1;
+            if (calls > 1) throw new Error("disk I/O error");
+            return [
+              { id: "repo-luke", name: "luke", remote_url: null, root_path: "/Users/dev/luke" },
+            ];
+          },
+        };
+      }
+    },
+  });
+  const adapter = new ConductorLocalWorkspaceAdapter({
+    reader: new ConductorRepositoryReader({ databasePath, sqlite }),
+    openExternal: async () => {},
+  });
+  await adapter.refresh();
+  assert.equal(adapter.workspaceProjects().length, 1);
+  // A non-ignorable read failure surfaces, and must leave nothing behind to
+  // validate a later create against.
+  await assert.rejects(() => adapter.refresh());
+  assert.deepEqual(adapter.workspaceProjects(), []);
+});
+
 test("creating a workspace with no task lands clean, with no send warning", async (t) => {
   const databasePath = await temporaryDatabasePath(t);
   const database = createReposDatabase(databasePath);

--- a/packages/providers/src/conductor/local-workspace-adapter.test.ts
+++ b/packages/providers/src/conductor/local-workspace-adapter.test.ts
@@ -216,6 +216,29 @@ test("creating a workspace fires Conductor's create link for the offered reposit
   const parsed = parseConductorCreateLink(opened[0] ?? "");
   assert.equal(parsed.path, "/Users/dev/repos/luke");
   assert.equal(parsed.prompt, "Start on the parser");
+  // Conductor pre-fills the prompt but does not send it, so a create carrying a
+  // task warns rather than reading as an agent already at work.
+  assert.match(
+    "warning" in result ? (result.warning ?? "") : "",
+    /ready in its composer.*press Return|press Return.*send/i,
+  );
+});
+
+test("creating a workspace with no task lands clean, with no send warning", async (t) => {
+  const databasePath = await temporaryDatabasePath(t);
+  const database = createReposDatabase(databasePath);
+  writeRepo(database, { id: "repo-luke", name: "luke", rootPath: "/Users/dev/repos/luke" });
+  database.close();
+
+  const adapter = new ConductorLocalWorkspaceAdapter({
+    reader: new ConductorRepositoryReader({ databasePath }),
+    openExternal: async () => {},
+  });
+  await adapter.refresh();
+  const result = await adapter.createWorkspace({ providerProjectId: "repo-luke" });
+  assert.equal(result.status, PROVIDER_ACT_RESULT_STATUS.ACCEPTED);
+  // Nothing was pre-filled, so there is nothing to press Return on.
+  assert.ok(!("warning" in result && result.warning));
 });
 
 test("creating a workspace uses the offered root path, never the request's", async (t) => {

--- a/packages/providers/src/conductor/local-workspace-adapter.test.ts
+++ b/packages/providers/src/conductor/local-workspace-adapter.test.ts
@@ -1,0 +1,297 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import test, { type TestContext } from "node:test";
+import { PROVIDER_ACT_RESULT_STATUS, WORKSPACE_TASK_SUPPORT } from "@sidecar/session";
+import {
+  ConductorLocalWorkspaceAdapter,
+  ConductorRepositoryReader,
+} from "./local-workspace-adapter.js";
+import { conductorCreateWorkspaceLink } from "./session-applications.js";
+
+/**
+ * Conductor's own deep-link parser, faithful to the branch a create link
+ * reaches: an unknown host falls through to a raw split on `&`, each token cut
+ * at its first `=`, each value percent-decoded. The test owns this so the link
+ * builder is pinned to the exact shape Conductor reads, not merely to a shape
+ * that looks right.
+ */
+function parseConductorCreateLink(url: string) {
+  const parsed = new URL(url);
+  const raw = url.replace(/^[A-Za-z][A-Za-z0-9+.-]*:\/\//, "");
+  const fields: Record<string, string> = {};
+  for (const token of raw.split("&")) {
+    const equals = token.indexOf("=");
+    if (equals > 0) fields[token.slice(0, equals)] = decodeURIComponent(token.slice(equals + 1));
+  }
+  return { host: parsed.hostname, path: fields.path, prompt: fields.prompt };
+}
+
+async function temporaryDatabasePath(t: TestContext): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-conductor-repos-"));
+  t.after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  return path.join(directory, "conductor.db");
+}
+
+function createReposDatabase(databasePath: string): DatabaseSync {
+  const database = new DatabaseSync(databasePath, {});
+  database.exec(`
+    CREATE TABLE repos (
+      id TEXT PRIMARY KEY,
+      name TEXT,
+      remote_url TEXT,
+      root_path TEXT,
+      hidden INTEGER DEFAULT 0
+    );
+  `);
+  return database;
+}
+
+function createReposDatabaseWithoutHidden(databasePath: string): DatabaseSync {
+  const database = new DatabaseSync(databasePath, {});
+  database.exec(`
+    CREATE TABLE repos (
+      id TEXT PRIMARY KEY,
+      name TEXT,
+      remote_url TEXT,
+      root_path TEXT
+    );
+  `);
+  return database;
+}
+
+function writeRepo(
+  database: DatabaseSync,
+  repo: {
+    id: string;
+    name?: string;
+    remoteUrl?: string;
+    rootPath?: string | null;
+    hidden?: number;
+  },
+): void {
+  database
+    .prepare("INSERT INTO repos (id, name, remote_url, root_path, hidden) VALUES (?, ?, ?, ?, ?)")
+    .all(
+      repo.id,
+      repo.name ?? null,
+      repo.remoteUrl ?? null,
+      repo.rootPath === undefined ? null : repo.rootPath,
+      repo.hidden ?? 0,
+    );
+}
+
+/** The pre-hidden schema keeps its own insert: this test's whole point is the flag's absence. */
+function writeRepoWithoutHidden(
+  database: DatabaseSync,
+  repo: { id: string; name?: string; rootPath: string },
+): void {
+  database
+    .prepare("INSERT INTO repos (id, name, root_path) VALUES (?, ?, ?)")
+    .all(repo.id, repo.name ?? null, repo.rootPath);
+}
+
+test("the create link is the exact shape Conductor's parser reads back", () => {
+  const rootPath = "/Users/dev/conductor/repos/luke";
+  const prompt = "Add a toggle & fix the a=b bug";
+  const parsed = parseConductorCreateLink(conductorCreateWorkspaceLink(rootPath, prompt));
+  // A host or a `?` would fold into the first key and drop the path; the parse
+  // recovering both values exactly is the guard against that regression.
+  assert.notEqual(parsed.host, "workspace");
+  assert.notEqual(parsed.host, "session");
+  assert.equal(parsed.path, rootPath);
+  assert.equal(parsed.prompt, prompt);
+});
+
+test("the create link omits the prompt when there is no opening task", () => {
+  const link = conductorCreateWorkspaceLink("/Users/dev/repo");
+  assert.ok(!link.includes("prompt="));
+  const parsed = parseConductorCreateLink(link);
+  assert.equal(parsed.path, "/Users/dev/repo");
+  assert.equal(parsed.prompt, undefined);
+});
+
+test("the repository reader reports open repositories with a root path", async (t) => {
+  const databasePath = await temporaryDatabasePath(t);
+  const database = createReposDatabase(databasePath);
+  writeRepo(database, {
+    id: "repo-luke",
+    name: "luke",
+    remoteUrl: "https://github.com/ReviewStage/luke.git",
+    rootPath: "/Users/dev/repos/luke",
+  });
+  writeRepo(database, {
+    id: "repo-hidden",
+    name: "hidden",
+    rootPath: "/Users/dev/hidden",
+    hidden: 1,
+  });
+  writeRepo(database, { id: "repo-no-path", name: "no-path", rootPath: null });
+  writeRepo(database, { id: "repo-empty-path", name: "empty", rootPath: "" });
+  database.close();
+
+  const reader = new ConductorRepositoryReader({ databasePath });
+  const repositories = await reader.read();
+  assert.deepEqual(
+    repositories.map((repository) => repository.id),
+    ["repo-luke"],
+  );
+  assert.equal(repositories[0]?.rootPath, "/Users/dev/repos/luke");
+  // The label comes from the remote's last segment, git suffix stripped.
+  assert.equal(repositories[0]?.repositoryLabel, "luke");
+});
+
+test("the repository reader falls back for a schema without the hidden flag", async (t) => {
+  const databasePath = await temporaryDatabasePath(t);
+  const database = createReposDatabaseWithoutHidden(databasePath);
+  writeRepoWithoutHidden(database, { id: "repo-a", name: "a", rootPath: "/Users/dev/a" });
+  database.close();
+
+  const reader = new ConductorRepositoryReader({ databasePath });
+  const repositories = await reader.read();
+  assert.deepEqual(
+    repositories.map((repository) => repository.id),
+    ["repo-a"],
+  );
+});
+
+test("an absent Conductor database reports no repositories", async (t) => {
+  const databasePath = await temporaryDatabasePath(t);
+  const reader = new ConductorRepositoryReader({ databasePath });
+  assert.deepEqual(await reader.read(), []);
+});
+
+test("refresh offers each repository as an optional-task project", async (t) => {
+  const databasePath = await temporaryDatabasePath(t);
+  const database = createReposDatabase(databasePath);
+  writeRepo(database, {
+    id: "repo-luke",
+    name: "luke",
+    remoteUrl: "https://github.com/ReviewStage/luke.git",
+    rootPath: "/Users/dev/repos/luke",
+  });
+  database.close();
+
+  const adapter = new ConductorLocalWorkspaceAdapter({
+    reader: new ConductorRepositoryReader({ databasePath }),
+    openExternal: async () => {},
+  });
+  assert.deepEqual(adapter.workspaceProjects(), []);
+  await adapter.refresh();
+  assert.deepEqual(adapter.workspaceProjects(), [
+    {
+      providerProjectId: "repo-luke",
+      repository: "luke",
+      taskSupport: WORKSPACE_TASK_SUPPORT.OPTIONAL,
+      providerTargetId: "/Users/dev/repos/luke",
+    },
+  ]);
+});
+
+test("creating a workspace fires Conductor's create link for the offered repository", async (t) => {
+  const databasePath = await temporaryDatabasePath(t);
+  const database = createReposDatabase(databasePath);
+  writeRepo(database, { id: "repo-luke", name: "luke", rootPath: "/Users/dev/repos/luke" });
+  database.close();
+
+  const opened: string[] = [];
+  const adapter = new ConductorLocalWorkspaceAdapter({
+    reader: new ConductorRepositoryReader({ databasePath }),
+    openExternal: async (url) => {
+      opened.push(url);
+    },
+  });
+  await adapter.refresh();
+  const result = await adapter.createWorkspace({
+    providerProjectId: "repo-luke",
+    providerTargetId: "/Users/dev/repos/luke",
+    task: "Start on the parser",
+  });
+  assert.equal(result.status, PROVIDER_ACT_RESULT_STATUS.ACCEPTED);
+  assert.equal(opened.length, 1);
+  const parsed = parseConductorCreateLink(opened[0] ?? "");
+  assert.equal(parsed.path, "/Users/dev/repos/luke");
+  assert.equal(parsed.prompt, "Start on the parser");
+});
+
+test("creating a workspace uses the offered root path, never the request's", async (t) => {
+  const databasePath = await temporaryDatabasePath(t);
+  const database = createReposDatabase(databasePath);
+  writeRepo(database, { id: "repo-luke", name: "luke", rootPath: "/Users/dev/repos/luke" });
+  database.close();
+
+  const opened: string[] = [];
+  const adapter = new ConductorLocalWorkspaceAdapter({
+    reader: new ConductorRepositoryReader({ databasePath }),
+    openExternal: async (url) => {
+      opened.push(url);
+    },
+  });
+  await adapter.refresh();
+  // A request naming a different target than the one offered is not the project
+  // this pass reported, so it is refused rather than fired at a path of its own.
+  const result = await adapter.createWorkspace({
+    providerProjectId: "repo-luke",
+    providerTargetId: "/etc/passwd",
+    task: "anything",
+  });
+  assert.equal(result.status, PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED);
+  assert.equal(opened.length, 0);
+});
+
+test("creating a workspace in an unoffered project is unsupported", async (t) => {
+  const databasePath = await temporaryDatabasePath(t);
+  const database = createReposDatabase(databasePath);
+  writeRepo(database, { id: "repo-luke", name: "luke", rootPath: "/Users/dev/repos/luke" });
+  database.close();
+
+  const opened: string[] = [];
+  const adapter = new ConductorLocalWorkspaceAdapter({
+    reader: new ConductorRepositoryReader({ databasePath }),
+    openExternal: async (url) => {
+      opened.push(url);
+    },
+  });
+  await adapter.refresh();
+  const result = await adapter.createWorkspace({ providerProjectId: "repo-unknown" });
+  assert.equal(result.status, PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED);
+  assert.equal(opened.length, 0);
+});
+
+test("a failed open is reported as a rejection the user can act on", async (t) => {
+  const databasePath = await temporaryDatabasePath(t);
+  const database = createReposDatabase(databasePath);
+  writeRepo(database, { id: "repo-luke", name: "luke", rootPath: "/Users/dev/repos/luke" });
+  database.close();
+
+  const adapter = new ConductorLocalWorkspaceAdapter({
+    reader: new ConductorRepositoryReader({ databasePath }),
+    openExternal: async () => {
+      throw new Error("no handler for conductor://");
+    },
+  });
+  await adapter.refresh();
+  const result = await adapter.createWorkspace({ providerProjectId: "repo-luke" });
+  assert.equal(result.status, PROVIDER_ACT_RESULT_STATUS.REJECTED);
+  assert.match(
+    "reason" in result ? result.reason : "",
+    /Couldn't ask Conductor to create the workspace/,
+  );
+});
+
+test("the local creator observes no sessions of its own", async () => {
+  const adapter = new ConductorLocalWorkspaceAdapter({ openExternal: async () => {} });
+  assert.deepEqual(await adapter.observe(), []);
+});
+
+test("the local creator is named apart from cloud Conductor", () => {
+  const adapter = new ConductorLocalWorkspaceAdapter({ openExternal: async () => {} });
+  // The name is what tells the two Conductors apart in the picker and out loud;
+  // the id keeps them routed apart, and the two must not both read "Conductor".
+  assert.equal(adapter.provider.displayName, "Conductor (local)");
+  assert.notEqual(adapter.provider.id, "conductor");
+});

--- a/packages/providers/src/conductor/local-workspace-adapter.ts
+++ b/packages/providers/src/conductor/local-workspace-adapter.ts
@@ -161,12 +161,15 @@ export interface ConductorLocalWorkspaceAdapterOptions {
  * repositories the latest read of Conductor's index reported — and, only for
  * one of exactly those, to fire the create link the developer just asked for.
  *
- * The developer's opening task rides the link as Conductor's `prompt`; the
- * link carries no agent, model, or name, because Conductor's creation link
- * documents none, so a new local workspace runs the repository's own default
- * agent and wears the name Conductor gives it. The workspace it lands in is
- * always the offered project's own root path, read back here rather than taken
- * from the request, so a create can only ever reach a repository this pass saw.
+ * The developer's opening task rides the link as Conductor's `prompt`, which
+ * Conductor pre-fills in the new workspace's composer but does not send — its
+ * link documents no way to, so a create carrying a task reports that the prompt
+ * waits there for the developer's own send. The link carries no agent, model,
+ * or name, because Conductor's creation link documents none, so a new local
+ * workspace runs the repository's own default agent and wears the name
+ * Conductor gives it. The workspace it lands in is always the offered project's
+ * own root path, read back here rather than taken from the request, so a create
+ * can only ever reach a repository this pass saw.
  */
 export class ConductorLocalWorkspaceAdapter extends SessionProviderAdapterBase {
   readonly provider = {
@@ -240,6 +243,18 @@ export class ConductorLocalWorkspaceAdapter extends SessionProviderAdapterBase {
     // own window, and hands back no session id, so none is reported and the
     // created-workspace open tracker stays out of it: the workspace opens
     // where it was made.
-    return { status: PROVIDER_ACT_RESULT_STATUS.ACCEPTED };
+    //
+    // Conductor's creation link pre-fills the opening task in the new
+    // workspace's composer but does not send it — its link documents no way to,
+    // and a local chat has no message endpoint to send it after — so a create
+    // carrying a task says so, rather than letting the agent look started when
+    // the prompt is only waiting for the developer's own send.
+    return request.task
+      ? {
+          status: PROVIDER_ACT_RESULT_STATUS.ACCEPTED,
+          warning:
+            "Conductor opened the new workspace with your prompt ready in its composer — press Return there to send it, since Conductor's create link can't send it for you.",
+        }
+      : { status: PROVIDER_ACT_RESULT_STATUS.ACCEPTED };
   }
 }

--- a/packages/providers/src/conductor/local-workspace-adapter.ts
+++ b/packages/providers/src/conductor/local-workspace-adapter.ts
@@ -1,0 +1,245 @@
+import {
+  CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
+  PROVIDER_ACT_RESULT_STATUS,
+  type ProviderSessionObservation,
+  type ProviderWorkspaceRequest,
+  type ProviderWorkspaceResult,
+  SessionProviderAdapterBase,
+  WORKSPACE_TASK_SUPPORT,
+  type WorkspaceProject,
+} from "@sidecar/session";
+import { text, wireRecord } from "@sidecar/wire";
+import { repositoryLabel } from "../shared/cloud-session-adapter.js";
+import {
+  canIgnoreSqliteError,
+  defaultSqliteModule,
+  openReadOnlyDatabase,
+  type SqliteDatabase,
+  type SqliteModuleLoader,
+} from "../shared/local-sqlite.js";
+import {
+  conductorCreateWorkspaceLink,
+  defaultConductorDatabasePath,
+} from "./session-applications.js";
+
+/**
+ * The name a person reads for the local creator, set apart from the cloud
+ * adapter's plain "Conductor" on purpose: the two are one brand but different
+ * places — a repository on this Mac versus a cloud project behind a key — and
+ * a create offer that named both "Conductor" could not be told apart in the
+ * picker or asked for by name out loud. The mark stays Conductor's; only the
+ * word carries the locality.
+ */
+export const CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_NAME = "Conductor (local)";
+
+/** How the reader names the columns it reads, so a rename here is one edit. */
+const CONDUCTOR_REPO_FIELD = {
+  ID: "id",
+  NAME: "name",
+  REMOTE_URL: "remote_url",
+  ROOT_PATH: "root_path",
+} as const;
+
+/**
+ * The repositories Conductor holds, read from its own index. `root_path` is
+ * the repository's main worktree — the exact path Conductor's creation link
+ * matches a project by — so a row without one names no place a workspace can
+ * be created and is dropped. `hidden` is Conductor's own mark for a repository
+ * the user filed out of its sidebar, so a hidden repository is left off the
+ * offer the way an archived workspace is; a schema too old to carry the flag
+ * offers every repository, which is what that schema itself showed.
+ */
+const CONDUCTOR_REPOSITORY_QUERY = `
+  SELECT
+    repos.id AS ${CONDUCTOR_REPO_FIELD.ID},
+    repos.name AS ${CONDUCTOR_REPO_FIELD.NAME},
+    repos.remote_url AS ${CONDUCTOR_REPO_FIELD.REMOTE_URL},
+    repos.root_path AS ${CONDUCTOR_REPO_FIELD.ROOT_PATH}
+  FROM repos
+  WHERE repos.hidden = 0
+    AND repos.root_path IS NOT NULL
+    AND repos.root_path != ''
+`;
+
+const CONDUCTOR_REPOSITORY_QUERY_WITHOUT_HIDDEN = `
+  SELECT
+    repos.id AS ${CONDUCTOR_REPO_FIELD.ID},
+    repos.name AS ${CONDUCTOR_REPO_FIELD.NAME},
+    repos.remote_url AS ${CONDUCTOR_REPO_FIELD.REMOTE_URL},
+    repos.root_path AS ${CONDUCTOR_REPO_FIELD.ROOT_PATH}
+  FROM repos
+  WHERE repos.root_path IS NOT NULL
+    AND repos.root_path != ''
+`;
+
+/** How many repositories the offer holds, so an index of hundreds is bounded. */
+const CONDUCTOR_MAXIMUM_REPOSITORIES = 50;
+
+/** One repository Conductor holds: where a new workspace lands, and what it is called. */
+interface ConductorRepository {
+  id: string;
+  rootPath: string;
+  repositoryLabel: string;
+}
+
+export interface ConductorRepositoryReaderOptions {
+  databasePath?: string;
+  sqlite?: SqliteModuleLoader;
+}
+
+/**
+ * Reads the repositories Conductor holds from its own index, read-only and
+ * without opening any transcript, the same way the session reader does. An
+ * absent app, an older schema, or a failed read means no repositories — an
+ * empty offer, never a failed pass — because a place to create a workspace
+ * that cannot be read is a place nothing may be created.
+ */
+export class ConductorRepositoryReader {
+  readonly #databasePath: string;
+  readonly #sqlite: SqliteModuleLoader;
+
+  constructor(options: ConductorRepositoryReaderOptions = {}) {
+    this.#databasePath = options.databasePath ?? defaultConductorDatabasePath();
+    this.#sqlite = options.sqlite ?? defaultSqliteModule;
+  }
+
+  async read(): Promise<readonly ConductorRepository[]> {
+    const database = await openReadOnlyDatabase(this.#sqlite, this.#databasePath);
+    if (!database) return [];
+    try {
+      return this.#queryRows(database)
+        .flatMap((row) => {
+          const record = wireRecord(row);
+          if (!record) return [];
+          const id = text(record[CONDUCTOR_REPO_FIELD.ID]);
+          const rootPath = text(record[CONDUCTOR_REPO_FIELD.ROOT_PATH]);
+          if (!id || !rootPath) return [];
+          return [
+            {
+              id,
+              rootPath,
+              repositoryLabel: repositoryLabel(
+                text(record[CONDUCTOR_REPO_FIELD.REMOTE_URL]),
+                text(record[CONDUCTOR_REPO_FIELD.NAME]),
+              ),
+            },
+          ];
+        })
+        .slice(0, CONDUCTOR_MAXIMUM_REPOSITORIES);
+    } catch (error) {
+      if (error instanceof Error && canIgnoreSqliteError(error)) return [];
+      throw error;
+    } finally {
+      database.close();
+    }
+  }
+
+  /** The fuller read first, then the schema that predates the hidden flag. */
+  #queryRows(database: SqliteDatabase) {
+    try {
+      return database.prepare(CONDUCTOR_REPOSITORY_QUERY).all();
+    } catch (error) {
+      if (!(error instanceof Error && canIgnoreSqliteError(error))) throw error;
+      return database.prepare(CONDUCTOR_REPOSITORY_QUERY_WITHOUT_HIDDEN).all();
+    }
+  }
+}
+
+export interface ConductorLocalWorkspaceAdapterOptions {
+  reader?: ConductorRepositoryReader;
+  /** Hands one address to the operating system, the sole write this makes. */
+  openExternal: (url: string) => Promise<void>;
+}
+
+/**
+ * Creates a Conductor workspace on this machine by handing Conductor's own
+ * creation deep link to the operating system — the local counterpart of the
+ * cloud adapter's `POST /v0/workspaces`, and the same bounded exception. It
+ * observes no sessions of its own: the local Conductor chats are already
+ * reported by the agents that run them and grouped by the session-application
+ * reader. Its whole job is to say where a workspace can be created — the
+ * repositories the latest read of Conductor's index reported — and, only for
+ * one of exactly those, to fire the create link the developer just asked for.
+ *
+ * The developer's opening task rides the link as Conductor's `prompt`; the
+ * link carries no agent, model, or name, because Conductor's creation link
+ * documents none, so a new local workspace runs the repository's own default
+ * agent and wears the name Conductor gives it. The workspace it lands in is
+ * always the offered project's own root path, read back here rather than taken
+ * from the request, so a create can only ever reach a repository this pass saw.
+ */
+export class ConductorLocalWorkspaceAdapter extends SessionProviderAdapterBase {
+  readonly provider = {
+    id: CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
+    displayName: CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_NAME,
+  };
+  readonly #reader: ConductorRepositoryReader;
+  readonly #openExternal: (url: string) => Promise<void>;
+  #projects: readonly WorkspaceProject[] = [];
+
+  constructor(options: ConductorLocalWorkspaceAdapterOptions) {
+    super();
+    this.#reader = options.reader ?? new ConductorRepositoryReader();
+    this.#openExternal = options.openExternal;
+  }
+
+  /** Creates no rows: local Conductor chats are observed by their own agents. */
+  async observe(): Promise<readonly ProviderSessionObservation[]> {
+    return [];
+  }
+
+  /**
+   * Re-reads the repositories Conductor holds and turns each into a project a
+   * workspace can be created in. A read that fails or finds nothing empties
+   * the offer, so a create is never validated against repositories a later
+   * read could no longer see.
+   */
+  async refresh(): Promise<void> {
+    this.#projects = (await this.#reader.read()).map((repository) => ({
+      providerProjectId: repository.id,
+      repository: repository.repositoryLabel,
+      // Conductor makes an idle workspace happily and takes the opening task
+      // as its first prompt, so a task is welcome but never required.
+      taskSupport: WORKSPACE_TASK_SUPPORT.OPTIONAL,
+      // The repository's own main-worktree path, which the creation link
+      // matches a project by and which a create reads back rather than trusts
+      // from the request.
+      providerTargetId: repository.rootPath,
+    }));
+  }
+
+  override workspaceProjects(): readonly WorkspaceProject[] {
+    return this.#projects;
+  }
+
+  override async createWorkspace(
+    request: ProviderWorkspaceRequest,
+  ): Promise<ProviderWorkspaceResult> {
+    const project = this.#projects.find(
+      (candidate) =>
+        candidate.providerProjectId === request.providerProjectId &&
+        (request.providerTargetId === undefined ||
+          candidate.providerTargetId === request.providerTargetId),
+    );
+    // The root path a create fires against is the offered project's own, never
+    // the request's: a create can reach only a repository this pass reported.
+    const rootPath = project?.providerTargetId;
+    if (!rootPath) return { status: PROVIDER_ACT_RESULT_STATUS.UNSUPPORTED };
+    const link = conductorCreateWorkspaceLink(rootPath, request.task);
+    try {
+      await this.#openExternal(link);
+    } catch (error) {
+      return {
+        status: PROVIDER_ACT_RESULT_STATUS.REJECTED,
+        reason: `Couldn't ask Conductor to create the workspace: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      };
+    }
+    // Conductor's link both creates the workspace and opens it in Conductor's
+    // own window, and hands back no session id, so none is reported and the
+    // created-workspace open tracker stays out of it: the workspace opens
+    // where it was made.
+    return { status: PROVIDER_ACT_RESULT_STATUS.ACCEPTED };
+  }
+}

--- a/packages/providers/src/conductor/local-workspace-adapter.ts
+++ b/packages/providers/src/conductor/local-workspace-adapter.ts
@@ -198,7 +198,18 @@ export class ConductorLocalWorkspaceAdapter extends SessionProviderAdapterBase {
    * read could no longer see.
    */
   async refresh(): Promise<void> {
-    this.#projects = (await this.#reader.read()).map((repository) => ({
+    let repositories: readonly ConductorRepository[];
+    try {
+      repositories = await this.#reader.read();
+    } catch (error) {
+      // A read that fails empties the offer before the throw surfaces, so a
+      // create is never validated against repositories a later pass could no
+      // longer see — where Conductor's unmatched-path fallback would otherwise
+      // land a workspace in the wrong repository. The caller still logs it.
+      this.#projects = [];
+      throw error;
+    }
+    this.#projects = repositories.map((repository) => ({
       providerProjectId: repository.id,
       repository: repository.repositoryLabel,
       // Conductor makes an idle workspace happily and takes the opening task

--- a/packages/providers/src/conductor/session-applications.ts
+++ b/packages/providers/src/conductor/session-applications.ts
@@ -87,6 +87,32 @@ export function conductorWorkspaceLink(workspaceId: string, conductorChatId?: st
 }
 
 /**
+ * The address that asks Conductor's own app to create a new workspace in the
+ * repository whose main worktree is `rootPath`, seeded with the developer's
+ * opening prompt when they gave one. It is Conductor's own documented creation
+ * link — the same shape its Linear "open in Conductor" button fires, minus the
+ * issue id — so a create stays what an open is: an address handed to the
+ * operating system, which Conductor's own scheme handler acts on.
+ *
+ * The format is exact and not a `URL`'s to give: Conductor's handler reaches
+ * this branch only for a link whose host is none it knows, then re-parses the
+ * raw string by splitting on `&` and reading each `key=value`. So the encoded
+ * `path` and `prompt` are the whole authority — no host, no `?` — because a
+ * host or a query marker would fold into the first key and drop the path,
+ * which silently retargets the create at Conductor's first repository. Both
+ * values are fully percent-encoded, so a path or prompt carrying `&` or `=`
+ * cannot split the document, and Conductor matches `path` against a
+ * repository's own main-worktree path exactly.
+ */
+export function conductorCreateWorkspaceLink(rootPath: string, prompt?: string): string {
+  const query = [
+    `path=${encodeURIComponent(rootPath)}`,
+    ...(prompt ? [`prompt=${encodeURIComponent(prompt)}`] : []),
+  ].join("&");
+  return `conductor://${query}`;
+}
+
+/**
  * The one workspace state that means the user filed the whole workspace away
  * on Conductor's own surface. Its other states — active, ready, sleeping —
  * are all still-open workspaces.
@@ -186,7 +212,7 @@ export interface ConductorSessionApplicationReaderOptions {
   sqlite?: SqliteModuleLoader;
 }
 
-function defaultConductorDatabasePath(): string {
+export function defaultConductorDatabasePath(): string {
   return path.join(
     os.homedir(),
     "Library",

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -4,6 +4,10 @@ export {
 } from "./cmux/session-applications.js";
 export { CodexCloudSessionAdapter } from "./codex/cloud-adapter.js";
 export {
+  ConductorLocalWorkspaceAdapter,
+  ConductorRepositoryReader,
+} from "./conductor/local-workspace-adapter.js";
+export {
   ConductorSessionApplicationReader,
   ConductorSessionApplicationSnapshot,
 } from "./conductor/session-applications.js";

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -2,6 +2,7 @@ export { CompositeSessionProviderAdapter } from "./composite-provider-adapter.js
 export {
   CLI_CONNECTION,
   type CliConnection,
+  CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
   isProviderId,
   maximumObservedWorkspaceProjects,
   maximumWorkspaceNameLength,

--- a/packages/session/src/providers.ts
+++ b/packages/session/src/providers.ts
@@ -21,6 +21,18 @@ export const PROVIDER_ID = {
 export type ProviderId = (typeof PROVIDER_ID)[keyof typeof PROVIDER_ID];
 
 /**
+ * The provider id the local Conductor workspace creator answers to. It names
+ * no observed session provider — `isProviderId` stays false for it — because a
+ * local Conductor chat is already observed by the agent that runs it. The id
+ * exists only so the repositories Conductor holds can offer their creation
+ * projects apart from the cloud Conductor adapter, which owns
+ * `PROVIDER_ID.CONDUCTOR`: a creation request resolves to exactly one adapter,
+ * so a local repository and a cloud project must route under ids of their own,
+ * even as both wear Conductor's name and mark.
+ */
+export const CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID = "conductor-local";
+
+/**
  * The order any list of providers reads in. It is the registry's own order
  * rather than one derived from live sessions, so a list of agents does not
  * reshuffle as their sessions come and go.

--- a/packages/settings/src/schema.ts
+++ b/packages/settings/src/schema.ts
@@ -19,6 +19,7 @@ import {
   type RealtimeVoiceSpeed,
 } from "@sidecar/realtime";
 import {
+  CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
   isProviderId,
   isSessionFilter,
   PROVIDER_ID,
@@ -231,6 +232,10 @@ function voiceSpeedWord(speed: RealtimeVoiceSpeed | undefined): string {
 
 function workspaceProviderName(providerId: WorkspaceProviderId): string {
   if (providerId === SUPERSET_WORKSPACE_PROVIDER_ID) return "Superset";
+  // Local Conductor names itself apart from the cloud provider's plain
+  // "Conductor"; the string mirrors the adapter's own display name, which lives
+  // a layer up and must not be imported down here.
+  if (providerId === CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID) return "Conductor (local)";
   if (isCredentialProviderId(providerId)) return CREDENTIAL_PROVIDERS[providerId].displayName;
   // The one workspace-capable provider with no credential row to take a
   // display name from.

--- a/packages/superset/src/vocabulary.ts
+++ b/packages/superset/src/vocabulary.ts
@@ -1,10 +1,27 @@
-import { isProviderId, type ProviderId, SESSION_APPLICATION_ID } from "@sidecar/session";
+import {
+  CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
+  isProviderId,
+  type ProviderId,
+  SESSION_APPLICATION_ID,
+} from "@sidecar/session";
 
 export const SUPERSET_WORKSPACE_PROVIDER_ID = SESSION_APPLICATION_ID.SUPERSET;
 
-/** Every provider that can offer a workspace through the desktop app. */
-export type WorkspaceProviderId = ProviderId | typeof SUPERSET_WORKSPACE_PROVIDER_ID;
+/**
+ * Every provider that can offer a workspace through the desktop app: the
+ * observed session providers, Superset's own workspace provider, and local
+ * Conductor's — the last two name no observed session provider, so they are
+ * added beside `ProviderId` rather than found within it.
+ */
+export type WorkspaceProviderId =
+  | ProviderId
+  | typeof SUPERSET_WORKSPACE_PROVIDER_ID
+  | typeof CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID;
 
 export function isWorkspaceProviderId(value: string): value is WorkspaceProviderId {
-  return isProviderId(value) || value === SUPERSET_WORKSPACE_PROVIDER_ID;
+  return (
+    isProviderId(value) ||
+    value === SUPERSET_WORKSPACE_PROVIDER_ID ||
+    value === CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID
+  );
 }


### PR DESCRIPTION
## What

Adds local Conductor workspace **creation** and makes local Conductor clearly distinct from cloud Conductor everywhere it surfaces.

Reverse-engineering Conductor's app binary showed its only local cross-process surface is the `conductor://` URL scheme, and the only writable local action it exposes is workspace creation (the `session` route is explicitly "unsupported"; there is no local message/archive/add-agent route). So of the local-chat actions we explored, creation is the one that is actually possible — the rest stay read-only by Conductor's own design.

## Changes

- **Local creation.** `ConductorRepositoryReader` reads the repositories Conductor holds from its read-only index; `ConductorLocalWorkspaceAdapter` offers each as a creatable project and, for one the latest read reported, hands Conductor its own creation deep link to the OS (`conductor://path=…&prompt=…`) — the local counterpart of the cloud adapter's `POST /v0/workspaces`. The landing path is read back from the offered project, never the request. It runs through the existing creation pipeline (both roster-validation gates apply unchanged).
- **Cloud vs local, told apart.** The local creator answers to its own id (`conductor-local`) so a request routes to it rather than the cloud adapter, and reads as **"Conductor (local)"** in the create picker, the conversation's project list, and a dedicated Connections block directly beneath the cloud Conductor row — keeping Conductor's own mark. The guide teaches Luke the difference.
- **Prompt is pre-filled, not sent.** Conductor's create link pre-fills the opening task in the new workspace's composer but never sends it (no auto-send in its link, and a local chat has no message endpoint to send after). A local create carrying a task now returns an accepted result with a warning that the prompt is ready and waits for the developer's own Return, and Luke voices "ready to send" rather than implying the agent started.

## Trust boundary

This adds a new local write primitive — firing a state-changing provider deep link — where before, handing a `conductor://` URL to the OS only ever *opened* something. The workspace-creation trust prose in `AGENTS.md` is updated to describe this local deep-link exception in the existing register. Worth a deliberate review.

## Testing

- `./scripts/check.sh` — green (lint, typecheck, tests, build).
- `./scripts/evidence.sh` — green; packaged the app and captured all six fixture PNGs. The new Connections block does not appear in fixture evidence because those frames show the sessions list and deterministic runs offer no projects by design.
- New unit tests cover the reader (schema ladder, hidden/no-path filtering), the deep-link format (pinned to Conductor's own parser), create routing, the offered-path guard, the distinguishing name, and the pre-fill warning. Verified the reader read-only against the live `conductor.db` (repos read correctly); did not fire a live create.
- Physical-notch check: **not performed** (fixture evidence only, no physical device).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32445882091/artifacts/9434070217) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32445882091)

- Commit: `aa02be029246564c30480a531bd6d41bfc8e7d2e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
