### PR TITLE
feat(devtrace): record a local development trace of Luke's agent traffic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Canonical commands:
 | `./scripts/test-macos.sh` | Package and validate the macOS app |
 | `./scripts/verify.sh` | Complete macOS validation plus visual evidence |
 | `pnpm release:macos` | Create a local signed, notarized, and verified electron-builder DMG, zip, and update manifest |
-| `./scripts/run.sh` | Launch the app against live sessions, replacing any running instance (`--fixture smoke` for fixture data, `--keep-running` to keep the running instance) |
+| `./scripts/run.sh` | Launch the app against live sessions, replacing any running instance (`--fixture smoke` for fixture data, `--keep-running` to keep the running instance, `--no-trace` to skip the development trace) |
 | `./scripts/evidence.sh` | Write the fixture PNG under `artifacts/` |
 | `pnpm evidence:record` | Record the fixture transition on a physical Mac |
 | `pnpm lint:fix` | Apply repository formatting and safe lint fixes |
@@ -294,6 +294,25 @@ Trust constraints:
   or what the recording client may capture is a product decision, not an
   implementation detail. `PRIVACY.md` describes all three in kind and moves
   when any of them changes character.
+- The development trace is the one place Luke's own agent traffic may reach a
+  file, and it cannot exist for a user: only an unpackaged, live run whose
+  shell set `LUKE_TRACE_DIR` constructs a writer at all, so a packaged build
+  carries nothing to switch off and a fixture or evidence run stays silent
+  behind the same gate that keeps it off the network. `run.sh` sets the
+  variable by default, pointed at the gitignored build directory, so a
+  development launch is traced unless `--no-trace` says otherwise — the
+  launcher supplies the directory, and the app's own gate still decides
+  whether anything is recorded. What it records is the
+  desktop's own view of its own conversation — the realtime events already
+  crossing the data channel, with an audio append reduced to its byte count
+  before it leaves the renderer, and the attention evaluator's update and
+  decision — appended as JSONL under the developer's chosen directory and
+  sent nowhere; `pnpm trace:export` turns one file into a document a local
+  viewer opens. The tap only observes: nothing reads its result, and the
+  main process drops the renderer's tapped events whenever no writer stands.
+  A trace carries real titles, branches, and spoken words, so trace files are
+  never committed, for the same reason fixtures stay synthetic. Widening what
+  a trace records is a product decision, not an implementation detail.
 - The issue tracker follows the same rule at one remove, and is connected the
   way the calendar is rather than the way a cloud provider is. Luke reads the
   issues a tracker lists for the user under a grant the tracker's own consent

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -43,6 +43,7 @@
     "@sidecar/attention": "workspace:*",
     "@sidecar/calendar": "workspace:*",
     "@sidecar/credentials": "workspace:*",
+    "@sidecar/devtrace": "workspace:*",
     "@sidecar/feedback": "workspace:*",
     "@sidecar/fixtures": "workspace:*",
     "@sidecar/guide": "workspace:*",

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -21,6 +21,7 @@ import {
   nextMeetingBoundary,
 } from "@sidecar/calendar";
 import { CREDENTIAL_PROVIDER_ID, type CredentialProviderId } from "@sidecar/credentials";
+import { AgentTraceWriter, tracedAttentionEvaluator } from "@sidecar/devtrace";
 import { type FeedbackSubmission, feedbackDeliveryFromEnvironment } from "@sidecar/feedback";
 import { fixtureSnapshot } from "@sidecar/fixtures";
 import { normalizeTrackedIssue, type TrackedIssue } from "@sidecar/issues";
@@ -430,6 +431,21 @@ const createdWorkspaceOpens = new CreatedWorkspaceOpenTracker();
  * — and are dropped only when withdrawn or when the session itself goes.
  */
 const attentionRequests = new AttentionRequestRegistry();
