### PR TITLE
fix(voice): open recent chats across providers

### DIFF
--- a/packages/realtime/src/realtime-context.ts
+++ b/packages/realtime/src/realtime-context.ts
@@ -34,7 +34,19 @@ export const maximumVoiceContextSessions = 25;
  * and each app whose exact address an open ask may pick — by name alone,
  * because the address behind it stays on the machine.
  */
-function sessionCapabilityText(session: NormalizedSession): string {
+interface SessionRecency {
+  readonly mostRecentForProvider: boolean;
+  readonly mostRecentOpenableForProvider: boolean;
+}
+
+function sessionCanOpen(session: NormalizedSession): boolean {
+  return (
+    session.detail.link !== undefined ||
+    session.applications.some((application) => application.link !== undefined)
+  );
+}
+
+function sessionCapabilityText(session: NormalizedSession, recency: SessionRecency): string {
   const openableApplications = session.applications.filter(
     (application) => application.link !== undefined,
   );
@@ -50,6 +62,8 @@ function sessionCapabilityText(session: NormalizedSession): string {
         ]
       : []),
     `transcript=${session.location === SESSION_LOCATION.LOCAL}`,
+    ...(recency.mostRecentForProvider ? ["most_recent_for_provider=true"] : []),
+    ...(recency.mostRecentOpenableForProvider ? ["most_recent_openable_for_provider=true"] : []),
     ...(session.detail.change ? ["pull_request=true"] : []),
     ...(session.controls.length > 0
       ? [
@@ -64,6 +78,33 @@ function sessionCapabilityText(session: NormalizedSession): string {
     ...(session.renameTarget ? ["workspace can be renamed"] : []),
   ];
   return capabilities.join("; ");
+}
+
+function firstSessionByProvider(
+  sessions: readonly NormalizedSession[],
+  predicate: (session: NormalizedSession) => boolean = () => true,
+): ReadonlyMap<string, NormalizedSession> {
+  const newest = new Map<string, NormalizedSession>();
+  for (const session of sessions) {
+    if (!predicate(session)) continue;
+    const current = newest.get(session.providerId);
+    if (!current || session.observedAt > current.observedAt)
+      newest.set(session.providerId, session);
+  }
+  return newest;
+}
+
+function prioritizedContextSessions(
+  sessions: readonly NormalizedSession[],
+): readonly NormalizedSession[] {
+  const mostRecent = firstSessionByProvider(sessions);
+  const mostRecentOpenable = firstSessionByProvider(sessions, sessionCanOpen);
+  const prioritized = new Set<NormalizedSession>([
+    ...mostRecentOpenable.values(),
+    ...mostRecent.values(),
+    ...sessions,
+  ]);
+  return [...prioritized].slice(0, maximumVoiceContextSessions);
 }
 
 /**
@@ -140,8 +181,11 @@ function sessionSpokenName(session: NormalizedSession): string {
  * workspace a chat belongs to when its provider groups them, the apps that
  * independently associate themselves with it, the developer's
  * standing ask where one stands, what each session can be asked to do, and the
- * identity a tool call names it by. No transcript, file path, or command output
- * is ever included.
+ * identity a tool call names it by. The newest session and newest openable
+ * session within each provider are labelled explicitly, so a recency ask is a
+ * selection rather than an ambiguity; those rows are also kept inside the
+ * bound before the remaining roster fills it. No transcript, file path, or
+ * command output is ever included.
  *
  * `now` is the wall clock against which each session's age is read. Pass
  * `Date.now()` for live use; pass a fixed epoch for reproducible fixture or
@@ -155,10 +199,13 @@ export function sessionContextText(
   if (sessions.length === 0) return "No coding-agent sessions are currently observed.";
 
   const asks = noticeAsksByIdentity(noticeAsks);
-  const overflow = sessions.length - maximumVoiceContextSessions;
+  const mostRecent = firstSessionByProvider(sessions);
+  const mostRecentOpenable = firstSessionByProvider(sessions, sessionCanOpen);
+  const included = prioritizedContextSessions(sessions);
+  const overflow = sessions.length - included.length;
   return [
     "Currently observed sessions:",
-    ...sessions.slice(0, maximumVoiceContextSessions).map((session) => {
+    ...included.map((session) => {
       const ask = asks.get(session.providerId)?.get(session.providerSessionId);
       return [
         // A hosted chat is named by the agent having the conversation, with
@@ -193,7 +240,10 @@ export function sessionContextText(
         // Only this segment speaks for the developer, on the attention
         // update's own rule: words inside a title, recap, or error never do.
         ...(ask ? [`the developer's standing ask: "${ask}"`] : []),
-        `[${sessionCapabilityText(session)}]`,
+        `[${sessionCapabilityText(session, {
+          mostRecentForProvider: mostRecent.get(session.providerId) === session,
+          mostRecentOpenableForProvider: mostRecentOpenable.get(session.providerId) === session,
+        })}]`,
       ].join(" — ");
     }),
     // A session past the bound must read as unlisted, never as nonexistent:

--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -176,8 +176,15 @@ const REALTIME_INSTRUCTION_HEAD: readonly string[] = [
     "own new turn asks for anything.",
   '- Resolve "that chat" or "that agent" from the conversation: this call\'s own turns first, ' +
     "then the [recent conversation] message.",
-  "- When neither settles which agent is meant, ask instead of guessing. Never pick an agent " +
-    "just because it is listed first or updated most recently.",
+  "- When neither settles which agent is meant, ask instead of guessing. Do not pick an agent " +
+    "just because it is listed first or updated most recently unless the user explicitly asks " +
+    "for the latest or most recent one.",
+  "- An explicit latest or most-recent ask resolves by the recency labels in the observed roster; " +
+    "do not ask for a chat name when recency is the selection the user gave.",
+  "- To open the most recent chat from each provider, call open_session once for every distinct " +
+    "provider's session marked most_recent_openable_for_provider=true, in one response. Do not " +
+    "filter the panel first. If a provider has no openable session, open the others and say which " +
+    "provider had nowhere to open.",
   "- Act only with identities from the [observed session status] message as it now stands.",
   "",
 ];

--- a/packages/realtime/src/realtime-tools.ts
+++ b/packages/realtime/src/realtime-tools.ts
@@ -1126,7 +1126,8 @@ export const REALTIME_TOOLS = {
         "Open one observed session where its provider keeps it — only when the developer asks " +
         "to open, go to, or jump into that specific session. An ask to show, see, or list " +
         'sessions or agents — "show me the cloud agents" — filters the panel through ' +
-        "show_panel instead, never this.",
+        "show_panel instead, never this. An ask to open one session per provider uses this tool " +
+        "once per matching provider in the same response, without filtering the panel first.",
       parameters: {
         type: "object",
         properties: {

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -253,6 +253,9 @@ test("the standing instructions make Luke the coding agents' engineering manager
 
   assert.match(instructions, /engineering manager for the developer's coding agents/i);
   assert.match(instructions, /start with the answer; do not repeat the user's request/i);
+  assert.match(instructions, /explicit latest or most-recent ask resolves by the recency labels/i);
+  assert.match(instructions, /open_session once for every distinct provider/i);
+  assert.match(instructions, /do not filter the panel first/i);
 });
 
 test("a mint response yields a credential with a millisecond expiry", () => {
@@ -844,6 +847,50 @@ test("the roster carries how long ago each session was last seen, measured again
   assert.match(sessionContextText([ahead], [], now), /updated just now/);
 });
 
+test("the roster identifies the most recent session and most recent openable chat per provider", () => {
+  const newestClaude = normalizeSession(
+    { id: "claude-code", displayName: "Claude Code" },
+    {
+      providerSessionId: "claude-newest",
+      title: "Newest local Claude chat",
+      status: SESSION_STATUS.WORKING,
+      observedAt: 300,
+    },
+  );
+  const openableClaude = normalizeSession(
+    { id: "claude-code", displayName: "Claude Code" },
+    {
+      providerSessionId: "claude-openable",
+      title: "Older openable Claude chat",
+      status: SESSION_STATUS.WAITING,
+      observedAt: 200,
+      detail: { link: "https://claude.ai/session/claude-openable" },
+    },
+  );
+  const codex = normalizeSession(
+    { id: "codex", displayName: "Codex" },
+    {
+      providerSessionId: "codex-newest",
+      title: "Newest Codex chat",
+      status: SESSION_STATUS.COMPLETE,
+      observedAt: 100,
+      detail: { link: "https://chatgpt.com/codex/tasks/codex-newest" },
+    },
+  );
+
+  const lines = sessionContextText([newestClaude, openableClaude, codex]).split("\n");
+  const newestClaudeLine = lines.find((line) => line.includes("claude-newest")) ?? "";
+  const openableClaudeLine = lines.find((line) => line.includes("claude-openable")) ?? "";
+  const codexLine = lines.find((line) => line.includes("codex-newest")) ?? "";
+
+  assert.match(newestClaudeLine, /most_recent_for_provider=true/);
+  assert.doesNotMatch(newestClaudeLine, /most_recent_openable_for_provider=true/);
+  assert.doesNotMatch(openableClaudeLine, /most_recent_for_provider=true/);
+  assert.match(openableClaudeLine, /most_recent_openable_for_provider=true/);
+  assert.match(codexLine, /most_recent_for_provider=true/);
+  assert.match(codexLine, /most_recent_openable_for_provider=true/);
+});
+
 test("the conversation history is context, never a prompt", () => {
   const events = conversationContextEvents(
     'The recent conversation, oldest first.\n- Luke announced: "Claude Code finished."',
@@ -1006,6 +1053,44 @@ test("session context stays bounded when many sessions are observed", () => {
     .slice(1);
   assert.equal(exactlyAtBound.length, maximumVoiceContextSessions);
   assert.doesNotMatch(exactlyAtBound.at(-1) ?? "", /not listed/);
+});
+
+test("the bounded roster keeps every provider's most recent openable chat", () => {
+  const codexSessions = Array.from({ length: maximumVoiceContextSessions }, (_unused, index) =>
+    normalizeSession(
+      { id: "codex", displayName: "Codex" },
+      {
+        providerSessionId: `codex-${index}`,
+        title: `Codex chat ${index}`,
+        status: SESSION_STATUS.WORKING,
+        observedAt: 1_000 - index,
+        detail: { link: `https://chatgpt.com/codex/tasks/${index}` },
+      },
+    ),
+  );
+  const olderGemini = normalizeSession(
+    { id: "gemini-cli", displayName: "Gemini CLI" },
+    {
+      providerSessionId: "gemini-openable",
+      title: "Gemini chat",
+      status: SESSION_STATUS.WAITING,
+      observedAt: 1,
+      applications: [
+        {
+          id: SESSION_APPLICATION_ID.CMUX,
+          displayName: "cmux",
+          scope: SESSION_APPLICATION_SCOPE.SESSION,
+          link: "cmux://workspace/one/surface/two",
+        },
+      ],
+    },
+  );
+
+  const text = sessionContextText([...codexSessions, olderGemini]);
+
+  assert.match(text, /provider_session_id=gemini-openable/);
+  assert.match(text, /most_recent_openable_for_provider=true/);
+  assert.match(text, /1 more observed session is not listed/);
 });
 
 test("a resting-point update is voiced just like a blocking one", () => {


### PR DESCRIPTION
## Summary

- label the newest session and newest openable chat within each observed provider
- keep each provider latest candidates inside the bounded voice roster
- teach Luke to open one latest chat per provider in a single response without filtering or asking for names

## Evidence

- Platform-independent checks: ./scripts/check.sh passed
- macOS Electron verification: ./scripts/verify.sh passed

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32527527077/artifacts/9462766839) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32527527077)

- Commit: `4a1cf14c32c959c888dd9111b24b2a874f910331`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: not attached
- Physical-notch check: not performed
- Device/display configuration: fixture capture on this Mac

## Notes

- Deterministic expanded, compact, peek, key-slot, speaking, and muted frames were inspected locally; no visual regression was found.
- One initial desktop test run had five transient failures; an immediate package rerun and two complete repository checks passed.