### PR TITLE
fix(cursor): observe the CLI's chat store beside the transcripts

### DIFF
--- a/packages/providers/src/cursor/chat-store.ts
+++ b/packages/providers/src/cursor/chat-store.ts
@@ -1,0 +1,114 @@
+import path from "node:path";
+import {
+  isWireString,
+  text,
+  unparsedWire,
+  type WireBoundaryInput,
+  wholeNumber,
+  wireRecord,
+} from "@sidecar/wire";
+import {
+  fileStats,
+  readDirectory,
+  type SessionFileCandidate,
+} from "../shared/local-session-adapter.js";
+
+/**
+ * Where Cursor's CLI keeps each chat's own record: `chats/<hash>/<chat id>/`,
+ * the hash naming the folder the chat ran in. Each chat directory holds a
+ * small metadata file and the conversation itself as a blob store. Only the
+ * metadata is read: the store's conversation is a blob graph this build
+ * cannot read faithfully, and the metadata already carries what a row needs —
+ * the name Cursor gave the chat, the exact folder it ran in, and when it last
+ * moved.
+ */
+export const CURSOR_CHAT_STORE_DIRECTORY = "chats";
+const CURSOR_CHAT_META_FILE = "meta.json";
+const CURSOR_CHAT_STORE_FILE = "store.db";
+/** SQLite's write-ahead log, which is what moves while a turn is running. */
+const CURSOR_CHAT_STORE_JOURNAL_SUFFIX = "-wal";
+
+/**
+ * The one metadata version this build can read. Cursor stamps each record
+ * with its schema, so a future shape is skipped rather than misread.
+ */
+const CURSOR_CHAT_META_SCHEMA_VERSION = 1;
+
+const CURSOR_CHAT_META_FIELD = {
+  SCHEMA_VERSION: "schemaVersion",
+  HAS_CONVERSATION: "hasConversation",
+  TITLE: "title",
+  CWD: "cwd",
+  UPDATED_AT: "updatedAtMs",
+} as const;
+
+/** What one chat's metadata record says about it. */
+export interface CursorChatStoreMeta {
+  title?: string;
+  cwd?: string;
+  updatedAtMs?: number;
+}
+
+/**
+ * Reads one chat's metadata record. A record this build cannot parse, one
+ * stamped with a schema it does not know, or one whose chat has no
+ * conversation at all answers nothing — a chat Cursor itself says holds no
+ * conversation has nothing to draw a row from.
+ */
+export function readCursorChatStoreMeta(source: string): CursorChatStoreMeta | undefined {
+  let parsed: WireBoundaryInput;
+  try {
+    parsed = JSON.parse(source);
+  } catch {
+    return undefined;
+  }
+  const record = wireRecord(unparsedWire(parsed));
+  if (!record) return undefined;
+  if (record[CURSOR_CHAT_META_FIELD.SCHEMA_VERSION] !== CURSOR_CHAT_META_SCHEMA_VERSION) {
+    return undefined;
+  }
+  if (record[CURSOR_CHAT_META_FIELD.HAS_CONVERSATION] !== true) return undefined;
+  const meta: CursorChatStoreMeta = {};
+  const title = text(record[CURSOR_CHAT_META_FIELD.TITLE]);
+  if (title) meta.title = title;
+  const cwd = record[CURSOR_CHAT_META_FIELD.CWD];
+  if (isWireString(cwd) && path.isAbsolute(cwd)) meta.cwd = cwd;
+  const updatedAtMs = wholeNumber(record[CURSOR_CHAT_META_FIELD.UPDATED_AT]);
+  if (updatedAtMs !== undefined) meta.updatedAtMs = updatedAtMs;
+  return meta;
+}
+
+/**
+ * One chat directory per session, named after the session, with the metadata
+ * file as the candidate's own file. The candidate's clock is the newest of
+ * the metadata and the conversation store's files, because the store — its
+ * journal above all — is what moves while a turn runs, and the metadata
+ * alone is rewritten too rarely to say the chat is doing anything.
+ */
+export async function chatStoreSessionsIn(
+  sessionsDirectory: string,
+): Promise<SessionFileCandidate[]> {
+  const entries = await readDirectory(sessionsDirectory);
+  const candidates = await Promise.all(
+    entries.map(async (entry) => {
+      const providerSessionId = entry.name.trim();
+      if (!providerSessionId) return undefined;
+      const chatDirectory = path.join(sessionsDirectory, entry.name);
+      const metaStats = await fileStats(path.join(chatDirectory, CURSOR_CHAT_META_FILE));
+      if (!metaStats?.isFile()) return undefined;
+      const storePath = path.join(chatDirectory, CURSOR_CHAT_STORE_FILE);
+      const [storeStats, journalStats] = await Promise.all([
+        fileStats(storePath),
+        fileStats(`${storePath}${CURSOR_CHAT_STORE_JOURNAL_SUFFIX}`),
+      ]);
+      return {
+        filePath: path.join(chatDirectory, CURSOR_CHAT_META_FILE),
+        providerSessionId,
+        mtimeMs: Math.max(metaStats.mtimeMs, storeStats?.mtimeMs ?? 0, journalStats?.mtimeMs ?? 0),
+      };
+    }),
+  );
+  return candidates.filter(
+    (candidate): candidate is SessionFileCandidate => candidate !== undefined,
+  );
+}

