### PR TITLE
feat(admin): draw an account's days as a calendar

### DIFF
--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -26,6 +26,7 @@ import {
 import { accountInitials } from "./account-initials";
 import { accountLabel } from "./account-label";
 import { GitHubMark, GoogleMark } from "./account-marks";
+import { calendarWeeks, DAYS_PER_WEEK, monthLabels } from "./activity-calendar";
 import { settleRead } from "./admin-refresh";
 import {
   SIDEBAR_ICON_SLOT,
@@ -508,6 +509,113 @@ function UsageChart({
           </Bar>
         </BarChart>
       </ChartContainer>
+    </div>
+  );
+}
+
+/**
+ * The floor under a day cell's fill, the retention grid's own: a one-call day
+ * beside a busy account's peak would otherwise round to a fill too faint to
+ * read as a mark.
+ */
+const CALENDAR_FILL_FLOOR_PERCENT = 8;
+
+function calendarCellStyle(total: number, maxTotal: number): React.CSSProperties {
+  const fill = Math.max(CALENDAR_FILL_FLOOR_PERCENT, Math.round((total / maxTotal) * 100));
+  return { backgroundColor: `color-mix(in oklab, var(--chart-1) ${fill}%, transparent)` };
+}
+
+const CALENDAR_WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+
+function CalendarDayCell({
+  day,
+  maxTotal,
+  partialDay,
+}: {
+  day: AdminDailyUsage;
+  maxTotal: number;
+  partialDay: string | undefined;
+}): React.JSX.Element {
+  const total = day.voiceCalls + day.attentionReviews;
+  const provisional =
+    day.day === partialDay ? " border border-dashed border-muted-foreground/60" : "";
+  return (
+    <div
+      className={`size-4 rounded-[3px] ${total === 0 ? "bg-muted/60" : ""}${provisional}`}
+      style={total === 0 ? undefined : calendarCellStyle(total, maxTotal)}
+      title={`${formatTooltipDay(day.day, partialDay)} — ${formatNumber(day.voiceCalls)} voice · ${formatNumber(day.attentionReviews)} attention`}
+    />
+  );
+}
+
+/**
+ * The same days the bars above draw, folded into a GitHub-style calendar:
+ * columns are UTC weeks keyed by their Monday like the retention grid's,
+ * rows the seven weekdays, and each cell's fill is that day's share of the
+ * account's own busiest day in the window. The bars carry magnitude; this
+ * grid carries the pattern they hide — weekday rhythms, weekend gaps, a
+ * streak breaking. A day the window does not cover draws nothing, a covered
+ * day with no calls keeps the faintest neutral fill so absence still reads
+ * as an observed day, and today wears the retention grid's dashed border
+ * because a fade here would pose as a quiet day.
+ */
+function ActivityCalendar({
+  daily,
+  generatedAt,
+}: {
+  daily: readonly AdminDailyUsage[];
+  generatedAt: number;
+}): React.JSX.Element {
+  const weeks = calendarWeeks(daily);
+  const months = monthLabels(weeks);
+  const partialDay = partialDayKey(daily, generatedAt);
+  const maxTotal = Math.max(...daily.map((day) => day.voiceCalls + day.attentionReviews));
+  return (
+    <div className="rounded-lg border border-border bg-card p-5">
+      <div className="mb-4 text-xs text-muted-foreground">This account's days, week by week</div>
+      <div className="overflow-x-auto">
+        <div
+          className="grid w-max gap-1 tabular-nums"
+          style={{
+            gridAutoFlow: "column",
+            gridTemplateRows: `auto repeat(${DAYS_PER_WEEK}, 1rem)`,
+          }}
+        >
+          <div aria-hidden="true" />
+          {CALENDAR_WEEKDAY_LABELS.map((label) => (
+            <div
+              key={label}
+              className="pr-2 font-mono text-[10px] leading-4 text-muted-foreground uppercase"
+            >
+              {label}
+            </div>
+          ))}
+          {weeks.map((week, weekIndex) => (
+            <Fragment key={week.weekStart}>
+              <div className="font-mono text-[10px] leading-4 whitespace-nowrap text-muted-foreground uppercase">
+                {months[weekIndex]}
+              </div>
+              {week.days.map((day, slot) =>
+                day === undefined ? (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: an empty slot has no identity beyond its weekday position.
+                  <div key={slot} aria-hidden="true" />
+                ) : (
+                  <CalendarDayCell
+                    key={day.day}
+                    day={day}
+                    maxTotal={maxTotal}
+                    partialDay={partialDay}
+                  />
+                ),
+              )}
+            </Fragment>
+          ))}
+        </div>
+      </div>
+      <p className="mt-4 mb-0 text-xs text-muted-foreground">
+        Each cell is one UTC day — a deeper fill is more hosted calls against this account's busiest
+        day in the window, and the dashed cell is today, still filling.
+      </p>
     </div>
   );
 }
@@ -1379,6 +1487,24 @@ function SkeletonChartCard({ plot }: { plot: SkeletonPlot }): React.JSX.Element 
   );
 }
 
