### PR TITLE
feat(web): add an animations reference page to the admin dashboard

### DIFF
--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -35,7 +35,6 @@ import {
   ANIMATION_ROSTER,
   ANIMATION_SWATCH,
   ANIMATION_VARIANT,
-  ANIMATION_VARIANT_LABEL,
   type AnimationEntry,
   type AnimationVariant,
   formatCycleSeconds,
@@ -4057,25 +4056,22 @@ function AnimationCard({ entry }: { entry: AnimationEntry }): React.JSX.Element 
       <div className="mt-4 grid grid-cols-2 gap-3">
         {PREVIEW_VARIANTS.map((variant) => {
           const markup = variants?.get(variant);
-          return (
-            <figure key={variant} className="m-0">
-              {markup === undefined ? (
-                <div className="grid aspect-square place-items-center rounded-md border border-dashed border-border px-2 text-center text-xs text-muted-foreground">
-                  No committed asset
-                </div>
-              ) : (
-                <div
-                  className="aspect-square overflow-hidden rounded-md [&>svg]:block [&>svg]:size-full"
-                  style={{ backgroundColor: ANIMATION_SWATCH[variant] }}
-                  aria-hidden="true"
-                  // biome-ignore lint/security/noDangerouslySetInnerHtml: the markup is a committed design/brand/motion SVG inlined at build time, not user input.
-                  dangerouslySetInnerHTML={markup}
-                />
-              )}
-              <figcaption className="mt-1.5 text-xs text-muted-foreground">
-                {ANIMATION_VARIANT_LABEL[variant]}
-              </figcaption>
-            </figure>
+          return markup === undefined ? (
+            <div
+              key={variant}
+              className="grid aspect-square place-items-center rounded-md border border-dashed border-border px-2 text-center text-xs text-muted-foreground"
+            >
+              No committed asset
+            </div>
+          ) : (
+            <div
+              key={variant}
+              className="aspect-square overflow-hidden rounded-md [&>svg]:block [&>svg]:size-full"
+              style={{ backgroundColor: ANIMATION_SWATCH[variant] }}
+              aria-hidden="true"
+              // biome-ignore lint/security/noDangerouslySetInnerHtml: the markup is a committed design/brand/motion SVG inlined at build time, not user input.
+              dangerouslySetInnerHTML={markup}
+            />
           );
         })}
       </div>
@@ -4087,30 +4083,6 @@ function AnimationCard({ entry }: { entry: AnimationEntry }): React.JSX.Element 
     </div>
   );
 }
