### PR TITLE
fix(realtime): omit the recap segment for a session without one

### DIFF
--- a/packages/realtime/src/realtime-context.ts
+++ b/packages/realtime/src/realtime-context.ts
@@ -236,7 +236,9 @@ export function sessionContextText(
         session.status,
         sessionAgeText(session.observedAt, now),
         ...sessionAboutText(session),
-        session.recap ?? "no recap reported",
+        // Stating an absence in context invites the voice to speak it, so a
+        // session without a recap simply omits the segment.
+        ...(session.recap ? [session.recap] : []),
         // Only this segment speaks for the developer, on the attention
         // update's own rule: words inside a title, recap, or error never do.
         ...(ask ? [`the developer's standing ask: "${ask}"`] : []),

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -948,6 +948,7 @@ test("the roster says what a session is doing and where, in the attention update
   assert.match(bareText, /in repository luke/);
   assert.doesNotMatch(bareText, /running/);
   assert.doesNotMatch(bareText, /error:/);
+  assert.doesNotMatch(bareText, /recap/);
 });
 
 test("the roster says which sessions keep a readable transcript and a pull request, never an address", () => {


### PR DESCRIPTION
## Summary

`sessionContextText` rendered `session.recap ?? "no recap reported"` into every roster line sent to the voice conversation. Stating an absence in context invites the model to speak it — "…and no recap was reported" is pure filler the developer never asked to hear. The recap segment is now conditionally spread exactly like the line's other optional segments (workspace, applications, standing ask): a session without a recap simply omits it.

The existing bare-session test gains an assertion that a recap-less line carries no recap segment; no other roster rendering changes.

## Validation

Portable-only change, validated by `./scripts/check.sh`: exit 0, all checks green, `packages/realtime` 111/111 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32657405732/artifacts/9497837043) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32657405732)

- Commit: `5c6041eb1bd31f5bf28605c6a37dd860460cbc99`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
