### PR TITLE
feat(panel): keep the session search standing like the filter chips

### DIFF
--- a/apps/desktop/src/main/settings-store.test.ts
+++ b/apps/desktop/src/main/settings-store.test.ts
@@ -486,6 +486,67 @@ test("a corrupt session filter value reads as unset rather than narrowing the li
   assert.equal((await storeIn(directory).snapshot()).sessionFilters, undefined);
 });
 
+test("the session search query starts unset and survives a reopen as typed", async (t) => {
+  const directory = await temporaryDirectory(t);
+  // A view preference is not a credential, so storing it must reach the
+  // Keychain not at all.
+  const cipher = countingCipher();
+  const store = storeIn(directory, { cipher });
+
+  assert.equal((await store.snapshot()).sessionSearchQuery, undefined);
+  const held = await store.set(APP_SETTING_SCHEMA.sessionSearchQuery.field, "Fix CI  on main");
+
+  assert.equal(held.settings.sessionSearchQuery, "Fix CI  on main");
+  assert.equal((await storeIn(directory).snapshot()).sessionSearchQuery, "Fix CI  on main");
+  assert.equal(cipher.calls.isAvailable, 0);
+  assert.equal(cipher.calls.encrypt, 0);
+});
+
+test("clearing the session search query reads as unset after a reopen", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+  await store.set(APP_SETTING_SCHEMA.sessionSearchQuery.field, "conductor");
+
+  const cleared = await store.set(APP_SETTING_SCHEMA.sessionSearchQuery.field, undefined);
+
+  assert.equal(cleared.settings.sessionSearchQuery, undefined);
+  assert.equal((await storeIn(directory).snapshot()).sessionSearchQuery, undefined);
+});
+
+test("storing the session search query never disturbs a stored key", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const store = storeIn(directory);
+  await store.setApiKey(CONDUCTOR, TEST_API_KEY);
+
+  await store.set(APP_SETTING_SCHEMA.sessionSearchQuery.field, "review");
+
+  assert.equal(await storeIn(directory).readApiKey(CONDUCTOR), TEST_API_KEY);
+});
+
+// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+test("a stored query of nothing but whitespace reads as unset rather than narrowing", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({ version: 2, apiKeys: {}, sessionSearchQuery: "   " }),
+    "utf8",
+  );
+
+  assert.equal((await storeIn(directory).snapshot()).sessionSearchQuery, undefined);
+});
+
+// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+test("a corrupt session search query reads as unset rather than refilling the field", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({ version: 2, apiKeys: {}, sessionSearchQuery: 7 }),
+    "utf8",
+  );
+
+  assert.equal((await storeIn(directory).snapshot()).sessionSearchQuery, undefined);
+});
+
 test("a calendar account stores its grant encrypted and survives a reopen", async (t) => {
   const directory = await temporaryDirectory(t);
   const store = storeIn(directory);

--- a/apps/desktop/src/main/settings-store.ts
+++ b/apps/desktop/src/main/settings-store.ts
@@ -632,6 +632,9 @@ export class SettingsStore {
       shareUsageData: persisted.shareUsageData,
       formFactor: persisted.formFactor ?? DEFAULT_PANEL_FORM_FACTOR,
       ...(persisted.sessionFilters ? { sessionFilters: persisted.sessionFilters } : undefined),
+      ...(persisted.sessionSearchQuery
+        ? { sessionSearchQuery: persisted.sessionSearchQuery }
+        : undefined),
       ...(persisted.defaultWorkspaceProvider
         ? { defaultWorkspaceProvider: persisted.defaultWorkspaceProvider }
         : undefined),

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -200,6 +200,14 @@ import {
 const FEEDBACK_NOTICE_MS = 6_000;
 
 /**
+ * How long a changed search query waits before it is stored. The query moves
+ * at typing speed and the store is a file write per change, so only where the
+ * words settle is worth writing — long enough to sit out a burst of
+ * keystrokes, short enough that quitting mid-thought still keeps the search.
+ */
+const SEARCH_QUERY_STORE_DELAY_MS = 400;
+
+/**
  * The bridge acts behind each consent service's wait: the documented connect
  * the slot's send runs, the main-process side a mid-wait cancel must stop,
  * and — for the browser flows alone — the way a lost tab reopens. One row
@@ -686,15 +694,15 @@ export function App(): React.JSX.Element {
       setSettingsSearchOpen(false);
     },
     onCapsuleList: () => {
-      // A search is a question about the list as it was, so it closes with
-      // the panel — a remembered query could hide the very session the
-      // capsule is reporting — and the order goes back with it, so the top
-      // row keeps matching the mark the capsule kept. The filter chips stay:
-      // a chosen narrowing is a standing way of viewing the list, and the
-      // capsule stays honest over it because its tally is taken before the
-      // list is narrowed.
-      setSessionView((current) => ({ ...DEFAULT_SESSION_VIEW, filters: current.filters }));
-      setSearchOpen(false);
+      // The order goes back when the panel does, so the top row keeps
+      // matching the mark the capsule kept. The filter chips and the search
+      // stay: each is a standing way of viewing the list, and the capsule
+      // stays honest over both because its tally is taken before the list is
+      // narrowed. The search field stays open with its query — a session the
+      // query hides is admitted by the field on screen and the count it
+      // carries — waiting where the developer left it, like a search held
+      // while Settings shows.
+      setSessionView((current) => ({ ...current, sort: DEFAULT_SESSION_VIEW.sort }));
     },
     onCapsuleTab: () => changeTab(PANEL_TAB.SESSIONS),
   });
@@ -839,6 +847,34 @@ export function App(): React.JSX.Element {
       )
       .then(applySettingsReply);
   }, [bootstrap, sessionView.filters, applySettingsReply]);
+
+  /**
+   * The search query as last stored, on the filter selection's own terms:
+   * seeded from bootstrap's snapshot so restoring the stored words must not
+   * read as fresh typing to store again.
+   */
+  const storedSessionQuery = useRef<string | undefined>(undefined);
+  // The query funnels through the view the way the selection does — typing,
+  // a spoken ask, Escape clearing the field — so the store follows the view
+  // from one place, never in a fixture or capture run. Unlike a chip press
+  // the query changes at typing speed, so the write waits out the keystrokes
+  // and stores only where the words settled.
+  useEffect(() => {
+    if (!bootstrap || bootstrap.fixtureMode) return;
+    storedSessionQuery.current ??= bootstrap.settings.sessionSearchQuery ?? "";
+    const query = sessionView.query;
+    if (storedSessionQuery.current === query) return;
+    const settled = window.setTimeout(() => {
+      storedSessionQuery.current = query;
+      void window.sidecar
+        .updateSetting(
+          APP_SETTING_SCHEMA.sessionSearchQuery.field,
+          query !== "" ? query : undefined,
+        )
+        .then(applySettingsReply);
+    }, SEARCH_QUERY_STORE_DELAY_MS);
+    return () => window.clearTimeout(settled);
+  }, [bootstrap, sessionView.query, applySettingsReply]);
 
   const changeVoiceCaptions = useCallback(
     async (enabled: boolean) =>
@@ -2539,14 +2575,23 @@ export function App(): React.JSX.Element {
       acceptCalendarsBootstrap(value.calendars);
       acceptMeetingQuietBootstrap(value.meetingQuiet);
       acceptSettingsBootstrap(value.settings);
-      // The stored filter chips come back with the panel: a chosen narrowing
-      // is a standing way of viewing the list, and this is the one moment it
-      // is read from the store — from here on the view leads and the store
-      // follows. Never in a fixture or capture run, whose evidence must not
-      // vary with what a developer last chose.
+      // The stored filter chips and search words come back with the panel:
+      // each is a standing way of viewing the list, and this is the one
+      // moment they are read from the store — from here on the view leads and
+      // the store follows. Never in a fixture or capture run, whose evidence
+      // must not vary with what a developer last chose.
       const storedFilters = value.settings.sessionFilters;
-      if (!value.fixtureMode && storedFilters !== undefined) {
-        setSessionView((current) => ({ ...current, filters: storedFilters }));
+      const storedQuery = value.settings.sessionSearchQuery;
+      if (!value.fixtureMode && (storedFilters !== undefined || storedQuery !== undefined)) {
+        setSessionView((current) => ({
+          ...current,
+          ...(storedFilters !== undefined ? { filters: storedFilters } : undefined),
+          ...(storedQuery !== undefined ? { query: storedQuery } : undefined),
+        }));
+        // A restored query opens the field it refills, on the rule the
+        // field's own closing keeps: a narrowing in force behind no visible
+        // control would hide sessions with nothing on screen admitting it.
+        if (storedQuery !== undefined) setSearchOpen(true);
       }
       acceptAccountBootstrap(value.account);
       acceptUpdateBootstrap(value.update);
@@ -3055,11 +3100,14 @@ export function App(): React.JSX.Element {
   // to find that is not already on screen. Its being open goes when its button
   // does — and the query goes with it, by the same rule the emptied filter
   // follows, because a narrowing left in force behind no visible control would
-  // hide sessions with nothing admitting it. The tab is not part of this gate:
-  // a search held while Settings shows is still the sessions tab's own state,
-  // waiting where the developer left it.
+  // hide sessions with nothing admitting it. Only a roster actually read may
+  // decide that, on the emptied filter's own gate: an unread roster says
+  // nothing about how many sessions there are, and a search restored at
+  // launch must not be let go on its silence. The tab is not part of this
+  // gate: a search held while Settings shows is still the sessions tab's own
+  // state, waiting where the developer left it.
   const offerSearch = tab === PANEL_TAB.SESSIONS && list.total > 1;
-  if (searchOpen && list.total <= 1) {
+  if (searchOpen && sessionsSettled && list.total <= 1) {
     setSearchOpen(false);
     if (sessionView.query !== "") setSessionView({ ...sessionView, query: "" });
   }

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -857,14 +857,17 @@ export function App(): React.JSX.Element {
   // The query funnels through the view the way the selection does — typing,
   // a spoken ask, Escape clearing the field — so the store follows the view
   // from one place, never in a fixture or capture run. Unlike a chip press
-  // the query changes at typing speed, so the write waits out the keystrokes
-  // and stores only where the words settled.
+  // the query changes at typing speed, so a write waits out the keystrokes
+  // and stores only where the words settled — except letting go, which writes
+  // at once: a clear is a discrete act rather than a keystroke on the way
+  // somewhere, and a quit inside a waited write would bring back a search the
+  // developer deliberately let go.
   useEffect(() => {
     if (!bootstrap || bootstrap.fixtureMode) return;
     storedSessionQuery.current ??= bootstrap.settings.sessionSearchQuery ?? "";
     const query = sessionView.query;
     if (storedSessionQuery.current === query) return;
-    const settled = window.setTimeout(() => {
+    const store = () => {
       storedSessionQuery.current = query;
       void window.sidecar
         .updateSetting(
@@ -872,7 +875,12 @@ export function App(): React.JSX.Element {
           query !== "" ? query : undefined,
         )
         .then(applySettingsReply);
-    }, SEARCH_QUERY_STORE_DELAY_MS);
+    };
+    if (query === "") {
+      store();
+      return;
+    }
+    const settled = window.setTimeout(store, SEARCH_QUERY_STORE_DELAY_MS);
     return () => window.clearTimeout(settled);
   }, [bootstrap, sessionView.query, applySettingsReply]);
 

--- a/apps/desktop/src/renderer/luke-guide.test.ts
+++ b/apps/desktop/src/renderer/luke-guide.test.ts
@@ -794,7 +794,12 @@ test("the guide describes the search, its three ways in, and their shared bound"
     fact.detail,
     /title, status word or status line, branch, repository, workspace, agent, associated app, or model/,
   );
-  assert.match(fact.detail, /no search survives the panel closing/);
+  // A held search now outlives the panel, and the guide must say so with its
+  // bound — clearing or closing the field is the one way a search is let go —
+  // or Luke will promise words he forgot, or forget words he promised to keep.
+  assert.match(fact.detail, /clearing or closing is what lets a search go/);
+  assert.match(fact.detail, /survives the panel closing and the app restarting/);
+  assert.match(fact.detail, /comes back with its field open/);
 });
 
 test("the feedback fact says what a spoken open may do, and that sending stays by hand", () => {

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -429,8 +429,10 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "beside a list of more than one session. It keeps rows saying every typed word in " +
         "their title, status word or status line, branch, repository, workspace, agent, associated app, or model, and counts " +
         "what it left. A search matching nothing offers the matches a filter is hiding rather " +
-        "than pretending there are none. Escape clears the query and then closes the field; " +
-        "no search survives the panel closing. Command-F answers " +
+        "than pretending there are none. Escape clears the query and then closes the field, " +
+        "and clearing or closing is what lets a search go; a search left standing is a way of " +
+        "viewing the list like the filter chips, so it survives the panel closing and the app " +
+        "restarting and comes back with its field open. Command-F answers " +
         "for whichever tab is showing: the sessions list here, the settings search on Settings.",
     },
     {

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -193,14 +193,15 @@ export interface SessionView {
 }
 
 /**
- * What the panel opens on before any stored view arrives. The filters are the
- * one part of the view that outlives a closing: a chosen narrowing is a
- * standing way of viewing the list, restored from the stored settings at
- * launch and kept across capsule closings — and the capsule stays honest over
- * it because its tally is taken before the list is narrowed. The order is not
- * remembered, so the top row keeps matching the mark the capsule kept, and a
- * search is forgotten on the same terms — it is a question about the list as
- * it was, not a standing way of viewing it.
+ * What the panel opens on before any stored view arrives. The filters and the
+ * search are the parts of the view that outlive a closing: each is a standing
+ * way of viewing the list, restored from the stored settings at launch and
+ * kept across capsule closings — and the capsule stays honest over both
+ * because its tally is taken before the list is narrowed. A restored search
+ * brings its field back open, so the narrowing is never in force behind no
+ * visible control, and clearing or closing the field is what lets it go. The
+ * order alone is not remembered, so the top row keeps matching the mark the
+ * capsule kept.
  */
 export const DEFAULT_SESSION_VIEW: SessionView = {
   filters: [],

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -383,12 +383,20 @@ export interface AppSettings {
   /**
    * The session list's chosen filter chips, absent while nothing narrows it.
    * A chosen narrowing is a standing way of viewing the list, so it survives
-   * the panel closing and the app restarting; the search query and the order
-   * deliberately do not travel with it. Fixture and capture runs leave it
-   * unread, because their evidence must not vary with what a developer last
-   * chose.
+   * the panel closing and the app restarting; the order deliberately does not
+   * travel with it. Fixture and capture runs leave it unread, because their
+   * evidence must not vary with what a developer last chose.
    */
   sessionFilters?: readonly SessionFilter[];
+  /**
+   * The session list's held search words, absent while nothing is searched.
+   * A held search stands with the chips as a way of viewing the list, so it
+   * survives on the same terms and comes back with its field open — a
+   * narrowing must never be in force behind no visible control. Clearing or
+   * closing the field is what lets the words go. Fixture and capture runs
+   * leave it unread, like the chips.
+   */
+  sessionSearchQuery?: string;
   /**
    * The provider a conversational ask creates a new workspace in when the ask
    * names none, absent until one has been chosen. It starts unset on purpose:

--- a/packages/settings/src/schema.ts
+++ b/packages/settings/src/schema.ts
@@ -113,6 +113,8 @@ export interface StoredAppSettings {
   formFactor?: PanelFormFactor;
   /** The session list's chosen filter chips, absent while nothing narrows it. */
   sessionFilters?: readonly SessionFilter[];
+  /** The session list's held search words, absent while nothing is searched. */
+  sessionSearchQuery?: string;
   defaultWorkspaceProvider?: WorkspaceProviderId;
   workspaceAgentDefaults?: Readonly<Partial<Record<ProviderId, WorkspaceAgentSelection>>>;
   workspaceProjectDefaults?: Readonly<Partial<Record<WorkspaceProviderId, string>>>;
@@ -318,6 +320,26 @@ function sessionFilters(
     filters.push(candidate);
   }
   return valid(filters.length > 0 ? filters : undefined);
+}
+
+const MAXIMUM_SESSION_SEARCH_QUERY_LENGTH = 500;
+
+/**
+ * The stored words come back exactly as typed, because the field they refill
+ * is the developer's own text. Only a value that could not be a held search
+ * reads as unset instead: words that are all whitespace narrow nothing, and a
+ * value past any typeable length is a corrupted file rather than a question
+ * someone is still asking.
+ */
+function sessionSearchQuery(
+  value: UnparsedWireValue,
+): SettingGuardResult<StoredAppSettings["sessionSearchQuery"]> {
+  if (value === undefined) return valid(undefined);
+  if (!isWireString(value)) return invalid(undefined);
+  if (value.trim() === "" || value.length > MAXIMUM_SESSION_SEARCH_QUERY_LENGTH) {
+    return valid(undefined);
+  }
+  return valid(value);
 }
 
 const MAXIMUM_WORKSPACE_PROJECT_ID_LENGTH = 500;
@@ -667,6 +689,22 @@ export const APP_SETTING_SCHEMA = {
     // the spoken filter tool's own vocabulary; the stored selection is what
     // those already changed, not a setting of its own to describe.
     guideEntry: settingGuideEntry("sessionFilters", [], () => undefined),
+    mainProcessSideEffect: SETTING_SIDE_EFFECT.NONE,
+  },
+  sessionSearchQuery: {
+    field: "sessionSearchQuery",
+    default: undefined,
+    guard: sessionSearchQuery,
+    // The query backs no settings row, on the filter selection's own terms: it
+    // is the session list's view state, stored so a held search survives the
+    // panel closing and the app restarting. With no guide ids the page below
+    // is inert; the root page is named only because a definition must name one.
+    settingsPage: SETTINGS_PAGE.ROOT,
+    // The guide covers searching through the session-search facts and the
+    // spoken search tool's own vocabulary; the stored words are what those
+    // already typed, not a setting of their own to describe. No analytics
+    // either: the value is the developer's own text, which never travels.
+    guideEntry: settingGuideEntry("sessionSearchQuery", [], () => undefined),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.NONE,
   },
   defaultWorkspaceProvider: {

--- a/packages/settings/src/session-search-query.test.ts
+++ b/packages/settings/src/session-search-query.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { APP_SETTING_SCHEMA } from "./schema.js";
+
+const guard = APP_SETTING_SCHEMA.sessionSearchQuery.guard;
+
+test("an absent query is valid and reads as nothing searched", () => {
+  assert.deepEqual(guard(undefined), { valid: true, value: undefined });
+});
+
+test("held words come back exactly as typed", () => {
+  assert.deepEqual(guard("Fix CI  on main"), { valid: true, value: "Fix CI  on main" });
+  assert.deepEqual(guard(" trailing space "), { valid: true, value: " trailing space " });
+});
+
+test("words that are all whitespace read as unset, because they narrow nothing", () => {
+  assert.deepEqual(guard(""), { valid: true, value: undefined });
+  assert.deepEqual(guard("   \t"), { valid: true, value: undefined });
+});
+
+test("a value past any typeable length reads as unset rather than refilled", () => {
+  assert.deepEqual(guard("q".repeat(501)), { valid: true, value: undefined });
+  assert.deepEqual(guard("q".repeat(500)), { valid: true, value: "q".repeat(500) });
+});
+
+test("a query that is not text is invalid rather than guessed at", () => {
+  assert.deepEqual(guard(7), { valid: false, value: undefined });
+  assert.deepEqual(guard(["build"]), { valid: false, value: undefined });
+  assert.deepEqual(guard({ query: "build" }), { valid: false, value: undefined });
+});


### PR DESCRIPTION
## Summary

- The session list's search query now persists the way the chosen filter chips already did, instead of being forgotten on every panel closing. It is stored as a new `sessionSearchQuery` app setting beside `sessionFilters`, restored once at bootstrap, and a restored query brings its field back open so a narrowing is never in force behind no visible control.
- Navigation keeps it too: the capsule-list recede now resets only the sort (the top row keeps matching the capsule's mark) while the filters, the query, and the open field stay where the developer left them. Clearing or closing the field remains the one act that lets a search go, and the store follows the view, so an explicit clear also clears the store.
- The store write funnels through the view like the filter write, guarded out of fixture and capture runs, and debounced (400 ms) because the query changes at typing speed and each write is a settings-file write.
- The schema guard keeps the words exactly as typed; only whitespace-only values (which narrow nothing) and values past 500 characters (a corrupted file, not a question) read as unset. The setting backs no settings row, carries no guide id, no reset scope, and no analytics — the value is the developer's own text, which never travels.
- The render-time auto-close beside a one-session list now waits for the roster to actually settle (`sessionsSettled`), so an unread roster at launch cannot erase a restored search on its silence.
- Luke's guide facts and their tests now describe the new behavior ("Searching sessions"); the settings search is deliberately unchanged — it is a jump-to-row finder, not a standing view of a list, and still closes with the panel as its fact says.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (exit 0; all workspace tests green, including the new guard and store suites)
- macOS Electron verification (`./scripts/verify.sh`): `not run locally (Linux cloud workspace) — covered by the macOS CI job`

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32521277517/artifacts/9460692563) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32521277517)

- Commit: `e56c9fc9761d32dbe6c7e600c531f06ee04e2d7a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed (no visual/layout change — behavior and storage only)`
- Device/display configuration: `not recorded`

## Notes

- New tests: `packages/settings/src/session-search-query.test.ts` (guard behavior) and five store round-trip cases in `apps/desktop/src/main/settings-store.test.ts` mirroring the session-filter suite, including the no-Keychain assertion.
- Blockers or follow-up verification: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/014f8802-56a8-4c75-8c35-ffa651eaa6f7)
