### PR TITLE
refactor(providers): register workspace hosts behind one snapshot contract

### DIFF
--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -30,17 +30,17 @@ import { normalizeTrackedIssue, type TrackedIssue } from "@sidecar/issues";
 import { ObservationLoop, ObservationSupervisor } from "@sidecar/observation";
 import {
   CmuxSessionApplicationReader,
-  CmuxSessionApplicationSnapshot,
   CodexCloudSessionAdapter,
   ConductorLocalWorkspaceAdapter,
   ConductorSessionApplicationReader,
-  ConductorSessionApplicationSnapshot,
   defaultOrcaDataDirectory,
   ObservationHookRegistry,
   OrcaWorkspaceReader,
-  OrcaWorkspaceSnapshot,
   type ProviderRegistration,
   providerRegistrations,
+  type WorkspaceHostEnrichment,
+  type WorkspaceHostRegistration,
+  workspaceHostRegistrations,
 } from "@sidecar/providers";
 import {
   ATTENTION_SPEECH_SOURCE,
@@ -207,6 +207,20 @@ const supersetCli = new SupersetCli({ homeDirectory: supersetHomeDirectory });
 const supersetWorkspaceAdapter = new SupersetWorkspaceAdapter(supersetCli);
 let observedSupersetWorkspaces = new SupersetWorkspaceSnapshot([]);
 let observedSupersetOrganization: string | undefined;
+const supersetWorkspaceHost: WorkspaceHostRegistration = {
+  observationFailureLabel: "Superset observation",
+  read: readSupersetWorkspaceHost,
+  // The read absorbs its own failures into an empty snapshot so the act
+  // contexts and the workspace rows move with it; a rejection would be a
+  // bug, and it costs only the enrichment rather than the pass.
+  emptyEnrichment: (_providerId, observations) => observations,
+};
+const workspaceHosts = workspaceHostRegistrations({
+  superset: supersetWorkspaceHost,
+  conductorApplications: conductorSessionApplications,
+  orcaWorkspaces,
+  cmuxApplications: cmuxSessionApplications,
+});
 // `directory` and the cipher are read lazily so the store can be declared before
 // the Electron app is ready.
 const settingsStore = new SettingsStore({
@@ -1246,30 +1260,13 @@ async function applyLocalSessionHooks(): Promise<void> {
   );
 }
 
-async function refreshProviderSessions(generation: number): Promise<void> {
-  const actionsWereEnabled = observedSupersetOrganization !== undefined;
-  const conductorSnapshotPromise = conductorSessionApplications.read().catch((error) => {
-    const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`Conductor application observation failed: ${message}\n`);
-    return new ConductorSessionApplicationSnapshot();
-  });
-  const orcaSnapshotPromise = orcaWorkspaces.read().catch((error) => {
-    const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`Orca application observation failed: ${message}\n`);
-    return new OrcaWorkspaceSnapshot();
-  });
-  const cmuxSnapshotPromise = cmuxSessionApplications.read().catch((error) => {
-    const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`cmux application observation failed: ${message}\n`);
-    return new CmuxSessionApplicationSnapshot();
-  });
-  // Re-reads the repositories Conductor holds so the local create offer tracks
-  // its index. A failed read empties the offer inside the adapter, so a create
-  // is never validated against repositories a later read could no longer see.
-  const conductorRepositoriesPromise = conductorLocalWorkspaceAdapter.refresh().catch((error) => {
-    const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`Conductor repository observation failed: ${message}\n`);
-  });
+/**
+ * The Superset entry of the workspace-host registry carries the whole
+ * Superset pass, not only the enrichment: the acts a drawn row still
+ * advertises resolve against this module's latest snapshot, and the chatless
+ * workspace rows ride the same read, so all of it moves together.
+ */
+async function readSupersetWorkspaceHost(): Promise<WorkspaceHostEnrichment> {
   let supersetSnapshot = new SupersetWorkspaceSnapshot([]);
   let supersetOrganization: string | undefined;
   let supersetAgentDefault: string | undefined;
@@ -1302,11 +1299,30 @@ async function refreshProviderSessions(generation: number): Promise<void> {
     const message = error instanceof Error ? error.message : String(error);
     process.stderr.write(`Superset observation failed: ${message}\n`);
   }
-  const conductorSnapshot = await conductorSnapshotPromise;
-  const orcaSnapshot = await orcaSnapshotPromise;
-  const cmuxSnapshot = await cmuxSnapshotPromise;
+  return (providerId, observations) =>
+    supersetSnapshot.enrich(providerId, observations, supersetOrganization);
+}
+
+async function refreshProviderSessions(generation: number): Promise<void> {
+  const actionsWereEnabled = observedSupersetOrganization !== undefined;
+  // Re-reads the repositories Conductor holds so the local create offer tracks
+  // its index. A failed read empties the offer inside the adapter, so a create
+  // is never validated against repositories a later read could no longer see.
+  const conductorRepositoriesPromise = conductorLocalWorkspaceAdapter.refresh().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Conductor repository observation failed: ${message}\n`);
+  });
+  const hostEnrichments = await Promise.all(
+    workspaceHosts.map((host) =>
+      host.read().catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        process.stderr.write(`${host.observationFailureLabel} failed: ${message}\n`);
+        return host.emptyEnrichment;
+      }),
+    ),
+  );
   await conductorRepositoriesPromise;
-  const supersetActionsEnabled = supersetOrganization !== undefined;
+  const supersetActionsEnabled = observedSupersetOrganization !== undefined;
   if (actionsWereEnabled !== supersetActionsEnabled) {
     if (supersetActionsEnabled) {
       panels.broadcast(channels.supersetSignInChanged, {
@@ -1326,24 +1342,14 @@ async function refreshProviderSessions(generation: number): Promise<void> {
   await Promise.all([
     ...orderedRegistrations.map(async ({ adapter }) => {
       try {
-        // Superset claims its workspaces first and Conductor next — the
-        // precedence that stood before Orca joined, so no existing tray moves
-        // — and Orca defers to both: one chat is grouped by exactly one
-        // manager however many of them hold it, and a chat only Orca holds
-        // still groups under its worktree. cmux runs last and claims no
-        // workspace at all: it only adds its own association, and its pane
-        // address stands in as the row's link only where none of the
-        // managers before it gave one.
+        // The fold applies the managers in registry order, which is what
+        // makes the registry's declared claim order the enrichment
+        // precedence: the first registration annotates first, and each later
+        // one sees what the earlier ones already claimed.
         await sessionRegistry.refresh(adapter, (providerId, observations) =>
-          cmuxSnapshot.enrich(
-            providerId,
-            orcaSnapshot.enrich(
-              providerId,
-              conductorSnapshot.enrich(
-                providerId,
-                supersetSnapshot.enrich(providerId, observations, supersetOrganization),
-              ),
-            ),
+          hostEnrichments.reduce(
+            (enriched, enrichment) => enrichment(providerId, enriched),
+            observations,
           ),
         );
       } catch (error) {

--- a/packages/providers/src/cmux/session-applications.ts
+++ b/packages/providers/src/cmux/session-applications.ts
@@ -5,7 +5,6 @@ import {
   type ProviderSessionObservation,
   SESSION_APPLICATION_ID,
   SESSION_APPLICATION_SCOPE,
-  SESSION_LOCATION,
   type SessionApplication,
 } from "@sidecar/session";
 import {
@@ -16,6 +15,7 @@ import {
   wireRecord,
 } from "@sidecar/wire";
 import { readTextFile } from "../shared/local-session-adapter.js";
+import { WorkspaceHostSnapshot } from "../shared/workspace-host-snapshot.js";
 
 const CMUX_STATE_DIRECTORY_NAME = ".cmuxterm";
 
@@ -70,8 +70,6 @@ interface CmuxSessionContext {
   surfaceId: string;
 }
 
-type SessionContextsByProvider = ReadonlyMap<string, ReadonlyMap<string, CmuxSessionContext>>;
-
 export interface CmuxSessionApplicationReaderOptions {
   stateDirectory?: string;
 }
@@ -93,84 +91,41 @@ function contextFromRecord(value: UnparsedWireValue): CmuxSessionContext | undef
  * transcript. An absent app, an unreadable store, or an unfamiliar shape means
  * no annotation; it can never make the provider's own observation disappear.
  */
-export class CmuxSessionApplicationSnapshot {
-  readonly #sessionsByProvider: SessionContextsByProvider;
-
-  constructor(sessionsByProvider: SessionContextsByProvider = new Map()) {
-    this.#sessionsByProvider = sessionsByProvider;
-  }
-
-  has(providerId: string, providerSessionId: string): boolean {
-    return this.#sessionsByProvider.get(providerId)?.has(providerSessionId) === true;
-  }
+export class CmuxSessionApplicationSnapshot extends WorkspaceHostSnapshot<CmuxSessionContext> {
+  protected override readonly applicationId = SESSION_APPLICATION_ID.CMUX;
 
   /**
    * Adds cmux beside any app associations the provider already reported, with
    * the pane's own `cmux://` address, which also stands in as the row's link
-   * where no other manager gave it one. A sub-agent inherits its nearest
-   * cmux-known ancestor's association: the child runs in the same pane even
-   * though only the parent reached cmux's hooks. cmux names its workspaces
-   * only by identifier, so a matched row keeps whatever grouping another
-   * manager claimed and never groups under cmux.
+   * where no other manager gave it one. A sub-agent runs in the same pane as
+   * its nearest cmux-known ancestor even though only the parent reached
+   * cmux's hooks. cmux names its workspaces only by identifier, so a matched
+   * row keeps whatever grouping another manager claimed and never groups
+   * under cmux.
    */
-  enrich(
-    providerId: string,
-    observations: readonly ProviderSessionObservation[],
-  ): readonly ProviderSessionObservation[] {
-    const cmuxSessions = this.#sessionsByProvider.get(providerId);
-    if (!cmuxSessions) return observations;
-
-    const localObservationsById = new Map(
-      observations
-        .filter((observation) => observation.location !== SESSION_LOCATION.CLOUD)
-        .map((observation) => [observation.providerSessionId, observation] as const),
-    );
-
-    const cmuxContextFor = (
-      observation: ProviderSessionObservation,
-    ): CmuxSessionContext | undefined => {
-      if (observation.location === SESSION_LOCATION.CLOUD) return undefined;
-      let sessionId: string | undefined = observation.providerSessionId;
-      const visited = new Set<string>();
-      while (sessionId && !visited.has(sessionId)) {
-        const context = cmuxSessions.get(sessionId);
-        if (context) return context;
-        visited.add(sessionId);
-        sessionId = text(localObservationsById.get(sessionId)?.parentProviderSessionId);
-      }
-      return undefined;
+  protected override annotate(
+    observation: ProviderSessionObservation,
+    context: CmuxSessionContext,
+  ): ProviderSessionObservation {
+    const applicationLink = cmuxSurfaceLink(context.workspaceId, context.surfaceId);
+    const application: SessionApplication = {
+      id: SESSION_APPLICATION_ID.CMUX,
+      displayName: CMUX_APPLICATION_NAME,
+      scope: SESSION_APPLICATION_SCOPE.SESSION,
+      link: applicationLink,
     };
-
-    return observations.map((observation) => {
-      const context = cmuxContextFor(observation);
-      if (
-        !context ||
-        observation.applications?.some(
-          (application) => application.id === SESSION_APPLICATION_ID.CMUX,
-        )
-      ) {
-        return observation;
-      }
-      const applicationLink = cmuxSurfaceLink(context.workspaceId, context.surfaceId);
-      const application: SessionApplication = {
-        id: SESSION_APPLICATION_ID.CMUX,
-        displayName: CMUX_APPLICATION_NAME,
-        scope: SESSION_APPLICATION_SCOPE.SESSION,
-        link: applicationLink,
-      };
-      // The app that wrote the hook store is the scheme's registered handler,
-      // so the address stands on its own. A link another manager already gave
-      // the row wins as the row's primary press; the cmux association keeps
-      // its own exact pane address independently.
-      const detail = observation.detail?.link
-        ? observation.detail
-        : { ...observation.detail, link: applicationLink };
-      return {
-        ...observation,
-        detail,
-        applications: [...(observation.applications ?? []), application],
-      };
-    });
+    // The app that wrote the hook store is the scheme's registered handler,
+    // so the address stands on its own. A link another manager already gave
+    // the row wins as the row's primary press; the cmux association keeps
+    // its own exact pane address independently.
+    const detail = observation.detail?.link
+      ? observation.detail
+      : { ...observation.detail, link: applicationLink };
+    return {
+      ...observation,
+      detail,
+      applications: [...(observation.applications ?? []), application],
+    };
   }
 }
 

--- a/packages/providers/src/conductor/session-applications.ts
+++ b/packages/providers/src/conductor/session-applications.ts
@@ -6,7 +6,6 @@ import {
   type ProviderSessionObservation,
   SESSION_APPLICATION_ID,
   SESSION_APPLICATION_SCOPE,
-  SESSION_LOCATION,
   type SessionApplication,
   type SessionProvider,
 } from "@sidecar/session";
@@ -18,6 +17,7 @@ import {
   type SqliteDatabase,
   type SqliteModuleLoader,
 } from "../shared/local-sqlite.js";
+import { unclaimedWorkspace, WorkspaceHostSnapshot } from "../shared/workspace-host-snapshot.js";
 
 const CONDUCTOR_APPLICATION_SUPPORT_DIRECTORY = "com.conductor.app";
 const CONDUCTOR_DATABASE_FILE = "conductor.db";
@@ -199,8 +199,6 @@ interface ConductorSessionContext {
   filedAway?: boolean;
 }
 
-type SessionContextsByProvider = ReadonlyMap<string, ReadonlyMap<string, ConductorSessionContext>>;
-
 export interface ConductorSessionApplicationReaderOptions {
   databasePath?: string;
   sqlite?: SqliteModuleLoader;
@@ -235,125 +233,78 @@ function chatTitle(value: UnparsedWireValue): string | undefined {
  * away — the chat hidden, or its workspace archived — drops a row, and drops
  * it whole.
  */
-export class ConductorSessionApplicationSnapshot {
-  readonly #sessionsByProvider: SessionContextsByProvider;
+export class ConductorSessionApplicationSnapshot extends WorkspaceHostSnapshot<ConductorSessionContext> {
+  protected override readonly applicationId = SESSION_APPLICATION_ID.CONDUCTOR;
 
-  constructor(sessionsByProvider: SessionContextsByProvider = new Map()) {
-    this.#sessionsByProvider = sessionsByProvider;
-  }
-
-  has(providerId: string, providerSessionId: string): boolean {
-    return this.#sessionsByProvider.get(providerId)?.has(providerSessionId) === true;
+  // A filed-away chat is dropped rather than annotated: the user archived
+  // or hid it on Conductor's own surface, and a sub-agent inheriting that
+  // context was filed away with its parent — the agent's transcript outlives
+  // the chat the user already said goodbye to.
+  protected override retains(context: ConductorSessionContext): boolean {
+    return context.filedAway !== true;
   }
 
   /**
    * Adds Conductor beside any app associations the provider already reported,
    * titles the chat by the name Conductor gave it, and groups it under the
    * Conductor workspace it belongs to, the way a Superset-managed chat groups
-   * under its Superset workspace. Only local observations can match a local
-   * Conductor database; a cloud row with a coincidentally equal provider id
-   * is never annotated. A sub-agent inherits its nearest Conductor-known
-   * ancestor's association and workspace: the child is Conductor's work even
-   * though only the parent is in its index — and a chat the user filed away
-   * in Conductor is dropped from the roster with its sub-agents, because the
-   * agent's transcript outlives the chat the user already said goodbye to.
+   * under its Superset workspace.
    */
-  enrich(
-    providerId: string,
-    observations: readonly ProviderSessionObservation[],
-  ): readonly ProviderSessionObservation[] {
-    const conductorSessions = this.#sessionsByProvider.get(providerId);
-    if (!conductorSessions) return observations;
-
-    const localObservationsById = new Map(
-      observations
-        .filter((observation) => observation.location !== SESSION_LOCATION.CLOUD)
-        .map((observation) => [observation.providerSessionId, observation] as const),
-    );
-
-    const conductorContextFor = (
-      observation: ProviderSessionObservation,
-    ): ConductorSessionContext | undefined => {
-      if (observation.location === SESSION_LOCATION.CLOUD) return undefined;
-      let sessionId: string | undefined = observation.providerSessionId;
-      const visited = new Set<string>();
-      while (sessionId && !visited.has(sessionId)) {
-        const context = conductorSessions.get(sessionId);
-        if (context) return context;
-        visited.add(sessionId);
-        sessionId = text(localObservationsById.get(sessionId)?.parentProviderSessionId);
-      }
-      return undefined;
+  protected override annotate(
+    observation: ProviderSessionObservation,
+    context: ConductorSessionContext,
+    conductorSessions: ReadonlyMap<string, ConductorSessionContext>,
+  ): ProviderSessionObservation {
+    // The workspace is claimed only where no other manager already grouped
+    // the chat; the claim is what carries the manager's mark on the tray
+    // header, once, above the chats it holds.
+    const workspace = context.workspaceId
+      ? unclaimedWorkspace(observation, {
+          providerWorkspaceId: context.workspaceId,
+          ...(context.workspaceName ? { name: context.workspaceName } : undefined),
+          scopeId: SESSION_APPLICATION_ID.CONDUCTOR,
+          managerName: CONDUCTOR_APPLICATION_NAME,
+        })
+      : undefined;
+    // The address needs the workspace id — Conductor's handler drops a
+    // link without one — and a sub-agent's inherited context addresses the
+    // ancestor chat, which is where its conversation lives. The app that
+    // wrote the index is the scheme's handler, so the address stands with
+    // no credential at all.
+    const link = context.workspaceId
+      ? conductorWorkspaceLink(context.workspaceId, context.conductorSessionId)
+      : undefined;
+    // The association names the exact chat — its address does, when it has
+    // one — so it is the session's own and rides the row even inside the
+    // workspace's tray, where the tray header's manager mark comes from
+    // the workspace claim above rather than from this.
+    const application: SessionApplication = {
+      id: SESSION_APPLICATION_ID.CONDUCTOR,
+      displayName: CONDUCTOR_APPLICATION_NAME,
+      scope: SESSION_APPLICATION_SCOPE.SESSION,
+      ...(link ? { link } : undefined),
     };
-
-    return observations.flatMap((observation) => {
-      const context = conductorContextFor(observation);
-      // A filed-away chat is dropped rather than annotated: the user archived
-      // or hid it on Conductor's own surface, and a sub-agent inheriting that
-      // context was filed away with its parent.
-      if (context?.filedAway) return [];
-      if (
-        !context ||
-        observation.applications?.some(
-          (application) => application.id === SESSION_APPLICATION_ID.CONDUCTOR,
-        )
-      ) {
-        return [observation];
-      }
-      // The workspace is claimed only where no other manager already grouped
-      // the chat; the claim is what carries the manager's mark on the tray
-      // header, once, above the chats it holds.
-      const workspace =
-        context.workspaceId && !observation.workspace
-          ? {
-              providerWorkspaceId: context.workspaceId,
-              ...(context.workspaceName ? { name: context.workspaceName } : undefined),
-              scopeId: SESSION_APPLICATION_ID.CONDUCTOR,
-              managerName: CONDUCTOR_APPLICATION_NAME,
-            }
-          : undefined;
-      // The address needs the workspace id — Conductor's handler drops a
-      // link without one — and a sub-agent's inherited context addresses the
-      // ancestor chat, which is where its conversation lives. The app that
-      // wrote the index is the scheme's handler, so the address stands with
-      // no credential at all.
-      const link = context.workspaceId
-        ? conductorWorkspaceLink(context.workspaceId, context.conductorSessionId)
-        : undefined;
-      // The association names the exact chat — its address does, when it has
-      // one — so it is the session's own and rides the row even inside the
-      // workspace's tray, where the tray header's manager mark comes from
-      // the workspace claim above rather than from this.
-      const application: SessionApplication = {
-        id: SESSION_APPLICATION_ID.CONDUCTOR,
-        displayName: CONDUCTOR_APPLICATION_NAME,
-        scope: SESSION_APPLICATION_SCOPE.SESSION,
-        ...(link ? { link } : undefined),
-      };
-      // The address fills the row's link only where nothing else gave one.
-      // Which app a grouped row's press follows is not decided here: the
-      // session normalization orders every row's marks with its workspace's
-      // manager in the lead and points the press at the first linked mark,
-      // so Conductor's precedence over an agent's own app falls out of the
-      // grouping rather than out of any Conductor-specific write.
-      const detail =
-        link && !observation.detail?.link ? { ...observation.detail, link } : observation.detail;
-      // The name Conductor gave the chat is what the user reads in Conductor's
-      // own sidebar, so it titles the row here the way it titles a
-      // cloud-observed chat's — but only on the chat itself, never inherited:
-      // a sub-agent labelled with its parent's name would read as the same
-      // conversation twice while saying nothing about its own work.
-      const title = conductorSessions.get(observation.providerSessionId)?.chatTitle;
-      return [
-        {
-          ...observation,
-          ...(title ? { title } : undefined),
-          ...(detail ? { detail } : undefined),
-          applications: [...(observation.applications ?? []), application],
-          ...(workspace ? { workspace } : undefined),
-        },
-      ];
-    });
+    // The address fills the row's link only where nothing else gave one.
+    // Which app a grouped row's press follows is not decided here: the
+    // session normalization orders every row's marks with its workspace's
+    // manager in the lead and points the press at the first linked mark,
+    // so Conductor's precedence over an agent's own app falls out of the
+    // grouping rather than out of any Conductor-specific write.
+    const detail =
+      link && !observation.detail?.link ? { ...observation.detail, link } : observation.detail;
+    // The name Conductor gave the chat is what the user reads in Conductor's
+    // own sidebar, so it titles the row here the way it titles a
+    // cloud-observed chat's — but only on the chat itself, never inherited:
+    // a sub-agent labelled with its parent's name would read as the same
+    // conversation twice while saying nothing about its own work.
+    const title = conductorSessions.get(observation.providerSessionId)?.chatTitle;
+    return {
+      ...observation,
+      ...(title ? { title } : undefined),
+      ...(detail ? { detail } : undefined),
+      applications: [...(observation.applications ?? []), application],
+      ...(workspace ? { workspace } : undefined),
+    };
   }
 }
 

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -1,22 +1,12 @@
-export {
-  CmuxSessionApplicationReader,
-  CmuxSessionApplicationSnapshot,
-} from "./cmux/session-applications.js";
+export { CmuxSessionApplicationReader } from "./cmux/session-applications.js";
 export { CodexCloudSessionAdapter } from "./codex/cloud-adapter.js";
 export {
   ConductorLocalWorkspaceAdapter,
   ConductorRepositoryReader,
 } from "./conductor/local-workspace-adapter.js";
-export {
-  ConductorSessionApplicationReader,
-  ConductorSessionApplicationSnapshot,
-} from "./conductor/session-applications.js";
+export { ConductorSessionApplicationReader } from "./conductor/session-applications.js";
 export { ObservationHookRegistry } from "./hook-registry.js";
-export {
-  defaultOrcaDataDirectory,
-  OrcaWorkspaceReader,
-  OrcaWorkspaceSnapshot,
-} from "./orca/workspaces.js";
+export { defaultOrcaDataDirectory, OrcaWorkspaceReader } from "./orca/workspaces.js";
 export { type ProviderRegistration, providerRegistrations } from "./registrations.js";
 export { canIgnoreFilesystemError, readDirectory } from "./shared/local-session-adapter.js";
 export {
@@ -28,3 +18,9 @@ export {
   type SqliteModuleLoader,
   textFromRow,
 } from "./shared/local-sqlite.js";
+export {
+  type WorkspaceHostEnrichment,
+  type WorkspaceHostRegistration,
+  type WorkspaceHostRegistrationOptions,
+  workspaceHostRegistrations,
+} from "./shared/workspace-hosts.js";

--- a/packages/providers/src/orca/workspaces.ts
+++ b/packages/providers/src/orca/workspaces.ts
@@ -6,7 +6,6 @@ import {
   type ProviderSessionObservation,
   SESSION_APPLICATION_ID,
   SESSION_APPLICATION_SCOPE,
-  SESSION_LOCATION,
   type SessionApplication,
   type SessionProvider,
 } from "@sidecar/session";
@@ -20,6 +19,7 @@ import {
   wireRecord,
 } from "@sidecar/wire";
 import { fileStats, readTextFile, workspaceLabel } from "../shared/local-session-adapter.js";
+import { unclaimedWorkspace, WorkspaceHostSnapshot } from "../shared/workspace-host-snapshot.js";
 
 export const ORCA_APPLICATION_NAME = "Orca";
 
@@ -86,8 +86,6 @@ interface OrcaSessionContext {
   workspaceName?: string;
 }
 
-type SessionContextsByProvider = ReadonlyMap<string, ReadonlyMap<string, OrcaSessionContext>>;
-
 export interface OrcaWorkspaceReaderOptions {
   dataDirectory?: string;
 }
@@ -114,87 +112,40 @@ function worktreePathFromId(worktreeId: string): string | undefined {
  * know means no annotation; it can never make the provider's own observation
  * disappear.
  */
-export class OrcaWorkspaceSnapshot {
-  readonly #sessionsByProvider: SessionContextsByProvider;
-
-  constructor(sessionsByProvider: SessionContextsByProvider = new Map()) {
-    this.#sessionsByProvider = sessionsByProvider;
-  }
-
-  has(providerId: string, providerSessionId: string): boolean {
-    return this.#sessionsByProvider.get(providerId)?.has(providerSessionId) === true;
-  }
+export class OrcaWorkspaceSnapshot extends WorkspaceHostSnapshot<OrcaSessionContext> {
+  protected override readonly applicationId = SESSION_APPLICATION_ID.ORCA;
 
   /**
    * Adds Orca beside any app associations the provider already reported, and
    * groups the chat under the Orca worktree it belongs to, the way a
-   * Superset-managed chat groups under its Superset workspace. Only local
-   * observations can match a local Orca index; a cloud row with a
-   * coincidentally equal provider id is never annotated. A sub-agent inherits
-   * its nearest Orca-known ancestor's association and workspace: the child is
-   * Orca's work even though only the parent is in its index.
+   * Superset-managed chat groups under its Superset workspace. A sub-agent
+   * takes its nearest Orca-known ancestor's worktree: the child is Orca's
+   * work even though only the parent is in its index.
    */
-  enrich(
-    providerId: string,
-    observations: readonly ProviderSessionObservation[],
-  ): readonly ProviderSessionObservation[] {
-    const orcaSessions = this.#sessionsByProvider.get(providerId);
-    if (!orcaSessions) return observations;
-
-    const localObservationsById = new Map(
-      observations
-        .filter((observation) => observation.location !== SESSION_LOCATION.CLOUD)
-        .map((observation) => [observation.providerSessionId, observation] as const),
-    );
-
-    const orcaContextFor = (
-      observation: ProviderSessionObservation,
-    ): OrcaSessionContext | undefined => {
-      if (observation.location === SESSION_LOCATION.CLOUD) return undefined;
-      let sessionId: string | undefined = observation.providerSessionId;
-      const visited = new Set<string>();
-      while (sessionId && !visited.has(sessionId)) {
-        const context = orcaSessions.get(sessionId);
-        if (context) return context;
-        visited.add(sessionId);
-        sessionId = text(localObservationsById.get(sessionId)?.parentProviderSessionId);
-      }
-      return undefined;
-    };
-
-    return observations.map((observation) => {
-      const context = orcaContextFor(observation);
-      if (
-        !context ||
-        observation.applications?.some(
-          (application) => application.id === SESSION_APPLICATION_ID.ORCA,
-        )
-      ) {
-        return observation;
-      }
-      // The workspace is claimed only where no other manager already grouped
-      // the chat, and the association's scope follows it: carried by the
-      // workspace, the mark sits once on the tray header; carried by the
-      // session alone, it stays on the row.
-      const workspace = observation.workspace
-        ? undefined
-        : {
-            providerWorkspaceId: context.worktreeId,
-            ...(context.workspaceName ? { name: context.workspaceName } : undefined),
-            scopeId: SESSION_APPLICATION_ID.ORCA,
-            managerName: ORCA_APPLICATION_NAME,
-          };
-      const application: SessionApplication = {
-        id: SESSION_APPLICATION_ID.ORCA,
-        displayName: ORCA_APPLICATION_NAME,
-        scope: workspace ? SESSION_APPLICATION_SCOPE.WORKSPACE : SESSION_APPLICATION_SCOPE.SESSION,
-      };
-      return {
-        ...observation,
-        applications: [...(observation.applications ?? []), application],
-        ...(workspace ? { workspace } : undefined),
-      };
+  protected override annotate(
+    observation: ProviderSessionObservation,
+    context: OrcaSessionContext,
+  ): ProviderSessionObservation {
+    // The workspace is claimed only where no other manager already grouped
+    // the chat, and the association's scope follows it: carried by the
+    // workspace, the mark sits once on the tray header; carried by the
+    // session alone, it stays on the row.
+    const workspace = unclaimedWorkspace(observation, {
+      providerWorkspaceId: context.worktreeId,
+      ...(context.workspaceName ? { name: context.workspaceName } : undefined),
+      scopeId: SESSION_APPLICATION_ID.ORCA,
+      managerName: ORCA_APPLICATION_NAME,
     });
+    const application: SessionApplication = {
+      id: SESSION_APPLICATION_ID.ORCA,
+      displayName: ORCA_APPLICATION_NAME,
+      scope: workspace ? SESSION_APPLICATION_SCOPE.WORKSPACE : SESSION_APPLICATION_SCOPE.SESSION,
+    };
+    return {
+      ...observation,
+      applications: [...(observation.applications ?? []), application],
+      ...(workspace ? { workspace } : undefined),
+    };
   }
 }
 

--- a/packages/providers/src/shared/workspace-host-snapshot.ts
+++ b/packages/providers/src/shared/workspace-host-snapshot.ts
@@ -1,0 +1,106 @@
+import {
+  type ProviderSessionObservation,
+  SESSION_LOCATION,
+  type SessionApplicationId,
+  type SessionWorkspace,
+} from "@sidecar/session";
+import { text } from "@sidecar/wire";
+
+/**
+ * What one workspace manager's own records say about the sessions it holds,
+ * keyed by the agent provider Luke already observes each session under and
+ * then by the provider's own session id.
+ */
+export type WorkspaceHostContexts<Context> = ReadonlyMap<string, ReadonlyMap<string, Context>>;
+
+/**
+ * One chat is grouped by exactly one manager however many of them hold it, so
+ * a claim lands only where no manager earlier in the enrichment order already
+ * grouped the chat.
+ */
+export function unclaimedWorkspace(
+  observation: ProviderSessionObservation,
+  claim: SessionWorkspace,
+): SessionWorkspace | undefined {
+  return observation.workspace ? undefined : claim;
+}
+
+/**
+ * One local workspace manager's observed index of the agent sessions it
+ * holds, annotating already-observed rows without ever making a provider's
+ * own observation disappear: an absent app or an unreadable index is an empty
+ * snapshot, and an empty snapshot changes nothing. Only local observations
+ * can match a local manager's index — a cloud row with a coincidentally equal
+ * provider id is never annotated — and a sub-agent inherits its nearest
+ * indexed ancestor's context: the child is the manager's work even though
+ * only the parent reached the manager's records. A row already carrying this
+ * manager's association is left exactly as it stands.
+ */
+export abstract class WorkspaceHostSnapshot<Context> {
+  readonly #sessionsByProvider: WorkspaceHostContexts<Context>;
+
+  constructor(sessionsByProvider: WorkspaceHostContexts<Context> = new Map()) {
+    this.#sessionsByProvider = sessionsByProvider;
+  }
+
+  /** The association whose presence on a row means it is already annotated. */
+  protected abstract readonly applicationId: SessionApplicationId;
+
+  has(providerId: string, providerSessionId: string): boolean {
+    return this.#sessionsByProvider.get(providerId)?.has(providerSessionId) === true;
+  }
+
+  /**
+   * Whether a matched row should stand at all. Conductor drops a chat its
+   * records say the user filed away; every other manager keeps every match.
+   */
+  protected retains(_context: Context): boolean {
+    return true;
+  }
+
+  /** One matched row's annotation, everything a manager decorates for itself. */
+  protected abstract annotate(
+    observation: ProviderSessionObservation,
+    context: Context,
+    hostSessions: ReadonlyMap<string, Context>,
+  ): ProviderSessionObservation;
+
+  enrich(
+    providerId: string,
+    observations: readonly ProviderSessionObservation[],
+  ): readonly ProviderSessionObservation[] {
+    const hostSessions = this.#sessionsByProvider.get(providerId);
+    if (!hostSessions) return observations;
+
+    const localObservationsById = new Map(
+      observations
+        .filter((observation) => observation.location !== SESSION_LOCATION.CLOUD)
+        .map((observation) => [observation.providerSessionId, observation] as const),
+    );
+
+    const contextFor = (observation: ProviderSessionObservation): Context | undefined => {
+      if (observation.location === SESSION_LOCATION.CLOUD) return undefined;
+      let sessionId: string | undefined = observation.providerSessionId;
+      const visited = new Set<string>();
+      while (sessionId && !visited.has(sessionId)) {
+        const context = hostSessions.get(sessionId);
+        if (context) return context;
+        visited.add(sessionId);
+        sessionId = text(localObservationsById.get(sessionId)?.parentProviderSessionId);
+      }
+      return undefined;
+    };
+
+    return observations.flatMap((observation) => {
+      const context = contextFor(observation);
+      if (context && !this.retains(context)) return [];
+      if (
+        !context ||
+        observation.applications?.some((application) => application.id === this.applicationId)
+      ) {
+        return [observation];
+      }
+      return [this.annotate(observation, context, hostSessions)];
+    });
+  }
+}

--- a/packages/providers/src/shared/workspace-hosts.test.ts
+++ b/packages/providers/src/shared/workspace-hosts.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test, { type TestContext } from "node:test";
+import { PROVIDER_ID, SESSION_APPLICATION_ID, SESSION_STATUS } from "@sidecar/session";
+import { CmuxSessionApplicationReader } from "../cmux/session-applications.js";
+import { ConductorSessionApplicationReader } from "../conductor/session-applications.js";
+import { OrcaWorkspaceReader } from "../orca/workspaces.js";
+import { type WorkspaceHostRegistration, workspaceHostRegistrations } from "./workspace-hosts.js";
+
+async function temporaryDirectory(t: TestContext): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-workspace-hosts-"));
+  t.after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  return directory;
+}
+
+function registrations(directory: string, superset?: WorkspaceHostRegistration) {
+  return workspaceHostRegistrations({
+    superset: superset ?? {
+      observationFailureLabel: "Superset observation",
+      read: async () => (_providerId, observations) => observations,
+      emptyEnrichment: (_providerId, observations) => observations,
+    },
+    conductorApplications: new ConductorSessionApplicationReader({
+      databasePath: path.join(directory, "conductor.db"),
+    }),
+    orcaWorkspaces: new OrcaWorkspaceReader({ dataDirectory: path.join(directory, "orca") }),
+    cmuxApplications: new CmuxSessionApplicationReader({
+      stateDirectory: path.join(directory, "cmux"),
+    }),
+  });
+}
+
+test("registers the managers in the claim order the trays grew up with", async (t) => {
+  const superset: WorkspaceHostRegistration = {
+    observationFailureLabel: "Superset observation",
+    read: async () => (_providerId, observations) => observations,
+    emptyEnrichment: (_providerId, observations) => observations,
+  };
+  const hosts = registrations(await temporaryDirectory(t), superset);
+  assert.equal(hosts[0], superset);
+  assert.deepEqual(
+    hosts.map((host) => host.observationFailureLabel),
+    [
+      "Superset observation",
+      "Conductor application observation",
+      "Orca application observation",
+      "cmux application observation",
+    ],
+  );
+});
+
+test("a failed read's stand-in enriches with nothing", async (t) => {
+  const hosts = registrations(await temporaryDirectory(t));
+  const observations = [
+    { providerSessionId: "local", title: "Local", status: SESSION_STATUS.WORKING, observedAt: 1 },
+  ];
+  for (const host of hosts) {
+    assert.equal(host.emptyEnrichment(PROVIDER_ID.CLAUDE_CODE, observations), observations);
+  }
+});
+
+test("reads each manager's absent app as annotating nothing", async (t) => {
+  const hosts = registrations(await temporaryDirectory(t));
+  const observations = [
+    { providerSessionId: "local", title: "Local", status: SESSION_STATUS.WORKING, observedAt: 1 },
+  ];
+  for (const host of hosts) {
+    const enrichment = await host.read();
+    assert.equal(enrichment(PROVIDER_ID.CLAUDE_CODE, observations), observations);
+  }
+});
+
+test("a read enrichment annotates from the manager's own records", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const cmuxDirectory = path.join(directory, "cmux");
+  await fs.mkdir(cmuxDirectory, { recursive: true });
+  await fs.writeFile(
+    path.join(cmuxDirectory, "claude-hook-sessions.json"),
+    JSON.stringify({
+      version: 1,
+      sessions: { local: { sessionId: "local", workspaceId: "w", surfaceId: "s" } },
+    }),
+  );
+  const hosts = registrations(directory);
+  const cmux = hosts[hosts.length - 1];
+  assert.ok(cmux);
+  const enrichment = await cmux.read();
+  const observations = enrichment(PROVIDER_ID.CLAUDE_CODE, [
+    { providerSessionId: "local", title: "Local", status: SESSION_STATUS.WORKING, observedAt: 1 },
+  ]);
+  assert.equal(observations[0]?.applications?.[0]?.id, SESSION_APPLICATION_ID.CMUX);
+});

--- a/packages/providers/src/shared/workspace-hosts.ts
+++ b/packages/providers/src/shared/workspace-hosts.ts
@@ -1,0 +1,82 @@
+import type { ProviderSessionObservation } from "@sidecar/session";
+import {
+  type CmuxSessionApplicationReader,
+  CmuxSessionApplicationSnapshot,
+} from "../cmux/session-applications.js";
+import {
+  type ConductorSessionApplicationReader,
+  ConductorSessionApplicationSnapshot,
+} from "../conductor/session-applications.js";
+import { type OrcaWorkspaceReader, OrcaWorkspaceSnapshot } from "../orca/workspaces.js";
+
+/** One manager's annotation of one provider's already-observed sessions. */
+export type WorkspaceHostEnrichment = (
+  providerId: string,
+  observations: readonly ProviderSessionObservation[],
+) => readonly ProviderSessionObservation[];
+
+/**
+ * One workspace manager in the observation pass: how its own records become
+ * one pass's enrichment, and what a failed read stands in with — the manager
+ * annotating nothing, never a failed pass. `observationFailureLabel` opens
+ * the stderr line the caller reports a failed read under.
+ */
+export interface WorkspaceHostRegistration {
+  observationFailureLabel: string;
+  read(): Promise<WorkspaceHostEnrichment>;
+  emptyEnrichment: WorkspaceHostEnrichment;
+}
+
+export interface WorkspaceHostRegistrationOptions {
+  /**
+   * Superset's package sits above this one in the graph, so its entry — the
+   * read that also carries the CLI's active organization into the
+   * enrichment — is handed in rather than built here.
+   */
+  superset: WorkspaceHostRegistration;
+  conductorApplications: ConductorSessionApplicationReader;
+  orcaWorkspaces: OrcaWorkspaceReader;
+  cmuxApplications: CmuxSessionApplicationReader;
+}
+
+function enrichmentFrom(snapshot: {
+  enrich: (
+    providerId: string,
+    observations: readonly ProviderSessionObservation[],
+  ) => readonly ProviderSessionObservation[];
+}): WorkspaceHostEnrichment {
+  return (providerId, observations) => snapshot.enrich(providerId, observations);
+}
+
+/**
+ * The workspace managers of one observation pass, in claim order. Superset
+ * claims its workspaces first and Conductor next — the precedence that stood
+ * before Orca joined, so no existing tray moves — and Orca defers to both:
+ * one chat is grouped by exactly one manager however many of them hold it,
+ * and a chat only Orca holds still groups under its worktree. cmux runs last
+ * and claims no workspace at all: it only adds its own association, and its
+ * pane address stands in as the row's link only where none of the managers
+ * before it gave one.
+ */
+export function workspaceHostRegistrations(
+  options: WorkspaceHostRegistrationOptions,
+): readonly WorkspaceHostRegistration[] {
+  return [
+    options.superset,
+    {
+      observationFailureLabel: "Conductor application observation",
+      read: async () => enrichmentFrom(await options.conductorApplications.read()),
+      emptyEnrichment: enrichmentFrom(new ConductorSessionApplicationSnapshot()),
+    },
+    {
+      observationFailureLabel: "Orca application observation",
+      read: async () => enrichmentFrom(await options.orcaWorkspaces.read()),
+      emptyEnrichment: enrichmentFrom(new OrcaWorkspaceSnapshot()),
+    },
+    {
+      observationFailureLabel: "cmux application observation",
+      read: async () => enrichmentFrom(await options.cmuxApplications.read()),
+      emptyEnrichment: enrichmentFrom(new CmuxSessionApplicationSnapshot()),
+    },
+  ];
+}


### PR DESCRIPTION
## What deduplicated

Conductor, Orca, and cmux each shipped a snapshot class carrying a line-for-line copy of the same machinery: the nested `ReadonlyMap<providerId, ReadonlyMap<sessionId, Context>>` store, `has()`, the local-observation index that filters out `SESSION_LOCATION.CLOUD`, the `visited`-set ancestor walk up `parentProviderSessionId`, the already-annotated guard, and the claim-workspace-only-if-unclaimed rule. All of it now lives once in `WorkspaceHostSnapshot` (`packages/providers/src/shared/workspace-host-snapshot.ts`), with the `unclaimedWorkspace` helper beside it. Each manager keeps only what is genuinely its own:

- **cmux** — the pane's `cmux://` address, standing in as the row's link only where nothing else gave one, and never claiming a workspace.
- **Orca** — the worktree claim, with the association's scope following it.
- **Conductor** — the filed-away drop (a `retains` override, keeping its position before the annotate guard), the chat-title override that is never inherited by a sub-agent, and the workspace-gated deep link.

**Superset stays its fourth shape deliberately.** Its snapshot shares none of the base's guarantees: it matches by recorded binding *or* live worktree directory rather than by ancestor walk, it re-decorates a row even when the association already stands (detail, workspace, controls, capabilities all move with organization scope), and it carries stateful directory matches across passes. Folding it under the base would have meant either changing its observable behavior or making the base a lie, so it participates through the registry contract instead.

## Where the registry lives, and why

`workspaceHostRegistrations` lives in `packages/providers/src/shared/workspace-hosts.ts`. The claim order is a product fact — Superset first and Conductor next, the precedence that stood before Orca joined, cmux last claiming nothing — and product facts belong in packages, beside the three managers whose entries the registry builds itself, mirroring how agents are one entry in `registrations.ts`. Superset sits *above* providers in the package graph, so its entry is handed in by the desktop app: the entry shape is `{ observationFailureLabel, read(): Promise<WorkspaceHostEnrichment>, emptyEnrichment }`, so per-manager inputs (Superset's active organization, its adapter refresh, its directory-match adoption) ride inside its own `read` closure rather than through any stringly-typed channel, and the graph stays acyclic.

`desktop-app.ts` now reads all hosts in one loop (each failure absorbed into that host's empty enrichment, same stderr lines as before) and applies them with one fold, replacing the four copy-pasted `read().catch()` blocks and the hand-nested `cmux(orca(conductor(superset(...))))` chain. Adding a manager is now one registry entry.

## Behavior

None moved. The fold applies registrations in declaration order, so the enriched observations are identical to the old nesting for the same inputs; the precedence rationale comment moved onto the registry declaration. The `SessionProviderAdapter` interface, composite adapter, `adapterFor`, `offeredWorkspaceProjects`, and all trust-constraint behavior are untouched. The managers keep using `AGENT_IDENTITY` / `agentIdentityFor` from #480.

## Checks

`./scripts/check.sh` passes (repository checks, lint, typecheck, tests, builds). All 698 pre-existing provider tests pass unchanged; 4 new tests cover the registry's order, failure stand-ins, absent-app reads, and a wired read. Portable-only change: no UI moved, so no visual evidence run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32766809168/artifacts/9534804740) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32766809168)

- Commit: `b0c1a65bffe3c3b32bad7e44cd11e11870f96f30`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
