### PR TITLE
feat(voice): carry the app guide in session instructions

### DIFF
--- a/apps/desktop/src/renderer/AGENTS.md
+++ b/apps/desktop/src/renderer/AGENTS.md
@@ -122,8 +122,12 @@ against its rock deliberately, like a person mid-sentence.
 `apps/desktop/src/renderer/luke-guide.ts` is the one place Luke's
 self-knowledge is described: what Luke is on screen, every user-facing setting
 with its current value, and where each is changed by hand. The renderer builds
-an `AppGuideSnapshot` from it and sends it into the voice conversation as
-`[app guide]` context, the same way the session roster travels; the spoken
+an `AppGuideSnapshot` from it and sends it into the voice conversation inside
+the session's own instructions, behind an `[app guide]` marker — build-fixed
+prose belongs on the cacheable prefix rather than in a conversation item —
+refreshed by a `session.update` on the same economy the roster items keep: at
+the turn that reads it, only on the developer's call, and never re-sent
+unchanged. The spoken
 `change_app_setting` and `show_panel` tools are validated against that
 snapshot, so the guide is simultaneously what Luke can say about himself and
 the outer bound of what a spoken ask can do to him.

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -313,8 +313,9 @@ const UPDATE_BUTTON_FOR_ROW_ACTION = {
 /**
  * The guide's Updates entry, read from the same row the settings page draws
  * so the sentence out loud and the button on screen can never disagree. The
- * download's progress is stripped before the row is read: the guide re-sends
- * its context whenever its text changes, and a percent tick is not news.
+ * download's progress is stripped before the row is read: the guide refreshes
+ * the session instructions whenever its text changes, and a percent tick is
+ * not news.
  */
 function updateGuideEntry(update: UpdateSnapshot): AppGuideUpdate {
   const steady =

--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -28,7 +28,7 @@ import {
   type Session,
   WORKSPACE_TASK_SUPPORT,
 } from "@sidecar/session";
-import { isRecord } from "@sidecar/wire";
+import { isRecord, text } from "@sidecar/wire";
 import type { JsonValue, ParsedJsonObject } from "@sidecar/wire/testing";
 import {
   asMediaStream,
@@ -470,6 +470,17 @@ function contextItems(context: Harness, label: string, from = 0): ParsedJsonObje
         event.type === REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE &&
         itemText(event).startsWith(label),
     );
+}
+
+/** The instructions each guide-carrying session update sent, oldest first. */
+function guideInstructionUpdates(context: Harness, from = 0): string[] {
+  return context.sent
+    .slice(from)
+    .filter((event) => event.type === REALTIME_CLIENT_EVENT.SESSION_UPDATE)
+    .flatMap((event) => {
+      const instructions = text(sessionField(event)?.instructions);
+      return instructions !== undefined ? [instructions] : [];
+    });
 }
 
 /** The errors actually shown, past the clearing every connect starts with. */
@@ -4240,16 +4251,29 @@ const CAPTIONS_GUIDE: AppGuideSnapshot = {
   ],
 };
 
