### PR TITLE
feat(admin): add a last-seen column to the Users roster

### DIFF
--- a/apps/web/server/admin/admin-queries.ts
+++ b/apps/web/server/admin/admin-queries.ts
@@ -1,4 +1,18 @@
-import { and, count, desc, eq, gt, gte, isNull, ne, or, type SQL, sql, sum } from "drizzle-orm";
+import {
+  and,
+  count,
+  desc,
+  eq,
+  gt,
+  gte,
+  isNull,
+  max,
+  ne,
+  or,
+  type SQL,
+  sql,
+  sum,
+} from "drizzle-orm";
 import type { createDatabase } from "../db/index.js";
 import { account, session, user } from "../db/schema.js";
 import { hostedUsage } from "../db/usage-schema.js";
@@ -384,7 +398,9 @@ export async function readAdminUserSource(
  * — with zero active days and no last-active day — instead of vanishing the
  * way it does from every inner-joined aggregate above. Most recently active
  * first, the never-active tail ordered by youngest account, and the roster
- * cut at the stated bound while `total` still counts everyone.
+ * cut at the stated bound while `total` still counts everyone. Last-seen
+ * instants ride a query of their own: a second one-to-many join would fan
+ * the usage aggregates out across each account's session rows.
  */
 export async function readAdminUsersSource(
   database: Database,
@@ -393,8 +409,14 @@ export async function readAdminUsersSource(
   const dayKeys = lastNDayKeys(input.now, ADMIN_METRICS_WINDOW_DAYS);
   const windowStartDay = dayKeys[0] ?? utcDayKey(input.now);
 
-  const [[totalRow], rows] = await Promise.all([
+  const [[totalRow], lastSeenRows, rows] = await Promise.all([
     database.select({ value: count() }).from(user).where(scopeCondition(input.scope)),
+    database
+      .select({ userId: session.userId, lastSeenAt: max(session.updatedAt) })
+      .from(session)
+      .innerJoin(user, eq(session.userId, user.id))
+      .where(scopeCondition(input.scope))
+      .groupBy(session.userId),
     database
       .select({
         id: user.id,
@@ -418,6 +440,11 @@ export async function readAdminUsersSource(
       .limit(ADMIN_USERS_LIMIT),
   ]);
 
+  const lastSeenByUser = new Map<string, Date>();
+  for (const seen of lastSeenRows) {
+    if (seen.lastSeenAt) lastSeenByUser.set(seen.userId, seen.lastSeenAt);
+  }
+
   return {
     total: toNumber(totalRow?.value),
     rows: rows.map((row) => ({
@@ -428,6 +455,7 @@ export async function readAdminUsersSource(
       createdAt: row.createdAt.getTime(),
       activeDays: toNumber(row.activeDays),
       lastActiveDay: row.lastActiveDay,
+      lastSeenAt: lastSeenByUser.get(row.id)?.getTime() ?? null,
       voiceCalls: toNumber(row.voiceCalls),
       attentionReviews: toNumber(row.attentionReviews),
     })),

--- a/apps/web/server/admin/admin-users.ts
+++ b/apps/web/server/admin/admin-users.ts
@@ -38,6 +38,13 @@ export interface AdminUserListRow {
   activeDays: number;
   /** The account's most recent active day inside the window, if any. */
   lastActiveDay: string | null;
+  /**
+   * When the account last touched the service at all, in epoch milliseconds:
+   * its freshest auth-session write, which a plain sign-in moves where the
+   * hosted-tier aggregates above stay at zero. Null for an account whose
+   * sessions have all been pruned.
+   */
+  lastSeenAt: number | null;
   voiceCalls: number;
   attentionReviews: number;
 }

--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -1366,6 +1366,7 @@ async function readUsersState(response: Response): Promise<UsersState> {
 const USERS_SORT_KEY = {
   ACCOUNT: "account",
   JOINED: "joined",
+  LAST_SEEN: "lastSeen",
   ACTIVE_DAYS: "activeDays",
   LAST_ACTIVE: "lastActive",
   VOICE: "voice",
@@ -1386,6 +1387,7 @@ type SortDirection = (typeof SORT_DIRECTION)[keyof typeof SORT_DIRECTION];
 const USERS_SORT_FIRST_DIRECTION = {
   [USERS_SORT_KEY.ACCOUNT]: SORT_DIRECTION.ASCENDING,
   [USERS_SORT_KEY.JOINED]: SORT_DIRECTION.DESCENDING,
+  [USERS_SORT_KEY.LAST_SEEN]: SORT_DIRECTION.DESCENDING,
   [USERS_SORT_KEY.ACTIVE_DAYS]: SORT_DIRECTION.DESCENDING,
   [USERS_SORT_KEY.LAST_ACTIVE]: SORT_DIRECTION.DESCENDING,
   [USERS_SORT_KEY.VOICE]: SORT_DIRECTION.DESCENDING,
@@ -1400,6 +1402,7 @@ const USERS_SORT_FIRST_DIRECTION = {
 const USERS_SORT_VALUE = {
   [USERS_SORT_KEY.ACCOUNT]: (row) => (row.name || row.email).toLowerCase(),
   [USERS_SORT_KEY.JOINED]: (row) => row.createdAt,
+  [USERS_SORT_KEY.LAST_SEEN]: (row) => row.lastSeenAt,
   [USERS_SORT_KEY.ACTIVE_DAYS]: (row) => row.activeDays,
   [USERS_SORT_KEY.LAST_ACTIVE]: (row) => row.lastActiveDay,
   [USERS_SORT_KEY.VOICE]: (row) => row.voiceCalls,
@@ -1523,6 +1526,13 @@ function UsersTable({
               numeric
             />
             <SortableHeader
+              label="Last seen"
+              sortKey={USERS_SORT_KEY.LAST_SEEN}
+              sort={sort}
+              onSort={toggleSort}
+              numeric
+            />
+            <SortableHeader
               label="Active days"
               sortKey={USERS_SORT_KEY.ACTIVE_DAYS}
               sort={sort}
@@ -1582,6 +1592,9 @@ function UsersTable({
                 </a>
               </td>
               <td className="px-5 py-3 text-right tabular-nums">{formatDate(row.createdAt)}</td>
+              <td className="px-5 py-3 text-right tabular-nums">
+                {row.lastSeenAt === null ? "—" : formatDate(row.lastSeenAt)}
+              </td>
               <td className="px-5 py-3 text-right tabular-nums">
                 {formatNumber(row.activeDays)}
                 <span className="text-muted-foreground"> of {formatNumber(windowDays)}</span>
@@ -1682,7 +1695,9 @@ function UsersPage({
         <p className="mt-3 text-sm text-muted-foreground">
           Every account the service holds, most recently active first, whether or not it ever
           touched the hosted tier — active days count the window's UTC days with hosted voice or
-          attention. A heading sorts by its column, and a row opens the account's own page.
+          attention, while last seen is the account's freshest sign-in session, which a plain
+          sign-in moves without any hosted use. A heading sorts by its column, and a row opens the
+          account's own page.
           {list.total > list.rows.length
             ? ` Only the ${formatNumber(list.rows.length)} most recently active accounts are listed here, and the filter searches those alone.`
             : ""}

--- a/apps/web/tests/admin-users.test.ts
+++ b/apps/web/tests/admin-users.test.ts
@@ -26,6 +26,7 @@ const ROW = {
   createdAt: Date.parse("2026-06-01T08:00:00.000Z"),
   activeDays: 12,
   lastActiveDay: "2026-08-17",
+  lastSeenAt: Date.parse("2026-08-17T09:30:00.000Z"),
   voiceCalls: 120,
   attentionReviews: 400,
 };


### PR DESCRIPTION
## Summary

The Users roster's **Last active** column moves only when an account spends hosted voice or attention, so an account that signs in and works purely locally looks abandoned. Each roster row now also carries **Last seen** — the account's freshest auth-session write (`max(session.updated_at)`), which a plain sign-in moves without any hosted use — drawn between Joined and the hosted columns, dash for an account whose sessions have all been pruned.

- `AdminUserListRow` gains `lastSeenAt: number | null` (epoch ms).
- `readAdminUsersSource` reads the per-account session maximum in a query of its own, joined through the user row so the scope filter still governs it: a second one-to-many join on the roster query would fan the usage aggregates out across each account's session rows.
- The Users table draws the new column and the footer copy names the difference between the two recency columns.

## Testing

- `./scripts/check.sh` passes: lint, typecheck, all tests (apps/web 88/88, apps/desktop 722/722), and builds.
- Web-only admin dashboard change; no macOS surface touched, so no physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/8dff3e17-6496-484c-b9c8-1cd0f2490e42)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32529436916/artifacts/9463400303) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32529436916)

- Commit: `11b83778f6124d211825470b2357b84f17f66060`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
