### PR TITLE
feat(admin): show weekly signup cohorts and whether they come back

### DIFF
--- a/apps/web/server/admin/admin-metrics.ts
+++ b/apps/web/server/admin/admin-metrics.ts
@@ -30,6 +30,14 @@ export const ADMIN_METRICS_WINDOW_DAYS = 30;
 export const ADMIN_TREND_DAYS = 7;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+const WEEK_MS = 7 * DAY_MS;
+
+/**
+ * How many trailing UTC weeks the retention grid covers — its cohort rows and
+ * its offset columns alike, so the oldest cohort is the one row whose every
+ * offset the calendar has already reached.
+ */
+export const ADMIN_RETENTION_WEEKS = 8;
 
 export interface AdminUsageDay {
   voiceCalls: number;
@@ -95,6 +103,29 @@ export function countSignInMethods(
     else other.add(link.userId);
   }
   return { google: google.size, github: github.size, other: other.size };
+}
+
+/**
+ * One cell of the retention grid: of the accounts created in the cohort's
+ * week, how many used the hosted tier during the week `offset` weeks after it.
+ * `share` is null for a cohort with nobody to take a share of — a percentage
+ * of nothing would pose as precision — and a week the calendar has not
+ * reached is no cell at all rather than a zero.
+ */
+export interface AdminRetentionCell {
+  offset: number;
+  activeAccounts: number;
+  share: number | null;
+  /** The cell's week is the one `generatedAt` falls in, still accruing. */
+  inProgress: boolean;
+}
+
+export interface AdminRetentionCohort {
+  /** The cohort's UTC week, named by its Monday as YYYY-MM-DD. */
+  weekStart: string;
+  /** Accounts created during this week. */
+  size: number;
+  cells: AdminRetentionCell[];
 }
 
 /**
@@ -199,6 +230,11 @@ export interface AdminMetrics {
     daily: AdminDailyUsage[];
     topUsers: AdminTopUser[];
   };
+  retention: {
+    weeks: number;
+    /** Oldest cohort first; each row's cells stop at the current week. */
+    cohorts: AdminRetentionCohort[];
+  };
   reliability: {
     voiceDailyLimit: number;
     attentionDailyLimit: number;
@@ -237,6 +273,12 @@ export interface AdminMetricsSource {
     activeUsersWindow: number;
     topUsers: readonly AdminTopUser[];
   };
+  retention: {
+    /** Accounts created per UTC week, keyed by the week's Monday. */
+    cohortSizes: ReadonlyMap<string, number>;
+    /** Distinct accounts active per week, keyed by signup week then activity week. */
+    activeByCohortWeek: ReadonlyMap<string, ReadonlyMap<string, number>>;
+  };
   reliability: {
     quotaLimitedUserDaysToday: number;
     quotaLimitedUserDaysWindow: number;
@@ -261,6 +303,58 @@ export function lastNDayKeys(now: number, days: number): string[] {
     keys.push(utcDayKey(now - offset * DAY_MS));
   }
   return keys;
+}
+
+/**
+ * The Monday of the UTC week holding `instant`, as its YYYY-MM-DD key. Weeks
+ * start on Monday because Postgres's `date_trunc('week')` lands there, and
+ * the queries and this fold must name a week identically or every cohort
+ * would shear against its own activity.
+ */
+export function utcWeekStartKey(instant: number): string {
+  const daysSinceEpoch = Math.floor(instant / DAY_MS);
+  // The epoch, 1970-01-01, was a Thursday: three days past its week's Monday.
+  const daysSinceMonday = (daysSinceEpoch + 3) % 7;
+  return utcDayKey((daysSinceEpoch - daysSinceMonday) * DAY_MS);
+}
+
+/** The trailing weeks' Monday keys, oldest first and ending on `now`'s own week. */
+export function lastNWeekStartKeys(now: number, weeks: number): string[] {
+  const keys: string[] = [];
+  for (let offset = weeks - 1; offset >= 0; offset -= 1) {
+    keys.push(utcWeekStartKey(now - offset * WEEK_MS));
+  }
+  return keys;
+}
+
+/**
+ * Folds the queried cohort counts into the grid the dashboard draws. Each
+ * cohort's cells run from its own week to the current one and no further:
+ * a week the calendar has not reached is absent rather than a zero, which is
+ * what shapes the triangle, and the current week's cell in every row is
+ * marked still accruing.
+ */
+function buildRetentionCohorts(
+  retention: AdminMetricsSource["retention"],
+  now: number,
+): AdminRetentionCohort[] {
+  const weekKeys = lastNWeekStartKeys(now, ADMIN_RETENTION_WEEKS);
+  const currentWeek = utcWeekStartKey(now);
+
+  return weekKeys.map((weekStart, index) => {
+    const size = retention.cohortSizes.get(weekStart) ?? 0;
+    const activeByWeek = retention.activeByCohortWeek.get(weekStart);
+    const cells = weekKeys.slice(index).map((week, offset) => {
+      const activeAccounts = activeByWeek?.get(week) ?? 0;
+      return {
+        offset,
+        activeAccounts,
+        share: size === 0 ? null : activeAccounts / size,
+        inProgress: week === currentWeek,
+      };
+    });
+    return { weekStart, size, cells };
+  });
 }
 
 export function sum(values: readonly number[]): number {
@@ -329,6 +423,10 @@ export function buildAdminMetrics(source: AdminMetricsSource, now: number): Admi
       ),
       daily,
       topUsers: [...source.usage.topUsers],
+    },
+    retention: {
+      weeks: ADMIN_RETENTION_WEEKS,
+      cohorts: buildRetentionCohorts(source.retention, now),
     },
     reliability: {
       voiceDailyLimit: HOSTED_DAILY_LIMIT[HOSTED_METER.VOICE_CALL],

--- a/apps/web/server/admin/admin-queries.ts
+++ b/apps/web/server/admin/admin-queries.ts
@@ -21,12 +21,15 @@ import { HOSTED_DAILY_LIMIT, HOSTED_METER, utcDayKey } from "../hosted/quota.js"
 import { isAdminRole, USER_ROLE } from "./admin-access.js";
 import {
   ADMIN_METRICS_WINDOW_DAYS,
+  ADMIN_RETENTION_WEEKS,
   type AdminIntegration,
   type AdminMetricsSource,
   type AdminTopUser,
   type AdminUsageDay,
   countSignInMethods,
   lastNDayKeys,
+  lastNWeekStartKeys,
+  utcWeekStartKey,
 } from "./admin-metrics.js";
 import type { AdminUserSource } from "./admin-user.js";
 import { ADMIN_USERS_LIMIT, type AdminUserListSource } from "./admin-users.js";
@@ -198,6 +201,64 @@ async function readUsageMetrics(
 }
 
 /**
+ * Both week expressions truncate with Postgres's `date_trunc('week')`, which
+ * lands on Monday — the same Monday `utcWeekStartKey` derives — so the SQL
+ * and the fold name a week identically. A signup instant is a timestamp and
+ * a usage day a YYYY-MM-DD string, hence the two shapes of the same cast.
+ */
+const signupWeek = sql<string>`to_char(date_trunc('week', ${user.createdAt} at time zone 'UTC'), 'YYYY-MM-DD')`;
+const activityWeek = sql<string>`to_char(date_trunc('week', ${hostedUsage.day}::date), 'YYYY-MM-DD')`;
+
+async function readRetentionMetrics(
+  database: Database,
+  now: number,
+  scope: AdminMetricsScope,
+): Promise<AdminMetricsSource["retention"]> {
+  const weekKeys = lastNWeekStartKeys(now, ADMIN_RETENTION_WEEKS);
+  const oldestWeekStartDay = weekKeys[0] ?? utcWeekStartKey(now);
+  const oldestWeekStart = new Date(`${oldestWeekStartDay}T00:00:00.000Z`);
+
+  const [sizeRows, activeRows] = await Promise.all([
+    database
+      .select({ week: signupWeek, value: count() })
+      .from(user)
+      .where(and(gte(user.createdAt, oldestWeekStart), scopeCondition(scope)))
+      .groupBy(signupWeek),
+    // Distinct accounts per (signup week, activity week) pair: a cohort
+    // member with several active days in one week is retained once, not
+    // once per day.
+    database
+      .select({
+        signupWeek,
+        activityWeek,
+        value: sql<number>`count(distinct ${hostedUsage.userId})`,
+      })
+      .from(hostedUsage)
+      .innerJoin(user, eq(hostedUsage.userId, user.id))
+      .where(
+        and(
+          gte(user.createdAt, oldestWeekStart),
+          gte(hostedUsage.day, oldestWeekStartDay),
+          scopeCondition(scope),
+        ),
+      )
+      .groupBy(signupWeek, activityWeek),
+  ]);
+
+  const cohortSizes = new Map<string, number>();
+  for (const row of sizeRows) cohortSizes.set(row.week, toNumber(row.value));
+
+  const activeByCohortWeek = new Map<string, Map<string, number>>();
+  for (const row of activeRows) {
+    const byWeek = activeByCohortWeek.get(row.signupWeek) ?? new Map<string, number>();
+    byWeek.set(row.activityWeek, toNumber(row.value));
+    activeByCohortWeek.set(row.signupWeek, byWeek);
+  }
+
+  return { cohortSizes, activeByCohortWeek };
+}
+
+/**
  * Either meter past its daily ceiling — the row a spend was refused on. The
  * spend that lands exactly on the limit is still allowed, and a refused
  * attempt still increments, so only a count strictly past the limit proves a
@@ -249,6 +310,7 @@ function emptySource(
       signupsByDay: new Map(),
     },
     usage: { byDay: new Map(), activeUsersToday: 0, activeUsersWindow: 0, topUsers: [] },
+    retention: { cohortSizes: new Map(), activeByCohortWeek: new Map() },
     reliability: {
       quotaLimitedUserDaysToday: 0,
       quotaLimitedUserDaysWindow: 0,
@@ -282,15 +344,17 @@ export async function readAdminMetricsSource(
   const todayKey = utcDayKey(input.now);
   const windowStart = new Date(`${windowStartDay}T00:00:00.000Z`);
 
-  const [users, usage, reliability] = await Promise.all([
+  const [users, usage, retention, reliability] = await Promise.all([
     readUserMetrics(database, input.now, windowStart, input.scope),
     readUsageMetrics(database, todayKey, windowStartDay, input.scope),
+    readRetentionMetrics(database, input.now, input.scope),
     readReliabilityMetrics(database, todayKey, windowStartDay, input.scope),
   ]);
 
   return {
     users,
     usage,
+    retention,
     reliability: { ...reliability, analyticsConsoleUrl: input.analyticsConsoleUrl },
     systemHealth: { database: health, integrations: input.integrations },
   };

--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -1,11 +1,12 @@
 import { createAuthClient } from "better-auth/react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { Fragment, useCallback, useEffect, useRef, useState } from "react";
 import { Bar, BarChart, CartesianGrid, LabelList, XAxis, YAxis } from "recharts";
 import type {
   AdminDailySignups,
   AdminDailyUsage,
   AdminIntegration,
   AdminMetrics,
+  AdminRetentionCell,
   AdminTopUser,
   AdminTrend,
 } from "../server/admin/admin-metrics";
@@ -482,6 +483,125 @@ function SignInMethodsChart({
           </Bar>
         </BarChart>
       </ChartContainer>
+    </div>
+  );
+}
+
+/**
+ * The floor under a cell's fill, so a small nonzero share still reads as a
+ * mark against the card instead of vanishing into it.
+ */
+const RETENTION_FILL_FLOOR_PERCENT = 8;
+
+/**
+ * The share past which a cell's fill is strong enough that the page's light
+ * foreground stops clearing it, so the text flips to the dark background tone.
+ */
+const RETENTION_TEXT_FLIP_SHARE = 0.75;
+
+function retentionCellStyle(share: number): React.CSSProperties {
+  const fill = Math.max(RETENTION_FILL_FLOOR_PERCENT, Math.round(share * 100));
+  return {
+    backgroundColor: `color-mix(in oklab, var(--chart-1) ${fill}%, transparent)`,
+    color: share >= RETENTION_TEXT_FLIP_SHARE ? "var(--background)" : "var(--foreground)",
+  };
+}
+
+function RetentionCell({ cell }: { cell: AdminRetentionCell }): React.JSX.Element {
+  const provisional = cell.inProgress ? "border border-dashed border-muted-foreground/60" : "";
+  if (cell.share === null) {
+    return (
+      <div
+        className={`flex min-h-9 items-center justify-center rounded-sm text-muted-foreground ${provisional}`}
+        title="No accounts in this cohort"
+      >
+        —
+      </div>
+    );
+  }
+  const percent = `${Math.round(cell.share * 100)}%`;
+  const title = `${formatNumber(cell.activeAccounts)} ${
+    cell.activeAccounts === 1 ? "account" : "accounts"
+  } active${cell.inProgress ? " so far this week" : ""}`;
+  if (cell.share === 0) {
+    return (
+      <div
+        className={`flex min-h-9 items-center justify-center rounded-sm text-muted-foreground ${provisional}`}
+        title={title}
+      >
+        {percent}
+      </div>
+    );
+  }
+  return (
+    <div
+      className={`flex min-h-9 items-center justify-center rounded-sm ${provisional}`}
+      style={retentionCellStyle(cell.share)}
+      title={title}
+    >
+      {percent}
+    </div>
+  );
+}
+
+/**
+ * Weekly signup cohorts against the weeks after them, as a plain CSS grid
+ * rather than a chart: each row is the accounts created in one UTC week, each
+ * cell the share of them that used the hosted tier that many weeks after
+ * signing up. The grid is triangular because the builder emits no cell for a
+ * week the calendar has not reached, and the current week's cells wear a
+ * dashed border because their week is still accruing.
+ */
+function RetentionGrid({ retention }: { retention: AdminMetrics["retention"] }): React.JSX.Element {
+  const totalAccounts = retention.cohorts.reduce((total, cohort) => total + cohort.size, 0);
+  if (totalAccounts === 0) {
+    return (
+      <div className="rounded-lg border border-border bg-card px-5 py-8 text-center text-sm text-muted-foreground">
+        No accounts created in the last {retention.weeks} weeks yet.
+      </div>
+    );
+  }
+
+  const offsets = Array.from({ length: retention.weeks }, (_, offset) => offset);
+  return (
+    <div className="overflow-hidden rounded-lg border border-border bg-card">
+      <div className="overflow-x-auto">
+        <div
+          className="grid min-w-[640px] gap-1 p-5 text-xs tabular-nums"
+          style={{
+            gridTemplateColumns: `minmax(84px, auto) minmax(72px, auto) repeat(${retention.weeks}, minmax(52px, 1fr))`,
+          }}
+        >
+          <div className="flex items-center font-mono text-muted-foreground uppercase">Cohort</div>
+          <div className="flex items-center justify-end font-mono text-muted-foreground uppercase">
+            Accounts
+          </div>
+          {offsets.map((offset) => (
+            <div
+              key={offset}
+              className="flex items-center justify-center font-mono text-muted-foreground uppercase"
+            >
+              Wk {offset}
+            </div>
+          ))}
+          {retention.cohorts.map((cohort) => (
+            <Fragment key={cohort.weekStart}>
+              <div className="flex items-center">{formatDayTick(cohort.weekStart)}</div>
+              <div className="flex items-center justify-end pr-1 text-muted-foreground">
+                {formatNumber(cohort.size)}
+              </div>
+              {offsets.map((offset) => {
+                const cell = cohort.cells[offset];
+                return cell ? (
+                  <RetentionCell key={offset} cell={cell} />
+                ) : (
+                  <div key={offset} aria-hidden="true" />
+                );
+              })}
+            </Fragment>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }
@@ -1036,6 +1156,17 @@ function Dashboard({
             totalAccounts={metrics.users.total}
           />
         </div>
+
+        <SectionHeading>Signup retention · weekly cohorts</SectionHeading>
+        <RetentionGrid retention={metrics.retention} />
+        <p className="mt-3 text-sm text-muted-foreground">
+          Each row is the accounts created in one UTC week, named by its Monday; each cell is the
+          share of them that spent hosted voice or attention during the week that many weeks after
+          signup, so Wk 0 is activation in the signup week itself. A week the calendar has not
+          reached draws nothing, and dashed cells cover the week still in progress — those shares
+          can only rise. Purely local use of the desktop app writes no row here, so a cohort that
+          never touched the hosted tier reads the same as one that left.
+        </p>
 
         <SectionHeading>Feature usage · hosted tier</SectionHeading>
         <div className="grid grid-cols-2 gap-3 min-[720px]:grid-cols-4">

--- a/apps/web/tests/admin-metrics.test.ts
+++ b/apps/web/tests/admin-metrics.test.ts
@@ -4,6 +4,7 @@ import type { AdminViewer } from "../server/admin/admin-access";
 import {
   ADMIN_INTEGRATION,
   ADMIN_METRICS_WINDOW_DAYS,
+  ADMIN_RETENTION_WEEKS,
   ADMIN_TREND_DAYS,
   type AdminMetrics,
   type AdminMetricsSource,
@@ -12,7 +13,9 @@ import {
   countSignInMethods,
   handleAdminMetrics,
   lastNDayKeys,
+  lastNWeekStartKeys,
   SIGN_IN_PROVIDER_ID,
+  utcWeekStartKey,
 } from "../server/admin/admin-metrics";
 import {
   ADMIN_ERROR,
@@ -36,6 +39,7 @@ function source(overrides: Partial<AdminMetricsSource> = {}): AdminMetricsSource
       signupsByDay: new Map(),
     },
     usage: { byDay: new Map(), activeUsersToday: 0, activeUsersWindow: 0, topUsers: [] },
+    retention: { cohortSizes: new Map(), activeByCohortWeek: new Map() },
     reliability: { quotaLimitedUserDaysToday: 0, quotaLimitedUserDaysWindow: 0 },
     systemHealth: { database: { reachable: true, latencyMs: 4 }, integrations: [] },
     ...overrides,
@@ -187,6 +191,111 @@ test("a trend over an empty window is zero on both runs rather than absent", () 
     prior: 0,
   });
   assert.equal(metrics.users.newInWindow, 0);
+});
+
+test("a week is named by its Monday, whichever day the instant falls on", () => {
+  // 2026-08-17 is itself a Monday; 2026-08-20 is the Thursday of its week.
+  assert.equal(utcWeekStartKey(NOON_UTC), "2026-08-17");
+  assert.equal(utcWeekStartKey(Date.parse("2026-08-20T09:00:00.000Z")), "2026-08-17");
+  assert.equal(utcWeekStartKey(Date.parse("2026-08-16T23:59:59.999Z")), "2026-08-10");
+
+  const keys = lastNWeekStartKeys(NOON_UTC, ADMIN_RETENTION_WEEKS);
+  assert.equal(keys.length, ADMIN_RETENTION_WEEKS);
+  assert.equal(keys[0], "2026-06-29");
+  assert.equal(keys.at(-1), "2026-08-17");
+});
+
+test("retention cohorts are the trailing weeks, and unreached weeks are absent", () => {
+  const metrics = buildAdminMetrics(source(), NOON_UTC);
+  assert.equal(metrics.retention.weeks, ADMIN_RETENTION_WEEKS);
+  assert.equal(metrics.retention.cohorts.length, ADMIN_RETENTION_WEEKS);
+  assert.equal(metrics.retention.cohorts[0]?.weekStart, "2026-06-29");
+  assert.equal(metrics.retention.cohorts.at(-1)?.weekStart, "2026-08-17");
+  // The triangle: each cohort's cells run from its own week to the current
+  // one, so the oldest cohort holds every offset and the newest only Wk 0.
+  for (const [index, cohort] of metrics.retention.cohorts.entries()) {
+    assert.equal(cohort.cells.length, ADMIN_RETENTION_WEEKS - index);
+    assert.deepEqual(
+      cohort.cells.map((cell) => cell.offset),
+      cohort.cells.map((_, offset) => offset),
+    );
+  }
+});
+
+test("a cohort's shares are its active accounts over its size, week by week", () => {
+  const metrics = buildAdminMetrics(
+    source({
+      retention: {
+        cohortSizes: new Map([["2026-06-29", 4]]),
+        activeByCohortWeek: new Map([
+          [
+            "2026-06-29",
+            new Map([
+              ["2026-06-29", 4],
+              ["2026-07-06", 3],
+              ["2026-07-20", 1],
+              // Before the cohort's own week: no cell exists to carry it.
+              ["2026-06-22", 2],
+            ]),
+          ],
+        ]),
+      },
+    }),
+    NOON_UTC,
+  );
+
+  const cohort = metrics.retention.cohorts[0];
+  assert.equal(cohort?.size, 4);
+  assert.deepEqual(
+    cohort?.cells.map((cell) => [cell.activeAccounts, cell.share]),
+    [
+      [4, 1],
+      [3, 0.75],
+      [0, 0],
+      [1, 0.25],
+      [0, 0],
+      [0, 0],
+      [0, 0],
+      [0, 0],
+    ],
+  );
+});
+
+test("only the current week's cells are in progress, in every cohort", () => {
+  const metrics = buildAdminMetrics(
+    source({
+      retention: {
+        cohortSizes: new Map([
+          ["2026-06-29", 2],
+          ["2026-08-17", 5],
+        ]),
+        activeByCohortWeek: new Map([["2026-08-17", new Map([["2026-08-17", 3]])]]),
+      },
+    }),
+    NOON_UTC,
+  );
+
+  for (const cohort of metrics.retention.cohorts) {
+    const last = cohort.cells.at(-1);
+    assert.equal(last?.inProgress, true);
+    for (const cell of cohort.cells.slice(0, -1)) assert.equal(cell.inProgress, false);
+  }
+  const current = metrics.retention.cohorts.at(-1);
+  assert.equal(current?.size, 5);
+  assert.deepEqual(current?.cells, [
+    { offset: 0, activeAccounts: 3, share: 0.6, inProgress: true },
+  ]);
+});
+
+test("a cohort with no accounts keeps its count and states no share", () => {
+  const metrics = buildAdminMetrics(source(), NOON_UTC);
+  for (const cohort of metrics.retention.cohorts) {
+    assert.equal(cohort.size, 0);
+    for (const cell of cohort.cells) {
+      assert.equal(cell.activeAccounts, 0);
+      assert.equal(cell.share, null);
+    }
+  }
 });
 
 test("the most active accounts pass through the builder untouched", () => {


### PR DESCRIPTION
## What

A weekly signup-cohort retention section on the admin dashboard, placed after User activity. Each row is the accounts created in one of the last eight UTC weeks (named by its Monday); each cell is the share of that cohort with any hosted voice or attention use during the week that many weeks after signup, with Wk 0 as activation in the signup week itself. The dashboard already showed totals and per-day activity but nothing about whether new accounts come back.

The grid keeps its honesty structural:

- A cohort-week the calendar has not reached is no cell at all, so the grid is triangular by construction rather than a field of false zeros.
- The current week's cells are visibly provisional — dashed border, "so far this week" in the tooltip — and in-progress is derived from the server's `generatedAt`, never the browser clock.
- A cohort with zero signups renders its size and an em dash, no percentages pretending precision.
- The empty deployment renders a plain empty-state card.

## How

- `admin-metrics.ts`: `utcWeekStartKey` / `lastNWeekStartKeys` (Monday-keyed UTC weeks, matching Postgres's `date_trunc('week')`), `AdminRetentionCohort` / `AdminRetentionCell` on `AdminMetrics`, a cohort-count block on `AdminMetricsSource`, and a pure `buildRetentionCohorts` fold inside `buildAdminMetrics`, beside the existing zero-filling builders.
- `admin-queries.ts`: two grouped reads — accounts per signup week, and distinct active accounts per (signup week, activity week) pair — both joined through the user row and filtered by the same `scope` condition as every other metric; the empty-database fallback carries an empty retention block.
- `AdminDashboard.tsx`: a compact CSS grid (no recharts) with a cohort-Monday label column, a size column, and Wk 0–7 columns; cell intensity via `color-mix` against `--chart-1` with an 8% floor so small shares stay visible, text flipping to the background tone on strong fills, `tabular-nums` throughout, and the same `overflow-x-auto` + min-width scroll wrapper the tables use. A caption under the grid states exactly what a cell means and that purely local desktop use writes no row here.
- `tests/admin-metrics.test.ts`: week keying from midweek instants, the triangle (unreached weeks absent), per-week share math, in-progress marking on exactly the current week's cells, and the zero-signup cohort. Scope filtering lives in SQL below the fold's seam; the existing handler test covers scope pass-through.

## Verification

- `./scripts/check.sh` passes (exit 0) with the final code. One earlier run flagged two desktop native-helper test files under parallel load; both pass in isolation and the full suite passes cleanly on rerun — unrelated to this change, which touches only `apps/web`.
- Rendered the section in headless Chrome from a static `react-dom/server` render of the real component with representative fixture data (varied cohort sizes including a zero cohort, a midweek "now") against the built stylesheet, and inspected the screenshot: triangle shape correct, dashed in-progress cells on every row's last column, em dashes for the empty cohort, 0% cells unfilled, fill intensity tracking the share with the floor keeping 11–17% cells legible, dark text on strong fills, and the empty state rendering.
- Web-only change; no desktop surface touched, so no macOS/notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32538508490/artifacts/9466237170) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32538508490)

- Commit: `812f506cd28d0dc1ce7791c664a20fa46bbd28f6`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
