### PR TITLE
refactor(settings): fold the Superset agent default into the workspace agent defaults

### DIFF
--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -52,6 +52,7 @@ import {
   CreatedWorkspaceOpenTracker,
   InMemorySessionRegistry,
   isProviderId,
+  isWorkspaceProviderId,
   type NormalizedSession,
   normalizeObservedWorkspaceProjects,
   type ObservedWorkspaceProject,
@@ -808,11 +809,7 @@ async function rememberWorkspaceDefaults(
   agent: string | undefined,
 ): Promise<void> {
   const providerId = adapter.provider.id;
-  if (
-    !isProviderId(providerId) &&
-    providerId !== SUPERSET_WORKSPACE_PROVIDER_ID &&
-    providerId !== CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID
-  ) {
+  if (!isWorkspaceProviderId(providerId)) {
     return;
   }
   try {
@@ -828,9 +825,15 @@ async function rememberWorkspaceDefaults(
     if (
       providerId === SUPERSET_WORKSPACE_PROVIDER_ID &&
       agent !== undefined &&
-      (await settingsStore.get(APP_SETTING_SCHEMA.supersetAgentDefault.field)) === undefined
+      (await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field))?.[
+        SUPERSET_WORKSPACE_PROVIDER_ID
+      ] === undefined
     ) {
-      const saved = await settingsStore.set(APP_SETTING_SCHEMA.supersetAgentDefault.field, agent);
+      const saved = await settingsStore.setEntry(
+        APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
+        SUPERSET_WORKSPACE_PROVIDER_ID,
+        { agent },
+      );
       panels.broadcast(channels.settingsChanged, saved.settings);
     }
     // The project the workspace landed in becomes that provider's default on
@@ -1274,7 +1277,9 @@ async function refreshProviderSessions(generation: number): Promise<void> {
   let supersetOrganization: string | undefined;
   let supersetAgentDefault: string | undefined;
   try {
-    supersetAgentDefault = await settingsStore.get(APP_SETTING_SCHEMA.supersetAgentDefault.field);
+    supersetAgentDefault = (
+      await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field)
+    )?.[SUPERSET_WORKSPACE_PROVIDER_ID]?.agent;
     [supersetSnapshot, supersetOrganization] = await Promise.all([
       supersetWorkspaces.read(),
       supersetCli.activeOrganization(),

--- a/apps/desktop/src/main/settings-store.test.ts
+++ b/apps/desktop/src/main/settings-store.test.ts
@@ -1580,12 +1580,62 @@ test("stores Superset workspace and agent defaults without touching credentials"
 
   await store.set(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field, "superset");
   await store.setEntry(APP_SETTING_SCHEMA.workspaceProjectDefaults.field, "superset", "project-1");
-  const { settings } = await store.set(APP_SETTING_SCHEMA.supersetAgentDefault.field, "codex");
+  const { settings } = await store.setEntry(
+    APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
+    "superset",
+    { agent: "codex" },
+  );
 
   assert.equal(settings.defaultWorkspaceProvider, "superset");
   assert.equal(settings.workspaceProjectDefaults?.superset, "project-1");
-  assert.equal(settings.supersetAgentDefault, "codex");
-  assert.equal((await storeIn(directory).snapshot()).supersetAgentDefault, "codex");
+  assert.deepEqual(settings.workspaceAgentDefaults?.superset, { agent: "codex" });
+  assert.deepEqual((await storeIn(directory).snapshot()).workspaceAgentDefaults?.superset, {
+    agent: "codex",
+  });
+});
+
+test("folds a Superset agent default stored apart by an earlier build into the record", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({ version: 2, apiKeys: {}, supersetAgentDefault: "codex" }),
+  );
+
+  const store = storeIn(directory);
+  assert.deepEqual((await store.snapshot()).workspaceAgentDefaults?.superset, { agent: "codex" });
+
+  // The next write carries the folded entry and drops the legacy field.
+  await store.set(APP_SETTING_SCHEMA.voiceCaptions.field, true);
+  const written = JSON.parse(await fs.readFile(path.join(directory, SETTINGS_FILE_NAME), "utf8"));
+  assert.equal(written.supersetAgentDefault, undefined);
+  assert.deepEqual(written.workspaceAgentDefaults, { superset: { agent: "codex" } });
+});
+
+test("a folded Superset entry outranks the legacy field it replaced", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({
+      version: 2,
+      apiKeys: {},
+      supersetAgentDefault: "codex",
+      workspaceAgentDefaults: { superset: { agent: "claude-code" } },
+    }),
+  );
+
+  assert.deepEqual((await storeIn(directory).snapshot()).workspaceAgentDefaults?.superset, {
+    agent: "claude-code",
+  });
+});
+
+test("ignores a legacy Superset agent default that is not an agent kind", async (t) => {
+  const directory = await temporaryDirectory(t);
+  await fs.writeFile(
+    path.join(directory, SETTINGS_FILE_NAME),
+    JSON.stringify({ version: 2, apiKeys: {}, supersetAgentDefault: "Not An Agent!" }),
+  );
+
+  assert.equal((await storeIn(directory).snapshot()).workspaceAgentDefaults, undefined);
 });
 
 test("starts new workspaces on the provider's defaults until a pairing is chosen", async (t) => {
@@ -1764,6 +1814,22 @@ test("an entry the field cannot hold is refused rather than quietly dropped", ()
     }),
     { valid: true, value: { agent: "codex", model: "gpt-5.6-sol" } },
   );
+
+  // Superset's entry is the kind alone: a model beside it names a choice the
+  // provider does not document, so it is refused rather than trimmed.
+  assert.equal(
+    settingEntryGuard(APP_SETTING_SCHEMA.workspaceAgentDefaults.field, "superset", {
+      agent: "codex",
+      model: "gpt-5.6-sol",
+    }).valid,
+    false,
+  );
+  assert.deepEqual(
+    settingEntryGuard(APP_SETTING_SCHEMA.workspaceAgentDefaults.field, "superset", {
+      agent: "codex",
+    }),
+    { valid: true, value: { agent: "codex" } },
+  );
 });
 
 test("every map-valued setting is written one entry at a time", () => {
@@ -1847,11 +1913,13 @@ test("ignores a stored pairing this build's table does not list", async (t) => {
       apiKeys: {},
       workspaceAgentDefaults: {
         // A listed model under an effort its agent does not document, a
-        // provider the table documents nothing for, and a provider this build
-        // does not know: each names a request no endpoint takes.
+        // provider the table documents nothing for, a provider this build
+        // does not know, and a model beside a Superset kind, which documents
+        // no model choice: each names a request no endpoint takes.
         conductor: { agent: "claude", model: "sonnet", effort: "sideways" },
         cursor: { agent: "cursor", model: "composer-2.5" },
         "someone-else": { agent: "claude", model: "sonnet" },
+        superset: { agent: "codex", model: "gpt-5.5" },
       },
     }),
   );
@@ -1965,15 +2033,22 @@ test("a workspaces reset forgets the provider and project defaults but never the
   await store.set(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field, PROVIDER_ID.CONDUCTOR);
   await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "proj-1");
   await setWorkspaceAgentDefault(store, PROVIDER_ID.CONDUCTOR, pairing);
+  await store.setEntry(APP_SETTING_SCHEMA.workspaceAgentDefaults.field, "superset", {
+    agent: "codex",
+  });
 
   const { settings, reason } = await store.resetSettings(SETTINGS_RESET_SCOPE.WORKSPACES);
 
   assert.equal(reason, undefined);
   assert.equal(settings.defaultWorkspaceProvider, undefined);
   assert.equal(settings.workspaceProjectDefaults, undefined);
-  // The pairing lives on the Conductor row, whose own menu already offers the
-  // provider's default — no reset here may reach it.
-  assert.deepEqual(settings.workspaceAgentDefaults, { [PROVIDER_ID.CONDUCTOR]: pairing });
+  // The pairing lives on its provider's own row, whose menu already offers
+  // the provider's default — no reset here may reach it, and Superset's kind
+  // stands with the Conductor pairing.
+  assert.deepEqual(settings.workspaceAgentDefaults, {
+    [PROVIDER_ID.CONDUCTOR]: pairing,
+    superset: { agent: "codex" },
+  });
 });
 
 test("a reset of settings already at their defaults writes nothing", async (t) => {

--- a/apps/desktop/src/main/settings-store.ts
+++ b/apps/desktop/src/main/settings-store.ts
@@ -10,6 +10,7 @@ import {
   VOICE_CREDENTIAL_PROVIDER_ID,
 } from "@sidecar/credentials";
 import { REALTIME_DEFAULTS } from "@sidecar/realtime";
+import { parseWorkspaceAgentKindSelection, SUPERSET_WORKSPACE_PROVIDER_ID } from "@sidecar/session";
 import { DEFAULT_PANEL_FORM_FACTOR } from "@sidecar/surface";
 import {
   isRecord,
@@ -81,6 +82,7 @@ const SETTINGS_FIELD = {
   CALENDAR_ACCOUNTS: "calendarAccounts",
   GRANTS: "grants",
   LEGACY_CONDUCTOR_API_KEY: "conductorApiKey",
+  LEGACY_SUPERSET_AGENT_DEFAULT: "supersetAgentDefault",
   VERSION: "version",
 } as const;
 
@@ -401,6 +403,32 @@ function readStoredSettings(record: WireRecord): StoredAppSettings {
   );
 }
 
+/**
+ * An installation that stored the Superset agent default apart — before it
+ * joined `workspaceAgentDefaults` — keeps its choice: the legacy field is
+ * folded in on read, under the same guard a folded entry answers to, and the
+ * next write drops it from the file the way the legacy Conductor key is
+ * dropped. A choice already held in the folded record wins, because it is the
+ * newer one.
+ */
+function withLegacySupersetAgentDefault(
+  settings: StoredAppSettings,
+  record: WireRecord,
+): StoredAppSettings {
+  if (settings.workspaceAgentDefaults?.[SUPERSET_WORKSPACE_PROVIDER_ID]) return settings;
+  const legacy = parseWorkspaceAgentKindSelection(
+    unparsedWire({ agent: record[SETTINGS_FIELD.LEGACY_SUPERSET_AGENT_DEFAULT] }),
+  );
+  if (!legacy) return settings;
+  return {
+    ...settings,
+    workspaceAgentDefaults: {
+      ...settings.workspaceAgentDefaults,
+      [SUPERSET_WORKSPACE_PROVIDER_ID]: legacy,
+    },
+  };
+}
+
 function parsePersistedSettings(
   source: string,
   providers: readonly CredentialProvider[],
@@ -414,7 +442,7 @@ function parsePersistedSettings(
   const calendarAccounts = storedCalendarAccounts(record);
   const appleCalendar = storedAppleCalendar(record);
   const grants = storedGrants(record);
-  const settings = readStoredSettings(record);
+  const settings = withLegacySupersetAgentDefault(readStoredSettings(record), record);
   const persisted = {
     ...settings,
     version: isWireNumber(version) ? version : SETTINGS_FILE_VERSION,
@@ -647,9 +675,6 @@ export class SettingsStore {
         : undefined),
       ...(persisted.workspaceProjectDefaults
         ? { workspaceProjectDefaults: persisted.workspaceProjectDefaults }
-        : undefined),
-      ...(persisted.supersetAgentDefault
-        ? { supersetAgentDefault: persisted.supersetAgentDefault }
         : undefined),
     };
   }

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1408,7 +1408,11 @@ export function App(): React.JSX.Element {
   const changeSupersetAgentDefault = useCallback(
     async (agent: string | undefined) =>
       applySettingsReply(
-        await window.sidecar.updateSetting(APP_SETTING_SCHEMA.supersetAgentDefault.field, agent),
+        await window.sidecar.updateSettingEntry(
+          APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
+          SUPERSET_WORKSPACE_PROVIDER_ID,
+          agent === undefined ? undefined : { agent },
+        ),
       ),
     [applySettingsReply],
   );
@@ -3444,7 +3448,8 @@ export function App(): React.JSX.Element {
                 onDisconnect: disconnectLinear,
               },
               superset: (() => {
-                const supersetAgentDefault = (settings ?? bootstrap.settings).supersetAgentDefault;
+                const supersetAgentDefault = (settings ?? bootstrap.settings)
+                  .workspaceAgentDefaults?.[SUPERSET_WORKSPACE_PROVIDER_ID]?.agent;
                 const superset: SupersetControl = {
                   installed: bootstrap.supersetInstalled,
                   connected: supersetConnected ?? bootstrap.supersetConnected,

--- a/apps/desktop/src/shared/contracts.ts
+++ b/apps/desktop/src/shared/contracts.ts
@@ -25,12 +25,12 @@ import type {
   ObservedWorkspaceProject,
   ProviderActResult,
   ProviderControlResult,
-  ProviderId,
   ProviderMessageResult,
   ProviderWorkspaceResult,
   SessionApplicationId,
   SessionFilter,
   SessionIdentity,
+  WorkspaceAgentDefaults,
   WorkspaceAgentSelection,
   WorkspaceProviderId,
 } from "@sidecar/session";
@@ -420,13 +420,15 @@ export interface AppSettings {
    */
   defaultWorkspaceProvider?: WorkspaceProviderId;
   /**
-   * The agent kind and model new workspaces start with, per provider, each
-   * entry absent while that provider's own defaults stand. Keyed by provider
-   * id and held to the build's documented table for that provider — a pairing
-   * outside it is dropped rather than honoured, because it names nothing the
-   * provider's endpoints take.
+   * The agent new workspaces start with, per provider, each entry absent
+   * while that provider's own defaults stand. Keyed by workspace provider id:
+   * a provider with a build-fixed models table holds an agent-and-model
+   * pairing held to that table — a pairing outside it is dropped rather than
+   * honoured, because it names nothing the provider's endpoints take — and
+   * Superset, whose agents are observed presets with no model choice
+   * documented, holds the agent kind alone.
    */
-  workspaceAgentDefaults?: Readonly<Partial<Record<ProviderId, WorkspaceAgentSelection>>>;
+  workspaceAgentDefaults?: WorkspaceAgentDefaults;
   /**
    * The project a conversational ask creates a workspace in when the ask
    * names none, per provider, each entry absent until one has been chosen. It
@@ -438,8 +440,6 @@ export interface AppSettings {
    * still offers that exact project target.
    */
   workspaceProjectDefaults?: Readonly<Partial<Record<WorkspaceProviderId, string>>>;
-  /** The configured Superset agent used when a creation ask names none. */
-  supersetAgentDefault?: string;
 }
 
 /**

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -33,6 +33,8 @@ export {
   SUPERSET_WORKSPACE_PROVIDER_ID,
   staleWorkspaceProjectDefaults,
   WORKSPACE_TASK_SUPPORT,
+  type WorkspaceAgentDefaults,
+  type WorkspaceAgentKindSelection,
   type WorkspaceAgentModels,
   type WorkspaceAgentSelection,
   type WorkspaceProject,
@@ -122,6 +124,7 @@ export { InMemorySessionRegistry } from "./session-registry.js";
 export {
   isListedWorkspaceAgentModel,
   isWorkspaceAgentSelection,
+  parseWorkspaceAgentKindSelection,
   parseWorkspaceAgentSelection,
   WORKSPACE_AGENT_MODELS,
   workspaceAgentModelLabel,

--- a/packages/session/src/providers.ts
+++ b/packages/session/src/providers.ts
@@ -441,6 +441,31 @@ export interface WorkspaceAgentSelection {
   effort?: string;
 }
 
+/**
+ * The agent kind a user chose for new workspaces on a provider whose agent
+ * kinds are observed presets rather than a build-fixed table, and which
+ * documents no model choice (Superset today). The `never` fields are the
+ * boundary stated as a type: no model or effort can ride beside a kind the
+ * provider's endpoints take alone.
+ */
+export interface WorkspaceAgentKindSelection {
+  agent: string;
+  model?: never;
+  effort?: never;
+}
+
+/**
+ * The chosen defaults for new workspaces, one entry per workspace provider
+ * that documents an agent choice at all: a provider with a build-fixed models
+ * table holds a full selection, and Superset holds the kind alone. Local
+ * Conductor's creation link documents no agent, model, or name, so it can
+ * hold no entry.
+ */
+export type WorkspaceAgentDefaults = Readonly<
+  Partial<Record<ProviderId, WorkspaceAgentSelection>> &
+    Partial<Record<typeof SUPERSET_WORKSPACE_PROVIDER_ID, WorkspaceAgentKindSelection>>
+>;
+
 /** A user-asked request for a new workspace in one reported project. */
 export interface ProviderWorkspaceRequest {
   providerProjectId: string;

--- a/packages/session/src/workspace-agents.ts
+++ b/packages/session/src/workspace-agents.ts
@@ -3,6 +3,7 @@ import {
   isProviderId,
   PROVIDER_ID,
   type ProviderId,
+  type WorkspaceAgentKindSelection,
   type WorkspaceAgentModels,
   type WorkspaceAgentSelection,
 } from "./providers.js";
@@ -132,4 +133,29 @@ export function parseWorkspaceAgentSelection(
   const selection: WorkspaceAgentSelection =
     effort !== undefined ? { agent, model, effort } : { agent, model };
   return isListedWorkspaceAgentModel(providerId, selection) ? selection : undefined;
+}
+
+/**
+ * The shape of an observed agent preset's name: agent kinds this build cannot
+ * list come from a provider's own configuration, so the bound is on form
+ * alone, and whether a kind is actually offered is answered where the
+ * observation lives.
+ */
+const WORKSPACE_AGENT_KIND_PATTERN = /^[a-z0-9][a-z0-9-]{0,79}$/u;
+
+/**
+ * Guards a kind-only selection arriving over IPC or read back from disk, for
+ * the one workspace provider whose agents carry no models table. A value
+ * carrying a model or an effort is refused rather than trimmed: the provider
+ * documents no model choice, so such a value is not a selection it takes.
+ */
+export function parseWorkspaceAgentKindSelection(
+  value: UnparsedWireValue,
+): WorkspaceAgentKindSelection | undefined {
+  const record = wireRecord(value);
+  if (!record) return undefined;
+  const { agent, model, effort } = record;
+  if (model !== undefined || effort !== undefined) return undefined;
+  if (!isWireString(agent) || !WORKSPACE_AGENT_KIND_PATTERN.test(agent)) return undefined;
+  return { agent };
 }

--- a/packages/settings/src/schema.ts
+++ b/packages/settings/src/schema.ts
@@ -25,9 +25,12 @@ import {
   isWorkspaceProviderId,
   PROVIDER_ID,
   type ProviderId,
+  parseWorkspaceAgentKindSelection,
   parseWorkspaceAgentSelection,
   type SessionFilter,
   SUPERSET_WORKSPACE_PROVIDER_ID,
+  type WorkspaceAgentDefaults,
+  type WorkspaceAgentKindSelection,
   type WorkspaceAgentSelection,
   type WorkspaceProviderId,
   workspaceAgentModelLabel,
@@ -115,9 +118,8 @@ export interface StoredAppSettings {
   /** The session list's held search words, absent while nothing is searched. */
   sessionSearchQuery?: string;
   defaultWorkspaceProvider?: WorkspaceProviderId;
-  workspaceAgentDefaults?: Readonly<Partial<Record<ProviderId, WorkspaceAgentSelection>>>;
+  workspaceAgentDefaults?: WorkspaceAgentDefaults;
   workspaceProjectDefaults?: Readonly<Partial<Record<WorkspaceProviderId, string>>>;
-  supersetAgentDefault?: string;
 }
 
 export type AppSettingField = keyof StoredAppSettings;
@@ -291,8 +293,14 @@ function workspaceAgentDefaults(
   if (!isRecord(value)) {
     return invalid(undefined);
   }
-  const defaults: Partial<Record<ProviderId, WorkspaceAgentSelection>> = {};
+  const defaults: Partial<Record<ProviderId, WorkspaceAgentSelection>> &
+    Partial<Record<typeof SUPERSET_WORKSPACE_PROVIDER_ID, WorkspaceAgentKindSelection>> = {};
   for (const [providerId, selection] of Object.entries(value)) {
+    if (providerId === SUPERSET_WORKSPACE_PROVIDER_ID) {
+      const parsed = parseWorkspaceAgentKindSelection(selection);
+      if (parsed) defaults[SUPERSET_WORKSPACE_PROVIDER_ID] = parsed;
+      continue;
+    }
     const parsed = parseWorkspaceAgentSelection(providerId, selection);
     if (!isProviderId(providerId) || !parsed) continue;
     defaults[providerId] = parsed;
@@ -799,7 +807,10 @@ export const APP_SETTING_SCHEMA = {
     default: undefined,
     guard: workspaceAgentDefaults,
     entry: {
-      isKey: isProviderId,
+      // Local Conductor is deliberately not a key: its creation link
+      // documents no agent choice, so no entry could ever steer one.
+      isKey: (value): value is ProviderId | typeof SUPERSET_WORKSPACE_PROVIDER_ID =>
+        isWireString(value) && (value === SUPERSET_WORKSPACE_PROVIDER_ID || isProviderId(value)),
       same: (current, next) =>
         current?.agent === next?.agent &&
         current?.model === next?.model &&
@@ -808,9 +819,15 @@ export const APP_SETTING_SCHEMA = {
     settingsPage: SETTINGS_PAGE.CONNECTIONS,
     guideEntry: settingGuideEntry(
       "workspaceAgentDefaults",
-      [APP_SETTING_ID.WORKSPACE_AGENT_MODEL, APP_SETTING_ID.WORKSPACE_AGENT_EFFORT],
+      [
+        APP_SETTING_ID.WORKSPACE_AGENT_MODEL,
+        APP_SETTING_ID.WORKSPACE_AGENT_EFFORT,
+        APP_SETTING_ID.SUPERSET_AGENT,
+      ],
       (settings) => {
         const chosen = settings.workspaceAgentDefaults?.[PROVIDER_ID.CONDUCTOR];
+        const supersetAgent =
+          settings.workspaceAgentDefaults?.[SUPERSET_WORKSPACE_PROVIDER_ID]?.agent;
         const chosenAgent = chosen
           ? workspaceAgentModels(PROVIDER_ID.CONDUCTOR).find(
               (entry) => entry.agent === chosen.agent,
@@ -861,13 +878,26 @@ export const APP_SETTING_SCHEMA = {
                 },
               ]
             : []),
+          {
+            id: APP_SETTING_ID.SUPERSET_AGENT,
+            label: "New Superset sessions run",
+            description:
+              "Which configured Superset agent starts when a creation ask names none. Unset, Luke asks which agent to use.",
+            kind: APP_SETTING_KIND.CHOICE,
+            value: supersetAgent ?? ASK_EACH_TIME_CHOICE,
+            choices: [ASK_EACH_TIME_CHOICE, ...(supersetAgent ? [supersetAgent] : [])],
+            defaultValue: ASK_EACH_TIME_CHOICE,
+            adjustable: false,
+            manual: `${CONNECTIONS_PAGE}, under Superset`,
+          },
         ];
       },
     ),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.NONE,
-    // The model and the effort ride one stored write, so one id counts the
-    // pair: a separate effort count would say a second change happened where
-    // the developer made one.
+    // Every entry rides one stored write, so one id counts them all — the
+    // Conductor pairing with its effort, and the Superset kind alike: a
+    // separate count per facet would say a second change happened where the
+    // developer made one.
     analytics: { id: APP_SETTING_ID.WORKSPACE_AGENT_MODEL, value: choiceAnalytics },
   },
   workspaceProjectDefaults: {
@@ -884,41 +914,6 @@ export const APP_SETTING_SCHEMA = {
     // Observed project names and defaults travel in the workspace-project context.
     guideEntry: settingGuideEntry("workspaceProjectDefaults", [], () => undefined),
     mainProcessSideEffect: SETTING_SIDE_EFFECT.NONE,
-  },
-  supersetAgentDefault: {
-    field: "supersetAgentDefault",
-    default: undefined,
-    guard: (value) =>
-      optional(
-        value,
-        (candidate): candidate is string =>
-          isWireString(candidate) && /^[a-z0-9][a-z0-9-]{0,79}$/u.test(candidate),
-      ),
-    settingsPage: SETTINGS_PAGE.CONNECTIONS,
-    resetScope: SETTINGS_RESET_SCOPE.WORKSPACES,
-    guideEntry: settingGuideEntry(
-      "supersetAgentDefault",
-      [APP_SETTING_ID.SUPERSET_AGENT],
-      (settings) => [
-        {
-          id: APP_SETTING_ID.SUPERSET_AGENT,
-          label: "New Superset sessions run",
-          description:
-            "Which configured Superset agent starts when a creation ask names none. Unset, Luke asks which agent to use.",
-          kind: APP_SETTING_KIND.CHOICE,
-          value: settings.supersetAgentDefault ?? ASK_EACH_TIME_CHOICE,
-          choices: [
-            ASK_EACH_TIME_CHOICE,
-            ...(settings.supersetAgentDefault ? [settings.supersetAgentDefault] : []),
-          ],
-          defaultValue: ASK_EACH_TIME_CHOICE,
-          adjustable: false,
-          manual: `${CONNECTIONS_PAGE}, under Superset`,
-        },
-      ],
-    ),
-    mainProcessSideEffect: SETTING_SIDE_EFFECT.NONE,
-    analytics: { id: APP_SETTING_ID.SUPERSET_AGENT, value: choiceAnalytics },
   },
 } as const satisfies {
   [Field in AppSettingField]: SettingDefinition<Field>;


### PR DESCRIPTION
## What

Two parallel "default agent for new workspaces" settings existed only because Superset's workspace creator was not a `ProviderId`. Since `WorkspaceProviderId` moved into `@sidecar/session` (#481), the record can key every workspace-capable provider, so this folds `supersetAgentDefault` into `workspaceAgentDefaults`: one setting concept, one shape.

## The folded shape

`workspaceAgentDefaults` is now a `WorkspaceAgentDefaults` (`@sidecar/session`): one entry per workspace provider that documents an agent choice at all —

- a provider with a build-fixed models table (Conductor today) holds a full `WorkspaceAgentSelection`, still gated by `isListedWorkspaceAgentModel` through `parseWorkspaceAgentSelection`;
- Superset holds a `WorkspaceAgentKindSelection` — the agent kind alone, with `model`/`effort` typed `never`, because Superset documents no model choice; a stored or written value carrying one is refused rather than trimmed;
- local Conductor deliberately holds no entry: its creation deep link documents no agent, model, or name.

## Validation is unchanged in strength

- A Superset kind answers to `parseWorkspaceAgentKindSelection`, the same `^[a-z0-9][a-z0-9-]{0,79}$` bound the legacy field's guard applied, now applied on the IPC write (via `settingEntryGuard`, which the legacy whole-field write never had) and again on every read from disk.
- The first-creation remember in `rememberWorkspaceDefaults` still writes only an agent the roster offered, only while nothing is chosen, and its three-way provider guard collapses to `isWorkspaceProviderId`.
- The observation pass hands the same `string | undefined` to `supersetWorkspaceAdapter.refresh(...)`, read from the folded record; creation asks read their stored defaults exactly as before.

## A stored legacy value migrates

A `supersetAgentDefault` left by an earlier build is folded into the record on read — under the same guard a folded entry answers to, with an already-held folded entry winning as the newer choice — and the next settings write drops the legacy field from the file, the same idiom the legacy Conductor key follows. Nothing is lost and nothing needs re-picking.

One deliberate posture change rides the fold: the legacy field belonged to the workspaces reset scope, while `workspaceAgentDefaults` is deliberately outside every reset scope ("never the agent pairing" — the row's own menu already offers the provider's default). The Superset entry now stands with the Conductor pairing through a workspaces reset, and the reset test states so. Likewise a Superset default change is now counted under the `WORKSPACE_AGENT_MODEL` setting id like every other entry of the one field, still as set/cleared only.

## Checks

`./scripts/check.sh` passes (repository checks, typecheck, all workspace tests, builds). No UI drawing changed — the Superset row reads the same control shape — so no visual evidence run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32766632867/artifacts/9534728745) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32766632867)

- Commit: `f8dd5df1e889080d01771839cb6e334747c59ef7`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
