### PR TITLE
feat(desktop): add Luke conversation history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,7 +302,7 @@ Trust constraints:
   posture Luke keeps. The one explicit blocked subtree is History: its root
   carries the recording library's fixed blocking class, so the conversation's
   words do not leave the machine in a recording. That view retains every
-  bounded line from the current renderer lifetime until the developer clears
+  bounded line from the current renderer lifetime, including session acts, until the developer clears
   it or quits, while only the 20 most recent lines enter model context. There
   is no general masking module to consult and nothing that makes any other new
   component silent by construction, so what a recording may see is decided by

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,30 +292,36 @@ Trust constraints:
   them. Both stop with the recording switch, because the client opts out
   rather than only stopping the recorder; a switch that named recording and
   left these running would be a consent nobody gave.
-- The replay stream has the opposite shape from the counted events. It records
-  the rendered panel, so everything drawn travels: a session's title, branch,
-  recap, and error line, the account's own name and address, and any
+- The replay stream has the opposite shape from the counted events. Except for
+  the conversation History tab, it records the rendered panel, so everything
+  drawn travels: a session's title, branch, recap, and error line, the account's
+  own name and address, and any
   screenshot attached to the feedback composer, which is drawn as its own
   bytes and which input masking does not reach. The one thing withheld is what
   is typed into a field, and that is the library's default rather than a
-  posture Luke keeps. There is no masking module to consult and nothing that
-  makes a new component silent by construction, so what a recording may see is
-  decided by what the panel draws — which makes drawing something new on the
-  panel a decision about what leaves the machine. It is still Luke's own panel
-  and never the machine's screen. Recording posts to the provider directly,
-  and it begins at the first paint of every ordinary launch, before any
-  account exists and through the spoken introduction, because the launch is
-  where a first run goes wrong and a recording that waited for a sign-in never
-  saw it. Recording is the one place an account id travels to the desktop, and
-  it travels for what it does when a sign-in lands: the anonymous session
-  already running is joined to that person, so it files with their counts and
-  is erased with them. A session that never reaches a sign-in stays anonymous
-  and can be erased with no account, which is a thing `PRIVACY.md` has to say
-  in as many words rather than leave to be inferred. Deleting an account
-  stands recording down for the rest of that run, unlike signing out, which
-  leaves an anonymous recording running the way the launch before the sign-in
-  was: nothing erased is re-created either way, but a recorder starting up
-  again on the panel that just erased everything reads as though something
+  posture Luke keeps. The one explicit blocked subtree is History: its root
+  carries the recording library's fixed blocking class, so the conversation's
+  words do not leave the machine in a recording. That view retains every
+  bounded line from the current renderer lifetime until the developer clears
+  it or quits, while only the 20 most recent lines enter model context. There
+  is no general masking module to consult and nothing that makes any other new
+  component silent by construction, so what a recording may see is decided by
+  what the panel draws or explicitly blocks — which makes drawing something
+  new on the panel a decision about what leaves the machine. It is still Luke's
+  own panel and never the machine's screen. Recording posts to the provider
+  directly, and it begins at the first paint of every ordinary launch, before
+  any account exists and through the spoken introduction, because the launch
+  is where a first run goes wrong and a recording that waited for a sign-in
+  never saw it. Recording is the one place an account id travels to the
+  desktop, and it travels for what it does when a sign-in lands: the anonymous
+  session already running is joined to that person, so it files with their
+  counts and is erased with them. A session that never reaches a sign-in stays
+  anonymous and can be erased with no account, which is a thing `PRIVACY.md`
+  has to say in as many words rather than leave to be inferred. Deleting an
+  account stands recording down for the rest of that run, unlike signing out,
+  which leaves an anonymous recording running the way the launch before the
+  sign-in was: nothing erased is re-created either way, but a recorder starting
+  up again on the panel that just erased everything reads as though something
   were, and deletion is the one act treated here as unrecoverable.
   None of the three sends anything in a fixture or evidence run, or while the
   developer has switched sharing off. The counts have their own switch and the

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -14,7 +14,10 @@ contents, or command output, and it writes none of this to disk. If you run
 agents inside the Herdr terminal manager, Luke also asks Herdr's own
 command-line tool which of those sessions it holds, so their rows can say so;
 that read never starts Herdr, reads no terminal output, and sends nothing
-anywhere. It stays on your Mac unless a feature below sends it.
+anywhere. It stays on your Mac unless a feature below sends it. Luke also keeps
+your conversation with him in memory for the current app launch so you can
+review it; it is never written to disk, and only the 20 most recent entries are
+carried into a call.
 
 **Your account.** Signing in with Google or GitHub gives us your name, email
 address, and which of the two you used. We also keep the records that keep you
@@ -29,11 +32,12 @@ branches, file paths, summaries, prompts, or error text.
 screen, your editor, your terminal, or any other app. A recording shows whatever
 the panel showed you, including session titles, branches, summaries and error
 text, your name and email address, and any screenshot you attached to the
-feedback form. Text you type into a field is replaced with blocks before the
-recording leaves your Mac, so an API key or a sign-in code you enter is not in
-it. While recording is on, Luke also reports what you clicked, including the
-text on it, and any error his panel runs into, with its message and code path;
-the fixed list above does not cover those two.
+feedback form. The History tab is blocked from recordings, so the words in your
+conversation with Luke are not included. Text you type into a field is replaced
+with blocks before the recording leaves your Mac, so an API key or a sign-in
+code you enter is not in it. While recording is on, Luke also reports what you
+clicked, including the text on it, and any error his panel runs into, with its
+message and code path; the fixed list above does not cover those two.
 
 Recording starts when Luke opens, before you sign in, so it covers the spoken
 introduction on first launch and the signed-out panel. A recording that begins

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Hold <kbd>⌥</kbd><kbd>Space</kbd> to talk to Luke from any app, or press
 status of your agents, kick fresh ones off for you, or message them on your
 behalf.
 
+The **History** tab keeps the complete conversation from the current app launch
+on your Mac until you clear it or quit. It is not saved or exportable, and only
+the 20 most recent entries are carried into Luke's next call.
+
 ![Luke's capsule under the notch, speaking a summary of which sessions finished and which are waiting.](docs/media/luke-talking.png)
 
 ### Announcements

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -2079,6 +2079,8 @@ export function App(): React.JSX.Element {
     startMicrophone,
     stopMicrophone,
     askLuke,
+    conversationHistory,
+    clearConversationHistory,
     voiceTurn,
     lukeCaptions,
     mentionedSessions,
@@ -2753,7 +2755,7 @@ export function App(): React.JSX.Element {
         if (presentation !== PANEL_PRESENTATION.PANEL) return;
         event.preventDefault();
         if (tab === PANEL_TAB.SETTINGS) openSettingsSearch();
-        else openSearch();
+        else if (tab === PANEL_TAB.SESSIONS) openSearch();
         return;
       }
       if (event.key !== "Escape") return;
@@ -2805,6 +2807,7 @@ export function App(): React.JSX.Element {
       else if (tab === PANEL_TAB.SETTINGS && settingsView !== SETTINGS_VIEW.ROOT) {
         setSettingsView(SETTINGS_VIEW.ROOT);
       } else if (tab === PANEL_TAB.SETTINGS) changeTab(PANEL_TAB.SESSIONS);
+      else if (tab === PANEL_TAB.HISTORY) changeTab(PANEL_TAB.SESSIONS);
       else void changeMode(false);
     };
     window.addEventListener("keydown", handleKey);
@@ -3212,6 +3215,8 @@ export function App(): React.JSX.Element {
             onOpenSession={openSession}
             onOpenSessionApplication={openSessionApplication}
             writes={sessionWrites}
+            conversationHistory={conversationHistory}
+            onClearConversationHistory={clearConversationHistory}
             ask={askLuke}
             // Reaching for the composer during a spent day is answered before
             // a keystroke: the caret arriving re-announces the spent caption

--- a/apps/desktop/src/renderer/conversation-history-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-history-panel.test.ts
@@ -20,19 +20,41 @@ test("conversation asks are shown as the developer's own words", () => {
   });
 });
 
-test("Luke replies and non-dialogue events stay distinct", () => {
+test("Luke replies and announcements use the received-message side", () => {
   assert.deepEqual(historyEntryPresentation(CONVERSATION_ENTRY_KIND.REPLY), {
     speaker: HISTORY_ENTRY_SPEAKER.LUKE,
     label: "Luke",
   });
-  assert.equal(
-    historyEntryPresentation(CONVERSATION_ENTRY_KIND.ANNOUNCEMENT).speaker,
-    HISTORY_ENTRY_SPEAKER.EVENT,
-  );
+  assert.deepEqual(historyEntryPresentation(CONVERSATION_ENTRY_KIND.ANNOUNCEMENT), {
+    speaker: HISTORY_ENTRY_SPEAKER.LUKE,
+    label: "Luke",
+  });
+});
+
+test("session acts remain quiet events between messages", () => {
   assert.equal(
     historyEntryPresentation(CONVERSATION_ENTRY_KIND.ACT).speaker,
     HISTORY_ENTRY_SPEAKER.EVENT,
   );
+});
+
+test("an announcement shows its readable copy instead of model context", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ConversationHistoryPanel, {
+      entries: [
+        {
+          kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
+          words: 'provider: "Codex"; event: finished; work recap: "Checkout is ready."',
+          displayWords: "Checkout is ready.",
+        },
+      ],
+      onClear: () => undefined,
+    }),
+  );
+
+  assert.match(markup, /data-speaker="luke"/);
+  assert.match(markup, />Checkout is ready\.<\/p>/);
+  assert.doesNotMatch(markup, /provider:|work recap:/);
 });
 
 test("conversation history is blocked from optional panel recordings", () => {

--- a/apps/desktop/src/renderer/conversation-history-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-history-panel.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { CONVERSATION_ENTRY_KIND } from "@sidecar/realtime";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+  ConversationHistoryPanel,
+  HISTORY_ENTRY_SPEAKER,
+  historyEntryPresentation,
+} from "./conversation-history-panel";
+
+test("conversation asks are shown as the developer's own words", () => {
+  assert.deepEqual(historyEntryPresentation(CONVERSATION_ENTRY_KIND.TYPED_ASK), {
+    speaker: HISTORY_ENTRY_SPEAKER.YOU,
+    label: "You",
+  });
+  assert.deepEqual(historyEntryPresentation(CONVERSATION_ENTRY_KIND.SPOKEN_ASK), {
+    speaker: HISTORY_ENTRY_SPEAKER.YOU,
+    label: "You",
+  });
+});
+
+test("Luke replies and non-dialogue events stay distinct", () => {
+  assert.deepEqual(historyEntryPresentation(CONVERSATION_ENTRY_KIND.REPLY), {
+    speaker: HISTORY_ENTRY_SPEAKER.LUKE,
+    label: "Luke",
+  });
+  assert.equal(
+    historyEntryPresentation(CONVERSATION_ENTRY_KIND.ANNOUNCEMENT).speaker,
+    HISTORY_ENTRY_SPEAKER.EVENT,
+  );
+  assert.equal(
+    historyEntryPresentation(CONVERSATION_ENTRY_KIND.ACT).speaker,
+    HISTORY_ENTRY_SPEAKER.EVENT,
+  );
+});
+
+test("conversation history is blocked from optional panel recordings", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ConversationHistoryPanel, {
+      entries: [{ kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: "private words" }],
+      onClear: () => undefined,
+    }),
+  );
+
+  assert.match(markup, /class="history-view ph-no-capture"/);
+});

--- a/apps/desktop/src/renderer/conversation-history-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-history-panel.test.ts
@@ -44,4 +44,17 @@ test("conversation history is blocked from optional panel recordings", () => {
   );
 
   assert.match(markup, /class="history-view ph-no-capture"/);
+  assert.doesNotMatch(markup, /stays in memory|typed or spoken exchange/);
+});
+
+test("the empty history reports only its state", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ConversationHistoryPanel, {
+      entries: [],
+      onClear: () => undefined,
+    }),
+  );
+
+  assert.match(markup, />No conversation yet</);
+  assert.doesNotMatch(markup, /history-header|next typed|stays in memory/);
 });

--- a/apps/desktop/src/renderer/conversation-history-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-history-panel.test.ts
@@ -44,6 +44,7 @@ test("conversation history is blocked from optional panel recordings", () => {
   );
 
   assert.match(markup, /class="history-view ph-no-capture"/);
+  assert.match(markup, /<small class="visually-hidden">You<\/small>/);
   assert.doesNotMatch(markup, /stays in memory|typed or spoken exchange/);
 });
 
@@ -55,6 +56,6 @@ test("the empty history reports only its state", () => {
     }),
   );
 
-  assert.match(markup, />No conversation yet</);
+  assert.match(markup, />No messages yet</);
   assert.doesNotMatch(markup, /history-header|next typed|stays in memory/);
 });

