### PR TITLE
fix(desktop): backfill introduction completion on signed-in launch

### DIFF
--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -124,6 +124,7 @@ import {
   INTRODUCTION_STATE_FILE,
   introductionCompleted,
   introductionRecord,
+  shouldBackfillIntroductionCompletion,
   shouldRunIntroduction,
 } from "./introduction-flow";
 import { registerAccountSessionIpc } from "./ipc/account-session";
@@ -2230,11 +2231,16 @@ export function startDesktopApp(): void {
       // spoken introduction plays on. Everything below reads the takeover's
       // liveness rather than this flag, because the introduction can end —
       // completed or abandoned — while the launch is still settling.
-      const giveIntroduction = shouldRunIntroduction({
+      const introductionInput = {
         requiresAccount: runMode.requiresAccount,
         signedIn: account.status === ACCOUNT_STATUS.SIGNED_IN,
         completed: introductionCompletedOnDisk(),
-      });
+      };
+      const giveIntroduction = shouldRunIntroduction(introductionInput);
+      // A signed-in launch that never wrote the record — an install upgrading
+      // from before the introduction existed — writes it now, so a later
+      // sign-out lands on the ordinary gate instead of a first meeting.
+      if (shouldBackfillIntroductionCompletion(introductionInput)) markIntroductionComplete();
       await panels.refreshGeometry();
       registerIpc();
       // Resolving settings touches the filesystem, and the OS keychain only for a

--- a/apps/desktop/src/main/introduction-flow.test.ts
+++ b/apps/desktop/src/main/introduction-flow.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   introductionCompleted,
   introductionRecord,
+  shouldBackfillIntroductionCompletion,
   shouldRunIntroduction,
 } from "./introduction-flow";
 
@@ -30,6 +31,44 @@ test("a deterministic run never gives the introduction", () => {
 test("a completed introduction never replays", () => {
   assert.equal(
     shouldRunIntroduction({ requiresAccount: true, signedIn: false, completed: true }),
+    false,
+  );
+});
+
+test("a signed-in launch with no record backfills one, so a sign-out cannot replay", () => {
+  assert.equal(
+    shouldBackfillIntroductionCompletion({
+      requiresAccount: true,
+      signedIn: true,
+      completed: false,
+    }),
+    true,
+  );
+});
+
+test("a launch with the record on file, or none to prove a meeting, backfills nothing", () => {
+  assert.equal(
+    shouldBackfillIntroductionCompletion({
+      requiresAccount: true,
+      signedIn: true,
+      completed: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldBackfillIntroductionCompletion({
+      requiresAccount: true,
+      signedIn: false,
+      completed: false,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldBackfillIntroductionCompletion({
+      requiresAccount: false,
+      signedIn: true,
+      completed: false,
+    }),
     false,
   );
 });

--- a/apps/desktop/src/main/introduction-flow.ts
+++ b/apps/desktop/src/main/introduction-flow.ts
@@ -63,6 +63,22 @@ export function shouldRunIntroduction(input: {
   return input.requiresAccount && !input.signedIn && !input.completed;
 }
 
+/**
+ * Whether this launch should write the completion record without playing
+ * anything. A signed-in launch proves the user has already met Luke — an
+ * install that predates the introduction upgrades into exactly this state —
+ * and without the record on file, a later sign-out would replay a first
+ * meeting to someone months in. Only an interactive launch may write it: a
+ * fixture or capture run says nothing about who has met whom.
+ */
+export function shouldBackfillIntroductionCompletion(input: {
+  requiresAccount: boolean;
+  signedIn: boolean;
+  completed: boolean;
+}): boolean {
+  return input.requiresAccount && input.signedIn && !input.completed;
+}
+
 /** Whether a stored record says the introduction finished. */
 export function introductionCompleted(stored: string | undefined): boolean {
   if (stored === undefined) return false;


### PR DESCRIPTION
## Problem

The spoken introduction plays on a signed-out interactive launch with no completion record on file. An install that predates v0.3.10 upgrades signed in — so the introduction is correctly skipped — but nothing writes the completion record on that path. If that user later signs out and relaunches, the launch sees signed-out + no record and plays the full first-meeting takeover to someone who has been using Luke for months.

## Fix

A signed-in interactive launch proves the user has already met Luke (the principle `shouldRunIntroduction`'s doc already states), so the launch now persists that knowledge: a new pure decision, `shouldBackfillIntroductionCompletion`, returns true for a signed-in launch that requires an account and has no record, and `desktop-app` writes the existing completion record when it does. Fixture and capture runs (`requiresAccount: false`) backfill nothing.

This is self-healing for every pre-introduction install the first time it launches v0.3.10+ signed in, and it also covers a fresh install that abandoned the introduction and then signed in: once signed in, a later sign-out lands on the ordinary gate, never a replayed first meeting.

## Testing

- `./scripts/check.sh` passes (exit 0); new unit tests cover the backfill decision on all four input corners.
- No UI change: the introduction window, script, and completion record shape are untouched — only when the record gets written widened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/1cd1460e-2308-4b3e-88df-251116e99e9a)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32882767354/artifacts/9576530602) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32882767354)

- Commit: `b06c386c41a768d477bc29b11807b22654e91512`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
