### PR TITLE
feat(web): add favicon and Open Graph card to the admin page

### DIFF
--- a/apps/web/admin.html
+++ b/apps/web/admin.html
@@ -6,6 +6,34 @@
     <meta name="color-scheme" content="dark" />
     <meta name="robots" content="noindex" />
     <title>Luke admin</title>
+    <!-- Matches the page background so mobile browser chrome blends into it. -->
+    <meta name="theme-color" content="#08090b" />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Luke" />
+    <meta property="og:title" content="Luke admin" />
+    <meta property="og:description" content="Maintainer metrics for Luke." />
+    <meta property="og:url" content="https://tryluke.dev/admin" />
+    <!-- The same 1200x630 card the landing page shares — the tag set is
+         documented there, in index.html. The page is noindex, but a link
+         pasted into a maintainer chat still unfurls, and the card says whose
+         page it is. -->
+    <meta property="og:image" content="https://tryluke.dev/luke-og-card.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:type" content="image/png" />
+    <meta
+      property="og:image:alt"
+      content="The LUKE wordmark — a smiling L-face followed by U, K, E — on space black."
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+
+    <!-- Luke's app icon, the same mark the landing page carries — the tag set
+         is documented there, in index.html. -->
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 240 240' fill='none'><defs><linearGradient id='tile' x1='0' y1='0' x2='1' y2='1'><stop offset='0' stop-color='%2348484a'/><stop offset='1' stop-color='%231c1c1e'/></linearGradient></defs><rect x='8' y='8' width='224' height='224' rx='52' fill='url(%23tile)'/><g transform='translate(-8.54 -11.59) scale(1.06)'><g transform='rotate(-8 120 124)'><path d='M 104 84 V 150 Q 104 164 118 164 Q 140 164 168 142' fill='none' stroke='%23f8fafc' stroke-width='16' stroke-linecap='round' stroke-linejoin='round'/><circle cx='78' cy='92' r='12' fill='%23f8fafc'/><circle cx='162' cy='92' r='12' fill='%23f8fafc'/></g></g></svg>"
+    />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
The admin dashboard page (`/admin`) shipped with a bare `<head>`: no favicon in the tab strip and nothing for a pasted link to unfurl. This gives `admin.html` the same head the other pages carry:

- the inline app-icon favicon the landing and changelog pages use
- the shared 1200×630 `luke-og-card.png` Open Graph/Twitter card (the page stays `noindex`, but a link pasted into a maintainer chat still unfurls)
- a `theme-color` matching the dark page background (`#08090b`)

No new assets: the OG card already ships in `apps/web/public/` and the favicon is the same inline SVG data URI the landing page inlines.

## Testing
- `./scripts/check.sh` passes (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/27334251-b320-4eea-966e-db524a341492)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32445388838/artifacts/9433917910) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32445388838)

- Commit: `173d65dd95978b8d8ef4dabe8ad0bbbe88d997a3`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
