### PR TITLE
feat(voice): change the default voice from cedar to echo

### DIFF
--- a/packages/realtime/src/realtime-voice-settings.ts
+++ b/packages/realtime/src/realtime-voice-settings.ts
@@ -58,7 +58,7 @@ export function isRealtimeVoiceSpeed(value: UnparsedWireValue): value is Realtim
 
 export const REALTIME_DEFAULTS = {
   MODEL: "gpt-realtime-2.1",
-  VOICE: REALTIME_VOICE.ASH,
+  VOICE: REALTIME_VOICE.ECHO,
   SPEED: REALTIME_VOICE_SPEED.NORMAL,
   /**
    * What transcribes the developer's spoken turns, so their own words can

--- a/packages/realtime/src/realtime-voice-settings.ts
+++ b/packages/realtime/src/realtime-voice-settings.ts
@@ -58,7 +58,7 @@ export function isRealtimeVoiceSpeed(value: UnparsedWireValue): value is Realtim
 
 export const REALTIME_DEFAULTS = {
   MODEL: "gpt-realtime-2.1",
-  VOICE: REALTIME_VOICE.CEDAR,
+  VOICE: REALTIME_VOICE.ASH,
   SPEED: REALTIME_VOICE_SPEED.NORMAL,
   /**
    * What transcribes the developer's spoken turns, so their own words can

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -328,8 +328,8 @@ test("a mint response without a session model falls back to the requested model"
 });
 
 test("a male voice is what the session is minted with", () => {
-  assert.equal(REALTIME_DEFAULTS.VOICE, "ash");
-  assert.equal(realtimeSessionConfig().audio.output.voice, "ash");
+  assert.equal(REALTIME_DEFAULTS.VOICE, "echo");
+  assert.equal(realtimeSessionConfig().audio.output.voice, "echo");
 });
 
 test("the default voice is one the settings can offer", () => {

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -328,8 +328,8 @@ test("a mint response without a session model falls back to the requested model"
 });
 
 test("a male voice is what the session is minted with", () => {
-  assert.equal(REALTIME_DEFAULTS.VOICE, "cedar");
-  assert.equal(realtimeSessionConfig().audio.output.voice, "cedar");
+  assert.equal(REALTIME_DEFAULTS.VOICE, "ash");
+  assert.equal(realtimeSessionConfig().audio.output.voice, "ash");
 });
 
 test("the default voice is one the settings can offer", () => {


### PR DESCRIPTION
## What

Changes Luke's default Realtime voice from `cedar` to `echo`, another of the API's masculine voices.

## How

Every consumer — the desktop settings store, the settings row's "(default)" label, the guide's stated default, the local key mint, the hosted mints, and the introduction — reads the default through `REALTIME_DEFAULTS.VOICE`, so the change is the constant in `packages/realtime/src/realtime-voice-settings.ts` plus the test that pins its literal. A developer who already picked a voice by hand keeps it; only the unset default moves.

## Verification

`./scripts/check.sh` passes (exit 0), including `a male voice is what the session is minted with` in `packages/realtime`. Portable-only change — no UI drawing moved, so no visual evidence run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32906902127/artifacts/9585208247) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32906902127)

- Commit: `d45cb3510e9ff3525e63db5e165e69a402de2aa0`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
