### PR TITLE
fix(web): let the mock's display end borderless on the page

### DIFF
--- a/apps/web/src/notch-mock.css
+++ b/apps/web/src/notch-mock.css
@@ -61,7 +61,6 @@
      it alone is allowed to end on the page's own ground. */
   --text-secondary: rgba(255, 255, 255, 0.56);
   --hairline: rgba(255, 255, 255, 0.08);
-  --hairline-strong: rgba(255, 255, 255, 0.09);
   --raised: rgba(255, 255, 255, 0.05);
   --raised-strong: rgba(255, 255, 255, 0.09);
   --frame-top: #14171c;
@@ -137,27 +136,27 @@
 
 /* The persistent display the capsule is cut into. It stays in place while the
    surface grows, so the panel remains inside the same rounded stage instead
-   of exposing the square ends of a narrower strip. */
+   of exposing the square ends of a narrower strip. Borderless: the mesh is
+   bright enough to end on the page's own ground, and a rim read as a black
+   outline around the art. */
 .mock-frame {
   position: absolute;
   z-index: 0;
   inset: 0;
-  border: 1px solid var(--hairline-strong);
   border-radius: 18px;
   background: linear-gradient(180deg, var(--frame-top) 0%, var(--frame-bottom) 100%);
 }
 
-/* The mesh gradient that paints the display, inset one pixel so the frame's
-   hairline stays visible and stacked under the surface so everything the mock
-   draws reads against it. The host's own rule wins over ShaderMount's
-   zero-specificity `:where` styles, and the canvas inherits this radius. The
-   frame's gradient stays underneath as the display for a machine whose WebGL
-   never mounts. */
+/* The mesh gradient that paints the display, edge to edge, stacked under the
+   surface so everything the mock draws reads against it. The host's own rule
+   wins over ShaderMount's zero-specificity `:where` styles, and the canvas
+   inherits this radius. The frame's gradient stays underneath as the display
+   for a machine whose WebGL never mounts. */
 .mock-backdrop {
   position: absolute;
   z-index: 0;
-  inset: 1px;
-  border-radius: 17px;
+  inset: 0;
+  border-radius: 18px;
 }
 
 /* The black surface is the whole animation: one leaf element with no children


### PR DESCRIPTION
## What

Removes the dark rim around the hero mock's simulated display: the frame's 1px hairline border goes, and the mesh backdrop paints edge to edge (`inset: 0`, radius matching the frame) instead of sitting one pixel inside it. The now-unread `--hairline-strong` token is removed with its only reader.

## Why

Since #499 the display is a bright mesh gradient, and the hairline plus the exposed pixel of dark frame gradient read together as a black outline around the art on the light page. The mesh is bright enough to end on the page's own ground.

## Behavior notes

- The frame element keeps its dark gradient underneath as the display for a machine whose WebGL never mounts — that fallback is now also borderless.

## Verification

- `./scripts/check.sh` passes.
- Headless-Chrome screenshot inspected against the built site: the mesh ends cleanly on the page ground with no rim. Web-only change; the macOS `verify.sh` invariant does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32791055494/artifacts/9543198693) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32791055494)

- Commit: `8888339516674152d4f29709d8c17ff7a496771a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
