### PR TITLE
fix(voice): restore the default workspace project narration

### DIFF
--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -3208,13 +3208,15 @@ test("a spoken ask for a new workspace is carried, and an unlisted project is re
   await armDeveloperTurn(context);
   assert.equal(contextItems(context, "[workspace projects").length, 1);
 
-  // Changing a default does not change the context payload.
+  // The default provider is part of the same answer, so choosing one is news
+  // even while the list itself has not moved.
   const sentBeforeDefault = context.sent.length;
   context.session.updateWorkspaceProjects([project], "conductor");
   context.session.stopSpeaking();
   await armDeveloperTurn(context);
   const chosen = contextItems(context, "[workspace projects", sentBeforeDefault);
-  assert.equal(chosen.length, 0);
+  assert.equal(chosen.length, 1);
+  assert.match(itemText(chosen[0]), /default provider for new workspaces is Conductor/);
 
   const sentBefore = context.sent.length;
 

--- a/packages/realtime/src/realtime-context.ts
+++ b/packages/realtime/src/realtime-context.ts
@@ -480,7 +480,7 @@ export const maximumVoiceContextWorkspaceProjects = 10;
  */
 export function workspaceProjectContextText(
   projects: readonly ObservedWorkspaceProject[],
-  _defaultProviderId?: string,
+  defaultProviderId?: string,
   defaultProjectIds?: Readonly<Partial<Record<string, string>>>,
 ): string {
   if (projects.length === 0) return "No provider currently offers workspace creation.";
@@ -491,7 +491,72 @@ export function workspaceProjectContextText(
       (project) =>
         `- ${project.providerName} — ${project.repository}${project.targetName ? ` on ${project.targetName}` : ""} [provider_id=${project.providerId} project_id=${project.providerProjectId}${project.providerTargetId ? ` target_id=${project.providerTargetId}` : ""}]; ${TASK_SUPPORT_TEXT[project.taskSupport]}${project.spawnableAgents?.length ? `; agents: ${project.spawnableAgents.join(", ")}${project.defaultAgent ? `; default agent: ${project.defaultAgent}` : ""}` : ""}`,
     ),
+    ...workspaceDefaultProviderLines(listed, defaultProviderId),
+    ...workspaceDefaultProjectLines(listed, defaultProjectIds),
   ].join("\n");
+}
+
+/**
+ * How the default provider reads under the projects list. A default that is
+ * chosen but not currently offering earns no line at all: it is not a place
+ * an ask can go, and the choice already made must not be presented as still
+ * open — only a developer who has never chosen is told the first creation
+ * chooses for them.
+ */
+function workspaceDefaultProviderLines(
+  projects: readonly ObservedWorkspaceProject[],
+  defaultProviderId: string | undefined,
+): readonly string[] {
+  const chosen = defaultProviderId
+    ? projects.find((project) => project.providerId === defaultProviderId)
+    : undefined;
+  if (chosen) {
+    return [
+      `The developer's default provider for new workspaces is ${chosen.providerName}: an ask that names no provider creates there.`,
+    ];
+  }
+  if (defaultProviderId) return [];
+  const providers = new Set(projects.map((project) => project.providerId));
+  return [
+    providers.size > 1
+      ? "No default provider is chosen yet: when an ask names no provider, ask which listed provider it should be. The first workspace created saves its provider as the developer's default."
+      : "No default provider is chosen yet: the first workspace created saves its provider as the developer's default.",
+  ];
+}
+
+/**
+ * How each provider's default project reads under the projects list, on the
+ * provider default's own terms. A default that is chosen but no longer
+ * offered earns no line at all; a provider with exactly one project earns
+ * none either while nothing is chosen, because there is nothing to steer —
+ * only a provider actually offering a choice is said to be decided by the
+ * first creation there.
+ */
+function workspaceDefaultProjectLines(
+  projects: readonly ObservedWorkspaceProject[],
+  defaultProjectIds: Readonly<Partial<Record<string, string>>> | undefined,
+): readonly string[] {
+  const lines: string[] = [];
+  const said = new Set<string>();
+  for (const project of projects) {
+    if (said.has(project.providerId)) continue;
+    said.add(project.providerId);
+    const offered = projects.filter((candidate) => candidate.providerId === project.providerId);
+    const chosenId = defaultProjectIds?.[project.providerId];
+    const chosen = chosenId
+      ? offered.find((candidate) => workspaceProjectSelectionId(candidate) === chosenId)
+      : undefined;
+    if (chosen) {
+      lines.push(
+        `The developer's default ${chosen.providerName} project is ${chosen.repository}${chosen.targetName ? ` on ${chosen.targetName}` : ""}: an ask that names no project creates there.`,
+      );
+    } else if (chosenId === undefined && offered.length > 1) {
+      lines.push(
+        `No default ${project.providerName} project is chosen yet: when an ask names no project there, ask which listed project it should be. The first workspace created in ${project.providerName} saves its project as the default.`,
+      );
+    }
+  }
+  return lines;
 }
 
 /**

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -1569,6 +1569,107 @@ test("the projects context lists each project with the identity a call names", (
   );
 });
 
+test("the projects context says where a nameless creation ask goes", () => {
+  const cursorProject: ObservedWorkspaceProject = {
+    providerId: "cursor",
+    providerName: "Cursor",
+    providerProjectId: "https://github.com/acme/luke",
+    repository: "acme/luke",
+    taskSupport: WORKSPACE_TASK_SUPPORT.REQUIRED,
+  };
+
+  // A chosen default that is offering is named as where a nameless ask goes.
+  const chosen = workspaceProjectContextText([OFFERED_PROJECT, cursorProject], "conductor");
+  assert.match(chosen, /default provider for new workspaces is Conductor/);
+  assert.doesNotMatch(chosen, /No default provider is chosen/);
+
+  // Nothing chosen and more than one provider listed: ask first, and say that
+  // the first creation decides — that sentence is how the developer learns
+  // their answer will be remembered.
+  const open = workspaceProjectContextText([OFFERED_PROJECT, cursorProject]);
+  assert.match(open, /No default provider is chosen yet/);
+  assert.match(open, /ask which listed provider/);
+  assert.match(open, /first workspace created saves its provider/);
+
+  // One provider alone leaves nothing to ask about, but the save is still
+  // said, or the remembered choice would be a surprise.
+  const single = workspaceProjectContextText([OFFERED_PROJECT]);
+  assert.match(single, /No default provider is chosen yet/);
+  assert.doesNotMatch(single, /ask which/);
+  assert.match(single, /first workspace created saves its provider/);
+
+  // A default whose provider is not offering earns no line at all: it is not
+  // somewhere an ask can go, and a choice already made is not re-offered to
+  // the first creation.
+  const away = workspaceProjectContextText([cursorProject], "conductor");
+  assert.doesNotMatch(away, /default provider/);
+
+  // The default rides the same context event the list does.
+  const [event] = workspaceProjectContextEvents(
+    [OFFERED_PROJECT],
+    "luke_ctx_workspace-projects_2",
+    "conductor",
+  );
+  assert.match(conversationItemText(event), /default provider for new workspaces is Conductor/);
+});
+
+test("the projects context says which project a nameless ask lands in", () => {
+  const secondProject: ObservedWorkspaceProject = {
+    providerId: "conductor",
+    providerName: "Conductor",
+    providerProjectId: "proj-2",
+    repository: "acme/other",
+    taskSupport: WORKSPACE_TASK_SUPPORT.OPTIONAL,
+  };
+
+  // A chosen default that is still offered is named by its repository, as
+  // where a nameless ask goes.
+  const chosen = workspaceProjectContextText([OFFERED_PROJECT, secondProject], undefined, {
+    conductor: "proj-1",
+  });
+  assert.match(chosen, /default Conductor project is luke/);
+  assert.doesNotMatch(chosen, /No default Conductor project/);
+
+  // Nothing chosen and more than one project listed: ask first, and say that
+  // the first creation there decides — that sentence is how the developer
+  // learns their answer will be remembered.
+  const open = workspaceProjectContextText([OFFERED_PROJECT, secondProject]);
+  assert.match(open, /No default Conductor project is chosen yet/);
+  assert.match(open, /ask which listed project/);
+  assert.match(open, /first workspace created in Conductor saves its project/);
+
+  // One project alone leaves nothing to steer, so nothing is said of it.
+  const single = workspaceProjectContextText([OFFERED_PROJECT]);
+  assert.doesNotMatch(single, /default Conductor project/);
+
+  // A default the provider no longer offers earns no line at all: it is not
+  // somewhere an ask can go, and the choice already made is not re-offered to
+  // the first creation.
+  const away = workspaceProjectContextText([OFFERED_PROJECT, secondProject], undefined, {
+    conductor: "proj-gone",
+  });
+  assert.doesNotMatch(away, /default Conductor project/);
+  assert.doesNotMatch(away, /No default Conductor project/);
+
+  // The default rides the same context event the list does.
+  const [event] = workspaceProjectContextEvents(
+    [OFFERED_PROJECT, secondProject],
+    "luke_ctx_workspace-projects_3",
+    undefined,
+    { conductor: "proj-2" },
+  );
+  assert.match(conversationItemText(event), /default Conductor project is acme\/other/);
+});
+
+test("a host-scoped default names only its exact target", () => {
+  const local = { ...OFFERED_PROJECT, providerTargetId: "local", targetName: "This Mac" };
+  const remote = { ...OFFERED_PROJECT, providerTargetId: "studio", targetName: "Studio" };
+  const chosen = workspaceProjectContextText([local, remote], undefined, {
+    conductor: JSON.stringify(["proj-1", "studio"]),
+  });
+  assert.match(chosen, /default Conductor project is luke on Studio/);
+});
+
 test("a chosen default project survives the context cap", () => {
   // One more project than the context will list, alphabetical like the
   // normalizer hands them over, with the developer's chosen default sorted
@@ -1585,12 +1686,13 @@ test("a chosen default project survives the context cap", () => {
   const capless = workspaceProjectContextText(crowd);
   assert.doesNotMatch(capless, new RegExp(last.providerProjectId));
 
-  // The chosen default rides past the cut so it remains available to the
-  // validator even though the context no longer narrates defaulting behavior.
+  // The chosen default rides past the cut, listed and steered both — a
+  // default the sentence names but the list omits would be unaskable.
   const kept = workspaceProjectContextText(crowd, undefined, {
     conductor: last.providerProjectId,
   });
   assert.match(kept, new RegExp(`project_id=${last.providerProjectId}`));
+  assert.match(kept, new RegExp(`default Conductor project is ${last.repository}`));
 });
 
 /**


### PR DESCRIPTION
## Problem

Asking Luke to spin up a new Conductor (cloud) workspace makes him ask which project to use, even when a default project is already set in Settings.

## Cause

#313 (`0a56a23`, "simplify Luke prompt surfaces") removed `workspaceDefaultProviderLines` and `workspaceDefaultProjectLines` from the `[workspace projects]` context. Those lines were the mechanism behind the defaults: the conversation model reads "The developer's default Conductor project is …: an ask that names no project creates there" and fills in the project identity itself — `validateCreateWorkspace` deliberately knows nothing about defaults and refuses a call matching more than one listed project. With the narration gone, a nameless ask left the model with several listed projects, no tie-break, and its own instruction to ask rather than guess — so it asked, every time.

The doc comments on `workspaceProjectContextText`, `listedWorkspaceProjects`, and `updateWorkspaceProjects` all still describe the defaults riding along; the parameters kept arriving (`_defaultProviderId` was underscored as unused) and rendered nothing.

## Fix

Restore the two narration helpers exactly as they stood before #313, and re-point the call sites at them:

- A chosen default that is offering is named as where a nameless ask goes.
- Nothing chosen with a real choice on offer says the first creation decides (and asks which, when more than one is listed).
- A default that is chosen but no longer offered earns no line at all.

Tests restored alongside: the three context-narration tests removed by #313, the default-narration assertion in the cap-survival test, and the renderer test's original assertion that choosing a default re-sends the projects context (its doc comment — "a changed default is news the way a changed list is" — had survived while the behavior under it was cut).

## Validation

`./scripts/check.sh` passes (exit 0; realtime 114/114, desktop 737 tests, 0 failures). No macOS/UI change, so no visual evidence run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/dff5ae66-fdaf-4724-acc2-4ed7273e5884)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32679530779/artifacts/9503745593) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32679530779)

- Commit: `a2968b13a49509ed4624987041aa36e690b74c7e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
