### PR TITLE
feat(web): paint the notch mock's display with a live mesh gradient

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
     "@fontsource-variable/bricolage-grotesque": "5.3.0",
     "@fontsource-variable/geist": "5.3.0",
     "@fontsource-variable/jetbrains-mono": "5.3.0",
+    "@paper-design/shaders": "0.0.80",
     "@sidecar/attention": "workspace:*",
     "@sidecar/fixtures": "workspace:*",
     "@sidecar/panel": "workspace:*",

--- a/apps/web/src/NotchMock.tsx
+++ b/apps/web/src/NotchMock.tsx
@@ -217,12 +217,15 @@ export function NotchMock(): React.JSX.Element {
 
   // Mounted imperatively because ShaderMount owns its canvas. Reduced motion
   // holds the gradient at its first frame rather than hiding it — a still
-  // image is not motion — and a machine without WebGL throws here, leaving
-  // the frame's own gradient as the display.
+  // image is not motion — and the query is watched live, so toggling the
+  // setting mid-visit answers like the rest of the mock does. A machine
+  // without WebGL throws here, leaving the frame's own gradient as the
+  // display.
   const backdrop = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const host = backdrop.current;
     if (!host) return;
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
     let mount: ShaderMount | undefined;
     try {
       mount = new ShaderMount(
@@ -246,12 +249,17 @@ export function NotchMock(): React.JSX.Element {
           u_grainOverlay: 0,
         },
         undefined,
-        window.matchMedia("(prefers-reduced-motion: reduce)").matches ? 0 : BACKDROP_SPEED,
+        reduceMotion.matches ? 0 : BACKDROP_SPEED,
       );
     } catch {
       // Nothing to do: the backdrop div stays empty over the frame.
     }
-    return () => mount?.dispose();
+    const applySpeed = () => mount?.setSpeed(reduceMotion.matches ? 0 : BACKDROP_SPEED);
+    reduceMotion.addEventListener("change", applySpeed);
+    return () => {
+      reduceMotion.removeEventListener("change", applySpeed);
+      mount?.dispose();
+    };
   }, []);
 
   // The wing is bounded by the shape its state draws, so its mark capacity is

--- a/apps/web/src/NotchMock.tsx
+++ b/apps/web/src/NotchMock.tsx
@@ -1,3 +1,8 @@
+import {
+  getShaderColorFromString,
+  meshGradientFragmentShader,
+  ShaderMount,
+} from "@paper-design/shaders";
 import { FIXTURE_EPOCH_MS, fixtureSnapshot } from "@sidecar/fixtures";
 import {
   OptionsIcon,
@@ -102,6 +107,18 @@ const PANEL_CAPACITY = wingMarkCapacity((PANEL_WIDTH - HOUSING_WIDTH) / 2);
 const MARK_EXIT_MS = MOTION_DURATION_MS.EXIT;
 
 /**
+ * The display the mock sits in, painted by Paper's mesh gradient — bundled
+ * and pinned, so the page carries its own shader instead of fetching one at
+ * runtime. The palette runs indigo into the product's cyan with one violet
+ * spot: bright enough that the pure-black capsule and panel cut a hard
+ * silhouette, dark enough that the art stays a backdrop rather than a rival.
+ */
+const BACKDROP_COLORS = ["#0c1430", "#20308f", "#5cd5ff", "#123f6e", "#7a5cff"];
+const BACKDROP_DISTORTION = 0.85;
+const BACKDROP_SWIRL = 0.5;
+const BACKDROP_SPEED = 0.5;
+
+/**
  * `observedAgoLabel` in the renderer, read against the fixture's own epoch so
  * the page's labels match the product's evidence captures exactly.
  */
@@ -198,6 +215,45 @@ export function NotchMock(): React.JSX.Element {
   }, []);
   useEffect(() => () => observer.current?.disconnect(), []);
 
+  // Mounted imperatively because ShaderMount owns its canvas. Reduced motion
+  // holds the gradient at its first frame rather than hiding it — a still
+  // image is not motion — and a machine without WebGL throws here, leaving
+  // the frame's own gradient as the display.
+  const backdrop = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const host = backdrop.current;
+    if (!host) return;
+    let mount: ShaderMount | undefined;
+    try {
+      mount = new ShaderMount(
+        host,
+        meshGradientFragmentShader,
+        {
+          u_fit: 1,
+          u_scale: 1,
+          u_rotation: 0,
+          u_originX: 0.5,
+          u_originY: 0.5,
+          u_offsetX: 0,
+          u_offsetY: 0,
+          u_worldWidth: 0,
+          u_worldHeight: 0,
+          u_colors: BACKDROP_COLORS.map((color) => getShaderColorFromString(color)),
+          u_colorsCount: BACKDROP_COLORS.length,
+          u_distortion: BACKDROP_DISTORTION,
+          u_swirl: BACKDROP_SWIRL,
+          u_grainMixer: 0,
+          u_grainOverlay: 0,
+        },
+        undefined,
+        window.matchMedia("(prefers-reduced-motion: reduce)").matches ? 0 : BACKDROP_SPEED,
+      );
+    } catch {
+      // Nothing to do: the backdrop div stays empty over the frame.
+    }
+    return () => mount?.dispose();
+  }, []);
+
   // The wing is bounded by the shape its state draws, so its mark capacity is
   // too — and a shrinking capacity waits out the exit fade, as the renderer's
   // does, so no mark is unmounted mid-fade.
