### PR TITLE
feat(desktop): minimize Luke while macOS asks for the microphone during onboarding

### DIFF
--- a/apps/desktop/src/renderer/introduction/introduction-beats.test.ts
+++ b/apps/desktop/src/renderer/introduction/introduction-beats.test.ts
@@ -15,6 +15,7 @@ test("the happy path walks every beat in order", () => {
     [INTRODUCTION_EVENT.LINES_DONE, INTRODUCTION_BEAT.FLIGHT],
     [INTRODUCTION_EVENT.FLIGHT_SETTLED, INTRODUCTION_BEAT.TOUR],
     [INTRODUCTION_EVENT.LINES_DONE, INTRODUCTION_BEAT.MICROPHONE],
+    [INTRODUCTION_EVENT.LINES_DONE, INTRODUCTION_BEAT.MICROPHONE_DIALOG],
     [INTRODUCTION_EVENT.MICROPHONE_GRANTED, INTRODUCTION_BEAT.PRACTICE],
     [INTRODUCTION_EVENT.PRACTICE_DONE, INTRODUCTION_BEAT.SIGN_OFF],
     [INTRODUCTION_EVENT.LINES_DONE, INTRODUCTION_BEAT.STAND_DOWN],
@@ -27,7 +28,28 @@ test("the happy path walks every beat in order", () => {
   }
 });
 
-test("a denied microphone walks past practice to the sign-off", () => {
+test("a granted microphone needs no dialog and walks straight to practice", () => {
+  assert.equal(
+    nextIntroductionBeat(INTRODUCTION_BEAT.MICROPHONE, INTRODUCTION_EVENT.MICROPHONE_GRANTED),
+    INTRODUCTION_BEAT.PRACTICE,
+  );
+});
+
+test("a refused dialog is answered kindly, then walks past practice to the sign-off", () => {
+  assert.equal(
+    nextIntroductionBeat(INTRODUCTION_BEAT.MICROPHONE_DIALOG, INTRODUCTION_EVENT.MICROPHONE_DENIED),
+    INTRODUCTION_BEAT.MICROPHONE_DENIED,
+  );
+  assert.equal(
+    nextIntroductionBeat(
+      INTRODUCTION_BEAT.MICROPHONE_DENIED,
+      INTRODUCTION_EVENT.MICROPHONE_DENIED_SAID,
+    ),
+    INTRODUCTION_BEAT.SIGN_OFF,
+  );
+});
+
+test("a refusal standing before Luke ever asked skips the dialog and the answer", () => {
   assert.equal(
     nextIntroductionBeat(INTRODUCTION_BEAT.MICROPHONE, INTRODUCTION_EVENT.MICROPHONE_DENIED_SAID),
     INTRODUCTION_BEAT.SIGN_OFF,
@@ -72,6 +94,10 @@ test("a voice that failed before the flight glides; one that died after stands d
   );
   assert.equal(
     nextIntroductionBeat(INTRODUCTION_BEAT.TOUR, INTRODUCTION_EVENT.VOICE_FAILED),
+    INTRODUCTION_BEAT.STAND_DOWN,
+  );
+  assert.equal(
+    nextIntroductionBeat(INTRODUCTION_BEAT.MICROPHONE_DIALOG, INTRODUCTION_EVENT.VOICE_FAILED),
     INTRODUCTION_BEAT.STAND_DOWN,
   );
   assert.equal(

--- a/apps/desktop/src/renderer/introduction/introduction-beats.ts
+++ b/apps/desktop/src/renderer/introduction/introduction-beats.ts
@@ -28,6 +28,14 @@ export const INTRODUCTION_BEAT = {
   TOUR: "tour",
   /** Luke asks before macOS does. */
   MICROPHONE: "microphone",
+  /**
+   * macOS's own dialog is up: the landed panel stands aside to the capsule
+   * for as long as the ask stands — the same courtesy the panel pays a
+   * calendar consent — and springs back the moment it is answered.
+   */
+  MICROPHONE_DIALOG: "microphone-dialog",
+  /** The panel back up, the refusal answered kindly. */
+  MICROPHONE_DENIED: "microphone-denied",
   /** The talk key is drawn and a real spoken exchange happens. */
   PRACTICE: "practice",
   /** The sign-off line, spoken over the landed panel with the voice still up. */
@@ -50,6 +58,8 @@ export const INTRODUCTION_EVENT = {
   LINES_DONE: "lines-done",
   FLIGHT_SETTLED: "flight-settled",
   MICROPHONE_GRANTED: "microphone-granted",
+  /** macOS's dialog was refused; the kind answer has not been spoken yet. */
+  MICROPHONE_DENIED: "microphone-refused",
   /** The refusal was answered kindly and the answer has finished. */
   MICROPHONE_DENIED_SAID: "microphone-denied-said",
   /** The practice exchange was answered, or its patience ran out. */
@@ -94,7 +104,18 @@ const TRANSITIONS = {
     [INTRODUCTION_EVENT.LINES_DONE]: INTRODUCTION_BEAT.MICROPHONE,
   },
   [INTRODUCTION_BEAT.MICROPHONE]: {
+    // A grant or refusal already standing needs no dialog: the beat's own
+    // probe short-circuits straight past the aside.
     [INTRODUCTION_EVENT.MICROPHONE_GRANTED]: INTRODUCTION_BEAT.PRACTICE,
+    [INTRODUCTION_EVENT.MICROPHONE_DENIED_SAID]: INTRODUCTION_BEAT.SIGN_OFF,
+    // The warning spoken, macOS asks next — and the panel gets out of its way.
+    [INTRODUCTION_EVENT.LINES_DONE]: INTRODUCTION_BEAT.MICROPHONE_DIALOG,
+  },
+  [INTRODUCTION_BEAT.MICROPHONE_DIALOG]: {
+    [INTRODUCTION_EVENT.MICROPHONE_GRANTED]: INTRODUCTION_BEAT.PRACTICE,
+    [INTRODUCTION_EVENT.MICROPHONE_DENIED]: INTRODUCTION_BEAT.MICROPHONE_DENIED,
+  },
+  [INTRODUCTION_BEAT.MICROPHONE_DENIED]: {
     [INTRODUCTION_EVENT.MICROPHONE_DENIED_SAID]: INTRODUCTION_BEAT.SIGN_OFF,
   },
   [INTRODUCTION_BEAT.PRACTICE]: {

--- a/apps/desktop/src/renderer/introduction/introduction-beats.ts
+++ b/apps/desktop/src/renderer/introduction/introduction-beats.ts
@@ -29,9 +29,9 @@ export const INTRODUCTION_BEAT = {
   /** Luke asks before macOS does. */
   MICROPHONE: "microphone",
   /**
-   * macOS's own dialog is up: the landed panel stands aside to the capsule
-   * for as long as the ask stands — the same courtesy the panel pays a
-   * calendar consent — and springs back the moment it is answered.
+   * macOS's own dialog is up: the landed panel stands aside to the waiting
+   * slot for as long as the ask stands — the same pill a calendar consent
+   * stands down to — and springs back the moment it is answered.
    */
   MICROPHONE_DIALOG: "microphone-dialog",
   /** The panel back up, the refusal answered kindly. */

--- a/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
+++ b/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
@@ -89,6 +89,8 @@ const FLOWN_BEATS: ReadonlySet<IntroductionBeat> = new Set([
   INTRODUCTION_BEAT.GLIDE,
   INTRODUCTION_BEAT.TOUR,
   INTRODUCTION_BEAT.MICROPHONE,
+  INTRODUCTION_BEAT.MICROPHONE_DIALOG,
+  INTRODUCTION_BEAT.MICROPHONE_DENIED,
   INTRODUCTION_BEAT.PRACTICE,
   INTRODUCTION_BEAT.SIGN_OFF,
   INTRODUCTION_BEAT.STAND_DOWN,
@@ -104,6 +106,8 @@ const FLOWN_BEATS: ReadonlySet<IntroductionBeat> = new Set([
 const LANDED_BEATS: ReadonlySet<IntroductionBeat> = new Set([
   INTRODUCTION_BEAT.TOUR,
   INTRODUCTION_BEAT.MICROPHONE,
+  INTRODUCTION_BEAT.MICROPHONE_DIALOG,
+  INTRODUCTION_BEAT.MICROPHONE_DENIED,
   INTRODUCTION_BEAT.PRACTICE,
   INTRODUCTION_BEAT.SIGN_OFF,
   INTRODUCTION_BEAT.STAND_DOWN,
@@ -534,18 +538,29 @@ export function IntroductionTakeover({
           dispatch(INTRODUCTION_EVENT.MICROPHONE_DENIED_SAID);
           return;
         }
-        speakLines(INTRODUCTION_SCRIPT.MICROPHONE, undefined, () => {
-          void window.sidecar.requestMicrophone().then((status) => {
-            if (beatRef.current !== INTRODUCTION_BEAT.MICROPHONE) return;
-            if (status === "granted") {
-              dispatch(INTRODUCTION_EVENT.MICROPHONE_GRANTED);
-              return;
-            }
-            speakLines(INTRODUCTION_SCRIPT.MICROPHONE_DENIED, undefined, () =>
-              dispatch(INTRODUCTION_EVENT.MICROPHONE_DENIED_SAID),
-            );
-          });
+        speakLines(INTRODUCTION_SCRIPT.MICROPHONE, undefined, () =>
+          dispatch(INTRODUCTION_EVENT.LINES_DONE),
+        );
+        return;
+      }
+      case INTRODUCTION_BEAT.MICROPHONE_DIALOG: {
+        // The dialog is macOS's own window mid-screen; while it stands, the
+        // panel is the capsule beside the housing — the same courtesy it pays
+        // a calendar consent — and the answer is what brings it back.
+        void window.sidecar.requestMicrophone().then((status) => {
+          if (beatRef.current !== INTRODUCTION_BEAT.MICROPHONE_DIALOG) return;
+          dispatch(
+            status === "granted"
+              ? INTRODUCTION_EVENT.MICROPHONE_GRANTED
+              : INTRODUCTION_EVENT.MICROPHONE_DENIED,
+          );
         });
+        return;
+      }
+      case INTRODUCTION_BEAT.MICROPHONE_DENIED: {
+        speakLines(INTRODUCTION_SCRIPT.MICROPHONE_DENIED, undefined, () =>
+          dispatch(INTRODUCTION_EVENT.MICROPHONE_DENIED_SAID),
+        );
         return;
       }
       case INTRODUCTION_BEAT.PRACTICE: {
@@ -651,6 +666,9 @@ export function IntroductionTakeover({
     return () => clearTimeout(timer);
   }, [landed]);
   const standingDown = STANDING_DOWN_BEATS.has(beat);
+  // Stood aside, not down: the capsule while macOS's microphone dialog is
+  // up, with the wings ungated — the panel it springs back to is unchanged.
+  const standingAside = beat === INTRODUCTION_BEAT.MICROPHONE_DIALOG;
   // The tour's flipped row wears the attention look and rides to the top,
   // exactly as the panel re-sorts a session that starts needing someone.
   const tourFlipped = tourFlipId ? rows.find((row) => row.id === tourFlipId) : undefined;
@@ -697,9 +715,8 @@ export function IntroductionTakeover({
       data-notch={String(bootstrap.display.notch.hasNotch)}
       {...(landed
         ? {
-            "data-presentation": standingDown
-              ? PANEL_PRESENTATION.CAPSULE
-              : PANEL_PRESENTATION.PANEL,
+            "data-presentation":
+              standingDown || standingAside ? PANEL_PRESENTATION.CAPSULE : PANEL_PRESENTATION.PANEL,
           }
         : undefined)}
       style={{
@@ -760,7 +777,9 @@ export function IntroductionTakeover({
           meetingQuiet={false}
           voiceSpent={false}
           sessionsSettled={true}
-          presentation={standingDown ? PANEL_PRESENTATION.CAPSULE : PANEL_PRESENTATION.PANEL}
+          presentation={
+            standingDown || standingAside ? PANEL_PRESENTATION.CAPSULE : PANEL_PRESENTATION.PANEL
+          }
           housingWidth={bootstrap.display.notch.housingWidth}
           accountGated={standingDown}
         />

--- a/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
+++ b/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
@@ -27,6 +27,7 @@ import { RealtimeVoiceSession } from "../realtime-session";
 import { displaySessions, type SessionView, sessionTally } from "../session-model";
 import { parseMilliseconds, useSessionReorderMotion } from "../session-motion";
 import { useSignInFaceCycle } from "../sign-in-gate";
+import { useMeasuredHeight } from "../use-measured-height";
 import { activeVoiceStream } from "../use-voice-conversation";
 import { outputSilent } from "../volume-hint";
 import { WAVEFORM_VOICE, Waveform, type WaveformVoice } from "../waveform";
@@ -188,6 +189,8 @@ export function IntroductionTakeover({
     observer.observe(group);
     return () => observer.disconnect();
   }, []);
+  /** The microphone wait's own pill, measured so the surface ends where it does. */
+  const [slotElement, slotHeight] = useMeasuredHeight();
   /** The current beat's remaining lines, and what to do when the last one ends. */
   const lineQueueRef = useRef<readonly string[]>([]);
   const afterLinesRef = useRef<(() => void) | undefined>(undefined);
@@ -545,8 +548,8 @@ export function IntroductionTakeover({
       }
       case INTRODUCTION_BEAT.MICROPHONE_DIALOG: {
         // The dialog is macOS's own window mid-screen; while it stands, the
-        // panel is the capsule beside the housing — the same courtesy it pays
-        // a calendar consent — and the answer is what brings it back.
+        // panel is the waiting slot — the same pill a calendar consent
+        // stands down to — and the answer is what brings it back.
         void window.sidecar.requestMicrophone().then((status) => {
           if (beatRef.current !== INTRODUCTION_BEAT.MICROPHONE_DIALOG) return;
           dispatch(
@@ -634,7 +637,7 @@ export function IntroductionTakeover({
     const handleMove = (event: MouseEvent) => {
       const island = document
         .elementFromPoint(event.clientX, event.clientY)
-        ?.closest(".introduction-panel, .notch-wings");
+        ?.closest(".introduction-panel, .notch-wings, .slot-stage");
       update(island != null);
     };
     const handleLeave = () => {
@@ -666,9 +669,15 @@ export function IntroductionTakeover({
     return () => clearTimeout(timer);
   }, [landed]);
   const standingDown = STANDING_DOWN_BEATS.has(beat);
-  // Stood aside, not down: the capsule while macOS's microphone dialog is
-  // up, with the wings ungated — the panel it springs back to is unchanged.
+  // Stood aside, not down: while macOS's microphone dialog is up the panel
+  // is the waiting slot — the same pill a calendar consent stands down to,
+  // wings ungated — and the panel it springs back to is unchanged.
   const standingAside = beat === INTRODUCTION_BEAT.MICROPHONE_DIALOG;
+  const presentation = standingDown
+    ? PANEL_PRESENTATION.CAPSULE
+    : standingAside
+      ? PANEL_PRESENTATION.SLOT
+      : PANEL_PRESENTATION.PANEL;
   // The tour's flipped row wears the attention look and rides to the top,
   // exactly as the panel re-sorts a session that starts needing someone.
   const tourFlipped = tourFlipId ? rows.find((row) => row.id === tourFlipId) : undefined;
@@ -713,17 +722,13 @@ export function IntroductionTakeover({
       data-settled={String(surfaceSettled)}
       data-lifted={String(rows.length > 0)}
       data-notch={String(bootstrap.display.notch.hasNotch)}
-      {...(landed
-        ? {
-            "data-presentation":
-              standingDown || standingAside ? PANEL_PRESENTATION.CAPSULE : PANEL_PRESENTATION.PANEL,
-          }
-        : undefined)}
+      {...(landed ? { "data-presentation": presentation } : undefined)}
       style={{
         ...cssCustomProperties({
           "--notch-top-inset": `${bootstrap.display.notch.topInset}px`,
           "--notch-housing-width": `${bootstrap.display.notch.housingWidth}px`,
           "--panel-height": `${panelHeight}px`,
+          ...(slotHeight !== undefined ? { "--slot-height": `${slotHeight}px` } : undefined),
         }),
         ...flightStyle,
       }}
@@ -762,6 +767,29 @@ export function IntroductionTakeover({
           </div>
         ) : null}
       </div>
+      {/* The microphone wait's pill, on the consent slot's exact terms: the
+          shape shrinks to a line that says what it is waiting for while
+          macOS's own dialog holds the room. No mark and no way out, because
+          no service tells the pills apart here and the dialog's own buttons
+          are the only honest answer — base.css's slot rules own its arrival,
+          its exit, and the pointer it may take while drawn. */}
+      {flown ? (
+        <div
+          className="slot-stage"
+          data-drawn={String(standingAside)}
+          aria-hidden={!standingAside}
+          inert={!standingAside}
+        >
+          <div ref={slotElement} className="key-slot sign-in-slot">
+            <div className="key-slot-row">
+              <span className="sign-in-slot-copy" role="status">
+                <strong>Waiting for macOS…</strong>
+                <small>Allow microphone access in macOS's dialog.</small>
+              </span>
+            </div>
+          </div>
+        </div>
+      ) : null}
       {/* The real wings, the moment there is a strip to stand in: the same
           face, meter, and count the app draws, trading the face for the meter
           while the developer holds the floor. At the gate the strip goes
@@ -777,9 +805,7 @@ export function IntroductionTakeover({
           meetingQuiet={false}
           voiceSpent={false}
           sessionsSettled={true}
-          presentation={
-            standingDown || standingAside ? PANEL_PRESENTATION.CAPSULE : PANEL_PRESENTATION.PANEL
-          }
+          presentation={presentation}
           housingWidth={bootstrap.display.notch.housingWidth}
           accountGated={standingDown}
         />

--- a/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
+++ b/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
@@ -26,6 +26,7 @@ import { PANEL_PRESENTATION } from "../panel-state";
 import { RealtimeVoiceSession } from "../realtime-session";
 import { displaySessions, type SessionView, sessionTally } from "../session-model";
 import { parseMilliseconds, useSessionReorderMotion } from "../session-motion";
+import { MicrophoneIcon } from "../settings-icons";
 import { useSignInFaceCycle } from "../sign-in-gate";
 import { useMeasuredHeight } from "../use-measured-height";
 import { activeVoiceStream } from "../use-voice-conversation";
@@ -769,10 +770,11 @@ export function IntroductionTakeover({
       </div>
       {/* The microphone wait's pill, on the consent slot's exact terms: the
           shape shrinks to a line that says what it is waiting for while
-          macOS's own dialog holds the room. No mark and no way out, because
-          no service tells the pills apart here and the dialog's own buttons
-          are the only honest answer — base.css's slot rules own its arrival,
-          its exit, and the pointer it may take while drawn. */}
+          macOS's own dialog holds the room. Its mark is the microphone
+          itself, in Luke's own glyph vocabulary, because macOS's ask has no
+          brand mark of its own; there is no way out, because the dialog's
+          buttons are the only honest answer — base.css's slot rules own its
+          arrival, its exit, and the pointer it may take while drawn. */}
       {flown ? (
         <div
           className="slot-stage"
@@ -782,6 +784,9 @@ export function IntroductionTakeover({
         >
           <div ref={slotElement} className="key-slot sign-in-slot">
             <div className="key-slot-row">
+              <span className="key-slot-mark">
+                <MicrophoneIcon />
+              </span>
               <span className="sign-in-slot-copy" role="status">
                 <strong>Waiting for macOS…</strong>
                 <small>Allow microphone access in macOS's dialog.</small>

--- a/apps/desktop/src/renderer/settings-icons.tsx
+++ b/apps/desktop/src/renderer/settings-icons.tsx
@@ -331,6 +331,17 @@ export function VoiceIcon(): React.JSX.Element {
   );
 }
 
+/** The microphone itself — what macOS's own access ask is about. */
+export function MicrophoneIcon(): React.JSX.Element {
+  return (
+    <Glyph>
+      <rect x="9.2" y="2.6" width="5.6" height="10.6" rx="2.8" />
+      <path d="M5.6 11.4a6.4 6.4 0 0 0 12.8 0" />
+      <path d="M12 17.8V21" />
+    </Glyph>
+  );
+}
+
 /**
  * The stop glyph every chat surface uses: a filled, slightly rounded square.
  * Filled rather than stroked, because at control size a stroked square reads

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -2943,7 +2943,8 @@ html[data-keyboard="true"] .wing-mark:focus-visible {
   place-items: center;
 }
 
-.key-slot-mark .provider-mark {
+.key-slot-mark .provider-mark,
+.key-slot-mark .settings-icon {
   width: 16px;
   height: 16px;
 }

--- a/apps/desktop/src/renderer/styles/introduction.css
+++ b/apps/desktop/src/renderer/styles/introduction.css
@@ -316,7 +316,10 @@
 }
 
 /* The practice beat's keycaps, drawn on the panel itself: the surface takes
-   their room at once and they arrive over black behind the shape's delay. */
+   their room at once, and they wait out the shape's whole travel like the
+   returning rows do, because practice arrives from the microphone aside with
+   the surface still springing back from the capsule — a shorter delay would
+   draw the caps over desktop the shape does not yet back. */
 .introduction-keycaps {
   display: flex;
   align-items: center;
@@ -326,7 +329,7 @@
   --keycap-size: 32px;
   --keycap-text: 15px;
   animation: introduction-arrive var(--duration-fast) var(--spring) backwards;
-  animation-delay: var(--slot-delay);
+  animation-delay: calc(var(--duration-exit) + var(--duration-shape));
 }
 
 .introduction-keycaps-hold {

--- a/apps/desktop/src/renderer/styles/introduction.css
+++ b/apps/desktop/src/renderer/styles/introduction.css
@@ -271,6 +271,19 @@
   transition: opacity var(--duration-exit) var(--motion-exit);
 }
 
+/* With its rows away the group is a footprint, not a surface: it keeps its
+   full layout box while only opacity has left, and the takeover's pointer
+   island is read off elementFromPoint — so an invisible group that still
+   hit-tests holds the window's interception across the whole box the panel
+   no longer draws, and swallows the clicks meant for what stands behind it:
+   the desktop, and macOS's own microphone dialog above all. */
+.introduction-stage[data-beat="glide"] .introduction-panel,
+.introduction-stage[data-beat="microphone-dialog"] .introduction-panel,
+.introduction-stage[data-beat="stand-down"] .introduction-panel,
+.introduction-stage[data-beat="done"] .introduction-panel {
+  pointer-events: none;
+}
+
 /* Away from the panel each row is its own solid card — no panel box around
    the list, and nothing of the desktop reading through a row. They hold that
    solidity through the whole flight *and* through the surface's own spring

--- a/apps/desktop/src/renderer/styles/introduction.css
+++ b/apps/desktop/src/renderer/styles/introduction.css
@@ -250,12 +250,20 @@
   scrollbar-width: thin;
   animation: scroll-edge-fade linear both;
   animation-timeline: scroll(self block);
+  /* The return from the microphone aside: the rows wait out the surface's
+     whole spring back to the panel's bounds — the exit hold plus the shape —
+     so they never stand over desktop the shape does not yet back. Leaving
+     rides the exit rule below instead, exit-first as every shrink is. */
+  transition: opacity var(--duration-fast) var(--motion-exit)
+    calc(var(--duration-exit) + var(--duration-shape));
 }
 
-/* Standing down, the rows leave first — the same exit-first ordering the
-   real collapse keeps — and the real surface follows them on its own spring
-   into the capsule's bounds. */
+/* Standing down — or aside, while macOS's microphone dialog holds the room —
+   the rows leave first, the same exit-first ordering the real collapse
+   keeps, and the real surface follows them on its own spring into the
+   capsule's bounds. */
 .introduction-stage[data-beat="glide"] .introduction-rows,
+.introduction-stage[data-beat="microphone-dialog"] .introduction-rows,
 .introduction-stage[data-beat="stand-down"] .introduction-rows,
 .introduction-stage[data-beat="done"] .introduction-rows {
   opacity: 0;

--- a/apps/desktop/src/renderer/styles/introduction.css
+++ b/apps/desktop/src/renderer/styles/introduction.css
@@ -261,7 +261,7 @@
 /* Standing down — or aside, while macOS's microphone dialog holds the room —
    the rows leave first, the same exit-first ordering the real collapse
    keeps, and the real surface follows them on its own spring into the
-   capsule's bounds. */
+   capsule's bounds, or the waiting slot's for the aside. */
 .introduction-stage[data-beat="glide"] .introduction-rows,
 .introduction-stage[data-beat="microphone-dialog"] .introduction-rows,
 .introduction-stage[data-beat="stand-down"] .introduction-rows,


### PR DESCRIPTION
## What

During the introduction's microphone beat, the landed panel stayed fully expanded beside the notch while macOS's own microphone consent dialog held the room. This gives the dialog the same courtesy the settings panel already pays an Apple Calendar consent: the panel stands aside to the capsule for as long as the ask stands, and springs back the moment it is answered — into the practice beat on a grant, or into the kindly spoken answer on a refusal.

## How

- `introduction-beats.ts`: the aside (`microphone-dialog`) and the answered refusal (`microphone-denied`) are beats of their own in the pure transition table, with a new `microphone-refused` event carrying the dialog's "no". The pre-existing short-circuits (already granted, refused before Luke ever asked) keep their paths on the `microphone` beat's own row.
- `introduction-takeover.tsx`: `requestMicrophone()` now runs on the dialog beat's arrival, whose presentation is derived from the beat alone. The panel stands down to the **waiting slot** — the same pill a calendar consent draws ("Waiting for macOS… Allow microphone access in macOS's dialog."), wings ungated, marked with a microphone glyph in Luke's own currentColor icon vocabulary (macOS's ask has no brand mark of its own), with no cancel since the dialog's own buttons are the only honest answer.
- `introduction.css`: the rows leave exit-first like every shrink, and their return waits out the surface's whole spring back (`--duration-exit` + `--duration-shape`), so they never stand over desktop the shape does not yet back.

## Verification

- `./scripts/check.sh` passes (repository, type, test, and build checks), including the extended beats-table walk in `introduction-beats.test.ts`.
- macOS validation rides this PR's CI (`./scripts/verify.sh` on the macOS runner links its evidence below). No physical-notch check was performed; the introduction's microphone beat only plays on a first interactive launch, so the fixture evidence does not exercise the aside itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/f39bbbfc-0671-41b1-b1a2-fd0ebaac3bca)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32916403370/artifacts/9588380018) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32916403370)

- Commit: `c26224664fcc96448fe4a6d1da19568072019af8`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->


