### PR TITLE
fix(desktop): record session replays from first paint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,10 +281,21 @@ Trust constraints:
   makes a new component silent by construction, so what a recording may see is
   decided by what the panel draws — which makes drawing something new on the
   panel a decision about what leaves the machine. It is still Luke's own panel
-  and never the machine's screen. Recording posts to the provider directly; it
-  is the one place an account id travels to the desktop, and it travels
-  because a recording filed under nobody could neither join the counts nor be
-  erased with them.
+  and never the machine's screen. Recording posts to the provider directly,
+  and it begins at the first paint of every ordinary launch, before any
+  account exists and through the spoken introduction, because the launch is
+  where a first run goes wrong and a recording that waited for a sign-in never
+  saw it. Recording is the one place an account id travels to the desktop, and
+  it travels for what it does when a sign-in lands: the anonymous session
+  already running is joined to that person, so it files with their counts and
+  is erased with them. A session that never reaches a sign-in stays anonymous
+  and can be erased with no account, which is a thing `PRIVACY.md` has to say
+  in as many words rather than leave to be inferred. Deleting an account
+  stands recording down for the rest of that run, unlike signing out, which
+  leaves an anonymous recording running the way the launch before the sign-in
+  was: nothing erased is re-created either way, but a recorder starting up
+  again on the panel that just erased everything reads as though something
+  were, and deletion is the one act treated here as unrecoverable.
   None of the three sends anything in a fixture or evidence run, or while the
   developer has switched sharing off. The counts have their own switch and the
   other two share the recording one, both on by default on the settings front

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy
 
-Last updated: 24 August 2026
+Last updated: 25 August 2026
 
 Luke is a macOS app that watches your coding agent sessions. This policy
 explains what we collect, who we send it to, and how to turn it off.
@@ -31,6 +31,12 @@ recording leaves your Mac, so an API key or a sign-in code you enter is not in
 it. While recording is on, Luke also reports what you clicked, including the
 text on it, and any error his panel runs into, with its message and code path;
 the fixed list above does not cover those two.
+
+Recording starts when Luke opens, before you sign in, so it covers the spoken
+introduction on first launch and the signed-out panel. A recording that begins
+before you sign in is attached to your account if you sign in while it is
+running. One that never reaches a sign-in belongs to nobody, so deleting your
+account does not reach it — we have no way to tell it was yours.
 
 Usage data and recording are both on by default, with their own switches in
 Settings. Turning off Record my screen in Luke leaves the counts on; turning off
@@ -91,8 +97,11 @@ held by our own service, and usage counts and recordings by PostHog.
 - Luke does not use your microphone until you start a turn.
 - Delete your account from the Account section in Settings. This erases your
   account, your sign-in records, and your usage counts, and asks PostHog to
-  erase your usage data and recordings. It does not affect your Google or GitHub
-  account, and anything stored only on your Mac stays there until you remove it.
+  erase your usage data and recordings. It does not reach a recording that was
+  never attached to your account, as described above. Luke stops recording for
+  the rest of the session, and starts again the next time you open it or sign
+  in. Deleting does not affect your Google or GitHub account, and anything
+  stored only on your Mac stays there until you remove it.
 
 ## Google user data
 

--- a/apps/desktop/src/main/desktop-app.ts
+++ b/apps/desktop/src/main/desktop-app.ts
@@ -528,9 +528,12 @@ const recordProductEvent: RecordProductEvent = (name, properties) =>
  * which is the other half of the same question.
  *
  * `sendsNetwork` is the same suppression the event sender takes — recording