@@ -228,6 +284,7 @@ export function NotchMock(): React.JSX.Element {
             a drag cannot select text nobody can see. */}
         <div className="mock" data-mode={mode} role="img" aria-label={MOCK_LABEL} style={mockStyle}>
           <span className="mock-frame" />
+          <div className="mock-backdrop" ref={backdrop} />
 
           {/* Capsule, peek and panel are all this one shape at different sizes,
               so the surface is never cross-faded — it is only ever resized. */}

--- a/apps/web/src/notch-mock.css
+++ b/apps/web/src/notch-mock.css
@@ -147,6 +147,19 @@
   background: linear-gradient(180deg, var(--frame-top) 0%, var(--frame-bottom) 100%);
 }
 
+/* The mesh gradient that paints the display, inset one pixel so the frame's
+   hairline stays visible and stacked under the surface so everything the mock
+   draws reads against it. The host's own rule wins over ShaderMount's
+   zero-specificity `:where` styles, and the canvas inherits this radius. The
+   frame's gradient stays underneath as the display for a machine whose WebGL
+   never mounts. */
+.mock-backdrop {
+  position: absolute;
+  z-index: 0;
+  inset: 1px;
+  border-radius: 17px;
+}
+
 /* The black surface is the whole animation: one leaf element with no children
    and no text, so growing it costs a rounded-rect fill rather than a relayout
    of the panel. Capsule, peek and panel are all this one shape. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       '@fontsource-variable/jetbrains-mono':
         specifier: 5.3.0
         version: 5.3.0
+      '@paper-design/shaders':
+        specifier: 0.0.80
+        version: 0.0.80
       '@sidecar/attention':
         specifier: workspace:*
         version: link:../../packages/attention
@@ -2011,6 +2014,9 @@ packages:
   '@oxlint/plugins@1.79.0':
     resolution: {integrity: sha512-S0uyoxakDINJ4DPgqxGlEEvrdSMeQb7Z2lKVjxoY2gwsbZbfg2Xr8Klfeo5ZeraHmmdBCELFUHkSe6KEmBpMvg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@paper-design/shaders@0.0.80':
+    resolution: {integrity: sha512-pcabvt5xDlFoEhpjUj4b1tGJMfqb0i5mXifWMNQf6z7FoOJYxYDo7F8R6k0JAh5D/7ouxjX5+N0cIq5WURyQ1Q==}
 
   '@posthog/browser-common@0.5.0':
     resolution: {integrity: sha512-8DaxVZS1bQPbA514RePurLNbYjei3P4jhnC206DwVv5XThmZM3QdlsXenI2ujE3pLbgQ79hYn9o1Kda8I3WK/Q==}
@@ -5072,6 +5078,8 @@ snapshots:
     optional: true
 
   '@oxlint/plugins@1.79.0': {}
+
+  '@paper-design/shaders@0.0.80': {}
 
   '@posthog/browser-common@0.5.0':
     dependencies:


### PR DESCRIPTION
## What

The simulated Mac display behind the landing page's notch mock is now painted by Paper's mesh gradient (`@paper-design/shaders`, pinned at 0.0.80 and bundled by Vite — nothing is fetched at runtime). The palette runs indigo into the product's cyan with one violet spot, chosen from a 15-variant exploration for how hard the pure-black capsule and panel silhouette against it.

## Why

The display was a flat near-black gradient, so the black notch surface — the thing the hero exists to show — barely read against it. This lands as a standalone precursor so the follow-up hero-motion work rebases onto it.

## Behavior notes

- Reduced motion holds the gradient at its first frame (`speed 0`): a still image is not motion, so the display stays painted rather than going dark.
- A machine without WebGL leaves the backdrop unmounted and keeps the frame's existing gradient as the display.
- The shader canvas sits between the frame and the panel surface, inset one pixel so the frame's hairline border stays visible.

## Verification

- `./scripts/check.sh` passes (all suites green). Web-only change, so the macOS `verify.sh` invariant does not apply and no physical-notch check is involved.
- Visual evidence inspected via headless Chrome against the built site: capsule state, open-panel state, and a `prefers-reduced-motion` run all render the backdrop correctly with the intended contrast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32789367262/artifacts/9542649070) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32789367262)

- Commit: `982de21725b551e1d7e9ba205e76faec5c459b2f`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
