### PR TITLE
fix(superset): match OpenCode chats by worktree when Superset records no session id

### DIFF
--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -1153,6 +1153,10 @@ async function refreshProviderSessions(generation: number): Promise<void> {
     const message = error instanceof Error ? error.message : String(error);
     process.stderr.write(`Superset observation failed: ${message}\n`);
   }
+  // The fresh snapshot answers acts the drawn rows still advertise from
+  // before this pass's enrichment runs, so the directory matches enrichment
+  // made carry over, re-anchored to the worktrees just read.
+  supersetSnapshot.adoptDirectoryMatches(observedSupersetWorkspaces);
   observedSupersetWorkspaces = supersetSnapshot;
   observedSupersetOrganization = supersetOrganization;
   // Refreshed outside the read's own try so a failed pass hands the adapter

--- a/packages/providers/src/opencode/adapter.test.ts
+++ b/packages/providers/src/opencode/adapter.test.ts
@@ -268,6 +268,9 @@ test("observes an OpenCode session under the name OpenCode gave it", async (t) =
   assert.equal(observations[0]?.title, "Wire the notch geometry to the housing");
   assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
   assert.equal(observations[0]?.controls, undefined);
+  // The raw directory rides for workspace managers to match by; the bounded
+  // repository label below is what a surface draws.
+  assert.equal(observations[0]?.directory, "/Users/test/luke");
   assert.deepEqual(observations[0]?.detail, {
     repository: "luke",
     model: "claude-sonnet-5 · high",
@@ -741,6 +744,7 @@ test("observes legacy JSON sessions when no database exists", async (t) => {
   assert.equal(observations[0]?.providerSessionId, "ses_legacy");
   assert.equal(observations[0]?.title, "Migrate the settings store");
   assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
+  assert.equal(observations[0]?.directory, "/Users/test/luke");
   assert.deepEqual(observations[0]?.detail, { repository: "luke" });
 });
 

--- a/packages/providers/src/opencode/adapter.ts
+++ b/packages/providers/src/opencode/adapter.ts
@@ -400,6 +400,7 @@ function observationFromSnapshot(
       ? { completionCause: SESSION_COMPLETION_CAUSE.SESSION_CLOSED }
       : undefined),
     observedAt: refined.observedAt,
+    ...(snapshot.directory ? { directory: snapshot.directory } : undefined),
     detail: detailFromSnapshot(snapshot),
     ...(refined.holdingForDeveloper ? { holdingForDeveloper: true } : undefined),
   };

--- a/packages/session/src/session.ts
+++ b/packages/session/src/session.ts
@@ -381,6 +381,15 @@ export interface ProviderSessionObservation {
   /** Omitted by an adapter that reads sessions off this machine. */
   location?: SessionLocation;
   /**
+   * The working directory the provider itself recorded for a local session,
+   * as the absolute path it wrote. Identity for grouping only: a workspace
+   * manager that recorded no session id for a chat (Superset's OpenCode
+   * terminals today) can still claim the chat by the worktree both sides
+   * named independently. Never reported for a cloud session, and never
+   * drawn — the bounded `detail.repository` label is what a surface shows.
+   */
+  directory?: string;
+  /**
    * The agent having the conversation, when the session's provider hosts
    * agents rather than being one — a Conductor chat is a Claude Code or Codex
    * conversation before it is a Conductor one. Identity only: the provider

--- a/packages/superset/src/workspaces.test.ts
+++ b/packages/superset/src/workspaces.test.ts
@@ -8,6 +8,7 @@ import {
   PROVIDER_ID,
   SESSION_APPLICATION_ID,
   SESSION_APPLICATION_SCOPE,
+  SESSION_LOCATION,
   SESSION_STATUS,
 } from "@sidecar/session";
 import { SUPERSET_WORKSPACE_PROVIDER_ID } from "../../../apps/desktop/src/shared/contracts.js";
@@ -38,7 +39,8 @@ function createSchema(database: DatabaseSync): void {
       branch TEXT NOT NULL,
       updated_at INTEGER NOT NULL,
       type TEXT NOT NULL DEFAULT 'worktree',
-      archived_at INTEGER
+      archived_at INTEGER,
+      worktree_path TEXT
     );
     CREATE TABLE terminal_agent_bindings (
       terminal_id TEXT PRIMARY KEY,
@@ -171,6 +173,124 @@ test("binds Cursor's agents CLI under Superset's own name for it", async (t) => 
     ])[0]?.detail?.link,
     "superset://v2-workspace/workspace-1?terminalId=terminal-1",
   );
+});
+
+test("matches a chat Superset recorded no session id for by its worktree", async (t) => {
+  const home = await temporarySupersetHome(t);
+  const database = await writeHostDatabase(home, "host-local");
+  createSchema(database);
+  // Superset's own events for OpenCode never carry the agent's session id, so
+  // the binding row stands with agent_session_id NULL for the chat's whole
+  // life. The worktree path is what both sides recorded independently.
+  database.exec(`
+    INSERT INTO projects VALUES ('project-1', 'Luke');
+    INSERT INTO workspaces (id, project_id, pull_request_id, name, branch, updated_at, worktree_path) VALUES
+      ('workspace-1', 'project-1', NULL, 'parallel-hippopotamus', 'feat/grok-bot', 200,
+       '/Users/test/.superset/worktrees/repo-1/parallel-hippopotamus');
+    INSERT INTO host_agent_configs VALUES ('claude', 0), ('opencode', 1);
+    INSERT INTO terminal_agent_bindings VALUES (
+      'terminal-1', 'workspace-1', 'opencode', NULL, 'Start'
+    );
+  `);
+  database.close();
+
+  const snapshot = await new SupersetWorkspaceReader({ homeDirectory: home }).read();
+  const observation = {
+    providerSessionId: "ses_grok",
+    title: "Add Grok Bot support",
+    status: SESSION_STATUS.WAITING,
+    observedAt: 100,
+    directory: "/Users/test/.superset/worktrees/repo-1/parallel-hippopotamus",
+  };
+
+  const enriched = snapshot.enrich(PROVIDER_ID.OPENCODE, [observation], "host-local")[0];
+  assert.deepEqual(enriched?.workspace, {
+    providerWorkspaceId: "workspace-1",
+    name: "parallel-hippopotamus",
+    scopeId: SUPERSET_WORKSPACE_PROVIDER_ID,
+    managerName: "Superset",
+  });
+  assert.deepEqual(enriched?.applications, [
+    {
+      id: SESSION_APPLICATION_ID.SUPERSET,
+      displayName: "Superset",
+      scope: SESSION_APPLICATION_SCOPE.WORKSPACE,
+      link: "superset://v2-workspace/workspace-1",
+    },
+  ]);
+  assert.equal(enriched?.detail?.link, "superset://v2-workspace/workspace-1");
+  assert.equal(enriched?.detail?.repository, "Luke");
+  assert.equal(enriched?.detail?.branch, "feat/grok-bot");
+  // No observed binding identifies the exact terminal this chat is behind, so
+  // a message has nowhere it can be known to land — the workspace-scoped acts
+  // still ride, because the workspace's identity is exactly known.
+  assert.equal(enriched?.canReceiveMessage, undefined);
+  assert.equal(enriched?.renameTarget, "workspace-1");
+  assert.deepEqual(enriched?.spawnableAgents, ["claude", "opencode"]);
+  assert.equal(enriched?.spawnTarget, "workspace-1");
+  assert.deepEqual(enriched?.controls, [
+    {
+      id: SUPERSET_CONTROL_ID.DELETE_WORKSPACE,
+      label: "Delete workspace",
+      target: "workspace-1",
+    },
+  ]);
+
+  // The act router resolves the matched chat against the same snapshot the
+  // advertisement rode, terminal-less like a chatless workspace row.
+  const context = snapshot.actableContext(PROVIDER_ID.OPENCODE, "ses_grok", "host-local");
+  assert.equal(context?.workspaceId, "workspace-1");
+  assert.equal(context?.terminalId, undefined);
+
+  // A chat somewhere else, or one a cloud provider holds under a
+  // coincidentally equal path, is never Superset's.
+  const elsewhere = snapshot.enrich(
+    PROVIDER_ID.OPENCODE,
+    [{ ...observation, providerSessionId: "ses_other", directory: "/Users/test/luke" }],
+    "host-local",
+  )[0];
+  assert.equal(elsewhere?.workspace, undefined);
+  const cloud = snapshot.enrich(
+    PROVIDER_ID.OPENCODE,
+    [{ ...observation, providerSessionId: "ses_cloud", location: SESSION_LOCATION.CLOUD }],
+    "host-local",
+  )[0];
+  assert.equal(cloud?.workspace, undefined);
+  assert.equal(snapshot.actableContext(PROVIDER_ID.OPENCODE, "ses_cloud", "host-local"), undefined);
+});
+
+test("path matching claims only live worktrees, never the main checkout or an archive", async (t) => {
+  const home = await temporarySupersetHome(t);
+  const database = await writeHostDatabase(home, "host-local");
+  createSchema(database);
+  database.exec(`
+    INSERT INTO workspaces (id, project_id, pull_request_id, name, branch, updated_at, type, archived_at, worktree_path) VALUES
+      ('workspace-main', NULL, NULL, 'main', 'main', 500, 'main', NULL, '/Users/test/luke'),
+      ('workspace-archived', NULL, NULL, 'filed-away', 'old', 400, 'worktree', 350,
+       '/Users/test/.superset/worktrees/repo-1/filed-away');
+  `);
+  database.close();
+
+  const snapshot = await new SupersetWorkspaceReader({ homeDirectory: home }).read();
+  for (const directory of [
+    "/Users/test/luke",
+    "/Users/test/.superset/worktrees/repo-1/filed-away",
+  ]) {
+    const enriched = snapshot.enrich(
+      PROVIDER_ID.OPENCODE,
+      [
+        {
+          providerSessionId: `ses_${directory}`,
+          title: "By hand",
+          status: SESSION_STATUS.WAITING,
+          observedAt: 100,
+          directory,
+        },
+      ],
+      "host-local",
+    )[0];
+    assert.equal(enriched?.workspace, undefined);
+  }
 });
 
 test("keeps the newest duplicate binding across host databases", async (t) => {

--- a/packages/superset/src/workspaces.test.ts
+++ b/packages/superset/src/workspaces.test.ts
@@ -259,6 +259,60 @@ test("matches a chat Superset recorded no session id for by its worktree", async
   assert.equal(snapshot.actableContext(PROVIDER_ID.OPENCODE, "ses_cloud", "host-local"), undefined);
 });
 
+test("carries directory matches into the next snapshot until enrichment re-decides", async (t) => {
+  const home = await temporarySupersetHome(t);
+  const database = await writeHostDatabase(home, "host-local");
+  createSchema(database);
+  database.exec(`
+    INSERT INTO workspaces (id, project_id, pull_request_id, name, branch, updated_at, worktree_path) VALUES
+      ('workspace-1', NULL, NULL, 'parallel-hippopotamus', 'feat/grok-bot', 200,
+       '/Users/test/.superset/worktrees/repo-1/parallel-hippopotamus');
+    INSERT INTO terminal_agent_bindings VALUES (
+      'terminal-1', 'workspace-1', 'opencode', NULL, 'Start'
+    );
+  `);
+  database.close();
+
+  const reader = new SupersetWorkspaceReader({ homeDirectory: home });
+  const observation = {
+    providerSessionId: "ses_grok",
+    title: "Add Grok Bot support",
+    status: SESSION_STATUS.WAITING,
+    observedAt: 100,
+    directory: "/Users/test/.superset/worktrees/repo-1/parallel-hippopotamus",
+  };
+  const first = await reader.read();
+  first.enrich(PROVIDER_ID.OPENCODE, [observation], "host-local");
+
+  // A drawn row keeps advertising its acts until the next enrichment pass
+  // commits, so the fresh snapshot must answer them before that pass runs.
+  const second = await reader.read();
+  assert.equal(second.actableContext(PROVIDER_ID.OPENCODE, "ses_grok", "host-local"), undefined);
+  second.adoptDirectoryMatches(first);
+  assert.equal(
+    second.actableContext(PROVIDER_ID.OPENCODE, "ses_grok", "host-local")?.workspaceId,
+    "workspace-1",
+  );
+
+  // The observation is the match's whole authority: a chat re-observed
+  // somewhere else loses the adopted entry on the same pass.
+  second.enrich(
+    PROVIDER_ID.OPENCODE,
+    [{ ...observation, directory: "/Users/test/elsewhere" }],
+    "host-local",
+  );
+  assert.equal(second.actableContext(PROVIDER_ID.OPENCODE, "ses_grok", "host-local"), undefined);
+
+  // A worktree gone from the latest read anchors nothing, however recently
+  // it was matched.
+  const archived = await writeHostDatabase(home, "host-local");
+  archived.exec("UPDATE workspaces SET archived_at = 300");
+  archived.close();
+  const third = await reader.read();
+  third.adoptDirectoryMatches(first);
+  assert.equal(third.actableContext(PROVIDER_ID.OPENCODE, "ses_grok", "host-local"), undefined);
+});
+
 test("path matching claims only live worktrees, never the main checkout or an archive", async (t) => {
   const home = await temporarySupersetHome(t);
   const database = await writeHostDatabase(home, "host-local");

--- a/packages/superset/src/workspaces.ts
+++ b/packages/superset/src/workspaces.ts
@@ -171,6 +171,11 @@ export interface SupersetSessionContext {
   branch?: string;
   pullRequestUrl?: string;
   spawnableAgents: readonly string[];
+  /**
+   * The worktree a directory-matched chat was anchored by, carried only on
+   * such matches so a fresh snapshot can re-anchor them against its own read.
+   */
+  worktreePath?: string;
 }
 
 /**
@@ -284,10 +289,12 @@ export class SupersetWorkspaceSnapshot {
   readonly #sessions = new Map<string, Map<string, SupersetSessionContext>>();
   readonly #worktreesByPath = new Map<string, SupersetSessionContext>();
   /**
-   * The chats this snapshot matched by worktree path, remembered under the
-   * chat's own identity so the act router resolves an act against the exact
-   * context its advertisement rode — the same lifetime an id-recorded
-   * context has, since the snapshot itself is replaced every pass.
+   * The chats matched by worktree path, remembered under the chat's own
+   * identity so the act router resolves an act against the same context its
+   * advertisement rode. Every enrich pass rewrites a chat's entry from its
+   * latest observation — confirming, moving, or dropping it — and a fresh
+   * snapshot adopts its predecessor's entries so the acts a drawn row still
+   * advertises keep resolving between the snapshot standing and that pass.
    */
   readonly #directoryMatches = new Map<string, Map<string, SupersetSessionContext>>();
 
@@ -332,22 +339,66 @@ export class SupersetWorkspaceSnapshot {
     providerId: string,
     observation: ProviderSessionObservation,
   ): SupersetSessionContext | undefined {
-    const recorded = this.context(providerId, observation.providerSessionId);
+    const recorded = this.#sessions.get(providerId)?.get(observation.providerSessionId);
     if (recorded) return recorded;
-    if (observation.location === SESSION_LOCATION.CLOUD || !observation.directory) {
+    // The observation is the match's whole authority, so it is re-decided
+    // here from the observation alone, never read back from the remembered
+    // entry: a chat that moved directories or stopped reporting one loses
+    // its entry on the same pass.
+    const worktree =
+      observation.location !== SESSION_LOCATION.CLOUD && observation.directory
+        ? this.#worktreesByPath.get(observation.directory)
+        : undefined;
+    if (!worktree) {
+      this.#directoryMatches.get(providerId)?.delete(observation.providerSessionId);
       return undefined;
     }
-    const worktree = this.#worktreesByPath.get(observation.directory);
-    if (!worktree) return undefined;
+    return this.#rememberDirectoryMatch(
+      providerId,
+      observation.providerSessionId,
+      worktree,
+      observation.directory ?? "",
+    );
+  }
+
+  #rememberDirectoryMatch(
+    providerId: string,
+    providerSessionId: string,
+    worktree: SupersetSessionContext,
+    worktreePath: string,
+  ): SupersetSessionContext {
     const context: SupersetSessionContext = {
       ...worktree,
       providerId,
-      providerSessionId: observation.providerSessionId,
+      providerSessionId,
+      worktreePath,
     };
     const matches = this.#directoryMatches.get(providerId) ?? new Map();
-    matches.set(observation.providerSessionId, context);
+    matches.set(providerSessionId, context);
     this.#directoryMatches.set(providerId, matches);
     return context;
+  }
+
+  /**
+   * Carries the previous snapshot's directory matches into this one, each
+   * re-anchored to this snapshot's own read: an entry survives only while
+   * the same worktree still stands, and is rebuilt from that worktree's
+   * fresh fields. Without this, an act pressed between this snapshot
+   * standing and the next enrich pass would find nothing behind the
+   * advertisement the drawn row still carries; the workspace-scoped acts an
+   * adopted entry resolves stay honest either way, because they act on the
+   * workspace whose worktree was just re-read, not on the chat.
+   */
+  adoptDirectoryMatches(previous: SupersetWorkspaceSnapshot): void {
+    for (const [providerId, matches] of previous.#directoryMatches) {
+      for (const [providerSessionId, match] of matches) {
+        const worktree = match.worktreePath
+          ? this.#worktreesByPath.get(match.worktreePath)
+          : undefined;
+        if (!worktree || !match.worktreePath) continue;
+        this.#rememberDirectoryMatch(providerId, providerSessionId, worktree, match.worktreePath);
+      }
+    }
   }
 
   actableContext(

--- a/packages/superset/src/workspaces.ts
+++ b/packages/superset/src/workspaces.ts
@@ -14,6 +14,7 @@ import {
   type ProviderSessionObservation,
   SESSION_APPLICATION_ID,
   SESSION_APPLICATION_SCOPE,
+  SESSION_LOCATION,
   SESSION_STATUS,
 } from "@sidecar/session";
 import { type WireRecord, wireRecord } from "@sidecar/wire";
@@ -110,6 +111,34 @@ const SUPERSET_CHATLESS_WORKSPACE_QUERY = `
       SELECT 1 FROM terminal_agent_bindings
       WHERE terminal_agent_bindings.workspace_id = workspaces.id
     )
+`;
+
+/**
+ * Every worktree a chat could be running in without Superset having recorded
+ * which chat it is. Superset's own events for some agents (OpenCode today)
+ * never carry the agent's session id, so the binding row says only that an
+ * agent of that kind ran somewhere in the workspace. The worktree path is the
+ * one thing both sides wrote down independently — Superset when it made the
+ * worktree, the agent's own record of the directory it ran in — so it is what
+ * a chat with no recorded id is matched by. Only the worktree shape
+ * qualifies: a main checkout is the user's own working copy, where an agent
+ * run by hand would be branded Superset's by nothing more than sharing the
+ * folder.
+ */
+const SUPERSET_WORKTREE_DIRECTORY_QUERY = `
+  SELECT
+    workspaces.id AS workspace_id,
+    workspaces.name AS workspace_name,
+    workspaces.worktree_path,
+    workspaces.branch,
+    workspaces.updated_at,
+    projects.name AS project_name,
+    pull_requests.url AS pull_request_url
+  FROM workspaces
+  LEFT JOIN projects ON projects.id = workspaces.project_id
+  LEFT JOIN pull_requests ON pull_requests.id = workspaces.pull_request_id
+  WHERE workspaces.type = 'worktree'
+    AND workspaces.archived_at IS NULL
 `;
 
 /**
@@ -230,10 +259,42 @@ function contextFromWorkspaceRow(
   return context;
 }
 
+/**
+ * A workspace offered for matching by its worktree path: the same
+ * workspace-shaped, terminal-less context a chatless row carries, keyed by
+ * the directory a chat Superset recorded no session id for would be
+ * running in.
+ */
+export interface SupersetWorktreeContext {
+  worktreePath: string;
+  context: SupersetSessionContext;
+}
+
+function worktreeContextFromRow(
+  organizationId: string,
+  row: WireRecord,
+  spawnableAgents: readonly string[],
+): SupersetWorktreeContext | undefined {
+  const worktreePath = textFromRow(row, "worktree_path");
+  const context = contextFromWorkspaceRow(organizationId, row, spawnableAgents);
+  return worktreePath && context ? { worktreePath, context } : undefined;
+}
+
 export class SupersetWorkspaceSnapshot {
   readonly #sessions = new Map<string, Map<string, SupersetSessionContext>>();
+  readonly #worktreesByPath = new Map<string, SupersetSessionContext>();
+  /**
+   * The chats this snapshot matched by worktree path, remembered under the
+   * chat's own identity so the act router resolves an act against the exact
+   * context its advertisement rode — the same lifetime an id-recorded
+   * context has, since the snapshot itself is replaced every pass.
+   */
+  readonly #directoryMatches = new Map<string, Map<string, SupersetSessionContext>>();
 
-  constructor(contexts: readonly SupersetSessionContext[]) {
+  constructor(
+    contexts: readonly SupersetSessionContext[],
+    worktrees: readonly SupersetWorktreeContext[] = [],
+  ) {
     for (const context of contexts) {
       const provider = this.#sessions.get(context.providerId) ?? new Map();
       const existing = provider.get(context.providerSessionId);
@@ -242,10 +303,51 @@ export class SupersetWorkspaceSnapshot {
       }
       this.#sessions.set(context.providerId, provider);
     }
+    for (const worktree of worktrees) {
+      const existing = this.#worktreesByPath.get(worktree.worktreePath);
+      if (!existing || existing.updatedAt < worktree.context.updatedAt) {
+        this.#worktreesByPath.set(worktree.worktreePath, worktree.context);
+      }
+    }
   }
 
   context(providerId: string, providerSessionId: string): SupersetSessionContext | undefined {
-    return this.#sessions.get(providerId)?.get(providerSessionId);
+    return (
+      this.#sessions.get(providerId)?.get(providerSessionId) ??
+      this.#directoryMatches.get(providerId)?.get(providerSessionId)
+    );
+  }
+
+  /**
+   * The recorded context for a chat, or the worktree standing in for one
+   * Superset never recorded: a local chat whose provider wrote down the same
+   * directory Superset made a live worktree at is that workspace's chat, even
+   * though the binding row carries no session id to say which. The match
+   * earns everything the workspace's own identity carries — the grouping and
+   * the workspace-scoped acts — but no terminal, because no observed binding
+   * identifies the exact terminal this chat is behind, and a message must
+   * land on the chat it was typed at.
+   */
+  #contextFor(
+    providerId: string,
+    observation: ProviderSessionObservation,
+  ): SupersetSessionContext | undefined {
+    const recorded = this.context(providerId, observation.providerSessionId);
+    if (recorded) return recorded;
+    if (observation.location === SESSION_LOCATION.CLOUD || !observation.directory) {
+      return undefined;
+    }
+    const worktree = this.#worktreesByPath.get(observation.directory);
+    if (!worktree) return undefined;
+    const context: SupersetSessionContext = {
+      ...worktree,
+      providerId,
+      providerSessionId: observation.providerSessionId,
+    };
+    const matches = this.#directoryMatches.get(providerId) ?? new Map();
+    matches.set(observation.providerSessionId, context);
+    this.#directoryMatches.set(providerId, matches);
+    return context;
   }
 
   actableContext(
@@ -263,7 +365,7 @@ export class SupersetWorkspaceSnapshot {
     activeOrganizationId?: string,
   ): readonly ProviderSessionObservation[] {
     return observations.map((observation) => {
-      const context = this.context(providerId, observation.providerSessionId);
+      const context = this.#contextFor(providerId, observation);
       if (!context) return observation;
       const detail = { ...observation.detail };
       if (context.projectName) detail.repository = context.projectName;
@@ -425,24 +527,28 @@ export class SupersetWorkspaceReader {
   async read(): Promise<SupersetWorkspaceSnapshot> {
     const hostDirectory = path.join(this.#homeDirectory, "host");
     const entries = await readDirectory(hostDirectory);
-    const contexts = (
-      await Promise.all(
-        entries
-          .filter((entry) => entry.isDirectory())
-          .map((entry) =>
-            this.#readOrganization(entry.name, path.join(hostDirectory, entry.name, "host.db")),
-          ),
-      )
-    ).flat();
-    return new SupersetWorkspaceSnapshot(contexts);
+    const organizations = await Promise.all(
+      entries
+        .filter((entry) => entry.isDirectory())
+        .map((entry) =>
+          this.#readOrganization(entry.name, path.join(hostDirectory, entry.name, "host.db")),
+        ),
+    );
+    return new SupersetWorkspaceSnapshot(
+      organizations.flatMap((organization) => organization.contexts),
+      organizations.flatMap((organization) => organization.worktrees),
+    );
   }
 
   async #readOrganization(
     organizationId: string,
     databasePath: string,
-  ): Promise<readonly SupersetSessionContext[]> {
+  ): Promise<{
+    contexts: readonly SupersetSessionContext[];
+    worktrees: readonly SupersetWorktreeContext[];
+  }> {
     const database = await openReadOnlyDatabase(this.#sqlite, databasePath);
-    if (!database) return [];
+    if (!database) return { contexts: [], worktrees: [] };
     try {
       const spawnableAgents = database
         .prepare(SUPERSET_AGENT_QUERY)
@@ -462,12 +568,45 @@ export class SupersetWorkspaceReader {
           const context = contextFromRow(organizationId, row, spawnableAgents);
           return context ? [context] : [];
         });
-      return [...bound, ...this.#chatlessWorkspaces(database, organizationId, spawnableAgents)];
+      return {
+        contexts: [
+          ...bound,
+          ...this.#chatlessWorkspaces(database, organizationId, spawnableAgents),
+        ],
+        worktrees: this.#worktreeDirectories(database, organizationId, spawnableAgents),
+      };
     } catch (error) {
-      if (error instanceof Error && canIgnoreSqliteError(error)) return [];
+      if (error instanceof Error && canIgnoreSqliteError(error))
+        return { contexts: [], worktrees: [] };
       throw error;
     } finally {
       database.close();
+    }
+  }
+
+  /**
+   * Read behind its own guard like the chatless rows: a host database from a
+   * Superset without the worktree columns loses only the path matching, never
+   * the chats whose session ids Superset did record.
+   */
+  #worktreeDirectories(
+    database: SqliteDatabase,
+    organizationId: string,
+    spawnableAgents: readonly string[],
+  ): readonly SupersetWorktreeContext[] {
+    try {
+      return database
+        .prepare(SUPERSET_WORKTREE_DIRECTORY_QUERY)
+        .all()
+        .flatMap((value) => {
+          const row = wireRecord(value);
+          if (!row) return [];
+          const worktree = worktreeContextFromRow(organizationId, row, spawnableAgents);
+          return worktree ? [worktree] : [];
+        });
+    } catch (error) {
+      if (error instanceof Error && canIgnoreSqliteError(error)) return [];
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Problem

OpenCode chats running inside Superset were never detected: their sessions drew plain ungrouped OpenCode rows, and the Superset workspace holding them drew nothing at all.

Root cause, verified against a real \`~/.superset/host/*/host.db\`: Superset's own events for OpenCode never carry the agent's session id, so its \`terminal_agent_bindings\` rows keep \`agent_session_id\` NULL for the chat's whole life (Claude and \`cursor-agent\` rows record one; both observed \`opencode\` rows never do, even after a Stop event). Luke's binding query filters \`WHERE agent_session_id IS NOT NULL\`, so every OpenCode chat fell out — and because the bindings still exist, the workspace was excluded from the chatless rows too.

## Fix

The worktree path is the one thing both sides wrote down independently — Superset when it made the worktree (\`workspaces.worktree_path\`), and OpenCode's own session record of the directory it ran in (verified to match exactly on a real machine). So:

- The OpenCode adapter now reports each local session's recorded working directory on its observation (a new optional \`directory\` field on \`ProviderSessionObservation\`, identity for grouping only — the bounded \`detail.repository\` label remains what the surface draws).
- The Superset reader also reads every live worktree's path (non-archived, \`type = 'worktree'\` only — never the main checkout, where a by-hand chat would be branded Superset's by nothing more than sharing the folder), behind its own schema guard like the chatless rows.
- \`SupersetWorkspaceSnapshot.enrich\` falls back to matching a local chat by that path when Superset recorded no session id. The match earns the workspace's grouping, detail, deep link, and workspace-scoped acts (rename, spawn, delete-on-settled), and is remembered under the chat's identity so the act router resolves against the same snapshot the advertisement rode. It never advertises a message: no observed binding identifies the exact terminal such a chat is behind, and a message must land on the chat it was typed at.

Cloud rows and chats in other directories are never matched; a host database without the worktree columns loses only the path matching, never the id-recorded chats.

## Testing

- \`./scripts/check.sh\` passes (portable-only change; exit 0).
- New tests: path matching end-to-end (grouping, acts, no \`canReceiveMessage\`, act-router resolution), and non-claims for the main checkout, archived worktrees, other directories, and cloud rows.
- Root cause and path equality verified against the real Superset host database and OpenCode database on a machine exhibiting the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/514d1e08-3a68-4569-b9a7-f17c6de8ab01)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32452476623/artifacts/9436157781) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32452476623)

- Commit: `63c019b3ec2ad451f79b74567526943d50ce60c4`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
