### PR TITLE
fix(conductor): drop listed-archived workspaces before any per-workspace read

### DIFF
--- a/packages/providers/src/conductor/adapter.test.ts
+++ b/packages/providers/src/conductor/adapter.test.ts
@@ -34,7 +34,8 @@ interface TestWorkspace {
   name: string;
   creatorId?: string;
   lastActivityAt: number;
-  archivedAt?: string;
+  /** What the listing marks the workspace as; the real page always carries one. */
+  state?: string;
   lifecycleStatus?: string;
   lifecycleErrorMessage?: string;
   lifecycleHttpStatus?: number;
@@ -77,15 +78,13 @@ function workspacePayload(workspace: TestWorkspace) {
   const payload: JsonObject = {
     id: workspace.id,
     name: workspace.name,
+    state: workspace.state ?? "ready",
     createdAt: isoTimestamp(workspace.lastActivityAt),
     deepLink: `conductor://workspace?id=${workspace.id}`,
     lastActivityAt: isoTimestamp(workspace.lastActivityAt),
   };
   if (workspace.creatorId) {
     payload.creatorId = workspace.creatorId;
-  }
-  if (workspace.archivedAt) {
-    payload.archivedAt = workspace.archivedAt;
   }
   return payload;
 }
@@ -1639,10 +1638,19 @@ test("leaves a filed-away workspace and its chats off the roster entirely", asyn
       // Filing a workspace away is how a user says its chats are done being
       // watched, so nothing of it survives to the roster — this is also what
       // makes a press of the archive control actually clear the rows it
-      // acted on, come the next pass.
+      // acted on, come the next pass. The listing marks it, and a page can
+      // hold hundreds of these, so it must cost nothing further: judged by a
+      // per-workspace read instead, one failed read on one long-archived
+      // workspace resurrected rows the user had already filed away.
       {
         ...ownedWorkspace("workspace-filed", TEST_TIME - 30_000),
-        archivedAt: isoTimestamp(TEST_TIME - 20_000),
+        state: "archived",
+        // Misbehave behind the mark: the pass must never ask.
+        lifecycleHttpStatus: HTTP_STATUS.SERVER_ERROR,
+      },
+      {
+        ...ownedWorkspace("workspace-erased", TEST_TIME - 40_000),
+        state: "deleted",
       },
       ownedWorkspace("workspace-open", TEST_TIME - 5_000),
     ],
@@ -1669,26 +1677,34 @@ test("leaves a filed-away workspace and its chats off the roster entirely", asyn
     observations.map((candidate) => candidate.providerSessionId),
     ["session-open"],
   );
-  // Dropped before its sessions are ever asked for: the filed-away workspace
-  // costs no requests, not just no rows.
+  // Dropped before its lifecycle or sessions are ever asked for: the
+  // filed-away workspaces cost no requests, not just no rows.
   assert.equal(
     api.requests.some((request) => request.pathname.includes("workspace-filed")),
+    false,
+  );
+  assert.equal(
+    api.requests.some((request) => request.pathname.includes("workspace-erased")),
     false,
   );
 });
 
 test("leaves a workspace whose lifecycle stands archived off the roster", async () => {
-  // Conductor's listing keeps a filed-away workspace in the page with no
-  // mark of it — no archive timestamp, nothing — and only the lifecycle
-  // endpoint says it was archived. Without that read deciding the roster,
-  // every chat of every workspace ever archived kept its row, standing gray
-  // forever.
+  // A filing-away the listing has not caught up with still shows at the
+  // lifecycle endpoint, and a listing state this build does not know says
+  // nothing either way — in both cases the lifecycle read decides, so
+  // every chat of a workspace actually archived is dropped rather than
+  // standing gray forever.
   const api = fakeConductorApi({
     userId: TEST_USER_ID,
     projects: [LUKE_PROJECT],
     workspaces: [
       { ...ownedWorkspace("workspace-archived", TEST_TIME - 30_000), lifecycleStatus: "archived" },
-      { ...ownedWorkspace("workspace-deleted", TEST_TIME - 40_000), lifecycleStatus: "deleted" },
+      {
+        ...ownedWorkspace("workspace-deleted", TEST_TIME - 40_000),
+        state: "some-future-state",
+        lifecycleStatus: "deleted",
+      },
       ownedWorkspace("workspace-open", TEST_TIME - 5_000),
     ],
     sessions: [

--- a/packages/providers/src/conductor/adapter.ts
+++ b/packages/providers/src/conductor/adapter.ts
@@ -182,6 +182,8 @@ const CONDUCTOR_FIELD = {
   MODEL: "model",
   NAME: "name",
   RESOLVED_MODEL: "resolvedModel",
+  /** The workspace listing's own word for where each workspace stands. */
+  STATE: "state",
   STATUS: "status",
   UPDATED_AT: "updatedAt",
   USER_ID: "userId",
@@ -308,9 +310,10 @@ const CONDUCTOR_WORKSPACE_ACTIVITY = {
 
 /**
  * The lifecycle states of a workspace no longer open. Conductor's workspace
- * listing keeps a filed-away workspace in the page without marking it — the
- * lifecycle endpoint is the one place the archive shows — so these are what
- * the roster filters on.
+ * listing keeps a filed-away workspace in the page, but marks it: the
+ * listing's `state` and the lifecycle endpoint's `status` document the same
+ * value set, and the roster filters on these states wherever either read
+ * reports one.
  */
 const CONDUCTOR_RETIRED_WORKSPACE_STATUSES: ReadonlySet<ConductorWorkspaceStatus> = new Set([
   CONDUCTOR_WORKSPACE_STATUS.ARCHIVED,
@@ -590,15 +593,16 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
       .filter((workspace) => workspace.creatorId === userId)
       .sort((first, second) => second.lastActivityAt - first.lastActivityAt);
 
-    // Conductor's listing keeps a filed-away workspace in the page without
-    // marking it — only the lifecycle endpoint says it was archived — so the
-    // lifecycle reads come before the session listings, one per listed
-    // workspace, and a workspace standing archived or deleted is dropped
-    // here, before its chats are ever asked for. This is what makes a press
-    // of the archive control actually clear the rows it acted on. A
-    // lifecycle that could not be read keeps its workspace: a transient
-    // failure costs that workspace's activity words and failure message,
-    // never its rows.
+    // The listing already dropped the workspaces it marked archived or
+    // deleted, so these lifecycle reads cover only the workspaces still
+    // standing: they carry each one's activity words and failure message,
+    // and they catch a filing-away the listing has not caught up with — a
+    // workspace standing archived or deleted here is dropped all the same,
+    // before its chats are ever asked for, which is what makes a press of
+    // the archive control clear the rows it acted on within the pass that
+    // follows it. A lifecycle that could not be read keeps its workspace: a
+    // transient failure costs that workspace's activity words and failure
+    // message, never its rows.
     const workspaceLifecycles = new Map(
       (
         await Promise.all(
@@ -726,11 +730,20 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
           timestampFromRecord(record, CONDUCTOR_FIELD.LAST_ACTIVITY_AT) ??
           timestampFromRecord(record, CONDUCTOR_FIELD.CREATED_AT);
         if (!id || lastActivityAt === undefined) return undefined;
-        // Conductor's listing does not mark a filed-away workspace today —
-        // the lifecycle read in the collect pass is what drops those — but a
-        // record that does carry an archive timestamp is honored without
-        // waiting for that read.
-        if (timestampFromRecord(record, CONDUCTOR_FIELD.ARCHIVED_AT) !== undefined) {
+        // The listing marks a filed-away workspace with its own state, so it
+        // is dropped here, before a lifecycle or session read ever spends a
+        // request on it. This is also what keeps a press of the archive
+        // control durable: judged by the lifecycle read alone, a page of
+        // long-archived workspaces stood or fell with dozens of per-workspace
+        // reads every pass, and any one of them failing resurrected a
+        // workspace the user had already filed away. A state this build does
+        // not know is kept, not dropped — the lifecycle read still decides
+        // for it, as it did when the listing marked nothing.
+        const state = knownValue(
+          CONDUCTOR_WORKSPACE_STATUS,
+          textFromRecord(record, CONDUCTOR_FIELD.STATE),
+        );
+        if (state && CONDUCTOR_RETIRED_WORKSPACE_STATUSES.has(state)) {
           return undefined;
         }
         const creatorId = textFromRecord(record, CONDUCTOR_FIELD.CREATOR_ID);


### PR DESCRIPTION
## What broke

Archiving a Conductor cloud workspace from Luke stopped sticking: the press landed (Conductor answered `200` and filed the workspace away), but archived workspaces kept coming back as rows, and on heavy passes the Archive chip stopped being offered at all.

## Why

Conductor's `GET /v0/projects/{id}/workspaces` contract moved under the adapter:

- The listing now carries a **required `state` field** (`initializing | ready | sleeping | archived | deleted | updating` — the same value set as the lifecycle endpoint), confirmed against the live [OpenAPI spec](https://api.conductor.build/v0/openapi.json).
- The `archivedAt` timestamp the adapter filtered on is **no longer in the listing schema** (`additionalProperties: false`), so that filter can never fire again.
- The listing keeps every archived workspace in the page. Against the reporting account there are **341 workspaces in one project, 93 of the first page's 100 archived**, and the count grows by ~20/day.

With the listing mark unread, every pass fanned out one lifecycle read per listed workspace (~110 requests, observed live) just to re-discover which ones were archived, racing the 8-second request deadline every ~15 seconds. And because a lifecycle read that fails deliberately keeps its workspace ("a transient failure costs words, never rows"), **any one failed read on a long-archived workspace resurrected rows the user had already filed away** — which reads exactly as "archiving doesn't work anymore", getting worse as the archive pile grows.

## The fix

Read the listing's own documented mark: a workspace whose listed `state` is `archived` or `deleted` is dropped before a lifecycle or session read ever spends a request on it.

- An observation pass against the live API shrinks from **126 requests to 27**, with an identical roster and identical advertised controls (verified by running the adapter directly against `api.conductor.build` before and after).
- A resurrection is no longer possible: there is no per-workspace read left to fail for a workspace the listing already marked.
- The lifecycle read stays for the workspaces left standing — it still carries activity words and failure messages, still catches a filing-away the listing hasn't caught up with, and still decides for any listing state this build does not know.

Sessions are untouched: the session listing still documents `archivedAt`, and the adapter still honors it.

## Verification

- `./scripts/check.sh` passes (706 provider tests, full workspace green, exit 0). Portable-only change — no UI or macOS surface touched, so no visual evidence applies.
- Live before/after probe against `api.conductor.build`: same 7 observations, same Archive/Stop controls, 126 → 27 requests per pass.
- Updated tests: a listing-marked-archived workspace draws no row and costs zero further requests even when its lifecycle endpoint would fail; a lagging listing (`state: ready`, lifecycle `archived`) and an unknown future `state` still fall to the lifecycle read.

## Noted, not changed here

The listing pages 100 workspaces per project ordered by creation time, and archived workspaces now fill ~93% of the first page. At the current churn rate, an open workspace older than the newest ~100 will fall off the observed page entirely (today every open workspace is still on page one). Following `hasMore` deeper is cheap once archived rows are dropped at the listing, but widening the fan-out bound is a product decision per `CLAUDE.md`, so it is flagged here rather than bundled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/31345ad6-0dbc-46e8-b36f-ca62be4f5a6c)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32911459375/artifacts/9586713243) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32911459375)

- Commit: `a0dfefacd985448604ce1d6962ed1089e30dc6f3`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
