### PR TITLE
feat(replicas): create workspaces with the sleep-when-done lifecycle

### DIFF
--- a/packages/providers/src/replicas/adapter.test.ts
+++ b/packages/providers/src/replicas/adapter.test.ts
@@ -776,11 +776,15 @@ test("offers the reported environments as projects and creates a workspace in on
   assert.equal(write?.method, "POST");
   assert.equal(write?.pathname, "/v1/replica");
   // The required name is the developer's own words slugged the way the
-  // dashboard slugs one; the task rides as the required initial message.
+  // dashboard slugs one; the task rides as the required initial message; and
+  // the lifecycle asks for sleep-when-done, because an API-created workspace
+  // left on the default lifecycle sits awake and metered for the full
+  // inactivity timeout after its agent finishes.
   assert.deepEqual(JSON.parse(write?.body ?? ""), {
     name: "fix-the-login-timeout-and-open-a-pull-request",
     message: "Fix the login timeout and open a pull request",
     environment_id: "environment-luke",
+    lifecycle_policy: "sleep_when_done",
   });
 
   // A task-less ask is refused rather than a workspace created idle.

--- a/packages/providers/src/replicas/adapter.ts
+++ b/packages/providers/src/replicas/adapter.ts
@@ -164,6 +164,7 @@ const REPLICAS_FIELD = {
   ID: "id",
   IS_GLOBAL: "is_global",
   LAST_ACTIVITY_AT: "last_activity_at",
+  LIFECYCLE_POLICY: "lifecycle_policy",
   MESSAGE: "message",
   MODEL: "model",
   NAME: "name",
@@ -182,6 +183,15 @@ const REPLICAS_FIELD = {
   TYPE: "type",
   UPDATED_AT: "updated_at",
   URL: "url",
+} as const;
+
+/**
+ * The one lifecycle a creation asks for, out of the four the endpoint
+ * documents. Sleep-when-done is the only one this build sends because the
+ * others either meter, archive, or delete what the developer just made.
+ */
+const REPLICAS_LIFECYCLE_POLICY = {
+  SLEEP_WHEN_DONE: "sleep_when_done",
 } as const;
 
 const REPLICAS_STATUS = {
@@ -988,6 +998,12 @@ export class ReplicasSessionAdapter extends CloudSessionAdapter {
    * is the initial message the endpoint requires; the agent choice is left
    * to the environment's own default, because this build fixes no
    * agent-and-model table for Replicas and a choice not offered is not sent.
+   * The lifecycle is asked for rather than defaulted: an API-created
+   * workspace is metered per awake minute, and the default lifecycle leaves
+   * it awake — and metered — for the full inactivity timeout after its agent
+   * finishes, so the creation names sleep-when-done, which stops the meter
+   * the moment the work ends while the documented message-wake keeps every
+   * follow-up working on the workspace it put to sleep.
    */
   protected override workspaceCreationRoute(
     project: WorkspaceProject,
@@ -1005,6 +1021,7 @@ export class ReplicasSessionAdapter extends CloudSessionAdapter {
         [REPLICAS_FIELD.NAME]: replicasWorkspaceName(name ?? task),
         [REPLICAS_FIELD.MESSAGE]: task,
         [REPLICAS_FIELD.ENVIRONMENT_ID]: project.providerProjectId,
+        [REPLICAS_FIELD.LIFECYCLE_POLICY]: REPLICAS_LIFECYCLE_POLICY.SLEEP_WHEN_DONE,
       },
     };
   }


### PR DESCRIPTION
## Why

Workspaces Luke creates through the documented `POST /v1/replica` endpoint are billed by Replicas as automated minutes — metered per awake minute ($0.008/min small, $0.016/min large past the plan allowance) — unlike manual dashboard-created workspaces, which are free under the seat. The creation body previously sent only `name`, `message`, and `environment_id`, so a created workspace got the default lifecycle: after its agent finishes, it sits awake and metered for the full one-hour inactivity timeout before auto-sleeping — up to ~60 unnecessary metered minutes per creation. Verified live on 2026-08-25: a Luke-created workspace's agent finished at 22:41Z and the workspace slept at 23:44Z.

## What

The creation body now names `lifecycle_policy: "sleep_when_done"`, one of the endpoint's documented enum values. The workspace sleeps when its agent finishes (after background tasks complete), accrues no charges asleep, and retains its chats and branch. Replicas documents that sending a message wakes a sleeping workspace automatically, and the adapter's `REPLICAS_MESSAGEABLE_STATUSES` already includes sleeping, so follow-up messages from Luke keep working unchanged.

Per the repository's value-set rules, the key is a `REPLICAS_FIELD.LIFECYCLE_POLICY` entry and the value comes from a new `REPLICAS_LIFECYCLE_POLICY` `as const` set; the creation test's exact-body assertion is extended to cover the new field. No data-flow character changes — the field is a build-fixed literal — so `PRIVACY.md` and the README are untouched.

## Tradeoff

A follow-up message to a finished workspace waits 30–90s for the documented wake instead of landing instantly on a still-awake one.

## Product decision

The repository owner approved this product decision in conversation on 2026-08-26.

## Checks

`./scripts/check.sh` passes (portable-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32914608186/artifacts/9587765311) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32914608186)

- Commit: `df3b37940993df2ae7afa4e8540e4afaa4da1c89`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
