### PR TITLE
feat(desktop): open Replicas sessions in the Replicas desktop app

### DIFF
--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -285,6 +285,11 @@ const providerRegistry = providerRegistrations({
   readApiKey: (providerId) => settingsStore.readApiKey(providerId),
   observationHookInstallation: (providerId) => observationHooks.installation(providerId),
   codexCloudAdapter,
+  // A Replicas workspace opens in the Replicas desktop app when the OS has a
+  // handler for its scheme, and on the web dashboard otherwise. This asks
+  // LaunchServices the very question the open will ask it, so the address a
+  // row carries and the app that answers its press can never disagree.
+  replicasDesktopAppPresent: () => app.getApplicationNameForProtocol("replicas://open") !== "",
 });
 // The record enforces completeness; the shared list preserves provider order.
 const orderedRegistrations: readonly ProviderRegistration[] = PROVIDER_ID_LIST.map(

--- a/packages/credentials/src/credential-providers.ts
+++ b/packages/credentials/src/credential-providers.ts
@@ -240,7 +240,7 @@ export const CREDENTIAL_PROVIDERS: CredentialProviderRegistry = {
     // Replicas issues organization keys and personal keys, and its API takes
     // either; the personal page is the one every member can reach.
     hint: "Create a key in the Replicas dashboard under Personal · API keys.",
-    apiKeysUrl: "https://tryreplicas.com/dashboard/account/api-keys",
+    apiKeysUrl: "https://replicas.dev/dashboard/account/api-keys",
     environmentVariables: [REPLICAS_ENVIRONMENT.API_KEY],
     // No key format: Replicas publishes none, so a prefix could only refuse a
     // working key.

--- a/packages/providers/src/registrations.ts
+++ b/packages/providers/src/registrations.ts
@@ -50,6 +50,14 @@ export interface ProviderRegistrationOptions {
    * settings read is the reference the composite observes with.
    */
   codexCloudAdapter: CodexCloudSessionAdapter;
+  /**
+   * Whether this machine currently registers a handler for the Replicas
+   * desktop app's URL scheme, answered by the caller because only the
+   * operating system knows — it is the same question the OS answers when a
+   * row's address is handed to it. Absent, Replicas addresses stay the web
+   * dashboard's.
+   */
+  replicasDesktopAppPresent?: () => boolean;
   now?: () => number;
 }
 
@@ -201,6 +209,9 @@ export function providerRegistrations(options: ProviderRegistrationOptions) {
     [PROVIDER_ID.REPLICAS]: {
       adapter: new ReplicasSessionAdapter({
         readApiKey: () => options.readApiKey(CREDENTIAL_PROVIDER_ID.REPLICAS),
+        ...(options.replicasDesktopAppPresent
+          ? { desktopAppPresent: options.replicasDesktopAppPresent }
+          : undefined),
       }),
       credential: CREDENTIAL_PROVIDERS[CREDENTIAL_PROVIDER_ID.REPLICAS],
     },

--- a/packages/providers/src/replicas/adapter.test.ts
+++ b/packages/providers/src/replicas/adapter.test.ts
@@ -348,6 +348,7 @@ function adapterFor(
     readApiKey?: () => Promise<string | undefined>;
     now?: () => number;
     minimumRefreshIntervalMs?: number;
+    desktopAppPresent?: () => boolean;
   } = {},
 ): ReplicasSessionAdapter {
   const apiKey = "apiKey" in overrides ? overrides.apiKey : TEST_API_KEY;
@@ -357,6 +358,9 @@ function adapterFor(
     fetch,
     now: overrides.now ?? (() => TEST_TIME),
     minimumRefreshIntervalMs: overrides.minimumRefreshIntervalMs ?? 0,
+    ...(overrides.desktopAppPresent
+      ? { desktopAppPresent: overrides.desktopAppPresent }
+      : undefined),
   });
 }
 
@@ -424,7 +428,7 @@ test("observes an active workspace titled by the name Replicas gave it", async (
   // Replicas mark rides as the app association carrying the same address.
   assert.deepEqual(observations[0]?.detail, {
     repository: "luke",
-    link: "https://tryreplicas.com/home/workspace/workspace-active",
+    link: "https://replicas.dev/home/workspace/workspace-active",
   });
   // Workspace-scoped, like Superset's: inside a tray the manager is named
   // once on the header, and only a lone chat's row keeps the chip.
@@ -433,9 +437,36 @@ test("observes an active workspace titled by the name Replicas gave it", async (
       id: "replicas",
       displayName: "Replicas",
       scope: "workspace",
-      link: "https://tryreplicas.com/home/workspace/workspace-active",
+      link: "https://replicas.dev/home/workspace/workspace-active",
     },
   ]);
+});
+
+test("addresses the desktop app while the OS has a handler for its scheme", async () => {
+  const api = fakeReplicasApi([
+    {
+      id: "workspace-active",
+      name: "fix-login-timeout",
+      status: TEST_STATUS.ACTIVE,
+      createdAt: TEST_TIME - 60_000,
+      lastActivityAt: TEST_TIME - 30_000,
+    },
+  ]);
+  // The deep link carries the dashboard path as the one query parameter the
+  // app's handler reads, so it opens exactly the page the web address does.
+  const desktopLink = "replicas://open?path=%2Fhome%2Fworkspace%2Fworkspace-active";
+  let handlerRegistered = false;
+  const adapter = adapterFor(api.fetch, { desktopAppPresent: () => handlerRegistered });
+
+  const webPass = await adapter.observe();
+  handlerRegistered = true;
+  const desktopPass = await adapter.observe();
+
+  // The probe answers per pass, so installing the app applies on the next
+  // one, and the row and its mark always carry the same address.
+  assert.equal(webPass[0]?.detail?.link, "https://replicas.dev/home/workspace/workspace-active");
+  assert.equal(desktopPass[0]?.detail?.link, desktopLink);
+  assert.equal(desktopPass[0]?.applications?.[0]?.link, desktopLink);
 });
 
 test("falls back to the repository for a workspace the list did not name", async () => {
@@ -1205,7 +1236,7 @@ test("reports the newest pull request as the workspace's published change", asyn
   // on the row lands on the workspace itself.
   assert.equal(
     observations[0]?.detail?.link,
-    "https://tryreplicas.com/home/workspace/workspace-published",
+    "https://replicas.dev/home/workspace/workspace-published",
   );
   assert.equal(observations[1]?.detail?.change, undefined);
 });

--- a/packages/providers/src/replicas/adapter.ts
+++ b/packages/providers/src/replicas/adapter.ts
@@ -72,12 +72,37 @@ const REPLICAS_REQUEST_HEADERS = {
  * address handed to the operating system, reaching no provider — and it
  * lands on the exact workspace the row is. A chat row carries the same
  * address, because the workspace page is where Replicas itself opens every
- * chat the workspace holds, and Replicas documents no narrower address.
+ * chat the workspace holds, and Replicas addresses no chat: the workspace
+ * page's whole URL state is its view mode and a plan or media selection, and
+ * which chat is open never reaches the address bar, so a narrower link could
+ * only land somewhere other than where it said. The origin is the canonical
+ * one the dashboard now answers on; its former home permanently redirects
+ * here.
  */
-const REPLICAS_WORKSPACE_LINK_BASE = "https://tryreplicas.com/home/workspace/";
+const REPLICAS_WEB_APP_ORIGIN = "https://replicas.dev";
 
-function replicasWorkspaceLink(workspaceId: string): string {
-  return `${REPLICAS_WORKSPACE_LINK_BASE}${encodeURIComponent(workspaceId)}`;
+const REPLICAS_WORKSPACE_PATH_PREFIX = "/home/workspace/";
+
+/**
+ * The desktop app's registered way to the same page. Its handler reads one
+ * `path` query parameter, requires it to be an absolute path, and resolves it
+ * against the app's own web origin — verified against the app's handler
+ * itself, which drops anything else unopened — so what travels is exactly the
+ * dashboard path the web address carries, opened in the window the user chose
+ * by installing the app. The host segment is ignored by the handler; `open`
+ * names the act for anyone reading the address.
+ */
+const REPLICAS_DESKTOP_LINK_PREFIX = "replicas://open?path=";
+
+function replicasWorkspacePath(workspaceId: string): string {
+  return `${REPLICAS_WORKSPACE_PATH_PREFIX}${encodeURIComponent(workspaceId)}`;
+}
+
+function replicasWorkspaceLink(workspaceId: string, desktopApp: boolean): string {
+  const path = replicasWorkspacePath(workspaceId);
+  return desktopApp
+    ? `${REPLICAS_DESKTOP_LINK_PREFIX}${encodeURIComponent(path)}`
+    : `${REPLICAS_WEB_APP_ORIGIN}${path}`;
 }
 
 const REPLICAS_ROUTE_SEGMENT = {
@@ -350,7 +375,17 @@ export const REPLICAS_PROVIDER: SessionProvider = {
   displayName: REPLICAS_PROVIDER_NAME,
 };
 
-export type ReplicasAdapterOptions = CloudAdapterOptions;
+export type ReplicasAdapterOptions = CloudAdapterOptions & {
+  /**
+   * Whether this machine currently registers a handler for the Replicas
+   * desktop app's URL scheme. The question is the operating system's to
+   * answer — it is what the OS will consult when a row's address is handed
+   * to it — so the caller supplies the probe and this adapter only chooses
+   * between two spellings of the same page. Absent, or answering no, every
+   * address stays the web dashboard's.
+   */
+  desktopAppPresent?: () => boolean;
+};
 
 interface ReplicasWorkspace {
   id: string;
@@ -813,6 +848,17 @@ export class ReplicasSessionAdapter extends CloudSessionAdapter {
   /** The environments the latest pass reported, offered as creation projects. */
   #projects: readonly WorkspaceProject[] = [];
 
+  #desktopAppPresent?: () => boolean;
+
+  /**
+   * Whether this pass's addresses open in the desktop app. Asked once per
+   * pass rather than per row, so every row of one roster agrees, and asked
+   * fresh each pass, so installing or removing the app applies on the next
+   * one — including to a workspace Luke just created, whose held open uses
+   * the address its first observation reports.
+   */
+  #openInDesktopApp = false;
+
   constructor(options: ReplicasAdapterOptions) {
     super(
       {
@@ -822,6 +868,7 @@ export class ReplicasSessionAdapter extends CloudSessionAdapter {
       },
       options,
     );
+    this.#desktopAppPresent = options.desktopAppPresent;
   }
 
   protected override requestHeaders() {
@@ -841,6 +888,7 @@ export class ReplicasSessionAdapter extends CloudSessionAdapter {
     request: CloudRequest,
     now: number,
   ): Promise<readonly ProviderSessionObservation[]> {
+    this.#openInDesktopApp = this.#desktopAppPresent?.() === true;
     // One list call, then bounded per-workspace reads for the newest
     // workspaces. The list carries the status, the timestamps, the
     // repositories, and the pull requests; the chat registry lists each
@@ -1308,7 +1356,7 @@ export class ReplicasSessionAdapter extends CloudSessionAdapter {
         // once, the hoist proving the reports one change by their shared
         // number.
         ...(workspace.pullRequestUrl ? { change: workspace.pullRequestUrl } : undefined),
-        link: replicasWorkspaceLink(workspace.id),
+        link: replicasWorkspaceLink(workspace.id, this.#openInDesktopApp),
       },
     };
   }
@@ -1392,12 +1440,14 @@ export class ReplicasSessionAdapter extends CloudSessionAdapter {
 
   /**
    * The Replicas mark rides as the workspace's own app association — scope
-   * workspace, because the one address Replicas documents is the workspace
-   * page, not any chat's own route — so inside a tray the manager is named
-   * once on the header, the way Superset's is, and a lone chat keeps the
-   * chip because no tray names it. Conductor's association stays
-   * session-scoped on the same reasoning read the other way: its address
-   * names the exact chat, so it is the session's own and rides every row.
+   * workspace, because the one address Replicas has is the workspace page,
+   * not any chat's own route, whichever app serves it: the desktop app's
+   * handler takes only dashboard paths, and the dashboard has none for a
+   * chat — so inside a tray the manager is named once on the header, the way
+   * Superset's is, and a lone chat keeps the chip because no tray names it.
+   * Conductor's association stays session-scoped on the same reasoning read
+   * the other way: its address names the exact chat, so it is the session's
+   * own and rides every row.
    */
   #applicationsFor(workspace: ReplicasWorkspace): SessionApplication[] {
     return [
@@ -1405,7 +1455,7 @@ export class ReplicasSessionAdapter extends CloudSessionAdapter {
         id: SESSION_APPLICATION_ID.REPLICAS,
         displayName: REPLICAS_PROVIDER_NAME,
         scope: SESSION_APPLICATION_SCOPE.WORKSPACE,
-        link: replicasWorkspaceLink(workspace.id),
+        link: replicasWorkspaceLink(workspace.id, this.#openInDesktopApp),
       },
     ];
   }
@@ -1419,7 +1469,7 @@ export class ReplicasSessionAdapter extends CloudSessionAdapter {
       ...(status === SESSION_STATUS.ERROR
         ? { error: REPLICAS_WORKSPACE_ERROR_MESSAGE }
         : undefined),
-      link: replicasWorkspaceLink(workspace.id),
+      link: replicasWorkspaceLink(workspace.id, this.#openInDesktopApp),
     };
   }
 

--- a/packages/session/src/session.ts
+++ b/packages/session/src/session.ts
@@ -306,6 +306,7 @@ export const SESSION_LINK_SCHEME = {
   CODEX: "codex:",
   CONDUCTOR: "conductor:",
   CURSOR: "cursor:",
+  REPLICAS: "replicas:",
   SUPERSET: "superset:",
 } as const;
 


### PR DESCRIPTION
## Problem

Replicas rows open on the web dashboard even when the user has the Replicas desktop app installed and would rather live there. The adapter also still composes its addresses on `tryreplicas.com`, which now permanently redirects to `replicas.dev`.

## Fix

A Replicas row's address becomes the desktop app's own deep link — `replicas://open?path=/home/workspace/{id}` — whenever the OS reports a handler for the app's scheme, and stays the web dashboard's otherwise. Opening keeps its shape: an address handed to the operating system, reaching no provider.

- The `replicas:` scheme joins `SESSION_LINK_SCHEME`, the one allowlist every session address passes at normalization.
- The adapter takes a `desktopAppPresent` probe, asked once per observation pass so every row of one roster agrees, and asked fresh each pass so installing or removing the app applies on the next one. All three link sites (chat rows, workspace rows, the app chip) flow through it.
- The main process answers the probe with `app.getApplicationNameForProtocol("replicas://open")` — LaunchServices' own answer to the exact question a press will ask it — so the address a row carries and the app that answers its press can never disagree.
- A workspace Luke just created opens the same way for free: its held open uses the address its first observation reports.
- The web fallback and the API-keys settings address move to the canonical `replicas.dev` origin.

No chat lands narrower in either app: verified against the live web app, the workspace page's whole URL state is its view mode and a plan or media selection — which chat is open never reaches the address bar — and the desktop app is a webview of that same app. The adapter's rationale now records this so the workspace-scoped address stays the narrowest honest one.

## Testing

- `./scripts/check.sh` passes (exit 0) after rebasing on origin/main; a new adapter test covers the web→desktop flip across passes and both link sites.
- `./scripts/verify.sh` passes (exit 0). The fixtures carry no Replicas sessions and nothing drawn on the panel changed, so the evidence is unchanged from main; no physical-notch check was performed (no UI geometry touched).
- Verified end-to-end on a Mac with Replicas.app 0.1.15 installed: the composed deep link launched the app and, fired again while running, navigated it to the requested dashboard page — confirmed by screenshot. Its handler (read from the app's own main process) takes the one `path` parameter exactly as composed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32896135857/artifacts/9581401408) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32896135857)

- Commit: `3c5eb24b99d2438e23a8ef28d88a0d015f651da9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
