### PR TITLE
chore(admin): drop the cards and rows that cannot inform a decision

### DIFF
--- a/apps/web/api/admin/metrics.ts
+++ b/apps/web/api/admin/metrics.ts
@@ -32,7 +32,6 @@ export default {
         configured(POSTHOG_ENVIRONMENT.PROJECT_ID),
       googleSignIn: configured("GOOGLE_CLIENT_ID") && configured("GOOGLE_CLIENT_SECRET"),
       githubSignIn: configured("GITHUB_CLIENT_ID") && configured("GITHUB_CLIENT_SECRET"),
-      authSecret: configured("BETTER_AUTH_SECRET"),
     });
 
     // The project id names which console to open, never a secret; the key

--- a/apps/web/server/admin/admin-metrics.ts
+++ b/apps/web/server/admin/admin-metrics.ts
@@ -14,8 +14,8 @@ import {
 /**
  * What the admin dashboard reads about the service, and only what the service's
  * own tables can answer. Every number here is an aggregate of rows Luke already
- * stores for its own operation — signups, active sessions, hosted-tier usage —
- * read by a maintainer on their own service. It is not the desktop observing
+ * stores for its own operation — signups and hosted-tier usage — read by a
+ * maintainer on their own service. It is not the desktop observing
  * sessions and it widens no analytics event: the product-event allowlist and
  * `PRIVACY.md` govern what leaves a user's machine, where this reads counts
  * that already landed.
@@ -193,7 +193,6 @@ export const ADMIN_INTEGRATION = {
   HOSTED_TIER: { key: "hosted-tier", label: "Hosted voice & attention (OpenAI)" },
   GOOGLE_SIGN_IN: { key: "google-sign-in", label: "Google sign-in" },
   GITHUB_SIGN_IN: { key: "github-sign-in", label: "GitHub sign-in" },
-  AUTH_SECRET: { key: "auth-secret", label: "Auth session secret" },
 } as const;
 
 /** Whether each integration's configuration is present — never its value. */
@@ -203,7 +202,6 @@ export interface AdminIntegrationPresence {
   hostedTier: boolean;
   googleSignIn: boolean;
   githubSignIn: boolean;
-  authSecret: boolean;
 }
 
 /** The integration health list, in the fixed order the dashboard draws it. */
@@ -214,7 +212,6 @@ export function adminIntegrations(present: AdminIntegrationPresence): AdminInteg
     { ...ADMIN_INTEGRATION.ANALYTICS_ERASURE, configured: present.analyticsErasure },
     { ...ADMIN_INTEGRATION.GOOGLE_SIGN_IN, configured: present.googleSignIn },
     { ...ADMIN_INTEGRATION.GITHUB_SIGN_IN, configured: present.githubSignIn },
-    { ...ADMIN_INTEGRATION.AUTH_SECRET, configured: present.authSecret },
   ];
 }
 
@@ -226,8 +223,6 @@ export interface AdminMetrics {
     /** Accounts created inside the window, the same rows the signup series draws. */
     newInWindow: number;
     signupTrend: AdminTrend;
-    activeSessions: number;
-    activeSessionUsers: number;
     signInMethods: AdminSignInMethods;
     dailySignups: AdminDailySignups[];
   };
