### PR TITLE
fix(settings): open the provider's key page on the Connect press

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1085,6 +1085,28 @@ export function App(): React.JSX.Element {
   );
 
   /**
+   * A Connect press: the same entry {@link beginEntry} opens, with the
+   * provider's key page opened in the same press. Someone connecting has no
+   * key yet, so the first thing they need is the page that issues one — the
+   * consent and CLI connectors already work this way, because their browser
+   * half *is* the connection. The entry starts `away` for the same reason
+   * {@link fetchKey} marks it: the person this slot is now waiting for is
+   * reading a browser, so giving up leaves the browser alone rather than
+   * bringing the panel back over it. The page is still opened by provider id,
+   * so the only addresses reachable are the ones the credential registry
+   * fixes.
+   */
+  const connectEntry = useCallback(
+    (providerId: CredentialProviderId) => {
+      standDownPage.current = standDownReturnPage({ kind: PANEL_STAND_DOWN.KEY, providerId });
+      slotOccupant.current = PANEL_STAND_DOWN.KEY;
+      window.sidecar.openProviderApiKeys(providerId);
+      credentialsEntry.begin({ providerId, draft: "", busy: false, away: true });
+    },
+    [credentialsEntry.begin],
+  );
+
+  /**
    * Sends the browser to the provider's key page. The entry remembers that it
    * did: from here on, the person this slot is waiting for is reading a page
    * that Luke — which floats above every window — would otherwise be sitting on
@@ -1122,6 +1144,7 @@ export function App(): React.JSX.Element {
   const credentials: CredentialEntryControl = {
     entry: credentialsEntry.entry,
     begin: beginEntry,
+    connect: connectEntry,
     change: (draft) => credentialsEntry.patch({ draft }),
     fetchKey,
     cancel: credentialsEntry.cancel,

--- a/apps/desktop/src/renderer/credential-entry.test.ts
+++ b/apps/desktop/src/renderer/credential-entry.test.ts
@@ -13,6 +13,7 @@ function control(entry?: CredentialEntry): CredentialEntryControl {
   return {
     entry,
     begin: () => undefined,
+    connect: () => undefined,
     change: () => undefined,
     fetchKey: () => undefined,
     cancel: () => undefined,

--- a/apps/desktop/src/renderer/credential-entry.ts
+++ b/apps/desktop/src/renderer/credential-entry.ts
@@ -50,6 +50,15 @@ export interface CredentialEntryControl {
   entry?: CredentialEntry;
   /** Opens a field for a provider, replacing whatever was being entered. */
   begin(providerId: CredentialProviderId): void;
+  /**
+   * Begins the entry the way a Connect press asks for it: the field and the
+   * page that issues the key, together. Someone connecting has no key yet, so
+   * the browser goes to the provider's key page in the same press — the way
+   * every consent and CLI connector already opens one — and the entry starts
+   * already `away`. A replace stays on {@link begin}, because whoever is
+   * rotating a key may already be holding the new one.
+   */
+  connect(providerId: CredentialProviderId): void;
   change(draft: string): void;
   /**
    * Sends the browser to the provider's key page and stands the panel down to

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -188,7 +188,9 @@ function providersFact(settings: AppSettings): AppGuideFact {
     label: "Cloud providers",
     detail:
       `${roster.join(", ")}. Connecting one takes the key its row names, typed by hand into ` +
-      `${CONNECTIONS_PAGE}, under Providers — never spoken, and never repeated back. ` +
+      `${CONNECTIONS_PAGE}, under Providers — never spoken, and never repeated back. The row's ` +
+      "Connect press opens the provider's own key page in the browser and leaves the field " +
+      "waiting under the notch, so the key is fetched and pasted in one trip. " +
       "Local providers such as Claude Code need no key and are observed on their own. " +
       `Codex cloud tasks (${CODEX_CLOUD_CONNECTION_WORD[settings.codexCloudConnection]}) take ` +
       "no key in Luke at all: they are observed through the Codex CLI's own login, and the " +

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -559,10 +559,17 @@ function ProviderCredential({
 
   // Every control that offers to write one begins the one entry — which takes
   // the panel down to the slot — and clears whatever the last attempt was
-  // rejected for on the way.
+  // rejected for on the way. Connect also opens the provider's key page,
+  // because whoever is connecting has no key yet; the pencil does not, because
+  // whoever is replacing one may already be holding the replacement.
   const beginEntry = () => {
     setRemovalRejection(undefined);
     control.begin(provider.id);
+  };
+
+  const connectEntry = () => {
+    setRemovalRejection(undefined);
+    control.connect(provider.id);
   };
 
   // The trash asks; only the answer acts. Nothing here can hand a key back, so
@@ -667,7 +674,7 @@ function ProviderCredential({
                 disabled={beginBlocked}
                 aria-label={`Connect ${provider.displayName}`}
                 title={held ? HELD_TITLE : undefined}
-                onClick={beginEntry}
+                onClick={connectEntry}
               >
                 Connect
               </button>
@@ -3173,7 +3180,7 @@ function WhatLukeRunsOnSection({
         keyStored={keyStored}
         storageLocked={storageLocked}
         onChoose={preferences.onVoiceSourceChange}
-        onConnect={() => credentials.begin(VOICE_CREDENTIAL_PROVIDER.id)}
+        onConnect={() => credentials.connect(VOICE_CREDENTIAL_PROVIDER.id)}
       />
       {/* Each half's own contents, drawn under the toggle for whichever is
           live. They answer the same two questions in the two ways the sources


### PR DESCRIPTION
## What

Pressing **Connect** on a key provider's row (Conductor, Copilot, Cursor, Devin, Jules, and the OpenAI voice key) now opens the provider's own key page in the browser in the same press, with the paste field waiting in the slot under the notch.

## Why

Every other connector already opens the browser at its Connect press, because the browser half *is* the connection: Superset and Codex run their CLI's own login, Linear and Google Calendar open their consent pages. Key rows were the odd ones out — Connect opened the paste field and left the key page a second press away, behind "Where to get one". Precursor to Replicas support (#402), which inherits the behavior through the same registry-driven row.

## How

- `CredentialEntryControl` gains `connect(providerId)`: the same entry `begin` opens, plus `openProviderApiKeys` — still opened by provider id, so the only addresses reachable are the ones the credential registry fixes.
- The entry starts `away`, for the same reason `fetchKey` marks it: the person the slot is waiting for is reading a browser, so giving up leaves the browser alone rather than bringing the panel back over it.
- The pencil (replace) deliberately keeps the old behavior — whoever is rotating a key may already be holding the replacement — and the evidence bootstrap keeps the plain `begin`, because a capture run must not open a browser.
- The guide's Cloud providers fact now describes the one-trip flow, per the renderer's teach-the-guide rule.

## Testing

`./scripts/check.sh` passes end to end (all 24 suites, fail 0). Developed in a Linux cloud workspace, so `./scripts/verify.sh` (macOS packaging + visual evidence) was not run; no drawn geometry changed — the slot, field, and copy are untouched — so there is no new visual state to capture, and a physical-notch check was not performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/89c052b9-cdbb-42fb-a98c-551686b24184)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32453653817/artifacts/9436553494) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32453653817)

- Commit: `1136d07379d35eab893269d4aeb4858645f43588`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
