### PR TITLE
v0.3.9 chore: prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,51 @@
 Notable changes to Luke, newest first. Each heading is a released version and
 the date its release was published.
 
+## 0.3.9 — 2026-08-23
+
+### More agents, one roster
+
+Luke observes local Antigravity, Grok Build, and Radius Browser agent chats,
+alongside Replicas cloud workspaces connected with your own API key. He reads
+each provider through its documented local or cloud surface while keeping
+providers without credentials working as before.
+
+### Improvements
+
+- Luke lets you filter the roster by the app or provider behind each chat
+  ([#455](https://github.com/ReviewStage/luke/pull/455))
+- Luke can create Conductor workspaces and message the live Superset terminal
+  attached to a chat
+  ([#392](https://github.com/ReviewStage/luke/pull/392),
+  [#450](https://github.com/ReviewStage/luke/pull/450))
+- Luke names, recaps, opens, and messages local Cursor chats through Cursor's
+  own records and agent CLI
+  ([#383](https://github.com/ReviewStage/luke/pull/383),
+  [#387](https://github.com/ReviewStage/luke/pull/387),
+  [#390](https://github.com/ReviewStage/luke/pull/390),
+  [#400](https://github.com/ReviewStage/luke/pull/400))
+- Luke can check for updates or restart into a downloaded update when you ask
+  ([#388](https://github.com/ReviewStage/luke/pull/388))
+
+### Fixes
+
+- Fixed archived cloud work continuing to appear in the roster
+  ([#385](https://github.com/ReviewStage/luke/pull/385),
+  [#427](https://github.com/ReviewStage/luke/pull/427))
+- Fixed Luke narrating tool calls and adding filler to spoken updates
+  ([#451](https://github.com/ReviewStage/luke/pull/451),
+  [#470](https://github.com/ReviewStage/luke/pull/470))
+- Fixed Luke inventing a recap segment when a session has no recap
+  ([#469](https://github.com/ReviewStage/luke/pull/469))
+
+### Miscellaneous
+
+- Updated analytics sharing to include broader product events and unmasked
+  session replay, with the recording control governing both
+  ([#409](https://github.com/ReviewStage/luke/pull/409))
+- Updated the workspace to pnpm 10
+  ([#449](https://github.com/ReviewStage/luke/pull/449))
+
 ## 0.3.8 — 2026-08-20
 
 ### Improvements

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@luke/desktop",
   "productName": "Luke",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "description": "Luke desktop application",
   "main": "dist/main.js",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luke/web",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "description": "Luke landing page",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luke",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "description": "A notch-attached desktop sidecar for coding-agent sessions",
   "packageManager": "pnpm@10.34.5",

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/account",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/analytics",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/attention/package.json
+++ b/packages/attention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/attention",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/calendar",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/credentials",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/feedback",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/fixtures/package.json
+++ b/packages/fixtures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/fixtures",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/guide/package.json
+++ b/packages/guide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/guide",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hosted/package.json
+++ b/packages/hosted/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/hosted",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/issues/package.json
+++ b/packages/issues/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/issues",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/oauth",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/observation/package.json
+++ b/packages/observation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/observation",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/providers",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/realtime",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/session",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/settings",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/superset/package.json
+++ b/packages/superset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/superset",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/surface/package.json
+++ b/packages/surface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/surface",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/trackers/package.json
+++ b/packages/trackers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/trackers",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/voice",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/wire/package.json
+++ b/packages/wire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/wire",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -50,7 +50,7 @@ function builderConfig(env = {}) {
   return createElectronBuilderConfig(env);
 }
 
-test("workspace package versions agree on v0.3.8", () => {
+test("workspace package versions agree on v0.3.9", () => {
   // Enumerated rather than listed, so a package added to the workspace is held
   // to the release version without anyone remembering to name it here.
   const packagePaths = [
@@ -74,7 +74,7 @@ test("workspace package versions agree on v0.3.8", () => {
 
   assert.deepEqual(
     versions.map(({ version }) => version),
-    packagePaths.map(() => "0.3.8"),
+    packagePaths.map(() => "0.3.9"),
   );
 });
 


### PR DESCRIPTION
## Summary

- bump every workspace package to 0.3.9
- add the 0.3.9 release notes for the provider, roster, Cursor, Conductor, updater, and voice changes landed since 0.3.8
- update the packaging version contract

## Verification

- ./scripts/check.sh
- ./scripts/verify.sh

Generated visual evidence was produced under artifacts/evidence/; physical-notch verification was not performed.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32658277269/artifacts/9498061054) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32658277269)

- Commit: `532445fcc4fdab981b3d00dbf9dc27dc826e9c87`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
