### PR TITLE
feat(admin): let an admin star accounts on the Users roster

### DIFF
--- a/apps/web/api/admin/favorite.ts
+++ b/apps/web/api/admin/favorite.ts
@@ -1,0 +1,21 @@
+import { handleAdminFavorite } from "../../server/admin/admin-favorite.js";
+import { writeAdminFavorite } from "../../server/admin/admin-queries.js";
+import { resolveSessionViewer } from "../../server/admin/viewer.js";
+import { getDatabase } from "../../server/db/index.js";
+
+/**
+ * The Users tab's star write: PUT favorites the named account for the signed-in
+ * admin, DELETE takes the star back. The logic lives behind seams in
+ * `server/admin/`; this file hands it the deployment's real session resolver
+ * and database.
+ */
+export default {
+  fetch(request: Request): Promise<Response> {
+    return handleAdminFavorite({
+      request,
+      resolveViewer: resolveSessionViewer,
+      writeFavorite: (adminId, userId, favorite) =>
+        writeAdminFavorite(getDatabase(), { adminId, userId, favorite }),
+    });
+  },
+};

--- a/apps/web/api/admin/users.ts
+++ b/apps/web/api/admin/users.ts
@@ -14,8 +14,11 @@ export default {
     return handleAdminUsers({
       request,
       resolveViewer: resolveSessionViewer,
-      readUsers: async (now, scope) =>
-        buildAdminUserList(await readAdminUsersSource(getDatabase(), { now, scope }), now),
+      readUsers: async (now, scope, viewerId) =>
+        buildAdminUserList(
+          await readAdminUsersSource(getDatabase(), { now, scope, viewerId }),
+          now,
+        ),
     });
   },
 };

