### PR TITLE
feat(oauth): count down on the connection pages that close themselves

### DIFF
--- a/packages/oauth/src/loopback-page.test.ts
+++ b/packages/oauth/src/loopback-page.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { accountLoopbackPage, LOOPBACK_PAGE_TONE } from "./loopback-page.js";
 
-test("a success page asks the browser to close its tab after a pause", () => {
+test("a success page says it will close itself and asks the browser to", () => {
   const page = accountLoopbackPage({
     tone: LOOPBACK_PAGE_TONE.SETTLED,
     badge: "Connected",
@@ -10,13 +10,12 @@ test("a success page asks the browser to close its tab after a pause", () => {
     body: "You can close this tab.",
     closesItself: true,
   });
-  assert.match(
-    page,
-    /<script>setTimeout\(function \(\) \{ window\.close\(\); \}, 5000\);<\/script>/,
-  );
+  assert.match(page, /<p class="close-note" id="close-note"><\/p>/);
+  assert.match(page, /This tab will close itself in/);
+  assert.match(page, /window\.close\(\)/);
 });
 
-test("a page not marked to close itself carries no script at all", () => {
+test("a page not marked to close itself carries no script and no note", () => {
   const page = accountLoopbackPage({
     tone: LOOPBACK_PAGE_TONE.ATTENTION,
     badge: "Not completed",
@@ -24,4 +23,5 @@ test("a page not marked to close itself carries no script at all", () => {
     body: "Return and try again.",
   });
   assert.doesNotMatch(page, /<script/);
+  assert.doesNotMatch(page, /id="close-note"/);
 });

--- a/packages/oauth/src/loopback-page.ts
+++ b/packages/oauth/src/loopback-page.ts
@@ -29,21 +29,42 @@ export interface LoopbackPage {
   body: string;
   /**
    * A success page the user needs nothing more from asks the browser to close
-   * its own tab once the outcome has had time to be read. Best-effort by
-   * design: a browser may refuse to close a tab the user navigated, so the
-   * body keeps saying the tab can be closed by hand.
+   * its own tab once the outcome has had time to be read, saying so on the
+   * page while it counts down. Best-effort by design: a browser may refuse to
+   * close a tab the user navigated, so the countdown note removes itself on a
+   * refusal and the body keeps saying the tab can be closed by hand.
    */
   closesItself?: boolean;
 }
 
 /** Long enough to read the outcome; short enough to not overstay it. */
-const CLOSE_DELAY_MS = 5_000;
+const CLOSE_DELAY_SECONDS = 5;
 
 /**
  * Inline and fixed by the build like everything else on the page — the
- * self-contained rule above forbids fetching a script, not carrying one.
+ * self-contained rule above forbids fetching a script, not carrying one. The
+ * script owns the countdown note's words outright: with scripting off nothing
+ * would close, so nothing says it will, and a browser that refuses the close
+ * is answered by taking the note away rather than leaving a promise standing.
  */
-const CLOSE_SCRIPT = `<script>setTimeout(function () { window.close(); }, ${CLOSE_DELAY_MS});</script>`;
+const CLOSE_SCRIPT =
+  `<script>(function () {` +
+  `var left = ${CLOSE_DELAY_SECONDS};` +
+  `var note = document.getElementById("close-note");` +
+  `var say = function () {` +
+  ` note.textContent = "This tab will close itself in " + left + (left === 1 ? " second." : " seconds.");` +
+  `};` +
+  `say();` +
+  `var timer = setInterval(function () {` +
+  ` left -= 1;` +
+  ` if (left > 0) { say(); return; }` +
+  ` clearInterval(timer);` +
+  ` window.close();` +
+  ` setTimeout(function () { note.remove(); }, 400);` +
+  `}, 1000);` +
+  `})();</script>`;
+
+const CLOSE_NOTE = `<p class="close-note" id="close-note"></p>`;
 
 /**
  * The face, drawn from the same generated constants the renderer draws it
@@ -97,6 +118,12 @@ const PAGE_STYLE = `
   .pill[data-tone="attention"] { background: rgba(255, 160, 73, 0.14); color: #ffa049; }
   h1 { margin: 12px 0 8px; font-size: 1.375rem; line-height: 1.2; }
   p { margin: 0; color: rgba(255, 255, 255, 0.56); font-size: 0.9375rem; line-height: 1.6; }
+  .close-note {
+    margin-top: 18px;
+    font-size: 0.8125rem;
+    color: rgba(255, 255, 255, 0.38);
+    font-variant-numeric: tabular-nums;
+  }
 `;
 
 export function accountLoopbackPage(page: LoopbackPage): string {
@@ -114,6 +141,7 @@ export function accountLoopbackPage(page: LoopbackPage): string {
     markSvg() +
     `<div><span class="pill" data-tone="${page.tone}">${page.badge}</span></div>` +
     `<h1>${page.title}</h1><p>${page.body}</p>` +
+    (page.closesItself ? CLOSE_NOTE : "") +
     `</section></main>${page.closesItself ? CLOSE_SCRIPT : ""}</body></html>`
   );
 }


### PR DESCRIPTION
## What

Follow-up to #413, which made the successful connection pages close their own tab after 5 seconds but said nothing about it on the page. Each self-closing success landing (Signed in to Luke, Connected to Google Calendar, Connected to Linear) now carries a muted line under the body — **“This tab will close itself in 5 seconds.”** — counting down each second in tabular numerals.

## Honesty at the edges

- The inline script owns the note's words outright: with scripting disabled nothing would close, so nothing claims it will.
- A browser that refuses `window.close()` (a tab whose history the user navigated) gets the note removed 400ms after the attempt, leaving the body's “You can close this tab and return to Luke.” as the one offer standing.
- Every string stays fixed by the build; the page remains fully self-contained and interpolates nothing the redirect carried.

## Validation

- `./scripts/check.sh` passes (lint, typecheck, tests, build).
- Exercised the rendered page in headless Chrome with virtual time: the note reads “in 5 seconds” at load, “in 3 seconds” at 2.5s, and the element is gone after a refused close at 6s.
- Unit tests cover the note and script appearing only on pages marked to close themselves.
- Browser-served loopback page, not the Electron surface, so no app visual evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/633856a1-9214-4e33-9085-8f0de7c1914f)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32518402671/artifacts/9459699157) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32518402671)

- Commit: `3cbe807e55a31ec2ad6a67c40f66e58518a47202`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