--- a/packages/providers/src/cursor/local-adapter.test.ts
+++ b/packages/providers/src/cursor/local-adapter.test.ts
@@ -1375,3 +1375,190 @@ test("returns an empty snapshot when Cursor has no local sessions", async (t) =>
 
   assert.deepEqual(await adapterFor(state).observe(), []);
 });
+
+const CURSOR_CHATS_DIRECTORY = "chats";
+
+/**
+ * One chat in the CLI's chat store: a metadata record beside the conversation
+ * store. The store's blobs are the conversation itself, which observation must
+ * never read, so the fixture plants transcript text there and the tests assert
+ * it never surfaces.
+ */
+async function writeChatStore(
+  state: CursorState,
+  hashDirectoryName: string,
+  sessionId: string,
+  meta: ParsedJsonObject,
+  mtimeMs: number,
+): Promise<void> {
+  const chatDirectory = path.join(
+    state.cursorHome,
+    CURSOR_CHATS_DIRECTORY,
+    hashDirectoryName,
+    sessionId,
+  );
+  await fs.mkdir(chatDirectory, { recursive: true });
+  const metaPath = path.join(chatDirectory, "meta.json");
+  await fs.writeFile(metaPath, JSON.stringify(meta));
+  await fs.utimes(metaPath, mtimeMs / 1000, mtimeMs / 1000);
+  const storePath = path.join(chatDirectory, "store.db");
+  await fs.writeFile(storePath, SECRET_TRANSCRIPT_TEXT);
+  await fs.utimes(storePath, mtimeMs / 1000, mtimeMs / 1000);
+}
+
+function chatStoreMeta(overrides: ParsedJsonObject = {}): ParsedJsonObject {
+  return {
+    schemaVersion: 1,
+    hasConversation: true,
+    createdAtMs: TEST_TIME - 60_000,
+    updatedAtMs: TEST_TIME - 5_000,
+    cwd: "/Users/test/worktree",
+    ...overrides,
+  };
+}
+
+test("observes a chat only the chat store holds, named and placed by its own record", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeChatStore(
+    state,
+    "a34afeeb",
+    "ses-store-only",
+    chatStoreMeta({ title: "Math Question" }),
+    TEST_TIME - 5_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.equal(observations.length, 1);
+  const observation = observations[0];
+  assert.equal(observation?.providerSessionId, "ses-store-only");
+  assert.equal(observation?.title, "Math Question");
+  assert.equal(observation?.directory, "/Users/test/worktree");
+  assert.equal(observation?.detail?.repository, "worktree");
+  // The store is written while a turn runs, so a store that just moved is a
+  // chat doing something; the blob graph holds the conversation and stays
+  // unread, so no tool call, recap, or message advertisement can ride.
+  assert.equal(observation?.status, SESSION_STATUS.WORKING);
+  assert.equal(observation?.recap, undefined);
+  assert.equal(observation?.canReceiveMessage, undefined);
+  assert.ok(!JSON.stringify(observations).includes(SECRET_TRANSCRIPT_TEXT));
+});
+
+test("a chat store gone quiet is unknown, because its turn boundary is unreadable", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeChatStore(
+    state,
+    "a34afeeb",
+    "ses-quiet",
+    chatStoreMeta({ title: "Older work", updatedAtMs: TEST_TIME - YEAR_MS }),
+    TEST_TIME - YEAR_MS,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
+});
+
+test("skips a chat record this build does not know, or one with no conversation", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeChatStore(
+    state,
+    "a34afeeb",
+    "ses-future",
+    chatStoreMeta({ schemaVersion: 2 }),
+    TEST_TIME - 5_000,
+  );
+  await writeChatStore(
+    state,
+    "a34afeeb",
+    "ses-empty",
+    chatStoreMeta({ hasConversation: false }),
+    TEST_TIME - 5_000,
+  );
+
+  assert.deepEqual(await adapterFor(state).observe(), []);
+});
+
+test("the chat store names and places a chat whose transcript is observed", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeTranscript(
+    state,
+    "Users-test-superset-worktrees-repo-square-geometry",
+    "ses-both",
+    [
+      messageRecord(TEST_ROLE.USER, TEST_CONTENT_TYPE.TEXT),
+      messageRecord(TEST_ROLE.ASSISTANT, TEST_CONTENT_TYPE.TEXT),
+      turnEndedRecord(TEST_TURN_STATUS.SUCCESS),
+    ],
+    TEST_TIME - 5_000,
+  );
+  await writeChatStore(
+    state,
+    "a34afeeb",
+    "ses-both",
+    chatStoreMeta({
+      title: "Square geometry",
+      cwd: "/Users/test/.superset/worktrees/repo/square-geometry",
+    }),
+    TEST_TIME - 4_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  // One row: the transcript is the richer record and keeps the turn's own
+  // verdict, while the store supplies the name and exact folder the
+  // transcript never wrote down.
+  assert.equal(observations.length, 1);
+  const observation = observations[0];
+  assert.equal(observation?.title, "Square geometry");
+  assert.equal(observation?.directory, "/Users/test/.superset/worktrees/repo/square-geometry");
+  assert.equal(observation?.status, SESSION_STATUS.WAITING);
+});
+
+test("a chat resumed from another folder reads its freshest record", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeChatStore(
+    state,
+    "hash-old",
+    "ses-moved",
+    chatStoreMeta({ title: "Where it started", cwd: "/Users/test/first" }),
+    TEST_TIME - 60_000,
+  );
+  await writeChatStore(
+    state,
+    "hash-new",
+    "ses-moved",
+    chatStoreMeta({ title: "Where it moved", cwd: "/Users/test/second" }),
+    TEST_TIME - 5_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.title, "Where it moved");
+  assert.equal(observations[0]?.directory, "/Users/test/second");
+});
+
+test("leaves a chat-store chat the app filed away off the roster", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeChatStore(state, "a34afeeb", "ses-filed", chatStoreMeta(), TEST_TIME - 5_000);
+  await writeChatHeaders(state, [{ sessionId: "ses-filed", archived: true }]);
+
+  assert.deepEqual(await adapterFor(state).observe(), []);
+});
+
+test("a transcript chat reports the folder a resume would be pinned to", async (t) => {
+  const state = await temporaryCursorState(t);
+  await writeWorkspaceRecord(state, "9f1c", "/Users/test/luke");
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "ses-pinned",
+    [turnEndedRecord(TEST_TURN_STATUS.SUCCESS)],
+    TEST_TIME - 5_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.equal(observations[0]?.directory, "/Users/test/luke");
+});

