### PR TITLE
fix(admin): put Google above GitHub on the sign-in card

### DIFF
--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -744,23 +744,23 @@ function SignInCard(): React.JSX.Element {
             type="button"
             className={`${AUTH_BUTTON} inline-flex items-center justify-center gap-2.5`}
             disabled={pending !== undefined}
-            onClick={() => void begin(SOCIAL_PROVIDER.GITHUB)}
-          >
-            <GitHubMark className="size-[15px] shrink-0" />
-            {pending === SOCIAL_PROVIDER.GITHUB
-              ? "Opening…"
-              : `Continue with ${SOCIAL_PROVIDER_LABEL[SOCIAL_PROVIDER.GITHUB]}`}
-          </button>
-          <button
-            type="button"
-            className={`${AUTH_BUTTON} inline-flex items-center justify-center gap-2.5`}
-            disabled={pending !== undefined}
             onClick={() => void begin(SOCIAL_PROVIDER.GOOGLE)}
           >
             <GoogleMark className="size-[15px] shrink-0" />
             {pending === SOCIAL_PROVIDER.GOOGLE
               ? "Opening…"
               : `Continue with ${SOCIAL_PROVIDER_LABEL[SOCIAL_PROVIDER.GOOGLE]}`}
+          </button>
+          <button
+            type="button"
+            className={`${AUTH_BUTTON} inline-flex items-center justify-center gap-2.5`}
+            disabled={pending !== undefined}
+            onClick={() => void begin(SOCIAL_PROVIDER.GITHUB)}
+          >
+            <GitHubMark className="size-[15px] shrink-0" />
+            {pending === SOCIAL_PROVIDER.GITHUB
+              ? "Opening…"
+              : `Continue with ${SOCIAL_PROVIDER_LABEL[SOCIAL_PROVIDER.GITHUB]}`}
           </button>
         </div>
         {failed ? <p className="m-0 text-attention">Sign-in could not start. Try again.</p> : null}


### PR DESCRIPTION
## Summary

The admin dashboard's sign-in card offered Continue with GitHub above Continue with Google, while the product's own sign-in gate (`apps/desktop/src/renderer/sign-in-gate.tsx`) offers Google first. This reorders the admin card's buttons so Google sits on top, matching the product.

No behavior change beyond button order: same providers, handlers, and pending/failure states.

## Testing

- `./scripts/check.sh` passes (lint, typecheck, tests, builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ab272f13-e207-44ce-bda7-feb2cbecdd51)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32514881611/artifacts/9458471263) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32514881611)

- Commit: `a603cf89d299c42a939c753425c2ed8ebd9368e4`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
