### PR TITLE
fix(web): give @sidecar/acts its door in server/core.ts

### DIFF
--- a/apps/web/server/core.ts
+++ b/apps/web/server/core.ts
@@ -21,6 +21,7 @@
  * compilation alone cannot silently collide with a name a door above it
  * already exports.
  */
+import "../../../packages/acts/src/index.js";
 import "../../../packages/guide/src/index.js";
 import "../../../packages/issues/src/index.js";
 

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -154,6 +154,50 @@ if [[ -n "$extensionless_imports" ]]; then
     exit 1
 fi
 
+# Every package the web functions reach must have its own door in
+# server/core.ts. The Vercel builder compiles the TypeScript its *relative*
+# import graph reaches, but a bare `@sidecar/…` specifier it cannot follow: the
+# package's `exports` names `./src/index.js`, a file that exists only after
+# compilation, so the builder skips the package and ships functions whose
+# runtime import has nothing to resolve to. Nothing local reports the absence —
+# every toolchain in this repository substitutes the `.ts` back — so the first
+# report is FUNCTION_INVOCATION_FAILED on every deployed route, which is how
+# adding one `export * from "@sidecar/acts"` inside an already-doored package
+# took down sign-in. The closure is computed here from the doors' own bare
+# imports so the door list cannot fall behind the graph it exists to cover.
+core_doors_file="$SIDECAR_REPO_ROOT/apps/web/server/core.ts"
+doored_packages=$(grep -oE '"\.\./\.\./\.\./packages/[a-z-]+/src/index\.js"' "$core_doors_file" |
+    sed -E 's#.*/packages/([a-z-]+)/.*#\1#' | sort -u)
+reached_packages=$doored_packages
+frontier=$doored_packages
+while [[ -n "$frontier" ]]; do
+    next_frontier=""
+    for package_name in $frontier; do
+        imported=$(grep -rhoE '(from|import) "@sidecar/[a-z-]+"' \
+            "$SIDECAR_REPO_ROOT/packages/$package_name/src" --include='*.ts' \
+            --exclude='*.test.ts' 2>/dev/null |
+            sed -E 's#.*"@sidecar/([a-z-]+)"#\1#' | sort -u || true)
+        for imported_name in $imported; do
+            if ! grep -qx "$imported_name" <<<"$reached_packages"; then
+                reached_packages=$(printf '%s\n%s' "$reached_packages" "$imported_name")
+                next_frontier="$next_frontier $imported_name"
+            fi
+        done
+    done
+    frontier=$next_frontier
+done
+undoored_packages=""
+while IFS= read -r reached_name; do
+    if ! grep -qx "$reached_name" <<<"$doored_packages"; then
+        undoored_packages+="$reached_name"$'\n'
+    fi
+done <<<"$(sort -u <<<"$reached_packages")"
+if [[ -n "$undoored_packages" ]]; then
+    printf 'error: apps/web/server/core.ts is missing a door for packages its import graph reaches (the Vercel builder cannot follow bare @sidecar specifiers, so deployed functions crash at module load):\n%s\n' \
+        "$undoored_packages" >&2
+    exit 1
+fi
+
 # Packages must not reach into apps: the dependency points the other way, and
 # a relative path into apps/ evades the declared package graph, so typecheck
 # resolves it without seeing the package → app → package cycle it creates.

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -173,9 +173,9 @@ frontier=$doored_packages
 while [[ -n "$frontier" ]]; do
     next_frontier=""
     for package_name in $frontier; do
-        imported=$(grep -rhoE '(from|import) "@sidecar/[a-z-]+"' \
-            "$SIDECAR_REPO_ROOT/packages/$package_name/src" --include='*.ts' \
-            --exclude='*.test.ts' 2>/dev/null |
+        imported=$(grep -rhoE --include='*.ts' --exclude='*.test.ts' \
+            '(from|import) "@sidecar/[a-z-]+"' \
+            "$SIDECAR_REPO_ROOT/packages/$package_name/src" 2>/dev/null |
             sed -E 's#.*"@sidecar/([a-z-]+)"#\1#' | sort -u || true)
         for imported_name in $imported; do
             if ! grep -qx "$imported_name" <<<"$reached_packages"; then


### PR DESCRIPTION
## Symptom

Sign-in with Google or GitHub returns `500: INTERNAL_SERVER_ERROR / FUNCTION_INVOCATION_FAILED` on production and on dev builds. In fact **every** serverless function is down, not just auth — events, usage, voice mint, attention review, account delete, and the admin routes all crash at module load before any request handling runs; sign-in is just where it gets seen.

## Root cause

Bisected to #490 (`refactor: unify the act pipeline`), which created `packages/acts` and re-exported it from `@sidecar/realtime` as `export * from "@sidecar/acts"`.

Vercel's builder compiles every TypeScript file the functions' **relative** import graph reaches, but it cannot follow a bare `@sidecar/…` specifier: each package's `exports` names `./src/index.js`, a file that exists only after compilation, so the tracer fails the resolution (a swallowed nft warning: `Cannot find module '…/packages/realtime/node_modules/@sidecar/acts/src/index.js'`) and ships functions **without `packages/acts` compiled in** — while the runtime symlink for it is still hydrated into the bundle. Node then throws `ERR_MODULE_NOT_FOUND` for `@sidecar/acts` at module load, which Vercel reports only as `FUNCTION_INVOCATION_FAILED`.

This is the exact failure mode the doors in `apps/web/server/core.ts` exist to prevent (see #202): one relative side-effect import per package in the transitive closure, because relative paths are what the builder compiles. `acts` joined the closure without a door. No local toolchain reports the absence — tsx, tsc, Vite, and esbuild all substitute the `.ts` back — so nothing failed until deploy.

## Fix

- `apps/web/server/core.ts`: add the one-line door, `import "../../../packages/acts/src/index.js"`.
- `scripts/repository-checks.sh`: add a check that computes the `@sidecar` closure from the doors' own bare imports and fails when a reached package has no door, so the door list can never silently fall behind the graph again. Without the core.ts fix the check fails naming exactly `acts`; with it, it passes.

## Verification

Reproduced and verified offline with Vercel's own builder (`vercel build`), then loading each compiled function under plain Node with the deployment's `filePathMap` symlinks hydrated into a clean directory (the same method as #202):

- At `ea889f5` (pre-#490): auth and events **load**.
- At `474a22f` (main): auth, events, usage, voice/mint all **crash** with `Cannot find package '@sidecar/acts' imported from packages/realtime/src/realtime-tools.js`.
- With this fix: `auth/[...all]`, `events`, `usage`, `voice/mint`, `attention/review`, `account/delete`, and `admin/users` all **PASS**, and the bundle contains `packages/acts` plus its dependency symlinks in `filePathMap`.

`./scripts/check.sh` passes (exit 0). Portable-only change — no macOS or UI surface touched, so no visual evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/21049afd-75e5-4555-8d31-0bacdaefd958)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32784953799/artifacts/9541172250) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32784953799)

- Commit: `a802f1ff64914ba6a63a48dad420305629e84c25`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