@@ -275,8 +270,6 @@ export interface AdminMetrics {
 export interface AdminMetricsSource {
   users: {
     total: number;
-    activeSessions: number;
-    activeSessionUsers: number;
     signInMethods: AdminSignInMethods;
     signupsByDay: ReadonlyMap<string, number>;
   };
@@ -428,8 +421,6 @@ export function buildAdminMetrics(
         trendKeys.map((day) => source.users.signupsByDay.get(day) ?? 0),
         ADMIN_TREND_DAYS,
       ),
-      activeSessions: source.users.activeSessions,
-      activeSessionUsers: source.users.activeSessionUsers,
       signInMethods: source.users.signInMethods,
       dailySignups,
     },

--- a/apps/web/server/admin/admin-queries.ts
+++ b/apps/web/server/admin/admin-queries.ts
@@ -71,46 +71,32 @@ async function probeDatabase(
 
 async function readUserMetrics(
   database: Database,
-  now: number,
   fetchStart: Date,
   scope: AdminMetricsScope,
 ): Promise<AdminMetricsSource["users"]> {
   const dayExpression = sql<string>`to_char(${user.createdAt} at time zone 'UTC', 'YYYY-MM-DD')`;
-  const [[totalRow], [activeSessionRow], [activeSessionUsersRow], providerRows, signupRows] =
-    await Promise.all([
-      database.select({ value: count() }).from(user).where(scopeCondition(scope)),
-      database
-        .select({ value: count() })
-        .from(session)
-        .innerJoin(user, eq(session.userId, user.id))
-        .where(and(gt(session.expiresAt, new Date(now)), scopeCondition(scope))),
-      database
-        .select({ value: sql<number>`count(distinct ${session.userId})` })
-        .from(session)
-        .innerJoin(user, eq(session.userId, user.id))
-        .where(and(gt(session.expiresAt, new Date(now)), scopeCondition(scope))),
-      // Distinct pairs rather than a count of linked rows: the chart states
-      // accounts per method, and an account can hold several rows of one
-      // provider. The per-method counting itself lives in the fold below.
-      database
-        .selectDistinct({ userId: account.userId, providerId: account.providerId })
-        .from(account)
-        .innerJoin(user, eq(account.userId, user.id))
-        .where(scopeCondition(scope)),
-      database
-        .select({ day: dayExpression, value: count() })
-        .from(user)
-        .where(and(gte(user.createdAt, fetchStart), scopeCondition(scope)))
-        .groupBy(dayExpression),
-    ]);
+  const [[totalRow], providerRows, signupRows] = await Promise.all([
+    database.select({ value: count() }).from(user).where(scopeCondition(scope)),
+    // Distinct pairs rather than a count of linked rows: the chart states
+    // accounts per method, and an account can hold several rows of one
+    // provider. The per-method counting itself lives in the fold below.
+    database
+      .selectDistinct({ userId: account.userId, providerId: account.providerId })
+      .from(account)
+      .innerJoin(user, eq(account.userId, user.id))
+      .where(scopeCondition(scope)),
+    database
+      .select({ day: dayExpression, value: count() })
+      .from(user)
+      .where(and(gte(user.createdAt, fetchStart), scopeCondition(scope)))
+      .groupBy(dayExpression),
+  ]);
 
   const signupsByDay = new Map<string, number>();
   for (const row of signupRows) signupsByDay.set(row.day, toNumber(row.value));
 
   return {
     total: toNumber(totalRow?.value),
-    activeSessions: toNumber(activeSessionRow?.value),
-    activeSessionUsers: toNumber(activeSessionUsersRow?.value),
     signInMethods: countSignInMethods(providerRows),
     signupsByDay,
   };
@@ -312,8 +298,6 @@ function emptySource(
   return {
     users: {
       total: 0,
-      activeSessions: 0,
-      activeSessionUsers: 0,
       signInMethods: { google: 0, github: 0, other: 0 },
       signupsByDay: new Map(),
     },
@@ -355,7 +339,7 @@ export async function readAdminMetricsSource(
   const fetchStart = new Date(`${fetchStartDay}T00:00:00.000Z`);
 
   const [users, usage, retention, reliability] = await Promise.all([
-    readUserMetrics(database, input.now, fetchStart, input.scope),
+    readUserMetrics(database, fetchStart, input.scope),
     readUsageMetrics(database, todayKey, windowStartDay, fetchStartDay, input.scope),
     readRetentionMetrics(database, input.now, input.scope),
     readReliabilityMetrics(database, todayKey, windowStartDay, input.scope),

--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -1213,7 +1213,7 @@ function Dashboard({
         aria-busy={refreshing}
       >
         <SectionHeading>User activity</SectionHeading>
-        <div className="grid grid-cols-2 gap-3 min-[720px]:grid-cols-4">
+        <div className="grid gap-3 min-[720px]:grid-cols-3">
           <StatCard label="Total accounts" value={formatNumber(metrics.users.total)} />
           {/* The hint already carries the window total, so the run this count
               is read against rides the title attribute instead. */}
@@ -1222,11 +1222,6 @@ function Dashboard({
             value={formatNumber(metrics.users.signupTrend.recent)}
             hint={`${formatNumber(metrics.users.newInWindow)} in ${metrics.windowDays} days`}
             title={`against ${formatNumber(metrics.users.signupTrend.prior)} in the ${metrics.users.signupTrend.days} days before`}
-          />
-          <StatCard
-            label="Active sessions"
-            value={formatNumber(metrics.users.activeSessions)}
-            hint={`${formatNumber(metrics.users.activeSessionUsers)} distinct accounts`}
           />
           <StatCard
             label="Active today"
@@ -1249,16 +1244,14 @@ function Dashboard({
         <SectionHeading>Signup retention · weekly cohorts</SectionHeading>
         <RetentionGrid retention={metrics.retention} />
         <p className="mt-3 text-sm text-muted-foreground">
-          Each row is the accounts created in one UTC week, named by its Monday; each cell is the
-          share of them that spent hosted voice or attention during the week that many weeks after
-          signup, so Wk 0 is activation in the signup week itself. A week the calendar has not
-          reached draws nothing, and dashed cells cover the week still in progress — those shares
-          can only rise. Purely local use of the desktop app writes no row here, so a cohort that
-          never touched the hosted tier reads the same as one that left.
+          Each cell is the share of one UTC week's signups that spent hosted voice or attention that
+          many weeks after signup — Wk 0 is activation in the signup week itself, and dashed cells
+          are still accruing. Purely local use of the desktop app writes no row here, so a cohort
+          that never touched the hosted tier reads the same as one that left.
         </p>
 
         <SectionHeading>Feature usage · hosted tier</SectionHeading>
-        <div className="grid grid-cols-2 gap-3 min-[720px]:grid-cols-4">
+        <div className="grid grid-cols-2 gap-3">
           <StatCard
             label="Voice · today"
             value={formatNumber(metrics.featureUsage.voiceCallsToday)}
@@ -1268,16 +1261,6 @@ function Dashboard({
             label="Attention · today"
             value={formatNumber(metrics.featureUsage.attentionReviewsToday)}
             hint={`${formatNumber(metrics.featureUsage.attentionReviewsWindow)} in ${metrics.windowDays} days`}
-          />
-          <StatCard
-            label="Voice ceiling"
-            value={formatNumber(metrics.reliability.voiceDailyLimit)}
-            hint="calls per account per day"
-          />
-          <StatCard
-            label="Attention ceiling"
-            value={formatNumber(metrics.reliability.attentionDailyLimit)}
-            hint="reviews per account per day"
           />
         </div>
         <div className="mt-3">
@@ -1316,10 +1299,13 @@ function Dashboard({
           />
         </div>
         <p className="mt-3 text-sm text-muted-foreground">
-          A hosted request that reaches a daily ceiling is refused with{" "}
-          <code className="font-mono text-xs">quota-exhausted</code>; the count above is the closest
-          rejection signal the service's own tables hold. Per-request error rates and client-side
-          failures are recorded as product-analytics events, which live with{" "}
+          A hosted request that reaches a daily ceiling —{" "}
+          {formatNumber(metrics.reliability.voiceDailyLimit)} voice calls or{" "}
+          {formatNumber(metrics.reliability.attentionDailyLimit)} attention reviews per account per
+          day — is refused with <code className="font-mono text-xs">quota-exhausted</code>; the
+          count above is the closest rejection signal the service's own tables hold. Per-request
+          error rates and client-side failures are recorded as product-analytics events, which live
+          with{" "}
           {metrics.reliability.analyticsConsoleUrl ? (
             <a
               href={metrics.reliability.analyticsConsoleUrl}

--- a/apps/web/tests/admin-metrics.test.ts
+++ b/apps/web/tests/admin-metrics.test.ts
@@ -38,8 +38,6 @@ function source(overrides: Partial<AdminMetricsSource> = {}): AdminMetricsSource
   return {
     users: {
       total: 0,
-      activeSessions: 0,
-      activeSessionUsers: 0,
       signInMethods: { google: 0, github: 0, other: 0 },
       signupsByDay: new Map(),
     },
@@ -437,14 +435,13 @@ test("integration health reads presence, in a fixed order, never a value", () =>
     analyticsErasure: false,
     googleSignIn: true,
     githubSignIn: true,
-    authSecret: true,
   });
   assert.equal(rows[0]?.key, ADMIN_INTEGRATION.HOSTED_TIER.key);
   assert.equal(rows[0]?.configured, true);
   assert.equal(rows[1]?.key, ADMIN_INTEGRATION.ANALYTICS_RECORDING.key);
   assert.equal(rows[1]?.configured, false);
-  assert.equal(rows.length, 6);
-  assert.equal(rows.filter((row) => row.configured).length, 4);
+  assert.equal(rows.length, 5);
+  assert.equal(rows.filter((row) => row.configured).length, 3);
   for (const row of rows) {
     assert.ok(row.label.length > 0);
     assert.ok(row.key.length > 0);


### PR DESCRIPTION
## What

Four removals, each of something that could not inform a decision:

- **"Voice ceiling" and "Attention ceiling" stat cards** (Feature usage · hosted tier): both rendered compile-time constants from the hosted quota that never move, so the cards could never show change. The two numbers now live in the Reliability caption, where ceilings are the subject — "a daily ceiling — N voice calls or M attention reviews per account per day". The `voiceDailyLimit`/`attentionDailyLimit` response fields stay.
- **"Active sessions" stat card** (User activity): it counted Better Auth session rows, not people, and the dashboard's usage signals (Active today, Active days, retention) answer the real question. Removed end to end: the card, the `activeSessions`/`activeSessionUsers` queries, the response fields, and their test assertions.
- **"Auth session secret" row** (System health → Integrations): an admin can only be reading the page if auth already works, so the row could never usefully report absence. Removed the row, its entry in the integrations construction, the env-presence read, and its test coverage. Every other integration row stays.
- **Retention grid caption trimmed by roughly a third**: it keeps what a cell means (share of the cohort active N weeks after signup, Wk 0 = activation) and the local-desktop-use-writes-no-row constraint, and compresses the restatements of what the grid already draws into one short clause ("dashed cells are still accruing").

## How

- `apps/web/src/AdminDashboard.tsx`: dropped the three cards, folded the ceilings into the Reliability caption, trimmed the retention caption, and fixed the stat grids — two cards in Feature usage (`grid-cols-2`, matching Reliability), three in User activity (`min-[720px]:grid-cols-3`).
- `apps/web/server/admin/admin-metrics.ts`: removed `activeSessions`/`activeSessionUsers` from `AdminMetrics` and `AdminMetricsSource`, and `AUTH_SECRET` from the integration set and presence shape.
- `apps/web/server/admin/admin-queries.ts`: removed the two session-count queries (and the now-unused `now` parameter of `readUserMetrics`) and the empty-source fields.
- `apps/web/api/admin/metrics.ts`: removed the `BETTER_AUTH_SECRET` presence read.
- `apps/web/tests/admin-metrics.test.ts`: pruned the shaping fixture and updated the integrations assertions to the five remaining rows.

## Verification

`./scripts/check.sh` passes: repository and design contract checks, lint, typecheck, all test suites (24 suites, 0 failures), and the workspace build, run again after rebasing onto current main. Web-only change; no desktop surface touched, so no macOS/notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32540816523/artifacts/9466992122) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32540816523)

- Commit: `34589d8d50c10f070c6165b58016a1bfc153e1ce`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