+/**
+ * The development trace: Luke's own agent traffic — the realtime wire and the
+ * attention evaluator's passes — appended as JSONL under a directory the
+ * developer's own shell named. Gated so it cannot exist for a user: a
+ * packaged build never reads the variable, a fixture or evidence run has no
+ * traffic to tap and constructs no writer, and everything a traced run
+ * writes stays under that directory on this machine. What a trace may record
+ * is a product decision, not an implementation detail.
+ */
+const agentTraceDirectory =
+  app.isPackaged || !runMode.sendsNetwork ? undefined : process.env.LUKE_TRACE_DIR;
+const agentTrace = agentTraceDirectory
+  ? new AgentTraceWriter({ directory: agentTraceDirectory })
+  : undefined;
+if (agentTrace) process.stderr.write(`Agent trace: ${agentTrace.file}\n`);
 const voiceCapabilities = new VoiceCapabilityAssembler({
   settings: settingsStore,
   credentialsUsable: () => runMode.sendsNetwork && accountCapabilitiesActive(),
@@ -439,6 +455,12 @@ const voiceCapabilities = new VoiceCapabilityAssembler({
   refreshAccount: accountSession.refreshOnce,
   currentSession: (identity) => sessionRegistry.get(identity),
   noticeRequestFor: (identity) => attentionRequests.get(identity),
+  ...(agentTrace
+    ? {
+        wrapEvaluator: (evaluator) =>
+          tracedAttentionEvaluator(evaluator, (record) => agentTrace.recordAttention(record)),
+      }
+    : undefined),
 });
 // Quiets Music and Spotify while a spoken exchange is live. It lives here
 // rather than in the renderer because letting the players back up must survive
@@ -1086,6 +1108,7 @@ function registerIpc(): void {
         fixture,
         captureMode,
         fixtureMode,
+        agentTraceEnabled: agentTrace !== undefined,
         supersetInstalled,
         supersetConnected,
         accountRequired: runMode.requiresAccount,
@@ -1305,6 +1328,7 @@ function registerIpc(): void {
     unavailableDiagnostics: () => voiceCapabilities.unavailableDiagnostics,
     hostedUsageReader: () => voiceCapabilities.hostedUsageReader,
     recordProductEvent,
+    recordAgentTrace: (trace) => agentTrace?.recordWire(trace),
   });
 
   registerSessionActsIpc({

--- a/apps/desktop/src/main/ipc/voice-runtime.ts
+++ b/apps/desktop/src/main/ipc/voice-runtime.ts
@@ -4,6 +4,7 @@ import {
   type RecordProductEvent,
 } from "@sidecar/analytics";
 import { CREDENTIAL_CONNECTION, CREDENTIAL_PROVIDERS } from "@sidecar/credentials";
+import type { AgentWireTrace } from "@sidecar/devtrace/vocabulary";
 import type { HostedUsageReader, RealtimeCredentialMinter } from "@sidecar/voice";
 import type { IpcMain, IpcMainEvent, IpcMainInvokeEvent } from "electron";
 import { BRIDGE } from "#shared/bridge";
@@ -30,6 +31,12 @@ export interface VoiceRuntimeIpcDependencies {
   unavailableDiagnostics: () => ReturnType<RealtimeCredentialMinter["diagnostics"]>;
   hostedUsageReader: () => HostedUsageReader | undefined;
   recordProductEvent: RecordProductEvent;
+  /**
+   * Takes one tapped wire event into the development trace. On a run without
+   * a writer — packaged, fixture, or simply untraced — the renderer's
+   * fire-and-forget send lands here and stops.
+   */
+  recordAgentTrace: (trace: AgentWireTrace) => void;
 }
 
 export function registerVoiceRuntimeIpc(dependencies: VoiceRuntimeIpcDependencies): void {
@@ -72,6 +79,9 @@ export function registerVoiceRuntimeIpc(dependencies: VoiceRuntimeIpcDependencie
         dependencies.chooseRealtimeCredentials()?.minter.diagnostics() ??
         dependencies.unavailableDiagnostics(),
       requestHostedUsage: () => dependencies.hostedUsageReader()?.read(),
+      recordAgentTrace(_context, trace) {
+        dependencies.recordAgentTrace(trace);
+      },
     },
     { ipcMain: dependencies.ipcMain, trustedSender: dependencies.trustedSender },
   );

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -2090,6 +2090,7 @@ export function App(): React.JSX.Element {
     syncIssues,
   } = useVoiceConversation({
     preferBuiltInMicrophone: (settings ?? bootstrapSettings)?.preferBuiltInMicrophone ?? true,
+    agentTraceEnabled: bootstrap?.agentTraceEnabled === true,
     sessions,
     noticeAsks,
     workspaceProjects,

--- a/apps/desktop/src/renderer/realtime-session.test.ts
+++ b/apps/desktop/src/renderer/realtime-session.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
+import { TRACE_DIRECTION, type TraceDirection } from "@sidecar/devtrace/vocabulary";
 import { APP_SETTING_KIND, type AppGuideSnapshot } from "@sidecar/guide";
 import { ISSUE_TRACKER_ID, normalizeTrackedIssue, type TrackedIssue } from "@sidecar/issues";
 import {
@@ -28,7 +29,7 @@ import {
   type Session,
   WORKSPACE_TASK_SUPPORT,
 } from "@sidecar/session";
-import { isRecord, text } from "@sidecar/wire";
+import { isRecord, text, type WireRecord } from "@sidecar/wire";
 import type { JsonValue, ParsedJsonObject } from "@sidecar/wire/testing";
 import {
   asMediaStream,
@@ -182,6 +183,8 @@ function harness(
     captureSessionSync?: boolean;
     /** Lets a test ride the status edges, the way the announcer does. */
     onStatus?: (status: RealtimeStatus) => void;
+    /** Lets a test stand where the development trace's tap does. */
+    onWireEvent?: (direction: TraceDirection, event: WireRecord) => void;
     /** Lets a test see what the element would be handed to play. */
     onRemoteStream?: (stream: MediaStream | undefined) => void;
     /**
@@ -352,6 +355,9 @@ function harness(
   if (options.connectTimeoutMs !== undefined) {
     sessionOptions.connectTimeoutMs = options.connectTimeoutMs;
   }
+  if (options.onWireEvent) {
+    sessionOptions.onWireEvent = options.onWireEvent;
+  }
   if (options.now) {
     sessionOptions.now = options.now;
   }
@@ -506,6 +512,34 @@ test("connecting opens the call and leaves the microphone closed", async () => {
   assert.equal(headers.authorization, `Bearer ${CONNECTION.value}`);
   assert.equal(headers["content-type"], "application/sdp");
   assert.equal(request?.init.body, "v=0 local");
+});
+
+test("the wire tap sees both directions, raw, before the parser narrows or drops", async () => {
+  const tapped: { direction: TraceDirection; event: WireRecord }[] = [];
+  const context = harness({
+    onWireEvent: (direction, event) => tapped.push({ direction, event }),
+  });
+  await context.session.connect();
+
+  // The session sync the harness's channel filters out of `sent` still
+  // crosses the tap: it is what the call sends, instructions and tools whole.
+  const clientTypes = tapped
+    .filter((entry) => entry.direction === TRACE_DIRECTION.CLIENT)
+    .map((entry) => entry.event.type);
+  assert.ok(clientTypes.includes(REALTIME_CLIENT_EVENT.SESSION_UPDATE));
+
+  // A reply's `done` reaches the tap with the fields the parser discards, and
+  // an event type this build does not act on reaches it at all.
+  context.emit({
+    type: REALTIME_SERVER_EVENT.RESPONSE_DONE,
+    response: { id: "resp_1", usage: { input_tokens: 12 } },
+  });
+  context.emit({ type: "rate_limits.updated", rate_limits: [] });
+  const server = tapped.filter((entry) => entry.direction === TRACE_DIRECTION.SERVER);
+  const done = server.find((entry) => entry.event.type === REALTIME_SERVER_EVENT.RESPONSE_DONE);
+  assert.ok(isRecord(done?.event.response));
+  assert.deepEqual(done?.event.response.usage, { input_tokens: 12 });
+  assert.ok(server.some((entry) => entry.event.type === "rate_limits.updated"));
 });
 
 test("no credential leaves the voice experience explicitly unavailable", async () => {

--- a/apps/desktop/src/renderer/realtime-session.ts
+++ b/apps/desktop/src/renderer/realtime-session.ts
@@ -1,4 +1,5 @@
 import type { SessionNoticeAsk } from "@sidecar/attention";
+import { TRACE_DIRECTION, type TraceDirection } from "@sidecar/devtrace/vocabulary";
 import { type AppGuideSnapshot, appGuideContextText, EMPTY_APP_GUIDE } from "@sidecar/guide";
 import type { TrackedIssue } from "@sidecar/issues";
 import {
@@ -20,6 +21,7 @@ import {
   contextSupersedeEvents,
   conversationContextEvents,
   conversationHistoryText,
+  decodeRealtimePayload,
   functionCallFollowUpEvents,
   functionCallOutputEvents,
   type IntroductionLine,
@@ -333,6 +335,14 @@ export interface RealtimeVoiceSessionOptions extends RealtimeVoiceSessionCallbac
   cancel?: (timer: ScheduledTimer) => void;
   /** Injectable so a test can hold the clock a truncate measures against. */
   now?: () => number;
+  /**
+   * A development tap on the wire itself: every event this call sends and
+   * every event the service answers, as they cross the data channel. The tap
+   * observes and never steers — nothing here reads its result — and the
+   * caller decides per event whether anything leaves it, because the session
+   * outlives the bootstrap that says whether a trace is being written.
+   */
+  onWireEvent?: (direction: TraceDirection, event: WireRecord) => void;
 }
 
 function errorMessage(error: Error): string {
@@ -2258,7 +2268,14 @@ export class RealtimeVoiceSession {
   }
 
   #handleServerEvent(data: UnparsedWireValue): void {
-    const event = parseRealtimeServerEvent(data);
+    // Decoded once, here: the tap reads the record whole — the parser below
+    // keeps only the events the conversation acts on, and what it discards
+    // (usage, errors in full, event types this build does not know) is half
+    // of what a trace exists to show — and the parser accepts the decoded
+    // record as readily as the string, so nothing is parsed twice.
+    const record = decodeRealtimePayload(data);
+    if (record) this.#options.onWireEvent?.(TRACE_DIRECTION.SERVER, record);
+    const event = parseRealtimeServerEvent(record);
     if (!event) return;
 
     switch (event.type) {
@@ -2591,7 +2608,10 @@ export class RealtimeVoiceSession {
   #send(events: readonly WireRecord[]): void {
     const channel = this.#channel;
     if (channel?.readyState !== "open") return;
-    for (const event of events) channel.send(JSON.stringify(event));
+    for (const event of events) {
+      channel.send(JSON.stringify(event));
+      this.#options.onWireEvent?.(TRACE_DIRECTION.CLIENT, event);
+    }
   }
 
   #fail(message: string): boolean {

--- a/apps/desktop/src/renderer/use-voice-conversation.ts
+++ b/apps/desktop/src/renderer/use-voice-conversation.ts
@@ -1,4 +1,5 @@
 import type { SessionNoticeAsk } from "@sidecar/attention";
+import { sanitizedTraceEvent } from "@sidecar/devtrace/vocabulary";
 import { FIXTURE_SPEAKING_CAPTION } from "@sidecar/fixtures";
 import { type AppGuideSnapshot, EMPTY_APP_GUIDE } from "@sidecar/guide";
 import { mentionedIssues, type TrackedIssue } from "@sidecar/issues";
@@ -365,6 +366,12 @@ export interface VoiceConversationOptions {
    * the user's exact choice.
    */
   preferBuiltInMicrophone: boolean;
+  /**
+   * Whether this run records the development trace. True only when the main
+   * process built a writer — an unpackaged, live run the developer pointed at
+   * a directory — so on every other run the wire is never even tapped.
+   */
+  agentTraceEnabled: boolean;
   sessions: readonly Session[];
   /**
    * The standing asks riding the roster they annotate, so a conversation can
@@ -717,6 +724,14 @@ export function useVoiceConversation(options: VoiceConversationOptions): VoiceCo
       // placed where their turn happened: the thread holds both halves of
       // the exchange, in the order they were said.
       onSpokenAsk: rememberSpokenAsk,
+      // The development trace's tap, checked at each event rather than at
+      // construction because the session outlives the bootstrap that says
+      // whether a writer stands behind the bridge. The audio is stripped
+      // here, before the event ever crosses the sandbox.
+      onWireEvent: (direction, event) => {
+        if (!optionsRef.current.agentTraceEnabled) return;
+        window.sidecar.recordAgentTrace({ direction, event: sanitizedTraceEvent(event) });
+      },
     });
     return voiceSession.current;
   }, [rememberConversationEntry, rememberSpokenAsk, setVoiceStatus]);

--- a/apps/desktop/src/shared/bridge.ts
+++ b/apps/desktop/src/shared/bridge.ts
@@ -13,6 +13,7 @@ import {
 import type { AttentionRequestResult, SessionNoticeAsk } from "@sidecar/attention";
 import type { ObservedAccountCalendars } from "@sidecar/calendar/observation";
 import { type CredentialProviderId, isCredentialProviderId } from "@sidecar/credentials/vocabulary";
+import { type AgentWireTrace, isAgentWireTrace } from "@sidecar/devtrace/vocabulary";
 import {
   type FeedbackKind,
   type FeedbackResult,
@@ -629,6 +630,18 @@ export const BRIDGE = {
     channel: "app:request-hosted-usage",
     args: noArgs,
     result: result<HostedUsageAnswer | undefined>(),
+  }),
+  /**
+   * One tapped realtime event for the development trace. Fire-and-forget on
+   * purpose: the tap must cost the conversation nothing, and the main process
+   * simply drops it when no traced run is on — which is every packaged run,
+   * because the writer only exists behind the unpackaged `LUKE_TRACE_DIR`
+   * gate.
+   */
+  recordAgentTrace: entry({
+    kind: "send",
+    channel: "app:record-agent-trace",
+    args: args<[AgentWireTrace]>((v) => v.length === 1 && isAgentWireTrace(v[0])),
   }),
   notifyReady: entry({ kind: "send", channel: "app:renderer-ready", args: noArgs }),
   /**

--- a/apps/desktop/src/shared/wire/session.ts
+++ b/apps/desktop/src/shared/wire/session.ts
@@ -113,6 +113,12 @@ export interface AppBootstrap {
   captureMode: boolean;
   /** True when `--fixture` (or a capture run) makes the panel render fixture sessions. */
   fixtureMode: boolean;
+  /**
+   * Whether this run records the development trace, so the conversation taps
+   * the wire only while a writer actually stands behind the bridge. False on
+   * every packaged run by construction.
+   */
+  agentTraceEnabled: boolean;
   /** Whether Superset's bundled CLI exists on this Mac. */
   supersetInstalled: boolean;
   /** Whether that CLI also has its own login configuration. */

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "start": "pnpm --filter @luke/desktop start",
     "test": "pnpm test:harness && pnpm --recursive --if-present run test",
     "test:harness": "node --test scripts/*.test.mjs",
+    "trace:export": "tsx packages/devtrace/src/cli.ts",
     "typecheck": "pnpm --recursive --if-present run typecheck"
   },
   "lint-staged": {
@@ -31,6 +32,7 @@
     "@oxlint/plugins": "1.79.0",
     "husky": "9.1.7",
     "lint-staged": "17.3.0",
-    "oxlint": "1.79.0"
+    "oxlint": "1.79.0",
+    "tsx": "4.23.12"
   }
 }

--- a/packages/devtrace/package.json
+++ b/packages/devtrace/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@sidecar/devtrace",
+  "version": "0.3.11",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.js",
+    "./vocabulary": "./src/vocabulary.js"
+  },
+  "types": "./src/index.ts",
+  "scripts": {
+    "export": "tsx src/cli.ts",
+    "test": "tsx --test 'src/**/*.test.ts'",
+    "typecheck": "tsc --project tsconfig.json"
+  },
+  "dependencies": {
+    "@sidecar/attention": "workspace:*",
+    "@sidecar/realtime": "workspace:*",
+    "@sidecar/session": "workspace:*",
+    "@sidecar/wire": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "26.2.0",
+    "tsx": "4.23.12",
+    "typescript": "7.0.2"
+  }
+}

--- a/packages/devtrace/src/attention-trace.test.ts
+++ b/packages/devtrace/src/attention-trace.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ATTENTION_TRIGGER, type AttentionUpdate } from "@sidecar/attention";
+import { ATTENTION_DISPOSITION, type AttentionDecision, SESSION_STATUS } from "@sidecar/session";
+import { tracedAttentionEvaluator } from "./attention-trace.js";
+import type { AttentionTraceRecord } from "./trace-writer.js";
+
+const UPDATE: AttentionUpdate = {
+  providerId: "claude-code",
+  providerSessionId: "abc",
+  trigger: ATTENTION_TRIGGER.STATUS_CHANGED,
+  providerName: "Claude Code",
+  title: "checkout-service",
+  status: SESSION_STATUS.WAITING,
+  observedAt: 1_800_000_000_000,
+};
+
+const DECISION: AttentionDecision = {
+  disposition: ATTENTION_DISPOSITION.SPEAK_AT_TURN_END,
+  decidedAt: 1_800_000_000_500,
+  summary: "The checkout agent wants an answer.",
+};
+
+test("a traced pass returns the decision unchanged and records both halves", async () => {
+  const records: AttentionTraceRecord[] = [];
+  let clock = 1_000;
+  const evaluator = tracedAttentionEvaluator(
+    { evaluate: async () => DECISION },
+    (record) => records.push(record),
+    () => {
+      clock += 40;
+      return clock;
+    },
+  );
+  const decision = await evaluator.evaluate(UPDATE);
+  assert.equal(decision, DECISION);
+  assert.deepEqual(records, [{ update: UPDATE, decision: DECISION, elapsedMs: 40 }]);
+});
+
+test("a failed pass still throws, and the trace keeps the failure", async () => {
+  const records: AttentionTraceRecord[] = [];
+  const evaluator = tracedAttentionEvaluator(
+    {
+      evaluate: async () => {
+        throw new Error("rate limited");
+      },
+    },
+    (record) => records.push(record),
+    () => 7,
+  );
+  await assert.rejects(() => evaluator.evaluate(UPDATE), /rate limited/u);
+  assert.deepEqual(records, [
+    { update: UPDATE, decision: undefined, elapsedMs: 0, error: "rate limited" },
+  ]);
+});
+
+test("a recorder that throws costs the trace line, never the pass", async () => {
+  const evaluator = tracedAttentionEvaluator({ evaluate: async () => DECISION }, () => {
+    throw new Error("disk full");
+  });
+  assert.equal(await evaluator.evaluate(UPDATE), DECISION);
+});
+
+test("quietUntil is forwarded only when the wrapped evaluator has one", () => {
+  const quiet = tracedAttentionEvaluator(
+    { evaluate: async () => undefined, quietUntil: () => 42 },
+    () => undefined,
+  );
+  assert.equal(quiet.quietUntil?.(), 42);
+  const plain = tracedAttentionEvaluator({ evaluate: async () => undefined }, () => undefined);
+  assert.equal(plain.quietUntil, undefined);
+});

--- a/packages/devtrace/src/attention-trace.ts
+++ b/packages/devtrace/src/attention-trace.ts
@@ -1,0 +1,47 @@
+import type { AttentionEvaluator, AttentionUpdate } from "@sidecar/attention";
+import type { AttentionTraceRecord } from "./trace-writer.js";
+
+/**
+ * Wraps an evaluator so a traced run records what every pass sent and got
+ * back, keyed and hosted alike, without either evaluator learning it is being
+ * watched. The tap observes and never steers: the decision returns exactly as
+ * the wrapped evaluator produced it, a failed pass still throws, and a
+ * recorder that itself fails is swallowed here, because an instrument reading
+ * the evaluator must not be able to break it.
+ */
+export function tracedAttentionEvaluator(
+  evaluator: AttentionEvaluator,
+  record: (record: AttentionTraceRecord) => void,
+  now: () => number = Date.now,
+): AttentionEvaluator {
+  const recordQuietly = (entry: AttentionTraceRecord): void => {
+    try {
+      record(entry);
+    } catch {
+      // The trace is the instrument; the pass is the point.
+    }
+  };
+  const quietUntil = evaluator.quietUntil;
+  return {
+    evaluate: async (update: AttentionUpdate) => {
+      const started = now();
+      try {
+        const decision = await evaluator.evaluate(update);
+        recordQuietly({ update, decision, elapsedMs: now() - started });
+        return decision;
+      } catch (error) {
+        recordQuietly({
+          update,
+          decision: undefined,
+          elapsedMs: now() - started,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      }
+    },
+    // Forwarded only when the wrapped evaluator has one: the reviewer treats
+    // the member's absence as "requests are welcome", and a wrapper that
+    // always answered would change that reading.
+    ...(quietUntil ? { quietUntil: () => quietUntil.call(evaluator) } : undefined),
+  };
+}

--- a/packages/devtrace/src/cli.ts
+++ b/packages/devtrace/src/cli.ts
@@ -1,0 +1,37 @@
+/**
+ * Turns a recorded trace into the JSON unbox-ai opens:
+ *
+ *   pnpm --filter @sidecar/devtrace export <trace.jsonl> [out.json]
+ *   npx unbox-ai out.json
+ *
+ * Reading and writing stay on this machine; the viewer the output is meant
+ * for runs locally too.
+ */
+
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { unboxTraceFromLines } from "./unbox-export.js";
+
+const [source, destination] = process.argv.slice(2);
+if (!source) {
+  process.stderr.write("Usage: export <trace.jsonl> [out.json]\n");
+  process.exit(1);
+}
+
+// pnpm runs a script with the owning package as its working directory — the
+// workspace root for the `trace:export` alias, this package for `--filter` —
+// not where the command was typed, so a relative path resolved against the
+// process's own cwd lands inside the repository. INIT_CWD is pnpm's record
+// of where the developer actually stood.
+const invocationDirectory = process.env.INIT_CWD ?? process.cwd();
+const sourcePath = path.resolve(invocationDirectory, source);
+const lines = (await readFile(sourcePath, "utf8")).split("\n");
+const trace = unboxTraceFromLines(lines, { name: path.basename(sourcePath, ".jsonl") });
+const document = `${JSON.stringify(trace, undefined, 2)}\n`;
+if (destination) {
+  const destinationPath = path.resolve(invocationDirectory, destination);
+  await writeFile(destinationPath, document);
+  process.stderr.write(`Wrote ${destinationPath}\n`);
+} else {
+  process.stdout.write(document);
+}

--- a/packages/devtrace/src/index.ts
+++ b/packages/devtrace/src/index.ts
@@ -1,0 +1,5 @@
+// The barrel carries only what the main process takes; the wire vocabulary
+// travels through `./vocabulary`, its own door, because this barrel reaches
+// `node:fs` through the writer and a renderer bundle must never resolve it.
+export { tracedAttentionEvaluator } from "./attention-trace.js";
+export { AgentTraceWriter } from "./trace-writer.js";

--- a/packages/devtrace/src/trace-writer.test.ts
+++ b/packages/devtrace/src/trace-writer.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { ATTENTION_TRIGGER } from "@sidecar/attention";
+import { ATTENTION_DISPOSITION, SESSION_STATUS } from "@sidecar/session";
+import { isRecord, isWireString, recordFromJsonLine } from "@sidecar/wire";
+import { AgentTraceWriter, TRACE_ENTRY_KIND } from "./trace-writer.js";
+import { TRACE_DIRECTION } from "./vocabulary.js";
+
+function fixedClock(): () => Date {
+  let tick = 0;
+  return () => {
+    tick += 1_000;
+    return new Date(1_800_000_000_000 + tick);
+  };
+}
+
+test("lines land in the named file, stamped, in the order they were recorded", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "devtrace-"));
+  const writer = new AgentTraceWriter({ directory, now: fixedClock() });
+  writer.recordWire({
+    direction: TRACE_DIRECTION.CLIENT,
+    event: { type: "response.create" },
+  });
+  writer.recordAttention({
+    update: {
+      providerId: "claude-code",
+      providerSessionId: "abc",
+      trigger: ATTENTION_TRIGGER.OBSERVED,
+      providerName: "Claude Code",
+      title: "checkout-service",
+      status: SESSION_STATUS.WAITING,
+      observedAt: 1_800_000_000_000,
+    },
+    decision: {
+      disposition: ATTENTION_DISPOSITION.SILENT,
+      decidedAt: 1_800_000_000_500,
+    },
+    elapsedMs: 250,
+  });
+  await writer.settled();
+  const lines = (await readFile(writer.file, "utf8")).split("\n").filter((line) => line.length > 0);
+  const entries = lines.map(recordFromJsonLine);
+  assert.equal(entries.length, 2);
+  assert.equal(entries[0]?.kind, TRACE_ENTRY_KIND.WIRE);
+  assert.equal(entries[0]?.direction, TRACE_DIRECTION.CLIENT);
+  assert.equal(entries[1]?.kind, TRACE_ENTRY_KIND.ATTENTION);
+  assert.equal(entries[1]?.elapsedMs, 250);
+  assert.ok(isRecord(entries[1]?.decision));
+  for (const entry of entries) {
+    assert.ok(isWireString(entry?.at));
+  }
+});
+
+test("raw audio handed straight to the writer still never reaches the file", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "devtrace-"));
+  const writer = new AgentTraceWriter({ directory });
+  writer.recordWire({
+    direction: TRACE_DIRECTION.CLIENT,
+    event: { type: "input_audio_buffer.append", audio: "AAAAAAA=" },
+  });
+  await writer.settled();
+  const [line] = (await readFile(writer.file, "utf8")).split("\n");
+  const entry = recordFromJsonLine(line ?? "");
+  assert.ok(isRecord(entry?.event));
+  assert.deepEqual(entry?.event, { type: "input_audio_buffer.append", audioBytes: 5 });
+});
+
+test("a writer that cannot write reports once and stays quiet after", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "devtrace-"));
+  // A file where the trace directory should be makes every mkdir fail.
+  const blocked = path.join(directory, "blocked");
+  await writeFile(blocked, "");
+  const reports: string[] = [];
+  const writer = new AgentTraceWriter({
+    directory: blocked,
+    report: (message) => reports.push(message),
+  });
+  writer.recordWire({ direction: TRACE_DIRECTION.CLIENT, event: { type: "one" } });
+  writer.recordWire({ direction: TRACE_DIRECTION.CLIENT, event: { type: "two" } });
+  await writer.settled();
+  assert.equal(reports.length, 1);
+  assert.match(reports[0] ?? "", /Agent trace could not be written/u);
+});

