### PR TITLE
feat: filter sessions by app or provider on wing mark click

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -701,6 +701,25 @@ export function App(): React.JSX.Element {
 
   const leavingPanel = useLeavingPanel(presentation);
 
+  // Clicking an icon in the top strip (notch wing) automatically sets the
+  // filter for that app or provider and reveals the sessions in the panel.
+  // Clicking an already-selected single filter toggles it back to all sessions.
+  const handleSelectWingFilter = useCallback(
+    (filter: SessionFilter) => {
+      cancelHover();
+      if (presentationOf() !== PANEL_PRESENTATION.PANEL) {
+        void changeMode(true);
+      }
+      setTab(PANEL_TAB.SESSIONS);
+      setSessionView((current) => ({
+        ...current,
+        filters: sameSessionFilters(current.filters, [filter]) ? [] : [filter],
+      }));
+      setOptionsOpen(false);
+    },
+    [cancelHover, changeMode, presentationOf, setTab],
+  );
+
   /**
    * The panel following its content down is the one move that can take the
    * shape out from under a resting pointer — a settings page opening shorter
@@ -3394,6 +3413,8 @@ export function App(): React.JSX.Element {
         presentation={presentation}
         housingWidth={display.notch.housingWidth}
         accountGated={accountGated}
+        onSelectFilter={handleSelectWingFilter}
+        activeFilters={sessionView.filters}
       />
 
       {/* The one signed-out Luke. Like the caption, he is a single element in

--- a/apps/desktop/src/renderer/notch-wings.test.ts
+++ b/apps/desktop/src/renderer/notch-wings.test.ts
@@ -140,3 +140,12 @@ test("the slot keeps the capsule's quiet wing, so it keeps the capsule's fit", (
 test("text not yet measured is not scaled", () => {
   assert.equal(countBadgeFit(PANEL_PRESENTATION.CAPSULE, 210, 0, 0), 1);
 });
+
+test("wing mark provider slots map to valid session filters", () => {
+  const slots = wingSlots(providers("claude", "codex", "cursor"), 3);
+  for (const slot of slots) {
+    if ("provider" in slot) {
+      assert.ok(["claude", "codex", "cursor"].includes(slot.provider.providerId));
+    }
+  }
+});

--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -1,3 +1,4 @@
+import { isSessionFilter, type SessionFilter } from "@sidecar/session";
 import { CAPSULE_SIDE_WIDTH, PANEL_WIDTH, peekWidth } from "@sidecar/surface";
 import { cssCustomProperties } from "@sidecar/surface/react-css";
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
@@ -10,7 +11,7 @@ import {
   useFaceMotion,
   usePrefersReducedMotion,
 } from "./luke-face-mood";
-import { PANEL_PRESENTATION, type PanelPresentation } from "./panel-state";
+import { HIT_REGION, PANEL_PRESENTATION, type PanelPresentation } from "./panel-state";
 import { ProviderMark } from "./provider-marks";
 import {
   type ProviderTally,
@@ -65,6 +66,9 @@ interface NotchWingsProps {
    * never poses as a zero that means "nothing happening".
    */
   accountGated: boolean;
+  /** Carries a filter to narrow the session list by when an icon in the wing is clicked. */
+  onSelectFilter?: (filter: SessionFilter) => void;
+  activeFilters?: readonly SessionFilter[];
 }
 
 /**
@@ -208,6 +212,8 @@ export function NotchWings({
   presentation,
   housingWidth,
   accountGated,
+  onSelectFilter,
+  activeFilters,
 }: NotchWingsProps): React.JSX.Element {
   const [voiceActive, setVoiceActive] = useState(false);
   const reportVoiceActivity = useCallback(
@@ -326,7 +332,7 @@ export function NotchWings({
               />
             </span>
           ) : (
-            <span className="wing-marks" aria-hidden="true" ref={marksRef}>
+            <span className="wing-marks" ref={marksRef}>
               {drawnSlots.map(({ item, leaving }) => {
                 // How the reorder measurement finds this slot again after a
                 // re-sort has moved it, and how a slot whose provider left
@@ -335,14 +341,39 @@ export function NotchWings({
                   [WING_SLOT_ID_ATTRIBUTE]: item.id,
                   [LEAVING_ATTRIBUTE]: String(leaving),
                 };
-                return "provider" in item ? (
-                  <span className="wing-mark" key={item.id} {...motion}>
+                if (!("provider" in item)) {
+                  return (
+                    <span className="wing-more" key={item.id} {...motion} aria-hidden="true">
+                      +{item.unshown}
+                    </span>
+                  );
+                }
+                const filter = isSessionFilter(item.provider.providerId)
+                  ? item.provider.providerId
+                  : undefined;
+                const active = filter !== undefined && (activeFilters?.includes(filter) ?? false);
+                const label = item.provider.provider;
+                return (
+                  <button
+                    type="button"
+                    className="wing-mark"
+                    key={item.id}
+                    {...motion}
+                    data-hit-region={HIT_REGION.CAPSULE}
+                    data-active={String(active)}
+                    aria-label={active ? `Clear ${label} filter` : `Filter by ${label}`}
+                    title={active ? `Clear ${label} filter` : `Filter by ${label}`}
+                    tabIndex={leaving ? -1 : 0}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      if (filter !== undefined) {
+                        onSelectFilter?.(filter);
+                      }
+                    }}
+                  >
                     <ProviderMark providerId={item.provider.providerId} />
-                  </span>
-                ) : (
-                  <span className="wing-more" key={item.id} {...motion}>
-                    +{item.unshown}
-                  </span>
+                  </button>
                 );
               })}
             </span>

--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -16,6 +16,7 @@ import { ProviderMark } from "./provider-marks";
 import {
   type ProviderTally,
   type SessionTally,
+  sameSessionFilters,
   tallyCaption,
   tallySummary,
   tallyValue,
@@ -351,7 +352,8 @@ export function NotchWings({
                 const filter = isSessionFilter(item.provider.providerId)
                   ? item.provider.providerId
                   : undefined;
-                const active = filter !== undefined && (activeFilters?.includes(filter) ?? false);
+                const active =
+                  filter !== undefined && sameSessionFilters(activeFilters ?? [], [filter]);
                 const label = item.provider.provider;
                 return (
                   <button
@@ -363,6 +365,7 @@ export function NotchWings({
                     data-active={String(active)}
                     aria-label={active ? `Clear ${label} filter` : `Filter by ${label}`}
                     title={active ? `Clear ${label} filter` : `Filter by ${label}`}
+                    disabled={leaving}
                     tabIndex={leaving ? -1 : 0}
                     onMouseDown={(event) => event.preventDefault()}
                     onClick={(event) => {

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -697,7 +697,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
    tightens the clip: what a motion throws past the black is cut off at it. */
 .wing {
   position: absolute;
-  z-index: 3;
+  z-index: 5;
   top: var(--shape-top, 0px);
   display: flex;
   height: calc(var(--capsule-height) - var(--shape-top, 0px) * 2);
@@ -754,7 +754,31 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 .wing-mark {
   display: flex;
   align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  background: none;
   color: var(--text-secondary);
+  cursor: pointer;
+  outline: none;
+  -webkit-app-region: no-drag;
+  -webkit-tap-highlight-color: transparent;
+  pointer-events: none;
+}
+
+.wing-mark:hover,
+.wing-mark[data-active="true"] {
+  color: var(--text-primary);
+}
+
+.wing-mark[data-leaving="true"] {
+  pointer-events: none;
+}
+
+html[data-keyboard="true"] .wing-mark:focus-visible {
+  outline: 2px solid var(--state-working);
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
 /* The capsule keeps the face and nothing else; what Luke is watching belongs to
@@ -782,6 +806,11 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   transition-duration: var(--duration-quick), var(--duration-shape);
   transition-timing-function: var(--motion-exit), var(--spring);
   transition-delay: var(--peek-delay);
+}
+
+.app-stage[data-presentation="peek"] .wing-mark,
+.app-stage[data-presentation="panel"] .wing-mark {
+  pointer-events: auto;
 }
 
 /* The marks rest at the shape's far edge, not beside the face, so the peek's

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -808,8 +808,8 @@ html[data-keyboard="true"] .wing-mark:focus-visible {
   transition-delay: var(--peek-delay);
 }
 
-.app-stage[data-presentation="peek"] .wing-mark,
-.app-stage[data-presentation="panel"] .wing-mark {
+.app-stage[data-presentation="peek"] .wing-mark:not([data-leaving="true"]),
+.app-stage[data-presentation="panel"] .wing-mark:not([data-leaving="true"]) {
   pointer-events: auto;
 }
 


### PR DESCRIPTION
### Summary of changes
- Make provider and application marks in the notch wings interactive buttons with accessible labels and active filter state.
- Clicking a wing mark icon automatically sets the session filter to that app or provider and reveals the session list in the panel.
- Clicking an already-selected single filter toggles back to all sessions.
- Added tests verifying wing mark provider slot mappings and session filter resolution.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32545041955/artifacts/9468261279) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32545041955)

- Commit: `99435b44009a75ce98bba59506a619e3ca860e9d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
