### PR TITLE
fix(realtime): carry the default workspace provider into creation asks

### DIFF
--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -3208,13 +3208,20 @@ test("a spoken ask for a new workspace is carried, and an unlisted project is re
   await armDeveloperTurn(context);
   assert.equal(contextItems(context, "[workspace projects").length, 1);
 
-  // Changing a default does not change the context payload.
+  // A changed default is news the way a changed list is: the context is
+  // resent, now saying by id where a nameless ask goes.
   const sentBeforeDefault = context.sent.length;
   context.session.updateWorkspaceProjects([project], "conductor");
   context.session.stopSpeaking();
   await armDeveloperTurn(context);
   const chosen = contextItems(context, "[workspace projects", sentBeforeDefault);
-  assert.equal(chosen.length, 0);
+  assert.equal(chosen.length, 1);
+  const chosenItem = chosen[0];
+  assert.ok(chosenItem);
+  assert.match(
+    itemText(chosenItem),
+    /names no provider creates in Conductor \[provider_id=conductor\]/,
+  );
 
   const sentBefore = context.sent.length;
 

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -447,6 +447,15 @@ export class RealtimeVoiceSession {
    */
   #workspaceProjects: readonly ObservedWorkspaceProject[] = [];
   /**
+   * The developer's saved creation tie-breaks, as last reported beside the
+   * projects — kept because the validator applies them to a creation ask that
+   * names less than a full identity, the same defaulting the context text
+   * narrates. Held here or the narrated default and the validated one could
+   * drift apart.
+   */
+  #defaultWorkspaceProviderId: string | undefined;
+  #workspaceProjectDefaultIds: Readonly<Partial<Record<string, string>>> | undefined;
+  /**
    * The issue roster, held to the same rule — and `undefined` while no
    * tracker is connected, so an issue call then has nothing to be validated
    * against and is refused as such.
@@ -1993,6 +2002,8 @@ export class RealtimeVoiceSession {
     defaultProjectIds?: Readonly<Partial<Record<string, string>>>,
   ): void {
     this.#workspaceProjects = projects;
+    this.#defaultWorkspaceProviderId = defaultProviderId;
+    this.#workspaceProjectDefaultIds = defaultProjectIds;
     this.#rememberContext(
       CONTEXT_ITEM_KIND.WORKSPACE_PROJECTS,
       workspaceProjectContextText(projects, defaultProviderId, defaultProjectIds),
@@ -2468,6 +2479,8 @@ export class RealtimeVoiceSession {
       this.#sessions,
       this.#workspaceProjects,
       workspaceAgentModels,
+      this.#defaultWorkspaceProviderId,
+      this.#workspaceProjectDefaultIds,
     );
     if (action.kind === "refused") return { status: "refused", reason: action.reason };
     if (!this.#options.carryAction) {

--- a/packages/realtime/src/realtime-context.ts
+++ b/packages/realtime/src/realtime-context.ts
@@ -480,17 +480,27 @@ export const maximumVoiceContextWorkspaceProjects = 10;
  */
 export function workspaceProjectContextText(
   projects: readonly ObservedWorkspaceProject[],
-  _defaultProviderId?: string,
+  defaultProviderId?: string,
   defaultProjectIds?: Readonly<Partial<Record<string, string>>>,
 ): string {
   if (projects.length === 0) return "No provider currently offers workspace creation.";
   const listed = listedWorkspaceProjects(projects, defaultProjectIds);
+  // The default is said by id, never by name alone: two providers may share a
+  // name's first word (Conductor and Conductor (local) today), and a default
+  // the conversation cannot bind to one provider_id is a question it will ask
+  // the developer instead.
+  const chosenDefault = listed.find((project) => project.providerId === defaultProviderId);
   return [
     "Projects a new workspace can be created in:",
     ...listed.map(
       (project) =>
-        `- ${project.providerName} — ${project.repository}${project.targetName ? ` on ${project.targetName}` : ""} [provider_id=${project.providerId} project_id=${project.providerProjectId}${project.providerTargetId ? ` target_id=${project.providerTargetId}` : ""}]; ${TASK_SUPPORT_TEXT[project.taskSupport]}${project.spawnableAgents?.length ? `; agents: ${project.spawnableAgents.join(", ")}${project.defaultAgent ? `; default agent: ${project.defaultAgent}` : ""}` : ""}`,
+        `- ${project.providerName} — ${project.repository}${project.targetName ? ` on ${project.targetName}` : ""} [provider_id=${project.providerId} project_id=${project.providerProjectId}${project.providerTargetId ? ` target_id=${project.providerTargetId}` : ""}]; ${TASK_SUPPORT_TEXT[project.taskSupport]}${defaultProjectIds?.[project.providerId] === workspaceProjectSelectionId(project) ? "; the provider's default project" : ""}${project.spawnableAgents?.length ? `; agents: ${project.spawnableAgents.join(", ")}${project.defaultAgent ? `; default agent: ${project.defaultAgent}` : ""}` : ""}`,
     ),
+    chosenDefault
+      ? `An ask that names no provider creates in ${chosenDefault.providerName} [provider_id=${chosenDefault.providerId}]; do not ask which provider unless the ask names a different one.`
+      : defaultProviderId
+        ? "The chosen default provider is not currently offering; ask which project when more than one could take the ask."
+        : "No default provider is chosen yet; ask which project when more than one could take the ask, and the first workspace created saves its provider as the default.",
   ].join("\n");
 }
 

--- a/packages/realtime/src/realtime-context.ts
+++ b/packages/realtime/src/realtime-context.ts
@@ -488,8 +488,10 @@ export function workspaceProjectContextText(
   // The default is said by id, never by name alone: two providers may share a
   // name's first word (Conductor and Conductor (local) today), and a default
   // the conversation cannot bind to one provider_id is a question it will ask
-  // the developer instead.
-  const chosenDefault = listed.find((project) => project.providerId === defaultProviderId);
+  // the developer instead. Whether it is offering is judged against everything
+  // offered, not the capped slice below, or the sentence would disown a
+  // default the validator still honors.
+  const chosenDefault = projects.find((project) => project.providerId === defaultProviderId);
   return [
     "Projects a new workspace can be created in:",
     ...listed.map(

--- a/packages/realtime/src/realtime-tools.ts
+++ b/packages/realtime/src/realtime-tools.ts
@@ -621,7 +621,14 @@ function validateCreateWorkspace(
     );
     if (offeredByDefault.length > 0) matchingProjects = offeredByDefault;
   }
-  if (!projectId && matchingProjects.length > 1) {
+  // A provider's chosen project settles which project, never which provider:
+  // while candidates still span providers, one provider's saved project must
+  // not quietly decide an ask the developer left open between them.
+  const [firstMatch] = matchingProjects;
+  const oneProviderMatches =
+    firstMatch !== undefined &&
+    matchingProjects.every((candidate) => candidate.providerId === firstMatch.providerId);
+  if (!projectId && oneProviderMatches && matchingProjects.length > 1) {
     const chosenProjects = matchingProjects.filter(
       (candidate) =>
         context.defaultProjectIds?.[candidate.providerId] ===

--- a/packages/realtime/src/realtime-tools.ts
+++ b/packages/realtime/src/realtime-tools.ts
@@ -66,6 +66,7 @@ import {
   type WorkspaceAgentModels,
   type WorkspaceAgentSelection,
   workspaceNameText,
+  workspaceProjectSelectionId,
 } from "@sidecar/session";
 import {
   isRecord,
@@ -249,6 +250,15 @@ export interface SessionToolContext {
   sessions: readonly NormalizedSession[];
   workspaceProjects: readonly ObservedWorkspaceProject[];
   agentModels: (providerId: string) => readonly WorkspaceAgentModels[];
+  /**
+   * The developer's saved tie-breaks for a creation ask, the same ones the
+   * projects context narrates: the provider a nameless ask goes to, and each
+   * provider's chosen project. Both only ever narrow within the listed
+   * projects — a default can settle an ambiguous ask, never widen where one
+   * can land or override a provider or project the ask actually named.
+   */
+  defaultProviderId?: string;
+  defaultProjectIds?: Readonly<Partial<Record<string, string>>>;
 }
 
 export interface IssueToolContext {
@@ -594,12 +604,31 @@ function validateCreateWorkspace(
   const providerId = textArgument(parsed, "provider_id");
   const projectId = textArgument(parsed, "project_id");
   const targetId = textArgument(parsed, "target_id");
-  const matchingProjects = context.workspaceProjects.filter(
+  let matchingProjects = context.workspaceProjects.filter(
     (candidate) =>
       (!providerId || candidate.providerId === providerId) &&
       (!projectId || candidate.providerProjectId === projectId) &&
       (!targetId || candidate.providerTargetId === targetId),
   );
+  // The saved defaults settle only what the ask left unnamed: no provider
+  // named sends a still-ambiguous ask to the default provider while it is
+  // offering, and no project named sends it on to that provider's chosen
+  // project. Neither step can leave the listed set, and an ask that named
+  // its own provider or project is never overridden.
+  if (!providerId && context.defaultProviderId && matchingProjects.length > 1) {
+    const offeredByDefault = matchingProjects.filter(
+      (candidate) => candidate.providerId === context.defaultProviderId,
+    );
+    if (offeredByDefault.length > 0) matchingProjects = offeredByDefault;
+  }
+  if (!projectId && matchingProjects.length > 1) {
+    const chosenProjects = matchingProjects.filter(
+      (candidate) =>
+        context.defaultProjectIds?.[candidate.providerId] ===
+        workspaceProjectSelectionId(candidate),
+    );
+    if (chosenProjects.length === 1) matchingProjects = chosenProjects;
+  }
   if (matchingProjects.length !== 1) {
     return {
       kind: "refused",
@@ -1199,11 +1228,11 @@ export const REALTIME_TOOLS = {
         properties: {
           provider_id: {
             type: "string",
-            description: "The provider ID.",
+            description: "The provider ID; omit it to create in the default provider.",
           },
           project_id: {
             type: "string",
-            description: "The project ID.",
+            description: "The project ID; omit it to create in that provider's default project.",
           },
           target_id: {
             type: "string",
@@ -1573,6 +1602,10 @@ export function sessionToolAction(
   // default offers none, so an ask that names a model is refused rather than
   // forwarded unchecked.
   agentModels: (providerId: string) => readonly WorkspaceAgentModels[] = () => [],
+  // The developer's saved creation tie-breaks, riding in beside the projects
+  // they narrow — see {@link SessionToolContext}.
+  defaultProviderId?: string,
+  defaultProjectIds?: Readonly<Partial<Record<string, string>>>,
 ): SessionToolAction {
   const parsed = parseToolArguments(call);
   if (!parsed.ok) return { kind: "refused", reason: parsed.reason };
@@ -1580,7 +1613,13 @@ export function sessionToolAction(
   if (!tool || tool.family !== REALTIME_TOOL_FAMILY.SESSION) {
     return { kind: "refused", reason: "No such tool exists." };
   }
-  return tool.validate(parsed.value, { sessions, workspaceProjects, agentModels });
+  return tool.validate(parsed.value, {
+    sessions,
+    workspaceProjects,
+    agentModels,
+    defaultProviderId,
+    defaultProjectIds,
+  });
 }
 
 /**

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -1585,12 +1585,47 @@ test("a chosen default project survives the context cap", () => {
   const capless = workspaceProjectContextText(crowd);
   assert.doesNotMatch(capless, new RegExp(last.providerProjectId));
 
-  // The chosen default rides past the cut so it remains available to the
-  // validator even though the context no longer narrates defaulting behavior.
+  // The chosen default rides past the cut so the one project a nameless ask
+  // lands in stays listed, marked, and steerable.
   const kept = workspaceProjectContextText(crowd, undefined, {
     conductor: last.providerProjectId,
   });
   assert.match(kept, new RegExp(`project_id=${last.providerProjectId}`));
+});
+
+test("the projects context says where a nameless ask goes, by id", () => {
+  const localTwin: ObservedWorkspaceProject = {
+    ...OFFERED_PROJECT,
+    providerId: "conductor-local",
+    providerName: "Conductor (local)",
+    providerProjectId: "repo-7",
+  };
+
+  // Two providers wearing the same first word: the default is narrated by
+  // provider_id, so the conversation can bind it to one of them instead of
+  // asking which Conductor is meant.
+  const chosen = workspaceProjectContextText([OFFERED_PROJECT, localTwin], "conductor");
+  assert.match(
+    chosen,
+    /An ask that names no provider creates in Conductor \[provider_id=conductor\]/,
+  );
+
+  // A provider's chosen project is marked on its own line.
+  const marked = workspaceProjectContextText(
+    [OFFERED_PROJECT, { ...OFFERED_PROJECT, providerProjectId: "proj-2" }],
+    "conductor",
+    { conductor: "proj-2" },
+  );
+  assert.match(marked, /project_id=proj-2[^\n]*the provider's default project/);
+  assert.doesNotMatch(marked, /project_id=proj-1[^\n]*default project/);
+
+  // While no default is chosen the context says the first creation decides;
+  // a chosen default that stopped being offered steers nothing.
+  assert.match(workspaceProjectContextText([OFFERED_PROJECT]), /No default provider is chosen yet/);
+  assert.match(
+    workspaceProjectContextText([OFFERED_PROJECT], "superset"),
+    /default provider is not currently offering/,
+  );
 });
 
 /**
@@ -1782,6 +1817,64 @@ test("an implicit project resolves only when the latest roster has one match", (
   assert.equal(ambiguous.kind, "refused");
   // SAFETY: Refused session-tool actions carry a reason string this assertion inspects.
   assert.match((ambiguous as { reason?: string }).reason ?? "", /More than one listed project/);
+});
+
+test("the saved defaults settle what a creation ask leaves unnamed", () => {
+  const localTwin: ObservedWorkspaceProject = {
+    ...OFFERED_PROJECT,
+    providerId: "conductor-local",
+    providerName: "Conductor (local)",
+    providerProjectId: "repo-7",
+  };
+  const noModels = () => [];
+
+  // A nameless ask between the two Conductors goes to the default provider.
+  assert.deepEqual(
+    sessionToolAction(
+      messageCall("{}", REALTIME_TOOL.CREATE_WORKSPACE),
+      [],
+      [OFFERED_PROJECT, localTwin],
+      noModels,
+      "conductor",
+    ),
+    { kind: "create-workspace", providerId: "conductor", providerProjectId: "proj-1" },
+  );
+
+  // An ask that names its own provider is never overridden by the default.
+  assert.deepEqual(
+    sessionToolAction(
+      messageCall('{"provider_id":"conductor-local"}', REALTIME_TOOL.CREATE_WORKSPACE),
+      [],
+      [OFFERED_PROJECT, localTwin],
+      noModels,
+      "conductor",
+    ),
+    { kind: "create-workspace", providerId: "conductor-local", providerProjectId: "repo-7" },
+  );
+
+  // The provider's chosen project settles an ask that names no project.
+  assert.deepEqual(
+    sessionToolAction(
+      messageCall('{"provider_id":"conductor"}', REALTIME_TOOL.CREATE_WORKSPACE),
+      [],
+      [OFFERED_PROJECT, { ...OFFERED_PROJECT, providerProjectId: "proj-2" }],
+      noModels,
+      undefined,
+      { conductor: "proj-2" },
+    ),
+    { kind: "create-workspace", providerId: "conductor", providerProjectId: "proj-2" },
+  );
+
+  // A default provider offering nothing settles nothing: the ask stays
+  // ambiguous between the projects actually listed.
+  const unsettled = sessionToolAction(
+    messageCall("{}", REALTIME_TOOL.CREATE_WORKSPACE),
+    [],
+    [OFFERED_PROJECT, localTwin],
+    noModels,
+    "superset",
+  );
+  assert.equal(unsettled.kind, "refused");
 });
 
 test("another agent can only be added as a kind the session's own entry lists", () => {

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -1626,6 +1626,21 @@ test("the projects context says where a nameless ask goes, by id", () => {
     workspaceProjectContextText([OFFERED_PROJECT], "superset"),
     /default provider is not currently offering/,
   );
+
+  // Offering is judged against everything offered, not the capped slice: a
+  // default provider whose projects all fell past the cut still takes a
+  // nameless ask, so the sentence must not disown it.
+  const crowdedOut = [
+    ...Array.from({ length: maximumVoiceContextWorkspaceProjects }, (_, index) => ({
+      ...OFFERED_PROJECT,
+      providerProjectId: `proj-${String(index).padStart(2, "0")}`,
+    })),
+    { ...OFFERED_PROJECT, providerId: "cursor", providerName: "Cursor" },
+  ];
+  assert.match(
+    workspaceProjectContextText(crowdedOut, "cursor"),
+    /An ask that names no provider creates in Cursor \[provider_id=cursor\]/,
+  );
 });
 
 /**
@@ -1875,6 +1890,20 @@ test("the saved defaults settle what a creation ask leaves unnamed", () => {
     "superset",
   );
   assert.equal(unsettled.kind, "refused");
+
+  // A saved project settles which project, never which provider: while no
+  // default provider is chosen, an ask still spanning providers stays a
+  // question even when exactly one candidate is some provider's chosen
+  // project.
+  const crossProvider = sessionToolAction(
+    messageCall("{}", REALTIME_TOOL.CREATE_WORKSPACE),
+    [],
+    [OFFERED_PROJECT, { ...OFFERED_PROJECT, providerProjectId: "proj-2" }, localTwin],
+    noModels,
+    undefined,
+    { conductor: "proj-2" },
+  );
+  assert.equal(crossProvider.kind, "refused");
 });
 
 test("another agent can only be added as a kind the session's own entry lists", () => {

--- a/packages/settings/src/schema.ts
+++ b/packages/settings/src/schema.ts
@@ -781,7 +781,10 @@ export const APP_SETTING_SCHEMA = {
         choices: [
           ASK_EACH_TIME_CHOICE,
           workspaceProviderName(PROVIDER_ID.CODEX),
+          // Both Conductors, or the guide would read the stored cloud
+          // default's plain "Conductor" as the only Conductor there is.
           workspaceProviderName(PROVIDER_ID.CONDUCTOR),
+          workspaceProviderName(CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID),
           workspaceProviderName(PROVIDER_ID.CURSOR),
           "Superset",
         ],


### PR DESCRIPTION
## Why

With both Conductor (cloud) and Conductor (local) connected, a spoken or typed ask for a new workspace made Luke ask which project to use every time — even with the default workspace provider set to Conductor (cloud). The stored default was threaded toward the voice conversation and then dropped on the floor:

- `workspaceProjectContextText` took the default provider as `_defaultProviderId` and never read it, so the conversation saw two providers both wearing the Conductor name with nothing binding the default to one `provider_id`.
- `validateCreateWorkspace` never received the defaults, so any ask short of a full project identity was refused as ambiguous.
- The setting's guide `choices` omitted "Conductor (local)" entirely, so the guide read the stored "Conductor" as the only Conductor there is.

## What

- **Context** (`packages/realtime/src/realtime-context.ts`): the projects list now ends with the default said by id — "An ask that names no provider creates in Conductor [provider_id=conductor]…" — and marks each provider's chosen default project on its own line. While no default is chosen the text says the first creation decides, and a chosen default that stopped being offered steers nothing.
- **Validation** (`packages/realtime/src/realtime-tools.ts`): the saved defaults settle only what a creation ask leaves unnamed — no provider named goes to the default provider while it is offering, no project named goes on to that provider's chosen project. Both tie-breaks narrow within the listed projects and never override a provider or project the ask actually named. The tool schema now says the two ids may be omitted in favor of the defaults.
- **Plumbing** (`apps/desktop/src/renderer/realtime-session.ts`): the session holds the defaults it already narrated and hands them to the validator, so the narrated default and the validated one cannot drift apart.
- **Guide** (`packages/settings/src/schema.ts`): the default-provider setting's choices list both Conductors.

## Tests

- New realtime tests: the context names the default by id between the two Conductors, marks the default project, and keeps the honest no-default/not-offering sentences; the validator settles nameless asks, respects explicit names, and refuses when a default offers nothing.
- Updated the desktop test that had cemented the old behavior (a changed default now resends the projects context, as `updateWorkspaceProjects`'s own doc comment always promised).

## Verification

`./scripts/check.sh` passes end to end (typecheck, Biome, all package tests, builds). No drawn surface changed — context text and validation logic only — so there is no visual evidence for this change and no physical-notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/08a300d4-cb01-4701-9888-e63c7ffca50b)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32691919170/artifacts/9507583829) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32691919170)

- Commit: `1577840dde591b61d20068247f055f1885648b42`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
