### PR TITLE
Fix Superset workspace launches

### DIFF
--- a/apps/desktop/src/main/register-bridge.test.ts
+++ b/apps/desktop/src/main/register-bridge.test.ts
@@ -1,6 +1,11 @@
 /* oxlint-disable anti-slop/no-unknown-returns -- Fake Electron listeners deliberately retain the IPC boundary shape. */
 import assert from "node:assert/strict";
 import test from "node:test";
+import {
+  CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
+  SUPERSET_WORKSPACE_PROVIDER_ID,
+} from "@sidecar/session";
+import { ACT_RESULT_STATUS } from "@sidecar/wire";
 import type { IpcMainEvent, IpcMainInvokeEvent } from "electron";
 import { BRIDGE } from "#shared/bridge";
 import { registerBridge } from "./register-bridge";
@@ -85,6 +90,33 @@ test("a validated request reaches its domain handler", async () => {
   // SAFETY: registerBridge reads only the sender field supplied by this focused fixture.
   const event = { sender: {} } as IpcMainInvokeEvent;
   assert.equal(await fixture.invokes.get(BRIDGE.setExpanded.channel)?.(event, true), "expanded");
+});
+
+test("workspace-only providers reach workspace creation", async () => {
+  const fixture = fixtureHost(true);
+  registerBridge(
+    BRIDGE,
+    {
+      createSessionWorkspace: (_context, providerId) => ({
+        status: ACT_RESULT_STATUS.ACCEPTED,
+        providerSessionId: providerId,
+      }),
+    },
+    fixture.host,
+  );
+  // SAFETY: registerBridge reads only the sender field supplied by this focused fixture.
+  const event = { sender: {} } as IpcMainInvokeEvent;
+  const invoke = fixture.invokes.get(BRIDGE.createSessionWorkspace.channel);
+
+  for (const providerId of [
+    SUPERSET_WORKSPACE_PROVIDER_ID,
+    CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
+  ]) {
+    assert.deepEqual(await invoke?.(event, providerId, "project-1"), {
+      status: ACT_RESULT_STATUS.ACCEPTED,
+      providerSessionId: providerId,
+    });
+  }
 });
 
 test("an omitted optional argument cannot steal the bridge context", async () => {

--- a/apps/desktop/src/shared/bridge.ts
+++ b/apps/desktop/src/shared/bridge.ts
@@ -37,6 +37,7 @@ import {
   isProviderId,
   isSessionApplicationId,
   isWorkspaceAgentSelection,
+  isWorkspaceProviderId,
   type ObservedWorkspaceProject,
   type ProviderActResult,
   type ProviderControlResult,
@@ -528,7 +529,7 @@ export const BRIDGE = {
           v.length < 2 ||
           v.length > 7 ||
           !isWireString(v[0]) ||
-          !isProviderId(v[0]) ||
+          !isWorkspaceProviderId(v[0]) ||
           !isWireString(v[1])
         )
           return false;


### PR DESCRIPTION
## Summary

- allow workspace-only provider IDs through the workspace creation bridge
- restore Superset and local Conductor workspace launches
- cover both provider IDs at the Electron IPC boundary

## Test plan

- [x] ./scripts/check.sh
- [x] focused bridge regression test
- [x] desktop typecheck

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32809096842/artifacts/9549217813) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32809096842)

- Commit: `52b5bd0475bc35760f3eb284c1fd5d52a26527d0`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
