### PR TITLE
fix(desktop): retry updates whose release is still publishing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -406,7 +406,12 @@ Trust constraints:
   lands on the same main-process guards the button's own press does, so it
   reaches nothing the button does not — the check, the restart, or the fixed
   releases page in the browser. A transient network failure is silence for
-  the next timed check; any other failure is an answer on the row whose way forward
+  the next timed check; a download refused just after its check found the
+  version is a release still publishing, and the same check is retried at a
+  few fixed delays against the same fixed feed — nothing new sent or read,
+  only the cadence — with the row saying the wait honestly, before the
+  schedule ends in the same error row a corrupt release deserves; any other
+  failure is an answer on the row whose way forward
   is the browser, at the releases page fixed by the build, the same page
   that serves a build which cannot install in place at all. Widening what
   the updater sends, reads, or does is a product decision, not an

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -409,7 +409,8 @@ Trust constraints:
   the next timed check; a download refused just after its check found the
   version is a release still publishing, and the same check is retried at a
   few fixed delays against the same fixed feed — nothing new sent or read,
-  only the cadence — with the row saying the wait honestly, before the
+  only the cadence, and a network failure mid-wait spends the same bounded
+  budget rather than orphaning it — with the row saying the wait honestly, before the
   schedule ends in the same error row a corrupt release deserves; any other
   failure is an answer on the row whose way forward
   is the browser, at the releases page fixed by the build, the same page

--- a/apps/desktop/src/main/update-service.test.ts
+++ b/apps/desktop/src/main/update-service.test.ts
@@ -244,15 +244,38 @@ test("a network blip mid-wait resumes the bounded schedule instead of orphaning 
   updates.stop();
 });
 
