### PR TITLE
fix(voice): keep roster context text stable across clock ticks

### DIFF
--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -1796,6 +1796,27 @@ test("an unchanged session roster is not resent", async () => {
   );
 });
 
+test("a stale session aging across clock ticks does not resend the roster", async (t) => {
+  const context = harness();
+  await context.session.connect();
+  // Six minutes past the fixture's observedAt, inside the minutes bucket.
+  t.mock.timers.enable({ apis: ["Date"], now: 1_800_000_360_000 });
+
+  context.session.updateSessions([observedSession("session-a")]);
+  await armDeveloperTurn(context);
+  const sentBefore = context.sent.length;
+
+  // Two minutes pass and the same roster is reported against the fresh clock.
+  // The bucketed age phrase holds still, so the item keeps its place and the
+  // conversation's cached prefix survives the tick.
+  t.mock.timers.tick(2 * 60_000);
+  context.session.updateSessions([observedSession("session-a")]);
+  context.session.stopSpeaking();
+  await armDeveloperTurn(context);
+
+  assert.deepEqual(contextItems(context, "[observed session status", sentBefore), []);
+});
+
 function conversationEntries(
   ...entries: readonly ConversationEntry[]
 ): readonly ConversationEntry[] {

--- a/packages/realtime/src/realtime-context.ts
+++ b/packages/realtime/src/realtime-context.ts
@@ -106,23 +106,39 @@ function prioritizedContextSessions(sessions: readonly Session[]): readonly Sess
 }
 
 /**
- * How long ago Luke last observed this session, as a prose phrase. "Updated"
+ * How long ago Luke last observed this session, in coarse buckets. "Updated"
  * names what observedAt actually measures — when Luke last received fresh data
  * from the provider — without implying anything about the session's current
- * activity level, which the status field already covers. Spelled out in full
- * units so it reads naturally in the conversation context and quotes back
- * clearly when the voice model names it aloud.
+ * activity level, which the status field already covers.
+ *
+ * Coarse deliberately: the roster travels again only when its text changes,
+ * and an unchanged item is what keeps the conversation's cached prefix warm —
+ * so the phrase must hold still across pure clock ticks and move only at a
+ * bucket edge a session actually crossed. An exact age would reword the whole
+ * roster every minute a stale session merely sat there, and the buckets are
+ * wide enough that an ordinary conversation crosses few edges.
  */