--- a/apps/desktop/src/renderer/conversation-history-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-history-panel.tsx
@@ -26,9 +26,8 @@ export function historyEntryPresentation(kind: ConversationEntryKind): HistoryEn
     case CONVERSATION_ENTRY_KIND.SPOKEN_ASK:
       return { speaker: HISTORY_ENTRY_SPEAKER.YOU, label: "You" };
     case CONVERSATION_ENTRY_KIND.REPLY:
-      return { speaker: HISTORY_ENTRY_SPEAKER.LUKE, label: "Luke" };
     case CONVERSATION_ENTRY_KIND.ANNOUNCEMENT:
-      return { speaker: HISTORY_ENTRY_SPEAKER.EVENT, label: "Luke updated you" };
+      return { speaker: HISTORY_ENTRY_SPEAKER.LUKE, label: "Luke" };
     case CONVERSATION_ENTRY_KIND.ACT:
       return { speaker: HISTORY_ENTRY_SPEAKER.EVENT, label: "At your request" };
   }
@@ -39,7 +38,7 @@ function HistoryEntryRow({ entry }: { entry: ConversationEntry }): React.JSX.Ele
   return (
     <li className="history-entry" data-speaker={presentation.speaker}>
       <small className="visually-hidden">{presentation.label}</small>
-      <p>{entry.words}</p>
+      <p>{entry.displayWords ?? entry.words}</p>
     </li>
   );
 }