--- a/packages/devtrace/src/trace-writer.ts
+++ b/packages/devtrace/src/trace-writer.ts
@@ -1,0 +1,103 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import path from "node:path";
+import type { AttentionUpdate } from "@sidecar/attention";
+import type { AttentionDecision } from "@sidecar/session";
+import { type AgentWireTrace, sanitizedTraceEvent } from "./vocabulary.js";
+
+/**
+ * One evaluator pass as the trace records it: the bounded update that went to
+ * the model, the decision that came back — absent when the pass failed — and
+ * how long the round trip took.
+ */
+export interface AttentionTraceRecord {
+  update: AttentionUpdate;
+  decision: AttentionDecision | undefined;
+  elapsedMs: number;
+  error?: string;
+}
+
+export const TRACE_ENTRY_KIND = {
+  WIRE: "wire",
+  ATTENTION: "attention",
+} as const;
+
+/**
+ * One line of the trace before its timestamp is stamped on. `JSON.stringify`
+ * drops undefined-valued fields, so an absent decision or error never reaches
+ * the file as a key.
+ */
+type PendingTraceEntry =
+  | ({ kind: typeof TRACE_ENTRY_KIND.WIRE } & AgentWireTrace)
+  | ({ kind: typeof TRACE_ENTRY_KIND.ATTENTION } & AttentionTraceRecord);
+
+export interface AgentTraceWriterOptions {
+  /** Where the trace lands, created on the first line rather than up front. */
+  directory: string;
+  now?: () => Date;
+  report?: (message: string) => void;
+}
+
+/**
+ * Appends the development trace as JSONL, one line per tapped event. The file
+ * is named at construction so one app run is one trace, and lines queue behind
+ * one another so the file keeps wire order even though appends are
+ * asynchronous. A write failure is reported once and then silent: the trace is
+ * an instrument reading the app, and a full disk must never become a voice
+ * bug.
+ */
+export class AgentTraceWriter {
+  readonly file: string;
+  readonly #directory: string;
+  readonly #now: () => Date;
+  readonly #report: (message: string) => void;
+  /** The directory made once, whichever line gets there first. */
+  #directoryReady: Promise<void> | undefined;
+  #queue: Promise<void> = Promise.resolve();
+  #failed = false;
+
+  constructor(options: AgentTraceWriterOptions) {
+    this.#directory = options.directory;
+    this.#now = options.now ?? (() => new Date());
+    this.#report = options.report ?? ((text: string) => process.stderr.write(text));
+    const stamp = this.#now().toISOString().replace(/[:.]/gu, "-");
+    this.file = path.join(options.directory, `agent-trace-${stamp}.jsonl`);
+  }
+
+  recordWire(trace: AgentWireTrace): void {
+    // Sanitized here as well as at the renderer's tap, because this is the
+    // one place that touches the file: the trust constraint is that audio
+    // never reaches disk, and a rule enforced only by a caller's manners is
+    // one a second caller forgets. The sanitizer returns an already-stripped
+    // event unchanged, so the two passes cost one field read.
+    this.#append({
+      kind: TRACE_ENTRY_KIND.WIRE,
+      ...trace,
+      event: sanitizedTraceEvent(trace.event),
+    });
+  }
+
+  recordAttention(record: AttentionTraceRecord): void {
+    this.#append({ kind: TRACE_ENTRY_KIND.ATTENTION, ...record });
+  }
+
+  /** The queue drained, for a test to await what `record*` fired and forgot. */
+  settled(): Promise<void> {
+    return this.#queue;
+  }
+
+  #append(entry: PendingTraceEntry): void {
+    const line = `${JSON.stringify({ at: this.#now().toISOString(), ...entry })}\n`;
+    this.#queue = this.#queue
+      .then(async () => {
+        this.#directoryReady ??= mkdir(this.#directory, { recursive: true }).then(() => undefined);
+        await this.#directoryReady;
+        await appendFile(this.file, line);
+      })
+      .catch((error) => {
+        if (this.#failed) return;
+        this.#failed = true;
+        const message = error instanceof Error ? error.message : String(error);
+        this.#report(`Agent trace could not be written: ${message}\n`);
+      });
+  }
+}

