### PR TITLE
fix(superset): open and message a chat's live terminal, not the binding its restart ended

### DIFF
--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -71,6 +72,7 @@ import {
   SupersetWorkspaceAdapter,
   SupersetWorkspaceReader,
   SupersetWorkspaceSnapshot,
+  supersetPressedLink,
 } from "@sidecar/superset";
 import { DEFAULT_PANEL_FORM_FACTOR } from "@sidecar/surface";
 import { LinearCredentials, LinearIssueTracker, LinearSignIn } from "@sidecar/trackers";
@@ -1489,13 +1491,16 @@ function countSpokenAnnouncements(notices: readonly SessionNotice[]): void {
  * registry holds for that session, read the way a row press reads it: an
  * address in a scheme outside `SESSION_LINK_SCHEME` never reached the
  * registry at all. A created session that never reports an address inside
- * its window is left unopened, like any other row without one.
+ * its window is left unopened, like any other row without one. The one thing
+ * added to the address is the same per-press focus nonce a row press adds,
+ * because Superset's own `workspaces open` follow-through usually has the
+ * workspace on screen already before this open fires.
  */
 function openCreatedWorkspaces(sessions: readonly NormalizedSession[]): void {
   for (const created of createdWorkspaceOpens.claim(sessions, Date.now())) {
     const link = created.detail.link;
     if (!link) continue;
-    shell.openExternal(link).catch((error: Error) => {
+    shell.openExternal(supersetPressedLink(link, randomUUID())).catch((error: Error) => {
       const message = error instanceof Error ? error.message : String(error);
       process.stderr.write(`Created workspace could not be opened: ${message}\n`);
     });

--- a/apps/desktop/src/main/ipc/session-acts.ts
+++ b/apps/desktop/src/main/ipc/session-acts.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import {
   PRODUCT_EVENT,
   PRODUCT_ISSUE_ACT,
@@ -42,7 +43,7 @@ import {
 } from "@sidecar/session";
 import { APP_SETTING_SCHEMA } from "@sidecar/settings";
 import type { SupersetSessionContext } from "@sidecar/superset";
-import { isSupersetControlId, type SupersetCli } from "@sidecar/superset";
+import { isSupersetControlId, type SupersetCli, supersetPressedLink } from "@sidecar/superset";
 import type { LinearIssueTracker } from "@sidecar/trackers";
 import {
   isRecord,
@@ -189,9 +190,15 @@ export function registerSessionActsIpc(dependencies: SessionActsIpcDependencies)
       },
       failure: () => ({ status: SESSION_OPEN_RESULT_STATUS.REJECTED, reason: failureReason }),
     });
+  // What a press fires is the address the roster reported, plus the one
+  // nonce Superset's own rows mint per press: the app consumes a terminal
+  // focus once per request id, so a nonce composed at observation time would
+  // be spent by the first press and dead for every later one.
+  const pressedLink = (link: string | undefined): string | undefined =>
+    link === undefined ? undefined : supersetPressedLink(link, randomUUID());
   registerOpenAction(
     channels.openSession,
-    (identity) => sessionRegistry.get(identity)?.detail.link,
+    (identity) => pressedLink(sessionRegistry.get(identity)?.detail.link),
     "The system could not open that session.",
   );
   registerAction<[SessionIdentity, string], SessionOpenResult>(channels.openSessionApplication, {
@@ -210,9 +217,11 @@ export function registerSessionActsIpc(dependencies: SessionActsIpcDependencies)
       return [identity, applicationId];
     },
     async act(identity, applicationId) {
-      const url = sessionRegistry
-        .get(identity)
-        ?.applications.find((application) => application.id === applicationId)?.link;
+      const url = pressedLink(
+        sessionRegistry
+          .get(identity)
+          ?.applications.find((application) => application.id === applicationId)?.link,
+      );
       if (!url) return { status: SESSION_OPEN_RESULT_STATUS.UNSUPPORTED };
       await openExternal(url);
       if (isProviderId(identity.providerId)) {

--- a/packages/superset/src/index.ts
+++ b/packages/superset/src/index.ts
@@ -28,4 +28,5 @@ export {
   SupersetWorkspaceReader,
   type SupersetWorkspaceReaderOptions,
   SupersetWorkspaceSnapshot,
+  supersetPressedLink,
 } from "./workspaces.js";

--- a/packages/superset/src/workspaces.test.ts
+++ b/packages/superset/src/workspaces.test.ts
@@ -13,7 +13,7 @@ import {
 } from "@sidecar/session";
 import { SUPERSET_WORKSPACE_PROVIDER_ID } from "../../../apps/desktop/src/shared/contracts.js";
 import { SUPERSET_CONTROL_ID } from "./cli.js";
-import { SupersetWorkspaceReader } from "./workspaces.js";
+import { SupersetWorkspaceReader, supersetPressedLink } from "./workspaces.js";
 
 async function temporarySupersetHome(t: TestContext): Promise<string> {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-superset-"));
@@ -53,6 +53,17 @@ function createSchema(database: DatabaseSync): void {
       preset_id TEXT,
       display_order INTEGER NOT NULL
     );
+  `);
+}
+
+/**
+ * The columns Superset's own binding lifecycle writes; `createSchema` stays
+ * without them so the tests above it keep exercising the legacy fallback.
+ */
+function addBindingLifecycleColumns(database: DatabaseSync): void {
+  database.exec(`
+    ALTER TABLE terminal_agent_bindings ADD COLUMN last_event_at INTEGER NOT NULL DEFAULT 0;
+    ALTER TABLE terminal_agent_bindings ADD COLUMN ended_at INTEGER;
   `);
 }
 
@@ -637,4 +648,116 @@ test("attaches Superset's Gemini terminals to Gemini CLI rows", async (t) => {
 
   const snapshot = await new SupersetWorkspaceReader({ homeDirectory: home }).read();
   assert.equal(snapshot.context(PROVIDER_ID.GEMINI_CLI, "session-1")?.workspaceId, "workspace-1");
+});
+
+test("prefers the live binding a resumed chat's terminal moved to", async (t) => {
+  const home = await temporarySupersetHome(t);
+  const database = await writeHostDatabase(home, "host-local");
+  createSchema(database);
+  addBindingLifecycleColumns(database);
+  // Restarting Superset resumes the chat's terminal under a fresh id: the
+  // ended binding stays beside the live row, first in read order and with
+  // the richer event history, and must still lose to the live terminal.
+  database.exec(`
+    INSERT INTO workspaces (id, project_id, pull_request_id, name, branch, updated_at)
+      VALUES ('workspace-1', NULL, NULL, 'power-vacation', 'main', 200);
+    INSERT INTO terminal_agent_bindings
+      (terminal_id, workspace_id, agent_id, agent_session_id, last_event_type, last_event_at, ended_at)
+      VALUES
+      ('terminal-old', 'workspace-1', 'claude', 'session-1', 'Stop', 900, 950),
+      ('terminal-live', 'workspace-1', 'claude', 'session-1', 'Attached', 400, NULL);
+  `);
+  database.close();
+
+  const snapshot = await new SupersetWorkspaceReader({ homeDirectory: home }).read();
+  assert.equal(snapshot.context(PROVIDER_ID.CLAUDE_CODE, "session-1")?.terminalId, "terminal-live");
+  assert.equal(
+    snapshot.enrich(PROVIDER_ID.CLAUDE_CODE, [
+      {
+        providerSessionId: "session-1",
+        title: "Debug sign-in",
+        status: SESSION_STATUS.WAITING,
+        observedAt: 100,
+      },
+    ])[0]?.detail?.link,
+    "superset://v2-workspace/workspace-1?terminalId=terminal-live",
+  );
+});
+
+test("two live bindings for one chat resolve to the freshest event", async (t) => {
+  const home = await temporarySupersetHome(t);
+  const database = await writeHostDatabase(home, "host-local");
+  createSchema(database);
+  addBindingLifecycleColumns(database);
+  database.exec(`
+    INSERT INTO workspaces (id, project_id, pull_request_id, name, branch, updated_at)
+      VALUES ('workspace-1', NULL, NULL, 'power-vacation', 'main', 200);
+    INSERT INTO terminal_agent_bindings
+      (terminal_id, workspace_id, agent_id, agent_session_id, last_event_type, last_event_at, ended_at)
+      VALUES
+      ('terminal-a', 'workspace-1', 'claude', 'session-1', 'Stop', 100, NULL),
+      ('terminal-b', 'workspace-1', 'claude', 'session-1', 'Stop', 300, NULL);
+  `);
+  database.close();
+
+  const snapshot = await new SupersetWorkspaceReader({ homeDirectory: home }).read();
+  assert.equal(snapshot.context(PROVIDER_ID.CLAUDE_CODE, "session-1")?.terminalId, "terminal-b");
+});
+
+test("a chat whose every binding ended keeps its workspace and loses the terminal", async (t) => {
+  const home = await temporarySupersetHome(t);
+  const database = await writeHostDatabase(home, "host-local");
+  createSchema(database);
+  addBindingLifecycleColumns(database);
+  database.exec(`
+    INSERT INTO workspaces (id, project_id, pull_request_id, name, branch, updated_at)
+      VALUES ('workspace-1', NULL, NULL, 'power-vacation', 'main', 200);
+    INSERT INTO terminal_agent_bindings
+      (terminal_id, workspace_id, agent_id, agent_session_id, last_event_type, last_event_at, ended_at)
+      VALUES ('terminal-old', 'workspace-1', 'claude', 'session-1', 'Stop', 900, 950);
+  `);
+  database.close();
+
+  const snapshot = await new SupersetWorkspaceReader({ homeDirectory: home }).read();
+  assert.equal(snapshot.context(PROVIDER_ID.CLAUDE_CODE, "session-1")?.terminalId, undefined);
+  const [enriched] = snapshot.enrich(
+    PROVIDER_ID.CLAUDE_CODE,
+    [
+      {
+        providerSessionId: "session-1",
+        title: "Review AGENTS.md",
+        status: SESSION_STATUS.COMPLETE,
+        observedAt: 100,
+      },
+    ],
+    "host-local",
+  );
+  // The workspace identity and its acts stand; only the terminal is gone, so
+  // nothing offers to land a message or a focus in a terminal Superset ended.
+  assert.equal(enriched?.workspace?.providerWorkspaceId, "workspace-1");
+  assert.equal(enriched?.canReceiveMessage, undefined);
+  assert.equal(enriched?.detail?.link, "superset://v2-workspace/workspace-1");
+});
+
+test("a press mints a focus request only onto a bound terminal address", () => {
+  assert.equal(
+    supersetPressedLink("superset://v2-workspace/workspace-1?terminalId=terminal-1", "focus-1"),
+    "superset://v2-workspace/workspace-1?terminalId=terminal-1&focusRequestId=focus-1",
+  );
+  // A repeated press replaces the nonce rather than stacking a second one.
+  assert.equal(
+    supersetPressedLink(
+      "superset://v2-workspace/workspace-1?terminalId=terminal-1&focusRequestId=focus-1",
+      "focus-2",
+    ),
+    "superset://v2-workspace/workspace-1?terminalId=terminal-1&focusRequestId=focus-2",
+  );
+  assert.equal(
+    supersetPressedLink("superset://v2-workspace/workspace-1", "focus-1"),
+    "superset://v2-workspace/workspace-1",
+  );
+  assert.equal(
+    supersetPressedLink("https://github.com/example/luke/pull/42", "focus-1"),
+    "https://github.com/example/luke/pull/42",
+  );
 });

--- a/packages/superset/src/workspaces.ts
+++ b/packages/superset/src/workspaces.ts
@@ -41,6 +41,8 @@ function supersetProviderId(agentId: string): string | undefined {
   return undefined;
 }
 
+const SUPERSET_WORKSPACE_LINK_PREFIX = "superset://v2-workspace/";
+
 /**
  * The address of one workspace in Superset's own app — the same deep link
  * Superset's CLI fires for `workspaces open`, composed here from the observed
@@ -49,7 +51,7 @@ function supersetProviderId(agentId: string): string | undefined {
  * provider and needing no login.
  */
 export function supersetWorkspaceLink(workspaceId: string): string {
-  return `superset://v2-workspace/${workspaceId}`;
+  return `${SUPERSET_WORKSPACE_LINK_PREFIX}${workspaceId}`;
 }
 
 /** Superset's documented route to one terminal inside an observed workspace. */
@@ -59,7 +61,58 @@ export function supersetTerminalLink(workspaceId: string, terminalId: string): s
   return link.toString();
 }
 
+/**
+ * The address a press actually fires for a session behind a bound terminal.
+ * Superset consumes a terminal focus once per request id — its own rows mint
+ * a fresh `focusRequestId` for every press — so the roster's static address
+ * focuses the terminal only while the workspace draws fresh, and a press on a
+ * workspace already on screen lands nowhere. The nonce is the caller's,
+ * minted at the moment of the press, and names nothing observed; every other
+ * address, a terminal-less workspace link included, is handed on untouched.
+ */
+export function supersetPressedLink(link: string, focusRequestId: string): string {
+  if (!link.startsWith(SUPERSET_WORKSPACE_LINK_PREFIX)) return link;
+  const url = new URL(link);
+  if (!url.searchParams.get("terminalId")) return link;
+  url.searchParams.set("focusRequestId", focusRequestId);
+  return url.toString();
+}
+
+/**
+ * Superset keeps every binding a chat ever had: restarting the app resumes
+ * each terminal under a fresh id, ending the old binding (`end_reason`
+ * "resumed") beside the live row it records for the new terminal. Both rows
+ * name the same agent session, so each binding's own lifecycle rides along
+ * and the snapshot chooses between them — a link or a message aimed at the
+ * ended terminal would be silently refused by Superset's own liveness check.
+ */
 const SUPERSET_WORKSPACE_QUERY = `
+  SELECT
+    bindings.agent_id,
+    bindings.agent_session_id,
+    bindings.terminal_id,
+    bindings.ended_at AS binding_ended_at,
+    bindings.last_event_at AS binding_last_event_at,
+    workspaces.id AS workspace_id,
+    workspaces.name AS workspace_name,
+    workspaces.branch,
+    workspaces.updated_at,
+    projects.name AS project_name,
+    pull_requests.url AS pull_request_url
+  FROM terminal_agent_bindings AS bindings
+  JOIN workspaces ON workspaces.id = bindings.workspace_id
+  LEFT JOIN projects ON projects.id = workspaces.project_id
+  LEFT JOIN pull_requests ON pull_requests.id = workspaces.pull_request_id
+  WHERE bindings.agent_session_id IS NOT NULL
+`;
+
+/**
+ * The same read for a host database from before bindings carried their
+ * lifecycle columns. Such a database still holds the chats, it just cannot
+ * say which bindings have ended, so its rows are read as the live ones they
+ * were under that schema.
+ */
+const SUPERSET_LEGACY_WORKSPACE_QUERY = `
   SELECT
     bindings.agent_id,
     bindings.agent_session_id,
@@ -163,10 +216,17 @@ export interface SupersetSessionContext {
   workspaceName: string;
   /**
    * The bound terminal a message lands in. A chatless workspace row has none
-   * — there is nothing there to message — so every act that needs one must
-   * check rather than assume.
+   * — there is nothing there to message — and neither does a chat whose every
+   * binding Superset has ended, so every act that needs one must check rather
+   * than assume.
    */
   terminalId?: string;
+  /**
+   * When Superset last recorded an event on the binding behind this context,
+   * carried so a chat with several bindings resolves to its freshest one.
+   * Absent on chatless rows and on databases from before bindings kept it.
+   */
+  bindingLastEventAt?: number;
   updatedAt: number;
   projectName?: string;
   branch?: string;
@@ -223,14 +283,36 @@ function contextFromRow(
     organizationId,
     workspaceId,
     workspaceName,
-    terminalId,
     updatedAt,
     spawnableAgents,
   };
+  // A binding Superset has ended no longer identifies a live terminal — the
+  // chat resumed into another terminal, or the terminal is gone — so the row
+  // keeps its workspace identity and offers no terminal to act through.
+  if (numberFromRow(row, "binding_ended_at") === undefined) context.terminalId = terminalId;
+  const bindingLastEventAt = numberFromRow(row, "binding_last_event_at");
+  if (bindingLastEventAt !== undefined) context.bindingLastEventAt = bindingLastEventAt;
   if (projectName) context.projectName = projectName;
   if (branch) context.branch = branch;
   if (pullRequestUrl) context.pullRequestUrl = pullRequestUrl;
   return context;
+}
+
+/**
+ * Whether a binding read later should displace the one already held for the
+ * same chat. A live terminal outranks an ended one regardless of the order
+ * the database returned the rows in, the freshest binding event breaks a tie
+ * between two of the same standing, and the workspace's own clock decides
+ * only between rows carrying no binding history — a chatless row, or a
+ * database from before the lifecycle columns.
+ */
+function bindingOutranks(candidate: SupersetSessionContext, held: SupersetSessionContext): boolean {
+  const candidateLive = candidate.terminalId !== undefined;
+  if (candidateLive !== (held.terminalId !== undefined)) return candidateLive;
+  const candidateEvent = candidate.bindingLastEventAt ?? 0;
+  const heldEvent = held.bindingLastEventAt ?? 0;
+  if (candidateEvent !== heldEvent) return candidateEvent > heldEvent;
+  return held.updatedAt < candidate.updatedAt;
 }
 
 /**
@@ -306,7 +388,7 @@ export class SupersetWorkspaceSnapshot {
     for (const context of contexts) {
       const provider = this.#sessions.get(context.providerId) ?? new Map();
       const existing = provider.get(context.providerSessionId);
-      if (!existing || existing.updatedAt < context.updatedAt) {
+      if (!existing || bindingOutranks(context, existing)) {
         provider.set(context.providerSessionId, context);
       }
       this.#sessions.set(context.providerId, provider);
@@ -611,15 +693,7 @@ export class SupersetWorkspaceReader {
           const presetId = textFromRow(row, "preset_id");
           return presetId ? [presetId] : [];
         });
-      const bound = database
-        .prepare(SUPERSET_WORKSPACE_QUERY)
-        .all()
-        .flatMap((value) => {
-          const row = wireRecord(value);
-          if (!row) return [];
-          const context = contextFromRow(organizationId, row, spawnableAgents);
-          return context ? [context] : [];
-        });
+      const bound = this.#boundChats(database, organizationId, spawnableAgents);
       return {
         contexts: [
           ...bound,
@@ -633,6 +707,35 @@ export class SupersetWorkspaceReader {
       throw error;
     } finally {
       database.close();
+    }
+  }
+
+  /**
+   * Read behind a fallback rather than a guard: a host database from a
+   * Superset before bindings carried their lifecycle columns still holds the
+   * chats, so losing the columns falls back to reading every binding as the
+   * live one it was under that schema, never to losing the chats.
+   */
+  #boundChats(
+    database: SqliteDatabase,
+    organizationId: string,
+    spawnableAgents: readonly string[],
+  ): readonly SupersetSessionContext[] {
+    const read = (query: string) =>
+      database
+        .prepare(query)
+        .all()
+        .flatMap((value) => {
+          const row = wireRecord(value);
+          if (!row) return [];
+          const context = contextFromRow(organizationId, row, spawnableAgents);
+          return context ? [context] : [];
+        });
+    try {
+      return read(SUPERSET_WORKSPACE_QUERY);
+    } catch (error) {
+      if (!(error instanceof Error && canIgnoreSqliteError(error))) throw error;
+      return read(SUPERSET_LEGACY_WORKSPACE_QUERY);
     }
   }
 


### PR DESCRIPTION
## What

Pressing a Superset-managed session row could open the workspace without focusing the session's terminal, and the row's message target could go just as stale. Restarting Superset resumes every terminal under a fresh id, ending the old binding (`end_reason` `"resumed"`) beside the live row it records for the new terminal. Luke's bindings read ignored those lifecycle columns and tie-broke duplicate bindings on the workspace's own `updated_at` — identical for both rows — so a chat could resolve to whichever binding SQLite returned first, including the dead terminal. Superset's focus hook validates a deep link's terminal against its live list and silently ignores unknown ones, so the press looked like it did nothing.

Separately, even a link naming the live terminal only focused it while the workspace drew fresh: Superset consumes a terminal focus once per request id, and its own rows mint a fresh `focusRequestId` on every press.

## How

- `SUPERSET_WORKSPACE_QUERY` now reads each binding's `ended_at` and `last_event_at`, with a fallback to the previous query for a host database from before bindings carried lifecycle columns, so older Supersets lose nothing.
- A binding Superset has ended contributes no terminal: the chat keeps its workspace identity, grouping, and workspace-scoped acts, but advertises no message target and links at the workspace — a message into a dead terminal would vanish silently, and the honest absence stands until Superset re-binds the live one.
- Snapshot dedup prefers the live binding over an ended one regardless of read order, then the freshest `last_event_at`, then the old workspace-clock tie-break (which still decides the cross-organization duplicate case).
- New `supersetPressedLink` mints the per-press `focusRequestId` nonce at the open sites — the row press, the application chip, and the created-workspace follow-through — leaving every non-Superset address untouched.

## Verification

- `./scripts/check.sh` passes (exit 0); `packages/superset` 43/43, including three new lifecycle tests and the pressed-link test.
- Validated against a real Superset 1.24.2 host database: the resumed chat resolves to its live terminal, and the lifecycle query's columns exist. The deep-link grammar (`terminalId` + `focusRequestId`) was confirmed against Superset's own bundled route and focus hook, and query-string parsing against the exact TanStack Router version it ships (1.170.16).
- No visual surface changed, so no macOS/notch check applies; `./scripts/verify.sh` not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32541955872/artifacts/9467331070) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32541955872)

- Commit: `5830e28598f7b0853381050b4be477ec033c9c55`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/0cba7b20-0b74-4a74-ac10-d1be377d886e)
