### PR TITLE
feat(admin): rank accounts by days present and give each its own page

### DIFF
--- a/apps/web/api/admin/metrics.ts
+++ b/apps/web/api/admin/metrics.ts
@@ -1,11 +1,10 @@
-import type { AdminViewer } from "../../server/admin/admin-access.js";
 import {
   adminIntegrations,
   buildAdminMetrics,
   handleAdminMetrics,
 } from "../../server/admin/admin-metrics.js";
 import { readAdminMetricsSource } from "../../server/admin/admin-queries.js";
-import { auth } from "../../server/auth.js";
+import { resolveSessionViewer } from "../../server/admin/viewer.js";
 import { getDatabase } from "../../server/db/index.js";
 import { HOSTED_OPENAI_ENVIRONMENT } from "../../server/hosted/openai.js";
 import { POSTHOG_ENVIRONMENT } from "../../server/hosted/posthog.js";
@@ -25,16 +24,6 @@ function configured(name: string): boolean {
  */
 export default {
   fetch(request: Request): Promise<Response> {
-    const resolveViewer = async (incoming: Request): Promise<AdminViewer | undefined> => {
-      // A getSession failure must propagate: the handler turns a thrown viewer
-      // seam into a 503, where swallowing it here would misreport an auth
-      // outage as a signed-out 401 and offer a sign-in that cannot succeed.
-      const authenticated = await auth.api.getSession({ headers: incoming.headers });
-      const account = authenticated?.user;
-      if (!account) return undefined;
-      return { userId: account.id, role: account.role };
-    };
-
     const integrations = adminIntegrations({
       hostedTier: configured(HOSTED_OPENAI_ENVIRONMENT.API_KEY),
       analyticsRecording: configured(POSTHOG_ENVIRONMENT.PROJECT_API_KEY),
@@ -48,7 +37,7 @@ export default {
 
     return handleAdminMetrics({
       request,
-      resolveViewer,
+      resolveViewer: resolveSessionViewer,
       readMetrics: async (now, scope) =>
         buildAdminMetrics(
           await readAdminMetricsSource(getDatabase(), { now, integrations, scope }),

--- a/apps/web/api/admin/user.ts
+++ b/apps/web/api/admin/user.ts
@@ -1,0 +1,24 @@
+import { readAdminUserSource } from "../../server/admin/admin-queries.js";
+import { buildAdminUserDetail, handleAdminUser } from "../../server/admin/admin-user.js";
+import { resolveSessionViewer } from "../../server/admin/viewer.js";
+import { getDatabase } from "../../server/db/index.js";
+
+/**
+ * One account's own page behind the overview's table. The gate and the day
+ * arithmetic live behind seams in `server/admin/`; this file hands them the
+ * deployment's real session resolver and database. The id arrives from the
+ * page's own roster of accounts and lands in one equality against the user
+ * table's key — it is never rendered back and never reaches a write.
+ */
+export default {
+  fetch(request: Request): Promise<Response> {
+    return handleAdminUser({
+      request,
+      resolveViewer: resolveSessionViewer,
+      readUser: async (userId, now) => {
+        const source = await readAdminUserSource(getDatabase(), { userId, now });
+        return source && buildAdminUserDetail(source, now);
+      },
+    });
+  },
+};

--- a/apps/web/server/admin/admin-metrics.ts
+++ b/apps/web/server/admin/admin-metrics.ts
@@ -67,14 +67,24 @@ export interface AdminSignInMethods {
 }
 
 /**
- * A heaviest user of the hosted tier over the window. This is the one place the
- * dashboard names an individual account, and it names it to the maintainer who
- * operates the service, from that service's own user row — the same two fields
- * the account already holds and the analytics person record already carries.
+ * A most-active account of the hosted tier over the window, ordered by the
+ * days it showed up rather than the volume it spent: the question the table
+ * answers is who lives in Luke daily, which a single heavy day cannot fake.
+ * The overview names an individual account here and nowhere else, and it
+ * names it to the maintainer who operates the service, from that service's
+ * own user row — the same fields the account already holds and the analytics
+ * person record already carries. The id is carried so the row can open the
+ * account's own page, and it goes back into the detail endpoint's gate,
+ * never into a rendered string.
  */
 export interface AdminTopUser {
+  id: string;
   name: string;
   email: string;
+  /** Window days with a hosted-usage row — the account showed up that day. */
+  activeDays: number;
+  /** The account's most recent active day inside the window, as YYYY-MM-DD. */
+  lastActiveDay: string;
   voiceCalls: number;
   attentionReviews: number;
   total: number;
@@ -214,12 +224,12 @@ export function lastNDayKeys(now: number, days: number): string[] {
   return keys;
 }
 
-function sum(values: readonly number[]): number {
+export function sum(values: readonly number[]): number {
   return values.reduce((total, value) => total + value, 0);
 }
 
 /** The last `days` of a windowed series beside the `days` before them. */
-function trailingTrend(counts: readonly number[], days: number): AdminTrend {
+export function trailingTrend(counts: readonly number[], days: number): AdminTrend {
   return {
     days,
     recent: sum(counts.slice(-days)),

--- a/apps/web/server/admin/admin-queries.ts
+++ b/apps/web/server/admin/admin-queries.ts
@@ -3,7 +3,7 @@ import type { createDatabase } from "../db/index.js";
 import { account, session, user } from "../db/schema.js";
 import { hostedUsage } from "../db/usage-schema.js";
 import { HOSTED_DAILY_LIMIT, HOSTED_METER, utcDayKey } from "../hosted/quota.js";
-import { USER_ROLE } from "./admin-access.js";
+import { isAdminRole, USER_ROLE } from "./admin-access.js";
 import {
   ADMIN_METRICS_WINDOW_DAYS,
   type AdminIntegration,
@@ -13,10 +13,11 @@ import {
   type AdminUsageDay,
   lastNDayKeys,
 } from "./admin-metrics.js";
+import type { AdminUserSource } from "./admin-user.js";
 import { ADMIN_METRICS_SCOPE, type AdminMetricsScope } from "./http.js";
 
-/** How many of the heaviest hosted-tier users the dashboard names. */
-export const ADMIN_TOP_USERS_LIMIT = 5;
+/** How many of the most active hosted-tier accounts the overview names. */
+export const ADMIN_TOP_USERS_LIMIT = 10;
 
 type Database = ReturnType<typeof createDatabase>;
 
@@ -131,10 +132,16 @@ async function readUsageMetrics(
       .from(hostedUsage)
       .innerJoin(user, eq(hostedUsage.userId, user.id))
       .where(and(gte(hostedUsage.day, windowStartDay), scopeCondition(scope))),
+    // Ordered by days present before volume spent: the table asks who shows
+    // up daily, and thirty quiet days outrank one heavy one. Volume breaks the
+    // ties that a short window makes common.
     database
       .select({
+        id: user.id,
         name: user.name,
         email: user.email,
+        activeDays: count(),
+        lastActiveDay: sql<string>`max(${hostedUsage.day})`,
         voiceCalls: sum(hostedUsage.voiceCalls),
         attentionReviews: sum(hostedUsage.attentionReviews),
       })
@@ -142,7 +149,10 @@ async function readUsageMetrics(
       .innerJoin(user, eq(hostedUsage.userId, user.id))
       .where(and(gte(hostedUsage.day, windowStartDay), scopeCondition(scope)))
       .groupBy(user.id, user.name, user.email)
-      .orderBy(desc(sql`sum(${hostedUsage.voiceCalls}) + sum(${hostedUsage.attentionReviews})`))
+      .orderBy(
+        desc(count()),
+        desc(sql`sum(${hostedUsage.voiceCalls}) + sum(${hostedUsage.attentionReviews})`),
+      )
       .limit(ADMIN_TOP_USERS_LIMIT),
   ]);
 
@@ -158,8 +168,11 @@ async function readUsageMetrics(
     const voiceCalls = toNumber(row.voiceCalls);
     const attentionReviews = toNumber(row.attentionReviews);
     return {
+      id: row.id,
       name: row.name,
       email: row.email,
+      activeDays: toNumber(row.activeDays),
+      lastActiveDay: row.lastActiveDay,
       voiceCalls,
       attentionReviews,
       total: voiceCalls + attentionReviews,
@@ -264,5 +277,101 @@ export async function readAdminMetricsSource(
     usage,
     reliability,
     systemHealth: { database: health, integrations: input.integrations },
+  };
+}
+
+/**
+ * Reads everything one account's page shows, or nothing when no user row
+ * carries the id. No probe and no empty fallback here: the detail page has no
+ * health card to report an outage on, so a database that does not answer is
+ * left to throw and become the handler's 503, where the metrics read instead
+ * degrades to a page that can say so.
+ */
+export async function readAdminUserSource(
+  database: Database,
+  input: { userId: string; now: number },
+): Promise<AdminUserSource | undefined> {
+  const dayKeys = lastNDayKeys(input.now, ADMIN_METRICS_WINDOW_DAYS);
+  const windowStartDay = dayKeys[0] ?? utcDayKey(input.now);
+
+  const [userRows, accountRows, windowRows, [allTimeRow], [quotaRow]] = await Promise.all([
+    database
+      .select({
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        image: user.image,
+        role: user.role,
+        createdAt: user.createdAt,
+      })
+      .from(user)
+      .where(eq(user.id, input.userId))
+      .limit(1),
+    database
+      .select({ providerId: account.providerId })
+      .from(account)
+      .where(eq(account.userId, input.userId)),
+    database
+      .select({
+        day: hostedUsage.day,
+        voiceCalls: hostedUsage.voiceCalls,
+        attentionReviews: hostedUsage.attentionReviews,
+      })
+      .from(hostedUsage)
+      .where(and(eq(hostedUsage.userId, input.userId), gte(hostedUsage.day, windowStartDay))),
+    database
+      .select({
+        activeDays: count(),
+        firstActiveDay: sql<string | null>`min(${hostedUsage.day})`,
+        lastActiveDay: sql<string | null>`max(${hostedUsage.day})`,
+        voiceCalls: sum(hostedUsage.voiceCalls),
+        attentionReviews: sum(hostedUsage.attentionReviews),
+      })
+      .from(hostedUsage)
+      .where(eq(hostedUsage.userId, input.userId)),
+    database
+      .select({ value: count() })
+      .from(hostedUsage)
+      .where(
+        and(
+          eq(hostedUsage.userId, input.userId),
+          gte(hostedUsage.day, windowStartDay),
+          ceilingReached(),
+        ),
+      ),
+  ]);
+
+  const row = userRows[0];
+  if (!row) return undefined;
+
+  const byDay = new Map<string, AdminUsageDay>();
+  for (const usageRow of windowRows) {
+    byDay.set(usageRow.day, {
+      voiceCalls: usageRow.voiceCalls,
+      attentionReviews: usageRow.attentionReviews,
+    });
+  }
+
+  return {
+    account: {
+      id: row.id,
+      name: row.name,
+      email: row.email,
+      image: row.image,
+      admin: isAdminRole(row.role),
+      createdAt: row.createdAt.getTime(),
+      signInMethods: accountRows.map((linked) => linked.providerId),
+    },
+    usage: {
+      byDay,
+      allTime: {
+        activeDays: toNumber(allTimeRow?.activeDays),
+        firstActiveDay: allTimeRow?.firstActiveDay ?? null,
+        lastActiveDay: allTimeRow?.lastActiveDay ?? null,
+        voiceCalls: toNumber(allTimeRow?.voiceCalls),
+        attentionReviews: toNumber(allTimeRow?.attentionReviews),
+      },
+      quotaLimitedDaysWindow: toNumber(quotaRow?.value),
+    },
   };
 }

--- a/apps/web/server/admin/admin-user.ts
+++ b/apps/web/server/admin/admin-user.ts
@@ -1,0 +1,187 @@
+import type { AdminViewer } from "./admin-access.js";
+import { isAdminRole } from "./admin-access.js";
+import {
+  ADMIN_METRICS_WINDOW_DAYS,
+  ADMIN_TREND_DAYS,
+  type AdminDailyUsage,
+  type AdminTrend,
+  type AdminUsageDay,
+  lastNDayKeys,
+  sum,
+  trailingTrend,
+} from "./admin-metrics.js";
+import {
+  ADMIN_ERROR,
+  ADMIN_HTTP_STATUS,
+  adminUserId,
+  errorResponse,
+  jsonResponse,
+} from "./http.js";
+
+/**
+ * One account's own page behind the overview's table, answering the question
+ * the aggregates cannot: is this person living in Luke daily, or did one heavy
+ * afternoon put them on the board? It reads the same rows the overview already
+ * aggregates — the user row, its linked provider rows, and the hosted-usage
+ * days — behind the same admin gate, and it widens no analytics event: the
+ * day-level signal here is the row the hosted tier already writes to meter
+ * itself, never anything read off the user's machine.
+ */
+
+/** The account the page names, from the service's own user row. */
+export interface AdminUserAccount {
+  id: string;
+  name: string;
+  email: string;
+  /** The avatar URL the sign-in provider gave the account, when it gave one. */
+  image: string | null;
+  admin: boolean;
+  /** When the account was created, in epoch milliseconds. */
+  createdAt: number;
+  /** Linked sign-in providers, as their account rows name them (e.g. "github"). */
+  signInMethods: string[];
+}
+
+/** The account's whole hosted-tier history, folded to counts and two dates. */
+export interface AdminUserAllTime {
+  activeDays: number;
+  firstActiveDay: string | null;
+  lastActiveDay: string | null;
+  voiceCalls: number;
+  attentionReviews: number;
+}
+
+/**
+ * The raw shape the queries produce for one account, before the pure builder
+ * zero-fills the series and reads the streak off it — split out, like the
+ * overview's source, so the day arithmetic is testable without a database.
+ */
+export interface AdminUserSource {
+  account: AdminUserAccount;
+  usage: {
+    byDay: ReadonlyMap<string, AdminUsageDay>;
+    allTime: AdminUserAllTime;
+    /** Window days on which this account reached a hosted daily ceiling. */
+    quotaLimitedDaysWindow: number;
+  };
+}
+
+export interface AdminUserDetail {
+  generatedAt: number;
+  windowDays: number;
+  account: AdminUserAccount;
+  activity: {
+    daily: AdminDailyUsage[];
+    usageTrend: AdminTrend;
+    activeDaysWindow: number;
+    /** Active days in the trailing run beside the run before it. */
+    activeDaysTrend: AdminTrend;
+    /**
+     * Consecutive active days ending today or yesterday — today may simply not
+     * have started yet. Read off the window's own series, so a run older than
+     * the window reports the window's length and the page words it as "or
+     * longer" rather than posing a truncation as the exact count.
+     */
+    currentStreakDays: number;
+    voiceCallsWindow: number;
+    attentionReviewsWindow: number;
+    quotaLimitedDaysWindow: number;
+    allTime: AdminUserAllTime;
+  };
+}
+
+/** Shapes one account's queried source into the page's answer. */
+export function buildAdminUserDetail(source: AdminUserSource, now: number): AdminUserDetail {
+  const dayKeys = lastNDayKeys(now, ADMIN_METRICS_WINDOW_DAYS);
+
+  const daily = dayKeys.map((day) => {
+    const row = source.usage.byDay.get(day);
+    return {
+      day,
+      voiceCalls: row?.voiceCalls ?? 0,
+      attentionReviews: row?.attentionReviews ?? 0,
+    };
+  });
+
+  const activeFlags = daily.map((day) => day.voiceCalls + day.attentionReviews > 0);
+  let streakEnd = activeFlags.length - 1;
+  if (!activeFlags[streakEnd]) streakEnd -= 1;
+  let currentStreakDays = 0;
+  for (let index = streakEnd; index >= 0 && activeFlags[index]; index -= 1) {
+    currentStreakDays += 1;
+  }
+
+  return {
+    generatedAt: now,
+    windowDays: ADMIN_METRICS_WINDOW_DAYS,
+    account: source.account,
+    activity: {
+      daily,
+      usageTrend: trailingTrend(
+        daily.map((day) => day.voiceCalls + day.attentionReviews),
+        ADMIN_TREND_DAYS,
+      ),
+      activeDaysWindow: activeFlags.filter(Boolean).length,
+      activeDaysTrend: trailingTrend(
+        activeFlags.map((active) => (active ? 1 : 0)),
+        ADMIN_TREND_DAYS,
+      ),
+      currentStreakDays,
+      voiceCallsWindow: sum(daily.map((day) => day.voiceCalls)),
+      attentionReviewsWindow: sum(daily.map((day) => day.attentionReviews)),
+      quotaLimitedDaysWindow: source.usage.quotaLimitedDaysWindow,
+      allTime: source.usage.allTime,
+    },
+  };
+}
+
+export interface AdminUserOptions {
+  request: Request;
+  resolveViewer: (request: Request) => Promise<AdminViewer | undefined>;
+  /** The named account's detail, or nothing when no user row carries that id. */
+  readUser: (userId: string, now: number) => Promise<AdminUserDetail | undefined>;
+  now?: () => number;
+}
+
+/**
+ * Answers one account's read behind the same gate the overview's metrics
+ * stand behind, with the same distinct refusals, plus the two of its own: a
+ * request that named no account is a 400 before any seam is touched, and an
+ * id no user row carries is a 404 the page can word as the account being
+ * gone rather than the service being down.
+ */
+export async function handleAdminUser(options: AdminUserOptions): Promise<Response> {
+  const { request } = options;
+  if (request.method !== "GET") {
+    return errorResponse(ADMIN_HTTP_STATUS.METHOD_NOT_ALLOWED, ADMIN_ERROR.METHOD_NOT_ALLOWED);
+  }
+
+  let viewer: AdminViewer | undefined;
+  try {
+    viewer = await options.resolveViewer(request);
+  } catch {
+    return errorResponse(ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE, ADMIN_ERROR.UNAVAILABLE);
+  }
+  if (!viewer) {
+    return errorResponse(ADMIN_HTTP_STATUS.UNAUTHORIZED, ADMIN_ERROR.NOT_SIGNED_IN);
+  }
+  if (!isAdminRole(viewer.role)) {
+    return errorResponse(ADMIN_HTTP_STATUS.FORBIDDEN, ADMIN_ERROR.NOT_AUTHORIZED);
+  }
+
+  const userId = adminUserId(request.url);
+  if (userId === undefined) {
+    return errorResponse(ADMIN_HTTP_STATUS.BAD_REQUEST, ADMIN_ERROR.MISSING_USER_ID);
+  }
+
+  const now = (options.now ?? Date.now)();
+  try {
+    const detail = await options.readUser(userId, now);
+    if (detail === undefined) {
+      return errorResponse(ADMIN_HTTP_STATUS.NOT_FOUND, ADMIN_ERROR.USER_NOT_FOUND);
+    }
+    return jsonResponse(ADMIN_HTTP_STATUS.OK, detail);
+  } catch {
+    return errorResponse(ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE, ADMIN_ERROR.UNAVAILABLE);
+  }
+}

--- a/apps/web/server/admin/http.ts
+++ b/apps/web/server/admin/http.ts
@@ -10,8 +10,10 @@
 
 export const ADMIN_HTTP_STATUS = {
   OK: 200,
+  BAD_REQUEST: 400,
   UNAUTHORIZED: 401,
   FORBIDDEN: 403,
+  NOT_FOUND: 404,
   METHOD_NOT_ALLOWED: 405,
   SERVICE_UNAVAILABLE: 503,
 } as const;
@@ -22,6 +24,10 @@ export const ADMIN_ERROR = {
   /** Signed in, but the account has no admin row. */
   NOT_AUTHORIZED: "not-authorized",
   METHOD_NOT_ALLOWED: "method-not-allowed",
+  /** A detail read that named no account, or named one past the id bound. */
+  MISSING_USER_ID: "missing-user-id",
+  /** The named account has no user row — deleted, or the id never existed. */
+  USER_NOT_FOUND: "user-not-found",
   /** A seam (auth or the database) did not answer; the answer is a JSON refusal, never a crash. */
   UNAVAILABLE: "unavailable",
 } as const;
@@ -55,6 +61,20 @@ export function adminMetricsScope(url: string): AdminMetricsScope {
   return value === ADMIN_METRICS_SCOPE.ALL
     ? ADMIN_METRICS_SCOPE.ALL
     : ADMIN_METRICS_SCOPE.NON_ADMINS;
+}
+
+export const ADMIN_USER_ID_PARAM = "id";
+
+/**
+ * The account a detail read named, or nothing when it named none worth asking
+ * the database about. The bound is generous against any id Better Auth mints —
+ * it exists so an arbitrarily long query string never reaches a query, not to
+ * validate the id's shape, which only the user table itself can answer.
+ */
+export function adminUserId(url: string): string | undefined {
+  const value = new URL(url).searchParams.get(ADMIN_USER_ID_PARAM)?.trim() ?? "";
+  if (value.length === 0 || value.length > 128) return undefined;
+  return value;
 }
 
 export function jsonResponse<Body extends object>(status: number, body: Body): Response {

--- a/apps/web/server/admin/viewer.ts
+++ b/apps/web/server/admin/viewer.ts
@@ -1,0 +1,16 @@
+import { auth } from "../auth.js";
+import type { AdminViewer } from "./admin-access.js";
+
+/**
+ * The browser session an admin request rides in on — the maintainer's own
+ * sign-in on this site, carrying that account's `role`, never the desktop's
+ * bearer token. A getSession failure must propagate: each handler turns a
+ * thrown viewer seam into a 503, where swallowing it here would misreport an
+ * auth outage as a signed-out 401 and offer a sign-in that cannot succeed.
+ */
+export async function resolveSessionViewer(request: Request): Promise<AdminViewer | undefined> {
+  const authenticated = await auth.api.getSession({ headers: request.headers });
+  const account = authenticated?.user;
+  if (!account) return undefined;
+  return { userId: account.id, role: account.role };
+}

--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -8,10 +8,12 @@ import type {
   AdminTopUser,
   AdminTrend,
 } from "../server/admin/admin-metrics";
+import type { AdminUserAccount, AdminUserDetail } from "../server/admin/admin-user";
 import {
   ADMIN_HTTP_STATUS,
   ADMIN_METRICS_SCOPE,
   ADMIN_METRICS_SCOPE_PARAM,
+  ADMIN_USER_ID_PARAM,
 } from "../server/admin/http";
 import { accountInitials } from "./account-initials";
 import { GitHubMark, GoogleMark } from "./account-marks";
@@ -22,6 +24,37 @@ import { SOCIAL_PROVIDER, SOCIAL_PROVIDER_LABEL, type SocialProvider } from "./s
 const authClient = createAuthClient();
 
 const METRICS_PATH = "/api/admin/metrics";
+const USER_DETAIL_PATH = "/api/admin/user";
+
+/**
+ * The page's own address for one account, distinct from the API's `id` so a
+ * pasted dashboard link and an API call never read as each other. The id
+ * rides the query string because the page is served at `/admin` alone — a
+ * path segment would need its own route — and it goes back into the detail
+ * endpoint's gate, never into anything rendered.
+ */
+const ACCOUNT_VIEW_PARAM = "user";
+
+/** Which of the page's two views the address bar names. */
+type AdminView = { kind: "overview" } | { kind: "account"; id: string };
+
+function viewFromLocation(): AdminView {
+  const id = new URLSearchParams(window.location.search).get(ACCOUNT_VIEW_PARAM);
+  return id ? { kind: "account", id } : { kind: "overview" };
+}
+
+function accountHref(id: string): string {
+  return `${window.location.pathname}?${ACCOUNT_VIEW_PARAM}=${encodeURIComponent(id)}`;
+}
+
+/**
+ * Whether a click on a link is asking this page to navigate, or asking the
+ * browser for its own gesture — a new tab, a window, a download — which the
+ * real anchor underneath must keep answering.
+ */
+function plainLeftClick(event: React.MouseEvent): boolean {
+  return event.button === 0 && !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey;
+}
 
 /**
  * The site's session cookie is shared with the sign-in flow the desktop app
@@ -96,6 +129,14 @@ function formatTimestamp(epochMs: number): string {
   return new Date(epochMs).toLocaleString("en-US", {
     dateStyle: "medium",
     timeStyle: "short",
+    timeZone: "UTC",
+  });
+}
+
+/** An instant drawn as its UTC date alone, e.g. "Aug 3, 2026". */
+function formatDate(epochMs: number): string {
+  return new Date(epochMs).toLocaleDateString("en-US", {
+    dateStyle: "medium",
     timeZone: "UTC",
   });
 }
@@ -332,7 +373,22 @@ function ProviderBar({
   );
 }
 
-function TopUsersTable({ users }: { users: readonly AdminTopUser[] }): React.JSX.Element {
+/**
+ * The accounts that show up most, ordered by days present before volume
+ * spent, so the people living in Luke daily sit on top of the people who had
+ * one heavy afternoon. Every row opens the account's own page: the row for
+ * the pointer, and a real anchor on the name so a keyboard reaches it and a
+ * modified click still gets the browser's own gesture.
+ */
+function ActiveAccountsTable({
+  users,
+  windowDays,
+  onOpen,
+}: {
+  users: readonly AdminTopUser[];
+  windowDays: number;
+  onOpen: (id: string) => void;
+}): React.JSX.Element {
   if (users.length === 0) {
     return (
       <div className="rounded-lg border border-border bg-card px-5 py-8 text-center text-sm text-muted-foreground">
@@ -346,6 +402,8 @@ function TopUsersTable({ users }: { users: readonly AdminTopUser[] }): React.JSX
         <thead>
           <tr className="border-b border-border text-left font-mono text-xs text-muted-foreground uppercase">
             <th className="px-5 py-3 font-medium">Account</th>
+            <th className="px-5 py-3 text-right font-medium">Active days</th>
+            <th className="px-5 py-3 text-right font-medium">Last active</th>
             <th className="px-5 py-3 text-right font-medium">Voice</th>
             <th className="px-5 py-3 text-right font-medium">Attention</th>
             <th className="px-5 py-3 text-right font-medium">Total</th>
@@ -353,10 +411,32 @@ function TopUsersTable({ users }: { users: readonly AdminTopUser[] }): React.JSX
         </thead>
         <tbody>
           {users.map((entry) => (
-            <tr key={entry.email} className="border-b border-border last:border-0">
+            <tr
+              key={entry.id}
+              className="cursor-pointer border-b border-border transition-colors duration-150 last:border-0 hover:bg-muted"
+              onClick={() => onOpen(entry.id)}
+            >
               <td className="px-5 py-3">
-                <div className="font-medium">{entry.name}</div>
-                <div className="text-xs text-muted-foreground">{entry.email}</div>
+                <a
+                  href={accountHref(entry.id)}
+                  className="block outline-offset-2"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    if (!plainLeftClick(event)) return;
+                    event.preventDefault();
+                    onOpen(entry.id);
+                  }}
+                >
+                  <div className="font-medium">{entry.name}</div>
+                  <div className="text-xs text-muted-foreground">{entry.email}</div>
+                </a>
+              </td>
+              <td className="px-5 py-3 text-right tabular-nums">
+                {formatNumber(entry.activeDays)}
+                <span className="text-muted-foreground"> of {formatNumber(windowDays)}</span>
+              </td>
+              <td className="px-5 py-3 text-right tabular-nums">
+                {formatDayTick(entry.lastActiveDay)}
               </td>
               <td className="px-5 py-3 text-right tabular-nums">
                 {formatNumber(entry.voiceCalls)}
@@ -396,12 +476,29 @@ function IntegrationRow({ integration }: { integration: AdminIntegration }): Rea
   );
 }
 
+const AVATAR_FRAME = {
+  small: "size-8",
+  large: "size-14",
+} as const;
+
+const AVATAR_TEXT = {
+  small: "text-xs",
+  large: "text-lg",
+} as const;
+
 /**
- * The account's own avatar, falling back to its initials. A provider's avatar
+ * An account's own avatar, falling back to its initials. A provider's avatar
  * URL can outlive the image it named, so a failed fetch falls back to the
- * letters rather than leaving a broken frame in the header.
+ * letters rather than leaving a broken frame. Small is the header's, large is
+ * the detail page's masthead.
  */
-function AccountAvatar({ account }: { account: ViewerAccount }): React.JSX.Element {
+function AccountAvatar({
+  account,
+  size = "small",
+}: {
+  account: ViewerAccount;
+  size?: keyof typeof AVATAR_FRAME;
+}): React.JSX.Element {
   const [imageFailed, setImageFailed] = useState(false);
 
   if (account.image !== undefined && !imageFailed) {
@@ -409,7 +506,7 @@ function AccountAvatar({ account }: { account: ViewerAccount }): React.JSX.Eleme
       <img
         src={account.image}
         alt=""
-        className="size-8 rounded-full object-cover"
+        className={`${AVATAR_FRAME[size]} rounded-full object-cover`}
         // Google's avatar host answers 403 to a request carrying a Referer, so
         // without this a Google-signed-in admin falls to initials every time.
         referrerPolicy="no-referrer"
@@ -419,7 +516,7 @@ function AccountAvatar({ account }: { account: ViewerAccount }): React.JSX.Eleme
   }
   return (
     <span
-      className="grid size-8 place-items-center rounded-full bg-muted text-xs font-semibold"
+      className={`grid ${AVATAR_FRAME[size]} place-items-center rounded-full bg-muted ${AVATAR_TEXT[size]} font-semibold`}
       aria-hidden="true"
     >
       {accountInitials(account.name, account.email)}
@@ -505,6 +602,56 @@ function AccountMenu({
   );
 }
 
+/** The brand block and account menu both views wear; controls sit between them. */
+function PageHeader({
+  controls,
+  account,
+  onSignOut,
+}: {
+  controls: React.ReactNode;
+  account: ViewerAccount | undefined;
+  onSignOut: () => void;
+}): React.JSX.Element {
+  return (
+    <header className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
+      <div className="inline-flex items-center gap-2">
+        <span className="inline-flex w-6 text-foreground" aria-hidden="true">
+          <LukeMark className="h-auto w-full" />
+        </span>
+        <span className="font-brand text-base font-bold tracking-[-0.01em]">Luke admin</span>
+      </div>
+      <div className="flex flex-wrap items-center gap-4">
+        {controls}
+        {account ? (
+          <>
+            <span className="h-8 w-px bg-border" aria-hidden="true" />
+            <AccountMenu account={account} onSignOut={onSignOut} />
+          </>
+        ) : null}
+      </div>
+    </header>
+  );
+}
+
+function GeneratedStamp({
+  generatedAt,
+  windowDays,
+  now,
+}: {
+  generatedAt: number;
+  windowDays: number;
+  now: number;
+}): React.JSX.Element {
+  return (
+    <span
+      className="font-mono text-xs text-muted-foreground"
+      title={`${formatTimestamp(generatedAt)} UTC`}
+    >
+      {windowDays}-day window · generated {formatAge(Math.max(0, now - generatedAt))}
+    </span>
+  );
+}
+
 function Dashboard({
   metrics,
   hideAdmins,
@@ -513,6 +660,7 @@ function Dashboard({
   onSignOut,
   refreshing,
   onRefresh,
+  onOpenAccount,
   now,
 }: {
   metrics: AdminMetrics;
@@ -522,6 +670,7 @@ function Dashboard({
   onSignOut: () => void;
   refreshing: boolean;
   onRefresh: () => void;
+  onOpenAccount: (id: string) => void;
   now: number;
 }): React.JSX.Element {
   const providerTotal =
@@ -532,41 +681,36 @@ function Dashboard({
 
   return (
     <div className="mx-auto max-w-[1040px] px-6 py-10">
-      <header className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
-        <div className="inline-flex items-center gap-2">
-          <span className="inline-flex w-6 text-foreground" aria-hidden="true">
-            <LukeMark className="h-auto w-full" />
-          </span>
-          <span className="font-brand text-base font-bold tracking-[-0.01em]">Luke admin</span>
-        </div>
-        <div className="flex flex-wrap items-center gap-4">
-          <label className="inline-flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground select-none">
-            <input
-              type="checkbox"
-              className="size-3.5 cursor-pointer accent-primary"
-              checked={hideAdmins}
-              onChange={(event) => onHideAdminsChange(event.target.checked)}
+      <PageHeader
+        account={account}
+        onSignOut={onSignOut}
+        controls={
+          <>
+            <label className="inline-flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground select-none">
+              <input
+                type="checkbox"
+                className="size-3.5 cursor-pointer accent-primary"
+                checked={hideAdmins}
+                onChange={(event) => onHideAdminsChange(event.target.checked)}
+              />
+              Hide admins
+            </label>
+            <GeneratedStamp
+              generatedAt={metrics.generatedAt}
+              windowDays={metrics.windowDays}
+              now={now}
             />
-            Hide admins
-          </label>
-          <span
-            className="font-mono text-xs text-muted-foreground"
-            title={`${formatTimestamp(metrics.generatedAt)} UTC`}
-          >
-            {metrics.windowDays}-day window · generated{" "}
-            {formatAge(Math.max(0, now - metrics.generatedAt))}
-          </span>
-          <button type="button" className={PLAIN_BUTTON} onClick={onRefresh} disabled={refreshing}>
-            {refreshing ? "Refreshing…" : "Refresh"}
-          </button>
-          {account ? (
-            <>
-              <span className="h-8 w-px bg-border" aria-hidden="true" />
-              <AccountMenu account={account} onSignOut={onSignOut} />
-            </>
-          ) : null}
-        </div>
-      </header>
+            <button
+              type="button"
+              className={PLAIN_BUTTON}
+              onClick={onRefresh}
+              disabled={refreshing}
+            >
+              {refreshing ? "Refreshing…" : "Refresh"}
+            </button>
+          </>
+        }
+      />
 
       {/* A refetch dims the answer already on screen rather than replacing it:
           the numbers below stay the last ones actually read, and the dimming
@@ -647,8 +791,17 @@ function Dashboard({
         <div className="mt-3">
           <UsageChart daily={metrics.featureUsage.daily} trend={metrics.featureUsage.usageTrend} />
         </div>
-        <SectionHeading>Heaviest hosted-tier accounts</SectionHeading>
-        <TopUsersTable users={metrics.featureUsage.topUsers} />
+        <SectionHeading>Most active hosted-tier accounts</SectionHeading>
+        <ActiveAccountsTable
+          users={metrics.featureUsage.topUsers}
+          windowDays={metrics.windowDays}
+          onOpen={onOpenAccount}
+        />
+        <p className="mt-3 text-sm text-muted-foreground">
+          An active day is a UTC day the account spent hosted voice or attention — the one
+          per-account daily signal the service's own tables hold. A row opens the account's own
+          page.
+        </p>
 
         <SectionHeading>Reliability</SectionHeading>
         <div className="grid grid-cols-2 gap-3">
@@ -789,6 +942,28 @@ function Centered({
   );
 }
 
+/** The gate's one non-admin refusal, worded the same on both views. */
+function ForbiddenCard({
+  email,
+  onSignOut,
+}: {
+  email: string | undefined;
+  onSignOut: () => void;
+}): React.JSX.Element {
+  return (
+    <Centered title="Not authorized">
+      You are signed in{email ? ` as ${email}` : ""}, but this account does not have the admin role.
+      Admin access is the <code className="font-mono">admin</code> role on your account, set
+      directly in the database.
+      <div className="mt-6">
+        <button type="button" className={PLAIN_BUTTON} onClick={onSignOut}>
+          Sign out
+        </button>
+      </div>
+    </Centered>
+  );
+}
+
 /** What one answer from the metrics endpoint means, with the gate's refusals kept distinct. */
 async function readDashboardState(response: Response): Promise<DashboardState> {
   // A followed cross-origin redirect means something sat in front of the API —
@@ -803,6 +978,305 @@ async function readDashboardState(response: Response): Promise<DashboardState> {
   if (!response.ok) return { status: "error", detail: ERROR_DETAIL.GENERIC };
   // SAFETY: a 200 from the admin metrics endpoint is an AdminMetrics body by its contract.
   return { status: "ready", metrics: (await response.json()) as AdminMetrics };
+}
+
+/** What the detail fetch resolved to: the overview's states plus a gone account. */
+type DetailState =
+  | { status: "loading" }
+  | { status: "signed-out" }
+  | { status: "forbidden" }
+  | { status: "missing" }
+  | { status: "error"; detail: string }
+  | { status: "ready"; detail: AdminUserDetail };
+
+async function readDetailState(response: Response): Promise<DetailState> {
+  if (response.redirected) return { status: "error", detail: ERROR_DETAIL.PROTECTED };
+  if (response.status === ADMIN_HTTP_STATUS.UNAUTHORIZED) return { status: "signed-out" };
+  if (response.status === ADMIN_HTTP_STATUS.FORBIDDEN) return { status: "forbidden" };
+  if (response.status === ADMIN_HTTP_STATUS.NOT_FOUND) return { status: "missing" };
+  if (response.status === ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE) {
+    return { status: "error", detail: ERROR_DETAIL.UNAVAILABLE };
+  }
+  if (!response.ok) return { status: "error", detail: ERROR_DETAIL.GENERIC };
+  // SAFETY: a 200 from the admin user endpoint is an AdminUserDetail body by its contract.
+  return { status: "ready", detail: (await response.json()) as AdminUserDetail };
+}
+
+/** A linked provider's row value drawn as its label where the page knows one. */
+function signInMethodLabel(providerId: string): string {
+  if (providerId === SOCIAL_PROVIDER.GITHUB) return SOCIAL_PROVIDER_LABEL[SOCIAL_PROVIDER.GITHUB];
+  if (providerId === SOCIAL_PROVIDER.GOOGLE) return SOCIAL_PROVIDER_LABEL[SOCIAL_PROVIDER.GOOGLE];
+  return providerId;
+}
+
+function UserDetailPage({
+  detail,
+  account,
+  onSignOut,
+  onBack,
+  refreshing,
+  onRefresh,
+  now,
+}: {
+  detail: AdminUserDetail;
+  account: ViewerAccount | undefined;
+  onSignOut: () => void;
+  onBack: () => void;
+  refreshing: boolean;
+  onRefresh: () => void;
+  now: number;
+}): React.JSX.Element {
+  const subject: AdminUserAccount = detail.account;
+  const activity = detail.activity;
+  // A streak as long as the window may run past it; the page says so rather
+  // than posing the truncation as the exact count.
+  const streak =
+    activity.currentStreakDays >= detail.windowDays
+      ? `${formatNumber(detail.windowDays)}+`
+      : formatNumber(activity.currentStreakDays);
+
+  return (
+    <div className="mx-auto max-w-[1040px] px-6 py-10">
+      <PageHeader
+        account={account}
+        onSignOut={onSignOut}
+        controls={
+          <>
+            <GeneratedStamp
+              generatedAt={detail.generatedAt}
+              windowDays={detail.windowDays}
+              now={now}
+            />
+            <button
+              type="button"
+              className={PLAIN_BUTTON}
+              onClick={onRefresh}
+              disabled={refreshing}
+            >
+              {refreshing ? "Refreshing…" : "Refresh"}
+            </button>
+          </>
+        }
+      />
+
+      <div
+        className="transition-opacity duration-150 data-[busy=true]:opacity-50"
+        data-busy={refreshing}
+        aria-busy={refreshing}
+      >
+        <a
+          href={window.location.pathname}
+          className="mt-8 inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors duration-150 hover:text-foreground"
+          onClick={(event) => {
+            if (!plainLeftClick(event)) return;
+            event.preventDefault();
+            onBack();
+          }}
+        >
+          <span aria-hidden="true">←</span> All accounts
+        </a>
+
+        <div className="mt-6 flex flex-wrap items-center gap-4">
+          <AccountAvatar
+            account={{
+              name: subject.name,
+              email: subject.email,
+              image: subject.image ?? undefined,
+            }}
+            size="large"
+          />
+          <div>
+            <div className="flex flex-wrap items-center gap-2.5">
+              <h1 className="text-2xl font-semibold tracking-[-0.01em]">
+                {subject.name || subject.email}
+              </h1>
+              {subject.admin ? (
+                <span className="rounded-full border border-border px-2 py-0.5 font-mono text-[10px] tracking-[0.2px] text-muted-foreground uppercase">
+                  Admin
+                </span>
+              ) : null}
+            </div>
+            <div className="mt-1 text-sm text-muted-foreground">{subject.email}</div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              Joined {formatDate(subject.createdAt)}
+              {subject.signInMethods.length > 0
+                ? ` · signs in with ${subject.signInMethods.map(signInMethodLabel).join(", ")}`
+                : ""}
+            </div>
+          </div>
+        </div>
+
+        <SectionHeading>Daily use · hosted tier</SectionHeading>
+        <div className="grid grid-cols-2 gap-3 min-[720px]:grid-cols-4">
+          <StatCard
+            label={`Active days · ${detail.windowDays} days`}
+            value={formatNumber(activity.activeDaysWindow)}
+            hint={`of ${formatNumber(detail.windowDays)} window days`}
+          />
+          <StatCard
+            label="Current streak"
+            value={`${streak} ${activity.currentStreakDays === 1 ? "day" : "days"}`}
+            hint="consecutive active days"
+          />
+          <StatCard
+            label={`Active days · ${activity.activeDaysTrend.days} days`}
+            value={formatNumber(activity.activeDaysTrend.recent)}
+            hint={`${formatNumber(activity.activeDaysTrend.prior)} the week before`}
+          />
+          <StatCard
+            label="Last active"
+            value={
+              activity.allTime.lastActiveDay ? formatDayTick(activity.allTime.lastActiveDay) : "—"
+            }
+            hint={
+              activity.allTime.firstActiveDay
+                ? `first active ${formatDayTick(activity.allTime.firstActiveDay)}`
+                : "no hosted usage yet"
+            }
+          />
+        </div>
+        <div className="mt-3">
+          <UsageChart daily={activity.daily} trend={activity.usageTrend} />
+        </div>
+
+        <SectionHeading>Volume</SectionHeading>
+        <div className="grid grid-cols-2 gap-3 min-[720px]:grid-cols-4">
+          <StatCard
+            label={`Voice · ${detail.windowDays} days`}
+            value={formatNumber(activity.voiceCallsWindow)}
+            hint={`${formatNumber(activity.allTime.voiceCalls)} all time`}
+          />
+          <StatCard
+            label={`Attention · ${detail.windowDays} days`}
+            value={formatNumber(activity.attentionReviewsWindow)}
+            hint={`${formatNumber(activity.allTime.attentionReviews)} all time`}
+          />
+          <StatCard
+            label="Active days · all time"
+            value={formatNumber(activity.allTime.activeDays)}
+          />
+          <StatCard
+            label={`Throttled days · ${detail.windowDays} days`}
+            value={formatNumber(activity.quotaLimitedDaysWindow)}
+            hint="days a daily ceiling was reached"
+          />
+        </div>
+        <p className="mt-3 text-sm text-muted-foreground">
+          An active day is a UTC day this account spent hosted voice or attention — the one
+          per-account daily signal the service's own tables hold. Purely local use of the desktop
+          app writes no row here; day-level launch activity is recorded as product-analytics events,
+          which live with the analytics processor rather than in this database.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function UserDetailScreen({
+  id,
+  account,
+  onSignOut,
+  onBack,
+  now,
+}: {
+  id: string;
+  account: ViewerAccount | undefined;
+  onSignOut: () => void;
+  onBack: () => void;
+  now: number;
+}): React.JSX.Element {
+  const [state, setState] = useState<DetailState>(() =>
+    signInChosenHere() ? { status: "loading" } : { status: "signed-out" },
+  );
+  const [refreshing, setRefreshing] = useState(false);
+  const inFlight = useRef<AbortController>(null);
+
+  const load = useCallback(() => {
+    // The same local consent the overview asks for: a deep link into an
+    // account page still opens on the sign-in card until a sign-in has been
+    // pressed on this page once.
+    if (!signInChosenHere()) {
+      setState({ status: "signed-out" });
+      return;
+    }
+    inFlight.current?.abort();
+    const controller = new AbortController();
+    inFlight.current = controller;
+    // A refresh keeps the page it is refreshing; a different account — the
+    // browser's own back and forward can swap ids without passing the
+    // overview — must not stand dimmed behind the other account's read.
+    setState((current) =>
+      current.status === "ready" && current.detail.account.id === id
+        ? current
+        : { status: "loading" },
+    );
+    setRefreshing(true);
+    void (async () => {
+      try {
+        const next = await readDetailState(
+          await fetch(`${USER_DETAIL_PATH}?${ADMIN_USER_ID_PARAM}=${encodeURIComponent(id)}`, {
+            headers: { accept: "application/json" },
+            signal: controller.signal,
+          }),
+        );
+        if (!controller.signal.aborted) setState(next);
+      } catch {
+        if (!controller.signal.aborted) {
+          setState({ status: "error", detail: ERROR_DETAIL.GENERIC });
+        }
+      } finally {
+        if (!controller.signal.aborted) setRefreshing(false);
+      }
+    })();
+  }, [id]);
+
+  useEffect(() => {
+    load();
+    return () => inFlight.current?.abort();
+  }, [load]);
+
+  switch (state.status) {
+    case "loading":
+      return <Centered title="Loading…">Reading the account's own rows.</Centered>;
+    case "signed-out":
+      return <SignInCard />;
+    case "forbidden":
+      return <ForbiddenCard email={account?.email} onSignOut={onSignOut} />;
+    case "missing":
+      return (
+        <Centered title="No such account">
+          No account carries this id — it may have been deleted since the overview was read.
+          <div className="mt-6">
+            <button type="button" className={PLAIN_BUTTON} onClick={onBack}>
+              Back to overview
+            </button>
+          </div>
+        </Centered>
+      );
+    case "error":
+      return (
+        <Centered title="Could not load">
+          {state.detail}
+          <div className="mt-6">
+            <button type="button" className={PLAIN_BUTTON} onClick={load} disabled={refreshing}>
+              {refreshing ? "Trying…" : "Try again"}
+            </button>
+          </div>
+        </Centered>
+      );
+    case "ready":
+      return (
+        <UserDetailPage
+          detail={state.detail}
+          account={account}
+          onSignOut={onSignOut}
+          onBack={onBack}
+          refreshing={refreshing}
+          onRefresh={load}
+          now={now}
+        />
+      );
+  }
 }
 
 /** A clock of its own, so the header's age stays true without refetching to learn it. */
@@ -831,6 +1305,23 @@ export function AdminDashboard(): React.JSX.Element {
   const now = useNow(AGE_TICK_MS);
   const session = authClient.useSession();
   const account = session.data?.user;
+
+  // The address bar owns which view is open, so an account page can be
+  // reloaded, shared, and left with the browser's own back button.
+  const [view, setView] = useState<AdminView>(viewFromLocation);
+  useEffect(() => {
+    const onPopState = () => setView(viewFromLocation());
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
+  const openAccount = useCallback((id: string) => {
+    window.history.pushState(null, "", accountHref(id));
+    setView({ kind: "account", id });
+  }, []);
+  const closeAccount = useCallback(() => {
+    window.history.pushState(null, "", window.location.pathname);
+    setView({ kind: "overview" });
+  }, []);
 
   const load = useCallback(() => {
     // A session earned elsewhere on the site does not open the dashboard by
@@ -875,9 +1366,13 @@ export function AdminDashboard(): React.JSX.Element {
   }, [hideAdmins]);
 
   useEffect(() => {
+    // The overview's read waits while an account page is open; coming back
+    // re-runs it, which refreshes the numbers while the last answer stands
+    // dimmed the way any refetch does.
+    if (view.kind !== "overview") return;
     load();
     return () => inFlight.current?.abort();
-  }, [load]);
+  }, [load, view.kind]);
 
   const signOut = async () => {
     // The header stays live through a refetch, so this press can land on an open
@@ -891,24 +1386,29 @@ export function AdminDashboard(): React.JSX.Element {
     setState({ status: "signed-out" });
   };
 
+  if (view.kind === "account") {
+    return (
+      <UserDetailScreen
+        id={view.id}
+        account={
+          account
+            ? { name: account.name, email: account.email, image: account.image ?? undefined }
+            : undefined
+        }
+        onSignOut={() => void signOut()}
+        onBack={closeAccount}
+        now={now}
+      />
+    );
+  }
+
   switch (state.status) {
     case "loading":
       return <Centered title="Loading…">Reading the service's own tables.</Centered>;
     case "signed-out":
       return <SignInCard />;
     case "forbidden":
-      return (
-        <Centered title="Not authorized">
-          You are signed in{account ? ` as ${account.email}` : ""}, but this account does not have
-          the admin role. Admin access is the <code className="font-mono">admin</code> role on your
-          account, set directly in the database.
-          <div className="mt-6">
-            <button type="button" className={PLAIN_BUTTON} onClick={() => void signOut()}>
-              Sign out
-            </button>
-          </div>
-        </Centered>
-      );
+      return <ForbiddenCard email={account?.email} onSignOut={() => void signOut()} />;
     case "error":
       return (
         <Centered title="Could not load">
@@ -934,6 +1434,7 @@ export function AdminDashboard(): React.JSX.Element {
           onSignOut={() => void signOut()}
           refreshing={refreshing}
           onRefresh={load}
+          onOpenAccount={openAccount}
           now={now}
         />
       );

--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -1181,7 +1181,7 @@ function UserDetailScreen({
 }: {
   id: string;
   account: ViewerAccount | undefined;
-  onSignOut: () => void;
+  onSignOut: () => Promise<void>;
   onBack: () => void;
   now: number;
 }): React.JSX.Element {
@@ -1190,6 +1190,18 @@ function UserDetailScreen({
   );
   const [refreshing, setRefreshing] = useState(false);
   const inFlight = useRef<AbortController>(null);
+
+  // The parent's sign-out resets the overview, but this screen renders in the
+  // overview's place and holds a ready answer of its own — left alone, the
+  // account's identity and usage would stand on screen after the consent
+  // behind them was withdrawn. So the withdrawal lands here too: the open
+  // read is dropped first, for the same reason the overview drops its own.
+  const signOut = async () => {
+    inFlight.current?.abort();
+    setRefreshing(false);
+    await onSignOut();
+    setState({ status: "signed-out" });
+  };
 
   const load = useCallback(() => {
     // The same local consent the overview asks for: a deep link into an
@@ -1241,7 +1253,7 @@ function UserDetailScreen({
     case "signed-out":
       return <SignInCard />;
     case "forbidden":
-      return <ForbiddenCard email={account?.email} onSignOut={onSignOut} />;
+      return <ForbiddenCard email={account?.email} onSignOut={() => void signOut()} />;
     case "missing":
       return (
         <Centered title="No such account">
@@ -1269,7 +1281,7 @@ function UserDetailScreen({
         <UserDetailPage
           detail={state.detail}
           account={account}
-          onSignOut={onSignOut}
+          onSignOut={() => void signOut()}
           onBack={onBack}
           refreshing={refreshing}
           onRefresh={load}
@@ -1395,7 +1407,7 @@ export function AdminDashboard(): React.JSX.Element {
             ? { name: account.name, email: account.email, image: account.image ?? undefined }
             : undefined
         }
-        onSignOut={() => void signOut()}
+        onSignOut={signOut}
         onBack={closeAccount}
         now={now}
       />

--- a/apps/web/tests/admin-metrics.test.ts
+++ b/apps/web/tests/admin-metrics.test.ts
@@ -166,6 +166,23 @@ test("a trend over an empty window is zero on both runs rather than absent", () 
   assert.equal(metrics.users.newInWindow, 0);
 });
 
+test("the most active accounts pass through the builder untouched", () => {
+  const topUsers = [
+    {
+      id: "user-9",
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+      activeDays: 12,
+      lastActiveDay: "2026-08-17",
+      voiceCalls: 3,
+      attentionReviews: 40,
+      total: 43,
+    },
+  ];
+  const metrics = buildAdminMetrics(source({ usage: { ...source().usage, topUsers } }), NOON_UTC);
+  assert.deepEqual(metrics.featureUsage.topUsers, topUsers);
+});
+
 test("the daily ceilings are reported from the hosted quota, not restated", () => {
   const metrics = buildAdminMetrics(source(), NOON_UTC);
   assert.equal(metrics.reliability.voiceDailyLimit, HOSTED_DAILY_LIMIT[HOSTED_METER.VOICE_CALL]);

--- a/apps/web/tests/admin-user.test.ts
+++ b/apps/web/tests/admin-user.test.ts
@@ -1,0 +1,267 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AdminViewer } from "../server/admin/admin-access";
+import {
+  ADMIN_METRICS_WINDOW_DAYS,
+  ADMIN_TREND_DAYS,
+  type AdminUsageDay,
+  lastNDayKeys,
+} from "../server/admin/admin-metrics";
+import {
+  type AdminUserDetail,
+  type AdminUserSource,
+  buildAdminUserDetail,
+  handleAdminUser,
+} from "../server/admin/admin-user";
+import { ADMIN_ERROR, ADMIN_USER_ID_PARAM, adminUserId } from "../server/admin/http";
+
+const NOON_UTC = Date.parse("2026-08-17T12:00:00.000Z");
+
+function userSource(usage: Partial<AdminUserSource["usage"]> = {}): AdminUserSource {
+  return {
+    account: {
+      id: "user-9",
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+      image: null,
+      admin: false,
+      createdAt: Date.parse("2026-06-01T08:00:00.000Z"),
+      signInMethods: ["github"],
+    },
+    usage: {
+      byDay: new Map(),
+      allTime: {
+        activeDays: 0,
+        firstActiveDay: null,
+        lastActiveDay: null,
+        voiceCalls: 0,
+        attentionReviews: 0,
+      },
+      quotaLimitedDaysWindow: 0,
+      ...usage,
+    },
+  };
+}
+
+function build(usage: Partial<AdminUserSource["usage"]> = {}): AdminUserDetail {
+  return buildAdminUserDetail(userSource(usage), NOON_UTC);
+}
+
+test("the daily series is zero-filled and the window counts fold from it", () => {
+  const detail = build({
+    byDay: new Map([
+      ["2026-08-17", { voiceCalls: 2, attentionReviews: 1 }],
+      ["2026-08-10", { voiceCalls: 5, attentionReviews: 0 }],
+      ["2026-07-19", { voiceCalls: 0, attentionReviews: 7 }],
+    ]),
+  });
+
+  assert.equal(detail.windowDays, ADMIN_METRICS_WINDOW_DAYS);
+  assert.equal(detail.activity.daily.length, ADMIN_METRICS_WINDOW_DAYS);
+  assert.equal(detail.activity.activeDaysWindow, 3);
+  assert.equal(detail.activity.voiceCallsWindow, 7);
+  assert.equal(detail.activity.attentionReviewsWindow, 8);
+  const emptyDay = detail.activity.daily.find((day) => day.day === "2026-08-01");
+  assert.deepEqual(emptyDay, { day: "2026-08-01", voiceCalls: 0, attentionReviews: 0 });
+});
+
+test("a streak ending today counts back to its first gap", () => {
+  const detail = build({
+    byDay: new Map([
+      ["2026-08-17", { voiceCalls: 1, attentionReviews: 0 }],
+      ["2026-08-16", { voiceCalls: 1, attentionReviews: 0 }],
+      ["2026-08-15", { voiceCalls: 0, attentionReviews: 3 }],
+      // 2026-08-14 is the gap; this day must not extend the streak.
+      ["2026-08-13", { voiceCalls: 9, attentionReviews: 9 }],
+    ]),
+  });
+  assert.equal(detail.activity.currentStreakDays, 3);
+});
+
+test("a quiet today does not break a streak that ran through yesterday", () => {
+  const detail = build({
+    byDay: new Map([
+      ["2026-08-16", { voiceCalls: 1, attentionReviews: 0 }],
+      ["2026-08-15", { voiceCalls: 1, attentionReviews: 0 }],
+    ]),
+  });
+  assert.equal(detail.activity.currentStreakDays, 2);
+});
+
+test("a streak broken before yesterday is over, whatever came earlier", () => {
+  const detail = build({
+    byDay: new Map([
+      ["2026-08-14", { voiceCalls: 1, attentionReviews: 0 }],
+      ["2026-08-13", { voiceCalls: 1, attentionReviews: 0 }],
+    ]),
+  });
+  assert.equal(detail.activity.currentStreakDays, 0);
+});
+
+test("a streak covering the whole window reports the window's length", () => {
+  const byDay = new Map<string, AdminUsageDay>(
+    lastNDayKeys(NOON_UTC, ADMIN_METRICS_WINDOW_DAYS).map((day) => [
+      day,
+      { voiceCalls: 1, attentionReviews: 0 },
+    ]),
+  );
+  const detail = build({ byDay });
+  assert.equal(detail.activity.currentStreakDays, ADMIN_METRICS_WINDOW_DAYS);
+  assert.equal(detail.activity.activeDaysWindow, ADMIN_METRICS_WINDOW_DAYS);
+});
+
+test("the active-days trend counts days present, not volume spent", () => {
+  const detail = build({
+    byDay: new Map([
+      // The recent run is 2026-08-11 through 2026-08-17; one loud day cannot
+      // outweigh two quiet ones the week before.
+      ["2026-08-16", { voiceCalls: 500, attentionReviews: 500 }],
+      ["2026-08-09", { voiceCalls: 1, attentionReviews: 0 }],
+      ["2026-08-07", { voiceCalls: 1, attentionReviews: 0 }],
+    ]),
+  });
+  assert.deepEqual(detail.activity.activeDaysTrend, {
+    days: ADMIN_TREND_DAYS,
+    recent: 1,
+    prior: 2,
+  });
+});
+
+test("the account and its all-time history pass through untouched", () => {
+  const allTime = {
+    activeDays: 41,
+    firstActiveDay: "2026-06-02",
+    lastActiveDay: "2026-08-17",
+    voiceCalls: 120,
+    attentionReviews: 900,
+  };
+  const detail = build({ allTime, quotaLimitedDaysWindow: 2 });
+  assert.equal(detail.generatedAt, NOON_UTC);
+  assert.deepEqual(detail.account, userSource().account);
+  assert.deepEqual(detail.activity.allTime, allTime);
+  assert.equal(detail.activity.quotaLimitedDaysWindow, 2);
+});
+
+test("an account id is read bounded from the query, or not at all", () => {
+  assert.equal(adminUserId("https://luke.test/api/admin/user?id=user-9"), "user-9");
+  assert.equal(adminUserId("https://luke.test/api/admin/user?id=%20user-9%20"), "user-9");
+  assert.equal(adminUserId("https://luke.test/api/admin/user"), undefined);
+  assert.equal(adminUserId("https://luke.test/api/admin/user?id="), undefined);
+  assert.equal(adminUserId(`https://luke.test/api/admin/user?id=${"x".repeat(129)}`), undefined);
+});
+
+function userRequest(id: string | null = "user-9", method = "GET"): Request {
+  const query = id === null ? "" : `?${ADMIN_USER_ID_PARAM}=${encodeURIComponent(id)}`;
+  return new Request(`https://luke.test/api/admin/user${query}`, { method });
+}
+
+const ADMIN_VIEWER: AdminViewer = { userId: "user-1", role: "admin" };
+
+const readUser = async (userId: string, now: number): Promise<AdminUserDetail | undefined> =>
+  userId === "user-9" ? buildAdminUserDetail(userSource(), now) : undefined;
+
+test("the gate answers 405, 401, 403, 400, 404, and 200 as distinct outcomes", async () => {
+  const wrongMethod = await handleAdminUser({
+    request: userRequest("user-9", "POST"),
+    resolveViewer: async () => ADMIN_VIEWER,
+    readUser,
+  });
+  assert.equal(wrongMethod.status, 405);
+
+  const anonymous = await handleAdminUser({
+    request: userRequest(),
+    resolveViewer: async () => undefined,
+    readUser,
+  });
+  assert.equal(anonymous.status, 401);
+  assert.equal((await anonymous.json()).error, ADMIN_ERROR.NOT_SIGNED_IN);
+
+  const forbidden = await handleAdminUser({
+    request: userRequest(),
+    resolveViewer: async () => ({ ...ADMIN_VIEWER, role: "user" }),
+    readUser,
+  });
+  assert.equal(forbidden.status, 403);
+  assert.equal((await forbidden.json()).error, ADMIN_ERROR.NOT_AUTHORIZED);
+
+  const unnamed = await handleAdminUser({
+    request: userRequest(null),
+    resolveViewer: async () => ADMIN_VIEWER,
+    readUser,
+  });
+  assert.equal(unnamed.status, 400);
+  assert.equal((await unnamed.json()).error, ADMIN_ERROR.MISSING_USER_ID);
+
+  const missing = await handleAdminUser({
+    request: userRequest("user-gone"),
+    resolveViewer: async () => ADMIN_VIEWER,
+    readUser,
+  });
+  assert.equal(missing.status, 404);
+  assert.equal((await missing.json()).error, ADMIN_ERROR.USER_NOT_FOUND);
+
+  const ok = await handleAdminUser({
+    request: userRequest(),
+    resolveViewer: async () => ADMIN_VIEWER,
+    readUser,
+    now: () => NOON_UTC,
+  });
+  assert.equal(ok.status, 200);
+  // SAFETY: handleAdminUser answered 200, whose body is an AdminUserDetail document.
+  const body = (await ok.json()) as AdminUserDetail;
+  assert.equal(body.generatedAt, NOON_UTC);
+  assert.equal(body.account.id, "user-9");
+});
+
+test("no account is read for a request that fails the gate or names none", async () => {
+  const reads: string[] = [];
+  const countingRead = async (userId: string, now: number) => {
+    reads.push(userId);
+    return readUser(userId, now);
+  };
+
+  const anonymous = await handleAdminUser({
+    request: userRequest(),
+    resolveViewer: async () => undefined,
+    readUser: countingRead,
+  });
+  assert.equal(anonymous.status, 401);
+
+  const unnamed = await handleAdminUser({
+    request: userRequest(null),
+    resolveViewer: async () => ADMIN_VIEWER,
+    readUser: countingRead,
+  });
+  assert.equal(unnamed.status, 400);
+  assert.deepEqual(reads, []);
+
+  const ok = await handleAdminUser({
+    request: userRequest(),
+    resolveViewer: async () => ADMIN_VIEWER,
+    readUser: countingRead,
+  });
+  assert.equal(ok.status, 200);
+  assert.deepEqual(reads, ["user-9"]);
+});
+
+test("a seam that throws is a 503 refusal rather than a crash", async () => {
+  const viewerThrew = await handleAdminUser({
+    request: userRequest(),
+    resolveViewer: async () => {
+      throw new Error("auth is down");
+    },
+    readUser,
+  });
+  assert.equal(viewerThrew.status, 503);
+  assert.equal((await viewerThrew.json()).error, ADMIN_ERROR.UNAVAILABLE);
+
+  const readThrew = await handleAdminUser({
+    request: userRequest(),
+    resolveViewer: async () => ADMIN_VIEWER,
+    readUser: async () => {
+      throw new Error("database is down");
+    },
+  });
+  assert.equal(readThrew.status, 503);
+  assert.equal((await readThrew.json()).error, ADMIN_ERROR.UNAVAILABLE);
+});


### PR DESCRIPTION
## What

The dashboard could say how much the hosted tier was used, but not *who* is
living in Luke daily: the one per-account table ranked by volume, where a
single heavy afternoon outranks thirty quiet days. This PR turns the question
around and gives every account a page of its own.

### The overview's table asks who shows up

**Heaviest hosted-tier accounts** is now **Most active hosted-tier accounts**:
ordered by active days — the days an account actually spent hosted voice or
attention — before volume, carrying each account's last active day beside the
existing volume columns, and widened from five rows to ten. An active day is
the one per-account daily signal the service's own tables hold
(`hosted_usage` has one row per account per UTC day), and the caption under
the table says so.

### A detail page behind every row

Each row opens `/admin?user=<id>` — a real address, so an account page can be
reloaded, shared, and left with the browser's back button; the row is
clickable and the account name is a real anchor, so a modified click still
gets the browser's own gesture. The page shows:

- **Identity** — avatar, name, email, an Admin badge where the role carries
  one, joined date, and linked sign-in providers.
- **Daily use** — active days in the window, the current streak (consecutive
  active days ending today or yesterday, reported as `30+` when it runs past
  the window rather than posing the truncation as exact), active days this
  week against last week, and last/first active days.
- The same stacked **per-day usage chart** the overview draws, scoped to the
  account, with its trailing-run trend.
- **Volume** — window and all-time voice/attention totals, all-time active
  days, and days a daily ceiling was reached.

### The endpoint underneath

`GET /api/admin/user?id=<id>` stands on the same gate as the metrics read —
405/401/403 kept distinct, 503 for a seam that throws — plus two refusals of
its own: 400 for a request that names no account and 404 for an id no user
row carries, so the page can word a gone account differently from a down
service. The session resolver both endpoints share moved to
`server/admin/viewer.ts`. The day arithmetic (zero-fill, streak, trends)
lives in a pure builder in `server/admin/admin-user.ts`, split from the
queries the way the overview's already is, so it is testable without a
database.

This reads only rows the service already stores for its own operation and
widens no analytics event; the one new thing named to the maintainer — an
account's daily presence — is read from the same `hosted_usage` table the
overview already aggregates.

## Evidence

`./scripts/check.sh` passes (lint, typecheck, 84 web tests including 12 new
ones for the detail builder, the streak arithmetic, and the endpoint gate,
and all builds). `./scripts/verify.sh` was not run: it captures the packaged
macOS Electron app, which this web-only change does not touch. No
physical-notch check applies.

Screenshots were captured against the built page with the session and both
admin endpoints stubbed by synthetic data; the harness is untracked and not
committed. They are saved in this workspace at
`.context/admin-usage-evidence/{overview,detail}.png` — attach through the PR
editor if wanted:

- **overview.png** — the reworked table: Active days ("27 of 30"), Last
  active, Voice, Attention, Total, ordered by days present.
- **detail.png** — Ada's page: identity block, a 7-day streak over a
  24-of-30 window, the per-account daily chart, and window-beside-all-time
  volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/4c837f05-95c9-4e8a-823c-7b381d2f2707)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32518556347/artifacts/9459755596) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32518556347)

- Commit: `64cf2b67efe76e62622269de2786c89eff07d799`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