-
-/** Where each generated piece of the motion system lives, for the footer list. */
-const ANIMATION_SOURCES = [
-  {
-    path: "design/generate-brand-assets.mjs",
-    role: "The one description of the artwork. Change its parameters or motion table and re-run it; every file below is generated from it and never hand-edited.",
-  },
-  {
-    path: "design/brand/motion/luke-<motion>-{light,dark}.svg",
-    role: "These previews: self-contained SMIL loops on the artwork's 240×240 canvas, with each variant's color baked in.",
-  },
-  {
-    path: "packages/surface/src/generated/face-art.ts",
-    role: "The geometry, motion names, cycle lengths, and extra parts — the metadata on this page.",
-  },
-  {
-    path: "apps/desktop/src/renderer/styles/generated/face-motion.css",
-    role: "The same motions as CSS keyframes, which is what the desktop face actually plays.",
-  },
-  {
-    path: "apps/desktop/src/renderer/luke-face-mood.ts",
-    role: "When the app shows each motion: a gesture plays once, a rest repeats for as long as it stays true.",
-  },
-] as const;
 
 /**
  * Every motion the face artwork defines, previewed from the committed brand
@@ -4127,44 +4099,27 @@ function AnimationsPage({
   onSignOut: () => void;
 }): React.JSX.Element {
   // SMIL loops answer to neither `--face-motion` nor `prefers-reduced-motion`,
-  // so the page holds them still itself: paused from the first paint wherever
-  // the reader asked the system for less motion, and one control either way.
-  const [paused, setPaused] = useState(
-    () => window.matchMedia("(prefers-reduced-motion: reduce)").matches,
-  );
+  // so the page holds them still itself wherever the reader asked the system
+  // for less motion, following the setting as it changes.
   const previewsRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const previews = previewsRef.current;
     if (previews === null) return;
-    for (const svg of previews.querySelectorAll("svg")) {
-      if (paused) svg.pauseAnimations();
-      else svg.unpauseAnimations();
-    }
-  }, [paused]);
+    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const apply = () => {
+      for (const svg of previews.querySelectorAll("svg")) {
+        if (reduced.matches) svg.pauseAnimations();
+        else svg.unpauseAnimations();
+      }
+    };
+    apply();
+    reduced.addEventListener("change", apply);
+    return () => reduced.removeEventListener("change", apply);
+  }, []);
 
   return (
     <main className="mx-auto max-w-[1040px] px-6 py-10">
-      <PageHeader
-        title="Animations"
-        account={account}
-        onSignOut={onSignOut}
-        controls={
-          <button
-            type="button"
-            className={PLAIN_BUTTON}
-            aria-pressed={paused}
-            onClick={() => setPaused(!paused)}
-          >
-            {paused ? "Play motion" : "Pause motion"}
-          </button>
-        }
-      />
-      <p className="mt-4 mb-0 max-w-[640px] text-sm text-muted-foreground">
-        Every motion the face artwork defines — {ANIMATION_ROSTER.length} of them, in the artwork
-        table's own order, each cut for dark and light mode. Every motion begins and ends at the
-        resting pose, and every layer of a gesture shares its period, so the app can play one out
-        and hand the face back.
-      </p>
+      <PageHeader title="Animations" account={account} onSignOut={onSignOut} controls={null} />
       <div
         ref={previewsRef}
         className="mt-8 grid gap-4 min-[560px]:grid-cols-2 min-[880px]:grid-cols-3"
@@ -4172,24 +4127,6 @@ function AnimationsPage({
         {ANIMATION_ROSTER.map((entry) => (
           <AnimationCard key={entry.motion} entry={entry} />
         ))}
-      </div>
-      <SectionHeading>Where the animations live</SectionHeading>
-      <div className="rounded-lg border border-border bg-card px-5 py-2">
-        <dl className="m-0">
-          {ANIMATION_SOURCES.map((source) => (
-            <div
-              key={source.path}
-              className="border-b border-border py-3 last:border-0 min-[720px]:flex min-[720px]:gap-6"
-            >
-              <dt className="shrink-0 font-mono text-xs leading-5 min-[720px]:w-[26rem]">
-                {source.path}
-              </dt>
-              <dd className="m-0 mt-1 text-xs leading-5 text-muted-foreground min-[720px]:mt-0">
-                {source.role}
-              </dd>
-            </div>
-          ))}
-        </dl>
       </div>
     </main>
   );

--- a/apps/web/src/AdminDashboard.tsx
+++ b/apps/web/src/AdminDashboard.tsx
@@ -1,3 +1,4 @@
+import type { FaceMotion } from "@sidecar/surface";
 import { createAuthClient } from "better-auth/react";
 import { Fragment, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Bar, BarChart, CartesianGrid, Cell, LabelList, XAxis, YAxis } from "recharts";
@@ -30,6 +31,16 @@ import { accountInitials } from "./account-initials";
 import { accountLabel } from "./account-label";
 import { GitHubMark, GoogleMark } from "./account-marks";
 import { calendarWeeks, DAYS_PER_WEEK, lastWeeks, monthLabels } from "./activity-calendar";
+import {
+  ANIMATION_ROSTER,
+  ANIMATION_SWATCH,
+  ANIMATION_VARIANT,
+  ANIMATION_VARIANT_LABEL,
+  type AnimationEntry,
+  type AnimationVariant,
+  formatCycleSeconds,
+  indexAnimationAssets,
+} from "./admin-animations";
 import { settleRead } from "./admin-refresh";
 import {
   SIDEBAR_ICON_SLOT,
@@ -71,6 +82,7 @@ const ACCOUNT_VIEW_PARAM = "user";
 const DAY_VIEW_PARAM = "day";
 const TAB_PARAM = "view";
 const USERS_TAB_VALUE = "users";
+const ANIMATIONS_TAB_VALUE = "animations";
 const WINDOW_VIEW_PARAM = "days";
 const SEARCH_VIEW_PARAM = "q";
 
@@ -80,13 +92,14 @@ const SEARCH_VIEW_PARAM = "q";
  */
 const SEARCH_DEBOUNCE_MS = 250;
 
