### PR TITLE
feat(panel): say a workspace's shared pull request once on its tray header

### DIFF
--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -379,7 +379,8 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "orderable by urgency or recency by the same button or ask. " +
         "A row can be opened, messaged, or controlled " +
         "where its provider allows. A session whose provider reported a pull request grows a " +
-        "chip that opens it in the browser. A row the developer asked Luke to listen for wears " +
+        "chip that opens it in the browser — said once on a workspace tray's header when its " +
+        "chats share the one change. A row the developer asked Luke to listen for wears " +
         "a listening mark beside its age. Luke's own composer at the foot takes a typed ask.",
     },
     {
@@ -445,7 +446,8 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "individually where its latest roster entry offers that act. A Superset, Conductor, " +
         "or Orca " +
         "tray carries the managing app's mark once in its header rather than repeating it on " +
-        "every child row.",
+        "every child row, and the header also carries the workspace's acts and the one " +
+        "pull-request chip its chats share, where each row would have repeated them.",
     },
     {
       label: "The Settings tab",

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -33,7 +33,9 @@ import {
   sessionListRuns,
   sessionRunKeys,
   type WorkspaceTrayAction,
+  type WorkspaceTrayChange,
   workspaceTrayActions,
+  workspaceTrayChange,
 } from "./session-model";
 import {
   LEAVING_ATTRIBUTE,
@@ -155,12 +157,16 @@ function RowActionButton({
 function SessionRowActions({
   session,
   actions,
+  withChange,
   writes,
 }: {
   session: DisplaySession;
   /** The actions this row draws itself: inside a tray, the workspace-level
    * ones live in the tray's own header. */
   actions: readonly SessionAction[];
+  /** Whether this row draws the pull-request chip itself: inside a tray whose
+   * header carries the workspace's one change, it does not. */
+  withChange: boolean;
   writes: SessionWriteHandlers;
 }): React.JSX.Element {
   const [sending, setSending] = useState(false);
@@ -301,7 +307,7 @@ function SessionRowActions({
           onRun={(actionId) => void runAction(actionId)}
         />
       ))}
-      {session.hasChange ? (
+      {withChange ? (
         <button
           type="button"
           className="row-action"
@@ -329,13 +335,18 @@ function SessionRowActions({
  * several different acts when any press did the whole thing. The press still
  * travels as a session write — through the first chat that advertised the act
  * — so it is validated against the same roster row that promised it, and its
- * outcome answers on the header's own line the way a row's writes do.
+ * outcome answers on the header's own line the way a row's writes do. The
+ * workspace's one pull request rides here on the same reasoning: the chats
+ * share a branch, so the chip repeated on each row read as several changes,
+ * and its open travels through the chat that reported it the way an act does.
  */
 function WorkspaceTrayActs({
   acts,
+  change,
   writes,
 }: {
   acts: readonly WorkspaceTrayAction[];
+  change?: WorkspaceTrayChange | undefined;
   writes: SessionWriteHandlers;
 }): React.JSX.Element {
   const [pendingAction, setPendingAction] = useState<string | undefined>(undefined);
@@ -368,6 +379,18 @@ function WorkspaceTrayActs({
     [writes],
   );
 
+  const openChange = useCallback(async () => {
+    if (!change) return;
+    const result = await writes.openChange(change.session);
+    // An opened page is its own answer; only a failure needs the line.
+    if (result.status === SESSION_OPEN_RESULT_STATUS.OPENED) return;
+    setFeedback(
+      result.status === SESSION_OPEN_RESULT_STATUS.REJECTED
+        ? result.reason
+        : "The workspace no longer reports a pull request.",
+    );
+  }, [change, writes]);
+
   return (
     <>
       {acts.map((act) => (
@@ -379,6 +402,19 @@ function WorkspaceTrayActs({
           onRun={() => void run(act)}
         />
       ))}
+      {change ? (
+        <button
+          type="button"
+          className="row-action"
+          title="Open the pull request this workspace published"
+          // Opening the pull request hands an address to the system, not a
+          // write to a provider, so it stays offered while a provider write is
+          // in flight.
+          onClick={() => void openChange()}
+        >
+          {change.changeNumber !== undefined ? `#${change.changeNumber}` : "Pull request"}
+        </button>
+      ) : null}
       {feedback ? <small className="row-feedback">{feedback}</small> : null}
     </>
   );
@@ -415,6 +451,7 @@ function SessionRow({
   now,
   leaving,
   inWorkspaceTray = false,
+  changeInTrayHeader = false,
   highlight,
   onOpen,
   onOpenApplication,
@@ -426,6 +463,9 @@ function SessionRow({
   leaving: boolean;
   /** Whether this row is drawn inside its workspace's tray. */
   inWorkspaceTray?: boolean;
+  /** Whether the tray's header carries the workspace's one pull-request chip,
+   * so this row leaves its own report unsaid. */
+  changeInTrayHeader?: boolean;
   /** The search's words, marked on the row's lines so it says why it matched. */
   highlight?: readonly string[] | undefined;
   onOpen: (session: DisplaySession) => void;
@@ -440,7 +480,10 @@ function SessionRow({
   const actions = inWorkspaceTray
     ? session.actions.filter((action) => !actsOnWorkspace(session, action))
     : session.actions;
-  const withActions = session.canMessage || actions.length > 0 || session.hasChange;
+  // The workspace's pull request is the tray header's chip on the same terms:
+  // repeated on every chat of the branch it read as several changes.
+  const withChange = session.hasChange && !changeInTrayHeader;
+  const withActions = session.canMessage || actions.length > 0 || withChange;
   const shared = {
     className: "session-row",
     "data-state": session.urgency,
@@ -636,7 +679,12 @@ function SessionRow({
       ) : (
         <div className="row-main">{content}</div>
       )}
-      <SessionRowActions session={session} actions={actions} writes={writes} />
+      <SessionRowActions
+        session={session}
+        actions={actions}
+        withChange={withChange}
+        writes={writes}
+      />
     </article>
   );
 }
@@ -663,7 +711,8 @@ export function runDrawsTray(run: SessionListRun): boolean {
  * window — but it does carry the acts that belong to the workspace rather
  * than to any one chat: an archive files away every chat in the tray, so its
  * chip sits where the workspace is named once instead of on each row it
- * would empty. The header names the tray in the reading order the same way
+ * would empty, and the one pull request the chats share sits beside it on the
+ * same reasoning. The header names the tray in the reading order the same way
  * it does on screen: the workspace once, then its chats. A tray is a member of the
  * arrival stack in its rows' stead: it fans in at its lead row's turn, and
  * the rows ride it rather than fanning a second time inside it. A wrapper
@@ -672,6 +721,7 @@ export function runDrawsTray(run: SessionListRun): boolean {
 function SessionRun({
   run,
   sessions,
+  change,
   highlight,
   writes,
   children,
@@ -681,6 +731,10 @@ function SessionRun({
    * read from and carried through. A leaving row's session is already gone
    * from the model, so it can neither offer an act nor carry one. */
   sessions: readonly DisplaySession[];
+  /** The workspace's one pull request, when the header carries it. Handed in
+   * rather than read here, because the rows suppressing their own chips must
+   * answer to the same reading. */
+  change?: WorkspaceTrayChange | undefined;
   /** The search's words, marked on the tray's own header lines too. */
   highlight?: readonly string[] | undefined;
   writes: SessionWriteHandlers;
@@ -726,7 +780,9 @@ function SessionRun({
               </span>
             ) : null}
           </span>
-          {acts.length > 0 ? <WorkspaceTrayActs acts={acts} writes={writes} /> : null}
+          {acts.length > 0 || change ? (
+            <WorkspaceTrayActs acts={acts} {...(change ? { change } : undefined)} writes={writes} />
+          ) : null}
         </header>
       ) : null}
       {children}
@@ -935,11 +991,13 @@ export function PanelBody({
                     (row): row is RosterRow<DisplaySession> => row !== undefined && !row.leaving,
                   )
                   .map((row) => row.item);
+                const change = tray ? workspaceTrayChange(living) : undefined;
                 return (
                   <SessionRun
                     key={runKeys[at]}
                     run={run}
                     sessions={living}
+                    {...(change ? { change } : undefined)}
                     highlight={highlight}
                     writes={writes}
                   >
@@ -953,6 +1011,7 @@ export function PanelBody({
                           now={now}
                           leaving={row.leaving}
                           inWorkspaceTray={tray}
+                          changeInTrayHeader={change !== undefined}
                           highlight={highlight}
                           onOpen={onOpenSession}
                           onOpenApplication={onOpenSessionApplication}

--- a/apps/desktop/src/renderer/session-model.test.ts
+++ b/apps/desktop/src/renderer/session-model.test.ts
@@ -38,6 +38,7 @@ import {
   tallyValue,
   toggledSessionFilters,
   workspaceTrayActions,
+  workspaceTrayChange,
 } from "./session-model";
 
 const CLAUDE_PROVIDER = { id: PROVIDER_ID.CLAUDE_CODE, displayName: "Claude Code" };
@@ -1090,6 +1091,62 @@ test("an ungrouped session's acts never read as a workspace's", () => {
   assert.ok(action);
   assert.equal(actsOnWorkspace(row, action), false);
   assert.deepEqual(workspaceTrayActions([row]), []);
+});
+
+// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+test("a tray's shared pull request is said once, through the chat that reported it", () => {
+  const chatOf = (id: string, change?: string) =>
+    normalizeSession(CONDUCTOR_PROVIDER, {
+      providerSessionId: id,
+      title: `Chat ${id}`,
+      status: SESSION_STATUS.COMPLETE,
+      observedAt: 1_000,
+      ...(change ? { detail: { change } } : undefined),
+      workspace: { providerWorkspaceId: "workspace-lisbon", name: "lisbon-v2" },
+    });
+  const changeUrl = "https://github.com/example/luke/pull/245";
+
+  // Every chat reporting the one change collapses to one header chip, opened
+  // through the first chat that reported it.
+  const shared = displaySessions(bootstrap(false), [
+    chatOf("chat-one", changeUrl),
+    chatOf("chat-two", changeUrl),
+  ]);
+  const hoisted = workspaceTrayChange(shared);
+  assert.equal(hoisted?.session.id, "chat-one");
+  assert.equal(hoisted?.changeNumber, 245);
+
+  // A single reporting chat is trivially the workspace's one change, even
+  // when its address names no number for the chip to wear.
+  const lone = displaySessions(bootstrap(false), [
+    chatOf("chat-one", "https://github.com/example/luke/pulls"),
+    chatOf("chat-two"),
+  ]);
+  const loneHoisted = workspaceTrayChange(lone);
+  assert.equal(loneHoisted?.session.id, "chat-one");
+  assert.equal(loneHoisted?.changeNumber, undefined);
+
+  // Two chats naming different numbers are two changes; the header offering
+  // one would hide the other, so each stays on its own row.
+  const differing = displaySessions(bootstrap(false), [
+    chatOf("chat-one", changeUrl),
+    chatOf("chat-two", "https://github.com/example/luke/pull/246"),
+  ]);
+  assert.equal(workspaceTrayChange(differing), undefined);
+
+  // Reports the numbers cannot compare may be one change or two, and the
+  // header must not gamble on which; they stay on their rows.
+  const unnumbered = displaySessions(bootstrap(false), [
+    chatOf("chat-one", changeUrl),
+    chatOf("chat-two", "https://github.com/example/luke/pulls"),
+  ]);
+  assert.equal(workspaceTrayChange(unnumbered), undefined);
+
+  // A tray with no reported change offers no chip at all.
+  assert.equal(
+    workspaceTrayChange(displaySessions(bootstrap(false), [chatOf("chat-one")])),
+    undefined,
+  );
 });
 
 test("a row carries its workspace by name, falling back to the id", () => {

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -1014,6 +1014,41 @@ export function workspaceTrayActions(
   return [...acts.values()];
 }
 
+/** The tray header's pull request, and the chat whose report carries it. */
+export interface WorkspaceTrayChange {
+  session: DisplaySession;
+  changeNumber?: number;
+}
+
+/**
+ * The pull request a tray's header offers: a workspace's chats work one
+ * branch, so each chat reporting the change draws the same chip and the tray
+ * reads as several pull requests when every press opens the one — the header
+ * says it once, where the workspace is named once. Hoisted only while the
+ * reports are provably one change: a single reporting chat, or every report
+ * naming the same number. Two chats naming different numbers are two changes,
+ * and reports the numbers cannot compare stay on their own rows rather than
+ * letting the header stand one chip for what may be two. The first reporting
+ * chat is the one the press travels through, which keeps the open validated
+ * against the same roster row that reported it.
+ */
+export function workspaceTrayChange(
+  sessions: readonly DisplaySession[],
+): WorkspaceTrayChange | undefined {
+  const reporting = sessions.filter((session) => session.hasChange);
+  const [first] = reporting;
+  if (!first) return undefined;
+  const oneChange =
+    reporting.length === 1 ||
+    (first.changeNumber !== undefined &&
+      reporting.every((session) => session.changeNumber === first.changeNumber));
+  if (!oneChange) return undefined;
+  return {
+    session: first,
+    ...(first.changeNumber !== undefined ? { changeNumber: first.changeNumber } : undefined),
+  };
+}
+
 export function sessionListRuns(sessions: readonly DisplaySession[]): readonly SessionListRun[] {
   const runs: SessionListRun[] = [];
   for (let index = 0; index < sessions.length; index += 1) {

--- a/packages/fixtures/src/fixtures.ts
+++ b/packages/fixtures/src/fixtures.ts
@@ -160,7 +160,9 @@ const smokeFixture: FixtureSnapshot = {
     // into one card in the one screenshot the evidence is reviewed from —
     // each row led by the agent's own mark and trailed by the Conductor mark
     // that opens its exact chat, with the tray header carrying the manager's
-    // mark once the way a Superset workspace carries its own.
+    // mark once the way a Superset workspace carries its own. Both chats
+    // report the workspace's one pull request, so the same screenshot proves
+    // the chip is said once on the tray header rather than on each row.
     {
       id: "conductor-chat-package",
       title: "amber-shoal",
@@ -181,6 +183,8 @@ const smokeFixture: FixtureSnapshot = {
       urgency: SESSION_URGENCY.WORKING,
       location: SESSION_LOCATION.CLOUD,
       observedAt: minutesBeforeEpoch(6),
+      hasChange: true,
+      changeNumber: 245,
       workspace: {
         id: "conductor-lisbon",
         name: "lisbon-v2",
@@ -213,6 +217,8 @@ const smokeFixture: FixtureSnapshot = {
       urgency: SESSION_URGENCY.COMPLETE,
       location: SESSION_LOCATION.CLOUD,
       observedAt: minutesBeforeEpoch(1),
+      hasChange: true,
+      changeNumber: 245,
       workspace: {
         id: "conductor-lisbon",
         name: "lisbon-v2",


### PR DESCRIPTION
## Summary

- A workspace's chats work one branch, so each chat reporting the published change drew the same pull-request chip and a tray read as several pull requests when every press opened the one. The tray header now carries the chip once, beside the workspace-level acts and on their reasoning, with failures answering on the header's own feedback line and rows inside the tray leaving their own report unsaid.
- The hoist is bounded to what is provably one change: a single reporting chat, or every reporting chat naming the same pull-request number. Two chats naming different numbers are two changes, and reports the numbers cannot compare may be one or two, so both cases keep the chip on each row rather than letting the header stand one chip for what may be two. The press travels through the first chat that reported the change, keeping the open validated against the same roster row (`workspaceTrayChange` in `session-model.ts`, mirroring `workspaceTrayActions`).
- A single-chat workspace and an ungrouped session keep the chip on the row, since no tray names them.
- The smoke fixture's two Conductor chats of `lisbon-v2` now share change `#245`, so the one evidence screenshot proves the chip is said once on the tray header; the ungrouped Cursor row still proves the row placement.
- The guide's session-list and workspace facts now say where the chip sits, so Luke describes the surface as drawn.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (exit 0, every package test suite reports `fail 0`; includes the new `workspaceTrayChange` hoisting/refusal tests)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — authored in a Linux cloud workspace with no macOS host; relying on CI's macOS validation and visual evidence

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed` (no physical Mac available in this environment)
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: inspect the CI-generated visual evidence for the `#245` chip on the lisbon-v2 tray header — and its absence from the two rows inside — before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/cb0ebb6d-600d-44c3-9ad4-108a21704c9f)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32530122697/artifacts/9463642011) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32530122697)

- Commit: `fd4d532750ffb62890f0dd3be8adb39d70cf62a5`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
