### PR TITLE
fix(admin): fit the year calendar to any viewport without scrolling

### DIFF
--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -29,7 +29,7 @@ import {
 import { accountInitials } from "./account-initials";
 import { accountLabel } from "./account-label";
 import { GitHubMark, GoogleMark } from "./account-marks";
-import { calendarWeeks, DAYS_PER_WEEK, monthLabels } from "./activity-calendar";
+import { calendarWeeks, DAYS_PER_WEEK, monthLabels, thinMonthLabels } from "./activity-calendar";
 import { settleRead } from "./admin-refresh";
 import {
   SIDEBAR_ICON_SLOT,
@@ -591,8 +591,13 @@ function CalendarDayCell({
   onHide: () => void;
 }): React.JSX.Element {
   const total = day.voiceCalls + day.attentionReviews;
+  // Below the container width where a dash can draw on a cell at all, today
+  // wears a solid one-pixel ring instead: it costs no inner area a tiny cell
+  // cannot spare, and stays visible at any cell size.
   const provisional =
-    day.day === partialDay ? " border border-dashed border-muted-foreground/60" : "";
+    day.day === partialDay
+      ? " ring-1 ring-muted-foreground/70 @xl:border @xl:border-dashed @xl:border-muted-foreground/60 @xl:ring-0"
+      : "";
   return (
     <div
       role="img"
@@ -600,7 +605,7 @@ function CalendarDayCell({
       tabIndex={0}
       aria-label={`${formatTooltipDay(day.day, partialDay)} — ${formatNumber(day.voiceCalls)} voice · ${formatNumber(day.attentionReviews)} attention`}
       data-calendar-day={day.day}
-      className={`aspect-square w-full rounded-[3px] outline-offset-2 ${total === 0 ? "bg-muted/60" : ""}${provisional}`}
+      className={`aspect-square w-full rounded-[clamp(1px,0.3cqw,3px)] outline-offset-2 ${total === 0 ? "bg-muted/60" : ""}${provisional}`}
       style={total === 0 ? undefined : calendarCellStyle(total, maxTotal)}
       onPointerEnter={(event) => onShow(day, event.currentTarget)}
       onPointerLeave={(event) => {
@@ -623,9 +628,6 @@ function CalendarDayCell({
 /** The clearance between a day cell and the tooltip riding above or below it. */
 const CALENDAR_TOOLTIP_GAP_PX = 6;
 
-/** Below this cell width the year stops flexing and the wrapper scrolls instead. */
-const CALENDAR_MIN_CELL_PX = 10;
-
 interface CalendarTooltipAnchor {
   day: AdminDailyUsage;
   /** The cell's edges in the card's own coordinates, where the tooltip lives. */
@@ -642,15 +644,18 @@ interface CalendarTooltipAnchor {
  * weekdays Sunday to Saturday, and each cell's fill is that day's share of
  * the account's own busiest day in the year. The bars carry magnitude; this
  * grid carries the pattern they hide — weekday rhythms, weekend gaps, a
- * streak breaking. The week columns flex to fill the card, and below the
- * minimum readable cell the grid holds that minimum and the wrapper
- * scrolls. A day the year does not cover draws nothing, a covered day with
- * no calls keeps the faintest neutral fill so absence still reads as an
- * observed day, and today wears the retention grid's dashed border because
- * a fade here would pose as a quiet day. A hovered or focused cell answers
+ * streak breaking. The week columns always divide the card's width — a year
+ * that scrolls is a year whose shape cannot be seen — so the gaps and cell
+ * rounding scale with the container rather than eating cells a phone can
+ * barely afford, and on a narrow card the weekday column folds away and
+ * every second month label drops so the survivors never collide. A day the
+ * year does not cover draws nothing, a covered day with no calls keeps the
+ * faintest neutral fill so absence still reads as an observed day, and
+ * today wears the retention grid's dashed border — a fade here would pose
+ * as a quiet day — until the cells are too small for a dash to draw, where
+ * it becomes a solid ring. A hovered or focused cell answers
  * at once with the charts' own tooltip — one element the whole grid shares,
- * anchored to the card rather than the week scroller so the scroller's
- * overflow cannot clip it, and clamped to the card's edges.
+ * anchored to the card and clamped to its edges.
  */
 function ActivityCalendar({
   daily,
@@ -661,6 +666,7 @@ function ActivityCalendar({
 }): React.JSX.Element {
   const weeks = calendarWeeks(daily);
   const months = monthLabels(weeks);
+  const sparseMonths = thinMonthLabels(months, 2);
   const partialDay = partialDayKey(daily, generatedAt);
   const maxTotal = Math.max(...daily.map((day) => day.voiceCalls + day.attentionReviews));
   const cardRef = useRef<HTMLDivElement>(null);
@@ -699,12 +705,12 @@ function ActivityCalendar({
       <div className="mb-4 text-xs text-muted-foreground">
         This account's trailing year, week by week
       </div>
-      <div className="overflow-x-auto" onScroll={hideTooltip}>
+      <div className="@container">
         <div
-          className="grid w-full gap-1 tabular-nums"
+          className="grid w-full gap-[clamp(1px,0.35cqw,4px)] tabular-nums"
           style={{
             gridAutoFlow: "column",
-            gridTemplateColumns: `auto repeat(${weeks.length}, minmax(${CALENDAR_MIN_CELL_PX}px, 1fr))`,
+            gridTemplateColumns: `auto repeat(${weeks.length}, minmax(0, 1fr))`,
             gridTemplateRows: `auto repeat(${DAYS_PER_WEEK}, auto)`,
           }}
         >
@@ -712,15 +718,16 @@ function ActivityCalendar({
           {CALENDAR_WEEKDAY_LABELS.map((label) => (
             <div
               key={label}
-              className="self-center pr-2 font-mono text-[10px] leading-none text-muted-foreground uppercase"
+              className="self-center font-mono text-[min(10px,1.5cqw)] leading-none text-muted-foreground uppercase @xl:pr-2"
             >
-              {label}
+              <span className="hidden @xl:inline">{label}</span>
             </div>
           ))}
           {weeks.map((week, weekIndex) => (
             <Fragment key={week.weekStart}>
-              <div className="font-mono text-[10px] leading-4 whitespace-nowrap text-muted-foreground uppercase">
-                {months[weekIndex]}
+              <div className="font-mono text-[9px] leading-4 whitespace-nowrap text-muted-foreground uppercase @xl:text-[10px]">
+                <span className="@xl:hidden">{sparseMonths[weekIndex]}</span>
+                <span className="hidden @xl:inline">{months[weekIndex]}</span>
               </div>
               {week.days.map((day, slot) =>
                 day === undefined ? (
@@ -744,7 +751,7 @@ function ActivityCalendar({
       <p className="mt-4 mb-0 text-xs text-muted-foreground">
         Each cell is one UTC day across the trailing year, whatever window is chosen above — a
         deeper fill is more hosted calls against this account's busiest day in the year, and the
-        dashed cell is today, still filling.
+        outlined cell is today, still filling.
       </p>
       {anchor !== undefined ? (
         <div

--- a/apps/web/src/activity-calendar.ts
+++ b/apps/web/src/activity-calendar.ts
@@ -73,3 +73,21 @@ export function monthLabels(
     });
   });
 }
+
+/**
+ * Every `keepEvery`th of the labels `monthLabels` set, first kept, in their
+ * columns. At widths where a year's thirteen labels would collide, dropping
+ * whole labels keeps the survivors readable; squeezing all thirteen would
+ * overlap them into none.
+ */
+export function thinMonthLabels(
+  labels: readonly (string | undefined)[],
+  keepEvery: number,
+): readonly (string | undefined)[] {
+  let ordinal = 0;
+  return labels.map((label) => {
+    if (label === undefined) return undefined;
+    ordinal += 1;
+    return (ordinal - 1) % keepEvery === 0 ? label : undefined;
+  });
+}

--- a/apps/web/tests/activity-calendar.test.ts
+++ b/apps/web/tests/activity-calendar.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { calendarWeeks, monthLabels } from "../src/activity-calendar";
+import { calendarWeeks, monthLabels, thinMonthLabels } from "../src/activity-calendar";
 
 function series(firstDay: string, days: number): { day: string }[] {
   const start = Date.parse(`${firstDay}T00:00:00.000Z`);
@@ -94,4 +94,29 @@ test("a first column starting mid-week is labeled for the days it shows", () => 
   // 2026-08-01 is a Saturday inside July's last calendar week.
   const labels = monthLabels(calendarWeeks(series("2026-08-01", 9)));
   assert.deepEqual(labels, ["Aug", undefined, undefined]);
+});
+
+test("thinning keeps every second label in place, first kept", () => {
+  const labels = thinMonthLabels(
+    ["Jul", undefined, "Aug", undefined, "Sep", "Oct", undefined, "Nov"],
+    2,
+  );
+  assert.deepEqual(labels, [
+    "Jul",
+    undefined,
+    undefined,
+    undefined,
+    "Sep",
+    undefined,
+    undefined,
+    "Nov",
+  ]);
+});
+
+test("a trailing year thins from thirteen labels to seven, both ends kept", () => {
+  const labels = thinMonthLabels(monthLabels(calendarWeeks(series("2025-08-17", 366))), 2);
+  const kept = labels.filter((label) => label !== undefined);
+  assert.equal(kept.length, 7);
+  assert.equal(labels[0], "Aug");
+  assert.equal(kept.at(-1), "Aug");
 });


### PR DESCRIPTION
## What

The account page's trailing-year calendar fell back to a horizontal scroller below a minimum cell width, so on a phone the year arrived one swipe-window at a time. The grid's 53 week columns now always divide the card's width, at any viewport, with no scroller and no minimum cell: at ~360px the cells land around 4px, and the year's shape — weekday rhythms, weekend gaps, streaks breaking — is the point at that size.

## How

- The `minmax(10px, 1fr)` columns and the `overflow-x-auto` wrapper are gone; columns are `minmax(0, 1fr)` inside a `@container` wrapper.
- The fixed `gap-1` was the real cost: 4px × 52 inter-column gaps is ~208px, more than the cells themselves would get at phone width. Both gaps now scale with the card (`clamp(1px, 0.35cqw, 4px)`), so cells keep the majority of the width at every size while still reading as discrete marks, and rows track columns so cells stay square.
- Cell rounding scales the same way (`clamp(1px, 0.3cqw, 3px)`), so a 3px radius never smears a 4px cell.
- Labels are container-driven, keyed to the card rather than the viewport since a sidebar can narrow the card on a wide screen: below the `@xl` container width the weekday column folds away entirely (no label is legible at a 4–5px row height, and unreadable text is decoration), and the month row thins to every second month via a tested `thinMonthLabels` helper in `activity-calendar.ts`, so the seven survivors never collide. At `@xl` and up all thirteen months and Sun–Sat return, with the weekday font capped at `min(10px, 1.5cqw)` so labels never inflate the rows past the cells.
- Today's provisional treatment stays visible at every size: the retention grid's dashed border where cells are large enough for a dash to draw (`@xl` and up), and a solid one-pixel ring below that, since a dash cannot draw on a 4px cell and a ring costs no inner area. The card's footnote now says "outlined" so it stays true in both regimes.
- The shared instant tooltip is untouched; its card-clamped placement already holds when the grid is viewport-wide.

## Verification

- `./scripts/check.sh` passed (exit 0: repository checks, types, tests including the new `thinMonthLabels` tests, and builds).
- Headless Chrome against the built app with stubbed session and account data, at 1200px, 768px, 390px, and 360px viewports (screenshots inspected at each):
  - Zero horizontal document overflow (`scrollWidth − clientWidth = 0`) and zero elements with scrollable overflow inside the card at every width.
  - Cells: 12.8px at 1200 (gap 3.1px, dashed today, 13 month labels, Sun–Sat column), 6.8px at 768 (card narrowed to 496px by the sidebar, so container-driven thinning engages), 4.5px at 390 and 4px at 360 (gap 1px, 7 non-colliding month labels, today as a visible 1px ring).
  - Month label bounding boxes verified non-overlapping programmatically at every width.
  - Tooltip verified at 390px on the first and last columns: shown instantly, correct day text ("Aug 23" / "Aug 23 (so far today)"), clamped inside the card's edges, no viewport overflow.
- Web-only change; no desktop surface touched, so no macOS/notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32616357556/artifacts/9487085910) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32616357556)

- Commit: `c1e5cbca6fd1f4431da64d559dbd4f021b9dd60d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
