### PR TITLE
fix(conductor): keep a walked-away cloud chat stale across a VM wake

### DIFF
--- a/packages/providers/src/conductor/adapter.test.ts
+++ b/packages/providers/src/conductor/adapter.test.ts
@@ -1259,6 +1259,43 @@ test("a failed read never counts as the chat's work moving", async () => {
   assert.equal(statusless[0]?.observedAt, walkedAwayAt);
 });
 
+// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+test("a chat first seen through a failed status read is not pinned to the fallback", async () => {
+  // With no readable status there is nothing to remember yet: seeding from
+  // the workspace's fallback timestamp would stand as a moment no later read
+  // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+  // could displace, so the first readable status is the true first sight.
+  const walkedAwayAt = TEST_TIME - 2 * 60 * 60 * 1000;
+  const workspace = ownedWorkspace("workspace-first-unreadable", TEST_TIME - 1_000);
+  const chat: TestSession = {
+    id: IDLE_SESSION_UUID,
+    workspaceId: "workspace-first-unreadable",
+    name: TEST_SESSION_NAME,
+    transcriptTail: TEST_TRANSCRIPT_TAIL,
+    status: TEST_CONDUCTOR_STATUS.IDLE,
+    statusUpdatedAt: walkedAwayAt,
+    statusHttpStatus: HTTP_STATUS.SERVER_ERROR,
+  };
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [workspace],
+    sessions: [chat],
+  });
+  let now = TEST_TIME;
+  const adapter = adapterFor(api.fetch, { now: () => now });
+
+  const unreadable = await adapter.observe();
+  assert.equal(unreadable[0]?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(unreadable[0]?.observedAt, workspace.lastActivityAt);
+
+  now = TEST_TIME + 60_000;
+  delete chat.statusHttpStatus;
+  const readable = await adapter.observe();
+  assert.equal(readable[0]?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(readable[0]?.observedAt, walkedAwayAt);
+});
+
 test("ignores workspaces created by another user and workspaces without a creator", async () => {
   const api = fakeConductorApi({
     userId: TEST_USER_ID,

--- a/packages/providers/src/conductor/adapter.test.ts
+++ b/packages/providers/src/conductor/adapter.test.ts
@@ -1029,9 +1029,9 @@ test("leaves a filed-away chat off the roster while its workspace stays", async 
 
 // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
 test("keeps reporting a long turn as working", async () => {
-  // Conductor stamps a status with the moment it was entered, so a turn that
+  // Only waiting decays with age, so a turn that started an hour ago and is
   // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-  // started an hour ago and is still running must not read as stale.
+  // still running must not read as stale.
   const startedAt = TEST_TIME - 60 * 60 * 1000;
   const api = fakeConductorApi({
     userId: TEST_USER_ID,
@@ -1092,6 +1092,171 @@ test("does not treat a long-idle chat as waiting because its workspace is busy",
   assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
   assert.equal(observations[1]?.providerSessionId, "session-just-finished");
   assert.equal(observations[1]?.status, SESSION_STATUS.WAITING);
+});
+
+// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+test("keeps a walked-away chat stale across the wake its own press caused", async () => {
+  // Opening a stale chat in Conductor's app wakes its sleeping workspace, and
+  // the wake rewrites the session record: `updatedAt` and the workspace's
+  // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+  // `lastActivityAt` both jump to now while the chat itself did nothing.
+  const walkedAwayAt = TEST_TIME - 2 * 60 * 60 * 1000;
+  const workspace = ownedWorkspace("workspace-woken", walkedAwayAt);
+  const chat: TestSession = {
+    id: IDLE_SESSION_UUID,
+    workspaceId: "workspace-woken",
+    name: TEST_SESSION_NAME,
+    transcriptTail: TEST_TRANSCRIPT_TAIL,
+    status: TEST_CONDUCTOR_STATUS.IDLE,
+    statusUpdatedAt: walkedAwayAt,
+  };
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [workspace],
+    sessions: [chat],
+  });
+  let now = TEST_TIME;
+  const adapter = adapterFor(api.fetch, { now: () => now });
+
+  const beforeWake = await adapter.observe();
+  assert.equal(beforeWake[0]?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(beforeWake[0]?.observedAt, walkedAwayAt);
+
+  now = TEST_TIME + 60_000;
+  chat.statusUpdatedAt = now;
+  workspace.lastActivityAt = now;
+
+  const afterWake = await adapter.observe();
+  assert.equal(afterWake[0]?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(afterWake[0]?.observedAt, walkedAwayAt);
+});
+
+// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+test("adopts the provider's timestamp again the moment the chat's work moves", async () => {
+  const walkedAwayAt = TEST_TIME - 2 * 60 * 60 * 1000;
+  const workspace = ownedWorkspace("workspace-resumed", walkedAwayAt);
+  const chat: TestSession = {
+    id: IDLE_SESSION_UUID,
+    workspaceId: "workspace-resumed",
+    name: TEST_SESSION_NAME,
+    transcriptTail: TEST_TRANSCRIPT_TAIL,
+    status: TEST_CONDUCTOR_STATUS.IDLE,
+    statusUpdatedAt: walkedAwayAt,
+  };
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [workspace],
+    sessions: [chat],
+  });
+  let now = TEST_TIME;
+  const adapter = adapterFor(api.fetch, { now: () => now });
+  await adapter.observe();
+
+  // The user sends the woken chat a message: the status itself moves.
+  now = TEST_TIME + 60_000;
+  chat.status = TEST_CONDUCTOR_STATUS.WORKING;
+  chat.statusUpdatedAt = now;
+  workspace.lastActivityAt = now;
+  const working = await adapter.observe();
+  assert.equal(working[0]?.status, SESSION_STATUS.WORKING);
+  assert.equal(working[0]?.observedAt, now);
+
+  // The turn settles with new parting words: freshly waiting, on the
+  // provider's own timestamp for the settle.
+  const settledAt = TEST_TIME + 120_000;
+  now = settledAt + 5_000;
+  chat.status = TEST_CONDUCTOR_STATUS.IDLE;
+  chat.statusUpdatedAt = settledAt;
+  chat.transcriptTail = "## Assistant\n\nShipped; anything else?";
+  const settled = await adapter.observe();
+  assert.equal(settled[0]?.status, SESSION_STATUS.WAITING);
+  assert.equal(settled[0]?.observedAt, settledAt);
+});
+
+// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+test("a whole turn between passes still reads as fresh through its parting words", async () => {
+  // A short turn can start and settle inside one refresh interval, so both
+  // passes read idle — the new parting words are what say the work moved.
+  const walkedAwayAt = TEST_TIME - 2 * 60 * 60 * 1000;
+  const workspace = ownedWorkspace("workspace-quick-turn", walkedAwayAt);
+  const chat: TestSession = {
+    id: IDLE_SESSION_UUID,
+    workspaceId: "workspace-quick-turn",
+    name: TEST_SESSION_NAME,
+    transcriptTail: TEST_TRANSCRIPT_TAIL,
+    status: TEST_CONDUCTOR_STATUS.IDLE,
+    statusUpdatedAt: walkedAwayAt,
+  };
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [workspace],
+    sessions: [chat],
+  });
+  let now = TEST_TIME;
+  const adapter = adapterFor(api.fetch, { now: () => now });
+  await adapter.observe();
+
+  const settledAt = TEST_TIME + 60_000;
+  now = settledAt + 5_000;
+  chat.statusUpdatedAt = settledAt;
+  chat.transcriptTail = "## Assistant\n\nDone; want the follow-up too?";
+  const settled = await adapter.observe();
+  assert.equal(settled[0]?.status, SESSION_STATUS.WAITING);
+  assert.equal(settled[0]?.observedAt, settledAt);
+  assert.equal(settled[0]?.recap, "Done; want the follow-up too?");
+});
+
+// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+test("a failed read never counts as the chat's work moving", async () => {
+  const walkedAwayAt = TEST_TIME - 2 * 60 * 60 * 1000;
+  const workspace = ownedWorkspace("workspace-unreadable", walkedAwayAt);
+  const chat: TestSession = {
+    id: IDLE_SESSION_UUID,
+    workspaceId: "workspace-unreadable",
+    name: TEST_SESSION_NAME,
+    transcriptTail: TEST_TRANSCRIPT_TAIL,
+    status: TEST_CONDUCTOR_STATUS.IDLE,
+    statusUpdatedAt: walkedAwayAt,
+  };
+  const testApi: TestApi = {
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces: [workspace],
+    sessions: [chat],
+  };
+  const api = fakeConductorApi(testApi);
+  let now = TEST_TIME;
+  const adapter = adapterFor(api.fetch, { now: () => now });
+  await adapter.observe();
+
+  // A wake bumps the timestamps on a pass whose transcripts read fails: the
+  // recap is unknowable, which says nothing about the chat, not that it moved.
+  now = TEST_TIME + 60_000;
+  chat.statusUpdatedAt = now;
+  workspace.lastActivityAt = now;
+  testApi.sqlHttpStatus = HTTP_STATUS.SERVER_ERROR;
+  const unreadable = await adapter.observe();
+  assert.equal(unreadable[0]?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(unreadable[0]?.observedAt, walkedAwayAt);
+
+  // The transcripts answer again with the same parting words: still nothing
+  // moved, so the wake's timestamps stay a side effect.
+  now = TEST_TIME + 120_000;
+  delete testApi.sqlHttpStatus;
+  const readable = await adapter.observe();
+  assert.equal(readable[0]?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(readable[0]?.observedAt, walkedAwayAt);
+
+  // The status read failing likewise leaves the walked-away moment standing
+  // rather than falling back to the workspace's wake-bumped activity.
+  now = TEST_TIME + 180_000;
+  chat.statusHttpStatus = HTTP_STATUS.SERVER_ERROR;
+  const statusless = await adapter.observe();
+  assert.equal(statusless[0]?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(statusless[0]?.observedAt, walkedAwayAt);
 });
 
 test("ignores workspaces created by another user and workspaces without a creator", async () => {

--- a/packages/providers/src/conductor/adapter.ts
+++ b/packages/providers/src/conductor/adapter.ts
@@ -346,6 +346,25 @@ interface ConductorTranscript {
   recap?: string;
 }
 
+/**
+ * One chat's last readable facts, beside the moment reported for them.
+ * Conductor's status `updatedAt` is the session record's write time, not the
+ * moment its status was entered: opening a stale chat wakes its sleeping
+ * workspace, and the wake alone rewrites the record. Judged on that timestamp,
+ * a chat walked away from hours ago flips back to freshly waiting at a press
+ * that asked it nothing — so the moment is advanced only when the facts
+ * themselves moved. A fact a pass could not read is `undefined` here and never
+ * compared, because a failed read says nothing about the chat; `recapKnown`
+ * tells a transcript that answered with nothing from one never read at all.
+ */
+interface ConductorSessionMemory {
+  status: ConductorSessionStatus | undefined;
+  errorMessage: string | undefined;
+  recapKnown: boolean;
+  recap: string | undefined;
+  observedAt: number;
+}
+
 export const CONDUCTOR_PROVIDER: SessionProvider = {
   id: CONDUCTOR_PROVIDER_ID,
   displayName: CONDUCTOR_PROVIDER_NAME,
@@ -418,6 +437,13 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
    * this cache holds, so it can never name a project observation did not see.
    */
   #projects: readonly ConductorProject[] = [];
+  /**
+   * Each observed chat's last readable facts, for telling a record a workspace
+   * wake touched from a chat whose work moved. In memory only: the first pass
+   * after a launch has no earlier reading and takes the provider's timestamp
+   * at its word.
+   */
+  readonly #memories = new Map<string, ConductorSessionMemory>();
 
   constructor(options: ConductorAdapterOptions) {
     super(
@@ -433,6 +459,7 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
   protected override forgetCachedIdentity(): void {
     this.#userId = undefined;
     this.#projects = [];
+    this.#memories.clear();
   }
 
   /**
@@ -630,6 +657,13 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
       if (!settled) settledWorkspaceIds.delete(session.workspace.id);
     });
 
+    // A chat gone from the listing frees its memory here: the roster owns
+    // retention, and remembering a filed-away chat would only grow the map.
+    const observedSessionIds = new Set(sessions.map((session) => session.id));
+    for (const sessionId of this.#memories.keys()) {
+      if (!observedSessionIds.has(sessionId)) this.#memories.delete(sessionId);
+    }
+
     // One row per chat, each grouped under its workspace. The grouping names
     // the workspace once, which leaves each chat free to say what it alone is
     // doing, be opened where it alone lives, and take the message meant for it
@@ -639,7 +673,7 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
         this.#observationFor(
           session,
           reportedStatuses[index],
-          transcripts?.get(session.id),
+          transcripts,
           workspaceLifecycles.get(session.workspace.id),
           settledWorkspaceIds,
           now,
@@ -845,16 +879,13 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
   #observationFor(
     session: ConductorSession,
     reported: ConductorReportedStatus | undefined,
-    transcript: ConductorTranscript | undefined,
+    transcripts: ReadonlyMap<string, ConductorTranscript> | undefined,
     lifecycle: ConductorWorkspaceLifecycle | undefined,
     settledWorkspaceIds: ReadonlySet<string>,
     now: number,
   ): ProviderSessionObservation | undefined {
-    // A workspace timestamp covers every chat in that workspace, so it would
-    // make chats a user left hours ago look like they just stopped. The status
-    // timestamp is per-session; the workspace timestamp is only the last
-    // resort.
-    const observedAt = reported?.updatedAt ?? session.workspace.lastActivityAt;
+    const transcript = transcripts?.get(session.id);
+    const observedAt = this.#observedMoment(session, reported, transcripts);
     const status = this.#statusFor(reported?.status, observedAt, now);
     // The parting words are a recap only once the turn has actually parted:
     // read for an idle chat, they say where the agent left the work; read
@@ -957,6 +988,51 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
         ...(session.deepLink ? { link: session.deepLink } : undefined),
       },
     };
+  }
+
+  /**
+   * The moment this chat's work last moved. Conductor's own timestamps cannot
+   * carry it alone: the workspace's covers every sibling chat, and the status
+   * endpoint's `updatedAt` is the record's write time, bumped by a workspace
+   * wake — the side effect of merely opening a stale chat — as readily as by
+   * a turn. So the provider's timestamp is adopted only when the chat's own
+   * facts moved: its status, the failure it reports, or its parting words.
+   * Unchanged facts keep the moment already reported, which is what lets a
+   * chat walked away from stay walked away from across the wake its press
+   * caused. Comparison needs both readings, so a fact this pass or the
+   * remembered one could not read never counts as movement, and first sight
+   * takes the provider at its word — including, on the first pass after a
+   * launch, a wake that happened just before it.
+   */
+  #observedMoment(
+    session: ConductorSession,
+    reported: ConductorReportedStatus | undefined,
+    transcripts: ReadonlyMap<string, ConductorTranscript> | undefined,
+  ): number {
+    const reportedAt = reported?.updatedAt ?? session.workspace.lastActivityAt;
+    const transcript = transcripts?.get(session.id);
+    const remembered = this.#memories.get(session.id);
+    const statusMoved =
+      remembered !== undefined &&
+      remembered.status !== undefined &&
+      reported?.status !== undefined &&
+      (reported.status !== remembered.status || reported.errorMessage !== remembered.errorMessage);
+    const recapMoved =
+      remembered !== undefined &&
+      remembered.recapKnown &&
+      transcripts !== undefined &&
+      transcript?.recap !== remembered.recap;
+    const observedAt =
+      remembered === undefined || statusMoved || recapMoved ? reportedAt : remembered.observedAt;
+    this.#memories.set(session.id, {
+      status: reported?.status ?? remembered?.status,
+      errorMessage:
+        reported?.status !== undefined ? reported.errorMessage : remembered?.errorMessage,
+      recapKnown: transcripts !== undefined || remembered?.recapKnown === true,
+      recap: transcripts !== undefined ? transcript?.recap : remembered?.recap,
+      observedAt,
+    });
+    return observedAt;
   }
 
   #statusFor(

--- a/packages/providers/src/conductor/adapter.ts
+++ b/packages/providers/src/conductor/adapter.ts
@@ -1012,6 +1012,12 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
     const reportedAt = reported?.updatedAt ?? session.workspace.lastActivityAt;
     const transcript = transcripts?.get(session.id);
     const remembered = this.#memories.get(session.id);
+    // A chat is remembered only once its status has actually been read.
+    // Seeded from a failed read, the workspace's fallback timestamp would
+    // stand as the moment no later read could displace — pinning a sibling's
+    // activity, or a wake's, onto this chat. Until then each pass reports the
+    // fallback afresh, and the first readable status is the true first sight.
+    if (remembered === undefined && reported?.status === undefined) return reportedAt;
     const statusMoved =
       remembered !== undefined &&
       remembered.status !== undefined &&


### PR DESCRIPTION
## Summary

Opening a stale Conductor cloud chat in the app wakes its sleeping workspace, and the wake rewrites the session record. The status endpoint's `updatedAt` is the record's write time, not the moment the status was entered — confirmed against the live API, where a sleeping workspace's session carried an `updatedAt` two hours past the workspace entering `sleeping`, and the endpoint returns no richer field (`{workspaceId, sessionId, status, updatedAt}` only). Judged on that timestamp, a chat walked away from hours ago flipped from `unknown` back to freshly `waiting` at a press that asked it nothing, passed the notice tracker's and attention evaluator's 5-minute freshness gates as news, and sorted to the top of the roster.

The adapter now remembers each observed chat's last readable facts — its Conductor status, failure message, and the transcript's parting words — beside the moment it reported for them, and adopts the provider's timestamp only when those facts moved. Real work still reads fresh through either signal: a status transition, or new parting words, which also catches a whole turn settling between two passes. A fact a pass could not read (a failed status or transcripts request) compares as unknown, never as movement, so a transient failure neither refreshes nor stales a chat. The memory is pruned to the observed roster each pass and cleared with the credential.

The fix stays in the adapter rather than the shared model: `agedStatus` already documents its contract as a timestamp marking when the state was entered, and the adapter is where Conductor's record-write timestamp gets corrected to meet it.

## Limitations

- The memory is per-process: on the first pass after a launch there is no earlier reading, so a wake inside the 15-minute window just before launch still reads fresh until it ages out. First sight seeds the notice tracker silently, so no banner fires — the residue is a too-fresh row.
- A turn that starts and settles entirely between passes with byte-identical parting words and an unchanged status does not refresh; there would be nothing new to say.

## Testing

- 4 new adapter tests: a wake bump keeps a walked-away chat stale; a real status move re-adopts the provider's timestamp; a turn settling between passes reads fresh through its new parting words; failed status/transcripts reads never count as movement.
- `./scripts/check.sh` passes (portable-only change; no capability or data-flow change, so `PRIVACY.md` and the README table stand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/1e188602-a713-4a08-a287-75a1c3eb4c3a)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32527954988/artifacts/9462907012) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32527954988)

- Commit: `a468b7860c42960138e20ef63f8ccc2f97c73b23`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
