### PR TITLE
Remove dead production code

### DIFF
--- a/apps/desktop/src/renderer/feedback-confirmation.test.ts
+++ b/apps/desktop/src/renderer/feedback-confirmation.test.ts
@@ -5,11 +5,12 @@ import {
   CONFIRMATION_ENTRANCE_MS,
   CONFIRMATION_REST_MS,
   CONFIRMATION_SCENE,
-  CONFIRMATIONS,
   confirmationHoldMs,
   feedbackConfirmation,
   STILL_CONFIRMATION_MS,
 } from "./feedback-confirmation";
+
+const CONFIRMATIONS = [feedbackConfirmation(() => 0), feedbackConfirmation(() => 0.999)] as const;
 
 test("the coin lands on the shockwave or the boop, and nothing else", () => {
   const low = feedbackConfirmation(() => 0);

--- a/apps/desktop/src/renderer/feedback-confirmation.ts
+++ b/apps/desktop/src/renderer/feedback-confirmation.ts
@@ -38,12 +38,6 @@ const BOOP_CONFIRMATION: FeedbackConfirmation = {
   scene: CONFIRMATION_SCENE.BOOP,
 };
 
-/** The two landings a send may draw. Each motion is one the artwork defines. */
-export const CONFIRMATIONS: readonly FeedbackConfirmation[] = [
-  SHOCKWAVE_CONFIRMATION,
-  BOOP_CONFIRMATION,
-];
-
 /**
  * The confirmation a landed send plays: a coin flip between the two
  * landings. The flip is injectable so a test can watch both faces of the

--- a/apps/desktop/src/renderer/luke-guide.test.ts
+++ b/apps/desktop/src/renderer/luke-guide.test.ts
@@ -24,15 +24,10 @@ import {
   SECRET_STORAGE,
 } from "#shared/wire/account";
 import type { AppSettingsView, SettingsUpdateResult } from "#shared/wire/settings";
-import {
-  APP_SETTING_DEFAULTS,
-  appSettingsView,
-  appSettingsWire,
-  CLI_CONNECTION,
-} from "#shared/wire/settings";
+import { APP_SETTING_DEFAULTS, appSettingsView, CLI_CONNECTION } from "#shared/wire/settings";
 import type { UpdateSnapshot } from "#shared/wire/update";
 import { UPDATE_STATUS } from "#shared/wire/update";
-import { spokenSettingBridge } from "#testing/spoken-setting-bridge";
+import { appSettingsWire, spokenSettingBridge } from "#testing/spoken-setting-bridge";
 import {
   APP_SETTING_ID,
   applySpokenSetting,

--- a/apps/desktop/src/renderer/panel-state.ts
+++ b/apps/desktop/src/renderer/panel-state.ts
@@ -32,8 +32,6 @@ export const HIT_REGION = {
   FEEDBACK: "feedback",
 } as const;
 
-export type HitRegion = (typeof HIT_REGION)[keyof typeof HIT_REGION];
-
 /** Long enough that sweeping the pointer past the notch does not wake it. */
 export const PEEK_ENTER_DELAY_MS = 60;
 /**

--- a/apps/desktop/src/renderer/settings-icons.tsx
+++ b/apps/desktop/src/renderer/settings-icons.tsx
@@ -243,16 +243,6 @@ export function ShieldIcon(): React.JSX.Element {
   );
 }
 
-export function MicrophoneIcon(): React.JSX.Element {
-  return (
-    <Glyph>
-      <rect x="9" y="2.6" width="6" height="11" rx="3" />
-      <path d="M5.4 11.4a6.6 6.6 0 0 0 13.2 0" />
-      <path d="M12 18v3.4" />
-    </Glyph>
-  );
-}
-
 /** Heads the Updates section: the arrival a newer release waits as. */
 export function DownloadIcon(): React.JSX.Element {
   return (
@@ -294,39 +284,12 @@ export function PowerIcon(): React.JSX.Element {
   );
 }
 
-/** Two sliders, drawn once for both controls that mean "choices". */
-function SliderMarks(): React.JSX.Element {
-  return (
-    <>
-      <path d="M3.6 8.4h5.2" />
-      <path d="M13.2 8.4h7.2" />
-      <circle cx="11" cy="8.4" r="2.2" />
-      <path d="M3.6 15.6h2.6" />
-      <path d="M10.6 15.6h9.8" />
-      <circle cx="8.4" cy="15.6" r="2.2" />
-    </>
-  );
-}
-
 /** A magnifier: the list read for the rows that say the typed words. */
 export function SearchIcon(): React.JSX.Element {
   return (
     <Glyph className="search-glyph">
       <circle cx="10.6" cy="10.6" r="6.1" />
       <path d="M15.2 15.2L20.2 20.2" />
-    </Glyph>
-  );
-}
-
-/**
- * Two sliders rather than a funnel: the control it opens holds an order as well
- * as a filter, and a funnel would promise only the second.
- */
-/** The same two sliders at a heading's size: settings the user has chosen. */
-export function PreferencesIcon(): React.JSX.Element {
-  return (
-    <Glyph>
-      <SliderMarks />
     </Glyph>
   );
 }

--- a/apps/desktop/src/renderer/settings-views.ts
+++ b/apps/desktop/src/renderer/settings-views.ts
@@ -70,8 +70,6 @@ export const PANEL_STAND_DOWN = {
   FEEDBACK: "feedback",
 } as const;
 
-export type PanelStandDown = (typeof PANEL_STAND_DOWN)[keyof typeof PANEL_STAND_DOWN];
-
 /**
  * The two of those three the slot shape is drawn around, never both at once.
  * A note is not one of them: the composer is its own shape, at its own size.

--- a/apps/desktop/src/shared/wire/settings.ts
+++ b/apps/desktop/src/shared/wire/settings.ts
@@ -1,11 +1,6 @@
 import type { CredentialProviderId } from "@sidecar/credentials/vocabulary";
 import type { CliConnection } from "@sidecar/session";
-import {
-  APP_SETTING_DEFAULTS,
-  APP_SETTING_FIELDS,
-  type StoredAppSettings,
-  VOICE_SOURCE,
-} from "@sidecar/settings";
+import { APP_SETTING_DEFAULTS, type StoredAppSettings, VOICE_SOURCE } from "@sidecar/settings";
 import type { ActResult } from "@sidecar/wire";
 import type { CredentialSource, SecretStorage } from "./account";
 import type { CalendarAccount } from "./calendar";
@@ -61,26 +56,6 @@ export function appSettingsView(settings: AppSettings): AppSettingsView {
     voiceSource: settings.stored.voiceSource ?? VOICE_SOURCE.ACCOUNT,
     formFactor: settings.stored.formFactor ?? APP_SETTING_DEFAULTS.formFactor,
   };
-}
-
-export function appSettingsWire(settings: AppSettingsView): AppSettings {
-  const storedEntries = Object.fromEntries(
-    APP_SETTING_FIELDS.map((field) => [field, settings[field]]),
-  );
-  // SAFETY: APP_SETTING_FIELDS enumerates every schema-derived stored field exactly once.
-  const stored = storedEntries as StoredAppSettings;
-  const status: RuntimeStatus = {
-    credentialSources: settings.credentialSources,
-    codexCloudConnection: settings.codexCloudConnection,
-    secretStorage: settings.secretStorage,
-    voiceAvailable: settings.voiceAvailable,
-    calendarSignInAvailable: settings.calendarSignInAvailable,
-    linearSignInAvailable: settings.linearSignInAvailable,
-    calendarAccounts: settings.calendarAccounts,
-    appleCalendarAvailable: settings.appleCalendarAvailable,
-    ...(settings.appleCalendar ? { appleCalendar: settings.appleCalendar } : undefined),
-  };
-  return { stored, status };
 }
 
 /** Every settings write returns the canonical act result and the latest stored snapshot. */

--- a/apps/desktop/src/testing/spoken-setting-bridge.ts
+++ b/apps/desktop/src/testing/spoken-setting-bridge.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import type { WorkspaceAgentSelection } from "@sidecar/session";
-import type { AppSettingField, AppSettingValue } from "@sidecar/settings";
+import {
+  APP_SETTING_FIELDS,
+  type AppSettingField,
+  type AppSettingValue,
+  type StoredAppSettings,
+} from "@sidecar/settings";
 import type { AppBridge, SettingsUpdateResult } from "#shared/contracts";
+import type { AppSettings, AppSettingsView, RuntimeStatus } from "#shared/wire/settings";
 
 export type SpokenSettingBridge = Pick<AppBridge, "updateSetting" | "updateSettingEntry">;
 
@@ -45,4 +51,25 @@ export function spokenSettingBridge(fixture: SpokenSettingBridgeFixture): Spoken
       return carry(field, key, value as WorkspaceAgentSelection | undefined);
     },
   };
+}
+
+/** Turns a renderer view back into wire state for settings-update fixtures. */
+export function appSettingsWire(settings: AppSettingsView): AppSettings {
+  const storedEntries = Object.fromEntries(
+    APP_SETTING_FIELDS.map((field) => [field, settings[field]]),
+  );
+  // SAFETY: APP_SETTING_FIELDS enumerates every schema-derived stored field exactly once.
+  const stored = storedEntries as StoredAppSettings;
+  const status: RuntimeStatus = {
+    credentialSources: settings.credentialSources,
+    codexCloudConnection: settings.codexCloudConnection,
+    secretStorage: settings.secretStorage,
+    voiceAvailable: settings.voiceAvailable,
+    calendarSignInAvailable: settings.calendarSignInAvailable,
+    linearSignInAvailable: settings.linearSignInAvailable,
+    calendarAccounts: settings.calendarAccounts,
+    appleCalendarAvailable: settings.appleCalendarAvailable,
+    ...(settings.appleCalendar ? { appleCalendar: settings.appleCalendar } : undefined),
+  };
+  return { stored, status };
 }

