### PR TITLE
feat(admin): open a day's accounts from the usage chart

### DIFF
--- a/apps/web/api/admin/day.ts
+++ b/apps/web/api/admin/day.ts
@@ -1,0 +1,23 @@
+import { buildAdminDayDetail, handleAdminDay } from "../../server/admin/admin-day.js";
+import { readAdminDaySource } from "../../server/admin/admin-queries.js";
+import { resolveSessionViewer } from "../../server/admin/viewer.js";
+import { getDatabase } from "../../server/db/index.js";
+
+/**
+ * One day of the overview's usage chart, opened into its accounts. The gate
+ * and the day validation live behind seams in `server/admin/`; this file
+ * hands them the deployment's real session resolver and database. The day
+ * arrives validated as a real UTC calendar key and lands in one equality
+ * against the usage table's day column — it is never rendered back and never
+ * reaches a write.
+ */
+export default {
+  fetch(request: Request): Promise<Response> {
+    return handleAdminDay({
+      request,
+      resolveViewer: resolveSessionViewer,
+      readDay: async (day, now, scope) =>
+        buildAdminDayDetail(await readAdminDaySource(getDatabase(), { day, scope }), now, day),
+    });
+  },
+};

--- a/apps/web/server/admin/admin-day.ts
+++ b/apps/web/server/admin/admin-day.ts
@@ -1,0 +1,135 @@
+import type { AdminViewer } from "./admin-access.js";
+import { isAdminRole } from "./admin-access.js";
+import {
+  ADMIN_ERROR,
+  ADMIN_HTTP_STATUS,
+  type AdminMetricsScope,
+  adminDayKey,
+  adminMetricsScope,
+  errorResponse,
+  jsonResponse,
+} from "./http.js";
+
+/**
+ * One UTC day of the overview's usage chart opened into the accounts behind
+ * it, answering the question the bar cannot: forty calls that day, but whose?
+ * It reads the same hosted-usage rows the chart's series aggregates — one row
+ * per account per day, the service's own metering — behind the same admin
+ * gate and the same scope, and it widens no analytics event: nothing here is
+ * read off a user's machine.
+ */
+
+/**
+ * How many of the day's accounts one read returns, busiest first. The bound
+ * exists so a heavy day degrades to a stated truncation — the totals still
+ * count everyone — rather than an unbounded response.
+ */
+export const ADMIN_DAY_ACCOUNTS_LIMIT = 50;
+
+/** One account's share of the day, the same account fields the tables draw. */
+export interface AdminDayAccount {
+  id: string;
+  name: string;
+  email: string;
+  /** The avatar URL the sign-in provider gave the account, when it gave one. */
+  image: string | null;
+  admin: boolean;
+  voiceCalls: number;
+  attentionReviews: number;
+  total: number;
+}
+
+/** The whole day's counts, over every account the scope keeps, past the row bound. */
+export interface AdminDayTotals {
+  accounts: number;
+  voiceCalls: number;
+  attentionReviews: number;
+}
+
+/**
+ * The raw shape the queries produce for one day. The rows arrive bounded and
+ * ordered, so the totals ride their own aggregate read — folding them from
+ * the rows would state a truncated day's totals short.
+ */
+export interface AdminDaySource {
+  accounts: readonly AdminDayAccount[];
+  totals: AdminDayTotals;
+}
+
+export interface AdminDayDetail {
+  generatedAt: number;
+  /** The UTC day the counts cover, as YYYY-MM-DD. */
+  day: string;
+  /** The bound `accounts` was read under, so the page can word a truncation. */
+  limit: number;
+  totals: AdminDayTotals & { total: number };
+  /** The day's active accounts, busiest first, cut at the stated bound. */
+  accounts: AdminDayAccount[];
+}
+
+/** Stamps one day's queried source with the day it covers and the bound it was read under. */
+export function buildAdminDayDetail(
+  source: AdminDaySource,
+  now: number,
+  day: string,
+): AdminDayDetail {
+  return {
+    generatedAt: now,
+    day,
+    limit: ADMIN_DAY_ACCOUNTS_LIMIT,
+    totals: {
+      ...source.totals,
+      total: source.totals.voiceCalls + source.totals.attentionReviews,
+    },
+    accounts: [...source.accounts],
+  };
+}
+
+export interface AdminDayOptions {
+  request: Request;
+  resolveViewer: (request: Request) => Promise<AdminViewer | undefined>;
+  readDay: (day: string, now: number, scope: AdminMetricsScope) => Promise<AdminDayDetail>;
+  now?: () => number;
+}
+
+/**
+ * Answers one day's read behind the same gate the overview's metrics stand
+ * behind, with the same distinct refusals, plus one of its own: a request
+ * naming no real UTC calendar day is a 400 before any seam is touched. A real
+ * day nobody spent anything on is an ordinary 200 with empty rows — unlike an
+ * account, a day cannot be gone, so there is no 404 here.
+ */
+export async function handleAdminDay(options: AdminDayOptions): Promise<Response> {
+  const { request } = options;
+  if (request.method !== "GET") {
+    return errorResponse(ADMIN_HTTP_STATUS.METHOD_NOT_ALLOWED, ADMIN_ERROR.METHOD_NOT_ALLOWED);
+  }
+
+  let viewer: AdminViewer | undefined;
+  try {
+    viewer = await options.resolveViewer(request);
+  } catch {
+    return errorResponse(ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE, ADMIN_ERROR.UNAVAILABLE);
+  }
+  if (!viewer) {
+    return errorResponse(ADMIN_HTTP_STATUS.UNAUTHORIZED, ADMIN_ERROR.NOT_SIGNED_IN);
+  }
+  if (!isAdminRole(viewer.role)) {
+    return errorResponse(ADMIN_HTTP_STATUS.FORBIDDEN, ADMIN_ERROR.NOT_AUTHORIZED);
+  }
+
+  const day = adminDayKey(request.url);
+  if (day === undefined) {
+    return errorResponse(ADMIN_HTTP_STATUS.BAD_REQUEST, ADMIN_ERROR.INVALID_DAY);
+  }
+
+  const now = (options.now ?? Date.now)();
+  try {
+    return jsonResponse(
+      ADMIN_HTTP_STATUS.OK,
+      await options.readDay(day, now, adminMetricsScope(request.url)),
+    );
+  } catch {
+    return errorResponse(ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE, ADMIN_ERROR.UNAVAILABLE);
+  }
+}

