### PR TITLE
feat(admin): search the whole roster, not the newest 200

### DIFF
--- a/apps/web/api/admin/users.ts
+++ b/apps/web/api/admin/users.ts
@@ -14,11 +14,12 @@ export default {
     return handleAdminUsers({
       request,
       resolveViewer: resolveSessionViewer,
-      readUsers: async (now, scope, viewerId, windowDays) =>
+      readUsers: async (now, scope, viewerId, windowDays, search) =>
         buildAdminUserList(
-          await readAdminUsersSource(getDatabase(), { now, scope, viewerId, windowDays }),
+          await readAdminUsersSource(getDatabase(), { now, scope, search, viewerId, windowDays }),
           now,
           windowDays,
+          search,
         ),
     });
   },

--- a/apps/web/server/admin/admin-queries.ts
+++ b/apps/web/server/admin/admin-queries.ts
@@ -5,6 +5,7 @@ import {
   eq,
   gt,
   gte,
+  ilike,
   isNull,
   max,
   ne,
@@ -32,7 +33,7 @@ import {
   windowFetchDays,
 } from "./admin-metrics.js";
 import type { AdminUserSource } from "./admin-user.js";
-import { ADMIN_USERS_LIMIT, type AdminUserListSource } from "./admin-users.js";
+import { ADMIN_USERS_LIMIT, type AdminUserListSource, searchLikePattern } from "./admin-users.js";
 import { ADMIN_METRICS_SCOPE, type AdminMetricsScope, type AdminMetricsWindow } from "./http.js";
 
 /** How many of the most active hosted-tier accounts the overview names. */
@@ -49,6 +50,18 @@ type Database = ReturnType<typeof createDatabase>;
 function scopeCondition(scope: AdminMetricsScope): SQL<unknown> | undefined {
   if (scope === ADMIN_METRICS_SCOPE.ALL) return undefined;
   return or(ne(user.role, USER_ROLE.ADMIN), isNull(user.role));
+}
+
+/**
+ * The accounts a search keeps: a case-insensitive substring of the name or
+ * the email, the two fields a roster row is found by. The term travels as a
+ * bound parameter — never interpolated into the SQL — with its own
+ * wildcards escaped, so it can only ever name characters to find.
+ */
+function searchCondition(search: string | undefined): SQL<unknown> | undefined {
+  if (search === undefined) return undefined;
+  const pattern = searchLikePattern(search);
+  return or(ilike(user.name, pattern), ilike(user.email, pattern));
 }
 
 /** Postgres returns a `count` as a number and a bigint `sum` as a string or null. */
@@ -460,7 +473,9 @@ export async function readAdminUserSource(
  * — with zero active days and no last-active day — instead of vanishing the
  * way it does from every inner-joined aggregate above. Most recently active
  * first, the never-active tail ordered by youngest account, and the roster
- * cut at the stated bound while `total` still counts everyone. Last-seen
+ * cut at the stated bound while `total` still counts everyone. A search
+ * narrows the rows and the total alike, so a truncated answer still states
+ * how many accounts match. Last-seen
  * instants ride a query of their own: a second one-to-many join would fan
  * the usage aggregates out across each account's session rows.
  */
@@ -469,19 +484,21 @@ export async function readAdminUsersSource(
   input: {
     now: number;
     scope: AdminMetricsScope;
+    search: string | undefined;
     viewerId: string;
     windowDays: AdminMetricsWindow;
   },
 ): Promise<AdminUserListSource> {
   const windowStartDay = lastNDayKeys(input.now, input.windowDays)[0] ?? utcDayKey(input.now);
+  const kept = and(scopeCondition(input.scope), searchCondition(input.search));
 
   const [[totalRow], lastSeenRows, rows] = await Promise.all([
-    database.select({ value: count() }).from(user).where(scopeCondition(input.scope)),
+    database.select({ value: count() }).from(user).where(kept),
     database
       .select({ userId: session.userId, lastSeenAt: max(session.updatedAt) })
       .from(session)
       .innerJoin(user, eq(session.userId, user.id))
-      .where(scopeCondition(input.scope))
+      .where(kept)
       .groupBy(session.userId),
     database
       .select({
@@ -508,7 +525,7 @@ export async function readAdminUsersSource(
         adminFavorite,
         and(eq(adminFavorite.userId, user.id), eq(adminFavorite.adminId, input.viewerId)),
       )
-      .where(scopeCondition(input.scope))
+      .where(kept)
       .groupBy(user.id, user.name, user.email, user.image, user.role, user.createdAt)
       .orderBy(sql`max(${hostedUsage.day}) desc nulls last`, desc(user.createdAt))
       .limit(ADMIN_USERS_LIMIT),

--- a/apps/web/server/admin/admin-users.ts
+++ b/apps/web/server/admin/admin-users.ts
@@ -7,6 +7,7 @@ import {
   type AdminMetricsWindow,
   adminMetricsScope,
   adminMetricsWindow,
+  adminUsersSearch,
   errorResponse,
   jsonResponse,
 } from "./http.js";
@@ -20,13 +21,23 @@ import {
  */
 
 /**
- * How many rows one read returns. The roster is drawn whole because search
- * and the reading both happen client-side; the bound exists so an account
- * table that has grown past what a page can usefully draw degrades to a
- * stated truncation — `total` still counts everyone — rather than an
- * unbounded response.
+ * How many rows one read returns. The bound exists so an account table that
+ * has grown past what a page can usefully draw degrades to a stated
+ * truncation — `total` still counts everyone the filter keeps — rather than
+ * an unbounded response, and the search narrows the read itself, so an
+ * account past the bound is still findable by name or email.
  */
 export const ADMIN_USERS_LIMIT = 200;
+
+/**
+ * An `ILIKE` pattern matching the term as a literal substring: Postgres's
+ * default escape character is the backslash, so the term's own `%`, `_`,
+ * and `\` are escaped before the wildcards wrap it — a searched "100%" must
+ * match those four characters, never widen into a prefix scan.
+ */
+export function searchLikePattern(term: string): string {
+  return `%${term.replace(/[\\%_]/g, "\\$&")}%`;
+}
 
 export interface AdminUserListRow {
   id: string;
@@ -57,10 +68,12 @@ export interface AdminUserListRow {
 export interface AdminUserList {
   generatedAt: number;
   windowDays: number;
-  /** Every account the scope covers, counted past the row bound. */
+  /** Every account the scope — and the search, when one rode the read — covers, counted past the row bound. */
   total: number;
   /** The bound `rows` was read under, so the page can word a truncation. */
   limit: number;
+  /** The term the rows and total were filtered by, echoed so the page words the answer it shows. */
+  search: string | undefined;
   rows: AdminUserListRow[];
 }
 
@@ -69,17 +82,19 @@ export interface AdminUserListSource {
   rows: readonly AdminUserListRow[];
 }
 
-/** Stamps the queried roster with the window the aggregates cover. */
+/** Stamps the queried roster with the window its aggregates cover and the search that scoped it. */
 export function buildAdminUserList(
   source: AdminUserListSource,
   now: number,
   windowDays: AdminMetricsWindow,
+  search: string | undefined,
 ): AdminUserList {
   return {
     generatedAt: now,
     windowDays,
     total: source.total,
     limit: ADMIN_USERS_LIMIT,
+    search,
     rows: [...source.rows],
   };
 }
@@ -93,6 +108,7 @@ export interface AdminUsersOptions {
     scope: AdminMetricsScope,
     viewerId: string,
     windowDays: AdminMetricsWindow,
+    search: string | undefined,
   ) => Promise<AdminUserList>;
   now?: () => number;
 }
@@ -126,11 +142,22 @@ export async function handleAdminUsers(options: AdminUsersOptions): Promise<Resp
     return errorResponse(ADMIN_HTTP_STATUS.BAD_REQUEST, ADMIN_ERROR.INVALID_WINDOW);
   }
 
+  const search = adminUsersSearch(request.url);
+  if (search === undefined) {
+    return errorResponse(ADMIN_HTTP_STATUS.BAD_REQUEST, ADMIN_ERROR.INVALID_SEARCH);
+  }
+
   const now = (options.now ?? Date.now)();
   try {
     return jsonResponse(
       ADMIN_HTTP_STATUS.OK,
-      await options.readUsers(now, adminMetricsScope(request.url), viewer.userId, windowDays),
+      await options.readUsers(
+        now,
+        adminMetricsScope(request.url),
+        viewer.userId,
+        windowDays,
+        search.term,
+      ),
     );
   } catch {
     return errorResponse(ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE, ADMIN_ERROR.UNAVAILABLE);

--- a/apps/web/server/admin/http.ts
+++ b/apps/web/server/admin/http.ts
@@ -28,6 +28,8 @@ export const ADMIN_ERROR = {
   MISSING_USER_ID: "missing-user-id",
   /** A read that named a window outside the fixed set of lengths. */
   INVALID_WINDOW: "invalid-window",
+  /** A roster read whose search term ran past the length bound. */
+  INVALID_SEARCH: "invalid-search",
   /** The named account has no user row — deleted, or the id never existed. */
   USER_NOT_FOUND: "user-not-found",
   /** A seam (auth or the database) did not answer; the answer is a JSON refusal, never a crash. */
@@ -94,6 +96,29 @@ export function adminMetricsWindow(url: string): AdminMetricsWindow | undefined 
   const value = new URL(url).searchParams.get(ADMIN_METRICS_WINDOW_PARAM);
   if (value === null) return ADMIN_METRICS_WINDOW_DEFAULT;
   return Object.values(ADMIN_METRICS_WINDOW).find((candidate) => String(candidate) === value);
+}
+
+export const ADMIN_USERS_SEARCH_PARAM = "search";
+
+/**
+ * Generous against any name or address worth finding, and small against a
+ * query string used as a battering ram: the term is the one parameter typed
+ * rather than picked from a fixed set, so a length bound is the validation
+ * it can carry.
+ */
+export const ADMIN_USERS_SEARCH_MAX_LENGTH = 100;
+
+/**
+ * The search a roster read asked for: no term when the request carried none
+ * or only whitespace, and no answer at all past the length bound — refused
+ * rather than silently clipped to a search nobody asked for.
+ */
+export function adminUsersSearch(url: string): { term: string | undefined } | undefined {
+  const value = new URL(url).searchParams.get(ADMIN_USERS_SEARCH_PARAM);
+  if (value === null) return { term: undefined };
+  if (value.length > ADMIN_USERS_SEARCH_MAX_LENGTH) return undefined;
+  const term = value.trim();
+  return { term: term.length === 0 ? undefined : term };
 }
 
 export const ADMIN_USER_ID_PARAM = "id";

--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -19,6 +19,8 @@ import {
   ADMIN_METRICS_WINDOW_DEFAULT,
   ADMIN_METRICS_WINDOW_PARAM,
   ADMIN_USER_ID_PARAM,
+  ADMIN_USERS_SEARCH_MAX_LENGTH,
+  ADMIN_USERS_SEARCH_PARAM,
   type AdminMetricsWindow,
 } from "../server/admin/http";
 import { accountInitials } from "./account-initials";
@@ -64,6 +66,13 @@ const ACCOUNT_VIEW_PARAM = "user";
 const TAB_PARAM = "view";
 const USERS_TAB_VALUE = "users";
 const WINDOW_VIEW_PARAM = "days";
+const SEARCH_VIEW_PARAM = "q";
+
+/**
+ * Long enough that a typed word coalesces into one roster read, short enough
+ * that the searched answer still feels like the box's own.
+ */
+const SEARCH_DEBOUNCE_MS = 250;
 
 /** The sidebar's two destinations; an open account highlights Users. */
 type AdminTab = "dashboard" | "users";
@@ -91,6 +100,36 @@ function windowFromLocation(): AdminMetricsWindow {
     Object.values(ADMIN_METRICS_WINDOW).find((candidate) => String(candidate) === value) ??
     ADMIN_METRICS_WINDOW_DEFAULT
   );
+}
+
+/**
+ * The search the address bar names, so a searched roster is shareable and
+ * survives a reload. An address naming a term past the API's length bound is
+ * clipped to it rather than refused — a link is the reader's — and matches
+ * the bound the input below enforces on typing.
+ */
+function searchFromLocation(): string {
+  const value = new URLSearchParams(window.location.search).get(SEARCH_VIEW_PARAM) ?? "";
+  return value.slice(0, ADMIN_USERS_SEARCH_MAX_LENGTH);
+}
+
+/**
+ * The current address with the search set or cleared. Typing rewrites the
+ * entry in place rather than pushing one, so the back button walks views,
+ * not keystrokes.
+ */
+function searchHref(query: string): string {
+  const params = new URLSearchParams(window.location.search);
+  if (query) params.set(SEARCH_VIEW_PARAM, query);
+  else params.delete(SEARCH_VIEW_PARAM);
+  const queryString = params.toString();
+  return queryString ? `${window.location.pathname}?${queryString}` : window.location.pathname;
+}
+
+/** The term a typed query asks the service to search for: none when blank. */
+function searchTerm(query: string): string | undefined {
+  const term = query.trim();
+  return term.length === 0 ? undefined : term;
 }
 
 /**
@@ -1425,7 +1464,13 @@ function AccountActivityNote(): React.JSX.Element {
   );
 }
 
-function RosterNote({ truncatedTo }: { truncatedTo?: number }): React.JSX.Element {
+function RosterNote({
+  truncatedTo,
+  searched,
+}: {
+  truncatedTo?: number;
+  searched?: boolean;
+}): React.JSX.Element {
   return (
     <p className="mt-3 text-sm text-muted-foreground">
       Every account the service holds, most recently active first, whether or not it ever touched
@@ -1434,7 +1479,9 @@ function RosterNote({ truncatedTo }: { truncatedTo?: number }): React.JSX.Elemen
       any hosted use. A heading sorts by its column, a row opens the account's own page, and a row's
       star favorites the account for you alone, following your sign-in rather than this browser.
       {truncatedTo !== undefined
-        ? ` Only the ${formatNumber(truncatedTo)} most recently active accounts are listed here, and the filter searches those alone.`
+        ? searched
+          ? ` Only the ${formatNumber(truncatedTo)} most recently active matching accounts are listed here — narrow the search to reach the rest.`
+          : ` Only the ${formatNumber(truncatedTo)} most recently active accounts are listed here — searching reads the whole roster, not just these.`
         : ""}
     </p>
   );
@@ -1652,17 +1699,19 @@ function AccountSkeleton({
   );
 }
 
-/** A windowed read's address: the default scope and window ride as no params. */
+/** A windowed read's address: the default scope, window, and no search ride as no params. */
 function windowedReadPath(
   base: string,
   hideAdmins: boolean,
   windowDays: AdminMetricsWindow,
+  search?: string,
 ): string {
   const params = new URLSearchParams();
   if (!hideAdmins) params.set(ADMIN_METRICS_SCOPE_PARAM, ADMIN_METRICS_SCOPE.ALL);
   if (windowDays !== ADMIN_METRICS_WINDOW_DEFAULT) {
     params.set(ADMIN_METRICS_WINDOW_PARAM, String(windowDays));
   }
+  if (search !== undefined) params.set(ADMIN_USERS_SEARCH_PARAM, search);
   const query = params.toString();
   return query ? `${base}?${query}` : base;
 }
@@ -2684,6 +2733,8 @@ function UsersPage({
   onSignOut,
   onOpenAccount,
   onToggleFavorite,
+  query,
+  onQueryChange,
   refreshing,
   onRefresh,
   now,
@@ -2698,11 +2749,15 @@ function UsersPage({
   onSignOut: () => void;
   onOpenAccount: (id: string) => void;
   onToggleFavorite: (id: string, favorite: boolean) => void;
+  query: string;
+  onQueryChange: (query: string) => void;
   refreshing: boolean;
   onRefresh: () => void;
   now: number;
 }): React.JSX.Element {
-  const [query, setQuery] = useState("");
+  // The service searches the whole roster once the debounce settles; until
+  // that answer lands, the same needle filters the rows already loaded, so
+  // the box stays instant between refetches.
   const needle = query.trim().toLowerCase();
   const rows = needle
     ? list.rows.filter((row) => `${row.name} ${row.email}`.toLowerCase().includes(needle))
@@ -2742,13 +2797,15 @@ function UsersPage({
           <input
             type="search"
             value={query}
-            placeholder="Filter by name or email…"
-            aria-label="Filter accounts by name or email"
+            maxLength={ADMIN_USERS_SEARCH_MAX_LENGTH}
+            placeholder="Search by name or email…"
+            aria-label="Search accounts by name or email"
             className="w-full max-w-[320px] rounded-md border border-border bg-card px-3 py-1.5 text-sm placeholder:text-muted-foreground focus-visible:outline-2 focus-visible:outline-offset-2"
-            onChange={(event) => setQuery(event.target.value)}
+            onChange={(event) => onQueryChange(event.target.value)}
           />
           <span className="text-xs text-muted-foreground tabular-nums">
             {formatNumber(rows.length)} of {formatNumber(list.total)} accounts
+            {list.search === undefined ? "" : " matching"}
           </span>
         </div>
         <div className="mt-4">
@@ -2763,7 +2820,10 @@ function UsersPage({
             favorite={{ starred: (row) => row.favorite, onToggle: onToggleFavorite }}
           />
         </div>
-        <RosterNote truncatedTo={list.total > list.rows.length ? list.rows.length : undefined} />
+        <RosterNote
+          truncatedTo={list.total > list.rows.length ? list.rows.length : undefined}
+          searched={list.search !== undefined}
+        />
       </div>
     </main>
   );
@@ -2797,6 +2857,32 @@ function UsersScreen({
   const [refreshing, setRefreshing] = useState(false);
   const inFlight = useRef<AbortController>(null);
 
+  // What the box holds and what the service was asked to search for, apart:
+  // the query redraws on every keystroke and filters the loaded rows at once,
+  // while the debounce below commits it into the term the roster is refetched
+  // under, so the whole account table is not scanned per keystroke. Typing
+  // rides the address bar in place, so a searched roster is shareable without
+  // the back button walking keystrokes.
+  const [query, setQuery] = useState(searchFromLocation);
+  const [search, setSearch] = useState(() => searchTerm(searchFromLocation()));
+  const changeQuery = (next: string) => {
+    setQuery(next);
+    window.history.replaceState(null, "", searchHref(next.trim()));
+  };
+  useEffect(() => {
+    const timer = window.setTimeout(() => setSearch(searchTerm(query)), SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(timer);
+  }, [query]);
+  useEffect(() => {
+    const onPopState = () => {
+      const restored = searchFromLocation();
+      setQuery(restored);
+      setSearch(searchTerm(restored));
+    };
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
+
   // The same withdrawal the detail screen lands: this screen renders in the
   // overview's place with a ready answer of its own, so the parent's sign-out
   // alone would leave the roster on screen after the consent behind it left.
@@ -2817,7 +2903,7 @@ function UsersScreen({
     inFlight.current = controller;
     setState((current) => (current.status === "ready" ? current : { status: "loading" }));
     setRefreshing(true);
-    const path = windowedReadPath(USERS_PATH, hideAdmins, windowDays);
+    const path = windowedReadPath(USERS_PATH, hideAdmins, windowDays, search);
     void (async () => {
       try {
         const next = await readUsersState(
@@ -2838,7 +2924,7 @@ function UsersScreen({
         if (!controller.signal.aborted) setRefreshing(false);
       }
     })();
-  }, [hideAdmins, windowDays]);
+  }, [hideAdmins, search, windowDays]);
 
   useEffect(() => {
     load();
@@ -2937,6 +3023,8 @@ function UsersScreen({
           onSignOut={() => void signOut()}
           onOpenAccount={onOpenAccount}
           onToggleFavorite={toggleFavorite}
+          query={query}
+          onQueryChange={changeQuery}
           refreshing={refreshing}
           onRefresh={load}
           now={now}

--- a/apps/web/tests/admin-users.test.ts
+++ b/apps/web/tests/admin-users.test.ts
@@ -7,6 +7,7 @@ import {
   type AdminUserListSource,
   buildAdminUserList,
   handleAdminUsers,
+  searchLikePattern,
 } from "../server/admin/admin-users";
 import {
   ADMIN_ERROR,
@@ -15,6 +16,8 @@ import {
   ADMIN_METRICS_WINDOW,
   ADMIN_METRICS_WINDOW_DEFAULT,
   ADMIN_METRICS_WINDOW_PARAM,
+  ADMIN_USERS_SEARCH_MAX_LENGTH,
+  ADMIN_USERS_SEARCH_PARAM,
   type AdminMetricsScope,
   type AdminMetricsWindow,
 } from "../server/admin/http";
@@ -41,15 +44,47 @@ function listSource(overrides: Partial<AdminUserListSource> = {}): AdminUserList
 }
 
 test("the roster is stamped with the window its aggregates cover", () => {
-  const list = buildAdminUserList(listSource({ total: 340 }), NOON_UTC, ADMIN_METRICS_WINDOW.MONTH);
+  const list = buildAdminUserList(
+    listSource({ total: 340 }),
+    NOON_UTC,
+    ADMIN_METRICS_WINDOW.MONTH,
+    undefined,
+  );
   assert.equal(list.generatedAt, NOON_UTC);
   assert.equal(list.windowDays, ADMIN_METRICS_WINDOW.MONTH);
   assert.equal(list.limit, ADMIN_USERS_LIMIT);
   assert.equal(list.total, 340);
+  assert.equal(list.search, undefined);
   assert.deepEqual(list.rows, [ROW]);
 
-  const quarter = buildAdminUserList(listSource(), NOON_UTC, ADMIN_METRICS_WINDOW.QUARTER);
+  const quarter = buildAdminUserList(
+    listSource(),
+    NOON_UTC,
+    ADMIN_METRICS_WINDOW.QUARTER,
+    undefined,
+  );
   assert.equal(quarter.windowDays, ADMIN_METRICS_WINDOW.QUARTER);
+});
+
+test("a searched roster echoes the term its rows and total were filtered by", () => {
+  const searched = buildAdminUserList(
+    listSource({ total: 3 }),
+    NOON_UTC,
+    ADMIN_METRICS_WINDOW.MONTH,
+    "ada",
+  );
+  assert.equal(searched.search, "ada");
+  assert.equal(searched.total, 3);
+  assert.equal(searched.limit, ADMIN_USERS_LIMIT);
+  assert.deepEqual(searched.rows, [ROW]);
+});
+
+test("a search pattern matches the term literally, wildcards escaped", () => {
+  assert.equal(searchLikePattern("ada"), "%ada%");
+  assert.equal(searchLikePattern("100%"), "%100\\%%");
+  assert.equal(searchLikePattern("a_b"), "%a\\_b%");
+  assert.equal(searchLikePattern("back\\slash"), "%back\\\\slash%");
+  assert.equal(searchLikePattern("%_\\"), "%\\%\\_\\\\%");
 });
 
 function usersRequest(method = "GET", query = ""): Request {
@@ -59,7 +94,7 @@ function usersRequest(method = "GET", query = ""): Request {
 const ADMIN_VIEWER: AdminViewer = { userId: "user-1", role: "admin" };
 
 const readUsers = async (now: number): Promise<AdminUserList> =>
-  buildAdminUserList(listSource(), now, ADMIN_METRICS_WINDOW_DEFAULT);
+  buildAdminUserList(listSource(), now, ADMIN_METRICS_WINDOW_DEFAULT, undefined);
 
 test("the gate answers 405, 401, 403, and 200 as distinct outcomes", async () => {
   const wrongMethod = await handleAdminUsers({
@@ -109,11 +144,12 @@ test("the roster is read at the scope and window the request asked for, as the v
     scope: AdminMetricsScope,
     viewerId: string,
     windowDays: AdminMetricsWindow,
+    search: string | undefined,
   ): Promise<AdminUserList> => {
     scopes.push(scope);
     viewerIds.push(viewerId);
     windows.push(windowDays);
-    return buildAdminUserList(listSource(), now, windowDays);
+    return buildAdminUserList(listSource(), now, windowDays, search);
   };
   const respond = (request: Request) =>
     handleAdminUsers({ request, resolveViewer: async () => ADMIN_VIEWER, readUsers: countingRead });
@@ -150,6 +186,64 @@ test("the roster is read at the scope and window the request asked for, as the v
   assert.equal(invalid.status, 400);
   assert.equal((await invalid.json()).error, ADMIN_ERROR.INVALID_WINDOW);
   assert.equal(scopes.length, 3);
+});
+
+test("the roster is searched by the term the request carried, trimmed, and only a real one", async () => {
+  const searches: (string | undefined)[] = [];
+  const countingRead = async (
+    now: number,
+    _scope: AdminMetricsScope,
+    _viewerId: string,
+    windowDays: AdminMetricsWindow,
+    search: string | undefined,
+  ): Promise<AdminUserList> => {
+    searches.push(search);
+    return buildAdminUserList(listSource({ total: 3 }), now, windowDays, search);
+  };
+  const respond = (query: string) =>
+    handleAdminUsers({
+      request: usersRequest("GET", query),
+      resolveViewer: async () => ADMIN_VIEWER,
+      readUsers: countingRead,
+    });
+
+  const searched = await respond(`?${ADMIN_USERS_SEARCH_PARAM}=${encodeURIComponent(" Ada ")}`);
+  assert.equal(searched.status, 200);
+  // SAFETY: handleAdminUsers answered 200, whose body is an AdminUserList document.
+  const body = (await searched.json()) as AdminUserList;
+  assert.equal(body.search, "Ada");
+  assert.equal(body.total, 3);
+
+  assert.equal((await respond("")).status, 200);
+  assert.equal((await respond(`?${ADMIN_USERS_SEARCH_PARAM}=`)).status, 200);
+  assert.equal(
+    (await respond(`?${ADMIN_USERS_SEARCH_PARAM}=${encodeURIComponent("   ")}`)).status,
+    200,
+  );
+  assert.deepEqual(searches, ["Ada", undefined, undefined, undefined]);
+});
+
+test("a term past the length bound is a 400 refusal that reaches no read", async () => {
+  let reads = 0;
+  const countingRead = async (now: number): Promise<AdminUserList> => {
+    reads += 1;
+    return buildAdminUserList(listSource(), now, ADMIN_METRICS_WINDOW_DEFAULT, undefined);
+  };
+  const respond = (term: string) =>
+    handleAdminUsers({
+      request: usersRequest("GET", `?${ADMIN_USERS_SEARCH_PARAM}=${encodeURIComponent(term)}`),
+      resolveViewer: async () => ADMIN_VIEWER,
+      readUsers: countingRead,
+    });
+
+  const atBound = await respond("a".repeat(ADMIN_USERS_SEARCH_MAX_LENGTH));
+  assert.equal(atBound.status, 200);
+  assert.equal(reads, 1);
+
+  const pastBound = await respond("a".repeat(ADMIN_USERS_SEARCH_MAX_LENGTH + 1));
+  assert.equal(pastBound.status, 400);
+  assert.equal((await pastBound.json()).error, ADMIN_ERROR.INVALID_SEARCH);
+  assert.equal(reads, 1);
 });
 
 test("a seam that throws is a 503 refusal rather than a crash", async () => {


### PR DESCRIPTION
## What

The Users roster fetches at most 200 rows ordered by recency, and the search box filtered only those client-side — the roster note even admitted that an account outside the newest 200 was unfindable. The one tool that names every account now searches every account: the users endpoint takes an optional search term, and the box on the Users tab reaches the whole roster through it.

## How

- **Wire vocabulary** (`apps/web/server/admin/http.ts`): a `search` query parameter beside `window` and `scope`. Search is freeform user text rather than a value set, so its validation is a length bound: absent or blank means no search, a term past 100 characters is refused with a 400 `invalid-search` rather than silently clipped to a search nobody asked for.
- **Query** (`apps/web/server/admin/admin-queries.ts`): the roster read keeps its exact shape — window-bounded usage left join, hide-admins scope, limit 200 — with one added condition: a case-insensitive `ilike` substring match over name and email. The term travels as a bound parameter, never interpolated into the SQL, and `searchLikePattern` escapes the term's own `%`, `_`, and `\` (backslash is Postgres's default escape), so a searched "100%" matches those characters instead of widening into a prefix scan. The total is counted under the same filter, so a truncated answer still says "N of M matching".
- **Response** (`apps/web/server/admin/admin-users.ts`): the list echoes the term it was filtered by, so the page words the caption for the answer it actually shows rather than for whatever is being typed.
- **Client** (`apps/web/src/AdminDashboard.tsx`): the existing search input debounces 250ms into a refetch carrying the term, while the instant client-side filter keeps working over the loaded rows between refetches. The term rides the page address as `?q=` the way `?days=` does — rewritten in place while typing so the back button walks views, not keystrokes — making a searched roster shareable and reload-proof. Sorting, the favorites star, the empty "No account matches." state, and the refresh-failure settling all keep working over searched results, and the roster note's truncation sentence now tells the truth for both the searched and unsearched case.
- **Tests** (`apps/web/tests/admin-users.test.ts`): term validation at the length bound (200 at the bound, 400 one past it, no read reached), trimming and blank-term handling, the escaped-wildcard pattern, and the shaping of a searched response.

## Verification

`./scripts/check.sh` passes (exit 0): repository, type, test, and build checks green, including the four new roster-search tests. Web-only change; no desktop surface touched, so no macOS/notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32544871290/artifacts/9468203134) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32544871290)

- Commit: `3def359d43aa7ba0fc89f2cb6695b1d07b1f4147`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