--- a/packages/providers/src/cursor/local-adapter.test.ts
+++ b/packages/providers/src/cursor/local-adapter.test.ts
@@ -1562,3 +1562,29 @@ test("a transcript chat reports the folder a resume would be pinned to", async (
 
   assert.equal(observations[0]?.directory, "/Users/test/luke");
 });
+
+test("the store's clock keeps an open turn working while only the store moves", async (t) => {
+  const state = await temporaryCursorState(t);
+  // The transcript went quiet long ago and the metadata record's own
+  // timestamp with it — but the store's files just moved, which is what an
+  // open turn looks like from the store's side.
+  await writeTranscript(
+    state,
+    "Users-test-luke",
+    "ses-open",
+    [messageRecord(TEST_ROLE.USER, TEST_CONTENT_TYPE.TEXT)],
+    TEST_TIME - YEAR_MS,
+  );
+  await writeChatStore(
+    state,
+    "a34afeeb",
+    "ses-open",
+    chatStoreMeta({ updatedAtMs: TEST_TIME - YEAR_MS }),
+    TEST_TIME - 5_000,
+  );
+
+  const observations = await adapterFor(state).observe();
+
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
+});

--- a/packages/providers/src/cursor/local-adapter.ts
+++ b/packages/providers/src/cursor/local-adapter.ts
@@ -58,6 +58,12 @@ import { transcriptContentBlocks, transcriptMessageText } from "../shared/local-
 import { CURSOR_PROVIDER } from "./adapter.js";
 import { cursorApplication, cursorChatLink } from "./app-links.js";
 import {
+  CURSOR_CHAT_STORE_DIRECTORY,
+  type CursorChatStoreMeta,
+  chatStoreSessionsIn,
+  readCursorChatStoreMeta,
+} from "./chat-store.js";
+import {
   CURSOR_HOOK_EVENT,
   type CursorHookEvent,
   type ObservedCursorHookEvent,
@@ -201,9 +207,30 @@ interface CursorSendTarget {
   transcriptFilePath: string;
 }
 
+const CURSOR_CANDIDATE_KIND = {
+  /** A chat with a transcript in the projects tree, the richer read. */
+  TRANSCRIPT: "transcript",
+  /** A chat only the chat store holds, drawn from its metadata record alone. */
+  CHAT_STORE: "chat-store",
+} as const;
+
 interface CursorTranscriptCandidate extends SessionFileCandidate {
+  kind: typeof CURSOR_CANDIDATE_KIND.TRANSCRIPT;
   projectDirectoryName: string;
+  /**
+   * The chat store's metadata record for this same chat, when one exists: the
+   * name Cursor gave the chat and the exact folder it ran in, which the
+   * transcript itself never records.
+   */
+  meta?: CursorChatStoreMeta;
 }
+
+interface CursorChatStoreCandidate extends SessionFileCandidate {
+  kind: typeof CURSOR_CANDIDATE_KIND.CHAT_STORE;
+  meta: CursorChatStoreMeta;
+}
+
+type CursorSessionCandidate = CursorTranscriptCandidate | CursorChatStoreCandidate;
 
 /**
  * Reduces a name to what both halves of Cursor's local state can still agree
@@ -342,6 +369,7 @@ async function transcriptsIn(
       const stats = await fileStats(filePath);
       if (!stats?.isFile()) return undefined;
       return {
+        kind: CURSOR_CANDIDATE_KIND.TRANSCRIPT,
         filePath,
         providerSessionId,
         mtimeMs: stats.mtimeMs,
@@ -850,7 +878,7 @@ function defaultGlobalStorageStatePath(): string {
  * Cursor has not written down.
  */
 export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
-  CursorTranscriptCandidate,
+  CursorSessionCandidate,
   ParsedCursorTail
 > {
   readonly provider = CURSOR_PROVIDER;
@@ -868,6 +896,7 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
   #cursorAgentBinaryPath: string | undefined;
   #trustedFoldersByProject: ReadonlyMap<string, string> = new Map();
   readonly #sendTargets = new Map<string, CursorSendTarget>();
+  readonly #chatStoreMetaCache = new Map<string, { mtimeMs: number; meta?: CursorChatStoreMeta }>();
 
   constructor(options: CursorLocalAdapterOptions = {}) {
     super(options);
@@ -897,13 +926,43 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
     this.#transcriptMaximumRenderedLength = options.transcriptMaximumRenderedLength;
   }
 
-  protected async discover(): Promise<CursorTranscriptCandidate[]> {
-    const candidates = await discoverSessionFiles({
-      projectsDirectory: path.join(this.#cursorHome, CURSOR_DIRECTORY.PROJECTS),
-      sessionsDirectoryName: CURSOR_DIRECTORY.TRANSCRIPTS,
-      maximumProjectDirectories: this.#maximumProjectDirectories,
-      sessionFilesIn: transcriptsIn,
-    });
+  protected async discover(): Promise<CursorSessionCandidate[]> {
+    const [transcripts, storeFiles] = await Promise.all([
+      discoverSessionFiles({
+        projectsDirectory: path.join(this.#cursorHome, CURSOR_DIRECTORY.PROJECTS),
+        sessionsDirectoryName: CURSOR_DIRECTORY.TRANSCRIPTS,
+        maximumProjectDirectories: this.#maximumProjectDirectories,
+        sessionFilesIn: transcriptsIn,
+      }),
+      discoverSessionFiles({
+        projectsDirectory: path.join(this.#cursorHome, CURSOR_CHAT_STORE_DIRECTORY),
+        maximumProjectDirectories: this.#maximumProjectDirectories,
+        sessionFilesIn: (sessionsDirectory) => chatStoreSessionsIn(sessionsDirectory),
+      }),
+    ]);
+    const metaByFile = await this.#chatStoreMetas(storeFiles);
+    // Newest first from discovery, so a chat resumed from another folder — the
+    // store keys chats by folder, and a resume re-files one — reads its
+    // freshest record.
+    const metaById = new Map<string, CursorChatStoreMeta>();
+    const transcriptIds = new Set(transcripts.map((candidate) => candidate.providerSessionId));
+    const stores: CursorChatStoreCandidate[] = [];
+    for (const file of storeFiles) {
+      const meta = metaByFile.get(file.filePath);
+      if (!meta) continue;
+      if (!metaById.has(file.providerSessionId)) metaById.set(file.providerSessionId, meta);
+      // A chat with a transcript is read from the transcript — the richer
+      // record — and its store metadata rides that candidate instead.
+      if (transcriptIds.has(file.providerSessionId)) continue;
+      stores.push({ ...file, kind: CURSOR_CANDIDATE_KIND.CHAT_STORE, meta });
+    }
+    const candidates: CursorSessionCandidate[] = [
+      ...transcripts.map((candidate) => {
+        const meta = metaById.get(candidate.providerSessionId);
+        return meta ? { ...candidate, meta } : candidate;
+      }),
+      ...stores,
+    ].sort((first, second) => second.mtimeMs - first.mtimeMs);
     const index = await this.#appChatRegistry.index(
       candidates.map((candidate) => candidate.providerSessionId),
     );
@@ -914,9 +973,36 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
     return candidates.filter((candidate) => !index.archived.has(candidate.providerSessionId));
   }
 
-  protected override async prepare(
-    candidates: readonly CursorTranscriptCandidate[],
-  ): Promise<void> {
+  /**
+   * Each candidate's metadata record, re-read only when its chat has moved —
+   * the same clock the parse cache runs on — and dropped when the chat is
+   * gone. An unreadable, foreign, or conversation-less record resolves to
+   * nothing, which is what drops its candidate.
+   */
+  async #chatStoreMetas(
+    storeFiles: readonly SessionFileCandidate[],
+  ): Promise<ReadonlyMap<string, CursorChatStoreMeta | undefined>> {
+    const metas = new Map<string, CursorChatStoreMeta | undefined>();
+    await Promise.all(
+      storeFiles.map(async (file) => {
+        const cached = this.#chatStoreMetaCache.get(file.filePath);
+        if (cached && cached.mtimeMs === file.mtimeMs) {
+          metas.set(file.filePath, cached.meta);
+          return;
+        }
+        const source = await readTextFile(file.filePath);
+        const meta = source === undefined ? undefined : readCursorChatStoreMeta(source);
+        this.#chatStoreMetaCache.set(file.filePath, { mtimeMs: file.mtimeMs, meta });
+        metas.set(file.filePath, meta);
+      }),
+    );
+    for (const filePath of this.#chatStoreMetaCache.keys()) {
+      if (!metas.has(filePath)) this.#chatStoreMetaCache.delete(filePath);
+    }
+    return metas;
+  }
+
+  protected override async prepare(candidates: readonly CursorSessionCandidate[]): Promise<void> {
     // A send target lives exactly as long as its chat stays on the roster this
     // pass discovered. A chat archived or gone since the last pass never
     // reaches observation() again, so its entry is pruned here rather than
@@ -928,7 +1014,13 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
       if (!discovered.has(providerSessionId)) this.#sendTargets.delete(providerSessionId);
     }
     const projectDirectoryNames = [
-      ...new Set(candidates.map((candidate) => candidate.projectDirectoryName)),
+      ...new Set(
+        candidates.flatMap((candidate) =>
+          candidate.kind === CURSOR_CANDIDATE_KIND.TRANSCRIPT
+            ? [candidate.projectDirectoryName]
+            : [],
+        ),
+      ),
     ];
     const [binaryPath, trustedFolders] = await Promise.all([
       // Located every pass, so an install or removal is honoured on the next
@@ -987,7 +1079,11 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
     });
   }
 
-  protected async parse(candidate: CursorTranscriptCandidate): Promise<ParsedCursorTail> {
+  protected async parse(candidate: CursorSessionCandidate): Promise<ParsedCursorTail> {
+    // A chat-store candidate's tail is legitimately empty: the store's
+    // conversation is a blob graph this build cannot read, so no turn, tool
+    // call, or recap can honestly come out of it.
+    if (candidate.kind === CURSOR_CANDIDATE_KIND.CHAT_STORE) return {};
     return parseCursorTail(await readTail(candidate.filePath, this.#readTailBytes));
   }
 
@@ -999,11 +1095,14 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
    * reading this machine reports one that runs on it.
    */
   protected async observation(
-    candidate: CursorTranscriptCandidate,
+    candidate: CursorSessionCandidate,
     parsed: ParsedCursorTail,
     now: number,
     activeSessionFreshnessMs: number,
   ): Promise<ProviderSessionObservation> {
+    if (candidate.kind === CURSOR_CANDIDATE_KIND.CHAT_STORE) {
+      return this.#chatStoreObservation(candidate, now, activeSessionFreshnessMs);
+    }
     const header = this.#appChatIndex.headers.get(candidate.providerSessionId);
     // One folder answers for the label, the branch, and the send pin, in the
     // order of how exactly each source names it: the chat's own header, the
@@ -1015,15 +1114,12 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
     const label = folderPath
       ? workspaceLabel(folderPath)
       : this.#workspaceLabels.label(candidate.projectDirectoryName);
-    const hookEventsDirectory = this.#hookEventsDirectory?.();
-    const hookEvent: ObservedCursorHookEvent | undefined = hookEventsDirectory
-      ? await readCursorHookEvent(hookEventsDirectory, candidate.providerSessionId).catch(
-          () => undefined,
-        )
-      : undefined;
+    const hookEvent = await this.#hookEvent(candidate.providerSessionId);
     // A transcript carries no timestamps of its own, so when it was last
-    // written is Cursor's only account of when this session last did anything.
-    const transcriptAt = candidate.mtimeMs;
+    // written is Cursor's only account of when this session last did anything —
+    // sharpened by the chat store's own clock where the store holds this chat,
+    // because the store is written while a turn runs and the transcript is not.
+    const transcriptAt = Math.max(candidate.mtimeMs, candidate.meta?.updatedAtMs ?? 0);
     const refined = hookRefinedStatus({
       refinement: CURSOR_HOOK_STATUS_REFINEMENT,
       hookEvent,
@@ -1073,11 +1169,16 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
     } else {
       this.#sendTargets.delete(candidate.providerSessionId);
     }
+    // The chat store names the chat and the exact folder it ran in, neither
+    // of which the transcript records; the folder Luke would pin a resume to
+    // stands in for a chat the store does not hold.
+    const directory = candidate.meta?.cwd ?? folderPath;
     return {
       providerSessionId: candidate.providerSessionId,
-      title: header?.name ?? label,
+      title: header?.name ?? oneLine(candidate.meta?.title, maximumSessionTitleLength) ?? label,
       status,
       observedAt,
+      ...(directory ? { directory } : undefined),
       detail: detailFor(label, status, link, parsed.activity, branch, header?.diff),
       ...(parsed.recap ? { recap: parsed.recap } : undefined),
       ...(canReceiveMessage ? { canReceiveMessage: true } : undefined),
@@ -1086,6 +1187,69 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
         : undefined),
       ...(link ? { applications: [cursorApplication(link)] } : undefined),
     };
+  }
+
+  /**
+   * A chat only the chat store holds, drawn from its metadata record alone.
+   * The store's conversation is a blob graph this build cannot read, so the
+   * turn boundary is unreadable: a store still being written is a chat doing
+   * something, one gone quiet is unknown rather than holding, and the hooks
+   * sharpen both exactly as they do for a transcript. No tool call, recap, or
+   * message advertisement can honestly come out of a record this thin — the
+   * send stays with chats whose settled turn the transcript can show.
+   */
+  async #chatStoreObservation(
+    candidate: CursorChatStoreCandidate,
+    now: number,
+    activeSessionFreshnessMs: number,
+  ): Promise<ProviderSessionObservation> {
+    const header = this.#appChatIndex.headers.get(candidate.providerSessionId);
+    const label = workspaceLabel(candidate.meta.cwd);
+    const hookEvent = await this.#hookEvent(candidate.providerSessionId);
+    const providerAt = Math.max(candidate.mtimeMs, candidate.meta.updatedAtMs ?? 0);
+    const refined = hookRefinedStatus({
+      refinement: CURSOR_HOOK_STATUS_REFINEMENT,
+      hookEvent,
+      providerAtMs: providerAt,
+      statusAt: (observedAt) =>
+        statusFromTurn(undefined, observedAt, now, activeSessionFreshnessMs),
+      now,
+      activeSessionFreshnessMs,
+    });
+    const { observedAt } = refined;
+    let status = refined.status;
+    // The same held-call upgrade a transcript row gets: a store row's turn is
+    // always unreadable, so the header's record of a live hold is the one
+    // word there is, decaying with the freshness that made the row working.
+    if (header?.blockedPending && status === SESSION_STATUS.WORKING) {
+      status = SESSION_STATUS.WAITING;
+    }
+    const appHeld = this.#appChatIndex.held.has(candidate.providerSessionId);
+    const link = appHeld ? cursorChatLink(candidate.providerSessionId) : undefined;
+    const branch =
+      (candidate.meta.cwd ? await branchFromGitHead(candidate.meta.cwd) : undefined) ??
+      header?.branch;
+    this.#sendTargets.delete(candidate.providerSessionId);
+    return {
+      providerSessionId: candidate.providerSessionId,
+      title:
+        header?.name ?? oneLine(candidate.meta.title, maximumSessionTitleLength) ?? label,
+      status,
+      observedAt,
+      ...(candidate.meta.cwd ? { directory: candidate.meta.cwd } : undefined),
+      detail: detailFor(label, status, link, undefined, branch, header?.diff),
+      ...(refined.sessionClosed
+        ? { completionCause: SESSION_COMPLETION_CAUSE.SESSION_CLOSED }
+        : undefined),
+      ...(link ? { applications: [cursorApplication(link)] } : undefined),
+    };
+  }
+
+  /** The observation hook's last word about one session, where hooks are on at all. */
+  async #hookEvent(providerSessionId: string): Promise<ObservedCursorHookEvent | undefined> {
+    const hookEventsDirectory = this.#hookEventsDirectory?.();
+    if (!hookEventsDirectory) return undefined;
+    return readCursorHookEvent(hookEventsDirectory, providerSessionId).catch(() => undefined);
   }
 
   /**

--- a/packages/providers/src/cursor/local-adapter.ts
+++ b/packages/providers/src/cursor/local-adapter.ts
@@ -1112,15 +1112,23 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
       return this.#chatStoreObservation(candidate, now, activeSessionFreshnessMs);
     }
     const header = this.#appChatIndex.headers.get(candidate.providerSessionId);
-    // One folder answers for the label, the branch, and the send pin, in the
-    // order of how exactly each source names it: the chat's own header, the
-    // project's trust record, and last the reduced-name workspace match.
+    // The send pin's folder, in the order of how exactly each source names
+    // it: the chat's own header, the project's trust record, and last the
+    // reduced-name workspace match. Deliberately not the chat store's cwd:
+    // the messaging exception pins a resume to the folder Cursor's workspace
+    // records name, and widening that set is a product decision, not an
+    // implementation detail.
     const folderPath =
       header?.folderPath ??
       this.#trustedFoldersByProject.get(candidate.projectDirectoryName) ??
       this.#workspaceLabels.folder(candidate.projectDirectoryName);
-    const label = folderPath
-      ? workspaceLabel(folderPath)
+    // What the row shows and groups by is the chat's own folder, and the
+    // store's record of it is the most exact where one stands — the cwd the
+    // chat actually ran in, which is also what a workspace manager's worktree
+    // is matched against.
+    const directory = candidate.meta?.cwd ?? folderPath;
+    const label = directory
+      ? workspaceLabel(directory)
       : this.#workspaceLabels.label(candidate.projectDirectoryName);
     const hookEvent = await this.#hookEvent(candidate.providerSessionId);
     // A transcript carries no timestamps of its own, so when it was last
@@ -1156,7 +1164,7 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
     // header's created-on branch says where a chat began, not where its
     // folder stands after a checkout — with that header record standing in
     // where the folder cannot say.
-    const branch = (folderPath ? await branchFromGitHead(folderPath) : undefined) ?? header?.branch;
+    const branch = (directory ? await branchFromGitHead(directory) : undefined) ?? header?.branch;
     // A message is advertised only where the CLI's documented resume can
     // honestly land one: the turn is settled and nothing newer says work is
     // running — a prompt hook can know about a turn the transcript has not
@@ -1181,10 +1189,6 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
     } else {
       this.#sendTargets.delete(candidate.providerSessionId);
     }
-    // The chat store names the chat and the exact folder it ran in, neither
-    // of which the transcript records; the folder Luke would pin a resume to
-    // stands in for a chat the store does not hold.
-    const directory = candidate.meta?.cwd ?? folderPath;
     return {
       providerSessionId: candidate.providerSessionId,
       title: header?.name ?? oneLine(candidate.meta?.title, maximumSessionTitleLength) ?? label,

--- a/packages/providers/src/cursor/local-adapter.ts
+++ b/packages/providers/src/cursor/local-adapter.ts
@@ -223,6 +223,12 @@ interface CursorTranscriptCandidate extends SessionFileCandidate {
    * transcript itself never records.
    */
   meta?: CursorChatStoreMeta;
+  /**
+   * The store's own file clock for the same chat — its journal is what moves
+   * while a turn runs, which neither the transcript nor the metadata record's
+   * timestamp shows.
+   */
+  storeAtMs?: number;
 }
 
 interface CursorChatStoreCandidate extends SessionFileCandidate {
@@ -944,13 +950,15 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
     // Newest first from discovery, so a chat resumed from another folder — the
     // store keys chats by folder, and a resume re-files one — reads its
     // freshest record.
-    const metaById = new Map<string, CursorChatStoreMeta>();
+    const metaById = new Map<string, { meta: CursorChatStoreMeta; atMs: number }>();
     const transcriptIds = new Set(transcripts.map((candidate) => candidate.providerSessionId));
     const stores: CursorChatStoreCandidate[] = [];
     for (const file of storeFiles) {
       const meta = metaByFile.get(file.filePath);
       if (!meta) continue;
-      if (!metaById.has(file.providerSessionId)) metaById.set(file.providerSessionId, meta);
+      if (!metaById.has(file.providerSessionId)) {
+        metaById.set(file.providerSessionId, { meta, atMs: file.mtimeMs });
+      }
       // A chat with a transcript is read from the transcript — the richer
       // record — and its store metadata rides that candidate instead.
       if (transcriptIds.has(file.providerSessionId)) continue;
@@ -958,8 +966,8 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
     }
     const candidates: CursorSessionCandidate[] = [
       ...transcripts.map((candidate) => {
-        const meta = metaById.get(candidate.providerSessionId);
-        return meta ? { ...candidate, meta } : candidate;
+        const store = metaById.get(candidate.providerSessionId);
+        return store ? { ...candidate, meta: store.meta, storeAtMs: store.atMs } : candidate;
       }),
       ...stores,
     ].sort((first, second) => second.mtimeMs - first.mtimeMs);
@@ -1119,7 +1127,11 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
     // written is Cursor's only account of when this session last did anything —
     // sharpened by the chat store's own clock where the store holds this chat,
     // because the store is written while a turn runs and the transcript is not.
-    const transcriptAt = Math.max(candidate.mtimeMs, candidate.meta?.updatedAtMs ?? 0);
+    const transcriptAt = Math.max(
+      candidate.mtimeMs,
+      candidate.storeAtMs ?? 0,
+      candidate.meta?.updatedAtMs ?? 0,
+    );
     const refined = hookRefinedStatus({
       refinement: CURSOR_HOOK_STATUS_REFINEMENT,
       hookEvent,
@@ -1232,8 +1244,7 @@ export class CursorLocalSessionAdapter extends LocalFileSessionAdapter<
     this.#sendTargets.delete(candidate.providerSessionId);
     return {
       providerSessionId: candidate.providerSessionId,
-      title:
-        header?.name ?? oneLine(candidate.meta.title, maximumSessionTitleLength) ?? label,
+      title: header?.name ?? oneLine(candidate.meta.title, maximumSessionTitleLength) ?? label,
       status,
       observedAt,
       ...(candidate.meta.cwd ? { directory: candidate.meta.cwd } : undefined),


### PR DESCRIPTION
Stacked on #395 (it uses the `directory` observation field introduced there). Retarget to `main` once #395 merges.

## Problem

Cursor chats inside Superset were detected inconsistently, and investigation on a real machine found two causes:

1. Newer `cursor-agent` builds (2026.08) keep each chat under `~/.cursor/chats/<md5(cwd)>/<chat id>/` as a `meta.json` metadata record beside a `store.db` conversation blob store — sometimes with **no transcript in the projects tree at all**. Those chats were entirely invisible to Luke, Superset workspace or not.
2. Superset's `terminal_agent_bindings` rows die with their terminal, so a Cursor chat in a Superset worktree loses its id match once the terminal closes — and the worktree never appears in the Cursor app's workspace records, so even a transcript-observed chat drew an unnamed "workspace" row with no folder to match by.

## Fix

The chat store's metadata record (verified on a real machine: `{schemaVersion: 1, hasConversation, title, cwd, createdAtMs, updatedAtMs}`) is now read wherever it stands:

- A chat only the store holds draws a row from it: named by Cursor's own title, placed by the exact folder Cursor recorded, its status from the store's own clock (the WAL is what moves while a turn runs) sharpened by the observation hooks, and unknown once quiet — the blob graph's turn boundary is unreadable, so nothing richer can honestly be said. No tool call, recap, or message advertisement rides a record this thin, and the conversation blobs are never opened.
- A chat with a transcript keeps the transcript's richer read (turn verdict, activity, recap, message advertisement) while the store supplies the name and exact folder the transcript never wrote down.
- The folder rides observations as the `directory` field workspace managers match by (from #395), so a Superset worktree chat groups under its workspace even after Superset's binding row is gone — the same path matching that fixes OpenCode.
- A record with a foreign schema or `hasConversation: false` draws nothing; a chat resumed from another folder (the store re-files chats by cwd) reads its freshest record; the app's archived filing applies to store-only chats too.

## Testing

- `./scripts/check.sh` passes (portable-only change; exit 0).
- 7 new tests: store-only observation (title, folder, status, no sends, blob text never surfaces), quiet-store unknown, foreign-schema/conversation-less skips, transcript+store join, resumed-chat freshest record, archived filing, and the transcript folder riding as `directory`.
- Storage shapes verified against a real `~/.cursor` exhibiting the bug (chat store with and without jsonl counterparts, hash-named project directories, Superset worktree chats).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/514d1e08-3a68-4569-b9a7-f17c6de8ab01)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32454172413/artifacts/9436719269) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32454172413)

- Commit: `3fb421653bb66f10454aaa4600767c0d6e435c41`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
