### PR TITLE
feat(web): walk the hero mock open once and let it rest

### DIFF
--- a/apps/web/src/NotchMock.tsx
+++ b/apps/web/src/NotchMock.tsx
@@ -15,7 +15,6 @@ import {
 import {
   CAPSULE_SIDE_WIDTH,
   compareSessionsByUrgency,
-  MOTION_DURATION_MS,
   PANEL_WIDTH,
   PEEK_SIDE_GROWTH,
   SESSION_URGENCY,
@@ -32,11 +31,13 @@ import { type CSSProperties, useCallback, useEffect, useRef, useState } from "re
  * the panel — on the same sampled spring, so the page and the app read as one
  * piece of software.
  *
- * In the product the pointer drives those presentations. On the page the
- * scroll does: the mock pins while the visitor scrolls through its section
- * and steps capsule → peek → panel as they go, so the motion is seen by
- * everyone who reaches the hero — including everyone on a phone — instead of
- * only by whoever thought to hover an unlabelled strip.
+ * In the product the pointer drives those presentations. On the page the mock
+ * drives itself: it arrives at rest and walks capsule → peek → panel once,
+ * then stays open. The open panel is the page's real hero — the state that
+ * shows what Luke is for — so no gesture has to be discovered to earn it, on
+ * a phone as well as under a pointer, and the walk on the way there is seen
+ * by everyone rather than staged behind a scroll or a hover. Under reduced
+ * motion the walk is skipped and the panel is simply there.
  */
 const MOCK_MODE = {
   CAPSULE: "capsule",
@@ -47,15 +48,13 @@ const MOCK_MODE = {
 type MockMode = (typeof MOCK_MODE)[keyof typeof MOCK_MODE];
 
 /**
- * Where each presentation begins, as a share of the pinned travel — from the
- * moment the pin catches to the moment the section lets it go. The capsule
- * keeps a beat at the start so arriving at the section shows the product at
- * rest before it answers; the panel takes the back of the travel, so it is
- * open for the whole of the pin's tail and is what the section leaves the
- * visitor looking at.
+ * The walk's cue points. The capsule keeps a beat so the product is seen at
+ * rest before it answers; the peek holds long enough for its count caption to
+ * be read after the surface settles; the panel then takes the stage and keeps
+ * it.
  */
-const PEEK_AT = 0.1;
-const PANEL_AT = 0.35;
+const WALK_PEEK_AT_MS = 1000;
+const WALK_PANEL_AT_MS = 2200;
 
 /** The values a MacBook's notch reports, matching the renderer's fixture. */
 const HOUSING_WIDTH = 210;
@@ -103,9 +102,6 @@ const WING_PROVIDERS = MOCK_SESSIONS.map(
 const PEEK_CAPACITY = wingMarkCapacity(CAPSULE_SIDE_WIDTH + PEEK_SIDE_GROWTH);
 const PANEL_CAPACITY = wingMarkCapacity((PANEL_WIDTH - HOUSING_WIDTH) / 2);
 
-/** `--duration-exit`: a shrinking wing keeps its marks until their fade ends. */
-const MARK_EXIT_MS = MOTION_DURATION_MS.EXIT;
-
 /**
  * The display the mock sits in, painted by Paper's mesh gradient — bundled
  * and pinned, so the page carries its own shader instead of fetching one at
@@ -136,65 +132,22 @@ const MOCK_LABEL = `Luke's notch capsule expanding into its session panel, listi
 export function NotchMock(): React.JSX.Element {
   const [mode, setMode] = useState<MockMode>(MOCK_MODE.CAPSULE);
   const [panelHeight, setPanelHeight] = useState<number>();
-  const modeRef = useRef<MockMode>(MOCK_MODE.CAPSULE);
-  const scrollSection = useRef<HTMLDivElement>(null);
-  const pin = useRef<HTMLDivElement>(null);
 
-  const applyMode = useCallback((next: MockMode) => {
-    if (modeRef.current === next) return;
-    modeRef.current = next;
-    setMode(next);
-  }, []);
-
-  // The scroll is the whole interaction. Progress is the pin's own travel —
-  // from where the sticky top catches the art to where the section's end
-  // releases it — read entirely off layout-resolved values. Nothing here is
-  // the live viewport: `window.innerHeight` shrinks and grows as a phone's
-  // URL bar collapses, and a threshold measured against it jumps mid-scroll,
-  // which is the very bounce the runway's `svh` units exist to avoid. Each
-  // presentation holds its share of the travel in either direction:
-  // scrolling back up folds the panel down to the peek and the peek back
-  // into the capsule.
+  // The walk never plays under reduced motion, where a timed tour is exactly
+  // the motion the visitor asked not to see: the panel is simply there.
   useEffect(() => {
-    const section = scrollSection.current;
-    const pinned = pin.current;
-    if (!section || !pinned) return;
-    let frame: number | undefined;
-    const update = () => {
-      frame = undefined;
-      // The sticky offset is written in svh, so its used value only moves on
-      // a real viewport change — orientation, not browser chrome. It is the
-      // zero point and nothing else: the pin catches at `top = pinTop` and
-      // the section lets go at `top = pinTop + pin - section`, so the travel
-      // between the two is their difference alone, with the offset already
-      // spent anchoring the start.
-      const pinTop = Number.parseFloat(getComputedStyle(pinned).top) || 0;
-      const travel = section.offsetHeight - pinned.offsetHeight;
-      if (travel <= 0) {
-        applyMode(MOCK_MODE.PANEL);
-        return;
-      }
-      const progress = (pinTop - section.getBoundingClientRect().top) / travel;
-      applyMode(
-        progress >= PANEL_AT
-          ? MOCK_MODE.PANEL
-          : progress >= PEEK_AT
-            ? MOCK_MODE.PEEK
-            : MOCK_MODE.CAPSULE,
-      );
-    };
-    const schedule = () => {
-      frame ??= window.requestAnimationFrame(update);
-    };
-    update();
-    window.addEventListener("scroll", schedule, { passive: true });
-    window.addEventListener("resize", schedule);
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      setMode(MOCK_MODE.PANEL);
+      return;
+    }
+    const timers = [
+      window.setTimeout(() => setMode(MOCK_MODE.PEEK), WALK_PEEK_AT_MS),
+      window.setTimeout(() => setMode(MOCK_MODE.PANEL), WALK_PANEL_AT_MS),
+    ];
     return () => {
-      if (frame !== undefined) window.cancelAnimationFrame(frame);
-      window.removeEventListener("scroll", schedule);
-      window.removeEventListener("resize", schedule);
+      for (const timer of timers) window.clearTimeout(timer);
     };
-  }, [applyMode]);
+  }, []);
 
   // `useShapeHeight` in the renderer: the black surface ends where the content
   // does, so the panel's height is measured rather than guessed. Measured as
@@ -263,19 +216,11 @@ export function NotchMock(): React.JSX.Element {
   }, []);
 
   // The wing is bounded by the shape its state draws, so its mark capacity is
-  // too — and a shrinking capacity waits out the exit fade, as the renderer's
-  // does, so no mark is unmounted mid-fade.
+  // too. The walk only ever widens, so a grown capacity never has to wait out
+  // an exit fade the way the renderer's shrinking wing does.
   const capacity = mode === MOCK_MODE.PANEL ? PANEL_CAPACITY : PEEK_CAPACITY;
-  const [drawnCapacity, setDrawnCapacity] = useState(capacity);
-  if (capacity > drawnCapacity) setDrawnCapacity(capacity);
-  useEffect(() => {
-    if (capacity >= drawnCapacity) return;
-    const timer = window.setTimeout(() => setDrawnCapacity(capacity), MARK_EXIT_MS);
-    return () => window.clearTimeout(timer);
-  }, [capacity, drawnCapacity]);
-
-  const overflowing = WING_PROVIDERS.length > drawnCapacity;
-  const providers = WING_PROVIDERS.slice(0, overflowing ? drawnCapacity - 1 : drawnCapacity);
+  const overflowing = WING_PROVIDERS.length > capacity;
+  const providers = WING_PROVIDERS.slice(0, overflowing ? capacity - 1 : capacity);
   const unshown = WING_PROVIDERS.length - providers.length;
 
   const mockStyle =
@@ -284,96 +229,94 @@ export function NotchMock(): React.JSX.Element {
       : cssCustomProperties({ "--panel-height": `${panelHeight}px` });
 
   return (
-    <div className="mock-scroll" ref={scrollSection}>
-      <div className="mock-pin" ref={pin}>
-        {/* One labelled image: nothing inside is a control,
-            so the whole recreation reads as a single illustration. The hidden
-            stage stays inert so find-in-page cannot match invisible titles and
-            a drag cannot select text nobody can see. */}
-        <div className="mock" data-mode={mode} role="img" aria-label={MOCK_LABEL} style={mockStyle}>
-          <span className="mock-frame" />
-          <div className="mock-backdrop" ref={backdrop} />
+    <div className="mock-stage">
+      {/* One labelled image: nothing inside is a control,
+          so the whole recreation reads as a single illustration. The hidden
+          stage stays inert so find-in-page cannot match invisible titles and
+          a drag cannot select text nobody can see. */}
+      <div className="mock" data-mode={mode} role="img" aria-label={MOCK_LABEL} style={mockStyle}>
+        <span className="mock-frame" />
+        <div className="mock-backdrop" ref={backdrop} />
 
-          {/* Capsule, peek and panel are all this one shape at different sizes,
+        {/* Capsule, peek and panel are all this one shape at different sizes,
               so the surface is never cross-faded — it is only ever resized. */}
-          <span className="panel-surface" />
+        <span className="panel-surface" />
 
-          <div className="expanded-stage" inert>
-            <section className="expanded-panel" ref={measurePanel}>
-              <div className="body">
+        <div className="expanded-stage" inert>
+          <section className="expanded-panel" ref={measurePanel}>
+            <div className="body">
+              <div
+                className="panel-header"
+                // SAFETY: React.CSSProperties omits custom properties; --row-index is a declared custom property.
+                style={{ "--row-index": 0 } as CSSProperties}
+              >
                 <div
-                  className="panel-header"
-                  // SAFETY: React.CSSProperties omits custom properties; --row-index is a declared custom property.
-                  style={{ "--row-index": 0 } as CSSProperties}
+                  className="tab-bar"
+                  // SAFETY: React.CSSProperties omits custom properties; --tab-count and --tab-index are declared custom properties.
+                  style={{ "--tab-count": 2, "--tab-index": 0 } as CSSProperties}
                 >
-                  <div
-                    className="tab-bar"
-                    // SAFETY: React.CSSProperties omits custom properties; --tab-count and --tab-index are declared custom properties.
-                    style={{ "--tab-count": 2, "--tab-index": 0 } as CSSProperties}
-                  >
-                    <span className="tab-thumb" />
-                    <span className="tab" data-active="true">
-                      Sessions
-                    </span>
-                    <span className="tab" data-active="false">
-                      Settings
-                    </span>
-                  </div>
-                  <span className="options-button">
-                    <OptionsIcon />
+                  <span className="tab-thumb" />
+                  <span className="tab" data-active="true">
+                    Sessions
+                  </span>
+                  <span className="tab" data-active="false">
+                    Settings
                   </span>
                 </div>
-                <div className="session-list">
-                  {MOCK_SESSIONS.map((session, index) => (
-                    // SAFETY: React.CSSProperties omits the declared --row-index custom property.
-                    <article
-                      className="session-row"
-                      data-state={session.urgency}
-                      style={{ "--row-index": index + 1 } as CSSProperties}
-                      key={session.id}
-                    >
-                      <SessionRow
-                        providerId={session.providerId}
-                        cloud={session.location === "cloud"}
-                        title={session.title}
-                        detail={session.detail}
-                        working={session.urgency === SESSION_URGENCY.WORKING}
-                        complete={session.urgency === SESSION_URGENCY.COMPLETE}
-                        place={session.branch ?? session.repository}
-                        branch={Boolean(session.branch)}
-                        when={observedAgoLabel(session.observedAt, FIXTURE_EPOCH_MS)}
-                      />
-                    </article>
-                  ))}
-                </div>
+                <span className="options-button">
+                  <OptionsIcon />
+                </span>
               </div>
-            </section>
-          </div>
+              <div className="session-list">
+                {MOCK_SESSIONS.map((session, index) => (
+                  // SAFETY: React.CSSProperties omits the declared --row-index custom property.
+                  <article
+                    className="session-row"
+                    data-state={session.urgency}
+                    style={{ "--row-index": index + 1 } as CSSProperties}
+                    key={session.id}
+                  >
+                    <SessionRow
+                      providerId={session.providerId}
+                      cloud={session.location === "cloud"}
+                      title={session.title}
+                      detail={session.detail}
+                      working={session.urgency === SESSION_URGENCY.WORKING}
+                      complete={session.urgency === SESSION_URGENCY.COMPLETE}
+                      place={session.branch ?? session.repository}
+                      branch={Boolean(session.branch)}
+                      when={observedAgoLabel(session.observedAt, FIXTURE_EPOCH_MS)}
+                    />
+                  </article>
+                ))}
+              </div>
+            </div>
+          </section>
+        </div>
 
-          {/* The wings: Luke nearest the housing, what he is watching resting
+        {/* The wings: Luke nearest the housing, what he is watching resting
               against the shape's far edge, the count and its caption on the
               other side. */}
-          <div className="wing wing-left">
-            <div className="wing-inner">
-              <span className="wing-marks">
-                {providers.map((providerId) => (
-                  <span className="wing-mark" key={providerId}>
-                    <ProviderMark providerId={providerId} />
-                  </span>
-                ))}
-                {unshown > 0 ? <span className="wing-more">+{unshown}</span> : null}
-              </span>
-              <WingFace />
-            </div>
+        <div className="wing wing-left">
+          <div className="wing-inner">
+            <span className="wing-marks">
+              {providers.map((providerId) => (
+                <span className="wing-mark" key={providerId}>
+                  <ProviderMark providerId={providerId} />
+                </span>
+              ))}
+              {unshown > 0 ? <span className="wing-more">+{unshown}</span> : null}
+            </span>
+            <WingFace />
           </div>
+        </div>
 
-          <div className="wing wing-right">
-            <div className="wing-inner">
-              <span className="count-badge" data-state={TALLY_URGENCY}>
-                <span className="count-value">{MOCK_SESSIONS.length}</span>
-                <span className="count-caption">{TALLY_CAPTION}</span>
-              </span>
-            </div>
+        <div className="wing wing-right">
+          <div className="wing-inner">
+            <span className="count-badge" data-state={TALLY_URGENCY}>
+              <span className="count-value">{MOCK_SESSIONS.length}</span>
+              <span className="count-caption">{TALLY_CAPTION}</span>
+            </span>
           </div>
         </div>
       </div>

--- a/apps/web/src/NotchMock.tsx
+++ b/apps/web/src/NotchMock.tsx
@@ -56,6 +56,8 @@ type MockMode = (typeof MOCK_MODE)[keyof typeof MOCK_MODE];
 const WALK_PEEK_AT_MS = 1000;
 const WALK_PANEL_AT_MS = 2200;
 
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
 /** The values a MacBook's notch reports, matching the renderer's fixture. */
 const HOUSING_WIDTH = 210;
 
@@ -130,16 +132,16 @@ const MOCK_LABEL = `Luke's notch capsule expanding into its session panel, listi
  * the face's usual condition: it only moves when something happens to it.
  */
 export function NotchMock(): React.JSX.Element {
-  const [mode, setMode] = useState<MockMode>(MOCK_MODE.CAPSULE);
+  // The walk never plays under reduced motion, where a timed tour is exactly
+  // the motion the visitor asked not to see: the panel is there from the
+  // first paint, not popped in by a mount effect.
+  const [mode, setMode] = useState<MockMode>(() =>
+    window.matchMedia(REDUCED_MOTION_QUERY).matches ? MOCK_MODE.PANEL : MOCK_MODE.CAPSULE,
+  );
   const [panelHeight, setPanelHeight] = useState<number>();
 
-  // The walk never plays under reduced motion, where a timed tour is exactly
-  // the motion the visitor asked not to see: the panel is simply there.
   useEffect(() => {
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
-      setMode(MOCK_MODE.PANEL);
-      return;
-    }
+    if (window.matchMedia(REDUCED_MOTION_QUERY).matches) return;
     const timers = [
       window.setTimeout(() => setMode(MOCK_MODE.PEEK), WALK_PEEK_AT_MS),
       window.setTimeout(() => setMode(MOCK_MODE.PANEL), WALK_PANEL_AT_MS),
@@ -178,7 +180,7 @@ export function NotchMock(): React.JSX.Element {
   useEffect(() => {
     const host = backdrop.current;
     if (!host) return;
-    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const reduceMotion = window.matchMedia(REDUCED_MOTION_QUERY);
     let mount: ShaderMount | undefined;
     try {
       mount = new ShaderMount(

--- a/apps/web/src/notch-mock.css
+++ b/apps/web/src/notch-mock.css
@@ -1,39 +1,27 @@
 /* Notch mock
    Ported from apps/desktop/src/renderer/styles/base.css and styles/sessions.css.
    The class names are the renderer's own so the two sheets stay diffable; the
-   `.mock` scope, the display frame, and the scroll pin are the only page-side
+   `.mock` scope, the display frame, and the stage are the only page-side
    inventions. `data-mode` here is `data-presentation` there, with the slot —
    a credential entry the page has no story for — left out.
    ------------------------------------------------------------------------- */
 
-/* The runway the mock plays through. In the product the pointer drives the
-   presentations; here the scroll does: the art pins while its section scrolls
-   past, and progress through the section steps capsule → peek → panel. The
-   one gesture every visitor already makes is what plays the motion, on a
-   phone as well as under a pointer. */
-.mock-scroll {
-  /* Small-viewport units, so a collapsing mobile URL bar neither stretches
-     the runway nor bounces the thresholds while the visitor is mid-scroll. */
-  height: 165svh;
-  margin-top: var(--space-7);
-}
-
-.mock-pin {
-  position: sticky;
-  /* High enough that the open panel sits comfortably on screen, low enough
-     that the capsule clears a phone browser's own chrome. */
-  top: max(72px, 14svh);
+/* The stage the mock plays on. In the product the pointer drives the
+   presentations; here the mock walks capsule → peek → panel by itself once on
+   arrival and rests open, so the hero is the product's most telling state and
+   no gesture has to be discovered to earn it. */
+.mock-stage {
   display: flex;
   justify-content: center;
+  margin-top: var(--space-7);
   /* The stage is wider than the shell's content box, whose padding belongs to
      the prose. Give the display the viewport width at every breakpoint so the
      clip keeps its rounded corners instead of shaving them to the measure. */
   margin-inline: calc(50% - 50vw);
-  /* `transform: scale()` leaves the layout box at full size, so the pin
+  /* `transform: scale()` leaves the layout box at full size, so the stage
      tracks the scale itself or a phone reserves 560px for a 300px visual.
      `clip` keeps the untransformed art width from opening a horizontal
-     scrollbar — and it must be `clip`, not `hidden`: a scroll container
-     ancestor is exactly what stops `position: sticky` from sticking. */
+     scrollbar without making a scroll container of the stage. */
   height: calc(var(--mock-height) * var(--mock-scale));
   overflow: clip;
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -178,10 +178,10 @@
      gutter is a horizontal scrollbar on every page anywhere scrollbars take
      space, which is everywhere the visitor is not on a Mac.
 
-     It has to be `clip` and not `hidden`, for the reason `.mock-pin` gives
-     below: `hidden` makes a scroll container, and a scroll container ancestor
-     is exactly what stops the pin from sticking. `overflow-y` is left alone,
-     which a `clip` on the other axis permits, so the page still scrolls down.
+     It has to be `clip` and not `hidden`: `hidden` makes a scroll container,
+     which script and keyboard can scroll even without bars, where `clip`
+     merely crops. `overflow-y` is left alone, which a `clip` on the other
+     axis permits, so the page still scrolls down.
 
      And it has to name both elements. The root's overflow propagates to the
      viewport and the root itself is then drawn as `visible`, so `html` alone
@@ -399,14 +399,10 @@
 
 /* Each step is the largest scale whose 660px art still clears the screen at
    the step's floor, so the mock fills a phone instead of floating in it and
-   the pin's clip never eats the frame's edges. */
+   the stage's clip never eats the frame's edges. */
 @media (width < 520px) {
   :root {
     --mock-scale: 0.58;
-  }
-
-  .mock-scroll {
-    margin-top: var(--space-7);
   }
 }
 


### PR DESCRIPTION
## What

Replaces the scroll-driven hero (sticky pin + 165svh runway stepping capsule → peek → panel with scroll progress) with a self-playing walk: the mock arrives at rest, peeks at 1s, opens its panel at 2.2s, and stays open. Page scrolling becomes ordinary scrolling.

## Why

The scroll mechanism required discovery — nothing signaled that the animation was scroll-bound, so most visitors saw only the closed capsule. The open panel is the state that shows what Luke is for, so it becomes the hero's resting state, and the signature motion plays for everyone on the way there.

## Behavior notes

- Under `prefers-reduced-motion` the walk is skipped and the panel is simply there (previously the reduced-motion page sat on the closed capsule until scrolled).
- The wing's mark capacity only ever grows now, so the exit-fade wait that existed for the shrinking scroll direction is removed with the runway.
- The dead scroll distance is gone: the page is hero, art, footer.

## Verification

- `./scripts/check.sh` passes.
- Headless-Chrome screenshots inspected against the built site: capsule at rest, mid-walk peek, and the open-panel resting state, all over the mesh backdrop from #499. Web-only change; the macOS `verify.sh` invariant does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32791393127/artifacts/9543300617) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32791393127)

- Commit: `32a6575dba49aa48e9d9104734259fafc8d96fd9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