--- a/apps/web/server/admin/admin-queries.ts
+++ b/apps/web/server/admin/admin-queries.ts
@@ -20,6 +20,7 @@ import { account, session, user } from "../db/schema.js";
 import { hostedUsage } from "../db/usage-schema.js";
 import { HOSTED_DAILY_LIMIT, HOSTED_METER, utcDayKey } from "../hosted/quota.js";
 import { isAdminRole, USER_ROLE } from "./admin-access.js";
+import { ADMIN_DAY_ACCOUNTS_LIMIT, type AdminDaySource } from "./admin-day.js";
 import {
   ADMIN_RETENTION_WEEKS,
   type AdminIntegration,
@@ -462,6 +463,70 @@ export async function readAdminUserSource(
         attentionReviews: toNumber(allTimeRow?.attentionReviews),
       },
       quotaLimitedDaysWindow: toNumber(quotaRow?.value),
+    },
+  };
+}
+
+/**
+ * Reads one UTC day's active accounts with the day's totals. The usage table
+ * holds one row per account per day, so each bounded row is already the
+ * account's whole day and needs no aggregation; the totals ride their own
+ * aggregate read because the rows are cut at the bound. Busiest first, with
+ * voice breaking ties so equal days keep a stable order across refreshes.
+ * Like the account detail, this has no probe and no empty fallback: a
+ * database that does not answer throws into the handler's 503.
+ */
+export async function readAdminDaySource(
+  database: Database,
+  input: { day: string; scope: AdminMetricsScope },
+): Promise<AdminDaySource> {
+  const kept = and(eq(hostedUsage.day, input.day), scopeCondition(input.scope));
+
+  const [accountRows, [totalsRow]] = await Promise.all([
+    database
+      .select({
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        image: user.image,
+        role: user.role,
+        voiceCalls: hostedUsage.voiceCalls,
+        attentionReviews: hostedUsage.attentionReviews,
+      })
+      .from(hostedUsage)
+      .innerJoin(user, eq(hostedUsage.userId, user.id))
+      .where(kept)
+      .orderBy(
+        desc(sql`${hostedUsage.voiceCalls} + ${hostedUsage.attentionReviews}`),
+        desc(hostedUsage.voiceCalls),
+      )
+      .limit(ADMIN_DAY_ACCOUNTS_LIMIT),
+    database
+      .select({
+        accounts: count(),
+        voiceCalls: sum(hostedUsage.voiceCalls),
+        attentionReviews: sum(hostedUsage.attentionReviews),
+      })
+      .from(hostedUsage)
+      .innerJoin(user, eq(hostedUsage.userId, user.id))
+      .where(kept),
+  ]);
+
+  return {
+    accounts: accountRows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      email: row.email,
+      image: row.image,
+      admin: isAdminRole(row.role),
+      voiceCalls: row.voiceCalls,
+      attentionReviews: row.attentionReviews,
+      total: row.voiceCalls + row.attentionReviews,
+    })),
+    totals: {
+      accounts: toNumber(totalsRow?.accounts),
+      voiceCalls: toNumber(totalsRow?.voiceCalls),
+      attentionReviews: toNumber(totalsRow?.attentionReviews),
     },
   };
 }