--- a/packages/acts/src/acts.ts
+++ b/packages/acts/src/acts.ts
@@ -117,15 +117,11 @@ export const SESSION_TOOL_KIND = {
   RENAME_SESSION: "rename-session",
 } as const;
 
-export type SessionToolKind = (typeof SESSION_TOOL_KIND)[keyof typeof SESSION_TOOL_KIND];
-
 /** What a validated issue tool call asks for, as the bridge names it. */
 export const ISSUE_TOOL_KIND = {
   ISSUE_STATE: "issue-state",
   ISSUE_COMMENT: "issue-comment",
 } as const;
-
-export type IssueToolKind = (typeof ISSUE_TOOL_KIND)[keyof typeof ISSUE_TOOL_KIND];
 
 /** What a validated app tool call asks for, as the app performs it. */
 export const APP_TOOL_KIND = {
@@ -134,8 +130,6 @@ export const APP_TOOL_KIND = {
   FEEDBACK: "feedback",
   UPDATE: "update",
 } as const;
-
-export type AppToolKind = (typeof APP_TOOL_KIND)[keyof typeof APP_TOOL_KIND];
 
 /** The two whole-list scopes of a spoken panel ask beyond the locations. */
 export const SESSION_LIST_ALL = "all";
@@ -1790,27 +1784,6 @@ export function actNarration(action: CarriedAct, sessions: readonly Session[]): 
   return row?.narration(action, sessions) ?? "carried an act";
 }
 