+/**
+ * The bone block is the calendar grid's own height: a month-label row and
+ * seven 1rem day rows with 0.25rem gaps.
+ */
+function SkeletonCalendarCard(): React.JSX.Element {
+  return (
+    <div className="rounded-lg border border-border bg-card p-5">
+      <div className="mb-4">
+        <SkeletonLine box="h-4" bone="h-3 w-52" />
+      </div>
+      <Skeleton className="h-[156px] w-full" />
+      <div className="mt-4">
+        <SkeletonLine box="h-4" bone="h-3 w-96 max-w-full" />
+      </div>
+    </div>
+  );
+}
+
 function SkeletonRetentionGrid(): React.JSX.Element {
   return (
     <div className="rounded-lg border border-border bg-card p-5">
@@ -1698,6 +1824,11 @@ function AccountSkeleton({
       <div className="mt-3">
         <SkeletonChartCard plot={SKELETON_PLOT.USAGE} />
       </div>
+      {windowDays > DAYS_PER_WEEK ? (
+        <div className="mt-3">
+          <SkeletonCalendarCard />
+        </div>
+      ) : null}
       <SectionHeading>Volume</SectionHeading>
       <div className="grid grid-cols-2 gap-3 min-[720px]:grid-cols-4">
         <SkeletonStatCard />
@@ -2224,6 +2355,16 @@ function UserDetailPage({
             generatedAt={detail.generatedAt}
           />
         </div>
+        {/* A 7-day window folds to a single column, which restates the bars
+            above with less resolution, so the calendar draws only for windows
+            past a week; a window with no calls already says so on the chart
+            card, and an all-neutral grid under it would restate the absence. */}
+        {detail.windowDays > DAYS_PER_WEEK &&
+        !seriesHasNoData(activity.daily.map((day) => day.voiceCalls + day.attentionReviews)) ? (
+          <div className="mt-3">
+            <ActivityCalendar daily={activity.daily} generatedAt={detail.generatedAt} />
+          </div>
+        ) : null}
 
         <SectionHeading>Volume</SectionHeading>
         <div className="grid grid-cols-2 gap-3 min-[720px]:grid-cols-4">

--- a/apps/web/src/activity-calendar.ts
+++ b/apps/web/src/activity-calendar.ts
@@ -1,0 +1,73 @@
+/**
+ * Folds the admin page's zero-filled daily series into calendar weeks so a
+ * GitHub-style grid can draw them: columns are UTC weeks keyed by their
+ * Monday — the same weeks the retention grid stands on — and each week holds
+ * seven slots, Monday first. A slot outside the window stays empty rather
+ * than borrowing a neighbor's day, which is what lets a window opening
+ * mid-week, or a window ending on today, draw an honestly ragged edge.
+ */
+
+export const DAYS_PER_WEEK = 7;
+
+const DAY_MS = 86_400_000;
+
+export interface CalendarWeek<Day extends { day: string }> {
+  /** The week's UTC Monday, as YYYY-MM-DD. */
+  weekStart: string;
+  /** Seven slots, Monday first; a slot the window does not cover is undefined. */
+  days: readonly (Day | undefined)[];
+}
+
+function daysSinceEpoch(day: string): number {
+  return Date.parse(`${day}T00:00:00.000Z`) / DAY_MS;
+}
+
+/** The epoch, 1970-01-01, was a Thursday: three days past its week's Monday. */
+function weekdaySlot(day: string): number {
+  return (daysSinceEpoch(day) + 3) % DAYS_PER_WEEK;
+}
+
+function mondayKey(day: string): string {
+  return new Date((daysSinceEpoch(day) - weekdaySlot(day)) * DAY_MS).toISOString().slice(0, 10);
+}
+
+/** Reads the series as the server sends it: consecutive UTC days, oldest first. */
+export function calendarWeeks<Day extends { day: string }>(
+  daily: readonly Day[],
+): readonly CalendarWeek<Day>[] {
+  const weeks: { weekStart: string; days: (Day | undefined)[] }[] = [];
+  for (const entry of daily) {
+    const weekStart = mondayKey(entry.day);
+    let week = weeks.at(-1);
+    if (week === undefined || week.weekStart !== weekStart) {
+      week = { weekStart, days: Array.from({ length: DAYS_PER_WEEK }, () => undefined) };
+      weeks.push(week);
+    }
+    week.days[weekdaySlot(entry.day)] = entry;
+  }
+  return weeks;
+}
+
+/**
+ * One label per week column, set where a month begins: the first column, and
+ * any column whose earliest covered day opens a month its predecessor's did
+ * not. The earliest covered day — not the Monday — names the month, so a
+ * first column that starts mid-week is labeled for the days it actually
+ * shows.
+ */
+export function monthLabels(
+  weeks: readonly CalendarWeek<{ day: string }>[],
+): readonly (string | undefined)[] {
+  let previousMonth: string | undefined;
+  return weeks.map((week) => {
+    const firstDay = week.days.find((day) => day !== undefined);
+    if (firstDay === undefined) return undefined;
+    const month = firstDay.day.slice(0, 7);
+    if (month === previousMonth) return undefined;
+    previousMonth = month;
+    return new Date(`${firstDay.day}T00:00:00.000Z`).toLocaleDateString("en-US", {
+      month: "short",
+      timeZone: "UTC",
+    });
+  });
+}

--- a/apps/web/tests/activity-calendar.test.ts
+++ b/apps/web/tests/activity-calendar.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { calendarWeeks, monthLabels } from "../src/activity-calendar";
+
+function series(firstDay: string, days: number): { day: string }[] {
+  const start = Date.parse(`${firstDay}T00:00:00.000Z`);
+  return Array.from({ length: days }, (_, offset) => ({
+    day: new Date(start + offset * 86_400_000).toISOString().slice(0, 10),
+  }));
+}
+
+test("an empty account folds to no weeks at all", () => {
+  assert.deepEqual(calendarWeeks([]), []);
+});
+
+test("a full Monday-to-Sunday week fills its seven slots in order", () => {
+  // 2026-08-17 is a Monday.
+  const weeks = calendarWeeks(series("2026-08-17", 7));
+  assert.equal(weeks.length, 1);
+  assert.equal(weeks[0]?.weekStart, "2026-08-17");
+  assert.deepEqual(
+    weeks[0]?.days.map((day) => day?.day),
+    [
+      "2026-08-17",
+      "2026-08-18",
+      "2026-08-19",
+      "2026-08-20",
+      "2026-08-21",
+      "2026-08-22",
+      "2026-08-23",
+    ],
+  );
+});
+
+test("a window opening mid-week leaves the days before it empty", () => {
+  // 2026-08-19 is a Wednesday; nine days end the following Thursday.
+  const weeks = calendarWeeks(series("2026-08-19", 9));
+  assert.equal(weeks.length, 2);
+  assert.equal(weeks[0]?.weekStart, "2026-08-17");
+  assert.deepEqual(
+    weeks[0]?.days.map((day) => day?.day),
+    [undefined, undefined, "2026-08-19", "2026-08-20", "2026-08-21", "2026-08-22", "2026-08-23"],
+  );
+  assert.equal(weeks[1]?.weekStart, "2026-08-24");
+  assert.deepEqual(
+    weeks[1]?.days.map((day) => day?.day),
+    ["2026-08-24", "2026-08-25", "2026-08-26", "2026-08-27", undefined, undefined, undefined],
+  );
+});
+
+test("a window ending on a partial today leaves the days after it empty", () => {
+  // Five days from Monday 2026-08-17 end on Friday the 21st, today's own day.
+  const weeks = calendarWeeks(series("2026-08-17", 5));
+  assert.equal(weeks.length, 1);
+  assert.deepEqual(
+    weeks[0]?.days.map((day) => day?.day),
+    ["2026-08-17", "2026-08-18", "2026-08-19", "2026-08-20", "2026-08-21", undefined, undefined],
+  );
+});
+
+test("a 90-day window folds to fourteen Monday-keyed weeks with ragged ends", () => {
+  // 2026-05-24 is a Sunday, so 90 days ending Friday 2026-08-21 span a
+  // one-day first week, twelve full weeks, and a five-day last week.
+  const weeks = calendarWeeks(series("2026-05-24", 90));
+  assert.equal(weeks.length, 14);
+  assert.equal(weeks[0]?.weekStart, "2026-05-18");
+  assert.deepEqual(
+    weeks[0]?.days.map((day) => day?.day),
+    [undefined, undefined, undefined, undefined, undefined, undefined, "2026-05-24"],
+  );
+  assert.equal(weeks.at(-1)?.weekStart, "2026-08-17");
+  assert.equal(weeks.at(-1)?.days[4]?.day, "2026-08-21");
+  assert.equal(weeks.at(-1)?.days[5], undefined);
+  const coveredDays = weeks.flatMap((week) => week.days.filter((day) => day !== undefined));
+  assert.equal(coveredDays.length, 90);
+});
+
+test("month labels mark the first column and each column opening a new month", () => {
+  // 2026-07-27 is a Monday; two weeks later August has begun.
+  const labels = monthLabels(calendarWeeks(series("2026-07-27", 14)));
+  assert.deepEqual(labels, ["Jul", "Aug"]);
+});
+
+test("a first column starting mid-week is labeled for the days it shows", () => {
+  // 2026-08-01 is a Saturday inside July's last calendar week.
+  const labels = monthLabels(calendarWeeks(series("2026-08-01", 9)));
+  assert.deepEqual(labels, ["Aug", undefined]);
+});


### PR DESCRIPTION
## What

An intensity calendar of the account's activity on the admin account detail page, under the existing "Daily use · hosted tier" bar chart. The bars stay — they carry magnitude — and the calendar carries the pattern they hide: weekday rhythms, weekend gaps, and streak breaks.

- GitHub-style layout: columns are UTC weeks keyed by their Monday (the retention grid's weeks), rows the seven weekdays, cells the window's days. Weekday and month labels wear the page's mono micro-label style, and each cell carries a title like `Aug 12 — 5 voice · 3 attention`, with the page's "(so far today)" wording on the partial day.
- Cell intensity is the retention grid's own technique — `color-mix(var(--chart-1) P%, transparent)` with the same 8% floor so a one-call day stays a visible mark — scaled against the account's own busiest day in the window. One deliberate reading of the spec: the retention grid mixes `in oklab`, not `in oklch`, so the calendar reuses the grid's expression verbatim to keep the page on one interpolation space (mixing into transparent makes the two visually indistinguishable anyway).
- A covered day with no calls keeps the faintest neutral fill so absence still reads as an observed day; a day outside the window (before its start, or after today) draws nothing. Today wears the retention grid's dashed provisional border, derived from `generatedAt` via the existing `partialDayKey` helper, never the browser clock — a fade here would pose as a quiet day.
- Render rule: the calendar draws only for windows past a week (30d and 90d). A 7-day window folds to a single column that restates the bars above with less resolution, so the honest answer there is no calendar at all. A window with no calls also draws none — the chart card already says so, and an all-neutral grid would restate the absence.
- The account skeleton grows a matching card at the calendar's real height, under the same past-a-week rule.

## How

Pure presentation; no server changes. The calendar composes from the response the page already holds — the zero-filled `activity.daily` series, `windowDays`, and `generatedAt`. The week folding is a small pure helper, `apps/web/src/activity-calendar.ts` (`calendarWeeks`, `monthLabels`, structurally typed over `{ day: string }` like `daily-series.ts`), with tests in `apps/web/tests/activity-calendar.test.ts` covering a window opening mid-week, a window ending on a partial today, the 90-day span's ragged first and last weeks, month labeling, and an empty account.

## Verification

- `./scripts/check.sh` passes (exit 0) after rebasing onto `feae90a`. One earlier full run tripped on `apps/desktop/src/main/native/microphone-route.test.ts`, which passes in isolation and on re-run — a flaky, unrelated desktop test.
- Web-only change; no desktop surface touched, so no macOS/notch check applies.
- Rendered in headless Chrome against stubbed 7/30/90-day responses. At 90d the calendar draws fourteen week columns (~300px) with May–Aug month labels, sitting comfortably inside the card with no horizontal scroll (the `overflow-x-auto` wrapper is there for narrow viewports); the weekday rhythm, empty weekends, and a stubbed mid-window break all read at a glance, and today draws dashed. At 30d it draws five columns with Jul/Aug labels. At 7d no calendar draws. The loading state shows the new skeleton card in place below the chart skeleton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32547607617/artifacts/9469052071) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32547607617)

- Commit: `cc52eacd3c56ef71e1f542d2a4beb84e691128cb`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
