### PR TITLE
fix: seat the filter clear X as a hairline-split segment of the options pill

### DIFF
--- a/apps/desktop/src/renderer/styles/sessions-options-clear.test.ts
+++ b/apps/desktop/src/renderer/styles/sessions-options-clear.test.ts
@@ -59,11 +59,11 @@ test("the narrowed pill is the wrapper, so the X can sit inside it", () => {
   assert.match(pill, /border-radius: 10px;/);
 });
 
-test("the X is a disc that must not grow inside the pill", () => {
+test("the X is the pill's own right segment, split off by a hairline", () => {
   const clear = rule(".options-clear");
-  assert.match(clear, /width: 20px;/);
-  assert.match(clear, /height: 20px;/);
-  assert.match(clear, /padding: 0;/);
+  assert.match(clear, /align-self: stretch;/);
+  assert.match(clear, /border-left: 1px solid var\(--hairline\);/);
+  assert.match(clear, /border-radius: 0 10px 10px 0;/);
   assert.match(clear, /flex: 0 0 auto;/);
-  assert.match(clear, /margin-right: 4px;/);
+  assert.doesNotMatch(clear, /margin/);
 });

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -166,6 +166,7 @@
   padding: 0 8px;
   border-left: 1px solid var(--hairline);
   border-radius: 0 10px 10px 0;
+  background: none;
   color: var(--text-tertiary);
   place-items: center;
   transition:

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -85,7 +85,10 @@
     color var(--duration-hover) ease;
 }
 
-.options-control[data-narrowed="true"]:hover,
+/* The pill lights for the toggle's own hover, not the wrapper's: the X is a
+   second press inside the same shape, and a hover there must name the segment
+   it will take rather than promising the whole pill. */
+.options-control[data-narrowed="true"]:has(.options-button:hover),
 .options-control[data-narrowed="true"]:has(.options-button[data-active="true"]) {
   background: var(--raised-strong);
 }
@@ -114,7 +117,6 @@
 }
 
 .options-control[data-narrowed="true"] .options-button {
-  padding-right: 4px;
   background: none;
   color: inherit;
 }
@@ -151,19 +153,19 @@
   color: var(--text-primary);
 }
 
-/* The way out of a held selection without opening the sheet. Colour is the
-   whole hover: the button must not grow or move inside a pill that names the
-   narrowing. Padding is zeroed by hand — the engine's own button padding is
-   asymmetric, and in a 20px disc it reads as the glyph leaning to one side. */
+/* The way out of a held selection without opening the sheet. Not a disc of its
+   own but the pill's right segment, split from the filter names by a hairline,
+   so the control reads as one joint button with two presses. It stretches to
+   the pill's full height and rounds only its outer corners, at the pill's own
+   radius, so its hover fill meets the hairline and the pill's edge with no
+   background of its own at rest. */
 .options-clear {
   display: grid;
-  width: 20px;
-  height: 20px;
+  align-self: stretch;
   flex: 0 0 auto;
-  margin-right: 4px;
-  padding: 0;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.14);
+  padding: 0 8px;
+  border-left: 1px solid var(--hairline);
+  border-radius: 0 10px 10px 0;
   color: var(--text-tertiary);
   place-items: center;
   transition:
@@ -172,7 +174,7 @@
 }
 
 .options-clear:hover {
-  background: rgba(255, 255, 255, 0.22);
+  background: var(--raised-strong);
   color: var(--text-primary);
 }
 


### PR DESCRIPTION
## Summary

- The clear-filters X on the sessions options control was a floating 20px disc with its own fill inside the pill. It is now the pill's own right segment: full height, split from the filter names by a vertical hairline, rounded only on its outer corners, with no background of its own at rest — so the control reads as one joint button with two presses, the way Linear seats a filter's clear.
- Hover now names the press it will take: the pill lights whole only for the toggle's own hover (or while the sheet is open), and the X segment carries its own hover fill against a resting pill.
- The style guard test follows the seat: it now asserts the hairline split, the full-height stretch, and the right-only radius instead of the disc's dimensions.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (exit 0)
- macOS Electron verification (`./scripts/verify.sh`): not run (Linux cloud agent; CI supplies automated visual evidence)

### Physical-device evidence

- Screenshot or screen recording: not attached
- Physical-notch check: not performed
- Device/display configuration: not recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/bc6a1bd7-56ec-48af-ac58-8630b0deb2df)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32453220426/artifacts/9436405856) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32453220426)

- Commit: `459490c85676aeb4752abf4a9e077a7137bf3c0c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
