### PR TITLE
v0.3.10 chore: prepare Luke release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,54 @@
 Notable changes to Luke, newest first. Each heading is a released version and
 the date its release was published.
 
+## 0.3.10 — 2026-08-24
+
+### A proper introduction
+
+Luke introduces himself on the first interactive launch, points out the coding
+agents already running on your Mac, and hands off to the ordinary signed-out
+panel when the conversation ends. The introduction runs without an account,
+asks for the microphone only when it needs one, and cannot take actions.
+([#497](https://github.com/ReviewStage/luke/pull/497),
+[#508](https://github.com/ReviewStage/luke/pull/508))
+
+### Improvements
+
+- Luke is more conversational and proactive about work that needs your
+  attention ([#500](https://github.com/ReviewStage/luke/pull/500))
+- Luke draws loading rows while a provider roster is temporarily unreadable
+  instead of making those agents disappear
+  ([#498](https://github.com/ReviewStage/luke/pull/498))
+- The website demonstrates Luke's panel with a live mesh gradient and an
+  animated tour of its presentations
+  ([#499](https://github.com/ReviewStage/luke/pull/499),
+  [#502](https://github.com/ReviewStage/luke/pull/502),
+  [#504](https://github.com/ReviewStage/luke/pull/504))
+
+### Fixes
+
+- Fixed Preview deployments failing to complete sign-in
+  ([#408](https://github.com/ReviewStage/luke/pull/408))
+- Fixed workspace creation losing the provider selected in Settings
+  ([#475](https://github.com/ReviewStage/luke/pull/475))
+- Fixed the web service omitting the acts package from its runtime wiring
+  ([#495](https://github.com/ReviewStage/luke/pull/495))
+- Fixed signed-out voice runs reporting the wrong missing credential
+  ([#505](https://github.com/ReviewStage/luke/pull/505))
+- Fixed workspace-only providers being rejected by the desktop bridge
+  ([#507](https://github.com/ReviewStage/luke/pull/507))
+- Fixed Apple notarization uploads using the accelerated transfer path that
+  could leave incomplete submissions stuck as In Progress
+
+### Miscellaneous
+
+- Updated the README and privacy policy for the current product behavior
+  ([#474](https://github.com/ReviewStage/luke/pull/474),
+  [#476](https://github.com/ReviewStage/luke/pull/476))
+- Updated the account connection pages and the internal animation reference
+  ([#488](https://github.com/ReviewStage/luke/pull/488),
+  [#501](https://github.com/ReviewStage/luke/pull/501))
+
 ## 0.3.9 — 2026-08-23
 
 ### More agents, one roster

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@luke/desktop",
   "productName": "Luke",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "description": "Luke desktop application",
   "main": "dist/main.js",

--- a/apps/desktop/scripts/release-config.mjs
+++ b/apps/desktop/scripts/release-config.mjs
@@ -78,9 +78,9 @@ function notaryCredentialArguments(credentials) {
   return ["--keychain-profile", NOTARY_KEYCHAIN_PROFILE];
 }
 
-// notarytool's own --wait crashes with SIGBUS on most runs, and the upload has
-// already reached Apple by the time it does, so resubmitting would only
-// duplicate a submission that is already queued: submit once, then poll.
+// notarytool's own --wait crashes with SIGBUS on most runs, and its accelerated
+// upload path has left incomplete submissions reported as In Progress. Use the
+// alternate endpoint, submit once, then poll the returned submission id.
 export function notarySubmitArguments(artifactPath, credentials) {
   return [
     "notarytool",
@@ -89,6 +89,7 @@ export function notarySubmitArguments(artifactPath, credentials) {
     ...notaryCredentialArguments(credentials),
     "--output-format",
     "json",
+    "--no-s3-acceleration",
   ];
 }
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luke/web",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "description": "Luke landing page",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luke",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "description": "A notch-attached desktop sidecar for coding-agent sessions",
   "packageManager": "pnpm@10.34.5",

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/account",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/acts/package.json
+++ b/packages/acts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/acts",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/analytics",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/attention/package.json
+++ b/packages/attention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/attention",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/calendar",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/credentials",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/feedback",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/fixtures/package.json
+++ b/packages/fixtures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/fixtures",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/guide/package.json
+++ b/packages/guide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/guide",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hosted/package.json
+++ b/packages/hosted/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/hosted",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/issues/package.json
+++ b/packages/issues/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/issues",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/panel/package.json
+++ b/packages/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/panel",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/process",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/providers",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/realtime",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/session",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/settings",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/superset/package.json
+++ b/packages/superset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/superset",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/surface/package.json
+++ b/packages/surface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/surface",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/trackers/package.json
+++ b/packages/trackers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/trackers",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/voice",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/wire/package.json
+++ b/packages/wire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/wire",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -50,7 +50,7 @@ function builderConfig(env = {}) {
   return createElectronBuilderConfig(env);
 }
 
-test("workspace package versions agree on v0.3.9", () => {
+test("workspace package versions agree on v0.3.10", () => {
   // Enumerated rather than listed, so a package added to the workspace is held
   // to the release version without anyone remembering to name it here.
   const packagePaths = [
@@ -74,7 +74,7 @@ test("workspace package versions agree on v0.3.9", () => {
 
   assert.deepEqual(
     versions.map(({ version }) => version),
-    packagePaths.map(() => "0.3.9"),
+    packagePaths.map(() => "0.3.10"),
   );
 });
 

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -166,6 +166,7 @@ test("release notarization commands carry key-file credentials", () => {
     "issuer-id",
     "--output-format",
     "json",
+    "--no-s3-acceleration",
   ]);
   assert.deepEqual(notaryInfoArguments("submission-id", credentials), [
     "notarytool",
@@ -203,6 +204,7 @@ test("release notarization commands use the local keychain profile", () => {
     "luke-notary",
     "--output-format",
     "json",
+    "--no-s3-acceleration",
   ]);
   assert.deepEqual(notaryInfoArguments("submission-id", credentials), [
     "notarytool",
@@ -223,7 +225,7 @@ test("release notarization commands use the local keychain profile", () => {
   assert.deepEqual(stapleArguments("/tmp/Luke.dmg"), ["stapler", "staple", "/tmp/Luke.dmg"]);
 });
 
-test("neither notarization path asks notarytool to wait", () => {
+test("notarization uses the stable upload path without asking notarytool to wait", () => {
   const credentials = { source: NOTARY_CREDENTIAL_SOURCE.KEYCHAIN_PROFILE };
   const builderConfig = createElectronBuilderConfig();
   const hooks = fs.readFileSync(
@@ -233,6 +235,7 @@ test("neither notarization path asks notarytool to wait", () => {
 
   assert.ok(!notarySubmitArguments("/tmp/Luke.dmg", credentials).includes("--wait"));
   assert.ok(!notarySubmitArguments("/tmp/Luke.dmg", credentials).includes("--timeout"));
+  assert.ok(notarySubmitArguments("/tmp/Luke.dmg", credentials).includes("--no-s3-acceleration"));
   assert.equal(builderConfig.mac.notarize, false);
   assert.ok(hooks.includes("notaryInfoArguments(submission.id, credentials)"));
 });


### PR DESCRIPTION
## Summary

- Prepare Luke 0.3.10 across all 25 versioned workspace packages
- Add release notes for the spoken onboarding introduction, proactive conversation updates, loading states, website motion, and fixes shipped since v0.3.9
- Send Apple notarization uploads through the stable non-accelerated endpoint while retaining bounded submit-and-poll behavior

## Test Coverage

The notarization change has 100% path coverage: key-file credentials, keychain credentials, and the submit-once/poll flow are all exercised. No gaps were found.

Tests: 185 → 185 (+0 new files)

## Pre-Landing Review

No issues found.

## Design Review

No frontend implementation changed in this PR. All six generated fixture states were inspected during `./scripts/verify.sh`.

## Eval Results

No prompt-related files changed; evals skipped.

## Plan Completion

No relevant plan detected.

## Verification Results

- [x] `./scripts/bootstrap.sh`
- [x] `./scripts/check.sh` (40 harness tests and 762 workspace tests, plus typecheck and builds)
- [x] `./scripts/verify.sh` (macOS packaging and six fixture evidence states)
- [x] Focused release and packaging tests (36/36)
- [x] All 25 workspace package versions agree on 0.3.10

## Test plan

- [x] Verify both notarization credential modes include `--no-s3-acceleration`
- [x] Verify notarization never uses `--wait` or `--timeout`
- [x] Verify electron-builder still submits once and polls Apple by submission ID
- [x] Verify generated macOS artifacts and fixture evidence

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32815016543/artifacts/9551149479) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32815016543)

- Commit: `1dd1a7a3ae868c2d25aa8a220f4e721a325ade62`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
