### PR TITLE
feat(admin): make the account calendar a full-width trailing year

### DIFF
--- a/apps/web/server/admin/admin-queries.ts
+++ b/apps/web/server/admin/admin-queries.ts
@@ -33,7 +33,7 @@ import {
   utcWeekStartKey,
   windowFetchDays,
 } from "./admin-metrics.js";
-import type { AdminUserSource } from "./admin-user.js";
+import { type AdminUserSource, calendarDayKeys } from "./admin-user.js";
 import { ADMIN_USERS_LIMIT, type AdminUserListSource, searchLikePattern } from "./admin-users.js";
 import { ADMIN_METRICS_SCOPE, type AdminMetricsScope, type AdminMetricsWindow } from "./http.js";
 
@@ -384,53 +384,65 @@ export async function readAdminUserSource(
   // both runs; the throttle count below stays on the window's own.
   const fetchStartDay =
     lastNDayKeys(input.now, windowFetchDays(input.windowDays))[0] ?? utcDayKey(input.now);
+  // The calendar keeps a trailing-year bound of its own, apart from the
+  // window, so switching windows never redraws the year.
+  const calendarStartDay = calendarDayKeys(input.now)[0] ?? utcDayKey(input.now);
 
-  const [userRows, accountRows, windowRows, [allTimeRow], [quotaRow]] = await Promise.all([
-    database
-      .select({
-        id: user.id,
-        name: user.name,
-        email: user.email,
-        image: user.image,
-        role: user.role,
-        createdAt: user.createdAt,
-      })
-      .from(user)
-      .where(eq(user.id, input.userId))
-      .limit(1),
-    database
-      .select({ providerId: account.providerId })
-      .from(account)
-      .where(eq(account.userId, input.userId)),
-    database
-      .select({
-        day: hostedUsage.day,
-        voiceCalls: hostedUsage.voiceCalls,
-        attentionReviews: hostedUsage.attentionReviews,
-      })
-      .from(hostedUsage)
-      .where(and(eq(hostedUsage.userId, input.userId), gte(hostedUsage.day, fetchStartDay))),
-    database
-      .select({
-        activeDays: count(),
-        firstActiveDay: sql<string | null>`min(${hostedUsage.day})`,
-        lastActiveDay: sql<string | null>`max(${hostedUsage.day})`,
-        voiceCalls: sum(hostedUsage.voiceCalls),
-        attentionReviews: sum(hostedUsage.attentionReviews),
-      })
-      .from(hostedUsage)
-      .where(eq(hostedUsage.userId, input.userId)),
-    database
-      .select({ value: count() })
-      .from(hostedUsage)
-      .where(
-        and(
-          eq(hostedUsage.userId, input.userId),
-          gte(hostedUsage.day, windowStartDay),
-          ceilingReached(),
+  const [userRows, accountRows, windowRows, calendarRows, [allTimeRow], [quotaRow]] =
+    await Promise.all([
+      database
+        .select({
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          image: user.image,
+          role: user.role,
+          createdAt: user.createdAt,
+        })
+        .from(user)
+        .where(eq(user.id, input.userId))
+        .limit(1),
+      database
+        .select({ providerId: account.providerId })
+        .from(account)
+        .where(eq(account.userId, input.userId)),
+      database
+        .select({
+          day: hostedUsage.day,
+          voiceCalls: hostedUsage.voiceCalls,
+          attentionReviews: hostedUsage.attentionReviews,
+        })
+        .from(hostedUsage)
+        .where(and(eq(hostedUsage.userId, input.userId), gte(hostedUsage.day, fetchStartDay))),
+      database
+        .select({
+          day: hostedUsage.day,
+          voiceCalls: hostedUsage.voiceCalls,
+          attentionReviews: hostedUsage.attentionReviews,
+        })
+        .from(hostedUsage)
+        .where(and(eq(hostedUsage.userId, input.userId), gte(hostedUsage.day, calendarStartDay))),
+      database
+        .select({
+          activeDays: count(),
+          firstActiveDay: sql<string | null>`min(${hostedUsage.day})`,
+          lastActiveDay: sql<string | null>`max(${hostedUsage.day})`,
+          voiceCalls: sum(hostedUsage.voiceCalls),
+          attentionReviews: sum(hostedUsage.attentionReviews),
+        })
+        .from(hostedUsage)
+        .where(eq(hostedUsage.userId, input.userId)),
+      database
+        .select({ value: count() })
+        .from(hostedUsage)
+        .where(
+          and(
+            eq(hostedUsage.userId, input.userId),
+            gte(hostedUsage.day, windowStartDay),
+            ceilingReached(),
+          ),
         ),
-      ),
-  ]);
+    ]);
 
   const row = userRows[0];
   if (!row) return undefined;
@@ -438,6 +450,14 @@ export async function readAdminUserSource(
   const byDay = new Map<string, AdminUsageDay>();
   for (const usageRow of windowRows) {
     byDay.set(usageRow.day, {
+      voiceCalls: usageRow.voiceCalls,
+      attentionReviews: usageRow.attentionReviews,
+    });
+  }
+
+  const calendarByDay = new Map<string, AdminUsageDay>();
+  for (const usageRow of calendarRows) {
+    calendarByDay.set(usageRow.day, {
       voiceCalls: usageRow.voiceCalls,
       attentionReviews: usageRow.attentionReviews,
     });
@@ -455,6 +475,7 @@ export async function readAdminUserSource(
     },
     usage: {
       byDay,
+      calendarByDay,
       allTime: {
         activeDays: toNumber(allTimeRow?.activeDays),
         firstActiveDay: allTimeRow?.firstActiveDay ?? null,

--- a/apps/web/server/admin/admin-user.ts
+++ b/apps/web/server/admin/admin-user.ts
@@ -29,6 +29,25 @@ import {
  * itself, never anything read off the user's machine.
  */
 
+/** How many complete weeks the account calendar reaches back past the current one. */
+export const CALENDAR_COMPLETE_WEEKS = 52;
+
+const DAY_MS = 86_400_000;
+const DAYS_PER_WEEK = 7;
+
+/**
+ * The account calendar's UTC day keys, oldest first: the last 52 complete
+ * weeks plus the current partial one, ending on `now`'s own day — a trailing
+ * year that stands apart from the page's window. The calendar's weeks open
+ * on Sunday, its own requested convention, unlike the retention grid's
+ * Monday-keyed weeks, which follow Postgres's `date_trunc('week')`. The
+ * epoch, 1970-01-01, was a Thursday: four days past its week's Sunday.
+ */
+export function calendarDayKeys(now: number): string[] {
+  const daysIntoWeek = ((Math.floor(now / DAY_MS) + 4) % DAYS_PER_WEEK) + 1;
+  return lastNDayKeys(now, CALENDAR_COMPLETE_WEEKS * DAYS_PER_WEEK + daysIntoWeek);
+}
+
 /** The account the page names, from the service's own user row. */
 export interface AdminUserAccount {
   id: string;
@@ -61,6 +80,8 @@ export interface AdminUserSource {
   account: AdminUserAccount;
   usage: {
     byDay: ReadonlyMap<string, AdminUsageDay>;
+    /** The calendar's own rows, read at the trailing-year bound. */
+    calendarByDay: ReadonlyMap<string, AdminUsageDay>;
     allTime: AdminUserAllTime;
     /** Window days on which this account reached a hosted daily ceiling. */
     quotaLimitedDaysWindow: number;
@@ -73,6 +94,11 @@ export interface AdminUserDetail {
   account: AdminUserAccount;
   activity: {
     daily: AdminDailyUsage[];
+    /**
+     * The calendar's zero-filled trailing year, `calendarDayKeys`'s span,
+     * whatever window the rest of the page is read at.
+     */
+    calendarDaily: AdminDailyUsage[];
     usageTrend: AdminTrend;
     activeDaysWindow: number;
     /** Active days in the trailing run beside the run before it. */
@@ -115,6 +141,15 @@ export function buildAdminUserDetail(
     };
   });
 
+  const calendarDaily = calendarDayKeys(now).map((day) => {
+    const row = source.usage.calendarByDay.get(day);
+    return {
+      day,
+      voiceCalls: row?.voiceCalls ?? 0,
+      attentionReviews: row?.attentionReviews ?? 0,
+    };
+  });
+
   const activeFlags = daily.map((day) => day.voiceCalls + day.attentionReviews > 0);
   let streakEnd = activeFlags.length - 1;
   if (!activeFlags[streakEnd]) streakEnd -= 1;
@@ -129,6 +164,7 @@ export function buildAdminUserDetail(
     account: source.account,
     activity: {
       daily,
+      calendarDaily,
       usageTrend: trailingTrend(trendTotals, ADMIN_TREND_DAYS),
       activeDaysWindow: activeFlags.filter(Boolean).length,
       activeDaysTrend: trailingTrend(

--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -574,7 +574,8 @@ function calendarCellStyle(total: number, maxTotal: number): React.CSSProperties
   return { backgroundColor: `color-mix(in oklab, var(--chart-1) ${fill}%, transparent)` };
 }
 
-const CALENDAR_WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+/** Sunday first, the calendar's own week convention (`activity-calendar.ts`). */
+const CALENDAR_WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
 
 function CalendarDayCell({
   day,
@@ -599,7 +600,7 @@ function CalendarDayCell({
       tabIndex={0}
       aria-label={`${formatTooltipDay(day.day, partialDay)} — ${formatNumber(day.voiceCalls)} voice · ${formatNumber(day.attentionReviews)} attention`}
       data-calendar-day={day.day}
-      className={`size-4 rounded-[3px] outline-offset-2 ${total === 0 ? "bg-muted/60" : ""}${provisional}`}
+      className={`aspect-square w-full rounded-[3px] outline-offset-2 ${total === 0 ? "bg-muted/60" : ""}${provisional}`}
       style={total === 0 ? undefined : calendarCellStyle(total, maxTotal)}
       onPointerEnter={(event) => onShow(day, event.currentTarget)}
       onPointerLeave={(event) => {
@@ -622,6 +623,9 @@ function CalendarDayCell({
 /** The clearance between a day cell and the tooltip riding above or below it. */
 const CALENDAR_TOOLTIP_GAP_PX = 6;
 
+/** Below this cell width the year stops flexing and the wrapper scrolls instead. */
+const CALENDAR_MIN_CELL_PX = 10;
+
 interface CalendarTooltipAnchor {
   day: AdminDailyUsage;
   /** The cell's edges in the card's own coordinates, where the tooltip lives. */
@@ -631,18 +635,22 @@ interface CalendarTooltipAnchor {
 }
 
 /**
- * The same days the bars above draw, folded into a GitHub-style calendar:
- * columns are UTC weeks keyed by their Monday like the retention grid's,
- * rows the seven weekdays, and each cell's fill is that day's share of the
- * account's own busiest day in the window. The bars carry magnitude; this
+ * The account's trailing year — the server's own calendar series, apart from
+ * the window the bars above are read at — folded into an intensity calendar:
+ * columns are UTC weeks keyed by their Sunday (this calendar's own
+ * convention; the retention grid stays Monday-keyed), rows the seven
+ * weekdays Sunday to Saturday, and each cell's fill is that day's share of
+ * the account's own busiest day in the year. The bars carry magnitude; this
  * grid carries the pattern they hide — weekday rhythms, weekend gaps, a
- * streak breaking. A day the window does not cover draws nothing, a covered
- * day with no calls keeps the faintest neutral fill so absence still reads
- * as an observed day, and today wears the retention grid's dashed border
- * because a fade here would pose as a quiet day. A hovered or focused cell
- * answers at once with the charts' own tooltip — one element the whole grid
- * shares, anchored to the card rather than the week scroller so the
- * scroller's overflow cannot clip it, and clamped to the card's edges.
+ * streak breaking. The week columns flex to fill the card, and below the
+ * minimum readable cell the grid holds that minimum and the wrapper
+ * scrolls. A day the year does not cover draws nothing, a covered day with
+ * no calls keeps the faintest neutral fill so absence still reads as an
+ * observed day, and today wears the retention grid's dashed border because
+ * a fade here would pose as a quiet day. A hovered or focused cell answers
+ * at once with the charts' own tooltip — one element the whole grid shares,
+ * anchored to the card rather than the week scroller so the scroller's
+ * overflow cannot clip it, and clamped to the card's edges.
  */
 function ActivityCalendar({
   daily,
@@ -688,20 +696,23 @@ function ActivityCalendar({
   }, [anchor]);
   return (
     <div ref={cardRef} className="relative rounded-lg border border-border bg-card p-5">
-      <div className="mb-4 text-xs text-muted-foreground">This account's days, week by week</div>
+      <div className="mb-4 text-xs text-muted-foreground">
+        This account's trailing year, week by week
+      </div>
       <div className="overflow-x-auto" onScroll={hideTooltip}>
         <div
-          className="grid w-max gap-1 tabular-nums"
+          className="grid w-full gap-1 tabular-nums"
           style={{
             gridAutoFlow: "column",
-            gridTemplateRows: `auto repeat(${DAYS_PER_WEEK}, 1rem)`,
+            gridTemplateColumns: `auto repeat(${weeks.length}, minmax(${CALENDAR_MIN_CELL_PX}px, 1fr))`,
+            gridTemplateRows: `auto repeat(${DAYS_PER_WEEK}, auto)`,
           }}
         >
           <div aria-hidden="true" />
           {CALENDAR_WEEKDAY_LABELS.map((label) => (
             <div
               key={label}
-              className="pr-2 font-mono text-[10px] leading-4 text-muted-foreground uppercase"
+              className="self-center pr-2 font-mono text-[10px] leading-none text-muted-foreground uppercase"
             >
               {label}
             </div>
@@ -731,8 +742,9 @@ function ActivityCalendar({
         </div>
       </div>
       <p className="mt-4 mb-0 text-xs text-muted-foreground">
-        Each cell is one UTC day — a deeper fill is more hosted calls against this account's busiest
-        day in the window, and the dashed cell is today, still filling.
+        Each cell is one UTC day across the trailing year, whatever window is chosen above — a
+        deeper fill is more hosted calls against this account's busiest day in the year, and the
+        dashed cell is today, still filling.
       </p>
       {anchor !== undefined ? (
         <div
@@ -1635,8 +1647,9 @@ function SkeletonChartCard({ plot }: { plot: SkeletonPlot }): React.JSX.Element 
 }
 
 /**
- * The bone block is the calendar grid's own height: a month-label row and
- * seven 1rem day rows with 0.25rem gaps.
+ * The bone block approximates the calendar grid's height at the page's own
+ * max width, where a flexed day cell lands near 1rem: a month-label row and
+ * seven day rows with 0.25rem gaps.
  */
 function SkeletonCalendarCard(): React.JSX.Element {
   return (
@@ -1971,11 +1984,9 @@ function AccountSkeleton({
       <div className="mt-3">
         <SkeletonChartCard plot={SKELETON_PLOT.USAGE} />
       </div>
-      {windowDays > DAYS_PER_WEEK ? (
-        <div className="mt-3">
-          <SkeletonCalendarCard />
-        </div>
-      ) : null}
+      <div className="mt-3">
+        <SkeletonCalendarCard />
+      </div>
       <SectionHeading>Volume</SectionHeading>
       <div className="grid grid-cols-2 gap-3 min-[720px]:grid-cols-4">
         <SkeletonStatCard />
@@ -2567,16 +2578,14 @@ function UserDetailPage({
             generatedAt={detail.generatedAt}
           />
         </div>
-        {/* A 7-day window folds to a single column, which restates the bars
-            above with less resolution, so the calendar draws only for windows
-            past a week; a window with no calls already says so on the chart
-            card, and an all-neutral grid under it would restate the absence. */}
-        {detail.windowDays > DAYS_PER_WEEK &&
-        !seriesHasNoData(activity.daily.map((day) => day.voiceCalls + day.attentionReviews)) ? (
-          <div className="mt-3">
-            <ActivityCalendar daily={activity.daily} generatedAt={detail.generatedAt} />
-          </div>
-        ) : null}
+        {/* The calendar spans its own trailing year, so it draws whatever
+            window is chosen above — and an account with no calls at all
+            draws the all-neutral year, because at a year's span the quiet
+            grid is the answer rather than a restatement of the chart's
+            empty notice. */}
+        <div className="mt-3">
+          <ActivityCalendar daily={activity.calendarDaily} generatedAt={detail.generatedAt} />
+        </div>
 
         <SectionHeading>Volume</SectionHeading>
         <div className="grid grid-cols-2 gap-3 min-[720px]:grid-cols-4">

--- a/apps/web/src/activity-calendar.ts
+++ b/apps/web/src/activity-calendar.ts
@@ -1,10 +1,12 @@
 /**
- * Folds the admin page's zero-filled daily series into calendar weeks so a
- * GitHub-style grid can draw them: columns are UTC weeks keyed by their
- * Monday — the same weeks the retention grid stands on — and each week holds
- * seven slots, Monday first. A slot outside the window stays empty rather
- * than borrowing a neighbor's day, which is what lets a window opening
- * mid-week, or a window ending on today, draw an honestly ragged edge.
+ * Folds the account page's zero-filled daily series into calendar weeks so a
+ * trailing-year intensity grid can draw them: columns are UTC weeks keyed by
+ * their Sunday, and each week holds seven slots, Sunday first. Sunday-first
+ * weeks are this calendar's own convention — the retention grid and every
+ * other weekly surface stay on Monday-keyed UTC weeks, where Postgres's
+ * `date_trunc('week')` lands. A slot outside the span stays empty rather
+ * than borrowing a neighbor's day, which is what lets a span opening
+ * mid-week, or a span ending on today, draw an honestly ragged edge.
  */
 
 export const DAYS_PER_WEEK = 7;
@@ -12,9 +14,9 @@ export const DAYS_PER_WEEK = 7;
 const DAY_MS = 86_400_000;
 
 export interface CalendarWeek<Day extends { day: string }> {
-  /** The week's UTC Monday, as YYYY-MM-DD. */
+  /** The week's UTC Sunday, as YYYY-MM-DD. */
   weekStart: string;
-  /** Seven slots, Monday first; a slot the window does not cover is undefined. */
+  /** Seven slots, Sunday first; a slot the span does not cover is undefined. */
   days: readonly (Day | undefined)[];
 }
 
@@ -22,12 +24,12 @@ function daysSinceEpoch(day: string): number {
   return Date.parse(`${day}T00:00:00.000Z`) / DAY_MS;
 }
 
-/** The epoch, 1970-01-01, was a Thursday: three days past its week's Monday. */
+/** The epoch, 1970-01-01, was a Thursday: four days past its week's Sunday. */
 function weekdaySlot(day: string): number {
-  return (daysSinceEpoch(day) + 3) % DAYS_PER_WEEK;
+  return (daysSinceEpoch(day) + 4) % DAYS_PER_WEEK;
 }
 
-function mondayKey(day: string): string {
+function sundayKey(day: string): string {
   return new Date((daysSinceEpoch(day) - weekdaySlot(day)) * DAY_MS).toISOString().slice(0, 10);
 }
 
@@ -37,7 +39,7 @@ export function calendarWeeks<Day extends { day: string }>(
 ): readonly CalendarWeek<Day>[] {
   const weeks: { weekStart: string; days: (Day | undefined)[] }[] = [];
   for (const entry of daily) {
-    const weekStart = mondayKey(entry.day);
+    const weekStart = sundayKey(entry.day);
     let week = weeks.at(-1);
     if (week === undefined || week.weekStart !== weekStart) {
       week = { weekStart, days: Array.from({ length: DAYS_PER_WEEK }, () => undefined) };
@@ -51,7 +53,7 @@ export function calendarWeeks<Day extends { day: string }>(
 /**
  * One label per week column, set where a month begins: the first column, and
  * any column whose earliest covered day opens a month its predecessor's did
- * not. The earliest covered day — not the Monday — names the month, so a
+ * not. The earliest covered day — not the Sunday — names the month, so a
  * first column that starts mid-week is labeled for the days it actually
  * shows.
  */

--- a/apps/web/tests/activity-calendar.test.ts
+++ b/apps/web/tests/activity-calendar.test.ts
@@ -13,76 +13,85 @@ test("an empty account folds to no weeks at all", () => {
   assert.deepEqual(calendarWeeks([]), []);
 });
 
-test("a full Monday-to-Sunday week fills its seven slots in order", () => {
-  // 2026-08-17 is a Monday.
-  const weeks = calendarWeeks(series("2026-08-17", 7));
+test("a full Sunday-to-Saturday week fills its seven slots in order", () => {
+  // 2026-08-16 is a Sunday.
+  const weeks = calendarWeeks(series("2026-08-16", 7));
   assert.equal(weeks.length, 1);
-  assert.equal(weeks[0]?.weekStart, "2026-08-17");
+  assert.equal(weeks[0]?.weekStart, "2026-08-16");
   assert.deepEqual(
     weeks[0]?.days.map((day) => day?.day),
     [
+      "2026-08-16",
       "2026-08-17",
       "2026-08-18",
       "2026-08-19",
       "2026-08-20",
       "2026-08-21",
       "2026-08-22",
-      "2026-08-23",
     ],
   );
 });
 
-test("a window opening mid-week leaves the days before it empty", () => {
+test("a span opening mid-week leaves the days before it empty", () => {
   // 2026-08-19 is a Wednesday; nine days end the following Thursday.
   const weeks = calendarWeeks(series("2026-08-19", 9));
   assert.equal(weeks.length, 2);
-  assert.equal(weeks[0]?.weekStart, "2026-08-17");
+  assert.equal(weeks[0]?.weekStart, "2026-08-16");
   assert.deepEqual(
     weeks[0]?.days.map((day) => day?.day),
-    [undefined, undefined, "2026-08-19", "2026-08-20", "2026-08-21", "2026-08-22", "2026-08-23"],
+    [undefined, undefined, undefined, "2026-08-19", "2026-08-20", "2026-08-21", "2026-08-22"],
   );
-  assert.equal(weeks[1]?.weekStart, "2026-08-24");
+  assert.equal(weeks[1]?.weekStart, "2026-08-23");
   assert.deepEqual(
     weeks[1]?.days.map((day) => day?.day),
-    ["2026-08-24", "2026-08-25", "2026-08-26", "2026-08-27", undefined, undefined, undefined],
+    ["2026-08-23", "2026-08-24", "2026-08-25", "2026-08-26", "2026-08-27", undefined, undefined],
   );
 });
 
-test("a window ending on a partial today leaves the days after it empty", () => {
+test("a span ending on a partial today leaves the days after it empty", () => {
   // Five days from Monday 2026-08-17 end on Friday the 21st, today's own day.
   const weeks = calendarWeeks(series("2026-08-17", 5));
   assert.equal(weeks.length, 1);
   assert.deepEqual(
     weeks[0]?.days.map((day) => day?.day),
-    ["2026-08-17", "2026-08-18", "2026-08-19", "2026-08-20", "2026-08-21", undefined, undefined],
+    [undefined, "2026-08-17", "2026-08-18", "2026-08-19", "2026-08-20", "2026-08-21", undefined],
   );
 });
 
-test("a 90-day window folds to fourteen Monday-keyed weeks with ragged ends", () => {
-  // 2026-05-24 is a Sunday, so 90 days ending Friday 2026-08-21 span a
-  // one-day first week, twelve full weeks, and a five-day last week.
+test("a 90-day span folds to thirteen Sunday-keyed weeks with a ragged end", () => {
+  // 2026-05-24 is a Sunday, so 90 days ending Friday 2026-08-21 span twelve
+  // full weeks and a six-day last week.
   const weeks = calendarWeeks(series("2026-05-24", 90));
-  assert.equal(weeks.length, 14);
-  assert.equal(weeks[0]?.weekStart, "2026-05-18");
-  assert.deepEqual(
-    weeks[0]?.days.map((day) => day?.day),
-    [undefined, undefined, undefined, undefined, undefined, undefined, "2026-05-24"],
-  );
-  assert.equal(weeks.at(-1)?.weekStart, "2026-08-17");
-  assert.equal(weeks.at(-1)?.days[4]?.day, "2026-08-21");
-  assert.equal(weeks.at(-1)?.days[5], undefined);
+  assert.equal(weeks.length, 13);
+  assert.equal(weeks[0]?.weekStart, "2026-05-24");
+  assert.equal(weeks[0]?.days[0]?.day, "2026-05-24");
+  assert.equal(weeks.at(-1)?.weekStart, "2026-08-16");
+  assert.equal(weeks.at(-1)?.days[5]?.day, "2026-08-21");
+  assert.equal(weeks.at(-1)?.days[6], undefined);
   const coveredDays = weeks.flatMap((week) => week.days.filter((day) => day !== undefined));
   assert.equal(coveredDays.length, 90);
 });
 
+test("a trailing year folds to 53 columns: 52 complete weeks and today's partial one", () => {
+  // 2025-08-17 is a Sunday; 366 days end on Monday 2026-08-17.
+  const weeks = calendarWeeks(series("2025-08-17", 366));
+  assert.equal(weeks.length, 53);
+  assert.equal(weeks[0]?.weekStart, "2025-08-17");
+  assert.equal(weeks.at(-1)?.weekStart, "2026-08-16");
+  assert.equal(weeks.at(-1)?.days[1]?.day, "2026-08-17");
+  assert.equal(weeks.at(-1)?.days[2], undefined);
+  const coveredDays = weeks.flatMap((week) => week.days.filter((day) => day !== undefined));
+  assert.equal(coveredDays.length, 366);
+});
+
 test("month labels mark the first column and each column opening a new month", () => {
-  // 2026-07-27 is a Monday; two weeks later August has begun.
+  // 2026-07-27 is a Monday; a week and a half later August has begun.
   const labels = monthLabels(calendarWeeks(series("2026-07-27", 14)));
-  assert.deepEqual(labels, ["Jul", "Aug"]);
+  assert.deepEqual(labels, ["Jul", "Aug", undefined]);
 });
 
 test("a first column starting mid-week is labeled for the days it shows", () => {
   // 2026-08-01 is a Saturday inside July's last calendar week.
   const labels = monthLabels(calendarWeeks(series("2026-08-01", 9)));
-  assert.deepEqual(labels, ["Aug", undefined]);
+  assert.deepEqual(labels, ["Aug", undefined, undefined]);
 });

--- a/apps/web/tests/admin-user.test.ts
+++ b/apps/web/tests/admin-user.test.ts
@@ -33,6 +33,7 @@ function userSource(usage: Partial<AdminUserSource["usage"]> = {}): AdminUserSou
     },
     usage: {
       byDay: new Map(),
+      calendarByDay: new Map(),
       allTime: {
         activeDays: 0,
         firstActiveDay: null,
@@ -69,6 +70,37 @@ test("the daily series is zero-filled and the window counts fold from it", () =>
   assert.equal(detail.activity.attentionReviewsWindow, 8);
   const emptyDay = detail.activity.daily.find((day) => day.day === "2026-08-01");
   assert.deepEqual(emptyDay, { day: "2026-08-01", voiceCalls: 0, attentionReviews: 0 });
+});
+
+test("the calendar series spans the trailing year, opening on a Sunday", () => {
+  const detail = build({
+    calendarByDay: new Map([
+      ["2025-09-01", { voiceCalls: 4, attentionReviews: 2 }],
+      ["2026-08-17", { voiceCalls: 1, attentionReviews: 0 }],
+    ]),
+  });
+
+  // NOON_UTC's day, 2026-08-17, is a Monday: one day into a Sunday-opened
+  // week, so the year is 52 complete weeks plus two partial-week days.
+  assert.equal(detail.activity.calendarDaily.length, 366);
+  assert.equal(detail.activity.calendarDaily[0]?.day, "2025-08-17");
+  assert.equal(detail.activity.calendarDaily.at(-1)?.day, "2026-08-17");
+  const filled = detail.activity.calendarDaily.find((day) => day.day === "2025-09-01");
+  assert.deepEqual(filled, { day: "2025-09-01", voiceCalls: 4, attentionReviews: 2 });
+  const quiet = detail.activity.calendarDaily.find((day) => day.day === "2026-01-01");
+  assert.deepEqual(quiet, { day: "2026-01-01", voiceCalls: 0, attentionReviews: 0 });
+});
+
+test("the calendar series keeps its year whatever window the page is read at", () => {
+  const calendarByDay = new Map<string, AdminUsageDay>([
+    ["2025-12-25", { voiceCalls: 3, attentionReviews: 1 }],
+  ]);
+  const week = build({ calendarByDay }, ADMIN_METRICS_WINDOW.WEEK);
+  const quarter = build({ calendarByDay }, ADMIN_METRICS_WINDOW.QUARTER);
+
+  assert.equal(week.activity.daily.length, ADMIN_METRICS_WINDOW.WEEK);
+  assert.equal(quarter.activity.daily.length, ADMIN_METRICS_WINDOW.QUARTER);
+  assert.deepEqual(week.activity.calendarDaily, quarter.activity.calendarDaily);
 });
 
 test("a streak ending today counts back to its first gap", () => {


### PR DESCRIPTION
## What

The account page's activity calendar no longer follows the 7/30/90-day window switcher. It is now a trailing-year intensity calendar: always the same span — the last 52 complete UTC weeks plus the current partial one — and always drawn, filling the full card width.

- The account detail response gains a calendar-specific daily series independent of the window: trailing-year UTC day rows, zero-filled, in the same voice/attention shape as the windowed series (`AdminUserSource.usage.calendarByDay`, `AdminUserDetail.activity.calendarDaily`).
- Per the user's requested convention, the calendar's weeks open on **Sunday**: rows read Sun..Sat top to bottom and columns are Sunday-keyed UTC weeks. This is the account calendar's own convention — the retention grid and every other weekly surface stay Monday-keyed UTC, and each surface's comment now states its own keying.
- The calendar draws whatever window is chosen above, and an account with zero calls draws the all-neutral year: at a year's span the quiet grid is itself the answer. Intensity scales to the account's busiest day in the year span, and today keeps the dashed partial-day treatment.
- Week columns flex to fill the card (fr-unit columns with aspect-square cells), so at the content max-width the ~53 columns span edge to edge; below a 10px cell the grid holds that minimum and the existing horizontal scroller takes over. Month labels mark only a month's first week, so twelve months sit uncrowded.

## How

- `apps/web/server/admin/admin-user.ts`: `calendarDayKeys(now)` names the Sunday-opened trailing-year span; the builder zero-fills `calendarDaily` from the new `calendarByDay` map.
- `apps/web/server/admin/admin-queries.ts`: one additional bounded query in the account read, alongside the existing parallel reads, at the calendar's own start bound.
- `apps/web/src/activity-calendar.ts`: the week fold is Sunday-keyed for this surface, with the convention (and its difference from the retention grid's) stated where the keying lives.
- `apps/web/src/AdminDashboard.tsx`: the render rule loses the `windowDays > DAYS_PER_WEEK` and no-calls skips (comment updated to carry the year-span rationale), the grid gains `minmax(10px, 1fr)` columns with aspect-square cells, weekday labels read Sun..Sat, and the caption says the span is the trailing year regardless of the window above.
- Tests: the week-fold helper tests are rewritten for Sunday keys (including a 53-column trailing-year fold), and the account shaping tests cover the calendar series' span, zero-fill, Sunday opening, and independence from the window.

## Verification

- `./scripts/check.sh` passes (exit 0; one unrelated `apps/desktop` test, `microphone-route.test.ts`, flaked in an earlier run and passes standalone and in the clean rerun).
- Headless Chrome against the dev server with stubbed `/api/admin/user` payloads built by the real `buildAdminUserDetail`:
  - 1200px viewport: 371 cells from Sunday 2025-08-17 through today 2026-08-22, grid width equal to the wrapper width (edge-to-edge fill), 13 month labels Aug..Aug uncrowded, dashed today cell bottom-right.
  - Instant tooltip at the first column clamps 1px inside the card's left edge and at the last column 16px inside the right edge, wording intact ("Aug 22 (so far today) · Voice calls 3 · Attention reviews 2").
  - 390px viewport: cells hold the 10px minimum, the wrapper scrolls (270px viewport over a 768px grid), and the tooltip inside the scrolled grid draws clamped within the card, not clipped by the scroller.
  - An all-quiet account draws the full all-neutral year with only the dashed today cell.
- Web-only change; no desktop surface touched, so no macOS/notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32556723912/artifacts/9471668474) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32556723912)

- Commit: `69de0a4d04e4e664fa81e981577a4a0926c2e8ad`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