-function sessionAgeText(observedAt: number, now: number): string {
-  const elapsedMinutes = Math.floor((now - observedAt) / 60_000);
-  if (elapsedMinutes < 1) return "updated just now";
-  if (elapsedMinutes < 60)
-    return `updated ${elapsedMinutes} ${elapsedMinutes === 1 ? "minute" : "minutes"} ago`;
-  const elapsedHours = Math.floor(elapsedMinutes / 60);
-  if (elapsedHours < 24)
-    return `updated ${elapsedHours} ${elapsedHours === 1 ? "hour" : "hours"} ago`;
-  const elapsedDays = Math.floor(elapsedHours / 24);
-  return `updated ${elapsedDays} ${elapsedDays === 1 ? "day" : "days"} ago`;
+const SESSION_AGE_TEXT = {
+  JUST_NOW: "updated just now",
+  MINUTES: "updated minutes ago",
+  ABOUT_AN_HOUR: "updated about an hour ago",
+  HOURS: "updated hours ago",
+  DAY_OR_MORE: "updated a day or more ago",
+} as const;
+
+type SessionAgeText = (typeof SESSION_AGE_TEXT)[keyof typeof SESSION_AGE_TEXT];
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+function sessionAgeText(observedAt: number, now: number): SessionAgeText {
+  const elapsed = now - observedAt;
+  if (elapsed < 5 * MINUTE_MS) return SESSION_AGE_TEXT.JUST_NOW;
+  if (elapsed < HOUR_MS) return SESSION_AGE_TEXT.MINUTES;
+  if (elapsed < 2 * HOUR_MS) return SESSION_AGE_TEXT.ABOUT_AN_HOUR;
+  if (elapsed < DAY_MS) return SESSION_AGE_TEXT.HOURS;
+  return SESSION_AGE_TEXT.DAY_OR_MORE;
 }
 
 /**

--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -185,7 +185,7 @@ const REALTIME_INSTRUCTION_HEAD: readonly string[] = [
     "suggestion, offer, or question. If the result is what the user asked to hear (a transcript " +
     "reading, a check's answer, a provider with nowhere to open), speak it in full.",
   "- Do not mention internal identifiers such as commit hashes or session IDs, and do not read " +
-    'a roster line\'s bracketed capability data, ages ("updated two minutes ago"), or branches ' +
+    'a roster line\'s bracketed capability data, ages ("updated minutes ago"), or branches ' +
     "aloud unless asked, or unless they tell two agents apart.",
   "- A refusal is the reason in one sentence, with no apology.",
   "- When asked about the app itself, answer with the one relevant fact from the app guide, " +

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -862,46 +862,58 @@ test("an empty roster says so rather than implying Luke sees nothing at all", ()
   assert.match(sessionContextText([]), /No coding-agent sessions/);
 });
 
-test("the roster carries how long ago each session was last seen, measured against the supplied clock", () => {
+test("the roster carries how long ago each session was last seen, in coarse buckets", () => {
   const minute = 60_000;
+  const hour = 60 * minute;
   const now = DECIDED_AT;
+  const rosterAt = (elapsed: number): string => {
+    const session = normalizeSession(
+      { id: "claude-code", displayName: "Claude Code" },
+      {
+        providerSessionId: "session-a",
+        title: "Bootstrap the desktop shell",
+        status: SESSION_STATUS.WORKING,
+        observedAt: now - elapsed,
+      },
+    );
+    return sessionContextText([session], [], now);
+  };
+
+  assert.match(rosterAt(30_000), /updated just now/);
+  assert.match(rosterAt(4 * minute), /updated just now/);
+  assert.match(rosterAt(30 * minute), /updated minutes ago/);
+  assert.match(rosterAt(90 * minute), /updated about an hour ago/);
+  assert.match(rosterAt(5 * hour), /updated hours ago/);
+  assert.match(rosterAt(3 * 24 * hour), /updated a day or more ago/);
+
+  // Provider clock skew (observedAt ahead of now) also reads as "just now".
+  assert.match(rosterAt(-minute), /updated just now/);
+});
+
+test("the roster text holds still across clock ticks inside one age bucket and moves at its edge", () => {
+  const minute = 60_000;
+  const observedAt = DECIDED_AT;
   const session = normalizeSession(
     { id: "claude-code", displayName: "Claude Code" },
     {
       providerSessionId: "session-a",
       title: "Bootstrap the desktop shell",
       status: SESSION_STATUS.WORKING,
-      observedAt: now - 4 * minute,
+      observedAt,
     },
   );
 
-  const text = sessionContextText([session], [], now);
-
-  assert.match(text, /updated 4 minutes ago/);
-
-  // Under a minute reads as "just now".
-  const fresh = normalizeSession(
-    { id: "claude-code", displayName: "Claude Code" },
-    {
-      providerSessionId: "session-b",
-      title: "Fresh session",
-      status: SESSION_STATUS.WORKING,
-      observedAt: now - 30_000,
-    },
+  // Byte-identical, not merely similar: the roster is re-sent only when its
+  // text changes, and text that moved with every minute tick would invalidate
+  // the conversation's cached prefix with nothing new to say.
+  assert.equal(
+    sessionContextText([session], [], observedAt + 10 * minute),
+    sessionContextText([session], [], observedAt + 45 * minute),
   );
-  assert.match(sessionContextText([fresh], [], now), /updated just now/);
-
-  // Provider clock skew (observedAt ahead of now) also reads as "just now".
-  const ahead = normalizeSession(
-    { id: "claude-code", displayName: "Claude Code" },
-    {
-      providerSessionId: "session-c",
-      title: "Clock-skewed session",
-      status: SESSION_STATUS.WORKING,
-      observedAt: now + minute,
-    },
+  assert.notEqual(
+    sessionContextText([session], [], observedAt + 45 * minute),
+    sessionContextText([session], [], observedAt + 65 * minute),
   );
-  assert.match(sessionContextText([ahead], [], now), /updated just now/);
 });
 
 test("the roster identifies the most recent session and most recent openable chat per provider", () => {


### PR DESCRIPTION
## The spurious re-send

`#flushContext` in `apps/desktop/src/renderer/realtime-session.ts` diffs each context kind by exact string compare before re-sending, which is what keeps a quiet stretch of the conversation cached server-side. But `sessionAgeText` in `packages/realtime/src/realtime-context.ts` baked exact relative phrasing ("updated 3 minutes ago") into the serialized roster, and `updateSessions` passes a fresh `Date.now()` on every 5-second roster poll. So any stale session crossing a minute boundary reworded its line, the diff saw a "change", and the entire 25-session roster item was deleted and re-created — with zero real news, invalidating the prompt-cache prefix behind it every minute a stale session merely sat there. The repo already treats this class of churn as a bug: `luke-guide.ts` strips download-progress percentages because "the guide re-sends its context whenever its text changes, and a percent tick is not news."

## Why quantize rather than drop

The age is genuinely useful to the model — the protocol instructions let ages tell two agents apart, and "which session went quiet ages ago" is a real question — so the phrase stays but quantizes into five coarse buckets: just now (< 5 min), minutes ago (< 1 h), about an hour ago (< 2 h), hours ago (< 1 day), a day or more ago. Text now moves only at a bucket edge a session actually crossed, and the edges are wide enough that an ordinary conversation crosses few of them; an actively observed session refreshes its `observedAt` anyway and stays in the freshest bucket. The bucket is an `as const` value set with a derived union per the repo's TypeScript rules, and the protocol's example age phrase ("updated two minutes ago") follows the new wording.

## Tests

- `packages/realtime/src/realtime.test.ts`: the age test now covers every bucket plus clock skew, and a new test asserts the serialized roster is byte-identical for two clocks inside one bucket and differs across a bucket edge.
- `apps/desktop/src/renderer/realtime-session.test.ts`: a new test mocks `Date`, ticks the clock two minutes between two identical roster reports, and asserts nothing is resent. Verified it fails against the previous `sessionAgeText` (the tick alone reworded the roster and resent it) and passes now.

Genuine status/recap churn on the 5-second poll is real news and deliberately untouched; only the clock-tick churn is addressed.

## Checks

`./scripts/check.sh` passes (exit 0; all package tests green, including 120 realtime and 777 desktop tests). `./scripts/verify.sh` was not run because this environment is Linux; the change is portable with no drawn UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32913855161/artifacts/9587482878) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32913855161)

- Commit: `fb16e320836744a09ea1784bb0ad3f47a200fa11`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
