### PR TITLE
fix(admin): remember the hide-admins choice across reloads

### DIFF
--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -142,6 +142,30 @@ function rememberSidebarCollapsed(collapsed: boolean): void {
   }
 }
 
+/**
+ * Whether the "Hide admins" filter was left off, remembered the way the
+ * sidebar fold is: locally, as the presence of a key marking the exception,
+ * so a browser that refuses storage simply opens with admins hidden.
+ */
+const HIDE_ADMINS_STORAGE_KEY = "luke-admin-hide-admins";
+
+function adminsLeftHidden(): boolean {
+  try {
+    return window.localStorage.getItem(HIDE_ADMINS_STORAGE_KEY) === null;
+  } catch {
+    return true;
+  }
+}
+
+function rememberAdminsHidden(hide: boolean): void {
+  try {
+    if (hide) window.localStorage.removeItem(HIDE_ADMINS_STORAGE_KEY);
+    else window.localStorage.setItem(HIDE_ADMINS_STORAGE_KEY, "false");
+  } catch {
+    // Storage refused: admins hide again on the next visit.
+  }
+}
+
 /** The signed-in account the header names; read from the session, shown as-is. */
 interface ViewerAccount {
   name: string;
@@ -1995,10 +2019,14 @@ export function AdminDashboard(): React.JSX.Element {
     signInChosenHere() ? { status: "loading" } : { status: "signed-out" },
   );
   // Admin accounts are the maintainers' own; their traffic reads as noise in
-  // every count, so the dashboard opens with them hidden and the toggle is the
-  // explicit ask to include them. The scope is the server's filter — aggregates
-  // cannot be unpicked client-side — so flipping it refetches.
-  const [hideAdmins, setHideAdmins] = useState(true);
+  // every count, so admins start hidden and the toggle is the explicit ask to
+  // include them, remembered across visits. The scope is the server's filter —
+  // aggregates cannot be unpicked client-side — so flipping it refetches.
+  const [hideAdmins, setHideAdmins] = useState(adminsLeftHidden);
+  const changeHideAdmins = (hide: boolean) => {
+    rememberAdminsHidden(hide);
+    setHideAdmins(hide);
+  };
   const [refreshing, setRefreshing] = useState(false);
   const inFlight = useRef<AbortController>(null);
   const now = useNow(AGE_TICK_MS);
@@ -2133,7 +2161,7 @@ export function AdminDashboard(): React.JSX.Element {
     return (
       <UsersScreen
         hideAdmins={hideAdmins}
-        onHideAdminsChange={setHideAdmins}
+        onHideAdminsChange={changeHideAdmins}
         account={viewer}
         onSignOut={signOut}
         onOpenAccount={openAccount}
@@ -2171,7 +2199,7 @@ export function AdminDashboard(): React.JSX.Element {
         <Dashboard
           metrics={state.metrics}
           hideAdmins={hideAdmins}
-          onHideAdminsChange={setHideAdmins}
+          onHideAdminsChange={changeHideAdmins}
           account={viewer}
           onSignOut={() => void signOut()}
           refreshing={refreshing}


### PR DESCRIPTION
## What

The **Hide admins** checkbox — shared by the dashboard and Users views — was plain component state, so every reload reset it to hidden and a maintainer studying admin traffic had to re-tick it on each visit. The choice now survives reloads.

## How

The filter is remembered the way the sidebar fold and the sign-in press already are: locally, as the presence of a key (`luke-admin-hide-admins`) marking the exception, read lazily into state and written where the choice changes.

- `adminsLeftHidden` reads the key's absence, so the default stays hidden and a browser that refuses storage simply opens with admins hidden every visit.
- `rememberAdminsHidden` removes the key when hiding (the default) and writes it when the maintainer asks to include admins; a refused write means admins hide again on the next visit, the same degradation the sidebar accepts.
- Both change sites route through one `changeHideAdmins` that remembers and then sets, so the server-filter refetch behavior is untouched.

## Verification

- `./scripts/check.sh` passes (exit 0): lint, typecheck, all tests (apps/web 92/92, apps/desktop 734/734, all packages 0 failures), and builds.
- Web-only change; no desktop surface touched, so no macOS/notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32535141499/artifacts/9465216856) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32535141499)

- Commit: `1fe7deba206e03f92e9038f09ac84953a5e53ade`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