@@ -49,7 +48,7 @@ function keyedHistoryEntries(entries: readonly ConversationEntry[]) {
   const occurrences = new Map<string, number>();
   return entries.map((entry) => {
     const identity = entry.identity;
-    const base = `${entry.kind}:${entry.words}:${identity?.providerId ?? ""}:${identity?.providerSessionId ?? ""}`;
+    const base = `${entry.kind}:${entry.words}:${entry.displayWords ?? ""}:${identity?.providerId ?? ""}:${identity?.providerSessionId ?? ""}`;
     const occurrence = (occurrences.get(base) ?? 0) + 1;
     occurrences.set(base, occurrence);
     return { entry, key: `${base}:${occurrence}` };

--- a/apps/desktop/src/renderer/conversation-history-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-history-panel.tsx
@@ -1,0 +1,134 @@
+import {
+  CONVERSATION_ENTRY_KIND,
+  type ConversationEntry,
+  type ConversationEntryKind,
+} from "@sidecar/realtime";
+import { useEffect, useRef, useState } from "react";
+import { PANEL_TAB, panelPanelId, panelTabId } from "./panel-tabs";
+
+export const HISTORY_ENTRY_SPEAKER = {
+  YOU: "you",
+  LUKE: "luke",
+  EVENT: "event",
+} as const;
+
+type HistoryEntrySpeaker = (typeof HISTORY_ENTRY_SPEAKER)[keyof typeof HISTORY_ENTRY_SPEAKER];
+
+export interface HistoryEntryPresentation {
+  speaker: HistoryEntrySpeaker;
+  label: string;
+}
+
+/** The user-facing voice for each kind of line in Luke's current-launch thread. */
+export function historyEntryPresentation(kind: ConversationEntryKind): HistoryEntryPresentation {
+  switch (kind) {
+    case CONVERSATION_ENTRY_KIND.TYPED_ASK:
+    case CONVERSATION_ENTRY_KIND.SPOKEN_ASK:
+      return { speaker: HISTORY_ENTRY_SPEAKER.YOU, label: "You" };
+    case CONVERSATION_ENTRY_KIND.REPLY:
+      return { speaker: HISTORY_ENTRY_SPEAKER.LUKE, label: "Luke" };
+    case CONVERSATION_ENTRY_KIND.ANNOUNCEMENT:
+      return { speaker: HISTORY_ENTRY_SPEAKER.EVENT, label: "Luke updated you" };
+    case CONVERSATION_ENTRY_KIND.ACT:
+      return { speaker: HISTORY_ENTRY_SPEAKER.EVENT, label: "At your request" };
+  }
+}
+
+function HistoryEntryRow({ entry }: { entry: ConversationEntry }): React.JSX.Element {
+  const presentation = historyEntryPresentation(entry.kind);
+  return (
+    <li className="history-entry" data-speaker={presentation.speaker}>
+      <small>{presentation.label}</small>
+      <p>{entry.words}</p>
+    </li>
+  );
+}
+
+/** Stable enough for repeated identical lines without pretending the record has durable ids. */
+function keyedHistoryEntries(entries: readonly ConversationEntry[]) {
+  const occurrences = new Map<string, number>();
+  return entries.map((entry) => {
+    const identity = entry.identity;
+    const base = `${entry.kind}:${entry.words}:${identity?.providerId ?? ""}:${identity?.providerSessionId ?? ""}`;
+    const occurrence = (occurrences.get(base) ?? 0) + 1;
+    occurrences.set(base, occurrence);
+    return { entry, key: `${base}:${occurrence}` };
+  });
+}
+
+export function ConversationHistoryPanel({
+  entries,
+  onClear,
+}: {
+  entries: readonly ConversationEntry[];
+  onClear: () => void;
+}): React.JSX.Element {
+  const [confirmingClear, setConfirmingClear] = useState(false);
+  const list = useRef<HTMLOListElement | null>(null);
+  const entryCount = entries.length;
+
+  useEffect(() => {
+    // Reading the count binds the scroll to an append or clear, not to an
+    // unrelated render of the same history.
+    if (entryCount === 0) return;
+    const element = list.current;
+    if (element) element.scrollTop = element.scrollHeight;
+  }, [entryCount]);
+
+  useEffect(() => {
+    if (entries.length === 0) setConfirmingClear(false);
+  }, [entries.length]);
+
+  return (
+    <section
+      // PostHog blocks this fixed class and its whole subtree. Conversation
+      // history belongs on this screen, but never in an optional recording.
+      className="history-view ph-no-capture"
+      role="tabpanel"
+      id={panelPanelId(PANEL_TAB.HISTORY)}
+      aria-labelledby={panelTabId(PANEL_TAB.HISTORY)}
+    >
+      <header className="history-header">
+        <p>This launch's conversation stays in memory until you clear it or quit.</p>
+        {entries.length > 0 ? (
+          <span className="history-clear-controls">
+            {confirmingClear ? (
+              <button
+                type="button"
+                className="history-clear-cancel"
+                onClick={() => setConfirmingClear(false)}
+              >
+                Cancel
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className="history-clear"
+              onClick={() => {
+                if (!confirmingClear) {
+                  setConfirmingClear(true);
+                  return;
+                }
+                onClear();
+              }}
+            >
+              {confirmingClear ? "Clear history" : "Clear"}
+            </button>
+          </span>
+        ) : null}
+      </header>
+      {entries.length === 0 ? (
+        <div className="history-empty">
+          <strong>No conversation yet</strong>
+          <span>Your next typed or spoken exchange with Luke will appear here.</span>
+        </div>
+      ) : (
+        <ol className="history-list" ref={list}>
+          {keyedHistoryEntries(entries).map(({ entry, key }) => (
+            <HistoryEntryRow key={key} entry={entry} />
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/apps/desktop/src/renderer/conversation-history-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-history-panel.tsx
@@ -38,7 +38,7 @@ function HistoryEntryRow({ entry }: { entry: ConversationEntry }): React.JSX.Ele
   const presentation = historyEntryPresentation(entry.kind);
   return (
     <li className="history-entry" data-speaker={presentation.speaker}>
-      <small>{presentation.label}</small>
+      <small className="visually-hidden">{presentation.label}</small>
       <p>{entry.words}</p>
     </li>
   );
@@ -118,7 +118,7 @@ export function ConversationHistoryPanel({
       ) : null}
       {entries.length === 0 ? (
         <div className="history-empty">
-          <strong>No conversation yet</strong>
+          <strong>No messages yet</strong>
         </div>
       ) : (
         <ol className="history-list" ref={list}>

--- a/apps/desktop/src/renderer/conversation-history-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-history-panel.tsx
@@ -88,9 +88,8 @@ export function ConversationHistoryPanel({
       id={panelPanelId(PANEL_TAB.HISTORY)}
       aria-labelledby={panelTabId(PANEL_TAB.HISTORY)}
     >
-      <header className="history-header">
-        <p>This launch's conversation stays in memory until you clear it or quit.</p>
-        {entries.length > 0 ? (
+      {entries.length > 0 ? (
+        <header className="history-header">
           <span className="history-clear-controls">
             {confirmingClear ? (
               <button
@@ -115,12 +114,11 @@ export function ConversationHistoryPanel({
               {confirmingClear ? "Clear history" : "Clear"}
             </button>
           </span>
-        ) : null}
-      </header>
+        </header>
+      ) : null}
       {entries.length === 0 ? (
         <div className="history-empty">
           <strong>No conversation yet</strong>
-          <span>Your next typed or spoken exchange with Luke will appear here.</span>
         </div>
       ) : (
         <ol className="history-list" ref={list}>

--- a/apps/desktop/src/renderer/luke-errand.test.ts
+++ b/apps/desktop/src/renderer/luke-errand.test.ts
@@ -126,6 +126,9 @@ test("showing a tab is signed on that tab", () => {
   assert.deepEqual(errandTargets({ kind: "panel", tab: APP_PANEL_TAB.SESSIONS }), [
     ERRAND_TARGET.SESSIONS_TAB,
   ]);
+  assert.deepEqual(errandTargets({ kind: "panel", tab: APP_PANEL_TAB.HISTORY }), [
+    ERRAND_TARGET.HISTORY_TAB,
+  ]);
   assert.deepEqual(errandTargets({ kind: "panel", tab: APP_PANEL_TAB.SETTINGS }), [
     ERRAND_TARGET.SETTINGS_TAB,
   ]);

--- a/apps/desktop/src/renderer/luke-errand.tsx
+++ b/apps/desktop/src/renderer/luke-errand.tsx
@@ -79,6 +79,7 @@ export const ERRAND_ORIGIN_ATTRIBUTE = "data-errand-origin";
  */
 export const ERRAND_TARGET = {
   SESSIONS_TAB: "tab-sessions",
+  HISTORY_TAB: "tab-history",
   SETTINGS_TAB: "tab-settings",
   LIST_OPTIONS: "list-options",
   LIST_CLEAR: "list-clear",
@@ -89,6 +90,7 @@ export type ErrandTarget = AppSettingId | (typeof ERRAND_TARGET)[keyof typeof ER
 
 const TAB_ERRAND_TARGET = {
   [APP_PANEL_TAB.SESSIONS]: ERRAND_TARGET.SESSIONS_TAB,
+  [APP_PANEL_TAB.HISTORY]: ERRAND_TARGET.HISTORY_TAB,
   [APP_PANEL_TAB.SETTINGS]: ERRAND_TARGET.SETTINGS_TAB,
 };
 

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -382,7 +382,7 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
       label: "Conversation history",
       detail:
         "The panel's History tab shows every typed ask, transcribed spoken ask, reply, " +
-        "announcement, and act from this app launch. Luke carries only the 20 most recent " +
+        "announcement, and session act from this app launch. Luke carries only the 20 most recent " +
         "entries into a call. The full view stays only in this app's memory, is blocked from " +
         "optional panel recordings, disappears when Luke quits, and can be cleared by hand " +
         "from that tab. It is not saved or exportable.",

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -379,6 +379,15 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "can search it.",
     },
     {
+      label: "Conversation history",
+      detail:
+        "The panel's History tab shows every typed ask, transcribed spoken ask, reply, " +
+        "announcement, and act from this app launch. Luke carries only the 20 most recent " +
+        "entries into a call. The full view stays only in this app's memory, is blocked from " +
+        "optional panel recordings, disappears when Luke quits, and can be cleared by hand " +
+        "from that tab. It is not saved or exportable.",
+    },
+    {
       label: "Account",
       detail:
         account.status === ACCOUNT_STATUS.SIGNED_IN

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -1,4 +1,5 @@
 import { SessionRow as PanelSessionRow, ProviderMark } from "@sidecar/panel";
+import type { ConversationEntry } from "@sidecar/realtime";
 import {
   isSessionApplicationId,
   type ProviderControlResult,
@@ -15,6 +16,7 @@ import { useCallback, useRef, useState } from "react";
 import { ACCOUNT_STATUS, type AccountProvider, type AccountSnapshot } from "#shared/wire/account";
 import type { SessionOpenResult } from "#shared/wire/session";
 import { type AskHandler, AskLuke } from "./ask-luke";
+import { ConversationHistoryPanel } from "./conversation-history-panel";
 import { PANEL_TAB, type PanelTab, TabBar } from "./panel-tabs";
 import {
   type ArrangedSessions,
@@ -788,6 +790,10 @@ export interface PanelBodyProps {
   onOpenSessionApplication: (session: SessionView, applicationId: SessionApplicationId) => void;
   /** Carries a typed reply or an advertised action to the session's provider. */
   writes: SessionWriteHandlers;
+  /** The current-launch, renderer-memory conversation between the developer and Luke. */
+  conversationHistory: readonly ConversationEntry[];
+  /** Clears that same thread from the view and Luke's next conversational context. */
+  onClearConversationHistory: () => void;
   /** Carries a typed ask to Luke's own conversation, answering why it could not go. */
   ask: AskHandler;
   /** Reports someone being part-way through an ask, so the panel holds for them. */
@@ -836,6 +842,8 @@ export function PanelBody({
   onOpenSession,
   onOpenSessionApplication,
   writes,
+  conversationHistory,
+  onClearConversationHistory,
   ask,
   onAskEngaged,
   askShortcut,
@@ -919,6 +927,11 @@ export function PanelBody({
       </div>
       {tab === PANEL_TAB.SETTINGS ? (
         <SettingsPanel {...settings} />
+      ) : tab === PANEL_TAB.HISTORY ? (
+        <ConversationHistoryPanel
+          entries={conversationHistory}
+          onClear={onClearConversationHistory}
+        />
       ) : (
         <SessionsPanel
           className="session-view"

--- a/apps/desktop/src/renderer/panel-tabs.test.ts
+++ b/apps/desktop/src/renderer/panel-tabs.test.ts
@@ -3,8 +3,9 @@ import test from "node:test";
 import { PANEL_TAB, panelTabForKey } from "./panel-tabs";
 
 test("panel tabs wrap with horizontal arrows", () => {
-  assert.equal(panelTabForKey(PANEL_TAB.SESSIONS, "ArrowRight"), PANEL_TAB.SETTINGS);
-  assert.equal(panelTabForKey(PANEL_TAB.SETTINGS, "ArrowRight"), PANEL_TAB.SESSIONS);
+  assert.equal(panelTabForKey(PANEL_TAB.SESSIONS, "ArrowRight"), PANEL_TAB.HISTORY);
+  assert.equal(panelTabForKey(PANEL_TAB.HISTORY, "ArrowRight"), PANEL_TAB.SETTINGS);
+  assert.equal(panelTabForKey(PANEL_TAB.SETTINGS, "ArrowLeft"), PANEL_TAB.HISTORY);
   assert.equal(panelTabForKey(PANEL_TAB.SESSIONS, "ArrowLeft"), PANEL_TAB.SETTINGS);
 });
 

--- a/apps/desktop/src/renderer/panel-tabs.tsx
+++ b/apps/desktop/src/renderer/panel-tabs.tsx
@@ -3,7 +3,7 @@ import { cssCustomProperties } from "@sidecar/surface/react-css";
 import { errandTargetProps, tabErrandTarget } from "./luke-errand";
 
 /**
- * The panel's two tabs, aliased from the core's set rather than declared here
+ * The panel's tabs, aliased from the core's set rather than declared here
  * — the same rule the sort follows: a spoken ask names a tab in the same words
  * this bar does, and the two must not drift into separate vocabularies.
  */
@@ -18,15 +18,16 @@ interface PanelTabDescriptor {
 
 export const PANEL_TABS: readonly PanelTabDescriptor[] = [
   { id: PANEL_TAB.SESSIONS, label: "Sessions" },
+  { id: PANEL_TAB.HISTORY, label: "History" },
   { id: PANEL_TAB.SETTINGS, label: "Settings" },
 ];
 
 export function panelTabId(tab: PanelTab): string {
-  return tab === PANEL_TAB.SETTINGS ? "panel-tab-settings" : "panel-tab-sessions";
+  return `panel-tab-${tab}`;
 }
 
 export function panelPanelId(tab: PanelTab): string {
-  return tab === PANEL_TAB.SETTINGS ? "panel-view-settings" : "panel-view-sessions";
+  return `panel-view-${tab}`;
 }
 
 /** The horizontal tablist's roving-focus destination for one keyboard key. */

--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -106,6 +106,8 @@ interface Harness {
   spokenAsks: string[];
   /** Conversation items fixed for those turns before their transcripts returned. */
   spokenAskItems: string[];
+  /** Number of local audio turns closed before the server acknowledged them. */
+  spokenAskClosures: () => number;
   microphoneEnabled: () => boolean;
   microphoneStopped: () => boolean;
   emit: (event: JsonValue) => void;
@@ -215,6 +217,7 @@ function harness(
   const replyEndings: { texts: readonly string[]; about: string | undefined }[] = [];
   const spokenAsks: string[] = [];
   const spokenAskItems: string[] = [];
+  let spokenAskClosures = 0;
   const requests: { url: string; init: RequestInit }[] = [];
   const calls: string[] = [];
   let enabled = false;
@@ -355,6 +358,9 @@ function harness(
     onSpokenAsk: (transcript) => {
       spokenAsks.push(transcript);
     },
+    onSpokenAskClosed: () => {
+      spokenAskClosures += 1;
+    },
     onSpokenAskCommitted: (itemId) => spokenAskItems.push(itemId),
   };
   if (options.connectTimeoutMs !== undefined) {
@@ -393,6 +399,7 @@ function harness(
     replyEndings,
     spokenAsks,
     spokenAskItems,
+    spokenAskClosures: () => spokenAskClosures,
     microphoneEnabled: () => enabled,
     microphoneStopped: () => stopped,
     lukeAudible: () => remoteTrack.enabled,
@@ -875,6 +882,7 @@ test("a release during the handshake delivers the words once the channel opens",
   await deviceArrives();
 
   assert.equal(context.session.status, REALTIME_STATUS.RESPONDING);
+  assert.equal(context.spokenAskClosures(), 1);
   assert.equal(context.session.turnPending, false);
   assert.deepEqual(
     context.sent.map((event) => event.type),
@@ -2110,6 +2118,10 @@ test("the developer's spoken words come back only from their own call", async ()
 test("a developer turn is identified before its transcript returns", async () => {
   const context = harness();
   await context.session.connect();
+  await armDeveloperTurn(context);
+
+  assert.equal(context.spokenAskClosures(), 1);
+  assert.deepEqual(context.spokenAskItems, []);
 
   context.emit({
     type: REALTIME_SERVER_EVENT.INPUT_AUDIO_BUFFER_COMMITTED,

--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -15,6 +15,7 @@ import {
   inputAudioFormatUpdateEvents,
   isCarriedAppAction,
   isCarriedIssueAction,
+  maximumConversationEntries,
   REALTIME_CLIENT_EVENT,
   REALTIME_SERVER_EVENT,
   REALTIME_STATUS,
@@ -1916,6 +1917,27 @@ test("an empty history says nothing at all", async () => {
   await armDeveloperTurn(context);
 
   assert.deepEqual(contextItems(context, "[recent conversation"), []);
+});
+
+test("a call accepts only the recent slice of a full current-launch thread", async () => {
+  const context = harness();
+  await context.session.connect();
+  const thread = Array.from(
+    { length: maximumConversationEntries + 3 },
+    (_, index): ConversationEntry => ({
+      kind: CONVERSATION_ENTRY_KIND.REPLY,
+      words: `launch line ${index}`,
+    }),
+  );
+
+  context.session.updateConversation(thread);
+  await armDeveloperTurn(context);
+
+  const item = contextItems(context, "[recent conversation")[0];
+  assert.ok(item);
+  assert.doesNotMatch(itemText(item), /launch line 0/);
+  assert.match(itemText(item), /launch line 3/);
+  assert.match(itemText(item), /launch line 22/);
 });
 
 test("the history is rendered from the roster as it now stands", async () => {

--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -2989,6 +2989,26 @@ test("closing stops the microphone track", async () => {
   assert.equal(context.microphoneStopped(), true);
   assert.equal(context.session.status, REALTIME_STATUS.IDLE);
 });
+
+test("clearing a conversation retires its call before another turn can begin", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.session.updateConversation([
+    { kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: "Do not keep this after Clear." },
+  ]);
+  assert.equal(context.session.sendText("This real turn belongs to the old call."), true);
+
+  context.session.clearConversation();
+
+  assert.equal(context.session.status, REALTIME_STATUS.IDLE);
+  assert.equal(context.session.isConnected, false);
+  const sentBeforeReconnect = context.sent.length;
+  await context.session.connect();
+  await armDeveloperTurn(context);
+
+  assert.equal(context.requests.length, 2);
+  assert.deepEqual(contextItems(context, "[recent conversation", sentBeforeReconnect), []);
+});
 /** Opens and commits a developer turn, which is the only turn a tool may run in. */
 async function armDeveloperTurn(context: Harness): Promise<void> {
   await holdTurn(context);

--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -104,6 +104,8 @@ interface Harness {
   replyEndings: { texts: readonly string[]; about: string | undefined }[];
   /** The developer's spoken turns, as the service handed them back. */
   spokenAsks: string[];
+  /** Conversation items fixed for those turns before their transcripts returned. */
+  spokenAskItems: string[];
   microphoneEnabled: () => boolean;
   microphoneStopped: () => boolean;
   emit: (event: JsonValue) => void;
@@ -212,6 +214,7 @@ function harness(
   const captionSubjects: (string | undefined)[] = [];
   const replyEndings: { texts: readonly string[]; about: string | undefined }[] = [];
   const spokenAsks: string[] = [];
+  const spokenAskItems: string[] = [];
   const requests: { url: string; init: RequestInit }[] = [];
   const calls: string[] = [];
   let enabled = false;
@@ -352,6 +355,7 @@ function harness(
     onSpokenAsk: (transcript) => {
       spokenAsks.push(transcript);
     },
+    onSpokenAskCommitted: (itemId) => spokenAskItems.push(itemId),
   };
   if (options.connectTimeoutMs !== undefined) {
     sessionOptions.connectTimeoutMs = options.connectTimeoutMs;
@@ -388,6 +392,7 @@ function harness(
     captionSubjects,
     replyEndings,
     spokenAsks,
+    spokenAskItems,
     microphoneEnabled: () => enabled,
     microphoneStopped: () => stopped,
     lukeAudible: () => remoteTrack.enabled,
@@ -2100,6 +2105,18 @@ test("the developer's spoken words come back only from their own call", async ()
   });
 
   assert.deepEqual(context.spokenAsks, ["how is the checkout agent doing?"]);
+});
+
+test("a developer turn is identified before its transcript returns", async () => {
+  const context = harness();
+  await context.session.connect();
+
+  context.emit({
+    type: REALTIME_SERVER_EVENT.INPUT_AUDIO_BUFFER_COMMITTED,
+    item_id: "item-1",
+  });
+
+  assert.deepEqual(context.spokenAskItems, ["item-1"]);
 });
 
 test("a speak-only call has no spoken turns to hand back", async () => {

--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -2031,6 +2031,34 @@ test("a new call after teardown re-seeds the accumulated history", async () => {
   assert.match(itemText(items[0]), /failed in payments/);
 });
 
+test("clearing history deletes its live model-context item", async () => {
+  const context = harness();
+  await context.session.connect();
+  context.session.updateConversation(
+    conversationEntries({ kind: CONVERSATION_ENTRY_KIND.REPLY, words: "Earlier words." }),
+  );
+  await armDeveloperTurn(context);
+  const historyItem = context.session.liveContextItemIds.get(CONTEXT_ITEM_KIND.CONVERSATION);
+  assert.ok(historyItem);
+
+  context.session.stopSpeaking();
+  context.session.updateConversation([]);
+  const sentBefore = context.sent.length;
+  await armDeveloperTurn(context);
+
+  assert.equal(
+    context.sent.slice(sentBefore).some(
+      (event) =>
+        event.type === CONVERSATION_ITEM_DELETE &&
+        // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+        (event as { item_id?: string }).item_id === historyItem,
+    ),
+    true,
+  );
+  assert.equal(context.session.liveContextItemIds.has(CONTEXT_ITEM_KIND.CONVERSATION), false);
+  assert.deepEqual(contextItems(context, "[recent conversation", sentBefore), []);
+});
+
 test("a reply ending at teardown writes nothing back into the retired call", async () => {
   const context = harness({ writeBackOnReplyEnded: true });
   await context.session.connect();

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -148,10 +148,15 @@ const TRUNCATION_PAST_AUDIO_END = /^Audio content of \d+ms is already shorter th
  * unchanged answer from a fresh one, and how to build the item once it has a
  * name to occupy.
  */
-interface PendingContext {
-  text: string;
-  build: (itemId: string) => readonly WireRecord[];
-}
+type PendingContext =
+  | {
+      text: string;
+      build: (itemId: string) => readonly WireRecord[];
+    }
+  | {
+      /** This kind should occupy no item once the next turn flushes context. */
+      text: undefined;
+    };
 
 /** A context item this call put in the conversation, and what it says. */
 interface LiveContext {
@@ -2050,7 +2055,10 @@ export class RealtimeVoiceSession {
    */
   #rememberConversation(): void {
     const text = conversationHistoryText(this.#conversationEntries, this.#sessions);
-    if (text === undefined) return;
+    if (text === undefined) {
+      this.#forgetContext(CONTEXT_ITEM_KIND.CONVERSATION);
+      return;
+    }
     this.#rememberContext(CONTEXT_ITEM_KIND.CONVERSATION, text, (itemId) =>
       conversationContextEvents(text, itemId),
     );
@@ -2115,6 +2123,11 @@ export class RealtimeVoiceSession {
     this.#contextPending.set(kind, { text, build });
   }
 
+  /** Holds the absence of one context kind until the next developer turn. */
+  #forgetContext(kind: ContextItemKind): void {
+    this.#contextPending.set(kind, { text: undefined });
+  }
+
   /**
    * Puts the context a turn is about to be answered from into the conversation,
    * each kind replacing whatever it said before.
@@ -2140,6 +2153,13 @@ export class RealtimeVoiceSession {
       const pending = this.#contextPending.get(kind);
       if (!pending) continue;
       const live = this.#contextLive.get(kind);
+      if (pending.text === undefined) {
+        if (!live) continue;
+        this.#contextSequence += 1;
+        this.#supersede(live.itemId);
+        this.#contextLive.delete(kind);
+        continue;
+      }
       // The history is seeded once per call. It exists to bridge the calls
       // that came before this one, and every turn taken since it went in is
       // already held by this call as real conversation items — so superseding

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -36,6 +36,7 @@ import {
   parseRealtimeServerEvent,
   proactiveSpeechEvents,
   pushToTalkCommitEvents,
+  REALTIME_CLIENT_EVENT,
   REALTIME_DATA_CHANNEL,
   REALTIME_SERVER_EVENT,
   REALTIME_STATUS,
@@ -254,6 +255,8 @@ export interface RealtimeVoiceSessionCallbacks {
    * records the words so the thread holds both halves of the exchange.
    */
   onSpokenAsk?(transcript: string, itemId: string): void;
+  /** The local audio turn closed, before its commit can be acknowledged. */
+  onSpokenAskClosed?(): void;
   /** The server item that fixes which current-launch history a spoken turn belongs to. */
   onSpokenAskCommitted?(itemId: string): void;
   /**
@@ -1759,6 +1762,9 @@ export class RealtimeVoiceSession {
     // exchange keeps the words just said, and its own words stack under them.
     if (!keepCaption) this.#clearCaption();
     this.#clearSettleTimer();
+    if (events.some((event) => event.type === REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_COMMIT)) {
+      this.#options.onSpokenAskClosed?.();
+    }
     this.#send(events);
     this.#setStatus(REALTIME_STATUS.RESPONDING);
   }

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -1624,6 +1624,16 @@ export class RealtimeVoiceSession {
   }
 
   async close(): Promise<void> {
+    this.clearConversation();
+  }
+
+  /**
+   * Retires the call that owns the current conversation. Realtime items cannot
+   * be enumerated and deleted reliably, so Clear crosses a call boundary: the
+   * next developer turn receives a fresh server-side conversation as well as
+   * the caller's freshly emptied local history.
+   */
+  clearConversation(): void {
     this.#closed = true;
     this.#teardown();
     this.#setStatus(REALTIME_STATUS.IDLE);

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -46,6 +46,7 @@ import {
   type RealtimeToolFamily,
   realtimeSessionSyncEvents,
   realtimeToolFamily,
+  recentConversationEntries,
   type ScheduledTimer,
   SESSION_TOOL_KIND,
   sessionContextEvents,
@@ -2036,7 +2037,9 @@ export class RealtimeVoiceSession {
    * own conversation items.
    */
   updateConversation(entries: readonly ConversationEntry[]): void {
-    this.#conversationEntries = entries;
+    // The caller may retain the whole current-launch thread for its own UI;
+    // this transport accepts only the recent slice that may reach the model.
+    this.#conversationEntries = recentConversationEntries(entries);
     this.#rememberConversation();
   }
 

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -253,7 +253,9 @@ export interface RealtimeVoiceSessionCallbacks {
    * offers no microphone, so it has no spoken turns to hand back. The caller
    * records the words so the thread holds both halves of the exchange.
    */
-  onSpokenAsk?(transcript: string): void;
+  onSpokenAsk?(transcript: string, itemId: string): void;
+  /** The server item that fixes which current-launch history a spoken turn belongs to. */
+  onSpokenAskCommitted?(itemId: string): void;
   /**
    * A reply concluding, words or none. `onReplyEnded` hands over only words
    * that exist, so a reply the server failed or answered without a transcript
@@ -2350,7 +2352,10 @@ export class RealtimeVoiceSession {
         // Only the developer's own call has spoken turns to hand back; the
         // guard is belt to the speak-only shape's suspenders, so a stray
         // event on Luke's own call can never write a developer line.
-        if (this.#withMicrophone) this.#options.onSpokenAsk?.(event.transcript);
+        if (this.#withMicrophone) this.#options.onSpokenAsk?.(event.transcript, event.itemId);
+        return;
+      case REALTIME_SERVER_EVENT.INPUT_AUDIO_BUFFER_COMMITTED:
+        if (this.#withMicrophone) this.#options.onSpokenAskCommitted?.(event.itemId);
         return;
       case REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED:
         this.#audioEndingsReported = true;

--- a/apps/desktop/src/renderer/session-replay.ts
+++ b/apps/desktop/src/renderer/session-replay.ts
@@ -16,12 +16,13 @@ import type { SessionReplayBootstrap } from "#shared/wire/session";
  * recap, error line, and the account's own name and address all travel
  * because they are drawn; autocapture puts the text of whatever was clicked
  * on an event; and an unhandled error travels with its message and stack.
- * Only what is typed into a field stays masked, which is the library's own
- * default rather than anything asked for here.
+ * What is typed into a field stays masked by the library's default, and the
+ * conversation History tab explicitly blocks its whole subtree with the
+ * library's fixed `ph-no-capture` class.
  *
  * `PRIVACY.md` says all of that plainly, and it has to keep saying it: this
- * file is the whole of what decides it, and there is nothing else standing
- * between what the panel draws and what leaves the machine.
+ * file and that one blocked subtree are the whole of what decides it. Nothing
+ * else stands between what the panel draws and what leaves the machine.
  *
  * What this file decides on its own is only whether to record at all: the
  * main process says whether this run may, and the developer's two switches

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -5,6 +5,9 @@
   background: transparent;
 
   --state-working: #5cd5ff;
+  /* A sent message is an action the developer already took, not a session
+     state. Keep its familiar chat blue separate from the roster palette. */
+  --message-sent: #0071e3;
   /* Whose voice is live, so a glance says who is talking. Your turn is green,
      which is nowhere else on the surface and so belongs to you alone; Luke
      answers in the blue the rest of the surface already uses for something

--- a/apps/desktop/src/renderer/styles/history.css
+++ b/apps/desktop/src/renderer/styles/history.css
@@ -13,17 +13,8 @@
   display: flex;
   flex: 0 0 auto;
   align-items: center;
-  justify-content: space-between;
-  gap: 14px;
+  justify-content: flex-end;
   padding: 0 2px;
-}
-
-.history-header p {
-  max-width: 58ch;
-  margin: 0;
-  color: var(--text-tertiary);
-  font-size: 10.5px;
-  line-height: 1.45;
 }
 
 .history-clear-controls {
@@ -143,11 +134,4 @@
 .history-empty strong {
   color: var(--text-primary);
   font-size: 12px;
-}
-
-.history-empty span {
-  max-width: 42ch;
-  color: var(--text-tertiary);
-  font-size: 10.5px;
-  line-height: 1.45;
 }

--- a/apps/desktop/src/renderer/styles/history.css
+++ b/apps/desktop/src/renderer/styles/history.css
@@ -1,0 +1,153 @@
+/* The developer's current-launch conversation with Luke. The tab reads like a
+   transcript, not another roster: dialogue aligns by speaker, while actions
+   and announcements stay quiet lines in the flow between them. */
+.history-view {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.history-header {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 0 2px;
+}
+
+.history-header p {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--text-tertiary);
+  font-size: 10.5px;
+  line-height: 1.45;
+}
+
+.history-clear-controls {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 5px;
+}
+
+.history-clear,
+.history-clear-cancel {
+  min-height: 28px;
+  padding: 0 9px;
+  border-radius: 9px;
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 620;
+  transition:
+    background-color var(--duration-hover) ease,
+    color var(--duration-hover) ease;
+}
+
+.history-clear:hover,
+.history-clear-cancel:hover {
+  background: var(--raised);
+  color: var(--text-primary);
+}
+
+.history-clear-controls:has(.history-clear-cancel) .history-clear {
+  color: var(--danger);
+}
+
+.history-list {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 12px;
+  margin: 0;
+  padding: 0 2px 2px;
+  overflow-x: clip;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
+  scrollbar-width: thin;
+  list-style: none;
+  animation: scroll-edge-fade linear both;
+  animation-timeline: scroll(self block);
+}
+
+.history-entry {
+  display: flex;
+  max-width: min(78%, 62ch);
+  flex: 0 0 auto;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.history-entry small {
+  color: var(--text-tertiary);
+  font-size: 9.5px;
+  font-weight: 650;
+}
+
+.history-entry p {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 12px;
+  line-height: 1.48;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.history-entry[data-speaker="you"] {
+  align-self: flex-end;
+  align-items: flex-end;
+}
+
+.history-entry[data-speaker="you"] p {
+  padding: 9px 11px;
+  border-radius: 13px 13px 4px 13px;
+  background: var(--raised-strong);
+}
+
+.history-entry[data-speaker="luke"] {
+  align-self: flex-start;
+}
+
+.history-entry[data-speaker="luke"] p {
+  padding: 2px 1px;
+}
+
+.history-entry[data-speaker="event"] {
+  max-width: 90%;
+  align-self: center;
+  align-items: center;
+  padding: 2px 12px;
+  text-align: center;
+}
+
+.history-entry[data-speaker="event"] p {
+  color: var(--text-secondary);
+  font-size: 10.5px;
+}
+
+.history-empty {
+  display: grid;
+  min-height: 126px;
+  flex: 1;
+  align-content: center;
+  justify-items: center;
+  gap: 5px;
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.history-empty strong {
+  color: var(--text-primary);
+  font-size: 12px;
+}
+
+.history-empty span {
+  max-width: 42ch;
+  color: var(--text-tertiary);
+  font-size: 10.5px;
+  line-height: 1.45;
+}

--- a/apps/desktop/src/renderer/styles/history.css
+++ b/apps/desktop/src/renderer/styles/history.css
@@ -1,12 +1,11 @@
-/* The developer's current-launch conversation with Luke. The tab reads like a
-   transcript, not another roster: dialogue aligns by speaker, while actions
-   and announcements stay quiet lines in the flow between them. */
+/* A compact chat thread: sent and received messages use the familiar two-sided
+   bubble grammar, while actions and announcements sit centered between them. */
 .history-view {
   display: flex;
   min-height: 0;
   flex: 1;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
 }
 
 .history-header {
@@ -29,6 +28,7 @@
   min-height: 28px;
   padding: 0 9px;
   border-radius: 9px;
+  background: transparent;
   color: var(--text-secondary);
   font-size: 10px;
   font-weight: 620;
@@ -52,9 +52,9 @@
   min-height: 0;
   flex: 1;
   flex-direction: column;
-  gap: 12px;
+  gap: 4px;
   margin: 0;
-  padding: 0 2px 2px;
+  padding: 4px 4px 8px;
   overflow-x: clip;
   overflow-y: auto;
   overscroll-behavior: contain;
@@ -67,23 +67,17 @@
 
 .history-entry {
   display: flex;
-  max-width: min(78%, 62ch);
+  max-width: min(82%, 58ch);
   flex: 0 0 auto;
   flex-direction: column;
-  gap: 4px;
-}
-
-.history-entry small {
-  color: var(--text-tertiary);
-  font-size: 9.5px;
-  font-weight: 650;
 }
 
 .history-entry p {
   margin: 0;
+  padding: 7px 10px 8px;
   color: var(--text-primary);
-  font-size: 12px;
-  line-height: 1.48;
+  font-size: 12.5px;
+  line-height: 1.38;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
 }
@@ -94,9 +88,9 @@
 }
 
 .history-entry[data-speaker="you"] p {
-  padding: 9px 11px;
-  border-radius: 13px 13px 4px 13px;
-  background: var(--raised-strong);
+  border-radius: 15px 15px 5px 15px;
+  background: var(--message-sent);
+  color: rgba(255, 255, 255, 0.98);
 }
 
 .history-entry[data-speaker="luke"] {
@@ -104,20 +98,30 @@
 }
 
 .history-entry[data-speaker="luke"] p {
-  padding: 2px 1px;
+  border-radius: 15px 15px 15px 5px;
+  background: var(--raised-strong);
 }
 
 .history-entry[data-speaker="event"] {
-  max-width: 90%;
+  max-width: 84%;
   align-self: center;
   align-items: center;
-  padding: 2px 12px;
+  padding: 8px 12px;
   text-align: center;
 }
 
 .history-entry[data-speaker="event"] p {
+  padding: 0;
   color: var(--text-secondary);
   font-size: 10.5px;
+  line-height: 1.4;
+}
+
+/* Consecutive bubbles stay conversationally tight. A speaker change gets the
+   small pause chat apps use instead of repeating names above every message. */
+.history-entry[data-speaker="you"] + .history-entry[data-speaker="luke"],
+.history-entry[data-speaker="luke"] + .history-entry[data-speaker="you"] {
+  margin-top: 6px;
 }
 
 .history-empty {

--- a/apps/desktop/src/renderer/styles/history.css
+++ b/apps/desktop/src/renderer/styles/history.css
@@ -1,5 +1,5 @@
 /* A compact chat thread: sent and received messages use the familiar two-sided
-   bubble grammar, while actions and announcements sit centered between them. */
+   bubble grammar, while the developer's requested actions sit between them. */
 .history-view {
   display: flex;
   min-height: 0;

--- a/apps/desktop/src/renderer/styles/index.css
+++ b/apps/desktop/src/renderer/styles/index.css
@@ -10,6 +10,7 @@
    out-specifying the cap itself. */
 @import "./keycaps.css";
 @import "./sessions.css";
+@import "./history.css";
 @import "./sign-in.css";
 @import "./voice.css";
 /* After sessions.css and sign-in.css: the takeover restages their rows and

--- a/apps/desktop/src/renderer/use-voice-conversation.test.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.test.ts
@@ -20,6 +20,7 @@ import {
 import {
   activeVoiceStream,
   announcerNotices,
+  authorizeConversationAct,
   conversationEntryBelongsToConversation,
   evaluatorSummaries,
   liveSpeedApplies,
@@ -50,6 +51,38 @@ test("work that began before Clear cannot repopulate conversation history", () =
   assert.equal(conversationEntryBelongsToConversation(3, 4), false);
   assert.equal(conversationEntryBelongsToConversation(4, 4), true);
   assert.equal(conversationEntryBelongsToConversation(undefined, 4), false);
+});
+
+test("an authorization that outlives Clear cannot record its act", async () => {
+  let resolveAuthorization: ((value: string) => void) | undefined;
+  const authorization = new Promise<string>((resolve) => {
+    resolveAuthorization = resolve;
+  });
+  let activeReplyGeneration: number | undefined = 3;
+  const activeReply = {
+    get current(): number | undefined {
+      return activeReplyGeneration;
+    },
+  };
+  let conversationGeneration = 3;
+  const history: string[] = [];
+  const pending = authorizeConversationAct(activeReply, () => authorization);
+
+  conversationGeneration = 4;
+  activeReplyGeneration = undefined;
+  resolveAuthorization?.("accepted");
+  const stale = await pending;
+  if (conversationEntryBelongsToConversation(stale.generation, conversationGeneration)) {
+    history.push("stale act");
+  }
+  assert.equal(history.length, 0);
+
+  activeReplyGeneration = conversationGeneration;
+  const current = await authorizeConversationAct(activeReply, async () => "accepted");
+  if (conversationEntryBelongsToConversation(current.generation, conversationGeneration)) {
+    history.push("current act");
+  }
+  assert.deepEqual(history, ["current act"]);
 });
 
 test("the meter follows whoever is actually talking", () => {

--- a/apps/desktop/src/renderer/use-voice-conversation.test.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.test.ts
@@ -42,7 +42,7 @@ import { WAVEFORM_VOICE } from "./waveform";
 test("a delayed transcription cannot repopulate history after Clear", () => {
   assert.equal(spokenAskBelongsToConversation(3, 4), false);
   assert.equal(spokenAskBelongsToConversation(4, 4), true);
-  assert.equal(spokenAskBelongsToConversation(undefined, 4), true);
+  assert.equal(spokenAskBelongsToConversation(undefined, 4), false);
 });
 
 test("the meter follows whoever is actually talking", () => {

--- a/apps/desktop/src/renderer/use-voice-conversation.test.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.test.ts
@@ -20,6 +20,7 @@ import {
 import {
   activeVoiceStream,
   announcerNotices,
+  conversationEntryBelongsToConversation,
   evaluatorSummaries,
   liveSpeedApplies,
   lukeCaptionsToShow,
@@ -43,6 +44,12 @@ test("a delayed transcription cannot repopulate history after Clear", () => {
   assert.equal(spokenAskBelongsToConversation(3, 4), false);
   assert.equal(spokenAskBelongsToConversation(4, 4), true);
   assert.equal(spokenAskBelongsToConversation(undefined, 4), false);
+});
+
+test("work that began before Clear cannot repopulate conversation history", () => {
+  assert.equal(conversationEntryBelongsToConversation(3, 4), false);
+  assert.equal(conversationEntryBelongsToConversation(4, 4), true);
+  assert.equal(conversationEntryBelongsToConversation(undefined, 4), false);
 });
 
 test("the meter follows whoever is actually talking", () => {

--- a/apps/desktop/src/renderer/use-voice-conversation.test.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.test.ts
@@ -26,6 +26,7 @@ import {
   replyIssueMentions,
   replyMentions,
   speechByDecision,
+  spokenAskBelongsToConversation,
   talkKeyPress,
   talkOpeningHolds,
   typedAskHolds,
@@ -37,6 +38,12 @@ import {
   waveformVoice,
 } from "./use-voice-conversation";
 import { WAVEFORM_VOICE } from "./waveform";
+
+test("a delayed transcription cannot repopulate history after Clear", () => {
+  assert.equal(spokenAskBelongsToConversation(3, 4), false);
+  assert.equal(spokenAskBelongsToConversation(4, 4), true);
+  assert.equal(spokenAskBelongsToConversation(undefined, 4), true);
+});
 
 test("the meter follows whoever is actually talking", () => {
   assert.equal(waveformVoice(REALTIME_STATUS.RESPONDING), WAVEFORM_VOICE.LUKE);

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -9,11 +9,11 @@ import {
   ATTENTION_SPEECH_SOURCE,
   type AttentionSpeech,
   announcementConversationEntry,
-  appendConversationEntry,
+  appendConversationThreadEntry,
   CONVERSATION_ENTRY_KIND,
   type ConversationEntry,
   dispatchByKind,
-  insertSpokenAskEntry,
+  insertSpokenAskThreadEntry,
   isArrivalSpeech,
   isCarriedAppAction,
   isCarriedIssueAction,
@@ -22,6 +22,7 @@ import {
   type RealtimeStatus,
   type RealtimeVoice,
   type RealtimeVoiceSpeed,
+  recentConversationEntries,
   SESSION_TOOL_KIND,
   sessionActConversationEntry,
 } from "@sidecar/realtime";
@@ -466,6 +467,13 @@ export interface VoiceConversation {
   startMicrophone: () => Promise<MicrophoneStatus>;
   stopMicrophone: () => Promise<void>;
   askLuke: (text: string) => Promise<string | undefined>;
+  /**
+   * Every bounded line from this app launch. It lives only in this renderer;
+   * the model receives a recent slice and the whole view disappears on exit.
+   */
+  conversationHistory: readonly ConversationEntry[];
+  /** Clears the visible history and the context handed to the next call. */
+  clearConversationHistory: () => void;
   voiceTurn: WaveformVoice | undefined;
   /**
    * The words being spoken, one entry per response: a turn that speaks twice
@@ -571,10 +579,14 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
    * transport that comes and goes — an announcement is often read out on
    * Luke's own speak-only call, which the talk-key press tears down on its
    * way to opening the developer's, and an idle call retires — while the
-   * thread itself lives here and re-feeds whichever call opens next. The
-   * session's own copy goes with its teardown; this one is the conversation.
+   * whole thread itself lives here for this app launch. Only its bounded
+   * recent slice re-feeds whichever call opens next; the session's own copy
+   * goes with its teardown.
    */
   const conversationRef = useRef<readonly ConversationEntry[]>([]);
+  // State is the ref's identical drawn copy, so History retains the whole
+  // current launch even though a call receives only the recent context slice.
+  const [conversationHistory, setConversationHistory] = useState<readonly ConversationEntry[]>([]);
   /**
    * Whether the turn under way read a transcript aloud. The rendering travels
    * only in the turn that asked for it, so the reply that spoke it must not
@@ -584,15 +596,21 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   const transcriptSpokenRef = useRef(false);
 
   /**
-   * Appends one line to the history and tells the call now open, when there
-   * is a line to append. Nothing here ever removes a line — the history's own
-   * bounds retire the oldest, and a session leaving the roster costs a line
-   * its identity at render, never its words.
+   * Appends one bounded line to this launch's history and tells the call now
+   * open about only the recent context slice. A session leaving the roster
+   * costs a line its identity at model render, never its visible words.
    */
   const rememberConversationEntry = useCallback((entry: ConversationEntry | undefined) => {
     if (!entry) return;
-    conversationRef.current = appendConversationEntry(conversationRef.current, entry);
-    voiceSession.current?.updateConversation(conversationRef.current);
+    conversationRef.current = appendConversationThreadEntry(conversationRef.current, entry);
+    setConversationHistory(conversationRef.current);
+    voiceSession.current?.updateConversation(recentConversationEntries(conversationRef.current));
+  }, []);
+
+  const clearConversationHistory = useCallback(() => {
+    conversationRef.current = [];
+    setConversationHistory([]);
+    voiceSession.current?.updateConversation([]);
   }, []);
 
   /**
@@ -620,12 +638,13 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     const mark = spokenTurnMarkRef.current;
     spokenTurnMarkRef.current = undefined;
     conversationRef.current = mark
-      ? insertSpokenAskEntry(conversationRef.current, transcript, mark.after)
-      : appendConversationEntry(conversationRef.current, {
+      ? insertSpokenAskThreadEntry(conversationRef.current, transcript, mark.after)
+      : appendConversationThreadEntry(conversationRef.current, {
           kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK,
           words: transcript,
         });
-    voiceSession.current?.updateConversation(conversationRef.current);
+    setConversationHistory(conversationRef.current);
+    voiceSession.current?.updateConversation(recentConversationEntries(conversationRef.current));
   }, []);
 
   const ensureVoiceSession = useCallback((): RealtimeVoiceSession => {
@@ -875,7 +894,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     // is only the newest transport to carry it — the announcement a "what did
     // you just say?" points back at was often read out on the speak-only call
     // this one just replaced.
-    session.updateConversation(conversationRef.current);
+    session.updateConversation(recentConversationEntries(conversationRef.current));
     session.updateWorkspaceProjects(
       workspaceProjectsRef.current,
       defaultWorkspaceProviderRef.current,
@@ -1439,6 +1458,8 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     startMicrophone,
     stopMicrophone,
     askLuke,
+    conversationHistory,
+    clearConversationHistory,
     voiceTurn,
     lukeCaptions,
     mentionedSessions: mentioned,

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -605,10 +605,10 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   const pendingSpokenTurnMarksRef = useRef<
     { after: ConversationEntry | undefined; generation: number }[]
   >([]);
-  /** The status edge that fixes the local turn-close mark above. */
-  const previousVoiceStatus = useRef<RealtimeStatus>(REALTIME_STATUS.IDLE);
-  /** The history generation in which the developer began the active spoken turn. */
-  const activeSpokenTurnGenerationRef = useRef<number | undefined>(undefined);
+  /** The turn opened by the current talk-key press, before it closes. */
+  const activeSpokenTurnMarkRef = useRef<
+    { after: ConversationEntry | undefined; generation: number } | undefined
+  >(undefined);
   /**
    * Whether the turn under way read a transcript aloud. The rendering travels
    * only in the turn that asked for it, so the reply that spoke it must not
@@ -773,6 +773,11 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       onSpokenAskCommitted: (itemId) => {
         const mark = pendingSpokenTurnMarksRef.current.shift();
         if (mark) spokenTurnMarksRef.current.set(itemId, mark);
+      },
+      onSpokenAskClosed: () => {
+        const mark = activeSpokenTurnMarkRef.current;
+        activeSpokenTurnMarkRef.current = undefined;
+        if (mark) pendingSpokenTurnMarksRef.current.push(mark);
       },
       // The developer's spoken words, back from the service that heard them,
       // placed where their turn happened: the thread holds both halves of
@@ -1022,6 +1027,10 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       // that is already up.
       if (talkPressedAt.current !== pressedAt) return;
     }
+    activeSpokenTurnMarkRef.current = {
+      after: conversationRef.current.at(-1),
+      generation: conversationGenerationRef.current,
+    };
     session.beginTurn();
     const press = talkKeyPress({ latched: false, microphoneCall: session.microphoneCall });
     // A press against no call — or against Luke's own speak-only call, which
@@ -1236,24 +1245,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     // next reply from the history.
     if (voiceStatus === REALTIME_STATUS.LISTENING) {
       transcriptSpokenRef.current = false;
-      if (previousVoiceStatus.current !== REALTIME_STATUS.LISTENING) {
-        activeSpokenTurnGenerationRef.current = conversationGenerationRef.current;
-      }
     }
-    // Capture the ask's place at the local turn boundary. The server's commit
-    // acknowledgement supplies its item id later; any announcement arriving
-    // between those two edges still belongs after the ask.
-    if (
-      previousVoiceStatus.current === REALTIME_STATUS.LISTENING &&
-      voiceStatus === REALTIME_STATUS.RESPONDING
-    ) {
-      pendingSpokenTurnMarksRef.current.push({
-        after: conversationRef.current.at(-1),
-        generation: activeSpokenTurnGenerationRef.current ?? conversationGenerationRef.current,
-      });
-      activeSpokenTurnGenerationRef.current = undefined;
-    }
-    previousVoiceStatus.current = voiceStatus;
     // Any settled status ends the wait the press started, however it ended:
     // listening takes the meter live, ready means the turn was dropped
     // mid-handshake, and a failure has its own message to show. Unless the

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -601,6 +601,14 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   const spokenTurnMarksRef = useRef(
     new Map<string, { after: ConversationEntry | undefined; generation: number }>(),
   );
+  /** Local turn-close marks waiting for the server item ids that name them. */
+  const pendingSpokenTurnMarksRef = useRef<
+    { after: ConversationEntry | undefined; generation: number }[]
+  >([]);
+  /** The status edge that fixes the local turn-close mark above. */
+  const previousVoiceStatus = useRef<RealtimeStatus>(REALTIME_STATUS.IDLE);
+  /** The history generation in which the developer began the active spoken turn. */
+  const activeSpokenTurnGenerationRef = useRef<number | undefined>(undefined);
   /**
    * Whether the turn under way read a transcript aloud. The rendering travels
    * only in the turn that asked for it, so the reply that spoke it must not
@@ -625,6 +633,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     conversationGenerationRef.current += 1;
     conversationRef.current = [];
     spokenTurnMarksRef.current.clear();
+    pendingSpokenTurnMarksRef.current = [];
     setConversationHistory([]);
     voiceSession.current?.updateConversation([]);
   }, []);
@@ -762,10 +771,8 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
         rememberConversationEntry({ kind: CONVERSATION_ENTRY_KIND.REPLY, words: texts.join(" ") });
       },
       onSpokenAskCommitted: (itemId) => {
-        spokenTurnMarksRef.current.set(itemId, {
-          after: conversationRef.current.at(-1),
-          generation: conversationGenerationRef.current,
-        });
+        const mark = pendingSpokenTurnMarksRef.current.shift();
+        if (mark) spokenTurnMarksRef.current.set(itemId, mark);
       },
       // The developer's spoken words, back from the service that heard them,
       // placed where their turn happened: the thread holds both halves of
@@ -1229,7 +1236,24 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     // next reply from the history.
     if (voiceStatus === REALTIME_STATUS.LISTENING) {
       transcriptSpokenRef.current = false;
+      if (previousVoiceStatus.current !== REALTIME_STATUS.LISTENING) {
+        activeSpokenTurnGenerationRef.current = conversationGenerationRef.current;
+      }
     }
+    // Capture the ask's place at the local turn boundary. The server's commit
+    // acknowledgement supplies its item id later; any announcement arriving
+    // between those two edges still belongs after the ask.
+    if (
+      previousVoiceStatus.current === REALTIME_STATUS.LISTENING &&
+      voiceStatus === REALTIME_STATUS.RESPONDING
+    ) {
+      pendingSpokenTurnMarksRef.current.push({
+        after: conversationRef.current.at(-1),
+        generation: activeSpokenTurnGenerationRef.current ?? conversationGenerationRef.current,
+      });
+      activeSpokenTurnGenerationRef.current = undefined;
+    }
+    previousVoiceStatus.current = voiceStatus;
     // Any settled status ends the wait the press started, however it ended:
     // listening takes the meter live, ready means the turn was dropped
     // mid-handshake, and a failure has its own message to show. Unless the

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -312,7 +312,7 @@ export function spokenAskBelongsToConversation(
   markGeneration: number | undefined,
   conversationGeneration: number,
 ): boolean {
-  return markGeneration === undefined || markGeneration === conversationGeneration;
+  return markGeneration !== undefined && markGeneration === conversationGeneration;
 }
 
 /**
@@ -597,6 +597,10 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   // State is the ref's identical drawn copy, so History retains the whole
   // current launch even though a call receives only the recent context slice.
   const [conversationHistory, setConversationHistory] = useState<readonly ConversationEntry[]>([]);
+  /** Where each server-identified spoken turn belongs when its transcript returns. */
+  const spokenTurnMarksRef = useRef(
+    new Map<string, { after: ConversationEntry | undefined; generation: number }>(),
+  );
   /**
    * Whether the turn under way read a transcript aloud. The rendering travels
    * only in the turn that asked for it, so the reply that spoke it must not
@@ -620,45 +624,33 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   const clearConversationHistory = useCallback(() => {
     conversationGenerationRef.current += 1;
     conversationRef.current = [];
+    spokenTurnMarksRef.current.clear();
     setConversationHistory([]);
     voiceSession.current?.updateConversation([]);
   }, []);
 
   /**
-   * Where the spoken turn now owed a transcription belongs in the history:
-   * the entry the history ended with at the moment the turn committed —
-   * everything recorded after that mark is the turn's own produce. Marked at
-   * the commit edge, consumed by the transcription, and overwritten by the
-   * next commit, so a transcription that never arrives leaves nothing stale
-   * standing.
-   */
-  const spokenTurnMarkRef = useRef<
-    { after: ConversationEntry | undefined; generation: number } | undefined
-  >(undefined);
-  /** The status an edge is read against, for the commit mark above. */
-  const previousVoiceStatus = useRef<RealtimeStatus>(REALTIME_STATUS.IDLE);
-
-  /**
    * Records a spoken ask where its turn happened rather than where its
    * transcription landed: the words come back on the service's own clock,
    * sometimes after the reply they asked for has ended, and an exchange
-   * stored in reverse would be re-fed in reverse to every later call. A
-   * transcription with no mark to land on — a turn delivered without a
-   * listening edge — appends plainly, which is the order said in the common
-   * case of the words beating the reply.
+   * stored in reverse would be re-fed in reverse to every later call. The
+   * server item binds it to the mark made for that exact turn, so a transcript
+   * delayed past Clear cannot borrow a newer turn's place.
    */
-  const rememberSpokenAsk = useCallback((transcript: string) => {
-    const mark = spokenTurnMarkRef.current;
-    spokenTurnMarkRef.current = undefined;
-    if (!spokenAskBelongsToConversation(mark?.generation, conversationGenerationRef.current)) {
+  const rememberSpokenAsk = useCallback((transcript: string, itemId: string) => {
+    const mark = spokenTurnMarksRef.current.get(itemId);
+    spokenTurnMarksRef.current.delete(itemId);
+    if (
+      !mark ||
+      !spokenAskBelongsToConversation(mark.generation, conversationGenerationRef.current)
+    ) {
       return;
     }
-    conversationRef.current = mark
-      ? insertSpokenAskThreadEntry(conversationRef.current, transcript, mark.after)
-      : appendConversationThreadEntry(conversationRef.current, {
-          kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK,
-          words: transcript,
-        });
+    conversationRef.current = insertSpokenAskThreadEntry(
+      conversationRef.current,
+      transcript,
+      mark.after,
+    );
     setConversationHistory(conversationRef.current);
     voiceSession.current?.updateConversation(recentConversationEntries(conversationRef.current));
   }, []);
@@ -768,6 +760,12 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
         // record only as the act it was.
         if (about || spokeTranscript) return;
         rememberConversationEntry({ kind: CONVERSATION_ENTRY_KIND.REPLY, words: texts.join(" ") });
+      },
+      onSpokenAskCommitted: (itemId) => {
+        spokenTurnMarksRef.current.set(itemId, {
+          after: conversationRef.current.at(-1),
+          generation: conversationGenerationRef.current,
+        });
       },
       // The developer's spoken words, back from the service that heard them,
       // placed where their turn happened: the thread holds both halves of
@@ -1232,20 +1230,6 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     if (voiceStatus === REALTIME_STATUS.LISTENING) {
       transcriptSpokenRef.current = false;
     }
-    // A spoken turn committing — the microphone closing into a reply — is the
-    // moment its ask belongs at: the words come back later, on the
-    // transcription's own clock, and this mark is what lets them land where
-    // the turn actually was rather than behind a reply that outran them.
-    if (
-      previousVoiceStatus.current === REALTIME_STATUS.LISTENING &&
-      voiceStatus === REALTIME_STATUS.RESPONDING
-    ) {
-      spokenTurnMarkRef.current = {
-        after: conversationRef.current.at(-1),
-        generation: conversationGenerationRef.current,
-      };
-    }
-    previousVoiceStatus.current = voiceStatus;
     // Any settled status ends the wait the press started, however it ended:
     // listening takes the meter live, ready means the turn was dropped
     // mid-handshake, and a failure has its own message to show. Unless the

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -307,6 +307,14 @@ export function speechByDecision(speech: readonly AttentionSpeech[]): readonly A
   return [...speech].sort((a, b) => a.decidedAt - b.decidedAt);
 }
 
+/** A transcription belongs only to the same visible history generation as its turn. */
+export function spokenAskBelongsToConversation(
+  markGeneration: number | undefined,
+  conversationGeneration: number,
+): boolean {
+  return markGeneration === undefined || markGeneration === conversationGeneration;
+}
+
 /**
  * The sessions the replies being spoken are about, for the surface to draw
  * pressable previews of. An announcement already carries its one
@@ -584,6 +592,8 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
    * goes with its teardown.
    */
   const conversationRef = useRef<readonly ConversationEntry[]>([]);
+  /** Rises when Clear retires every event that began before that press. */
+  const conversationGenerationRef = useRef(0);
   // State is the ref's identical drawn copy, so History retains the whole
   // current launch even though a call receives only the recent context slice.
   const [conversationHistory, setConversationHistory] = useState<readonly ConversationEntry[]>([]);
@@ -608,6 +618,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   }, []);
 
   const clearConversationHistory = useCallback(() => {
+    conversationGenerationRef.current += 1;
     conversationRef.current = [];
     setConversationHistory([]);
     voiceSession.current?.updateConversation([]);
@@ -621,7 +632,9 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
    * next commit, so a transcription that never arrives leaves nothing stale
    * standing.
    */
-  const spokenTurnMarkRef = useRef<{ after: ConversationEntry | undefined } | undefined>(undefined);
+  const spokenTurnMarkRef = useRef<
+    { after: ConversationEntry | undefined; generation: number } | undefined
+  >(undefined);
   /** The status an edge is read against, for the commit mark above. */
   const previousVoiceStatus = useRef<RealtimeStatus>(REALTIME_STATUS.IDLE);
 
@@ -637,6 +650,9 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   const rememberSpokenAsk = useCallback((transcript: string) => {
     const mark = spokenTurnMarkRef.current;
     spokenTurnMarkRef.current = undefined;
+    if (!spokenAskBelongsToConversation(mark?.generation, conversationGenerationRef.current)) {
+      return;
+    }
     conversationRef.current = mark
       ? insertSpokenAskThreadEntry(conversationRef.current, transcript, mark.after)
       : appendConversationThreadEntry(conversationRef.current, {
@@ -1224,7 +1240,10 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       previousVoiceStatus.current === REALTIME_STATUS.LISTENING &&
       voiceStatus === REALTIME_STATUS.RESPONDING
     ) {
-      spokenTurnMarkRef.current = { after: conversationRef.current.at(-1) };
+      spokenTurnMarkRef.current = {
+        after: conversationRef.current.at(-1),
+        generation: conversationGenerationRef.current,
+      };
     }
     previousVoiceStatus.current = voiceStatus;
     // Any settled status ends the wait the press started, however it ended:

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -653,7 +653,10 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
     spokenTurnMarksRef.current.clear();
     pendingSpokenTurnMarksRef.current = [];
     setConversationHistory([]);
-    voiceSession.current?.updateConversation([]);
+    talkLatched.current = false;
+    talkPressedAt.current = undefined;
+    voiceSession.current?.clearConversation();
+    activeReplyGenerationRef.current = undefined;
   }, []);
 
   /**

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -312,7 +312,15 @@ export function spokenAskBelongsToConversation(
   markGeneration: number | undefined,
   conversationGeneration: number,
 ): boolean {
-  return markGeneration !== undefined && markGeneration === conversationGeneration;
+  return conversationEntryBelongsToConversation(markGeneration, conversationGeneration);
+}
+
+/** An asynchronous entry belongs only to the history generation in which its work began. */
+export function conversationEntryBelongsToConversation(
+  entryGeneration: number | undefined,
+  conversationGeneration: number,
+): boolean {
+  return entryGeneration !== undefined && entryGeneration === conversationGeneration;
 }
 
 /**
@@ -609,6 +617,8 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
   const activeSpokenTurnMarkRef = useRef<
     { after: ConversationEntry | undefined; generation: number } | undefined
   >(undefined);
+  /** The generation of the developer-opened turn whose reply is still in flight. */
+  const activeReplyGenerationRef = useRef<number | undefined>(undefined);
   /**
    * Whether the turn under way read a transcript aloud. The rendering travels
    * only in the turn that asked for it, so the reply that spoke it must not
@@ -622,12 +632,20 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
    * open about only the recent context slice. A session leaving the roster
    * costs a line its identity at model render, never its visible words.
    */
-  const rememberConversationEntry = useCallback((entry: ConversationEntry | undefined) => {
-    if (!entry) return;
-    conversationRef.current = appendConversationThreadEntry(conversationRef.current, entry);
-    setConversationHistory(conversationRef.current);
-    voiceSession.current?.updateConversation(recentConversationEntries(conversationRef.current));
-  }, []);
+  const rememberConversationEntry = useCallback(
+    (entry: ConversationEntry | undefined, generation = conversationGenerationRef.current) => {
+      if (
+        !entry ||
+        !conversationEntryBelongsToConversation(generation, conversationGenerationRef.current)
+      ) {
+        return;
+      }
+      conversationRef.current = appendConversationThreadEntry(conversationRef.current, entry);
+      setConversationHistory(conversationRef.current);
+      voiceSession.current?.updateConversation(recentConversationEntries(conversationRef.current));
+    },
+    [],
+  );
 
   const clearConversationHistory = useCallback(() => {
     conversationGenerationRef.current += 1;
@@ -684,6 +702,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       // press that opens a session: a spoken ask is a third way to ask for the
       // same act, behind the same gauntlet in the main process.
       carryAct: async (envelope) => {
+        const generation = activeReplyGenerationRef.current;
         const authorization = await window.sidecar.authorizeAct(envelope);
         if (authorization.status !== ACT_RESULT_STATUS.ACCEPTED) return authorization;
         const { act: action, armed } = envelope;
@@ -709,7 +728,10 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
         // leaves the developer having asked it, and the next turn may point
         // back at the session it named. The outcome needs no line of its own —
         // the reply voicing it is recorded as what Luke said.
-        rememberConversationEntry(sessionActConversationEntry(action, sessionsRef.current));
+        rememberConversationEntry(
+          sessionActConversationEntry(action, sessionsRef.current),
+          generation,
+        );
         // The reply that voices a transcript reading must stay out of the
         // history: the rendering travels only in the turn that asked for it.
         if (action.kind === SESSION_TOOL_KIND.READ_TRANSCRIPT) {
@@ -761,6 +783,8 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       onError: setVoiceError,
       onCaption: (texts, about) => setVoiceCaption({ texts, about }),
       onReplyEnded: (texts, about) => {
+        const generation = activeReplyGenerationRef.current;
+        activeReplyGenerationRef.current = undefined;
         const spokeTranscript = transcriptSpokenRef.current;
         transcriptSpokenRef.current = false;
         // An announcement's reply is already recorded from the update that
@@ -768,7 +792,10 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
         // the words alone cannot carry — and a transcript reading enters the
         // record only as the act it was.
         if (about || spokeTranscript) return;
-        rememberConversationEntry({ kind: CONVERSATION_ENTRY_KIND.REPLY, words: texts.join(" ") });
+        rememberConversationEntry(
+          { kind: CONVERSATION_ENTRY_KIND.REPLY, words: texts.join(" ") },
+          generation,
+        );
       },
       onSpokenAskCommitted: (itemId) => {
         const mark = pendingSpokenTurnMarksRef.current.shift();
@@ -1027,11 +1054,17 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       // that is already up.
       if (talkPressedAt.current !== pressedAt) return;
     }
+    // The interruption can synchronously hand over the reply the developer
+    // just cut off. Let that older line land before marking the new turn, so
+    // its delayed transcript is inserted after everything that preceded it.
+    session.beginTurn();
     activeSpokenTurnMarkRef.current = {
       after: conversationRef.current.at(-1),
       generation: conversationGenerationRef.current,
     };
-    session.beginTurn();
+    // Only after the interrupted reply's handover does this new turn own the
+    // active reply generation.
+    activeReplyGenerationRef.current = activeSpokenTurnMarkRef.current.generation;
     const press = talkKeyPress({ latched: false, microphoneCall: session.microphoneCall });
     // A press against no call — or against Luke's own speak-only call, which
     // has no microphone to offer — has seconds of handshake ahead of it, and
@@ -1113,6 +1146,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
    */
   const askLuke = useCallback(
     async (text: string): Promise<string | undefined> => {
+      const generation = conversationGenerationRef.current;
       const session = ensureVoiceSession();
       // Luke's own speak-only call cannot carry a typed ask — it was sent no
       // roster to validate one against — so it counts as no call here, and
@@ -1122,6 +1156,7 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
         await startConversation();
       }
       if (session.sendText(text)) {
+        activeReplyGenerationRef.current = generation;
         setTypedAsk(true);
         // A new typed turn lets a leftover transcript skip go, exactly as a
         // spoken one does — after the send, whose interrupt hands over the
@@ -1129,7 +1164,10 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
         transcriptSpokenRef.current = false;
         // The developer's own words enter the history as they were typed, so
         // the thread holds both halves of the exchange the reply answers.
-        rememberConversationEntry({ kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: text });
+        rememberConversationEntry(
+          { kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: text },
+          generation,
+        );
         // A sent ask outdates whatever refusal the strip was still reading:
         // a call already open skips `startConversation`, so the clear it
         // would have run happens here.

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -323,6 +323,15 @@ export function conversationEntryBelongsToConversation(
   return entryGeneration !== undefined && entryGeneration === conversationGeneration;
 }
 
+/** Captures the reply that owns an act before main-process authorization can pause it. */
+export async function authorizeConversationAct<T>(
+  activeReplyGeneration: { readonly current: number | undefined },
+  authorize: () => Promise<T>,
+): Promise<{ authorization: T; generation: number | undefined }> {
+  const generation = activeReplyGeneration.current;
+  return { authorization: await authorize(), generation };
+}
+
 /**
  * The sessions the replies being spoken are about, for the surface to draw
  * pressable previews of. An announcement already carries its one
@@ -705,8 +714,10 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       // press that opens a session: a spoken ask is a third way to ask for the
       // same act, behind the same gauntlet in the main process.
       carryAct: async (envelope) => {
-        const generation = activeReplyGenerationRef.current;
-        const authorization = await window.sidecar.authorizeAct(envelope);
+        const { authorization, generation } = await authorizeConversationAct(
+          activeReplyGenerationRef,
+          () => window.sidecar.authorizeAct(envelope),
+        );
         if (authorization.status !== ACT_RESULT_STATUS.ACCEPTED) return authorization;
         const { act: action, armed } = envelope;
         if (!armed) {

--- a/packages/analytics/AGENTS.md
+++ b/packages/analytics/AGENTS.md
@@ -38,11 +38,12 @@ the app runs, on the library's own configuration, and nothing in this package
 governs a byte of it. Do not let this file's promise be read as covering it.
 Three things leave that way and none is validated here:
 
-- The recording itself, which is the rendered panel — a session's title,
-  branch, recap, and error line, the account's name and address, and a
-  screenshot attached to the feedback composer all travel because they are
-  drawn. Only what is typed into a field is masked, and that is the library's
-  default rather than a posture the app keeps.
+- The recording itself, which is the rendered panel except for the History
+  tab's explicitly blocked `ph-no-capture` subtree — a session's title, branch,
+  recap, and error line, the account's name and address, and a screenshot
+  attached to the feedback composer all travel because they are drawn. Only
+  what is typed into a field is masked, and that is the library's default
+  rather than a posture the app keeps.
 - Autocaptured events, which name the text of whatever was clicked. Pressing a
   session row sends that row's words.
 - Unhandled exceptions, with their message and stack.

--- a/packages/analytics/src/product-events.ts
+++ b/packages/analytics/src/product-events.ts
@@ -243,6 +243,7 @@ export type ProductUpdateAct = (typeof PRODUCT_UPDATE_ACT)[keyof typeof PRODUCT_
 /** Which half of the panel is drawn, said exactly as the guide says it. */
 export const PRODUCT_PANEL_TAB = {
   SESSIONS: APP_PANEL_TAB.SESSIONS,
+  HISTORY: APP_PANEL_TAB.HISTORY,
   SETTINGS: APP_PANEL_TAB.SETTINGS,
 } as const satisfies Record<string, AppPanelTab>;
 

--- a/packages/guide/src/guide.ts
+++ b/packages/guide/src/guide.ts
@@ -144,6 +144,7 @@ export const EMPTY_APP_GUIDE: AppGuideSnapshot = { facts: [], settings: [] };
  */
 export const APP_PANEL_TAB = {
   SESSIONS: "sessions",
+  HISTORY: "history",
   SETTINGS: "settings",
 } as const;
 

--- a/packages/realtime/src/conversation-history.test.ts
+++ b/packages/realtime/src/conversation-history.test.ts
@@ -34,13 +34,14 @@ function rosterSession(providerSessionId: string, title: string) {
   );
 }
 
-function announcement(summary: string): AttentionSpeech {
+function announcement(summary: string, historyText?: string): AttentionSpeech {
   return {
     providerId: "claude-code",
     providerSessionId: "session-a",
     disposition: ATTENTION_DISPOSITION.SPEAK_AT_TURN_END,
     source: ATTENTION_SPEECH_SOURCE.NOTICE_REQUEST,
     summary,
+    ...(historyText ? { historyText } : undefined),
     decidedAt: OBSERVED_AT,
   };
 }
@@ -92,12 +93,19 @@ test("the current-launch thread keeps every entry while model context stays rece
 
 test("an announcement's line carries its bounded words and validated identity", () => {
   const entry = announcementConversationEntry(
-    announcement("Claude Code finished checkout-service."),
+    announcement(
+      'provider: "Claude Code"; event: finished; work recap: "Checkout is ready."',
+      "Checkout is ready.",
+    ),
   );
 
   assert.ok(entry);
   assert.equal(entry.kind, CONVERSATION_ENTRY_KIND.ANNOUNCEMENT);
-  assert.equal(entry.words, "Claude Code finished checkout-service.");
+  assert.equal(
+    entry.words,
+    'provider: "Claude Code"; event: finished; work recap: "Checkout is ready."',
+  );
+  assert.equal(entry.displayWords, "Checkout is ready.");
   assert.deepEqual(entry.identity, {
     providerId: "claude-code",
     providerSessionId: "session-a",

--- a/packages/realtime/src/conversation-history.test.ts
+++ b/packages/realtime/src/conversation-history.test.ts
@@ -11,12 +11,15 @@ import {
 import {
   announcementConversationEntry,
   appendConversationEntry,
+  appendConversationThreadEntry,
   CONVERSATION_ENTRY_KIND,
   type ConversationEntry,
   conversationHistoryText,
   insertSpokenAskEntry,
+  insertSpokenAskThreadEntry,
   maximumConversationEntries,
   maximumConversationEntryLength,
+  recentConversationEntries,
   sessionActConversationEntry,
 } from "./conversation-history.js";
 import { ATTENTION_SPEECH_SOURCE, type AttentionSpeech } from "./realtime-protocol.js";
@@ -69,6 +72,22 @@ test("appending flattens, bounds, and retires the oldest lines", () => {
   }
   assert.equal(entries.length, maximumConversationEntries);
   assert.equal(entries[0]?.words, "line 3");
+});
+
+test("the current-launch thread keeps every entry while model context stays recent", () => {
+  let thread: readonly ConversationEntry[] = [];
+  for (let index = 0; index < maximumConversationEntries + 3; index += 1) {
+    thread = appendConversationThreadEntry(thread, {
+      kind: CONVERSATION_ENTRY_KIND.REPLY,
+      words: `line ${index}`,
+    });
+  }
+
+  assert.equal(thread.length, maximumConversationEntries + 3);
+  assert.equal(thread[0]?.words, "line 0");
+  const recent = recentConversationEntries(thread);
+  assert.equal(recent.length, maximumConversationEntries);
+  assert.equal(recent[0]?.words, "line 3");
 });
 
 test("an announcement's line carries its bounded words and validated identity", () => {
@@ -206,6 +225,24 @@ test("a spoken ask reads as the developer's own words, said rather than typed", 
 
   assert.ok(text);
   assert.match(text, /^- the developer said: "how is the checkout agent doing\?"$/m);
+});
+
+test("a delayed spoken ask keeps its place in the full current-launch thread", () => {
+  const prior: ConversationEntry = {
+    kind: CONVERSATION_ENTRY_KIND.REPLY,
+    words: "Earlier reply.",
+  };
+  const later: ConversationEntry = {
+    kind: CONVERSATION_ENTRY_KIND.REPLY,
+    words: "Later reply.",
+  };
+
+  const placed = insertSpokenAskThreadEntry([prior, later], "What happened between those?", prior);
+
+  assert.deepEqual(
+    placed.map((entry) => entry.words),
+    ["Earlier reply.", "What happened between those?", "Later reply."],
+  );
 });
 
 test("a spoken ask lands at its turn's own mark, not where its transcription did", () => {

--- a/packages/realtime/src/conversation-history.ts
+++ b/packages/realtime/src/conversation-history.ts
@@ -53,6 +53,8 @@ export interface ConversationEntry {
    * about, not every word of it.
    */
   words: string;
+  /** Cleaner visible copy when the model context in `words` is structured. */
+  displayWords?: string;
   /**
    * The roster-validated session the line was about, when it was about one.
    * Only ever an identity the roster reported at the moment of the entry —
@@ -75,6 +77,8 @@ export function appendConversationThreadEntry(
   const words = boundedEntryWords(entry.words);
   if (!words) return entries;
   const appended: ConversationEntry = { kind: entry.kind, words };
+  const displayWords = entry.displayWords ? boundedEntryWords(entry.displayWords) : undefined;
+  if (displayWords) appended.displayWords = displayWords;
   if (entry.identity) appended.identity = entry.identity;
   return [...entries, appended];
 }
@@ -148,6 +152,7 @@ export function announcementConversationEntry(
   return {
     kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
     words,
+    ...(speech.historyText ? { displayWords: speech.historyText } : undefined),
     identity: { providerId: speech.providerId, providerSessionId: speech.providerSessionId },
   };
 }

--- a/packages/realtime/src/conversation-history.ts
+++ b/packages/realtime/src/conversation-history.ts
@@ -3,8 +3,10 @@
  * of the wire. A Realtime call is a transport that comes and goes — the
  * announcer's speak-only call is torn down by the very talk-key press that
  * asks about it, and the developer's call retires when idle — so the thread
- * itself is kept here, as a bounded record of what was already said and done,
- * and re-fed to whichever call the developer opens next.
+ * itself is kept here, as a record of what was already said and done during
+ * this app launch. A bounded recent slice is re-fed to whichever call the
+ * developer opens next; the whole in-memory thread remains available to the
+ * developer in the panel until they clear it or quit.
  *
  * Every line already traveled to the voice service once, on the call that
  * said it: the developer's own asks — typed, or spoken and handed back as
@@ -36,10 +38,9 @@ export type ConversationEntryKind =
   (typeof CONVERSATION_ENTRY_KIND)[keyof typeof CONVERSATION_ENTRY_KIND];
 
 /**
- * How many lines the history keeps, and how long each may run. Together they
- * bound what one context item can cost the model's window: the record is a
- * thread to pick back up, not an archive, and its oldest lines leave first —
- * the same eviction the window itself would choose.
+ * How many recent lines the model receives, and how long every stored line may
+ * run. Together they bound what one context item can cost the model's window;
+ * the panel may keep more lines from this launch without sending them all.
  */
 export const maximumConversationEntries = 20;
 export const maximumConversationEntryLength = 400;
@@ -63,11 +64,11 @@ export interface ConversationEntry {
 }
 
 /**
- * Appends one line, holding the history to its bounds. An entry with nothing
- * left after flattening appends nothing: an empty line says nothing worth a
- * window's space.
+ * Appends one length-bounded line to the current-launch thread. An entry with
+ * nothing left after flattening appends nothing: an empty line says nothing
+ * worth keeping or spending model-window space on.
  */
-export function appendConversationEntry(
+export function appendConversationThreadEntry(
   entries: readonly ConversationEntry[],
   entry: ConversationEntry,
 ): readonly ConversationEntry[] {
@@ -75,7 +76,22 @@ export function appendConversationEntry(
   if (!words) return entries;
   const appended: ConversationEntry = { kind: entry.kind, words };
   if (entry.identity) appended.identity = entry.identity;
-  return [...entries, appended].slice(-maximumConversationEntries);
+  return [...entries, appended];
+}
+
+/** The recent slice safe to place back into the model's context window. */
+export function recentConversationEntries(
+  entries: readonly ConversationEntry[],
+): readonly ConversationEntry[] {
+  return entries.slice(-maximumConversationEntries);
+}
+
+/** Appends one bounded line to the recent model context. */
+export function appendConversationEntry(
+  entries: readonly ConversationEntry[],
+  entry: ConversationEntry,
+): readonly ConversationEntry[] {
+  return recentConversationEntries(appendConversationThreadEntry(entries, entry));
 }
 
 /** One flattening and one bound for every line, however it enters. */
@@ -92,22 +108,31 @@ function boundedEntryWords(words: string): string {
  * against the entries: `after` is the entry the history ended with at the
  * moment the spoken turn committed — everything behind it is that turn's own
  * produce — or nothing for a turn committed against an empty history, which
- * belongs at the very front. A mark the bounds have already retired lands
- * there too: an ask older than everything left comes before all of it.
+ * belongs at the very front. A missing mark lands there too: an ask older than
+ * everything left comes before all of it.
  */
-export function insertSpokenAskEntry(
+export function insertSpokenAskThreadEntry(
   entries: readonly ConversationEntry[],
   words: string,
   after: ConversationEntry | undefined,
 ): readonly ConversationEntry[] {
   const bounded = boundedEntryWords(words);
   if (!bounded) return entries;
-  // indexOf answers -1 for a retired mark, so the ask lands at the front —
+  // indexOf answers -1 for a missing mark, so the ask lands at the front —
   // exactly where an entry older than the whole history belongs.
   const at = after ? entries.indexOf(after) + 1 : 0;
   const placed = [...entries];
   placed.splice(at, 0, { kind: CONVERSATION_ENTRY_KIND.SPOKEN_ASK, words: bounded });
-  return placed.slice(-maximumConversationEntries);
+  return placed;
+}
+
+/** Places a spoken ask into the recent model context and retires old lines. */
+export function insertSpokenAskEntry(
+  entries: readonly ConversationEntry[],
+  words: string,
+  after: ConversationEntry | undefined,
+): readonly ConversationEntry[] {
+  return recentConversationEntries(insertSpokenAskThreadEntry(entries, words, after));
 }
 
 /**

--- a/packages/realtime/src/index.ts
+++ b/packages/realtime/src/index.ts
@@ -7,13 +7,16 @@ export {
 export {
   announcementConversationEntry,
   appendConversationEntry,
+  appendConversationThreadEntry,
   CONVERSATION_ENTRY_KIND,
   type ConversationEntry,
   type ConversationEntryKind,
   conversationHistoryText,
   insertSpokenAskEntry,
+  insertSpokenAskThreadEntry,
   maximumConversationEntries,
   maximumConversationEntryLength,
+  recentConversationEntries,
   sessionActConversationEntry,
 } from "./conversation-history.js";
 export {

--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -158,6 +158,8 @@ export interface AttentionSpeech extends SessionIdentity {
   disposition: AttentionDisposition;
   source: AttentionSpeechSource;
   summary: string;
+  /** User-facing words for History when `summary` is structured model context. */
+  historyText?: string;
   decidedAt: number;
 }
 

--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -122,6 +122,8 @@ export const REALTIME_SERVER_EVENT = {
   RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA: "response.output_audio_transcript.delta",
   /** The reply's complete text, which supersedes whatever the deltas built. */
   RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DONE: "response.output_audio_transcript.done",
+  /** The server has made one developer audio turn into a conversation item. */
+  INPUT_AUDIO_BUFFER_COMMITTED: "input_audio_buffer.committed",
   /**
    * The developer's own spoken turn, as the service transcribed it. It
    * arrives on its own clock — transcription runs beside the reply, not ahead
@@ -728,8 +730,10 @@ export type ParsedRealtimeServerEvent =
     }
   | {
       type: typeof REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED;
+      itemId: string;
       transcript: string;
     }
+  | { type: typeof REALTIME_SERVER_EVENT.INPUT_AUDIO_BUFFER_COMMITTED; itemId: string }
   | { type: typeof REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED; responseId?: string }
   | { type: typeof REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STARTED; responseId?: string }
   | {
@@ -875,11 +879,18 @@ export function parseRealtimeServerEvent(
       // A transcription that came back empty said nothing worth a history
       // line, and a failed one arrives as its own event this parser ignores.
       const transcript = text(event.transcript);
-      if (!transcript) return undefined;
+      const itemId = text(event.item_id);
+      if (!transcript || !itemId) return undefined;
       return {
         type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED,
+        itemId,
         transcript,
       };
+    }
+    case REALTIME_SERVER_EVENT.INPUT_AUDIO_BUFFER_COMMITTED: {
+      const itemId = text(event.item_id);
+      if (!itemId) return undefined;
+      return { type: REALTIME_SERVER_EVENT.INPUT_AUDIO_BUFFER_COMMITTED, itemId };
     }
     case REALTIME_SERVER_EVENT.OUTPUT_AUDIO_BUFFER_STOPPED: {
       // The drain names the response it drained. An old reply's buffer can

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -1341,8 +1341,16 @@ test("inbound events the conversation acts on are parsed, and nothing else is", 
     }),
     {
       type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED,
+      itemId: "item-2",
       transcript: "how is the checkout agent doing?",
     },
+  );
+  assert.deepEqual(
+    parseRealtimeServerEvent({
+      type: REALTIME_SERVER_EVENT.INPUT_AUDIO_BUFFER_COMMITTED,
+      item_id: "item-2",
+    }),
+    { type: REALTIME_SERVER_EVENT.INPUT_AUDIO_BUFFER_COMMITTED, itemId: "item-2" },
   );
   assert.deepEqual(parseRealtimeServerEvent({ type: REALTIME_SERVER_EVENT.RESPONSE_DONE }), {
     type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
@@ -1384,6 +1392,8 @@ test("inbound events the conversation acts on are parsed, and nothing else is", 
     { type: REALTIME_SERVER_EVENT.RESPONSE_OUTPUT_AUDIO_TRANSCRIPT_DELTA, item_id: "item-1" },
     // A transcription that came back empty said nothing worth acting on.
     { type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED, transcript: "  " },
+    { type: REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED, transcript: "hello" },
+    { type: REALTIME_SERVER_EVENT.INPUT_AUDIO_BUFFER_COMMITTED },
     { type: "session.updated" },
   ];
   for (const payload of payloads) {

--- a/packages/voice/src/session-notifications.test.ts
+++ b/packages/voice/src/session-notifications.test.ts
@@ -55,6 +55,7 @@ test("a concrete question is announced with the decision itself", () => {
   assert.match(speech.summary, /work: "Notification fix"/);
   assert.match(speech.summary, /event: needs a decision to continue/);
   assert.match(speech.summary, /decision: "Should session replay capture screenshots\?"/);
+  assert.equal(speech.historyText, "Should session replay capture screenshots?");
   assert.match(speech.summary, /can take a message now: yes/);
   assert.doesNotMatch(speech.summary, /\bturn\b|\bdeveloper\b/);
 });
@@ -71,5 +72,6 @@ test("a permission hold is announced with the action awaiting approval", () => {
 
   assert.ok(speech);
   assert.match(speech.summary, /permission context: "Bash: pnpm test"/);
+  assert.equal(speech.historyText, "Should the test plan cover live audio?");
   assert.doesNotMatch(speech.summary, /test plan cover live audio/);
 });

--- a/packages/voice/src/session-notifications.ts
+++ b/packages/voice/src/session-notifications.ts
@@ -56,6 +56,14 @@ function decisionContext(notice: SessionNotice): readonly [string, string] | und
   return undefined;
 }
 
+/** The useful part of a status edge when it is read later as a chat message. */
+function noticeHistoryText(notice: SessionNotice): string {
+  if (notice.error) return flattened(notice.error);
+  if (notice.recap) return recapExcerpt(notice.recap);
+  const event = noticeEvent(notice);
+  return `${event[0]?.toUpperCase() ?? ""}${event.slice(1)}.`;
+}
+
 /** Renders provider-observed status fields for the voice to summarize. */
 function noticeUpdateContext(notice: SessionNotice): string {
   const decision = notice.holdingForDeveloper === true ? decisionContext(notice) : undefined;
@@ -99,6 +107,7 @@ export function sessionNoticeSpeech(
     disposition: ATTENTION_DISPOSITION.SPEAK_AT_TURN_END,
     source: ATTENTION_SPEECH_SOURCE.STATUS_EDGE,
     summary: noticeUpdateContext(notice),
+    historyText: noticeHistoryText(notice),
     decidedAt,
   };
 }


### PR DESCRIPTION
## Summary

- add a History tab containing Luke's full in-memory conversation from the current app launch
- keep model context independently bounded to the 20 most recent entries
- let users clear both the visible thread and live model context, including protection from delayed transcriptions
- block the entire history subtree from optional PostHog session replay and document the privacy boundary

## Privacy

- history is renderer memory only and disappears on quit
- no persistence or export is added
- conversation words are explicitly excluded from panel recordings

## Verification

- `./scripts/check.sh`
  - repository and design contracts passed
  - lint and typecheck passed
  - 771 desktop tests passed, 0 failed
  - production builds passed
- inspected the History empty state in the macOS fixture UI

## Commits

- `feat(realtime): retain launch conversation history`
- `feat(desktop): add Luke conversation history`
- `fix(desktop): clear Luke history completely`
- `docs: explain Luke history privacy`

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/33126434472/artifacts/9668614686) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/33126434472)

- Commit: `3e440eeb440798a8734fb683d9fda4bcf0827f62`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
