### PR TITLE
refactor(providers): table the hook registry and share hook status refinement

### DIFF
--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -233,9 +233,7 @@ const observationHooks = new ObservationHookRegistry(() => app.getPath("userData
 // from three parallel lists here.
 const providerRegistry = providerRegistrations({
   readApiKey: (providerId) => settingsStore.readApiKey(providerId),
-  claudeHookInstallation: () => observationHooks.claudeInstallation(),
-  codexHookInstallation: () => observationHooks.codexInstallation(),
-  cursorHookInstallation: () => observationHooks.cursorInstallation(),
+  observationHookInstallation: (providerId) => observationHooks.installation(providerId),
   codexCloudAdapter,
 });
 // The record enforces completeness; the shared list preserves provider order.

--- a/packages/providers/src/claude-code/adapter.ts
+++ b/packages/providers/src/claude-code/adapter.ts
@@ -23,13 +23,13 @@ import {
 import {
   discoverSessionFiles,
   type HookStatusRefinement,
+  hookRefinedStatus,
   LOCAL_ADAPTER_DEFAULTS,
   LocalFileSessionAdapter,
   localSessionStatus,
   readDirectory,
   readHead,
   readTail,
-  refineStatusWithHookEvent,
   type SessionFileCandidate,
   sessionIdFromFileName,
   statDirectoryEntry,
@@ -111,15 +111,6 @@ const CLAUDE_ADAPTER_DEFAULTS = {
    * is the only account left, and the mtime fallback stands.
    */
   CLOCK_RESCUE_TAIL_BYTES: 512 * 1024,
-  /**
-   * How much older than the transcript's clock a hook event may run and still
-   * describe the same moment. The hook fires as a turn boundary happens and
-   * the closing records land moments later under their own timestamps, so a
-   * boundary's event usually trails the record it belongs with by a breath —
-   * never by more than this. An event further behind describes a turn the
-   * transcript has already moved past, and refines nothing.
-   */
-  HOOK_EVENT_TOLERANCE_MS: 5_000,
 } as const;
 
 export const CLAUDE_CODE_PROVIDER: SessionProvider = {
@@ -427,15 +418,11 @@ function statusFromTail(
 }
 
 /**
- * Sharpens the tail's verdict with what the observation hook last said, in the
- * order the meanings bind. A failed or closed session is definite in either
- * direction: the hook saying so outranks the tail, and a tail that says so is
- * never talked out of it by a softer event. Past those, the events refine only
- * a fresh session — the decay to `UNKNOWN` exists because a hook can go
- * silent (a crash fires no `SessionEnd`), so an old "waiting" must age the
- * same way an old tail does. What the refinement actually buys is the states
- * the transcript cannot show: a tool call holding for permission writes no
- * records while it holds, and a turn's true end can sit past the tail's read.
+ * What the refinement actually buys here is the states the transcript cannot
+ * show: a tool call holding for permission writes no records while it holds,
+ * and a turn's true end can sit past the tail's read. A failed turn is
+ * definite alongside a closed session because the tail may hold nothing about
+ * either.
  */
 const CLAUDE_HOOK_STATUS_REFINEMENT = {
   definitive: [
@@ -447,15 +434,9 @@ const CLAUDE_HOOK_STATUS_REFINEMENT = {
     { event: CLAUDE_HOOK_EVENT.STOP, fresh: SESSION_STATUS.WAITING },
     { event: CLAUDE_HOOK_EVENT.NOTIFICATION, fresh: SESSION_STATUS.WAITING },
   ],
+  notificationEvent: CLAUDE_HOOK_EVENT.NOTIFICATION,
+  sessionEndEvent: CLAUDE_HOOK_EVENT.SESSION_END,
 } as const satisfies HookStatusRefinement<ClaudeHookEvent>;
-
-function statusWithHookEvent(
-  status: ProviderSessionObservation["status"],
-  event: ClaudeHookEvent,
-  isFresh: boolean,
-): ProviderSessionObservation["status"] {
-  return refineStatusWithHookEvent(status, event, isFresh, CLAUDE_HOOK_STATUS_REFINEMENT);
-}
 
 /**
  * Claude Code names its own sessions, and that name is what a developer is
@@ -501,29 +482,17 @@ function observationFromSessionFile(
   // read as active just now. The file's date remains the fallback for a
   // transcript in which no conversation clock could be found at all.
   const transcriptAt = parsed.timestampMs ?? candidate.mtimeMs;
-  // A hook event trailing the transcript's clock by more than the tolerance
-  // describes a turn the transcript already moved past, so it is ignored
-  // whole. One that stands is proof the session moved — only Luke's own
-  // script writes the spool, so its date cannot suffer the bulk-touch problem
-  // above — and dates the session for the freshness decay as well. A
-  // notification alone gets no tolerance: it means the session is holding for
-  // the user, and holding writes nothing, so a record at or past the event is
-  // itself the news that the hold ended — a granted permission must not read
-  // as waiting for even one more pass.
-  const toleranceMs =
-    hookEvent?.event === CLAUDE_HOOK_EVENT.NOTIFICATION
-      ? 0
-      : CLAUDE_ADAPTER_DEFAULTS.HOOK_EVENT_TOLERANCE_MS;
-  const eventStands = hookEvent !== undefined && hookEvent.atMs + toleranceMs >= transcriptAt;
-  const observedAt = eventStands ? Math.max(transcriptAt, hookEvent.atMs) : transcriptAt;
-  let status = statusFromTail(parsed, observedAt, now, activeSessionFreshnessMs);
-  if (eventStands) {
-    const isFresh = now - observedAt <= activeSessionFreshnessMs;
-    status = statusWithHookEvent(status, hookEvent.event, isFresh);
-  }
+  const refined = hookRefinedStatus({
+    refinement: CLAUDE_HOOK_STATUS_REFINEMENT,
+    hookEvent,
+    providerAtMs: transcriptAt,
+    statusAt: (observedAt) => statusFromTail(parsed, observedAt, now, activeSessionFreshnessMs),
+    now,
+    activeSessionFreshnessMs,
+  });
   const completionCause =
-    status === SESSION_STATUS.COMPLETE
-      ? eventStands && hookEvent.event === CLAUDE_HOOK_EVENT.SESSION_END
+    refined.status === SESSION_STATUS.COMPLETE
+      ? refined.sessionClosed
         ? SESSION_COMPLETION_CAUSE.SESSION_CLOSED
         : parsed.eventType === CLAUDE_EVENT_TYPE.RESULT
           ? SESSION_COMPLETION_CAUSE.WORK_FINISHED
@@ -532,16 +501,12 @@ function observationFromSessionFile(
   return {
     providerSessionId: candidate.providerSessionId,
     title: titleFromTail(parsed),
-    status,
+    status: refined.status,
     ...(completionCause ? { completionCause } : undefined),
-    observedAt,
+    observedAt: refined.observedAt,
     ...(parsed.awaySummary ? { recap: parsed.awaySummary } : undefined),
     detail: detailFromTail(parsed),
-    ...(status === SESSION_STATUS.WAITING &&
-    eventStands &&
-    hookEvent?.event === CLAUDE_HOOK_EVENT.NOTIFICATION
-      ? { holdingForDeveloper: true }
-      : undefined),
+    ...(refined.holdingForDeveloper ? { holdingForDeveloper: true } : undefined),
   };
 }
 

--- a/packages/providers/src/claude-code/hooks.test.ts
+++ b/packages/providers/src/claude-code/hooks.test.ts
@@ -7,11 +7,13 @@ import test, { type TestContext } from "node:test";
 import { promisify } from "node:util";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
 import {
+  type ObservationHookInstallation,
+  pruneObservationHookSpool,
+} from "../shared/hook-merge.js";
+import {
   CLAUDE_HOOK_EVENT,
   CLAUDE_HOOK_SCRIPT_NAME,
-  type ClaudeCodeHookInstallation,
   installClaudeCodeObservationHooks,
-  pruneClaudeHookSpool,
   readClaudeHookEvent,
   removeClaudeCodeObservationHooks,
 } from "./hooks.js";
@@ -34,25 +36,25 @@ const REGISTERED_EVENT_NAMES = [
   "SessionEnd",
 ] as const;
 
-async function temporaryInstallation(t: TestContext): Promise<ClaudeCodeHookInstallation> {
+async function temporaryInstallation(t: TestContext): Promise<ObservationHookInstallation> {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-claude-hooks-"));
   t.after(async () => {
     await fs.rm(directory, { recursive: true, force: true });
   });
-  const claudeHome = path.join(directory, "claude-home");
-  await fs.mkdir(claudeHome, { recursive: true });
+  const providerHome = path.join(directory, "claude-home");
+  await fs.mkdir(providerHome, { recursive: true });
   return {
-    claudeHome,
+    providerHome,
     hookScriptPath: path.join(directory, "luke-data", CLAUDE_HOOK_SCRIPT_NAME),
     spoolDirectory: path.join(directory, "luke-data", "events"),
   };
 }
 
-function settingsPath(installation: ClaudeCodeHookInstallation): string {
-  return path.join(installation.claudeHome, CLAUDE_SETTINGS_FILE_NAME);
+function settingsPath(installation: ObservationHookInstallation): string {
+  return path.join(installation.providerHome, CLAUDE_SETTINGS_FILE_NAME);
 }
 
-async function readSettings(installation: ClaudeCodeHookInstallation): Promise<ParsedJsonObject> {
+async function readSettings(installation: ObservationHookInstallation): Promise<ParsedJsonObject> {
   return JSON.parse(await fs.readFile(settingsPath(installation), "utf8"));
 }
 
@@ -83,7 +85,7 @@ function entryCommands(entries: unknown[]): string[] {
  * envelope rides in from a file beside the script through `sh -c`.
  */
 async function pipeToHookScript(
-  installation: ClaudeCodeHookInstallation,
+  installation: ObservationHookInstallation,
   eventArgument: string,
   envelope: string,
 ): Promise<void> {
@@ -151,13 +153,13 @@ test("creates the settings file for a Claude home that has none yet", async (t) 
 
 test("touches nothing on a machine with no Claude home at all", async (t) => {
   const installation = await temporaryInstallation(t);
-  await fs.rm(installation.claudeHome, { recursive: true, force: true });
+  await fs.rm(installation.providerHome, { recursive: true, force: true });
 
   await installClaudeCodeObservationHooks(installation);
 
   // No provider directory is created on the provider's behalf, and no script
   // or spool is staged for sessions that cannot exist.
-  await assert.rejects(fs.stat(installation.claudeHome));
+  await assert.rejects(fs.stat(installation.providerHome));
   await assert.rejects(fs.stat(installation.hookScriptPath));
   await assert.rejects(fs.stat(installation.spoolDirectory));
 });
@@ -384,12 +386,16 @@ test("pruning drops only the events past the observation window", async (t) => {
   await fs.utimes(freshPath, (TEST_TIME - 60_000) / 1000, (TEST_TIME - 60_000) / 1000);
   await fs.utimes(stalePath, (TEST_TIME - 2 * dayMs) / 1000, (TEST_TIME - 2 * dayMs) / 1000);
 
-  await pruneClaudeHookSpool(installation.spoolDirectory, dayMs, TEST_TIME);
+  await pruneObservationHookSpool(installation.spoolDirectory, dayMs, TEST_TIME);
 
   await fs.stat(freshPath);
   await assert.rejects(fs.stat(stalePath));
   // A spool that does not exist is nothing to prune rather than a failure.
-  await pruneClaudeHookSpool(path.join(installation.spoolDirectory, "absent"), dayMs, TEST_TIME);
+  await pruneObservationHookSpool(
+    path.join(installation.spoolDirectory, "absent"),
+    dayMs,
+    TEST_TIME,
+  );
 });
 
 test("removal leaves a file with no Luke entries byte-for-byte alone", async (t) => {
@@ -412,7 +418,7 @@ test("the settings write keeps the file's own mode and leaves no debris", async 
 
   // The rename replaced the file, and the user's own protection rode along.
   assert.equal((await fs.stat(settingsPath(installation))).mode & 0o777, 0o600);
-  const leftovers = (await fs.readdir(installation.claudeHome)).filter((name) =>
+  const leftovers = (await fs.readdir(installation.providerHome)).filter((name) =>
     name.includes(".luke-tmp"),
   );
   assert.deepEqual(leftovers, []);
@@ -421,7 +427,7 @@ test("the settings write keeps the file's own mode and leaves no debris", async 
 test("the settings write lands through a symlink rather than replacing it", async (t) => {
   const installation = await temporaryInstallation(t);
   // A dotfiles-managed home: settings.json is a link into a synced store.
-  const syncedPath = path.join(installation.claudeHome, "synced-settings.json");
+  const syncedPath = path.join(installation.providerHome, "synced-settings.json");
   await fs.writeFile(syncedPath, "{}\n");
   await fs.symlink(syncedPath, settingsPath(installation));
 

--- a/packages/providers/src/claude-code/hooks.ts
+++ b/packages/providers/src/claude-code/hooks.ts
@@ -2,7 +2,6 @@ import os from "node:os";
 import path from "node:path";
 import {
   HOOK_ENTRY_NESTING,
-  HOOK_SPOOL_MAXIMUM_AGE_MS,
   type ObservationHookSpec,
   type ObservedHookEvent,
   observationHooksFor,
@@ -10,7 +9,7 @@ import {
 
 /**
  * Claude Code's observation hooks, described for the shared machinery in
- * `observation-hooks.ts`: which file the registration merges into, which
+ * `hook-merge.ts`: which file the registration merges into, which
  * lifecycle moments are registered, and what the envelope Claude Code pipes
  * the script looks like. Everything the arrangement guarantees — the merge
  * beside the user's entries, the refusal to rewrite an unparseable file, the
@@ -31,8 +30,6 @@ export const CLAUDE_HOOK_SCRIPT_NAME = "luke-claude-observation-hook.sh";
 
 /** How long Claude Code lets the spool write run before giving up on it. */
 const CLAUDE_HOOK_TIMEOUT_SECONDS = 10;
-
-export const CLAUDE_HOOK_SPOOL_MAXIMUM_AGE_MS = HOOK_SPOOL_MAXIMUM_AGE_MS;
 
 /**
  * The tokens the script may write, fixed at registration: each hook entry
@@ -91,21 +88,8 @@ export function defaultClaudeHome(): string {
   return configuredHome || path.join(os.homedir(), ".claude");
 }
 
-export interface ClaudeCodeHookInstallation {
-  /** Claude Code's own home, holding the `settings.json` entries merge into. */
-  claudeHome: string;
-  /** Where Luke keeps the script, under Luke's own application data. */
-  hookScriptPath: string;
-  /** Where the script writes its event files, under Luke's own data too. */
-  spoolDirectory: string;
-}
-
-const claudeHooks = observationHooksFor(
-  CLAUDE_HOOK_SPEC,
-  (installation: ClaudeCodeHookInstallation) => installation.claudeHome,
-);
+const claudeHooks = observationHooksFor(CLAUDE_HOOK_SPEC);
 
 export const installClaudeCodeObservationHooks = claudeHooks.install;
 export const removeClaudeCodeObservationHooks = claudeHooks.remove;
 export const readClaudeHookEvent = claudeHooks.read;
-export const pruneClaudeHookSpool = claudeHooks.prune;

--- a/packages/providers/src/codex/adapter.ts
+++ b/packages/providers/src/codex/adapter.ts
@@ -25,10 +25,10 @@ import {
 } from "@sidecar/wire";
 import {
   type HookStatusRefinement,
+  hookRefinedStatus,
   LocalSessionAdapter,
   readTail,
   readTextFile,
-  refineStatusWithHookEvent,
   uniquePaths,
   workspaceLabel,
 } from "../shared/local-session-adapter.js";
@@ -187,15 +187,6 @@ const CODEX_ADAPTER_DEFAULTS = {
    */
   READ_SESSION_INDEX_TAIL_BYTES: 128 * 1024,
   MAXIMUM_ACTIVITY_LENGTH: 80,
-  /**
-   * How much older than the thread row's clock a hook event may run and still
-   * describe the same moment. The hook fires as a turn boundary happens and
-   * Codex touches the row moments later under its own clock, so a boundary's
-   * event usually trails the row it belongs with by a breath — never by more
-   * than this. An event further behind describes a turn the thread has
-   * already moved past, and refines nothing.
-   */
-  HOOK_EVENT_TOLERANCE_MS: 5_000,
 } as const;
 
 const CODEX_REALTIME_DELEGATION_MARKER = "<realtime_delegation>";
@@ -657,16 +648,9 @@ function statusFromRow(
 }
 
 /**
- * Sharpens the row's verdict with what the observation hook last said, in the
- * order the meanings bind. A closed or failed session is definite: the hook
- * saying closed outranks the row, and a row that says complete or error is
- * never talked out of it by a softer event. Past those, the events refine
- * only a fresh session — the decay to `UNKNOWN` exists because a hook can go
- * silent (a killed process
- * fires no `SessionEnd`), so an old "waiting" must age the same way an old
- * row does. What the refinement actually buys is the states the state
- * database cannot show: a tool call holding for approval writes no records
- * while it holds, and a turn's true end can sit past the rollout's read.
+ * What the refinement actually buys here is the states the state database
+ * cannot show: a tool call holding for approval writes no records while it
+ * holds, and a turn's true end can sit past the rollout's read.
  */
 const CODEX_HOOK_STATUS_REFINEMENT = {
   definitive: [{ event: CODEX_HOOK_EVENT.SESSION_END, fresh: SESSION_STATUS.COMPLETE }],
@@ -679,15 +663,9 @@ const CODEX_HOOK_STATUS_REFINEMENT = {
     { event: CODEX_HOOK_EVENT.PROMPT, fresh: SESSION_STATUS.WORKING },
     { event: CODEX_HOOK_EVENT.STOP, fresh: SESSION_STATUS.WAITING },
   ],
+  notificationEvent: CODEX_HOOK_EVENT.NOTIFICATION,
+  sessionEndEvent: CODEX_HOOK_EVENT.SESSION_END,
 } as const satisfies HookStatusRefinement<CodexHookEvent>;
-
-function statusWithHookEvent(
-  status: ProviderSessionObservation["status"],
-  event: CodexHookEvent,
-  isFresh: boolean,
-): ProviderSessionObservation["status"] {
-  return refineStatusWithHookEvent(status, event, isFresh, CODEX_HOOK_STATUS_REFINEMENT);
-}
 
 function detailFromRow(
   row: CodexThreadRow,
@@ -730,48 +708,31 @@ function observationFromThreadRow(
   const providerSessionId = textFromRow(row, CODEX_THREAD_COLUMN.ID);
   if (!providerSessionId) return undefined;
 
-  // A hook event trailing the row's clock by more than the tolerance
-  // describes a turn the thread has already moved past, so it is ignored
-  // whole. One that stands is proof the session moved — only Luke's own
-  // script writes the spool — and dates the session for the freshness decay
-  // as well. A notification alone gets no tolerance: it means the session is
-  // holding for approval, and holding writes nothing, so a row touched at or
-  // past the event is itself the news that the hold ended.
   const rowAt = timestampFromRow(row);
-  const toleranceMs =
-    hookEvent?.event === CODEX_HOOK_EVENT.NOTIFICATION
-      ? 0
-      : CODEX_ADAPTER_DEFAULTS.HOOK_EVENT_TOLERANCE_MS;
-  const eventStands = hookEvent !== undefined && hookEvent.atMs + toleranceMs >= rowAt;
-  const observedAt = eventStands ? Math.max(rowAt, hookEvent.atMs) : rowAt;
-  let status = statusFromRow(rollout, observedAt, now, activeSessionFreshnessMs);
-  if (eventStands) {
-    const isFresh = now - observedAt <= activeSessionFreshnessMs;
-    status = statusWithHookEvent(status, hookEvent.event, isFresh);
-  }
-  const completionCause =
-    status === SESSION_STATUS.COMPLETE &&
-    eventStands &&
-    hookEvent.event === CODEX_HOOK_EVENT.SESSION_END
-      ? SESSION_COMPLETION_CAUSE.SESSION_CLOSED
-      : undefined;
+  const refined = hookRefinedStatus({
+    refinement: CODEX_HOOK_STATUS_REFINEMENT,
+    hookEvent,
+    providerAtMs: rowAt,
+    statusAt: (observedAt) => statusFromRow(rollout, observedAt, now, activeSessionFreshnessMs),
+    now,
+    activeSessionFreshnessMs,
+  });
+  const completionCause = refined.sessionClosed
+    ? SESSION_COMPLETION_CAUSE.SESSION_CLOSED
+    : undefined;
   const detail = detailFromRow(row, rollout);
   const parentProviderSessionId = delegationSourceFromRow(row);
   const observation: ProviderSessionObservation = {
     providerSessionId,
     ...(parentProviderSessionId ? { parentProviderSessionId } : undefined),
     title: titleFromRow(row, names),
-    status,
+    status: refined.status,
     ...(completionCause ? { completionCause } : undefined),
-    observedAt,
+    observedAt: refined.observedAt,
     ...(rollout?.lastAgentMessage ? { recap: rollout.lastAgentMessage } : undefined),
     detail,
     ...(detail.link ? { applications: [chatGptApplication(detail.link)] } : undefined),
-    ...(status === SESSION_STATUS.WAITING &&
-    eventStands &&
-    hookEvent?.event === CODEX_HOOK_EVENT.NOTIFICATION
-      ? { holdingForDeveloper: true }
-      : undefined),
+    ...(refined.holdingForDeveloper ? { holdingForDeveloper: true } : undefined),
   };
   if (isCodexRealtimeDelegationThread(row)) observation.realtimeVoice = true;
   if (rollout?.realtimeVoiceLive === true) observation.realtimeVoiceLive = true;

--- a/packages/providers/src/codex/hooks.test.ts
+++ b/packages/providers/src/codex/hooks.test.ts
@@ -6,10 +6,10 @@ import path from "node:path";
 import test, { type TestContext } from "node:test";
 import { promisify } from "node:util";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import type { ObservationHookInstallation } from "../shared/hook-merge.js";
 import {
   CODEX_HOOK_EVENT,
   CODEX_HOOK_SCRIPT_NAME,
-  type CodexHookInstallation,
   installCodexObservationHooks,
   readCodexHookEvent,
   removeCodexObservationHooks,
@@ -32,25 +32,25 @@ const REGISTERED_EVENT_NAMES = [
   "SessionEnd",
 ] as const;
 
-async function temporaryInstallation(t: TestContext): Promise<CodexHookInstallation> {
+async function temporaryInstallation(t: TestContext): Promise<ObservationHookInstallation> {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-codex-hooks-"));
   t.after(async () => {
     await fs.rm(directory, { recursive: true, force: true });
   });
-  const codexHome = path.join(directory, "codex-home");
-  await fs.mkdir(codexHome, { recursive: true });
+  const providerHome = path.join(directory, "codex-home");
+  await fs.mkdir(providerHome, { recursive: true });
   return {
-    codexHome,
+    providerHome,
     hookScriptPath: path.join(directory, "luke-data", CODEX_HOOK_SCRIPT_NAME),
     spoolDirectory: path.join(directory, "luke-data", "events"),
   };
 }
 
-function hooksPath(installation: CodexHookInstallation): string {
-  return path.join(installation.codexHome, CODEX_HOOKS_FILE_NAME);
+function hooksPath(installation: ObservationHookInstallation): string {
+  return path.join(installation.providerHome, CODEX_HOOKS_FILE_NAME);
 }
 
-async function readHooksFile(installation: CodexHookInstallation): Promise<ParsedJsonObject> {
+async function readHooksFile(installation: ObservationHookInstallation): Promise<ParsedJsonObject> {
   return JSON.parse(await fs.readFile(hooksPath(installation), "utf8"));
 }
 
@@ -81,7 +81,7 @@ function entryCommands(entries: unknown[]): string[] {
  * the envelope rides in from a file beside the script through `sh -c`.
  */
 async function pipeToHookScript(
-  installation: CodexHookInstallation,
+  installation: ObservationHookInstallation,
   eventArgument: string,
   envelope: string,
 ): Promise<void> {
@@ -101,7 +101,7 @@ async function pipeToHookScript(
  * must not sit waiting on a pipe no one is writing.
  */
 async function callHookScript(
-  installation: CodexHookInstallation,
+  installation: ObservationHookInstallation,
   eventArgument: string,
   envelope: string,
 ): Promise<void> {
@@ -152,11 +152,11 @@ test("registers every lifecycle event beside the user's own hooks", async (t) =>
 
 test("touches nothing on a machine with no Codex home at all", async (t) => {
   const installation = await temporaryInstallation(t);
-  await fs.rm(installation.codexHome, { recursive: true, force: true });
+  await fs.rm(installation.providerHome, { recursive: true, force: true });
 
   await installCodexObservationHooks(installation);
 
-  await assert.rejects(fs.stat(installation.codexHome));
+  await assert.rejects(fs.stat(installation.providerHome));
   await assert.rejects(fs.stat(installation.hookScriptPath));
   await assert.rejects(fs.stat(installation.spoolDirectory));
 });

--- a/packages/providers/src/codex/hooks.ts
+++ b/packages/providers/src/codex/hooks.ts
@@ -1,6 +1,5 @@
 import {
   HOOK_ENTRY_NESTING,
-  HOOK_SPOOL_MAXIMUM_AGE_MS,
   type ObservationHookSpec,
   type ObservedHookEvent,
   observationHooksFor,
@@ -8,7 +7,7 @@ import {
 
 /**
  * Codex's observation hooks, described for the shared machinery in
- * `observation-hooks.ts`. Codex keeps user-level hooks in a `hooks.json` of
+ * `hook-merge.ts`. Codex keeps user-level hooks in a `hooks.json` of
  * their own inside its home, nested the same way Claude Code's are, and hands
  * a registered command its envelope as JSON on stdin. The envelope's
  * `session_id` is the same thread id the adapter reads from `threads.id`, so
@@ -30,8 +29,6 @@ export const CODEX_HOOK_SCRIPT_NAME = "luke-codex-observation-hook.sh";
 
 /** How long Codex lets the spool write run before giving up on it. */
 const CODEX_HOOK_TIMEOUT_SECONDS = 10;
-
-export const CODEX_HOOK_SPOOL_MAXIMUM_AGE_MS = HOOK_SPOOL_MAXIMUM_AGE_MS;
 
 /**
  * The tokens the script may write, fixed at registration: each hook entry
@@ -80,21 +77,8 @@ const CODEX_HOOK_SPEC: ObservationHookSpec<CodexHookEvent> = {
   entryNesting: HOOK_ENTRY_NESTING.NESTED,
 };
 
-export interface CodexHookInstallation {
-  /** Codex's own home, holding the `hooks.json` entries merge into. */
-  codexHome: string;
-  /** Where Luke keeps the script, under Luke's own application data. */
-  hookScriptPath: string;
-  /** Where the script writes its event files, under Luke's own data too. */
-  spoolDirectory: string;
-}
-
-const codexHooks = observationHooksFor(
-  CODEX_HOOK_SPEC,
-  (installation: CodexHookInstallation) => installation.codexHome,
-);
+const codexHooks = observationHooksFor(CODEX_HOOK_SPEC);
 
 export const installCodexObservationHooks = codexHooks.install;
 export const removeCodexObservationHooks = codexHooks.remove;
 export const readCodexHookEvent = codexHooks.read;
-export const pruneCodexHookSpool = codexHooks.prune;

--- a/packages/providers/src/cursor/hooks.test.ts
+++ b/packages/providers/src/cursor/hooks.test.ts
@@ -6,10 +6,10 @@ import path from "node:path";
 import test, { type TestContext } from "node:test";
 import { promisify } from "node:util";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import type { ObservationHookInstallation } from "../shared/hook-merge.js";
 import {
   CURSOR_HOOK_EVENT,
   CURSOR_HOOK_SCRIPT_NAME,
-  type CursorHookInstallation,
   installCursorObservationHooks,
   readCursorHookEvent,
   removeCursorObservationHooks,
@@ -31,25 +31,25 @@ const REGISTERED_EVENT_NAMES = [
   "sessionEnd",
 ] as const;
 
-async function temporaryInstallation(t: TestContext): Promise<CursorHookInstallation> {
+async function temporaryInstallation(t: TestContext): Promise<ObservationHookInstallation> {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-cursor-hooks-"));
   t.after(async () => {
     await fs.rm(directory, { recursive: true, force: true });
   });
-  const cursorHome = path.join(directory, "cursor-home");
-  await fs.mkdir(cursorHome, { recursive: true });
+  const providerHome = path.join(directory, "cursor-home");
+  await fs.mkdir(providerHome, { recursive: true });
   return {
-    cursorHome,
+    providerHome,
     hookScriptPath: path.join(directory, "luke-data", CURSOR_HOOK_SCRIPT_NAME),
     spoolDirectory: path.join(directory, "luke-data", "events"),
   };
 }
 
-function hooksPath(installation: CursorHookInstallation): string {
-  return path.join(installation.cursorHome, CURSOR_HOOKS_FILE_NAME);
+function hooksPath(installation: ObservationHookInstallation): string {
+  return path.join(installation.providerHome, CURSOR_HOOKS_FILE_NAME);
 }
 
-async function readHooksFile(installation: CursorHookInstallation): Promise<ParsedJsonObject> {
+async function readHooksFile(installation: ObservationHookInstallation): Promise<ParsedJsonObject> {
   return JSON.parse(await fs.readFile(hooksPath(installation), "utf8"));
 }
 
@@ -76,7 +76,7 @@ function entryCommands(entries: unknown[]): string[] {
  * JSON answer.
  */
 async function pipeToHookScript(
-  installation: CursorHookInstallation,
+  installation: ObservationHookInstallation,
   eventArgument: string,
   envelope: string,
 ): Promise<string> {
@@ -147,11 +147,11 @@ test("the user's own schema version is never rewritten", async (t) => {
 
 test("touches nothing on a machine with no Cursor home at all", async (t) => {
   const installation = await temporaryInstallation(t);
-  await fs.rm(installation.cursorHome, { recursive: true, force: true });
+  await fs.rm(installation.providerHome, { recursive: true, force: true });
 
   await installCursorObservationHooks(installation);
 
-  await assert.rejects(fs.stat(installation.cursorHome));
+  await assert.rejects(fs.stat(installation.providerHome));
   await assert.rejects(fs.stat(installation.hookScriptPath));
   await assert.rejects(fs.stat(installation.spoolDirectory));
 });

--- a/packages/providers/src/cursor/hooks.ts
+++ b/packages/providers/src/cursor/hooks.ts
@@ -1,6 +1,5 @@
 import {
   HOOK_ENTRY_NESTING,
-  HOOK_SPOOL_MAXIMUM_AGE_MS,
   type ObservationHookSpec,
   type ObservedHookEvent,
   observationHooksFor,
@@ -32,8 +31,6 @@ export const CURSOR_HOOK_SCRIPT_NAME = "luke-cursor-observation-hook.sh";
 
 /** How long Cursor lets the spool write run before giving up on it. */
 const CURSOR_HOOK_TIMEOUT_SECONDS = 10;
-
-export const CURSOR_HOOK_SPOOL_MAXIMUM_AGE_MS = HOOK_SPOOL_MAXIMUM_AGE_MS;
 
 /**
  * The tokens the script may write, fixed at registration: each hook entry
@@ -76,21 +73,8 @@ const CURSOR_HOOK_SPEC: ObservationHookSpec<CursorHookEvent> = {
   rootDefaults: { version: 1 },
 };
 
-export interface CursorHookInstallation {
-  /** Cursor's own home, holding the `hooks.json` entries merge into. */
-  cursorHome: string;
-  /** Where Luke keeps the script, under Luke's own application data. */
-  hookScriptPath: string;
-  /** Where the script writes its event files, under Luke's own data too. */
-  spoolDirectory: string;
-}
-
-const cursorHooks = observationHooksFor(
-  CURSOR_HOOK_SPEC,
-  (installation: CursorHookInstallation) => installation.cursorHome,
-);
+const cursorHooks = observationHooksFor(CURSOR_HOOK_SPEC);
 
 export const installCursorObservationHooks = cursorHooks.install;
 export const removeCursorObservationHooks = cursorHooks.remove;
 export const readCursorHookEvent = cursorHooks.read;
-export const pruneCursorHookSpool = cursorHooks.prune;

--- a/packages/providers/src/cursor/local-adapter.ts
+++ b/packages/providers/src/cursor/local-adapter.ts
@@ -33,13 +33,13 @@ import {
   discoverSessionFiles,
   fileStats,
   type HookStatusRefinement,
+  hookRefinedStatus,
   LOCAL_ADAPTER_DEFAULTS,
   LocalFileSessionAdapter,
   localSessionStatus,
   readDirectory,
   readTail,
   readTextFile,
-  refineStatusWithHookEvent,
   type SessionFileCandidate,
   tailRecords,
   workspaceLabel,
@@ -159,7 +159,6 @@ const CURSOR_CONTENT_TYPE = {
 const CURSOR_LOCAL_ADAPTER_DEFAULTS = {
   MAXIMUM_PROJECT_DIRECTORIES: 200,
   MAXIMUM_ACTIVITY_LENGTH: 80,
-  HOOK_EVENT_TOLERANCE_MS: 5_000,
 } as const;
 
 export interface CursorLocalAdapterOptions {
@@ -444,15 +443,11 @@ interface CursorAppChatIndex {
 const EMPTY_APP_CHAT_INDEX: CursorAppChatIndex = { held: new Set(), archived: new Set() };
 
 /**
- * Sharpens the transcript's verdict with what the observation hook last said,
- * in the order the meanings bind. A closed session is definite: the hook
- * saying so outranks the transcript, and a transcript that says error is
- * never talked out of it by a softer event. Past that, the events refine only
- * a fresh session — the decay to `UNKNOWN` exists because a hook can go
- * silent (a killed process fires no `sessionEnd`), so an old "waiting" must
- * age the same way an old transcript does. What the refinement actually buys
- * is the state the transcript cannot show at all: a chat whose window or CLI
- * closed looks exactly like one holding for its developer.
+ * What the refinement actually buys here is the state the transcript cannot
+ * show at all: a chat whose window or CLI closed looks exactly like one
+ * holding for its developer. No notification token is registered — Cursor
+ * documents no event that fires only while a call holds for approval — so
+ * the refinement names no such moment, the honest absence.
  */
 const CURSOR_HOOK_STATUS_REFINEMENT = {
   definitive: [{ event: CURSOR_HOOK_EVENT.SESSION_END, fresh: SESSION_STATUS.COMPLETE }],
@@ -460,15 +455,8 @@ const CURSOR_HOOK_STATUS_REFINEMENT = {
     { event: CURSOR_HOOK_EVENT.PROMPT, fresh: SESSION_STATUS.WORKING },
     { event: CURSOR_HOOK_EVENT.STOP, fresh: SESSION_STATUS.WAITING },
   ],
+  sessionEndEvent: CURSOR_HOOK_EVENT.SESSION_END,
 } as const satisfies HookStatusRefinement<CursorHookEvent>;
-
-function statusWithHookEvent(
-  status: SessionStatus,
-  event: CursorHookEvent,
-  isFresh: boolean,
-): SessionStatus {
-  return refineStatusWithHookEvent(status, event, isFresh, CURSOR_HOOK_STATUS_REFINEMENT);
-}
 
 /**
  * Reads which of the observed chats Cursor's app holds, and which of them the
@@ -868,20 +856,17 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
       : undefined;
     // A transcript carries no timestamps of its own, so when it was last
     // written is Cursor's only account of when this session last did anything.
-    // A hook event trailing that clock by more than the tolerance describes a
-    // turn the transcript already moved past, so it is ignored whole; one that
-    // stands is proof the session moved — only Luke's own script writes the
-    // spool — and dates the session for the freshness decay as well.
     const transcriptAt = candidate.mtimeMs;
-    const eventStands =
-      hookEvent !== undefined &&
-      hookEvent.atMs + CURSOR_LOCAL_ADAPTER_DEFAULTS.HOOK_EVENT_TOLERANCE_MS >= transcriptAt;
-    const observedAt = eventStands ? Math.max(transcriptAt, hookEvent.atMs) : transcriptAt;
-    let status = statusFromTurn(parsed.turn, observedAt, now, activeSessionFreshnessMs);
-    if (eventStands) {
-      const isFresh = now - observedAt <= activeSessionFreshnessMs;
-      status = statusWithHookEvent(status, hookEvent.event, isFresh);
-    }
+    const refined = hookRefinedStatus({
+      refinement: CURSOR_HOOK_STATUS_REFINEMENT,
+      hookEvent,
+      providerAtMs: transcriptAt,
+      statusAt: (observedAt) =>
+        statusFromTurn(parsed.turn, observedAt, now, activeSessionFreshnessMs),
+      now,
+      activeSessionFreshnessMs,
+    });
+    const { status, observedAt } = refined;
     const appHeld = this.#appChats.has(candidate.providerSessionId);
     const link = appHeld ? cursorChatLink(candidate.providerSessionId) : undefined;
     // A message is advertised only where the CLI's documented resume can
@@ -919,7 +904,7 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
       detail: detailFor(label, status, link, parsed.activity),
       ...(parsed.recap ? { recap: parsed.recap } : undefined),
       ...(canReceiveMessage ? { canReceiveMessage: true } : undefined),
-      ...(status === SESSION_STATUS.COMPLETE
+      ...(refined.sessionClosed
         ? { completionCause: SESSION_COMPLETION_CAUSE.SESSION_CLOSED }
         : undefined),
       ...(link ? { applications: [cursorApplication(link)] } : undefined),

--- a/packages/providers/src/hook-registry.ts
+++ b/packages/providers/src/hook-registry.ts
@@ -1,20 +1,39 @@
 import path from "node:path";
-import {
-  CLAUDE_HOOK_SCRIPT_NAME,
-  type ClaudeCodeHookInstallation,
-  defaultClaudeHome,
-} from "./claude-code/hooks.js";
+import { PROVIDER_ID } from "@sidecar/session";
+import { CLAUDE_HOOK_SCRIPT_NAME, defaultClaudeHome } from "./claude-code/hooks.js";
 import { defaultCodexHome } from "./codex/adapter.js";
-import { CODEX_HOOK_SCRIPT_NAME, type CodexHookInstallation } from "./codex/hooks.js";
-import { CURSOR_HOOK_SCRIPT_NAME, type CursorHookInstallation } from "./cursor/hooks.js";
+import { CODEX_HOOK_SCRIPT_NAME } from "./codex/hooks.js";
+import { CURSOR_HOOK_SCRIPT_NAME } from "./cursor/hooks.js";
 import { defaultCursorHome } from "./cursor/local-adapter.js";
+import type { ObservationHookInstallation } from "./shared/hook-merge.js";
 
-const HOOK_DIRECTORY = {
-  CLAUDE_CODE: "claude-code-hooks",
-  CODEX: "codex-hooks",
-  CURSOR: "cursor-hooks",
-} as const;
 const SPOOL_DIRECTORY = "events";
+
+/**
+ * One row per provider that registers observation hooks at all: the directory
+ * each arrangement keeps under Luke's own application data, the script inside
+ * it, and the provider home its registration merges into. Widening this table
+ * to another provider is a product decision, not an implementation detail.
+ */
+const OBSERVATION_HOOK_PROVIDERS = {
+  [PROVIDER_ID.CLAUDE_CODE]: {
+    directoryName: "claude-code-hooks",
+    scriptName: CLAUDE_HOOK_SCRIPT_NAME,
+    providerHome: defaultClaudeHome,
+  },
+  [PROVIDER_ID.CODEX]: {
+    directoryName: "codex-hooks",
+    scriptName: CODEX_HOOK_SCRIPT_NAME,
+    providerHome: defaultCodexHome,
+  },
+  [PROVIDER_ID.CURSOR]: {
+    directoryName: "cursor-hooks",
+    scriptName: CURSOR_HOOK_SCRIPT_NAME,
+    providerHome: defaultCursorHome,
+  },
+} as const;
+
+export type ObservationHookProviderId = keyof typeof OBSERVATION_HOOK_PROVIDERS;
 
 /**
  * Luke's own corners of the application data, holding each provider's
@@ -30,31 +49,12 @@ export class ObservationHookRegistry {
     this.#userDataDirectory = userDataDirectory;
   }
 
-  claudeInstallation(): ClaudeCodeHookInstallation {
+  installation(providerId: ObservationHookProviderId): ObservationHookInstallation {
+    const entry = OBSERVATION_HOOK_PROVIDERS[providerId];
+    const directory = path.join(this.#userDataDirectory(), entry.directoryName);
     return {
-      claudeHome: defaultClaudeHome(),
-      ...this.#paths(HOOK_DIRECTORY.CLAUDE_CODE, CLAUDE_HOOK_SCRIPT_NAME),
-    };
-  }
-
-  codexInstallation(): CodexHookInstallation {
-    return {
-      codexHome: defaultCodexHome(),
-      ...this.#paths(HOOK_DIRECTORY.CODEX, CODEX_HOOK_SCRIPT_NAME),
-    };
-  }
-
-  cursorInstallation(): CursorHookInstallation {
-    return {
-      cursorHome: defaultCursorHome(),
-      ...this.#paths(HOOK_DIRECTORY.CURSOR, CURSOR_HOOK_SCRIPT_NAME),
-    };
-  }
-
-  #paths(directoryName: string, scriptName: string) {
-    const directory = path.join(this.#userDataDirectory(), directoryName);
-    return {
-      hookScriptPath: path.join(directory, scriptName),
+      providerHome: entry.providerHome(),
+      hookScriptPath: path.join(directory, entry.scriptName),
       spoolDirectory: path.join(directory, SPOOL_DIRECTORY),
     };
   }

--- a/packages/providers/src/registrations.test.ts
+++ b/packages/providers/src/registrations.test.ts
@@ -11,20 +11,10 @@ const registrations = providerRegistrations({
   codexCloudAdapter: new CodexCloudSessionAdapter({
     run: async () => ({ exitCode: 1, stdout: "" }),
   }),
-  claudeHookInstallation: () => ({
-    claudeHome: "/missing/claude",
-    hookScriptPath: "/missing/claude-hook",
-    spoolDirectory: "/missing/claude-spool",
-  }),
-  codexHookInstallation: () => ({
-    codexHome: "/missing/codex",
-    hookScriptPath: "/missing/codex-hook",
-    spoolDirectory: "/missing/codex-spool",
-  }),
-  cursorHookInstallation: () => ({
-    cursorHome: "/missing/cursor",
-    hookScriptPath: "/missing/cursor-hook",
-    spoolDirectory: "/missing/cursor-spool",
+  observationHookInstallation: (providerId) => ({
+    providerHome: `/missing/${providerId}`,
+    hookScriptPath: `/missing/${providerId}-hook`,
+    spoolDirectory: `/missing/${providerId}-spool`,
   }),
 });
 

--- a/packages/providers/src/registrations.ts
+++ b/packages/providers/src/registrations.ts
@@ -11,35 +11,26 @@ import {
   type SessionProviderAdapter,
 } from "@sidecar/session";
 import { ClaudeCodeSessionAdapter } from "./claude-code/adapter.js";
-import {
-  CLAUDE_HOOK_SPOOL_MAXIMUM_AGE_MS,
-  type ClaudeCodeHookInstallation,
-  installClaudeCodeObservationHooks,
-  pruneClaudeHookSpool,
-} from "./claude-code/hooks.js";
+import { installClaudeCodeObservationHooks } from "./claude-code/hooks.js";
 import { CODEX_PROVIDER, CodexSessionAdapter } from "./codex/adapter.js";
 import type { CodexCloudSessionAdapter } from "./codex/cloud-adapter.js";
-import {
-  CODEX_HOOK_SPOOL_MAXIMUM_AGE_MS,
-  type CodexHookInstallation,
-  installCodexObservationHooks,
-  pruneCodexHookSpool,
-} from "./codex/hooks.js";
+import { installCodexObservationHooks } from "./codex/hooks.js";
 import { ConductorSessionAdapter } from "./conductor/adapter.js";
 import { CopilotSessionAdapter } from "./copilot/adapter.js";
 import { CURSOR_PROVIDER, CursorSessionAdapter } from "./cursor/adapter.js";
-import {
-  CURSOR_HOOK_SPOOL_MAXIMUM_AGE_MS,
-  type CursorHookInstallation,
-  installCursorObservationHooks,
-  pruneCursorHookSpool,
-} from "./cursor/hooks.js";
+import { installCursorObservationHooks } from "./cursor/hooks.js";
 import { CursorLocalSessionAdapter } from "./cursor/local-adapter.js";
 import { DEVIN_PROVIDER, DevinSessionAdapter } from "./devin/adapter.js";
 import { DevinLocalSessionAdapter } from "./devin/local-adapter.js";
 import { GeminiCliSessionAdapter } from "./gemini-cli/adapter.js";
+import type { ObservationHookProviderId } from "./hook-registry.js";
 import { JulesSessionAdapter } from "./jules/adapter.js";
 import { OpenCodeSessionAdapter } from "./opencode/adapter.js";
+import {
+  HOOK_SPOOL_MAXIMUM_AGE_MS,
+  type ObservationHookInstallation,
+  pruneObservationHookSpool,
+} from "./shared/hook-merge.js";
 
 export interface ProviderRegistration {
   adapter: SessionProviderAdapter;
@@ -49,9 +40,9 @@ export interface ProviderRegistration {
 
 export interface ProviderRegistrationOptions {
   readApiKey: (providerId: CredentialProviderId) => Promise<string | undefined>;
-  claudeHookInstallation: () => ClaudeCodeHookInstallation;
-  codexHookInstallation: () => CodexHookInstallation;
-  cursorHookInstallation: () => CursorHookInstallation;
+  observationHookInstallation: (
+    providerId: ObservationHookProviderId,
+  ) => ObservationHookInstallation;
   /**
    * Constructed by the caller rather than here, because the app also asks it
    * what the latest pass learned about the Codex CLI login — the settings
@@ -62,10 +53,32 @@ export interface ProviderRegistrationOptions {
   now?: () => number;
 }
 
+/**
+ * One provider's launch convergence: install the arrangement, then prune the
+ * spool it writes into, so the spool's size tracks the sessions actually
+ * alive rather than every session ever observed.
+ */
+function observationHookRegistration(
+  installHooks: (installation: ObservationHookInstallation) => Promise<void>,
+  installation: () => ObservationHookInstallation,
+  now: () => number,
+): () => Promise<void> {
+  return async () => {
+    const resolved = installation();
+    await installHooks(resolved);
+    await pruneObservationHookSpool(resolved.spoolDirectory, HOOK_SPOOL_MAXIMUM_AGE_MS, now());
+  };
+}
+
 export function providerRegistrations(options: ProviderRegistrationOptions) {
   const now = options.now ?? Date.now;
+  const hookInstallation = (providerId: ObservationHookProviderId) => () =>
+    options.observationHookInstallation(providerId);
+  const claudeInstallation = hookInstallation(PROVIDER_ID.CLAUDE_CODE);
+  const codexInstallation = hookInstallation(PROVIDER_ID.CODEX);
+  const cursorInstallation = hookInstallation(PROVIDER_ID.CURSOR);
   const claude = new ClaudeCodeSessionAdapter({
-    hookEventsDirectory: () => options.claudeHookInstallation().spoolDirectory,
+    hookEventsDirectory: () => claudeInstallation().spoolDirectory,
   });
   // Codex runs sessions in two places: on this machine, observed from its own
   // transcripts, and in Codex cloud, observed through the Codex CLI's
@@ -74,7 +87,7 @@ export function providerRegistrations(options: ProviderRegistrationOptions) {
     provider: CODEX_PROVIDER,
     adapters: [
       new CodexSessionAdapter({
-        hookEventsDirectory: () => options.codexHookInstallation().spoolDirectory,
+        hookEventsDirectory: () => codexInstallation().spoolDirectory,
       }),
       options.codexCloudAdapter,
     ],
@@ -83,7 +96,7 @@ export function providerRegistrations(options: ProviderRegistrationOptions) {
     provider: CURSOR_PROVIDER,
     adapters: [
       new CursorLocalSessionAdapter({
-        hookEventsDirectory: () => options.cursorHookInstallation().spoolDirectory,
+        hookEventsDirectory: () => cursorInstallation().spoolDirectory,
       }),
       new CursorSessionAdapter({
         readApiKey: () => options.readApiKey(CREDENTIAL_PROVIDER_ID.CURSOR),
@@ -103,27 +116,19 @@ export function providerRegistrations(options: ProviderRegistrationOptions) {
   return {
     [PROVIDER_ID.CLAUDE_CODE]: {
       adapter: claude,
-      registerObservationHook: async () => {
-        const installation = options.claudeHookInstallation();
-        await installClaudeCodeObservationHooks(installation);
-        await pruneClaudeHookSpool(
-          installation.spoolDirectory,
-          CLAUDE_HOOK_SPOOL_MAXIMUM_AGE_MS,
-          now(),
-        );
-      },
+      registerObservationHook: observationHookRegistration(
+        installClaudeCodeObservationHooks,
+        claudeInstallation,
+        now,
+      ),
     },
     [PROVIDER_ID.CODEX]: {
       adapter: codex,
-      registerObservationHook: async () => {
-        const installation = options.codexHookInstallation();
-        await installCodexObservationHooks(installation);
-        await pruneCodexHookSpool(
-          installation.spoolDirectory,
-          CODEX_HOOK_SPOOL_MAXIMUM_AGE_MS,
-          now(),
-        );
-      },
+      registerObservationHook: observationHookRegistration(
+        installCodexObservationHooks,
+        codexInstallation,
+        now,
+      ),
     },
     [PROVIDER_ID.CONDUCTOR]: {
       adapter: new ConductorSessionAdapter({
@@ -140,15 +145,11 @@ export function providerRegistrations(options: ProviderRegistrationOptions) {
     [PROVIDER_ID.CURSOR]: {
       adapter: cursor,
       credential: CREDENTIAL_PROVIDERS[CREDENTIAL_PROVIDER_ID.CURSOR],
-      registerObservationHook: async () => {
-        const installation = options.cursorHookInstallation();
-        await installCursorObservationHooks(installation);
-        await pruneCursorHookSpool(
-          installation.spoolDirectory,
-          CURSOR_HOOK_SPOOL_MAXIMUM_AGE_MS,
-          now(),
-        );
-      },
+      registerObservationHook: observationHookRegistration(
+        installCursorObservationHooks,
+        cursorInstallation,
+        now,
+      ),
     },
     [PROVIDER_ID.DEVIN]: {
       adapter: devin,

--- a/packages/providers/src/shared/hook-merge.ts
+++ b/packages/providers/src/shared/hook-merge.ts
@@ -598,27 +598,13 @@ export async function pruneObservationHookSpool(
   }
 }
 
-interface BoundObservationHookInstallation {
-  hookScriptPath: string;
-  spoolDirectory: string;
-}
-
-export function observationHooksFor<
-  Event extends string,
-  Installation extends BoundObservationHookInstallation,
->(spec: ObservationHookSpec<Event>, providerHome: (installation: Installation) => string) {
-  const sharedInstallation = (installation: Installation): ObservationHookInstallation => ({
-    providerHome: providerHome(installation),
-    hookScriptPath: installation.hookScriptPath,
-    spoolDirectory: installation.spoolDirectory,
-  });
+export function observationHooksFor<Event extends string>(spec: ObservationHookSpec<Event>) {
   return {
-    install: (installation: Installation) =>
-      installObservationHooks(spec, sharedInstallation(installation)),
-    remove: (installation: Installation) =>
-      removeObservationHooks(spec, sharedInstallation(installation)),
+    install: (installation: ObservationHookInstallation) =>
+      installObservationHooks(spec, installation),
+    remove: (installation: ObservationHookInstallation) =>
+      removeObservationHooks(spec, installation),
     read: (spoolDirectory: string, providerSessionId: string) =>
       readObservationHookEvent(spec, spoolDirectory, providerSessionId),
-    prune: pruneObservationHookSpool,
   } as const;
 }

--- a/packages/providers/src/shared/local-session-adapter.ts
+++ b/packages/providers/src/shared/local-session-adapter.ts
@@ -34,9 +34,24 @@ export interface HookEventStatus<Event extends string> {
 export interface HookStatusRefinement<Event extends string> {
   definitive: readonly HookEventStatus<Event>[];
   fresh: readonly HookEventStatus<Event>[];
+  /**
+   * The token meaning the session is holding on a question only the developer
+   * can answer. It is the one event granted no tolerance against the
+   * provider's clock — holding writes nothing, so provider state at or past
+   * the event is itself the news that the hold ended — and the one that marks
+   * the observation as holding for the developer while it stands. A provider
+   * whose hooks carry no such moment omits it, and the honest absence stands.
+   */
+  notificationEvent?: Event;
+  /**
+   * The token meaning the provider closed the session for good, which is what
+   * lets the observation report the closure as the completion's cause. A
+   * provider that fires no closing hook omits it.
+   */
+  sessionEndEvent?: Event;
 }
 
-export function refineStatusWithHookEvent<Event extends string>(
+function refineStatusWithHookEvent<Event extends string>(
   status: SessionStatus,
   event: Event,
   isFresh: boolean,
@@ -48,6 +63,82 @@ export function refineStatusWithHookEvent<Event extends string>(
   const candidate = refinement.fresh.find((entry) => entry.event === event);
   if (!candidate) return status;
   return isFresh ? candidate.fresh : (candidate.stale ?? status);
+}
+
+/**
+ * How much older than the provider's clock a hook event may run and still
+ * describe the same moment. The hook fires as a turn boundary happens and the
+ * provider's own closing records land moments later under their own
+ * timestamps, so a boundary's event usually trails the record it belongs with
+ * by a breath — never by more than this. An event further behind describes a
+ * turn the provider has already moved past, and refines nothing.
+ */
+export const HOOK_EVENT_TOLERANCE_MS = 5_000;
+
+/** What the hook settled for one observation, beyond the status itself. */
+export interface HookRefinedStatus {
+  status: SessionStatus;
+  /**
+   * The clock the freshness decay runs on: the provider's own, or the
+   * event's when it stands past it.
+   */
+  observedAt: number;
+  /** The provider closed the session, on the hook's word. */
+  sessionClosed: boolean;
+  /** The session is holding on a question only the developer can answer. */
+  holdingForDeveloper: boolean;
+}
+
+/**
+ * Sharpens a provider's own verdict with what the observation hook last said,
+ * in the order the meanings bind: a definitive event outranks the provider,
+ * a provider that already settled on complete or error is never talked out
+ * of it by a softer event, and the rest refine only a fresh session — the
+ * decay to unknown exists because a hook can go silent (a killed process
+ * fires no session end), so an old event must age the same way old provider
+ * state does. A hook event trailing the provider's clock by more than the
+ * tolerance describes a turn the session already moved past, so it is
+ * ignored whole. One that stands is proof the session moved — only Luke's
+ * own script writes the spool, so its date cannot suffer the bulk-touch
+ * problem a provider's files can — and dates the session for the freshness
+ * decay as well. A notification alone gets no tolerance: a granted
+ * permission must not read as waiting for even one more pass.
+ */
+export function hookRefinedStatus<Event extends string>(options: {
+  refinement: HookStatusRefinement<Event>;
+  /** The spool's last word about the session, if the hook said anything. */
+  hookEvent: { event: Event; atMs: number } | undefined;
+  /** When the provider's own state last said the session moved. */
+  providerAtMs: number;
+  /** The provider's own verdict, given the clock the refinement settles on. */
+  statusAt: (observedAt: number) => SessionStatus;
+  now: number;
+  activeSessionFreshnessMs: number;
+}): HookRefinedStatus {
+  const { refinement, hookEvent, providerAtMs } = options;
+  const toleranceMs =
+    refinement.notificationEvent !== undefined && hookEvent?.event === refinement.notificationEvent
+      ? 0
+      : HOOK_EVENT_TOLERANCE_MS;
+  const eventStands = hookEvent !== undefined && hookEvent.atMs + toleranceMs >= providerAtMs;
+  const observedAt = eventStands ? Math.max(providerAtMs, hookEvent.atMs) : providerAtMs;
+  let status = options.statusAt(observedAt);
+  if (eventStands) {
+    const isFresh = options.now - observedAt <= options.activeSessionFreshnessMs;
+    status = refineStatusWithHookEvent(status, hookEvent.event, isFresh, refinement);
+  }
+  return {
+    status,
+    observedAt,
+    sessionClosed:
+      status === SESSION_STATUS.COMPLETE &&
+      eventStands &&
+      hookEvent.event === refinement.sessionEndEvent,
+    holdingForDeveloper:
+      status === SESSION_STATUS.WAITING &&
+      eventStands &&
+      hookEvent.event === refinement.notificationEvent,
+  };
 }
 
 /**


### PR DESCRIPTION
Phase 0 of widening observation-hook support to more local providers (Gemini CLI, Devin, Cursor, and OpenCode follow in their own PRs). No behavior change.

- `hookRefinedStatus` in `shared/local-session-adapter.ts` now carries the tolerance gate, the `observedAt` election, and the completion-cause and holding-for-developer verdicts that the Claude Code and Codex adapters each duplicated; each adapter keeps only its refinement table, which now names its own notification and session-end tokens.
- The per-provider installation types (`ClaudeCodeHookInstallation`, `CodexHookInstallation`) collapse into the shared `ObservationHookInstallation`, and `observationHooksFor` loses its projector generic.
- `ObservationHookRegistry` becomes one table keyed by provider id, and `providerRegistrations` takes one `observationHookInstallation` lookup in place of a field per provider, with the install-then-prune launch convergence expressed once — so a provider gaining hooks adds rows rather than plumbing.

`./scripts/check.sh` passes end to end (typecheck, 445 provider tests among the full suite, builds). Portable-only change; no macOS or UI surface moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/e751a745-db94-44ba-9fc8-f05ee5f0236a)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32445893410/artifacts/9434077337) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32445893410)

- Commit: `eac86f6ebc7b3cd60f8fd125c2a851492a911a0d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
