### PR TITLE
chore: adopt pnpm 10 and let packageManager name the version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-        with:
-          version: 9.15.0
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
@@ -39,8 +37,6 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-        with:
-          version: 9.15.0
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,6 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-        with:
-          version: 9.15.0
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ until you connect them in Luke's Settings.
 ## Build from source
 
 Requires an Apple Silicon Mac on macOS 14 or newer, Node.js 24 or newer,
-pnpm 9.15.0, and the Xcode Command Line Tools.
+pnpm 10.34.5, and the Xcode Command Line Tools.
 
 ```sh
 ./scripts/bootstrap.sh   # install pinned workspace dependencies

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.8",
   "private": true,
   "description": "A notch-attached desktop sidecar for coding-agent sessions",
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@10.34.5",
   "engines": {
     "node": ">=24.0.0"
   },


### PR DESCRIPTION
## The drift

The lockfile has been generated by pnpm 10 for some time while `packageManager` still pinned `9.15.0`. Vercel reported it on every build:

```
Detected `pnpm-lock.yaml` version 9 generated by pnpm@10.x
  with package.json#packageManager pnpm@9.15.0
```

Same class as the Node majors: several places naming a version, one of them stale, nothing failing.

## What changed

- `packageManager` → `pnpm@10.34.5`.
- The three workflow steps stop pinning `version: 9.15.0`. `pnpm/action-setup` reads `packageManager` when given no `version`, so the field becomes the single source the way `.nvmrc` already is for Node. Three copies of a version string were three more places for this exact drift to start.
- README updated.

**No lockfile migration was needed.** `lockfileVersion: '9.0'` is what both majors write, so `pnpm-lock.yaml` is byte-identical after a full pnpm 10 install — which is also the evidence the lockfile really was already pnpm-10-generated.

## pnpm 10's breaking change, and why nothing needed allowlisting

pnpm 10 runs no dependency's build script unless named in `onlyBuiltDependencies`. It reports six ignored here, and each was checked rather than assumed:

| Ignored script | Why it can stay ignored |
|---|---|
| `esbuild` ×4 | Ships a binary per platform as an optional dep; the script isn't a download step. `esbuild --version` → `0.28.2`, and the desktop build runs. |
| `core-js` | Prints a funding notice. |
| `electron-winstaller` | Builds the Windows installer this project never makes. |

So `pnpm-workspace.yaml` is untouched and every dependency script stays blocked, which is the point of pnpm's policy.

I did first add a `macos-alias` entry, for the native addon `ds-store` reached in the legacy packager DMG path — then dropped it: that path (`apps/desktop/scripts/release.mjs`) has since been removed in favour of electron-builder, and `ds-store`/`macos-alias` are no longer in the lockfile at all. Allowlisting a package that isn't in the tree would have been dead config.

## Verification

- Clean install with pnpm 10.34.5 from an empty `node_modules`, then `./scripts/check.sh` → **exit 0**, 24 suites clean.
- `pnpm --filter @luke/desktop run build` succeeds — the esbuild-driven path, which is what the unapproved esbuild scripts would have broken.
- Corepack resolves `pnpm` to 10.34.5 from the field, so a contributor with an older pnpm on `PATH` is switched automatically rather than left on 9.

Portable-only change; no macOS or UI surface touched, so no visual evidence applies. CI's macOS job exercises `verify.sh` against the pnpm 10 install.

### Pre-existing flakiness, unrelated to this change

`apps/desktop`'s native/Electron-adjacent tests (`talk-key`, `output-volume`, `apple-calendar`, `settings-handler`, `dock-presence`, `microphone-route`, `hotkey-registrar`) intermittently fail under `check.sh`'s parallel load with a bare `'test failed'` and uniform sub-second durations — the signature of a helper timeout. They pass 734/734 run alone and 34/34 in isolation, and this reproduced on pnpm 9 before any change in this branch. Flagging it as worth a look on its own; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32541707287/artifacts/9467265622) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32541707287)

- Commit: `4da7647c64b1ac3236c97f9c66e5aebbd6acf719`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
