### PR TITLE
feat(desktop): draw loading rows while the roster is unread

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -3202,6 +3202,7 @@ export function App(): React.JSX.Element {
             onBeginSignIn={beginSignIn}
             {...(signInFailure ? { signInFailure } : undefined)}
             list={list}
+            sessionsSettled={sessionsSettled}
             view={sessionView}
             onViewChange={changeSessionView}
             onFiltersChange={changeSessionFilters}

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -43,6 +43,7 @@ import {
 import {
   EmptyState,
   ListeningGlyph,
+  LoadingState,
   SessionOptions,
   SessionOptionsButton,
   SessionsPanel,
@@ -765,6 +766,12 @@ export interface PanelBodyProps {
   /** Why the last sign-in ended without landing, for the gate to show. */
   signInFailure?: string;
   list: ArrangedSessions;
+  /**
+   * Whether the roster has been read at all yet. Until it has, an empty list
+   * draws loading rows rather than the empty state: an unread zero only means
+   * "not looked yet", never "nothing to watch".
+   */
+  sessionsSettled: boolean;
   view: SessionArrangement;
   onViewChange: (view: SessionArrangement) => void;
   /** Carries a toggled filter selection; unlike a view change it leaves the sheet open. */
@@ -821,6 +828,7 @@ export function PanelBody({
   onBeginSignIn,
   signInFailure,
   list,
+  sessionsSettled,
   view,
   onViewChange,
   onFiltersChange,
@@ -941,8 +949,10 @@ export function PanelBody({
                   beyondFilter={list.search.beyondFilter}
                   onWiden={() => onViewChange(widenedView(view))}
                 />
-              ) : (
+              ) : sessionsSettled ? (
                 <EmptyState />
+              ) : (
+                <LoadingState />
               )
             ) : (
               // Runs are read over the drawn order, leaving rows and all: a

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -944,15 +944,20 @@ export function PanelBody({
           ) : null}
           <div className="session-list" ref={sessionListRef}>
             {rows.length === 0 ? (
-              list.search ? (
+              // Only a roster actually read may say the list is empty: before
+              // the first reading, "nothing to watch" and "no matches" alike
+              // would claim a fact nobody has checked — a search restored at
+              // launch arrives before the roster does — so the loading rows
+              // stand in for both.
+              !sessionsSettled ? (
+                <LoadingState />
+              ) : list.search ? (
                 <SearchEmptyState
                   beyondFilter={list.search.beyondFilter}
                   onWiden={() => onViewChange(widenedView(view))}
                 />
-              ) : sessionsSettled ? (
-                <EmptyState />
               ) : (
-                <LoadingState />
+                <EmptyState />
               )
             ) : (
               // Runs are read over the drawn order, leaving rows and all: a

--- a/apps/desktop/src/renderer/session-parts.tsx
+++ b/apps/desktop/src/renderer/session-parts.tsx
@@ -1,4 +1,5 @@
 import { OptionsIcon, ProviderMark } from "@sidecar/panel";
+import { cssCustomProperties } from "@sidecar/surface/react-css";
 import { useRef } from "react";
 import { ERRAND_TARGET, errandTargetProps } from "./luke-errand";
 import { PANEL_TAB, panelPanelId, panelTabId } from "./panel-tabs";
@@ -72,6 +73,47 @@ export function EmptyState(): React.JSX.Element {
     <div className="empty-state">
       <strong>Nothing to watch yet</strong>
     </div>
+  );
+}
+
+/**
+ * As many placeholder rows as the panel usually has real ones on screen, each
+ * named by the `--row-index` it is drawn at: the slot is the row's identity,
+ * because nothing else about a placeholder tells it from its neighbours.
+ */
+const LOADING_ROW_SLOTS = [1, 2, 3] as const;
+
+/**
+ * Stands where the rows will, before the first roster reading has landed.
+ * An unread zero only means "not looked yet", so the empty state's words
+ * would claim a fact nobody has checked — the same rule the wing's badge
+ * keeps by saying it is checking rather than counting nothing. The rows
+ * pulse on `--loop-motion`, so reduced motion and capture runs hold them
+ * still like every other endless loop.
+ */
+export function LoadingState(): React.JSX.Element {
+  return (
+    <>
+      <span className="visually-hidden" role="status">
+        Checking for sessions
+      </span>
+      {LOADING_ROW_SLOTS.map((slot) => (
+        <div
+          key={slot}
+          className="session-row session-skeleton"
+          aria-hidden="true"
+          style={cssCustomProperties({ "--row-index": slot })}
+        >
+          <span className="row-mark">
+            <span className="skeleton-mark" />
+          </span>
+          <span className="row-copy">
+            <span className="skeleton-line skeleton-title" />
+            <span className="skeleton-line skeleton-detail" />
+          </span>
+        </div>
+      ))}
+    </>
   );
 }
 

--- a/apps/desktop/src/renderer/styles/sessions.css
+++ b/apps/desktop/src/renderer/styles/sessions.css
@@ -588,6 +588,51 @@ html[data-keyboard="true"] button.session-row:focus-visible {
   outline-offset: -3px;
 }
 
+/* The loading rows: the row's own card with pulsing blocks where the mark and
+   the two lines of copy will be, so what waits is the shape of what is coming.
+   Only opacity moves, in step across every block so the wait reads as one
+   object, and the loop answers `--loop-motion` like every animation with no
+   end of its own, so reduced motion and a capture hold it on one frame. The
+   widths lean on `--row-index` so the rows read as different sessions rather
+   than a repeated tile. */
+.session-skeleton .skeleton-mark,
+.session-skeleton .skeleton-line {
+  background: var(--raised-strong);
+  animation: skeleton-pulse 1500ms ease-in-out infinite;
+  animation-play-state: var(--loop-motion);
+}
+
+.session-skeleton .skeleton-mark {
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+}
+
+.session-skeleton .skeleton-line {
+  height: 10px;
+  border-radius: 5px;
+}
+
+.session-skeleton .skeleton-title {
+  width: calc(30% + var(--row-index) * 8%);
+  height: 12px;
+}
+
+.session-skeleton .skeleton-detail {
+  width: calc(66% - var(--row-index) * 7%);
+}
+
+@keyframes skeleton-pulse {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}
+
 /* The mark stands bare — no tile around it: a hairline square inside a
    hairline card would be the one box on the row carrying no information, and
    the mark's own colour and silhouette are the identification. The slot keeps a


### PR DESCRIPTION
## Summary

- While a live run's first roster reading is still on its way, an empty session list means "not looked yet" — but the panel answered it with the empty state's "Nothing to watch yet", a claim nobody had checked. The list now draws three placeholder rows in the session row's own shape (mark slot plus two copy lines, widths varied by `--row-index`) until the roster settles, gated on the same `sessionsSettled` flag the wing's badge already keeps when it says "checking" rather than counting nothing.
- The placeholder pulse is an endless loop, so per `docs/DESIGN.md` its literal period answers `--loop-motion`: reduced motion and capture runs hold it on one frame, and only opacity moves. A visually-hidden `role="status"` line says "Checking for sessions", the same wording the capsule announces.
- Fixture and capture runs are settled from the start (`desktop-app.ts` bootstraps `sessionsSettled: true` there), so the deterministic evidence PNGs can never land on the skeleton.

## Evidence

- Platform-independent checks: `./scripts/check.sh` passed (exit 0)
- macOS Electron verification (`./scripts/verify.sh`): `not run` — authored in a Linux cloud workspace; both states were rendered in headless Chromium against the built stylesheet (skeleton rows while unsettled, unchanged empty state once settled)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32788268777/artifacts/9542308302) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32788268777)

- Commit: `ceedcb7056a23d4ff466b8479a97b6f9c74529f1`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Notes

- Blockers or follow-up verification: worth one look at the pulse on a physical Mac (`./scripts/run.sh`, the first second after launch before the roster lands) — a still frame cannot prove the loop reads well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/15a9dec1-a636-4376-b16a-501516bd0ff4)
