### PR TITLE
refactor(packages): import shared vocabulary from its defining packages

### DIFF
--- a/packages/account/src/client.test.ts
+++ b/packages/account/src/client.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { JsonValue } from "@sidecar/wire/testing";
-import { ACCOUNT_PROVIDER } from "../../../apps/desktop/src/shared/contracts.js";
 import { AccountClient, AccountClientError, type FetchLike } from "./client.js";
+import { ACCOUNT_PROVIDER } from "./snapshot.js";
 
 function json(body: JsonValue, status = 200): Response {
   return new Response(JSON.stringify(body), {

--- a/packages/account/src/client.ts
+++ b/packages/account/src/client.ts
@@ -5,7 +5,7 @@ import {
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
-import type { AccountProvider } from "../../../apps/desktop/src/shared/contracts.js";
+import type { AccountProvider } from "./snapshot.js";
 
 export interface AccountTokens {
   accessToken: string;

--- a/packages/account/src/loopback.test.ts
+++ b/packages/account/src/loopback.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { ACCOUNT_PROVIDER } from "../../../apps/desktop/src/shared/contracts.js";
 import { startAccountLoopback } from "./loopback.js";
+import { ACCOUNT_PROVIDER } from "./snapshot.js";
 
 test("a mismatched state is refused without consuming the callback", async () => {
   const loopback = await startAccountLoopback({ timeoutMs: 2_000 });

--- a/packages/account/src/loopback.ts
+++ b/packages/account/src/loopback.ts
@@ -7,7 +7,7 @@ import {
   createCodeVerifier,
   LOOPBACK_PAGE_TONE,
 } from "@sidecar/oauth";
-import type { AccountProvider } from "../../../apps/desktop/src/shared/contracts.js";
+import type { AccountProvider } from "./snapshot.js";
 
 const CALLBACK_PATH = "/callback";
 const LOOPBACK_HOST = "127.0.0.1";

--- a/packages/account/src/session-manager.test.ts
+++ b/packages/account/src/session-manager.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { ACCOUNT_PROVIDER, ACCOUNT_STATUS } from "../../../apps/desktop/src/shared/contracts.js";
 import type { AccountClient, StoredAccount } from "./client.js";
 import { AccountSessionManager } from "./session-manager.js";
+import { ACCOUNT_PROVIDER, ACCOUNT_STATUS } from "./snapshot.js";
 
 const STORED: StoredAccount = {
   accessToken: "access",

--- a/packages/account/src/session-manager.ts
+++ b/packages/account/src/session-manager.ts
@@ -1,9 +1,4 @@
 import { singleFlight } from "@sidecar/oauth";
-import {
-  ACCOUNT_STATUS,
-  type AccountProvider,
-  type AccountSnapshot,
-} from "../../../apps/desktop/src/shared/contracts.js";
 import type { AccountClient, AccountIdentity, AccountTokens, StoredAccount } from "./client.js";
 import { deleteHostedAccount } from "./deletion.js";
 import { ACCOUNT_FAILURE_ACTION, accessTokenNeedsRefresh, accountFailureAction } from "./gate.js";
@@ -12,6 +7,7 @@ import {
   SIGN_IN_CANCELLED_MESSAGE,
   startAccountLoopback,
 } from "./loopback.js";
+import { ACCOUNT_STATUS, type AccountProvider, type AccountSnapshot } from "./snapshot.js";
 import { withIssuedAccountTokens } from "./token-lifecycle.js";
 
 export interface AccountSessionStore {

--- a/packages/calendar/src/reader.ts
+++ b/packages/calendar/src/reader.ts
@@ -13,15 +13,12 @@ import {
   unparsedWire,
   type WireValue,
 } from "@sidecar/wire";
-import type {
-  AccountCalendar,
-  ObservedAccountCalendars,
-} from "../../../apps/desktop/src/shared/contracts.js";
 import {
   GOOGLE_TOKEN_URL,
   type GoogleCalendarSignInConfig,
   googleCalendarSignInConfig,
 } from "./oauth.js";
+import type { AccountCalendar, ObservedAccountCalendars } from "./observation.js";
 
 /**
  * The two reads a signed-in calendar account answers, both fixed by this

--- a/packages/superset/src/sign-in.test.ts
+++ b/packages/superset/src/sign-in.test.ts
@@ -6,9 +6,9 @@ import path from "node:path";
 import { PassThrough } from "node:stream";
 import test, { type TestContext } from "node:test";
 import { isRecord, text, type UnparsedWireValue } from "@sidecar/wire";
-import { SUPERSET_SIGN_IN_STAGE } from "../../../apps/desktop/src/shared/contracts.js";
 import { SupersetCli } from "./cli.js";
 import { SupersetSignIn, validSupersetSignInCode } from "./sign-in.js";
+import { SUPERSET_SIGN_IN_STAGE } from "./sign-in-stage.js";
 
 class FakeChild extends EventEmitter {
   readonly stdin = new PassThrough();

--- a/packages/superset/src/sign-in.ts
+++ b/packages/superset/src/sign-in.ts
@@ -1,9 +1,6 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
-import {
-  SUPERSET_SIGN_IN_STAGE,
-  type SupersetSignInSnapshot,
-} from "../../../apps/desktop/src/shared/contracts.js";
 import type { SupersetCli } from "./cli.js";
+import { SUPERSET_SIGN_IN_STAGE, type SupersetSignInSnapshot } from "./sign-in-stage.js";
 
 const SIGN_IN_TIMEOUT_MS = 3 * 60_000;
 const OUTPUT_TAIL_LIMIT = 16_384;

--- a/packages/voice/src/capability-assembler.test.ts
+++ b/packages/voice/src/capability-assembler.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { APP_SETTING_SCHEMA } from "@sidecar/settings";
-import { VOICE_SOURCE } from "../../../apps/desktop/src/shared/contracts.js";
+import { APP_SETTING_SCHEMA, VOICE_SOURCE } from "@sidecar/settings";
 import {
   resolveVoiceCapability,
   VoiceCapabilityAssembler,

--- a/packages/voice/src/capability-assembler.ts
+++ b/packages/voice/src/capability-assembler.ts
@@ -3,8 +3,13 @@ import { VOICE_CREDENTIAL_PROVIDER_ID } from "@sidecar/credentials";
 import { HOSTED_SERVICE_PATH, HostedAttentionEvaluator } from "@sidecar/hosted";
 import { type RealtimeDiagnostics, realtimeMintExplanation } from "@sidecar/realtime";
 import type { NormalizedSession, SessionIdentity } from "@sidecar/session";
-import { APP_SETTING_SCHEMA, type AppSettingField, type AppSettingValue } from "@sidecar/settings";
-import { VOICE_SOURCE, type VoiceSource } from "../../../apps/desktop/src/shared/contracts.js";
+import {
+  APP_SETTING_SCHEMA,
+  type AppSettingField,
+  type AppSettingValue,
+  VOICE_SOURCE,
+  type VoiceSource,
+} from "@sidecar/settings";
 import { HostedRealtimeCredentialMinter } from "./hosted-credentials.js";
 import type { RealtimeCredentialMinter } from "./minter.js";
 import { openAiRealtimeCredentials, unavailableRealtimeDiagnostics } from "./openai-credentials.js";

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -154,6 +154,19 @@ if [[ -n "$extensionless_imports" ]]; then
     exit 1
 fi
 
+# Packages must not reach into apps: the dependency points the other way, and
+# a relative path into apps/ evades the declared package graph, so typecheck
+# resolves it without seeing the package → app → package cycle it creates.
+# Every name the app re-exports originates in a package; import it from the
+# defining package instead.
+package_app_imports=$(grep -rEn '(from|import) "[^"]*apps/[^"]*"' \
+    "$SIDECAR_REPO_ROOT"/packages/*/src || true)
+if [[ -n "$package_app_imports" ]]; then
+    printf 'error: packages must not import from apps/ (the path import hides a package → app → package cycle from the declared dependency graph):\n%s\n' \
+        "$package_app_imports" >&2
+    exit 1
+fi
+
 # The renderer is a sandboxed browser context: it reaches the main process
 # through the preload bridge alone, so `#shared/bridge` and `#shared/wire/*`
 # are its widest doors. A `#main/` import compiles and bundles happily and then fails in the


### PR DESCRIPTION
## What

Closes the remaining package → app imports: several files under `packages/` imported names from `apps/desktop/src/shared/contracts.js` by relative path. Every one of those names originates in a package and is merely re-exported by contracts.ts, so each import was a hidden package → app → package cycle that typecheck could not see, because a path import bypasses the declared dependency graph. Follows #479 and #481, which closed the superset/workspaces and superset/vocabulary instances.

## Repointed files

- `packages/account/src/client.ts`, `loopback.ts`, `session-manager.ts` and their `.test.ts` files (`client.test.ts`, `loopback.test.ts`, `session-manager.test.ts`): `AccountProvider`, `ACCOUNT_STATUS`, `ACCOUNT_PROVIDER`, `AccountSnapshot` now come from `./snapshot.js`, the defining module in the same package.
- `packages/calendar/src/reader.ts`: `AccountCalendar`, `ObservedAccountCalendars` now come from `./observation.js`.
- `packages/superset/src/sign-in.ts` and `sign-in.test.ts`: `SUPERSET_SIGN_IN_STAGE`, `SupersetSignInSnapshot` now come from `./sign-in-stage.js`.
- `packages/voice/src/capability-assembler.ts` and its test: `VOICE_SOURCE`, `VoiceSource` now come from `@sidecar/settings`, folded into the settings import both files already carried.

## The voice → settings edge

`@sidecar/voice` already declares `@sidecar/settings` in its dependencies and imports its barrel in these very files, so no `package.json` change was needed; settings does not depend on voice, so the graph stays acyclic. The re-exports in `apps/desktop/src/shared/contracts.ts` are untouched — app code importing from contracts remains fine; only the packages → apps direction is closed.

## The new repository check

`scripts/repository-checks.sh` gains a check in the style of the existing `.js`-suffix rule: it greps every `packages/*/src` file (tests included) for an import whose specifier contains `apps/` and fails with an error stating the rule — packages must not import from apps, because the path import hides a package → app → package cycle from the declared dependency graph. Verified to pass on this branch and to fail (exit 1, naming the offending line) on a synthetic violation.

## Validation

`./scripts/check.sh` passes end to end (repository checks, typecheck, all workspace tests, web and desktop builds). Portable-only change; no UI touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32773516079/artifacts/9537173817) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32773516079)

- Commit: `753a088feed426da43384a0af7055a58dec0ffaa`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