--- a/apps/web/drizzle/0003_little_purifiers.sql
+++ b/apps/web/drizzle/0003_little_purifiers.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "admin_favorite" (
+	"admin_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	CONSTRAINT "admin_favorite_admin_id_user_id_pk" PRIMARY KEY("admin_id","user_id")
+);
+--> statement-breakpoint
+ALTER TABLE "admin_favorite" ADD CONSTRAINT "admin_favorite_admin_id_user_id_fk" FOREIGN KEY ("admin_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "admin_favorite" ADD CONSTRAINT "admin_favorite_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/apps/web/drizzle/meta/0003_snapshot.json
+++ b/apps/web/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1188 @@
+{
+  "id": "f8107a07-4172-40d2-bff1-4756039d6caf",
+  "prevId": "768dba2c-68bf-451b-ae4c-aff7a32e6ef3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": ["refresh_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_login_method": {
+          "name": "last_login_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_favorite": {
+      "name": "admin_favorite",
+      "schema": "",
+      "columns": {
+        "admin_id": {
+          "name": "admin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_favorite_admin_id_user_id_fk": {
+          "name": "admin_favorite_admin_id_user_id_fk",
+          "tableFrom": "admin_favorite",
+          "tableTo": "user",
+          "columnsFrom": ["admin_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admin_favorite_user_id_user_id_fk": {
+          "name": "admin_favorite_user_id_user_id_fk",
+          "tableFrom": "admin_favorite",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "admin_favorite_admin_id_user_id_pk": {
+          "name": "admin_favorite_admin_id_user_id_pk",
+          "columns": ["admin_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosted_usage": {
+      "name": "hosted_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voice_calls": {
+          "name": "voice_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attention_reviews": {
+          "name": "attention_reviews",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hosted_usage_user_id_user_id_fk": {
+          "name": "hosted_usage_user_id_user_id_fk",
+          "tableFrom": "hosted_usage",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "hosted_usage_user_id_day_pk": {
+          "name": "hosted_usage_user_id_day_pk",
+          "columns": ["user_id", "day"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1787274933957,
       "tag": "0002_living_zarek",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1787350737457,
+      "tag": "0003_little_purifiers",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/server/admin/admin-favorite.ts
+++ b/apps/web/server/admin/admin-favorite.ts
@@ -1,0 +1,71 @@
+import type { AdminViewer } from "./admin-access.js";
+import { isAdminRole } from "./admin-access.js";
+import {
+  ADMIN_ERROR,
+  ADMIN_HTTP_STATUS,
+  adminUserId,
+  errorResponse,
+  jsonResponse,
+} from "./http.js";
+
+/**
+ * The one thing an admin may write about an account: whether it is a favorite
+ * of theirs. The mark belongs to the viewer alone — the handler takes the
+ * admin's identity from the same session the gate already resolved, never from
+ * the request — and the method is the whole ask: PUT sets the star, DELETE
+ * takes it back, and either lands twice without complaint, because a star
+ * already where the press put it is the outcome the press wanted.
+ */
+
+export interface AdminFavoriteOptions {
+  request: Request;
+  resolveViewer: (request: Request) => Promise<AdminViewer | undefined>;
+  /**
+   * Sets whether the viewer favorites the named account; false when no user
+   * row carries that id, so the page can word a stale roster rather than an
+   * outage.
+   */
+  writeFavorite: (adminId: string, userId: string, favorite: boolean) => Promise<boolean>;
+}
+
+/**
+ * Answers the star write behind the same gate and refusals the roster read
+ * stands behind, plus the detail read's two: a request that named no account
+ * is a 400 before any seam is touched, and an id no user row carries is a 404.
+ */
+export async function handleAdminFavorite(options: AdminFavoriteOptions): Promise<Response> {
+  const { request } = options;
+  const favorite =
+    request.method === "PUT" ? true : request.method === "DELETE" ? false : undefined;
+  if (favorite === undefined) {
+    return errorResponse(ADMIN_HTTP_STATUS.METHOD_NOT_ALLOWED, ADMIN_ERROR.METHOD_NOT_ALLOWED);
+  }
+
+  let viewer: AdminViewer | undefined;
+  try {
+    viewer = await options.resolveViewer(request);
+  } catch {
+    return errorResponse(ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE, ADMIN_ERROR.UNAVAILABLE);
+  }
+  if (!viewer) {
+    return errorResponse(ADMIN_HTTP_STATUS.UNAUTHORIZED, ADMIN_ERROR.NOT_SIGNED_IN);
+  }
+  if (!isAdminRole(viewer.role)) {
+    return errorResponse(ADMIN_HTTP_STATUS.FORBIDDEN, ADMIN_ERROR.NOT_AUTHORIZED);
+  }
+
+  const userId = adminUserId(request.url);
+  if (userId === undefined) {
+    return errorResponse(ADMIN_HTTP_STATUS.BAD_REQUEST, ADMIN_ERROR.MISSING_USER_ID);
+  }
+
+  try {
+    const found = await options.writeFavorite(viewer.userId, userId, favorite);
+    if (!found) {
+      return errorResponse(ADMIN_HTTP_STATUS.NOT_FOUND, ADMIN_ERROR.USER_NOT_FOUND);
+    }
+    return jsonResponse(ADMIN_HTTP_STATUS.OK, { favorite });
+  } catch {
+    return errorResponse(ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE, ADMIN_ERROR.UNAVAILABLE);
+  }
+}

--- a/apps/web/server/admin/admin-queries.ts
+++ b/apps/web/server/admin/admin-queries.ts
@@ -13,6 +13,7 @@ import {
   sql,
   sum,
 } from "drizzle-orm";
+import { adminFavorite } from "../db/favorite-schema.js";
 import type { createDatabase } from "../db/index.js";
 import { account, session, user } from "../db/schema.js";
 import { hostedUsage } from "../db/usage-schema.js";
@@ -404,7 +405,7 @@ export async function readAdminUserSource(
  */
 export async function readAdminUsersSource(
   database: Database,
-  input: { now: number; scope: AdminMetricsScope },
+  input: { now: number; scope: AdminMetricsScope; viewerId: string },
 ): Promise<AdminUserListSource> {
   const dayKeys = lastNDayKeys(input.now, ADMIN_METRICS_WINDOW_DAYS);
   const windowStartDay = dayKeys[0] ?? utcDayKey(input.now);
@@ -428,11 +429,18 @@ export async function readAdminUsersSource(
         lastActiveDay: sql<string | null>`max(${hostedUsage.day})`,
         voiceCalls: sum(hostedUsage.voiceCalls),
         attentionReviews: sum(hostedUsage.attentionReviews),
+        // At most one star row joins per account, so aggregating its presence
+        // leaves the usage aggregates' fan-out untouched.
+        favorite: sql<boolean>`bool_or(${adminFavorite.adminId} is not null)`,
       })
       .from(user)
       .leftJoin(
         hostedUsage,
         and(eq(hostedUsage.userId, user.id), gte(hostedUsage.day, windowStartDay)),
+      )
+      .leftJoin(
+        adminFavorite,
+        and(eq(adminFavorite.userId, user.id), eq(adminFavorite.adminId, input.viewerId)),
       )
       .where(scopeCondition(input.scope))
       .groupBy(user.id, user.name, user.email, user.role, user.createdAt)
@@ -458,6 +466,37 @@ export async function readAdminUsersSource(
       lastSeenAt: lastSeenByUser.get(row.id)?.getTime() ?? null,
       voiceCalls: toNumber(row.voiceCalls),
       attentionReviews: toNumber(row.attentionReviews),
+      favorite: row.favorite === true,
     })),
   };
+}
+
+/**
+ * Sets whether one admin favorites one account, answering whether the account
+ * exists at all: a press on a roster the account has since left should read as
+ * the account being gone, not the write landing nowhere. Both writes land
+ * twice without complaint — the star's presence is the whole state.
+ */
+export async function writeAdminFavorite(
+  database: Database,
+  input: { adminId: string; userId: string; favorite: boolean },
+): Promise<boolean> {
+  const [target] = await database
+    .select({ id: user.id })
+    .from(user)
+    .where(eq(user.id, input.userId))
+    .limit(1);
+  if (!target) return false;
+
+  if (input.favorite) {
+    await database
+      .insert(adminFavorite)
+      .values({ adminId: input.adminId, userId: input.userId })
+      .onConflictDoNothing();
+  } else {
+    await database
+      .delete(adminFavorite)
+      .where(and(eq(adminFavorite.adminId, input.adminId), eq(adminFavorite.userId, input.userId)));
+  }
+  return true;
 }

--- a/apps/web/server/admin/admin-users.ts
+++ b/apps/web/server/admin/admin-users.ts
@@ -47,6 +47,8 @@ export interface AdminUserListRow {
   lastSeenAt: number | null;
   voiceCalls: number;
   attentionReviews: number;
+  /** Whether the viewing admin starred this account, theirs alone to see. */
+  favorite: boolean;
 }
 
 export interface AdminUserList {
@@ -78,7 +80,8 @@ export function buildAdminUserList(source: AdminUserListSource, now: number): Ad
 export interface AdminUsersOptions {
   request: Request;
   resolveViewer: (request: Request) => Promise<AdminViewer | undefined>;
-  readUsers: (now: number, scope: AdminMetricsScope) => Promise<AdminUserList>;
+  /** Reads the roster as one viewer sees it: the favorites are theirs. */
+  readUsers: (now: number, scope: AdminMetricsScope, viewerId: string) => Promise<AdminUserList>;
   now?: () => number;
 }
 
@@ -110,7 +113,7 @@ export async function handleAdminUsers(options: AdminUsersOptions): Promise<Resp
   try {
     return jsonResponse(
       ADMIN_HTTP_STATUS.OK,
-      await options.readUsers(now, adminMetricsScope(request.url)),
+      await options.readUsers(now, adminMetricsScope(request.url), viewer.userId),
     );
   } catch {
     return errorResponse(ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE, ADMIN_ERROR.UNAVAILABLE);

--- a/apps/web/server/db/favorite-schema.ts
+++ b/apps/web/server/db/favorite-schema.ts
@@ -1,0 +1,23 @@
+import { pgTable, primaryKey, text } from "drizzle-orm/pg-core";
+import { user } from "./auth-schema.js";
+
+/**
+ * One admin's own star on one account, purely a marker for the admin who set
+ * it. It lives in the database rather than the browser because it is the
+ * admin's reading of an account, not this machine's state: it follows their
+ * sign-in across browsers and never bleeds into another admin's roster on a
+ * shared one. Each row belongs to the (admin, account) pair and leaves with
+ * either side.
+ */
+export const adminFavorite = pgTable(
+  "admin_favorite",
+  {
+    adminId: text("admin_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+  },
+  (table) => [primaryKey({ columns: [table.adminId, table.userId] })],
+);

--- a/apps/web/server/db/schema.ts
+++ b/apps/web/server/db/schema.ts
@@ -1,4 +1,5 @@
 // Better Auth owns its generated schema; Luke-owned tables can join this
 // aggregate from their own schema modules without being overwritten by it.
 export * from "./auth-schema.js";
+export * from "./favorite-schema.js";
 export * from "./usage-schema.js";

--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -1827,8 +1827,14 @@ function UsersScreen({
     return () => inFlight.current?.abort();
   }, [load]);
 
-  // The star answers the press at once; a write the service refused or never
-  // received puts it back, rather than leaving a favorite nobody keeps.
+  // The star answers the press at once, while one write chain per account
+  // carries the newest intent to the service: presses faster than the network
+  // coalesce into the chain's next request instead of racing it out of order.
+  // A landed write redraws its own outcome, so a roster refresh that crossed
+  // it mid-flight cannot leave a stale star, and a failed one puts the star
+  // back only when no newer press has spoken since.
+  const favoriteIntents = useRef(new Map<string, boolean>());
+  const favoriteWriting = useRef(new Set<string>());
   const toggleFavorite = useCallback((id: string, favorite: boolean) => {
     const draw = (value: boolean) =>
       setState((current) =>
@@ -1845,15 +1851,30 @@ function UsersScreen({
           : current,
       );
     draw(favorite);
+    favoriteIntents.current.set(id, favorite);
+    if (favoriteWriting.current.has(id)) return;
+    favoriteWriting.current.add(id);
     void (async () => {
       try {
-        const response = await fetch(
-          `${FAVORITE_PATH}?${ADMIN_USER_ID_PARAM}=${encodeURIComponent(id)}`,
-          { method: favorite ? "PUT" : "DELETE", headers: { accept: "application/json" } },
-        );
-        if (!response.ok) draw(!favorite);
-      } catch {
-        draw(!favorite);
+        for (;;) {
+          const want = favoriteIntents.current.get(id);
+          if (want === undefined) return;
+          favoriteIntents.current.delete(id);
+          let landed = false;
+          try {
+            const response = await fetch(
+              `${FAVORITE_PATH}?${ADMIN_USER_ID_PARAM}=${encodeURIComponent(id)}`,
+              { method: want ? "PUT" : "DELETE", headers: { accept: "application/json" } },
+            );
+            landed = response.ok;
+          } catch {
+            landed = false;
+          }
+          if (landed) draw(want);
+          else if (!favoriteIntents.current.has(id)) draw(!want);
+        }
+      } finally {
+        favoriteWriting.current.delete(id);
       }
     })();
   }, []);

--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -36,6 +36,7 @@ const authClient = createAuthClient();
 const METRICS_PATH = "/api/admin/metrics";
 const USER_DETAIL_PATH = "/api/admin/user";
 const USERS_PATH = "/api/admin/users";
+const FAVORITE_PATH = "/api/admin/favorite";
 
 /**
  * The page's own addresses, distinct from the API's parameters so a pasted
@@ -1479,14 +1480,32 @@ function SortableHeader({
   );
 }
 
+function StarIcon({ filled }: { filled: boolean }): React.JSX.Element {
+  return (
+    <svg
+      className="size-4 shrink-0"
+      viewBox="0 0 16 16"
+      fill={filled ? "currentColor" : "none"}
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M8 1.9l1.87 3.79 4.18.61-3.02 2.95.71 4.16L8 11.44l-3.74 1.97.71-4.16-3.02-2.95 4.18-.61L8 1.9z" />
+    </svg>
+  );
+}
+
 function UsersTable({
   rows,
   windowDays,
   onOpen,
+  onToggleFavorite,
 }: {
   rows: readonly AdminUserListRow[];
   windowDays: number;
   onOpen: (id: string) => void;
+  onToggleFavorite: (id: string, favorite: boolean) => void;
 }): React.JSX.Element {
   const [sort, setSort] = useState<UsersSort>();
   const toggleSort = (key: UsersSortKey) => {
@@ -1516,6 +1535,9 @@ function UsersTable({
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b border-border text-left font-mono text-xs text-muted-foreground uppercase">
+            <th className="w-0 py-3 pr-0 pl-5">
+              <span className="sr-only">Favorite</span>
+            </th>
             <SortableHeader
               label="Account"
               sortKey={USERS_SORT_KEY.ACCOUNT}
@@ -1570,9 +1592,24 @@ function UsersTable({
           {sorted.map((row) => (
             <tr
               key={row.id}
-              className="cursor-pointer border-b border-border transition-colors duration-150 last:border-0 hover:bg-muted"
+              className="group cursor-pointer border-b border-border transition-colors duration-150 last:border-0 hover:bg-muted"
               onClick={() => onOpen(row.id)}
             >
+              <td className="w-0 py-3 pr-0 pl-5">
+                <button
+                  type="button"
+                  className="flex cursor-pointer text-muted-foreground opacity-0 transition-opacity duration-150 outline-offset-2 group-hover:opacity-100 hover:text-foreground focus-visible:opacity-100 data-[favorite=true]:text-attention data-[favorite=true]:opacity-100"
+                  data-favorite={row.favorite}
+                  aria-pressed={row.favorite}
+                  aria-label={`${row.favorite ? "Unfavorite" : "Favorite"} ${row.name || row.email}`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onToggleFavorite(row.id, !row.favorite);
+                  }}
+                >
+                  <StarIcon filled={row.favorite} />
+                </button>
+              </td>
               <td className="px-5 py-3">
                 <a
                   href={accountHref(row.id)}
@@ -1625,6 +1662,7 @@ function UsersPage({
   account,
   onSignOut,
   onOpenAccount,
+  onToggleFavorite,
   refreshing,
   onRefresh,
   now,
@@ -1635,6 +1673,7 @@ function UsersPage({
   account: ViewerAccount | undefined;
   onSignOut: () => void;
   onOpenAccount: (id: string) => void;
+  onToggleFavorite: (id: string, favorite: boolean) => void;
   refreshing: boolean;
   onRefresh: () => void;
   now: number;
@@ -1694,14 +1733,20 @@ function UsersPage({
           </span>
         </div>
         <div className="mt-4">
-          <UsersTable rows={rows} windowDays={list.windowDays} onOpen={onOpenAccount} />
+          <UsersTable
+            rows={rows}
+            windowDays={list.windowDays}
+            onOpen={onOpenAccount}
+            onToggleFavorite={onToggleFavorite}
+          />
         </div>
         <p className="mt-3 text-sm text-muted-foreground">
           Every account the service holds, most recently active first, whether or not it ever
           touched the hosted tier — active days count the window's UTC days with hosted voice or
           attention, while last seen is the account's freshest sign-in session, which a plain
-          sign-in moves without any hosted use. A heading sorts by its column, and a row opens the
-          account's own page.
+          sign-in moves without any hosted use. A heading sorts by its column, a row opens the
+          account's own page, and a row's star favorites the account for you alone, following your
+          sign-in rather than this browser.
           {list.total > list.rows.length
             ? ` Only the ${formatNumber(list.rows.length)} most recently active accounts are listed here, and the filter searches those alone.`
             : ""}
@@ -1782,6 +1827,37 @@ function UsersScreen({
     return () => inFlight.current?.abort();
   }, [load]);
 
+  // The star answers the press at once; a write the service refused or never
+  // received puts it back, rather than leaving a favorite nobody keeps.
+  const toggleFavorite = useCallback((id: string, favorite: boolean) => {
+    const draw = (value: boolean) =>
+      setState((current) =>
+        current.status === "ready"
+          ? {
+              status: "ready",
+              list: {
+                ...current.list,
+                rows: current.list.rows.map((row) =>
+                  row.id === id ? { ...row, favorite: value } : row,
+                ),
+              },
+            }
+          : current,
+      );
+    draw(favorite);
+    void (async () => {
+      try {
+        const response = await fetch(
+          `${FAVORITE_PATH}?${ADMIN_USER_ID_PARAM}=${encodeURIComponent(id)}`,
+          { method: favorite ? "PUT" : "DELETE", headers: { accept: "application/json" } },
+        );
+        if (!response.ok) draw(!favorite);
+      } catch {
+        draw(!favorite);
+      }
+    })();
+  }, []);
+
   switch (state.status) {
     case "loading":
       return frame(<Centered title="Loading…">Reading the service's own tables.</Centered>);
@@ -1809,6 +1885,7 @@ function UsersScreen({
           account={account}
           onSignOut={() => void signOut()}
           onOpenAccount={onOpenAccount}
+          onToggleFavorite={toggleFavorite}
           refreshing={refreshing}
           onRefresh={load}
           now={now}

--- a/apps/web/tests/admin-favorite.test.ts
+++ b/apps/web/tests/admin-favorite.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AdminViewer } from "../server/admin/admin-access";
+import { type AdminFavoriteOptions, handleAdminFavorite } from "../server/admin/admin-favorite";
+import { ADMIN_ERROR, ADMIN_USER_ID_PARAM } from "../server/admin/http";
+
+const ADMIN_VIEWER: AdminViewer = { userId: "admin-1", role: "admin" };
+
+function favoriteRequest(method: string, id?: string): Request {
+  const query = id === undefined ? "" : `?${ADMIN_USER_ID_PARAM}=${encodeURIComponent(id)}`;
+  return new Request(`https://luke.test/api/admin/favorite${query}`, { method });
+}
+
+function respond(overrides: Partial<AdminFavoriteOptions> = {}): Promise<Response> {
+  return handleAdminFavorite({
+    request: favoriteRequest("PUT", "user-9"),
+    resolveViewer: async () => ADMIN_VIEWER,
+    writeFavorite: async () => true,
+    ...overrides,
+  });
+}
+
+test("only the two star methods are answered, and the gate refuses in its own words", async () => {
+  for (const method of ["GET", "POST", "PATCH"]) {
+    assert.equal((await respond({ request: favoriteRequest(method, "user-9") })).status, 405);
+  }
+
+  const anonymous = await respond({ resolveViewer: async () => undefined });
+  assert.equal(anonymous.status, 401);
+  assert.equal((await anonymous.json()).error, ADMIN_ERROR.NOT_SIGNED_IN);
+
+  const forbidden = await respond({
+    resolveViewer: async () => ({ ...ADMIN_VIEWER, role: "user" }),
+  });
+  assert.equal(forbidden.status, 403);
+  assert.equal((await forbidden.json()).error, ADMIN_ERROR.NOT_AUTHORIZED);
+});
+
+test("the write is the viewer's own star on the named account, PUT on and DELETE off", async () => {
+  const writes: Array<{ adminId: string; userId: string; favorite: boolean }> = [];
+  const writeFavorite = async (adminId: string, userId: string, favorite: boolean) => {
+    writes.push({ adminId, userId, favorite });
+    return true;
+  };
+
+  const starred = await respond({ writeFavorite });
+  assert.equal(starred.status, 200);
+  assert.equal((await starred.json()).favorite, true);
+
+  const unstarred = await respond({ request: favoriteRequest("DELETE", "user-9"), writeFavorite });
+  assert.equal(unstarred.status, 200);
+  assert.equal((await unstarred.json()).favorite, false);
+
+  assert.deepEqual(writes, [
+    { adminId: ADMIN_VIEWER.userId, userId: "user-9", favorite: true },
+    { adminId: ADMIN_VIEWER.userId, userId: "user-9", favorite: false },
+  ]);
+});
+
+test("a request naming no account is a 400 before the seam, and an unknown one a 404", async () => {
+  let written = false;
+  const writeFavorite = async () => {
+    written = true;
+    return true;
+  };
+
+  const unnamed = await respond({ request: favoriteRequest("PUT"), writeFavorite });
+  assert.equal(unnamed.status, 400);
+  assert.equal((await unnamed.json()).error, ADMIN_ERROR.MISSING_USER_ID);
+  assert.equal(written, false);
+
+  const unknown = await respond({ writeFavorite: async () => false });
+  assert.equal(unknown.status, 404);
+  assert.equal((await unknown.json()).error, ADMIN_ERROR.USER_NOT_FOUND);
+});
+
+test("a seam that throws is a 503 refusal rather than a crash", async () => {
+  const viewerThrew = await respond({
+    resolveViewer: async () => {
+      throw new Error("auth is down");
+    },
+  });
+  assert.equal(viewerThrew.status, 503);
+  assert.equal((await viewerThrew.json()).error, ADMIN_ERROR.UNAVAILABLE);
+
+  const writeThrew = await respond({
+    writeFavorite: async () => {
+      throw new Error("database is down");
+    },
+  });
+  assert.equal(writeThrew.status, 503);
+  assert.equal((await writeThrew.json()).error, ADMIN_ERROR.UNAVAILABLE);
+});

--- a/apps/web/tests/admin-users.test.ts
+++ b/apps/web/tests/admin-users.test.ts
@@ -29,6 +29,7 @@ const ROW = {
   lastSeenAt: Date.parse("2026-08-17T09:30:00.000Z"),
   voiceCalls: 120,
   attentionReviews: 400,
+  favorite: false,
 };
 
 function listSource(overrides: Partial<AdminUserListSource> = {}): AdminUserListSource {
@@ -90,10 +91,16 @@ test("the gate answers 405, 401, 403, and 200 as distinct outcomes", async () =>
   assert.equal(body.rows[0]?.id, "user-9");
 });
 
-test("the roster is read at the scope the request asked for, and not past a failed gate", async () => {
+test("the roster is read at the scope the request asked for, as the viewer, and not past a failed gate", async () => {
   const scopes: AdminMetricsScope[] = [];
-  const countingRead = async (now: number, scope: AdminMetricsScope): Promise<AdminUserList> => {
+  const viewerIds: string[] = [];
+  const countingRead = async (
+    now: number,
+    scope: AdminMetricsScope,
+    viewerId: string,
+  ): Promise<AdminUserList> => {
     scopes.push(scope);
+    viewerIds.push(viewerId);
     return readUsers(now);
   };
   const respond = (request: Request) =>
@@ -103,6 +110,7 @@ test("the roster is read at the scope the request asked for, and not past a fail
   const widened = usersRequest("GET", `?${ADMIN_METRICS_SCOPE_PARAM}=${ADMIN_METRICS_SCOPE.ALL}`);
   assert.equal((await respond(widened)).status, 200);
   assert.deepEqual(scopes, [ADMIN_METRICS_SCOPE.NON_ADMINS, ADMIN_METRICS_SCOPE.ALL]);
+  assert.deepEqual(viewerIds, [ADMIN_VIEWER.userId, ADMIN_VIEWER.userId]);
 
   const gated = await handleAdminUsers({
     request: usersRequest(),


### PR DESCRIPTION
## Summary

Admins can now favorite accounts for themselves on the Users roster. Each row leads with a star to the left of the account: **filled amber** for an account the viewing admin favorited, an **empty star on row hover** (and on keyboard focus) otherwise, toggled in place without leaving the table. The footer copy names the behavior.

**Persistence decision: the database, not localStorage.** A favorite is the admin's reading of an account, not this browser's state — localStorage would lose the stars on the admin's next machine and leak them between two admins sharing one browser, and the page's existing localStorage keys (the sign-in press, the sidebar fold) are genuinely device-local in a way a curated list is not. So:

- New `admin_favorite` table keyed `(admin_id, user_id)`, both cascading `user` references, mirroring `hosted_usage`'s shape (`favorite-schema.ts`, migration `0003_little_purifiers.sql`).
- `AdminUserListRow` gains `favorite: boolean`; `handleAdminUsers` hands the seam the gated viewer's id, and `readAdminUsersSource` left-joins the viewer's own stars — at most one star row per account, so the usage aggregates' fan-out is untouched.
- New `/api/admin/favorite` endpoint (`handleAdminFavorite`): PUT sets the star, DELETE takes it back, behind the same 405/401/403/503 gate as every admin read plus the detail read's 400 (no id named) and 404 (no such account). Both writes land twice without complaint — the star's presence is the whole state. The admin's identity comes from the resolved session, never the request.
- The page flips the star optimistically and puts it back on a refused write; the star button stops propagation so a press never opens the account page.

## Testing

- `./scripts/check.sh` passes: lint, typecheck, all tests (apps/web 92/92 including the new `admin-favorite.test.ts` gate matrix, apps/desktop 724/724), and builds.
- `pnpm db:generate` produced the migration; `db:check` runs in the suite.
- Visually inspected the served page (`vite` dev + stubbed API, headless Chrome): filled stars draw on favorited rows, the empty star appears on row hover, and a press fills it in place and it stays after the 200. (The hover affordance sits behind Tailwind's `@media (hover: hover)`, so it needed a hover-capable pointer emulated to capture.)
- Web-only admin dashboard change; no macOS surface touched, so no physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ec743864-a16b-46c1-b45c-7679a19e9b92)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32534981169/artifacts/9465162750) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32534981169)

- Commit: `c7e9c3b9afcdf1b06e0721f39b1801d9e590f9ab`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