- * must be off wherever counting is — and an account is required because a
- * recording under no person could neither join the counts nor be erased with
- * them.
+ * must be off wherever counting is. An account is not among the reasons: a
+ * recording begins at the first paint of an ordinary launch, before anyone
+ * has signed in, because the launch and the introduction before it are where
+ * a first run goes wrong and a recording that waited for a sign-in never saw
+ * it. A sign-in that lands afterwards is what the id is for, and it joins the
+ * session already running to the person rather than starting a new one.
  */
 async function sessionReplayBootstrap(): Promise<SessionReplayBootstrap> {
   // The in-memory snapshot leads the stored account, and this reads the
@@ -541,7 +544,7 @@ async function sessionReplayBootstrap(): Promise<SessionReplayBootstrap> {
   const signedIn = account.status === ACCOUNT_STATUS.SIGNED_IN;
   const accountId = signedIn ? (await settingsStore.readAccount())?.id : undefined;
   return {
-    permitted: runMode.sendsNetwork && accountId !== undefined,
+    permitted: runMode.sendsNetwork && !sessionReplayEndedByDeletion,
     appVersion: app.getVersion(),
     ...(accountId ? { accountId } : undefined),
   };
@@ -564,6 +567,35 @@ function haltSessionReplay(): void {
     permitted: false,
     appVersion: app.getVersion(),
   });
+}
+
+/**
+ * Whether an account was deleted in this run, which stands recording down for
+ * the rest of it.
+ *
+ * A sign-out is the ordinary way back to a signed-out panel, and one recording
+ * anonymously afterwards is the same thing the launch before the sign-in was.
+ * A deletion is not: it is the one act this repository treats as
+ * unrecoverable, and a recorder that resumed the instant the erasure landed
+ * would be filing fresh recordings of the panel that erased them. Nothing is
+ * re-created by it — the new session is anonymous and joins no person — but
+ * the developer cannot see that, and the reading is the harm. The next launch
+ * or sign-in starts one again.
+ */
+let sessionReplayEndedByDeletion = false;
+
+/**
+ * Stands recording down after a deletion that landed, for good this time.
+ *
+ * The generation moves for the same reason `haltSessionReplay`'s does, and
+ * here it is load-bearing rather than defensive: the erasure reports the
+ * account transition on its way out, so a `broadcastSessionReplay` is already
+ * in flight when this runs and would otherwise answer after it with the
+ * permission this just withdrew.
+ */
+function endSessionReplay(): void {
+  sessionReplayEndedByDeletion = true;
+  haltSessionReplay();
 }
 /**
  * The output's switches as last read, and the helper that reads them. The
@@ -1204,6 +1236,7 @@ function registerIpc(): void {
     recordProductEvent,
     flushProductEvents: () => productEvents.flush(),
     haltSessionReplay,
+    endSessionReplay,
     resumeSessionReplay: () => void broadcastSessionReplay(),
   });
 

--- a/apps/desktop/src/main/ipc/account-session.ts
+++ b/apps/desktop/src/main/ipc/account-session.ts
@@ -26,6 +26,16 @@ export interface AccountSessionIpcDependencies {
    */
   haltSessionReplay: () => void;
   /**
+   * Stands recording down for the rest of the run, after a deletion that
+   * landed. A halt alone would not: signed out, recording is wanted again the
+   * moment the account transition is broadcast, which is right for a sign-out
+   * and wrong here. The new recording would be anonymous and join no person,
+   * so nothing erased is re-created — but a recorder that starts up again on
+   * the panel that just erased everything reads as though something were, and
+   * deletion is the one act this repository treats as unrecoverable.
+   */
+  endSessionReplay: () => void;
+  /**
    * Re-answers what recording may do, for an act that did not happen. A halt
    * ahead of a refused sign-out or a failed deletion is one the account
    * transition never follows, so without this the panel stays halted while the
@@ -41,6 +51,7 @@ export function registerAccountSessionIpc(dependencies: AccountSessionIpcDepende
     recordProductEvent,
     flushProductEvents,
     haltSessionReplay,
+    endSessionReplay,
     resumeSessionReplay,
   } = dependencies;
   // Which provider a sign-in was begun with is deliberately not counted. The
@@ -80,7 +91,13 @@ export function registerAccountSessionIpc(dependencies: AccountSessionIpcDepende
         haltSessionReplay();
         await flushProductEvents();
         try {
-          return await accountSession.deleteEverywhere();
+          const deleted = await accountSession.deleteEverywhere();
+          // After the erasure rather than before it, because only a deletion
+          // that landed stands recording down: one that threw leaves the
+          // account where it was, and `resumeSessionReplay` puts the panel
+          // back the way it found it.
+          endSessionReplay();
+          return deleted;
         } catch (error) {
           resumeSessionReplay();
           throw error;

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https://*.googleusercontent.com https://avatars.githubusercontent.com; media-src 'self' blob: mediastream:; connect-src https://api.openai.com https://us.i.posthog.com; worker-src blob:; object-src 'none'; frame-src 'none'"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https://*.googleusercontent.com https://avatars.githubusercontent.com; media-src 'self' blob: mediastream:; connect-src https://api.openai.com https://us.i.posthog.com https://us-assets.i.posthog.com; worker-src blob:; object-src 'none'; frame-src 'none'"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Luke</title>

--- a/apps/desktop/src/renderer/session-replay.test.ts
+++ b/apps/desktop/src/renderer/session-replay.test.ts
@@ -1,9 +1,15 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import test from "node:test";
 import type { UnparsedWireValue } from "@sidecar/wire";
 import type { SessionReplayBootstrap } from "#shared/wire/session";
-import { POSTHOG_HOST, sessionReplayWanted, withoutLocalAddress } from "./session-replay";
+import {
+  POSTHOG_ASSETS_HOST,
+  POSTHOG_HOST,
+  sessionReplayWanted,
+  withoutLocalAddress,
+} from "./session-replay";
 
 /**
  * The gate, on its own. Recording is the one thing Luke sends that a fixed
@@ -38,22 +44,77 @@ test("sharing is the outer switch: recording cannot outlive it", () => {
   assert.equal(sessionReplayWanted(bootstrap(), false, false), false);
 });
 
-test("no account means no recording, because none could be erased with one", () => {
-  assert.equal(sessionReplayWanted(bootstrap({ accountId: undefined }), true, true), false);
+test("no account is no reason not to record: the launch is what it is there for", () => {
+  // The signed-out panel and the spoken introduction before it are where a
+  // first run goes wrong, and a recording that waited for a sign-in never saw
+  // any of it. What the id decides is whom the recording is filed under, not
+  // whether there is one.
+  assert.equal(sessionReplayWanted(bootstrap({ accountId: undefined }), true, true), true);
 });
 
 /**
- * The recorder's host and the renderer's connect policy are two literals in
- * two files, and nothing at run time reconciles them: a host the policy does
- * not name is refused by the browser, which looks exactly like a recording
- * that never started. Asserted as the whole list rather than as containment,
- * so widening what this renderer may reach at all has to be done deliberately
- * here as well.
+ * The recorder's hosts and the renderer's connect policy are separate
+ * literals in separate files, and nothing at run time reconciles them: a host
+ * the policy does not name is refused by the browser, which looks exactly like
+ * a recording that never started — which is what it looked like for every
+ * build before the assets host was named here. Asserted as the whole list
+ * rather than as containment, so widening what this renderer may reach at all
+ * has to be done deliberately here as well.
  */