--- a/packages/devtrace/src/unbox-export.test.ts
+++ b/packages/devtrace/src/unbox-export.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isRecord, type WireRecord, type WireValue } from "@sidecar/wire";
+import { TRACE_ENTRY_KIND } from "./trace-writer.js";
+import { unboxTraceFromLines } from "./unbox-export.js";
+import { TRACE_DIRECTION } from "./vocabulary.js";
+
+function wireLine(at: string, direction: string, event: WireRecord): string {
+  return JSON.stringify({ at, kind: TRACE_ENTRY_KIND.WIRE, direction, event });
+}
+
+function generations(trace: WireRecord): readonly WireRecord[] {
+  const events = trace.events;
+  return Array.isArray(events) ? events.filter(isRecord) : [];
+}
+
+function messagesOf(generation: WireRecord | undefined): readonly WireRecord[] {
+  const messages = generation?.messages;
+  return Array.isArray(messages) ? messages.filter(isRecord) : [];
+}
+
+const SESSION_SYNC = wireLine("2026-08-25T10:00:00.000Z", TRACE_DIRECTION.CLIENT, {
+  type: "session.update",
+  session: {
+    instructions: "You are Luke.",
+    tools: [
+      {
+        type: "function",
+        name: "open_session",
+        description: "Opens a session.",
+        parameters: { type: "object", properties: { title: { type: "string" } } },
+      },
+    ],
+  },
+});
+
+const TYPED_ASK = wireLine("2026-08-25T10:00:01.000Z", TRACE_DIRECTION.CLIENT, {
+  type: "conversation.item.create",
+  item: {
+    type: "message",
+    role: "user",
+    content: [{ type: "input_text", text: "What is the checkout agent doing?" }],
+  },
+});
+
+const RESPONSE_ASKED = wireLine("2026-08-25T10:00:01.200Z", TRACE_DIRECTION.CLIENT, {
+  type: "response.create",
+});
+
+const RESPONSE_DONE = wireLine("2026-08-25T10:00:03.200Z", TRACE_DIRECTION.SERVER, {
+  type: "response.done",
+  response: {
+    id: "resp_1",
+    usage: {
+      input_tokens: 900,
+      output_tokens: 40,
+      input_token_details: { cached_tokens: 512 },
+    },
+    output: [
+      {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_audio", transcript: "It is waiting on you." }],
+      },
+    ],
+  },
+});
+
+test("a replied turn becomes one generation with the cumulative conversation", () => {
+  const trace = unboxTraceFromLines([SESSION_SYNC, TYPED_ASK, RESPONSE_ASKED, RESPONSE_DONE], {
+    name: "smoke",
+  });
+  assert.equal(trace.trace_id, "smoke");
+  assert.equal(trace.timestamp, "2026-08-25T10:00:00.000Z");
+  assert.deepEqual(trace.total_tokens, { input: 900, output: 40 });
+  const [generation] = generations(trace);
+  assert.ok(generation);
+  assert.equal(generation.type, "generation");
+  assert.equal(generation.name, "resp_1");
+  assert.deepEqual(generation.metrics, {
+    latency: 2,
+    tokens: { input: 900, output: 40, cache_read: 512 },
+    cost: 0,
+  });
+  const tools = generation.available_tools;
+  assert.ok(Array.isArray(tools) && tools.length === 1);
+  const [tool] = tools.filter(isRecord);
+  assert.equal(tool?.name, "open_session");
+  assert.ok(isRecord(tool?.inputSchema));
+  assert.deepEqual(
+    messagesOf(generation).map((message) => [message.role, message.content]),
+    [
+      ["system", "You are Luke."],
+      ["user", "What is the checkout agent doing?"],
+      ["assistant", "It is waiting on you."],
+    ],
+  );
+});
+
+test("a tool call pairs with its output across two generations", () => {
+  const callDone = wireLine("2026-08-25T10:00:03.000Z", TRACE_DIRECTION.SERVER, {
+    type: "response.done",
+    response: {
+      id: "resp_call",
+      usage: { input_tokens: 10, output_tokens: 5 },
+      output: [
+        {
+          type: "function_call",
+          name: "open_session",
+          call_id: "call_1",
+          arguments: '{"title":"checkout"}',
+        },
+      ],
+    },
+  });
+  const callOutput = wireLine("2026-08-25T10:00:03.500Z", TRACE_DIRECTION.CLIENT, {
+    type: "conversation.item.create",
+    item: { type: "function_call_output", call_id: "call_1", output: '{"status":"accepted"}' },
+  });
+  const trace = unboxTraceFromLines([SESSION_SYNC, TYPED_ASK, callDone, callOutput, RESPONSE_DONE]);
+  const [first, second] = generations(trace);
+  const callMessage = messagesOf(first).at(-1);
+  const calls: WireValue | undefined = callMessage?.tool_calls;
+  assert.ok(Array.isArray(calls));
+  const [call] = calls.filter(isRecord);
+  assert.deepEqual(call, {
+    type: "function",
+    id: "call_1",
+    function: { name: "open_session", arguments: '{"title":"checkout"}' },
+  });
+  const roles = messagesOf(second).map((message) => message.role);
+  assert.deepEqual(roles, ["system", "user", "assistant", "tool", "assistant"]);
+  const output = messagesOf(second).find((message) => message.role === "tool");
+  assert.equal(output?.tool_call_id, "call_1");
+});
+
+test("a spoken turn's transcription joins the conversation as the developer's words", () => {
+  const transcription = wireLine("2026-08-25T10:00:02.000Z", TRACE_DIRECTION.SERVER, {
+    type: "conversation.item.input_audio_transcription.completed",
+    transcript: "Read me the update.",
+  });
+  const trace = unboxTraceFromLines([SESSION_SYNC, transcription, RESPONSE_DONE]);
+  const [generation] = generations(trace);
+  const user = messagesOf(generation).find((message) => message.role === "user");
+  assert.equal(user?.content, "Read me the update.");
+});
+
+test("an attention pass becomes its own generation, and junk lines cost only themselves", () => {
+  const attention = JSON.stringify({
+    at: "2026-08-25T10:05:00.000Z",
+    kind: TRACE_ENTRY_KIND.ATTENTION,
+    update: { title: "checkout-service", status: "waiting" },
+    decision: { disposition: "silent" },
+    elapsedMs: 321,
+  });
+  const trace = unboxTraceFromLines(["not json", attention]);
+  const [generation] = generations(trace);
+  assert.ok(generation);
+  assert.equal(generation.name, "attention-review");
+  const metrics = isRecord(generation.metrics) ? generation.metrics : undefined;
+  assert.equal(metrics?.latency, 0.321);
+  const [update, decision] = messagesOf(generation);
+  assert.equal(update?.role, "user");
+  assert.match(String(update?.content), /checkout-service/u);
+  assert.equal(decision?.role, "assistant");
+  assert.match(String(decision?.content), /silent/u);
+});

