### PR TITLE
fix(release): publish releases only after assets finish uploading

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,7 +198,9 @@ jobs:
       # resolving the previous release's self-consistent manifest instead of
       # a new manifest whose archive is incomplete. gh resolves a draft by
       # its pending tag, so a re-run's view and upload find it the same way
-      # they find a published release, and re-publishing one is a no-op.
+      # they find a published release, and the flip runs only while the
+      # release is still a draft, so re-running an old tag's workflow can
+      # never re-mark a superseded release Latest.
       - name: Publish GitHub Release
         if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
         env:
@@ -220,7 +222,9 @@ jobs:
             "$DIST_DIR/$LATEST_DMG_ASSET_NAME" \
             "$DIST_DIR/$UPDATE_FEED_ASSET_NAME" \
             --clobber
-          gh release edit "$TAG" --draft=false --latest
+          if [[ "$(gh release view "$TAG" --json isDraft --jq .isDraft)" == "true" ]]; then
+            gh release edit "$TAG" --draft=false --latest
+          fi
 
       - name: Preserve rehearsal artifacts
         if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,6 +192,13 @@ jobs:
           if (!/size: \d+/.test(manifest)) throw new Error("latest-mac.yml is missing size");
           NODE
 
+      # The release stays a draft until every asset has finished uploading,
+      # so nothing points releases/latest at the new version while its
+      # archive is still in flight: an updater that checks mid-upload keeps
+      # resolving the previous release's self-consistent manifest instead of
+      # a new manifest whose archive is incomplete. gh resolves a draft by
+      # its pending tag, so a re-run's view and upload find it the same way
+      # they find a published release, and re-publishing one is a no-op.
       - name: Publish GitHub Release
         if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
         env:
@@ -200,6 +207,7 @@ jobs:
           TAG="$GITHUB_REF_NAME"
           if ! gh release view "$TAG" >/dev/null 2>&1; then
             gh release create "$TAG" \
+              --draft \
               --verify-tag \
               --title "Luke $VERSION" \
               --generate-notes
@@ -212,6 +220,7 @@ jobs:
             "$DIST_DIR/$LATEST_DMG_ASSET_NAME" \
             "$DIST_DIR/$UPDATE_FEED_ASSET_NAME" \
             --clobber
+          gh release edit "$TAG" --draft=false --latest
 
       - name: Preserve rehearsal artifacts
         if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/scripts/release/publish-github.sh
+++ b/scripts/release/publish-github.sh
@@ -80,7 +80,9 @@ gh release upload "$TAG" \
     "$staging_directory/$ZIP_ASSET_NAME.sha256" \
     "$staging_directory/$UPDATE_FEED_ASSET_NAME" \
     --clobber
-gh release edit "$TAG" --draft=false --latest
+if [[ "$(gh release view "$TAG" --json isDraft --jq .isDraft)" == "true" ]]; then
+    gh release edit "$TAG" --draft=false --latest
+fi
 
 printf 'Published %s. The website reaches this build at:\n' "$TAG"
 printf '  https://github.com/ReviewStage/luke/releases/latest/download/%s\n' "$LATEST_DMG_ASSET_NAME"

--- a/scripts/release/publish-github.sh
+++ b/scripts/release/publish-github.sh
@@ -6,8 +6,10 @@ set -euo pipefail
 # release cannot break either: the version-free Luke.dmg is what the website's
 # download link reaches through releases/latest, and the version-free
 # latest-mac.yml is the electron-updater manifest the app updates from — so
-# the release must be a published, non-draft, non-prerelease one whose tag
-# matches the desktop version exactly.
+# the release must end up a published, non-draft, non-prerelease one whose
+# tag matches the desktop version exactly, and it stays a draft until every
+# asset has finished uploading, because a release published mid-upload points
+# releases/latest at a manifest whose archive is still incomplete.
 
 SCRIPT_DIRECTORY=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIRECTORY/../.." && pwd)
@@ -65,6 +67,7 @@ cp "$ZIP_PATH.sha256" "$staging_directory/$ZIP_ASSET_NAME.sha256"
 
 if ! gh release view "$TAG" > /dev/null 2>&1; then
     gh release create "$TAG" \
+        --draft \
         --verify-tag \
         --title "Luke $VERSION" \
         --generate-notes
@@ -77,6 +80,7 @@ gh release upload "$TAG" \
     "$staging_directory/$ZIP_ASSET_NAME.sha256" \
     "$staging_directory/$UPDATE_FEED_ASSET_NAME" \
     --clobber
+gh release edit "$TAG" --draft=false --latest
 
 printf 'Published %s. The website reaches this build at:\n' "$TAG"
 printf '  https://github.com/ReviewStage/luke/releases/latest/download/%s\n' "$LATEST_DMG_ASSET_NAME"


### PR DESCRIPTION
## The race

The Publish GitHub Release step ran `gh release create` (published immediately) and then uploaded ~236 MB of assets with `gh release upload --clobber`. For v0.3.11 that opened a ~2-minute window — `latest-mac.yml` finished uploading at 21:18:53 UTC, the 116 MB zip not until 21:21:01 — where `releases/latest/download/latest-mac.yml` advertised 0.3.11 while the zip behind it was incomplete/404. electron-updater clients that checked in that window failed with "The update could not be installed."

## The fix

Create the release with `--draft`, upload every asset exactly as before, then flip it live with `gh release edit "$TAG" --draft=false --latest`. A draft is invisible to `releases/latest`, so until the flip, updaters keep resolving the previous release's self-consistent manifest: nothing points `releases/latest` at the new version until every asset is complete.

Verified against gh's own source and manual:

- `gh release view` and `gh release upload` resolve a draft by its pending tag name (`FetchRelease` runs a GraphQL draft lookup alongside the `releases/tags/:tag` REST call), so the existing idempotency guard and the uploads address the draft exactly as they addressed a published release, and `--verify-tag` guarantees the tag exists.
- `gh release edit <tag> --draft=false` is the documented way to publish a draft, and `--latest` marks it Latest explicitly. Both flags shipped in gh 2.21 (2022); the macos-15 runner's preinstalled gh is far newer.
- A re-run after a successful publish stays safe: create is skipped, upload re-clobbers, and the flip runs only while the release is still a draft, so re-running an old tag's workflow after a newer release exists can never re-mark the superseded release Latest (Bugbot's catch — `--latest` sends `make_latest` unconditionally).

The manual fallback `scripts/release/publish-github.sh` had the identical create-then-upload race, so it gets the identical fix, and its header comment now states the drafted-until-uploaded invariant.

This is a workflow/script-only change with no UI, so `./scripts/verify.sh` is not required.

## check.sh

`./scripts/check.sh` passed (exit 0) under Node 24: design contract checks passed, repository contract checks passed, and lint, typecheck, test, and build all green. (A first run hit the known local flake — bare `test failed` in the apple-calendar, media-duck, screen-geometry, and talk-key native tests under parallel load on this machine — and the re-run passed clean.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32907318412/artifacts/9585337788) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32907318412)

- Commit: `072e1755e38701609db46f9094a509968000c2ed`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
