### PR TITLE
fix(panel): sign filter errands on the split options pill, and clears on its X

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -2007,9 +2007,10 @@ export function App(): React.JSX.Element {
           // its values would show more than the sentence names.
           const filters = action.filters ? (spoken ?? []) : undefined;
           // Caught rather than applied, on the settings switch's terms: the
-          // narrowing is what Luke is on his way to the options button to do, and
-          // a list that has already re-sorted itself by the time he gets there
-          // makes the flight a report rather than the act.
+          // narrowing is what Luke is on his way to the options control — or
+          // its clear X, for a whole-list ask — to do, and a list that has
+          // already re-sorted itself by the time he gets there makes the
+          // flight a report rather than the act.
           const view =
             filters || action.sort || action.query !== undefined
               ? {

--- a/apps/desktop/src/renderer/luke-errand.test.ts
+++ b/apps/desktop/src/renderer/luke-errand.test.ts
@@ -7,7 +7,7 @@ import {
   type AppGuideSetting,
   SESSION_LIST_SORT,
 } from "@sidecar/guide";
-import { REALTIME_VOICE, REALTIME_VOICE_SPEED } from "@sidecar/realtime";
+import { REALTIME_VOICE, REALTIME_VOICE_SPEED, SESSION_LIST_ALL } from "@sidecar/realtime";
 import { PANEL_FORM_FACTOR } from "@sidecar/surface";
 import type { AppSettings } from "#shared/contracts";
 import {
@@ -135,7 +135,7 @@ test("showing a tab is signed on that tab", () => {
 });
 
 test("a narrowing or a re-ordering is signed on the control that carries it", () => {
-  // The options button says how the list is being shown, so it comes first —
+  // The options control says how the list is being shown, so it comes first —
   // and it is only drawn beside a list with something to choose between, which
   // is why the tab stands behind it rather than instead of it.
   assert.deepEqual(
@@ -149,6 +149,16 @@ test("a narrowing or a re-ordering is signed on the control that carries it", ()
       sort: SESSION_LIST_SORT.RECENCY,
     }),
     [ERRAND_TARGET.LIST_OPTIONS, ERRAND_TARGET.SESSIONS_TAB],
+  );
+});
+
+test("asking for the whole list back is signed on the X that clears it by hand", () => {
+  // The X is only drawn while a selection stands — asking for everything when
+  // everything is already shown leaves nothing to clear — so the options
+  // control and the tab stand behind it rather than nowhere.
+  assert.deepEqual(
+    errandTargets({ kind: "panel", tab: APP_PANEL_TAB.SESSIONS, filters: [SESSION_LIST_ALL] }),
+    [ERRAND_TARGET.LIST_CLEAR, ERRAND_TARGET.LIST_OPTIONS, ERRAND_TARGET.SESSIONS_TAB],
   );
 });
 

--- a/apps/desktop/src/renderer/luke-errand.tsx
+++ b/apps/desktop/src/renderer/luke-errand.tsx
@@ -1,5 +1,5 @@
 import { APP_PANEL_TAB, type AppPanelTab } from "@sidecar/guide";
-import type { AppToolAction } from "@sidecar/realtime";
+import { type AppToolAction, SESSION_LIST_ALL } from "@sidecar/realtime";
 import { useEffect, useRef } from "react";
 import { flushSync } from "react-dom";
 import { LukeFace } from "./luke-face";
@@ -81,6 +81,7 @@ export const ERRAND_TARGET = {
   SESSIONS_TAB: "tab-sessions",
   SETTINGS_TAB: "tab-settings",
   LIST_OPTIONS: "list-options",
+  LIST_CLEAR: "list-clear",
   LIST_SEARCH: "list-search",
 } as const;
 
@@ -117,7 +118,7 @@ export function errandOriginProps() {
 
 /**
  * Where an act should be signed, best first. More than one because the panel
- * does not always draw the best answer: the options button carries both the
+ * does not always draw the best answer: the options control carries the
  * narrowing and the ordering, but it is only offered beside a list with
  * something to choose between, so the tab stands behind it. The flight takes
  * the first candidate actually drawn, and an act with none flies nowhere.
@@ -130,11 +131,18 @@ export function errandTargets(action: AppToolAction): readonly ErrandTarget[] {
   }
   if (action.kind !== "panel") return [];
   const tab = tabErrandTarget(action.tab);
+  // Asking for the whole list back is what the X on the options control does
+  // by hand, so that is where it is signed. The X is only drawn while a
+  // selection stands — asking for everything when everything is already shown
+  // leaves nothing to clear — so the control and the tab stand behind it.
+  const clearing = action.filters?.includes(SESSION_LIST_ALL) === true;
   // A narrowing or a re-ordering is the news; the tab is only where it
   // happened, and it may not have changed at all.
   const narrowed =
     action.filters !== undefined || action.sort !== undefined
-      ? [ERRAND_TARGET.LIST_OPTIONS, tab]
+      ? clearing
+        ? [ERRAND_TARGET.LIST_CLEAR, ERRAND_TARGET.LIST_OPTIONS, tab]
+        : [ERRAND_TARGET.LIST_OPTIONS, tab]
       : [tab];
   // A search is signed on the magnifier that opens its field, ahead of
   // whatever else the same ask changed: the field appearing is the loudest
@@ -824,11 +832,12 @@ export function LukeErrand({ errand, onLanded, onReturned }: LukeErrandProps): R
       // errand may stand back down.
       beat = window.setTimeout(() => {
         // The control changes shape at the tap and not before: the options
-        // button grows a label as the list narrows — by a provider's whole
-        // name and mark, which is the widest it gets — and a pop-up is as wide
-        // as the value it is showing. So the ring is measured after the change
-        // is in the DOM rather than at the launch, when it would be the
-        // outline of a control that is about to stop existing.
+        // control grows a label and a clear segment as the list narrows — by
+        // a provider's whole name and mark plus the X, which is the widest it
+        // gets — and a pop-up is as wide as the value it is showing. So the
+        // ring is measured after the change is in the DOM rather than at the
+        // launch, when it would be the outline of a control that is about to
+        // stop existing.
         //
         // Flushed rather than waited a frame for. The release is a React state
         // change made from a timer, which React is free to commit on its own
@@ -840,6 +849,8 @@ export function LukeErrand({ errand, onLanded, onReturned }: LukeErrandProps): R
         const landing = errandBound(stage.getBoundingClientRect(), target.getBoundingClientRect());
         // A control the change took off the panel has no outline worth
         // drawing, and a zero box would draw a ring at the stage's corner.
+        // The clear X is the ordinary case rather than a corner: it unmounts
+        // with the very selection its tap just cleared.
         if (landing.width === 0 || landing.height === 0) return;
         ringElement.style.left = `${landing.left}px`;
         ringElement.style.top = `${landing.top}px`;

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -374,8 +374,8 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "with an X on its right that clears every chosen chip at once. " +
         "Chosen chips are un-pressed the same way they were pressed, a spoken ask can narrow " +
         "to one or several values combined the same way — local Codex voice chats is one ask " +
-        "— naming an agent or app by its everyday name, or back to all, replacing what was " +
-        "picked by hand, and the list is " +
+        "— naming an agent or app by its everyday name, or back to all, the same clear the X " +
+        "makes, replacing what was picked by hand, and the list is " +
         "orderable by urgency or recency by the same button or ask. " +
         "A row can be opened, messaged, or controlled " +
         "where its provider allows. A session whose provider reported a pull request grows a " +

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -2,6 +2,7 @@ import type { SessionNoticeAsk } from "@sidecar/attention";
 import type { SessionSnapshot } from "@sidecar/fixtures";
 import { SESSION_LIST_SORT, type SessionListSort } from "@sidecar/guide";
 import type { IssueIdentity } from "@sidecar/issues";
+import { SESSION_LIST_ALL } from "@sidecar/realtime";
 import {
   ATTENTION_DISPOSITION,
   isProviderId,
@@ -103,9 +104,6 @@ export function sameSessionFilters(
   return first.length === second.length && first.every((filter) => second.includes(filter));
 }
 
-/** The spoken name for the unnarrowed list, shared with the voice tool's vocabulary. */
-const SPOKEN_ALL = "all";
-
 /** One spoken value read as the chip it names, or nothing when no chip holds it. */
 function sessionFilterFromSpoken(value: string): SessionFilter | undefined {
   if (
@@ -133,7 +131,7 @@ function sessionFilterFromSpoken(value: string): SessionFilter | undefined {
 export function sessionFiltersFromSpoken(
   values: readonly string[],
 ): readonly SessionFilter[] | undefined {
-  if (values.length === 1 && values[0] === SPOKEN_ALL) return [];
+  if (values.length === 1 && values[0] === SESSION_LIST_ALL) return [];
   const selection: SessionFilter[] = [];
   for (const value of values) {
     const filter = sessionFilterFromSpoken(value);

--- a/apps/desktop/src/renderer/session-parts.tsx
+++ b/apps/desktop/src/renderer/session-parts.tsx
@@ -219,15 +219,18 @@ export function SessionOptionsButton({
       className="options-control"
       id={SESSION_OPTIONS_CONTROL_ID}
       data-narrowed={String(narrowed)}
+      // The control already says how the list is being shown, so it is where
+      // a narrowing or a re-ordering Luke made himself is signed. The mark
+      // sits on the wrapper rather than the toggle because while a selection
+      // stands the wrapper is the drawn pill, X segment and all, and a ring
+      // around the toggle alone would outline half a control.
+      {...errandTargetProps(ERRAND_TARGET.LIST_OPTIONS)}
     >
       <button
         ref={toggle}
         type="button"
         id={SESSION_OPTIONS_BUTTON_ID}
         className="options-button"
-        // The button already says how the list is being shown, so it is where a
-        // narrowing or a re-ordering Luke made himself is signed.
-        {...errandTargetProps(ERRAND_TARGET.LIST_OPTIONS)}
         data-active={String(open)}
         data-narrowed={String(narrowed)}
         aria-expanded={open}
@@ -253,6 +256,10 @@ export function SessionOptionsButton({
         <button
           type="button"
           className="options-clear"
+          // Asking Luke for the whole list back is this X's own act, so that
+          // is where he signs it — and the X unmounts under his tap, which
+          // the errand already treats as a control the change took away.
+          {...errandTargetProps(ERRAND_TARGET.LIST_CLEAR)}
           aria-label="Clear filters"
           title="Clear filters"
           onClick={() => {

--- a/apps/desktop/src/renderer/styles/sessions-options-clear.test.ts
+++ b/apps/desktop/src/renderer/styles/sessions-options-clear.test.ts
@@ -54,9 +54,12 @@ test("clearing returns focus to the toggle the X sat beside", () => {
 test("the narrowed pill is the wrapper, so the X can sit inside it", () => {
   assert.match(rule(".options-control"), /display: inline-flex;/);
   assert.match(rule(".options-control"), /align-items: center;/);
+  // The radius stands on the wrapper in both states rather than only while
+  // narrowed: the errand's ring takes its corners from the element it marks,
+  // and at rest the wrapper hugs the toggle's own rounded box exactly.
+  assert.match(rule(".options-control"), /border-radius: 10px;/);
   const pill = rule('.options-control[data-narrowed="true"]');
   assert.match(pill, /background: var\(--raised\);/);
-  assert.match(pill, /border-radius: 10px;/);
 });
 
 test("the X is the pill's own right segment, split off by a hairline", () => {

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -73,11 +73,14 @@
 .options-control {
   display: inline-flex;
   align-items: center;
+  /* The wrapper is where an errand lands, and the ring takes its corners from
+     the element it marks — so the pill's radius stands here even at rest,
+     when the wrapper draws nothing and hugs the toggle's own rounded box. */
+  border-radius: 10px;
 }
 
 .options-control[data-narrowed="true"] {
   min-height: 28px;
-  border-radius: 10px;
   background: var(--raised);
   color: var(--text-primary);
   transition:

--- a/packages/realtime/src/index.ts
+++ b/packages/realtime/src/index.ts
@@ -92,6 +92,7 @@ export {
   REALTIME_TOOL_FAMILY,
   type RealtimeToolFamily,
   realtimeToolFamily,
+  SESSION_LIST_ALL,
   SESSION_LIST_VOICE,
   SESSION_TOOL_KIND,
   type SessionToolAction,


### PR DESCRIPTION
## Summary

- Since #399/#403 split the options button into a two-segment pill with a clear X, the errand for a spoken narrowing still landed on the toggle segment alone, so its ring outlined half a control with corners the pill does not have. The `LIST_OPTIONS` mark now sits on the wrapper — the drawn pill while a selection stands, and exactly the toggle's box at rest — with the pill's radius declared on the wrapper in both states, because the ring takes its corners from the element it marks.
- A spoken whole-list ask ("back to all") is now signed on the clear X itself — the control that makes the same clear by hand — as a new `LIST_CLEAR` errand target, with the options control and the tab standing behind it for the case where nothing is narrowed and no X is drawn. The X unmounting under the tap is the ring's documented control-taken-away case, now named as the ordinary one.
- The spoken `all` token is exported from the realtime vocabulary (`SESSION_LIST_ALL`) and shared by `errandTargets` and `sessionFiltersFromSpoken` instead of being restated locally, and the guide's sessions-list fact now says a spoken back-to-all is the same clear the X makes.
- Stale wording that described the pre-X lone options button is updated across the errand's comments and tests.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (exit 0, all package test suites report `fail 0`; includes the new `errandTargets` clearing test and the updated options-pill style guards)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — authored in a Linux cloud workspace with no macOS host; relying on CI's macOS validation and visual evidence

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32528141940/artifacts/9462968382) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32528141940)

- Commit: `981391b0e60f9359fc5209dd6d28e885a37a4eb0`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed` (no physical Mac available in this environment)
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: inspect the CI-generated visual evidence for the errand ring on the narrowed pill before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/7d429664-1f75-4f39-83b5-99675390a36c)
