### PR TITLE
fix(voice): diagnose a signed-out live run as missing credentials

### DIFF
--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -405,6 +405,7 @@ const attentionRequests = new AttentionRequestRegistry();
 const voiceCapabilities = new VoiceCapabilityAssembler({
   settings: settingsStore,
   credentialsUsable: () => runMode.sendsNetwork && accountCapabilitiesActive(),
+  fixtureRun: () => !runMode.sendsNetwork,
   accountSignedIn: () => account.status === ACCOUNT_STATUS.SIGNED_IN,
   hostedServiceBaseUrl: HOSTED_SERVICE_BASE_URL,
   refreshAccount: accountSession.refreshOnce,

--- a/packages/voice/src/capability-assembler.test.ts
+++ b/packages/voice/src/capability-assembler.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { REALTIME_MINT_OUTCOME } from "@sidecar/realtime";
 import { APP_SETTING_SCHEMA, VOICE_SOURCE } from "@sidecar/settings";
 import {
   resolveVoiceCapability,
@@ -76,6 +77,7 @@ test("the assembler builds and clears the keyed voice capabilities as one unit",
       readApiKey: async () => key,
     },
     credentialsUsable: () => true,
+    fixtureRun: () => false,
     accountSignedIn: () => false,
     hostedServiceBaseUrl: "https://example.test",
     refreshAccount: async () => undefined,
@@ -107,6 +109,7 @@ test("the assembler keeps fixture runs credential-free without reading a key", a
       },
     },
     credentialsUsable: () => false,
+    fixtureRun: () => true,
     accountSignedIn: () => true,
     hostedServiceBaseUrl: "https://example.test",
     refreshAccount: async () => undefined,
@@ -119,4 +122,30 @@ test("the assembler keeps fixture runs credential-free without reading a key", a
   assert.equal(keyReads, 0);
   assert.equal(assembler.realtimeCredentials, undefined);
   assert.equal(assembler.hostedUsageReader, undefined);
+  assert.equal(
+    assembler.unavailableDiagnostics.lastOutcome,
+    REALTIME_MINT_OUTCOME.DISABLED_BY_FIXTURE,
+  );
+});
+
+test("a signed-out live run is diagnosed as missing credentials, not as a fixture run", async () => {
+  const reports: string[] = [];
+  const assembler = new VoiceCapabilityAssembler({
+    settings: settingsFor({ source: VOICE_SOURCE.ACCOUNT }),
+    credentialsUsable: () => false,
+    fixtureRun: () => false,
+    accountSignedIn: () => false,
+    hostedServiceBaseUrl: "https://example.test",
+    refreshAccount: async () => undefined,
+    currentSession: () => undefined,
+    noticeRequestFor: () => undefined,
+    report: (message) => reports.push(message),
+  });
+
+  await assembler.apply();
+  assert.equal(assembler.realtimeCredentials, undefined);
+  assert.equal(assembler.unavailableDiagnostics.fixtureMode, false);
+  assert.equal(assembler.unavailableDiagnostics.lastOutcome, REALTIME_MINT_OUTCOME.NO_API_KEY);
+  assert.doesNotMatch(reports.at(-1) ?? "", /fixture/);
+  assert.match(reports.at(-1) ?? "", /Signing in/);
 });

--- a/packages/voice/src/capability-assembler.ts
+++ b/packages/voice/src/capability-assembler.ts
@@ -56,6 +56,12 @@ export interface VoiceSettings {
 export interface VoiceCapabilityAssemblerOptions {
   settings: VoiceSettings;
   credentialsUsable: () => boolean;
+  /**
+   * Whether this is a fixture or evidence run. `credentialsUsable` cannot say:
+   * it is also false on a live run whose account gate is closed, and that state
+   * must be diagnosed as the missing credential it is, not as a fixture run.
+   */
+  fixtureRun: () => boolean;
   accountSignedIn: () => boolean;
   hostedServiceBaseUrl: string;
   refreshAccount: () => Promise<void>;
@@ -76,7 +82,7 @@ export class VoiceCapabilityAssembler {
   constructor(options: VoiceCapabilityAssemblerOptions) {
     this.#options = options;
     this.#unavailableDiagnostics = unavailableRealtimeDiagnostics({
-      fixtureMode: !options.credentialsUsable(),
+      fixtureMode: options.fixtureRun(),
       apiKeyConfigured: false,
     });
   }
@@ -147,7 +153,7 @@ export class VoiceCapabilityAssembler {
         ? new HostedRealtimeCredentialMinter({ ...seams, ...preferences })
         : undefined;
     this.#unavailableDiagnostics = unavailableRealtimeDiagnostics({
-      fixtureMode: !credentialsUsable,
+      fixtureMode: this.#options.fixtureRun(),
       apiKeyConfigured: apiKey !== undefined,
     });
     this.#hostedUsageReader = policy.useHosted ? new HostedUsageReader(seams) : undefined;


### PR DESCRIPTION
## Problem

Running `./scripts/run.sh` (a live run) while signed out logs:

> Luke voice: unavailable — This is a fixture or evidence run, which never uses credentials.

That diagnosis is wrong — nothing about the run is a fixture; the account gate is simply closed.

## Cause

`VoiceCapabilityAssembler` derived its diagnostics' `fixtureMode` from `!credentialsUsable`, but the desktop app wires `credentialsUsable` as `runMode.sendsNetwork && accountCapabilitiesActive()`. That predicate is false both on a fixture/evidence run *and* on a live run with no signed-in account, so a sign-out collapsed into the fixture diagnosis.

## Fix

The assembler takes a dedicated `fixtureRun` seam carrying the one fact the diagnostics field names, wired from `!runMode.sendsNetwork`. A signed-out live run now reaches the `no-api-key` outcome, whose existing explanation already says the right thing:

> Voice has nothing to run on: no signed-in Luke account, and no OpenAI key. Signing in turns voice on with its included allowance; a key connected under What Luke runs on, at the top of the Settings tab, also works.

The account gate itself is unchanged: voice stays unavailable while signed out; only the diagnosis (log line and panel diagnostics) is corrected.

## Verification

`./scripts/check.sh` passes (exit 0), including the new test asserting a signed-out live run reports `no-api-key` with `fixtureMode: false` and the existing fixture-run test now asserting `disabled-by-fixture`. No renderer or macOS surface changed, so `./scripts/verify.sh` was not run (this environment is Linux); no visual evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/0d7f91e9-88be-485b-a694-ce46a3abc327)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32794103417/artifacts/9544265327) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32794103417)

- Commit: `536db948a34f5ab621bec32a153c9c48db0e4471`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
