### PR TITLE
v0.3.11 chore: prepare Luke release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
           MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
           MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
           GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET }}
+          POSTHOG_PROJECT_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
         run: |
           for secret_name in \
             MACOS_CERTIFICATE_P12_BASE64 \
@@ -66,7 +67,8 @@ jobs:
             APPLE_API_KEY_P8_BASE64 \
             APPLE_API_KEY_ID \
             APPLE_API_ISSUER_ID \
-            GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET; do
+            GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET \
+            POSTHOG_PROJECT_API_KEY; do
             if [[ -z "${!secret_name:-}" ]]; then
               echo "error: required GitHub Actions secret is missing: $secret_name" >&2
               exit 1
@@ -117,6 +119,7 @@ jobs:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
           GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET }}
+          POSTHOG_PROJECT_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
         run: |
           key_directory=$(mktemp -d "$RUNNER_TEMP/luke-notary.XXXXXX")
           trap 'rm -rf "$key_directory"' EXIT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,35 @@
 Notable changes to Luke, newest first. Each heading is a released version and
 the date its release was published.
 
+## 0.3.11 — 2026-08-25
+
+### Improvements
+
+- Luke opens Replicas sessions directly in the Replicas desktop app
+  ([#516](https://github.com/ReviewStage/luke/pull/516))
+- Luke keeps agent updates concise, specific to the work, and available after
+  meeting quiet ends
+  ([#514](https://github.com/ReviewStage/luke/pull/514),
+  [#515](https://github.com/ReviewStage/luke/pull/515))
+- The admin dashboard makes account status, usage, and controls easier to scan
+  ([#511](https://github.com/ReviewStage/luke/pull/511))
+
+### Fixes
+
+- Fixed first-launch announcements waiting for an interaction before they
+  could be heard ([#477](https://github.com/ReviewStage/luke/pull/477))
+- Fixed signed-in users who finished onboarding being offered the introduction
+  again ([#512](https://github.com/ReviewStage/luke/pull/512))
+- Fixed swallowed admin API failures omitting the upstream 503 cause from logs
+  ([#492](https://github.com/ReviewStage/luke/pull/492))
+- Fixed hosted macOS releases omitting the PostHog project key and silently
+  disabling recording
+
+### Miscellaneous
+
+- Updated the 0.3.10 onboarding notes with its release screenshot
+  ([#510](https://github.com/ReviewStage/luke/pull/510))
+
 ## 0.3.10 — 2026-08-24
 
 ### Onboarding

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@luke/desktop",
   "productName": "Luke",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "description": "Luke desktop application",
   "main": "dist/main.js",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luke/web",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "description": "Luke landing page",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luke",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "description": "A notch-attached desktop sidecar for coding-agent sessions",
   "packageManager": "pnpm@10.34.5",

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/account",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/acts/package.json
+++ b/packages/acts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/acts",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/analytics",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/attention/package.json
+++ b/packages/attention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/attention",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/calendar",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/credentials",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/feedback",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/fixtures/package.json
+++ b/packages/fixtures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/fixtures",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/guide/package.json
+++ b/packages/guide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/guide",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/hosted/package.json
+++ b/packages/hosted/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/hosted",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/issues/package.json
+++ b/packages/issues/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/issues",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/panel/package.json
+++ b/packages/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/panel",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/process",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/providers",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/realtime",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/session",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/settings",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/superset/package.json
+++ b/packages/superset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/superset",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/surface/package.json
+++ b/packages/surface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/surface",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/trackers/package.json
+++ b/packages/trackers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/trackers",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/voice",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/wire/package.json
+++ b/packages/wire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidecar/wire",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/packaging.test.mjs
+++ b/scripts/packaging.test.mjs
@@ -50,7 +50,7 @@ function builderConfig(env = {}) {
   return createElectronBuilderConfig(env);
 }
 
-test("workspace package versions agree on v0.3.10", () => {
+test("workspace package versions agree on v0.3.11", () => {
   // Enumerated rather than listed, so a package added to the workspace is held
   // to the release version without anyone remembering to name it here.
   const packagePaths = [
@@ -74,7 +74,7 @@ test("workspace package versions agree on v0.3.10", () => {
 
   assert.deepEqual(
     versions.map(({ version }) => version),
-    packagePaths.map(() => "0.3.10"),
+    packagePaths.map(() => "0.3.11"),
   );
 });
 

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -121,10 +121,20 @@ test("hosted releases require and package every desktop integration credential",
     path.join(repoRoot, ".github", "workflows", "release.yml"),
     "utf8",
   );
+  const credentialCheck = workflow.slice(
+    workflow.indexOf("- name: Check release secrets"),
+    workflow.indexOf("- name: Resolve release version"),
+  );
+  const releaseBuild = workflow.slice(
+    workflow.indexOf("- name: Build signed, notarized release artifacts"),
+    workflow.indexOf("- name: Verify signed application"),
+  );
 
   for (const credential of ["GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET", "POSTHOG_PROJECT_API_KEY"]) {
-    assert.match(workflow, new RegExp(`${credential}: \\\${{ secrets\\.${credential} }}`));
-    const trimmedLines = workflow.split("\n").map((line) => line.trim());
+    const secretMapping = new RegExp(`${credential}: \\\${{ secrets\\.${credential} }}`);
+    assert.match(credentialCheck, secretMapping);
+    assert.match(releaseBuild, secretMapping);
+    const trimmedLines = credentialCheck.split("\n").map((line) => line.trim());
     assert.ok(
       trimmedLines.includes(`${credential}; do`) || trimmedLines.includes(`${credential} \\`),
     );

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -116,6 +116,21 @@ test("the update manifest asset name stays fixed while electron-builder writes i
   assert.ok(workflow.includes("if (!/size: \\d+/.test(manifest))"));
 });
 
+test("hosted releases require and package every desktop integration credential", () => {
+  const workflow = fs.readFileSync(
+    path.join(repoRoot, ".github", "workflows", "release.yml"),
+    "utf8",
+  );
+
+  for (const credential of ["GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET", "POSTHOG_PROJECT_API_KEY"]) {
+    assert.match(workflow, new RegExp(`${credential}: \\\${{ secrets\\.${credential} }}`));
+    const trimmedLines = workflow.split("\n").map((line) => line.trim());
+    assert.ok(
+      trimmedLines.includes(`${credential}; do`) || trimmedLines.includes(`${credential} \\`),
+    );
+  }
+});
+
 test("notary credentials come from the keychain profile unless a key file is provided whole", () => {
   assert.deepEqual(resolveNotaryCredentials({}), {
     source: NOTARY_CREDENTIAL_SOURCE.KEYCHAIN_PROFILE,


### PR DESCRIPTION
## Summary

- Bump all workspace packages to 0.3.11 and add release notes for changes since 0.3.10
- Require and package the PostHog project key in hosted macOS releases
- Add a regression test covering every desktop integration credential used by the release workflow

## Verification

- `./scripts/bootstrap.sh`
- `./scripts/check.sh`
- Release and packaging tests: 37 passed
- Public-repository credential scan: no findings
- Pre-landing review: no issues found

## Release plan

After merge, tag the merge commit as `v0.3.11`; the hosted workflow will sign, notarize, staple, validate, and publish the six required GitHub Release assets.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32898825442/artifacts/9582328601) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32898825442)

- Commit: `35c6bfec117240ad83bd673ba08486baec693d4b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
