### PR TITLE
fix(admin): treat a whitespace-only account name as no name

### DIFF
--- a/apps/web/src/account-label.ts
+++ b/apps/web/src/account-label.ts
@@ -4,5 +4,6 @@
  * rather than a blank cell.
  */
 export function accountLabel(account: { name: string; email: string }): string {
-  return account.name || account.email;
+  const name = account.name.trim();
+  return name || account.email;
 }

--- a/apps/web/tests/account-label.test.ts
+++ b/apps/web/tests/account-label.test.ts
@@ -11,6 +11,14 @@ test("a named account is labeled by the provider's own name", () => {
 
 test("an account with no name is labeled by its address", () => {
   assert.equal(accountLabel({ name: "", email: "dean@example.com" }), "dean@example.com");
+  assert.equal(accountLabel({ name: "   ", email: "dean@example.com" }), "dean@example.com");
+});
+
+test("a name wearing stray padding is labeled without it", () => {
+  assert.equal(
+    accountLabel({ name: "  Dean Stratakos  ", email: "dean@example.com" }),
+    "Dean Stratakos",
+  );
 });
 
 test("an account named by its own address labels as that address once", () => {


### PR DESCRIPTION
## What

`accountLabel` fell back to the email only when the name was the empty string, so a name of bare whitespace was truthy and drew a blank Account label past the fallback. The label now trims the name before falling back, which also keeps a padded name tidy — the same reading of whitespace the sibling `accountInitials` helper already applies.

## How

- `apps/web/src/account-label.ts` trims the name and returns the trimmed name or the email.
- `apps/web/tests/account-label.test.ts` gains the whitespace-only-name case and a stray-padding case.

## Verification

- `./scripts/check.sh` passes: lint, typecheck, all tests (apps/web 102/102, apps/desktop 734/734), and builds.
- Web-only change; no desktop surface touched, so no macOS/notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32536883824/artifacts/9465737933) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32536883824)

- Commit: `686ac2a4a98a7d740159d575d1b8c328ed897812`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