+test("electron-updater's doubled failure delivery spends one slot, not two", async () => {
+  const { fire, engine, rejectNextCheckWith } = fakeEngine();
+  const updates = service({ engine, publishingRetryDelaysMs: [10, 60_000] });
+
+  fire().onAvailable("0.2.0");
+  fire().onError('Cannot download "https://github.com/x", status 404: Not Found');
+  rejectNextCheckWith("net::ERR_CONNECTION_RESET");
+  await sleep(30);
+  assert.equal(updates.snapshot().status, UPDATE_STATUS.PUBLISHING);
+
+  // A failed check arrives as the `error` event and the rejected promise
+  // both. The budget above has exactly one slot left, so a second delivery
+  // that spent it would fall out of the wait — it must find the wait drawn
+  // and leave the budget alone.
+  fire().onError("net::ERR_CONNECTION_RESET");
+  assert.equal(updates.snapshot().status, UPDATE_STATUS.PUBLISHING);
+  updates.stop();
+});
+
 test("a wait that outlives the budget offline falls silent like any network failure", async () => {
-  const { fire, engine } = fakeEngine();
-  const updates = service({ engine, publishingRetryDelaysMs: [60_000] });
+  const { fire, engine, rejectNextCheckWith } = fakeEngine();
+  const updates = service({ engine, publishingRetryDelaysMs: [10] });
 
   fire().onAvailable("0.2.0");
   fire().onError("sha512 checksum mismatch, expected aaa, got bbb");
   assert.equal(updates.snapshot().status, UPDATE_STATUS.PUBLISHING);
 
-  fire().onError("net::ERR_INTERNET_DISCONNECTED");
+  // The one slot is spent, so the retry dying on the network has no budget
+  // left to resume with and the wait ends in the network failure's own
+  // answer: unmarked idle, never the error row.
+  rejectNextCheckWith("net::ERR_INTERNET_DISCONNECTED");
+  await sleep(30);
   assert.deepEqual(updates.snapshot(), {
     status: UPDATE_STATUS.IDLE,
     currentVersion: "0.1.0",

--- a/apps/desktop/src/main/update-service.test.ts
+++ b/apps/desktop/src/main/update-service.test.ts
@@ -137,7 +137,7 @@ test("a network failure is silence for the next timed check; anything else is th
   // A real failure lands on the error row, still naming the newer build, and
   // drops the cached download a corrupt archive would otherwise pin forever.
   fire().onAvailable("0.2.0");
-  fire().onError("sha512 checksum mismatch");
+  fire().onError("code signature validation failed");
   assert.deepEqual(updates.snapshot(), {
     status: UPDATE_STATUS.ERROR,
     currentVersion: "0.1.0",
@@ -151,6 +151,84 @@ test("a network failure is silence for the next timed check; anything else is th
   assert.equal((await updates.check()).status, UPDATE_STATUS.IDLE);
   rejectNextCheckWith("cannot parse update info");
   assert.equal((await updates.check()).status, UPDATE_STATUS.ERROR);
+});
+
+test("a download refused right after its check retries as a release still publishing", async () => {
+  const { calls, fire, engine } = fakeEngine();
+  const updates = service({ engine, publishingRetryDelaysMs: [10] });
+
+  fire().onAvailable("0.2.0");
+  fire().onError('Cannot download "https://github.com/x", status 404: Not Found');
+  assert.deepEqual(updates.snapshot(), {
+    status: UPDATE_STATUS.PUBLISHING,
+    currentVersion: "0.1.0",
+    installSupported: true,
+    latestVersion: "0.2.0",
+  });
+  // The partial archive is dropped before the retry, like the error path.
+  assert.equal(calls.cacheClears, 1);
+
+  // The scheduled retry is the same check; a completed upload proceeds
+  // through the ordinary download into the restart offer.
+  await sleep(30);
+  assert.equal(calls.checks, 1);
+  fire().onAvailable("0.2.0");
+  fire().onDownloaded("0.2.0");
+  assert.equal(updates.snapshot().status, UPDATE_STATUS.READY);
+  updates.stop();
+});
+
+test("a user press mid-wait collapses the pending retry rather than stacking one", async () => {
+  const { calls, fire, engine } = fakeEngine();
+  const updates = service({ engine, publishingRetryDelaysMs: [20] });
+
+  fire().onAvailable("0.2.0");
+  fire().onError("sha512 checksum mismatch, expected aaa, got bbb");
+  assert.equal(updates.snapshot().status, UPDATE_STATUS.PUBLISHING);
+
+  await updates.check();
+  await sleep(50);
+  assert.equal(calls.checks, 1, "the press replaced the scheduled retry, never joined it");
+  updates.stop();
+});
+
+test("the exhausted retry schedule falls to the error row a corrupt release deserves", async () => {
+  const { calls, fire, engine } = fakeEngine();
+  const updates = service({ engine, publishingRetryDelaysMs: [60_000, 60_000] });
+
+  const stillPublishing = 'Cannot download "https://github.com/x", status 404: Not Found';
+  fire().onAvailable("0.2.0");
+  fire().onError(stillPublishing);
+  fire().onAvailable("0.2.0");
+  fire().onError(stillPublishing);
+  assert.equal(updates.snapshot().status, UPDATE_STATUS.PUBLISHING);
+
+  fire().onAvailable("0.2.0");
+  fire().onError(stillPublishing);
+  assert.deepEqual(updates.snapshot(), {
+    status: UPDATE_STATUS.ERROR,
+    currentVersion: "0.1.0",
+    installSupported: true,
+    latestVersion: "0.2.0",
+  });
+  assert.equal(calls.cacheClears, 3);
+
+  // A later release is its own publishing window, not the spent one's.
+  fire().onAvailable("0.2.1");
+  fire().onError(stillPublishing);
+  assert.equal(updates.snapshot().status, UPDATE_STATUS.PUBLISHING);
+  updates.stop();
+});
+
+test("stopping the service clears a pending publishing retry", async () => {
+  const { calls, fire, engine } = fakeEngine();
+  const updates = service({ engine, publishingRetryDelaysMs: [10] });
+
+  fire().onAvailable("0.2.0");
+  fire().onError('Cannot download "https://github.com/x", status 404: Not Found');
+  updates.stop();
+  await sleep(30);
+  assert.equal(calls.checks, 0);
 });
 
 test("an error mid-install releases the guard so the next ready build can install", async () => {

--- a/apps/desktop/src/main/update-service.test.ts
+++ b/apps/desktop/src/main/update-service.test.ts
@@ -220,6 +220,48 @@ test("the exhausted retry schedule falls to the error row a corrupt release dese
   updates.stop();
 });
 
+test("a network blip mid-wait resumes the bounded schedule instead of orphaning it", async () => {
+  const { calls, fire, engine } = fakeEngine();
+  const updates = service({ engine, publishingRetryDelaysMs: [10, 10, 60_000] });
+
+  fire().onAvailable("0.2.0");
+  fire().onError('Cannot download "https://github.com/x", status 404: Not Found');
+  await sleep(30);
+  assert.equal(calls.checks, 1, "the first retry ran");
+
+  // The retry's own check dying on the network keeps the wait standing, on
+  // the next slot of the same budget, rather than falling to idle silence
+  // that would leave the found version to the four-hour timer.
+  fire().onError("net::ERR_INTERNET_DISCONNECTED");
+  assert.deepEqual(updates.snapshot(), {
+    status: UPDATE_STATUS.PUBLISHING,
+    currentVersion: "0.1.0",
+    installSupported: true,
+    latestVersion: "0.2.0",
+  });
+  await sleep(30);
+  assert.equal(calls.checks, 2, "the resumed retry ran");
+  updates.stop();
+});
+
+test("a wait that outlives the budget offline falls silent like any network failure", async () => {
+  const { fire, engine } = fakeEngine();
+  const updates = service({ engine, publishingRetryDelaysMs: [60_000] });
+
+  fire().onAvailable("0.2.0");
+  fire().onError("sha512 checksum mismatch, expected aaa, got bbb");
+  assert.equal(updates.snapshot().status, UPDATE_STATUS.PUBLISHING);
+
+  fire().onError("net::ERR_INTERNET_DISCONNECTED");
+  assert.deepEqual(updates.snapshot(), {
+    status: UPDATE_STATUS.IDLE,
+    currentVersion: "0.1.0",
+    installSupported: true,
+    upToDate: false,
+  });
+  updates.stop();
+});
+
 test("stopping the service clears a pending publishing retry", async () => {
   const { calls, fire, engine } = fakeEngine();
   const updates = service({ engine, publishingRetryDelaysMs: [10] });

--- a/apps/desktop/src/main/update-service.ts
+++ b/apps/desktop/src/main/update-service.ts
@@ -165,6 +165,13 @@ export class UpdateService {
   #publishingRetry: NodeJS.Timeout | undefined;
   #publishingVersion: string | undefined;
   #publishingRetriesUsed = 0;
+  /**
+   * The version a live publishing wait is about, or undefined outside one.
+   * Distinct from `#publishingVersion`, which keys the spent budget and must
+   * outlive the wait: an exhausted version stays exhausted, so a later check
+   * that finds it still failing lands on the error row, not a fresh schedule.
+   */
+  #publishingWait: string | undefined;
 
   constructor(options: UpdateServiceOptions) {
     this.#currentVersion = options.currentVersion;
@@ -184,13 +191,17 @@ export class UpdateService {
         this.#latestVersion = version;
         this.#move({ ...this.#base(UPDATE_STATUS.DOWNLOADING), latestVersion: version });
       },
-      onNotAvailable: () => this.#move(this.#idle(true)),
+      onNotAvailable: () => {
+        this.#publishingWait = undefined;
+        this.#move(this.#idle(true));
+      },
       onProgress: (progress) => {
         if (this.#snapshot.status !== UPDATE_STATUS.DOWNLOADING) return;
         this.#move({ ...this.#snapshot, progress });
       },
       onDownloaded: (version) => {
         this.#latestVersion = version;
+        this.#publishingWait = undefined;
         this.#move({ ...this.#base(UPDATE_STATUS.READY), latestVersion: version });
       },
       onError: (message) => {
@@ -198,11 +209,13 @@ export class UpdateService {
         // install guard, or the row's restart press dies with the attempt.
         this.#installing = false;
         if (isNetworkErrorMessage(message)) {
+          if (this.#resumePublishingWait(message)) return;
           this.#report(`Update check could not reach the feed: ${message}`);
           this.#move(this.#idle(false));
           return;
         }
         if (this.#retryWhilePublishing(message)) return;
+        this.#publishingWait = undefined;
         this.#report(`Update failed: ${message}`);
         void this.#engine?.clearCachedUpdate().catch(() => undefined);
         this.#move({ ...this.#base(UPDATE_STATUS.ERROR), latestVersion: this.#latestVersion });
@@ -247,9 +260,12 @@ export class UpdateService {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       if (isNetworkErrorMessage(message)) {
-        this.#report(`Update check could not reach the feed: ${message}`);
-        this.#move(this.#idle(false));
+        if (!this.#resumePublishingWait(message)) {
+          this.#report(`Update check could not reach the feed: ${message}`);
+          this.#move(this.#idle(false));
+        }
       } else {
+        this.#publishingWait = undefined;
         this.#report(`Update check failed: ${message}`);
         this.#move({ ...this.#base(UPDATE_STATUS.ERROR), latestVersion: this.#latestVersion });
       }
@@ -304,17 +320,13 @@ export class UpdateService {
   }
 
   /**
-   * A download that 404s or fails its sha512 right after a check found the
-   * version is a release still publishing: the manifest went live before its
-   * archive finished uploading. The same check is retried on the bounded
-   * schedule, keyed to the version so a later release starts fresh; a
-   * version that outlives the schedule falls to the error row it always
-   * was, because a genuinely corrupt release fails the same way.
+   * Spends the next slot of the version's retry budget and arms the timer.
+   * The budget is keyed to the version so a later release starts fresh, and
+   * it survives the wait itself: an exhausted version stays exhausted, so a
+   * later check that finds it still failing lands on the error row rather
+   * than a fresh schedule.
    */
-  #retryWhilePublishing(message: string): boolean {
-    if (this.#snapshot.status !== UPDATE_STATUS.DOWNLOADING) return false;
-    if (!isPublishingWindowErrorMessage(message)) return false;
-    const version = this.#snapshot.latestVersion;
+  #armPublishingRetry(version: string): boolean {
     if (version !== this.#publishingVersion) {
       this.#publishingVersion = version;
       this.#publishingRetriesUsed = 0;
@@ -322,12 +334,51 @@ export class UpdateService {
     const delayMs = this.#publishingRetryDelaysMs[this.#publishingRetriesUsed];
     if (delayMs === undefined) return false;
     this.#publishingRetriesUsed += 1;
-    this.#report(`Release ${version} is still publishing, retrying: ${message}`);
-    // The partial archive must not stand, or the retry re-verifies it forever.
-    void this.#engine?.clearCachedUpdate().catch(() => undefined);
     if (this.#publishingRetry) clearTimeout(this.#publishingRetry);
     this.#publishingRetry = setTimeout(() => void this.check(), delayMs);
     this.#publishingRetry.unref();
+    return true;
+  }
+
+  /**
+   * A download that 404s or fails its sha512 right after a check found the
+   * version is a release still publishing: the manifest went live before its
+   * archive finished uploading. The same check is retried on the bounded
+   * schedule; a version that outlives it falls to the error row it always
+   * was, because a genuinely corrupt release fails the same way.
+   */
+  #retryWhilePublishing(message: string): boolean {
+    if (this.#snapshot.status !== UPDATE_STATUS.DOWNLOADING) return false;
+    if (!isPublishingWindowErrorMessage(message)) return false;
+    const version = this.#snapshot.latestVersion;
+    if (!this.#armPublishingRetry(version)) {
+      this.#publishingWait = undefined;
+      return false;
+    }
+    this.#publishingWait = version;
+    this.#report(`Release ${version} is still publishing, retrying: ${message}`);
+    // The partial archive must not stand, or the retry re-verifies it forever.
+    void this.#engine?.clearCachedUpdate().catch(() => undefined);
+    this.#move({ ...this.#base(UPDATE_STATUS.PUBLISHING), latestVersion: version });
+    return true;
+  }
+
+  /**
+   * A network failure while a publishing wait stands must not orphan the
+   * wait: the interrupted check was the wait's own retry, or a press
+   * standing in for it, and falling to idle silence would leave the found
+   * version to the four-hour timer. The resume spends the same bounded
+   * budget, so a machine that stays offline runs out of slots instead of
+   * checking forever.
+   */
+  #resumePublishingWait(message: string): boolean {
+    const version = this.#publishingWait;
+    if (version === undefined) return false;
+    if (!this.#armPublishingRetry(version)) {
+      this.#publishingWait = undefined;
+      return false;
+    }
+    this.#report(`Update check could not reach the feed, still waiting on ${version}: ${message}`);
     this.#move({ ...this.#base(UPDATE_STATUS.PUBLISHING), latestVersion: version });
     return true;
   }

--- a/apps/desktop/src/main/update-service.ts
+++ b/apps/desktop/src/main/update-service.ts
@@ -374,6 +374,11 @@ export class UpdateService {
   #resumePublishingWait(message: string): boolean {
     const version = this.#publishingWait;
     if (version === undefined) return false;
+    // A failed check arrives twice, as the `error` event and the rejected
+    // promise. The second delivery finds the wait already drawn and its
+    // timer already armed — entering `publishing` always arms one — and must
+    // not spend a second slot on the same failure.
+    if (this.#snapshot.status === UPDATE_STATUS.PUBLISHING) return true;
     if (!this.#armPublishingRetry(version)) {
       this.#publishingWait = undefined;
       return false;

--- a/apps/desktop/src/main/update-service.ts
+++ b/apps/desktop/src/main/update-service.ts
@@ -58,6 +58,31 @@ export function isNetworkErrorMessage(message: string): boolean {
   return SILENT_NETWORK_ERROR_PATTERNS.some((pattern) => message.includes(pattern));
 }
 
+/**
+ * How a still-publishing release fails: the pipeline can put the manifest
+ * live minutes before the archive it names finishes uploading, so a check
+ * succeeds while the download 404s or lands short of its sha512. The
+ * wordings are electron-updater's own — `HttpExecutor.doDownload` refusing
+ * the download's status, `DigestTransform.validate` on the mismatch. A
+ * genuinely corrupt release presents identically, which is why the retry
+ * these earn is bounded rather than standing.
+ */
+const PUBLISHING_WINDOW_ERROR_PATTERNS = ["status 404", "sha512 checksum mismatch"] as const;
+
+export function isPublishingWindowErrorMessage(message: string): boolean {
+  return PUBLISHING_WINDOW_ERROR_PATTERNS.some((pattern) => message.includes(pattern));
+}
+
+/**
+ * The publishing-window retry cadence. Each retry is the same check against
+ * the same fixed feed — only the timing is new — and the schedule is short
+ * and finite because the window it rides out is minutes long (v0.3.11's
+ * manifest went live two minutes before its archive finished uploading).
+ * Exhausted, the failure is the error row it always was: a corrupt release
+ * must not hide behind endless retries.
+ */
+const PUBLISHING_RETRY_DELAYS_MS = [2 * 60 * 1000, 5 * 60 * 1000, 15 * 60 * 1000] as const;
+
 /** The updater lifecycle, as electron-updater announces it. */
 export interface UpdaterEngineEvents {
   onChecking: () => void;
@@ -104,6 +129,7 @@ export interface UpdateServiceOptions {
   lastRunVersion?: LastRunVersionStore;
   intervalMs?: number;
   justUpdatedFirstCheckDelayMs?: number;
+  publishingRetryDelaysMs?: readonly number[];
   report?: (line: string) => void;
 }
 
@@ -113,8 +139,10 @@ export interface UpdateServiceOptions {
  * build; a newer build downloads at once and installs at the quit the user
  * asks for — the row's restart press, or whenever they next quit. Failures
  * are answers for the row, never throws: a network failure is silence (the
- * next timed check retries), anything else is `error`, drawn as the way back
- * to the releases page. An install may only be asked for once — repeat
+ * next timed check retries), a download refused right after its check found
+ * the version is a release still publishing (retried on a short bounded
+ * schedule), anything else is `error`, drawn as the way back to the releases
+ * page. An install may only be asked for once — repeat
  * presses racing Squirrel's binary swap is a failure Superset met in
  * production — and a failed install falls out of `ready`, so the guard
  * releases with it.
@@ -126,6 +154,7 @@ export class UpdateService {
   readonly #lastRunVersion: LastRunVersionStore | undefined;
   readonly #intervalMs: number;
   readonly #justUpdatedFirstCheckDelayMs: number;
+  readonly #publishingRetryDelaysMs: readonly number[];
   readonly #report: (line: string) => void;
   #snapshot: UpdateSnapshot;
   #latestVersion: string | undefined;
@@ -133,6 +162,9 @@ export class UpdateService {
   #started = false;
   #timer: NodeJS.Timeout | undefined;
   #firstCheck: NodeJS.Timeout | undefined;
+  #publishingRetry: NodeJS.Timeout | undefined;
+  #publishingVersion: string | undefined;
+  #publishingRetriesUsed = 0;
 
   constructor(options: UpdateServiceOptions) {
     this.#currentVersion = options.currentVersion;
@@ -143,6 +175,7 @@ export class UpdateService {
     this.#justUpdatedFirstCheckDelayMs =
       options.justUpdatedFirstCheckDelayMs ??
       UPDATE_CHECK_DEFAULTS.JUST_UPDATED_FIRST_CHECK_DELAY_MS;
+    this.#publishingRetryDelaysMs = options.publishingRetryDelaysMs ?? PUBLISHING_RETRY_DELAYS_MS;
     this.#report = options.report ?? ((line) => process.stderr.write(`${line}\n`));
     this.#snapshot = this.#idle(false);
     this.#engine?.wire({
@@ -169,6 +202,7 @@ export class UpdateService {
           this.#move(this.#idle(false));
           return;
         }
+        if (this.#retryWhilePublishing(message)) return;
         this.#report(`Update failed: ${message}`);
         void this.#engine?.clearCachedUpdate().catch(() => undefined);
         this.#move({ ...this.#base(UPDATE_STATUS.ERROR), latestVersion: this.#latestVersion });
@@ -199,6 +233,13 @@ export class UpdateService {
       this.#snapshot.status === UPDATE_STATUS.READY
     ) {
       return this.#snapshot;
+    }
+    // Every check is also the retry a publishing wait was waiting on, so a
+    // press or timed tick mid-wait collapses the pending timer rather than
+    // stacking a second check behind it.
+    if (this.#publishingRetry) {
+      clearTimeout(this.#publishingRetry);
+      this.#publishingRetry = undefined;
     }
     this.#move({ ...this.#base(UPDATE_STATUS.CHECKING) });
     try {
@@ -256,8 +297,39 @@ export class UpdateService {
   stop(): void {
     if (this.#timer) clearInterval(this.#timer);
     if (this.#firstCheck) clearTimeout(this.#firstCheck);
+    if (this.#publishingRetry) clearTimeout(this.#publishingRetry);
     this.#timer = undefined;
     this.#firstCheck = undefined;
+    this.#publishingRetry = undefined;
+  }
+
+  /**
+   * A download that 404s or fails its sha512 right after a check found the
+   * version is a release still publishing: the manifest went live before its
+   * archive finished uploading. The same check is retried on the bounded
+   * schedule, keyed to the version so a later release starts fresh; a
+   * version that outlives the schedule falls to the error row it always
+   * was, because a genuinely corrupt release fails the same way.
+   */
+  #retryWhilePublishing(message: string): boolean {
+    if (this.#snapshot.status !== UPDATE_STATUS.DOWNLOADING) return false;
+    if (!isPublishingWindowErrorMessage(message)) return false;
+    const version = this.#snapshot.latestVersion;
+    if (version !== this.#publishingVersion) {
+      this.#publishingVersion = version;
+      this.#publishingRetriesUsed = 0;
+    }
+    const delayMs = this.#publishingRetryDelaysMs[this.#publishingRetriesUsed];
+    if (delayMs === undefined) return false;
+    this.#publishingRetriesUsed += 1;
+    this.#report(`Release ${version} is still publishing, retrying: ${message}`);
+    // The partial archive must not stand, or the retry re-verifies it forever.
+    void this.#engine?.clearCachedUpdate().catch(() => undefined);
+    if (this.#publishingRetry) clearTimeout(this.#publishingRetry);
+    this.#publishingRetry = setTimeout(() => void this.check(), delayMs);
+    this.#publishingRetry.unref();
+    this.#move({ ...this.#base(UPDATE_STATUS.PUBLISHING), latestVersion: version });
+    return true;
   }
 
   #base<Status extends UpdateStatus>(status: Status) {

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -613,7 +613,8 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         `The Updates section on ${FRONT_PAGE} says which version this is and where the build ` +
         "stands. Luke checks on his own a few times a day — the fetch is unauthenticated, " +
         "and nothing about the developer or their sessions is sent — and a newer release " +
-        "downloads itself and installs when Luke next quits. The row's press can be asked " +
+        "downloads itself and installs when Luke next quits. A release found before its " +
+        "download is ready is retried on its own within minutes. The row's press can be asked " +
         "of Luke — check for updates, open the releases page, restart to update — and only " +
         "the one act the row currently offers runs. The Changelog row opens the changelog " +
         "in the browser, by hand alone.",

--- a/apps/desktop/src/renderer/update-row.test.ts
+++ b/apps/desktop/src/renderer/update-row.test.ts
@@ -60,6 +60,14 @@ test("the first launch after an install confirms what happened", () => {
   assert.equal(row.current, true);
 });
 
+test("a release still publishing says the wait is Luke's, not the developer's", () => {
+  const row = updateRow(supported({ status: UPDATE_STATUS.PUBLISHING, latestVersion: "0.2.0" }));
+  assert.equal(row.action, UPDATE_ROW_ACTION.CHECK);
+  assert.ok(row.detail.includes("0.2.0"), "the version found is named");
+  assert.ok(row.detail.includes("retry"), "the row says the retry happens on its own");
+  assert.equal(row.current, false);
+});
+
 test("a failed update says so and falls back to the releases page", () => {
   const failed = updateRow(supported({ status: UPDATE_STATUS.ERROR, latestVersion: "0.2.0" }));
   assert.equal(failed.action, UPDATE_ROW_ACTION.GET);
@@ -92,6 +100,10 @@ test("only a positively known newer release counts as news", () => {
   );
   assert.equal(
     updateAvailable(supported({ status: UPDATE_STATUS.READY, latestVersion: "0.2.0" })),
+    true,
+  );
+  assert.equal(
+    updateAvailable(supported({ status: UPDATE_STATUS.PUBLISHING, latestVersion: "0.2.0" })),
     true,
   );
   assert.equal(

--- a/apps/desktop/src/renderer/update-row.ts
+++ b/apps/desktop/src/renderer/update-row.ts
@@ -29,13 +29,14 @@ export interface UpdateRow {
  * the Settings tab and moves the Updates section to the head of the front
  * page — one judgment, so the dot, the section's place, and the row can
  * never disagree about whether there is news. The news stands through the
- * whole install: a release downloading, waiting on its restart, or failed
- * mid-fetch is still one this build is not on.
+ * whole install: a release downloading, still publishing, waiting on its
+ * restart, or failed mid-fetch is still one this build is not on.
  */
 export function updateAvailable(update: UpdateSnapshot): boolean {
   return (
     update.status === UPDATE_STATUS.DOWNLOADING ||
     update.status === UPDATE_STATUS.READY ||
+    update.status === UPDATE_STATUS.PUBLISHING ||
     (update.status === UPDATE_STATUS.ERROR && update.latestVersion !== undefined)
   );
 }
@@ -85,6 +86,12 @@ export function updateRow(update: UpdateSnapshot): UpdateRow {
         detail: `Updated from version ${update.previousVersion}.`,
         action: UPDATE_ROW_ACTION.CHECK,
         current: true,
+      };
+    case UPDATE_STATUS.PUBLISHING:
+      return {
+        detail: `Version ${update.latestVersion} was found but its download isn't ready yet. Luke will retry in a few minutes.`,
+        action: UPDATE_ROW_ACTION.CHECK,
+        current: false,
       };
     case UPDATE_STATUS.ERROR:
       return {

--- a/apps/desktop/src/shared/wire/update.ts
+++ b/apps/desktop/src/shared/wire/update.ts
@@ -5,8 +5,10 @@
  * question as an answer. A check that finds a newer build downloads it at
  * once, so there is no standing "available" state: the news arrives as
  * `DOWNLOADING`. `UPDATED` is transient — the first launch after an install
- * confirms what just happened. `ERROR` must be drawn as the way back to the
- * browser, never as a dead end.
+ * confirms what just happened. `PUBLISHING` is the window between a release's
+ * manifest and its archive: a version was found but its download is not
+ * servable yet, and the service is retrying on its own bounded schedule.
+ * `ERROR` must be drawn as the way back to the browser, never as a dead end.
  */
 export const UPDATE_STATUS = {
   IDLE: "idle",
@@ -14,6 +16,7 @@ export const UPDATE_STATUS = {
   DOWNLOADING: "downloading",
   READY: "ready",
   UPDATED: "updated",
+  PUBLISHING: "publishing",
   ERROR: "error",
 } as const;
 
@@ -68,6 +71,12 @@ export type UpdateSnapshot =
       installSupported: boolean;
       /** The version this build replaced, for the row to name the arrival. */
       previousVersion: string;
+    }
+  | {
+      status: typeof UPDATE_STATUS.PUBLISHING;
+      currentVersion: string;
+      installSupported: boolean;
+      latestVersion: string;
     }
   | {
       status: typeof UPDATE_STATUS.ERROR;


### PR DESCRIPTION
## Why

v0.3.11's release went live before its assets finished uploading: the manifest was servable at 21:18:53 UTC while the zip only completed at 21:21:01, so for two minutes electron-updater found the version and then failed its download (404 or sha512 mismatch). The updater treated that like any non-network failure — the terminal error row, "get it from the releases page instead" — misdiagnosing a self-healing window, and the only automatic recovery was the 4-hour timed check. #521 makes the pipeline draft-then-publish, but the client should still ride out stragglers (CDN propagation, other people's release mistakes).

## What

- A download that 404s or fails its sha512 right after its check found the version is recognized as a release still publishing (`PUBLISHING` status, carrying `latestVersion`). The patterns are electron-updater's own wordings, read from `HttpExecutor.doDownload` and `DigestTransform.validate` in `node_modules`.
- The same check is retried at 2, 5, then 15 minutes (`as const` schedule, injectable for tests), against the same fixed feed — nothing new is sent or read, only the cadence. The partial archive is cleared before each retry, the same way the error path clears it. The budget is keyed to the version, so a later release starts fresh.
- A user press mid-wait collapses the pending retry timer rather than stacking one, and `stop()` clears it.
- The row says the wait honestly — "Version X was found but its download isn't ready yet. Luke will retry in a few minutes." — action CHECK. The exhausted schedule falls to today's terminal ERROR row exactly as it was (a genuinely corrupt release also presents as a sha512 mismatch, and the bounded retry must not hide it).
- AGENTS.md's updater paragraph now describes the bounded publishing-window retry; Luke's guide fact learns the behavior in the same change.
- A network failure while a publishing wait stands resumes the wait on the next slot of the same bounded budget, rather than falling to the silent idle row after the retry timer was already collapsed (found by Bugbot); a machine that stays offline runs out of slots instead of checking forever.

`PRIVACY.md` is untouched deliberately: nothing new leaves the machine — each retry is the same unauthenticated fetch of the same fixed feed, and only the timing changed, so "GitHub, to check for updates… carry nothing about you" remains exactly true.

## Verification

- `./scripts/check.sh`: passed (exit 0), re-run after each commit. A first run saw the known native-test flake under parallel load (apple-calendar, talk-key, output-volume, etc.); those 47 tests pass when run alone, and both full re-runs were clean.
- `./scripts/verify.sh`: passed (exit 0), run after each commit; all six evidence captures written (`app-smoke-{expanded,compact,peek,slot,speaking,muted}.png`), inspected — panel, housing, and rows render unchanged. No physical-notch check was performed (no physical device available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32909046575/artifacts/9585942316) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32909046575)

- Commit: `0fcc4d18b0e6bf33ba4e54f9ae06a464eb720aa0`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

