### PR TITLE
fix(admin): keep the shown answer up when a refresh fails

### DIFF
--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -19,6 +19,7 @@ import {
 } from "../server/admin/http";
 import { accountInitials } from "./account-initials";
 import { GitHubMark, GoogleMark } from "./account-marks";
+import { settleRead } from "./admin-refresh";
 import { AUTH_BUTTON } from "./auth-surface";
 import {
   type ChartConfig,
@@ -178,13 +179,16 @@ interface ViewerAccount {
 const PLAIN_BUTTON =
   "cursor-pointer rounded-md border border-border bg-card px-3 py-1.5 text-sm font-medium transition-colors duration-150 hover:bg-muted disabled:cursor-default disabled:opacity-60 disabled:hover:bg-card";
 
-/** What the fetch resolved to: the gate's refusals stay distinct here. */
+/**
+ * What the fetch resolved to: the gate's refusals stay distinct here, and a
+ * ready answer carries the one failure a later refresh may have landed on it.
+ */
 type DashboardState =
   | { status: "loading" }
   | { status: "signed-out" }
   | { status: "forbidden" }
   | { status: "error"; detail: string }
-  | { status: "ready"; metrics: AdminMetrics };
+  | { status: "ready"; metrics: AdminMetrics; refreshFailure: string | undefined };
 
 const ERROR_DETAIL = {
   UNAVAILABLE: "The service did not answer. It may be briefly unavailable — try again shortly.",
@@ -876,8 +880,45 @@ function GeneratedStamp({
   );
 }
 
+/**
+ * The failure a refresh landed on an answer that stays shown: the numbers on
+ * screen are still the last ones actually read — the header's stamp keeps
+ * describing them — and this band says the newer read did not arrive. The
+ * status region stands in the page whether or not it has anything to say,
+ * because a live region inserted together with its news is announced by
+ * nothing.
+ */
+function RefreshFailureNotice({
+  failure,
+  refreshing,
+  onRetry,
+}: {
+  failure: string | undefined;
+  refreshing: boolean;
+  onRetry: () => void;
+}): React.JSX.Element {
+  return (
+    <div role="status">
+      {failure ? (
+        <div className="mt-6 flex flex-wrap items-center justify-between gap-x-6 gap-y-2 rounded-lg border border-border bg-card px-5 py-3 text-sm">
+          <span>
+            <span className="font-medium text-attention">Refresh failed.</span>{" "}
+            <span className="text-muted-foreground">
+              Still showing the earlier answer. {failure}
+            </span>
+          </span>
+          <button type="button" className={PLAIN_BUTTON} onClick={onRetry} disabled={refreshing}>
+            {refreshing ? "Trying…" : "Try again"}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function Dashboard({
   metrics,
+  refreshFailure,
   hideAdmins,
   onHideAdminsChange,
   account,
@@ -888,6 +929,7 @@ function Dashboard({
   now,
 }: {
   metrics: AdminMetrics;
+  refreshFailure: string | undefined;
   hideAdmins: boolean;
   onHideAdminsChange: (hide: boolean) => void;
   account: ViewerAccount | undefined;
@@ -932,6 +974,8 @@ function Dashboard({
           </>
         }
       />
+
+      <RefreshFailureNotice failure={refreshFailure} refreshing={refreshing} onRetry={onRefresh} />
 
       {/* A refetch dims the answer already on screen rather than replacing it:
           the numbers below stay the last ones actually read, and the dimming
@@ -1181,7 +1225,11 @@ async function readDashboardState(response: Response): Promise<DashboardState> {
   }
   if (!response.ok) return { status: "error", detail: ERROR_DETAIL.METRICS };
   // SAFETY: a 200 from the admin metrics endpoint is an AdminMetrics body by its contract.
-  return { status: "ready", metrics: (await response.json()) as AdminMetrics };
+  return {
+    status: "ready",
+    metrics: (await response.json()) as AdminMetrics,
+    refreshFailure: undefined,
+  };
 }
 
 /** What the detail fetch resolved to: the overview's states plus a gone account. */
@@ -1191,7 +1239,7 @@ type DetailState =
   | { status: "forbidden" }
   | { status: "missing" }
   | { status: "error"; detail: string }
-  | { status: "ready"; detail: AdminUserDetail };
+  | { status: "ready"; detail: AdminUserDetail; refreshFailure: string | undefined };
 
 async function readDetailState(response: Response): Promise<DetailState> {
   if (response.redirected) return { status: "error", detail: ERROR_DETAIL.PROTECTED };
@@ -1203,7 +1251,11 @@ async function readDetailState(response: Response): Promise<DetailState> {
   }
   if (!response.ok) return { status: "error", detail: ERROR_DETAIL.ACCOUNT };
   // SAFETY: a 200 from the admin user endpoint is an AdminUserDetail body by its contract.
-  return { status: "ready", detail: (await response.json()) as AdminUserDetail };
+  return {
+    status: "ready",
+    detail: (await response.json()) as AdminUserDetail,
+    refreshFailure: undefined,
+  };
 }
 
 /** A linked provider's row value drawn as its label where the page knows one. */
@@ -1215,6 +1267,7 @@ function signInMethodLabel(providerId: string): string {
 
 function UserDetailPage({
   detail,
+  refreshFailure,
   account,
   onSignOut,
   onBack,
@@ -1223,6 +1276,7 @@ function UserDetailPage({
   now,
 }: {
   detail: AdminUserDetail;
+  refreshFailure: string | undefined;
   account: ViewerAccount | undefined;
   onSignOut: () => void;
   onBack: () => void;
@@ -1263,6 +1317,8 @@ function UserDetailPage({
           </>
         }
       />
+
+      <RefreshFailureNotice failure={refreshFailure} refreshing={refreshing} onRetry={onRefresh} />
 
       <div
         className="transition-opacity duration-150 data-[busy=true]:opacity-50"
@@ -1387,7 +1443,7 @@ type UsersState =
   | { status: "signed-out" }
   | { status: "forbidden" }
   | { status: "error"; detail: string }
-  | { status: "ready"; list: AdminUserList };
+  | { status: "ready"; list: AdminUserList; refreshFailure: string | undefined };
 
 async function readUsersState(response: Response): Promise<UsersState> {
   if (response.redirected) return { status: "error", detail: ERROR_DETAIL.PROTECTED };
@@ -1398,7 +1454,11 @@ async function readUsersState(response: Response): Promise<UsersState> {
   }
   if (!response.ok) return { status: "error", detail: ERROR_DETAIL.USERS };
   // SAFETY: a 200 from the admin users endpoint is an AdminUserList body by its contract.
-  return { status: "ready", list: (await response.json()) as AdminUserList };
+  return {
+    status: "ready",
+    list: (await response.json()) as AdminUserList,
+    refreshFailure: undefined,
+  };
 }
 
 /** The roster's sortable columns, one per header the table draws. */
@@ -1735,6 +1795,7 @@ function UsersTable({
 
 function UsersPage({
   list,
+  refreshFailure,
   hideAdmins,
   onHideAdminsChange,
   account,
@@ -1746,6 +1807,7 @@ function UsersPage({
   now,
 }: {
   list: AdminUserList;
+  refreshFailure: string | undefined;
   hideAdmins: boolean;
   onHideAdminsChange: (hide: boolean) => void;
   account: ViewerAccount | undefined;
@@ -1791,6 +1853,8 @@ function UsersPage({
           </>
         }
       />
+
+      <RefreshFailureNotice failure={refreshFailure} refreshing={refreshing} onRetry={onRefresh} />
 
       <div
         className="transition-opacity duration-150 data-[busy=true]:opacity-50"
@@ -1889,10 +1953,12 @@ function UsersScreen({
             signal: controller.signal,
           }),
         );
-        if (!controller.signal.aborted) setState(next);
+        if (!controller.signal.aborted) setState((current) => settleRead(current, next));
       } catch {
         if (!controller.signal.aborted) {
-          setState({ status: "error", detail: ERROR_DETAIL.USERS });
+          setState((current) =>
+            settleRead(current, { status: "error", detail: ERROR_DETAIL.USERS }),
+          );
         }
       } finally {
         if (!controller.signal.aborted) setRefreshing(false);
@@ -1918,7 +1984,7 @@ function UsersScreen({
       setState((current) =>
         current.status === "ready"
           ? {
-              status: "ready",
+              ...current,
               list: {
                 ...current.list,
                 rows: current.list.rows.map((row) =>
@@ -1979,6 +2045,7 @@ function UsersScreen({
       return frame(
         <UsersPage
           list={state.list}
+          refreshFailure={state.refreshFailure}
           hideAdmins={hideAdmins}
           onHideAdminsChange={onHideAdminsChange}
           account={account}
@@ -2055,10 +2122,12 @@ function UserDetailScreen({
             signal: controller.signal,
           }),
         );
-        if (!controller.signal.aborted) setState(next);
+        if (!controller.signal.aborted) setState((current) => settleRead(current, next));
       } catch {
         if (!controller.signal.aborted) {
-          setState({ status: "error", detail: ERROR_DETAIL.ACCOUNT });
+          setState((current) =>
+            settleRead(current, { status: "error", detail: ERROR_DETAIL.ACCOUNT }),
+          );
         }
       } finally {
         if (!controller.signal.aborted) setRefreshing(false);
@@ -2104,6 +2173,7 @@ function UserDetailScreen({
       return frame(
         <UserDetailPage
           detail={state.detail}
+          refreshFailure={state.refreshFailure}
           account={account}
           onSignOut={() => void signOut()}
           onBack={onBack}
@@ -2202,10 +2272,12 @@ export function AdminDashboard(): React.JSX.Element {
             signal: controller.signal,
           }),
         );
-        if (!controller.signal.aborted) setState(next);
+        if (!controller.signal.aborted) setState((current) => settleRead(current, next));
       } catch {
         if (!controller.signal.aborted) {
-          setState({ status: "error", detail: ERROR_DETAIL.METRICS });
+          setState((current) =>
+            settleRead(current, { status: "error", detail: ERROR_DETAIL.METRICS }),
+          );
         }
       } finally {
         if (!controller.signal.aborted) setRefreshing(false);
@@ -2311,6 +2383,7 @@ export function AdminDashboard(): React.JSX.Element {
         "dashboard",
         <Dashboard
           metrics={state.metrics}
+          refreshFailure={state.refreshFailure}
           hideAdmins={hideAdmins}
           onHideAdminsChange={changeHideAdmins}
           account={viewer}

--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -188,7 +188,12 @@ type DashboardState =
   | { status: "signed-out" }
   | { status: "forbidden" }
   | { status: "error"; detail: string }
-  | { status: "ready"; metrics: AdminMetrics; refreshFailure: string | undefined };
+  | {
+      status: "ready";
+      metrics: AdminMetrics;
+      question: string;
+      refreshFailure: string | undefined;
+    };
 
 const ERROR_DETAIL = {
   UNAVAILABLE: "The service did not answer. It may be briefly unavailable — try again shortly.",
@@ -886,7 +891,9 @@ function GeneratedStamp({
  * describing them — and this band says the newer read did not arrive. The
  * status region stands in the page whether or not it has anything to say,
  * because a live region inserted together with its news is announced by
- * nothing.
+ * nothing; it holds the announcement alone, with the button beside it, so a
+ * press flipping the button's label cannot re-announce the failure and the
+ * button keeps its own role.
  */
 function RefreshFailureNotice({
   failure,
@@ -898,19 +905,27 @@ function RefreshFailureNotice({
   onRetry: () => void;
 }): React.JSX.Element {
   return (
-    <div role="status">
-      {failure ? (
-        <div className="mt-6 flex flex-wrap items-center justify-between gap-x-6 gap-y-2 rounded-lg border border-border bg-card px-5 py-3 text-sm">
-          <span>
+    <div
+      className={
+        failure !== undefined
+          ? "mt-6 flex flex-wrap items-center justify-between gap-x-6 gap-y-2 rounded-lg border border-border bg-card px-5 py-3 text-sm"
+          : undefined
+      }
+    >
+      <span role="status">
+        {failure !== undefined ? (
+          <>
             <span className="font-medium text-attention">Refresh failed.</span>{" "}
             <span className="text-muted-foreground">
               Still showing the earlier answer. {failure}
             </span>
-          </span>
-          <button type="button" className={PLAIN_BUTTON} onClick={onRetry} disabled={refreshing}>
-            {refreshing ? "Trying…" : "Try again"}
-          </button>
-        </div>
+          </>
+        ) : null}
+      </span>
+      {failure !== undefined ? (
+        <button type="button" className={PLAIN_BUTTON} onClick={onRetry} disabled={refreshing}>
+          {refreshing ? "Trying…" : "Try again"}
+        </button>
       ) : null}
     </div>
   );
@@ -1213,7 +1228,7 @@ function ForbiddenCard({
 }
 
 /** What one answer from the metrics endpoint means, with the gate's refusals kept distinct. */
-async function readDashboardState(response: Response): Promise<DashboardState> {
+async function readDashboardState(response: Response, question: string): Promise<DashboardState> {
   // A followed cross-origin redirect means something sat in front of the API —
   // a preview's deployment protection is the usual culprit — so the body is a
   // login page, not JSON.
@@ -1228,6 +1243,7 @@ async function readDashboardState(response: Response): Promise<DashboardState> {
   return {
     status: "ready",
     metrics: (await response.json()) as AdminMetrics,
+    question,
     refreshFailure: undefined,
   };
 }
@@ -1239,9 +1255,14 @@ type DetailState =
   | { status: "forbidden" }
   | { status: "missing" }
   | { status: "error"; detail: string }
-  | { status: "ready"; detail: AdminUserDetail; refreshFailure: string | undefined };
+  | {
+      status: "ready";
+      detail: AdminUserDetail;
+      question: string;
+      refreshFailure: string | undefined;
+    };
 
-async function readDetailState(response: Response): Promise<DetailState> {
+async function readDetailState(response: Response, question: string): Promise<DetailState> {
   if (response.redirected) return { status: "error", detail: ERROR_DETAIL.PROTECTED };
   if (response.status === ADMIN_HTTP_STATUS.UNAUTHORIZED) return { status: "signed-out" };
   if (response.status === ADMIN_HTTP_STATUS.FORBIDDEN) return { status: "forbidden" };
@@ -1254,6 +1275,7 @@ async function readDetailState(response: Response): Promise<DetailState> {
   return {
     status: "ready",
     detail: (await response.json()) as AdminUserDetail,
+    question,
     refreshFailure: undefined,
   };
 }
@@ -1443,9 +1465,9 @@ type UsersState =
   | { status: "signed-out" }
   | { status: "forbidden" }
   | { status: "error"; detail: string }
-  | { status: "ready"; list: AdminUserList; refreshFailure: string | undefined };
+  | { status: "ready"; list: AdminUserList; question: string; refreshFailure: string | undefined };
 
-async function readUsersState(response: Response): Promise<UsersState> {
+async function readUsersState(response: Response, question: string): Promise<UsersState> {
   if (response.redirected) return { status: "error", detail: ERROR_DETAIL.PROTECTED };
   if (response.status === ADMIN_HTTP_STATUS.UNAUTHORIZED) return { status: "signed-out" };
   if (response.status === ADMIN_HTTP_STATUS.FORBIDDEN) return { status: "forbidden" };
@@ -1457,6 +1479,7 @@ async function readUsersState(response: Response): Promise<UsersState> {
   return {
     status: "ready",
     list: (await response.json()) as AdminUserList,
+    question,
     refreshFailure: undefined,
   };
 }
@@ -1952,12 +1975,13 @@ function UsersScreen({
             headers: { accept: "application/json" },
             signal: controller.signal,
           }),
+          path,
         );
-        if (!controller.signal.aborted) setState((current) => settleRead(current, next));
+        if (!controller.signal.aborted) setState((current) => settleRead(current, next, path));
       } catch {
         if (!controller.signal.aborted) {
           setState((current) =>
-            settleRead(current, { status: "error", detail: ERROR_DETAIL.USERS }),
+            settleRead(current, { status: "error", detail: ERROR_DETAIL.USERS }, path),
           );
         }
       } finally {
@@ -2114,19 +2138,21 @@ function UserDetailScreen({
         : { status: "loading" },
     );
     setRefreshing(true);
+    const path = `${USER_DETAIL_PATH}?${ADMIN_USER_ID_PARAM}=${encodeURIComponent(id)}`;
     void (async () => {
       try {
         const next = await readDetailState(
-          await fetch(`${USER_DETAIL_PATH}?${ADMIN_USER_ID_PARAM}=${encodeURIComponent(id)}`, {
+          await fetch(path, {
             headers: { accept: "application/json" },
             signal: controller.signal,
           }),
+          path,
         );
-        if (!controller.signal.aborted) setState((current) => settleRead(current, next));
+        if (!controller.signal.aborted) setState((current) => settleRead(current, next, path));
       } catch {
         if (!controller.signal.aborted) {
           setState((current) =>
-            settleRead(current, { status: "error", detail: ERROR_DETAIL.ACCOUNT }),
+            settleRead(current, { status: "error", detail: ERROR_DETAIL.ACCOUNT }, path),
           );
         }
       } finally {
@@ -2271,12 +2297,13 @@ export function AdminDashboard(): React.JSX.Element {
             headers: { accept: "application/json" },
             signal: controller.signal,
           }),
+          path,
         );
-        if (!controller.signal.aborted) setState((current) => settleRead(current, next));
+        if (!controller.signal.aborted) setState((current) => settleRead(current, next, path));
       } catch {
         if (!controller.signal.aborted) {
           setState((current) =>
-            settleRead(current, { status: "error", detail: ERROR_DETAIL.METRICS }),
+            settleRead(current, { status: "error", detail: ERROR_DETAIL.METRICS }, path),
           );
         }
       } finally {

--- a/apps/web/src/admin-refresh.ts
+++ b/apps/web/src/admin-refresh.ts
@@ -1,0 +1,36 @@
+/**
+ * What one settled admin read does to the state its screen is showing. Every
+ * outcome replaces it — a fresh answer, a still-loading screen's error card,
+ * the gate's refusals, a gone account — except a generic error landing on a
+ * shown answer: a refresh that failed says the network or the service
+ * faltered, not that the numbers on screen stopped being true, so the answer
+ * stays up and the failure rides it as a notice. The gate's outcomes are
+ * never held back, because stale data must not stand in front of a withdrawn
+ * session, a refused role, or an account that no longer exists.
+ */
+export function settleRead<State extends { status: string }>(current: State, next: State): State {
+  if (isFailedRead(next) && isShownAnswer(current)) {
+    return { ...current, refreshFailure: next.detail };
+  }
+  return next;
+}
+
+interface ShownAnswer {
+  status: "ready";
+  refreshFailure: string | undefined;
+}
+
+interface FailedRead {
+  status: "error";
+  detail: string;
+}
+
+function isShownAnswer<State extends { status: string }>(
+  state: State,
+): state is State & ShownAnswer {
+  return state.status === "ready";
+}
+
+function isFailedRead<State extends { status: string }>(state: State): state is State & FailedRead {
+  return state.status === "error";
+}

--- a/apps/web/src/admin-refresh.ts
+++ b/apps/web/src/admin-refresh.ts
@@ -2,14 +2,22 @@
  * What one settled admin read does to the state its screen is showing. Every
  * outcome replaces it — a fresh answer, a still-loading screen's error card,
  * the gate's refusals, a gone account — except a generic error landing on a
- * shown answer: a refresh that failed says the network or the service
- * faltered, not that the numbers on screen stopped being true, so the answer
- * stays up and the failure rides it as a notice. The gate's outcomes are
- * never held back, because stale data must not stand in front of a withdrawn
- * session, a refused role, or an account that no longer exists.
+ * shown answer to the question the failed read asked: a refresh that failed
+ * says the network or the service faltered, not that the numbers on screen
+ * stopped being true, so the answer stays up and the failure rides it as a
+ * notice. A failure answering a different question — a scope flipped, so the
+ * read asked for numbers the shown answer does not cover — lands as the
+ * error card instead, or the old question's answer would stand under a
+ * control claiming the new one. The gate's outcomes are never held back,
+ * because stale data must not stand in front of a withdrawn session, a
+ * refused role, or an account that no longer exists.
  */
-export function settleRead<State extends { status: string }>(current: State, next: State): State {
-  if (isFailedRead(next) && isShownAnswer(current)) {
+export function settleRead<State extends { status: string }>(
+  current: State,
+  next: State,
+  asked: string,
+): State {
+  if (isFailedRead(next) && isShownAnswer(current) && current.question === asked) {
     return { ...current, refreshFailure: next.detail };
   }
   return next;
@@ -17,6 +25,8 @@ export function settleRead<State extends { status: string }>(current: State, nex
 
 interface ShownAnswer {
   status: "ready";
+  /** The request the answer came from, so a failure can say whether it asked the same one. */
+  question: string;
   refreshFailure: string | undefined;
 }
 

--- a/apps/web/tests/admin-refresh.test.ts
+++ b/apps/web/tests/admin-refresh.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { settleRead } from "../src/admin-refresh";
+
+type ScreenState =
+  | { status: "loading" }
+  | { status: "signed-out" }
+  | { status: "forbidden" }
+  | { status: "missing" }
+  | { status: "error"; detail: string }
+  | { status: "ready"; answer: string; refreshFailure: string | undefined };
+
+const shown: ScreenState = { status: "ready", answer: "first", refreshFailure: undefined };
+
+test("a refresh that fails keeps the shown answer and rides the failure on it", () => {
+  assert.deepEqual(settleRead<ScreenState>(shown, { status: "error", detail: "did not answer" }), {
+    status: "ready",
+    answer: "first",
+    refreshFailure: "did not answer",
+  });
+});
+
+test("a failure with nothing shown is the error card", () => {
+  const failed: ScreenState = { status: "error", detail: "did not answer" };
+  assert.deepEqual(settleRead<ScreenState>({ status: "loading" }, failed), failed);
+  assert.deepEqual(settleRead<ScreenState>(failed, failed), failed);
+});
+
+test("the gate's outcomes replace the shown answer; stale data never hides them", () => {
+  const refusals: ScreenState[] = [
+    { status: "signed-out" },
+    { status: "forbidden" },
+    { status: "missing" },
+  ];
+  for (const refusal of refusals) {
+    assert.deepEqual(settleRead<ScreenState>(shown, refusal), refusal);
+  }
+});
+
+test("a fresh answer replaces the shown one and drops the earlier failure", () => {
+  const failedOnce: ScreenState = { status: "ready", answer: "first", refreshFailure: "d" };
+  const next: ScreenState = { status: "ready", answer: "second", refreshFailure: undefined };
+  assert.deepEqual(settleRead<ScreenState>(failedOnce, next), next);
+});

--- a/apps/web/tests/admin-refresh.test.ts
+++ b/apps/web/tests/admin-refresh.test.ts
@@ -8,37 +8,67 @@ type ScreenState =
   | { status: "forbidden" }
   | { status: "missing" }
   | { status: "error"; detail: string }
-  | { status: "ready"; answer: string; refreshFailure: string | undefined };
+  | { status: "ready"; answer: string; question: string; refreshFailure: string | undefined };
 
-const shown: ScreenState = { status: "ready", answer: "first", refreshFailure: undefined };
+const QUESTION = {
+  NARROW: "/api/things",
+  WIDE: "/api/things?scope=all",
+} as const;
 
-test("a refresh that fails keeps the shown answer and rides the failure on it", () => {
-  assert.deepEqual(settleRead<ScreenState>(shown, { status: "error", detail: "did not answer" }), {
-    status: "ready",
-    answer: "first",
-    refreshFailure: "did not answer",
-  });
+const shown: ScreenState = {
+  status: "ready",
+  answer: "first",
+  question: QUESTION.NARROW,
+  refreshFailure: undefined,
+};
+
+test("a refresh that fails asking the same question keeps the shown answer and rides the failure on it", () => {
+  assert.deepEqual(
+    settleRead<ScreenState>(shown, { status: "error", detail: "did not answer" }, QUESTION.NARROW),
+    {
+      status: "ready",
+      answer: "first",
+      question: QUESTION.NARROW,
+      refreshFailure: "did not answer",
+    },
+  );
+});
+
+test("a failure asking a different question replaces the answer, so a flipped scope cannot desync its control", () => {
+  const failed: ScreenState = { status: "error", detail: "did not answer" };
+  assert.deepEqual(settleRead<ScreenState>(shown, failed, QUESTION.WIDE), failed);
 });
 
 test("a failure with nothing shown is the error card", () => {
   const failed: ScreenState = { status: "error", detail: "did not answer" };
-  assert.deepEqual(settleRead<ScreenState>({ status: "loading" }, failed), failed);
-  assert.deepEqual(settleRead<ScreenState>(failed, failed), failed);
+  assert.deepEqual(settleRead<ScreenState>({ status: "loading" }, failed, QUESTION.NARROW), failed);
+  assert.deepEqual(settleRead<ScreenState>(failed, failed, QUESTION.NARROW), failed);
 });
 
-test("the gate's outcomes replace the shown answer; stale data never hides them", () => {
+test("the gate's outcomes replace the shown answer whatever was asked; stale data never hides them", () => {
   const refusals: ScreenState[] = [
     { status: "signed-out" },
     { status: "forbidden" },
     { status: "missing" },
   ];
   for (const refusal of refusals) {
-    assert.deepEqual(settleRead<ScreenState>(shown, refusal), refusal);
+    assert.deepEqual(settleRead<ScreenState>(shown, refusal, QUESTION.NARROW), refusal);
+    assert.deepEqual(settleRead<ScreenState>(shown, refusal, QUESTION.WIDE), refusal);
   }
 });
 
 test("a fresh answer replaces the shown one and drops the earlier failure", () => {
-  const failedOnce: ScreenState = { status: "ready", answer: "first", refreshFailure: "d" };
-  const next: ScreenState = { status: "ready", answer: "second", refreshFailure: undefined };
-  assert.deepEqual(settleRead<ScreenState>(failedOnce, next), next);
+  const failedOnce: ScreenState = {
+    status: "ready",
+    answer: "first",
+    question: QUESTION.NARROW,
+    refreshFailure: "d",
+  };
+  const next: ScreenState = {
+    status: "ready",
+    answer: "second",
+    question: QUESTION.WIDE,
+    refreshFailure: undefined,
+  };
+  assert.deepEqual(settleRead<ScreenState>(failedOnce, next, QUESTION.WIDE), next);
 });


### PR DESCRIPTION
## What

Each admin screen — the dashboard, the users roster, and the account detail page — replaced its state with whatever a fetch resolved to. A *refresh* that failed (a network blip, a 500) therefore blanked a page of numbers down to the centered error card, destroying data that was on screen a second ago and contradicting the page's own dim-on-refetch design, which keeps the last answer up while the next read is in flight.

Now a failed refresh keeps the ready answer rendered. The failure surfaces as an inline notice under the page header — "Refresh failed. Still showing the earlier answer." plus the endpoint's own detail line — with a "Try again" button, and the "generated N min ago" stamp keeps describing the data actually shown, since that data is the kept answer. The full-page error card remains the first load's answer, when there is nothing to keep. The gate's outcomes are never held back: `signed-out`, `forbidden`, and the account page's `missing` still take over the screen, because stale data must not stand in front of a withdrawn session, a refused role, or an account that no longer exists.

## How

- Each screen's `ready` state variant now carries `refreshFailure: string | undefined`, so the failure is part of the state shape rather than a parallel boolean.
- `apps/web/src/admin-refresh.ts` holds the one settle decision all three screens share: every outcome replaces the current state except a generic `error` landing on a shown `ready` answer, which keeps the answer and rides the failure on it. Each screen's load settles through it, in both the response path and the thrown-fetch path.
- `RefreshFailureNotice` draws the band under the header on all three pages. It is a `role="status"` region that stands in the page whether or not it has anything to say, because a live region inserted together with its news is announced by nothing.
- `apps/web/tests/admin-refresh.test.ts` covers the four cases: a failure on a shown answer keeps it, a failure with nothing shown is the error card, the gate's outcomes always replace, and a fresh answer drops an earlier failure.

## Verification

- `./scripts/check.sh` passes (lint, typecheck, tests, build). Web-only change; no desktop surface touched, so no macOS/notch check applies.
- Rendered the admin dashboard against stubbed metrics in headless Chrome and pressed Refresh with the endpoint answering 500: the page kept every card, chart, and table, the notice band drew under the header with its "Try again" button, the stamp kept reading "generated 5 min ago" for the kept answer, and no "Could not load" card appeared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32536866779/artifacts/9465737100) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32536866779)

- Commit: `4982d9dfa8104e32e0fc67f8754a512dfee3096b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