--- a/apps/web/server/admin/http.ts
+++ b/apps/web/server/admin/http.ts
@@ -30,6 +30,8 @@ export const ADMIN_ERROR = {
   INVALID_WINDOW: "invalid-window",
   /** A roster read whose search term ran past the length bound. */
   INVALID_SEARCH: "invalid-search",
+  /** A day read that named no real UTC calendar day. */
+  INVALID_DAY: "invalid-day",
   /** The named account has no user row — deleted, or the id never existed. */
   USER_NOT_FOUND: "user-not-found",
   /** A seam (auth or the database) did not answer; the answer is a JSON refusal, never a crash. */
@@ -119,6 +121,29 @@ export function adminUsersSearch(url: string): { term: string | undefined } | un
   if (value.length > ADMIN_USERS_SEARCH_MAX_LENGTH) return undefined;
   const term = value.trim();
   return { term: term.length === 0 ? undefined : term };
+}
+
+export const ADMIN_DAY_PARAM = "date";
+
+const UTC_DAY_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Whether a value names a real UTC calendar day. The shape check alone is not
+ * enough: V8 parses `2026-02-30` by rolling it into March, so a wearer of the
+ * shape must also survive the round trip back to the same key. Exported
+ * because the page validates a pasted day address with the same reading the
+ * endpoint refuses on.
+ */
+export function isUtcDayKey(value: string): boolean {
+  if (!UTC_DAY_KEY_PATTERN.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+}
+
+/** The UTC day a detail read named, or nothing when it named no real one. */
+export function adminDayKey(url: string): string | undefined {
+  const value = new URL(url).searchParams.get(ADMIN_DAY_PARAM) ?? "";
+  return isUtcDayKey(value) ? value : undefined;
 }
 
 export const ADMIN_USER_ID_PARAM = "id";

--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -1,6 +1,7 @@
 import { createAuthClient } from "better-auth/react";
 import { Fragment, useCallback, useEffect, useRef, useState } from "react";
 import { Bar, BarChart, CartesianGrid, Cell, LabelList, XAxis, YAxis } from "recharts";
+import type { AdminDayAccount, AdminDayDetail } from "../server/admin/admin-day";
 import type {
   AdminDailySignups,
   AdminDailyUsage,
@@ -12,6 +13,7 @@ import type {
 import type { AdminUserAccount, AdminUserDetail } from "../server/admin/admin-user";
 import type { AdminUserList, AdminUserListRow } from "../server/admin/admin-users";
 import {
+  ADMIN_DAY_PARAM,
   ADMIN_HTTP_STATUS,
   ADMIN_METRICS_SCOPE,
   ADMIN_METRICS_SCOPE_PARAM,
@@ -22,6 +24,7 @@ import {
   ADMIN_USERS_SEARCH_MAX_LENGTH,
   ADMIN_USERS_SEARCH_PARAM,
   type AdminMetricsWindow,
+  isUtcDayKey,
 } from "../server/admin/http";
 import { accountInitials } from "./account-initials";
 import { accountLabel } from "./account-label";
@@ -54,6 +57,7 @@ const METRICS_PATH = "/api/admin/metrics";
 const USER_DETAIL_PATH = "/api/admin/user";
 const USERS_PATH = "/api/admin/users";
 const FAVORITE_PATH = "/api/admin/favorite";
+const DAY_DETAIL_PATH = "/api/admin/day";
 
 /**
  * The page's own addresses, distinct from the API's parameters so a pasted
@@ -63,6 +67,7 @@ const FAVORITE_PATH = "/api/admin/favorite";
  * endpoint's gate, never into anything rendered.
  */
 const ACCOUNT_VIEW_PARAM = "user";
+const DAY_VIEW_PARAM = "day";
 const TAB_PARAM = "view";
 const USERS_TAB_VALUE = "users";
 const WINDOW_VIEW_PARAM = "days";
@@ -78,12 +83,20 @@ const SEARCH_DEBOUNCE_MS = 250;
 type AdminTab = "dashboard" | "users";
 
 /** Which of the page's views the address bar names. */
-type AdminView = { kind: "dashboard" } | { kind: "users" } | { kind: "account"; id: string };
+type AdminView =
+  | { kind: "dashboard" }
+  | { kind: "users" }
+  | { kind: "account"; id: string }
+  | { kind: "day"; day: string };
 
 function viewFromLocation(): AdminView {
   const params = new URLSearchParams(window.location.search);
   const id = params.get(ACCOUNT_VIEW_PARAM);
   if (id) return { kind: "account", id };
+  // An address naming no real UTC day is the plain dashboard rather than a
+  // broken page, the same reading an out-of-set window gets.
+  const day = params.get(DAY_VIEW_PARAM);
+  if (day !== null && isUtcDayKey(day)) return { kind: "day", day };
   if (params.get(TAB_PARAM) === USERS_TAB_VALUE) return { kind: "users" };
   return { kind: "dashboard" };
 }
@@ -149,6 +162,12 @@ function hrefWithWindow(params: URLSearchParams): string {
 function accountHref(id: string): string {
   const params = new URLSearchParams();
   params.set(ACCOUNT_VIEW_PARAM, id);
+  return hrefWithWindow(params);
+}
+
+function dayHref(day: string): string {
+  const params = new URLSearchParams();
+  params.set(DAY_VIEW_PARAM, day);
   return hrefWithWindow(params);
 }
 
@@ -294,6 +313,7 @@ const ERROR_DETAIL = {
   METRICS: "The metrics endpoint did not answer. Try again shortly.",
   USERS: "The users endpoint did not answer. Try again shortly.",
   ACCOUNT: "The account endpoint did not answer. Try again shortly.",
+  DAY: "The day endpoint did not answer. Try again shortly.",
 } as const;
 
 const numberFormat = new Intl.NumberFormat("en-US");
@@ -323,6 +343,14 @@ function formatDayTick(day: string): string {
   return new Date(`${day}T00:00:00.000Z`).toLocaleDateString("en-US", {
     month: "short",
     day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+/** A day key drawn as the day page's own masthead, e.g. "August 21, 2026". */
+function formatDayHeading(day: string): string {
+  return new Date(`${day}T00:00:00.000Z`).toLocaleDateString("en-US", {
+    dateStyle: "long",
     timeZone: "UTC",
   });
 }
@@ -437,18 +465,24 @@ const USAGE_CHART = {
  * visible; the tooltip carries each day's exact numbers, and the legend names
  * the two series. A window with no calls at all says so instead of drawing
  * the server's zero-fill as a flat measurement, and today's bar wears the
- * partial-day fade.
+ * partial-day fade. Where a day has a roster to open, a click anywhere in a
+ * day's column opens it — read from the chart's own axis datum, so either
+ * stacked segment and the hover band between them land on the same day —
+ * and the pointer says so; one account's chart passes no opener, because
+ * its day needs no roster.
  */
 function UsageChart({
   daily,
   trend,
   label,
   generatedAt,
+  onOpenDay,
 }: {
   daily: readonly AdminDailyUsage[];
   trend: AdminTrend;
   label: string;
   generatedAt: number;
+  onOpenDay?: (day: string) => void;
 }): React.JSX.Element {
   if (seriesHasNoData(daily.map((point) => point.voiceCalls + point.attentionReviews))) {
     return (
@@ -465,8 +499,23 @@ function UsageChart({
   return (
     <div className="rounded-lg border border-border bg-card p-5">
       <ChartHeading label={label} trend={trend} />
-      <ChartContainer config={USAGE_CHART} className="aspect-auto h-48 w-full">
-        <BarChart data={[...daily]}>
+      <ChartContainer
+        config={USAGE_CHART}
+        className={`aspect-auto h-48 w-full ${onOpenDay ? "cursor-pointer" : ""}`}
+      >
+        <BarChart
+          data={[...daily]}
+          // The clicked label is resolved against the drawn series itself, so
+          // only a day these bars actually state can open.
+          onClick={
+            onOpenDay
+              ? ({ activeLabel }) => {
+                  const clicked = daily.find((point) => point.day === activeLabel);
+                  if (clicked) onOpenDay(clicked.day);
+                }
+              : undefined
+          }
+        >
           <CartesianGrid vertical={false} />
           <XAxis
             dataKey="day"
@@ -1710,6 +1759,68 @@ function AccountSkeleton({
   );
 }
 
+function DaySkeleton({
+  day,
+  hideAdmins,
+  onHideAdminsChange,
+  account,
+  onSignOut,
+  onBack,
+}: {
+  day: string;
+  hideAdmins: boolean;
+  onHideAdminsChange: (hide: boolean) => void;
+  account: ViewerAccount | undefined;
+  onSignOut: () => void;
+  onBack: () => void;
+}): React.JSX.Element {
+  return (
+    <main className="mx-auto max-w-[1040px] px-6 py-10" aria-busy="true">
+      <PageHeader
+        title="Day"
+        account={account}
+        onSignOut={onSignOut}
+        controls={
+          <>
+            <HideAdminsToggle checked={hideAdmins} onChange={onHideAdminsChange} />
+            <SkeletonLine box="h-4" bone="h-3 w-48" />
+            <button type="button" className={PLAIN_BUTTON} disabled>
+              Loading…
+            </button>
+          </>
+        }
+      />
+      <p className="sr-only">Loading. Reading the day's own rows.</p>
+      <a
+        href={tabHref("dashboard")}
+        className="mt-8 inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors duration-150 hover:text-foreground"
+        onClick={(event) => {
+          if (!plainLeftClick(event)) return;
+          event.preventDefault();
+          onBack();
+        }}
+      >
+        <span aria-hidden="true">←</span> Dashboard
+      </a>
+      <div className="mt-6">
+        <h1 className="text-2xl font-semibold tracking-[-0.01em]">{formatDayHeading(day)}</h1>
+        <div className="mt-1">
+          <SkeletonLine box="h-5" bone="h-3.5 w-56" />
+        </div>
+      </div>
+      <SectionHeading>Hosted tier · this day</SectionHeading>
+      <div className="grid grid-cols-2 gap-3 min-[720px]:grid-cols-4">
+        <SkeletonStatCard />
+        <SkeletonStatCard />
+        <SkeletonStatCard />
+        <SkeletonStatCard />
+      </div>
+      <SectionHeading>Accounts active this day</SectionHeading>
+      <SkeletonAccountsTable rows={5} numericColumns={3} />
+    </main>
+  );
+}
+
 /** A windowed read's address: the default scope, window, and no search ride as no params. */
 function windowedReadPath(
   base: string,
@@ -1739,6 +1850,7 @@ function Dashboard({
   refreshing,
   onRefresh,
   onOpenAccount,
+  onOpenDay,
 }: {
   metrics: AdminMetrics;
   refreshFailure: string | undefined;
@@ -1751,6 +1863,7 @@ function Dashboard({
   refreshing: boolean;
   onRefresh: () => void;
   onOpenAccount: (id: string) => void;
+  onOpenDay: (day: string) => void;
 }): React.JSX.Element {
   const db = metrics.systemHealth.database;
 
@@ -1839,6 +1952,7 @@ function Dashboard({
             trend={metrics.featureUsage.usageTrend}
             label="Hosted-tier calls per day"
             generatedAt={metrics.generatedAt}
+            onOpenDay={onOpenDay}
           />
         </div>
         <SectionHeading>Most active hosted-tier accounts</SectionHeading>
@@ -2248,6 +2362,252 @@ function UserDetailPage({
           />
         </div>
         <AccountActivityNote />
+      </div>
+    </main>
+  );
+}
+
+/** What the day fetch resolved to, in the overview's own vocabulary. */
+type DayState =
+  | { status: "loading" }
+  | { status: "signed-out" }
+  | { status: "forbidden" }
+  | { status: "error"; detail: string }
+  | {
+      status: "ready";
+      detail: AdminDayDetail;
+      question: string;
+      refreshFailure: string | undefined;
+    };
+
+async function readDayState(response: Response, question: string): Promise<DayState> {
+  if (response.redirected) return { status: "error", detail: ERROR_DETAIL.PROTECTED };
+  if (response.status === ADMIN_HTTP_STATUS.UNAUTHORIZED) return { status: "signed-out" };
+  if (response.status === ADMIN_HTTP_STATUS.FORBIDDEN) return { status: "forbidden" };
+  if (response.status === ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE) {
+    return { status: "error", detail: ERROR_DETAIL.UNAVAILABLE };
+  }
+  if (!response.ok) return { status: "error", detail: ERROR_DETAIL.DAY };
+  // SAFETY: a 200 from the admin day endpoint is an AdminDayDetail body by its contract.
+  return {
+    status: "ready",
+    detail: (await response.json()) as AdminDayDetail,
+    question,
+    refreshFailure: undefined,
+  };
+}
+
+/**
+ * The day's accounts, busiest first as the endpoint orders them. The shared
+ * `AccountsTable` draws windowed columns a single day does not have, so the
+ * day page keeps a table of its own with the same row anatomy: the row for
+ * the pointer, and a real anchor on the name so a keyboard reaches it and a
+ * modified click still gets the browser's own gesture.
+ */
+function DayAccountsTable({
+  accounts,
+  onOpen,
+}: {
+  accounts: readonly AdminDayAccount[];
+  onOpen: (id: string) => void;
+}): React.JSX.Element {
+  if (accounts.length === 0) {
+    return (
+      <div className="rounded-lg border border-border bg-card px-5 py-8 text-center text-sm text-muted-foreground">
+        No hosted-tier calls recorded on this day.
+      </div>
+    );
+  }
+  return (
+    <div className="overflow-hidden rounded-lg border border-border bg-card">
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[520px] text-sm">
+          <thead>
+            <tr className="border-b border-border text-left font-mono text-xs text-muted-foreground uppercase">
+              <th className="px-5 py-3 font-medium">Account</th>
+              <th className="px-5 py-3 text-right font-medium">Voice</th>
+              <th className="px-5 py-3 text-right font-medium">Attention</th>
+              <th className="px-5 py-3 text-right font-medium">Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {accounts.map((row) => (
+              <tr
+                key={row.id}
+                className="cursor-pointer border-b border-border transition-colors duration-150 last:border-0 hover:bg-muted"
+                onClick={() => onOpen(row.id)}
+              >
+                <td className="px-5 py-3">
+                  <a
+                    href={accountHref(row.id)}
+                    className="flex items-center gap-3 outline-offset-2"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      if (!plainLeftClick(event)) return;
+                      event.preventDefault();
+                      onOpen(row.id);
+                    }}
+                  >
+                    <AccountAvatar
+                      account={{ name: row.name, email: row.email, image: row.image ?? undefined }}
+                    />
+                    <div>
+                      <div className="flex items-center gap-2 font-medium">
+                        {accountLabel(row)}
+                        {row.admin ? (
+                          <span className="rounded-full border border-border px-1.5 py-px font-mono text-[10px] tracking-[0.2px] text-muted-foreground uppercase">
+                            Admin
+                          </span>
+                        ) : null}
+                      </div>
+                      {accountLabel(row) === row.email ? null : (
+                        <div className="text-xs text-muted-foreground">{row.email}</div>
+                      )}
+                    </div>
+                  </a>
+                </td>
+                <td className="px-5 py-3 text-right tabular-nums">
+                  {formatNumber(row.voiceCalls)}
+                </td>
+                <td className="px-5 py-3 text-right tabular-nums">
+                  {formatNumber(row.attentionReviews)}
+                </td>
+                <td className="px-5 py-3 text-right font-semibold tabular-nums">
+                  {formatNumber(row.total)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function DayNote({
+  truncatedTo,
+  totalAccounts,
+}: {
+  truncatedTo?: number;
+  totalAccounts: number;
+}): React.JSX.Element {
+  return (
+    <p className="mt-3 text-sm text-muted-foreground">
+      Voice and attention count the hosted-tier calls each account spent on this UTC day. A row
+      opens the account's own page.
+      {truncatedTo !== undefined
+        ? ` Only the ${formatNumber(truncatedTo)} busiest accounts are listed here — the totals above still count all ${formatNumber(totalAccounts)}.`
+        : ""}
+    </p>
+  );
+}
+
+function DayDetailPage({
+  detail,
+  refreshFailure,
+  hideAdmins,
+  onHideAdminsChange,
+  account,
+  onSignOut,
+  onBack,
+  onOpenAccount,
+  refreshing,
+  onRefresh,
+}: {
+  detail: AdminDayDetail;
+  refreshFailure: string | undefined;
+  hideAdmins: boolean;
+  onHideAdminsChange: (hide: boolean) => void;
+  account: ViewerAccount | undefined;
+  onSignOut: () => void;
+  onBack: () => void;
+  onOpenAccount: (id: string) => void;
+  refreshing: boolean;
+  onRefresh: () => void;
+}): React.JSX.Element {
+  const stillFilling = partialDayKey([{ day: detail.day }], detail.generatedAt) !== undefined;
+  const soFar = stillFilling ? "so far today" : undefined;
+
+  return (
+    <main className="mx-auto max-w-[1040px] px-6 py-10">
+      <PageHeader
+        title="Day"
+        account={account}
+        onSignOut={onSignOut}
+        controls={
+          <>
+            <HideAdminsToggle checked={hideAdmins} onChange={onHideAdminsChange} />
+            <GeneratedStamp generatedAt={detail.generatedAt} />
+            <button
+              type="button"
+              className={PLAIN_BUTTON}
+              onClick={onRefresh}
+              disabled={refreshing}
+            >
+              {refreshing ? "Refreshing…" : "Refresh"}
+            </button>
+          </>
+        }
+      />
+
+      <RefreshFailureNotice failure={refreshFailure} refreshing={refreshing} onRetry={onRefresh} />
+
+      <div
+        className="transition-opacity duration-150 data-[busy=true]:opacity-50"
+        data-busy={refreshing}
+        aria-busy={refreshing}
+      >
+        <a
+          href={tabHref("dashboard")}
+          className="mt-8 inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors duration-150 hover:text-foreground"
+          onClick={(event) => {
+            if (!plainLeftClick(event)) return;
+            event.preventDefault();
+            onBack();
+          }}
+        >
+          <span aria-hidden="true">←</span> Dashboard
+        </a>
+
+        <div className="mt-6">
+          <h1 className="text-2xl font-semibold tracking-[-0.01em]">
+            {formatDayHeading(detail.day)}
+          </h1>
+          <div className="mt-1 text-sm text-muted-foreground">
+            One UTC day of hosted-tier calls{stillFilling ? " — still filling" : ""}
+          </div>
+        </div>
+
+        <SectionHeading>Hosted tier · this day</SectionHeading>
+        <div className="grid grid-cols-2 gap-3 min-[720px]:grid-cols-4">
+          <StatCard
+            label="Active accounts"
+            value={formatNumber(detail.totals.accounts)}
+            hint={soFar}
+          />
+          <StatCard
+            label="Voice calls"
+            value={formatNumber(detail.totals.voiceCalls)}
+            hint={soFar}
+          />
+          <StatCard
+            label="Attention reviews"
+            value={formatNumber(detail.totals.attentionReviews)}
+            hint={soFar}
+          />
+          <StatCard label="Total calls" value={formatNumber(detail.totals.total)} hint={soFar} />
+        </div>
+
+        <SectionHeading>Accounts active this day</SectionHeading>
+        <DayAccountsTable accounts={detail.accounts} onOpen={onOpenAccount} />
+        {detail.accounts.length > 0 ? (
+          <DayNote
+            truncatedTo={
+              detail.totals.accounts > detail.accounts.length ? detail.accounts.length : undefined
+            }
+            totalAccounts={detail.totals.accounts}
+          />
+        ) : null}
       </div>
     </main>
   );
@@ -3175,6 +3535,142 @@ function UserDetailScreen({
   }
 }
 
+/** The day read's address: one day, with the default scope riding as no param. */
+function dayReadPath(day: string, hideAdmins: boolean): string {
+  const params = new URLSearchParams();
+  params.set(ADMIN_DAY_PARAM, day);
+  if (!hideAdmins) params.set(ADMIN_METRICS_SCOPE_PARAM, ADMIN_METRICS_SCOPE.ALL);
+  return `${DAY_DETAIL_PATH}?${params.toString()}`;
+}
+
+function DayDetailScreen({
+  day,
+  hideAdmins,
+  onHideAdminsChange,
+  account,
+  onSignOut,
+  onBack,
+  onOpenAccount,
+  frame,
+}: {
+  day: string;
+  hideAdmins: boolean;
+  onHideAdminsChange: (hide: boolean) => void;
+  account: ViewerAccount | undefined;
+  onSignOut: () => Promise<void>;
+  onBack: () => void;
+  onOpenAccount: (id: string) => void;
+  /** Applied around every answer but the gate's own cards, which stand alone. */
+  frame: (content: React.JSX.Element) => React.JSX.Element;
+}): React.JSX.Element {
+  const [state, setState] = useState<DayState>(() =>
+    signInChosenHere() ? { status: "loading" } : { status: "signed-out" },
+  );
+  const [refreshing, setRefreshing] = useState(false);
+  const inFlight = useRef<AbortController>(null);
+
+  // The same withdrawal the detail screen lands: this screen renders in the
+  // overview's place with a ready answer of its own, so the parent's sign-out
+  // alone would leave the day's roster on screen after the consent behind it
+  // left.
+  const signOut = async () => {
+    inFlight.current?.abort();
+    setRefreshing(false);
+    await onSignOut();
+    setState({ status: "signed-out" });
+  };
+
+  const load = useCallback(() => {
+    // The same local consent the overview asks for: a deep link into a day
+    // page still opens on the sign-in card until a sign-in has been pressed
+    // on this page once.
+    if (!signInChosenHere()) {
+      setState({ status: "signed-out" });
+      return;
+    }
+    inFlight.current?.abort();
+    const controller = new AbortController();
+    inFlight.current = controller;
+    // A refresh keeps the page it is refreshing; a different day — the
+    // browser's own back and forward can swap days without passing the
+    // overview — must not stand dimmed behind the other day's read.
+    setState((current) =>
+      current.status === "ready" && current.detail.day === day ? current : { status: "loading" },
+    );
+    setRefreshing(true);
+    const path = dayReadPath(day, hideAdmins);
+    void (async () => {
+      try {
+        const next = await readDayState(
+          await fetch(path, {
+            headers: { accept: "application/json" },
+            signal: controller.signal,
+          }),
+          path,
+        );
+        if (!controller.signal.aborted) setState((current) => settleRead(current, next, path));
+      } catch {
+        if (!controller.signal.aborted) {
+          setState((current) =>
+            settleRead(current, { status: "error", detail: ERROR_DETAIL.DAY }, path),
+          );
+        }
+      } finally {
+        if (!controller.signal.aborted) setRefreshing(false);
+      }
+    })();
+  }, [day, hideAdmins]);
+
+  useEffect(() => {
+    load();
+    return () => inFlight.current?.abort();
+  }, [load]);
+
+  switch (state.status) {
+    case "loading":
+      return frame(
+        <DaySkeleton
+          day={day}
+          hideAdmins={hideAdmins}
+          onHideAdminsChange={onHideAdminsChange}
+          account={account}
+          onSignOut={() => void signOut()}
+          onBack={onBack}
+        />,
+      );
+    case "signed-out":
+      return <SignInCard />;
+    case "forbidden":
+      return <ForbiddenCard email={account?.email} onSignOut={() => void signOut()} />;
+    case "error":
+      return frame(
+        <Centered title="Could not load">
+          {state.detail}
+          <div className="mt-6">
+            <button type="button" className={PLAIN_BUTTON} onClick={load} disabled={refreshing}>
+              {refreshing ? "Trying…" : "Try again"}
+            </button>
+          </div>
+        </Centered>,
+      );
+    case "ready":
+      return frame(
+        <DayDetailPage
+          detail={state.detail}
+          refreshFailure={state.refreshFailure}
+          hideAdmins={hideAdmins}
+          onHideAdminsChange={onHideAdminsChange}
+          account={account}
+          onSignOut={() => void signOut()}
+          onBack={onBack}
+          onOpenAccount={onOpenAccount}
+          refreshing={refreshing}
+          onRefresh={load}
+        />,
+      );
+  }
+}
+
 export function AdminDashboard(): React.JSX.Element {
   // A first visit is signed-out from the very first frame: it never fetches,
   // so a loading state would pose as a request that is not in flight.
@@ -3211,6 +3707,10 @@ export function AdminDashboard(): React.JSX.Element {
   const openAccount = useCallback((id: string) => {
     window.history.pushState(null, "", accountHref(id));
     setView({ kind: "account", id });
+  }, []);
+  const openDay = useCallback((day: string) => {
+    window.history.pushState(null, "", dayHref(day));
+    setView({ kind: "day", day });
   }, []);
   const navigate = useCallback((tab: AdminTab) => {
     window.history.pushState(null, "", tabHref(tab));
@@ -3333,6 +3833,21 @@ export function AdminDashboard(): React.JSX.Element {
     );
   }
 
+  if (view.kind === "day") {
+    return (
+      <DayDetailScreen
+        day={view.day}
+        hideAdmins={hideAdmins}
+        onHideAdminsChange={changeHideAdmins}
+        account={viewer}
+        onSignOut={signOut}
+        onBack={() => navigate("dashboard")}
+        onOpenAccount={openAccount}
+        frame={(content) => shell("dashboard", content)}
+      />
+    );
+  }
+
   if (view.kind === "users") {
     return (
       <UsersScreen
@@ -3392,6 +3907,7 @@ export function AdminDashboard(): React.JSX.Element {
           refreshing={refreshing}
           onRefresh={load}
           onOpenAccount={openAccount}
+          onOpenDay={openDay}
         />,
       );
   }

--- a/apps/web/tests/admin-day.test.ts
+++ b/apps/web/tests/admin-day.test.ts
@@ -1,0 +1,249 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AdminViewer } from "../server/admin/admin-access";
+import {
+  ADMIN_DAY_ACCOUNTS_LIMIT,
+  type AdminDayDetail,
+  type AdminDaySource,
+  buildAdminDayDetail,
+  handleAdminDay,
+} from "../server/admin/admin-day";
+import type { AdminMetricsScope } from "../server/admin/http";
+import {
+  ADMIN_DAY_PARAM,
+  ADMIN_ERROR,
+  ADMIN_METRICS_SCOPE,
+  ADMIN_METRICS_SCOPE_PARAM,
+  adminDayKey,
+  isUtcDayKey,
+} from "../server/admin/http";
+
+const NOON_UTC = Date.parse("2026-08-17T12:00:00.000Z");
+const DAY = "2026-08-14";
+
+function daySource(overrides: Partial<AdminDaySource> = {}): AdminDaySource {
+  return {
+    accounts: [
+      {
+        id: "user-9",
+        name: "Ada Lovelace",
+        email: "ada@example.com",
+        image: null,
+        admin: false,
+        voiceCalls: 24,
+        attentionReviews: 12,
+        total: 36,
+      },
+      {
+        id: "user-3",
+        name: "Grace Hopper",
+        email: "grace@example.com",
+        image: null,
+        admin: false,
+        voiceCalls: 1,
+        attentionReviews: 3,
+        total: 4,
+      },
+    ],
+    totals: { accounts: 2, voiceCalls: 25, attentionReviews: 15 },
+    ...overrides,
+  };
+}
+
+test("the builder stamps the day and bound, and totals fold from the day's own sums", () => {
+  const detail = buildAdminDayDetail(daySource(), NOON_UTC, DAY);
+  assert.equal(detail.generatedAt, NOON_UTC);
+  assert.equal(detail.day, DAY);
+  assert.equal(detail.limit, ADMIN_DAY_ACCOUNTS_LIMIT);
+  assert.deepEqual(detail.totals, { accounts: 2, voiceCalls: 25, attentionReviews: 15, total: 40 });
+  assert.deepEqual(detail.accounts, [...daySource().accounts]);
+});
+
+test("a day key is a real UTC calendar day or nothing", () => {
+  assert.equal(isUtcDayKey("2026-08-14"), true);
+  assert.equal(isUtcDayKey("2024-02-29"), true);
+  assert.equal(isUtcDayKey("2026-02-29"), false);
+  assert.equal(isUtcDayKey("2026-02-30"), false);
+  assert.equal(isUtcDayKey("2026-13-01"), false);
+  assert.equal(isUtcDayKey("2026-00-14"), false);
+  assert.equal(isUtcDayKey("2026-08-00"), false);
+  assert.equal(isUtcDayKey("2026-08-32"), false);
+  assert.equal(isUtcDayKey("2026-8-14"), false);
+  assert.equal(isUtcDayKey("20260814"), false);
+  assert.equal(isUtcDayKey("2026-08-14T00:00:00.000Z"), false);
+  assert.equal(isUtcDayKey(""), false);
+  assert.equal(isUtcDayKey("yesterday"), false);
+});
+
+test("a day is read bounded from the query, or not at all", () => {
+  assert.equal(adminDayKey(`https://luke.test/api/admin/day?date=${DAY}`), DAY);
+  assert.equal(adminDayKey("https://luke.test/api/admin/day?date=2026-02-30"), undefined);
+  assert.equal(adminDayKey("https://luke.test/api/admin/day?date="), undefined);
+  assert.equal(adminDayKey("https://luke.test/api/admin/day"), undefined);
+});
+
+function dayRequest(day: string | null = DAY, method = "GET", scope?: string): Request {
+  const params = new URLSearchParams();
+  if (day !== null) params.set(ADMIN_DAY_PARAM, day);
+  if (scope !== undefined) params.set(ADMIN_METRICS_SCOPE_PARAM, scope);
+  const query = params.toString();
+  return new Request(`https://luke.test/api/admin/day${query ? `?${query}` : ""}`, { method });
+}
+
+const ADMIN_VIEWER: AdminViewer = { userId: "user-1", role: "admin" };
+
+const readDay = async (
+  day: string,
+  now: number,
+  _scope: AdminMetricsScope,
+): Promise<AdminDayDetail> => buildAdminDayDetail(daySource(), now, day);
+
+test("the gate answers 405, 401, 403, 400, and 200 as distinct outcomes", async () => {
+  const wrongMethod = await handleAdminDay({
+    request: dayRequest(DAY, "POST"),
+    resolveViewer: async () => ADMIN_VIEWER,
+    readDay,
+  });
+  assert.equal(wrongMethod.status, 405);
+  assert.equal(wrongMethod.headers.get("cache-control"), "no-store");
+
+  const anonymous = await handleAdminDay({
+    request: dayRequest(),
+    resolveViewer: async () => undefined,
+    readDay,
+  });
+  assert.equal(anonymous.status, 401);
+  assert.equal((await anonymous.json()).error, ADMIN_ERROR.NOT_SIGNED_IN);
+
+  const forbidden = await handleAdminDay({
+    request: dayRequest(),
+    resolveViewer: async () => ({ ...ADMIN_VIEWER, role: "user" }),
+    readDay,
+  });
+  assert.equal(forbidden.status, 403);
+  assert.equal((await forbidden.json()).error, ADMIN_ERROR.NOT_AUTHORIZED);
+
+  const unnamed = await handleAdminDay({
+    request: dayRequest(null),
+    resolveViewer: async () => ADMIN_VIEWER,
+    readDay,
+  });
+  assert.equal(unnamed.status, 400);
+  assert.equal((await unnamed.json()).error, ADMIN_ERROR.INVALID_DAY);
+
+  const unreal = await handleAdminDay({
+    request: dayRequest("2026-02-30"),
+    resolveViewer: async () => ADMIN_VIEWER,
+    readDay,
+  });
+  assert.equal(unreal.status, 400);
+  assert.equal((await unreal.json()).error, ADMIN_ERROR.INVALID_DAY);
+
+  const ok = await handleAdminDay({
+    request: dayRequest(),
+    resolveViewer: async () => ADMIN_VIEWER,
+    readDay,
+    now: () => NOON_UTC,
+  });
+  assert.equal(ok.status, 200);
+  assert.equal(ok.headers.get("cache-control"), "no-store");
+  // SAFETY: handleAdminDay answered 200, whose body is an AdminDayDetail document.
+  const body = (await ok.json()) as AdminDayDetail;
+  assert.equal(body.generatedAt, NOON_UTC);
+  assert.equal(body.day, DAY);
+  assert.equal(body.totals.total, 40);
+});
+
+test("the day is read at the scope the request asked for, defaulting to non-admins", async () => {
+  const scopes: AdminMetricsScope[] = [];
+  const countingRead = async (day: string, now: number, scope: AdminMetricsScope) => {
+    scopes.push(scope);
+    return readDay(day, now, scope);
+  };
+  const respond = (scope?: string) =>
+    handleAdminDay({
+      request: dayRequest(DAY, "GET", scope),
+      resolveViewer: async () => ADMIN_VIEWER,
+      readDay: countingRead,
+    });
+
+  assert.equal((await respond()).status, 200);
+  assert.equal((await respond(ADMIN_METRICS_SCOPE.ALL)).status, 200);
+  assert.equal((await respond("everyone")).status, 200);
+  assert.deepEqual(scopes, [
+    ADMIN_METRICS_SCOPE.NON_ADMINS,
+    ADMIN_METRICS_SCOPE.ALL,
+    ADMIN_METRICS_SCOPE.NON_ADMINS,
+  ]);
+});
+
+test("no day is read for a request that fails the gate or names no real day", async () => {
+  const reads: string[] = [];
+  const countingRead = async (day: string, now: number, scope: AdminMetricsScope) => {
+    reads.push(day);
+    return readDay(day, now, scope);
+  };
+
+  const anonymous = await handleAdminDay({
+    request: dayRequest(),
+    resolveViewer: async () => undefined,
+    readDay: countingRead,
+  });
+  assert.equal(anonymous.status, 401);
+
+  const unreal = await handleAdminDay({
+    request: dayRequest("2026-13-01"),
+    resolveViewer: async () => ADMIN_VIEWER,
+    readDay: countingRead,
+  });
+  assert.equal(unreal.status, 400);
+  assert.deepEqual(reads, []);
+
+  const ok = await handleAdminDay({
+    request: dayRequest(),
+    resolveViewer: async () => ADMIN_VIEWER,
+    readDay: countingRead,
+  });
+  assert.equal(ok.status, 200);
+  assert.deepEqual(reads, [DAY]);
+});
+
+test("a quiet day is an ordinary answer with empty rows, never a 404", async () => {
+  const response = await handleAdminDay({
+    request: dayRequest(),
+    resolveViewer: async () => ADMIN_VIEWER,
+    readDay: async (day, now) =>
+      buildAdminDayDetail(
+        { accounts: [], totals: { accounts: 0, voiceCalls: 0, attentionReviews: 0 } },
+        now,
+        day,
+      ),
+  });
+  assert.equal(response.status, 200);
+  // SAFETY: handleAdminDay answered 200, whose body is an AdminDayDetail document.
+  const body = (await response.json()) as AdminDayDetail;
+  assert.deepEqual(body.accounts, []);
+  assert.deepEqual(body.totals, { accounts: 0, voiceCalls: 0, attentionReviews: 0, total: 0 });
+});
+
+test("a seam that throws is a 503 refusal rather than a crash", async () => {
+  const viewerThrew = await handleAdminDay({
+    request: dayRequest(),
+    resolveViewer: async () => {
+      throw new Error("auth is down");
+    },
+    readDay,
+  });
+  assert.equal(viewerThrew.status, 503);
+  assert.equal((await viewerThrew.json()).error, ADMIN_ERROR.UNAVAILABLE);
+
+  const readThrew = await handleAdminDay({
+    request: dayRequest(),
+    resolveViewer: async () => ADMIN_VIEWER,
+    readDay: async () => {
+      throw new Error("database is down");
+    },
+  });
+  assert.equal(readThrew.status, 503);
+  assert.equal((await readThrew.json()).error, ADMIN_ERROR.UNAVAILABLE);
+});


### PR DESCRIPTION
## What

Clicking a bar in the dashboard's "Hosted-tier calls per day" chart now opens that UTC day's accounts: who called, their voice and attention counts ordered busiest first, and the day's totals. The chart said a day had 40 calls but not who made them; this answers that without leaving the address bar's view routing.

## How

- **Server** — a new `GET /api/admin/day?date=YYYY-MM-DD` follows the user endpoint's structure exactly: method gate, viewer gate, then param validation. The day must wear the strict `^\d{4}-\d{2}-\d{2}$` shape *and* survive a round trip through `Date` back to the same key (V8 rolls `2026-02-30` into March, so shape alone lies); anything else is a 400 with the new `invalid-day` token. The read honors the `scope` param like every other admin read, queries the same `hosted_usage`/`user` join the metrics use — one row per account per day, so each bounded row is already the account's whole day — cut at 50 rows with the totals riding their own aggregate so a truncated answer still states honest sums. Same `no-store` on every path. A real day nobody spent anything on is an ordinary 200 with empty rows, never a 404.
- **Client** — the usage chart takes an optional `onOpenDay`; the click lands at the chart level and the day is resolved against the drawn series itself, so only a day the bars actually state can open, and the chart wears `cursor-pointer` only when an opener is passed. Clicking pushes `?day=YYYY-MM-DD` (composing with `?days=` like the other views), and the day view renders with the page's usual anatomy: first-load skeleton, refresh that dims and keeps the last answer per `settleRead`, hide-admins toggle, an empty state for a quiet day, a truncation note for a heavy one, a "← Dashboard" dismiss, and account rows that are real anchors to `?user=<id>` honoring modified clicks. An address naming no real day falls to the plain dashboard, the same reading an out-of-set window gets.
- The account page's own usage chart passes no opener — one account's day needs no roster.
- Tests: `apps/web/tests/admin-day.test.ts` follows `admin-user.test.ts`'s shape — distinct gate outcomes, calendar-day validation, scope pass-through, no read past a failed gate, 503 on a throwing seam, and the builder's totals fold.

## Verification

- `./scripts/check.sh` passes (exit 0): repository contract checks, types, all workspace tests (including the 8 new day-endpoint tests), and builds.
- Web-only change; no desktop surface touched, so no macOS/notch check applies.
- Verified in headless Chrome against a stubbed API: the dashboard's usage chart shows `cursor: pointer`, clicking a bar pushed `?day=2026-08-03` and rendered the day panel (masthead date, four total cards, both account rows with real `?user=<id>` anchors, the note), the dismiss returned to the plain dashboard, browser back restored the day view with its state, and back again reached the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32547570363/artifacts/9469044602) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32547570363)

- Commit: `7a21554d13a76030a80b002c4414d5d854e47373`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
