### PR TITLE
feat(admin): pin favorited accounts to the top of the Users roster

### DIFF
--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -1492,20 +1492,23 @@ function rememberUsersSort(sort: UsersSort): void {
 }
 
 /**
- * Orders the roster for one sort. No sort keeps the server's order — most
- * recently active first — and ties keep it too, since the sort is stable. An
- * account with no active day yet sits below the dated rows in either
- * direction: it has no place in a chronology, and flipping one should not
- * bury the answer under the blanks.
+ * Orders the roster for one sort. Favorites stand above everything first —
+ * the star marks the accounts the admin actually watches, so no column order
+ * may bury them — and the sort chosen orders each tier on its own. No sort
+ * keeps the server's order — most recently active first — and ties keep it
+ * too, since the sort is stable. An account with no active day yet sits below
+ * the dated rows of its tier in either direction: it has no place in a
+ * chronology, and flipping one should not bury the answer under the blanks.
  */
 function sortUsersRows(
   rows: readonly AdminUserListRow[],
   sort: UsersSort | undefined,
 ): readonly AdminUserListRow[] {
-  if (!sort) return rows;
-  const value = USERS_SORT_VALUE[sort.key];
-  const flip = sort.direction === SORT_DIRECTION.DESCENDING ? -1 : 1;
+  const value = sort ? USERS_SORT_VALUE[sort.key] : undefined;
+  const flip = sort?.direction === SORT_DIRECTION.DESCENDING ? -1 : 1;
   return [...rows].sort((a, b) => {
+    if (a.favorite !== b.favorite) return a.favorite ? -1 : 1;
+    if (value === undefined) return 0;
     const left = value(a);
     const right = value(b);
     if (left === null) return right === null ? 0 : 1;


### PR DESCRIPTION
## Summary
A star already marks the accounts an admin actually watches, but the roster ordered everyone alike, so the watched handful stayed scattered through two hundred rows. Favorited accounts now stand above the rest as their own tier of the roster:

- The chosen column sort orders each tier on its own, so a starred group is still readable by name, join date, or activity.
- With no sort chosen, both tiers keep the server's most-recently-active order, as before.
- A toggled star moves its row at once — the roster re-sorts on the same optimistic flip that fills the star.

## Testing
- `./scripts/check.sh` passes (lint, typecheck, tests, build).
- Web-only change to the admin dashboard; no macOS surface touched, so no `verify.sh` run or physical-notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/2d12b4a7-b5ad-4ffd-89e0-79c4625b6fc9)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32536052210/artifacts/9465482270) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32536052210)

- Commit: `b1ea04642574b11275c99314c852515aaea3931c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
