### PR TITLE
fix(admin): scope the account page's usage chart heading to the account

### DIFF
--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -300,13 +300,15 @@ const USAGE_CHART = {
 function UsageChart({
   daily,
   trend,
+  label,
 }: {
   daily: readonly AdminDailyUsage[];
   trend: AdminTrend;
+  label: string;
 }): React.JSX.Element {
   return (
     <div className="rounded-lg border border-border bg-card p-5">
-      <ChartHeading label="Hosted-tier calls per day" trend={trend} />
+      <ChartHeading label={label} trend={trend} />
       <ChartContainer config={USAGE_CHART} className="aspect-auto h-48 w-full">
         <BarChart data={[...daily]}>
           <CartesianGrid vertical={false} />
@@ -962,7 +964,11 @@ function Dashboard({
           />
         </div>
         <div className="mt-3">
-          <UsageChart daily={metrics.featureUsage.daily} trend={metrics.featureUsage.usageTrend} />
+          <UsageChart
+            daily={metrics.featureUsage.daily}
+            trend={metrics.featureUsage.usageTrend}
+            label="Hosted-tier calls per day"
+          />
         </div>
         <SectionHeading>Most active hosted-tier accounts</SectionHeading>
         <ActiveAccountsTable
@@ -1310,7 +1316,11 @@ function UserDetailPage({
           />
         </div>
         <div className="mt-3">
-          <UsageChart daily={activity.daily} trend={activity.usageTrend} />
+          <UsageChart
+            daily={activity.daily}
+            trend={activity.usageTrend}
+            label="This account's calls per day"
+          />
         </div>
 
         <SectionHeading>Volume</SectionHeading>


### PR DESCRIPTION
## What

`UsageChart` hardcoded its card heading, "Hosted-tier calls per day", and the account detail page reuses the component unchanged — so a chart drawing one account's daily calls carried a service-wide heading. The heading is now a prop: the dashboard keeps its current wording, and the account page's chart reads "This account's calls per day", matching the account-scoped register of the captions around it.

## How

- `UsageChart` takes a required `label` prop and hands it to `ChartHeading` instead of a literal; both call sites pass their own wording. `ChartHeading` carries no separate description line, so the label is the whole surface that needed scoping.

## Verification

- `./scripts/check.sh` passes (lint, typecheck, tests, build; 734 desktop tests, 0 failures). Web-only change; no desktop surface touched, so no macOS/notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32535019406/artifacts/9465167363) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32535019406)

- Commit: `20da5b68f0cc6cf3fa663a62bb83449febac2cc1`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
