### PR TITLE
fix(admin): fall back to the email when an account has no name

### DIFF
--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -18,6 +18,7 @@ import {
   ADMIN_USER_ID_PARAM,
 } from "../server/admin/http";
 import { accountInitials } from "./account-initials";
+import { accountLabel } from "./account-label";
 import { GitHubMark, GoogleMark } from "./account-marks";
 import { AUTH_BUTTON } from "./auth-surface";
 import {
@@ -500,8 +501,10 @@ function ActiveAccountsTable({
                     onOpen(entry.id);
                   }}
                 >
-                  <div className="font-medium">{entry.name}</div>
-                  <div className="text-xs text-muted-foreground">{entry.email}</div>
+                  <div className="font-medium">{accountLabel(entry)}</div>
+                  {accountLabel(entry) === entry.email ? null : (
+                    <div className="text-xs text-muted-foreground">{entry.email}</div>
+                  )}
                 </a>
               </td>
               <td className="px-5 py-3 text-right tabular-nums">
@@ -646,7 +649,7 @@ function AccountMenu({
         className="flex cursor-pointer items-center rounded-full transition-opacity duration-150 hover:opacity-80"
         aria-haspopup="menu"
         aria-expanded={open}
-        aria-label={`Account menu for ${account.name || account.email}`}
+        aria-label={`Account menu for ${accountLabel(account)}`}
         onClick={() => setOpen(!open)}
       >
         <AccountAvatar account={account} />
@@ -1267,9 +1270,7 @@ function UserDetailPage({
           />
           <div>
             <div className="flex flex-wrap items-center gap-2.5">
-              <h1 className="text-2xl font-semibold tracking-[-0.01em]">
-                {subject.name || subject.email}
-              </h1>
+              <h1 className="text-2xl font-semibold tracking-[-0.01em]">{accountLabel(subject)}</h1>
               {subject.admin ? (
                 <span className="rounded-full border border-border px-2 py-0.5 font-mono text-[10px] tracking-[0.2px] text-muted-foreground uppercase">
                   Admin
@@ -1414,7 +1415,7 @@ const USERS_SORT_FIRST_DIRECTION = {
  * is an ISO date, so its lexicographic order is its chronological one.
  */
 const USERS_SORT_VALUE = {
-  [USERS_SORT_KEY.ACCOUNT]: (row) => (row.name || row.email).toLowerCase(),
+  [USERS_SORT_KEY.ACCOUNT]: (row) => accountLabel(row).toLowerCase(),
   [USERS_SORT_KEY.JOINED]: (row) => row.createdAt,
   [USERS_SORT_KEY.LAST_SEEN]: (row) => row.lastSeenAt,
   [USERS_SORT_KEY.ACTIVE_DAYS]: (row) => row.activeDays,
@@ -1638,14 +1639,16 @@ function UsersTable({
                   />
                   <div>
                     <div className="flex items-center gap-2 font-medium">
-                      {row.name}
+                      {accountLabel(row)}
                       {row.admin ? (
                         <span className="rounded-full border border-border px-1.5 py-px font-mono text-[10px] tracking-[0.2px] text-muted-foreground uppercase">
                           Admin
                         </span>
                       ) : null}
                     </div>
-                    <div className="text-xs text-muted-foreground">{row.email}</div>
+                    {accountLabel(row) === row.email ? null : (
+                      <div className="text-xs text-muted-foreground">{row.email}</div>
+                    )}
                   </div>
                 </a>
               </td>

--- a/apps/web/src/account-label.ts
+++ b/apps/web/src/account-label.ts
@@ -1,0 +1,8 @@
+/**
+ * The one line an account is named by: the provider's own name for it, or the
+ * address when no name was set, so a nameless account still reads as somebody
+ * rather than a blank cell.
+ */
+export function accountLabel(account: { name: string; email: string }): string {
+  return account.name || account.email;
+}

--- a/apps/web/tests/account-label.test.ts
+++ b/apps/web/tests/account-label.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { accountLabel } from "../src/account-label";
+
+test("a named account is labeled by the provider's own name", () => {
+  assert.equal(
+    accountLabel({ name: "Dean Stratakos", email: "dean@example.com" }),
+    "Dean Stratakos",
+  );
+});
+
+test("an account with no name is labeled by its address", () => {
+  assert.equal(accountLabel({ name: "", email: "dean@example.com" }), "dean@example.com");
+});
+
+test("an account named by its own address labels as that address once", () => {
+  assert.equal(
+    accountLabel({ name: "dean@example.com", email: "dean@example.com" }),
+    "dean@example.com",
+  );
+});


### PR DESCRIPTION
## What

An account whose name is empty drew a blank **Account** cell in the Users roster and in the dashboard's **Most active hosted-tier accounts** table, while the roster's sort comparator and the account detail masthead already fell back to the email. Both tables now label such an account by its address, and the secondary email line under the name is suppressed when the label already is the email, so the same string is never printed twice.

## How

- One `accountLabel` helper in `apps/web/src/account-label.ts` carries the name-or-email fallback, shaped like the existing `account-initials` module.
- The two table cells, the sort comparator, the detail masthead, and the account menu's aria-label all read the same helper, so every surface names an account the same way.
- `apps/web/tests/account-label.test.ts` covers the named, nameless, and named-by-its-own-address cases.

## Verification

- `./scripts/check.sh` passes: lint, typecheck, all tests (apps/web 95/95, apps/desktop 734/734), and builds.
- Web-only change; no desktop surface touched, so no macOS/notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32535543327/artifacts/9465323730) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32535543327)

- Commit: `c9df1180633f40b9d0230b751785d1d53f96fdc7`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
