### PR TITLE
fix(desktop): keep provider marks visible while Luke speaks

### DIFF
--- a/apps/desktop/src/renderer/notch-wings.test.ts
+++ b/apps/desktop/src/renderer/notch-wings.test.ts
@@ -37,6 +37,23 @@ test("a wing too narrow for the arithmetic still shows one mark", () => {
   assert.equal(wingMarkCapacity(0), 1);
 });
 
+test("while Luke speaks the meter reserves its own room beside the face", () => {
+  // Both reservations spend the same 29 + 26 + 14 the plain arithmetic does,
+  // plus a second 26 for the meter now standing beside the face too.
+  assert.equal(wingMarkCapacity(peekSideWidth(210), true), 2);
+  assert.equal(wingMarkCapacity(panelSideWidth(210), true), 6);
+});
+
+test("the meter's reservation never grows the capacity, only shrinks it", () => {
+  for (const sideWidth of [0, 40, peekSideWidth(210), panelSideWidth(210), panelSideWidth(0)]) {
+    assert.ok(wingMarkCapacity(sideWidth, true) <= wingMarkCapacity(sideWidth));
+  }
+});
+
+test("a wing too narrow for the meter's own room still shows one mark", () => {
+  assert.equal(wingMarkCapacity(0, true), 1);
+});
+
 const providers = (...ids: string[]): ProviderTally[] =>
   ids.map((providerId) => ({ providerId, provider: providerId, total: 1, attention: 0 }));
 

--- a/apps/desktop/src/renderer/notch-wings.test.ts
+++ b/apps/desktop/src/renderer/notch-wings.test.ts
@@ -37,7 +37,7 @@ test("a wing too narrow for the arithmetic still shows one mark", () => {
   assert.equal(wingMarkCapacity(0), 1);
 });
 
