### PR TITLE
feat(admin): link the reliability caption to the analytics project when configured

### DIFF
--- a/apps/web/api/admin/metrics.ts
+++ b/apps/web/api/admin/metrics.ts
@@ -7,7 +7,7 @@ import { readAdminMetricsSource } from "../../server/admin/admin-queries.js";
 import { resolveSessionViewer } from "../../server/admin/viewer.js";
 import { getDatabase } from "../../server/db/index.js";
 import { HOSTED_OPENAI_ENVIRONMENT } from "../../server/hosted/openai.js";
-import { POSTHOG_ENVIRONMENT } from "../../server/hosted/posthog.js";
+import { POSTHOG_ENVIRONMENT, posthogProjectConsoleUrl } from "../../server/hosted/posthog.js";
 
 /** An environment value counts as configured only when it holds a non-blank string. */
 function configured(name: string): boolean {
@@ -35,12 +35,22 @@ export default {
       authSecret: configured("BETTER_AUTH_SECRET"),
     });
 
+    // The project id names which console to open, never a secret; the key
+    // presence booleans above are still the only thing said about the keys.
+    const projectId = (process.env[POSTHOG_ENVIRONMENT.PROJECT_ID] ?? "").trim();
+    const analyticsConsoleUrl = projectId ? posthogProjectConsoleUrl(projectId) : undefined;
+
     return handleAdminMetrics({
       request,
       resolveViewer: resolveSessionViewer,
       readMetrics: async (now, scope) =>
         buildAdminMetrics(
-          await readAdminMetricsSource(getDatabase(), { now, integrations, scope }),
+          await readAdminMetricsSource(getDatabase(), {
+            now,
+            integrations,
+            analyticsConsoleUrl,
+            scope,
+          }),
           now,
         ),
     });

