### PR TITLE
test(analytics): lock the erasure request the account delete sends

### DIFF
--- a/apps/web/tests/hosted-posthog.test.ts
+++ b/apps/web/tests/hosted-posthog.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  forgetPosthogPerson,
+  POSTHOG_DEFAULTS,
+  type PosthogForgetOptions,
+} from "../server/hosted/posthog";
+
+const PERSONAL_KEY = "phx_personal";
+const PROJECT_ID = "12345";
+
+interface Sent {
+  url: string;
+  init: RequestInit;
+}
+
+function upstream(status = 200) {
+  const sent: Sent[] = [];
+  const fetch = async (url: string, init: RequestInit) => {
+    sent.push({ url, init });
+    return new Response("{}", { status });
+  };
+  return { fetch, sent };
+}
+
+function onlySent(sent: readonly Sent[]): Sent {
+  assert.equal(sent.length, 1);
+  const request = sent[0];
+  assert.ok(request);
+  return request;
+}
+
+function options(overrides: Partial<PosthogForgetOptions> = {}): PosthogForgetOptions {
+  return { personalApiKey: PERSONAL_KEY, projectId: PROJECT_ID, ...overrides };
+}
+
+test("erasure asks the documented bulk delete for the one person and their events", async () => {
+  const posthog = upstream();
+  await forgetPosthogPerson("user-1", options({ fetch: posthog.fetch }));
+
+  const { url, init } = onlySent(posthog.sent);
+  assert.equal(
+    url,
+    `${POSTHOG_DEFAULTS.API_HOST}/api/projects/${PROJECT_ID}/persons/bulk_delete/?delete_events=true`,
+  );
+  assert.equal(init.method, "POST");
+  const headers = new Headers(init.headers);
+  assert.equal(headers.get("authorization"), `Bearer ${PERSONAL_KEY}`);
+  assert.equal(headers.get("content-type"), "application/json");
+  assert.deepEqual(JSON.parse(String(init.body)), { distinct_ids: ["user-1"] });
+});
+
+test("a configured private API host is used as given, without its trailing slash", async () => {
+  const posthog = upstream();
+  await forgetPosthogPerson(
+    "user-1",
+    options({ host: "https://eu.posthog.com/", fetch: posthog.fetch }),
+  );
+
+  const { url } = onlySent(posthog.sent);
+  assert.equal(
+    url,
+    `https://eu.posthog.com/api/projects/${PROJECT_ID}/persons/bulk_delete/?delete_events=true`,
+  );
+});
+
+test("a refusal throws the status alone, never anything that could name the key", async () => {
+  const posthog = upstream(401);
+  await assert.rejects(forgetPosthogPerson("user-1", options({ fetch: posthog.fetch })), {
+    message: "Analytics erasure refused with status 401",
+  });
+});
+
+test("a network fault reaches the caller, which owns deciding the delete proceeds", async () => {
+  await assert.rejects(
+    forgetPosthogPerson(
+      "user-1",
+      options({
+        fetch: async () => {
+          throw new Error("processor unreachable");
+        },
+      }),
+    ),
+    /processor unreachable/,
+  );
+});


### PR DESCRIPTION
## What

Analytics erasure on account delete turned out to already be implemented and shipped (#289): `handleAccountDelete` asks the optional `forgetAnalytics` seam to erase the analytics person before the user row goes, the route wires that seam to PostHog's documented `persons/bulk_delete/?delete_events=true` endpoint whenever the deployment holds the personal key and project id, and `PRIVACY.md` and the server README already describe it.

What was missing is any test over `forgetPosthogPerson` itself — the function that actually sends the erasure. The handler tests pin the ordering (forget before delete) and the tolerance (a refusal never blocks the delete), but nothing pinned the request. This PR adds `apps/web/tests/hosted-posthog.test.ts`:

- the documented bulk-delete request: the one distinct id in the body, `delete_events=true` in the query, the personal key as the bearer, JSON content type
- a configured private API host is used as given, trailing slash trimmed
- a refusal throws the status alone, an exact message that can never carry the key
- a network fault propagates to the caller — `handleAccountDelete` is the one that decides the delete proceeds anyway, so the function must not swallow it the way `postPosthogBatch` deliberately does

## Verification

- `./scripts/check.sh` passes (portable-only change; no UI touched, so no `verify.sh` run)
- `pnpm exec tsx --test tests/hosted-posthog.test.ts` in `apps/web`: 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/e686c43e-a1a0-4f62-9933-cf4b211538e9)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32514051115/artifacts/9458164369) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32514051115)

- Commit: `1680eec9d75105c1695d69448d76f9ff2fca9403`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
