### PR TITLE
fix(conductor): read open workspaces from the filtered workspace listing

### DIFF
--- a/packages/providers/src/conductor/adapter.test.ts
+++ b/packages/providers/src/conductor/adapter.test.ts
@@ -74,11 +74,12 @@ function page(data: readonly JsonValue[]): JsonObject {
   return { data, offset: 0, hasMore: false };
 }
 
-function workspacePayload(workspace: TestWorkspace) {
+function workspacePayload(workspace: TestWorkspace, projects: readonly TestProject[]) {
   const payload: JsonObject = {
     id: workspace.id,
     name: workspace.name,
     state: workspace.state ?? "ready",
+    repoUrl: projects.find((project) => project.id === workspace.projectId)?.gitRemote ?? "",
     createdAt: isoTimestamp(workspace.lastActivityAt),
     deepLink: `conductor://workspace?id=${workspace.id}`,
     lastActivityAt: isoTimestamp(workspace.lastActivityAt),
@@ -206,14 +207,21 @@ function fakeConductorApi(api: TestApi) {
     if (segments[1] === "projects" && segments.length === 2) {
       return jsonResponse(page(api.projects));
     }
-    if (segments[1] === "projects" && segments[3] === "workspaces") {
-      return jsonResponse(
-        page(
-          api.workspaces
-            .filter((workspace) => workspace.projectId === segments[2])
-            .map(workspacePayload),
-        ),
+    if (segments[1] === "workspaces" && segments.length === 2) {
+      const limit = Number(request.searchParams.get("limit") ?? "100");
+      const offset = Number(request.searchParams.get("offset") ?? "0");
+      // The real index hides archived work when asked to; a deleted
+      // workspace stays in the page here so the adapter's own record check
+      // answers for it. The creator filter is deliberately not honored: the
+      // adapter's attribution check answers for whose workspaces these are.
+      const listed = api.workspaces.filter(
+        (workspace) =>
+          request.searchParams.get("includeArchived") !== "false" || workspace.state !== "archived",
       );
+      const rows = listed
+        .slice(offset, offset + limit)
+        .map((workspace) => workspacePayload(workspace, api.projects));
+      return jsonResponse({ data: rows, offset, hasMore: offset + rows.length < listed.length });
     }
     if (segments[1] === "workspaces" && segments[3] === "sessions") {
       return jsonResponse(
@@ -1374,6 +1382,50 @@ test("observes every workspace and chat the pages hold", async () => {
     observations.map((observation) => observation.providerSessionId),
     ["session-0", "session-1", "session-2", "session-3", "session-4", "session-5"],
   );
+});
+
+test("keeps an old open workspace that newer pages would have crowded out", async () => {
+  // The listing pages newest-first, so an open workspace can be older than a
+  // whole page of newer work. Following the listing while it says more
+  // remain is what keeps that workspace's chat a row; stopping at the first
+  // page silently retired a conversation to spare a request.
+  const workspaces = [
+    ...Array.from({ length: 100 }, (_value, index) =>
+      ownedWorkspace(`workspace-new-${index}`, TEST_TIME - index * 1_000),
+    ),
+    ownedWorkspace("workspace-old", TEST_TIME - 500_000),
+  ];
+  const api = fakeConductorApi({
+    userId: TEST_USER_ID,
+    projects: [LUKE_PROJECT],
+    workspaces,
+    sessions: [
+      {
+        id: "session-old",
+        workspaceId: "workspace-old",
+        name: TEST_SESSION_NAME,
+        status: TEST_CONDUCTOR_STATUS.IDLE,
+        statusUpdatedAt: TEST_TIME - 1_000,
+      },
+    ],
+  });
+
+  const observations = await adapterFor(api.fetch).observe();
+
+  assert.deepEqual(
+    observations.map((observation) => observation.providerSessionId),
+    ["session-old"],
+  );
+  // The second page was asked for where the first said more remained, and
+  // every page carried the documented filters: the user the same pass's
+  // identity read reported, and no archived work.
+  const listings = api.requests.filter(
+    (request) => request.method === "GET" && request.pathname === "/v0/workspaces",
+  );
+  assert.equal(listings.length, 2);
+  assert.equal(listings[0]?.searchParams.get("creator"), TEST_USER_ID);
+  assert.equal(listings[0]?.searchParams.get("includeArchived"), "false");
+  assert.equal(listings[1]?.searchParams.get("offset"), "100");
 });
 
 test("lets a crowded workspace keep every chat beside its quiet neighbour", async () => {

--- a/packages/providers/src/conductor/adapter.ts
+++ b/packages/providers/src/conductor/adapter.ts
@@ -47,8 +47,10 @@ const CONDUCTOR_ENVIRONMENT = {
 const CONDUCTOR_DEFAULT_API_URL = "https://api.conductor.build";
 
 /**
- * Documented public API routes. The reads walk projects, workspaces, and
- * sessions, and poll the status endpoints both of those document; the writers
+ * Documented public API routes. The reads walk projects, the user's own open
+ * workspaces through the workspace listing's documented creator and archive
+ * filters, and each workspace's sessions, and poll the status endpoints
+ * workspaces and sessions document; the writers
  * are `POST …/sessions/{id}/messages`, which is
  * Conductor's documented way to hand a prompt to an existing session — queued
  * while it is idle, steered into the running turn while it works —
@@ -162,8 +164,17 @@ function conductorArchiveWorkspaceControl(workspaceId: string): SessionControl {
   };
 }
 
+/**
+ * The query parameters the reads send, all documented by the endpoints they
+ * ride. Nothing enters a value but what the build fixed, the user id the same
+ * pass's identity read reported, and the arithmetic page cursor the previous
+ * page's own answer earned.
+ */
 const CONDUCTOR_QUERY = {
+  CREATOR: "creator",
+  INCLUDE_ARCHIVED: "includeArchived",
   LIMIT: "limit",
+  OFFSET: "offset",
 } as const;
 
 const CONDUCTOR_FIELD = {
@@ -176,11 +187,13 @@ const CONDUCTOR_FIELD = {
   ERROR_MESSAGE: "errorMessage",
   FAST_MODE: "fastMode",
   GIT_REMOTE: "gitRemote",
+  HAS_MORE: "hasMore",
   ID: "id",
   LAST_ACTIVITY_AT: "lastActivityAt",
   LAST_ERROR: "lastError",
   MODEL: "model",
   NAME: "name",
+  REPO_URL: "repoUrl",
   RESOLVED_MODEL: "resolvedModel",
   /** The workspace listing's own word for where each workspace stands. */
   STATE: "state",
@@ -323,6 +336,13 @@ const CONDUCTOR_RETIRED_WORKSPACE_STATUSES: ReadonlySet<ConductorWorkspaceStatus
 const CONDUCTOR_ADAPTER_DEFAULTS = {
   MAXIMUM_PROJECTS: 10,
   WORKSPACE_PAGE_SIZE: 100,
+  /**
+   * How far the workspace listing is followed while it says more remain. The
+   * pages hold only the user's own open workspaces, so the bound is on live
+   * conversations rather than on everything ever archived, and five hundred
+   * of them is far past what one person's panel can mean anything for.
+   */
+  MAXIMUM_WORKSPACE_PAGES: 5,
   SESSION_PAGE_SIZE: 20,
   MAXIMUM_MODEL_LABEL_LENGTH: 60,
   MAXIMUM_ERROR_LENGTH: 120,
@@ -573,23 +593,19 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
     if (!userId) return [];
 
     // Every fan-out below is bounded by the page sizes in
-    // CONDUCTOR_ADAPTER_DEFAULTS — one page of workspaces per project, one
-    // page of chats per workspace — and workspaces and chats are never
-    // capped beyond that: a conversation is never dropped to spare a request.
+    // CONDUCTOR_ADAPTER_DEFAULTS — a bounded run of pages of the user's own
+    // open workspaces, one page of chats per workspace — and workspaces and
+    // chats are never capped beyond that: a conversation is never dropped to
+    // spare a request. The projects are read for their own sake: they are
+    // where a new workspace can be created, not where the workspaces come
+    // from.
     const projects = await this.#listProjects(request);
     this.#projects = projects;
-    const workspaces = (
-      await Promise.all(
-        projects.map((project) =>
-          this.tolerateItemFailure(() => this.#listWorkspaces(request, project)),
-        ),
-      )
-    )
-      .filter(isDefined)
-      .flat()
-      // Conductor does not attribute a workspace Luke can prove belongs to this
-      // user unless it reports a creator, and unattributed org workspaces stay
-      // out of a personal sidecar.
+    const workspaces = (await this.#listWorkspaces(request, userId))
+      // The listing was asked for this user's workspaces, but the records
+      // answer for themselves: Conductor does not attribute a workspace Luke
+      // can prove belongs to this user unless it reports a creator, and
+      // unattributed org workspaces stay out of a personal sidecar.
       .filter((workspace) => workspace.creatorId === userId)
       .sort((first, second) => second.lastActivityAt - first.lastActivityAt);
 
@@ -715,51 +731,33 @@ export class ConductorSessionAdapter extends CloudSessionAdapter {
       .slice(0, CONDUCTOR_ADAPTER_DEFAULTS.MAXIMUM_PROJECTS);
   }
 
-  async #listWorkspaces(
-    request: CloudRequest,
-    project: ConductorProject,
-  ): Promise<ConductorWorkspace[]> {
-    const body = await request(
-      [...CONDUCTOR_ROUTE.PROJECTS, project.id, CONDUCTOR_ROUTE_SEGMENT.WORKSPACES],
-      { [CONDUCTOR_QUERY.LIMIT]: String(CONDUCTOR_ADAPTER_DEFAULTS.WORKSPACE_PAGE_SIZE) },
-    );
-    return recordsFromPage(body, CONDUCTOR_FIELD.DATA)
-      .map((record): ConductorWorkspace | undefined => {
-        const id = textFromRecord(record, CONDUCTOR_FIELD.ID);
-        const lastActivityAt =
-          timestampFromRecord(record, CONDUCTOR_FIELD.LAST_ACTIVITY_AT) ??
-          timestampFromRecord(record, CONDUCTOR_FIELD.CREATED_AT);
-        if (!id || lastActivityAt === undefined) return undefined;
-        // The listing marks a filed-away workspace with its own state, so it
-        // is dropped here, before a lifecycle or session read ever spends a
-        // request on it. This is also what keeps a press of the archive
-        // control durable: judged by the lifecycle read alone, a page of
-        // long-archived workspaces stood or fell with dozens of per-workspace
-        // reads every pass, and any one of them failing resurrected a
-        // workspace the user had already filed away. A state this build does
-        // not know is kept, not dropped — the lifecycle read still decides
-        // for it, as it did when the listing marked nothing.
-        const state = knownValue(
-          CONDUCTOR_WORKSPACE_STATUS,
-          textFromRecord(record, CONDUCTOR_FIELD.STATE),
-        );
-        if (state && CONDUCTOR_RETIRED_WORKSPACE_STATUSES.has(state)) {
-          return undefined;
-        }
-        const creatorId = textFromRecord(record, CONDUCTOR_FIELD.CREATOR_ID);
-        const name = textFromRecord(record, CONDUCTOR_FIELD.NAME)?.slice(
-          0,
-          maximumSessionTitleLength,
-        );
-        return {
-          id,
-          repositoryLabel: project.repositoryLabel,
-          lastActivityAt,
-          ...(name ? { name } : undefined),
-          ...(creatorId ? { creatorId } : undefined),
-        };
-      })
-      .filter(isDefined);
+  /**
+   * The user's own open workspaces, from the documented workspace listing
+   * under its own filters: the creator is the user the same pass's identity
+   * read reported, and the archived are excluded where they are indexed
+   * rather than paged through and dropped — a user who files away dozens of
+   * workspaces a week would otherwise fill every page with them and crowd an
+   * old but open workspace off the end of the read. The listing is followed
+   * while it says more remain, to the fixed page bound, and a page that
+   * could not be read fails the pass whole rather than quietly retiring
+   * every row a later page was holding.
+   */
+  async #listWorkspaces(request: CloudRequest, userId: string): Promise<ConductorWorkspace[]> {
+    const workspaces: ConductorWorkspace[] = [];
+    let offset = 0;
+    for (let page = 0; page < CONDUCTOR_ADAPTER_DEFAULTS.MAXIMUM_WORKSPACE_PAGES; page += 1) {
+      const body = await request([CONDUCTOR_ROUTE_SEGMENT.V0, CONDUCTOR_ROUTE_SEGMENT.WORKSPACES], {
+        [CONDUCTOR_QUERY.LIMIT]: String(CONDUCTOR_ADAPTER_DEFAULTS.WORKSPACE_PAGE_SIZE),
+        [CONDUCTOR_QUERY.OFFSET]: String(offset),
+        [CONDUCTOR_QUERY.CREATOR]: userId,
+        [CONDUCTOR_QUERY.INCLUDE_ARCHIVED]: "false",
+      });
+      const records = recordsFromPage(body, CONDUCTOR_FIELD.DATA);
+      workspaces.push(...records.map(workspaceFromRecord).filter(isDefined));
+      offset += records.length;
+      if (body[CONDUCTOR_FIELD.HAS_MORE] !== true || records.length === 0) break;
+    }
+    return workspaces;
   }
 
   async #listSessions(
@@ -1205,6 +1203,40 @@ function agentAndModelLabel(
 ): string | undefined {
   const label = [agentKind, model].filter(isDefined).join(" · ");
   return label || undefined;
+}
+
+/**
+ * One listed workspace, answering for itself. The listing was already asked
+ * to leave the archived out, but a record marked retired is dropped here all
+ * the same, before a lifecycle or session read ever spends a request on it —
+ * judged by the lifecycle read alone, a page of long-archived workspaces
+ * stood or fell with dozens of per-workspace reads every pass, and any one
+ * of them failing resurrected a workspace the user had already filed away.
+ * A state this build does not know is kept, not dropped: the lifecycle read
+ * still decides for it, as it did when the listing marked nothing.
+ */
+function workspaceFromRecord(record: WireRecord): ConductorWorkspace | undefined {
+  const id = textFromRecord(record, CONDUCTOR_FIELD.ID);
+  const lastActivityAt =
+    timestampFromRecord(record, CONDUCTOR_FIELD.LAST_ACTIVITY_AT) ??
+    timestampFromRecord(record, CONDUCTOR_FIELD.CREATED_AT);
+  if (!id || lastActivityAt === undefined) return undefined;
+  const state = knownValue(
+    CONDUCTOR_WORKSPACE_STATUS,
+    textFromRecord(record, CONDUCTOR_FIELD.STATE),
+  );
+  if (state && CONDUCTOR_RETIRED_WORKSPACE_STATUSES.has(state)) return undefined;
+  const creatorId = textFromRecord(record, CONDUCTOR_FIELD.CREATOR_ID);
+  const name = textFromRecord(record, CONDUCTOR_FIELD.NAME)?.slice(0, maximumSessionTitleLength);
+  return {
+    id,
+    // The listing names each workspace's repository itself, so the label no
+    // longer rides in from the project that grouped it.
+    repositoryLabel: repositoryLabel(textFromRecord(record, CONDUCTOR_FIELD.REPO_URL), undefined),
+    lastActivityAt,
+    ...(name ? { name } : undefined),
+    ...(creatorId ? { creatorId } : undefined),
+  };
 }
 
 /** Conductor reports the model it resolved as well as the one that was asked for. */


### PR DESCRIPTION
## The gap #525 flagged

The per-project workspace listing (`GET /v0/projects/{id}/workspaces`) pages 100 workspaces newest-first and keeps every archived workspace in the page, with no filter params. Against the reporting account that page is already ~93% archived and refills within days — so an **open workspace older than the newest ~100 falls off the observed page entirely**, silently retiring its rows. #525 made archived workspaces cheap to drop; this closes the coverage hole they still cause.

## The fix

Observation now reads the documented org-wide listing, `GET /v0/workspaces`, which carries exactly the filters the roster means (verified against the live [OpenAPI spec](https://api.conductor.build/v0/openapi.json) and API):

- `creator` — the user id the same pass's `/me` read reported, so the read asks for the user's own workspaces instead of filtering an org page down.
- `includeArchived=false` — the archived are excluded where they are indexed, rather than paged through and dropped.
- `limit`/`offset` — followed while `hasMore` says more remain, bounded at 5 pages (500 **open** workspaces, a bound on live conversations rather than on everything ever archived — the old page bound was consumed by archive churn).

Every record still answers for itself: the creator attribution check, the retired-state drop from #525, and the per-workspace lifecycle read all stand unchanged, so a lagging index or an unknown future state falls to the same guards as before. Each workspace's repository label now comes from its own `repoUrl` (required in the listing schema), so the projects read remains only for what it alone offers — where a new workspace can be created. A listing page that cannot be read fails the pass whole (previous snapshot stands), rather than quietly retiring every row a later page was holding.

## Verification

- `./scripts/check.sh` passes (709 provider tests, exit 0). Portable-only change — no UI or macOS surface touched.
- Live probe against `api.conductor.build`: the adapter now observes all 9 open workspaces across every project in one filtered listing page (31 requests per pass), with identical Archive/Stop controls; the query carries `creator`, `includeArchived=false`, and the page cursor exactly as documented.
- New test: an open workspace older than a full page of newer work is still observed through the `hasMore` follow, and every listing request carries the documented filters. The test fake deliberately leaves the `creator` filter unhonored and keeps `deleted` workspaces in the page, so the adapter's own attribution and retired-state checks stay exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/31345ad6-0dbc-46e8-b36f-ca62be4f5a6c)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/32923842679/artifacts/9590813987) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/32923842679)

- Commit: `c7c55d5c2b37e552eec0d0d1e145f0627ffca862`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