--- a/apps/web/api/admin/metrics.ts
+++ b/apps/web/api/admin/metrics.ts
@@ -38,7 +38,9 @@ export default {
     // The project id names which console to open, never a secret; the key
     // presence booleans above are still the only thing said about the keys.
     const projectId = (process.env[POSTHOG_ENVIRONMENT.PROJECT_ID] ?? "").trim();
-    const analyticsConsoleUrl = projectId ? posthogProjectConsoleUrl(projectId) : undefined;
+    const analyticsConsoleUrl = projectId
+      ? posthogProjectConsoleUrl(projectId, process.env[POSTHOG_ENVIRONMENT.API_HOST])
+      : undefined;
 
     return handleAdminMetrics({
       request,

--- a/apps/web/server/admin/admin-metrics.ts
+++ b/apps/web/server/admin/admin-metrics.ts
@@ -205,6 +205,12 @@ export interface AdminMetrics {
     /** (user, day) rows that reached a ceiling — throttling made visible, since a rejected call still counts. */
     quotaLimitedUserDaysToday: number;
     quotaLimitedUserDaysWindow: number;
+    /**
+     * The analytics project's console, where the per-request error rates this
+     * section cannot show actually live. Absent when the deployment names no
+     * project, so the page states the absence rather than drawing a dead link.
+     */
+    analyticsConsoleUrl?: string;
   };
   systemHealth: {
     database: AdminDatabaseHealth;
@@ -234,6 +240,8 @@ export interface AdminMetricsSource {
   reliability: {
     quotaLimitedUserDaysToday: number;
     quotaLimitedUserDaysWindow: number;
+    /** Read from the environment like the integrations, not from a table. */
+    analyticsConsoleUrl?: string;
   };
   systemHealth: {
     database: AdminDatabaseHealth;
@@ -327,6 +335,7 @@ export function buildAdminMetrics(source: AdminMetricsSource, now: number): Admi
       attentionDailyLimit: HOSTED_DAILY_LIMIT[HOSTED_METER.ATTENTION_REVIEW],
       quotaLimitedUserDaysToday: source.reliability.quotaLimitedUserDaysToday,
       quotaLimitedUserDaysWindow: source.reliability.quotaLimitedUserDaysWindow,
+      analyticsConsoleUrl: source.reliability.analyticsConsoleUrl,
     },
     systemHealth: {
       database: source.systemHealth.database,

--- a/apps/web/server/admin/admin-queries.ts
+++ b/apps/web/server/admin/admin-queries.ts
@@ -238,6 +238,7 @@ async function readReliabilityMetrics(
 function emptySource(
   integrations: readonly AdminIntegration[],
   database: { reachable: boolean; latencyMs: number },
+  analyticsConsoleUrl: string | undefined,
 ): AdminMetricsSource {
   return {
     users: {
@@ -248,7 +249,11 @@ function emptySource(
       signupsByDay: new Map(),
     },
     usage: { byDay: new Map(), activeUsersToday: 0, activeUsersWindow: 0, topUsers: [] },
-    reliability: { quotaLimitedUserDaysToday: 0, quotaLimitedUserDaysWindow: 0 },
+    reliability: {
+      quotaLimitedUserDaysToday: 0,
+      quotaLimitedUserDaysWindow: 0,
+      analyticsConsoleUrl,
+    },
     systemHealth: { database, integrations },
   };
 }
@@ -257,19 +262,20 @@ function emptySource(
  * Reads every aggregate the dashboard shows, from the service's own tables. A
  * database that does not answer the probe short-circuits to an empty source
  * whose health card reports the outage rather than a page of misleading zeros
- * with a green light — the integrations, read from the environment, still fill
- * in.
+ * with a green light — the integrations and the analytics console address,
+ * read from the environment, still fill in.
  */
 export async function readAdminMetricsSource(
   database: Database,
   input: {
     now: number;
     integrations: readonly AdminIntegration[];
+    analyticsConsoleUrl?: string;
     scope: AdminMetricsScope;
   },
 ): Promise<AdminMetricsSource> {
   const health = await probeDatabase(database);
-  if (!health.reachable) return emptySource(input.integrations, health);
+  if (!health.reachable) return emptySource(input.integrations, health, input.analyticsConsoleUrl);
 
   const dayKeys = lastNDayKeys(input.now, ADMIN_METRICS_WINDOW_DAYS);
   const windowStartDay = dayKeys[0] ?? utcDayKey(input.now);
@@ -285,7 +291,7 @@ export async function readAdminMetricsSource(
   return {
     users,
     usage,
-    reliability,
+    reliability: { ...reliability, analyticsConsoleUrl: input.analyticsConsoleUrl },
     systemHealth: { database: health, integrations: input.integrations },
   };
 }

--- a/apps/web/server/hosted/posthog.ts
+++ b/apps/web/server/hosted/posthog.ts
@@ -35,10 +35,12 @@ export const POSTHOG_DEFAULTS = {
 /**
  * One project's console page, on the app host the private API lives on —
  * never the ingestion host, which serves no pages. This is an address for a
- * maintainer's browser, not an endpoint Luke calls.
+ * maintainer's browser, not an endpoint Luke calls, and it honors the same
+ * host override the erasure call does, so an EU project links to its own
+ * console.
  */
-export function posthogProjectConsoleUrl(projectId: string): string {
-  return `${POSTHOG_DEFAULTS.API_HOST}/project/${encodeURIComponent(projectId)}`;
+export function posthogProjectConsoleUrl(projectId: string, host?: string): string {
+  return `${resolvePosthogApiHost(host)}/project/${encodeURIComponent(projectId)}`;
 }
 
 export type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
@@ -81,6 +83,11 @@ function withoutTrailingSlash(value: string): string {
   return value.endsWith("/") ? value.slice(0, -1) : value;
 }
 
+/** The deployment's private-API host override when it holds one, the default otherwise. */
+function resolvePosthogApiHost(host: string | undefined): string {
+  return withoutTrailingSlash(host?.trim() || POSTHOG_DEFAULTS.API_HOST);
+}
+
 /**
  * Posts one batch document, resolving to nothing on a network fault so the
  * caller answers 502 without ever holding an error that could name the key.
@@ -120,7 +127,7 @@ export async function forgetPosthogPerson(
   options: PosthogForgetOptions,
 ): Promise<void> {
   const send = options.fetch ?? ((input: string, init: RequestInit) => fetch(input, init));
-  const host = withoutTrailingSlash(options.host?.trim() || POSTHOG_DEFAULTS.API_HOST);
+  const host = resolvePosthogApiHost(options.host);
   const url = `${host}/api/projects/${encodeURIComponent(options.projectId)}/persons/bulk_delete/?delete_events=true`;
   const response = await send(url, {
     method: "POST",

--- a/apps/web/server/hosted/posthog.ts
+++ b/apps/web/server/hosted/posthog.ts
@@ -32,6 +32,15 @@ export const POSTHOG_DEFAULTS = {
   REQUEST_TIMEOUT_MS: 5_000,
 } as const;
 
+/**
+ * One project's console page, on the app host the private API lives on —
+ * never the ingestion host, which serves no pages. This is an address for a
+ * maintainer's browser, not an endpoint Luke calls.
+ */
+export function posthogProjectConsoleUrl(projectId: string): string {
+  return `${POSTHOG_DEFAULTS.API_HOST}/project/${encodeURIComponent(projectId)}`;
+}
+
 export type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
 
 /**

--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -1034,7 +1034,19 @@ function Dashboard({
           A hosted request that reaches a daily ceiling is refused with{" "}
           <code className="font-mono text-xs">quota-exhausted</code>; the count above is the closest
           rejection signal the service's own tables hold. Per-request error rates and client-side
-          failures are recorded as product-analytics events, which live with the analytics processor
+          failures are recorded as product-analytics events, which live with{" "}
+          {metrics.reliability.analyticsConsoleUrl ? (
+            <a
+              href={metrics.reliability.analyticsConsoleUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="underline underline-offset-2 transition-colors duration-150 hover:text-foreground"
+            >
+              the analytics processor
+            </a>
+          ) : (
+            "the analytics processor"
+          )}{" "}
           rather than in this database.
         </p>
 

--- a/apps/web/tests/admin-metrics.test.ts
+++ b/apps/web/tests/admin-metrics.test.ts
@@ -21,6 +21,7 @@ import {
   type AdminMetricsScope,
   adminMetricsScope,
 } from "../server/admin/http";
+import { posthogProjectConsoleUrl } from "../server/hosted/posthog";
 import { HOSTED_DAILY_LIMIT, HOSTED_METER } from "../server/hosted/quota";
 
 const NOON_UTC = Date.parse("2026-08-17T12:00:00.000Z");
@@ -216,6 +217,23 @@ test("the daily ceilings are reported from the hosted quota, not restated", () =
   assert.equal(metrics.generatedAt, NOON_UTC);
 });
 
+test("the analytics console address rides through when configured and stays absent when not", () => {
+  const configured = buildAdminMetrics(
+    source({
+      reliability: {
+        quotaLimitedUserDaysToday: 0,
+        quotaLimitedUserDaysWindow: 0,
+        analyticsConsoleUrl: posthogProjectConsoleUrl("12345"),
+      },
+    }),
+    NOON_UTC,
+  );
+  assert.equal(configured.reliability.analyticsConsoleUrl, "https://us.posthog.com/project/12345");
+
+  const absent = buildAdminMetrics(source(), NOON_UTC);
+  assert.equal(absent.reliability.analyticsConsoleUrl, undefined);
+});
+
 test("integration health reads presence, in a fixed order, never a value", () => {
   const rows = adminIntegrations({
     hostedTier: true,
@@ -288,6 +306,8 @@ test("the gate answers 405, 401, 403, and 200 as distinct outcomes", async () =>
   const body = (await ok.json()) as AdminMetrics;
   assert.equal(body.generatedAt, NOON_UTC);
   assert.equal(body.windowDays, ADMIN_METRICS_WINDOW_DAYS);
+  // An unconfigured analytics project travels as absence, never a placeholder.
+  assert.ok(!("analyticsConsoleUrl" in body.reliability));
 });
 
 test("the scope defaults to hiding admins; only the explicit `all` widens it", () => {

--- a/apps/web/tests/admin-metrics.test.ts
+++ b/apps/web/tests/admin-metrics.test.ts
@@ -230,6 +230,22 @@ test("the analytics console address rides through when configured and stays abse
   );
   assert.equal(configured.reliability.analyticsConsoleUrl, "https://us.posthog.com/project/12345");
 
+  const overriddenHost = buildAdminMetrics(
+    source({
+      reliability: {
+        quotaLimitedUserDaysToday: 0,
+        quotaLimitedUserDaysWindow: 0,
+        // A deployment on another region's host must link to its own console.
+        analyticsConsoleUrl: posthogProjectConsoleUrl("12345", "https://eu.posthog.com/"),
+      },
+    }),
+    NOON_UTC,
+  );
+  assert.equal(
+    overriddenHost.reliability.analyticsConsoleUrl,
+    "https://eu.posthog.com/project/12345",
+  );
+
   const absent = buildAdminMetrics(source(), NOON_UTC);
   assert.equal(absent.reliability.analyticsConsoleUrl, undefined);
 });


### PR DESCRIPTION
## What

The admin dashboard's Reliability caption says per-request error rates and client-side failures live with the analytics processor rather than in this database — but offered no way there. When the deployment configures an analytics project id, the metrics response now carries that project's console address and the caption's mention becomes a real link opening in a new tab (`target="_blank" rel="noreferrer"`). When no project id is configured, the caption stays exactly the plain sentence it was: an honest absence, no dead link, no fallback control.

## How

- `apps/web/server/hosted/posthog.ts` gains `posthogProjectConsoleUrl`, composing the console page from the existing `POSTHOG_DEFAULTS.API_HOST` constant and an encoded project id, so the host string lives in one place.
- `apps/web/api/admin/metrics.ts` reads `POSTHOG_PROJECT_ID` presence the same way the integration booleans are read, composes the address server-side, and hands it into the metrics read; the id names which console to open, never a secret.
- The address rides `AdminMetricsSource.reliability` through `readAdminMetricsSource` into `AdminMetrics.reliability` the way the integrations flow, still filling in on the database-unreachable path since it is env-read.
- `AdminDashboard.tsx` renders the caption's "the analytics processor" as an anchor only when the address is present, styled with the page's anchor hover treatment plus the site's underline-offset convention.
- Tests: the shaping test covers both the configured pass-through and the absent case, and the gate test asserts an unconfigured project travels as JSON absence, never a placeholder.

## Verification

- `./scripts/check.sh` passes (exit 0), including the new `apps/web` test "the analytics console address rides through when configured and stays absent when not".
- Web-only change; no desktop surface touched, so no macOS/notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32537638571/artifacts/9465975878) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32537638571)

- Commit: `d712afd447524f7f4d49aba4f47aca1aa5a7b17d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
