### PR TITLE
fix(admin): keep a gap between a chart tooltip's label and value

### DIFF
--- a/apps/web/src/components/ui/chart.tsx
+++ b/apps/web/src/components/ui/chart.tsx
@@ -257,7 +257,7 @@ function ChartTooltipContent({
                     )}
                     <div
                       className={cn(
-                        "flex flex-1 justify-between leading-none",
+                        "flex flex-1 justify-between gap-4 leading-none",
                         nestLabel ? "items-end" : "items-center",
                       )}
                     >


### PR DESCRIPTION
## Summary
The admin charts' hover tooltips ran the series label straight into its number ("Attention reviews263") because the vendored shadcn `ChartTooltipContent` row uses `justify-between` with no gap, which collapses whenever the tooltip sits at its 8rem min-width. The hand-rolled trailing-year calendar tooltip already kept a `gap-4` on the same row, which is why it looked right.

This adds the same `gap-4` to the shared primitive, fixing every recharts-based chart at once: the account detail's calls-per-day chart, and the dashboard's new-accounts-per-day and hosted-tier-calls-per-day charts.

## Testing
- `./scripts/check.sh` — passed (lint, typecheck, tests, builds).
- Web-only change to the admin dashboard's tooltip styling; no macOS surface moved, so no packaged-app or physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/1378ed81-643a-402b-a6f5-743704d8a5f0)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32658059298/artifacts/9498011216) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32658059298)

- Commit: `d65954fa15655c3c1d941d9631f114a18c0f8081`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