--- a/packages/devtrace/src/unbox-export.ts
+++ b/packages/devtrace/src/unbox-export.ts
@@ -1,0 +1,270 @@
+/**
+ * Converts a recorded trace into the gateway document unbox-ai reads
+ * (https://github.com/tester-army/unbox-ai): `{events[]}` of generation
+ * entries, each carrying the model, its metrics, the tools it could call,
+ * and a cumulative snapshot of the conversation at that generation.
+ *
+ * The realtime wire is an event stream rather than request/response, so the
+ * conversion replays it: session updates stand the instructions and tools,
+ * created items and transcriptions grow the conversation, and each
+ * `response.done` becomes one generation whose snapshot is everything said up
+ * to and including it. Every reader here is defensive — the stream is what a
+ * service actually sent, not what this build expects — so one odd event costs
+ * itself, never the export.
+ */
+
+import { REALTIME_CLIENT_EVENT, REALTIME_SERVER_EVENT } from "@sidecar/realtime";
+import {
+  isRecord,
+  recordFromJsonLine,
+  text,
+  type WireRecord,
+  type WireValue,
+  wholeNumber,
+  wireRecord,
+} from "@sidecar/wire";
+import { TRACE_ENTRY_KIND } from "./trace-writer.js";
+import { TRACE_DIRECTION } from "./vocabulary.js";
+
+export interface UnboxExportOptions {
+  /** Names the trace in the viewer, defaulting to a fixed label. */
+  name?: string;
+}
+
+const DEFAULT_TRACE_NAME = "luke-agent-trace";
+const UNKNOWN_MODEL = "gpt-realtime";
+const ATTENTION_GENERATION_NAME = "attention-review";
+
+function recordItems(value: WireValue | undefined): readonly WireRecord[] {
+  return Array.isArray(value) ? value.filter(isRecord) : [];
+}
+
+/** The words inside a content list, whichever of the wire's text fields carries them. */
+function contentText(content: WireValue | undefined): string {
+  return recordItems(content)
+    .map((part) => text(part.text) ?? text(part.transcript) ?? "")
+    .filter((part) => part.length > 0)
+    .join("\n");
+}
+
+function toolDefinitions(tools: WireValue | undefined): readonly WireRecord[] {
+  return recordItems(tools).map((tool) => ({
+    type: text(tool.type) ?? "function",
+    name: text(tool.name) ?? "",
+    ...(text(tool.description) ? { description: text(tool.description) ?? "" } : undefined),
+    ...(isRecord(tool.parameters) ? { inputSchema: tool.parameters } : undefined),
+  }));
+}
+
+interface TokenCounts {
+  input: number;
+  output: number;
+  cacheRead: number | undefined;
+}
+
+function tokenCounts(usage: WireRecord | undefined): TokenCounts {
+  return {
+    input: wholeNumber(usage?.input_tokens) ?? 0,
+    output: wholeNumber(usage?.output_tokens) ?? 0,
+    cacheRead: wholeNumber(wireRecord(usage?.input_token_details)?.cached_tokens),
+  };
+}
+
+interface ExportState {
+  instructions: string | undefined;
+  tools: readonly WireRecord[];
+  model: string;
+  messages: WireRecord[];
+  events: WireRecord[];
+  totalInput: number;
+  totalOutput: number;
+  /** When the reply now owed was asked for, for the generation's latency. */
+  responseAskedAtMs: number | undefined;
+  firstAt: string | undefined;
+}
+
+function conversationSnapshot(state: ExportState): WireRecord[] {
+  return [
+    ...(state.instructions !== undefined ? [{ role: "system", content: state.instructions }] : []),
+    ...state.messages,
+  ];
+}
+
+function applySessionUpdate(state: ExportState, event: WireRecord): void {
+  const session = wireRecord(event.session);
+  if (!session) return;
+  state.instructions = text(session.instructions) ?? state.instructions;
+  state.model = text(session.model) ?? state.model;
+  if (Array.isArray(session.tools)) state.tools = toolDefinitions(session.tools);
+}
+
+function applyItemCreate(state: ExportState, event: WireRecord): void {
+  const item = wireRecord(event.item);
+  if (!item) return;
+  if (item.type === "message") {
+    const content = contentText(item.content);
+    if (content.length > 0) {
+      state.messages.push({ role: text(item.role) ?? "user", content });
+    }
+    return;
+  }
+  if (item.type === "function_call_output") {
+    state.messages.push({
+      role: "tool",
+      content: text(item.output) ?? "",
+      ...(text(item.call_id) ? { tool_call_id: text(item.call_id) ?? "" } : undefined),
+    });
+  }
+}
+
+/** The reply's own produce, as the messages the snapshot appends. */
+function responseMessages(output: readonly WireRecord[]): readonly WireRecord[] {
+  return output.flatMap((item) => {
+    if (item.type === "message") {
+      const content = contentText(item.content);
+      return content.length > 0 ? [{ role: text(item.role) ?? "assistant", content }] : [];
+    }
+    if (item.type === "function_call") {
+      return [
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            {
+              type: "function",
+              id: text(item.call_id) ?? "",
+              function: { name: text(item.name) ?? "", arguments: text(item.arguments) ?? "" },
+            },
+          ],
+        },
+      ];
+    }
+    return [];
+  });
+}
+
+function applyResponseDone(state: ExportState, event: WireRecord, atMs: number | undefined): void {
+  const response = wireRecord(event.response);
+  const produced = responseMessages(recordItems(response?.output));
+  const tokens = tokenCounts(wireRecord(response?.usage));
+  const latencyMs =
+    atMs !== undefined && state.responseAskedAtMs !== undefined && atMs >= state.responseAskedAtMs
+      ? atMs - state.responseAskedAtMs
+      : 0;
+  // The reply's own produce joins the conversation first, so the snapshot
+  // below is simply the conversation as it stands after this generation.
+  state.messages.push(...produced);
+  state.events.push({
+    type: "generation",
+    name: text(response?.id) ?? "reply",
+    model: state.model,
+    provider: "openai",
+    metrics: {
+      // The viewer reads latency in seconds; the trace stamps milliseconds.
+      latency: latencyMs / 1_000,
+      tokens: {
+        input: tokens.input,
+        output: tokens.output,
+        ...(tokens.cacheRead !== undefined ? { cache_read: tokens.cacheRead } : undefined),
+      },
+      cost: 0,
+    },
+    available_tools: state.tools,
+    messages: conversationSnapshot(state),
+  });
+  state.totalInput += tokens.input;
+  state.totalOutput += tokens.output;
+  state.responseAskedAtMs = undefined;
+}
+
+function applyWireEntry(state: ExportState, entry: WireRecord, atMs: number | undefined): void {
+  const event = wireRecord(entry.event);
+  if (!event) return;
+  if (entry.direction === TRACE_DIRECTION.CLIENT) {
+    switch (event.type) {
+      case REALTIME_CLIENT_EVENT.SESSION_UPDATE:
+        applySessionUpdate(state, event);
+        return;
+      case REALTIME_CLIENT_EVENT.CONVERSATION_ITEM_CREATE:
+        applyItemCreate(state, event);
+        return;
+      case REALTIME_CLIENT_EVENT.RESPONSE_CREATE:
+        state.responseAskedAtMs = atMs;
+        return;
+      default:
+        return;
+    }
+  }
+  switch (event.type) {
+    case REALTIME_SERVER_EVENT.INPUT_AUDIO_TRANSCRIPTION_COMPLETED: {
+      const transcript = text(event.transcript);
+      if (transcript) state.messages.push({ role: "user", content: transcript });
+      return;
+    }
+    case REALTIME_SERVER_EVENT.RESPONSE_DONE:
+      applyResponseDone(state, event, atMs);
+      return;
+    default:
+      return;
+  }
+}
+
+function applyAttentionEntry(state: ExportState, entry: WireRecord): void {
+  const decision = wireRecord(entry.decision);
+  const error = text(entry.error);
+  state.events.push({
+    type: "generation",
+    name: ATTENTION_GENERATION_NAME,
+    model: ATTENTION_GENERATION_NAME,
+    provider: "openai",
+    metrics: {
+      // The viewer reads latency in seconds; the trace stamps milliseconds.
+      latency: (wholeNumber(entry.elapsedMs) ?? 0) / 1_000,
+      tokens: { input: 0, output: 0 },
+      cost: 0,
+    },
+    messages: [
+      { role: "user", content: JSON.stringify(entry.update ?? {}, undefined, 2) },
+      decision
+        ? { role: "assistant", content: JSON.stringify(decision, undefined, 2) }
+        : { role: "assistant", content: error ?? "no decision" },
+    ],
+  });
+}
+
+/** Reads one trace, already split into lines, into unbox-ai's gateway document. */
+export function unboxTraceFromLines(
+  lines: readonly string[],
+  options: UnboxExportOptions = {},
+): WireRecord {
+  const state: ExportState = {
+    instructions: undefined,
+    tools: [],
+    model: UNKNOWN_MODEL,
+    messages: [],
+    events: [],
+    totalInput: 0,
+    totalOutput: 0,
+    responseAskedAtMs: undefined,
+    firstAt: undefined,
+  };
+  for (const line of lines) {
+    const entry = recordFromJsonLine(line);
+    if (!entry) continue;
+    const at = text(entry.at);
+    state.firstAt ??= at;
+    const parsedAt = at !== undefined ? Date.parse(at) : Number.NaN;
+    const atMs = Number.isFinite(parsedAt) ? parsedAt : undefined;
+    if (entry.kind === TRACE_ENTRY_KIND.WIRE) applyWireEntry(state, entry, atMs);
+    if (entry.kind === TRACE_ENTRY_KIND.ATTENTION) applyAttentionEntry(state, entry);
+  }
+  const name = options.name ?? DEFAULT_TRACE_NAME;
+  return {
+    trace_id: name,
+    timestamp: state.firstAt ?? "",
+    name,
+    total_tokens: { input: state.totalInput, output: state.totalOutput },
+    total_cost: 0,
+    events: state.events,
+  };
+}

