### PR TITLE
refactor(desktop): split the app guide into targeted facts

### DIFF
--- a/apps/desktop/src/renderer/AGENTS.md
+++ b/apps/desktop/src/renderer/AGENTS.md
@@ -134,6 +134,11 @@ you either write its guide entry or return `undefined` with a comment saying
 how the guide covers it instead. The facts half has no such lever, so the rule
 is stated here: a capability, surface, or shortcut the guide does not describe
 is one Luke will deny having, and a stale entry is one he will misdescribe.
+The facts deliberately cover what a developer would ask Luke and what a spoken
+ask may do — not exhaustive surface or connector behavior, which the guide's
+closing fact has Luke redirect to the surface rather than deny — so the rule
+binds in full for capabilities, acts, refusals, and boundaries, and a new one
+still lands here in the same change.
 Update the facts whenever you change what the panel holds, what a key does, or
 what a provider connection means.
 

--- a/apps/desktop/src/renderer/luke-guide.test.ts
+++ b/apps/desktop/src/renderer/luke-guide.test.ts
@@ -298,23 +298,16 @@ test("the facts say what is connected, never what connects it", () => {
   assert.doesNotMatch(rendered, /API key:/);
 });
 
-test("the guide distinguishes app identity from exact app opening", () => {
+test("the app-mark fact stays at the ask level: identity, and opening where addressed", () => {
   const rendered = JSON.stringify(buildLukeGuide(guideInput()).facts);
 
-  // Identity and opening are separate facts, so an ask about either draws a
-  // targeted answer; both must keep describing the whole capability between
-  // them.
+  // The taxonomy is deliberately one fact of two sentences: which apps a chat
+  // appears in, that an addressed mark opens there, and that an ask can pick
+  // the app. Finer per-app mechanics are the surface's to show, not the
+  // guide's to recite.
   assert.match(rendered, /"label":"Apps beside a session"/);
-  assert.match(rendered, /"label":"Opening a chat in its apps"/);
-  assert.match(rendered, /app mark with an exact address is a button/);
-  assert.match(rendered, /ChatGPT opens that Codex thread/);
-  assert.match(rendered, /Superset opens its bound terminal/);
-  assert.match(rendered, /Codex sub-agent spawned there keeps the Conductor association/);
-  // A Conductor cloud chat leads with its agent's own mark, its Conductor
-  // mark opens the exact chat, and a local one stays identification alone.
-  assert.match(rendered, /leads?[^.]*with the agent running it/);
-  assert.match(rendered, /Conductor cloud chat's Conductor mark opens that exact chat/);
-  assert.match(rendered, /adds no open or send control/);
+  assert.match(rendered, /mark with an exact address opens the chat in that app/);
+  assert.match(rendered, /ask can name which app/);
 });
 
 test("the guide names the signed-in identity and keeps sign-out manual", () => {
@@ -351,29 +344,20 @@ test("the facts describe creating a workspace, so Luke does not deny the capabil
   // Where a nameless ask goes rides with it too, so the remembered first
   // choice is something Luke explains rather than something that surprises.
   assert.match(rendered, /default workspace provider/);
-  assert.match(rendered, /first workspace created saves its provider/);
-  // The project a nameless ask lands in rides the same way, so the remembered
-  // first choice within a provider is explained rather than a surprise.
   assert.match(rendered, /default project/);
-  assert.match(rendered, /first workspace created there/);
+  assert.match(rendered, /first workspace created fills each in/);
   // And so is what the new agent runs, because a model the user never chose
   // is exactly the surprise this setting exists to end.
   assert.match(rendered, /its model, and its effort/);
   // Where a bare "new agent" ask lands rides with both facts, so the guide
   // explains the default the same way the conversation acts on it: a new
   // workspace, unless the ask itself names the existing one to join.
-  assert.match(rendered, /bare ask for a new agent lands here/);
-  // The join exception names both handles a developer might say — the
-  // workspace and a session in it — so a named session is not steered into
-  // a fresh workspace it did not ask for.
-  assert.match(rendered, /names the existing workspace or session/);
-  assert.match(rendered, /bare ask for a new agent creates a new workspace instead/);
+  assert.match(rendered, /bare ask for a new agent creates a new workspace/);
+  assert.match(rendered, /naming an existing workspace or session adds an agent beside it/);
   // Superset creates workspaces too, and asks for more than the others do —
   // a guide that named only Conductor and Cursor would have Luke deny a
   // capability he has, then be surprised by the refusal a task-less ask earns.
-  assert.match(rendered, /Superset/);
-  assert.match(rendered, /new Superset workspace needs that host, an agent/);
-  assert.match(rendered, /opening task/);
+  assert.match(rendered, /new Superset workspace needs a host, an agent, and an opening task/);
 
   // The one removal a Superset row takes is deleting its settled workspace,
   // and the guide says every half out loud: what the delete is — permanent,
@@ -382,11 +366,7 @@ test("the facts describe creating a workspace, so Luke does not deny the capabil
   // and that the developer's own word for tidying, archive, is taken as the
   // delete rather than refused over vocabulary.
   assert.match(rendered, /Delete workspace once its work settled/);
-  // The idle workspaces are the ones a cleanup ask is usually about, so the
-  // guide teaches that they stand as rows at all — and which never do.
-  assert.match(rendered, /no agent chat at all stands as its own idle row/);
-  assert.match(rendered, /agentless workspace row counts as settled/);
-  assert.match(rendered, /main checkout and workspaces Superset already archived draw no row/);
+  assert.match(rendered, /idle worktree workspace stands as its own row/);
   assert.match(rendered, /deleting is permanent/);
   assert.match(rendered, /single chat cannot be closed or removed on its own/);
   assert.match(rendered, /ask to archive one means exactly this delete/);
@@ -400,8 +380,7 @@ test("the facts describe renaming workspaces and chats, so Luke does not deny th
   assert.match(rendered, /Renaming workspaces and chats/);
   // The refusal shape rides with the offer: only a session whose roster entry
   // advertises a rename takes one.
-  assert.match(rendered, /roster entry says the workspace can be renamed/);
-  assert.match(rendered, /says neither takes no such ask/);
+  assert.match(rendered, /roster entry allows neither takes no such ask/);
   // Both surfaces that can rename are named, and the disambiguation the
   // conversation applies is the one the guide teaches.
   assert.match(rendered, /Superset-managed workspace, or a Conductor chat/);
@@ -807,40 +786,41 @@ test("the panel fact says the tabs answer an ask as well as a press", () => {
   assert.ok(guide.facts.some((candidate) => candidate.label === "The Settings tab"));
 });
 
-test("the sessions list fact says the options button wears an X that clears", () => {
+test("the sessions list fact offers the filter, order, and clear to a spoken ask", () => {
   const fact = buildLukeGuide(guideInput()).facts.find(
     (candidate) => candidate.label === "The sessions list",
   );
 
   assert.ok(fact);
-  // The X is a capability of the list itself, and a capability the guide does
-  // not describe is one Luke will deny having — or misdescribe as only
-  // un-pressing chips one at a time.
-  assert.match(fact.detail, /An X on the options button clears every chosen chip at once/);
+  // The list's acts are what a spoken ask is validated against; the chip
+  // choreography behind them is the surface's to show.
+  assert.match(fact.detail, /filters by location, kind, app, and agent/);
+  assert.match(fact.detail, /spoken ask can filter, sort, or clear/);
 });
 
-test("the guide describes the search, its three ways in, and their shared bound", () => {
+test("the guide describes the search's ways in and the spoken bound", () => {
   const fact = buildLukeGuide(guideInput()).facts.find(
     (candidate) => candidate.label === "Searching sessions",
   );
 
   assert.ok(fact);
-  // A capability the guide does not describe is one Luke will deny having —
-  // and the spoken way in must be described with its bound, because the
-  // refusal Luke voices beside a one-session list is itself the guidance.
+  // The spoken way in must be described with its bound: a spoken search does
+  // nothing the field cannot.
   assert.match(fact.detail, /magnifier/);
   assert.match(fact.detail, /Command-F/);
   assert.match(fact.detail, /asking Luke to search out loud/);
   assert.match(fact.detail, /reaches no further than the magnifier/);
-  assert.match(
-    fact.detail,
-    /title, status word or status line, branch, repository, workspace, agent, associated app, or model/,
-  );
-  // A held search now outlives the panel, and the guide must say so with its
-  // bound — clearing or closing the field is the one way a search is let go —
-  // or Luke will promise words he forgot, or forget words he promised to keep.
-  assert.match(fact.detail, /survives the panel closing and the app restarting/);
-  assert.match(fact.detail, /until its query is cleared or its field closed/);
+});
+
+test("the guide ends by redirecting what it leaves out rather than denying it", () => {
+  const fact = buildLukeGuide(guideInput()).facts.at(-1);
+
+  assert.ok(fact);
+  // The facts deliberately stop at what a developer would ask; this closing
+  // fact is what keeps an undescribed detail a redirection instead of a
+  // denial.
+  assert.equal(fact.label, "Beyond this guide");
+  assert.match(fact.detail, /rather than concluding the feature does not exist/);
 });
 
 test("the feedback fact says what a spoken open may do, and that sending stays by hand", () => {

--- a/apps/desktop/src/renderer/luke-guide.test.ts
+++ b/apps/desktop/src/renderer/luke-guide.test.ts
@@ -309,7 +309,7 @@ test("the guide distinguishes app identity from exact app opening", () => {
   assert.match(rendered, /app mark with an exact address is a button/);
   assert.match(rendered, /ChatGPT opens that Codex thread/);
   assert.match(rendered, /Superset opens its bound terminal/);
-  assert.match(rendered, /exact parent-thread record carries that Conductor association/);
+  assert.match(rendered, /Codex sub-agent spawned there keeps the Conductor association/);
   // A Conductor cloud chat leads with its agent's own mark, its Conductor
   // mark opens the exact chat, and a local one stays identification alone.
   assert.match(rendered, /leads?[^.]*with the agent running it/);
@@ -385,12 +385,12 @@ test("the facts describe creating a workspace, so Luke does not deny the capabil
   // The idle workspaces are the ones a cleanup ask is usually about, so the
   // guide teaches that they stand as rows at all — and which never do.
   assert.match(rendered, /no agent chat at all stands as its own idle row/);
-  assert.match(rendered, /settled by construction/);
+  assert.match(rendered, /agentless workspace row counts as settled/);
   assert.match(rendered, /main checkout and workspaces Superset already archived draw no row/);
   assert.match(rendered, /deleting is permanent/);
   assert.match(rendered, /single chat cannot be closed or removed on its own/);
   assert.match(rendered, /ask to archive one means exactly this delete/);
-  assert.match(rendered, /ask to archive one is taken as the one removal it does take/);
+  assert.match(rendered, /ask to archive one is taken as its Delete workspace control/);
   assert.match(rendered, /permanent, never filed away/);
 });
 
@@ -816,7 +816,7 @@ test("the sessions list fact says the options button wears an X that clears", ()
   // The X is a capability of the list itself, and a capability the guide does
   // not describe is one Luke will deny having — or misdescribe as only
   // un-pressing chips one at a time.
-  assert.match(fact.detail, /an X on its right that clears every chosen chip at once/);
+  assert.match(fact.detail, /An X on the options button clears every chosen chip at once/);
 });
 
 test("the guide describes the search, its three ways in, and their shared bound", () => {
@@ -839,9 +839,8 @@ test("the guide describes the search, its three ways in, and their shared bound"
   // A held search now outlives the panel, and the guide must say so with its
   // bound — clearing or closing the field is the one way a search is let go —
   // or Luke will promise words he forgot, or forget words he promised to keep.
-  assert.match(fact.detail, /clearing or closing is what lets a search go/);
   assert.match(fact.detail, /survives the panel closing and the app restarting/);
-  assert.match(fact.detail, /comes back with its field open/);
+  assert.match(fact.detail, /until its query is cleared or its field closed/);
 });
 
 test("the feedback fact says what a spoken open may do, and that sending stays by hand", () => {

--- a/apps/desktop/src/renderer/luke-guide.test.ts
+++ b/apps/desktop/src/renderer/luke-guide.test.ts
@@ -290,6 +290,9 @@ test("the facts say what is connected, never what connects it", () => {
   assert.match(rendered, /signed-in Luke account's daily allowance/);
   assert.match(rendered, /billed by OpenAI/);
   assert.match(rendered, /What Luke runs on section at the top/);
+  // The voice key's handling bound lives in its own fact, not only in Cloud
+  // providers, so an ask about this key retrieves it.
+  assert.match(rendered, /never read from the environment, never spoken, and never repeated back/);
   const voiceless = JSON.stringify(buildLukeGuide(guideInput({ voiceAvailable: false })).facts);
   assert.match(voiceless, /Signing in — or connecting a key — is what lets Luke speak/);
   assert.doesNotMatch(rendered, /OpenAI[^"]*under Integrations/);
@@ -366,6 +369,9 @@ test("the facts describe creating a workspace, so Luke does not deny the capabil
   // and that the developer's own word for tidying, archive, is taken as the
   // delete rather than refused over vocabulary.
   assert.match(rendered, /Delete workspace once its work settled/);
+  // An idle workspace is the one a cleanup ask is usually about, so the
+  // guide must say its row is settled, or Luke wrongly refuses the delete.
+  assert.match(rendered, /agentless idle row counts as settled/);
   assert.match(rendered, /idle worktree workspace stands as its own row/);
   assert.match(rendered, /deleting is permanent/);
   assert.match(rendered, /single chat cannot be closed or removed on its own/);
@@ -805,11 +811,21 @@ test("the guide describes the search's ways in and the spoken bound", () => {
 
   assert.ok(fact);
   // The spoken way in must be described with its bound: a spoken search does
-  // nothing the field cannot.
+  // nothing the field cannot, and neither exists beside a one-session list,
+  // where the carrier refuses the ask.
   assert.match(fact.detail, /magnifier/);
   assert.match(fact.detail, /Command-F/);
   assert.match(fact.detail, /asking Luke to search out loud/);
   assert.match(fact.detail, /reaches no further than the magnifier/);
+  assert.match(fact.detail, /only offered beside a list of more than one session/);
+
+  // The settings search keeps its hand-only bound on the Settings tab fact,
+  // so a spoken ask to search settings is refused honestly.
+  const settingsTab = buildLukeGuide(guideInput()).facts.find(
+    (candidate) => candidate.label === "The Settings tab",
+  );
+  assert.ok(settingsTab);
+  assert.match(settingsTab.detail, /by hand alone: no spoken ask can search it/);
 });
 
 test("the guide ends by redirecting what it leaves out rather than denying it", () => {

--- a/apps/desktop/src/renderer/luke-guide.test.ts
+++ b/apps/desktop/src/renderer/luke-guide.test.ts
@@ -208,7 +208,10 @@ test("the facts say what is connected, never what connects it", () => {
   assert.match(rendered, /Conductor \(connected\)/);
   assert.match(rendered, /Copilot \(not connected\)/);
   assert.match(rendered, /Devin \(connected from the environment\)/);
-  assert.match(rendered, /Integrations/);
+  // Each integration is its own labeled fact, so an ask about one draws that
+  // one alone rather than a summary of every integration at once.
+  assert.match(rendered, /"label":"Superset"/);
+  assert.match(rendered, /"label":"Conductor"/);
   // A build carrying neither registration draws neither integration row, so
   // the guide says nothing about either — a capability the guide describes is
   // one Luke will claim to have.
@@ -221,6 +224,7 @@ test("the facts say what is connected, never what connects it", () => {
   const tracker = JSON.stringify(
     buildLukeGuide(guideInput({ settings: settings({ linearSignInAvailable: true }) })).facts,
   );
+  assert.match(tracker, /"label":"Linear"/);
   assert.match(tracker, /Linear \(not connected\)/);
   assert.match(tracker, /signing in with Linear/);
   assert.match(tracker, /move one to another state or comment on it/);
@@ -233,6 +237,7 @@ test("the facts say what is connected, never what connects it", () => {
   const offered = JSON.stringify(
     buildLukeGuide(guideInput({ settings: settings({ calendarSignInAvailable: true }) })).facts,
   );
+  assert.match(offered, /"label":"Google Calendar"/);
   assert.match(offered, /Google Calendar \(not connected\)/);
   assert.match(offered, /when meetings start and end/);
   assert.match(offered, /signing in with Google/);
@@ -258,6 +263,7 @@ test("the facts say what is connected, never what connects it", () => {
   const appleOffered = JSON.stringify(
     buildLukeGuide(guideInput({ settings: settings({ appleCalendarAvailable: true }) })).facts,
   );
+  assert.match(appleOffered, /"label":"Apple Calendar"/);
   assert.match(appleOffered, /Apple Calendar \(not connected\)/);
   assert.match(appleOffered, /macOS's own calendar-access ask/);
   assert.match(appleOffered, /never their titles/);
@@ -295,6 +301,11 @@ test("the facts say what is connected, never what connects it", () => {
 test("the guide distinguishes app identity from exact app opening", () => {
   const rendered = JSON.stringify(buildLukeGuide(guideInput()).facts);
 
+  // Identity and opening are separate facts, so an ask about either draws a
+  // targeted answer; both must keep describing the whole capability between
+  // them.
+  assert.match(rendered, /"label":"Apps beside a session"/);
+  assert.match(rendered, /"label":"Opening a chat in its apps"/);
   assert.match(rendered, /app mark with an exact address is a button/);
   assert.match(rendered, /ChatGPT opens that Codex thread/);
   assert.match(rendered, /Superset opens its bound terminal/);
@@ -332,6 +343,9 @@ test("the facts describe creating a workspace, so Luke does not deny the capabil
   const rendered = JSON.stringify(buildLukeGuide(guideInput()).facts);
 
   assert.match(rendered, /Creating workspaces/);
+  // The defaults a nameless ask falls back to are their own fact, beside the
+  // act they steer.
+  assert.match(rendered, /"label":"Workspace creation defaults"/);
   // The refusal shape rides with the offer: only reported projects exist.
   assert.match(rendered, /Only reported projects/);
   // Where a nameless ask goes rides with it too, so the remembered first
@@ -706,6 +720,32 @@ test("the facts describe stopping a reply, exactly where a reply can exist", () 
   // key that does nothing.
   const voiceless = JSON.stringify(buildLukeGuide(guideInput({ voiceAvailable: false })).facts);
   assert.doesNotMatch(voiceless, /Stopping a reply/);
+});
+
+test("the announcement facts split the chips band and the meeting quiet", () => {
+  const rendered = JSON.stringify(buildLukeGuide(guideInput()).facts);
+  assert.match(rendered, /"label":"Announcements"/);
+  assert.match(rendered, /"label":"Session and issue chips"/);
+  // A build with no calendar row to connect may not describe the quiet: a
+  // hold Luke claims without one is a capability he does not have.
+  assert.doesNotMatch(rendered, /Quiet during meetings/);
+
+  const withCalendar = JSON.stringify(
+    buildLukeGuide(guideInput({ settings: settings({ appleCalendarAvailable: true }) })).facts,
+  );
+  assert.match(withCalendar, /"label":"Quiet during meetings"/);
+  assert.match(withCalendar, /announcements decided during a meeting wait/);
+
+  // Announcements exist only with a voice to speak them, and the chips and
+  // the quiet ride the same availability.
+  const voiceless = JSON.stringify(
+    buildLukeGuide(
+      guideInput({ voiceAvailable: false, settings: settings({ appleCalendarAvailable: true }) }),
+    ).facts,
+  );
+  assert.doesNotMatch(voiceless, /"label":"Announcements"/);
+  assert.doesNotMatch(voiceless, /"label":"Session and issue chips"/);
+  assert.doesNotMatch(voiceless, /"label":"Quiet during meetings"/);
 });
 
 test("the facts follow the talk key, the microphone, and the storage the system offers", () => {

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -257,7 +257,8 @@ function integrationFacts(settings: AppSettings): AppGuideFact[] {
       "Luke — and an idle worktree workspace stands as its own row. When Superset's CLI is " +
       "logged in, chat rows can send the developer's own message, rename the workspace, " +
       "start another agent in it, or create a new Superset workspace by ask. Every Superset " +
-      "row offers Delete workspace once its work settled, and Superset keeps no archive: " +
+      "row offers Delete workspace once its work settled — an agentless idle row counts as " +
+      "settled — and Superset keeps no archive: " +
       "deleting is permanent and takes the whole workspace with every chat in it, a row " +
       "still working is never offered it, a single chat cannot be closed or removed on its " +
       "own, and an ask to archive one means exactly this delete. Superset connects and " +
@@ -299,8 +300,8 @@ function voiceKeyFact(settings: AppSettings, voiceAvailable: boolean): AppGuideF
           ? `Signing in — or connecting a key — is what lets Luke speak and review sessions. `
           : `Voice and session review run on this key: no daily limit, nothing through Luke's ` +
             `service, and OpenAI bills you for what you use. `) +
-      `The key is typed by hand into ${VOICE_SOURCE_SECTION} and never read from the ` +
-      `environment.`,
+      `The key is typed by hand into ${VOICE_SOURCE_SECTION} — never read from the ` +
+      `environment, never spoken, and never repeated back.`,
   };
 }
 
@@ -376,7 +377,7 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       detail:
         "The list is searchable by the magnifier, Command-F, or asking Luke to search out " +
         "loud — a spoken search fills the same field and reaches no further than the " +
-        "magnifier.",
+        "magnifier, which is only offered beside a list of more than one session.",
     },
     {
       label: "Workspaces in the list",
@@ -391,7 +392,9 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "Where Luke is configured by hand. The front page leads with What Luke runs on — the " +
         "signed-in account's daily allowance against the developer's own OpenAI key — with " +
         "meters for the day's use, and opens the Voice, Appearance, Keyboard shortcuts, and " +
-        "Connections pages; Feedback, Account, and Quit stay on the front page.",
+        "Connections pages; Feedback, Account, and Quit stay on the front page. A settings " +
+        "search — the magnifier, or Command-F — finds any row, by hand alone: no spoken ask " +
+        "can search it.",
     },
     {
       label: "Account",

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -4,10 +4,12 @@
  * Everything the voice conversation may know about the app — what Luke is on
  * screen, every setting with its current value and its default, and where
  * each is changed by hand — is assembled here into the `AppGuideSnapshot` the
- * conversation is sent. A feature this file does not describe is one Luke
- * will deny having, and a setting it does not mark changeable is one no
- * spoken ask can touch, so adding either to the app means adding it here in
- * the same change.
+ * conversation is sent. A capability this file does not describe is one Luke
+ * will not offer, and a setting it does not mark changeable is one no spoken
+ * ask can touch, so adding either to the app means adding it here in the same
+ * change. The facts cover what a developer would ask and what a spoken ask
+ * may do — not exhaustive surface behavior, which the closing fact has Luke
+ * redirect to the surface rather than deny.
  *
  * The settings half is built from the exhaustive schema in
  * `shared/settings-schema.ts`, so a new stored setting does not build until its
@@ -189,12 +191,10 @@ function providersFact(settings: AppSettings): AppGuideFact {
     detail:
       `${roster.join(", ")}. Connecting one takes the key its row names, typed by hand into ` +
       `${CONNECTIONS_PAGE}, under Providers — like every key, never spoken, and never ` +
-      "repeated back; the row's Connect press opens the provider's own key page in the " +
-      "browser. Local providers such as Claude Code need no key and are observed on their " +
-      `own. Codex cloud tasks (${CODEX_CLOUD_CONNECTION_WORD[settings.codexCloudConnection]}) ` +
-      "take no key in Luke at all: they are observed through the Codex CLI's own login, " +
-      "reported by the Codex row on the same page — codex login in a terminal connects them, " +
-      "and signing that CLI out stops them.",
+      "repeated back. Local providers such as Claude Code need no key and are observed on " +
+      `their own. Codex cloud tasks (${CODEX_CLOUD_CONNECTION_WORD[settings.codexCloudConnection]}) ` +
+      "take no key in Luke at all: they follow the Codex CLI's own login — codex login " +
+      "connects them, and signing that CLI out stops them.",
   };
 }
 
@@ -212,11 +212,11 @@ function integrationFacts(settings: AppSettings): AppGuideFact[] {
       detail:
         `${linearProvider.displayName} ` +
         `(${connectionWord(settings.credentialSources[linearProvider.id])}) connects by signing ` +
-        `in with Linear from its row in ${CONNECTIONS_PAGE}, under Integrations — Linear's own ` +
-        `consent page opens in the browser, and no key is ever typed or spoken. Connecting it ` +
-        `lets Luke read the developer's assigned issues and, only when asked in a turn the ` +
-        `developer opened, move one to another state or comment on it. Disconnecting from the ` +
-        `same row ends the access at Linear as well as here.`,
+        `in with Linear from its row in ${CONNECTIONS_PAGE}, under Integrations — no key is ` +
+        `ever typed or spoken. Connected, Luke reads the developer's assigned issues and, ` +
+        `only when asked in a turn the developer opened, can move one to another state or ` +
+        `comment on it; disconnecting from the same row ends the access at Linear as well ` +
+        `as here.`,
     });
   }
   if (settings.appleCalendarAvailable) {
@@ -253,38 +253,26 @@ function integrationFacts(settings: AppSettings): AppGuideFact[] {
     label: "Superset",
     detail:
       "Superset workspaces on this Mac are recognized read-only from Superset's own host " +
-      "state, grouping agents from different providers under their workspace, " +
-      "and every grouped chat opens at its exact terminal in Superset — " +
-      "pressed, or asked of Luke — with no login needed. A worktree workspace with no agent " +
-      "chat at all stands as its own idle row, titled by the workspace and opening in " +
-      "Superset on press; the main checkout and workspaces " +
-      "Superset already archived draw no row. When Superset's CLI is logged in, chat rows " +
-      "can send the developer's own message, rename the workspace, or start another agent " +
-      "in it, and a conversation ask can create a new Superset " +
-      "workspace. Every Superset row offers Delete workspace once its " +
-      "work settled — an agentless workspace row counts as settled — and Superset keeps no " +
-      "archive: deleting is permanent and takes the whole workspace with every chat in it, " +
-      "a row still working is never offered it, a single chat cannot be closed or removed " +
-      "on its own, and an ask to archive one means exactly this delete. Superset's row sits " +
-      "under Providers on the Connections page: connecting runs Superset's own sign-in in " +
-      "the browser and takes its one-time code pasted into Luke — the CLI exchanges and " +
-      "stores the login, and Luke never reads its token or clipboard — its pencil runs the " +
-      "sign-in again to switch organizations, and disconnecting runs the CLI's own sign-out.",
+      "state; their chats open at their exact terminal in Superset — pressed, or asked of " +
+      "Luke — and an idle worktree workspace stands as its own row. When Superset's CLI is " +
+      "logged in, chat rows can send the developer's own message, rename the workspace, " +
+      "start another agent in it, or create a new Superset workspace by ask. Every Superset " +
+      "row offers Delete workspace once its work settled, and Superset keeps no archive: " +
+      "deleting is permanent and takes the whole workspace with every chat in it, a row " +
+      "still working is never offered it, a single chat cannot be closed or removed on its " +
+      "own, and an ask to archive one means exactly this delete. Superset connects and " +
+      "disconnects from its row under Providers on the Connections page, through Superset's " +
+      "own sign-in; Luke never reads its token or clipboard.",
   });
   facts.push({
     label: "Conductor",
     detail:
-      "Conductor comes two ways. Conductor cloud connects with a key under Providers and " +
-      "creates workspaces in the cloud projects that key lists. Conductor on this Mac needs " +
-      "no key: it is recognized read-only from Conductor's own index, and a conversation ask " +
-      "can create a new workspace in any repository Conductor holds locally — shown as " +
-      "“Conductor (local)” in the create picker and its own block under Providers. A local " +
-      "creation opens the new workspace in Conductor itself; an opening task is pre-filled " +
-      "in its composer but not sent — Luke says the prompt is ready, and the developer " +
-      "presses Return in Conductor to start it. " +
-      "It carries no agent, model, or name choice — the repository's own default agent runs, " +
-      "under the name Conductor gives it. Local Conductor chats stay read-only otherwise: " +
-      "Luke cannot message, archive, or add an agent to one.",
+      "Conductor cloud connects with a key under Providers and creates workspaces in the " +
+      "cloud projects that key lists. Conductor on this Mac needs no key — it is recognized " +
+      "read-only from Conductor's own index — and an ask can create a new workspace in any " +
+      "repository it holds locally; the opening task is pre-filled in Conductor but not " +
+      "sent, so the developer presses Return there to start it. Local Conductor chats stay " +
+      "read-only otherwise: Luke cannot message, archive, or add an agent to one.",
   });
   return facts;
 }
@@ -362,134 +350,66 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       label: "The panel",
       detail:
         "Two tabs, Sessions and Settings, switched by pressing one or by asking Luke to show " +
-        "it. Asked while the panel is closed, the panel opens on that tab. Command-comma " +
-        "switches to Settings while the panel has the keyboard.",
+        "it. Asked while the panel is closed, the panel opens on that tab.",
     },
     {
       label: "The sessions list",
       detail:
-        "Lists every session that still matters: one working or waiting stays at any age, a " +
-        "failure for three days, a finished or quiet one for two. The options button filters " +
-        "by location (local, cloud), kind (voice chats), app (Conductor, ChatGPT, Cursor, " +
-        "Orca, Superset, cmux), and agent; several chips can be chosen at once, choices on " +
-        "one row widening each other and choices across rows narrowing. Cursor sits on both " +
-        "rows: its app chip narrows to the chats the Cursor app can open, its agent chip to " +
-        "every Cursor chat. An X on the options button clears every chosen chip at once, and " +
-        "a spoken ask can narrow to the same values or back to all. The list is orderable by " +
-        "urgency or recency by the same button or ask. " +
-        "A row can be opened, messaged, or controlled where its provider allows, a session " +
-        "whose provider reported a pull request grows a chip that opens it in the browser, " +
-        "and a row the developer asked Luke to listen for wears a listening mark beside its " +
-        "age. Luke's own composer at the foot takes a typed ask.",
+        "Lists every observed session that still matters. The options button filters by " +
+        "location, kind, app, and agent and orders the list by urgency or recency; a spoken " +
+        "ask can filter, sort, or clear the same way. A row can be opened, messaged, or " +
+        "controlled where its provider allows, a session whose provider reported a pull " +
+        "request grows a chip that opens it in the browser, and Luke's own composer at the " +
+        "foot takes a typed ask.",
     },
     {
       label: "Apps beside a session",
       detail:
-        "The large mark leading a row names the coding agent; the small bare marks after its " +
-        "title name apps where the same chat also appears — none replaces the agent or " +
-        "changes local versus cloud. A Conductor cloud chat leads " +
-        "with the agent running it, Claude Code or Codex, a small cloud badge saying where it " +
-        "runs; Conductor's own letter mark stands in only when the agent went unreported, and " +
-        "a Codex sub-agent spawned there keeps the Conductor association on its own row. Each " +
-        "association is recognized read-only from that app's own records, and cmux records a " +
-        "session only where its agent hooks are installed — Claude Code's automatically; " +
-        "Codex, Cursor, Gemini CLI, and OpenCode after `cmux hooks setup` — so a session cmux " +
-        "never recorded carries no cmux mark. A local Codex chat also names ChatGPT, which " +
-        "documents the exact Codex thread address. A Cursor chat names Cursor itself when the " +
-        "app can open it: a local chat in the app's own index, or any Cursor cloud agent. A " +
-        "chat Cursor's agents CLI started in a plain terminal carries no Cursor app mark and " +
-        "opens nowhere unless cmux, Superset, or Conductor hosts its terminal.",
-    },
-    {
-      label: "Opening a chat in its apps",
-      detail:
-        "An app mark with an exact address is a button: ChatGPT opens that Codex thread, " +
-        "Cursor opens the exact chat, Superset opens its bound terminal, " +
-        "cmux opens the exact terminal pane the agent runs in — standing in as the row's " +
-        "own destination when no other app gave it one — and a Conductor cloud chat's " +
-        "Conductor mark opens that exact chat. The row body, or an ask in conversation, " +
-        "opens the row's preferred address; an ask naming an app whose mark is a button " +
-        "opens that app's exact address instead. A local Conductor chat or an Orca worktree " +
-        "has no documented exact address or message endpoint, so its mark identifies the " +
-        "association but adds no open or send control; a cmux chat takes no message or " +
-        "control through cmux either — its mark only opens the pane.",
+        "The large mark leading a row names the coding agent; the small marks after its " +
+        "title name the apps holding the same chat — Conductor, ChatGPT, Cursor, Orca, " +
+        "Superset, cmux — recognized read-only from each app's own records. A mark with an " +
+        "exact address opens the chat in that app, the row body opens its preferred one, and " +
+        "an ask can name which app a chat held by several comes forward in.",
     },
     {
       label: "Searching sessions",
       detail:
-        "The list is searchable by the magnifier beside the options button, Command-F while " +
-        "the panel has the keyboard, or asking Luke to search out loud — a spoken search " +
-        "fills the same field and reaches no further than the magnifier, which is only " +
-        "offered beside a list of more than one session. It keeps rows saying every typed " +
-        "word in their title, status word or status line, branch, repository, workspace, " +
-        "agent, associated app, or model, and a search matching nothing offers the matches a " +
-        "filter is hiding. A standing search survives the panel closing and the app " +
-        "restarting until its query is cleared or its field closed — Escape does both. " +
-        "Command-F answers for whichever tab is showing: the sessions list here, " +
-        "the settings search on Settings.",
+        "The list is searchable by the magnifier, Command-F, or asking Luke to search out " +
+        "loud — a spoken search fills the same field and reaches no further than the " +
+        "magnifier.",
     },
     {
       label: "Workspaces in the list",
       detail:
-        "Where chats nest in a workspace — Conductor's, cloud and local alike, and Superset's " +
-        "and Orca's on this machine — each chat is its own row: a workspace holding several " +
-        "draws them inside one tray named by the workspace, and one holding a single chat " +
-        "stays one row titled by it. Every chat can be seen, opened, and messaged " +
-        "individually where its latest roster entry offers that act. A tray's header carries " +
-        "the managing app's mark, the workspace's acts, and the one pull-request chip its " +
-        "chats share, each said once for the group.",
+        "Chats nested in a workspace — Conductor's, Superset's, or Orca's — group under one " +
+        "tray named by the workspace, and each chat is still its own row, opened and " +
+        "messaged individually where its roster entry allows.",
     },
     {
       label: "The Settings tab",
       detail:
-        "A front page led by the What Luke runs on section: a two-way toggle naming the " +
-        "signed-in Luke account (free, a daily amount) against the developer's own OpenAI key " +
-        "(unmetered, billed by OpenAI). Choosing the key with none stored asks for one; " +
-        "choosing the account parks a stored key without deleting it. Under the toggle: on " +
-        "the account, meters for the day's talking, announcements, and session checks, and " +
-        "when they reset; on the key, the " +
-        "OpenAI row itself. Below are rows opening the Voice, Appearance, Keyboard shortcuts, " +
-        "and Connections pages; the Feedback section, the Account section, and Quit stay on " +
-        "the front page itself.",
-    },
-    {
-      label: "Searching settings",
-      detail:
-        "The magnifier beside the tab bar — or Command-F — while Settings is showing searches " +
-        "every settings page at once. It finds any row — a page itself, a setting by its name " +
-        "or what it does, a provider, a shortcut, a way out — and pressing a match opens its " +
-        "page at the row itself. The search is by hand alone: no spoken ask can search, and " +
-        "no search survives the panel closing.",
-    },
-    {
-      label: "What a settings page marks",
-      detail:
-        "A dot beside a row marks a value changed from its default, and a page holding one " +
-        "offers a reset at its head — pressed by hand and never spoken — returning that " +
-        "page's settings to their defaults. The Connections page has no group reset: its " +
-        "defaults are changed row by row, and no reset touches a key, an account, or the " +
-        "Conductor agent choice. An exclamation mark sits on whatever still needs a hand — " +
-        "voice with nothing to run on, an ungranted microphone permission, or the keyboard " +
-        "shortcuts while voice is off, whose chords stay shown and changeable but answer " +
-        "nothing until voice is available.",
+        "Where Luke is configured by hand. The front page leads with What Luke runs on — the " +
+        "signed-in account's daily allowance against the developer's own OpenAI key — with " +
+        "meters for the day's use, and opens the Voice, Appearance, Keyboard shortcuts, and " +
+        "Connections pages; Feedback, Account, and Quit stay on the front page.",
     },
     {
       label: "Account",
       detail:
         account.status === ACCOUNT_STATUS.SIGNED_IN
           ? `Signed in as ${account.email} through ${account.provider === ACCOUNT_PROVIDER.GITHUB ? "GitHub" : "Google"}. Sign out by hand from ${ACCOUNT_SECTION} — it asks before acting. The same section's Delete account row erases the account and everything Luke's service holds for it, cannot be undone, and is only ever done by hand — its button asks before acting, and no spoken ask can reach it.`
-          : "Not signed in. The sign-in screen greets the launch once with Google and GitHub; while signed out the strip beside the housing keeps Luke's face and a small Sign in label, and hovering or pressing it brings the sign-in screen back. Live sessions and Luke's controls stay off until sign-in finishes; signing in finishes in the browser — cancellable — and the panel opens itself once it lands.",
+          : "Not signed in. The sign-in screen offers Google and GitHub, and hovering or pressing the strip beside the housing brings it back; live sessions and Luke's controls stay off until sign-in finishes.",
     },
     {
       label: "Feedback and prompts",
       detail:
-        "The Feedback section near the foot of the Settings tab opens a composer under the " +
-        "notch: Send feedback for bugs and ideas, Submit a prompt for a prompt to a coding " +
-        "agent. Either goes by email to the founders, with an optional name and email for " +
-        "credit and up to three screenshots. A spoken ask can open the composer and start it " +
-        "with the developer's own words — Luke offers exactly that, once, after refusing " +
-        "something he cannot do — but a note already being written is never overwritten, and " +
-        "sending is always the Send button's own press: no spoken ask can send one.",
+        "The Feedback section on the Settings tab opens a composer: Send feedback for bugs " +
+        "and ideas, Submit a prompt for a prompt to a coding agent, either going by email to " +
+        "the founders with optional credit and up to three screenshots. A spoken ask can " +
+        "open the composer with the developer's own words — Luke offers exactly that after " +
+        "refusing something he cannot do, and a note already being written is never " +
+        "overwritten — but sending is always the Send button's own press: no spoken ask can " +
+        "send one.",
     },
     {
       label: "Reading a session's transcript",
@@ -497,111 +417,85 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "Asked what a local session did, said, or is stuck on, Luke can read that session's " +
         "own recent transcript — Antigravity, Claude Code, Codex, Gemini CLI, Grok Build, " +
         "OpenCode, Radius, and the Devin and Cursor agents on this machine today — and answer " +
-        "from it. Cursor and Radius keep tool outputs out of their transcripts, and " +
-        "Antigravity's are stored where Luke does not read them, so those readings carry the " +
-        "words and the calls but no results. The reading happens when asked and is kept " +
-        "nowhere; a cloud session's conversation stays with its provider, and Luke answers " +
-        "about it from roster fields alone.",
+        "from it; the reading is kept nowhere. Some of those transcripts store no tool " +
+        "results, so a reading may carry words and calls alone. A cloud session's " +
+        "conversation stays with its provider, answered from roster fields alone.",
     },
     {
       label: "Messaging local Cursor chats",
       detail:
         "A local Cursor chat whose turn has settled can take the developer's own message, " +
-        "typed on its row or asked of Luke: Luke runs Cursor's own agents CLI, resuming " +
-        "exactly that chat in its own folder with the message as its one prompt, and the " +
-        "reply lands in the transcript the row already reads. It is offered only with the " +
-        "CLI installed and signed in, the chat's folder named by Cursor's own records, and " +
-        "the turn not still running — and never for chats the Cursor app's own windows hold, " +
-        "whose rows open the exact chat in the app instead. A Superset-managed Cursor chat " +
-        "still messages through Superset's own terminal.",
+        "typed on its row or asked of Luke, and the reply lands in the same transcript the " +
+        "row reads. It is offered only with Cursor's own CLI installed and signed in, and " +
+        "never for chats the Cursor app's own windows hold, whose rows open the chat in the " +
+        "app instead; a Superset-managed Cursor chat messages through Superset.",
     },
     {
       label: "Creating workspaces",
       detail:
         "Where a connected provider documents a creation endpoint — Conductor, Cursor, and " +
-        "Superset today — an ask in conversation, spoken or typed, can create a new workspace " +
-        "in one of the projects that provider reports, optionally under a name the developer " +
-        "chose, with an opening task in the developer's own words where the project takes one. " +
-        "A bare ask for a new agent lands here: only an ask that itself names the existing " +
-        "workspace or session the agent should join adds one beside it instead. Only reported " +
-        "projects can be named, a project that needs a task cannot be created without one, and " +
-        "a provider that reports none takes no ask. Every Superset project carries the host " +
-        "that runs it, and a new Superset " +
-        "workspace needs that host, an agent Superset currently lists for it, and an opening " +
-        "task, so a task-less ask for one is refused rather than created idle. A workspace " +
-        "that lands opens on screen by itself once observation reports it with an address; " +
-        "one whose provider reports no address stays on its row, unopened.",
+        "Superset today — an ask in conversation, spoken or typed, can create a new " +
+        "workspace in a project that provider reports, optionally named, with an opening " +
+        "task in the developer's own words where the project takes one. Only reported " +
+        "projects can be named, a project that needs a task cannot be created without one, " +
+        "and a provider that reports none takes no ask; a new Superset workspace needs a " +
+        "host, an agent, and an opening task, so a task-less ask for one is refused. A bare " +
+        "ask for a new agent creates a new workspace — an ask naming an existing workspace " +
+        "or session adds an agent beside it instead — and a workspace that lands opens on " +
+        "screen by itself once it reports an address.",
     },
     {
       label: "Workspace creation defaults",
       detail:
         "An ask that names no provider goes to the default workspace provider, and one that " +
-        "names no project to that provider's default project. The first workspace created " +
-        "saves its provider as the default — changed or cleared by hand in the Settings tab — " +
-        "and each provider remembers a default project, filled in by the first workspace " +
-        "created there and changed or cleared by hand on that provider's own row on the " +
-        "Connections page: under Providers for a provider connected by key and for Conductor " +
-        "(local), under Superset for Superset. Superset also remembers a default agent for " +
-        "creation asks that name none, chosen under Superset in Settings. Until one is " +
-        "chosen, Luke asks whenever more than one provider, project, or agent could take " +
-        "the ask. What a new Conductor agent runs — " +
-        "its model, and its effort where the model's agent takes one — follows the choice on " +
-        "the Conductor row under Providers, or Conductor's own defaults while none is made. A " +
-        "model named in a creation ask rides that creation alone and is saved as the default " +
-        "only while none is chosen; the settings change only when the developer asks, and " +
-        "Luke never asks or suggests a model.",
+        "names no project to that provider's default project; the first workspace created " +
+        "fills each in, both are changed or cleared by hand in Settings, and until one is " +
+        "chosen, Luke asks. What a new Conductor agent runs — its model, and its effort " +
+        "where the model takes one — follows the choice on the Conductor row; a model named " +
+        "in the ask rides that creation alone, and Luke never asks or suggests a model.",
     },
     {
       label: "Adding agents to a workspace",
       detail:
-        "Where a session's provider documents it — Conductor today — the same kind of ask can " +
-        "start another agent in an observed session's workspace, as one of the agent " +
-        "kinds that session's roster entry lists, optionally named and optionally with an " +
-        "opening task. The ask must name that workspace or session; a bare ask for a new " +
-        "agent creates a new workspace instead. A model named in the ask — with an effort " +
-        "where its agent takes one — rides that agent alone; unnamed, the Conductor row's " +
-        "choice rides along only when it names the same agent kind. A session whose entry " +
-        "lists no new agents takes no such ask.",
+        "Where a session's provider documents it — Conductor today — the same kind of ask " +
+        "can start another agent in an observed session's workspace, as one of the agent " +
+        "kinds its roster entry lists; a session whose entry lists none takes no such ask. " +
+        "The ask must name the workspace or session — a bare ask for a new agent creates a " +
+        "new workspace instead — and a model named in the ask rides that agent alone.",
     },
     {
       label: "Renaming workspaces and chats",
       detail:
-        "Where a provider documents it, an ask can rename what is observed, to a name in the " +
-        "developer's own words: a Conductor or Superset-managed workspace, or a Conductor " +
-        "chat on its own. An ask that names the workspace renames the workspace; one about " +
-        "the chat renames the chat. Only sessions whose roster entry says the workspace can " +
-        "be renamed — or the chat can — take one, and a session whose entry says neither " +
-        "takes no such ask; the new name shows up on the next observation.",
+        "Where a provider documents it — a Conductor or Superset-managed workspace, or a " +
+        "Conductor chat on its own — an ask can rename what is observed to a name in the " +
+        "developer's own words. An ask naming the workspace renames the workspace, one " +
+        "about the chat renames the chat, and a session whose roster entry allows neither " +
+        "takes no such ask.",
     },
     {
       label: "Archiving",
       detail:
         "Where a provider documents an archive endpoint — a Conductor workspace, a Cursor " +
         "cloud agent, and a Devin cloud session today — Archive is offered once the work " +
-        "there was positively seen to settle: pressed, or asked of Luke, it files the work " +
-        "away through the provider's own endpoint. Archiving a Conductor workspace files " +
-        "away every chat in it at once, so the control sits once on a group's header and " +
-        "otherwise on the row. An archived Cursor agent " +
-        "stays readable but takes no new runs; an archived Devin session can be viewed but " +
-        "not resumed. A row mid-turn — or one whose state could not be read — offers no " +
-        "archive, a session whose roster entry lists no archive control takes no such ask, " +
-        "and local sessions — which Luke only reads — are never archived. A Superset-managed " +
-        "workspace keeps no archive: an ask to archive one is taken as its Delete workspace " +
-        "control, and Luke words the outcome as the delete it is — permanent, never filed " +
-        "away.",
+        "was positively seen to settle: pressed, or asked of Luke, it files the work away " +
+        "through the provider's own endpoint, and archiving a Conductor workspace files " +
+        "away every chat in it at once. A row mid-turn offers no archive, a session whose " +
+        "roster entry lists no archive control takes no such ask, and local sessions — " +
+        "which Luke only reads — are never archived. A Superset-managed workspace keeps no " +
+        "archive: an ask to archive one is taken as its Delete workspace control — " +
+        "permanent, never filed away.",
     },
     {
       label: "Standing asks about sessions",
       detail:
-        "An ask can be kept standing for one observed session — told when it finishes, warned " +
-        "if it fails, whatever the developer asked in their own words. Luke's background " +
-        "review weighs that session's updates against the ask and speaks when one satisfies " +
-        "it, opening a speak-only call if no conversation is up; the ask itself is " +
-        "the consent. One ask stands per session, a new one replaces it, asking Luke to drop " +
-        "it withdraws it, and an ask ends with the session it was about. A row with an ask " +
-        "standing wears a small listening mark beside its age, and Luke can say what he is " +
-        "already listening for. It needs voice to be available, changes nothing about the " +
-        "session itself, and is never sent to a provider.",
+        "An ask can be kept standing for one observed session — told when it finishes, " +
+        "warned if it fails, whatever the developer asked in their own words. Luke's " +
+        "background review weighs that session's updates against the ask and speaks when " +
+        "one satisfies it, opening a speak-only call if no conversation is up; the ask " +
+        "itself is the consent. One ask stands per session, a new one replaces it, asking " +
+        "Luke to drop it withdraws it, and an ask ends with its session — Luke can say what " +
+        "he is already listening for. It needs voice to be available, changes nothing about " +
+        "the session itself, and is never sent to a provider.",
     },
     talkKeyFact(input.hotkey),
     askKeyFact(input.askKey),
@@ -626,29 +520,21 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
             // denies announcing nor offers to turn it off.
             label: "Announcements",
             detail:
-              "Luke says it out loud when an observed session is holding for you, stops on an " +
-              "error, or finishes — a hold is a question, a permission, or an approval, not a " +
-              "turn that merely ended — in his own words, naming the session and what it " +
-              "needs, from the agent's parting words or the provider's error line. No " +
-              "conversation needs to be open, the microphone stays off, and " +
-              "it is always on while voice is available. A session the developer is speaking " +
-              "with through its provider's own realtime voice — a Codex thread in a live " +
-              "voice conversation, and any chat it delegated — announces nothing while the " +
-              "conversation holds; the first change after it closes is announced as usual, " +
-              "and nothing from inside it is replayed.",
+              "Luke says it out loud when an observed session is holding for you, stops on " +
+              "an error, or finishes — a hold is a question, a permission, or an approval, " +
+              "not a turn that merely ended — in his own words, naming the session and what " +
+              "it needs. No conversation needs to be open, the microphone stays off, and it " +
+              "is always on while voice is available. A session already in a live voice " +
+              "conversation with its own provider announces nothing until that conversation " +
+              "closes, and nothing from inside it is replayed.",
           },
           {
             label: "Session and issue chips",
             detail:
-              "While Luke says an announcement, a pressable notice names the session he is " +
-              "talking about — under the housing, or at the open panel's foot: pressing it " +
-              "opens the session where its provider keeps it, or the panel for a local " +
-              "session with no page of its own. The same pressable chips appear while a " +
-              "conversation reply names observed sessions by title, or a workspace of grouped chats by its " +
-              "name — one chip per thing named, up to a dozen, a workspace's opening its most " +
-              "recent chat — and a reply naming tracked issues, by identifier like LUKE-123 " +
-              "or by whole title, draws their chips on the same band, each opening its issue " +
-              "where the tracker keeps it. The chips leave when the reply ends.",
+              "While Luke speaks, pressable chips name the sessions and tracked issues the " +
+              "reply is about — under the housing, or at the open panel's foot. Pressing one " +
+              "opens it where its provider or tracker keeps it; a local session with no page " +
+              "of its own opens Luke's panel. They leave when the reply ends.",
           },
           // Only a build that offers a calendar may describe the quiet: a hold
           // Luke claims without a calendar row to connect is a capability he
@@ -658,14 +544,12 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
                 {
                   label: "Quiet during meetings",
                   detail:
-                    "With a calendar connected — a Google Calendar account, or this Mac's own " +
-                    "Apple Calendar — and Quiet during meetings on, announcements decided " +
-                    "during a meeting wait and are read out together once it ends. The quiet " +
-                    "begins the moment a meeting starts — or the setting is switched on " +
-                    "mid-meeting — and silences everything Luke would say unbidden, an " +
-                    "announcement mid-sentence included, even on an open conversation; " +
-                    "questions asked of him still get their replies. Luke's face sleeps " +
-                    "beside the housing for as long as the quiet holds.",
+                    "With a calendar connected and Quiet during meetings on, announcements " +
+                    "decided during a meeting wait and are read out together once it ends. " +
+                    "The quiet silences everything Luke would say unbidden — an announcement " +
+                    "mid-sentence included, even on an open conversation — while questions " +
+                    "asked of him still get their replies, and his face sleeps beside the " +
+                    "housing for as long as it holds.",
                 },
               ]
             : []),
@@ -673,29 +557,23 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
             label: "Muted output",
             detail:
               "While the Mac is muted or its volume is at zero, Luke's replies are captioned " +
-              "on screen even with Captions off, the whole reply staying on screen, and a " +
-              "hint under the words asks for volume. The hint's Got it button rests it for " +
-              "that stretch of silence and any that begins within fifteen minutes; the " +
-              "captions stay.",
+              "on screen even with Captions off, and a hint under the words asks for volume; " +
+              "its Got it button rests the hint, and the captions stay.",
           },
           {
             label: "How long a conversation lasts",
             detail:
-              "A call opens on the first " +
-              "press of the talk key or the first typed ask, stays open across as many turns " +
-              "as the developer takes, and is put away after three minutes with nothing said " +
-              "on it; the voice service also ends any call at an hour. Either way the next " +
-              "press picks the conversation back up: a bounded history of the recent " +
-              "exchange — what was asked, answered, announced, and done — is kept in memory, " +
-              "never written to disk, and re-fed to the new call, so Luke remembers what was " +
-              "just said. A call that ends underneath a conversation ends quietly.",
+              "A call opens on the first press of the talk key or the first typed ask and is " +
+              "put away after three minutes with nothing said on it; the voice service also " +
+              "ends any call at an hour. The next press picks the conversation back up: a " +
+              "bounded history of the recent exchange is kept in memory, never written to " +
+              "disk, and re-fed to the new call, so Luke remembers what was just said.",
           },
           {
             label: "When a call fails",
             detail:
               "Why a call failed or ended is shown for a few seconds where the captions are " +
-              "drawn — under the housing, or at the open panel's foot. Nothing about it " +
-              "lives in Settings; trying again is the only fix.",
+              "drawn; trying again is the only fix.",
           },
         ]
       : [
@@ -724,16 +602,12 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       // Luke neither denies checking nor offers a switch that does not exist.
       detail:
         `The Updates section on ${FRONT_PAGE} says which version this is and where the build ` +
-        "stands. Its button checks the release manifest on the spot, and Luke also checks on " +
-        "his own a few times a day — always on; the fetch is unauthenticated and nothing " +
-        "about the developer or their sessions is sent. A newer release downloads itself " +
-        "when a check finds one and installs when Luke next quits — the row offers Restart " +
-        "to update. If a download or install fails, the " +
-        "row says so and offers the fixed releases page in the browser instead. The button's " +
-        "press can also be asked of Luke — check for updates, open the releases page, " +
-        "restart to update — and only the one act the row currently offers runs. The " +
-        "Changelog row under the version opens the changelog in the browser; that is a press " +
-        "by hand, and no spoken ask reaches it.",
+        "stands. Luke checks on his own a few times a day — the fetch is unauthenticated, " +
+        "and nothing about the developer or their sessions is sent — and a newer release " +
+        "downloads itself and installs when Luke next quits. The row's press can be asked " +
+        "of Luke — check for updates, open the releases page, restart to update — and only " +
+        "the one act the row currently offers runs. The Changelog row opens the changelog " +
+        "in the browser, by hand alone.",
     },
     {
       label: "Usage data",
@@ -741,8 +615,7 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       // switch, and a Luke who could describe only that would be one who could
       // not say what it governs.
       detail:
-        "Luke counts how his own features are used — a launch, a provider connected, sessions " +
-        "observed, a call opened, an announcement spoken — and sends those counts to Luke's own " +
+        "Luke counts how his own features are used and sends those counts to Luke's own " +
         "service, tied to the signed-in account by name and email. Every event and value is " +
         "fixed by this build, so nothing about a session — no title, branch, path, recap, or " +
         "transcript — and nothing typed or spoken can travel in one. Nothing is sent while " +
@@ -752,6 +625,16 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
     {
       label: "Quitting",
       detail: `The Quit button at the foot of ${SETTINGS_TAB} or on the sign-in screen when it is shown.`,
+    },
+    {
+      // The deliberate bound of this guide: minutiae are redirected, not
+      // denied, so leaving a surface detail out of the facts stays safe.
+      label: "Beyond this guide",
+      detail:
+        "This guide lists what Luke can do, promise, and refuse — not every detail of the " +
+        "surface or its providers. Asked about finer behavior it does not cover, Luke points " +
+        "to where it lives — the panel, a session's row, or the Settings tab — rather than " +
+        "concluding the feature does not exist.",
     },
   ];
 

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -158,7 +158,7 @@ const MICROPHONE_DETAIL = {
   "not-determined":
     "Not asked yet — typing to Luke needs no permission, and only the talk key's capture " +
     "does. The Permissions section on the Settings tab's Voice page can ask while voice is " +
-    "available — a signed-in account includes it, and an OpenAI key also provides it.",
+    "available.",
   unknown: "Unknown. The Permissions section on the Settings tab's Voice page shows its state.",
 };
 
@@ -188,14 +188,13 @@ function providersFact(settings: AppSettings): AppGuideFact {
     label: "Cloud providers",
     detail:
       `${roster.join(", ")}. Connecting one takes the key its row names, typed by hand into ` +
-      `${CONNECTIONS_PAGE}, under Providers — never spoken, and never repeated back. The row's ` +
-      "Connect press opens the provider's own key page in the browser and leaves the field " +
-      "waiting under the notch, so the key is fetched and pasted in one trip. " +
-      "Local providers such as Claude Code need no key and are observed on their own. " +
-      `Codex cloud tasks (${CODEX_CLOUD_CONNECTION_WORD[settings.codexCloudConnection]}) take ` +
-      "no key in Luke at all: they are observed through the Codex CLI's own login, and the " +
-      "Codex row on the same page reports that login's state. Running codex login once in a " +
-      "terminal connects them, and signing that CLI out stops them.",
+      `${CONNECTIONS_PAGE}, under Providers — like every key, never spoken, and never ` +
+      "repeated back; the row's Connect press opens the provider's own key page in the " +
+      "browser. Local providers such as Claude Code need no key and are observed on their " +
+      `own. Codex cloud tasks (${CODEX_CLOUD_CONNECTION_WORD[settings.codexCloudConnection]}) ` +
+      "take no key in Luke at all: they are observed through the Codex CLI's own login, " +
+      "reported by the Codex row on the same page — codex login in a terminal connects them, " +
+      "and signing that CLI out stops them.",
   };
 }
 
@@ -226,9 +225,9 @@ function integrationFacts(settings: AppSettings): AppGuideFact[] {
       detail:
         settings.appleCalendar === undefined
           ? "Apple Calendar (not connected) connects from its row through macOS's own " +
-            "calendar-access ask — no sign-in and no key. Connecting it lets Luke read only when " +
-            "the meetings in this Mac's Calendar start and end — never their titles or who " +
-            "attends — so announcements can wait out a meeting."
+            "calendar-access ask — no sign-in and no key. Connecting it lets Luke read only " +
+            "when the meetings in this Mac's Calendar start and end — never their titles or " +
+            "who attends."
           : "Apple Calendar (connected) reads only when the meetings in this Mac's Calendar " +
             "start and end — never their titles or who attends. Which calendars count is chosen " +
             "with the checkboxes on its row, and the access itself stays the user's in System " +
@@ -242,8 +241,8 @@ function integrationFacts(settings: AppSettings): AppGuideFact[] {
       detail:
         accounts === 0
           ? "Google Calendar (not connected) connects by signing in with Google from its row. " +
-            "Connecting it lets Luke read only when meetings start and end — never their titles " +
-            "or who attends — so announcements can wait out a meeting."
+            "Connecting it lets Luke read only when meetings start and end — never their " +
+            "titles or who attends."
           : `Google Calendar (${accounts === 1 ? "1 account" : `${accounts} accounts`} connected) ` +
             "reads only when meetings start and end — never their titles or who attends. Which " +
             "calendars count is chosen with the checkboxes under each account, and more accounts " +
@@ -253,46 +252,39 @@ function integrationFacts(settings: AppSettings): AppGuideFact[] {
   facts.push({
     label: "Superset",
     detail:
-      "Superset workspaces on this Mac are recognized automatically from Superset's local " +
-      "read-only host state, so agents from different providers group under the project and " +
-      "workspace that owns them. Every grouped chat carries its workspace's own Superset " +
-      "and terminal identifiers, so a chat with no native address opens at its exact terminal " +
-      "in Superset — pressed, or asked of Luke — with no login needed. A worktree workspace " +
-      "with no agent chat at all stands as its own idle row — titled by the workspace, opening " +
-      "in Superset on press, staying however long it has sat idle, which is how a stale " +
-      "workspace is found and cleaned up; the main checkout and workspaces Superset already " +
-      "archived draw no row. When Superset's CLI is logged in, chat rows can also send the " +
-      "developer's own message, every Superset row offers Delete workspace once its work " +
-      "settled — an agentless workspace row counts as settled by construction — Superset " +
-      "keeps no archive, so deleting is permanent and takes the whole workspace with every " +
-      "chat in it, and a row still working is never offered it; a single chat cannot be " +
-      "closed or removed on its own, so deleting the settled workspace is the one removal " +
-      "a Superset row takes, and an ask to archive one means exactly this delete. Those rows " +
-      "also rename the workspace and start another agent in it, and a conversation ask can " +
-      "create a new Superset workspace; the default agent for a creation ask that names " +
-      "none is chosen under Superset in Settings, and until one is chosen, Luke asks. " +
-      "Connect from Luke's Settings, finish Superset's own sign-in flow in the browser, and " +
-      "paste its one-time code into Luke. Superset's CLI exchanges that code, stores the " +
-      "login, and switches organizations; Luke never reads its token or clipboard. Superset's " +
-      "row sits under Providers on the Connections page; while connected it keeps a pencil " +
-      "that runs the same sign-in again — the CLI's way of switching organizations — and " +
-      "disconnecting from it runs the CLI's own sign-out, clearing the login the CLI stored.",
+      "Superset workspaces on this Mac are recognized read-only from Superset's own host " +
+      "state, grouping agents from different providers under their workspace, " +
+      "and every grouped chat opens at its exact terminal in Superset — " +
+      "pressed, or asked of Luke — with no login needed. A worktree workspace with no agent " +
+      "chat at all stands as its own idle row, titled by the workspace and opening in " +
+      "Superset on press; the main checkout and workspaces " +
+      "Superset already archived draw no row. When Superset's CLI is logged in, chat rows " +
+      "can send the developer's own message, rename the workspace, or start another agent " +
+      "in it, and a conversation ask can create a new Superset " +
+      "workspace. Every Superset row offers Delete workspace once its " +
+      "work settled — an agentless workspace row counts as settled — and Superset keeps no " +
+      "archive: deleting is permanent and takes the whole workspace with every chat in it, " +
+      "a row still working is never offered it, a single chat cannot be closed or removed " +
+      "on its own, and an ask to archive one means exactly this delete. Superset's row sits " +
+      "under Providers on the Connections page: connecting runs Superset's own sign-in in " +
+      "the browser and takes its one-time code pasted into Luke — the CLI exchanges and " +
+      "stores the login, and Luke never reads its token or clipboard — its pencil runs the " +
+      "sign-in again to switch organizations, and disconnecting runs the CLI's own sign-out.",
   });
   facts.push({
     label: "Conductor",
     detail:
-      "Conductor comes two ways, told apart by where the work lands. Conductor cloud connects " +
-      "with a key under Providers and creates workspaces in the cloud projects that key " +
-      "lists. Conductor on this Mac needs no key: it is recognized read-only from Conductor's own " +
-      "index, and a conversation ask can create a new workspace in any repository Conductor holds " +
-      "locally — shown as “Conductor (local)” in the create picker and its own block under " +
-      "Providers. A local creation opens the new workspace in Conductor itself and may carry an " +
-      "opening task, which Conductor pre-fills in the new workspace's composer but does not send — " +
-      "its link cannot, so Luke says the prompt is ready and the developer presses Return in " +
-      "Conductor to start it. It carries no agent, model, or name choice, so it runs the " +
-      "repository's own default agent and wears the name Conductor gives it. Local " +
-      "Conductor chats stay read-only otherwise: Luke cannot message, archive, or add an agent to " +
-      "one, because Conductor documents no local way in for those.",
+      "Conductor comes two ways. Conductor cloud connects with a key under Providers and " +
+      "creates workspaces in the cloud projects that key lists. Conductor on this Mac needs " +
+      "no key: it is recognized read-only from Conductor's own index, and a conversation ask " +
+      "can create a new workspace in any repository Conductor holds locally — shown as " +
+      "“Conductor (local)” in the create picker and its own block under Providers. A local " +
+      "creation opens the new workspace in Conductor itself; an opening task is pre-filled " +
+      "in its composer but not sent — Luke says the prompt is ready, and the developer " +
+      "presses Return in Conductor to start it. " +
+      "It carries no agent, model, or name choice — the repository's own default agent runs, " +
+      "under the name Conductor gives it. Local Conductor chats stay read-only otherwise: " +
+      "Luke cannot message, archive, or add an agent to one.",
   });
   return facts;
 }
@@ -310,19 +302,17 @@ function voiceKeyFact(settings: AppSettings, voiceAvailable: boolean): AppGuideF
     detail:
       `${openai.displayName} (${connectionWord(source)}). ` +
       (hosted
-        ? `Voice and session review run on the signed-in Luke account's daily allowance. A ` +
+        ? `Voice and session review run on the signed-in Luke account's daily allowance; a ` +
           `key of the developer's own runs them unmetered instead, billed by OpenAI. When a ` +
-          `day's allowance is spent, watching continues unmetered and only voice pauses until ` +
-          `the reset: the face beside the housing stays awake but grays out to half ink, ` +
-          `and a caption where replies land says when voice ` +
-          `returns — once at the ` +
-          `run-out, again whenever the composer is reached for or an ask is refused. `
+          `day's allowance is spent, watching continues unmetered and only voice pauses ` +
+          `until the reset — the face beside the housing grays out, and a caption where ` +
+          `replies land says when voice returns. `
         : source === CREDENTIAL_SOURCE.NONE
           ? `Signing in — or connecting a key — is what lets Luke speak and review sessions. `
           : `Voice and session review run on this key: no daily limit, nothing through Luke's ` +
             `service, and OpenAI bills you for what you use. `) +
-      `The key is typed by hand into ${VOICE_SOURCE_SECTION} — never read from the environment, ` +
-      `never spoken, and never repeated back.`,
+      `The key is typed by hand into ${VOICE_SOURCE_SECTION} and never read from the ` +
+      `environment.`,
   };
 }
 
@@ -364,10 +354,9 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       label: "What Luke is",
       detail:
         "A macOS sidecar living beside the notch. The number beside the housing is the most " +
-        "pressing count among the sessions the panel lists: how many need the developer, else " +
-        "how many are working, else how many settled. It wears that state's colour, and the " +
-        "peek's caption names the state in words. Hovering peeks, pressing opens the panel, " +
-        "and Escape closes what is open.",
+        "pressing count among the sessions the panel lists — how many need the developer, else " +
+        "how many are working, else how many settled — wearing that state's colour. Hovering " +
+        "peeks, pressing opens the panel, and Escape closes what is open.",
     },
     {
       label: "The panel",
@@ -380,175 +369,151 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       label: "The sessions list",
       detail:
         "Lists every session that still matters: one working or waiting stays at any age, a " +
-        "failure for three days, a finished or quiet one for two. The options button opens " +
-        "filter rows by axis — location (local, cloud), kind (voice chats), app (Conductor, " +
-        "ChatGPT, Cursor, Orca, Superset, cmux), and agent — where several chips can be pressed at once: choices " +
-        "on one row widen each other and choices across rows narrow, so Codex beside " +
-        "Conductor means Codex chats associated with Conductor. Cursor sits on both rows: " +
-        "its app chip narrows to the chats the Cursor app can open, its agent chip to every " +
-        "Cursor chat. The sheet stays open while " +
-        "chips toggle, and the options button wears the narrowing while the sheet is closed, " +
-        "with an X on its right that clears every chosen chip at once. " +
-        "Chosen chips are un-pressed the same way they were pressed, a spoken ask can narrow " +
-        "to one or several values combined the same way — local Codex voice chats is one ask " +
-        "— naming an agent or app by its everyday name, or back to all, the same clear the X " +
-        "makes, replacing what was picked by hand, and the list is " +
-        "orderable by urgency or recency by the same button or ask. " +
-        "A row can be opened, messaged, or controlled " +
-        "where its provider allows. A session whose provider reported a pull request grows a " +
-        "chip that opens it in the browser — said once on a workspace tray's header when its " +
-        "chats share the one change. A row the developer asked Luke to listen for wears " +
-        "a listening mark beside its age. Luke's own composer at the foot takes a typed ask.",
+        "failure for three days, a finished or quiet one for two. The options button filters " +
+        "by location (local, cloud), kind (voice chats), app (Conductor, ChatGPT, Cursor, " +
+        "Orca, Superset, cmux), and agent; several chips can be chosen at once, choices on " +
+        "one row widening each other and choices across rows narrowing. Cursor sits on both " +
+        "rows: its app chip narrows to the chats the Cursor app can open, its agent chip to " +
+        "every Cursor chat. An X on the options button clears every chosen chip at once, and " +
+        "a spoken ask can narrow to the same values or back to all. The list is orderable by " +
+        "urgency or recency by the same button or ask. " +
+        "A row can be opened, messaged, or controlled where its provider allows, a session " +
+        "whose provider reported a pull request grows a chip that opens it in the browser, " +
+        "and a row the developer asked Luke to listen for wears a listening mark beside its " +
+        "age. Luke's own composer at the foot takes a typed ask.",
     },
     {
       label: "Apps beside a session",
       detail:
         "The large mark leading a row names the coding agent; the small bare marks after its " +
-        "title name apps where the same chat also appears — more than one may appear, and none " +
-        "replaces the agent or changes local versus cloud. A Conductor cloud chat leads " +
+        "title name apps where the same chat also appears — none replaces the agent or " +
+        "changes local versus cloud. A Conductor cloud chat leads " +
         "with the agent running it, Claude Code or Codex, a small cloud badge saying where it " +
-        "runs; Conductor's own letter mark stands in only when the agent went unreported. Each " +
-        "association is read where its app keeps it, read-only: Conductor's session index — a " +
-        "Codex chat's exact parent-thread record carries that Conductor association to a " +
-        "spawned sub-agent's separate row — Superset's host state, Orca's hook-status cache, " +
-        "grouping chats under the Orca worktree hosting them, and the session stores cmux's " +
-        "own CLI writes, which exist only where cmux's agent hooks are installed (Claude " +
-        "Code's automatically; Codex, Cursor, Gemini CLI, and OpenCode after `cmux hooks " +
-        "setup`), so a session cmux never recorded carries no cmux mark. A local Codex chat " +
-        "also names ChatGPT, whose desktop app documents the exact Codex thread address. A " +
-        "Cursor chat names Cursor itself when the app can open it: a local chat in the app's " +
-        "own index, read as key presence alone, or any Cursor cloud agent, opened by id like " +
-        "its own dashboard; a chat Cursor's agents CLI started in a plain terminal carries no " +
-        "Cursor app mark and opens nowhere unless cmux, Superset, or Conductor hosts its " +
-        "terminal.",
+        "runs; Conductor's own letter mark stands in only when the agent went unreported, and " +
+        "a Codex sub-agent spawned there keeps the Conductor association on its own row. Each " +
+        "association is recognized read-only from that app's own records, and cmux records a " +
+        "session only where its agent hooks are installed — Claude Code's automatically; " +
+        "Codex, Cursor, Gemini CLI, and OpenCode after `cmux hooks setup` — so a session cmux " +
+        "never recorded carries no cmux mark. A local Codex chat also names ChatGPT, which " +
+        "documents the exact Codex thread address. A Cursor chat names Cursor itself when the " +
+        "app can open it: a local chat in the app's own index, or any Cursor cloud agent. A " +
+        "chat Cursor's agents CLI started in a plain terminal carries no Cursor app mark and " +
+        "opens nowhere unless cmux, Superset, or Conductor hosts its terminal.",
     },
     {
       label: "Opening a chat in its apps",
       detail:
         "An app mark with an exact address is a button: ChatGPT opens that Codex thread, " +
-        "Cursor opens the exact chat in its own window, Superset opens its bound terminal, " +
+        "Cursor opens the exact chat, Superset opens its bound terminal, " +
         "cmux opens the exact terminal pane the agent runs in — standing in as the row's " +
         "own destination when no other app gave it one — and a Conductor cloud chat's " +
-        "Conductor mark opens that exact chat; the row body still opens its preferred exact " +
-        "destination. A local Conductor chat or an Orca worktree exposes no documented exact " +
-        "address or message endpoint, so each of those marks identifies the association but " +
-        "adds no open or send control; a cmux chat takes no message or control through cmux " +
-        "either — its mark opens the pane, nothing more. An ask in conversation, spoken or " +
-        "typed, opens the same destinations the row offers: the row's own preferred address " +
-        "by default, or that app's exact address when the chat appears in more than one app " +
-        "and the ask names one whose mark is a button.",
+        "Conductor mark opens that exact chat. The row body, or an ask in conversation, " +
+        "opens the row's preferred address; an ask naming an app whose mark is a button " +
+        "opens that app's exact address instead. A local Conductor chat or an Orca worktree " +
+        "has no documented exact address or message endpoint, so its mark identifies the " +
+        "association but adds no open or send control; a cmux chat takes no message or " +
+        "control through cmux either — its mark only opens the pane.",
     },
     {
       label: "Searching sessions",
       detail:
-        "The list is searchable three ways: the magnifier beside the options button, Command-F " +
-        "while the panel has the keyboard, or asking Luke to search out loud — a spoken search " +
-        "fills the same field and reaches no further than the magnifier, which is only offered " +
-        "beside a list of more than one session. It keeps rows saying every typed word in " +
-        "their title, status word or status line, branch, repository, workspace, agent, associated app, or model, and counts " +
-        "what it left. A search matching nothing offers the matches a filter is hiding rather " +
-        "than pretending there are none. Escape clears the query and then closes the field, " +
-        "and clearing or closing is what lets a search go; a search left standing is a way of " +
-        "viewing the list like the filter chips, so it survives the panel closing and the app " +
-        "restarting and comes back with its field open. Command-F answers " +
-        "for whichever tab is showing: the sessions list here, the settings search on Settings.",
+        "The list is searchable by the magnifier beside the options button, Command-F while " +
+        "the panel has the keyboard, or asking Luke to search out loud — a spoken search " +
+        "fills the same field and reaches no further than the magnifier, which is only " +
+        "offered beside a list of more than one session. It keeps rows saying every typed " +
+        "word in their title, status word or status line, branch, repository, workspace, " +
+        "agent, associated app, or model, and a search matching nothing offers the matches a " +
+        "filter is hiding. A standing search survives the panel closing and the app " +
+        "restarting until its query is cleared or its field closed — Escape does both. " +
+        "Command-F answers for whichever tab is showing: the sessions list here, " +
+        "the settings search on Settings.",
     },
     {
       label: "Workspaces in the list",
       detail:
-        "Where chats nest in a workspace — Conductor's, cloud and local alike, and " +
-        "Superset's and Orca's on this machine — each chat is its own row. A workspace holding several " +
-        "draws them inside one tray named by the workspace; one holding a single chat stays " +
-        "one row titled by the workspace. Every chat can be seen, opened, and messaged " +
-        "individually where its latest roster entry offers that act. A Superset, Conductor, " +
-        "or Orca " +
-        "tray carries the managing app's mark once in its header rather than repeating it on " +
-        "every child row, and the header also carries the workspace's acts and the one " +
-        "pull-request chip its chats share, where each row would have repeated them.",
+        "Where chats nest in a workspace — Conductor's, cloud and local alike, and Superset's " +
+        "and Orca's on this machine — each chat is its own row: a workspace holding several " +
+        "draws them inside one tray named by the workspace, and one holding a single chat " +
+        "stays one row titled by it. Every chat can be seen, opened, and messaged " +
+        "individually where its latest roster entry offers that act. A tray's header carries " +
+        "the managing app's mark, the workspace's acts, and the one pull-request chip its " +
+        "chats share, each said once for the group.",
     },
     {
       label: "The Settings tab",
       detail:
         "A front page led by the What Luke runs on section: a two-way toggle naming the " +
         "signed-in Luke account (free, a daily amount) against the developer's own OpenAI key " +
-        "(unmetered, billed by OpenAI), with the live one marked and the other pressable to " +
-        "switch. Choosing the key with none stored asks for one; choosing the account parks a " +
-        "stored key without deleting it. Under the toggle stands whichever half is live: on " +
-        "the account, meters for the day's talking and announcements and checks on your " +
-        "sessions, and when they reset; on the key, the OpenAI row itself. Below are rows " +
-        "opening the Voice, Appearance, Keyboard shortcuts, and Connections pages, each led " +
-        "back out by its back button or Escape. The Feedback section, the Account section, and " +
-        "Quit stay on the front page itself.",
+        "(unmetered, billed by OpenAI). Choosing the key with none stored asks for one; " +
+        "choosing the account parks a stored key without deleting it. Under the toggle: on " +
+        "the account, meters for the day's talking, announcements, and session checks, and " +
+        "when they reset; on the key, the " +
+        "OpenAI row itself. Below are rows opening the Voice, Appearance, Keyboard shortcuts, " +
+        "and Connections pages; the Feedback section, the Account section, and Quit stay on " +
+        "the front page itself.",
     },
     {
       label: "Searching settings",
       detail:
-        "The magnifier beside the tab bar — or Command-F — while Settings is showing opens a " +
-        "search field pinned at the head of whichever settings page is showing, and the search " +
-        "always reads across every page. It finds any row — a page itself, a setting by its " +
-        "name or what it does, a provider, a shortcut, a way out. Typing swaps the page for " +
-        "the matches, grouped under the page that holds each; pressing a page opens it, and " +
-        "pressing a row opens its page and takes the view to the row itself. Escape clears " +
-        "the query, then closes the field, then leaves the page. The search is by hand alone: " +
-        "no spoken ask can search, and no search survives the panel closing.",
+        "The magnifier beside the tab bar — or Command-F — while Settings is showing searches " +
+        "every settings page at once. It finds any row — a page itself, a setting by its name " +
+        "or what it does, a provider, a shortcut, a way out — and pressing a match opens its " +
+        "page at the row itself. The search is by hand alone: no spoken ask can search, and " +
+        "no search survives the panel closing.",
     },
     {
       label: "What a settings page marks",
       detail:
         "A dot beside a row marks a value changed from its default, and a page holding one " +
-        "ends its head with a reset, pressed by hand and never spoken, returning that page's " +
-        "settings to their defaults. The Connections page carries no group reset: its defaults " +
-        "are changed row by row. No reset touches a key, an account, or the Conductor agent choice. An " +
-        "exclamation mark sits on whatever still needs a hand: the What Luke runs on heading " +
-        "while voice has nothing to run on, the Voice and microphone rows while the permission " +
-        "is ungranted, and the Keyboard shortcuts rows while voice is off, where each chord " +
-        "stays shown and changeable but answers nothing until voice is available.",
+        "offers a reset at its head — pressed by hand and never spoken — returning that " +
+        "page's settings to their defaults. The Connections page has no group reset: its " +
+        "defaults are changed row by row, and no reset touches a key, an account, or the " +
+        "Conductor agent choice. An exclamation mark sits on whatever still needs a hand — " +
+        "voice with nothing to run on, an ungranted microphone permission, or the keyboard " +
+        "shortcuts while voice is off, whose chords stay shown and changeable but answer " +
+        "nothing until voice is available.",
     },
     {
       label: "Account",
       detail:
         account.status === ACCOUNT_STATUS.SIGNED_IN
           ? `Signed in as ${account.email} through ${account.provider === ACCOUNT_PROVIDER.GITHUB ? "GitHub" : "Google"}. Sign out by hand from ${ACCOUNT_SECTION} — it asks before acting. The same section's Delete account row erases the account and everything Luke's service holds for it, cannot be undone, and is only ever done by hand — its button asks before acting, and no spoken ask can reach it.`
-          : "Not signed in. The sign-in screen greets the launch once with Google and GitHub, then closes like any panel. While signed out the strip beside the housing keeps Luke's face and a small Sign in label in place of the session count, and hovering or pressing it brings the sign-in screen back. Live sessions and Luke's controls stay off until sign-in finishes. Choosing a provider stands the panel down to a small waiting popup with a Cancel button while the browser finishes, and the panel opens itself once the sign-in lands.",
+          : "Not signed in. The sign-in screen greets the launch once with Google and GitHub; while signed out the strip beside the housing keeps Luke's face and a small Sign in label, and hovering or pressing it brings the sign-in screen back. Live sessions and Luke's controls stay off until sign-in finishes; signing in finishes in the browser — cancellable — and the panel opens itself once it lands.",
     },
     {
       label: "Feedback and prompts",
       detail:
-        "The Feedback section near the foot of the Settings tab, just above Quit, opens a " +
-        "composer under the notch. Send feedback is for bugs and ideas; Submit a prompt sends a " +
-        "prompt to a coding agent. Either goes by email to the founders with an optional name " +
-        "and email for credit, and up to three screenshots. A spoken ask can open the composer " +
-        "and start it with the developer's own words — Luke offers exactly that, once, after " +
-        "refusing something he cannot do — but a note already being written is never " +
-        "overwritten, and sending is always the Send button's own press: no spoken ask can " +
-        "send one.",
+        "The Feedback section near the foot of the Settings tab opens a composer under the " +
+        "notch: Send feedback for bugs and ideas, Submit a prompt for a prompt to a coding " +
+        "agent. Either goes by email to the founders, with an optional name and email for " +
+        "credit and up to three screenshots. A spoken ask can open the composer and start it " +
+        "with the developer's own words — Luke offers exactly that, once, after refusing " +
+        "something he cannot do — but a note already being written is never overwritten, and " +
+        "sending is always the Send button's own press: no spoken ask can send one.",
     },
     {
       label: "Reading a session's transcript",
       detail:
-        "Asked what a local session did, said, or is stuck on, Luke can read that session's own " +
-        "recent transcript — Antigravity, Claude Code, Codex, Gemini CLI, Grok Build, " +
-        "OpenCode, Radius, and the Devin and Cursor agents running on this machine today — and " +
-        "answer from it. Cursor and Radius keep tool outputs out of their own transcripts, and " +
+        "Asked what a local session did, said, or is stuck on, Luke can read that session's " +
+        "own recent transcript — Antigravity, Claude Code, Codex, Gemini CLI, Grok Build, " +
+        "OpenCode, Radius, and the Devin and Cursor agents on this machine today — and answer " +
+        "from it. Cursor and Radius keep tool outputs out of their transcripts, and " +
         "Antigravity's are stored where Luke does not read them, so those readings carry the " +
-        "words and the calls but no results. " +
-        "The reading happens when asked and is kept nowhere; cloud sessions keep their " +
-        "conversations with their provider, so Luke answers about those from their roster " +
-        "fields alone.",
+        "words and the calls but no results. The reading happens when asked and is kept " +
+        "nowhere; a cloud session's conversation stays with its provider, and Luke answers " +
+        "about it from roster fields alone.",
     },
     {
       label: "Messaging local Cursor chats",
       detail:
         "A local Cursor chat whose turn has settled can take the developer's own message, " +
-        "typed on its row or asked of Luke in conversation: Luke runs Cursor's own agents " +
-        "CLI, resuming exactly that chat in its own folder with the message as its one " +
-        "prompt, and the reply lands in the same transcript the row already reads. It is " +
-        "offered only where that is honest — the CLI installed and signed in, the chat's " +
-        "folder named by Cursor's own records, the turn not still running — and not for " +
-        "chats the Cursor app's own windows hold, whose rows open the exact chat in the " +
-        "app instead, because Cursor does not document whether an app window would show a " +
-        "turn landed behind it. A Superset-managed Cursor chat still messages through " +
-        "Superset's own terminal, which shows the message where the agent actually runs.",
+        "typed on its row or asked of Luke: Luke runs Cursor's own agents CLI, resuming " +
+        "exactly that chat in its own folder with the message as its one prompt, and the " +
+        "reply lands in the transcript the row already reads. It is offered only with the " +
+        "CLI installed and signed in, the chat's folder named by Cursor's own records, and " +
+        "the turn not still running — and never for chats the Cursor app's own windows hold, " +
+        "whose rows open the exact chat in the app instead. A Superset-managed Cursor chat " +
+        "still messages through Superset's own terminal.",
     },
     {
       label: "Creating workspaces",
@@ -561,12 +526,11 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "workspace or session the agent should join adds one beside it instead. Only reported " +
         "projects can be named, a project that needs a task cannot be created without one, and " +
         "a provider that reports none takes no ask. Every Superset project carries the host " +
-        "that runs it — named for a remote host, unannotated on this Mac — and a new Superset " +
+        "that runs it, and a new Superset " +
         "workspace needs that host, an agent Superset currently lists for it, and an opening " +
         "task, so a task-less ask for one is refused rather than created idle. A workspace " +
-        "that lands opens by itself: the moment observation reports the new session with an " +
-        "address, that address is handed to the operating system, as pressing the session's " +
-        "row would; one whose provider reports no address stays on its row, unopened.",
+        "that lands opens on screen by itself once observation reports it with an address; " +
+        "one whose provider reports no address stays on its row, unopened.",
     },
     {
       label: "Workspace creation defaults",
@@ -574,71 +538,70 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "An ask that names no provider goes to the default workspace provider, and one that " +
         "names no project to that provider's default project. The first workspace created " +
         "saves its provider as the default — changed or cleared by hand in the Settings tab — " +
-        "and each provider remembers a default project the same way, filled in by the first " +
-        "workspace created there and changed or cleared by hand on the Connections page, on that " +
-        "provider's own row: under Providers for a provider connected by key and for " +
-        "Conductor (local), under Superset for Superset. Until one is chosen, Luke asks " +
-        "whenever more than one provider or project could take the ask. What a new Conductor " +
-        "agent runs — its model, and its effort where the model's agent takes one — follows " +
-        "the choice on the Conductor row under Providers, or Conductor's own defaults while " +
-        "none is made. A model named in a creation ask rides that creation alone and is saved " +
-        "as the default only while none is chosen; the settings themselves change only when " +
-        "the developer asks, and Luke never asks or suggests a model.",
+        "and each provider remembers a default project, filled in by the first workspace " +
+        "created there and changed or cleared by hand on that provider's own row on the " +
+        "Connections page: under Providers for a provider connected by key and for Conductor " +
+        "(local), under Superset for Superset. Superset also remembers a default agent for " +
+        "creation asks that name none, chosen under Superset in Settings. Until one is " +
+        "chosen, Luke asks whenever more than one provider, project, or agent could take " +
+        "the ask. What a new Conductor agent runs — " +
+        "its model, and its effort where the model's agent takes one — follows the choice on " +
+        "the Conductor row under Providers, or Conductor's own defaults while none is made. A " +
+        "model named in a creation ask rides that creation alone and is saved as the default " +
+        "only while none is chosen; the settings change only when the developer asks, and " +
+        "Luke never asks or suggests a model.",
     },
     {
       label: "Adding agents to a workspace",
       detail:
         "Where a session's provider documents it — Conductor today — the same kind of ask can " +
-        "start another agent in the workspace an observed session runs in, as one of the agent " +
+        "start another agent in an observed session's workspace, as one of the agent " +
         "kinds that session's roster entry lists, optionally named and optionally with an " +
-        "opening task. The ask must name that workspace or session in its own words; a bare " +
-        "ask for a new agent creates a new workspace instead. A model named in the ask — with an effort where its agent takes one — " +
-        "rides that agent alone; unnamed, the Conductor row's choice rides along only when it " +
-        "names the same agent kind. A session whose entry lists no new agents takes no such ask.",
+        "opening task. The ask must name that workspace or session; a bare ask for a new " +
+        "agent creates a new workspace instead. A model named in the ask — with an effort " +
+        "where its agent takes one — rides that agent alone; unnamed, the Conductor row's " +
+        "choice rides along only when it names the same agent kind. A session whose entry " +
+        "lists no new agents takes no such ask.",
     },
     {
       label: "Renaming workspaces and chats",
       detail:
-        "Where a provider documents it, an ask in conversation, spoken or typed, can rename " +
-        "what is observed, to a name in the developer's own words: a Conductor or " +
-        "Superset-managed workspace, or a Conductor chat on its own. An ask that names the " +
-        "workspace renames the workspace; one about the chat renames the chat. Only sessions " +
-        "whose roster entry says the workspace can be renamed — or the chat can — take one; " +
-        "the tray and the provider's own surface pick the new name up on the next observation. " +
-        "A session whose entry says neither takes no such ask.",
+        "Where a provider documents it, an ask can rename what is observed, to a name in the " +
+        "developer's own words: a Conductor or Superset-managed workspace, or a Conductor " +
+        "chat on its own. An ask that names the workspace renames the workspace; one about " +
+        "the chat renames the chat. Only sessions whose roster entry says the workspace can " +
+        "be renamed — or the chat can — take one, and a session whose entry says neither " +
+        "takes no such ask; the new name shows up on the next observation.",
     },
     {
       label: "Archiving",
       detail:
         "Where a provider documents an archive endpoint — a Conductor workspace, a Cursor " +
-        "cloud agent, and a Devin cloud session today — Archive is offered as a control once the " +
-        "work there was positively seen to settle: pressed, or asked of Luke in " +
-        "conversation, it files the work away through the provider's own endpoint. Archiving a " +
-        "Conductor workspace files away every chat in it at once, so when several of its chats " +
-        "are drawn together the control sits once on the group's own header rather than on " +
-        "each row; a lone chat, or any other provider's session, carries it on the row. An " +
-        "archived Cursor agent " +
-        "stays readable but takes no new runs; an archived Devin session can be viewed but not " +
-        "resumed. A row mid-turn — or one whose state could not be read — offers no archive, a " +
-        "session whose roster entry lists no archive control takes no such ask, and local " +
-        "sessions — which Luke only reads — are never archived. A Superset-managed workspace " +
-        "keeps no archive, so an ask to archive one is taken as the one removal it does take " +
-        "— its Delete workspace control, offered only once its work settled — and Luke words " +
-        "the outcome as the delete it is: permanent, never filed away.",
+        "cloud agent, and a Devin cloud session today — Archive is offered once the work " +
+        "there was positively seen to settle: pressed, or asked of Luke, it files the work " +
+        "away through the provider's own endpoint. Archiving a Conductor workspace files " +
+        "away every chat in it at once, so the control sits once on a group's header and " +
+        "otherwise on the row. An archived Cursor agent " +
+        "stays readable but takes no new runs; an archived Devin session can be viewed but " +
+        "not resumed. A row mid-turn — or one whose state could not be read — offers no " +
+        "archive, a session whose roster entry lists no archive control takes no such ask, " +
+        "and local sessions — which Luke only reads — are never archived. A Superset-managed " +
+        "workspace keeps no archive: an ask to archive one is taken as its Delete workspace " +
+        "control, and Luke words the outcome as the delete it is — permanent, never filed " +
+        "away.",
     },
     {
       label: "Standing asks about sessions",
       detail:
-        "An ask in conversation, spoken or typed, can be kept standing for one observed session " +
-        "— told when it finishes, warned if it fails, whatever the developer asked in their own " +
-        "words. Luke's background review weighs each of that session's updates against the ask " +
-        "and speaks when one satisfies it, opening a speak-only call if no conversation is up; " +
-        "the ask itself is the consent. One ask stands per session, a new one replaces it, asking Luke to drop " +
-        "it withdraws it, and an ask ends with the session it was about. A row with an ask standing wears a " +
-        "small listening mark beside its age, and the conversation roster carries each standing ask, so Luke " +
-        "can say what he is already listening for. It needs voice to be available — the " +
-        "signed-in account includes it, and a personal OpenAI key also provides it — " +
-        "changes nothing about the session itself, and is never sent to a provider.",
+        "An ask can be kept standing for one observed session — told when it finishes, warned " +
+        "if it fails, whatever the developer asked in their own words. Luke's background " +
+        "review weighs that session's updates against the ask and speaks when one satisfies " +
+        "it, opening a speak-only call if no conversation is up; the ask itself is " +
+        "the consent. One ask stands per session, a new one replaces it, asking Luke to drop " +
+        "it withdraws it, and an ask ends with the session it was about. A row with an ask " +
+        "standing wears a small listening mark beside its age, and Luke can say what he is " +
+        "already listening for. It needs voice to be available, changes nothing about the " +
+        "session itself, and is never sent to a provider.",
     },
     talkKeyFact(input.hotkey),
     askKeyFact(input.askKey),
@@ -666,12 +629,11 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
               "Luke says it out loud when an observed session is holding for you, stops on an " +
               "error, or finishes — a hold is a question, a permission, or an approval, not a " +
               "turn that merely ended — in his own words, naming the session and what it " +
-              "needs, from the agent's parting words or the provider's error line when one " +
-              "was reported. No conversation needs to be open, and the microphone stays off. " +
-              "Always on while voice is available; the panel and the capsule count show the " +
-              "same states either way. A session the developer is speaking with through its " +
-              "provider's own realtime voice — a Codex thread in a live voice conversation, " +
-              "and any chat that conversation delegated — announces nothing while the " +
+              "needs, from the agent's parting words or the provider's error line. No " +
+              "conversation needs to be open, the microphone stays off, and " +
+              "it is always on while voice is available. A session the developer is speaking " +
+              "with through its provider's own realtime voice — a Codex thread in a live " +
+              "voice conversation, and any chat it delegated — announces nothing while the " +
               "conversation holds; the first change after it closes is announced as usual, " +
               "and nothing from inside it is replayed.",
           },
@@ -681,17 +643,12 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
               "While Luke says an announcement, a pressable notice names the session he is " +
               "talking about — under the housing, or at the open panel's foot: pressing it " +
               "opens the session where its provider keeps it, or the panel for a local " +
-              "session with no page of its own. A session's chip wears the same marks its row " +
-              "does, the agent's own in front and the apps holding the chat trailing the " +
-              "name. The same chips appear while a conversation " +
-              "reply names observed sessions by title, or a workspace of grouped chats by its " +
+              "session with no page of its own. The same pressable chips appear while a " +
+              "conversation reply names observed sessions by title, or a workspace of grouped chats by its " +
               "name — one chip per thing named, up to a dozen, a workspace's opening its most " +
-              "recent chat. A reply naming tracked issues — by identifier like LUKE-123, or " +
-              "by whole title — draws their chips on the same band, each opening its issue " +
-              "where the tracker keeps it. Past three rows the chips scroll in place, and " +
-              "each presses the same way. The chips and the captioned words leave when the " +
-              "reply ends, but never out from under the pointer: resting on them holds them " +
-              "until it moves away.",
+              "recent chat — and a reply naming tracked issues, by identifier like LUKE-123 " +
+              "or by whole title, draws their chips on the same band, each opening its issue " +
+              "where the tracker keeps it. The chips leave when the reply ends.",
           },
           // Only a build that offers a calendar may describe the quiet: a hold
           // Luke claims without a calendar row to connect is a capability he
@@ -704,43 +661,41 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
                     "With a calendar connected — a Google Calendar account, or this Mac's own " +
                     "Apple Calendar — and Quiet during meetings on, announcements decided " +
                     "during a meeting wait and are read out together once it ends. The quiet " +
-                    "beginning — a meeting starting, or the setting switched on mid-meeting — " +
-                    "silences Luke at once, an announcement mid-sentence included, and holds " +
-                    "everything he would say unbidden, even on an open conversation; " +
+                    "begins the moment a meeting starts — or the setting is switched on " +
+                    "mid-meeting — and silences everything Luke would say unbidden, an " +
+                    "announcement mid-sentence included, even on an open conversation; " +
                     "questions asked of him still get their replies. Luke's face sleeps " +
-                    "beside the housing for as long as the quiet holds, which is how the " +
-                    "hold is seen.",
+                    "beside the housing for as long as the quiet holds.",
                 },
               ]
             : []),
           {
             label: "Muted output",
             detail:
-              "While the Mac is muted or its volume is at zero, Luke's replies are captioned on " +
-              "screen even with Captions off, and a hint under the words asks for volume. The " +
-              "whole reply stays on screen, the block growing to fit the words. " +
-              "The hint's Got it button rests it for that stretch of silence and any that " +
-              "begins within fifteen minutes; the captions stay.",
+              "While the Mac is muted or its volume is at zero, Luke's replies are captioned " +
+              "on screen even with Captions off, the whole reply staying on screen, and a " +
+              "hint under the words asks for volume. The hint's Got it button rests it for " +
+              "that stretch of silence and any that begins within fifteen minutes; the " +
+              "captions stay.",
           },
           {
             label: "How long a conversation lasts",
             detail:
-              "One conversation outlives the calls that carry it. A call opens on the first " +
-              "press of the talk key or the first typed ask, stays open across as many turns as " +
-              "the developer takes, and is put away after three minutes with nothing said on " +
-              "it — costing only the next handshake. The voice service " +
-              "also ends any call at an hour. Either way the next press picks the conversation " +
-              "back up: a bounded history of the recent exchange — what was asked, answered, " +
-              "announced, and done — is kept in memory and re-fed to the new call, so Luke " +
-              "remembers what was just said without writing anything to disk. A call that ends " +
-              "underneath a conversation ends quietly, because nothing said is lost with it.",
+              "A call opens on the first " +
+              "press of the talk key or the first typed ask, stays open across as many turns " +
+              "as the developer takes, and is put away after three minutes with nothing said " +
+              "on it; the voice service also ends any call at an hour. Either way the next " +
+              "press picks the conversation back up: a bounded history of the recent " +
+              "exchange — what was asked, answered, announced, and done — is kept in memory, " +
+              "never written to disk, and re-fed to the new call, so Luke remembers what was " +
+              "just said. A call that ends underneath a conversation ends quietly.",
           },
           {
             label: "When a call fails",
             detail:
               "Why a call failed or ended is shown for a few seconds where the captions are " +
-              "drawn — under the housing, or at the open panel's foot — and then fades. " +
-              "Nothing about it lives in Settings; trying again is the only fix to reach for.",
+              "drawn — under the housing, or at the open panel's foot. Nothing about it " +
+              "lives in Settings; trying again is the only fix.",
           },
         ]
       : [
@@ -770,16 +725,15 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       detail:
         `The Updates section on ${FRONT_PAGE} says which version this is and where the build ` +
         "stands. Its button checks the release manifest on the spot, and Luke also checks on " +
-        "his own a few times a day — always on; the fetch is unauthenticated and nothing about " +
-        "the developer or their sessions is sent. A newer release downloads itself when a check " +
-        "finds one — while it does, the Settings tab wears a dot and the section stands at the " +
-        "top of that page — and installs when Luke next quits: the row offers Restart to update, " +
-        "or it simply lands on the next quit. If a download or install fails, the row says so " +
-        "and offers the fixed releases page in the browser instead. The button's press can also " +
-        "be asked of Luke — check for updates, open the releases page, restart to update — and " +
-        "only the one act the row currently offers runs. The Changelog row under the version " +
-        "opens the changelog in the browser, at the fixed changelog page, where every release's " +
-        "notes live. Opening it is a press by hand; no spoken ask reaches it.",
+        "his own a few times a day — always on; the fetch is unauthenticated and nothing " +
+        "about the developer or their sessions is sent. A newer release downloads itself " +
+        "when a check finds one and installs when Luke next quits — the row offers Restart " +
+        "to update. If a download or install fails, the " +
+        "row says so and offers the fixed releases page in the browser instead. The button's " +
+        "press can also be asked of Luke — check for updates, open the releases page, " +
+        "restart to update — and only the one act the row currently offers runs. The " +
+        "Changelog row under the version opens the changelog in the browser; that is a press " +
+        "by hand, and no spoken ask reaches it.",
     },
     {
       label: "Usage data",

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -199,85 +199,102 @@ function providersFact(settings: AppSettings): AppGuideFact {
   };
 }
 
-function integrationsFact(settings: AppSettings): AppGuideFact {
+/**
+ * One labeled fact per integration, so an ask about one draws that one alone.
+ * An integration a build does not carry contributes no fact at all: a
+ * capability the guide describes is one Luke will claim to have.
+ */
+function integrationFacts(settings: AppSettings): AppGuideFact[] {
+  const facts: AppGuideFact[] = [];
   const linearProvider = CREDENTIAL_PROVIDERS[CREDENTIAL_PROVIDER_ID.LINEAR];
-  const linear = !settings.linearSignInAvailable
-    ? ""
-    : `${linearProvider.displayName} ` +
-      `(${connectionWord(settings.credentialSources[linearProvider.id])}) connects by signing ` +
-      `in with Linear from its row in ${CONNECTIONS_PAGE}, under Integrations — Linear's own ` +
-      `consent page opens in the browser, and no key is ever typed or spoken. Connecting it ` +
-      `lets Luke read the developer's assigned issues and, only when asked in a turn the ` +
-      `developer opened, move one to another state or comment on it. Disconnecting from the ` +
-      `same row ends the access at Linear as well as here.`;
+  if (settings.linearSignInAvailable) {
+    facts.push({
+      label: "Linear",
+      detail:
+        `${linearProvider.displayName} ` +
+        `(${connectionWord(settings.credentialSources[linearProvider.id])}) connects by signing ` +
+        `in with Linear from its row in ${CONNECTIONS_PAGE}, under Integrations — Linear's own ` +
+        `consent page opens in the browser, and no key is ever typed or spoken. Connecting it ` +
+        `lets Luke read the developer's assigned issues and, only when asked in a turn the ` +
+        `developer opened, move one to another state or comment on it. Disconnecting from the ` +
+        `same row ends the access at Linear as well as here.`,
+    });
+  }
+  if (settings.appleCalendarAvailable) {
+    facts.push({
+      label: "Apple Calendar",
+      detail:
+        settings.appleCalendar === undefined
+          ? "Apple Calendar (not connected) connects from its row through macOS's own " +
+            "calendar-access ask — no sign-in and no key. Connecting it lets Luke read only when " +
+            "the meetings in this Mac's Calendar start and end — never their titles or who " +
+            "attends — so announcements can wait out a meeting."
+          : "Apple Calendar (connected) reads only when the meetings in this Mac's Calendar " +
+            "start and end — never their titles or who attends. Which calendars count is chosen " +
+            "with the checkboxes on its row, and the access itself stays the user's in System " +
+            "Settings under Privacy & Security, Calendars.",
+    });
+  }
   const accounts = settings.calendarAccounts.length;
-  const calendar = !settings.calendarSignInAvailable
-    ? ""
-    : accounts === 0
-      ? " Google Calendar (not connected) connects by signing in with Google from its row. " +
-        "Connecting it lets Luke read only when meetings start and end — never their titles " +
-        "or who attends — so announcements can wait out a meeting."
-      : ` Google Calendar (${accounts === 1 ? "1 account" : `${accounts} accounts`} connected) ` +
-        "reads only when meetings start and end — never their titles or who attends. Which " +
-        "calendars count is chosen with the checkboxes under each account, and more accounts " +
-        "can be added from the same row.";
-  const apple = !settings.appleCalendarAvailable
-    ? ""
-    : settings.appleCalendar === undefined
-      ? " Apple Calendar (not connected) connects from its row through macOS's own " +
-        "calendar-access ask — no sign-in and no key. Connecting it lets Luke read only when " +
-        "the meetings in this Mac's Calendar start and end — never their titles or who " +
-        "attends — so announcements can wait out a meeting."
-      : " Apple Calendar (connected) reads only when the meetings in this Mac's Calendar " +
-        "start and end — never their titles or who attends. Which calendars count is chosen " +
-        "with the checkboxes on its row, and the access itself stays the user's in System " +
-        "Settings under Privacy & Security, Calendars.";
-  const superset =
-    " Superset workspaces on this Mac are recognized automatically from Superset's local " +
-    "read-only host state, so agents from different providers group under the project and " +
-    "workspace that owns them. Every grouped chat carries its workspace's own Superset " +
-    "and terminal identifiers, so a chat with no native address opens at its exact terminal " +
-    "in Superset — pressed, or asked of Luke — with no login needed. A worktree workspace " +
-    "with no agent chat at all stands as its own idle row — titled by the workspace, opening " +
-    "in Superset on press, staying however long it has sat idle, which is how a stale " +
-    "workspace is found and cleaned up; the main checkout and workspaces Superset already " +
-    "archived draw no row. When Superset's CLI is " +
-    "logged in, chat rows can also send the " +
-    "developer's own message, every Superset row offers Delete workspace once its work " +
-    "settled — an agentless workspace row counts as settled by construction — Superset " +
-    "keeps no archive, so deleting is permanent and takes the whole workspace with every " +
-    "chat in it, and a row still working is never offered it; a single chat cannot be " +
-    "closed or removed on its own, so deleting the settled workspace is the one removal " +
-    "a Superset row takes, and an ask to archive one means exactly this delete. Those rows " +
-    "also rename the workspace and start another agent in it, and a conversation ask can " +
-    "create a new workspace " +
-    "with an agent in a project and host Superset currently lists; connect from Luke's " +
-    "Settings, finish Superset's own sign-in flow in the browser, and paste its one-time code " +
-    "into Luke. Superset's CLI exchanges that code, stores the login, and switches organizations; " +
-    "Luke never reads its token or clipboard. Superset's row sits under Providers on the " +
-    "Connections page; while connected it keeps a pencil that runs the same sign-in again — " +
-    "the CLI's way of switching organizations — and disconnecting from it runs the CLI's own " +
-    "sign-out, clearing the login the CLI stored. The default agent for a creation ask that names " +
-    "none is chosen under Superset in Settings; until one is chosen, Luke asks.";
-  const conductor =
-    " Conductor comes two ways, told apart by where the work lands. Conductor cloud connects " +
-    "with a key under Providers and creates workspaces in the cloud projects that key " +
-    "lists. Conductor on this Mac needs no key: it is recognized read-only from Conductor's own " +
-    "index, and a conversation ask can create a new workspace in any repository Conductor holds " +
-    "locally — shown as “Conductor (local)” in the create picker and its own block under " +
-    "Providers. A local creation opens the new workspace in Conductor itself and may carry an " +
-    "opening task, which Conductor pre-fills in the new workspace's composer but does not send — " +
-    "its link cannot, so Luke says the prompt is ready and the developer presses Return in " +
-    "Conductor to start it. It carries no agent, model, or name choice, so it runs the " +
-    "repository's own default agent and wears the name Conductor gives it; the default repository " +
-    "a nameless ask lands in " +
-    "is chosen under Conductor (local) in Settings, and until one is chosen Luke asks. Local " +
-    "Conductor chats stay read-only otherwise: Luke cannot message, archive, or add an agent to " +
-    "one, because Conductor documents no local way in for those.";
-  return {
-    label: "Integrations",
-    detail: `${linear}${apple}${calendar}${superset}${conductor}`.trim(),
-  };
+  if (settings.calendarSignInAvailable) {
+    facts.push({
+      label: "Google Calendar",
+      detail:
+        accounts === 0
+          ? "Google Calendar (not connected) connects by signing in with Google from its row. " +
+            "Connecting it lets Luke read only when meetings start and end — never their titles " +
+            "or who attends — so announcements can wait out a meeting."
+          : `Google Calendar (${accounts === 1 ? "1 account" : `${accounts} accounts`} connected) ` +
+            "reads only when meetings start and end — never their titles or who attends. Which " +
+            "calendars count is chosen with the checkboxes under each account, and more accounts " +
+            "can be added from the same row.",
+    });
+  }
+  facts.push({
+    label: "Superset",
+    detail:
+      "Superset workspaces on this Mac are recognized automatically from Superset's local " +
+      "read-only host state, so agents from different providers group under the project and " +
+      "workspace that owns them. Every grouped chat carries its workspace's own Superset " +
+      "and terminal identifiers, so a chat with no native address opens at its exact terminal " +
+      "in Superset — pressed, or asked of Luke — with no login needed. A worktree workspace " +
+      "with no agent chat at all stands as its own idle row — titled by the workspace, opening " +
+      "in Superset on press, staying however long it has sat idle, which is how a stale " +
+      "workspace is found and cleaned up; the main checkout and workspaces Superset already " +
+      "archived draw no row. When Superset's CLI is logged in, chat rows can also send the " +
+      "developer's own message, every Superset row offers Delete workspace once its work " +
+      "settled — an agentless workspace row counts as settled by construction — Superset " +
+      "keeps no archive, so deleting is permanent and takes the whole workspace with every " +
+      "chat in it, and a row still working is never offered it; a single chat cannot be " +
+      "closed or removed on its own, so deleting the settled workspace is the one removal " +
+      "a Superset row takes, and an ask to archive one means exactly this delete. Those rows " +
+      "also rename the workspace and start another agent in it, and a conversation ask can " +
+      "create a new Superset workspace; the default agent for a creation ask that names " +
+      "none is chosen under Superset in Settings, and until one is chosen, Luke asks. " +
+      "Connect from Luke's Settings, finish Superset's own sign-in flow in the browser, and " +
+      "paste its one-time code into Luke. Superset's CLI exchanges that code, stores the " +
+      "login, and switches organizations; Luke never reads its token or clipboard. Superset's " +
+      "row sits under Providers on the Connections page; while connected it keeps a pencil " +
+      "that runs the same sign-in again — the CLI's way of switching organizations — and " +
+      "disconnecting from it runs the CLI's own sign-out, clearing the login the CLI stored.",
+  });
+  facts.push({
+    label: "Conductor",
+    detail:
+      "Conductor comes two ways, told apart by where the work lands. Conductor cloud connects " +
+      "with a key under Providers and creates workspaces in the cloud projects that key " +
+      "lists. Conductor on this Mac needs no key: it is recognized read-only from Conductor's own " +
+      "index, and a conversation ask can create a new workspace in any repository Conductor holds " +
+      "locally — shown as “Conductor (local)” in the create picker and its own block under " +
+      "Providers. A local creation opens the new workspace in Conductor itself and may carry an " +
+      "opening task, which Conductor pre-fills in the new workspace's composer but does not send — " +
+      "its link cannot, so Luke says the prompt is ready and the developer presses Return in " +
+      "Conductor to start it. It carries no agent, model, or name choice, so it runs the " +
+      "repository's own default agent and wears the name Conductor gives it. Local " +
+      "Conductor chats stay read-only otherwise: Luke cannot message, archive, or add an agent to " +
+      "one, because Conductor documents no local way in for those.",
+  });
+  return facts;
 }
 
 /**
@@ -386,40 +403,40 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
     {
       label: "Apps beside a session",
       detail:
-        "The large mark leading a row names the coding agent — a Conductor cloud chat leads " +
-        "with the agent running it, Claude Code or Codex, with the small cloud badge saying " +
-        "where it runs; Conductor's own letter mark stands in only when the agent went " +
-        "unreported. The small bare marks after a row's title name apps where the same chat " +
-        "also appears. Luke recognizes Conductor locally from Conductor's read-only session " +
-        "index; when a Codex chat there spawns a sub-agent, Codex's exact parent-thread " +
-        "record carries that Conductor association to the sub-agent's separate row. Luke " +
-        "recognizes Superset from its read-only host state, Orca from its read-only " +
-        "hook-status cache, grouping chats under the Orca worktree that hosts them, and the " +
-        "cmux terminal from the read-only session stores cmux's own CLI writes — which exist " +
-        "only where cmux's own agent hooks are installed: Claude Code's automatically, Codex, " +
-        "Cursor, Gemini CLI, and OpenCode only after cmux's `cmux hooks setup`, so a session cmux never " +
-        "recorded carries no cmux mark. A local Codex chat also names " +
-        "ChatGPT because OpenAI's desktop app documents the exact Codex thread address Luke " +
-        "already opens. A Cursor chat the Cursor app can open names Cursor itself the same " +
-        "way — a local chat the app's own index holds, read as key presence alone, or any " +
-        "Cursor cloud agent, which the app opens by id like its own dashboard does — where " +
-        "a chat Cursor's agents CLI started in a plain terminal " +
-        "carries no Cursor app mark and opens nowhere unless cmux, Superset, or Conductor " +
-        "hosts its terminal. More than one app mark may appear on one row; none replaces the agent " +
-        "or changes local versus cloud. An app mark with an exact address is a button: " +
-        "ChatGPT opens that Codex thread, Cursor opens the exact chat in its own window, " +
-        "Superset opens its bound terminal, cmux opens the " +
-        "exact terminal pane the agent runs in — and stands in as the row's own destination " +
-        "when no other app gave it one — and a Conductor " +
-        "cloud chat's Conductor mark opens that exact chat. The row body still opens its " +
-        "preferred exact destination. A local Conductor chat or an Orca worktree exposes no " +
-        "documented exact address or message endpoint, so each of those marks identifies the " +
-        "association but adds no open or send control; a cmux chat takes no message or " +
-        "control through cmux either — its mark opens the pane, nothing more. An ask in " +
-        "conversation, spoken or typed, opens the same destinations the row offers: the row's " +
-        "own preferred address by default, or — when the chat appears in more than one app and " +
-        "the ask names one whose mark is a button — that app's exact address instead, so the " +
-        "developer picks where a chat held by several apps comes forward.",
+        "The large mark leading a row names the coding agent; the small bare marks after its " +
+        "title name apps where the same chat also appears — more than one may appear, and none " +
+        "replaces the agent or changes local versus cloud. A Conductor cloud chat leads " +
+        "with the agent running it, Claude Code or Codex, a small cloud badge saying where it " +
+        "runs; Conductor's own letter mark stands in only when the agent went unreported. Each " +
+        "association is read where its app keeps it, read-only: Conductor's session index — a " +
+        "Codex chat's exact parent-thread record carries that Conductor association to a " +
+        "spawned sub-agent's separate row — Superset's host state, Orca's hook-status cache, " +
+        "grouping chats under the Orca worktree hosting them, and the session stores cmux's " +
+        "own CLI writes, which exist only where cmux's agent hooks are installed (Claude " +
+        "Code's automatically; Codex, Cursor, Gemini CLI, and OpenCode after `cmux hooks " +
+        "setup`), so a session cmux never recorded carries no cmux mark. A local Codex chat " +
+        "also names ChatGPT, whose desktop app documents the exact Codex thread address. A " +
+        "Cursor chat names Cursor itself when the app can open it: a local chat in the app's " +
+        "own index, read as key presence alone, or any Cursor cloud agent, opened by id like " +
+        "its own dashboard; a chat Cursor's agents CLI started in a plain terminal carries no " +
+        "Cursor app mark and opens nowhere unless cmux, Superset, or Conductor hosts its " +
+        "terminal.",
+    },
+    {
+      label: "Opening a chat in its apps",
+      detail:
+        "An app mark with an exact address is a button: ChatGPT opens that Codex thread, " +
+        "Cursor opens the exact chat in its own window, Superset opens its bound terminal, " +
+        "cmux opens the exact terminal pane the agent runs in — standing in as the row's " +
+        "own destination when no other app gave it one — and a Conductor cloud chat's " +
+        "Conductor mark opens that exact chat; the row body still opens its preferred exact " +
+        "destination. A local Conductor chat or an Orca worktree exposes no documented exact " +
+        "address or message endpoint, so each of those marks identifies the association but " +
+        "adds no open or send control; a cmux chat takes no message or control through cmux " +
+        "either — its mark opens the pane, nothing more. An ask in conversation, spoken or " +
+        "typed, opens the same destinations the row offers: the row's own preferred address " +
+        "by default, or that app's exact address when the chat appears in more than one app " +
+        "and the ask names one whose mark is a button.",
     },
     {
       label: "Searching sessions",
@@ -537,35 +554,36 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       label: "Creating workspaces",
       detail:
         "Where a connected provider documents a creation endpoint — Conductor, Cursor, and " +
-        "Superset today — " +
-        "an ask in conversation, spoken or typed, can create a new workspace in one of the " +
-        "projects that provider reports, optionally under a name the developer chose, and can " +
-        "hand the new agent an opening task in the developer's own words where the project takes " +
-        "one. A bare ask for a new agent lands here: only an ask that itself names the existing " +
+        "Superset today — an ask in conversation, spoken or typed, can create a new workspace " +
+        "in one of the projects that provider reports, optionally under a name the developer " +
+        "chose, with an opening task in the developer's own words where the project takes one. " +
+        "A bare ask for a new agent lands here: only an ask that itself names the existing " +
         "workspace or session the agent should join adds one beside it instead. Only reported " +
-        "projects can be named, a project that needs a task cannot be created " +
-        "without one, and a provider that reports none takes no ask. Superset asks for more than " +
-        "the others: every Superset project carries the host that runs it — named for a remote " +
-        "host, unannotated on this Mac — and a new " +
-        "Superset workspace needs that host, an agent Superset currently lists for it, and an " +
-        "opening task — so a task-less ask for one is refused rather than created idle. An ask that names no " +
-        "provider goes to the default workspace provider; until one is chosen Luke asks when " +
-        "more than one provider could take it, and the first workspace created saves its " +
-        "provider as the default — changed or cleared by hand in the Settings tab. An ask that " +
-        "names no project goes the same way: each provider remembers a default project, filled " +
-        "in by the first workspace created there and changed or cleared by hand on the " +
-        "Connections page, on that provider's own row — under Providers for a " +
-        "provider connected by key, and under Superset for Superset; until one is chosen Luke " +
-        "asks when the provider lists more than one project. What a new " +
-        "Conductor agent runs — its model, and its effort where the model's agent takes one — " +
-        "follows the choice on the Conductor row under Providers, or Conductor's own " +
-        "defaults while none is made. A model named in a creation ask rides that creation alone " +
-        "and is saved as the default only while none is chosen; the settings themselves change " +
-        "only when the developer asks for that, and Luke never asks or suggests a model. A " +
-        "workspace that lands opens on the developer's screen by itself: the moment observation " +
-        "reports the new session with an address, that address is handed to the operating " +
-        "system, the same as pressing the session's row. One whose provider reports no address " +
-        "stays on its row, unopened.",
+        "projects can be named, a project that needs a task cannot be created without one, and " +
+        "a provider that reports none takes no ask. Every Superset project carries the host " +
+        "that runs it — named for a remote host, unannotated on this Mac — and a new Superset " +
+        "workspace needs that host, an agent Superset currently lists for it, and an opening " +
+        "task, so a task-less ask for one is refused rather than created idle. A workspace " +
+        "that lands opens by itself: the moment observation reports the new session with an " +
+        "address, that address is handed to the operating system, as pressing the session's " +
+        "row would; one whose provider reports no address stays on its row, unopened.",
+    },
+    {
+      label: "Workspace creation defaults",
+      detail:
+        "An ask that names no provider goes to the default workspace provider, and one that " +
+        "names no project to that provider's default project. The first workspace created " +
+        "saves its provider as the default — changed or cleared by hand in the Settings tab — " +
+        "and each provider remembers a default project the same way, filled in by the first " +
+        "workspace created there and changed or cleared by hand on the Connections page, on that " +
+        "provider's own row: under Providers for a provider connected by key and for " +
+        "Conductor (local), under Superset for Superset. Until one is chosen, Luke asks " +
+        "whenever more than one provider or project could take the ask. What a new Conductor " +
+        "agent runs — its model, and its effort where the model's agent takes one — follows " +
+        "the choice on the Conductor row under Providers, or Conductor's own defaults while " +
+        "none is made. A model named in a creation ask rides that creation alone and is saved " +
+        "as the default only while none is chosen; the settings themselves change only when " +
+        "the developer asks, and Luke never asks or suggests a model.",
     },
     {
       label: "Adding agents to a workspace",
@@ -636,8 +654,8 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
                 : "Escape while Luke is speaking cuts the reply off and asks for nothing in " +
                   "its place. No system-wide stop key is registered right now — another app " +
                   "may own the shortcut.") +
-              " The talk key over a reply interrupts too, but takes the turn: the microphone " +
-              `opens with the same press. A different stop chord can be recorded, or the ` +
+              " The talk key over a reply interrupts too, but takes the turn with the same " +
+              `press. A different stop chord can be recorded, or the ` +
               `default restored, in ${SHORTCUTS_PAGE}.`,
           },
           {
@@ -647,45 +665,54 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
             detail:
               "Luke says it out loud when an observed session is holding for you, stops on an " +
               "error, or finishes — a hold is a question, a permission, or an approval, not a " +
-              "turn that merely ended — in his own words, naming the session and saying " +
-              "what it needs, from the agent's parting words or the provider's error line when " +
-              "one was reported. No conversation needs to be open, and the microphone stays " +
-              "off. While he says it, a pressable notice names the session he is talking " +
-              "about — under the housing, or at the open panel's foot: pressing it opens the " +
-              "session where its provider keeps it, or opens the panel for a local session " +
-              "with no page of its own. A session's chip wears the same marks its row " +
-              "does: the agent's own in front, and the apps holding the chat — Conductor, " +
-              "Orca, and kin — trailing the name. The same chips appear while a conversation reply " +
-              "names observed sessions by title, or a workspace of grouped chats by its " +
-              "name — asking what is being worked on draws one chip per thing named, up to " +
-              "a dozen, a workspace's opening its most recent chat. A reply naming tracked " +
-              "issues — by identifier like LUKE-123, or by whole title — draws their chips " +
-              "on the same band, each opening its issue where the tracker keeps it. Past " +
-              "three rows the chips scroll in place, and each presses the same way. The " +
-              "chips and the captioned words leave when the reply ends, but never out from " +
-              "under the pointer: resting on them holds them until it moves away. " +
+              "turn that merely ended — in his own words, naming the session and what it " +
+              "needs, from the agent's parting words or the provider's error line when one " +
+              "was reported. No conversation needs to be open, and the microphone stays off. " +
               "Always on while voice is available; the panel and the capsule count show the " +
               "same states either way. A session the developer is speaking with through its " +
               "provider's own realtime voice — a Codex thread in a live voice conversation, " +
               "and any chat that conversation delegated — announces nothing while the " +
-              "conversation holds, because its turn boundaries are already being heard " +
-              "first-hand; the first change after the conversation closes is announced as " +
-              "usual, and nothing from inside it is replayed." +
-              // Only a build that offers a calendar may describe the quiet:
-              // a hold Luke claims without a calendar row to connect is a
-              // capability he does not have.
-              (input.settings.calendarSignInAvailable || input.settings.appleCalendarAvailable
-                ? " With a calendar connected — a Google Calendar account, or this Mac's own " +
-                  "Apple Calendar — and Quiet during meetings on, " +
-                  "announcements decided during a meeting wait and are read out together once " +
-                  "it ends. The quiet beginning — a meeting starting, or the setting switched " +
-                  "on mid-meeting — silences Luke at once, an announcement mid-sentence " +
-                  "included, and holds everything he would say unbidden, even on an open " +
-                  "conversation; questions asked of him still get their replies. Luke's face " +
-                  "sleeps beside the housing for as long as the quiet holds, which is how the " +
-                  "hold is seen."
-                : ""),
+              "conversation holds; the first change after it closes is announced as usual, " +
+              "and nothing from inside it is replayed.",
           },
+          {
+            label: "Session and issue chips",
+            detail:
+              "While Luke says an announcement, a pressable notice names the session he is " +
+              "talking about — under the housing, or at the open panel's foot: pressing it " +
+              "opens the session where its provider keeps it, or the panel for a local " +
+              "session with no page of its own. A session's chip wears the same marks its row " +
+              "does, the agent's own in front and the apps holding the chat trailing the " +
+              "name. The same chips appear while a conversation " +
+              "reply names observed sessions by title, or a workspace of grouped chats by its " +
+              "name — one chip per thing named, up to a dozen, a workspace's opening its most " +
+              "recent chat. A reply naming tracked issues — by identifier like LUKE-123, or " +
+              "by whole title — draws their chips on the same band, each opening its issue " +
+              "where the tracker keeps it. Past three rows the chips scroll in place, and " +
+              "each presses the same way. The chips and the captioned words leave when the " +
+              "reply ends, but never out from under the pointer: resting on them holds them " +
+              "until it moves away.",
+          },
+          // Only a build that offers a calendar may describe the quiet: a hold
+          // Luke claims without a calendar row to connect is a capability he
+          // does not have.
+          ...(input.settings.calendarSignInAvailable || input.settings.appleCalendarAvailable
+            ? [
+                {
+                  label: "Quiet during meetings",
+                  detail:
+                    "With a calendar connected — a Google Calendar account, or this Mac's own " +
+                    "Apple Calendar — and Quiet during meetings on, announcements decided " +
+                    "during a meeting wait and are read out together once it ends. The quiet " +
+                    "beginning — a meeting starting, or the setting switched on mid-meeting — " +
+                    "silences Luke at once, an announcement mid-sentence included, and holds " +
+                    "everything he would say unbidden, even on an open conversation; " +
+                    "questions asked of him still get their replies. Luke's face sleeps " +
+                    "beside the housing for as long as the quiet holds, which is how the " +
+                    "hold is seen.",
+                },
+              ]
+            : []),
           {
             label: "Muted output",
             detail:
@@ -701,8 +728,7 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
               "One conversation outlives the calls that carry it. A call opens on the first " +
               "press of the talk key or the first typed ask, stays open across as many turns as " +
               "the developer takes, and is put away after three minutes with nothing said on " +
-              "it — which releases the microphone rather than holding it all day, and costs " +
-              "only the next handshake. The voice service " +
+              "it — costing only the next handshake. The voice service " +
               "also ends any call at an hour. Either way the next press picks the conversation " +
               "back up: a bounded history of the recent exchange — what was asked, answered, " +
               "announced, and done — is kept in memory and re-fed to the new call, so Luke " +
@@ -727,7 +753,7 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         ]),
     providersFact(input.settings),
     voiceKeyFact(input.settings, input.voiceAvailable),
-    integrationsFact(input.settings),
+    ...integrationFacts(input.settings),
     ...(input.settings.secretStorage === SECRET_STORAGE.UNAVAILABLE
       ? [
           {


### PR DESCRIPTION
## The retrieval problem

`luke-guide.ts` sends Luke's self-knowledge into the voice conversation as labeled facts, and the voice model retrieves and paraphrases at the granularity of a fact. The "Integrations" fact was one ~700-word paragraph covering five integrations, so a question about one drew a summary of the whole blob; the longest manual-style facts had the same shape, plus material duplicated across facts.

## Pass 1: split for retrieval

"Integrations" became five labeled facts — **Linear**, **Apple Calendar**, **Google Calendar**, **Superset**, **Conductor** — each keeping its availability conditional (an unavailable integration contributes no fact at all). The three longest manuals split along their topics: Apps beside a session / Opening a chat in its apps, Creating workspaces / Workspace creation defaults, Announcements / Session and issue chips / Quiet during meetings.

## Pass 2: describe, don't justify

Design-rationale clauses addressed to an engineer, frame-by-frame UI narration, and repeated key-handling/provenance boilerplate were cut, with every capability, location, conditional, refusal boundary, and trust statement kept.

## Pass 3: scope the guide to what developers ask Luke (this is a product decision)

**This pass is a deliberate product decision by the developer to stop describing UI and connector minutiae, accepting that Luke will redirect rather than describe those.** Each sentence was kept only if (a) a developer would plausibly ask Luke about it, or (b) it changes what a spoken ask may do or must refuse. What left under that rule:

- The app-mark taxonomy is now two sentences (agent mark leads, app marks trail, an addressed mark opens there, an ask can name the app) — the per-app recognition mechanics, ChatGPT/Cursor/cmux special cases, and sub-agent parent-thread detail are gone.
- Filter/search/tray choreography reduced to what exists and that a spoken ask can filter, sort, search, or clear; retention windows, chip-combination semantics, and search persistence rules are gone.
- "Searching settings" and "What a settings page marks" (dots, exclamation marks, reset choreography) are gone; sign-in screen and update-flow mechanics reduced (kept: the Updates row's three askable acts and that only the offered one runs; sign-out and account deletion by hand, deletion cannot be undone).
- Each integration is now: connected-or-not, what Luke can read or do through it, its one or two boundaries, where it connects. Superset host semantics, Conductor local-vs-cloud mechanics, and Codex CLI login prose are gone.

**Kept in force:** every conversational act with its refusal shape (creating, adding agents, renaming, archiving, messaging, standing asks, transcript reading, settings changes), connection status and rows, the talk/ask/stop keys, microphone status, allowance behavior, quiet-during-meetings, and every trust/privacy/permanence statement — "never their titles or who attends", "never spoken, and never repeated back", "deleting is permanent and takes the whole workspace with every chat in it", "cannot be undone", "no spoken ask can send/reach it", what usage data can and cannot carry, mic open/close.

### The rule this relaxes, and the mitigation

The renderer guide (`apps/desktop/src/renderer/AGENTS.md`) states: *"a capability, surface, or shortcut the guide does not describe is one Luke will deny having, and a stale entry is one he will misdescribe."* This pass deliberately relaxes that for minutiae. The mitigation is a new closing fact, **"Beyond this guide"**: asked about finer behavior the guide does not cover, Luke points to where it lives — the panel, a session's row, or the Settings tab — rather than concluding the feature does not exist. A test pins the closing fact as the guide's last word. The AGENTS.md guide section was amended in place (the facts cover what a developer would ask and what a spoken ask may do; the rule binds in full for capabilities, acts, refusals, and boundaries), so the document and the posture no longer contradict.

## Word counts

| | File string literals | Rendered facts (typical build) |
| --- | --- | --- |
| Before pass 1 | 5,255 | — |
| After pass 1 | 5,133 | — |
| After pass 2 | 4,310 | 3,998 |
| After pass 3 | **2,754** | **2,468** (2,697 with every integration present and connected) |
| After the Bugbot fixes (four bounds restored) | **2,796** | **2,516** |

Final fact labels (full build): What Luke is, The panel, The sessions list, Apps beside a session, Searching sessions, Workspaces in the list, The Settings tab, Account, Feedback and prompts, Reading a session's transcript, Messaging local Cursor chats, Creating workspaces, Workspace creation defaults, Adding agents to a workspace, Renaming workspaces and chats, Archiving, Standing asks about sessions, Talk key, Ask key, Microphone access, Stopping a reply, Announcements, Session and issue chips, Quiet during meetings, Muted output, How long a conversation lasts, When a call fails, Cloud providers, OpenAI, Linear, Apple Calendar, Google Calendar, Superset, Conductor, Updates, Usage data, Quitting, Beyond this guide.

## Verification

Prompt-text change in the renderer, not a visual UI change, so `./scripts/check.sh` is the completion invariant: **`./scripts/check.sh` exits 0** on every commit (repository checks, typecheck, all workspace tests — including the 27 in `luke-guide.test.ts` — and builds all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32672120363/artifacts/9501686949) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32672120363)

- Commit: `85988b9c3af81f95a5fc0179494a26118f4f50d5`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

