### PR TITLE
fix(admin): count accounts, not linked rows, in the sign-in methods chart

### DIFF
--- a/apps/web/server/admin/admin-metrics.ts
+++ b/apps/web/server/admin/admin-metrics.ts
@@ -59,11 +59,42 @@ export interface AdminTrend {
   prior: number;
 }
 
-/** How accounts reached the service, counted from their linked provider rows. */
+/** The provider ids the dashboard names; every other linked provider pools into `other`. */
+export const SIGN_IN_PROVIDER_ID = {
+  GOOGLE: "google",
+  GITHUB: "github",
+} as const;
+
+/**
+ * How many accounts linked each sign-in method. An account that linked more
+ * than one method counts once under each, so the methods can legitimately sum
+ * past the account total — never past it per method.
+ */
 export interface AdminSignInMethods {
   google: number;
   github: number;
   other: number;
+}
+
+/**
+ * Folds the linked (account, provider) pairs the query reads into per-method
+ * account counts. The dedupe lives here rather than in a grouped SQL count
+ * because `other` pools every unnamed provider: an account that linked two of
+ * them is still one account, which per-provider counts summed after the fact
+ * would state as two.
+ */
+export function countSignInMethods(
+  links: readonly { userId: string; providerId: string }[],
+): AdminSignInMethods {
+  const google = new Set<string>();
+  const github = new Set<string>();
+  const other = new Set<string>();
+  for (const link of links) {
+    if (link.providerId === SIGN_IN_PROVIDER_ID.GOOGLE) google.add(link.userId);
+    else if (link.providerId === SIGN_IN_PROVIDER_ID.GITHUB) github.add(link.userId);
+    else other.add(link.userId);
+  }
+  return { google: google.size, github: github.size, other: other.size };
 }
 
 /**

--- a/apps/web/server/admin/admin-queries.ts
+++ b/apps/web/server/admin/admin-queries.ts
@@ -22,9 +22,9 @@ import {
   ADMIN_METRICS_WINDOW_DAYS,
   type AdminIntegration,
   type AdminMetricsSource,
-  type AdminSignInMethods,
   type AdminTopUser,
   type AdminUsageDay,
+  countSignInMethods,
   lastNDayKeys,
 } from "./admin-metrics.js";
 import type { AdminUserSource } from "./admin-user.js";
@@ -85,26 +85,20 @@ async function readUserMetrics(
         .from(session)
         .innerJoin(user, eq(session.userId, user.id))
         .where(and(gt(session.expiresAt, new Date(now)), scopeCondition(scope))),
+      // Distinct pairs rather than a count of linked rows: the chart states
+      // accounts per method, and an account can hold several rows of one
+      // provider. The per-method counting itself lives in the fold below.
       database
-        .select({ providerId: account.providerId, value: count() })
+        .selectDistinct({ userId: account.userId, providerId: account.providerId })
         .from(account)
         .innerJoin(user, eq(account.userId, user.id))
-        .where(scopeCondition(scope))
-        .groupBy(account.providerId),
+        .where(scopeCondition(scope)),
       database
         .select({ day: dayExpression, value: count() })
         .from(user)
         .where(and(gte(user.createdAt, windowStart), scopeCondition(scope)))
         .groupBy(dayExpression),
     ]);
-
-  const signInMethods: AdminSignInMethods = { google: 0, github: 0, other: 0 };
-  for (const row of providerRows) {
-    const value = toNumber(row.value);
-    if (row.providerId === "google") signInMethods.google += value;
-    else if (row.providerId === "github") signInMethods.github += value;
-    else signInMethods.other += value;
-  }
 
   const signupsByDay = new Map<string, number>();
   for (const row of signupRows) signupsByDay.set(row.day, toNumber(row.value));
@@ -113,7 +107,7 @@ async function readUserMetrics(
     total: toNumber(totalRow?.value),
     activeSessions: toNumber(activeSessionRow?.value),
     activeSessionUsers: toNumber(activeSessionUsersRow?.value),
-    signInMethods,
+    signInMethods: countSignInMethods(providerRows),
     signupsByDay,
   };
 }

--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -384,17 +384,20 @@ const SIGN_IN_METHODS_CHART = {
 /**
  * How the accounts sign in, as horizontal bars. One measure across nominal
  * categories, so every bar wears the first slot's hue and the end labels
- * carry the exact count and share the meter rows used to state. A method
- * nobody has linked draws no bar at all: a zero-length bar parks its end
- * label at the plot origin, where two empty methods would stack their labels
- * over the category axis.
+ * carry the exact count and its share of all accounts — shares that can sum
+ * past 100%, since an account may link more than one method, which is why
+ * each label says "of accounts" instead of posing as a slice of the bars. A
+ * method nobody has linked draws no bar at all: a zero-length bar parks its
+ * end label at the plot origin, where two empty methods would stack their
+ * labels over the category axis.
  */
 function SignInMethodsChart({
   methods,
+  totalAccounts,
 }: {
   methods: AdminMetrics["users"]["signInMethods"];
+  totalAccounts: number;
 }): React.JSX.Element {
-  const total = methods.github + methods.google + methods.other;
   const rows = [
     { method: "GitHub", accounts: methods.github },
     { method: "Google", accounts: methods.google },
@@ -403,7 +406,9 @@ function SignInMethodsChart({
     .filter((row) => row.accounts > 0)
     .map((row) => ({
       ...row,
-      label: `${formatNumber(row.accounts)} · ${Math.round((row.accounts / total) * 100)}%`,
+      label: `${formatNumber(row.accounts)} · ${Math.round(
+        (row.accounts / totalAccounts) * 100,
+      )}% of accounts`,
     }));
 
   if (rows.length === 0) {
@@ -425,7 +430,7 @@ function SignInMethodsChart({
         className="aspect-auto w-full"
         style={{ height: rows.length * 40 }}
       >
-        <BarChart data={rows} layout="vertical" margin={{ right: 96 }}>
+        <BarChart data={rows} layout="vertical" margin={{ right: 160 }}>
           <XAxis type="number" hide />
           <YAxis dataKey="method" type="category" tickLine={false} axisLine={false} width={56} />
           <ChartTooltip content={<ChartTooltipContent />} />
@@ -935,7 +940,10 @@ function Dashboard({
         </div>
         <div className="mt-3 grid gap-3 min-[720px]:grid-cols-[1.6fr_1fr]">
           <SignupsChart daily={metrics.users.dailySignups} trend={metrics.users.signupTrend} />
-          <SignInMethodsChart methods={metrics.users.signInMethods} />
+          <SignInMethodsChart
+            methods={metrics.users.signInMethods}
+            totalAccounts={metrics.users.total}
+          />
         </div>
 
         <SectionHeading>Feature usage · hosted tier</SectionHeading>

--- a/apps/web/tests/admin-metrics.test.ts
+++ b/apps/web/tests/admin-metrics.test.ts
@@ -9,8 +9,10 @@ import {
   type AdminMetricsSource,
   adminIntegrations,
   buildAdminMetrics,
+  countSignInMethods,
   handleAdminMetrics,
   lastNDayKeys,
+  SIGN_IN_PROVIDER_ID,
 } from "../server/admin/admin-metrics";
 import {
   ADMIN_ERROR,
@@ -38,6 +40,26 @@ function source(overrides: Partial<AdminMetricsSource> = {}): AdminMetricsSource
     ...overrides,
   };
 }
+
+test("sign-in methods count accounts, not linked rows", () => {
+  const methods = countSignInMethods([
+    // One account holding both methods counts once under each.
+    { userId: "user-1", providerId: SIGN_IN_PROVIDER_ID.GOOGLE },
+    { userId: "user-1", providerId: SIGN_IN_PROVIDER_ID.GITHUB },
+    { userId: "user-2", providerId: SIGN_IN_PROVIDER_ID.GITHUB },
+    // Two rows of one provider are still one account with it linked.
+    { userId: "user-3", providerId: SIGN_IN_PROVIDER_ID.GITHUB },
+    { userId: "user-3", providerId: SIGN_IN_PROVIDER_ID.GITHUB },
+    // Two unnamed providers pool into one `other` account, not two.
+    { userId: "user-4", providerId: "sso-alpha" },
+    { userId: "user-4", providerId: "sso-beta" },
+  ]);
+  assert.deepEqual(methods, { google: 1, github: 3, other: 1 });
+});
+
+test("an empty account table is zero on every method", () => {
+  assert.deepEqual(countSignInMethods([]), { google: 0, github: 0, other: 0 });
+});
 
 test("the window is a contiguous run of day keys ending on today", () => {
   const keys = lastNDayKeys(NOON_UTC, ADMIN_METRICS_WINDOW_DAYS);


### PR DESCRIPTION
## What

The dashboard's "Linked sign-in methods" chart said "Accounts" and counted rows: the query summed linked provider rows from the `account` table, so an account with both Google and GitHub linked counted twice, and each bar's percentage divided the inflated row sum rather than anything an admin could name. Each method now counts the accounts that linked it, and each end label states that method's share of all accounts — `N · P% of accounts` — wording that stays true when accounts link both methods and the shares legitimately sum past 100%.

## How

- `readUserMetrics` reads distinct `(account, provider)` pairs instead of grouped row counts, and a pure `countSignInMethods` fold in `admin-metrics.ts` turns them into per-method account counts. The dedupe lives in the fold rather than a grouped SQL count because the `other` bucket pools every unnamed provider: an account that linked two of them is one account, which per-provider counts summed after the fact would state as two.
- `SignInMethodsChart` takes the account total the same response already carries and cuts each share from it, with the chart's right margin widened for the longer end labels. The provider ids move into a `SIGN_IN_PROVIDER_ID` value set beside the fold.
- The fold sits in `admin-metrics.ts` so it is testable without a database, like the rest of the shaping: new cases in `admin-metrics.test.ts` cover an account holding both methods, several rows of one provider, two unnamed providers pooling into one `other` account, and the empty table.

## Verification

- `./scripts/check.sh` passes (lint, typecheck, tests, build), including the new `countSignInMethods` cases. Web-only change; no desktop surface touched, so no macOS/notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32535391554/artifacts/9465295198) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32535391554)

- Commit: `f6a0ec0846014ffc9bf6230d1e6b70567fa10bd4`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