--- a/packages/devtrace/src/vocabulary.test.ts
+++ b/packages/devtrace/src/vocabulary.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isAgentWireTrace, sanitizedTraceEvent, TRACE_DIRECTION } from "./vocabulary.js";
+
+test("isAgentWireTrace accepts a tapped event and refuses anything else", () => {
+  assert.equal(
+    isAgentWireTrace({ direction: TRACE_DIRECTION.CLIENT, event: { type: "response.create" } }),
+    true,
+  );
+  assert.equal(
+    isAgentWireTrace({ direction: TRACE_DIRECTION.SERVER, event: { type: "response.done" } }),
+    true,
+  );
+  assert.equal(isAgentWireTrace({ direction: "sideways", event: {} }), false);
+  assert.equal(isAgentWireTrace({ direction: TRACE_DIRECTION.CLIENT, event: "text" }), false);
+  assert.equal(isAgentWireTrace({ direction: TRACE_DIRECTION.CLIENT }), false);
+  assert.equal(isAgentWireTrace("trace"), false);
+  assert.equal(isAgentWireTrace(undefined), false);
+});
+
+test("sanitizedTraceEvent replaces appended audio with its byte count", () => {
+  const sanitized = sanitizedTraceEvent({
+    type: "input_audio_buffer.append",
+    audio: "AAAAAAA=",
+  });
+  assert.deepEqual(sanitized, { type: "input_audio_buffer.append", audioBytes: 5 });
+});
+
+test("sanitizedTraceEvent leaves every other event exactly as it went over the wire", () => {
+  const event = {
+    type: "conversation.item.create",
+    item: { type: "message", role: "user", content: [{ type: "input_text", text: "hello" }] },
+  };
+  assert.equal(sanitizedTraceEvent(event), event);
+});

