### PR TITLE
feat(devin): merge the observation hook into Devin's hook configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,10 +122,11 @@ Trust constraints:
 - One registration is the exception the previous rule's word "require" leaves
   room for, and it is bounded on every side: Luke may join an observation
   hook to a provider's own user-level hook surface (today the `settings.json`
-  of Claude Code and Gemini CLI, the `hooks.json` of Codex and Cursor, and
-  OpenCode's plugin directory, and nothing else of any provider's) so local
-  rows can tell a turn that just ended from a session walked away from, and
-  can see a tool call holding for permission at all. The
+  of Claude Code and Gemini CLI, the `hooks.json` of Codex and Cursor,
+  Devin's `config.json`, and OpenCode's plugin directory, and nothing else of
+  any provider's) so local rows can tell a turn that just ended from a
+  session walked away from, and can see a tool call holding for permission at
+  all. The
   hook itself writes one fixed status token into a spool under Luke's own
   application data, named by the session's id; the envelope the provider hands
   it — piped in, passed as an argument, or handed over in process — is read

--- a/packages/providers/src/devin/hooks.test.ts
+++ b/packages/providers/src/devin/hooks.test.ts
@@ -1,0 +1,442 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test, { type TestContext } from "node:test";
+import { promisify } from "node:util";
+import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import {
+  type ObservationHookInstallation,
+  pruneObservationHookSpool,
+} from "../shared/hook-merge.js";
+import {
+  DEVIN_HOOK_EVENT,
+  DEVIN_HOOK_SCRIPT_NAME,
+  installDevinObservationHooks,
+  readDevinHookEvent,
+  removeDevinObservationHooks,
+} from "./hooks.js";
+
+const execFileAsync = promisify(execFile);
+
+const TEST_TIME = Date.parse("2026-08-11T23:45:00.000Z");
+/** The shape Devin mints: lowercase words joined by hyphens. */
+const TEST_SESSION_ID = "solid-rest";
+const SECRET_ENVELOPE_TEXT = "SECRET_ENVELOPE_TEXT";
+const DEVIN_CONFIGURATION_FILE_NAME = "config.json";
+
+// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+/** Every lifecycle event the build registers, as config.json names them. */
+const REGISTERED_EVENT_NAMES = [
+  "SessionStart",
+  "UserPromptSubmit",
+  "Stop",
+  "PermissionRequest",
+  "SessionEnd",
+] as const;
+
+async function temporaryInstallation(t: TestContext): Promise<ObservationHookInstallation> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-devin-hooks-"));
+  t.after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  const providerHome = path.join(directory, "devin-config-home");
+  await fs.mkdir(providerHome, { recursive: true });
+  return {
+    providerHome,
+    hookScriptPath: path.join(directory, "luke-data", DEVIN_HOOK_SCRIPT_NAME),
+    spoolDirectory: path.join(directory, "luke-data", "events"),
+  };
+}
+
+function configurationPath(installation: ObservationHookInstallation): string {
+  return path.join(installation.providerHome, DEVIN_CONFIGURATION_FILE_NAME);
+}
+
+async function readConfiguration(
+  installation: ObservationHookInstallation,
+): Promise<ParsedJsonObject> {
+  return JSON.parse(await fs.readFile(configurationPath(installation), "utf8"));
+}
+
+function hookEntries(configuration: ParsedJsonObject, eventName: string): unknown[] {
+  // SAFETY: Parsed JSON matches the event object shape this harness exercises.
+  const events = configuration.hooks as ParsedJsonObject;
+  const entries = events[eventName];
+  return Array.isArray(entries) ? entries : [];
+}
+
+function entryCommands(entries: unknown[]): string[] {
+  return entries.flatMap((entry) => {
+    // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+    const hooks = (entry as { hooks?: { command?: unknown }[] }).hooks;
+    if (!Array.isArray(hooks)) return [];
+    return hooks
+      .map((hook) => hook.command)
+      .filter(
+        (command): command is string =>
+          Object.prototype.toString.call(command) === "[object String]",
+      );
+  });
+}
+
+/**
+ * Runs the installed script the way Devin would: the event as its one
+ * argument, the envelope on stdin. `execFile` cannot feed stdin, so the
+ * envelope rides in from a file beside the script through `sh -c`.
+ */
+async function pipeToHookScript(
+  installation: ObservationHookInstallation,
+  eventArgument: string,
+  envelope: string,
+): Promise<void> {
+  const envelopeFile = path.join(path.dirname(installation.hookScriptPath), "envelope.json");
+  await fs.writeFile(envelopeFile, envelope, "utf8");
+  await execFileAsync("sh", [
+    "-c",
+    `"${installation.hookScriptPath}" "${eventArgument}" < "${envelopeFile}"`,
+  ]);
+  await fs.rm(envelopeFile, { force: true });
+}
+
+test("registers every lifecycle event beside the user's own configuration", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.writeFile(
+    configurationPath(installation),
+    JSON.stringify({
+      version: 1,
+      theme_mode: "dark",
+      hooks: {
+        Stop: [{ hooks: [{ type: "command", command: "afplay /System/done.aiff" }] }],
+      },
+    }),
+  );
+
+  await installDevinObservationHooks(installation);
+
+  const configuration = await readConfiguration(installation);
+  // The user's own settings and hook all survive the merge untouched.
+  assert.equal(configuration.theme_mode, "dark");
+  const stopCommands = entryCommands(hookEntries(configuration, "Stop"));
+  assert.ok(stopCommands.includes("afplay /System/done.aiff"));
+  for (const eventName of REGISTERED_EVENT_NAMES) {
+    const commands = entryCommands(hookEntries(configuration, eventName)).filter((command) =>
+      command.includes(DEVIN_HOOK_SCRIPT_NAME),
+    );
+    assert.equal(commands.length, 1, `${eventName} carries exactly one Luke entry`);
+    // Guarded on the script's own presence, so an entry outliving an
+    // uninstalled Luke is a no-op rather than a "not found" in every session.
+    assert.ok(commands[0]?.startsWith(`[ -x "${installation.hookScriptPath}" ]`));
+    assert.ok(commands[0]?.endsWith("|| true"));
+  }
+
+  const script = await fs.readFile(installation.hookScriptPath, "utf8");
+  assert.ok(script.includes(installation.spoolDirectory));
+  const mode = (await fs.stat(installation.hookScriptPath)).mode & 0o777;
+  assert.equal(mode, 0o755);
+});
+
+test("creates the configuration file for a Devin home that has none yet", async (t) => {
+  const installation = await temporaryInstallation(t);
+
+  await installDevinObservationHooks(installation);
+
+  const configuration = await readConfiguration(installation);
+  assert.equal(entryCommands(hookEntries(configuration, "Stop")).length, 1);
+  // A file being created gets the documented schema version beside the hooks.
+  assert.equal(configuration.version, 1);
+});
+
+test("the user's own schema version is never rewritten", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.writeFile(configurationPath(installation), JSON.stringify({ version: 2, hooks: {} }));
+
+  await installDevinObservationHooks(installation);
+
+  assert.equal((await readConfiguration(installation)).version, 2);
+});
+
+test("touches nothing on a machine with no Devin home at all", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.rm(installation.providerHome, { recursive: true, force: true });
+
+  await installDevinObservationHooks(installation);
+
+  // No provider directory is created on the provider's behalf, and no script
+  // or spool is staged for sessions that cannot exist.
+  await assert.rejects(fs.stat(installation.providerHome));
+  await assert.rejects(fs.stat(installation.hookScriptPath));
+  await assert.rejects(fs.stat(installation.spoolDirectory));
+});
+
+// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+test("leaves a configuration file it cannot parse exactly as it was", async (t) => {
+  const installation = await temporaryInstallation(t);
+  const corrupt = "{ this is not json";
+  await fs.writeFile(configurationPath(installation), corrupt);
+
+  await installDevinObservationHooks(installation);
+
+  assert.equal(await fs.readFile(configurationPath(installation), "utf8"), corrupt);
+});
+
+test("converges rather than accumulates: reinstalling changes nothing", async (t) => {
+  const installation = await temporaryInstallation(t);
+
+  await installDevinObservationHooks(installation);
+  const first = await fs.readFile(configurationPath(installation), "utf8");
+  await installDevinObservationHooks(installation);
+
+  assert.equal(await fs.readFile(configurationPath(installation), "utf8"), first);
+});
+
+test("reconciles entries an older build registered under another path", async (t) => {
+  const installation = await temporaryInstallation(t);
+  const staleCommand = `/old/data/${DEVIN_HOOK_SCRIPT_NAME} stop`;
+  await fs.writeFile(
+    configurationPath(installation),
+    JSON.stringify({
+      hooks: {
+        Stop: [{ hooks: [{ type: "command", command: staleCommand }] }],
+        // An event this build no longer registers is cleaned up too.
+        PostToolUse: [{ matcher: "*", hooks: [{ type: "command", command: staleCommand }] }],
+      },
+    }),
+  );
+
+  await installDevinObservationHooks(installation);
+
+  const configuration = await readConfiguration(installation);
+  const stopCommands = entryCommands(hookEntries(configuration, "Stop")).filter((command) =>
+    command.includes(DEVIN_HOOK_SCRIPT_NAME),
+  );
+  assert.equal(stopCommands.length, 1);
+  assert.ok(!stopCommands[0]?.includes("/old/data/"));
+  assert.equal(hookEntries(configuration, "PostToolUse").length, 0);
+});
+
+test("removal strips Luke's entries and leaves the user's configuration standing", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.writeFile(
+    configurationPath(installation),
+    JSON.stringify({
+      version: 1,
+      theme_mode: "dark",
+      hooks: {
+        Stop: [{ hooks: [{ type: "command", command: "afplay /System/done.aiff" }] }],
+      },
+    }),
+  );
+  await installDevinObservationHooks(installation);
+
+  await removeDevinObservationHooks(installation);
+
+  const configuration = await readConfiguration(installation);
+  assert.equal(configuration.theme_mode, "dark");
+  assert.deepEqual(entryCommands(hookEntries(configuration, "Stop")), ["afplay /System/done.aiff"]);
+  for (const eventName of REGISTERED_EVENT_NAMES) {
+    const lukeCommands = entryCommands(hookEntries(configuration, eventName)).filter((command) =>
+      command.includes(DEVIN_HOOK_SCRIPT_NAME),
+    );
+    assert.equal(lukeCommands.length, 0, `${eventName} carries no Luke entry after removal`);
+  }
+  await assert.rejects(fs.stat(installation.hookScriptPath));
+  await assert.rejects(fs.stat(installation.spoolDirectory));
+});
+
+test("removal drops the hooks container once nothing of the user's remains", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await installDevinObservationHooks(installation);
+
+  await removeDevinObservationHooks(installation);
+
+  const configuration = await readConfiguration(installation);
+  assert.equal("hooks" in configuration, false);
+  // The settings around the container are the user's file, and stay.
+  assert.equal(configuration.version, 1);
+});
+
+test("removal never creates a configuration file", async (t) => {
+  const installation = await temporaryInstallation(t);
+
+  await removeDevinObservationHooks(installation);
+
+  await assert.rejects(fs.stat(configurationPath(installation)));
+});
+
+test("the script writes one fixed token named by the session, and nothing else", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await installDevinObservationHooks(installation);
+  const envelope = JSON.stringify({
+    hook_event_name: "Stop",
+    session_id: TEST_SESSION_ID,
+    // A per-turn id in the same hyphenated alphabet: only the session field
+    // may name the spool file.
+    prompt_id: "c57624f6-52e6-4ac1-b450-90ac2b50b8ec",
+    prompt: SECRET_ENVELOPE_TEXT,
+  });
+
+  await pipeToHookScript(installation, DEVIN_HOOK_EVENT.STOP, envelope);
+
+  assert.deepEqual(await fs.readdir(installation.spoolDirectory), [`${TEST_SESSION_ID}.json`]);
+  const spooled = await fs.readFile(
+    path.join(installation.spoolDirectory, `${TEST_SESSION_ID}.json`),
+    "utf8",
+  );
+  // The whole file is the fixed token: the envelope's text never reaches disk.
+  assert.equal(spooled, '{"event":"stop"}');
+  assert.ok(!spooled.includes(SECRET_ENVELOPE_TEXT));
+});
+
+test("a later event replaces the earlier one", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await installDevinObservationHooks(installation);
+  const envelope = JSON.stringify({ session_id: TEST_SESSION_ID });
+
+  await pipeToHookScript(installation, DEVIN_HOOK_EVENT.STOP, envelope);
+  await pipeToHookScript(installation, DEVIN_HOOK_EVENT.PROMPT, envelope);
+
+  const spooled = await fs.readFile(
+    path.join(installation.spoolDirectory, `${TEST_SESSION_ID}.json`),
+    "utf8",
+  );
+  assert.equal(spooled, '{"event":"prompt"}');
+});
+
+test("the script refuses a token the build never registered", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await installDevinObservationHooks(installation);
+
+  await pipeToHookScript(
+    installation,
+    "made-up-event",
+    JSON.stringify({ session_id: TEST_SESSION_ID }),
+  );
+
+  assert.deepEqual(await fs.readdir(installation.spoolDirectory), []);
+});
+
+test("the script refuses a session id outside the shape Devin mints", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await installDevinObservationHooks(installation);
+
+  // A path is not a petname, and neither is a single word: the id pattern
+  // demands the hyphenated shape, so nothing else can name a spool file.
+  for (const sessionId of ["../../../etc/passwd", "solidrest", "SOLID-REST"]) {
+    await pipeToHookScript(
+      installation,
+      DEVIN_HOOK_EVENT.STOP,
+      JSON.stringify({ session_id: sessionId }),
+    );
+  }
+
+  assert.deepEqual(await fs.readdir(installation.spoolDirectory), []);
+});
+
+test("the script is silent once the spool is gone", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await installDevinObservationHooks(installation);
+  await fs.rm(installation.spoolDirectory, { recursive: true, force: true });
+
+  await pipeToHookScript(
+    installation,
+    DEVIN_HOOK_EVENT.STOP,
+    JSON.stringify({ session_id: TEST_SESSION_ID }),
+  );
+
+  await assert.rejects(fs.stat(installation.spoolDirectory));
+});
+
+test("reads the spooled event back with the file's own clock", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.mkdir(installation.spoolDirectory, { recursive: true });
+  const filePath = path.join(installation.spoolDirectory, `${TEST_SESSION_ID}.json`);
+  await fs.writeFile(filePath, '{"event":"stop"}');
+  await fs.utimes(filePath, TEST_TIME / 1000, TEST_TIME / 1000);
+
+  const event = await readDevinHookEvent(installation.spoolDirectory, TEST_SESSION_ID);
+
+  assert.equal(event?.event, DEVIN_HOOK_EVENT.STOP);
+  assert.equal(event?.atMs, TEST_TIME);
+});
+
+test("reads nothing from a missing, foreign, or oversized spool file", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.mkdir(installation.spoolDirectory, { recursive: true });
+  const write = (name: string, content: string) =>
+    fs.writeFile(path.join(installation.spoolDirectory, `${name}.json`), content);
+  await write("unknown-token", '{"event":"reboot"}');
+  await write("not-json", "not json at all");
+  await write("oversized", `{"event":"stop","padding":"${"x".repeat(512)}"}`);
+
+  assert.equal(await readDevinHookEvent(installation.spoolDirectory, "absent"), undefined);
+  assert.equal(await readDevinHookEvent(installation.spoolDirectory, "unknown-token"), undefined);
+  assert.equal(await readDevinHookEvent(installation.spoolDirectory, "not-json"), undefined);
+  assert.equal(await readDevinHookEvent(installation.spoolDirectory, "oversized"), undefined);
+});
+
+test("pruning drops only the events past the observation window", async (t) => {
+  const installation = await temporaryInstallation(t);
+  await fs.mkdir(installation.spoolDirectory, { recursive: true });
+  const dayMs = 24 * 60 * 60 * 1000;
+  const freshPath = path.join(installation.spoolDirectory, "fresh.json");
+  const stalePath = path.join(installation.spoolDirectory, "stale.json");
+  await fs.writeFile(freshPath, '{"event":"stop"}');
+  await fs.writeFile(stalePath, '{"event":"stop"}');
+  await fs.utimes(freshPath, (TEST_TIME - 60_000) / 1000, (TEST_TIME - 60_000) / 1000);
+  await fs.utimes(stalePath, (TEST_TIME - 2 * dayMs) / 1000, (TEST_TIME - 2 * dayMs) / 1000);
+
+  await pruneObservationHookSpool(installation.spoolDirectory, dayMs, TEST_TIME);
+
+  await fs.stat(freshPath);
+  await assert.rejects(fs.stat(stalePath));
+  // A spool that does not exist is nothing to prune rather than a failure.
+  await pruneObservationHookSpool(
+    path.join(installation.spoolDirectory, "absent"),
+    dayMs,
+    TEST_TIME,
+  );
+});
+
+test("removal leaves a file with no Luke entries byte-for-byte alone", async (t) => {
+  const installation = await temporaryInstallation(t);
+  // Formatted unlike anything this module writes: compact, no trailing line.
+  const foreign = '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"afplay /a.aiff"}]}]}}';
+  await fs.writeFile(configurationPath(installation), foreign);
+
+  await removeDevinObservationHooks(installation);
+
+  assert.equal(await fs.readFile(configurationPath(installation), "utf8"), foreign);
+});
+
+test("the configuration write keeps the file's own mode and leaves no debris", async (t) => {
+  const installation = await temporaryInstallation(t);
+  // The CLI writes its config.json owner-only, and the merge must not widen it.
+  await fs.writeFile(configurationPath(installation), "{}\n", { mode: 0o600 });
+  await fs.chmod(configurationPath(installation), 0o600);
+
+  await installDevinObservationHooks(installation);
+
+  // The rename replaced the file, and the user's own protection rode along.
+  assert.equal((await fs.stat(configurationPath(installation))).mode & 0o777, 0o600);
+  const leftovers = (await fs.readdir(installation.providerHome)).filter((name) =>
+    name.includes(".luke-tmp"),
+  );
+  assert.deepEqual(leftovers, []);
+});
+
+test("the configuration write lands through a symlink rather than replacing it", async (t) => {
+  const installation = await temporaryInstallation(t);
+  // A dotfiles-managed home: config.json is a link into a synced store.
+  const syncedPath = path.join(installation.providerHome, "synced-config.json");
+  await fs.writeFile(syncedPath, "{}\n");
+  await fs.symlink(syncedPath, configurationPath(installation));
+
+  await installDevinObservationHooks(installation);
+
+  const linked = await fs.lstat(configurationPath(installation));
+  assert.ok(linked.isSymbolicLink(), "the link survives the write");
+  const synced = JSON.parse(await fs.readFile(syncedPath, "utf8"));
+  assert.equal(entryCommands(hookEntries(synced, "Stop")).length, 1);
+});

