### PR TITLE
chore(admin): drop the window label the switcher already states

### DIFF
--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -1188,13 +1188,7 @@ function useNow(intervalMs: number): number {
   return now;
 }
 
-function GeneratedStamp({
-  generatedAt,
-  windowDays,
-}: {
-  generatedAt: number;
-  windowDays: number;
-}): React.JSX.Element {
+function GeneratedStamp({ generatedAt }: { generatedAt: number }): React.JSX.Element {
   // The tick lives here, on the one component that draws relative time. At a
   // screen root it would re-render every chart and table each 30 s to move
   // this one string.
@@ -1204,7 +1198,7 @@ function GeneratedStamp({
       className="font-mono text-xs text-muted-foreground"
       title={`${formatTimestamp(generatedAt)} UTC`}
     >
-      {windowDays}-day window · generated {formatAge(Math.max(0, now - generatedAt))}
+      generated {formatAge(Math.max(0, now - generatedAt))}
     </span>
   );
 }
@@ -1524,7 +1518,7 @@ function DashboardSkeleton({
           <>
             <WindowSwitcher value={windowDays} onChange={onWindowDaysChange} />
             <HideAdminsToggle checked={hideAdmins} onChange={onHideAdminsChange} />
-            <SkeletonLine box="h-4" bone="h-3 w-48" />
+            <SkeletonLine box="h-4" bone="h-3 w-28" />
             <button type="button" className={PLAIN_BUTTON} disabled>
               Loading…
             </button>
@@ -1621,7 +1615,7 @@ function UsersSkeleton({
           <>
             <WindowSwitcher value={windowDays} onChange={onWindowDaysChange} />
             <HideAdminsToggle checked={hideAdmins} onChange={onHideAdminsChange} />
-            <SkeletonLine box="h-4" bone="h-3 w-48" />
+            <SkeletonLine box="h-4" bone="h-3 w-28" />
             <button type="button" className={PLAIN_BUTTON} disabled>
               Loading…
             </button>
@@ -1663,7 +1657,7 @@ function AccountSkeleton({
         controls={
           <>
             <WindowSwitcher value={windowDays} onChange={onWindowDaysChange} />
-            <SkeletonLine box="h-4" bone="h-3 w-48" />
+            <SkeletonLine box="h-4" bone="h-3 w-28" />
             <button type="button" className={PLAIN_BUTTON} disabled>
               Loading…
             </button>
@@ -1770,7 +1764,7 @@ function Dashboard({
           <>
             <WindowSwitcher value={windowDays} onChange={onWindowDaysChange} />
             <HideAdminsToggle checked={hideAdmins} onChange={onHideAdminsChange} />
-            <GeneratedStamp generatedAt={metrics.generatedAt} windowDays={metrics.windowDays} />
+            <GeneratedStamp generatedAt={metrics.generatedAt} />
             <button
               type="button"
               className={PLAIN_BUTTON}
@@ -2133,7 +2127,7 @@ function UserDetailPage({
         controls={
           <>
             <WindowSwitcher value={windowDays} onChange={onWindowDaysChange} />
-            <GeneratedStamp generatedAt={detail.generatedAt} windowDays={detail.windowDays} />
+            <GeneratedStamp generatedAt={detail.generatedAt} />
             <button
               type="button"
               className={PLAIN_BUTTON}
@@ -2781,7 +2775,7 @@ function UsersPage({
           <>
             <WindowSwitcher value={windowDays} onChange={onWindowDaysChange} />
             <HideAdminsToggle checked={hideAdmins} onChange={onHideAdminsChange} />
-            <GeneratedStamp generatedAt={list.generatedAt} windowDays={list.windowDays} />
+            <GeneratedStamp generatedAt={list.generatedAt} />
             <button
               type="button"
               className={PLAIN_BUTTON}


### PR DESCRIPTION
## What

Every admin page header showed a stamp reading like "30-day window · generated 4 min ago" directly beside the 7d/30d/90d window switcher, so the "N-day window" phrase restated what the control beside it already says. The stamp now reads only "generated 4 min ago".

## How

- `GeneratedStamp` loses its `windowDays` prop and the window phrase; the "generated N min ago" text and its absolute-time `title` attribute are unchanged.
- All three call sites (dashboard, users, account detail) drop the prop; each renders the stamp beside the switcher, so no surface keeps the phrase.
- The three loading skeletons' header stamp placeholders shrink from `w-48` to `w-28` to match the shorter string.

No tests assert the stamp's wording; the "day window" mentions in `apps/web/tests` cover server-side windowing logic and are untouched.

## Verification

- `./scripts/check.sh` passes (exit 0; an apple-calendar/microphone-route desktop test flake on the first run passed standalone and on a clean re-run).
- Web-only change; no desktop surface touched, so no macOS/notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32547114345/artifacts/9468895487) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32547114345)

- Commit: `9e54af5d40d76b250faca26ffcf5302339a99bfb`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