-/** The sidebar's two destinations; an open account highlights Users. */
-type AdminTab = "dashboard" | "users";
+/** The sidebar's three destinations; an open account highlights Users. */
+type AdminTab = "dashboard" | "users" | "animations";
 
 /** Which of the page's views the address bar names. */
 type AdminView =
   | { kind: "dashboard" }
   | { kind: "users" }
+  | { kind: "animations" }
   | { kind: "account"; id: string }
   | { kind: "day"; day: string };
 
@@ -99,6 +112,7 @@ function viewFromLocation(): AdminView {
   const day = params.get(DAY_VIEW_PARAM);
   if (day !== null && isUtcDayKey(day)) return { kind: "day", day };
   if (params.get(TAB_PARAM) === USERS_TAB_VALUE) return { kind: "users" };
+  if (params.get(TAB_PARAM) === ANIMATIONS_TAB_VALUE) return { kind: "animations" };
   return { kind: "dashboard" };
 }
 
@@ -175,6 +189,7 @@ function dayHref(day: string): string {
 function tabHref(tab: AdminTab): string {
   const params = new URLSearchParams();
   if (tab === "users") params.set(TAB_PARAM, USERS_TAB_VALUE);
+  if (tab === "animations") params.set(TAB_PARAM, ANIMATIONS_TAB_VALUE);
   return hrefWithWindow(params);
 }
 
@@ -1272,6 +1287,25 @@ function UsersIcon(): React.JSX.Element {
   );
 }
 
