### PR TITLE
fix(admin): validate chart config before it reaches the injected style block

### DIFF
--- a/apps/web/src/components/ui/chart-css.ts
+++ b/apps/web/src/components/ui/chart-css.ts
@@ -1,0 +1,40 @@
+/**
+ * Validators for the two strings <ChartStyle> interpolates into its injected
+ * <style> block: a config entry's key (which becomes a custom property name)
+ * and its color (which becomes that property's value). Every config in this
+ * repository is a module-level constant, but the primitive accepts arbitrary
+ * config, so the check has to live where the interpolation happens: a call
+ * site that one day feeds it something observed — a provider name, a title —
+ * must not be able to turn a color string into CSS of its own.
+ */
+
+/** A key is a CSS custom-property name fragment; anything beyond identifier
+ * characters could close the declaration or the rule. */
+const SAFE_KEY = /^[a-zA-Z_][\w-]*$/;
+
+/** Rejects everything that could end a declaration, close or open a rule,
+ * escape the style element, or smuggle a fetch or nested sheet in. */
+const FORBIDDEN_COLOR_FRAGMENT = /[;{}<>]|url\(|expression\(|@import/i;
+
+/** The color forms chart configs legitimately use: hex, a named keyword,
+ * the color functions (rgb, hsl, oklch, oklab, color-mix, with nesting for
+ * color-mix's arguments), and var(--x) references with an optional fallback. */
+const COLOR_FORMATS = [
+  /^#[0-9a-fA-F]{3,8}$/,
+  /^[a-zA-Z]+$/,
+  /^(?:rgb|rgba|hsl|hsla|oklch|oklab|color-mix)\([^;{}<>]*\)$/i,
+  /^var\(--[a-zA-Z_][\w-]*(?:\s*,\s*[^;{}<>]*)?\)$/,
+] as const;
+
+export function isSafeChartCssKey(key: string): boolean {
+  return SAFE_KEY.test(key);
+}
+
+export function isSafeChartCssColor(color: string): boolean {
+  const trimmed = color.trim();
+  return (
+    trimmed.length > 0 &&
+    !FORBIDDEN_COLOR_FRAGMENT.test(trimmed) &&
+    COLOR_FORMATS.some((format) => format.test(trimmed))
+  );
+}

--- a/apps/web/src/components/ui/chart.tsx
+++ b/apps/web/src/components/ui/chart.tsx
@@ -11,6 +11,7 @@
 import * as React from "react";
 import type { TooltipValueType } from "recharts";
 import * as RechartsPrimitive from "recharts";
+import { isSafeChartCssColor, isSafeChartCssKey } from "./chart-css";
 
 type ClassValue = string | false | null | undefined;
 
@@ -93,7 +94,20 @@ function ChartContainer({
 }
 
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
-  const colorConfig = Object.entries(config).filter(([, config]) => config.theme ?? config.color);
+  // SAFETY: the interpolation below is raw CSS, so the boundary must sit here
+  // in the primitive rather than at call sites: every config funnels through
+  // this component, and a future call site feeding it anything observed would
+  // otherwise turn a key or color string into an injection point. An entry
+  // that fails validation is skipped, not thrown on, because one bad series
+  // color should cost that series its variable, not the chart its render.
+  const colorConfig = Object.entries(config).filter(([key, itemConfig]) => {
+    const colors = itemConfig.theme
+      ? Object.values(itemConfig.theme)
+      : itemConfig.color
+        ? [itemConfig.color]
+        : [];
+    return colors.length > 0 && isSafeChartCssKey(key) && colors.every(isSafeChartCssColor);
+  });
 
   if (!colorConfig.length) {
     return null;
@@ -101,7 +115,7 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
 
   return (
     <style
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: the generated rules interpolate only ChartConfig keys and colors, which are fixed at build time, never user input.
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: the generated rules interpolate only keys and colors the filter above validated against identifier and color-format allowlists.
       dangerouslySetInnerHTML={{
         __html: Object.entries(THEMES)
           .map(

--- a/apps/web/tests/chart-css.test.ts
+++ b/apps/web/tests/chart-css.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isSafeChartCssColor, isSafeChartCssKey } from "../src/components/ui/chart-css";
+
+test("a config key must be a plain identifier", () => {
+  assert.equal(isSafeChartCssKey("users"), true);
+  assert.equal(isSafeChartCssKey("active_users"), true);
+  assert.equal(isSafeChartCssKey("chart-2"), true);
+  assert.equal(isSafeChartCssKey("_internal"), true);
+});
+
+test("a key that could close the declaration or the rule is rejected", () => {
+  assert.equal(isSafeChartCssKey(""), false);
+  assert.equal(isSafeChartCssKey("2users"), false);
+  assert.equal(isSafeChartCssKey("users;color:red"), false);
+  assert.equal(isSafeChartCssKey("users} body{"), false);
+  assert.equal(isSafeChartCssKey("users</style>"), false);
+  assert.equal(isSafeChartCssKey("a b"), false);
+});
+
+test("the color shapes chart configs use pass", () => {
+  assert.equal(isSafeChartCssColor("#fff"), true);
+  assert.equal(isSafeChartCssColor("#22c55e"), true);
+  assert.equal(isSafeChartCssColor("#22c55e80"), true);
+  assert.equal(isSafeChartCssColor("rebeccapurple"), true);
+  assert.equal(isSafeChartCssColor("transparent"), true);
+  assert.equal(isSafeChartCssColor("rgb(34 197 94)"), true);
+  assert.equal(isSafeChartCssColor("rgba(34, 197, 94, 0.5)"), true);
+  assert.equal(isSafeChartCssColor("hsl(142 71% 45%)"), true);
+  assert.equal(isSafeChartCssColor("oklch(0.72 0.19 150)"), true);
+  assert.equal(isSafeChartCssColor("oklab(0.72 -0.15 0.1)"), true);
+  assert.equal(isSafeChartCssColor("color-mix(in oklch, var(--a), var(--b) 40%)"), true);
+  assert.equal(isSafeChartCssColor("var(--chart-1)"), true);
+  assert.equal(isSafeChartCssColor("var(--chart-1, #fff)"), true);
+  assert.equal(isSafeChartCssColor(" #fff "), true);
+});
+
+test("a color that could escape the declaration or fetch anything is rejected", () => {
+  assert.equal(isSafeChartCssColor(""), false);
+  assert.equal(isSafeChartCssColor("red;background:url(https://example.com)"), false);
+  assert.equal(isSafeChartCssColor("red} body{display:none"), false);
+  assert.equal(isSafeChartCssColor("</style><script>"), false);
+  assert.equal(isSafeChartCssColor("url(https://example.com/pixel)"), false);
+  assert.equal(isSafeChartCssColor("expression(alert(1))"), false);
+  assert.equal(isSafeChartCssColor("@import 'https://example.com/a.css'"), false);
+  assert.equal(isSafeChartCssColor("rgb(0 0 0); color: red"), false);
+  assert.equal(isSafeChartCssColor("var(--a, url(https://example.com))"), false);
+  assert.equal(isSafeChartCssColor("hsl(0 0% 0%) extra"), false);
+});


### PR DESCRIPTION
## What

Hardens the vendored chart primitives in `apps/web/src/components/ui/chart.tsx`. `ChartStyle` injects per-chart CSS through `dangerouslySetInnerHTML`, interpolating each `ChartConfig` entry's key and color string into a `<style>` block. Every config in the repository today is a static module-level constant, but the primitive accepts arbitrary config, so a future call site feeding it anything observed (a provider name, a title) would turn a color string into a CSS injection point. The validation now lives in the primitive, where the interpolation happens, rather than trusting call sites.

## How

- New pure module `apps/web/src/components/ui/chart-css.ts` exports two validators: `isSafeChartCssKey` requires a plain identifier (`^[a-zA-Z_][\w-]*$`), and `isSafeChartCssColor` requires an allowlisted CSS color form — hex, named keyword, `rgb()`/`rgba()`/`hsl()`/`hsla()`/`oklch()`/`oklab()`/`color-mix()`, or a `var(--x)` reference — while rejecting anything containing `;`, `{`, `}`, `<`, `>`, `url(`, `expression(`, or `@import`.
- `ChartStyle` filters config entries through both validators before building the style block; an entry that fails is skipped rather than thrown on, so one bad series color costs that series its variable, not the chart its render. A SAFETY comment states why the boundary must sit in the primitive.
- Focused test `apps/web/tests/chart-css.test.ts` covers the accepted forms and the escape/fetch rejections, following the app's existing pure-helper test pattern.

## Verification

- `./scripts/check.sh` passes (exit 0). One unrelated desktop native test (`output-volume.test.ts`) flaked on a first run and passes in isolation and on rerun.
- Web-only change; no desktop surface touched, so no macOS/notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32540317383/artifacts/9466838429) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32540317383)

- Commit: `96e5d81c35ca0cd743042b34f54b32e67fcdb153`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
