### PR TITLE
feat(panel): lead the wing's marks with the app holding each chat

### DIFF
--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -163,8 +163,9 @@ export function countBadgeFit(
 }
 
 /**
- * The wing's strip, as slots: each provider's mark, then — when the
- * providers outnumber the slots — the count standing in for the rest. The
+ * The wing's strip, as slots: the mark of each app holding tracked work,
+ * then — when the apps outnumber the slots — the count standing in for the
+ * rest. The
  * marks are a summary, and a summary that hides its own remainder reads as a
  * complete list, so whatever does not fit is counted rather than dropped. The
  * count is a slot like any other, so it takes the last one rather than being

--- a/apps/desktop/src/renderer/session-model.test.ts
+++ b/apps/desktop/src/renderer/session-model.test.ts
@@ -274,7 +274,7 @@ test("a speaking disposition needs a person even while the session works", () =>
   assert.equal(session?.urgency, SESSION_URGENCY.ATTENTION);
 });
 
-test("the tally counts per state and per provider", () => {
+test("the tally counts per state and per app", () => {
   const tally = sessionTally(displaySessions(bootstrap(true), []));
 
   assert.deepEqual(
@@ -293,35 +293,36 @@ test("the tally counts per state and per provider", () => {
       providers: undefined,
     },
   );
-  // Providers follow the order their most urgent session takes, and a hosted
-  // chat counts under the agent having the conversation: Conductor's working
-  // Claude chat counts beside the local Claude Code session under one mark,
-  // while its agent-less chat stays under Conductor's own. Five is one more
-  // than the wings hold, so the fixture also proves the remainder is counted
-  // rather than dropped.
+  // Apps follow the order their most urgent session takes, and a chat counts
+  // under the app holding it: both Conductor chats land under Conductor's
+  // mark whatever agent runs them, the Codex chat under ChatGPT, its lead
+  // app, and a chat no app holds — the local Claude Code session, the Devin
+  // cloud session — under its provider's own. Five is one more than the
+  // wings hold, so the fixture also proves the remainder is counted rather
+  // than dropped.
   assert.deepEqual(tally.providers, [
-    { providerId: PROVIDER_ID.CLAUDE_CODE, provider: "Claude Code", total: 2, attention: 1 },
-    { providerId: PROVIDER_ID.CODEX, provider: "Codex", total: 1, attention: 0 },
-    { providerId: PROVIDER_ID.CURSOR, provider: "Cursor", total: 1, attention: 0 },
-    { providerId: PROVIDER_ID.CONDUCTOR, provider: "Conductor", total: 1, attention: 0 },
+    { providerId: PROVIDER_ID.CLAUDE_CODE, provider: "Claude Code", total: 1, attention: 1 },
+    { providerId: SESSION_APPLICATION_ID.CHATGPT, provider: "ChatGPT", total: 1, attention: 0 },
+    { providerId: SESSION_APPLICATION_ID.CONDUCTOR, provider: "Conductor", total: 2, attention: 0 },
+    { providerId: SESSION_APPLICATION_ID.CURSOR, provider: "Cursor", total: 1, attention: 0 },
     { providerId: PROVIDER_ID.DEVIN, provider: "Devin", total: 1, attention: 0 },
   ]);
 });
 
 // The wing's marks and the rows are two drawings of the same order, so
-// choosing the other sort re-seats the providers with the sessions: a mark
-// that stayed put while the rows re-sorted would name the top row's agent
-// wrong. The counts are counts, and no ordering may change them.
-test("the providers re-seat with the rows when the other sort is chosen", () => {
+// choosing the other sort re-seats the apps with the sessions: a mark that
+// stayed put while the rows re-sorted would name the top row's app wrong.
+// The counts are counts, and no ordering may change them.
+test("the apps re-seat with the rows when the other sort is chosen", () => {
   const recent = sessionTally(FIXTURE_SESSIONS, SESSION_SORT.RECENCY);
 
   assert.deepEqual(
     recent.providers.map((provider) => provider.providerId),
     [
-      PROVIDER_ID.CONDUCTOR,
-      PROVIDER_ID.CODEX,
+      SESSION_APPLICATION_ID.CONDUCTOR,
+      SESSION_APPLICATION_ID.CHATGPT,
       PROVIDER_ID.CLAUDE_CODE,
-      PROVIDER_ID.CURSOR,
+      SESSION_APPLICATION_ID.CURSOR,
       PROVIDER_ID.DEVIN,
     ],
   );
@@ -1473,11 +1474,12 @@ test("a hosted chat carries its agent for the mark, the chips, and the search", 
     ["conductor-claude"],
   );
 
-  // The wing counts the chat under the agent having the conversation.
+  // The wing counts the chat under the app holding it — here the hosting
+  // provider itself, since no app association was reported — not the agent.
   const tally = sessionTally(rows);
   assert.deepEqual(
     tally.providers.map((provider) => provider.providerId),
-    [PROVIDER_ID.CLAUDE_CODE, PROVIDER_ID.CODEX],
+    [PROVIDER_ID.CONDUCTOR, PROVIDER_ID.CODEX],
   );
 });
 

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -482,7 +482,7 @@ export interface SessionTally {
   idle: number;
   /** The urgency the count badge and the notch capsule adopt. */
   urgency: SessionUrgency;
