### PR TITLE
feat(admin): say what a trend moved from, not just which way

### DIFF
--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -335,13 +335,15 @@ function StatCard({
   label,
   value,
   hint,
+  title,
 }: {
   label: string;
   value: string;
   hint?: string;
+  title?: string;
 }): React.JSX.Element {
   return (
-    <div className="rounded-lg border border-border bg-card px-5 py-4">
+    <div className="rounded-lg border border-border bg-card px-5 py-4" title={title}>
       <div className="font-mono text-xs tracking-[0.2px] text-muted-foreground uppercase">
         {label}
       </div>
@@ -1300,10 +1302,13 @@ function Dashboard({
         <SectionHeading>User activity</SectionHeading>
         <div className="grid grid-cols-2 gap-3 min-[720px]:grid-cols-4">
           <StatCard label="Total accounts" value={formatNumber(metrics.users.total)} />
+          {/* The hint already carries the window total, so the run this count
+              is read against rides the title attribute instead. */}
           <StatCard
             label={`New · ${metrics.users.signupTrend.days} days`}
             value={formatNumber(metrics.users.signupTrend.recent)}
             hint={`${formatNumber(metrics.users.newInWindow)} in ${metrics.windowDays} days`}
+            title={`against ${formatNumber(metrics.users.signupTrend.prior)} in the ${metrics.users.signupTrend.days} days before`}
           />
           <StatCard
             label="Active sessions"


### PR DESCRIPTION
## What

A stat card carrying an `AdminTrend` stated its trailing run's count without the number it is read against. The dashboard's "New · 7 days" card now names the prior run — `against N in the 7 days before` — as a title tooltip on the card, since its hint line already carries the window total and stacking a second figure there would crowd the caption. `StatCard` gains an optional `title` prop to carry it.

## How

Audit of every place a trend renders, before this change:

- Dashboard `SignupsChart` heading (`ChartHeading`) — already states the prior: "N in the last 7 days, against M before". Unchanged.
- Dashboard `UsageChart` heading (`ChartHeading`) — same, already states the prior. Unchanged.
- Account detail `UsageChart` heading (`ChartHeading`) — same. Unchanged.
- Account detail "Active days · 7 days" stat card — already states the prior in its hint: "N the week before". Unchanged.
- Dashboard "New · 7 days" stat card — used `signupTrend.recent` as its value but stated the prior nowhere, and its hint is already occupied by the window total. This is the one gap; the prior now rides the card's `title` attribute, worded in the chart headings' own "against … before" register and formatted with the existing `formatNumber`.

Presentation-only: `AdminTrend` already carries both `recent` and `prior` for every trend the page receives, so no server change.

## Verification

- `./scripts/check.sh` passes (exit 0): repository, type, test, and build checks.
- Web-only change; no desktop surface touched, so no macOS/notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32540299967/artifacts/9466831588) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32540299967)

- Commit: `17c8ce635781192ee5d62109c3042326989cc2d5`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
