### PR TITLE
Restyle OAuth connection pages

### DIFF
--- a/apps/web/oauth-preview.html
+++ b/apps/web/oauth-preview.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark" />
+    <meta name="robots" content="noindex" />
+    <title>OAuth Page Preview</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/oauth-preview.tsx"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,7 @@
     "@fontsource-variable/geist": "5.3.0",
     "@fontsource-variable/jetbrains-mono": "5.3.0",
     "@sidecar/attention": "workspace:*",
+    "@sidecar/credentials": "workspace:*",
     "@sidecar/fixtures": "workspace:*",
     "@sidecar/panel": "workspace:*",
     "@sidecar/realtime": "workspace:*",

--- a/apps/web/src/SiteChrome.tsx
+++ b/apps/web/src/SiteChrome.tsx
@@ -1,3 +1,5 @@
+import { FACE_ART } from "@sidecar/surface";
+
 export const REPOSITORY_URL = "https://github.com/ReviewStage/luke";
 export const DMG_URL = `${REPOSITORY_URL}/releases/latest/download/Luke.dmg`;
 
@@ -29,28 +31,29 @@ export function GitHubMark({ className = "block size-4" }: MarkProps): React.JSX
 }
 
 /**
- * Luke's face, traced from `design/brand/luke-mark-{dark,light}.svg`. Those two
- * files differ only in a hard-coded stroke color, so drawing in `currentColor`
- * collapses them into one inline mark and keeps the page free of fetched
- * assets. Decorative: the wordmark beside it already says "Luke".
+ * Luke's face, drawn from the generated `FACE_ART` constants so the web mark
+ * stays tied to the product artwork. Drawing in `currentColor` keeps the page
+ * free of fetched assets. Decorative: the wordmark beside it already says
+ * "Luke".
  *
  * Wider than tall, so a caller sizes both axes and lets the default
  * `xMidYMid meet` letterbox the face inside that box rather than stretch it.
  */
 export function LukeMark({ className = "block h-[18px] w-5" }: MarkProps): React.JSX.Element {
+  const { MARK_VIEW_BOX, TILT, SMILE, STROKE_WIDTH, EYE_X, EYE_Y, EYE_RADIUS } = FACE_ART;
   return (
-    <svg className={className} viewBox="53.85 62.67 134.29 122.37" fill="none" aria-hidden="true">
-      <g transform="rotate(-8 120 124)">
+    <svg className={className} viewBox={MARK_VIEW_BOX} fill="none" aria-hidden="true">
+      <g transform={TILT}>
         <path
-          d="M 104 84 V 150 Q 104 164 118 164 Q 140 164 168 142"
+          d={SMILE}
           fill="none"
           stroke="currentColor"
-          strokeWidth="16"
+          strokeWidth={STROKE_WIDTH}
           strokeLinecap="round"
           strokeLinejoin="round"
         />
-        <circle cx="78" cy="92" r="12" fill="currentColor" />
-        <circle cx="162" cy="92" r="12" fill="currentColor" />
+        <circle cx={EYE_X.LEFT} cy={EYE_Y} r={EYE_RADIUS} fill="currentColor" />
+        <circle cx={EYE_X.RIGHT} cy={EYE_Y} r={EYE_RADIUS} fill="currentColor" />
       </g>
     </svg>
   );

--- a/apps/web/src/auth-surface.ts
+++ b/apps/web/src/auth-surface.ts
@@ -1,6 +1,6 @@
 /**
- * The card the sign-in and consent windows are drawn as. Both pages are the
- * same object at two moments of one flow, so the surface is written once here
+ * The card the sign-in and consent windows are drawn as. Both pages sit in
+ * the same dark OAuth vocabulary, so the surface is written once here
  * rather than twice at two call sites that would drift.
  *
  * Deliberately not a component: the two pages differ in what the card holds,
@@ -11,14 +11,8 @@
 /** A single card, centered in the window, with nothing else on the page. */
 export const AUTH_SHELL = "grid min-h-screen place-items-center p-6";
 
-/**
- * The shadow is the loopback page's, not the landing page's: both pages here
- * run dark (`class="dark"` on their HTML roots), where a light-page shadow at
- * a few percent black disappears, and the flow should end on the same card it
- * ran on.
- */
 export const AUTH_CARD =
-  "w-full max-w-[390px] rounded-lg border border-border bg-card px-8 py-12 text-center shadow-[0_24px_80px_rgba(0,0,0,0.42)]";
+  "w-full max-w-[430px] rounded-lg border border-border bg-card px-8 py-10 text-center shadow-[0_24px_80px_rgba(0,0,0,0.42)]";
 
 export const AUTH_TITLE = "mt-4 mb-2 text-[1.75rem] leading-[1.15] font-semibold";
 

--- a/apps/web/src/oauth-preview.tsx
+++ b/apps/web/src/oauth-preview.tsx
@@ -1,0 +1,198 @@
+import {
+  accountLoopbackPage,
+  LOOPBACK_CONNECTION_SOURCE,
+  LOOPBACK_PAGE_TONE,
+  type LoopbackPage,
+} from "@sidecar/credentials/loopback-page";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./styles.css";
+
+type PreviewLink = {
+  readonly label: string;
+  readonly href: string;
+};
+
+function pageUrl(path: string): string {
+  return path;
+}
+
+function loopbackUrl(page: LoopbackPage): string {
+  return URL.createObjectURL(
+    new Blob([accountLoopbackPage(page)], { type: "text/html;charset=utf-8" }),
+  );
+}
+
+const hostedLinks: readonly PreviewLink[] = [
+  {
+    label: "Hosted Sign-In: Google",
+    href: pageUrl("/sign-in.html?preview=1&state=google.preview"),
+  },
+  {
+    label: "Hosted Sign-In: GitHub",
+    href: pageUrl("/sign-in.html?preview=1&state=github.preview"),
+  },
+  {
+    label: "Hosted Sign-In: Missing Provider",
+    href: pageUrl("/sign-in.html"),
+  },
+  {
+    label: "Hosted Consent",
+    href: pageUrl("/consent.html"),
+  },
+];
+
+const accountLinks: readonly PreviewLink[] = [
+  {
+    label: "Signed In To Luke: Google",
+    href: loopbackUrl({
+      tone: LOOPBACK_PAGE_TONE.SETTLED,
+      badge: "Signed in",
+      title: "Signed in to Luke",
+      body: "You can close this tab and return to Luke.",
+      source: LOOPBACK_CONNECTION_SOURCE.GOOGLE,
+    }),
+  },
+  {
+    label: "Signed In To Luke: GitHub",
+    href: loopbackUrl({
+      tone: LOOPBACK_PAGE_TONE.SETTLED,
+      badge: "Signed in",
+      title: "Signed in to Luke",
+      body: "You can close this tab and return to Luke.",
+      source: LOOPBACK_CONNECTION_SOURCE.GITHUB,
+    }),
+  },
+  {
+    label: "Account: Not Verified",
+    href: loopbackUrl({
+      tone: LOOPBACK_PAGE_TONE.ATTENTION,
+      badge: "Not verified",
+      title: "Luke could not verify this sign-in",
+      body: "Return to Luke and try again.",
+      source: LOOPBACK_CONNECTION_SOURCE.GOOGLE,
+    }),
+  },
+  {
+    label: "Account: Not Completed",
+    href: loopbackUrl({
+      tone: LOOPBACK_PAGE_TONE.ATTENTION,
+      badge: "Not completed",
+      title: "Sign-in was not completed",
+      body: "Return to Luke and try again.",
+      source: LOOPBACK_CONNECTION_SOURCE.GOOGLE,
+    }),
+  },
+  {
+    label: "Account: Already Used",
+    href: loopbackUrl({
+      tone: LOOPBACK_PAGE_TONE.SETTLED,
+      badge: "Already used",
+      title: "This sign-in has already been used",
+      body: "You can close this tab and return to Luke.",
+      source: LOOPBACK_CONNECTION_SOURCE.GOOGLE,
+    }),
+  },
+];
+
+const calendarLinks: readonly PreviewLink[] = [
+  {
+    label: "Connected To Google Calendar",
+    href: loopbackUrl({
+      tone: LOOPBACK_PAGE_TONE.SETTLED,
+      badge: "Connected",
+      title: "Connected to Google Calendar",
+      body: "You can close this tab and return to Luke.",
+      source: LOOPBACK_CONNECTION_SOURCE.GOOGLE_CALENDAR,
+    }),
+  },
+  {
+    label: "Google Calendar: Not Connected",
+    href: loopbackUrl({
+      tone: LOOPBACK_PAGE_TONE.ATTENTION,
+      badge: "Not connected",
+      title: "Sign-in didn\u2019t complete",
+      body: "You can close this tab and try again from Luke.",
+      source: LOOPBACK_CONNECTION_SOURCE.GOOGLE_CALENDAR,
+    }),
+  },
+];
+
+const linearLinks: readonly PreviewLink[] = [
+  {
+    label: "Connected To Linear",
+    href: loopbackUrl({
+      tone: LOOPBACK_PAGE_TONE.SETTLED,
+      badge: "Connected",
+      title: "Connected to Linear",
+      body: "You can close this tab and return to Luke.",
+      source: LOOPBACK_CONNECTION_SOURCE.LINEAR,
+    }),
+  },
+  {
+    label: "Linear: Not Connected",
+    href: loopbackUrl({
+      tone: LOOPBACK_PAGE_TONE.ATTENTION,
+      badge: "Not connected",
+      title: "Sign-in didn\u2019t complete",
+      body: "You can close this tab and try again from Luke.",
+      source: LOOPBACK_CONNECTION_SOURCE.LINEAR,
+    }),
+  },
+];
+
+function LinkSection({
+  title,
+  links,
+}: {
+  readonly title: string;
+  readonly links: readonly PreviewLink[];
+}): React.JSX.Element {
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <h2 className="m-0 text-base font-semibold">{title}</h2>
+      <div className="mt-4 grid gap-2">
+        {links.map((link) => (
+          <a
+            key={link.label}
+            className="inline-flex min-h-11 items-center justify-center rounded-md border border-border bg-card px-4 py-2 text-sm font-semibold text-foreground no-underline transition-colors duration-150 hover:bg-muted"
+            href={link.href}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {link.label}
+          </a>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function OAuthPreview(): React.JSX.Element {
+  return (
+    <main className="mx-auto grid min-h-screen w-full max-w-[760px] content-center gap-5 p-6">
+      <header>
+        <h1 className="m-0 text-3xl leading-tight font-semibold">OAuth Page Preview</h1>
+        <p className="mt-2 mb-0 text-muted-foreground">
+          Opens each page in a new tab. Hosted sign-in links use a dev-only preview flag so they do
+          not immediately leave for the identity provider.
+        </p>
+      </header>
+      <div className="grid gap-4 min-[720px]:grid-cols-2">
+        <LinkSection title="Hosted" links={hostedLinks} />
+        <LinkSection title="Account Loopback" links={accountLinks} />
+        <LinkSection title="Calendar Loopback" links={calendarLinks} />
+        <LinkSection title="Tracker Loopback" links={linearLinks} />
+      </div>
+    </main>
+  );
+}
+
+const rootElement = document.getElementById("root");
+if (!rootElement) throw new Error("Root element is missing");
+
+createRoot(rootElement).render(
+  <StrictMode>
+    <OAuthPreview />
+  </StrictMode>,
+);

--- a/apps/web/src/sign-in.tsx
+++ b/apps/web/src/sign-in.tsx
@@ -2,10 +2,12 @@ import { oauthProviderClient } from "@better-auth/oauth-provider/client";
 import { createAuthClient } from "better-auth/react";
 import { StrictMode, useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
+import { GitHubMark, GoogleMark } from "./account-marks";
 import { captureSiteEvent, SITE_EVENT, startSiteAnalytics } from "./analytics";
 import { AUTH_BUTTON, AUTH_CARD, AUTH_SHELL, AUTH_TITLE } from "./auth-surface";
 import { LukeMark } from "./SiteChrome";
 import {
+  SOCIAL_PROVIDER,
   SOCIAL_PROVIDER_LABEL,
   type SocialProvider,
   socialProviderFromState,
@@ -21,14 +23,66 @@ function providerHint(): SocialProvider | undefined {
   return socialProviderFromState(new URLSearchParams(window.location.search).get("state"));
 }
 
+function previewMode(): boolean {
+  return import.meta.env.DEV && new URLSearchParams(window.location.search).get("preview") === "1";
+}
+
+function ProviderMark({
+  provider,
+  className,
+}: {
+  provider: SocialProvider;
+  className?: string;
+}): React.JSX.Element {
+  return provider === SOCIAL_PROVIDER.GITHUB ? (
+    <GitHubMark className={className} />
+  ) : (
+    <GoogleMark className={className} />
+  );
+}
+
+function ArrowMark(): React.JSX.Element {
+  return (
+    <svg
+      className="size-6 shrink-0 text-muted-foreground"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path
+        d="M5 12h14M13 6l6 6-6 6"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function ConnectionGraphic({ provider }: { provider: SocialProvider }): React.JSX.Element {
+  return (
+    <div
+      className="mx-auto mb-5 flex items-center justify-center gap-4 text-foreground"
+      aria-hidden="true"
+    >
+      <ProviderMark provider={provider} className="size-10 shrink-0" />
+      <ArrowMark />
+      <LukeMark className="h-auto w-12 shrink-0" />
+    </div>
+  );
+}
+
 function SignIn(): React.JSX.Element {
   const [provider] = useState(providerHint);
+  const [preview] = useState(previewMode);
   const [pending, setPending] = useState<SocialProvider>();
   const [failure, setFailure] = useState<string>();
   const startedFromHint = useRef(false);
 
   useEffect(() => {
-    if (!provider || startedFromHint.current) return;
+    if (preview || !provider || startedFromHint.current) return;
     startedFromHint.current = true;
     setPending(provider);
     captureSiteEvent(SITE_EVENT.SIGN_IN_START);
@@ -37,7 +91,7 @@ function SignIn(): React.JSX.Element {
       setPending(undefined);
       setFailure("Sign-in could not start. Try again.");
     });
-  }, [provider]);
+  }, [provider, preview]);
 
   const begin = async () => {
     if (!provider || pending) return;
@@ -57,9 +111,13 @@ function SignIn(): React.JSX.Element {
         {/* The full mark, not a pair of dots: the card is the one thing on the
             page, so it carries the same face the product and the landing page
             wear. */}
-        <div className="inline-flex w-13" aria-hidden="true">
-          <LukeMark className="h-auto w-full" />
-        </div>
+        {provider ? (
+          <ConnectionGraphic provider={provider} />
+        ) : (
+          <div className="inline-flex w-13" aria-hidden="true">
+            <LukeMark className="h-auto w-full" />
+          </div>
+        )}
         <h1 id="auth-title" className={AUTH_TITLE}>
           Sign in to Luke
         </h1>
@@ -72,10 +130,11 @@ function SignIn(): React.JSX.Element {
           <div className="mt-8 mb-4 grid gap-3">
             <button
               type="button"
-              className={AUTH_BUTTON}
+              className={`${AUTH_BUTTON} inline-flex items-center justify-center gap-2.5`}
               disabled={pending !== undefined}
               onClick={() => void begin()}
             >
+              <ProviderMark provider={provider} className="size-[15px] shrink-0" />
               {pending ? "Opening…" : `Continue with ${SOCIAL_PROVIDER_LABEL[provider]}`}
             </button>
           </div>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -135,26 +135,15 @@
   font-synthesis: none;
 }
 
-/* The sign-in and consent pages opt in with `class="dark"` on their root
-   element: they are the browser moments of the desktop sign-in, and the flow
-   ends on the loopback's dark card, so the theme holds from the first card to
-   the last instead of flashing light in the middle. The values are the
-   loopback page's own (`packages/credentials/src/loopback-page.ts`), restated
-   only for the tokens those two pages actually read — everything else stays
-   the light page's, unread here and drift waiting to happen if copied. */
+/* The admin dashboard and OAuth cards opt into this dark vocabulary. Ordinary
+   site pages use the light root tokens above. */
 .dark {
   color-scheme: dark;
 
   --background: #08090b;
   --foreground: rgba(255, 255, 255, 0.92);
 
-  /* The one value that deliberately leaves the loopback's own (#000 there):
-     the admin dashboard is a full page of card surfaces, and pure black on
-     this ground separated them by the 8%-white border alone, so an empty
-     region and a card read the same until the hairline resolved. A step
-     above the page (1.06:1) lets the grid read as raised surfaces before
-     borders do; the loopback keeps black because its single card is carried
-     by its own shadow. */
+  /* A step above the page (1.06:1) lets card surfaces read before borders do. */
   --card: #101114;
   --muted: rgba(255, 255, 255, 0.05);
   --muted-foreground: rgba(255, 255, 255, 0.56);

--- a/packages/account/src/loopback.ts
+++ b/packages/account/src/loopback.ts
@@ -5,7 +5,9 @@ import {
   accountLoopbackPage,
   codeChallenge,
   createCodeVerifier,
+  LOOPBACK_CONNECTION_SOURCE,
   LOOPBACK_PAGE_TONE,
+  type LoopbackConnectionSource,
 } from "@sidecar/credentials";
 import type { AccountProvider } from "./snapshot.js";
 
@@ -56,12 +58,21 @@ const LOOPBACK_ANSWER = {
   },
 } as const;
 
+function connectionSource(
+  provider: AccountProvider | undefined,
+): LoopbackConnectionSource | undefined {
+  if (provider === LOOPBACK_CONNECTION_SOURCE.GOOGLE) return LOOPBACK_CONNECTION_SOURCE.GOOGLE;
+  if (provider === LOOPBACK_CONNECTION_SOURCE.GITHUB) return LOOPBACK_CONNECTION_SOURCE.GITHUB;
+  return undefined;
+}
+
 function answer(
   response: ServerResponse,
   { status, page }: (typeof LOOPBACK_ANSWER)[keyof typeof LOOPBACK_ANSWER],
+  source: LoopbackConnectionSource | undefined,
 ): void {
   response.writeHead(status, { "content-type": "text/html; charset=utf-8" });
-  response.end(accountLoopbackPage(page));
+  response.end(accountLoopbackPage({ ...page, source }));
 }
 
 /**
@@ -99,6 +110,7 @@ export async function startAccountLoopback(
 ): Promise<AccountLoopback> {
   const randomState = randomBytes(32).toString("base64url");
   const state = options.providerHint ? `${options.providerHint}.${randomState}` : randomState;
+  const source = connectionSource(options.providerHint);
   const timeoutMs = options.timeoutMs ?? 5 * 60_000;
   const codeVerifier = createCodeVerifier();
   let settle: ((code: string) => void) | undefined;
@@ -115,26 +127,26 @@ export async function startAccountLoopback(
     const oauthError = url.searchParams.get("error");
     const returnedState = url.searchParams.get("state");
     if (url.pathname !== CALLBACK_PATH || returnedState !== state) {
-      answer(response, LOOPBACK_ANSWER.NOT_VERIFIED);
+      answer(response, LOOPBACK_ANSWER.NOT_VERIFIED, source);
       return;
     }
     if (accepted) {
-      answer(response, LOOPBACK_ANSWER.ALREADY_USED);
+      answer(response, LOOPBACK_ANSWER.ALREADY_USED, source);
       return;
     }
     if (oauthError) {
       accepted = true;
-      answer(response, LOOPBACK_ANSWER.NOT_COMPLETED);
+      answer(response, LOOPBACK_ANSWER.NOT_COMPLETED, source);
       reject?.(new Error(`Sign-in was not completed (${oauthError})`));
       reject = undefined;
       return;
     }
     if (!code) {
-      answer(response, LOOPBACK_ANSWER.NOT_VERIFIED);
+      answer(response, LOOPBACK_ANSWER.NOT_VERIFIED, source);
       return;
     }
     accepted = true;
-    answer(response, LOOPBACK_ANSWER.SIGNED_IN);
+    answer(response, LOOPBACK_ANSWER.SIGNED_IN, source);
     settle?.(code);
     settle = undefined;
   });

--- a/packages/calendar/src/oauth.ts
+++ b/packages/calendar/src/oauth.ts
@@ -9,6 +9,7 @@ import {
   accountLoopbackPage,
   codeChallenge,
   createCodeVerifier,
+  LOOPBACK_CONNECTION_SOURCE,
   LOOPBACK_PAGE_TONE,
 } from "@sidecar/credentials";
 import { isWireString, type UnparsedWireValue, unparsedWire, wireRecord } from "@sidecar/wire";
@@ -126,12 +127,14 @@ function signInPage(granted: boolean): string {
         badge: "Connected",
         title: "Connected to Google Calendar",
         body: "You can close this tab and return to Luke.",
+        source: LOOPBACK_CONNECTION_SOURCE.GOOGLE_CALENDAR,
       })
     : accountLoopbackPage({
         tone: LOOPBACK_PAGE_TONE.ATTENTION,
         badge: "Not connected",
         title: "Sign-in didn’t complete",
         body: "You can close this tab and try again from Luke.",
+        source: LOOPBACK_CONNECTION_SOURCE.GOOGLE_CALENDAR,
       });
 }
 

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.js",
+    "./loopback-page": "./src/loopback-page.js",
     "./vocabulary": "./src/credential-providers.js"
   },
   "types": "./src/index.ts",

--- a/packages/credentials/src/index.ts
+++ b/packages/credentials/src/index.ts
@@ -16,7 +16,9 @@ export {
 } from "./credential-providers.js";
 export {
   accountLoopbackPage,
+  LOOPBACK_CONNECTION_SOURCE,
   LOOPBACK_PAGE_TONE,
+  type LoopbackConnectionSource,
   type LoopbackPage,
   type LoopbackPageTone,
 } from "./loopback-page.js";

--- a/packages/credentials/src/loopback-page.test.ts
+++ b/packages/credentials/src/loopback-page.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  accountLoopbackPage,
+  LOOPBACK_CONNECTION_SOURCE,
+  LOOPBACK_PAGE_TONE,
+} from "./loopback-page.js";
+
+test("loopback pages render the dark card and inline connection graphic", () => {
+  const page = accountLoopbackPage({
+    tone: LOOPBACK_PAGE_TONE.SETTLED,
+    badge: "Connected",
+    title: "Connected to Google Calendar",
+    body: "You can close this tab and return to Luke.",
+    source: LOOPBACK_CONNECTION_SOURCE.GOOGLE_CALENDAR,
+  });
+
+  assert.match(page, /<meta name="color-scheme" content="dark">/);
+  assert.match(page, /class="connection"/);
+  assert.match(page, /provider-mark-google-calendar/);
+  assert.match(page, /class="mark mark-connection"/);
+  assert.doesNotMatch(page, /logo-box/);
+  assert.match(page, /data:image\/svg\+xml;utf8,/);
+});
+
+test("loopback pages stay self-contained", () => {
+  const page = accountLoopbackPage({
+    tone: LOOPBACK_PAGE_TONE.ATTENTION,
+    badge: "Not connected",
+    title: "Sign-in did not complete",
+    body: "You can close this tab and try again from Luke.",
+    source: LOOPBACK_CONNECTION_SOURCE.LINEAR,
+  });
+
+  assert.doesNotMatch(page, /<script\b/i);
+  assert.doesNotMatch(page, /\b(?:src|href)=["']https?:\/\//i);
+  assert.match(page, /provider-mark-linear/);
+});

--- a/packages/credentials/src/loopback-page.ts
+++ b/packages/credentials/src/loopback-page.ts
@@ -1,4 +1,4 @@
-import { FACE_ART } from "@sidecar/surface";
+import { FACE_ART, GOOGLE_CALENDAR_MARK_LAYERS, LINEAR_PATH } from "@sidecar/surface";
 
 /**
  * The page the browser is left on after the OAuth redirect lands on the
@@ -21,12 +21,23 @@ export const LOOPBACK_PAGE_TONE = {
 
 export type LoopbackPageTone = (typeof LOOPBACK_PAGE_TONE)[keyof typeof LOOPBACK_PAGE_TONE];
 
+export const LOOPBACK_CONNECTION_SOURCE = {
+  GOOGLE: "google",
+  GITHUB: "github",
+  GOOGLE_CALENDAR: "google-calendar",
+  LINEAR: "linear",
+} as const;
+
+export type LoopbackConnectionSource =
+  (typeof LOOPBACK_CONNECTION_SOURCE)[keyof typeof LOOPBACK_CONNECTION_SOURCE];
+
 export interface LoopbackPage {
   tone: LoopbackPageTone;
   /** The pill's one word or two: "Signed in", "Not completed". */
   badge: string;
   title: string;
   body: string;
+  source?: LoopbackConnectionSource;
 }
 
 /**
@@ -34,15 +45,82 @@ export interface LoopbackPage {
  * from, so this copy cannot drift from the artwork. The tight viewBox is the
  * mark's own, as the landing page crops it.
  */
-function markSvg(ink = "currentColor"): string {
-  const { TILT, SMILE, STROKE_WIDTH, EYE_X, EYE_Y, EYE_RADIUS } = FACE_ART;
+function markSvg(ink = "currentColor", className = "mark"): string {
+  const { MARK_VIEW_BOX, TILT, SMILE, STROKE_WIDTH, EYE_X, EYE_Y, EYE_RADIUS } = FACE_ART;
   return (
-    `<svg class="mark" xmlns="http://www.w3.org/2000/svg" viewBox="53.85 62.67 134.29 122.37" fill="none" aria-hidden="true">` +
+    `<svg class="${className}" xmlns="http://www.w3.org/2000/svg" viewBox="${MARK_VIEW_BOX}" fill="none" aria-hidden="true">` +
     `<g transform="${TILT}">` +
     `<path d="${SMILE}" fill="none" stroke="${ink}" stroke-width="${STROKE_WIDTH}" stroke-linecap="round" stroke-linejoin="round"/>` +
     `<circle cx="${EYE_X.LEFT}" cy="${EYE_Y}" r="${EYE_RADIUS}" fill="${ink}"/>` +
     `<circle cx="${EYE_X.RIGHT}" cy="${EYE_Y}" r="${EYE_RADIUS}" fill="${ink}"/>` +
     `</g></svg>`
+  );
+}
+
+function googleMarkSvg(): string {
+  return (
+    `<svg class="provider-mark provider-mark-google" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" aria-hidden="true">` +
+    `<path fill="#4285F4" d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z"/>` +
+    `<path fill="#34A853" d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z"/>` +
+    `<path fill="#FBBC05" d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332z"/>` +
+    `<path fill="#EA4335" d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z"/>` +
+    `</svg>`
+  );
+}
+
+const GITHUB_MARK_PATH =
+  "M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z";
+
+function githubMarkSvg(): string {
+  return (
+    `<svg class="provider-mark provider-mark-github" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" aria-hidden="true">` +
+    `<path fill="currentColor" d="${GITHUB_MARK_PATH}"/>` +
+    `</svg>`
+  );
+}
+
+function googleCalendarMarkSvg(): string {
+  return (
+    `<svg class="provider-mark provider-mark-google-calendar" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" aria-hidden="true">` +
+    `<g transform="translate(3.75 3.75)">` +
+    GOOGLE_CALENDAR_MARK_LAYERS.map(
+      (layer) => `<path fill="${layer.fill}" d="${layer.path}"/>`,
+    ).join("") +
+    `</g></svg>`
+  );
+}
+
+function linearMarkSvg(): string {
+  return (
+    `<svg class="provider-mark provider-mark-linear" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">` +
+    `<path fill="currentColor" d="${LINEAR_PATH}"/>` +
+    `</svg>`
+  );
+}
+
+function providerMarkSvg(source: LoopbackConnectionSource): string {
+  switch (source) {
+    case LOOPBACK_CONNECTION_SOURCE.GOOGLE:
+      return googleMarkSvg();
+    case LOOPBACK_CONNECTION_SOURCE.GITHUB:
+      return githubMarkSvg();
+    case LOOPBACK_CONNECTION_SOURCE.GOOGLE_CALENDAR:
+      return googleCalendarMarkSvg();
+    case LOOPBACK_CONNECTION_SOURCE.LINEAR:
+      return linearMarkSvg();
+  }
+}
+
+function connectionGraphic(source: LoopbackConnectionSource | undefined): string {
+  if (!source) return `<div class="solo-mark">${markSvg()}</div>`;
+  return (
+    `<div class="connection" aria-hidden="true">` +
+    providerMarkSvg(source) +
+    `<svg class="arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" aria-hidden="true">` +
+    `<path d="M5 12h14M13 6l6 6-6 6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>` +
+    `</svg>` +
+    markSvg("currentColor", "mark mark-connection") +
+    `</div>`
   );
 }
 
@@ -58,18 +136,32 @@ const PAGE_STYLE = `
   }
   .shell { min-height: 100vh; display: grid; place-items: center; padding: 24px; }
   .card {
-    width: min(100%, 390px);
-    padding: 48px 32px;
+    width: min(100%, 430px);
+    padding: 40px 32px;
     border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 17px;
-    background: #000;
+    border-radius: 8px;
+    background: #101114;
     box-shadow: 0 24px 80px rgba(0, 0, 0, 0.42);
     text-align: center;
   }
+  .solo-mark { display: inline-flex; margin-bottom: 4px; }
   .mark { width: 52px; height: auto; color: rgba(255, 255, 255, 0.92); }
+  .connection {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    margin: 0 auto 20px;
+  }
+  .provider-mark { display: block; width: 38px; height: 38px; flex: 0 0 auto; color: rgba(255, 255, 255, 0.92); }
+  .provider-mark-google { width: 38px; height: 38px; }
+  .provider-mark-github { width: 38px; height: 38px; }
+  .provider-mark-google-calendar { width: 42px; height: 42px; }
+  .provider-mark-linear { width: 38px; height: 38px; color: #5e6ad2; }
+  .mark-connection { width: 48px; flex: 0 0 auto; }
+  .arrow { width: 24px; height: 24px; color: rgba(255, 255, 255, 0.56); flex: 0 0 auto; }
   .pill {
     display: inline-block;
-    margin-top: 16px;
     padding: 3px 11px;
     border-radius: 999px;
     font-size: 0.75rem;
@@ -95,7 +187,7 @@ export function accountLoopbackPage(page: LoopbackPage): string {
     `<link rel="icon" href="data:image/svg+xml;utf8,${favicon}">` +
     `<title>${page.title}</title><style>${PAGE_STYLE}</style></head>` +
     `<body><main class="shell"><section class="card">` +
-    markSvg() +
+    connectionGraphic(page.source) +
     `<div><span class="pill" data-tone="${page.tone}">${page.badge}</span></div>` +
     `<h1>${page.title}</h1><p>${page.body}</p>` +
     `</section></main></body></html>`

--- a/packages/trackers/src/linear/oauth.ts
+++ b/packages/trackers/src/linear/oauth.ts
@@ -8,6 +8,7 @@ import {
   accountLoopbackPage,
   codeChallenge,
   createCodeVerifier,
+  LOOPBACK_CONNECTION_SOURCE,
   LOOPBACK_PAGE_TONE,
 } from "@sidecar/credentials";
 import {
@@ -119,12 +120,14 @@ function signInPage(granted: boolean): string {
         badge: "Connected",
         title: "Connected to Linear",
         body: "You can close this tab and return to Luke.",
+        source: LOOPBACK_CONNECTION_SOURCE.LINEAR,
       })
     : accountLoopbackPage({
         tone: LOOPBACK_PAGE_TONE.ATTENTION,
         badge: "Not connected",
         title: "Sign-in didn’t complete",
         body: "You can close this tab and try again from Luke.",
+        source: LOOPBACK_CONNECTION_SOURCE.LINEAR,
       });
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       '@sidecar/attention':
         specifier: workspace:*
         version: link:../../packages/attention
+      '@sidecar/credentials':
+        specifier: workspace:*
+        version: link:../../packages/credentials
       '@sidecar/fixtures':
         specifier: workspace:*
         version: link:../../packages/fixtures


### PR DESCRIPTION
## Summary
- unify hosted sign-in and loopback OAuth pages on the dark card design
- add direct provider -> Luke connection graphics using inline marks
- add a dev-only OAuth preview screen for quickly opening all page states

## Verification
- ./scripts/check.sh

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/19a6f74c-fea3-47cc-9728-b95ae09f7e7e)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32789541275/artifacts/9542704476) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32789541275)

- Commit: `687c2e9f393fb3fef9585269dfa78826fbfa3c20`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
