### PR TITLE
feat(admin): make the admin surface work on a phone

### DIFF
--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -952,7 +952,11 @@ const SIDEBAR_ITEM = {
 /**
  * The page's one navigation, wearing the brand the headers used to carry.
  * Each tab is a real anchor to its own address, so a modified click still
- * gets the browser's own gesture.
+ * gets the browser's own gesture. On a phone the rail would eat a fifth of
+ * the width for two links, so below the page's breakpoint the same
+ * navigation stands as a compact top bar instead — two sibling renders
+ * rather than one reshaped tree, because the fold below is the rail's own
+ * geometry and never reaches the bar's inline labels.
  *
  * The fold is a single width transition on the outer rail over a fixed-width
  * inner panel it clips: the panel is always laid out at the expanded width, so
@@ -1020,40 +1024,82 @@ function AdminSidebar({
     );
   };
 
+  const barItem = (tab: AdminTab, label: string, icon: React.ReactNode) => {
+    const styling = active === tab ? SIDEBAR_ITEM.ACTIVE : SIDEBAR_ITEM.IDLE;
+    return (
+      <a
+        href={tabHref(tab)}
+        aria-current={active === tab ? "page" : undefined}
+        className={`group relative flex items-center px-2.5 py-2 text-sm font-medium transition-colors duration-150 focus-visible:outline-none ${styling.ROW}`}
+        onClick={(event) => {
+          if (!plainLeftClick(event)) return;
+          event.preventDefault();
+          onNavigate(tab);
+        }}
+      >
+        {/* The bar never folds, so the rail's pill needs no width of its own
+            here: the same fills simply cover the item. */}
+        <span
+          aria-hidden="true"
+          className={`absolute inset-0 rounded-full transition-[background-color] duration-150 ${styling.PILL}`}
+        />
+        <span className="relative flex items-center gap-2.5">
+          {icon}
+          {label}
+        </span>
+      </a>
+    );
+  };
+
   return (
-    <nav
-      aria-label="Admin sections"
-      style={{ width: sidebarRailWidth(collapsed) }}
-      className="sticky top-0 flex h-screen shrink-0 overflow-hidden border-r border-border bg-card transition-[width] duration-150 ease-out motion-reduce:transition-none"
-    >
-      <div style={{ width: SIDEBAR_WIDTH.EXPANDED }} className="flex h-full shrink-0 flex-col py-5">
-        <div className="flex items-center pr-3">
-          {iconSlot(
-            <span className="inline-flex w-6 text-foreground">
-              <LukeMark className="h-auto w-full" />
-            </span>,
-          )}
-          <span className="whitespace-nowrap font-brand text-base font-bold tracking-[-0.01em]">
-            Luke admin
-          </span>
-        </div>
-        <div className="mt-8 grid gap-1">
-          {item("dashboard", "Dashboard", <DashboardIcon />)}
-          {item("users", "Users", <UsersIcon />)}
-        </div>
-        <div className="flex-1" />
-        <button
-          type="button"
-          aria-label={sidebarToggleLabel(collapsed)}
-          className={`group relative flex cursor-pointer items-center py-2 pr-3 text-sm font-medium transition-colors duration-150 focus-visible:outline-none ${SIDEBAR_ITEM.IDLE.ROW}`}
-          onClick={onToggle}
+    <>
+      <nav
+        aria-label="Admin sections"
+        className="flex items-center gap-1 border-b border-border bg-card px-4 py-2 min-[720px]:hidden"
+      >
+        <span className="mr-2 inline-flex w-6 shrink-0 text-foreground" aria-hidden="true">
+          <LukeMark className="h-auto w-full" />
+        </span>
+        {barItem("dashboard", "Dashboard", <DashboardIcon />)}
+        {barItem("users", "Users", <UsersIcon />)}
+      </nav>
+      <nav
+        aria-label="Admin sections"
+        style={{ width: sidebarRailWidth(collapsed) }}
+        className="sticky top-0 hidden h-screen shrink-0 overflow-hidden border-r border-border bg-card transition-[width] duration-150 ease-out min-[720px]:flex motion-reduce:transition-none"
+      >
+        <div
+          style={{ width: SIDEBAR_WIDTH.EXPANDED }}
+          className="flex h-full shrink-0 flex-col py-5"
         >
-          {pill(SIDEBAR_ITEM.IDLE)}
-          {iconSlot(<CollapseIcon collapsed={collapsed} />)}
-          <span className="relative whitespace-nowrap">Collapse</span>
-        </button>
-      </div>
-    </nav>
+          <div className="flex items-center pr-3">
+            {iconSlot(
+              <span className="inline-flex w-6 text-foreground">
+                <LukeMark className="h-auto w-full" />
+              </span>,
+            )}
+            <span className="whitespace-nowrap font-brand text-base font-bold tracking-[-0.01em]">
+              Luke admin
+            </span>
+          </div>
+          <div className="mt-8 grid gap-1">
+            {item("dashboard", "Dashboard", <DashboardIcon />)}
+            {item("users", "Users", <UsersIcon />)}
+          </div>
+          <div className="flex-1" />
+          <button
+            type="button"
+            aria-label={sidebarToggleLabel(collapsed)}
+            className={`group relative flex cursor-pointer items-center py-2 pr-3 text-sm font-medium transition-colors duration-150 focus-visible:outline-none ${SIDEBAR_ITEM.IDLE.ROW}`}
+            onClick={onToggle}
+          >
+            {pill(SIDEBAR_ITEM.IDLE)}
+            {iconSlot(<CollapseIcon collapsed={collapsed} />)}
+            <span className="relative whitespace-nowrap">Collapse</span>
+          </button>
+        </div>
+      </nav>
+    </>
   );
 }
 
