### PR TITLE
feat(replicas): surface an accidental workspace wake as a diagnostic

### DIFF
--- a/packages/providers/src/replicas/adapter.test.ts
+++ b/packages/providers/src/replicas/adapter.test.ts
@@ -52,6 +52,8 @@ interface TestWorkspace {
   historyEvents?: readonly JsonObject[];
   refuseHistory?: boolean;
   chats?: readonly TestChat[];
+  /** The detail read woke this workspace: it fell asleep after the list. */
+  waking?: boolean;
 }
 
 interface TestEnvironment {
@@ -301,7 +303,7 @@ function fakeReplicasApi(
         replica: {
           ...workspacePayload(workspace),
           coding_agent: workspace.codingAgent ?? null,
-          waking: null,
+          waking: workspace.waking ?? null,
           chats: (workspace.chats ?? []).map(detailChatPayload),
           repository_statuses: workspace.branch
             ? [
@@ -349,6 +351,7 @@ function adapterFor(
     now?: () => number;
     minimumRefreshIntervalMs?: number;
     desktopAppPresent?: () => boolean;
+    onDiagnostic?: (error: Error) => void;
   } = {},
 ): ReplicasSessionAdapter {
   const apiKey = "apiKey" in overrides ? overrides.apiKey : TEST_API_KEY;
@@ -361,6 +364,7 @@ function adapterFor(
     ...(overrides.desktopAppPresent
       ? { desktopAppPresent: overrides.desktopAppPresent }
       : undefined),
+    ...(overrides.onDiagnostic ? { onDiagnostic: overrides.onDiagnostic } : undefined),
   });
 }
 
@@ -521,6 +525,34 @@ test("reads awake detail and history tails, never a waking or key-refused read",
     "/v1/replica/workspace-one/history",
     "/v1/replica/workspace-two/history",
   ]);
+});
+
+test("surfaces a detail read that woke its workspace as a diagnostic", async () => {
+  // The list-to-detail race: a workspace that fell asleep between the two
+  // reads is woken back by the detail read, billed for an API-sourced
+  // workspace until it re-sleeps, and the response's own `waking` is the one
+  // place that shows.
+  const api = fakeReplicasApi([
+    { ...activeWorkspace("workspace-woken", TEST_TIME - 1_000), waking: true },
+  ]);
+  const diagnostics: Error[] = [];
+
+  const observations = await adapterFor(api.fetch, {
+    onDiagnostic: (error) => diagnostics.push(error),
+  }).observe();
+
+  assert.equal(diagnostics.length, 1);
+  // Detection only: the read still succeeded, so its body still serves the pass.
+  assert.equal(observations.length, 1);
+});
+
+test("reports no diagnostic for a detail read that woke nothing", async () => {
+  const api = fakeReplicasApi([activeWorkspace("workspace-awake", TEST_TIME - 1_000)]);
+  const diagnostics: Error[] = [];
+
+  await adapterFor(api.fetch, { onDiagnostic: (error) => diagnostics.push(error) }).observe();
+
+  assert.equal(diagnostics.length, 0);
 });
 
 test("reads a workspace's history once until its activity moves", async () => {

--- a/packages/providers/src/replicas/adapter.ts
+++ b/packages/providers/src/replicas/adapter.ts
@@ -46,6 +46,15 @@ const REPLICAS_PROVIDER_NAME = CREDENTIAL_PROVIDERS[CREDENTIAL_PROVIDER_ID.REPLI
  */
 const REPLICAS_WORKSPACE_ERROR_MESSAGE = "The workspace failed to start or wake";
 
+/**
+ * A detail response marked `waking` means the read itself woke a workspace
+ * that fell asleep after the list reported it active — billed runtime for an
+ * API-sourced workspace until it re-sleeps — and this is the one place the
+ * accident is visible.
+ */
+const REPLICAS_ACCIDENTAL_WAKE_MESSAGE =
+  "A detail read woke a workspace that fell asleep after the list reported it active";
+
 const REPLICAS_ENVIRONMENT = {
   API_URL: "REPLICAS_API_URL",
 } as const;
@@ -182,6 +191,7 @@ const REPLICAS_FIELD = {
   TYPE: "type",
   UPDATED_AT: "updated_at",
   URL: "url",
+  WAKING: "waking",
 } as const;
 
 const REPLICAS_STATUS = {
@@ -1124,6 +1134,12 @@ export class ReplicasSessionAdapter extends CloudSessionAdapter {
           return;
         }
         const replica = body[REPLICAS_FIELD.REPLICA];
+        if (
+          body[REPLICAS_FIELD.WAKING] === true ||
+          (isRecord(replica) && replica[REPLICAS_FIELD.WAKING] === true)
+        ) {
+          this.reportDiagnostic(new Error(REPLICAS_ACCIDENTAL_WAKE_MESSAGE));
+        }
         if (!isRecord(replica)) return;
         const chats = recordsFromPage(replica, REPLICAS_FIELD.CHATS)
           .map(chatFromDetailRecord)

--- a/packages/providers/src/shared/cloud-session-adapter.ts
+++ b/packages/providers/src/shared/cloud-session-adapter.ts
@@ -337,10 +337,18 @@ export abstract class CloudSessionAdapter extends SessionProviderAdapterBase {
       // Anything else is a bug in this pass — a TypeError thrown by a
       // subclass's parsing is not a network blip, and must not keep serving
       // the stale snapshot with no log, counter, or hook.
-      this.#onDiagnostic?.(error instanceof Error ? error : new Error(String(error)));
+      this.reportDiagnostic(error instanceof Error ? error : new Error(String(error)));
       throw error;
     }
     return this.#observations;
+  }
+
+  /**
+   * A subclass's way onto the same diagnostic channel, for a problem worth
+   * surfacing from a pass that otherwise succeeded.
+   */
+  protected reportDiagnostic(error: Error): void {
+    this.#onDiagnostic?.(error);
   }
 
   /**


### PR DESCRIPTION
## The race

`#refreshDetails` issues `GET /v1/replica/{id}` only for workspaces the same pass's list just reported active, because that endpoint is documented to wake a sleeping or archived workspace. There is an unavoidable window: a workspace that falls asleep in the ~second between the list read and the detail read gets woken back by the read itself.

## Why it matters

For an API- or automation-source workspace, that wake starts billed runtime — Replicas meters awake minutes for those — until the workspace re-sleeps at its idle timeout. Today the accident is silent: the detail response carries a `waking` field (per the OpenAPI spec, "Whether the workspace was just woken from a sleeping or archived state") and the adapter never reads it.

## The change

- `REPLICAS_FIELD` gains a `WAKING` entry, and `#refreshDetails` checks it on the `replica` record and defensively at the response's top level (the shape the history endpoint uses).
- A `waking: true` answer is reported through the adapter's existing diagnostic channel via a new narrow protected seam, `CloudSessionAdapter.reportDiagnostic`, which forwards to the privately held `onDiagnostic` callback; the base class's own pass-failure diagnostic now routes through the same seam. The message is fixed by the build and carries no observed values or identifiers, matching what existing diagnostics carry.
- Tests: a detail response carrying `waking: true` produces exactly one diagnostic, and one without it produces none.

This is detection only. No request set, failure containment, or pass behavior changes: the read still succeeded and the pass still uses its body.

## Checks

`./scripts/check.sh` passes (portable-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32914743915/artifacts/9587817471) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32914743915)

- Commit: `ae5573a25508777c293bed2fbf0c4f3a3c93760b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