-type RealtimeToolProjection<T extends Record<string, RealtimeToolSpec>> = {
-  [K in keyof T]: Pick<T[K], "name" | "family" | "schema" | "validate">;
-};
-
-function realtimeToolsFromActs<T extends Record<string, RealtimeToolSpec>>(
-  acts: T,
-): RealtimeToolProjection<T> {
-  // SAFETY: every projected entry is constructed from exactly the four fields
-  // required by RealtimeToolProjection, while Object.fromEntries preserves the
-  // keys supplied by Object.entries.
-  return Object.fromEntries(
-    Object.entries(acts).map(([key, act]) => [
-      key,
-      { name: act.name, family: act.family, schema: act.schema, validate: act.validate },
-    ]),
-  ) as RealtimeToolProjection<T>;
-}
-
-/** The Realtime API sees the tool-only projection of the complete act registry. */
-export const REALTIME_TOOLS = realtimeToolsFromActs(ACTS);
-
 function namesFromToolTable<T extends Record<string, { readonly name: string }>>(table: T) {
   // SAFETY: keys are drawn from the same table object; each entry's name field is the tool id.
   const names = {} as { [K in keyof T]: T[K]["name"] };
@@ -1823,8 +1796,6 @@ function namesFromToolTable<T extends Record<string, { readonly name: string }>>
 }
 
 export const REALTIME_TOOL = namesFromToolTable(ACTS);
