### PR TITLE
fix(admin): mark every admin response no-store

### DIFF
--- a/apps/web/server/admin/http.ts
+++ b/apps/web/server/admin/http.ts
@@ -77,10 +77,16 @@ export function adminUserId(url: string): string | undefined {
   return value;
 }
 
+/**
+ * Every admin answer is viewer-gated account data, so every path — refusals
+ * included, since even a refusal names how far a viewer got — is marked
+ * no-store: a shared machine's browser or an intermediary cache must never
+ * replay one admin's view to whoever sits down next.
+ */
 export function jsonResponse<Body extends object>(status: number, body: Body): Response {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
   });
 }
 

--- a/apps/web/tests/admin-metrics.test.ts
+++ b/apps/web/tests/admin-metrics.test.ts
@@ -235,6 +235,7 @@ test("the gate answers 405, 401, 403, and 200 as distinct outcomes", async () =>
     readMetrics: async (now) => emptyMetrics(now),
   });
   assert.equal(wrongMethod.status, 405);
+  assert.equal(wrongMethod.headers.get("cache-control"), "no-store");
   assert.equal((await wrongMethod.json()).error, ADMIN_ERROR.METHOD_NOT_ALLOWED);
 
   const anonymous = await handleAdminMetrics({
@@ -260,6 +261,7 @@ test("the gate answers 405, 401, 403, and 200 as distinct outcomes", async () =>
     now: () => NOON_UTC,
   });
   assert.equal(ok.status, 200);
+  assert.equal(ok.headers.get("cache-control"), "no-store");
   // SAFETY: handleAdminMetrics answered 200, whose body is an AdminMetrics document.
   const body = (await ok.json()) as AdminMetrics;
   assert.equal(body.generatedAt, NOON_UTC);

--- a/apps/web/tests/admin-user.test.ts
+++ b/apps/web/tests/admin-user.test.ts
@@ -167,6 +167,7 @@ test("the gate answers 405, 401, 403, 400, 404, and 200 as distinct outcomes", a
     readUser,
   });
   assert.equal(wrongMethod.status, 405);
+  assert.equal(wrongMethod.headers.get("cache-control"), "no-store");
 
   const anonymous = await handleAdminUser({
     request: userRequest(),
@@ -207,6 +208,7 @@ test("the gate answers 405, 401, 403, 400, 404, and 200 as distinct outcomes", a
     now: () => NOON_UTC,
   });
   assert.equal(ok.status, 200);
+  assert.equal(ok.headers.get("cache-control"), "no-store");
   // SAFETY: handleAdminUser answered 200, whose body is an AdminUserDetail document.
   const body = (await ok.json()) as AdminUserDetail;
   assert.equal(body.generatedAt, NOON_UTC);

--- a/apps/web/tests/admin-users.test.ts
+++ b/apps/web/tests/admin-users.test.ts
@@ -60,6 +60,7 @@ test("the gate answers 405, 401, 403, and 200 as distinct outcomes", async () =>
     readUsers,
   });
   assert.equal(wrongMethod.status, 405);
+  assert.equal(wrongMethod.headers.get("cache-control"), "no-store");
 
   const anonymous = await handleAdminUsers({
     request: usersRequest(),
@@ -84,6 +85,7 @@ test("the gate answers 405, 401, 403, and 200 as distinct outcomes", async () =>
     now: () => NOON_UTC,
   });
   assert.equal(ok.status, 200);
+  assert.equal(ok.headers.get("cache-control"), "no-store");
   // SAFETY: handleAdminUsers answered 200, whose body is an AdminUserList document.
   const body = (await ok.json()) as AdminUserList;
   assert.equal(body.generatedAt, NOON_UTC);


### PR DESCRIPTION
## What

The three admin JSON endpoints answered with only a `content-type` header, leaving viewer-gated metrics and per-account data eligible for browser and intermediary caching — on a shared machine, a cache could replay one admin's view of user data to whoever sits down next. Every admin JSON response now carries `Cache-Control: no-store`, on success and refusal paths alike.

## How

- The header is set in the shared `jsonResponse` helper in `apps/web/server/admin/http.ts`, which `errorResponse` funnels through and which is the only place the admin tree constructs a `Response`, so no handler can forget it. A comment on the helper states why every path is marked, refusals included.
- The gate tests for all three handlers (`admin-metrics`, `admin-users`, `admin-user`) now assert the header on both a 405 refusal and a 200 answer.

## Verification

- `./scripts/check.sh` passes: lint, typecheck, all tests (apps/web 92/92, apps/desktop 734/734), and builds.
- Web-only change; no desktop surface touched, so no macOS/notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32535153860/artifacts/9465216840) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32535153860)

- Commit: `53378dede31579e7c7f9f5ee641cea0e9703ca98`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
