### PR TITLE
feat(sessions): keep a provider-asserted ask waiting until it is answered

### DIFF
--- a/packages/providers/src/claude-code/adapter.ts
+++ b/packages/providers/src/claude-code/adapter.ts
@@ -422,7 +422,10 @@ function statusFromTail(
  * show: a tool call holding for permission writes no records while it holds,
  * and a turn's true end can sit past the tail's read. A failed turn is
  * definite alongside a closed session because the tail may hold nothing about
- * either.
+ * either. The notification keeps waiting past freshness — a standing event is
+ * proof the permission dialog is still up, because any record at or past it
+ * would have discarded it, and a crash mid-hold leaves that proof standing
+ * only until the spool prune retires it.
  */
 const CLAUDE_HOOK_STATUS_REFINEMENT = {
   definitive: [
@@ -432,7 +435,11 @@ const CLAUDE_HOOK_STATUS_REFINEMENT = {
   fresh: [
     { event: CLAUDE_HOOK_EVENT.PROMPT, fresh: SESSION_STATUS.WORKING },
     { event: CLAUDE_HOOK_EVENT.STOP, fresh: SESSION_STATUS.WAITING },
-    { event: CLAUDE_HOOK_EVENT.NOTIFICATION, fresh: SESSION_STATUS.WAITING },
+    {
+      event: CLAUDE_HOOK_EVENT.NOTIFICATION,
+      fresh: SESSION_STATUS.WAITING,
+      stale: SESSION_STATUS.WAITING,
+    },
   ],
   notificationEvent: CLAUDE_HOOK_EVENT.NOTIFICATION,
   sessionEndEvent: CLAUDE_HOOK_EVENT.SESSION_END,

--- a/packages/providers/src/codex/adapter.test.ts
+++ b/packages/providers/src/codex/adapter.test.ts
@@ -1526,12 +1526,14 @@ test("a spool that cannot be read costs only the refinement", async (t) => {
 });
 
 // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-test("a permission hold that outlives the freshness window never reads as work", async (t) => {
+test("a permission hold that outlives the freshness window is still an ask", async (t) => {
   const codexHome = await temporaryCodexHome(t);
   const spool = await temporaryHookSpool(t);
   const rolloutPath = path.join(codexHome, "rollout-long-hold.jsonl");
-  // Codex deliberately holds a long open turn at working, so without this
-  // rule a hold past the window would flip from waiting back to active work.
+  // A standing notification is proof the approval dialog is still up — the
+  // hold writes no records, so any record at or past it would have discarded
+  // it — and an ask still asking must neither flip back to active work nor
+  // melt into an idle row however long it has stood.
   await writeCodexState(codexHome, [
     {
       id: "codex-long-hold",
@@ -1551,5 +1553,5 @@ test("a permission hold that outlives the freshness window never reads as work",
   });
   const [observation] = await adapter.observe();
 
-  assert.equal(observation?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(observation?.status, SESSION_STATUS.WAITING);
 });

--- a/packages/providers/src/codex/adapter.ts
+++ b/packages/providers/src/codex/adapter.ts
@@ -650,7 +650,11 @@ function statusFromRow(
 /**
  * What the refinement actually buys here is the states the state database
  * cannot show: a tool call holding for approval writes no records while it
- * holds, and a turn's true end can sit past the rollout's read.
+ * holds, and a turn's true end can sit past the rollout's read. The
+ * notification keeps waiting past freshness — a standing event is proof the
+ * approval dialog is still up, because any record at or past it would have
+ * discarded it, and a process killed mid-hold leaves that proof standing
+ * only until the spool prune retires it.
  */
 const CODEX_HOOK_STATUS_REFINEMENT = {
   definitive: [{ event: CODEX_HOOK_EVENT.SESSION_END, fresh: SESSION_STATUS.COMPLETE }],
@@ -658,7 +662,7 @@ const CODEX_HOOK_STATUS_REFINEMENT = {
     {
       event: CODEX_HOOK_EVENT.NOTIFICATION,
       fresh: SESSION_STATUS.WAITING,
-      stale: SESSION_STATUS.UNKNOWN,
+      stale: SESSION_STATUS.WAITING,
     },
     { event: CODEX_HOOK_EVENT.PROMPT, fresh: SESSION_STATUS.WORKING },
     { event: CODEX_HOOK_EVENT.STOP, fresh: SESSION_STATUS.WAITING },

--- a/packages/providers/src/copilot/adapter.test.ts
+++ b/packages/providers/src/copilot/adapter.test.ts
@@ -265,11 +265,13 @@ test("keeps reporting a long turn as working", async () => {
   assert.equal(observations[0]?.observedAt, startedAt);
 });
 
-test("stops calling a task that asked for the user waiting once it goes stale", async () => {
+test("a task holding for the user keeps asking however long it has stood", async () => {
+  // GitHub asserting waiting_for_user is a live fact about this moment, not a
+  // turn boundary to be guessed stale, so the ask never melts into an idle row.
   const askedAt = TEST_TIME - 2 * 60 * 60 * 1000;
   const api = fakeAgentTasksApi([
     {
-      id: "task-abandoned",
+      id: "task-standing-ask",
       state: TEST_STATE.WAITING_FOR_USER,
       createdAt: askedAt,
       updatedAt: askedAt,
@@ -278,7 +280,7 @@ test("stops calling a task that asked for the user waiting once it goes stale", 
 
   const observations = await adapterFor(api.fetch).observe();
 
-  assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
 });
 
 test("keeps a completed task complete however long ago it finished", async () => {

--- a/packages/providers/src/copilot/adapter.ts
+++ b/packages/providers/src/copilot/adapter.ts
@@ -284,6 +284,9 @@ export class CopilotSessionAdapter extends CloudSessionAdapter {
   #statusFor(task: CopilotTask, now: number): SessionStatus {
     // A state this build does not know is not guessed at.
     if (!task.state) return SESSION_STATUS.UNKNOWN;
+    // GitHub asserting the task is holding for the user is a live fact, not a
+    // turn boundary to be guessed stale, so the ask stands until it changes.
+    if (task.state === COPILOT_TASK_STATE.WAITING_FOR_USER) return SESSION_STATUS.WAITING;
     return agedStatus(
       SESSION_STATUS_BY_COPILOT_STATE[task.state],
       task.observedAt,

--- a/packages/providers/src/devin/adapter.test.ts
+++ b/packages/providers/src/devin/adapter.test.ts
@@ -480,10 +480,12 @@ test("keeps reporting a long turn as working, and a session that ended as comple
   assert.equal(observations[0]?.observedAt, startedAt);
 });
 
-test("stops calling a session that is holding for the user waiting once it goes stale", async () => {
+test("a session holding for the user keeps asking however long it has stood", async () => {
+  // Devin asserting waiting-for-user is a live fact about this moment, not a
+  // turn boundary to be guessed stale, so the ask never melts into an idle row.
   const api = fakeDevinApi([
     {
-      id: "devin-abandoned",
+      id: "devin-standing-ask",
       status: TEST_STATUS.RUNNING,
       detail: TEST_DETAIL.WAITING_FOR_USER,
       updatedAt: TEST_TIME - 2 * 60 * 60 * 1000,
@@ -492,7 +494,7 @@ test("stops calling a session that is holding for the user waiting once it goes 
 
   const observations = await adapterFor(api.fetch).observe();
 
-  assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
 });
 
 // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.

--- a/packages/providers/src/devin/adapter.ts
+++ b/packages/providers/src/devin/adapter.ts
@@ -479,10 +479,19 @@ export class DevinSessionAdapter extends CloudSessionAdapter {
     // The detail is what a live session is actually doing, and it is only
     // meaningful while one is running: for a suspended session Devin puts the
     // reason for the suspension there instead, which this build knows none of.
+    const detail = session.status === DEVIN_SESSION_STATUS.RUNNING ? session.detail : undefined;
+    // Devin asserting the session is waiting on the user or an approval is a
+    // live fact, not a turn boundary to be guessed stale, so the ask stands
+    // until it changes; a finished turn is a boundary and ages like one.
+    if (
+      detail === DEVIN_RUNNING_DETAIL.WAITING_FOR_USER ||
+      detail === DEVIN_RUNNING_DETAIL.WAITING_FOR_APPROVAL
+    ) {
+      return SESSION_STATUS.WAITING;
+    }
     const status =
-      (session.status === DEVIN_SESSION_STATUS.RUNNING && session.detail
-        ? SESSION_STATUS_BY_RUNNING_DETAIL[session.detail]
-        : undefined) ?? SESSION_STATUS_BY_DEVIN_STATUS[session.status];
+      (detail ? SESSION_STATUS_BY_RUNNING_DETAIL[detail] : undefined) ??
+      SESSION_STATUS_BY_DEVIN_STATUS[session.status];
     return agedStatus(
       status,
       session.observedAt,

--- a/packages/providers/src/devin/local-adapter.test.ts
+++ b/packages/providers/src/devin/local-adapter.test.ts
@@ -840,11 +840,13 @@ test("a spool that cannot be read costs only the refinement", async (t) => {
   assert.equal(observation?.status, SESSION_STATUS.WORKING);
 });
 
-test("a permission hold that outlives the freshness window never reads as work", async (t) => {
+test("a permission hold that outlives the freshness window is still an ask", async (t) => {
   const cliDirectory = await temporaryCliDirectory(t);
   const spool = await temporaryHookSpool(t);
-  // An open turn past the window already decays to unknown; the stale hold
-  // must land in the same place rather than revive it as waiting.
+  // A standing notification is proof the approval dialog is still up — the
+  // hold writes no rows, so any row at or past it would have discarded it —
+  // and an ask still asking must neither flip back to active work nor melt
+  // into an idle row however long it has stood.
   await writeOpenTurnState(cliDirectory, "long-hold", TEST_TIME - 30 * 60_000);
   await writeHookEvent(spool, "long-hold", "notification", TEST_TIME - 20 * 60_000);
 
@@ -856,7 +858,7 @@ test("a permission hold that outlives the freshness window never reads as work",
   });
   const [observation] = await adapter.observe();
 
-  assert.equal(observation?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(observation?.status, SESSION_STATUS.WAITING);
 });
 
 test("honors the CLI's own database override", async (t) => {

--- a/packages/providers/src/devin/local-adapter.ts
+++ b/packages/providers/src/devin/local-adapter.ts
@@ -322,10 +322,11 @@ function activityFromToolCallRows(rows: readonly DevinRow[]): string | undefined
  * What the refinement actually buys here is the states the session database
  * cannot show: a tool call holding for approval writes no node while it
  * holds, a settled turn and a session walked away from write the same rows,
- * and the database records no closure at all. The stale notification decays
- * to unknown for the same reason Codex's does — a hold nobody has answered in
- * a window is indistinguishable from a session left behind, and must never
- * read as anything livelier.
+ * and the database records no closure at all. The notification keeps waiting
+ * past freshness for the same reason Codex's does — a standing event is
+ * proof the approval dialog is still up, because any row at or past it would
+ * have discarded it, and a process killed mid-hold leaves that proof
+ * standing only until the spool prune retires it.
  */
 const DEVIN_HOOK_STATUS_REFINEMENT = {
   definitive: [{ event: DEVIN_HOOK_EVENT.SESSION_END, fresh: SESSION_STATUS.COMPLETE }],
@@ -333,7 +334,7 @@ const DEVIN_HOOK_STATUS_REFINEMENT = {
     {
       event: DEVIN_HOOK_EVENT.NOTIFICATION,
       fresh: SESSION_STATUS.WAITING,
-      stale: SESSION_STATUS.UNKNOWN,
+      stale: SESSION_STATUS.WAITING,
     },
     { event: DEVIN_HOOK_EVENT.PROMPT, fresh: SESSION_STATUS.WORKING },
     { event: DEVIN_HOOK_EVENT.STOP, fresh: SESSION_STATUS.WAITING },

--- a/packages/providers/src/gemini-cli/adapter.test.ts
+++ b/packages/providers/src/gemini-cli/adapter.test.ts
@@ -581,6 +581,33 @@ test("a permission prompt the tail has not written yet turns the row to waiting"
   assert.equal(observation?.observedAt, TEST_TIME - 60_000);
 });
 
+test("a permission hold that outlives the freshness window is still an ask", async (t) => {
+  const geminiHome = await temporaryGeminiHome(t);
+  const spool = await temporaryHookSpool(t);
+  // A standing notification is proof the confirmation is still up — the hold
+  // writes no records, so any record at or past it would have discarded it —
+  // and an ask still asking must not melt into an idle row however long it
+  // has stood.
+  await writeSessionFile(
+    geminiHome,
+    "luke",
+    "session-2026-08-20T11-00-abcd1234",
+    midTurnRecords("2026-08-20T11:40:00.000Z"),
+    TEST_TIME - 20 * 60 * 1000,
+  );
+  await writeHookEvent(spool, FULL_SESSION_ID, "notification", TEST_TIME - 18 * 60_000);
+
+  const adapter = new GeminiCliSessionAdapter({
+    geminiHome,
+    hookEventsDirectory: () => spool,
+    now: () => TEST_TIME,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WAITING);
+  assert.equal(observation?.holdingForDeveloper, true);
+});
+
 test("a stop event keeps a finished turn waiting past the freshness decay", async (t) => {
   const geminiHome = await temporaryGeminiHome(t);
   const spool = await temporaryHookSpool(t);

--- a/packages/providers/src/gemini-cli/adapter.ts
+++ b/packages/providers/src/gemini-cli/adapter.ts
@@ -246,14 +246,21 @@ function statusFromTail(
  * `session-end` token is the one thing that can ever report a local Gemini
  * session complete, a notification marks a hold the moment it starts rather
  * than when the awaiting call reaches the tail, and a stop keeps a settled
- * turn waiting past the freshness decay.
+ * turn waiting past the freshness decay. The notification keeps waiting past
+ * freshness too — a standing event is proof the hold still stands, because
+ * any record at or past it would have discarded it, and a crash mid-hold
+ * leaves that proof standing only until the spool prune retires it.
  */
 const GEMINI_HOOK_STATUS_REFINEMENT = {
   definitive: [{ event: GEMINI_HOOK_EVENT.SESSION_END, fresh: SESSION_STATUS.COMPLETE }],
   fresh: [
     { event: GEMINI_HOOK_EVENT.PROMPT, fresh: SESSION_STATUS.WORKING },
     { event: GEMINI_HOOK_EVENT.STOP, fresh: SESSION_STATUS.WAITING },
-    { event: GEMINI_HOOK_EVENT.NOTIFICATION, fresh: SESSION_STATUS.WAITING },
+    {
+      event: GEMINI_HOOK_EVENT.NOTIFICATION,
+      fresh: SESSION_STATUS.WAITING,
+      stale: SESSION_STATUS.WAITING,
+    },
   ],
   notificationEvent: GEMINI_HOOK_EVENT.NOTIFICATION,
   sessionEndEvent: GEMINI_HOOK_EVENT.SESSION_END,

--- a/packages/providers/src/jules/adapter.test.ts
+++ b/packages/providers/src/jules/adapter.test.ts
@@ -283,11 +283,14 @@ test("keeps reporting a long turn as working", async () => {
   assert.equal(observations[0]?.observedAt, startedAt);
 });
 
-test("stops calling a session that asked for feedback waiting once it goes stale", async () => {
+test("a session awaiting feedback keeps asking however long it has stood", async () => {
+  // Jules asserting the session awaits feedback is a live fact about this
+  // moment, not a turn boundary to be guessed stale, so the ask never melts
+  // into an idle row.
   const askedAt = TEST_TIME - 2 * 60 * 60 * 1000;
   const api = fakeJulesApi([
     {
-      id: "session-abandoned",
+      id: "session-standing-ask",
       state: TEST_STATE.AWAITING_USER_FEEDBACK,
       createTime: askedAt,
       updateTime: askedAt,
@@ -296,7 +299,7 @@ test("stops calling a session that asked for feedback waiting once it goes stale
 
   const observations = await adapterFor(api.fetch).observe();
 
-  assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
+  assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
 });
 
 test("keeps a completed session complete however long ago it finished", async () => {

--- a/packages/providers/src/jules/adapter.ts
+++ b/packages/providers/src/jules/adapter.ts
@@ -122,6 +122,19 @@ const SESSION_STATUS_BY_JULES_STATE = {
   [JULES_STATE.STATE_UNSPECIFIED]: SESSION_STATUS.UNKNOWN,
 };
 
+/**
+ * The states in which Jules is asserting, right now, that the session is
+ * holding for the user — a plan awaiting approval or a question awaiting an
+ * answer. These stay waiting however long they have stood, because the
+ * provider is describing this moment rather than a turn boundary Luke would
+ * otherwise have to guess had been walked away from; a pause is the user's
+ * own act, so it ages like any other quiet session instead.
+ */
+const JULES_STANDING_ASK_STATES: ReadonlySet<JulesState> = new Set([
+  JULES_STATE.AWAITING_PLAN_APPROVAL,
+  JULES_STATE.AWAITING_USER_FEEDBACK,
+]);
+
 const JULES_ADAPTER_DEFAULTS = {
   /** The documented maximum, so one call reaches as deep into the history as it can. */
   SESSION_PAGE_SIZE: 100,
@@ -282,6 +295,9 @@ export class JulesSessionAdapter extends CloudSessionAdapter {
   #statusFor(session: JulesSession, now: number): SessionStatus {
     // A state this build does not know is not guessed at.
     if (!session.state) return SESSION_STATUS.UNKNOWN;
+    if (JULES_STANDING_ASK_STATES.has(session.state)) {
+      return SESSION_STATUS_BY_JULES_STATE[session.state];
+    }
     return agedStatus(
       SESSION_STATUS_BY_JULES_STATE[session.state],
       session.observedAt,

--- a/packages/providers/src/opencode/adapter.test.ts
+++ b/packages/providers/src/opencode/adapter.test.ts
@@ -893,6 +893,26 @@ test("a fresh permission ask reads as holding for the developer", async (t) => {
   assert.equal(observation?.observedAt, TEST_TIME);
 });
 
+test("a permission hold that outlives the freshness window is still an ask", async (t) => {
+  const dataDirectory = await temporaryDataDirectory(t);
+  const spoolDirectory = path.join(dataDirectory, "events");
+  await writeWorkingSession(dataDirectory, "ses_long_hold");
+  await writeHookEvent(spoolDirectory, "ses_long_hold", "notification", TEST_TIME);
+
+  // A standing notification is proof the ask is still up — the hold writes
+  // no record, so any record at or past it would have discarded it — and an
+  // ask still asking must not melt into an idle row however long it stands.
+  const adapter = new OpenCodeSessionAdapter({
+    dataDirectory,
+    now: () => TEST_TIME + 20 * 60_000,
+    hookEventsDirectory: () => spoolDirectory,
+  });
+  const [observation] = await adapter.observe();
+
+  assert.equal(observation?.status, SESSION_STATUS.WAITING);
+  assert.equal(observation?.holdingForDeveloper, true);
+});
+
 test("a session-end event reads as complete with the closure as its cause", async (t) => {
   const dataDirectory = await temporaryDataDirectory(t);
   const spoolDirectory = path.join(dataDirectory, "events");

--- a/packages/providers/src/opencode/adapter.ts
+++ b/packages/providers/src/opencode/adapter.ts
@@ -354,7 +354,15 @@ const OPENCODE_HOOK_STATUS_REFINEMENT = {
   fresh: [
     { event: OPENCODE_HOOK_EVENT.PROMPT, fresh: SESSION_STATUS.WORKING },
     { event: OPENCODE_HOOK_EVENT.STOP, fresh: SESSION_STATUS.WAITING },
-    { event: OPENCODE_HOOK_EVENT.NOTIFICATION, fresh: SESSION_STATUS.WAITING },
+    // The notification keeps waiting past freshness: a standing event is
+    // proof the hold still stands, because any record at or past it would
+    // have discarded it, and a crash mid-hold leaves that proof standing
+    // only until the spool prune retires it.
+    {
+      event: OPENCODE_HOOK_EVENT.NOTIFICATION,
+      fresh: SESSION_STATUS.WAITING,
+      stale: SESSION_STATUS.WAITING,
+    },
   ],
   notificationEvent: OPENCODE_HOOK_EVENT.NOTIFICATION,
   sessionEndEvent: OPENCODE_HOOK_EVENT.SESSION_END,

--- a/packages/session/src/session.ts
+++ b/packages/session/src/session.ts
@@ -45,6 +45,14 @@ export type SessionCompletionCause =
  * is stale, Luke cannot tell a turn that just asked for the user from one
  * they walked away from hours ago, and reporting the stale state would speak
  * at the wrong moment.
+ *
+ * The decay is for asks that are inferences — a transcript's turn that ended,
+ * a chat a provider reports as merely idle. An adapter whose provider asserts
+ * that a session is holding for the user right now — a plan awaiting
+ * approval, a task waiting for input, a tool call holding for permission —
+ * keeps that status out of this helper: the ask stands until the provider
+ * stops reporting it, because it is a live fact rather than a guess about
+ * where a quiet session left off.
  */
 export function agedStatus(
   status: SessionStatus,


### PR DESCRIPTION
## Summary

Narrow, single-purpose change: **what counts as "Needs you" becomes accurate.** Roster retention is untouched — every status keeps exactly the lifetime it has on main.

Every waiting session used to melt into idle after fifteen minutes. That decay is right for *inferred* asks — a transcript's turn that ended, a Conductor chat reported as merely idle, a finished Cursor run — because past the window Luke cannot tell a fresh ask from a chat walked away from. It is wrong for asks a provider asserts as a live fact about this moment. After this PR, a **standing ask keeps saying "Needs you" until it is answered**:

- **Jules** — `AWAITING_PLAN_APPROVAL` and `AWAITING_USER_FEEDBACK` (a pause is the user's own act and keeps aging).
- **Copilot** — `waiting_for_user`.
- **Devin cloud** — running with `waiting_for_user` / `waiting_for_approval` detail (`finished` is a turn boundary and keeps aging).
- **Local permission holds (Claude Code, Codex)** — the hook notification's `stale` mapping becomes `WAITING`: the notification carries zero tolerance, so any transcript record at or past it discards it, which makes a standing event proof the dialog is still up. A crash mid-hold is bounded by the 24-hour spool prune.

Turn-ended soft asks are deliberately unchanged, and so is everything else: retention windows, the badge, completion causes, the guide's retention wording.

## One consequence to weigh

Waiting rows have infinite retention on main (it never mattered while everything decayed within fifteen minutes). With standing asks no longer decaying, an unanswered ask now keeps its row for as long as its provider reports it — which is the point ("asks stay until answered"), but it means a Jules plan nobody ever approves is a permanent "Needs you" row until dealt with in the provider. Bounding that with a retention window is a separate decision this PR deliberately does not take.

## Test plan

- [x] `./scripts/check.sh` exits 0 — lint, typecheck, build, 2,013 tests across the workspace
- [x] Per-adapter standing-ask tests replace the old "goes stale" tests (Jules, Copilot, Devin, Codex permission hold)
- [x] No UI or macOS surface change — check.sh is the completion invariant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32757991555/artifacts/9531677718) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32757991555)

- Commit: `f20c642e61d8b594142694bc07ded4c2f7aadfd2`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d8f9af8a-f3ac-4c93-86e6-46315cede3aa)