--- a/packages/providers/src/devin/hooks.ts
+++ b/packages/providers/src/devin/hooks.ts
@@ -1,0 +1,114 @@
+import os from "node:os";
+import path from "node:path";
+import {
+  HOOK_ENTRY_NESTING,
+  type ObservationHookSpec,
+  type ObservedHookEvent,
+  observationHooksFor,
+} from "../shared/hook-merge.js";
+
+/**
+ * Devin's observation hooks, described for the shared machinery in
+ * `hook-merge.ts`. The Devin CLI keeps its user-level configuration in
+ * `~/.config/devin/config.json` (under `XDG_CONFIG_HOME` where that is set),
+ * a settings file that carries hooks under a `hooks` key beside the user's
+ * other settings, nested the same way Claude Code's are, and it pipes a
+ * registered command its envelope as JSON on stdin. The envelope's
+ * `session_id` is the same id the CLI writes as the session row's primary key
+ * in its own SQLite — verified against a live CLI, six sessions for six — so
+ * the spool token lands under the name the roster already knows. The CLI runs
+ * a newly registered user-level hook without a review gate of its own; the
+ * consent here is the same as every provider's, the registration Luke
+ * converges and removes.
+ */
+
+/**
+ * The script's name is also the marker a managed entry is recognized by, so
+ * renaming it is a migration: an entry naming the old script would stop being
+ * recognized as ours and would be left behind.
+ */
+export const DEVIN_HOOK_SCRIPT_NAME = "luke-devin-observation-hook.sh";
+
+/** How long Devin lets the spool write run before giving up on it. */
+const DEVIN_HOOK_TIMEOUT_SECONDS = 10;
+
+const DEVIN_ENVIRONMENT = {
+  CONFIG_HOME: "XDG_CONFIG_HOME",
+} as const;
+
+const DEVIN_CONFIG_HOME_SEGMENT = ".config";
+const DEVIN_CONFIG_DIRECTORY = "devin";
+
+/**
+ * The tokens the script may write, fixed at registration: each hook entry
+ * passes its own token as the script's one argument, so nothing in the
+ * envelope Devin pipes in can choose what lands in the spool. The same
+ * vocabulary Codex's spool speaks, minus nothing — Devin documents the same
+ * five moments — though the CLI observed today fires no `SessionEnd` for a
+ * quit, so the closing token is registered on the documentation's word and
+ * refines a row only if a build ever sends it.
+ */
+export const DEVIN_HOOK_EVENT = {
+  SESSION_START: "session-start",
+  PROMPT: "prompt",
+  STOP: "stop",
+  NOTIFICATION: "notification",
+  SESSION_END: "session-end",
+} as const;
+
+export type DevinHookEvent = (typeof DEVIN_HOOK_EVENT)[keyof typeof DEVIN_HOOK_EVENT];
+
+/** The latest thing the hook reported about one session, dated by the spool. */
+export type ObservedDevinHookEvent = ObservedHookEvent<DevinHookEvent>;
+
+/**
+ * Which Devin lifecycle moments are registered, and the token each one hands
+ * the script. Turn boundaries and lifecycle edges only, for the same reason
+ * Claude Code's registration stops there. `PermissionRequest` is Devin's own
+ * name for a tool call holding for approval — the one moment the session
+ * database shows nothing new — and the entry only observes it: the command
+ * always exits zero and prints nothing, which Devin reads as no decision, so
+ * nothing here can answer the request. Subagent turns are not skipped by an
+ * envelope field because Devin's envelope carries none; its subagents end
+ * under their own `SubagentStop` event, which is simply not registered.
+ */
+const DEVIN_HOOK_SPEC: ObservationHookSpec<DevinHookEvent> = {
+  scriptName: DEVIN_HOOK_SCRIPT_NAME,
+  configurationFileName: "config.json",
+  scriptTitle: "Luke Devin observation hook v1",
+  registration: {
+    SessionStart: { event: DEVIN_HOOK_EVENT.SESSION_START },
+    UserPromptSubmit: { event: DEVIN_HOOK_EVENT.PROMPT },
+    Stop: { event: DEVIN_HOOK_EVENT.STOP },
+    PermissionRequest: { event: DEVIN_HOOK_EVENT.NOTIFICATION },
+    SessionEnd: { event: DEVIN_HOOK_EVENT.SESSION_END },
+  },
+  timeoutSeconds: DEVIN_HOOK_TIMEOUT_SECONDS,
+  sessionIdField: "session_id",
+  // The shape Devin mints: lowercase words joined by hyphens ("solid-rest").
+  // The hyphen is required because the script greps this pattern back out of
+  // the matched `"session_id":"…"` fragment, and a single-word pattern would
+  // match the field's own name before the id.
+  sessionIdPattern: "[a-z0-9]{1,24}(-[a-z0-9]{1,24}){1,5}",
+  entryNesting: HOOK_ENTRY_NESTING.NESTED,
+  // Devin documents a schema version beside the settings; a file being
+  // created gets it, and a user's own value is never rewritten.
+  rootDefaults: { version: 1 },
+};
+
+/**
+ * Where the Devin CLI keeps its user-level configuration. Deliberately not
+ * the data home the session database lives under: the CLI splits the two
+ * along the XDG lines, and each side keeps its own resolution.
+ */
+export function defaultDevinConfigHome(): string {
+  const configHome = process.env[DEVIN_ENVIRONMENT.CONFIG_HOME]?.trim();
+  const base = configHome || path.join(os.homedir(), DEVIN_CONFIG_HOME_SEGMENT);
+  return path.join(base, DEVIN_CONFIG_DIRECTORY);
+}
+
+const devinHooks = observationHooksFor(DEVIN_HOOK_SPEC);
+
+export const installDevinObservationHooks = devinHooks.install;
+export const removeDevinObservationHooks = devinHooks.remove;
+export const readDevinHookEvent = devinHooks.read;

