### PR TITLE
docs(replicas): correct the accidental-wake billing rationale

### DIFF
--- a/packages/providers/src/replicas/adapter.ts
+++ b/packages/providers/src/replicas/adapter.ts
@@ -1101,11 +1101,19 @@ export class ReplicasSessionAdapter extends CloudSessionAdapter {
    * agent for a row with no chats to say so. The read is documented to wake
    * a sleeping or archived workspace, so it is issued only for a workspace
    * the same pass's list just reported awake, where there is nothing to
-   * wake; a workspace that fell asleep in the second between the two reads
-   * would be woken back, which Replicas prices at nothing and the next pass
-   * reports honestly, but the window is a second against a lifecycle
-   * measured in hours. Failures are contained the way every enrichment's
-   * are. It is also the fallback chat source: a workspace the registry did
+   * wake. The read itself counts as no activity: verified live, an idle
+   * workspace polled every fifteen seconds kept its last-activity stamp
+   * unmoved and slept exactly on its one-hour idle schedule under that
+   * polling, so steady-state polling extends no billed runtime. What can
+   * cost is the race: a workspace that fell asleep in the second between
+   * the two reads would be woken back, and while the wake itself is
+   * unpriced, Replicas meters every awake minute of a workspace created by
+   * the API or an automation until its idle timeout re-sleeps it, an hour
+   * by default, so one accidental wake can bill that timeout's worth of
+   * minutes, where a manually created workspace bills nothing under the
+   * seat. The next pass reports the wake honestly, and the window is a
+   * second against a lifecycle measured in hours. Failures are contained
+   * the way every enrichment's are. It is also the fallback chat source: a workspace the registry did
    * not answer for this pass still lists its chats here, turn state
    * included, so an awake workspace's rows survive the registry's
    * organization-header demands.


### PR DESCRIPTION
## What

Corrects the `#refreshDetails` doc comment in `packages/providers/src/replicas/adapter.ts`, which claimed a workspace accidentally woken by the detail read is something "Replicas prices at nothing." That claim is wrong.

## The correction

- Per docs.replicas.dev/admin/billing and the OpenAPI spec, Replicas meters awake minutes for workspaces created by the API or an automation ($0.008/min small, $0.016/min large past the plan allowance). Manually created workspaces (app/Slack/CLI) bill nothing under the seat subscription.
- The wake itself is unpriced, but a woken API/automation-source workspace bills every awake minute until its idle timeout re-sleeps it — one hour by default — so one accidental wake in the list/detail race window can cost up to that timeout's worth of metered minutes.
- Verified live (2026-08-25): `GET /v1/replica/{id}` on an active workspace does not count as activity. An idle workspace polled at a 15-second cadence kept `last_activity_at` unmoved and auto-slept exactly on its one-hour schedule under that polling. Steady-state detail polling therefore extends no billed runtime; only the accidental wake in the race window costs anything.

The diff is confined to that one doc comment — no code, no other comments — so it rebases trivially against the in-flight sibling PRs touching this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32914575207/artifacts/9587742435) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32914575207)

- Commit: `d66b442435e2df80c9fffb3e249951a166f6c09b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
