### PR TITLE
feat(admin): give the account page the same window switcher

### DIFF
--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -1642,10 +1642,14 @@ function UsersSkeleton({
 }
 
 function AccountSkeleton({
+  windowDays,
+  onWindowDaysChange,
   account,
   onSignOut,
   onBack,
 }: {
+  windowDays: AdminMetricsWindow;
+  onWindowDaysChange: (windowDays: AdminMetricsWindow) => void;
   account: ViewerAccount | undefined;
   onSignOut: () => void;
   onBack: () => void;
@@ -1658,6 +1662,7 @@ function AccountSkeleton({
         onSignOut={onSignOut}
         controls={
           <>
+            <WindowSwitcher value={windowDays} onChange={onWindowDaysChange} />
             <SkeletonLine box="h-4" bone="h-3 w-48" />
             <button type="button" className={PLAIN_BUTTON} disabled>
               Loading…
@@ -2092,6 +2097,8 @@ function signInMethodLabel(providerId: string): string {
 function UserDetailPage({
   detail,
   refreshFailure,
+  windowDays,
+  onWindowDaysChange,
   account,
   onSignOut,
   onBack,
@@ -2100,6 +2107,8 @@ function UserDetailPage({
 }: {
   detail: AdminUserDetail;
   refreshFailure: string | undefined;
+  windowDays: AdminMetricsWindow;
+  onWindowDaysChange: (windowDays: AdminMetricsWindow) => void;
   account: ViewerAccount | undefined;
   onSignOut: () => void;
   onBack: () => void;
@@ -2123,6 +2132,7 @@ function UserDetailPage({
         onSignOut={onSignOut}
         controls={
           <>
+            <WindowSwitcher value={windowDays} onChange={onWindowDaysChange} />
             <GeneratedStamp generatedAt={detail.generatedAt} windowDays={detail.windowDays} />
             <button
               type="button"
@@ -3030,12 +3040,16 @@ function UsersScreen({
 
 function UserDetailScreen({
   id,
+  windowDays,
+  onWindowDaysChange,
   account,
   onSignOut,
   onBack,
   frame,
 }: {
   id: string;
+  windowDays: AdminMetricsWindow;
+  onWindowDaysChange: (windowDays: AdminMetricsWindow) => void;
   account: ViewerAccount | undefined;
   onSignOut: () => Promise<void>;
   onBack: () => void;
@@ -3080,7 +3094,12 @@ function UserDetailScreen({
         : { status: "loading" },
     );
     setRefreshing(true);
-    const path = `${USER_DETAIL_PATH}?${ADMIN_USER_ID_PARAM}=${encodeURIComponent(id)}`;
+    const params = new URLSearchParams();
+    params.set(ADMIN_USER_ID_PARAM, id);
+    if (windowDays !== ADMIN_METRICS_WINDOW_DEFAULT) {
+      params.set(ADMIN_METRICS_WINDOW_PARAM, String(windowDays));
+    }
+    const path = `${USER_DETAIL_PATH}?${params.toString()}`;
     void (async () => {
       try {
         const next = await readDetailState(
@@ -3101,7 +3120,7 @@ function UserDetailScreen({
         if (!controller.signal.aborted) setRefreshing(false);
       }
     })();
-  }, [id]);
+  }, [id, windowDays]);
 
   useEffect(() => {
     load();
@@ -3111,7 +3130,13 @@ function UserDetailScreen({
   switch (state.status) {
     case "loading":
       return frame(
-        <AccountSkeleton account={account} onSignOut={() => void signOut()} onBack={onBack} />,
+        <AccountSkeleton
+          windowDays={windowDays}
+          onWindowDaysChange={onWindowDaysChange}
+          account={account}
+          onSignOut={() => void signOut()}
+          onBack={onBack}
+        />,
       );
     case "signed-out":
       return <SignInCard />;
@@ -3144,6 +3169,8 @@ function UserDetailScreen({
         <UserDetailPage
           detail={state.detail}
           refreshFailure={state.refreshFailure}
+          windowDays={windowDays}
+          onWindowDaysChange={onWindowDaysChange}
           account={account}
           onSignOut={() => void signOut()}
           onBack={onBack}
@@ -3302,6 +3329,8 @@ export function AdminDashboard(): React.JSX.Element {
     return (
       <UserDetailScreen
         id={view.id}
+        windowDays={windowDays}
+        onWindowDaysChange={changeWindow}
         account={viewer}
         onSignOut={signOut}
         onBack={() => navigate("users")}


### PR DESCRIPTION
## What

The account detail page now carries the same 7/30/90-day window switcher the dashboard and Users views already have. The chosen window rides the same `?days=` URL param, composing with the existing `?user=<id>`, so a 90-day account view is shareable, survives a reload, and is kept when navigating dashboard → account → back.

## How

- `UserDetailScreen` takes the page's shared `windowDays`/`onWindowDaysChange`, sends the non-default window on the `GET /api/admin/user` request (`window` query param, which the endpoint already validates), and refetches on a window flip the way the other views do — the standing answer stays up, dimmed, until the new one lands.
- `UserDetailPage` and `AccountSkeleton` draw the `WindowSwitcher` in their headers, in the same position the other views give it; the switcher's press goes through the existing `changeWindow`/`windowHref`, which rewrites `?days=` in place while preserving `?user=`.
- The page's wordings already follow the response's `windowDays` ("Active days · N days", the "of N window days" fraction, the streak's "N+" cap, "Voice/Attention/Throttled days · N days"), so they move with the window mechanically; the all-time figures and the 7-day trend keep their own meanings. Links between views (`accountHref`, `tabHref`) already carry `?days=` through `hrefWithWindow`, so no link changes were needed.
- No server change: the user endpoint already reads and validates the window, and `apps/web/tests/admin-user.test.ts` already covers a non-default window's shaping (the 7-day test asserts the narrowed series, window counts, trends, and the echoed `windowDays`) and the handler's window param and 400 on an out-of-set value.

## Verification

- `./scripts/check.sh` passes (exit 0: generated files up to date, design and repository contract checks passed, lint, typecheck, all workspace tests, and build all green). One earlier run tripped on two desktop-native tests (`apple-calendar.test.ts`, `output-volume.test.ts`) untouched by this change; both pass standalone and in the full rerun.
- Web-only change; no desktop surface touched, so no macOS/notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32546103864/artifacts/9468565922) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32546103864)

- Commit: `3bd2077d3b659ccc780f691166a4a4bcf6f8ac2e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
