### PR TITLE
docs(replicas): rewrap the refreshDetails doc comment

### DIFF
--- a/packages/providers/src/replicas/adapter.ts
+++ b/packages/providers/src/replicas/adapter.ts
@@ -1113,10 +1113,10 @@ export class ReplicasSessionAdapter extends CloudSessionAdapter {
    * minutes, where a manually created workspace bills nothing under the
    * seat. The next pass reports the wake honestly, and the window is a
    * second against a lifecycle measured in hours. Failures are contained
-   * the way every enrichment's are. It is also the fallback chat source: a workspace the registry did
-   * not answer for this pass still lists its chats here, turn state
-   * included, so an awake workspace's rows survive the registry's
-   * organization-header demands.
+   * the way every enrichment's are. It is also the fallback chat source: a
+   * workspace the registry did not answer for this pass still lists its
+   * chats here, turn state included, so an awake workspace's rows survive
+   * the registry's organization-header demands.
    */
   async #refreshDetails(request: CloudRequest, awake: readonly ReplicasWorkspace[]): Promise<void> {
     if (this.#detailsRefused) return;


### PR DESCRIPTION
## What

Whitespace-only follow-up to #529: that squash left one line of the `#refreshDetails` doc comment running about 100 characters where the file wraps its rationale prose near 76. This rewraps the tail of the paragraph to the file's own width; not a word changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32915282923/artifacts/9588000365) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32915282923)

- Commit: `4b6f2800ba525e17678018038bce19c5b217243a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
