### PR TITLE
fix(admin): tick the clock only where time is drawn

### DIFF
--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -1178,15 +1178,27 @@ function PageHeader({
   );
 }
 
+/** A clock of its own, so the header's age stays true without refetching to learn it. */
+function useNow(intervalMs: number): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), intervalMs);
+    return () => window.clearInterval(timer);
+  }, [intervalMs]);
+  return now;
+}
+
 function GeneratedStamp({
   generatedAt,
   windowDays,
-  now,
 }: {
   generatedAt: number;
   windowDays: number;
-  now: number;
 }): React.JSX.Element {
+  // The tick lives here, on the one component that draws relative time. At a
+  // screen root it would re-render every chart and table each 30 s to move
+  // this one string.
+  const now = useNow(AGE_TICK_MS);
   return (
     <span
       className="font-mono text-xs text-muted-foreground"
@@ -1728,7 +1740,6 @@ function Dashboard({
   refreshing,
   onRefresh,
   onOpenAccount,
-  now,
 }: {
   metrics: AdminMetrics;
   refreshFailure: string | undefined;
@@ -1741,7 +1752,6 @@ function Dashboard({
   refreshing: boolean;
   onRefresh: () => void;
   onOpenAccount: (id: string) => void;
-  now: number;
 }): React.JSX.Element {
   const db = metrics.systemHealth.database;
 
@@ -1755,11 +1765,7 @@ function Dashboard({
           <>
             <WindowSwitcher value={windowDays} onChange={onWindowDaysChange} />
             <HideAdminsToggle checked={hideAdmins} onChange={onHideAdminsChange} />
-            <GeneratedStamp
-              generatedAt={metrics.generatedAt}
-              windowDays={metrics.windowDays}
-              now={now}
-            />
+            <GeneratedStamp generatedAt={metrics.generatedAt} windowDays={metrics.windowDays} />
             <button
               type="button"
               className={PLAIN_BUTTON}
@@ -2091,7 +2097,6 @@ function UserDetailPage({
   onBack,
   refreshing,
   onRefresh,
-  now,
 }: {
   detail: AdminUserDetail;
   refreshFailure: string | undefined;
@@ -2100,7 +2105,6 @@ function UserDetailPage({
   onBack: () => void;
   refreshing: boolean;
   onRefresh: () => void;
-  now: number;
 }): React.JSX.Element {
   const subject: AdminUserAccount = detail.account;
   const activity = detail.activity;
@@ -2119,11 +2123,7 @@ function UserDetailPage({
         onSignOut={onSignOut}
         controls={
           <>
-            <GeneratedStamp
-              generatedAt={detail.generatedAt}
-              windowDays={detail.windowDays}
-              now={now}
-            />
+            <GeneratedStamp generatedAt={detail.generatedAt} windowDays={detail.windowDays} />
             <button
               type="button"
               className={PLAIN_BUTTON}
@@ -2737,7 +2737,6 @@ function UsersPage({
   onQueryChange,
   refreshing,
   onRefresh,
-  now,
 }: {
   list: AdminUserList;
   refreshFailure: string | undefined;
@@ -2753,7 +2752,6 @@ function UsersPage({
   onQueryChange: (query: string) => void;
   refreshing: boolean;
   onRefresh: () => void;
-  now: number;
 }): React.JSX.Element {
   // The service searches the whole roster once the debounce settles; until
   // that answer lands, the same needle filters the rows already loaded, so
@@ -2773,7 +2771,7 @@ function UsersPage({
           <>
             <WindowSwitcher value={windowDays} onChange={onWindowDaysChange} />
             <HideAdminsToggle checked={hideAdmins} onChange={onHideAdminsChange} />
-            <GeneratedStamp generatedAt={list.generatedAt} windowDays={list.windowDays} now={now} />
+            <GeneratedStamp generatedAt={list.generatedAt} windowDays={list.windowDays} />
             <button
               type="button"
               className={PLAIN_BUTTON}
@@ -2838,7 +2836,6 @@ function UsersScreen({
   onSignOut,
   onOpenAccount,
   frame,
-  now,
 }: {
   hideAdmins: boolean;
   onHideAdminsChange: (hide: boolean) => void;
@@ -2849,7 +2846,6 @@ function UsersScreen({
   onOpenAccount: (id: string) => void;
   /** Applied around every answer but the gate's own cards, which stand alone. */
   frame: (content: React.JSX.Element) => React.JSX.Element;
-  now: number;
 }): React.JSX.Element {
   const [state, setState] = useState<UsersState>(() =>
     signInChosenHere() ? { status: "loading" } : { status: "signed-out" },
@@ -3027,7 +3023,6 @@ function UsersScreen({
           onQueryChange={changeQuery}
           refreshing={refreshing}
           onRefresh={load}
-          now={now}
         />,
       );
   }
@@ -3039,7 +3034,6 @@ function UserDetailScreen({
   onSignOut,
   onBack,
   frame,
-  now,
 }: {
   id: string;
   account: ViewerAccount | undefined;
@@ -3047,7 +3041,6 @@ function UserDetailScreen({
   onBack: () => void;
   /** Applied around every answer but the gate's own cards, which stand alone. */
   frame: (content: React.JSX.Element) => React.JSX.Element;
-  now: number;
 }): React.JSX.Element {
   const [state, setState] = useState<DetailState>(() =>
     signInChosenHere() ? { status: "loading" } : { status: "signed-out" },
@@ -3156,20 +3149,9 @@ function UserDetailScreen({
           onBack={onBack}
           refreshing={refreshing}
           onRefresh={load}
-          now={now}
         />,
       );
   }
-}
-
-/** A clock of its own, so the header's age stays true without refetching to learn it. */
-function useNow(intervalMs: number): number {
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    const timer = window.setInterval(() => setNow(Date.now()), intervalMs);
-    return () => window.clearInterval(timer);
-  }, [intervalMs]);
-  return now;
 }
 
 export function AdminDashboard(): React.JSX.Element {
@@ -3189,7 +3171,6 @@ export function AdminDashboard(): React.JSX.Element {
   };
   const [refreshing, setRefreshing] = useState(false);
   const inFlight = useRef<AbortController>(null);
-  const now = useNow(AGE_TICK_MS);
   const session = authClient.useSession();
   const account = session.data?.user;
 
@@ -3325,7 +3306,6 @@ export function AdminDashboard(): React.JSX.Element {
         onSignOut={signOut}
         onBack={() => navigate("users")}
         frame={(content) => shell("users", content)}
-        now={now}
       />
     );
   }
@@ -3341,7 +3321,6 @@ export function AdminDashboard(): React.JSX.Element {
         onSignOut={signOut}
         onOpenAccount={openAccount}
         frame={(content) => shell("users", content)}
-        now={now}
       />
     );
   }
@@ -3390,7 +3369,6 @@ export function AdminDashboard(): React.JSX.Element {
           refreshing={refreshing}
           onRefresh={load}
           onOpenAccount={openAccount}
-          now={now}
         />,
       );
   }


### PR DESCRIPTION
## What

The admin dashboard's 30-second age tick (`useNow(AGE_TICK_MS)`) lived at the screen root, so every tick re-rendered the entire active screen — the recharts charts, the retention grid, and both account tables — purely to move the header's one "generated N min ago" string. The tick now lives inside `GeneratedStamp`, the one component that draws relative time, so a tick redraws that single span and nothing else. The stamp still updates every 30 seconds, exactly as before.

## How

- Moved the `useNow` hook definition beside `GeneratedStamp` and made the stamp subscribe to it itself, with a comment stating why the tick lives there and must not return to a screen root.
- Removed the root subscription in `AdminDashboard` and the `now` prop threading through `Dashboard`, `UsersScreen`/`UsersPage`, and `UserDetailScreen`/`UserDetailPage` — all of it existed only to reach the stamp.
- Everything that needs the response's generation moment keeps reading `generatedAt` from the answer itself: the charts' partial-day fade, and the stamp's `title` attribute (the absolute UTC timestamp), which stays static.

## Verification

- `./scripts/check.sh` passed (exit code 0): repository checks, types, tests, and builds all green.
- Render behavior verified by reasoned audit rather than instrumentation, stated honestly: `grep` confirms `formatAge` is the file's only relative-time formatter and `GeneratedStamp` its only caller, and after the change the only `now` references in the file are inside `useNow` and `GeneratedStamp`. Nothing else silently depended on the periodic re-render — `RefreshFailureNotice`'s wording is a pure function of its `failure`/`refreshing` props, no notice ages out on a timer, and the partial-day fade keys off the response's `generatedAt`, not the clock. Since no component between the root and the stamp is memoized, the root tick previously re-rendered the whole tree each 30 s; with the state moved into the leaf, React re-renders only the stamp's subtree (one `span`).
- Behavior is identical to the eye: same hook, same 30-second cadence, `Date.now()` read fresh at mount and on each tick.
- Web-only change; no desktop surface touched, so no macOS/notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32545421554/artifacts/9468375255) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32545421554)

- Commit: `038634a3a2b19f44740686a9540fa93f7f1b638e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
