### PR TITLE
feat(admin): say when a chart has nothing yet, and mark today's partial bar

### DIFF
--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -1,6 +1,6 @@
 import { createAuthClient } from "better-auth/react";
 import { Fragment, useCallback, useEffect, useRef, useState } from "react";
-import { Bar, BarChart, CartesianGrid, LabelList, XAxis, YAxis } from "recharts";
+import { Bar, BarChart, CartesianGrid, Cell, LabelList, XAxis, YAxis } from "recharts";
 import type {
   AdminDailySignups,
   AdminDailyUsage,
@@ -35,6 +35,7 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "./components/ui/chart";
+import { partialDayKey, seriesHasNoData } from "./daily-series";
 import { LukeMark } from "./SiteChrome";
 import { SOCIAL_PROVIDER, SOCIAL_PROVIDER_LABEL, type SocialProvider } from "./sign-in-provider";
 
@@ -280,6 +281,18 @@ function formatDayTick(day: string): string {
   });
 }
 
+/**
+ * How faded today's bar draws. The series' last day is still filling, so a
+ * bar rendered like a complete day's always reads as a dip; the fade and the
+ * tooltip's "(so far today)" say the day is partial instead.
+ */
+const PARTIAL_DAY_OPACITY = 0.45;
+
+/** A tooltip label for one bar's day, saying so when that day is still filling. */
+function formatTooltipDay(day: string, partialDay: string | undefined): string {
+  return day === partialDay ? `${formatDayTick(day)} (so far today)` : formatDayTick(day);
+}
+
 /** How often the header's age re-reads the clock, so a page left open says so. */
 const AGE_TICK_MS = 30_000;
 
