### PR TITLE
style(admin): lift card surfaces above the page ground

### DIFF
--- a/apps/web/src/components/ui/chart.tsx
+++ b/apps/web/src/components/ui/chart.tsx
@@ -186,9 +186,12 @@ function ChartTooltipContent({
   const nestLabel = payload.length === 1 && indicator !== "dot";
 
   return (
+    // The tooltip floats above a chart that sits on a card, and the dark
+    // theme's card is lighter than its page, so the stock `bg-background`
+    // here would draw the one floating surface *below* the ground it covers.
     <div
       className={cn(
-        "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
+        "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-card px-2.5 py-1.5 text-xs shadow-xl",
         className,
       )}
     >

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -138,7 +138,7 @@
    element: they are the browser moments of the desktop sign-in, and the flow
    ends on the loopback's dark card, so the theme holds from the first card to
    the last instead of flashing light in the middle. The values are the
-   loopback page's own (`apps/desktop/src/account-loopback-page.ts`), restated
+   loopback page's own (`packages/oauth/src/loopback-page.ts`), restated
    only for the tokens those two pages actually read — everything else stays
    the light page's, unread here and drift waiting to happen if copied. */
 .dark {
@@ -146,7 +146,15 @@
 
   --background: #08090b;
   --foreground: rgba(255, 255, 255, 0.92);
-  --card: #000;
+
+  /* The one value that deliberately leaves the loopback's own (#000 there):
+     the admin dashboard is a full page of card surfaces, and pure black on
+     this ground separated them by the 8%-white border alone, so an empty
+     region and a card read the same until the hairline resolved. A step
+     above the page (1.06:1) lets the grid read as raised surfaces before
+     borders do; the loopback keeps black because its single card is carried
+     by its own shadow. */
+  --card: #101114;
   --muted: rgba(255, 255, 255, 0.05);
   --muted-foreground: rgba(255, 255, 255, 0.56);
   --border: rgba(255, 255, 255, 0.08);
@@ -160,11 +168,11 @@
 
   /* The admin dashboard's chart series, declared here because that page is
      the one chart surface and it opts into this theme. The accent cyan and
-     the state green themselves sit too light for a mark on the black card —
+     the state green themselves sit too light for a mark on the dark card —
      side by side they blur (ΔE 13.6) — so each slot is a darker step of the
-     same hue family, validated as a categorical pair against the card
-     (worst CVD ΔE 15.4, both ≥ 3:1): voice keeps the working cyan's family,
-     attention reviews keep complete's. */
+     same hue family, validated as a categorical pair against the card at
+     #101114 (worst CVD ΔE 15.4; 6.1:1 and 6.3:1, both ≥ 3:1): voice keeps
+     the working cyan's family, attention reviews keep complete's. */
   --chart-1: #2f9bd8;
   --chart-2: #35a877;
 }


### PR DESCRIPTION
## What

The admin page's dark theme drew pure-black cards (`--card: #000`) on a near-black page (`--background: #08090b`), so every card separated from the ground only by the 8%-white border: an empty region and a card read the same until the hairline resolved. The card surface now sits a step above the page (`--card: #101114`), so the grid reads as raised surfaces before borders do. The sidebar shares the lift deliberately — it is the same surface token, and the raised rail frames the page.

## How

- `--card: #101114` in the `.dark` block of `apps/web/src/styles.css`, with the rationale beside it: this is the one token that deliberately leaves the loopback page's own values (the loopback keeps `#000`, carried by its single card's shadow), and the block comment's stale path to the loopback page (`packages/oauth/src/loopback-page.ts`, which moved out of `apps/desktop/`) is corrected while stating that divergence.
- The chart tooltip was the page's one floating surface on `bg-background`, which the lift would have drawn *darker* than the card it covers — an inverted elevation. The vendored `ChartTooltipContent` now uses `bg-card`, one change that holds for every chart, so floating surfaces sit above their ground.
- The `--chart-1`/`--chart-2` comment documented CVD and contrast figures validated against the black card; the figures are recomputed against `#101114` and the comment now states what is true of the new ground.
- Hover and active states need no adjustment: `--muted` is `rgba(255, 255, 255, 0.05)`, a translucent overlay that composites on any surface, so `hover:bg-muted`, the sidebar's active item, and the window switcher's active segment all remain visible on the lifted card.

## Verification

- `./scripts/check.sh` passes (exit 0).
- Palette revalidation against the new card surface: the `#2f9bd8`/`#35a877` pair keeps worst-case CVD ΔE 15.4 (deutan; pairwise separation is surface-independent), and contrast against `#101114` is 6.1:1 and 6.3:1 respectively — both well above the 3:1 floor (they were 6.8:1 and 7.0:1 on `#000`). Card against page is a 1.06:1 surface step.
- Headless-Chrome inspection of the admin page against a stubbed metrics response, full-page at 1440px: cards, tables, the retention grid, and the sidebar all read as raised surfaces before borders; the usage chart's tooltip, held open over a bar, draws on the card surface visibly above the chart card; the sidebar's active pill and the window switcher's active segment (the same `bg-muted` token hover uses) are clearly visible on the lifted surface; the sign-in gate card reads as a raised surface rather than a hole in the page, its auth buttons keeping their border separation. Hover itself could not be exercised in the capture run because headless Chrome reports `(hover: hover)` false, which makes Tailwind's `hover:` variants inert there; the token arithmetic above is what guarantees it.
- Web-only change; no desktop surface touched, so no macOS/notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32540927952/artifacts/9467014247) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32540927952)

- Commit: `dc53732472c8dc108a1a661b03f922731a0008a6`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
