### PR TITLE
feat(admin): draw profile photos beside names in the Users roster

### DIFF
--- a/apps/web/server/admin/admin-queries.ts
+++ b/apps/web/server/admin/admin-queries.ts
@@ -422,6 +422,7 @@ export async function readAdminUsersSource(
         id: user.id,
         name: user.name,
         email: user.email,
+        image: user.image,
         role: user.role,
         createdAt: user.createdAt,
         activeDays: sql<number | string | null>`count(${hostedUsage.day})`,
@@ -435,7 +436,7 @@ export async function readAdminUsersSource(
         and(eq(hostedUsage.userId, user.id), gte(hostedUsage.day, windowStartDay)),
       )
       .where(scopeCondition(input.scope))
-      .groupBy(user.id, user.name, user.email, user.role, user.createdAt)
+      .groupBy(user.id, user.name, user.email, user.image, user.role, user.createdAt)
       .orderBy(sql`max(${hostedUsage.day}) desc nulls last`, desc(user.createdAt))
       .limit(ADMIN_USERS_LIMIT),
   ]);
@@ -451,6 +452,7 @@ export async function readAdminUsersSource(
       id: row.id,
       name: row.name,
       email: row.email,
+      image: row.image,
       admin: isAdminRole(row.role),
       createdAt: row.createdAt.getTime(),
       activeDays: toNumber(row.activeDays),

--- a/apps/web/server/admin/admin-users.ts
+++ b/apps/web/server/admin/admin-users.ts
@@ -31,6 +31,8 @@ export interface AdminUserListRow {
   id: string;
   name: string;
   email: string;
+  /** The avatar URL the sign-in provider gave the account, when it gave one. */
+  image: string | null;
   admin: boolean;
   /** When the account was created, in epoch milliseconds. */
   createdAt: number;

--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -1576,7 +1576,7 @@ function UsersTable({
               <td className="px-5 py-3">
                 <a
                   href={accountHref(row.id)}
-                  className="block outline-offset-2"
+                  className="flex items-center gap-3 outline-offset-2"
                   onClick={(event) => {
                     event.stopPropagation();
                     if (!plainLeftClick(event)) return;
@@ -1584,15 +1584,20 @@ function UsersTable({
                     onOpen(row.id);
                   }}
                 >
-                  <div className="flex items-center gap-2 font-medium">
-                    {row.name}
-                    {row.admin ? (
-                      <span className="rounded-full border border-border px-1.5 py-px font-mono text-[10px] tracking-[0.2px] text-muted-foreground uppercase">
-                        Admin
-                      </span>
-                    ) : null}
+                  <AccountAvatar
+                    account={{ name: row.name, email: row.email, image: row.image ?? undefined }}
+                  />
+                  <div>
+                    <div className="flex items-center gap-2 font-medium">
+                      {row.name}
+                      {row.admin ? (
+                        <span className="rounded-full border border-border px-1.5 py-px font-mono text-[10px] tracking-[0.2px] text-muted-foreground uppercase">
+                          Admin
+                        </span>
+                      ) : null}
+                    </div>
+                    <div className="text-xs text-muted-foreground">{row.email}</div>
                   </div>
-                  <div className="text-xs text-muted-foreground">{row.email}</div>
                 </a>
               </td>
               <td className="px-5 py-3 text-right tabular-nums">{formatDate(row.createdAt)}</td>

--- a/apps/web/tests/admin-users.test.ts
+++ b/apps/web/tests/admin-users.test.ts
@@ -22,6 +22,7 @@ const ROW = {
   id: "user-9",
   name: "Ada Lovelace",
   email: "ada@example.com",
+  image: null,
   admin: false,
   createdAt: Date.parse("2026-06-01T08:00:00.000Z"),
   activeDays: 12,


### PR DESCRIPTION
## What

The admin dashboard's Users table now draws each account's profile photo to the left of its name and email.

- `AdminUserListRow` carries `image` — the avatar URL the sign-in provider gave the account — and the roster query reads it alongside the fields it already selected.
- The Account cell renders the existing `AccountAvatar` (small, initials fallback, `no-referrer` so Google-hosted avatars load) inside the same anchor, so the whole cell still opens the account's page.

## Verification

`./scripts/check.sh` passed end to end (lint, typecheck, tests, builds). Web-only change; no desktop surface touched, so no packaged-app or physical-notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/69028ba9-8de2-4c1c-946f-e60f6cc73398)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32534890997/artifacts/9465144982) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32534890997)

- Commit: `8346847018b4d301a5e41c4a641dd2ae39653063`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