-test("while Luke speaks the meter reserves its own room beside the face", () => {
+test("while the meter stands beside the face it reserves its own room", () => {
   // Both reservations spend the same 29 + 26 + 14 the plain arithmetic does,
   // plus a second 26 for the meter now standing beside the face too.
   assert.equal(wingMarkCapacity(peekSideWidth(210), true), 2);

--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -83,7 +83,9 @@ interface NotchWingsProps {
  * limit of three comes from: the face and its gap cost 26px of the 95px
  * between the wing's insets, and each mark past the first costs 21px of the
  * 55px that remain. The panel's side is what is left of `--panel-width` after
- * the housing, so it holds roughly twice as many.
+ * the housing, so it holds roughly twice as many. While Luke is speaking the
+ * second argument reserves the same 26px again for the meter standing beside
+ * the face, so the marks give up a slot rather than the meter drawing over one.
  */
 export { wingMarkCapacity } from "@sidecar/panel";
 
@@ -228,6 +230,11 @@ export function NotchWings({
     ...(meterVoice ? { turn: meterVoice } : undefined),
     hasAudioSignal: meterShown,
   });
+  // Luke's own turn is the one stretch that does not cost the marks their
+  // place: the developer's turn already reads as "you are being heard" from
+  // the meter alone, but Luke talking over a strip that just went blank reads
+  // as the sessions vanishing rather than as Luke speaking.
+  const lukeSpeaking = meterShown && meterVoice === WAVEFORM_VOICE.LUKE;
   // The box the hover is read against, not the face itself: the drawing is
   // remounted for every play, and the hover has to survive the trick it fires.
   const faceElement = useRef<HTMLSpanElement>(null);
@@ -254,10 +261,12 @@ export function NotchWings({
   // The wing is bounded by the shape its state draws, so its capacity is too:
   // the panel's side holds more marks than the peek's, and every other state
   // keeps the peek's capacity because that is the set the next peek unfolds.
+  // While Luke is speaking the meter stands beside the face too, so the marks
+  // give up whatever room it costs rather than letting it draw across them.
   const capacity =
     presentation === PANEL_PRESENTATION.PANEL
-      ? wingMarkCapacity((PANEL_WIDTH - housingWidth) / 2)
-      : wingMarkCapacity(peekSideWidth(housingWidth));
+      ? wingMarkCapacity((PANEL_WIDTH - housingWidth) / 2, lukeSpeaking)
+      : wingMarkCapacity(peekSideWidth(housingWidth), lukeSpeaking);
   // Memoized because the roster below notices a new list by identity: the
   // slots may only change when what they summarize does, not on every render
   // a spoken word or a face gesture asks for.
@@ -304,25 +313,12 @@ export function NotchWings({
         {/* Ordered so the element nearest the notch is the one the capsule
             keeps: the rest unfold outward and never displace it. */}
         <div className="wing-inner">
-          {meterShown ? (
-            /* Keyed on whose turn it is, so each voice's meter is a fresh
-               mount: the arrival choreography lives in a starting style, and
-               only a mount reads one. Luke's turn is what grows the capsule,
-               and a meter the developer's turn already had on screen would
-               otherwise relocate beside the returning face on the frame the
-               turn flips — drawn on the desktop, ahead of an edge still most
-               of its travel away. */
-            <span className="wing-meter" data-turn={meterVoice} key={meterVoice}>
-              <Waveform
-                analyser={analyser}
-                speaking={fixtureSpeaking}
-                voice={meterVoice}
-                voiceActive={voiceActive}
-                connecting={voiceOpening && !analyser}
-                onVoiceActivity={reportVoiceActivity}
-              />
-            </span>
-          ) : (
+          {/* Hidden only while the meter has taken this place outright — the
+              developer's own turn, or an audio signal with no turn to read.
+              Luke's turn keeps the marks: the meter stands beside him rather
+              than in their place, so what he is watching stays on screen
+              while he answers it. */}
+          {meterShown && !lukeSpeaking ? null : (
             <span className="wing-marks" ref={marksRef}>
               {drawnSlots.map(({ item, leaving }) => {
                 // How the reorder measurement finds this slot again after a
@@ -369,6 +365,25 @@ export function NotchWings({
                   </button>
                 );
               })}
+            </span>
+          )}
+          {meterShown && (
+            /* Keyed on whose turn it is, so each voice's meter is a fresh
+               mount: the arrival choreography lives in a starting style, and
+               only a mount reads one. Luke's turn is what grows the capsule,
+               and a meter the developer's turn already had on screen would
+               otherwise relocate beside the returning face on the frame the
+               turn flips — drawn on the desktop, ahead of an edge still most
+               of its travel away. */
+            <span className="wing-meter" data-turn={meterVoice} key={meterVoice}>
+              <Waveform
+                analyser={analyser}
+                speaking={fixtureSpeaking}
+                voice={meterVoice}
+                voiceActive={voiceActive}
+                connecting={voiceOpening && !analyser}
+                onVoiceActivity={reportVoiceActivity}
+              />
             </span>
           )}
           {/* Luke himself. He is drawn in every state but one: he steps out of

--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -83,9 +83,10 @@ interface NotchWingsProps {
  * limit of three comes from: the face and its gap cost 26px of the 95px
  * between the wing's insets, and each mark past the first costs 21px of the
  * 55px that remain. The panel's side is what is left of `--panel-width` after
- * the housing, so it holds roughly twice as many. While Luke is speaking the
- * second argument reserves the same 26px again for the meter standing beside
- * the face, so the marks give up a slot rather than the meter drawing over one.
+ * the housing, so it holds roughly twice as many. Whenever the meter stands
+ * beside the face rather than in its place, the second argument reserves the
+ * same 26px again for it, so the marks give up a slot rather than the meter
+ * drawing over one.
  */
 export { wingMarkCapacity } from "@sidecar/panel";
 
@@ -230,11 +231,12 @@ export function NotchWings({
     ...(meterVoice ? { turn: meterVoice } : undefined),
     hasAudioSignal: meterShown,
   });
-  // Luke's own turn is the one stretch that does not cost the marks their
-  // place: the developer's turn already reads as "you are being heard" from
-  // the meter alone, but Luke talking over a strip that just went blank reads
-  // as the sessions vanishing rather than as Luke speaking.
-  const lukeSpeaking = meterShown && meterVoice === WAVEFORM_VOICE.LUKE;
+  // Whether the meter is standing beside the face rather than in its place —
+  // Luke's own turn, and an audio signal with no turn to read at all. Only
+  // then does the wing draw two things nearest the housing instead of one;
+  // the developer's real turn hands the meter the face's own slot, at the
+  // face's own width, so it costs the marks nothing extra.
+  const meterBesideFace = meterShown && !yieldToMeter;
   // The box the hover is read against, not the face itself: the drawing is
   // remounted for every play, and the hover has to survive the trick it fires.
   const faceElement = useRef<HTMLSpanElement>(null);
@@ -261,12 +263,13 @@ export function NotchWings({
   // The wing is bounded by the shape its state draws, so its capacity is too:
   // the panel's side holds more marks than the peek's, and every other state
   // keeps the peek's capacity because that is the set the next peek unfolds.
-  // While Luke is speaking the meter stands beside the face too, so the marks
-  // give up whatever room it costs rather than letting it draw across them.
+  // Whenever the meter stands beside the face rather than in its place, the
+  // marks give up whatever room it costs rather than letting it draw across
+  // them.
   const capacity =
     presentation === PANEL_PRESENTATION.PANEL
-      ? wingMarkCapacity((PANEL_WIDTH - housingWidth) / 2, lukeSpeaking)
-      : wingMarkCapacity(peekSideWidth(housingWidth), lukeSpeaking);
+      ? wingMarkCapacity((PANEL_WIDTH - housingWidth) / 2, meterBesideFace)
+      : wingMarkCapacity(peekSideWidth(housingWidth), meterBesideFace);
   // Memoized because the roster below notices a new list by identity: the
   // slots may only change when what they summarize does, not on every render
   // a spoken word or a face gesture asks for.
@@ -313,60 +316,57 @@ export function NotchWings({
         {/* Ordered so the element nearest the notch is the one the capsule
             keeps: the rest unfold outward and never displace it. */}
         <div className="wing-inner">
-          {/* Hidden only while the meter has taken this place outright — the
-              developer's own turn, or an audio signal with no turn to read.
-              Luke's turn keeps the marks: the meter stands beside him rather
-              than in their place, so what he is watching stays on screen
-              while he answers it. */}
-          {meterShown && !lukeSpeaking ? null : (
-            <span className="wing-marks" ref={marksRef}>
-              {drawnSlots.map(({ item, leaving }) => {
-                // How the reorder measurement finds this slot again after a
-                // re-sort has moved it, and how a slot whose provider left
-                // says so while it fades where the reader last saw it.
-                const motion = {
-                  [WING_SLOT_ID_ATTRIBUTE]: item.id,
-                  [LEAVING_ATTRIBUTE]: String(leaving),
-                };
-                if (!("provider" in item)) {
-                  return (
-                    <span className="wing-more" key={item.id} {...motion} aria-hidden="true">
-                      +{item.unshown}
-                    </span>
-                  );
-                }
-                const filter = isSessionFilter(item.provider.providerId)
-                  ? item.provider.providerId
-                  : undefined;
-                const active =
-                  filter !== undefined && sameSessionFilters(activeFilters ?? [], [filter]);
-                const label = item.provider.provider;
+          {/* What Luke is watching stays on screen through every turn: whoever
+              is speaking, the marks hold their own place at the shape's far
+              edge rather than giving it up to the meter — the capacity above
+              is what keeps the meter from ever drawing across one. */}
+          <span className="wing-marks" ref={marksRef}>
+            {drawnSlots.map(({ item, leaving }) => {
+              // How the reorder measurement finds this slot again after a
+              // re-sort has moved it, and how a slot whose provider left
+              // says so while it fades where the reader last saw it.
+              const motion = {
+                [WING_SLOT_ID_ATTRIBUTE]: item.id,
+                [LEAVING_ATTRIBUTE]: String(leaving),
+              };
+              if (!("provider" in item)) {
                 return (
-                  <button
-                    type="button"
-                    className="wing-mark"
-                    key={item.id}
-                    {...motion}
-                    data-hit-region={HIT_REGION.CAPSULE}
-                    data-active={String(active)}
-                    aria-label={active ? `Clear ${label} filter` : `Filter by ${label}`}
-                    title={active ? `Clear ${label} filter` : `Filter by ${label}`}
-                    disabled={leaving}
-                    tabIndex={leaving ? -1 : 0}
-                    onMouseDown={(event) => event.preventDefault()}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      if (filter !== undefined) {
-                        onSelectFilter?.(filter);
-                      }
-                    }}
-                  >
-                    <ProviderMark providerId={item.provider.providerId} />
-                  </button>
+                  <span className="wing-more" key={item.id} {...motion} aria-hidden="true">
+                    +{item.unshown}
+                  </span>
                 );
-              })}
-            </span>
-          )}
+              }
+              const filter = isSessionFilter(item.provider.providerId)
+                ? item.provider.providerId
+                : undefined;
+              const active =
+                filter !== undefined && sameSessionFilters(activeFilters ?? [], [filter]);
+              const label = item.provider.provider;
+              return (
+                <button
+                  type="button"
+                  className="wing-mark"
+                  key={item.id}
+                  {...motion}
+                  data-hit-region={HIT_REGION.CAPSULE}
+                  data-active={String(active)}
+                  aria-label={active ? `Clear ${label} filter` : `Filter by ${label}`}
+                  title={active ? `Clear ${label} filter` : `Filter by ${label}`}
+                  disabled={leaving}
+                  tabIndex={leaving ? -1 : 0}
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    if (filter !== undefined) {
+                      onSelectFilter?.(filter);
+                    }
+                  }}
+                >
+                  <ProviderMark providerId={item.provider.providerId} />
+                </button>
+              );
+            })}
+          </span>
           {meterShown && (
             /* Keyed on whose turn it is, so each voice's meter is a fresh
                mount: the arrival choreography lives in a starting style, and

--- a/packages/panel/src/layout.ts
+++ b/packages/panel/src/layout.ts
@@ -2,10 +2,20 @@ const WING_INSETS = 29;
 const FACE_AND_GAP = 26;
 const MARK_WIDTH = 14;
 const MARK_AND_GAP = 21;
+/** The meter is as wide as the face it stands beside, so it costs the same. */
+const METER_AND_GAP = 26;
 
-export function wingMarkCapacity(sideWidth: number): number {
+/**
+ * How many marks fit beside the face, in a wing where the meter is also
+ * standing beside it — Luke's own turn, which is the one stretch the meter
+ * does not take the marks' place. Reserving its width here rather than
+ * hiding marks to make room is what keeps the strip from ever drawing the
+ * meter across a mark it already committed to.
+ */
+export function wingMarkCapacity(sideWidth: number, meterBesideFace = false): number {
   const beyondFirst = Math.floor(
-    (sideWidth - WING_INSETS - FACE_AND_GAP - MARK_WIDTH) / MARK_AND_GAP,
+    (sideWidth - WING_INSETS - FACE_AND_GAP - (meterBesideFace ? METER_AND_GAP : 0) - MARK_WIDTH) /
+      MARK_AND_GAP,
   );
   return Math.max(1, 1 + beyondFirst);
 }

--- a/packages/panel/src/layout.ts
+++ b/packages/panel/src/layout.ts
@@ -7,10 +7,12 @@ const METER_AND_GAP = 26;
 
 /**
  * How many marks fit beside the face, in a wing where the meter is also
- * standing beside it — Luke's own turn, which is the one stretch the meter
- * does not take the marks' place. Reserving its width here rather than
- * hiding marks to make room is what keeps the strip from ever drawing the
- * meter across a mark it already committed to.
+ * standing beside it rather than taking its place — Luke's own turn, or an
+ * audio signal with no turn to read at all. The developer's own live turn
+ * hands the meter the face's own slot instead, at the face's own width, so
+ * it costs the marks nothing extra. Reserving the meter's width here rather
+ * than hiding marks to make room is what keeps the strip from ever drawing
+ * the meter across a mark it already committed to.
  */
 export function wingMarkCapacity(sideWidth: number, meterBesideFace = false): number {
   const beyondFirst = Math.floor(


### PR DESCRIPTION
## Summary

- Provider icons in the top-left wing used to be fully replaced by the speaking meter, so while Luke was talking — or while the developer held the turn with an open mic — the strip showed only the meter (and, for Luke's turn, his face); the icons vanished until the meter went away.
- The marks now stay mounted and visible through every speaking state: Luke's turn, the developer's turn, and an open microphone with no call behind it.
- `wingMarkCapacity` takes a new optional argument (`meterBesideFace`) that reserves the meter's own width (26px, the same as the face) whenever the meter is drawn *beside* the face rather than *in place of* it — Luke's turn, or an audio signal with no turn to read. The developer's real live turn hands the meter the face's own slot at the same width, so it costs the marks nothing extra there. Either way, the wing narrows the mark count (spilling extras into the existing "+N" overflow slot) rather than ever drawing the meter across a mark.

## Test plan

- [x] `./scripts/check.sh` — lint, typecheck, unit tests, build all pass
- [x] `./scripts/verify.sh` — packages the app and captures fixture evidence; all evidence PNGs validate
- [x] Added unit tests in `notch-wings.test.ts` covering the new capacity reservation (exact peek/panel numbers, monotonicity, and the narrow-wing floor)
- [x] Visually verified via the fixture's own "speaking" and "muted" evidence profiles (open-mic state, no live call): the provider mark and "+4" overflow badge now render beside the meter and face with no overlap, where before that space was empty
- [x] Also manually spot-checked Luke's own turn (temporarily forced the fixture to report `voice: "luke"`, rebuilt, confirmed the same non-overlapping layout, then reverted the diagnostic change before committing — not part of this PR's diff)
- [ ] Physical-notch check not performed (no physical Mac with a display notch available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32908618436/artifacts/9585787589) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32908618436)

- Commit: `892c4a08cba42c3d07b8d68e69b28a73cc0756ff`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
