### PR TITLE
fix(realtime): stop Luke narrating tool calls

### DIFF
--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -166,6 +166,9 @@ const REALTIME_INSTRUCTION_HEAD: readonly string[] = [
   "- Refer to sessions as agents and speak about them as if they were humans.",
   "- Be concise. Prefer short answers unless the user asks for more detail.",
   "- Start with the answer; do not repeat the user's request.",
+  "- Call a tool without announcing it; do not restate what the user asked for first.",
+  '- When a tool call succeeds, say "Done." and nothing more unless the user asked a question ' +
+    "the result answers.",
   "- When the user asks about overall progress, summarize across the observed agents.",
   "- When referring to an agent, identify it by the work it is doing.",
   "- Do not mention internal identifiers such as commit hashes or session IDs.",

--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -167,8 +167,9 @@ const REALTIME_INSTRUCTION_HEAD: readonly string[] = [
   "- Be concise. Prefer short answers unless the user asks for more detail.",
   "- Start with the answer; do not repeat the user's request.",
   "- Call a tool without announcing it; do not restate what the user asked for first.",
-  '- When a tool call succeeds, say "Done." and nothing more unless the user asked a question ' +
-    "the result answers.",
+  '- When a tool call succeeds, say "Done." and nothing more — unless the result itself is ' +
+    "what the user asked to hear (a transcript reading, a check's answer, a provider with " +
+    "nowhere to open), which is still spoken in full.",
   "- When the user asks about overall progress, summarize across the observed agents.",
   "- When referring to an agent, identify it by the work it is doing.",
   "- Do not mention internal identifiers such as commit hashes or session IDs.",

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -255,6 +255,7 @@ test("the standing instructions make Luke the coding agents' engineering manager
   assert.match(instructions, /start with the answer; do not repeat the user's request/i);
   assert.match(instructions, /call a tool without announcing it/i);
   assert.match(instructions, /when a tool call succeeds, say "done\."/i);
+  assert.match(instructions, /unless the result itself is what the user asked to hear/i);
   assert.match(instructions, /explicit latest or most-recent ask resolves by the recency labels/i);
   assert.match(instructions, /open_session once for every distinct provider/i);
   assert.match(instructions, /do not filter the panel first/i);

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -253,6 +253,8 @@ test("the standing instructions make Luke the coding agents' engineering manager
 
   assert.match(instructions, /engineering manager for the developer's coding agents/i);
   assert.match(instructions, /start with the answer; do not repeat the user's request/i);
+  assert.match(instructions, /call a tool without announcing it/i);
+  assert.match(instructions, /when a tool call succeeds, say "done\."/i);
   assert.match(instructions, /explicit latest or most-recent ask resolves by the recency labels/i);
   assert.match(instructions, /open_session once for every distinct provider/i);
   assert.match(instructions, /do not filter the panel first/i);


### PR DESCRIPTION
Luke restated the developer's ask before calling a tool and repeated it again once the call succeeded. This adds two lines to the standing spoken instructions: call a tool without announcing it, and answer a successful tool call with "Done." alone unless the user asked a question the result answers. The instruction test asserts both lines.

## Verification

`./scripts/check.sh` passed (lint, typecheck, tests, build). Prompt-text change only; no UI or macOS surface moved, so no visual evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/1422e647-b974-405d-89bf-667eeaa2650c)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32542364707/artifacts/9467448241) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32542364707)

- Commit: `47c9adfca4272ee233517c63eab0682cfc8bb7b9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
