### PR TITLE
feat: link the changelog from the Updates section

### DIFF
--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -1094,6 +1094,14 @@ function registerIpc(): void {
     void shell.openExternal(UPDATE_ENDPOINT.LATEST_RELEASE_PAGE_URL);
   });
 
+  // The changelog, in the browser — the Changelog row's press. The address
+  // is fixed here on the releases page's terms.
+  ipcMain.on(channels.openChangelog, (event) => {
+    if (!trustedSender(event)) return;
+    recordProductEvent(PRODUCT_EVENT.UPDATE_ACT, { update_act: PRODUCT_UPDATE_ACT.CHANGELOG_OPEN });
+    void shell.openExternal(UPDATE_ENDPOINT.CHANGELOG_PAGE_URL);
+  });
+
   registerVoiceRuntimeIpc({
     ipcMain,
     trustedSender,

--- a/apps/desktop/src/main/update-service.ts
+++ b/apps/desktop/src/main/update-service.ts
@@ -6,12 +6,13 @@ import {
 } from "#shared/contracts";
 
 /**
- * The two addresses updating ever touches, fixed here rather than passed in,
+ * The addresses updating ever touches, fixed here rather than passed in,
  * so the renderer names an intent and never an address — and nothing a check
  * read can steer where a press goes. The feed is where electron-updater reads
  * `latest-mac.yml` and the archive it names, both published by this
  * repository's release pipeline; `releases/latest` is what keeps the address
- * from ever moving.
+ * from ever moving. The changelog page is the site's rendering of the same
+ * repository's CHANGELOG.md, where the Updates section's Changelog row goes.
  */
 export const UPDATE_ENDPOINT = {
   // The trailing slash keeps the last segment a directory under every URL
@@ -19,6 +20,7 @@ export const UPDATE_ENDPOINT = {
   // literal should not need that reading.
   UPDATE_FEED_URL: "https://github.com/ReviewStage/luke/releases/latest/download/",
   LATEST_RELEASE_PAGE_URL: "https://github.com/ReviewStage/luke/releases/latest",
+  CHANGELOG_PAGE_URL: "https://tryluke.dev/changelog",
 } as const;
 
 const UPDATE_CHECK_DEFAULTS = {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -82,6 +82,7 @@ const bridge: AppBridge = {
   checkForUpdates: invokeMethod<"checkForUpdates">(channels.checkForUpdates),
   installUpdate: () => ipcRenderer.send(channels.installUpdate),
   openLatestRelease: () => ipcRenderer.send(channels.openLatestRelease),
+  openChangelog: () => ipcRenderer.send(channels.openChangelog),
   beginSupersetSignIn: invokeMethod<"beginSupersetSignIn">(channels.beginSupersetSignIn),
   submitSupersetSignInCode: invokeMethod<"submitSupersetSignInCode">(
     channels.submitSupersetSignInCode,

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -751,7 +751,9 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "or it simply lands on the next quit. If a download or install fails, the row says so " +
         "and offers the fixed releases page in the browser instead. The button's press can also " +
         "be asked of Luke — check for updates, open the releases page, restart to update — and " +
-        "only the one act the row currently offers runs.",
+        "only the one act the row currently offers runs. The Changelog row under the version " +
+        "opens the changelog in the browser, at the fixed changelog page, where every release's " +
+        "notes live. Opening it is a press by hand; no spoken ask reaches it.",
     },
     {
       label: "Usage data",

--- a/apps/desktop/src/renderer/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings-panel.tsx
@@ -3571,6 +3571,23 @@ function UpdatesSection({
         </span>
         {updateButton(row.action, control)}
       </div>
+      {/* What the versions the row talks about actually changed — beside the
+          version, as a trip to the fixed changelog page in the browser. */}
+      <div className="settings-row" {...searchAnchorProps(SETTINGS_SEARCH_ROW.CHANGELOG)}>
+        <span className="settings-copy">
+          <span className="settings-name">
+            <strong>Changelog</strong>
+          </span>
+        </span>
+        <button
+          type="button"
+          className="quiet-button"
+          onClick={() => window.sidecar.openChangelog()}
+        >
+          Open
+          <ExternalIcon />
+        </button>
+      </div>
     </section>
   );
 }

--- a/apps/desktop/src/renderer/settings-search.tsx
+++ b/apps/desktop/src/renderer/settings-search.tsx
@@ -103,6 +103,7 @@ export function searchAnchorProps(id: string) {
  */
 export const SETTINGS_SEARCH_ROW = {
   UPDATES: "updates",
+  CHANGELOG: "changelog",
   FEEDBACK: "feedback",
   SIGN_OUT: "sign-out",
   DELETE_ACCOUNT: "delete-account",
@@ -277,6 +278,13 @@ function fixedEntries(input: SettingsSearchInput): readonly SettingsSearchEntry[
       page: SETTINGS_VIEW.ROOT,
       icon: <DownloadIcon />,
       haystack: ["Updates", "version release download check for updates"],
+    },
+    {
+      id: SETTINGS_SEARCH_ROW.CHANGELOG,
+      label: "Changelog",
+      page: SETTINGS_VIEW.ROOT,
+      icon: <DownloadIcon />,
+      haystack: ["Changelog", "release notes version history what's new what changed"],
     },
     {
       id: SETTINGS_SEARCH_ROW.FEEDBACK,

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -763,6 +763,12 @@ export interface AppBridge {
    * main process, so nothing an update check read can steer where this goes.
    */
   openLatestRelease(): void;
+  /**
+   * Opens the changelog page in the default browser — the Changelog row's
+   * press. Fixed in the main process on the releases page's terms: the
+   * renderer names an intent and never an address.
+   */
+  openChangelog(): void;
   /** Starts Superset's own OAuth login in one directly spawned CLI child. */
   beginSupersetSignIn(): Promise<SupersetSignInSnapshot>;
   /** Hands one explicit paste to that exact child; the code is never stored. */
@@ -1163,6 +1169,7 @@ export const channels = {
   checkForUpdates: "app:check-for-updates",
   installUpdate: "app:install-update",
   openLatestRelease: "app:open-latest-release",
+  openChangelog: "app:open-changelog",
   beginSupersetSignIn: "app:begin-superset-sign-in",
   submitSupersetSignInCode: "app:submit-superset-sign-in-code",
   reopenSupersetSignIn: "app:reopen-superset-sign-in",

--- a/packages/analytics/src/product-events.ts
+++ b/packages/analytics/src/product-events.ts
@@ -200,16 +200,18 @@ export const PRODUCT_SUPERSET_ACT = {
 export type ProductSupersetAct = (typeof PRODUCT_SUPERSET_ACT)[keyof typeof PRODUCT_SUPERSET_ACT];
 
 /**
- * The three things the Updates row's button ever does. It repeats the guide's
+ * The things the Updates section's buttons ever do. It repeats the guide's
  * own act set rather than importing it, because the guide names the act a
  * spoken ask may reach and this names the act that happened: the row offers a
  * browser trip where the guide says `download`, and a restart the count sees
- * as the install it schedules.
+ * as the install it schedules. `changelog_open` is the Changelog row's own
+ * browser trip, to the fixed changelog page rather than the releases one.
  */
 export const PRODUCT_UPDATE_ACT = {
   CHECK: "check",
   INSTALL: "install",
   RELEASE_OPEN: "release_open",
+  CHANGELOG_OPEN: "changelog_open",
 } as const;
 
 export type ProductUpdateAct = (typeof PRODUCT_UPDATE_ACT)[keyof typeof PRODUCT_UPDATE_ACT];


### PR DESCRIPTION
## What

Adds a **Changelog** row to Settings' Updates section, directly under the version row. Its **Open ↗** button opens the changelog website (`tryluke.dev/changelog`) in the default browser.

## How

- The press goes through a new bridge channel (`openChangelog`) on the releases-page press's terms: the address is fixed in the main process (`UPDATE_ENDPOINT.CHANGELOG_PAGE_URL`), so the renderer names an intent and never an address, and nothing an update check read can steer where the press goes.
- The press is counted as `update_act: changelog_open`, matching the existing `release_open` — one deliberate widening of that property's value set.
- The row is findable in settings search ("changelog", "release notes", "what's new"), and the guide's Updates fact describes it, including that no spoken ask reaches it.

## Verification

- `./scripts/check.sh` passes.
- `./scripts/verify.sh` was not run: this change was made in a Linux cloud workspace, so no macOS packaging or physical-notch check was performed. The row was visually inspected against the compiled stylesheet in a static harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32555293546/artifacts/9471259174) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32555293546)

- Commit: `c6042a7dedf66323306d0477d480a0208c2df8b3`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
