### PR TITLE
feat: clear session filters from an X on the options button

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -144,7 +144,7 @@ import {
   tallySummary,
 } from "./session-model";
 import { parsePixels } from "./session-motion";
-import { SESSION_OPTIONS_BUTTON_ID, SESSION_OPTIONS_ID } from "./session-parts";
+import { SESSION_OPTIONS_CONTROL_ID, SESSION_OPTIONS_ID } from "./session-parts";
 import { focusSearchField, SESSION_SEARCH_INPUT_ID } from "./session-search";
 import type {
   MicrophoneControl,
@@ -2838,19 +2838,20 @@ export function App(): React.JSX.Element {
   // A press anywhere else is the same dismissal Escape is, and the one a sheet
   // over a list has to answer: what is behind it can only be reached by asking
   // it to move, so pressing there has to be what asks. The press is taken on the
-  // way down, before whatever it lands on can act on it, and the button that
-  // opened the sheet is left to its own toggle. Nothing outside the drawn shape
-  // reaches this renderer at all — those presses belong to whatever is behind
-  // Luke — so leaving the shape is what closes the panel, and closing the panel
-  // is what puts the sheet away.
+  // way down, before whatever it lands on can act on it, and the control that
+  // opened the sheet — toggle and, while a selection stands, the X that clears
+  // it — is left to its own clicks. Nothing outside the drawn shape reaches
+  // this renderer at all — those presses belong to whatever is behind Luke —
+  // so leaving the shape is what closes the panel, and closing the panel is
+  // what puts the sheet away.
   useEffect(() => {
     if (!optionsOpen) return;
     const handlePointerDown = (event: PointerEvent) => {
       const target = event.target instanceof Node ? event.target : undefined;
       if (!target) return;
       const sheet = document.getElementById(SESSION_OPTIONS_ID);
-      const button = document.getElementById(SESSION_OPTIONS_BUTTON_ID);
-      if (sheet?.contains(target) || button?.contains(target)) return;
+      const control = document.getElementById(SESSION_OPTIONS_CONTROL_ID);
+      if (sheet?.contains(target) || control?.contains(target)) return;
       setOptionsOpen(false);
     };
     window.addEventListener("pointerdown", handlePointerDown, { capture: true });

--- a/apps/desktop/src/renderer/luke-guide.test.ts
+++ b/apps/desktop/src/renderer/luke-guide.test.ts
@@ -765,6 +765,18 @@ test("the panel fact says the tabs answer an ask as well as a press", () => {
   assert.ok(guide.facts.some((candidate) => candidate.label === "The Settings tab"));
 });
 
+test("the sessions list fact says the options button wears an X that clears", () => {
+  const fact = buildLukeGuide(guideInput()).facts.find(
+    (candidate) => candidate.label === "The sessions list",
+  );
+
+  assert.ok(fact);
+  // The X is a capability of the list itself, and a capability the guide does
+  // not describe is one Luke will deny having — or misdescribe as only
+  // un-pressing chips one at a time.
+  assert.match(fact.detail, /an X on its right that clears every chosen chip at once/);
+});
+
 test("the guide describes the search, its three ways in, and their shared bound", () => {
   const fact = buildLukeGuide(guideInput()).facts.find(
     (candidate) => candidate.label === "Searching sessions",

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -368,7 +368,8 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "Conductor means Codex chats associated with Conductor. Cursor sits on both rows: " +
         "its app chip narrows to the chats the Cursor app can open, its agent chip to every " +
         "Cursor chat. The sheet stays open while " +
-        "chips toggle, and the options button wears the narrowing while the sheet is closed. " +
+        "chips toggle, and the options button wears the narrowing while the sheet is closed, " +
+        "with an X on its right that clears every chosen chip at once. " +
         "Chosen chips are un-pressed the same way they were pressed, a spoken ask can narrow " +
         "to one or several values combined the same way — local Codex voice chats is one ask " +
         "— naming an agent or app by its everyday name, or back to all, replacing what was " +

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -876,7 +876,12 @@ export function PanelBody({
               <SettingsSearchButton open={settingsSearchOpen} onToggle={onSettingsSearchToggle} />
             ) : null}
             {offerOptions ? (
-              <SessionOptionsButton list={list} open={optionsOpen} onToggle={onOptionsToggle} />
+              <SessionOptionsButton
+                list={list}
+                open={optionsOpen}
+                onToggle={onOptionsToggle}
+                onClear={() => onFiltersChange([])}
+              />
             ) : null}
           </span>
         ) : null}

--- a/apps/desktop/src/renderer/session-parts.tsx
+++ b/apps/desktop/src/renderer/session-parts.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { ERRAND_TARGET, errandTargetProps } from "./luke-errand";
 import { PANEL_TAB, panelPanelId, panelTabId } from "./panel-tabs";
 import { ProviderMark } from "./provider-marks";
@@ -207,6 +208,7 @@ export function SessionOptionsButton({
   /** Drops every chosen chip. Offered only while a selection stands. */
   onClear: () => void;
 }): React.JSX.Element {
+  const toggle = useRef<HTMLButtonElement | null>(null);
   const narrowed = list.filters.length > 0;
   const named = selectedFilterOptions(list).slice(0, NARROWED_ON_BUTTON);
   const beyond = list.filters.length - named.length;
@@ -219,6 +221,7 @@ export function SessionOptionsButton({
       data-narrowed={String(narrowed)}
     >
       <button
+        ref={toggle}
         type="button"
         id={SESSION_OPTIONS_BUTTON_ID}
         className="options-button"
@@ -252,7 +255,13 @@ export function SessionOptionsButton({
           className="options-clear"
           aria-label="Clear filters"
           title="Clear filters"
-          onClick={onClear}
+          onClick={() => {
+            onClear();
+            // The X unmounts with the selection. Return focus to the toggle
+            // it sat beside, the way the search clear returns to its field,
+            // so a keyboard press is not dumped onto the document.
+            toggle.current?.focus();
+          }}
         >
           <CloseIcon />
         </button>

--- a/apps/desktop/src/renderer/session-parts.tsx
+++ b/apps/desktop/src/renderer/session-parts.tsx
@@ -12,7 +12,7 @@ import {
   type SessionView,
   toggledSessionFilters,
 } from "./session-model";
-import { CloudIcon, LaptopIcon, OptionsIcon, VoiceIcon } from "./settings-icons";
+import { CloseIcon, CloudIcon, LaptopIcon, OptionsIcon, VoiceIcon } from "./settings-icons";
 
 /**
  * Rides beside a branch name to say which kind of identifier it is: a branch
@@ -145,10 +145,14 @@ const SORT_DESCRIPTORS: readonly SortDescriptor[] = [
 const SORT_LABEL_ID = "session-sort-label";
 export const SESSION_OPTIONS_ID = "session-options";
 /**
- * Named so the panel can tell a press on the button from a press outside the
- * sheet. The button keeps its own toggle: dismissed on the way down and toggled
- * on the way up, a press here would close and reopen the sheet in one gesture.
+ * The whole control the sheet answers to: the toggle and, while a selection
+ * stands, the X that clears it. Named so the panel can tell a press here from
+ * a press outside the sheet. The toggle keeps its own click: dismissed on the
+ * way down and toggled on the way up, a press here would close and reopen the
+ * sheet in one gesture. The X sits on the same control, so clearing is not
+ * "outside" either.
  */
+export const SESSION_OPTIONS_CONTROL_ID = "session-options-control";
 export const SESSION_OPTIONS_BUTTON_ID = "session-options-button";
 
 /** What each coarse chip is drawn with. An agent carries its own mark instead. */
@@ -187,15 +191,21 @@ const NARROWED_ON_BUTTON = 2;
  * is named on the button itself rather than only inside the sheet it opens.
  * The button has one line to say it on, so it names the first two choices and
  * counts the rest; the full selection stays on the hover and in the sheet.
+ * While a selection stands, an X on the right clears every chosen chip at
+ * once — a sibling rather than a nested button, because a button cannot hold
+ * another, and a press there must not also toggle the sheet.
  */
 export function SessionOptionsButton({
   list,
   open,
   onToggle,
+  onClear,
 }: {
   list: ArrangedSessions;
   open: boolean;
   onToggle: () => void;
+  /** Drops every chosen chip. Offered only while a selection stands. */
+  onClear: () => void;
 }): React.JSX.Element {
   const narrowed = list.filters.length > 0;
   const named = selectedFilterOptions(list).slice(0, NARROWED_ON_BUTTON);
@@ -203,34 +213,51 @@ export function SessionOptionsButton({
   const summary = selectionSummary(list);
 
   return (
-    <button
-      type="button"
-      id={SESSION_OPTIONS_BUTTON_ID}
-      className="options-button"
-      // The button already says how the list is being shown, so it is where a
-      // narrowing or a re-ordering Luke made himself is signed.
-      {...errandTargetProps(ERRAND_TARGET.LIST_OPTIONS)}
-      data-active={String(open)}
+    <span
+      className="options-control"
+      id={SESSION_OPTIONS_CONTROL_ID}
       data-narrowed={String(narrowed)}
-      aria-expanded={open}
-      aria-controls={SESSION_OPTIONS_ID}
-      aria-label={narrowed ? `Options — showing ${summary} only` : "Options"}
-      title={narrowed ? `Showing ${summary} only` : "Filter and sort"}
-      onClick={onToggle}
     >
-      <OptionsIcon />
+      <button
+        type="button"
+        id={SESSION_OPTIONS_BUTTON_ID}
+        className="options-button"
+        // The button already says how the list is being shown, so it is where a
+        // narrowing or a re-ordering Luke made himself is signed.
+        {...errandTargetProps(ERRAND_TARGET.LIST_OPTIONS)}
+        data-active={String(open)}
+        data-narrowed={String(narrowed)}
+        aria-expanded={open}
+        aria-controls={SESSION_OPTIONS_ID}
+        aria-label={narrowed ? `Options — showing ${summary} only` : "Options"}
+        title={narrowed ? `Showing ${summary} only` : "Filter and sort"}
+        onClick={onToggle}
+      >
+        <OptionsIcon />
+        {narrowed ? (
+          <span className="options-current">
+            {named.map((option) => (
+              <span className="options-current-item" key={option.filter}>
+                <FilterMark option={option} />
+                {option.label}
+              </span>
+            ))}
+            {beyond > 0 ? <span className="options-current-item">+{beyond}</span> : null}
+          </span>
+        ) : null}
+      </button>
       {narrowed ? (
-        <span className="options-current">
-          {named.map((option) => (
-            <span className="options-current-item" key={option.filter}>
-              <FilterMark option={option} />
-              {option.label}
-            </span>
-          ))}
-          {beyond > 0 ? <span className="options-current-item">+{beyond}</span> : null}
-        </span>
+        <button
+          type="button"
+          className="options-clear"
+          aria-label="Clear filters"
+          title="Clear filters"
+          onClick={onClear}
+        >
+          <CloseIcon />
+        </button>
       ) : null}
-    </button>
+    </span>
   );
 }
 

--- a/apps/desktop/src/renderer/styles/sessions-options-clear.test.ts
+++ b/apps/desktop/src/renderer/styles/sessions-options-clear.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+/**
+ * While a selection stands, the options control wears an X on its right that
+ * clears every chosen chip. These read the stylesheet and the control's markup
+ * as text, the way the row-side tests do, and guard the facts that seat stands
+ * on: the X is a sibling rather than a nested button, it sits on the right of
+ * the pill, and pressing it is the same empty selection the chips already know.
+ */
+const css = readFileSync(new URL("./sessions.css", import.meta.url), "utf8");
+const parts = readFileSync(new URL("../session-parts.tsx", import.meta.url), "utf8");
+const body = readFileSync(new URL("../panel-body.tsx", import.meta.url), "utf8");
+
+const rule = (selector: string): string => {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`${escaped} \\{([^}]*)\\}`).exec(css)?.[1] ?? "";
+};
+
+test("the X sits on the right of the options pill, as a sibling", () => {
+  const control = parts.indexOf('className="options-control"');
+  const toggle = parts.indexOf('className="options-button"', control);
+  const clear = parts.indexOf('className="options-clear"', toggle);
+  assert.notEqual(control, -1);
+  assert.notEqual(toggle, -1);
+  assert.notEqual(clear, -1);
+  assert.ok(toggle < clear, "the X belongs on the right of the filter names, not before them");
+  // Nested buttons are invalid HTML and would make a press on the X also
+  // toggle the sheet. The X has to be a sibling inside the wrapper.
+  const toggleClose = parts.indexOf("</button>", toggle);
+  assert.ok(toggleClose < clear, "the X is not nested inside the toggle");
+});
+
+test("the X is offered only while a selection stands, and names the clear", () => {
+  const clear = parts.indexOf('className="options-clear"');
+  const guarded = parts.lastIndexOf("{narrowed ?", clear);
+  assert.notEqual(clear, -1);
+  assert.notEqual(guarded, -1);
+  assert.match(parts.slice(clear), /aria-label="Clear filters"/);
+});
+
+test("clearing the control drops every chosen chip", () => {
+  assert.match(body, /onClear=\{\(\) => onFiltersChange\(\[\]\)\}/);
+});
+
+test("the narrowed pill is the wrapper, so the X can sit inside it", () => {
+  assert.match(rule(".options-control"), /display: inline-flex;/);
+  assert.match(rule(".options-control"), /align-items: center;/);
+  const pill = rule('.options-control[data-narrowed="true"]');
+  assert.match(pill, /background: var\(--raised\);/);
+  assert.match(pill, /border-radius: 10px;/);
+});
+
+test("the X is a disc that must not grow inside the pill", () => {
+  const clear = rule(".options-clear");
+  assert.match(clear, /width: 20px;/);
+  assert.match(clear, /height: 20px;/);
+  assert.match(clear, /padding: 0;/);
+  assert.match(clear, /flex: 0 0 auto;/);
+  assert.match(clear, /margin-right: 4px;/);
+});

--- a/apps/desktop/src/renderer/styles/sessions-options-clear.test.ts
+++ b/apps/desktop/src/renderer/styles/sessions-options-clear.test.ts
@@ -44,6 +44,13 @@ test("clearing the control drops every chosen chip", () => {
   assert.match(body, /onClear=\{\(\) => onFiltersChange\(\[\]\)\}/);
 });
 
+test("clearing returns focus to the toggle the X sat beside", () => {
+  const clear = parts.indexOf('className="options-clear"');
+  const handler = parts.slice(clear, parts.indexOf("</button>", clear));
+  assert.match(handler, /onClear\(\);/);
+  assert.match(handler, /toggle\.current\?\.focus\(\)/);
+});
+
 test("the narrowed pill is the wrapper, so the X can sit inside it", () => {
   assert.match(rule(".options-control"), /display: inline-flex;/);
   assert.match(rule(".options-control"), /align-items: center;/);

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -66,6 +66,30 @@
   flex: 0 0 auto;
 }
 
+/* The toggle and its clear share one seat: while nothing is chosen the
+   wrapper is invisible and the button is the pill; while a selection stands
+   the wrapper becomes the pill so the X can sit on its right without nesting
+   a button inside a button. */
+.options-control {
+  display: inline-flex;
+  align-items: center;
+}
+
+.options-control[data-narrowed="true"] {
+  min-height: 28px;
+  border-radius: 10px;
+  background: var(--raised);
+  color: var(--text-primary);
+  transition:
+    background-color var(--duration-hover) ease,
+    color var(--duration-hover) ease;
+}
+
+.options-control[data-narrowed="true"]:hover,
+.options-control[data-narrowed="true"]:has(.options-button[data-active="true"]) {
+  background: var(--raised-strong);
+}
+
 .options-button {
   display: inline-flex;
   min-height: 28px;
@@ -87,6 +111,18 @@
 .options-button[data-active="true"] {
   background: var(--raised-strong);
   color: var(--text-primary);
+}
+
+.options-control[data-narrowed="true"] .options-button {
+  padding-right: 4px;
+  background: none;
+  color: inherit;
+}
+
+.options-control[data-narrowed="true"] .options-button:hover,
+.options-control[data-narrowed="true"] .options-button[data-active="true"] {
+  background: none;
+  color: inherit;
 }
 
 .options-glyph {
@@ -113,6 +149,36 @@
 
 .options-button[data-narrowed="true"] {
   color: var(--text-primary);
+}
+
+/* The way out of a held selection without opening the sheet. Colour is the
+   whole hover: the button must not grow or move inside a pill that names the
+   narrowing. Padding is zeroed by hand — the engine's own button padding is
+   asymmetric, and in a 20px disc it reads as the glyph leaning to one side. */
+.options-clear {
+  display: grid;
+  width: 20px;
+  height: 20px;
+  flex: 0 0 auto;
+  margin-right: 4px;
+  padding: 0;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.14);
+  color: var(--text-tertiary);
+  place-items: center;
+  transition:
+    background-color var(--duration-hover) ease,
+    color var(--duration-hover) ease;
+}
+
+.options-clear:hover {
+  background: rgba(255, 255, 255, 0.22);
+  color: var(--text-primary);
+}
+
+.options-clear .icon-button-glyph {
+  width: 10px;
+  height: 10px;
 }
 
 /* Floating rather than in the flow. In the flow it would push the last row down


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- When a session filter is in force, the options button already names the selection. An X now sits on the right of that control so the user can drop every chosen chip at once, without opening the sheet.
- The X is a sibling button, not nested inside the toggle, so a press there clears and does not also open or close the filter sheet.
- Clearing returns keyboard focus to the options toggle, because the X unmounts with the selection.
- Luke's sessions-list guide now describes the clear control.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed on the first revision; follow-up focus restore re-tested locally
- macOS Electron verification (`./scripts/verify.sh`): `not run` (Linux cloud agent; CI supplies automated visual evidence)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32449181332/artifacts/9435115888) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32449181332)

- Commit: `d9962b843f81653f262df975c09b6e1be50497fe`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Follow-up commit addresses Bugbot: keyboard focus no longer falls to the document after Clear filters.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43ef37fe-57a9-4245-a975-66547c4f952a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43ef37fe-57a9-4245-a975-66547c4f952a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