-test("the app guide reaches the conversation, and identical guides are not resent", async () => {
+test("the app guide rides the session instructions, and identical guides are not resent", async () => {
   const context = harness();
   await context.session.connect();
 
   context.session.updateGuide(CAPTIONS_GUIDE);
   // The same knowledge again is not news; a changed value is. Neither is worth
-  // an item on its own — the turn that asks is what collects the latest.
+  // an update on its own — the turn that asks is what collects the latest.
   context.session.updateGuide({ ...CAPTIONS_GUIDE });
   await armDeveloperTurn(context);
-  assert.equal(contextItems(context, "[app guide").length, 1);
+  const updates = guideInstructionUpdates(context);
+  assert.equal(updates.length, 1);
+  // The guide is instructions now, never a conversation item: the standing
+  // prompt stays the stable prefix and the guide travels appended behind it.
+  assert.match(updates[0] ?? "", /engineering manager for the developer's coding agents/i);
+  assert.match(updates[0] ?? "", /setting_id=voice_captions/);
+  assert.match(updates[0] ?? "", /value=off/);
+  assert.deepEqual(contextItems(context, "[app guide"), []);
+
+  // A turn opened over an unchanged guide re-sends nothing: the instructions
+  // the call already holds are still true.
+  context.session.stopSpeaking();
+  await armDeveloperTurn(context);
+  assert.equal(guideInstructionUpdates(context).length, 1);
 
   const sentBefore = context.sent.length;
   context.session.updateGuide({
@@ -4262,9 +4286,9 @@ test("the app guide reaches the conversation, and identical guides are not resen
   context.session.stopSpeaking();
   await armDeveloperTurn(context);
 
-  const guideEvents = contextItems(context, "[app guide", sentBefore);
-  assert.equal(guideEvents.length, 1);
-  assert.match(itemText(guideEvents[0]), /on/);
+  const refreshed = guideInstructionUpdates(context, sentBefore);
+  assert.equal(refreshed.length, 1);
+  assert.match(refreshed[0] ?? "", /value=on/);
 });
 
 test("a spoken settings change is validated against the guide and carried", async () => {
@@ -5138,6 +5162,26 @@ test("the rosters and the guide never travel on Luke's own call", async () => {
   // The stores still updated — the developer's next call starts current — but
   // nothing left on this one beyond the sentence it exists to say.
   assert.equal(context.sent.length, before);
+
+  // Even the announcement it exists for carries no guide: the readout is the
+  // update's own fields and the ask for the reply, with no instructions
+  // refresh riding ahead of them.
+  assert.equal(
+    context.session.speak({
+      providerId: "claude-code",
+      providerSessionId: "session-a",
+      disposition: ATTENTION_DISPOSITION.SPEAK_AT_TURN_END,
+      source: ATTENTION_SPEECH_SOURCE.NOTICE_REQUEST,
+      summary: "Claude Code finished checkout-service.",
+      decidedAt: 1_800_000_000_000,
+    }),
+    true,
+  );
+  assert.deepEqual(guideInstructionUpdates(context, before), []);
+  assert.deepEqual(
+    context.sent.slice(before).map((event) => event.type),
+    [REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE, REALTIME_CLIENT_EVENT.RESPONSE_CREATE],
+  );
 });
 
 test("an idle call is put away, and a call being used is not", async () => {

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -4,7 +4,7 @@ import type { TrackedIssue } from "@sidecar/issues";
 import {
   type ActEnvelope,
   type AttentionSpeech,
-  appGuideContextEvents,
+  appGuideInstructionsEvents,
   appToolAction,
   type CarriedAppAction,
   type CarriedIssueAction,
@@ -103,14 +103,14 @@ export const VOICE_IDLE_TIMEOUT_MS = 3 * 60_000;
 /**
  * The order context is flushed in, so a turn's items land the same way every
  * time: what Luke can see, then what was already said across calls, then
- * where he can create, then what he knows about himself, then what the
- * tracker lists.
+ * where he can create, then what the tracker lists. What Luke knows about
+ * himself is not an item at all: the guide rides the session instructions,
+ * flushed ahead of these.
  */
 const CONTEXT_FLUSH_ORDER: readonly ContextItemKind[] = [
   CONTEXT_ITEM_KIND.SESSIONS,
   CONTEXT_ITEM_KIND.CONVERSATION,
   CONTEXT_ITEM_KIND.WORKSPACE_PROJECTS,
-  CONTEXT_ITEM_KIND.APP_GUIDE,
   CONTEXT_ITEM_KIND.ISSUES,
 ];
 
@@ -458,6 +458,16 @@ export class RealtimeVoiceSession {
    * call may only name a setting Luke was actually described as having.
    */
   #guide: AppGuideSnapshot = EMPTY_APP_GUIDE;
+  /**
+   * The guide's rendered text, waiting to ride the session instructions, and
+   * the text the call's instructions last carried. The guide is not a context
+   * item: it is the same build-fixed prose on every turn, so it travels as a
+   * `session.update` refreshing the instructions — a stable prefix the
+   * service can cache — held here on the items' own economy: sent at the
+   * turn that reads it, and an unchanged guide sends nothing at all.
+   */
+  #guideTextPending: string | undefined;
+  #guideTextLive: string | undefined;
   /**
    * The projects a workspace can be created in, as last reported — kept whole
    * for the same reason the roster is: a spoken creation ask may only name a
@@ -1649,6 +1659,8 @@ export class RealtimeVoiceSession {
     // is filled from the app afresh before it takes a turn.
     this.#contextPending.clear();
     this.#contextLive.clear();
+    this.#guideTextPending = undefined;
+    this.#guideTextLive = undefined;
     this.#pendingSupersedes.clear();
     this.#pendingInterruptions.clear();
     this.#clearIdleTimer();
@@ -2047,17 +2059,17 @@ export class RealtimeVoiceSession {
   }
 
   /**
-   * Tells the conversation what Luke currently knows about himself, the same
-   * way the roster does: the standing instructions promise an app guide, so
-   * one has to arrive before a question about Luke can be answered from real
-   * state. Identical guides are not resent, and the snapshot is kept whole for
-   * validating the spoken asks it advertises.
+   * Tells the conversation what Luke currently knows about himself. The guide
+   * rides the session instructions rather than a context item — build-fixed
+   * prose belongs on the cacheable prefix, not in a user message competing
+   * with the conversation — but it travels on the items' own terms: at the
+   * turn that reads it, only on the developer's call, and identical guides
+   * are not resent. The snapshot is kept whole for validating the spoken asks
+   * it advertises.
    */
   updateGuide(guide: AppGuideSnapshot): void {
     this.#guide = guide;
-    this.#rememberContext(CONTEXT_ITEM_KIND.APP_GUIDE, appGuideContextText(guide), (itemId) =>
-      appGuideContextEvents(guide, itemId),
-    );
+    this.#guideTextPending = appGuideContextText(guide);
   }
 
   /**
@@ -2115,6 +2127,13 @@ export class RealtimeVoiceSession {
    */
   #flushContext(): void {
     if (!this.#carriesContext()) return;
+    // The guide leads the items: it refreshes the instructions rather than
+    // occupying a conversation item, so there is nothing to supersede and an
+    // unchanged guide leaves the cached prefix exactly where it was.
+    if (this.#guideTextPending !== undefined && this.#guideTextPending !== this.#guideTextLive) {
+      this.#send(appGuideInstructionsEvents(this.#guideTextPending));
+      this.#guideTextLive = this.#guideTextPending;
+    }
     for (const kind of CONTEXT_FLUSH_ORDER) {
       const pending = this.#contextPending.get(kind);
       if (!pending) continue;

--- a/packages/realtime/src/guide.test.ts
+++ b/packages/realtime/src/guide.test.ts
@@ -15,32 +15,18 @@ import {
   SESSION_LIST_SORT,
 } from "@sidecar/guide";
 import {
-  appGuideContextEvents,
+  appGuideInstructionsEvents,
   appToolAction,
   isAppToolCall,
   REALTIME_CLIENT_EVENT,
   type RealtimeFunctionCall,
+  realtimeInstructions,
   SESSION_LIST_VOICE,
 } from "@sidecar/realtime";
 import { normalizeSession, SESSION_LOCATION, SESSION_STATUS } from "@sidecar/session";
-import { ACT_RESULT_STATUS, isRecord, text, type WireRecord } from "@sidecar/wire";
+import { ACT_RESULT_STATUS, isRecord, text } from "@sidecar/wire";
 import { maximumFeedbackDraftLength } from "./realtime-protocol.js";
 import { REALTIME_TOOL } from "./realtime-tools.js";
-
-function conversationItem(event: WireRecord | undefined): WireRecord | undefined {
-  if (!event) return undefined;
-  const item = event.item;
-  return isRecord(item) ? item : undefined;
-}
-
-function conversationItemText(event: WireRecord | undefined): string {
-  const item = conversationItem(event);
-  if (!item) return "";
-  const content = item.content;
-  if (!Array.isArray(content)) return "";
-  const first = content[0];
-  return isRecord(first) ? (text(first.text) ?? "") : "";
-}
 
 const GUIDE: AppGuideSnapshot = {
   facts: [
@@ -135,18 +121,28 @@ test("an empty guide says so rather than describing an app it was never told abo
   assert.match(appGuideContextText(EMPTY_APP_GUIDE), /has not been provided/);
 });
 
-test("the guide travels as context and never opens Luke's mouth", () => {
-  const events = appGuideContextEvents(GUIDE, "luke_ctx_app-guide_1");
+test("the guide rides the session instructions and never opens Luke's mouth", () => {
+  const events = appGuideInstructionsEvents(appGuideContextText(GUIDE));
 
   assert.equal(events.length, 1);
-  assert.equal(events[0]?.type, REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE);
-  const item = conversationItem(events[0]);
-  assert.equal(text(item?.role), "user");
-  assert.match(conversationItemText(events[0]), /^\[app guide, sent automatically\]/);
+  assert.equal(events[0]?.type, REALTIME_CLIENT_EVENT.SESSION_UPDATE);
+  const session = isRecord(events[0]?.session) ? events[0].session : undefined;
+  const instructions = text(session?.instructions) ?? "";
+  // The standing instructions stay the stable prefix the service can cache;
+  // the guide is appended behind its marker as data, never as a new prompt.
+  assert.ok(instructions.startsWith(realtimeInstructions()));
+  assert.match(instructions, /\[app guide\]/);
+  assert.match(instructions, /setting_id=voice_captions/);
+  // A partial update: the tools the call opened with are not touched, so the
+  // guide can never widen or narrow what a turn may do.
+  assert.equal(session !== undefined && "tools" in session, false);
   assert.equal(
     events.some((event) => event.type === REALTIME_CLIENT_EVENT.RESPONSE_CREATE),
     false,
   );
+
+  // Blank text builds nothing rather than erasing the standing instructions.
+  assert.deepEqual(appGuideInstructionsEvents("   "), []);
 });
 
 test("a spoken toggle accepts the unambiguous words and nothing else", () => {

--- a/packages/realtime/src/index.ts
+++ b/packages/realtime/src/index.ts
@@ -28,7 +28,6 @@ export {
   PressAudioBuffer,
 } from "./press-audio.js";
 export {
-  appGuideContextEvents,
   CONTEXT_ITEM_KIND,
   type ContextItemKind,
   contextItemId,
@@ -60,6 +59,7 @@ export {
   ATTENTION_SPEECH_SOURCE,
   type AttentionSpeech,
   announcementSummaryText,
+  appGuideInstructionsEvents,
   attentionSpeechFromReviews,
   cancelResponseEvents,
   clearInputAudioEvents,

--- a/packages/realtime/src/realtime-context.ts
+++ b/packages/realtime/src/realtime-context.ts
@@ -1,5 +1,4 @@
 import type { SessionNoticeAsk } from "@sidecar/attention";
-import { type AppGuideSnapshot, appGuideContextText } from "@sidecar/guide";
 import type { TrackedIssue } from "@sidecar/issues";
 import {
   type ObservedWorkspaceProject,
@@ -14,8 +13,10 @@ import { REALTIME_CLIENT_EVENT } from "./realtime-protocol.js";
 
 /**
  * Roster context serialization: the bounded, redacted view of sessions, issues,
- * workspace projects, and the app guide that a conversation is allowed to know
- * about. Context, never a prompt — arriving must not open Luke's mouth.
+ * and workspace projects that a conversation is allowed to know about.
+ * Context, never a prompt — arriving must not open Luke's mouth. The app
+ * guide deliberately does not travel this way: it is build-fixed prose, so it
+ * rides the session instructions instead of a conversation item.
  */
 
 /**
@@ -262,8 +263,7 @@ export function sessionContextText(
 /**
  * The kinds of context a conversation is told, each of which answers exactly
  * one standing question: what Luke can see, what was already said across
- * calls, where he can create, what he knows about himself, and what the
- * tracker lists.
+ * calls, where he can create, and what the tracker lists.
  *
  * A kind holds one live item at a time. Saying it again replaces the item that
  * said it before rather than adding a second answer beside the first, because
@@ -274,7 +274,6 @@ export const CONTEXT_ITEM_KIND = {
   SESSIONS: "sessions",
   CONVERSATION: "conversation",
   WORKSPACE_PROJECTS: "workspace-projects",
-  APP_GUIDE: "app-guide",
   ISSUES: "issues",
 } as const;
 
@@ -556,17 +555,4 @@ export function workspaceProjectContextEvents(
       itemId,
     ),
   ];
-}
-
-/**
- * Builds the event that tells the conversation what the app knows about
- * itself. The same shape as the session roster, for the same reason: the
- * standing instructions describe a guide, so one has to actually arrive, and
- * it must never open Luke's mouth by itself — context, not a prompt.
- */
-export function appGuideContextEvents(
-  guide: AppGuideSnapshot,
-  itemId: string,
-): readonly WireRecord[] {
-  return [labeledContextEvent("app guide, sent automatically", appGuideContextText(guide), itemId)];
 }

--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -215,9 +215,45 @@ function trimmedText(value: string | undefined): string | undefined {
   return normalized || undefined;
 }
 
-/** The standing instructions that give Luke its spoken voice and its limits. */
-export function realtimeInstructions(): string {
-  return REALTIME_INSTRUCTION_HEAD.join("\n");
+/**
+ * The marker the app guide stands behind inside the instructions. The guide
+ * is observed data riding the standing prompt — settings values, versions —
+ * so it is fenced off from the instruction text above it the same way every
+ * observed value the conversation sees is labelled as data.
+ */
+const APP_GUIDE_INSTRUCTIONS_MARKER = "[app guide]";
+
+/**
+ * The standing instructions that give Luke its spoken voice and its limits.
+ *
+ * The guide rides here rather than as a conversation item because it is the
+ * same build-fixed prose on every turn: instructions are a stable prefix the
+ * service can cache, where a user message re-created on each change is paid
+ * for out of the window the developer's own turns are evicted from.
+ */
+export function realtimeInstructions(guideText?: string): string {
+  const guide = guideText?.trim();
+  const lines = guide
+    ? [...REALTIME_INSTRUCTION_HEAD, APP_GUIDE_INSTRUCTIONS_MARKER, guide]
+    : REALTIME_INSTRUCTION_HEAD;
+  return lines.join("\n");
+}
+
+/**
+ * Builds the event that carries the app guide on a live call, as a refresh of
+ * the session's own instructions. Only the instructions travel: the update is
+ * a partial one, so the tools and audio the call opened with stay exactly as
+ * the sync asserted them. Blank text builds nothing rather than an update
+ * that would erase the standing instructions.
+ */
+export function appGuideInstructionsEvents(guideText: string): readonly WireRecord[] {
+  if (!guideText.trim()) return [];
+  return [
+    {
+      type: REALTIME_CLIENT_EVENT.SESSION_UPDATE,
+      session: { type: REALTIME_SESSION_TYPE, instructions: realtimeInstructions(guideText) },
+    },
+  ];
 }
 
 /** Clears audio already queued for playback, naming the request for error correlation. */

--- a/packages/realtime/src/realtime.test.ts
+++ b/packages/realtime/src/realtime.test.ts
@@ -10,11 +10,9 @@ import {
   maximumAttentionRequestLength,
   maximumAttentionSummaryLength,
 } from "@sidecar/attention";
-import { EMPTY_APP_GUIDE } from "@sidecar/guide";
 import { ISSUE_TRACKER_ID, normalizeTrackedIssue } from "@sidecar/issues";
 import {
   ATTENTION_SPEECH_SOURCE,
-  appGuideContextEvents,
   attentionSpeechFromReviews,
   CONTEXT_ITEM_KIND,
   cancelResponseEvents,
@@ -203,9 +201,8 @@ test("every kind of context travels as one nameable item and never as a prompt",
   const built = [
     sessionContextEvents([], contextItemId(CONTEXT_ITEM_KIND.SESSIONS, 1)),
     workspaceProjectContextEvents([], contextItemId(CONTEXT_ITEM_KIND.WORKSPACE_PROJECTS, 2)),
-    appGuideContextEvents(EMPTY_APP_GUIDE, contextItemId(CONTEXT_ITEM_KIND.APP_GUIDE, 3)),
-    issueContextEvents([], contextItemId(CONTEXT_ITEM_KIND.ISSUES, 4)),
-    issueTrackerDisconnectedEvents(contextItemId(CONTEXT_ITEM_KIND.ISSUES, 5)),
+    issueContextEvents([], contextItemId(CONTEXT_ITEM_KIND.ISSUES, 3)),
+    issueTrackerDisconnectedEvents(contextItemId(CONTEXT_ITEM_KIND.ISSUES, 4)),
   ];
 
   for (const events of built) {


### PR DESCRIPTION
## Why

The app guide — what Luke knows about himself — is ~16–18 KB of build-fixed prose, the same on every turn. It traveled as a `conversation.item.create` user message beside the four observed context kinds, which is the wrong vehicle for static content: each guide change deleted the old item and created a new one mid-conversation, moving the cached prefix and spending window the developer's own turns are evicted from. The Realtime session's `instructions` are the right home — a stable, cacheable prefix the service holds outside the conversation — so the guide now rides there, appended behind an `[app guide]` marker after the standing instruction head, which stays byte-identical as the prefix.

## How

- `realtimeInstructions()` takes an optional guide text and appends it behind the marker; called bare (the mint, the connect-time sync) it is unchanged, so nothing new reaches the speak-only call or the introduction.
- New `appGuideInstructionsEvents(guideText)` in `@sidecar/realtime` builds one partial `session.update` carrying only the refreshed instructions — tools and audio are untouched, so the guide can never widen what a turn may do.
- `RealtimeVoiceSession.updateGuide` keeps the snapshot whole for validation and holds the rendered text pending; `#flushContext` sends the instructions refresh ahead of the context items, on the items' own economy: at the developer-opened turn that reads it, diffed by text, so **an unchanged guide sends nothing** and a mid-call guide change (settings, integration facts, update-row state) is a follow-up `session.update` at the next turn.
- The flush is gated by the same `#carriesContext()` check as the rosters, and `speak()` never flushes, so **the speak-only announcement call stays guide-free** exactly as it was context-free — it already received only the base instructions via the connect sync, and still does.
- `APP_GUIDE` is removed from `CONTEXT_ITEM_KIND` and the flush order; `appGuideContextEvents` is deleted rather than stubbed. Renderer `AGENTS.md` and the affected comments now describe the instructions carriage.

## Tests

- The guide lands in `session.update` instructions on the developer call (standing head as prefix, guide behind the marker) and never as a `[app guide]` conversation item.
- A turn over an unchanged guide sends no further instructions update; a changed value sends exactly one carrying it.
- The speak-only call receives no guide on update or on an announcement readout (announcement is still item + `response.create` alone).
- Builder-level coverage: partial update (no tools), no `response.create`, blank text builds nothing.

## Checks

`./scripts/check.sh` — exit 0: lint (biome + oxlint), typecheck, tests (2292 pass / 0 fail across the workspace), and builds all pass. `./scripts/verify.sh` was not run because this environment is Linux; the change is portable (renderer/session logic and packages only, no macOS surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32914317034/artifacts/9587668421) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32914317034)

- Commit: `bd847ba5d2509b3312d4971b516055caf91f6084`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