--- a/packages/devtrace/src/vocabulary.ts
+++ b/packages/devtrace/src/vocabulary.ts
@@ -1,0 +1,56 @@
+/**
+ * The wire vocabulary of the development trace: what one tapped event looks
+ * like as it crosses from the renderer to the writer. It lives behind its own
+ * door because the renderer and the bridge need exactly this and nothing that
+ * touches a file — the writer stays behind the barrel, on the main process's
+ * side of the sandbox.
+ *
+ * The trace is a development instrument, never a product surface: nothing here
+ * decides anything, and everything recorded stays on this machine. What a
+ * trace may record is a product decision, not an implementation detail.
+ */
+
+import { REALTIME_CLIENT_EVENT } from "@sidecar/realtime";
+import { isRecord, isWireString, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
+
+export const TRACE_DIRECTION = {
+  CLIENT: "client",
+  SERVER: "server",
+} as const;
+
+export type TraceDirection = (typeof TRACE_DIRECTION)[keyof typeof TRACE_DIRECTION];
+
+const TRACE_DIRECTIONS: readonly string[] = Object.values(TRACE_DIRECTION);
+
+/** One realtime event as the tap saw it cross the data channel. */
+export interface AgentWireTrace {
+  readonly direction: TraceDirection;
+  readonly event: WireRecord;
+}
+
+function isTraceDirection(value: UnparsedWireValue): value is TraceDirection {
+  return isWireString(value) && TRACE_DIRECTIONS.includes(value);
+}
+
+export function isAgentWireTrace(value: UnparsedWireValue): value is AgentWireTrace & WireRecord {
+  return isRecord(value) && isTraceDirection(value.direction) && isRecord(value.event);
+}
+
+/**
+ * Strips the one payload a trace must not carry whole: the developer's own
+ * voice. An audio append is base64 microphone samples — megabytes an hour of
+ * something no one reads in a trace viewer — so it is replaced by its size
+ * before it ever crosses to the writer. Every other event travels as it went
+ * over the wire, because the words and documents are exactly what a trace
+ * exists to show.
+ */
+export function sanitizedTraceEvent(event: WireRecord): WireRecord {
+  if (event.type !== REALTIME_CLIENT_EVENT.INPUT_AUDIO_BUFFER_APPEND) return event;
+  const audio = event.audio;
+  if (!isWireString(audio)) return event;
+  const padding = audio.endsWith("==") ? 2 : audio.endsWith("=") ? 1 : 0;
+  return {
+    type: event.type,
+    audioBytes: Math.floor((audio.length * 3) / 4) - padding,
+  };
+}

--- a/packages/devtrace/tsconfig.json
+++ b/packages/devtrace/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/realtime/src/index.ts
+++ b/packages/realtime/src/index.ts
@@ -64,6 +64,7 @@ export {
   cancelResponseEvents,
   clearInputAudioEvents,
   clearOutputAudioEvents,
+  decodeRealtimePayload,
   functionCallFollowUpEvents,
   functionCallOutputEvents,
   inputAudioAppendEvents,

--- a/packages/realtime/src/realtime-protocol.ts
+++ b/packages/realtime/src/realtime-protocol.ts
@@ -662,7 +662,13 @@ function audioFromDone(event: WireRecord): boolean | undefined {
   });
 }
 