--- a/packages/providers/src/devin/local-adapter.test.ts
+++ b/packages/providers/src/devin/local-adapter.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import test, { type TestContext } from "node:test";
-import { SESSION_STATUS } from "@sidecar/session";
+import { SESSION_COMPLETION_CAUSE, SESSION_STATUS } from "@sidecar/session";
 import type { MutableWireRecord, ParsedJsonObject } from "@sidecar/wire/testing";
 import { DEVIN_PROVIDER } from "./adapter.js";
 import { DevinLocalSessionAdapter } from "./local-adapter.js";
@@ -647,6 +647,216 @@ test("observes nothing where the runtime has no sqlite module", async (t) => {
     },
   });
   assert.deepEqual(await adapter.observe(), []);
+});
+
+// ---------------------------------------------------------------------------
+// Hook-event refinement. Every test here layers a spool the observation hook
+// would have written over the session database, because that is the
+// arrangement in production: the rows and chains are always read, and the
+// event only sharpens them.
+// ---------------------------------------------------------------------------
+
+async function temporaryHookSpool(t: TestContext): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-devin-spool-"));
+  t.after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  return directory;
+}
+
+async function writeHookEvent(
+  spoolDirectory: string,
+  providerSessionId: string,
+  event: string,
+  mtimeMs: number,
+): Promise<void> {
+  const filePath = path.join(spoolDirectory, `${providerSessionId}.json`);
+  await fs.writeFile(filePath, JSON.stringify({ event }));
+  await fs.utimes(filePath, mtimeMs / 1000, mtimeMs / 1000);
+}
+
+/** A session mid-turn by every record: the developer's prompt is the tip. */
+async function writeOpenTurnState(
+  cliDirectory: string,
+  sessionId: string,
+  observedAt: number,
+): Promise<void> {
+  await writeDevinState(
+    cliDirectory,
+    [{ id: sessionId, workingDirectory: "/Users/test/luke", observedAt, mainChainId: 0 }],
+    {
+      nodes: [
+        { sessionId, nodeId: 0, time: observedAt, message: chatMessage("user", "run the suite") },
+      ],
+    },
+  );
+}
+
+/** A session whose turn settled: the assistant's reply is the tip. */
+async function writeSettledTurnState(
+  cliDirectory: string,
+  sessionId: string,
+  observedAt: number,
+): Promise<void> {
+  await writeDevinState(
+    cliDirectory,
+    [{ id: sessionId, workingDirectory: "/Users/test/luke", observedAt, mainChainId: 1 }],
+    {
+      nodes: [
+        { sessionId, nodeId: 0, time: observedAt, message: chatMessage("user", "hello") },
+        {
+          sessionId,
+          nodeId: 1,
+          parentNodeId: 0,
+          time: observedAt,
+          message: chatMessage("assistant", "Hi!"),
+        },
+      ],
+    },
+  );
+}
+
+test("a permission request the database cannot show turns the row to waiting", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  const spool = await temporaryHookSpool(t);
+  // Mid-turn by every record: a call holding for approval writes no node
+  // further, so without the event this session reads as working.
+  await writeOpenTurnState(cliDirectory, "held-call", TEST_TIME - 5 * 60_000);
+  await writeHookEvent(spool, "held-call", "notification", TEST_TIME - 60_000);
+
+  const adapter = new DevinLocalSessionAdapter({
+    cliDirectory,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WAITING);
+  assert.equal(observation?.holdingForDeveloper, true);
+  // The event also dates the session: the spool is written only by Luke's own
+  // script, so its clock is the moment the session actually moved.
+  assert.equal(observation?.observedAt, TEST_TIME - 60_000);
+});
+
+test("a session-end event settles a row the database would leave waiting", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  const spool = await temporaryHookSpool(t);
+  await writeSettledTurnState(cliDirectory, "closed-out", TEST_TIME - 5 * 60_000);
+  await writeHookEvent(spool, "closed-out", "session-end", TEST_TIME - 60_000);
+
+  const adapter = new DevinLocalSessionAdapter({
+    cliDirectory,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.COMPLETE);
+  assert.equal(observation?.completionCause, SESSION_COMPLETION_CAUSE.SESSION_CLOSED);
+});
+
+test("a stop event keeps a finished turn waiting past the freshness decay", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  const spool = await temporaryHookSpool(t);
+  // Twenty minutes past the row's clock, the database alone decays to unknown.
+  await writeSettledTurnState(cliDirectory, "still-waiting", TEST_TIME - 20 * 60_000);
+  await writeHookEvent(spool, "still-waiting", "stop", TEST_TIME - 60_000);
+
+  const adapter = new DevinLocalSessionAdapter({
+    activeSessionFreshnessMs: 15 * 60_000,
+    cliDirectory,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WAITING);
+});
+
+test("an event the session has moved past refines nothing", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  const spool = await temporaryHookSpool(t);
+  await writeOpenTurnState(cliDirectory, "moved-on", TEST_TIME - 60_000);
+  // A stop from a minute before the row's clock: hooks were off, or the write
+  // raced. The session is demonstrably mid-turn again.
+  await writeHookEvent(spool, "moved-on", "stop", TEST_TIME - 2 * 60_000);
+
+  const adapter = new DevinLocalSessionAdapter({
+    cliDirectory,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WORKING);
+  assert.equal(observation?.observedAt, TEST_TIME - 60_000);
+});
+
+test("a prompt event reads a fresh turn as working before the node shows it", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  const spool = await temporaryHookSpool(t);
+  await writeSettledTurnState(cliDirectory, "prompted", TEST_TIME - 60_000);
+  await writeHookEvent(spool, "prompted", "prompt", TEST_TIME - 5_000);
+
+  const adapter = new DevinLocalSessionAdapter({
+    cliDirectory,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WORKING);
+});
+
+test("a notification the session has answered stands down at once", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  const spool = await temporaryHookSpool(t);
+  // The approval was granted and the call ran: a row touched after the
+  // notification, though within the tolerance the other events enjoy.
+  await writeOpenTurnState(cliDirectory, "approved", TEST_TIME - 1_000);
+  await writeHookEvent(spool, "approved", "notification", TEST_TIME - 3_000);
+
+  const adapter = new DevinLocalSessionAdapter({
+    cliDirectory,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WORKING);
+});
+
+test("a spool that cannot be read costs only the refinement", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  await writeOpenTurnState(cliDirectory, "unrefined", TEST_TIME - 1_000);
+
+  const adapter = new DevinLocalSessionAdapter({
+    cliDirectory,
+    hookEventsDirectory: () => path.join(cliDirectory, "no-such-spool"),
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WORKING);
+});
+
+test("a permission hold that outlives the freshness window never reads as work", async (t) => {
+  const cliDirectory = await temporaryCliDirectory(t);
+  const spool = await temporaryHookSpool(t);
+  // An open turn past the window already decays to unknown; the stale hold
+  // must land in the same place rather than revive it as waiting.
+  await writeOpenTurnState(cliDirectory, "long-hold", TEST_TIME - 30 * 60_000);
+  await writeHookEvent(spool, "long-hold", "notification", TEST_TIME - 20 * 60_000);
+
+  const adapter = new DevinLocalSessionAdapter({
+    activeSessionFreshnessMs: 15 * 60_000,
+    cliDirectory,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.UNKNOWN);
 });
 
 test("honors the CLI's own database override", async (t) => {

--- a/packages/providers/src/devin/local-adapter.ts
+++ b/packages/providers/src/devin/local-adapter.ts
@@ -4,6 +4,7 @@ import {
   agedStatus,
   maximumSessionTitleLength,
   type ProviderSessionObservation,
+  SESSION_COMPLETION_CAUSE,
   SESSION_STATUS,
   type SessionDetail,
   type SessionStatus,
@@ -17,6 +18,8 @@ import {
   type WireRecord,
 } from "@sidecar/wire";
 import {
+  type HookStatusRefinement,
+  hookRefinedStatus,
   LocalSessionAdapter,
   uniquePaths,
   workspaceLabel,
@@ -29,6 +32,12 @@ import {
   type SqliteModuleLoader,
 } from "../shared/local-sqlite.js";
 import { DEVIN_PROVIDER, millisecondsFromRecord } from "./adapter.js";
+import {
+  DEVIN_HOOK_EVENT,
+  type DevinHookEvent,
+  type ObservedDevinHookEvent,
+  readDevinHookEvent,
+} from "./hooks.js";
 import { readDevinSessionTranscript } from "./transcript.js";
 
 /**
@@ -176,6 +185,14 @@ export interface DevinLocalAdapterOptions {
   activeSessionFreshnessMs?: number;
   sqlite?: SqliteModuleLoader;
   transcriptMaximumRenderedLength?: number;
+  /**
+   * Where the observation hook spools its events, when hooks are on at all.
+   * Read lazily like the cloud adapters' credentials, because the app decides
+   * the path after this adapter is declared. Absent — or answering nothing —
+   * the adapter reads the session database alone, exactly as it always has:
+   * the hooks only ever sharpen what the rows already showed.
+   */
+  hookEventsDirectory?: () => string | undefined;
 }
 
 /**
@@ -301,6 +318,30 @@ function activityFromToolCallRows(rows: readonly DevinRow[]): string | undefined
   return undefined;
 }
 
+/**
+ * What the refinement actually buys here is the states the session database
+ * cannot show: a tool call holding for approval writes no node while it
+ * holds, a settled turn and a session walked away from write the same rows,
+ * and the database records no closure at all. The stale notification decays
+ * to unknown for the same reason Codex's does — a hold nobody has answered in
+ * a window is indistinguishable from a session left behind, and must never
+ * read as anything livelier.
+ */
+const DEVIN_HOOK_STATUS_REFINEMENT = {
+  definitive: [{ event: DEVIN_HOOK_EVENT.SESSION_END, fresh: SESSION_STATUS.COMPLETE }],
+  fresh: [
+    {
+      event: DEVIN_HOOK_EVENT.NOTIFICATION,
+      fresh: SESSION_STATUS.WAITING,
+      stale: SESSION_STATUS.UNKNOWN,
+    },
+    { event: DEVIN_HOOK_EVENT.PROMPT, fresh: SESSION_STATUS.WORKING },
+    { event: DEVIN_HOOK_EVENT.STOP, fresh: SESSION_STATUS.WAITING },
+  ],
+  notificationEvent: DEVIN_HOOK_EVENT.NOTIFICATION,
+  sessionEndEvent: DEVIN_HOOK_EVENT.SESSION_END,
+} as const satisfies HookStatusRefinement<DevinHookEvent>;
+
 function detailFromSnapshot(snapshot: DevinLocalSessionSnapshot): SessionDetail {
   return {
     ...(snapshot.activity ? { activity: snapshot.activity } : undefined),
@@ -311,15 +352,29 @@ function detailFromSnapshot(snapshot: DevinLocalSessionSnapshot): SessionDetail 
 
 function observationFromSnapshot(
   snapshot: DevinLocalSessionSnapshot,
+  hookEvent: ObservedDevinHookEvent | undefined,
   now: number,
   activeSessionFreshnessMs: number,
 ): ProviderSessionObservation {
+  const refined = hookRefinedStatus({
+    refinement: DEVIN_HOOK_STATUS_REFINEMENT,
+    hookEvent,
+    providerAtMs: snapshot.observedAt,
+    statusAt: (observedAt) =>
+      statusFromTurn(snapshot.turn, observedAt, now, activeSessionFreshnessMs),
+    now,
+    activeSessionFreshnessMs,
+  });
   return {
     providerSessionId: snapshot.providerSessionId,
     title: sessionTitle(snapshot.title, snapshot.workingDirectory),
-    status: statusFromTurn(snapshot.turn, snapshot.observedAt, now, activeSessionFreshnessMs),
-    observedAt: snapshot.observedAt,
+    status: refined.status,
+    ...(refined.sessionClosed
+      ? { completionCause: SESSION_COMPLETION_CAUSE.SESSION_CLOSED }
+      : undefined),
+    observedAt: refined.observedAt,
     detail: detailFromSnapshot(snapshot),
+    ...(refined.holdingForDeveloper ? { holdingForDeveloper: true } : undefined),
   };
 }
 
@@ -355,12 +410,14 @@ export class DevinLocalSessionAdapter extends LocalSessionAdapter {
   readonly #cliDirectory: string;
   readonly #sqlite: SqliteModuleLoader;
   readonly #transcriptMaximumRenderedLength: number | undefined;
+  readonly #hookEventsDirectory: (() => string | undefined) | undefined;
 
   constructor(options: DevinLocalAdapterOptions = {}) {
     super(options);
     this.#cliDirectory = options.cliDirectory ?? defaultDevinCliDirectory();
     this.#sqlite = options.sqlite ?? defaultSqliteModule;
     this.#transcriptMaximumRenderedLength = options.transcriptMaximumRenderedLength;
+    this.#hookEventsDirectory = options.hookEventsDirectory;
   }
 
   async observe(): Promise<readonly ProviderSessionObservation[]> {
@@ -378,8 +435,14 @@ export class DevinLocalSessionAdapter extends LocalSessionAdapter {
       // A database whose schema was unusable answers nothing; the next
       // candidate may still answer.
       if (snapshots === undefined) continue;
+      const hookEvents = await this.#hookEvents(snapshots);
       return snapshots.map((snapshot) =>
-        observationFromSnapshot(snapshot, now, this.activeSessionFreshnessMs),
+        observationFromSnapshot(
+          snapshot,
+          hookEvents.get(snapshot.providerSessionId),
+          now,
+          this.activeSessionFreshnessMs,
+        ),
       );
     }
     return [];
@@ -460,6 +523,30 @@ export class DevinLocalSessionAdapter extends LocalSessionAdapter {
     return activityFromToolCallRows(
       this.#rowsFor(database, DEVIN_TOOL_CALL_QUERY, [providerSessionId]),
     );
+  }
+
+  /**
+   * Reads what the observation hook last said about each session. The spool
+   * is a refinement, never a dependency: a directory that is missing,
+   * unreadable, or holding something unexpected reads as no event, and the
+   * row's own verdict stands.
+   */
+  async #hookEvents(
+    snapshots: readonly DevinLocalSessionSnapshot[],
+  ): Promise<Map<string, ObservedDevinHookEvent>> {
+    const events = new Map<string, ObservedDevinHookEvent>();
+    const hookEventsDirectory = this.#hookEventsDirectory?.();
+    if (!hookEventsDirectory) return events;
+    await Promise.all(
+      snapshots.map(async (snapshot) => {
+        const event = await readDevinHookEvent(
+          hookEventsDirectory,
+          snapshot.providerSessionId,
+        ).catch(() => undefined);
+        if (event) events.set(snapshot.providerSessionId, event);
+      }),
+    );
+    return events;
   }
 
   /** A node or tool table this build cannot read costs a field, not the pass. */

--- a/packages/providers/src/hook-registry.ts
+++ b/packages/providers/src/hook-registry.ts
@@ -5,6 +5,7 @@ import { defaultCodexHome } from "./codex/adapter.js";
 import { CODEX_HOOK_SCRIPT_NAME } from "./codex/hooks.js";
 import { CURSOR_HOOK_SCRIPT_NAME } from "./cursor/hooks.js";
 import { defaultCursorHome } from "./cursor/local-adapter.js";
+import { DEVIN_HOOK_SCRIPT_NAME, defaultDevinConfigHome } from "./devin/hooks.js";
 import { GEMINI_HOOK_SCRIPT_NAME } from "./gemini-cli/hooks.js";
 import { defaultGeminiCliHome } from "./gemini-cli/records.js";
 import {
@@ -49,6 +50,14 @@ const OBSERVATION_HOOK_PROVIDERS = {
     directoryName: "cursor-hooks",
     scriptName: CURSOR_HOOK_SCRIPT_NAME,
     providerHome: defaultCursorHome,
+  },
+  [PROVIDER_ID.DEVIN]: {
+    directoryName: "devin-hooks",
+    scriptName: DEVIN_HOOK_SCRIPT_NAME,
+    // The configuration home, not the data home the session database lives
+    // under: the registration merges into the CLI's user-level config.json,
+    // and the CLI creates this directory for itself on its first run.
+    providerHome: defaultDevinConfigHome,
   },
   [PROVIDER_ID.GEMINI_CLI]: {
     directoryName: "gemini-cli-hooks",

--- a/packages/providers/src/registrations.test.ts
+++ b/packages/providers/src/registrations.test.ts
@@ -33,6 +33,7 @@ test("declares credentials and observation hooks beside their adapters", () => {
   assert.ok(registrations[PROVIDER_ID.CLAUDE_CODE].registerObservationHook instanceof Function);
   assert.ok(registrations[PROVIDER_ID.CODEX].registerObservationHook instanceof Function);
   assert.ok(registrations[PROVIDER_ID.CURSOR].registerObservationHook instanceof Function);
+  assert.ok(registrations[PROVIDER_ID.DEVIN].registerObservationHook instanceof Function);
   assert.ok(registrations[PROVIDER_ID.GEMINI_CLI].registerObservationHook instanceof Function);
   assert.ok(registrations[PROVIDER_ID.OPENCODE].registerObservationHook instanceof Function);
   assert.equal("credential" in registrations[PROVIDER_ID.OPENCODE], false);

--- a/packages/providers/src/registrations.ts
+++ b/packages/providers/src/registrations.ts
@@ -21,6 +21,7 @@ import { CURSOR_PROVIDER, CursorSessionAdapter } from "./cursor/adapter.js";
 import { installCursorObservationHooks } from "./cursor/hooks.js";
 import { CursorLocalSessionAdapter } from "./cursor/local-adapter.js";
 import { DEVIN_PROVIDER, DevinSessionAdapter } from "./devin/adapter.js";
+import { installDevinObservationHooks } from "./devin/hooks.js";
 import { DevinLocalSessionAdapter } from "./devin/local-adapter.js";
 import { GeminiCliSessionAdapter } from "./gemini-cli/adapter.js";
 import { installGeminiObservationHooks } from "./gemini-cli/hooks.js";
@@ -79,6 +80,7 @@ export function providerRegistrations(options: ProviderRegistrationOptions) {
   const claudeInstallation = hookInstallation(PROVIDER_ID.CLAUDE_CODE);
   const codexInstallation = hookInstallation(PROVIDER_ID.CODEX);
   const cursorInstallation = hookInstallation(PROVIDER_ID.CURSOR);
+  const devinInstallation = hookInstallation(PROVIDER_ID.DEVIN);
   const geminiInstallation = hookInstallation(PROVIDER_ID.GEMINI_CLI);
   const opencodeInstallation = hookInstallation(PROVIDER_ID.OPENCODE);
   const claude = new ClaudeCodeSessionAdapter({
@@ -110,7 +112,9 @@ export function providerRegistrations(options: ProviderRegistrationOptions) {
   const devin = new CompositeSessionProviderAdapter({
     provider: DEVIN_PROVIDER,
     adapters: [
-      new DevinLocalSessionAdapter(),
+      new DevinLocalSessionAdapter({
+        hookEventsDirectory: () => devinInstallation().spoolDirectory,
+      }),
       new DevinSessionAdapter({
         readApiKey: () => options.readApiKey(CREDENTIAL_PROVIDER_ID.DEVIN),
       }),
@@ -158,6 +162,11 @@ export function providerRegistrations(options: ProviderRegistrationOptions) {
     [PROVIDER_ID.DEVIN]: {
       adapter: devin,
       credential: CREDENTIAL_PROVIDERS[CREDENTIAL_PROVIDER_ID.DEVIN],
+      registerObservationHook: observationHookRegistration(
+        installDevinObservationHooks,
+        devinInstallation,
+        now,
+      ),
     },
     [PROVIDER_ID.GEMINI_CLI]: {
       adapter: new GeminiCliSessionAdapter({


### PR DESCRIPTION
## What

Registers Luke's observation hook with Devin's local CLI, so Devin's local sessions gain the sharper statuses Claude Code, Codex, and Cursor rows already have: a fresh turn-end reads as waiting instead of decaying to unknown, a tool call holding for approval turns the row to waiting with `holdingForDeveloper`, and a session the CLI closes reports `SESSION_CLOSED` — if a build ever fires the closing hook (see below).

- `devin/hooks.ts`: the `ObservationHookSpec` — nested entries like Claude Code's, merged into the CLI's user-level `config.json` under `~/.config/devin` (`XDG_CONFIG_HOME` honored), five lifecycle events, stdin envelope, 10s timeout, `rootDefaults: { version: 1 }`.
- `devin/local-adapter.ts`: `hookEventsDirectory` option and `hookRefinedStatus` wiring — definitive `session-end` → COMPLETE with `SESSION_CLOSED`, fresh `prompt` → WORKING, `stop` → WAITING, `notification` → WAITING with `stale: UNKNOWN` (Codex's rationale holds: a hold nobody answered in a window must never read as anything livelier). `providerAtMs` is the session row's own clock.
- `hook-registry.ts`: one Devin row (`devin-hooks`, `luke-devin-observation-hook.sh`, provider home = the config home, not the data home the SQLite lives under).
- `registrations.ts`: spool wired into the composite's local adapter, `registerObservationHook` beside the credential.
- `AGENTS.md`/`CLAUDE.md`: the consent sentence now names Devin's `config.json` explicitly.
- Tests: the full invariant suite mirrored from `claude-code/hooks.test.ts` (21 tests), plus 8 adapter refinement tests mirroring Codex's.

## Verified against the real CLI (v3000.4.25, installed and run in this sandbox)

**The session-id join (the hard gate)** — proven empirically, not just from docs. Six live sessions: the hook envelope's `session_id` equaled the SQLite `sessions.id` (the adapter's `providerSessionId`) every time. Final end-to-end proof: Luke's actual generated script, merged by `installDevinObservationHooks` into the real `~/.config/devin/config.json`, ran under the live CLI and spooled `{"event":"stop"}` as `electric-twig.json` — exactly the id the session row carries.

**The id shape is a petname, not a UUID** (`solid-rest`, `dust-rhubarb`, `vivacious-report`). This forced a deliberate pattern: the shared script greps the id pattern back out of the matched `"session_id":"…"` fragment, and a plain lowercase-word pattern would match the field's own name (`session`) before the id. The pattern therefore demands the hyphenated multi-word shape Devin mints: `[a-z0-9]{1,24}(-[a-z0-9]{1,24}){1,5}`.

**The user-level file** is `~/.config/devin/config.json`, per the docs' hooks-overview page, the CLI's own `--config` help text, and a live test: hooks placed in `$XDG_CONFIG_HOME/devin/config.json` fired. It is a settings file holding other keys (`version`, `shell`, `theme_mode`) with hooks under a `hooks` key; the merge preserves them, and the CLI itself creates the directory and file (mode 0600 — the merge keeps the file's own mode, tested). `.devin/hooks.v1.json` is project-level and was not chosen; Devin also reads Claude Code's files, which Luke must never carry Devin entries into.

**Other verified facts:**
- Hooks entries are `{ type: "command", command, timeout }` nested under matcher records; timeout in seconds. A hook that prints nothing to stdout is tolerated (tested live), so no `repliesWithJson`.
- No trust gate: a newly registered user-level hook ran without any review prompt (unlike Codex's).
- `PermissionRequest` fires while a tool call is pending approval (docs; the same name and semantics Codex maps to `notification`). Exit 0 with no output is no decision, so the entry only observes. Could not be fired live — the sandbox has no real model backend — so this mapping rests on Devin's documentation.
- `SessionEnd` is documented but **did not fire** in the CLI tested, neither for print-mode exit nor a clean interactive `/exit`. It is registered on the documentation's word: if a build ever sends it, the closure refinement stands ready; until then the entry is a no-op and no row can falsely read closed.
- Subagents end under a separate `SubagentStop` event (visible in the CLI's own serde structs); the envelope carries no subagent-marking field, so `subagentField` is omitted and `SubagentStop` simply isn't registered.

## Repo obligations checked

- README agent table: Devin's local row already exists — no change.
- `PRIVACY.md`: hooks add no data leaving the machine (the spool holds one fixed token under Luke's own app data) — no change, matching the Claude Code/Codex/Cursor precedent.

## Checks

`./scripts/check.sh` passes end to end (exit 0). Portable-only change; no UI or macOS surface touched, so no visual evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c5658cd5-2a74-41db-9f3b-bdfcb4af4704)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32449896135/artifacts/9435347829) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32449896135)

- Commit: `176213046ea53776f27953bb552432dc4f74b081`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
