### PR TITLE
feat(oauth): close the successful connection tabs on their own after 5 seconds

### DIFF
--- a/packages/account/src/loopback.ts
+++ b/packages/account/src/loopback.ts
@@ -25,6 +25,7 @@ const LOOPBACK_ANSWER = {
       badge: "Signed in",
       title: "Signed in to Luke",
       body: "You can close this tab and return to Luke.",
+      closesItself: true,
     },
   },
   NOT_VERIFIED: {

--- a/packages/calendar/src/oauth.ts
+++ b/packages/calendar/src/oauth.ts
@@ -126,6 +126,7 @@ function signInPage(granted: boolean): string {
         badge: "Connected",
         title: "Connected to Google Calendar",
         body: "You can close this tab and return to Luke.",
+        closesItself: true,
       })
     : accountLoopbackPage({
         tone: LOOPBACK_PAGE_TONE.ATTENTION,

--- a/packages/oauth/src/loopback-page.test.ts
+++ b/packages/oauth/src/loopback-page.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { accountLoopbackPage, LOOPBACK_PAGE_TONE } from "./loopback-page.js";
+
+test("a success page asks the browser to close its tab after a pause", () => {
+  const page = accountLoopbackPage({
+    tone: LOOPBACK_PAGE_TONE.SETTLED,
+    badge: "Connected",
+    title: "Connected",
+    body: "You can close this tab.",
+    closesItself: true,
+  });
+  assert.match(
+    page,
+    /<script>setTimeout\(function \(\) \{ window\.close\(\); \}, 5000\);<\/script>/,
+  );
+});
+
+test("a page not marked to close itself carries no script at all", () => {
+  const page = accountLoopbackPage({
+    tone: LOOPBACK_PAGE_TONE.ATTENTION,
+    badge: "Not completed",
+    title: "Sign-in was not completed",
+    body: "Return and try again.",
+  });
+  assert.doesNotMatch(page, /<script/);
+});

--- a/packages/oauth/src/loopback-page.ts
+++ b/packages/oauth/src/loopback-page.ts
@@ -27,7 +27,23 @@ export interface LoopbackPage {
   badge: string;
   title: string;
   body: string;
+  /**
+   * A success page the user needs nothing more from asks the browser to close
+   * its own tab once the outcome has had time to be read. Best-effort by
+   * design: a browser may refuse to close a tab the user navigated, so the
+   * body keeps saying the tab can be closed by hand.
+   */
+  closesItself?: boolean;
 }
+
+/** Long enough to read the outcome; short enough to not overstay it. */
+const CLOSE_DELAY_MS = 5_000;
+
+/**
+ * Inline and fixed by the build like everything else on the page — the
+ * self-contained rule above forbids fetching a script, not carrying one.
+ */
+const CLOSE_SCRIPT = `<script>setTimeout(function () { window.close(); }, ${CLOSE_DELAY_MS});</script>`;
 
 /**
  * The face, drawn from the same generated constants the renderer draws it
@@ -98,6 +114,6 @@ export function accountLoopbackPage(page: LoopbackPage): string {
     markSvg() +
     `<div><span class="pill" data-tone="${page.tone}">${page.badge}</span></div>` +
     `<h1>${page.title}</h1><p>${page.body}</p>` +
-    `</section></main></body></html>`
+    `</section></main>${page.closesItself ? CLOSE_SCRIPT : ""}</body></html>`
   );
 }

--- a/packages/trackers/src/linear/oauth.ts
+++ b/packages/trackers/src/linear/oauth.ts
@@ -113,6 +113,7 @@ function signInPage(granted: boolean): string {
         badge: "Connected",
         title: "Connected to Linear",
         body: "You can close this tab and return to Luke.",
+        closesItself: true,
       })
     : accountLoopbackPage({
         tone: LOOPBACK_PAGE_TONE.ATTENTION,


### PR DESCRIPTION
## What

The loopback landing page a finished OAuth flow leaves the browser on now asks the browser to close its own tab five seconds after a success:

- **Signed in to Luke** (account sign-in)
- **Connected to Google Calendar**
- **Connected to Linear**

The attention pages (not completed, not verified) stay put so the user can read what went wrong, and the "Already used" page keeps standing too since it isn't a fresh success.

## How

`LoopbackPage` grows an optional `closesItself` flag; when set, `accountLoopbackPage` appends one inline `<script>` fixed by the build that calls `window.close()` after 5 seconds. The page stays fully self-contained — the script is carried inside the document, fetched from nowhere, and interpolates nothing the redirect carried.

The close is best-effort by design: a browser may refuse to close a tab whose history the user navigated, so the body keeps offering the by-hand close.

## Validation

- `./scripts/check.sh` passes (lint, typecheck, tests, build). One unrelated flake in `apps/desktop/src/main/native/talk-key.test.ts` on the first run under full-suite load; it passes in isolation on both the clean tree and this branch, and the full suite passed on rerun.
- New unit test covers the script appearing only on pages marked to close themselves.
- No macOS UI change: these are browser-served loopback pages, not the Electron surface, so no visual evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/633856a1-9214-4e33-9085-8f0de7c1914f)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32516030847/artifacts/9458879092) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32516030847)

- Commit: `b86a16701333b2ee06bd3124e80f2a27950fe228`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