-
-export type RealtimeToolName = (typeof REALTIME_TOOL)[keyof typeof REALTIME_TOOL];
 
 const REALTIME_TOOL_LIST: readonly RealtimeToolSpec[] = Object.values(ACTS);
 
@@ -1864,37 +1835,6 @@ export function isAppToolCall(call: RealtimeFunctionCall): boolean {
 /** The family a named tool belongs to, or nothing when no such tool exists. */
 export function realtimeToolFamily(name: string): RealtimeToolFamily | undefined {
   return ACTS_BY_NAME.get(name)?.family;
-}
-
-const SPOKEN_CARDINAL = {
-  0: "zero",
-  1: "one",
-  2: "two",
-  3: "three",
-  4: "four",
-  5: "five",
-  6: "six",
-  7: "seven",
-  8: "eight",
-  9: "nine",
-  10: "ten",
-  11: "eleven",
-  12: "twelve",
-  13: "thirteen",
-  14: "fourteen",
-  15: "fifteen",
-  16: "sixteen",
-  17: "seventeen",
-  18: "eighteen",
-  19: "nineteen",
-  20: "twenty",
-} as const;
-
-/** How many tools Luke has, as he says it in the standing instructions. */
-export function spokenRealtimeToolCount(): string {
-  const count = REALTIME_TOOL_LIST.length;
-  // SAFETY: count is a small cardinal; SPOKEN_CARDINAL keys are the documented spoken counts.
-  return SPOKEN_CARDINAL[count as keyof typeof SPOKEN_CARDINAL] ?? String(count);
 }
 
 /** The tool schemas a Realtime session is configured with. */

--- a/packages/analytics/src/product-events.ts
+++ b/packages/analytics/src/product-events.ts
@@ -486,11 +486,6 @@ export type ProductEventBatch = readonly ProductEvent[];
  */
 export const PRODUCT_EVENT_BATCH_LIMIT = 50;
 
-/** The one shape a recording request has: events and nothing else. */
-export interface ProductEventBatchRequest {
-  events: readonly unknown[];
-}
-
 type PropertyReader = {
   [Property in ProductEventProperty]: (
     value: UnparsedWireValue,

--- a/packages/issues/src/issues.test.ts
+++ b/packages/issues/src/issues.test.ts
@@ -11,7 +11,6 @@ import {
   maximumIssueIdentifierLength,
   maximumIssueStateNameLength,
   maximumIssueTitleLength,
-  supportsIssueTransition,
 } from "./issues.js";
 
 const OBSERVED_AT = 1_800_000_000_000;
@@ -40,8 +39,14 @@ test("a tracked issue is bounded wherever a tracker could run long", () => {
   assert.equal(issue.transitions.length, maximumIssueTransitions);
   assert.equal(issue.url, "https://linear.app/luke/issue/LUKE-123");
   assert.equal(issue.canComment, true);
-  assert.equal(supportsIssueTransition(issue, "state-0"), true);
-  assert.equal(supportsIssueTransition(issue, "state-999"), false);
+  assert.equal(
+    issue.transitions.some((transition) => transition.id === "state-0"),
+    true,
+  );
+  assert.equal(
+    issue.transitions.some((transition) => transition.id === "state-999"),
+    false,
+  );
 });
 
 test("what a tracker left unsaid stays a refusal rather than a guess", () => {

--- a/packages/issues/src/issues.ts
+++ b/packages/issues/src/issues.ts
@@ -208,11 +208,6 @@ export function normalizeTrackedIssue(
   return issue;
 }
 
-/** Returns whether a tracker explicitly advertised a transition for an issue. */
-export function supportsIssueTransition(issue: TrackedIssue, transitionId: string): boolean {
-  return issue.transitions.some((transition) => transition.id === transitionId);
-}
-
 /**
  * What became of an act. A rejection carries a reason the developer can hear,
  * never the body itself; unsupported means the tracker has no documented way
@@ -224,8 +219,6 @@ export const ISSUE_ACTION_KIND = {
   SET_STATE: "set-state",
   COMMENT: "comment",
 } as const;
-
-export type IssueActionKind = (typeof ISSUE_ACTION_KIND)[keyof typeof ISSUE_ACTION_KIND];
 
 /**
  * A tracker-local request whose every field the main process resolved from its

--- a/packages/realtime/AGENTS.md
+++ b/packages/realtime/AGENTS.md
@@ -4,9 +4,8 @@
 
 `realtime-tools.ts` imports `type RealtimeFunctionCall` from
 `realtime-protocol.ts`, and the protocol imports nothing back. The cycle these
-six modules were kept together for is gone: `spokenRealtimeToolCount` was the
-protocol's one reach into the tools, and it stopped being called when the
-spoken surfaces were simplified.
+six modules were kept together for is gone: the spoken surfaces no longer
+count tools, so the protocol has no reach into the tools.
 
 So splitting a protocol package from a tools package is now possible where it
 once was not. It is still a product decision rather than a tidying: the two

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -88,9 +88,9 @@ import {
   realtimeInstructions,
 } from "./realtime-protocol.js";
 import {
+  ACTS,
   REALTIME_TOOL,
   REALTIME_TOOL_FAMILY,
-  REALTIME_TOOLS,
   SESSION_LIST_ALL,
   SESSION_LIST_VOICE,
 } from "./realtime-tools.js";
@@ -1244,7 +1244,7 @@ test("the session is minted with the sixteen acts and nothing wider", () => {
 });
 
 test("show_panel's filter enum carries the whole vocabulary its validator accepts", () => {
-  const filters = REALTIME_TOOLS.SHOW_PANEL.schema.parameters.properties.filters;
+  const filters = ACTS.SHOW_PANEL.schema.parameters.properties.filters;
   const values = filters.items.enum;
 
   // The enum is what binds the model to real tokens instead of the
@@ -2327,9 +2327,9 @@ test("the session and issue tools answer to their own validators", () => {
   assert.equal(isIssueToolName(REALTIME_TOOL.UPDATE_ISSUE_STATE), true);
   assert.equal(isIssueToolName(REALTIME_TOOL.COMMENT_ON_ISSUE), true);
   assert.equal(isIssueToolName("delete_everything"), false);
-  assert.equal(REALTIME_TOOLS.CHANGE_APP_SETTING.family, REALTIME_TOOL_FAMILY.APP);
-  assert.equal(REALTIME_TOOLS.SEND_SESSION_MESSAGE.family, REALTIME_TOOL_FAMILY.SESSION);
-  assert.equal(REALTIME_TOOLS.UPDATE_ISSUE_STATE.family, REALTIME_TOOL_FAMILY.ISSUE);
+  assert.equal(ACTS.CHANGE_APP_SETTING.family, REALTIME_TOOL_FAMILY.APP);
+  assert.equal(ACTS.SEND_SESSION_MESSAGE.family, REALTIME_TOOL_FAMILY.SESSION);
+  assert.equal(ACTS.UPDATE_ISSUE_STATE.family, REALTIME_TOOL_FAMILY.ISSUE);
 });
 
 test("a disconnected tracker withdraws the roster without starting a reply", () => {

--- a/packages/session/src/session.ts
+++ b/packages/session/src/session.ts
@@ -309,8 +309,6 @@ export const SESSION_LINK_SCHEME = {
   SUPERSET: "superset:",
 } as const;
 
-export type SessionLinkScheme = (typeof SESSION_LINK_SCHEME)[keyof typeof SESSION_LINK_SCHEME];
-
 const SESSION_LINK_SCHEMES: ReadonlySet<string> = new Set(Object.values(SESSION_LINK_SCHEME));
 
 /** Whether an address is one Luke may ask the system to open. */


### PR DESCRIPTION
## Summary
- remove unused realtime projections, spoken tool-count code, icon components, and type aliases
- move settings wire conversion into test fixtures and keep assertions on live registries
- remove additional unreferenced issue, analytics, and session declarations

## Validation
- `./scripts/check.sh`

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32809121756/artifacts/9549227575) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32809121756)

- Commit: `abff970b6a7ebf29111cd9cfd7dcfbd010d965c6`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
