### PR TITLE
refactor(superset): import the workspace provider id from its own vocabulary

### DIFF
--- a/packages/superset/src/cli.ts
+++ b/packages/superset/src/cli.ts
@@ -23,10 +23,8 @@ import {
   type WireRecord,
   wireRecord,
 } from "@sidecar/wire";
-import {
-  SUPERSET_WORKSPACE_PROVIDER_ID,
-  type SupersetOrganizationChoice,
-} from "../../../apps/desktop/src/shared/contracts.js";
+import type { SupersetOrganizationChoice } from "./sign-in-stage.js";
+import { SUPERSET_WORKSPACE_PROVIDER_ID } from "./vocabulary.js";
 import type { SupersetSessionContext } from "./workspaces.js";
 
 export const SUPERSET_CONTROL_ID = {

--- a/packages/superset/src/workspaces.ts
+++ b/packages/superset/src/workspaces.ts
@@ -18,8 +18,8 @@ import {
   SESSION_STATUS,
 } from "@sidecar/session";
 import { type WireRecord, wireRecord } from "@sidecar/wire";
-import { SUPERSET_WORKSPACE_PROVIDER_ID } from "../../../apps/desktop/src/shared/contracts.js";
 import { SUPERSET_CONTROL_ID } from "./cli.js";
+import { SUPERSET_WORKSPACE_PROVIDER_ID } from "./vocabulary.js";
 
 const SUPERSET_AGENT_PROVIDER = {
   claude: PROVIDER_ID.CLAUDE_CODE,


### PR DESCRIPTION
`packages/superset/src/workspaces.ts` and `packages/superset/src/cli.ts` imported `SUPERSET_WORKSPACE_PROVIDER_ID` from `apps/desktop/src/shared/contracts.js` by relative path — a package reaching up into an app. `packages/CLAUDE.md` keeps the dependency graph acyclic and app-free below `packages/`, and a relative path into `apps/` evades the workspace dependency graph that `pnpm --recursive run typecheck` checks, since it names no package edge at all. The constant already lives in the package's own `vocabulary.ts` (contracts merely re-exports it from `@sidecar/superset/vocabulary`), so both files now import it from `./vocabulary.js`; `cli.ts` also takes `SupersetOrganizationChoice` from the `sign-in-stage.ts` that defines it, dropping its app import entirely.

`./scripts/check.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32762170321/artifacts/9533187305) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32762170321)

- Commit: `804affcffc80b1886c69053c2f93c0821ce07ada`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
