### PR TITLE
fix(voice): seed conversation history once per call

### DIFF
--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -1861,24 +1861,21 @@ test("the history is rendered from the roster as it now stands", async () => {
   });
   context.session.updateSessions([observedSession("session-a")]);
   context.session.updateConversation(history);
-  await armDeveloperTurn(context);
 
   // The words are history and keep their line; the identity is an offer to a
   // tool call, and a session the roster no longer shows is one no call may
   // name — so the line lets go of it rather than steering "that chat" toward
   // a certain refusal.
   context.session.updateSessions([]);
-  context.session.stopSpeaking();
-  const sentBefore = context.sent.length;
   await armDeveloperTurn(context);
 
-  const items = contextItems(context, "[recent conversation", sentBefore);
+  const items = contextItems(context, "[recent conversation");
   assert.equal(items.length, 1);
   assert.match(itemText(items[0]), /finished checkout-service/);
   assert.doesNotMatch(itemText(items[0]), /provider_session_id=session-a/);
 });
 
-test("a fresh history line replaces the item before it", async () => {
+test("the history is seeded once per call and later lines are not re-sent", async () => {
   const context = harness();
   await context.session.connect();
 
@@ -1888,9 +1885,13 @@ test("a fresh history line replaces the item before it", async () => {
   });
   context.session.updateConversation(first);
   await armDeveloperTurn(context);
-  const firstItem = context.session.liveContextItemIds.get(CONTEXT_ITEM_KIND.CONVERSATION);
-  assert.ok(firstItem);
+  const seeded = context.session.liveContextItemIds.get(CONTEXT_ITEM_KIND.CONVERSATION);
+  assert.ok(seeded);
 
+  // Every line said from here on rides this call as its own conversation
+  // items, so re-sending the digest would delete an item out of the cached
+  // prefix to restate turns the model already holds. The seed stands, and the
+  // new line waits for the next call.
   context.session.stopSpeaking();
   context.session.updateConversation(
     appendConversationEntry(first, {
@@ -1901,31 +1902,43 @@ test("a fresh history line replaces the item before it", async () => {
   const sentBefore = context.sent.length;
   await armDeveloperTurn(context);
 
-  // One live item per kind: the old record is deleted before the new goes in,
-  // so the conversation never holds two histories.
+  assert.deepEqual(contextItems(context, "[recent conversation", sentBefore), []);
   assert.equal(
-    context.sent.slice(sentBefore).some(
-      (event) =>
-        event.type === CONVERSATION_ITEM_DELETE &&
-        // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-        (event as { item_id?: string }).item_id === firstItem,
-    ),
-    true,
+    context.sent.slice(sentBefore).some((event) => event.type === CONVERSATION_ITEM_DELETE),
+    false,
   );
+  assert.equal(context.session.liveContextItemIds.get(CONTEXT_ITEM_KIND.CONVERSATION), seeded);
+});
+
+test("a new call after teardown re-seeds the accumulated history", async () => {
+  const context = harness();
+  await context.session.connect();
+
+  const first = conversationEntries({
+    kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
+    words: "Claude Code finished checkout-service.",
+  });
+  context.session.updateConversation(first);
+  await armDeveloperTurn(context);
+
+  const grown = appendConversationEntry(first, {
+    kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT,
+    words: "Codex failed in payments.",
+  });
+  context.session.updateConversation(grown);
+
+  // The call retires with everything said on it; the caller keeps the thread
+  // and re-reports it, and the next call seeds the whole of it.
+  context.closeChannel();
+  await context.session.connect();
+  context.session.updateConversation(grown);
+  const sentBefore = context.sent.length;
+  await armDeveloperTurn(context);
+
   const items = contextItems(context, "[recent conversation", sentBefore);
   assert.equal(items.length, 1);
   assert.match(itemText(items[0]), /finished checkout-service/);
   assert.match(itemText(items[0]), /failed in payments/);
-  assert.notEqual(
-    context.session.liveContextItemIds.get(CONTEXT_ITEM_KIND.CONVERSATION),
-    firstItem,
-  );
-
-  // The same history again is not news: nothing is resent.
-  context.session.stopSpeaking();
-  const repeatBefore = context.sent.length;
-  await armDeveloperTurn(context);
-  assert.deepEqual(contextItems(context, "[recent conversation", repeatBefore), []);
 });
 
 test("a reply ending at teardown writes nothing back into the retired call", async () => {

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -1990,7 +1990,9 @@ export class RealtimeVoiceSession {
     );
     // The history is rendered against the roster, so a fresh roster re-renders
     // it: a line whose session left the roster keeps its words and lets go of
-    // the identity no tool call may name any more.
+    // the identity no tool call may name any more. The render reaches the wire
+    // only until this call seeds its one history item; after that it keeps the
+    // staged copy current for nothing but teardown to clear.
     this.#rememberConversation();
   }
 
@@ -2001,7 +2003,9 @@ export class RealtimeVoiceSession {
    * heard the words it points back at: an announcement is often read out on
    * Luke's own speak-only call, which the developer's own press tears down,
    * and an idle call retires with everything said on it. Context on the
-   * roster's own terms, flushed with it at the turn that reads it.
+   * roster's own terms, flushed with it at the first turn of each call and
+   * left standing after that: what is said from then on lives in the call's
+   * own conversation items.
    */
   updateConversation(entries: readonly ConversationEntry[]): void {
     this.#conversationEntries = entries;
@@ -2119,6 +2123,14 @@ export class RealtimeVoiceSession {
       const pending = this.#contextPending.get(kind);
       if (!pending) continue;
       const live = this.#contextLive.get(kind);
+      // The history is seeded once per call. It exists to bridge the calls
+      // that came before this one, and every turn taken since it went in is
+      // already held by this call as real conversation items — so superseding
+      // it mid-call would delete an item out of the conversation's cached
+      // prefix to restate turns the model already has. The entries keep
+      // accumulating either way, and teardown clears the live map, so the
+      // next call seeds everything said by then.
+      if (kind === CONTEXT_ITEM_KIND.CONVERSATION && live) continue;
       if (live?.text === pending.text) continue;
       this.#contextSequence += 1;
       const itemId = contextItemId(kind, this.#contextSequence);


### PR DESCRIPTION
## What

The conversation-history context item is now created once per call, at the call's first developer turn, instead of being deleted and re-created on essentially every turn.

## Why

Every developer ask and Luke reply appends to the in-memory conversation history, the digest is re-serialized, and its text therefore changes on nearly every turn — so `#flushContext`'s diff-by-text superseded the live history item (`conversation.item.delete` + `conversation.item.create`) again and again within a single live call. That re-send is redundant: the Realtime session already holds those same turns as real conversation items, so the digest was restating what the model already had. It is also not free: deleting an item out of the middle of the conversation invalidates the session's cached prefix from that point on, so every turn paid a cache-miss cost to say nothing new.

The digest's actual job is to bridge one logical conversation across the calls that transport it — an announcement read out on Luke's own speak-only call, or a call retired at the 3-minute idle timeout, is still remembered by the next call. That bridging only needs the item at call open.

## How

- `#flushContext` skips the `CONVERSATION` kind whenever a live history item already stands, instead of diffing it by text. Entries still accumulate in memory (`updateConversation` keeps staging them), and teardown still clears `#contextLive`/`#contextPending`, so the next call seeds the full accumulated history naturally — `startConversation()` re-reports the caller's copy on every connect.
- The speak-only announcement call is untouched: `#carriesContext()` still requires the microphone, so it carries no context at all.
- Rendering the history against the freshest roster still holds for the seed itself: a roster change before the call's first turn re-renders the staged text, so the seeded item drops identities the roster no longer reports.

## Tests

- Reworked "a fresh history line replaces the item before it" into "the history is seeded once per call and later lines are not re-sent": a second turn after an appended entry sends no new history item, issues no delete, and keeps the seeded item id.
- Added "a new call after teardown re-seeds the accumulated history": after the channel closes and the caller re-reports the grown history, the new call's first turn seeds an item carrying both lines.
- Restructured "the history is rendered from the roster as it now stands" so the roster change lands before the first turn, keeping the identity-dropping behavior covered under the new semantics.

## Checks

`./scripts/check.sh` — exit 0; every workspace suite reports `fail 0` (apps/desktop: 777/777 tests pass, including the reworked and new history tests; packages/realtime: 119/119, unchanged).

`./scripts/verify.sh` was not run: this environment is Linux, and the change is portable behavior with no drawn UI change, so `check.sh` is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32913795017/artifacts/9587471519) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32913795017)

- Commit: `f35ea9a40ece6f16e908c7b8e1043cfca8ed8897`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
