### PR TITLE
fix(admin): fold the sidebar without flickering its labels

### DIFF
--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -21,6 +21,7 @@ import { accountInitials } from "./account-initials";
 import { accountLabel } from "./account-label";
 import { GitHubMark, GoogleMark } from "./account-marks";
 import { settleRead } from "./admin-refresh";
+import { SIDEBAR_WIDTH, sidebarRailWidth, sidebarToggleLabel } from "./admin-sidebar";
 import { AUTH_BUTTON } from "./auth-surface";
 import {
   type ChartConfig,
@@ -782,8 +783,17 @@ const SIDEBAR_ITEM = {
 /**
  * The page's one navigation, wearing the brand the headers used to carry.
  * Each tab is a real anchor to its own address, so a modified click still
- * gets the browser's own gesture; collapsed, the labels fold away and each
- * item keeps its name on a title and the toggle on its aria-label.
+ * gets the browser's own gesture.
+ *
+ * The fold is a single width transition on the outer rail over a fixed-width
+ * inner panel it clips: the panel is always laid out at the expanded width, so
+ * a label is revealed or hidden by the moving clip edge rather than inserted
+ * and removed. Nothing inside the panel re-flows as the rail moves, so the
+ * fold neither pops a label in nor wraps one nor shoves an icon, and the
+ * icons stay centred in the collapsed rail by the panel's own left inset
+ * rather than by re-centring each row. Collapsed, every item keeps its name on
+ * a `title` and the toggle on its `aria-label`; the labels themselves stay in
+ * the tree, clipped, so a reader still hears them.
  */
 function AdminSidebar({
   active,
@@ -803,7 +813,7 @@ function AdminSidebar({
       title={collapsed ? label : undefined}
       className={`flex items-center gap-2.5 rounded-md px-2.5 py-2 text-sm font-medium transition-colors duration-150 ${
         active === tab ? SIDEBAR_ITEM.ACTIVE : SIDEBAR_ITEM.IDLE
-      } ${collapsed ? "justify-center" : ""}`}
+      }`}
       onClick={(event) => {
         if (!plainLeftClick(event)) return;
         event.preventDefault();
@@ -811,39 +821,43 @@ function AdminSidebar({
       }}
     >
       {icon}
-      {collapsed ? null : label}
+      <span className="min-w-0 whitespace-nowrap">{label}</span>
     </a>
   );
 
   return (
     <nav
       aria-label="Admin sections"
-      className={`sticky top-0 flex h-screen shrink-0 flex-col border-r border-border bg-card px-3 py-5 transition-[width] duration-150 ${
-        collapsed ? "w-[62px]" : "w-56"
-      }`}
+      style={{ width: sidebarRailWidth(collapsed) }}
+      className="sticky top-0 flex h-screen shrink-0 overflow-hidden border-r border-border bg-card transition-[width] duration-150 ease-out motion-reduce:transition-none"
     >
-      <div className={`flex items-center gap-2 px-1 ${collapsed ? "justify-center" : ""}`}>
-        <span className="inline-flex w-6 shrink-0 text-foreground" aria-hidden="true">
-          <LukeMark className="h-auto w-full" />
-        </span>
-        {collapsed ? null : (
-          <span className="font-brand text-base font-bold tracking-[-0.01em]">Luke admin</span>
-        )}
-      </div>
-      <div className="mt-8 grid gap-1">
-        {item("dashboard", "Dashboard", <DashboardIcon />)}
-        {item("users", "Users", <UsersIcon />)}
-      </div>
-      <div className="flex-1" />
-      <button
-        type="button"
-        aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-        className={`flex cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-2 text-sm font-medium transition-colors duration-150 ${SIDEBAR_ITEM.IDLE} ${collapsed ? "justify-center" : ""}`}
-        onClick={onToggle}
+      <div
+        style={{ width: SIDEBAR_WIDTH.EXPANDED }}
+        className="flex h-full shrink-0 flex-col px-3 py-5"
       >
-        <CollapseIcon collapsed={collapsed} />
-        {collapsed ? null : "Collapse"}
-      </button>
+        <div className="flex items-center gap-2 px-1">
+          <span className="inline-flex w-6 shrink-0 text-foreground" aria-hidden="true">
+            <LukeMark className="h-auto w-full" />
+          </span>
+          <span className="whitespace-nowrap font-brand text-base font-bold tracking-[-0.01em]">
+            Luke admin
+          </span>
+        </div>
+        <div className="mt-8 grid gap-1">
+          {item("dashboard", "Dashboard", <DashboardIcon />)}
+          {item("users", "Users", <UsersIcon />)}
+        </div>
+        <div className="flex-1" />
+        <button
+          type="button"
+          aria-label={sidebarToggleLabel(collapsed)}
+          className={`flex cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-2 text-sm font-medium transition-colors duration-150 ${SIDEBAR_ITEM.IDLE}`}
+          onClick={onToggle}
+        >
+          <CollapseIcon collapsed={collapsed} />
+          <span className="whitespace-nowrap">Collapse</span>
+        </button>
+      </div>
     </nav>
   );
 }

--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -21,7 +21,12 @@ import { accountInitials } from "./account-initials";
 import { accountLabel } from "./account-label";
 import { GitHubMark, GoogleMark } from "./account-marks";
 import { settleRead } from "./admin-refresh";
-import { SIDEBAR_WIDTH, sidebarRailWidth, sidebarToggleLabel } from "./admin-sidebar";
+import {
+  SIDEBAR_ICON_SLOT,
+  SIDEBAR_WIDTH,
+  sidebarRailWidth,
+  sidebarToggleLabel,
+} from "./admin-sidebar";
 import { AUTH_BUTTON } from "./auth-surface";
 import {
   type ChartConfig,
@@ -789,11 +794,13 @@ const SIDEBAR_ITEM = {
  * inner panel it clips: the panel is always laid out at the expanded width, so
  * a label is revealed or hidden by the moving clip edge rather than inserted
  * and removed. Nothing inside the panel re-flows as the rail moves, so the
- * fold neither pops a label in nor wraps one nor shoves an icon, and the
- * icons stay centred in the collapsed rail by the panel's own left inset
- * rather than by re-centring each row. Collapsed, every item keeps its name on
- * a `title` and the toggle on its `aria-label`; the labels themselves stay in
- * the tree, clipped, so a reader still hears them.
+ * fold neither pops a label in nor wraps one nor shoves an icon. Each row
+ * leads with an icon slot exactly the collapsed rail's width, so the icon sits
+ * on the rail's centre and the label begins at the rail's edge — past the clip,
+ * never a fragment inside it — which is why the rows carry no horizontal
+ * padding of their own: any would start the label short of that edge. Collapsed,
+ * every item keeps its name on a `title` and the toggle on its `aria-label`;
+ * the labels themselves stay in the tree, clipped, so a reader still hears them.
  */
 function AdminSidebar({
   active,
@@ -806,12 +813,22 @@ function AdminSidebar({
   onToggle: () => void;
   onNavigate: (tab: AdminTab) => void;
 }): React.JSX.Element {
+  const iconSlot = (icon: React.ReactNode) => (
+    <span
+      className="flex shrink-0 items-center justify-center"
+      style={{ width: SIDEBAR_ICON_SLOT }}
+      aria-hidden="true"
+    >
+      {icon}
+    </span>
+  );
+
   const item = (tab: AdminTab, label: string, icon: React.ReactNode) => (
     <a
       href={tabHref(tab)}
       aria-current={active === tab ? "page" : undefined}
       title={collapsed ? label : undefined}
-      className={`flex items-center gap-2.5 rounded-md px-2.5 py-2 text-sm font-medium transition-colors duration-150 ${
+      className={`flex items-center rounded-md py-2 pr-3 text-sm font-medium transition-colors duration-150 ${
         active === tab ? SIDEBAR_ITEM.ACTIVE : SIDEBAR_ITEM.IDLE
       }`}
       onClick={(event) => {
@@ -820,7 +837,7 @@ function AdminSidebar({
         onNavigate(tab);
       }}
     >
-      {icon}
+      {iconSlot(icon)}
       <span className="min-w-0 whitespace-nowrap">{label}</span>
     </a>
   );
@@ -831,14 +848,13 @@ function AdminSidebar({
       style={{ width: sidebarRailWidth(collapsed) }}
       className="sticky top-0 flex h-screen shrink-0 overflow-hidden border-r border-border bg-card transition-[width] duration-150 ease-out motion-reduce:transition-none"
     >
-      <div
-        style={{ width: SIDEBAR_WIDTH.EXPANDED }}
-        className="flex h-full shrink-0 flex-col px-3 py-5"
-      >
-        <div className="flex items-center gap-2 px-1">
-          <span className="inline-flex w-6 shrink-0 text-foreground" aria-hidden="true">
-            <LukeMark className="h-auto w-full" />
-          </span>
+      <div style={{ width: SIDEBAR_WIDTH.EXPANDED }} className="flex h-full shrink-0 flex-col py-5">
+        <div className="flex items-center pr-3">
+          {iconSlot(
+            <span className="inline-flex w-6 text-foreground">
+              <LukeMark className="h-auto w-full" />
+            </span>,
+          )}
           <span className="whitespace-nowrap font-brand text-base font-bold tracking-[-0.01em]">
             Luke admin
           </span>
@@ -851,10 +867,10 @@ function AdminSidebar({
         <button
           type="button"
           aria-label={sidebarToggleLabel(collapsed)}
-          className={`flex cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-2 text-sm font-medium transition-colors duration-150 ${SIDEBAR_ITEM.IDLE}`}
+          className={`flex cursor-pointer items-center rounded-md py-2 pr-3 text-sm font-medium transition-colors duration-150 ${SIDEBAR_ITEM.IDLE}`}
           onClick={onToggle}
         >
-          <CollapseIcon collapsed={collapsed} />
+          {iconSlot(<CollapseIcon collapsed={collapsed} />)}
           <span className="whitespace-nowrap">Collapse</span>
         </button>
       </div>

--- a/apps/web/src/admin-sidebar.ts
+++ b/apps/web/src/admin-sidebar.ts
@@ -1,0 +1,58 @@
+/**
+ * The admin sidebar's fold, held apart from the component that draws it so the
+ * one invariant it rests on can be asserted without a DOM.
+ *
+ * The rail folds by moving a single property — its own width — over an inner
+ * panel that is always laid out at the expanded width and clipped, never by
+ * swapping the panel's contents. That is what keeps the fold from flickering:
+ * a label is clipped by the moving rail, never removed and re-inserted, so it
+ * cannot pop in, wrap, or shove the icon beside it as the width animates, and
+ * nothing inside the panel re-flows while the rail moves.
+ */
+
+/**
+ * The rail's two widths, in pixels, kept here as the single source the drawn
+ * `style` reads so the fold's geometry is one value a test can pin rather than
+ * a Tailwind class literal it cannot.
+ */
+export const SIDEBAR_WIDTH = {
+  EXPANDED: 224,
+  COLLAPSED: 62,
+} as const;
+
+export type SidebarWidth = (typeof SIDEBAR_WIDTH)[keyof typeof SIDEBAR_WIDTH];
+
+export function sidebarRailWidth(collapsed: boolean): SidebarWidth {
+  return collapsed ? SIDEBAR_WIDTH.COLLAPSED : SIDEBAR_WIDTH.EXPANDED;
+}
+
+/**
+ * What the fold toggle names for a reader, distinct from the chevron it draws:
+ * collapsed it offers to expand, expanded to collapse. The icon carries the
+ * direction; this carries the word.
+ */
+export const SIDEBAR_TOGGLE_LABEL = {
+  EXPAND: "Expand sidebar",
+  COLLAPSE: "Collapse sidebar",
+} as const;
+
+export function sidebarToggleLabel(collapsed: boolean): string {
+  return collapsed ? SIDEBAR_TOGGLE_LABEL.EXPAND : SIDEBAR_TOGGLE_LABEL.COLLAPSE;
+}
+
+/**
+ * The collapsed rail centers each icon by arithmetic rather than by
+ * re-centering the row once its label is gone. The inner panel's left inset —
+ * its own padding plus each item's — places a 16px icon so its centre sits
+ * within a pixel of the collapsed rail's centre; while this holds the label
+ * can stay in the flow, clipped by the rail, without the fold needing to
+ * restructure the row and flicker.
+ */
+export const SIDEBAR_ICON_SIZE = 16;
+export const SIDEBAR_ITEM_INSET = 22;
+
+export function collapsedIconCenterOffset(): number {
+  const iconCenter = SIDEBAR_ITEM_INSET + SIDEBAR_ICON_SIZE / 2;
+  const railCenter = SIDEBAR_WIDTH.COLLAPSED / 2;
+  return iconCenter - railCenter;
+}

--- a/apps/web/src/admin-sidebar.ts
+++ b/apps/web/src/admin-sidebar.ts
@@ -41,18 +41,26 @@ export function sidebarToggleLabel(collapsed: boolean): string {
 }
 
 /**
- * The collapsed rail centers each icon by arithmetic rather than by
- * re-centering the row once its label is gone. The inner panel's left inset —
- * its own padding plus each item's — places a 16px icon so its centre sits
- * within a pixel of the collapsed rail's centre; while this holds the label
- * can stay in the flow, clipped by the rail, without the fold needing to
- * restructure the row and flicker.
+ * Each row leads with an icon slot exactly the collapsed rail's width. That one
+ * choice carries both halves of a clean fold: the icon centred in the slot sits
+ * on the rail's own centre, and the label that follows the slot begins at the
+ * rail's edge — so when the rail is collapsed the label starts past the clip
+ * and no fragment of it shows, without the label ever leaving the flow (which
+ * is what would re-flow the row and flicker). A slot narrower than the rail
+ * would leave a sliver of the next label inside it; a wider one would push the
+ * icon off centre. Tying it to the collapsed width keeps both true at once.
  */
-export const SIDEBAR_ICON_SIZE = 16;
-export const SIDEBAR_ITEM_INSET = 22;
+export const SIDEBAR_ICON_SLOT = SIDEBAR_WIDTH.COLLAPSED;
 
 export function collapsedIconCenterOffset(): number {
-  const iconCenter = SIDEBAR_ITEM_INSET + SIDEBAR_ICON_SIZE / 2;
-  const railCenter = SIDEBAR_WIDTH.COLLAPSED / 2;
-  return iconCenter - railCenter;
+  return SIDEBAR_ICON_SLOT / 2 - SIDEBAR_WIDTH.COLLAPSED / 2;
+}
+
+/**
+ * Where a label begins, measured from the rail's left edge: the slot's far
+ * edge. It must be at least the collapsed width so the collapsed rail clips the
+ * label entirely rather than revealing its first characters.
+ */
+export function labelStartOffset(): number {
+  return SIDEBAR_ICON_SLOT;
 }

--- a/apps/web/tests/admin-sidebar.test.ts
+++ b/apps/web/tests/admin-sidebar.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  collapsedIconCenterOffset,
+  SIDEBAR_TOGGLE_LABEL,
+  SIDEBAR_WIDTH,
+  sidebarRailWidth,
+  sidebarToggleLabel,
+} from "../src/admin-sidebar";
+
+test("the rail folds between its two fixed widths and nothing between", () => {
+  assert.equal(sidebarRailWidth(false), SIDEBAR_WIDTH.EXPANDED);
+  assert.equal(sidebarRailWidth(true), SIDEBAR_WIDTH.COLLAPSED);
+  assert.ok(SIDEBAR_WIDTH.COLLAPSED < SIDEBAR_WIDTH.EXPANDED);
+});
+
+test("the collapsed rail keeps the icon within a pixel of centre without re-centring the row", () => {
+  // The fold's smoothness rests on this: because the icon is already centred
+  // by the panel's inset, the label can stay in the flow and be clipped rather
+  // than removed, so folding never restructures the row and flickers.
+  assert.ok(Math.abs(collapsedIconCenterOffset()) <= 1);
+});
+
+test("the toggle names the act it offers, opposite to the state it is in", () => {
+  assert.equal(sidebarToggleLabel(true), SIDEBAR_TOGGLE_LABEL.EXPAND);
+  assert.equal(sidebarToggleLabel(false), SIDEBAR_TOGGLE_LABEL.COLLAPSE);
+});

--- a/apps/web/tests/admin-sidebar.test.ts
+++ b/apps/web/tests/admin-sidebar.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   collapsedIconCenterOffset,
+  labelStartOffset,
   SIDEBAR_TOGGLE_LABEL,
   SIDEBAR_WIDTH,
   sidebarRailWidth,
@@ -14,11 +15,17 @@ test("the rail folds between its two fixed widths and nothing between", () => {
   assert.ok(SIDEBAR_WIDTH.COLLAPSED < SIDEBAR_WIDTH.EXPANDED);
 });
 
-test("the collapsed rail keeps the icon within a pixel of centre without re-centring the row", () => {
-  // The fold's smoothness rests on this: because the icon is already centred
-  // by the panel's inset, the label can stay in the flow and be clipped rather
-  // than removed, so folding never restructures the row and flickers.
-  assert.ok(Math.abs(collapsedIconCenterOffset()) <= 1);
+test("the collapsed rail sits the icon on its centre without re-centring the row", () => {
+  // The fold's smoothness rests on this: because the icon slot is the rail's
+  // own width, the icon is centred and the label can stay in the flow and be
+  // clipped rather than removed, so folding never restructures the row.
+  assert.equal(collapsedIconCenterOffset(), 0);
+});
+
+test("a label begins at the collapsed edge, so the folded rail shows no fragment of it", () => {
+  // The bug this guards: a label that begins inside the collapsed width leaves
+  // its first characters peeking out of the folded rail.
+  assert.ok(labelStartOffset() >= SIDEBAR_WIDTH.COLLAPSED);
 });
 
 test("the toggle names the act it offers, opposite to the state it is in", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- The admin dashboard's sidebar folded by **swapping its contents while its width animated**: labels were conditionally removed and re-inserted (`collapsed ? null : label`) and each row toggled `justify-center`. So on every fold a label popped in, wrapped inside the still-narrow rail, and shoved its icon sideways before the `transition-[width]` caught up — the flicker.
- Now the rail folds by moving **one property, its width**, over a **fixed-width inner panel it clips**. The panel is always laid out at the expanded width, so a label is revealed or hidden by the moving clip edge rather than inserted; nothing inside the panel re-flows as the rail moves.
- Each row **leads with an icon slot exactly the collapsed rail's width** (62px). The icon centres in that slot — on the rail's own centre — and the label begins at the slot's far edge, i.e. the rail's edge, so the collapsed rail clips every label entirely with **no sliver peeking out**. Rows carry no horizontal padding of their own, since any would start the label short of that edge. (This is the fix for the Cursor Bugbot finding on the first pass, where the 62px rail was wider than where labels began ~48px in and showed a fragment.)
- The fold honours `prefers-reduced-motion` (`motion-reduce:transition-none`), snapping instantly for readers who ask for less motion.
- The two rail widths, the icon-slot width, the toggle's words, and the centring/label-start arithmetic live in a small pure module `apps/web/src/admin-sidebar.ts`, so the layout invariants the fold rests on are asserted without a DOM.

Labels stay in the tree (clipped) rather than removed, so a screen reader still hears every item; each collapsed item keeps its name on a `title` and the toggle keeps its `aria-label`.

## Evidence

- Platform-independent checks: `pnpm check` (= lint + typecheck + test + build, all packages) — **pass** on Node 24.
- macOS Electron verification (`./scripts/verify.sh`): `not applicable` — the change is confined to the web admin dashboard (`apps/web`) and does not touch the macOS Electron app or its notch surface; there is no macOS host in this environment.
- New unit tests: `apps/web/tests/admin-sidebar.test.ts` — the rail folds between its two fixed widths and nothing between; the collapsed icon sits exactly on centre; and a label begins at (or past) the collapsed edge so the folded rail shows no fragment. Web suite: **112 pass / 0 fail**.
- **Smoothness, measured at runtime** (real component in a dev harness): the rail's computed transition is `transition-property: width | duration: 0.15s | timing: cubic-bezier(0, 0, 0.2, 1)`, and sampling the width across a fold traces a clean ease-out curve — `224 → 171 → 137 → 113 → 95 → 82 → 73 → 67 → 63 → 62`px — i.e. an animated 150ms transition, not a snap.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32540531926/artifacts/9466895709) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32540531926)

- Commit: `c9b116b1352ff1d52ebd18f236ac558011491de7`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

Real `AdminSidebar` mounted in a dev harness (real classes, real `styles.css`); the harness is not part of this diff.

Collapsed rail at 200% zoom — icons only, no label fragments at the right edge:

![Collapsed sidebar rail showing only icons, no text fragments](https://cursor.com/artifacts/c/art-5702afc5-16fe-4900-a666-d82d138c04fb)

Expanded rail — full labels:

![Expanded sidebar showing Luke admin, Dashboard, Users, and Collapse labels](https://cursor.com/artifacts/c/art-5e18ee47-eec0-4707-8388-7445a56071d3)

- Physical-notch check: `not performed` — no notch surface is involved (web admin page, not the macOS panel).
- Device/display configuration: Chromium at 100% and 200% zoom, Linux VM.

## Notes

- Blockers or follow-up verification: None. Rebased onto latest `main` (resolved an import-order conflict). The Bugbot review comment on the first pass is addressed by the icon-slot geometry above.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-832e8276-bf8d-4f90-81ee-3a276494c2bd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-832e8276-bf8d-4f90-81ee-3a276494c2bd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