@@ -374,17 +387,33 @@ const USAGE_CHART = {
  * A trailing-window stacked bar chart on shadcn/ui's chart primitives. Voice
  * and attention stack so one bar reads as a day's total while its split stays
  * visible; the tooltip carries each day's exact numbers, and the legend names
- * the two series.
+ * the two series. A window with no calls at all says so instead of drawing
+ * the server's zero-fill as a flat measurement, and today's bar wears the
+ * partial-day fade.
  */
 function UsageChart({
   daily,
   trend,
   label,
+  generatedAt,
 }: {
   daily: readonly AdminDailyUsage[];
   trend: AdminTrend;
   label: string;
+  generatedAt: number;
 }): React.JSX.Element {
+  if (seriesHasNoData(daily.map((point) => point.voiceCalls + point.attentionReviews))) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-5">
+        <ChartHeading label={label} trend={trend} />
+        <p className="m-0 py-6 text-center text-sm text-muted-foreground">
+          No hosted-tier calls recorded in this window yet.
+        </p>
+      </div>
+    );
+  }
+
+  const partialDay = partialDayKey(daily, generatedAt);
   return (
     <div className="rounded-lg border border-border bg-card p-5">
       <ChartHeading label={label} trend={trend} />
@@ -402,17 +431,33 @@ function UsageChart({
           <YAxis width={36} tickLine={false} axisLine={false} allowDecimals={false} />
           <ChartTooltip
             content={
-              <ChartTooltipContent labelFormatter={(value) => formatDayTick(String(value))} />
+              <ChartTooltipContent
+                labelFormatter={(value) => formatTooltipDay(String(value), partialDay)}
+              />
             }
           />
           <ChartLegend content={<ChartLegendContent />} />
-          <Bar dataKey="voiceCalls" stackId="calls" fill="var(--color-voiceCalls)" />
+          <Bar dataKey="voiceCalls" stackId="calls" fill="var(--color-voiceCalls)">
+            {daily.map((point) => (
+              <Cell
+                key={point.day}
+                fillOpacity={point.day === partialDay ? PARTIAL_DAY_OPACITY : 1}
+              />
+            ))}
+          </Bar>
           <Bar
             dataKey="attentionReviews"
             stackId="calls"
             fill="var(--color-attentionReviews)"
             radius={[4, 4, 0, 0]}
-          />
+          >
+            {daily.map((point) => (
+              <Cell
+                key={point.day}
+                fillOpacity={point.day === partialDay ? PARTIAL_DAY_OPACITY : 1}
+              />
+            ))}
+          </Bar>
         </BarChart>
       </ChartContainer>
     </div>
@@ -423,14 +468,32 @@ const SIGNUPS_CHART = {
   count: { label: "New accounts", color: "var(--chart-1)" },
 } satisfies ChartConfig;
 
-/** One series, so the heading names it and no legend box restates the heading. */
+/**
+ * One series, so the heading names it and no legend box restates the heading.
+ * A window with no signups says so instead of drawing the server's zero-fill
+ * as a flat measurement, and today's bar wears the partial-day fade.
+ */
 function SignupsChart({
   daily,
   trend,
+  generatedAt,
 }: {
   daily: readonly AdminDailySignups[];
   trend: AdminTrend;
+  generatedAt: number;
 }): React.JSX.Element {
+  if (seriesHasNoData(daily.map((point) => point.count))) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-5">
+        <ChartHeading label="New accounts per day" trend={trend} />
+        <p className="m-0 py-6 text-center text-sm text-muted-foreground">
+          No accounts created in this window yet.
+        </p>
+      </div>
+    );
+  }
+
+  const partialDay = partialDayKey(daily, generatedAt);
   return (
     <div className="rounded-lg border border-border bg-card p-5">
       <ChartHeading label="New accounts per day" trend={trend} />
@@ -448,10 +511,19 @@ function SignupsChart({
           <YAxis width={36} tickLine={false} axisLine={false} allowDecimals={false} />
           <ChartTooltip
             content={
-              <ChartTooltipContent labelFormatter={(value) => formatDayTick(String(value))} />
+              <ChartTooltipContent
+                labelFormatter={(value) => formatTooltipDay(String(value), partialDay)}
+              />
             }
           />
-          <Bar dataKey="count" fill="var(--color-count)" radius={[4, 4, 0, 0]} />
+          <Bar dataKey="count" fill="var(--color-count)" radius={[4, 4, 0, 0]}>
+            {daily.map((point) => (
+              <Cell
+                key={point.day}
+                fillOpacity={point.day === partialDay ? PARTIAL_DAY_OPACITY : 1}
+              />
+            ))}
+          </Bar>
         </BarChart>
       </ChartContainer>
     </div>
@@ -1245,7 +1317,11 @@ function Dashboard({
           />
         </div>
         <div className="mt-3 grid gap-3 min-[720px]:grid-cols-[1.6fr_1fr]">
-          <SignupsChart daily={metrics.users.dailySignups} trend={metrics.users.signupTrend} />
+          <SignupsChart
+            daily={metrics.users.dailySignups}
+            trend={metrics.users.signupTrend}
+            generatedAt={metrics.generatedAt}
+          />
           <SignInMethodsChart
             methods={metrics.users.signInMethods}
             totalAccounts={metrics.users.total}
@@ -1291,6 +1367,7 @@ function Dashboard({
             daily={metrics.featureUsage.daily}
             trend={metrics.featureUsage.usageTrend}
             label="Hosted-tier calls per day"
+            generatedAt={metrics.generatedAt}
           />
         </div>
         <SectionHeading>Most active hosted-tier accounts</SectionHeading>
@@ -1672,6 +1749,7 @@ function UserDetailPage({
             daily={activity.daily}
             trend={activity.usageTrend}
             label="This account's calls per day"
+            generatedAt={detail.generatedAt}
           />
         </div>
 

--- a/apps/web/src/daily-series.ts
+++ b/apps/web/src/daily-series.ts
@@ -1,0 +1,21 @@
+/**
+ * Honest readings of the admin page's zero-filled daily series. The server
+ * fills every day of its window, so a deployment with no activity draws the
+ * same bars a flat one would, and the series runs through today (UTC), a
+ * partial day whose bar reads as a dip beside complete ones. Both readings
+ * derive from the response alone — "today" is `generatedAt`'s UTC day, never
+ * this browser's clock — so neither can disagree with the series it reads.
+ */
+
+export function seriesHasNoData(totals: readonly number[]): boolean {
+  return totals.every((total) => total === 0);
+}
+
+export function partialDayKey(
+  daily: readonly { day: string }[],
+  generatedAt: number,
+): string | undefined {
+  const last = daily.at(-1);
+  if (last === undefined) return undefined;
+  return last.day === new Date(generatedAt).toISOString().slice(0, 10) ? last.day : undefined;
+}

--- a/apps/web/tests/daily-series.test.ts
+++ b/apps/web/tests/daily-series.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { partialDayKey, seriesHasNoData } from "../src/daily-series";
+
+test("a zero-filled series reads as no data", () => {
+  assert.equal(seriesHasNoData([0, 0, 0]), true);
+});
+
+test("one active day means the series has data", () => {
+  assert.equal(seriesHasNoData([0, 3, 0]), false);
+});
+
+test("a series with no days at all reads as no data", () => {
+  assert.equal(seriesHasNoData([]), true);
+});
+
+test("the last day is partial when it is the day the response was generated", () => {
+  const daily = [{ day: "2026-08-20" }, { day: "2026-08-21" }];
+  assert.equal(partialDayKey(daily, Date.UTC(2026, 7, 21, 14, 30)), "2026-08-21");
+});
+
+test("a generation instant just inside a UTC day still marks that day", () => {
+  const daily = [{ day: "2026-08-21" }];
+  assert.equal(partialDayKey(daily, Date.UTC(2026, 7, 21, 0, 0, 1)), "2026-08-21");
+});
+
+test("a series ending before the generated day has no partial day", () => {
+  const daily = [{ day: "2026-08-19" }, { day: "2026-08-20" }];
+  assert.equal(partialDayKey(daily, Date.UTC(2026, 7, 21)), undefined);
+});
+
+test("an empty series has no partial day", () => {
+  assert.equal(partialDayKey([], Date.UTC(2026, 7, 21)), undefined);
+});


### PR DESCRIPTION
## What

The dashboard's two daily bar charts now tell the truth at both edges of the data.

- **Empty windows say so.** The server zero-fills every day of the window, so a deployment with no activity drew the same 30-bar flat axis a quiet one would. `UsageChart` (dashboard and account detail) and `SignupsChart` now render a bounded message in the card when every point is zero, in the same register as `SignInMethodsChart`'s existing empty state: "No hosted-tier calls recorded in this window yet." / "No accounts created in this window yet."
- **Today's bar reads as partial.** The daily series run through today (UTC), a day still filling, so the last bar always read as a dip. Today's bar now draws at reduced opacity (a recharts `Cell` per point), and its tooltip label carries "(so far today)".

## How

- A small pure module, `apps/web/src/daily-series.ts`, holds both decisions: `seriesHasNoData` over the points' totals, and `partialDayKey`, which names the series' last day only when it is `generatedAt`'s UTC day. "Today" is derived from the response the server sent, never the browser's local clock, so the marking can never disagree with the series it marks — a browser in another timezone, or a stale response, fades exactly the bar the data calls today, or none.
- Both charts take `generatedAt` from the payload they already render (`metrics.generatedAt`, `detail.generatedAt`), keep their `ChartHeading` (trend caption) above the empty message, and share one `PARTIAL_DAY_OPACITY` and one `formatTooltipDay`.
- Unit tests in `apps/web/tests/daily-series.test.ts` cover the all-zero, empty-series, matching-day, day-boundary, and stale-response cases.

## Verification

- `./scripts/check.sh` passes (exit 0) — repository, type, test, and build checks, including the new `daily-series` tests (7/7).
- Rendered the admin dashboard in headless Chrome against a stubbed metrics response, in both states, and inspected the screenshots:
  - All-zero series: both charts show their empty message in the card; the sign-in-methods empty state is unchanged beside them.
  - Data including a partial today: every complete day draws at full opacity while the Aug 21 bar draws visibly faded in both charts, and the tooltip over it reads "Aug 21 (so far today)". A DOM probe confirmed exactly one `fill-opacity="0.45"` rect in the signups chart and two (the stacked pair) in the usage chart, with all other bars at 1.
- Web-only change; no desktop surface touched, so no macOS/notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32539580368/artifacts/9466593155) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32539580368)

- Commit: `feadf50f61042ca2f9ddc11c9a74c3340c7228b8`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