-  /** One agent each, seated where its first session reads under the sort. */
+  /** One app each, seated where its first session reads under the sort. */
   providers: readonly ProviderTally[];
 }
 
@@ -1105,8 +1105,8 @@ export function arrangeSessions(
 
 /**
  * Counted across everything tracked, whatever the list is narrowed to — but
- * read in the sort the list is read in, so the providers sit in the order
- * their first sessions do and the wing's marks match the rows. With no view in
+ * read in the sort the list is read in, so the apps sit in the order their
+ * first sessions do and the wing's marks follow the rows. With no view in
  * force — the capsule, say — the sessions read by urgency, which is also the
  * sort the panel opens on.
  */
@@ -1126,12 +1126,15 @@ export function sessionTally(
     else if (session.urgency === SESSION_URGENCY.COMPLETE) counts.complete += 1;
     else counts.idle += 1;
 
-    // The wing draws the agent having the conversation, the same identity the
-    // row's own mark leads with, so a hosted chat counts under its agent.
-    const markId = session.agentId ?? session.providerId;
+    // The wing draws the app holding the chat — the lead of the row's own
+    // application marks, which the workspace manager already heads — so the
+    // strip says where the tracked work is held rather than which agent runs
+    // it. A chat no app holds still counts under its provider's own mark.
+    const application = session.applications[0];
+    const markId = application?.id ?? session.providerId;
     const tally = providers.get(markId) ?? {
       providerId: markId,
-      provider: session.agent ?? session.provider,
+      provider: application?.name ?? session.provider,
       total: 0,
       attention: 0,
     };

--- a/apps/web/src/NotchMock.tsx
+++ b/apps/web/src/NotchMock.tsx
@@ -73,10 +73,14 @@ const TALLY_URGENCY: SessionUrgency =
 const TALLY_CAPTION =
   ATTENTION_COUNT > 0 ? `${ATTENTION_COUNT} ${ATTENTION_COUNT === 1 ? "needs" : "need"} you` : "";
 
-/** Providers in the order the wing draws them: first to need a person first. */
-const WING_PROVIDERS = MOCK_SESSIONS.map((session) => session.providerId).filter(
-  (providerId, index, all) => all.indexOf(providerId) === index,
-);
+/**
+ * The wing's marks as the renderer's `sessionTally` seats them, first to need
+ * a person first: each chat counts under the app holding it — the lead of its
+ * application marks — or under its provider's own where no app holds one.
+ */
+const WING_PROVIDERS = MOCK_SESSIONS.map(
+  (session) => session.applications?.[0]?.id ?? session.providerId,
+).filter((markId, index, all) => all.indexOf(markId) === index);
 
 /**
  * `wingMarkCapacity` and its constants in the renderer's notch-wings.tsx: what

--- a/apps/web/src/provider-marks.tsx
+++ b/apps/web/src/provider-marks.tsx
@@ -1,4 +1,4 @@
-import { PROVIDER_ID } from "@sidecar/session";
+import { PROVIDER_ID, SESSION_APPLICATION_ID } from "@sidecar/session";
 import {
   CLAUDE_CODE_PATH,
   CLOUD_BADGE_PATH,
@@ -6,6 +6,7 @@ import {
   CONDUCTOR_MARK_PATHS,
   CURSOR_PATH,
   DEVIN_PATH,
+  OPENAI_PATH,
 } from "@sidecar/surface";
 import { useId } from "react";
 
@@ -14,15 +15,17 @@ import { useId } from "react";
  * `@sidecar/surface` from `design/generate-surface-shared.mjs`, the same table
  * the desktop renderer reads, so a provider publishing an updated mark cannot
  * land in one surface and not the other. The React that traces it stays here:
- * the mock only needs the five the smoke fixture uses, plus the badge that
+ * the mock only needs what the smoke fixture draws — the five providers its
+ * rows lead with, the apps its wing counts them under, plus the badge that
  * rides them.
  *
  * Each is the provider's own mark, reproduced rather than redrawn — Claude
  * Code via Simple Icons (CC0-1.0, sourced from code.claude.com), Codex via
  * @lobehub/icons (MIT), Conductor's letter mark verbatim from the published
  * brand kit at https://www.conductor.build/brandkit, Cursor via Simple Icons
- * (CC0-1.0, sourced from https://cursor.com/brand), and Devin's verbatim from
- * the mark https://devin.ai serves as its own favicon and site header. Each
+ * (CC0-1.0, sourced from https://cursor.com/brand), Devin's verbatim from
+ * the mark https://devin.ai serves as its own favicon and site header, and
+ * ChatGPT's OpenAI mark via Simple Icons (CC0-1.0). Each
  * keeps its own brand colour (see the `--mark-*` custom properties). Cursor
  * and Devin publish one silhouette rather than a colour, so both are drawn in
  * the light form their brand uses on a dark surface. They are trademarks of
@@ -126,6 +129,20 @@ function DevinMark({ className }: MarkProps): React.JSX.Element {
   );
 }
 
+function ChatGptMark({ className }: MarkProps): React.JSX.Element {
+  return (
+    <svg
+      className={className}
+      data-mark={SESSION_APPLICATION_ID.CHATGPT}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path fill="currentColor" d={OPENAI_PATH} />
+    </svg>
+  );
+}
+
 /** Drawn here, not a brand: a provider the mock has no mark for still needs a slot. */
 function UnknownProviderMark({ className }: MarkProps): React.JSX.Element {
   return (
@@ -138,9 +155,12 @@ function UnknownProviderMark({ className }: MarkProps): React.JSX.Element {
 
 const PROVIDER_MARKS = new Map<string, (props: MarkProps) => React.JSX.Element>([
   [PROVIDER_ID.CLAUDE_CODE, ClaudeCodeMark],
+  [SESSION_APPLICATION_ID.CHATGPT, ChatGptMark],
   [PROVIDER_ID.CODEX, CodexMark],
   [PROVIDER_ID.CONDUCTOR, ConductorMark],
   [PROVIDER_ID.CURSOR, CursorMark],
+  // Cursor the app draws Cursor's own mark, exactly as the desktop maps it.
+  [SESSION_APPLICATION_ID.CURSOR, CursorMark],
   [PROVIDER_ID.DEVIN, DevinMark],
 ]);
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -620,6 +620,10 @@
   transform: scale(0.94);
 }
 
+.mock .provider-mark[data-mark="chatgpt"] {
+  transform: scale(0.94);
+}
+
 .mock .provider-mark[data-mark="conductor"] {
   color: var(--mark-conductor);
   transform: scale(0.93);

--- a/packages/fixtures/src/fixtures.ts
+++ b/packages/fixtures/src/fixtures.ts
@@ -192,9 +192,9 @@ const smokeFixture: FixtureSnapshot = {
     // among the least urgent, so the fixture tells the two orderings apart
     // rather than agreeing with both. A provider that reported no activity,
     // failure, or recap: the surface words the state itself, and this row is
-    // what proves it does. Its agent went unreported, so the Conductor mark
-    // stands in for the agent's — the honest fallback this row is also proof
-    // of — which keeps the fixture at five distinct wing marks.
+    // what proves it does. Its agent went unreported, so the row's mark falls
+    // back to the Conductor mark — the honest fallback this row is also proof
+    // of.
     {
       id: "conductor-chat-tidy",
       title: "gentle-cove",
@@ -250,12 +250,14 @@ const smokeFixture: FixtureSnapshot = {
       hasChange: true,
       changeNumber: 31,
     },
-    // A fifth session keeps every state and every provider mark visible in the
-    // one screenshot the visual evidence is reviewed from. It is also one more
-    // provider than the wings hold — the face has the place nearest the
-    // housing — so the same screenshot proves the remainder is counted rather
-    // than dropped. Reporting a repository and no branch, it is also the row
-    // that shows the identifier line falling back.
+    // A fifth session keeps every state visible in the one screenshot the
+    // visual evidence is reviewed from, and keeps the wing at five distinct
+    // marks — the apps holding the fixture's chats, and this provider's own
+    // where no app holds one. That is one more mark than the wings hold — the
+    // face has the place nearest the housing — so the same screenshot proves
+    // the remainder is counted rather than dropped. Reporting a repository
+    // and no branch, it is also the row that shows the identifier line
+    // falling back.
     {
       id: "devin-session",
       title: "Watch a cloud session",


### PR DESCRIPTION
## What

The strip beside the housing (the left wing's marks) counted sessions by the agent having the conversation. It now counts each chat under the app holding it — the lead of the row's own application marks, which the workspace manager already heads — falling back to the provider's own mark for a chat no app holds. Two Conductor chats run by different agents now draw one Conductor mark, and a Codex chat held by ChatGPT draws ChatGPT's, so the strip says what apps the tracked work sits in rather than which agents run it.

The session rows are unchanged: each still leads with the agent's mark and trails the app marks.

## How

- `sessionTally` seats each session under `applications[0]?.id ?? providerId` (name from the same lead), and the comments around the wing state the new rule.
- The fixture comments stop claiming the wing's five marks rest on the agent fallback; the smoke fixture still draws five distinct marks (Claude Code, ChatGPT, Conductor, Cursor, Devin), one more than the wings hold, so the overflow count stays in the evidence.
- The web hero mock's wing follows the same rule, growing a ChatGPT mark (OpenAI path, Simple Icons CC0-1.0) and the Cursor-app mapping its fixture now needs, with the matching `data-mark` scale rule.

## Testing

- `./scripts/check.sh` passes (desktop: 723 tests, 0 failures).
- `./scripts/verify.sh` could not run here (Linux sandbox); CI's macOS job generates and links the visual evidence. No physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/1917c325-f198-497f-90ba-8d20c20928f5)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32530743850/artifacts/9463807601) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32530743850)

- Commit: `5a912cb46f2715889d619fe658e75482e4a2edc8`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