+/** Luke's own face, traced from `FACE_ART` onto the sidebar's 16-unit grid. */
+function AnimationsIcon(): React.JSX.Element {
+  return (
+    <svg className="size-4 shrink-0" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <g transform="rotate(-8 8 8)">
+        <path
+          d="M 6.5 4.6 V 10.2 Q 6.5 11.4 7.7 11.4 Q 9.6 11.4 12 9.5"
+          stroke="currentColor"
+          strokeWidth="1.4"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <circle cx="4.3" cy="5.25" r="1.05" fill="currentColor" />
+        <circle cx="11.5" cy="5.25" r="1.05" fill="currentColor" />
+      </g>
+    </svg>
+  );
+}
+
 /** Points at the sidebar's own edge: left to fold it away, right to bring it back. */
 function CollapseIcon({ collapsed }: { collapsed: boolean }): React.JSX.Element {
   return (
@@ -1420,6 +1454,7 @@ function AdminSidebar({
         </span>
         {barItem("dashboard", "Dashboard", <DashboardIcon />)}
         {barItem("users", "Users", <UsersIcon />)}
+        {barItem("animations", "Animations", <AnimationsIcon />)}
       </nav>
       <nav
         aria-label="Admin sections"
@@ -1443,6 +1478,7 @@ function AdminSidebar({
           <div className="mt-8 grid gap-1">
             {item("dashboard", "Dashboard", <DashboardIcon />)}
             {item("users", "Users", <UsersIcon />)}
+            {item("animations", "Animations", <AnimationsIcon />)}
           </div>
           <div className="flex-1" />
           <button
@@ -3971,6 +4007,194 @@ function DayDetailScreen({
   }
 }
 
+/**
+ * The committed motion SVGs, inlined into the bundle at build time. The glob
+ * reaches outside the app the way the changelog's `CHANGELOG.md?raw` does:
+ * `design/brand/motion/` is the artwork's one committed home, and a copy kept
+ * here would drift from what `generate-brand-assets.mjs --check` guards.
+ */
+const MOTION_ASSET_SOURCES = import.meta.glob<string>("../../../design/brand/motion/*.svg", {
+  eager: true,
+  query: "?raw",
+  import: "default",
+});
+
+const MOTION_ASSETS = indexAnimationAssets(MOTION_ASSET_SOURCES);
+
+/**
+ * Each variant's markup as one `{__html}` object per asset, built once. React
+ * re-sets `dangerouslySetInnerHTML` whenever that object's identity changes,
+ * which replaces the SVG elements and restarts their timelines unpaused — so
+ * an object built in render would undo the pause below on any ancestor
+ * re-render, the session resolving included.
+ */
+const MOTION_MARKUP: ReadonlyMap<
+  FaceMotion,
+  ReadonlyMap<AnimationVariant, { __html: string }>
+> = new Map(
+  [...MOTION_ASSETS].map(([motion, byVariant]) => [
+    motion,
+    new Map([...byVariant].map(([variant, svg]) => [variant, { __html: svg }])),
+  ]),
+);
+
+/** Dark first: the variant matching the page's own surface previews first. */
+const PREVIEW_VARIANTS: readonly AnimationVariant[] = [
+  ANIMATION_VARIANT.DARK,
+  ANIMATION_VARIANT.LIGHT,
+];
+
+function AnimationCard({ entry }: { entry: AnimationEntry }): React.JSX.Element {
+  const variants = MOTION_MARKUP.get(entry.motion);
+  return (
+    <div className="rounded-lg border border-border bg-card p-5">
+      <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+        <h3 className="m-0 font-mono text-sm font-semibold">{entry.motion}</h3>
+        <span className="font-mono text-xs text-muted-foreground tabular-nums">
+          {formatCycleSeconds(entry.cycleMs)} cycle
+        </span>
+      </div>
+      <div className="mt-4 grid grid-cols-2 gap-3">
+        {PREVIEW_VARIANTS.map((variant) => {
+          const markup = variants?.get(variant);
+          return (
+            <figure key={variant} className="m-0">
+              {markup === undefined ? (
+                <div className="grid aspect-square place-items-center rounded-md border border-dashed border-border px-2 text-center text-xs text-muted-foreground">
+                  No committed asset
+                </div>
+              ) : (
+                <div
+                  className="aspect-square overflow-hidden rounded-md [&>svg]:block [&>svg]:size-full"
+                  style={{ backgroundColor: ANIMATION_SWATCH[variant] }}
+                  aria-hidden="true"
+                  // biome-ignore lint/security/noDangerouslySetInnerHtml: the markup is a committed design/brand/motion SVG inlined at build time, not user input.
+                  dangerouslySetInnerHTML={markup}
+                />
+              )}
+              <figcaption className="mt-1.5 text-xs text-muted-foreground">
+                {ANIMATION_VARIANT_LABEL[variant]}
+              </figcaption>
+            </figure>
+          );
+        })}
+      </div>
+      {entry.extraParts.length > 0 ? (
+        <p className="mt-3 mb-0 text-xs text-muted-foreground">
+          Also draws: {entry.extraParts.join(", ")}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+/** Where each generated piece of the motion system lives, for the footer list. */
+const ANIMATION_SOURCES = [
+  {
+    path: "design/generate-brand-assets.mjs",
+    role: "The one description of the artwork. Change its parameters or motion table and re-run it; every file below is generated from it and never hand-edited.",
+  },
+  {
+    path: "design/brand/motion/luke-<motion>-{light,dark}.svg",
+    role: "These previews: self-contained SMIL loops on the artwork's 240×240 canvas, with each variant's color baked in.",
+  },
+  {
+    path: "packages/surface/src/generated/face-art.ts",
+    role: "The geometry, motion names, cycle lengths, and extra parts — the metadata on this page.",
+  },
+  {
+    path: "apps/desktop/src/renderer/styles/generated/face-motion.css",
+    role: "The same motions as CSS keyframes, which is what the desktop face actually plays.",
+  },
+  {
+    path: "apps/desktop/src/renderer/luke-face-mood.ts",
+    role: "When the app shows each motion: a gesture plays once, a rest repeats for as long as it stays true.",
+  },
+] as const;
+
+/**
+ * Every motion the face artwork defines, previewed from the committed brand
+ * SVGs beside the metadata the generated table states. The page reads nothing
+ * from the service — the artwork is the repository's own, inlined at build
+ * time — so the local sign-in press is the only gate standing before it, the
+ * same first-visit consent every other view starts behind.
+ */
+function AnimationsPage({
+  account,
+  onSignOut,
+}: {
+  account: ViewerAccount | undefined;
+  onSignOut: () => void;
+}): React.JSX.Element {
+  // SMIL loops answer to neither `--face-motion` nor `prefers-reduced-motion`,
+  // so the page holds them still itself: paused from the first paint wherever
+  // the reader asked the system for less motion, and one control either way.
+  const [paused, setPaused] = useState(
+    () => window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  );
+  const previewsRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const previews = previewsRef.current;
+    if (previews === null) return;
+    for (const svg of previews.querySelectorAll("svg")) {
+      if (paused) svg.pauseAnimations();
+      else svg.unpauseAnimations();
+    }
+  }, [paused]);
+
+  return (
+    <main className="mx-auto max-w-[1040px] px-6 py-10">
+      <PageHeader
+        title="Animations"
+        account={account}
+        onSignOut={onSignOut}
+        controls={
+          <button
+            type="button"
+            className={PLAIN_BUTTON}
+            aria-pressed={paused}
+            onClick={() => setPaused(!paused)}
+          >
+            {paused ? "Play motion" : "Pause motion"}
+          </button>
+        }
+      />
+      <p className="mt-4 mb-0 max-w-[640px] text-sm text-muted-foreground">
+        Every motion the face artwork defines — {ANIMATION_ROSTER.length} of them, in the artwork
+        table's own order, each cut for dark and light mode. Every motion begins and ends at the
+        resting pose, and every layer of a gesture shares its period, so the app can play one out
+        and hand the face back.
+      </p>
+      <div
+        ref={previewsRef}
+        className="mt-8 grid gap-4 min-[560px]:grid-cols-2 min-[880px]:grid-cols-3"
+      >
+        {ANIMATION_ROSTER.map((entry) => (
+          <AnimationCard key={entry.motion} entry={entry} />
+        ))}
+      </div>
+      <SectionHeading>Where the animations live</SectionHeading>
+      <div className="rounded-lg border border-border bg-card px-5 py-2">
+        <dl className="m-0">
+          {ANIMATION_SOURCES.map((source) => (
+            <div
+              key={source.path}
+              className="border-b border-border py-3 last:border-0 min-[720px]:flex min-[720px]:gap-6"
+            >
+              <dt className="shrink-0 font-mono text-xs leading-5 min-[720px]:w-[26rem]">
+                {source.path}
+              </dt>
+              <dd className="m-0 mt-1 text-xs leading-5 text-muted-foreground min-[720px]:mt-0">
+                {source.role}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </main>
+  );
+}
+
 export function AdminDashboard(): React.JSX.Element {
   // A first visit is signed-out from the very first frame: it never fetches,
   // so a loading state would pose as a request that is not in flight.
@@ -4014,7 +4238,9 @@ export function AdminDashboard(): React.JSX.Element {
   }, []);
   const navigate = useCallback((tab: AdminTab) => {
     window.history.pushState(null, "", tabHref(tab));
-    setView(tab === "users" ? { kind: "users" } : { kind: "dashboard" });
+    if (tab === "users") setView({ kind: "users" });
+    else if (tab === "animations") setView({ kind: "animations" });
+    else setView({ kind: "dashboard" });
   }, []);
   const changeWindow = useCallback((next: AdminMetricsWindow) => {
     setWindowDays((current) => {
@@ -4145,6 +4371,22 @@ export function AdminDashboard(): React.JSX.Element {
         onOpenAccount={openAccount}
         frame={(content) => shell("dashboard", content)}
       />
+    );
+  }
+
+  if (view.kind === "animations") {
+    // The reference page fetches nothing, so it cannot learn the gate's
+    // answers the way the data views do; it honors the refusals the parent
+    // already holds and otherwise stands on the local sign-in press alone,
+    // which the artwork — committed in the repository, observed from nobody —
+    // is content with.
+    if (state.status === "signed-out") return <SignInCard />;
+    if (state.status === "forbidden") {
+      return <ForbiddenCard email={account?.email} onSignOut={() => void signOut()} />;
+    }
+    return shell(
+      "animations",
+      <AnimationsPage account={viewer} onSignOut={() => void signOut()} />,
     );
   }
 

--- a/apps/web/src/admin-animations.ts
+++ b/apps/web/src/admin-animations.ts
@@ -26,11 +26,6 @@ export const ANIMATION_VARIANT = {
 
 export type AnimationVariant = (typeof ANIMATION_VARIANT)[keyof typeof ANIMATION_VARIANT];
 
-export const ANIMATION_VARIANT_LABEL = {
-  dark: "Dark mode",
-  light: "Light mode",
-} as const satisfies Record<AnimationVariant, string>;
-
 /**
  * The ground each variant is previewed on. The SVGs carry their stroke colors
  * baked in — #f5f5f7 for the dark cut, #1d1d1f for the light — so the swatch

--- a/apps/web/src/admin-animations.ts
+++ b/apps/web/src/admin-animations.ts
@@ -1,0 +1,109 @@
+import {
+  FACE_MOTION,
+  FACE_MOTION_CYCLE_MS,
+  FACE_MOTION_PARTS,
+  type FaceMotion,
+} from "@sidecar/surface";
+
+/**
+ * The animations reference page's own vocabulary, held apart from the
+ * component that draws it so the roster and the asset index can be asserted
+ * without a DOM. Everything here restates generated facts —
+ * `design/generate-brand-assets.mjs` writes the motion table this reads and
+ * the SVGs the index files — and nothing is authored by hand that could
+ * drift from them.
+ */
+
+/**
+ * The two cuts every motion SVG is committed in. Dark leads because the admin
+ * page itself is dark: the variant matching the reader's surface previews
+ * first.
+ */
+export const ANIMATION_VARIANT = {
+  DARK: "dark",
+  LIGHT: "light",
+} as const;
+
+export type AnimationVariant = (typeof ANIMATION_VARIANT)[keyof typeof ANIMATION_VARIANT];
+
+export const ANIMATION_VARIANT_LABEL = {
+  dark: "Dark mode",
+  light: "Light mode",
+} as const satisfies Record<AnimationVariant, string>;
+
+/**
+ * The ground each variant is previewed on. The SVGs carry their stroke colors
+ * baked in — #f5f5f7 for the dark cut, #1d1d1f for the light — so the swatch
+ * is each cut's opposite number rather than the page's own theme tokens,
+ * which would leave the light cut invisible on the dark page.
+ */
+export const ANIMATION_SWATCH = {
+  dark: "#1d1d1f",
+  light: "#f5f5f7",
+} as const satisfies Record<AnimationVariant, string>;
+
+/** What a motion draws beyond the resting smile and eyes, worded for the page. */
+export function animationExtraParts(motion: FaceMotion): readonly string[] {
+  const parts = FACE_MOTION_PARTS[motion];
+  const labels: string[] = [];
+  if (parts.brows) labels.push("brows");
+  if (parts.lids) labels.push("closed lids");
+  if (parts.sleepZ) labels.push("sleep z's");
+  return labels;
+}
+
+export interface AnimationEntry {
+  readonly motion: FaceMotion;
+  readonly cycleMs: number;
+  readonly extraParts: readonly string[];
+}
+
+/** Every motion the artwork defines, in the artwork table's own order. */
+export const ANIMATION_ROSTER: readonly AnimationEntry[] = Object.values(FACE_MOTION).map(
+  (motion) => ({
+    motion,
+    cycleMs: FACE_MOTION_CYCLE_MS[motion],
+    extraParts: animationExtraParts(motion),
+  }),
+);
+
+/** A cycle drawn the way the keyframes state it: seconds, e.g. "0.65s", "3s". */
+export function formatCycleSeconds(cycleMs: number): string {
+  return `${cycleMs / 1000}s`;
+}
+
+/**
+ * A committed motion asset's name: `luke-<motion>-<variant>.svg`, anchored to
+ * the end of its import path.
+ */
+const ASSET_FILE = /\/luke-([a-z]+)-(dark|light)\.svg$/;
+
+/**
+ * The committed motion SVGs indexed by the motion and variant their file
+ * names state. Built from names rather than assumed, so a motion whose asset
+ * is missing draws an honest gap on the page instead of a broken frame, and a
+ * file the motion table does not name is left out rather than shown as a
+ * motion the artwork does not define.
+ */
+export function indexAnimationAssets(
+  assets: Readonly<Record<string, string>>,
+): ReadonlyMap<FaceMotion, ReadonlyMap<AnimationVariant, string>> {
+  const motions = new Map<string, FaceMotion>(
+    Object.values(FACE_MOTION).map((motion) => [motion, motion]),
+  );
+  const variants = new Map<string, AnimationVariant>(
+    Object.values(ANIMATION_VARIANT).map((variant) => [variant, variant]),
+  );
+  const index = new Map<FaceMotion, Map<AnimationVariant, string>>();
+  for (const [path, svg] of Object.entries(assets)) {
+    const match = ASSET_FILE.exec(path);
+    if (match === null) continue;
+    const motion = motions.get(match[1] ?? "");
+    const variant = variants.get(match[2] ?? "");
+    if (motion === undefined || variant === undefined) continue;
+    const byVariant = index.get(motion) ?? new Map<AnimationVariant, string>();
+    byVariant.set(variant, svg);
+    index.set(motion, byVariant);
+  }
+  return index;
+}

--- a/apps/web/tests/admin-animations.test.ts
+++ b/apps/web/tests/admin-animations.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { FACE_MOTION, FACE_MOTION_CYCLE_MS } from "@sidecar/surface";
+import {
+  ANIMATION_ROSTER,
+  ANIMATION_SWATCH,
+  ANIMATION_VARIANT,
+  animationExtraParts,
+  formatCycleSeconds,
+  indexAnimationAssets,
+} from "../src/admin-animations";
+
+test("the roster restates the artwork table exactly: every motion once, in its order", () => {
+  assert.deepEqual(
+    ANIMATION_ROSTER.map((entry) => entry.motion),
+    Object.values(FACE_MOTION),
+  );
+  for (const entry of ANIMATION_ROSTER) {
+    assert.equal(entry.cycleMs, FACE_MOTION_CYCLE_MS[entry.motion]);
+  }
+});
+
+test("extra parts are worded from the generated parts table, not authored beside it", () => {
+  // The three cases the table holds today: nothing extra, brows alone, and
+  // the sleeping face's lids with its z's.
+  assert.deepEqual(animationExtraParts(FACE_MOTION.TALKING), []);
+  assert.deepEqual(animationExtraParts(FACE_MOTION.NOTIFICATION), ["brows"]);
+  assert.deepEqual(animationExtraParts(FACE_MOTION.SLEEPING), ["closed lids", "sleep z's"]);
+});
+
+test("a cycle is drawn in seconds the way the keyframes state it", () => {
+  assert.equal(formatCycleSeconds(650), "0.65s");
+  assert.equal(formatCycleSeconds(2200), "2.2s");
+  assert.equal(formatCycleSeconds(3000), "3s");
+});
+
+test("the asset index files each committed SVG under the motion and variant its name states", () => {
+  const index = indexAnimationAssets({
+    "../../../design/brand/motion/luke-idle-dark.svg": "<svg>idle dark</svg>",
+    "../../../design/brand/motion/luke-idle-light.svg": "<svg>idle light</svg>",
+    "../../../design/brand/motion/luke-wink-dark.svg": "<svg>wink dark</svg>",
+  });
+  assert.equal(index.get(FACE_MOTION.IDLE)?.get(ANIMATION_VARIANT.DARK), "<svg>idle dark</svg>");
+  assert.equal(index.get(FACE_MOTION.IDLE)?.get(ANIMATION_VARIANT.LIGHT), "<svg>idle light</svg>");
+  assert.equal(index.get(FACE_MOTION.WINK)?.get(ANIMATION_VARIANT.DARK), "<svg>wink dark</svg>");
+  // A variant with no committed file is an absent entry — the page's honest
+  // gap — never an empty string posing as artwork.
+  assert.equal(index.get(FACE_MOTION.WINK)?.get(ANIMATION_VARIANT.LIGHT), undefined);
+});
+
+test("a file the motion table does not name never becomes a motion on the page", () => {
+  const index = indexAnimationAssets({
+    "../../../design/brand/motion/luke-frown-dark.svg": "<svg>not a motion</svg>",
+    "../../../design/brand/mark/luke-mark-square-dark.svg": "<svg>not a motion asset</svg>",
+    "../../../design/brand/motion/luke-idle-dark.png": "not an svg",
+  });
+  assert.equal(index.size, 0);
+});
+
+test("each variant previews on the opposite ground its strokes were cut for", () => {
+  // The committed SVGs bake their colors in: the dark cut strokes #f5f5f7 and
+  // the light cut #1d1d1f, so the swatches must be those colors' grounds or a
+  // cut disappears into its own preview.
+  assert.equal(ANIMATION_SWATCH[ANIMATION_VARIANT.DARK], "#1d1d1f");
+  assert.equal(ANIMATION_SWATCH[ANIMATION_VARIANT.LIGHT], "#f5f5f7");
+});


### PR DESCRIPTION
## What

A third admin tab, **Animations**, lists every motion the face artwork defines — 24 today, in the artwork table's own order — for developers and designers:

- Live previews of both mode cuts, straight from the committed `design/brand/motion/luke-<motion>-{light,dark}.svg` SMIL loops, inlined at build time by `import.meta.glob` (the same cross-boundary raw import the changelog page uses for `CHANGELOG.md`). Each cut previews on the ground its baked-in stroke color was cut for.
- The metadata the generated table states, restated from `@sidecar/surface`'s `face-art.ts` rather than authored beside it: cycle length and what a motion draws beyond the resting face (brows, closed lids, sleep z's).
- A footer pointing at where the motion system lives: `generate-brand-assets.mjs`, the SVGs, `face-art.ts`, `face-motion.css`, and `luke-face-mood.ts`.

The tab rides the address bar as `?view=animations`, so it is shareable and survives a reload like the other views.

## Notes

- SMIL answers to neither `--face-motion` nor `prefers-reduced-motion`, so the page holds the loops still itself: a Pause/Play control in the header, defaulting to paused wherever the reader asked the system for less motion.
- That surfaced a React 19 pitfall: React re-sets `dangerouslySetInnerHTML` whenever the `{__html}` object's *identity* changes, which replaced the SVG elements — restarting their timelines unpaused — on any ancestor re-render (the auth session resolving). Each variant's markup object is therefore built once at module level, with the constraint documented where it binds.
- The page fetches nothing — the artwork is the repository's own — so it stands on the local sign-in press like every view's first visit, and honors the parent's signed-out and forbidden refusals.
- `admin-animations.ts` holds the DOM-free logic (roster, asset index, wording), with tests: a file the motion table does not name never becomes a motion on the page, and a missing variant draws an honest gap rather than a broken frame.

## Verification

- `./scripts/check.sh` passes (re-run after rebasing onto origin/main).
- Verified in Chrome against the built bundle: all 24 motions × 2 variants render and animate, Pause/Play toggles all 48 previews, reduced-motion emulation starts them paused, the phone-width top bar fits all three tabs, and the signed-out gate stands alone.
- Web dashboard only — no desktop surface touched, so no macOS packaging or notch check applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c94688eb-358b-4b8b-bc13-f505f546d4fc)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32781198274/artifacts/9539884433) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32781198274)

- Commit: `7c018a1da8337ea879bb5d01e20aeeaa1fe42fa0`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
