### PR TITLE
fix(admin): give the sidebar hover a pill the fold cannot slice

### DIFF
--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -27,7 +27,9 @@ import { GitHubMark, GoogleMark } from "./account-marks";
 import { settleRead } from "./admin-refresh";
 import {
   SIDEBAR_ICON_SLOT,
+  SIDEBAR_PILL_INSET,
   SIDEBAR_WIDTH,
+  sidebarPillWidth,
   sidebarRailWidth,
   sidebarToggleLabel,
 } from "./admin-sidebar";
@@ -930,9 +932,21 @@ function CollapseIcon({ collapsed }: { collapsed: boolean }): React.JSX.Element 
   );
 }
 
+/**
+ * The pill's fill is scoped here rather than taken from `--muted`: 5% white is
+ * a resting tint for flat surfaces, too faint to read as a state on the
+ * lifted card the rail sits on, and raising the shared token would brighten
+ * every muted surface on the page.
+ */
 const SIDEBAR_ITEM = {
-  ACTIVE: "bg-muted text-foreground",
-  IDLE: "text-muted-foreground hover:bg-muted hover:text-foreground",
+  ACTIVE: {
+    ROW: "text-foreground",
+    PILL: "bg-foreground/10",
+  },
+  IDLE: {
+    ROW: "text-muted-foreground hover:text-foreground focus-visible:text-foreground",
+    PILL: "group-hover:bg-foreground/10 group-focus-visible:bg-foreground/10",
+  },
 } as const;
 
 /**
@@ -951,6 +965,10 @@ const SIDEBAR_ITEM = {
  * padding of their own: any would start the label short of that edge. Collapsed,
  * every item keeps its name on a `title` and the toggle on its `aria-label`;
  * the labels themselves stay in the tree, clipped, so a reader still hears them.
+ * The same clip is why hover and the active state are drawn by a pill layer
+ * sized against the rail (`sidebarPillWidth`) instead of the row's background:
+ * the fixed-width row runs under the clip edge, so its background would be
+ * sliced there, expanded flush against the borders and collapsed cut mid-pill.
  */
 function AdminSidebar({
   active,
@@ -965,7 +983,7 @@ function AdminSidebar({
 }): React.JSX.Element {
   const iconSlot = (icon: React.ReactNode) => (
     <span
-      className="flex shrink-0 items-center justify-center"
+      className="relative flex shrink-0 items-center justify-center"
       style={{ width: SIDEBAR_ICON_SLOT }}
       aria-hidden="true"
     >
@@ -973,24 +991,34 @@ function AdminSidebar({
     </span>
   );
 
-  const item = (tab: AdminTab, label: string, icon: React.ReactNode) => (
-    <a
-      href={tabHref(tab)}
-      aria-current={active === tab ? "page" : undefined}
-      title={collapsed ? label : undefined}
-      className={`flex items-center rounded-md py-2 pr-3 text-sm font-medium transition-colors duration-150 ${
-        active === tab ? SIDEBAR_ITEM.ACTIVE : SIDEBAR_ITEM.IDLE
-      }`}
-      onClick={(event) => {
-        if (!plainLeftClick(event)) return;
-        event.preventDefault();
-        onNavigate(tab);
-      }}
-    >
-      {iconSlot(icon)}
-      <span className="min-w-0 whitespace-nowrap">{label}</span>
-    </a>
+  const pill = (styling: (typeof SIDEBAR_ITEM)[keyof typeof SIDEBAR_ITEM]) => (
+    <span
+      aria-hidden="true"
+      style={{ left: SIDEBAR_PILL_INSET, width: sidebarPillWidth(collapsed) }}
+      className={`absolute inset-y-0 rounded-full transition-[width,background-color] duration-150 ease-out motion-reduce:transition-none ${styling.PILL}`}
+    />
   );
+
+  const item = (tab: AdminTab, label: string, icon: React.ReactNode) => {
+    const styling = active === tab ? SIDEBAR_ITEM.ACTIVE : SIDEBAR_ITEM.IDLE;
+    return (
+      <a
+        href={tabHref(tab)}
+        aria-current={active === tab ? "page" : undefined}
+        title={collapsed ? label : undefined}
+        className={`group relative flex items-center py-2 pr-3 text-sm font-medium transition-colors duration-150 focus-visible:outline-none ${styling.ROW}`}
+        onClick={(event) => {
+          if (!plainLeftClick(event)) return;
+          event.preventDefault();
+          onNavigate(tab);
+        }}
+      >
+        {pill(styling)}
+        {iconSlot(icon)}
+        <span className="relative min-w-0 whitespace-nowrap">{label}</span>
+      </a>
+    );
+  };
 
   return (
     <nav
@@ -1017,11 +1045,12 @@ function AdminSidebar({
         <button
           type="button"
           aria-label={sidebarToggleLabel(collapsed)}
-          className={`flex cursor-pointer items-center rounded-md py-2 pr-3 text-sm font-medium transition-colors duration-150 ${SIDEBAR_ITEM.IDLE}`}
+          className={`group relative flex cursor-pointer items-center py-2 pr-3 text-sm font-medium transition-colors duration-150 focus-visible:outline-none ${SIDEBAR_ITEM.IDLE.ROW}`}
           onClick={onToggle}
         >
+          {pill(SIDEBAR_ITEM.IDLE)}
           {iconSlot(<CollapseIcon collapsed={collapsed} />)}
-          <span className="whitespace-nowrap">Collapse</span>
+          <span className="relative whitespace-nowrap">Collapse</span>
         </button>
       </div>
     </nav>

--- a/apps/web/src/admin-sidebar.ts
+++ b/apps/web/src/admin-sidebar.ts
@@ -64,3 +64,19 @@ export function collapsedIconCenterOffset(): number {
 export function labelStartOffset(): number {
   return SIDEBAR_ICON_SLOT;
 }
+
+/**
+ * The hover and active fill cannot be the row's own background: the row is
+ * laid out at the expanded width and clipped by the rail, so its background
+ * would be sliced mid-pill by the moving clip edge. Each row instead layers a
+ * pill of its own, inset by this margin from the rail's left edge and sized by
+ * `sidebarPillWidth`, whose width moves between the same two endpoints as the
+ * rail's under the same transition. The two width deltas are therefore equal,
+ * which is what keeps the pill's rounded right end exactly this margin inside
+ * the clip edge at every intermediate width, not only at rest.
+ */
+export const SIDEBAR_PILL_INSET = 8;
+
+export function sidebarPillWidth(collapsed: boolean): number {
+  return sidebarRailWidth(collapsed) - SIDEBAR_PILL_INSET * 2;
+}

--- a/apps/web/tests/admin-sidebar.test.ts
+++ b/apps/web/tests/admin-sidebar.test.ts
@@ -3,8 +3,11 @@ import test from "node:test";
 import {
   collapsedIconCenterOffset,
   labelStartOffset,
+  SIDEBAR_ICON_SLOT,
+  SIDEBAR_PILL_INSET,
   SIDEBAR_TOGGLE_LABEL,
   SIDEBAR_WIDTH,
+  sidebarPillWidth,
   sidebarRailWidth,
   sidebarToggleLabel,
 } from "../src/admin-sidebar";
@@ -26,6 +29,22 @@ test("a label begins at the collapsed edge, so the folded rail shows no fragment
   // The bug this guards: a label that begins inside the collapsed width leaves
   // its first characters peeking out of the folded rail.
   assert.ok(labelStartOffset() >= SIDEBAR_WIDTH.COLLAPSED);
+});
+
+test("the pill keeps the same margin inside the rail at both widths", () => {
+  // Equal margins at both endpoints is what makes the margin hold mid-fold
+  // too: the pill and the rail move their widths under the same transition,
+  // so equal deltas keep the pill's right end clear of the clip edge at every
+  // intermediate width. A pill sized off the row instead would run under the
+  // clip and be sliced, which is the bug this guards.
+  for (const collapsed of [false, true]) {
+    assert.equal(sidebarPillWidth(collapsed) + SIDEBAR_PILL_INSET * 2, sidebarRailWidth(collapsed));
+  }
+  assert.ok(SIDEBAR_PILL_INSET > 0);
+});
+
+test("the collapsed pill is centred on the icon it wraps", () => {
+  assert.equal(SIDEBAR_PILL_INSET + sidebarPillWidth(true) / 2, SIDEBAR_ICON_SLOT / 2);
 });
 
 test("the toggle names the act it offers, opposite to the state it is in", () => {


### PR DESCRIPTION
## What

Hover and the active state on the admin sidebar's rows painted `bg-muted` across the whole fixed-width row. Expanded, the fill ran edge-to-edge and read as a sliced block against the rail's borders; collapsed, the rail's clip edge cut the fill mid-shape into a truncated rectangle around the icon; and the shared 5%-white `--muted` fill sat too faint on the lifted `#101114` rail. Rows now draw an inset, fully rounded pill that the fold cannot slice, hover and active share the same geometry so activating a row does not jump, focus-visible takes the same treatment as hover, and the collapse toggle at the rail's foot shares the pill.

## How

The fold lays every row out at the expanded width under the rail's moving clip, which is exactly why a background on the row itself cannot work: the row always runs under the clip edge. Each row instead layers an absolutely positioned pill of its own behind the icon and label, inset `SIDEBAR_PILL_INSET` (8px) from the rail's left edge and sized by `sidebarPillWidth` — the rail's width minus the inset on both sides — transitioned over the same 150ms ease-out width transition the rail moves on. Both widths travel between endpoints that differ by the same delta under the same easing, so the pill's rounded right end sits exactly the inset inside the clip edge at every intermediate frame, not only at rest. The fold's mechanics are untouched: one width transition on the outer rail, the fixed-width inner panel, the clip-edge label reveal, rows with no horizontal padding, and the icon slot at the collapsed rail's width all stand as they were, and the existing fold rationale comment is extended rather than reworked. The fill steps up to a sidebar-scoped `bg-foreground/10` (about 9% white on the dark card) instead of raising the shared `--muted` token, keeping `hover:text-foreground`. New unit tests pin the pill's margin identity at both widths and its centring on the collapsed icon.

## Verification

`./scripts/check.sh` passes (exit 0) on the rebased branch, including the two new `apps/web` sidebar tests. Rendered the sidebar in headless Chrome (hover-capable pointer forced via blink settings, real mouse-move events over CDP) at three states: expanded shows the active and hovered rows each wearing an inset rounded pill with breathing room from every rail edge; collapsed shows neat pills centred around the icons, fully inside the 62px rail with nothing truncated at the clip edge, and the collapse toggle wearing the same pill on hover; a mid-transition frame (fold slowed to 1200ms, captured at ~50%) shows both pills' rounded ends riding cleanly inside the moving clip edge while the labels are mid-reveal — no slicing, no shape pop. Web-only change; no desktop surface touched, so no macOS/notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32542979362/artifacts/9467631629) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32542979362)

- Commit: `852717081f67f71407a87821c30602452405ab25`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
