### PR TITLE
feat(gemini-cli): merge the observation hook into Gemini's settings.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,9 +121,10 @@ Trust constraints:
   product decision, not an implementation detail.
 - One registration is the exception the previous rule's word "require" leaves
   room for, and it is bounded on every side: Luke may merge an observation
-  hook into a provider's own user-level hook configuration (today Claude
-  Code's `settings.json` and the `hooks.json` of Codex and Cursor, and nothing
-  else of any provider's) so local rows can tell a turn that just ended from a session
+  hook into a provider's own user-level hook configuration (today the
+  `settings.json` of Claude Code and Gemini CLI and the `hooks.json` of Codex
+  and Cursor, and nothing else of any provider's) so local rows can tell a
+  turn that just ended from a session
   walked away from, and can see a tool call holding for permission at all. The
   hook itself writes one fixed status token into a spool under Luke's own
   application data, named by the session's id; the envelope the provider hands

--- a/packages/providers/src/gemini-cli/adapter.test.ts
+++ b/packages/providers/src/gemini-cli/adapter.test.ts
@@ -739,3 +739,41 @@ test("a spool that cannot be read costs only the refinement", async (t) => {
 
   assert.equal(observation?.status, SESSION_STATUS.WORKING);
 });
+
+test("a prompt event never clears the hold the recording already shows", async (t) => {
+  const geminiHome = await temporaryGeminiHome(t);
+  const spool = await temporaryHookSpool(t);
+  await writeSessionFile(
+    geminiHome,
+    "luke",
+    "session-2026-08-20T11-00-abcd1234",
+    [
+      metadataRecord(FULL_SESSION_ID, "2026-08-20T11:00:00.000Z"),
+      geminiMessage("m1", "2026-08-20T11:59:58.000Z", {
+        toolCalls: [
+          {
+            id: "t1",
+            name: "write_file",
+            args: { file_path: "/Users/test/luke/README.md" },
+            status: "awaiting_approval",
+            timestamp: "2026-08-20T11:59:58.000Z",
+          },
+        ],
+      }),
+    ],
+    TEST_TIME - 1_000,
+  );
+  // The prompt opened the very turn now holding, so it stands newer than the
+  // record — and must still lose to it.
+  await writeHookEvent(spool, FULL_SESSION_ID, "prompt", TEST_TIME - 1_000);
+
+  const adapter = new GeminiCliSessionAdapter({
+    geminiHome,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WAITING);
+  assert.equal(observation?.holdingForDeveloper, true);
+});

--- a/packages/providers/src/gemini-cli/adapter.test.ts
+++ b/packages/providers/src/gemini-cli/adapter.test.ts
@@ -3,7 +3,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test, { type TestContext } from "node:test";
-import { SESSION_STATUS, UNKNOWN_WORKSPACE_LABEL } from "@sidecar/session";
+import {
+  SESSION_COMPLETION_CAUSE,
+  SESSION_STATUS,
+  UNKNOWN_WORKSPACE_LABEL,
+} from "@sidecar/session";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
 import { GEMINI_CLI_PROVIDER, GeminiCliSessionAdapter } from "./adapter.js";
 
@@ -467,4 +471,271 @@ test("answers every write as unsupported", async (t) => {
     "unsupported",
   );
   assert.equal(adapter.workspaceProjects().length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Hook-event refinement. Every test here layers a spool the observation hook
+// would have written over a recording, because that is the arrangement in
+// production: the tail is always read, and the event only sharpens it. The
+// spool is keyed by the full session id the recording's metadata line names,
+// never by the file stem the adapter reports as `providerSessionId`.
+// ---------------------------------------------------------------------------
+
+const FULL_SESSION_ID = "abcd1234-4d5e-6789-abcd-ef0123456789";
+
+async function temporaryHookSpool(t: TestContext): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-gemini-spool-"));
+  t.after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  return directory;
+}
+
+async function writeHookEvent(
+  spoolDirectory: string,
+  sessionId: string,
+  event: string,
+  mtimeMs: number,
+): Promise<void> {
+  const filePath = path.join(spoolDirectory, `${sessionId}.json`);
+  await fs.writeFile(filePath, JSON.stringify({ event }));
+  await fs.utimes(filePath, mtimeMs / 1000, mtimeMs / 1000);
+}
+
+/** A recording mid-turn: the reply reached for a tool that has not returned. */
+function midTurnRecords(timestamp: string): ParsedJsonObject[] {
+  return [
+    metadataRecord(FULL_SESSION_ID, "2026-08-20T11:00:00.000Z"),
+    geminiMessage("m1", timestamp, {
+      toolCalls: [
+        {
+          id: "t1",
+          name: "run_shell_command",
+          args: { command: "pnpm test" },
+          status: "executing",
+          timestamp,
+        },
+      ],
+    }),
+  ];
+}
+
+/** A recording whose last turn settled cleanly. */
+function settledRecords(timestamp: string): ParsedJsonObject[] {
+  return [
+    metadataRecord(FULL_SESSION_ID, "2026-08-20T11:00:00.000Z"),
+    geminiMessage("m1", timestamp),
+  ];
+}
+
+test("a session-end event completes a row nothing in the recording could settle", async (t) => {
+  const geminiHome = await temporaryGeminiHome(t);
+  const spool = await temporaryHookSpool(t);
+  await writeSessionFile(
+    geminiHome,
+    "luke",
+    "session-2026-08-20T11-00-abcd1234",
+    settledRecords("2026-08-20T11:40:00.000Z"),
+    TEST_TIME - 5 * 60 * 1000,
+  );
+  await writeHookEvent(spool, FULL_SESSION_ID, "session-end", TEST_TIME - 60_000);
+
+  const adapter = new GeminiCliSessionAdapter({
+    geminiHome,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.COMPLETE);
+  assert.equal(observation?.completionCause, SESSION_COMPLETION_CAUSE.SESSION_CLOSED);
+  // The event also dates the session: the spool is written only by Luke's own
+  // script, so its clock cannot suffer the recordings' bulk-touch problem.
+  assert.equal(observation?.observedAt, TEST_TIME - 60_000);
+});
+
+test("a permission prompt the tail has not written yet turns the row to waiting", async (t) => {
+  const geminiHome = await temporaryGeminiHome(t);
+  const spool = await temporaryHookSpool(t);
+  // Mid-turn by every record: the CLI can hold a confirmation before the
+  // awaiting call reaches the recording, so without the event this session
+  // reads as working.
+  await writeSessionFile(
+    geminiHome,
+    "luke",
+    "session-2026-08-20T11-00-abcd1234",
+    midTurnRecords("2026-08-20T11:40:00.000Z"),
+    TEST_TIME - 5 * 60 * 1000,
+  );
+  await writeHookEvent(spool, FULL_SESSION_ID, "notification", TEST_TIME - 60_000);
+
+  const adapter = new GeminiCliSessionAdapter({
+    geminiHome,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WAITING);
+  assert.equal(observation?.holdingForDeveloper, true);
+  assert.equal(observation?.observedAt, TEST_TIME - 60_000);
+});
+
+test("a stop event keeps a finished turn waiting past the freshness decay", async (t) => {
+  const geminiHome = await temporaryGeminiHome(t);
+  const spool = await temporaryHookSpool(t);
+  // Twenty minutes past the last record, the tail alone decays to unknown.
+  await writeSessionFile(
+    geminiHome,
+    "luke",
+    "session-2026-08-20T11-00-abcd1234",
+    settledRecords("2026-08-20T11:40:00.000Z"),
+    TEST_TIME - 20 * 60 * 1000,
+  );
+  await writeHookEvent(spool, FULL_SESSION_ID, "stop", TEST_TIME - 60_000);
+
+  const adapter = new GeminiCliSessionAdapter({
+    activeSessionFreshnessMs: 15 * 60 * 1000,
+    geminiHome,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WAITING);
+});
+
+test("an event the conversation has moved past refines nothing", async (t) => {
+  const geminiHome = await temporaryGeminiHome(t);
+  const spool = await temporaryHookSpool(t);
+  await writeSessionFile(
+    geminiHome,
+    "luke",
+    "session-2026-08-20T11-00-abcd1234",
+    midTurnRecords("2026-08-20T11:59:00.000Z"),
+    TEST_TIME - 60_000,
+  );
+  // A stop from a minute before the conversation's last record: hooks were
+  // off, or the write raced. The session is demonstrably mid-turn again.
+  await writeHookEvent(spool, FULL_SESSION_ID, "stop", TEST_TIME - 2 * 60 * 1000);
+
+  const adapter = new GeminiCliSessionAdapter({
+    geminiHome,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WORKING);
+  assert.equal(observation?.observedAt, Date.parse("2026-08-20T11:59:00.000Z"));
+});
+
+test("a notification the conversation has answered stands down at once", async (t) => {
+  const geminiHome = await temporaryGeminiHome(t);
+  const spool = await temporaryHookSpool(t);
+  // The permission was granted and the tool ran: a record newer than the
+  // notification, though within the tolerance the other events enjoy.
+  await writeSessionFile(
+    geminiHome,
+    "luke",
+    "session-2026-08-20T11-00-abcd1234",
+    midTurnRecords("2026-08-20T11:59:59.000Z"),
+    TEST_TIME - 1_000,
+  );
+  await writeHookEvent(spool, FULL_SESSION_ID, "notification", TEST_TIME - 3_000);
+
+  const adapter = new GeminiCliSessionAdapter({
+    geminiHome,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WORKING);
+});
+
+test("a stop event does not unsay an error the CLI recorded", async (t) => {
+  const geminiHome = await temporaryGeminiHome(t);
+  const spool = await temporaryHookSpool(t);
+  await writeSessionFile(
+    geminiHome,
+    "luke",
+    "session-2026-08-20T11-00-abcd1234",
+    [
+      metadataRecord(FULL_SESSION_ID, "2026-08-20T11:00:00.000Z"),
+      { id: "m1", type: "error", timestamp: "2026-08-20T11:59:00.000Z", content: "Quota exceeded" },
+    ],
+    TEST_TIME - 60_000,
+  );
+  await writeHookEvent(spool, FULL_SESSION_ID, "stop", TEST_TIME - 59_000);
+
+  const adapter = new GeminiCliSessionAdapter({
+    geminiHome,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.ERROR);
+});
+
+test("the spool joins on the metadata line's full id, never the file stem", async (t) => {
+  const geminiHome = await temporaryGeminiHome(t);
+  const spool = await temporaryHookSpool(t);
+  await writeSessionFile(
+    geminiHome,
+    "stemmed",
+    "session-2026-08-20T11-00-abcd1234",
+    settledRecords("2026-08-20T11:40:00.000Z"),
+    TEST_TIME - 5 * 60 * 1000,
+  );
+  // A recording whose slice carries no metadata line offers nothing to join.
+  await writeSessionFile(
+    geminiHome,
+    "unnamed",
+    "session-2026-08-20T11-00-00000000",
+    [geminiMessage("m1", "2026-08-20T11:59:00.000Z")],
+    TEST_TIME - 60_000,
+  );
+  await writeHookEvent(
+    spool,
+    "session-2026-08-20T11-00-abcd1234",
+    "session-end",
+    TEST_TIME - 60_000,
+  );
+  await writeHookEvent(spool, FULL_SESSION_ID, "session-end", TEST_TIME - 60_000);
+
+  const adapter = new GeminiCliSessionAdapter({
+    geminiHome,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const observations = await adapter.observe();
+  const byId = new Map(
+    observations.map((observation) => [observation.providerSessionId, observation]),
+  );
+
+  assert.equal(byId.get("session-2026-08-20T11-00-abcd1234")?.status, SESSION_STATUS.COMPLETE);
+  assert.equal(byId.get("session-2026-08-20T11-00-00000000")?.status, SESSION_STATUS.WAITING);
+  assert.equal(byId.get("session-2026-08-20T11-00-00000000")?.completionCause, undefined);
+});
+
+test("a spool that cannot be read costs only the refinement", async (t) => {
+  const geminiHome = await temporaryGeminiHome(t);
+  await writeSessionFile(
+    geminiHome,
+    "luke",
+    "session-2026-08-20T11-00-abcd1234",
+    midTurnRecords("2026-08-20T11:59:00.000Z"),
+    TEST_TIME - 60_000,
+  );
+
+  const adapter = new GeminiCliSessionAdapter({
+    geminiHome,
+    hookEventsDirectory: () => path.join(geminiHome, "no-such-spool"),
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WORKING);
 });

--- a/packages/providers/src/gemini-cli/adapter.ts
+++ b/packages/providers/src/gemini-cli/adapter.ts
@@ -4,6 +4,7 @@ import {
   maximumSessionTitleLength,
   PROVIDER_ID,
   type ProviderSessionObservation,
+  SESSION_COMPLETION_CAUSE,
   SESSION_STATUS,
   type SessionDetail,
   type SessionProvider,
@@ -12,10 +13,13 @@ import {
 import { isRecord, isWireString, oneLine, text, type WireRecord } from "@sidecar/wire";
 import {
   discoverSessionFiles,
+  type HookStatusRefinement,
+  hookRefinedStatus,
   LOCAL_ADAPTER_DEFAULTS,
   LocalFileSessionAdapter,
   localSessionStatus,
   readDirectory,
+  readHead,
   readTail,
   readTextFile,
   type SessionFileCandidate,
@@ -24,6 +28,7 @@ import {
   tailRecords,
   workspaceLabel,
 } from "../shared/local-session-adapter.js";
+import { GEMINI_HOOK_EVENT, type GeminiHookEvent, readGeminiHookEvent } from "./hooks.js";
 import {
   defaultGeminiCliHome,
   GEMINI_CHATS_DIRECTORY,
@@ -60,6 +65,8 @@ const GEMINI_LEGACY_HASH_DIRECTORY_PATTERN = /^[0-9a-f]{64}$/;
 const GEMINI_ADAPTER_DEFAULTS = {
   MAXIMUM_PROJECT_DIRECTORIES: 200,
   MAXIMUM_ACTIVITY_LENGTH: 80,
+  /** Enough of a recording's start to hold its one opening metadata line. */
+  READ_HEAD_BYTES: 16 * 1024,
 } as const;
 
 export const GEMINI_CLI_PROVIDER: SessionProvider = {
@@ -72,6 +79,14 @@ export interface GeminiCliAdapterOptions {
   now?: () => number;
   activeSessionFreshnessMs?: number;
   transcriptMaximumRenderedLength?: number;
+  /**
+   * Where the observation hook spools its events, when hooks are on at all.
+   * Read lazily like the cloud adapters' credentials, because the app decides
+   * the path after this adapter is declared. Absent — or answering nothing —
+   * the adapter reads the recordings alone, exactly as it always has: the
+   * hooks only ever sharpen what the tail already showed.
+   */
+  hookEventsDirectory?: () => string | undefined;
 }
 
 function timestampMsFrom(record: WireRecord): number | undefined {
@@ -121,6 +136,8 @@ function conversationClockMs(records: readonly WireRecord[]): number | undefined
  */
 interface ParsedGeminiSessionTail {
   summary?: string;
+  /** The full id the opening metadata line names, keying the hook spool. */
+  sessionId?: string;
   model?: string;
   timestampMs?: number;
   tipType?: string;
@@ -206,8 +223,9 @@ export function parseGeminiSessionTail(tail: string): ParsedGeminiSessionTail {
  * cannot: a reply holding a call for permission — or one whose calls all
  * settled — is holding for the developer, and one with a call still open is
  * working. A killed process leaves an open call on disk forever, so an open
- * turn gone quiet is unknown rather than still working. Nothing on disk marks
- * a session closed, so a local Gemini session is never complete.
+ * turn gone quiet is unknown rather than still working. Nothing in the
+ * recording marks a session closed, so the tail alone never reports a local
+ * Gemini session complete; the hook's own `session-end` is what can.
  */
 function statusFromTail(
   parsed: ParsedGeminiSessionTail,
@@ -221,6 +239,38 @@ function statusFromTail(
     (parsed.holdingForApproval === true || parsed.toolCallsOpen !== true);
   const status = settled ? SESSION_STATUS.WAITING : SESSION_STATUS.WORKING;
   return localSessionStatus(status, observedAt, now, freshnessMs);
+}
+
+/**
+ * What the refinement buys here is what the recording cannot say: the
+ * `session-end` token is the one thing that can ever report a local Gemini
+ * session complete, a notification marks a hold the moment it starts rather
+ * than when the awaiting call reaches the tail, and a stop keeps a settled
+ * turn waiting past the freshness decay.
+ */
+const GEMINI_HOOK_STATUS_REFINEMENT = {
+  definitive: [{ event: GEMINI_HOOK_EVENT.SESSION_END, fresh: SESSION_STATUS.COMPLETE }],
+  fresh: [
+    { event: GEMINI_HOOK_EVENT.PROMPT, fresh: SESSION_STATUS.WORKING },
+    { event: GEMINI_HOOK_EVENT.STOP, fresh: SESSION_STATUS.WAITING },
+    { event: GEMINI_HOOK_EVENT.NOTIFICATION, fresh: SESSION_STATUS.WAITING },
+  ],
+  notificationEvent: GEMINI_HOOK_EVENT.NOTIFICATION,
+  sessionEndEvent: GEMINI_HOOK_EVENT.SESSION_END,
+} as const satisfies HookStatusRefinement<GeminiHookEvent>;
+
+/**
+ * The session's full id, from the metadata line the CLI writes once as a
+ * recording opens. The file's own name truncates the id to eight characters,
+ * but the hook envelope names sessions whole, so this line is the one join
+ * between the spool and the recording it refines.
+ */
+function sessionIdFromHead(head: string): string | undefined {
+  for (const record of tailRecords(head)) {
+    const sessionId = text(record.sessionId);
+    if (sessionId) return sessionId;
+  }
+  return undefined;
 }
 
 /**
@@ -296,8 +346,9 @@ function workspaceFrom(projectRoot: string | undefined, projectDirectory: string
 /**
  * Observes the Gemini CLI sessions on this machine from the recordings the
  * CLI already writes for itself: the append-only JSONL files under its own
- * per-project chats directories. It runs no server, needs no credential,
- * registers no hook, and opens everything read-only.
+ * per-project chats directories. It runs no server, needs no credential, and
+ * opens everything read-only; the observation hook registered beside it only
+ * ever sharpens what those recordings already showed.
  */
 export class GeminiCliSessionAdapter extends LocalFileSessionAdapter<
   GeminiSessionFileCandidate,
@@ -307,6 +358,7 @@ export class GeminiCliSessionAdapter extends LocalFileSessionAdapter<
 
   readonly #geminiHome: string;
   readonly #transcriptMaximumRenderedLength: number | undefined;
+  readonly #hookEventsDirectory: (() => string | undefined) | undefined;
   /** What each project's marker named, refreshed every pass and never grown past it. */
   #projectRoots = new Map<string, string | undefined>();
 
@@ -314,6 +366,7 @@ export class GeminiCliSessionAdapter extends LocalFileSessionAdapter<
     super(options);
     this.#geminiHome = options.geminiHome ?? defaultGeminiCliHome();
     this.#transcriptMaximumRenderedLength = options.transcriptMaximumRenderedLength;
+    this.#hookEventsDirectory = options.hookEventsDirectory;
   }
 
   protected discover(): Promise<GeminiSessionFileCandidate[]> {
@@ -340,17 +393,25 @@ export class GeminiCliSessionAdapter extends LocalFileSessionAdapter<
   }
 
   protected async parse(candidate: GeminiSessionFileCandidate): Promise<ParsedGeminiSessionTail> {
-    return parseGeminiSessionTail(
+    const parsed = parseGeminiSessionTail(
       await readTail(candidate.filePath, LOCAL_ADAPTER_DEFAULTS.READ_TAIL_BYTES),
     );
+    // The head is read only where a spool could answer for it: the full id
+    // matters to nothing else this adapter reports.
+    if (this.#hookEventsDirectory !== undefined) {
+      parsed.sessionId = sessionIdFromHead(
+        await readHead(candidate.filePath, GEMINI_ADAPTER_DEFAULTS.READ_HEAD_BYTES),
+      );
+    }
+    return parsed;
   }
 
-  protected observation(
+  protected async observation(
     candidate: GeminiSessionFileCandidate,
     parsed: ParsedGeminiSessionTail,
     now: number,
     activeSessionFreshnessMs: number,
-  ): ProviderSessionObservation {
+  ): Promise<ProviderSessionObservation> {
     const workspace = workspaceFrom(
       this.#projectRoots.get(candidate.projectDirectory),
       candidate.projectDirectory,
@@ -359,18 +420,34 @@ export class GeminiCliSessionAdapter extends LocalFileSessionAdapter<
     // summary bookkeeping to old sessions at later startups, bumping their
     // mtimes the way any bulk touch would. The file's date remains the
     // fallback for a slice holding no conversation stamp at all.
-    const observedAt = parsed.timestampMs ?? candidate.mtimeMs;
-    const status = statusFromTail(parsed, observedAt, now, activeSessionFreshnessMs);
+    const conversationAt = parsed.timestampMs ?? candidate.mtimeMs;
+    const hookEventsDirectory = this.#hookEventsDirectory?.();
+    const hookEvent =
+      hookEventsDirectory !== undefined && parsed.sessionId !== undefined
+        ? await readGeminiHookEvent(hookEventsDirectory, parsed.sessionId).catch(() => undefined)
+        : undefined;
+    const refined = hookRefinedStatus({
+      refinement: GEMINI_HOOK_STATUS_REFINEMENT,
+      hookEvent,
+      providerAtMs: conversationAt,
+      statusAt: (observedAt) => statusFromTail(parsed, observedAt, now, activeSessionFreshnessMs),
+      now,
+      activeSessionFreshnessMs,
+    });
+    const holdingForDeveloper =
+      refined.holdingForDeveloper ||
+      (refined.status === SESSION_STATUS.WAITING && parsed.holdingForApproval === true);
     return {
       providerSessionId: candidate.providerSessionId,
       title: titleFromTail(parsed, workspace),
-      status,
-      observedAt,
+      status: refined.status,
+      ...(refined.sessionClosed
+        ? { completionCause: SESSION_COMPLETION_CAUSE.SESSION_CLOSED }
+        : undefined),
+      observedAt: refined.observedAt,
       ...(parsed.recap ? { recap: parsed.recap } : undefined),
       detail: detailFromTail(parsed, workspace),
-      ...(status === SESSION_STATUS.WAITING && parsed.holdingForApproval === true
-        ? { holdingForDeveloper: true }
-        : undefined),
+      ...(holdingForDeveloper ? { holdingForDeveloper: true } : undefined),
     };
   }
 

--- a/packages/providers/src/gemini-cli/adapter.ts
+++ b/packages/providers/src/gemini-cli/adapter.ts
@@ -426,9 +426,16 @@ export class GeminiCliSessionAdapter extends LocalFileSessionAdapter<
       hookEventsDirectory !== undefined && parsed.sessionId !== undefined
         ? await readGeminiHookEvent(hookEventsDirectory, parsed.sessionId).catch(() => undefined)
         : undefined;
+    // A prompt event always precedes the reply it opened, so a tip already
+    // holding a call for approval has outrun it: the hold stands rather than
+    // reading as busy for the tolerance window before the notification lands.
+    const standingHookEvent =
+      hookEvent?.event === GEMINI_HOOK_EVENT.PROMPT && parsed.holdingForApproval === true
+        ? undefined
+        : hookEvent;
     const refined = hookRefinedStatus({
       refinement: GEMINI_HOOK_STATUS_REFINEMENT,
-      hookEvent,
+      hookEvent: standingHookEvent,
       providerAtMs: conversationAt,
       statusAt: (observedAt) => statusFromTail(parsed, observedAt, now, activeSessionFreshnessMs),
       now,

--- a/packages/providers/src/gemini-cli/hooks.test.ts
+++ b/packages/providers/src/gemini-cli/hooks.test.ts
@@ -1,0 +1,438 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test, { type TestContext } from "node:test";
+import { promisify } from "node:util";
+import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import {
+  type ObservationHookInstallation,
+  pruneObservationHookSpool,
+} from "../shared/hook-merge.js";
+import {
+  GEMINI_HOOK_EVENT,
+  GEMINI_HOOK_SCRIPT_NAME,
+  installGeminiObservationHooks,
+  readGeminiHookEvent,
+  removeGeminiObservationHooks,
+} from "./hooks.js";
+
+const execFileAsync = promisify(execFile);
+
+const TEST_TIME = Date.parse("2026-08-20T20:15:00.000Z");
+const TEST_SESSION_ID = "9c2e4d6a-1b3f-4a5c-8d7e-000000000000";
+const SECRET_ENVELOPE_TEXT = "SECRET_ENVELOPE_TEXT";
+const GEMINI_SETTINGS_FILE_NAME = "settings.json";
+
+// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+/** Every lifecycle event the build registers, as settings.json names them. */
+const REGISTERED_EVENT_NAMES = [
+  "SessionStart",
+  "BeforeAgent",
+  "AfterAgent",
+  "Notification",
+  "SessionEnd",
+] as const;
+
+async function temporaryInstallation(t: TestContext): Promise<ObservationHookInstallation> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-gemini-hooks-"));
+  t.after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  const providerHome = path.join(directory, "gemini-home");
+  await fs.mkdir(providerHome, { recursive: true });
+  return {
+    providerHome,
+    hookScriptPath: path.join(directory, "luke-data", GEMINI_HOOK_SCRIPT_NAME),
+    spoolDirectory: path.join(directory, "luke-data", "events"),
+  };
+}
+
+function settingsPath(installation: ObservationHookInstallation): string {
+  return path.join(installation.providerHome, GEMINI_SETTINGS_FILE_NAME);
+}
+
+async function readSettings(installation: ObservationHookInstallation): Promise<ParsedJsonObject> {
+  return JSON.parse(await fs.readFile(settingsPath(installation), "utf8"));
+}
+
+function hookEntries(settings: ParsedJsonObject, eventName: string): unknown[] {
+  // SAFETY: Parsed JSON matches the event object shape this harness exercises.
+  const events = settings.hooks as ParsedJsonObject;
+  const entries = events[eventName];
+  return Array.isArray(entries) ? entries : [];
+}
+
+function innerHooks(entries: unknown[]): { command?: unknown; timeout?: unknown }[] {
+  return entries.flatMap((entry) => {
+    // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+    const hooks = (entry as { hooks?: { command?: unknown; timeout?: unknown }[] }).hooks;
+    return Array.isArray(hooks) ? hooks : [];
+  });
+}
+
+function entryCommands(entries: unknown[]): string[] {
+  return innerHooks(entries)
+    .map((hook) => hook.command)
+    .filter(
+      (command): command is string => Object.prototype.toString.call(command) === "[object String]",
+    );
+}
+
+/**
+ * Runs the installed script the way Gemini CLI would: the event as its one
+ * argument, the envelope as JSON on stdin, and stdout read back as the hook's
+ * JSON answer.
+ */
+async function pipeToHookScript(
+  installation: ObservationHookInstallation,
+  eventArgument: string,
+  envelope: string,
+): Promise<string> {
+  const envelopeFile = path.join(path.dirname(installation.hookScriptPath), "envelope.json");
+  await fs.writeFile(envelopeFile, envelope, "utf8");
+  const { stdout } = await execFileAsync("sh", [
+    "-c",
+    `"${installation.hookScriptPath}" "${eventArgument}" < "${envelopeFile}"`,
+  ]);
+  await fs.rm(envelopeFile, { force: true });
+  return stdout;
+}
+
+test("registers every lifecycle event beside the user's own settings", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.writeFile(
+    settingsPath(installation),
+    JSON.stringify({
+      theme: "Default",
+      hooks: {
+        AfterAgent: [{ hooks: [{ type: "command", command: "afplay /System/done.aiff" }] }],
+      },
+    }),
+  );
+
+  await installGeminiObservationHooks(installation);
+
+  const settings = await readSettings(installation);
+  // The user's own setting and hook both survive the merge untouched.
+  assert.equal(settings.theme, "Default");
+  const afterAgentCommands = entryCommands(hookEntries(settings, "AfterAgent"));
+  assert.ok(afterAgentCommands.includes("afplay /System/done.aiff"));
+  for (const eventName of REGISTERED_EVENT_NAMES) {
+    const commands = entryCommands(hookEntries(settings, eventName)).filter((command) =>
+      command.includes(GEMINI_HOOK_SCRIPT_NAME),
+    );
+    assert.equal(commands.length, 1, `${eventName} carries exactly one Luke entry`);
+    // Guarded on the script's own presence, and the fallback drains the piped
+    // envelope and answers the empty decision, because Gemini CLI reads
+    // stdout as the hook's JSON answer.
+    assert.ok(commands[0]?.startsWith(`[ -x "${installation.hookScriptPath}" ]`));
+    assert.ok(commands[0]?.endsWith(`|| { cat >/dev/null 2>&1; printf '{}'; }`));
+  }
+  // Gemini CLI documents the entry timeout in milliseconds, not seconds.
+  const timeouts = innerHooks(hookEntries(settings, "AfterAgent"))
+    .filter((hook) => String(hook.command).includes(GEMINI_HOOK_SCRIPT_NAME))
+    .map((hook) => hook.timeout);
+  assert.deepEqual(timeouts, [10_000]);
+  // The one documented notification kind is the hold itself, so the entry
+  // carries no matcher to narrow it.
+  const notificationEntry = hookEntries(settings, "Notification").find((entry) =>
+    entryCommands([entry]).some((command) => command.includes(GEMINI_HOOK_SCRIPT_NAME)),
+  );
+  // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+  assert.equal("matcher" in (notificationEntry as ParsedJsonObject), false);
+
+  const script = await fs.readFile(installation.hookScriptPath, "utf8");
+  assert.ok(script.includes(installation.spoolDirectory));
+  const mode = (await fs.stat(installation.hookScriptPath)).mode & 0o777;
+  assert.equal(mode, 0o755);
+});
+
+test("creates the settings file for a Gemini home that has none yet", async (t) => {
+  const installation = await temporaryInstallation(t);
+
+  await installGeminiObservationHooks(installation);
+
+  const settings = await readSettings(installation);
+  assert.equal(entryCommands(hookEntries(settings, "AfterAgent")).length, 1);
+});
+
+test("touches nothing on a machine with no Gemini home at all", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.rm(installation.providerHome, { recursive: true, force: true });
+
+  await installGeminiObservationHooks(installation);
+
+  // No provider directory is created on the provider's behalf, and no script
+  // or spool is staged for sessions that cannot exist.
+  await assert.rejects(fs.stat(installation.providerHome));
+  await assert.rejects(fs.stat(installation.hookScriptPath));
+  await assert.rejects(fs.stat(installation.spoolDirectory));
+});
+
+// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+test("leaves a settings file it cannot parse exactly as it was", async (t) => {
+  const installation = await temporaryInstallation(t);
+  const corrupt = "{ this is not json";
+  await fs.writeFile(settingsPath(installation), corrupt);
+
+  await installGeminiObservationHooks(installation);
+
+  assert.equal(await fs.readFile(settingsPath(installation), "utf8"), corrupt);
+});
+
+test("converges rather than accumulates: reinstalling changes nothing", async (t) => {
+  const installation = await temporaryInstallation(t);
+
+  await installGeminiObservationHooks(installation);
+  const first = await fs.readFile(settingsPath(installation), "utf8");
+  await installGeminiObservationHooks(installation);
+
+  assert.equal(await fs.readFile(settingsPath(installation), "utf8"), first);
+});
+
+test("reconciles entries an older build registered under another path", async (t) => {
+  const installation = await temporaryInstallation(t);
+  const staleCommand = `/old/data/${GEMINI_HOOK_SCRIPT_NAME} stop`;
+  await fs.writeFile(
+    settingsPath(installation),
+    JSON.stringify({
+      hooks: {
+        AfterAgent: [{ hooks: [{ type: "command", command: staleCommand }] }],
+        // An event this build no longer registers is cleaned up too.
+        BeforeTool: [{ matcher: "*", hooks: [{ type: "command", command: staleCommand }] }],
+      },
+    }),
+  );
+
+  await installGeminiObservationHooks(installation);
+
+  const settings = await readSettings(installation);
+  const afterAgentCommands = entryCommands(hookEntries(settings, "AfterAgent")).filter((command) =>
+    command.includes(GEMINI_HOOK_SCRIPT_NAME),
+  );
+  assert.equal(afterAgentCommands.length, 1);
+  assert.ok(!afterAgentCommands[0]?.includes("/old/data/"));
+  assert.equal(hookEntries(settings, "BeforeTool").length, 0);
+});
+
+test("removal strips Luke's entries and leaves the user's hooks standing", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.writeFile(
+    settingsPath(installation),
+    JSON.stringify({
+      theme: "Default",
+      hooks: {
+        AfterAgent: [{ hooks: [{ type: "command", command: "afplay /System/done.aiff" }] }],
+      },
+    }),
+  );
+  await installGeminiObservationHooks(installation);
+
+  await removeGeminiObservationHooks(installation);
+
+  const settings = await readSettings(installation);
+  assert.equal(settings.theme, "Default");
+  assert.deepEqual(entryCommands(hookEntries(settings, "AfterAgent")), [
+    "afplay /System/done.aiff",
+  ]);
+  for (const eventName of REGISTERED_EVENT_NAMES) {
+    const lukeCommands = entryCommands(hookEntries(settings, eventName)).filter((command) =>
+      command.includes(GEMINI_HOOK_SCRIPT_NAME),
+    );
+    assert.equal(lukeCommands.length, 0, `${eventName} carries no Luke entry after removal`);
+  }
+  await assert.rejects(fs.stat(installation.hookScriptPath));
+  await assert.rejects(fs.stat(installation.spoolDirectory));
+});
+
+test("removal drops the hooks container once nothing of the user's remains", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await installGeminiObservationHooks(installation);
+
+  await removeGeminiObservationHooks(installation);
+
+  const settings = await readSettings(installation);
+  assert.equal("hooks" in settings, false);
+});
+
+test("removal never creates a settings file", async (t) => {
+  const installation = await temporaryInstallation(t);
+
+  await removeGeminiObservationHooks(installation);
+
+  await assert.rejects(fs.stat(settingsPath(installation)));
+});
+
+test("the script writes one fixed token named by the session, and nothing else", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await installGeminiObservationHooks(installation);
+  const envelope = JSON.stringify({
+    session_id: TEST_SESSION_ID,
+    transcript_path: `/somewhere/chats/session-2026-08-20T20-14-9c2e4d6a.jsonl`,
+    hook_event_name: "AfterAgent",
+    prompt: SECRET_ENVELOPE_TEXT,
+  });
+
+  const answer = await pipeToHookScript(installation, GEMINI_HOOK_EVENT.STOP, envelope);
+
+  // Gemini CLI reads stdout as the hook's JSON answer; observing decides
+  // nothing, so the answer is the empty decision.
+  assert.equal(answer, "{}");
+  const spooled = await fs.readFile(
+    path.join(installation.spoolDirectory, `${TEST_SESSION_ID}.json`),
+    "utf8",
+  );
+  // The whole file is the fixed token: the envelope's text never reaches disk.
+  assert.equal(spooled, '{"event":"stop"}');
+  for (const entry of await fs.readdir(installation.spoolDirectory)) {
+    const content = await fs.readFile(path.join(installation.spoolDirectory, entry), "utf8");
+    assert.ok(!content.includes(SECRET_ENVELOPE_TEXT));
+  }
+});
+
+test("a later event replaces the earlier one", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await installGeminiObservationHooks(installation);
+  const envelope = JSON.stringify({ session_id: TEST_SESSION_ID });
+
+  await pipeToHookScript(installation, GEMINI_HOOK_EVENT.STOP, envelope);
+  await pipeToHookScript(installation, GEMINI_HOOK_EVENT.PROMPT, envelope);
+
+  const spooled = await fs.readFile(
+    path.join(installation.spoolDirectory, `${TEST_SESSION_ID}.json`),
+    "utf8",
+  );
+  assert.equal(spooled, '{"event":"prompt"}');
+});
+
+test("the script refuses a token the build never registered", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await installGeminiObservationHooks(installation);
+
+  const answer = await pipeToHookScript(
+    installation,
+    "made-up-event",
+    JSON.stringify({ session_id: TEST_SESSION_ID }),
+  );
+
+  assert.equal(answer, "{}");
+  assert.deepEqual(await fs.readdir(installation.spoolDirectory), []);
+});
+
+test("the script refuses a session id outside the shape Gemini CLI mints", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await installGeminiObservationHooks(installation);
+
+  const answer = await pipeToHookScript(
+    installation,
+    GEMINI_HOOK_EVENT.STOP,
+    JSON.stringify({ session_id: "../../../etc/passwd" }),
+  );
+
+  assert.equal(answer, "{}");
+  assert.deepEqual(await fs.readdir(installation.spoolDirectory), []);
+});
+
+test("the script is silent once the spool is gone", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await installGeminiObservationHooks(installation);
+  await fs.rm(installation.spoolDirectory, { recursive: true, force: true });
+
+  const answer = await pipeToHookScript(
+    installation,
+    GEMINI_HOOK_EVENT.STOP,
+    JSON.stringify({ session_id: TEST_SESSION_ID }),
+  );
+
+  assert.equal(answer, "{}");
+  await assert.rejects(fs.stat(installation.spoolDirectory));
+});
+
+test("reads the spooled event back with the file's own clock", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.mkdir(installation.spoolDirectory, { recursive: true });
+  const filePath = path.join(installation.spoolDirectory, `${TEST_SESSION_ID}.json`);
+  await fs.writeFile(filePath, '{"event":"session-end"}');
+  await fs.utimes(filePath, TEST_TIME / 1000, TEST_TIME / 1000);
+
+  const event = await readGeminiHookEvent(installation.spoolDirectory, TEST_SESSION_ID);
+
+  assert.equal(event?.event, GEMINI_HOOK_EVENT.SESSION_END);
+  assert.equal(event?.atMs, TEST_TIME);
+});
+
+test("reads nothing from a missing, foreign, or oversized spool file", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.mkdir(installation.spoolDirectory, { recursive: true });
+  const write = (name: string, content: string) =>
+    fs.writeFile(path.join(installation.spoolDirectory, `${name}.json`), content);
+  await write("unknown-token", '{"event":"reboot"}');
+  await write("not-json", "not json at all");
+  await write("oversized", `{"event":"stop","padding":"${"x".repeat(512)}"}`);
+
+  assert.equal(await readGeminiHookEvent(installation.spoolDirectory, "absent"), undefined);
+  assert.equal(await readGeminiHookEvent(installation.spoolDirectory, "unknown-token"), undefined);
+  assert.equal(await readGeminiHookEvent(installation.spoolDirectory, "not-json"), undefined);
+  assert.equal(await readGeminiHookEvent(installation.spoolDirectory, "oversized"), undefined);
+});
+
+test("pruning drops only the events past the observation window", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.mkdir(installation.spoolDirectory, { recursive: true });
+  const dayMs = 24 * 60 * 60 * 1000;
+  const freshPath = path.join(installation.spoolDirectory, "fresh.json");
+  const stalePath = path.join(installation.spoolDirectory, "stale.json");
+  await fs.writeFile(freshPath, '{"event":"stop"}');
+  await fs.writeFile(stalePath, '{"event":"stop"}');
+  await fs.utimes(freshPath, (TEST_TIME - 60_000) / 1000, (TEST_TIME - 60_000) / 1000);
+  await fs.utimes(stalePath, (TEST_TIME - 2 * dayMs) / 1000, (TEST_TIME - 2 * dayMs) / 1000);
+
+  await pruneObservationHookSpool(installation.spoolDirectory, dayMs, TEST_TIME);
+
+  await fs.stat(freshPath);
+  await assert.rejects(fs.stat(stalePath));
+});
+
+test("removal leaves a file with no Luke entries byte-for-byte alone", async (t) => {
+  const installation = await temporaryInstallation(t);
+  // Formatted unlike anything this module writes: compact, no trailing line.
+  const foreign =
+    '{"hooks":{"AfterAgent":[{"hooks":[{"type":"command","command":"afplay /a.aiff"}]}]}}';
+  await fs.writeFile(settingsPath(installation), foreign);
+
+  await removeGeminiObservationHooks(installation);
+
+  assert.equal(await fs.readFile(settingsPath(installation), "utf8"), foreign);
+});
+
+test("the settings write keeps the file's own mode and leaves no debris", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.writeFile(settingsPath(installation), "{}\n", { mode: 0o600 });
+  await fs.chmod(settingsPath(installation), 0o600);
+
+  await installGeminiObservationHooks(installation);
+
+  // The rename replaced the file, and the user's own protection rode along.
+  assert.equal((await fs.stat(settingsPath(installation))).mode & 0o777, 0o600);
+  const leftovers = (await fs.readdir(installation.providerHome)).filter((name) =>
+    name.includes(".luke-tmp"),
+  );
+  assert.deepEqual(leftovers, []);
+});
+
+test("the settings write lands through a symlink rather than replacing it", async (t) => {
+  const installation = await temporaryInstallation(t);
+  // A dotfiles-managed home: settings.json is a link into a synced store.
+  const syncedPath = path.join(installation.providerHome, "synced-settings.json");
+  await fs.writeFile(syncedPath, "{}\n");
+  await fs.symlink(syncedPath, settingsPath(installation));
+
+  await installGeminiObservationHooks(installation);
+
+  const linked = await fs.lstat(settingsPath(installation));
+  assert.ok(linked.isSymbolicLink(), "the link survives the write");
+  const synced = JSON.parse(await fs.readFile(syncedPath, "utf8"));
+  assert.equal(entryCommands(hookEntries(synced, "AfterAgent")).length, 1);
+});

--- a/packages/providers/src/gemini-cli/hooks.ts
+++ b/packages/providers/src/gemini-cli/hooks.ts
@@ -1,0 +1,88 @@
+import {
+  HOOK_ENTRY_NESTING,
+  type ObservationHookSpec,
+  type ObservedHookEvent,
+  observationHooksFor,
+} from "../shared/hook-merge.js";
+
+/**
+ * Gemini CLI's observation hooks, described for the shared machinery in
+ * `hook-merge.ts`. Gemini CLI keeps user-level hooks under the `hooks` key of
+ * `~/.gemini/settings.json` — honoring the same `GEMINI_CLI_HOME` override its
+ * transcripts do, so the registration and the adapter observe one install —
+ * with entries nested the way Claude Code's are, and it pipes a registered
+ * command its envelope as JSON on stdin. The CLI reads the hook's stdout as
+ * its JSON answer, so the script replies with the empty decision on every
+ * path out, and its entry timeout is documented in milliseconds where Claude
+ * Code's is seconds.
+ *
+ * The envelope's `session_id` is the session's full id, but the CLI names the
+ * recording the adapter observes by a timestamp and that id's first eight
+ * characters, so the spool file cannot land under the adapter's own
+ * `providerSessionId`. The recording's opening metadata line carries the same
+ * full id, and the adapter joins the spool to the recording there.
+ *
+ * The agent events fire only from the CLI's own main loop — a subagent's
+ * turns run through the chat layer beneath the one that fires hooks — so the
+ * envelope carries no subagent field and needs none skipped.
+ */
+
+/**
+ * The script's name is also the marker a managed entry is recognized by, so
+ * renaming it is a migration: an entry naming the old script would stop being
+ * recognized as ours and would be left behind.
+ */
+export const GEMINI_HOOK_SCRIPT_NAME = "luke-gemini-observation-hook.sh";
+
+/** How long Gemini CLI lets the spool write run before giving up on it. */
+const GEMINI_HOOK_TIMEOUT_MILLISECONDS = 10_000;
+
+/**
+ * The tokens the script may write, fixed at registration: each hook entry
+ * passes its own token as the script's one argument, so nothing in the
+ * envelope Gemini CLI pipes in can choose what lands in the spool.
+ */
+export const GEMINI_HOOK_EVENT = {
+  SESSION_START: "session-start",
+  PROMPT: "prompt",
+  STOP: "stop",
+  NOTIFICATION: "notification",
+  SESSION_END: "session-end",
+} as const;
+
+export type GeminiHookEvent = (typeof GEMINI_HOOK_EVENT)[keyof typeof GEMINI_HOOK_EVENT];
+
+/** The latest thing the hook reported about one session, dated by the spool. */
+export type ObservedGeminiHookEvent = ObservedHookEvent<GeminiHookEvent>;
+
+/**
+ * Which Gemini CLI lifecycle moments are registered, and the token each one
+ * hands the script: turn boundaries and lifecycle edges only, like every
+ * provider's. `Notification` fires for exactly one documented kind — a tool
+ * call holding for permission — so it is registered whole, with no matcher to
+ * narrow what is already the hold itself.
+ */
+const GEMINI_HOOK_SPEC: ObservationHookSpec<GeminiHookEvent> = {
+  scriptName: GEMINI_HOOK_SCRIPT_NAME,
+  configurationFileName: "settings.json",
+  scriptTitle: "Luke Gemini CLI observation hook v1",
+  registration: {
+    SessionStart: { event: GEMINI_HOOK_EVENT.SESSION_START },
+    BeforeAgent: { event: GEMINI_HOOK_EVENT.PROMPT },
+    AfterAgent: { event: GEMINI_HOOK_EVENT.STOP },
+    Notification: { event: GEMINI_HOOK_EVENT.NOTIFICATION },
+    SessionEnd: { event: GEMINI_HOOK_EVENT.SESSION_END },
+  },
+  timeoutMilliseconds: GEMINI_HOOK_TIMEOUT_MILLISECONDS,
+  sessionIdField: "session_id",
+  // The shape Gemini CLI mints: UUIDs, hex and hyphens.
+  sessionIdPattern: "[0-9a-fA-F-]{8,64}",
+  entryNesting: HOOK_ENTRY_NESTING.NESTED,
+  repliesWithJson: true,
+};
+
+const geminiHooks = observationHooksFor(GEMINI_HOOK_SPEC);
+
+export const installGeminiObservationHooks = geminiHooks.install;
+export const removeGeminiObservationHooks = geminiHooks.remove;
+export const readGeminiHookEvent = geminiHooks.read;

--- a/packages/providers/src/hook-registry.ts
+++ b/packages/providers/src/hook-registry.ts
@@ -5,6 +5,8 @@ import { defaultCodexHome } from "./codex/adapter.js";
 import { CODEX_HOOK_SCRIPT_NAME } from "./codex/hooks.js";
 import { CURSOR_HOOK_SCRIPT_NAME } from "./cursor/hooks.js";
 import { defaultCursorHome } from "./cursor/local-adapter.js";
+import { GEMINI_HOOK_SCRIPT_NAME } from "./gemini-cli/hooks.js";
+import { defaultGeminiCliHome } from "./gemini-cli/records.js";
 import type { ObservationHookInstallation } from "./shared/hook-merge.js";
 
 const SPOOL_DIRECTORY = "events";
@@ -30,6 +32,11 @@ const OBSERVATION_HOOK_PROVIDERS = {
     directoryName: "cursor-hooks",
     scriptName: CURSOR_HOOK_SCRIPT_NAME,
     providerHome: defaultCursorHome,
+  },
+  [PROVIDER_ID.GEMINI_CLI]: {
+    directoryName: "gemini-cli-hooks",
+    scriptName: GEMINI_HOOK_SCRIPT_NAME,
+    providerHome: defaultGeminiCliHome,
   },
 } as const;
 

--- a/packages/providers/src/registrations.test.ts
+++ b/packages/providers/src/registrations.test.ts
@@ -33,9 +33,9 @@ test("declares credentials and observation hooks beside their adapters", () => {
   assert.ok(registrations[PROVIDER_ID.CLAUDE_CODE].registerObservationHook instanceof Function);
   assert.ok(registrations[PROVIDER_ID.CODEX].registerObservationHook instanceof Function);
   assert.ok(registrations[PROVIDER_ID.CURSOR].registerObservationHook instanceof Function);
+  assert.ok(registrations[PROVIDER_ID.GEMINI_CLI].registerObservationHook instanceof Function);
   assert.equal("credential" in registrations[PROVIDER_ID.OPENCODE], false);
   assert.equal("credential" in registrations[PROVIDER_ID.GEMINI_CLI], false);
-  assert.equal("registerObservationHook" in registrations[PROVIDER_ID.GEMINI_CLI], false);
 });
 
 test("every registration exposes the one total adapter interface", () => {

--- a/packages/providers/src/registrations.ts
+++ b/packages/providers/src/registrations.ts
@@ -23,6 +23,7 @@ import { CursorLocalSessionAdapter } from "./cursor/local-adapter.js";
 import { DEVIN_PROVIDER, DevinSessionAdapter } from "./devin/adapter.js";
 import { DevinLocalSessionAdapter } from "./devin/local-adapter.js";
 import { GeminiCliSessionAdapter } from "./gemini-cli/adapter.js";
+import { installGeminiObservationHooks } from "./gemini-cli/hooks.js";
 import type { ObservationHookProviderId } from "./hook-registry.js";
 import { JulesSessionAdapter } from "./jules/adapter.js";
 import { OpenCodeSessionAdapter } from "./opencode/adapter.js";
@@ -77,6 +78,7 @@ export function providerRegistrations(options: ProviderRegistrationOptions) {
   const claudeInstallation = hookInstallation(PROVIDER_ID.CLAUDE_CODE);
   const codexInstallation = hookInstallation(PROVIDER_ID.CODEX);
   const cursorInstallation = hookInstallation(PROVIDER_ID.CURSOR);
+  const geminiInstallation = hookInstallation(PROVIDER_ID.GEMINI_CLI);
   const claude = new ClaudeCodeSessionAdapter({
     hookEventsDirectory: () => claudeInstallation().spoolDirectory,
   });
@@ -155,7 +157,16 @@ export function providerRegistrations(options: ProviderRegistrationOptions) {
       adapter: devin,
       credential: CREDENTIAL_PROVIDERS[CREDENTIAL_PROVIDER_ID.DEVIN],
     },
-    [PROVIDER_ID.GEMINI_CLI]: { adapter: new GeminiCliSessionAdapter() },
+    [PROVIDER_ID.GEMINI_CLI]: {
+      adapter: new GeminiCliSessionAdapter({
+        hookEventsDirectory: () => geminiInstallation().spoolDirectory,
+      }),
+      registerObservationHook: observationHookRegistration(
+        installGeminiObservationHooks,
+        geminiInstallation,
+        now,
+      ),
+    },
     [PROVIDER_ID.JULES]: {
       adapter: new JulesSessionAdapter({
         readApiKey: () => options.readApiKey(CREDENTIAL_PROVIDER_ID.JULES),

--- a/packages/providers/src/shared/hook-merge.ts
+++ b/packages/providers/src/shared/hook-merge.ts
@@ -95,6 +95,13 @@ export interface ObservationHookSpec<Event extends string> {
    * for a provider whose entries take a timeout at all.
    */
   timeoutSeconds?: number;
+  /**
+   * The same bound for a provider whose configuration documents the entry
+   * timeout in milliseconds (Gemini CLI) rather than seconds. Both land on
+   * the same `timeout` key — only the provider knows its unit — so a spec
+   * declares exactly one of the two.
+   */
+  timeoutMilliseconds?: number;
   /** The envelope field naming the session the event belongs to. */
   sessionIdField: string;
   /**
@@ -330,7 +337,8 @@ function registrationEntry<Event extends string>(
     registration.event,
     spec.repliesWithJson === true,
   );
-  const timeout = spec.timeoutSeconds !== undefined ? { timeout: spec.timeoutSeconds } : undefined;
+  const timeoutValue = spec.timeoutSeconds ?? spec.timeoutMilliseconds;
+  const timeout = timeoutValue !== undefined ? { timeout: timeoutValue } : undefined;
   if (spec.entryNesting === HOOK_ENTRY_NESTING.FLAT) {
     return { ...matcher, command, ...timeout };
   }


### PR DESCRIPTION
Local Gemini CLI sessions gain the sharper statuses Claude Code, Codex, and Cursor rows already have: a fresh turn-end versus a session walked away from, a tool call holding for permission the moment it starts, and — the biggest win — a closed session reading COMPLETE with `completionCause: SESSION_CLOSED`, the first way a local Gemini session can ever read complete at all.

## What Gemini's real behavior says (verified against docs and source)

- **Entry schema**: user-level hooks live under the `hooks` key of `~/.gemini/settings.json`, entries nested exactly like Claude Code's (`matcher?` + `hooks: [{type: "command", command, timeout?}]`). `name` is optional for command hooks, so no spec extension for it. The entry **timeout is milliseconds** (default 60000), where Claude Code's is seconds — `ObservationHookSpec` grows one `timeoutMilliseconds` field beside `timeoutSeconds`, landing on the same `timeout` key.
- **Home**: Gemini CLI answers `GEMINI_CLI_HOME` before the OS home and joins `.gemini` onto whichever answered — exactly what `defaultGeminiCliHome()` already resolves, so the hook registry reuses it and the registration and the adapter observe the same install. Hooks are on by default (`enableHooks ?? true` in `config.ts`).
- **Events**: `SessionStart`, `BeforeAgent` (→ `prompt`), `AfterAgent` (→ `stop`), `SessionEnd` (→ `session-end`) all confirmed. **`Notification` is registered mapped to `notification`**: `NotificationType` has exactly one member, `ToolPermission`, and `hookSystem.ts`'s `fireToolNotificationEvent` fires it precisely when a tool call awaits user confirmation — the event *is* the hold, so it carries no matcher because there is nothing broader to narrow away.
- **The session-id join**: the envelope's `session_id` is the full session id, but `chatRecordingService.ts` names the recording `session-<timestamp>-<first 8 chars>.jsonl` — so the spool **cannot** be keyed by the adapter's `providerSessionId` (the file stem). The recording's opening metadata line carries the full `sessionId`, so the spool is keyed by the full id and the adapter joins through a bounded `readHead` of that line (the same shape as Claude's title-from-head read). A recording whose slice carries no metadata line simply takes no refinement.
- **stdout**: Gemini reads the hook's stdout as its JSON answer on exit 0, so `repliesWithJson: true` — the script and the guard's fallback both print the empty decision `{}` on every path out.
- **Subagents**: the envelope defines no subagent field, and none is needed — `local-executor.ts` drives `GeminiChat.sendMessageStream` directly, beneath the `GeminiClient` layer where `BeforeAgent`/`AfterAgent` fire, so subagent turns cannot flap a row. `subagentField` is honestly omitted.

## Adapter interplay

The transcript's own `awaiting_approval` detection stays the fallback hold signal; the hook's `notification` adds the zero-tolerance moment-of-hold (and stands down the instant a newer record answers it, per `hookRefinedStatus`). `holdingForDeveloper` is the union of both. `session-end` is the sole definitive event — Gemini's tail can already say ERROR itself and is never talked out of it.

## Repo obligations

- The CLAUDE.md trust-constraint sentence is widened deliberately and exactly: "today the `settings.json` of Claude Code and Gemini CLI and the `hooks.json` of Codex and Cursor, and nothing else of any provider's".
- README agent table: unchanged — Gemini CLI's row already exists and hooks add no new capability column. PRIVACY.md: unchanged — the hook writes a fixed token into Luke's own spool on this machine; no new kind of data leaves the machine and no new third party receives anything.

## Tests

`gemini-cli/hooks.test.ts` mirrors the full Claude invariant suite (merge beside user entries, create-only-with-home, untouched unparseable files, convergence, stale-path reconciliation, removal semantics, one-token spool, refused unregistered tokens and malformed ids, silence once the spool is gone, mode/symlink preservation) plus Gemini-specific assertions: millisecond timeout on the entry, no Notification matcher, and the `{}` JSON answer on every path. `gemini-cli/adapter.test.ts` adds the refinement suite, including a test that the spool joins on the metadata line's full id and never the file stem.

`./scripts/check.sh` passes end to end (exit 0). Portable-only change; no macOS or UI surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d359791e-8c3b-424c-83eb-78b20ca9739c)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32447905166/artifacts/9434711556) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32447905166)

- Commit: `31a64098536841b1d7c0f50cad67dc4bdc038704`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
