### PR TITLE
fix(realtime): cut filler from Luke's standing voice instructions

### DIFF
--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -164,15 +164,24 @@ const REALTIME_INSTRUCTION_HEAD: readonly string[] = [
   "How to speak:",
   '- Speak as Luke in first person and address the user directly as "you".',
   "- Refer to sessions as agents and speak about them as if they were humans.",
-  "- Be concise. Prefer short answers unless the user asks for more detail.",
-  "- Start with the answer; do not repeat the user's request.",
-  "- Call a tool without announcing it; do not restate what the user asked for first.",
+  "- Answer in one or two sentences; go past three only when the user asks for detail.",
+  '- No greetings, acknowledgments, or lead-ins ("Sure", "Got it", "Let me check"), and never ' +
+    "end a reply with an offer of more help.",
+  "- Start with the answer or the tool call, announcing neither; do not repeat the user's " +
+    "request.",
   '- When a tool call succeeds, say "Done." and nothing more — unless the result itself is ' +
     "what the user asked to hear (a transcript reading, a check's answer, a provider with " +
     "nowhere to open), which is still spoken in full.",
-  "- When the user asks about overall progress, summarize across the observed agents.",
+  "- When the user asks about overall progress, lead with what needs them; aggregate the rest " +
+    'by count ("three still working") and name an agent only when it needs attention or was ' +
+    "asked about.",
   "- When referring to an agent, identify it by the work it is doing.",
-  "- Do not mention internal identifiers such as commit hashes or session IDs.",
+  "- Do not mention internal identifiers such as commit hashes or session IDs, and do not read " +
+    'a roster line\'s bracketed capability data, ages ("updated two minutes ago"), or branches ' +
+    "aloud unless asked, or unless they tell two agents apart.",
+  "- A refusal is the reason in one sentence, with no apology.",
+  "- When asked about the app itself, answer with the one relevant fact from the app guide, " +
+    "not its whole entry.",
   "",
   "How to know which agent an ask means:",
   "- A [recent conversation] message is memory carried across calls: what you and the user " +

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -252,8 +252,9 @@ test("the standing instructions make Luke the coding agents' engineering manager
   const instructions = realtimeInstructions();
 
   assert.match(instructions, /engineering manager for the developer's coding agents/i);
-  assert.match(instructions, /start with the answer; do not repeat the user's request/i);
-  assert.match(instructions, /call a tool without announcing it/i);
+  assert.match(instructions, /answer in one or two sentences/i);
+  assert.match(instructions, /never end a reply with an offer of more help/i);
+  assert.match(instructions, /start with the answer or the tool call, announcing neither/i);
   assert.match(instructions, /when a tool call succeeds, say "done\."/i);
   assert.match(instructions, /unless the result itself is what the user asked to hear/i);
   assert.match(instructions, /explicit latest or most-recent ask resolves by the recency labels/i);


### PR DESCRIPTION
## What

Rewrites the "How to speak" section of `REALTIME_INSTRUCTION_HEAD` in `packages/realtime/src/realtime-protocol.ts` so Luke's spoken replies stop carrying the filler realtime voice models default to. Each change names the filler it targets:

- **Padding past the answer** — "Be concise. Prefer short answers…" was abstract and easy to satisfy with three sentences of hedging. It is now a hard default: one or two sentences, past three only when the user asks for detail.
- **Acknowledgment and closing filler** — realtime voice models open with "Sure", "Got it", "Let me check" and close with "Let me know if you need anything else". Both are now banned by name; nothing in the old head addressed them.
- **Roll-call progress summaries** — "summarize across the observed agents" read as an invitation to walk the roster row by row. The rule now leads with what needs the user, aggregates the rest by count ("three still working"), and names an agent only when it needs attention or was asked about.
- **Plumbing read aloud** — the roster's bracketed capability data, ages ("updated two minutes ago"), and branches were only implicitly off-limits. They now join the internal-identifiers rule: never spoken unless asked, or unless they tell two agents apart.
- **Apologetic refusals** — a refusal is now the reason in one sentence, with no apology.
- **Guide recitals** — an ask about the app itself now gets the one relevant fact from the app guide, not its whole entry.
- **A duplicated rule** — "Start with the answer; do not repeat the user's request." and "Call a tool without announcing it; do not restate what the user asked for first." said the same thing about the two kinds of turn openings. They are merged into one rule covering both.

Unchanged: the persona lines, the `"Done."` rule for tool success, identifying agents by their work, and the entire "How to know which agent an ask means" section — that is disambiguation policy, not verbosity.

`realtime.test.ts` assertions updated to match the merged rule and to pin the sentence budget and the closing-offer ban.

## Validation

Portable-only change, validated by `./scripts/check.sh` (passes, exit 0). No UI change, so no macOS evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32657479486/artifacts/9497859311) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32657479486)

- Commit: `cd38378859c7a27f25a44f6b38baa2381a8fc93e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