-test("the connect policy names the recorder's host, and only what else is reached", () => {
+test("the connect policy names both recorder hosts, and only what else is reached", () => {
   const html = readFileSync(new URL("./index.html", import.meta.url), "utf8");
   const connectSrc = html.match(/connect-src ([^;"]+)/)?.[1];
-  assert.deepEqual(connectSrc?.split(" "), ["https://api.openai.com", POSTHOG_HOST]);
+  assert.deepEqual(connectSrc?.split(" "), [
+    "https://api.openai.com",
+    POSTHOG_HOST,
+    POSTHOG_ASSETS_HOST,
+  ]);
+});
+
+/**
+ * What the preload rests on, read out of the bundle it rests on.
+ *
+ * `preloadRemoteConfig` writes a global posthog-js does not declare, and the
+ * whole of what turns recording on is that the library finds a truthy
+ * `sessionRecording` there. Nothing in the type system holds either half
+ * still, and an upgrade that moved one would take recording out in exactly
+ * the silence this change exists to end — so both are asserted against the
+ * installed bundle instead of trusted.
+ *
+ * Read around the member names rather than as bare substrings, because
+ * `sessionRecording` alone appears throughout the surveys code and an
+ * assertion that cannot fail is worse than none. The names survive
+ * minification; the locals beside them do not, which is what the windows and
+ * the `\w` are for.
+ */
+function posthogBundle(): string {
+  return readFileSync(
+    createRequire(import.meta.url).resolve("posthog-js/dist/module.full.no-external"),
+    "utf8",
+  );
+}
+
+function bodyAfter(bundle: string, member: string): string {
+  const start = bundle.indexOf(member);
+  assert.notEqual(start, -1, `posthog-js no longer defines ${member}`);
+  return bundle.slice(start, start + 1400);
+}
+
+test("the library still reads the preloaded config", () => {
+  const loader = bodyAfter(posthogBundle(), "get remoteConfig()");
+  // The token index and `.config` are the shape `preloadRemoteConfig` writes;
+  // the loader returning nothing from this is what makes it fetch instead.
+  assert.match(loader, /_POSTHOG_REMOTE_CONFIG/);
+  assert.match(loader, /\.config\b/);
+});
+
+test("recording is still on for any truthy sessionRecording, which is why {} does", () => {
+  const persist = bodyAfter(posthogBundle(), "_persistRemoteConfig(");
+  assert.match(persist, /sessionRecording/);
+  // The gate itself. A release that asked the remote config for a field —
+  // `enabled === true`, a sample rate, anything — rather than for truthiness
+  // would read the preload's `{}` as a no and record nothing.
+  assert.match(persist, /enabled:!!\w/);
 });
 
 /**

--- a/apps/desktop/src/renderer/session-replay.ts
+++ b/apps/desktop/src/renderer/session-replay.ts
@@ -25,7 +25,13 @@ import type { SessionReplayBootstrap } from "#shared/wire/session";
  *
  * What this file decides on its own is only whether to record at all: the
  * main process says whether this run may, and the developer's two switches
- * say whether it does.
+ * say whether it does. No account is among those reasons. Recording begins at
+ * the first paint of an ordinary launch, before anyone has signed in and
+ * through the spoken introduction, because the launch is where what goes
+ * wrong goes wrong and a recording that waited for a sign-in never saw it. A
+ * session that reaches one is joined to the person there; a session that
+ * never does stays anonymous, which is the part `PRIVACY.md` has to say
+ * plainly, because such a recording cannot be erased with an account.
  */
 
 /**
@@ -34,10 +40,24 @@ import type { SessionReplayBootstrap } from "#shared/wire/session";
  * sees the address a request arrives from.
  *
  * Exported so the connect policy in `index.html` can be asserted against it.
- * The two are separate literals, and a recording the policy refuses to send
- * is indistinguishable from one that was never started.
+ * The host and the policy are separate literals in separate files, and a
+ * recording the policy refuses to send is indistinguishable from one that was
+ * never started — which is exactly how this went unnoticed once already.
  */
 export const POSTHOG_HOST = "https://us.i.posthog.com";
+
+/**
+ * The library's other host, which it derives from `POSTHOG_HOST`'s region
+ * rather than taking as configuration: captured events go to the ingestion
+ * host above, and the remote configuration saying whether recording is on
+ * comes from this one.
+ *
+ * Named in the policy even though `preloadRemoteConfig` means nothing here
+ * asks for it today. The preload rests on an undocumented global, and a
+ * library that stopped reading it would fall through to fetching this — which
+ * this entry lets succeed rather than fail the same silent way it did before.
+ */
+export const POSTHOG_ASSETS_HOST = "https://us-assets.i.posthog.com";
 
 /**
  * What this window says its address is, in place of the one it has.
@@ -167,6 +187,55 @@ function projectApiKey(): string {
   }
 }
 
+/**
+ * The library's own preloaded-configuration global, which its
+ * `RemoteConfigLoader` reads before it fetches anything: a config found here
+ * is used as it stands, and the fetch never happens.
+ *
+ * Declared here because posthog-js does not declare it — it is assigned by
+ * the hosted `/array/<token>/config.js` bundle rather than by anything in the
+ * package's own types, so the shape is documented by what the loader reads
+ * and nothing in the type system holds it still. `session-replay.test.ts`
+ * asserts both halves against the installed bundle, because a library that
+ * renamed either would take recording out silently.
+ */
+declare global {
+  interface Window {
+    _POSTHOG_REMOTE_CONFIG?: Record<
+      string,
+      { config: { sessionRecording: object; hasFeatureFlags: boolean } }
+    >;
+  }
+}
+
+/**
+ * Says recording is on, without asking.
+ *
+ * The library splits its traffic by kind: what it captures goes to the
+ * ingestion host, and the configuration deciding whether to record at all
+ * comes from `POSTHOG_ASSETS_HOST`, which it derives from the region rather
+ * than taking as configuration. A renderer policy naming only the first
+ * refuses that read, and the refusal is silent — recording is gated on a
+ * property only that response writes, so a blocked config reads exactly like
+ * a project with recording switched off. It was, for every build until this
+ * one.
+ *
+ * Preloading answers it here instead. `sessionRecording` decides the gate by
+ * truthiness alone, so an empty object turns recording on and leaves every
+ * field the library's own default, including the input masking documented
+ * above. `hasFeatureFlags: false` declines the flag fetch Luke has no use for.
+ *
+ * What this omits is deliberate and costs nothing: unhandled errors are
+ * forced on by `capture_exceptions` client-side, and autocapture answers to a
+ * disable flag rather than to a remote yes — which is why clicks and errors
+ * arrived throughout, and recordings never did.
+ */
+function preloadRemoteConfig(key: string): void {
+  window._POSTHOG_REMOTE_CONFIG = {
+    [key]: { config: { sessionRecording: {}, hasFeatureFlags: false } },
+  };
+}
+
 let started = false;
 let initialized = false;
 
@@ -202,14 +271,12 @@ export function sessionReplayWanted(
   sharesUsageData: boolean,
   recordsSurface: boolean,
 ): boolean {
-  return (
-    bootstrap.permitted && sharesUsageData && recordsSurface && bootstrap.accountId !== undefined
-  );
+  return bootstrap.permitted && sharesUsageData && recordsSurface;
 }
 
 function startSessionReplay(bootstrap: SessionReplayBootstrap): void {
   const key = projectApiKey();
-  if (!key || !bootstrap.accountId) return;
+  if (!key) return;
   started = true;
   if (initialized) {
     // The client is built once per window. A second `init` would not rebuild
@@ -218,11 +285,12 @@ function startSessionReplay(bootstrap: SessionReplayBootstrap): void {
     // recording it is, because the person may have changed since the last one.
     optIn();
     registerBuild(bootstrap);
-    posthog.identify(bootstrap.accountId);
+    identifyAccount(bootstrap);
     posthog.startSessionRecording();
     return;
   }
   initialized = true;
+  preloadRemoteConfig(key);
   posthog.init(key, {
     api_host: POSTHOG_HOST,
     defaults: "2025-11-30",
@@ -259,10 +327,24 @@ function startSessionReplay(bootstrap: SessionReplayBootstrap): void {
   // was recording.
   optIn();
   registerBuild(bootstrap);
-  // The same opaque id the counted events resolve to, so a recording and the
-  // counts around it belong to one person — which is also what makes deleting
-  // the account erase the recordings with it.
-  posthog.identify(bootstrap.accountId);
+  identifyAccount(bootstrap);
+}
+
+/**
+ * Files what is being recorded under the account, when there is one.
+ *
+ * The id is the same opaque one the counted events resolve to, so a recording
+ * and the counts around it belong to one person — which is what makes
+ * deleting the account erase the recordings with it.
+ *
+ * Signed out there is no id and none is invented: the recording runs under
+ * the anonymous id the library made for itself, and a sign-in that lands
+ * later calls this, which is where the library joins that anonymous session
+ * to the person. What never reaches a sign-in stays anonymous, and so cannot
+ * be erased with an account — `PRIVACY.md` says so, because it is now true.
+ */
+function identifyAccount(bootstrap: SessionReplayBootstrap): void {
+  if (bootstrap.accountId) posthog.identify(bootstrap.accountId);
 }
 
 /**

--- a/apps/desktop/src/shared/wire/session.ts
+++ b/apps/desktop/src/shared/wire/session.ts
@@ -82,8 +82,9 @@ export interface SessionReplayBootstrap {
   /**
    * Whether this run may record at all, whatever the switches say. False for
    * a fixture and a capture run, which must stay deterministic and send
-   * nothing, and false with no account, because a recording filed under
-   * nobody could be neither joined to its counts nor erased with them.
+   * nothing, and false for the rest of a run in which an account was deleted.
+   * Being signed out is not one of the reasons: recording begins at the first
+   * paint, before an account exists.
    */
   permitted: boolean;
   /**
@@ -97,7 +98,9 @@ export interface SessionReplayBootstrap {
    * The account's opaque id, absent while signed out. It is the same id the
    * hosted endpoints resolve a bearer token to, so a recording lands on the
    * person the counted events already belong to — which is also what makes
-   * deleting the account erase the recordings with it.
+   * deleting the account erase the recordings with it. A recording that runs
+   * while this is absent is anonymous, joined to the person if a sign-in
+   * lands during it and to nobody if none ever does.
    */
   accountId?: string;
 }


### PR DESCRIPTION
## What was wrong

No desktop session replay has ever reached PostHog. "Record user sessions" was on in the project the whole time — the renderer's own connect policy was refusing the read that decides whether to record at all.

`posthog-js` splits its traffic by kind. Captured events go to the **api** host; the remote config that gates the recorder comes from an **assets** host it derives from the region rather than taking as configuration:

```js
case "assets": return "https://" + region + "-assets." + "i.posthog.com" + path
case "api":    return "https://" + region + "."        + "i.posthog.com" + path
```

`index.html` named only `us.i.posthog.com`, so the browser refused `us-assets.i.posthog.com/array/<token>/config`. The refusal was silent, because recording is gated on a `$session_recording_remote_config` property that only that response ever writes. It never arrived, so rrweb never started.

**Only replay was affected**, and that asymmetry was the symptom: `capture_exceptions` is forced on client-side and autocapture's gate is a *disable* flag, so clicks and errors travelled normally throughout.

## What changed

**Preload the config** rather than fetch it. `RemoteConfigLoader.load()` short-circuits on `_POSTHOG_REMOTE_CONFIG`, and the gate is truthiness alone, so an empty `sessionRecording` turns recording on and leaves every field the library's own default — including the input masking already documented there. Recording no longer depends on a network answer that can be blocked, slow, or switched off elsewhere.

**Name the assets host in `connect-src` anyway.** Dead code today, and the only thing standing between a library upgrade and another silent outage: the preload rests on an undocumented global, and a posthog-js that stopped reading it would fall through to the fetch, which this entry now lets succeed.

**Record before sign-in.** The signed-out panel and the spoken introduction are where a first run goes wrong, and a recording that waited for a sign-in never saw any of it. `identify` is called only when there is an id, so a session that reaches a sign-in is joined to that person.

**Deletion stands recording down** for the rest of the run, unlike a sign-out. Nothing erased is re-created either way — the new session is anonymous and joins no person — but a recorder starting up again on the panel that just erased everything reads as though something were.

## Docs move, because this changes character

`AGENTS.md` stated the opposite as a trust constraint ("a recording filed under nobody could neither join the counts nor be erased with them"). Both it and `PRIVACY.md` now say recording begins before an account exists, that a session reaching a sign-in is linked to it, and that one which never does cannot be erased with an account. `apps/web/src/PrivacyPage.tsx` renders `PRIVACY.md` directly, so the site follows on its own.

## Verification

`./scripts/check.sh` (783/783) and `./scripts/verify.sh` both pass. Visual evidence inspected — unchanged, as expected for a change that draws nothing. **No physical-notch check was performed.**

Against the real packaged app with the project key:

| Check | Result |
|---|---|
| CSP violations | 0 |
| `$session_recording_remote_config` | `{"enabled": true, …}` — **was absent before** |
| `$sesid` | present — recorder started |
| `$capture_rate_limit` | PostHog responded, traffic round-tripping |

Both new tests were checked to fail when what they guard breaks:

| Mutation | Result |
|---|---|
| Drop `us-assets` from `index.html` | ✖ CSP pin fails |
| Change library gate to `enabled:!0===i.enabled` | ✖ drift test fails |

Also reproduced in real Chromium under real CSP: with the preload, the gate reads `enabled: true` with **zero** network requests; without it, gate `undefined` and a request to the blocked URL. Old policy blocks that host, new policy allows it.

### Not verified

The **signed-out** path is covered by unit test but not watched live. Electron on macOS derives `appData` from the user record rather than `$HOME`, so a fresh profile could not be isolated without displacing the real dev profile and stopping another workspace's running Luke.

### Dropped from this PR

The CI-key work landed on `main` independently while this was in flight, so all that remained was an explanatory comment — and the token here lacks `workflow` scope to push it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1NczgFK82ywxxVZWeY4hh

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32921084640/artifacts/9589908660) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32921084640)

- Commit: `d3eb99dbd13b546ae37fbfd7335958801c490fdd`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
