### PR TITLE
fix(web): log the admin API's swallowed 503 causes

### DIFF
--- a/apps/web/server/admin/admin-day.ts
+++ b/apps/web/server/admin/admin-day.ts
@@ -108,7 +108,8 @@ export async function handleAdminDay(options: AdminDayOptions): Promise<Response
   let viewer: AdminViewer | undefined;
   try {
     viewer = await options.resolveViewer(request);
-  } catch {
+  } catch (error) {
+    console.error("admin day viewer resolution failed", error);
     return errorResponse(ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE, ADMIN_ERROR.UNAVAILABLE);
   }
   if (!viewer) {
@@ -129,7 +130,8 @@ export async function handleAdminDay(options: AdminDayOptions): Promise<Response
       ADMIN_HTTP_STATUS.OK,
       await options.readDay(day, now, adminMetricsScope(request.url)),
     );
-  } catch {
+  } catch (error) {
+    console.error("admin day read failed", error);
     return errorResponse(ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE, ADMIN_ERROR.UNAVAILABLE);
   }
 }

--- a/apps/web/server/admin/admin-favorite.ts
+++ b/apps/web/server/admin/admin-favorite.ts
@@ -44,7 +44,8 @@ export async function handleAdminFavorite(options: AdminFavoriteOptions): Promis
   let viewer: AdminViewer | undefined;
   try {
     viewer = await options.resolveViewer(request);
-  } catch {
+  } catch (error) {
+    console.error("admin favorite viewer resolution failed", error);
     return errorResponse(ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE, ADMIN_ERROR.UNAVAILABLE);
   }
   if (!viewer) {
@@ -65,7 +66,8 @@ export async function handleAdminFavorite(options: AdminFavoriteOptions): Promis
       return errorResponse(ADMIN_HTTP_STATUS.NOT_FOUND, ADMIN_ERROR.USER_NOT_FOUND);
     }
     return jsonResponse(ADMIN_HTTP_STATUS.OK, { favorite });
-  } catch {
+  } catch (error) {
+    console.error("admin favorite write failed", error);
     return errorResponse(ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE, ADMIN_ERROR.UNAVAILABLE);
   }
 }

--- a/apps/web/server/admin/admin-metrics.ts
+++ b/apps/web/server/admin/admin-metrics.ts
@@ -492,7 +492,8 @@ export async function handleAdminMetrics(options: AdminMetricsOptions): Promise<
   let viewer: AdminViewer | undefined;
   try {
     viewer = await options.resolveViewer(request);
-  } catch {
+  } catch (error) {
+    console.error("admin metrics viewer resolution failed", error);
     return errorResponse(ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE, ADMIN_ERROR.UNAVAILABLE);
   }
   if (!viewer) {
@@ -513,7 +514,8 @@ export async function handleAdminMetrics(options: AdminMetricsOptions): Promise<
       ADMIN_HTTP_STATUS.OK,
       await options.readMetrics(now, adminMetricsScope(request.url), windowDays),
     );
-  } catch {
+  } catch (error) {
+    console.error("admin metrics read failed", error);
     return errorResponse(ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE, ADMIN_ERROR.UNAVAILABLE);
   }
 }

--- a/apps/web/server/admin/admin-user.ts
+++ b/apps/web/server/admin/admin-user.ts
@@ -209,7 +209,8 @@ export async function handleAdminUser(options: AdminUserOptions): Promise<Respon
   let viewer: AdminViewer | undefined;
   try {
     viewer = await options.resolveViewer(request);
-  } catch {
+  } catch (error) {
+    console.error("admin user viewer resolution failed", error);
     return errorResponse(ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE, ADMIN_ERROR.UNAVAILABLE);
   }
   if (!viewer) {
@@ -236,7 +237,8 @@ export async function handleAdminUser(options: AdminUserOptions): Promise<Respon
       return errorResponse(ADMIN_HTTP_STATUS.NOT_FOUND, ADMIN_ERROR.USER_NOT_FOUND);
     }
     return jsonResponse(ADMIN_HTTP_STATUS.OK, detail);
-  } catch {
+  } catch (error) {
+    console.error("admin user read failed", error);
     return errorResponse(ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE, ADMIN_ERROR.UNAVAILABLE);
   }
 }

--- a/apps/web/server/admin/admin-users.ts
+++ b/apps/web/server/admin/admin-users.ts
@@ -127,7 +127,8 @@ export async function handleAdminUsers(options: AdminUsersOptions): Promise<Resp
   let viewer: AdminViewer | undefined;
   try {
     viewer = await options.resolveViewer(request);
-  } catch {
+  } catch (error) {
+    console.error("admin users viewer resolution failed", error);
     return errorResponse(ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE, ADMIN_ERROR.UNAVAILABLE);
   }
   if (!viewer) {
@@ -159,7 +160,8 @@ export async function handleAdminUsers(options: AdminUsersOptions): Promise<Resp
         search.term,
       ),
     );
-  } catch {
+  } catch (error) {
+    console.error("admin users read failed", error);
     return errorResponse(ADMIN_HTTP_STATUS.SERVICE_UNAVAILABLE, ADMIN_ERROR.UNAVAILABLE);
   }
 }


### PR DESCRIPTION
The admin handlers turned every thrown seam failure into a 503 JSON refusal with a bare `catch`, so when a preview's database read failed, the Vercel function logs showed nothing — we debugged a production incident blind. Each catch that answers 503 UNAVAILABLE now captures the error and logs it with `console.error` under a short stable label naming its seam (viewer resolution vs. the read or write behind it), one distinct label per catch site, before returning the same refusal. No behavior change otherwise: same status, same body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32781215446/artifacts/9539896402) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32781215446)

- Commit: `bc37430aff464d5e538f1ccaba2f9fd8953461e5`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
