### PR TITLE
feat(web): add a works-with section to the landing page

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { captureSiteEvent, SITE_EVENT } from "./analytics";
 import { NotchMock } from "./NotchMock";
 import { DMG_URL, GitHubMark, REPOSITORY_URL, SiteFooter, SiteHeader } from "./SiteChrome";
+import { WorksWith } from "./WorksWith";
 
 export function App(): React.JSX.Element {
   return (
@@ -47,6 +48,8 @@ export function App(): React.JSX.Element {
 
           <NotchMock />
         </section>
+
+        <WorksWith />
       </main>
 
       <SiteFooter />

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,7 @@
 import { captureSiteEvent, SITE_EVENT } from "./analytics";
 import { NotchMock } from "./NotchMock";
 import { DMG_URL, GitHubMark, REPOSITORY_URL, SiteFooter, SiteHeader } from "./SiteChrome";
-import { WorksWith } from "./WorksWith";
+import { WorksWithSwitcher } from "./WorksWithVariants";
 
 export function App(): React.JSX.Element {
   return (
@@ -49,7 +49,7 @@ export function App(): React.JSX.Element {
           <NotchMock />
         </section>
 
-        <WorksWith />
+        <WorksWithSwitcher />
       </main>
 
       <SiteFooter />

--- a/apps/web/src/WorksWith.tsx
+++ b/apps/web/src/WorksWith.tsx
@@ -1,0 +1,99 @@
+import { ProviderMark } from "@sidecar/panel";
+import {
+  PROVIDER_ID_LIST,
+  PROVIDER_IDENTITY_BY_ID,
+  SESSION_APPLICATION_ID,
+  SESSION_APPLICATION_ID_LIST,
+  type SessionApplicationId,
+} from "@sidecar/session";
+
+/**
+ * The landing page's answer to "does it work with mine?": the agents Luke
+ * observes and the apps that hold their sessions, each under its own mark.
+ *
+ * Both rosters walk the product's own id lists — `PROVIDER_ID_LIST` and
+ * `SESSION_APPLICATION_ID_LIST` — in each list's own registry order, an agent
+ * being a session provider and an app holding agent sessions without becoming
+ * their provider. Because the rosters are the id lists rather than a
+ * hand-written array, a renamed or removed provider breaks this page's build
+ * instead of leaving it advertising one the app no longer knows. Agent names
+ * come from the registry's own `displayName`; apps have no such registry, so
+ * `APPLICATION_DISPLAY_NAME` stands in as one, typed to require an entry for
+ * every id `SESSION_APPLICATION_ID_LIST` can hand it.
+ *
+ * `ProviderMark` is `@sidecar/panel`'s own, the same component the desktop
+ * panel and the hero mock above draw with — not a duplicate traced from path
+ * data, per the standing decision in `packages/surface/AGENTS.md` that
+ * `@sidecar/panel` is the one shared React layer for provider marks.
+ */
+interface RosterEntry {
+  readonly id: string;
+  readonly name: string;
+}
+
+const AGENTS: readonly RosterEntry[] = PROVIDER_ID_LIST.map((id) => ({
+  id,
+  name: PROVIDER_IDENTITY_BY_ID[id].displayName,
+}));
+
+const APPLICATION_DISPLAY_NAME = {
+  [SESSION_APPLICATION_ID.CHATGPT]: "ChatGPT",
+  [SESSION_APPLICATION_ID.CMUX]: "cmux",
+  [SESSION_APPLICATION_ID.CONDUCTOR]: "Conductor",
+  [SESSION_APPLICATION_ID.CURSOR]: "Cursor",
+  [SESSION_APPLICATION_ID.ORCA]: "Orca",
+  [SESSION_APPLICATION_ID.RADIUS]: "Radius",
+  [SESSION_APPLICATION_ID.REPLICAS]: "Replicas",
+  [SESSION_APPLICATION_ID.SUPERSET]: "Superset",
+} as const satisfies Readonly<Record<SessionApplicationId, string>>;
+
+const APPS: readonly RosterEntry[] = SESSION_APPLICATION_ID_LIST.map((id) => ({
+  id,
+  name: APPLICATION_DISPLAY_NAME[id],
+}));
+
+function Roster({
+  label,
+  entries,
+}: {
+  label: string;
+  entries: readonly RosterEntry[];
+}): React.JSX.Element {
+  return (
+    <div className="mt-8">
+      {/* The group label is a technical token rather than a sentence, so it
+          takes the mono the page reserves for those. */}
+      <h3 className="m-0 font-mono text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">
+        {label}
+      </h3>
+      <ul className="m-0 mt-4 flex list-none flex-wrap gap-x-7 gap-y-4 p-0">
+        {entries.map((entry) => (
+          <li key={entry.id} className="flex items-center gap-2.5">
+            <span className="mark-tile">
+              <ProviderMark providerId={entry.id} />
+            </span>
+            <span className="text-sm font-medium">{entry.name}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export function WorksWith(): React.JSX.Element {
+  return (
+    <section className="hairline pt-12 pb-16">
+      <h2 className="m-0 text-2xl leading-[1.15] font-semibold tracking-[-0.02em] text-pretty">
+        Works with the agents you already run.
+      </h2>
+      <p className="mt-4 mb-0 max-w-[34rem] text-base text-pretty text-muted-foreground">
+        Luke reads what each agent writes about its own sessions — on this machine or in its cloud —
+        and tells the agents apart from the apps that hold them, so a Codex chat inside Conductor
+        stays one row.
+      </p>
+
+      <Roster label="Agents" entries={AGENTS} />
+      <Roster label="Apps" entries={APPS} />
+    </section>
+  );
+}

--- a/apps/web/src/WorksWith.tsx
+++ b/apps/web/src/WorksWith.tsx
@@ -1,57 +1,20 @@
 import { ProviderMark } from "@sidecar/panel";
-import {
-  PROVIDER_ID_LIST,
-  PROVIDER_IDENTITY_BY_ID,
-  SESSION_APPLICATION_ID,
-  SESSION_APPLICATION_ID_LIST,
-  type SessionApplicationId,
-} from "@sidecar/session";
+import { AGENTS, APPS, type RosterEntry } from "./connections-roster";
 
 /**
  * The landing page's answer to "does it work with mine?": the agents Luke
  * observes and the apps that hold their sessions, each under its own mark.
  *
- * Both rosters walk the product's own id lists — `PROVIDER_ID_LIST` and
- * `SESSION_APPLICATION_ID_LIST` — in each list's own registry order, an agent
- * being a session provider and an app holding agent sessions without becoming
- * their provider. Because the rosters are the id lists rather than a
- * hand-written array, a renamed or removed provider breaks this page's build
- * instead of leaving it advertising one the app no longer knows. Agent names
- * come from the registry's own `displayName`; apps have no such registry, so
- * `APPLICATION_DISPLAY_NAME` stands in as one, typed to require an entry for
- * every id `SESSION_APPLICATION_ID_LIST` can hand it.
+ * The roster itself lives in `connections-roster.ts`, walking the product's
+ * own id lists in each list's own registry order rather than a hand-written
+ * array, so a renamed or removed provider breaks this page's build instead of
+ * leaving it advertising one the app no longer knows.
  *
  * `ProviderMark` is `@sidecar/panel`'s own, the same component the desktop
  * panel and the hero mock above draw with — not a duplicate traced from path
  * data, per the standing decision in `packages/surface/AGENTS.md` that
  * `@sidecar/panel` is the one shared React layer for provider marks.
  */
-interface RosterEntry {
-  readonly id: string;
-  readonly name: string;
-}
-
-const AGENTS: readonly RosterEntry[] = PROVIDER_ID_LIST.map((id) => ({
-  id,
-  name: PROVIDER_IDENTITY_BY_ID[id].displayName,
-}));
-
-const APPLICATION_DISPLAY_NAME = {
-  [SESSION_APPLICATION_ID.CHATGPT]: "ChatGPT",
-  [SESSION_APPLICATION_ID.CMUX]: "cmux",
-  [SESSION_APPLICATION_ID.CONDUCTOR]: "Conductor",
-  [SESSION_APPLICATION_ID.CURSOR]: "Cursor",
-  [SESSION_APPLICATION_ID.ORCA]: "Orca",
-  [SESSION_APPLICATION_ID.RADIUS]: "Radius",
-  [SESSION_APPLICATION_ID.REPLICAS]: "Replicas",
-  [SESSION_APPLICATION_ID.SUPERSET]: "Superset",
-} as const satisfies Readonly<Record<SessionApplicationId, string>>;
-
-const APPS: readonly RosterEntry[] = SESSION_APPLICATION_ID_LIST.map((id) => ({
-  id,
-  name: APPLICATION_DISPLAY_NAME[id],
-}));
-
 function Roster({
   label,
   entries,

--- a/apps/web/src/WorksWithVariants.tsx
+++ b/apps/web/src/WorksWithVariants.tsx
@@ -1,0 +1,303 @@
+import { ProviderMark } from "@sidecar/panel";
+import { cssCustomProperties } from "@sidecar/surface/react-css";
+import { useState } from "react";
+import { AGENTS, APPS, type RosterEntry } from "./connections-roster";
+
+/**
+ * Five drastically different treatments of the same "works with" roster,
+ * switchable live on the landing page for design review. This file is a
+ * comparison rig, not a shipped surface — once one variant is chosen,
+ * `WorksWith.tsx` should absorb it and this file (and the switcher's App.tsx
+ * wiring) should come back out.
+ */
+
+const VARIANT = {
+  GRID: "grid",
+  BELT: "belt",
+  ORBIT: "orbit",
+  LOG: "log",
+  INDEX: "index",
+} as const;
+
+type Variant = (typeof VARIANT)[keyof typeof VARIANT];
+
+const VARIANTS: readonly { readonly id: Variant; readonly label: string }[] = [
+  { id: VARIANT.GRID, label: "Signal Grid" },
+  { id: VARIANT.BELT, label: "Rolling Belt" },
+  { id: VARIANT.ORBIT, label: "Orbit" },
+  { id: VARIANT.LOG, label: "Status Log" },
+  { id: VARIANT.INDEX, label: "The Roster" },
+];
+
+export function WorksWithSwitcher(): React.JSX.Element {
+  const [variant, setVariant] = useState<Variant>(VARIANT.GRID);
+
+  return (
+    <section className="hairline pt-12 pb-16">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h2 className="m-0 text-2xl leading-[1.15] font-semibold tracking-[-0.02em] text-pretty">
+            Works with the agents you already run.
+          </h2>
+          <p className="mt-4 mb-0 max-w-[34rem] text-base text-pretty text-muted-foreground">
+            Luke reads what each agent writes about its own sessions — on this machine or in its
+            cloud — and tells the agents apart from the apps that hold them, so a Codex chat inside
+            Conductor stays one row.
+          </p>
+        </div>
+
+        <div
+          className="flex flex-wrap gap-1 rounded-lg border border-border bg-muted p-1"
+          role="tablist"
+          aria-label="Works-with presentation"
+        >
+          {VARIANTS.map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              role="tab"
+              aria-selected={variant === option.id}
+              onClick={() => setVariant(option.id)}
+              className={
+                variant === option.id
+                  ? "rounded-md bg-card px-3 py-1.5 font-mono text-xs font-medium text-foreground shadow-sm"
+                  : "rounded-md px-3 py-1.5 font-mono text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+              }
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-10">
+        {variant === VARIANT.GRID && <SignalGrid />}
+        {variant === VARIANT.BELT && <RollingBelt />}
+        {variant === VARIANT.ORBIT && <Orbit />}
+        {variant === VARIANT.LOG && <StatusLog />}
+        {variant === VARIANT.INDEX && <TheRoster />}
+      </div>
+    </section>
+  );
+}
+
+/* 1. Signal Grid — a bordered card per provider, mark over name, agents and
+   apps each their own responsive grid. The most literal "roster" reading: a
+   spec sheet of everything Luke plugs into. */
+function SignalGrid(): React.JSX.Element {
+  return (
+    <div className="flex flex-col gap-8">
+      <GridGroup label="Agents" entries={AGENTS} />
+      <GridGroup label="Apps" entries={APPS} />
+    </div>
+  );
+}
+
+function GridGroup({
+  label,
+  entries,
+}: {
+  label: string;
+  entries: readonly RosterEntry[];
+}): React.JSX.Element {
+  return (
+    <div>
+      <h3 className="m-0 font-mono text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">
+        {label}
+      </h3>
+      <ul className="m-0 mt-3 grid grid-cols-2 gap-2 p-0 sm:grid-cols-3 md:grid-cols-4">
+        {entries.map((entry) => (
+          <li
+            key={entry.id}
+            className="flex list-none flex-col items-start gap-3 rounded-lg border border-border bg-card px-4 py-3.5 transition-colors hover:border-muted-foreground"
+          >
+            <span className="mark-tile">
+              <ProviderMark providerId={entry.id} />
+            </span>
+            <span className="text-sm font-medium">{entry.name}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/* 2. Rolling Belt — oversized display type in two counter-scrolling
+   marquees, one per roster. Reads as a ticker of everything Luke plugs into
+   rather than a reference list. */
+function RollingBelt(): React.JSX.Element {
+  return (
+    <div className="-mx-5 flex flex-col gap-3">
+      <BeltRow entries={AGENTS} direction="left" />
+      <BeltRow entries={APPS} direction="right" />
+    </div>
+  );
+}
+
+function BeltRow({
+  entries,
+  direction,
+}: {
+  entries: readonly RosterEntry[];
+  direction: "left" | "right";
+}): React.JSX.Element {
+  // Doubled so the belt can loop at -50% with no seam.
+  const doubled = [...entries, ...entries];
+  return (
+    <div className="belt-row">
+      <div
+        className={
+          direction === "left" ? "belt-track belt-track-left" : "belt-track belt-track-right"
+        }
+      >
+        {doubled.map((entry, index) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: the roster is doubled for the seamless loop, so entry.id repeats.
+          <span className="belt-item" key={`${entry.id}-${index}`}>
+            <span className="mark-tile belt-mark">
+              <ProviderMark providerId={entry.id} />
+            </span>
+            <span className="belt-name">{entry.name}</span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* 3. Orbit — Luke's own mark at the center, agents in the inner ring, apps
+   in the outer ring, each mark upright and evenly spaced around its circle. */
+function Orbit(): React.JSX.Element {
+  return (
+    <div className="orbit-stage">
+      <OrbitRing
+        entries={AGENTS}
+        radius="clamp(72px, 24vw, 108px)"
+        ringClassName="orbit-ring-inner"
+      />
+      <OrbitRing
+        entries={APPS}
+        radius="clamp(126px, 40vw, 188px)"
+        ringClassName="orbit-ring-outer"
+      />
+      <div className="orbit-center">
+        <span className="orbit-center-dot" aria-hidden="true" />
+        <span className="orbit-center-label">Luke</span>
+      </div>
+    </div>
+  );
+}
+
+function OrbitRing({
+  entries,
+  radius,
+  ringClassName,
+}: {
+  entries: readonly RosterEntry[];
+  radius: string;
+  ringClassName: string;
+}): React.JSX.Element {
+  return (
+    <div
+      className={`orbit-ring ${ringClassName}`}
+      style={cssCustomProperties({ "--orbit-radius": radius })}
+    >
+      {entries.map((entry, index) => {
+        const angle = (360 / entries.length) * index;
+        return (
+          <div
+            key={entry.id}
+            className="orbit-node"
+            style={cssCustomProperties({ "--orbit-angle": `${angle}deg` })}
+            title={entry.name}
+          >
+            <span className="mark-tile orbit-mark">
+              <ProviderMark providerId={entry.id} />
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/* 4. Status Log — a terminal window reading out `luke observe --all`,
+   listing the roster as command output. */
+function StatusLog(): React.JSX.Element {
+  return (
+    <div className="term-window">
+      <div className="term-titlebar">
+        <span className="term-dot term-dot-red" />
+        <span className="term-dot term-dot-yellow" />
+        <span className="term-dot term-dot-green" />
+        <span className="term-title">luke — observe --all</span>
+      </div>
+      <div className="term-body">
+        <p className="term-line">
+          <span className="term-prompt">$</span> luke observe --all
+        </p>
+        <TermSection label="agents" entries={AGENTS} />
+        <TermSection label="apps" entries={APPS} />
+        <p className="term-line term-cursor-line">
+          <span className="term-prompt">$</span>
+          <span className="term-cursor" aria-hidden="true" />
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function TermSection({
+  label,
+  entries,
+}: {
+  label: string;
+  entries: readonly RosterEntry[];
+}): React.JSX.Element {
+  return (
+    <>
+      <p className="term-line term-heading">{label}:</p>
+      {entries.map((entry) => (
+        <p className="term-line term-row" key={entry.id}>
+          <span className="term-ok">✓</span>
+          <span className="mark-tile term-mark">
+            <ProviderMark providerId={entry.id} />
+          </span>
+          {entry.name}
+        </p>
+      ))}
+    </>
+  );
+}
+
+/* 5. The Roster — a print-style typographic directory. No colour, no marks:
+   hierarchy carries the whole thing, the way a masthead or an index does. */
+function TheRoster(): React.JSX.Element {
+  return (
+    <div className="index-sheet">
+      <IndexColumn label="Agents" entries={AGENTS} />
+      <IndexColumn label="Apps" entries={APPS} />
+    </div>
+  );
+}
+
+function IndexColumn({
+  label,
+  entries,
+}: {
+  label: string;
+  entries: readonly RosterEntry[];
+}): React.JSX.Element {
+  return (
+    <div className="index-column">
+      <h3 className="index-heading">{label}</h3>
+      <ol className="index-list">
+        {entries.map((entry, position) => (
+          <li className="index-row" key={entry.id}>
+            <span className="index-number">{String(position + 1).padStart(2, "0")}</span>
+            <span className="index-name">{entry.name}</span>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/apps/web/src/WorksWithVariants.tsx
+++ b/apps/web/src/WorksWithVariants.tsx
@@ -1,5 +1,4 @@
 import { ProviderMark } from "@sidecar/panel";
-import { cssCustomProperties } from "@sidecar/surface/react-css";
 import { useState } from "react";
 import { AGENTS, APPS, type RosterEntry } from "./connections-roster";
 
@@ -9,28 +8,45 @@ import { AGENTS, APPS, type RosterEntry } from "./connections-roster";
  * comparison rig, not a shipped surface — once one variant is chosen,
  * `WorksWith.tsx` should absorb it and this file (and the switcher's App.tsx
  * wiring) should come back out.
+ *
+ * Round two, after feedback on round one: individual black tiles scattered
+ * across the light page read as noisy, several rosters felt overstuffed, and
+ * Cursor, Radius, Replicas, and Conductor each drew their icon twice — once
+ * as an agent, once as the same-named app. `packages/panel/src/provider-marks.tsx`
+ * really does render those four agent ids with the exact same mark component
+ * as their app counterpart, so `FEATURED_AGENTS` below drops them: apps win
+ * the icon, agents keep the name. Every variant here also either puts marks on
+ * one deliberate shared dark surface (the thing that read right about the
+ * first round's Status Log) rather than many isolated boxes, or shrinks the
+ * per-mark tile into a small soft chip instead of a hard black square.
  */
 
+const DUPLICATED_BY_AN_APP_MARK = new Set(["cursor", "radius", "replicas", "conductor"]);
+
+const FEATURED_AGENTS: readonly RosterEntry[] = AGENTS.filter(
+  (agent) => !DUPLICATED_BY_AN_APP_MARK.has(agent.id),
+);
+
 const VARIANT = {
-  GRID: "grid",
-  BELT: "belt",
-  ORBIT: "orbit",
-  LOG: "log",
-  INDEX: "index",
+  PANEL: "panel",
+  CONSOLE: "console",
+  RAIL: "rail",
+  LIST: "list",
+  MINIMAL: "minimal",
 } as const;
 
 type Variant = (typeof VARIANT)[keyof typeof VARIANT];
 
 const VARIANTS: readonly { readonly id: Variant; readonly label: string }[] = [
-  { id: VARIANT.GRID, label: "Signal Grid" },
-  { id: VARIANT.BELT, label: "Rolling Belt" },
-  { id: VARIANT.ORBIT, label: "Orbit" },
-  { id: VARIANT.LOG, label: "Status Log" },
-  { id: VARIANT.INDEX, label: "The Roster" },
+  { id: VARIANT.PANEL, label: "Device Panel" },
+  { id: VARIANT.CONSOLE, label: "Console" },
+  { id: VARIANT.RAIL, label: "Rail Marquee" },
+  { id: VARIANT.LIST, label: "Compact List" },
+  { id: VARIANT.MINIMAL, label: "Minimal Row" },
 ];
 
 export function WorksWithSwitcher(): React.JSX.Element {
-  const [variant, setVariant] = useState<Variant>(VARIANT.GRID);
+  const [variant, setVariant] = useState<Variant>(VARIANT.PANEL);
 
   return (
     <section className="hairline pt-12 pb-16">
@@ -71,92 +87,42 @@ export function WorksWithSwitcher(): React.JSX.Element {
       </div>
 
       <div className="mt-10">
-        {variant === VARIANT.GRID && <SignalGrid />}
-        {variant === VARIANT.BELT && <RollingBelt />}
-        {variant === VARIANT.ORBIT && <Orbit />}
-        {variant === VARIANT.LOG && <StatusLog />}
-        {variant === VARIANT.INDEX && <TheRoster />}
+        {variant === VARIANT.PANEL && <DevicePanel />}
+        {variant === VARIANT.CONSOLE && <Console />}
+        {variant === VARIANT.RAIL && <RailMarquee />}
+        {variant === VARIANT.LIST && <CompactList />}
+        {variant === VARIANT.MINIMAL && <MinimalRow />}
       </div>
     </section>
   );
 }
 
-/* 1. Signal Grid — a bordered card per provider, mark over name, agents and
-   apps each their own responsive grid. The most literal "roster" reading: a
-   spec sheet of everything Luke plugs into. */
-function SignalGrid(): React.JSX.Element {
+/* 1. Device Panel — one shared dark card, the way the hero mock above is
+   already a dark surface on this light page. Apps get the icon treatment,
+   full-size and bare (no per-icon box needed — the whole card is already
+   dark); the rest of the roster is named, not iconified, as quiet pills. */
+function DevicePanel(): React.JSX.Element {
   return (
-    <div className="flex flex-col gap-8">
-      <GridGroup label="Agents" entries={AGENTS} />
-      <GridGroup label="Apps" entries={APPS} />
-    </div>
-  );
-}
-
-function GridGroup({
-  label,
-  entries,
-}: {
-  label: string;
-  entries: readonly RosterEntry[];
-}): React.JSX.Element {
-  return (
-    <div>
-      <h3 className="m-0 font-mono text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">
-        {label}
-      </h3>
-      <ul className="m-0 mt-3 grid grid-cols-2 gap-2 p-0 sm:grid-cols-3 md:grid-cols-4">
-        {entries.map((entry) => (
-          <li
-            key={entry.id}
-            className="flex list-none flex-col items-start gap-3 rounded-lg border border-border bg-card px-4 py-3.5 transition-colors hover:border-muted-foreground"
-          >
-            <span className="mark-tile">
-              <ProviderMark providerId={entry.id} />
+    <div className="panel-card">
+      <p className="panel-eyebrow">Apps</p>
+      <div className="panel-app-row">
+        {APPS.map((app) => (
+          <div className="panel-app" key={app.id}>
+            <span className="mark-tile mark-tile--bare panel-app-mark">
+              <ProviderMark providerId={app.id} />
             </span>
-            <span className="text-sm font-medium">{entry.name}</span>
-          </li>
+            <span className="panel-app-name">{app.name}</span>
+          </div>
         ))}
-      </ul>
-    </div>
-  );
-}
+      </div>
 
-/* 2. Rolling Belt — oversized display type in two counter-scrolling
-   marquees, one per roster. Reads as a ticker of everything Luke plugs into
-   rather than a reference list. */
-function RollingBelt(): React.JSX.Element {
-  return (
-    <div className="-mx-5 flex flex-col gap-3">
-      <BeltRow entries={AGENTS} direction="left" />
-      <BeltRow entries={APPS} direction="right" />
-    </div>
-  );
-}
+      <div className="panel-divider" />
 
-function BeltRow({
-  entries,
-  direction,
-}: {
-  entries: readonly RosterEntry[];
-  direction: "left" | "right";
-}): React.JSX.Element {
-  // Doubled so the belt can loop at -50% with no seam.
-  const doubled = [...entries, ...entries];
-  return (
-    <div className="belt-row">
-      <div
-        className={
-          direction === "left" ? "belt-track belt-track-left" : "belt-track belt-track-right"
-        }
-      >
-        {doubled.map((entry, index) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: the roster is doubled for the seamless loop, so entry.id repeats.
-          <span className="belt-item" key={`${entry.id}-${index}`}>
-            <span className="mark-tile belt-mark">
-              <ProviderMark providerId={entry.id} />
-            </span>
-            <span className="belt-name">{entry.name}</span>
+      <p className="panel-eyebrow">Also works with</p>
+      <div className="panel-agent-row">
+        {FEATURED_AGENTS.map((agent) => (
+          <span className="panel-agent-pill" key={agent.id}>
+            {agent.name}
           </span>
         ))}
       </div>
@@ -164,65 +130,11 @@ function BeltRow({
   );
 }
 
-/* 3. Orbit — Luke's own mark at the center, agents in the inner ring, apps
-   in the outer ring, each mark upright and evenly spaced around its circle. */
-function Orbit(): React.JSX.Element {
-  return (
-    <div className="orbit-stage">
-      <OrbitRing
-        entries={AGENTS}
-        radius="clamp(72px, 24vw, 108px)"
-        ringClassName="orbit-ring-inner"
-      />
-      <OrbitRing
-        entries={APPS}
-        radius="clamp(126px, 40vw, 188px)"
-        ringClassName="orbit-ring-outer"
-      />
-      <div className="orbit-center">
-        <span className="orbit-center-dot" aria-hidden="true" />
-        <span className="orbit-center-label">Luke</span>
-      </div>
-    </div>
-  );
-}
-
-function OrbitRing({
-  entries,
-  radius,
-  ringClassName,
-}: {
-  entries: readonly RosterEntry[];
-  radius: string;
-  ringClassName: string;
-}): React.JSX.Element {
-  return (
-    <div
-      className={`orbit-ring ${ringClassName}`}
-      style={cssCustomProperties({ "--orbit-radius": radius })}
-    >
-      {entries.map((entry, index) => {
-        const angle = (360 / entries.length) * index;
-        return (
-          <div
-            key={entry.id}
-            className="orbit-node"
-            style={cssCustomProperties({ "--orbit-angle": `${angle}deg` })}
-            title={entry.name}
-          >
-            <span className="mark-tile orbit-mark">
-              <ProviderMark providerId={entry.id} />
-            </span>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-/* 4. Status Log — a terminal window reading out `luke observe --all`,
-   listing the roster as command output. */
-function StatusLog(): React.JSX.Element {
+/* 2. Console — the one thing round one got right, kept and tightened: real
+   command output rather than a decorated list. Marks sit bare on the
+   terminal's own dark ground instead of inside a second, smaller box, and
+   the roster is deduped so nothing prints twice. */
+function Console(): React.JSX.Element {
   return (
     <div className="term-window">
       <div className="term-titlebar">
@@ -235,8 +147,8 @@ function StatusLog(): React.JSX.Element {
         <p className="term-line">
           <span className="term-prompt">$</span> luke observe --all
         </p>
-        <TermSection label="agents" entries={AGENTS} />
-        <TermSection label="apps" entries={APPS} />
+        <ConsoleSection label="apps" entries={APPS} />
+        <ConsoleSection label="agents" entries={FEATURED_AGENTS} />
         <p className="term-line term-cursor-line">
           <span className="term-prompt">$</span>
           <span className="term-cursor" aria-hidden="true" />
@@ -246,7 +158,7 @@ function StatusLog(): React.JSX.Element {
   );
 }
 
-function TermSection({
+function ConsoleSection({
   label,
   entries,
 }: {
@@ -259,7 +171,7 @@ function TermSection({
       {entries.map((entry) => (
         <p className="term-line term-row" key={entry.id}>
           <span className="term-ok">✓</span>
-          <span className="mark-tile term-mark">
+          <span className="mark-tile mark-tile--bare term-mark">
             <ProviderMark providerId={entry.id} />
           </span>
           {entry.name}
@@ -269,18 +181,46 @@ function TermSection({
   );
 }
 
-/* 5. The Roster — a print-style typographic directory. No colour, no marks:
-   hierarchy carries the whole thing, the way a masthead or an index does. */
-function TheRoster(): React.JSX.Element {
+/* 3. Rail Marquee — a single dark rail (not two competing belts) scrolling
+   only the apps, since those are what a visitor actually recognizes on
+   sight; the rest of the roster is named underneath in plain prose rather
+   than drawn twice. */
+function RailMarquee(): React.JSX.Element {
+  const doubled = [...APPS, ...APPS];
   return (
-    <div className="index-sheet">
-      <IndexColumn label="Agents" entries={AGENTS} />
-      <IndexColumn label="Apps" entries={APPS} />
+    <div>
+      <div className="rail">
+        <div className="rail-track">
+          {doubled.map((app, index) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: the roster is doubled for the seamless loop, so app.id repeats.
+            <span className="rail-item" key={`${app.id}-${index}`}>
+              <span className="mark-tile mark-tile--bare rail-mark">
+                <ProviderMark providerId={app.id} />
+              </span>
+              <span className="rail-name">{app.name}</span>
+            </span>
+          ))}
+        </div>
+      </div>
+      <p className="rail-footnote">
+        Also works with {FEATURED_AGENTS.map((agent) => agent.name).join(", ")}, wherever they run.
+      </p>
     </div>
   );
 }
 
-function IndexColumn({
+/* 4. Compact List — the plainest reading: no card, no border, a small soft
+   chip (not a hard black square) beside each name in a wrapped row. */
+function CompactList(): React.JSX.Element {
+  return (
+    <div className="compact-list">
+      <CompactGroup label="Apps" entries={APPS} />
+      <CompactGroup label="Agents" entries={FEATURED_AGENTS} />
+    </div>
+  );
+}
+
+function CompactGroup({
   label,
   entries,
 }: {
@@ -288,16 +228,39 @@ function IndexColumn({
   entries: readonly RosterEntry[];
 }): React.JSX.Element {
   return (
-    <div className="index-column">
-      <h3 className="index-heading">{label}</h3>
-      <ol className="index-list">
-        {entries.map((entry, position) => (
-          <li className="index-row" key={entry.id}>
-            <span className="index-number">{String(position + 1).padStart(2, "0")}</span>
-            <span className="index-name">{entry.name}</span>
+    <div>
+      <h3 className="compact-label">{label}</h3>
+      <ul className="compact-items">
+        {entries.map((entry) => (
+          <li className="compact-item" key={entry.id}>
+            <span className="mark-tile mark-tile--soft compact-mark">
+              <ProviderMark providerId={entry.id} />
+            </span>
+            <span className="compact-name">{entry.name}</span>
           </li>
         ))}
-      </ol>
+      </ul>
+    </div>
+  );
+}
+
+/* 5. Minimal Row — the calmest option: a single row of small soft app
+   marks, everything else carried as a sentence rather than a chip. */
+function MinimalRow(): React.JSX.Element {
+  return (
+    <div className="minimal-row">
+      <div className="minimal-marks">
+        {APPS.map((app) => (
+          <span className="mark-tile mark-tile--soft minimal-mark" key={app.id} title={app.name}>
+            <ProviderMark providerId={app.id} />
+          </span>
+        ))}
+      </div>
+      <p className="minimal-copy">
+        Shows up wherever you already work — {APPS.map((app) => app.name).join(", ")} — and reads
+        what {FEATURED_AGENTS.map((agent) => agent.name).join(", ")}, and more, write about their
+        own sessions.
+      </p>
     </div>
   );
 }

--- a/apps/web/src/connections-roster.ts
+++ b/apps/web/src/connections-roster.ts
@@ -1,0 +1,40 @@
+import {
+  PROVIDER_ID_LIST,
+  PROVIDER_IDENTITY_BY_ID,
+  SESSION_APPLICATION_ID,
+  SESSION_APPLICATION_ID_LIST,
+  type SessionApplicationId,
+} from "@sidecar/session";
+
+/**
+ * The roster every "works with" presentation draws from, whatever its
+ * styling: the agents Luke observes and the apps that hold their sessions,
+ * each keyed by the product's own id lists so a renamed or removed provider
+ * breaks the build instead of leaving stale marketing. See `WorksWith.tsx`
+ * for the shipped presentation.
+ */
+export interface RosterEntry {
+  readonly id: string;
+  readonly name: string;
+}
+
+export const AGENTS: readonly RosterEntry[] = PROVIDER_ID_LIST.map((id) => ({
+  id,
+  name: PROVIDER_IDENTITY_BY_ID[id].displayName,
+}));
+
+const APPLICATION_DISPLAY_NAME = {
+  [SESSION_APPLICATION_ID.CHATGPT]: "ChatGPT",
+  [SESSION_APPLICATION_ID.CMUX]: "cmux",
+  [SESSION_APPLICATION_ID.CONDUCTOR]: "Conductor",
+  [SESSION_APPLICATION_ID.CURSOR]: "Cursor",
+  [SESSION_APPLICATION_ID.ORCA]: "Orca",
+  [SESSION_APPLICATION_ID.RADIUS]: "Radius",
+  [SESSION_APPLICATION_ID.REPLICAS]: "Replicas",
+  [SESSION_APPLICATION_ID.SUPERSET]: "Superset",
+} as const satisfies Readonly<Record<SessionApplicationId, string>>;
+
+export const APPS: readonly RosterEntry[] = SESSION_APPLICATION_ID_LIST.map((id) => ({
+  id,
+  name: APPLICATION_DISPLAY_NAME[id],
+}));

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -236,6 +236,154 @@
   }
 }
 
+/* Works-with tiles
+   The provider marks are the product's own artwork, published for the dark
+   surface the renderer draws them on — several are light silhouettes — so on
+   the light page each sits on its own small tile of the product's ground
+   instead of being recoloured for the page, which the marks' contract forbids.
+   The brand tokens and the per-mark optical scales are the renderer's
+   (apps/desktop/src/renderer/styles/base.css), restated here for the marks
+   this page shows because the page's palette deliberately stays out of the
+   mock's scope above. */
+.mark-tile {
+  --mark-claude-code: #d97757;
+  --mark-cmux-left: #12c7f5;
+  --mark-cmux-middle: #2d8cff;
+  --mark-cmux-right: #6c5cff;
+  --mark-codex-top: #b1a7ff;
+  --mark-codex-middle: #7a9dff;
+  --mark-codex-bottom: #3941ff;
+  --mark-conductor: #eae8e6;
+  --mark-copilot: #ffffff;
+  --mark-cursor: #ffffff;
+  --mark-devin: #ffffff;
+  --mark-grok-build: #fcfcfc;
+  --mark-jules: #715cd7;
+  --mark-opencode: #ffffff;
+  --mark-opencode-block: #5a5858;
+  --mark-orca: #ffffff;
+  --mark-radius: #ffffff;
+  --mark-replicas: #3eeba3;
+  --mark-superset-top: #b9b7b5;
+  --mark-superset-bottom: #858483;
+
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  /* The product surface's own fill and text colour, so a tile reads as a chip
+     of the mock and a mark with no brand token — ChatGPT's — inherits the
+     colour it inherits in the renderer. */
+  background: #000;
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.mark-tile .provider-mark {
+  width: 20px;
+  height: 20px;
+  flex: 0 0 auto;
+}
+
+/* The renderer's optical scales, verbatim: the marks fill their boxes very
+   differently, and each scale brings one to the same optical weight without
+   touching its proportion. */
+
+/* Antigravity's double-arch mark carries Google's own published colours, so
+   none is set here; its box crops the site logo's canvas to the glyph, which
+   fills it edge to edge, so it takes the full-bleed marks' scale. */
+.mark-tile .provider-mark[data-mark="antigravity"] {
+  transform: scale(0.94);
+}
+
+.mark-tile .provider-mark[data-mark="claude-code"] {
+  color: var(--mark-claude-code);
+  transform: scale(1.12);
+}
+
+.mark-tile .provider-mark[data-mark="chatgpt"] {
+  transform: scale(0.94);
+}
+
+.mark-tile .provider-mark[data-mark="cmux"] {
+  transform: scale(1.9);
+}
+
+.mark-tile .provider-mark[data-mark="codex"] {
+  transform: scale(0.94);
+}
+
+.mark-tile .provider-mark[data-mark="conductor"] {
+  color: var(--mark-conductor);
+  transform: scale(0.93);
+}
+
+.mark-tile .provider-mark[data-mark="copilot"] {
+  color: var(--mark-copilot);
+  transform: scale(0.94);
+}
+
+.mark-tile .provider-mark[data-mark="cursor"] {
+  color: var(--mark-cursor);
+  transform: scale(0.94);
+}
+
+.mark-tile .provider-mark[data-mark="devin"] {
+  color: var(--mark-devin);
+  transform: scale(1.22);
+}
+
+/* Gemini's aurora sparkle carries Google's own published colours, so none is
+   set here; it fills its box edge to edge the way Codex and Cursor do and
+   takes the same scale they do. */
+.mark-tile .provider-mark[data-mark="gemini-cli"] {
+  transform: scale(0.94);
+}
+
+/* Grok's comet fills its box edge to edge the way the Codex and Cursor marks
+   do, so it takes the same scale they do; it carries the near-white xAI
+   publishes it in. */
+.mark-tile .provider-mark[data-mark="grok-build"] {
+  color: var(--mark-grok-build);
+  transform: scale(0.94);
+}
+
+.mark-tile .provider-mark[data-mark="jules"] {
+  color: var(--mark-jules);
+  transform: scale(0.94);
+}
+
+.mark-tile .provider-mark[data-mark="opencode"] {
+  color: var(--mark-opencode);
+  transform: scale(0.94);
+}
+
+.mark-tile .provider-mark[data-mark="orca"] {
+  color: var(--mark-orca);
+  transform: scale(1.18);
+}
+
+/* Radius' banded sphere fills its box top to bottom the way the Codex and
+   Cursor marks do, so it takes the same scale they do. */
+.mark-tile .provider-mark[data-mark="radius"] {
+  color: var(--mark-radius);
+  transform: scale(0.94);
+}
+
+.mark-tile .provider-mark[data-mark="replicas"] {
+  color: var(--mark-replicas);
+  transform: scale(0.94);
+}
+
+/* Superset's bracket mark is two and a half times as wide as it is tall and
+   takes no scale — that is the published proportion, shown whole. A wider box
+   inside the square tile is what brings its ink to the others' weight. */
+.mark-tile .provider-mark[data-mark="superset"] {
+  width: 26px;
+}
+
 /* Documents
    Generated markdown — the privacy policy and each changelog release — read
    start to finish, so they get more vertical rhythm than the marketing copy

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -384,6 +384,318 @@
   width: 26px;
 }
 
+/* Works-with variants — comparison rig
+   Four of the five "works with" presentations in WorksWithVariants.tsx need
+   hand-written CSS Tailwind utilities cannot express: a looping marquee, a
+   trigonometric ring layout, and a terminal window's own vocabulary. The
+   fifth (Signal Grid) is plain utilities at its call site. This whole block
+   is scaffolding for that comparison and leaves with it once one variant is
+   chosen. --------------------------------------------------------------- */
+
+/* Rolling Belt */
+.belt-row {
+  overflow: hidden;
+  padding-block: var(--space-2);
+  mask-image: linear-gradient(
+    to right,
+    transparent,
+    black var(--space-7),
+    black calc(100% - var(--space-7)),
+    transparent
+  );
+}
+
+.belt-track {
+  display: flex;
+  width: max-content;
+  align-items: center;
+  gap: var(--space-7);
+  padding-inline: var(--space-5);
+  animation: belt-scroll-left 36s linear infinite;
+}
+
+.belt-track-right {
+  animation-name: belt-scroll-right;
+  animation-duration: 32s;
+}
+
+@keyframes belt-scroll-left {
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+@keyframes belt-scroll-right {
+  from {
+    transform: translateX(-50%);
+  }
+}
+
+.belt-item {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.mark-tile.belt-mark {
+  width: 56px;
+  height: 56px;
+  border-radius: 14px;
+}
+
+.mark-tile.belt-mark .provider-mark {
+  width: 30px;
+  height: 30px;
+}
+
+.belt-name {
+  font-family: var(--font-brand);
+  font-size: 2rem;
+  font-weight: 500;
+  white-space: nowrap;
+  letter-spacing: -0.01em;
+}
+
+/* Orbit */
+.orbit-stage {
+  position: relative;
+  width: min(92vw, 460px);
+  aspect-ratio: 1;
+  margin: 0 auto;
+}
+
+.orbit-ring {
+  position: absolute;
+  inset: 0;
+}
+
+.orbit-ring::before {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: calc(var(--orbit-radius) * 2);
+  height: calc(var(--orbit-radius) * 2);
+  border: 1px dashed var(--border);
+  border-radius: 50%;
+  content: "";
+  transform: translate(-50%, -50%);
+}
+
+.orbit-node {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) rotate(var(--orbit-angle))
+    translateY(calc(var(--orbit-radius) * -1)) rotate(calc(var(--orbit-angle) * -1));
+}
+
+.mark-tile.orbit-mark {
+  width: 40px;
+  height: 40px;
+}
+
+.orbit-center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  transform: translate(-50%, -50%);
+}
+
+.orbit-center-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--primary);
+  box-shadow: 0 0 0 7px color-mix(in oklab, var(--primary) 16%, transparent);
+}
+
+.orbit-center-label {
+  font-family: var(--font-brand);
+  font-size: 0.8rem;
+  color: var(--muted-foreground);
+}
+
+/* Status Log */
+.term-window {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: #0b0d10;
+  box-shadow: 0 20px 60px -30px rgba(0, 0, 0, 0.5);
+}
+
+.term-titlebar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  background: #16181c;
+}
+
+.term-dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+}
+
+.term-dot-red {
+  background: #ff5f57;
+}
+
+.term-dot-yellow {
+  background: #febc2e;
+}
+
+.term-dot-green {
+  background: #28c840;
+}
+
+.term-title {
+  margin-left: var(--space-2);
+  color: rgba(255, 255, 255, 0.45);
+  font-family: var(--font-code);
+  font-size: 0.75rem;
+}
+
+.term-body {
+  max-height: 420px;
+  overflow-y: auto;
+  padding: var(--space-5);
+  color: rgba(255, 255, 255, 0.82);
+  font-family: var(--font-code);
+  font-size: 0.85rem;
+  line-height: 1.9;
+}
+
+.term-line {
+  margin: 0;
+}
+
+.term-prompt {
+  margin-right: var(--space-2);
+  color: #5cd5ff;
+}
+
+.term-heading {
+  margin-top: var(--space-3);
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.term-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding-left: var(--space-4);
+}
+
+.term-ok {
+  color: #6fdca4;
+}
+
+.mark-tile.term-mark {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+}
+
+.mark-tile.term-mark .provider-mark {
+  width: 13px;
+  height: 13px;
+}
+
+.term-cursor-line {
+  display: flex;
+  align-items: center;
+  margin-top: var(--space-2);
+}
+
+.term-cursor {
+  display: inline-block;
+  width: 8px;
+  height: 16px;
+  background: #5cd5ff;
+  animation: term-blink 1s steps(1) infinite;
+}
+
+@keyframes term-blink {
+  50% {
+    opacity: 0;
+  }
+}
+
+/* The Roster */
+.index-sheet {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-7);
+}
+
+@media (width >= 640px) {
+  .index-sheet {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.index-heading {
+  margin: 0 0 var(--space-3);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--foreground);
+  font-family: var(--font-brand);
+  font-size: 1.1rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.index-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.index-row {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.index-row:last-child {
+  border-bottom: none;
+}
+
+.index-number {
+  min-width: 1.5em;
+  color: var(--muted-foreground);
+  font-family: var(--font-code);
+  font-size: 0.7rem;
+}
+
+.index-name {
+  font-size: 0.95rem;
+  letter-spacing: -0.005em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .belt-track {
+    animation: none;
+  }
+
+  .term-cursor {
+    animation: none;
+    opacity: 1;
+  }
+}
+
 /* Documents
    Generated markdown — the privacy policy and each changelog release — read
    start to finish, so they get more vertical rhythm than the marketing copy

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -385,142 +385,227 @@
 }
 
 /* Works-with variants — comparison rig
-   Four of the five "works with" presentations in WorksWithVariants.tsx need
-   hand-written CSS Tailwind utilities cannot express: a looping marquee, a
-   trigonometric ring layout, and a terminal window's own vocabulary. The
-   fifth (Signal Grid) is plain utilities at its call site. This whole block
-   is scaffolding for that comparison and leaves with it once one variant is
-   chosen. --------------------------------------------------------------- */
+   Round two, after feedback that round one's per-mark black tiles read as
+   noisy scattered across the light page, that several rosters felt
+   overstuffed, and that four ids (Cursor, Radius, Replicas, Conductor) drew
+   their icon twice — once as an agent, once as the same-named app.
+   WorksWithVariants.tsx now dedupes those four out of the agent list, and
+   every variant below either puts marks on one deliberate shared dark
+   surface (`mark-tile--bare`, sized per variant) instead of many isolated
+   boxes, or shrinks the tile into a small soft chip (`mark-tile--soft`)
+   rather than a hard black square. This whole block is scaffolding for the
+   comparison and leaves with it once one variant is chosen.
+   --------------------------------------------------------------------- */
 
-/* Rolling Belt */
-.belt-row {
+.mark-tile.mark-tile--bare {
+  background: transparent;
+}
+
+.mark-tile.mark-tile--soft {
+  width: 32px;
+  height: 32px;
+  border-radius: 9px;
+  background: #1c1e22;
+}
+
+.mark-tile.mark-tile--soft .provider-mark {
+  width: 17px;
+  height: 17px;
+}
+
+/* Device Panel */
+.panel-card {
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  background: #0b0d10;
+}
+
+.panel-eyebrow {
+  margin: 0 0 var(--space-4);
+  color: rgba(255, 255, 255, 0.4);
+  font-family: var(--font-code);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.panel-app-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-6);
+}
+
+.panel-app {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 76px;
+  gap: var(--space-2);
+}
+
+.mark-tile.mark-tile--bare.panel-app-mark {
+  width: 36px;
+  height: 36px;
+}
+
+.mark-tile.mark-tile--bare.panel-app-mark .provider-mark {
+  width: 22px;
+  height: 22px;
+}
+
+.panel-app-name {
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.78rem;
+  font-weight: 500;
+  text-align: center;
+}
+
+.panel-divider {
+  height: 1px;
+  margin: var(--space-6) 0;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.panel-agent-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.panel-agent-pill {
+  padding: 0.3em 0.75em;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  color: rgba(255, 255, 255, 0.6);
+  font-family: var(--font-code);
+  font-size: 0.72rem;
+}
+
+/* Rail Marquee */
+.rail {
   overflow: hidden;
-  padding-block: var(--space-2);
+  border-radius: var(--radius-lg);
+  background: #0b0d10;
+  padding-block: var(--space-5);
   mask-image: linear-gradient(
     to right,
     transparent,
-    black var(--space-7),
-    black calc(100% - var(--space-7)),
+    black var(--space-6),
+    black calc(100% - var(--space-6)),
     transparent
   );
 }
 
-.belt-track {
+.rail-track {
   display: flex;
   width: max-content;
   align-items: center;
   gap: var(--space-7);
-  padding-inline: var(--space-5);
-  animation: belt-scroll-left 36s linear infinite;
+  padding-inline: var(--space-6);
+  animation: rail-scroll 30s linear infinite;
 }
 
-.belt-track-right {
-  animation-name: belt-scroll-right;
-  animation-duration: 32s;
-}
-
-@keyframes belt-scroll-left {
+@keyframes rail-scroll {
   to {
     transform: translateX(-50%);
   }
 }
 
-@keyframes belt-scroll-right {
-  from {
-    transform: translateX(-50%);
-  }
-}
-
-.belt-item {
+.rail-item {
   display: flex;
   flex: 0 0 auto;
   align-items: center;
   gap: var(--space-3);
 }
 
-.mark-tile.belt-mark {
-  width: 56px;
-  height: 56px;
-  border-radius: 14px;
+.mark-tile.mark-tile--bare.rail-mark {
+  width: 34px;
+  height: 34px;
 }
 
-.mark-tile.belt-mark .provider-mark {
-  width: 30px;
-  height: 30px;
+.mark-tile.mark-tile--bare.rail-mark .provider-mark {
+  width: 20px;
+  height: 20px;
 }
 
-.belt-name {
+.rail-name {
+  color: rgba(255, 255, 255, 0.88);
   font-family: var(--font-brand);
-  font-size: 2rem;
+  font-size: 1.15rem;
   font-weight: 500;
   white-space: nowrap;
-  letter-spacing: -0.01em;
 }
 
-/* Orbit */
-.orbit-stage {
-  position: relative;
-  width: min(92vw, 460px);
-  aspect-ratio: 1;
-  margin: 0 auto;
+.rail-footnote {
+  margin: var(--space-4) 0 0;
+  color: var(--muted-foreground);
+  font-size: 0.85rem;
 }
 
-.orbit-ring {
-  position: absolute;
-  inset: 0;
-}
-
-.orbit-ring::before {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: calc(var(--orbit-radius) * 2);
-  height: calc(var(--orbit-radius) * 2);
-  border: 1px dashed var(--border);
-  border-radius: 50%;
-  content: "";
-  transform: translate(-50%, -50%);
-}
-
-.orbit-node {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%) rotate(var(--orbit-angle))
-    translateY(calc(var(--orbit-radius) * -1)) rotate(calc(var(--orbit-angle) * -1));
-}
-
-.mark-tile.orbit-mark {
-  width: 40px;
-  height: 40px;
-}
-
-.orbit-center {
-  position: absolute;
-  top: 50%;
-  left: 50%;
+/* Compact List */
+.compact-list {
   display: flex;
   flex-direction: column;
+  gap: var(--space-6);
+}
+
+.compact-label {
+  margin: 0 0 var(--space-3);
+  color: var(--muted-foreground);
+  font-family: var(--font-code);
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.compact-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.compact-item {
+  display: flex;
   align-items: center;
   gap: var(--space-2);
-  transform: translate(-50%, -50%);
 }
 
-.orbit-center-dot {
-  width: 14px;
-  height: 14px;
+.compact-name {
+  font-size: 0.88rem;
+  font-weight: 500;
+}
+
+/* Minimal Row */
+.minimal-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.minimal-marks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.mark-tile.mark-tile--soft.minimal-mark {
   border-radius: 50%;
-  background: var(--primary);
-  box-shadow: 0 0 0 7px color-mix(in oklab, var(--primary) 16%, transparent);
 }
 
-.orbit-center-label {
-  font-family: var(--font-brand);
-  font-size: 0.8rem;
+.minimal-copy {
+  max-width: 38rem;
+  margin: 0;
   color: var(--muted-foreground);
+  font-size: 0.95rem;
+  line-height: 1.7;
 }
 
-/* Status Log */
+/* Console (formerly Status Log) */
 .term-window {
   overflow: hidden;
   border: 1px solid var(--border);
@@ -601,15 +686,14 @@
   color: #6fdca4;
 }
 
-.mark-tile.term-mark {
-  width: 22px;
-  height: 22px;
-  border-radius: 6px;
+.mark-tile.mark-tile--bare.term-mark {
+  width: 18px;
+  height: 18px;
 }
 
-.mark-tile.term-mark .provider-mark {
-  width: 13px;
-  height: 13px;
+.mark-tile.mark-tile--bare.term-mark .provider-mark {
+  width: 12px;
+  height: 12px;
 }
 
 .term-cursor-line {
@@ -632,61 +716,8 @@
   }
 }
 
-/* The Roster */
-.index-sheet {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: var(--space-7);
-}
-
-@media (width >= 640px) {
-  .index-sheet {
-    grid-template-columns: 1fr 1fr;
-  }
-}
-
-.index-heading {
-  margin: 0 0 var(--space-3);
-  padding-bottom: var(--space-2);
-  border-bottom: 1px solid var(--foreground);
-  font-family: var(--font-brand);
-  font-size: 1.1rem;
-  font-weight: 500;
-  letter-spacing: 0.01em;
-}
-
-.index-list {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.index-row {
-  display: flex;
-  align-items: baseline;
-  gap: var(--space-3);
-  padding: var(--space-2) 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.index-row:last-child {
-  border-bottom: none;
-}
-
-.index-number {
-  min-width: 1.5em;
-  color: var(--muted-foreground);
-  font-family: var(--font-code);
-  font-size: 0.7rem;
-}
-
-.index-name {
-  font-size: 0.95rem;
-  letter-spacing: -0.005em;
-}
-
 @media (prefers-reduced-motion: reduce) {
-  .belt-track {
+  .rail-track {
     animation: none;
   }
 


### PR DESCRIPTION
## What

Adds a **Works with** section to the landing page, after the hero, showing the full roster of agents Luke observes and the apps that hold their sessions — each under its provider's official mark.

- `apps/web/src/connections-roster.ts` — the roster both `WorksWith.tsx` and the variant rig below draw from: two lists walking `PROVIDER_ID_LIST` (13 agents) and `SESSION_APPLICATION_ID_LIST` (8 apps) in each list's own registry order, so a renamed or removed provider breaks the build instead of leaving stale marketing. (`docs/PROVIDERS.md`, which the roster originally mirrored, has since been removed from main; the canonical source is now these id lists plus the generated agent table in `README.md`.)
- `apps/web/src/WorksWith.tsx` — the shipped section. Marks are `@sidecar/panel`'s own `ProviderMark`, the same component the desktop panel and this page's hero mock already draw with, per the standing decision in `packages/surface/AGENTS.md` that `@sidecar/panel` is the one shared React layer for provider marks (superseding this PR's original per-app-traced `provider-marks.tsx`, which no longer exists on `main`).
- `apps/web/src/styles.css` — a `.mark-tile` block: each mark sits on a small tile of the product's dark ground, because several providers publish light silhouettes and the marks' contract forbids recolouring them for the light page. Brand tokens and per-mark optical scales are the renderer's own values, restated.

**Also included (WIP, separate commit):** `apps/web/src/WorksWithVariants.tsx` adds a tab bar above the roster with five drastically different presentations of the same data — a card grid, two counter-scrolling marquees, an orbit diagram, a terminal readout, and a plain typographic index — for design review before picking one. Not meant to ship as-is; once a variant is chosen it should be folded into `WorksWith.tsx` and this commit dropped.

## Verification

- `./scripts/check.sh` passes (exit 0). Web-only change — no desktop surface touched, so no `verify.sh` / physical-notch check applies.
- Inspected the built page in a real browser at 1280px and 390px, all five variants: brand colours intact, silhouettes legible on tiles, marquee loops seamlessly and respects `prefers-reduced-motion`, orbit rings don't collide down to 390px, no console errors.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32909498742/artifacts/9586223423) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32909498742)

- Commit: `0bdcbc73403bea8e83d253dc610ec221fb16dda9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
