### PR TITLE
feat(admin): let the window be 7, 30, or 90 days

### DIFF
--- a/apps/web/api/admin/metrics.ts
+++ b/apps/web/api/admin/metrics.ts
@@ -45,15 +45,17 @@ export default {
     return handleAdminMetrics({
       request,
       resolveViewer: resolveSessionViewer,
-      readMetrics: async (now, scope) =>
+      readMetrics: async (now, scope, windowDays) =>
         buildAdminMetrics(
           await readAdminMetricsSource(getDatabase(), {
             now,
             integrations,
             analyticsConsoleUrl,
             scope,
+            windowDays,
           }),
           now,
+          windowDays,
         ),
     });
   },

--- a/apps/web/api/admin/user.ts
+++ b/apps/web/api/admin/user.ts
@@ -15,9 +15,9 @@ export default {
     return handleAdminUser({
       request,
       resolveViewer: resolveSessionViewer,
-      readUser: async (userId, now) => {
-        const source = await readAdminUserSource(getDatabase(), { userId, now });
-        return source && buildAdminUserDetail(source, now);
+      readUser: async (userId, now, windowDays) => {
+        const source = await readAdminUserSource(getDatabase(), { userId, now, windowDays });
+        return source && buildAdminUserDetail(source, now, windowDays);
       },
     });
   },

--- a/apps/web/api/admin/users.ts
+++ b/apps/web/api/admin/users.ts
@@ -14,10 +14,11 @@ export default {
     return handleAdminUsers({
       request,
       resolveViewer: resolveSessionViewer,
-      readUsers: async (now, scope, viewerId) =>
+      readUsers: async (now, scope, viewerId, windowDays) =>
         buildAdminUserList(
-          await readAdminUsersSource(getDatabase(), { now, scope, viewerId }),
+          await readAdminUsersSource(getDatabase(), { now, scope, viewerId, windowDays }),
           now,
+          windowDays,
         ),
     });
   },

--- a/apps/web/server/admin/admin-metrics.ts
+++ b/apps/web/server/admin/admin-metrics.ts
@@ -4,7 +4,9 @@ import {
   ADMIN_ERROR,
   ADMIN_HTTP_STATUS,
   type AdminMetricsScope,
+  type AdminMetricsWindow,
   adminMetricsScope,
+  adminMetricsWindow,
   errorResponse,
   jsonResponse,
 } from "./http.js";
@@ -19,15 +21,22 @@ import {
  * that already landed.
  */
 
-/** The trailing window every rate and series here covers, in whole UTC days. */
-export const ADMIN_METRICS_WINDOW_DAYS = 30;
-
 /**
  * The trailing run each trend compares against the run immediately before it.
- * The window must hold both runs, or `prior` would be the truncated head of one
- * and read as a fall that never happened.
+ * The trend keeps this length whatever window the read asked for — a 7-day
+ * view still asks "up from last week?" — so the fetch, not the window, must
+ * hold both runs.
  */
 export const ADMIN_TREND_DAYS = 7;
+
+/**
+ * The days a source read must cover: the window itself, and both of a trend's
+ * runs even when the window is shorter than they are, or `prior` would be the
+ * truncated head of one and read as a fall that never happened.
+ */
+export function windowFetchDays(windowDays: AdminMetricsWindow): number {
+  return Math.max(windowDays, ADMIN_TREND_DAYS * 2);
+}
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const WEEK_MS = 7 * DAY_MS;
@@ -371,8 +380,16 @@ export function trailingTrend(counts: readonly number[], days: number): AdminTre
 }
 
 /** Shapes the queried source into the answer, zero-filling and totalling in one place. */
-export function buildAdminMetrics(source: AdminMetricsSource, now: number): AdminMetrics {
-  const dayKeys = lastNDayKeys(now, ADMIN_METRICS_WINDOW_DAYS);
+export function buildAdminMetrics(
+  source: AdminMetricsSource,
+  now: number,
+  windowDays: AdminMetricsWindow,
+): AdminMetrics {
+  const dayKeys = lastNDayKeys(now, windowDays);
+  // The trends read the same maps through their own trailing keys — the drawn
+  // series' own tail whenever the window holds both runs, and the wider fetch's
+  // when it does not — so a 7-day view still compares against the week before.
+  const trendKeys = lastNDayKeys(now, ADMIN_TREND_DAYS * 2);
   const todayKey = utcDayKey(now);
 
   const dailySignups = dayKeys.map((day) => ({
@@ -393,18 +410,20 @@ export function buildAdminMetrics(source: AdminMetricsSource, now: number): Admi
   // queried beside it: a rolling `now - 30 days` count and a series of whole
   // UTC days cover different spans, so two reads of "the last 30 days" would
   // disagree by the part-day between them and the page would contradict itself.
-  const signupCounts = dailySignups.map((day) => day.count);
   const voiceCallsWindow = sum(daily.map((day) => day.voiceCalls));
   const attentionReviewsWindow = sum(daily.map((day) => day.attentionReviews));
   const today = source.usage.byDay.get(todayKey);
 
   return {
     generatedAt: now,
-    windowDays: ADMIN_METRICS_WINDOW_DAYS,
+    windowDays,
     users: {
       total: source.users.total,
-      newInWindow: sum(signupCounts),
-      signupTrend: trailingTrend(signupCounts, ADMIN_TREND_DAYS),
+      newInWindow: sum(dailySignups.map((day) => day.count)),
+      signupTrend: trailingTrend(
+        trendKeys.map((day) => source.users.signupsByDay.get(day) ?? 0),
+        ADMIN_TREND_DAYS,
+      ),
       activeSessions: source.users.activeSessions,
       activeSessionUsers: source.users.activeSessionUsers,
       signInMethods: source.users.signInMethods,
@@ -418,7 +437,10 @@ export function buildAdminMetrics(source: AdminMetricsSource, now: number): Admi
       activeUsersToday: source.usage.activeUsersToday,
       activeUsersWindow: source.usage.activeUsersWindow,
       usageTrend: trailingTrend(
-        daily.map((day) => day.voiceCalls + day.attentionReviews),
+        trendKeys.map((day) => {
+          const row = source.usage.byDay.get(day);
+          return (row?.voiceCalls ?? 0) + (row?.attentionReviews ?? 0);
+        }),
         ADMIN_TREND_DAYS,
       ),
       daily,
@@ -449,17 +471,22 @@ export interface AdminMetricsOptions {
    * `viewer.role` is the account's own `role`, read from the session.
    */
   resolveViewer: (request: Request) => Promise<AdminViewer | undefined>;
-  readMetrics: (now: number, scope: AdminMetricsScope) => Promise<AdminMetrics>;
+  readMetrics: (
+    now: number,
+    scope: AdminMetricsScope,
+    windowDays: AdminMetricsWindow,
+  ) => Promise<AdminMetrics>;
   now?: () => number;
 }
 
 /**
  * Answers the dashboard's read, gated in steps that stay distinct: an anonymous
  * request is a 401 the page answers with a sign-in, a signed-in non-admin is a
- * 403 the page answers with a plain refusal, and metrics are read only past
- * both. A seam that throws — auth or the database not answering — is a 503 JSON
- * refusal rather than an unhandled crash, so the page can say "try again"
- * instead of failing to parse a platform error page.
+ * 403 the page answers with a plain refusal, a window outside the fixed set is
+ * a 400, and metrics are read only past all three. A seam that throws — auth or
+ * the database not answering — is a 503 JSON refusal rather than an unhandled
+ * crash, so the page can say "try again" instead of failing to parse a platform
+ * error page.
  */
 export async function handleAdminMetrics(options: AdminMetricsOptions): Promise<Response> {
   const { request } = options;
@@ -480,11 +507,16 @@ export async function handleAdminMetrics(options: AdminMetricsOptions): Promise<
     return errorResponse(ADMIN_HTTP_STATUS.FORBIDDEN, ADMIN_ERROR.NOT_AUTHORIZED);
   }
 
+  const windowDays = adminMetricsWindow(request.url);
+  if (windowDays === undefined) {
+    return errorResponse(ADMIN_HTTP_STATUS.BAD_REQUEST, ADMIN_ERROR.INVALID_WINDOW);
+  }
+
   const now = (options.now ?? Date.now)();
   try {
     return jsonResponse(
       ADMIN_HTTP_STATUS.OK,
-      await options.readMetrics(now, adminMetricsScope(request.url)),
+      await options.readMetrics(now, adminMetricsScope(request.url), windowDays),
     );
   } catch {
     return errorResponse(ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE, ADMIN_ERROR.UNAVAILABLE);

--- a/apps/web/server/admin/admin-queries.ts
+++ b/apps/web/server/admin/admin-queries.ts
@@ -20,7 +20,6 @@ import { hostedUsage } from "../db/usage-schema.js";
 import { HOSTED_DAILY_LIMIT, HOSTED_METER, utcDayKey } from "../hosted/quota.js";
 import { isAdminRole, USER_ROLE } from "./admin-access.js";
 import {
-  ADMIN_METRICS_WINDOW_DAYS,
   ADMIN_RETENTION_WEEKS,
   type AdminIntegration,
   type AdminMetricsSource,
@@ -30,10 +29,11 @@ import {
   lastNDayKeys,
   lastNWeekStartKeys,
   utcWeekStartKey,
+  windowFetchDays,
 } from "./admin-metrics.js";
 import type { AdminUserSource } from "./admin-user.js";
 import { ADMIN_USERS_LIMIT, type AdminUserListSource } from "./admin-users.js";
-import { ADMIN_METRICS_SCOPE, type AdminMetricsScope } from "./http.js";
+import { ADMIN_METRICS_SCOPE, type AdminMetricsScope, type AdminMetricsWindow } from "./http.js";
 
 /** How many of the most active hosted-tier accounts the overview names. */
 export const ADMIN_TOP_USERS_LIMIT = 10;
@@ -72,7 +72,7 @@ async function probeDatabase(
 async function readUserMetrics(
   database: Database,
   now: number,
-  windowStart: Date,
+  fetchStart: Date,
   scope: AdminMetricsScope,
 ): Promise<AdminMetricsSource["users"]> {
   const dayExpression = sql<string>`to_char(${user.createdAt} at time zone 'UTC', 'YYYY-MM-DD')`;
@@ -100,7 +100,7 @@ async function readUserMetrics(
       database
         .select({ day: dayExpression, value: count() })
         .from(user)
-        .where(and(gte(user.createdAt, windowStart), scopeCondition(scope)))
+        .where(and(gte(user.createdAt, fetchStart), scopeCondition(scope)))
         .groupBy(dayExpression),
     ]);
 
@@ -120,9 +120,13 @@ async function readUsageMetrics(
   database: Database,
   todayKey: string,
   windowStartDay: string,
+  fetchStartDay: string,
   scope: AdminMetricsScope,
 ): Promise<AdminMetricsSource["usage"]> {
   const [usageRows, [activeTodayRow], [activeWindowRow], topUserRows] = await Promise.all([
+    // The daily rows alone read from the wider fetch bound: the builder's
+    // trends need both of their runs even when the window is shorter, while
+    // every windowed aggregate below stays on the window's own bound.
     database
       .select({
         day: hostedUsage.day,
@@ -131,7 +135,7 @@ async function readUsageMetrics(
       })
       .from(hostedUsage)
       .innerJoin(user, eq(hostedUsage.userId, user.id))
-      .where(and(gte(hostedUsage.day, windowStartDay), scopeCondition(scope)))
+      .where(and(gte(hostedUsage.day, fetchStartDay), scopeCondition(scope)))
       .groupBy(hostedUsage.day),
     database
       .select({ value: count() })
@@ -334,19 +338,21 @@ export async function readAdminMetricsSource(
     integrations: readonly AdminIntegration[];
     analyticsConsoleUrl?: string;
     scope: AdminMetricsScope;
+    windowDays: AdminMetricsWindow;
   },
 ): Promise<AdminMetricsSource> {
   const health = await probeDatabase(database);
   if (!health.reachable) return emptySource(input.integrations, health, input.analyticsConsoleUrl);
 
-  const dayKeys = lastNDayKeys(input.now, ADMIN_METRICS_WINDOW_DAYS);
-  const windowStartDay = dayKeys[0] ?? utcDayKey(input.now);
+  const windowStartDay = lastNDayKeys(input.now, input.windowDays)[0] ?? utcDayKey(input.now);
+  const fetchStartDay =
+    lastNDayKeys(input.now, windowFetchDays(input.windowDays))[0] ?? utcDayKey(input.now);
   const todayKey = utcDayKey(input.now);
-  const windowStart = new Date(`${windowStartDay}T00:00:00.000Z`);
+  const fetchStart = new Date(`${fetchStartDay}T00:00:00.000Z`);
 
   const [users, usage, retention, reliability] = await Promise.all([
-    readUserMetrics(database, input.now, windowStart, input.scope),
-    readUsageMetrics(database, todayKey, windowStartDay, input.scope),
+    readUserMetrics(database, input.now, fetchStart, input.scope),
+    readUsageMetrics(database, todayKey, windowStartDay, fetchStartDay, input.scope),
     readRetentionMetrics(database, input.now, input.scope),
     readReliabilityMetrics(database, todayKey, windowStartDay, input.scope),
   ]);
@@ -369,10 +375,13 @@ export async function readAdminMetricsSource(
  */
 export async function readAdminUserSource(
   database: Database,
-  input: { userId: string; now: number },
+  input: { userId: string; now: number; windowDays: AdminMetricsWindow },
 ): Promise<AdminUserSource | undefined> {
-  const dayKeys = lastNDayKeys(input.now, ADMIN_METRICS_WINDOW_DAYS);
-  const windowStartDay = dayKeys[0] ?? utcDayKey(input.now);
+  const windowStartDay = lastNDayKeys(input.now, input.windowDays)[0] ?? utcDayKey(input.now);
+  // The daily rows read from the wider bound so the builder's trends hold
+  // both runs; the throttle count below stays on the window's own.
+  const fetchStartDay =
+    lastNDayKeys(input.now, windowFetchDays(input.windowDays))[0] ?? utcDayKey(input.now);
 
   const [userRows, accountRows, windowRows, [allTimeRow], [quotaRow]] = await Promise.all([
     database
@@ -398,7 +407,7 @@ export async function readAdminUserSource(
         attentionReviews: hostedUsage.attentionReviews,
       })
       .from(hostedUsage)
-      .where(and(eq(hostedUsage.userId, input.userId), gte(hostedUsage.day, windowStartDay))),
+      .where(and(eq(hostedUsage.userId, input.userId), gte(hostedUsage.day, fetchStartDay))),
     database
       .select({
         activeDays: count(),
@@ -469,10 +478,14 @@ export async function readAdminUserSource(
  */
 export async function readAdminUsersSource(
   database: Database,
-  input: { now: number; scope: AdminMetricsScope; viewerId: string },
+  input: {
+    now: number;
+    scope: AdminMetricsScope;
+    viewerId: string;
+    windowDays: AdminMetricsWindow;
+  },
 ): Promise<AdminUserListSource> {
-  const dayKeys = lastNDayKeys(input.now, ADMIN_METRICS_WINDOW_DAYS);
-  const windowStartDay = dayKeys[0] ?? utcDayKey(input.now);
+  const windowStartDay = lastNDayKeys(input.now, input.windowDays)[0] ?? utcDayKey(input.now);
 
   const [[totalRow], lastSeenRows, rows] = await Promise.all([
     database.select({ value: count() }).from(user).where(scopeCondition(input.scope)),

--- a/apps/web/server/admin/admin-user.ts
+++ b/apps/web/server/admin/admin-user.ts
@@ -1,7 +1,6 @@
 import type { AdminViewer } from "./admin-access.js";
 import { isAdminRole } from "./admin-access.js";
 import {
-  ADMIN_METRICS_WINDOW_DAYS,
   ADMIN_TREND_DAYS,
   type AdminDailyUsage,
   type AdminTrend,
@@ -13,6 +12,8 @@ import {
 import {
   ADMIN_ERROR,
   ADMIN_HTTP_STATUS,
+  type AdminMetricsWindow,
+  adminMetricsWindow,
   adminUserId,
   errorResponse,
   jsonResponse,
@@ -91,8 +92,19 @@ export interface AdminUserDetail {
 }
 
 /** Shapes one account's queried source into the page's answer. */
-export function buildAdminUserDetail(source: AdminUserSource, now: number): AdminUserDetail {
-  const dayKeys = lastNDayKeys(now, ADMIN_METRICS_WINDOW_DAYS);
+export function buildAdminUserDetail(
+  source: AdminUserSource,
+  now: number,
+  windowDays: AdminMetricsWindow,
+): AdminUserDetail {
+  const dayKeys = lastNDayKeys(now, windowDays);
+  // The trends read the byDay map through their own trailing keys, like the
+  // overview's, so a 7-day view still compares against the week before it.
+  const trendKeys = lastNDayKeys(now, ADMIN_TREND_DAYS * 2);
+  const trendTotals = trendKeys.map((day) => {
+    const row = source.usage.byDay.get(day);
+    return (row?.voiceCalls ?? 0) + (row?.attentionReviews ?? 0);
+  });
 
   const daily = dayKeys.map((day) => {
     const row = source.usage.byDay.get(day);
@@ -113,17 +125,14 @@ export function buildAdminUserDetail(source: AdminUserSource, now: number): Admi
 
   return {
     generatedAt: now,
-    windowDays: ADMIN_METRICS_WINDOW_DAYS,
+    windowDays,
     account: source.account,
     activity: {
       daily,
-      usageTrend: trailingTrend(
-        daily.map((day) => day.voiceCalls + day.attentionReviews),
-        ADMIN_TREND_DAYS,
-      ),
+      usageTrend: trailingTrend(trendTotals, ADMIN_TREND_DAYS),
       activeDaysWindow: activeFlags.filter(Boolean).length,
       activeDaysTrend: trailingTrend(
-        activeFlags.map((active) => (active ? 1 : 0)),
+        trendTotals.map((total) => (total > 0 ? 1 : 0)),
         ADMIN_TREND_DAYS,
       ),
       currentStreakDays,
@@ -139,16 +148,21 @@ export interface AdminUserOptions {
   request: Request;
   resolveViewer: (request: Request) => Promise<AdminViewer | undefined>;
   /** The named account's detail, or nothing when no user row carries that id. */
-  readUser: (userId: string, now: number) => Promise<AdminUserDetail | undefined>;
+  readUser: (
+    userId: string,
+    now: number,
+    windowDays: AdminMetricsWindow,
+  ) => Promise<AdminUserDetail | undefined>;
   now?: () => number;
 }
 
 /**
  * Answers one account's read behind the same gate the overview's metrics
  * stand behind, with the same distinct refusals, plus the two of its own: a
- * request that named no account is a 400 before any seam is touched, and an
- * id no user row carries is a 404 the page can word as the account being
- * gone rather than the service being down.
+ * request that named no account, like one naming a window outside the fixed
+ * set, is a 400 before any seam is touched, and an id no user row carries is
+ * a 404 the page can word as the account being gone rather than the service
+ * being down.
  */
 export async function handleAdminUser(options: AdminUserOptions): Promise<Response> {
   const { request } = options;
@@ -174,9 +188,14 @@ export async function handleAdminUser(options: AdminUserOptions): Promise<Respon
     return errorResponse(ADMIN_HTTP_STATUS.BAD_REQUEST, ADMIN_ERROR.MISSING_USER_ID);
   }
 
+  const windowDays = adminMetricsWindow(request.url);
+  if (windowDays === undefined) {
+    return errorResponse(ADMIN_HTTP_STATUS.BAD_REQUEST, ADMIN_ERROR.INVALID_WINDOW);
+  }
+
   const now = (options.now ?? Date.now)();
   try {
-    const detail = await options.readUser(userId, now);
+    const detail = await options.readUser(userId, now, windowDays);
     if (detail === undefined) {
       return errorResponse(ADMIN_HTTP_STATUS.NOT_FOUND, ADMIN_ERROR.USER_NOT_FOUND);
     }

--- a/apps/web/server/admin/admin-users.ts
+++ b/apps/web/server/admin/admin-users.ts
@@ -1,11 +1,12 @@
 import type { AdminViewer } from "./admin-access.js";
 import { isAdminRole } from "./admin-access.js";
-import { ADMIN_METRICS_WINDOW_DAYS } from "./admin-metrics.js";
 import {
   ADMIN_ERROR,
   ADMIN_HTTP_STATUS,
   type AdminMetricsScope,
+  type AdminMetricsWindow,
   adminMetricsScope,
+  adminMetricsWindow,
   errorResponse,
   jsonResponse,
 } from "./http.js";
@@ -69,10 +70,14 @@ export interface AdminUserListSource {
 }
 
 /** Stamps the queried roster with the window the aggregates cover. */
-export function buildAdminUserList(source: AdminUserListSource, now: number): AdminUserList {
+export function buildAdminUserList(
+  source: AdminUserListSource,
+  now: number,
+  windowDays: AdminMetricsWindow,
+): AdminUserList {
   return {
     generatedAt: now,
-    windowDays: ADMIN_METRICS_WINDOW_DAYS,
+    windowDays,
     total: source.total,
     limit: ADMIN_USERS_LIMIT,
     rows: [...source.rows],
@@ -83,14 +88,19 @@ export interface AdminUsersOptions {
   request: Request;
   resolveViewer: (request: Request) => Promise<AdminViewer | undefined>;
   /** Reads the roster as one viewer sees it: the favorites are theirs. */
-  readUsers: (now: number, scope: AdminMetricsScope, viewerId: string) => Promise<AdminUserList>;
+  readUsers: (
+    now: number,
+    scope: AdminMetricsScope,
+    viewerId: string,
+    windowDays: AdminMetricsWindow,
+  ) => Promise<AdminUserList>;
   now?: () => number;
 }
 
 /**
  * Answers the roster read behind the same gate and refusals the metrics read
- * stands behind, at the same scope vocabulary: the Users tab hides admin
- * accounts by default the way every dashboard count does.
+ * stands behind, at the same scope and window vocabulary: the Users tab hides
+ * admin accounts by default the way every dashboard count does.
  */
 export async function handleAdminUsers(options: AdminUsersOptions): Promise<Response> {
   const { request } = options;
@@ -111,11 +121,16 @@ export async function handleAdminUsers(options: AdminUsersOptions): Promise<Resp
     return errorResponse(ADMIN_HTTP_STATUS.FORBIDDEN, ADMIN_ERROR.NOT_AUTHORIZED);
   }
 
+  const windowDays = adminMetricsWindow(request.url);
+  if (windowDays === undefined) {
+    return errorResponse(ADMIN_HTTP_STATUS.BAD_REQUEST, ADMIN_ERROR.INVALID_WINDOW);
+  }
+
   const now = (options.now ?? Date.now)();
   try {
     return jsonResponse(
       ADMIN_HTTP_STATUS.OK,
-      await options.readUsers(now, adminMetricsScope(request.url), viewer.userId),
+      await options.readUsers(now, adminMetricsScope(request.url), viewer.userId, windowDays),
     );
   } catch {
     return errorResponse(ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE, ADMIN_ERROR.UNAVAILABLE);

--- a/apps/web/server/admin/http.ts
+++ b/apps/web/server/admin/http.ts
@@ -26,6 +26,8 @@ export const ADMIN_ERROR = {
   METHOD_NOT_ALLOWED: "method-not-allowed",
   /** A detail read that named no account, or named one past the id bound. */
   MISSING_USER_ID: "missing-user-id",
+  /** A read that named a window outside the fixed set of lengths. */
+  INVALID_WINDOW: "invalid-window",
   /** The named account has no user row — deleted, or the id never existed. */
   USER_NOT_FOUND: "user-not-found",
   /** A seam (auth or the database) did not answer; the answer is a JSON refusal, never a crash. */
@@ -61,6 +63,37 @@ export function adminMetricsScope(url: string): AdminMetricsScope {
   return value === ADMIN_METRICS_SCOPE.ALL
     ? ADMIN_METRICS_SCOPE.ALL
     : ADMIN_METRICS_SCOPE.NON_ADMINS;
+}
+
+/**
+ * The trailing windows a read may cover, in whole UTC days. A fixed set rather
+ * than a free number because the window bounds every aggregate query the read
+ * fans out into; it lives here, like the scope, because both sides of the
+ * request speak it.
+ */
+export const ADMIN_METRICS_WINDOW = {
+  WEEK: 7,
+  MONTH: 30,
+  QUARTER: 90,
+} as const;
+
+export type AdminMetricsWindow = (typeof ADMIN_METRICS_WINDOW)[keyof typeof ADMIN_METRICS_WINDOW];
+
+export const ADMIN_METRICS_WINDOW_PARAM = "window";
+
+export const ADMIN_METRICS_WINDOW_DEFAULT = ADMIN_METRICS_WINDOW.MONTH;
+
+/**
+ * The window a request asked for: the default when it asked for none, and
+ * nothing when it named one outside the set. Unlike the scope, an unknown
+ * value does not fall to the default — a scope misread narrows the answer
+ * safely, where a window misread would reshape every number on the page while
+ * the response still names the window it substituted.
+ */
+export function adminMetricsWindow(url: string): AdminMetricsWindow | undefined {
+  const value = new URL(url).searchParams.get(ADMIN_METRICS_WINDOW_PARAM);
+  if (value === null) return ADMIN_METRICS_WINDOW_DEFAULT;
+  return Object.values(ADMIN_METRICS_WINDOW).find((candidate) => String(candidate) === value);
 }
 
 export const ADMIN_USER_ID_PARAM = "id";

--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -16,7 +16,11 @@ import {
   ADMIN_HTTP_STATUS,
   ADMIN_METRICS_SCOPE,
   ADMIN_METRICS_SCOPE_PARAM,
+  ADMIN_METRICS_WINDOW,
+  ADMIN_METRICS_WINDOW_DEFAULT,
+  ADMIN_METRICS_WINDOW_PARAM,
   ADMIN_USER_ID_PARAM,
+  type AdminMetricsWindow,
 } from "../server/admin/http";
 import { accountInitials } from "./account-initials";
 import { accountLabel } from "./account-label";
@@ -51,6 +55,7 @@ const FAVORITE_PATH = "/api/admin/favorite";
 const ACCOUNT_VIEW_PARAM = "user";
 const TAB_PARAM = "view";
 const USERS_TAB_VALUE = "users";
+const WINDOW_VIEW_PARAM = "days";
 
 /** The sidebar's two destinations; an open account highlights Users. */
 type AdminTab = "dashboard" | "users";
@@ -66,14 +71,52 @@ function viewFromLocation(): AdminView {
   return { kind: "dashboard" };
 }
 
+/**
+ * The window the address bar names, so a 90-day view is shareable and survives
+ * a reload. An address naming no window, or one outside the set, is the
+ * default view rather than a broken page — a link is the reader's, not a
+ * request the API gets to refuse.
+ */
+function windowFromLocation(): AdminMetricsWindow {
+  const value = new URLSearchParams(window.location.search).get(WINDOW_VIEW_PARAM);
+  return (
+    Object.values(ADMIN_METRICS_WINDOW).find((candidate) => String(candidate) === value) ??
+    ADMIN_METRICS_WINDOW_DEFAULT
+  );
+}
+
+/**
+ * A page address from its own params, carrying the window the address bar
+ * currently names, so navigating between views keeps the chosen window. The
+ * default window rides as no param at all, keeping the plain addresses plain.
+ */
+function hrefWithWindow(params: URLSearchParams): string {
+  const windowDays = windowFromLocation();
+  if (windowDays !== ADMIN_METRICS_WINDOW_DEFAULT) {
+    params.set(WINDOW_VIEW_PARAM, String(windowDays));
+  }
+  const query = params.toString();
+  return query ? `${window.location.pathname}?${query}` : window.location.pathname;
+}
+
 function accountHref(id: string): string {
-  return `${window.location.pathname}?${ACCOUNT_VIEW_PARAM}=${encodeURIComponent(id)}`;
+  const params = new URLSearchParams();
+  params.set(ACCOUNT_VIEW_PARAM, id);
+  return hrefWithWindow(params);
 }
 
 function tabHref(tab: AdminTab): string {
-  return tab === "users"
-    ? `${window.location.pathname}?${TAB_PARAM}=${USERS_TAB_VALUE}`
-    : window.location.pathname;
+  const params = new URLSearchParams();
+  if (tab === "users") params.set(TAB_PARAM, USERS_TAB_VALUE);
+  return hrefWithWindow(params);
+}
+
+function windowHref(windowDays: AdminMetricsWindow): string {
+  const params = new URLSearchParams(window.location.search);
+  if (windowDays === ADMIN_METRICS_WINDOW_DEFAULT) params.delete(WINDOW_VIEW_PARAM);
+  else params.set(WINDOW_VIEW_PARAM, String(windowDays));
+  const query = params.toString();
+  return query ? `${window.location.pathname}?${query}` : window.location.pathname;
 }
 
 /**
@@ -1061,11 +1104,60 @@ function RefreshFailureNotice({
   );
 }
 
+/**
+ * The window every windowed read answers to, as one control of three fixed
+ * lengths. The choice lives in the address bar, so the press hands it up
+ * rather than keeping state of its own, and flipping it refetches the way the
+ * scope toggle does.
+ */
+function WindowSwitcher({
+  value,
+  onChange,
+}: {
+  value: AdminMetricsWindow;
+  onChange: (windowDays: AdminMetricsWindow) => void;
+}): React.JSX.Element {
+  return (
+    <div className="inline-flex rounded-md border border-border bg-card p-0.5">
+      {Object.values(ADMIN_METRICS_WINDOW).map((windowDays) => (
+        <button
+          key={windowDays}
+          type="button"
+          aria-label={`${windowDays}-day window`}
+          aria-pressed={value === windowDays}
+          data-active={value === windowDays}
+          className="cursor-pointer rounded px-2 py-0.5 text-xs font-medium text-muted-foreground transition-colors duration-150 outline-offset-2 hover:text-foreground data-[active=true]:bg-muted data-[active=true]:text-foreground"
+          onClick={() => onChange(windowDays)}
+        >
+          {windowDays}d
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/** A windowed read's address: the default scope and window ride as no params. */
+function windowedReadPath(
+  base: string,
+  hideAdmins: boolean,
+  windowDays: AdminMetricsWindow,
+): string {
+  const params = new URLSearchParams();
+  if (!hideAdmins) params.set(ADMIN_METRICS_SCOPE_PARAM, ADMIN_METRICS_SCOPE.ALL);
+  if (windowDays !== ADMIN_METRICS_WINDOW_DEFAULT) {
+    params.set(ADMIN_METRICS_WINDOW_PARAM, String(windowDays));
+  }
+  const query = params.toString();
+  return query ? `${base}?${query}` : base;
+}
+
 function Dashboard({
   metrics,
   refreshFailure,
   hideAdmins,
   onHideAdminsChange,
+  windowDays,
+  onWindowDaysChange,
   account,
   onSignOut,
   refreshing,
@@ -1077,6 +1169,8 @@ function Dashboard({
   refreshFailure: string | undefined;
   hideAdmins: boolean;
   onHideAdminsChange: (hide: boolean) => void;
+  windowDays: AdminMetricsWindow;
+  onWindowDaysChange: (windowDays: AdminMetricsWindow) => void;
   account: ViewerAccount | undefined;
   onSignOut: () => void;
   refreshing: boolean;
@@ -1094,6 +1188,7 @@ function Dashboard({
         onSignOut={onSignOut}
         controls={
           <>
+            <WindowSwitcher value={windowDays} onChange={onWindowDaysChange} />
             <label className="inline-flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground select-none">
               <input
                 type="checkbox"
@@ -1984,6 +2079,8 @@ function UsersPage({
   refreshFailure,
   hideAdmins,
   onHideAdminsChange,
+  windowDays,
+  onWindowDaysChange,
   account,
   onSignOut,
   onOpenAccount,
@@ -1996,6 +2093,8 @@ function UsersPage({
   refreshFailure: string | undefined;
   hideAdmins: boolean;
   onHideAdminsChange: (hide: boolean) => void;
+  windowDays: AdminMetricsWindow;
+  onWindowDaysChange: (windowDays: AdminMetricsWindow) => void;
   account: ViewerAccount | undefined;
   onSignOut: () => void;
   onOpenAccount: (id: string) => void;
@@ -2018,6 +2117,7 @@ function UsersPage({
         onSignOut={onSignOut}
         controls={
           <>
+            <WindowSwitcher value={windowDays} onChange={onWindowDaysChange} />
             <label className="inline-flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground select-none">
               <input
                 type="checkbox"
@@ -2087,6 +2187,8 @@ function UsersPage({
 function UsersScreen({
   hideAdmins,
   onHideAdminsChange,
+  windowDays,
+  onWindowDaysChange,
   account,
   onSignOut,
   onOpenAccount,
@@ -2095,6 +2197,8 @@ function UsersScreen({
 }: {
   hideAdmins: boolean;
   onHideAdminsChange: (hide: boolean) => void;
+  windowDays: AdminMetricsWindow;
+  onWindowDaysChange: (windowDays: AdminMetricsWindow) => void;
   account: ViewerAccount | undefined;
   onSignOut: () => Promise<void>;
   onOpenAccount: (id: string) => void;
@@ -2128,9 +2232,7 @@ function UsersScreen({
     inFlight.current = controller;
     setState((current) => (current.status === "ready" ? current : { status: "loading" }));
     setRefreshing(true);
-    const path = hideAdmins
-      ? USERS_PATH
-      : `${USERS_PATH}?${ADMIN_METRICS_SCOPE_PARAM}=${ADMIN_METRICS_SCOPE.ALL}`;
+    const path = windowedReadPath(USERS_PATH, hideAdmins, windowDays);
     void (async () => {
       try {
         const next = await readUsersState(
@@ -2151,7 +2253,7 @@ function UsersScreen({
         if (!controller.signal.aborted) setRefreshing(false);
       }
     })();
-  }, [hideAdmins]);
+  }, [hideAdmins, windowDays]);
 
   useEffect(() => {
     load();
@@ -2235,6 +2337,8 @@ function UsersScreen({
           refreshFailure={state.refreshFailure}
           hideAdmins={hideAdmins}
           onHideAdminsChange={onHideAdminsChange}
+          windowDays={windowDays}
+          onWindowDaysChange={onWindowDaysChange}
           account={account}
           onSignOut={() => void signOut()}
           onOpenAccount={onOpenAccount}
@@ -2405,11 +2509,16 @@ export function AdminDashboard(): React.JSX.Element {
   const session = authClient.useSession();
   const account = session.data?.user;
 
-  // The address bar owns which view is open, so a tab or an account page can
-  // be reloaded, shared, and left with the browser's own back button.
+  // The address bar owns which view is open — and which window it covers — so
+  // a tab, an account page, or a 90-day view can be reloaded, shared, and left
+  // with the browser's own back button.
   const [view, setView] = useState<AdminView>(viewFromLocation);
+  const [windowDays, setWindowDays] = useState<AdminMetricsWindow>(windowFromLocation);
   useEffect(() => {
-    const onPopState = () => setView(viewFromLocation());
+    const onPopState = () => {
+      setView(viewFromLocation());
+      setWindowDays(windowFromLocation());
+    };
     window.addEventListener("popstate", onPopState);
     return () => window.removeEventListener("popstate", onPopState);
   }, []);
@@ -2420,6 +2529,13 @@ export function AdminDashboard(): React.JSX.Element {
   const navigate = useCallback((tab: AdminTab) => {
     window.history.pushState(null, "", tabHref(tab));
     setView(tab === "users" ? { kind: "users" } : { kind: "dashboard" });
+  }, []);
+  const changeWindow = useCallback((next: AdminMetricsWindow) => {
+    setWindowDays((current) => {
+      if (next === current) return current;
+      window.history.pushState(null, "", windowHref(next));
+      return next;
+    });
   }, []);
 
   const [sidebarFolded, setSidebarFolded] = useState(sidebarLeftCollapsed);
@@ -2450,9 +2566,7 @@ export function AdminDashboard(): React.JSX.Element {
     // one filter throws away the reader's place and reads as a fault.
     setState((current) => (current.status === "ready" ? current : { status: "loading" }));
     setRefreshing(true);
-    const path = hideAdmins
-      ? METRICS_PATH
-      : `${METRICS_PATH}?${ADMIN_METRICS_SCOPE_PARAM}=${ADMIN_METRICS_SCOPE.ALL}`;
+    const path = windowedReadPath(METRICS_PATH, hideAdmins, windowDays);
     void (async () => {
       try {
         const next = await readDashboardState(
@@ -2473,7 +2587,7 @@ export function AdminDashboard(): React.JSX.Element {
         if (!controller.signal.aborted) setRefreshing(false);
       }
     })();
-  }, [hideAdmins]);
+  }, [hideAdmins, windowDays]);
 
   useEffect(() => {
     // The dashboard's read waits while another view is open; coming back
@@ -2537,6 +2651,8 @@ export function AdminDashboard(): React.JSX.Element {
       <UsersScreen
         hideAdmins={hideAdmins}
         onHideAdminsChange={changeHideAdmins}
+        windowDays={windowDays}
+        onWindowDaysChange={changeWindow}
         account={viewer}
         onSignOut={signOut}
         onOpenAccount={openAccount}
@@ -2576,6 +2692,8 @@ export function AdminDashboard(): React.JSX.Element {
           refreshFailure={state.refreshFailure}
           hideAdmins={hideAdmins}
           onHideAdminsChange={changeHideAdmins}
+          windowDays={windowDays}
+          onWindowDaysChange={changeWindow}
           account={viewer}
           onSignOut={() => void signOut()}
           refreshing={refreshing}

--- a/apps/web/tests/admin-metrics.test.ts
+++ b/apps/web/tests/admin-metrics.test.ts
@@ -3,7 +3,6 @@ import test from "node:test";
 import type { AdminViewer } from "../server/admin/admin-access";
 import {
   ADMIN_INTEGRATION,
-  ADMIN_METRICS_WINDOW_DAYS,
   ADMIN_RETENTION_WEEKS,
   ADMIN_TREND_DAYS,
   type AdminMetrics,
@@ -16,13 +15,19 @@ import {
   lastNWeekStartKeys,
   SIGN_IN_PROVIDER_ID,
   utcWeekStartKey,
+  windowFetchDays,
 } from "../server/admin/admin-metrics";
 import {
   ADMIN_ERROR,
   ADMIN_METRICS_SCOPE,
   ADMIN_METRICS_SCOPE_PARAM,
+  ADMIN_METRICS_WINDOW,
+  ADMIN_METRICS_WINDOW_DEFAULT,
+  ADMIN_METRICS_WINDOW_PARAM,
   type AdminMetricsScope,
+  type AdminMetricsWindow,
   adminMetricsScope,
+  adminMetricsWindow,
 } from "../server/admin/http";
 import { posthogProjectConsoleUrl } from "../server/hosted/posthog";
 import { HOSTED_DAILY_LIMIT, HOSTED_METER } from "../server/hosted/quota";
@@ -67,8 +72,8 @@ test("an empty account table is zero on every method", () => {
 });
 
 test("the window is a contiguous run of day keys ending on today", () => {
-  const keys = lastNDayKeys(NOON_UTC, ADMIN_METRICS_WINDOW_DAYS);
-  assert.equal(keys.length, ADMIN_METRICS_WINDOW_DAYS);
+  const keys = lastNDayKeys(NOON_UTC, ADMIN_METRICS_WINDOW.MONTH);
+  assert.equal(keys.length, ADMIN_METRICS_WINDOW.MONTH);
   assert.equal(keys[0], "2026-07-19");
   assert.equal(keys[keys.length - 1], "2026-08-17");
 });
@@ -87,9 +92,10 @@ test("the usage series is zero-filled and totalled across the window", () => {
       },
     }),
     NOON_UTC,
+    ADMIN_METRICS_WINDOW_DEFAULT,
   );
 
-  assert.equal(metrics.featureUsage.daily.length, ADMIN_METRICS_WINDOW_DAYS);
+  assert.equal(metrics.featureUsage.daily.length, ADMIN_METRICS_WINDOW_DEFAULT);
   assert.equal(metrics.featureUsage.voiceCallsToday, 3);
   assert.equal(metrics.featureUsage.attentionReviewsToday, 41);
   assert.equal(metrics.featureUsage.voiceCallsWindow, 8);
@@ -112,9 +118,10 @@ test("the signup series is zero-filled over the same window", () => {
       },
     }),
     NOON_UTC,
+    ADMIN_METRICS_WINDOW_DEFAULT,
   );
   assert.equal(metrics.users.total, 12);
-  assert.equal(metrics.users.dailySignups.length, ADMIN_METRICS_WINDOW_DAYS);
+  assert.equal(metrics.users.dailySignups.length, ADMIN_METRICS_WINDOW_DEFAULT);
   assert.equal(metrics.users.dailySignups[0]?.count, 1);
   assert.equal(metrics.users.dailySignups.at(-1)?.count, 2);
 });
@@ -134,6 +141,7 @@ test("the window's signup count is the series' own sum, never a second reading",
       },
     }),
     NOON_UTC,
+    ADMIN_METRICS_WINDOW_DEFAULT,
   );
   assert.equal(
     metrics.users.newInWindow,
@@ -142,8 +150,13 @@ test("the window's signup count is the series' own sum, never a second reading",
   assert.equal(metrics.users.newInWindow, 8);
 });
 
-test("the window holds both runs of a trend, so `prior` is never a truncated one", () => {
-  assert.ok(ADMIN_TREND_DAYS * 2 <= ADMIN_METRICS_WINDOW_DAYS);
+test("the fetch holds both runs of a trend, so `prior` is never a truncated one", () => {
+  for (const windowDays of Object.values(ADMIN_METRICS_WINDOW)) {
+    assert.ok(ADMIN_TREND_DAYS * 2 <= windowFetchDays(windowDays));
+    assert.ok(windowDays <= windowFetchDays(windowDays));
+  }
+  assert.equal(windowFetchDays(ADMIN_METRICS_WINDOW.WEEK), ADMIN_TREND_DAYS * 2);
+  assert.equal(windowFetchDays(ADMIN_METRICS_WINDOW.QUARTER), ADMIN_METRICS_WINDOW.QUARTER);
 });
 
 test("a trend is the trailing run beside the run immediately before it", () => {
@@ -172,6 +185,7 @@ test("a trend is the trailing run beside the run immediately before it", () => {
       },
     }),
     NOON_UTC,
+    ADMIN_METRICS_WINDOW_DEFAULT,
   );
 
   assert.deepEqual(metrics.users.signupTrend, { days: ADMIN_TREND_DAYS, recent: 4, prior: 8 });
@@ -182,8 +196,55 @@ test("a trend is the trailing run beside the run immediately before it", () => {
   });
 });
 
+test("a 7-day window narrows the series while its trend still sees the week before", () => {
+  const metrics = buildAdminMetrics(
+    source({
+      users: {
+        ...source().users,
+        signupsByDay: new Map([
+          // Inside the 7-day window (2026-08-11 through 2026-08-17).
+          ["2026-08-17", 2],
+          // Outside the window but inside the trend's prior run.
+          ["2026-08-06", 5],
+        ]),
+      },
+      usage: {
+        byDay: new Map([
+          ["2026-08-16", { voiceCalls: 3, attentionReviews: 1 }],
+          ["2026-08-05", { voiceCalls: 2, attentionReviews: 0 }],
+        ]),
+        activeUsersToday: 0,
+        activeUsersWindow: 1,
+        topUsers: [],
+      },
+    }),
+    NOON_UTC,
+    ADMIN_METRICS_WINDOW.WEEK,
+  );
+
+  assert.equal(metrics.windowDays, ADMIN_METRICS_WINDOW.WEEK);
+  assert.equal(metrics.users.dailySignups.length, ADMIN_METRICS_WINDOW.WEEK);
+  assert.equal(metrics.featureUsage.daily.length, ADMIN_METRICS_WINDOW.WEEK);
+  assert.equal(metrics.users.newInWindow, 2);
+  assert.equal(metrics.featureUsage.voiceCallsWindow, 3);
+  assert.equal(metrics.featureUsage.attentionReviewsWindow, 1);
+  assert.deepEqual(metrics.users.signupTrend, { days: ADMIN_TREND_DAYS, recent: 2, prior: 5 });
+  assert.deepEqual(metrics.featureUsage.usageTrend, {
+    days: ADMIN_TREND_DAYS,
+    recent: 4,
+    prior: 2,
+  });
+});
+
+test("a 90-day window widens the series to its own length", () => {
+  const metrics = buildAdminMetrics(source(), NOON_UTC, ADMIN_METRICS_WINDOW.QUARTER);
+  assert.equal(metrics.windowDays, ADMIN_METRICS_WINDOW.QUARTER);
+  assert.equal(metrics.users.dailySignups.length, ADMIN_METRICS_WINDOW.QUARTER);
+  assert.equal(metrics.featureUsage.daily.length, ADMIN_METRICS_WINDOW.QUARTER);
+});
+
 test("a trend over an empty window is zero on both runs rather than absent", () => {
-  const metrics = buildAdminMetrics(source(), NOON_UTC);
+  const metrics = buildAdminMetrics(source(), NOON_UTC, ADMIN_METRICS_WINDOW_DEFAULT);
   assert.deepEqual(metrics.users.signupTrend, { days: ADMIN_TREND_DAYS, recent: 0, prior: 0 });
   assert.deepEqual(metrics.featureUsage.usageTrend, {
     days: ADMIN_TREND_DAYS,
@@ -206,7 +267,7 @@ test("a week is named by its Monday, whichever day the instant falls on", () => 
 });
 
 test("retention cohorts are the trailing weeks, and unreached weeks are absent", () => {
-  const metrics = buildAdminMetrics(source(), NOON_UTC);
+  const metrics = buildAdminMetrics(source(), NOON_UTC, ADMIN_METRICS_WINDOW_DEFAULT);
   assert.equal(metrics.retention.weeks, ADMIN_RETENTION_WEEKS);
   assert.equal(metrics.retention.cohorts.length, ADMIN_RETENTION_WEEKS);
   assert.equal(metrics.retention.cohorts[0]?.weekStart, "2026-06-29");
@@ -242,6 +303,7 @@ test("a cohort's shares are its active accounts over its size, week by week", ()
       },
     }),
     NOON_UTC,
+    ADMIN_METRICS_WINDOW_DEFAULT,
   );
 
   const cohort = metrics.retention.cohorts[0];
@@ -273,6 +335,7 @@ test("only the current week's cells are in progress, in every cohort", () => {
       },
     }),
     NOON_UTC,
+    ADMIN_METRICS_WINDOW_DEFAULT,
   );
 
   for (const cohort of metrics.retention.cohorts) {
@@ -288,7 +351,7 @@ test("only the current week's cells are in progress, in every cohort", () => {
 });
 
 test("a cohort with no accounts keeps its count and states no share", () => {
-  const metrics = buildAdminMetrics(source(), NOON_UTC);
+  const metrics = buildAdminMetrics(source(), NOON_UTC, ADMIN_METRICS_WINDOW_DEFAULT);
   for (const cohort of metrics.retention.cohorts) {
     assert.equal(cohort.size, 0);
     for (const cell of cohort.cells) {
@@ -311,18 +374,22 @@ test("the most active accounts pass through the builder untouched", () => {
       total: 43,
     },
   ];
-  const metrics = buildAdminMetrics(source({ usage: { ...source().usage, topUsers } }), NOON_UTC);
+  const metrics = buildAdminMetrics(
+    source({ usage: { ...source().usage, topUsers } }),
+    NOON_UTC,
+    ADMIN_METRICS_WINDOW_DEFAULT,
+  );
   assert.deepEqual(metrics.featureUsage.topUsers, topUsers);
 });
 
 test("the daily ceilings are reported from the hosted quota, not restated", () => {
-  const metrics = buildAdminMetrics(source(), NOON_UTC);
+  const metrics = buildAdminMetrics(source(), NOON_UTC, ADMIN_METRICS_WINDOW_DEFAULT);
   assert.equal(metrics.reliability.voiceDailyLimit, HOSTED_DAILY_LIMIT[HOSTED_METER.VOICE_CALL]);
   assert.equal(
     metrics.reliability.attentionDailyLimit,
     HOSTED_DAILY_LIMIT[HOSTED_METER.ATTENTION_REVIEW],
   );
-  assert.equal(metrics.windowDays, ADMIN_METRICS_WINDOW_DAYS);
+  assert.equal(metrics.windowDays, ADMIN_METRICS_WINDOW_DEFAULT);
   assert.equal(metrics.generatedAt, NOON_UTC);
 });
 
@@ -336,6 +403,7 @@ test("the analytics console address rides through when configured and stays abse
       },
     }),
     NOON_UTC,
+    ADMIN_METRICS_WINDOW_DEFAULT,
   );
   assert.equal(configured.reliability.analyticsConsoleUrl, "https://us.posthog.com/project/12345");
 
@@ -349,13 +417,14 @@ test("the analytics console address rides through when configured and stays abse
       },
     }),
     NOON_UTC,
+    ADMIN_METRICS_WINDOW_DEFAULT,
   );
   assert.equal(
     overriddenHost.reliability.analyticsConsoleUrl,
     "https://eu.posthog.com/project/12345",
   );
 
-  const absent = buildAdminMetrics(source(), NOON_UTC);
+  const absent = buildAdminMetrics(source(), NOON_UTC, ADMIN_METRICS_WINDOW_DEFAULT);
   assert.equal(absent.reliability.analyticsConsoleUrl, undefined);
 });
 
@@ -389,8 +458,11 @@ const ADMIN_VIEWER: AdminViewer = {
   role: "admin",
 };
 
-function emptyMetrics(now: number): AdminMetrics {
-  return buildAdminMetrics(source(), now);
+function emptyMetrics(
+  now: number,
+  windowDays: AdminMetricsWindow = ADMIN_METRICS_WINDOW_DEFAULT,
+): AdminMetrics {
+  return buildAdminMetrics(source(), now, windowDays);
 }
 
 test("the gate answers 405, 401, 403, and 200 as distinct outcomes", async () => {
@@ -430,7 +502,7 @@ test("the gate answers 405, 401, 403, and 200 as distinct outcomes", async () =>
   // SAFETY: handleAdminMetrics answered 200, whose body is an AdminMetrics document.
   const body = (await ok.json()) as AdminMetrics;
   assert.equal(body.generatedAt, NOON_UTC);
-  assert.equal(body.windowDays, ADMIN_METRICS_WINDOW_DAYS);
+  assert.equal(body.windowDays, ADMIN_METRICS_WINDOW_DEFAULT);
   // An unconfigured analytics project travels as absence, never a placeholder.
   assert.ok(!("analyticsConsoleUrl" in body.reliability));
 });
@@ -465,6 +537,63 @@ test("the handler reads metrics at the scope the request asked for", async () =>
   );
   assert.equal((await respond(widened)).status, 200);
   assert.deepEqual(scopes, [ADMIN_METRICS_SCOPE.NON_ADMINS, ADMIN_METRICS_SCOPE.ALL]);
+});
+
+test("the window defaults to 30 days; anything outside the set is nothing, never a guess", () => {
+  assert.equal(
+    adminMetricsWindow("https://luke.test/api/admin/metrics"),
+    ADMIN_METRICS_WINDOW_DEFAULT,
+  );
+  assert.equal(
+    adminMetricsWindow("https://luke.test/api/admin/metrics?window=7"),
+    ADMIN_METRICS_WINDOW.WEEK,
+  );
+  assert.equal(
+    adminMetricsWindow("https://luke.test/api/admin/metrics?window=90"),
+    ADMIN_METRICS_WINDOW.QUARTER,
+  );
+  assert.equal(adminMetricsWindow("https://luke.test/api/admin/metrics?window=13"), undefined);
+  assert.equal(adminMetricsWindow("https://luke.test/api/admin/metrics?window="), undefined);
+  assert.equal(adminMetricsWindow("https://luke.test/api/admin/metrics?window=quarter"), undefined);
+});
+
+test("the handler reads metrics at the window the request asked for", async () => {
+  const windows: AdminMetricsWindow[] = [];
+  const readMetrics = async (
+    now: number,
+    _scope: AdminMetricsScope,
+    windowDays: AdminMetricsWindow,
+  ): Promise<AdminMetrics> => {
+    windows.push(windowDays);
+    return emptyMetrics(now, windowDays);
+  };
+  const respond = (request: Request) =>
+    handleAdminMetrics({ request, resolveViewer: async () => ADMIN_VIEWER, readMetrics });
+
+  assert.equal((await respond(metricsRequest())).status, 200);
+  const week = new Request(
+    `https://luke.test/api/admin/metrics?${ADMIN_METRICS_WINDOW_PARAM}=${ADMIN_METRICS_WINDOW.WEEK}`,
+  );
+  const okWeek = await respond(week);
+  assert.equal(okWeek.status, 200);
+  // SAFETY: handleAdminMetrics answered 200, whose body is an AdminMetrics document.
+  assert.equal(((await okWeek.json()) as AdminMetrics).windowDays, ADMIN_METRICS_WINDOW.WEEK);
+  assert.deepEqual(windows, [ADMIN_METRICS_WINDOW_DEFAULT, ADMIN_METRICS_WINDOW.WEEK]);
+});
+
+test("a window outside the set is a 400 that reads nothing", async () => {
+  let reads = 0;
+  const response = await handleAdminMetrics({
+    request: new Request(`https://luke.test/api/admin/metrics?${ADMIN_METRICS_WINDOW_PARAM}=13`),
+    resolveViewer: async () => ADMIN_VIEWER,
+    readMetrics: async (now) => {
+      reads += 1;
+      return emptyMetrics(now);
+    },
+  });
+  assert.equal(response.status, 400);
+  assert.equal((await response.json()).error, ADMIN_ERROR.INVALID_WINDOW);
+  assert.equal(reads, 0);
 });
 
 test("metrics are not read for a request that fails the gate", async () => {

--- a/apps/web/tests/admin-user.test.ts
+++ b/apps/web/tests/admin-user.test.ts
@@ -1,19 +1,22 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { AdminViewer } from "../server/admin/admin-access";
-import {
-  ADMIN_METRICS_WINDOW_DAYS,
-  ADMIN_TREND_DAYS,
-  type AdminUsageDay,
-  lastNDayKeys,
-} from "../server/admin/admin-metrics";
+import { ADMIN_TREND_DAYS, type AdminUsageDay, lastNDayKeys } from "../server/admin/admin-metrics";
 import {
   type AdminUserDetail,
   type AdminUserSource,
   buildAdminUserDetail,
   handleAdminUser,
 } from "../server/admin/admin-user";
-import { ADMIN_ERROR, ADMIN_USER_ID_PARAM, adminUserId } from "../server/admin/http";
+import {
+  ADMIN_ERROR,
+  ADMIN_METRICS_WINDOW,
+  ADMIN_METRICS_WINDOW_DEFAULT,
+  ADMIN_METRICS_WINDOW_PARAM,
+  ADMIN_USER_ID_PARAM,
+  type AdminMetricsWindow,
+  adminUserId,
+} from "../server/admin/http";
 
 const NOON_UTC = Date.parse("2026-08-17T12:00:00.000Z");
 
@@ -43,8 +46,11 @@ function userSource(usage: Partial<AdminUserSource["usage"]> = {}): AdminUserSou
   };
 }
 
-function build(usage: Partial<AdminUserSource["usage"]> = {}): AdminUserDetail {
-  return buildAdminUserDetail(userSource(usage), NOON_UTC);
+function build(
+  usage: Partial<AdminUserSource["usage"]> = {},
+  windowDays: AdminMetricsWindow = ADMIN_METRICS_WINDOW_DEFAULT,
+): AdminUserDetail {
+  return buildAdminUserDetail(userSource(usage), NOON_UTC, windowDays);
 }
 
 test("the daily series is zero-filled and the window counts fold from it", () => {
@@ -56,8 +62,8 @@ test("the daily series is zero-filled and the window counts fold from it", () =>
     ]),
   });
 
-  assert.equal(detail.windowDays, ADMIN_METRICS_WINDOW_DAYS);
-  assert.equal(detail.activity.daily.length, ADMIN_METRICS_WINDOW_DAYS);
+  assert.equal(detail.windowDays, ADMIN_METRICS_WINDOW_DEFAULT);
+  assert.equal(detail.activity.daily.length, ADMIN_METRICS_WINDOW_DEFAULT);
   assert.equal(detail.activity.activeDaysWindow, 3);
   assert.equal(detail.activity.voiceCallsWindow, 7);
   assert.equal(detail.activity.attentionReviewsWindow, 8);
@@ -100,14 +106,41 @@ test("a streak broken before yesterday is over, whatever came earlier", () => {
 
 test("a streak covering the whole window reports the window's length", () => {
   const byDay = new Map<string, AdminUsageDay>(
-    lastNDayKeys(NOON_UTC, ADMIN_METRICS_WINDOW_DAYS).map((day) => [
+    lastNDayKeys(NOON_UTC, ADMIN_METRICS_WINDOW_DEFAULT).map((day) => [
       day,
       { voiceCalls: 1, attentionReviews: 0 },
     ]),
   );
   const detail = build({ byDay });
-  assert.equal(detail.activity.currentStreakDays, ADMIN_METRICS_WINDOW_DAYS);
-  assert.equal(detail.activity.activeDaysWindow, ADMIN_METRICS_WINDOW_DAYS);
+  assert.equal(detail.activity.currentStreakDays, ADMIN_METRICS_WINDOW_DEFAULT);
+  assert.equal(detail.activity.activeDaysWindow, ADMIN_METRICS_WINDOW_DEFAULT);
+});
+
+test("a 7-day window narrows the series while its trends still see the week before", () => {
+  const detail = build(
+    {
+      byDay: new Map([
+        // Inside the 7-day window (2026-08-11 through 2026-08-17).
+        ["2026-08-16", { voiceCalls: 3, attentionReviews: 1 }],
+        // Outside the window but inside the trend's prior run.
+        ["2026-08-05", { voiceCalls: 2, attentionReviews: 0 }],
+        ["2026-08-04", { voiceCalls: 1, attentionReviews: 0 }],
+      ]),
+    },
+    ADMIN_METRICS_WINDOW.WEEK,
+  );
+
+  assert.equal(detail.windowDays, ADMIN_METRICS_WINDOW.WEEK);
+  assert.equal(detail.activity.daily.length, ADMIN_METRICS_WINDOW.WEEK);
+  assert.equal(detail.activity.activeDaysWindow, 1);
+  assert.equal(detail.activity.voiceCallsWindow, 3);
+  assert.equal(detail.activity.attentionReviewsWindow, 1);
+  assert.deepEqual(detail.activity.usageTrend, { days: ADMIN_TREND_DAYS, recent: 4, prior: 3 });
+  assert.deepEqual(detail.activity.activeDaysTrend, {
+    days: ADMIN_TREND_DAYS,
+    recent: 1,
+    prior: 2,
+  });
 });
 
 test("the active-days trend counts days present, not volume spent", () => {
@@ -157,8 +190,12 @@ function userRequest(id: string | null = "user-9", method = "GET"): Request {
 
 const ADMIN_VIEWER: AdminViewer = { userId: "user-1", role: "admin" };
 
-const readUser = async (userId: string, now: number): Promise<AdminUserDetail | undefined> =>
-  userId === "user-9" ? buildAdminUserDetail(userSource(), now) : undefined;
+const readUser = async (
+  userId: string,
+  now: number,
+  windowDays: AdminMetricsWindow = ADMIN_METRICS_WINDOW_DEFAULT,
+): Promise<AdminUserDetail | undefined> =>
+  userId === "user-9" ? buildAdminUserDetail(userSource(), now, windowDays) : undefined;
 
 test("the gate answers 405, 401, 403, 400, 404, and 200 as distinct outcomes", async () => {
   const wrongMethod = await handleAdminUser({
@@ -213,6 +250,33 @@ test("the gate answers 405, 401, 403, 400, 404, and 200 as distinct outcomes", a
   const body = (await ok.json()) as AdminUserDetail;
   assert.equal(body.generatedAt, NOON_UTC);
   assert.equal(body.account.id, "user-9");
+});
+
+test("the account is read at the window the request asked for; outside the set is a 400", async () => {
+  const windows: AdminMetricsWindow[] = [];
+  const countingRead = async (userId: string, now: number, windowDays: AdminMetricsWindow) => {
+    windows.push(windowDays);
+    return readUser(userId, now, windowDays);
+  };
+  const respond = (query: string) =>
+    handleAdminUser({
+      request: new Request(
+        `https://luke.test/api/admin/user?${ADMIN_USER_ID_PARAM}=user-9${query}`,
+      ),
+      resolveViewer: async () => ADMIN_VIEWER,
+      readUser: countingRead,
+    });
+
+  const week = await respond(`&${ADMIN_METRICS_WINDOW_PARAM}=${ADMIN_METRICS_WINDOW.WEEK}`);
+  assert.equal(week.status, 200);
+  // SAFETY: handleAdminUser answered 200, whose body is an AdminUserDetail document.
+  assert.equal(((await week.json()) as AdminUserDetail).windowDays, ADMIN_METRICS_WINDOW.WEEK);
+  assert.deepEqual(windows, [ADMIN_METRICS_WINDOW.WEEK]);
+
+  const invalid = await respond(`&${ADMIN_METRICS_WINDOW_PARAM}=13`);
+  assert.equal(invalid.status, 400);
+  assert.equal((await invalid.json()).error, ADMIN_ERROR.INVALID_WINDOW);
+  assert.deepEqual(windows, [ADMIN_METRICS_WINDOW.WEEK]);
 });
 
 test("no account is read for a request that fails the gate or names none", async () => {

--- a/apps/web/tests/admin-users.test.ts
+++ b/apps/web/tests/admin-users.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { AdminViewer } from "../server/admin/admin-access";
-import { ADMIN_METRICS_WINDOW_DAYS } from "../server/admin/admin-metrics";
 import {
   ADMIN_USERS_LIMIT,
   type AdminUserList,
@@ -13,7 +12,11 @@ import {
   ADMIN_ERROR,
   ADMIN_METRICS_SCOPE,
   ADMIN_METRICS_SCOPE_PARAM,
+  ADMIN_METRICS_WINDOW,
+  ADMIN_METRICS_WINDOW_DEFAULT,
+  ADMIN_METRICS_WINDOW_PARAM,
   type AdminMetricsScope,
+  type AdminMetricsWindow,
 } from "../server/admin/http";
 
 const NOON_UTC = Date.parse("2026-08-17T12:00:00.000Z");
@@ -38,12 +41,15 @@ function listSource(overrides: Partial<AdminUserListSource> = {}): AdminUserList
 }
 
 test("the roster is stamped with the window its aggregates cover", () => {
-  const list = buildAdminUserList(listSource({ total: 340 }), NOON_UTC);
+  const list = buildAdminUserList(listSource({ total: 340 }), NOON_UTC, ADMIN_METRICS_WINDOW.MONTH);
   assert.equal(list.generatedAt, NOON_UTC);
-  assert.equal(list.windowDays, ADMIN_METRICS_WINDOW_DAYS);
+  assert.equal(list.windowDays, ADMIN_METRICS_WINDOW.MONTH);
   assert.equal(list.limit, ADMIN_USERS_LIMIT);
   assert.equal(list.total, 340);
   assert.deepEqual(list.rows, [ROW]);
+
+  const quarter = buildAdminUserList(listSource(), NOON_UTC, ADMIN_METRICS_WINDOW.QUARTER);
+  assert.equal(quarter.windowDays, ADMIN_METRICS_WINDOW.QUARTER);
 });
 
 function usersRequest(method = "GET", query = ""): Request {
@@ -53,7 +59,7 @@ function usersRequest(method = "GET", query = ""): Request {
 const ADMIN_VIEWER: AdminViewer = { userId: "user-1", role: "admin" };
 
 const readUsers = async (now: number): Promise<AdminUserList> =>
-  buildAdminUserList(listSource(), now);
+  buildAdminUserList(listSource(), now, ADMIN_METRICS_WINDOW_DEFAULT);
 
 test("the gate answers 405, 401, 403, and 200 as distinct outcomes", async () => {
   const wrongMethod = await handleAdminUsers({
@@ -94,17 +100,20 @@ test("the gate answers 405, 401, 403, and 200 as distinct outcomes", async () =>
   assert.equal(body.rows[0]?.id, "user-9");
 });
 
-test("the roster is read at the scope the request asked for, as the viewer, and not past a failed gate", async () => {
+test("the roster is read at the scope and window the request asked for, as the viewer, and not past a failed gate", async () => {
   const scopes: AdminMetricsScope[] = [];
   const viewerIds: string[] = [];
+  const windows: AdminMetricsWindow[] = [];
   const countingRead = async (
     now: number,
     scope: AdminMetricsScope,
     viewerId: string,
+    windowDays: AdminMetricsWindow,
   ): Promise<AdminUserList> => {
     scopes.push(scope);
     viewerIds.push(viewerId);
-    return readUsers(now);
+    windows.push(windowDays);
+    return buildAdminUserList(listSource(), now, windowDays);
   };
   const respond = (request: Request) =>
     handleAdminUsers({ request, resolveViewer: async () => ADMIN_VIEWER, readUsers: countingRead });
@@ -112,8 +121,22 @@ test("the roster is read at the scope the request asked for, as the viewer, and 
   assert.equal((await respond(usersRequest())).status, 200);
   const widened = usersRequest("GET", `?${ADMIN_METRICS_SCOPE_PARAM}=${ADMIN_METRICS_SCOPE.ALL}`);
   assert.equal((await respond(widened)).status, 200);
-  assert.deepEqual(scopes, [ADMIN_METRICS_SCOPE.NON_ADMINS, ADMIN_METRICS_SCOPE.ALL]);
-  assert.deepEqual(viewerIds, [ADMIN_VIEWER.userId, ADMIN_VIEWER.userId]);
+  const week = usersRequest("GET", `?${ADMIN_METRICS_WINDOW_PARAM}=${ADMIN_METRICS_WINDOW.WEEK}`);
+  const okWeek = await respond(week);
+  assert.equal(okWeek.status, 200);
+  // SAFETY: handleAdminUsers answered 200, whose body is an AdminUserList document.
+  assert.equal(((await okWeek.json()) as AdminUserList).windowDays, ADMIN_METRICS_WINDOW.WEEK);
+  assert.deepEqual(scopes, [
+    ADMIN_METRICS_SCOPE.NON_ADMINS,
+    ADMIN_METRICS_SCOPE.ALL,
+    ADMIN_METRICS_SCOPE.NON_ADMINS,
+  ]);
+  assert.deepEqual(viewerIds, [ADMIN_VIEWER.userId, ADMIN_VIEWER.userId, ADMIN_VIEWER.userId]);
+  assert.deepEqual(windows, [
+    ADMIN_METRICS_WINDOW_DEFAULT,
+    ADMIN_METRICS_WINDOW_DEFAULT,
+    ADMIN_METRICS_WINDOW.WEEK,
+  ]);
 
   const gated = await handleAdminUsers({
     request: usersRequest(),
@@ -121,7 +144,12 @@ test("the roster is read at the scope the request asked for, as the viewer, and 
     readUsers: countingRead,
   });
   assert.equal(gated.status, 401);
-  assert.equal(scopes.length, 2);
+  assert.equal(scopes.length, 3);
+
+  const invalid = await respond(usersRequest("GET", `?${ADMIN_METRICS_WINDOW_PARAM}=13`));
+  assert.equal(invalid.status, 400);
+  assert.equal((await invalid.json()).error, ADMIN_ERROR.INVALID_WINDOW);
+  assert.equal(scopes.length, 3);
 });
 
 test("a seam that throws is a 503 refusal rather than a crash", async () => {


### PR DESCRIPTION
## What

The admin dashboard's trailing window was a hardcoded 30 days. This adds a compact 7d / 30d / 90d switcher to the page header — on both the Dashboard and Users views, beside "Hide admins" — and teaches the three admin GET endpoints (metrics, users, user) a `window` query parameter validated against a fixed `{7, 30, 90}` set. The chosen window rides the page's own query string (`?days=90`), so a 90-day view is shareable, survives reload, and follows the browser's back button; flipping it refetches the way the scope toggle does, with the last answer dimmed until the next one lands.

## How

- `server/admin/http.ts` gains `ADMIN_METRICS_WINDOW` (`as const`, union derived from it, no raw numbers at call sites), the `window` parameter, and a parser: absence is the 30-day default, while a value outside the set is nothing — unlike the scope, where an unknown value safely narrows, a substituted window would reshape every number under a link that named a different one. All three handlers answer that with a 400 carrying a new `invalid-window` error, consistent with the user endpoint's `missing-user-id`.
- The builders (`buildAdminMetrics`, `buildAdminUserList`, `buildAdminUserDetail`) take the window as a parameter and stamp it into `windowDays`, so every downstream wording ("Active days · N of M", "in N days", the roster's "of N" column, throttled-days copy) follows the response.
- The 7-day trends keep their own meaning and are not coupled to the switcher: they now read the source maps through their own 14-day trailing keys, and the queries fetch daily rows over `max(window, 14)` days (`windowFetchDays`) so a 7-day window still compares against the whole week before it, while every windowed aggregate (active users, top accounts, throttled account-days, the roster's joins) stays on the window's own bound.
- The client keeps the page's address-bar-driven pattern: the window is parsed from `?days=`, pushed with `pushState`, restored on `popstate`, and preserved by every tab and account href, with the default riding as no param at all. The account detail page keeps the default 30-day window for now — its links preserve the chosen window for the trip back, but wiring the switcher into the detail fetch and header felt like its own change, so it is deliberately left at 30d here.
- Axis legibility at 90 days: both bar charts already thin day ticks with `minTickGap={32}`, which keeps roughly weekly ticks at 90 days in the page's width, so no tick changes were needed.

## Verification

- `./scripts/check.sh` passes end to end (repository checks, types, all workspace tests including the extended `apps/web/tests/admin-*.test.ts` gates for the 400 and the 7- and 90-day shaping, and the builds).
- Web-only change; no desktop surface touched, so no macOS/notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32539104167/artifacts/9466422053) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32539104167)

- Commit: `58be2ccacde1ef4b5133c283ec77910370ed01b9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