-function decodeRealtimePayload(data: UnparsedWireValue): WireRecord | undefined {
+/**
+ * Decodes one data-channel payload to the record it carries, or nothing. This
+ * is the wire format's own reader — exported so a tap on the channel reads
+ * the payload the same way the parser below does, rather than re-encoding
+ * the grammar in a second style.
+ */
+export function decodeRealtimePayload(data: UnparsedWireValue): WireRecord | undefined {
   let payload: UnparsedWireValue = data;
   if (isWireString(data)) {
     try {

--- a/packages/voice/src/capability-assembler.test.ts
+++ b/packages/voice/src/capability-assembler.test.ts
@@ -98,6 +98,39 @@ test("the assembler builds and clears the keyed voice capabilities as one unit",
   assert.match(reports.at(-1) ?? "", /unavailable/);
 });
 
+test("a wrapped evaluator stands where the built one would, and only when one was built", async () => {
+  const wrapped: string[] = [];
+  let key: string | undefined = "test-key";
+  const assembler = new VoiceCapabilityAssembler({
+    settings: {
+      ...settingsFor({ source: VOICE_SOURCE.KEY }),
+      readApiKey: async () => key,
+    },
+    credentialsUsable: () => true,
+    fixtureRun: () => false,
+    accountSignedIn: () => false,
+    hostedServiceBaseUrl: "https://example.test",
+    refreshAccount: async () => undefined,
+    currentSession: () => undefined,
+    noticeRequestFor: () => undefined,
+    report: () => undefined,
+    wrapEvaluator: (evaluator) => {
+      wrapped.push("wrapped");
+      return evaluator;
+    },
+  });
+
+  await assembler.apply();
+  assert.ok(assembler.attentionReviewer);
+  assert.deepEqual(wrapped, ["wrapped"]);
+
+  // No evaluator, nothing to decorate: the wrapper must not conjure one.
+  key = undefined;
+  await assembler.apply();
+  assert.equal(assembler.attentionReviewer, undefined);
+  assert.deepEqual(wrapped, ["wrapped"]);
+});
+
 test("the assembler keeps fixture runs credential-free without reading a key", async () => {
   let keyReads = 0;
   const assembler = new VoiceCapabilityAssembler({

--- a/packages/voice/src/capability-assembler.ts
+++ b/packages/voice/src/capability-assembler.ts
@@ -1,4 +1,8 @@
-import { openAiAttentionEvaluator, SessionAttentionReviewer } from "@sidecar/attention";
+import {
+  type AttentionEvaluator,
+  openAiAttentionEvaluator,
+  SessionAttentionReviewer,
+} from "@sidecar/attention";
 import { VOICE_CREDENTIAL_PROVIDER_ID } from "@sidecar/credentials/vocabulary";
 import { HOSTED_SERVICE_PATH } from "@sidecar/hosted";
 import { type RealtimeDiagnostics, realtimeMintExplanation } from "@sidecar/realtime";
@@ -69,6 +73,13 @@ export interface VoiceCapabilityAssemblerOptions {
   noticeRequestFor: (identity: SessionIdentity) => string | undefined;
   fetch?: typeof fetch;
   report?: (message: string) => void;
+  /**
+   * Decorates whichever evaluator the policy builds — keyed or hosted — so a
+   * traced development run reads the same however the pass is credentialed.
+   * The decoration may only observe: the reviewer still sees an
+   * `AttentionEvaluator`, and absence means the evaluator is used as built.
+   */
+  wrapEvaluator?: (evaluator: AttentionEvaluator) => AttentionEvaluator;
 }
 
 export class VoiceCapabilityAssembler {
@@ -127,11 +138,15 @@ export class VoiceCapabilityAssembler {
       refreshAccount: this.#options.refreshAccount,
       ...(this.#options.fetch ? { fetch: this.#options.fetch } : undefined),
     };
-    const evaluator = apiKey
+    const builtEvaluator = apiKey
       ? openAiAttentionEvaluator(apiKey)
       : policy.useHosted
         ? new HostedAttentionEvaluator(seams)
         : undefined;
+    const evaluator =
+      builtEvaluator && this.#options.wrapEvaluator
+        ? this.#options.wrapEvaluator(builtEvaluator)
+        : builtEvaluator;
     this.#attentionReviewer = evaluator
       ? new SessionAttentionReviewer({
           evaluator,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       oxlint:
         specifier: 1.79.0
         version: 1.79.0
+      tsx:
+        specifier: 4.23.12
+        version: 4.23.12
 
   apps/desktop:
     dependencies:
@@ -48,6 +51,9 @@ importers:
       '@sidecar/credentials':
         specifier: workspace:*
         version: link:../../packages/credentials
+      '@sidecar/devtrace':
+        specifier: workspace:*
+        version: link:../../packages/devtrace
       '@sidecar/feedback':
         specifier: workspace:*
         version: link:../../packages/feedback
@@ -354,6 +360,31 @@ importers:
       '@sidecar/surface':
         specifier: workspace:*
         version: link:../surface
+      '@sidecar/wire':
+        specifier: workspace:*
+        version: link:../wire
+    devDependencies:
+      '@types/node':
+        specifier: 26.2.0
+        version: 26.2.0
+      tsx:
+        specifier: 4.23.12
+        version: 4.23.12
+      typescript:
+        specifier: 7.0.2
+        version: 7.0.2
+
+  packages/devtrace:
+    dependencies:
+      '@sidecar/attention':
+        specifier: workspace:*
+        version: link:../attention
+      '@sidecar/realtime':
+        specifier: workspace:*
+        version: link:../realtime
+      '@sidecar/session':
+        specifier: workspace:*
+        version: link:../session
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../wire

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -14,6 +14,7 @@ sidecar_ensure_dependencies
 # new launch then quits on startup and only re-asserts the running panel. Every
 # other argument is forwarded to Electron.
 replace_running_app=true
+capture_trace=true
 remaining_arguments=$#
 while ((remaining_arguments-- > 0)); do
     argument=$1
@@ -22,8 +23,22 @@ while ((remaining_arguments-- > 0)); do
         replace_running_app=false
         continue
     fi
+    if [[ $argument == --no-trace ]]; then
+        capture_trace=false
+        continue
+    fi
     set -- "$@" "$argument"
 done
+
+# Development runs record the trace of Luke's own agent traffic by default,
+# under the gitignored build directory; `pnpm trace:export` turns one file
+# into the document unbox-ai opens. `--no-trace` opts a run out, a directory
+# already in the environment wins over the default, and the app itself keeps
+# the last word: only an unpackaged live run honours the variable at all, so
+# fixture runs and packaged builds record nothing whatever this exports.
+if [[ $capture_trace == true && -z ${LUKE_TRACE_DIR:-} ]]; then
+    export LUKE_TRACE_DIR="$SIDECAR_REPO_ROOT/.build/traces"
+fi
 
 if [[ $replace_running_app == true ]]; then
     sidecar_stop_running_app


### PR DESCRIPTION
## What

Development runs now record Luke's own agent traffic locally, for debugging with the open-source [unbox-ai](https://github.com/tester-army/unbox-ai) trace viewer:

- **`packages/devtrace`** — a JSONL trace writer, the wire/attention entry vocabulary (own `./vocabulary` door so the renderer never resolves `node:fs`), an evaluator decorator, and an exporter to unbox-ai's gateway format with a small CLI (`pnpm trace:export <trace.jsonl> [out.json]`, paths resolved against `INIT_CWD`).
- **Realtime wire tap** — `RealtimeVoiceSession` gains an optional `onWireEvent` observer; inbound payloads are decoded once via a newly exported `decodeRealtimePayload` and shared between the tap and the parser, so untraced runs parse nothing twice. Audio appends are reduced to their byte count in the renderer *and* again inside the writer, so raw audio can never reach disk.
- **Attention tap** — `VoiceCapabilityAssembler` gains a `wrapEvaluator` seam; a decorator records each pass's update, decision, latency, and error for keyed and hosted evaluators alike, without touching either.
- **Gating** — the writer exists only on an unpackaged, live run with `LUKE_TRACE_DIR` set: a packaged build never reads the variable, fixture/evidence runs are refused by the same gate that keeps them off the network, and nothing recorded leaves the machine. `run.sh` sets the variable by default (gitignored `.build/traces`); `--no-trace` opts out. AGENTS.md documents the bounds as a trust constraint.

## Verification

- `./scripts/check.sh` passes (lint, typecheck, all workspace tests, builds).
- 18 new tests: writer ordering/failure/sanitization, evaluator decorator, exporter conversion, wire-tap capture, `wrapEvaluator` seam.
- End-to-end validated against the real viewer: exported traces are detected as unbox-ai's `gateway` format and render token attribution, latency, cache reads, tool calls, and attention passes correctly.
- No UI is drawn or changed, so no visual evidence applies and no physical-notch check was performed; a live traced run was exercised on a physical Mac (recorder + export verified against a real voice session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/50eac961-12eb-43ab-af9c-18dda0f9da78)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32917951732/artifacts/9588882584) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32917951732)

- Commit: `c02856c802047c6c89f8132ee44d5828f3c56363`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