@@ -1071,12 +1117,20 @@ function PageHeader({
 }): React.JSX.Element {
   return (
     <header className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
-      <h1 className="text-lg font-semibold tracking-[-0.01em]">{title}</h1>
-      <div className="flex flex-wrap items-center gap-4">
+      {/* The title holds a whole line on a phone, so the controls wrap into
+          rows of their own instead of raggedly around it; the divider stands
+          only beside the rail, where the row is wide enough to need a seam. */}
+      <h1 className="w-full text-lg font-semibold tracking-[-0.01em] min-[720px]:w-auto">
+        {title}
+      </h1>
+      <div className="flex flex-wrap items-center gap-3 min-[720px]:gap-4">
         {controls}
         {account ? (
           <>
-            <span className="h-8 w-px bg-border" aria-hidden="true" />
+            <span
+              className="hidden h-8 w-px bg-border min-[720px]:inline-block"
+              aria-hidden="true"
+            />
             <AccountMenu account={account} onSignOut={onSignOut} />
           </>
         ) : null}
@@ -3164,7 +3218,7 @@ export function AdminDashboard(): React.JSX.Element {
   // `main` landmark belongs to whatever stands inside it — a page's own root
   // or a centered card's — and each render path stands exactly one.
   const shell = (tab: AdminTab, content: React.JSX.Element) => (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen flex-col min-[720px]:flex-row">
       <AdminSidebar
         active={tab}
         collapsed={sidebarFolded}


### PR DESCRIPTION
## What

Makes the admin surface usable on a phone (~360–430px). Below the page's existing `min-[720px]` breakpoint:

- The sticky left rail becomes a compact top bar — brand mark plus the two nav links (Dashboard, Users) inline, each still a real anchor with `aria-current` preserved. The collapse toggle is not drawn there, since folding buys nothing on a bar. At `min-[720px]` and up the rail is untouched, including its clip-based fold and the persisted collapse state.
- The page header gives the title a whole line (`w-full`), so the window switcher, Hide-admins, stamp, Refresh, and avatar wrap into rows of their own instead of raggedly around it; control gaps tighten from `gap-4` to `gap-3`; and the `h-8 w-px` divider before the avatar is hidden, where a wrapped row would otherwise lead with it.
- The shell flex switches to `flex-col` so the bar sits on top, back to `flex-row` at `min-[720px]`.

`admin.html` already carries the viewport meta, so no change there. The stat grids were judged from real renders at 390/375/360 and left alone: values and hints wrap inside their cards without clipping, so the two-column layout holds and no narrower breakpoint was added.

## How

Two sibling renders inside `AdminSidebar` — a `min-[720px]:hidden` top bar and the existing rail as `hidden min-[720px]:flex` — rather than one reshaped tree, because the fold is the rail's own clip geometry (fixed-width inner panel, icon slots) and never reaches the bar's inline labels. The bar's items get their own small helper sharing `SIDEBAR_ITEM` tones and the same navigate handler; the rail's item, fold, and toggle are exactly as main left them.

## Verification

- `./scripts/check.sh` passes (repository contracts, Biome, oxlint, typecheck, tests, build).
- Rendered in headless Chrome against stubbed `/api/admin/*` endpoints, on this branch rebased onto current main (after the card pruning and sidebar-fold rework landed), at 390×844, 375×812, 360×780, and 900×700:
  - Dashboard and Users views both show `document.documentElement.scrollWidth == innerWidth` at every phone width — no horizontal body overflow; the only elements wider than the viewport sit inside the retention grid's and tables' own `overflow-x-auto` wrappers, which is their designed scroll.
  - The top bar draws at phone widths with 36px-tall links and correct `aria-current`; at 900px the rail, its collapse toggle, and the header divider are back and the bar is gone.
  - The header title takes its own line at phone widths with the controls grouped beneath it; the divider is hidden there and visible at 900px.
  - Full-page 390px renders of both views inspected end to end: stat cards, charts, retention grid, tables, reliability, and system health all legible with no clipped values.
  - Touch targets: nav links 36px tall; the window switcher's 7d/30d/90d buttons remain ~20px tall as on desktop — pre-existing sizing, unchanged here.

Web-only change; no desktop surface touched, so no macOS/notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32543984024/artifacts/9467942720) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32543984024)

- Commit: `7975105e763fa116d1216b33712f6cb8f6d0378c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
